### PR TITLE
i#5456: Add drbbdup support for meta bbs

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1541,7 +1541,8 @@ drbbdup_handle_new_case()
     /* Scratch register holds the tag. */
     void *tag = (void *)reg_get_value(DRBBDUP_SCRATCH_REG, &mcontext);
 
-    app_pc pc = dr_fragment_app_pc(tag);
+    instrlist_t *ilist = decode_as_bb(drcontext, dr_fragment_app_pc(tag));
+    app_pc pc = instr_get_app_pc(drbbdup_first_app(ilist));
     ASSERT(pc != NULL, "pc cannot be NULL");
 
     bool do_flush = false;

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -335,11 +335,14 @@ drbbdup_create_manager(void *drcontext, void *tag, instrlist_t *bb, bool for_met
     /* XXX i#3778: To remove once we support specific fragment deletion. */
     DR_ASSERT_MSG(!manager->enable_dynamic_handling,
                   "dynamic case generation is not yet supported");
-    /* XXX: For now we do not support dynamic handling for-meta-type managers. */
-    DR_ASSERT_MSG(!manager->enable_dynamic_handling && for_meta,
-                  "dynamic case generation is not yet possible for bbs consisting solely "
-                  "of meta instructions");
 
+    if (for_meta) {
+        /* XXX: For now we do not support dynamic handling for-meta-type managers. */
+        DR_ASSERT_MSG(
+            !manager->enable_dynamic_handling,
+            "dynamic case generation is not yet possible for bbs consisting solely "
+            "of meta instructions");
+    }
     /* Check whether user wants copies for this particular bb. */
     if (!manager->enable_dup && manager->cases != NULL) {
         /* Multiple cases not wanted. Destroy cases. */

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -231,7 +231,6 @@ drbbdup_is_special_instr(instr_t *instr)
  */
 
 #ifdef DEBUG
-
 void
 drbbdup_debug_check_for_meta(drbbdup_manager_t *manager, instrlist_t *bb)
 {
@@ -475,7 +474,7 @@ drbbdup_duplicate_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_tr
         return DR_EMIT_DEFAULT;
 
     app_pc pc = instr_get_app_pc(instrlist_first_app(bb));
-    bool for_meta = pc != NULL;
+    bool for_meta = pc == NULL;
 
     dr_rwlock_write_lock(rw_lock);
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2579,6 +2579,37 @@ use_DynamoRIO_extension(client.drbbdup-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-test.dll drreg)
 use_DynamoRIO_extension(client.drbbdup-test.dll drbbdup)
 
+if (X86 AND UNIX)
+  add_exe(client.drbbdup-meta-label-bb-test client-interface/drbbdup-meta-label-bb-test.asm)
+  set_target_properties(client.drbbdup-meta-label-bb-test PROPERTIES LINKER_LANGUAGE C)
+  append_link_flags(client.drbbdup-meta-label-bb-test "-nostartfiles -nodefaultlibs -static")
+
+  add_library(client.drbbdup-meta-label-bb-test.dll SHARED  client-interface/drbbdup-meta-label-bb-test.dll.c)
+  setup_test_client_dll_basics(client.drbbdup-meta-label-bb-test.dll)
+  use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drmgr)
+  use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drreg)
+  use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drbbdup)
+  
+  torunonly_ci(client.drbbdup-meta-label-bb-test client.drbbdup-meta-label-bb-test
+    client.drbbdup-meta-label-bb-test.dll client-interface/drbbdup-meta-label-bb-test.asm "" "-max_bb_instrs 0" "")
+endif (X86 AND UNIX)
+
+if (X86 AND UNIX)
+  add_exe(client.drbbdup-meta-nop-bb-test client-interface/drbbdup-meta-nop-bb-test.asm)
+  set_target_properties(client.drbbdup-meta-nop-bb-test PROPERTIES LINKER_LANGUAGE C)
+  append_link_flags(client.drbbdup-meta-nop-bb-test "-nostartfiles -nodefaultlibs -static")
+
+  add_library(client.drbbdup-meta-nop-bb-test.dll SHARED  client-interface/drbbdup-meta-nop-bb-test.dll.c)
+  setup_test_client_dll_basics(client.drbbdup-meta-nop-bb-test.dll)
+  use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drmgr)
+  use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drreg)
+  use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drbbdup)
+  
+  torunonly_ci(client.drbbdup-meta-nop-bb-test client.drbbdup-meta-nop-bb-test
+    client.drbbdup-meta-nop-bb-test.dll client-interface/drbbdup-meta-nop-bb-test.asm "" "-max_bb_instrs 0" "")
+endif (X86 AND UNIX)
+
+
 tobuild_ci(client.drbbdup-no-encode-test client-interface/drbbdup-no-encode-test.c "" "" "")
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drreg)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2579,7 +2579,7 @@ use_DynamoRIO_extension(client.drbbdup-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-test.dll drreg)
 use_DynamoRIO_extension(client.drbbdup-test.dll drbbdup)
 
-if (X86 AND UNIX)
+if (X86 AND LINUX)
   add_exe(client.drbbdup-meta-label-bb-test client-interface/drbbdup-meta-label-bb-test.asm)
   set_target_properties(client.drbbdup-meta-label-bb-test PROPERTIES LINKER_LANGUAGE C)
   append_link_flags(client.drbbdup-meta-label-bb-test "-nostartfiles -nodefaultlibs -static")
@@ -2592,9 +2592,9 @@ if (X86 AND UNIX)
 
   torunonly_ci(client.drbbdup-meta-label-bb-test client.drbbdup-meta-label-bb-test
     client.drbbdup-meta-label-bb-test.dll client-interface/drbbdup-meta-label-bb-test.asm "" "-max_bb_instrs 0" "")
-endif (X86 AND UNIX)
+endif (X86 AND LINUX)
 
-if (X86 AND UNIX)
+if (X86 AND LINUX)
   add_exe(client.drbbdup-meta-nop-bb-test client-interface/drbbdup-meta-nop-bb-test.asm)
   set_target_properties(client.drbbdup-meta-nop-bb-test PROPERTIES LINKER_LANGUAGE C)
   append_link_flags(client.drbbdup-meta-nop-bb-test "-nostartfiles -nodefaultlibs -static")
@@ -2607,9 +2607,9 @@ if (X86 AND UNIX)
 
   torunonly_ci(client.drbbdup-meta-nop-bb-test client.drbbdup-meta-nop-bb-test
     client.drbbdup-meta-nop-bb-test.dll client-interface/drbbdup-meta-nop-bb-test.asm "" "-max_bb_instrs 0" "")
-endif (X86 AND UNIX)
+endif (X86 AND LINUX)
 
-if (X86 AND UNIX)
+if (X86 AND LINUX)
   add_exe(client.drbbdup-empty-bb-test client-interface/drbbdup-empty-bb-test.asm)
   set_target_properties(client.drbbdup-empty-bb-test PROPERTIES LINKER_LANGUAGE C)
   append_link_flags(client.drbbdup-empty-bb-test "-nostartfiles -nodefaultlibs -static")
@@ -2622,7 +2622,7 @@ if (X86 AND UNIX)
 
   torunonly_ci(client.drbbdup-empty-bb-test client.drbbdup-empty-bb-test
     client.drbbdup-empty-bb-test.dll client-interface/drbbdup-empty-bb-test.asm "" "-max_bb_instrs 0" "")
-endif (X86 AND UNIX)
+endif (X86 AND LINUX)
 
 tobuild_ci(client.drbbdup-no-encode-test client-interface/drbbdup-no-encode-test.c "" "" "")
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2589,7 +2589,7 @@ if (X86 AND UNIX)
   use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drmgr)
   use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drreg)
   use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drbbdup)
-  
+
   torunonly_ci(client.drbbdup-meta-label-bb-test client.drbbdup-meta-label-bb-test
     client.drbbdup-meta-label-bb-test.dll client-interface/drbbdup-meta-label-bb-test.asm "" "-max_bb_instrs 0" "")
 endif (X86 AND UNIX)
@@ -2604,11 +2604,10 @@ if (X86 AND UNIX)
   use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drmgr)
   use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drreg)
   use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drbbdup)
-  
+
   torunonly_ci(client.drbbdup-meta-nop-bb-test client.drbbdup-meta-nop-bb-test
     client.drbbdup-meta-nop-bb-test.dll client-interface/drbbdup-meta-nop-bb-test.asm "" "-max_bb_instrs 0" "")
 endif (X86 AND UNIX)
-
 
 tobuild_ci(client.drbbdup-no-encode-test client-interface/drbbdup-no-encode-test.c "" "" "")
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2579,50 +2579,26 @@ use_DynamoRIO_extension(client.drbbdup-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-test.dll drreg)
 use_DynamoRIO_extension(client.drbbdup-test.dll drbbdup)
 
-if (X86 AND LINUX)
-  add_exe(client.drbbdup-meta-label-bb-test client-interface/drbbdup-meta-label-bb-test.asm)
-  set_target_properties(client.drbbdup-meta-label-bb-test PROPERTIES LINKER_LANGUAGE C)
-  append_link_flags(client.drbbdup-meta-label-bb-test "-nostartfiles -nodefaultlibs -static")
+macro(drbbdup_bb_test test)
+  add_exe(client.${test}-exe client-interface/${test}.asm)
+  set_target_properties(client.${test}-exe PROPERTIES LINKER_LANGUAGE C)
+  append_link_flags(client.${test}-exe "-nostartfiles -nodefaultlibs -static")
 
-  add_library(client.drbbdup-meta-label-bb-test.dll SHARED  client-interface/drbbdup-meta-label-bb-test.dll.c)
-  setup_test_client_dll_basics(client.drbbdup-meta-label-bb-test.dll)
-  use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drmgr)
-  use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drreg)
-  use_DynamoRIO_extension(client.drbbdup-meta-label-bb-test.dll drbbdup)
+  add_library(client.${test}.dll SHARED  client-interface/${test}.dll.c)
+  setup_test_client_dll_basics(client.${test}.dll)
+  use_DynamoRIO_extension(client.${test}.dll drmgr)
+  use_DynamoRIO_extension(client.${test}.dll drreg)
+  use_DynamoRIO_extension(client.${test}.dll drbbdup)
 
-  torunonly_ci(client.drbbdup-meta-label-bb-test client.drbbdup-meta-label-bb-test
-    client.drbbdup-meta-label-bb-test.dll client-interface/drbbdup-meta-label-bb-test.asm "" "-max_bb_instrs 0" "")
-endif (X86 AND LINUX)
+  torunonly_ci(client.${test} client.${test}-exe
+    client.${test}.dll client-interface/${test}.asm "" "-max_bb_instrs 0" "")
+endmacro(drbbdup_bb_test)
 
-if (X86 AND LINUX)
-  add_exe(client.drbbdup-meta-nop-bb-test client-interface/drbbdup-meta-nop-bb-test.asm)
-  set_target_properties(client.drbbdup-meta-nop-bb-test PROPERTIES LINKER_LANGUAGE C)
-  append_link_flags(client.drbbdup-meta-nop-bb-test "-nostartfiles -nodefaultlibs -static")
-
-  add_library(client.drbbdup-meta-nop-bb-test.dll SHARED  client-interface/drbbdup-meta-nop-bb-test.dll.c)
-  setup_test_client_dll_basics(client.drbbdup-meta-nop-bb-test.dll)
-  use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drmgr)
-  use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drreg)
-  use_DynamoRIO_extension(client.drbbdup-meta-nop-bb-test.dll drbbdup)
-
-  torunonly_ci(client.drbbdup-meta-nop-bb-test client.drbbdup-meta-nop-bb-test
-    client.drbbdup-meta-nop-bb-test.dll client-interface/drbbdup-meta-nop-bb-test.asm "" "-max_bb_instrs 0" "")
-endif (X86 AND LINUX)
-
-if (X86 AND LINUX)
-  add_exe(client.drbbdup-empty-bb-test client-interface/drbbdup-empty-bb-test.asm)
-  set_target_properties(client.drbbdup-empty-bb-test PROPERTIES LINKER_LANGUAGE C)
-  append_link_flags(client.drbbdup-empty-bb-test "-nostartfiles -nodefaultlibs -static")
-
-  add_library(client.drbbdup-empty-bb-test.dll SHARED  client-interface/drbbdup-empty-bb-test.dll.c)
-  setup_test_client_dll_basics(client.drbbdup-empty-bb-test.dll)
-  use_DynamoRIO_extension(client.drbbdup-empty-bb-test.dll drmgr)
-  use_DynamoRIO_extension(client.drbbdup-empty-bb-test.dll drreg)
-  use_DynamoRIO_extension(client.drbbdup-empty-bb-test.dll drbbdup)
-
-  torunonly_ci(client.drbbdup-empty-bb-test client.drbbdup-empty-bb-test
-    client.drbbdup-empty-bb-test.dll client-interface/drbbdup-empty-bb-test.asm "" "-max_bb_instrs 0" "")
-endif (X86 AND LINUX)
+if (X86 AND X64 AND LINUX)
+  drbbdup_bb_test(drbbdup-meta-label-bb-test)
+  drbbdup_bb_test(drbbdup-meta-nop-bb-test)
+  drbbdup_bb_test(drbbdup-empty-bb-test)
+endif (X86 AND X64 AND LINUX)
 
 tobuild_ci(client.drbbdup-no-encode-test client-interface/drbbdup-no-encode-test.c "" "" "")
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2609,6 +2609,21 @@ if (X86 AND UNIX)
     client.drbbdup-meta-nop-bb-test.dll client-interface/drbbdup-meta-nop-bb-test.asm "" "-max_bb_instrs 0" "")
 endif (X86 AND UNIX)
 
+if (X86 AND UNIX)
+  add_exe(client.drbbdup-empty-bb-test client-interface/drbbdup-empty-bb-test.asm)
+  set_target_properties(client.drbbdup-empty-bb-test PROPERTIES LINKER_LANGUAGE C)
+  append_link_flags(client.drbbdup-empty-bb-test "-nostartfiles -nodefaultlibs -static")
+
+  add_library(client.drbbdup-empty-bb-test.dll SHARED  client-interface/drbbdup-empty-bb-test.dll.c)
+  setup_test_client_dll_basics(client.drbbdup-empty-bb-test.dll)
+  use_DynamoRIO_extension(client.drbbdup-empty-bb-test.dll drmgr)
+  use_DynamoRIO_extension(client.drbbdup-empty-bb-test.dll drreg)
+  use_DynamoRIO_extension(client.drbbdup-empty-bb-test.dll drbbdup)
+
+  torunonly_ci(client.drbbdup-empty-bb-test client.drbbdup-empty-bb-test
+    client.drbbdup-empty-bb-test.dll client-interface/drbbdup-empty-bb-test.asm "" "-max_bb_instrs 0" "")
+endif (X86 AND UNIX)
+
 tobuild_ci(client.drbbdup-no-encode-test client-interface/drbbdup-no-encode-test.c "" "" "")
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drreg)

--- a/suite/tests/client-interface/drbbdup-drwrap-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-drwrap-test.dll.c
@@ -128,10 +128,8 @@ event_module_load(void *drcontext, const module_data_t *mod, bool loaded)
     app_pc target = (app_pc)dr_get_proc_address(mod->handle, "wrapme");
     CHECK(target != NULL, "cannot find lib export");
     int flags = 0;
-#if 0 /* TODO i#5356: Enable once drbbdup handles the no-app-pc sentinel block. */
     /* We test the hard-to-handle retaddr-replacing scheme. */
     flags |= DRWRAP_REPLACE_RETADDR;
-#endif
     bool res = drwrap_wrap_ex(target, wrap_pre, wrap_post, NULL, flags);
     CHECK(res, "wrap failed");
 }

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.asm
@@ -32,7 +32,6 @@
 
 .section .text
         .global main
-
 main:
         or eax,eax
         nop

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.asm
@@ -30,14 +30,18 @@
  * DAMAGE.
  */
 
-.global _start
+.text
+.globl _start
+.type _start, @function
+
+        .align   8
 _start:
-    or eax,eax
-    nop
-    nop
-    nop
-    mov eax, 1
-    nop
-    xor edx, edx
-    nop
-    int 0x80
+        or eax,eax
+        nop
+        nop
+        nop
+        mov eax, 1
+        nop
+        xor edx, edx
+        nop
+        int 0x80

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.asm
@@ -1,0 +1,43 @@
+/* **********************************************************
+ * Copyright (c) 2022 Google, Inc.   All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+.global _start
+_start:
+    or eax,eax
+    nop
+    nop
+    nop
+    mov eax, 1
+    nop
+    xor edx, edx
+    nop
+    int 0x80

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.asm
@@ -30,12 +30,10 @@
  * DAMAGE.
  */
 
-.text
-.globl _start
-.type _start, @function
+.section .text
+        .global main
 
-        .align   8
-_start:
+main:
         or eax,eax
         nop
         nop

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.asm
@@ -30,6 +30,9 @@
  * DAMAGE.
  */
 
+// X86 test program.
+// Must include nop instructions as they are assumed by the test.
+
 .section .text
         .global main
 main:
@@ -41,4 +44,6 @@ main:
         nop
         xor edx, edx
         nop
-        int 0x80
+        xor rdi, rdi
+        mov rax, 0x3c
+        syscall

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.dll.c
@@ -180,6 +180,7 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
     CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is first non-label");
     CHECK(is_first_nonlabel, "must be first non-label");
 
+    /* Relies on the -max_bb_instrs 0 option. */
     res = drbbdup_is_last_instr(drcontext, instr, &is_last);
     CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is last");
     CHECK(is_last, "must be last");

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.dll.c
@@ -1,0 +1,300 @@
+/* **********************************************************
+ * Copyright (c) 2022 Google, Inc.   All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Tests the drbbdup extension. */
+
+#include "dr_api.h"
+#include "client_tools.h"
+#include "drmgr.h"
+#include "drbbdup.h"
+
+#define TEST_PRIORITY_APP2APP_NAME "TEST_PRIORITY_APP2APP"
+#define TEST_PRIORITY_APP2APP 100
+
+#define ORIG_ANALYSIS_VAL (void *)555
+#define ANALYSIS_VAL_1 (void *)888
+#define ANALYSIS_VAL_2 (void *)999
+
+static bool orig_analysis_called = false;
+static bool orig_analysis_destroy_called = false;
+static bool default_analysis_called = false;
+static bool case1_analysis_called = false;
+static bool case1_analysis_destroy_called = false;
+static bool case2_analysis_called = false;
+static bool case2_analysis_destroy_called = false;
+static bool instrum_called = false;
+static bool encountered_empty = false;
+static bool is_cur_empty = false;
+
+/* Assume single threaded. */
+static uintptr_t encode_val = 3;
+
+static bool
+is_empty_bb(instrlist_t *bb)
+{
+    return instrlist_first(bb) == NULL;
+}
+
+static dr_emit_flags_t
+remove_app_instr(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+                 bool translating)
+{
+    instr_t *first_instr = instrlist_first_app(bb);
+    CHECK(instr_get_next(first_instr) == NULL, "must just be 1 instr");
+
+    /* Remove app instruction to create an empty block. */
+    if (instr_is_nop(first_instr)) {
+        instrlist_remove(bb, first_instr);
+        instr_destroy(drcontext, first_instr);
+        CHECK(is_empty_bb(bb), "now must be an empty block");
+        is_cur_empty = true;
+    } else {
+        is_cur_empty = false; /* note, current block is not empty. */
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    drbbdup_status_t res;
+
+    if (is_empty_bb(bb))
+        encountered_empty = true;
+
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 1);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 2);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 2");
+
+    *enable_dups = true;              /* always enable dups */
+    *enable_dynamic_handling = false; /* disable dynamic handling */
+
+    return 0; /* return default case */
+}
+
+static void
+orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
+                void **orig_analysis_data)
+{
+    if (is_cur_empty)
+        CHECK(is_empty_bb(bb), "should be empty");
+
+    *orig_analysis_data = ORIG_ANALYSIS_VAL;
+    orig_analysis_called = true;
+}
+
+static void
+destroy_orig_analysis(void *drcontext, void *user_data, void *orig_analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+    orig_analysis_destroy_called = true;
+}
+
+static dr_emit_flags_t
+analyse_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating,
+           uintptr_t encoding, void *user_data, void *orig_analysis_data,
+           void **analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    if (is_cur_empty)
+        CHECK(is_empty_bb(bb), "should be empty");
+
+    switch (encoding) {
+    case 0:
+        *analysis_data = NULL;
+        default_analysis_called = true;
+        break;
+    case 1:
+        *analysis_data = ANALYSIS_VAL_1;
+        case1_analysis_called = true;
+        break;
+    case 2:
+        *analysis_data = ANALYSIS_VAL_2;
+        case2_analysis_called = true;
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+destroy_analysis(void *drcontext, uintptr_t encoding, void *user_data,
+                 void *orig_analysis_data, void *analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    switch (encoding) {
+    case 0: CHECK(false, "should not be called because analysis data is NULL"); break;
+    case 1:
+        CHECK(analysis_data == ANALYSIS_VAL_1, "invalid encoding for case 1");
+        case1_analysis_destroy_called = true;
+        break;
+    case 2:
+        CHECK(analysis_data == ANALYSIS_VAL_2, "invalid encoding for case 2");
+        case2_analysis_destroy_called = true;
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+}
+
+static void
+update_encoding()
+{
+    if (encode_val != 0)
+        encode_val--;
+}
+
+static void
+insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
+              void *user_data, void *orig_analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    if (!is_cur_empty)
+        dr_insert_clean_call(drcontext, bb, where, update_encoding, false, 0);
+}
+
+static void
+print_case(uintptr_t case_val)
+{
+    dr_fprintf(STDERR, "case %u\n", case_val);
+}
+
+static dr_emit_flags_t
+instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                 instr_t *where, bool for_trace, bool translating, uintptr_t encoding,
+                 void *user_data, void *orig_analysis_data, void *analysis_data)
+{
+    bool is_first, is_first_nonlabel, is_last;
+    drbbdup_status_t res;
+
+    CHECK(!is_cur_empty, "should not be called for empty basic block");
+
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    switch (encoding) {
+    case 0:
+        CHECK(analysis_data == NULL, "case analysis does not match for default case");
+        break;
+    case 1:
+        CHECK(analysis_data == ANALYSIS_VAL_1, "case analysis does not match for case 1");
+        break;
+    case 2:
+        CHECK(analysis_data == ANALYSIS_VAL_2, "case analysis does not match for case 2");
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+
+    res = drbbdup_is_first_instr(drcontext, instr, &is_first);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is start");
+    CHECK(is_first, "must be first");
+
+    res = drbbdup_is_first_nonlabel_instr(drcontext, instr, &is_first_nonlabel);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is first non-label");
+    CHECK(is_first_nonlabel, "must be first non-label");
+
+    res = drbbdup_is_last_instr(drcontext, instr, &is_last);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is last");
+    CHECK(is_last, "must be last");
+
+    if (is_first && encoding != 0) {
+        instrum_called = true;
+        dr_insert_clean_call(drcontext, bb, where, print_case, false, 1,
+                             OPND_CREATE_INTPTR(encoding));
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+event_exit(void)
+{
+    drbbdup_status_t res;
+
+    res = drbbdup_exit();
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");
+
+    CHECK(orig_analysis_called, "orig analysis was not done");
+    CHECK(default_analysis_called, "default analysis was not done");
+    CHECK(case1_analysis_called, "case 1 analysis was not done");
+    CHECK(case2_analysis_called, "case 2 analysis was not done");
+
+    CHECK(orig_analysis_destroy_called, "orig analysis was not destroyed");
+    CHECK(case1_analysis_destroy_called, "case 1 analysis was not destroyed");
+    CHECK(case2_analysis_destroy_called, "case 2 analysis was not destroyed");
+
+    CHECK(instrum_called, "instrumentation was not inserted");
+    CHECK(encountered_empty, "encountered empty bb");
+
+    bool app2app_res = drmgr_unregister_bb_app2app_event(remove_app_instr);
+    CHECK(app2app_res, "failed to unregister app2app event");
+
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    drmgr_init();
+
+    drbbdup_options_t opts = { 0 };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = set_up_bb_dups;
+    opts.insert_encode = insert_encode;
+    opts.analyze_orig = orig_analyse_bb;
+    opts.destroy_orig_analysis = destroy_orig_analysis;
+    opts.analyze_case_ex = analyse_bb;
+    opts.destroy_case_analysis = destroy_analysis;
+    opts.instrument_instr_ex = instrument_instr;
+    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&encode_val, OPSZ_PTR);
+    /* Though single-threaded, we sanity-check the atomic load feature. */
+    opts.atomic_load_encoding = true;
+    opts.user_data = NULL;
+    opts.non_default_case_limit = 2;
+    opts.is_stat_enabled = false;
+
+    drmgr_priority_t app2app_priority = { sizeof(app2app_priority),
+                                          TEST_PRIORITY_APP2APP_NAME, NULL, NULL,
+                                          TEST_PRIORITY_APP2APP };
+
+    bool app2app_res =
+        drmgr_register_bb_app2app_event(remove_app_instr, &app2app_priority);
+    CHECK(app2app_res, "app2app failed");
+
+    drbbdup_status_t res = drbbdup_init(&opts);
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup init failed");
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.expect
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.expect
@@ -1,0 +1,2 @@
+case 2
+case 1

--- a/suite/tests/client-interface/drbbdup-empty-bb-test.expect
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.expect
@@ -1,2 +1,1 @@
-case 2
 case 1

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -1,0 +1,44 @@
+/* **********************************************************
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+.global _start
+
+_start:
+    or eax,eax
+    nop
+    nop
+    nop
+    mov eax, 1
+    nop
+    xor edx, edx
+    nop
+    int 0x80

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -31,7 +31,6 @@
  */
 
 .global _start
-
 _start:
     or eax,eax
     nop

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * Copyright (c) 2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -13,14 +13,14 @@
  *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
  *
- * * Neither the name of ARM Limited nor the names of its contributors may be
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
  *   used to endorse or promote products derived from this software without
  *   specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -32,7 +32,6 @@
 
 .section .text
         .global main
-
 main:
         or eax,eax
         nop

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -30,14 +30,18 @@
  * DAMAGE.
  */
 
-.global _start
+.text
+.globl _start
+.type _start, @function
+
+        .align   8
 _start:
-    or eax,eax
-    nop
-    nop
-    nop
-    mov eax, 1
-    nop
-    xor edx, edx
-    nop
-    int 0x80
+        or eax,eax
+        nop
+        nop
+        nop
+        mov eax, 1
+        nop
+        xor edx, edx
+        nop
+        int 0x80

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -30,12 +30,10 @@
  * DAMAGE.
  */
 
-.text
-.globl _start
-.type _start, @function
+.section .text
+        .global main
 
-        .align   8
-_start:
+main:
         or eax,eax
         nop
         nop

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -30,6 +30,9 @@
  * DAMAGE.
  */
 
+// X86 test program.
+// Must include nop instructions as they are assumed by the test.
+
 .section .text
         .global main
 main:
@@ -41,4 +44,6 @@ main:
         nop
         xor edx, edx
         nop
-        int 0x80
+        xor rdi, rdi
+        mov rax, 0x3c
+        syscall

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
@@ -1,0 +1,327 @@
+/* **********************************************************
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Tests the drbbdup extension. */
+
+#include "dr_api.h"
+#include "client_tools.h"
+#include "drmgr.h"
+#include "drbbdup.h"
+
+#define TEST_PRIORITY_APP2APP_NAME "TEST_PRIORITY_APP2APP"
+#define TEST_PRIORITY_APP2APP 100
+
+#define ORIG_ANALYSIS_VAL (void *)555
+#define ANALYSIS_VAL_1 (void *)888
+#define ANALYSIS_VAL_2 (void *)999
+
+static bool orig_analysis_called = false;
+static bool orig_analysis_destroy_called = false;
+static bool default_analysis_called = false;
+static bool case1_analysis_called = false;
+static bool case1_analysis_destroy_called = false;
+static bool case2_analysis_called = false;
+static bool case2_analysis_destroy_called = false;
+static bool instrum_called = false;
+static bool encountered_all_meta = false;
+static bool is_cur_all_meta = false;
+
+/* Assume single threaded. */
+static uintptr_t encode_val = 3;
+
+static bool
+is_meta_label(instr_t *meta_label_instr)
+{
+
+    if (meta_label_instr == NULL)
+        return false;
+
+    return instr_is_meta(meta_label_instr) && instr_is_label(meta_label_instr);
+}
+
+static bool
+is_meta_bb(instrlist_t *bb)
+{
+
+    /* A meta bb should only contain meta instructions (i.e., no app instructions). */
+    if (instrlist_first_app(bb) != NULL)
+        return false;
+
+    instr_t *meta_label_instr = instrlist_first(bb);
+    if (!is_meta_label(meta_label_instr))
+        return false;
+
+    return instr_get_next(meta_label_instr) == NULL;
+}
+
+static dr_emit_flags_t
+remove_app_instr(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+                 bool translating)
+{
+
+    instr_t *first_instr = instrlist_first_app(bb);
+    CHECK(instr_get_next(first_instr) == NULL, "Must just be 1 instr");
+
+    /* Remove app instruction and instead add a meta label. */
+    if (instr_is_nop(first_instr)) {
+        instrlist_meta_preinsert(bb, first_instr, INSTR_CREATE_label(drcontext));
+        instrlist_remove(bb, first_instr);
+        instr_destroy(drcontext, first_instr);
+        CHECK(is_meta_bb(bb), "Now must be a meta block");
+        is_cur_all_meta = true;
+    } else {
+        is_cur_all_meta = false; /* note, current block is not a meta block. */
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    drbbdup_status_t res;
+
+    if (is_meta_bb(bb))
+        encountered_all_meta = true;
+
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 1);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 2);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 2");
+
+    *enable_dups = true;              /* always enable dups */
+    *enable_dynamic_handling = false; /* disable dynamic handling */
+
+    return 0; /* return default case */
+}
+
+static void
+orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
+                void **orig_analysis_data)
+{
+
+    if (is_cur_all_meta)
+        CHECK(is_meta_bb(bb), "should be all meta");
+
+    *orig_analysis_data = ORIG_ANALYSIS_VAL;
+    orig_analysis_called = true;
+}
+
+static void
+destroy_orig_analysis(void *drcontext, void *user_data, void *orig_analysis_data)
+{
+
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+    orig_analysis_destroy_called = true;
+}
+
+static dr_emit_flags_t
+analyse_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating,
+           uintptr_t encoding, void *user_data, void *orig_analysis_data,
+           void **analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    if (is_cur_all_meta)
+        CHECK(is_meta_bb(bb), "should be all meta");
+
+    switch (encoding) {
+    case 0:
+        *analysis_data = NULL;
+        default_analysis_called = true;
+        break;
+    case 1:
+        *analysis_data = ANALYSIS_VAL_1;
+        case1_analysis_called = true;
+        break;
+    case 2:
+        *analysis_data = ANALYSIS_VAL_2;
+        case2_analysis_called = true;
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+destroy_analysis(void *drcontext, uintptr_t encoding, void *user_data,
+                 void *orig_analysis_data, void *analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    switch (encoding) {
+    case 0: CHECK(false, "should not be called because analysis data is NULL"); break;
+    case 1:
+        CHECK(analysis_data == ANALYSIS_VAL_1, "invalid encoding for case 1");
+        case1_analysis_destroy_called = true;
+        break;
+    case 2:
+        CHECK(analysis_data == ANALYSIS_VAL_2, "invalid encoding for case 2");
+        case2_analysis_destroy_called = true;
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+}
+
+static void
+update_encoding()
+{
+    if (encode_val != 0)
+        encode_val--;
+}
+
+static void
+insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
+              void *user_data, void *orig_analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    dr_insert_clean_call(drcontext, bb, where, update_encoding, false, 0);
+}
+
+static void
+print_case(uintptr_t case_val)
+{
+    dr_fprintf(STDERR, "case %u\n", case_val);
+}
+
+static dr_emit_flags_t
+instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                 instr_t *where, bool for_trace, bool translating, uintptr_t encoding,
+                 void *user_data, void *orig_analysis_data, void *analysis_data)
+{
+
+    bool is_first, is_first_nonlabel, is_last;
+    drbbdup_status_t res;
+
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    switch (encoding) {
+    case 0:
+        CHECK(analysis_data == NULL, "case analysis does not match for default case");
+        break;
+    case 1:
+        CHECK(analysis_data == ANALYSIS_VAL_1, "case analysis does not match for case 1");
+        break;
+    case 2:
+        CHECK(analysis_data == ANALYSIS_VAL_2, "case analysis does not match for case 2");
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+
+    if (is_cur_all_meta)
+        CHECK(is_meta_label(instr), "should be the meta label instruction");
+
+    res = drbbdup_is_first_instr(drcontext, instr, &is_first);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is start");
+    CHECK(is_first, "must be first");
+
+    res = drbbdup_is_first_nonlabel_instr(drcontext, instr, &is_first_nonlabel);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is first non-label");
+    if (is_cur_all_meta)
+        CHECK(!is_first_nonlabel, "no non-label should be available");
+    else
+        CHECK(is_first_nonlabel, "must be first non-label");
+
+    res = drbbdup_is_last_instr(drcontext, instr, &is_last);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is last");
+    CHECK(is_last, "must be last");
+
+    if (is_first && encoding != 0) {
+        instrum_called = true;
+        dr_insert_clean_call(drcontext, bb, where, print_case, false, 1,
+                             OPND_CREATE_INTPTR(encoding));
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+event_exit(void)
+{
+    drbbdup_status_t res;
+
+    res = drbbdup_exit();
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");
+
+    CHECK(orig_analysis_called, "orig analysis was not done");
+    CHECK(default_analysis_called, "default analysis was not done");
+    CHECK(case1_analysis_called, "case 1 analysis was not done");
+    CHECK(case2_analysis_called, "case 2 analysis was not done");
+
+    CHECK(orig_analysis_destroy_called, "orig analysis was not destroyed");
+    CHECK(case1_analysis_destroy_called, "case 1 analysis was not destroyed");
+    CHECK(case2_analysis_destroy_called, "case 2 analysis was not destroyed");
+
+    CHECK(instrum_called, "instrumentation was not inserted");
+    CHECK(encountered_all_meta, "encountered bb consisting solely of meta instructions");
+
+    bool app2app_res = drmgr_unregister_bb_app2app_event(remove_app_instr);
+    CHECK(app2app_res, "failed to unregister app2app event");
+
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    drmgr_init();
+
+    drbbdup_options_t opts = { 0 };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = set_up_bb_dups;
+    opts.insert_encode = insert_encode;
+    opts.analyze_orig = orig_analyse_bb;
+    opts.destroy_orig_analysis = destroy_orig_analysis;
+    opts.analyze_case_ex = analyse_bb;
+    opts.destroy_case_analysis = destroy_analysis;
+    opts.instrument_instr_ex = instrument_instr;
+    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&encode_val, OPSZ_PTR);
+    /* Though single-threaded, we sanity-check the atomic load feature. */
+    opts.atomic_load_encoding = true;
+    opts.user_data = NULL;
+    opts.non_default_case_limit = 2;
+    opts.is_stat_enabled = false;
+
+    drmgr_priority_t app2app_priority = { sizeof(app2app_priority),
+                                          TEST_PRIORITY_APP2APP_NAME, NULL, NULL,
+                                          TEST_PRIORITY_APP2APP };
+
+    bool app2app_res =
+        drmgr_register_bb_app2app_event(remove_app_instr, &app2app_priority);
+    CHECK(app2app_res, "app2app failed");
+
+    drbbdup_status_t res = drbbdup_init(&opts);
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup init failed");
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
@@ -61,7 +61,6 @@ static uintptr_t encode_val = 3;
 static bool
 is_meta_label(instr_t *meta_label_instr)
 {
-
     if (meta_label_instr == NULL)
         return false;
 
@@ -71,7 +70,6 @@ is_meta_label(instr_t *meta_label_instr)
 static bool
 is_meta_bb(instrlist_t *bb)
 {
-
     /* A meta bb should only contain meta instructions (i.e., no app instructions). */
     if (instrlist_first_app(bb) != NULL)
         return false;
@@ -87,16 +85,15 @@ static dr_emit_flags_t
 remove_app_instr(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                  bool translating)
 {
-
     instr_t *first_instr = instrlist_first_app(bb);
-    CHECK(instr_get_next(first_instr) == NULL, "Must just be 1 instr");
+    CHECK(instr_get_next(first_instr) == NULL, "must just be 1 instr");
 
     /* Remove app instruction and instead add a meta label. */
     if (instr_is_nop(first_instr)) {
         instrlist_meta_preinsert(bb, first_instr, INSTR_CREATE_label(drcontext));
         instrlist_remove(bb, first_instr);
         instr_destroy(drcontext, first_instr);
-        CHECK(is_meta_bb(bb), "Now must be a meta block");
+        CHECK(is_meta_bb(bb), "now must be a meta block");
         is_cur_all_meta = true;
     } else {
         is_cur_all_meta = false; /* note, current block is not a meta block. */
@@ -129,7 +126,6 @@ static void
 orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
                 void **orig_analysis_data)
 {
-
     if (is_cur_all_meta)
         CHECK(is_meta_bb(bb), "should be all meta");
 
@@ -140,7 +136,6 @@ orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
 static void
 destroy_orig_analysis(void *drcontext, void *user_data, void *orig_analysis_data)
 {
-
     CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
     orig_analysis_destroy_called = true;
 }
@@ -221,7 +216,6 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
                  instr_t *where, bool for_trace, bool translating, uintptr_t encoding,
                  void *user_data, void *orig_analysis_data, void *analysis_data)
 {
-
     bool is_first, is_first_nonlabel, is_last;
     drbbdup_status_t res;
 

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.dll.c
@@ -32,6 +32,16 @@
 
 /* Tests the drbbdup extension. */
 
+/* This test checks drbbdup's processing of basic blocks containing one meta label
+ * instruction. */
+
+/* Assumes that the target program contains nop instructions and that basic blocks
+ * constructed by DynamoRIO are size of 1 instruction. The latter is achieved using the
+ * max_bb_instrs runtime option.
+ *
+ * Nops are required as they are the type of instructions replaced by this test.
+ */
+
 #include "dr_api.h"
 #include "client_tools.h"
 #include "drmgr.h"
@@ -42,21 +52,17 @@
 
 #define ORIG_ANALYSIS_VAL (void *)555
 #define ANALYSIS_VAL_1 (void *)888
-#define ANALYSIS_VAL_2 (void *)999
 
 static bool orig_analysis_called = false;
-static bool orig_analysis_destroy_called = false;
 static bool default_analysis_called = false;
 static bool case1_analysis_called = false;
 static bool case1_analysis_destroy_called = false;
-static bool case2_analysis_called = false;
-static bool case2_analysis_destroy_called = false;
 static bool instrum_called = false;
 static bool encountered_all_meta = false;
 static bool is_cur_all_meta = false;
 
 /* Assume single threaded. */
-static uintptr_t encode_val = 3;
+static uintptr_t encode_val = 2;
 
 static bool
 is_meta_label(instr_t *meta_label_instr)
@@ -86,6 +92,7 @@ remove_app_instr(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                  bool translating)
 {
     instr_t *first_instr = instrlist_first_app(bb);
+    /* Relies on the -max_bb_instrs 0 option. */
     CHECK(instr_get_next(first_instr) == NULL, "must just be 1 instr");
 
     /* Remove app instruction and instead add a meta label. */
@@ -113,8 +120,6 @@ set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
 
     res = drbbdup_register_case_encoding(drbbdup_ctx, 1);
     CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
-    res = drbbdup_register_case_encoding(drbbdup_ctx, 2);
-    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 2");
 
     *enable_dups = true;              /* always enable dups */
     *enable_dynamic_handling = false; /* disable dynamic handling */
@@ -133,20 +138,11 @@ orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
     orig_analysis_called = true;
 }
 
-static void
-destroy_orig_analysis(void *drcontext, void *user_data, void *orig_analysis_data)
-{
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-    orig_analysis_destroy_called = true;
-}
-
 static dr_emit_flags_t
 analyse_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating,
            uintptr_t encoding, void *user_data, void *orig_analysis_data,
            void **analysis_data)
 {
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
     if (is_cur_all_meta)
         CHECK(is_meta_bb(bb), "should be all meta");
 
@@ -159,34 +155,10 @@ analyse_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool tra
         *analysis_data = ANALYSIS_VAL_1;
         case1_analysis_called = true;
         break;
-    case 2:
-        *analysis_data = ANALYSIS_VAL_2;
-        case2_analysis_called = true;
-        break;
     default: CHECK(false, "invalid encoding");
     }
 
     return DR_EMIT_DEFAULT;
-}
-
-static void
-destroy_analysis(void *drcontext, uintptr_t encoding, void *user_data,
-                 void *orig_analysis_data, void *analysis_data)
-{
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
-    switch (encoding) {
-    case 0: CHECK(false, "should not be called because analysis data is NULL"); break;
-    case 1:
-        CHECK(analysis_data == ANALYSIS_VAL_1, "invalid encoding for case 1");
-        case1_analysis_destroy_called = true;
-        break;
-    case 2:
-        CHECK(analysis_data == ANALYSIS_VAL_2, "invalid encoding for case 2");
-        case2_analysis_destroy_called = true;
-        break;
-    default: CHECK(false, "invalid encoding");
-    }
 }
 
 static void
@@ -200,8 +172,6 @@ static void
 insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
               void *user_data, void *orig_analysis_data)
 {
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
     dr_insert_clean_call(drcontext, bb, where, update_encoding, false, 0);
 }
 
@@ -218,21 +188,6 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
 {
     bool is_first, is_first_nonlabel, is_last;
     drbbdup_status_t res;
-
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
-    switch (encoding) {
-    case 0:
-        CHECK(analysis_data == NULL, "case analysis does not match for default case");
-        break;
-    case 1:
-        CHECK(analysis_data == ANALYSIS_VAL_1, "case analysis does not match for case 1");
-        break;
-    case 2:
-        CHECK(analysis_data == ANALYSIS_VAL_2, "case analysis does not match for case 2");
-        break;
-    default: CHECK(false, "invalid encoding");
-    }
 
     if (is_cur_all_meta)
         CHECK(is_meta_label(instr), "should be the meta label instruction");
@@ -271,11 +226,6 @@ event_exit(void)
     CHECK(orig_analysis_called, "orig analysis was not done");
     CHECK(default_analysis_called, "default analysis was not done");
     CHECK(case1_analysis_called, "case 1 analysis was not done");
-    CHECK(case2_analysis_called, "case 2 analysis was not done");
-
-    CHECK(orig_analysis_destroy_called, "orig analysis was not destroyed");
-    CHECK(case1_analysis_destroy_called, "case 1 analysis was not destroyed");
-    CHECK(case2_analysis_destroy_called, "case 2 analysis was not destroyed");
 
     CHECK(instrum_called, "instrumentation was not inserted");
     CHECK(encountered_all_meta, "encountered bb consisting solely of meta instructions");
@@ -296,9 +246,9 @@ dr_init(client_id_t id)
     opts.set_up_bb_dups = set_up_bb_dups;
     opts.insert_encode = insert_encode;
     opts.analyze_orig = orig_analyse_bb;
-    opts.destroy_orig_analysis = destroy_orig_analysis;
+    opts.destroy_orig_analysis = NULL;
     opts.analyze_case_ex = analyse_bb;
-    opts.destroy_case_analysis = destroy_analysis;
+    opts.destroy_case_analysis = NULL;
     opts.instrument_instr_ex = instrument_instr;
     opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&encode_val, OPSZ_PTR);
     /* Though single-threaded, we sanity-check the atomic load feature. */

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.expect
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.expect
@@ -1,0 +1,2 @@
+case 2
+case 1

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.expect
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.expect
@@ -1,2 +1,1 @@
-case 2
 case 1

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -1,0 +1,44 @@
+/* **********************************************************
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+.global _start
+
+_start:
+    or eax,eax
+    nop
+    nop
+    nop
+    mov eax, 1
+    nop
+    xor edx, edx
+    nop
+    int 0x80

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -31,7 +31,6 @@
  */
 
 .global _start
-
 _start:
     or eax,eax
     nop

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * Copyright (c) 2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -13,14 +13,14 @@
  *   this list of conditions and the following disclaimer in the documentation
  *   and/or other materials provided with the distribution.
  *
- * * Neither the name of ARM Limited nor the names of its contributors may be
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
  *   used to endorse or promote products derived from this software without
  *   specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -32,7 +32,6 @@
 
 .section .text
         .global main
-
 main:
         or eax,eax
         nop

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -30,14 +30,18 @@
  * DAMAGE.
  */
 
-.global _start
+.text
+.globl _start
+.type _start, @function
+
+        .align   8
 _start:
-    or eax,eax
-    nop
-    nop
-    nop
-    mov eax, 1
-    nop
-    xor edx, edx
-    nop
-    int 0x80
+        or eax,eax
+        nop
+        nop
+        nop
+        mov eax, 1
+        nop
+        xor edx, edx
+        nop
+        int 0x80

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -30,12 +30,10 @@
  * DAMAGE.
  */
 
-.text
-.globl _start
-.type _start, @function
+.section .text
+        .global main
 
-        .align   8
-_start:
+main:
         or eax,eax
         nop
         nop

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -30,6 +30,9 @@
  * DAMAGE.
  */
 
+// X86 test program.
+// Must include nop instructions as they are assumed by the test.
+
 .section .text
         .global main
 main:
@@ -41,4 +44,6 @@ main:
         nop
         xor edx, edx
         nop
-        int 0x80
+        xor rdi, rdi
+        mov rax, 0x3c
+        syscall

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
@@ -61,7 +61,6 @@ static uintptr_t encode_val = 3;
 static bool
 is_meta_nop(instr_t *meta_nop_instr)
 {
-
     if (meta_nop_instr == NULL)
         return false;
 
@@ -71,7 +70,6 @@ is_meta_nop(instr_t *meta_nop_instr)
 static bool
 is_meta_bb(instrlist_t *bb)
 {
-
     /* A meta bb should only contain meta instructions (i.e., no app instructions). */
     if (instrlist_first_app(bb) != NULL)
         return false;
@@ -87,16 +85,15 @@ static dr_emit_flags_t
 remove_app_instr(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                  bool translating)
 {
-
     instr_t *first_instr = instrlist_first_app(bb);
-    CHECK(instr_get_next(first_instr) == NULL, "Must just be 1 instr");
+    CHECK(instr_get_next(first_instr) == NULL, "must just be 1 instr");
 
     /* Remove app instruction and instead add a meta nop. */
     if (instr_is_nop(first_instr)) {
         instrlist_meta_preinsert(bb, first_instr, XINST_CREATE_nop(drcontext));
         instrlist_remove(bb, first_instr);
         instr_destroy(drcontext, first_instr);
-        CHECK(is_meta_bb(bb), "Now must be a meta block");
+        CHECK(is_meta_bb(bb), "now must be a meta block");
         is_cur_all_meta = true;
     } else {
         is_cur_all_meta = false; /* note, current block is not a meta block. */
@@ -129,7 +126,6 @@ static void
 orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
                 void **orig_analysis_data)
 {
-
     if (is_cur_all_meta)
         CHECK(is_meta_bb(bb), "should be all meta");
 
@@ -140,7 +136,6 @@ orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
 static void
 destroy_orig_analysis(void *drcontext, void *user_data, void *orig_analysis_data)
 {
-
     CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
     orig_analysis_destroy_called = true;
 }
@@ -221,7 +216,6 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
                  instr_t *where, bool for_trace, bool translating, uintptr_t encoding,
                  void *user_data, void *orig_analysis_data, void *analysis_data)
 {
-
     bool is_first, is_first_nonlabel, is_last;
     drbbdup_status_t res;
 

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
@@ -32,6 +32,18 @@
 
 /* Tests the drbbdup extension. */
 
+/* Tests the drbbdup extension. */
+
+/* This test checks drbbdup's processing of basic blocks containing one meta nop
+ * instruction (and no app instructions). */
+
+/* Assumes that the target program contains nop instructions and that basic blocks
+ * constructed by DynamoRIO are size of 1 instruction. The latter is achieved using the
+ * max_bb_instrs runtime option.
+ *
+ * Nops are required as they are the type of instructions replaced by this test.
+ */
+
 #include "dr_api.h"
 #include "client_tools.h"
 #include "drmgr.h"
@@ -42,21 +54,16 @@
 
 #define ORIG_ANALYSIS_VAL (void *)555
 #define ANALYSIS_VAL_1 (void *)888
-#define ANALYSIS_VAL_2 (void *)999
 
 static bool orig_analysis_called = false;
-static bool orig_analysis_destroy_called = false;
 static bool default_analysis_called = false;
 static bool case1_analysis_called = false;
-static bool case1_analysis_destroy_called = false;
-static bool case2_analysis_called = false;
-static bool case2_analysis_destroy_called = false;
 static bool instrum_called = false;
 static bool encountered_all_meta = false;
 static bool is_cur_all_meta = false;
 
 /* Assume single threaded. */
-static uintptr_t encode_val = 3;
+static uintptr_t encode_val = 2;
 
 static bool
 is_meta_nop(instr_t *meta_nop_instr)
@@ -86,6 +93,7 @@ remove_app_instr(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                  bool translating)
 {
     instr_t *first_instr = instrlist_first_app(bb);
+    /* Relies on the -max_bb_instrs 0 option. */
     CHECK(instr_get_next(first_instr) == NULL, "must just be 1 instr");
 
     /* Remove app instruction and instead add a meta nop. */
@@ -113,8 +121,6 @@ set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
 
     res = drbbdup_register_case_encoding(drbbdup_ctx, 1);
     CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
-    res = drbbdup_register_case_encoding(drbbdup_ctx, 2);
-    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 2");
 
     *enable_dups = true;              /* always enable dups */
     *enable_dynamic_handling = false; /* disable dynamic handling */
@@ -133,20 +139,11 @@ orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
     orig_analysis_called = true;
 }
 
-static void
-destroy_orig_analysis(void *drcontext, void *user_data, void *orig_analysis_data)
-{
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-    orig_analysis_destroy_called = true;
-}
-
 static dr_emit_flags_t
 analyse_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating,
            uintptr_t encoding, void *user_data, void *orig_analysis_data,
            void **analysis_data)
 {
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
     if (is_cur_all_meta)
         CHECK(is_meta_bb(bb), "should be all meta");
 
@@ -159,34 +156,10 @@ analyse_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool tra
         *analysis_data = ANALYSIS_VAL_1;
         case1_analysis_called = true;
         break;
-    case 2:
-        *analysis_data = ANALYSIS_VAL_2;
-        case2_analysis_called = true;
-        break;
     default: CHECK(false, "invalid encoding");
     }
 
     return DR_EMIT_DEFAULT;
-}
-
-static void
-destroy_analysis(void *drcontext, uintptr_t encoding, void *user_data,
-                 void *orig_analysis_data, void *analysis_data)
-{
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
-    switch (encoding) {
-    case 0: CHECK(false, "should not be called because analysis data is NULL"); break;
-    case 1:
-        CHECK(analysis_data == ANALYSIS_VAL_1, "invalid encoding for case 1");
-        case1_analysis_destroy_called = true;
-        break;
-    case 2:
-        CHECK(analysis_data == ANALYSIS_VAL_2, "invalid encoding for case 2");
-        case2_analysis_destroy_called = true;
-        break;
-    default: CHECK(false, "invalid encoding");
-    }
 }
 
 static void
@@ -200,8 +173,6 @@ static void
 insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
               void *user_data, void *orig_analysis_data)
 {
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
     dr_insert_clean_call(drcontext, bb, where, update_encoding, false, 0);
 }
 
@@ -218,21 +189,6 @@ instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
 {
     bool is_first, is_first_nonlabel, is_last;
     drbbdup_status_t res;
-
-    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
-
-    switch (encoding) {
-    case 0:
-        CHECK(analysis_data == NULL, "case analysis does not match for default case");
-        break;
-    case 1:
-        CHECK(analysis_data == ANALYSIS_VAL_1, "case analysis does not match for case 1");
-        break;
-    case 2:
-        CHECK(analysis_data == ANALYSIS_VAL_2, "case analysis does not match for case 2");
-        break;
-    default: CHECK(false, "invalid encoding");
-    }
 
     if (is_cur_all_meta)
         CHECK(is_meta_nop(instr), "should be the meta nop instruction");
@@ -268,11 +224,6 @@ event_exit(void)
     CHECK(orig_analysis_called, "orig analysis was not done");
     CHECK(default_analysis_called, "default analysis was not done");
     CHECK(case1_analysis_called, "case 1 analysis was not done");
-    CHECK(case2_analysis_called, "case 2 analysis was not done");
-
-    CHECK(orig_analysis_destroy_called, "orig analysis was not destroyed");
-    CHECK(case1_analysis_destroy_called, "case 1 analysis was not destroyed");
-    CHECK(case2_analysis_destroy_called, "case 2 analysis was not destroyed");
 
     CHECK(instrum_called, "instrumentation was not inserted");
     CHECK(encountered_all_meta, "encountered bb consisting solely of meta instructions");
@@ -293,9 +244,9 @@ dr_init(client_id_t id)
     opts.set_up_bb_dups = set_up_bb_dups;
     opts.insert_encode = insert_encode;
     opts.analyze_orig = orig_analyse_bb;
-    opts.destroy_orig_analysis = destroy_orig_analysis;
+    opts.destroy_orig_analysis = NULL;
     opts.analyze_case_ex = analyse_bb;
-    opts.destroy_case_analysis = destroy_analysis;
+    opts.destroy_case_analysis = NULL;
     opts.instrument_instr_ex = instrument_instr;
     opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&encode_val, OPSZ_PTR);
     /* Though single-threaded, we sanity-check the atomic load feature. */

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.dll.c
@@ -1,0 +1,324 @@
+/* **********************************************************
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Tests the drbbdup extension. */
+
+#include "dr_api.h"
+#include "client_tools.h"
+#include "drmgr.h"
+#include "drbbdup.h"
+
+#define TEST_PRIORITY_APP2APP_NAME "TEST_PRIORITY_APP2APP"
+#define TEST_PRIORITY_APP2APP 100
+
+#define ORIG_ANALYSIS_VAL (void *)555
+#define ANALYSIS_VAL_1 (void *)888
+#define ANALYSIS_VAL_2 (void *)999
+
+static bool orig_analysis_called = false;
+static bool orig_analysis_destroy_called = false;
+static bool default_analysis_called = false;
+static bool case1_analysis_called = false;
+static bool case1_analysis_destroy_called = false;
+static bool case2_analysis_called = false;
+static bool case2_analysis_destroy_called = false;
+static bool instrum_called = false;
+static bool encountered_all_meta = false;
+static bool is_cur_all_meta = false;
+
+/* Assume single threaded. */
+static uintptr_t encode_val = 3;
+
+static bool
+is_meta_nop(instr_t *meta_nop_instr)
+{
+
+    if (meta_nop_instr == NULL)
+        return false;
+
+    return instr_is_meta(meta_nop_instr) && instr_is_nop(meta_nop_instr);
+}
+
+static bool
+is_meta_bb(instrlist_t *bb)
+{
+
+    /* A meta bb should only contain meta instructions (i.e., no app instructions). */
+    if (instrlist_first_app(bb) != NULL)
+        return false;
+
+    instr_t *meta_nop_instr = instrlist_first(bb);
+    if (!is_meta_nop(meta_nop_instr))
+        return false;
+
+    return instr_get_next(meta_nop_instr) == NULL;
+}
+
+static dr_emit_flags_t
+remove_app_instr(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+                 bool translating)
+{
+
+    instr_t *first_instr = instrlist_first_app(bb);
+    CHECK(instr_get_next(first_instr) == NULL, "Must just be 1 instr");
+
+    /* Remove app instruction and instead add a meta nop. */
+    if (instr_is_nop(first_instr)) {
+        instrlist_meta_preinsert(bb, first_instr, XINST_CREATE_nop(drcontext));
+        instrlist_remove(bb, first_instr);
+        instr_destroy(drcontext, first_instr);
+        CHECK(is_meta_bb(bb), "Now must be a meta block");
+        is_cur_all_meta = true;
+    } else {
+        is_cur_all_meta = false; /* note, current block is not a meta block. */
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    drbbdup_status_t res;
+
+    if (is_meta_bb(bb))
+        encountered_all_meta = true;
+
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 1);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 1");
+    res = drbbdup_register_case_encoding(drbbdup_ctx, 2);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to register case 2");
+
+    *enable_dups = true;              /* always enable dups */
+    *enable_dynamic_handling = false; /* disable dynamic handling */
+
+    return 0; /* return default case */
+}
+
+static void
+orig_analyse_bb(void *drcontext, void *tag, instrlist_t *bb, void *user_data,
+                void **orig_analysis_data)
+{
+
+    if (is_cur_all_meta)
+        CHECK(is_meta_bb(bb), "should be all meta");
+
+    *orig_analysis_data = ORIG_ANALYSIS_VAL;
+    orig_analysis_called = true;
+}
+
+static void
+destroy_orig_analysis(void *drcontext, void *user_data, void *orig_analysis_data)
+{
+
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+    orig_analysis_destroy_called = true;
+}
+
+static dr_emit_flags_t
+analyse_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating,
+           uintptr_t encoding, void *user_data, void *orig_analysis_data,
+           void **analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    if (is_cur_all_meta)
+        CHECK(is_meta_bb(bb), "should be all meta");
+
+    switch (encoding) {
+    case 0:
+        *analysis_data = NULL;
+        default_analysis_called = true;
+        break;
+    case 1:
+        *analysis_data = ANALYSIS_VAL_1;
+        case1_analysis_called = true;
+        break;
+    case 2:
+        *analysis_data = ANALYSIS_VAL_2;
+        case2_analysis_called = true;
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+destroy_analysis(void *drcontext, uintptr_t encoding, void *user_data,
+                 void *orig_analysis_data, void *analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    switch (encoding) {
+    case 0: CHECK(false, "should not be called because analysis data is NULL"); break;
+    case 1:
+        CHECK(analysis_data == ANALYSIS_VAL_1, "invalid encoding for case 1");
+        case1_analysis_destroy_called = true;
+        break;
+    case 2:
+        CHECK(analysis_data == ANALYSIS_VAL_2, "invalid encoding for case 2");
+        case2_analysis_destroy_called = true;
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+}
+
+static void
+update_encoding()
+{
+    if (encode_val != 0)
+        encode_val--;
+}
+
+static void
+insert_encode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
+              void *user_data, void *orig_analysis_data)
+{
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    dr_insert_clean_call(drcontext, bb, where, update_encoding, false, 0);
+}
+
+static void
+print_case(uintptr_t case_val)
+{
+    dr_fprintf(STDERR, "case %u\n", case_val);
+}
+
+static dr_emit_flags_t
+instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                 instr_t *where, bool for_trace, bool translating, uintptr_t encoding,
+                 void *user_data, void *orig_analysis_data, void *analysis_data)
+{
+
+    bool is_first, is_first_nonlabel, is_last;
+    drbbdup_status_t res;
+
+    CHECK(orig_analysis_data == ORIG_ANALYSIS_VAL, "orig analysis data does not match");
+
+    switch (encoding) {
+    case 0:
+        CHECK(analysis_data == NULL, "case analysis does not match for default case");
+        break;
+    case 1:
+        CHECK(analysis_data == ANALYSIS_VAL_1, "case analysis does not match for case 1");
+        break;
+    case 2:
+        CHECK(analysis_data == ANALYSIS_VAL_2, "case analysis does not match for case 2");
+        break;
+    default: CHECK(false, "invalid encoding");
+    }
+
+    if (is_cur_all_meta)
+        CHECK(is_meta_nop(instr), "should be the meta nop instruction");
+
+    res = drbbdup_is_first_instr(drcontext, instr, &is_first);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is start");
+    CHECK(is_first, "must be first");
+
+    res = drbbdup_is_first_nonlabel_instr(drcontext, instr, &is_first_nonlabel);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is first non-label");
+    CHECK(is_first_nonlabel, "must be first non-label");
+
+    res = drbbdup_is_last_instr(drcontext, instr, &is_last);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is last");
+    CHECK(is_last, "must be last");
+
+    if (is_first && encoding != 0) {
+        instrum_called = true;
+        dr_insert_clean_call(drcontext, bb, where, print_case, false, 1,
+                             OPND_CREATE_INTPTR(encoding));
+    }
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+event_exit(void)
+{
+    drbbdup_status_t res;
+
+    res = drbbdup_exit();
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");
+
+    CHECK(orig_analysis_called, "orig analysis was not done");
+    CHECK(default_analysis_called, "default analysis was not done");
+    CHECK(case1_analysis_called, "case 1 analysis was not done");
+    CHECK(case2_analysis_called, "case 2 analysis was not done");
+
+    CHECK(orig_analysis_destroy_called, "orig analysis was not destroyed");
+    CHECK(case1_analysis_destroy_called, "case 1 analysis was not destroyed");
+    CHECK(case2_analysis_destroy_called, "case 2 analysis was not destroyed");
+
+    CHECK(instrum_called, "instrumentation was not inserted");
+    CHECK(encountered_all_meta, "encountered bb consisting solely of meta instructions");
+
+    bool app2app_res = drmgr_unregister_bb_app2app_event(remove_app_instr);
+    CHECK(app2app_res, "failed to unregister app2app event");
+
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    drmgr_init();
+
+    drbbdup_options_t opts = { 0 };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = set_up_bb_dups;
+    opts.insert_encode = insert_encode;
+    opts.analyze_orig = orig_analyse_bb;
+    opts.destroy_orig_analysis = destroy_orig_analysis;
+    opts.analyze_case_ex = analyse_bb;
+    opts.destroy_case_analysis = destroy_analysis;
+    opts.instrument_instr_ex = instrument_instr;
+    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&encode_val, OPSZ_PTR);
+    /* Though single-threaded, we sanity-check the atomic load feature. */
+    opts.atomic_load_encoding = true;
+    opts.user_data = NULL;
+    opts.non_default_case_limit = 2;
+    opts.is_stat_enabled = false;
+
+    drmgr_priority_t app2app_priority = { sizeof(app2app_priority),
+                                          TEST_PRIORITY_APP2APP_NAME, NULL, NULL,
+                                          TEST_PRIORITY_APP2APP };
+
+    bool app2app_res =
+        drmgr_register_bb_app2app_event(remove_app_instr, &app2app_priority);
+    CHECK(app2app_res, "app2app failed");
+
+    drbbdup_status_t res = drbbdup_init(&opts);
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup init failed");
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.expect
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.expect
@@ -1,0 +1,2 @@
+case 2
+case 1

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.expect
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.expect
@@ -1,2 +1,1 @@
-case 2
 case 1


### PR DESCRIPTION
Adds drbbdup support for basic blocks consisting solely of meta instructions. The hash-table manager no longer uses  PCs of the first app instructions inside basic blocks as keys. Instead, tags of basic blocks are now used.

The PR also adds tests. 

Issue: #5356  