### PR TITLE
i#2626: AArch64 v8 decode: Fix missing element sizes in fp instrs

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -3544,6 +3544,41 @@ encode_opnd_sd_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
     return false;
 }
 
+/* hs_fsz: Operand size for half and single precision encoding of floating point
+ * vector instructions. We need to convert the generic size operand to the right
+ * encoding bits. It only supports VECTOR_ELEM_WIDTH_HALF and VECTOR_ELEM_WIDTH_SINGLE.
+ */
+static inline bool
+decode_opnd_hs_fsz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    if (((enc >> 22) & 1) == 0) {
+        *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_HALF, OPSZ_2b);
+        return true;
+    }
+    if (((enc >> 22) & 1) == 1) {
+        *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_SINGLE, OPSZ_2b);
+        return true;
+    }
+    return false;
+}
+
+static inline bool
+encode_opnd_hs_fsz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF) {
+        *enc_out = 0;
+        return true;
+    }
+    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_SINGLE) {
+        *enc_out = 1 << 22;
+        return true;
+    }
+    return false;
+}
+
 /* dq5_sz: D/Q register at bit position 5; bit 22 selects Q reg */
 
 static inline bool
@@ -3583,7 +3618,6 @@ immhb_shf_decode(uint enc, int opcode, byte *pc, OUT opnd_t *opnd, uint min_shif
     else
         return false;
 
-    opnd_add_flags(*opnd, DR_OPND_IS_SHIFT);
     return true;
 }
 
@@ -3591,7 +3625,13 @@ static inline bool
 immhb_shf_encode(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out,
                  uint min_shift)
 {
+
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+
     opnd_size_t shift_size = opnd_get_size(opnd);
+
     uint highest_bit;
     switch (shift_size) {
     case OPSZ_3b: highest_bit = 0; break;
@@ -3602,9 +3642,6 @@ immhb_shf_encode(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out,
     }
     ptr_int_t shift_amount;
     uint esize = 8 << highest_bit;
-
-    if (!opnd_is_immed_int(opnd))
-        return false;
 
     shift_amount = opnd_get_immed_int(opnd);
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -3629,7 +3629,6 @@ immhb_shf_encode(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out,
     if (!opnd_is_immed_int(opnd))
         return false;
 
-
     opnd_size_t shift_size = opnd_get_size(opnd);
 
     uint highest_bit;

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -324,8 +324,8 @@ x1001010xx0xxxxxxxxxxxxxxxxxxxxx  n   90          eor            wx0 : wx5 wx16 
 0111111000100001110010xxxxxxxxxx  n   112      fcvtau             s0 : s5
 0111111001100001110010xxxxxxxxxx  n   112      fcvtau             d0 : d5
 0x1011100x100001110010xxxxxxxxxx  n   112      fcvtau            dq0 : dq5 sd_sz
-000011100x100001011110xxxxxxxxxx  n   113       fcvtl            dq0 : dq5 sd_sz
-010011100x100001011110xxxxxxxxxx  n   114      fcvtl2            dq0 : dq5 sd_sz
+000011100x100001011110xxxxxxxxxx  n   113       fcvtl             q0 : dq5 hs_fsz
+010011100x100001011110xxxxxxxxxx  n   114      fcvtl2             q0 : dq5 hs_fsz
 0001111000110000000000xxxxxxxxxx  n   115      fcvtms             w0 : s5
 1001111000110000000000xxxxxxxxxx  n   115      fcvtms             x0 : s5
 0001111001110000000000xxxxxxxxxx  n   115      fcvtms             w0 : d5
@@ -367,8 +367,8 @@ x001111001100001000000xxxxxxxxxx  n   120      fcvtnu            wx0 : d5
 0111111011100001101010xxxxxxxxxx  n   122      fcvtpu             d0 : d5
 0x1011101x100001101010xxxxxxxxxx  n   122      fcvtpu            dq0 : dq5 sd_sz
 0111111001100001011010xxxxxxxxxx  n   123      fcvtxn             s0 : d5
-0010111001100001011010xxxxxxxxxx  n   123      fcvtxn             d0 : q5
-0110111001100001011010xxxxxxxxxx  n   124     fcvtxn2             q0 : q5
+0010111001100001011010xxxxxxxxxx  n   123      fcvtxn             d0 : q5 sd_sz
+0110111001100001011010xxxxxxxxxx  n   124     fcvtxn2             q0 : q5 sd_sz
 x001111000111000000000xxxxxxxxxx  n   125      fcvtzs            wx0 : s5
 x001111001111000000000xxxxxxxxxx  n   125      fcvtzs            wx0 : d5
 0101111010100001101110xxxxxxxxxx  n   125      fcvtzs             s0 : s5
@@ -397,11 +397,11 @@ x001111001011001xxxxxxxxxxxxxxxx  n   126      fcvtzu            wx0 : d5 scale
 0x1011100x1xxxxx110001xxxxxxxxxx  n   131     fmaxnmp            dq0 : dq5 dq16 sd_sz
 0111111000110000110010xxxxxxxxxx  n   131     fmaxnmp             s0 : dq5_sz sd_sz
 0111111001110000110010xxxxxxxxxx  n   131     fmaxnmp             d0 : dq5_sz sd_sz
-0110111000110000110010xxxxxxxxxx  n   132     fmaxnmv             s0 : q5
+0110111000110000110010xxxxxxxxxx  n   132     fmaxnmv             s0 : q5 sd_sz
 0x1011100x1xxxxx111101xxxxxxxxxx  n   133       fmaxp            dq0 : dq5 dq16 sd_sz
 0111111000110000111110xxxxxxxxxx  n   133       fmaxp             s0 : dq5_sz sd_sz
 0111111001110000111110xxxxxxxxxx  n   133       fmaxp             d0 : dq5_sz sd_sz
-0x10111000110000111110xxxxxxxxxx  n   134       fmaxv             s0 : dq5
+0x10111000110000111110xxxxxxxxxx  n   134       fmaxv             s0 : dq5 s_const_sz
 0x0011101x1xxxxx111101xxxxxxxxxx  n   135        fmin            dq0 : dq5 dq16 sd_sz
 00011110xx1xxxxx010110xxxxxxxxxx  n   135        fmin     float_reg0 : float_reg5 float_reg16
 0x0011101x1xxxxx110001xxxxxxxxxx  n   136      fminnm            dq0 : dq5 dq16 sd_sz
@@ -409,11 +409,11 @@ x001111001011001xxxxxxxxxxxxxxxx  n   126      fcvtzu            wx0 : d5 scale
 0x1011101x1xxxxx110001xxxxxxxxxx  n   137     fminnmp            dq0 : dq5 dq16 sd_sz
 0111111010110000110010xxxxxxxxxx  n   137     fminnmp             s0 : dq5_sz sd_sz
 0111111011110000110010xxxxxxxxxx  n   137     fminnmp             d0 : dq5_sz sd_sz
-0110111010110000110010xxxxxxxxxx  n   138     fminnmv             s0 : q5
+0110111010110000110010xxxxxxxxxx  n   138     fminnmv             s0 : q5 sd_sz
 0x1011101x1xxxxx111101xxxxxxxxxx  n   139       fminp            dq0 : dq5 dq16 sd_sz
 0111111010110000111110xxxxxxxxxx  n   139       fminp             s0 : dq5_sz sd_sz
 0111111011110000111110xxxxxxxxxx  n   139       fminp             d0 : dq5_sz sd_sz
-0x10111010110000111110xxxxxxxxxx  n   140       fminv             s0 : dq5
+0x10111010110000111110xxxxxxxxxx  n   140       fminv             s0 : dq5 s_const_sz
 0x0011100x1xxxxx110011xxxxxxxxxx  n   141        fmla            dq0 : dq0 dq5 dq16 sd_sz
 0x0011111xxxxxxx0001x0xxxxxxxxxx  n   141        fmla            dq0 : dq0 dq5 dq16 vindex_SD sd_sz
 0101111110xxxxxx0001x0xxxxxxxxxx  n   141        fmla             s0 : s0 s5 dq16 vindex_SD sd_sz
@@ -478,7 +478,7 @@ x001111001011001xxxxxxxxxxxxxxxx  n   126      fcvtzu            wx0 : d5 scale
 0x0011101x100001100110xxxxxxxxxx  n   164      frintz            dq0 : dq5 sd_sz
 0111111010100001110110xxxxxxxxxx  n   165     frsqrte             s0 : s5
 0111111011100001110110xxxxxxxxxx  n   165     frsqrte             d0 : d5
-0x1011101x100001110110xxxxxxxxxx  n   165     frsqrte            dq0 : dq5 bd_sz
+0x1011101x100001110110xxxxxxxxxx  n   165     frsqrte            dq0 : dq5 sd_sz
 0x0011101x1xxxxx111111xxxxxxxxxx  n   166     frsqrts            dq0 : dq5 dq16 sd_sz
 01011110101xxxxx111111xxxxxxxxxx  n   166     frsqrts             s0 : s5 s16
 01011110111xxxxx111111xxxxxxxxxx  n   166     frsqrts             d0 : d5 d16

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -70,17 +70,16 @@ x001111011100001000000xxxxxxxxxx  n   120   fcvtnu  wx0 : h5
 0x001110010xxxxx001101xxxxxxxxxx  n   129     fmax  dq0 : dq5 dq16 h_sz
 0x001110010xxxxx000001xxxxxxxxxx  n   130   fmaxnm  dq0 : dq5 dq16 h_sz
 0x101110010xxxxx000001xxxxxxxxxx  n   131  fmaxnmp  dq0 : dq5 dq16 h_sz
-0000111000110000110010xxxxxxxxxx  n   132  fmaxnmv   h0 : d5
-0100111000110000110010xxxxxxxxxx  n   132  fmaxnmv   h0 : q5
+0x00111000110000110010xxxxxxxxxx  n   132  fmaxnmv   h0 : dq5 h_sz
 0x101110010xxxxx001101xxxxxxxxxx  n   133    fmaxp  dq0 : dq5 dq16 h_sz
-0x00111000110000111110xxxxxxxxxx  n   134    fmaxv   h0 : dq5
+0x00111000110000111110xxxxxxxxxx  n   134    fmaxv   h0 : dq5 h_sz
 0x001110110xxxxx001101xxxxxxxxxx  n   135     fmin  dq0 : dq5 dq16 h_sz
 0x001110110xxxxx000001xxxxxxxxxx  n   136   fminnm  dq0 : dq5 dq16 h_sz
 0x101110110xxxxx000001xxxxxxxxxx  n   137  fminnmp  dq0 : dq5 dq16 h_sz
 0000111010110000110010xxxxxxxxxx  n   138  fminnmv   h0 : d5
 0100111010110000110010xxxxxxxxxx  n   138  fminnmv   h0 : q5
 0x101110110xxxxx001101xxxxxxxxxx  n   139    fminp  dq0 : dq5 dq16 h_sz
-0x00111010110000111110xxxxxxxxxx  n   140    fminv   h0 : dq5
+0x00111010110000111110xxxxxxxxxx  n   140    fminv   h0 : dq5 h_sz
 0x001110010xxxxx000011xxxxxxxxxx  n   141     fmla  dq0 : dq0 dq5 dq16 h_sz
 0x001110110xxxxx000011xxxxxxxxxx  n   144     fmls  dq0 : dq0 dq5 dq16 h_sz
 0x00111100xxxxxx0101x0xxxxxxxxxx  n   144     fmls  dq0 : dq5 dq16_h_sz vindex_H h_sz

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -172,7 +172,8 @@
 ---------?x---------x-----------  vindex_SD  # Index for vector with single or double
 ---------x----------------------  imm12sh    # shift for ADD/SUB (immediate); '0x'
                                              # elements, depending on bit 22 (sz)
----------x----------------------  sd_sz      # element width of FP vector reg for single
+---------x----------------------  sd_sz      # element width of FP vector reg for single or double
+---------x----------------------  hs_fsz      # element width of FP vector reg for half or single
 ---------x------------xxxxx-----  dq5_sz     # as dqx, but depending on the sz bit rather than the Q bit
 ---------++++xxx----------------  immhb_shf  # encoding of #shift value in immh:immb fields
 ---------++++xxx----------------  immhb_0shf # encoding of #shift value in zero-indexed immh:immb fields

--- a/suite/tests/api/dis-a64.txt
+++ b/suite/tests/api/dis-a64.txt
@@ -1472,16 +1472,6 @@ d69f03e0 : eret                           : eret
 7e616a74 : fcvtxn s20, d19                : fcvtxn %d19 -> %s20
 7e616bbe : fcvtxn s30, d29                : fcvtxn %d29 -> %s30
 
-# FCVTXN{2} <Vd>.<Tb>, <Vn>.<Ta>
-2e616820 : fcvtxn v0.2s, v1.2d            : fcvtxn %q1 -> %d0
-2e61692a : fcvtxn v10.2s, v9.2d           : fcvtxn %q9 -> %d10
-2e616a74 : fcvtxn v20.2s, v19.2d          : fcvtxn %q19 -> %d20
-2e616bbe : fcvtxn v30.2s, v29.2d          : fcvtxn %q29 -> %d30
-6e616820 : fcvtxn2 v0.4s, v1.2d            : fcvtxn2 %q1 -> %q0
-6e61692a : fcvtxn2 v10.4s, v9.2d           : fcvtxn2 %q9 -> %q10
-6e616a74 : fcvtxn2 v20.4s, v19.2d          : fcvtxn2 %q19 -> %q20
-6e616bbe : fcvtxn2 v30.4s, v29.2d          : fcvtxn2 %q29 -> %q30
-
 # FCCMP <Hn>, <Hm>, #<nzcv>, <cond>
 1ee10400 : fccmp  h0, h1, #0x0, eq        : fccmp  %h1 eq $0x00 -> %h0
 1ee31441 : fccmp  h2, h3, #0x1, ne        : fccmp  %h3 ne $0x01 -> %h2
@@ -2680,40 +2670,40 @@ d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x
 6e61abbe : fcvtnu v30.2d, v29.2d                    : fcvtnu %q29 $0x03 -> %q30
 
 # FCVTL <Vd>.4s, <Vn>.4h
-0e217800 : fcvtl v0.4s, v0.4h                       : fcvtl  %d0 $0x02 -> %d0
-0e2178a5 : fcvtl v5.4s, v5.4h                       : fcvtl  %d5 $0x02 -> %d5
-0e21794a : fcvtl v10.4s, v10.4h                     : fcvtl  %d10 $0x02 -> %d10
-0e2179ef : fcvtl v15.4s, v15.4h                     : fcvtl  %d15 $0x02 -> %d15
-0e217a94 : fcvtl v20.4s, v20.4h                     : fcvtl  %d20 $0x02 -> %d20
-0e217b39 : fcvtl v25.4s, v25.4h                     : fcvtl  %d25 $0x02 -> %d25
-0e217bde : fcvtl v30.4s, v30.4h                     : fcvtl  %d30 $0x02 -> %d30
+0e217800 : fcvtl v0.4s, v0.4h                       : fcvtl  %d0 $0x01 -> %q0
+0e2178a5 : fcvtl v5.4s, v5.4h                       : fcvtl  %d5 $0x01 -> %q5
+0e21794a : fcvtl v10.4s, v10.4h                     : fcvtl  %d10 $0x01 -> %q10
+0e2179ef : fcvtl v15.4s, v15.4h                     : fcvtl  %d15 $0x01 -> %q15
+0e217a94 : fcvtl v20.4s, v20.4h                     : fcvtl  %d20 $0x01 -> %q20
+0e217b39 : fcvtl v25.4s, v25.4h                     : fcvtl  %d25 $0x01 -> %q25
+0e217bde : fcvtl v30.4s, v30.4h                     : fcvtl  %d30 $0x01 -> %q30
 
 # FCVTL <Vd>.2d, <Vn>.2s
-0e617800 : fcvtl v0.2d, v0.2s                       : fcvtl  %d0 $0x03 -> %d0
-0e6178a5 : fcvtl v5.2d, v5.2s                       : fcvtl  %d5 $0x03 -> %d5
-0e61794a : fcvtl v10.2d, v10.2s                     : fcvtl  %d10 $0x03 -> %d10
-0e6179ef : fcvtl v15.2d, v15.2s                     : fcvtl  %d15 $0x03 -> %d15
-0e617a94 : fcvtl v20.2d, v20.2s                     : fcvtl  %d20 $0x03 -> %d20
-0e617b39 : fcvtl v25.2d, v25.2s                     : fcvtl  %d25 $0x03 -> %d25
-0e617bde : fcvtl v30.2d, v30.2s                     : fcvtl  %d30 $0x03 -> %d30
+0e617800 : fcvtl v0.2d, v0.2s                       : fcvtl  %d0 $0x02 -> %q0
+0e6178a5 : fcvtl v5.2d, v5.2s                       : fcvtl  %d5 $0x02 -> %q5
+0e61794a : fcvtl v10.2d, v10.2s                     : fcvtl  %d10 $0x02 -> %q10
+0e6179ef : fcvtl v15.2d, v15.2s                     : fcvtl  %d15 $0x02 -> %q15
+0e617a94 : fcvtl v20.2d, v20.2s                     : fcvtl  %d20 $0x02 -> %q20
+0e617b39 : fcvtl v25.2d, v25.2s                     : fcvtl  %d25 $0x02 -> %q25
+0e617bde : fcvtl v30.2d, v30.2s                     : fcvtl  %d30 $0x02 -> %q30
 
 # FCVTL2 <Vd>.4s, <Vn>.8h
-4e217800 : fcvtl2 v0.4s, v0.8h                      : fcvtl2 %q0 $0x02 -> %q0
-4e2178a5 : fcvtl2 v5.4s, v5.8h                      : fcvtl2 %q5 $0x02 -> %q5
-4e21794a : fcvtl2 v10.4s, v10.8h                    : fcvtl2 %q10 $0x02 -> %q10
-4e2179ef : fcvtl2 v15.4s, v15.8h                    : fcvtl2 %q15 $0x02 -> %q15
-4e217a94 : fcvtl2 v20.4s, v20.8h                    : fcvtl2 %q20 $0x02 -> %q20
-4e217b39 : fcvtl2 v25.4s, v25.8h                    : fcvtl2 %q25 $0x02 -> %q25
-4e217bde : fcvtl2 v30.4s, v30.8h                    : fcvtl2 %q30 $0x02 -> %q30
+4e217800 : fcvtl2 v0.4s, v0.8h                      : fcvtl2 %q0 $0x01 -> %q0
+4e2178a5 : fcvtl2 v5.4s, v5.8h                      : fcvtl2 %q5 $0x01 -> %q5
+4e21794a : fcvtl2 v10.4s, v10.8h                    : fcvtl2 %q10 $0x01 -> %q10
+4e2179ef : fcvtl2 v15.4s, v15.8h                    : fcvtl2 %q15 $0x01 -> %q15
+4e217a94 : fcvtl2 v20.4s, v20.8h                    : fcvtl2 %q20 $0x01 -> %q20
+4e217b39 : fcvtl2 v25.4s, v25.8h                    : fcvtl2 %q25 $0x01 -> %q25
+4e217bde : fcvtl2 v30.4s, v30.8h                    : fcvtl2 %q30 $0x01 -> %q30
 
 # FCVTL2 <Vd>.2d, <Vn>.4s
-4e617800 : fcvtl2 v0.2d, v0.4s                      : fcvtl2 %q0 $0x03 -> %q0
-4e6178a5 : fcvtl2 v5.2d, v5.4s                      : fcvtl2 %q5 $0x03 -> %q5
-4e61794a : fcvtl2 v10.2d, v10.4s                    : fcvtl2 %q10 $0x03 -> %q10
-4e6179ef : fcvtl2 v15.2d, v15.4s                    : fcvtl2 %q15 $0x03 -> %q15
-4e617a94 : fcvtl2 v20.2d, v20.4s                    : fcvtl2 %q20 $0x03 -> %q20
-4e617b39 : fcvtl2 v25.2d, v25.4s                    : fcvtl2 %q25 $0x03 -> %q25
-4e617bde : fcvtl2 v30.2d, v30.4s                    : fcvtl2 %q30 $0x03 -> %q30
+4e617800 : fcvtl2 v0.2d, v0.4s                      : fcvtl2 %q0 $0x02 -> %q0
+4e6178a5 : fcvtl2 v5.2d, v5.4s                      : fcvtl2 %q5 $0x02 -> %q5
+4e61794a : fcvtl2 v10.2d, v10.4s                    : fcvtl2 %q10 $0x02 -> %q10
+4e6179ef : fcvtl2 v15.2d, v15.4s                    : fcvtl2 %q15 $0x02 -> %q15
+4e617a94 : fcvtl2 v20.2d, v20.4s                    : fcvtl2 %q20 $0x02 -> %q20
+4e617b39 : fcvtl2 v25.2d, v25.4s                    : fcvtl2 %q25 $0x02 -> %q25
+4e617bde : fcvtl2 v30.2d, v30.4s                    : fcvtl2 %q30 $0x02 -> %q30
 
 # FCVTN <Vd>.4h, <Vn>.4s
 0e216800 : fcvtn v0.4h, v0.4s                       : fcvtn  %d0 $0x02 -> %d0
@@ -3014,20 +3004,20 @@ d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x
 6e79f6e5 : fmaxp v5.2d, v23.2d, v25.2d              : fmaxp  %q23 %q25 $0x03 -> %q5
 
 # FMAXV <V><d>, <Vn>.<T>
-6e30f820 : fmaxv s0, v1.4s                          : fmaxv  %q1 -> %s0
-6e30f96a : fmaxv s10, v11.4s                        : fmaxv  %q11 -> %s10
-6e30fab4 : fmaxv s20, v21.4s                        : fmaxv  %q21 -> %s20
-6e30fbdd : fmaxv s29, v30.4s                        : fmaxv  %q30 -> %s29
+6e30f820 : fmaxv s0, v1.4s                          : fmaxv  %q1 $0x02 -> %s0
+6e30f96a : fmaxv s10, v11.4s                        : fmaxv  %q11 $0x02 -> %s10
+6e30fab4 : fmaxv s20, v21.4s                        : fmaxv  %q21 $0x02 -> %s20
+6e30fbdd : fmaxv s29, v30.4s                        : fmaxv  %q30 $0x02 -> %s29
 
-0e30f820 : fmaxv h0, v1.4h                          : fmaxv  %d1 -> %h0
-0e30f96a : fmaxv h10, v11.4h                        : fmaxv  %d11 -> %h10
-0e30fab4 : fmaxv h20, v21.4h                        : fmaxv  %d21 -> %h20
-0e30fbdd : fmaxv h29, v30.4h                        : fmaxv  %d30 -> %h29
+0e30f820 : fmaxv h0, v1.4h                          : fmaxv  %d1 $0x01 -> %h0
+0e30f96a : fmaxv h10, v11.4h                        : fmaxv  %d11 $0x01 -> %h10
+0e30fab4 : fmaxv h20, v21.4h                        : fmaxv  %d21 $0x01 -> %h20
+0e30fbdd : fmaxv h29, v30.4h                        : fmaxv  %d30 $0x01 -> %h29
 
-4e30f841 : fmaxv h1, v2.8h                          : fmaxv  %q2 -> %h1
-4e30f98b : fmaxv h11, v12.8h                        : fmaxv  %q12 -> %h11
-4e30fad5 : fmaxv h21, v22.8h                        : fmaxv  %q22 -> %h21
-4e30fb9b : fmaxv h27, v28.8h                        : fmaxv  %q28 -> %h27
+4e30f841 : fmaxv h1, v2.8h                          : fmaxv  %q2 $0x01 -> %h1
+4e30f98b : fmaxv h11, v12.8h                        : fmaxv  %q12 $0x01 -> %h11
+4e30fad5 : fmaxv h21, v22.8h                        : fmaxv  %q22 $0x01 -> %h21
+4e30fb9b : fmaxv h27, v28.8h                        : fmaxv  %q28 $0x01 -> %h27
 
 0ecf3402 : fmin v2.4h, v0.4h, v15.4h                : fmin   %d0 %d15 $0x01 -> %d2
 4ecf3402 : fmin v2.8h, v0.8h, v15.8h                : fmin   %q0 %q15 $0x01 -> %q2
@@ -3060,20 +3050,20 @@ d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x
 6ef9f43c : fminp v28.2d, v1.2d, v25.2d              : fminp  %q1 %q25 $0x03 -> %q28
 
 # FMINV <V><d>, <Vn>.<T>
-6eb0f820 : fminv s0, v1.4s                          : fminv  %q1 -> %s0
-6eb0f96a : fminv s10, v11.4s                        : fminv  %q11 -> %s10
-6eb0fab4 : fminv s20, v21.4s                        : fminv  %q21 -> %s20
-6eb0fbdd : fminv s29, v30.4s                        : fminv  %q30 -> %s29
+6eb0f820 : fminv s0, v1.4s                          : fminv  %q1 $0x02 -> %s0
+6eb0f96a : fminv s10, v11.4s                        : fminv  %q11 $0x02 -> %s10
+6eb0fab4 : fminv s20, v21.4s                        : fminv  %q21 $0x02 -> %s20
+6eb0fbdd : fminv s29, v30.4s                        : fminv  %q30 $0x02 -> %s29
 
-0eb0f820 : fminv h0, v1.4h                          : fminv  %d1 -> %h0
-0eb0f96a : fminv h10, v11.4h                        : fminv  %d11 -> %h10
-0eb0fab4 : fminv h20, v21.4h                        : fminv  %d21 -> %h20
-0eb0fbdd : fminv h29, v30.4h                        : fminv  %d30 -> %h29
+0eb0f820 : fminv h0, v1.4h                          : fminv  %d1 $0x01 -> %h0
+0eb0f96a : fminv h10, v11.4h                        : fminv  %d11 $0x01 -> %h10
+0eb0fab4 : fminv h20, v21.4h                        : fminv  %d21 $0x01 -> %h20
+0eb0fbdd : fminv h29, v30.4h                        : fminv  %d30 $0x01 -> %h29
 
-4eb0f841 : fminv h1, v2.8h                          : fminv  %q2 -> %h1
-4eb0f98b : fminv h11, v12.8h                        : fminv  %q12 -> %h11
-4eb0fad5 : fminv h21, v22.8h                        : fminv  %q22 -> %h21
-4eb0fb9b : fminv h27, v28.8h                        : fminv  %q28 -> %h27
+4eb0f841 : fminv h1, v2.8h                          : fminv  %q2 $0x01 -> %h1
+4eb0f98b : fminv h11, v12.8h                        : fminv  %q12 $0x01 -> %h11
+4eb0fad5 : fminv h21, v22.8h                        : fminv  %q22 $0x01 -> %h21
+4eb0fb9b : fminv h27, v28.8h                        : fminv  %q28 $0x01 -> %h27
 
 # FRINTA <Vd>.<T>, <Vn>.<T>
 2e218841 : frinta  v1.2s, v2.2s                     : frinta %d2 $0x02 -> %d1
@@ -3853,32 +3843,18 @@ d2400441 : eor    x1, x2, #0x3            : eor    %x2 $0x0000000000000003 -> %x
 1fff504a : fnmadd h10, h2, h31, h20                 : fnmadd %h2 %h31 %h20 -> %h10
 
 # FMAXNMV <V><d>, <Vn>.<T>
-0e30c820 : fmaxnmv h0, v1.4h                        : fmaxnmv %d1 -> %h0
-0e30c92a : fmaxnmv h10, v9.4h                       : fmaxnmv %d9 -> %h10
-0e30ca74 : fmaxnmv h20, v19.4h                      : fmaxnmv %d19 -> %h20
-0e30cbbe : fmaxnmv h30, v29.4h                      : fmaxnmv %d29 -> %h30
-4e30c820 : fmaxnmv h0, v1.8h                        : fmaxnmv %q1 -> %h0
-4e30c92a : fmaxnmv h10, v9.8h                       : fmaxnmv %q9 -> %h10
-4e30ca74 : fmaxnmv h20, v19.8h                      : fmaxnmv %q19 -> %h20
-4e30cbbe : fmaxnmv h30, v29.8h                      : fmaxnmv %q29 -> %h30
-6e30c820 : fmaxnmv s0, v1.4s                        : fmaxnmv %q1 -> %s0
-6e30c92a : fmaxnmv s10, v9.4s                       : fmaxnmv %q9 -> %s10
-6e30ca74 : fmaxnmv s20, v19.4s                      : fmaxnmv %q19 -> %s20
-6e30cbbe : fmaxnmv s30, v29.4s                      : fmaxnmv %q29 -> %s30
-
-# FMINNMV <V><d>, <Vn>.<T>
-0eb0c820 : fminnmv h0, v1.4h                        : fminnmv %d1 -> %h0
-0eb0c92a : fminnmv h10, v9.4h                       : fminnmv %d9 -> %h10
-0eb0ca74 : fminnmv h20, v19.4h                      : fminnmv %d19 -> %h20
-0eb0cbbe : fminnmv h30, v29.4h                      : fminnmv %d29 -> %h30
-4eb0c820 : fminnmv h0, v1.8h                        : fminnmv %q1 -> %h0
-4eb0c92a : fminnmv h10, v9.8h                       : fminnmv %q9 -> %h10
-4eb0ca74 : fminnmv h20, v19.8h                      : fminnmv %q19 -> %h20
-4eb0cbbe : fminnmv h30, v29.8h                      : fminnmv %q29 -> %h30
-6eb0c820 : fminnmv s0, v1.4s                        : fminnmv %q1 -> %s0
-6eb0c92a : fminnmv s10, v9.4s                       : fminnmv %q9 -> %s10
-6eb0ca74 : fminnmv s20, v19.4s                      : fminnmv %q19 -> %s20
-6eb0cbbe : fminnmv s30, v29.4s                      : fminnmv %q29 -> %s30
+0e30c820 : fmaxnmv h0, v1.4h                        : fmaxnmv %d1 $0x01 -> %h0
+0e30c92a : fmaxnmv h10, v9.4h                       : fmaxnmv %d9 $0x01 -> %h10
+0e30ca74 : fmaxnmv h20, v19.4h                      : fmaxnmv %d19 $0x01 -> %h20
+0e30cbbe : fmaxnmv h30, v29.4h                      : fmaxnmv %d29 $0x01 -> %h30
+4e30c820 : fmaxnmv h0, v1.8h                        : fmaxnmv %q1 $0x01 -> %h0
+4e30c92a : fmaxnmv h10, v9.8h                       : fmaxnmv %q9 $0x01 -> %h10
+4e30ca74 : fmaxnmv h20, v19.8h                      : fmaxnmv %q19 $0x01 -> %h20
+4e30cbbe : fmaxnmv h30, v29.8h                      : fmaxnmv %q29 $0x01 -> %h30
+6e30c820 : fmaxnmv s0, v1.4s                        : fmaxnmv %q1 $0x02 -> %s0
+6e30c92a : fmaxnmv s10, v9.4s                       : fmaxnmv %q9 $0x02 -> %s10
+6e30ca74 : fmaxnmv s20, v19.4s                      : fmaxnmv %q19 $0x02 -> %s20
+6e30cbbe : fmaxnmv s30, v29.4s                      : fmaxnmv %q29 $0x02 -> %s30
 
 1f7789e4 : fnmsub d4, d15, d23, d2                  : fnmsub %d15 %d23 %d2 -> %d4
 1f3789e4 : fnmsub s4, s15, s23, s2                  : fnmsub %s15 %s23 %s2 -> %s4
@@ -28823,6 +28799,124 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 345ffffa : cbz w26, #0xbfffc                         : cbz    $0x00000000100bfffc %w26
 347ffffe : cbz w30, #0xffffc                         : cbz    $0x00000000100ffffc %w30
 
+# FCVTXN2 <Sd>.4S, <Dn>.2D (FCVTXN2-Q.Q-asimdmisc_N)
+6e616820 : fcvtxn2 v0.4s, v1.2d                      : fcvtxn2 %q1 $0x03 -> %q0
+6e616862 : fcvtxn2 v2.4s, v3.2d                      : fcvtxn2 %q3 $0x03 -> %q2
+6e6168a4 : fcvtxn2 v4.4s, v5.2d                      : fcvtxn2 %q5 $0x03 -> %q4
+6e6168e6 : fcvtxn2 v6.4s, v7.2d                      : fcvtxn2 %q7 $0x03 -> %q6
+6e616928 : fcvtxn2 v8.4s, v9.2d                      : fcvtxn2 %q9 $0x03 -> %q8
+6e61696a : fcvtxn2 v10.4s, v11.2d                    : fcvtxn2 %q11 $0x03 -> %q10
+6e6169ac : fcvtxn2 v12.4s, v13.2d                    : fcvtxn2 %q13 $0x03 -> %q12
+6e6169ee : fcvtxn2 v14.4s, v15.2d                    : fcvtxn2 %q15 $0x03 -> %q14
+6e616a30 : fcvtxn2 v16.4s, v17.2d                    : fcvtxn2 %q17 $0x03 -> %q16
+6e616a51 : fcvtxn2 v17.4s, v18.2d                    : fcvtxn2 %q18 $0x03 -> %q17
+6e616a93 : fcvtxn2 v19.4s, v20.2d                    : fcvtxn2 %q20 $0x03 -> %q19
+6e616ad5 : fcvtxn2 v21.4s, v22.2d                    : fcvtxn2 %q22 $0x03 -> %q21
+6e616b17 : fcvtxn2 v23.4s, v24.2d                    : fcvtxn2 %q24 $0x03 -> %q23
+6e616b59 : fcvtxn2 v25.4s, v26.2d                    : fcvtxn2 %q26 $0x03 -> %q25
+6e616b9b : fcvtxn2 v27.4s, v28.2d                    : fcvtxn2 %q28 $0x03 -> %q27
+6e61681f : fcvtxn2 v31.4s, v0.2d                     : fcvtxn2 %q0 $0x03 -> %q31
+
+# FMINNMP <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMINNMP-Q.QQ-asimdsame_only)
+2ea2c420 : fminnmp v0.2s, v1.2s, v2.2s               : fminnmp %d1 %d2 $0x02 -> %d0
+2ea4c462 : fminnmp v2.2s, v3.2s, v4.2s               : fminnmp %d3 %d4 $0x02 -> %d2
+2ea6c4a4 : fminnmp v4.2s, v5.2s, v6.2s               : fminnmp %d5 %d6 $0x02 -> %d4
+2ea8c4e6 : fminnmp v6.2s, v7.2s, v8.2s               : fminnmp %d7 %d8 $0x02 -> %d6
+2eaac528 : fminnmp v8.2s, v9.2s, v10.2s              : fminnmp %d9 %d10 $0x02 -> %d8
+2eacc56a : fminnmp v10.2s, v11.2s, v12.2s            : fminnmp %d11 %d12 $0x02 -> %d10
+2eaec5ac : fminnmp v12.2s, v13.2s, v14.2s            : fminnmp %d13 %d14 $0x02 -> %d12
+2eb0c5ee : fminnmp v14.2s, v15.2s, v16.2s            : fminnmp %d15 %d16 $0x02 -> %d14
+2eb2c630 : fminnmp v16.2s, v17.2s, v18.2s            : fminnmp %d17 %d18 $0x02 -> %d16
+2eb3c651 : fminnmp v17.2s, v18.2s, v19.2s            : fminnmp %d18 %d19 $0x02 -> %d17
+2eb5c693 : fminnmp v19.2s, v20.2s, v21.2s            : fminnmp %d20 %d21 $0x02 -> %d19
+2eb7c6d5 : fminnmp v21.2s, v22.2s, v23.2s            : fminnmp %d22 %d23 $0x02 -> %d21
+2eb9c717 : fminnmp v23.2s, v24.2s, v25.2s            : fminnmp %d24 %d25 $0x02 -> %d23
+2ebbc759 : fminnmp v25.2s, v26.2s, v27.2s            : fminnmp %d26 %d27 $0x02 -> %d25
+2ebdc79b : fminnmp v27.2s, v28.2s, v29.2s            : fminnmp %d28 %d29 $0x02 -> %d27
+2ea1c41f : fminnmp v31.2s, v0.2s, v1.2s              : fminnmp %d0 %d1 $0x02 -> %d31
+6ea2c420 : fminnmp v0.4s, v1.4s, v2.4s               : fminnmp %q1 %q2 $0x02 -> %q0
+6ea4c462 : fminnmp v2.4s, v3.4s, v4.4s               : fminnmp %q3 %q4 $0x02 -> %q2
+6ea6c4a4 : fminnmp v4.4s, v5.4s, v6.4s               : fminnmp %q5 %q6 $0x02 -> %q4
+6ea8c4e6 : fminnmp v6.4s, v7.4s, v8.4s               : fminnmp %q7 %q8 $0x02 -> %q6
+6eaac528 : fminnmp v8.4s, v9.4s, v10.4s              : fminnmp %q9 %q10 $0x02 -> %q8
+6eacc56a : fminnmp v10.4s, v11.4s, v12.4s            : fminnmp %q11 %q12 $0x02 -> %q10
+6eaec5ac : fminnmp v12.4s, v13.4s, v14.4s            : fminnmp %q13 %q14 $0x02 -> %q12
+6eb0c5ee : fminnmp v14.4s, v15.4s, v16.4s            : fminnmp %q15 %q16 $0x02 -> %q14
+6eb2c630 : fminnmp v16.4s, v17.4s, v18.4s            : fminnmp %q17 %q18 $0x02 -> %q16
+6eb3c651 : fminnmp v17.4s, v18.4s, v19.4s            : fminnmp %q18 %q19 $0x02 -> %q17
+6eb5c693 : fminnmp v19.4s, v20.4s, v21.4s            : fminnmp %q20 %q21 $0x02 -> %q19
+6eb7c6d5 : fminnmp v21.4s, v22.4s, v23.4s            : fminnmp %q22 %q23 $0x02 -> %q21
+6eb9c717 : fminnmp v23.4s, v24.4s, v25.4s            : fminnmp %q24 %q25 $0x02 -> %q23
+6ebbc759 : fminnmp v25.4s, v26.4s, v27.4s            : fminnmp %q26 %q27 $0x02 -> %q25
+6ebdc79b : fminnmp v27.4s, v28.4s, v29.4s            : fminnmp %q28 %q29 $0x02 -> %q27
+6ea1c41f : fminnmp v31.4s, v0.4s, v1.4s              : fminnmp %q0 %q1 $0x02 -> %q31
+6ee2c420 : fminnmp v0.2d, v1.2d, v2.2d               : fminnmp %q1 %q2 $0x03 -> %q0
+6ee4c462 : fminnmp v2.2d, v3.2d, v4.2d               : fminnmp %q3 %q4 $0x03 -> %q2
+6ee6c4a4 : fminnmp v4.2d, v5.2d, v6.2d               : fminnmp %q5 %q6 $0x03 -> %q4
+6ee8c4e6 : fminnmp v6.2d, v7.2d, v8.2d               : fminnmp %q7 %q8 $0x03 -> %q6
+6eeac528 : fminnmp v8.2d, v9.2d, v10.2d              : fminnmp %q9 %q10 $0x03 -> %q8
+6eecc56a : fminnmp v10.2d, v11.2d, v12.2d            : fminnmp %q11 %q12 $0x03 -> %q10
+6eeec5ac : fminnmp v12.2d, v13.2d, v14.2d            : fminnmp %q13 %q14 $0x03 -> %q12
+6ef0c5ee : fminnmp v14.2d, v15.2d, v16.2d            : fminnmp %q15 %q16 $0x03 -> %q14
+6ef2c630 : fminnmp v16.2d, v17.2d, v18.2d            : fminnmp %q17 %q18 $0x03 -> %q16
+6ef3c651 : fminnmp v17.2d, v18.2d, v19.2d            : fminnmp %q18 %q19 $0x03 -> %q17
+6ef5c693 : fminnmp v19.2d, v20.2d, v21.2d            : fminnmp %q20 %q21 $0x03 -> %q19
+6ef7c6d5 : fminnmp v21.2d, v22.2d, v23.2d            : fminnmp %q22 %q23 $0x03 -> %q21
+6ef9c717 : fminnmp v23.2d, v24.2d, v25.2d            : fminnmp %q24 %q25 $0x03 -> %q23
+6efbc759 : fminnmp v25.2d, v26.2d, v27.2d            : fminnmp %q26 %q27 $0x03 -> %q25
+6efdc79b : fminnmp v27.2d, v28.2d, v29.2d            : fminnmp %q28 %q29 $0x03 -> %q27
+6ee1c41f : fminnmp v31.2d, v0.2d, v1.2d              : fminnmp %q0 %q1 $0x03 -> %q31
+
+# FCVTAS  <Dd>.<T>, <Dn>.<T> (FCVTAS-Q.Q-asimdmisc_R)
+0e21c820 : fcvtas v0.2s, v1.2s                       : fcvtas %d1 $0x02 -> %d0
+0e21c862 : fcvtas v2.2s, v3.2s                       : fcvtas %d3 $0x02 -> %d2
+0e21c8a4 : fcvtas v4.2s, v5.2s                       : fcvtas %d5 $0x02 -> %d4
+0e21c8e6 : fcvtas v6.2s, v7.2s                       : fcvtas %d7 $0x02 -> %d6
+0e21c928 : fcvtas v8.2s, v9.2s                       : fcvtas %d9 $0x02 -> %d8
+0e21c96a : fcvtas v10.2s, v11.2s                     : fcvtas %d11 $0x02 -> %d10
+0e21c9ac : fcvtas v12.2s, v13.2s                     : fcvtas %d13 $0x02 -> %d12
+0e21c9ee : fcvtas v14.2s, v15.2s                     : fcvtas %d15 $0x02 -> %d14
+0e21ca30 : fcvtas v16.2s, v17.2s                     : fcvtas %d17 $0x02 -> %d16
+0e21ca51 : fcvtas v17.2s, v18.2s                     : fcvtas %d18 $0x02 -> %d17
+0e21ca93 : fcvtas v19.2s, v20.2s                     : fcvtas %d20 $0x02 -> %d19
+0e21cad5 : fcvtas v21.2s, v22.2s                     : fcvtas %d22 $0x02 -> %d21
+0e21cb17 : fcvtas v23.2s, v24.2s                     : fcvtas %d24 $0x02 -> %d23
+0e21cb59 : fcvtas v25.2s, v26.2s                     : fcvtas %d26 $0x02 -> %d25
+0e21cb9b : fcvtas v27.2s, v28.2s                     : fcvtas %d28 $0x02 -> %d27
+0e21c81f : fcvtas v31.2s, v0.2s                      : fcvtas %d0 $0x02 -> %d31
+4e21c820 : fcvtas v0.4s, v1.4s                       : fcvtas %q1 $0x02 -> %q0
+4e21c862 : fcvtas v2.4s, v3.4s                       : fcvtas %q3 $0x02 -> %q2
+4e21c8a4 : fcvtas v4.4s, v5.4s                       : fcvtas %q5 $0x02 -> %q4
+4e21c8e6 : fcvtas v6.4s, v7.4s                       : fcvtas %q7 $0x02 -> %q6
+4e21c928 : fcvtas v8.4s, v9.4s                       : fcvtas %q9 $0x02 -> %q8
+4e21c96a : fcvtas v10.4s, v11.4s                     : fcvtas %q11 $0x02 -> %q10
+4e21c9ac : fcvtas v12.4s, v13.4s                     : fcvtas %q13 $0x02 -> %q12
+4e21c9ee : fcvtas v14.4s, v15.4s                     : fcvtas %q15 $0x02 -> %q14
+4e21ca30 : fcvtas v16.4s, v17.4s                     : fcvtas %q17 $0x02 -> %q16
+4e21ca51 : fcvtas v17.4s, v18.4s                     : fcvtas %q18 $0x02 -> %q17
+4e21ca93 : fcvtas v19.4s, v20.4s                     : fcvtas %q20 $0x02 -> %q19
+4e21cad5 : fcvtas v21.4s, v22.4s                     : fcvtas %q22 $0x02 -> %q21
+4e21cb17 : fcvtas v23.4s, v24.4s                     : fcvtas %q24 $0x02 -> %q23
+4e21cb59 : fcvtas v25.4s, v26.4s                     : fcvtas %q26 $0x02 -> %q25
+4e21cb9b : fcvtas v27.4s, v28.4s                     : fcvtas %q28 $0x02 -> %q27
+4e21c81f : fcvtas v31.4s, v0.4s                      : fcvtas %q0 $0x02 -> %q31
+4e61c820 : fcvtas v0.2d, v1.2d                       : fcvtas %q1 $0x03 -> %q0
+4e61c862 : fcvtas v2.2d, v3.2d                       : fcvtas %q3 $0x03 -> %q2
+4e61c8a4 : fcvtas v4.2d, v5.2d                       : fcvtas %q5 $0x03 -> %q4
+4e61c8e6 : fcvtas v6.2d, v7.2d                       : fcvtas %q7 $0x03 -> %q6
+4e61c928 : fcvtas v8.2d, v9.2d                       : fcvtas %q9 $0x03 -> %q8
+4e61c96a : fcvtas v10.2d, v11.2d                     : fcvtas %q11 $0x03 -> %q10
+4e61c9ac : fcvtas v12.2d, v13.2d                     : fcvtas %q13 $0x03 -> %q12
+4e61c9ee : fcvtas v14.2d, v15.2d                     : fcvtas %q15 $0x03 -> %q14
+4e61ca30 : fcvtas v16.2d, v17.2d                     : fcvtas %q17 $0x03 -> %q16
+4e61ca51 : fcvtas v17.2d, v18.2d                     : fcvtas %q18 $0x03 -> %q17
+4e61ca93 : fcvtas v19.2d, v20.2d                     : fcvtas %q20 $0x03 -> %q19
+4e61cad5 : fcvtas v21.2d, v22.2d                     : fcvtas %q22 $0x03 -> %q21
+4e61cb17 : fcvtas v23.2d, v24.2d                     : fcvtas %q24 $0x03 -> %q23
+4e61cb59 : fcvtas v25.2d, v26.2d                     : fcvtas %q26 $0x03 -> %q25
+4e61cb9b : fcvtas v27.2d, v28.2d                     : fcvtas %q28 $0x03 -> %q27
+4e61c81f : fcvtas v31.2d, v0.2d                      : fcvtas %q0 $0x03 -> %q31
+
 # FCMEQ   <Dd>.<T>, <Dn>.<T>, #0 (FCMEQ-Q.Q-asimdmisc_FZ)
 0ea0d820 : fcmeq v0.2s, v1.2s, #0                    : fcmeq  %d1 $0.000000 $0x02 -> %d0
 0ea0d862 : fcmeq v2.2s, v3.2s, #0                    : fcmeq  %d3 $0.000000 $0x02 -> %d2
@@ -28873,6 +28967,156 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 4ee0db9b : fcmeq v27.2d, v28.2d, #0                  : fcmeq  %q28 $0.000000 $0x03 -> %q27
 4ee0d81f : fcmeq v31.2d, v0.2d, #0                   : fcmeq  %q0 $0.000000 $0x03 -> %q31
 
+# FRECPE  <Dd>.<T>, <Dn>.<T> (FRECPE-Q.Q-asimdmisc_R)
+0ea1d820 : frecpe v0.2s, v1.2s                       : frecpe %d1 $0x02 -> %d0
+0ea1d862 : frecpe v2.2s, v3.2s                       : frecpe %d3 $0x02 -> %d2
+0ea1d8a4 : frecpe v4.2s, v5.2s                       : frecpe %d5 $0x02 -> %d4
+0ea1d8e6 : frecpe v6.2s, v7.2s                       : frecpe %d7 $0x02 -> %d6
+0ea1d928 : frecpe v8.2s, v9.2s                       : frecpe %d9 $0x02 -> %d8
+0ea1d96a : frecpe v10.2s, v11.2s                     : frecpe %d11 $0x02 -> %d10
+0ea1d9ac : frecpe v12.2s, v13.2s                     : frecpe %d13 $0x02 -> %d12
+0ea1d9ee : frecpe v14.2s, v15.2s                     : frecpe %d15 $0x02 -> %d14
+0ea1da30 : frecpe v16.2s, v17.2s                     : frecpe %d17 $0x02 -> %d16
+0ea1da51 : frecpe v17.2s, v18.2s                     : frecpe %d18 $0x02 -> %d17
+0ea1da93 : frecpe v19.2s, v20.2s                     : frecpe %d20 $0x02 -> %d19
+0ea1dad5 : frecpe v21.2s, v22.2s                     : frecpe %d22 $0x02 -> %d21
+0ea1db17 : frecpe v23.2s, v24.2s                     : frecpe %d24 $0x02 -> %d23
+0ea1db59 : frecpe v25.2s, v26.2s                     : frecpe %d26 $0x02 -> %d25
+0ea1db9b : frecpe v27.2s, v28.2s                     : frecpe %d28 $0x02 -> %d27
+0ea1d81f : frecpe v31.2s, v0.2s                      : frecpe %d0 $0x02 -> %d31
+4ea1d820 : frecpe v0.4s, v1.4s                       : frecpe %q1 $0x02 -> %q0
+4ea1d862 : frecpe v2.4s, v3.4s                       : frecpe %q3 $0x02 -> %q2
+4ea1d8a4 : frecpe v4.4s, v5.4s                       : frecpe %q5 $0x02 -> %q4
+4ea1d8e6 : frecpe v6.4s, v7.4s                       : frecpe %q7 $0x02 -> %q6
+4ea1d928 : frecpe v8.4s, v9.4s                       : frecpe %q9 $0x02 -> %q8
+4ea1d96a : frecpe v10.4s, v11.4s                     : frecpe %q11 $0x02 -> %q10
+4ea1d9ac : frecpe v12.4s, v13.4s                     : frecpe %q13 $0x02 -> %q12
+4ea1d9ee : frecpe v14.4s, v15.4s                     : frecpe %q15 $0x02 -> %q14
+4ea1da30 : frecpe v16.4s, v17.4s                     : frecpe %q17 $0x02 -> %q16
+4ea1da51 : frecpe v17.4s, v18.4s                     : frecpe %q18 $0x02 -> %q17
+4ea1da93 : frecpe v19.4s, v20.4s                     : frecpe %q20 $0x02 -> %q19
+4ea1dad5 : frecpe v21.4s, v22.4s                     : frecpe %q22 $0x02 -> %q21
+4ea1db17 : frecpe v23.4s, v24.4s                     : frecpe %q24 $0x02 -> %q23
+4ea1db59 : frecpe v25.4s, v26.4s                     : frecpe %q26 $0x02 -> %q25
+4ea1db9b : frecpe v27.4s, v28.4s                     : frecpe %q28 $0x02 -> %q27
+4ea1d81f : frecpe v31.4s, v0.4s                      : frecpe %q0 $0x02 -> %q31
+4ee1d820 : frecpe v0.2d, v1.2d                       : frecpe %q1 $0x03 -> %q0
+4ee1d862 : frecpe v2.2d, v3.2d                       : frecpe %q3 $0x03 -> %q2
+4ee1d8a4 : frecpe v4.2d, v5.2d                       : frecpe %q5 $0x03 -> %q4
+4ee1d8e6 : frecpe v6.2d, v7.2d                       : frecpe %q7 $0x03 -> %q6
+4ee1d928 : frecpe v8.2d, v9.2d                       : frecpe %q9 $0x03 -> %q8
+4ee1d96a : frecpe v10.2d, v11.2d                     : frecpe %q11 $0x03 -> %q10
+4ee1d9ac : frecpe v12.2d, v13.2d                     : frecpe %q13 $0x03 -> %q12
+4ee1d9ee : frecpe v14.2d, v15.2d                     : frecpe %q15 $0x03 -> %q14
+4ee1da30 : frecpe v16.2d, v17.2d                     : frecpe %q17 $0x03 -> %q16
+4ee1da51 : frecpe v17.2d, v18.2d                     : frecpe %q18 $0x03 -> %q17
+4ee1da93 : frecpe v19.2d, v20.2d                     : frecpe %q20 $0x03 -> %q19
+4ee1dad5 : frecpe v21.2d, v22.2d                     : frecpe %q22 $0x03 -> %q21
+4ee1db17 : frecpe v23.2d, v24.2d                     : frecpe %q24 $0x03 -> %q23
+4ee1db59 : frecpe v25.2d, v26.2d                     : frecpe %q26 $0x03 -> %q25
+4ee1db9b : frecpe v27.2d, v28.2d                     : frecpe %q28 $0x03 -> %q27
+4ee1d81f : frecpe v31.2d, v0.2d                      : frecpe %q0 $0x03 -> %q31
+
+# FCVTMU  <Dd>.<T>, <Dn>.<T> (FCVTMU-Q.Q-asimdmisc_R)
+2e21b820 : fcvtmu v0.2s, v1.2s                       : fcvtmu %d1 $0x02 -> %d0
+2e21b862 : fcvtmu v2.2s, v3.2s                       : fcvtmu %d3 $0x02 -> %d2
+2e21b8a4 : fcvtmu v4.2s, v5.2s                       : fcvtmu %d5 $0x02 -> %d4
+2e21b8e6 : fcvtmu v6.2s, v7.2s                       : fcvtmu %d7 $0x02 -> %d6
+2e21b928 : fcvtmu v8.2s, v9.2s                       : fcvtmu %d9 $0x02 -> %d8
+2e21b96a : fcvtmu v10.2s, v11.2s                     : fcvtmu %d11 $0x02 -> %d10
+2e21b9ac : fcvtmu v12.2s, v13.2s                     : fcvtmu %d13 $0x02 -> %d12
+2e21b9ee : fcvtmu v14.2s, v15.2s                     : fcvtmu %d15 $0x02 -> %d14
+2e21ba30 : fcvtmu v16.2s, v17.2s                     : fcvtmu %d17 $0x02 -> %d16
+2e21ba51 : fcvtmu v17.2s, v18.2s                     : fcvtmu %d18 $0x02 -> %d17
+2e21ba93 : fcvtmu v19.2s, v20.2s                     : fcvtmu %d20 $0x02 -> %d19
+2e21bad5 : fcvtmu v21.2s, v22.2s                     : fcvtmu %d22 $0x02 -> %d21
+2e21bb17 : fcvtmu v23.2s, v24.2s                     : fcvtmu %d24 $0x02 -> %d23
+2e21bb59 : fcvtmu v25.2s, v26.2s                     : fcvtmu %d26 $0x02 -> %d25
+2e21bb9b : fcvtmu v27.2s, v28.2s                     : fcvtmu %d28 $0x02 -> %d27
+2e21b81f : fcvtmu v31.2s, v0.2s                      : fcvtmu %d0 $0x02 -> %d31
+6e21b820 : fcvtmu v0.4s, v1.4s                       : fcvtmu %q1 $0x02 -> %q0
+6e21b862 : fcvtmu v2.4s, v3.4s                       : fcvtmu %q3 $0x02 -> %q2
+6e21b8a4 : fcvtmu v4.4s, v5.4s                       : fcvtmu %q5 $0x02 -> %q4
+6e21b8e6 : fcvtmu v6.4s, v7.4s                       : fcvtmu %q7 $0x02 -> %q6
+6e21b928 : fcvtmu v8.4s, v9.4s                       : fcvtmu %q9 $0x02 -> %q8
+6e21b96a : fcvtmu v10.4s, v11.4s                     : fcvtmu %q11 $0x02 -> %q10
+6e21b9ac : fcvtmu v12.4s, v13.4s                     : fcvtmu %q13 $0x02 -> %q12
+6e21b9ee : fcvtmu v14.4s, v15.4s                     : fcvtmu %q15 $0x02 -> %q14
+6e21ba30 : fcvtmu v16.4s, v17.4s                     : fcvtmu %q17 $0x02 -> %q16
+6e21ba51 : fcvtmu v17.4s, v18.4s                     : fcvtmu %q18 $0x02 -> %q17
+6e21ba93 : fcvtmu v19.4s, v20.4s                     : fcvtmu %q20 $0x02 -> %q19
+6e21bad5 : fcvtmu v21.4s, v22.4s                     : fcvtmu %q22 $0x02 -> %q21
+6e21bb17 : fcvtmu v23.4s, v24.4s                     : fcvtmu %q24 $0x02 -> %q23
+6e21bb59 : fcvtmu v25.4s, v26.4s                     : fcvtmu %q26 $0x02 -> %q25
+6e21bb9b : fcvtmu v27.4s, v28.4s                     : fcvtmu %q28 $0x02 -> %q27
+6e21b81f : fcvtmu v31.4s, v0.4s                      : fcvtmu %q0 $0x02 -> %q31
+6e61b820 : fcvtmu v0.2d, v1.2d                       : fcvtmu %q1 $0x03 -> %q0
+6e61b862 : fcvtmu v2.2d, v3.2d                       : fcvtmu %q3 $0x03 -> %q2
+6e61b8a4 : fcvtmu v4.2d, v5.2d                       : fcvtmu %q5 $0x03 -> %q4
+6e61b8e6 : fcvtmu v6.2d, v7.2d                       : fcvtmu %q7 $0x03 -> %q6
+6e61b928 : fcvtmu v8.2d, v9.2d                       : fcvtmu %q9 $0x03 -> %q8
+6e61b96a : fcvtmu v10.2d, v11.2d                     : fcvtmu %q11 $0x03 -> %q10
+6e61b9ac : fcvtmu v12.2d, v13.2d                     : fcvtmu %q13 $0x03 -> %q12
+6e61b9ee : fcvtmu v14.2d, v15.2d                     : fcvtmu %q15 $0x03 -> %q14
+6e61ba30 : fcvtmu v16.2d, v17.2d                     : fcvtmu %q17 $0x03 -> %q16
+6e61ba51 : fcvtmu v17.2d, v18.2d                     : fcvtmu %q18 $0x03 -> %q17
+6e61ba93 : fcvtmu v19.2d, v20.2d                     : fcvtmu %q20 $0x03 -> %q19
+6e61bad5 : fcvtmu v21.2d, v22.2d                     : fcvtmu %q22 $0x03 -> %q21
+6e61bb17 : fcvtmu v23.2d, v24.2d                     : fcvtmu %q24 $0x03 -> %q23
+6e61bb59 : fcvtmu v25.2d, v26.2d                     : fcvtmu %q26 $0x03 -> %q25
+6e61bb9b : fcvtmu v27.2d, v28.2d                     : fcvtmu %q28 $0x03 -> %q27
+6e61b81f : fcvtmu v31.2d, v0.2d                      : fcvtmu %q0 $0x03 -> %q31
+
+# FRINTZ  <Dd>.<T>, <Dn>.<T> (FRINTZ-Q.Q-asimdmisc_R)
+0ea19820 : frintz v0.2s, v1.2s                       : frintz %d1 $0x02 -> %d0
+0ea19862 : frintz v2.2s, v3.2s                       : frintz %d3 $0x02 -> %d2
+0ea198a4 : frintz v4.2s, v5.2s                       : frintz %d5 $0x02 -> %d4
+0ea198e6 : frintz v6.2s, v7.2s                       : frintz %d7 $0x02 -> %d6
+0ea19928 : frintz v8.2s, v9.2s                       : frintz %d9 $0x02 -> %d8
+0ea1996a : frintz v10.2s, v11.2s                     : frintz %d11 $0x02 -> %d10
+0ea199ac : frintz v12.2s, v13.2s                     : frintz %d13 $0x02 -> %d12
+0ea199ee : frintz v14.2s, v15.2s                     : frintz %d15 $0x02 -> %d14
+0ea19a30 : frintz v16.2s, v17.2s                     : frintz %d17 $0x02 -> %d16
+0ea19a51 : frintz v17.2s, v18.2s                     : frintz %d18 $0x02 -> %d17
+0ea19a93 : frintz v19.2s, v20.2s                     : frintz %d20 $0x02 -> %d19
+0ea19ad5 : frintz v21.2s, v22.2s                     : frintz %d22 $0x02 -> %d21
+0ea19b17 : frintz v23.2s, v24.2s                     : frintz %d24 $0x02 -> %d23
+0ea19b59 : frintz v25.2s, v26.2s                     : frintz %d26 $0x02 -> %d25
+0ea19b9b : frintz v27.2s, v28.2s                     : frintz %d28 $0x02 -> %d27
+0ea1981f : frintz v31.2s, v0.2s                      : frintz %d0 $0x02 -> %d31
+4ea19820 : frintz v0.4s, v1.4s                       : frintz %q1 $0x02 -> %q0
+4ea19862 : frintz v2.4s, v3.4s                       : frintz %q3 $0x02 -> %q2
+4ea198a4 : frintz v4.4s, v5.4s                       : frintz %q5 $0x02 -> %q4
+4ea198e6 : frintz v6.4s, v7.4s                       : frintz %q7 $0x02 -> %q6
+4ea19928 : frintz v8.4s, v9.4s                       : frintz %q9 $0x02 -> %q8
+4ea1996a : frintz v10.4s, v11.4s                     : frintz %q11 $0x02 -> %q10
+4ea199ac : frintz v12.4s, v13.4s                     : frintz %q13 $0x02 -> %q12
+4ea199ee : frintz v14.4s, v15.4s                     : frintz %q15 $0x02 -> %q14
+4ea19a30 : frintz v16.4s, v17.4s                     : frintz %q17 $0x02 -> %q16
+4ea19a51 : frintz v17.4s, v18.4s                     : frintz %q18 $0x02 -> %q17
+4ea19a93 : frintz v19.4s, v20.4s                     : frintz %q20 $0x02 -> %q19
+4ea19ad5 : frintz v21.4s, v22.4s                     : frintz %q22 $0x02 -> %q21
+4ea19b17 : frintz v23.4s, v24.4s                     : frintz %q24 $0x02 -> %q23
+4ea19b59 : frintz v25.4s, v26.4s                     : frintz %q26 $0x02 -> %q25
+4ea19b9b : frintz v27.4s, v28.4s                     : frintz %q28 $0x02 -> %q27
+4ea1981f : frintz v31.4s, v0.4s                      : frintz %q0 $0x02 -> %q31
+4ee19820 : frintz v0.2d, v1.2d                       : frintz %q1 $0x03 -> %q0
+4ee19862 : frintz v2.2d, v3.2d                       : frintz %q3 $0x03 -> %q2
+4ee198a4 : frintz v4.2d, v5.2d                       : frintz %q5 $0x03 -> %q4
+4ee198e6 : frintz v6.2d, v7.2d                       : frintz %q7 $0x03 -> %q6
+4ee19928 : frintz v8.2d, v9.2d                       : frintz %q9 $0x03 -> %q8
+4ee1996a : frintz v10.2d, v11.2d                     : frintz %q11 $0x03 -> %q10
+4ee199ac : frintz v12.2d, v13.2d                     : frintz %q13 $0x03 -> %q12
+4ee199ee : frintz v14.2d, v15.2d                     : frintz %q15 $0x03 -> %q14
+4ee19a30 : frintz v16.2d, v17.2d                     : frintz %q17 $0x03 -> %q16
+4ee19a51 : frintz v17.2d, v18.2d                     : frintz %q18 $0x03 -> %q17
+4ee19a93 : frintz v19.2d, v20.2d                     : frintz %q20 $0x03 -> %q19
+4ee19ad5 : frintz v21.2d, v22.2d                     : frintz %q22 $0x03 -> %q21
+4ee19b17 : frintz v23.2d, v24.2d                     : frintz %q24 $0x03 -> %q23
+4ee19b59 : frintz v25.2d, v26.2d                     : frintz %q26 $0x03 -> %q25
+4ee19b9b : frintz v27.2d, v28.2d                     : frintz %q28 $0x03 -> %q27
+4ee1981f : frintz v31.2d, v0.2d                      : frintz %q0 $0x03 -> %q31
+
 # FCMPE   <Dn>, #0.0 (FCMPE-V-DZ_floatcmp)
 1e602018 : fcmpe d0, #0.0                            : fcmpe  %d0 $0.000000
 1e602058 : fcmpe d2, #0.0                            : fcmpe  %d2 $0.000000
@@ -28891,6 +29135,442 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 1e602378 : fcmpe d27, #0.0                           : fcmpe  %d27 $0.000000
 1e6023f8 : fcmpe d31, #0.0                           : fcmpe  %d31 $0.000000
 
+# URECPE  <Sd>.<T>, <Sn>.<T> (URECPE-Q.Q-asimdmisc_R)
+0ea1c820 : urecpe v0.2s, v1.2s                       : urecpe %d1 $0x02 -> %d0
+0ea1c862 : urecpe v2.2s, v3.2s                       : urecpe %d3 $0x02 -> %d2
+0ea1c8a4 : urecpe v4.2s, v5.2s                       : urecpe %d5 $0x02 -> %d4
+0ea1c8e6 : urecpe v6.2s, v7.2s                       : urecpe %d7 $0x02 -> %d6
+0ea1c928 : urecpe v8.2s, v9.2s                       : urecpe %d9 $0x02 -> %d8
+0ea1c96a : urecpe v10.2s, v11.2s                     : urecpe %d11 $0x02 -> %d10
+0ea1c9ac : urecpe v12.2s, v13.2s                     : urecpe %d13 $0x02 -> %d12
+0ea1c9ee : urecpe v14.2s, v15.2s                     : urecpe %d15 $0x02 -> %d14
+0ea1ca30 : urecpe v16.2s, v17.2s                     : urecpe %d17 $0x02 -> %d16
+0ea1ca51 : urecpe v17.2s, v18.2s                     : urecpe %d18 $0x02 -> %d17
+0ea1ca93 : urecpe v19.2s, v20.2s                     : urecpe %d20 $0x02 -> %d19
+0ea1cad5 : urecpe v21.2s, v22.2s                     : urecpe %d22 $0x02 -> %d21
+0ea1cb17 : urecpe v23.2s, v24.2s                     : urecpe %d24 $0x02 -> %d23
+0ea1cb59 : urecpe v25.2s, v26.2s                     : urecpe %d26 $0x02 -> %d25
+0ea1cb9b : urecpe v27.2s, v28.2s                     : urecpe %d28 $0x02 -> %d27
+0ea1c81f : urecpe v31.2s, v0.2s                      : urecpe %d0 $0x02 -> %d31
+4ea1c820 : urecpe v0.4s, v1.4s                       : urecpe %q1 $0x02 -> %q0
+4ea1c862 : urecpe v2.4s, v3.4s                       : urecpe %q3 $0x02 -> %q2
+4ea1c8a4 : urecpe v4.4s, v5.4s                       : urecpe %q5 $0x02 -> %q4
+4ea1c8e6 : urecpe v6.4s, v7.4s                       : urecpe %q7 $0x02 -> %q6
+4ea1c928 : urecpe v8.4s, v9.4s                       : urecpe %q9 $0x02 -> %q8
+4ea1c96a : urecpe v10.4s, v11.4s                     : urecpe %q11 $0x02 -> %q10
+4ea1c9ac : urecpe v12.4s, v13.4s                     : urecpe %q13 $0x02 -> %q12
+4ea1c9ee : urecpe v14.4s, v15.4s                     : urecpe %q15 $0x02 -> %q14
+4ea1ca30 : urecpe v16.4s, v17.4s                     : urecpe %q17 $0x02 -> %q16
+4ea1ca51 : urecpe v17.4s, v18.4s                     : urecpe %q18 $0x02 -> %q17
+4ea1ca93 : urecpe v19.4s, v20.4s                     : urecpe %q20 $0x02 -> %q19
+4ea1cad5 : urecpe v21.4s, v22.4s                     : urecpe %q22 $0x02 -> %q21
+4ea1cb17 : urecpe v23.4s, v24.4s                     : urecpe %q24 $0x02 -> %q23
+4ea1cb59 : urecpe v25.4s, v26.4s                     : urecpe %q26 $0x02 -> %q25
+4ea1cb9b : urecpe v27.4s, v28.4s                     : urecpe %q28 $0x02 -> %q27
+4ea1c81f : urecpe v31.4s, v0.4s                      : urecpe %q0 $0x02 -> %q31
+
+# FMLS    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMLS-Q.QQ-asimdsame_only)
+0ea2cc20 : fmls v0.2s, v1.2s, v2.2s                  : fmls   %d0 %d1 %d2 $0x02 -> %d0
+0ea4cc62 : fmls v2.2s, v3.2s, v4.2s                  : fmls   %d2 %d3 %d4 $0x02 -> %d2
+0ea6cca4 : fmls v4.2s, v5.2s, v6.2s                  : fmls   %d4 %d5 %d6 $0x02 -> %d4
+0ea8cce6 : fmls v6.2s, v7.2s, v8.2s                  : fmls   %d6 %d7 %d8 $0x02 -> %d6
+0eaacd28 : fmls v8.2s, v9.2s, v10.2s                 : fmls   %d8 %d9 %d10 $0x02 -> %d8
+0eaccd6a : fmls v10.2s, v11.2s, v12.2s               : fmls   %d10 %d11 %d12 $0x02 -> %d10
+0eaecdac : fmls v12.2s, v13.2s, v14.2s               : fmls   %d12 %d13 %d14 $0x02 -> %d12
+0eb0cdee : fmls v14.2s, v15.2s, v16.2s               : fmls   %d14 %d15 %d16 $0x02 -> %d14
+0eb2ce30 : fmls v16.2s, v17.2s, v18.2s               : fmls   %d16 %d17 %d18 $0x02 -> %d16
+0eb3ce51 : fmls v17.2s, v18.2s, v19.2s               : fmls   %d17 %d18 %d19 $0x02 -> %d17
+0eb5ce93 : fmls v19.2s, v20.2s, v21.2s               : fmls   %d19 %d20 %d21 $0x02 -> %d19
+0eb7ced5 : fmls v21.2s, v22.2s, v23.2s               : fmls   %d21 %d22 %d23 $0x02 -> %d21
+0eb9cf17 : fmls v23.2s, v24.2s, v25.2s               : fmls   %d23 %d24 %d25 $0x02 -> %d23
+0ebbcf59 : fmls v25.2s, v26.2s, v27.2s               : fmls   %d25 %d26 %d27 $0x02 -> %d25
+0ebdcf9b : fmls v27.2s, v28.2s, v29.2s               : fmls   %d27 %d28 %d29 $0x02 -> %d27
+0ea1cc1f : fmls v31.2s, v0.2s, v1.2s                 : fmls   %d31 %d0 %d1 $0x02 -> %d31
+4ea2cc20 : fmls v0.4s, v1.4s, v2.4s                  : fmls   %q0 %q1 %q2 $0x02 -> %q0
+4ea4cc62 : fmls v2.4s, v3.4s, v4.4s                  : fmls   %q2 %q3 %q4 $0x02 -> %q2
+4ea6cca4 : fmls v4.4s, v5.4s, v6.4s                  : fmls   %q4 %q5 %q6 $0x02 -> %q4
+4ea8cce6 : fmls v6.4s, v7.4s, v8.4s                  : fmls   %q6 %q7 %q8 $0x02 -> %q6
+4eaacd28 : fmls v8.4s, v9.4s, v10.4s                 : fmls   %q8 %q9 %q10 $0x02 -> %q8
+4eaccd6a : fmls v10.4s, v11.4s, v12.4s               : fmls   %q10 %q11 %q12 $0x02 -> %q10
+4eaecdac : fmls v12.4s, v13.4s, v14.4s               : fmls   %q12 %q13 %q14 $0x02 -> %q12
+4eb0cdee : fmls v14.4s, v15.4s, v16.4s               : fmls   %q14 %q15 %q16 $0x02 -> %q14
+4eb2ce30 : fmls v16.4s, v17.4s, v18.4s               : fmls   %q16 %q17 %q18 $0x02 -> %q16
+4eb3ce51 : fmls v17.4s, v18.4s, v19.4s               : fmls   %q17 %q18 %q19 $0x02 -> %q17
+4eb5ce93 : fmls v19.4s, v20.4s, v21.4s               : fmls   %q19 %q20 %q21 $0x02 -> %q19
+4eb7ced5 : fmls v21.4s, v22.4s, v23.4s               : fmls   %q21 %q22 %q23 $0x02 -> %q21
+4eb9cf17 : fmls v23.4s, v24.4s, v25.4s               : fmls   %q23 %q24 %q25 $0x02 -> %q23
+4ebbcf59 : fmls v25.4s, v26.4s, v27.4s               : fmls   %q25 %q26 %q27 $0x02 -> %q25
+4ebdcf9b : fmls v27.4s, v28.4s, v29.4s               : fmls   %q27 %q28 %q29 $0x02 -> %q27
+4ea1cc1f : fmls v31.4s, v0.4s, v1.4s                 : fmls   %q31 %q0 %q1 $0x02 -> %q31
+4ee2cc20 : fmls v0.2d, v1.2d, v2.2d                  : fmls   %q0 %q1 %q2 $0x03 -> %q0
+4ee4cc62 : fmls v2.2d, v3.2d, v4.2d                  : fmls   %q2 %q3 %q4 $0x03 -> %q2
+4ee6cca4 : fmls v4.2d, v5.2d, v6.2d                  : fmls   %q4 %q5 %q6 $0x03 -> %q4
+4ee8cce6 : fmls v6.2d, v7.2d, v8.2d                  : fmls   %q6 %q7 %q8 $0x03 -> %q6
+4eeacd28 : fmls v8.2d, v9.2d, v10.2d                 : fmls   %q8 %q9 %q10 $0x03 -> %q8
+4eeccd6a : fmls v10.2d, v11.2d, v12.2d               : fmls   %q10 %q11 %q12 $0x03 -> %q10
+4eeecdac : fmls v12.2d, v13.2d, v14.2d               : fmls   %q12 %q13 %q14 $0x03 -> %q12
+4ef0cdee : fmls v14.2d, v15.2d, v16.2d               : fmls   %q14 %q15 %q16 $0x03 -> %q14
+4ef2ce30 : fmls v16.2d, v17.2d, v18.2d               : fmls   %q16 %q17 %q18 $0x03 -> %q16
+4ef3ce51 : fmls v17.2d, v18.2d, v19.2d               : fmls   %q17 %q18 %q19 $0x03 -> %q17
+4ef5ce93 : fmls v19.2d, v20.2d, v21.2d               : fmls   %q19 %q20 %q21 $0x03 -> %q19
+4ef7ced5 : fmls v21.2d, v22.2d, v23.2d               : fmls   %q21 %q22 %q23 $0x03 -> %q21
+4ef9cf17 : fmls v23.2d, v24.2d, v25.2d               : fmls   %q23 %q24 %q25 $0x03 -> %q23
+4efbcf59 : fmls v25.2d, v26.2d, v27.2d               : fmls   %q25 %q26 %q27 $0x03 -> %q25
+4efdcf9b : fmls v27.2d, v28.2d, v29.2d               : fmls   %q27 %q28 %q29 $0x03 -> %q27
+4ee1cc1f : fmls v31.2d, v0.2d, v1.2d                 : fmls   %q31 %q0 %q1 $0x03 -> %q31
+
+# FCVTXN  <Sd>.2S, <Dn>.2D (FCVTXN-Q.Q-asimdmisc_N)
+2e616820 : fcvtxn v0.2s, v1.2d                       : fcvtxn %q1 $0x03 -> %d0
+2e616862 : fcvtxn v2.2s, v3.2d                       : fcvtxn %q3 $0x03 -> %d2
+2e6168a4 : fcvtxn v4.2s, v5.2d                       : fcvtxn %q5 $0x03 -> %d4
+2e6168e6 : fcvtxn v6.2s, v7.2d                       : fcvtxn %q7 $0x03 -> %d6
+2e616928 : fcvtxn v8.2s, v9.2d                       : fcvtxn %q9 $0x03 -> %d8
+2e61696a : fcvtxn v10.2s, v11.2d                     : fcvtxn %q11 $0x03 -> %d10
+2e6169ac : fcvtxn v12.2s, v13.2d                     : fcvtxn %q13 $0x03 -> %d12
+2e6169ee : fcvtxn v14.2s, v15.2d                     : fcvtxn %q15 $0x03 -> %d14
+2e616a30 : fcvtxn v16.2s, v17.2d                     : fcvtxn %q17 $0x03 -> %d16
+2e616a51 : fcvtxn v17.2s, v18.2d                     : fcvtxn %q18 $0x03 -> %d17
+2e616a93 : fcvtxn v19.2s, v20.2d                     : fcvtxn %q20 $0x03 -> %d19
+2e616ad5 : fcvtxn v21.2s, v22.2d                     : fcvtxn %q22 $0x03 -> %d21
+2e616b17 : fcvtxn v23.2s, v24.2d                     : fcvtxn %q24 $0x03 -> %d23
+2e616b59 : fcvtxn v25.2s, v26.2d                     : fcvtxn %q26 $0x03 -> %d25
+2e616b9b : fcvtxn v27.2s, v28.2d                     : fcvtxn %q28 $0x03 -> %d27
+2e61681f : fcvtxn v31.2s, v0.2d                      : fcvtxn %q0 $0x03 -> %d31
+
+# SCVTF   <Dd>.<T>, <Dn>.<T> (SCVTF-Q.Q-asimdmisc_R)
+0e21d820 : scvtf v0.2s, v1.2s                        : scvtf  %d1 $0x02 -> %d0
+0e21d862 : scvtf v2.2s, v3.2s                        : scvtf  %d3 $0x02 -> %d2
+0e21d8a4 : scvtf v4.2s, v5.2s                        : scvtf  %d5 $0x02 -> %d4
+0e21d8e6 : scvtf v6.2s, v7.2s                        : scvtf  %d7 $0x02 -> %d6
+0e21d928 : scvtf v8.2s, v9.2s                        : scvtf  %d9 $0x02 -> %d8
+0e21d96a : scvtf v10.2s, v11.2s                      : scvtf  %d11 $0x02 -> %d10
+0e21d9ac : scvtf v12.2s, v13.2s                      : scvtf  %d13 $0x02 -> %d12
+0e21d9ee : scvtf v14.2s, v15.2s                      : scvtf  %d15 $0x02 -> %d14
+0e21da30 : scvtf v16.2s, v17.2s                      : scvtf  %d17 $0x02 -> %d16
+0e21da51 : scvtf v17.2s, v18.2s                      : scvtf  %d18 $0x02 -> %d17
+0e21da93 : scvtf v19.2s, v20.2s                      : scvtf  %d20 $0x02 -> %d19
+0e21dad5 : scvtf v21.2s, v22.2s                      : scvtf  %d22 $0x02 -> %d21
+0e21db17 : scvtf v23.2s, v24.2s                      : scvtf  %d24 $0x02 -> %d23
+0e21db59 : scvtf v25.2s, v26.2s                      : scvtf  %d26 $0x02 -> %d25
+0e21db9b : scvtf v27.2s, v28.2s                      : scvtf  %d28 $0x02 -> %d27
+0e21d81f : scvtf v31.2s, v0.2s                       : scvtf  %d0 $0x02 -> %d31
+4e21d820 : scvtf v0.4s, v1.4s                        : scvtf  %q1 $0x02 -> %q0
+4e21d862 : scvtf v2.4s, v3.4s                        : scvtf  %q3 $0x02 -> %q2
+4e21d8a4 : scvtf v4.4s, v5.4s                        : scvtf  %q5 $0x02 -> %q4
+4e21d8e6 : scvtf v6.4s, v7.4s                        : scvtf  %q7 $0x02 -> %q6
+4e21d928 : scvtf v8.4s, v9.4s                        : scvtf  %q9 $0x02 -> %q8
+4e21d96a : scvtf v10.4s, v11.4s                      : scvtf  %q11 $0x02 -> %q10
+4e21d9ac : scvtf v12.4s, v13.4s                      : scvtf  %q13 $0x02 -> %q12
+4e21d9ee : scvtf v14.4s, v15.4s                      : scvtf  %q15 $0x02 -> %q14
+4e21da30 : scvtf v16.4s, v17.4s                      : scvtf  %q17 $0x02 -> %q16
+4e21da51 : scvtf v17.4s, v18.4s                      : scvtf  %q18 $0x02 -> %q17
+4e21da93 : scvtf v19.4s, v20.4s                      : scvtf  %q20 $0x02 -> %q19
+4e21dad5 : scvtf v21.4s, v22.4s                      : scvtf  %q22 $0x02 -> %q21
+4e21db17 : scvtf v23.4s, v24.4s                      : scvtf  %q24 $0x02 -> %q23
+4e21db59 : scvtf v25.4s, v26.4s                      : scvtf  %q26 $0x02 -> %q25
+4e21db9b : scvtf v27.4s, v28.4s                      : scvtf  %q28 $0x02 -> %q27
+4e21d81f : scvtf v31.4s, v0.4s                       : scvtf  %q0 $0x02 -> %q31
+4e61d820 : scvtf v0.2d, v1.2d                        : scvtf  %q1 $0x03 -> %q0
+4e61d862 : scvtf v2.2d, v3.2d                        : scvtf  %q3 $0x03 -> %q2
+4e61d8a4 : scvtf v4.2d, v5.2d                        : scvtf  %q5 $0x03 -> %q4
+4e61d8e6 : scvtf v6.2d, v7.2d                        : scvtf  %q7 $0x03 -> %q6
+4e61d928 : scvtf v8.2d, v9.2d                        : scvtf  %q9 $0x03 -> %q8
+4e61d96a : scvtf v10.2d, v11.2d                      : scvtf  %q11 $0x03 -> %q10
+4e61d9ac : scvtf v12.2d, v13.2d                      : scvtf  %q13 $0x03 -> %q12
+4e61d9ee : scvtf v14.2d, v15.2d                      : scvtf  %q15 $0x03 -> %q14
+4e61da30 : scvtf v16.2d, v17.2d                      : scvtf  %q17 $0x03 -> %q16
+4e61da51 : scvtf v17.2d, v18.2d                      : scvtf  %q18 $0x03 -> %q17
+4e61da93 : scvtf v19.2d, v20.2d                      : scvtf  %q20 $0x03 -> %q19
+4e61dad5 : scvtf v21.2d, v22.2d                      : scvtf  %q22 $0x03 -> %q21
+4e61db17 : scvtf v23.2d, v24.2d                      : scvtf  %q24 $0x03 -> %q23
+4e61db59 : scvtf v25.2d, v26.2d                      : scvtf  %q26 $0x03 -> %q25
+4e61db9b : scvtf v27.2d, v28.2d                      : scvtf  %q28 $0x03 -> %q27
+4e61d81f : scvtf v31.2d, v0.2d                       : scvtf  %q0 $0x03 -> %q31
+
+# FCVTZS  <Dd>.<T>, <Dn>.<T> (FCVTZS-Q.Q-asimdmisc_R)
+0ea1b820 : fcvtzs v0.2s, v1.2s                       : fcvtzs %d1 $0x02 -> %d0
+0ea1b862 : fcvtzs v2.2s, v3.2s                       : fcvtzs %d3 $0x02 -> %d2
+0ea1b8a4 : fcvtzs v4.2s, v5.2s                       : fcvtzs %d5 $0x02 -> %d4
+0ea1b8e6 : fcvtzs v6.2s, v7.2s                       : fcvtzs %d7 $0x02 -> %d6
+0ea1b928 : fcvtzs v8.2s, v9.2s                       : fcvtzs %d9 $0x02 -> %d8
+0ea1b96a : fcvtzs v10.2s, v11.2s                     : fcvtzs %d11 $0x02 -> %d10
+0ea1b9ac : fcvtzs v12.2s, v13.2s                     : fcvtzs %d13 $0x02 -> %d12
+0ea1b9ee : fcvtzs v14.2s, v15.2s                     : fcvtzs %d15 $0x02 -> %d14
+0ea1ba30 : fcvtzs v16.2s, v17.2s                     : fcvtzs %d17 $0x02 -> %d16
+0ea1ba51 : fcvtzs v17.2s, v18.2s                     : fcvtzs %d18 $0x02 -> %d17
+0ea1ba93 : fcvtzs v19.2s, v20.2s                     : fcvtzs %d20 $0x02 -> %d19
+0ea1bad5 : fcvtzs v21.2s, v22.2s                     : fcvtzs %d22 $0x02 -> %d21
+0ea1bb17 : fcvtzs v23.2s, v24.2s                     : fcvtzs %d24 $0x02 -> %d23
+0ea1bb59 : fcvtzs v25.2s, v26.2s                     : fcvtzs %d26 $0x02 -> %d25
+0ea1bb9b : fcvtzs v27.2s, v28.2s                     : fcvtzs %d28 $0x02 -> %d27
+0ea1b81f : fcvtzs v31.2s, v0.2s                      : fcvtzs %d0 $0x02 -> %d31
+4ea1b820 : fcvtzs v0.4s, v1.4s                       : fcvtzs %q1 $0x02 -> %q0
+4ea1b862 : fcvtzs v2.4s, v3.4s                       : fcvtzs %q3 $0x02 -> %q2
+4ea1b8a4 : fcvtzs v4.4s, v5.4s                       : fcvtzs %q5 $0x02 -> %q4
+4ea1b8e6 : fcvtzs v6.4s, v7.4s                       : fcvtzs %q7 $0x02 -> %q6
+4ea1b928 : fcvtzs v8.4s, v9.4s                       : fcvtzs %q9 $0x02 -> %q8
+4ea1b96a : fcvtzs v10.4s, v11.4s                     : fcvtzs %q11 $0x02 -> %q10
+4ea1b9ac : fcvtzs v12.4s, v13.4s                     : fcvtzs %q13 $0x02 -> %q12
+4ea1b9ee : fcvtzs v14.4s, v15.4s                     : fcvtzs %q15 $0x02 -> %q14
+4ea1ba30 : fcvtzs v16.4s, v17.4s                     : fcvtzs %q17 $0x02 -> %q16
+4ea1ba51 : fcvtzs v17.4s, v18.4s                     : fcvtzs %q18 $0x02 -> %q17
+4ea1ba93 : fcvtzs v19.4s, v20.4s                     : fcvtzs %q20 $0x02 -> %q19
+4ea1bad5 : fcvtzs v21.4s, v22.4s                     : fcvtzs %q22 $0x02 -> %q21
+4ea1bb17 : fcvtzs v23.4s, v24.4s                     : fcvtzs %q24 $0x02 -> %q23
+4ea1bb59 : fcvtzs v25.4s, v26.4s                     : fcvtzs %q26 $0x02 -> %q25
+4ea1bb9b : fcvtzs v27.4s, v28.4s                     : fcvtzs %q28 $0x02 -> %q27
+4ea1b81f : fcvtzs v31.4s, v0.4s                      : fcvtzs %q0 $0x02 -> %q31
+4ee1b820 : fcvtzs v0.2d, v1.2d                       : fcvtzs %q1 $0x03 -> %q0
+4ee1b862 : fcvtzs v2.2d, v3.2d                       : fcvtzs %q3 $0x03 -> %q2
+4ee1b8a4 : fcvtzs v4.2d, v5.2d                       : fcvtzs %q5 $0x03 -> %q4
+4ee1b8e6 : fcvtzs v6.2d, v7.2d                       : fcvtzs %q7 $0x03 -> %q6
+4ee1b928 : fcvtzs v8.2d, v9.2d                       : fcvtzs %q9 $0x03 -> %q8
+4ee1b96a : fcvtzs v10.2d, v11.2d                     : fcvtzs %q11 $0x03 -> %q10
+4ee1b9ac : fcvtzs v12.2d, v13.2d                     : fcvtzs %q13 $0x03 -> %q12
+4ee1b9ee : fcvtzs v14.2d, v15.2d                     : fcvtzs %q15 $0x03 -> %q14
+4ee1ba30 : fcvtzs v16.2d, v17.2d                     : fcvtzs %q17 $0x03 -> %q16
+4ee1ba51 : fcvtzs v17.2d, v18.2d                     : fcvtzs %q18 $0x03 -> %q17
+4ee1ba93 : fcvtzs v19.2d, v20.2d                     : fcvtzs %q20 $0x03 -> %q19
+4ee1bad5 : fcvtzs v21.2d, v22.2d                     : fcvtzs %q22 $0x03 -> %q21
+4ee1bb17 : fcvtzs v23.2d, v24.2d                     : fcvtzs %q24 $0x03 -> %q23
+4ee1bb59 : fcvtzs v25.2d, v26.2d                     : fcvtzs %q26 $0x03 -> %q25
+4ee1bb9b : fcvtzs v27.2d, v28.2d                     : fcvtzs %q28 $0x03 -> %q27
+4ee1b81f : fcvtzs v31.2d, v0.2d                      : fcvtzs %q0 $0x03 -> %q31
+
+# FABS    <Dd>.<T>, <Dn>.<T> (FABS-Q.Q-asimdmisc_R)
+0ea0f820 : fabs v0.2s, v1.2s                         : fabs   %d1 $0x02 -> %d0
+0ea0f862 : fabs v2.2s, v3.2s                         : fabs   %d3 $0x02 -> %d2
+0ea0f8a4 : fabs v4.2s, v5.2s                         : fabs   %d5 $0x02 -> %d4
+0ea0f8e6 : fabs v6.2s, v7.2s                         : fabs   %d7 $0x02 -> %d6
+0ea0f928 : fabs v8.2s, v9.2s                         : fabs   %d9 $0x02 -> %d8
+0ea0f96a : fabs v10.2s, v11.2s                       : fabs   %d11 $0x02 -> %d10
+0ea0f9ac : fabs v12.2s, v13.2s                       : fabs   %d13 $0x02 -> %d12
+0ea0f9ee : fabs v14.2s, v15.2s                       : fabs   %d15 $0x02 -> %d14
+0ea0fa30 : fabs v16.2s, v17.2s                       : fabs   %d17 $0x02 -> %d16
+0ea0fa51 : fabs v17.2s, v18.2s                       : fabs   %d18 $0x02 -> %d17
+0ea0fa93 : fabs v19.2s, v20.2s                       : fabs   %d20 $0x02 -> %d19
+0ea0fad5 : fabs v21.2s, v22.2s                       : fabs   %d22 $0x02 -> %d21
+0ea0fb17 : fabs v23.2s, v24.2s                       : fabs   %d24 $0x02 -> %d23
+0ea0fb59 : fabs v25.2s, v26.2s                       : fabs   %d26 $0x02 -> %d25
+0ea0fb9b : fabs v27.2s, v28.2s                       : fabs   %d28 $0x02 -> %d27
+0ea0f81f : fabs v31.2s, v0.2s                        : fabs   %d0 $0x02 -> %d31
+4ea0f820 : fabs v0.4s, v1.4s                         : fabs   %q1 $0x02 -> %q0
+4ea0f862 : fabs v2.4s, v3.4s                         : fabs   %q3 $0x02 -> %q2
+4ea0f8a4 : fabs v4.4s, v5.4s                         : fabs   %q5 $0x02 -> %q4
+4ea0f8e6 : fabs v6.4s, v7.4s                         : fabs   %q7 $0x02 -> %q6
+4ea0f928 : fabs v8.4s, v9.4s                         : fabs   %q9 $0x02 -> %q8
+4ea0f96a : fabs v10.4s, v11.4s                       : fabs   %q11 $0x02 -> %q10
+4ea0f9ac : fabs v12.4s, v13.4s                       : fabs   %q13 $0x02 -> %q12
+4ea0f9ee : fabs v14.4s, v15.4s                       : fabs   %q15 $0x02 -> %q14
+4ea0fa30 : fabs v16.4s, v17.4s                       : fabs   %q17 $0x02 -> %q16
+4ea0fa51 : fabs v17.4s, v18.4s                       : fabs   %q18 $0x02 -> %q17
+4ea0fa93 : fabs v19.4s, v20.4s                       : fabs   %q20 $0x02 -> %q19
+4ea0fad5 : fabs v21.4s, v22.4s                       : fabs   %q22 $0x02 -> %q21
+4ea0fb17 : fabs v23.4s, v24.4s                       : fabs   %q24 $0x02 -> %q23
+4ea0fb59 : fabs v25.4s, v26.4s                       : fabs   %q26 $0x02 -> %q25
+4ea0fb9b : fabs v27.4s, v28.4s                       : fabs   %q28 $0x02 -> %q27
+4ea0f81f : fabs v31.4s, v0.4s                        : fabs   %q0 $0x02 -> %q31
+4ee0f820 : fabs v0.2d, v1.2d                         : fabs   %q1 $0x03 -> %q0
+4ee0f862 : fabs v2.2d, v3.2d                         : fabs   %q3 $0x03 -> %q2
+4ee0f8a4 : fabs v4.2d, v5.2d                         : fabs   %q5 $0x03 -> %q4
+4ee0f8e6 : fabs v6.2d, v7.2d                         : fabs   %q7 $0x03 -> %q6
+4ee0f928 : fabs v8.2d, v9.2d                         : fabs   %q9 $0x03 -> %q8
+4ee0f96a : fabs v10.2d, v11.2d                       : fabs   %q11 $0x03 -> %q10
+4ee0f9ac : fabs v12.2d, v13.2d                       : fabs   %q13 $0x03 -> %q12
+4ee0f9ee : fabs v14.2d, v15.2d                       : fabs   %q15 $0x03 -> %q14
+4ee0fa30 : fabs v16.2d, v17.2d                       : fabs   %q17 $0x03 -> %q16
+4ee0fa51 : fabs v17.2d, v18.2d                       : fabs   %q18 $0x03 -> %q17
+4ee0fa93 : fabs v19.2d, v20.2d                       : fabs   %q20 $0x03 -> %q19
+4ee0fad5 : fabs v21.2d, v22.2d                       : fabs   %q22 $0x03 -> %q21
+4ee0fb17 : fabs v23.2d, v24.2d                       : fabs   %q24 $0x03 -> %q23
+4ee0fb59 : fabs v25.2d, v26.2d                       : fabs   %q26 $0x03 -> %q25
+4ee0fb9b : fabs v27.2d, v28.2d                       : fabs   %q28 $0x03 -> %q27
+4ee0f81f : fabs v31.2d, v0.2d                        : fabs   %q0 $0x03 -> %q31
+
+# FCMEQ   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FCMEQ-Q.QQ-asimdsame_only)
+0e22e420 : fcmeq v0.2s, v1.2s, v2.2s                 : fcmeq  %d1 %d2 $0x02 -> %d0
+0e24e462 : fcmeq v2.2s, v3.2s, v4.2s                 : fcmeq  %d3 %d4 $0x02 -> %d2
+0e26e4a4 : fcmeq v4.2s, v5.2s, v6.2s                 : fcmeq  %d5 %d6 $0x02 -> %d4
+0e28e4e6 : fcmeq v6.2s, v7.2s, v8.2s                 : fcmeq  %d7 %d8 $0x02 -> %d6
+0e2ae528 : fcmeq v8.2s, v9.2s, v10.2s                : fcmeq  %d9 %d10 $0x02 -> %d8
+0e2ce56a : fcmeq v10.2s, v11.2s, v12.2s              : fcmeq  %d11 %d12 $0x02 -> %d10
+0e2ee5ac : fcmeq v12.2s, v13.2s, v14.2s              : fcmeq  %d13 %d14 $0x02 -> %d12
+0e30e5ee : fcmeq v14.2s, v15.2s, v16.2s              : fcmeq  %d15 %d16 $0x02 -> %d14
+0e32e630 : fcmeq v16.2s, v17.2s, v18.2s              : fcmeq  %d17 %d18 $0x02 -> %d16
+0e33e651 : fcmeq v17.2s, v18.2s, v19.2s              : fcmeq  %d18 %d19 $0x02 -> %d17
+0e35e693 : fcmeq v19.2s, v20.2s, v21.2s              : fcmeq  %d20 %d21 $0x02 -> %d19
+0e37e6d5 : fcmeq v21.2s, v22.2s, v23.2s              : fcmeq  %d22 %d23 $0x02 -> %d21
+0e39e717 : fcmeq v23.2s, v24.2s, v25.2s              : fcmeq  %d24 %d25 $0x02 -> %d23
+0e3be759 : fcmeq v25.2s, v26.2s, v27.2s              : fcmeq  %d26 %d27 $0x02 -> %d25
+0e3de79b : fcmeq v27.2s, v28.2s, v29.2s              : fcmeq  %d28 %d29 $0x02 -> %d27
+0e21e41f : fcmeq v31.2s, v0.2s, v1.2s                : fcmeq  %d0 %d1 $0x02 -> %d31
+4e22e420 : fcmeq v0.4s, v1.4s, v2.4s                 : fcmeq  %q1 %q2 $0x02 -> %q0
+4e24e462 : fcmeq v2.4s, v3.4s, v4.4s                 : fcmeq  %q3 %q4 $0x02 -> %q2
+4e26e4a4 : fcmeq v4.4s, v5.4s, v6.4s                 : fcmeq  %q5 %q6 $0x02 -> %q4
+4e28e4e6 : fcmeq v6.4s, v7.4s, v8.4s                 : fcmeq  %q7 %q8 $0x02 -> %q6
+4e2ae528 : fcmeq v8.4s, v9.4s, v10.4s                : fcmeq  %q9 %q10 $0x02 -> %q8
+4e2ce56a : fcmeq v10.4s, v11.4s, v12.4s              : fcmeq  %q11 %q12 $0x02 -> %q10
+4e2ee5ac : fcmeq v12.4s, v13.4s, v14.4s              : fcmeq  %q13 %q14 $0x02 -> %q12
+4e30e5ee : fcmeq v14.4s, v15.4s, v16.4s              : fcmeq  %q15 %q16 $0x02 -> %q14
+4e32e630 : fcmeq v16.4s, v17.4s, v18.4s              : fcmeq  %q17 %q18 $0x02 -> %q16
+4e33e651 : fcmeq v17.4s, v18.4s, v19.4s              : fcmeq  %q18 %q19 $0x02 -> %q17
+4e35e693 : fcmeq v19.4s, v20.4s, v21.4s              : fcmeq  %q20 %q21 $0x02 -> %q19
+4e37e6d5 : fcmeq v21.4s, v22.4s, v23.4s              : fcmeq  %q22 %q23 $0x02 -> %q21
+4e39e717 : fcmeq v23.4s, v24.4s, v25.4s              : fcmeq  %q24 %q25 $0x02 -> %q23
+4e3be759 : fcmeq v25.4s, v26.4s, v27.4s              : fcmeq  %q26 %q27 $0x02 -> %q25
+4e3de79b : fcmeq v27.4s, v28.4s, v29.4s              : fcmeq  %q28 %q29 $0x02 -> %q27
+4e21e41f : fcmeq v31.4s, v0.4s, v1.4s                : fcmeq  %q0 %q1 $0x02 -> %q31
+4e62e420 : fcmeq v0.2d, v1.2d, v2.2d                 : fcmeq  %q1 %q2 $0x03 -> %q0
+4e64e462 : fcmeq v2.2d, v3.2d, v4.2d                 : fcmeq  %q3 %q4 $0x03 -> %q2
+4e66e4a4 : fcmeq v4.2d, v5.2d, v6.2d                 : fcmeq  %q5 %q6 $0x03 -> %q4
+4e68e4e6 : fcmeq v6.2d, v7.2d, v8.2d                 : fcmeq  %q7 %q8 $0x03 -> %q6
+4e6ae528 : fcmeq v8.2d, v9.2d, v10.2d                : fcmeq  %q9 %q10 $0x03 -> %q8
+4e6ce56a : fcmeq v10.2d, v11.2d, v12.2d              : fcmeq  %q11 %q12 $0x03 -> %q10
+4e6ee5ac : fcmeq v12.2d, v13.2d, v14.2d              : fcmeq  %q13 %q14 $0x03 -> %q12
+4e70e5ee : fcmeq v14.2d, v15.2d, v16.2d              : fcmeq  %q15 %q16 $0x03 -> %q14
+4e72e630 : fcmeq v16.2d, v17.2d, v18.2d              : fcmeq  %q17 %q18 $0x03 -> %q16
+4e73e651 : fcmeq v17.2d, v18.2d, v19.2d              : fcmeq  %q18 %q19 $0x03 -> %q17
+4e75e693 : fcmeq v19.2d, v20.2d, v21.2d              : fcmeq  %q20 %q21 $0x03 -> %q19
+4e77e6d5 : fcmeq v21.2d, v22.2d, v23.2d              : fcmeq  %q22 %q23 $0x03 -> %q21
+4e79e717 : fcmeq v23.2d, v24.2d, v25.2d              : fcmeq  %q24 %q25 $0x03 -> %q23
+4e7be759 : fcmeq v25.2d, v26.2d, v27.2d              : fcmeq  %q26 %q27 $0x03 -> %q25
+4e7de79b : fcmeq v27.2d, v28.2d, v29.2d              : fcmeq  %q28 %q29 $0x03 -> %q27
+4e61e41f : fcmeq v31.2d, v0.2d, v1.2d                : fcmeq  %q0 %q1 $0x03 -> %q31
+
+# FRSQRTE <Dd>.<T>, <Dn>.<T> (FRSQRTE-Q.Q-asimdmisc_R)
+2ea1d820 : frsqrte v0.2s, v1.2s                      : frsqrte %d1 $0x02 -> %d0
+2ea1d862 : frsqrte v2.2s, v3.2s                      : frsqrte %d3 $0x02 -> %d2
+2ea1d8a4 : frsqrte v4.2s, v5.2s                      : frsqrte %d5 $0x02 -> %d4
+2ea1d8e6 : frsqrte v6.2s, v7.2s                      : frsqrte %d7 $0x02 -> %d6
+2ea1d928 : frsqrte v8.2s, v9.2s                      : frsqrte %d9 $0x02 -> %d8
+2ea1d96a : frsqrte v10.2s, v11.2s                    : frsqrte %d11 $0x02 -> %d10
+2ea1d9ac : frsqrte v12.2s, v13.2s                    : frsqrte %d13 $0x02 -> %d12
+2ea1d9ee : frsqrte v14.2s, v15.2s                    : frsqrte %d15 $0x02 -> %d14
+2ea1da30 : frsqrte v16.2s, v17.2s                    : frsqrte %d17 $0x02 -> %d16
+2ea1da51 : frsqrte v17.2s, v18.2s                    : frsqrte %d18 $0x02 -> %d17
+2ea1da93 : frsqrte v19.2s, v20.2s                    : frsqrte %d20 $0x02 -> %d19
+2ea1dad5 : frsqrte v21.2s, v22.2s                    : frsqrte %d22 $0x02 -> %d21
+2ea1db17 : frsqrte v23.2s, v24.2s                    : frsqrte %d24 $0x02 -> %d23
+2ea1db59 : frsqrte v25.2s, v26.2s                    : frsqrte %d26 $0x02 -> %d25
+2ea1db9b : frsqrte v27.2s, v28.2s                    : frsqrte %d28 $0x02 -> %d27
+2ea1d81f : frsqrte v31.2s, v0.2s                     : frsqrte %d0 $0x02 -> %d31
+6ea1d820 : frsqrte v0.4s, v1.4s                      : frsqrte %q1 $0x02 -> %q0
+6ea1d862 : frsqrte v2.4s, v3.4s                      : frsqrte %q3 $0x02 -> %q2
+6ea1d8a4 : frsqrte v4.4s, v5.4s                      : frsqrte %q5 $0x02 -> %q4
+6ea1d8e6 : frsqrte v6.4s, v7.4s                      : frsqrte %q7 $0x02 -> %q6
+6ea1d928 : frsqrte v8.4s, v9.4s                      : frsqrte %q9 $0x02 -> %q8
+6ea1d96a : frsqrte v10.4s, v11.4s                    : frsqrte %q11 $0x02 -> %q10
+6ea1d9ac : frsqrte v12.4s, v13.4s                    : frsqrte %q13 $0x02 -> %q12
+6ea1d9ee : frsqrte v14.4s, v15.4s                    : frsqrte %q15 $0x02 -> %q14
+6ea1da30 : frsqrte v16.4s, v17.4s                    : frsqrte %q17 $0x02 -> %q16
+6ea1da51 : frsqrte v17.4s, v18.4s                    : frsqrte %q18 $0x02 -> %q17
+6ea1da93 : frsqrte v19.4s, v20.4s                    : frsqrte %q20 $0x02 -> %q19
+6ea1dad5 : frsqrte v21.4s, v22.4s                    : frsqrte %q22 $0x02 -> %q21
+6ea1db17 : frsqrte v23.4s, v24.4s                    : frsqrte %q24 $0x02 -> %q23
+6ea1db59 : frsqrte v25.4s, v26.4s                    : frsqrte %q26 $0x02 -> %q25
+6ea1db9b : frsqrte v27.4s, v28.4s                    : frsqrte %q28 $0x02 -> %q27
+6ea1d81f : frsqrte v31.4s, v0.4s                     : frsqrte %q0 $0x02 -> %q31
+6ee1d820 : frsqrte v0.2d, v1.2d                      : frsqrte %q1 $0x03 -> %q0
+6ee1d862 : frsqrte v2.2d, v3.2d                      : frsqrte %q3 $0x03 -> %q2
+6ee1d8a4 : frsqrte v4.2d, v5.2d                      : frsqrte %q5 $0x03 -> %q4
+6ee1d8e6 : frsqrte v6.2d, v7.2d                      : frsqrte %q7 $0x03 -> %q6
+6ee1d928 : frsqrte v8.2d, v9.2d                      : frsqrte %q9 $0x03 -> %q8
+6ee1d96a : frsqrte v10.2d, v11.2d                    : frsqrte %q11 $0x03 -> %q10
+6ee1d9ac : frsqrte v12.2d, v13.2d                    : frsqrte %q13 $0x03 -> %q12
+6ee1d9ee : frsqrte v14.2d, v15.2d                    : frsqrte %q15 $0x03 -> %q14
+6ee1da30 : frsqrte v16.2d, v17.2d                    : frsqrte %q17 $0x03 -> %q16
+6ee1da51 : frsqrte v17.2d, v18.2d                    : frsqrte %q18 $0x03 -> %q17
+6ee1da93 : frsqrte v19.2d, v20.2d                    : frsqrte %q20 $0x03 -> %q19
+6ee1dad5 : frsqrte v21.2d, v22.2d                    : frsqrte %q22 $0x03 -> %q21
+6ee1db17 : frsqrte v23.2d, v24.2d                    : frsqrte %q24 $0x03 -> %q23
+6ee1db59 : frsqrte v25.2d, v26.2d                    : frsqrte %q26 $0x03 -> %q25
+6ee1db9b : frsqrte v27.2d, v28.2d                    : frsqrte %q28 $0x03 -> %q27
+6ee1d81f : frsqrte v31.2d, v0.2d                     : frsqrte %q0 $0x03 -> %q31
+
+# URSQRTE <Sd>.<T>, <Sn>.<T> (URSQRTE-Q.Q-asimdmisc_R)
+2ea1c820 : ursqrte v0.2s, v1.2s                      : ursqrte %d1 $0x02 -> %d0
+2ea1c862 : ursqrte v2.2s, v3.2s                      : ursqrte %d3 $0x02 -> %d2
+2ea1c8a4 : ursqrte v4.2s, v5.2s                      : ursqrte %d5 $0x02 -> %d4
+2ea1c8e6 : ursqrte v6.2s, v7.2s                      : ursqrte %d7 $0x02 -> %d6
+2ea1c928 : ursqrte v8.2s, v9.2s                      : ursqrte %d9 $0x02 -> %d8
+2ea1c96a : ursqrte v10.2s, v11.2s                    : ursqrte %d11 $0x02 -> %d10
+2ea1c9ac : ursqrte v12.2s, v13.2s                    : ursqrte %d13 $0x02 -> %d12
+2ea1c9ee : ursqrte v14.2s, v15.2s                    : ursqrte %d15 $0x02 -> %d14
+2ea1ca30 : ursqrte v16.2s, v17.2s                    : ursqrte %d17 $0x02 -> %d16
+2ea1ca51 : ursqrte v17.2s, v18.2s                    : ursqrte %d18 $0x02 -> %d17
+2ea1ca93 : ursqrte v19.2s, v20.2s                    : ursqrte %d20 $0x02 -> %d19
+2ea1cad5 : ursqrte v21.2s, v22.2s                    : ursqrte %d22 $0x02 -> %d21
+2ea1cb17 : ursqrte v23.2s, v24.2s                    : ursqrte %d24 $0x02 -> %d23
+2ea1cb59 : ursqrte v25.2s, v26.2s                    : ursqrte %d26 $0x02 -> %d25
+2ea1cb9b : ursqrte v27.2s, v28.2s                    : ursqrte %d28 $0x02 -> %d27
+2ea1c81f : ursqrte v31.2s, v0.2s                     : ursqrte %d0 $0x02 -> %d31
+6ea1c820 : ursqrte v0.4s, v1.4s                      : ursqrte %q1 $0x02 -> %q0
+6ea1c862 : ursqrte v2.4s, v3.4s                      : ursqrte %q3 $0x02 -> %q2
+6ea1c8a4 : ursqrte v4.4s, v5.4s                      : ursqrte %q5 $0x02 -> %q4
+6ea1c8e6 : ursqrte v6.4s, v7.4s                      : ursqrte %q7 $0x02 -> %q6
+6ea1c928 : ursqrte v8.4s, v9.4s                      : ursqrte %q9 $0x02 -> %q8
+6ea1c96a : ursqrte v10.4s, v11.4s                    : ursqrte %q11 $0x02 -> %q10
+6ea1c9ac : ursqrte v12.4s, v13.4s                    : ursqrte %q13 $0x02 -> %q12
+6ea1c9ee : ursqrte v14.4s, v15.4s                    : ursqrte %q15 $0x02 -> %q14
+6ea1ca30 : ursqrte v16.4s, v17.4s                    : ursqrte %q17 $0x02 -> %q16
+6ea1ca51 : ursqrte v17.4s, v18.4s                    : ursqrte %q18 $0x02 -> %q17
+6ea1ca93 : ursqrte v19.4s, v20.4s                    : ursqrte %q20 $0x02 -> %q19
+6ea1cad5 : ursqrte v21.4s, v22.4s                    : ursqrte %q22 $0x02 -> %q21
+6ea1cb17 : ursqrte v23.4s, v24.4s                    : ursqrte %q24 $0x02 -> %q23
+6ea1cb59 : ursqrte v25.4s, v26.4s                    : ursqrte %q26 $0x02 -> %q25
+6ea1cb9b : ursqrte v27.4s, v28.4s                    : ursqrte %q28 $0x02 -> %q27
+6ea1c81f : ursqrte v31.4s, v0.4s                     : ursqrte %q0 $0x02 -> %q31
+
+# FCVTMS  <Dd>.<T>, <Dn>.<T> (FCVTMS-Q.Q-asimdmisc_R)
+0e21b820 : fcvtms v0.2s, v1.2s                       : fcvtms %d1 $0x02 -> %d0
+0e21b862 : fcvtms v2.2s, v3.2s                       : fcvtms %d3 $0x02 -> %d2
+0e21b8a4 : fcvtms v4.2s, v5.2s                       : fcvtms %d5 $0x02 -> %d4
+0e21b8e6 : fcvtms v6.2s, v7.2s                       : fcvtms %d7 $0x02 -> %d6
+0e21b928 : fcvtms v8.2s, v9.2s                       : fcvtms %d9 $0x02 -> %d8
+0e21b96a : fcvtms v10.2s, v11.2s                     : fcvtms %d11 $0x02 -> %d10
+0e21b9ac : fcvtms v12.2s, v13.2s                     : fcvtms %d13 $0x02 -> %d12
+0e21b9ee : fcvtms v14.2s, v15.2s                     : fcvtms %d15 $0x02 -> %d14
+0e21ba30 : fcvtms v16.2s, v17.2s                     : fcvtms %d17 $0x02 -> %d16
+0e21ba51 : fcvtms v17.2s, v18.2s                     : fcvtms %d18 $0x02 -> %d17
+0e21ba93 : fcvtms v19.2s, v20.2s                     : fcvtms %d20 $0x02 -> %d19
+0e21bad5 : fcvtms v21.2s, v22.2s                     : fcvtms %d22 $0x02 -> %d21
+0e21bb17 : fcvtms v23.2s, v24.2s                     : fcvtms %d24 $0x02 -> %d23
+0e21bb59 : fcvtms v25.2s, v26.2s                     : fcvtms %d26 $0x02 -> %d25
+0e21bb9b : fcvtms v27.2s, v28.2s                     : fcvtms %d28 $0x02 -> %d27
+0e21b81f : fcvtms v31.2s, v0.2s                      : fcvtms %d0 $0x02 -> %d31
+4e21b820 : fcvtms v0.4s, v1.4s                       : fcvtms %q1 $0x02 -> %q0
+4e21b862 : fcvtms v2.4s, v3.4s                       : fcvtms %q3 $0x02 -> %q2
+4e21b8a4 : fcvtms v4.4s, v5.4s                       : fcvtms %q5 $0x02 -> %q4
+4e21b8e6 : fcvtms v6.4s, v7.4s                       : fcvtms %q7 $0x02 -> %q6
+4e21b928 : fcvtms v8.4s, v9.4s                       : fcvtms %q9 $0x02 -> %q8
+4e21b96a : fcvtms v10.4s, v11.4s                     : fcvtms %q11 $0x02 -> %q10
+4e21b9ac : fcvtms v12.4s, v13.4s                     : fcvtms %q13 $0x02 -> %q12
+4e21b9ee : fcvtms v14.4s, v15.4s                     : fcvtms %q15 $0x02 -> %q14
+4e21ba30 : fcvtms v16.4s, v17.4s                     : fcvtms %q17 $0x02 -> %q16
+4e21ba51 : fcvtms v17.4s, v18.4s                     : fcvtms %q18 $0x02 -> %q17
+4e21ba93 : fcvtms v19.4s, v20.4s                     : fcvtms %q20 $0x02 -> %q19
+4e21bad5 : fcvtms v21.4s, v22.4s                     : fcvtms %q22 $0x02 -> %q21
+4e21bb17 : fcvtms v23.4s, v24.4s                     : fcvtms %q24 $0x02 -> %q23
+4e21bb59 : fcvtms v25.4s, v26.4s                     : fcvtms %q26 $0x02 -> %q25
+4e21bb9b : fcvtms v27.4s, v28.4s                     : fcvtms %q28 $0x02 -> %q27
+4e21b81f : fcvtms v31.4s, v0.4s                      : fcvtms %q0 $0x02 -> %q31
+4e61b820 : fcvtms v0.2d, v1.2d                       : fcvtms %q1 $0x03 -> %q0
+4e61b862 : fcvtms v2.2d, v3.2d                       : fcvtms %q3 $0x03 -> %q2
+4e61b8a4 : fcvtms v4.2d, v5.2d                       : fcvtms %q5 $0x03 -> %q4
+4e61b8e6 : fcvtms v6.2d, v7.2d                       : fcvtms %q7 $0x03 -> %q6
+4e61b928 : fcvtms v8.2d, v9.2d                       : fcvtms %q9 $0x03 -> %q8
+4e61b96a : fcvtms v10.2d, v11.2d                     : fcvtms %q11 $0x03 -> %q10
+4e61b9ac : fcvtms v12.2d, v13.2d                     : fcvtms %q13 $0x03 -> %q12
+4e61b9ee : fcvtms v14.2d, v15.2d                     : fcvtms %q15 $0x03 -> %q14
+4e61ba30 : fcvtms v16.2d, v17.2d                     : fcvtms %q17 $0x03 -> %q16
+4e61ba51 : fcvtms v17.2d, v18.2d                     : fcvtms %q18 $0x03 -> %q17
+4e61ba93 : fcvtms v19.2d, v20.2d                     : fcvtms %q20 $0x03 -> %q19
+4e61bad5 : fcvtms v21.2d, v22.2d                     : fcvtms %q22 $0x03 -> %q21
+4e61bb17 : fcvtms v23.2d, v24.2d                     : fcvtms %q24 $0x03 -> %q23
+4e61bb59 : fcvtms v25.2d, v26.2d                     : fcvtms %q26 $0x03 -> %q25
+4e61bb9b : fcvtms v27.2d, v28.2d                     : fcvtms %q28 $0x03 -> %q27
+4e61b81f : fcvtms v31.2d, v0.2d                      : fcvtms %q0 $0x03 -> %q31
+
 # FCMP    <Dn>, #0.0 (FCMP-V-DZ_floatcmp)
 1e602008 : fcmp d0, #0.0                             : fcmp   %d0 $0.000000
 1e602048 : fcmp d2, #0.0                             : fcmp   %d2 $0.000000
@@ -28908,6 +29588,490 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 1e602328 : fcmp d25, #0.0                            : fcmp   %d25 $0.000000
 1e602368 : fcmp d27, #0.0                            : fcmp   %d27 $0.000000
 1e6023e8 : fcmp d31, #0.0                            : fcmp   %d31 $0.000000
+
+# FCVTAU  <Dd>.<T>, <Dn>.<T> (FCVTAU-Q.Q-asimdmisc_R)
+2e21c820 : fcvtau v0.2s, v1.2s                       : fcvtau %d1 $0x02 -> %d0
+2e21c862 : fcvtau v2.2s, v3.2s                       : fcvtau %d3 $0x02 -> %d2
+2e21c8a4 : fcvtau v4.2s, v5.2s                       : fcvtau %d5 $0x02 -> %d4
+2e21c8e6 : fcvtau v6.2s, v7.2s                       : fcvtau %d7 $0x02 -> %d6
+2e21c928 : fcvtau v8.2s, v9.2s                       : fcvtau %d9 $0x02 -> %d8
+2e21c96a : fcvtau v10.2s, v11.2s                     : fcvtau %d11 $0x02 -> %d10
+2e21c9ac : fcvtau v12.2s, v13.2s                     : fcvtau %d13 $0x02 -> %d12
+2e21c9ee : fcvtau v14.2s, v15.2s                     : fcvtau %d15 $0x02 -> %d14
+2e21ca30 : fcvtau v16.2s, v17.2s                     : fcvtau %d17 $0x02 -> %d16
+2e21ca51 : fcvtau v17.2s, v18.2s                     : fcvtau %d18 $0x02 -> %d17
+2e21ca93 : fcvtau v19.2s, v20.2s                     : fcvtau %d20 $0x02 -> %d19
+2e21cad5 : fcvtau v21.2s, v22.2s                     : fcvtau %d22 $0x02 -> %d21
+2e21cb17 : fcvtau v23.2s, v24.2s                     : fcvtau %d24 $0x02 -> %d23
+2e21cb59 : fcvtau v25.2s, v26.2s                     : fcvtau %d26 $0x02 -> %d25
+2e21cb9b : fcvtau v27.2s, v28.2s                     : fcvtau %d28 $0x02 -> %d27
+2e21c81f : fcvtau v31.2s, v0.2s                      : fcvtau %d0 $0x02 -> %d31
+6e21c820 : fcvtau v0.4s, v1.4s                       : fcvtau %q1 $0x02 -> %q0
+6e21c862 : fcvtau v2.4s, v3.4s                       : fcvtau %q3 $0x02 -> %q2
+6e21c8a4 : fcvtau v4.4s, v5.4s                       : fcvtau %q5 $0x02 -> %q4
+6e21c8e6 : fcvtau v6.4s, v7.4s                       : fcvtau %q7 $0x02 -> %q6
+6e21c928 : fcvtau v8.4s, v9.4s                       : fcvtau %q9 $0x02 -> %q8
+6e21c96a : fcvtau v10.4s, v11.4s                     : fcvtau %q11 $0x02 -> %q10
+6e21c9ac : fcvtau v12.4s, v13.4s                     : fcvtau %q13 $0x02 -> %q12
+6e21c9ee : fcvtau v14.4s, v15.4s                     : fcvtau %q15 $0x02 -> %q14
+6e21ca30 : fcvtau v16.4s, v17.4s                     : fcvtau %q17 $0x02 -> %q16
+6e21ca51 : fcvtau v17.4s, v18.4s                     : fcvtau %q18 $0x02 -> %q17
+6e21ca93 : fcvtau v19.4s, v20.4s                     : fcvtau %q20 $0x02 -> %q19
+6e21cad5 : fcvtau v21.4s, v22.4s                     : fcvtau %q22 $0x02 -> %q21
+6e21cb17 : fcvtau v23.4s, v24.4s                     : fcvtau %q24 $0x02 -> %q23
+6e21cb59 : fcvtau v25.4s, v26.4s                     : fcvtau %q26 $0x02 -> %q25
+6e21cb9b : fcvtau v27.4s, v28.4s                     : fcvtau %q28 $0x02 -> %q27
+6e21c81f : fcvtau v31.4s, v0.4s                      : fcvtau %q0 $0x02 -> %q31
+6e61c820 : fcvtau v0.2d, v1.2d                       : fcvtau %q1 $0x03 -> %q0
+6e61c862 : fcvtau v2.2d, v3.2d                       : fcvtau %q3 $0x03 -> %q2
+6e61c8a4 : fcvtau v4.2d, v5.2d                       : fcvtau %q5 $0x03 -> %q4
+6e61c8e6 : fcvtau v6.2d, v7.2d                       : fcvtau %q7 $0x03 -> %q6
+6e61c928 : fcvtau v8.2d, v9.2d                       : fcvtau %q9 $0x03 -> %q8
+6e61c96a : fcvtau v10.2d, v11.2d                     : fcvtau %q11 $0x03 -> %q10
+6e61c9ac : fcvtau v12.2d, v13.2d                     : fcvtau %q13 $0x03 -> %q12
+6e61c9ee : fcvtau v14.2d, v15.2d                     : fcvtau %q15 $0x03 -> %q14
+6e61ca30 : fcvtau v16.2d, v17.2d                     : fcvtau %q17 $0x03 -> %q16
+6e61ca51 : fcvtau v17.2d, v18.2d                     : fcvtau %q18 $0x03 -> %q17
+6e61ca93 : fcvtau v19.2d, v20.2d                     : fcvtau %q20 $0x03 -> %q19
+6e61cad5 : fcvtau v21.2d, v22.2d                     : fcvtau %q22 $0x03 -> %q21
+6e61cb17 : fcvtau v23.2d, v24.2d                     : fcvtau %q24 $0x03 -> %q23
+6e61cb59 : fcvtau v25.2d, v26.2d                     : fcvtau %q26 $0x03 -> %q25
+6e61cb9b : fcvtau v27.2d, v28.2d                     : fcvtau %q28 $0x03 -> %q27
+6e61c81f : fcvtau v31.2d, v0.2d                      : fcvtau %q0 $0x03 -> %q31
+
+# FDIV    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FDIV-Q.QQ-asimdsame_only)
+2e22fc20 : fdiv v0.2s, v1.2s, v2.2s                  : fdiv   %d1 %d2 $0x02 -> %d0
+2e24fc62 : fdiv v2.2s, v3.2s, v4.2s                  : fdiv   %d3 %d4 $0x02 -> %d2
+2e26fca4 : fdiv v4.2s, v5.2s, v6.2s                  : fdiv   %d5 %d6 $0x02 -> %d4
+2e28fce6 : fdiv v6.2s, v7.2s, v8.2s                  : fdiv   %d7 %d8 $0x02 -> %d6
+2e2afd28 : fdiv v8.2s, v9.2s, v10.2s                 : fdiv   %d9 %d10 $0x02 -> %d8
+2e2cfd6a : fdiv v10.2s, v11.2s, v12.2s               : fdiv   %d11 %d12 $0x02 -> %d10
+2e2efdac : fdiv v12.2s, v13.2s, v14.2s               : fdiv   %d13 %d14 $0x02 -> %d12
+2e30fdee : fdiv v14.2s, v15.2s, v16.2s               : fdiv   %d15 %d16 $0x02 -> %d14
+2e32fe30 : fdiv v16.2s, v17.2s, v18.2s               : fdiv   %d17 %d18 $0x02 -> %d16
+2e33fe51 : fdiv v17.2s, v18.2s, v19.2s               : fdiv   %d18 %d19 $0x02 -> %d17
+2e35fe93 : fdiv v19.2s, v20.2s, v21.2s               : fdiv   %d20 %d21 $0x02 -> %d19
+2e37fed5 : fdiv v21.2s, v22.2s, v23.2s               : fdiv   %d22 %d23 $0x02 -> %d21
+2e39ff17 : fdiv v23.2s, v24.2s, v25.2s               : fdiv   %d24 %d25 $0x02 -> %d23
+2e3bff59 : fdiv v25.2s, v26.2s, v27.2s               : fdiv   %d26 %d27 $0x02 -> %d25
+2e3dff9b : fdiv v27.2s, v28.2s, v29.2s               : fdiv   %d28 %d29 $0x02 -> %d27
+2e21fc1f : fdiv v31.2s, v0.2s, v1.2s                 : fdiv   %d0 %d1 $0x02 -> %d31
+6e22fc20 : fdiv v0.4s, v1.4s, v2.4s                  : fdiv   %q1 %q2 $0x02 -> %q0
+6e24fc62 : fdiv v2.4s, v3.4s, v4.4s                  : fdiv   %q3 %q4 $0x02 -> %q2
+6e26fca4 : fdiv v4.4s, v5.4s, v6.4s                  : fdiv   %q5 %q6 $0x02 -> %q4
+6e28fce6 : fdiv v6.4s, v7.4s, v8.4s                  : fdiv   %q7 %q8 $0x02 -> %q6
+6e2afd28 : fdiv v8.4s, v9.4s, v10.4s                 : fdiv   %q9 %q10 $0x02 -> %q8
+6e2cfd6a : fdiv v10.4s, v11.4s, v12.4s               : fdiv   %q11 %q12 $0x02 -> %q10
+6e2efdac : fdiv v12.4s, v13.4s, v14.4s               : fdiv   %q13 %q14 $0x02 -> %q12
+6e30fdee : fdiv v14.4s, v15.4s, v16.4s               : fdiv   %q15 %q16 $0x02 -> %q14
+6e32fe30 : fdiv v16.4s, v17.4s, v18.4s               : fdiv   %q17 %q18 $0x02 -> %q16
+6e33fe51 : fdiv v17.4s, v18.4s, v19.4s               : fdiv   %q18 %q19 $0x02 -> %q17
+6e35fe93 : fdiv v19.4s, v20.4s, v21.4s               : fdiv   %q20 %q21 $0x02 -> %q19
+6e37fed5 : fdiv v21.4s, v22.4s, v23.4s               : fdiv   %q22 %q23 $0x02 -> %q21
+6e39ff17 : fdiv v23.4s, v24.4s, v25.4s               : fdiv   %q24 %q25 $0x02 -> %q23
+6e3bff59 : fdiv v25.4s, v26.4s, v27.4s               : fdiv   %q26 %q27 $0x02 -> %q25
+6e3dff9b : fdiv v27.4s, v28.4s, v29.4s               : fdiv   %q28 %q29 $0x02 -> %q27
+6e21fc1f : fdiv v31.4s, v0.4s, v1.4s                 : fdiv   %q0 %q1 $0x02 -> %q31
+6e62fc20 : fdiv v0.2d, v1.2d, v2.2d                  : fdiv   %q1 %q2 $0x03 -> %q0
+6e64fc62 : fdiv v2.2d, v3.2d, v4.2d                  : fdiv   %q3 %q4 $0x03 -> %q2
+6e66fca4 : fdiv v4.2d, v5.2d, v6.2d                  : fdiv   %q5 %q6 $0x03 -> %q4
+6e68fce6 : fdiv v6.2d, v7.2d, v8.2d                  : fdiv   %q7 %q8 $0x03 -> %q6
+6e6afd28 : fdiv v8.2d, v9.2d, v10.2d                 : fdiv   %q9 %q10 $0x03 -> %q8
+6e6cfd6a : fdiv v10.2d, v11.2d, v12.2d               : fdiv   %q11 %q12 $0x03 -> %q10
+6e6efdac : fdiv v12.2d, v13.2d, v14.2d               : fdiv   %q13 %q14 $0x03 -> %q12
+6e70fdee : fdiv v14.2d, v15.2d, v16.2d               : fdiv   %q15 %q16 $0x03 -> %q14
+6e72fe30 : fdiv v16.2d, v17.2d, v18.2d               : fdiv   %q17 %q18 $0x03 -> %q16
+6e73fe51 : fdiv v17.2d, v18.2d, v19.2d               : fdiv   %q18 %q19 $0x03 -> %q17
+6e75fe93 : fdiv v19.2d, v20.2d, v21.2d               : fdiv   %q20 %q21 $0x03 -> %q19
+6e77fed5 : fdiv v21.2d, v22.2d, v23.2d               : fdiv   %q22 %q23 $0x03 -> %q21
+6e79ff17 : fdiv v23.2d, v24.2d, v25.2d               : fdiv   %q24 %q25 $0x03 -> %q23
+6e7bff59 : fdiv v25.2d, v26.2d, v27.2d               : fdiv   %q26 %q27 $0x03 -> %q25
+6e7dff9b : fdiv v27.2d, v28.2d, v29.2d               : fdiv   %q28 %q29 $0x03 -> %q27
+6e61fc1f : fdiv v31.2d, v0.2d, v1.2d                 : fdiv   %q0 %q1 $0x03 -> %q31
+
+# FACGE   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FACGE-Q.QQ-asimdsame_only)
+2e22ec20 : facge v0.2s, v1.2s, v2.2s                 : facge  %d1 %d2 $0x02 -> %d0
+2e24ec62 : facge v2.2s, v3.2s, v4.2s                 : facge  %d3 %d4 $0x02 -> %d2
+2e26eca4 : facge v4.2s, v5.2s, v6.2s                 : facge  %d5 %d6 $0x02 -> %d4
+2e28ece6 : facge v6.2s, v7.2s, v8.2s                 : facge  %d7 %d8 $0x02 -> %d6
+2e2aed28 : facge v8.2s, v9.2s, v10.2s                : facge  %d9 %d10 $0x02 -> %d8
+2e2ced6a : facge v10.2s, v11.2s, v12.2s              : facge  %d11 %d12 $0x02 -> %d10
+2e2eedac : facge v12.2s, v13.2s, v14.2s              : facge  %d13 %d14 $0x02 -> %d12
+2e30edee : facge v14.2s, v15.2s, v16.2s              : facge  %d15 %d16 $0x02 -> %d14
+2e32ee30 : facge v16.2s, v17.2s, v18.2s              : facge  %d17 %d18 $0x02 -> %d16
+2e33ee51 : facge v17.2s, v18.2s, v19.2s              : facge  %d18 %d19 $0x02 -> %d17
+2e35ee93 : facge v19.2s, v20.2s, v21.2s              : facge  %d20 %d21 $0x02 -> %d19
+2e37eed5 : facge v21.2s, v22.2s, v23.2s              : facge  %d22 %d23 $0x02 -> %d21
+2e39ef17 : facge v23.2s, v24.2s, v25.2s              : facge  %d24 %d25 $0x02 -> %d23
+2e3bef59 : facge v25.2s, v26.2s, v27.2s              : facge  %d26 %d27 $0x02 -> %d25
+2e3def9b : facge v27.2s, v28.2s, v29.2s              : facge  %d28 %d29 $0x02 -> %d27
+2e21ec1f : facge v31.2s, v0.2s, v1.2s                : facge  %d0 %d1 $0x02 -> %d31
+6e22ec20 : facge v0.4s, v1.4s, v2.4s                 : facge  %q1 %q2 $0x02 -> %q0
+6e24ec62 : facge v2.4s, v3.4s, v4.4s                 : facge  %q3 %q4 $0x02 -> %q2
+6e26eca4 : facge v4.4s, v5.4s, v6.4s                 : facge  %q5 %q6 $0x02 -> %q4
+6e28ece6 : facge v6.4s, v7.4s, v8.4s                 : facge  %q7 %q8 $0x02 -> %q6
+6e2aed28 : facge v8.4s, v9.4s, v10.4s                : facge  %q9 %q10 $0x02 -> %q8
+6e2ced6a : facge v10.4s, v11.4s, v12.4s              : facge  %q11 %q12 $0x02 -> %q10
+6e2eedac : facge v12.4s, v13.4s, v14.4s              : facge  %q13 %q14 $0x02 -> %q12
+6e30edee : facge v14.4s, v15.4s, v16.4s              : facge  %q15 %q16 $0x02 -> %q14
+6e32ee30 : facge v16.4s, v17.4s, v18.4s              : facge  %q17 %q18 $0x02 -> %q16
+6e33ee51 : facge v17.4s, v18.4s, v19.4s              : facge  %q18 %q19 $0x02 -> %q17
+6e35ee93 : facge v19.4s, v20.4s, v21.4s              : facge  %q20 %q21 $0x02 -> %q19
+6e37eed5 : facge v21.4s, v22.4s, v23.4s              : facge  %q22 %q23 $0x02 -> %q21
+6e39ef17 : facge v23.4s, v24.4s, v25.4s              : facge  %q24 %q25 $0x02 -> %q23
+6e3bef59 : facge v25.4s, v26.4s, v27.4s              : facge  %q26 %q27 $0x02 -> %q25
+6e3def9b : facge v27.4s, v28.4s, v29.4s              : facge  %q28 %q29 $0x02 -> %q27
+6e21ec1f : facge v31.4s, v0.4s, v1.4s                : facge  %q0 %q1 $0x02 -> %q31
+6e62ec20 : facge v0.2d, v1.2d, v2.2d                 : facge  %q1 %q2 $0x03 -> %q0
+6e64ec62 : facge v2.2d, v3.2d, v4.2d                 : facge  %q3 %q4 $0x03 -> %q2
+6e66eca4 : facge v4.2d, v5.2d, v6.2d                 : facge  %q5 %q6 $0x03 -> %q4
+6e68ece6 : facge v6.2d, v7.2d, v8.2d                 : facge  %q7 %q8 $0x03 -> %q6
+6e6aed28 : facge v8.2d, v9.2d, v10.2d                : facge  %q9 %q10 $0x03 -> %q8
+6e6ced6a : facge v10.2d, v11.2d, v12.2d              : facge  %q11 %q12 $0x03 -> %q10
+6e6eedac : facge v12.2d, v13.2d, v14.2d              : facge  %q13 %q14 $0x03 -> %q12
+6e70edee : facge v14.2d, v15.2d, v16.2d              : facge  %q15 %q16 $0x03 -> %q14
+6e72ee30 : facge v16.2d, v17.2d, v18.2d              : facge  %q17 %q18 $0x03 -> %q16
+6e73ee51 : facge v17.2d, v18.2d, v19.2d              : facge  %q18 %q19 $0x03 -> %q17
+6e75ee93 : facge v19.2d, v20.2d, v21.2d              : facge  %q20 %q21 $0x03 -> %q19
+6e77eed5 : facge v21.2d, v22.2d, v23.2d              : facge  %q22 %q23 $0x03 -> %q21
+6e79ef17 : facge v23.2d, v24.2d, v25.2d              : facge  %q24 %q25 $0x03 -> %q23
+6e7bef59 : facge v25.2d, v26.2d, v27.2d              : facge  %q26 %q27 $0x03 -> %q25
+6e7def9b : facge v27.2d, v28.2d, v29.2d              : facge  %q28 %q29 $0x03 -> %q27
+6e61ec1f : facge v31.2d, v0.2d, v1.2d                : facge  %q0 %q1 $0x03 -> %q31
+
+# FCVTPU  <Dd>.<T>, <Dn>.<T> (FCVTPU-Q.Q-asimdmisc_R)
+2ea1a820 : fcvtpu v0.2s, v1.2s                       : fcvtpu %d1 $0x02 -> %d0
+2ea1a862 : fcvtpu v2.2s, v3.2s                       : fcvtpu %d3 $0x02 -> %d2
+2ea1a8a4 : fcvtpu v4.2s, v5.2s                       : fcvtpu %d5 $0x02 -> %d4
+2ea1a8e6 : fcvtpu v6.2s, v7.2s                       : fcvtpu %d7 $0x02 -> %d6
+2ea1a928 : fcvtpu v8.2s, v9.2s                       : fcvtpu %d9 $0x02 -> %d8
+2ea1a96a : fcvtpu v10.2s, v11.2s                     : fcvtpu %d11 $0x02 -> %d10
+2ea1a9ac : fcvtpu v12.2s, v13.2s                     : fcvtpu %d13 $0x02 -> %d12
+2ea1a9ee : fcvtpu v14.2s, v15.2s                     : fcvtpu %d15 $0x02 -> %d14
+2ea1aa30 : fcvtpu v16.2s, v17.2s                     : fcvtpu %d17 $0x02 -> %d16
+2ea1aa51 : fcvtpu v17.2s, v18.2s                     : fcvtpu %d18 $0x02 -> %d17
+2ea1aa93 : fcvtpu v19.2s, v20.2s                     : fcvtpu %d20 $0x02 -> %d19
+2ea1aad5 : fcvtpu v21.2s, v22.2s                     : fcvtpu %d22 $0x02 -> %d21
+2ea1ab17 : fcvtpu v23.2s, v24.2s                     : fcvtpu %d24 $0x02 -> %d23
+2ea1ab59 : fcvtpu v25.2s, v26.2s                     : fcvtpu %d26 $0x02 -> %d25
+2ea1ab9b : fcvtpu v27.2s, v28.2s                     : fcvtpu %d28 $0x02 -> %d27
+2ea1a81f : fcvtpu v31.2s, v0.2s                      : fcvtpu %d0 $0x02 -> %d31
+6ea1a820 : fcvtpu v0.4s, v1.4s                       : fcvtpu %q1 $0x02 -> %q0
+6ea1a862 : fcvtpu v2.4s, v3.4s                       : fcvtpu %q3 $0x02 -> %q2
+6ea1a8a4 : fcvtpu v4.4s, v5.4s                       : fcvtpu %q5 $0x02 -> %q4
+6ea1a8e6 : fcvtpu v6.4s, v7.4s                       : fcvtpu %q7 $0x02 -> %q6
+6ea1a928 : fcvtpu v8.4s, v9.4s                       : fcvtpu %q9 $0x02 -> %q8
+6ea1a96a : fcvtpu v10.4s, v11.4s                     : fcvtpu %q11 $0x02 -> %q10
+6ea1a9ac : fcvtpu v12.4s, v13.4s                     : fcvtpu %q13 $0x02 -> %q12
+6ea1a9ee : fcvtpu v14.4s, v15.4s                     : fcvtpu %q15 $0x02 -> %q14
+6ea1aa30 : fcvtpu v16.4s, v17.4s                     : fcvtpu %q17 $0x02 -> %q16
+6ea1aa51 : fcvtpu v17.4s, v18.4s                     : fcvtpu %q18 $0x02 -> %q17
+6ea1aa93 : fcvtpu v19.4s, v20.4s                     : fcvtpu %q20 $0x02 -> %q19
+6ea1aad5 : fcvtpu v21.4s, v22.4s                     : fcvtpu %q22 $0x02 -> %q21
+6ea1ab17 : fcvtpu v23.4s, v24.4s                     : fcvtpu %q24 $0x02 -> %q23
+6ea1ab59 : fcvtpu v25.4s, v26.4s                     : fcvtpu %q26 $0x02 -> %q25
+6ea1ab9b : fcvtpu v27.4s, v28.4s                     : fcvtpu %q28 $0x02 -> %q27
+6ea1a81f : fcvtpu v31.4s, v0.4s                      : fcvtpu %q0 $0x02 -> %q31
+6ee1a820 : fcvtpu v0.2d, v1.2d                       : fcvtpu %q1 $0x03 -> %q0
+6ee1a862 : fcvtpu v2.2d, v3.2d                       : fcvtpu %q3 $0x03 -> %q2
+6ee1a8a4 : fcvtpu v4.2d, v5.2d                       : fcvtpu %q5 $0x03 -> %q4
+6ee1a8e6 : fcvtpu v6.2d, v7.2d                       : fcvtpu %q7 $0x03 -> %q6
+6ee1a928 : fcvtpu v8.2d, v9.2d                       : fcvtpu %q9 $0x03 -> %q8
+6ee1a96a : fcvtpu v10.2d, v11.2d                     : fcvtpu %q11 $0x03 -> %q10
+6ee1a9ac : fcvtpu v12.2d, v13.2d                     : fcvtpu %q13 $0x03 -> %q12
+6ee1a9ee : fcvtpu v14.2d, v15.2d                     : fcvtpu %q15 $0x03 -> %q14
+6ee1aa30 : fcvtpu v16.2d, v17.2d                     : fcvtpu %q17 $0x03 -> %q16
+6ee1aa51 : fcvtpu v17.2d, v18.2d                     : fcvtpu %q18 $0x03 -> %q17
+6ee1aa93 : fcvtpu v19.2d, v20.2d                     : fcvtpu %q20 $0x03 -> %q19
+6ee1aad5 : fcvtpu v21.2d, v22.2d                     : fcvtpu %q22 $0x03 -> %q21
+6ee1ab17 : fcvtpu v23.2d, v24.2d                     : fcvtpu %q24 $0x03 -> %q23
+6ee1ab59 : fcvtpu v25.2d, v26.2d                     : fcvtpu %q26 $0x03 -> %q25
+6ee1ab9b : fcvtpu v27.2d, v28.2d                     : fcvtpu %q28 $0x03 -> %q27
+6ee1a81f : fcvtpu v31.2d, v0.2d                      : fcvtpu %q0 $0x03 -> %q31
+
+# FMINNM  <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMINNM-Q.QQ-asimdsame_only)
+0ea2c420 : fminnm v0.2s, v1.2s, v2.2s                : fminnm %d1 %d2 $0x02 -> %d0
+0ea4c462 : fminnm v2.2s, v3.2s, v4.2s                : fminnm %d3 %d4 $0x02 -> %d2
+0ea6c4a4 : fminnm v4.2s, v5.2s, v6.2s                : fminnm %d5 %d6 $0x02 -> %d4
+0ea8c4e6 : fminnm v6.2s, v7.2s, v8.2s                : fminnm %d7 %d8 $0x02 -> %d6
+0eaac528 : fminnm v8.2s, v9.2s, v10.2s               : fminnm %d9 %d10 $0x02 -> %d8
+0eacc56a : fminnm v10.2s, v11.2s, v12.2s             : fminnm %d11 %d12 $0x02 -> %d10
+0eaec5ac : fminnm v12.2s, v13.2s, v14.2s             : fminnm %d13 %d14 $0x02 -> %d12
+0eb0c5ee : fminnm v14.2s, v15.2s, v16.2s             : fminnm %d15 %d16 $0x02 -> %d14
+0eb2c630 : fminnm v16.2s, v17.2s, v18.2s             : fminnm %d17 %d18 $0x02 -> %d16
+0eb3c651 : fminnm v17.2s, v18.2s, v19.2s             : fminnm %d18 %d19 $0x02 -> %d17
+0eb5c693 : fminnm v19.2s, v20.2s, v21.2s             : fminnm %d20 %d21 $0x02 -> %d19
+0eb7c6d5 : fminnm v21.2s, v22.2s, v23.2s             : fminnm %d22 %d23 $0x02 -> %d21
+0eb9c717 : fminnm v23.2s, v24.2s, v25.2s             : fminnm %d24 %d25 $0x02 -> %d23
+0ebbc759 : fminnm v25.2s, v26.2s, v27.2s             : fminnm %d26 %d27 $0x02 -> %d25
+0ebdc79b : fminnm v27.2s, v28.2s, v29.2s             : fminnm %d28 %d29 $0x02 -> %d27
+0ea1c41f : fminnm v31.2s, v0.2s, v1.2s               : fminnm %d0 %d1 $0x02 -> %d31
+4ea2c420 : fminnm v0.4s, v1.4s, v2.4s                : fminnm %q1 %q2 $0x02 -> %q0
+4ea4c462 : fminnm v2.4s, v3.4s, v4.4s                : fminnm %q3 %q4 $0x02 -> %q2
+4ea6c4a4 : fminnm v4.4s, v5.4s, v6.4s                : fminnm %q5 %q6 $0x02 -> %q4
+4ea8c4e6 : fminnm v6.4s, v7.4s, v8.4s                : fminnm %q7 %q8 $0x02 -> %q6
+4eaac528 : fminnm v8.4s, v9.4s, v10.4s               : fminnm %q9 %q10 $0x02 -> %q8
+4eacc56a : fminnm v10.4s, v11.4s, v12.4s             : fminnm %q11 %q12 $0x02 -> %q10
+4eaec5ac : fminnm v12.4s, v13.4s, v14.4s             : fminnm %q13 %q14 $0x02 -> %q12
+4eb0c5ee : fminnm v14.4s, v15.4s, v16.4s             : fminnm %q15 %q16 $0x02 -> %q14
+4eb2c630 : fminnm v16.4s, v17.4s, v18.4s             : fminnm %q17 %q18 $0x02 -> %q16
+4eb3c651 : fminnm v17.4s, v18.4s, v19.4s             : fminnm %q18 %q19 $0x02 -> %q17
+4eb5c693 : fminnm v19.4s, v20.4s, v21.4s             : fminnm %q20 %q21 $0x02 -> %q19
+4eb7c6d5 : fminnm v21.4s, v22.4s, v23.4s             : fminnm %q22 %q23 $0x02 -> %q21
+4eb9c717 : fminnm v23.4s, v24.4s, v25.4s             : fminnm %q24 %q25 $0x02 -> %q23
+4ebbc759 : fminnm v25.4s, v26.4s, v27.4s             : fminnm %q26 %q27 $0x02 -> %q25
+4ebdc79b : fminnm v27.4s, v28.4s, v29.4s             : fminnm %q28 %q29 $0x02 -> %q27
+4ea1c41f : fminnm v31.4s, v0.4s, v1.4s               : fminnm %q0 %q1 $0x02 -> %q31
+4ee2c420 : fminnm v0.2d, v1.2d, v2.2d                : fminnm %q1 %q2 $0x03 -> %q0
+4ee4c462 : fminnm v2.2d, v3.2d, v4.2d                : fminnm %q3 %q4 $0x03 -> %q2
+4ee6c4a4 : fminnm v4.2d, v5.2d, v6.2d                : fminnm %q5 %q6 $0x03 -> %q4
+4ee8c4e6 : fminnm v6.2d, v7.2d, v8.2d                : fminnm %q7 %q8 $0x03 -> %q6
+4eeac528 : fminnm v8.2d, v9.2d, v10.2d               : fminnm %q9 %q10 $0x03 -> %q8
+4eecc56a : fminnm v10.2d, v11.2d, v12.2d             : fminnm %q11 %q12 $0x03 -> %q10
+4eeec5ac : fminnm v12.2d, v13.2d, v14.2d             : fminnm %q13 %q14 $0x03 -> %q12
+4ef0c5ee : fminnm v14.2d, v15.2d, v16.2d             : fminnm %q15 %q16 $0x03 -> %q14
+4ef2c630 : fminnm v16.2d, v17.2d, v18.2d             : fminnm %q17 %q18 $0x03 -> %q16
+4ef3c651 : fminnm v17.2d, v18.2d, v19.2d             : fminnm %q18 %q19 $0x03 -> %q17
+4ef5c693 : fminnm v19.2d, v20.2d, v21.2d             : fminnm %q20 %q21 $0x03 -> %q19
+4ef7c6d5 : fminnm v21.2d, v22.2d, v23.2d             : fminnm %q22 %q23 $0x03 -> %q21
+4ef9c717 : fminnm v23.2d, v24.2d, v25.2d             : fminnm %q24 %q25 $0x03 -> %q23
+4efbc759 : fminnm v25.2d, v26.2d, v27.2d             : fminnm %q26 %q27 $0x03 -> %q25
+4efdc79b : fminnm v27.2d, v28.2d, v29.2d             : fminnm %q28 %q29 $0x03 -> %q27
+4ee1c41f : fminnm v31.2d, v0.2d, v1.2d               : fminnm %q0 %q1 $0x03 -> %q31
+
+# FRINTM  <Dd>.<T>, <Dn>.<T> (FRINTM-Q.Q-asimdmisc_R)
+0e219820 : frintm v0.2s, v1.2s                       : frintm %d1 $0x02 -> %d0
+0e219862 : frintm v2.2s, v3.2s                       : frintm %d3 $0x02 -> %d2
+0e2198a4 : frintm v4.2s, v5.2s                       : frintm %d5 $0x02 -> %d4
+0e2198e6 : frintm v6.2s, v7.2s                       : frintm %d7 $0x02 -> %d6
+0e219928 : frintm v8.2s, v9.2s                       : frintm %d9 $0x02 -> %d8
+0e21996a : frintm v10.2s, v11.2s                     : frintm %d11 $0x02 -> %d10
+0e2199ac : frintm v12.2s, v13.2s                     : frintm %d13 $0x02 -> %d12
+0e2199ee : frintm v14.2s, v15.2s                     : frintm %d15 $0x02 -> %d14
+0e219a30 : frintm v16.2s, v17.2s                     : frintm %d17 $0x02 -> %d16
+0e219a51 : frintm v17.2s, v18.2s                     : frintm %d18 $0x02 -> %d17
+0e219a93 : frintm v19.2s, v20.2s                     : frintm %d20 $0x02 -> %d19
+0e219ad5 : frintm v21.2s, v22.2s                     : frintm %d22 $0x02 -> %d21
+0e219b17 : frintm v23.2s, v24.2s                     : frintm %d24 $0x02 -> %d23
+0e219b59 : frintm v25.2s, v26.2s                     : frintm %d26 $0x02 -> %d25
+0e219b9b : frintm v27.2s, v28.2s                     : frintm %d28 $0x02 -> %d27
+0e21981f : frintm v31.2s, v0.2s                      : frintm %d0 $0x02 -> %d31
+4e219820 : frintm v0.4s, v1.4s                       : frintm %q1 $0x02 -> %q0
+4e219862 : frintm v2.4s, v3.4s                       : frintm %q3 $0x02 -> %q2
+4e2198a4 : frintm v4.4s, v5.4s                       : frintm %q5 $0x02 -> %q4
+4e2198e6 : frintm v6.4s, v7.4s                       : frintm %q7 $0x02 -> %q6
+4e219928 : frintm v8.4s, v9.4s                       : frintm %q9 $0x02 -> %q8
+4e21996a : frintm v10.4s, v11.4s                     : frintm %q11 $0x02 -> %q10
+4e2199ac : frintm v12.4s, v13.4s                     : frintm %q13 $0x02 -> %q12
+4e2199ee : frintm v14.4s, v15.4s                     : frintm %q15 $0x02 -> %q14
+4e219a30 : frintm v16.4s, v17.4s                     : frintm %q17 $0x02 -> %q16
+4e219a51 : frintm v17.4s, v18.4s                     : frintm %q18 $0x02 -> %q17
+4e219a93 : frintm v19.4s, v20.4s                     : frintm %q20 $0x02 -> %q19
+4e219ad5 : frintm v21.4s, v22.4s                     : frintm %q22 $0x02 -> %q21
+4e219b17 : frintm v23.4s, v24.4s                     : frintm %q24 $0x02 -> %q23
+4e219b59 : frintm v25.4s, v26.4s                     : frintm %q26 $0x02 -> %q25
+4e219b9b : frintm v27.4s, v28.4s                     : frintm %q28 $0x02 -> %q27
+4e21981f : frintm v31.4s, v0.4s                      : frintm %q0 $0x02 -> %q31
+4e619820 : frintm v0.2d, v1.2d                       : frintm %q1 $0x03 -> %q0
+4e619862 : frintm v2.2d, v3.2d                       : frintm %q3 $0x03 -> %q2
+4e6198a4 : frintm v4.2d, v5.2d                       : frintm %q5 $0x03 -> %q4
+4e6198e6 : frintm v6.2d, v7.2d                       : frintm %q7 $0x03 -> %q6
+4e619928 : frintm v8.2d, v9.2d                       : frintm %q9 $0x03 -> %q8
+4e61996a : frintm v10.2d, v11.2d                     : frintm %q11 $0x03 -> %q10
+4e6199ac : frintm v12.2d, v13.2d                     : frintm %q13 $0x03 -> %q12
+4e6199ee : frintm v14.2d, v15.2d                     : frintm %q15 $0x03 -> %q14
+4e619a30 : frintm v16.2d, v17.2d                     : frintm %q17 $0x03 -> %q16
+4e619a51 : frintm v17.2d, v18.2d                     : frintm %q18 $0x03 -> %q17
+4e619a93 : frintm v19.2d, v20.2d                     : frintm %q20 $0x03 -> %q19
+4e619ad5 : frintm v21.2d, v22.2d                     : frintm %q22 $0x03 -> %q21
+4e619b17 : frintm v23.2d, v24.2d                     : frintm %q24 $0x03 -> %q23
+4e619b59 : frintm v25.2d, v26.2d                     : frintm %q26 $0x03 -> %q25
+4e619b9b : frintm v27.2d, v28.2d                     : frintm %q28 $0x03 -> %q27
+4e61981f : frintm v31.2d, v0.2d                      : frintm %q0 $0x03 -> %q31
+
+# FCMGT   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FCMGT-Q.QQ-asimdsame_only)
+2ea2e420 : fcmgt v0.2s, v1.2s, v2.2s                 : fcmgt  %d1 %d2 $0x02 -> %d0
+2ea4e462 : fcmgt v2.2s, v3.2s, v4.2s                 : fcmgt  %d3 %d4 $0x02 -> %d2
+2ea6e4a4 : fcmgt v4.2s, v5.2s, v6.2s                 : fcmgt  %d5 %d6 $0x02 -> %d4
+2ea8e4e6 : fcmgt v6.2s, v7.2s, v8.2s                 : fcmgt  %d7 %d8 $0x02 -> %d6
+2eaae528 : fcmgt v8.2s, v9.2s, v10.2s                : fcmgt  %d9 %d10 $0x02 -> %d8
+2eace56a : fcmgt v10.2s, v11.2s, v12.2s              : fcmgt  %d11 %d12 $0x02 -> %d10
+2eaee5ac : fcmgt v12.2s, v13.2s, v14.2s              : fcmgt  %d13 %d14 $0x02 -> %d12
+2eb0e5ee : fcmgt v14.2s, v15.2s, v16.2s              : fcmgt  %d15 %d16 $0x02 -> %d14
+2eb2e630 : fcmgt v16.2s, v17.2s, v18.2s              : fcmgt  %d17 %d18 $0x02 -> %d16
+2eb3e651 : fcmgt v17.2s, v18.2s, v19.2s              : fcmgt  %d18 %d19 $0x02 -> %d17
+2eb5e693 : fcmgt v19.2s, v20.2s, v21.2s              : fcmgt  %d20 %d21 $0x02 -> %d19
+2eb7e6d5 : fcmgt v21.2s, v22.2s, v23.2s              : fcmgt  %d22 %d23 $0x02 -> %d21
+2eb9e717 : fcmgt v23.2s, v24.2s, v25.2s              : fcmgt  %d24 %d25 $0x02 -> %d23
+2ebbe759 : fcmgt v25.2s, v26.2s, v27.2s              : fcmgt  %d26 %d27 $0x02 -> %d25
+2ebde79b : fcmgt v27.2s, v28.2s, v29.2s              : fcmgt  %d28 %d29 $0x02 -> %d27
+2ea1e41f : fcmgt v31.2s, v0.2s, v1.2s                : fcmgt  %d0 %d1 $0x02 -> %d31
+6ea2e420 : fcmgt v0.4s, v1.4s, v2.4s                 : fcmgt  %q1 %q2 $0x02 -> %q0
+6ea4e462 : fcmgt v2.4s, v3.4s, v4.4s                 : fcmgt  %q3 %q4 $0x02 -> %q2
+6ea6e4a4 : fcmgt v4.4s, v5.4s, v6.4s                 : fcmgt  %q5 %q6 $0x02 -> %q4
+6ea8e4e6 : fcmgt v6.4s, v7.4s, v8.4s                 : fcmgt  %q7 %q8 $0x02 -> %q6
+6eaae528 : fcmgt v8.4s, v9.4s, v10.4s                : fcmgt  %q9 %q10 $0x02 -> %q8
+6eace56a : fcmgt v10.4s, v11.4s, v12.4s              : fcmgt  %q11 %q12 $0x02 -> %q10
+6eaee5ac : fcmgt v12.4s, v13.4s, v14.4s              : fcmgt  %q13 %q14 $0x02 -> %q12
+6eb0e5ee : fcmgt v14.4s, v15.4s, v16.4s              : fcmgt  %q15 %q16 $0x02 -> %q14
+6eb2e630 : fcmgt v16.4s, v17.4s, v18.4s              : fcmgt  %q17 %q18 $0x02 -> %q16
+6eb3e651 : fcmgt v17.4s, v18.4s, v19.4s              : fcmgt  %q18 %q19 $0x02 -> %q17
+6eb5e693 : fcmgt v19.4s, v20.4s, v21.4s              : fcmgt  %q20 %q21 $0x02 -> %q19
+6eb7e6d5 : fcmgt v21.4s, v22.4s, v23.4s              : fcmgt  %q22 %q23 $0x02 -> %q21
+6eb9e717 : fcmgt v23.4s, v24.4s, v25.4s              : fcmgt  %q24 %q25 $0x02 -> %q23
+6ebbe759 : fcmgt v25.4s, v26.4s, v27.4s              : fcmgt  %q26 %q27 $0x02 -> %q25
+6ebde79b : fcmgt v27.4s, v28.4s, v29.4s              : fcmgt  %q28 %q29 $0x02 -> %q27
+6ea1e41f : fcmgt v31.4s, v0.4s, v1.4s                : fcmgt  %q0 %q1 $0x02 -> %q31
+6ee2e420 : fcmgt v0.2d, v1.2d, v2.2d                 : fcmgt  %q1 %q2 $0x03 -> %q0
+6ee4e462 : fcmgt v2.2d, v3.2d, v4.2d                 : fcmgt  %q3 %q4 $0x03 -> %q2
+6ee6e4a4 : fcmgt v4.2d, v5.2d, v6.2d                 : fcmgt  %q5 %q6 $0x03 -> %q4
+6ee8e4e6 : fcmgt v6.2d, v7.2d, v8.2d                 : fcmgt  %q7 %q8 $0x03 -> %q6
+6eeae528 : fcmgt v8.2d, v9.2d, v10.2d                : fcmgt  %q9 %q10 $0x03 -> %q8
+6eece56a : fcmgt v10.2d, v11.2d, v12.2d              : fcmgt  %q11 %q12 $0x03 -> %q10
+6eeee5ac : fcmgt v12.2d, v13.2d, v14.2d              : fcmgt  %q13 %q14 $0x03 -> %q12
+6ef0e5ee : fcmgt v14.2d, v15.2d, v16.2d              : fcmgt  %q15 %q16 $0x03 -> %q14
+6ef2e630 : fcmgt v16.2d, v17.2d, v18.2d              : fcmgt  %q17 %q18 $0x03 -> %q16
+6ef3e651 : fcmgt v17.2d, v18.2d, v19.2d              : fcmgt  %q18 %q19 $0x03 -> %q17
+6ef5e693 : fcmgt v19.2d, v20.2d, v21.2d              : fcmgt  %q20 %q21 $0x03 -> %q19
+6ef7e6d5 : fcmgt v21.2d, v22.2d, v23.2d              : fcmgt  %q22 %q23 $0x03 -> %q21
+6ef9e717 : fcmgt v23.2d, v24.2d, v25.2d              : fcmgt  %q24 %q25 $0x03 -> %q23
+6efbe759 : fcmgt v25.2d, v26.2d, v27.2d              : fcmgt  %q26 %q27 $0x03 -> %q25
+6efde79b : fcmgt v27.2d, v28.2d, v29.2d              : fcmgt  %q28 %q29 $0x03 -> %q27
+6ee1e41f : fcmgt v31.2d, v0.2d, v1.2d                : fcmgt  %q0 %q1 $0x03 -> %q31
+
+# FMAXP   <V><d>, <Sn>.<T> (FMAXP-V.Q-asisdpair_only)
+7e30f820 : fmaxp s0, v1.2s                           : fmaxp  %d1 $0x02 -> %s0
+7e30f862 : fmaxp s2, v3.2s                           : fmaxp  %d3 $0x02 -> %s2
+7e30f8a4 : fmaxp s4, v5.2s                           : fmaxp  %d5 $0x02 -> %s4
+7e30f8e6 : fmaxp s6, v7.2s                           : fmaxp  %d7 $0x02 -> %s6
+7e30f928 : fmaxp s8, v9.2s                           : fmaxp  %d9 $0x02 -> %s8
+7e30f96a : fmaxp s10, v11.2s                         : fmaxp  %d11 $0x02 -> %s10
+7e30f9ac : fmaxp s12, v13.2s                         : fmaxp  %d13 $0x02 -> %s12
+7e30f9ee : fmaxp s14, v15.2s                         : fmaxp  %d15 $0x02 -> %s14
+7e30fa30 : fmaxp s16, v17.2s                         : fmaxp  %d17 $0x02 -> %s16
+7e30fa51 : fmaxp s17, v18.2s                         : fmaxp  %d18 $0x02 -> %s17
+7e30fa93 : fmaxp s19, v20.2s                         : fmaxp  %d20 $0x02 -> %s19
+7e30fad5 : fmaxp s21, v22.2s                         : fmaxp  %d22 $0x02 -> %s21
+7e30fb17 : fmaxp s23, v24.2s                         : fmaxp  %d24 $0x02 -> %s23
+7e30fb59 : fmaxp s25, v26.2s                         : fmaxp  %d26 $0x02 -> %s25
+7e30fb9b : fmaxp s27, v28.2s                         : fmaxp  %d28 $0x02 -> %s27
+7e30f81f : fmaxp s31, v0.2s                          : fmaxp  %d0 $0x02 -> %s31
+7e70f820 : fmaxp d0, v1.2d                           : fmaxp  %q1 $0x03 -> %d0
+7e70f862 : fmaxp d2, v3.2d                           : fmaxp  %q3 $0x03 -> %d2
+7e70f8a4 : fmaxp d4, v5.2d                           : fmaxp  %q5 $0x03 -> %d4
+7e70f8e6 : fmaxp d6, v7.2d                           : fmaxp  %q7 $0x03 -> %d6
+7e70f928 : fmaxp d8, v9.2d                           : fmaxp  %q9 $0x03 -> %d8
+7e70f96a : fmaxp d10, v11.2d                         : fmaxp  %q11 $0x03 -> %d10
+7e70f9ac : fmaxp d12, v13.2d                         : fmaxp  %q13 $0x03 -> %d12
+7e70f9ee : fmaxp d14, v15.2d                         : fmaxp  %q15 $0x03 -> %d14
+7e70fa30 : fmaxp d16, v17.2d                         : fmaxp  %q17 $0x03 -> %d16
+7e70fa51 : fmaxp d17, v18.2d                         : fmaxp  %q18 $0x03 -> %d17
+7e70fa93 : fmaxp d19, v20.2d                         : fmaxp  %q20 $0x03 -> %d19
+7e70fad5 : fmaxp d21, v22.2d                         : fmaxp  %q22 $0x03 -> %d21
+7e70fb17 : fmaxp d23, v24.2d                         : fmaxp  %q24 $0x03 -> %d23
+7e70fb59 : fmaxp d25, v26.2d                         : fmaxp  %q26 $0x03 -> %d25
+7e70fb9b : fmaxp d27, v28.2d                         : fmaxp  %q28 $0x03 -> %d27
+7e70f81f : fmaxp d31, v0.2d                          : fmaxp  %q0 $0x03 -> %d31
+
+# FSUB    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FSUB-Q.QQ-asimdsame_only)
+0ea2d420 : fsub v0.2s, v1.2s, v2.2s                  : fsub   %d1 %d2 $0x02 -> %d0
+0ea4d462 : fsub v2.2s, v3.2s, v4.2s                  : fsub   %d3 %d4 $0x02 -> %d2
+0ea6d4a4 : fsub v4.2s, v5.2s, v6.2s                  : fsub   %d5 %d6 $0x02 -> %d4
+0ea8d4e6 : fsub v6.2s, v7.2s, v8.2s                  : fsub   %d7 %d8 $0x02 -> %d6
+0eaad528 : fsub v8.2s, v9.2s, v10.2s                 : fsub   %d9 %d10 $0x02 -> %d8
+0eacd56a : fsub v10.2s, v11.2s, v12.2s               : fsub   %d11 %d12 $0x02 -> %d10
+0eaed5ac : fsub v12.2s, v13.2s, v14.2s               : fsub   %d13 %d14 $0x02 -> %d12
+0eb0d5ee : fsub v14.2s, v15.2s, v16.2s               : fsub   %d15 %d16 $0x02 -> %d14
+0eb2d630 : fsub v16.2s, v17.2s, v18.2s               : fsub   %d17 %d18 $0x02 -> %d16
+0eb3d651 : fsub v17.2s, v18.2s, v19.2s               : fsub   %d18 %d19 $0x02 -> %d17
+0eb5d693 : fsub v19.2s, v20.2s, v21.2s               : fsub   %d20 %d21 $0x02 -> %d19
+0eb7d6d5 : fsub v21.2s, v22.2s, v23.2s               : fsub   %d22 %d23 $0x02 -> %d21
+0eb9d717 : fsub v23.2s, v24.2s, v25.2s               : fsub   %d24 %d25 $0x02 -> %d23
+0ebbd759 : fsub v25.2s, v26.2s, v27.2s               : fsub   %d26 %d27 $0x02 -> %d25
+0ebdd79b : fsub v27.2s, v28.2s, v29.2s               : fsub   %d28 %d29 $0x02 -> %d27
+0ea1d41f : fsub v31.2s, v0.2s, v1.2s                 : fsub   %d0 %d1 $0x02 -> %d31
+4ea2d420 : fsub v0.4s, v1.4s, v2.4s                  : fsub   %q1 %q2 $0x02 -> %q0
+4ea4d462 : fsub v2.4s, v3.4s, v4.4s                  : fsub   %q3 %q4 $0x02 -> %q2
+4ea6d4a4 : fsub v4.4s, v5.4s, v6.4s                  : fsub   %q5 %q6 $0x02 -> %q4
+4ea8d4e6 : fsub v6.4s, v7.4s, v8.4s                  : fsub   %q7 %q8 $0x02 -> %q6
+4eaad528 : fsub v8.4s, v9.4s, v10.4s                 : fsub   %q9 %q10 $0x02 -> %q8
+4eacd56a : fsub v10.4s, v11.4s, v12.4s               : fsub   %q11 %q12 $0x02 -> %q10
+4eaed5ac : fsub v12.4s, v13.4s, v14.4s               : fsub   %q13 %q14 $0x02 -> %q12
+4eb0d5ee : fsub v14.4s, v15.4s, v16.4s               : fsub   %q15 %q16 $0x02 -> %q14
+4eb2d630 : fsub v16.4s, v17.4s, v18.4s               : fsub   %q17 %q18 $0x02 -> %q16
+4eb3d651 : fsub v17.4s, v18.4s, v19.4s               : fsub   %q18 %q19 $0x02 -> %q17
+4eb5d693 : fsub v19.4s, v20.4s, v21.4s               : fsub   %q20 %q21 $0x02 -> %q19
+4eb7d6d5 : fsub v21.4s, v22.4s, v23.4s               : fsub   %q22 %q23 $0x02 -> %q21
+4eb9d717 : fsub v23.4s, v24.4s, v25.4s               : fsub   %q24 %q25 $0x02 -> %q23
+4ebbd759 : fsub v25.4s, v26.4s, v27.4s               : fsub   %q26 %q27 $0x02 -> %q25
+4ebdd79b : fsub v27.4s, v28.4s, v29.4s               : fsub   %q28 %q29 $0x02 -> %q27
+4ea1d41f : fsub v31.4s, v0.4s, v1.4s                 : fsub   %q0 %q1 $0x02 -> %q31
+4ee2d420 : fsub v0.2d, v1.2d, v2.2d                  : fsub   %q1 %q2 $0x03 -> %q0
+4ee4d462 : fsub v2.2d, v3.2d, v4.2d                  : fsub   %q3 %q4 $0x03 -> %q2
+4ee6d4a4 : fsub v4.2d, v5.2d, v6.2d                  : fsub   %q5 %q6 $0x03 -> %q4
+4ee8d4e6 : fsub v6.2d, v7.2d, v8.2d                  : fsub   %q7 %q8 $0x03 -> %q6
+4eead528 : fsub v8.2d, v9.2d, v10.2d                 : fsub   %q9 %q10 $0x03 -> %q8
+4eecd56a : fsub v10.2d, v11.2d, v12.2d               : fsub   %q11 %q12 $0x03 -> %q10
+4eeed5ac : fsub v12.2d, v13.2d, v14.2d               : fsub   %q13 %q14 $0x03 -> %q12
+4ef0d5ee : fsub v14.2d, v15.2d, v16.2d               : fsub   %q15 %q16 $0x03 -> %q14
+4ef2d630 : fsub v16.2d, v17.2d, v18.2d               : fsub   %q17 %q18 $0x03 -> %q16
+4ef3d651 : fsub v17.2d, v18.2d, v19.2d               : fsub   %q18 %q19 $0x03 -> %q17
+4ef5d693 : fsub v19.2d, v20.2d, v21.2d               : fsub   %q20 %q21 $0x03 -> %q19
+4ef7d6d5 : fsub v21.2d, v22.2d, v23.2d               : fsub   %q22 %q23 $0x03 -> %q21
+4ef9d717 : fsub v23.2d, v24.2d, v25.2d               : fsub   %q24 %q25 $0x03 -> %q23
+4efbd759 : fsub v25.2d, v26.2d, v27.2d               : fsub   %q26 %q27 $0x03 -> %q25
+4efdd79b : fsub v27.2d, v28.2d, v29.2d               : fsub   %q28 %q29 $0x03 -> %q27
+4ee1d41f : fsub v31.2d, v0.2d, v1.2d                 : fsub   %q0 %q1 $0x03 -> %q31
+
+# FACGT   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FACGT-Q.QQ-asimdsame_only)
+2ea2ec20 : facgt v0.2s, v1.2s, v2.2s                 : facgt  %d1 %d2 $0x02 -> %d0
+2ea4ec62 : facgt v2.2s, v3.2s, v4.2s                 : facgt  %d3 %d4 $0x02 -> %d2
+2ea6eca4 : facgt v4.2s, v5.2s, v6.2s                 : facgt  %d5 %d6 $0x02 -> %d4
+2ea8ece6 : facgt v6.2s, v7.2s, v8.2s                 : facgt  %d7 %d8 $0x02 -> %d6
+2eaaed28 : facgt v8.2s, v9.2s, v10.2s                : facgt  %d9 %d10 $0x02 -> %d8
+2eaced6a : facgt v10.2s, v11.2s, v12.2s              : facgt  %d11 %d12 $0x02 -> %d10
+2eaeedac : facgt v12.2s, v13.2s, v14.2s              : facgt  %d13 %d14 $0x02 -> %d12
+2eb0edee : facgt v14.2s, v15.2s, v16.2s              : facgt  %d15 %d16 $0x02 -> %d14
+2eb2ee30 : facgt v16.2s, v17.2s, v18.2s              : facgt  %d17 %d18 $0x02 -> %d16
+2eb3ee51 : facgt v17.2s, v18.2s, v19.2s              : facgt  %d18 %d19 $0x02 -> %d17
+2eb5ee93 : facgt v19.2s, v20.2s, v21.2s              : facgt  %d20 %d21 $0x02 -> %d19
+2eb7eed5 : facgt v21.2s, v22.2s, v23.2s              : facgt  %d22 %d23 $0x02 -> %d21
+2eb9ef17 : facgt v23.2s, v24.2s, v25.2s              : facgt  %d24 %d25 $0x02 -> %d23
+2ebbef59 : facgt v25.2s, v26.2s, v27.2s              : facgt  %d26 %d27 $0x02 -> %d25
+2ebdef9b : facgt v27.2s, v28.2s, v29.2s              : facgt  %d28 %d29 $0x02 -> %d27
+2ea1ec1f : facgt v31.2s, v0.2s, v1.2s                : facgt  %d0 %d1 $0x02 -> %d31
+6ea2ec20 : facgt v0.4s, v1.4s, v2.4s                 : facgt  %q1 %q2 $0x02 -> %q0
+6ea4ec62 : facgt v2.4s, v3.4s, v4.4s                 : facgt  %q3 %q4 $0x02 -> %q2
+6ea6eca4 : facgt v4.4s, v5.4s, v6.4s                 : facgt  %q5 %q6 $0x02 -> %q4
+6ea8ece6 : facgt v6.4s, v7.4s, v8.4s                 : facgt  %q7 %q8 $0x02 -> %q6
+6eaaed28 : facgt v8.4s, v9.4s, v10.4s                : facgt  %q9 %q10 $0x02 -> %q8
+6eaced6a : facgt v10.4s, v11.4s, v12.4s              : facgt  %q11 %q12 $0x02 -> %q10
+6eaeedac : facgt v12.4s, v13.4s, v14.4s              : facgt  %q13 %q14 $0x02 -> %q12
+6eb0edee : facgt v14.4s, v15.4s, v16.4s              : facgt  %q15 %q16 $0x02 -> %q14
+6eb2ee30 : facgt v16.4s, v17.4s, v18.4s              : facgt  %q17 %q18 $0x02 -> %q16
+6eb3ee51 : facgt v17.4s, v18.4s, v19.4s              : facgt  %q18 %q19 $0x02 -> %q17
+6eb5ee93 : facgt v19.4s, v20.4s, v21.4s              : facgt  %q20 %q21 $0x02 -> %q19
+6eb7eed5 : facgt v21.4s, v22.4s, v23.4s              : facgt  %q22 %q23 $0x02 -> %q21
+6eb9ef17 : facgt v23.4s, v24.4s, v25.4s              : facgt  %q24 %q25 $0x02 -> %q23
+6ebbef59 : facgt v25.4s, v26.4s, v27.4s              : facgt  %q26 %q27 $0x02 -> %q25
+6ebdef9b : facgt v27.4s, v28.4s, v29.4s              : facgt  %q28 %q29 $0x02 -> %q27
+6ea1ec1f : facgt v31.4s, v0.4s, v1.4s                : facgt  %q0 %q1 $0x02 -> %q31
+6ee2ec20 : facgt v0.2d, v1.2d, v2.2d                 : facgt  %q1 %q2 $0x03 -> %q0
+6ee4ec62 : facgt v2.2d, v3.2d, v4.2d                 : facgt  %q3 %q4 $0x03 -> %q2
+6ee6eca4 : facgt v4.2d, v5.2d, v6.2d                 : facgt  %q5 %q6 $0x03 -> %q4
+6ee8ece6 : facgt v6.2d, v7.2d, v8.2d                 : facgt  %q7 %q8 $0x03 -> %q6
+6eeaed28 : facgt v8.2d, v9.2d, v10.2d                : facgt  %q9 %q10 $0x03 -> %q8
+6eeced6a : facgt v10.2d, v11.2d, v12.2d              : facgt  %q11 %q12 $0x03 -> %q10
+6eeeedac : facgt v12.2d, v13.2d, v14.2d              : facgt  %q13 %q14 $0x03 -> %q12
+6ef0edee : facgt v14.2d, v15.2d, v16.2d              : facgt  %q15 %q16 $0x03 -> %q14
+6ef2ee30 : facgt v16.2d, v17.2d, v18.2d              : facgt  %q17 %q18 $0x03 -> %q16
+6ef3ee51 : facgt v17.2d, v18.2d, v19.2d              : facgt  %q18 %q19 $0x03 -> %q17
+6ef5ee93 : facgt v19.2d, v20.2d, v21.2d              : facgt  %q20 %q21 $0x03 -> %q19
+6ef7eed5 : facgt v21.2d, v22.2d, v23.2d              : facgt  %q22 %q23 $0x03 -> %q21
+6ef9ef17 : facgt v23.2d, v24.2d, v25.2d              : facgt  %q24 %q25 $0x03 -> %q23
+6efbef59 : facgt v25.2d, v26.2d, v27.2d              : facgt  %q26 %q27 $0x03 -> %q25
+6efdef9b : facgt v27.2d, v28.2d, v29.2d              : facgt  %q28 %q29 $0x03 -> %q27
+6ee1ec1f : facgt v31.2d, v0.2d, v1.2d                : facgt  %q0 %q1 $0x03 -> %q31
 
 # FCMLE   <V><d>, <V><n>, #0 (FCMLE-V.V-asisdmisc_FZ)
 7ea0d820 : fcmle s0, s1, #0                          : fcmle  %s1 $0.000000 -> %s0
@@ -28977,6 +30141,56 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 7ee0cb9b : fcmge d27, d28, #0                        : fcmge  %d28 $0.000000 -> %d27
 7ee0c81f : fcmge d31, d0, #0                         : fcmge  %d0 $0.000000 -> %d31
 
+# UCVTF   <Dd>.<T>, <Dn>.<T> (UCVTF-Q.Q-asimdmisc_R)
+2e21d820 : ucvtf v0.2s, v1.2s                        : ucvtf  %d1 $0x02 -> %d0
+2e21d862 : ucvtf v2.2s, v3.2s                        : ucvtf  %d3 $0x02 -> %d2
+2e21d8a4 : ucvtf v4.2s, v5.2s                        : ucvtf  %d5 $0x02 -> %d4
+2e21d8e6 : ucvtf v6.2s, v7.2s                        : ucvtf  %d7 $0x02 -> %d6
+2e21d928 : ucvtf v8.2s, v9.2s                        : ucvtf  %d9 $0x02 -> %d8
+2e21d96a : ucvtf v10.2s, v11.2s                      : ucvtf  %d11 $0x02 -> %d10
+2e21d9ac : ucvtf v12.2s, v13.2s                      : ucvtf  %d13 $0x02 -> %d12
+2e21d9ee : ucvtf v14.2s, v15.2s                      : ucvtf  %d15 $0x02 -> %d14
+2e21da30 : ucvtf v16.2s, v17.2s                      : ucvtf  %d17 $0x02 -> %d16
+2e21da51 : ucvtf v17.2s, v18.2s                      : ucvtf  %d18 $0x02 -> %d17
+2e21da93 : ucvtf v19.2s, v20.2s                      : ucvtf  %d20 $0x02 -> %d19
+2e21dad5 : ucvtf v21.2s, v22.2s                      : ucvtf  %d22 $0x02 -> %d21
+2e21db17 : ucvtf v23.2s, v24.2s                      : ucvtf  %d24 $0x02 -> %d23
+2e21db59 : ucvtf v25.2s, v26.2s                      : ucvtf  %d26 $0x02 -> %d25
+2e21db9b : ucvtf v27.2s, v28.2s                      : ucvtf  %d28 $0x02 -> %d27
+2e21d81f : ucvtf v31.2s, v0.2s                       : ucvtf  %d0 $0x02 -> %d31
+6e21d820 : ucvtf v0.4s, v1.4s                        : ucvtf  %q1 $0x02 -> %q0
+6e21d862 : ucvtf v2.4s, v3.4s                        : ucvtf  %q3 $0x02 -> %q2
+6e21d8a4 : ucvtf v4.4s, v5.4s                        : ucvtf  %q5 $0x02 -> %q4
+6e21d8e6 : ucvtf v6.4s, v7.4s                        : ucvtf  %q7 $0x02 -> %q6
+6e21d928 : ucvtf v8.4s, v9.4s                        : ucvtf  %q9 $0x02 -> %q8
+6e21d96a : ucvtf v10.4s, v11.4s                      : ucvtf  %q11 $0x02 -> %q10
+6e21d9ac : ucvtf v12.4s, v13.4s                      : ucvtf  %q13 $0x02 -> %q12
+6e21d9ee : ucvtf v14.4s, v15.4s                      : ucvtf  %q15 $0x02 -> %q14
+6e21da30 : ucvtf v16.4s, v17.4s                      : ucvtf  %q17 $0x02 -> %q16
+6e21da51 : ucvtf v17.4s, v18.4s                      : ucvtf  %q18 $0x02 -> %q17
+6e21da93 : ucvtf v19.4s, v20.4s                      : ucvtf  %q20 $0x02 -> %q19
+6e21dad5 : ucvtf v21.4s, v22.4s                      : ucvtf  %q22 $0x02 -> %q21
+6e21db17 : ucvtf v23.4s, v24.4s                      : ucvtf  %q24 $0x02 -> %q23
+6e21db59 : ucvtf v25.4s, v26.4s                      : ucvtf  %q26 $0x02 -> %q25
+6e21db9b : ucvtf v27.4s, v28.4s                      : ucvtf  %q28 $0x02 -> %q27
+6e21d81f : ucvtf v31.4s, v0.4s                       : ucvtf  %q0 $0x02 -> %q31
+6e61d820 : ucvtf v0.2d, v1.2d                        : ucvtf  %q1 $0x03 -> %q0
+6e61d862 : ucvtf v2.2d, v3.2d                        : ucvtf  %q3 $0x03 -> %q2
+6e61d8a4 : ucvtf v4.2d, v5.2d                        : ucvtf  %q5 $0x03 -> %q4
+6e61d8e6 : ucvtf v6.2d, v7.2d                        : ucvtf  %q7 $0x03 -> %q6
+6e61d928 : ucvtf v8.2d, v9.2d                        : ucvtf  %q9 $0x03 -> %q8
+6e61d96a : ucvtf v10.2d, v11.2d                      : ucvtf  %q11 $0x03 -> %q10
+6e61d9ac : ucvtf v12.2d, v13.2d                      : ucvtf  %q13 $0x03 -> %q12
+6e61d9ee : ucvtf v14.2d, v15.2d                      : ucvtf  %q15 $0x03 -> %q14
+6e61da30 : ucvtf v16.2d, v17.2d                      : ucvtf  %q17 $0x03 -> %q16
+6e61da51 : ucvtf v17.2d, v18.2d                      : ucvtf  %q18 $0x03 -> %q17
+6e61da93 : ucvtf v19.2d, v20.2d                      : ucvtf  %q20 $0x03 -> %q19
+6e61dad5 : ucvtf v21.2d, v22.2d                      : ucvtf  %q22 $0x03 -> %q21
+6e61db17 : ucvtf v23.2d, v24.2d                      : ucvtf  %q24 $0x03 -> %q23
+6e61db59 : ucvtf v25.2d, v26.2d                      : ucvtf  %q26 $0x03 -> %q25
+6e61db9b : ucvtf v27.2d, v28.2d                      : ucvtf  %q28 $0x03 -> %q27
+6e61d81f : ucvtf v31.2d, v0.2d                       : ucvtf  %q0 $0x03 -> %q31
+
 # FCMGT   <V><d>, <V><n>, #0 (FCMGT-V.V-asisdmisc_FZ)
 5ea0c820 : fcmgt s0, s1, #0                          : fcmgt  %s1 $0.000000 -> %s0
 5ea0c862 : fcmgt s2, s3, #0                          : fcmgt  %s3 $0.000000 -> %s2
@@ -29010,6 +30224,56 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 5ee0cb59 : fcmgt d25, d26, #0                        : fcmgt  %d26 $0.000000 -> %d25
 5ee0cb9b : fcmgt d27, d28, #0                        : fcmgt  %d28 $0.000000 -> %d27
 5ee0c81f : fcmgt d31, d0, #0                         : fcmgt  %d0 $0.000000 -> %d31
+
+# FRINTX  <Dd>.<T>, <Dn>.<T> (FRINTX-Q.Q-asimdmisc_R)
+2e219820 : frintx v0.2s, v1.2s                       : frintx %d1 $0x02 -> %d0
+2e219862 : frintx v2.2s, v3.2s                       : frintx %d3 $0x02 -> %d2
+2e2198a4 : frintx v4.2s, v5.2s                       : frintx %d5 $0x02 -> %d4
+2e2198e6 : frintx v6.2s, v7.2s                       : frintx %d7 $0x02 -> %d6
+2e219928 : frintx v8.2s, v9.2s                       : frintx %d9 $0x02 -> %d8
+2e21996a : frintx v10.2s, v11.2s                     : frintx %d11 $0x02 -> %d10
+2e2199ac : frintx v12.2s, v13.2s                     : frintx %d13 $0x02 -> %d12
+2e2199ee : frintx v14.2s, v15.2s                     : frintx %d15 $0x02 -> %d14
+2e219a30 : frintx v16.2s, v17.2s                     : frintx %d17 $0x02 -> %d16
+2e219a51 : frintx v17.2s, v18.2s                     : frintx %d18 $0x02 -> %d17
+2e219a93 : frintx v19.2s, v20.2s                     : frintx %d20 $0x02 -> %d19
+2e219ad5 : frintx v21.2s, v22.2s                     : frintx %d22 $0x02 -> %d21
+2e219b17 : frintx v23.2s, v24.2s                     : frintx %d24 $0x02 -> %d23
+2e219b59 : frintx v25.2s, v26.2s                     : frintx %d26 $0x02 -> %d25
+2e219b9b : frintx v27.2s, v28.2s                     : frintx %d28 $0x02 -> %d27
+2e21981f : frintx v31.2s, v0.2s                      : frintx %d0 $0x02 -> %d31
+6e219820 : frintx v0.4s, v1.4s                       : frintx %q1 $0x02 -> %q0
+6e219862 : frintx v2.4s, v3.4s                       : frintx %q3 $0x02 -> %q2
+6e2198a4 : frintx v4.4s, v5.4s                       : frintx %q5 $0x02 -> %q4
+6e2198e6 : frintx v6.4s, v7.4s                       : frintx %q7 $0x02 -> %q6
+6e219928 : frintx v8.4s, v9.4s                       : frintx %q9 $0x02 -> %q8
+6e21996a : frintx v10.4s, v11.4s                     : frintx %q11 $0x02 -> %q10
+6e2199ac : frintx v12.4s, v13.4s                     : frintx %q13 $0x02 -> %q12
+6e2199ee : frintx v14.4s, v15.4s                     : frintx %q15 $0x02 -> %q14
+6e219a30 : frintx v16.4s, v17.4s                     : frintx %q17 $0x02 -> %q16
+6e219a51 : frintx v17.4s, v18.4s                     : frintx %q18 $0x02 -> %q17
+6e219a93 : frintx v19.4s, v20.4s                     : frintx %q20 $0x02 -> %q19
+6e219ad5 : frintx v21.4s, v22.4s                     : frintx %q22 $0x02 -> %q21
+6e219b17 : frintx v23.4s, v24.4s                     : frintx %q24 $0x02 -> %q23
+6e219b59 : frintx v25.4s, v26.4s                     : frintx %q26 $0x02 -> %q25
+6e219b9b : frintx v27.4s, v28.4s                     : frintx %q28 $0x02 -> %q27
+6e21981f : frintx v31.4s, v0.4s                      : frintx %q0 $0x02 -> %q31
+6e619820 : frintx v0.2d, v1.2d                       : frintx %q1 $0x03 -> %q0
+6e619862 : frintx v2.2d, v3.2d                       : frintx %q3 $0x03 -> %q2
+6e6198a4 : frintx v4.2d, v5.2d                       : frintx %q5 $0x03 -> %q4
+6e6198e6 : frintx v6.2d, v7.2d                       : frintx %q7 $0x03 -> %q6
+6e619928 : frintx v8.2d, v9.2d                       : frintx %q9 $0x03 -> %q8
+6e61996a : frintx v10.2d, v11.2d                     : frintx %q11 $0x03 -> %q10
+6e6199ac : frintx v12.2d, v13.2d                     : frintx %q13 $0x03 -> %q12
+6e6199ee : frintx v14.2d, v15.2d                     : frintx %q15 $0x03 -> %q14
+6e619a30 : frintx v16.2d, v17.2d                     : frintx %q17 $0x03 -> %q16
+6e619a51 : frintx v17.2d, v18.2d                     : frintx %q18 $0x03 -> %q17
+6e619a93 : frintx v19.2d, v20.2d                     : frintx %q20 $0x03 -> %q19
+6e619ad5 : frintx v21.2d, v22.2d                     : frintx %q22 $0x03 -> %q21
+6e619b17 : frintx v23.2d, v24.2d                     : frintx %q24 $0x03 -> %q23
+6e619b59 : frintx v25.2d, v26.2d                     : frintx %q26 $0x03 -> %q25
+6e619b9b : frintx v27.2d, v28.2d                     : frintx %q28 $0x03 -> %q27
+6e61981f : frintx v31.2d, v0.2d                      : frintx %q0 $0x03 -> %q31
 
 # FCMGT   <Dd>.<T>, <Dn>.<T>, #0 (FCMGT-Q.Q-asimdmisc_FZ)
 0ea0c820 : fcmgt v0.2s, v1.2s, #0                    : fcmgt  %d1 $0.000000 $0x02 -> %d0
@@ -29061,6 +30325,610 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 4ee0cb9b : fcmgt v27.2d, v28.2d, #0                  : fcmgt  %q28 $0.000000 $0x03 -> %q27
 4ee0c81f : fcmgt v31.2d, v0.2d, #0                   : fcmgt  %q0 $0.000000 $0x03 -> %q31
 
+# FMULX   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMULX-Q.QQ-asimdsame_only)
+0e22dc20 : fmulx v0.2s, v1.2s, v2.2s                 : fmulx  %d1 %d2 $0x02 -> %d0
+0e24dc62 : fmulx v2.2s, v3.2s, v4.2s                 : fmulx  %d3 %d4 $0x02 -> %d2
+0e26dca4 : fmulx v4.2s, v5.2s, v6.2s                 : fmulx  %d5 %d6 $0x02 -> %d4
+0e28dce6 : fmulx v6.2s, v7.2s, v8.2s                 : fmulx  %d7 %d8 $0x02 -> %d6
+0e2add28 : fmulx v8.2s, v9.2s, v10.2s                : fmulx  %d9 %d10 $0x02 -> %d8
+0e2cdd6a : fmulx v10.2s, v11.2s, v12.2s              : fmulx  %d11 %d12 $0x02 -> %d10
+0e2eddac : fmulx v12.2s, v13.2s, v14.2s              : fmulx  %d13 %d14 $0x02 -> %d12
+0e30ddee : fmulx v14.2s, v15.2s, v16.2s              : fmulx  %d15 %d16 $0x02 -> %d14
+0e32de30 : fmulx v16.2s, v17.2s, v18.2s              : fmulx  %d17 %d18 $0x02 -> %d16
+0e33de51 : fmulx v17.2s, v18.2s, v19.2s              : fmulx  %d18 %d19 $0x02 -> %d17
+0e35de93 : fmulx v19.2s, v20.2s, v21.2s              : fmulx  %d20 %d21 $0x02 -> %d19
+0e37ded5 : fmulx v21.2s, v22.2s, v23.2s              : fmulx  %d22 %d23 $0x02 -> %d21
+0e39df17 : fmulx v23.2s, v24.2s, v25.2s              : fmulx  %d24 %d25 $0x02 -> %d23
+0e3bdf59 : fmulx v25.2s, v26.2s, v27.2s              : fmulx  %d26 %d27 $0x02 -> %d25
+0e3ddf9b : fmulx v27.2s, v28.2s, v29.2s              : fmulx  %d28 %d29 $0x02 -> %d27
+0e21dc1f : fmulx v31.2s, v0.2s, v1.2s                : fmulx  %d0 %d1 $0x02 -> %d31
+4e22dc20 : fmulx v0.4s, v1.4s, v2.4s                 : fmulx  %q1 %q2 $0x02 -> %q0
+4e24dc62 : fmulx v2.4s, v3.4s, v4.4s                 : fmulx  %q3 %q4 $0x02 -> %q2
+4e26dca4 : fmulx v4.4s, v5.4s, v6.4s                 : fmulx  %q5 %q6 $0x02 -> %q4
+4e28dce6 : fmulx v6.4s, v7.4s, v8.4s                 : fmulx  %q7 %q8 $0x02 -> %q6
+4e2add28 : fmulx v8.4s, v9.4s, v10.4s                : fmulx  %q9 %q10 $0x02 -> %q8
+4e2cdd6a : fmulx v10.4s, v11.4s, v12.4s              : fmulx  %q11 %q12 $0x02 -> %q10
+4e2eddac : fmulx v12.4s, v13.4s, v14.4s              : fmulx  %q13 %q14 $0x02 -> %q12
+4e30ddee : fmulx v14.4s, v15.4s, v16.4s              : fmulx  %q15 %q16 $0x02 -> %q14
+4e32de30 : fmulx v16.4s, v17.4s, v18.4s              : fmulx  %q17 %q18 $0x02 -> %q16
+4e33de51 : fmulx v17.4s, v18.4s, v19.4s              : fmulx  %q18 %q19 $0x02 -> %q17
+4e35de93 : fmulx v19.4s, v20.4s, v21.4s              : fmulx  %q20 %q21 $0x02 -> %q19
+4e37ded5 : fmulx v21.4s, v22.4s, v23.4s              : fmulx  %q22 %q23 $0x02 -> %q21
+4e39df17 : fmulx v23.4s, v24.4s, v25.4s              : fmulx  %q24 %q25 $0x02 -> %q23
+4e3bdf59 : fmulx v25.4s, v26.4s, v27.4s              : fmulx  %q26 %q27 $0x02 -> %q25
+4e3ddf9b : fmulx v27.4s, v28.4s, v29.4s              : fmulx  %q28 %q29 $0x02 -> %q27
+4e21dc1f : fmulx v31.4s, v0.4s, v1.4s                : fmulx  %q0 %q1 $0x02 -> %q31
+4e62dc20 : fmulx v0.2d, v1.2d, v2.2d                 : fmulx  %q1 %q2 $0x03 -> %q0
+4e64dc62 : fmulx v2.2d, v3.2d, v4.2d                 : fmulx  %q3 %q4 $0x03 -> %q2
+4e66dca4 : fmulx v4.2d, v5.2d, v6.2d                 : fmulx  %q5 %q6 $0x03 -> %q4
+4e68dce6 : fmulx v6.2d, v7.2d, v8.2d                 : fmulx  %q7 %q8 $0x03 -> %q6
+4e6add28 : fmulx v8.2d, v9.2d, v10.2d                : fmulx  %q9 %q10 $0x03 -> %q8
+4e6cdd6a : fmulx v10.2d, v11.2d, v12.2d              : fmulx  %q11 %q12 $0x03 -> %q10
+4e6eddac : fmulx v12.2d, v13.2d, v14.2d              : fmulx  %q13 %q14 $0x03 -> %q12
+4e70ddee : fmulx v14.2d, v15.2d, v16.2d              : fmulx  %q15 %q16 $0x03 -> %q14
+4e72de30 : fmulx v16.2d, v17.2d, v18.2d              : fmulx  %q17 %q18 $0x03 -> %q16
+4e73de51 : fmulx v17.2d, v18.2d, v19.2d              : fmulx  %q18 %q19 $0x03 -> %q17
+4e75de93 : fmulx v19.2d, v20.2d, v21.2d              : fmulx  %q20 %q21 $0x03 -> %q19
+4e77ded5 : fmulx v21.2d, v22.2d, v23.2d              : fmulx  %q22 %q23 $0x03 -> %q21
+4e79df17 : fmulx v23.2d, v24.2d, v25.2d              : fmulx  %q24 %q25 $0x03 -> %q23
+4e7bdf59 : fmulx v25.2d, v26.2d, v27.2d              : fmulx  %q26 %q27 $0x03 -> %q25
+4e7ddf9b : fmulx v27.2d, v28.2d, v29.2d              : fmulx  %q28 %q29 $0x03 -> %q27
+4e61dc1f : fmulx v31.2d, v0.2d, v1.2d                : fmulx  %q0 %q1 $0x03 -> %q31
+
+# FCVTL2  <Dd>.<T>, <Sn>.<Tb> (FCVTL2-Q.Q-asimdmisc_L)
+4e217820 : fcvtl2 v0.4s, v1.8h                       : fcvtl2 %q1 $0x01 -> %q0
+4e217862 : fcvtl2 v2.4s, v3.8h                       : fcvtl2 %q3 $0x01 -> %q2
+4e2178a4 : fcvtl2 v4.4s, v5.8h                       : fcvtl2 %q5 $0x01 -> %q4
+4e2178e6 : fcvtl2 v6.4s, v7.8h                       : fcvtl2 %q7 $0x01 -> %q6
+4e217928 : fcvtl2 v8.4s, v9.8h                       : fcvtl2 %q9 $0x01 -> %q8
+4e21796a : fcvtl2 v10.4s, v11.8h                     : fcvtl2 %q11 $0x01 -> %q10
+4e2179ac : fcvtl2 v12.4s, v13.8h                     : fcvtl2 %q13 $0x01 -> %q12
+4e2179ee : fcvtl2 v14.4s, v15.8h                     : fcvtl2 %q15 $0x01 -> %q14
+4e217a30 : fcvtl2 v16.4s, v17.8h                     : fcvtl2 %q17 $0x01 -> %q16
+4e217a51 : fcvtl2 v17.4s, v18.8h                     : fcvtl2 %q18 $0x01 -> %q17
+4e217a93 : fcvtl2 v19.4s, v20.8h                     : fcvtl2 %q20 $0x01 -> %q19
+4e217ad5 : fcvtl2 v21.4s, v22.8h                     : fcvtl2 %q22 $0x01 -> %q21
+4e217b17 : fcvtl2 v23.4s, v24.8h                     : fcvtl2 %q24 $0x01 -> %q23
+4e217b59 : fcvtl2 v25.4s, v26.8h                     : fcvtl2 %q26 $0x01 -> %q25
+4e217b9b : fcvtl2 v27.4s, v28.8h                     : fcvtl2 %q28 $0x01 -> %q27
+4e21781f : fcvtl2 v31.4s, v0.8h                      : fcvtl2 %q0 $0x01 -> %q31
+4e617820 : fcvtl2 v0.2d, v1.4s                       : fcvtl2 %q1 $0x02 -> %q0
+4e617862 : fcvtl2 v2.2d, v3.4s                       : fcvtl2 %q3 $0x02 -> %q2
+4e6178a4 : fcvtl2 v4.2d, v5.4s                       : fcvtl2 %q5 $0x02 -> %q4
+4e6178e6 : fcvtl2 v6.2d, v7.4s                       : fcvtl2 %q7 $0x02 -> %q6
+4e617928 : fcvtl2 v8.2d, v9.4s                       : fcvtl2 %q9 $0x02 -> %q8
+4e61796a : fcvtl2 v10.2d, v11.4s                     : fcvtl2 %q11 $0x02 -> %q10
+4e6179ac : fcvtl2 v12.2d, v13.4s                     : fcvtl2 %q13 $0x02 -> %q12
+4e6179ee : fcvtl2 v14.2d, v15.4s                     : fcvtl2 %q15 $0x02 -> %q14
+4e617a30 : fcvtl2 v16.2d, v17.4s                     : fcvtl2 %q17 $0x02 -> %q16
+4e617a51 : fcvtl2 v17.2d, v18.4s                     : fcvtl2 %q18 $0x02 -> %q17
+4e617a93 : fcvtl2 v19.2d, v20.4s                     : fcvtl2 %q20 $0x02 -> %q19
+4e617ad5 : fcvtl2 v21.2d, v22.4s                     : fcvtl2 %q22 $0x02 -> %q21
+4e617b17 : fcvtl2 v23.2d, v24.4s                     : fcvtl2 %q24 $0x02 -> %q23
+4e617b59 : fcvtl2 v25.2d, v26.4s                     : fcvtl2 %q26 $0x02 -> %q25
+4e617b9b : fcvtl2 v27.2d, v28.4s                     : fcvtl2 %q28 $0x02 -> %q27
+4e61781f : fcvtl2 v31.2d, v0.4s                      : fcvtl2 %q0 $0x02 -> %q31
+
+# FMINNMV <Sd>, <Sn>.4S (FMINNMV-V.Q-asimdall_only)
+6eb0c820 : fminnmv s0, v1.4s                         : fminnmv %q1 $0x02 -> %s0
+6eb0c862 : fminnmv s2, v3.4s                         : fminnmv %q3 $0x02 -> %s2
+6eb0c8a4 : fminnmv s4, v5.4s                         : fminnmv %q5 $0x02 -> %s4
+6eb0c8e6 : fminnmv s6, v7.4s                         : fminnmv %q7 $0x02 -> %s6
+6eb0c928 : fminnmv s8, v9.4s                         : fminnmv %q9 $0x02 -> %s8
+6eb0c96a : fminnmv s10, v11.4s                       : fminnmv %q11 $0x02 -> %s10
+6eb0c9ac : fminnmv s12, v13.4s                       : fminnmv %q13 $0x02 -> %s12
+6eb0c9ee : fminnmv s14, v15.4s                       : fminnmv %q15 $0x02 -> %s14
+6eb0ca30 : fminnmv s16, v17.4s                       : fminnmv %q17 $0x02 -> %s16
+6eb0ca51 : fminnmv s17, v18.4s                       : fminnmv %q18 $0x02 -> %s17
+6eb0ca93 : fminnmv s19, v20.4s                       : fminnmv %q20 $0x02 -> %s19
+6eb0cad5 : fminnmv s21, v22.4s                       : fminnmv %q22 $0x02 -> %s21
+6eb0cb17 : fminnmv s23, v24.4s                       : fminnmv %q24 $0x02 -> %s23
+6eb0cb59 : fminnmv s25, v26.4s                       : fminnmv %q26 $0x02 -> %s25
+6eb0cb9b : fminnmv s27, v28.4s                       : fminnmv %q28 $0x02 -> %s27
+6eb0c81f : fminnmv s31, v0.4s                        : fminnmv %q0 $0x02 -> %s31
+
+# FMUL    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMUL-Q.QQ-asimdsame_only)
+2e22dc20 : fmul v0.2s, v1.2s, v2.2s                  : fmul   %d1 %d2 $0x02 -> %d0
+2e24dc62 : fmul v2.2s, v3.2s, v4.2s                  : fmul   %d3 %d4 $0x02 -> %d2
+2e26dca4 : fmul v4.2s, v5.2s, v6.2s                  : fmul   %d5 %d6 $0x02 -> %d4
+2e28dce6 : fmul v6.2s, v7.2s, v8.2s                  : fmul   %d7 %d8 $0x02 -> %d6
+2e2add28 : fmul v8.2s, v9.2s, v10.2s                 : fmul   %d9 %d10 $0x02 -> %d8
+2e2cdd6a : fmul v10.2s, v11.2s, v12.2s               : fmul   %d11 %d12 $0x02 -> %d10
+2e2eddac : fmul v12.2s, v13.2s, v14.2s               : fmul   %d13 %d14 $0x02 -> %d12
+2e30ddee : fmul v14.2s, v15.2s, v16.2s               : fmul   %d15 %d16 $0x02 -> %d14
+2e32de30 : fmul v16.2s, v17.2s, v18.2s               : fmul   %d17 %d18 $0x02 -> %d16
+2e33de51 : fmul v17.2s, v18.2s, v19.2s               : fmul   %d18 %d19 $0x02 -> %d17
+2e35de93 : fmul v19.2s, v20.2s, v21.2s               : fmul   %d20 %d21 $0x02 -> %d19
+2e37ded5 : fmul v21.2s, v22.2s, v23.2s               : fmul   %d22 %d23 $0x02 -> %d21
+2e39df17 : fmul v23.2s, v24.2s, v25.2s               : fmul   %d24 %d25 $0x02 -> %d23
+2e3bdf59 : fmul v25.2s, v26.2s, v27.2s               : fmul   %d26 %d27 $0x02 -> %d25
+2e3ddf9b : fmul v27.2s, v28.2s, v29.2s               : fmul   %d28 %d29 $0x02 -> %d27
+2e21dc1f : fmul v31.2s, v0.2s, v1.2s                 : fmul   %d0 %d1 $0x02 -> %d31
+6e22dc20 : fmul v0.4s, v1.4s, v2.4s                  : fmul   %q1 %q2 $0x02 -> %q0
+6e24dc62 : fmul v2.4s, v3.4s, v4.4s                  : fmul   %q3 %q4 $0x02 -> %q2
+6e26dca4 : fmul v4.4s, v5.4s, v6.4s                  : fmul   %q5 %q6 $0x02 -> %q4
+6e28dce6 : fmul v6.4s, v7.4s, v8.4s                  : fmul   %q7 %q8 $0x02 -> %q6
+6e2add28 : fmul v8.4s, v9.4s, v10.4s                 : fmul   %q9 %q10 $0x02 -> %q8
+6e2cdd6a : fmul v10.4s, v11.4s, v12.4s               : fmul   %q11 %q12 $0x02 -> %q10
+6e2eddac : fmul v12.4s, v13.4s, v14.4s               : fmul   %q13 %q14 $0x02 -> %q12
+6e30ddee : fmul v14.4s, v15.4s, v16.4s               : fmul   %q15 %q16 $0x02 -> %q14
+6e32de30 : fmul v16.4s, v17.4s, v18.4s               : fmul   %q17 %q18 $0x02 -> %q16
+6e33de51 : fmul v17.4s, v18.4s, v19.4s               : fmul   %q18 %q19 $0x02 -> %q17
+6e35de93 : fmul v19.4s, v20.4s, v21.4s               : fmul   %q20 %q21 $0x02 -> %q19
+6e37ded5 : fmul v21.4s, v22.4s, v23.4s               : fmul   %q22 %q23 $0x02 -> %q21
+6e39df17 : fmul v23.4s, v24.4s, v25.4s               : fmul   %q24 %q25 $0x02 -> %q23
+6e3bdf59 : fmul v25.4s, v26.4s, v27.4s               : fmul   %q26 %q27 $0x02 -> %q25
+6e3ddf9b : fmul v27.4s, v28.4s, v29.4s               : fmul   %q28 %q29 $0x02 -> %q27
+6e21dc1f : fmul v31.4s, v0.4s, v1.4s                 : fmul   %q0 %q1 $0x02 -> %q31
+6e62dc20 : fmul v0.2d, v1.2d, v2.2d                  : fmul   %q1 %q2 $0x03 -> %q0
+6e64dc62 : fmul v2.2d, v3.2d, v4.2d                  : fmul   %q3 %q4 $0x03 -> %q2
+6e66dca4 : fmul v4.2d, v5.2d, v6.2d                  : fmul   %q5 %q6 $0x03 -> %q4
+6e68dce6 : fmul v6.2d, v7.2d, v8.2d                  : fmul   %q7 %q8 $0x03 -> %q6
+6e6add28 : fmul v8.2d, v9.2d, v10.2d                 : fmul   %q9 %q10 $0x03 -> %q8
+6e6cdd6a : fmul v10.2d, v11.2d, v12.2d               : fmul   %q11 %q12 $0x03 -> %q10
+6e6eddac : fmul v12.2d, v13.2d, v14.2d               : fmul   %q13 %q14 $0x03 -> %q12
+6e70ddee : fmul v14.2d, v15.2d, v16.2d               : fmul   %q15 %q16 $0x03 -> %q14
+6e72de30 : fmul v16.2d, v17.2d, v18.2d               : fmul   %q17 %q18 $0x03 -> %q16
+6e73de51 : fmul v17.2d, v18.2d, v19.2d               : fmul   %q18 %q19 $0x03 -> %q17
+6e75de93 : fmul v19.2d, v20.2d, v21.2d               : fmul   %q20 %q21 $0x03 -> %q19
+6e77ded5 : fmul v21.2d, v22.2d, v23.2d               : fmul   %q22 %q23 $0x03 -> %q21
+6e79df17 : fmul v23.2d, v24.2d, v25.2d               : fmul   %q24 %q25 $0x03 -> %q23
+6e7bdf59 : fmul v25.2d, v26.2d, v27.2d               : fmul   %q26 %q27 $0x03 -> %q25
+6e7ddf9b : fmul v27.2d, v28.2d, v29.2d               : fmul   %q28 %q29 $0x03 -> %q27
+6e61dc1f : fmul v31.2d, v0.2d, v1.2d                 : fmul   %q0 %q1 $0x03 -> %q31
+
+# FMAXNMV <Sd>, <Sn>.4S (FMAXNMV-V.Q-asimdall_only)
+6e30c820 : fmaxnmv s0, v1.4s                         : fmaxnmv %q1 $0x02 -> %s0
+6e30c862 : fmaxnmv s2, v3.4s                         : fmaxnmv %q3 $0x02 -> %s2
+6e30c8a4 : fmaxnmv s4, v5.4s                         : fmaxnmv %q5 $0x02 -> %s4
+6e30c8e6 : fmaxnmv s6, v7.4s                         : fmaxnmv %q7 $0x02 -> %s6
+6e30c928 : fmaxnmv s8, v9.4s                         : fmaxnmv %q9 $0x02 -> %s8
+6e30c96a : fmaxnmv s10, v11.4s                       : fmaxnmv %q11 $0x02 -> %s10
+6e30c9ac : fmaxnmv s12, v13.4s                       : fmaxnmv %q13 $0x02 -> %s12
+6e30c9ee : fmaxnmv s14, v15.4s                       : fmaxnmv %q15 $0x02 -> %s14
+6e30ca30 : fmaxnmv s16, v17.4s                       : fmaxnmv %q17 $0x02 -> %s16
+6e30ca51 : fmaxnmv s17, v18.4s                       : fmaxnmv %q18 $0x02 -> %s17
+6e30ca93 : fmaxnmv s19, v20.4s                       : fmaxnmv %q20 $0x02 -> %s19
+6e30cad5 : fmaxnmv s21, v22.4s                       : fmaxnmv %q22 $0x02 -> %s21
+6e30cb17 : fmaxnmv s23, v24.4s                       : fmaxnmv %q24 $0x02 -> %s23
+6e30cb59 : fmaxnmv s25, v26.4s                       : fmaxnmv %q26 $0x02 -> %s25
+6e30cb9b : fmaxnmv s27, v28.4s                       : fmaxnmv %q28 $0x02 -> %s27
+6e30c81f : fmaxnmv s31, v0.4s                        : fmaxnmv %q0 $0x02 -> %s31
+
+# FMINP   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMINP-Q.QQ-asimdsame_only)
+2ea2f420 : fminp v0.2s, v1.2s, v2.2s                 : fminp  %d1 %d2 $0x02 -> %d0
+2ea4f462 : fminp v2.2s, v3.2s, v4.2s                 : fminp  %d3 %d4 $0x02 -> %d2
+2ea6f4a4 : fminp v4.2s, v5.2s, v6.2s                 : fminp  %d5 %d6 $0x02 -> %d4
+2ea8f4e6 : fminp v6.2s, v7.2s, v8.2s                 : fminp  %d7 %d8 $0x02 -> %d6
+2eaaf528 : fminp v8.2s, v9.2s, v10.2s                : fminp  %d9 %d10 $0x02 -> %d8
+2eacf56a : fminp v10.2s, v11.2s, v12.2s              : fminp  %d11 %d12 $0x02 -> %d10
+2eaef5ac : fminp v12.2s, v13.2s, v14.2s              : fminp  %d13 %d14 $0x02 -> %d12
+2eb0f5ee : fminp v14.2s, v15.2s, v16.2s              : fminp  %d15 %d16 $0x02 -> %d14
+2eb2f630 : fminp v16.2s, v17.2s, v18.2s              : fminp  %d17 %d18 $0x02 -> %d16
+2eb3f651 : fminp v17.2s, v18.2s, v19.2s              : fminp  %d18 %d19 $0x02 -> %d17
+2eb5f693 : fminp v19.2s, v20.2s, v21.2s              : fminp  %d20 %d21 $0x02 -> %d19
+2eb7f6d5 : fminp v21.2s, v22.2s, v23.2s              : fminp  %d22 %d23 $0x02 -> %d21
+2eb9f717 : fminp v23.2s, v24.2s, v25.2s              : fminp  %d24 %d25 $0x02 -> %d23
+2ebbf759 : fminp v25.2s, v26.2s, v27.2s              : fminp  %d26 %d27 $0x02 -> %d25
+2ebdf79b : fminp v27.2s, v28.2s, v29.2s              : fminp  %d28 %d29 $0x02 -> %d27
+2ea1f41f : fminp v31.2s, v0.2s, v1.2s                : fminp  %d0 %d1 $0x02 -> %d31
+6ea2f420 : fminp v0.4s, v1.4s, v2.4s                 : fminp  %q1 %q2 $0x02 -> %q0
+6ea4f462 : fminp v2.4s, v3.4s, v4.4s                 : fminp  %q3 %q4 $0x02 -> %q2
+6ea6f4a4 : fminp v4.4s, v5.4s, v6.4s                 : fminp  %q5 %q6 $0x02 -> %q4
+6ea8f4e6 : fminp v6.4s, v7.4s, v8.4s                 : fminp  %q7 %q8 $0x02 -> %q6
+6eaaf528 : fminp v8.4s, v9.4s, v10.4s                : fminp  %q9 %q10 $0x02 -> %q8
+6eacf56a : fminp v10.4s, v11.4s, v12.4s              : fminp  %q11 %q12 $0x02 -> %q10
+6eaef5ac : fminp v12.4s, v13.4s, v14.4s              : fminp  %q13 %q14 $0x02 -> %q12
+6eb0f5ee : fminp v14.4s, v15.4s, v16.4s              : fminp  %q15 %q16 $0x02 -> %q14
+6eb2f630 : fminp v16.4s, v17.4s, v18.4s              : fminp  %q17 %q18 $0x02 -> %q16
+6eb3f651 : fminp v17.4s, v18.4s, v19.4s              : fminp  %q18 %q19 $0x02 -> %q17
+6eb5f693 : fminp v19.4s, v20.4s, v21.4s              : fminp  %q20 %q21 $0x02 -> %q19
+6eb7f6d5 : fminp v21.4s, v22.4s, v23.4s              : fminp  %q22 %q23 $0x02 -> %q21
+6eb9f717 : fminp v23.4s, v24.4s, v25.4s              : fminp  %q24 %q25 $0x02 -> %q23
+6ebbf759 : fminp v25.4s, v26.4s, v27.4s              : fminp  %q26 %q27 $0x02 -> %q25
+6ebdf79b : fminp v27.4s, v28.4s, v29.4s              : fminp  %q28 %q29 $0x02 -> %q27
+6ea1f41f : fminp v31.4s, v0.4s, v1.4s                : fminp  %q0 %q1 $0x02 -> %q31
+6ee2f420 : fminp v0.2d, v1.2d, v2.2d                 : fminp  %q1 %q2 $0x03 -> %q0
+6ee4f462 : fminp v2.2d, v3.2d, v4.2d                 : fminp  %q3 %q4 $0x03 -> %q2
+6ee6f4a4 : fminp v4.2d, v5.2d, v6.2d                 : fminp  %q5 %q6 $0x03 -> %q4
+6ee8f4e6 : fminp v6.2d, v7.2d, v8.2d                 : fminp  %q7 %q8 $0x03 -> %q6
+6eeaf528 : fminp v8.2d, v9.2d, v10.2d                : fminp  %q9 %q10 $0x03 -> %q8
+6eecf56a : fminp v10.2d, v11.2d, v12.2d              : fminp  %q11 %q12 $0x03 -> %q10
+6eeef5ac : fminp v12.2d, v13.2d, v14.2d              : fminp  %q13 %q14 $0x03 -> %q12
+6ef0f5ee : fminp v14.2d, v15.2d, v16.2d              : fminp  %q15 %q16 $0x03 -> %q14
+6ef2f630 : fminp v16.2d, v17.2d, v18.2d              : fminp  %q17 %q18 $0x03 -> %q16
+6ef3f651 : fminp v17.2d, v18.2d, v19.2d              : fminp  %q18 %q19 $0x03 -> %q17
+6ef5f693 : fminp v19.2d, v20.2d, v21.2d              : fminp  %q20 %q21 $0x03 -> %q19
+6ef7f6d5 : fminp v21.2d, v22.2d, v23.2d              : fminp  %q22 %q23 $0x03 -> %q21
+6ef9f717 : fminp v23.2d, v24.2d, v25.2d              : fminp  %q24 %q25 $0x03 -> %q23
+6efbf759 : fminp v25.2d, v26.2d, v27.2d              : fminp  %q26 %q27 $0x03 -> %q25
+6efdf79b : fminp v27.2d, v28.2d, v29.2d              : fminp  %q28 %q29 $0x03 -> %q27
+6ee1f41f : fminp v31.2d, v0.2d, v1.2d                : fminp  %q0 %q1 $0x03 -> %q31
+
+# FRINTI  <Dd>.<T>, <Dn>.<T> (FRINTI-Q.Q-asimdmisc_R)
+2ea19820 : frinti v0.2s, v1.2s                       : frinti %d1 $0x02 -> %d0
+2ea19862 : frinti v2.2s, v3.2s                       : frinti %d3 $0x02 -> %d2
+2ea198a4 : frinti v4.2s, v5.2s                       : frinti %d5 $0x02 -> %d4
+2ea198e6 : frinti v6.2s, v7.2s                       : frinti %d7 $0x02 -> %d6
+2ea19928 : frinti v8.2s, v9.2s                       : frinti %d9 $0x02 -> %d8
+2ea1996a : frinti v10.2s, v11.2s                     : frinti %d11 $0x02 -> %d10
+2ea199ac : frinti v12.2s, v13.2s                     : frinti %d13 $0x02 -> %d12
+2ea199ee : frinti v14.2s, v15.2s                     : frinti %d15 $0x02 -> %d14
+2ea19a30 : frinti v16.2s, v17.2s                     : frinti %d17 $0x02 -> %d16
+2ea19a51 : frinti v17.2s, v18.2s                     : frinti %d18 $0x02 -> %d17
+2ea19a93 : frinti v19.2s, v20.2s                     : frinti %d20 $0x02 -> %d19
+2ea19ad5 : frinti v21.2s, v22.2s                     : frinti %d22 $0x02 -> %d21
+2ea19b17 : frinti v23.2s, v24.2s                     : frinti %d24 $0x02 -> %d23
+2ea19b59 : frinti v25.2s, v26.2s                     : frinti %d26 $0x02 -> %d25
+2ea19b9b : frinti v27.2s, v28.2s                     : frinti %d28 $0x02 -> %d27
+2ea1981f : frinti v31.2s, v0.2s                      : frinti %d0 $0x02 -> %d31
+6ea19820 : frinti v0.4s, v1.4s                       : frinti %q1 $0x02 -> %q0
+6ea19862 : frinti v2.4s, v3.4s                       : frinti %q3 $0x02 -> %q2
+6ea198a4 : frinti v4.4s, v5.4s                       : frinti %q5 $0x02 -> %q4
+6ea198e6 : frinti v6.4s, v7.4s                       : frinti %q7 $0x02 -> %q6
+6ea19928 : frinti v8.4s, v9.4s                       : frinti %q9 $0x02 -> %q8
+6ea1996a : frinti v10.4s, v11.4s                     : frinti %q11 $0x02 -> %q10
+6ea199ac : frinti v12.4s, v13.4s                     : frinti %q13 $0x02 -> %q12
+6ea199ee : frinti v14.4s, v15.4s                     : frinti %q15 $0x02 -> %q14
+6ea19a30 : frinti v16.4s, v17.4s                     : frinti %q17 $0x02 -> %q16
+6ea19a51 : frinti v17.4s, v18.4s                     : frinti %q18 $0x02 -> %q17
+6ea19a93 : frinti v19.4s, v20.4s                     : frinti %q20 $0x02 -> %q19
+6ea19ad5 : frinti v21.4s, v22.4s                     : frinti %q22 $0x02 -> %q21
+6ea19b17 : frinti v23.4s, v24.4s                     : frinti %q24 $0x02 -> %q23
+6ea19b59 : frinti v25.4s, v26.4s                     : frinti %q26 $0x02 -> %q25
+6ea19b9b : frinti v27.4s, v28.4s                     : frinti %q28 $0x02 -> %q27
+6ea1981f : frinti v31.4s, v0.4s                      : frinti %q0 $0x02 -> %q31
+6ee19820 : frinti v0.2d, v1.2d                       : frinti %q1 $0x03 -> %q0
+6ee19862 : frinti v2.2d, v3.2d                       : frinti %q3 $0x03 -> %q2
+6ee198a4 : frinti v4.2d, v5.2d                       : frinti %q5 $0x03 -> %q4
+6ee198e6 : frinti v6.2d, v7.2d                       : frinti %q7 $0x03 -> %q6
+6ee19928 : frinti v8.2d, v9.2d                       : frinti %q9 $0x03 -> %q8
+6ee1996a : frinti v10.2d, v11.2d                     : frinti %q11 $0x03 -> %q10
+6ee199ac : frinti v12.2d, v13.2d                     : frinti %q13 $0x03 -> %q12
+6ee199ee : frinti v14.2d, v15.2d                     : frinti %q15 $0x03 -> %q14
+6ee19a30 : frinti v16.2d, v17.2d                     : frinti %q17 $0x03 -> %q16
+6ee19a51 : frinti v17.2d, v18.2d                     : frinti %q18 $0x03 -> %q17
+6ee19a93 : frinti v19.2d, v20.2d                     : frinti %q20 $0x03 -> %q19
+6ee19ad5 : frinti v21.2d, v22.2d                     : frinti %q22 $0x03 -> %q21
+6ee19b17 : frinti v23.2d, v24.2d                     : frinti %q24 $0x03 -> %q23
+6ee19b59 : frinti v25.2d, v26.2d                     : frinti %q26 $0x03 -> %q25
+6ee19b9b : frinti v27.2d, v28.2d                     : frinti %q28 $0x03 -> %q27
+6ee1981f : frinti v31.2d, v0.2d                      : frinti %q0 $0x03 -> %q31
+
+# FCVTN2  <Sd>.<T>, <Dn>.<Tb> (FCVTN2-Q.Q-asimdmisc_N)
+4e216820 : fcvtn2 v0.8h, v1.4s                       : fcvtn2 %q1 $0x02 -> %q0
+4e216862 : fcvtn2 v2.8h, v3.4s                       : fcvtn2 %q3 $0x02 -> %q2
+4e2168a4 : fcvtn2 v4.8h, v5.4s                       : fcvtn2 %q5 $0x02 -> %q4
+4e2168e6 : fcvtn2 v6.8h, v7.4s                       : fcvtn2 %q7 $0x02 -> %q6
+4e216928 : fcvtn2 v8.8h, v9.4s                       : fcvtn2 %q9 $0x02 -> %q8
+4e21696a : fcvtn2 v10.8h, v11.4s                     : fcvtn2 %q11 $0x02 -> %q10
+4e2169ac : fcvtn2 v12.8h, v13.4s                     : fcvtn2 %q13 $0x02 -> %q12
+4e2169ee : fcvtn2 v14.8h, v15.4s                     : fcvtn2 %q15 $0x02 -> %q14
+4e216a30 : fcvtn2 v16.8h, v17.4s                     : fcvtn2 %q17 $0x02 -> %q16
+4e216a51 : fcvtn2 v17.8h, v18.4s                     : fcvtn2 %q18 $0x02 -> %q17
+4e216a93 : fcvtn2 v19.8h, v20.4s                     : fcvtn2 %q20 $0x02 -> %q19
+4e216ad5 : fcvtn2 v21.8h, v22.4s                     : fcvtn2 %q22 $0x02 -> %q21
+4e216b17 : fcvtn2 v23.8h, v24.4s                     : fcvtn2 %q24 $0x02 -> %q23
+4e216b59 : fcvtn2 v25.8h, v26.4s                     : fcvtn2 %q26 $0x02 -> %q25
+4e216b9b : fcvtn2 v27.8h, v28.4s                     : fcvtn2 %q28 $0x02 -> %q27
+4e21681f : fcvtn2 v31.8h, v0.4s                      : fcvtn2 %q0 $0x02 -> %q31
+4e616820 : fcvtn2 v0.4s, v1.2d                       : fcvtn2 %q1 $0x03 -> %q0
+4e616862 : fcvtn2 v2.4s, v3.2d                       : fcvtn2 %q3 $0x03 -> %q2
+4e6168a4 : fcvtn2 v4.4s, v5.2d                       : fcvtn2 %q5 $0x03 -> %q4
+4e6168e6 : fcvtn2 v6.4s, v7.2d                       : fcvtn2 %q7 $0x03 -> %q6
+4e616928 : fcvtn2 v8.4s, v9.2d                       : fcvtn2 %q9 $0x03 -> %q8
+4e61696a : fcvtn2 v10.4s, v11.2d                     : fcvtn2 %q11 $0x03 -> %q10
+4e6169ac : fcvtn2 v12.4s, v13.2d                     : fcvtn2 %q13 $0x03 -> %q12
+4e6169ee : fcvtn2 v14.4s, v15.2d                     : fcvtn2 %q15 $0x03 -> %q14
+4e616a30 : fcvtn2 v16.4s, v17.2d                     : fcvtn2 %q17 $0x03 -> %q16
+4e616a51 : fcvtn2 v17.4s, v18.2d                     : fcvtn2 %q18 $0x03 -> %q17
+4e616a93 : fcvtn2 v19.4s, v20.2d                     : fcvtn2 %q20 $0x03 -> %q19
+4e616ad5 : fcvtn2 v21.4s, v22.2d                     : fcvtn2 %q22 $0x03 -> %q21
+4e616b17 : fcvtn2 v23.4s, v24.2d                     : fcvtn2 %q24 $0x03 -> %q23
+4e616b59 : fcvtn2 v25.4s, v26.2d                     : fcvtn2 %q26 $0x03 -> %q25
+4e616b9b : fcvtn2 v27.4s, v28.2d                     : fcvtn2 %q28 $0x03 -> %q27
+4e61681f : fcvtn2 v31.4s, v0.2d                      : fcvtn2 %q0 $0x03 -> %q31
+
+# FRINTP  <Dd>.<T>, <Dn>.<T> (FRINTP-Q.Q-asimdmisc_R)
+0ea18820 : frintp v0.2s, v1.2s                       : frintp %d1 $0x02 -> %d0
+0ea18862 : frintp v2.2s, v3.2s                       : frintp %d3 $0x02 -> %d2
+0ea188a4 : frintp v4.2s, v5.2s                       : frintp %d5 $0x02 -> %d4
+0ea188e6 : frintp v6.2s, v7.2s                       : frintp %d7 $0x02 -> %d6
+0ea18928 : frintp v8.2s, v9.2s                       : frintp %d9 $0x02 -> %d8
+0ea1896a : frintp v10.2s, v11.2s                     : frintp %d11 $0x02 -> %d10
+0ea189ac : frintp v12.2s, v13.2s                     : frintp %d13 $0x02 -> %d12
+0ea189ee : frintp v14.2s, v15.2s                     : frintp %d15 $0x02 -> %d14
+0ea18a30 : frintp v16.2s, v17.2s                     : frintp %d17 $0x02 -> %d16
+0ea18a51 : frintp v17.2s, v18.2s                     : frintp %d18 $0x02 -> %d17
+0ea18a93 : frintp v19.2s, v20.2s                     : frintp %d20 $0x02 -> %d19
+0ea18ad5 : frintp v21.2s, v22.2s                     : frintp %d22 $0x02 -> %d21
+0ea18b17 : frintp v23.2s, v24.2s                     : frintp %d24 $0x02 -> %d23
+0ea18b59 : frintp v25.2s, v26.2s                     : frintp %d26 $0x02 -> %d25
+0ea18b9b : frintp v27.2s, v28.2s                     : frintp %d28 $0x02 -> %d27
+0ea1881f : frintp v31.2s, v0.2s                      : frintp %d0 $0x02 -> %d31
+4ea18820 : frintp v0.4s, v1.4s                       : frintp %q1 $0x02 -> %q0
+4ea18862 : frintp v2.4s, v3.4s                       : frintp %q3 $0x02 -> %q2
+4ea188a4 : frintp v4.4s, v5.4s                       : frintp %q5 $0x02 -> %q4
+4ea188e6 : frintp v6.4s, v7.4s                       : frintp %q7 $0x02 -> %q6
+4ea18928 : frintp v8.4s, v9.4s                       : frintp %q9 $0x02 -> %q8
+4ea1896a : frintp v10.4s, v11.4s                     : frintp %q11 $0x02 -> %q10
+4ea189ac : frintp v12.4s, v13.4s                     : frintp %q13 $0x02 -> %q12
+4ea189ee : frintp v14.4s, v15.4s                     : frintp %q15 $0x02 -> %q14
+4ea18a30 : frintp v16.4s, v17.4s                     : frintp %q17 $0x02 -> %q16
+4ea18a51 : frintp v17.4s, v18.4s                     : frintp %q18 $0x02 -> %q17
+4ea18a93 : frintp v19.4s, v20.4s                     : frintp %q20 $0x02 -> %q19
+4ea18ad5 : frintp v21.4s, v22.4s                     : frintp %q22 $0x02 -> %q21
+4ea18b17 : frintp v23.4s, v24.4s                     : frintp %q24 $0x02 -> %q23
+4ea18b59 : frintp v25.4s, v26.4s                     : frintp %q26 $0x02 -> %q25
+4ea18b9b : frintp v27.4s, v28.4s                     : frintp %q28 $0x02 -> %q27
+4ea1881f : frintp v31.4s, v0.4s                      : frintp %q0 $0x02 -> %q31
+4ee18820 : frintp v0.2d, v1.2d                       : frintp %q1 $0x03 -> %q0
+4ee18862 : frintp v2.2d, v3.2d                       : frintp %q3 $0x03 -> %q2
+4ee188a4 : frintp v4.2d, v5.2d                       : frintp %q5 $0x03 -> %q4
+4ee188e6 : frintp v6.2d, v7.2d                       : frintp %q7 $0x03 -> %q6
+4ee18928 : frintp v8.2d, v9.2d                       : frintp %q9 $0x03 -> %q8
+4ee1896a : frintp v10.2d, v11.2d                     : frintp %q11 $0x03 -> %q10
+4ee189ac : frintp v12.2d, v13.2d                     : frintp %q13 $0x03 -> %q12
+4ee189ee : frintp v14.2d, v15.2d                     : frintp %q15 $0x03 -> %q14
+4ee18a30 : frintp v16.2d, v17.2d                     : frintp %q17 $0x03 -> %q16
+4ee18a51 : frintp v17.2d, v18.2d                     : frintp %q18 $0x03 -> %q17
+4ee18a93 : frintp v19.2d, v20.2d                     : frintp %q20 $0x03 -> %q19
+4ee18ad5 : frintp v21.2d, v22.2d                     : frintp %q22 $0x03 -> %q21
+4ee18b17 : frintp v23.2d, v24.2d                     : frintp %q24 $0x03 -> %q23
+4ee18b59 : frintp v25.2d, v26.2d                     : frintp %q26 $0x03 -> %q25
+4ee18b9b : frintp v27.2d, v28.2d                     : frintp %q28 $0x03 -> %q27
+4ee1881f : frintp v31.2d, v0.2d                      : frintp %q0 $0x03 -> %q31
+
+# FMAX    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMAX-Q.QQ-asimdsame_only)
+0e22f420 : fmax v0.2s, v1.2s, v2.2s                  : fmax   %d1 %d2 $0x02 -> %d0
+0e24f462 : fmax v2.2s, v3.2s, v4.2s                  : fmax   %d3 %d4 $0x02 -> %d2
+0e26f4a4 : fmax v4.2s, v5.2s, v6.2s                  : fmax   %d5 %d6 $0x02 -> %d4
+0e28f4e6 : fmax v6.2s, v7.2s, v8.2s                  : fmax   %d7 %d8 $0x02 -> %d6
+0e2af528 : fmax v8.2s, v9.2s, v10.2s                 : fmax   %d9 %d10 $0x02 -> %d8
+0e2cf56a : fmax v10.2s, v11.2s, v12.2s               : fmax   %d11 %d12 $0x02 -> %d10
+0e2ef5ac : fmax v12.2s, v13.2s, v14.2s               : fmax   %d13 %d14 $0x02 -> %d12
+0e30f5ee : fmax v14.2s, v15.2s, v16.2s               : fmax   %d15 %d16 $0x02 -> %d14
+0e32f630 : fmax v16.2s, v17.2s, v18.2s               : fmax   %d17 %d18 $0x02 -> %d16
+0e33f651 : fmax v17.2s, v18.2s, v19.2s               : fmax   %d18 %d19 $0x02 -> %d17
+0e35f693 : fmax v19.2s, v20.2s, v21.2s               : fmax   %d20 %d21 $0x02 -> %d19
+0e37f6d5 : fmax v21.2s, v22.2s, v23.2s               : fmax   %d22 %d23 $0x02 -> %d21
+0e39f717 : fmax v23.2s, v24.2s, v25.2s               : fmax   %d24 %d25 $0x02 -> %d23
+0e3bf759 : fmax v25.2s, v26.2s, v27.2s               : fmax   %d26 %d27 $0x02 -> %d25
+0e3df79b : fmax v27.2s, v28.2s, v29.2s               : fmax   %d28 %d29 $0x02 -> %d27
+0e21f41f : fmax v31.2s, v0.2s, v1.2s                 : fmax   %d0 %d1 $0x02 -> %d31
+4e22f420 : fmax v0.4s, v1.4s, v2.4s                  : fmax   %q1 %q2 $0x02 -> %q0
+4e24f462 : fmax v2.4s, v3.4s, v4.4s                  : fmax   %q3 %q4 $0x02 -> %q2
+4e26f4a4 : fmax v4.4s, v5.4s, v6.4s                  : fmax   %q5 %q6 $0x02 -> %q4
+4e28f4e6 : fmax v6.4s, v7.4s, v8.4s                  : fmax   %q7 %q8 $0x02 -> %q6
+4e2af528 : fmax v8.4s, v9.4s, v10.4s                 : fmax   %q9 %q10 $0x02 -> %q8
+4e2cf56a : fmax v10.4s, v11.4s, v12.4s               : fmax   %q11 %q12 $0x02 -> %q10
+4e2ef5ac : fmax v12.4s, v13.4s, v14.4s               : fmax   %q13 %q14 $0x02 -> %q12
+4e30f5ee : fmax v14.4s, v15.4s, v16.4s               : fmax   %q15 %q16 $0x02 -> %q14
+4e32f630 : fmax v16.4s, v17.4s, v18.4s               : fmax   %q17 %q18 $0x02 -> %q16
+4e33f651 : fmax v17.4s, v18.4s, v19.4s               : fmax   %q18 %q19 $0x02 -> %q17
+4e35f693 : fmax v19.4s, v20.4s, v21.4s               : fmax   %q20 %q21 $0x02 -> %q19
+4e37f6d5 : fmax v21.4s, v22.4s, v23.4s               : fmax   %q22 %q23 $0x02 -> %q21
+4e39f717 : fmax v23.4s, v24.4s, v25.4s               : fmax   %q24 %q25 $0x02 -> %q23
+4e3bf759 : fmax v25.4s, v26.4s, v27.4s               : fmax   %q26 %q27 $0x02 -> %q25
+4e3df79b : fmax v27.4s, v28.4s, v29.4s               : fmax   %q28 %q29 $0x02 -> %q27
+4e21f41f : fmax v31.4s, v0.4s, v1.4s                 : fmax   %q0 %q1 $0x02 -> %q31
+4e62f420 : fmax v0.2d, v1.2d, v2.2d                  : fmax   %q1 %q2 $0x03 -> %q0
+4e64f462 : fmax v2.2d, v3.2d, v4.2d                  : fmax   %q3 %q4 $0x03 -> %q2
+4e66f4a4 : fmax v4.2d, v5.2d, v6.2d                  : fmax   %q5 %q6 $0x03 -> %q4
+4e68f4e6 : fmax v6.2d, v7.2d, v8.2d                  : fmax   %q7 %q8 $0x03 -> %q6
+4e6af528 : fmax v8.2d, v9.2d, v10.2d                 : fmax   %q9 %q10 $0x03 -> %q8
+4e6cf56a : fmax v10.2d, v11.2d, v12.2d               : fmax   %q11 %q12 $0x03 -> %q10
+4e6ef5ac : fmax v12.2d, v13.2d, v14.2d               : fmax   %q13 %q14 $0x03 -> %q12
+4e70f5ee : fmax v14.2d, v15.2d, v16.2d               : fmax   %q15 %q16 $0x03 -> %q14
+4e72f630 : fmax v16.2d, v17.2d, v18.2d               : fmax   %q17 %q18 $0x03 -> %q16
+4e73f651 : fmax v17.2d, v18.2d, v19.2d               : fmax   %q18 %q19 $0x03 -> %q17
+4e75f693 : fmax v19.2d, v20.2d, v21.2d               : fmax   %q20 %q21 $0x03 -> %q19
+4e77f6d5 : fmax v21.2d, v22.2d, v23.2d               : fmax   %q22 %q23 $0x03 -> %q21
+4e79f717 : fmax v23.2d, v24.2d, v25.2d               : fmax   %q24 %q25 $0x03 -> %q23
+4e7bf759 : fmax v25.2d, v26.2d, v27.2d               : fmax   %q26 %q27 $0x03 -> %q25
+4e7df79b : fmax v27.2d, v28.2d, v29.2d               : fmax   %q28 %q29 $0x03 -> %q27
+4e61f41f : fmax v31.2d, v0.2d, v1.2d                 : fmax   %q0 %q1 $0x03 -> %q31
+
+# FRINTN  <Dd>.<T>, <Dn>.<T> (FRINTN-Q.Q-asimdmisc_R)
+0e218820 : frintn v0.2s, v1.2s                       : frintn %d1 $0x02 -> %d0
+0e218862 : frintn v2.2s, v3.2s                       : frintn %d3 $0x02 -> %d2
+0e2188a4 : frintn v4.2s, v5.2s                       : frintn %d5 $0x02 -> %d4
+0e2188e6 : frintn v6.2s, v7.2s                       : frintn %d7 $0x02 -> %d6
+0e218928 : frintn v8.2s, v9.2s                       : frintn %d9 $0x02 -> %d8
+0e21896a : frintn v10.2s, v11.2s                     : frintn %d11 $0x02 -> %d10
+0e2189ac : frintn v12.2s, v13.2s                     : frintn %d13 $0x02 -> %d12
+0e2189ee : frintn v14.2s, v15.2s                     : frintn %d15 $0x02 -> %d14
+0e218a30 : frintn v16.2s, v17.2s                     : frintn %d17 $0x02 -> %d16
+0e218a51 : frintn v17.2s, v18.2s                     : frintn %d18 $0x02 -> %d17
+0e218a93 : frintn v19.2s, v20.2s                     : frintn %d20 $0x02 -> %d19
+0e218ad5 : frintn v21.2s, v22.2s                     : frintn %d22 $0x02 -> %d21
+0e218b17 : frintn v23.2s, v24.2s                     : frintn %d24 $0x02 -> %d23
+0e218b59 : frintn v25.2s, v26.2s                     : frintn %d26 $0x02 -> %d25
+0e218b9b : frintn v27.2s, v28.2s                     : frintn %d28 $0x02 -> %d27
+0e21881f : frintn v31.2s, v0.2s                      : frintn %d0 $0x02 -> %d31
+4e218820 : frintn v0.4s, v1.4s                       : frintn %q1 $0x02 -> %q0
+4e218862 : frintn v2.4s, v3.4s                       : frintn %q3 $0x02 -> %q2
+4e2188a4 : frintn v4.4s, v5.4s                       : frintn %q5 $0x02 -> %q4
+4e2188e6 : frintn v6.4s, v7.4s                       : frintn %q7 $0x02 -> %q6
+4e218928 : frintn v8.4s, v9.4s                       : frintn %q9 $0x02 -> %q8
+4e21896a : frintn v10.4s, v11.4s                     : frintn %q11 $0x02 -> %q10
+4e2189ac : frintn v12.4s, v13.4s                     : frintn %q13 $0x02 -> %q12
+4e2189ee : frintn v14.4s, v15.4s                     : frintn %q15 $0x02 -> %q14
+4e218a30 : frintn v16.4s, v17.4s                     : frintn %q17 $0x02 -> %q16
+4e218a51 : frintn v17.4s, v18.4s                     : frintn %q18 $0x02 -> %q17
+4e218a93 : frintn v19.4s, v20.4s                     : frintn %q20 $0x02 -> %q19
+4e218ad5 : frintn v21.4s, v22.4s                     : frintn %q22 $0x02 -> %q21
+4e218b17 : frintn v23.4s, v24.4s                     : frintn %q24 $0x02 -> %q23
+4e218b59 : frintn v25.4s, v26.4s                     : frintn %q26 $0x02 -> %q25
+4e218b9b : frintn v27.4s, v28.4s                     : frintn %q28 $0x02 -> %q27
+4e21881f : frintn v31.4s, v0.4s                      : frintn %q0 $0x02 -> %q31
+4e618820 : frintn v0.2d, v1.2d                       : frintn %q1 $0x03 -> %q0
+4e618862 : frintn v2.2d, v3.2d                       : frintn %q3 $0x03 -> %q2
+4e6188a4 : frintn v4.2d, v5.2d                       : frintn %q5 $0x03 -> %q4
+4e6188e6 : frintn v6.2d, v7.2d                       : frintn %q7 $0x03 -> %q6
+4e618928 : frintn v8.2d, v9.2d                       : frintn %q9 $0x03 -> %q8
+4e61896a : frintn v10.2d, v11.2d                     : frintn %q11 $0x03 -> %q10
+4e6189ac : frintn v12.2d, v13.2d                     : frintn %q13 $0x03 -> %q12
+4e6189ee : frintn v14.2d, v15.2d                     : frintn %q15 $0x03 -> %q14
+4e618a30 : frintn v16.2d, v17.2d                     : frintn %q17 $0x03 -> %q16
+4e618a51 : frintn v17.2d, v18.2d                     : frintn %q18 $0x03 -> %q17
+4e618a93 : frintn v19.2d, v20.2d                     : frintn %q20 $0x03 -> %q19
+4e618ad5 : frintn v21.2d, v22.2d                     : frintn %q22 $0x03 -> %q21
+4e618b17 : frintn v23.2d, v24.2d                     : frintn %q24 $0x03 -> %q23
+4e618b59 : frintn v25.2d, v26.2d                     : frintn %q26 $0x03 -> %q25
+4e618b9b : frintn v27.2d, v28.2d                     : frintn %q28 $0x03 -> %q27
+4e61881f : frintn v31.2d, v0.2d                      : frintn %q0 $0x03 -> %q31
+
+# FRECPS  <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FRECPS-Q.QQ-asimdsame_only)
+0e22fc20 : frecps v0.2s, v1.2s, v2.2s                : frecps %d1 %d2 $0x02 -> %d0
+0e24fc62 : frecps v2.2s, v3.2s, v4.2s                : frecps %d3 %d4 $0x02 -> %d2
+0e26fca4 : frecps v4.2s, v5.2s, v6.2s                : frecps %d5 %d6 $0x02 -> %d4
+0e28fce6 : frecps v6.2s, v7.2s, v8.2s                : frecps %d7 %d8 $0x02 -> %d6
+0e2afd28 : frecps v8.2s, v9.2s, v10.2s               : frecps %d9 %d10 $0x02 -> %d8
+0e2cfd6a : frecps v10.2s, v11.2s, v12.2s             : frecps %d11 %d12 $0x02 -> %d10
+0e2efdac : frecps v12.2s, v13.2s, v14.2s             : frecps %d13 %d14 $0x02 -> %d12
+0e30fdee : frecps v14.2s, v15.2s, v16.2s             : frecps %d15 %d16 $0x02 -> %d14
+0e32fe30 : frecps v16.2s, v17.2s, v18.2s             : frecps %d17 %d18 $0x02 -> %d16
+0e33fe51 : frecps v17.2s, v18.2s, v19.2s             : frecps %d18 %d19 $0x02 -> %d17
+0e35fe93 : frecps v19.2s, v20.2s, v21.2s             : frecps %d20 %d21 $0x02 -> %d19
+0e37fed5 : frecps v21.2s, v22.2s, v23.2s             : frecps %d22 %d23 $0x02 -> %d21
+0e39ff17 : frecps v23.2s, v24.2s, v25.2s             : frecps %d24 %d25 $0x02 -> %d23
+0e3bff59 : frecps v25.2s, v26.2s, v27.2s             : frecps %d26 %d27 $0x02 -> %d25
+0e3dff9b : frecps v27.2s, v28.2s, v29.2s             : frecps %d28 %d29 $0x02 -> %d27
+0e21fc1f : frecps v31.2s, v0.2s, v1.2s               : frecps %d0 %d1 $0x02 -> %d31
+4e22fc20 : frecps v0.4s, v1.4s, v2.4s                : frecps %q1 %q2 $0x02 -> %q0
+4e24fc62 : frecps v2.4s, v3.4s, v4.4s                : frecps %q3 %q4 $0x02 -> %q2
+4e26fca4 : frecps v4.4s, v5.4s, v6.4s                : frecps %q5 %q6 $0x02 -> %q4
+4e28fce6 : frecps v6.4s, v7.4s, v8.4s                : frecps %q7 %q8 $0x02 -> %q6
+4e2afd28 : frecps v8.4s, v9.4s, v10.4s               : frecps %q9 %q10 $0x02 -> %q8
+4e2cfd6a : frecps v10.4s, v11.4s, v12.4s             : frecps %q11 %q12 $0x02 -> %q10
+4e2efdac : frecps v12.4s, v13.4s, v14.4s             : frecps %q13 %q14 $0x02 -> %q12
+4e30fdee : frecps v14.4s, v15.4s, v16.4s             : frecps %q15 %q16 $0x02 -> %q14
+4e32fe30 : frecps v16.4s, v17.4s, v18.4s             : frecps %q17 %q18 $0x02 -> %q16
+4e33fe51 : frecps v17.4s, v18.4s, v19.4s             : frecps %q18 %q19 $0x02 -> %q17
+4e35fe93 : frecps v19.4s, v20.4s, v21.4s             : frecps %q20 %q21 $0x02 -> %q19
+4e37fed5 : frecps v21.4s, v22.4s, v23.4s             : frecps %q22 %q23 $0x02 -> %q21
+4e39ff17 : frecps v23.4s, v24.4s, v25.4s             : frecps %q24 %q25 $0x02 -> %q23
+4e3bff59 : frecps v25.4s, v26.4s, v27.4s             : frecps %q26 %q27 $0x02 -> %q25
+4e3dff9b : frecps v27.4s, v28.4s, v29.4s             : frecps %q28 %q29 $0x02 -> %q27
+4e21fc1f : frecps v31.4s, v0.4s, v1.4s               : frecps %q0 %q1 $0x02 -> %q31
+4e62fc20 : frecps v0.2d, v1.2d, v2.2d                : frecps %q1 %q2 $0x03 -> %q0
+4e64fc62 : frecps v2.2d, v3.2d, v4.2d                : frecps %q3 %q4 $0x03 -> %q2
+4e66fca4 : frecps v4.2d, v5.2d, v6.2d                : frecps %q5 %q6 $0x03 -> %q4
+4e68fce6 : frecps v6.2d, v7.2d, v8.2d                : frecps %q7 %q8 $0x03 -> %q6
+4e6afd28 : frecps v8.2d, v9.2d, v10.2d               : frecps %q9 %q10 $0x03 -> %q8
+4e6cfd6a : frecps v10.2d, v11.2d, v12.2d             : frecps %q11 %q12 $0x03 -> %q10
+4e6efdac : frecps v12.2d, v13.2d, v14.2d             : frecps %q13 %q14 $0x03 -> %q12
+4e70fdee : frecps v14.2d, v15.2d, v16.2d             : frecps %q15 %q16 $0x03 -> %q14
+4e72fe30 : frecps v16.2d, v17.2d, v18.2d             : frecps %q17 %q18 $0x03 -> %q16
+4e73fe51 : frecps v17.2d, v18.2d, v19.2d             : frecps %q18 %q19 $0x03 -> %q17
+4e75fe93 : frecps v19.2d, v20.2d, v21.2d             : frecps %q20 %q21 $0x03 -> %q19
+4e77fed5 : frecps v21.2d, v22.2d, v23.2d             : frecps %q22 %q23 $0x03 -> %q21
+4e79ff17 : frecps v23.2d, v24.2d, v25.2d             : frecps %q24 %q25 $0x03 -> %q23
+4e7bff59 : frecps v25.2d, v26.2d, v27.2d             : frecps %q26 %q27 $0x03 -> %q25
+4e7dff9b : frecps v27.2d, v28.2d, v29.2d             : frecps %q28 %q29 $0x03 -> %q27
+4e61fc1f : frecps v31.2d, v0.2d, v1.2d               : frecps %q0 %q1 $0x03 -> %q31
+
+# FRSQRTS <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FRSQRTS-Q.QQ-asimdsame_only)
+0ea2fc20 : frsqrts v0.2s, v1.2s, v2.2s               : frsqrts %d1 %d2 $0x02 -> %d0
+0ea4fc62 : frsqrts v2.2s, v3.2s, v4.2s               : frsqrts %d3 %d4 $0x02 -> %d2
+0ea6fca4 : frsqrts v4.2s, v5.2s, v6.2s               : frsqrts %d5 %d6 $0x02 -> %d4
+0ea8fce6 : frsqrts v6.2s, v7.2s, v8.2s               : frsqrts %d7 %d8 $0x02 -> %d6
+0eaafd28 : frsqrts v8.2s, v9.2s, v10.2s              : frsqrts %d9 %d10 $0x02 -> %d8
+0eacfd6a : frsqrts v10.2s, v11.2s, v12.2s            : frsqrts %d11 %d12 $0x02 -> %d10
+0eaefdac : frsqrts v12.2s, v13.2s, v14.2s            : frsqrts %d13 %d14 $0x02 -> %d12
+0eb0fdee : frsqrts v14.2s, v15.2s, v16.2s            : frsqrts %d15 %d16 $0x02 -> %d14
+0eb2fe30 : frsqrts v16.2s, v17.2s, v18.2s            : frsqrts %d17 %d18 $0x02 -> %d16
+0eb3fe51 : frsqrts v17.2s, v18.2s, v19.2s            : frsqrts %d18 %d19 $0x02 -> %d17
+0eb5fe93 : frsqrts v19.2s, v20.2s, v21.2s            : frsqrts %d20 %d21 $0x02 -> %d19
+0eb7fed5 : frsqrts v21.2s, v22.2s, v23.2s            : frsqrts %d22 %d23 $0x02 -> %d21
+0eb9ff17 : frsqrts v23.2s, v24.2s, v25.2s            : frsqrts %d24 %d25 $0x02 -> %d23
+0ebbff59 : frsqrts v25.2s, v26.2s, v27.2s            : frsqrts %d26 %d27 $0x02 -> %d25
+0ebdff9b : frsqrts v27.2s, v28.2s, v29.2s            : frsqrts %d28 %d29 $0x02 -> %d27
+0ea1fc1f : frsqrts v31.2s, v0.2s, v1.2s              : frsqrts %d0 %d1 $0x02 -> %d31
+4ea2fc20 : frsqrts v0.4s, v1.4s, v2.4s               : frsqrts %q1 %q2 $0x02 -> %q0
+4ea4fc62 : frsqrts v2.4s, v3.4s, v4.4s               : frsqrts %q3 %q4 $0x02 -> %q2
+4ea6fca4 : frsqrts v4.4s, v5.4s, v6.4s               : frsqrts %q5 %q6 $0x02 -> %q4
+4ea8fce6 : frsqrts v6.4s, v7.4s, v8.4s               : frsqrts %q7 %q8 $0x02 -> %q6
+4eaafd28 : frsqrts v8.4s, v9.4s, v10.4s              : frsqrts %q9 %q10 $0x02 -> %q8
+4eacfd6a : frsqrts v10.4s, v11.4s, v12.4s            : frsqrts %q11 %q12 $0x02 -> %q10
+4eaefdac : frsqrts v12.4s, v13.4s, v14.4s            : frsqrts %q13 %q14 $0x02 -> %q12
+4eb0fdee : frsqrts v14.4s, v15.4s, v16.4s            : frsqrts %q15 %q16 $0x02 -> %q14
+4eb2fe30 : frsqrts v16.4s, v17.4s, v18.4s            : frsqrts %q17 %q18 $0x02 -> %q16
+4eb3fe51 : frsqrts v17.4s, v18.4s, v19.4s            : frsqrts %q18 %q19 $0x02 -> %q17
+4eb5fe93 : frsqrts v19.4s, v20.4s, v21.4s            : frsqrts %q20 %q21 $0x02 -> %q19
+4eb7fed5 : frsqrts v21.4s, v22.4s, v23.4s            : frsqrts %q22 %q23 $0x02 -> %q21
+4eb9ff17 : frsqrts v23.4s, v24.4s, v25.4s            : frsqrts %q24 %q25 $0x02 -> %q23
+4ebbff59 : frsqrts v25.4s, v26.4s, v27.4s            : frsqrts %q26 %q27 $0x02 -> %q25
+4ebdff9b : frsqrts v27.4s, v28.4s, v29.4s            : frsqrts %q28 %q29 $0x02 -> %q27
+4ea1fc1f : frsqrts v31.4s, v0.4s, v1.4s              : frsqrts %q0 %q1 $0x02 -> %q31
+4ee2fc20 : frsqrts v0.2d, v1.2d, v2.2d               : frsqrts %q1 %q2 $0x03 -> %q0
+4ee4fc62 : frsqrts v2.2d, v3.2d, v4.2d               : frsqrts %q3 %q4 $0x03 -> %q2
+4ee6fca4 : frsqrts v4.2d, v5.2d, v6.2d               : frsqrts %q5 %q6 $0x03 -> %q4
+4ee8fce6 : frsqrts v6.2d, v7.2d, v8.2d               : frsqrts %q7 %q8 $0x03 -> %q6
+4eeafd28 : frsqrts v8.2d, v9.2d, v10.2d              : frsqrts %q9 %q10 $0x03 -> %q8
+4eecfd6a : frsqrts v10.2d, v11.2d, v12.2d            : frsqrts %q11 %q12 $0x03 -> %q10
+4eeefdac : frsqrts v12.2d, v13.2d, v14.2d            : frsqrts %q13 %q14 $0x03 -> %q12
+4ef0fdee : frsqrts v14.2d, v15.2d, v16.2d            : frsqrts %q15 %q16 $0x03 -> %q14
+4ef2fe30 : frsqrts v16.2d, v17.2d, v18.2d            : frsqrts %q17 %q18 $0x03 -> %q16
+4ef3fe51 : frsqrts v17.2d, v18.2d, v19.2d            : frsqrts %q18 %q19 $0x03 -> %q17
+4ef5fe93 : frsqrts v19.2d, v20.2d, v21.2d            : frsqrts %q20 %q21 $0x03 -> %q19
+4ef7fed5 : frsqrts v21.2d, v22.2d, v23.2d            : frsqrts %q22 %q23 $0x03 -> %q21
+4ef9ff17 : frsqrts v23.2d, v24.2d, v25.2d            : frsqrts %q24 %q25 $0x03 -> %q23
+4efbff59 : frsqrts v25.2d, v26.2d, v27.2d            : frsqrts %q26 %q27 $0x03 -> %q25
+4efdff9b : frsqrts v27.2d, v28.2d, v29.2d            : frsqrts %q28 %q29 $0x03 -> %q27
+4ee1fc1f : frsqrts v31.2d, v0.2d, v1.2d              : frsqrts %q0 %q1 $0x03 -> %q31
+
+# FABD    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FABD-Q.QQ-asimdsame_only)
+2ea2d420 : fabd v0.2s, v1.2s, v2.2s                  : fabd   %d1 %d2 $0x02 -> %d0
+2ea4d462 : fabd v2.2s, v3.2s, v4.2s                  : fabd   %d3 %d4 $0x02 -> %d2
+2ea6d4a4 : fabd v4.2s, v5.2s, v6.2s                  : fabd   %d5 %d6 $0x02 -> %d4
+2ea8d4e6 : fabd v6.2s, v7.2s, v8.2s                  : fabd   %d7 %d8 $0x02 -> %d6
+2eaad528 : fabd v8.2s, v9.2s, v10.2s                 : fabd   %d9 %d10 $0x02 -> %d8
+2eacd56a : fabd v10.2s, v11.2s, v12.2s               : fabd   %d11 %d12 $0x02 -> %d10
+2eaed5ac : fabd v12.2s, v13.2s, v14.2s               : fabd   %d13 %d14 $0x02 -> %d12
+2eb0d5ee : fabd v14.2s, v15.2s, v16.2s               : fabd   %d15 %d16 $0x02 -> %d14
+2eb2d630 : fabd v16.2s, v17.2s, v18.2s               : fabd   %d17 %d18 $0x02 -> %d16
+2eb3d651 : fabd v17.2s, v18.2s, v19.2s               : fabd   %d18 %d19 $0x02 -> %d17
+2eb5d693 : fabd v19.2s, v20.2s, v21.2s               : fabd   %d20 %d21 $0x02 -> %d19
+2eb7d6d5 : fabd v21.2s, v22.2s, v23.2s               : fabd   %d22 %d23 $0x02 -> %d21
+2eb9d717 : fabd v23.2s, v24.2s, v25.2s               : fabd   %d24 %d25 $0x02 -> %d23
+2ebbd759 : fabd v25.2s, v26.2s, v27.2s               : fabd   %d26 %d27 $0x02 -> %d25
+2ebdd79b : fabd v27.2s, v28.2s, v29.2s               : fabd   %d28 %d29 $0x02 -> %d27
+2ea1d41f : fabd v31.2s, v0.2s, v1.2s                 : fabd   %d0 %d1 $0x02 -> %d31
+6ea2d420 : fabd v0.4s, v1.4s, v2.4s                  : fabd   %q1 %q2 $0x02 -> %q0
+6ea4d462 : fabd v2.4s, v3.4s, v4.4s                  : fabd   %q3 %q4 $0x02 -> %q2
+6ea6d4a4 : fabd v4.4s, v5.4s, v6.4s                  : fabd   %q5 %q6 $0x02 -> %q4
+6ea8d4e6 : fabd v6.4s, v7.4s, v8.4s                  : fabd   %q7 %q8 $0x02 -> %q6
+6eaad528 : fabd v8.4s, v9.4s, v10.4s                 : fabd   %q9 %q10 $0x02 -> %q8
+6eacd56a : fabd v10.4s, v11.4s, v12.4s               : fabd   %q11 %q12 $0x02 -> %q10
+6eaed5ac : fabd v12.4s, v13.4s, v14.4s               : fabd   %q13 %q14 $0x02 -> %q12
+6eb0d5ee : fabd v14.4s, v15.4s, v16.4s               : fabd   %q15 %q16 $0x02 -> %q14
+6eb2d630 : fabd v16.4s, v17.4s, v18.4s               : fabd   %q17 %q18 $0x02 -> %q16
+6eb3d651 : fabd v17.4s, v18.4s, v19.4s               : fabd   %q18 %q19 $0x02 -> %q17
+6eb5d693 : fabd v19.4s, v20.4s, v21.4s               : fabd   %q20 %q21 $0x02 -> %q19
+6eb7d6d5 : fabd v21.4s, v22.4s, v23.4s               : fabd   %q22 %q23 $0x02 -> %q21
+6eb9d717 : fabd v23.4s, v24.4s, v25.4s               : fabd   %q24 %q25 $0x02 -> %q23
+6ebbd759 : fabd v25.4s, v26.4s, v27.4s               : fabd   %q26 %q27 $0x02 -> %q25
+6ebdd79b : fabd v27.4s, v28.4s, v29.4s               : fabd   %q28 %q29 $0x02 -> %q27
+6ea1d41f : fabd v31.4s, v0.4s, v1.4s                 : fabd   %q0 %q1 $0x02 -> %q31
+6ee2d420 : fabd v0.2d, v1.2d, v2.2d                  : fabd   %q1 %q2 $0x03 -> %q0
+6ee4d462 : fabd v2.2d, v3.2d, v4.2d                  : fabd   %q3 %q4 $0x03 -> %q2
+6ee6d4a4 : fabd v4.2d, v5.2d, v6.2d                  : fabd   %q5 %q6 $0x03 -> %q4
+6ee8d4e6 : fabd v6.2d, v7.2d, v8.2d                  : fabd   %q7 %q8 $0x03 -> %q6
+6eead528 : fabd v8.2d, v9.2d, v10.2d                 : fabd   %q9 %q10 $0x03 -> %q8
+6eecd56a : fabd v10.2d, v11.2d, v12.2d               : fabd   %q11 %q12 $0x03 -> %q10
+6eeed5ac : fabd v12.2d, v13.2d, v14.2d               : fabd   %q13 %q14 $0x03 -> %q12
+6ef0d5ee : fabd v14.2d, v15.2d, v16.2d               : fabd   %q15 %q16 $0x03 -> %q14
+6ef2d630 : fabd v16.2d, v17.2d, v18.2d               : fabd   %q17 %q18 $0x03 -> %q16
+6ef3d651 : fabd v17.2d, v18.2d, v19.2d               : fabd   %q18 %q19 $0x03 -> %q17
+6ef5d693 : fabd v19.2d, v20.2d, v21.2d               : fabd   %q20 %q21 $0x03 -> %q19
+6ef7d6d5 : fabd v21.2d, v22.2d, v23.2d               : fabd   %q22 %q23 $0x03 -> %q21
+6ef9d717 : fabd v23.2d, v24.2d, v25.2d               : fabd   %q24 %q25 $0x03 -> %q23
+6efbd759 : fabd v25.2d, v26.2d, v27.2d               : fabd   %q26 %q27 $0x03 -> %q25
+6efdd79b : fabd v27.2d, v28.2d, v29.2d               : fabd   %q28 %q29 $0x03 -> %q27
+6ee1d41f : fabd v31.2d, v0.2d, v1.2d                 : fabd   %q0 %q1 $0x03 -> %q31
+
 # FCMPE   <Sn>, #0.0 (FCMPE-V-SZ_floatcmp)
 1e202018 : fcmpe s0, #0.0                            : fcmpe  %s0 $0.000000
 1e202058 : fcmpe s2, #0.0                            : fcmpe  %s2 $0.000000
@@ -29078,6 +30946,174 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 1e202338 : fcmpe s25, #0.0                           : fcmpe  %s25 $0.000000
 1e202378 : fcmpe s27, #0.0                           : fcmpe  %s27 $0.000000
 1e2023f8 : fcmpe s31, #0.0                           : fcmpe  %s31 $0.000000
+
+# FMOV    <Sd>.<T>, #<imm> (FMOV-Q.I-asimdimm_S_s)
+0f04f400 : fmov v0.2s, #-2.0                         : fmov   $-2.000000 $0x02 -> %d0
+0f04f442 : fmov v2.2s, #-2.25                        : fmov   $-2.250000 $0x02 -> %d2
+0f04f484 : fmov v4.2s, #-2.5                         : fmov   $-2.500000 $0x02 -> %d4
+0f04f4c6 : fmov v6.2s, #-2.75                        : fmov   $-2.750000 $0x02 -> %d6
+0f04f508 : fmov v8.2s, #-3.0                         : fmov   $-3.000000 $0x02 -> %d8
+0f04f54a : fmov v10.2s, #-3.25                       : fmov   $-3.250000 $0x02 -> %d10
+0f04f58c : fmov v12.2s, #-3.5                        : fmov   $-3.500000 $0x02 -> %d12
+0f04f5ce : fmov v14.2s, #-3.75                       : fmov   $-3.750000 $0x02 -> %d14
+0f00f410 : fmov v16.2s, #2.0                         : fmov   $2.000000 $0x02 -> %d16
+0f03f631 : fmov v17.2s, #1.0625                      : fmov   $1.062500 $0x02 -> %d17
+0f03f673 : fmov v19.2s, #1.1875                      : fmov   $1.187500 $0x02 -> %d19
+0f03f6b5 : fmov v21.2s, #1.3125                      : fmov   $1.312500 $0x02 -> %d21
+0f03f6f7 : fmov v23.2s, #1.4375                      : fmov   $1.437500 $0x02 -> %d23
+0f03f739 : fmov v25.2s, #1.5625                      : fmov   $1.562500 $0x02 -> %d25
+0f03f77b : fmov v27.2s, #1.6875                      : fmov   $1.687500 $0x02 -> %d27
+0f03f7ff : fmov v31.2s, #1.9375                      : fmov   $1.937500 $0x02 -> %d31
+4f04f400 : fmov v0.4s, #-2.0                         : fmov   $-2.000000 $0x02 -> %q0
+4f04f442 : fmov v2.4s, #-2.25                        : fmov   $-2.250000 $0x02 -> %q2
+4f04f484 : fmov v4.4s, #-2.5                         : fmov   $-2.500000 $0x02 -> %q4
+4f04f4c6 : fmov v6.4s, #-2.75                        : fmov   $-2.750000 $0x02 -> %q6
+4f04f508 : fmov v8.4s, #-3.0                         : fmov   $-3.000000 $0x02 -> %q8
+4f04f54a : fmov v10.4s, #-3.25                       : fmov   $-3.250000 $0x02 -> %q10
+4f04f58c : fmov v12.4s, #-3.5                        : fmov   $-3.500000 $0x02 -> %q12
+4f04f5ce : fmov v14.4s, #-3.75                       : fmov   $-3.750000 $0x02 -> %q14
+4f00f410 : fmov v16.4s, #2.0                         : fmov   $2.000000 $0x02 -> %q16
+4f03f631 : fmov v17.4s, #1.0625                      : fmov   $1.062500 $0x02 -> %q17
+4f03f673 : fmov v19.4s, #1.1875                      : fmov   $1.187500 $0x02 -> %q19
+4f03f6b5 : fmov v21.4s, #1.3125                      : fmov   $1.312500 $0x02 -> %q21
+4f03f6f7 : fmov v23.4s, #1.4375                      : fmov   $1.437500 $0x02 -> %q23
+4f03f739 : fmov v25.4s, #1.5625                      : fmov   $1.562500 $0x02 -> %q25
+4f03f77b : fmov v27.4s, #1.6875                      : fmov   $1.687500 $0x02 -> %q27
+4f03f7ff : fmov v31.4s, #1.9375                      : fmov   $1.937500 $0x02 -> %q31
+
+# FADD    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FADD-Q.QQ-asimdsame_only)
+0e22d420 : fadd v0.2s, v1.2s, v2.2s                  : fadd   %d1 %d2 $0x02 -> %d0
+0e24d462 : fadd v2.2s, v3.2s, v4.2s                  : fadd   %d3 %d4 $0x02 -> %d2
+0e26d4a4 : fadd v4.2s, v5.2s, v6.2s                  : fadd   %d5 %d6 $0x02 -> %d4
+0e28d4e6 : fadd v6.2s, v7.2s, v8.2s                  : fadd   %d7 %d8 $0x02 -> %d6
+0e2ad528 : fadd v8.2s, v9.2s, v10.2s                 : fadd   %d9 %d10 $0x02 -> %d8
+0e2cd56a : fadd v10.2s, v11.2s, v12.2s               : fadd   %d11 %d12 $0x02 -> %d10
+0e2ed5ac : fadd v12.2s, v13.2s, v14.2s               : fadd   %d13 %d14 $0x02 -> %d12
+0e30d5ee : fadd v14.2s, v15.2s, v16.2s               : fadd   %d15 %d16 $0x02 -> %d14
+0e32d630 : fadd v16.2s, v17.2s, v18.2s               : fadd   %d17 %d18 $0x02 -> %d16
+0e33d651 : fadd v17.2s, v18.2s, v19.2s               : fadd   %d18 %d19 $0x02 -> %d17
+0e35d693 : fadd v19.2s, v20.2s, v21.2s               : fadd   %d20 %d21 $0x02 -> %d19
+0e37d6d5 : fadd v21.2s, v22.2s, v23.2s               : fadd   %d22 %d23 $0x02 -> %d21
+0e39d717 : fadd v23.2s, v24.2s, v25.2s               : fadd   %d24 %d25 $0x02 -> %d23
+0e3bd759 : fadd v25.2s, v26.2s, v27.2s               : fadd   %d26 %d27 $0x02 -> %d25
+0e3dd79b : fadd v27.2s, v28.2s, v29.2s               : fadd   %d28 %d29 $0x02 -> %d27
+0e21d41f : fadd v31.2s, v0.2s, v1.2s                 : fadd   %d0 %d1 $0x02 -> %d31
+4e22d420 : fadd v0.4s, v1.4s, v2.4s                  : fadd   %q1 %q2 $0x02 -> %q0
+4e24d462 : fadd v2.4s, v3.4s, v4.4s                  : fadd   %q3 %q4 $0x02 -> %q2
+4e26d4a4 : fadd v4.4s, v5.4s, v6.4s                  : fadd   %q5 %q6 $0x02 -> %q4
+4e28d4e6 : fadd v6.4s, v7.4s, v8.4s                  : fadd   %q7 %q8 $0x02 -> %q6
+4e2ad528 : fadd v8.4s, v9.4s, v10.4s                 : fadd   %q9 %q10 $0x02 -> %q8
+4e2cd56a : fadd v10.4s, v11.4s, v12.4s               : fadd   %q11 %q12 $0x02 -> %q10
+4e2ed5ac : fadd v12.4s, v13.4s, v14.4s               : fadd   %q13 %q14 $0x02 -> %q12
+4e30d5ee : fadd v14.4s, v15.4s, v16.4s               : fadd   %q15 %q16 $0x02 -> %q14
+4e32d630 : fadd v16.4s, v17.4s, v18.4s               : fadd   %q17 %q18 $0x02 -> %q16
+4e33d651 : fadd v17.4s, v18.4s, v19.4s               : fadd   %q18 %q19 $0x02 -> %q17
+4e35d693 : fadd v19.4s, v20.4s, v21.4s               : fadd   %q20 %q21 $0x02 -> %q19
+4e37d6d5 : fadd v21.4s, v22.4s, v23.4s               : fadd   %q22 %q23 $0x02 -> %q21
+4e39d717 : fadd v23.4s, v24.4s, v25.4s               : fadd   %q24 %q25 $0x02 -> %q23
+4e3bd759 : fadd v25.4s, v26.4s, v27.4s               : fadd   %q26 %q27 $0x02 -> %q25
+4e3dd79b : fadd v27.4s, v28.4s, v29.4s               : fadd   %q28 %q29 $0x02 -> %q27
+4e21d41f : fadd v31.4s, v0.4s, v1.4s                 : fadd   %q0 %q1 $0x02 -> %q31
+4e62d420 : fadd v0.2d, v1.2d, v2.2d                  : fadd   %q1 %q2 $0x03 -> %q0
+4e64d462 : fadd v2.2d, v3.2d, v4.2d                  : fadd   %q3 %q4 $0x03 -> %q2
+4e66d4a4 : fadd v4.2d, v5.2d, v6.2d                  : fadd   %q5 %q6 $0x03 -> %q4
+4e68d4e6 : fadd v6.2d, v7.2d, v8.2d                  : fadd   %q7 %q8 $0x03 -> %q6
+4e6ad528 : fadd v8.2d, v9.2d, v10.2d                 : fadd   %q9 %q10 $0x03 -> %q8
+4e6cd56a : fadd v10.2d, v11.2d, v12.2d               : fadd   %q11 %q12 $0x03 -> %q10
+4e6ed5ac : fadd v12.2d, v13.2d, v14.2d               : fadd   %q13 %q14 $0x03 -> %q12
+4e70d5ee : fadd v14.2d, v15.2d, v16.2d               : fadd   %q15 %q16 $0x03 -> %q14
+4e72d630 : fadd v16.2d, v17.2d, v18.2d               : fadd   %q17 %q18 $0x03 -> %q16
+4e73d651 : fadd v17.2d, v18.2d, v19.2d               : fadd   %q18 %q19 $0x03 -> %q17
+4e75d693 : fadd v19.2d, v20.2d, v21.2d               : fadd   %q20 %q21 $0x03 -> %q19
+4e77d6d5 : fadd v21.2d, v22.2d, v23.2d               : fadd   %q22 %q23 $0x03 -> %q21
+4e79d717 : fadd v23.2d, v24.2d, v25.2d               : fadd   %q24 %q25 $0x03 -> %q23
+4e7bd759 : fadd v25.2d, v26.2d, v27.2d               : fadd   %q26 %q27 $0x03 -> %q25
+4e7dd79b : fadd v27.2d, v28.2d, v29.2d               : fadd   %q28 %q29 $0x03 -> %q27
+4e61d41f : fadd v31.2d, v0.2d, v1.2d                 : fadd   %q0 %q1 $0x03 -> %q31
+
+# FCVTL   <Dd>.<T>, <Sn>.<Tb> (FCVTL-Q.Q-asimdmisc_L)
+0e217820 : fcvtl v0.4s, v1.4h                        : fcvtl  %d1 $0x01 -> %q0
+0e217862 : fcvtl v2.4s, v3.4h                        : fcvtl  %d3 $0x01 -> %q2
+0e2178a4 : fcvtl v4.4s, v5.4h                        : fcvtl  %d5 $0x01 -> %q4
+0e2178e6 : fcvtl v6.4s, v7.4h                        : fcvtl  %d7 $0x01 -> %q6
+0e217928 : fcvtl v8.4s, v9.4h                        : fcvtl  %d9 $0x01 -> %q8
+0e21796a : fcvtl v10.4s, v11.4h                      : fcvtl  %d11 $0x01 -> %q10
+0e2179ac : fcvtl v12.4s, v13.4h                      : fcvtl  %d13 $0x01 -> %q12
+0e2179ee : fcvtl v14.4s, v15.4h                      : fcvtl  %d15 $0x01 -> %q14
+0e217a30 : fcvtl v16.4s, v17.4h                      : fcvtl  %d17 $0x01 -> %q16
+0e217a51 : fcvtl v17.4s, v18.4h                      : fcvtl  %d18 $0x01 -> %q17
+0e217a93 : fcvtl v19.4s, v20.4h                      : fcvtl  %d20 $0x01 -> %q19
+0e217ad5 : fcvtl v21.4s, v22.4h                      : fcvtl  %d22 $0x01 -> %q21
+0e217b17 : fcvtl v23.4s, v24.4h                      : fcvtl  %d24 $0x01 -> %q23
+0e217b59 : fcvtl v25.4s, v26.4h                      : fcvtl  %d26 $0x01 -> %q25
+0e217b9b : fcvtl v27.4s, v28.4h                      : fcvtl  %d28 $0x01 -> %q27
+0e21781f : fcvtl v31.4s, v0.4h                       : fcvtl  %d0 $0x01 -> %q31
+0e617820 : fcvtl v0.2d, v1.2s                        : fcvtl  %d1 $0x02 -> %q0
+0e617862 : fcvtl v2.2d, v3.2s                        : fcvtl  %d3 $0x02 -> %q2
+0e6178a4 : fcvtl v4.2d, v5.2s                        : fcvtl  %d5 $0x02 -> %q4
+0e6178e6 : fcvtl v6.2d, v7.2s                        : fcvtl  %d7 $0x02 -> %q6
+0e617928 : fcvtl v8.2d, v9.2s                        : fcvtl  %d9 $0x02 -> %q8
+0e61796a : fcvtl v10.2d, v11.2s                      : fcvtl  %d11 $0x02 -> %q10
+0e6179ac : fcvtl v12.2d, v13.2s                      : fcvtl  %d13 $0x02 -> %q12
+0e6179ee : fcvtl v14.2d, v15.2s                      : fcvtl  %d15 $0x02 -> %q14
+0e617a30 : fcvtl v16.2d, v17.2s                      : fcvtl  %d17 $0x02 -> %q16
+0e617a51 : fcvtl v17.2d, v18.2s                      : fcvtl  %d18 $0x02 -> %q17
+0e617a93 : fcvtl v19.2d, v20.2s                      : fcvtl  %d20 $0x02 -> %q19
+0e617ad5 : fcvtl v21.2d, v22.2s                      : fcvtl  %d22 $0x02 -> %q21
+0e617b17 : fcvtl v23.2d, v24.2s                      : fcvtl  %d24 $0x02 -> %q23
+0e617b59 : fcvtl v25.2d, v26.2s                      : fcvtl  %d26 $0x02 -> %q25
+0e617b9b : fcvtl v27.2d, v28.2s                      : fcvtl  %d28 $0x02 -> %q27
+0e61781f : fcvtl v31.2d, v0.2s                       : fcvtl  %d0 $0x02 -> %q31
+
+# FSQRT   <Dd>.<T>, <Dn>.<T> (FSQRT-Q.Q-asimdmisc_R)
+2ea1f820 : fsqrt v0.2s, v1.2s                        : fsqrt  %d1 $0x02 -> %d0
+2ea1f862 : fsqrt v2.2s, v3.2s                        : fsqrt  %d3 $0x02 -> %d2
+2ea1f8a4 : fsqrt v4.2s, v5.2s                        : fsqrt  %d5 $0x02 -> %d4
+2ea1f8e6 : fsqrt v6.2s, v7.2s                        : fsqrt  %d7 $0x02 -> %d6
+2ea1f928 : fsqrt v8.2s, v9.2s                        : fsqrt  %d9 $0x02 -> %d8
+2ea1f96a : fsqrt v10.2s, v11.2s                      : fsqrt  %d11 $0x02 -> %d10
+2ea1f9ac : fsqrt v12.2s, v13.2s                      : fsqrt  %d13 $0x02 -> %d12
+2ea1f9ee : fsqrt v14.2s, v15.2s                      : fsqrt  %d15 $0x02 -> %d14
+2ea1fa30 : fsqrt v16.2s, v17.2s                      : fsqrt  %d17 $0x02 -> %d16
+2ea1fa51 : fsqrt v17.2s, v18.2s                      : fsqrt  %d18 $0x02 -> %d17
+2ea1fa93 : fsqrt v19.2s, v20.2s                      : fsqrt  %d20 $0x02 -> %d19
+2ea1fad5 : fsqrt v21.2s, v22.2s                      : fsqrt  %d22 $0x02 -> %d21
+2ea1fb17 : fsqrt v23.2s, v24.2s                      : fsqrt  %d24 $0x02 -> %d23
+2ea1fb59 : fsqrt v25.2s, v26.2s                      : fsqrt  %d26 $0x02 -> %d25
+2ea1fb9b : fsqrt v27.2s, v28.2s                      : fsqrt  %d28 $0x02 -> %d27
+2ea1f81f : fsqrt v31.2s, v0.2s                       : fsqrt  %d0 $0x02 -> %d31
+6ea1f820 : fsqrt v0.4s, v1.4s                        : fsqrt  %q1 $0x02 -> %q0
+6ea1f862 : fsqrt v2.4s, v3.4s                        : fsqrt  %q3 $0x02 -> %q2
+6ea1f8a4 : fsqrt v4.4s, v5.4s                        : fsqrt  %q5 $0x02 -> %q4
+6ea1f8e6 : fsqrt v6.4s, v7.4s                        : fsqrt  %q7 $0x02 -> %q6
+6ea1f928 : fsqrt v8.4s, v9.4s                        : fsqrt  %q9 $0x02 -> %q8
+6ea1f96a : fsqrt v10.4s, v11.4s                      : fsqrt  %q11 $0x02 -> %q10
+6ea1f9ac : fsqrt v12.4s, v13.4s                      : fsqrt  %q13 $0x02 -> %q12
+6ea1f9ee : fsqrt v14.4s, v15.4s                      : fsqrt  %q15 $0x02 -> %q14
+6ea1fa30 : fsqrt v16.4s, v17.4s                      : fsqrt  %q17 $0x02 -> %q16
+6ea1fa51 : fsqrt v17.4s, v18.4s                      : fsqrt  %q18 $0x02 -> %q17
+6ea1fa93 : fsqrt v19.4s, v20.4s                      : fsqrt  %q20 $0x02 -> %q19
+6ea1fad5 : fsqrt v21.4s, v22.4s                      : fsqrt  %q22 $0x02 -> %q21
+6ea1fb17 : fsqrt v23.4s, v24.4s                      : fsqrt  %q24 $0x02 -> %q23
+6ea1fb59 : fsqrt v25.4s, v26.4s                      : fsqrt  %q26 $0x02 -> %q25
+6ea1fb9b : fsqrt v27.4s, v28.4s                      : fsqrt  %q28 $0x02 -> %q27
+6ea1f81f : fsqrt v31.4s, v0.4s                       : fsqrt  %q0 $0x02 -> %q31
+6ee1f820 : fsqrt v0.2d, v1.2d                        : fsqrt  %q1 $0x03 -> %q0
+6ee1f862 : fsqrt v2.2d, v3.2d                        : fsqrt  %q3 $0x03 -> %q2
+6ee1f8a4 : fsqrt v4.2d, v5.2d                        : fsqrt  %q5 $0x03 -> %q4
+6ee1f8e6 : fsqrt v6.2d, v7.2d                        : fsqrt  %q7 $0x03 -> %q6
+6ee1f928 : fsqrt v8.2d, v9.2d                        : fsqrt  %q9 $0x03 -> %q8
+6ee1f96a : fsqrt v10.2d, v11.2d                      : fsqrt  %q11 $0x03 -> %q10
+6ee1f9ac : fsqrt v12.2d, v13.2d                      : fsqrt  %q13 $0x03 -> %q12
+6ee1f9ee : fsqrt v14.2d, v15.2d                      : fsqrt  %q15 $0x03 -> %q14
+6ee1fa30 : fsqrt v16.2d, v17.2d                      : fsqrt  %q17 $0x03 -> %q16
+6ee1fa51 : fsqrt v17.2d, v18.2d                      : fsqrt  %q18 $0x03 -> %q17
+6ee1fa93 : fsqrt v19.2d, v20.2d                      : fsqrt  %q20 $0x03 -> %q19
+6ee1fad5 : fsqrt v21.2d, v22.2d                      : fsqrt  %q22 $0x03 -> %q21
+6ee1fb17 : fsqrt v23.2d, v24.2d                      : fsqrt  %q24 $0x03 -> %q23
+6ee1fb59 : fsqrt v25.2d, v26.2d                      : fsqrt  %q26 $0x03 -> %q25
+6ee1fb9b : fsqrt v27.2d, v28.2d                      : fsqrt  %q28 $0x03 -> %q27
+6ee1f81f : fsqrt v31.2d, v0.2d                       : fsqrt  %q0 $0x03 -> %q31
 
 # FCMEQ   <V><d>, <V><n>, #0 (FCMEQ-V.V-asisdmisc_FZ)
 5ea0d820 : fcmeq s0, s1, #0                          : fcmeq  %s1 $0.000000 -> %s0
@@ -29113,6 +31149,56 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 5ee0db9b : fcmeq d27, d28, #0                        : fcmeq  %d28 $0.000000 -> %d27
 5ee0d81f : fcmeq d31, d0, #0                         : fcmeq  %d0 $0.000000 -> %d31
 
+# FCMGE   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FCMGE-Q.QQ-asimdsame_only)
+2e22e420 : fcmge v0.2s, v1.2s, v2.2s                 : fcmge  %d1 %d2 $0x02 -> %d0
+2e24e462 : fcmge v2.2s, v3.2s, v4.2s                 : fcmge  %d3 %d4 $0x02 -> %d2
+2e26e4a4 : fcmge v4.2s, v5.2s, v6.2s                 : fcmge  %d5 %d6 $0x02 -> %d4
+2e28e4e6 : fcmge v6.2s, v7.2s, v8.2s                 : fcmge  %d7 %d8 $0x02 -> %d6
+2e2ae528 : fcmge v8.2s, v9.2s, v10.2s                : fcmge  %d9 %d10 $0x02 -> %d8
+2e2ce56a : fcmge v10.2s, v11.2s, v12.2s              : fcmge  %d11 %d12 $0x02 -> %d10
+2e2ee5ac : fcmge v12.2s, v13.2s, v14.2s              : fcmge  %d13 %d14 $0x02 -> %d12
+2e30e5ee : fcmge v14.2s, v15.2s, v16.2s              : fcmge  %d15 %d16 $0x02 -> %d14
+2e32e630 : fcmge v16.2s, v17.2s, v18.2s              : fcmge  %d17 %d18 $0x02 -> %d16
+2e33e651 : fcmge v17.2s, v18.2s, v19.2s              : fcmge  %d18 %d19 $0x02 -> %d17
+2e35e693 : fcmge v19.2s, v20.2s, v21.2s              : fcmge  %d20 %d21 $0x02 -> %d19
+2e37e6d5 : fcmge v21.2s, v22.2s, v23.2s              : fcmge  %d22 %d23 $0x02 -> %d21
+2e39e717 : fcmge v23.2s, v24.2s, v25.2s              : fcmge  %d24 %d25 $0x02 -> %d23
+2e3be759 : fcmge v25.2s, v26.2s, v27.2s              : fcmge  %d26 %d27 $0x02 -> %d25
+2e3de79b : fcmge v27.2s, v28.2s, v29.2s              : fcmge  %d28 %d29 $0x02 -> %d27
+2e21e41f : fcmge v31.2s, v0.2s, v1.2s                : fcmge  %d0 %d1 $0x02 -> %d31
+6e22e420 : fcmge v0.4s, v1.4s, v2.4s                 : fcmge  %q1 %q2 $0x02 -> %q0
+6e24e462 : fcmge v2.4s, v3.4s, v4.4s                 : fcmge  %q3 %q4 $0x02 -> %q2
+6e26e4a4 : fcmge v4.4s, v5.4s, v6.4s                 : fcmge  %q5 %q6 $0x02 -> %q4
+6e28e4e6 : fcmge v6.4s, v7.4s, v8.4s                 : fcmge  %q7 %q8 $0x02 -> %q6
+6e2ae528 : fcmge v8.4s, v9.4s, v10.4s                : fcmge  %q9 %q10 $0x02 -> %q8
+6e2ce56a : fcmge v10.4s, v11.4s, v12.4s              : fcmge  %q11 %q12 $0x02 -> %q10
+6e2ee5ac : fcmge v12.4s, v13.4s, v14.4s              : fcmge  %q13 %q14 $0x02 -> %q12
+6e30e5ee : fcmge v14.4s, v15.4s, v16.4s              : fcmge  %q15 %q16 $0x02 -> %q14
+6e32e630 : fcmge v16.4s, v17.4s, v18.4s              : fcmge  %q17 %q18 $0x02 -> %q16
+6e33e651 : fcmge v17.4s, v18.4s, v19.4s              : fcmge  %q18 %q19 $0x02 -> %q17
+6e35e693 : fcmge v19.4s, v20.4s, v21.4s              : fcmge  %q20 %q21 $0x02 -> %q19
+6e37e6d5 : fcmge v21.4s, v22.4s, v23.4s              : fcmge  %q22 %q23 $0x02 -> %q21
+6e39e717 : fcmge v23.4s, v24.4s, v25.4s              : fcmge  %q24 %q25 $0x02 -> %q23
+6e3be759 : fcmge v25.4s, v26.4s, v27.4s              : fcmge  %q26 %q27 $0x02 -> %q25
+6e3de79b : fcmge v27.4s, v28.4s, v29.4s              : fcmge  %q28 %q29 $0x02 -> %q27
+6e21e41f : fcmge v31.4s, v0.4s, v1.4s                : fcmge  %q0 %q1 $0x02 -> %q31
+6e62e420 : fcmge v0.2d, v1.2d, v2.2d                 : fcmge  %q1 %q2 $0x03 -> %q0
+6e64e462 : fcmge v2.2d, v3.2d, v4.2d                 : fcmge  %q3 %q4 $0x03 -> %q2
+6e66e4a4 : fcmge v4.2d, v5.2d, v6.2d                 : fcmge  %q5 %q6 $0x03 -> %q4
+6e68e4e6 : fcmge v6.2d, v7.2d, v8.2d                 : fcmge  %q7 %q8 $0x03 -> %q6
+6e6ae528 : fcmge v8.2d, v9.2d, v10.2d                : fcmge  %q9 %q10 $0x03 -> %q8
+6e6ce56a : fcmge v10.2d, v11.2d, v12.2d              : fcmge  %q11 %q12 $0x03 -> %q10
+6e6ee5ac : fcmge v12.2d, v13.2d, v14.2d              : fcmge  %q13 %q14 $0x03 -> %q12
+6e70e5ee : fcmge v14.2d, v15.2d, v16.2d              : fcmge  %q15 %q16 $0x03 -> %q14
+6e72e630 : fcmge v16.2d, v17.2d, v18.2d              : fcmge  %q17 %q18 $0x03 -> %q16
+6e73e651 : fcmge v17.2d, v18.2d, v19.2d              : fcmge  %q18 %q19 $0x03 -> %q17
+6e75e693 : fcmge v19.2d, v20.2d, v21.2d              : fcmge  %q20 %q21 $0x03 -> %q19
+6e77e6d5 : fcmge v21.2d, v22.2d, v23.2d              : fcmge  %q22 %q23 $0x03 -> %q21
+6e79e717 : fcmge v23.2d, v24.2d, v25.2d              : fcmge  %q24 %q25 $0x03 -> %q23
+6e7be759 : fcmge v25.2d, v26.2d, v27.2d              : fcmge  %q26 %q27 $0x03 -> %q25
+6e7de79b : fcmge v27.2d, v28.2d, v29.2d              : fcmge  %q28 %q29 $0x03 -> %q27
+6e61e41f : fcmge v31.2d, v0.2d, v1.2d                : fcmge  %q0 %q1 $0x03 -> %q31
+
 # FCMLT   <V><d>, <V><n>, #0 (FCMLT-V.V-asisdmisc_FZ)
 5ea0e820 : fcmlt s0, s1, #0                          : fcmlt  %s1 $0.000000 -> %s0
 5ea0e862 : fcmlt s2, s3, #0                          : fcmlt  %s3 $0.000000 -> %s2
@@ -29147,6 +31233,56 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 5ee0eb9b : fcmlt d27, d28, #0                        : fcmlt  %d28 $0.000000 -> %d27
 5ee0e81f : fcmlt d31, d0, #0                         : fcmlt  %d0 $0.000000 -> %d31
 
+# FCVTNS  <Dd>.<T>, <Dn>.<T> (FCVTNS-Q.Q-asimdmisc_R)
+0e21a820 : fcvtns v0.2s, v1.2s                       : fcvtns %d1 $0x02 -> %d0
+0e21a862 : fcvtns v2.2s, v3.2s                       : fcvtns %d3 $0x02 -> %d2
+0e21a8a4 : fcvtns v4.2s, v5.2s                       : fcvtns %d5 $0x02 -> %d4
+0e21a8e6 : fcvtns v6.2s, v7.2s                       : fcvtns %d7 $0x02 -> %d6
+0e21a928 : fcvtns v8.2s, v9.2s                       : fcvtns %d9 $0x02 -> %d8
+0e21a96a : fcvtns v10.2s, v11.2s                     : fcvtns %d11 $0x02 -> %d10
+0e21a9ac : fcvtns v12.2s, v13.2s                     : fcvtns %d13 $0x02 -> %d12
+0e21a9ee : fcvtns v14.2s, v15.2s                     : fcvtns %d15 $0x02 -> %d14
+0e21aa30 : fcvtns v16.2s, v17.2s                     : fcvtns %d17 $0x02 -> %d16
+0e21aa51 : fcvtns v17.2s, v18.2s                     : fcvtns %d18 $0x02 -> %d17
+0e21aa93 : fcvtns v19.2s, v20.2s                     : fcvtns %d20 $0x02 -> %d19
+0e21aad5 : fcvtns v21.2s, v22.2s                     : fcvtns %d22 $0x02 -> %d21
+0e21ab17 : fcvtns v23.2s, v24.2s                     : fcvtns %d24 $0x02 -> %d23
+0e21ab59 : fcvtns v25.2s, v26.2s                     : fcvtns %d26 $0x02 -> %d25
+0e21ab9b : fcvtns v27.2s, v28.2s                     : fcvtns %d28 $0x02 -> %d27
+0e21a81f : fcvtns v31.2s, v0.2s                      : fcvtns %d0 $0x02 -> %d31
+4e21a820 : fcvtns v0.4s, v1.4s                       : fcvtns %q1 $0x02 -> %q0
+4e21a862 : fcvtns v2.4s, v3.4s                       : fcvtns %q3 $0x02 -> %q2
+4e21a8a4 : fcvtns v4.4s, v5.4s                       : fcvtns %q5 $0x02 -> %q4
+4e21a8e6 : fcvtns v6.4s, v7.4s                       : fcvtns %q7 $0x02 -> %q6
+4e21a928 : fcvtns v8.4s, v9.4s                       : fcvtns %q9 $0x02 -> %q8
+4e21a96a : fcvtns v10.4s, v11.4s                     : fcvtns %q11 $0x02 -> %q10
+4e21a9ac : fcvtns v12.4s, v13.4s                     : fcvtns %q13 $0x02 -> %q12
+4e21a9ee : fcvtns v14.4s, v15.4s                     : fcvtns %q15 $0x02 -> %q14
+4e21aa30 : fcvtns v16.4s, v17.4s                     : fcvtns %q17 $0x02 -> %q16
+4e21aa51 : fcvtns v17.4s, v18.4s                     : fcvtns %q18 $0x02 -> %q17
+4e21aa93 : fcvtns v19.4s, v20.4s                     : fcvtns %q20 $0x02 -> %q19
+4e21aad5 : fcvtns v21.4s, v22.4s                     : fcvtns %q22 $0x02 -> %q21
+4e21ab17 : fcvtns v23.4s, v24.4s                     : fcvtns %q24 $0x02 -> %q23
+4e21ab59 : fcvtns v25.4s, v26.4s                     : fcvtns %q26 $0x02 -> %q25
+4e21ab9b : fcvtns v27.4s, v28.4s                     : fcvtns %q28 $0x02 -> %q27
+4e21a81f : fcvtns v31.4s, v0.4s                      : fcvtns %q0 $0x02 -> %q31
+4e61a820 : fcvtns v0.2d, v1.2d                       : fcvtns %q1 $0x03 -> %q0
+4e61a862 : fcvtns v2.2d, v3.2d                       : fcvtns %q3 $0x03 -> %q2
+4e61a8a4 : fcvtns v4.2d, v5.2d                       : fcvtns %q5 $0x03 -> %q4
+4e61a8e6 : fcvtns v6.2d, v7.2d                       : fcvtns %q7 $0x03 -> %q6
+4e61a928 : fcvtns v8.2d, v9.2d                       : fcvtns %q9 $0x03 -> %q8
+4e61a96a : fcvtns v10.2d, v11.2d                     : fcvtns %q11 $0x03 -> %q10
+4e61a9ac : fcvtns v12.2d, v13.2d                     : fcvtns %q13 $0x03 -> %q12
+4e61a9ee : fcvtns v14.2d, v15.2d                     : fcvtns %q15 $0x03 -> %q14
+4e61aa30 : fcvtns v16.2d, v17.2d                     : fcvtns %q17 $0x03 -> %q16
+4e61aa51 : fcvtns v17.2d, v18.2d                     : fcvtns %q18 $0x03 -> %q17
+4e61aa93 : fcvtns v19.2d, v20.2d                     : fcvtns %q20 $0x03 -> %q19
+4e61aad5 : fcvtns v21.2d, v22.2d                     : fcvtns %q22 $0x03 -> %q21
+4e61ab17 : fcvtns v23.2d, v24.2d                     : fcvtns %q24 $0x03 -> %q23
+4e61ab59 : fcvtns v25.2d, v26.2d                     : fcvtns %q26 $0x03 -> %q25
+4e61ab9b : fcvtns v27.2d, v28.2d                     : fcvtns %q28 $0x03 -> %q27
+4e61a81f : fcvtns v31.2d, v0.2d                      : fcvtns %q0 $0x03 -> %q31
+
 # FCMP    <Sn>, #0.0 (FCMP-V-SZ_floatcmp)
 1e202008 : fcmp s0, #0.0                             : fcmp   %s0 $0.000000
 1e202048 : fcmp s2, #0.0                             : fcmp   %s2 $0.000000
@@ -29164,6 +31300,124 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 1e202328 : fcmp s25, #0.0                            : fcmp   %s25 $0.000000
 1e202368 : fcmp s27, #0.0                            : fcmp   %s27 $0.000000
 1e2023e8 : fcmp s31, #0.0                            : fcmp   %s31 $0.000000
+
+# FADDP   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FADDP-Q.QQ-asimdsame_only)
+2e22d420 : faddp v0.2s, v1.2s, v2.2s                 : faddp  %d1 %d2 $0x02 -> %d0
+2e24d462 : faddp v2.2s, v3.2s, v4.2s                 : faddp  %d3 %d4 $0x02 -> %d2
+2e26d4a4 : faddp v4.2s, v5.2s, v6.2s                 : faddp  %d5 %d6 $0x02 -> %d4
+2e28d4e6 : faddp v6.2s, v7.2s, v8.2s                 : faddp  %d7 %d8 $0x02 -> %d6
+2e2ad528 : faddp v8.2s, v9.2s, v10.2s                : faddp  %d9 %d10 $0x02 -> %d8
+2e2cd56a : faddp v10.2s, v11.2s, v12.2s              : faddp  %d11 %d12 $0x02 -> %d10
+2e2ed5ac : faddp v12.2s, v13.2s, v14.2s              : faddp  %d13 %d14 $0x02 -> %d12
+2e30d5ee : faddp v14.2s, v15.2s, v16.2s              : faddp  %d15 %d16 $0x02 -> %d14
+2e32d630 : faddp v16.2s, v17.2s, v18.2s              : faddp  %d17 %d18 $0x02 -> %d16
+2e33d651 : faddp v17.2s, v18.2s, v19.2s              : faddp  %d18 %d19 $0x02 -> %d17
+2e35d693 : faddp v19.2s, v20.2s, v21.2s              : faddp  %d20 %d21 $0x02 -> %d19
+2e37d6d5 : faddp v21.2s, v22.2s, v23.2s              : faddp  %d22 %d23 $0x02 -> %d21
+2e39d717 : faddp v23.2s, v24.2s, v25.2s              : faddp  %d24 %d25 $0x02 -> %d23
+2e3bd759 : faddp v25.2s, v26.2s, v27.2s              : faddp  %d26 %d27 $0x02 -> %d25
+2e3dd79b : faddp v27.2s, v28.2s, v29.2s              : faddp  %d28 %d29 $0x02 -> %d27
+2e21d41f : faddp v31.2s, v0.2s, v1.2s                : faddp  %d0 %d1 $0x02 -> %d31
+6e22d420 : faddp v0.4s, v1.4s, v2.4s                 : faddp  %q1 %q2 $0x02 -> %q0
+6e24d462 : faddp v2.4s, v3.4s, v4.4s                 : faddp  %q3 %q4 $0x02 -> %q2
+6e26d4a4 : faddp v4.4s, v5.4s, v6.4s                 : faddp  %q5 %q6 $0x02 -> %q4
+6e28d4e6 : faddp v6.4s, v7.4s, v8.4s                 : faddp  %q7 %q8 $0x02 -> %q6
+6e2ad528 : faddp v8.4s, v9.4s, v10.4s                : faddp  %q9 %q10 $0x02 -> %q8
+6e2cd56a : faddp v10.4s, v11.4s, v12.4s              : faddp  %q11 %q12 $0x02 -> %q10
+6e2ed5ac : faddp v12.4s, v13.4s, v14.4s              : faddp  %q13 %q14 $0x02 -> %q12
+6e30d5ee : faddp v14.4s, v15.4s, v16.4s              : faddp  %q15 %q16 $0x02 -> %q14
+6e32d630 : faddp v16.4s, v17.4s, v18.4s              : faddp  %q17 %q18 $0x02 -> %q16
+6e33d651 : faddp v17.4s, v18.4s, v19.4s              : faddp  %q18 %q19 $0x02 -> %q17
+6e35d693 : faddp v19.4s, v20.4s, v21.4s              : faddp  %q20 %q21 $0x02 -> %q19
+6e37d6d5 : faddp v21.4s, v22.4s, v23.4s              : faddp  %q22 %q23 $0x02 -> %q21
+6e39d717 : faddp v23.4s, v24.4s, v25.4s              : faddp  %q24 %q25 $0x02 -> %q23
+6e3bd759 : faddp v25.4s, v26.4s, v27.4s              : faddp  %q26 %q27 $0x02 -> %q25
+6e3dd79b : faddp v27.4s, v28.4s, v29.4s              : faddp  %q28 %q29 $0x02 -> %q27
+6e21d41f : faddp v31.4s, v0.4s, v1.4s                : faddp  %q0 %q1 $0x02 -> %q31
+6e62d420 : faddp v0.2d, v1.2d, v2.2d                 : faddp  %q1 %q2 $0x03 -> %q0
+6e64d462 : faddp v2.2d, v3.2d, v4.2d                 : faddp  %q3 %q4 $0x03 -> %q2
+6e66d4a4 : faddp v4.2d, v5.2d, v6.2d                 : faddp  %q5 %q6 $0x03 -> %q4
+6e68d4e6 : faddp v6.2d, v7.2d, v8.2d                 : faddp  %q7 %q8 $0x03 -> %q6
+6e6ad528 : faddp v8.2d, v9.2d, v10.2d                : faddp  %q9 %q10 $0x03 -> %q8
+6e6cd56a : faddp v10.2d, v11.2d, v12.2d              : faddp  %q11 %q12 $0x03 -> %q10
+6e6ed5ac : faddp v12.2d, v13.2d, v14.2d              : faddp  %q13 %q14 $0x03 -> %q12
+6e70d5ee : faddp v14.2d, v15.2d, v16.2d              : faddp  %q15 %q16 $0x03 -> %q14
+6e72d630 : faddp v16.2d, v17.2d, v18.2d              : faddp  %q17 %q18 $0x03 -> %q16
+6e73d651 : faddp v17.2d, v18.2d, v19.2d              : faddp  %q18 %q19 $0x03 -> %q17
+6e75d693 : faddp v19.2d, v20.2d, v21.2d              : faddp  %q20 %q21 $0x03 -> %q19
+6e77d6d5 : faddp v21.2d, v22.2d, v23.2d              : faddp  %q22 %q23 $0x03 -> %q21
+6e79d717 : faddp v23.2d, v24.2d, v25.2d              : faddp  %q24 %q25 $0x03 -> %q23
+6e7bd759 : faddp v25.2d, v26.2d, v27.2d              : faddp  %q26 %q27 $0x03 -> %q25
+6e7dd79b : faddp v27.2d, v28.2d, v29.2d              : faddp  %q28 %q29 $0x03 -> %q27
+6e61d41f : faddp v31.2d, v0.2d, v1.2d                : faddp  %q0 %q1 $0x03 -> %q31
+
+# FCVTNU  <Dd>.<T>, <Dn>.<T> (FCVTNU-Q.Q-asimdmisc_R)
+2e21a820 : fcvtnu v0.2s, v1.2s                       : fcvtnu %d1 $0x02 -> %d0
+2e21a862 : fcvtnu v2.2s, v3.2s                       : fcvtnu %d3 $0x02 -> %d2
+2e21a8a4 : fcvtnu v4.2s, v5.2s                       : fcvtnu %d5 $0x02 -> %d4
+2e21a8e6 : fcvtnu v6.2s, v7.2s                       : fcvtnu %d7 $0x02 -> %d6
+2e21a928 : fcvtnu v8.2s, v9.2s                       : fcvtnu %d9 $0x02 -> %d8
+2e21a96a : fcvtnu v10.2s, v11.2s                     : fcvtnu %d11 $0x02 -> %d10
+2e21a9ac : fcvtnu v12.2s, v13.2s                     : fcvtnu %d13 $0x02 -> %d12
+2e21a9ee : fcvtnu v14.2s, v15.2s                     : fcvtnu %d15 $0x02 -> %d14
+2e21aa30 : fcvtnu v16.2s, v17.2s                     : fcvtnu %d17 $0x02 -> %d16
+2e21aa51 : fcvtnu v17.2s, v18.2s                     : fcvtnu %d18 $0x02 -> %d17
+2e21aa93 : fcvtnu v19.2s, v20.2s                     : fcvtnu %d20 $0x02 -> %d19
+2e21aad5 : fcvtnu v21.2s, v22.2s                     : fcvtnu %d22 $0x02 -> %d21
+2e21ab17 : fcvtnu v23.2s, v24.2s                     : fcvtnu %d24 $0x02 -> %d23
+2e21ab59 : fcvtnu v25.2s, v26.2s                     : fcvtnu %d26 $0x02 -> %d25
+2e21ab9b : fcvtnu v27.2s, v28.2s                     : fcvtnu %d28 $0x02 -> %d27
+2e21a81f : fcvtnu v31.2s, v0.2s                      : fcvtnu %d0 $0x02 -> %d31
+6e21a820 : fcvtnu v0.4s, v1.4s                       : fcvtnu %q1 $0x02 -> %q0
+6e21a862 : fcvtnu v2.4s, v3.4s                       : fcvtnu %q3 $0x02 -> %q2
+6e21a8a4 : fcvtnu v4.4s, v5.4s                       : fcvtnu %q5 $0x02 -> %q4
+6e21a8e6 : fcvtnu v6.4s, v7.4s                       : fcvtnu %q7 $0x02 -> %q6
+6e21a928 : fcvtnu v8.4s, v9.4s                       : fcvtnu %q9 $0x02 -> %q8
+6e21a96a : fcvtnu v10.4s, v11.4s                     : fcvtnu %q11 $0x02 -> %q10
+6e21a9ac : fcvtnu v12.4s, v13.4s                     : fcvtnu %q13 $0x02 -> %q12
+6e21a9ee : fcvtnu v14.4s, v15.4s                     : fcvtnu %q15 $0x02 -> %q14
+6e21aa30 : fcvtnu v16.4s, v17.4s                     : fcvtnu %q17 $0x02 -> %q16
+6e21aa51 : fcvtnu v17.4s, v18.4s                     : fcvtnu %q18 $0x02 -> %q17
+6e21aa93 : fcvtnu v19.4s, v20.4s                     : fcvtnu %q20 $0x02 -> %q19
+6e21aad5 : fcvtnu v21.4s, v22.4s                     : fcvtnu %q22 $0x02 -> %q21
+6e21ab17 : fcvtnu v23.4s, v24.4s                     : fcvtnu %q24 $0x02 -> %q23
+6e21ab59 : fcvtnu v25.4s, v26.4s                     : fcvtnu %q26 $0x02 -> %q25
+6e21ab9b : fcvtnu v27.4s, v28.4s                     : fcvtnu %q28 $0x02 -> %q27
+6e21a81f : fcvtnu v31.4s, v0.4s                      : fcvtnu %q0 $0x02 -> %q31
+6e61a820 : fcvtnu v0.2d, v1.2d                       : fcvtnu %q1 $0x03 -> %q0
+6e61a862 : fcvtnu v2.2d, v3.2d                       : fcvtnu %q3 $0x03 -> %q2
+6e61a8a4 : fcvtnu v4.2d, v5.2d                       : fcvtnu %q5 $0x03 -> %q4
+6e61a8e6 : fcvtnu v6.2d, v7.2d                       : fcvtnu %q7 $0x03 -> %q6
+6e61a928 : fcvtnu v8.2d, v9.2d                       : fcvtnu %q9 $0x03 -> %q8
+6e61a96a : fcvtnu v10.2d, v11.2d                     : fcvtnu %q11 $0x03 -> %q10
+6e61a9ac : fcvtnu v12.2d, v13.2d                     : fcvtnu %q13 $0x03 -> %q12
+6e61a9ee : fcvtnu v14.2d, v15.2d                     : fcvtnu %q15 $0x03 -> %q14
+6e61aa30 : fcvtnu v16.2d, v17.2d                     : fcvtnu %q17 $0x03 -> %q16
+6e61aa51 : fcvtnu v17.2d, v18.2d                     : fcvtnu %q18 $0x03 -> %q17
+6e61aa93 : fcvtnu v19.2d, v20.2d                     : fcvtnu %q20 $0x03 -> %q19
+6e61aad5 : fcvtnu v21.2d, v22.2d                     : fcvtnu %q22 $0x03 -> %q21
+6e61ab17 : fcvtnu v23.2d, v24.2d                     : fcvtnu %q24 $0x03 -> %q23
+6e61ab59 : fcvtnu v25.2d, v26.2d                     : fcvtnu %q26 $0x03 -> %q25
+6e61ab9b : fcvtnu v27.2d, v28.2d                     : fcvtnu %q28 $0x03 -> %q27
+6e61a81f : fcvtnu v31.2d, v0.2d                      : fcvtnu %q0 $0x03 -> %q31
+
+# FMAXV   <Sd>, <Sn>.4S (FMAXV-V.Q-asimdall_only)
+6e30f820 : fmaxv s0, v1.4s                           : fmaxv  %q1 $0x02 -> %s0
+6e30f862 : fmaxv s2, v3.4s                           : fmaxv  %q3 $0x02 -> %s2
+6e30f8a4 : fmaxv s4, v5.4s                           : fmaxv  %q5 $0x02 -> %s4
+6e30f8e6 : fmaxv s6, v7.4s                           : fmaxv  %q7 $0x02 -> %s6
+6e30f928 : fmaxv s8, v9.4s                           : fmaxv  %q9 $0x02 -> %s8
+6e30f96a : fmaxv s10, v11.4s                         : fmaxv  %q11 $0x02 -> %s10
+6e30f9ac : fmaxv s12, v13.4s                         : fmaxv  %q13 $0x02 -> %s12
+6e30f9ee : fmaxv s14, v15.4s                         : fmaxv  %q15 $0x02 -> %s14
+6e30fa30 : fmaxv s16, v17.4s                         : fmaxv  %q17 $0x02 -> %s16
+6e30fa51 : fmaxv s17, v18.4s                         : fmaxv  %q18 $0x02 -> %s17
+6e30fa93 : fmaxv s19, v20.4s                         : fmaxv  %q20 $0x02 -> %s19
+6e30fad5 : fmaxv s21, v22.4s                         : fmaxv  %q22 $0x02 -> %s21
+6e30fb17 : fmaxv s23, v24.4s                         : fmaxv  %q24 $0x02 -> %s23
+6e30fb59 : fmaxv s25, v26.4s                         : fmaxv  %q26 $0x02 -> %s25
+6e30fb9b : fmaxv s27, v28.4s                         : fmaxv  %q28 $0x02 -> %s27
+6e30f81f : fmaxv s31, v0.4s                          : fmaxv  %q0 $0x02 -> %s31
 
 # FCMLT   <Dd>.<T>, <Dn>.<T>, #0 (FCMLT-Q.Q-asimdmisc_FZ)
 0ea0e820 : fcmlt v0.2s, v1.2s, #0                    : fcmlt  %d1 $0.000000 $0x02 -> %d0
@@ -29215,6 +31469,224 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 4ee0eb9b : fcmlt v27.2d, v28.2d, #0                  : fcmlt  %q28 $0.000000 $0x03 -> %q27
 4ee0e81f : fcmlt v31.2d, v0.2d, #0                   : fcmlt  %q0 $0.000000 $0x03 -> %q31
 
+# FRINTA  <Dd>.<T>, <Dn>.<T> (FRINTA-Q.Q-asimdmisc_R)
+2e218820 : frinta v0.2s, v1.2s                       : frinta %d1 $0x02 -> %d0
+2e218862 : frinta v2.2s, v3.2s                       : frinta %d3 $0x02 -> %d2
+2e2188a4 : frinta v4.2s, v5.2s                       : frinta %d5 $0x02 -> %d4
+2e2188e6 : frinta v6.2s, v7.2s                       : frinta %d7 $0x02 -> %d6
+2e218928 : frinta v8.2s, v9.2s                       : frinta %d9 $0x02 -> %d8
+2e21896a : frinta v10.2s, v11.2s                     : frinta %d11 $0x02 -> %d10
+2e2189ac : frinta v12.2s, v13.2s                     : frinta %d13 $0x02 -> %d12
+2e2189ee : frinta v14.2s, v15.2s                     : frinta %d15 $0x02 -> %d14
+2e218a30 : frinta v16.2s, v17.2s                     : frinta %d17 $0x02 -> %d16
+2e218a51 : frinta v17.2s, v18.2s                     : frinta %d18 $0x02 -> %d17
+2e218a93 : frinta v19.2s, v20.2s                     : frinta %d20 $0x02 -> %d19
+2e218ad5 : frinta v21.2s, v22.2s                     : frinta %d22 $0x02 -> %d21
+2e218b17 : frinta v23.2s, v24.2s                     : frinta %d24 $0x02 -> %d23
+2e218b59 : frinta v25.2s, v26.2s                     : frinta %d26 $0x02 -> %d25
+2e218b9b : frinta v27.2s, v28.2s                     : frinta %d28 $0x02 -> %d27
+2e21881f : frinta v31.2s, v0.2s                      : frinta %d0 $0x02 -> %d31
+6e218820 : frinta v0.4s, v1.4s                       : frinta %q1 $0x02 -> %q0
+6e218862 : frinta v2.4s, v3.4s                       : frinta %q3 $0x02 -> %q2
+6e2188a4 : frinta v4.4s, v5.4s                       : frinta %q5 $0x02 -> %q4
+6e2188e6 : frinta v6.4s, v7.4s                       : frinta %q7 $0x02 -> %q6
+6e218928 : frinta v8.4s, v9.4s                       : frinta %q9 $0x02 -> %q8
+6e21896a : frinta v10.4s, v11.4s                     : frinta %q11 $0x02 -> %q10
+6e2189ac : frinta v12.4s, v13.4s                     : frinta %q13 $0x02 -> %q12
+6e2189ee : frinta v14.4s, v15.4s                     : frinta %q15 $0x02 -> %q14
+6e218a30 : frinta v16.4s, v17.4s                     : frinta %q17 $0x02 -> %q16
+6e218a51 : frinta v17.4s, v18.4s                     : frinta %q18 $0x02 -> %q17
+6e218a93 : frinta v19.4s, v20.4s                     : frinta %q20 $0x02 -> %q19
+6e218ad5 : frinta v21.4s, v22.4s                     : frinta %q22 $0x02 -> %q21
+6e218b17 : frinta v23.4s, v24.4s                     : frinta %q24 $0x02 -> %q23
+6e218b59 : frinta v25.4s, v26.4s                     : frinta %q26 $0x02 -> %q25
+6e218b9b : frinta v27.4s, v28.4s                     : frinta %q28 $0x02 -> %q27
+6e21881f : frinta v31.4s, v0.4s                      : frinta %q0 $0x02 -> %q31
+6e618820 : frinta v0.2d, v1.2d                       : frinta %q1 $0x03 -> %q0
+6e618862 : frinta v2.2d, v3.2d                       : frinta %q3 $0x03 -> %q2
+6e6188a4 : frinta v4.2d, v5.2d                       : frinta %q5 $0x03 -> %q4
+6e6188e6 : frinta v6.2d, v7.2d                       : frinta %q7 $0x03 -> %q6
+6e618928 : frinta v8.2d, v9.2d                       : frinta %q9 $0x03 -> %q8
+6e61896a : frinta v10.2d, v11.2d                     : frinta %q11 $0x03 -> %q10
+6e6189ac : frinta v12.2d, v13.2d                     : frinta %q13 $0x03 -> %q12
+6e6189ee : frinta v14.2d, v15.2d                     : frinta %q15 $0x03 -> %q14
+6e618a30 : frinta v16.2d, v17.2d                     : frinta %q17 $0x03 -> %q16
+6e618a51 : frinta v17.2d, v18.2d                     : frinta %q18 $0x03 -> %q17
+6e618a93 : frinta v19.2d, v20.2d                     : frinta %q20 $0x03 -> %q19
+6e618ad5 : frinta v21.2d, v22.2d                     : frinta %q22 $0x03 -> %q21
+6e618b17 : frinta v23.2d, v24.2d                     : frinta %q24 $0x03 -> %q23
+6e618b59 : frinta v25.2d, v26.2d                     : frinta %q26 $0x03 -> %q25
+6e618b9b : frinta v27.2d, v28.2d                     : frinta %q28 $0x03 -> %q27
+6e61881f : frinta v31.2d, v0.2d                      : frinta %q0 $0x03 -> %q31
+
+# FMAXNMP <V><d>, <Sn>.<T> (FMAXNMP-V.Q-asisdpair_only)
+7e30c820 : fmaxnmp s0, v1.2s                         : fmaxnmp %d1 $0x02 -> %s0
+7e30c862 : fmaxnmp s2, v3.2s                         : fmaxnmp %d3 $0x02 -> %s2
+7e30c8a4 : fmaxnmp s4, v5.2s                         : fmaxnmp %d5 $0x02 -> %s4
+7e30c8e6 : fmaxnmp s6, v7.2s                         : fmaxnmp %d7 $0x02 -> %s6
+7e30c928 : fmaxnmp s8, v9.2s                         : fmaxnmp %d9 $0x02 -> %s8
+7e30c96a : fmaxnmp s10, v11.2s                       : fmaxnmp %d11 $0x02 -> %s10
+7e30c9ac : fmaxnmp s12, v13.2s                       : fmaxnmp %d13 $0x02 -> %s12
+7e30c9ee : fmaxnmp s14, v15.2s                       : fmaxnmp %d15 $0x02 -> %s14
+7e30ca30 : fmaxnmp s16, v17.2s                       : fmaxnmp %d17 $0x02 -> %s16
+7e30ca51 : fmaxnmp s17, v18.2s                       : fmaxnmp %d18 $0x02 -> %s17
+7e30ca93 : fmaxnmp s19, v20.2s                       : fmaxnmp %d20 $0x02 -> %s19
+7e30cad5 : fmaxnmp s21, v22.2s                       : fmaxnmp %d22 $0x02 -> %s21
+7e30cb17 : fmaxnmp s23, v24.2s                       : fmaxnmp %d24 $0x02 -> %s23
+7e30cb59 : fmaxnmp s25, v26.2s                       : fmaxnmp %d26 $0x02 -> %s25
+7e30cb9b : fmaxnmp s27, v28.2s                       : fmaxnmp %d28 $0x02 -> %s27
+7e30c81f : fmaxnmp s31, v0.2s                        : fmaxnmp %d0 $0x02 -> %s31
+7e70c820 : fmaxnmp d0, v1.2d                         : fmaxnmp %q1 $0x03 -> %d0
+7e70c862 : fmaxnmp d2, v3.2d                         : fmaxnmp %q3 $0x03 -> %d2
+7e70c8a4 : fmaxnmp d4, v5.2d                         : fmaxnmp %q5 $0x03 -> %d4
+7e70c8e6 : fmaxnmp d6, v7.2d                         : fmaxnmp %q7 $0x03 -> %d6
+7e70c928 : fmaxnmp d8, v9.2d                         : fmaxnmp %q9 $0x03 -> %d8
+7e70c96a : fmaxnmp d10, v11.2d                       : fmaxnmp %q11 $0x03 -> %d10
+7e70c9ac : fmaxnmp d12, v13.2d                       : fmaxnmp %q13 $0x03 -> %d12
+7e70c9ee : fmaxnmp d14, v15.2d                       : fmaxnmp %q15 $0x03 -> %d14
+7e70ca30 : fmaxnmp d16, v17.2d                       : fmaxnmp %q17 $0x03 -> %d16
+7e70ca51 : fmaxnmp d17, v18.2d                       : fmaxnmp %q18 $0x03 -> %d17
+7e70ca93 : fmaxnmp d19, v20.2d                       : fmaxnmp %q20 $0x03 -> %d19
+7e70cad5 : fmaxnmp d21, v22.2d                       : fmaxnmp %q22 $0x03 -> %d21
+7e70cb17 : fmaxnmp d23, v24.2d                       : fmaxnmp %q24 $0x03 -> %d23
+7e70cb59 : fmaxnmp d25, v26.2d                       : fmaxnmp %q26 $0x03 -> %d25
+7e70cb9b : fmaxnmp d27, v28.2d                       : fmaxnmp %q28 $0x03 -> %d27
+7e70c81f : fmaxnmp d31, v0.2d                        : fmaxnmp %q0 $0x03 -> %d31
+
+# FMAXP   <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMAXP-Q.QQ-asimdsame_only)
+2e22f420 : fmaxp v0.2s, v1.2s, v2.2s                 : fmaxp  %d1 %d2 $0x02 -> %d0
+2e24f462 : fmaxp v2.2s, v3.2s, v4.2s                 : fmaxp  %d3 %d4 $0x02 -> %d2
+2e26f4a4 : fmaxp v4.2s, v5.2s, v6.2s                 : fmaxp  %d5 %d6 $0x02 -> %d4
+2e28f4e6 : fmaxp v6.2s, v7.2s, v8.2s                 : fmaxp  %d7 %d8 $0x02 -> %d6
+2e2af528 : fmaxp v8.2s, v9.2s, v10.2s                : fmaxp  %d9 %d10 $0x02 -> %d8
+2e2cf56a : fmaxp v10.2s, v11.2s, v12.2s              : fmaxp  %d11 %d12 $0x02 -> %d10
+2e2ef5ac : fmaxp v12.2s, v13.2s, v14.2s              : fmaxp  %d13 %d14 $0x02 -> %d12
+2e30f5ee : fmaxp v14.2s, v15.2s, v16.2s              : fmaxp  %d15 %d16 $0x02 -> %d14
+2e32f630 : fmaxp v16.2s, v17.2s, v18.2s              : fmaxp  %d17 %d18 $0x02 -> %d16
+2e33f651 : fmaxp v17.2s, v18.2s, v19.2s              : fmaxp  %d18 %d19 $0x02 -> %d17
+2e35f693 : fmaxp v19.2s, v20.2s, v21.2s              : fmaxp  %d20 %d21 $0x02 -> %d19
+2e37f6d5 : fmaxp v21.2s, v22.2s, v23.2s              : fmaxp  %d22 %d23 $0x02 -> %d21
+2e39f717 : fmaxp v23.2s, v24.2s, v25.2s              : fmaxp  %d24 %d25 $0x02 -> %d23
+2e3bf759 : fmaxp v25.2s, v26.2s, v27.2s              : fmaxp  %d26 %d27 $0x02 -> %d25
+2e3df79b : fmaxp v27.2s, v28.2s, v29.2s              : fmaxp  %d28 %d29 $0x02 -> %d27
+2e21f41f : fmaxp v31.2s, v0.2s, v1.2s                : fmaxp  %d0 %d1 $0x02 -> %d31
+6e22f420 : fmaxp v0.4s, v1.4s, v2.4s                 : fmaxp  %q1 %q2 $0x02 -> %q0
+6e24f462 : fmaxp v2.4s, v3.4s, v4.4s                 : fmaxp  %q3 %q4 $0x02 -> %q2
+6e26f4a4 : fmaxp v4.4s, v5.4s, v6.4s                 : fmaxp  %q5 %q6 $0x02 -> %q4
+6e28f4e6 : fmaxp v6.4s, v7.4s, v8.4s                 : fmaxp  %q7 %q8 $0x02 -> %q6
+6e2af528 : fmaxp v8.4s, v9.4s, v10.4s                : fmaxp  %q9 %q10 $0x02 -> %q8
+6e2cf56a : fmaxp v10.4s, v11.4s, v12.4s              : fmaxp  %q11 %q12 $0x02 -> %q10
+6e2ef5ac : fmaxp v12.4s, v13.4s, v14.4s              : fmaxp  %q13 %q14 $0x02 -> %q12
+6e30f5ee : fmaxp v14.4s, v15.4s, v16.4s              : fmaxp  %q15 %q16 $0x02 -> %q14
+6e32f630 : fmaxp v16.4s, v17.4s, v18.4s              : fmaxp  %q17 %q18 $0x02 -> %q16
+6e33f651 : fmaxp v17.4s, v18.4s, v19.4s              : fmaxp  %q18 %q19 $0x02 -> %q17
+6e35f693 : fmaxp v19.4s, v20.4s, v21.4s              : fmaxp  %q20 %q21 $0x02 -> %q19
+6e37f6d5 : fmaxp v21.4s, v22.4s, v23.4s              : fmaxp  %q22 %q23 $0x02 -> %q21
+6e39f717 : fmaxp v23.4s, v24.4s, v25.4s              : fmaxp  %q24 %q25 $0x02 -> %q23
+6e3bf759 : fmaxp v25.4s, v26.4s, v27.4s              : fmaxp  %q26 %q27 $0x02 -> %q25
+6e3df79b : fmaxp v27.4s, v28.4s, v29.4s              : fmaxp  %q28 %q29 $0x02 -> %q27
+6e21f41f : fmaxp v31.4s, v0.4s, v1.4s                : fmaxp  %q0 %q1 $0x02 -> %q31
+6e62f420 : fmaxp v0.2d, v1.2d, v2.2d                 : fmaxp  %q1 %q2 $0x03 -> %q0
+6e64f462 : fmaxp v2.2d, v3.2d, v4.2d                 : fmaxp  %q3 %q4 $0x03 -> %q2
+6e66f4a4 : fmaxp v4.2d, v5.2d, v6.2d                 : fmaxp  %q5 %q6 $0x03 -> %q4
+6e68f4e6 : fmaxp v6.2d, v7.2d, v8.2d                 : fmaxp  %q7 %q8 $0x03 -> %q6
+6e6af528 : fmaxp v8.2d, v9.2d, v10.2d                : fmaxp  %q9 %q10 $0x03 -> %q8
+6e6cf56a : fmaxp v10.2d, v11.2d, v12.2d              : fmaxp  %q11 %q12 $0x03 -> %q10
+6e6ef5ac : fmaxp v12.2d, v13.2d, v14.2d              : fmaxp  %q13 %q14 $0x03 -> %q12
+6e70f5ee : fmaxp v14.2d, v15.2d, v16.2d              : fmaxp  %q15 %q16 $0x03 -> %q14
+6e72f630 : fmaxp v16.2d, v17.2d, v18.2d              : fmaxp  %q17 %q18 $0x03 -> %q16
+6e73f651 : fmaxp v17.2d, v18.2d, v19.2d              : fmaxp  %q18 %q19 $0x03 -> %q17
+6e75f693 : fmaxp v19.2d, v20.2d, v21.2d              : fmaxp  %q20 %q21 $0x03 -> %q19
+6e77f6d5 : fmaxp v21.2d, v22.2d, v23.2d              : fmaxp  %q22 %q23 $0x03 -> %q21
+6e79f717 : fmaxp v23.2d, v24.2d, v25.2d              : fmaxp  %q24 %q25 $0x03 -> %q23
+6e7bf759 : fmaxp v25.2d, v26.2d, v27.2d              : fmaxp  %q26 %q27 $0x03 -> %q25
+6e7df79b : fmaxp v27.2d, v28.2d, v29.2d              : fmaxp  %q28 %q29 $0x03 -> %q27
+6e61f41f : fmaxp v31.2d, v0.2d, v1.2d                : fmaxp  %q0 %q1 $0x03 -> %q31
+
+# FMLA    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMLA-Q.QQ-asimdsame_only)
+0e22cc20 : fmla v0.2s, v1.2s, v2.2s                  : fmla   %d0 %d1 %d2 $0x02 -> %d0
+0e24cc62 : fmla v2.2s, v3.2s, v4.2s                  : fmla   %d2 %d3 %d4 $0x02 -> %d2
+0e26cca4 : fmla v4.2s, v5.2s, v6.2s                  : fmla   %d4 %d5 %d6 $0x02 -> %d4
+0e28cce6 : fmla v6.2s, v7.2s, v8.2s                  : fmla   %d6 %d7 %d8 $0x02 -> %d6
+0e2acd28 : fmla v8.2s, v9.2s, v10.2s                 : fmla   %d8 %d9 %d10 $0x02 -> %d8
+0e2ccd6a : fmla v10.2s, v11.2s, v12.2s               : fmla   %d10 %d11 %d12 $0x02 -> %d10
+0e2ecdac : fmla v12.2s, v13.2s, v14.2s               : fmla   %d12 %d13 %d14 $0x02 -> %d12
+0e30cdee : fmla v14.2s, v15.2s, v16.2s               : fmla   %d14 %d15 %d16 $0x02 -> %d14
+0e32ce30 : fmla v16.2s, v17.2s, v18.2s               : fmla   %d16 %d17 %d18 $0x02 -> %d16
+0e33ce51 : fmla v17.2s, v18.2s, v19.2s               : fmla   %d17 %d18 %d19 $0x02 -> %d17
+0e35ce93 : fmla v19.2s, v20.2s, v21.2s               : fmla   %d19 %d20 %d21 $0x02 -> %d19
+0e37ced5 : fmla v21.2s, v22.2s, v23.2s               : fmla   %d21 %d22 %d23 $0x02 -> %d21
+0e39cf17 : fmla v23.2s, v24.2s, v25.2s               : fmla   %d23 %d24 %d25 $0x02 -> %d23
+0e3bcf59 : fmla v25.2s, v26.2s, v27.2s               : fmla   %d25 %d26 %d27 $0x02 -> %d25
+0e3dcf9b : fmla v27.2s, v28.2s, v29.2s               : fmla   %d27 %d28 %d29 $0x02 -> %d27
+0e21cc1f : fmla v31.2s, v0.2s, v1.2s                 : fmla   %d31 %d0 %d1 $0x02 -> %d31
+4e22cc20 : fmla v0.4s, v1.4s, v2.4s                  : fmla   %q0 %q1 %q2 $0x02 -> %q0
+4e24cc62 : fmla v2.4s, v3.4s, v4.4s                  : fmla   %q2 %q3 %q4 $0x02 -> %q2
+4e26cca4 : fmla v4.4s, v5.4s, v6.4s                  : fmla   %q4 %q5 %q6 $0x02 -> %q4
+4e28cce6 : fmla v6.4s, v7.4s, v8.4s                  : fmla   %q6 %q7 %q8 $0x02 -> %q6
+4e2acd28 : fmla v8.4s, v9.4s, v10.4s                 : fmla   %q8 %q9 %q10 $0x02 -> %q8
+4e2ccd6a : fmla v10.4s, v11.4s, v12.4s               : fmla   %q10 %q11 %q12 $0x02 -> %q10
+4e2ecdac : fmla v12.4s, v13.4s, v14.4s               : fmla   %q12 %q13 %q14 $0x02 -> %q12
+4e30cdee : fmla v14.4s, v15.4s, v16.4s               : fmla   %q14 %q15 %q16 $0x02 -> %q14
+4e32ce30 : fmla v16.4s, v17.4s, v18.4s               : fmla   %q16 %q17 %q18 $0x02 -> %q16
+4e33ce51 : fmla v17.4s, v18.4s, v19.4s               : fmla   %q17 %q18 %q19 $0x02 -> %q17
+4e35ce93 : fmla v19.4s, v20.4s, v21.4s               : fmla   %q19 %q20 %q21 $0x02 -> %q19
+4e37ced5 : fmla v21.4s, v22.4s, v23.4s               : fmla   %q21 %q22 %q23 $0x02 -> %q21
+4e39cf17 : fmla v23.4s, v24.4s, v25.4s               : fmla   %q23 %q24 %q25 $0x02 -> %q23
+4e3bcf59 : fmla v25.4s, v26.4s, v27.4s               : fmla   %q25 %q26 %q27 $0x02 -> %q25
+4e3dcf9b : fmla v27.4s, v28.4s, v29.4s               : fmla   %q27 %q28 %q29 $0x02 -> %q27
+4e21cc1f : fmla v31.4s, v0.4s, v1.4s                 : fmla   %q31 %q0 %q1 $0x02 -> %q31
+4e62cc20 : fmla v0.2d, v1.2d, v2.2d                  : fmla   %q0 %q1 %q2 $0x03 -> %q0
+4e64cc62 : fmla v2.2d, v3.2d, v4.2d                  : fmla   %q2 %q3 %q4 $0x03 -> %q2
+4e66cca4 : fmla v4.2d, v5.2d, v6.2d                  : fmla   %q4 %q5 %q6 $0x03 -> %q4
+4e68cce6 : fmla v6.2d, v7.2d, v8.2d                  : fmla   %q6 %q7 %q8 $0x03 -> %q6
+4e6acd28 : fmla v8.2d, v9.2d, v10.2d                 : fmla   %q8 %q9 %q10 $0x03 -> %q8
+4e6ccd6a : fmla v10.2d, v11.2d, v12.2d               : fmla   %q10 %q11 %q12 $0x03 -> %q10
+4e6ecdac : fmla v12.2d, v13.2d, v14.2d               : fmla   %q12 %q13 %q14 $0x03 -> %q12
+4e70cdee : fmla v14.2d, v15.2d, v16.2d               : fmla   %q14 %q15 %q16 $0x03 -> %q14
+4e72ce30 : fmla v16.2d, v17.2d, v18.2d               : fmla   %q16 %q17 %q18 $0x03 -> %q16
+4e73ce51 : fmla v17.2d, v18.2d, v19.2d               : fmla   %q17 %q18 %q19 $0x03 -> %q17
+4e75ce93 : fmla v19.2d, v20.2d, v21.2d               : fmla   %q19 %q20 %q21 $0x03 -> %q19
+4e77ced5 : fmla v21.2d, v22.2d, v23.2d               : fmla   %q21 %q22 %q23 $0x03 -> %q21
+4e79cf17 : fmla v23.2d, v24.2d, v25.2d               : fmla   %q23 %q24 %q25 $0x03 -> %q23
+4e7bcf59 : fmla v25.2d, v26.2d, v27.2d               : fmla   %q25 %q26 %q27 $0x03 -> %q25
+4e7dcf9b : fmla v27.2d, v28.2d, v29.2d               : fmla   %q27 %q28 %q29 $0x03 -> %q27
+4e61cc1f : fmla v31.2d, v0.2d, v1.2d                 : fmla   %q31 %q0 %q1 $0x03 -> %q31
+
+# FMINNMP <V><d>, <Sn>.<T> (FMINNMP-V.Q-asisdpair_only)
+7eb0c820 : fminnmp s0, v1.2s                         : fminnmp %d1 $0x02 -> %s0
+7eb0c862 : fminnmp s2, v3.2s                         : fminnmp %d3 $0x02 -> %s2
+7eb0c8a4 : fminnmp s4, v5.2s                         : fminnmp %d5 $0x02 -> %s4
+7eb0c8e6 : fminnmp s6, v7.2s                         : fminnmp %d7 $0x02 -> %s6
+7eb0c928 : fminnmp s8, v9.2s                         : fminnmp %d9 $0x02 -> %s8
+7eb0c96a : fminnmp s10, v11.2s                       : fminnmp %d11 $0x02 -> %s10
+7eb0c9ac : fminnmp s12, v13.2s                       : fminnmp %d13 $0x02 -> %s12
+7eb0c9ee : fminnmp s14, v15.2s                       : fminnmp %d15 $0x02 -> %s14
+7eb0ca30 : fminnmp s16, v17.2s                       : fminnmp %d17 $0x02 -> %s16
+7eb0ca51 : fminnmp s17, v18.2s                       : fminnmp %d18 $0x02 -> %s17
+7eb0ca93 : fminnmp s19, v20.2s                       : fminnmp %d20 $0x02 -> %s19
+7eb0cad5 : fminnmp s21, v22.2s                       : fminnmp %d22 $0x02 -> %s21
+7eb0cb17 : fminnmp s23, v24.2s                       : fminnmp %d24 $0x02 -> %s23
+7eb0cb59 : fminnmp s25, v26.2s                       : fminnmp %d26 $0x02 -> %s25
+7eb0cb9b : fminnmp s27, v28.2s                       : fminnmp %d28 $0x02 -> %s27
+7eb0c81f : fminnmp s31, v0.2s                        : fminnmp %d0 $0x02 -> %s31
+7ef0c820 : fminnmp d0, v1.2d                         : fminnmp %q1 $0x03 -> %d0
+7ef0c862 : fminnmp d2, v3.2d                         : fminnmp %q3 $0x03 -> %d2
+7ef0c8a4 : fminnmp d4, v5.2d                         : fminnmp %q5 $0x03 -> %d4
+7ef0c8e6 : fminnmp d6, v7.2d                         : fminnmp %q7 $0x03 -> %d6
+7ef0c928 : fminnmp d8, v9.2d                         : fminnmp %q9 $0x03 -> %d8
+7ef0c96a : fminnmp d10, v11.2d                       : fminnmp %q11 $0x03 -> %d10
+7ef0c9ac : fminnmp d12, v13.2d                       : fminnmp %q13 $0x03 -> %d12
+7ef0c9ee : fminnmp d14, v15.2d                       : fminnmp %q15 $0x03 -> %d14
+7ef0ca30 : fminnmp d16, v17.2d                       : fminnmp %q17 $0x03 -> %d16
+7ef0ca51 : fminnmp d17, v18.2d                       : fminnmp %q18 $0x03 -> %d17
+7ef0ca93 : fminnmp d19, v20.2d                       : fminnmp %q20 $0x03 -> %d19
+7ef0cad5 : fminnmp d21, v22.2d                       : fminnmp %q22 $0x03 -> %d21
+7ef0cb17 : fminnmp d23, v24.2d                       : fminnmp %q24 $0x03 -> %d23
+7ef0cb59 : fminnmp d25, v26.2d                       : fminnmp %q26 $0x03 -> %d25
+7ef0cb9b : fminnmp d27, v28.2d                       : fminnmp %q28 $0x03 -> %d27
+7ef0c81f : fminnmp d31, v0.2d                        : fminnmp %q0 $0x03 -> %d31
+
 # FCMLE   <Dd>.<T>, <Dn>.<T>, #0 (FCMLE-Q.Q-asimdmisc_FZ)
 2ea0d820 : fcmle v0.2s, v1.2s, #0                    : fcmle  %d1 $0.000000 $0x02 -> %d0
 2ea0d862 : fcmle v2.2s, v3.2s, #0                    : fcmle  %d3 $0.000000 $0x02 -> %d2
@@ -29265,6 +31737,276 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 6ee0db9b : fcmle v27.2d, v28.2d, #0                  : fcmle  %q28 $0.000000 $0x03 -> %q27
 6ee0d81f : fcmle v31.2d, v0.2d, #0                   : fcmle  %q0 $0.000000 $0x03 -> %q31
 
+# FMOV    <Dd>.2D, #<imm> (FMOV-Q.I-asimdimm_D2_d)
+6f04f400 : fmov v0.2d, #-2.0                         : fmov   $-2.000000 $0x03 -> %q0
+6f04f442 : fmov v2.2d, #-2.25                        : fmov   $-2.250000 $0x03 -> %q2
+6f04f484 : fmov v4.2d, #-2.5                         : fmov   $-2.500000 $0x03 -> %q4
+6f04f4c6 : fmov v6.2d, #-2.75                        : fmov   $-2.750000 $0x03 -> %q6
+6f04f508 : fmov v8.2d, #-3.0                         : fmov   $-3.000000 $0x03 -> %q8
+6f04f54a : fmov v10.2d, #-3.25                       : fmov   $-3.250000 $0x03 -> %q10
+6f04f58c : fmov v12.2d, #-3.5                        : fmov   $-3.500000 $0x03 -> %q12
+6f04f5ce : fmov v14.2d, #-3.75                       : fmov   $-3.750000 $0x03 -> %q14
+6f00f410 : fmov v16.2d, #2.0                         : fmov   $2.000000 $0x03 -> %q16
+6f03f631 : fmov v17.2d, #1.0625                      : fmov   $1.062500 $0x03 -> %q17
+6f03f673 : fmov v19.2d, #1.1875                      : fmov   $1.187500 $0x03 -> %q19
+6f03f6b5 : fmov v21.2d, #1.3125                      : fmov   $1.312500 $0x03 -> %q21
+6f03f6f7 : fmov v23.2d, #1.4375                      : fmov   $1.437500 $0x03 -> %q23
+6f03f739 : fmov v25.2d, #1.5625                      : fmov   $1.562500 $0x03 -> %q25
+6f03f77b : fmov v27.2d, #1.6875                      : fmov   $1.687500 $0x03 -> %q27
+6f03f7ff : fmov v31.2d, #1.9375                      : fmov   $1.937500 $0x03 -> %q31
+
+# FMIN    <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMIN-Q.QQ-asimdsame_only)
+0ea2f420 : fmin v0.2s, v1.2s, v2.2s                  : fmin   %d1 %d2 $0x02 -> %d0
+0ea4f462 : fmin v2.2s, v3.2s, v4.2s                  : fmin   %d3 %d4 $0x02 -> %d2
+0ea6f4a4 : fmin v4.2s, v5.2s, v6.2s                  : fmin   %d5 %d6 $0x02 -> %d4
+0ea8f4e6 : fmin v6.2s, v7.2s, v8.2s                  : fmin   %d7 %d8 $0x02 -> %d6
+0eaaf528 : fmin v8.2s, v9.2s, v10.2s                 : fmin   %d9 %d10 $0x02 -> %d8
+0eacf56a : fmin v10.2s, v11.2s, v12.2s               : fmin   %d11 %d12 $0x02 -> %d10
+0eaef5ac : fmin v12.2s, v13.2s, v14.2s               : fmin   %d13 %d14 $0x02 -> %d12
+0eb0f5ee : fmin v14.2s, v15.2s, v16.2s               : fmin   %d15 %d16 $0x02 -> %d14
+0eb2f630 : fmin v16.2s, v17.2s, v18.2s               : fmin   %d17 %d18 $0x02 -> %d16
+0eb3f651 : fmin v17.2s, v18.2s, v19.2s               : fmin   %d18 %d19 $0x02 -> %d17
+0eb5f693 : fmin v19.2s, v20.2s, v21.2s               : fmin   %d20 %d21 $0x02 -> %d19
+0eb7f6d5 : fmin v21.2s, v22.2s, v23.2s               : fmin   %d22 %d23 $0x02 -> %d21
+0eb9f717 : fmin v23.2s, v24.2s, v25.2s               : fmin   %d24 %d25 $0x02 -> %d23
+0ebbf759 : fmin v25.2s, v26.2s, v27.2s               : fmin   %d26 %d27 $0x02 -> %d25
+0ebdf79b : fmin v27.2s, v28.2s, v29.2s               : fmin   %d28 %d29 $0x02 -> %d27
+0ea1f41f : fmin v31.2s, v0.2s, v1.2s                 : fmin   %d0 %d1 $0x02 -> %d31
+4ea2f420 : fmin v0.4s, v1.4s, v2.4s                  : fmin   %q1 %q2 $0x02 -> %q0
+4ea4f462 : fmin v2.4s, v3.4s, v4.4s                  : fmin   %q3 %q4 $0x02 -> %q2
+4ea6f4a4 : fmin v4.4s, v5.4s, v6.4s                  : fmin   %q5 %q6 $0x02 -> %q4
+4ea8f4e6 : fmin v6.4s, v7.4s, v8.4s                  : fmin   %q7 %q8 $0x02 -> %q6
+4eaaf528 : fmin v8.4s, v9.4s, v10.4s                 : fmin   %q9 %q10 $0x02 -> %q8
+4eacf56a : fmin v10.4s, v11.4s, v12.4s               : fmin   %q11 %q12 $0x02 -> %q10
+4eaef5ac : fmin v12.4s, v13.4s, v14.4s               : fmin   %q13 %q14 $0x02 -> %q12
+4eb0f5ee : fmin v14.4s, v15.4s, v16.4s               : fmin   %q15 %q16 $0x02 -> %q14
+4eb2f630 : fmin v16.4s, v17.4s, v18.4s               : fmin   %q17 %q18 $0x02 -> %q16
+4eb3f651 : fmin v17.4s, v18.4s, v19.4s               : fmin   %q18 %q19 $0x02 -> %q17
+4eb5f693 : fmin v19.4s, v20.4s, v21.4s               : fmin   %q20 %q21 $0x02 -> %q19
+4eb7f6d5 : fmin v21.4s, v22.4s, v23.4s               : fmin   %q22 %q23 $0x02 -> %q21
+4eb9f717 : fmin v23.4s, v24.4s, v25.4s               : fmin   %q24 %q25 $0x02 -> %q23
+4ebbf759 : fmin v25.4s, v26.4s, v27.4s               : fmin   %q26 %q27 $0x02 -> %q25
+4ebdf79b : fmin v27.4s, v28.4s, v29.4s               : fmin   %q28 %q29 $0x02 -> %q27
+4ea1f41f : fmin v31.4s, v0.4s, v1.4s                 : fmin   %q0 %q1 $0x02 -> %q31
+4ee2f420 : fmin v0.2d, v1.2d, v2.2d                  : fmin   %q1 %q2 $0x03 -> %q0
+4ee4f462 : fmin v2.2d, v3.2d, v4.2d                  : fmin   %q3 %q4 $0x03 -> %q2
+4ee6f4a4 : fmin v4.2d, v5.2d, v6.2d                  : fmin   %q5 %q6 $0x03 -> %q4
+4ee8f4e6 : fmin v6.2d, v7.2d, v8.2d                  : fmin   %q7 %q8 $0x03 -> %q6
+4eeaf528 : fmin v8.2d, v9.2d, v10.2d                 : fmin   %q9 %q10 $0x03 -> %q8
+4eecf56a : fmin v10.2d, v11.2d, v12.2d               : fmin   %q11 %q12 $0x03 -> %q10
+4eeef5ac : fmin v12.2d, v13.2d, v14.2d               : fmin   %q13 %q14 $0x03 -> %q12
+4ef0f5ee : fmin v14.2d, v15.2d, v16.2d               : fmin   %q15 %q16 $0x03 -> %q14
+4ef2f630 : fmin v16.2d, v17.2d, v18.2d               : fmin   %q17 %q18 $0x03 -> %q16
+4ef3f651 : fmin v17.2d, v18.2d, v19.2d               : fmin   %q18 %q19 $0x03 -> %q17
+4ef5f693 : fmin v19.2d, v20.2d, v21.2d               : fmin   %q20 %q21 $0x03 -> %q19
+4ef7f6d5 : fmin v21.2d, v22.2d, v23.2d               : fmin   %q22 %q23 $0x03 -> %q21
+4ef9f717 : fmin v23.2d, v24.2d, v25.2d               : fmin   %q24 %q25 $0x03 -> %q23
+4efbf759 : fmin v25.2d, v26.2d, v27.2d               : fmin   %q26 %q27 $0x03 -> %q25
+4efdf79b : fmin v27.2d, v28.2d, v29.2d               : fmin   %q28 %q29 $0x03 -> %q27
+4ee1f41f : fmin v31.2d, v0.2d, v1.2d                 : fmin   %q0 %q1 $0x03 -> %q31
+
+# FMAXNMP <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMAXNMP-Q.QQ-asimdsame_only)
+2e22c420 : fmaxnmp v0.2s, v1.2s, v2.2s               : fmaxnmp %d1 %d2 $0x02 -> %d0
+2e24c462 : fmaxnmp v2.2s, v3.2s, v4.2s               : fmaxnmp %d3 %d4 $0x02 -> %d2
+2e26c4a4 : fmaxnmp v4.2s, v5.2s, v6.2s               : fmaxnmp %d5 %d6 $0x02 -> %d4
+2e28c4e6 : fmaxnmp v6.2s, v7.2s, v8.2s               : fmaxnmp %d7 %d8 $0x02 -> %d6
+2e2ac528 : fmaxnmp v8.2s, v9.2s, v10.2s              : fmaxnmp %d9 %d10 $0x02 -> %d8
+2e2cc56a : fmaxnmp v10.2s, v11.2s, v12.2s            : fmaxnmp %d11 %d12 $0x02 -> %d10
+2e2ec5ac : fmaxnmp v12.2s, v13.2s, v14.2s            : fmaxnmp %d13 %d14 $0x02 -> %d12
+2e30c5ee : fmaxnmp v14.2s, v15.2s, v16.2s            : fmaxnmp %d15 %d16 $0x02 -> %d14
+2e32c630 : fmaxnmp v16.2s, v17.2s, v18.2s            : fmaxnmp %d17 %d18 $0x02 -> %d16
+2e33c651 : fmaxnmp v17.2s, v18.2s, v19.2s            : fmaxnmp %d18 %d19 $0x02 -> %d17
+2e35c693 : fmaxnmp v19.2s, v20.2s, v21.2s            : fmaxnmp %d20 %d21 $0x02 -> %d19
+2e37c6d5 : fmaxnmp v21.2s, v22.2s, v23.2s            : fmaxnmp %d22 %d23 $0x02 -> %d21
+2e39c717 : fmaxnmp v23.2s, v24.2s, v25.2s            : fmaxnmp %d24 %d25 $0x02 -> %d23
+2e3bc759 : fmaxnmp v25.2s, v26.2s, v27.2s            : fmaxnmp %d26 %d27 $0x02 -> %d25
+2e3dc79b : fmaxnmp v27.2s, v28.2s, v29.2s            : fmaxnmp %d28 %d29 $0x02 -> %d27
+2e21c41f : fmaxnmp v31.2s, v0.2s, v1.2s              : fmaxnmp %d0 %d1 $0x02 -> %d31
+6e22c420 : fmaxnmp v0.4s, v1.4s, v2.4s               : fmaxnmp %q1 %q2 $0x02 -> %q0
+6e24c462 : fmaxnmp v2.4s, v3.4s, v4.4s               : fmaxnmp %q3 %q4 $0x02 -> %q2
+6e26c4a4 : fmaxnmp v4.4s, v5.4s, v6.4s               : fmaxnmp %q5 %q6 $0x02 -> %q4
+6e28c4e6 : fmaxnmp v6.4s, v7.4s, v8.4s               : fmaxnmp %q7 %q8 $0x02 -> %q6
+6e2ac528 : fmaxnmp v8.4s, v9.4s, v10.4s              : fmaxnmp %q9 %q10 $0x02 -> %q8
+6e2cc56a : fmaxnmp v10.4s, v11.4s, v12.4s            : fmaxnmp %q11 %q12 $0x02 -> %q10
+6e2ec5ac : fmaxnmp v12.4s, v13.4s, v14.4s            : fmaxnmp %q13 %q14 $0x02 -> %q12
+6e30c5ee : fmaxnmp v14.4s, v15.4s, v16.4s            : fmaxnmp %q15 %q16 $0x02 -> %q14
+6e32c630 : fmaxnmp v16.4s, v17.4s, v18.4s            : fmaxnmp %q17 %q18 $0x02 -> %q16
+6e33c651 : fmaxnmp v17.4s, v18.4s, v19.4s            : fmaxnmp %q18 %q19 $0x02 -> %q17
+6e35c693 : fmaxnmp v19.4s, v20.4s, v21.4s            : fmaxnmp %q20 %q21 $0x02 -> %q19
+6e37c6d5 : fmaxnmp v21.4s, v22.4s, v23.4s            : fmaxnmp %q22 %q23 $0x02 -> %q21
+6e39c717 : fmaxnmp v23.4s, v24.4s, v25.4s            : fmaxnmp %q24 %q25 $0x02 -> %q23
+6e3bc759 : fmaxnmp v25.4s, v26.4s, v27.4s            : fmaxnmp %q26 %q27 $0x02 -> %q25
+6e3dc79b : fmaxnmp v27.4s, v28.4s, v29.4s            : fmaxnmp %q28 %q29 $0x02 -> %q27
+6e21c41f : fmaxnmp v31.4s, v0.4s, v1.4s              : fmaxnmp %q0 %q1 $0x02 -> %q31
+6e62c420 : fmaxnmp v0.2d, v1.2d, v2.2d               : fmaxnmp %q1 %q2 $0x03 -> %q0
+6e64c462 : fmaxnmp v2.2d, v3.2d, v4.2d               : fmaxnmp %q3 %q4 $0x03 -> %q2
+6e66c4a4 : fmaxnmp v4.2d, v5.2d, v6.2d               : fmaxnmp %q5 %q6 $0x03 -> %q4
+6e68c4e6 : fmaxnmp v6.2d, v7.2d, v8.2d               : fmaxnmp %q7 %q8 $0x03 -> %q6
+6e6ac528 : fmaxnmp v8.2d, v9.2d, v10.2d              : fmaxnmp %q9 %q10 $0x03 -> %q8
+6e6cc56a : fmaxnmp v10.2d, v11.2d, v12.2d            : fmaxnmp %q11 %q12 $0x03 -> %q10
+6e6ec5ac : fmaxnmp v12.2d, v13.2d, v14.2d            : fmaxnmp %q13 %q14 $0x03 -> %q12
+6e70c5ee : fmaxnmp v14.2d, v15.2d, v16.2d            : fmaxnmp %q15 %q16 $0x03 -> %q14
+6e72c630 : fmaxnmp v16.2d, v17.2d, v18.2d            : fmaxnmp %q17 %q18 $0x03 -> %q16
+6e73c651 : fmaxnmp v17.2d, v18.2d, v19.2d            : fmaxnmp %q18 %q19 $0x03 -> %q17
+6e75c693 : fmaxnmp v19.2d, v20.2d, v21.2d            : fmaxnmp %q20 %q21 $0x03 -> %q19
+6e77c6d5 : fmaxnmp v21.2d, v22.2d, v23.2d            : fmaxnmp %q22 %q23 $0x03 -> %q21
+6e79c717 : fmaxnmp v23.2d, v24.2d, v25.2d            : fmaxnmp %q24 %q25 $0x03 -> %q23
+6e7bc759 : fmaxnmp v25.2d, v26.2d, v27.2d            : fmaxnmp %q26 %q27 $0x03 -> %q25
+6e7dc79b : fmaxnmp v27.2d, v28.2d, v29.2d            : fmaxnmp %q28 %q29 $0x03 -> %q27
+6e61c41f : fmaxnmp v31.2d, v0.2d, v1.2d              : fmaxnmp %q0 %q1 $0x03 -> %q31
+
+# FMINP   <V><d>, <Sn>.<T> (FMINP-V.Q-asisdpair_only)
+7eb0f820 : fminp s0, v1.2s                           : fminp  %d1 $0x02 -> %s0
+7eb0f862 : fminp s2, v3.2s                           : fminp  %d3 $0x02 -> %s2
+7eb0f8a4 : fminp s4, v5.2s                           : fminp  %d5 $0x02 -> %s4
+7eb0f8e6 : fminp s6, v7.2s                           : fminp  %d7 $0x02 -> %s6
+7eb0f928 : fminp s8, v9.2s                           : fminp  %d9 $0x02 -> %s8
+7eb0f96a : fminp s10, v11.2s                         : fminp  %d11 $0x02 -> %s10
+7eb0f9ac : fminp s12, v13.2s                         : fminp  %d13 $0x02 -> %s12
+7eb0f9ee : fminp s14, v15.2s                         : fminp  %d15 $0x02 -> %s14
+7eb0fa30 : fminp s16, v17.2s                         : fminp  %d17 $0x02 -> %s16
+7eb0fa51 : fminp s17, v18.2s                         : fminp  %d18 $0x02 -> %s17
+7eb0fa93 : fminp s19, v20.2s                         : fminp  %d20 $0x02 -> %s19
+7eb0fad5 : fminp s21, v22.2s                         : fminp  %d22 $0x02 -> %s21
+7eb0fb17 : fminp s23, v24.2s                         : fminp  %d24 $0x02 -> %s23
+7eb0fb59 : fminp s25, v26.2s                         : fminp  %d26 $0x02 -> %s25
+7eb0fb9b : fminp s27, v28.2s                         : fminp  %d28 $0x02 -> %s27
+7eb0f81f : fminp s31, v0.2s                          : fminp  %d0 $0x02 -> %s31
+7ef0f820 : fminp d0, v1.2d                           : fminp  %q1 $0x03 -> %d0
+7ef0f862 : fminp d2, v3.2d                           : fminp  %q3 $0x03 -> %d2
+7ef0f8a4 : fminp d4, v5.2d                           : fminp  %q5 $0x03 -> %d4
+7ef0f8e6 : fminp d6, v7.2d                           : fminp  %q7 $0x03 -> %d6
+7ef0f928 : fminp d8, v9.2d                           : fminp  %q9 $0x03 -> %d8
+7ef0f96a : fminp d10, v11.2d                         : fminp  %q11 $0x03 -> %d10
+7ef0f9ac : fminp d12, v13.2d                         : fminp  %q13 $0x03 -> %d12
+7ef0f9ee : fminp d14, v15.2d                         : fminp  %q15 $0x03 -> %d14
+7ef0fa30 : fminp d16, v17.2d                         : fminp  %q17 $0x03 -> %d16
+7ef0fa51 : fminp d17, v18.2d                         : fminp  %q18 $0x03 -> %d17
+7ef0fa93 : fminp d19, v20.2d                         : fminp  %q20 $0x03 -> %d19
+7ef0fad5 : fminp d21, v22.2d                         : fminp  %q22 $0x03 -> %d21
+7ef0fb17 : fminp d23, v24.2d                         : fminp  %q24 $0x03 -> %d23
+7ef0fb59 : fminp d25, v26.2d                         : fminp  %q26 $0x03 -> %d25
+7ef0fb9b : fminp d27, v28.2d                         : fminp  %q28 $0x03 -> %d27
+7ef0f81f : fminp d31, v0.2d                          : fminp  %q0 $0x03 -> %d31
+
+# FCVTZU  <Dd>.<T>, <Dn>.<T> (FCVTZU-Q.Q-asimdmisc_R)
+2ea1b820 : fcvtzu v0.2s, v1.2s                       : fcvtzu %d1 $0x02 -> %d0
+2ea1b862 : fcvtzu v2.2s, v3.2s                       : fcvtzu %d3 $0x02 -> %d2
+2ea1b8a4 : fcvtzu v4.2s, v5.2s                       : fcvtzu %d5 $0x02 -> %d4
+2ea1b8e6 : fcvtzu v6.2s, v7.2s                       : fcvtzu %d7 $0x02 -> %d6
+2ea1b928 : fcvtzu v8.2s, v9.2s                       : fcvtzu %d9 $0x02 -> %d8
+2ea1b96a : fcvtzu v10.2s, v11.2s                     : fcvtzu %d11 $0x02 -> %d10
+2ea1b9ac : fcvtzu v12.2s, v13.2s                     : fcvtzu %d13 $0x02 -> %d12
+2ea1b9ee : fcvtzu v14.2s, v15.2s                     : fcvtzu %d15 $0x02 -> %d14
+2ea1ba30 : fcvtzu v16.2s, v17.2s                     : fcvtzu %d17 $0x02 -> %d16
+2ea1ba51 : fcvtzu v17.2s, v18.2s                     : fcvtzu %d18 $0x02 -> %d17
+2ea1ba93 : fcvtzu v19.2s, v20.2s                     : fcvtzu %d20 $0x02 -> %d19
+2ea1bad5 : fcvtzu v21.2s, v22.2s                     : fcvtzu %d22 $0x02 -> %d21
+2ea1bb17 : fcvtzu v23.2s, v24.2s                     : fcvtzu %d24 $0x02 -> %d23
+2ea1bb59 : fcvtzu v25.2s, v26.2s                     : fcvtzu %d26 $0x02 -> %d25
+2ea1bb9b : fcvtzu v27.2s, v28.2s                     : fcvtzu %d28 $0x02 -> %d27
+2ea1b81f : fcvtzu v31.2s, v0.2s                      : fcvtzu %d0 $0x02 -> %d31
+6ea1b820 : fcvtzu v0.4s, v1.4s                       : fcvtzu %q1 $0x02 -> %q0
+6ea1b862 : fcvtzu v2.4s, v3.4s                       : fcvtzu %q3 $0x02 -> %q2
+6ea1b8a4 : fcvtzu v4.4s, v5.4s                       : fcvtzu %q5 $0x02 -> %q4
+6ea1b8e6 : fcvtzu v6.4s, v7.4s                       : fcvtzu %q7 $0x02 -> %q6
+6ea1b928 : fcvtzu v8.4s, v9.4s                       : fcvtzu %q9 $0x02 -> %q8
+6ea1b96a : fcvtzu v10.4s, v11.4s                     : fcvtzu %q11 $0x02 -> %q10
+6ea1b9ac : fcvtzu v12.4s, v13.4s                     : fcvtzu %q13 $0x02 -> %q12
+6ea1b9ee : fcvtzu v14.4s, v15.4s                     : fcvtzu %q15 $0x02 -> %q14
+6ea1ba30 : fcvtzu v16.4s, v17.4s                     : fcvtzu %q17 $0x02 -> %q16
+6ea1ba51 : fcvtzu v17.4s, v18.4s                     : fcvtzu %q18 $0x02 -> %q17
+6ea1ba93 : fcvtzu v19.4s, v20.4s                     : fcvtzu %q20 $0x02 -> %q19
+6ea1bad5 : fcvtzu v21.4s, v22.4s                     : fcvtzu %q22 $0x02 -> %q21
+6ea1bb17 : fcvtzu v23.4s, v24.4s                     : fcvtzu %q24 $0x02 -> %q23
+6ea1bb59 : fcvtzu v25.4s, v26.4s                     : fcvtzu %q26 $0x02 -> %q25
+6ea1bb9b : fcvtzu v27.4s, v28.4s                     : fcvtzu %q28 $0x02 -> %q27
+6ea1b81f : fcvtzu v31.4s, v0.4s                      : fcvtzu %q0 $0x02 -> %q31
+6ee1b820 : fcvtzu v0.2d, v1.2d                       : fcvtzu %q1 $0x03 -> %q0
+6ee1b862 : fcvtzu v2.2d, v3.2d                       : fcvtzu %q3 $0x03 -> %q2
+6ee1b8a4 : fcvtzu v4.2d, v5.2d                       : fcvtzu %q5 $0x03 -> %q4
+6ee1b8e6 : fcvtzu v6.2d, v7.2d                       : fcvtzu %q7 $0x03 -> %q6
+6ee1b928 : fcvtzu v8.2d, v9.2d                       : fcvtzu %q9 $0x03 -> %q8
+6ee1b96a : fcvtzu v10.2d, v11.2d                     : fcvtzu %q11 $0x03 -> %q10
+6ee1b9ac : fcvtzu v12.2d, v13.2d                     : fcvtzu %q13 $0x03 -> %q12
+6ee1b9ee : fcvtzu v14.2d, v15.2d                     : fcvtzu %q15 $0x03 -> %q14
+6ee1ba30 : fcvtzu v16.2d, v17.2d                     : fcvtzu %q17 $0x03 -> %q16
+6ee1ba51 : fcvtzu v17.2d, v18.2d                     : fcvtzu %q18 $0x03 -> %q17
+6ee1ba93 : fcvtzu v19.2d, v20.2d                     : fcvtzu %q20 $0x03 -> %q19
+6ee1bad5 : fcvtzu v21.2d, v22.2d                     : fcvtzu %q22 $0x03 -> %q21
+6ee1bb17 : fcvtzu v23.2d, v24.2d                     : fcvtzu %q24 $0x03 -> %q23
+6ee1bb59 : fcvtzu v25.2d, v26.2d                     : fcvtzu %q26 $0x03 -> %q25
+6ee1bb9b : fcvtzu v27.2d, v28.2d                     : fcvtzu %q28 $0x03 -> %q27
+6ee1b81f : fcvtzu v31.2d, v0.2d                      : fcvtzu %q0 $0x03 -> %q31
+
+# FMINV   <Sd>, <Sn>.4S (FMINV-V.Q-asimdall_only)
+6eb0f820 : fminv s0, v1.4s                           : fminv  %q1 $0x02 -> %s0
+6eb0f862 : fminv s2, v3.4s                           : fminv  %q3 $0x02 -> %s2
+6eb0f8a4 : fminv s4, v5.4s                           : fminv  %q5 $0x02 -> %s4
+6eb0f8e6 : fminv s6, v7.4s                           : fminv  %q7 $0x02 -> %s6
+6eb0f928 : fminv s8, v9.4s                           : fminv  %q9 $0x02 -> %s8
+6eb0f96a : fminv s10, v11.4s                         : fminv  %q11 $0x02 -> %s10
+6eb0f9ac : fminv s12, v13.4s                         : fminv  %q13 $0x02 -> %s12
+6eb0f9ee : fminv s14, v15.4s                         : fminv  %q15 $0x02 -> %s14
+6eb0fa30 : fminv s16, v17.4s                         : fminv  %q17 $0x02 -> %s16
+6eb0fa51 : fminv s17, v18.4s                         : fminv  %q18 $0x02 -> %s17
+6eb0fa93 : fminv s19, v20.4s                         : fminv  %q20 $0x02 -> %s19
+6eb0fad5 : fminv s21, v22.4s                         : fminv  %q22 $0x02 -> %s21
+6eb0fb17 : fminv s23, v24.4s                         : fminv  %q24 $0x02 -> %s23
+6eb0fb59 : fminv s25, v26.4s                         : fminv  %q26 $0x02 -> %s25
+6eb0fb9b : fminv s27, v28.4s                         : fminv  %q28 $0x02 -> %s27
+6eb0f81f : fminv s31, v0.4s                          : fminv  %q0 $0x02 -> %s31
+
+# FMAXNM  <Dd>.<T>, <Dn>.<T>, <Dm>.<T> (FMAXNM-Q.QQ-asimdsame_only)
+0e22c420 : fmaxnm v0.2s, v1.2s, v2.2s                : fmaxnm %d1 %d2 $0x02 -> %d0
+0e24c462 : fmaxnm v2.2s, v3.2s, v4.2s                : fmaxnm %d3 %d4 $0x02 -> %d2
+0e26c4a4 : fmaxnm v4.2s, v5.2s, v6.2s                : fmaxnm %d5 %d6 $0x02 -> %d4
+0e28c4e6 : fmaxnm v6.2s, v7.2s, v8.2s                : fmaxnm %d7 %d8 $0x02 -> %d6
+0e2ac528 : fmaxnm v8.2s, v9.2s, v10.2s               : fmaxnm %d9 %d10 $0x02 -> %d8
+0e2cc56a : fmaxnm v10.2s, v11.2s, v12.2s             : fmaxnm %d11 %d12 $0x02 -> %d10
+0e2ec5ac : fmaxnm v12.2s, v13.2s, v14.2s             : fmaxnm %d13 %d14 $0x02 -> %d12
+0e30c5ee : fmaxnm v14.2s, v15.2s, v16.2s             : fmaxnm %d15 %d16 $0x02 -> %d14
+0e32c630 : fmaxnm v16.2s, v17.2s, v18.2s             : fmaxnm %d17 %d18 $0x02 -> %d16
+0e33c651 : fmaxnm v17.2s, v18.2s, v19.2s             : fmaxnm %d18 %d19 $0x02 -> %d17
+0e35c693 : fmaxnm v19.2s, v20.2s, v21.2s             : fmaxnm %d20 %d21 $0x02 -> %d19
+0e37c6d5 : fmaxnm v21.2s, v22.2s, v23.2s             : fmaxnm %d22 %d23 $0x02 -> %d21
+0e39c717 : fmaxnm v23.2s, v24.2s, v25.2s             : fmaxnm %d24 %d25 $0x02 -> %d23
+0e3bc759 : fmaxnm v25.2s, v26.2s, v27.2s             : fmaxnm %d26 %d27 $0x02 -> %d25
+0e3dc79b : fmaxnm v27.2s, v28.2s, v29.2s             : fmaxnm %d28 %d29 $0x02 -> %d27
+0e21c41f : fmaxnm v31.2s, v0.2s, v1.2s               : fmaxnm %d0 %d1 $0x02 -> %d31
+4e22c420 : fmaxnm v0.4s, v1.4s, v2.4s                : fmaxnm %q1 %q2 $0x02 -> %q0
+4e24c462 : fmaxnm v2.4s, v3.4s, v4.4s                : fmaxnm %q3 %q4 $0x02 -> %q2
+4e26c4a4 : fmaxnm v4.4s, v5.4s, v6.4s                : fmaxnm %q5 %q6 $0x02 -> %q4
+4e28c4e6 : fmaxnm v6.4s, v7.4s, v8.4s                : fmaxnm %q7 %q8 $0x02 -> %q6
+4e2ac528 : fmaxnm v8.4s, v9.4s, v10.4s               : fmaxnm %q9 %q10 $0x02 -> %q8
+4e2cc56a : fmaxnm v10.4s, v11.4s, v12.4s             : fmaxnm %q11 %q12 $0x02 -> %q10
+4e2ec5ac : fmaxnm v12.4s, v13.4s, v14.4s             : fmaxnm %q13 %q14 $0x02 -> %q12
+4e30c5ee : fmaxnm v14.4s, v15.4s, v16.4s             : fmaxnm %q15 %q16 $0x02 -> %q14
+4e32c630 : fmaxnm v16.4s, v17.4s, v18.4s             : fmaxnm %q17 %q18 $0x02 -> %q16
+4e33c651 : fmaxnm v17.4s, v18.4s, v19.4s             : fmaxnm %q18 %q19 $0x02 -> %q17
+4e35c693 : fmaxnm v19.4s, v20.4s, v21.4s             : fmaxnm %q20 %q21 $0x02 -> %q19
+4e37c6d5 : fmaxnm v21.4s, v22.4s, v23.4s             : fmaxnm %q22 %q23 $0x02 -> %q21
+4e39c717 : fmaxnm v23.4s, v24.4s, v25.4s             : fmaxnm %q24 %q25 $0x02 -> %q23
+4e3bc759 : fmaxnm v25.4s, v26.4s, v27.4s             : fmaxnm %q26 %q27 $0x02 -> %q25
+4e3dc79b : fmaxnm v27.4s, v28.4s, v29.4s             : fmaxnm %q28 %q29 $0x02 -> %q27
+4e21c41f : fmaxnm v31.4s, v0.4s, v1.4s               : fmaxnm %q0 %q1 $0x02 -> %q31
+4e62c420 : fmaxnm v0.2d, v1.2d, v2.2d                : fmaxnm %q1 %q2 $0x03 -> %q0
+4e64c462 : fmaxnm v2.2d, v3.2d, v4.2d                : fmaxnm %q3 %q4 $0x03 -> %q2
+4e66c4a4 : fmaxnm v4.2d, v5.2d, v6.2d                : fmaxnm %q5 %q6 $0x03 -> %q4
+4e68c4e6 : fmaxnm v6.2d, v7.2d, v8.2d                : fmaxnm %q7 %q8 $0x03 -> %q6
+4e6ac528 : fmaxnm v8.2d, v9.2d, v10.2d               : fmaxnm %q9 %q10 $0x03 -> %q8
+4e6cc56a : fmaxnm v10.2d, v11.2d, v12.2d             : fmaxnm %q11 %q12 $0x03 -> %q10
+4e6ec5ac : fmaxnm v12.2d, v13.2d, v14.2d             : fmaxnm %q13 %q14 $0x03 -> %q12
+4e70c5ee : fmaxnm v14.2d, v15.2d, v16.2d             : fmaxnm %q15 %q16 $0x03 -> %q14
+4e72c630 : fmaxnm v16.2d, v17.2d, v18.2d             : fmaxnm %q17 %q18 $0x03 -> %q16
+4e73c651 : fmaxnm v17.2d, v18.2d, v19.2d             : fmaxnm %q18 %q19 $0x03 -> %q17
+4e75c693 : fmaxnm v19.2d, v20.2d, v21.2d             : fmaxnm %q20 %q21 $0x03 -> %q19
+4e77c6d5 : fmaxnm v21.2d, v22.2d, v23.2d             : fmaxnm %q22 %q23 $0x03 -> %q21
+4e79c717 : fmaxnm v23.2d, v24.2d, v25.2d             : fmaxnm %q24 %q25 $0x03 -> %q23
+4e7bc759 : fmaxnm v25.2d, v26.2d, v27.2d             : fmaxnm %q26 %q27 $0x03 -> %q25
+4e7dc79b : fmaxnm v27.2d, v28.2d, v29.2d             : fmaxnm %q28 %q29 $0x03 -> %q27
+4e61c41f : fmaxnm v31.2d, v0.2d, v1.2d               : fmaxnm %q0 %q1 $0x03 -> %q31
+
 # FCMGE   <Dd>.<T>, <Dn>.<T>, #0 (FCMGE-Q.Q-asimdmisc_FZ)
 2ea0c820 : fcmge v0.2s, v1.2s, #0                    : fcmge  %d1 $0.000000 $0x02 -> %d0
 2ea0c862 : fcmge v2.2s, v3.2s, #0                    : fcmge  %d3 $0.000000 $0x02 -> %d2
@@ -29314,3 +32056,103 @@ b57ffffe : cbnz x30, #0xffffc                        : cbnz   $0x00000000100ffff
 6ee0cb59 : fcmge v25.2d, v26.2d, #0                  : fcmge  %q26 $0.000000 $0x03 -> %q25
 6ee0cb9b : fcmge v27.2d, v28.2d, #0                  : fcmge  %q28 $0.000000 $0x03 -> %q27
 6ee0c81f : fcmge v31.2d, v0.2d, #0                   : fcmge  %q0 $0.000000 $0x03 -> %q31
+
+# FNEG    <Dd>.<T>, <Dn>.<T> (FNEG-Q.Q-asimdmisc_R)
+2ea0f820 : fneg v0.2s, v1.2s                         : fneg   %d1 $0x02 -> %d0
+2ea0f862 : fneg v2.2s, v3.2s                         : fneg   %d3 $0x02 -> %d2
+2ea0f8a4 : fneg v4.2s, v5.2s                         : fneg   %d5 $0x02 -> %d4
+2ea0f8e6 : fneg v6.2s, v7.2s                         : fneg   %d7 $0x02 -> %d6
+2ea0f928 : fneg v8.2s, v9.2s                         : fneg   %d9 $0x02 -> %d8
+2ea0f96a : fneg v10.2s, v11.2s                       : fneg   %d11 $0x02 -> %d10
+2ea0f9ac : fneg v12.2s, v13.2s                       : fneg   %d13 $0x02 -> %d12
+2ea0f9ee : fneg v14.2s, v15.2s                       : fneg   %d15 $0x02 -> %d14
+2ea0fa30 : fneg v16.2s, v17.2s                       : fneg   %d17 $0x02 -> %d16
+2ea0fa51 : fneg v17.2s, v18.2s                       : fneg   %d18 $0x02 -> %d17
+2ea0fa93 : fneg v19.2s, v20.2s                       : fneg   %d20 $0x02 -> %d19
+2ea0fad5 : fneg v21.2s, v22.2s                       : fneg   %d22 $0x02 -> %d21
+2ea0fb17 : fneg v23.2s, v24.2s                       : fneg   %d24 $0x02 -> %d23
+2ea0fb59 : fneg v25.2s, v26.2s                       : fneg   %d26 $0x02 -> %d25
+2ea0fb9b : fneg v27.2s, v28.2s                       : fneg   %d28 $0x02 -> %d27
+2ea0f81f : fneg v31.2s, v0.2s                        : fneg   %d0 $0x02 -> %d31
+6ea0f820 : fneg v0.4s, v1.4s                         : fneg   %q1 $0x02 -> %q0
+6ea0f862 : fneg v2.4s, v3.4s                         : fneg   %q3 $0x02 -> %q2
+6ea0f8a4 : fneg v4.4s, v5.4s                         : fneg   %q5 $0x02 -> %q4
+6ea0f8e6 : fneg v6.4s, v7.4s                         : fneg   %q7 $0x02 -> %q6
+6ea0f928 : fneg v8.4s, v9.4s                         : fneg   %q9 $0x02 -> %q8
+6ea0f96a : fneg v10.4s, v11.4s                       : fneg   %q11 $0x02 -> %q10
+6ea0f9ac : fneg v12.4s, v13.4s                       : fneg   %q13 $0x02 -> %q12
+6ea0f9ee : fneg v14.4s, v15.4s                       : fneg   %q15 $0x02 -> %q14
+6ea0fa30 : fneg v16.4s, v17.4s                       : fneg   %q17 $0x02 -> %q16
+6ea0fa51 : fneg v17.4s, v18.4s                       : fneg   %q18 $0x02 -> %q17
+6ea0fa93 : fneg v19.4s, v20.4s                       : fneg   %q20 $0x02 -> %q19
+6ea0fad5 : fneg v21.4s, v22.4s                       : fneg   %q22 $0x02 -> %q21
+6ea0fb17 : fneg v23.4s, v24.4s                       : fneg   %q24 $0x02 -> %q23
+6ea0fb59 : fneg v25.4s, v26.4s                       : fneg   %q26 $0x02 -> %q25
+6ea0fb9b : fneg v27.4s, v28.4s                       : fneg   %q28 $0x02 -> %q27
+6ea0f81f : fneg v31.4s, v0.4s                        : fneg   %q0 $0x02 -> %q31
+6ee0f820 : fneg v0.2d, v1.2d                         : fneg   %q1 $0x03 -> %q0
+6ee0f862 : fneg v2.2d, v3.2d                         : fneg   %q3 $0x03 -> %q2
+6ee0f8a4 : fneg v4.2d, v5.2d                         : fneg   %q5 $0x03 -> %q4
+6ee0f8e6 : fneg v6.2d, v7.2d                         : fneg   %q7 $0x03 -> %q6
+6ee0f928 : fneg v8.2d, v9.2d                         : fneg   %q9 $0x03 -> %q8
+6ee0f96a : fneg v10.2d, v11.2d                       : fneg   %q11 $0x03 -> %q10
+6ee0f9ac : fneg v12.2d, v13.2d                       : fneg   %q13 $0x03 -> %q12
+6ee0f9ee : fneg v14.2d, v15.2d                       : fneg   %q15 $0x03 -> %q14
+6ee0fa30 : fneg v16.2d, v17.2d                       : fneg   %q17 $0x03 -> %q16
+6ee0fa51 : fneg v17.2d, v18.2d                       : fneg   %q18 $0x03 -> %q17
+6ee0fa93 : fneg v19.2d, v20.2d                       : fneg   %q20 $0x03 -> %q19
+6ee0fad5 : fneg v21.2d, v22.2d                       : fneg   %q22 $0x03 -> %q21
+6ee0fb17 : fneg v23.2d, v24.2d                       : fneg   %q24 $0x03 -> %q23
+6ee0fb59 : fneg v25.2d, v26.2d                       : fneg   %q26 $0x03 -> %q25
+6ee0fb9b : fneg v27.2d, v28.2d                       : fneg   %q28 $0x03 -> %q27
+6ee0f81f : fneg v31.2d, v0.2d                        : fneg   %q0 $0x03 -> %q31
+
+# FCVTPS  <Dd>.<T>, <Dn>.<T> (FCVTPS-Q.Q-asimdmisc_R)
+0ea1a820 : fcvtps v0.2s, v1.2s                       : fcvtps %d1 $0x02 -> %d0
+0ea1a862 : fcvtps v2.2s, v3.2s                       : fcvtps %d3 $0x02 -> %d2
+0ea1a8a4 : fcvtps v4.2s, v5.2s                       : fcvtps %d5 $0x02 -> %d4
+0ea1a8e6 : fcvtps v6.2s, v7.2s                       : fcvtps %d7 $0x02 -> %d6
+0ea1a928 : fcvtps v8.2s, v9.2s                       : fcvtps %d9 $0x02 -> %d8
+0ea1a96a : fcvtps v10.2s, v11.2s                     : fcvtps %d11 $0x02 -> %d10
+0ea1a9ac : fcvtps v12.2s, v13.2s                     : fcvtps %d13 $0x02 -> %d12
+0ea1a9ee : fcvtps v14.2s, v15.2s                     : fcvtps %d15 $0x02 -> %d14
+0ea1aa30 : fcvtps v16.2s, v17.2s                     : fcvtps %d17 $0x02 -> %d16
+0ea1aa51 : fcvtps v17.2s, v18.2s                     : fcvtps %d18 $0x02 -> %d17
+0ea1aa93 : fcvtps v19.2s, v20.2s                     : fcvtps %d20 $0x02 -> %d19
+0ea1aad5 : fcvtps v21.2s, v22.2s                     : fcvtps %d22 $0x02 -> %d21
+0ea1ab17 : fcvtps v23.2s, v24.2s                     : fcvtps %d24 $0x02 -> %d23
+0ea1ab59 : fcvtps v25.2s, v26.2s                     : fcvtps %d26 $0x02 -> %d25
+0ea1ab9b : fcvtps v27.2s, v28.2s                     : fcvtps %d28 $0x02 -> %d27
+0ea1a81f : fcvtps v31.2s, v0.2s                      : fcvtps %d0 $0x02 -> %d31
+4ea1a820 : fcvtps v0.4s, v1.4s                       : fcvtps %q1 $0x02 -> %q0
+4ea1a862 : fcvtps v2.4s, v3.4s                       : fcvtps %q3 $0x02 -> %q2
+4ea1a8a4 : fcvtps v4.4s, v5.4s                       : fcvtps %q5 $0x02 -> %q4
+4ea1a8e6 : fcvtps v6.4s, v7.4s                       : fcvtps %q7 $0x02 -> %q6
+4ea1a928 : fcvtps v8.4s, v9.4s                       : fcvtps %q9 $0x02 -> %q8
+4ea1a96a : fcvtps v10.4s, v11.4s                     : fcvtps %q11 $0x02 -> %q10
+4ea1a9ac : fcvtps v12.4s, v13.4s                     : fcvtps %q13 $0x02 -> %q12
+4ea1a9ee : fcvtps v14.4s, v15.4s                     : fcvtps %q15 $0x02 -> %q14
+4ea1aa30 : fcvtps v16.4s, v17.4s                     : fcvtps %q17 $0x02 -> %q16
+4ea1aa51 : fcvtps v17.4s, v18.4s                     : fcvtps %q18 $0x02 -> %q17
+4ea1aa93 : fcvtps v19.4s, v20.4s                     : fcvtps %q20 $0x02 -> %q19
+4ea1aad5 : fcvtps v21.4s, v22.4s                     : fcvtps %q22 $0x02 -> %q21
+4ea1ab17 : fcvtps v23.4s, v24.4s                     : fcvtps %q24 $0x02 -> %q23
+4ea1ab59 : fcvtps v25.4s, v26.4s                     : fcvtps %q26 $0x02 -> %q25
+4ea1ab9b : fcvtps v27.4s, v28.4s                     : fcvtps %q28 $0x02 -> %q27
+4ea1a81f : fcvtps v31.4s, v0.4s                      : fcvtps %q0 $0x02 -> %q31
+4ee1a820 : fcvtps v0.2d, v1.2d                       : fcvtps %q1 $0x03 -> %q0
+4ee1a862 : fcvtps v2.2d, v3.2d                       : fcvtps %q3 $0x03 -> %q2
+4ee1a8a4 : fcvtps v4.2d, v5.2d                       : fcvtps %q5 $0x03 -> %q4
+4ee1a8e6 : fcvtps v6.2d, v7.2d                       : fcvtps %q7 $0x03 -> %q6
+4ee1a928 : fcvtps v8.2d, v9.2d                       : fcvtps %q9 $0x03 -> %q8
+4ee1a96a : fcvtps v10.2d, v11.2d                     : fcvtps %q11 $0x03 -> %q10
+4ee1a9ac : fcvtps v12.2d, v13.2d                     : fcvtps %q13 $0x03 -> %q12
+4ee1a9ee : fcvtps v14.2d, v15.2d                     : fcvtps %q15 $0x03 -> %q14
+4ee1aa30 : fcvtps v16.2d, v17.2d                     : fcvtps %q17 $0x03 -> %q16
+4ee1aa51 : fcvtps v17.2d, v18.2d                     : fcvtps %q18 $0x03 -> %q17
+4ee1aa93 : fcvtps v19.2d, v20.2d                     : fcvtps %q20 $0x03 -> %q19
+4ee1aad5 : fcvtps v21.2d, v22.2d                     : fcvtps %q22 $0x03 -> %q21
+4ee1ab17 : fcvtps v23.2d, v24.2d                     : fcvtps %q24 $0x03 -> %q23
+4ee1ab59 : fcvtps v25.2d, v26.2d                     : fcvtps %q26 $0x03 -> %q25
+4ee1ab9b : fcvtps v27.2d, v28.2d                     : fcvtps %q28 $0x03 -> %q27
+4ee1a81f : fcvtps v31.2d, v0.2d                      : fcvtps %q0 $0x03 -> %q31


### PR DESCRIPTION
This patch corrects missing element operand sizes
for fminv, fmaxv, fmaxnmv, fminnmv and fcvtxn{2}
as well as adding tests for other instructions to
ensure they are correct.

issues: #2626
