### PR TITLE
i#5398: Handle rep string expansion in drbbdup

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -343,6 +343,7 @@ drbbdup_destroy_manager(void *manager_opaque)
     dr_global_free(manager, sizeof(drbbdup_manager_t));
 }
 
+/* This must be called prior to inserting drbbdup's own cti. */
 static bool
 drbbdup_ilist_has_cti(instrlist_t *bb)
 {
@@ -413,7 +414,8 @@ drbbdup_set_up_copies(void *drcontext, instrlist_t *bb, drbbdup_manager_t *manag
 
     /* Tell drreg to ignore control flow as it is ensured that all registers
      * are live at the start of bb copies, unless there is other control
-     * flow from prior expansions such as drutil_expand_rep_string().
+     * flow from prior expansions such as drutil_expand_rep_string(), in which
+     * case we have to disable drreg optimizations for this block for safety.
      */
     if (!has_prior_control_flow)
         drreg_set_bb_properties(drcontext, DRREG_IGNORE_CONTROL_FLOW);

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -344,6 +344,16 @@ drbbdup_destroy_manager(void *manager_opaque)
 }
 
 static bool
+drbbdup_ilist_has_cti(instrlist_t *bb)
+{
+    for (instr_t *inst = instrlist_first(bb); inst != NULL; inst = instr_get_next(inst)) {
+        if (instr_is_cti(inst))
+            return true;
+    }
+    return false;
+}
+
+static bool
 drbbdup_ilist_has_unending_emulation(instrlist_t *bb)
 {
     emulated_instr_t emul_info = { sizeof(emul_info), 0 };
@@ -387,6 +397,7 @@ drbbdup_set_up_copies(void *drcontext, instrlist_t *bb, drbbdup_manager_t *manag
      */
 
     bool has_rest_of_block_emulation = drbbdup_ilist_has_unending_emulation(bb);
+    bool has_prior_control_flow = drbbdup_ilist_has_cti(bb);
 
     /* We create a duplication here to keep track of original bb. */
     instrlist_t *original = instrlist_clone(drcontext, bb);
@@ -404,7 +415,8 @@ drbbdup_set_up_copies(void *drcontext, instrlist_t *bb, drbbdup_manager_t *manag
      * are live at the start of bb copies, unless there is other control
      * flow from prior expansions such as drutil_expand_rep_string().
      */
-    drreg_set_bb_properties(drcontext, DRREG_IGNORE_CONTROL_FLOW);
+    if (!has_prior_control_flow)
+        drreg_set_bb_properties(drcontext, DRREG_IGNORE_CONTROL_FLOW);
     /* Restoration at the end of the block is not done automatically
      * by drreg but is managed by drbbdup. Different cases could
      * have different registers spilled and therefore restoration is

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2630,6 +2630,7 @@ tobuild_ci(client.drbbdup-emul-test client-interface/drbbdup-emul-test.c "" "" "
 use_DynamoRIO_extension(client.drbbdup-emul-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-emul-test.dll drutil)
 use_DynamoRIO_extension(client.drbbdup-emul-test.dll drbbdup)
+use_DynamoRIO_extension(client.drbbdup-emul-test.dll drreg)
 
 if (ARM)
   tobuild_ci(client.predicate-test client-interface/predicate-test.c "" "" "")

--- a/suite/tests/client-interface/drbbdup-emul-test.c
+++ b/suite/tests/client-interface/drbbdup-emul-test.c
@@ -41,9 +41,9 @@ main(int argc, char **argv)
     char buf2[1024];
 #    ifdef WINDOWS
 #        ifdef X64
-    __movsq(buf2, buf1, 0);
+    __movsq((unsigned long *)buf2, (unsigned long *)buf1, 0);
 #        else
-    __movsd(buf2, buf1, 0);
+    __movsd((unsigned long *)buf2, (unsigned long *)buf1, 0);
 #        endif
 #    else
 #        ifdef X64

--- a/suite/tests/client-interface/drbbdup-emul-test.c
+++ b/suite/tests/client-interface/drbbdup-emul-test.c
@@ -1,0 +1,70 @@
+/* **********************************************************
+ * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "tools.h"
+
+int
+main(int argc, char **argv)
+{
+#ifdef X86
+    /* Test i#5398 with a zero-iter rep movs loop. */
+    char buf1[1024];
+    char buf2[1024];
+#    ifdef WINDOWS
+#        ifdef X64
+    __movsq(buf2, buf1, 0);
+#        else
+    __movsd(buf2, buf1, 0);
+#        endif
+#    else
+#        ifdef X64
+    __asm("lea %[buf1], %%rdi\n\t"
+          "lea %[buf2], %%rsi\n\t"
+          "mov $0, %%ecx\n\t"
+          "rep movsq\n\t"
+          :
+          : [ buf1 ] "m"(buf1), [ buf2 ] "m"(buf2)
+          : "ecx", "rdi", "rsi", "memory");
+#        else
+    __asm("lea %[buf1], %%edi\n\t"
+          "lea %[buf2], %%esi\n\t"
+          "mov $0, %%ecx\n\t"
+          "rep movsd\n\t"
+          :
+          : [ buf1 ] "m"(buf1), [ buf2 ] "m"(buf2)
+          : "ecx", "edi", "esi", "memory");
+#        endif
+#    endif
+#endif
+    print("Hello, world!\n");
+    return 0;
+}

--- a/suite/tests/client-interface/drbbdup-emul-test.c
+++ b/suite/tests/client-interface/drbbdup-emul-test.c
@@ -41,7 +41,7 @@ main(int argc, char **argv)
     char buf2[1024];
 #    ifdef WINDOWS
 #        ifdef X64
-    __movsq((unsigned long *)buf2, (unsigned long *)buf1, 0);
+    __movsq((unsigned long long *)buf2, (unsigned long long *)buf1, 0);
 #        else
     __movsd((unsigned long *)buf2, (unsigned long *)buf1, 0);
 #        endif


### PR DESCRIPTION
Fixes a bug involving rep string expansion where drbbdup told drreg
to ignore control flow even when it was present in the app block.
Adds a guard on that setting based on a check for app control flow.

Adds a custom app for the drbbdup-emul-test which contains a zero-iter
rep string, and augments the test client to reserve rcx on the movs
only.  This reproduces the #5398 crash, and is fixed by the changes
here.

Fixes #5398