### PR TITLE
Print label note values when disassembling

### DIFF
--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -1096,7 +1096,10 @@ internal_instr_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT,
         print_to_buffer(buf, bufsz, sofar, "<INVALID>");
         return;
     } else if (instr_is_label(instr)) {
-        print_to_buffer(buf, bufsz, sofar, "<label>");
+        /* Since labels with different note values are used during instrumentation
+         * to mark different regions, it is useful to display the note.
+         */
+        print_to_buffer(buf, bufsz, sofar, "<label note=%p>", instr_get_note(instr));
         return;
     } else if (instr_opcode_valid(instr)) {
 #ifdef AARCH64


### PR DESCRIPTION
The note values of labels is very useful for debugging.  Here we add them to the disassembly of a label.

For example, with drbbdup we can eaily see the start (4e) and exit
(4f) labels and the emulation markers (1 and 2) around the firt case's
jump to the end label:

 +0    m4 @0x00007f1d2d6b0c20                       <label note=0x000000000000004e>
 +0    L3 @0x00007f1d2d6b09a0  48 83 e4 f0          and    $0xfffffffffffffff0 %rsp -> %rsp
 +4    m4 @0x00007f1d2d6b14b0                       <label note=0x0000000000000001>
 +4    L4 @0x00007f1d2d6b0ba0  e9 4a 00 00 00       jmp    @0x00007f1d2d6b0b20[8byte]
 +9    m4 @0x00007f1d2d6b1600                       <label note=0x0000000000000002>
 +9    m4 @0x00007f1d2d6b0f68                       <label note=0x000000000000004e>
 +9    L3 @0x00007f1d2d6b1ca0  48 83 e4 f0          and    $0xfffffffffffffff0 %rsp -> %rsp
 +13   m4 @0x00007f1d2d6b0b20                       <label note=0x000000000000004f>
 +13   L3 @0x00007f1d2d6b0920  67 e3 01             addr32 jecxz  $0x0000000000401008 %ecx