### PR TITLE
i#4842 drcachesim unit tests: Add cache_lru unit test

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -499,7 +499,8 @@ endif ()
 # Be sure to give the targets qualified test names ("tool.drcache*...").
 
 if (BUILD_TESTS)
-  add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp tests/cache_replacement_policy_unit_test.cpp)
+  add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp
+    tests/cache_replacement_policy_unit_test.cpp)
   if (ZLIB_FOUND)
     target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator
       drmemtrace_static drmemtrace_analyzer ${ZLIB_LIBRARIES})

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -499,6 +499,17 @@ endif ()
 # Be sure to give the targets qualified test names ("tool.drcache*...").
 
 if (BUILD_TESTS)
+  add_executable(tool.drcachesim.cache_lru_unit_tests tests/cache_lru_unit_tests.cpp)
+  if (ZLIB_FOUND)
+    target_link_libraries(tool.drcachesim.cache_lru_unit_tests drmemtrace_simulator
+      drmemtrace_static drmemtrace_analyzer ${ZLIB_LIBRARIES})
+  else ()
+    target_link_libraries(tool.drcachesim.cache_lru_unit_tests drmemtrace_simulator
+      drmemtrace_static drmemtrace_analyzer)
+  endif ()
+  add_win32_flags(tool.drcachesim.cache_lru_unit_tests)
+  add_test(NAME tool.drcachesim.cache_lru_unit_tests
+           COMMAND tool.drcachesim.cache_lru_unit_tests)
   add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp)
   if (ZLIB_FOUND)
     target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -87,6 +87,7 @@ macro (add_exported_library name type)
   add_dependencies(${name} api_headers)
 endmacro ()
 
+add_exported_library(drcachesim_cache_replacement_policy_test STATIC tests/cache_replacement_policy_unit_test.cpp)
 add_exported_library(drmemtrace_reuse_distance STATIC tools/reuse_distance.cpp)
 add_exported_library(drmemtrace_histogram STATIC tools/histogram.cpp)
 add_exported_library(drmemtrace_reuse_time STATIC tools/reuse_time.cpp)
@@ -499,23 +500,12 @@ endif ()
 # Be sure to give the targets qualified test names ("tool.drcache*...").
 
 if (BUILD_TESTS)
-  add_executable(tool.drcachesim.cache_lru_unit_tests tests/cache_lru_unit_tests.cpp)
-  if (ZLIB_FOUND)
-    target_link_libraries(tool.drcachesim.cache_lru_unit_tests drmemtrace_simulator
-      drmemtrace_static drmemtrace_analyzer ${ZLIB_LIBRARIES})
-  else ()
-    target_link_libraries(tool.drcachesim.cache_lru_unit_tests drmemtrace_simulator
-      drmemtrace_static drmemtrace_analyzer)
-  endif ()
-  add_win32_flags(tool.drcachesim.cache_lru_unit_tests)
-  add_test(NAME tool.drcachesim.cache_lru_unit_tests
-           COMMAND tool.drcachesim.cache_lru_unit_tests)
   add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp)
   if (ZLIB_FOUND)
-    target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator
+    target_link_libraries(tool.drcachesim.unit_tests drcachesim_cache_replacement_policy_test drmemtrace_simulator
       drmemtrace_static drmemtrace_analyzer ${ZLIB_LIBRARIES})
   else ()
-    target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator
+    target_link_libraries(tool.drcachesim.unit_tests drcachesim_cache_replacement_policy_test drmemtrace_simulator
       drmemtrace_static drmemtrace_analyzer)
   endif ()
   add_win32_flags(tool.drcachesim.unit_tests)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -87,7 +87,6 @@ macro (add_exported_library name type)
   add_dependencies(${name} api_headers)
 endmacro ()
 
-add_exported_library(drcachesim_cache_replacement_policy_test STATIC tests/cache_replacement_policy_unit_test.cpp)
 add_exported_library(drmemtrace_reuse_distance STATIC tools/reuse_distance.cpp)
 add_exported_library(drmemtrace_histogram STATIC tools/histogram.cpp)
 add_exported_library(drmemtrace_reuse_time STATIC tools/reuse_time.cpp)
@@ -500,12 +499,12 @@ endif ()
 # Be sure to give the targets qualified test names ("tool.drcache*...").
 
 if (BUILD_TESTS)
-  add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp)
+  add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp tests/cache_replacement_policy_unit_test.cpp)
   if (ZLIB_FOUND)
-    target_link_libraries(tool.drcachesim.unit_tests drcachesim_cache_replacement_policy_test drmemtrace_simulator
+    target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator
       drmemtrace_static drmemtrace_analyzer ${ZLIB_LIBRARIES})
   else ()
-    target_link_libraries(tool.drcachesim.unit_tests drcachesim_cache_replacement_policy_test drmemtrace_simulator
+    target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator
       drmemtrace_static drmemtrace_analyzer)
   endif ()
   add_win32_flags(tool.drcachesim.unit_tests)

--- a/clients/drcachesim/tests/cache_lru_unit_tests.cpp
+++ b/clients/drcachesim/tests/cache_lru_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -75,7 +75,7 @@ public:
             exit(1);
         }
 
-        // Access the cacheclines in set 1 in the following sequence and ensure the
+        // Access the cache lines in set 1 in the following sequence and ensure the
         // counters are updated properly.
         access_update(1, 6);
         access_update(1, 1);

--- a/clients/drcachesim/tests/cache_lru_unit_tests.cpp
+++ b/clients/drcachesim/tests/cache_lru_unit_tests.cpp
@@ -1,0 +1,106 @@
+/* **********************************************************
+ * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+// Unit tests for cache_lru
+#include <iostream>
+#include <assert.h>
+#include "simulator/cache_lru.h"
+
+struct cache_config_t {
+    int associativity = 4;
+    int line_size = 32;
+    int total_size = 256;
+    caching_device_t *parent = nullptr;
+    caching_device_stats_t *stats = new cache_stats_t(line_size, "", true);
+    prefetcher_t *prefetcher = nullptr;
+    bool inclusive = true;
+    bool coherent_cache = true;
+    int id = -1;
+    snoop_filter_t *snoop_filter = nullptr;
+};
+
+static cache_config_t
+make_test_configs(int associativity, int line_size, int total_size)
+{
+    cache_config_t config;
+    config.associativity = associativity;
+    config.line_size = line_size;
+    config.total_size = total_size;
+    return config;
+}
+
+class cache_lru_test_t : public cache_lru_t {
+public:
+    void
+    unit_test_access_update()
+    {
+        // Create and initialize an 8-way set associative cache with line size of 32 and
+        // total size of 1024 bytes.
+        cache_config_t config_two = make_test_configs(8, 32, 1024);
+        if (!init(config_two.associativity, config_two.line_size, config_two.total_size,
+                  config_two.parent, config_two.stats, config_two.prefetcher,
+                  config_two.inclusive, config_two.coherent_cache, config_two.id,
+                  config_two.snoop_filter)) {
+            std::cerr << "LRU cache failed to initialize"
+                      << "\n";
+            exit(1);
+        }
+
+        // Access the cacheclines in set 1 in the following sequence and ensure the
+        // counters are updated properly.
+        access_update(1, 6);
+        access_update(1, 1);
+        access_update(1, 2);
+        access_update(1, 3);
+        access_update(1, 4);
+        access_update(1, 5);
+        access_update(1, 0);
+        access_update(1, 7);
+
+        assert(get_caching_device_block(1, 0).counter_ == 1);
+        assert(get_caching_device_block(1, 1).counter_ == 6);
+        assert(get_caching_device_block(1, 2).counter_ == 5);
+        assert(get_caching_device_block(1, 3).counter_ == 4);
+        assert(get_caching_device_block(1, 4).counter_ == 3);
+        assert(get_caching_device_block(1, 5).counter_ == 2);
+        assert(get_caching_device_block(1, 6).counter_ == 7);
+        assert(get_caching_device_block(1, 7).counter_ == 0);
+    }
+};
+
+int
+main(int argc, const char *argv[])
+{
+    cache_lru_test_t cache_lru;
+    cache_lru.unit_test_access_update();
+    return 0;
+}

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -44,8 +44,7 @@ public:
     {
         caching_device_stats_t *stats = new cache_stats_t(line_size, "", true);
         if (!init(associativity, line_size, total_size, nullptr, stats, nullptr)) {
-            std::cerr << "LRU cache failed to initialize"
-                      << "\n";
+            std::cerr << "LRU cache failed to initialize\n";
             exit(1);
         }
     }

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -41,9 +41,7 @@ public:
     void
     unit_test_replace_which_way()
     {
-        // Create and initialize a 4-way set associative cache with line size of 32 and
-        // total size of 256 bytes.
-        initialize_cache(4, 32, 256);
+        initialize_cache(/*associativity=*/4, /*line_size=*/32, /*total_size=*/256);
 
         // Access the cache line in the following fashion. This sequence follows the
         // sequence shown in https://github.com/DynamoRIO/dynamorio/issues/4881.

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -55,7 +55,7 @@ public:
     unit_test_replace_which_way()
     {
         // Create and initialize a 4-way set associative cache with line size of 32 and
-        // total size of 128 bytes.
+        // total size of 256 bytes.
         // 0            32          64         96
         //  ----------------------------------------------
         // |   way 0    |   way 1   |   way 2   |  way 3  |

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -32,6 +32,7 @@
 
 // Unit tests for cache replacement policies
 #include <iostream>
+#undef NDEBUG
 #include <assert.h>
 #include "cache_replacement_policy_unit_test.h"
 #include "simulator/cache_lru.h"

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -50,7 +50,7 @@ struct cache_config_t {
 };
 
 static cache_config_t
-make_test_configs(int associativity, int line_size, int total_size)
+make_test_config(int associativity, int line_size, int total_size)
 {
     cache_config_t config;
     config.associativity = associativity;
@@ -59,40 +59,126 @@ make_test_configs(int associativity, int line_size, int total_size)
     return config;
 }
 
-void
-cache_lru_test_t::unit_test_replace_which_way()
-{
-    // Create and initialize an 8-way set associative cache with line size of 32 and
-    // total size of 256 bytes.
-    cache_config_t config_two = make_test_configs(8, 32, 256);
-    if (!init(config_two.associativity, config_two.line_size, config_two.total_size,
-              config_two.parent, config_two.stats, config_two.prefetcher,
-              config_two.inclusive, config_two.coherent_cache, config_two.id,
-              config_two.snoop_filter)) {
-        std::cerr << "LRU cache failed to initialize"
-                  << "\n";
-        exit(1);
+class cache_lru_test_t : public cache_lru_t {
+public:
+    void
+    unit_test_replace_which_way()
+    {
+        // Create and initialize a 4-way set associative cache with line size of 32 and
+        // total size of 128 bytes.
+        // 0            32          64         96
+        //  ----------------------------------------------
+        // |   way 0    |   way 1   |   way 2   |  way 3  |
+        // -----------------------------------------------
+        cache_config_t config_1 = make_test_config(4, 32, 256);
+        if (!init(config_1.associativity, config_1.line_size, config_1.total_size,
+                  config_1.parent, config_1.stats, config_1.prefetcher,
+                  config_1.inclusive, config_1.coherent_cache, config_1.id,
+                  config_1.snoop_filter)) {
+            std::cerr << "LRU cache failed to initialize"
+                      << "\n";
+            exit(1);
+        }
+
+        memref_t ref_1;
+        ref_1.data.type = TRACE_TYPE_READ;
+        ref_1.data.size = 1;
+        for (int i = 0; i < 256; i++) {
+            ref_1.data.addr = i;
+            request(ref_1);
+        }
+        // Access the ways in the following fashion. This sequence follows the sequence
+        // shown in https://github.com/DynamoRIO/dynamorio/issues/4881.
+        // Access the ways in 3, 0, 1, 2 order.
+        ref_1.data.addr = 192; // Access way 3 ("a" in issue 4881).
+        request(ref_1);
+
+        ref_1.data.addr = 0; // Access way 0 ("b" in issue 4881).
+        request(ref_1);
+
+        ref_1.data.addr = 64; // Access way 1 ("c" in issue 4881).
+        request(ref_1);
+
+        ref_1.data.addr = 128; // Access way 2 ("d" in issue 4881).
+        request(ref_1);
+
+        assert(replace_which_way(0) == 3);
+
+        // Create and initialize an 8-way set associative cache with line size of 32 and
+        // total size of 256 bytes.
+        cache_config_t config_2 = make_test_config(8, 32, 256);
+        if (!init(config_2.associativity, config_2.line_size, config_2.total_size,
+                  config_2.parent, config_2.stats, config_2.prefetcher,
+                  config_2.inclusive, config_2.coherent_cache, config_2.id,
+                  config_2.snoop_filter)) {
+            std::cerr << "LRU cache failed to initialize"
+                      << "\n";
+            exit(1);
+        }
+
+        memref_t ref_2;
+        ref_2.data.type = TRACE_TYPE_READ;
+        ref_2.data.size = 1;
+        for (int i = 0; i < 256; i++) {
+            ref_2.data.addr = i;
+            request(ref_2);
+        }
+
+        // Access the ways in 1, 0, 2, 3, 4, 5, 7, 6 order.
+        ref_2.data.addr = 32; // Access way 1.
+        request(ref_2);
+
+        ref_2.data.addr = 0; // Access way 0.
+        request(ref_2);
+
+        ref_2.data.addr = 64; // Access way 2.
+        request(ref_2);
+
+        ref_2.data.addr = 96; // Access way 3.
+        request(ref_2);
+
+        ref_2.data.addr = 128; // Access way 4.
+        request(ref_2);
+
+        ref_2.data.addr = 160; // Access way 5.
+        request(ref_2);
+
+        ref_2.data.addr = 224; // Access way 7.
+        request(ref_2);
+
+        ref_2.data.addr = 192; // Access way 6.
+        request(ref_2);
+
+        assert(replace_which_way(0) == 1);
+
+        // Access the ways in 2, 1, 0, 3, 4, 5, 7, 6 order.
+        ref_2.data.addr = 64; // Access way 2.
+        request(ref_2);
+
+        ref_2.data.addr = 32; // Access way 1.
+        request(ref_2);
+
+        ref_2.data.addr = 0; // Access way 0.
+        request(ref_2);
+
+        ref_2.data.addr = 96; // Access way 3.
+        request(ref_2);
+
+        ref_2.data.addr = 128; // Access way 4.
+        request(ref_2);
+
+        ref_2.data.addr = 160; // Access way 5.
+        request(ref_2);
+
+        ref_2.data.addr = 192; // Access way 6.
+        request(ref_2);
+
+        ref_2.data.addr = 224; // Access way 7.
+        request(ref_2);
+
+        assert(replace_which_way(0) == 2);
     }
-
-    memref_t ref;
-    ref.data.type = TRACE_TYPE_READ;
-    ref.data.size = 1;
-    for (int i = 0; i < 256; i++) {
-        ref.data.addr = i;
-        request(ref);
-    }
-
-    assert(get_caching_device_block(0, 0).counter_ == 7);
-    assert(get_caching_device_block(0, 1).counter_ == 6);
-    assert(get_caching_device_block(0, 2).counter_ == 5);
-    assert(get_caching_device_block(0, 3).counter_ == 4);
-    assert(get_caching_device_block(0, 4).counter_ == 3);
-    assert(get_caching_device_block(0, 5).counter_ == 2);
-    assert(get_caching_device_block(0, 6).counter_ == 1);
-    assert(get_caching_device_block(0, 7).counter_ == 0);
-
-    assert(replace_which_way(0) == 0);
-}
+};
 
 void
 unit_test_cache_replacement_policy()

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
@@ -1,0 +1,47 @@
+/* **********************************************************
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _CACHE_REPL_POLICY_UNIT_TESTS_
+#define _CACHE_REPL_POLICY_UNIT_TESTS_ 1
+
+#include "simulator/cache_lru.h"
+
+class cache_lru_test_t : public cache_lru_t {
+public:
+    void
+    unit_test_replace_which_way();
+};
+
+void
+unit_test_cache_replacement_policy();
+
+#endif /* _CACHE_REPL_POLICY_UNIT_TESTS_ */

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
@@ -35,12 +35,6 @@
 
 #include "simulator/cache_lru.h"
 
-class cache_lru_test_t : public cache_lru_t {
-public:
-    void
-    unit_test_replace_which_way();
-};
-
 void
 unit_test_cache_replacement_policy();
 

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
@@ -33,8 +33,6 @@
 #ifndef _CACHE_REPLACEMENT_POLICY_UNIT_TESTS_
 #define _CACHE_REPLACEMENT_POLICY_UNIT_TESTS_ 1
 
-#include "simulator/cache_lru.h"
-
 void
 unit_test_cache_replacement_policy();
 

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
@@ -30,12 +30,12 @@
  * DAMAGE.
  */
 
-#ifndef _CACHE_REPL_POLICY_UNIT_TESTS_
-#define _CACHE_REPL_POLICY_UNIT_TESTS_ 1
+#ifndef _CACHE_REPLACEMENT_POLICY_UNIT_TESTS_
+#define _CACHE_REPLACEMENT_POLICY_UNIT_TESTS_ 1
 
 #include "simulator/cache_lru.h"
 
 void
 unit_test_cache_replacement_policy();
 
-#endif /* _CACHE_REPL_POLICY_UNIT_TESTS_ */
+#endif /* _CACHE_REPLACEMENT_POLICY_UNIT_TESTS_ */

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -33,6 +33,7 @@
 // Unit tests for drcachesim
 #include <iostream>
 #include <cstdlib>
+#undef NDEBUG
 #include <assert.h>
 #include "cache_replacement_policy_unit_test.h"
 #include "simulator/cache_simulator.h"

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <cstdlib>
 #include <assert.h>
+#include "cache_replacement_policy_unit_test.h"
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
 
@@ -313,5 +314,6 @@ main(int argc, const char *argv[])
     unit_test_warmup_refs();
     unit_test_sim_refs();
     unit_test_child_hits();
+    unit_test_cache_replacement_policy();
     return 0;
 }


### PR DESCRIPTION
This change adds unit tests for clients/drcachesim/simulators/cache_lru.cpp.
These unit tests catch issues reported in i#4881 which was tested by
reverting the fix for that issue #4883.
    
Issue: #4842, #4881
