### PR TITLE
Add rstats and alloc type to beyond-vmm diagnostics

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -2132,6 +2132,9 @@ drbbdup_exit(void)
         if (opts.is_stat_enabled)
             dr_mutex_destroy(stat_mutex);
 
+        /* Reset for re-attach. */
+        new_case_cache_pc = NULL;
+
     } else {
         /* Cannot have more than one initialisation of drbbdup. */
         return DRBBDUP_ERROR;

--- a/suite/tests/api/static_prepop.c
+++ b/suite/tests/api/static_prepop.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -131,10 +131,7 @@ main(int argc, const char *argv[])
         dr_stats_t stats = { sizeof(dr_stats_t) };
         bool got_stats = dr_get_stats(&stats);
         assert(got_stats);
-        // TODO(#2964): remove the conditional below when the issue is addressed.
-        // At that point, the stats should have been reset at reattach.
-        if (i == 0)
-            assert(stats.basic_block_count == 0);
+        assert(stats.basic_block_count == 0);
 #    ifdef ARM
         /* Our asm is arm, not thumb. */
         dr_isa_mode_t old_mode;


### PR DESCRIPTION
Adds diagnostics and fixes related to running out of memory with
drmemtrace now using drbbdup:

Augments the beyond-vmm diagnostics to dump the rstats and print the
allocation type.

Makes a beyond-vmm event non-fatal for -satisfy_w_xor_x for vmheap.

Resets a global drbbdup variable for reattach.

Removes a conditional for static_prepop that is not needed now that
stats are reset on reattach (#2964).

Issue: #2964