### PR TITLE
i#5195 win2019: Improve dbghelp.dll searching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2022 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2018 Arm Limited          All rights reserved.
 # **********************************************************
@@ -1463,36 +1463,37 @@ endmacro()
 # tests in our suite.
 # The system dbghelp pre-Vista is too old, so we copy one from VS.
 # We locate it here for use in both subdirs.
+# We just try all variants that we can to avoid the complexities of which
+# versions are in "Program Files" vs "Program Files (x86)".
+set(PROGFILES "$ENV{PROGRAMW6432}")
+set(PROGFILES32 "$ENV{ProgramFiles\(x86\)}")
+if ("${PROGFILES}" STREQUAL "")
+  set(PROGFILES "$ENV{PROGRAMFILES}")
+endif ()
 if (X64)
-  set(PROGFILES "$ENV{PROGRAMW6432}") # cmake is 32-bit
-  set(PROGFILES32 "$ENV{ProgramFiles\(x86\)}")
-  if ("${PROGFILES32}" STREQUAL "")
-    set(PROGFILES32 "$ENV{PROGRAMFILES}")
-  endif ()
   set(ARCH_SFX "x64")
 else (X64)
-  set(PROGFILES "$ENV{PROGRAMFILES}")
-  set(PROGFILES32 "$ENV{PROGRAMFILES}")
   set(ARCH_SFX "x86")
 endif (X64)
 set(dbghelp_paths
   "${PROGFILES32}/Microsoft Visual Studio/*/Professional/Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
+  "${PROGFILES}/Microsoft Visual Studio/*/Professional/Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
+  "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
   "${PROGFILES}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
-  "${PROGFILES32}/Windows Kits/*/Debuggers/${ARCH_SFX}/dbghelp.dll")
+  "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/dbghelp.dll"
+  "${PROGFILES}/Microsoft Visual Studio */Common7/IDE/dbghelp.dll"
+  "${PROGFILES32}/Windows Kits/*/Debuggers/${ARCH_SFX}/dbghelp.dll"
+  "${PROGFILES}/Windows Kits/*/Debuggers/${ARCH_SFX}/dbghelp.dll")
+# Older DTFW installed into its own dir:
 if (X64)
   set(dbghelp_paths ${dbghelp_paths}
-    # For Visual Studio 2010+, x64 dbghelp.dll resides in Program
-    # Files (x86) rather than Program Files.
-    "${PROGFILES32}/Microsoft Visual Studio */Common7/IDE/Remote Debugger/${ARCH_SFX}/dbghelp.dll"
-    # Older DTFW installed into its own dir:
     "${PROGFILES}/Debugging Tools for Windows (x64)/dbghelp.dll")
-else (X64)
+else ()
   set(dbghelp_paths ${dbghelp_paths}
-    "${PROGFILES}/Microsoft Visual Studio */Common7/IDE/dbghelp.dll"
-    # Older DTFW installed into its own dir:
-    "${PROGFILES}/Debugging Tools for Windows/dbghelp.dll")
-endif (X64)
+  "${PROGFILES}/Debugging Tools for Windows/dbghelp.dll")
+endif ()
 file(GLOB dbghelp_loc ${dbghelp_paths})
+message(STATUS "For dbghelp, choosing among: ${dbghelp_loc}")
 if (dbghelp_loc)
   # i#1219: exclude VS2005 x64 dbghelp as it is buggy
   list(LENGTH dbghelp_loc dbghelp_max)


### PR DESCRIPTION
Searches both Program Files and Program Files (x86) for dbghelp.dll to
fix problems where 32-bit fails to find an SDK or VS version and ends
up using the system version which DR"s private loader has trouble
with.

Adds a CMake status message listing all the dghelp.dll paths found, to
help diagnose selection issues.

Issue: #5195