### PR TITLE
i#5195 win2019: Relax drsyms-test output ordering

### DIFF
--- a/suite/tests/client-interface/drsyms-test.templatex
+++ b/suite/tests/client-interface/drsyms-test.templatex
@@ -1,6 +1,6 @@
 #ifdef WINDOWS
-compound arg std::nothrow_t has 0 field\(s\), size 1
-(compound arg `anonymous-namespace'::HasFields has 4 field\(s\), size 12
+(compound arg std::nothrow_t has 0 field\(s\), size 1
+compound arg `anonymous-namespace'::HasFields has 4 field\(s\), size 12
   class field 0 is type 1 and size 4
   class field 1 is type 1 and size 1
   class field 2 is type 1 and size 2
@@ -9,6 +9,16 @@ compound arg `anonymous-namespace'::Foo has 1 field\(s\), size 1
   class field 0 is type 3 and size 0
     func has 1 args
       arg 0 is type 1 and size 4
+|compound arg std::nothrow_t has 0 field\(s\), size 1
+compound arg `anonymous-namespace'::Foo has 1 field\(s\), size 1
+  class field 0 is type 3 and size 0
+    func has 1 args
+      arg 0 is type 1 and size 4
+compound arg `anonymous-namespace'::HasFields has 4 field\(s\), size 12
+  class field 0 is type 1 and size 4
+  class field 1 is type 1 and size 1
+  class field 2 is type 1 and size 2
+  class field 3 is type 6 and size 4
 |compound arg `anonymous-namespace'::Foo has 1 field\(s\), size 1
   class field 0 is type 3 and size 0
     func has 1 args
@@ -18,6 +28,17 @@ compound arg `anonymous-namespace'::HasFields has 4 field\(s\), size 12
   class field 1 is type 1 and size 1
   class field 2 is type 1 and size 2
   class field 3 is type 6 and size 4
+compound arg std::nothrow_t has 0 field\(s\), size 1
+|compound arg `anonymous-namespace'::HasFields has 4 field\(s\), size 12
+  class field 0 is type 1 and size 4
+  class field 1 is type 1 and size 1
+  class field 2 is type 1 and size 2
+  class field 3 is type 6 and size 4
+compound arg `anonymous-namespace'::Foo has 1 field\(s\), size 1
+  class field 0 is type 3 and size 0
+    func has 1 args
+      arg 0 is type 1 and size 4
+compound arg std::nothrow_t has 0 field\(s\), size 1
 )found all overloads
 found name_outer::name_middle::name_inner::sample_class<>::nested_class<>::templated_func<>
 found name_outer::name_middle::name_inner::sample_class<>::nested_class<>::templated_func<>


### PR DESCRIPTION
Relaxes the ordering of symbols found through the dbghelp iterator to
handle orderings seen with VS2019.

This has the client.drsyms-test (and client.drsyms-testgcc) tests now
passing for both 32-bit and 64-bit on my VS2019 local setup.
Unfortunately the GA CI setup has further problems.

Issue: #5195