### PR TITLE
i#5421: Prevent app from closing dual_map_file.

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -325,15 +325,15 @@ static int min_dr_fd;
  */
 static generic_table_t *fd_table;
 #define INIT_HTABLE_SIZE_FD 6 /* should remain small */
-/* vmm_heap_unit_init creates the dual_map_file before the fd_table is created
- * by d_r_os_init. This is due to constraints on the order of invoking various
- * init routines in dynamorio_app_init_part_two_finalize. This means that
- * fd_table_add would not be able to really save the dual_map_file FD.
- * Therefore, we have to remember the FD so that we can add it to the fd_table
- * later when we create it. This is required when we are running with
- * -satisfy_w_xor_x.
- * XXX: try refactoring init code so that we don't have to track dual_map_file_fd
- * and add it later.
+/* DR needs to open some files before the fd_table is allocated by d_r_os_init:
+ * - dynamorio_app_init_part_one_options opens the global log file when logging
+ *   is enabled in the debug build.
+ * - vmm_heap_unit_init opens the dual_map_file when -satisfy_w_xor_x is set.
+ * This is due to constraints on the order of invoking various init routines in
+ * the dynamorio_app_init_part_* routines.
+ * For these files, fd_table_add would not be able to really add the FD.
+ * Therefore, we have to remember them so that we can add it to fd_table later
+ * when we create it.
  */
 #define MAX_FD_ADD_PRE_HEAP 2
 static int fd_add_pre_heap[MAX_FD_ADD_PRE_HEAP];

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1380,6 +1380,7 @@ os_slow_exit(void)
 
     if (doing_detach) {
         vsyscall_page_start = NULL;
+        ASSERT(num_fd_add_pre_heap == 0);
     }
 
     DELETE_LOCK(set_thread_area_lock);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -325,12 +325,13 @@ static int min_dr_fd;
  */
 static generic_table_t *fd_table;
 #define INIT_HTABLE_SIZE_FD 6 /* should remain small */
-/* DR needs to open some files before the fd_table is allocated by d_r_os_init:
+/* DR needs to open some files before the fd_table is allocated by d_r_os_init.
+ * This is due to constraints on the order of invoking various init routines in
+ * the dynamorio_app_init_part_* routines.
  * - dynamorio_app_init_part_one_options opens the global log file when logging
  *   is enabled in the debug build.
  * - vmm_heap_unit_init opens the dual_map_file when -satisfy_w_xor_x is set.
- * This is due to constraints on the order of invoking various init routines in
- * the dynamorio_app_init_part_* routines.
+
  * For these files, fd_table_add would not be able to really add the FD.
  * Therefore, we have to remember them so that we can add it to fd_table later
  * when we create it.
@@ -4154,7 +4155,7 @@ fd_table_add(file_t fd, uint flags)
     } else {
         /* We come here only for the main_logfile and the dual_map_file. */
         ASSERT(num_fd_add_pre_heap < MAX_FD_ADD_PRE_HEAP &&
-               (DYNAMO_OPTION(satisfy_w_xor_x) ? 2 : 1) <= MAX_FD_ADD_PRE_HEAP &&
+               (num_fd_add_pre_heap < DYNAMO_OPTION(satisfy_w_xor_x) ? 2 : 1) &&
                "only main_logfile and dual_map_file should come here");
         if (num_fd_add_pre_heap < MAX_FD_ADD_PRE_HEAP) {
             /* We add the main_logfile and dual_map_file in d_r_os_init() */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4155,7 +4155,7 @@ fd_table_add(file_t fd, uint flags)
     } else {
         /* We come here only for the main_logfile and the dual_map_file. */
         ASSERT(num_fd_add_pre_heap < MAX_FD_ADD_PRE_HEAP &&
-               (num_fd_add_pre_heap < DYNAMO_OPTION(satisfy_w_xor_x) ? 2 : 1) &&
+               num_fd_add_pre_heap < (DYNAMO_OPTION(satisfy_w_xor_x) ? 2 : 1) &&
                "only main_logfile and dual_map_file should come here");
         if (num_fd_add_pre_heap < MAX_FD_ADD_PRE_HEAP) {
             /* We add the main_logfile and dual_map_file in d_r_os_init() */

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4153,12 +4153,13 @@ fd_table_add(file_t fd, uint flags)
                          (void *)(ptr_uint_t)(flags | OS_OPEN_RESERVED));
         TABLE_RWLOCK(fd_table, write, unlock);
     } else {
-        /* We come here only for the main_logfile and the dual_map_file. */
+        /* We come here only for the main_logfile and the dual_map_file, which
+         * we add to the fd_table in d_r_os_init().
+         */
         ASSERT(num_fd_add_pre_heap < MAX_FD_ADD_PRE_HEAP &&
                num_fd_add_pre_heap < (DYNAMO_OPTION(satisfy_w_xor_x) ? 2 : 1) &&
                "only main_logfile and dual_map_file should come here");
         if (num_fd_add_pre_heap < MAX_FD_ADD_PRE_HEAP) {
-            /* We add the main_logfile and dual_map_file in d_r_os_init() */
             fd_add_pre_heap[num_fd_add_pre_heap] = fd;
             fd_add_pre_heap_flags[num_fd_add_pre_heap] = flags;
             num_fd_add_pre_heap++;

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -945,7 +945,7 @@ d_r_os_init(void)
 #endif
     if (DYNAMO_OPTION(satisfy_w_xor_x)) {
         ASSERT(dual_map_file_fd != 0);
-        fd_table_add(dual_map_file_fd, OS_OPEN_CLOSE_ON_FORK);
+        fd_table_add(dual_map_file_fd, 0 /*keep across fork*/);
         dual_map_file_fd = 0;
     }
 
@@ -4450,7 +4450,7 @@ os_create_memory_file(const char *name, size_t size)
     }
     fd = priv_fd;
     fd_mark_close_on_exec(fd); /* We could use MFD_CLOEXEC for memfd_create. */
-    fd_table_add(fd, OS_OPEN_CLOSE_ON_FORK);
+    fd_table_add(fd, 0 /*keep across fork*/);
     return fd;
 #else
     ASSERT_NOT_IMPLEMENTED(false && "i#3556 NYI for Mac");

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -942,7 +942,8 @@ d_r_os_init(void)
     /* Add to fd_table the entries that we could not add before as fd_table was
      * not initialized.
      */
-    while (num_fd_add_pre_heap--) {
+    while (num_fd_add_pre_heap > 0) {
+        num_fd_add_pre_heap--;
         fd_table_add(fd_add_pre_heap[num_fd_add_pre_heap],
                      fd_add_pre_heap_flags[num_fd_add_pre_heap]);
     }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -113,7 +113,7 @@ set(main_run_list
   "SHORT::X86::ONLY::client.events$::-code_api -thread_private -disable_traces"
   "SHORT::X86::LIN::ONLY::client.events$::-code_api -no_early_inject" # only early on ARM
   # XXX i#3556: NYI on Windows and Mac (and not supported on 32-bit).
-  "SHORT::X64::LIN::ONLY::drcache.*\\.simple$|selfmod2|racesys|reachability|fork|file_io$::-code_api -satisfy_w_xor_x"
+  "SHORT::X64::LIN::ONLY::drcache.*\\.simple$|selfmod2|racesys|reachability|fork|file_io|loglevel$::-code_api -satisfy_w_xor_x"
   # maybe this should be SHORT as -coarse_units will eventually be the default?
   "X86::-code_api -opt_memory"       # i#1575: ARM -coarse_units NYI
   "X86::-code_api -opt_speed"        # i#1551: ARM indcall2direct NYI

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -113,7 +113,7 @@ set(main_run_list
   "SHORT::X86::ONLY::client.events$::-code_api -thread_private -disable_traces"
   "SHORT::X86::LIN::ONLY::client.events$::-code_api -no_early_inject" # only early on ARM
   # XXX i#3556: NYI on Windows and Mac (and not supported on 32-bit).
-  "SHORT::X64::LIN::ONLY::drcache.*\\.simple$|selfmod2|racesys|reachability|fork$::-code_api -satisfy_w_xor_x"
+  "SHORT::X64::LIN::ONLY::drcache.*\\.simple$|selfmod2|racesys|reachability|fork|file_io$::-code_api -satisfy_w_xor_x"
   # maybe this should be SHORT as -coarse_units will eventually be the default?
   "X86::-code_api -opt_memory"       # i#1575: ARM -coarse_units NYI
   "X86::-code_api -opt_speed"        # i#1551: ARM indcall2direct NYI


### PR DESCRIPTION
Adds the `dual_map_file` to the DR `fd_table`. This is to prevent the app from
closing this FD, which manifests as an OOM on an extending commit.

Unfortunately, due to constraints on the order of invocation of
`vmm_heap_unit_init` and `d_r_os_init` in `dynamorio_app_init_part_two_finalize`,
the `fd_table` is not initialized when the `dual_map_file` is created. This means that
`fd_table_add` will not really add it to the `fd_table`. So, we remember the
`dual_map_file_fd` and add it to `fd_table` when we create it.

Modifies the handling for the global log file to use the same mechanism, instead of
adding it explicitly in the DEBUG build.

Also adds a `-satisfy_w_xor_x` variant for the `client.file_io` test which attempts to
close DR FDs. It fails without adding `dual_map_file` to `fd_table`.

Also adds the same variant for the `common.loglevel` test where both, the global
log file and the `dual_map_file`, are recorded for  later `fd_table_add`.

Fixes: #5421