### PR TITLE
i#5195 win2019: Switch to VS2019 in GA CI and docs

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2021 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -51,9 +51,9 @@ defaults:
 
 jobs:
   ###########################################################################
-  # 32-bit VS2017 and tests:
-  vs2017-32:
-    runs-on: windows-2016
+  # 32-bit VS2019 and tests:
+  vs2019-32:
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
         set PATH=c:\projects\install\ninja;%PATH%
         7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
         set PATH=c:\projects\install\doxygen;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
@@ -104,7 +104,7 @@ jobs:
           on ${{github.event_name}} at ${{github.ref}}
         body: |
           Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/vs2017-32
+          Workflow: ${{github.workflow}}/vs2019-32
           Repository: ${{github.repository}}
           Branch ref: ${{github.ref}}
           SHA: ${{github.sha}}
@@ -116,9 +116,9 @@ jobs:
         from: Github Action CI
 
   ###########################################################################
-  # 64-bit VS2017 and tests:
-  vs2017-64:
-    runs-on: windows-2016
+  # 64-bit VS2019 and tests:
+  vs2019-64:
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2
@@ -147,7 +147,7 @@ jobs:
         set PATH=c:\projects\install\ninja;%PATH%
         7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
         set PATH=c:\projects\install\doxygen;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
@@ -169,7 +169,7 @@ jobs:
           on ${{github.event_name}} at ${{github.ref}}
         body: |
           Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/vs2017-64
+          Workflow: ${{github.workflow}}/vs2019-64
           Repository: ${{github.repository}}
           Branch ref: ${{github.ref}}
           SHA: ${{github.sha}}
@@ -181,72 +181,7 @@ jobs:
         from: Github Action CI
 
   ###########################################################################
-  # 32-bit and 64-bit VS2017 release builds:
-  vs2017-builds:
-    runs-on: windows-2016
-
-    steps:
-    - uses: actions/checkout@v2
-
-    # Cancel any prior runs for a PR (but do not cancel master branch runs).
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'pull_request' }}
-
-    - name: Fetch Sources
-      run: git fetch --no-tags --depth=1 origin master
-
-    - name: Download Packages
-      shell: powershell
-      run: |
-        md c:\projects\install
-        (New-Object System.Net.WebClient).DownloadFile("https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip", "c:\projects\install\ninja.zip")
-        (New-Object System.Net.WebClient).DownloadFile("https://sourceforge.net/projects/doxygen/files/rel-1.8.19/doxygen-1.8.19.windows.x64.bin.zip", "c:\projects\install\doxygen.zip")
-
-    - name: Run Suite
-      working-directory: ${{ github.workspace }}
-      run: |
-        echo ------ Setting up paths ------
-        7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
-        set PATH=c:\projects\install\ninja;%PATH%
-        7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
-        set PATH=c:\projects\install\doxygen;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
-        echo ------ Running suite ------
-        echo PATH is "%PATH%"
-        echo Running in directory "%CD%"
-        perl suite/runsuite_wrapper.pl automated_ci use_ninja nontest_only
-      env:
-        CI_TRIGGER: ${{ github.event_name }}
-        CI_BRANCH: ${{ github.ref }}
-
-    - name: Send failure mail to dynamorio-devs
-      if: failure() && github.ref == 'refs/heads/master'
-      uses: dawidd6/action-send-mail@v2
-      with:
-        server_address: smtp.gmail.com
-        server_port: 465
-        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
-        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
-        subject: |
-          [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
-        body: |
-          Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/vs2017-builds
-          Repository: ${{github.repository}}
-          Branch ref: ${{github.ref}}
-          SHA: ${{github.sha}}
-          Triggering actor: ${{github.actor}}
-          Triggering event: ${{github.event_name}}
-          Run Id: ${{github.run_id}}
-          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
-        to: dynamorio-devs@googlegroups.com
-        from: Github Action CI
-
-  ###########################################################################
-  # 32-bit and 64-bit VS2019 debug builds:
+  # 32-bit and 64-bit VS2019 release builds:
   vs2019-builds:
     runs-on: windows-2019
 
@@ -281,7 +216,7 @@ jobs:
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
-        perl suite/runsuite_wrapper.pl automated_ci use_ninja debug_only build_only
+        perl suite/runsuite_wrapper.pl automated_ci use_ninja nontest_only
       env:
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}

--- a/api/docs/building.dox
+++ b/api/docs/building.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -66,7 +66,7 @@ To build DynamoRIO on Linux, use the following commands as a guide.  This builds
 
 To build DynamoRIO on Windows, first install the following software.
 
-  - Visual Studio 2017.  Other versions are not officially supported as our automated tests use VS 2017.
+  - Visual Studio 2019.  Other versions are not officially supported as our automated tests use VS 2019.
   - [CMake](http://cmake.org/cmake/resources/software.html). 3.7+ is required. When prompted, we recommend adding it to your PATH.
   - Git.  Any flavor should do, including [Git on Windows](https://git-scm.com/download/win) or Cygwin git.
   - Perl.  We recommend either [Strawberry Perl](http://strawberryperl.com/) or Cygwin perl.
@@ -74,7 +74,7 @@ To build DynamoRIO on Windows, first install the following software.
 
 Once these dependencies are installed, you need to generate your project and solution files for Visual Studio using CMake.  The easiest way to do this is to launch a cmd prompt with the right environment from the Visual Studio folder in the Start menu.
 
-To build 32-bit DynamoRIO in release mode, launch the `Visual Studio 2017 > x86 Native Tools Command Prompt for VS 2017` and run the following commands:
+To build 32-bit DynamoRIO in release mode, launch the `Visual Studio 2019 > x86 Native Tools Command Prompt for VS 2019` and run the following commands:
 
   ```
   # Get sources.
@@ -83,7 +83,7 @@ To build 32-bit DynamoRIO in release mode, launch the `Visual Studio 2017 > x86 
   # supported.
   $ cd dynamorio && mkdir build && cd build
   # Configure using cmake.  Pass in the path to your source directory.
-  $ cmake -G"Visual Studio 15" ..
+  $ cmake -G"Visual Studio 16" ..
   # Build from the command line.  Alternatively, open ALL_BUILD.vcproj in Visual
   # Studio and build from there.  You must pass --config to work around a cmake
   # bug.  (http://www.cmake.org/Bug/view.php?id=11830)
@@ -92,7 +92,7 @@ To build 32-bit DynamoRIO in release mode, launch the `Visual Studio 2017 > x86 
   $ bin32\drrun.exe notepad.exe
   ```
 
-If you need a 64-bit build, choose `x64 Native Tools Command Prompt` and pass `-G"Visual Studio 15 Win64"` to cmake.
+If you need a 64-bit build, choose `x64 Native Tools Command Prompt` and pass `-G"Visual Studio 16 Win64"` to cmake.
 
 An alternative to the command prompt is to execute the appropriate vcvars.bat command for your compiler in your shell of choice.
 
@@ -112,7 +112,7 @@ $ make -j
 
 or on Windows:
 ```
-$ cmake -G"Visual Studio 15" .. -DDEBUG=ON
+$ cmake -G"Visual Studio 16" .. -DDEBUG=ON
 $ cmake --build . --config Debug
 ```
 
@@ -121,7 +121,7 @@ produce a debug build currently.
 
 For 64-bit build on Windows:
 ```
-$ cmake -G"Visual Studio 15 Win64" .. -DDEBUG=ON
+$ cmake -G"Visual Studio 16 Win64" .. -DDEBUG=ON
 $ cmake --build . --config Debug
 ```
 
@@ -286,7 +286,7 @@ Support for aarch64-on-x86 on Windows is not yet finished; nor is support for ot
 ## Compiler
 
 First, you need the compiler, linker, and associated tools.
-Install Visual Studio 2017 which is the version used by our automated tests.
+Install Visual Studio 2019 which is the version used by our automated tests.
 
 You need to use a shell with command line support for using your
 compiler.  For example, this could be the `cmd` shell or a Cygwin shell.
@@ -391,10 +391,10 @@ slashes) for all variables except for `PATH`:
       export PATH=`cygpath -u ${SDKROOT}/VC/Bin/amd64`:`cygpath -u ${SDKROOT2}/bin/x64`:`cygpath -u ${SDKROOT}/VC/Bin`:${PRE_VS_PATH}
   }
 
-  function compilerVS2017_32 {
-      export CMAKEGEN="Visual Studio 15"
-      export VSVER=$(ls -1t /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/Professional/VC/Tools/MSVC | head -1)
-      export VSBASE=$(cygpath -d /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/Professional)
+  function compilerVS2019_32 {
+      export CMAKEGEN="Visual Studio 16"
+      export VSVER=$(ls -1t /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Professional/VC/Tools/MSVC | head -1)
+      export VSBASE=$(cygpath -d /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Professional)
       export VSROOT=$(cygpath -d ${VSBASE}/VC/Tools/MSVC/$VSVER)
       # We assume SDK 10
       export KITROOT=$(cygpath -d /c/Program\ Files\ \(x86\)/Windows\ Kits/10)
@@ -409,10 +409,10 @@ slashes) for all variables except for `PATH`:
       export PATH=`cygpath -u ${VSROOT}/bin/HostX86/x86`:`cygpath -u ${KITROOT}/bin/x86`:`cygpath -u ${KITROOT}/bin/${KITVER}/x86`:`cygpath -u ${VSBASE}/Common7/IDE`:${PRE_VS_PATH}
   }
 
-  function compilerVS2017_64 {
-      export CMAKEGEN="Visual Studio 15 Win64"
-      export VSVER=$(ls -1t /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/Professional/VC/Tools/MSVC | head -1)
-      export VSBASE=$(cygpath -d /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017/Professional)
+  function compilerVS2019_64 {
+      export CMAKEGEN="Visual Studio 16 Win64"
+      export VSVER=$(ls -1t /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Professional/VC/Tools/MSVC | head -1)
+      export VSBASE=$(cygpath -d /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019/Professional)
       export VSROOT=$(cygpath -d ${VSBASE}/VC/Tools/MSVC/$VSVER)
       # We assume SDK 10
       export KITROOT=$(cygpath -d /c/Program\ Files\ \(x86\)/Windows\ Kits/10)
@@ -427,8 +427,8 @@ slashes) for all variables except for `PATH`:
       export PATH=`cygpath -u ${VSROOT}/bin/HostX64/x64`:`cygpath -u ${KITROOT}/bin/x64`:`cygpath -u ${KITROOT}/bin/${KITVER}/x64`:`cygpath -u ${VSBASE}/Common7/IDE`:${PRE_VS_PATH}
   }
 
-  if test -e /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2017; then
-      compilerVS2017_32
+  if test -e /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio/2019; then
+      compilerVS2019_32
   elif test -e /c/Program\ Files\ \(x86\)/Microsoft\ Visual\ Studio\ 12.0; then
       compilerVS2013_32
   fi
@@ -485,7 +485,7 @@ cd build
 cmake-gui ..
 ```
 
-Press Configure.  On Windows, select **Visual Studio 15 2017**.  On Linux, select **Unix Makefiles**.
+Press Configure.  On Windows, select **Visual Studio 16 2019**.  On Linux, select **Unix Makefiles**.
 
 If you are on Linux, `ccmake`, a curses-based GUI, can be used instead of `cmake-gui`;
 it generates **Unix Makefiles** by default.  In `ccmake`, press `c` to configure.
@@ -581,7 +581,7 @@ cd build
 E:\dynamorio\build\>"c:\Program Files (x86)\CMake 3.7\bin\cmake-gui.exe" ..\
 \endverbatim
    - step 4.1: click "Configure" button
-   - step 4.2: select "Visual Studio 15"
+   - step 4.2: select "Visual studio 16"
    - step 4.3: generate configuration file
  - step 5: build and install
 \verbatim
@@ -597,7 +597,7 @@ On Windows:
 ```
 mkdir build
 cd build
-cmake -G"Visual Studio 15" -DBUILD_DOCS:BOOL=OFF ..
+cmake -G"Visual studio 16" -DBUILD_DOCS:BOOL=OFF ..
 cmake --build . --config Release
 ```
 
@@ -658,13 +658,12 @@ flag is set by default for not only parallel project builds but parallel file
 builds.  The fastest DynamoRIO build is a Visual Studio build from
 the command line.
 
-First, DynamoRIO requires CMake version 3.7 or higher (to support
-Visual Studio 2017).
+First, DynamoRIO requires CMake version 3.7 or higher.
 
 Then you can generate the Visual Studio project files with something like this:
 
 ```
-cmake -G"Visual Studio 15" -DDEBUG=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF ../src
+cmake -G"Visual studio 16" -DDEBUG=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF ../src
 ```
 
 You can build from the command line (actually for any generator) with this:
@@ -806,7 +805,7 @@ CMAKE_MAKE_PROGRAM variable at configuration time.  In a Visual Studio Command
 Prompt, MSBuild is on the PATH, so the absolute path is not needed:
 
 ```
-cmake -G"Visual Studio 15" -DCMAKE_MAKE_PROGRAM:FILEPATH=MSBuild ../src
+cmake -G"Visual studio 16" -DCMAKE_MAKE_PROGRAM:FILEPATH=MSBuild ../src
 ```
 
 Don't forget to pass the "/m" flag (after "--") as shown above when building.

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -206,6 +206,9 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             # FIXME i#2145: ignoring certain Windows CI test failures until
             # we get all tests passing.
             %ignore_failures_32 = (
+                # i#5195: These are failing on GA Server19.
+                'code_api|client.drsyms-test' => 1, # i#5195
+                'code_api|client.tls' => 1, # i#5195
                 # i#4131: These are failing on GA Server16 and need investigation.
                 # Some also failed on Appveyor (i#4058).
                 'code_api|win32.earlythread' => 1, # i#4131
@@ -242,7 +245,12 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api,thread_private,disable_traces|common.decode-stress' => 1, # i#1807
                 'code_api,thread_private,tracedump_binary|common.decode-stress' => 1, # i#1807
                 );
+
             %ignore_failures_64 = (
+                # i#5195: These are failing on GA Server19.
+                'code_api|client.drsyms-test' => 1, # i#5195
+                'code_api|client.drsyms-testgcc' => 1, # i#5195
+                'code_api|client.tls' => 1, # i#5195
                 # i#4131: These are failing on GA Server16 and need investigation.
                 # Some also failed on Appveyor (i#4058).
                 'code_api|client.cleancall' => 1, # i#4618


### PR DESCRIPTION
Updates our official supported Windows toolchain from VS2017 to VS2019.
Updates the documentation on how to build.

Updates our GA CI jobs.
Adds 3 tests to the ignore list as they fail on this platform and we
do not yet have fixes.

Issue: #5195