### PR TITLE
i#5195 win2019: Fix client.tls test.

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -208,7 +208,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             %ignore_failures_32 = (
                 # i#5195: These are failing on GA Server19.
                 'code_api|client.drsyms-test' => 1, # i#5195
-                'code_api|client.tls' => 1, # i#5195
                 # i#4131: These are failing on GA Server16 and need investigation.
                 # Some also failed on Appveyor (i#4058).
                 'code_api|win32.earlythread' => 1, # i#4131
@@ -250,7 +249,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 # i#5195: These are failing on GA Server19.
                 'code_api|client.drsyms-test' => 1, # i#5195
                 'code_api|client.drsyms-testgcc' => 1, # i#5195
-                'code_api|client.tls' => 1, # i#5195
                 # i#4131: These are failing on GA Server16 and need investigation.
                 # Some also failed on Appveyor (i#4058).
                 'code_api|client.cleancall' => 1, # i#4618

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1031,9 +1031,6 @@ function(template2expect outexpect template runops key)
   elseif ("${CMAKE_SYSTEM_VERSION}" STRLESS "6.3")
     set(rundefs "${rundefs} -DRUNREGRESSION_WIN8")
   endif ()
-  if (WIN32 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 19.0)
-    set(rundefs "${rundefs} -DPRE_VS2015")
-  endif ()
   if (${key}_is_cygwin)
     # i#1478 option used to avoid cygwin messes up output issue: though
     # whether the output is messed up seems to depend on the cygwin version,

--- a/suite/tests/client-interface/tls.template
+++ b/suite/tests/client-interface/tls.template
@@ -1,32 +1,20 @@
-#if !defined(WINDOWS) || !defined(PRE_VS2015)
 in foo_t::foo_t
-# ifdef WINDOWS
-// XXX i#4030: It is unclear why there's a 2nd one for the main thread.
 in foo_t::foo_t
-# endif
-in foo_t::foo_t
-#endif
 sum is 14
 static TLS is 0xdeadbeef
-#if !defined(WINDOWS) || !defined(PRE_VS2015)
 foo.val is 0xdeadbeef
-# ifdef WINDOWS
+#ifdef WINDOWS
 vector holds 0xdeadbeef
-# endif
-in foo_t::foo_t
 #endif
+in foo_t::foo_t
 sum is 14
 static TLS is 0xdeadbeef
-#if !defined(WINDOWS) || !defined(PRE_VS2015)
 foo.val is 0xdeadbeef
-# ifdef WINDOWS
+#ifdef WINDOWS
 vector holds 0xdeadbeef
-# endif
 #endif
 static TLS is 0xdeadbef0
-#if !defined(WINDOWS) || !defined(PRE_VS2015)
 foo.val is 0xdeadbeee
-# ifdef WINDOWS
+#ifdef WINDOWS
 vector holds 0xdeadbeee
-# endif
 #endif


### PR DESCRIPTION
Fixes the expected output for client.tls on Windows. The previous template
accounts for a mysterious output line, which we're not seeing anymore on
vs2019, so we just remove it from the expected output.

Also removes support for PRE_VS2015, seeing as we're effectively dropping
support for vs2017 too by removing the above-mentioned line.

Issue: #5195