### PR TITLE
i#5411 bbdup mem: Eliminate per-block bookkeeping for no-dup usage

### DIFF
--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -581,6 +581,10 @@ drbbdup_duplicate_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_tr
 {
     dr_emit_flags_t emit_flags = DR_EMIT_DEFAULT;
 
+    /* XXX i#5400: By integrating drbbdup into drmgr we should be able to simplify
+     * some of these awkward conditions where we have to handle a missing manager in
+     * order to not waste memory when duplication is disabled.
+     */
     if (opts.non_default_case_limit == 0)
         return emit_flags;
 
@@ -906,6 +910,10 @@ drbbdup_do_analysis(void *drcontext, drbbdup_per_thread *pt, hashtable_t *manage
 
     /* Perform analysis for default case. Note, we do the analysis even if the manager
      * does not have dups enabled.
+     */
+    /* XXX i#5400: By integrating drbbdup into drmgr we should be able to simplify
+     * some of these awkward conditions where we have to handle a missing manager in
+     * order to not waste memory when duplication is disabled.
      */
     drbbdup_case_t empty = { 0, true };
     if (manager == NULL)

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -579,7 +579,10 @@ static dr_emit_flags_t
 drbbdup_duplicate_phase(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
                         bool translating)
 {
-    dr_emit_flags_t emit_flags;
+    dr_emit_flags_t emit_flags = DR_EMIT_DEFAULT;
+
+    if (opts.non_default_case_limit == 0)
+        return emit_flags;
 
     if (is_thread_private) {
         drbbdup_per_thread *pt =
@@ -834,7 +837,7 @@ drbbdup_do_case_analysis(drbbdup_manager_t *manager, void *drcontext, void *tag,
 
     void *case_analysis_data = NULL;
     dr_emit_flags_t flags = DR_EMIT_DEFAULT;
-    if (manager->enable_dup) {
+    if (manager != NULL && manager->enable_dup) {
         instr_t *pre = NULL;  /* used for stitching */
         instr_t *post = NULL; /* used for stitching */
         instrlist_t *case_bb = drbbdup_extract_bb_copy(drcontext, bb, start, &pre, &post);
@@ -880,14 +883,15 @@ drbbdup_do_analysis(void *drcontext, drbbdup_per_thread *pt, hashtable_t *manage
 
     drbbdup_manager_t *manager =
         (drbbdup_manager_t *)hashtable_lookup(manager_table, tag);
-    ASSERT(manager != NULL, "manager cannot be NULL");
+    ASSERT(manager != NULL || opts.non_default_case_limit == 0,
+           "manager cannot be NULL unless dups are globally disabled");
 
     /* Perform orig analysis - only done once regardless of how many copies. */
     pt->orig_analysis_data = drbbdup_do_orig_analysis(manager, drcontext, tag, bb, first);
 
     /* Perform analysis for each (non-default) case. */
     dr_emit_flags_t emit_flags = DR_EMIT_DEFAULT;
-    if (manager->enable_dup) {
+    if (manager != NULL && manager->enable_dup) {
         ASSERT(manager->cases != NULL, "case information must exit");
         int i;
         for (i = 0; i < opts.non_default_case_limit; i++) {
@@ -903,7 +907,11 @@ drbbdup_do_analysis(void *drcontext, drbbdup_per_thread *pt, hashtable_t *manage
     /* Perform analysis for default case. Note, we do the analysis even if the manager
      * does not have dups enabled.
      */
-    case_info = &manager->default_case;
+    drbbdup_case_t empty = { 0, true };
+    if (manager == NULL)
+        case_info = &empty;
+    else
+        case_info = &manager->default_case;
     ASSERT(case_info->is_defined, "default case must be defined");
     pt->default_analysis_data = drbbdup_do_case_analysis(
         manager, drcontext, tag, bb, first, for_trace, translating, case_info,
@@ -1402,16 +1410,20 @@ drbbdup_instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *i
            "one of the instrument call-back functions must be non-NULL");
     ASSERT(pt->case_index != DRBBDUP_IGNORE_INDEX, "case index cannot be ignored");
 
+    drbbdup_case_t empty = { 0, true };
     if (pt->case_index == DRBBDUP_DEFAULT_INDEX) {
         /* Use default case. */
-        drbbdup_case = &manager->default_case;
+        if (manager == NULL)
+            drbbdup_case = &empty;
+        else
+            drbbdup_case = &manager->default_case;
         analysis_data = pt->default_analysis_data;
     } else {
         ASSERT(pt->case_analysis_data != NULL,
                "container for analysis data cannot be NULL");
         ASSERT(pt->case_index >= 0 && pt->case_index < opts.non_default_case_limit,
                "case index cannot be out-of-bounds");
-        ASSERT(manager->enable_dup, "bb dup must be enabled");
+        ASSERT(manager != NULL && manager->enable_dup, "bb dup must be enabled");
 
         drbbdup_case = &manager->cases[pt->case_index];
         analysis_data = pt->case_analysis_data[pt->case_index];
@@ -1564,7 +1576,7 @@ drbbdup_instrument_without_dups(void *drcontext, void *tag, instrlist_t *bb,
                                 instr_t *instr, bool for_trace, bool translating,
                                 drbbdup_per_thread *pt, drbbdup_manager_t *manager)
 {
-    ASSERT(manager->cases == NULL, "case info should not be needed");
+    ASSERT(manager == NULL || manager->cases == NULL, "case info should not be needed");
     ASSERT(pt != NULL, "thread-local storage should not be NULL");
 
     if (drmgr_is_first_instr(drcontext, instr)) {
@@ -1600,9 +1612,9 @@ drbbdup_destroy_all_analyses(void *drcontext, drbbdup_manager_t *manager,
             }
         }
         if (pt->default_analysis_data != NULL) {
-            opts.destroy_case_analysis(drcontext, manager->default_case.encoding,
-                                       opts.user_data, pt->orig_analysis_data,
-                                       pt->default_analysis_data);
+            opts.destroy_case_analysis(
+                drcontext, manager == NULL ? 0 : manager->default_case.encoding,
+                opts.user_data, pt->orig_analysis_data, pt->default_analysis_data);
             pt->default_analysis_data = NULL;
         }
     }
@@ -1623,10 +1635,11 @@ drbbdup_do_linking(void *drcontext, drbbdup_per_thread *pt, hashtable_t *manager
 
     drbbdup_manager_t *manager =
         (drbbdup_manager_t *)hashtable_lookup(manager_table, tag);
-    ASSERT(manager != NULL, "manager cannot be NULL");
+    ASSERT(manager != NULL || opts.non_default_case_limit == 0,
+           "manager cannot be NULL unless dups are globally disabled");
 
     dr_emit_flags_t flags = DR_EMIT_DEFAULT;
-    if (manager->enable_dup) {
+    if (manager != NULL && manager->enable_dup) {
         flags |= drbbdup_instrument_dups(drcontext, tag, bb, instr, for_trace,
                                          translating, pt, manager);
     } else {
@@ -2018,11 +2031,13 @@ drbbdup_thread_init(void *drcontext)
 
     pt->case_index = 0;
     pt->orig_analysis_data = NULL;
-    ASSERT(opts.non_default_case_limit > 0, "dup limit should be greater than zero");
-    pt->case_analysis_data = dr_custom_alloc(drcontext, DR_ALLOC_THREAD_PRIVATE,
-                                             sizeof(void *) * opts.non_default_case_limit,
-                                             DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
-    memset(pt->case_analysis_data, 0, sizeof(void *) * opts.non_default_case_limit);
+    if (opts.non_default_case_limit > 0) {
+        pt->case_analysis_data =
+            dr_custom_alloc(drcontext, DR_ALLOC_THREAD_PRIVATE,
+                            sizeof(void *) * opts.non_default_case_limit,
+                            DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
+        memset(pt->case_analysis_data, 0, sizeof(void *) * opts.non_default_case_limit);
+    }
 
     if (!opts.never_enable_dynamic_handling) {
         /* Dynamically allocated to avoid using space when not needed (128K per
@@ -2046,13 +2061,14 @@ drbbdup_thread_exit(void *drcontext)
     drbbdup_per_thread *pt =
         (drbbdup_per_thread *)drmgr_get_tls_field(drcontext, tls_idx);
     ASSERT(pt != NULL, "thread-local storage should not be NULL");
-    ASSERT(opts.non_default_case_limit > 0, "dup limit should be greater than zero");
 
     if (is_thread_private)
         hashtable_delete(&pt->manager_table);
 
-    dr_custom_free(drcontext, DR_ALLOC_THREAD_PRIVATE, pt->case_analysis_data,
-                   sizeof(void *) * opts.non_default_case_limit);
+    if (pt->case_analysis_data != NULL) {
+        dr_custom_free(drcontext, DR_ALLOC_THREAD_PRIVATE, pt->case_analysis_data,
+                       sizeof(void *) * opts.non_default_case_limit);
+    }
     if (pt->hit_counts != NULL) {
         DR_ASSERT_MSG(!opts.never_enable_dynamic_handling,
                       "should not reach here if dynamic cases were disabled globally");
@@ -2072,8 +2088,6 @@ drbbdup_check_options(drbbdup_options_t *ops_in)
     if (ops_in == NULL)
         return false;
     if (ops_in->set_up_bb_dups == NULL)
-        return false;
-    if (ops_in->non_default_case_limit == 0)
         return false;
     if (ops_in->struct_size < offsetof(drbbdup_options_t, analyze_case_ex)) {
         if (ops_in->instrument_instr == NULL)
@@ -2117,7 +2131,8 @@ drbbdup_init(drbbdup_options_t *ops_in)
 
     if (!drbbdup_check_options(ops_in))
         return DRBBDUP_ERROR_INVALID_PARAMETER;
-    if (!drbbdup_check_case_opnd(ops_in->runtime_case_opnd))
+    if (ops_in->non_default_case_limit > 0 &&
+        !drbbdup_check_case_opnd(ops_in->runtime_case_opnd))
         return DRBBDUP_ERROR_INVALID_OPND;
 
     if (ops_in->struct_size > sizeof(drbbdup_options_t) ||

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -237,8 +237,8 @@ typedef dr_emit_flags_t (*drbbdup_instrument_instr_ex_t)(
 
 /**
  * Specifies the options when initialising drbbdup. \p set_up_bb_dups
- * and \p instrument_instr cannot be NULL, while \p non_default_case_limit must be
- * greater than zero.
+ * and \p instrument_instr cannot be NULL.  \p runtime_case_opnd must be
+ * a pointer-sized memory reference, unless \p non_default_case_limit is 0.
  */
 typedef struct {
     /** Set this to the size of this structure. */
@@ -311,7 +311,9 @@ typedef struct {
     /**
      * The maximum number of alternative cases, excluding the default case, that can be
      * associated with a basic block. Once the limit is reached and an unhandled case is
-     * encountered, control is directed to the default case.
+     * encountered, control is directed to the default case.  If this is set to 0,
+     * no duplication is performed on any block, and 0 is passed as the encoding to the
+     * \p analyze_case and \p instrument_instr (and their extended version) callbacks.
      */
     ushort non_default_case_limit;
     /**

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2606,6 +2606,10 @@ tobuild_ci(client.drbbdup-no-encode-test client-interface/drbbdup-no-encode-test
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-no-encode-test.dll drbbdup)
 
+tobuild_ci(client.drbbdup-no-dup-test client-interface/drbbdup-no-dup-test.c "" "" "")
+use_DynamoRIO_extension(client.drbbdup-no-dup-test.dll drmgr)
+use_DynamoRIO_extension(client.drbbdup-no-dup-test.dll drbbdup)
+
 tobuild_ci(client.drbbdup-nonzero-test client-interface/drbbdup-nonzero-test.c "" "" "")
 use_DynamoRIO_extension(client.drbbdup-nonzero-test.dll drmgr)
 use_DynamoRIO_extension(client.drbbdup-nonzero-test.dll drbbdup)

--- a/suite/tests/client-interface/drbbdup-no-dup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-no-dup-test.dll.c
@@ -47,8 +47,6 @@ static uintptr_t
 set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
                bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
 {
-    drbbdup_status_t res;
-
     CHECK(enable_dups != NULL, "should not be NULL");
     CHECK(enable_dynamic_handling != NULL, "should not be NULL");
     CHECK(user_data == USER_DATA_VAL, "user data does not match");

--- a/suite/tests/client-interface/drbbdup-no-dup-test.dll.c
+++ b/suite/tests/client-interface/drbbdup-no-dup-test.dll.c
@@ -1,0 +1,117 @@
+/* **********************************************************
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Tests the drbbdup extension when encoding is not inserted at the start of
+ * basic blocks. It relies on drbbdup's guarantee that it does not modify
+ * any set encoding of a thread on its own accord.
+ */
+
+#include "dr_api.h"
+#include "client_tools.h"
+#include "drmgr.h"
+#include "drbbdup.h"
+
+#define USER_DATA_VAL (void *)222
+static bool instrum_called = false;
+
+static uintptr_t
+set_up_bb_dups(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    drbbdup_status_t res;
+
+    CHECK(enable_dups != NULL, "should not be NULL");
+    CHECK(enable_dynamic_handling != NULL, "should not be NULL");
+    CHECK(user_data == USER_DATA_VAL, "user data does not match");
+
+    *enable_dups = false;
+    *enable_dynamic_handling = false;
+    return 0;
+}
+
+static void
+print_case(void *tag, uintptr_t case_val)
+{
+    dr_fprintf(STDERR, "tag %p case %lu\n", tag, case_val);
+}
+
+static void
+instrument_instr(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                 instr_t *where, uintptr_t encoding, void *user_data,
+                 void *orig_analysis_data, void *analysis_data)
+{
+    bool is_start;
+    drbbdup_status_t res;
+
+    CHECK(user_data == USER_DATA_VAL, "user data does not match");
+    CHECK(orig_analysis_data == NULL, "orig analysis data should be NULL");
+    CHECK(analysis_data == NULL, "analysis should be NULL");
+
+    res = drbbdup_is_first_instr(drcontext, instr, &is_start);
+    CHECK(res == DRBBDUP_SUCCESS, "failed to check whether instr is start");
+
+    if (is_start && encoding != 0) {
+        dr_insert_clean_call(drcontext, bb, where, print_case, false, 2,
+                             OPND_CREATE_INTPTR(tag), OPND_CREATE_INTPTR(encoding));
+    } else {
+        instrum_called = true;
+    }
+}
+
+static void
+event_exit(void)
+{
+    drbbdup_status_t res = drbbdup_exit();
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");
+    CHECK(instrum_called, "instrumentation was not inserted");
+
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_init(client_id_t id)
+{
+    drmgr_init();
+
+    drbbdup_options_t opts = { 0 };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = set_up_bb_dups;
+    opts.instrument_instr = instrument_instr;
+    opts.atomic_load_encoding = false;
+    opts.user_data = USER_DATA_VAL;
+    /* Test disabling duplication completely. */
+    opts.non_default_case_limit = 0;
+
+    drbbdup_status_t res = drbbdup_init(&opts);
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup init failed");
+    dr_register_exit_event(event_exit);
+}

--- a/suite/tests/client-interface/drbbdup-no-dup-test.expect
+++ b/suite/tests/client-interface/drbbdup-no-dup-test.expect
@@ -1,0 +1,1 @@
+Hello, world!


### PR DESCRIPTION
Augments drbbdup to allow a value of 0 for
drbbdup_options_t.non_default_case_limit.  When it is set to 0, no
duplication will occur, and no per-block data structures will be
allocated, saving memory.

Adds a test case for this.

Updates drmemtrace to use this when multi-case options are not
selected.

Sanity test:
  Before:
```
  $ bin64/drrun -rstats_to_stderr -t drcachesim -offline -max_global_trace_refs 10K -- ~/spec2006/bzip2-test/bzip2_base.gcc-64bit ~/spec2006/bzip2-test/dryer.jpg 2
                Peak vmm blocks for unreachable heap :               747
              Peak vmm virtual memory in use (bytes) :           6963200
```
  After:
```
                Peak vmm blocks for unreachable heap :               631
              Peak vmm virtual memory in use (bytes) :           6389760
```
Along with the prior shift to use unreachable heap for per-block data
and then to eliminate and improve per-thread data, this concludes the
memory reductions for #5411.

Fixes #5411