### PR TITLE
Added missed unlock in case of failed binary search

### DIFF
--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -3335,7 +3335,8 @@ executable_area_overlap_bounds(app_pc start, app_pc end, app_pc *overlap_start /
     d_r_read_lock(&executable_areas->lock);
 
     /* Find first overlapping region */
-    if (!binary_search(executable_areas, start, end, NULL, &start_index, true /*first*/)) {
+    if (!binary_search(executable_areas, start, end, NULL, &start_index,
+                       true /*first*/)) {
         d_r_read_unlock(&executable_areas->lock);
         return false;
     }

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -3335,8 +3335,10 @@ executable_area_overlap_bounds(app_pc start, app_pc end, app_pc *overlap_start /
     d_r_read_lock(&executable_areas->lock);
 
     /* Find first overlapping region */
-    if (!binary_search(executable_areas, start, end, NULL, &start_index, true /*first*/))
+    if (!binary_search(executable_areas, start, end, NULL, &start_index, true /*first*/)) {
+        d_r_read_unlock(&executable_areas->lock);
         return false;
+    }
     ASSERT(start_index >= 0);
     if (frag_flags != 0) {
         for (i = start_index - 1; i >= 0; i--) {


### PR DESCRIPTION
There are some cases with null start and end app_pc-s during profiling java on AArch64.
As result, we caught hang in release build.
Kirill
