### PR TITLE
i#5427 compress: Add snappy_nocrc drmemtrace option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1766,6 +1766,9 @@ find_package(ZLIB)
 # On Ubuntu 14.10, 32-bit builds fail to link with -lsnappy, just ignore.
 if (UNIX AND X64)
   find_library(libsnappy snappy)
+  if (libsnappy)
+    message(STATUS "Found snappy: ${libsnappy}")
+  endif ()
 
   # Locate non-standard snappy directories on macOS.
   # TODO: Write proper package for snappy lookup.

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -274,10 +274,11 @@ droption_t<bytesize_t> op_exit_after_tracing(
 
 droption_t<std::string> op_raw_compress(
     DROPTION_SCOPE_CLIENT, "raw_compress", "none",
-    "Compression for raw offline files: \"snappy\", \"none\"",
-    "Specifies the compression type to use for raw offline files: either \"snappy\" "
-    "or \"none\".  Whether this reduces overhead depends on the storage type: for "
-    "an SSD this typically adds overhead and would only be used it space is at a "
+    "Compression for raw offline files: \"snappy\", \"snappy_nocrc\", \"none\"",
+    "Specifies the compression type to use for raw offline files: \"snappy\", "
+    "\"snappy_nocrc\" (snappy without checksums, which is much faster), or \"none\". "
+    "Whether this reduces overhead depends on the storage type: for "
+    "an SSD this typically adds overhead and would only be used if space is at a "
     "premium; for a spinning disk using snappy should be a performance win.");
 
 droption_t<bool> op_online_instr_types(

--- a/clients/drcachesim/common/snappy_consts.h
+++ b/clients/drcachesim/common/snappy_consts.h
@@ -47,6 +47,10 @@ protected:
     enum chunk_type_t : unsigned char {
         COMPRESSED_DATA = 0x00,
         UNCOMPRESSED_DATA = 0x01,
+        // We've added these no-CRC types only locally.
+        // XXX i#5427: Propose adding these to the public spec.
+        COMPRESSED_DATA_NO_CRC = 0x02,
+        UNCOMPRESSED_DATA_NO_CRC = 0x03,
         SKIP_BEGIN = 0x80,
         SKIP_END = 0xfd,
         PADDING = 0xfe,

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1026,7 +1026,8 @@ snappy that omits checksums (enabled with "snappy_crc" passed to -p
 raw_compress).  However, whether compressing the raw files is a net
 reduction in overhead depends on the storage medium; for an SSD it is
 typically slower to compress, though "snappy_crc" comes close to
-matching the uncompressed performance.
+matching the uncompressed performance.  For a spinning disk,
+compression should be a net win.
 
 Older versions of the simulator produced a single trace file containing all threads
 interleaved.  The \p -infile option supports reading these legacy files:

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1018,8 +1018,15 @@ subdirectory may be pointed at with \p -indir:
 $ bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/trace
 \endcode
 
-The canonical trace files may be manually compressed with gzip, as the
-trace reader supports reading gzipped files.
+If built with the zlib library, the canonical trace files are
+automatically compressed with gzip.  The trace reader supports reading
+gzip or snappy compressed files.  The raw files may also be compressed
+with the -p raw_compress option using either snappy or a version of
+snappy that omits checksums (enabled with "snappy_crc" passed to -p
+raw_compress).  However, whether compressing the raw files is a net
+reduction in overhead depends on the storage medium; for an SSD it is
+typically slower to compress, though "snappy_crc" comes close to
+matching the uncompressed performance.
 
 Older versions of the simulator produced a single trace file containing all threads
 interleaved.  The \p -infile option supports reading these legacy files:

--- a/clients/drcachesim/reader/snappy_file_reader.cpp
+++ b/clients/drcachesim/reader/snappy_file_reader.cpp
@@ -74,13 +74,18 @@ snappy_reader_t::check_magic()
 bool
 snappy_reader_t::read_data_chunk(uint32_t size, chunk_type_t type)
 {
-    char *buf =
-        (type == COMPRESSED_DATA) ? compressed_buf_.data() : uncompressed_buf_.data();
-    size_t max_size = (type == COMPRESSED_DATA) ? max_compressed_size_ : max_block_size_;
-    max_size += checksum_size_;
-    if (size < checksum_size_ || size > max_size) {
+    bool is_compressed = (type == COMPRESSED_DATA || type == COMPRESSED_DATA_NO_CRC);
+    bool has_checksum = (type == COMPRESSED_DATA || type == UNCOMPRESSED_DATA);
+    char *buf = is_compressed ? compressed_buf_.data() : uncompressed_buf_.data();
+    size_t max_size = is_compressed ? max_compressed_size_ : max_block_size_;
+    size_t crc_size = 0;
+    if (has_checksum) {
+        crc_size = checksum_size_;
+        max_size += crc_size;
+    }
+    if (size < crc_size || size > max_size) {
         ERRMSG("Corrupted chunk header. Size %u, want <= %zu >= %zu.\n", size, max_size,
-               checksum_size_);
+               crc_size);
         return false;
     }
 
@@ -92,14 +97,13 @@ snappy_reader_t::read_data_chunk(uint32_t size, chunk_type_t type)
     uint32_t read_checksum = 0;
     memcpy(&read_checksum, buf, 4);
 
-    src_.reset(new snappy::ByteArraySource(&uncompressed_buf_[checksum_size_],
-                                           size - checksum_size_));
+    src_.reset(
+        new snappy::ByteArraySource(&uncompressed_buf_[crc_size], size - crc_size));
 
     // Potentially uncompress.
-    if (type == COMPRESSED_DATA) {
+    if (is_compressed) {
         size_t uncompressed_chunk_size;
-        if (!snappy::GetUncompressedLength(&compressed_buf_[checksum_size_],
-                                           size - checksum_size_,
+        if (!snappy::GetUncompressedLength(&compressed_buf_[crc_size], size - crc_size,
                                            &uncompressed_chunk_size)) {
             ERRMSG("Failed getting snappy-compressed chunk length.\n");
             return false;
@@ -110,8 +114,8 @@ snappy_reader_t::read_data_chunk(uint32_t size, chunk_type_t type)
             return false;
         }
 
-        if (!snappy::RawUncompress(&compressed_buf_[checksum_size_],
-                                   size - checksum_size_, uncompressed_buf_.data())) {
+        if (!snappy::RawUncompress(&compressed_buf_[crc_size], size - crc_size,
+                                   uncompressed_buf_.data())) {
             ERRMSG("Failed decompressing snappy chunk\n");
             return false;
         }
@@ -119,12 +123,14 @@ snappy_reader_t::read_data_chunk(uint32_t size, chunk_type_t type)
                                                uncompressed_chunk_size));
     }
 
-    size_t dummy;
-    uint32_t checksum = mask_crc32(src_->Peek(&dummy), src_->Available());
-    if (checksum != read_checksum) {
-        ERRMSG("Checksum failure on snappy block. Want %x, got %x\n", read_checksum,
-               checksum);
-        return false;
+    if (has_checksum) {
+        size_t dummy;
+        uint32_t checksum = mask_crc32(src_->Peek(&dummy), src_->Available());
+        if (checksum != read_checksum) {
+            ERRMSG("Checksum failure on snappy block. Want %x, got %x\n", read_checksum,
+                   checksum);
+            return false;
+        }
     }
     return true;
 }
@@ -145,6 +151,8 @@ snappy_reader_t::read_new_chunk()
     case STREAM_IDENTIFIER: return read_magic(size); break;
     case COMPRESSED_DATA:
     case UNCOMPRESSED_DATA:
+    case COMPRESSED_DATA_NO_CRC:
+    case UNCOMPRESSED_DATA_NO_CRC:
         if (!check_magic())
             return false;
         return read_data_chunk(size, type);

--- a/clients/drcachesim/reader/snappy_file_reader.cpp
+++ b/clients/drcachesim/reader/snappy_file_reader.cpp
@@ -124,8 +124,8 @@ snappy_reader_t::read_data_chunk(uint32_t size, chunk_type_t type)
     }
 
     if (has_checksum) {
-        size_t dummy;
-        uint32_t checksum = mask_crc32(src_->Peek(&dummy), src_->Available());
+        size_t ignored;
+        uint32_t checksum = mask_crc32(src_->Peek(&ignored), src_->Available());
         if (checksum != read_checksum) {
             ERRMSG("Checksum failure on snappy block. Want %x, got %x\n", read_checksum,
                    checksum);

--- a/clients/drcachesim/tracer/snappy_file_writer.h
+++ b/clients/drcachesim/tracer/snappy_file_writer.h
@@ -63,9 +63,11 @@ class snappy_file_writer_t : snappy_consts_t {
 public:
     snappy_file_writer_t(file_t f,
                          ssize_t (*write_file)(file_t file, const void *data,
-                                               size_t count))
+                                               size_t count),
+                         bool include_checksums = true)
         : fd_(f)
         , write_func_(write_file)
+        , include_checksums_(include_checksums)
     {
     }
 
@@ -81,6 +83,7 @@ private:
     file_t fd_;
     char compressed_buf_[header_size_ + checksum_size_ + max_compressed_size_];
     ssize_t (*write_func_)(file_t file, const void *data, size_t count);
+    bool include_checksums_;
 };
 
 #endif /* _SNAPPY_FILE_WRITER_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3564,6 +3564,9 @@ if (BUILD_CLIENTS)
     # Sanity check for snappy compression of raw output files.
     torunonly_drcacheoff(raw-snappy ${ci_shared_app} "-raw_compress snappy" "" "")
     set(tool.drcacheoff.raw-snappy_expectbase "offline-simple")
+    torunonly_drcacheoff(raw-snappy-nocrc ${ci_shared_app}
+      "-raw_compress snappy_nocrc" "" "")
+    set(tool.drcacheoff.raw-snappy-nocrc_expectbase "offline-simple")
 
     # Test reading a trace in sharded snappy-compressed files.
     if (libsnappy)


### PR DESCRIPTION
Adds a new drmemtrace option -raw_compress snappy_nocrc.
This requests snappy compression but omitting checksums.
This is 2.5x faster than snappy with checksums.
This currently uses local-only snappy chunk types; we should
propose adding them to the public spec.

Adds a sanity test.

Issue: #5427