### PR TITLE
i#38 attach: Make -skip_syscall the default

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -126,7 +126,8 @@ clients.
 
 The changes between version \DR_VERSION and 9.0.1 include the following compatibility
 changes:
- - Nothing yet (placeholder).
+ - Eliminated the -skip_syscall option to drrun and drinject, which is now always
+   on by default.
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2390,8 +2390,11 @@ endif (ANNOTATIONS AND NOT ARM)
 
 if (NOT ANDROID) # TODO i#38: Port test to Android.
   tobuild_ci(client.attach_test client-interface/attach_test.runall "" "" "")
-  torunonly_ci(client.attach_blocking linux.infloop client.attach_test.dll
-    client-interface/attach_blocking.runall "" "" "")
+  if (UNIX)
+    # Test attaching during a blocking syscall.
+    torunonly_ci(client.attach_blocking linux.infloop client.attach_test.dll
+      client-interface/attach_blocking.runall "" "" "")
+  endif ()
 endif ()
 
 if (UNIX)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1317,6 +1317,9 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out pas
         # is failing).
         set(exe_ops "${exe_ops};-v;-attach")
       endif ()
+      if ("${runall}" MATCHES "<block>")
+        set(exe_ops "${exe_ops};-block")
+      endif ()
     else ()
       if ("${runall}" MATCHES "<attach>")
         # For attach we use attachee, which is identical to infloop, aside for writing
@@ -2386,10 +2389,9 @@ if (ANNOTATIONS AND NOT ARM)
 endif (ANNOTATIONS AND NOT ARM)
 
 if (NOT ANDROID) # TODO i#38: Port test to Android.
-  # TODO i#38: Add targeted Linux tests of attaching during a blocking syscall.
-  # That seems to happen with the infloop test on ARM already (we have to add
-  # -skip_syscall in runall.cmake).
   tobuild_ci(client.attach_test client-interface/attach_test.runall "" "" "")
+  torunonly_ci(client.attach_blocking linux.infloop client.attach_test.dll
+    client-interface/attach_blocking.runall "" "" "")
 endif ()
 
 if (UNIX)

--- a/suite/tests/client-interface/attach_blocking.expect
+++ b/suite/tests/client-interface/attach_blocking.expect
@@ -1,0 +1,6 @@
+starting
+thank you for testing attach
+thread init
+select error: Interrupted system call
+blocking syscall returned -1 errno=4
+done

--- a/suite/tests/client-interface/attach_blocking.expect
+++ b/suite/tests/client-interface/attach_blocking.expect
@@ -1,6 +1,4 @@
 starting
 thank you for testing attach
 thread init
-select error: Interrupted system call
-blocking syscall returned -1 errno=4
 done

--- a/suite/tests/client-interface/attach_blocking.runall
+++ b/suite/tests/client-interface/attach_blocking.runall
@@ -1,0 +1,1 @@
+<attach><block>

--- a/suite/tests/linux/infloop.c
+++ b/suite/tests/linux/infloop.c
@@ -118,15 +118,13 @@ main(int argc, const char *argv[])
             FD_ZERO(&set);
             FD_SET(pipefd[0], &set);
             int res = select(pipefd[0] + 1, &set, NULL, NULL, &timeout);
-            /* Don't print on EINTR nor on a timeout as both can happen depending
-             * on the timing of the attach.
+            /* For some kernels: our attach interrupts the syscall (which is not an
+             * auto-restart syscall) and returns EINTR.  Don't print on EINTR nor on a
+             * timeout as both can happen depending on the timing of the attach.
              */
-            if (res == -1 && errno == EINTR) {
-                /* What we expect for some kernels: our attach interrupted the
-                 * syscall, which is not an auto-restart syscall.
-                 */
-            } else if (res == -1)
+            if (res == -1 && errno != EINTR)
                 perror("select error");
+
             /* XXX i#38: We may want a test of an auto-restart syscall as well
              * once the injector handles that.
              */

--- a/suite/tests/runall.cmake
+++ b/suite/tests/runall.cmake
@@ -197,22 +197,8 @@ if ("${nudge}" MATCHES "<use-persisted>")
   endif ()
 elseif ("${nudge}" MATCHES "<attach>")
   set(nudge_cmd run_in_bg)
-
-  set(extra_ops "")
-  if (UNIX)
-    # We're not yet explicitly testing -skip_syscall b/c it's considered experimental,
-    # but we seem to need it on ARM where infloop is in a blocking syscall.
-    # Not sure why it's different vs other arches.
-    # XXX i#38: Add additional explicit tests of blocking syscalls, and then turn
-    # -skip_syscall on by default all the time.
-    execute_process(COMMAND uname -m OUTPUT_VARIABLE HOST_ARCH)
-    if ("${HOST_ARCH}" MATCHES "^arm")
-      set(extra_ops "@-skip_syscall")
-    endif ()
-  endif ()
-
   string(REGEX REPLACE "<attach>"
-    "${toolbindir}/drrun@-attach@${pid}${extra_ops}@-takeover_sleep@-takeovers@1000"
+    "${toolbindir}/drrun@-attach@${pid}@-takeover_sleep@-takeovers@1000"
     nudge "${nudge}")
   string(REGEX REPLACE "@" ";" nudge "${nudge}")
   execute_process(COMMAND "${toolbindir}/${nudge_cmd}" ${nudge}


### PR DESCRIPTION
Makes interrupting a blocking syscall on attach the default behavior.
Removes the -skip_syscall drrun/drinject parameter.
Adds a test by adding an optional blocking syscall to infloop.

Issue: #38