### PR TITLE
i#5456 cache_fifo: Add a method that returns next way to be replaced

### DIFF
--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -86,3 +86,14 @@ cache_fifo_t::replace_which_way(int block_idx)
     }
     return -1;
 }
+
+int
+cache_fifo_t::get_next_way_to_replace(int block_idx)
+{
+    for (int i = 0; i < associativity_; i++) {
+        if (get_caching_device_block(block_idx, i).counter_ == 1) {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/clients/drcachesim/simulator/cache_fifo.h
+++ b/clients/drcachesim/simulator/cache_fifo.h
@@ -52,6 +52,8 @@ protected:
     access_update(int line_idx, int way) override;
     int
     replace_which_way(int line_idx) override;
+    int
+    get_next_way_to_replace(int block_idx);
 };
 
 #endif /* _CACHE_FIFO_H_ */


### PR DESCRIPTION
Adds a non-state changing method get_next_way_to_replace() that
just returns the victim 'way' without updating the cache state. This
makes unit testing the FIFO cache replacement policy convenient.

Issue: #5456