### PR TITLE
i#5455 path-ignore-directory: Do not try to execute directories

### DIFF
--- a/suite/tests/libutil/frontend_test.c
+++ b/suite/tests/libutil/frontend_test.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2003 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -59,11 +59,13 @@ main()
     }
 
     path = getenv("PATH");
-    strncpy(path_buf, "test_dir:", 9);
-    strncat(path_buf, path, 512 - 10);
+    const char *const subdir = "test_dir:";
+    strncpy(path_buf, subdir, strlen(subdir));
+    strncat(path_buf, path, sizeof(full_path_buf) - strlen(subdir) - 1);
     setenv("PATH", path_buf, 1);
     drfront_create_dir("test_dir/test_ex");
-    if (drfront_searchenv("test_ex", "PATH", full_path_buf, 512, &ret) != DRFRONT_ERROR) {
+    if (drfront_searchenv("test_ex", "PATH", full_path_buf, sizeof(full_path_buf),
+                          &ret) != DRFRONT_ERROR) {
         printf("failed to ignore test_ex in PATH\n");
         return -1;
     }

--- a/suite/tests/libutil/frontend_test.c
+++ b/suite/tests/libutil/frontend_test.c
@@ -32,6 +32,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include "dr_api.h"
 #include "dr_frontend.h"
 
@@ -42,6 +43,10 @@ main()
 {
     bool dir_exists;
     int res;
+    const char *path;
+    char path_buf[512];
+    char full_path_buf[512];
+    bool ret;
     res = drfront_create_dir("test_dir");
     if (res != DRFRONT_SUCCESS && res != DRFRONT_EXIST) {
         printf("drfront_create_dir failed \n");
@@ -53,11 +58,22 @@ main()
         return -1;
     }
 
-    res = drfront_remove_dir("test_dir");
+    path = getenv("PATH");
+    strncpy(path_buf, "test_dir:", 9);
+    strncat(path_buf, path, 512 - 10);
+    setenv("PATH", path_buf, 1);
+    drfront_create_dir("test_dir/test_ex");
+    if (drfront_searchenv("test_ex", "PATH", full_path_buf, 512, &ret) != DRFRONT_ERROR) {
+        printf("failed to ignore test_ex in PATH\n");
+        return -1;
+    }
+
+    res = drfront_remove_dir("test_dir/test_ex");
     if (res != DRFRONT_SUCCESS) {
         printf("drfront_remove_dir failed\n");
         return -1;
     }
+    drfront_remove_dir("test_dir");
 #ifdef WINDOWS
     if (drfront_set_verbose(1) != DRFRONT_SUCCESS) {
         printf("drfront_set_verbose failed\n");

--- a/suite/tests/libutil/frontend_test.c
+++ b/suite/tests/libutil/frontend_test.c
@@ -31,6 +31,7 @@
  * DAMAGE.
  */
 
+#define _CRT_SECURE_NO_WARNINGS 1
 #include <stdio.h>
 #include <string.h>
 #include "dr_api.h"
@@ -43,9 +44,9 @@ main()
 {
     bool dir_exists;
     int res;
-    char path_env[512];
-    char path_buf[512];
-    char full_path_buf[512];
+    char path_env[4096];
+    char path_buf[4096];
+    char full_path_buf[4096];
     bool ret;
     res = drfront_create_dir("test_dir");
     if (res != DRFRONT_SUCCESS && res != DRFRONT_EXIST) {
@@ -58,8 +59,9 @@ main()
         return -1;
     }
 
-    if (drfront_get_env_var("PATH", path_env, sizeof(path_env)) != DRFRONT_SUCCESS) {
-        printf("failed to get env var\n");
+    res = drfront_get_env_var("PATH", path_env, sizeof(path_env));
+    if (res != DRFRONT_SUCCESS) {
+        printf("failed to get env var: %d\n", res);
         return -1;
     }
     const char *const subdir = "test_dir:";


### PR DESCRIPTION
I changed the required access mode to `DRFRONT_EXEC` to ciruumvent trying to execute files that aren't executable.
A new check in `drfront_searchenv()` is introduced to determine if the path in option is in fact a directory and should not be executed.

In this implementiation we are in the akward situation of calling `stat()` twice (first time in `drfront_access()` and then in `drfront_searchenv()`). An alternative approach would be to add a new variant for `drfront_access_mode_t` called `DRFRONT_ISDIR`. Though `ISDIR` isn't really an access mode.

So what would the preferable method be?

```
Fixes a bug where DynamoRIO tries to execute a directory or a file that
is not marked as executable when it is present in a directory contained
in the PATH environment variable.

Fixes #5455
```