### PR TITLE
i#5474: Eliminate stat glibc 2.33 dependence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,6 +611,11 @@ if (NOT UNIX)
     add_definitions(-D_X86_)
   endif (X64)
 endif (NOT UNIX)
+if (UNIX)
+  # Ensure we can export dr_stat_syscall() from drlibc and get everyone to agree
+  # that struct stat64 is the stat struct.
+  add_definitions(-D_LARGEFILE64_SOURCE)
+endif ()
 
 # Set up assembly support and CMAKE_CPP.
 # Note that in cmake < 2.6.4, I had to fix a bug in

--- a/core/drlibc/drlibc.h
+++ b/core/drlibc/drlibc.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -39,6 +39,15 @@
 
 #ifndef _DR_LIBC_H_
 #define _DR_LIBC_H_ 1
+
+#ifdef UNIX
+/* _LARGEFILE64_SOURCE should make libc struct match kernel. */
+#    ifndef _LARGEFILE64_SOURCE
+#        define _LARGEFILE64_SOURCE
+#    endif
+#    include <sys/types.h>
+#    include <sys/stat.h>
+#endif
 
 /* If the caller is using the DR API they'll have our types that way; else we
  * include globals_shared.h.
@@ -123,6 +132,9 @@ typedef struct _script_interpreter_t {
 bool
 find_script_interpreter(OUT script_interpreter_t *result, IN const char *fname,
                         ssize_t (*reader)(const char *pathname, void *buf, size_t count));
+
+ptr_int_t
+dr_stat_syscall(const char *fname, struct stat64 *st);
 #endif /* UNIX */
 
 #if defined(WINDOWS) && !defined(X64)

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -47,7 +47,9 @@
  * There are 3 different stat syscalls (SYS_oldstat, SYS_stat, and SYS_stat64)
  * and using _LARGEFILE64_SOURCE with SYS_stat64 is the best match.
  */
-#define _LARGEFILE64_SOURCE
+#ifndef _LARGEFILE64_SOURCE
+#    define _LARGEFILE64_SOURCE
+#endif
 /* for mmap-related #defines */
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/libutil/CMakeLists.txt
+++ b/libutil/CMakeLists.txt
@@ -51,6 +51,7 @@ include_directories(BEFORE
   ${PROJECT_SOURCE_DIR}/core/arch
   ${PROJECT_SOURCE_DIR}/core/arch/${ARCH_NAME}
   ${PROJECT_BINARY_DIR} # for events.h
+  ${PROJECT_SOURCE_DIR}/core/drlibc # drlibc.h
   )
 
 if (WIN32)

--- a/libutil/dr_frontend_unix.c
+++ b/libutil/dr_frontend_unix.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -53,6 +53,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include "dr_frontend.h"
+#include "drlibc.h"
 
 extern bool
 module_get_platform(file_t f, dr_platform_t *platform, dr_platform_t *alt_platform);
@@ -72,17 +73,18 @@ drfront_status_t
 drfront_access(const char *fname, drfront_access_mode_t mode, OUT bool *ret)
 {
     int r;
-    struct stat st;
+    struct stat64 st;
     uid_t euid;
 
     if (ret == NULL)
         return DRFRONT_ERROR_INVALID_PARAMETER;
 
-    r = stat(fname, &st);
+    /* Use the raw syscall to avoid glibc 2.33 deps (i#5474). */
+    r = dr_stat_syscall(fname, &st);
 
     if (r == -1) {
         *ret = false;
-        if (errno == EACCES || errno == ENOENT || errno == ENOTDIR)
+        if (r == -EACCES || r == -ENOENT || r == -ENOTDIR)
             return DRFRONT_SUCCESS;
         return DRFRONT_ERROR;
     } else if (mode == DRFRONT_EXIST) {
@@ -138,7 +140,7 @@ drfront_searchenv(const char *fname, const char *env_var, OUT char *full_path,
     drfront_status_t status_check = DRFRONT_ERROR;
     bool access_ret = false;
     int r;
-    struct stat st;
+    struct stat64 st;
 
     if (ret == NULL)
         return DRFRONT_ERROR_INVALID_PARAMETER;
@@ -176,7 +178,8 @@ drfront_searchenv(const char *fname, const char *env_var, OUT char *full_path,
                 // XXX: An other option to prevent calling stat() twice
                 // could be a new variant DRFRONT_NOTDIR for drfront_access_mode_t
                 // that drfront_access() then takes into account.
-                r = stat(realpath_buf, &st);
+                /* Use the raw syscall to avoid glibc 2.33 deps (i#5474). */
+                r = dr_stat_syscall(realpath_buf, &st);
                 if (r != -1 && !S_ISDIR(st.st_mode)) {
                     *ret = true;
                     snprintf(full_path, full_path_size, "%s", realpath_buf);
@@ -333,12 +336,13 @@ drfront_get_app_full_path(const char *app, OUT char *buf, size_t buflen /*# elem
 drfront_status_t
 drfront_dir_exists(const char *path, OUT bool *is_dir)
 {
-    struct stat st_buf;
+    struct stat64 st_buf;
     if (is_dir == NULL)
         return DRFRONT_ERROR_INVALID_PARAMETER;
 
     /* check if path is a file or directory */
-    if (stat(path, &st_buf) != 0) {
+    /* Use the raw syscall to avoid glibc 2.33 deps (i#5474). */
+    if (dr_stat_syscall(path, &st_buf) != 0) {
         *is_dir = false;
         return DRFRONT_ERROR_INVALID_PATH;
     } else {

--- a/libutil/dr_frontend_unix.c
+++ b/libutil/dr_frontend_unix.c
@@ -82,7 +82,7 @@ drfront_access(const char *fname, drfront_access_mode_t mode, OUT bool *ret)
     /* Use the raw syscall to avoid glibc 2.33 deps (i#5474). */
     r = dr_stat_syscall(fname, &st);
 
-    if (r == -1) {
+    if (r < 0) {
         *ret = false;
         if (r == -EACCES || r == -ENOENT || r == -ENOTDIR)
             return DRFRONT_SUCCESS;
@@ -180,7 +180,7 @@ drfront_searchenv(const char *fname, const char *env_var, OUT char *full_path,
                 // that drfront_access() then takes into account.
                 /* Use the raw syscall to avoid glibc 2.33 deps (i#5474). */
                 r = dr_stat_syscall(realpath_buf, &st);
-                if (r != -1 && !S_ISDIR(st.st_mode)) {
+                if (r == 0 && !S_ISDIR(st.st_mode)) {
                     *ret = true;
                     snprintf(full_path, full_path_size, "%s", realpath_buf);
                     full_path[full_path_size - 1] = '\0';

--- a/libutil/utils.c
+++ b/libutil/utils.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -32,6 +32,7 @@
  */
 
 #include "share.h"
+#include "drlibc.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -394,8 +395,9 @@ file_exists(const TCHAR *fn)
         return TRUE;
     }
 #    else
-    struct stat st;
-    return stat(fn, &st) == 0;
+    struct stat64 st;
+    /* Use the raw syscall to avoid glibc 2.33 deps (i#5474). */
+    return dr_stat_syscall(fn, &st) == 0;
 #    endif
 }
 


### PR DESCRIPTION
Eliminates a dependence on glibc 2.33 coming from the use of stat() in
drfrontendlib.  This is done by using the dr_stat_syscall() from drlibc.

Fixes #5474