### PR TITLE
i#2311 sigmask: Avoid rerouting alarms in handlers

### DIFF
--- a/core/lib/statsx.h
+++ b/core/lib/statsx.h
@@ -99,6 +99,7 @@ STATS_DEF("Re-takeovers after native", num_retakeover_after_native)
 #else
 RSTATS_DEF("Total signals delivered", num_signals)
 RSTATS_DEF("Total signals delivered to native threads", num_native_signals)
+RSTATS_DEF("Signals rerouted", num_signals_rerouted)
 RSTATS_DEF("Signals dropped", num_signals_dropped)
 RSTATS_DEF("Signals in coarse units delayed", num_signals_coarse_delayed)
 #endif

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -765,6 +765,8 @@ OPTION_DEFAULT(bool, avoid_dlclose, true, "Avoid calling dlclose from DynamoRIO.
 
 /* PR 304708: we intercept all signals for a better client interface */
 OPTION_DEFAULT(bool, intercept_all_signals, true, "intercept all signals")
+OPTION_DEFAULT(bool, reroute_alarm_signals, true,
+               "reroute alarm signals arriving in a blocked-for-app thread")
 OPTION_DEFAULT(uint, max_pending_signals, 8,
                "maximum count of pending signals per thread")
 

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -366,6 +366,21 @@ signal_is_interceptable(int sig)
     return (sig != SIGKILL && sig != SIGSTOP);
 }
 
+/* Checks for a for-certain-synchronous-fault signal. */
+static bool
+signal_is_fault(dcontext_t *dcontext, int sig, byte *pc, byte *xsp,
+                kernel_siginfo_t *info)
+{
+    switch (sig) {
+    case SIGSEGV:
+    case SIGBUS:
+    case SIGILL:
+    case SIGFPE:
+    case SIGTRAP: return !is_sys_kill(dcontext, pc, xsp, info);
+    default: return false;
+    }
+}
+
 static bool
 signal_is_process_wide(dcontext_t *dcontext, kernel_siginfo_t *info, byte *pc, byte *xsp)
 {
@@ -2434,6 +2449,10 @@ handle_sigprocmask(dcontext_t *dcontext, int how, kernel_sigset_t *app_set,
     thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
     int i;
     kernel_sigset_t safe_set;
+
+    /* We assume any change to the mask ends a handler: e.g., sigprocmask. */
+    info->in_app_handler = false;
+
     /* Some code uses this syscall to check whether the given address is
      * readable. E.g.
      * github.com/abseil/abseil-cpp/blob/master/absl/debugging/internal/
@@ -4658,7 +4677,10 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
             signal_is_process_wide(dcontext, &frame->info, pc, xsp), frame->info.si_code,
             atomic_aligned_read_int(&info->sighand->threads_unmasked[sig]));
         if (signal_is_process_wide(dcontext, &frame->info, pc, xsp) &&
-            atomic_aligned_read_int(&info->sighand->threads_unmasked[sig]) > 0) {
+            !signal_is_fault(dcontext, sig, pc, (byte *)sc->SC_XSP, &frame->info) &&
+            atomic_aligned_read_int(&info->sighand->threads_unmasked[sig]) > 0 &&
+            (!sig_is_alarm_signal(sig) ||
+             (!info->in_app_handler && DYNAMO_OPTION(reroute_alarm_signals)))) {
             /* We need to re-route this but cannot acquire the locks to search the
              * threads here.  We thus start delivery and once we come back from
              * dispatch we'll do the search in reroute_to_unmasked_thread().
@@ -4871,6 +4893,17 @@ record_pending_signal(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt,
     LOG(THREAD, LOG_ASYNCH, 3, "\tretaddr = " PFX "\n",
         frame->pretcode); /* pretcode has same offs for plain */
 #endif
+
+    if (receive_now && reroute) {
+        /* We can't delay, but we can't have interrupted any DR locks, so we
+         * can call this now.
+         */
+        handled = reroute_to_unmasked_thread(dcontext, frame, sig);
+        if (handled)
+            receive_now = false;
+        else
+            blocked = true;
+    }
 
     if (receive_now) {
         /* we need to translate sc before we know whether client wants to
@@ -6002,6 +6035,7 @@ execute_handler_from_cache(dcontext_t *dcontext, int sig, sigframe_rt_t *our_fra
          */
         info->sighand->action[sig]->handler = (handler_t)SIG_DFL;
     }
+    info->in_app_handler = true;
 
     LOG(THREAD, LOG_ASYNCH, 3, "\tset next_tag to handler " PFX ", xsp to " PFX "\n",
         SIGACT_PRIMARY_HANDLER(info->sighand->action[sig]), xsp);
@@ -6221,6 +6255,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
                            mcontext->pc, mcontext->xsp, osc_empty, mcontext, sig);
     dcontext->next_tag = canonicalize_pc_target(dcontext, mcontext->pc);
     sc->SC_XIP = official_xl8;
+    info->in_app_handler = true;
 
     LOG(THREAD, LOG_ASYNCH, 3, "\tset xsp to " PFX "\n", xsp);
     return true;
@@ -6756,6 +6791,9 @@ reroute_to_unmasked_thread(dcontext_t *dcontext, sigframe_rt_t *frame, int sig)
                  * If it's not available we have to fall back to SYS_tgkill.
                  * XXX: We ignore custom values in other siginfo fields for someone
                  * hackily using the raw syscall (like we do for nudges).
+                 * XXX: This reroute will have different si_code values than the
+                 * original process-wide signal.  We live with the loss of
+                 * transparency.
                  */
                 sent = thread_signal_queue(get_process_id(), trecs[i]->id, sig,
                                            siginfo->si_value.sival_ptr);
@@ -6763,6 +6801,7 @@ reroute_to_unmasked_thread(dcontext_t *dcontext, sigframe_rt_t *frame, int sig)
             if (!sent)
                 thread_signal(get_process_id(), trecs[i]->id, sig);
             found = true;
+            RSTATS_INC(num_signals_rerouted);
         }
         d_r_mutex_unlock(&tgt_info->sigblocked_lock);
     }
@@ -7125,6 +7164,7 @@ handle_sigreturn(dcontext_t *dcontext, void *ucxt_param, int style)
 
     LOG(THREAD, LOG_ASYNCH, 3, "set next tag to " PFX ", sc->SC_XIP to " PFX "\n",
         next_pc, sc->SC_XIP);
+    info->in_app_handler = false;
 
     return IF_VMX86_ELSE(false, true);
 }
@@ -7702,6 +7742,13 @@ handle_alarm(dcontext_t *dcontext, int sig, kernel_ucontext_t *ucxt)
             } else
                 reset_timer_manually = true;
         }
+    } else if ((*info->itimer)[which].dr.value == 0) {
+        /* This is an explicitly-sent signal, rather than generated by an itimer.
+         * XXX i#5017: We need to also identify such a signal when the app has no
+         * itimer and DR has one as today we'll swallow it and assume it was part of
+         * the DR itimer.
+         */
+        pass_to_app = true;
     }
     if ((*info->itimer)[which].dr.value > 0) {
         /* Alarm could have been on its way when DR value changed */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2450,7 +2450,10 @@ handle_sigprocmask(dcontext_t *dcontext, int how, kernel_sigset_t *app_set,
     int i;
     kernel_sigset_t safe_set;
 
-    /* We assume any change to the mask ends a handler: e.g., sigprocmask. */
+    /* We assume any change to the mask ends a handler: e.g., sigprocmask from
+     * siglongjmp.  It seems unusual to call sigprocmask in the middle; this
+     * in_app_handler is best-effort in any case.
+     */
     info->in_app_handler = false;
 
     /* Some code uses this syscall to check whether the given address is

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -467,6 +467,11 @@ typedef struct _thread_sig_info_t {
      */
     kernel_sigset_t app_sigblocked;
     mutex_t sigblocked_lock;
+    /* This is a not-guaranteed-accurate indicator of whether we're inside an
+     * app signal handler.  We can't know for sure when a handler ends if the
+     * app exits with a longjmp instead of siglongjmp.
+     */
+    bool in_app_handler;
 
     /* for returning the old mask (xref PR 523394) */
     kernel_sigset_t pre_syscall_app_sigblocked;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4409,6 +4409,9 @@ if (UNIX)
 
     tobuild(linux.sigmask linux/sigmask.c)
     link_with_pthread(linux.sigmask)
+    # Sanity check that this option works.
+    torunonly(linux.sigmask-noalarm linux.sigmask linux/sigmask.c
+      "-no_reroute_alarm_signals" "")
 
     if (UNIX)
       if (X64)

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -101,13 +101,16 @@ alarm_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
     if (pthread_self() == unblocked_thread) {
         if (sig != SIGALRM)
             print("Unexpected signal %d\n", sig);
+#ifdef LINUX
         /* We take advantage of DR's lack of transparency where its reroute uses tkill
          * but the original was process-wide so we can detect a rerouted signal.
          * Without the logic in DR to not reroute a signal when blocked due to
-         * being inside a handler, this code is triggered and the print fails the test.
+         * being inside a handler, this code is triggered and the print fails the
+         * test. Unfortunately we have no simple way of checking this on Mac.
          */
         if (siginfo->si_code == SI_TKILL)
             print("signal from tkill (rerouted?) not expected\n");
+#endif
     } else {
         if (sig == SIGALRM && !should_exit) {
             signal_cond_var(child_ready);

--- a/suite/tests/linux/sigmask.c
+++ b/suite/tests/linux/sigmask.c
@@ -51,6 +51,9 @@
 #include <sys/time.h> /* itimer */
 
 static void *child_ready;
+static void *child_exit;
+static volatile bool should_exit;
+static pthread_t unblocked_thread;
 
 #define MAGIC_VALUE 0xdeadbeef
 
@@ -92,6 +95,67 @@ thread_routine(void *arg)
     return NULL;
 }
 
+static void
+alarm_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
+{
+    if (pthread_self() == unblocked_thread) {
+        if (sig != SIGALRM)
+            print("Unexpected signal %d\n", sig);
+        /* We take advantage of DR's lack of transparency where its reroute uses tkill
+         * but the original was process-wide so we can detect a rerouted signal.
+         * Without the logic in DR to not reroute a signal when blocked due to
+         * being inside a handler, this code is triggered and the print fails the test.
+         */
+        if (siginfo->si_code == SI_TKILL)
+            print("signal from tkill (rerouted?) not expected\n");
+    } else {
+        if (sig == SIGALRM && !should_exit) {
+            signal_cond_var(child_ready);
+            /* Sit in the handler with SIGALRM blocked. */
+            wait_cond_var(child_exit);
+        }
+    }
+}
+
+static void *
+test_alarm_signals(void *arg)
+{
+    /* Test alarm signals not being rerouted from handlers. */
+    pthread_t init_thread = (pthread_t)arg;
+    unblocked_thread = pthread_self();
+    intercept_signal(SIGALRM, alarm_handler, false);
+
+    /* Get init thread inside its handler. */
+    pthread_kill(init_thread, SIGALRM);
+    wait_cond_var(child_ready);
+    reset_cond_var(child_ready);
+
+    print("init thread now inside handler: setting up itimer\n");
+    struct itimerval t;
+    t.it_interval.tv_sec = 0;
+    t.it_interval.tv_usec = 10000;
+    t.it_value.tv_sec = 0;
+    t.it_value.tv_usec = 10000;
+    int res = setitimer(ITIMER_REAL, &t, NULL);
+    if (res != 0)
+        perror("setitimer failed");
+    /* Let a bunch of real-time signals arrive. */
+    for (int i = 0; i < 10; i++)
+        thread_sleep(25);
+    /* Turn off the itimer. */
+    memset(&t, 0, sizeof(t));
+    res = setitimer(ITIMER_REAL, &t, NULL);
+    if (res != 0)
+        perror("setitimer failed");
+
+    /* Exit. */
+    print("done with itimer; exiting\n");
+    should_exit = true;
+    signal_cond_var(child_exit);
+
+    return NULL;
+}
+
 int
 main(int argc, char **argv)
 {
@@ -99,6 +163,7 @@ main(int argc, char **argv)
     void *retval;
 
     child_ready = create_cond_var();
+    child_exit = create_cond_var();
 
     if (pthread_create(&thread, NULL, thread_routine, NULL) != 0) {
         perror("failed to create thread");
@@ -145,7 +210,25 @@ main(int argc, char **argv)
     if (pthread_join(thread, &retval) != 0)
         perror("failed to join thread");
 
+    /* Test alarm signal rerouting.  Since process-wide signals are overwhelimingly
+     * delivered to the initial thread (I can't get them to go anywhere else), we
+     * need this thread to be the one sitting in a SIGALRM handler while we test whether
+     * signals are rerouted from there.  We create a thread to put us in the handler
+     * and drive the test.
+     */
+    if (pthread_create(&thread, NULL, test_alarm_signals, (void *)pthread_self()) != 0) {
+        perror("failed to create thread");
+        exit(1);
+    }
+    sigemptyset(&set);
+    while (!should_exit) {
+        sigsuspend(&set);
+    }
+    if (pthread_join(thread, &retval) != 0)
+        perror("failed to join thread");
+
     destroy_cond_var(child_ready);
+    destroy_cond_var(child_exit);
 
     print("all done\n");
 

--- a/suite/tests/linux/sigmask.expect
+++ b/suite/tests/linux/sigmask.expect
@@ -3,4 +3,6 @@ in handler for signal 10
 sending 28 with value
 in handler for signal 28 from -1 value 0xdeadbeef
 in handler for signal 12
+init thread now inside handler: setting up itimer
+done with itimer; exiting
 all done


### PR DESCRIPTION
Disables rerouting of blocked alarm signals while inside an app
handler.  This is not bulletproof: I have it considering the handler
as exited if we see sigreturn or sigprocmask, but there is no
requirement that the app use either siglongjmp or sigreturn to exit a
handler and to not use sigprocmask inside the handler.  But, if we get
it wrong, it will fall back to not rerouting alarms at all, which we
can live with as those are typically not used as required messages and
routed to a single thread.

The rerouting of alarms was seen to cause problems on large apps where
normally they can accumulate due to DR overhead causing a new one to
arrive while still in the handler for theprior one.  Rerouting sent
them to new threads, rather than marking pending and dropping if
several accumulated.

Adds an on-by-default option -reroute_alarm_signals that can be used
to disable routing of all alarm signals.

Adds a test to linux.sigmask which fails without this change.

The test was not easy to set up and it revealed two bugs in the
rerouting, which are fixed here:
+ Don't re-route synchronous fault signals.
+ Properly re-route receive-now signals.

Adds a new rstat counting rerouted signals.

Issue: #2311