### PR TITLE
i#5427 compress: Turn -raw_compress lz4 on by default

### DIFF
--- a/api/docs/debug_memtrace.dox
+++ b/api/docs/debug_memtrace.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -61,6 +61,8 @@ $ od -t x8 -A x drmemtrace.simple_app.09291.0000.dir/raw/drmemtrace.simple_app.0
 06ed90 c100000000000000
 06ed98
 ```
+
+Of course, if the raw file is compressed, it must first be uncompressed.  Use `unlz4` for lz4-compressed raw files.
 
 Cheat sheet:
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -137,7 +137,8 @@ Further non-compatibility-affecting changes include:
  - Added -trace_for_instrs and -retrace_every_instrs options to drcachesim
    for periodic trace bustrs of an unmodified application.
  - Added compression of drmemtrace raw offline files with various compression
-   choices under the -raw_compress option.
+   choices under the -raw_compress option.  Compressing with lz4 is now the
+   default (if built with lz4 support).
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -283,7 +283,17 @@ droption_t<bytesize_t> op_exit_after_tracing(
     "Use -max_global_trace_refs instead to avoid terminating the process.");
 
 droption_t<std::string> op_raw_compress(
-    DROPTION_SCOPE_CLIENT, "raw_compress", "none",
+    DROPTION_SCOPE_CLIENT, "raw_compress",
+#if defined(HAS_LZ4) && !defined(DRMEMTRACE_STATIC)
+    // lz4 performs best but has no allocator parameterization so cannot be static.
+    "lz4",
+#elif defined(HAS_SNAPPY) && !defined(DRMEMTRACE_STATIC)
+    // snappy_nocrc also has no allocator parameterization so cannot be static.
+    "snappy_nocrc",
+#else
+    // All other choices are slowdowns for an SSD so we turn them off by default.
+    "none",
+#endif
     "Raw compression: \"snappy\",\"snappy_nocrc\",\"gzip\",\"zlib\",\"lz4\",\"none\"",
     "Specifies the compression type to use for raw offline files: \"snappy\", "
     "\"snappy_nocrc\" (snappy without checksums, which is much faster), \"gzip\", "

--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -1020,13 +1020,16 @@ $ bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/trace
 
 If built with the zlib library, the canonical trace files are
 automatically compressed with gzip.  The trace reader supports reading
-gzip or snappy compressed files.  The raw files may also be compressed
-with the -p raw_compress option using a variety of compression options.
-Whether compressing the raw files is a net
-reduction in overhead depends on the storage medium; for an SSD it is
-typically slower to compress, though "lz4" and "snappy_crc" can exceed the
-uncompressed performance for some cases.  For a spinning disk,
-compression should always be a net win.
+gzip or snappy compressed files.
+
+The raw files are also compressed, controlled by the -p raw_compress
+option.  If built with lz4 support and not statically linked with the
+application, lz4 is used by default.  Whether compressing the raw
+files is a net reduction in overhead depends on the storage medium and
+compression scheme.  The "lz4" and "snappy_nocrc" schemes are
+generally performnce wins even for an SSD, while "gzip" or "zlib" slow
+things down.  For a spinning disk, any compression should be a net
+win.
 
 Older versions of the simulator produced a single trace file containing all threads
 interleaved.  The \p -infile option supports reading these legacy files:

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3584,11 +3584,9 @@ if (BUILD_CLIENTS)
       torunonly_drcacheoff(raw-gzip ${ci_shared_app} "-raw_compress gzip" "" "")
       set(tool.drcacheoff.raw-gzip_expectbase "offline-simple")
     endif ()
-    if (liblz4)
-      # lz4 is on by default so we test no compression here.
-      torunonly_drcacheoff(raw-none ${ci_shared_app} "-raw_compress none" "" "")
-      set(tool.drcacheoff.raw-none_expectbase "offline-simple")
-    endif ()
+    # lz4 is on by default so we test no compression here.
+    torunonly_drcacheoff(raw-none ${ci_shared_app} "-raw_compress none" "" "")
+    set(tool.drcacheoff.raw-none_expectbase "offline-simple")
 
     # Test reading a trace in sharded snappy-compressed files.
     if (libsnappy)
@@ -3657,13 +3655,11 @@ if (BUILD_CLIENTS)
         "@-simulator_type@basic_counts" "")
       set(tool.drcacheoff.windows-gzip_expectbase "offline-windows-simple")
     endif ()
-    if (liblz4)
-      # lz4 is on by default so we test no compression here.
-      torunonly_drcacheoff(windows-none ${ci_shared_app}
-        "-raw_compress none -no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
-        "@-simulator_type@basic_counts" "")
-      set(tool.drcacheoff.windows-none_expectbase "offline-windows-simple")
-    endif ()
+    # lz4 is on by default so we test no compression here.
+    torunonly_drcacheoff(windows-none ${ci_shared_app}
+      "-raw_compress none -no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
+      "@-simulator_type@basic_counts" "")
+    set(tool.drcacheoff.windows-none_expectbase "offline-windows-simple")
     # Ensure the invariant checker handles window transitions.
     torunonly_drcacheoff(windows-invar ${ci_shared_app}
       "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3585,8 +3585,9 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.raw-gzip_expectbase "offline-simple")
     endif ()
     if (liblz4)
-      torunonly_drcacheoff(raw-lz4 ${ci_shared_app} "-raw_compress lz4" "" "")
-      set(tool.drcacheoff.raw-lz4_expectbase "offline-simple")
+      # lz4 is on by default so we test no compression here.
+      torunonly_drcacheoff(raw-none ${ci_shared_app} "-raw_compress none" "" "")
+      set(tool.drcacheoff.raw-none_expectbase "offline-simple")
     endif ()
 
     # Test reading a trace in sharded snappy-compressed files.
@@ -3657,10 +3658,11 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.windows-gzip_expectbase "offline-windows-simple")
     endif ()
     if (liblz4)
-      torunonly_drcacheoff(windows-lz4 ${ci_shared_app}
-        "-raw_compress lz4 -no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
+      # lz4 is on by default so we test no compression here.
+      torunonly_drcacheoff(windows-none ${ci_shared_app}
+        "-raw_compress none -no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
         "@-simulator_type@basic_counts" "")
-      set(tool.drcacheoff.windows-lz4_expectbase "offline-windows-simple")
+      set(tool.drcacheoff.windows-none_expectbase "offline-windows-simple")
     endif ()
     # Ensure the invariant checker handles window transitions.
     torunonly_drcacheoff(windows-invar ${ci_shared_app}

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3825,7 +3825,10 @@ if (BUILD_CLIENTS)
             set(testname_full "tool.raw2trace.${testname}")
             torunonly_ci(tool.raw2trace.${testname} ${exetgt} drcachesim
               "raw2trace-${testname}.c" # for templatex basename
-              "-offline -subdir_prefix ${testname_full} ${extra_ops}" "" "${app_args}")
+              # Disable compression, since we need to seek and our compression
+              # readers do not support seeking.
+              "-offline -raw_compress none -subdir_prefix ${testname_full} ${extra_ops}"
+              "" "${app_args}")
             set(${testname_full}_toolname "drcachesim")
             set(${testname_full}_basedir
               "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")


### PR DESCRIPTION
For non-static drmemtrace, -raw_compress is now set to lz4 by default,
as that is nearly always faster than no compression or any other
compression scheme we've tried.

If lz4 is not enabled in the build, and again drmemtrace is not
static, snappy_nocrc is the default.

Otherwise, compression is disabled by default, just like today.

Inverts the raw-lz4 tests to become raw-none tests.

Updates the documentation.

Issue: #5427