### PR TITLE
i#3995 multi-window: Fix too-many-files and headers bugs

### DIFF
--- a/clients/drcachesim/tests/offline-windows-split.templatex
+++ b/clients/drcachesim/tests/offline-windows-split.templatex
@@ -1,8 +1,10 @@
 Hit delay threshold: enabling tracing.
 Hit tracing window #0 limit: disabling tracing.
 Hit retrace threshold: enabling tracing for window #1.
-.*
+[^W]*
 Basic counts tool results:
+.*
+           1 total threads
 .*
 Basic counts tool results:
 .*

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -794,17 +794,19 @@ set_local_window(void *drcontext, ptr_int_t value)
                 entry += instru->append_thread_exit(entry, dr_get_thread_id(drcontext));
                 DR_ASSERT(BUFFER_SIZE_BYTES(buf) >= (size_t)(entry - buf));
                 write_trace_data(drcontext, (byte *)buf, entry, old_val);
+                close_thread_file(drcontext);
             }
-            if (op_split_windows.get_value() || data->init_header_size == 0) {
+            if ((value > 0 && op_split_windows.get_value()) ||
+                data->init_header_size == 0) {
                 size_t header_size = prepend_offline_thread_header(drcontext);
                 if (data->init_header_size == 0)
-                    data->init_header_size = prepend_offline_thread_header(drcontext);
+                    data->init_header_size = header_size;
                 else
                     DR_ASSERT(header_size == data->init_header_size);
             }
             // We delay opening the next window's file to avoid an empty final file.
             // The initial file is opened at thread init.
-            if (data->file != INVALID_FILE && op_split_windows.get_value())
+            if (data->file != INVALID_FILE && value > 0 && op_split_windows.get_value())
                 close_thread_file(drcontext);
         }
     }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3671,7 +3671,7 @@ if (BUILD_CLIENTS)
     endif ()
     # Test split-file windows.
     torunonly_drcacheoff(windows-split ${ci_shared_app}
-      "-trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
+      "-trace_after_instrs 20K -trace_for_instrs 10K -retrace_every_instrs 30K"
       "@-simulator_type@basic_counts" "")
     # The first postcmd did window #0.  There should be at least 2 more windows.
     set(tool.drcacheoff.windows-split_postcmd2


### PR DESCRIPTION
Fixes bugs where a huge number of files are opened in the first window
of a multi-window drmemtrace run, and extra headers are added as well.

Augments the windows-split test to run long enough to reproduce this
problem, and adds to its output to detect errors in post-processing.

Issue: #3995