### PR TITLE
i#5474 Add FEATURE_ detection for AArch64

### DIFF
--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -115,12 +115,17 @@ GLOBAL_LABEL(unexpected_return:)
         JUMP  GLOBAL_REF(unexpected_return)
         END_FUNC(unexpected_return)
 
-/* All CPU ID registers are accessible only in privileged modes. */
-        DECLARE_FUNC(cpuid_supported)
-GLOBAL_LABEL(cpuid_supported:)
-        mov      w0, #0
+/* bool mrs_id_reg_supported(void)
+ * Checks for support of the MRS instr by attempting to read Instruction Set
+ * Attribute Register 0. Some older kernels on v8.0 systems do not support
+ * this, raising a SIGILL.
+ */
+        DECLARE_FUNC(mrs_id_reg_supported)
+GLOBAL_LABEL(mrs_id_reg_supported:)
+        mrs     x0, ID_AA64ISAR0_EL1
+        mov     w0, #1
         ret
-        END_FUNC(cpuid_supported)
+        END_FUNC(mrs_id_reg_supported)
 
 /* void call_switch_stack(void *func_arg,             // REG_X0
  *                        byte *stack,                // REG_X1

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -38,12 +38,59 @@ static int num_simd_saved;
 static int num_simd_registers;
 static int num_opmask_registers;
 
+const static int num_feature_registers = sizeof(features_t) / sizeof(uint64);
+
+#define MRS(REG, IDX)                                                            \
+    do {                                                                         \
+        if (IDX > (num_feature_registers - 1))                                   \
+            CLIENT_ASSERT(false, "Reading undefined AArch64 feature register!"); \
+        asm("mrs %0, " #REG : "=r"(isa_features[IDX]));                          \
+    } while (0);
+
+void
+read_feature_regs(uint64 isa_features[])
+{
+    MRS(ID_AA64ISAR0_EL1, AA64ISAR0);
+    MRS(ID_AA64ISAR1_EL1, AA64ISAR1);
+    MRS(ID_AA64PFR0_EL1, AA64PFR0);
+}
+
+static void
+get_processor_specific_info(void)
+{
+    uint64 isa_features[num_feature_registers];
+
+    /* FIXME i#5474: Catch and handle SIGILL if MRS not supported.
+     * Placeholder for some older kernels on v8.0 systems which do not support
+     * this, raising a SIGILL.
+     */
+    if (!mrs_id_reg_supported()) {
+        ASSERT_CURIOSITY(false && "MRS instruction unsupported");
+        SYSLOG_INTERNAL_WARNING("MRS instruction unsupported");
+        return;
+    }
+
+    /* Reads instruction attribute and preocessor feature registers
+     * ID_AA64ISAR0_EL1, ID_AA64ISAR1_EL1 and ID_AA64PFR0_EL1.
+     */
+    read_feature_regs(isa_features);
+    cpu_info.features.flags_aa64isar0 = isa_features[AA64ISAR0];
+    cpu_info.features.flags_aa64isar1 = isa_features[AA64ISAR1];
+    cpu_info.features.flags_aa64pfr0 = isa_features[AA64PFR0];
+}
+
+#define LOG_FEATURE(feature)       \
+    if (proc_has_feature(feature)) \
+        LOG(GLOBAL, LOG_TOP, 1, "   Processor has " #feature "\n");
+
 void
 proc_init_arch(void)
 {
     num_simd_saved = MCXT_NUM_SIMD_SLOTS;
     num_simd_registers = MCXT_NUM_SIMD_SLOTS;
     num_opmask_registers = MCXT_NUM_OPMASK_SLOTS;
+
+    get_processor_specific_info();
 
     /* When DR_HOST_NOT_TARGET, get_cache_line_size returns false and does
      * not set any value in given args.
@@ -53,14 +100,79 @@ proc_init_arch(void)
         LOG(GLOBAL, LOG_TOP, 1, "Unable to obtain cache line size");
     }
 
-    /* FIXME i#1569: NYI */
+    if (d_r_stats->loglevel > 0 && (d_r_stats->logmask & LOG_TOP) != 0) {
+        LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64ISAR0_EL1 = 0x%016lx\n",
+            cpu_info.features.flags_aa64isar0);
+        LOG_FEATURE(FEATURE_AES);
+        LOG_FEATURE(FEATURE_PMULL);
+        LOG_FEATURE(FEATURE_SHA1);
+        LOG_FEATURE(FEATURE_SHA256);
+        LOG_FEATURE(FEATURE_SHA512);
+        LOG_FEATURE(FEATURE_CRC32);
+        LOG_FEATURE(FEATURE_LSE);
+        LOG_FEATURE(FEATURE_RDM);
+        LOG_FEATURE(FEATURE_SHA3);
+        LOG_FEATURE(FEATURE_SM3);
+        LOG_FEATURE(FEATURE_SM4);
+        LOG_FEATURE(FEATURE_DotProd);
+        LOG_FEATURE(FEATURE_FHM);
+        LOG_FEATURE(FEATURE_FlagM);
+        LOG_FEATURE(FEATURE_FlagM2);
+        LOG_FEATURE(FEATURE_RNG);
+        LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64ISAR1_EL1 = 0x%016lx\n",
+            cpu_info.features.flags_aa64isar1);
+        /* FIXME i#5474: Log all FEATURE_s for ID_AA64ISAR1_EL1. */
+        LOG_FEATURE(FEATURE_DPB);
+        LOG_FEATURE(FEATURE_DPB2);
+        LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64PFR0_EL1 = 0x%016lx\n",
+            cpu_info.features.flags_aa64pfr0);
+        /* FIXME i#5474: Log all FEATURE_s for ID_AA64PFR0_EL1. */
+        LOG_FEATURE(FEATURE_FP16);
+    }
 }
 
 bool
 proc_has_feature(feature_bit_t f)
 {
-    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
-    return false;
+    ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;
+    uint64 freg_val = 0;
+
+    feature_reg_idx_t feat_reg = GET_FEAT_REG(f);
+    if (feat_reg >= AA64ISAR0 && feat_reg <= AA64PFR0) {
+        switch (feat_reg) {
+        case AA64ISAR0: {
+            freg_val = cpu_info.features.flags_aa64isar0;
+            break;
+        }
+        case AA64ISAR1: {
+            freg_val = cpu_info.features.flags_aa64isar1;
+            break;
+        }
+        case AA64PFR0: {
+            freg_val = cpu_info.features.flags_aa64pfr0;
+            break;
+        }
+        default: CLIENT_ASSERT(false, "proc_has_feature: feature register index error");
+        }
+    } else {
+        CLIENT_ASSERT(false, "proc_has_feature: invalid feature register");
+    }
+
+    /* Compare the nibble value in the feature register with the input
+     * feature nibble value to establish if the feature set represented by the
+     * nibble is supported. If the nibble value in the feature register is
+     * 0 or 0xF, the feature is not supported at all
+     */
+    feat_nibble = GET_FEAT_NIBPOS(f);
+    freg_nibble = (freg_val >> (feat_nibble * 4)) & 0xFULL;
+    feat_nsflag = GET_FEAT_NSFLAG(f);
+    if (feat_nsflag == 0 && freg_nibble == 0)
+        return false;
+    if (feat_nsflag == 1 && freg_nibble == 0xF)
+        return false;
+
+    feat_val = GET_FEAT_VAL(f);
+    return (freg_nibble >= feat_val) ? true : false;
 }
 
 void

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -216,6 +216,7 @@ reg_spill_tls_offs(reg_id_t reg);
 #define REG_SAVED_XMM0 (YMM_ENABLED() ? REG_YMM0 : REG_XMM0)
 #define OPSZ_SAVED_OPMASK (proc_has_feature(FEATURE_AVX512BW) ? OPSZ_8 : OPSZ_2)
 
+#ifdef X86
 /* Xref the partially overlapping CONTEXT_PRESERVE_XMM */
 /* This routine also determines whether ymm registers should be saved. */
 static inline bool
@@ -232,7 +233,6 @@ preserve_xmm_caller_saved(void)
     return proc_has_feature(FEATURE_SSE) /* do xmm registers exist? */;
 }
 
-#ifdef X86
 /* This is used for AVX-512 context switching and indicates whether AVX-512 has been seen
  * during decode. The variable is allocated on reachable heap during initialization.
  */

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -609,6 +609,10 @@ cleanup_and_terminate(dcontext_t *dcontext, int sysnum, ptr_uint_t sys_arg1,
 
 bool
 cpuid_supported(void);
+#ifdef AARCHXX
+bool
+mrs_id_reg_supported(void);
+#endif
 void
 our_cpuid(int res[4], int eax, int ecx);
 #ifdef WINDOWS

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -74,7 +74,11 @@ cpu_info_t cpu_info = { VENDOR_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
+#ifdef X86
                         { 0, 0, 0, 0 },
+#elif defined(AARCHXX)
+                        { 0, 0, 0 },
+#endif
                         { 0x6e6b6e75, 0x006e776f } };
 
 void

--- a/core/arch/x86_code_test.c
+++ b/core/arch/x86_code_test.c
@@ -93,10 +93,8 @@ test_cpuid()
 {
 #    ifdef X86
     int cpuid_res[4] = { 0 };
-#    endif
     print_file(STDERR, "testing asm cpuid\n");
-    EXPECT(cpuid_supported(), IF_X86_ELSE(true, false));
-#    ifdef X86
+    EXPECT(cpuid_supported(), true);
     our_cpuid(cpuid_res, 0, 0); /* get vendor id */
     /* cpuid_res[1..3] stores vendor info like "GenuineIntel" or "AuthenticAMD" for X86 */
     EXPECT_NE(cpuid_res[1], 0);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6287,7 +6287,11 @@ dr_clobber_retaddr_after_read(void *drcontext, instrlist_t *ilist, instr_t *inst
 DR_API bool
 dr_mcontext_xmm_fields_valid(void)
 {
+#ifdef X86
     return preserve_xmm_caller_saved();
+#else
+    return false;
+#endif
 }
 
 DR_API bool


### PR DESCRIPTION
This patch reads from the ID_AA64ISAR0_EL1 features register and sets
the following if supported:
FEATURE_AES    FEATURE_PMULL FEATURE_SHA1    FEATURE_SHA256
FEATURE_SHA512 FEATURE_CRC32 FEATURE_LSE     FEATURE_RDM
FEATURE_SM3    FEATURE_SM4   FEATURE_DotProd FEATURE_FHM
FEATURE_FlagM2 FEATURE_RNG   FEATURE_SHA3    FEATURE_FlagM

Example output in logfile:
Processor features:
 ID_AA64ISAR0_EL1 = 0x0000000000011120
   Processor has FEATURE_AES
   Processor has FEATURE_PMULL
   Processor has FEATURE_SHA1
   Processor has FEATURE_SHA256
   Processor has FEATURE_CRC32

ID_AA64ISAR1_EL1 and ID_AA64PFR0_EL1 are also read. The features for
these will be implemented in the next patch.

Issues: #5474, #1569