### PR TITLE
i#5486: Add drmemtrace view tool support for no binaries

### DIFF
--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -646,7 +646,7 @@ T80431   0x00007f2ae335de15  4c 2b 25 e4 91 02 00 sub    <rel> 0x00007f2ae338700
 T80431     read  8 byte(s) @ 0x7f2ae3387000
 T80431   0x00007f2ae335de1c  48 89 15 d5 9b 02 00 mov    %rdx, <rel> 0x00007f2ae33879f8
 View tool results:
-             20 : total disassembled instructions
+             20 : total instructions
 \endcode
 
 An example of thread switches:

--- a/clients/drcachesim/simulator/analyzer_interface.cpp
+++ b/clients/drcachesim/simulator/analyzer_interface.cpp
@@ -190,10 +190,7 @@ drmemtrace_analysis_tool_create()
                                       op_alt_module_dir.get_value());
     } else if (op_simulator_type.get_value() == VIEW) {
         std::string module_file_path = get_module_file_path();
-        if (module_file_path.empty()) {
-            ERRMSG("Usage error: the view tool requires offline traces.\n");
-            return nullptr;
-        }
+        // The module file is optional so we don't check for emptiness.
         return view_tool_create(module_file_path, op_only_thread.get_value(),
                                 op_skip_refs.get_value(), op_sim_refs.get_value(),
                                 op_view_syntax.get_value(), op_verbose.get_value(),

--- a/clients/drcachesim/tests/offline-view.templatex
+++ b/clients/drcachesim/tests/offline-view.templatex
@@ -4,4 +4,4 @@ Hello, world!
  *[0-9]*: T[0-9]* <marker: tid [0-9]* on core [0-9]*>
 .*
 View tool results:
-    *[0-9]* : total disassembled instructions
+    *[0-9]* : total instructions

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -72,23 +72,31 @@ view_t::view_t(const std::string &module_file_path, memref_tid_t thread,
     , filetype_(-1)
     , num_refs_(0)
     , timestamp_(0)
+    , has_modules_(true)
 {
 }
 
 std::string
 view_t::initialize()
 {
-    if (module_file_path_.empty())
-        return "Module file path is missing";
     dcontext_.dcontext = dr_standalone_init();
-    std::string error = directory_.initialize_module_file(module_file_path_);
-    if (!error.empty())
-        return "Failed to initialize directory: " + error;
+    if (module_file_path_.empty()) {
+        has_modules_ = false;
+    } else {
+        std::string error = directory_.initialize_module_file(module_file_path_);
+        if (!error.empty())
+            has_modules_ = false;
+    }
+    if (!has_modules_) {
+        // Continue but omit disassembly to support cases where binaries are
+        // not available.
+        return "";
+    }
     module_mapper_ =
         module_mapper_t::create(directory_.modfile_bytes_, nullptr, nullptr, nullptr,
                                 nullptr, knob_verbose_, knob_alt_module_dir_);
     module_mapper_->get_loaded_modules();
-    error = module_mapper_->get_last_error();
+    std::string error = module_mapper_->get_last_error();
     if (!error.empty())
         return "Failed to load binaries: " + error;
     dr_disasm_flags_t flags =
@@ -314,6 +322,7 @@ view_t::process_memref(const memref_t &memref)
 
     if (!type_is_instr(memref.instr.type) &&
         memref.data.type != TRACE_TYPE_INSTR_NO_FETCH) {
+        // XXX: Print prefetch info.
         switch (memref.data.type) {
         case TRACE_TYPE_READ:
             std::cerr << "    read  " << memref.data.size << " byte(s) @ 0x" << std::hex
@@ -328,6 +337,32 @@ view_t::process_memref(const memref_t &memref)
             break;
         default: std::cerr << "<entry type " << memref.data.type << ">\n"; break;
         }
+        return true;
+    }
+
+    if (!has_modules_) {
+        // We can't disassemble so we provide what info the trace itself contains.
+        // XXX i#5486: We may want to store the taken target for conditional
+        // branches; if added, we can print it here.
+        // XXX: It may avoid initial confusion over the record-oriented output
+        // to indicate whether an instruction accesses memory, but that requires
+        // delayed printing.
+        std::cerr << "  0x" << std::hex << std::setfill('0')
+                  << std::setw(sizeof(void *) / 4) << memref.instr.addr << "  "
+                  << std::dec << std::setfill(' ');
+        switch (memref.instr.type) {
+        case TRACE_TYPE_INSTR: std::cerr << "non-branch"; break;
+        case TRACE_TYPE_INSTR_DIRECT_JUMP: std::cerr << "jump"; break;
+        case TRACE_TYPE_INSTR_INDIRECT_JUMP: std::cerr << "indirect jump"; break;
+        case TRACE_TYPE_INSTR_CONDITIONAL_JUMP: std::cerr << "conditional jump"; break;
+        case TRACE_TYPE_INSTR_DIRECT_CALL: std::cerr << "call"; break;
+        case TRACE_TYPE_INSTR_INDIRECT_CALL: std::cerr << "indirect call"; break;
+        case TRACE_TYPE_INSTR_RETURN: std::cerr << "return"; break;
+        case TRACE_TYPE_INSTR_NO_FETCH: std::cerr << "non-fetched instruction"; break;
+        case TRACE_TYPE_INSTR_SYSENTER: std::cerr << "sysenter"; break;
+        default: error_string_ = "Uknown instruction type"; return false;
+        }
+        std::cerr << " " << memref.instr.size << " byte(s)\n";
         return true;
     }
 
@@ -375,7 +410,6 @@ bool
 view_t::print_results()
 {
     std::cerr << TOOL_NAME << " results:\n";
-    std::cerr << std::setw(15) << num_disasm_instrs_
-              << " : total disassembled instructions\n";
+    std::cerr << std::setw(15) << num_disasm_instrs_ << " : total instructions\n";
     return true;
 }

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -114,6 +114,7 @@ protected:
     uint64_t num_refs_;
     std::unordered_map<memref_tid_t, uintptr_t> last_window_;
     uintptr_t timestamp_;
+    bool has_modules_;
 };
 
 #endif /* _VIEW_H_ */


### PR DESCRIPTION
Adds support for using the drmemtrace view tool on a trace for which
no modules.log, and thus no binary, is available.

Adds a unit test.

The output looks like this:

```
----------------------------------------------------------------------
    63586: T3551528   0x7f7fe453152a  non-branch 5 byte(s)
    63587: T3551528   0x7f7fe453152f  non-branch 2 byte(s)
    63588: T3551528     read  1 byte(s) @ 0x7f7fe3ec538c
    63589: T3551528     read  1 byte(s) @ 0x7f7fe454e90d
    63590: T3551528   0x7f7fe453152f  non-fetched instruction 2 byte(s)
    63591: T3551528     read  1 byte(s) @ 0x7f7fe3ec538d
    63592: T3551528     read  1 byte(s) @ 0x7f7fe454e90e
    63593: T3551528   0x7f7fe453152f  non-fetched instruction 2 byte(s)
    63594: T3551528     read  1 byte(s) @ 0x7f7fe3ec538e
    63595: T3551528     read  1 byte(s) @ 0x7f7fe454e90f
    63596: T3551528   0x7f7fe453152f  non-fetched instruction 2 byte(s)
    63597: T3551528     read  1 byte(s) @ 0x7f7fe3ec538f
    63598: T3551528     read  1 byte(s) @ 0x7f7fe454e910
    63599: T3551528   0x7f7fe4531531  non-branch 3 byte(s)
...
  2923092: T3551528   0x7f7fe3a61755  non-branch 5 byte(s)
  2923093: T3551528     read  8 byte(s) @ 0x7ffd51ace110
  2923094: T3551528   0x7f7fe3a6175a  non-branch 5 byte(s)
  2923095: T3551528   0x7f7fe3a6175f  non-branch 2 byte(s)
------------------------------------------------------------
  2923096: T3551529 <marker: tid 3551529 on core 2>
  2923097: T3551529 <marker: timestamp 13296790404166936>
  2923098: T3551529   0x7f7fe3a61761  non-branch 3 byte(s)
  2923099: T3551529   0x7f7fe3a61764  conditional jump 2 byte(s)
  2923100: T3551529   0x7f7fe3a61766  conditional jump 2 byte(s)
  2923101: T3551529   0x7f7fe3a61769  non-branch 2 byte(s)
  2923102: T3551529   0x7f7fe3a6176b  non-branch 1 byte(s)
  2923103: T3551529     read  8 byte(s) @ 0x7f7fe3962ef0
  2923104: T3551529   0x7f7fe3a6176c  non-branch 1 byte(s)
  2923105: T3551529     read  8 byte(s) @ 0x7f7fe3962ef8
  2923106: T3551529   0x7f7fe3a6176d  indirect call 2 byte(s)
  2923107: T3551529     write 8 byte(s) @ 0x7f7fe3962ef8
----------------------------------------------------------------------
```

Fixes #5486