### PR TITLE
i#4014 dr$sim phys: Make physaddr_t per-thread

### DIFF
--- a/clients/drcachesim/tests/phys-threads.templatex
+++ b/clients/drcachesim/tests/phys-threads.templatex
@@ -30,7 +30,7 @@
     ...................................................................
 ---- <application exited with code 0> ----
 Cache simulation results:
-Core #0 \(4 thread\(s\)\)
+Core #0 \([0-9]+ thread\(s\)\)
   L1I stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
@@ -43,9 +43,9 @@ Core #0 \(4 thread\(s\)\)
     Compulsory misses:          *[0-9,\.]*
     Invalidations:              *0
 .*    Miss rate:                *[0-9,\.]*%
-Core #1 \(3 thread\(s\).*
-Core #2 \(3 thread\(s\).*
-Core #3 \(3 thread\(s\).*
+Core #1 \([0-9]+ thread\(s\).*
+Core #2 \([0-9]+ thread\(s\).*
+Core #3 \([0-9]+ thread\(s\).*
 LL stats:
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/phys-threads.templatex
+++ b/clients/drcachesim/tests/phys-threads.templatex
@@ -1,0 +1,56 @@
+
+    -------------------------------------------------------------------
+     Performance for solving AX=B Linear Equation using Jacobi method
+     Running on DynamoRIO
+     Client version .*
+    ...................................................................
+
+     Matrix Size :  64
+     Threads     :  4
+
+
+     Started iteration 1 of the computation...
+
+     Finished computing current solution distance in mode 0.
+     Mode changed to 0.
+
+     Started iteration 2 of the computation...
+
+     Finished computing current solution distance in mode 0.
+     Mode changed to 0.
+
+     Started iteration 3 of the computation...
+
+     Finished computing current solution distance in mode 0.
+     Mode changed to 0.
+
+
+     The Jacobi Method For AX=B .........DONE
+     Total Number Of iterations   :  3
+    ...................................................................
+---- <application exited with code 0> ----
+Cache simulation results:
+Core #0 \(4 thread\(s\)\)
+  L1I stats:
+    Hits:                       *[0-9,\.]*
+    Misses:                     *[0-9,\.]*
+    Compulsory misses:          *[0-9,\.]*
+    Invalidations:              *0
+.*    Miss rate:                *[0-9,\.]*%
+  L1D stats:
+    Hits:                       *[0-9,\.]*
+    Misses:                     *[0-9,\.]*
+    Compulsory misses:          *[0-9,\.]*
+    Invalidations:              *0
+.*    Miss rate:                *[0-9,\.]*%
+Core #1 \(3 thread\(s\).*
+Core #2 \(3 thread\(s\).*
+Core #3 \(3 thread\(s\).*
+LL stats:
+    Hits:                    *[0-9,\.]*
+    Misses:                  *[0-9,\.]*
+    Compulsory misses:       *[0-9,\.]*
+    Invalidations:           *0
+.*    Local miss rate:        *[0-9,.]*%
+    Child hits:              *[0-9,\.]*
+    Total miss rate:                  0[\.,]..%

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -57,8 +57,12 @@ private:
 #ifdef LINUX
     addr_t last_vpage_;
     addr_t last_ppage_;
-    // XXX: An app with thousands of threads might hit open file limits.
-    // Sharing the descriptor would require locks, however.
+    // TODO i#4014: An app with thousands of threads might hit open file limits,
+    // and even a hundred threads will use up DR's private FD limit and push
+    // other files into potential app conflicts.
+    // Sharing the descriptor would require locks, however.  Evaluating
+    // how best to do that (maybe the caching will reduce the contention enough)
+    // is future work.
     int fd_;
     // We would use std::unordered_map, but that is not compatible with
     // statically linking drmemtrace into an app.

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -42,6 +42,8 @@
 #include "hashtable.h"
 #include "../common/trace_entry.h"
 
+// This class is not thread-safe: the caller should create a separate instance
+// per thread.
 class physaddr_t {
 public:
     physaddr_t();
@@ -52,10 +54,11 @@ public:
     virtual2physical(addr_t virt);
 
 private:
-    // Assumed to be single-threaded
 #ifdef LINUX
     addr_t last_vpage_;
     addr_t last_ppage_;
+    // XXX: An app with thousands of threads might hit open file limits.
+    // Sharing the descriptor would require locks, however.
     int fd_;
     // We would use std::unordered_map, but that is not compatible with
     // statically linking drmemtrace into an app.

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2671,7 +2671,7 @@ event_thread_init(void *drcontext)
 {
     per_thread_t *data = (per_thread_t *)dr_thread_alloc(drcontext, sizeof(per_thread_t));
     DR_ASSERT(data != NULL);
-    *data = {};
+    *data = {}; // We must safely zero due to the C++ class member.
     data->file = INVALID_FILE;
     drmgr_set_tls_field(drcontext, tls_idx, data);
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2991,6 +2991,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     DR_ASSERT(std::atomic_is_lock_free(&reached_trace_after_instrs));
     DR_ASSERT(std::atomic_is_lock_free(&tracing_disabled));
     DR_ASSERT(std::atomic_is_lock_free(&tracing_window));
+    DR_ASSERT(std::atomic_is_lock_free(&have_phys));
 
     drreg_init_and_fill_vector(&scratch_reserve_vec, true);
 #ifdef X86

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3323,8 +3323,15 @@ if (BUILD_CLIENTS)
       "-config_file ${config_files_dir}/cores-1-levels-3-with-missfile.conf"
       "")
 
-    if (NOT WIN32) # No physaddr access on Windows.
+    if (LINUX) # Physaddr access limited to Linux.
+      # XXX: We should verify that we're actually getting physical addresses:
+      # but A) there may not be pagemap access for automated tests and B) we
+      # would need an analyzer to go examine addresses, or to use the view tool.
+      # For now these are just sanity tests that flipping on the option doesn't
+      # cause outright failure.
       torunonly_drcachesim(phys ${ci_shared_app} "-use_physical" "")
+      torunonly_drcachesim(phys-threads client.annotation-concurrency "-use_physical"
+        "${annotation_test_args_shorter}")
     endif ()
 
     set(test_mode_flag "-test_mode")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3324,7 +3324,7 @@ if (BUILD_CLIENTS)
       "")
 
     if (LINUX) # Physaddr access limited to Linux.
-      # XXX: We should verify that we're actually getting physical addresses:
+      # XXX i#4014: We should verify that we're actually getting physical addresses:
       # but A) there may not be pagemap access for automated tests and B) we
       # would need an analyzer to go examine addresses, or to use the view tool.
       # For now these are just sanity tests that flipping on the option doesn't


### PR DESCRIPTION
The physaddr_t class is not thread-safe and was previously used racily
in the drmemtrace code.  We fix that by creating a separate instance
per thread.  A test with multiple threads is added.

Issue: #4014