### PR TITLE
i#4014 dr$sim phys: Add drmodtrack_lookup_pc_from_index()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -139,6 +139,7 @@ Further non-compatibility-affecting changes include:
  - Added compression of drmemtrace raw offline files with various compression
    choices under the -raw_compress option.  Compressing with lz4 is now the
    default (if built with lz4 support).
+ - Added drmodtrack_lookup_pc_from_index().
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/ext/drcovlib/drcovlib.h
+++ b/ext/drcovlib/drcovlib.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.   All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -312,6 +312,14 @@ DR_EXPORT
 drcovlib_status_t
 drmodtrack_lookup_segment(void *drcontext, app_pc pc, OUT uint *segment_index,
                           OUT app_pc *segment_base);
+
+DR_EXPORT
+/**
+ * Returns the base address in \p mod_base for the index identifier \p
+ * mod_index that was previously returned by drmodtrack_lookup().
+ */
+drcovlib_status_t
+drmodtrack_lookup_pc_from_index(void *drcontext, uint mod_index, OUT app_pc *mod_base);
 
 DR_EXPORT
 /**

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2844,6 +2844,7 @@ link_with_pthread(client.drutil-test)
 tobuild_ci(client.drmodtrack-test client-interface/drmodtrack-test.cpp "" "" "")
 use_DynamoRIO_extension(client.drmodtrack-test.dll drcovlib)
 use_DynamoRIO_extension(client.drmodtrack-test.dll drx)
+use_DynamoRIO_extension(client.drmodtrack-test.dll drmgr)
 
 if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
   # We need to load w/ the same base so the test passes


### PR DESCRIPTION
Adds a new reverse-lookup routine drmodtrack_lookup_pc_from_index()
which is needed to implement physical address support for offline
dr$sim traces.

Adds a simple test.

Issue: #4014