### PR TITLE
i#4014 dr$sim phys: Add different page size support

### DIFF
--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -62,6 +62,13 @@
 
 #define ALIGN_FORWARD(x, alignment) \
     ((((ptr_uint_t)x) + ((alignment)-1)) & (~((ptr_uint_t)(alignment)-1)))
+#define ALIGN_BACKWARD(x, alignment) (((ptr_uint_t)x) & (~((ptr_uint_t)(alignment)-1)))
+
+#define NOTIFY(level, ...)                     \
+    do {                                       \
+        if (op_verbose.get_value() >= (level)) \
+            dr_fprintf(STDERR, __VA_ARGS__);   \
+    } while (0)
 
 #define BOOLS_MATCH(b1, b2) (!!(b1) == !!(b2))
 

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -67,6 +67,7 @@
         exit(1);                                            \
     } while (0)
 
+#undef NOTIFY
 #define NOTIFY(level, prefix, msg, ...)                              \
     do {                                                             \
         if (op_verbose.get_value() >= level) {                       \

--- a/clients/drcachesim/tracer/physaddr.cpp
+++ b/clients/drcachesim/tracer/physaddr.cpp
@@ -30,8 +30,6 @@
  * DAMAGE.
  */
 
-#include <iostream>
-#include <sstream>
 #ifdef LINUX
 #    include <sys/types.h>
 #    include <unistd.h>
@@ -56,15 +54,13 @@
 #    define PAGEMAP_VALID 0x8000000000000000
 #    define PAGEMAP_SWAP 0x4000000000000000
 #    define PAGEMAP_PFN 0x007fffffffffffff
-#    define PAGE_BITS 12 // XXX i#1703: handle large pages
-#    define PAGE_START(addr) ((addr) & (~((1 << PAGE_BITS) - 1)))
-#    define PAGE_OFFS(addr) ((addr) & ((1 << PAGE_BITS) - 1))
 static const addr_t PAGE_INVALID = (addr_t)-1;
 #endif
 
 physaddr_t::physaddr_t()
 #ifdef LINUX
-    : last_vpage_(PAGE_INVALID)
+    : page_size_(dr_page_size())
+    , last_vpage_(PAGE_INVALID)
     , last_ppage_(PAGE_INVALID)
     , fd_(-1)
     , count_(0)
@@ -72,6 +68,14 @@ physaddr_t::physaddr_t()
 {
 #ifdef LINUX
     v2p_.table = nullptr;
+
+    page_bits_ = 0;
+    size_t temp = page_size_;
+    while (temp > 1) {
+        ++page_bits_;
+        temp >>= 1;
+    }
+    NOTIFY(1, "Page size: %zu; bits: %d\n", page_size_, page_bits_);
 #endif
 }
 
@@ -111,11 +115,13 @@ physaddr_t::init()
 #endif
 }
 
-addr_t
-physaddr_t::virtual2physical(addr_t virt)
+bool
+physaddr_t::virtual2physical(addr_t virt, OUT addr_t *phys)
 {
 #ifdef LINUX
-    addr_t vpage = PAGE_START(virt);
+    if (phys == nullptr)
+        return false;
+    addr_t vpage = page_start(virt);
     bool use_cache = true;
     if (op_virt2phys_freq.get_value() > 0 && ++count_ >= op_virt2phys_freq.get_value()) {
         // Flush the cache and re-sync with the kernel
@@ -127,8 +133,10 @@ physaddr_t::virtual2physical(addr_t virt)
     if (use_cache) {
         // Use cached values on the assumption that the kernel hasn't re-mapped
         // this virtual page.
-        if (vpage == last_vpage_)
-            return last_ppage_ + PAGE_OFFS(virt);
+        if (vpage == last_vpage_) {
+            *phys = last_ppage_ + page_offs(virt);
+            return true;
+        }
         // XXX i#1703: add (debug-build-only) internal stats here and
         // on cache_t::request() fastpath.
         void *lookup = hashtable_lookup(&v2p_, reinterpret_cast<void *>(vpage));
@@ -139,36 +147,47 @@ physaddr_t::virtual2physical(addr_t virt)
                 ppage = 0;
             last_vpage_ = vpage;
             last_ppage_ = ppage;
-            return last_ppage_ + PAGE_OFFS(virt);
+            *phys = last_ppage_ + page_offs(virt);
+            return true;
         }
     }
     // Not cached, or forced to re-sync, so we have to read from the file.
-    if (fd_ == -1)
-        return 0;
-    // The pagemap file contains one 64-bit int per page, which we assume
-    // here is 4096 bytes.
-    // (XXX i#1703: handle large pages)
-    // Thus we want offset:
-    //   (addr / 4096 * 8) == ((addr >> 12) << 3) == addr >> 9
-    if (lseek64(fd_, vpage >> 9, SEEK_SET) < 0)
-        return 0;
-    unsigned long long entry;
-    if (read(fd_, (char *)&entry, sizeof(entry)) != sizeof(entry))
-        return 0;
-    if (!TESTALL(PAGEMAP_VALID, entry) || TESTANY(PAGEMAP_SWAP, entry))
-        return 0;
-    last_ppage_ = (addr_t)((entry & PAGEMAP_PFN) << PAGE_BITS);
-    if (op_verbose.get_value() >= 2) {
-        std::cerr << "virtual " << virt << " => physical "
-                  << (last_ppage_ + PAGE_OFFS(virt)) << std::endl;
+    if (fd_ == -1) {
+        NOTIFY(1, "v2p failure: file descriptor is invalid\n");
+        return false;
     }
+    // The pagemap file contains one 64-bit int per page.
+    // See the docs at https://www.kernel.org/doc/Documentation/vm/pagemap.txt
+    // For huge pages it's the same: there are just N consecutive entries, with
+    // the first marked COMPOUND_HEAD and the rest COMPOUND_TAIL in the flags,
+    // which we ignore here.
+    off64_t offs = vpage / page_size_ * 8;
+    if (lseek64(fd_, offs, SEEK_SET) < 0) {
+        NOTIFY(1, "v2p failure: seek to " INT64_FORMAT_STRING " for %p failed\n", offs,
+               vpage);
+        return false;
+    }
+    uint64_t entry;
+    if (read(fd_, (char *)&entry, sizeof(entry)) != sizeof(entry)) {
+        NOTIFY(1, "v2p failure: read failed for %p\n", vpage);
+        return false;
+    }
+    NOTIFY(3, "v2p: %p => entry " HEX64_FORMAT_STRING " @ offs " INT64_FORMAT_STRING "\n",
+           vpage, entry, offs);
+    if (!TESTALL(PAGEMAP_VALID, entry) || TESTANY(PAGEMAP_SWAP, entry)) {
+        NOTIFY(1, "v2p failure: entry is invalid for %p\n", vpage);
+        return false;
+    }
+    last_ppage_ = (addr_t)((entry & PAGEMAP_PFN) << page_bits_);
     // Store 0 as a sentinel since 0 means no entry.
     hashtable_add(
         &v2p_, reinterpret_cast<void *>(vpage),
         reinterpret_cast<void *>(last_ppage_ == 0 ? ZERO_ADDR_PAYLOAD : last_ppage_));
     last_vpage_ = vpage;
-    return last_ppage_ + PAGE_OFFS(virt);
+    *phys = last_ppage_ + page_offs(virt);
+    NOTIFY(2, "virtual %p => physical %p\n", virt, *phys);
+    return true;
 #else
-    return 0;
+    return false;
 #endif
 }

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -50,11 +50,24 @@ public:
     ~physaddr_t();
     bool
     init();
-    addr_t
-    virtual2physical(addr_t virt);
+    bool
+    virtual2physical(addr_t virt, OUT addr_t *phys);
 
 private:
 #ifdef LINUX
+    inline addr_t
+    page_start(addr_t addr)
+    {
+        return ALIGN_BACKWARD(addr, page_size_);
+    }
+    inline uint64_t
+    page_offs(addr_t addr)
+    {
+        return addr & ((1 << page_bits_) - 1);
+    }
+
+    size_t page_size_;
+    int page_bits_;
     addr_t last_vpage_;
     addr_t last_ppage_;
     // TODO i#4014: An app with thousands of threads might hit open file limits,

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -50,6 +50,11 @@ public:
     ~physaddr_t();
     bool
     init();
+
+    // If translation from "virt" to its corresponding physicall address is
+    // successful, returns true and stores the physical address in "phys".
+    // 0 is a possible valid physical address, as are large values beyond
+    // the amount of RAM due to holes in the physical address space.
     bool
     virtual2physical(addr_t virt, OUT addr_t *phys);
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -82,8 +82,6 @@
 #    define TRACE_SUFFIX "trace"
 #endif
 
-#define ALIGN_BACKWARD(x, alignment) (((ptr_uint_t)x) & (~((alignment)-1)))
-
 typedef enum {
     RAW2TRACE_STAT_COUNT_ELIDED,
 } raw2trace_statistic_t;


### PR DESCRIPTION
Adds support for different page sizes from 4K for drmemtrace's
-use_physical.

Adds hugepage support, which does not require anything special: just
updated the comment.

Improves the error reporting for physical translation.

Tested on an AArch64 machine with 64K pages.

Issue: #4014