### PR TITLE
i#4014 dr$sim phys: Solve placement and capacity issues

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -140,8 +140,9 @@ Further non-compatibility-affecting changes include:
    choices under the -raw_compress option.  Compressing with lz4 is now the
    default (if built with lz4 support).
  - Added drmodtrack_lookup_pc_from_index().
- - Added -use_physical support to drcachesim offline traces using two new
-   marker types: #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and
+ - Added -use_physical support to drcachesim offline traces using three new
+   marker types: #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS,
+   #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, and
    #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE.
  - Added an open-address hashtable implementation for cases where third-party
    libraries must be avoided and open addressing is best: dr_hashtable_create(),

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -198,7 +198,11 @@ droption_t<bool> op_use_physical(
     DROPTION_SCOPE_CLIENT, "use_physical", false, "Use physical addresses if possible",
     "If available, the default virtual addresses will be translated to physical.  "
     "This is not possible from user mode on all platforms.  "
-    "This is not supported with -offline at this time.");
+    "For -offline, the regular trace entries remain virtual, with a pair of markers of "
+    "types #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS "
+    "inserted at some prior point for each new or changed page mapping to show the "
+    "corresponding physical addresses.  This option may incur significant overhead "
+    "both for the physical translation and as it requires disabling optimizations.");
 
 droption_t<unsigned int> op_virt2phys_freq(
     DROPTION_SCOPE_CLIENT, "virt2phys_freq", 0, "Frequency of physical mapping refresh",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -199,7 +199,7 @@ droption_t<bool> op_use_physical(
     "If available, the default virtual addresses will be translated to physical.  "
     "This is not possible from user mode on all platforms.  "
     "For -offline, the regular trace entries remain virtual, with a pair of markers of "
-    "types #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS "
+    "types #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS "
     "inserted at some prior point for each new or changed page mapping to show the "
     "corresponding physical addresses.  This option may incur significant overhead "
     "both for the physical translation and as it requires disabling optimizations.");

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -348,9 +348,8 @@ typedef enum {
     TRACE_MARKER_TYPE_PHYSICAL_ADDRESS,
 
     /**
-     * Indicates a failure to obtain the physical address corresponding to some
-     * subsequent entry's instruction fetch PC or data virtual address.  The marker
-     * value is undefined.
+     * Indicates a failure to obtain the physical address corresponding to the
+     * virtual address contained in the marker value.
      */
     TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE,
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -338,17 +338,32 @@ typedef enum {
 
     /**
      * The marker value contains the physical address corresponding to the subsequent
-     * entry's instruction fetch PC or data address.  If translation failed, a
-     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be present instead.
+     * #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS's virtual address.  A pair of such markers
+     * will appear somewhere prior to a regular instruction fetch or data load or store
+     * whose page's physical address has not yet been reported, or when a physical
+     * mapping change is detected.  If translation failed, a
+     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be present instead,
+     * without a corresponding #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
      */
     TRACE_MARKER_TYPE_PHYSICAL_ADDRESS,
 
     /**
-     * Indicates a failure to obtain the physical address corresponding to the
-     * subsequent entry's instruction fetch PC or data address.  The marker value is
-     * undefined.
+     * Indicates a failure to obtain the physical address corresponding to some
+     * subsequent entry's instruction fetch PC or data virtual address.  The marker
+     * value is undefined.
      */
     TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE,
+
+    /**
+     * The marker value contains the virtual address corresponding to the prior
+     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS's physical address.  A pair of such markers
+     * will appear somewhere prior to a regular instruction fetch or data load or store
+     * whose page's physical address has not yet been reported, or when a physical
+     * mapping change is detected.  If translation failed, a
+     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be present instead,
+     * without a corresponding #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
+     */
+    TRACE_MARKER_TYPE_VIRTUAL_ADDRESS,
 
     // ...
     // These values are reserved for future built-in marker types.

--- a/clients/drcachesim/tests/offline-phys.templatex
+++ b/clients/drcachesim/tests/offline-phys.templatex
@@ -18,9 +18,12 @@ Output format:
 <record#>: T<tid> <record details>
 ------------------------------------------------------------
         1: T[0-9]+ <marker: version 3>
-        2: T[0-9]+ <marker: filetype 0x40>
+        2: T[0-9]+ <marker: filetype 0x42>
         3: T[0-9]+ <marker: cache line size [0-9]+>
         4: T[0-9]+ <marker: timestamp [0-9]+>
         5: T[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
-        6: T[0-9]+ <marker: physical address for following entry: 0x[0-9a-f][0-9a-f]+>
-        7: T[0-9]+ ifetch .*
+        6: T[0-9]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+        7: T[0-9]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+        8: T[0-9]+ <marker: timestamp [0-9]+>
+        9: T[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
+       10: T[0-9]+ ifetch .*

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -201,12 +201,19 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         }
     }
     if (shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
-        (shard->prev_entry_.marker.marker_type == TRACE_MARKER_TYPE_PHYSICAL_ADDRESS ||
-         shard->prev_entry_.marker.marker_type ==
-             TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE)) {
-        // Physical address markers must be immediately prior to the virtual entry.
-        report_if_false(shard, type_has_address(memref.data.type),
+        shard->prev_entry_.marker.marker_type == TRACE_MARKER_TYPE_PHYSICAL_ADDRESS) {
+        // A physical address marker must be immediately prior to its virtual marker.
+        report_if_false(shard,
+                        memref.marker.type == TRACE_TYPE_MARKER &&
+                            memref.marker.marker_type ==
+                                TRACE_MARKER_TYPE_VIRTUAL_ADDRESS,
                         "Physical addr marker not immediately prior to virtual addr");
+        // We don't have the actual page size, but it is always at least 4K, so
+        // make sure the bottom 12 bits are the same.
+        report_if_false(shard,
+                        (memref.marker.marker_value & 0xfff) ==
+                            (shard->prev_entry_.marker.marker_value & 0xfff),
+                        "Physical addr bottom 12 bits do not match virtual");
     }
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -207,7 +207,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         memref.marker.type == TRACE_TYPE_MARKER &&
                             memref.marker.marker_type ==
                                 TRACE_MARKER_TYPE_VIRTUAL_ADDRESS,
-                        "Physical addr marker not immediately prior to virtual addr");
+                        "Physical addr marker not immediately prior to virtual marker");
         // We don't have the actual page size, but it is always at least 4K, so
         // make sure the bottom 12 bits are the same.
         report_if_false(shard,

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -323,7 +323,11 @@ view_t::process_memref(const memref_t &memref)
                       << ">\n";
             break;
         case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS:
-            std::cerr << "<marker: physical address for following entry: 0x" << std::hex
+            std::cerr << "<marker: physical address for following virtual: 0x" << std::hex
+                      << memref.marker.marker_value << std::dec << ">\n";
+            break;
+        case TRACE_MARKER_TYPE_VIRTUAL_ADDRESS:
+            std::cerr << "<marker: virtual address for prior physical: 0x" << std::hex
                       << memref.marker.marker_value << std::dec << ">\n";
             break;
         case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE:

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -109,8 +109,6 @@ static int notify_beyond_global_max_once;
  * to hold all entries between clean calls.
  */
 // XXX i#1703: use an option instead.
-// If we increase this, we may need to increase MAX_V2P_ENTRIES -- until we
-// implement buffer splitting for i#4014 in any case.
 #define MAX_NUM_ENTRIES 4096
 /* The buffer size for holding trace entries. */
 static size_t trace_buf_size;
@@ -122,13 +120,6 @@ static size_t redzone_size;
 static size_t max_buf_size;
 
 static drvector_t scratch_reserve_vec;
-
-// For virtual-to-physical markers, we need extra space to insert them after
-// filling up a buffer.  We do not expect many per trace buffer as we only emit
-// them for never-before-seen pages.
-// TODO i#4014: Split the buffer if we hit this limit.  For now, our markers are
-// best-effort and we just drop them if this limit is exceeded.
-static constexpr int MAX_V2P_ENTRIES = 128;
 
 /* Thread private data.  This is all set to 0 at thread init. */
 typedef struct {
@@ -168,6 +159,8 @@ typedef struct {
     // The physaddr_t class is designed to be per-thread.
     physaddr_t physaddr;
     uint64 num_phys_markers;
+    byte *v2p_buf;
+    uint64 num_v2p_writeouts; /* v2p_buf writeout instances. */
 } per_thread_t;
 
 #define MAX_NUM_DELAY_INSTRS 32
@@ -198,6 +191,7 @@ static void *mutex;          /* for multithread support */
 static uint64 num_refs;      /* keep a global memory reference count */
 static uint64 num_refs_racy; /* racy global memory reference count */
 static uint64 num_writeouts;
+static uint64 num_v2p_writeouts;
 static uint64 num_phys_markers;
 static volatile bool exited_process;
 
@@ -856,6 +850,27 @@ create_buffer(per_thread_t *data)
     }
 }
 
+static size_t
+get_v2p_buffer_size()
+{
+    // The handoff interface requites we use dr_raw_mem_alloc and thus page alignment.
+    // We use one page which is 256 entries for 4K pages which is enough for
+    // most cases.
+    return dr_page_size();
+}
+
+static void
+create_v2p_buffer(per_thread_t *data)
+{
+    // The handoff interface requites we use dr_raw_mem_alloc and thus page alignment.
+    data->v2p_buf = (byte *)dr_raw_mem_alloc(get_v2p_buffer_size(),
+                                             DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
+    /* For file_ops_func.handoff_buf we have to handle failure as OOM is not unlikely. */
+    if (data->v2p_buf == NULL) {
+        FATAL("Out of memory for virtual-to-physical buffers.\n");
+    }
+}
+
 static bool
 is_ok_to_split_before(trace_type_t type)
 {
@@ -877,15 +892,105 @@ is_bytes_written_beyond_trace_max(per_thread_t *data)
         data->bytes_written > op_max_trace_size.get_value();
 }
 
+static size_t
+add_buffer_header(void *drcontext, per_thread_t *data, byte *buf_base)
+{
+    size_t header_size = 0;
+    // For online we already wrote the thread header but for offline it is in
+    // the first buffer, so skip over it.
+    if (data->has_thread_header && op_offline.get_value())
+        header_size = data->init_header_size;
+    data->has_thread_header = false;
+    // The initial slots are left empty for the header, which we add here.
+    header_size +=
+        append_unit_header(drcontext, buf_base + header_size, dr_get_thread_id(drcontext),
+                           get_local_window(data));
+    return header_size;
+}
+
+static uint
+output_buffer(void *drcontext, per_thread_t *data, byte *buf_base, byte *buf_ptr,
+              size_t header_size)
+{
+    byte *pipe_start = buf_base;
+    byte *pipe_end = pipe_start;
+    if (!op_offline.get_value()) {
+        for (byte *mem_ref = buf_base + header_size; mem_ref < buf_ptr;
+             mem_ref += instru->sizeof_entry()) {
+            // Split up the buffer into multiple writes to ensure atomic pipe writes.
+            // We can only split before TRACE_TYPE_INSTR, assuming only a few data
+            // entries in between instr entries.
+            // XXX i#2638: if we want to support branch target analysis in online
+            // traces we'll need to not split after a branch: either split before
+            // it or one instr after.
+            if (is_ok_to_split_before(instru->get_entry_type(mem_ref))) {
+                pipe_end = mem_ref;
+                // We check the end of this entry + the max # of delay entries to
+                // avoid splitting an instr from its subsequent bundle entry.
+                // An alternative is to have the reader use per-thread state.
+                if ((mem_ref + (1 + MAX_NUM_DELAY_ENTRIES) * instru->sizeof_entry() -
+                     pipe_start) > ipc_pipe.get_atomic_write_size()) {
+                    DR_ASSERT(is_ok_to_split_before(
+                        instru->get_entry_type(pipe_start + header_size)));
+                    pipe_start = atomic_pipe_write(drcontext, pipe_start, pipe_end,
+                                                   get_local_window(data));
+                }
+            }
+        }
+        // Write the rest to pipe
+        // The last few entries (e.g., instr + refs) may exceed the atomic write size,
+        // so we may need two writes.
+        // XXX i#2638: if we want to support branch target analysis in online
+        // traces we'll need to not split after a branch by carrying a write-final
+        // branch forward to the next buffer.
+        if ((buf_ptr - pipe_start) > ipc_pipe.get_atomic_write_size()) {
+            DR_ASSERT(
+                is_ok_to_split_before(instru->get_entry_type(pipe_start + header_size)));
+            pipe_start = atomic_pipe_write(drcontext, pipe_start, pipe_end,
+                                           get_local_window(data));
+        }
+        if ((buf_ptr - pipe_start) > (ssize_t)buf_hdr_slots_size) {
+            DR_ASSERT(
+                is_ok_to_split_before(instru->get_entry_type(pipe_start + header_size)));
+            atomic_pipe_write(drcontext, pipe_start, buf_ptr, get_local_window(data));
+        }
+    } else {
+        write_trace_data(drcontext, pipe_start, buf_ptr, get_local_window(data));
+    }
+    auto span = buf_ptr - buf_base; // Include the header.
+    DR_ASSERT(span % instru->sizeof_entry() == 0);
+    uint current_num_refs = (uint)(span / instru->sizeof_entry());
+    data->num_refs += current_num_refs;
+    data->bytes_written += buf_ptr - pipe_start;
+    bool is_v2p = false;
+    if (buf_base >= data->v2p_buf && buf_base < data->v2p_buf + get_v2p_buffer_size())
+        is_v2p = true;
+    if (is_v2p)
+        ++data->num_v2p_writeouts;
+    else
+        ++data->num_writeouts;
+
+    if (file_ops_func.handoff_buf != NULL) {
+        // The owner of the handoff callback now owns the buffer, and we get a new one.
+        if (is_v2p)
+            create_v2p_buffer(data);
+        else
+            create_buffer(data);
+    }
+    return current_num_refs;
+}
+
 // Should be called only for have_phys and -use_physical.
-// Returns the byte count added to the buffer.
+// Returns the byte count to skip in the trace buffer (due to shifting some headers
+// to the v2p buffer).
 static size_t
 process_buffer_for_physaddr(void *drcontext, per_thread_t *data, size_t header_size,
                             byte *buf_ptr)
 {
     ASSERT(have_phys, "Caller must check for use_physical being enabled");
-    uint64 start_count = data->num_phys_markers;
-    byte *orig_buf_ptr = buf_ptr;
+    byte *v2p_ptr = data->v2p_buf;
+    size_t skip = 0;
+    bool emitted = false;
     for (byte *mem_ref = data->buf_base + header_size; mem_ref < buf_ptr;
          mem_ref += instru->sizeof_entry()) {
         trace_type_t type = instru->get_entry_type(mem_ref);
@@ -896,7 +1001,8 @@ process_buffer_for_physaddr(void *drcontext, per_thread_t *data, size_t header_s
         // whole block: but the block could span 2 pages, and we want a physical
         // entry to appear before any virtual entries.
         // To solve for fixed-length instrs we could emit a 2nd PC entry
-        // at the page transition: but for x86 a single instr could span 2 pages.
+        // at the page transition: but for x86 we don't know whether the block
+        // crosses as we have only the instruction count.
         // Currently this is unsolved and the 2nd page is ignored.
         addr_t virt = instru->get_entry_addr(drcontext, mem_ref);
         bool from_cache = false;
@@ -921,34 +1027,56 @@ process_buffer_for_physaddr(void *drcontext, per_thread_t *data, size_t header_s
         if (op_offline.get_value()) {
             // For offline we keep the main entries as virtual but add markers showing
             // the corresponding physical.  We assume the mappings are static, allowing
-            // us to only emit one marker per new page seen (per thread to avoid locks).
+            // us to only emit one marker pair per new page seen (per thread to avoid
+            // locks).
             // XXX: Add spot-checks of mapping changes via a separate option from
             // -virt2phys_freq?
             if (from_cache)
                 continue;
-            // While inserting inside the buffer is expensive, it is rare, and using a
-            // separate buffer complicates the buffer handoff interface, requires a
-            // corresponding virtual marker, requires work in raw2trace to insert in the
-            // right place, and requires special handling with the very first buffer to
-            // be after its header but before its data.
-            // We made room for MAX_V2P_ENTRIES ahead of time.
-            if (data->num_phys_markers - start_count >= MAX_V2P_ENTRIES) {
-                // TODO i#4014: Split the buffer if we hit this limit.  For now, our
-                // markers are best-effort and we just drop them if this limit is
-                // exceeded.
-                NOTIFY(0, "Hit physical address marker limit; omitting markers\n");
-                continue;
+            // We have something to emit.  Rather than a memmove to insert inside the
+            // main buffer, we have a separate buffer, as our pair of markers means we
+            // do not need precise placement next to the corresponding regular entry
+            // (which also avoids extra work in raw2trace, esp for delayed branches and
+            // other cases).
+            // The downside is that we might have many buffers with a small number
+            // of markers on which we waste buffer output overhead.
+            // XXX: We could count them up and do a memmove if the count is small
+            // and we have space in the redzone?
+            if (!emitted) {
+                // We need to be sure to emit the initial thread header if this is before
+                // the first regular buffer and skip it in the regular buffer.
+                if (header_size > buf_hdr_slots_size) {
+                    size_t size = reinterpret_cast<offline_instru_t *>(instru)
+                                      ->append_thread_header(data->v2p_buf,
+                                                             dr_get_thread_id(drcontext),
+                                                             get_file_type());
+                    ASSERT(size == data->init_header_size, "inconsistent header");
+                    skip = data->init_header_size;
+                    v2p_ptr += size;
+                    header_size += size;
+                }
+                v2p_ptr += add_buffer_header(drcontext, data, v2p_ptr);
+                emitted = true;
             }
-            memmove(mem_ref + instru->sizeof_entry(), mem_ref, buf_ptr - mem_ref);
-            // For translation failure, we insert a distinct marker type, so analyzers
-            // know for sure and don't have to infer based on a missing marker.
-            mem_ref += instru->append_marker(
-                mem_ref,
-                success ? TRACE_MARKER_TYPE_PHYSICAL_ADDRESS
-                        : TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE,
-                phys);
-            buf_ptr += instru->sizeof_entry();
-            ++data->num_phys_markers;
+            if (v2p_ptr + 2 * instru->sizeof_entry() - data->v2p_buf >=
+                static_cast<ssize_t>(get_v2p_buffer_size())) {
+                NOTIFY(1, "Reached v2p buffer limit: emitting multiple times\n");
+                data->num_phys_markers +=
+                    output_buffer(drcontext, data, data->v2p_buf, v2p_ptr, header_size);
+                v2p_ptr = data->v2p_buf;
+                v2p_ptr += add_buffer_header(drcontext, data, v2p_ptr);
+            }
+            if (success) {
+                v2p_ptr += instru->append_marker(
+                    v2p_ptr, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS, phys);
+                v2p_ptr += instru->append_marker(v2p_ptr,
+                                                 TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, virt);
+            } else {
+                // For translation failure, we insert a distinct marker type, so analyzers
+                // know for sure and don't have to infer based on a missing marker.
+                v2p_ptr += instru->append_marker(
+                    v2p_ptr, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE, phys);
+            }
         } else {
             // For online we replace the virtual with physical.
             // XXX i#4014: For consistency we should break compatibility, *not* replace,
@@ -958,7 +1086,11 @@ process_buffer_for_physaddr(void *drcontext, per_thread_t *data, size_t header_s
                 instru->set_entry_addr(mem_ref, phys);
         }
     }
-    return buf_ptr - orig_buf_ptr;
+    if (emitted) {
+        data->num_phys_markers +=
+            output_buffer(drcontext, data, data->v2p_buf, v2p_ptr, header_size);
+    }
+    return skip;
 }
 
 // Should be invoked only in the middle of an active tracing window.
@@ -967,7 +1099,7 @@ memtrace(void *drcontext, bool skip_size_cap)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
     byte *mem_ref, *buf_ptr;
-    byte *pipe_start, *pipe_end, *redzone;
+    byte *redzone;
     bool do_write = true;
     size_t header_size = 0;
     uint current_num_refs = 0;
@@ -979,10 +1111,6 @@ memtrace(void *drcontext, bool skip_size_cap)
     }
 
     buf_ptr = BUF_PTR(data->seg_base);
-    // For online we already wrote the thread header but for offline it is in
-    // the first buffer, so skip over it.
-    if (data->has_thread_header && op_offline.get_value())
-        header_size = data->init_header_size;
     // We may get called with nothing to write: e.g., on a syscall for -L0_filter.
     if (buf_ptr == data->buf_base + header_size + buf_hdr_slots_size) {
         if (has_tracing_windows()) {
@@ -994,11 +1122,9 @@ memtrace(void *drcontext, bool skip_size_cap)
         }
         return;
     }
-    data->has_thread_header = false;
-    // The initial slots are left empty for the header, which we add here.
-    header_size +=
-        append_unit_header(drcontext, data->buf_base + header_size,
-                           dr_get_thread_id(drcontext), get_local_window(data));
+
+    header_size = add_buffer_header(drcontext, data, data->buf_base);
+
     bool window_changed = false;
     if (has_tracing_windows() &&
         get_local_window(data) != tracing_window.load(std::memory_order_acquire)) {
@@ -1013,8 +1139,6 @@ memtrace(void *drcontext, bool skip_size_cap)
         if (op_offline.get_value() && op_split_windows.get_value())
             buf_ptr += instru->append_thread_exit(buf_ptr, dr_get_thread_id(drcontext));
     }
-    pipe_start = data->buf_base;
-    pipe_end = pipe_start;
     if (!skip_size_cap &&
         (is_bytes_written_beyond_trace_max(data) || is_num_refs_beyond_global_max())) {
         /* We don't guarantee to match the limit exactly so we allow one buffer
@@ -1041,8 +1165,7 @@ memtrace(void *drcontext, bool skip_size_cap)
                 }
             }
         }
-    } else
-        data->bytes_written += buf_ptr - pipe_start;
+    }
 
     if (do_write) {
         bool hit_window_end = false;
@@ -1065,7 +1188,6 @@ memtrace(void *drcontext, bool skip_size_cap)
                 if (op_offline.get_value() && op_split_windows.get_value()) {
                     size_t add =
                         instru->append_thread_exit(buf_ptr, dr_get_thread_id(drcontext));
-                    data->bytes_written += add;
                     buf_ptr += add;
                 }
                 // Update the global window, but not the local so we can place the rest
@@ -1073,66 +1195,15 @@ memtrace(void *drcontext, bool skip_size_cap)
                 reached_traced_instrs_threshold(drcontext);
             }
         }
+        size_t skip = 0;
         if (have_phys && op_use_physical.get_value()) {
-            size_t add =
-                process_buffer_for_physaddr(drcontext, data, header_size, buf_ptr);
-            data->bytes_written += add;
-            buf_ptr += add;
+            skip = process_buffer_for_physaddr(drcontext, data, header_size, buf_ptr);
         }
-        if (!op_offline.get_value()) {
-            for (mem_ref = data->buf_base + header_size; mem_ref < buf_ptr;
-                 mem_ref += instru->sizeof_entry()) {
-                // Split up the buffer into multiple writes to ensure atomic pipe writes.
-                // We can only split before TRACE_TYPE_INSTR, assuming only a few data
-                // entries in between instr entries.
-                // XXX i#2638: if we want to support branch target analysis in online
-                // traces we'll need to not split after a branch: either split before
-                // it or one instr after.
-                if (is_ok_to_split_before(instru->get_entry_type(mem_ref))) {
-                    pipe_end = mem_ref;
-                    // We check the end of this entry + the max # of delay entries to
-                    // avoid splitting an instr from its subsequent bundle entry.
-                    // An alternative is to have the reader use per-thread state.
-                    if ((mem_ref + (1 + MAX_NUM_DELAY_ENTRIES) * instru->sizeof_entry() -
-                         pipe_start) > ipc_pipe.get_atomic_write_size()) {
-                        DR_ASSERT(is_ok_to_split_before(
-                            instru->get_entry_type(pipe_start + header_size)));
-                        pipe_start = atomic_pipe_write(drcontext, pipe_start, pipe_end,
-                                                       get_local_window(data));
-                    }
-                }
-            }
-            // Write the rest to pipe
-            // The last few entries (e.g., instr + refs) may exceed the atomic write size,
-            // so we may need two writes.
-            // XXX i#2638: if we want to support branch target analysis in online
-            // traces we'll need to not split after a branch by carrying a write-final
-            // branch forward to the next buffer.
-            if ((buf_ptr - pipe_start) > ipc_pipe.get_atomic_write_size()) {
-                DR_ASSERT(is_ok_to_split_before(
-                    instru->get_entry_type(pipe_start + header_size)));
-                pipe_start = atomic_pipe_write(drcontext, pipe_start, pipe_end,
-                                               get_local_window(data));
-            }
-            if ((buf_ptr - pipe_start) > (ssize_t)buf_hdr_slots_size) {
-                DR_ASSERT(is_ok_to_split_before(
-                    instru->get_entry_type(pipe_start + header_size)));
-                atomic_pipe_write(drcontext, pipe_start, buf_ptr, get_local_window(data));
-            }
-        } else {
-            write_trace_data(drcontext, pipe_start, buf_ptr, get_local_window(data));
-        }
-        auto span = buf_ptr - (data->buf_base + header_size);
-        DR_ASSERT(span % instru->sizeof_entry() == 0);
-        current_num_refs = (uint)(span / instru->sizeof_entry());
-        data->num_refs += current_num_refs;
-        ++data->num_writeouts;
+        current_num_refs +=
+            output_buffer(drcontext, data, data->buf_base + skip, buf_ptr, header_size);
     }
 
-    if (do_write && file_ops_func.handoff_buf != NULL) {
-        // The owner of the handoff callback now owns the buffer, and we get a new one.
-        create_buffer(data);
-    } else {
+    if (file_ops_func.handoff_buf == NULL) {
         // Our instrumentation reads from buffer and skips the clean call if the
         // content is 0, so we need set zero in the trace buffer and set non-zero
         // in redzone.
@@ -2637,12 +2708,20 @@ event_inscount_app_instruction(void *drcontext, void *tag, instrlist_t *bb,
  * Top level.
  */
 
+static bool
+optimizations_disabled()
+{
+    // We cannot elide addresses or ignore offsets when we need to translate
+    // all addresses during tracing.
+    return op_disable_optimizations.get_value() || op_use_physical.get_value();
+}
+
 static offline_file_type_t
 get_file_type()
 {
     offline_file_type_t file_type =
         op_L0_filter.get_value() ? OFFLINE_FILE_TYPE_FILTERED : OFFLINE_FILE_TYPE_DEFAULT;
-    if (op_disable_optimizations.get_value()) {
+    if (optimizations_disabled()) {
         file_type = static_cast<offline_file_type_t>(file_type |
                                                      OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS);
     }
@@ -2768,6 +2847,9 @@ event_thread_init(void *drcontext)
         BUF_PTR(data->seg_base) = NULL;
     else {
         create_buffer(data);
+        if (op_use_physical.get_value() && op_offline.get_value()) {
+            create_v2p_buffer(data);
+        }
         init_thread_in_process(drcontext);
         // XXX i#1729: gather and store an initial callstack for the thread.
     }
@@ -2850,6 +2932,7 @@ event_thread_exit(void *drcontext)
         dr_mutex_lock(mutex);
         num_refs += data->num_refs;
         num_writeouts += data->num_writeouts;
+        num_v2p_writeouts += data->num_v2p_writeouts;
         num_phys_markers += data->num_phys_markers;
         dr_mutex_unlock(mutex);
         dr_raw_mem_free(data->buf_base, max_buf_size);
@@ -2869,14 +2952,15 @@ event_exit(void)
            "drmemtrace exiting process " PIDFMT "; traced " UINT64_FORMAT_STRING
            " references in " UINT64_FORMAT_STRING " writeouts.\n",
            dr_get_process_id(), num_refs, num_writeouts);
-    if (op_use_physical.get_value()) {
+    if (op_use_physical.get_value() && op_offline.get_value()) {
         dr_log(NULL, DR_LOG_ALL, 1,
-               "drcachesim num physical address markers inserted: " UINT64_FORMAT_STRING
+               "drcachesim num physical address markers emitted: " UINT64_FORMAT_STRING
                "\n",
                num_phys_markers);
         NOTIFY(1,
-               "drmemtrace inserted " UINT64_FORMAT_STRING " physical address markers.\n",
-               num_phys_markers);
+               "drmemtrace emitted " UINT64_FORMAT_STRING
+               " physical address markers in " UINT64_FORMAT_STRING " writeouts.\n",
+               num_phys_markers, num_v2p_writeouts);
     }
     /* we use placement new for better isolation */
     instru->~instru_t();
@@ -3104,7 +3188,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         placement = dr_global_alloc(MAX_INSTRU_SIZE);
         instru = new (placement) offline_instru_t(
             insert_load_buf_ptr, op_L0_filter.get_value(), &scratch_reserve_vec,
-            file_ops_func.write_file, module_file, op_disable_optimizations.get_value());
+            file_ops_func.write_file, module_file, optimizations_disabled());
     } else {
         void *placement;
         /* we use placement new for better isolation */
@@ -3188,10 +3272,6 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         max_bb_instrs = 256; /* current default */
     DR_ASSERT(max_bb_instrs < uint64(1) << PC_INSTR_COUNT_BITS);
     redzone_size = instru->sizeof_entry() * (size_t)max_bb_instrs * 2;
-    if (op_use_physical.get_value() && op_offline.get_value()) {
-        // We need extra space for v2p markers.
-        redzone_size += instru->sizeof_entry() * MAX_V2P_ENTRIES;
-    }
 
     max_buf_size = ALIGN_FORWARD(trace_buf_size + redzone_size, dr_page_size());
     /* Mark any padding as redzone as well */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3755,7 +3755,7 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.phys_SUDO_sudo ON)
       set(tool.drcacheoff.phys_SUDO_expectbase "offline-phys")
       torunonly_drcacheoff(phys_SUDO allasm_x86_64
-        "-use_physical" "@-simulator_type@view" "")
+        "-use_physical" "@${test_mode_flag}@-simulator_type@view" "")
     endif ()
 
     if (UNIX AND ZLIB_FOUND)


### PR DESCRIPTION
Solves issues with requiring precise placement of physical markers
prior to their corresponding regular virtual address entry (ifetch
entries being inserted between the marker and memref by raw2trace;
delayed branches needing to carry their marker; page-spanning extra
markers needing to land in the right place) by switching to a scheme
where markers come in pairs with a physical and a virtual.  Such a
pair has flexibility on where it can appear in the trace so long as it
is prior to the regular entry with that virtual address.  This
eliminates all work and complexity for raw2trace to move the markers
around.

Solves issues with capacity where the tracer runs out of pre-allocated
space inside the main buffer for marker-heavy output by switching to
use a separately-allocated-and-emitted "v2p" buffer for the
physical,virtual pairs.  This is made possible by the flexible
location.  Two complexities of this scheme are solved: the buffer is
page-aligned and heap-allocated for buffer handoff; the initial thread
header is added to the v2p buffer and skipped in the regular buffer to
avoid the pairs appearing before the top-level metadata.

Refactors header insertion and buffer output into separate functions
out of the large memtrace() function.

Multi-output was tested on SPEC2K6 gzip which hits the 1-page limit 4
times during its run with a scaled-down test input set workload.

The view tool, invariant checker, release notes, and regression test
are updated.  The invariant checker now also checks that the physical
and virtual pair member share their bottom bits.  are identical.

Includes a significant fix for physical offline tracing:
Elision and address displacement optimizations are disabled for
physical addresses as the final address is required at tracing time.

Issue: #4014