### PR TITLE
i#4014 dr$sim phys: Add page size marker

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -147,6 +147,7 @@ Further non-compatibility-affecting changes include:
    libraries must be avoided and open addressing is best: dr_hashtable_create(),
    dr_hashtable_destroy(), dr_hashtable_clear(), dr_hashtable_lookup(),
    dr_hashtable_add(), dr_hashtable_remove().
+ - Added a new #TRACE_MARKER_TYPE_PAGE_SIZE record to drcachesim offline traces.
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -350,6 +350,11 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE,
 
+    /**
+     * The marker value contains the traced process's page size in bytes.
+     */
+    TRACE_MARKER_TYPE_PAGE_SIZE,
+
     // ...
     // These values are reserved for future built-in marker types.
     // ...

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -26,7 +26,7 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
-           3 total other markers
+           4 total other markers
 Thread [0-9]* counts:
           95 \(fetched\) instructions
           23 unique \(fetched\) instructions
@@ -42,4 +42,4 @@ Thread [0-9]* counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
-           3 other markers
+           4 other markers

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -223,6 +223,7 @@ main(int argc, const char *argv[])
                   << "\n";
     }
     bool found_cache_line_size_marker = false;
+    bool found_page_size_marker = false;
     int dc_zva_instr_count = 0;
     int dc_zva_memref_count = 0;
     addr_t last_dc_zva_pc = 0;
@@ -232,6 +233,11 @@ main(int argc, const char *argv[])
             memref.marker.marker_type == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {
             found_cache_line_size_marker = true;
             assert(memref.marker.marker_value == proc_get_cache_line_size());
+        }
+        if (memref.marker.type == TRACE_TYPE_MARKER &&
+            memref.marker.marker_type == TRACE_MARKER_TYPE_PAGE_SIZE) {
+            found_page_size_marker = true;
+            assert(memref.marker.marker_value == dr_page_size());
         }
         if (is_dc_zva_instr(dr_context, memref)) {
             dc_zva_instr_count++;
@@ -255,6 +261,7 @@ main(int argc, const char *argv[])
     assert(dc_zva_memref_count != 0);
     assert(dc_zva_instr_count == dc_zva_memref_count);
     assert(found_cache_line_size_marker);
+    assert(found_page_size_marker);
     dr_standalone_exit();
 
     return 0;

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2022 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -165,6 +165,7 @@ check_branch_target_after_branch()
     {
         std::vector<memref_t> memrefs = {
             gen_marker(3, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(3, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             gen_branch(3, 2),
             gen_exit(3),
             gen_instr(1, 1),

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -25,7 +25,7 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
-           3 total other markers
+           4 total other markers
 Thread [0-9]* counts:
           95 \(fetched\) instructions
           23 unique \(fetched\) instructions
@@ -41,4 +41,4 @@ Thread [0-9]* counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
-           3 other markers
+           4 other markers

--- a/clients/drcachesim/tests/offline-phys.templatex
+++ b/clients/drcachesim/tests/offline-phys.templatex
@@ -20,7 +20,8 @@ Output format:
         1: T[0-9]+ <marker: version 3>
         2: T[0-9]+ <marker: filetype 0x40>
         3: T[0-9]+ <marker: cache line size [0-9]+>
-        4: T[0-9]+ <marker: timestamp [0-9]+>
-        5: T[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
-        6: T[0-9]+ <marker: physical address for following entry: 0x[0-9a-f][0-9a-f]+>
-        7: T[0-9]+ ifetch .*
+        4: T[0-9]+ <marker: page size [0-9]+>
+        5: T[0-9]+ <marker: timestamp [0-9]+>
+        6: T[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
+        7: T[0-9]+ <marker: physical address for following entry: 0x[0-9a-f][0-9a-f]+>
+        8: T[0-9]+ ifetch .*

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -37,7 +37,7 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
-          10 total other markers
+          11 total other markers
 Total windows: 7
 Window #0:
           12 window \(fetched\) instructions
@@ -54,7 +54,7 @@ Window #0:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
-           4 window other markers
+           5 window other markers
 Window #1:
            8 window \(fetched\) instructions
            8 window unique \(fetched\) instructions
@@ -166,4 +166,4 @@ Thread [0-9]* counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
-           4 other markers
+           5 other markers

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -202,7 +202,7 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
     // size of this buffer, and the first read for timestamp2 below that checks the
     // exact position of the timestamp entry. Consider removing some checks or making
     // them flexible in some way.
-    offline_entry_t buffer[5];
+    offline_entry_t buffer[6];
     file->read((char *)buffer, BUFFER_SIZE_BYTES(buffer));
 
     std::string error;
@@ -218,7 +218,7 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
     REPORT("Read timestamp from thread header");
 
     uint64 timestamp2 = 0;
-    if (drmemtrace_get_timestamp_from_offline_trace(buffer + 4, sizeof(offline_entry_t),
+    if (drmemtrace_get_timestamp_from_offline_trace(buffer + 5, sizeof(offline_entry_t),
                                                     &timestamp2) != DRMEMTRACE_SUCCESS)
         return false;
     if (timestamp != timestamp2)

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -186,6 +186,10 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         memref.marker.marker_type == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {
         shard->found_cache_line_size_marker_ = true;
     }
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_PAGE_SIZE) {
+        shard->found_page_size_marker_ = true;
+    }
 
     if (memref.exit.type == TRACE_TYPE_THREAD_EXIT) {
         report_if_false(shard,
@@ -194,6 +198,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         "Missing instr count markers");
         report_if_false(shard, shard->found_cache_line_size_marker_,
                         "Missing cache line marker");
+        report_if_false(shard, shard->found_page_size_marker_,
+                        "Missing page size marker");
         if (knob_test_name_ == "filter_asm_instr_count") {
             static constexpr int ASM_INSTR_COUNT = 133;
             report_if_false(shard, shard->last_instr_count_marker_ == ASM_INSTR_COUNT,

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -89,6 +89,7 @@ protected:
         bool saw_timestamp_but_no_instr_ = false;
         bool found_cache_line_size_marker_ = false;
         bool found_instr_count_marker_ = false;
+        bool found_page_size_marker_ = false;
         uint64_t last_instr_count_marker_ = 0;
         std::string error;
         // Track the location of errors.

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -322,6 +322,9 @@ view_t::process_memref(const memref_t &memref)
             std::cerr << "<marker: cache line size " << memref.marker.marker_value
                       << ">\n";
             break;
+        case TRACE_MARKER_TYPE_PAGE_SIZE:
+            std::cerr << "<marker: page size " << memref.marker.marker_value << ">\n";
+            break;
         case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS:
             std::cerr << "<marker: physical address for following entry: 0x" << std::hex
                       << memref.marker.marker_value << std::dec << ">\n";

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -351,6 +351,7 @@ offline_instru_t::append_thread_header(byte *buf_ptr, thread_id_t tid,
     new_buf += append_pid(new_buf, dr_get_process_id());
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CACHE_LINE_SIZE,
                              proc_get_cache_line_size());
+    new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_PAGE_SIZE, dr_page_size());
     return (int)(new_buf - buf_ptr);
 }
 

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -169,6 +169,7 @@ online_instru_t::append_thread_header(byte *buf_ptr, thread_id_t tid,
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_FILETYPE, file_type);
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CACHE_LINE_SIZE,
                              proc_get_cache_line_size());
+    new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_PAGE_SIZE, dr_page_size());
     return (int)(new_buf - buf_ptr);
 }
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1254,7 +1254,7 @@ drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t trace_size
     if (trace_metadata_reader_t::is_thread_start(offline_entries, &error, nullptr,
                                                  nullptr) &&
         error.empty()) {
-        if (size < 4)
+        if (size < 5)
             return DRMEMTRACE_ERROR_INVALID_PARAMETER;
 
         // XXX: Make it easier to add more markers. Iterate over the entries until
@@ -1264,7 +1264,11 @@ drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t trace_size
             (offline_entries[++timestamp_pos].extended.type != OFFLINE_TYPE_EXTENDED ||
              offline_entries[timestamp_pos].extended.ext != OFFLINE_EXT_TYPE_MARKER ||
              offline_entries[timestamp_pos].extended.valueB !=
-                 TRACE_MARKER_TYPE_CACHE_LINE_SIZE))
+                 TRACE_MARKER_TYPE_CACHE_LINE_SIZE) ||
+            (offline_entries[++timestamp_pos].extended.type != OFFLINE_TYPE_EXTENDED ||
+             offline_entries[timestamp_pos].extended.ext != OFFLINE_EXT_TYPE_MARKER ||
+             offline_entries[timestamp_pos].extended.valueB !=
+                 TRACE_MARKER_TYPE_PAGE_SIZE))
             return DRMEMTRACE_ERROR_INVALID_PARAMETER;
         ++timestamp_pos;
     }


### PR DESCRIPTION
To use the new physical address markers in a trace analysis tool, the
page size must be known.  Here we add a new marker to the thread
headers holding the page size.  Sanity tests are added.

Issue: #4014