### PR TITLE
i#5527: fix android build broken by preset ANDROID_NDK_ROOT

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -209,6 +209,7 @@ jobs:
         cd /tmp
         wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
         unzip -q android-ndk-r10e-linux-x86_64.zip
+        export ANDROID_NDK_ROOT=/tmp/android-ndk-r10e
         android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
           --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
           --install-dir=/tmp/android-gcc-arm-ndk-10e

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -356,6 +356,7 @@ jobs:
         cd /tmp
         wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
         unzip -q android-ndk-r10e-linux-x86_64.zip
+        export ANDROID_NDK_ROOT=/tmp/android-ndk-r10e
         android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
           --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
           --install-dir=/tmp/android-gcc-arm-ndk-10e


### PR DESCRIPTION
Fixes the problem of NDK setup failing due to ANDROID_NDK_ROOT pointing to the wrong path. The GitHub VM system preset ANDROID_NDK_ROOT to a location which does not include the necessary resources that the setup process needs. We set the ANDROID_NDK_ROOT to the right location before running the setup script. 

Fixed: #5527