### PR TITLE
i#5486 view no-opc: Fix incorrect indent in drmemtrace view tool

### DIFF
--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -416,12 +416,13 @@ view_t::process_memref(const memref_t &memref)
         disasm = buf;
         disasm_cache_.insert({ mapped_pc, disasm });
     }
-    // Put our prefix on raw byte spillover.
+    // Put our prefix on raw byte spillover, and skip the other columns.
     auto newline = disasm.find('\n');
     if (newline != std::string::npos && newline < disasm.size() - 1) {
         std::stringstream prefix;
         print_prefix(memref, 0, prefix);
-        disasm.insert(newline + 1, prefix.str());
+        disasm.insert(newline + 1,
+                      prefix.str() + "                                     ");
     }
     std::cerr << disasm;
     ++num_disasm_instrs_;


### PR DESCRIPTION
The recent refactoring of the drmemtrace view output failed to update
the indent for second-line raw bytes from disassembly.  We correct
that here.

Before:
------------------------------------------------------------------------------------------------------------------------
      342: T2539054 ifetch 2 byte(s) @ 0x00007f5feed8cf42 74 0e                jz     $0x00007f5feed8cf52
      343: T2539054 ifetch 8 byte(s) @ 0x00007f5feed8cf52 48 83 3d 16 fc 02 00 cmp    <rel> 0x00007f5feedbcb70, $0x00
      343: T2539054  00
      344: T2539054 read   8 byte(s) @ 0x00007f5feedbcb70 by PC 0x00007f5feed8cf52
------------------------------------------------------------------------------------------------------------------------

After:
------------------------------------------------------------------------------------------------------------------------
      342: T2538939 ifetch 2 byte(s) @ 0x00007fa9eaed7f42 74 0e                jz     $0x00007fa9eaed7f52
      343: T2538939 ifetch 8 byte(s) @ 0x00007fa9eaed7f52 48 83 3d 16 fc 02 00 cmp    <rel> 0x00007fa9eaf07b70, $0x00
      343: T2538939                                       00
      344: T2538939 read   8 byte(s) @ 0x00007fa9eaf07b70 by PC 0x00007fa9eaed7f52
------------------------------------------------------------------------------------------------------------------------

Issue: #5486