### PR TITLE
Fix maybe-uninitialized compiler warnings

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -7748,7 +7748,8 @@ pre_system_call(dcontext_t *dcontext)
             DODEBUG({ dcontext->expect_last_syscall_to_fail = true; });
             break;
         }
-        uint cur_range_first_fd, cur_range_last_fd;
+        uint cur_range_first_fd = 0;
+        uint cur_range_last_fd = 0;
         bool cur_range_valid = false;
         int ret = 0;
         for (int i = first_fd; i <= last_fd; i++) {


### PR DESCRIPTION
This minimal fix ensures that the cur_range_*_fd variables
are always initialized to make it compatible with the gcc compiler
flag -Wmaybe-uninitialized.

Technically, this does not fix any bug but supresses the warning
as the compiler cannot see through the for loop that changes the
variables value.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>