### PR TITLE
i#4014 dr$sim phys: Handle page-spanning accesses

### DIFF
--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -11,11 +11,11 @@ Adios world!
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-          95 total \(fetched\) instructions
-          23 total unique \(fetched\) instructions
+          98 total \(fetched\) instructions
+          26 total unique \(fetched\) instructions
            4 total non-fetched instructions
            0 total prefetches
-           5 total data loads
+           7 total data loads
            5 total data stores
            0 total icache flushes
            0 total dcache flushes
@@ -28,11 +28,11 @@ Total counts:
            0 total function return value markers
            4 total other markers
 Thread [0-9]* counts:
-          95 \(fetched\) instructions
-          23 unique \(fetched\) instructions
+          98 \(fetched\) instructions
+          26 unique \(fetched\) instructions
            4 non-fetched instructions
            0 prefetches
-           5 data loads
+           7 data loads
            5 data stores
            0 icache flushes
            0 dcache flushes

--- a/clients/drcachesim/tests/allasm_repstr.asm
+++ b/clients/drcachesim/tests/allasm_repstr.asm
@@ -55,8 +55,8 @@ _start:
 
         // Test page-spanning accesses.
         lea      rcx, page_str
-        // Somehow the assembler is adding 4 to the displacements here
-        // (!!!), so these end up as -3 and -1 and both cross the page:
+        // Somehow the GNU assembler 2.38 is adding the load size (4 here) to
+        // whatever displacement is listed (!!!), so these end up as -3 and -1.
         mov      eax, DWORD [-7+rcx]
         mov      eax, DWORD [-5+rcx]
 
@@ -83,6 +83,8 @@ hello_str:
         .string  "Hello world!\n"
 bye_str:
         .string  "Adios\n"
+        // Push .data onto a 2nd page to test page-spanning accesses.
+        // We assume 4K pages here.
         .align   4096
 page_str:
         .word    0

--- a/clients/drcachesim/tests/allasm_repstr.asm
+++ b/clients/drcachesim/tests/allasm_repstr.asm
@@ -53,6 +53,13 @@ _start:
         cld
         rep      movsb
 
+        // Test page-spanning accesses.
+        lea      rcx, page_str
+        // Somehow the assembler is adding 4 to the displacements here
+        // (!!!), so these end up as -3 and -1 and both cross the page:
+        mov      eax, DWORD [-7+rcx]
+        mov      eax, DWORD [-5+rcx]
+
         // Print a message in a loop for testing tracing windows.
         mov      ebx, 10          // Loop count.
 repeat:
@@ -76,3 +83,6 @@ hello_str:
         .string  "Hello world!\n"
 bye_str:
         .string  "Adios\n"
+        .align   4096
+page_str:
+        .word    0

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -10,11 +10,11 @@ Adios world!
 Adios world!
 Basic counts tool results:
 Total counts:
-          95 total \(fetched\) instructions
-          23 total unique \(fetched\) instructions
+          98 total \(fetched\) instructions
+          26 total unique \(fetched\) instructions
            4 total non-fetched instructions
            0 total prefetches
-           5 total data loads
+           7 total data loads
            5 total data stores
            0 total icache flushes
            0 total dcache flushes
@@ -27,11 +27,11 @@ Total counts:
            0 total function return value markers
            4 total other markers
 Thread [0-9]* counts:
-          95 \(fetched\) instructions
-          23 unique \(fetched\) instructions
+          98 \(fetched\) instructions
+          26 unique \(fetched\) instructions
            4 non-fetched instructions
            0 prefetches
-           5 data loads
+           7 data loads
            5 data stores
            0 icache flushes
            0 dcache flushes

--- a/clients/drcachesim/tests/offline-phys.templatex
+++ b/clients/drcachesim/tests/offline-phys.templatex
@@ -1,19 +1,13 @@
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
-Hello world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
 Output format:
 <record#>: T<tid> <record details>
 ------------------------------------------------------------
@@ -25,6 +19,10 @@ Output format:
         6: T[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
         7: T[0-9]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
         8: T[0-9]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
-        9: T[0-9]+ <marker: timestamp [0-9]+>
-       10: T[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
-       11: T[0-9]+ ifetch .*
+        9: T[0-9]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+       10: T[0-9]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+       11: T[0-9]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+       12: T[0-9]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+       13: T[0-9]+ <marker: timestamp [0-9]+>
+       14: T[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
+       15: T[0-9]+ ifetch .*

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -22,11 +22,11 @@ Adios world!
 Hit tracing window #5 limit: disabling tracing.
 Basic counts tool results:
 Total counts:
-          50 total \(fetched\) instructions
-          18 total unique \(fetched\) instructions
+          53 total \(fetched\) instructions
+          21 total unique \(fetched\) instructions
            4 total non-fetched instructions
            0 total prefetches
-           5 total data loads
+           7 total data loads
            5 total data stores
            0 total icache flushes
            0 total dcache flushes
@@ -40,11 +40,11 @@ Total counts:
           11 total other markers
 Total windows: 7
 Window #0:
-          12 window \(fetched\) instructions
-          12 window unique \(fetched\) instructions
+          15 window \(fetched\) instructions
+          15 window unique \(fetched\) instructions
            4 window non-fetched instructions
            0 window prefetches
-           5 window data loads
+           7 window data loads
            5 window data stores
            0 window icache flushes
            0 window dcache flushes
@@ -152,11 +152,11 @@ Window #6:
            0 window function return value markers
            1 window other markers
 Thread [0-9]* counts:
-          12 \(fetched\) instructions
-          12 unique \(fetched\) instructions
+          15 \(fetched\) instructions
+          15 unique \(fetched\) instructions
            4 non-fetched instructions
            0 prefetches
-           5 data loads
+           7 data loads
            5 data stores
            0 icache flushes
            0 dcache flushes

--- a/clients/drcachesim/tracer/physaddr.cpp
+++ b/clients/drcachesim/tracer/physaddr.cpp
@@ -66,6 +66,9 @@ physaddr_t::physaddr_t()
     , fd_(-1)
     , v2p_(nullptr)
     , count_(0)
+    , num_hit_cache_(0)
+    , num_hit_table_(0)
+    , num_miss_(0)
 #endif
 {
 #ifdef LINUX
@@ -246,7 +249,7 @@ physaddr_t::virtual2physical(void *drcontext, addr_t virt, OUT addr_t *phys,
     NOTIFY(3, "v2p: %p => entry " HEX64_FORMAT_STRING " @ offs " INT64_FORMAT_STRING "\n",
            vpage, entry, offs);
     if (!TESTALL(PAGEMAP_VALID, entry) || TESTANY(PAGEMAP_SWAP, entry)) {
-        NOTIFY(1, "v2p failure: entry is invalid for %p\n", vpage);
+        NOTIFY(1, "v2p failure: entry %p is invalid for %p\n", vpage);
         return false;
     }
     addr_t ppage = (addr_t)((entry & PAGEMAP_PFN) << page_bits_);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1110,7 +1110,7 @@ process_buffer_for_physaddr(void *drcontext, per_thread_t *data, size_t header_s
                 static constexpr size_t PREDICT_INSTR_SIZE_BOUND = IF_X86_ELSE(8, 4);
                 mem_ref_size = instr_count * PREDICT_INSTR_SIZE_BOUND;
             } else
-                ASSERT(instr_count == 1, "bundles are disabled");
+                ASSERT(instr_count <= 1, "bundles are disabled");
         } else if (op_offline.get_value()) {
             // For data, we again do not have the size.
             static constexpr size_t PREDICT_DATA_SIZE_BOUND = sizeof(void *);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -995,6 +995,7 @@ process_entry_for_physaddr(void *drcontext, per_thread_t *data, size_t header_si
     bool from_cache = false;
     addr_t phys = 0;
     bool success = data->physaddr.virtual2physical(drcontext, virt, &phys, &from_cache);
+    ASSERT(emitted != NULL && skip != NULL, "invalid input parameters");
     NOTIFY(4, "%s: type=%2d virt=%p phys=%p\n", __FUNCTION__, type, virt, phys);
     if (!success) {
         // XXX i#1735: Unfortunately this happens; currently we use the virtual

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -987,6 +987,91 @@ output_buffer(void *drcontext, per_thread_t *data, byte *buf_base, byte *buf_ptr
     return current_num_refs;
 }
 
+static byte *
+process_entry_for_physaddr(void *drcontext, per_thread_t *data, size_t header_size,
+                           byte *v2p_ptr, byte *mem_ref, addr_t virt, trace_type_t type,
+                           bool *emitted, size_t *skip)
+{
+    bool from_cache = false;
+    addr_t phys = 0;
+    bool success = data->physaddr.virtual2physical(drcontext, virt, &phys, &from_cache);
+    NOTIFY(4, "%s: type=%2d virt=%p phys=%p\n", __FUNCTION__, type, virt, phys);
+    if (!success) {
+        // XXX i#1735: Unfortunately this happens; currently we use the virtual
+        // address and continue.
+        // Cases where xl8 fails include:
+        // - vsyscall/kernel page,
+        // - wild access (NULL or very large bogus address) by app
+        // - page is swapped out (unlikely since we're querying *after* the
+        //   the app just accessed, but could happen)
+        NOTIFY(1, "virtual2physical translation failure for type=%2d addr=%p\n", type,
+               virt);
+        phys = virt;
+    }
+    if (op_offline.get_value()) {
+        // For offline we keep the main entries as virtual but add markers showing
+        // the corresponding physical.  We assume the mappings are static, allowing
+        // us to only emit one marker pair per new page seen (per thread to avoid
+        // locks).
+        // XXX: Add spot-checks of mapping changes via a separate option from
+        // -virt2phys_freq?
+        if (from_cache)
+            return v2p_ptr;
+        // We have something to emit.  Rather than a memmove to insert inside the
+        // main buffer, we have a separate buffer, as our pair of markers means we
+        // do not need precise placement next to the corresponding regular entry
+        // (which also avoids extra work in raw2trace, esp for delayed branches and
+        // other cases).
+        // The downside is that we might have many buffers with a small number
+        // of markers on which we waste buffer output overhead.
+        // XXX: We could count them up and do a memmove if the count is small
+        // and we have space in the redzone?
+        if (!*emitted) {
+            // We need to be sure to emit the initial thread header if this is before
+            // the first regular buffer and skip it in the regular buffer.
+            if (header_size > buf_hdr_slots_size) {
+                size_t size =
+                    reinterpret_cast<offline_instru_t *>(instru)->append_thread_header(
+                        data->v2p_buf, dr_get_thread_id(drcontext), get_file_type());
+                ASSERT(size == data->init_header_size, "inconsistent header");
+                *skip = data->init_header_size;
+                v2p_ptr += size;
+                header_size += size;
+            }
+            v2p_ptr += add_buffer_header(drcontext, data, v2p_ptr);
+            *emitted = true;
+        }
+        if (v2p_ptr + 2 * instru->sizeof_entry() - data->v2p_buf >=
+            static_cast<ssize_t>(get_v2p_buffer_size())) {
+            NOTIFY(1, "Reached v2p buffer limit: emitting multiple times\n");
+            data->num_phys_markers +=
+                output_buffer(drcontext, data, data->v2p_buf, v2p_ptr, header_size);
+            v2p_ptr = data->v2p_buf;
+            v2p_ptr += add_buffer_header(drcontext, data, v2p_ptr);
+        }
+        if (success) {
+            v2p_ptr +=
+                instru->append_marker(v2p_ptr, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS, phys);
+            v2p_ptr +=
+                instru->append_marker(v2p_ptr, TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, virt);
+        } else {
+            // For translation failure, we insert a distinct marker type, so analyzers
+            // know for sure and don't have to infer based on a missing marker.
+            v2p_ptr += instru->append_marker(
+                v2p_ptr, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE, virt);
+        }
+    } else {
+        // For online we replace the virtual with physical.
+        // XXX i#4014: For consistency we should break compatibility, *not* replace,
+        // and insert the markers instead, updating dr$sim to use the markers
+        // to compute the physical addresses.  We should then update
+        // https://dynamorio.org/sec_drcachesim_phys.html.
+        if (success)
+            instru->set_entry_addr(mem_ref, phys);
+    }
+    return v2p_ptr;
+}
+
 // Should be called only for -use_physical.
 // Returns the byte count to skip in the trace buffer (due to shifting some headers
 // to the v2p buffer).
@@ -1005,94 +1090,39 @@ process_buffer_for_physaddr(void *drcontext, per_thread_t *data, size_t header_s
         DR_ASSERT(type != TRACE_TYPE_INSTR_BUNDLE); // Bundles disabled up front.
         if (!type_has_address(type))
             continue;
-        // TODO i#4014: For -offline we have just one PC entry for the
-        // whole block: but the block could span 2 pages, and we want a physical
-        // entry to appear before any virtual entries.
-        // To solve for fixed-length instrs we could emit a 2nd PC entry
-        // at the page transition: but for x86 we don't know whether the block
-        // crosses as we have only the instruction count.
-        // Currently this is unsolved and the 2nd page is ignored.
         addr_t virt = instru->get_entry_addr(drcontext, mem_ref);
-        bool from_cache = false;
-        addr_t phys = 0;
-        bool success =
-            data->physaddr.virtual2physical(drcontext, virt, &phys, &from_cache);
-        NOTIFY(4, "%s: type=%2d virt=%p phys=%p\n", __FUNCTION__, type, virt, phys);
-        if (!success) {
-            // XXX i#1735: Unfortunately this happens; currently we use the virtual
-            // address and continue.
-            // Cases where xl8 fails include:
-            // - vsyscall/kernel page,
-            // - wild access (NULL or very large bogus address) by app
-            // - page is swapped out (unlikely since we're querying *after* the
-            //   the app just accessed, but could happen)
-            NOTIFY(1,
-                   "virtual2physical translation failure for "
-                   "<%2d, %2d, " PFX ">\n",
-                   type, instru->get_entry_size(mem_ref), virt);
-            phys = virt;
+        v2p_ptr = process_entry_for_physaddr(drcontext, data, header_size, v2p_ptr,
+                                             mem_ref, virt, type, &emitted, &skip);
+        // Handle the memory reference crossing onto a second page.
+        size_t page_size = dr_page_size();
+        addr_t virt_page = ALIGN_BACKWARD(virt, page_size);
+        size_t mem_ref_size = instru->get_entry_size(mem_ref);
+        if (type_is_instr(type) || type == TRACE_TYPE_INSTR_NO_FETCH ||
+            type == TRACE_TYPE_INSTR_MAYBE_FETCH) {
+            int instr_count = instru->get_instr_count(mem_ref);
+            if (op_offline.get_value()) {
+                // We do not have the size so we have to guess.  It is ok to emit an
+                // unused translation so we err on the side of caution.  We do not use
+                // the maximum possible instruction sizes since for x86 that's 17 * 256
+                // (max_bb_instrs) that's >4096.  The average x86 instr length is <4 but
+                // we use 8 to be conservative while not as extreme as 17 which will
+                // lead to too many unused markers.
+                static constexpr size_t PREDICT_INSTR_SIZE_BOUND = IF_X86_ELSE(8, 4);
+                mem_ref_size = instr_count * PREDICT_INSTR_SIZE_BOUND;
+            } else
+                ASSERT(instr_count == 1, "bundles are disabled");
+        } else if (op_offline.get_value()) {
+            // For data, we again do not have the size.
+            static constexpr size_t PREDICT_DATA_SIZE_BOUND = sizeof(void *);
+            mem_ref_size = PREDICT_DATA_SIZE_BOUND;
         }
-        if (op_offline.get_value()) {
-            // For offline we keep the main entries as virtual but add markers showing
-            // the corresponding physical.  We assume the mappings are static, allowing
-            // us to only emit one marker pair per new page seen (per thread to avoid
-            // locks).
-            // XXX: Add spot-checks of mapping changes via a separate option from
-            // -virt2phys_freq?
-            if (from_cache)
-                continue;
-            // We have something to emit.  Rather than a memmove to insert inside the
-            // main buffer, we have a separate buffer, as our pair of markers means we
-            // do not need precise placement next to the corresponding regular entry
-            // (which also avoids extra work in raw2trace, esp for delayed branches and
-            // other cases).
-            // The downside is that we might have many buffers with a small number
-            // of markers on which we waste buffer output overhead.
-            // XXX: We could count them up and do a memmove if the count is small
-            // and we have space in the redzone?
-            if (!emitted) {
-                // We need to be sure to emit the initial thread header if this is before
-                // the first regular buffer and skip it in the regular buffer.
-                if (header_size > buf_hdr_slots_size) {
-                    size_t size = reinterpret_cast<offline_instru_t *>(instru)
-                                      ->append_thread_header(data->v2p_buf,
-                                                             dr_get_thread_id(drcontext),
-                                                             get_file_type());
-                    ASSERT(size == data->init_header_size, "inconsistent header");
-                    skip = data->init_header_size;
-                    v2p_ptr += size;
-                    header_size += size;
-                }
-                v2p_ptr += add_buffer_header(drcontext, data, v2p_ptr);
-                emitted = true;
-            }
-            if (v2p_ptr + 2 * instru->sizeof_entry() - data->v2p_buf >=
-                static_cast<ssize_t>(get_v2p_buffer_size())) {
-                NOTIFY(1, "Reached v2p buffer limit: emitting multiple times\n");
-                data->num_phys_markers +=
-                    output_buffer(drcontext, data, data->v2p_buf, v2p_ptr, header_size);
-                v2p_ptr = data->v2p_buf;
-                v2p_ptr += add_buffer_header(drcontext, data, v2p_ptr);
-            }
-            if (success) {
-                v2p_ptr += instru->append_marker(
-                    v2p_ptr, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS, phys);
-                v2p_ptr += instru->append_marker(v2p_ptr,
-                                                 TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, virt);
-            } else {
-                // For translation failure, we insert a distinct marker type, so analyzers
-                // know for sure and don't have to infer based on a missing marker.
-                v2p_ptr += instru->append_marker(
-                    v2p_ptr, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE, virt);
-            }
-        } else {
-            // For online we replace the virtual with physical.
-            // XXX i#4014: For consistency we should break compatibility, *not* replace,
-            // and insert the markers instead, updating dr$sim to use the markers
-            // to compute the physical addresses.  We should then update
-            // https://dynamorio.org/sec_drcachesim_phys.html.
-            if (success)
-                instru->set_entry_addr(mem_ref, phys);
+        if (ALIGN_BACKWARD(virt + mem_ref_size - 1 /*open-ended*/, page_size) !=
+            virt_page) {
+            NOTIFY(2, "Emitting physaddr for next page %p for type=%2d, addr=%p\n",
+                   virt_page + page_size, type, virt);
+            v2p_ptr =
+                process_entry_for_physaddr(drcontext, data, header_size, v2p_ptr, mem_ref,
+                                           virt_page + page_size, type, &emitted, &skip);
         }
     }
     if (emitted) {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3759,7 +3759,7 @@ if (BUILD_CLIENTS)
       # for local interactive test running.
       set(tool.drcacheoff.phys_SUDO_sudo ON)
       set(tool.drcacheoff.phys_SUDO_expectbase "offline-phys")
-      torunonly_drcacheoff(phys_SUDO allasm_x86_64
+      torunonly_drcacheoff(phys_SUDO allasm_repstr
         "-use_physical" "@${test_mode_flag}@-simulator_type@view" "")
       set(tool.drcacheoff.phys_nopriv_failok ON)
       set(tool.drcacheoff.phys_nopriv_nopost ON)

--- a/suite/tests/samples/memtrace_simple_repstr.templatex
+++ b/suite/tests/samples/memtrace_simple_repstr.templatex
@@ -16,6 +16,10 @@ Format: <data address>: <data size>, <\(r\)ead/\(w\)rite/opcode>
 0x[0-9a-f]*:  2, rep movs
 0x[0-9a-f]*:  1, r
 0x[0-9a-f]*:  1, w
+0x[0-9a-f]*:  3, mov
+0x[0-9a-f]*:  4, r
+0x[0-9a-f]*:  3, mov
+0x[0-9a-f]*:  4, r
 Adios world!
 Adios world!
 Adios world!


### PR DESCRIPTION
Adds handling of page-spanning instruction fetch and data accesses.
For offline traces these are heuristics as we do not know the precise
sizes at tracing time.  Since an extra physical page value is not
harmful, the heuristics emit a second page if there is any decent
change that it is reached.

Adds a data page span test by switching the drcacheoff.phys test to
use allasm_repstr and adding such an access there.  An instruction
cross is more difficult to synthesize.

Issue: #4014