### PR TITLE
i#4014 dr$sim phys: Fix 2 crashes

### DIFF
--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -252,7 +252,7 @@ offline_instru_t::get_entry_addr(void *drcontext, byte *buf_ptr) const
 {
     offline_entry_t *entry = (offline_entry_t *)buf_ptr;
     if (entry->addr.type == OFFLINE_TYPE_PC) {
-        // XXX i#4014: Use caching to avoid looup for last queried modbase.
+        // XXX i#4014: Use caching to avoid lookup for last queried modbase.
         app_pc modbase;
         if (drmodtrack_lookup_pc_from_index(drcontext, entry->pc.modidx, &modbase) !=
             DRCOVLIB_SUCCESS)

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -98,6 +98,8 @@ private:
     // The drcontainers hashtable is too slow due to the extra dereferences:
     // we need an open-addressed table.
     void *v2p_;
+    // We must pass the same context to free as we used to allocate.
+    void *drcontext_;
     static constexpr addr_t PAGE_INVALID = (addr_t)-1;
     // With hashtable_t nullptr is how non-existence is shown, so we store
     // an actual 0 address (can happen for physical) as this sentinel.

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -3280,8 +3280,13 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
 #ifdef UNIX
     dr_register_fork_init_event(fork_init);
 #endif
+    /* We need our thread exit event to run *before* drmodtrack's as we may
+     * need to translate physical addresses for the thread's final buffer.
+     */
+    drmgr_priority_t pri_thread_exit = { sizeof(drmgr_priority_t), "", nullptr, nullptr,
+                                         -100 };
     if (!drmgr_register_thread_init_event(event_thread_init) ||
-        !drmgr_register_thread_exit_event(event_thread_exit))
+        !drmgr_register_thread_exit_event_ex(event_thread_exit, &pri_thread_exit))
         DR_ASSERT(false);
 
     instrumentation_init();


### PR DESCRIPTION
Fixes two bugs causing crashes with -use_physical:

+ Records the drcontext used for hashtable creation to ensure the same
  one is used at destruction as a different thread can call the exit
  event.

+ Orders the drmemtrace thread exit event before the drmodtrack one to
  ensure drmodtrack access during the final thread buffer output is safe.

These fixes were manually tested on large multi-threaded applications
where these two crashes showed up before and disappear with the fixes.

Issue: #4014