### PR TITLE
Fix return of local addr in fragment_add_ibl_target

### DIFF
--- a/core/fragment.c
+++ b/core/fragment.c
@@ -4098,7 +4098,7 @@ fragment_add_ibl_target_helper(dcontext_t *dcontext, fragment_t *f,
 }
 
 /* IBL targeted fragments per branch type */
-fragment_t *
+void
 fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t branch_type)
 {
     per_thread_t *pt = (per_thread_t *)dcontext->fragment_field;
@@ -4136,7 +4136,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
                             TABLE_RWLOCK(ibl_table, read, unlock);
                             if (in_persisted_ibl) {
                                 d_r_mutex_unlock(&coarse->lock);
-                                return f;
+                                return;
                             }
                         }
                         d_r_mutex_unlock(&coarse->lock);
@@ -4203,7 +4203,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
         if (TEST(FRAG_TABLE_SHARED, ibl_table->table_flags) &&
             !TEST(FRAG_SHARED, f->flags)) {
             STATS_INC(num_ibt_shared_private_conflict);
-            return f;
+            return;
         }
 
         ASSERT(TEST(FRAG_IS_TRACE, f->flags) ==
@@ -4321,7 +4321,7 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
     }
 #endif /* HASHTABLE_STATISTICS */
     DOLOG(4, LOG_FRAGMENT, { dump_lookuptable_tls(dcontext); });
-    return f;
+    return;
 }
 
 /**********************************************************************/

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -741,7 +741,7 @@ fragment_shift_fcache_pointers(dcontext_t *dcontext, fragment_t *f, ssize_t shif
 void
 fragment_update_ibl_tables(dcontext_t *dcontext);
 
-fragment_t *
+void
 fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t branch_type);
 
 /* future fragments */


### PR DESCRIPTION
This fixes the return of a local stack addr by making the
function void. This is an internal API and the return value
is nowhere used across DynamoRIO.

closes: #5534

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>