### PR TITLE
Only enable alt-arch tools/clients when available

### DIFF
--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -976,7 +976,6 @@ read_tool_file(const char *toolname, const char *dr_root, const char *dr_toolcon
             alt_client[alt_size - 1] = '\0';
             if (!does_file_exist(alt_client)) {
                 alt_client[0] = '\0';
-                continue;
             }
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",
@@ -1003,7 +1002,6 @@ read_tool_file(const char *toolname, const char *dr_root, const char *dr_toolcon
                     alt_size);
             if (!does_file_exist(alt_client)) {
                 alt_client[0] = '\0';
-                continue;
             }
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -974,6 +974,10 @@ read_tool_file(const char *toolname, const char *dr_root, const char *dr_toolcon
             _snprintf(alt_client, alt_size, "%s/%s", dr_root,
                       line + strlen(IF_X64_ELSE("CLIENT32_REL=", "CLIENT64_REL=")));
             alt_client[alt_size - 1] = '\0';
+            if (!does_file_exist(alt_client)) {
+                alt_client[0] = '\0';
+                continue;
+            }
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",
                                  alt_client);
@@ -997,6 +1001,10 @@ read_tool_file(const char *toolname, const char *dr_root, const char *dr_toolcon
             strncpy(alt_client,
                     line + strlen(IF_X64_ELSE("CLIENT32_ABS=", "CLIENT64_ABS=")),
                     alt_size);
+            if (!does_file_exist(alt_client)) {
+                alt_client[0] = '\0';
+                continue;
+            }
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",
                                  alt_client);


### PR DESCRIPTION
This patch adds a check when parsing the tool config files:
Clients for alternative archs (e.g. for cross-exec) injection
are only appended if the path to the client lib actually
exists.

This is a preparation for system-wide deployments, where this
check has to be performed at runtime as users might only
install the dr library for a single architecture.

Previously having invalid paths in the tool config file
worked if the respective client was not requested, but led to a warning.
With this patch, the missing client is simply not registered at all.

Issue: #5153

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>