### PR TITLE
i#4014 dr$sim phys: Add counts of physaddr markers

### DIFF
--- a/clients/drcachesim/drcachesim.dox.in
+++ b/clients/drcachesim/drcachesim.dox.in
@@ -515,6 +515,12 @@ Total counts:
            3 total threads
          280 total scheduling markers
            0 total transfer markers
+           0 total function id markers
+           0 total function return address markers
+           0 total function argument markers
+           0 total function return value markers
+           0 total physical address + virtual address marker pairs
+           0 total physical address unavailable markers
            3 total other markers
 Thread 247451 counts:
       255009 (fetched) instructions
@@ -524,6 +530,12 @@ Thread 247451 counts:
        21243 data stores
          258 scheduling markers
            0 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           0 physical address + virtual address marker pairs
+           0 physical address unavailable markers
            1 other markers
 Thread 247453 counts:
         9195 (fetched) instructions
@@ -533,6 +545,12 @@ Thread 247453 counts:
          937 data stores
           12 scheduling markers
            0 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           0 physical address + virtual address marker pairs
+           0 physical address unavailable markers
            1 other markers
 Thread 247454 counts:
         2989 (fetched) instructions
@@ -542,6 +560,12 @@ Thread 247454 counts:
          323 data stores
           10 scheduling markers
            0 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           0 physical address + virtual address marker pairs
+           0 physical address unavailable markers
            1 other markers
 \endcode
 

--- a/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
@@ -17,6 +17,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
           96 \(fetched\) instructions
@@ -33,4 +35,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -26,6 +26,8 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
+           0 total physical address \+ virtual address marker pairs
+           0 total physical address unavailable markers
            4 total other markers
 Thread [0-9]* counts:
           98 \(fetched\) instructions
@@ -42,4 +44,6 @@ Thread [0-9]* counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
            4 other markers

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -18,6 +18,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
           96 \(fetched\) instructions
@@ -34,4 +36,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/basic_counts.templatex
+++ b/clients/drcachesim/tests/basic_counts.templatex
@@ -39,6 +39,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
      .* \(fetched\) instructions
@@ -59,4 +61,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
@@ -21,6 +21,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
      .* \(fetched\) instructions
@@ -41,4 +43,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
@@ -16,6 +16,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
           96 \(fetched\) instructions
@@ -32,6 +34,8 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers
 Prefetch operation frequencies:
            2 prefetch_read_l1

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -25,6 +25,8 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
+           0 total physical address \+ virtual address marker pairs
+           0 total physical address unavailable markers
            4 total other markers
 Thread [0-9]* counts:
           98 \(fetched\) instructions
@@ -41,4 +43,6 @@ Thread [0-9]* counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
            4 other markers

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
@@ -17,6 +17,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
           96 \(fetched\) instructions
@@ -33,4 +35,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -38,6 +38,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
      .* \(fetched\) instructions
@@ -58,4 +60,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/offline-builtin-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-builtin-prefetch-basic-counts.templatex
@@ -20,6 +20,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
      .* \(fetched\) instructions
@@ -40,4 +42,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/offline-burst_aarch64_sys.templatex
+++ b/clients/drcachesim/tests/offline-burst_aarch64_sys.templatex
@@ -21,6 +21,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
      .* \(fetched\) instructions
@@ -37,4 +39,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
@@ -28,4 +28,6 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
+           0 total physical address \+ virtual address marker pairs
+           0 total physical address unavailable markers
     *[0-9]* total other markers

--- a/clients/drcachesim/tests/offline-burst_threadfilter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadfilter.templatex
@@ -28,5 +28,7 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
+           0 total physical address \+ virtual address marker pairs
+           0 total physical address unavailable markers
     *[0-9]* total other markers
 .*

--- a/clients/drcachesim/tests/offline-legacy-int-offs.templatex
+++ b/clients/drcachesim/tests/offline-legacy-int-offs.templatex
@@ -18,6 +18,8 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
+           0 total physical address \+ virtual address marker pairs
+           0 total physical address unavailable markers
            9 total other markers
 Thread 552306 counts:
       101049 \(fetched\) instructions
@@ -34,6 +36,8 @@ Thread 552306 counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
            3 other markers
 Thread 552323 counts:
         4674 \(fetched\) instructions
@@ -50,6 +54,8 @@ Thread 552323 counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
            3 other markers
 Thread 552324 counts:
         3482 \(fetched\) instructions
@@ -66,6 +72,8 @@ Thread 552324 counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
            3 other markers
 #else
 ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.legacy-int-offs/raw/drmemtrace.drmemtrace.signal_invariants..*.raw.gz: Architecture mismatch: trace recorded on x86_64 but tools built for i386

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -37,6 +37,8 @@ Total counts:
            0 total function return address markers
            0 total function argument markers
            0 total function return value markers
+           0 total physical address \+ virtual address marker pairs
+           0 total physical address unavailable markers
           11 total other markers
 Total windows: 7
 Window #0:
@@ -54,6 +56,8 @@ Window #0:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
            5 window other markers
 Window #1:
            8 window \(fetched\) instructions
@@ -70,6 +74,8 @@ Window #1:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
            1 window other markers
 Window #2:
            8 window \(fetched\) instructions
@@ -86,6 +92,8 @@ Window #2:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
            1 window other markers
 Window #3:
            8 window \(fetched\) instructions
@@ -102,6 +110,8 @@ Window #3:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
            1 window other markers
 Window #4:
            8 window \(fetched\) instructions
@@ -118,6 +128,8 @@ Window #4:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
            1 window other markers
 Window #5:
            6 window \(fetched\) instructions
@@ -134,6 +146,8 @@ Window #5:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
            1 window other markers
 Window #6:
            0 window \(fetched\) instructions
@@ -150,6 +164,8 @@ Window #6:
            0 window function return address markers
            0 window function argument markers
            0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
            1 window other markers
 Thread [0-9]* counts:
           15 \(fetched\) instructions
@@ -166,4 +182,6 @@ Thread [0-9]* counts:
            0 function return address markers
            0 function argument markers
            0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
            5 other markers

--- a/clients/drcachesim/tests/scattergather.templatex
+++ b/clients/drcachesim/tests/scattergather.templatex
@@ -162,6 +162,8 @@ Total counts:
      .* total function return address markers
      .* total function argument markers
      .* total function return value markers
+     .* total physical address \+ virtual address marker pairs
+     .* total physical address unavailable markers
      .* total other markers
 Thread .* counts:
      .* \(fetched\) instructions
@@ -178,4 +180,6 @@ Thread .* counts:
      .* function return address markers
      .* function argument markers
      .* function return value markers
+     .* physical address \+ virtual address marker pairs
+     .* physical address unavailable markers
      .* other markers

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -136,6 +136,13 @@ basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             case TRACE_MARKER_TYPE_FUNC_RETADDR: ++counters->func_retaddr_markers; break;
             case TRACE_MARKER_TYPE_FUNC_ARG: ++counters->func_arg_markers; break;
             case TRACE_MARKER_TYPE_FUNC_RETVAL: ++counters->func_retval_markers; break;
+            case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS: ++counters->phys_addr_markers; break;
+            case TRACE_MARKER_TYPE_VIRTUAL_ADDRESS:
+                // Counted implicitly as part of phys_addr_markers.
+                break;
+            case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE:
+                ++counters->phys_unavail_markers;
+                break;
             default: ++counters->other_markers; break;
             }
         }
@@ -205,6 +212,10 @@ basic_counts_t::print_counters(const counters_t &counters, int_least64_t num_thr
               << " function argument markers\n";
     std::cerr << std::setw(12) << counters.func_retval_markers << prefix
               << " function return value markers\n";
+    std::cerr << std::setw(12) << counters.phys_addr_markers << prefix
+              << " physical address + virtual address marker pairs\n";
+    std::cerr << std::setw(12) << counters.phys_unavail_markers << prefix
+              << " physical address unavailable markers\n";
     std::cerr << std::setw(12) << counters.other_markers << prefix << " other markers\n";
 }
 

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -78,6 +78,8 @@ protected:
             func_retaddr_markers += rhs.func_retaddr_markers;
             func_arg_markers += rhs.func_arg_markers;
             func_retval_markers += rhs.func_retval_markers;
+            phys_addr_markers += rhs.phys_addr_markers;
+            phys_unavail_markers += rhs.phys_unavail_markers;
             other_markers += rhs.other_markers;
             icache_flushes += rhs.icache_flushes;
             dcache_flushes += rhs.dcache_flushes;
@@ -97,6 +99,8 @@ protected:
         int_least64_t func_retaddr_markers = 0;
         int_least64_t func_arg_markers = 0;
         int_least64_t func_retval_markers = 0;
+        int_least64_t phys_addr_markers = 0;
+        int_least64_t phys_unavail_markers = 0;
         int_least64_t other_markers = 0;
         int_least64_t icache_flushes = 0;
         int_least64_t dcache_flushes = 0;


### PR DESCRIPTION
Adds counts of physical,virtual marker pairs and of unavailable
physical address markers to the basic_counts tool.  Updates various
test outputs.

Issue: #4014