### PR TITLE
Remove redundant return statement at routine end

### DIFF
--- a/core/fragment.c
+++ b/core/fragment.c
@@ -4321,7 +4321,6 @@ fragment_add_ibl_target(dcontext_t *dcontext, app_pc tag, ibl_branch_type_t bran
     }
 #endif /* HASHTABLE_STATISTICS */
     DOLOG(4, LOG_FRAGMENT, { dump_lookuptable_tls(dcontext); });
-    return;
 }
 
 /**********************************************************************/


### PR DESCRIPTION
Removes a redundant return statement at the end of
fragment_add_ibl_target that's triggering a formatting
check.