### PR TITLE
Rename nudgeunix to drnudgeunix

### DIFF
--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -376,9 +376,9 @@ than invoking the script directly:
 
 To \ref sec_comm "nudge" a process with pid \c targetpid running under
 DynamoRIO and pass argument "5" to the nudge callback, use the \c
-nudgeunix tool:
+drnudgeunix tool:
 \code
-bin32/nudgeunix -pid targetpid -client 0 5
+bin32/drnudgeunix -pid targetpid -client 0 5
 \endcode
 This will result in a nudge event with argument=5 delivered to the
 client callback registered with dr_register_nudge_event() in the

--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -1546,7 +1546,7 @@ DR_API
  * Registers a callback function for nudge events.  External entities
  * can nudge a process through the dr_nudge_process() or
  * dr_nudge_pid() drconfig API routines on Windows or using the \p
- * nudgeunix tool on Linux.  A client in this process can use
+ * drnudgeunix tool on Linux.  A client in this process can use
  * dr_nudge_client() to raise a nudge, while a client in another
  * process can use dr_nudge_client_ex().
  *

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1397,7 +1397,7 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out pas
     string(REGEX REPLACE ";" "@" cmd_with_at "${cmd_with_at}")
     if (NOT APPLE) # XXX i#1286: implement nudge for MacOS
       if (UNIX)
-        get_target_path_for_execution(toolbindir nudgeunix "${location_suffix}")
+        get_target_path_for_execution(toolbindir drnudgeunix "${location_suffix}")
       else ()
         get_target_path_for_execution(toolbindir drconfig "${location_suffix}")
       endif ()

--- a/suite/tests/runall.cmake
+++ b/suite/tests/runall.cmake
@@ -213,7 +213,7 @@ elseif ("${nudge}" MATCHES "<attach>")
     message(FATAL_ERROR "*** ${nudge_cmd} failed (${nudge_result}): ${nudge_err}***\n")
   endif (nudge_result)
 else ()
-  # nudgeunix and drconfig have different syntax:
+  # drnudgeunix and drconfig have different syntax:
   if (WIN32)
     # XXX i#120: expand beyond -client.
     string(REGEX REPLACE "-client" "-nudge_timeout;30000;-nudge_pid;${pid}"

--- a/suite/tests/runall.cmake
+++ b/suite/tests/runall.cmake
@@ -40,7 +40,7 @@
 # * toolbindir
 # * out = file where output of background process will be sent
 # * pidfile = file where the pid of the background process will be written
-# * nudge = arguments to nudgeunix or drconfig
+# * nudge = arguments to drnudgeunix or drconfig
 # * clear = dir to clear ahead of time
 
 # intra-arg space=@@ and inter-arg space=@
@@ -80,7 +80,7 @@ if (UNIX)
   if (NOT SLEEP)
     message(FATAL_ERROR "cannot find 'sleep'")
   endif ()
-  set(nudge_cmd nudgeunix)
+  set(nudge_cmd drnudgeunix)
 else (UNIX)
   # We use "ping" on Windows to "sleep" :)
   find_program(PING "ping")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -39,7 +39,7 @@ if (UNIX)
   if (APPLE)
     # XXX i#1286: implement nudge for MacOS
   else (APPLE)
-    add_executable(nudgeunix nudgeunix.c ${PROJECT_SOURCE_DIR}/core/unix/nudgesig.c)
+    add_executable(drnudgeunix nudgeunix.c ${PROJECT_SOURCE_DIR}/core/unix/nudgesig.c)
   endif ()
   add_executable(drloader drloader.c)
 
@@ -88,7 +88,11 @@ if (UNIX)
   set(RESOURCES "")
 
   if (NOT APPLE) # FIXME i#1286: add MacOS nudge support
-    DR_install(TARGETS nudgeunix DESTINATION ${INSTALL_BIN})
+    DR_install(TARGETS drnudgeunix DESTINATION ${INSTALL_BIN})
+    # for backward compatibility we add a symlink to the old name
+    add_custom_command(TARGET drnudgeunix POST_BUILD
+      WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+      COMMAND ${CMAKE_COMMAND} -E create_symlink drnudgeunix nudgeunix)
   endif ()
 else (UNIX)
   # FIXME i#98: eventually upgrade to W4 with pragma exceptions.

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -265,8 +265,8 @@ const char *options_list_str =
     "                          wait.  A value of 0 means don't wait for nudges to\n"
     "                          complete."
 #    else  /* WINDOWS */
-    /* FIXME i#840: integrate nudgeunix into drconfig on Unix */
-    "Note: please use the nudgeunix tool to nudge processes on Unix.\n";
+    /* FIXME i#840: integrate drnudgeunix into drconfig on Unix */
+    "Note: please use the drnudgeunix tool to nudge processes on Unix.\n";
 #    endif /* !WINDOWS */
 #else      /* DRCONFIG */
     "       -no_wait           Return immediately: do not wait for application exit.\n"

--- a/tools/nudgeunix.c
+++ b/tools/nudgeunix.c
@@ -53,7 +53,7 @@ create_nudge_signal_payload(siginfo_t *info OUT, uint action_mask, client_id_t c
                             uint64 client_arg);
 
 static const char *usage_str =
-    "usage: nudgeunix [-help] [-v] [-pid <pid>] [-type <type>] [-client <ID> <arg>]\n"
+    "usage: drnudgeunix [-help] [-v] [-pid <pid>] [-type <type>] [-client <ID> <arg>]\n"
     "       -help              Display this usage information\n"
     "       -v                 Display version information\n"
     "       -pid <pid>         Nudge the process with id <pid>\n"
@@ -94,7 +94,7 @@ main(int argc, const char *argv[])
         if (strcmp(argv[arg_offs], "-help") == 0) {
             return usage();
         } else if (strcmp(argv[arg_offs], "-v") == 0) {
-            printf("nudgeunix version %s -- build %d\n", STRINGIFY(VERSION_NUMBER),
+            printf("drnudgeunix version %s -- build %d\n", STRINGIFY(VERSION_NUMBER),
                    BUILD_NUMBER);
             exit(0);
         } else if (strcmp(argv[arg_offs], "-pid") == 0) {


### PR DESCRIPTION
This patch renames the nudgeunix tool to drnudgeunix to be
named more consistently with the rest of DynamoRIOs frontend tooling.
This helps for packaging as nudgeunix is somehow non-specific.

For backward compatibility, a symlink with the old name is added.

Related to issue #5153

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>