### PR TITLE
Build libutil when clients are built to fix drcachesim dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1580,9 +1580,9 @@ if (BUILD_CORE)
   add_subdirectory(core)
 endif (BUILD_CORE)
 
-if (BUILD_TOOLS OR BUILD_DRSTATS)
+if (BUILD_TOOLS OR BUILD_DRSTATS OR BUILD_CLIENTS)
   add_subdirectory(libutil)
-endif (BUILD_TOOLS OR BUILD_DRSTATS)
+endif (BUILD_TOOLS OR BUILD_DRSTATS OR BUILD_CLIENTS)
 
 if (BUILD_TOOLS)
   add_subdirectory(tools)


### PR DESCRIPTION
Before this patch, libutil was not built in case building of
BUILD_TOOLS and BUILD_DRSTATS was disabled. This lead to a
link-time error as drcachesim (a client) depends on drfrontendlib.

This is now fixed by also building libutil when enabling BUILD_CLIENTS.

Signed-off-by: Felix Moessbauer <felix.moessbauer@siemens.com>