### PR TITLE
i#5505 kernel trace: Support octal and hex values in droption

### DIFF
--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -715,7 +715,7 @@ inline bool
 droption_t<unsigned long>::convert_from_string(const std::string s)
 {
     // Checks if the first non-space character of a string is a negative sign. If it is,
-    // it is invalid.
+    // the input string is invalid.
     for (size_t i = 0; i < s.size(); i++) {
         // XXX: The function isspace() only identify ASCII whitespace characters. We
         // should implement one function that can support non-ASCII whitespace characters.
@@ -735,7 +735,7 @@ inline bool
 droption_t<unsigned long long>::convert_from_string(const std::string s)
 {
     // Checks if the first non-space character of a string is a negative sign. If it is,
-    // it is invalid.
+    // the input string is invalid.
     for (size_t i = 0; i < s.size(); i++) {
         // XXX: The function isspace() only identify ASCII whitespace characters. We
         // should implement one function that can support non-ASCII whitespace characters.

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -371,6 +371,8 @@ protected:
     convert_from_string(const std::string s1, const std::string s2) = 0;
     virtual bool
     clamp_value() = 0;
+    virtual bool
+    is_negative_input(const std::string &s) = 0;
     virtual std::string
     default_as_string() const = 0;
     virtual void
@@ -571,6 +573,23 @@ protected:
     }
 
     bool
+    is_negative_input(const std::string &s) override
+    {
+        // Checks if the first non-space character of a string is a negative sign.
+        for (size_t i = 0; i < s.size(); i++) {
+            // XXX: The function isspace() only identify ASCII whitespace characters. We
+            // should implement one function that can support non-ASCII whitespace
+            // characters.
+            if (isspace(s[i]))
+                continue;
+            if (s[i] == '-')
+                return true;
+            break;
+        }
+        return false;
+    }
+
+    bool
     option_takes_arg() const override;
     bool
     option_takes_2args() const override;
@@ -691,8 +710,7 @@ inline bool
 droption_t<long long>::convert_from_string(const std::string s)
 {
     errno = 0;
-    // If we set 0 as the base, strtoll() will automatically identify the base like
-    // strtol().
+    // If we set 0 as the base, strtoll() will automatically identify the base.
     value_ = strtoll(s.c_str(), NULL, 0);
     return errno == 0;
 }
@@ -714,17 +732,8 @@ template <>
 inline bool
 droption_t<unsigned long>::convert_from_string(const std::string s)
 {
-    // Checks if the first non-space character of a string is a negative sign. If it is,
-    // the input string is invalid.
-    for (size_t i = 0; i < s.size(); i++) {
-        // XXX: The function isspace() only identify ASCII whitespace characters. We
-        // should implement one function that can support non-ASCII whitespace characters.
-        if (isspace(s[i]))
-            continue;
-        if (s[i] == '-')
-            return false;
-        break;
-    }
+    if (is_negative_input(s))
+        return false;
 
     errno = 0;
     value_ = strtoul(s.c_str(), NULL, 0);
@@ -734,17 +743,8 @@ template <>
 inline bool
 droption_t<unsigned long long>::convert_from_string(const std::string s)
 {
-    // Checks if the first non-space character of a string is a negative sign. If it is,
-    // the input string is invalid.
-    for (size_t i = 0; i < s.size(); i++) {
-        // XXX: The function isspace() only identify ASCII whitespace characters. We
-        // should implement one function that can support non-ASCII whitespace characters.
-        if (isspace(s[i]))
-            continue;
-        if (s[i] == '-')
-            return false;
-        break;
-    }
+    if (is_negative_input(s))
+        return false;
 
     errno = 0;
     value_ = strtoull(s.c_str(), NULL, 0);

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -47,6 +47,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <errno.h>
+#include <ctype.h>
 
 #define TESTALL(mask, var) (((mask) & (var)) == (mask))
 #define TESTANY(mask, var) (((mask) & (var)) != 0)
@@ -575,9 +576,8 @@ protected:
     {
         // Checks if the first non-space character of a string is a negative sign.
         for (size_t i = 0; i < s.size(); i++) {
-            // XXX: The function isspace() only identifies ASCII whitespace characters. We
-            // should implement one function that can support non-ASCII whitespace
-            // characters too.
+            // XXX: isspace() identifies whitespace in the current locale. We ignore
+            // locale effects here.
             if (isspace(s[i]))
                 continue;
             if (s[i] == '-')
@@ -684,7 +684,8 @@ droption_t<int>::convert_from_string(const std::string s)
     errno = 0;
     // If we set 0 as the base, strtol() will automatically identify the base of the
     // number to convert. By default, it will assume the number to be converted is
-    // decimal, and number starting with 0 or 0x is assumed to be octal or hexadecimal.
+    // decimal, and a number starting with 0 or 0x is assumed to be octal or hexadecimal,
+    // respectively.
     long input = strtol(s.c_str(), NULL, 0);
 
     // strtol returns a long, but this may not always fit into an integer.

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -665,7 +665,10 @@ inline bool
 droption_t<int>::convert_from_string(const std::string s)
 {
     errno = 0;
-    long input = strtol(s.c_str(), NULL, 10);
+    // If we set 0 as the base, strtol() will automatically identify the base of the
+    // number to convert. By default, it will assume the number to be converted is
+    // decimal, and number starting with 0 or 0x is assumed to be octal or hexadecimal.
+    long input = strtol(s.c_str(), NULL, 0);
 
     // strtol returns a long, but this may not always fit into an integer.
     if (input >= (long)INT_MIN && input <= (long)INT_MAX)
@@ -680,7 +683,7 @@ inline bool
 droption_t<long>::convert_from_string(const std::string s)
 {
     errno = 0;
-    value_ = strtol(s.c_str(), NULL, 10);
+    value_ = strtol(s.c_str(), NULL, 0);
     return errno == 0;
 }
 template <>
@@ -688,7 +691,9 @@ inline bool
 droption_t<long long>::convert_from_string(const std::string s)
 {
     errno = 0;
-    value_ = strtoll(s.c_str(), NULL, 10);
+    // If we set 0 as the base, strtoll() will automatically identify the base like
+    // strtol().
+    value_ = strtoll(s.c_str(), NULL, 0);
     return errno == 0;
 }
 template <>
@@ -696,8 +701,7 @@ inline bool
 droption_t<unsigned int>::convert_from_string(const std::string s)
 {
     errno = 0;
-    long input = strtol(s.c_str(), NULL, 10);
-
+    long input = strtol(s.c_str(), NULL, 0);
     // Is the value positive and fits into an unsigned integer?
     if (input >= 0 && (unsigned long)input <= (unsigned long)UINT_MAX)
         value_ = (unsigned int)input;
@@ -710,25 +714,40 @@ template <>
 inline bool
 droption_t<unsigned long>::convert_from_string(const std::string s)
 {
-    errno = 0;
-    long input = strtol(s.c_str(), NULL, 10);
-    if (input >= 0)
-        value_ = (unsigned long)input;
-    else
-        return false;
+    // Checks if the first non-space character of a string is a negative sign. If it is,
+    // it is invalid.
+    for (size_t i = 0; i < s.size(); i++) {
+        // XXX: The function isspace() only identify ASCII whitespace characters. We
+        // should implement one function that can support non-ASCII whitespace characters.
+        if (isspace(s[i]))
+            continue;
+        if (s[i] == '-')
+            return false;
+        break;
+    }
 
+    errno = 0;
+    value_ = strtoul(s.c_str(), NULL, 0);
     return errno == 0;
 }
 template <>
 inline bool
 droption_t<unsigned long long>::convert_from_string(const std::string s)
 {
-    long long input = strtoll(s.c_str(), NULL, 10);
-    if (input >= 0)
-        value_ = (unsigned long long)input;
-    else
-        return false;
+    // Checks if the first non-space character of a string is a negative sign. If it is,
+    // it is invalid.
+    for (size_t i = 0; i < s.size(); i++) {
+        // XXX: The function isspace() only identify ASCII whitespace characters. We
+        // should implement one function that can support non-ASCII whitespace characters.
+        if (isspace(s[i]))
+            continue;
+        if (s[i] == '-')
+            return false;
+        break;
+    }
 
+    errno = 0;
+    value_ = strtoull(s.c_str(), NULL, 0);
     return errno == 0;
 }
 template <>

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -571,13 +571,13 @@ protected:
         return true;
     }
 
+    /* Checks if the first non-space character of a string is a negative sign.
+     * XXX: This function does not work with UTF-16/UTF-32 formatted strings.
+     */
     static bool
     is_negative(const std::string &s)
     {
-        // Checks if the first non-space character of a string is a negative sign.
         for (size_t i = 0; i < s.size(); i++) {
-            // XXX: isspace() identifies whitespace in the current locale. We ignore
-            // locale effects here.
             if (isspace(s[i]))
                 continue;
             if (s[i] == '-')

--- a/ext/droption/droption.h
+++ b/ext/droption/droption.h
@@ -371,8 +371,6 @@ protected:
     convert_from_string(const std::string s1, const std::string s2) = 0;
     virtual bool
     clamp_value() = 0;
-    virtual bool
-    is_negative_input(const std::string &s) = 0;
     virtual std::string
     default_as_string() const = 0;
     virtual void
@@ -572,14 +570,14 @@ protected:
         return true;
     }
 
-    bool
-    is_negative_input(const std::string &s) override
+    static bool
+    is_negative(const std::string &s)
     {
         // Checks if the first non-space character of a string is a negative sign.
         for (size_t i = 0; i < s.size(); i++) {
-            // XXX: The function isspace() only identify ASCII whitespace characters. We
+            // XXX: The function isspace() only identifies ASCII whitespace characters. We
             // should implement one function that can support non-ASCII whitespace
-            // characters.
+            // characters too.
             if (isspace(s[i]))
                 continue;
             if (s[i] == '-')
@@ -732,7 +730,7 @@ template <>
 inline bool
 droption_t<unsigned long>::convert_from_string(const std::string s)
 {
-    if (is_negative_input(s))
+    if (is_negative(s))
         return false;
 
     errno = 0;
@@ -743,7 +741,7 @@ template <>
 inline bool
 droption_t<unsigned long long>::convert_from_string(const std::string s)
 {
-    if (is_negative_input(s))
+    if (is_negative(s))
         return false;
 
     errno = 0;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2564,7 +2564,7 @@ torunonly_ci(client.blackbox ${ci_shared_app} client.blackbox.dll.A
   "" "" "")
 
 tobuild_ci(client.option_parse client-interface/option_parse.cpp
-  "-l;-4;-ll;-3220721071790640321;-ul;4;-ull;1384772493926445887;-x;3;-x_alias;4;-y;quoted string;-z;first;-z_alias;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-flag;-flag_alias1;-no_flag_alias2;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999"
+  "-l;-4;-ll;-3220721071790640321;-ul;4;-ull;1384772493926445887;-x;3;-x_alias;4;-y;quoted string;-z;first;-z_alias;single quotes -dash --dashes;-front;value;-y;accum;-front2;value2;-flag;-flag_alias1;-no_flag_alias2;-takes2;1_of_4;2_of_4;-takes2;3_of_4;4_of_4;-val_sep;v1.1 v1.2;-val_sep;v2.1 v2.2;-val_sep2;v1;v2;-val_sep2;v3;v4;-large_bytesize;9999999999;-oi;-012;-ol;-012;-oll;-012;-ou;012;-oul;012;-oull;012;-xi;-0xa;-xl;-0xa;-xll;-0xa;-xu;0xa;-xul;0xa;-xull;0xa;"
   "" "")
 use_DynamoRIO_extension(client.option_parse.dll droption)
 set(client.option_parse_client_ops_islist ON)

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -91,11 +91,35 @@ static droption_t<bytesize_t>
     op_large_bytesize(DROPTION_SCOPE_CLIENT, "large_bytesize", DROPTION_FLAG_ACCUMULATE,
                       0, "Param that takes in a large bytesize value",
                       "Longer desc of param that takes in a large bytesize value");
+static droption_t<int> op_oi(DROPTION_SCOPE_CLIENT, "oi", 0, "Some param",
+                             "Longer desc of some param.");
+static droption_t<long> op_ol(DROPTION_SCOPE_CLIENT, "ol", 0L, "Some param",
+                              "Longer desc of some param.");
+static droption_t<long long> op_oll(DROPTION_SCOPE_CLIENT, "oll", 0LL, "Some param",
+                                    "Longer desc of some param.");
+static droption_t<unsigned int> op_ou(DROPTION_SCOPE_CLIENT, "ou", 0, "Some param",
+                                      "Longer desc of some param.");
+static droption_t<unsigned long> op_oul(DROPTION_SCOPE_CLIENT, "oul", 0UL, "Some param",
+                                        "Longer desc of some param.");
+static droption_t<unsigned long long> op_oull(DROPTION_SCOPE_CLIENT, "oull", 0ULL,
+                                              "Some param", "Longer desc of some param.");
+static droption_t<int> op_xi(DROPTION_SCOPE_CLIENT, "xi", 0, "Some param",
+                             "Longer desc of some param.");
+static droption_t<long> op_xl(DROPTION_SCOPE_CLIENT, "xl", 0L, "Some param",
+                              "Longer desc of some param.");
+static droption_t<long long> op_xll(DROPTION_SCOPE_CLIENT, "xll", 0LL, "Some param",
+                                    "Longer desc of some param.");
+static droption_t<unsigned int> op_xu(DROPTION_SCOPE_CLIENT, "xu", 0, "Some param",
+                                      "Longer desc of some param.");
+static droption_t<unsigned long> op_xul(DROPTION_SCOPE_CLIENT, "xul", 0UL, "Some param",
+                                        "Longer desc of some param.");
+static droption_t<unsigned long long> op_xull(DROPTION_SCOPE_CLIENT, "xull", 0ULL,
+                                              "Some param", "Longer desc of some param.");
 
 static void
 test_argv(int argc, const char *argv[])
 {
-    ASSERT(argc == 46);
+    ASSERT(argc == 70);
 
     int i = 1;
     ASSERT(strcmp(argv[i++], "-l") == 0);
@@ -143,6 +167,30 @@ test_argv(int argc, const char *argv[])
     ASSERT(strcmp(argv[i++], "v4") == 0);
     ASSERT(strcmp(argv[i++], "-large_bytesize") == 0);
     ASSERT(strcmp(argv[i++], "9999999999") == 0);
+    ASSERT(strcmp(argv[i++], "-oi") == 0);
+    ASSERT(strcmp(argv[i++], "-012") == 0);
+    ASSERT(strcmp(argv[i++], "-ol") == 0);
+    ASSERT(strcmp(argv[i++], "-012") == 0);
+    ASSERT(strcmp(argv[i++], "-oll") == 0);
+    ASSERT(strcmp(argv[i++], "-012") == 0);
+    ASSERT(strcmp(argv[i++], "-ou") == 0);
+    ASSERT(strcmp(argv[i++], "012") == 0);
+    ASSERT(strcmp(argv[i++], "-oul") == 0);
+    ASSERT(strcmp(argv[i++], "012") == 0);
+    ASSERT(strcmp(argv[i++], "-oull") == 0);
+    ASSERT(strcmp(argv[i++], "012") == 0);
+    ASSERT(strcmp(argv[i++], "-xi") == 0);
+    ASSERT(strcmp(argv[i++], "-0xa") == 0);
+    ASSERT(strcmp(argv[i++], "-xl") == 0);
+    ASSERT(strcmp(argv[i++], "-0xa") == 0);
+    ASSERT(strcmp(argv[i++], "-xll") == 0);
+    ASSERT(strcmp(argv[i++], "-0xa") == 0);
+    ASSERT(strcmp(argv[i++], "-xu") == 0);
+    ASSERT(strcmp(argv[i++], "0xa") == 0);
+    ASSERT(strcmp(argv[i++], "-xul") == 0);
+    ASSERT(strcmp(argv[i++], "0xa") == 0);
+    ASSERT(strcmp(argv[i++], "-xull") == 0);
+    ASSERT(strcmp(argv[i++], "0xa") == 0);
 }
 
 DR_EXPORT void
@@ -198,8 +246,42 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     ok = dr_parse_options(client_id, NULL, NULL);
     ASSERT(ok);
 
-    // Test get_value_separator()
+    // Test get_value_separator().
     ASSERT(op_y.get_value_separator() == std::string(" "));
     ASSERT(op_val_sep.get_value_separator() == std::string("+"));
     ASSERT(op_val_sep2.get_value_separator() == std::string("+"));
+
+    // Test parsing a string of octal digits.
+    dr_fprintf(STDERR, "param oi = %d\n", op_oi.get_value());
+    dr_fprintf(STDERR, "param ol = %ld\n", op_ol.get_value());
+    dr_fprintf(STDERR, "param oll = %lld\n", op_oll.get_value());
+    dr_fprintf(STDERR, "param ou = %u\n", op_ou.get_value());
+    dr_fprintf(STDERR, "param oul = %lu\n", op_oul.get_value());
+    dr_fprintf(STDERR, "param oull = %llu\n", op_oull.get_value());
+
+    // Test parsing a string of hexadecimal digits.
+    dr_fprintf(STDERR, "param xi = %d\n", op_xi.get_value());
+    dr_fprintf(STDERR, "param xl = %ld\n", op_xl.get_value());
+    dr_fprintf(STDERR, "param xll = %lld\n", op_xll.get_value());
+    dr_fprintf(STDERR, "param xu = %u\n", op_xu.get_value());
+    dr_fprintf(STDERR, "param xul = %lu\n", op_xul.get_value());
+    dr_fprintf(STDERR, "param xull = %llu\n", op_xull.get_value());
+
+    // Test parsing a string of negetive digits. These tests are used to check whether the
+    // unsigned option can recognize negative input and output an error.
+    std::vector<droption_parser_t *> negtive_test_options;
+    negtive_test_options.push_back(static_cast<droption_parser_t *>(&op_ou));
+    negtive_test_options.push_back(static_cast<droption_parser_t *>(&op_oul));
+    negtive_test_options.push_back(static_cast<droption_parser_t *>(&op_oull));
+    const char *negetive_test_args[3] = { "", "", "" };
+    std::string parse_err;
+    for (auto op : negtive_test_options) {
+        std::string op_name = "-" + op->get_name();
+        negetive_test_args[1] = op_name.c_str();
+        negetive_test_args[2] = "   -1";
+        ok = droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, 3, negetive_test_args,
+                                           &parse_err, NULL);
+        ASSERT(!ok);
+        dr_fprintf(STDERR, "%s\n", parse_err.c_str());
+    }
 }

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -251,7 +251,7 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     ASSERT(op_val_sep.get_value_separator() == std::string("+"));
     ASSERT(op_val_sep2.get_value_separator() == std::string("+"));
 
-    // Test parsing a string of octal digits.
+    // Test parsing octal format numeric strings.
     dr_fprintf(STDERR, "param oi = %d\n", op_oi.get_value());
     dr_fprintf(STDERR, "param ol = %ld\n", op_ol.get_value());
     dr_fprintf(STDERR, "param oll = %lld\n", op_oll.get_value());
@@ -259,7 +259,7 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     dr_fprintf(STDERR, "param oul = %lu\n", op_oul.get_value());
     dr_fprintf(STDERR, "param oull = %llu\n", op_oull.get_value());
 
-    // Test parsing a string of hexadecimal digits.
+    // Test parsing hexadecimal format numeric strings.
     dr_fprintf(STDERR, "param xi = %d\n", op_xi.get_value());
     dr_fprintf(STDERR, "param xl = %ld\n", op_xl.get_value());
     dr_fprintf(STDERR, "param xll = %lld\n", op_xll.get_value());

--- a/suite/tests/client-interface/option_parse.dll.cpp
+++ b/suite/tests/client-interface/option_parse.dll.cpp
@@ -267,19 +267,18 @@ dr_client_main(client_id_t client_id, int argc, const char *argv[])
     dr_fprintf(STDERR, "param xul = %lu\n", op_xul.get_value());
     dr_fprintf(STDERR, "param xull = %llu\n", op_xull.get_value());
 
-    // Test parsing a string of negetive digits. These tests are used to check whether the
+    // Test parsing a string of negative digits. These tests are used to check whether the
     // unsigned option can recognize negative input and output an error.
     std::vector<droption_parser_t *> negtive_test_options;
     negtive_test_options.push_back(static_cast<droption_parser_t *>(&op_ou));
     negtive_test_options.push_back(static_cast<droption_parser_t *>(&op_oul));
     negtive_test_options.push_back(static_cast<droption_parser_t *>(&op_oull));
-    const char *negetive_test_args[3] = { "", "", "" };
+    const char *negative_test_args[3] = { "", "", "   -1" };
     std::string parse_err;
     for (auto op : negtive_test_options) {
         std::string op_name = "-" + op->get_name();
-        negetive_test_args[1] = op_name.c_str();
-        negetive_test_args[2] = "   -1";
-        ok = droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, 3, negetive_test_args,
+        negative_test_args[1] = op_name.c_str();
+        ok = droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, 3, negative_test_args,
                                            &parse_err, NULL);
         ASSERT(!ok);
         dr_fprintf(STDERR, "%s\n", parse_err.c_str());

--- a/suite/tests/client-interface/option_parse.expect
+++ b/suite/tests/client-interface/option_parse.expect
@@ -13,4 +13,19 @@ param takes2 = |1_of_4 3_of_4|,|2_of_4 4_of_4|
 param val_sep = |v1.1 v1.2+v2.1 v2.2|
 param val_sep2 = |v1+v3|,|v2+v4|
 param large_bytesize = 9999999999
+param oi = -10
+param ol = -10
+param oll = -10
+param ou = 10
+param oul = 10
+param oull = 10
+param xi = -10
+param xl = -10
+param xll = -10
+param xu = 10
+param xul = 10
+param xull = 10
+Option ou value out of range
+Option oul value out of range
+Option oull value out of range
 Hello, world!


### PR DESCRIPTION
- Enhance the conversion of integer options to support parsing octal or hexadecimal format strings
- Added negative format string checking before unsigned integer option's parsing
- Added test cases in the  test client 'code_api|client.option_parse'. The new test cases use integer options to parse octal and hexadecimal format strings and unsigned integers to parse the negative format strings.

Issue: #5505