### PR TITLE
i#5326: AArch64 codec: refactor codecsort.py to apply to all codecs

### DIFF
--- a/core/ir/aarch64/codecsort.py
+++ b/core/ir/aarch64/codecsort.py
@@ -115,73 +115,69 @@ def handle_enums(instrs):
 def main():
     """Reorder the given codec_<version>.txt """
 
-    if len(sys.argv) < 2 or len(sys.argv) > 3:
-        print('Usage: codecsort.py [--rewrite|--global] <codec definitions file>')
+    if len(sys.argv) < 2:
+        print('Usage: codecsort.py [--rewrite|--global] <codec definitions files>')
         sys.exit(1)
 
     is_rewrite = False
-    is_global = False
-    if len(sys.argv) == 3 and sys.argv[1] == "--rewrite":
+    if len(sys.argv) >= 3 and sys.argv[1] == "--rewrite":
         is_rewrite = True
-        codec_file = sys.argv[2]
-    elif len(sys.argv) == 3 and sys.argv[1] == "--global":
-        is_global = True
-        codec_file = sys.argv[2]
+        codec_files = sys.argv[2:]
     else:
-        codec_file = sys.argv[1]
+        codec_files = sys.argv[1:]
 
-    instrs = read_instrs(codec_file)
-    instrs.sort(key=lambda line: line.opcode)
+    instr_orig = {codec_file: read_instrs(codec_file) for codec_file in codec_files}
+    file_instrs = {codec_file: sorted(instrs, key=lambda line: line.opcode) for codec_file, instrs in instr_orig.items()}
 
-    handle_enums(instrs)
-    if is_global:
-       status = str(len(instrs)) + ' instruction definitions checked in --global mode'
-       sys.stdout.write(status)
-       return
+    handle_enums([instr for finstrs in file_instrs.values() for instr in finstrs])
 
-    # Scan for some max lengths for formatting
-    instr_length = max(len(i.opcode) for i in instrs)
-    pre_colon = max(
-        len(i.opndtypes.split(":")[0].strip())
-        for i in instrs
-        if ":" in i.opndtypes
-        and len(i.opndtypes.split(":")[0].strip()) < 14)
+    for codec_file, instrs in file_instrs.items():
+        # Scan for some max lengths for formatting
+        instr_length = max(len(i.opcode) for i in instrs)
+        pre_colon = max(
+            len(i.opndtypes.split(":")[0].strip())
+            for i in instrs
+            if ":" in i.opndtypes
+            and len(i.opndtypes.split(":")[0].strip()) < 14)
 
-    new_lines = []
+        new_lines = []
 
-    for instr in instrs:
-        new_lines.append(
-            "{pattern}  {nzcv:<3} {enum:<4} {feat:<4} {opcode_pad}{opcode}  {opand_pad}{opand}".format(
-                enum=instr.enum,
-                feat=instr.feat,
-                pattern=instr.pattern,
-                nzcv=instr.nzcv,
-                opcode_pad=(instr_length - len(instr.opcode)) * " ",
-                opcode=instr.opcode,
-                opand_pad=(pre_colon - len(instr.opndtypes.split(":")[0].strip())) * " ",
-                opand="{} : {}".format(
-                    instr.opndtypes.split(":")[0].strip(),
-                    instr.opndtypes.split(":")[1].strip()) if ":" in instr.opndtypes
-                else instr.opndtypes
-                ).strip())
+        for instr in instrs:
+            new_lines.append(
+                "{pattern}  {nzcv:<3} {enum:<4} {feat:<4} {opcode_pad}{opcode}  {opand_pad}{opand}".format(
+                    enum=instr.enum,
+                    feat=instr.feat,
+                    pattern=instr.pattern,
+                    nzcv=instr.nzcv,
+                    opcode_pad=(instr_length - len(instr.opcode)) * " ",
+                    opcode=instr.opcode,
+                    opand_pad=(pre_colon - len(instr.opndtypes.split(":")[0].strip())) * " ",
+                    opand="{} : {}".format(
+                        instr.opndtypes.split(":")[0].strip(),
+                        instr.opndtypes.split(":")[1].strip()) if ":" in instr.opndtypes
+                    else instr.opndtypes
+                    ).strip())
 
-    header = []
-    with open(codec_file, "r") as lines:
-        for line in lines:
-            header.append(line.strip("\n"))
-            if line.strip() == DELIMITER:
-                header.append("")
-                break
+        header = []
+        with open(codec_file, "r") as lines:
+            for line in lines:
+                header.append(line.strip("\n"))
+                if line.strip() == DELIMITER:
+                    header.append("")
+                    break
 
-    def output(dest):
-        dest("\n".join(header))
-        dest("\n".join(new_lines))
+        def output(dest):
+            dest("\n".join(header))
+            dest("\n".join(new_lines))
 
-    if is_rewrite:
-        with open(codec_file, "w") as codec_txt:
-            output(lambda l: codec_txt.write(l+"\n"))
-    else:
-        output(lambda l: sys.stdout.write(l + "\n"))
+        if is_rewrite:
+            with open(codec_file, "w") as codec_txt:
+                output(lambda l: codec_txt.write(l+"\n"))
+        else:
+            output(lambda l: sys.stdout.write(l + "\n"))
+
+            if instr_orig != file_instrs:
+                sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/make/aarch64_check_codec_order.py
+++ b/make/aarch64_check_codec_order.py
@@ -108,35 +108,17 @@ def main():
     codecsort_py = os.path.join(src_dir, "codecsort.py")
 
     print("Checking if instructions are in the correct order and format in each codec_<version>.txt file.")
-    for isa_version in isa_versions:
-        codec_file = os.path.join(src_dir, 'codec_' + isa_version + '.txt')
-        reordered_codec = subprocess.check_output([codecsort_py, codec_file])
-        with open(codec_file) as f:
-
-            if f.read().strip() != reordered_codec.decode().strip():
-                print("{} instructions are out of order, run:\n{} --rewrite {}".format(
-                    codec_file, codecsort_py, codec_file))
-                sys.exit(1)
-            print(" " + codec_file + " OK!")
+    codec_files = [os.path.join(src_dir, 'codec_' + isa_version + '.txt') for isa_version in isa_versions]
+    with open(os.devnull, 'wb') as dev_null:
+        needs_reorder = subprocess.call([codecsort_py] + codec_files, stdout=dev_null)
+    if needs_reorder:
+        print("codec file instructions are out of order, run:\n{} --rewrite {}".format(
+            codecsort_py, " ".join(codec_files)))
+        sys.exit(1)
+    print(", ".join(codec_files), "OK!")
 
     print("Check there are no duplicate opcode enums across ALL codec_<version>.txt files.")
 
-    # Create one codec_all.txt file which concatanates all codec_<version>.txt files.
-    codec_all_file = os.path.join(bld_dir, 'codec_all.txt')
-    with open(codec_all_file, "w") as codec_all_txt:
-        codec_all_txt.write("\n# Instruction definitions:\n\n")
-        for isa_version in isa_versions:
-            codec_file = os.path.join(src_dir, 'codec_' + isa_version + '.txt')
-            with open(codec_file, "r") as lines:
-                for line in (l.strip() for l in lines if l.strip()):
-                    if line.strip().startswith("#"):
-                        continue
-                    codec_all_txt.write(line + "\n")
-
-    # Call codecsort.py to check for opcode enum duplicates in codec_all.txt
-    # using the --global option to limit checking for duplicates only.
-    opc_dup_enum_status = subprocess.check_output([codecsort_py, '--global', codec_all_file])
-    print(opc_dup_enum_status)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Previously codecsort.py was only applied to a single
codec at a time and thus couldn't allocate enums
uniquely as it didn't know about the enum values in
other files. This patch simplifies the process of
calling codecsort.py so that it can consider all the
codecs at once, and thus rewrite them as needed.

It also changes the default mode so that it returns
an exit code of 1 if it detects a rewrite is needed
making checking the order easier.

Issue: #5326
