### PR TITLE
i#5475 Add FEATURE_LOR for AArch64 v8.1

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -56,6 +56,7 @@ read_feature_regs(uint64 isa_features[])
     MRS(ID_AA64ISAR0_EL1, AA64ISAR0, isa_features);
     MRS(ID_AA64ISAR1_EL1, AA64ISAR1, isa_features);
     MRS(ID_AA64PFR0_EL1, AA64PFR0, isa_features);
+    MRS(ID_AA64MMFR1_EL1, AA64MMFR1, isa_features);
 }
 
 static void
@@ -74,12 +75,13 @@ get_processor_specific_info(void)
     }
 
     /* Reads instruction attribute and preocessor feature registers
-     * ID_AA64ISAR0_EL1, ID_AA64ISAR1_EL1 and ID_AA64PFR0_EL1.
+     * ID_AA64ISAR0_EL1, ID_AA64ISAR1_EL1, ID_AA64PFR0_EL1 and ID_AA64MMFR1_EL1.
      */
     read_feature_regs(isa_features);
     cpu_info.features.flags_aa64isar0 = isa_features[AA64ISAR0];
     cpu_info.features.flags_aa64isar1 = isa_features[AA64ISAR1];
     cpu_info.features.flags_aa64pfr0 = isa_features[AA64PFR0];
+    cpu_info.features.flags_aa64mmfr1 = isa_features[AA64MMFR1];
 }
 
 #    define LOG_FEATURE(feature)       \
@@ -125,16 +127,20 @@ proc_init_arch(void)
         LOG_FEATURE(FEATURE_FlagM);
         LOG_FEATURE(FEATURE_FlagM2);
         LOG_FEATURE(FEATURE_RNG);
+
         LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64ISAR1_EL1 = 0x%016lx\n",
             cpu_info.features.flags_aa64isar1);
-        /* FIXME i#5474: Log all FEATURE_s for ID_AA64ISAR1_EL1. */
         LOG_FEATURE(FEATURE_DPB);
         LOG_FEATURE(FEATURE_DPB2);
+
         LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64PFR0_EL1 = 0x%016lx\n",
             cpu_info.features.flags_aa64pfr0);
-        /* FIXME i#5474: Log all FEATURE_s for ID_AA64PFR0_EL1. */
         LOG_FEATURE(FEATURE_FP16);
         LOG_FEATURE(FEATURE_SVE);
+
+        LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64MMFR1_EL1 = 0x%016lx\n",
+            cpu_info.features.flags_aa64mmfr1);
+        LOG_FEATURE(FEATURE_LOR);
     });
 #endif
 }
@@ -153,7 +159,7 @@ proc_has_feature(feature_bit_t f)
      */
 #    if defined(BUILD_TESTS)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
-        f == FEATURE_DotProd || f == FEATURE_SVE)
+        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;
@@ -172,6 +178,10 @@ proc_has_feature(feature_bit_t f)
         }
         case AA64PFR0: {
             freg_val = cpu_info.features.flags_aa64pfr0;
+            break;
+        }
+        case AA64MMFR1: {
+            freg_val = cpu_info.features.flags_aa64mmfr1;
             break;
         }
         default: CLIENT_ASSERT(false, "proc_has_feature: feature register index error");

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -172,8 +172,14 @@ typedef struct {
     uint64 flags_aa64isar0; /**< AArch64 feature flags stored in ID_AA64ISAR0_EL1 */
     uint64 flags_aa64isar1; /**< AArch64 feature flags stored in ID_AA64ISAR1_EL1 */
     uint64 flags_aa64pfr0;  /**< AArch64 feature flags stored in ID_AA64PFR0_EL1 */
+    uint64 flags_aa64mmfr1; /**< AArch64 feature flags stored in ID_AA64MMFR1_EL1*/
 } features_t;
-typedef enum { AA64ISAR0 = 0, AA64ISAR1 = 1, AA64PFR0 = 2 } feature_reg_idx_t;
+typedef enum {
+    AA64ISAR0 = 0,
+    AA64ISAR1 = 1,
+    AA64PFR0 = 2,
+    AA64MMFR1 = 3
+} feature_reg_idx_t;
 #endif
 
 #ifdef X86
@@ -316,11 +322,11 @@ typedef enum {
     FEATURE_FlagM = DEF_FEAT(AA64ISAR0, 13, 1, 0),   /**< CFINV,RMIF,SETF<x> (AArch64) */
     FEATURE_FlagM2 = DEF_FEAT(AA64ISAR0, 13, 2, 0),  /**< AXFLAG, XAFLAG (AArch64) */
     FEATURE_RNG = DEF_FEAT(AA64ISAR0, 15, 1, 0),     /**< RNDR, RNDRRS (AArch64) */
-    /* FIXME i#5474: Define all FEATURE_s for ID_AA64ISAR1_EL1 and ID_AA64PFR0_EL1. */
     FEATURE_DPB = DEF_FEAT(AA64ISAR1, 0, 1, 0),  /**< DC CVAP (AArch64) */
     FEATURE_DPB2 = DEF_FEAT(AA64ISAR1, 0, 2, 0), /**< DC CVAP, DC CVADP (AArch64) */
     FEATURE_FP16 = DEF_FEAT(AA64PFR0, 4, 1, 1),  /**< Half-precision FP (AArch64) */
     FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 1),   /**< Scalable Vectors (AArch64) */
+    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 1),  /**< Limited order regions (AArch64) */
 } feature_bit_t;
 #endif
 

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -322,11 +322,11 @@ typedef enum {
     FEATURE_FlagM = DEF_FEAT(AA64ISAR0, 13, 1, 0),   /**< CFINV,RMIF,SETF<x> (AArch64) */
     FEATURE_FlagM2 = DEF_FEAT(AA64ISAR0, 13, 2, 0),  /**< AXFLAG, XAFLAG (AArch64) */
     FEATURE_RNG = DEF_FEAT(AA64ISAR0, 15, 1, 0),     /**< RNDR, RNDRRS (AArch64) */
-    FEATURE_DPB = DEF_FEAT(AA64ISAR1, 0, 1, 0),  /**< DC CVAP (AArch64) */
-    FEATURE_DPB2 = DEF_FEAT(AA64ISAR1, 0, 2, 0), /**< DC CVAP, DC CVADP (AArch64) */
-    FEATURE_FP16 = DEF_FEAT(AA64PFR0, 4, 1, 1),  /**< Half-precision FP (AArch64) */
-    FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 1),   /**< Scalable Vectors (AArch64) */
-    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 1),  /**< Limited order regions (AArch64) */
+    FEATURE_DPB = DEF_FEAT(AA64ISAR1, 0, 1, 0),      /**< DC CVAP (AArch64) */
+    FEATURE_DPB2 = DEF_FEAT(AA64ISAR1, 0, 2, 0),     /**< DC CVAP, DC CVADP (AArch64) */
+    FEATURE_FP16 = DEF_FEAT(AA64PFR0, 4, 1, 1),      /**< Half-precision FP (AArch64) */
+    FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 1),       /**< Scalable Vectors (AArch64) */
+    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 1), /**< Limited order regions (AArch64) */
 } feature_bit_t;
 #endif
 

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -74,11 +74,7 @@ cpu_info_t cpu_info = { VENDOR_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
                         CACHE_SIZE_UNKNOWN,
-#ifdef X86
                         { 0, 0, 0, 0 },
-#elif defined(AARCHXX)
-                        { 0, 0, 0 },
-#endif
                         { 0x6e6b6e75, 0x006e776f } };
 
 void


### PR DESCRIPTION
The Limited Ordering Regions feature is required for the v8.1
load-acquire and store-release instructions like LDLAR and STLLR which
rely on the hardware providing order between memory accesses to
regions of the physical address map. Read from ID_AA64MMFR1_EL1.

Issues: #5475, #1569