### PR TITLE
i#3544 RISC-V, part 2: Add opcode and instr macros

### DIFF
--- a/core/ir/instr_create_shared_api.h
+++ b/core/ir/instr_create_shared_api.h
@@ -49,6 +49,8 @@
 #        include "dr_ir_macros_aarch64.h"
 #    elif defined(ARM)
 #        include "dr_ir_macros_arm.h"
+#    elif defined(RISCV64)
+#        include "dr_ir_macros_riscv64.h"
 #    endif
 #    include "dr_ir_opnd.h"
 #    include "dr_ir_instr.h"

--- a/core/ir/instr_inline_api.h
+++ b/core/ir/instr_inline_api.h
@@ -183,8 +183,27 @@ opnd_is_far_rel_addr(opnd_t opnd)
 {
     return false;
 }
-#        endif
-#    endif /* X64 || ARM */
+#        elif defined(RISCV64)
+#            define OPND_IS_REL_ADDR(op) ((op).kind == REL_ADDR_kind)
+#            define opnd_is_rel_addr OPND_IS_REL_ADDR
+
+INSTR_INLINE
+bool
+opnd_is_near_rel_addr(opnd_t opnd)
+{
+    /* FIXME i#3544: Not implemented */
+    return opnd_is_rel_addr(opnd);
+}
+
+INSTR_INLINE
+bool
+opnd_is_far_rel_addr(opnd_t opnd)
+{
+    /* FIXME i#3544: Not implemented */
+    return false;
+}
+#        endif /* RISCV64 */
+#    endif     /* X64 || ARM */
 
 /* opnd_t constructors */
 
@@ -271,6 +290,11 @@ opnd_create_pc(app_pc pc)
                  "opnd_get_flags called on non-reg non-base-disp non-immed-int opnd")( \
                  opnd)                                                                 \
                  .aux.flags)
+#    elif defined(RISCV64)
+#        define OPND_GET_FLAGS(opnd)                                                     \
+            (CLIENT_ASSERT_(                                                             \
+                opnd_is_reg(opnd) || opnd_is_base_disp(opnd) || opnd_is_immed_int(opnd), \
+                "opnd_get_flags called on non-reg non-base-disp non-immed-int opnd") 0)
 #    endif
 #    define opnd_get_flags OPND_GET_FLAGS
 
@@ -302,7 +326,7 @@ opnd_create_pc(app_pc pc)
                                                            opnd_is_rel_addr(opnd)),     \
                             "opnd_get_segment called on invalid opnd type")(opnd)       \
                  .aux.segment)
-#    elif defined(AARCHXX)
+#    elif defined(AARCHXX) || defined(RISCV64)
 #        define OPND_GET_SEGMENT(opnd) DR_REG_NULL
 #    endif
 #    define opnd_get_segment OPND_GET_SEGMENT

--- a/core/ir/instr_inline_api.h
+++ b/core/ir/instr_inline_api.h
@@ -191,7 +191,6 @@ INSTR_INLINE
 bool
 opnd_is_near_rel_addr(opnd_t opnd)
 {
-    /* FIXME i#3544: Not implemented */
     return opnd_is_rel_addr(opnd);
 }
 
@@ -199,7 +198,7 @@ INSTR_INLINE
 bool
 opnd_is_far_rel_addr(opnd_t opnd)
 {
-    /* FIXME i#3544: Not implemented */
+    /* FIXME i#3544: Decide if this should differentiate between JAL and AUIPC+JALR. */
     return false;
 }
 #        endif /* RISCV64 */
@@ -277,7 +276,7 @@ opnd_create_pc(app_pc pc)
              .value.reg)
 #    define opnd_get_reg OPND_GET_REG
 
-#    ifdef X86
+#    if defined(X86) || defined(RISCV64)
 #        define OPND_GET_FLAGS(opnd)                                                     \
             (CLIENT_ASSERT_(                                                             \
                 opnd_is_reg(opnd) || opnd_is_base_disp(opnd) || opnd_is_immed_int(opnd), \
@@ -290,11 +289,6 @@ opnd_create_pc(app_pc pc)
                  "opnd_get_flags called on non-reg non-base-disp non-immed-int opnd")( \
                  opnd)                                                                 \
                  .aux.flags)
-#    elif defined(RISCV64)
-#        define OPND_GET_FLAGS(opnd)                                                     \
-            (CLIENT_ASSERT_(                                                             \
-                opnd_is_reg(opnd) || opnd_is_base_disp(opnd) || opnd_is_immed_int(opnd), \
-                "opnd_get_flags called on non-reg non-base-disp non-immed-int opnd") 0)
 #    endif
 #    define opnd_get_flags OPND_GET_FLAGS
 

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -3605,6 +3605,7 @@ instr_raw_is_tls_spill(byte *pc, reg_id_t reg, ushort offs)
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 #    elif defined(RISCV64)
+    /* FIXME i#3544: Not implemented. */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 #    endif /* X86/ARM/RISCV64 */

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -2656,7 +2656,8 @@ instr_is_cti(instr_t *instr) /* any control-transfer instruction */
 int
 instr_get_interrupt_number(instr_t *instr)
 {
-    CLIENT_ASSERT(instr_get_opcode(instr) == IF_X86_ELSE(OP_int, OP_svc),
+    CLIENT_ASSERT(instr_get_opcode(instr) ==
+                      IF_X86_ELSE(OP_int, IF_RISCV64_ELSE(OP_ecall, OP_svc)),
                   "instr_get_interrupt_number: instr not interrupt");
     if (instr_operands_valid(instr)) {
         ptr_int_t val = opnd_get_immed_int(instr_get_src(instr, 0));
@@ -3603,7 +3604,10 @@ instr_raw_is_tls_spill(byte *pc, reg_id_t reg, ushort offs)
     /* FIXME i#1551, i#1569: NYI on ARM/AArch64 */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
-#    endif /* X86/ARM */
+#    elif defined(RISCV64)
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+#    endif /* X86/ARM/RISCV64 */
 }
 
 /* this routine may upgrade a level 1 instr */
@@ -3639,6 +3643,10 @@ instr_check_tls_spill_restore(instr_t *instr, bool *spill, reg_id_t *reg, int *o
         opnd_is_abs_base_disp(memop)
 #    elif defined(AARCHXX)
         opnd_is_base_disp(memop) && opnd_get_base(memop) == dr_reg_stolen &&
+        opnd_get_index(memop) == DR_REG_NULL
+#    elif defined(RISCV64)
+        /* FIXME i#3544: Check if valid. */
+        opnd_is_base_disp(memop) && opnd_get_base(memop) == DR_REG_TP &&
         opnd_get_index(memop) == DR_REG_NULL
 #    endif
     ) {
@@ -3693,6 +3701,10 @@ instr_is_tls_xcx_spill(instr_t *instr)
         return instr_is_tls_spill(instr, REG_ECX, MANGLE_XCX_SPILL_SLOT);
 #    elif defined(AARCHXX)
     /* FIXME i#1551, i#1569: NYI on ARM/AArch64 */
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+#    elif defined(RISCV64)
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 #    endif
@@ -3883,7 +3895,11 @@ move_mm_reg_opcode(bool aligned16, bool aligned32)
 #    elif defined(AARCH64)
     ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
     return 0;
-#    endif /* X86/ARM */
+#    elif defined(RISCV64)
+    /* FIXME i#3544: Not implemented */
+    ASSERT_NOT_IMPLEMENTED(false);
+    return 0;
+#    endif /* X86/ARM/RISCV64 */
 }
 
 uint

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1179,6 +1179,8 @@ const reg_id_t d_r_regparms[] = {
 #    ifdef X64
     REGPARM_4,  REGPARM_5, REGPARM_6, REGPARM_7,
 #    endif
+#elif defined(RISCV64)
+    REGPARM_0,  REGPARM_1, REGPARM_2, REGPARM_3, REGPARM_4, REGPARM_5,
 #endif
     REG_INVALID
 };
@@ -1273,6 +1275,21 @@ opnd_replace_reg(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
             *opnd = opnd_create_far_base_disp_ex(
                 s, b, i, sc, d, size, opnd_is_disp_encode_zero(*opnd),
                 opnd_is_disp_force_full(*opnd), opnd_is_disp_short_addr(*opnd));
+#elif defined(RISCV64)
+            /* FIXME i#3544: RISC-V has no support for base + idx * scale + disp.
+             * We could support base + disp as long as disp == +/-1MB.
+             * If needed, instructions with this operand should be transformed
+             * to:
+             *   mul idx, idx, scale # or slli if scale is immediate
+             *   add base, base, idx
+             *   addi base, base, disp
+             */
+            CLIENT_ASSERT(false, "Not implemented");
+            (void)size;
+            (void)b;
+            (void)i;
+            (void)d;
+            return false;
 #endif
             return true;
         }
@@ -1381,6 +1398,19 @@ opnd_replace_reg_resize(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
             *opnd = opnd_create_far_base_disp_ex(
                 new_s, new_b, new_i, sc, disp, size, opnd_is_disp_encode_zero(*opnd),
                 opnd_is_disp_force_full(*opnd), opnd_is_disp_short_addr(*opnd));
+#elif defined(RISCV64)
+            /* FIXME i#3544: RISC-V has no support for base + idx * scale + disp.
+             * We could support base + disp as long as disp == +/-1MB.
+             * If needed, instructions with this operand should be transformed
+             * to:
+             *   mul idx, idx, scale # or slli if scale is immediate
+             *   add base, base, idx
+             *   addi base, base, disp
+             */
+            CLIENT_ASSERT(false, "Not implemented");
+            (void)disp;
+            (void)size;
+            return false;
 #endif
             return true;
         }
@@ -2161,6 +2191,11 @@ opnd_compute_address_priv(opnd_t opnd, priv_mcontext_t *mc)
             break;
         default: scaled_index = index_val;
         }
+#elif defined(RISCV64)
+        /* FIXME i#3544: Not implemented */
+        (void)index;
+        CLIENT_ASSERT(false, "Not implemented");
+        return NULL;
 #endif
     }
     return opnd_compute_address_helper(opnd, mc, scaled_index);
@@ -2200,6 +2235,11 @@ reg_32_to_16(reg_id_t reg)
 #elif defined(AARCHXX)
     CLIENT_ASSERT(false, "reg_32_to_16 not supported on ARM");
     return REG_NULL;
+#elif defined(RISCV64)
+    /* FIXME i#3544: There is no separate addressing for half registers.
+     * Semantics are part of the opcode.
+     */
+    return reg;
 #endif
 }
 
@@ -2222,6 +2262,11 @@ reg_32_to_8(reg_id_t reg)
 #elif defined(AARCHXX)
     CLIENT_ASSERT(false, "reg_32_to_8 not supported on ARM");
     return REG_NULL;
+#elif defined(RISCV64)
+    /* FIXME i#3544: There is no separate addressing for half registers.
+     * Semantics are part of the opcode.
+     */
+    return reg;
 #endif
 }
 

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1285,6 +1285,7 @@ opnd_replace_reg(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
              *   addi base, base, disp
              */
             CLIENT_ASSERT(false, "Not implemented");
+            /* Marking as unused to silence -Wunused-variable. */
             (void)size;
             (void)b;
             (void)i;
@@ -1408,6 +1409,7 @@ opnd_replace_reg_resize(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
              *   addi base, base, disp
              */
             CLIENT_ASSERT(false, "Not implemented");
+            /* Marking as unused to silence -Wunused-variable. */
             (void)disp;
             (void)size;
             return false;
@@ -2193,8 +2195,9 @@ opnd_compute_address_priv(opnd_t opnd, priv_mcontext_t *mc)
         }
 #elif defined(RISCV64)
         /* FIXME i#3544: Not implemented */
-        (void)index;
+        /* Marking as unused to silence -Wunused-variable. */
         CLIENT_ASSERT(false, "Not implemented");
+        (void)index;
         return NULL;
 #endif
     }

--- a/core/ir/riscv64/instr.c
+++ b/core/ir/riscv64/instr.c
@@ -48,7 +48,8 @@ instr_get_isa_mode(instr_t *instr)
 int
 instr_length_arch(dcontext_t *dcontext, instr_t *instr)
 {
-    /* FIXME i#3544: C ISA extension has a shorter instruction length. */
+    /* FIXME i#3544: Compressed Instructions ISA extension has a shorter instruction
+     * length. */
     return RISCV64_INSTR_SIZE;
 }
 

--- a/core/ir/riscv64/instr.c
+++ b/core/ir/riscv64/instr.c
@@ -1,0 +1,451 @@
+/* **********************************************************
+ * Copyright (c) 2022 Rivos, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "../globals.h"
+#include "instr.h"
+
+bool
+instr_set_isa_mode(instr_t *instr, dr_isa_mode_t mode)
+{
+    return (mode == DR_ISA_RV64IMAFDC);
+}
+
+dr_isa_mode_t
+instr_get_isa_mode(instr_t *instr)
+{
+    return DR_ISA_RV64IMAFDC;
+}
+
+int
+instr_length_arch(dcontext_t *dcontext, instr_t *instr)
+{
+    /* FIXME i#3544: C has shorter instruction length. */
+    return RISCV64_INSTR_SIZE;
+}
+
+bool
+opc_is_not_a_real_memory_load(int opc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return opc == OP_l;
+}
+
+uint
+instr_branch_type(instr_t *cti_instr)
+{
+    /* FIXME i#3544: Add parameter checking (inc table 2.1 in spec) */
+    int opcode = instr_get_opcode(cti_instr);
+    switch (opcode) {
+    case OP_jal: return LINK_DIRECT | LINK_CALL;
+    case OP_jalr: return LINK_INDIRECT | LINK_CALL;
+    case OP_beq:
+    case OP_bne:
+    case OP_blt:
+    case OP_bltu:
+    case OP_bge:
+    case OP_bgeu: return LINK_DIRECT | LINK_JMP;
+    }
+    CLIENT_ASSERT(false, "instr_branch_type: unknown opcode");
+    return LINK_INDIRECT;
+}
+
+const char *
+get_opcode_name(int opc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return "";
+}
+
+bool
+instr_is_mov(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_call_arch(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_call_direct(instr_t *instr)
+{
+    /* FIXME i#3544: Check if valid */
+    int opc = instr_get_opcode(instr);
+    return (opc == OP_jal);
+}
+
+bool
+instr_is_near_call_direct(instr_t *instr)
+{
+    /* FIXME i#3544: Check if valid */
+    int opc = instr_get_opcode(instr);
+    return (opc == OP_jal);
+}
+
+bool
+instr_is_call_indirect(instr_t *instr)
+{
+    /* FIXME i#3544: Check if valid */
+    int opc = instr_get_opcode(instr);
+    return (opc == OP_jalr);
+}
+
+bool
+instr_is_return(instr_t *instr)
+{
+    /* FIXME i#3544: Check if valid */
+    int opc = instr_get_opcode(instr);
+    opnd_t rd = instr_get_dst(instr, 0);
+    opnd_t rs = instr_get_src(instr, 0);
+    return (opc == OP_jalr && opnd_get_reg(rd) == DR_REG_X0 &&
+            opnd_is_memory_reference(rs) && opnd_get_base(rs) == DR_REG_X1 &&
+            opnd_get_disp(rs) == 0);
+}
+
+bool
+instr_is_cbr_arch(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_mbr_arch(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_far_cti(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_ubr_arch(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_near_ubr(instr_t *instr)
+{
+    return instr_is_ubr(instr);
+}
+
+bool
+instr_is_cti_short(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_cti_loop(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_cti_short_rewrite(instr_t *instr, byte *pc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_interrupt(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_syscall(instr_t *instr)
+{
+    /* FIXME i#3544: Check if valid */
+    int opc = instr_get_opcode(instr);
+    return (opc == OP_ecall);
+}
+
+bool
+instr_is_mov_constant(instr_t *instr, ptr_int_t *value)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_prefetch(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_string_op(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_rep_string_op(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_saves_float_pc(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_undefined(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+void
+instr_invert_cbr(instr_t *instr)
+{
+    int opc = instr_get_opcode(instr);
+    CLIENT_ASSERT(instr_is_cbr(instr), "instr_invert_cbr: instr not a cbr");
+    if (opc == OP_beq) {
+        instr_set_opcode(instr, OP_bne);
+    } else if (opc == OP_bne) {
+        instr_set_opcode(instr, OP_beq);
+    } else if (opc == OP_blt) {
+        instr_set_opcode(instr, OP_bge);
+    } else if (opc == OP_bltu) {
+        instr_set_opcode(instr, OP_bgeu);
+    } else if (opc == OP_bge) {
+        instr_set_opcode(instr, OP_blt);
+    } else if (opc == OP_bgeu) {
+        instr_set_opcode(instr, OP_bltu);
+    } else {
+        CLIENT_ASSERT(false, "instr_invert_cbr: unknown opcode");
+    }
+}
+
+bool
+instr_cbr_taken(instr_t *instr, priv_mcontext_t *mc, bool pre)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_predicate_reads_srcs(dr_pred_type_t pred)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_predicate_writes_eflags(dr_pred_type_t pred)
+{
+    return false;
+}
+
+bool
+instr_predicate_is_cond(dr_pred_type_t pred)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_gpr(reg_id_t reg)
+{
+    return (reg >= DR_REG_START_GPR && reg <= DR_REG_STOP_GPR);
+}
+
+bool
+reg_is_simd(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_vector_simd(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_opmask(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_bnd(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_strictly_zmm(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_ymm(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_strictly_ymm(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_xmm(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_strictly_xmm(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_mmx(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_opmask(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+reg_is_fp(reg_id_t reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_nop(instr_t *instr)
+{
+    uint opc = instr_get_opcode(instr);
+    opnd_t rd = instr_get_dst(instr, 0);
+    opnd_t rs = instr_get_src(instr, 0);
+    opnd_t i = instr_get_src(instr, 1);
+    return (opc == OP_addi && opnd_get_reg(rd) == DR_REG_X0 &&
+            opnd_get_reg(rs) == DR_REG_X0 && opnd_get_immed_int(i) == 0);
+}
+
+bool
+opnd_same_sizes_ok(opnd_size_t s1, opnd_size_t s2, bool is_reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+instr_t *
+instr_create_nbyte_nop(dcontext_t *dcontext, uint num_bytes, bool raw)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+DR_API
+bool
+instr_is_exclusive_load(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+DR_API
+bool
+instr_is_exclusive_store(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+DR_API
+bool
+instr_is_scatter(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+DR_API
+bool
+instr_is_gather(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+instr_is_jump_mem(instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}

--- a/core/ir/riscv64/instr_create_api.h
+++ b/core/ir/riscv64/instr_create_api.h
@@ -356,7 +356,7 @@
 /** @} */ /* end doxygen group */
 
 /****************************************************************************
- * x86-specific INSTR_CREATE_* macros
+ * RISC-V-specific INSTR_CREATE_* macros
  */
 
 /** @name No-operand instructions */

--- a/core/ir/riscv64/instr_create_api.h
+++ b/core/ir/riscv64/instr_create_api.h
@@ -39,10 +39,8 @@
 /** @name Platform-independent macros */
 /** @{ */ /* doxygen start group */
 
-/* FIXME i#3544: Check and implement all INSTR_CREATE_* macros. */
-
-#define INSTR_CREATE_ecall(dc) instr_create_0dst_0src(dc, OP_ecall)
-#define INSTR_CREATE_nop(dc) XINST_CREATE_nop(dc)
+/* FIXME i#3544: Check and implement all INSTR_CREATE_ and XINST_CREATE_ macros. For now
+ * all unimplemented instructions use OP_hint which is effectively a no-op. */
 
 /**
  * This platform-independent macro creates an instr_t for a debug trap
@@ -337,7 +335,7 @@
  * This platform-independent macro creates an instr_t for a nop instruction.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  */
-#define XINST_CREATE_nop(dc) instr_create_0dst_0src(dc, OP_hint)
+#define XINST_CREATE_nop(dc) INSTR_CREATE_nop(dc)
 
 /**
  * This platform-independent macro creates an instr_t for an indirect call instr
@@ -355,6 +353,21 @@
  */
 #define OPND_CREATE_ABSMEM(addr, size) opnd_create_rel_addr(addr, size)
 
+/** @} */ /* end doxygen group */
+
+/****************************************************************************
+ * x86-specific INSTR_CREATE_* macros
+ */
+
+/** @name No-operand instructions */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/**
+ * This INSTR_CREATE_xxx macro creates an instr_t with opcode OP_xxx, automatically
+ * supplying any implicit operands.
+ * \param dc The void * dcontext used to allocate memory for the instr_t.
+ */
+#define INSTR_CREATE_ecall(dc) instr_create_0dst_0src(dc, OP_ecall)
+#define INSTR_CREATE_nop(dc) instr_create_0dst_0src(dc, OP_hint)
 /** @} */ /* end doxygen group */
 
 #endif /* _DR_IR_MACROS_RISCV64_H_ */

--- a/core/ir/riscv64/instr_create_api.h
+++ b/core/ir/riscv64/instr_create_api.h
@@ -1,0 +1,360 @@
+/* **********************************************************
+ * Copyright (c) 2022 Rivos, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _DR_IR_MACROS_RISCV64_H_
+#define _DR_IR_MACROS_RISCV64_H_ 1
+
+/****************************************************************************
+ * Platform-independent INSTR_CREATE_* macros
+ */
+/** @name Platform-independent macros */
+/** @{ */ /* doxygen start group */
+
+/* FIXME i#3544: Check and implement all INSTR_CREATE_* macros. */
+
+#define INSTR_CREATE_ecall(dc) instr_create_0dst_0src(dc, OP_ecall)
+#define INSTR_CREATE_nop(dc) XINST_CREATE_nop(dc)
+
+/**
+ * This platform-independent macro creates an instr_t for a debug trap
+ * instruction, automatically supplying any implicit operands.
+ * \param dc The void * dcontext used to allocate memory for the instr_t.
+ */
+#define XINST_CREATE_debug_instr(dc) instr_create_0dst_0src(dc, OP_hint)
+
+/**
+ * This platform-independent macro creates an instr_t for a 4-byte
+ * or 8-byte memory load instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param m   The source memory opnd.
+ */
+#define XINST_CREATE_load(dc, r, m) instr_create_1dst_1src(dc, OP_hint, r, m)
+
+/**
+ * This platform-independent macro creates an instr_t which loads 1 byte
+ * from memory, zero-extends it to 4 bytes, and writes it to a 4 byte
+ * destination register.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param m   The source memory opnd.
+ */
+#define XINST_CREATE_load_1byte_zext4(dc, r, m) instr_create_1dst_1src(dc, OP_hint, r, m)
+
+/**
+ * This platform-independent macro creates an instr_t for a 1-byte
+ * memory load instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param m   The source memory opnd.
+ */
+#define XINST_CREATE_load_1byte(dc, r, m) instr_create_1dst_1src(dc, OP_hint, r, m)
+
+/**
+ * This platform-independent macro creates an instr_t for a 2-byte
+ * memory load instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param m   The source memory opnd.
+ */
+#define XINST_CREATE_load_2bytes(dc, r, m) instr_create_1dst_1src(dc, OP_hint, r, m)
+
+/**
+ * This platform-independent macro creates an instr_t for a 4-byte
+ * or 8-byte memory store instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param m   The destination memory opnd.
+ * \param r   The source register opnd.
+ */
+#define XINST_CREATE_store(dc, m, r) instr_create_1dst_1src(dc, OP_hint, m, r)
+
+/**
+ * This platform-independent macro creates an instr_t for a 1-byte
+ * memory store instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param m   The destination memory opnd.
+ * \param r   The source register opnd.
+ */
+#define XINST_CREATE_store_1byte(dc, m, r) instr_create_1dst_1src(dc, OP_hint, m, r)
+
+/**
+ * This platform-independent macro creates an instr_t for a 2-byte
+ * memory store instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param m   The destination memory opnd.
+ * \param r   The source register opnd.
+ */
+#define XINST_CREATE_store_2bytes(dc, m, r) instr_create_1dst_1src(dc, OP_hint, m, r)
+
+/**
+ * This platform-independent macro creates an instr_t for a register
+ * to register move instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d   The destination register opnd.
+ * \param s   The source register opnd.
+ */
+#define XINST_CREATE_move(dc, d, s) instr_create_1dst_1src(dc, OP_hint, d, s)
+
+/**
+ * This platform-independent macro creates an instr_t for a multimedia
+ * register load instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param m   The source memory opnd.
+ */
+#define XINST_CREATE_load_simd(dc, r, m) instr_create_1dst_1src(dc, OP_hint, r, m)
+
+/**
+ * This platform-independent macro creates an instr_t for a multimedia
+ * register store instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param m   The destination memory opnd.
+ * \param r   The source register opnd.
+ */
+#define XINST_CREATE_store_simd(dc, m, r) instr_create_1dst_1src(dc, OP_hint, m, r)
+
+/**
+ * This platform-independent macro creates an instr_t for an indirect
+ * jump through memory instruction.  For AArch32, the memory address
+ * must be aligned to 4.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param m   The memory opnd holding the target.
+ */
+#define XINST_CREATE_jump_mem(dc, m) \
+    instr_create_0dst_2src(dc, OP_hint, opnd_create_reg(DR_REG_PC), (m))
+
+/**
+ * This platform-independent macro creates an instr_t for an indirect
+ * jump instruction through a register.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The register opnd holding the target.
+ */
+#define XINST_CREATE_jump_reg(dc, r) instr_create_0dst_1src(dc, OP_hint, r)
+
+/**
+ * This platform-independent macro creates an instr_t for an immediate
+ * integer load instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The destination register opnd.
+ * \param i   The source immediate integer opnd.
+ */
+#define XINST_CREATE_load_int(dc, r, i) instr_create_1dst_1src(dc, OP_hint, r, i)
+
+/**
+ * This platform-independent macro creates an instr_t for a return instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ */
+#define XINST_CREATE_return(dc) instr_create_0dst_0src(dc, OP_hint)
+
+/**
+ * This platform-independent macro creates an instr_t for an unconditional
+ * branch instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param t   The opnd_t target operand for the instruction, which can be
+ * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
+ * Be sure to ensure that the limited reach of this short branch will reach
+ * the target (a pc operand is not suitable for most uses unless you know
+ * precisely where this instruction will be encoded).
+ */
+#define XINST_CREATE_jump(dc, t) instr_create_0dst_1src(dc, OP_hint, t)
+
+/**
+ * This platform-independent macro creates an instr_t for an unconditional
+ * branch instruction with the smallest available reach.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param t   The opnd_t target operand for the instruction, which can be
+ * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
+ * Be sure to ensure that the limited reach of this short branch will reach
+ * the target (a pc operand is not suitable for most uses unless you know
+ * precisely where this instruction will be encoded).
+ */
+#define XINST_CREATE_jump_short(dc, t) instr_create_0dst_1src(dc, OP_hint, t)
+
+/**
+ * This platform-independent macro creates an instr_t for an unconditional
+ * branch instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param t   The opnd_t target operand for the instruction, which can be
+ * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
+ * Be sure to ensure that the limited reach of this short branch will reach
+ * the target (a pc operand is not suitable for most uses unless you know
+ * precisely where this instruction will be encoded).
+ */
+#define XINST_CREATE_call(dc, t) instr_create_0dst_1src(dc, OP_hint, t)
+
+/**
+ * This platform-independent macro creates an instr_t for a conditional
+ * branch instruction that branches if the previously-set condition codes
+ * indicate the condition indicated by \p pred.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param pred  The #dr_pred_type_t condition to match.
+ * \param t   The opnd_t target operand for the instruction, which can be
+ * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
+ * Be sure to ensure that the limited reach of this short branch will reach
+ * the target (a pc operand is not suitable for most uses unless you know
+ * precisely where this instruction will be encoded).
+ */
+#define XINST_CREATE_jump_cond(dc, pred, t) \
+    (INSTR_PRED(instr_create_0dst_1src(dc, OP_hint, t), (pred)))
+
+/**
+ * This platform-independent macro creates an instr_t for an addition
+ * instruction that does not affect the status flags.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s  The opnd_t explicit source operand for the instruction.
+ */
+#define XINST_CREATE_add(dc, d, s) instr_create_1dst_2src(dc, OP_hint, d, d, s)
+
+/**
+ * This platform-independent macro creates an instr_t for an addition
+ * instruction that does not affect the status flags and takes two sources
+ * plus a destination.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s1  The opnd_t explicit first source operand for the instruction. This
+ * must be a register.
+ * \param s2  The opnd_t explicit source operand for the instruction. This
+ * can be either a register or an immediate integer.
+ */
+#define XINST_CREATE_add_2src(dc, d, s1, s2) \
+    instr_create_1dst_2src(dc, OP_hint, d, s1, s2)
+
+/**
+ * This platform-independent macro creates an instr_t for an addition
+ * instruction that does not affect the status flags and takes two register sources
+ * plus a destination, with one source being shifted logically left by
+ * an immediate amount that is limited to either 0, 1, 2, or 3.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s1  The opnd_t explicit first source operand for the instruction.  This
+ * must be a register.
+ * \param s2_toshift  The opnd_t explicit source operand for the instruction.  This
+ * must be a register.
+ * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
+ */
+#define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
+    instr_create_1dst_3src(dc, OP_hint, d, s1, s2_toshift,        \
+                           opnd_create_immed_int(shift_amount, OPSZ_1))
+
+/**
+ * This platform-independent macro creates an instr_t for an addition
+ * instruction that does affect the status flags.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s  The opnd_t explicit source operand for the instruction.
+ */
+#define XINST_CREATE_add_s(dc, d, s) instr_create_1dst_2src(dc, OP_hint, d, d, s)
+
+/**
+ * This platform-independent macro creates an instr_t for a subtraction
+ * instruction that does not affect the status flags.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s  The opnd_t explicit source operand for the instruction.
+ */
+/* FIXME: How to handle a lack of flags register? */
+#define XINST_CREATE_sub(dc, d, s) instr_create_1dst_2src(dc, OP_hint, d, d, s)
+
+/**
+ * This platform-independent macro creates an instr_t for a subtraction
+ * instruction that does affect the status flags.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s  The opnd_t explicit source operand for the instruction.
+ */
+/* FIXME: How to handle a lack of flags register? */
+#define XINST_CREATE_sub_s(dc, d, s) instr_create_1dst_2src(dc, OP_hint, d, d, s)
+
+/**
+ * This platform-independent macro creates an instr_t for a bitwise and
+ * instruction that does affect the status flags.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param d  The opnd_t explicit destination operand for the instruction.
+ * \param s  The opnd_t explicit source operand for the instruction.
+ */
+/* FIXME: How to handle a lack of flags register? */
+#define XINST_CREATE_and_s(dc, d, s) instr_create_1dst_2src(dc, OP_hint, d, d, s)
+
+/**
+ * This platform-independent macro creates an instr_t for a comparison
+ * instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param s1  The opnd_t explicit source operand for the instruction.
+ * \param s2  The opnd_t explicit source operand for the instruction.
+ */
+/* FIXME: How to handle a lack of flags register? */
+#define XINST_CREATE_cmp(dc, s1, s2) instr_create_0dst_2src(dc, OP_hint, s1, s2)
+
+/**
+ * This platform-independent macro creates an instr_t for a software
+ * interrupt instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param i   The source integer constant opnd_t operand.
+ */
+#define XINST_CREATE_interrupt(dc, i) instr_create_0dst_1src(dc, OP_hint, i)
+
+/**
+ * This platform-independent macro creates an instr_t for a logical right shift
+ * instruction that does affect the status flags.
+ * \param dc         The void * dcontext used to allocate memory for the instr_t.
+ * \param d          The opnd_t explicit destination operand for the instruction.
+ * \param rm_or_imm  The opnd_t explicit source operand for the instruction.
+ */
+#define XINST_CREATE_slr_s(dc, d, rm_or_imm) \
+    instr_create_1dst_1src(dc, OP_hint, d, rm_or_imm)
+
+/**
+ * This platform-independent macro creates an instr_t for a nop instruction.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ */
+#define XINST_CREATE_nop(dc) instr_create_0dst_0src(dc, OP_hint)
+
+/**
+ * This platform-independent macro creates an instr_t for an indirect call instr
+ * through a register.
+ * \param dc  The void * dcontext used to allocate memory for the instr_t.
+ * \param r   The opnd_t explicit source operand for the instruction. This should
+ * be a reg_id_t operand with the address of the subroutine.
+ */
+#define XINST_CREATE_call_reg(dc, r) instr_create_0dst_1src(dc, OP_hint, r)
+
+/**
+ * Create an absolute address operand encoded as pc-relative.
+ * Encoding will fail if addr is out of the maximum signed displacement
+ * reach for the architecture.
+ */
+#define OPND_CREATE_ABSMEM(addr, size) opnd_create_rel_addr(addr, size)
+
+/** @} */ /* end doxygen group */
+
+#endif /* _DR_IR_MACROS_RISCV64_H_ */

--- a/core/ir/riscv64/opcode_api.h
+++ b/core/ir/riscv64/opcode_api.h
@@ -1,0 +1,89 @@
+/* **********************************************************
+ * Copyright (c) 2022 Rivos, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _DR_IR_OPCODES_RISCV64_H_
+#define _DR_IR_OPCODES_RISCV64_H_ 1
+
+/****************************************************************************
+ * OPCODES
+ */
+/**
+ * @file dr_ir_opcodes_arm.h
+ * @brief Instruction opcode constants for RISC-V.
+ */
+/** Opcode constants for use in the instr_t data structure. */
+enum {
+    /*   0 */ OP_INVALID,
+    /* NULL, */ /**< INVALID opcode */
+    /*   1 */ OP_UNDECODED,
+    /* NULL, */ /**< UNDECODED opcode */
+    /*   2 */ OP_CONTD,
+    /* NULL, */ /**< CONTD opcode */
+    /*   3 */ OP_LABEL,
+    /* NULL, */ /**< LABEL opcode */
+
+    /* FIXME i#3544: Put real opcodes here ans make sure ordering matches HW */
+    /* FIXME i#3544: should load/store width be separate opcode or in the instruction
+       flags? */
+    /* FIXME i#3544: Should pseudo instructions be here too? */
+    OP_ecall, /**< RISC-V ecall opcode. */
+    OP_l,     /**< RISC-V load opcode. */
+    OP_s,     /**< RISC-V store opcode. */
+    OP_add,   /**< RISC-V add opcode. */
+    OP_addi,  /**< RISC-V addi opcode. */
+    OP_sub,   /**< RISC-V sub opcode. */
+    OP_mul,   /**< RISC-V mul opcode. */
+    OP_mulu,  /**< RISC-V mulu opcode. */
+    OP_div,   /**< RISC-V div opcode. */
+    OP_divu,  /**< RISC-V divu opcode. */
+    OP_jal,   /**< RISC-V jal opcode. */
+    OP_jalr,  /**< RISC-V jalr opcode. */
+    OP_beq,   /**< RISC-V beq opcode. */
+    OP_bne,   /**< RISC-V bne opcode. */
+    OP_blt,   /**< RISC-V blt opcode. */
+    OP_bltu,  /**< RISC-V bltu opcode. */
+    OP_bge,   /**< RISC-V bge opcode. */
+    OP_bgeu,  /**< RISC-V bgeu opcode. */
+    OP_hint,  /**< RISC-V hint opcode. */
+
+    OP_AFTER_LAST,
+    OP_FIRST = OP_hint,          /**< First real opcode. */
+    OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */
+};
+
+/* alternative names */
+#define OP_jmp OP_hint       /**< Platform-independent opcode name for jump. */
+#define OP_jmp_short OP_hint /**< Platform-independent opcode name for short jump. */
+#define OP_load OP_hint      /**< Platform-independent opcode name for load. */
+#define OP_store OP_hint     /**< Platform-independent opcode name for store. */
+
+#endif /* _DR_IR_OPCODES_RISCV64_H_ */

--- a/core/ir/riscv64/opcode_api.h
+++ b/core/ir/riscv64/opcode_api.h
@@ -51,13 +51,10 @@ enum {
     /*   3 */ OP_LABEL,
     /* NULL, */ /**< LABEL opcode */
 
-    /* FIXME i#3544: Put real opcodes here ans make sure ordering matches HW */
-    /* FIXME i#3544: should load/store width be separate opcode or in the instruction
-       flags? */
-    /* FIXME i#3544: Should pseudo instructions be here too? */
+    /* FIXME i#3544: Put real opcodes here and make sure ordering matches HW. */
     OP_ecall, /**< RISC-V ecall opcode. */
-    OP_l,     /**< RISC-V load opcode. */
-    OP_s,     /**< RISC-V store opcode. */
+    OP_l,     /**< RISC-V integer load opcode. Width is encoded in operand sizes. */
+    OP_s,     /**< RISC-V integer store opcode. Width is encoded in operand sizes. */
     OP_add,   /**< RISC-V add opcode. */
     OP_addi,  /**< RISC-V addi opcode. */
     OP_sub,   /**< RISC-V sub opcode. */
@@ -75,7 +72,13 @@ enum {
     OP_bgeu,  /**< RISC-V bgeu opcode. */
     OP_hint,  /**< RISC-V hint opcode. */
 
+#if defined(RISCV_ISA_F) || defined(RISCV_ISA_D)
+    OP_fl, /**< RISC-V FP load opcode. Width is encoded in operand sizes. */
+    OP_fs, /**< RISC-V FP store opcode. Width is encoded in operand sizes. */
+#endif
+
     OP_AFTER_LAST,
+    /* FIXME i#3544: Replace OP_hint with a real opcode. */
     OP_FIRST = OP_hint,          /**< First real opcode. */
     OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */
 };


### PR DESCRIPTION
Add minimal opcode, operand and instruction generation macro definitions
to enable the rest of the code to compile.

NOTE:
  This code is not validated and mostly contains stubs as the main point
  was to achieve compilation and estimate the effort required for the
  port. Some of the trivial logic has been implemented though.

Issue: #3544