### PR TITLE
i#3544 RISC-V, part 3: Add sample stubs

### DIFF
--- a/api/samples/div.c
+++ b/api/samples/div.c
@@ -119,6 +119,11 @@ instr_is_div(instr_t *instr, OUT opnd_t *opnd)
         *opnd = instr_get_src(instr, 1); /* divisor is 2nd src */
         return true;
     }
+#elif defined(RISCV64)
+    if (opc == OP_divu) {
+        *opnd = instr_get_src(instr, 1); /* divisor is 2nd src */
+        return true;
+    }
 #else
 #    error NYI
 #endif

--- a/api/samples/opcodes.c
+++ b/api/samples/opcodes.c
@@ -67,6 +67,8 @@ enum {
     ISA_ARM_THUMB,
 #elif defined(AARCH64)
     ISA_ARM_A64,
+#elif defined(RISCV64)
+    ISA_RV64IMAFDC,
 #endif
     NUM_ISA_MODE,
 };

--- a/api/samples/statecmp.c
+++ b/api/samples/statecmp.c
@@ -115,6 +115,11 @@ event_insert_instru(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
     if (drreg_unreserve_register(drcontext, bb, inst, reg1) != DRREG_SUCCESS ||
         drreg_unreserve_register(drcontext, bb, inst, reg2) != DRREG_SUCCESS)
         return DR_EMIT_DEFAULT;
+#elif defined(RISCV64)
+    /* FIXME i#3544: Not implemented */
+    DR_ASSERT_MSG(false, "Not implemented on RISC-V");
+    /* Marking as unused to silence -Wunused-variable. */
+    (void)global_count;
 #endif
     return DR_EMIT_DEFAULT;
 }


### PR DESCRIPTION
Add definitions required for samples to compile for RISC-V.

NOTE:
  This code is not validated and mostly contains stubs as the main point
  was to achieve compilation and estimate the effort required for the
  port. Some of the trivial logic has been implemented though.

Issue: #3544

Signed-off-by: Stanislaw Kardach <kda@semihalf.com>