### PR TITLE
i#5570: fix visibility of safe read routines.

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4656,7 +4656,7 @@ safe_read_ex(const void *base, size_t size, void *out_buf, size_t *bytes_read)
     }
 }
 
-bool
+DR_EXPORT bool
 safe_read_if_fast(const void *base, size_t size, void *out_buf)
 {
     if (!fault_handling_initialized) {
@@ -4668,7 +4668,7 @@ safe_read_if_fast(const void *base, size_t size, void *out_buf)
 }
 
 /* FIXME - fold this together with safe_read_ex() (is a lot of places to update) */
-bool
+DR_EXPORT bool
 d_r_safe_read(const void *base, size_t size, void *out_buf)
 {
     return safe_read_ex(base, size, out_buf, NULL);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4656,7 +4656,8 @@ safe_read_ex(const void *base, size_t size, void *out_buf, size_t *bytes_read)
     }
 }
 
-DR_EXPORT bool
+DR_EXPORT
+bool
 safe_read_if_fast(const void *base, size_t size, void *out_buf)
 {
     if (!fault_handling_initialized) {
@@ -4668,7 +4669,8 @@ safe_read_if_fast(const void *base, size_t size, void *out_buf)
 }
 
 /* FIXME - fold this together with safe_read_ex() (is a lot of places to update) */
-DR_EXPORT bool
+DR_EXPORT
+bool
 d_r_safe_read(const void *base, size_t size, void *out_buf)
 {
     return safe_read_ex(base, size, out_buf, NULL);


### PR DESCRIPTION
d_r_safe_read and safe_read_if_fast in core/unix/os.c are both non-weak
symbols, but they are not exported.
$ nm --defined ../../lib64/debug/libdynamorio_static.a | grep d_r_safe_read
00000000002962e8 t d_r_safe_read
$ nm --defined ../../lib64/debug/libdynamorio_static.a | grep safe_read_if_fast
0000000000296272 t safe_read_if_fast

This causes drlibc code to use the wrong routines in is_elf_so_header.

On Ubuntu 20, there's a non-readable vsyscall entry in maps. When drlibc
tries to read it, it crashes, and our main_signal_handler isn't able to
recognize it as a safe_read crash.

After this fix, the correct d_r_safe_read is used, which helps the DR
signal handler to recover as intended.

We may need to do the same for other WEAK symbols in drlibc, but we
want to submit this fix first to get our CI green again asap.

Issue: #5570