### PR TITLE
i#5570: Use unhide variant for linking DR statically

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -846,6 +846,9 @@ if (NOT APPLE)
     # Create a version without hidden symbols to support that model.
     # The symbol hiding step is complex and for some toolchains it is simpler
     # to avoid it and count on symbol names preventing collisions (i#3348).
+    # XXX i#5570: Cleanup: rename the following to make it clear that it's the
+    # default variant. Also evaluate which of the static_nohide_api tests we
+    # do not need anymore.
     configure_static_core_lib(dynamorio_static_nohide OFF)
 
     if (LINUX AND READELF_EXECUTABLE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -842,7 +842,7 @@ endfunction()
 # XXX i#1997: not fully supported on Mac yet
 if (NOT APPLE)
   configure_static_core_lib(dynamorio_static ON)
-  if (UNIX AND BUILD_TESTS)
+  if (UNIX)
     # Create a version without hidden symbols to support that model.
     # The symbol hiding step is complex and for some toolchains it is simpler
     # to avoid it and count on symbol names preventing collisions (i#3348).

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1112,7 +1112,11 @@ function (configure_DynamoRIO_static target)
   # For the weakly linked routines defined in drlibc, we want to use DR's
   # definitions instead. So we use dynamorio_static_nohide, which does not hide
   # its symbols for static binary building.
-  target_link_libraries(${target} dynamorio_static_nohide)
+  if (UNIX)
+    target_link_libraries(${target} dynamorio_static_nohide)
+  else (UNIX)
+    target_link_libraries(${target} dynamorio_static)
+  endif (UNIX)
   if (UNIX AND NOT APPLE) # --as-needed not supported by Mac ld
     # i#2070: avoid pulling libdynamorio.so
     # Assuming LINK_FLAGS goes before target_link_libraries.

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1111,7 +1111,10 @@ function (configure_DynamoRIO_static target)
   target_link_libraries(${target} ${static_libc})
   # For the weakly linked routines defined in drlibc, we want to use DR's
   # definitions when available. So we use dynamorio_static_nohide, which does
-  # not hide its symbols, for building static binaries.
+  # not hide its symbols, for building static binaries. There are downsides that
+  # we have to live with, including pushing our many global symbols into the app
+  # namespace. We have renamed some of the ones that are more likely to collide
+  # in #3348.
   if (UNIX)
     target_link_libraries(${target} dynamorio_static_nohide)
   else (UNIX)

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1109,7 +1109,10 @@ function (configure_DynamoRIO_static target)
   # We need libc before the ntdll_imports pulled in for DR.
   _DR_get_static_libc_list(static_libc)
   target_link_libraries(${target} ${static_libc})
-  target_link_libraries(${target} dynamorio_static)
+  # For the weakly linked routines defined in drlibc, we want to use DR's
+  # definitions instead. So we use dynamorio_static_nohide, which does not hide
+  # its symbols for static binary building.
+  target_link_libraries(${target} dynamorio_static_nohide)
   if (UNIX AND NOT APPLE) # --as-needed not supported by Mac ld
     # i#2070: avoid pulling libdynamorio.so
     # Assuming LINK_FLAGS goes before target_link_libraries.

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1110,11 +1110,12 @@ function (configure_DynamoRIO_static target)
   _DR_get_static_libc_list(static_libc)
   target_link_libraries(${target} ${static_libc})
   # For the weakly linked routines defined in drlibc, we want to use DR's
-  # definitions instead. So we use dynamorio_static_nohide, which does not hide
-  # its symbols for static binary building.
+  # definitions when available. So we use dynamorio_static_nohide, which does
+  # not hide its symbols, for building static binaries.
   if (UNIX)
     target_link_libraries(${target} dynamorio_static_nohide)
   else (UNIX)
+    # Non-Unix does not build the nohide version anyway.
     target_link_libraries(${target} dynamorio_static)
   endif (UNIX)
   if (UNIX AND NOT APPLE) # --as-needed not supported by Mac ld


### PR DESCRIPTION
Switches to dynamorio_static_unhide for configuring static DR so
that DR's symbols are visible when building static binaries.

Various symbols in dynamorio_static, like d_r_safe_read and
safe_read_if_fast in core/unix/os.c are non-weak symbols, but
they are not exported by the static DR library because we use
`--localize_hidden` during build.

$ nm --defined ../../lib64/debug/libdynamorio_static.a | grep d_r_safe_read
00000000002962e8 t d_r_safe_read
$ nm --defined ../../lib64/debug/libdynamorio_static.a | grep safe_read_if_fast
0000000000296272 t safe_read_if_fast

This causes drlibc code to use the wrong routines in is_elf_so_header.
The same would happen for other weakly linked routines in drlibc which
are actually supposed to be suppressed by their respective DR
definitions.

There's an existing version of static DR, libdynamorio_static_nohide,
which does not use `--localize_hidden`. Now, we use that instead
while configuring static DR.

This issue revealed itself on the recent Ubuntu 20 update which has a
non-readable vsyscall entry in maps. When drlibc tries to read it, it crashes,
and our main_signal_handler isn't able to recognize it as a safe_read crash
because the incorrect d_r_safe read is used. After this fix, the correct one
is used, which helps the DR signal handler to recover as intended.

Some cleanup will follow in the next PR: renaming the nohide version to
make it clear that it is the default, evaluating whether we still need the
static_nohide_api tests.

Issue: #5570