### PR TITLE
i#2626: AArch64 v8.2 codec: fix FMLAL/FMLSL instructions

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -159,7 +159,7 @@ proc_has_feature(feature_bit_t f)
      */
 #    if defined(BUILD_TESTS)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
-        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR)
+        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR || f == FEATURE_FHM)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -403,14 +403,10 @@ x001111001011001xxxxxxxxxxxxxxxx  n   126  BASE     fcvtzu            wx0 : d5 s
 0x0011111xxxxxxx0001x0xxxxxxxxxx  n   141  BASE       fmla            dq0 : dq0 dq5 dq16 vindex_SD sd_sz
 0101111110xxxxxx0001x0xxxxxxxxxx  n   141  BASE       fmla             s0 : s0 s5 dq16 vindex_SD sd_sz
 0101111111xxxxxx0001x0xxxxxxxxxx  n   141  BASE       fmla             d0 : d0 d5 dq16 vindex_SD sd_sz
-0x001110001xxxxx111011xxxxxxxxxx  n   142  BASE      fmlal            dq0 : dq0 dq5 dq16
-0x101110001xxxxx110011xxxxxxxxxx  n   143  BASE     fmlal2            dq0 : dq0 dq5 dq16
 0x0011111xxxxxxx0101x0xxxxxxxxxx  n   144  BASE       fmls            dq0 : dq5 dq16 vindex_SD sd_sz
 0x0011101x1xxxxx110011xxxxxxxxxx  n   144  BASE       fmls            dq0 : dq0 dq5 dq16 sd_sz
 0101111110xxxxxx0101x0xxxxxxxxxx  n   144  BASE       fmls             s0 : s0 s5 dq16 vindex_SD sd_sz
 0101111111xxxxxx0101x0xxxxxxxxxx  n   144  BASE       fmls             d0 : d0 d5 dq16 vindex_SD sd_sz
-0x001110101xxxxx111011xxxxxxxxxx  n   145  BASE      fmlsl            dq0 : dq0 dq5 dq16
-0x101110101xxxxx110011xxxxxxxxxx  n   146  BASE     fmlsl2            dq0 : dq0 dq5 dq16
 00011110001xxxxxxxx10000000xxxxx  n   147  BASE       fmov             s0 : fpimm13
 00011110011xxxxxxxx10000000xxxxx  n   147  BASE       fmov             d0 : fpimm13
 0001111000100111000000xxxxxxxxxx  n   147  BASE       fmov             s0 : w5

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -105,8 +105,12 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16  fcvtnu  wx0 : h5
 0x101110110xxxxx001101xxxxxxxxxx  n   139  FP16   fminp  dq0 : dq5 dq16 h_sz
 0x00111010110000111110xxxxxxxxxx  n   140  FP16   fminv   h0 : dq5 h_sz
 0x001110010xxxxx000011xxxxxxxxxx  n   141  FP16    fmla  dq0 : dq0 dq5 dq16 h_sz
+0x001110001xxxxx111011xxxxxxxxxx  n   142   FHM   fmlal  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+0x101110001xxxxx110011xxxxxxxxxx  n   143   FHM  fmlal2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
 0x001110110xxxxx000011xxxxxxxxxx  n   144  FP16    fmls  dq0 : dq0 dq5 dq16 h_sz
 0x00111100xxxxxx0101x0xxxxxxxxxx  n   144  FP16    fmls  dq0 : dq5 dq16_h_sz vindex_H h_sz
+0x001110101xxxxx111011xxxxxxxxxx  n   145   FHM   fmlsl  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+0x101110101xxxxx110011xxxxxxxxxx  n   146   FHM  fmlsl2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
 00011110111xxxxxxxx10000000xxxxx  n   147  FP16    fmov   h0 : fpimm13
 0001111011100111000000xxxxxxxxxx  n   147  FP16    fmov   h0 : w5
 1001111011100111000000xxxxxxxxxx  n   147  FP16    fmov   h0 : x5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1232,8 +1232,9 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlal_vector(dc, Rd, Rm, Rn) \
-    instr_create_1dst_3src(dc, OP_fmlal, Rd, Rd, Rm, Rn)
+#define INSTR_CREATE_fmlal_vector(dc, Rd, Rm, Rn)                              \
+    instr_create_1dst_5src(dc, OP_fmlal, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
+                           OPND_CREATE_HALF())
 
 /**
  * Creates a FMAX vector instruction.
@@ -1322,8 +1323,9 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlsl_vector(dc, Rd, Rm, Rn) \
-    instr_create_1dst_3src(dc, OP_fmlsl, Rd, Rd, Rm, Rn)
+#define INSTR_CREATE_fmlsl_vector(dc, Rd, Rm, Rn)                              \
+    instr_create_1dst_5src(dc, OP_fmlsl, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
+                           OPND_CREATE_HALF())
 
 /**
  * Creates a FMIN vector instruction.
@@ -1699,8 +1701,9 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlal2_vector(dc, Rd, Rm, Rn) \
-    instr_create_1dst_3src(dc, OP_fmlal2, Rd, Rd, Rm, Rn)
+#define INSTR_CREATE_fmlal2_vector(dc, Rd, Rm, Rn)                              \
+    instr_create_1dst_5src(dc, OP_fmlal2, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
+                           OPND_CREATE_HALF())
 
 /**
  * Creates a FADDP vector instruction.
@@ -1813,8 +1816,9 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlsl2_vector(dc, Rd, Rm, Rn) \
-    instr_create_1dst_3src(dc, OP_fmlsl2, Rd, Rd, Rm, Rn)
+#define INSTR_CREATE_fmlsl2_vector(dc, Rd, Rm, Rn)                              \
+    instr_create_1dst_5src(dc, OP_fmlsl2, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
+                           OPND_CREATE_HALF())
 
 /**
  * Creates a FABD vector instruction.

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -68,6 +68,7 @@
 --------------------------------  h_sz       # element width of FP vector reg, used to
                                              # distinguish FP16 and float/double encs
 --------------------------------  b_const_sz # as above, but for byte width
+--------------------------------  h_const_sz # as above, but for half width
 --------------------------------  s_const_sz # as above, but for single width
 --------------------------------  d_const_sz # as above, but for double width
 --------------------------------  vindex_D1  # An implicit index, at index 1
@@ -200,6 +201,7 @@
 -?---------xxxxx????------------  x16imm     # computes immed from 30 and 15:12
 -x------------------------------  index3     # index of D subreg in Q: 0-1
 -x-------------------------xxxxx  dq0        # Q register if bit 30 is set, else D
+-x-------------------------xxxxx  sd0        # D register if bit 30 is set, else S
 -x-------------------------xxxxx  dq0p1      # ... add 1
 -x-------------------------xxxxx  dq0p2      # ... add 2
 -x-------------------------xxxxx  dq0p3      # ... add 3
@@ -208,12 +210,14 @@
 -x-------------------------xxxxx  vt2        # ... add 2
 -x-------------------------xxxxx  vt3        # ... add 3
 -x--------------------xxxxx-----  dq5        # Q register if bit 30 is set, else D
+-x--------------------xxxxx-----  sd5        # D register if bit 30 is set, else S
 -x-----------------x------------  index2     # index of S subreg in Q: 0-3
 -x-----------------xx-----------  index1     # index of H subreg in Q: 0-7
 -x-----------------xxx----------  index0     # index of B subreg in Q: 0-15
 -x--------------????--xxxxx-----  memvm      # computes multiplier from 15:12
 -x----------xxxx----------------  dq16_h_sz # Q register (0-15) if bit 30 is set, else D
 -x---------xxxxx----------------  dq16       # Q register if bit 30 is set, else D
+-x---------xxxxx----------------  sd16       # D register if bit 30 is set, else S
 ?---------------xxxxxx----------  imm6       # shift amount
 ?---------------xxxxxx----------  imms       # bitfield immediate, checks 31
 ?---------xxxxxx----------------  immr       # bitfield immediate, checks 31

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -2877,16 +2877,6 @@ test_asimdsame(void *dc)
                                       opnd_create_reg(DR_REG_Q0), OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fcmeq, instr);
 
-    instr = INSTR_CREATE_fmlal_vector(dc, opnd_create_reg(DR_REG_D0),
-                                      opnd_create_reg(DR_REG_D29),
-                                      opnd_create_reg(DR_REG_D31));
-    test_instr_encoding(dc, OP_fmlal, instr);
-
-    instr = INSTR_CREATE_fmlal_vector(dc, opnd_create_reg(DR_REG_Q0),
-                                      opnd_create_reg(DR_REG_Q29),
-                                      opnd_create_reg(DR_REG_Q31));
-    test_instr_encoding(dc, OP_fmlal, instr);
-
     instr = INSTR_CREATE_fmax_vector(dc, opnd_create_reg(DR_REG_D2),
                                      opnd_create_reg(DR_REG_D21),
                                      opnd_create_reg(DR_REG_D20), OPND_CREATE_SINGLE());
@@ -2982,15 +2972,6 @@ test_asimdsame(void *dc)
                                      opnd_create_reg(DR_REG_Q26), OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fsub, instr);
 
-    instr = INSTR_CREATE_fmlsl_vector(dc, opnd_create_reg(DR_REG_D0),
-                                      opnd_create_reg(DR_REG_D29),
-                                      opnd_create_reg(DR_REG_D31));
-    test_instr_encoding(dc, OP_fmlsl, instr);
-
-    instr = INSTR_CREATE_fmlsl_vector(dc, opnd_create_reg(DR_REG_Q0),
-                                      opnd_create_reg(DR_REG_Q29),
-                                      opnd_create_reg(DR_REG_Q31));
-    test_instr_encoding(dc, OP_fmlsl, instr);
 
     instr = INSTR_CREATE_fmin_vector(dc, opnd_create_reg(DR_REG_D22),
                                      opnd_create_reg(DR_REG_D24),
@@ -3737,16 +3718,6 @@ test_asimdsame(void *dc)
         opnd_create_reg(DR_REG_Q29), OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fmaxnmp, instr);
 
-    instr = INSTR_CREATE_fmlal2_vector(dc, opnd_create_reg(DR_REG_D0),
-                                       opnd_create_reg(DR_REG_D29),
-                                       opnd_create_reg(DR_REG_D31));
-    test_instr_encoding(dc, OP_fmlal2, instr);
-
-    instr = INSTR_CREATE_fmlal2_vector(dc, opnd_create_reg(DR_REG_Q0),
-                                       opnd_create_reg(DR_REG_Q29),
-                                       opnd_create_reg(DR_REG_Q31));
-    test_instr_encoding(dc, OP_fmlal2, instr);
-
     instr = INSTR_CREATE_faddp_vector(dc, opnd_create_reg(DR_REG_D18),
                                       opnd_create_reg(DR_REG_D31),
                                       opnd_create_reg(DR_REG_D16), OPND_CREATE_SINGLE());
@@ -3871,16 +3842,6 @@ test_asimdsame(void *dc)
         dc, opnd_create_reg(DR_REG_Q23), opnd_create_reg(DR_REG_Q18),
         opnd_create_reg(DR_REG_Q11), OPND_CREATE_DOUBLE());
     test_instr_encoding(dc, OP_fminnmp, instr);
-
-    instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(DR_REG_D0),
-                                       opnd_create_reg(DR_REG_D29),
-                                       opnd_create_reg(DR_REG_D31));
-    test_instr_encoding(dc, OP_fmlsl2, instr);
-
-    instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(DR_REG_Q0),
-                                       opnd_create_reg(DR_REG_Q29),
-                                       opnd_create_reg(DR_REG_Q31));
-    test_instr_encoding(dc, OP_fmlsl2, instr);
 
     instr = INSTR_CREATE_fabd_vector(dc, opnd_create_reg(DR_REG_D15),
                                      opnd_create_reg(DR_REG_D10),

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -318,8 +318,6 @@ fmulx  %q22 %q20 $0x03 -> %q30
 fcmeq  %d14 %d0 $0x02 -> %d27
 fcmeq  %q14 %q0 $0x02 -> %q27
 fcmeq  %q14 %q0 $0x03 -> %q27
-fmlal  %d0 %d29 %d31 -> %d0
-fmlal  %q0 %q29 %q31 -> %q0
 fmax   %d21 %d20 $0x02 -> %d2
 fmax   %q21 %q20 $0x02 -> %q2
 fmax   %q21 %q20 $0x03 -> %q2
@@ -339,8 +337,6 @@ fmls   %q4 %q31 %q29 $0x03 -> %q4
 fsub   %d8 %d26 $0x02 -> %d25
 fsub   %q8 %q26 $0x02 -> %q25
 fsub   %q8 %q26 $0x03 -> %q25
-fmlsl  %d0 %d29 %d31 -> %d0
-fmlsl  %q0 %q29 %q31 -> %q0
 fmin   %d24 %d31 $0x02 -> %d22
 fmin   %q24 %q31 $0x02 -> %q22
 fmin   %q24 %q31 $0x03 -> %q22
@@ -490,8 +486,6 @@ sqrdmulh %q29 %q27 $0x02 -> %q23
 fmaxnmp %d18 %d29 $0x02 -> %d12
 fmaxnmp %q18 %q29 $0x02 -> %q12
 fmaxnmp %q18 %q29 $0x03 -> %q12
-fmlal2 %d0 %d29 %d31 -> %d0
-fmlal2 %q0 %q29 %q31 -> %q0
 faddp  %d31 %d16 $0x02 -> %d18
 faddp  %q31 %q16 $0x02 -> %q18
 faddp  %q31 %q16 $0x03 -> %q18
@@ -517,8 +511,6 @@ bsl    %q4 %q25 -> %q20
 fminnmp %d18 %d11 $0x02 -> %d23
 fminnmp %q18 %q11 $0x02 -> %q23
 fminnmp %q18 %q11 $0x03 -> %q23
-fmlsl2 %d0 %d29 %d31 -> %d0
-fmlsl2 %q0 %q29 %q31 -> %q0
 fabd   %d10 %d19 $0x02 -> %d15
 fabd   %q10 %q19 $0x02 -> %q15
 fabd   %q10 %q19 $0x03 -> %q15

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1126,6 +1126,202 @@ TEST_INSTR(frintz_scalar)
     return success;
 }
 
+/*
+ * FMLAL
+ */
+
+TEST_INSTR(fmlal_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLAL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb> */
+
+    /* FMLAL <Vd>.2S, <Vn>.2H, <Vm>.2H */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    const char *expected_0[3] = {
+        "fmlal  %d0 %s1 %s0 $0x02 $0x01 -> %d0",
+        "fmlal  %d10 %s11 %s10 $0x02 $0x01 -> %d10",
+        "fmlal  %d31 %s30 %s31 $0x02 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fmlal_vector(dc, opnd_create_reg(Rd_0[i]),
+                                      opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]));
+        if (!test_instr_encoding(dc, OP_fmlal, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FMLAL <Vd>.4S, <Vn>.4H, <Vm>.4H */
+    reg_id_t Rd_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
+    reg_id_t Rm_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    const char *expected_1[3] = {
+        "fmlal  %q0 %d1 %d0 $0x02 $0x01 -> %q0",
+        "fmlal  %q10 %d11 %d10 $0x02 $0x01 -> %q10",
+        "fmlal  %q31 %d30 %d31 $0x02 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fmlal_vector(dc, opnd_create_reg(Rd_1[i]),
+                                      opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
+        if (!test_instr_encoding(dc, OP_fmlal, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+/*
+ * FMLAL2
+ */
+
+TEST_INSTR(fmlal2_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLAL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb> */
+
+    /* FMLAL2 <Vd>.2S, <Vn>.2H, <Vm>.2H */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S2, DR_REG_S12, DR_REG_S29 };
+    const char *expected_0[3] = {
+        "fmlal2 %d0 %s1 %s2 $0x02 $0x01 -> %d0",
+        "fmlal2 %d10 %s11 %s12 $0x02 $0x01 -> %d10",
+        "fmlal2 %d31 %s30 %s29 $0x02 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlal2_vector(dc, opnd_create_reg(Rd_0[i]),
+                                           opnd_create_reg(Rn_0[i]),
+                                           opnd_create_reg(Rm_0[i]));
+        if (!test_instr_encoding(dc, OP_fmlal2, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FMLAL2 <Vd>.4S, <Vn>.4H, <Vm>.4H */
+    reg_id_t Rd_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
+    reg_id_t Rm_1[3] = { DR_REG_D2, DR_REG_D12, DR_REG_D29 };
+    const char *expected_1[3] = {
+        "fmlal2 %q0 %d1 %d2 $0x02 $0x01 -> %q0",
+        "fmlal2 %q10 %d11 %d12 $0x02 $0x01 -> %q10",
+        "fmlal2 %q31 %d30 %d29 $0x02 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlal2_vector(dc, opnd_create_reg(Rd_1[i]),
+                                           opnd_create_reg(Rn_1[i]),
+                                           opnd_create_reg(Rm_1[i]));
+        if (!test_instr_encoding(dc, OP_fmlal2, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+/*
+ * FMLSL
+ */
+
+TEST_INSTR(fmlsl_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLSL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb> */
+
+    /* FMLSL <Vd>.2S, <Vn>.2H, <Vm>.2H */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S2, DR_REG_S12, DR_REG_S29 };
+    const char *expected_0[3] = {
+        "fmlsl  %d0 %s1 %s2 $0x02 $0x01 -> %d0",
+        "fmlsl  %d10 %s11 %s12 $0x02 $0x01 -> %d10",
+        "fmlsl  %d31 %s30 %s29 $0x02 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fmlsl_vector(dc, opnd_create_reg(Rd_0[i]),
+                                      opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]));
+        if (!test_instr_encoding(dc, OP_fmlsl, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FMLSL <Vd>.4S, <Vn>.4H, <Vm>.4H */
+    reg_id_t Rd_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
+    reg_id_t Rm_1[3] = { DR_REG_D2, DR_REG_D12, DR_REG_D29 };
+    const char *expected_1[3] = {
+        "fmlsl  %q0 %d1 %d2 $0x02 $0x01 -> %q0",
+        "fmlsl  %q10 %d11 %d12 $0x02 $0x01 -> %q10",
+        "fmlsl  %q31 %d30 %d29 $0x02 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fmlsl_vector(dc, opnd_create_reg(Rd_1[i]),
+                                      opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
+        if (!test_instr_encoding(dc, OP_fmlsl, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+/*
+ * FMLSL2
+ */
+
+TEST_INSTR(fmlsl2_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLSL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb> */
+
+    /* FMLSL2 <Vd>.2S, <Vn>.2H, <Vm>.2H */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S2, DR_REG_S12, DR_REG_S29 };
+    const char *expected_0[3] = {
+        "fmlsl2 %d0 %s1 %s2 $0x02 $0x01 -> %d0",
+        "fmlsl2 %d10 %s11 %s12 $0x02 $0x01 -> %d10",
+        "fmlsl2 %d31 %s30 %s29 $0x02 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(Rd_0[i]),
+                                           opnd_create_reg(Rn_0[i]),
+                                           opnd_create_reg(Rm_0[i]));
+        if (!test_instr_encoding(dc, OP_fmlsl2, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FMLSL2 <Vd>.4S, <Vn>.4H, <Vm>.4H */
+    reg_id_t Rd_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
+    reg_id_t Rm_1[3] = { DR_REG_D2, DR_REG_D12, DR_REG_D29 };
+    const char *expected_1[3] = {
+        "fmlsl2 %q0 %d1 %d2 $0x02 $0x01 -> %q0",
+        "fmlsl2 %q10 %d11 %d12 $0x02 $0x01 -> %q10",
+        "fmlsl2 %q31 %d30 %d29 $0x02 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(Rd_1[i]),
+                                           opnd_create_reg(Rn_1[i]),
+                                           opnd_create_reg(Rm_1[i]));
+        if (!test_instr_encoding(dc, OP_fmlsl2, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1164,6 +1360,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(frintx_scalar);
     RUN_INSTR_TEST(frintz_vector);
     RUN_INSTR_TEST(frintz_scalar);
+
+    RUN_INSTR_TEST(fmlal_vector);
+    RUN_INSTR_TEST(fmlal2_vector);
+    RUN_INSTR_TEST(fmlsl_vector);
+    RUN_INSTR_TEST(fmlsl2_vector);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch fixes current implementations of the floating-point fused
multiply-add/subtract long to/from accumulator instructions.
```
FMLAL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb>
FMLAL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb>
FMLSL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb>
FMLSL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb>
```
Issue: #2626
