### PR TITLE
Add cross-line counting to histogram tool

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -616,6 +616,14 @@ if (BUILD_TESTS)
     add_test(NAME tool.drcacheoff.view_test
       COMMAND tool.drcacheoff.view_test)
 
+    add_executable(tool.drcachesim.histogram_test
+      tools/histogram.cpp tests/histogram_test.cpp)
+    target_link_libraries(tool.drcachesim.histogram_test
+      drmemtrace_static drmemtrace_analyzer)
+    add_win32_flags(tool.drcachesim.histogram_test)
+    add_test(NAME tool.drcachesim.histogram_test
+             COMMAND tool.drcachesim.histogram_test)
+
     add_executable(tool.drcacheoff.burst_static tests/burst_static.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_static)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_static drmemtrace_static)

--- a/clients/drcachesim/tests/histogram_test.cpp
+++ b/clients/drcachesim/tests/histogram_test.cpp
@@ -1,0 +1,92 @@
+/* **********************************************************
+ * Copyright (c) 2021-2022 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Test for checks performed by invariant_checker_t that are not tested
+ * by the signal_invariants app's prefetch and handler markers.
+ * This looks for precise error strings from invariant_checker.cpp: but
+ * we will notice if the literals get out of sync as the test will fail.
+ */
+
+#include <iostream>
+#include <vector>
+
+#include "../tools/histogram.h"
+#include "../common/memref.h"
+#include "memref_gen.h"
+
+namespace {
+
+bool
+check_cross_line()
+{
+    static constexpr unsigned int LINE_SIZE = 64;
+    histogram_t tool(LINE_SIZE, 0, 0);
+    std::vector<memref_t> memrefs = {
+        gen_instr(1, 20 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 10 * LINE_SIZE, 8),
+        gen_instr(1, 21 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 11 * LINE_SIZE, 8),
+        gen_instr(1, 22 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 12 * LINE_SIZE, 8),
+        // Test repeated lines: should not affect unique.
+        gen_instr(1, 20 * LINE_SIZE),
+        gen_data(1, /*load=*/true, 10 * LINE_SIZE, 8),
+        // Test crossing a cache line.
+        gen_data(1, /*load=*/false, 30 * LINE_SIZE - 4, 8),
+        gen_data(1, /*load=*/false, 40 * LINE_SIZE - 4, LINE_SIZE + 5),
+        gen_instr(1, 50 * LINE_SIZE - 3, 4),
+    };
+    for (const auto &memref : memrefs) {
+        tool.process_memref(memref);
+    }
+    uint64_t unique_icache_lines, unique_dcache_lines;
+    tool.reduce_results(&unique_icache_lines, &unique_dcache_lines);
+    if (unique_icache_lines != 5 || unique_dcache_lines != 8) {
+        std::cerr << "got incorrect icache " << unique_icache_lines << ", dcache "
+                  << unique_dcache_lines << "\n";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int
+main(int argc, const char *argv[])
+{
+    if (check_cross_line()) {
+        std::cerr << "histogram_test passed\n";
+        return 0;
+    }
+    std::cerr << "histogram_test FAILED\n";
+    exit(1);
+}

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2022 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,20 +49,20 @@ gen_data(memref_tid_t tid, bool load, addr_t addr, size_t size)
 }
 
 inline memref_t
-gen_instr_type(trace_type_t type, memref_tid_t tid, addr_t pc)
+gen_instr_type(trace_type_t type, memref_tid_t tid, addr_t pc, size_t size = 1)
 {
     memref_t memref = {};
     memref.instr.type = type;
     memref.instr.tid = tid;
     memref.instr.addr = pc;
-    memref.instr.size = 1;
+    memref.instr.size = size;
     return memref;
 }
 
 inline memref_t
-gen_instr(memref_tid_t tid, addr_t pc)
+gen_instr(memref_tid_t tid, addr_t pc, size_t size = 1)
 {
-    return gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
+    return gen_instr_type(TRACE_TYPE_INSTR, tid, pc, size);
 }
 
 inline memref_t

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -66,6 +66,11 @@ public:
     std::string
     parallel_shard_error(void *shard_data) override;
 
+    // This is public, with output parameters, for test use.
+    virtual bool
+    reduce_results(uint64_t *unique_icache_lines = nullptr,
+                   uint64_t *unique_dcache_lines = nullptr);
+
 protected:
     struct shard_data_t {
         std::unordered_map<addr_t, uint64_t> icache_map;
@@ -82,6 +87,8 @@ protected:
     // shard_map (process_memref, print_results) we are single-threaded.
     std::mutex shard_map_mutex_;
     shard_data_t serial_shard_;
+    // The combined data from all the shards.
+    shard_data_t reduced_;
 };
 
 #endif /* _HISTOGRAM_H_ */


### PR DESCRIPTION
Augments the histogram drcachesim tool to count every line a
cross-line access touches.  Previously it would incorrectly only
consider the first line.

Adds a test with synthetic test cases.