### PR TITLE
i#2626: AArch64 v8.2 codec: Add SM3/4 instructions

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -159,8 +159,8 @@ proc_has_feature(feature_bit_t f)
      */
 #    if defined(BUILD_TESTS)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
-        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR || f == FEATURE_FHM ||
-        f == FEATURE_SM3 || f == FEATURE_SM4)
+        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR ||
+        f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -159,7 +159,8 @@ proc_has_feature(feature_bit_t f)
      */
 #    if defined(BUILD_TESTS)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
-        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR || f == FEATURE_FHM)
+        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR || f == FEATURE_FHM ||
+        f == FEATURE_SM3 || f == FEATURE_SM4)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -513,9 +513,9 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
 static inline reg_id_t
 decode_reg(uint n, bool is_x, bool is_sp)
 {
-    return (n < 31      ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
-                : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
-                        : (is_x ? DR_REG_XZR : DR_REG_WZR));
+    return (n < 31 ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
+                   : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
+                           : (is_x ? DR_REG_XZR : DR_REG_WZR));
 }
 
 /* Encode integer register. */

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -513,9 +513,9 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
 static inline reg_id_t
 decode_reg(uint n, bool is_x, bool is_sp)
 {
-    return (n < 31 ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
-                   : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
-                           : (is_x ? DR_REG_XZR : DR_REG_WZR));
+    return (n < 31      ? (is_x ? DR_REG_X0 : DR_REG_W0) + n
+                : is_sp ? (is_x ? DR_REG_XSP : DR_REG_WSP)
+                        : (is_x ? DR_REG_XZR : DR_REG_WZR));
 }
 
 /* Encode integer register. */
@@ -1979,6 +1979,23 @@ encode_opnd_cmode_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     opnd = opnd_create_immed_uint(cmode, OPSZ_1b);
     encode_opnd_int(13, 1, false, false, 0, opnd, enc_out);
     return true;
+}
+
+/* imm2 encoded in bits 13-12 */
+static inline bool
+decode_opnd_imm2idx(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    uint value = extract_uint(enc, 12, 2);
+    *opnd = opnd_create_immed_uint(value, OPSZ_2b);
+    return true;
+}
+
+static inline bool
+encode_opnd_imm2idx(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+    return encode_opnd_int(12, 2, false, 0, 0, opnd, enc_out);
 }
 
 /* p10_low: P register at bit position 10; P0-P7 */

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -34,111 +34,120 @@
 
 # Instruction definitions:
 
-0x101110110xxxxx000101xxxxxxxxxx  n   94   FP16    fabd  dq0 : dq5 dq16 h_sz
-01111110110xxxxx000101xxxxxxxxxx  n   94   FP16    fabd   h0 : h5 h16
-0x00111011111000111110xxxxxxxxxx  n   95   FP16    fabs  dq0 : dq5 h_sz
-0x101110010xxxxx001011xxxxxxxxxx  n   96   FP16   facge  dq0 : dq5 dq16 h_sz
-0x101110110xxxxx001011xxxxxxxxxx  n   97   FP16   facgt  dq0 : dq5 dq16 h_sz
-0x001110010xxxxx000101xxxxxxxxxx  n   98   FP16    fadd  dq0 : dq5 dq16 h_sz
-0x101110010xxxxx000101xxxxxxxxxx  n   99   FP16   faddp  dq0 : dq5 dq16 h_sz
-0101111000110000110110xxxxxxxxxx  n   99   FP16   faddp   h0 : q5 h_sz
-0x001110010xxxxx001001xxxxxxxxxx  n   102  FP16   fcmeq  dq0 : dq5 dq16 h_sz
-0x00111011111000110110xxxxxxxxxx  n   102  FP16   fcmeq  dq0 : dq5 zero_fp_const h_sz
-0101111011111000110110xxxxxxxxxx  n   102  FP16   fcmeq   h0 : h5 zero_fp_const
-0x101110010xxxxx001001xxxxxxxxxx  n   103  FP16   fcmge  dq0 : dq5 dq16 h_sz
-0x10111011111000110010xxxxxxxxxx  n   103  FP16   fcmge  dq0 : dq5 zero_fp_const h_sz
-0111111011111000110010xxxxxxxxxx  n   103  FP16   fcmge   h0 : h5 zero_fp_const
-0x101110110xxxxx001001xxxxxxxxxx  n   104  FP16   fcmgt  dq0 : dq5 dq16 h_sz
-0x00111011111000110010xxxxxxxxxx  n   104  FP16   fcmgt  dq0 : dq5 zero_fp_const h_sz
-0101111011111000110010xxxxxxxxxx  n   104  FP16   fcmgt   h0 : h5 zero_fp_const
-0111111011111000110110xxxxxxxxxx  n   105  FP16   fcmle   h0 : h5 zero_fp_const
-0101111011111000111010xxxxxxxxxx  n   106  FP16   fcmlt   h0 : h5 zero_fp_const
-00011110111xxxxx001000xxxxx10000  w   108  FP16   fcmpe      : h5 h16
-0001111011100000001000xxxxx11000  w   108  FP16   fcmpe      : h5 zero_fp_const
-0001111000100011110000xxxxxxxxxx  n   110  FP16    fcvt   h0 : s5
-0001111001100011110000xxxxxxxxxx  n   110  FP16    fcvt   h0 : d5
-0001111011100010010000xxxxxxxxxx  n   110  FP16    fcvt   s0 : h5
-0001111011100010110000xxxxxxxxxx  n   110  FP16    fcvt   d0 : h5
-0x00111001111001110010xxxxxxxxxx  n   111  FP16  fcvtas  dq0 : dq5 h_sz
-0101111001111001110010xxxxxxxxxx  n   111  FP16  fcvtas   h0 : h5
-0001111011100100000000xxxxxxxxxx  n   111  FP16  fcvtas   w0 : h5
-1001111011100100000000xxxxxxxxxx  n   111  FP16  fcvtas   x0 : h5
-0x10111001111001110010xxxxxxxxxx  n   112  FP16  fcvtau  dq0 : dq5 h_sz
-0111111001111001110010xxxxxxxxxx  n   112  FP16  fcvtau   h0 : h5
-0001111011100101000000xxxxxxxxxx  n   112  FP16  fcvtau   w0 : h5
-1001111011100101000000xxxxxxxxxx  n   112  FP16  fcvtau   x0 : h5
-0x00111001111001101110xxxxxxxxxx  n   115  FP16  fcvtms  dq0 : dq5 h_sz
-0101111001111001101110xxxxxxxxxx  n   115  FP16  fcvtms   h0 : h5
-0001111011110000000000xxxxxxxxxx  n   115  FP16  fcvtms   w0 : h5
-1001111011110000000000xxxxxxxxxx  n   115  FP16  fcvtms   x0 : h5
-x001111011110001000000xxxxxxxxxx  n   116  FP16  fcvtmu  wx0 : h5
-0111111001111001101110xxxxxxxxxx  n   116  FP16  fcvtmu   h0 : h5
-0x00111001111001101010xxxxxxxxxx  n   119  FP16  fcvtns  dq0 : dq5 h_sz
-0101111001111001101010xxxxxxxxxx  n   119  FP16  fcvtns   h0 : h5
-0001111011100000000000xxxxxxxxxx  n   119  FP16  fcvtns   w0 : h5
-1001111011100000000000xxxxxxxxxx  n   119  FP16  fcvtns   x0 : h5
-x001111011100001000000xxxxxxxxxx  n   120  FP16  fcvtnu  wx0 : h5
-0111111001111001101010xxxxxxxxxx  n   120  FP16  fcvtnu   h0 : h5
-0x00111011111001101010xxxxxxxxxx  n   121  FP16  fcvtps  dq0 : dq5 h_sz
-0001111011101000000000xxxxxxxxxx  n   121  FP16  fcvtps   w0 : h5
-1001111011101000000000xxxxxxxxxx  n   121  FP16  fcvtps   x0 : h5
-0101111011111001101010xxxxxxxxxx  n   121  FP16  fcvtps   h0 : h5
-0x10111011111001101010xxxxxxxxxx  n   122  FP16  fcvtpu  dq0 : dq5 h_sz
-0111111011111001101010xxxxxxxxxx  n   122  FP16  fcvtpu   h0 : h5
-0001111011101001000000xxxxxxxxxx  n   122  FP16  fcvtpu   w0 : h5
-1001111011101001000000xxxxxxxxxx  n   122  FP16  fcvtpu   x0 : h5
-0x0011110xxxxxxx111111xxxxxxxxxx  n   125  FP16  fcvtzs  dq0 : dq5 immhb_fxp bhsd_immh_sz
-0x10111011111001101110xxxxxxxxxx  n   126  FP16  fcvtzu  dq0 : dq5 h_sz
-0x1011110xxxxxxx111111xxxxxxxxxx  n   126  FP16  fcvtzu  dq0 : dq5 immhb_fxp bhsd_immh_sz
-0x101110010xxxxx001111xxxxxxxxxx  n   127  FP16    fdiv  dq0 : dq5 dq16 h_sz
-0x001110010xxxxx001101xxxxxxxxxx  n   129  FP16    fmax  dq0 : dq5 dq16 h_sz
-0x001110010xxxxx000001xxxxxxxxxx  n   130  FP16  fmaxnm  dq0 : dq5 dq16 h_sz
-0x101110010xxxxx000001xxxxxxxxxx  n   131  FP16 fmaxnmp  dq0 : dq5 dq16 h_sz
-0x00111000110000110010xxxxxxxxxx  n   132  FP16 fmaxnmv   h0 : dq5 h_sz
-0x101110010xxxxx001101xxxxxxxxxx  n   133  FP16   fmaxp  dq0 : dq5 dq16 h_sz
-0x00111000110000111110xxxxxxxxxx  n   134  FP16   fmaxv   h0 : dq5 h_sz
-0x001110110xxxxx001101xxxxxxxxxx  n   135  FP16    fmin  dq0 : dq5 dq16 h_sz
-0x001110110xxxxx000001xxxxxxxxxx  n   136  FP16  fminnm  dq0 : dq5 dq16 h_sz
-0x101110110xxxxx000001xxxxxxxxxx  n   137  FP16 fminnmp  dq0 : dq5 dq16 h_sz
-0000111010110000110010xxxxxxxxxx  n   138  FP16 fminnmv   h0 : d5
-0100111010110000110010xxxxxxxxxx  n   138  FP16 fminnmv   h0 : q5
-0x101110110xxxxx001101xxxxxxxxxx  n   139  FP16   fminp  dq0 : dq5 dq16 h_sz
-0x00111010110000111110xxxxxxxxxx  n   140  FP16   fminv   h0 : dq5 h_sz
-0x001110010xxxxx000011xxxxxxxxxx  n   141  FP16    fmla  dq0 : dq0 dq5 dq16 h_sz
-0x001110001xxxxx111011xxxxxxxxxx  n   142   FHM   fmlal  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
-0x101110001xxxxx110011xxxxxxxxxx  n   143   FHM  fmlal2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
-0x001110110xxxxx000011xxxxxxxxxx  n   144  FP16    fmls  dq0 : dq0 dq5 dq16 h_sz
-0x00111100xxxxxx0101x0xxxxxxxxxx  n   144  FP16    fmls  dq0 : dq5 dq16_h_sz vindex_H h_sz
-0x001110101xxxxx111011xxxxxxxxxx  n   145   FHM   fmlsl  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
-0x101110101xxxxx110011xxxxxxxxxx  n   146   FHM  fmlsl2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
-00011110111xxxxxxxx10000000xxxxx  n   147  FP16    fmov   h0 : fpimm13
-0001111011100111000000xxxxxxxxxx  n   147  FP16    fmov   h0 : w5
-1001111011100111000000xxxxxxxxxx  n   147  FP16    fmov   h0 : x5
-0x00111100000xxx111111xxxxxxxxxx  n   147  FP16    fmov  dq0 : fpimm8 h_sz
-0x00111100xxxxxx1001x0xxxxxxxxxx  n   149  FP16    fmul  dq0 : dq5 dq16_h_sz vindex_H h_sz
-0101111100xxxxxx1001x0xxxxxxxxxx  n   149  FP16    fmul   h0 : h5 dq16_h_sz vindex_H h_sz
-0x101110010xxxxx000111xxxxxxxxxx  n   149  FP16    fmul  dq0 : dq5 dq16 h_sz
-0x001110010xxxxx000111xxxxxxxxxx  n   150  FP16   fmulx  dq0 : dq5 dq16 h_sz
-0x10111011111000111110xxxxxxxxxx  n   151  FP16    fneg  dq0 : dq5 h_sz
-0101111011111001110110xxxxxxxxxx  n   155  FP16  frecpe   h0 : h5
-0x001110010xxxxx001111xxxxxxxxxx  n   156  FP16  frecps  dq0 : dq5 dq16 h_sz
-0101111011111001111110xxxxxxxxxx  n   157  FP16  frecpx   h0 : h5
-0x10111001111001100010xxxxxxxxxx  n   158  FP16  frinta  dq0 : dq5 h_sz
-0001111011100110010000xxxxxxxxxx  n   158  FP16  frinta   h0 : h5
-0x10111011111001100110xxxxxxxxxx  n   159  FP16  frinti  dq0 : dq5 h_sz
-0001111011100111110000xxxxxxxxxx  n   159  FP16  frinti   h0 : h5
-0x00111001111001100110xxxxxxxxxx  n   160  FP16  frintm  dq0 : dq5 h_sz
-0001111011100101010000xxxxxxxxxx  n   160  FP16  frintm   h0 : h5
-0x00111001111001100010xxxxxxxxxx  n   161  FP16  frintn  dq0 : dq5 h_sz
-0001111011100100010000xxxxxxxxxx  n   161  FP16  frintn   h0 : h5
-0x00111011111001100010xxxxxxxxxx  n   162  FP16  frintp  dq0 : dq5 h_sz
-0001111011100100110000xxxxxxxxxx  n   162  FP16  frintp   h0 : h5
-0x10111001111001100110xxxxxxxxxx  n   163  FP16  frintx  dq0 : dq5 h_sz
-0001111011100111010000xxxxxxxxxx  n   163  FP16  frintx   h0 : h5
-0x00111011111001100110xxxxxxxxxx  n   164  FP16  frintz  dq0 : dq5 h_sz
-0001111011100101110000xxxxxxxxxx  n   164  FP16  frintz   h0 : h5
-0111111011111001110110xxxxxxxxxx  n   165  FP16 frsqrte   h0 : h5
-0x001110110xxxxx001111xxxxxxxxxx  n   166  FP16 frsqrts  dq0 : dq5 dq16 h_sz
-0x001110110xxxxx000101xxxxxxxxxx  n   168  FP16    fsub  dq0 : dq5 dq16 h_sz
-0x001110100xxxxx100101xxxxxxxxxx  n   364  DotProd    sdot  dq0 : dq5 dq16 s_const_sz b_const_sz
-0x101110100xxxxx100101xxxxxxxxxx  n   512  DotProd    udot  dq0 : dq5 dq16 s_const_sz b_const_sz
+0x101110110xxxxx000101xxxxxxxxxx  n   94   FP16      fabd  dq0 : dq5 dq16 h_sz
+01111110110xxxxx000101xxxxxxxxxx  n   94   FP16      fabd   h0 : h5 h16
+0x00111011111000111110xxxxxxxxxx  n   95   FP16      fabs  dq0 : dq5 h_sz
+0x101110010xxxxx001011xxxxxxxxxx  n   96   FP16     facge  dq0 : dq5 dq16 h_sz
+0x101110110xxxxx001011xxxxxxxxxx  n   97   FP16     facgt  dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000101xxxxxxxxxx  n   98   FP16      fadd  dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000101xxxxxxxxxx  n   99   FP16     faddp  dq0 : dq5 dq16 h_sz
+0101111000110000110110xxxxxxxxxx  n   99   FP16     faddp   h0 : q5 h_sz
+0x001110010xxxxx001001xxxxxxxxxx  n   102  FP16     fcmeq  dq0 : dq5 dq16 h_sz
+0x00111011111000110110xxxxxxxxxx  n   102  FP16     fcmeq  dq0 : dq5 zero_fp_const h_sz
+0101111011111000110110xxxxxxxxxx  n   102  FP16     fcmeq   h0 : h5 zero_fp_const
+0x101110010xxxxx001001xxxxxxxxxx  n   103  FP16     fcmge  dq0 : dq5 dq16 h_sz
+0x10111011111000110010xxxxxxxxxx  n   103  FP16     fcmge  dq0 : dq5 zero_fp_const h_sz
+0111111011111000110010xxxxxxxxxx  n   103  FP16     fcmge   h0 : h5 zero_fp_const
+0x101110110xxxxx001001xxxxxxxxxx  n   104  FP16     fcmgt  dq0 : dq5 dq16 h_sz
+0x00111011111000110010xxxxxxxxxx  n   104  FP16     fcmgt  dq0 : dq5 zero_fp_const h_sz
+0101111011111000110010xxxxxxxxxx  n   104  FP16     fcmgt   h0 : h5 zero_fp_const
+0111111011111000110110xxxxxxxxxx  n   105  FP16     fcmle   h0 : h5 zero_fp_const
+0101111011111000111010xxxxxxxxxx  n   106  FP16     fcmlt   h0 : h5 zero_fp_const
+00011110111xxxxx001000xxxxx10000  w   108  FP16     fcmpe      : h5 h16
+0001111011100000001000xxxxx11000  w   108  FP16     fcmpe      : h5 zero_fp_const
+0001111000100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : s5
+0001111001100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : d5
+0001111011100010010000xxxxxxxxxx  n   110  FP16      fcvt   s0 : h5
+0001111011100010110000xxxxxxxxxx  n   110  FP16      fcvt   d0 : h5
+0x00111001111001110010xxxxxxxxxx  n   111  FP16    fcvtas  dq0 : dq5 h_sz
+0101111001111001110010xxxxxxxxxx  n   111  FP16    fcvtas   h0 : h5
+0001111011100100000000xxxxxxxxxx  n   111  FP16    fcvtas   w0 : h5
+1001111011100100000000xxxxxxxxxx  n   111  FP16    fcvtas   x0 : h5
+0x10111001111001110010xxxxxxxxxx  n   112  FP16    fcvtau  dq0 : dq5 h_sz
+0111111001111001110010xxxxxxxxxx  n   112  FP16    fcvtau   h0 : h5
+0001111011100101000000xxxxxxxxxx  n   112  FP16    fcvtau   w0 : h5
+1001111011100101000000xxxxxxxxxx  n   112  FP16    fcvtau   x0 : h5
+0x00111001111001101110xxxxxxxxxx  n   115  FP16    fcvtms  dq0 : dq5 h_sz
+0101111001111001101110xxxxxxxxxx  n   115  FP16    fcvtms   h0 : h5
+0001111011110000000000xxxxxxxxxx  n   115  FP16    fcvtms   w0 : h5
+1001111011110000000000xxxxxxxxxx  n   115  FP16    fcvtms   x0 : h5
+x001111011110001000000xxxxxxxxxx  n   116  FP16    fcvtmu  wx0 : h5
+0111111001111001101110xxxxxxxxxx  n   116  FP16    fcvtmu   h0 : h5
+0x00111001111001101010xxxxxxxxxx  n   119  FP16    fcvtns  dq0 : dq5 h_sz
+0101111001111001101010xxxxxxxxxx  n   119  FP16    fcvtns   h0 : h5
+0001111011100000000000xxxxxxxxxx  n   119  FP16    fcvtns   w0 : h5
+1001111011100000000000xxxxxxxxxx  n   119  FP16    fcvtns   x0 : h5
+x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
+0111111001111001101010xxxxxxxxxx  n   120  FP16    fcvtnu   h0 : h5
+0x00111011111001101010xxxxxxxxxx  n   121  FP16    fcvtps  dq0 : dq5 h_sz
+0001111011101000000000xxxxxxxxxx  n   121  FP16    fcvtps   w0 : h5
+1001111011101000000000xxxxxxxxxx  n   121  FP16    fcvtps   x0 : h5
+0101111011111001101010xxxxxxxxxx  n   121  FP16    fcvtps   h0 : h5
+0x10111011111001101010xxxxxxxxxx  n   122  FP16    fcvtpu  dq0 : dq5 h_sz
+0111111011111001101010xxxxxxxxxx  n   122  FP16    fcvtpu   h0 : h5
+0001111011101001000000xxxxxxxxxx  n   122  FP16    fcvtpu   w0 : h5
+1001111011101001000000xxxxxxxxxx  n   122  FP16    fcvtpu   x0 : h5
+0x0011110xxxxxxx111111xxxxxxxxxx  n   125  FP16    fcvtzs  dq0 : dq5 immhb_fxp bhsd_immh_sz
+0x10111011111001101110xxxxxxxxxx  n   126  FP16    fcvtzu  dq0 : dq5 h_sz
+0x1011110xxxxxxx111111xxxxxxxxxx  n   126  FP16    fcvtzu  dq0 : dq5 immhb_fxp bhsd_immh_sz
+0x101110010xxxxx001111xxxxxxxxxx  n   127  FP16      fdiv  dq0 : dq5 dq16 h_sz
+0x001110010xxxxx001101xxxxxxxxxx  n   129  FP16      fmax  dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000001xxxxxxxxxx  n   130  FP16    fmaxnm  dq0 : dq5 dq16 h_sz
+0x101110010xxxxx000001xxxxxxxxxx  n   131  FP16   fmaxnmp  dq0 : dq5 dq16 h_sz
+0x00111000110000110010xxxxxxxxxx  n   132  FP16   fmaxnmv   h0 : dq5 h_sz
+0x101110010xxxxx001101xxxxxxxxxx  n   133  FP16     fmaxp  dq0 : dq5 dq16 h_sz
+0x00111000110000111110xxxxxxxxxx  n   134  FP16     fmaxv   h0 : dq5 h_sz
+0x001110110xxxxx001101xxxxxxxxxx  n   135  FP16      fmin  dq0 : dq5 dq16 h_sz
+0x001110110xxxxx000001xxxxxxxxxx  n   136  FP16    fminnm  dq0 : dq5 dq16 h_sz
+0x101110110xxxxx000001xxxxxxxxxx  n   137  FP16   fminnmp  dq0 : dq5 dq16 h_sz
+0000111010110000110010xxxxxxxxxx  n   138  FP16   fminnmv   h0 : d5
+0100111010110000110010xxxxxxxxxx  n   138  FP16   fminnmv   h0 : q5
+0x101110110xxxxx001101xxxxxxxxxx  n   139  FP16     fminp  dq0 : dq5 dq16 h_sz
+0x00111010110000111110xxxxxxxxxx  n   140  FP16     fminv   h0 : dq5 h_sz
+0x001110010xxxxx000011xxxxxxxxxx  n   141  FP16      fmla  dq0 : dq0 dq5 dq16 h_sz
+0x001110001xxxxx111011xxxxxxxxxx  n   142  FHM      fmlal  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+0x101110001xxxxx110011xxxxxxxxxx  n   143  FHM     fmlal2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+0x001110110xxxxx000011xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq0 dq5 dq16 h_sz
+0x00111100xxxxxx0101x0xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq5 dq16_h_sz vindex_H h_sz
+0x001110101xxxxx111011xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+0x101110101xxxxx110011xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+00011110111xxxxxxxx10000000xxxxx  n   147  FP16      fmov   h0 : fpimm13
+0001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : w5
+1001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : x5
+0x00111100000xxx111111xxxxxxxxxx  n   147  FP16      fmov  dq0 : fpimm8 h_sz
+0x00111100xxxxxx1001x0xxxxxxxxxx  n   149  FP16      fmul  dq0 : dq5 dq16_h_sz vindex_H h_sz
+0101111100xxxxxx1001x0xxxxxxxxxx  n   149  FP16      fmul   h0 : h5 dq16_h_sz vindex_H h_sz
+0x101110010xxxxx000111xxxxxxxxxx  n   149  FP16      fmul  dq0 : dq5 dq16 h_sz
+0x001110010xxxxx000111xxxxxxxxxx  n   150  FP16     fmulx  dq0 : dq5 dq16 h_sz
+0x10111011111000111110xxxxxxxxxx  n   151  FP16      fneg  dq0 : dq5 h_sz
+0101111011111001110110xxxxxxxxxx  n   155  FP16    frecpe   h0 : h5
+0x001110010xxxxx001111xxxxxxxxxx  n   156  FP16    frecps  dq0 : dq5 dq16 h_sz
+0101111011111001111110xxxxxxxxxx  n   157  FP16    frecpx   h0 : h5
+0x10111001111001100010xxxxxxxxxx  n   158  FP16    frinta  dq0 : dq5 h_sz
+0001111011100110010000xxxxxxxxxx  n   158  FP16    frinta   h0 : h5
+0x10111011111001100110xxxxxxxxxx  n   159  FP16    frinti  dq0 : dq5 h_sz
+0001111011100111110000xxxxxxxxxx  n   159  FP16    frinti   h0 : h5
+0x00111001111001100110xxxxxxxxxx  n   160  FP16    frintm  dq0 : dq5 h_sz
+0001111011100101010000xxxxxxxxxx  n   160  FP16    frintm   h0 : h5
+0x00111001111001100010xxxxxxxxxx  n   161  FP16    frintn  dq0 : dq5 h_sz
+0001111011100100010000xxxxxxxxxx  n   161  FP16    frintn   h0 : h5
+0x00111011111001100010xxxxxxxxxx  n   162  FP16    frintp  dq0 : dq5 h_sz
+0001111011100100110000xxxxxxxxxx  n   162  FP16    frintp   h0 : h5
+0x10111001111001100110xxxxxxxxxx  n   163  FP16    frintx  dq0 : dq5 h_sz
+0001111011100111010000xxxxxxxxxx  n   163  FP16    frintx   h0 : h5
+0x00111011111001100110xxxxxxxxxx  n   164  FP16    frintz  dq0 : dq5 h_sz
+0001111011100101110000xxxxxxxxxx  n   164  FP16    frintz   h0 : h5
+0111111011111001110110xxxxxxxxxx  n   165  FP16   frsqrte   h0 : h5
+0x001110110xxxxx001111xxxxxxxxxx  n   166  FP16   frsqrts  dq0 : dq5 dq16 h_sz
+0x001110110xxxxx000101xxxxxxxxxx  n   168  FP16      fsub  dq0 : dq5 dq16 h_sz
+0x001110100xxxxx100101xxxxxxxxxx  n   364  DotProd      sdot  dq0 : dq5 dq16 s_const_sz b_const_sz
+11001110011xxxxx110000xxxxxxxxxx  n   586  SM3  sm3partw1   q0 : q5 q16 s_const_sz
+11001110011xxxxx110001xxxxxxxxxx  n   587  SM3  sm3partw2   q0 : q5 q16 s_const_sz
+11001110010xxxxx0xxxxxxxxxxxxxxx  n   588  SM3     sm3ss1   q0 : q5 q16 q10 s_const_sz
+11001110010xxxxx10xx00xxxxxxxxxx  n   589  SM3    sm3tt1a   q0 : q5 q16 imm2idx s_const_sz
+11001110010xxxxx10xx01xxxxxxxxxx  n   590  SM3    sm3tt1b   q0 : q5 q16 imm2idx s_const_sz
+11001110010xxxxx10xx10xxxxxxxxxx  n   591  SM3    sm3tt2a   q0 : q5 q16 imm2idx s_const_sz
+11001110010xxxxx10xx11xxxxxxxxxx  n   592  SM3    sm3tt2b   q0 : q5 q16 imm2idx s_const_sz
+1100111011000000100001xxxxxxxxxx  n   593  SM4       sm4e   q0 : q5 s_const_sz
+11001110011xxxxx110010xxxxxxxxxx  n   594  SM4    sm4ekey   q0 : q5 q16 s_const_sz
+0x101110100xxxxx100101xxxxxxxxxx  n   512  DotProd      udot  dq0 : dq5 dq16 s_const_sz b_const_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -3625,4 +3625,152 @@
  */
 #define INSTR_CREATE_stllrh(dc, Rt, Rn) instr_create_1dst_1src(dc, OP_stllrh, Rt, Rn)
 
+/**
+ * Creates a SM3PARTW1 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM3PARTW1 <Sd>.4S, <Sn>.4S, <Sm>.4S
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm3partw1_vector(dc, Rd, Rn, Rm, Rm_elsz) \
+    instr_create_1dst_3src(dc, OP_sm3partw1, Rd, Rn, Rm, Rm_elsz)
+
+/**
+ * Creates a SM3PARTW2 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM3PARTW2 <Sd>.4S, <Sn>.4S, <Sm>.4S
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm3partw2_vector(dc, Rd, Rn, Rm, Rm_elsz) \
+    instr_create_1dst_3src(dc, OP_sm3partw2, Rd, Rn, Rm, Rm_elsz)
+
+/**
+ * Creates a SM3SS1 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM3SS1  <Sd>.4S, <Sn>.4S, <Sm>.4S, <Sa>.4S
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Ra   The fourth source vector register, Q (quadword, 128 bits)
+ * \param Ra_elsz   The element size for Ra, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm3ss1_vector(dc, Rd, Rn, Rm, Ra, Ra_elsz) \
+    instr_create_1dst_4src(dc, OP_sm3ss1, Rd, Rn, Rm, Ra, Ra_elsz)
+
+/**
+ * Creates a SM3TT1A instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM3TT1A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param imm2   The immediate index for Rm
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm3tt1a_vector_indexed(dc, Rd, Rn, Rm, imm2, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_sm3tt1a, Rd, Rn, Rm, imm2, Rm_elsz)
+
+/**
+ * Creates a SM3TT1B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM3TT1B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param imm2   The immediate index for Rm
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm3tt1b_vector_indexed(dc, Rd, Rn, Rm, imm2, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_sm3tt1b, Rd, Rn, Rm, imm2, Rm_elsz)
+
+/**
+ * Creates a SM3TT2A instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM3TT2A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param imm2   The immediate index for Rm
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm3tt2a_vector_indexed(dc, Rd, Rn, Rm, imm2, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_sm3tt2a, Rd, Rn, Rm, imm2, Rm_elsz)
+
+/**
+ * Creates a SM3TT2B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM3TT2B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param imm2   The immediate index for Rm
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm3tt2b_vector_indexed(dc, Rd, Rn, Rm, imm2, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_sm3tt2b, Rd, Rn, Rm, imm2, Rm_elsz)
+
+/**
+ * Creates a SM4E instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM4E    <Sd>.4S, <Sn>.4S
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rn_elsz   The element size for Rn, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm4e_vector(dc, Rd, Rn, Rn_elsz) \
+    instr_create_1dst_2src(dc, OP_sm4e, Rd, Rn, Rn_elsz)
+
+/**
+ * Creates a SM4EKEY instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SM4EKEY <Sd>.4S, <Sn>.4S, <Sm>.4S
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_SINGLE()
+ */
+#define INSTR_CREATE_sm4ekey_vector(dc, Rd, Rn, Rm, Rm_elsz) \
+    instr_create_1dst_3src(dc, OP_sm4ekey, Rd, Rn, Rm, Rm_elsz)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -108,6 +108,7 @@
 -------------------x------------  cmode4_s_sz_msl # MSL bit for 32 bit element shifts
 -------------------xxx----------  extam      # extend amount
 ------------------x-------------  cmode_h_sz # Vector shift for 16 bit elements
+------------------xx------------  imm2idx    # imm from 13-12, used as an index
 ------------------xxxx----------  p10_low    # SVE predicate registers p0-p7
 -----------------xx-------------  cmode_s_sz # Vector shift for 32 bit elements
 -----------------xx-------------  len        # imm2 len

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1322,6 +1322,256 @@ TEST_INSTR(fmlsl2_vector)
     return success;
 }
 
+TEST_INSTR(sm3partw1_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM3PARTW1 <Sd>.4S, <Sn>.4S, <Sm>.4S */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q1, DR_REG_Q31 };
+    opnd_t Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm3partw1 %q0 %q0 $0x02 -> %q0",
+        "sm3partw1 %q11 %q1 $0x02 -> %q10",
+        "sm3partw1 %q31 %q31 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm3partw1_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                              opnd_create_reg(Rn_0_0[i]),
+                                              opnd_create_reg(Rm_0_0[i]), Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sm3partw1, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm3partw2_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM3PARTW2 <Sd>.4S, <Sn>.4S, <Sm>.4S */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    opnd_t Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm3partw2 %q0 %q0 $0x02 -> %q0",
+        "sm3partw2 %q11 %q12 $0x02 -> %q10",
+        "sm3partw2 %q31 %q31 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm3partw2_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                              opnd_create_reg(Rn_0_0[i]),
+                                              opnd_create_reg(Rm_0_0[i]), Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sm3partw2, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm3ss1_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM3SS1  <Sd>.4S, <Sn>.4S, <Sm>.4S, <Sa>.4S */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    reg_id_t Ra_0_0[3] = { DR_REG_Q0, DR_REG_Q13, DR_REG_Q31 };
+    opnd_t Ra_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm3ss1 %q0 %q0 %q0 $0x02 -> %q0",
+        "sm3ss1 %q11 %q12 %q13 $0x02 -> %q10",
+        "sm3ss1 %q31 %q31 %q31 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm3ss1_vector(
+            dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+            opnd_create_reg(Rm_0_0[i]), opnd_create_reg(Ra_0_0[i]), Ra_elsz);
+        if (!test_instr_encoding(dc, OP_sm3ss1, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm3tt1a_vector_indexed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM3TT1A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint imm2_0_0[3] = { 0, 1, 3 };
+    opnd_t Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm3tt1a %q0 %q0 $0x00 $0x02 -> %q0",
+        "sm3tt1a %q11 %q12 $0x01 $0x02 -> %q10",
+        "sm3tt1a %q31 %q31 $0x03 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm3tt1a_vector_indexed(
+            dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+            opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
+            Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sm3tt1a, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm3tt1b_vector_indexed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM3TT1B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint imm2_0_0[3] = { 0, 1, 3 };
+    opnd_t Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm3tt1b %q0 %q0 $0x00 $0x02 -> %q0",
+        "sm3tt1b %q11 %q12 $0x01 $0x02 -> %q10",
+        "sm3tt1b %q31 %q31 $0x03 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm3tt1b_vector_indexed(
+            dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+            opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
+            Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sm3tt1b, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm3tt2a_vector_indexed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM3TT2A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint imm2_0_0[3] = { 0, 1, 3 };
+    opnd_t Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm3tt2a %q0 %q0 $0x00 $0x02 -> %q0",
+        "sm3tt2a %q11 %q12 $0x01 $0x02 -> %q10",
+        "sm3tt2a %q31 %q31 $0x03 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm3tt2a_vector_indexed(
+            dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+            opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
+            Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sm3tt2a, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm3tt2b_vector_indexed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM3TT2B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint imm2_0_0[3] = { 0, 1, 3 };
+    opnd_t Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm3tt2b %q0 %q0 $0x00 $0x02 -> %q0",
+        "sm3tt2b %q11 %q12 $0x01 $0x02 -> %q10",
+        "sm3tt2b %q31 %q31 $0x03 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm3tt2b_vector_indexed(
+            dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+            opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
+            Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sm3tt2b, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm4e_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM4E    <Sd>.4S, <Sn>.4S */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    opnd_t Rn_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm4e   %q0 $0x02 -> %q0",
+        "sm4e   %q11 $0x02 -> %q10",
+        "sm4e   %q31 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm4e_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                         opnd_create_reg(Rn_0_0[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_sm4e, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sm4ekey_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SM4EKEY <Sd>.4S, <Sn>.4S, <Sm>.4S */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    opnd_t Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_0_0[3] = {
+        "sm4ekey %q0 %q0 $0x02 -> %q0",
+        "sm4ekey %q11 %q12 $0x02 -> %q10",
+        "sm4ekey %q31 %q31 $0x02 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sm4ekey_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                            opnd_create_reg(Rn_0_0[i]),
+                                            opnd_create_reg(Rm_0_0[i]), Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sm4ekey, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1365,6 +1615,16 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(fmlal2_vector);
     RUN_INSTR_TEST(fmlsl_vector);
     RUN_INSTR_TEST(fmlsl2_vector);
+
+    RUN_INSTR_TEST(sm3partw1_vector);
+    RUN_INSTR_TEST(sm3partw2_vector);
+    RUN_INSTR_TEST(sm3ss1_vector);
+    RUN_INSTR_TEST(sm3tt1a_vector_indexed);
+    RUN_INSTR_TEST(sm3tt1b_vector_indexed);
+    RUN_INSTR_TEST(sm3tt2a_vector_indexed);
+    RUN_INSTR_TEST(sm3tt2b_vector_indexed);
+    RUN_INSTR_TEST(sm4e_vector);
+    RUN_INSTR_TEST(sm4ekey_vector);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
    This patch adds the following decodes, encoding macros
    and appropriate tests for both

```
    SM3PARTW1 <Sd>.4S, <Sn>.4S, <Sm>.4S
    SM3PARTW2 <Sd>.4S, <Sn>.4S, <Sm>.4S
    SM3SS1  <Sd>.4S, <Sn>.4S, <Sm>.4S, <Sa>.4S
    SM3TT1A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
    SM3TT1B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
    SM3TT2A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
    SM3TT2B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>]
    SM4E    <Sd>.4S, <Sn>.4S
    SM4EKEY <Sd>.4S, <Sn>.4S, <Sm>.4S
```

    Issue: #2626