### PR TITLE
i#2626: AArch64 v8.2 codec: add indexed FMLAL/FMLSL instructions

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4537,6 +4537,33 @@ encode_opnd_dq16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
     return true;
 }
 
+/* sd16_h_sz: S/D register at bit position 16 with 4 bits only, for the FP16
+ *             by-element encoding; bit 30 selects D reg
+ */
+
+static inline bool
+decode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg((TEST(1U << 30, enc) ? DR_REG_D0 : DR_REG_S0) +
+                            extract_uint(enc, 16, 4));
+    return true;
+}
+
+static inline bool
+encode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    uint num;
+    bool d;
+    if (!opnd_is_reg(opnd))
+        return false;
+    d = (uint)(opnd_get_reg(opnd) - DR_REG_D0) < 16;
+    num = opnd_get_reg(opnd) - (d ? DR_REG_D0 : DR_REG_S0);
+    if (num >= 16)
+        return false;
+    *enc_out = num << 16 | (uint)d << 30;
+    return true;
+}
+
 /* dq16: D/Q register at bit position 16; bit 30 selects Q reg */
 
 static inline bool

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -105,12 +105,16 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0x101110110xxxxx001101xxxxxxxxxx  n   139  FP16     fminp  dq0 : dq5 dq16 h_sz
 0x00111010110000111110xxxxxxxxxx  n   140  FP16     fminv   h0 : dq5 h_sz
 0x001110010xxxxx000011xxxxxxxxxx  n   141  FP16      fmla  dq0 : dq0 dq5 dq16 h_sz
-0x001110001xxxxx111011xxxxxxxxxx  n   142  FHM      fmlal  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
-0x101110001xxxxx110011xxxxxxxxxx  n   143  FHM     fmlal2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+0x001110001xxxxx111011xxxxxxxxxx  n   142   FHM   fmlal  dq0 : dq0 sd5 sd16 h_sz
+0x00111110xxxxxx0000x0xxxxxxxxxx  n   142   FHM   fmlal  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x101110001xxxxx110011xxxxxxxxxx  n   143   FHM  fmlal2  dq0 : dq0 sd5 sd16 h_sz
+0x10111110xxxxxx1000x0xxxxxxxxxx  n   143   FHM  fmlal2  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
 0x001110110xxxxx000011xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq0 dq5 dq16 h_sz
 0x00111100xxxxxx0101x0xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq5 dq16_h_sz vindex_H h_sz
-0x001110101xxxxx111011xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
-0x101110101xxxxx110011xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 sd16 s_const_sz h_const_sz
+0x001110101xxxxx111011xxxxxxxxxx  n   145   FHM   fmlsl  dq0 : dq0 sd5 sd16 h_sz
+0x00111110xxxxxx0100x0xxxxxxxxxx  n   145   FHM   fmlsl  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x101110101xxxxx110011xxxxxxxxxx  n   146   FHM  fmlsl2  dq0 : dq0 sd5 sd16 h_sz
+0x10111110xxxxxx1100x0xxxxxxxxxx  n   146   FHM  fmlsl2  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
 00011110111xxxxxxxx10000000xxxxx  n   147  FP16      fmov   h0 : fpimm13
 0001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : w5
 1001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : x5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1232,9 +1232,19 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlal_vector(dc, Rd, Rm, Rn)                              \
-    instr_create_1dst_5src(dc, OP_fmlal, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
-                           OPND_CREATE_HALF())
+#define INSTR_CREATE_fmlal_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_4src(dc, OP_fmlal, Rd, Rd, Rm, Rn, OPND_CREATE_HALF())
+
+/**
+ * Creates a FMLAL indexed vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param index   The first input register's vector element index.
+ */
+#define INSTR_CREATE_fmlal_vector_idx(dc, Rd, Rm, Rn, index) \
+    instr_create_1dst_5src(dc, OP_fmlal, Rd, Rd, Rm, Rn, index, OPND_CREATE_HALF())
 
 /**
  * Creates a FMAX vector instruction.
@@ -1323,9 +1333,18 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlsl_vector(dc, Rd, Rm, Rn)                              \
-    instr_create_1dst_5src(dc, OP_fmlsl, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
-                           OPND_CREATE_HALF())
+#define INSTR_CREATE_fmlsl_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_4src(dc, OP_fmlsl, Rd, Rd, Rm, Rn, OPND_CREATE_HALF())
+/**
+ * Creates a FMLSL indexed vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param index   The first input register's vector element index.
+ */
+#define INSTR_CREATE_fmlsl_vector_idx(dc, Rd, Rm, Rn, index) \
+    instr_create_1dst_5src(dc, OP_fmlsl, Rd, Rd, Rm, Rn, index, OPND_CREATE_HALF())
 
 /**
  * Creates a FMIN vector instruction.
@@ -1701,9 +1720,19 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlal2_vector(dc, Rd, Rm, Rn)                              \
-    instr_create_1dst_5src(dc, OP_fmlal2, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
-                           OPND_CREATE_HALF())
+#define INSTR_CREATE_fmlal2_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_4src(dc, OP_fmlal2, Rd, Rd, Rm, Rn, OPND_CREATE_HALF())
+
+/**
+ * Creates a FMLAL2 indexed vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param index   The first input register's vector element index.
+ */
+#define INSTR_CREATE_fmlal2_vector_idx(dc, Rd, Rm, Rn, index) \
+    instr_create_1dst_5src(dc, OP_fmlal2, Rd, Rd, Rm, Rn, index, OPND_CREATE_HALF())
 
 /**
  * Creates a FADDP vector instruction.
@@ -1816,9 +1845,18 @@
  * \param Rm      The first input register.
  * \param Rn      The second input register.
  */
-#define INSTR_CREATE_fmlsl2_vector(dc, Rd, Rm, Rn)                              \
-    instr_create_1dst_5src(dc, OP_fmlsl2, Rd, Rd, Rm, Rn, OPND_CREATE_SINGLE(), \
-                           OPND_CREATE_HALF())
+#define INSTR_CREATE_fmlsl2_vector(dc, Rd, Rm, Rn) \
+    instr_create_1dst_4src(dc, OP_fmlsl2, Rd, Rd, Rm, Rn, OPND_CREATE_HALF())
+/**
+ * Creates a FMLSL2 indexed vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the instr_t.
+ * \param Rd      The output register. The instruction also reads this register.
+ * \param Rm      The first input register.
+ * \param Rn      The second input register.
+ * \param index   The first input register's vector element index.
+ */
+#define INSTR_CREATE_fmlsl2_vector_idx(dc, Rd, Rm, Rn, index) \
+    instr_create_1dst_5src(dc, OP_fmlsl2, Rd, Rd, Rm, Rn, index, OPND_CREATE_HALF())
 
 /**
  * Creates a FABD vector instruction.

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -217,6 +217,7 @@
 -x-----------------xxx----------  index0     # index of B subreg in Q: 0-15
 -x--------------????--xxxxx-----  memvm      # computes multiplier from 15:12
 -x----------xxxx----------------  dq16_h_sz # Q register (0-15) if bit 30 is set, else D
+-x----------xxxx----------------  sd16_h_sz # D register (0-15) if bit 30 is set, else S
 -x---------xxxxx----------------  dq16       # Q register if bit 30 is set, else D
 -x---------xxxxx----------------  sd16       # D register if bit 30 is set, else S
 ?---------------xxxxxx----------  imm6       # shift amount

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1143,9 +1143,9 @@ TEST_INSTR(fmlal_vector)
     reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
     reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
     const char *expected_0[3] = {
-        "fmlal  %d0 %s1 %s0 $0x02 $0x01 -> %d0",
-        "fmlal  %d10 %s11 %s10 $0x02 $0x01 -> %d10",
-        "fmlal  %d31 %s30 %s31 $0x02 $0x01 -> %d31",
+        "fmlal  %d0 %s1 %s0 $0x01 -> %d0",
+        "fmlal  %d10 %s11 %s10 $0x01 -> %d10",
+        "fmlal  %d31 %s30 %s31 $0x01 -> %d31",
     };
     for (int i = 0; i < 3; i++) {
         instr =
@@ -1160,15 +1160,42 @@ TEST_INSTR(fmlal_vector)
     reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
     reg_id_t Rm_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     const char *expected_1[3] = {
-        "fmlal  %q0 %d1 %d0 $0x02 $0x01 -> %q0",
-        "fmlal  %q10 %d11 %d10 $0x02 $0x01 -> %q10",
-        "fmlal  %q31 %d30 %d31 $0x02 $0x01 -> %q31",
+        "fmlal  %q0 %d1 %d0 $0x01 -> %q0",
+        "fmlal  %q10 %d11 %d10 $0x01 -> %q10",
+        "fmlal  %q31 %d30 %d31 $0x01 -> %q31",
     };
     for (int i = 0; i < 3; i++) {
         instr =
             INSTR_CREATE_fmlal_vector(dc, opnd_create_reg(Rd_1[i]),
                                       opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
         if (!test_instr_encoding(dc, OP_fmlal, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(fmlal_vector_idx)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLAL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S2, DR_REG_S20, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S7, DR_REG_S15 };
+    short index[3] = { 0, 5, 7 };
+    const char *expected_0[3] = {
+        "fmlal  %d0 %s2 %s0 $0x0000000000000000 $0x01 -> %d0",
+        "fmlal  %d10 %s20 %s7 $0x0000000000000005 $0x01 -> %d10",
+        "fmlal  %d31 %s30 %s15 $0x0000000000000007 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlal_vector_idx(
+            dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
+            opnd_create_reg(Rm_0[i]), OPND_CREATE_INT(index[i]));
+        if (!test_instr_encoding(dc, OP_fmlal, instr, expected_0[i]))
             success = false;
     }
 
@@ -1192,9 +1219,9 @@ TEST_INSTR(fmlal2_vector)
     reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
     reg_id_t Rm_0[3] = { DR_REG_S2, DR_REG_S12, DR_REG_S29 };
     const char *expected_0[3] = {
-        "fmlal2 %d0 %s1 %s2 $0x02 $0x01 -> %d0",
-        "fmlal2 %d10 %s11 %s12 $0x02 $0x01 -> %d10",
-        "fmlal2 %d31 %s30 %s29 $0x02 $0x01 -> %d31",
+        "fmlal2 %d0 %s1 %s2 $0x01 -> %d0",
+        "fmlal2 %d10 %s11 %s12 $0x01 -> %d10",
+        "fmlal2 %d31 %s30 %s29 $0x01 -> %d31",
     };
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fmlal2_vector(dc, opnd_create_reg(Rd_0[i]),
@@ -1209,15 +1236,42 @@ TEST_INSTR(fmlal2_vector)
     reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
     reg_id_t Rm_1[3] = { DR_REG_D2, DR_REG_D12, DR_REG_D29 };
     const char *expected_1[3] = {
-        "fmlal2 %q0 %d1 %d2 $0x02 $0x01 -> %q0",
-        "fmlal2 %q10 %d11 %d12 $0x02 $0x01 -> %q10",
-        "fmlal2 %q31 %d30 %d29 $0x02 $0x01 -> %q31",
+        "fmlal2 %q0 %d1 %d2 $0x01 -> %q0",
+        "fmlal2 %q10 %d11 %d12 $0x01 -> %q10",
+        "fmlal2 %q31 %d30 %d29 $0x01 -> %q31",
     };
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fmlal2_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]),
                                            opnd_create_reg(Rm_1[i]));
         if (!test_instr_encoding(dc, OP_fmlal2, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(fmlal2_vector_idx)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLAL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S2, DR_REG_S20, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S7, DR_REG_S15 };
+    short index[3] = { 0, 5, 7 };
+    const char *expected_0[3] = {
+        "fmlal2 %d0 %s2 %s0 $0x0000000000000000 $0x01 -> %d0",
+        "fmlal2 %d10 %s20 %s7 $0x0000000000000005 $0x01 -> %d10",
+        "fmlal2 %d31 %s30 %s15 $0x0000000000000007 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlal2_vector_idx(
+            dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
+            opnd_create_reg(Rm_0[i]), OPND_CREATE_INT(index[i]));
+        if (!test_instr_encoding(dc, OP_fmlal2, instr, expected_0[i]))
             success = false;
     }
 
@@ -1241,9 +1295,9 @@ TEST_INSTR(fmlsl_vector)
     reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
     reg_id_t Rm_0[3] = { DR_REG_S2, DR_REG_S12, DR_REG_S29 };
     const char *expected_0[3] = {
-        "fmlsl  %d0 %s1 %s2 $0x02 $0x01 -> %d0",
-        "fmlsl  %d10 %s11 %s12 $0x02 $0x01 -> %d10",
-        "fmlsl  %d31 %s30 %s29 $0x02 $0x01 -> %d31",
+        "fmlsl  %d0 %s1 %s2 $0x01 -> %d0",
+        "fmlsl  %d10 %s11 %s12 $0x01 -> %d10",
+        "fmlsl  %d31 %s30 %s29 $0x01 -> %d31",
     };
     for (int i = 0; i < 3; i++) {
         instr =
@@ -1258,15 +1312,42 @@ TEST_INSTR(fmlsl_vector)
     reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
     reg_id_t Rm_1[3] = { DR_REG_D2, DR_REG_D12, DR_REG_D29 };
     const char *expected_1[3] = {
-        "fmlsl  %q0 %d1 %d2 $0x02 $0x01 -> %q0",
-        "fmlsl  %q10 %d11 %d12 $0x02 $0x01 -> %q10",
-        "fmlsl  %q31 %d30 %d29 $0x02 $0x01 -> %q31",
+        "fmlsl  %q0 %d1 %d2 $0x01 -> %q0",
+        "fmlsl  %q10 %d11 %d12 $0x01 -> %q10",
+        "fmlsl  %q31 %d30 %d29 $0x01 -> %q31",
     };
     for (int i = 0; i < 3; i++) {
         instr =
             INSTR_CREATE_fmlsl_vector(dc, opnd_create_reg(Rd_1[i]),
                                       opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
         if (!test_instr_encoding(dc, OP_fmlsl, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(fmlsl_vector_idx)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLSL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S2, DR_REG_S20, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S7, DR_REG_S15 };
+    short index[3] = { 0, 5, 7 };
+    const char *expected_0[3] = {
+        "fmlsl  %d0 %s2 %s0 $0x0000000000000000 $0x01 -> %d0",
+        "fmlsl  %d10 %s20 %s7 $0x0000000000000005 $0x01 -> %d10",
+        "fmlsl  %d31 %s30 %s15 $0x0000000000000007 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlsl_vector_idx(
+            dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
+            opnd_create_reg(Rm_0[i]), OPND_CREATE_INT(index[i]));
+        if (!test_instr_encoding(dc, OP_fmlsl, instr, expected_0[i]))
             success = false;
     }
 
@@ -1290,9 +1371,9 @@ TEST_INSTR(fmlsl2_vector)
     reg_id_t Rn_0[3] = { DR_REG_S1, DR_REG_S11, DR_REG_S30 };
     reg_id_t Rm_0[3] = { DR_REG_S2, DR_REG_S12, DR_REG_S29 };
     const char *expected_0[3] = {
-        "fmlsl2 %d0 %s1 %s2 $0x02 $0x01 -> %d0",
-        "fmlsl2 %d10 %s11 %s12 $0x02 $0x01 -> %d10",
-        "fmlsl2 %d31 %s30 %s29 $0x02 $0x01 -> %d31",
+        "fmlsl2 %d0 %s1 %s2 $0x01 -> %d0",
+        "fmlsl2 %d10 %s11 %s12 $0x01 -> %d10",
+        "fmlsl2 %d31 %s30 %s29 $0x01 -> %d31",
     };
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(Rd_0[i]),
@@ -1307,15 +1388,42 @@ TEST_INSTR(fmlsl2_vector)
     reg_id_t Rn_1[3] = { DR_REG_D1, DR_REG_D11, DR_REG_D30 };
     reg_id_t Rm_1[3] = { DR_REG_D2, DR_REG_D12, DR_REG_D29 };
     const char *expected_1[3] = {
-        "fmlsl2 %q0 %d1 %d2 $0x02 $0x01 -> %q0",
-        "fmlsl2 %q10 %d11 %d12 $0x02 $0x01 -> %q10",
-        "fmlsl2 %q31 %d30 %d29 $0x02 $0x01 -> %q31",
+        "fmlsl2 %q0 %d1 %d2 $0x01 -> %q0",
+        "fmlsl2 %q10 %d11 %d12 $0x01 -> %q10",
+        "fmlsl2 %q31 %d30 %d29 $0x01 -> %q31",
     };
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]),
                                            opnd_create_reg(Rm_1[i]));
         if (!test_instr_encoding(dc, OP_fmlsl2, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(fmlsl2_vector_idx)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FMLSL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
+    reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0[3] = { DR_REG_S2, DR_REG_S20, DR_REG_S30 };
+    reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S7, DR_REG_S15 };
+    short index[3] = { 0, 5, 7 };
+    const char *expected_0[3] = {
+        "fmlsl2 %d0 %s2 %s0 $0x0000000000000000 $0x01 -> %d0",
+        "fmlsl2 %d10 %s20 %s7 $0x0000000000000005 $0x01 -> %d10",
+        "fmlsl2 %d31 %s30 %s15 $0x0000000000000007 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fmlsl2_vector_idx(
+            dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
+            opnd_create_reg(Rm_0[i]), OPND_CREATE_INT(index[i]));
+        if (!test_instr_encoding(dc, OP_fmlsl2, instr, expected_0[i]))
             success = false;
     }
 
@@ -1612,9 +1720,13 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(frintz_scalar);
 
     RUN_INSTR_TEST(fmlal_vector);
+    RUN_INSTR_TEST(fmlal_vector_idx);
     RUN_INSTR_TEST(fmlal2_vector);
+    RUN_INSTR_TEST(fmlal2_vector_idx);
     RUN_INSTR_TEST(fmlsl_vector);
+    RUN_INSTR_TEST(fmlsl_vector_idx);
     RUN_INSTR_TEST(fmlsl2_vector);
+    RUN_INSTR_TEST(fmlsl2_vector_idx);
 
     RUN_INSTR_TEST(sm3partw1_vector);
     RUN_INSTR_TEST(sm3partw2_vector);


### PR DESCRIPTION
This patch adds indexed variants of the floating-point fused
multiply-add/subtract long to/from accumulator instructions.
```
FMLAL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>]
FMLAL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>]
FMLSL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>]
FMLSL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>]
```
Issue: #2626