### PR TITLE
i#3544 RISC-V, part 8: Add core/ir stubs

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3444,8 +3444,10 @@ dr_mcontext_to_priv_mcontext(priv_mcontext_t *dst, dr_mcontext_t *src)
         if (TEST(DR_MC_CONTROL, src->flags)) {
             /* XXX i#2710: mc->lr should be under DR_MC_CONTROL */
             dst->xsp = src->xsp;
+#if !defined(RISCV64)
             if (src->size > offsetof(dr_mcontext_t, xflags))
                 dst->xflags = src->xflags;
+#endif
             else
                 return false;
             if (src->size > offsetof(dr_mcontext_t, pc))
@@ -3538,8 +3540,10 @@ priv_mcontext_to_dr_mcontext(dr_mcontext_t *dst, priv_mcontext_t *src)
         }
         if (TEST(DR_MC_CONTROL, dst->flags)) {
             dst->xsp = src->xsp;
+#if !defined(RISCV64)
             if (dst->size > offsetof(dr_mcontext_t, xflags))
                 dst->xflags = src->xflags;
+#endif
             else
                 return false;
             if (dst->size > offsetof(dr_mcontext_t, pc))
@@ -3758,10 +3762,15 @@ dump_mcontext(priv_mcontext_t *context, file_t f, bool dump_xml)
     }
 #endif
 
+#if defined(RISCV64)
+    print_file(f, dump_xml ? "\n\t\tpc=\"" PFX "\" />\n" : "\tpc     = " PFX "\n",
+               context->pc);
+#else
     print_file(f,
                dump_xml ? "\n\t\teflags=\"" PFX "\"\n\t\tpc=\"" PFX "\" />\n"
                         : "\teflags = " PFX "\n\tpc     = " PFX "\n",
                context->xflags, context->pc);
+#endif
 }
 
 #ifdef AARCHXX

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3448,6 +3448,7 @@ dr_mcontext_to_priv_mcontext(priv_mcontext_t *dst, dr_mcontext_t *src)
             if (src->size > offsetof(dr_mcontext_t, fcsr))
                 dst->fcsr = src->fcsr;
 #else
+            /* XXX i#5595: AArch64 should handle fpcr and fpsr here. */
             if (src->size > offsetof(dr_mcontext_t, xflags))
                 dst->xflags = src->xflags;
 #endif
@@ -3547,6 +3548,7 @@ priv_mcontext_to_dr_mcontext(dr_mcontext_t *dst, priv_mcontext_t *src)
             if (dst->size > offsetof(dr_mcontext_t, fcsr))
                 dst->fcsr = src->fcsr;
 #else
+            /* XXX i#5595: AArch64 should handle fpcr and fpsr here. */
             if (dst->size > offsetof(dr_mcontext_t, xflags))
                 dst->xflags = src->xflags;
 #endif

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3444,7 +3444,10 @@ dr_mcontext_to_priv_mcontext(priv_mcontext_t *dst, dr_mcontext_t *src)
         if (TEST(DR_MC_CONTROL, src->flags)) {
             /* XXX i#2710: mc->lr should be under DR_MC_CONTROL */
             dst->xsp = src->xsp;
-#if !defined(RISCV64)
+#if defined(RISCV64)
+            if (src->size > offsetof(dr_mcontext_t, fcsr))
+                dst->fcsr = src->fcsr;
+#else
             if (src->size > offsetof(dr_mcontext_t, xflags))
                 dst->xflags = src->xflags;
 #endif
@@ -3540,7 +3543,10 @@ priv_mcontext_to_dr_mcontext(dr_mcontext_t *dst, priv_mcontext_t *src)
         }
         if (TEST(DR_MC_CONTROL, dst->flags)) {
             dst->xsp = src->xsp;
-#if !defined(RISCV64)
+#if defined(RISCV64)
+            if (dst->size > offsetof(dr_mcontext_t, fcsr))
+                dst->fcsr = src->fcsr;
+#else
             if (dst->size > offsetof(dr_mcontext_t, xflags))
                 dst->xflags = src->xflags;
 #endif

--- a/core/ir/decode.h
+++ b/core/ir/decode.h
@@ -236,7 +236,7 @@ is_isa_mode_legal(dr_isa_mode_t mode);
  * Later, if needed, we can introduce a new field in dcontext_t (xref i#862).
  */
 #    define X64_CACHE_MODE_DC(dc) (X64_MODE_DC(dc) IF_X64(|| DYNAMO_OPTION(x86_to_x64)))
-#elif defined(AARCHXX)
+#elif defined(AARCHXX) || defined(RISCV64)
 #    define X64_MODE_DC(dc) IF_X64_ELSE(true, false)
 #    define X64_CACHE_MODE_DC(dc) IF_X64_ELSE(true, false)
 #endif

--- a/core/ir/riscv64/decode.c
+++ b/core/ir/riscv64/decode.c
@@ -1,0 +1,247 @@
+/* **********************************************************
+ * Copyright (c) 2022 Rivos, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "../globals.h"
+#include "instr.h"
+#include "decode.h"
+
+bool
+is_isa_mode_legal(dr_isa_mode_t mode)
+{
+    return (mode == DR_ISA_RV64IMAFDC);
+}
+
+app_pc
+canonicalize_pc_target(dcontext_t *dcontext, app_pc pc)
+{
+    return pc;
+}
+
+DR_API
+app_pc
+dr_app_pc_as_jump_target(dr_isa_mode_t isa_mode, app_pc pc)
+{
+    return pc;
+}
+
+DR_API
+app_pc
+dr_app_pc_as_load_target(dr_isa_mode_t isa_mode, app_pc pc)
+{
+    return pc;
+}
+
+byte *
+decode_eflags_usage(void *drcontext, byte *pc, uint *usage, dr_opnd_query_flags_t flags)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte *
+decode_opcode(dcontext_t *dcontext, byte *pc, instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte *
+decode(void *drcontext, byte *pc, instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte *
+decode_from_copy(void *drcontext, byte *copy_pc, byte *orig_pc, instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte *
+decode_cti(void *drcontext, byte *pc, instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte *
+decode_next_pc(void *dcontext, byte *pc)
+{
+    /* FIXME i#3544: Compressed instructions may be smaller */
+    return pc + RISCV64_INSTR_SIZE;
+}
+
+int
+decode_sizeof(void *drcontext, byte *pc, int *num_prefixes)
+{
+    /* FIXME i#3544: Compressed instructions may be smaller */
+    return RISCV64_INSTR_SIZE;
+}
+
+byte *
+decode_raw(dcontext_t *dcontext, byte *pc, instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+bool
+decode_raw_is_jmp(dcontext_t *dcontext, byte *pc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+byte *
+decode_raw_jmp_target(dcontext_t *dcontext, byte *pc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+bool
+decode_raw_is_cond_branch_zero(dcontext_t *dcontext, byte *pc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+byte *
+decode_raw_cond_branch_zero_target(dcontext_t *dcontext, byte *pc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+const instr_info_t *
+instr_info_extra_opnds(const instr_info_t *info)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte
+instr_info_opnd_type(const instr_info_t *info, bool src, int num)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return 0;
+}
+
+const instr_info_t *
+get_next_instr_info(const instr_info_t *info)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte
+decode_first_opcode_byte(int opcode)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return 0;
+}
+
+const instr_info_t *
+opcode_to_encoding_info(uint opc, dr_isa_mode_t isa_mode)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+DR_API
+const char *
+decode_opcode_name(int opcode)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+opnd_size_t
+resolve_variable_size(decode_info_t *di, opnd_size_t sz, bool is_reg)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return 0;
+}
+
+bool
+optype_is_indir_reg(int optype)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+optype_is_reg(int optype)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+optype_is_gpr(int optype)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+#ifdef DEBUG
+#    ifndef STANDALONE_DECODER
+void
+check_encode_decode_consistency(dcontext_t *dcontext, instrlist_t *ilist)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+#    endif /* STANDALONE_DECODER */
+
+void
+decode_debug_checks_arch(void)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+#endif /* DEBUG */
+
+#ifdef DECODE_UNIT_TEST
+
+#    include "instr_create_shared.h"
+
+int
+main()
+{
+    bool res = true;
+    standalone_init();
+    standalone_exit();
+    return res;
+}
+
+#endif /* DECODE_UNIT_TEST */

--- a/core/ir/riscv64/decode.c
+++ b/core/ir/riscv64/decode.c
@@ -63,6 +63,7 @@ dr_app_pc_as_load_target(dr_isa_mode_t isa_mode, app_pc pc)
 byte *
 decode_eflags_usage(void *drcontext, byte *pc, uint *usage, dr_opnd_query_flags_t flags)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -70,6 +71,7 @@ decode_eflags_usage(void *drcontext, byte *pc, uint *usage, dr_opnd_query_flags_
 byte *
 decode_opcode(dcontext_t *dcontext, byte *pc, instr_t *instr)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -77,6 +79,7 @@ decode_opcode(dcontext_t *dcontext, byte *pc, instr_t *instr)
 byte *
 decode(void *drcontext, byte *pc, instr_t *instr)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -84,6 +87,7 @@ decode(void *drcontext, byte *pc, instr_t *instr)
 byte *
 decode_from_copy(void *drcontext, byte *copy_pc, byte *orig_pc, instr_t *instr)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -91,6 +95,7 @@ decode_from_copy(void *drcontext, byte *copy_pc, byte *orig_pc, instr_t *instr)
 byte *
 decode_cti(void *drcontext, byte *pc, instr_t *instr)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -112,6 +117,7 @@ decode_sizeof(void *drcontext, byte *pc, int *num_prefixes)
 byte *
 decode_raw(dcontext_t *dcontext, byte *pc, instr_t *instr)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -119,6 +125,7 @@ decode_raw(dcontext_t *dcontext, byte *pc, instr_t *instr)
 bool
 decode_raw_is_jmp(dcontext_t *dcontext, byte *pc)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -126,6 +133,7 @@ decode_raw_is_jmp(dcontext_t *dcontext, byte *pc)
 byte *
 decode_raw_jmp_target(dcontext_t *dcontext, byte *pc)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -133,6 +141,7 @@ decode_raw_jmp_target(dcontext_t *dcontext, byte *pc)
 bool
 decode_raw_is_cond_branch_zero(dcontext_t *dcontext, byte *pc)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -140,6 +149,7 @@ decode_raw_is_cond_branch_zero(dcontext_t *dcontext, byte *pc)
 byte *
 decode_raw_cond_branch_zero_target(dcontext_t *dcontext, byte *pc)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -147,6 +157,7 @@ decode_raw_cond_branch_zero_target(dcontext_t *dcontext, byte *pc)
 const instr_info_t *
 instr_info_extra_opnds(const instr_info_t *info)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -154,6 +165,7 @@ instr_info_extra_opnds(const instr_info_t *info)
 byte
 instr_info_opnd_type(const instr_info_t *info, bool src, int num)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return 0;
 }
@@ -161,6 +173,7 @@ instr_info_opnd_type(const instr_info_t *info, bool src, int num)
 const instr_info_t *
 get_next_instr_info(const instr_info_t *info)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -168,6 +181,7 @@ get_next_instr_info(const instr_info_t *info)
 byte
 decode_first_opcode_byte(int opcode)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return 0;
 }
@@ -175,6 +189,7 @@ decode_first_opcode_byte(int opcode)
 const instr_info_t *
 opcode_to_encoding_info(uint opc, dr_isa_mode_t isa_mode)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -183,6 +198,7 @@ DR_API
 const char *
 decode_opcode_name(int opcode)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -190,6 +206,7 @@ decode_opcode_name(int opcode)
 opnd_size_t
 resolve_variable_size(decode_info_t *di, opnd_size_t sz, bool is_reg)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return 0;
 }
@@ -197,6 +214,7 @@ resolve_variable_size(decode_info_t *di, opnd_size_t sz, bool is_reg)
 bool
 optype_is_indir_reg(int optype)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -204,6 +222,7 @@ optype_is_indir_reg(int optype)
 bool
 optype_is_reg(int optype)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -211,6 +230,7 @@ optype_is_reg(int optype)
 bool
 optype_is_gpr(int optype)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -220,6 +240,7 @@ optype_is_gpr(int optype)
 void
 check_encode_decode_consistency(dcontext_t *dcontext, instrlist_t *ilist)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 #    endif /* STANDALONE_DECODER */
@@ -227,6 +248,7 @@ check_encode_decode_consistency(dcontext_t *dcontext, instrlist_t *ilist)
 void
 decode_debug_checks_arch(void)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 #endif /* DEBUG */
@@ -238,6 +260,7 @@ decode_debug_checks_arch(void)
 int
 main()
 {
+    /* FIXME i#3544: Add decoder tests. */
     bool res = true;
     standalone_init();
     standalone_exit();

--- a/core/ir/riscv64/decode.c
+++ b/core/ir/riscv64/decode.c
@@ -261,6 +261,7 @@ int
 main()
 {
     /* FIXME i#3544: Add decoder tests. */
+
     bool res = true;
     standalone_init();
     standalone_exit();

--- a/core/ir/riscv64/decode_private.h
+++ b/core/ir/riscv64/decode_private.h
@@ -34,6 +34,7 @@
 #define DECODE_PRIVATE_H 1
 
 struct _decode_info_t {
+    /* FIXME i#3544: Add decoding info. */
 };
 
 #endif /* DECODE_PRIVATE_H */

--- a/core/ir/riscv64/decode_private.h
+++ b/core/ir/riscv64/decode_private.h
@@ -1,0 +1,38 @@
+/* **********************************************************
+ * Copyright (c) 2016 RIVOS, Inc. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef DECODE_PRIVATE_H
+#define DECODE_PRIVATE_H 1
+
+struct _decode_info_t { };
+
+#endif /* DECODE_PRIVATE_H */

--- a/core/ir/riscv64/decode_private.h
+++ b/core/ir/riscv64/decode_private.h
@@ -33,6 +33,7 @@
 #ifndef DECODE_PRIVATE_H
 #define DECODE_PRIVATE_H 1
 
-struct _decode_info_t { };
+struct _decode_info_t {
+};
 
 #endif /* DECODE_PRIVATE_H */

--- a/core/ir/riscv64/disassemble.c
+++ b/core/ir/riscv64/disassemble.c
@@ -45,6 +45,7 @@ void
 print_extra_bytes_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, byte *pc,
                             byte *next_pc, int extra_sz, const char *extra_bytes_prefix)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 
@@ -52,12 +53,14 @@ void
 opnd_base_disp_scale_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT,
                                  opnd_t opnd)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 
 bool
 opnd_disassemble_arch(char *buf, size_t bufsz, size_t *sofar INOUT, opnd_t opnd)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -68,6 +71,7 @@ opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar INOUT,
                             opnd_t opnd, bool prev, bool multiple_encodings, bool dst,
                             int *idx INOUT)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -76,6 +80,7 @@ void
 print_instr_prefixes(dcontext_t *dcontext, instr_t *instr, char *buf, size_t bufsz,
                      size_t *sofar INOUT)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 
@@ -83,5 +88,6 @@ void
 print_opcode_name(instr_t *instr, const char *name, char *buf, size_t bufsz,
                   size_t *sofar INOUT)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }

--- a/core/ir/riscv64/disassemble.c
+++ b/core/ir/riscv64/disassemble.c
@@ -1,0 +1,87 @@
+/* **********************************************************
+ * Copyright (c) 2022 Rivos, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "../globals.h"
+
+int
+print_bytes_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, byte *pc,
+                      byte *next_pc, instr_t *instr)
+{
+    /* FIXME i#3544: Check if valid */
+    print_to_buffer(buf, bufsz, sofar, " %08x   ", *(uint *)pc);
+    return 0;
+}
+
+void
+print_extra_bytes_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, byte *pc,
+                            byte *next_pc, int extra_sz, const char *extra_bytes_prefix)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+
+void
+opnd_base_disp_scale_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT,
+                                 opnd_t opnd)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+
+bool
+opnd_disassemble_arch(char *buf, size_t bufsz, size_t *sofar INOUT, opnd_t opnd)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+bool
+opnd_disassemble_noimplicit(char *buf, size_t bufsz, size_t *sofar INOUT,
+                            dcontext_t *dcontext, instr_t *instr, byte optype,
+                            opnd_t opnd, bool prev, bool multiple_encodings, bool dst,
+                            int *idx INOUT)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+void
+print_instr_prefixes(dcontext_t *dcontext, instr_t *instr, char *buf, size_t bufsz,
+                     size_t *sofar INOUT)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+
+void
+print_opcode_name(instr_t *instr, const char *name, char *buf, size_t bufsz,
+                  size_t *sofar INOUT)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}

--- a/core/ir/riscv64/encode.c
+++ b/core/ir/riscv64/encode.c
@@ -1,0 +1,116 @@
+/* **********************************************************
+ * Copyright (c) 2022 Rivos, Inc. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "../globals.h"
+#include "decode.h"
+
+/* Order corresponds to DR_REG_ enum. */
+/* clang-format off */
+const char *const reg_names[] = {
+    "<NULL>", "<invalid>",
+    "zero", "ra", "sp", "gp",  "tp",  "t0", "t1", "t2", "s0", "fp", "s1", "a0",
+    "a1",   "a2", "a3", "a4",  "a5",  "a6", "a7", "s2", "s3", "s4", "s5", "s6",
+    "s7",   "s8", "s9", "s10", "s11", "t3", "t4", "t5", "t6", "pc",
+#if defined(RISCV_ISA_F) || defined(RISCV_ISA_D)
+    "ft0",  "ft1",  "ft2", "ft3", "ft4", "ft5", "ft6",  "ft7",  "fs0", "fs1",
+    "fa0",  "fa1",  "fa2", "fa3", "fa4", "fa5", "fa6",  "fa7",  "fs2", "fs3",
+    "fs4",  "fs5",  "fs6", "fs7", "fs8", "fs9", "fs10", "fs11", "ft8", "ft9",
+    "ft10", "ft11", "fcsr",
+#endif
+};
+
+
+/* Maps sub-registers to their containing register. */
+/* Order corresponds to DR_REG_ enum. */
+const reg_id_t dr_reg_fixer[] = { REG_NULL,
+                                  REG_NULL,
+    DR_REG_X0,  DR_REG_X1,  DR_REG_X2,  DR_REG_X3,  DR_REG_X4,  DR_REG_X5,
+    DR_REG_X6,  DR_REG_X7,  DR_REG_X8,  DR_REG_X9,  DR_REG_X10, DR_REG_X11,
+    DR_REG_X12, DR_REG_X13, DR_REG_X14, DR_REG_X15, DR_REG_X16, DR_REG_X17,
+    DR_REG_X18, DR_REG_X19, DR_REG_X20, DR_REG_X21, DR_REG_X22, DR_REG_X23,
+    DR_REG_X24, DR_REG_X25, DR_REG_X26, DR_REG_X27, DR_REG_X28, DR_REG_X29,
+    DR_REG_X30, DR_REG_X31, DR_REG_PC,
+#if defined(RISCV_ISA_F) || defined(RISCV_ISA_D)
+    DR_REG_F0,  DR_REG_F1,  DR_REG_F2,  DR_REG_F3,  DR_REG_F4,  DR_REG_F5,
+    DR_REG_F6,  DR_REG_F7,  DR_REG_F8,  DR_REG_F9,  DR_REG_F10, DR_REG_F11,
+    DR_REG_F12, DR_REG_F13, DR_REG_F14, DR_REG_F15, DR_REG_F16, DR_REG_F17,
+    DR_REG_F18, DR_REG_F19, DR_REG_F20, DR_REG_F21, DR_REG_F22, DR_REG_F23,
+    DR_REG_F24, DR_REG_F25, DR_REG_F26, DR_REG_F27, DR_REG_F28, DR_REG_F29,
+    DR_REG_F30, DR_REG_F31, DR_REG_FCSR,
+#endif /* RISCV_ISA_F || RISCV_ISA_D */
+};
+/* clang-format on */
+
+#ifdef DEBUG
+void
+encode_debug_checks(void)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+#endif
+
+bool
+encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t *ii)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return false;
+}
+
+void
+decode_info_init_for_instr(decode_info_t *di, instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+
+byte *
+instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *final_pc,
+                  bool check_reachable,
+                  bool *has_instr_opnds /*OUT OPTIONAL*/
+                      _IF_DEBUG(bool assert_reachable))
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+byte *
+copy_and_re_relativize_raw_instr(dcontext_t *dcontext, instr_t *instr, byte *dst_pc,
+                                 byte *final_pc)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+void
+append_fcache_enter_prologue(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}

--- a/core/ir/riscv64/encode.c
+++ b/core/ir/riscv64/encode.c
@@ -74,6 +74,7 @@ const reg_id_t dr_reg_fixer[] = { REG_NULL,
 void
 encode_debug_checks(void)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 #endif
@@ -81,6 +82,7 @@ encode_debug_checks(void)
 bool
 encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t *ii)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 }
@@ -88,6 +90,7 @@ encoding_possible(decode_info_t *di, instr_t *in, const instr_info_t *ii)
 void
 decode_info_init_for_instr(decode_info_t *di, instr_t *instr)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 
@@ -97,6 +100,7 @@ instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *fin
                   bool *has_instr_opnds /*OUT OPTIONAL*/
                       _IF_DEBUG(bool assert_reachable))
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -105,12 +109,7 @@ byte *
 copy_and_re_relativize_raw_instr(dcontext_t *dcontext, instr_t *instr, byte *dst_pc,
                                  byte *final_pc)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
-}
-
-void
-append_fcache_enter_prologue(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
-{
-    ASSERT_NOT_IMPLEMENTED(false);
 }

--- a/core/ir/riscv64/ir_utils.c
+++ b/core/ir/riscv64/ir_utils.c
@@ -1,0 +1,64 @@
+/* **********************************************************
+ * Copyright (c) 2022 Rivos, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Rivos, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL RIVOS, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "../globals.h"
+
+byte *
+remangle_short_rewrite(dcontext_t *dcontext, instr_t *instr, byte *pc, app_pc target)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+instr_t *
+convert_to_near_rel_arch(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+    return NULL;
+}
+
+/* Keep this in sync with patch_mov_immed_arch(). */
+void
+insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                      ptr_int_t val, opnd_t dst, instrlist_t *ilist, instr_t *instr,
+                      OUT instr_t **first, OUT instr_t **last)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}
+
+void
+insert_push_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_estimate,
+                       ptr_int_t val, instrlist_t *ilist, instr_t *instr,
+                       OUT instr_t **first, OUT instr_t **last)
+{
+    ASSERT_NOT_IMPLEMENTED(false);
+}

--- a/core/ir/riscv64/ir_utils.c
+++ b/core/ir/riscv64/ir_utils.c
@@ -35,6 +35,7 @@
 byte *
 remangle_short_rewrite(dcontext_t *dcontext, instr_t *instr, byte *pc, app_pc target)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -42,6 +43,7 @@ remangle_short_rewrite(dcontext_t *dcontext, instr_t *instr, byte *pc, app_pc ta
 instr_t *
 convert_to_near_rel_arch(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
     return NULL;
 }
@@ -52,6 +54,7 @@ insert_mov_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_esti
                       ptr_int_t val, opnd_t dst, instrlist_t *ilist, instr_t *instr,
                       OUT instr_t **first, OUT instr_t **last)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }
 
@@ -60,5 +63,6 @@ insert_push_immed_arch(dcontext_t *dcontext, instr_t *src_inst, byte *encode_est
                        ptr_int_t val, instrlist_t *ilist, instr_t *instr,
                        OUT instr_t **first, OUT instr_t **last)
 {
+    /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
 }

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -780,6 +780,7 @@ typedef enum {
      * On x86, selects the xsp, xflags, and xip fields.
      * On ARM, selects the sp, pc, and cpsr fields.
      * On AArch64, selects the sp, pc, and nzcv fields.
+     * On RISC-V, selects the sp, and pc fields.
      * \note: The xip/pc field is only honored as an input for
      * dr_redirect_execution(), and as an output for system call
      * events.

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -780,7 +780,7 @@ typedef enum {
      * On x86, selects the xsp, xflags, and xip fields.
      * On ARM, selects the sp, pc, and cpsr fields.
      * On AArch64, selects the sp, pc, and nzcv fields.
-     * On RISC-V, selects the sp, and pc fields.
+     * On RISC-V, selects the sp, pc and fcsr fields.
      * \note: The xip/pc field is only honored as an input for
      * dr_redirect_execution(), and as an output for system call
      * events.


### PR DESCRIPTION
Add stubs to get the IR related code to compile. Most of the code is
non-functional, with exception of the register name list.

Issue: #3544

Signed-off-by: Stanislaw Kardach <kda@semihalf.com>