### PR TITLE
i#2626: AArch64 v8.2 codec: add SHA512 instructions

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -160,7 +160,7 @@ proc_has_feature(feature_bit_t f)
 #    if defined(BUILD_TESTS)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
         f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR ||
-        f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4)
+        f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4 || f == FEATURE_SHA512)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -145,6 +145,10 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0x001110110xxxxx001111xxxxxxxxxx  n   166  FP16   frsqrts  dq0 : dq5 dq16 h_sz
 0x001110110xxxxx000101xxxxxxxxxx  n   168  FP16      fsub  dq0 : dq5 dq16 h_sz
 0x001110100xxxxx100101xxxxxxxxxx  n   364  DotProd      sdot  dq0 : dq5 dq16 s_const_sz b_const_sz
+11001110011xxxxx100000xxxxxxxxxx  n   595  SHA512   sha512h   q0 : q0 q5 q16 d_const_sz
+11001110011xxxxx100001xxxxxxxxxx  n   596  SHA512  sha512h2   q0 : q0 q5 q16 d_const_sz
+1100111011000000100000xxxxxxxxxx  n   597  SHA512 sha512su0   q0 : q0 q5 d_const_sz
+11001110011xxxxx100010xxxxxxxxxx  n   598  SHA512 sha512su1   q0 : q0 q5 q16 d_const_sz
 11001110011xxxxx110000xxxxxxxxxx  n   586  SM3  sm3partw1   q0 : q5 q16 s_const_sz
 11001110011xxxxx110001xxxxxxxxxx  n   587  SM3  sm3partw2   q0 : q5 q16 s_const_sz
 11001110010xxxxx0xxxxxxxxxxxxxxx  n   588  SM3     sm3ss1   q0 : q5 q16 q10 s_const_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2100,6 +2100,69 @@
 #define INSTR_CREATE_scvtf_vector_fixed(dc, Rd, Rm, width, fbits) \
     instr_create_1dst_3src(dc, OP_scvtf, Rd, Rm, width, fbits)
 
+/**
+ * Creates a SHA512H instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SHA512H <Qd>, <Qn>, <Dm>.2D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination register, Q (quadword, 128 bits)
+ * \param Rn   The second source register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_DOUBLE()
+ */
+#define INSTR_CREATE_sha512h(dc, Rd, Rn, Rm, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_sha512h, Rd, Rd, Rn, Rm, Rm_elsz)
+
+/**
+ * Creates a SHA512H2 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SHA512H2 <Qd>, <Qn>, <Dm>.2D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination register, Q (quadword, 128 bits)
+ * \param Rn   The second source register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_DOUBLE()
+ */
+#define INSTR_CREATE_sha512h2(dc, Rd, Rn, Rm, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_sha512h2, Rd, Rd, Rn, Rm, Rm_elsz)
+
+/**
+ * Creates a SHA512SU0 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SHA512SU0 <Dd>.2D, <Dn>.2D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rn_elsz   The element size for Rn, OPND_CREATE_DOUBLE()
+ */
+#define INSTR_CREATE_sha512su0(dc, Rd, Rn, Rn_elsz) \
+    instr_create_1dst_3src(dc, OP_sha512su0, Rd, Rd, Rn, Rn_elsz)
+
+/**
+ * Creates a SHA512SU1 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SHA512SU1 <Dd>.2D, <Dn>.2D, <Dm>.2D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Rm_elsz   The element size for Rm, OPND_CREATE_DOUBLE()
+ */
+#define INSTR_CREATE_sha512su1(dc, Rd, Rn, Rm, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_sha512su1, Rd, Rd, Rn, Rm, Rm_elsz)
+
 /* -------- Memory Touching instructions ------------------------------- */
 
 /**

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1680,6 +1680,108 @@ TEST_INSTR(sm4ekey_vector)
     return success;
 }
 
+TEST_INSTR(sha512h)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SHA512H <Qd>, <Qn>, <Dm>.2D */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    opnd_t Rm_elsz = OPND_CREATE_DOUBLE();
+    const char *expected_0_0[3] = {
+        "sha512h %q0 %q0 %q0 $0x03 -> %q0",
+        "sha512h %q10 %q10 %q10 $0x03 -> %q10",
+        "sha512h %q31 %q31 %q31 $0x03 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sha512h(dc, opnd_create_reg(Rd_0_0[i]),
+                                     opnd_create_reg(Rn_0_0[i]),
+                                     opnd_create_reg(Rm_0_0[i]), Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sha512h, instr, expected_0_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(sha512h2)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SHA512H2 <Qd>, <Qn>, <Dm>.2D */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    opnd_t Rm_elsz = OPND_CREATE_DOUBLE();
+    const char *expected_0_0[3] = {
+        "sha512h2 %q0 %q0 %q0 $0x03 -> %q0",
+        "sha512h2 %q10 %q10 %q10 $0x03 -> %q10",
+        "sha512h2 %q31 %q31 %q31 $0x03 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sha512h2(dc, opnd_create_reg(Rd_0_0[i]),
+                                      opnd_create_reg(Rn_0_0[i]),
+                                      opnd_create_reg(Rm_0_0[i]), Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sha512h2, instr, expected_0_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(sha512su0)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SHA512SU0 <Dd>.2D, <Dn>.2D */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    opnd_t Rn_elsz = OPND_CREATE_DOUBLE();
+    const char *expected_0_0[3] = {
+        "sha512su0 %q0 %q0 $0x03 -> %q0",
+        "sha512su0 %q10 %q10 $0x03 -> %q10",
+        "sha512su0 %q31 %q31 $0x03 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sha512su0(dc, opnd_create_reg(Rd_0_0[i]),
+                                       opnd_create_reg(Rn_0_0[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_sha512su0, instr, expected_0_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(sha512su1)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SHA512SU1 <Dd>.2D, <Dn>.2D, <Dm>.2D */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    opnd_t Rm_elsz = OPND_CREATE_DOUBLE();
+    const char *expected_0_0[3] = {
+        "sha512su1 %q0 %q0 %q0 $0x03 -> %q0",
+        "sha512su1 %q10 %q10 %q10 $0x03 -> %q10",
+        "sha512su1 %q31 %q31 %q31 $0x03 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sha512su1(dc, opnd_create_reg(Rd_0_0[i]),
+                                       opnd_create_reg(Rn_0_0[i]),
+                                       opnd_create_reg(Rm_0_0[i]), Rm_elsz);
+        if (!test_instr_encoding(dc, OP_sha512su1, instr, expected_0_0[i]))
+            success = false;
+    }
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1737,6 +1839,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(sm3tt2b_vector_indexed);
     RUN_INSTR_TEST(sm4e_vector);
     RUN_INSTR_TEST(sm4ekey_vector);
+
+    RUN_INSTR_TEST(sha512h);
+    RUN_INSTR_TEST(sha512h2);
+    RUN_INSTR_TEST(sha512su0);
+    RUN_INSTR_TEST(sha512su1);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds hashing instructions introduced in v8.2, an extension
of the SHA256 instructions in v8.0.
```
SHA512H <Qd>, <Qn>, <Vm>.2D
SHA512H2 <Qd>, <Qn>, <Vm>.2D
SHA512SU0 <Vd>.2D, <Vn>.2D
SHA512SU1 <Vd>.2D, <Vn>.2D, <Vm>.2D
```
Issue: #2626