### PR TITLE
i#2626: AArch64 v8.2 codec: Add BCAX, EOR3, P/ESB instructions

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -160,7 +160,8 @@ proc_has_feature(feature_bit_t f)
 #    if defined(BUILD_TESTS)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
         f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR ||
-        f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4 || f == FEATURE_SHA512)
+        f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4 || f == FEATURE_SHA512 ||
+        f == FEATURE_SHA3)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -34,6 +34,9 @@
 
 # Instruction definitions:
 
+11001110001xxxxx0xxxxxxxxxxxxxxx  n   599  SHA3      bcax   q0 : q5 q16 q10 b_const_sz
+11001110000xxxxx0xxxxxxxxxxxxxxx  n   600  SHA3      eor3   q0 : q5 q16 q10 b_const_sz
+11010101000000110010001000011111  n   601  BASE       esb      :
 0x101110110xxxxx000101xxxxxxxxxx  n   94   FP16      fabd  dq0 : dq5 dq16 h_sz
 01111110110xxxxx000101xxxxxxxxxx  n   94   FP16      fabd   h0 : h5 h16
 0x00111011111000111110xxxxxxxxxx  n   95   FP16      fabs  dq0 : dq5 h_sz
@@ -105,16 +108,16 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0x101110110xxxxx001101xxxxxxxxxx  n   139  FP16     fminp  dq0 : dq5 dq16 h_sz
 0x00111010110000111110xxxxxxxxxx  n   140  FP16     fminv   h0 : dq5 h_sz
 0x001110010xxxxx000011xxxxxxxxxx  n   141  FP16      fmla  dq0 : dq0 dq5 dq16 h_sz
-0x001110001xxxxx111011xxxxxxxxxx  n   142   FHM   fmlal  dq0 : dq0 sd5 sd16 h_sz
-0x00111110xxxxxx0000x0xxxxxxxxxx  n   142   FHM   fmlal  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
-0x101110001xxxxx110011xxxxxxxxxx  n   143   FHM  fmlal2  dq0 : dq0 sd5 sd16 h_sz
-0x10111110xxxxxx1000x0xxxxxxxxxx  n   143   FHM  fmlal2  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x001110001xxxxx111011xxxxxxxxxx  n   142  FHM      fmlal  dq0 : dq0 sd5 sd16 h_sz
+0x00111110xxxxxx0000x0xxxxxxxxxx  n   142  FHM      fmlal  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x101110001xxxxx110011xxxxxxxxxx  n   143  FHM     fmlal2  dq0 : dq0 sd5 sd16 h_sz
+0x10111110xxxxxx1000x0xxxxxxxxxx  n   143  FHM     fmlal2  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
 0x001110110xxxxx000011xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq0 dq5 dq16 h_sz
 0x00111100xxxxxx0101x0xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq5 dq16_h_sz vindex_H h_sz
-0x001110101xxxxx111011xxxxxxxxxx  n   145   FHM   fmlsl  dq0 : dq0 sd5 sd16 h_sz
-0x00111110xxxxxx0100x0xxxxxxxxxx  n   145   FHM   fmlsl  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
-0x101110101xxxxx110011xxxxxxxxxx  n   146   FHM  fmlsl2  dq0 : dq0 sd5 sd16 h_sz
-0x10111110xxxxxx1100x0xxxxxxxxxx  n   146   FHM  fmlsl2  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x001110101xxxxx111011xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 sd16 h_sz
+0x00111110xxxxxx0100x0xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x101110101xxxxx110011xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 sd16 h_sz
+0x10111110xxxxxx1100x0xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
 00011110111xxxxxxxx10000000xxxxx  n   147  FP16      fmov   h0 : fpimm13
 0001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : w5
 1001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : x5
@@ -144,6 +147,7 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0111111011111001110110xxxxxxxxxx  n   165  FP16   frsqrte   h0 : h5
 0x001110110xxxxx001111xxxxxxxxxx  n   166  FP16   frsqrts  dq0 : dq5 dq16 h_sz
 0x001110110xxxxx000101xxxxxxxxxx  n   168  FP16      fsub  dq0 : dq5 dq16 h_sz
+11010101000000110010001000111111  n   602  BASE       psb      :
 0x001110100xxxxx100101xxxxxxxxxx  n   364  DotProd      sdot  dq0 : dq5 dq16 s_const_sz b_const_sz
 11001110011xxxxx100000xxxxxxxxxx  n   595  SHA512   sha512h   q0 : q0 q5 q16 d_const_sz
 11001110011xxxxx100001xxxxxxxxxx  n   596  SHA512  sha512h2   q0 : q0 q5 q16 d_const_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -3886,10 +3886,9 @@
  * \param Rn   The second source vector register, Q (quadword, 128 bits)
  * \param Rm   The third source vector register, Q (quadword, 128 bits)
  * \param Ra   The fourth source vector register, Q (quadword, 128 bits)
- * \param Ra_elsz   The element size for Ra, OPND_CREATE_BYTE()
  */
-#define INSTR_CREATE_bcax(dc, Rd, Rn, Rm, Ra, Ra_elsz) \
-    instr_create_1dst_4src(dc, OP_bcax, Rd, Rn, Rm, Ra, Ra_elsz)
+#define INSTR_CREATE_bcax(dc, Rd, Rn, Rm, Ra) \
+    instr_create_1dst_4src(dc, OP_bcax, Rd, Rn, Rm, Ra, OPND_CREATE_BYTE())
 
 /**
  * Creates a EOR3 instruction.
@@ -3903,10 +3902,9 @@
  * \param Rn   The second source vector register, Q (quadword, 128 bits)
  * \param Rm   The third source vector register, Q (quadword, 128 bits)
  * \param Ra   The fourth source vector register, Q (quadword, 128 bits)
- * \param Ra_elsz   The element size for Ra, OPND_CREATE_BYTE()
  */
-#define INSTR_CREATE_eor3(dc, Rd, Rn, Rm, Ra, Ra_elsz) \
-    instr_create_1dst_4src(dc, OP_eor3, Rd, Rn, Rm, Ra, Ra_elsz)
+#define INSTR_CREATE_eor3(dc, Rd, Rn, Rm, Ra) \
+    instr_create_1dst_4src(dc, OP_eor3, Rd, Rn, Rm, Ra, OPND_CREATE_BYTE())
 
 /**
  * Creates a ESB instruction.

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -3874,4 +3874,62 @@
 #define INSTR_CREATE_sm4ekey_vector(dc, Rd, Rn, Rm, Rm_elsz) \
     instr_create_1dst_3src(dc, OP_sm4ekey, Rd, Rn, Rm, Rm_elsz)
 
+/**
+ * Creates a BCAX instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BCAX    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Ra   The fourth source vector register, Q (quadword, 128 bits)
+ * \param Ra_elsz   The element size for Ra, OPND_CREATE_BYTE()
+ */
+#define INSTR_CREATE_bcax(dc, Rd, Rn, Rm, Ra, Ra_elsz) \
+    instr_create_1dst_4src(dc, OP_bcax, Rd, Rn, Rm, Ra, Ra_elsz)
+
+/**
+ * Creates a EOR3 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EOR3    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param Ra   The fourth source vector register, Q (quadword, 128 bits)
+ * \param Ra_elsz   The element size for Ra, OPND_CREATE_BYTE()
+ */
+#define INSTR_CREATE_eor3(dc, Rd, Rn, Rm, Ra, Ra_elsz) \
+    instr_create_1dst_4src(dc, OP_eor3, Rd, Rn, Rm, Ra, Ra_elsz)
+
+/**
+ * Creates a ESB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ESB
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_esb(dc) \
+    instr_create_0dst_0src(dc, OP_esb)
+
+/**
+ * Creates a PSB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PSB CSYNC
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_psb_csync(dc) \
+    instr_create_0dst_0src(dc, OP_psb)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -3917,8 +3917,7 @@
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  */
-#define INSTR_CREATE_esb(dc) \
-    instr_create_0dst_0src(dc, OP_esb)
+#define INSTR_CREATE_esb(dc) instr_create_0dst_0src(dc, OP_esb)
 
 /**
  * Creates a PSB instruction.
@@ -3929,7 +3928,6 @@
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  */
-#define INSTR_CREATE_psb_csync(dc) \
-    instr_create_0dst_0src(dc, OP_psb)
+#define INSTR_CREATE_psb_csync(dc) instr_create_0dst_0src(dc, OP_psb)
 
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1799,9 +1799,9 @@ TEST_INSTR(bcax)
         "bcax   %q31 %q31 %q31 $0x00 -> %q31",
     };
     for (int i = 0; i < 3; i++) {
-        instr = INSTR_CREATE_bcax(dc, opnd_create_reg(Rd_0_0[i]),
-                                  opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
-                                  opnd_create_reg(Ra_0_0[i]));
+        instr =
+            INSTR_CREATE_bcax(dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+                              opnd_create_reg(Rm_0_0[i]), opnd_create_reg(Ra_0_0[i]));
         if (!test_instr_encoding(dc, OP_bcax, instr, expected_0_0[i]))
             success = false;
     }
@@ -1826,9 +1826,9 @@ TEST_INSTR(eor3)
         "eor3   %q31 %q31 %q31 $0x00 -> %q31",
     };
     for (int i = 0; i < 3; i++) {
-        instr = INSTR_CREATE_eor3(dc, opnd_create_reg(Rd_0_0[i]),
-                                  opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
-                                  opnd_create_reg(Ra_0_0[i]));
+        instr =
+            INSTR_CREATE_eor3(dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+                              opnd_create_reg(Rm_0_0[i]), opnd_create_reg(Ra_0_0[i]));
         if (!test_instr_encoding(dc, OP_eor3, instr, expected_0_0[i]))
             success = false;
     }

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1782,6 +1782,91 @@ TEST_INSTR(sha512su1)
     return success;
 }
 
+TEST_INSTR(bcax)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing BCAX    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    reg_id_t Ra_0_0[3] = { DR_REG_Q0, DR_REG_Q13, DR_REG_Q31 };
+    opnd_t Ra_elsz = OPND_CREATE_BYTE();
+    const char *expected_0_0[3] = {
+        "bcax   %q0 %q0 %q0 $0x00 -> %q0",
+        "bcax   %q11 %q12 %q13 $0x00 -> %q10",
+        "bcax   %q31 %q31 %q31 $0x00 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_bcax(dc, opnd_create_reg(Rd_0_0[i]),
+                                  opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
+                                  opnd_create_reg(Ra_0_0[i]), Ra_elsz);
+        if (!test_instr_encoding(dc, OP_bcax, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(eor3)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing EOR3    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    reg_id_t Ra_0_0[3] = { DR_REG_Q0, DR_REG_Q13, DR_REG_Q31 };
+    opnd_t Ra_elsz = OPND_CREATE_BYTE();
+    const char *expected_0_0[3] = {
+        "eor3   %q0 %q0 %q0 $0x00 -> %q0",
+        "eor3   %q11 %q12 %q13 $0x00 -> %q10",
+        "eor3   %q31 %q31 %q31 $0x00 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_eor3(dc, opnd_create_reg(Rd_0_0[i]),
+                                  opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
+                                  opnd_create_reg(Ra_0_0[i]), Ra_elsz);
+        if (!test_instr_encoding(dc, OP_eor3, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(esb)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing ESB      */
+    const char *expected_0_0[1] = { "esb" };
+    instr = INSTR_CREATE_esb(dc);
+    if (!test_instr_encoding(dc, OP_esb, instr, expected_0_0[0]))
+        success = false;
+
+    return success;
+}
+
+TEST_INSTR(psb)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing PSB      */
+    const char *expected_0_0[1] = { "psb" };
+    instr = INSTR_CREATE_psb_csync(dc);
+    if (!test_instr_encoding(dc, OP_psb, instr, expected_0_0[0]))
+        success = false;
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1844,6 +1929,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(sha512h2);
     RUN_INSTR_TEST(sha512su0);
     RUN_INSTR_TEST(sha512su1);
+
+    RUN_INSTR_TEST(bcax);
+    RUN_INSTR_TEST(eor3);
+    RUN_INSTR_TEST(esb);
+    RUN_INSTR_TEST(psb);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1793,7 +1793,6 @@ TEST_INSTR(bcax)
     reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
     reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
     reg_id_t Ra_0_0[3] = { DR_REG_Q0, DR_REG_Q13, DR_REG_Q31 };
-    opnd_t Ra_elsz = OPND_CREATE_BYTE();
     const char *expected_0_0[3] = {
         "bcax   %q0 %q0 %q0 $0x00 -> %q0",
         "bcax   %q11 %q12 %q13 $0x00 -> %q10",
@@ -1802,7 +1801,7 @@ TEST_INSTR(bcax)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_bcax(dc, opnd_create_reg(Rd_0_0[i]),
                                   opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
-                                  opnd_create_reg(Ra_0_0[i]), Ra_elsz);
+                                  opnd_create_reg(Ra_0_0[i]));
         if (!test_instr_encoding(dc, OP_bcax, instr, expected_0_0[i]))
             success = false;
     }
@@ -1821,7 +1820,6 @@ TEST_INSTR(eor3)
     reg_id_t Rn_0_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
     reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
     reg_id_t Ra_0_0[3] = { DR_REG_Q0, DR_REG_Q13, DR_REG_Q31 };
-    opnd_t Ra_elsz = OPND_CREATE_BYTE();
     const char *expected_0_0[3] = {
         "eor3   %q0 %q0 %q0 $0x00 -> %q0",
         "eor3   %q11 %q12 %q13 $0x00 -> %q10",
@@ -1830,7 +1828,7 @@ TEST_INSTR(eor3)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_eor3(dc, opnd_create_reg(Rd_0_0[i]),
                                   opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
-                                  opnd_create_reg(Ra_0_0[i]), Ra_elsz);
+                                  opnd_create_reg(Ra_0_0[i]));
         if (!test_instr_encoding(dc, OP_eor3, instr, expected_0_0[i]))
             success = false;
     }


### PR DESCRIPTION
This patch  adds the following decodes, encoding macros
and appropriate tests for both

       BCAX    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B
       EOR3    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B
       ESB
       PSB

These instructions are part of features that have not
yet been added, so BASE has been used as a placeholder
where appropriate

Issue: #2626