### PR TITLE
i#2626: AArch64 v8.2 codec: add FSQRT, FP convert instructions

### DIFF
--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -146,8 +146,19 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0001111011100101110000xxxxxxxxxx  n   164  FP16    frintz   h0 : h5
 0111111011111001110110xxxxxxxxxx  n   165  FP16   frsqrte   h0 : h5
 0x001110110xxxxx001111xxxxxxxxxx  n   166  FP16   frsqrts  dq0 : dq5 dq16 h_sz
+0010111011111001111110xxxxxxxxxx  n   167  FP16     fsqrt   d0 : d5 h_sz
+0110111011111001111110xxxxxxxxxx  n   167  FP16     fsqrt   q0 : q5 h_sz
+0001111011100001110000xxxxxxxxxx  n   167  FP16     fsqrt   h0 : h5
 0x001110110xxxxx000101xxxxxxxxxx  n   168  FP16      fsub  dq0 : dq5 dq16 h_sz
 11010101000000110010001000111111  n   602  BASE       psb      :
+11001110011xxxxx100011xxxxxxxxxx  n   603  SHA3      rax1   q0 : q5 q16 d_const_sz
+0000111001111001110110xxxxxxxxxx  n   362  FP16     scvtf   d0 : d5 h_sz
+0100111001111001110110xxxxxxxxxx  n   362  FP16     scvtf   q0 : q5 h_sz
+0001111011100010000000xxxxxxxxxx  n   362  FP16     scvtf   h0 : w5
+1001111011100010000000xxxxxxxxxx  n   362  FP16     scvtf   h0 : x5
+0001111011000010xxxxxxxxxxxxxxxx  n   362  FP16     scvtf   h0 : w5 scale
+1001111011000010xxxxxxxxxxxxxxxx  n   362  FP16     scvtf   h0 : x5 scale
+0101111001111001110110xxxxxxxxxx  n   362  FP16     scvtf   h0 : h5
 0x001110100xxxxx100101xxxxxxxxxx  n   364  DotProd      sdot  dq0 : dq5 dq16 s_const_sz b_const_sz
 11001110011xxxxx100000xxxxxxxxxx  n   595  SHA512   sha512h   q0 : q0 q5 q16 d_const_sz
 11001110011xxxxx100001xxxxxxxxxx  n   596  SHA512  sha512h2   q0 : q0 q5 q16 d_const_sz
@@ -162,4 +173,12 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 11001110010xxxxx10xx11xxxxxxxxxx  n   592  SM3    sm3tt2b   q0 : q5 q16 imm2idx s_const_sz
 1100111011000000100001xxxxxxxxxx  n   593  SM4       sm4e   q0 : q5 s_const_sz
 11001110011xxxxx110010xxxxxxxxxx  n   594  SM4    sm4ekey   q0 : q5 q16 s_const_sz
+0010111001111001110110xxxxxxxxxx  n   510  FP16     ucvtf   d0 : d5 h_sz
+0110111001111001110110xxxxxxxxxx  n   510  FP16     ucvtf   q0 : q5 h_sz
+0001111011100011000000xxxxxxxxxx  n   510  FP16     ucvtf   h0 : w5
+1001111011100011000000xxxxxxxxxx  n   510  FP16     ucvtf   h0 : x5
+0001111011000011xxxxxxxxxxxxxxxx  n   510  FP16     ucvtf   h0 : w5 scale
+1001111011000011xxxxxxxxxxxxxxxx  n   510  FP16     ucvtf   h0 : x5 scale
+0111111001111001110110xxxxxxxxxx  n   510  FP16     ucvtf   h0 : h5
 0x101110100xxxxx100101xxxxxxxxxx  n   512  DotProd      udot  dq0 : dq5 dq16 s_const_sz b_const_sz
+11001110100xxxxxxxxxxxxxxxxxxxxx  n   604  SHA3       xar   q0 : q5 q16 imm6 d_const_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2058,7 +2058,7 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
- * or #OPND_CREATE_DOUBLE().
+ * or #OPND_CREATE_DOUBLE() or #OPND_CREATE_HALF().
  */
 #define INSTR_CREATE_ucvtf_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_ucvtf, Rd, Rm, width)
@@ -2069,7 +2069,7 @@
  * \param Rd      The output register.
  * \param Rm      The input register.
  * \param width   The vector element width. Must be #OPND_CREATE_SINGLE() or
- *                #OPND_CREATE_DOUBLE().
+ *                #OPND_CREATE_DOUBLE() or #OPND_CREATE_HALF().
  * \param fbits   The number of bits after the binary point in the fixed-point
  *                destination element.
  */
@@ -2082,7 +2082,7 @@
  * \param Rd      The output register.
  * \param Rm      The first input register.
  * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_SINGLE()
- * or #OPND_CREATE_DOUBLE().
+ * or #OPND_CREATE_DOUBLE() or #OPND_CREATE_HALF().
  */
 #define INSTR_CREATE_scvtf_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_scvtf, Rd, Rm, width)
@@ -2093,7 +2093,7 @@
  * \param Rd      The output register.
  * \param Rm      The input register.
  * \param width   The vector element width. Must be #OPND_CREATE_SINGLE() or
- *                #OPND_CREATE_DOUBLE().
+ *                #OPND_CREATE_DOUBLE() or #OPND_CREATE_HALF().
  * \param fbits   The number of bits after the binary point in the fixed-point
  *                destination element.
  */
@@ -2163,6 +2163,37 @@
 #define INSTR_CREATE_sha512su1(dc, Rd, Rn, Rm, Rm_elsz) \
     instr_create_1dst_4src(dc, OP_sha512su1, Rd, Rd, Rn, Rm, Rm_elsz)
 
+/**
+ * Creates a RAX1 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RAX1    <Dd>.2D, <Dn>.2D, <Dm>.2D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ */
+#define INSTR_CREATE_rax1(dc, Rd, Rn, Rm) \
+    instr_create_1dst_3src(dc, OP_rax1, Rd, Rn, Rm, OPND_CREATE_DOUBLE())
+
+/**
+ * Creates a XAR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    XAR     <Dd>.2D, <Dn>.2D, <Dm>.2D, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register, Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param imm6   The immediate imm
+ */
+#define INSTR_CREATE_xar(dc, Rd, Rn, Rm, imm6) \
+    instr_create_1dst_4src(dc, OP_xar, Rd, Rn, Rm, imm6, OPND_CREATE_DOUBLE())
+
 /* -------- Memory Touching instructions ------------------------------- */
 
 /**
@@ -2220,6 +2251,17 @@
  * \param Rm      The first input register.
  */
 #define INSTR_CREATE_fsqrt_scalar(dc, Rd, Rm) instr_create_1dst_1src(dc, OP_fsqrt, Rd, Rm)
+
+/**
+ * Creates a FSQRT instruction.
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register. Can be D (doubleword, 64 bits) or Q
+ * (quadword, 128 bits) \param Rn   The second source vector register. Can be D
+ * (doubleword, 64 bits) or Q (quadword, 128 bits) \param Rn_elsz   The element size for
+ * Rn. Can be #OPND_CREATE_HALF(), #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE()
+ */
+#define INSTR_CREATE_fsqrt_vector(dc, Rd, Rn, Rn_elsz) \
+    instr_create_1dst_2src(dc, OP_fsqrt, Rd, Rn, Rn_elsz)
 
 /**
  * Creates an FCVT floating point instruction.

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1865,6 +1865,353 @@ TEST_INSTR(psb)
     return success;
 }
 
+TEST_INSTR(fsqrt_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FSQRT   <Hd>.<Ts>, <Hn>.<Ts> */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    opnd_t Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_0[3] = {
+        "fsqrt  %d0 $0x01 -> %d0",
+        "fsqrt  %d11 $0x01 -> %d10",
+        "fsqrt  %d31 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fsqrt_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                          opnd_create_reg(Rn_0_0[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_0_0[i]))
+            success = false;
+    }
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_1[3] = {
+        "fsqrt  %q0 $0x01 -> %q0",
+        "fsqrt  %q11 $0x01 -> %q10",
+        "fsqrt  %q31 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fsqrt_vector(dc, opnd_create_reg(Rd_0_1[i]),
+                                          opnd_create_reg(Rn_0_1[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_0_1[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(fsqrt_scalar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FSQRT   <Hd>, <Hn> */
+    reg_id_t Rd_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_1_0[3] = {
+        "fsqrt  %h0 -> %h0",
+        "fsqrt  %h11 -> %h10",
+        "fsqrt  %h31 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fsqrt_scalar(dc, opnd_create_reg(Rd_1_0[i]),
+                                          opnd_create_reg(Rn_1_0[i]));
+        if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_1_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(scvtf_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SCVTF   <Hd>.<Ts>, <Hn>.<Ts> */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    opnd_t Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_0[3] = {
+        "scvtf  %d0 $0x01 -> %d0",
+        "scvtf  %d11 $0x01 -> %d10",
+        "scvtf  %d31 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_scvtf_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                          opnd_create_reg(Rn_0_0[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0_0[i]))
+            success = false;
+    }
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_1[3] = {
+        "scvtf  %q0 $0x01 -> %q0",
+        "scvtf  %q11 $0x01 -> %q10",
+        "scvtf  %q31 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_scvtf_vector(dc, opnd_create_reg(Rd_0_1[i]),
+                                          opnd_create_reg(Rn_0_1[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0_1[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(scvtf_scalar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SCVTF   <Hd>, <Wn> */
+    reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_W0, DR_REG_W11, DR_REG_W30 };
+    const char *expected_0_0[3] = {
+        "scvtf  %w0 -> %h0",
+        "scvtf  %w11 -> %h10",
+        "scvtf  %w30 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(Rd_0_0[i]),
+                                          opnd_create_reg(Rn_0_0[i]));
+        if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    /* Testing SCVTF   <Hd>, <Xn> */
+    reg_id_t Rd_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_1_0[3] = { DR_REG_X0, DR_REG_X11, DR_REG_X30 };
+    const char *expected_1_0[3] = {
+        "scvtf  %x0 -> %h0",
+        "scvtf  %x11 -> %h10",
+        "scvtf  %x30 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(Rd_1_0[i]),
+                                          opnd_create_reg(Rn_1_0[i]));
+        if (!test_instr_encoding(dc, OP_scvtf, instr, expected_1_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(scvtf_scalar_fixed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SCVTF   <Hd>, <Wn>, #<imm> */
+    reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_0[3] = { DR_REG_W0, DR_REG_W11, DR_REG_W30 };
+    uint scale_0[3] = { 32, 22, 1 };
+    const char *expected_0[3] = {
+        "scvtf  %w0 $0x0000000000000020 -> %h0",
+        "scvtf  %w11 $0x0000000000000016 -> %h10",
+        "scvtf  %w30 $0x0000000000000001 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(Rd_0[i]),
+                                                opnd_create_reg(Rn_0[i]),
+                                                OPND_CREATE_INT(scale_0[i]));
+        if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* Testing SCVTF   <Hd>, <Xn>, #<imm> */
+    reg_id_t Rd_1[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_1[3] = { DR_REG_X0, DR_REG_X11, DR_REG_X30 };
+    uint scale_1[3] = { 64, 43, 1 };
+    const char *expected_1[3] = {
+        "scvtf  %x0 $0x0000000000000040 -> %h0",
+        "scvtf  %x11 $0x000000000000002b -> %h10",
+        "scvtf  %x30 $0x0000000000000001 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_scvtf_scalar_fixed(dc, opnd_create_reg(Rd_1[i]),
+                                                opnd_create_reg(Rn_1[i]),
+                                                OPND_CREATE_INT(scale_1[i]));
+        if (!test_instr_encoding(dc, OP_scvtf, instr, expected_1[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(ucvtf_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing UCVTF   <Hd>.<Ts>, <Hn>.<Ts> */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    opnd_t Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_0[3] = {
+        "ucvtf  %d0 $0x01 -> %d0",
+        "ucvtf  %d11 $0x01 -> %d10",
+        "ucvtf  %d31 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_ucvtf_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                          opnd_create_reg(Rn_0_0[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0_0[i]))
+            success = false;
+    }
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_1[3] = {
+        "ucvtf  %q0 $0x01 -> %q0",
+        "ucvtf  %q11 $0x01 -> %q10",
+        "ucvtf  %q31 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_ucvtf_vector(dc, opnd_create_reg(Rd_0_1[i]),
+                                          opnd_create_reg(Rn_0_1[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0_1[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(ucvtf_scalar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing UCVTF   <Hd>, <Wn> */
+    reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_W0, DR_REG_W11, DR_REG_W30 };
+    const char *expected_0_0[3] = {
+        "ucvtf  %w0 -> %h0",
+        "ucvtf  %w11 -> %h10",
+        "ucvtf  %w30 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(Rd_0_0[i]),
+                                          opnd_create_reg(Rn_0_0[i]));
+        if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    /* Testing UCVTF   <Hd>, <Xn> */
+    reg_id_t Rd_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_1_0[3] = { DR_REG_X0, DR_REG_X11, DR_REG_X30 };
+    const char *expected_1_0[3] = {
+        "ucvtf  %x0 -> %h0",
+        "ucvtf  %x11 -> %h10",
+        "ucvtf  %x30 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(Rd_1_0[i]),
+                                          opnd_create_reg(Rn_1_0[i]));
+        if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_1_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(ucvtf_scalar_fixed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing UCVTF   <Hd>, <Wn>, #<imm> */
+    reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_0[3] = { DR_REG_W0, DR_REG_W11, DR_REG_W30 };
+    uint scale_0[3] = { 32, 22, 1 };
+    const char *expected_0[3] = {
+        "ucvtf  %w0 $0x0000000000000020 -> %h0",
+        "ucvtf  %w11 $0x0000000000000016 -> %h10",
+        "ucvtf  %w30 $0x0000000000000001 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(Rd_0[i]),
+                                                opnd_create_reg(Rn_0[i]),
+                                                OPND_CREATE_INT(scale_0[i]));
+        if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* Testing UCVTF   <Hd>, <Xn>, #<imm> */
+    reg_id_t Rd_1[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_1[3] = { DR_REG_X0, DR_REG_X11, DR_REG_X30 };
+    uint scale_1[3] = { 64, 43, 1 };
+    const char *expected_1[3] = {
+        "ucvtf  %x0 $0x0000000000000040 -> %h0",
+        "ucvtf  %x11 $0x000000000000002b -> %h10",
+        "ucvtf  %x30 $0x0000000000000001 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_ucvtf_scalar_fixed(dc, opnd_create_reg(Rd_1[i]),
+                                                opnd_create_reg(Rn_1[i]),
+                                                OPND_CREATE_INT(scale_1[i]));
+        if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_1[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(rax1)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing RAX1    <Dd>.2D, <Dn>.2D, <Dm>.2D */
+    reg_id_t Rd_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0[3] = { DR_REG_Q1, DR_REG_Q11, DR_REG_Q30 };
+    reg_id_t Rm_0[3] = { DR_REG_Q2, DR_REG_Q12, DR_REG_Q29 };
+    const char *expected_0[3] = {
+        "rax1   %q1 %q2 $0x03 -> %q0",
+        "rax1   %q11 %q12 $0x03 -> %q10",
+        "rax1   %q30 %q29 $0x03 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_rax1(dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
+                                  opnd_create_reg(Rm_0[i]));
+        if (!test_instr_encoding(dc, OP_rax1, instr, expected_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(xar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing XAR     <Dd>.2D, <Dn>.2D, <Dm>.2D, #<imm> */
+    reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_Q1, DR_REG_Q11, DR_REG_Q30 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q2, DR_REG_Q12, DR_REG_Q29 };
+    uint imm6_0_0[3] = { 0, 21, 63 };
+    const char *expected_0_0[3] = {
+        "xar    %q1 %q2 $0x00 $0x03 -> %q0",
+        "xar    %q11 %q12 $0x15 $0x03 -> %q10",
+        "xar    %q30 %q29 $0x3f $0x03 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_xar(dc, opnd_create_reg(Rd_0_0[i]),
+                                 opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
+                                 opnd_create_immed_uint(imm6_0_0[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_xar, instr, expected_0_0[i]))
+            success = false;
+    }
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1932,6 +2279,19 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(eor3);
     RUN_INSTR_TEST(esb);
     RUN_INSTR_TEST(psb);
+
+    RUN_INSTR_TEST(fsqrt_vector);
+    RUN_INSTR_TEST(fsqrt_scalar);
+
+    RUN_INSTR_TEST(scvtf_vector);
+    RUN_INSTR_TEST(scvtf_scalar);
+    RUN_INSTR_TEST(scvtf_scalar_fixed);
+    RUN_INSTR_TEST(ucvtf_vector);
+    RUN_INSTR_TEST(ucvtf_scalar);
+    RUN_INSTR_TEST(ucvtf_scalar_fixed);
+
+    RUN_INSTR_TEST(rax1);
+    RUN_INSTR_TEST(xar);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds half-precision FP arithmetic and conversion
instructions extending support of full-precision variants in v8.0.
```
FSQRT   <Hd>.<Ts>, <Hn>.<Ts>
FSQRT   <Hd>, <Hn>
SCVTF   <Hd>.<Ts>, <Hn>.<Ts>
SCVTF   <Hd>, <Wn>
SCVTF   <Hd>, <Xn>
SCVTF   <Hd>, <Hn>
SCVTF   <Hd>, <Wn>, #<imm>
SCVTF   <Hd>, <Xn>, #<imm>
UCVTF   <Hd>.<Ts>, <Hn>.<Ts>
UCVTF   <Hd>, <Wn>
UCVTF   <Hd>, <Xn>
UCVTF   <Hd>, <Wn>, #<imm>
UCVTF   <Hd>, <Xn>, #<imm>
UCVTF   <Hd>, <Hn>
```
Also adds bit manipulation instructions new in v8.2:
```
RAX1    <Dd>.2D, <Dn>.2D, <Dm>.2D
XAR     <Dd>.2D, <Dn>.2D, <Dm>.2D, #<imm>
```
Issue: #2626
