### PR TITLE
i#5475 Add RAS and SPE feature checks for AArch64 v8.2

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -57,6 +57,7 @@ read_feature_regs(uint64 isa_features[])
     MRS(ID_AA64ISAR1_EL1, AA64ISAR1, isa_features);
     MRS(ID_AA64PFR0_EL1, AA64PFR0, isa_features);
     MRS(ID_AA64MMFR1_EL1, AA64MMFR1, isa_features);
+    MRS(ID_AA64DFR0_EL1, AA64DFR0, isa_features);
 }
 
 static void
@@ -75,13 +76,15 @@ get_processor_specific_info(void)
     }
 
     /* Reads instruction attribute and preocessor feature registers
-     * ID_AA64ISAR0_EL1, ID_AA64ISAR1_EL1, ID_AA64PFR0_EL1 and ID_AA64MMFR1_EL1.
+     * ID_AA64ISAR0_EL1, ID_AA64ISAR1_EL1, ID_AA64PFR0_EL1, ID_AA64MMFR1_EL1
+     * and ID_AA64DFR0_EL1.
      */
     read_feature_regs(isa_features);
     cpu_info.features.flags_aa64isar0 = isa_features[AA64ISAR0];
     cpu_info.features.flags_aa64isar1 = isa_features[AA64ISAR1];
     cpu_info.features.flags_aa64pfr0 = isa_features[AA64PFR0];
     cpu_info.features.flags_aa64mmfr1 = isa_features[AA64MMFR1];
+    cpu_info.features.flags_aa64dfr0 = isa_features[AA64DFR0];
 }
 
 #    define LOG_FEATURE(feature)       \
@@ -136,11 +139,16 @@ proc_init_arch(void)
         LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64PFR0_EL1 = 0x%016lx\n",
             cpu_info.features.flags_aa64pfr0);
         LOG_FEATURE(FEATURE_FP16);
+        LOG_FEATURE(FEATURE_RAS);
         LOG_FEATURE(FEATURE_SVE);
 
         LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64MMFR1_EL1 = 0x%016lx\n",
             cpu_info.features.flags_aa64mmfr1);
         LOG_FEATURE(FEATURE_LOR);
+
+        LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64DFR0_EL1 = 0x%016lx\n",
+            cpu_info.features.flags_aa64dfr0);
+        LOG_FEATURE(FEATURE_SPE);
     });
 #endif
 }
@@ -161,7 +169,7 @@ proc_has_feature(feature_bit_t f)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
         f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR ||
         f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4 || f == FEATURE_SHA512 ||
-        f == FEATURE_SHA3)
+        f == FEATURE_SHA3 || f == FEATURE_RAS || f == FEATURE_SPE)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -177,13 +177,15 @@ typedef struct {
     uint64 flags_aa64isar0; /**< AArch64 feature flags stored in ID_AA64ISAR0_EL1 */
     uint64 flags_aa64isar1; /**< AArch64 feature flags stored in ID_AA64ISAR1_EL1 */
     uint64 flags_aa64pfr0;  /**< AArch64 feature flags stored in ID_AA64PFR0_EL1 */
-    uint64 flags_aa64mmfr1; /**< AArch64 feature flags stored in ID_AA64MMFR1_EL1*/
+    uint64 flags_aa64mmfr1; /**< AArch64 feature flags stored in ID_AA64MMFR1_EL1 */
+    uint64 flags_aa64dfr0;  /**< AArch64 feature flags stored in ID_AA64DFR0_EL1 */
 } features_t;
 typedef enum {
     AA64ISAR0 = 0,
     AA64ISAR1 = 1,
     AA64PFR0 = 2,
-    AA64MMFR1 = 3
+    AA64MMFR1 = 3,
+    AA64DFR0 = 4
 } feature_reg_idx_t;
 #endif
 #ifdef RISCV64
@@ -341,8 +343,10 @@ typedef enum {
     FEATURE_DPB = DEF_FEAT(AA64ISAR1, 0, 1, 0),      /**< DC CVAP (AArch64) */
     FEATURE_DPB2 = DEF_FEAT(AA64ISAR1, 0, 2, 0),     /**< DC CVAP, DC CVADP (AArch64) */
     FEATURE_FP16 = DEF_FEAT(AA64PFR0, 4, 1, 1),      /**< Half-precision FP (AArch64) */
-    FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 1),       /**< Scalable Vectors (AArch64) */
-    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 1), /**< Limited order regions (AArch64) */
+    FEATURE_RAS = DEF_FEAT(AA64PFR0, 7, 1, 0),       /**< RAS extension (AArch64) */
+    FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 0),       /**< Scalable Vectors (AArch64) */
+    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 0), /**< Limited order regions (AArch64) */
+    FEATURE_SPE = DEF_FEAT(AA64DFR0, 8, 1, 0),  /**< Profiling extension (AArch64) */
 } feature_bit_t;
 #endif
 #ifdef RISCV64

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -36,7 +36,7 @@
 
 11001110001xxxxx0xxxxxxxxxxxxxxx  n   599  SHA3      bcax   q0 : q5 q16 q10 b_const_sz
 11001110000xxxxx0xxxxxxxxxxxxxxx  n   600  SHA3      eor3   q0 : q5 q16 q10 b_const_sz
-11010101000000110010001000011111  n   601  BASE       esb      :
+11010101000000110010001000011111  n   601  RAS        esb      :
 0x101110110xxxxx000101xxxxxxxxxx  n   94   FP16      fabd  dq0 : dq5 dq16 h_sz
 01111110110xxxxx000101xxxxxxxxxx  n   94   FP16      fabd   h0 : h5 h16
 0x00111011111000111110xxxxxxxxxx  n   95   FP16      fabs  dq0 : dq5 h_sz
@@ -150,7 +150,7 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0110111011111001111110xxxxxxxxxx  n   167  FP16     fsqrt   q0 : q5 h_sz
 0001111011100001110000xxxxxxxxxx  n   167  FP16     fsqrt   h0 : h5
 0x001110110xxxxx000101xxxxxxxxxx  n   168  FP16      fsub  dq0 : dq5 dq16 h_sz
-11010101000000110010001000111111  n   602  BASE       psb      :
+11010101000000110010001000111111  n   602  SPE        psb      :
 11001110011xxxxx100011xxxxxxxxxx  n   603  SHA3      rax1   q0 : q5 q16 d_const_sz
 0000111001111001110110xxxxxxxxxx  n   362  FP16     scvtf   d0 : d5 h_sz
 0100111001111001110110xxxxxxxxxx  n   362  FP16     scvtf   q0 : q5 h_sz


### PR DESCRIPTION
The Reliability, Availability, and Serviceability (RAS) extension and
Statistical Profiling Extension (SPE) feature checks are required for
v8.2 instructions ESB and PSB. Hardware support for these read from
registers ID_AA64PFR0_EL1 and ID_AA64DFR0_EL1.

Issues: #5475, #2626