### PR TITLE
i#2626: AArch64 v8.2 codec: Add fccmp/e fcmp/e instructions

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1176,6 +1176,21 @@ decode_opnd_float_reg(int pos, uint enc, OUT opnd_t *opnd)
 }
 
 static inline bool
+size_to_ftype(opnd_size_t size, OUT uint *ftype)
+{
+    switch (size) {
+    case OPSZ_2:
+        /* Half precision operands are only supported in Armv8.2+. */
+        *ftype = 3;
+        break;
+    case OPSZ_4: *ftype = 0; break;
+    case OPSZ_8: *ftype = 1; break;
+    default: return false;
+    }
+    return true;
+}
+
+static inline bool
 encode_opnd_float_reg(int pos, opnd_t opnd, OUT uint *enc_out)
 {
     uint num;
@@ -1185,16 +1200,8 @@ encode_opnd_float_reg(int pos, opnd_t opnd, OUT uint *enc_out)
 
     if (!encode_vreg(&size, &num, opnd))
         return false;
-
-    switch (size) {
-    case OPSZ_2:
-        /* Half precision operands are only supported in Armv8.2+. */
-        type = 3;
-        break;
-    case OPSZ_4: type = 0; break;
-    case OPSZ_8: type = 1; break;
-    default: return false;
-    }
+    if (!size_to_ftype(size, &type))
+        return false;
 
     *enc_out = type << 22 | num << pos;
     return true;
@@ -5111,6 +5118,96 @@ encode_opnds_logic_imm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
             return ENCFAIL;
         return (enc | rd | rn | (uint)imm_enc << 10);
     }
+}
+
+/* fccm: operands for conditional compare instructions */
+
+static inline bool
+decode_opnds_fccm(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
+{
+    instr_set_opcode(instr, opcode);
+    instr_set_num_opnds(dcontext, instr, 0, 3);
+
+    reg_id_t rn, rm;
+    uint ftype = BITS(enc, 23, 22);
+
+    if (!decode_float_reg(BITS(enc, 9, 5), ftype, &rn))
+        return false;
+    if (!decode_float_reg(BITS(enc, 20, 16), ftype, &rm))
+        return false;
+
+    instr_set_src(instr, 0, opnd_create_reg(rn));
+    instr_set_src(instr, 1, opnd_create_reg(rm));
+
+    /* nzcv */
+    instr_set_src(instr, 2, opnd_create_immed_int(BITS(enc, 3, 0), OPSZ_4b));
+    /* cond */
+    instr_set_predicate(instr, DR_PRED_EQ + BITS(enc, 15, 12));
+
+    return true;
+}
+
+static inline uint
+encode_opnds_fccm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
+{
+    if (instr_num_dsts(instr) != 0 || instr_num_srcs(instr) != 3)
+        return ENCFAIL;
+
+    opnd_size_t rn_size, rm_size;
+    uint rn, rm;
+    uint ftype;
+
+    if (!encode_vreg(&rn_size, &rn, instr_get_src(instr, 0)))
+        return ENCFAIL;
+    if (!encode_vreg(&rm_size, &rm, instr_get_src(instr, 1)))
+        return ENCFAIL;
+    if (rn_size != rm_size)
+        return ENCFAIL;
+    if (!size_to_ftype(rn_size, &ftype))
+        return ENCFAIL;
+
+    if (!opnd_is_immed_int(instr_get_src(instr, 2)))
+        return ENCFAIL;
+    uint nzcv = opnd_get_immed_int(instr_get_src(instr, 2));
+
+    uint cond = instr_get_predicate(instr) - DR_PRED_EQ;
+    if (cond >= 16)
+        return ENCFAIL;
+
+    return (enc | (rn << 5) | (rm << 16) | (ftype << 22) | nzcv | (cond << 12));
+}
+
+static inline bool
+decode_opnds_fccm_h(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
+{
+    if (BITS(enc, 23, 22) != 0b11)
+        return false;
+    return decode_opnds_fccm(enc, dcontext, pc, instr, opcode);
+}
+
+static inline uint
+encode_opnds_fccm_h(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
+{
+    uint h_enc = encode_opnds_fccm(pc, instr, enc, di);
+    if (BITS(enc, 23, 22) != 0b11)
+        return ENCFAIL;
+    return h_enc;
+}
+
+static inline bool
+decode_opnds_fccm_sd(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
+{
+    if (BITS(enc, 23, 22) == 0b11)
+        return false;
+    return decode_opnds_fccm(enc, dcontext, pc, instr, opcode);
+}
+static inline uint
+encode_opnds_fccm_sd(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
+{
+    uint sd_enc = encode_opnds_fccm(pc, instr, enc, di);
+    if (BITS(enc, 23, 22) == 0b11)
+        return ENCFAIL;
+    return sd_enc;
 }
 
 /* mst: used for MSR.

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5153,7 +5153,7 @@ encode_opnds_fccm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     if (instr_num_dsts(instr) != 0 || instr_num_srcs(instr) != 3)
         return ENCFAIL;
 
-    opnd_size_t rn_size, rm_size;
+    opnd_size_t rn_size = OPSZ_NA, rm_size = OPSZ_NA;
     uint rn, rm;
     uint ftype;
 

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -259,8 +259,8 @@ x1001010xx0xxxxxxxxxxxxxxxxxxxxx  n   90   BASE        eor            wx0 : wx5 
 0x1011100x1xxxxx110101xxxxxxxxxx  n   99   BASE      faddp            dq0 : dq5 dq16 sd_sz
 0111111000110000110110xxxxxxxxxx  n   99   BASE      faddp             s0 : d5 sd_sz
 0111111001110000110110xxxxxxxxxx  n   99   BASE      faddp             d0 : q5 sd_sz
-00011110xx1xxxxxxxxx01xxxxx0xxxx  w   100  BASE      fccmp                : float_reg5 float_reg16 nzcv cond
-00011110xx1xxxxxxxxx01xxxxx1xxxx  w   101  BASE     fccmpe                : float_reg5 float_reg16 nzcv cond
+000111100x1xxxxxxxxx01xxxxx0xxxx  w   100  BASE      fccmp        fccm_sd
+000111100x1xxxxxxxxx01xxxxx1xxxx  w   101  BASE     fccmpe        fccm_sd
 0x0011100x1xxxxx111001xxxxxxxxxx  n   102  BASE      fcmeq            dq0 : dq5 dq16 sd_sz
 0x0011101x100000110110xxxxxxxxxx  n   102  BASE      fcmeq            dq0 : dq5 zero_fp_const sd_sz
 0101111010100000110110xxxxxxxxxx  n   102  BASE      fcmeq             s0 : s5 zero_fp_const
@@ -284,14 +284,14 @@ x1001010xx0xxxxxxxxxxxxxxxxxxxxx  n   90   BASE        eor            wx0 : wx5 
 0101111010100000111010xxxxxxxxxx  n   106  BASE      fcmlt             s0 : s5 zero_fp_const
 0101111011100000111010xxxxxxxxxx  n   106  BASE      fcmlt             d0 : d5 zero_fp_const
 0x0011101x100000111010xxxxxxxxxx  n   106  BASE      fcmlt            dq0 : dq5 zero_fp_const sd_sz
-00011110xx1xxxxx001000xxxxx00000  w   107  BASE       fcmp                : float_reg5 float_reg16
-0001111000100000001000xxxxx01000  w   107  BASE       fcmp                : s5 zero_fp_const
 0001111001100000001000xxxxx01000  w   107  BASE       fcmp                : d5 zero_fp_const
-00011110xx100000001000xxxxx01000  w   107  BASE       fcmp                : float_reg5 zero_fp_const
-00011110001xxxxx001000xxxxx10000  w   108  BASE      fcmpe                : s5 s16
+0001111000100000001000xxxxx01000  w   107  BASE       fcmp                : s5 zero_fp_const
+00011110011xxxxx001000xxxxx00000  w   107  BASE       fcmp                : d5 d16
+00011110001xxxxx001000xxxxx00000  w   107  BASE       fcmp                : s5 s16
+0001111001100000001000xxxxx11000  w   108  BASE      fcmpe                : d5 zero_fp_const
 0001111000100000001000xxxxx11000  w   108  BASE      fcmpe                : s5 zero_fp_const
 00011110011xxxxx001000xxxxx10000  w   108  BASE      fcmpe                : d5 d16
-0001111001100000001000xxxxx11000  w   108  BASE      fcmpe                : d5 zero_fp_const
+00011110001xxxxx001000xxxxx10000  w   108  BASE      fcmpe                : s5 s16
 00011110xx1xxxxxxxxx11xxxxxxxxxx  r   109  BASE      fcsel     float_reg0 : float_reg5 float_reg16 cond
 0001111000100010110000xxxxxxxxxx  n   110  BASE       fcvt             d0 : s5
 0001111001100010010000xxxxxxxxxx  n   110  BASE       fcvt             s0 : d5

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -45,6 +45,8 @@
 0x001110010xxxxx000101xxxxxxxxxx  n   98   FP16      fadd  dq0 : dq5 dq16 h_sz
 0x101110010xxxxx000101xxxxxxxxxx  n   99   FP16     faddp  dq0 : dq5 dq16 h_sz
 0101111000110000110110xxxxxxxxxx  n   99   FP16     faddp   h0 : q5 h_sz
+00011110111xxxxxxxxx01xxxxx0xxxx  w   100  FP16     fccmp  fccm_h
+00011110111xxxxxxxxx01xxxxx1xxxx  w   101  FP16    fccmpe  fccm_h
 0x001110010xxxxx001001xxxxxxxxxx  n   102  FP16     fcmeq  dq0 : dq5 dq16 h_sz
 0x00111011111000110110xxxxxxxxxx  n   102  FP16     fcmeq  dq0 : dq5 zero_fp_const h_sz
 0101111011111000110110xxxxxxxxxx  n   102  FP16     fcmeq   h0 : h5 zero_fp_const
@@ -56,8 +58,12 @@
 0101111011111000110010xxxxxxxxxx  n   104  FP16     fcmgt   h0 : h5 zero_fp_const
 0111111011111000110110xxxxxxxxxx  n   105  FP16     fcmle   h0 : h5 zero_fp_const
 0101111011111000111010xxxxxxxxxx  n   106  FP16     fcmlt   h0 : h5 zero_fp_const
+0001111011100000001000xxxxx01000  w   107  FP16      fcmp      : h5 zero_fp_const
+00011110111xxxxx001000xxxxx00000  w   107  FP16      fcmp      : h5 h16
 00011110111xxxxx001000xxxxx10000  w   108  FP16     fcmpe      : h5 h16
 0001111011100000001000xxxxx11000  w   108  FP16     fcmpe      : h5 zero_fp_const
+0001111011100000001000xxxxx11000  w   108  FP16     fcmpe      : h5 zero_fp_const
+00011110111xxxxx001000xxxxx10000  w   108  FP16     fcmpe      : h5 h16
 0001111000100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : s5
 0001111001100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : d5
 0001111011100010010000xxxxxxxxxx  n   110  FP16      fcvt   s0 : h5

--- a/core/ir/aarch64/disassemble.c
+++ b/core/ir/aarch64/disassemble.c
@@ -157,6 +157,12 @@ print_opcode_name(instr_t *instr, const char *name, char *buf, size_t bufsz,
     } else if (instr_get_opcode(instr) == OP_ccmn) {
         print_to_buffer(buf, bufsz, sofar, "ccmn.%s",
                         pred_names[instr_get_predicate(instr)]);
+    } else if (instr_get_opcode(instr) == OP_fccmp) {
+        print_to_buffer(buf, bufsz, sofar, "fccmp.%s",
+                        pred_names[instr_get_predicate(instr)]);
+    } else if (instr_get_opcode(instr) == OP_fccmpe) {
+        print_to_buffer(buf, bufsz, sofar, "fccmpe.%s",
+                        pred_names[instr_get_predicate(instr)]);
     } else
         print_to_buffer(buf, bufsz, sofar, "%s", name);
 }

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -3980,12 +3980,15 @@
  *    FCCMP   <Sn>, <Sm>, #<imm>, <cond>
  * \endverbatim
  * \param dc    The void * dcontext used to allocate memory for the #instr_t.
- * \param Rn    The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
- * \param Rm    The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rn    The first source register. Can be D (doubleword, 64 bits),
+ *              H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm    The second source register. Can be D (doubleword, 64 bits),
+ *              H (halfword, 16 bits) or S (singleword, 32 bits)
  * \param nzcv  The 4 bit NZCV flags value used if the input condition is false.
  *              (use #opnd_create_immed_uint() to create the operand, e.g.
  *              opnd_create_immed_uint(val, #OPSZ_4b)).
- * \param condition_code   The comparison condition specified by #dr_pred_type_t, e.g. #DR_PRED_EQ.
+ * \param condition_code   The comparison condition specified by #dr_pred_type_t,
+ *              e.g. #DR_PRED_EQ.
  */
 #define INSTR_CREATE_fccmp(dc, Rn, Rm, nzcv, condition_code) \
     INSTR_PRED(instr_create_0dst_3src(dc, OP_fccmp, Rn, Rm, nzcv), (condition_code))
@@ -4000,12 +4003,15 @@
  *    FCCMPE   <Sn>, <Sm>, #<imm>, <cond>
  * \endverbatim
  * \param dc    The void * dcontext used to allocate memory for the #instr_t.
- * \param Rn    The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
- * \param Rm    The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rn    The first source register. Can be D (doubleword, 64 bits),
+ *              H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm    The second source register. Can be D (doubleword, 64 bits),
+ *              H (halfword, 16 bits) or S (singleword, 32 bits)
  * \param nzcv  The 4 bit NZCV flags value used if the input condition is false.
  *              (use #opnd_create_immed_uint() to create the operand, e.g.
  *              opnd_create_immed_uint(val, #OPSZ_4b)).
- * \param condition_code   The comparison condition specified by #dr_pred_type_t, e.g. #DR_PRED_EQ.
+ * \param condition_code   The comparison condition specified by #dr_pred_type_t,
+ *              e.g. #DR_PRED_EQ.
  */
 #define INSTR_CREATE_fccmpe(dc, Rn, Rm, nzcv, condition_code) \
     INSTR_PRED(instr_create_0dst_3src(dc, OP_fccmpe, Rn, Rm, nzcv), (condition_code))
@@ -4020,7 +4026,8 @@
  *    FCMP    <Sn>, #0.0
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits),
+ *             H (halfword, 16 bits) or S (singleword, 32 bits)
  */
 #define INSTR_CREATE_fcmp_zero(dc, Rn) \
     instr_create_0dst_2src(dc, OP_fcmp, Rn, opnd_create_immed_float(0.0))
@@ -4035,8 +4042,10 @@
  *    FCMP    <Sn>, <Sm>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
- * \param Rm   The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits),
+ *             H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm   The second source register. Can be D (doubleword, 64 bits),
+ *             H (halfword, 16 bits) or S (singleword, 32 bits)
  */
 #define INSTR_CREATE_fcmp(dc, Rn, Rm) instr_create_0dst_2src(dc, OP_fcmp, Rn, Rm)
 
@@ -4050,7 +4059,8 @@
  *    FCMPE   <Sn>, #0.0
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits),
+ *             H (halfword, 16 bits) or S (singleword, 32 bits)
  */
 #define INSTR_CREATE_fcmpe_zero(dc, Rn) \
     instr_create_0dst_2src(dc, OP_fcmpe, Rn, opnd_create_immed_float(0.0))
@@ -4065,8 +4075,10 @@
  *    FCMPE   <Sn>, <Sm>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
- * \param Rm   The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits),
+ *             H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm   The second source register. Can be D (doubleword, 64 bits),
+ *             H (halfword, 16 bits) or S (singleword, 32 bits)
  */
 #define INSTR_CREATE_fcmpe(dc, Rn, Rm) instr_create_0dst_2src(dc, OP_fcmpe, Rn, Rm)
 

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -3970,4 +3970,104 @@
  */
 #define INSTR_CREATE_psb_csync(dc) instr_create_0dst_0src(dc, OP_psb)
 
+/**
+ * Creates a FCCMP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCCMP   <Dn>, <Dm>, #<imm>, <cond>
+ *    FCCMP   <Hn>, <Hm>, #<imm>, <cond>
+ *    FCCMP   <Sn>, <Sm>, #<imm>, <cond>
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn    The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm    The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param nzcv  The 4 bit NZCV flags value used if the input condition is false.
+ *              (use #opnd_create_immed_uint() to create the operand, e.g.
+ *              opnd_create_immed_uint(val, #OPSZ_4b)).
+ * \param condition_code   The comparison condition specified by #dr_pred_type_t, e.g. #DR_PRED_EQ.
+ */
+#define INSTR_CREATE_fccmp(dc, Rn, Rm, nzcv, condition_code) \
+    INSTR_PRED(instr_create_0dst_3src(dc, OP_fccmp, Rn, Rm, nzcv), (condition_code))
+
+/**
+ * Creates a FCCMPE instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCCMPE   <Dn>, <Dm>, #<imm>, <cond>
+ *    FCCMPE   <Hn>, <Hm>, #<imm>, <cond>
+ *    FCCMPE   <Sn>, <Sm>, #<imm>, <cond>
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn    The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm    The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param nzcv  The 4 bit NZCV flags value used if the input condition is false.
+ *              (use #opnd_create_immed_uint() to create the operand, e.g.
+ *              opnd_create_immed_uint(val, #OPSZ_4b)).
+ * \param condition_code   The comparison condition specified by #dr_pred_type_t, e.g. #DR_PRED_EQ.
+ */
+#define INSTR_CREATE_fccmpe(dc, Rn, Rm, nzcv, condition_code) \
+    INSTR_PRED(instr_create_0dst_3src(dc, OP_fccmpe, Rn, Rm, nzcv), (condition_code))
+
+/**
+ * Creates a FCMP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCMP    <Dn>, #0.0
+ *    FCMP    <Hn>, #0.0
+ *    FCMP    <Sn>, #0.0
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ */
+#define INSTR_CREATE_fcmp_zero(dc, Rn) \
+    instr_create_0dst_2src(dc, OP_fcmp, Rn, opnd_create_immed_float(0.0))
+
+/**
+ * Creates a FCMP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCMP    <Dn>, <Dm>
+ *    FCMP    <Hn>, <Hm>
+ *    FCMP    <Sn>, <Sm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm   The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ */
+#define INSTR_CREATE_fcmp(dc, Rn, Rm) instr_create_0dst_2src(dc, OP_fcmp, Rn, Rm)
+
+/**
+ * Creates a FCMPE instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCMPE   <Dn>, #0.0
+ *    FCMPE   <Hn>, #0.0
+ *    FCMPE   <Sn>, #0.0
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ */
+#define INSTR_CREATE_fcmpe_zero(dc, Rn) \
+    instr_create_0dst_2src(dc, OP_fcmpe, Rn, opnd_create_immed_float(0.0))
+
+/**
+ * Creates a FCMPE instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCMPE   <Dn>, <Dm>
+ *    FCMPE   <Hn>, <Hm>
+ *    FCMPE   <Sn>, <Sm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm   The second source register. Can be D (doubleword, 64 bits), H (halfword, 16 bits) or S (singleword, 32 bits)
+ */
+#define INSTR_CREATE_fcmpe(dc, Rn, Rm) instr_create_0dst_2src(dc, OP_fcmpe, Rn, Rm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1862,8 +1862,8 @@ TEST_INSTR(psb)
     instr = INSTR_CREATE_psb_csync(dc);
     if (!test_instr_encoding(dc, OP_psb, instr, expected_0_0[0]))
         success = false;
-      return success;
- }
+    return success;
+}
 
 TEST_INSTR(fsqrt_vector)
 {
@@ -2498,7 +2498,6 @@ TEST_INSTR(fcmpe)
     }
     return success;
 }
-
 
 int
 main(int argc, char *argv[])

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1862,8 +1862,8 @@ TEST_INSTR(psb)
     instr = INSTR_CREATE_psb_csync(dc);
     if (!test_instr_encoding(dc, OP_psb, instr, expected_0_0[0]))
         success = false;
-    return success;
-}
+      return success;
+ }
 
 TEST_INSTR(fsqrt_vector)
 {
@@ -2212,6 +2212,294 @@ TEST_INSTR(xar)
     return success;
 }
 
+TEST_INSTR(fccmp)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+    /* Testing FCCMP   <Dn>, <Dm>, #<imm>, <cond> */
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    uint nzcv_0_0[3] = { 0, 7, 15 };
+    dr_pred_type_t condition_code_0_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_0_0[3] = {
+        "fccmp.eq %d0 %d0 $0x00",
+        "fccmp.hi %d10 %d11 $0x07",
+        "fccmp.nv %d31 %d31 $0x0f",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fccmp(
+            dc, opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
+            opnd_create_immed_uint(nzcv_0_0[i], OPSZ_0), condition_code_0_0[i]);
+        if (!test_instr_encoding(dc, OP_fccmp, instr, expected_0_0[i]))
+            success = false;
+    }
+    /* Testing FCCMP   <Hn>, <Hm>, #<imm>, <cond> */
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rm_1_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    uint nzcv_1_0[3] = { 0, 7, 15 };
+    dr_pred_type_t condition_code_1_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_1_0[3] = {
+        "fccmp.eq %h0 %h0 $0x00",
+        "fccmp.hi %h10 %h11 $0x07",
+        "fccmp.nv %h31 %h31 $0x0f",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fccmp(
+            dc, opnd_create_reg(Rn_1_0[i]), opnd_create_reg(Rm_1_0[i]),
+            opnd_create_immed_uint(nzcv_1_0[i], OPSZ_0), condition_code_1_0[i]);
+        if (!test_instr_encoding(dc, OP_fccmp, instr, expected_1_0[i]))
+            success = false;
+    }
+    /* Testing FCCMP   <Sn>, <Sm>, #<imm>, <cond> */
+    reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    reg_id_t Rm_2_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    uint nzcv_2_0[3] = { 0, 7, 15 };
+    dr_pred_type_t condition_code_2_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_2_0[3] = {
+        "fccmp.eq %s0 %s0 $0x00",
+        "fccmp.hi %s10 %s11 $0x07",
+        "fccmp.nv %s31 %s31 $0x0f",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fccmp(
+            dc, opnd_create_reg(Rn_2_0[i]), opnd_create_reg(Rm_2_0[i]),
+            opnd_create_immed_uint(nzcv_2_0[i], OPSZ_0), condition_code_2_0[i]);
+        if (!test_instr_encoding(dc, OP_fccmp, instr, expected_2_0[i]))
+            success = false;
+    }
+    return success;
+}
+TEST_INSTR(fccmpe)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+    /* Testing FCCMPE  <Dn>, <Dm>, #<imm>, <cond> */
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    uint nzcv_0_0[3] = { 0, 7, 15 };
+    dr_pred_type_t condition_code_0_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_0_0[3] = {
+        "fccmpe.eq %d0 %d0 $0x00",
+        "fccmpe.hi %d10 %d11 $0x07",
+        "fccmpe.nv %d31 %d31 $0x0f",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fccmpe(
+            dc, opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
+            opnd_create_immed_uint(nzcv_0_0[i], OPSZ_0), condition_code_0_0[i]);
+        if (!test_instr_encoding(dc, OP_fccmpe, instr, expected_0_0[i]))
+            success = false;
+    }
+    /* Testing FCCMPE  <Hn>, <Hm>, #<imm>, <cond> */
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rm_1_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    uint nzcv_1_0[3] = { 0, 7, 15 };
+    dr_pred_type_t condition_code_1_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_1_0[3] = {
+        "fccmpe.eq %h0 %h0 $0x00",
+        "fccmpe.hi %h10 %h11 $0x07",
+        "fccmpe.nv %h31 %h31 $0x0f",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fccmpe(
+            dc, opnd_create_reg(Rn_1_0[i]), opnd_create_reg(Rm_1_0[i]),
+            opnd_create_immed_uint(nzcv_1_0[i], OPSZ_0), condition_code_1_0[i]);
+        if (!test_instr_encoding(dc, OP_fccmpe, instr, expected_1_0[i]))
+            success = false;
+    }
+    /* Testing FCCMPE  <Sn>, <Sm>, #<imm>, <cond> */
+    reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    reg_id_t Rm_2_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    uint nzcv_2_0[3] = { 0, 7, 15 };
+    dr_pred_type_t condition_code_2_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_2_0[3] = {
+        "fccmpe.eq %s0 %s0 $0x00",
+        "fccmpe.hi %s10 %s11 $0x07",
+        "fccmpe.nv %s31 %s31 $0x0f",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fccmpe(
+            dc, opnd_create_reg(Rn_2_0[i]), opnd_create_reg(Rm_2_0[i]),
+            opnd_create_immed_uint(nzcv_2_0[i], OPSZ_0), condition_code_2_0[i]);
+        if (!test_instr_encoding(dc, OP_fccmpe, instr, expected_2_0[i]))
+            success = false;
+    }
+    return success;
+}
+TEST_INSTR(fcmp)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+    /* Testing FCMP    <Dn>, #0.0 */
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    const char *expected_0_0[3] = {
+        "fcmp   %d0 $0.000000",
+        "fcmp   %d10 $0.000000",
+        "fcmp   %d31 $0.000000",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmp_zero(dc, opnd_create_reg(Rn_0_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmp, instr, expected_0_0[i]))
+            success = false;
+    }
+    /* Testing FCMP    <Hn>, #0.0 */
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    const char *expected_1_0[3] = {
+        "fcmp   %h0 $0.000000",
+        "fcmp   %h10 $0.000000",
+        "fcmp   %h31 $0.000000",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmp_zero(dc, opnd_create_reg(Rn_1_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmp, instr, expected_1_0[i]))
+            success = false;
+    }
+    /* Testing FCMP    <Sn>, #0.0 */
+    reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    const char *expected_2_0[3] = {
+        "fcmp   %s0 $0.000000",
+        "fcmp   %s10 $0.000000",
+        "fcmp   %s31 $0.000000",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmp_zero(dc, opnd_create_reg(Rn_2_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmp, instr, expected_2_0[i]))
+            success = false;
+    }
+    /* Testing FCMP    <Dn>, <Dm> */
+    reg_id_t Rn_3_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rm_3_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    const char *expected_3_0[3] = {
+        "fcmp   %d0 %d0",
+        "fcmp   %d10 %d11",
+        "fcmp   %d31 %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fcmp(dc, opnd_create_reg(Rn_3_0[i]), opnd_create_reg(Rm_3_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmp, instr, expected_3_0[i]))
+            success = false;
+    }
+    /* Testing FCMP    <Hn>, <Hm> */
+    reg_id_t Rn_4_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rm_4_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_4_0[3] = {
+        "fcmp   %h0 %h0",
+        "fcmp   %h10 %h11",
+        "fcmp   %h31 %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fcmp(dc, opnd_create_reg(Rn_4_0[i]), opnd_create_reg(Rm_4_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmp, instr, expected_4_0[i]))
+            success = false;
+    }
+    /* Testing FCMP    <Sn>, <Sm> */
+    reg_id_t Rn_5_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    reg_id_t Rm_5_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    const char *expected_5_0[3] = {
+        "fcmp   %s0 %s0",
+        "fcmp   %s10 %s11",
+        "fcmp   %s31 %s31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fcmp(dc, opnd_create_reg(Rn_5_0[i]), opnd_create_reg(Rm_5_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmp, instr, expected_5_0[i]))
+            success = false;
+    }
+    return success;
+}
+TEST_INSTR(fcmpe)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+    /* Testing FCMPE   <Dn>, #0.0 */
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    const char *expected_0_0[3] = {
+        "fcmpe  %d0 $0.000000",
+        "fcmpe  %d10 $0.000000",
+        "fcmpe  %d31 $0.000000",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmpe_zero(dc, opnd_create_reg(Rn_0_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_0_0[i]))
+            success = false;
+    }
+    /* Testing FCMPE   <Hn>, #0.0 */
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    const char *expected_1_0[3] = {
+        "fcmpe  %h0 $0.000000",
+        "fcmpe  %h10 $0.000000",
+        "fcmpe  %h31 $0.000000",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmpe_zero(dc, opnd_create_reg(Rn_1_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_1_0[i]))
+            success = false;
+    }
+    /* Testing FCMPE   <Sn>, #0.0 */
+    reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    const char *expected_2_0[3] = {
+        "fcmpe  %s0 $0.000000",
+        "fcmpe  %s10 $0.000000",
+        "fcmpe  %s31 $0.000000",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmpe_zero(dc, opnd_create_reg(Rn_2_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_2_0[i]))
+            success = false;
+    }
+    /* Testing FCMPE   <Dn>, <Dm> */
+    reg_id_t Rn_3_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rm_3_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    const char *expected_3_0[3] = {
+        "fcmpe  %d0 %d0",
+        "fcmpe  %d10 %d11",
+        "fcmpe  %d31 %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmpe(dc, opnd_create_reg(Rn_3_0[i]),
+                                   opnd_create_reg(Rm_3_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_3_0[i]))
+            success = false;
+    }
+    /* Testing FCMPE   <Hn>, <Hm> */
+    reg_id_t Rn_4_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rm_4_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_4_0[3] = {
+        "fcmpe  %h0 %h0",
+        "fcmpe  %h10 %h11",
+        "fcmpe  %h31 %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmpe(dc, opnd_create_reg(Rn_4_0[i]),
+                                   opnd_create_reg(Rm_4_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_4_0[i]))
+            success = false;
+    }
+    /* Testing FCMPE   <Sn>, <Sm> */
+    reg_id_t Rn_5_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    reg_id_t Rm_5_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    const char *expected_5_0[3] = {
+        "fcmpe  %s0 %s0",
+        "fcmpe  %s10 %s11",
+        "fcmpe  %s31 %s31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcmpe(dc, opnd_create_reg(Rn_5_0[i]),
+                                   opnd_create_reg(Rm_5_0[i]));
+        if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_5_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+
 int
 main(int argc, char *argv[])
 {
@@ -2292,6 +2580,11 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(rax1);
     RUN_INSTR_TEST(xar);
+
+    RUN_INSTR_TEST(fccmp);
+    RUN_INSTR_TEST(fccmpe);
+    RUN_INSTR_TEST(fcmp);
+    RUN_INSTR_TEST(fcmpe);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch updates the following decodes, encoding macros
and appropriate tests for both. It also aligns the fccm*
instructions with the ccm* instructions, it hoists the
condition to the mnemonic and designates it as a
predicate.
```
    FCCMP   <Dn>, <Dm>, #<imm>, <cond>
    FCCMP   <Hn>, <Hm>, #<imm>, <cond>
    FCCMP   <Sn>, <Sm>, #<imm>, <cond>
    FCCMPE  <Dn>, <Dm>, #<imm>, <cond>
    FCCMPE  <Hn>, <Hm>, #<imm>, <cond>
    FCCMPE  <Sn>, <Sm>, #<imm>, <cond>
    FCMP    <Dn>, #0.0
    FCMP    <Hn>, #0.0
    FCMP    <Sn>, #0.0
    FCMP    <Dn>, <Dm>
    FCMP    <Hn>, <Hm>
    FCMP    <Sn>, <Sm>
    FCMPE   <Dn>, #0.0
    FCMPE   <Hn>, #0.0
    FCMPE   <Sn>, #0.0
    FCMPE   <Dn>, <Dm>
    FCMPE   <Hn>, <Hm>
    FCMPE   <Sn>, <Sm>
```
Issue: #2626