### PR TITLE
i#2062 memtrace nonmod: Add test for generated code

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
-          liblz4-dev clang-format-9 libunwind-dev
+          liblz4-dev clang-format-12 libunwind-dev
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/api/docs/code_style.dox
+++ b/api/docs/code_style.dox
@@ -41,7 +41,7 @@ maintainable.
 
 # Automated Formatting
 
-We employ automated code formatting via [`clang-format` version 9.0](https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html). The [`.clang-format` top-level file](https://github.com/DynamoRIO/dynamorio/blob/master/.clang-format) specifies the style rules for all `.h`, `.c`, and `.cpp` source code files.  Developers are expected to set up their editors to use `clang-format` when saving each file (see [the `clang-format` documentation](https://releases.llvm.org/6.0.0/tools/clang/docs/ClangFormat.html) for pointers to vim, emacs, and Visual Studio setup instructions).  Our test suite includes a format check and will fail any code whose formatting does not match the `clang-format` output.
+We employ automated code formatting via [`clang-format` version 12.0](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormat.html). The [`.clang-format` top-level file](https://github.com/DynamoRIO/dynamorio/blob/master/.clang-format) specifies the style rules for all `.h`, `.c`, and `.cpp` source code files.  Developers are expected to set up their editors to use `clang-format` when saving each file (see [the `clang-format` documentation](https://releases.llvm.org/6.0.0/tools/clang/docs/ClangFormat.html) for pointers to vim, emacs, and Visual Studio setup instructions).  Our test suite includes a format check and will fail any code whose formatting does not match the `clang-format` output.
 
 # Legacy Code
 

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -38,10 +38,10 @@
 
 #include "configure.h"
 #include "dr_api.h"
-#include "tools.h"
 #include <assert.h>
 #include <iostream>
 #include <string>
+#include "tools.h" // Included after system headers to avoid printf warning.
 
 /***************************************************************************
  * Code generation.

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -1,0 +1,161 @@
+/* **********************************************************
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+// This application links in drmemtrace_static and acquires a trace during
+// a "burst" of execution that includes generated code.
+
+// This is set globally in CMake for other tests so easier to undef here.
+#undef DR_REG_ENUM_COMPATIBILITY
+
+#include "configure.h"
+#include "dr_api.h"
+#include "tools.h"
+#include <assert.h>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <math.h>
+#include <stdlib.h>
+
+/***************************************************************************
+ * Code generation.
+ */
+
+class code_generator_t {
+public:
+    explicit code_generator_t(bool verbose = false)
+        : verbose_(verbose)
+    {
+        generate_code();
+    }
+    ~code_generator_t()
+    {
+        munmap(map_, map_size_);
+    }
+    void
+    execute_generated_code() const
+    {
+        reinterpret_cast<void (*)()>(map_)();
+    }
+
+private:
+    void *map_ = nullptr;
+    size_t map_size_ = 0;
+    bool verbose_ = false;
+
+    void
+    generate_code()
+    {
+        void *dc = dr_standalone_init();
+        assert(dc != nullptr);
+
+        map_size_ = PAGE_SIZE;
+        map_ = allocate_mem(map_size_, ALLOW_EXEC | ALLOW_READ | ALLOW_WRITE);
+        assert(map_ != nullptr);
+
+        instrlist_t *ilist = instrlist_create(dc);
+        reg_id_t base = IF_X86_ELSE(IF_X64_ELSE(DR_REG_RAX, DR_REG_EAX), DR_REG_R0);
+        ssize_t ptrsz = static_cast<ssize_t>(sizeof(void *));
+        // TODO i#2062: Add more instructions and look for them in the final trace.
+        // For now we are testing that drmemtrace detects generated code.
+        instrlist_append(
+            ilist,
+            XINST_CREATE_move(dc, opnd_create_reg(base), opnd_create_reg(DR_REG_XSP)));
+        instrlist_append(ilist,
+                         XINST_CREATE_store(dc, OPND_CREATE_MEMPTR(base, -ptrsz),
+                                            opnd_create_reg(DR_REG_XSP)));
+        instrlist_append(ilist, XINST_CREATE_return(dc));
+
+        byte *last_pc = instrlist_encode(dc, ilist, reinterpret_cast<byte *>(map_), true);
+        assert(last_pc <= reinterpret_cast<byte *>(map_) + map_size_);
+
+        instrlist_clear_and_destroy(dc, ilist);
+
+        protect_mem(map_, map_size_, ALLOW_EXEC | ALLOW_READ);
+
+        if (verbose_) {
+            std::cerr << "Generated code:\n";
+            byte *start_pc = reinterpret_cast<byte *>(map_);
+            for (byte *pc = start_pc; pc < last_pc;) {
+                pc = disassemble_with_info(dc, pc, STDERR, true, true);
+                assert(pc != nullptr);
+            }
+        }
+
+        dr_standalone_exit();
+    }
+};
+
+/***************************************************************************
+ * Top-level tracing.
+ */
+
+// TODO i#2062: Run raw2trace and examine the final trace looking for the gencode
+// instrs; use a unique start and end pattern to identify.
+
+static int
+do_some_work(const code_generator_t &gen)
+{
+    static const int iters = 1000;
+    for (int i = 0; i < iters; ++i) {
+        gen.execute_generated_code();
+    }
+
+    // TODO i#2062: Test code that triggers DR's "selfmod" instrumentation.
+
+    // TODO i#2062: Test modified library code.
+
+    return 1;
+}
+
+int
+main(int argc, const char *argv[])
+{
+    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline"))
+        std::cerr << "failed to set env var!\n";
+
+    code_generator_t gen(false);
+    for (int i = 0; i < 3; i++) {
+        std::cerr << "pre-DR init\n";
+        dr_app_setup();
+        assert(!dr_app_running_under_dynamorio());
+        std::cerr << "pre-DR start\n";
+        dr_app_start();
+        if (do_some_work(gen) < 0)
+            std::cerr << "error in computation\n";
+        std::cerr << "pre-DR detach\n";
+        dr_app_stop_and_cleanup();
+        std::cerr << "all done\n";
+    }
+
+    return 0;
+}

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -59,7 +59,7 @@ public:
     }
     ~code_generator_t()
     {
-        munmap(map_, map_size_);
+        free_mem(map_, map_size_);
     }
     void
     execute_generated_code() const
@@ -84,7 +84,7 @@ private:
 
         instrlist_t *ilist = instrlist_create(dc);
         reg_id_t base = IF_X86_ELSE(IF_X64_ELSE(DR_REG_RAX, DR_REG_EAX), DR_REG_R0);
-        ssize_t ptrsz = static_cast<ssize_t>(sizeof(void *));
+        int ptrsz = static_cast<int>(sizeof(void *));
         // TODO i#2062: Add more instructions and look for them in the final trace.
         // For now we are testing that drmemtrace detects generated code.
         instrlist_append(
@@ -92,7 +92,7 @@ private:
             XINST_CREATE_move(dc, opnd_create_reg(base), opnd_create_reg(DR_REG_XSP)));
         instrlist_append(ilist,
                          XINST_CREATE_store(dc, OPND_CREATE_MEMPTR(base, -ptrsz),
-                                            opnd_create_reg(DR_REG_XSP)));
+                                            opnd_create_reg(base)));
         instrlist_append(ilist, XINST_CREATE_return(dc));
 
         byte *last_pc = instrlist_encode(dc, ilist, reinterpret_cast<byte *>(map_), true);

--- a/clients/drcachesim/tests/offline-gencode.templatex
+++ b/clients/drcachesim/tests/offline-gencode.templatex
@@ -1,0 +1,17 @@
+pre-DR init
+pre-DR start
+WARNING: Found unsupported non-module code
+pre-DR detach
+all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+\[drmemtrace\]: WARNING: Skipping ifetch for instructions not in a module
+Basic counts tool results:
+Total counts:
+.*

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -80,7 +80,8 @@ public:
         {
         }
 
-        reg_id_t operator*()
+        reg_id_t
+        operator*()
         {
             return static_cast<reg_id_t>(DR_REG_START_GPR + index_);
         }
@@ -372,7 +373,8 @@ public:
     offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *, instr_t *, reg_id_t),
                      bool memref_needs_info, drvector_t *reg_vector,
                      ssize_t (*write_file)(file_t file, const void *data, size_t count),
-                     file_t module_file, bool disable_optimizations = false);
+                     file_t module_file, bool disable_optimizations = false,
+                     void (*log)(uint level, const char *fmt, ...) = nullptr);
     virtual ~offline_instru_t();
 
     trace_type_t
@@ -501,6 +503,7 @@ private:
     static CONSTEXPR int LABEL_DATA_ELIDED_NEEDS_BASE = 3;
     ptr_uint_t elide_memref_note_;
     bool standalone_ = false;
+    void (*log_)(uint level, const char *fmt, ...);
 };
 
 #endif /* _INSTRU_H_ */

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1026,6 +1026,13 @@ private:
             // FIXME i#2062: add support for code not in a module (vsyscall, JIT, etc.).
             // Once that support is in we can remove the bool return value and handle
             // the memrefs up here.
+            // A race is fine for our visible ~one-time warning at level 0.
+            static volatile bool warned_once;
+            if (!warned_once) {
+                impl()->log(
+                    0, "WARNING: Skipping ifetch for instructions not in a module\n");
+                warned_once = true;
+            }
             impl()->log(
                 1, "Skipping ifetch for %u instrs not in a module (idx %d, +" PIFX ")\n",
                 instr_count, in_entry->pc.modidx, in_entry->pc.modoffs);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -169,6 +169,17 @@ clean_call(void)
     process_and_output_buffer(drcontext, false);
 }
 
+void
+instru_notify(uint level, const char *fmt, ...)
+{
+    if (op_verbose.get_value() < level)
+        return;
+    va_list args;
+    va_start(args, fmt);
+    dr_vfprintf(STDERR, fmt, args);
+    va_end(args);
+}
+
 /***************************************************************************
  * Alternating tracing-no-tracing feature.
  */
@@ -1737,9 +1748,10 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         /* we use placement new for better isolation */
         DR_ASSERT(MAX_INSTRU_SIZE >= sizeof(offline_instru_t));
         placement = dr_global_alloc(MAX_INSTRU_SIZE);
-        instru = new (placement) offline_instru_t(
-            insert_load_buf_ptr, op_L0I_filter.get_value(), &scratch_reserve_vec,
-            file_ops_func.write_file, module_file, op_disable_optimizations.get_value());
+        instru = new (placement)
+            offline_instru_t(insert_load_buf_ptr, op_L0I_filter.get_value(),
+                             &scratch_reserve_vec, file_ops_func.write_file, module_file,
+                             op_disable_optimizations.get_value(), instru_notify);
     } else {
         void *placement;
         /* we use placement new for better isolation */

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -223,8 +223,8 @@ endif ()
 # However, there's no simple way to do that.  For now we punt until someone
 # changes one of those.
 #
-# Prefer named version 9.0 from apt.llvm.org.
-find_program(CLANG_FORMAT_DIFF clang-format-diff-9 DOC "clang-format-diff")
+# Prefer named version 12.0 from apt.llvm.org.
+find_program(CLANG_FORMAT_DIFF clang-format-diff-12 DOC "clang-format-diff")
 if (NOT CLANG_FORMAT_DIFF)
   find_program(CLANG_FORMAT_DIFF clang-format-diff DOC "clang-format-diff")
 endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3825,6 +3825,17 @@ if (BUILD_CLIENTS)
       torunonly_drcacheoff(burst_aarch64_sys tool.drcacheoff.burst_aarch64_sys "" "@-simulator_type@basic_counts" "")
     endif ()
 
+    if (NOT APPLE) # XXX i#1997: static DR not fully supported on Mac yet
+      set(tool.drcacheoff.gencode_no_reg_compat)
+      add_api_exe(tool.drcacheoff.gencode
+        ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/burst_gencode.cpp
+        OFF ON)
+      use_DynamoRIO_static_client(tool.drcacheoff.gencode drmemtrace_static)
+      set(tool.drcacheoff.gencode_nodr ON)
+      torunonly_drcacheoff(gencode tool.drcacheoff.gencode
+        "" "@-simulator_type@basic_counts" "")
+    endif ()
+
     # XXX i#1551: startstop API is NYI on ARM
     # XXX i#1997: dynamorio_static is not supported on Mac yet
     # FIXME i#2949: gcc 7.3 fails to link certain configs


### PR DESCRIPTION
Adds a drmemtrace test which generates code outside of any module.

Adds a proper warning about this scenario at level 0 (with a do-once
to avoid spew) to both the tracer and raw2trace (previously it would
silently be traced without any indication of a problem, and the
raw2trace warning was at level 1).

Issue: #2062