### PR TITLE
i#2626: AArch64 v8.2 codec: add FCVT instructions

### DIFF
--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -82,10 +82,12 @@
 1001111011110000000000xxxxxxxxxx  n   115  FP16    fcvtms   x0 : h5
 x001111011110001000000xxxxxxxxxx  n   116  FP16    fcvtmu  wx0 : h5
 0111111001111001101110xxxxxxxxxx  n   116  FP16    fcvtmu   h0 : h5
+0x10111001111001101110xxxxxxxxxx  n   116  FP16    fcvtmu  dq0 : dq5 h_sz
 0x00111001111001101010xxxxxxxxxx  n   119  FP16    fcvtns  dq0 : dq5 h_sz
 0101111001111001101010xxxxxxxxxx  n   119  FP16    fcvtns   h0 : h5
 0001111011100000000000xxxxxxxxxx  n   119  FP16    fcvtns   w0 : h5
 1001111011100000000000xxxxxxxxxx  n   119  FP16    fcvtns   x0 : h5
+0x10111001111001101010xxxxxxxxxx  n   120  FP16    fcvtnu  dq0 : dq5 h_sz
 x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0111111001111001101010xxxxxxxxxx  n   120  FP16    fcvtnu   h0 : h5
 0x00111011111001101010xxxxxxxxxx  n   121  FP16    fcvtps  dq0 : dq5 h_sz
@@ -96,7 +98,18 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0111111011111001101010xxxxxxxxxx  n   122  FP16    fcvtpu   h0 : h5
 0001111011101001000000xxxxxxxxxx  n   122  FP16    fcvtpu   w0 : h5
 1001111011101001000000xxxxxxxxxx  n   122  FP16    fcvtpu   x0 : h5
+0001111011111000000000xxxxxxxxxx  n   125  FP16    fcvtzs   w0 : h5
+0001111011011000xxxxxxxxxxxxxxxx  n   125  FP16    fcvtzs   w0 : h5 scale
+1001111011011000xxxxxxxxxxxxxxxx  n   125  FP16    fcvtzs   x0 : h5 scale
+1001111011111000000000xxxxxxxxxx  n   125  FP16    fcvtzs   x0 : h5
+0101111011111001101110xxxxxxxxxx  n   125  FP16    fcvtzs   h0 : h5
+0x00111011111001101110xxxxxxxxxx  n   125  FP16    fcvtzs  dq0 : dq5 h_sz
 0x0011110xxxxxxx111111xxxxxxxxxx  n   125  FP16    fcvtzs  dq0 : dq5 immhb_fxp bhsd_immh_sz
+0111111011111001101110xxxxxxxxxx  n   126  FP16    fcvtzu   h0 : h5
+0001111011011001xxxxxxxxxxxxxxxx  n   126  FP16    fcvtzu   w0 : h5 scale
+1001111011011001xxxxxxxxxxxxxxxx  n   126  FP16    fcvtzu   x0 : h5 scale
+1001111011111001000000xxxxxxxxxx  n   126  FP16    fcvtzu   x0 : h5
+0001111011111001000000xxxxxxxxxx  n   126  FP16    fcvtzu   w0 : h5
 0x10111011111001101110xxxxxxxxxx  n   126  FP16    fcvtzu  dq0 : dq5 h_sz
 0x1011110xxxxxxx111111xxxxxxxxxx  n   126  FP16    fcvtzu  dq0 : dq5 immhb_fxp bhsd_immh_sz
 0x101110010xxxxx001111xxxxxxxxxx  n   127  FP16      fdiv  dq0 : dq5 dq16 h_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1960,6 +1960,17 @@
     instr_create_1dst_2src(dc, OP_fcvtms, Rd, Rm, width)
 
 /**
+ * Creates an FCVTMU vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The input vector register.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_HALF()
+ * or #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fcvtmu_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtmu, Rd, Rm, width)
+
+/**
  * Creates an FCVTNS vector instruction.
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      The output register.
@@ -1969,6 +1980,17 @@
  */
 #define INSTR_CREATE_fcvtns_vector(dc, Rd, Rm, width) \
     instr_create_1dst_2src(dc, OP_fcvtns, Rd, Rm, width)
+
+/**
+ * Creates an FCVTNU vector instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      The output register.
+ * \param Rm      The first input register.
+ * \param width   Immediate int of the vector element width. Must be #OPND_CREATE_HALF()
+ * or #OPND_CREATE_SINGLE() or #OPND_CREATE_DOUBLE().
+ */
+#define INSTR_CREATE_fcvtnu_vector(dc, Rd, Rm, width) \
+    instr_create_1dst_2src(dc, OP_fcvtnu, Rd, Rm, width)
 
 /**
  * Creates an FCVTPS vector instruction.
@@ -2299,6 +2321,15 @@
     instr_create_1dst_1src(dc, OP_fcvtms, Rd, Rm)
 
 /**
+ * Creates an FCVTMU floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
+ */
+#define INSTR_CREATE_fcvtmu_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtmu, Rd, Rm)
+
+/**
  * Creates an FCVTNS floating point instruction.
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rd      Floating-point or integer output register.
@@ -2306,6 +2337,15 @@
  */
 #define INSTR_CREATE_fcvtns_scalar(dc, Rd, Rm) \
     instr_create_1dst_1src(dc, OP_fcvtns, Rd, Rm)
+
+/**
+ * Creates an FCVTNU floating point instruction.
+ * \param dc      The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd      Floating-point or integer output register.
+ * \param Rm      Floating-point input register.
+ */
+#define INSTR_CREATE_fcvtnu_scalar(dc, Rd, Rm) \
+    instr_create_1dst_1src(dc, OP_fcvtnu, Rd, Rm)
 
 /**
  * Creates an FCVTPS floating point instruction.

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -343,6 +343,104 @@ TEST_INSTR(fcvtms_scalar)
 }
 
 /*
+ * FCVTMU
+ */
+
+TEST_INSTR(fcvtmu_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FCVTMU  <Vd>.8H, <Vn>.8H */
+    opnd_t elsz;
+    reg_id_t Rd_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    elsz = OPND_CREATE_HALF();
+    const char *expected_0[3] = {
+        "fcvtmu %q0 $0x01 -> %q0",
+        "fcvtmu %q11 $0x01 -> %q10",
+        "fcvtmu %q31 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtmu_vector(dc, opnd_create_reg(Rd_0[i]),
+                                           opnd_create_reg(Rn_0[i]), elsz);
+        if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FCVTMU  <Vd>.4H, <Vn>.4H */
+    reg_id_t Rd_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_1[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    elsz = OPND_CREATE_HALF();
+    const char *expected_1[3] = {
+        "fcvtmu %d0 $0x01 -> %d0",
+        "fcvtmu %d11 $0x01 -> %d10",
+        "fcvtmu %d31 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtmu_vector(dc, opnd_create_reg(Rd_1[i]),
+                                           opnd_create_reg(Rn_1[i]), elsz);
+        if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(fcvtmu_scalar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FCVTMU  <Wd>, <Hn> */
+    reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_0[3] = {
+        "fcvtmu %h0 -> %w0",
+        "fcvtmu %h11 -> %w10",
+        "fcvtmu %h31 -> %w30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtmu_scalar(dc, opnd_create_reg(Rd_0[i]),
+                                           opnd_create_reg(Rn_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FCVTMU  <Xd>, <Hn> */
+    reg_id_t Rd_1[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    const char *expected_1[3] = {
+        "fcvtmu %h0 -> %x0",
+        "fcvtmu %h11 -> %x10",
+        "fcvtmu %h31 -> %x30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtmu_scalar(dc, opnd_create_reg(Rd_1[i]),
+                                           opnd_create_reg(Rn_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_1[i]))
+            success = false;
+    }
+
+    /* FCVTMU  <Hd>, <Hn> */
+    reg_id_t Rd_2[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    const char *expected_2[3] = {
+        "fcvtmu %h0 -> %h0",
+        "fcvtmu %h11 -> %h10",
+        "fcvtmu %h31 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtmu_scalar(dc, opnd_create_reg(Rd_2[i]),
+                                           opnd_create_reg(Rn_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_2[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+/*
  * FCVTNS
  */
 
@@ -434,6 +532,104 @@ TEST_INSTR(fcvtns_scalar)
         instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtns, instr, expected_2[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+/*
+ * FCVTNU
+ */
+
+TEST_INSTR(fcvtnu_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FCVTNU  <Vd>.8H, <Vn>.8H */
+    opnd_t elsz;
+    reg_id_t Rd_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    elsz = OPND_CREATE_HALF();
+    const char *expected_0[3] = {
+        "fcvtnu %q0 $0x01 -> %q0",
+        "fcvtnu %q11 $0x01 -> %q10",
+        "fcvtnu %q31 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtnu_vector(dc, opnd_create_reg(Rd_0[i]),
+                                           opnd_create_reg(Rn_0[i]), elsz);
+        if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FCVTNU  <Vd>.4H, <Vn>.4H */
+    reg_id_t Rd_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_1[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    elsz = OPND_CREATE_HALF();
+    const char *expected_1[3] = {
+        "fcvtnu %d0 $0x01 -> %d0",
+        "fcvtnu %d11 $0x01 -> %d10",
+        "fcvtnu %d31 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtnu_vector(dc, opnd_create_reg(Rd_1[i]),
+                                           opnd_create_reg(Rn_1[i]), elsz);
+        if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(fcvtnu_scalar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* FCVTNU  <Wd>, <Hn> */
+    reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_0[3] = {
+        "fcvtnu %h0 -> %w0",
+        "fcvtnu %h11 -> %w10",
+        "fcvtnu %h31 -> %w30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtnu_scalar(dc, opnd_create_reg(Rd_0[i]),
+                                           opnd_create_reg(Rn_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_0[i]))
+            success = false;
+    }
+
+    /* FCVTNU  <Xd>, <Hn> */
+    reg_id_t Rd_1[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    const char *expected_1[3] = {
+        "fcvtnu %h0 -> %x0",
+        "fcvtnu %h11 -> %x10",
+        "fcvtnu %h31 -> %x30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtnu_scalar(dc, opnd_create_reg(Rd_1[i]),
+                                           opnd_create_reg(Rn_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_1[i]))
+            success = false;
+    }
+
+    /* FCVTNU  <Hd>, <Hn> */
+    reg_id_t Rd_2[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    const char *expected_2[3] = {
+        "fcvtnu %h0 -> %h0",
+        "fcvtnu %h11 -> %h10",
+        "fcvtnu %h31 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtnu_scalar(dc, opnd_create_reg(Rd_2[i]),
+                                           opnd_create_reg(Rn_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_2[i]))
             success = false;
     }
 
@@ -633,6 +829,272 @@ TEST_INSTR(fcvtpu_scalar)
             success = false;
     }
 
+    return success;
+}
+
+/*
+ * FCVTZS
+ */
+
+TEST_INSTR(fcvtzs_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FCVTZS  <Hd>.<Ts>, <Hn>.<Ts> */
+
+    /* Testing FCVTZS  <Hd>.4H, <Hn>.4H */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    opnd_t Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_0[3] = {
+        "fcvtzs %d0 $0x01 -> %d0",
+        "fcvtzs %d11 $0x01 -> %d10",
+        "fcvtzs %d31 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzs_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                           opnd_create_reg(Rn_0_0[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZS  <Hd>.8H, <Hn>.8H */
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_1[3] = {
+        "fcvtzs %q0 $0x01 -> %q0",
+        "fcvtzs %q11 $0x01 -> %q10",
+        "fcvtzs %q31 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzs_vector(dc, opnd_create_reg(Rd_0_1[i]),
+                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_0_1[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(fcvtzs_scalar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FCVTZS  <Wd>, <Hn> */
+    reg_id_t Rd_1_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_1_0[3] = {
+        "fcvtzs %h0 -> %w0",
+        "fcvtzs %h11 -> %w10",
+        "fcvtzs %h31 -> %w30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(Rd_1_0[i]),
+                                           opnd_create_reg(Rn_1_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_1_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZS  <Xd>, <Hn> */
+    reg_id_t Rd_4_0[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    reg_id_t Rn_4_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_4_0[3] = {
+        "fcvtzs %h0 -> %x0",
+        "fcvtzs %h11 -> %x10",
+        "fcvtzs %h31 -> %x30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(Rd_4_0[i]),
+                                           opnd_create_reg(Rn_4_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_4_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZS  <Wd>, <Hn>, #<fbits> */
+    reg_id_t Rd_10_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_10_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    uint scale_10_0[3] = { 32, 22, 1 };
+    const char *expected_10_0[3] = {
+        "fcvtzs %h0 $0x20 -> %w0",
+        "fcvtzs %h11 $0x16 -> %w10",
+        "fcvtzs %h31 $0x01 -> %w30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzs_scalar_fixed(
+            dc, opnd_create_reg(Rd_10_0[i]), opnd_create_reg(Rn_10_0[i]),
+            opnd_create_immed_uint(scale_10_0[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_10_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZS  <Xd>, <Hn>, #<fbits> */
+    reg_id_t Rd_11_0[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    reg_id_t Rn_11_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    uint scale_11_0[3] = { 64, 33, 1 };
+    const char *expected_11_0[3] = {
+        "fcvtzs %h0 $0x40 -> %x0",
+        "fcvtzs %h11 $0x21 -> %x10",
+        "fcvtzs %h31 $0x01 -> %x30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzs_scalar_fixed(
+            dc, opnd_create_reg(Rd_11_0[i]), opnd_create_reg(Rn_11_0[i]),
+            opnd_create_immed_uint(scale_11_0[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_11_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZS  <Hd>, <Hn> */
+    reg_id_t Rd_12_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_12_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_12_0[3] = {
+        "fcvtzs %h0 -> %h0",
+        "fcvtzs %h11 -> %h10",
+        "fcvtzs %h31 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(Rd_12_0[i]),
+                                           opnd_create_reg(Rn_12_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_12_0[i]))
+            success = false;
+    }
+    return success;
+}
+
+/*
+ * FCVTZU
+ */
+
+TEST_INSTR(fcvtzu_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FCVTZU  <Hd>.<Ts>, <Hn>.<Ts> */
+
+    /* Testing FCVTZU  <Hd>.4H, <Hn>.4H */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    opnd_t Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_0[3] = {
+        "fcvtzu %d0 $0x01 -> %d0",
+        "fcvtzu %d11 $0x01 -> %d10",
+        "fcvtzu %d31 $0x01 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                           opnd_create_reg(Rn_0_0[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZU  <Hd>.8H, <Hn>.8H */
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    Rn_elsz = OPND_CREATE_HALF();
+    const char *expected_0_1[3] = {
+        "fcvtzu %q0 $0x01 -> %q0",
+        "fcvtzu %q11 $0x01 -> %q10",
+        "fcvtzu %q31 $0x01 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(Rd_0_1[i]),
+                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
+        if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_0_1[i]))
+            success = false;
+    }
+    return success;
+}
+
+TEST_INSTR(fcvtzu_scalar)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FCVTZU  <Wd>, <Hn> */
+    reg_id_t Rd_1_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_1_0[3] = {
+        "fcvtzu %h0 -> %w0",
+        "fcvtzu %h11 -> %w10",
+        "fcvtzu %h31 -> %w30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(Rd_1_0[i]),
+                                           opnd_create_reg(Rn_1_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_1_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZU  <Xd>, <Hn> */
+    reg_id_t Rd_4_0[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    reg_id_t Rn_4_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_4_0[3] = {
+        "fcvtzu %h0 -> %x0",
+        "fcvtzu %h11 -> %x10",
+        "fcvtzu %h31 -> %x30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(Rd_4_0[i]),
+                                           opnd_create_reg(Rn_4_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_4_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZU  <Wd>, <Hn>, #<fbits> */
+    reg_id_t Rd_10_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_10_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    uint scale_10_0[3] = { 32, 22, 1 };
+    const char *expected_10_0[3] = {
+        "fcvtzu %h0 $0x20 -> %w0",
+        "fcvtzu %h11 $0x16 -> %w10",
+        "fcvtzu %h31 $0x01 -> %w30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzu_scalar_fixed(
+            dc, opnd_create_reg(Rd_10_0[i]), opnd_create_reg(Rn_10_0[i]),
+            opnd_create_immed_uint(scale_10_0[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_10_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZU  <Xd>, <Hn>, #<fbits> */
+    reg_id_t Rd_11_0[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    reg_id_t Rn_11_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    uint scale_11_0[3] = { 64, 33, 1 };
+    const char *expected_11_0[3] = {
+        "fcvtzu %h0 $0x40 -> %x0",
+        "fcvtzu %h11 $0x21 -> %x10",
+        "fcvtzu %h31 $0x01 -> %x30",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzu_scalar_fixed(
+            dc, opnd_create_reg(Rd_11_0[i]), opnd_create_reg(Rn_11_0[i]),
+            opnd_create_immed_uint(scale_11_0[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_11_0[i]))
+            success = false;
+    }
+
+    /* Testing FCVTZU  <Hd>, <Hn> */
+    reg_id_t Rd_12_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_12_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_12_0[3] = {
+        "fcvtzu %h0 -> %h0",
+        "fcvtzu %h11 -> %h10",
+        "fcvtzu %h31 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(Rd_12_0[i]),
+                                           opnd_create_reg(Rn_12_0[i]));
+        if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_12_0[i]))
+            success = false;
+    }
     return success;
 }
 
@@ -2516,12 +2978,20 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(fcvtau_scalar);
     RUN_INSTR_TEST(fcvtms_vector);
     RUN_INSTR_TEST(fcvtms_scalar);
+    RUN_INSTR_TEST(fcvtmu_vector);
+    RUN_INSTR_TEST(fcvtmu_scalar);
     RUN_INSTR_TEST(fcvtns_vector);
     RUN_INSTR_TEST(fcvtns_scalar);
+    RUN_INSTR_TEST(fcvtnu_vector);
+    RUN_INSTR_TEST(fcvtnu_scalar);
     RUN_INSTR_TEST(fcvtps_vector);
     RUN_INSTR_TEST(fcvtps_scalar);
     RUN_INSTR_TEST(fcvtpu_vector);
     RUN_INSTR_TEST(fcvtpu_scalar);
+    RUN_INSTR_TEST(fcvtzs_vector);
+    RUN_INSTR_TEST(fcvtzs_scalar);
+    RUN_INSTR_TEST(fcvtzu_vector);
+    RUN_INSTR_TEST(fcvtzu_scalar);
 
     RUN_INSTR_TEST(frinta_vector);
     RUN_INSTR_TEST(frinta_scalar);


### PR DESCRIPTION
This patch adds half-precision FP conversion instructions extending
support of full-precision variants in v8.0.
```
FCVTMU  <Hd>.<Ts>, <Hn>.<Ts>
FCVTNU  <Hd>.<Ts>, <Hn>.<Ts>
FCVTZS  <Hd>.<Ts>, <Hn>.<Ts>
FCVTZS  <Wd>, <Hn>
FCVTZS  <Xd>, <Hn>
FCVTZS  <Wd>, <Hn>, #<fbits>
FCVTZS  <Xd>, <Hn>, #<fbits>
FCVTZS  <Hd>, <Hn>
FCVTZU  <Hd>.<Ts>, <Hn>.<Ts>
FCVTZU  <Wd>, <Hn>
FCVTZU  <Xd>, <Hn>
FCVTZU  <Wd>, <Hn>, #<fbits>
FCVTZU  <Xd>, <Hn>, #<fbits>
FCVTZU  <Hd>, <Hn>
```
Issue: #2626