### PR TITLE
i#2626: AArch64 v8.2 codec: Update fcsel to use a predicate

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5147,6 +5147,27 @@ decode_opnds_fccm(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int 
     return true;
 }
 
+#define decode_h_variant(instr)                                                       \
+    static inline uint decode_opnds_##instr##_h(uint enc, dcontext_t *dcontext,       \
+                                                byte *pc, instr_t *instr, int opcode) \
+    {                                                                                 \
+        if (BITS(enc, 23, 22) != 0b11)                                                \
+            return false;                                                             \
+        return decode_opnds_##instr(enc, dcontext, pc, instr, opcode);                \
+    }
+
+#define decode_sd_variant(instr)                                                       \
+    static inline uint decode_opnds_##instr##_sd(uint enc, dcontext_t *dcontext,       \
+                                                 byte *pc, instr_t *instr, int opcode) \
+    {                                                                                  \
+        if (BITS(enc, 23, 22) == 0b11)                                                 \
+            return false;                                                              \
+        return decode_opnds_##instr(enc, dcontext, pc, instr, opcode);                 \
+    }
+
+decode_h_variant(fccm);
+decode_sd_variant(fccm);
+
 static inline uint
 encode_opnds_fccm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
 {
@@ -5177,38 +5198,90 @@ encode_opnds_fccm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     return (enc | (rn << 5) | (rm << 16) | (ftype << 22) | nzcv | (cond << 12));
 }
 
+#define encode_h_variant(instr)                                                     \
+    static inline uint encode_opnds_##instr##_h(byte *pc, instr_t *instr, uint enc, \
+                                                decode_info_t *di)                  \
+    {                                                                               \
+        uint h_enc = encode_opnds_##instr(pc, instr, enc, di);                      \
+        if (BITS(enc, 23, 22) != 0b11)                                              \
+            return ENCFAIL;                                                         \
+        return h_enc;                                                               \
+    }
+
+#define encode_sd_variant(instr)                                                     \
+    static inline uint encode_opnds_##instr##_sd(byte *pc, instr_t *instr, uint enc, \
+                                                 decode_info_t *di)                  \
+    {                                                                                \
+        uint sd_enc = encode_opnds_##instr(pc, instr, enc, di);                      \
+        if (BITS(enc, 23, 22) == 0b11)                                               \
+            return ENCFAIL;                                                          \
+        return sd_enc;                                                               \
+    }
+
+encode_h_variant(fccm);
+encode_sd_variant(fccm);
+
+/* fcsel: operands for conditional compare instructions */
+
 static inline bool
-decode_opnds_fccm_h(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
+decode_opnds_fcsel(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
 {
-    if (BITS(enc, 23, 22) != 0b11)
+    instr_set_opcode(instr, opcode);
+    instr_set_num_opnds(dcontext, instr, 1, 2);
+
+    reg_id_t rn, rm, rd;
+    uint ftype = BITS(enc, 23, 22);
+
+    if (!decode_float_reg(BITS(enc, 9, 5), ftype, &rn))
         return false;
-    return decode_opnds_fccm(enc, dcontext, pc, instr, opcode);
+    if (!decode_float_reg(BITS(enc, 20, 16), ftype, &rm))
+        return false;
+    if (!decode_float_reg(BITS(enc, 4, 0), ftype, &rd))
+        return false;
+
+    instr_set_src(instr, 0, opnd_create_reg(rn));
+    instr_set_src(instr, 1, opnd_create_reg(rm));
+    instr_set_dst(instr, 0, opnd_create_reg(rd));
+
+    /* cond */
+    instr_set_predicate(instr, DR_PRED_EQ + BITS(enc, 15, 12));
+
+    return true;
 }
 
+decode_h_variant(fcsel);
+decode_sd_variant(fcsel);
+
 static inline uint
-encode_opnds_fccm_h(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
+encode_opnds_fcsel(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
 {
-    uint h_enc = encode_opnds_fccm(pc, instr, enc, di);
-    if (BITS(enc, 23, 22) != 0b11)
+    if (instr_num_dsts(instr) != 1 || instr_num_srcs(instr) != 2)
         return ENCFAIL;
-    return h_enc;
+
+    opnd_size_t rn_size = OPSZ_NA, rm_size = OPSZ_NA, rd_size = OPSZ_NA;
+    uint rn, rm, rd;
+    uint ftype;
+
+    if (!encode_vreg(&rn_size, &rn, instr_get_src(instr, 0)))
+        return ENCFAIL;
+    if (!encode_vreg(&rm_size, &rm, instr_get_src(instr, 1)))
+        return ENCFAIL;
+    if (!encode_vreg(&rd_size, &rd, instr_get_dst(instr, 0)))
+        return ENCFAIL;
+    if ((rn_size != rm_size || rn_size != rd_size))
+        return ENCFAIL;
+    if (!size_to_ftype(rn_size, &ftype))
+        return ENCFAIL;
+
+    uint cond = instr_get_predicate(instr) - DR_PRED_EQ;
+    if (cond >= 16)
+        return ENCFAIL;
+
+    return (enc | (rn << 5) | (rm << 16) | rd | (ftype << 22) | (cond << 12));
 }
 
-static inline bool
-decode_opnds_fccm_sd(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int opcode)
-{
-    if (BITS(enc, 23, 22) == 0b11)
-        return false;
-    return decode_opnds_fccm(enc, dcontext, pc, instr, opcode);
-}
-static inline uint
-encode_opnds_fccm_sd(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
-{
-    uint sd_enc = encode_opnds_fccm(pc, instr, enc, di);
-    if (BITS(enc, 23, 22) == 0b11)
-        return ENCFAIL;
-    return sd_enc;
-}
+encode_h_variant(fcsel)
+encode_sd_variant(fcsel)
 
 /* mst: used for MSR.
  * With MSR the destination register may or may not be one of the system registers

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5280,10 +5280,10 @@ encode_opnds_fcsel(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     return (enc | (rn << 5) | (rm << 16) | rd | (ftype << 22) | (cond << 12));
 }
 
-encode_h_variant(fcsel)
-encode_sd_variant(fcsel)
+encode_h_variant(fcsel);
+encode_sd_variant(fcsel);
 
-/* mst: used for MSR.
+/* msr: used for MSR.
  * With MSR the destination register may or may not be one of the system registers
  * that we recognise.
  */

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -292,7 +292,7 @@ x1001010xx0xxxxxxxxxxxxxxxxxxxxx  n   90   BASE        eor            wx0 : wx5 
 0001111000100000001000xxxxx11000  w   108  BASE      fcmpe                : s5 zero_fp_const
 00011110011xxxxx001000xxxxx10000  w   108  BASE      fcmpe                : d5 d16
 00011110001xxxxx001000xxxxx10000  w   108  BASE      fcmpe                : s5 s16
-00011110xx1xxxxxxxxx11xxxxxxxxxx  r   109  BASE      fcsel     float_reg0 : float_reg5 float_reg16 cond
+000111100x1xxxxxxxxx11xxxxxxxxxx  r   109  BASE      fcsel       fcsel_sd
 0001111000100010110000xxxxxxxxxx  n   110  BASE       fcvt             d0 : s5
 0001111001100010010000xxxxxxxxxx  n   110  BASE       fcvt             s0 : d5
 0001111000100100000000xxxxxxxxxx  n   111  BASE     fcvtas             w0 : s5

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -64,6 +64,7 @@
 0001111011100000001000xxxxx11000  w   108  FP16     fcmpe      : h5 zero_fp_const
 0001111011100000001000xxxxx11000  w   108  FP16     fcmpe      : h5 zero_fp_const
 00011110111xxxxx001000xxxxx10000  w   108  FP16     fcmpe      : h5 h16
+00011110111xxxxxxxxx11xxxxxxxxxx  r   109  FP16     fcsel  fcsel_h
 0001111000100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : s5
 0001111001100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : d5
 0001111011100010010000xxxxxxxxxx  n   110  FP16      fcvt   s0 : h5

--- a/core/ir/aarch64/disassemble.c
+++ b/core/ir/aarch64/disassemble.c
@@ -148,21 +148,13 @@ void
 print_opcode_name(instr_t *instr, const char *name, char *buf, size_t bufsz,
                   size_t *sofar INOUT)
 {
-    if (instr_get_opcode(instr) == OP_bcond) {
-        print_to_buffer(buf, bufsz, sofar, "b.%s",
-                        pred_names[instr_get_predicate(instr)]);
-    } else if (instr_get_opcode(instr) == OP_ccmp) {
-        print_to_buffer(buf, bufsz, sofar, "ccmp.%s",
-                        pred_names[instr_get_predicate(instr)]);
-    } else if (instr_get_opcode(instr) == OP_ccmn) {
-        print_to_buffer(buf, bufsz, sofar, "ccmn.%s",
-                        pred_names[instr_get_predicate(instr)]);
-    } else if (instr_get_opcode(instr) == OP_fccmp) {
-        print_to_buffer(buf, bufsz, sofar, "fccmp.%s",
-                        pred_names[instr_get_predicate(instr)]);
-    } else if (instr_get_opcode(instr) == OP_fccmpe) {
-        print_to_buffer(buf, bufsz, sofar, "fccmpe.%s",
-                        pred_names[instr_get_predicate(instr)]);
+    if (instr_get_predicate(instr) != DR_PRED_NONE) {
+        if (instr_get_opcode(instr) == OP_bcond)
+            print_to_buffer(buf, bufsz, sofar, "b.%s",
+                            pred_names[instr_get_predicate(instr)]);
+        else
+            print_to_buffer(buf, bufsz, sofar, "%s.%s", name,
+                            pred_names[instr_get_predicate(instr)]);
     } else
         print_to_buffer(buf, bufsz, sofar, "%s", name);
 }

--- a/core/ir/aarch64/disassemble.c
+++ b/core/ir/aarch64/disassemble.c
@@ -149,12 +149,13 @@ print_opcode_name(instr_t *instr, const char *name, char *buf, size_t bufsz,
                   size_t *sofar INOUT)
 {
     if (instr_get_predicate(instr) != DR_PRED_NONE) {
-        if (instr_get_opcode(instr) == OP_bcond)
+        if (instr_get_opcode(instr) == OP_bcond) {
             print_to_buffer(buf, bufsz, sofar, "b.%s",
                             pred_names[instr_get_predicate(instr)]);
-        else
+        } else {
             print_to_buffer(buf, bufsz, sofar, "%s.%s", name,
                             pred_names[instr_get_predicate(instr)]);
+        }
     } else
         print_to_buffer(buf, bufsz, sofar, "%s", name);
 }

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -4057,6 +4057,28 @@
     INSTR_PRED(instr_create_0dst_3src(dc, OP_fccmpe, Rn, Rm, nzcv), (condition_code))
 
 /**
+ * Creates a FCSEL instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCSEL   <Dd>, <Dn>, <Dm>, <cond>
+ *    FCSEL   <Hd>, <Hn>, <Hm>, <cond>
+ *    FCSEL   <Sd>, <Sn>, <Sm>, <cond>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination register. Can be D (doubleword, 64 bits),
+ *             H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rn   The second source register. Can be D (doubleword, 64 bits),
+               H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param Rm   The third source register. Can be D (doubleword, 64 bits),
+               H (halfword, 16 bits) or S (singleword, 32 bits)
+ * \param condition_code   The comparison condition specified by #dr_pred_type_t,
+ *                         e.g. #DR_PRED_EQ.
+ */
+#define INSTR_CREATE_fcsel(dc, Rd, Rn, Rm, condition_code) \
+    INSTR_PRED(instr_create_1dst_2src(dc, OP_fcsel, Rd, Rn, Rm), (condition_code))
+
+/**
  * Creates a FCMP instruction.
  *
  * This macro is used to encode the forms:

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -2961,6 +2961,69 @@ TEST_INSTR(fcmpe)
     return success;
 }
 
+TEST_INSTR(fcsel)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FCSEL   <Dd>, <Dn>, <Dm>, <cond> */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D12, DR_REG_D31 };
+    dr_pred_type_t condition_code_0_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_0_0[3] = {
+        "fcsel.eq %d0 %d0 -> %d0",
+        "fcsel.hi %d11 %d12 -> %d10",
+        "fcsel.nv %d31 %d31 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fcsel(dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+                               opnd_create_reg(Rm_0_0[i]), condition_code_0_0[i]);
+        if (!test_instr_encoding(dc, OP_fcsel, instr, expected_0_0[i]))
+            success = false;
+    }
+
+    /* Testing FCSEL   <Hd>, <Hn>, <Hm>, <cond> */
+    reg_id_t Rd_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    reg_id_t Rm_1_0[3] = { DR_REG_H0, DR_REG_H12, DR_REG_H31 };
+    dr_pred_type_t condition_code_1_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_1_0[3] = {
+        "fcsel.eq %h0 %h0 -> %h0",
+        "fcsel.hi %h11 %h12 -> %h10",
+        "fcsel.nv %h31 %h31 -> %h31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fcsel(dc, opnd_create_reg(Rd_1_0[i]), opnd_create_reg(Rn_1_0[i]),
+                               opnd_create_reg(Rm_1_0[i]), condition_code_1_0[i]);
+        if (!test_instr_encoding(dc, OP_fcsel, instr, expected_1_0[i]))
+            success = false;
+    }
+
+    /* Testing FCSEL   <Sd>, <Sn>, <Sm>, <cond> */
+    reg_id_t Rd_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    reg_id_t Rm_2_0[3] = { DR_REG_S0, DR_REG_S12, DR_REG_S31 };
+    dr_pred_type_t condition_code_2_0[3] = { DR_PRED_EQ, DR_PRED_HI, DR_PRED_NV };
+    const char *expected_2_0[3] = {
+        "fcsel.eq %s0 %s0 -> %s0",
+        "fcsel.hi %s11 %s12 -> %s10",
+        "fcsel.nv %s31 %s31 -> %s31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr =
+            INSTR_CREATE_fcsel(dc, opnd_create_reg(Rd_2_0[i]), opnd_create_reg(Rn_2_0[i]),
+                               opnd_create_reg(Rm_2_0[i]), condition_code_2_0[i]);
+        if (!test_instr_encoding(dc, OP_fcsel, instr, expected_2_0[i]))
+            success = false;
+    }
+
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -3054,6 +3117,7 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(fccmpe);
     RUN_INSTR_TEST(fcmp);
     RUN_INSTR_TEST(fcmpe);
+    RUN_INSTR_TEST(fcsel);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch updates fcsel so that it sets the condition
parameter as a predicate and joins it to the mnemonic
when printing as debug. Also added are tests and
instr_create macros.

Issue: #2626
