### PR TITLE
i#2626: AArch64 v8.2 codec: Fix s/udot operands and add missing variants

### DIFF
--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -179,7 +179,8 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0001111011000010xxxxxxxxxxxxxxxx  n   362  FP16     scvtf   h0 : w5 scale
 1001111011000010xxxxxxxxxxxxxxxx  n   362  FP16     scvtf   h0 : x5 scale
 0101111001111001110110xxxxxxxxxx  n   362  FP16     scvtf   h0 : h5
-0x001110100xxxxx100101xxxxxxxxxx  n   364  DotProd      sdot  dq0 : dq5 dq16 s_const_sz b_const_sz
+0x001110100xxxxx100101xxxxxxxxxx  n   364  DotProd      sdot  dq0 : dq0 dq5 dq16 b_const_sz
+0x00111110xxxxxx1110x0xxxxxxxxxx  n   364  DotProd      sdot  dq0 : dq0 dq5 q16 vindex_SD b_const_sz
 11001110011xxxxx100000xxxxxxxxxx  n   595  SHA512   sha512h   q0 : q0 q5 q16 d_const_sz
 11001110011xxxxx100001xxxxxxxxxx  n   596  SHA512  sha512h2   q0 : q0 q5 q16 d_const_sz
 1100111011000000100000xxxxxxxxxx  n   597  SHA512 sha512su0   q0 : q0 q5 d_const_sz
@@ -200,5 +201,6 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0001111011000011xxxxxxxxxxxxxxxx  n   510  FP16     ucvtf   h0 : w5 scale
 1001111011000011xxxxxxxxxxxxxxxx  n   510  FP16     ucvtf   h0 : x5 scale
 0111111001111001110110xxxxxxxxxx  n   510  FP16     ucvtf   h0 : h5
-0x101110100xxxxx100101xxxxxxxxxx  n   512  DotProd      udot  dq0 : dq5 dq16 s_const_sz b_const_sz
+0x101110100xxxxx100101xxxxxxxxxx  n   512  DotProd      udot  dq0 : dq0 dq5 dq16 b_const_sz
+0x10111110xxxxxx1110x0xxxxxxxxxx  n   512  DotProd      udot  dq0 : dq0 dq5 q16 vindex_SD b_const_sz
 11001110100xxxxxxxxxxxxxxxxxxxxx  n   604  SHA3       xar   q0 : q5 q16 imm6 d_const_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -4144,4 +4144,76 @@
  */
 #define INSTR_CREATE_fcmpe(dc, Rn, Rm) instr_create_0dst_2src(dc, OP_fcmpe, Rn, Rm)
 
+/**
+ * Creates a SDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination vector register,
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, D (doubleword, 64 bits) or
+ *             Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, D (doubleword, 64 bits) or
+ *             Q (quadword, 128 bits)
+ */
+#define INSTR_CREATE_sdot_vector(dc, Rd, Rn, Rm) \
+    instr_create_1dst_4src(dc, OP_sdot, Rd, Rd, Rn, Rm, OPND_CREATE_BYTE())
+
+/**
+ * Creates a SDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination vector register,
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, D (doubleword, 64 bits) or
+ *             Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param index   The immediate index for Rm
+ */
+#define INSTR_CREATE_sdot_vector_indexed(dc, Rd, Rn, Rm, index) \
+    instr_create_1dst_5src(dc, OP_sdot, Rd, Rd, Rn, Rm, index, OPND_CREATE_BYTE())
+
+/**
+ * Creates a UDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination vector register,
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, D (doubleword, 64 bits) or
+ *             Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, D (doubleword, 64 bits) or
+ *             Q (quadword, 128 bits)
+ */
+#define INSTR_CREATE_udot_vector(dc, Rd, Rn, Rm) \
+    instr_create_1dst_4src(dc, OP_udot, Rd, Rd, Rn, Rm, OPND_CREATE_BYTE())
+
+/**
+ * Creates a UDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination vector register,
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register, D (doubleword, 64 bits) or
+ *             Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param index   The immediate index for Rm
+ */
+#define INSTR_CREATE_udot_vector_indexed(dc, Rd, Rn, Rm, index) \
+    instr_create_1dst_5src(dc, OP_udot, Rd, Rd, Rn, Rm, index, OPND_CREATE_BYTE())
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -3024,6 +3024,174 @@ TEST_INSTR(fcsel)
     return success;
 }
 
+TEST_INSTR(sdot_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb> */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D12, DR_REG_D31 };
+    const char *expected_0_0[3] = {
+        "sdot   %d0 %d0 %d0 $0x00 -> %d0",
+        "sdot   %d10 %d11 %d12 $0x00 -> %d10",
+        "sdot   %d31 %d31 %d31 $0x00 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sdot_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                         opnd_create_reg(Rn_0_0[i]),
+                                         opnd_create_reg(Rm_0_0[i]));
+        if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_0[i]))
+            success = false;
+    }
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    const char *expected_0_1[3] = {
+        "sdot   %q0 %q0 %q0 $0x00 -> %q0",
+        "sdot   %q10 %q11 %q12 $0x00 -> %q10",
+        "sdot   %q31 %q31 %q31 $0x00 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sdot_vector(dc, opnd_create_reg(Rd_0_1[i]),
+                                         opnd_create_reg(Rn_0_1[i]),
+                                         opnd_create_reg(Rm_0_1[i]));
+        if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(sdot_vector_indexed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>] */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_0_0[3] = { 0, 0, 3 };
+    const char *expected_0_0[3] = {
+        "sdot   %d0 %d0 %q0 $0x00 $0x00 -> %d0",
+        "sdot   %d10 %d11 %q12 $0x00 $0x00 -> %d10",
+        "sdot   %d31 %d31 %q31 $0x03 $0x00 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sdot_vector_indexed(
+            dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+            opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(index_0_0[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_0[i]))
+            success = false;
+    }
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_0_1[3] = { 0, 0, 3 };
+    const char *expected_0_1[3] = {
+        "sdot   %q0 %q0 %q0 $0x00 $0x00 -> %q0",
+        "sdot   %q10 %q11 %q12 $0x00 $0x00 -> %q10",
+        "sdot   %q31 %q31 %q31 $0x03 $0x00 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_sdot_vector_indexed(
+            dc, opnd_create_reg(Rd_0_1[i]), opnd_create_reg(Rn_0_1[i]),
+            opnd_create_reg(Rm_0_1[i]), opnd_create_immed_uint(index_0_1[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(udot_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb> */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D12, DR_REG_D31 };
+    const char *expected_0_0[3] = {
+        "udot   %d0 %d0 %d0 $0x00 -> %d0",
+        "udot   %d10 %d11 %d12 $0x00 -> %d10",
+        "udot   %d31 %d31 %d31 $0x00 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_udot_vector(dc, opnd_create_reg(Rd_0_0[i]),
+                                         opnd_create_reg(Rn_0_0[i]),
+                                         opnd_create_reg(Rm_0_0[i]));
+        if (!test_instr_encoding(dc, OP_udot, instr, expected_0_0[i]))
+            success = false;
+    }
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    const char *expected_0_1[3] = {
+        "udot   %q0 %q0 %q0 $0x00 -> %q0",
+        "udot   %q10 %q11 %q12 $0x00 -> %q10",
+        "udot   %q31 %q31 %q31 $0x00 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_udot_vector(dc, opnd_create_reg(Rd_0_1[i]),
+                                         opnd_create_reg(Rn_0_1[i]),
+                                         opnd_create_reg(Rm_0_1[i]));
+        if (!test_instr_encoding(dc, OP_udot, instr, expected_0_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
+TEST_INSTR(udot_vector_indexed)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>] */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_0_0[3] = { 0, 0, 3 };
+    const char *expected_0_0[3] = {
+        "udot   %d0 %d0 %q0 $0x00 $0x00 -> %d0",
+        "udot   %d10 %d11 %q12 $0x00 $0x00 -> %d10",
+        "udot   %d31 %d31 %q31 $0x03 $0x00 -> %d31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_udot_vector_indexed(
+            dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
+            opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(index_0_0[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_udot, instr, expected_0_0[i]))
+            success = false;
+    }
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_0_1[3] = { 0, 0, 3 };
+    const char *expected_0_1[3] = {
+        "udot   %q0 %q0 %q0 $0x00 $0x00 -> %q0",
+        "udot   %q10 %q11 %q12 $0x00 $0x00 -> %q10",
+        "udot   %q31 %q31 %q31 $0x03 $0x00 -> %q31",
+    };
+    for (int i = 0; i < 3; i++) {
+        instr = INSTR_CREATE_udot_vector_indexed(
+            dc, opnd_create_reg(Rd_0_1[i]), opnd_create_reg(Rn_0_1[i]),
+            opnd_create_reg(Rm_0_1[i]), opnd_create_immed_uint(index_0_1[i], OPSZ_0));
+        if (!test_instr_encoding(dc, OP_udot, instr, expected_0_1[i]))
+            success = false;
+    }
+
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -3118,6 +3286,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(fcmp);
     RUN_INSTR_TEST(fcmpe);
     RUN_INSTR_TEST(fcsel);
+
+    RUN_INSTR_TEST(sdot_vector);
+    RUN_INSTR_TEST(sdot_vector_indexed);
+    RUN_INSTR_TEST(udot_vector);
+    RUN_INSTR_TEST(udot_vector_indexed);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch corrects the signatures for un-indexed s/udot instructions
and adds the indexed operands as well as instr_create macros and tests.
It affects:
```
SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb>
SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>]
UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb>
UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>]
```
Issue: #2626
