### PR TITLE
i#2626: AArch64 v8.2 codec: add missing fmov and fmulx variants

### DIFF
--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -135,16 +135,20 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0x001110110xxxxx000011xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq0 dq5 dq16 h_sz
 0x00111100xxxxxx0101x0xxxxxxxxxx  n   144  FP16      fmls  dq0 : dq5 dq16_h_sz vindex_H h_sz
 0x001110101xxxxx111011xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 sd16 h_sz
-0x00111110xxxxxx0100x0xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x00111110xxxxxx0100x0xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 dq16_h_sz vindex_H h_sz
 0x101110101xxxxx110011xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 sd16 h_sz
-0x10111110xxxxxx1100x0xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 sd16_h_sz vindex_H h_sz
+0x10111110xxxxxx1100x0xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 dq16_h_sz vindex_H h_sz
 00011110111xxxxxxxx10000000xxxxx  n   147  FP16      fmov   h0 : fpimm13
 0001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : w5
 1001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : x5
+0001111011100110000000xxxxxxxxxx  n   147  FP16      fmov   w0 : h5
+1001111011100110000000xxxxxxxxxx  n   147  FP16      fmov   x0 : h5
 0x00111100000xxx111111xxxxxxxxxx  n   147  FP16      fmov  dq0 : fpimm8 h_sz
 0x00111100xxxxxx1001x0xxxxxxxxxx  n   149  FP16      fmul  dq0 : dq5 dq16_h_sz vindex_H h_sz
 0101111100xxxxxx1001x0xxxxxxxxxx  n   149  FP16      fmul   h0 : h5 dq16_h_sz vindex_H h_sz
 0x101110010xxxxx000111xxxxxxxxxx  n   149  FP16      fmul  dq0 : dq5 dq16 h_sz
+01011110010xxxxx000111xxxxxxxxxx  n   150  FP16     fmulx   h0 : h5 h16
+0x10111100xxxxxx1001x0xxxxxxxxxx  n   150  FP16     fmulx  dq0 : dq5 dq16_h_sz vindex_H h_sz
 0x001110010xxxxx000111xxxxxxxxxx  n   150  FP16     fmulx  dq0 : dq5 dq16 h_sz
 0x10111011111000111110xxxxxxxxxx  n   151  FP16      fneg  dq0 : dq5 h_sz
 0101111011111001110110xxxxxxxxxx  n   155  FP16    frecpe   h0 : h5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1224,11 +1224,14 @@
  *    FMULX   <Dd>.<Ts>, <Dn>.<Ts>, <Dm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rd   The first destination vector register. Can be D (doubleword, 64 bits) or Q (quadword, 128 bits)
- * \param Rn   The second source vector register. Can be D (doubleword, 64 bits) or Q (quadword, 128 bits)
- * \param Rm   The third source vector register. Can be D (doubleword, 64 bits) or Q (quadword, 128 bits)
-[16, 32, 32, 64]
- * \param Rm_elsz   The element size for Rm. Can be OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE()
+ * \param Rd   The first destination vector register. Can be
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register. Can be
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rm   The third source vector register. Can be D (doubleword, 64 bits) or
+ *             Q (quadword, 128 bits)
+ * \param Rm_elsz   The element size for Rm. Can be OPND_CREATE_HALF(),
+ *                  OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE()
  */
 #define INSTR_CREATE_fmulx_vector(dc, Rd, Rn, Rm, Rm_elsz) \
     instr_create_1dst_3src(dc, OP_fmulx, Rd, Rn, Rm, Rm_elsz)
@@ -1244,12 +1247,14 @@
  *    FMULX   <V><d>, <V><n>, <Sm>.<Ts>[<index>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rd   The first destination vector register. Can be S (singleword, 32 bits), D (doubleword, 64 bits) or Q (quadword, 128 bits)
- * \param Rn   The second source vector register. Can be S (singleword, 32 bits), D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rd   The first destination vector register. Can be S (singleword, 32 bits),
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register. Can be S (singleword, 32 bits),
+ *             D (doubleword, 64 bits) or Q (quadword, 128 bits)
  * \param Rm   The third source vector register, Q (quadword, 128 bits)
- * \param index   The immediate index for Rm
-[16, 32, 32, 64, 16]
- * \param Rm_elsz   The element size for Rm. Can be OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE()
+ * \param index     The immediate index for Rm
+ * \param Rm_elsz   The element size for Rm. Can be OPND_CREATE_HALF(),
+ *                  OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE()
  */
 #define INSTR_CREATE_fmulx_vector_idx(dc, Rd, Rn, Rm, index, Rm_elsz) \
     instr_create_1dst_4src(dc, OP_fmulx, Rd, Rn, Rm, index, Rm_elsz)
@@ -1263,9 +1268,12 @@
  *    FMULX   <V><d>, <V><n>, <V><m>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rd   The first destination register. Can be H (halfword, 16 bits), S (singleword, 32 bits) or D (doubleword, 64 bits)
- * \param Rn   The second source register. Can be H (halfword, 16 bits), S (singleword, 32 bits) or D (doubleword, 64 bits)
- * \param Rm   The third source register. Can be H (halfword, 16 bits), S (singleword, 32 bits) or D (doubleword, 64 bits)
+ * \param Rd   The first destination register. Can be H (halfword, 16 bits),
+ *             S (singleword, 32 bits) or D (doubleword, 64 bits)
+ * \param Rn   The second source register. Can be H (halfword, 16 bits),
+ *             S (singleword, 32 bits) or D (doubleword, 64 bits)
+ * \param Rm   The third source register. Can be H (halfword, 16 bits),
+ *             S (singleword, 32 bits) or D (doubleword, 64 bits)
 
  */
 #define INSTR_CREATE_fmulx(dc, Rd, Rn, Rm) \

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -867,6 +867,20 @@
 
 /**
  * Creates an FMOV instruction to move between GPRs and floating point registers.
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FMOV    <Wd>, <Hn>
+ *    FMOV    <Wd>, <Sn>
+ *    FMOV    <Xd>, <Dn>
+ *    FMOV    <Xd>, <Hn>
+ *    FMOV    <Dd>, <Xn>
+ *    FMOV    <Hd>, <Wn>
+ *    FMOV    <Hd>, <Xn>
+ *    FMOV    <Sd>, <Wn>
+ *    FMOV    <Dd>, <Dn>
+ *    FMOV    <Hd>, <Hn>
+ *    FMOV    <Sd>, <Sn>
+ * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
  * \param Rd   The output register.
  * \param Rn   The first input register.
@@ -1202,16 +1216,60 @@
     instr_create_1dst_3src(dc, OP_fadd, Rd, Rm, Rn, width)
 
 /**
- * Creates a FMULX vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Rd      The output register.
- * \param Rm      The first input register.
- * \param Rn      The second input register.
- * \param width   The vector element width. Use either OPND_CREATE_HALF(),
- *                OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * Creates a FMULX instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts>
+ *    FMULX   <Dd>.<Ts>, <Dn>.<Ts>, <Dm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register. Can be D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register. Can be D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rm   The third source vector register. Can be D (doubleword, 64 bits) or Q (quadword, 128 bits)
+[16, 32, 32, 64]
+ * \param Rm_elsz   The element size for Rm. Can be OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE()
  */
-#define INSTR_CREATE_fmulx_vector(dc, Rd, Rm, Rn, width) \
-    instr_create_1dst_3src(dc, OP_fmulx, Rd, Rm, Rn, width)
+#define INSTR_CREATE_fmulx_vector(dc, Rd, Rn, Rm, Rm_elsz) \
+    instr_create_1dst_3src(dc, OP_fmulx, Rd, Rn, Rm, Rm_elsz)
+
+/**
+ * Creates a FMULX instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.H[<index>]
+ *    FMULX   <Dd>.<Ts>, <Dn>.<Ts>, <Dm>.<Tb>[<index>]
+ *    FMULX   <Hd>, <Hn>, <Hm>.H[<index>]
+ *    FMULX   <V><d>, <V><n>, <Sm>.<Ts>[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination vector register. Can be S (singleword, 32 bits), D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rn   The second source vector register. Can be S (singleword, 32 bits), D (doubleword, 64 bits) or Q (quadword, 128 bits)
+ * \param Rm   The third source vector register, Q (quadword, 128 bits)
+ * \param index   The immediate index for Rm
+[16, 32, 32, 64, 16]
+ * \param Rm_elsz   The element size for Rm. Can be OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE()
+ */
+#define INSTR_CREATE_fmulx_vector_idx(dc, Rd, Rn, Rm, index, Rm_elsz) \
+    instr_create_1dst_4src(dc, OP_fmulx, Rd, Rn, Rm, index, Rm_elsz)
+
+/**
+ * Creates a FMULX instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FMULX   <Hd>, <Hn>, <Hm>
+ *    FMULX   <V><d>, <V><n>, <V><m>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first destination register. Can be H (halfword, 16 bits), S (singleword, 32 bits) or D (doubleword, 64 bits)
+ * \param Rn   The second source register. Can be H (halfword, 16 bits), S (singleword, 32 bits) or D (doubleword, 64 bits)
+ * \param Rm   The third source register. Can be H (halfword, 16 bits), S (singleword, 32 bits) or D (doubleword, 64 bits)
+
+ */
+#define INSTR_CREATE_fmulx(dc, Rd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_fmulx, Rd, Rn, Rm)
 
 /**
  * Creates a FCMEQ vector instruction.

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -56,6 +56,13 @@ static byte buf[8192];
         result = false;                                    \
     }
 
+#define TEST_LOOP(opcode, create_name, number, expected, args...)                \
+    for (int i = 0; i < number; i++) {                              \
+        instr = INSTR_CREATE_##create_name(dc, args);                     \
+        if (!test_instr_encoding(dc, OP_##opcode, instr, expected)) \
+            success = false;                                        \
+    }
+
 static bool
 test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
 {
@@ -68,38 +75,44 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
     char *buf = malloc(buflen);
 
     if (instr_get_opcode(instr) != opcode) {
-        print("incorrect opcode for instr %s: %s", opcode, instr_get_opcode(instr));
-        result = false;
+        print("incorrect opcode for instr %s: %s\n\n", opcode, instr_get_opcode(instr));
+        instr_destroy(dc, instr);
+        return false;
     }
     instr_disassemble_to_buffer(dc, instr, buf, buflen);
     end = buf + strlen(buf);
     if (end > buf && *(end - 1) == '\n')
         --end;
 
+    if (!instr_is_encoding_possible(instr)) {
+        print("encoding for expected %s not possible\n", expected);
+        instr_destroy(dc, instr);
+        return false;
+    }
+
     if (end - buf != len || memcmp(buf, expected, len) != 0) {
         print("dissassembled as:\n");
         print("   %s\n", buf);
         print("but expected:\n");
-        print("   %s\n", expected);
+        print("   %s\n\n", expected);
+        instr_destroy(dc, instr);
+        return false;
+    }
+
+
+
+    pc = instr_encode(dc, instr, buf);
+    decin = instr_create(dc);
+    decode(dc, buf, decin);
+    if (!instr_same(instr, decin)) {
+        print("Reencoding failed, dissassembled as:\n   ");
+        instr_disassemble(dc, decin, STDERR);
+        print("\n");
+        print("but expected:\n");
+        print("   %s\n\n", expected);
         result = false;
     }
 
-    if (!instr_is_encoding_possible(instr)) {
-        print("encoding for expected %s not possible\n", expected);
-        result = false;
-    } else {
-        pc = instr_encode(dc, instr, buf);
-        decin = instr_create(dc);
-        decode(dc, buf, decin);
-        if (!instr_same(instr, decin)) {
-            print("Reencoding failed, dissassembled as:\n   ");
-            instr_disassemble(dc, decin, STDERR);
-            print("\n");
-            print("but expected:\n");
-            print("   %s\n", expected);
-            result = false;
-        }
-    }
     instr_destroy(dc, instr);
     instr_destroy(dc, decin);
 

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -56,9 +56,9 @@ static byte buf[8192];
         result = false;                                    \
     }
 
-#define TEST_LOOP(opcode, create_name, number, expected, args...)                \
+#define TEST_LOOP(opcode, create_name, number, expected, args...)   \
     for (int i = 0; i < number; i++) {                              \
-        instr = INSTR_CREATE_##create_name(dc, args);                     \
+        instr = INSTR_CREATE_##create_name(dc, args);               \
         if (!test_instr_encoding(dc, OP_##opcode, instr, expected)) \
             success = false;                                        \
     }
@@ -98,8 +98,6 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
         instr_destroy(dc, instr);
         return false;
     }
-
-
 
     pc = instr_encode(dc, instr, buf);
     decin = instr_create(dc);

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -3392,10 +3392,9 @@ TEST_INSTR(fmulx_vector_idx)
         "fmulx  %s11 %q12 $0x00 $0x02 -> %s10",
         "fmulx  %s31 %q31 $0x03 $0x02 -> %s31",
     };
-    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_3_0[i],
-              opnd_create_reg(Rd_3_0[i]), opnd_create_reg(Rn_3_0[i]),
-              opnd_create_reg(Rm_3_0[i]), opnd_create_immed_uint(index_3_0[i], OPSZ_0),
-              Rm_elsz);
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_3_0[i], opnd_create_reg(Rd_3_0[i]),
+              opnd_create_reg(Rn_3_0[i]), opnd_create_reg(Rm_3_0[i]),
+              opnd_create_immed_uint(index_3_0[i], OPSZ_0), Rm_elsz);
 
     reg_id_t Rd_3_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     reg_id_t Rn_3_1[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
@@ -3407,10 +3406,9 @@ TEST_INSTR(fmulx_vector_idx)
         "fmulx  %d11 %q12 $0x01 $0x03 -> %d10",
         "fmulx  %d31 %q31 $0x01 $0x03 -> %d31",
     };
-    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_3_1[i],
-              opnd_create_reg(Rd_3_1[i]), opnd_create_reg(Rn_3_1[i]),
-              opnd_create_reg(Rm_3_1[i]), opnd_create_immed_uint(index_3_1[i], OPSZ_0),
-              Rm_elsz);
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_3_1[i], opnd_create_reg(Rd_3_1[i]),
+              opnd_create_reg(Rn_3_1[i]), opnd_create_reg(Rm_3_1[i]),
+              opnd_create_immed_uint(index_3_1[i], OPSZ_0), Rm_elsz);
 
     return success;
 }

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -1761,13 +1761,8 @@ TEST_INSTR(fmlsl_vector)
         "fmlsl  %d10 %s11 %s12 $0x01 -> %d10",
         "fmlsl  %d31 %s30 %s29 $0x01 -> %d31",
     };
-    for (int i = 0; i < 3; i++) {
-        instr =
-            INSTR_CREATE_fmlsl_vector(dc, opnd_create_reg(Rd_0[i]),
-                                      opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]));
-        if (!test_instr_encoding(dc, OP_fmlsl, instr, expected_0[i]))
-            success = false;
-    }
+    TEST_LOOP(fmlsl, fmlsl_vector, 3, expected_0[i], opnd_create_reg(Rd_0[i]),
+              opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]));
 
     /* FMLSL <Vd>.4S, <Vn>.4H, <Vm>.4H */
     reg_id_t Rd_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -1778,13 +1773,8 @@ TEST_INSTR(fmlsl_vector)
         "fmlsl  %q10 %d11 %d12 $0x01 -> %q10",
         "fmlsl  %q31 %d30 %d29 $0x01 -> %q31",
     };
-    for (int i = 0; i < 3; i++) {
-        instr =
-            INSTR_CREATE_fmlsl_vector(dc, opnd_create_reg(Rd_1[i]),
-                                      opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
-        if (!test_instr_encoding(dc, OP_fmlsl, instr, expected_1[i]))
-            success = false;
-    }
+    TEST_LOOP(fmlsl, fmlsl_vector, 3, expected_1[i], opnd_create_reg(Rd_1[i]),
+              opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
 
     return success;
 }
@@ -1798,20 +1788,16 @@ TEST_INSTR(fmlsl_vector_idx)
     /* FMLSL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
     reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     reg_id_t Rn_0[3] = { DR_REG_S2, DR_REG_S20, DR_REG_S30 };
-    reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S7, DR_REG_S15 };
+    reg_id_t Rm_0[3] = { DR_REG_D0, DR_REG_D7, DR_REG_D15 };
     short index[3] = { 0, 5, 7 };
     const char *expected_0[3] = {
-        "fmlsl  %d0 %s2 %s0 $0x0000000000000000 $0x01 -> %d0",
-        "fmlsl  %d10 %s20 %s7 $0x0000000000000005 $0x01 -> %d10",
-        "fmlsl  %d31 %s30 %s15 $0x0000000000000007 $0x01 -> %d31",
+        "fmlsl  %d0 %s2 %d0 $0x0000000000000000 $0x01 -> %d0",
+        "fmlsl  %d10 %s20 %d7 $0x0000000000000005 $0x01 -> %d10",
+        "fmlsl  %d31 %s30 %d15 $0x0000000000000007 $0x01 -> %d31",
     };
-    for (int i = 0; i < 3; i++) {
-        instr = INSTR_CREATE_fmlsl_vector_idx(
-            dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
-            opnd_create_reg(Rm_0[i]), OPND_CREATE_INT(index[i]));
-        if (!test_instr_encoding(dc, OP_fmlsl, instr, expected_0[i]))
-            success = false;
-    }
+    TEST_LOOP(fmlsl, fmlsl_vector_idx, 3, expected_0[i], opnd_create_reg(Rd_0[i]),
+              opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]),
+              OPND_CREATE_INT(index[i]));
 
     return success;
 }
@@ -1837,13 +1823,8 @@ TEST_INSTR(fmlsl2_vector)
         "fmlsl2 %d10 %s11 %s12 $0x01 -> %d10",
         "fmlsl2 %d31 %s30 %s29 $0x01 -> %d31",
     };
-    for (int i = 0; i < 3; i++) {
-        instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(Rd_0[i]),
-                                           opnd_create_reg(Rn_0[i]),
-                                           opnd_create_reg(Rm_0[i]));
-        if (!test_instr_encoding(dc, OP_fmlsl2, instr, expected_0[i]))
-            success = false;
-    }
+    TEST_LOOP(fmlsl2, fmlsl2_vector, 3, expected_0[i], opnd_create_reg(Rd_0[i]),
+              opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]));
 
     /* FMLSL2 <Vd>.4S, <Vn>.4H, <Vm>.4H */
     reg_id_t Rd_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -1854,13 +1835,8 @@ TEST_INSTR(fmlsl2_vector)
         "fmlsl2 %q10 %d11 %d12 $0x01 -> %q10",
         "fmlsl2 %q31 %d30 %d29 $0x01 -> %q31",
     };
-    for (int i = 0; i < 3; i++) {
-        instr = INSTR_CREATE_fmlsl2_vector(dc, opnd_create_reg(Rd_1[i]),
-                                           opnd_create_reg(Rn_1[i]),
-                                           opnd_create_reg(Rm_1[i]));
-        if (!test_instr_encoding(dc, OP_fmlsl2, instr, expected_1[i]))
-            success = false;
-    }
+    TEST_LOOP(fmlsl2, fmlsl2_vector, 3, expected_1[i], opnd_create_reg(Rd_1[i]),
+              opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
 
     return success;
 }
@@ -1874,20 +1850,16 @@ TEST_INSTR(fmlsl2_vector_idx)
     /* FMLSL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
     reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     reg_id_t Rn_0[3] = { DR_REG_S2, DR_REG_S20, DR_REG_S30 };
-    reg_id_t Rm_0[3] = { DR_REG_S0, DR_REG_S7, DR_REG_S15 };
+    reg_id_t Rm_0[3] = { DR_REG_D0, DR_REG_D7, DR_REG_D15 };
     short index[3] = { 0, 5, 7 };
     const char *expected_0[3] = {
-        "fmlsl2 %d0 %s2 %s0 $0x0000000000000000 $0x01 -> %d0",
-        "fmlsl2 %d10 %s20 %s7 $0x0000000000000005 $0x01 -> %d10",
-        "fmlsl2 %d31 %s30 %s15 $0x0000000000000007 $0x01 -> %d31",
+        "fmlsl2 %d0 %s2 %d0 $0x0000000000000000 $0x01 -> %d0",
+        "fmlsl2 %d10 %s20 %d7 $0x0000000000000005 $0x01 -> %d10",
+        "fmlsl2 %d31 %s30 %d15 $0x0000000000000007 $0x01 -> %d31",
     };
-    for (int i = 0; i < 3; i++) {
-        instr = INSTR_CREATE_fmlsl2_vector_idx(
-            dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
-            opnd_create_reg(Rm_0[i]), OPND_CREATE_INT(index[i]));
-        if (!test_instr_encoding(dc, OP_fmlsl2, instr, expected_0[i]))
-            success = false;
-    }
+    TEST_LOOP(fmlsl2, fmlsl2_vector_idx, 3, expected_0[i], opnd_create_reg(Rd_0[i]),
+              opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]),
+              OPND_CREATE_INT(index[i]));
 
     return success;
 }
@@ -3192,6 +3164,301 @@ TEST_INSTR(udot_vector_indexed)
     return success;
 }
 
+TEST_INSTR(fmov)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FMOV    <Wd>, <Hn> */
+    reg_id_t Rd_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_0_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_0_0[3] = {
+        "fmov   %h0 -> %w0",
+        "fmov   %h11 -> %w10",
+        "fmov   %h31 -> %w30",
+    };
+    TEST_LOOP(fmov, fmov_general, 3, expected_0_0[i], opnd_create_reg(Rd_0_0[i]),
+              opnd_create_reg(Rn_0_0[i]));
+
+    /* Testing FMOV    <Wd>, <Sn> */
+    reg_id_t Rd_1_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
+    reg_id_t Rn_1_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    const char *expected_1_0[3] = {
+        "fmov   %s0 -> %w0",
+        "fmov   %s11 -> %w10",
+        "fmov   %s31 -> %w30",
+    };
+    TEST_LOOP(fmov, fmov_general, 3, expected_1_0[i], opnd_create_reg(Rd_1_0[i]),
+              opnd_create_reg(Rn_1_0[i]));
+
+    /* Testing FMOV    <Xd>, <Dn> */
+    reg_id_t Rd_2_0[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    reg_id_t Rn_2_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    const char *expected_2_0[3] = {
+        "fmov   %d0 -> %x0",
+        "fmov   %d11 -> %x10",
+        "fmov   %d31 -> %x30",
+    };
+    TEST_LOOP(fmov, fmov_general, 3, expected_2_0[i], opnd_create_reg(Rd_2_0[i]),
+              opnd_create_reg(Rn_2_0[i]));
+
+    /* Testing FMOV    <Xd>, <Hn> */
+    reg_id_t Rd_3_0[3] = { DR_REG_X0, DR_REG_X10, DR_REG_X30 };
+    reg_id_t Rn_3_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    const char *expected_3_0[3] = {
+        "fmov   %h0 -> %x0",
+        "fmov   %h11 -> %x10",
+        "fmov   %h31 -> %x30",
+    };
+    TEST_LOOP(fmov, fmov_general, 3, expected_3_0[i], opnd_create_reg(Rd_3_0[i]),
+              opnd_create_reg(Rn_3_0[i]));
+
+    return success;
+}
+
+TEST_INSTR(fmulx_vector)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D12, DR_REG_D31 };
+    opnd_t Rm_elsz = OPND_CREATE_HALF();
+    const char *expected_0_0[3] = {
+        "fmulx  %d0 %d0 $0x01 -> %d0",
+        "fmulx  %d11 %d12 $0x01 -> %d10",
+        "fmulx  %d31 %d31 $0x01 -> %d31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector, 3, expected_0_0[i], opnd_create_reg(Rd_0_0[i]),
+              opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]), Rm_elsz);
+
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    Rm_elsz = OPND_CREATE_HALF();
+    const char *expected_0_1[3] = {
+        "fmulx  %q0 %q0 $0x01 -> %q0",
+        "fmulx  %q11 %q12 $0x01 -> %q10",
+        "fmulx  %q31 %q31 $0x01 -> %q31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector, 3, expected_0_1[i], opnd_create_reg(Rd_0_1[i]),
+              opnd_create_reg(Rn_0_1[i]), opnd_create_reg(Rm_0_1[i]), Rm_elsz);
+
+    /* Testing FMULX   <Dd>.<Ts>, <Dn>.<Ts>, <Dm>.<Ts> */
+    reg_id_t Rd_1_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_1_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_1_0[3] = { DR_REG_D0, DR_REG_D12, DR_REG_D31 };
+    Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_1_0[3] = {
+        "fmulx  %d0 %d0 $0x02 -> %d0",
+        "fmulx  %d11 %d12 $0x02 -> %d10",
+        "fmulx  %d31 %d31 $0x02 -> %d31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector, 3, expected_1_0[i], opnd_create_reg(Rd_1_0[i]),
+              opnd_create_reg(Rn_1_0[i]), opnd_create_reg(Rm_1_0[i]), Rm_elsz);
+
+    reg_id_t Rd_1_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_1_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_1_1[3] = {
+        "fmulx  %q0 %q0 $0x02 -> %q0",
+        "fmulx  %q11 %q12 $0x02 -> %q10",
+        "fmulx  %q31 %q31 $0x02 -> %q31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
+              opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]), Rm_elsz);
+
+    reg_id_t Rd_1_2[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1_2[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_1_2[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    Rm_elsz = OPND_CREATE_DOUBLE();
+    const char *expected_1_2[3] = {
+        "fmulx  %q0 %q0 $0x03 -> %q0",
+        "fmulx  %q11 %q12 $0x03 -> %q10",
+        "fmulx  %q31 %q31 $0x03 -> %q31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
+              opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
+
+    return success;
+}
+
+TEST_INSTR(fmulx_vector_idx)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.H[<index>] */
+    reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D7, DR_REG_D15 };
+    uint index_0_0[3] = { 0, 5, 7 };
+    opnd_t Rm_elsz = OPND_CREATE_HALF();
+    const char *expected_0_0[3] = {
+        "fmulx  %d0 %d0 $0x00 $0x01 -> %d0",
+        "fmulx  %d11 %d7 $0x05 $0x01 -> %d10",
+        "fmulx  %d31 %d15 $0x07 $0x01 -> %d31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_0_0[i], opnd_create_reg(Rd_0_0[i]),
+              opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
+              opnd_create_immed_uint(index_0_0[i], OPSZ_0), Rm_elsz);
+
+    reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_0_1[3] = { DR_REG_Q0, DR_REG_Q7, DR_REG_Q15 };
+    uint index_0_1[3] = { 0, 5, 7 };
+    Rm_elsz = OPND_CREATE_HALF();
+    const char *expected_0_1[3] = {
+        "fmulx  %q0 %q0 $0x00 $0x01 -> %q0",
+        "fmulx  %q11 %q7 $0x05 $0x01 -> %q10",
+        "fmulx  %q31 %q15 $0x07 $0x01 -> %q31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_0_1[i], opnd_create_reg(Rd_0_1[i]),
+              opnd_create_reg(Rn_0_1[i]), opnd_create_reg(Rm_0_1[i]),
+              opnd_create_immed_uint(index_0_1[i], OPSZ_0), Rm_elsz);
+
+    /* Testing FMULX   <Dd>.<Ts>, <Dn>.<Ts>, <Dm>.<Tb>[<index>] */
+    reg_id_t Rd_1_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_1_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_1_0[3] = { DR_REG_D0, DR_REG_D12, DR_REG_D31 };
+    uint index_1_0[3] = { 0, 0, 3 };
+    Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_1_0[3] = {
+        "fmulx  %d0 %d0 $0x00 $0x02 -> %d0",
+        "fmulx  %d11 %d12 $0x00 $0x02 -> %d10",
+        "fmulx  %d31 %d31 $0x03 $0x02 -> %d31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_1_0[i], opnd_create_reg(Rd_1_0[i]),
+              opnd_create_reg(Rn_1_0[i]), opnd_create_reg(Rm_1_0[i]),
+              opnd_create_immed_uint(index_1_0[i], OPSZ_0), Rm_elsz);
+
+    reg_id_t Rd_1_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_1_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_1_1[3] = { 0, 0, 3 };
+    Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_1_1[3] = {
+        "fmulx  %q0 %q0 $0x00 $0x02 -> %q0",
+        "fmulx  %q11 %q12 $0x00 $0x02 -> %q10",
+        "fmulx  %q31 %q31 $0x03 $0x02 -> %q31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
+              opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]),
+              opnd_create_immed_uint(index_1_1[i], OPSZ_0), Rm_elsz);
+
+    reg_id_t Rd_1_2[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_1_2[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_1_2[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_1_2[3] = { 0, 1, 1 };
+    Rm_elsz = OPND_CREATE_DOUBLE();
+    const char *expected_1_2[3] = {
+        "fmulx  %q0 %q0 $0x00 $0x03 -> %q0",
+        "fmulx  %q11 %q12 $0x01 $0x03 -> %q10",
+        "fmulx  %q31 %q31 $0x01 $0x03 -> %q31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
+              opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]),
+              opnd_create_immed_uint(index_1_2[i], OPSZ_0), Rm_elsz);
+
+    /* Testing FMULX   <Hd>, <Hn>, <Hm>.H[<index>] */
+    reg_id_t Rd_2_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
+    reg_id_t Rn_2_0[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
+    reg_id_t Rm_2_0[3] = { DR_REG_Q0, DR_REG_Q7, DR_REG_Q15 };
+    uint index_2_0[3] = { 0, 5, 7 };
+    Rm_elsz = OPND_CREATE_HALF();
+    const char *expected_2_0[3] = {
+        "fmulx  %q0 %q0 $0x00 $0x01 -> %q0",
+        "fmulx  %q11 %q7 $0x05 $0x01 -> %q10",
+        "fmulx  %q31 %q15 $0x07 $0x01 -> %q31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_2_0[i], opnd_create_reg(Rd_2_0[i]),
+              opnd_create_reg(Rn_2_0[i]), opnd_create_reg(Rm_2_0[i]),
+              opnd_create_immed_uint(index_2_0[i], OPSZ_0), Rm_elsz);
+
+    /* Testing FMULX   <V><d>, <V><n>, <Sm>.<Ts>[<index>] */
+    reg_id_t Rd_3_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    reg_id_t Rn_3_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    reg_id_t Rm_3_0[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_3_0[3] = { 0, 0, 3 };
+    Rm_elsz = OPND_CREATE_SINGLE();
+    const char *expected_3_0[3] = {
+        "fmulx  %s0 %q0 $0x00 $0x02 -> %s0",
+        "fmulx  %s11 %q12 $0x00 $0x02 -> %s10",
+        "fmulx  %s31 %q31 $0x03 $0x02 -> %s31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_3_0[i],
+              opnd_create_reg(Rd_3_0[i]), opnd_create_reg(Rn_3_0[i]),
+              opnd_create_reg(Rm_3_0[i]), opnd_create_immed_uint(index_3_0[i], OPSZ_0),
+              Rm_elsz);
+
+    reg_id_t Rd_3_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_3_1[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_3_1[3] = { DR_REG_Q0, DR_REG_Q12, DR_REG_Q31 };
+    uint index_3_1[3] = { 0, 1, 1 };
+    Rm_elsz = OPND_CREATE_DOUBLE();
+    const char *expected_3_1[3] = {
+        "fmulx  %d0 %q0 $0x00 $0x03 -> %d0",
+        "fmulx  %d11 %q12 $0x01 $0x03 -> %d10",
+        "fmulx  %d31 %q31 $0x01 $0x03 -> %d31",
+    };
+    TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_3_1[i],
+              opnd_create_reg(Rd_3_1[i]), opnd_create_reg(Rn_3_1[i]),
+              opnd_create_reg(Rm_3_1[i]), opnd_create_immed_uint(index_3_1[i], OPSZ_0),
+              Rm_elsz);
+
+    return success;
+}
+
+TEST_INSTR(fmulx)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FMULX   <Hd>, <Hn>, <Hm> */
+    reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
+    reg_id_t Rn_0_0[3] = { DR_REG_H0, DR_REG_H11, DR_REG_H31 };
+    reg_id_t Rm_0_0[3] = { DR_REG_H0, DR_REG_H12, DR_REG_H31 };
+    const char *expected_0_0[3] = {
+        "fmulx  %h0 %h0 -> %h0",
+        "fmulx  %h11 %h12 -> %h10",
+        "fmulx  %h31 %h31 -> %h31",
+    };
+    TEST_LOOP(fmulx, fmulx, 3, expected_0_0[i], opnd_create_reg(Rd_0_0[i]),
+              opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]));
+
+    /* Testing FMULX   <V><d>, <V><n>, <V><m> */
+    reg_id_t Rd_1_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
+    reg_id_t Rn_1_0[3] = { DR_REG_S0, DR_REG_S11, DR_REG_S31 };
+    reg_id_t Rm_1_0[3] = { DR_REG_S0, DR_REG_S12, DR_REG_S31 };
+    const char *expected_1_0[3] = {
+        "fmulx  %s0 %s0 -> %s0",
+        "fmulx  %s11 %s12 -> %s10",
+        "fmulx  %s31 %s31 -> %s31",
+    };
+    TEST_LOOP(fmulx, fmulx, 3, expected_1_0[i], opnd_create_reg(Rd_1_0[i]),
+              opnd_create_reg(Rn_1_0[i]), opnd_create_reg(Rm_1_0[i]));
+
+    reg_id_t Rd_1_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
+    reg_id_t Rn_1_1[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
+    reg_id_t Rm_1_1[3] = { DR_REG_D0, DR_REG_D12, DR_REG_D31 };
+    const char *expected_1_1[3] = {
+        "fmulx  %d0 %d0 -> %d0",
+        "fmulx  %d11 %d12 -> %d10",
+        "fmulx  %d31 %d31 -> %d31",
+    };
+    TEST_LOOP(fmulx, fmulx, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
+              opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
+
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -3291,6 +3558,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(sdot_vector_indexed);
     RUN_INSTR_TEST(udot_vector);
     RUN_INSTR_TEST(udot_vector_indexed);
+
+    RUN_INSTR_TEST(fmov);
+    RUN_INSTR_TEST(fmulx);
+    RUN_INSTR_TEST(fmulx_vector);
+    RUN_INSTR_TEST(fmulx_vector_idx);
 
     print("All v8.2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries
to encode the following variants:
```
 *    FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts>
 *    FMULX   <Dd>.<Ts>, <Dn>.<Ts>, <Dm>.<Ts>
 *    FMOV    <Wd>, <Hn>
 *    FMOV    <Xd>, <Hn>
 *    FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.H[<index>]
 *    FMULX   <Dd>.<Ts>, <Dn>.<Ts>, <Dm>.<Tb>[<index>]
 *    FMULX   <Hd>, <Hn>, <Hm>.H[<index>]
 *    FMULX   <V><d>, <V><n>, <Sm>.<Ts>[<index>]
 *    FMULX   <Hd>, <Hn>, <Hm>
 *    FMULX   <V><d>, <V><n>, <V><m>
 *    FMLSL/2   <Sd>.<T>, <Hn>.<Tb>, <Hm>.H[<imm>]
```
It also tidies up some of the ir tests by adding a
macro to implement the testing loops and making sure
that all failures are printed

Issues: #2626
