### PR TITLE
i#5615: Fix Doxygen 1.9.4 build

### DIFF
--- a/api/docs/API.doxy
+++ b/api/docs/API.doxy
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+# Copyright (c) 2012-2022 Google, Inc.  All rights reserved.
 # Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
 # **********************************************************/
 
@@ -222,7 +222,6 @@ EXTERNAL_GROUPS        = YES
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = NO
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = NO
 CLASS_GRAPH            = YES

--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -728,6 +728,13 @@ are specified via \c drconfig, \c drrun, or dr_register_process().  See
    If a client changes application instructions after an inserted clean call,
    the client may need to reduce the -opt_cleancall level to preserve correct
    execution.
+   There are four optimization levels:
+   - 0: no optimization.
+   - 1: callee register usage analysis and optimization on context switch.
+   - 2: simple callee inline optimization, callee-save register analysis,
+        and aflags usage analysis on the instruction list to be inserted.
+   - 3: more aggressive, but potentially unsafe, optimizations.
+   By default, the clean call optimization level is 2.
    The clean call will only be optimized if it is a leaf function.
    Currently, the callee will be inlined only if it is small, has at most
    one argument, and has no control flow other than for the PIC base.
@@ -740,13 +747,6 @@ are specified via \c drconfig, \c drrun, or dr_register_process().  See
    logfile size significantly) and grep for
    "CLEANCALL" in the log file to retrieve the information
    about clean call optimization.
-   There are four optimization levels.
-   By default, the clean call optimization level is 2.
-   - 0: no optimization.
-   - 1: callee register usage analysis and optimization on context switch.
-   - 2: simple callee inline optimization, callee-save register analysis,
-        and aflags usage analysis on the instruction list to be inserted.
-   - 3: more aggressive, but potentially unsafe, optimizations.
 
  - \b -opt_speed: \anchor op_speed
    By default, DynamoRIO provides a more straightforward code stream to

--- a/core/lib/dr_config.h
+++ b/core/lib/dr_config.h
@@ -732,7 +732,7 @@ DR_EXPORT
  *                              cannot exceed #MAXIMUM_PATH.  The client path may not
  *                              include any semicolons and when combined with
  *                              \p client_options may not include all
- *                              three quote characters (', ", `) simultaneously.
+ *                              three quote characters (\', \", \`) simultaneously.
  *
  * \param[in]   client_options  A NULL-terminated string specifying options that
  *                              are available to the client as arguments of
@@ -740,7 +740,7 @@ DR_EXPORT
  *                              The string length cannot exceed #DR_MAX_OPTIONS_LENGTH.
  *                              The client options may not include any semicolons
  *                              and when combined with \p client_path may not include
- *                              all three quote characters (', ", `) simultaneously.
+ *                              all three quote characters (\', \", \`) simultaneously.
  *
  * \return      A dr_config_status_t code indicating the result of registration.
  */

--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -175,7 +175,7 @@ DR_API
  * creation (false) or is for address translation (true).  This is
  * further explained below.
  *
- * \return a #dr_emit_flags_t flag.
+ * The callback function should return a #dr_emit_flags_t flag.
  *
  * The user is free to inspect and modify the block before it
  * executes, but must adhere to the following restrictions:
@@ -387,7 +387,7 @@ DR_API
  * (false) or is for fault address recreation (true).  This is further
  * explained below.
  *
- * \return a #dr_emit_flags_t flag.
+ * The callback function should return a #dr_emit_flags_t flag.
  *
  * The user is free to inspect and modify the non-control-flow
  * instructions in the trace before it


### PR DESCRIPTION
Fixes several errors raised by Doxygen 1.9.4:
+ Adds escapes to quotes which caused parsing to miss a \param.
+ Removes \return directives on void functions.
+ Removes a deprecated Doxyfile parameter.
+ Moves a nested list higher up to fix what looks like a bug
  in the Doxygen parser: I found no other explanation.

Tested manually on 1.9.4.

Fixes #5615