### PR TITLE
i#2062 memtrace nonmod: Emit encodings for non-module code

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -159,11 +159,12 @@ Further non-compatibility-affecting changes include:
  - Added a new DR extension, namely "drpttracer", which provides clients with tracing
    functionality via Intel's PT instruction tracing feature. This feature is still
    experimental and available only on Intel processors.
- - Added new drmemtrace options -enable_kernel_tracing that allow recording each
-   syscall's Kernel PT and write every syscall's PT and metadata to files in
+ - Added a new drmemtrace option -enable_kernel_tracing that allows recording each
+   syscall's Kernel PT and writes every syscall's PT and metadata to files in
    -outdir/kernel.raw/ for later offline analysis. This feature is still experimental
    and available only on Intel processors that support the Intel@ Processor Trace
    feature.
+ - Added drmemtrace_get_encoding_path().
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2022 Google, Inc.    All rights reserved.
 # Copyright (c) 2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -631,7 +631,7 @@ struct _encoding_entry_t {
     uint64_t start_pc;
 #ifdef WINDOWS
 #    pragma warning(push)
-#    pragma warning(disable : 2220) // Zero-sized array warning.
+#    pragma warning(disable : 4200) // Zero-sized array warning.
 #endif
     // Variable-length encodings for entire block, of length 'length'.
     unsigned char encodings[0];

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -505,6 +505,8 @@ typedef enum {
 
 #define PC_MODOFFS_BITS 33
 #define PC_MODIDX_BITS 16
+// We reserve the top value to indicate non-module generated code.
+#define PC_MODIDX_INVALID ((1 << PC_MODIDX_BITS) - 1)
 #define PC_INSTR_COUNT_BITS 12
 #define PC_TYPE_BITS 3
 
@@ -618,6 +620,20 @@ typedef union {
     uint64_t combined_value;
 } kernel_interrupted_raw_pc_t;
 
+// The encoding file begins with a 64-bit integer holding a version number,
+// followed by a series of records of type encoding_entry_t.
+#define ENCODING_FILE_VERSION 0
+
+START_PACKED_STRUCTURE
+struct _encoding_entry_t {
+    size_t length; // Size of the entire structure.
+    uint64_t id;
+    uint64_t start_pc;
+    // Variable-length encodings for entire block, of length 'length'.
+    unsigned char encodings[0];
+} END_PACKED_STRUCTURE;
+typedef struct _encoding_entry_t encoding_entry_t;
+
 /**
  * The name of the file in -offline mode where module data is written.
  * Its creation can be customized using drmemtrace_custom_module_data()
@@ -632,5 +648,11 @@ typedef union {
  * are written.  Use drmemtrace_get_funclist_path() to obtain the full path.
  */
 #define DRMEMTRACE_FUNCTION_LIST_FILENAME "funclist.log"
+
+/**
+ * The name of the file in -offline mode where non-module instruction encodings
+ * are written.  Use drmemtrace_get_encoding_path() to obtain the full path.
+ */
+#define DRMEMTRACE_ENCODING_FILENAME "encodings.log"
 
 #endif /* _TRACE_ENTRY_H_ */

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -629,8 +629,15 @@ struct _encoding_entry_t {
     size_t length; // Size of the entire structure.
     uint64_t id;
     uint64_t start_pc;
+#ifdef WINDOWS
+#    pragma warning(push)
+#    pragma warning(disable : 2220) // Zero-sized array warning.
+#endif
     // Variable-length encodings for entire block, of length 'length'.
     unsigned char encodings[0];
+#ifdef WINDOWS
+#    pragma warning(pop)
+#endif
 } END_PACKED_STRUCTURE;
 typedef struct _encoding_entry_t encoding_entry_t;
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -515,7 +515,8 @@ typedef enum {
 #define OFFLINE_FILE_VERSION_ELIDE_UNMOD_BASE 3
 #define OFFLINE_FILE_VERSION_KERNEL_INT_PC 4
 #define OFFLINE_FILE_VERSION_HEADER_FIELDS_SWAP 5
-#define OFFLINE_FILE_VERSION OFFLINE_FILE_VERSION_HEADER_FIELDS_SWAP
+#define OFFLINE_FILE_VERSION_ENCODINGS 6
+#define OFFLINE_FILE_VERSION OFFLINE_FILE_VERSION_ENCODINGS
 
 /**
  * Bitfields used to describe the high-level characteristics of both an
@@ -622,12 +623,13 @@ typedef union {
 
 // The encoding file begins with a 64-bit integer holding a version number,
 // followed by a series of records of type encoding_entry_t.
-#define ENCODING_FILE_VERSION 0
+#define ENCODING_FILE_INITIAL_VERSION 0
+#define ENCODING_FILE_VERSION ENCODING_FILE_INITIAL_VERSION
 
 START_PACKED_STRUCTURE
 struct _encoding_entry_t {
     size_t length; // Size of the entire structure.
-    uint64_t id;
+    uint64_t id;   // Incremented for each new non-module fragment DR creates.
     uint64_t start_pc;
 #ifdef WINDOWS
 #    pragma warning(push)
@@ -660,6 +662,6 @@ typedef struct _encoding_entry_t encoding_entry_t;
  * The name of the file in -offline mode where non-module instruction encodings
  * are written.  Use drmemtrace_get_encoding_path() to obtain the full path.
  */
-#define DRMEMTRACE_ENCODING_FILENAME "encodings.log"
+#define DRMEMTRACE_ENCODING_FILENAME "encodings.bin"
 
 #endif /* _TRACE_ENTRY_H_ */

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -132,7 +132,8 @@ protected:
                     continue;
                 // Skip the auxiliary files.
                 if (fname == DRMEMTRACE_MODULE_LIST_FILENAME ||
-                    fname == DRMEMTRACE_FUNCTION_LIST_FILENAME)
+                    fname == DRMEMTRACE_FUNCTION_LIST_FILENAME ||
+                    fname == DRMEMTRACE_ENCODING_FILENAME)
                     continue;
                 VPRINT(this, 2, "Found file %s\n", fname.c_str());
                 if (!open_single_file(input_path_ + DIRSEP + fname)) {

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -67,6 +67,7 @@ drvector_t all_buffers;
 #define ALL_BUFFERS_INIT_SIZE 256
 
 #define MODULE_FILENO 0
+#define IGNORE_FILENO 1
 
 typedef struct _buf_entry_t {
     file_t id; /* MODULE_FILENO or thread id */
@@ -101,8 +102,17 @@ local_open_file(const char *fname, uint mode_flags)
         called = true;
         /* This is where we initialize because DR is now initialized. */
         drvector_init(&all_buffers, ALL_BUFFERS_INIT_SIZE, false, free_entry);
-        return MODULE_FILENO;
     }
+    const char *mod_name, *func_name, *enc_name;
+    if (drmemtrace_get_modlist_path(&mod_name) != DRMEMTRACE_SUCCESS ||
+        drmemtrace_get_funclist_path(&func_name) != DRMEMTRACE_SUCCESS ||
+        drmemtrace_get_encoding_path(&enc_name) != DRMEMTRACE_SUCCESS)
+        ASSERT(false);
+    if (strncmp(fname, mod_name, MAXIMUM_PATH) == 0)
+        return MODULE_FILENO;
+    if (strncmp(fname, func_name, MAXIMUM_PATH) == 0 ||
+        strncmp(fname, enc_name, MAXIMUM_PATH) == 0)
+        return IGNORE_FILENO;
     return (file_t)dr_get_thread_id(dr_get_current_drcontext());
 }
 
@@ -115,6 +125,8 @@ local_read_file(file_t file, void *data, size_t count)
 static ssize_t
 local_write_file(file_t file, const void *data, size_t size)
 {
+    if (file == IGNORE_FILENO)
+        return size;
     if (file == MODULE_FILENO) {
         void *copy = dr_raw_mem_alloc(size, DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
         memcpy(copy, data, size);

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -109,10 +109,10 @@ local_open_file(const char *fname, uint mode_flags)
         drmemtrace_get_encoding_path(&enc_name) != DRMEMTRACE_SUCCESS)
         ASSERT(false);
     if (strncmp(fname, mod_name, MAXIMUM_PATH) == 0)
-        return MODULE_FILENO;
+        return (file_t)MODULE_FILENO;
     if (strncmp(fname, func_name, MAXIMUM_PATH) == 0 ||
         strncmp(fname, enc_name, MAXIMUM_PATH) == 0)
-        return IGNORE_FILENO;
+        return (file_t)IGNORE_FILENO;
     return (file_t)dr_get_thread_id(dr_get_current_drcontext());
 }
 
@@ -125,9 +125,9 @@ local_read_file(file_t file, void *data, size_t count)
 static ssize_t
 local_write_file(file_t file, const void *data, size_t size)
 {
-    if (file == IGNORE_FILENO)
+    if (file == (file_t)IGNORE_FILENO)
         return size;
-    if (file == MODULE_FILENO) {
+    if (file == (file_t)MODULE_FILENO) {
         void *copy = dr_raw_mem_alloc(size, DR_MEMPROT_READ | DR_MEMPROT_WRITE, NULL);
         memcpy(copy, data, size);
         drvector_lock(&all_buffers);

--- a/clients/drcachesim/tests/offline-gencode.templatex
+++ b/clients/drcachesim/tests/offline-gencode.templatex
@@ -1,6 +1,5 @@
 pre-DR init
 pre-DR start
-WARNING: Found unsupported non-module code
 pre-DR detach
 all done
 pre-DR init

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -250,6 +250,16 @@ drmemtrace_get_funclist_path(OUT const char **path);
 
 DR_EXPORT
 /**
+ * Retrieves the full path to the file in -offline mode where
+ * non-module instruction encoding data is written.  The basename of
+ * the file is #DRMEMTRACE_ENCODING_FILENAME.  It contains binary data
+ * read by the raw2trace tool.
+ */
+drmemtrace_status_t
+drmemtrace_get_encoding_path(OUT const char **path);
+
+DR_EXPORT
+/**
  * Adds custom data stored with each module in the module list produced for
  * offline trace post-processing.  The \p load_cb is called for each segment
  * of each new module (with \p seg_idx indicating the segment number, starting at 0),

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -95,7 +95,7 @@ offline_instru_t::offline_instru_t(
     uint64 max_bb_instrs;
     if (!dr_get_integer_option("max_bb_instrs", &max_bb_instrs))
         max_bb_instrs = 256; /* current default */
-    max_block_encoding_size_ = max_bb_instrs * MAX_INSTR_LENGTH;
+    max_block_encoding_size_ = static_cast<int>(max_bb_instrs) * MAX_INSTR_LENGTH;
     encoding_lock_ = dr_mutex_create();
     encoding_buf_sz_ = ALIGN_FORWARD(max_block_encoding_size_ * 10, dr_page_size());
     encoding_buf_start_ = reinterpret_cast<byte *>(

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -40,12 +40,13 @@
 #include "drcovlib.h"
 #include "instru.h"
 #include "../common/trace_entry.h"
+#include "../common/utils.h"
 #include <new>
 #include <limits.h> /* for USHRT_MAX */
 #include <stddef.h> /* for offsetof */
 #include <string.h> /* for strlen */
 
-static const ptr_uint_t MAX_INSTR_COUNT = 64 * 1024;
+static const uint MAX_INSTR_COUNT = 64 * 1024;
 
 void *(*offline_instru_t::user_load_)(module_data_t *module, int seg_idx);
 int (*offline_instru_t::user_print_)(void *data, char *dst, size_t max_len);
@@ -56,7 +57,6 @@ void (*offline_instru_t::user_free_)(void *data);
 offline_instru_t::offline_instru_t()
     : instru_t(nullptr, false, nullptr, sizeof(offline_entry_t))
     , write_file_func_(nullptr)
-    , modfile_(INVALID_FILE)
 {
     // We can't use drmgr in standalone mode, but for post-processing it's just us,
     // so we just pick a note value.
@@ -64,18 +64,18 @@ offline_instru_t::offline_instru_t()
     standalone_ = true;
 }
 
-offline_instru_t::offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *,
-                                                           instr_t *, reg_id_t),
-                                   bool memref_needs_info, drvector_t *reg_vector,
-                                   ssize_t (*write_file)(file_t file, const void *data,
-                                                         size_t count),
-                                   file_t module_file, bool disable_optimizations,
-                                   void (*log)(uint level, const char *fmt, ...))
+offline_instru_t::offline_instru_t(
+    void (*insert_load_buf)(void *, instrlist_t *, instr_t *, reg_id_t),
+    bool memref_needs_info, drvector_t *reg_vector,
+    ssize_t (*write_file)(file_t file, const void *data, size_t count),
+    file_t module_file, file_t encoding_file, bool disable_optimizations,
+    void (*log)(uint level, const char *fmt, ...))
     : instru_t(insert_load_buf, memref_needs_info, reg_vector, sizeof(offline_entry_t),
                disable_optimizations)
     , write_file_func_(write_file)
     , modfile_(module_file)
     , log_(log)
+    , encoding_file_(encoding_file)
 {
     drcovlib_status_t res = drmodtrack_init();
     DR_ASSERT(res == DRCOVLIB_SUCCESS);
@@ -91,12 +91,34 @@ offline_instru_t::offline_instru_t(void (*insert_load_buf)(void *, instrlist_t *
         DR_ASSERT(false);
     elide_memref_note_ = drmgr_reserve_note_range(1);
     DR_ASSERT(elide_memref_note_ != DRMGR_NOTE_NONE);
+
+    uint64 max_bb_instrs;
+    if (!dr_get_integer_option("max_bb_instrs", &max_bb_instrs))
+        max_bb_instrs = 256; /* current default */
+    max_block_encoding_size_ = max_bb_instrs * MAX_INSTR_LENGTH;
+    encoding_lock_ = dr_mutex_create();
+    encoding_buf_sz_ = ALIGN_FORWARD(max_block_encoding_size_ * 10, dr_page_size());
+    encoding_buf_start_ = reinterpret_cast<byte *>(
+        dr_raw_mem_alloc(encoding_buf_sz_, DR_MEMPROT_READ | DR_MEMPROT_WRITE, nullptr));
+    encoding_buf_ptr_ = encoding_buf_start_;
+    // Write out the header which is just a 64-bit version.
+    *reinterpret_cast<uint64_t *>(encoding_buf_ptr_) = ENCODING_FILE_VERSION;
+    encoding_buf_ptr_ += sizeof(uint64_t);
 }
 
 offline_instru_t::~offline_instru_t()
 {
     if (standalone_)
         return;
+
+    dr_mutex_lock(encoding_lock_);
+    flush_instr_encodings();
+    dr_raw_mem_free(encoding_buf_start_, encoding_buf_sz_);
+    dr_mutex_unlock(encoding_lock_);
+    dr_mutex_destroy(encoding_lock_);
+    log_(1, "Wrote " UINT64_FORMAT_STRING " bytes to encoding file\n",
+         encoding_bytes_written_);
+
     drcovlib_status_t res;
     size_t size = 8192;
     char *buf;
@@ -414,32 +436,100 @@ offline_instru_t::get_modoffs(void *drcontext, app_pc pc, OUT uint *modidx)
     return pc - modbase;
 }
 
+// Caller must hold the encoding_lock.
+void
+offline_instru_t::flush_instr_encodings()
+{
+    DR_ASSERT(dr_mutex_self_owns(encoding_lock_));
+    size_t size = encoding_buf_ptr_ - encoding_buf_start_;
+    if (size == 0)
+        return;
+    ssize_t written = write_file_func_(encoding_file_, encoding_buf_start_, size);
+    log_(2, "%s: Wrote %zu/%zu bytes to encoding file\n", __FUNCTION__, written, size);
+    DR_ASSERT(written == static_cast<ssize_t>(size));
+    encoding_buf_ptr_ = encoding_buf_start_;
+    encoding_bytes_written_ += written;
+}
+
+void
+offline_instru_t::record_instr_encodings(void *drcontext, app_pc tag_pc,
+                                         per_block_t *per_block, instrlist_t *ilist)
+{
+    dr_mutex_lock(encoding_lock_);
+    per_block->id = encoding_id_++;
+
+    if (encoding_buf_ptr_ + max_block_encoding_size_ >=
+        encoding_buf_start_ + encoding_buf_sz_) {
+        flush_instr_encodings();
+    }
+    byte *buf_start = encoding_buf_ptr_;
+    byte *buf = buf_start;
+    buf += sizeof(encoding_entry_t);
+
+    bool in_emulation_region = false;
+    for (instr_t *instr = instrlist_first(ilist); instr != NULL;
+         instr = instr_get_next(instr)) {
+        instr_t *to_copy = nullptr;
+        emulated_instr_t emulation_info = {};
+        if (in_emulation_region) {
+            if (drmgr_is_emulation_end(instr))
+                in_emulation_region = false;
+        } else if (drmgr_is_emulation_start(instr)) {
+            bool ok = drmgr_get_emulated_instr_data(instr, &emulation_info);
+            DR_ASSERT(ok);
+            to_copy = emulation_info.instr;
+            in_emulation_region = true;
+        } else if (instr_is_app(instr)) {
+            to_copy = instr;
+        }
+        if (to_copy == nullptr)
+            continue;
+        // To handle application code hooked by DR we cannot just copy from
+        // instr_get_app_pc(): we have to encode.  Nearly all the time this
+        // will be a pure memcpy so this only incurs an actual encoding walk
+        // for the hooked level 4 instrs.
+        byte *end_pc =
+            instr_encode_to_copy(drcontext, to_copy, buf, instr_get_app_pc(to_copy));
+        DR_ASSERT(end_pc != nullptr);
+        buf = end_pc;
+        DR_ASSERT(buf < encoding_buf_start_ + encoding_buf_sz_);
+    }
+
+    encoding_entry_t *enc = reinterpret_cast<encoding_entry_t *>(buf_start);
+    enc->length = buf - buf_start;
+    enc->id = per_block->id;
+    enc->start_pc = reinterpret_cast<uint64_t>(tag_pc);
+    log_(2, "%s: Recorded %zu bytes for id " UINT64_FORMAT_STRING " @ %p\n", __FUNCTION__,
+         enc->length, enc->id, tag_pc);
+
+    encoding_buf_ptr_ += enc->length;
+    dr_mutex_unlock(encoding_lock_);
+}
+
 int
 offline_instru_t::insert_save_pc(void *drcontext, instrlist_t *ilist, instr_t *where,
                                  reg_id_t reg_ptr, reg_id_t scratch, int adjust,
-                                 app_pc pc, uint instr_count)
+                                 app_pc pc, uint instr_count, per_block_t *per_block)
 {
-    app_pc modbase;
-    uint modidx;
-    if (drmodtrack_lookup(drcontext, pc, &modidx, &modbase) != DRCOVLIB_SUCCESS) {
-        // FIXME i#2062: add non-module support by storing instruction encodings at
-        // tracing time.
-        if (log_ != nullptr) {
-            // We want a visible non-spewing one-time warning.  A race is fine here.
-            static volatile bool warned_once;
-            if (!warned_once) {
-                log_(0, "WARNING: Found unsupported non-module code\n");
-                warned_once = true;
-            }
-            log_(1, "Found unsupported non-module code at %p\n", pc);
-        }
-        modidx = 0;
-        modbase = pc;
-    }
     offline_entry_t entry;
     entry.pc.type = OFFLINE_TYPE_PC;
-    // We put the ARM vs Thumb mode into the modoffs to ensure proper decoding.
-    uint64_t modoffs = dr_app_pc_as_jump_target(instr_get_isa_mode(where), pc) - modbase;
+    app_pc modbase;
+    uint modidx;
+    uint64_t modoffs;
+    if (drmodtrack_lookup(drcontext, pc, &modidx, &modbase) == DRCOVLIB_SUCCESS) {
+        // TODO i#2062: We need to also identify modified library code and record
+        // its encodings.  The plan is to augment drmodtrack to track this for us;
+        // for now we will incorrectly use the original bits in the trace.
+        //
+        // We put the ARM vs Thumb mode into the modoffs to ensure proper decoding.
+        modoffs = dr_app_pc_as_jump_target(instr_get_isa_mode(where), pc) - modbase;
+        DR_ASSERT(modidx != PC_MODIDX_INVALID);
+    } else {
+        modidx = PC_MODIDX_INVALID;
+        // For generated code we store the id for matching with the encodings recorded
+        // into the encoding file.
+        modoffs = per_block->id;
+    }
     // Check that the values we want to assign to the bitfields in offline_entry_t do not
     // overflow. In i#2956 we observed an overflow for the modidx field.
     DR_ASSERT(modoffs < uint64_t(1) << PC_MODOFFS_BITS);
@@ -566,9 +656,9 @@ offline_instru_t::instr_has_multiple_different_memrefs(instr_t *instr)
 }
 
 int
-offline_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t *where,
-                                    reg_id_t reg_ptr, int adjust, instr_t *app,
-                                    opnd_t ref, int ref_index, bool write,
+offline_instru_t::instrument_memref(void *drcontext, void *bb_field, instrlist_t *ilist,
+                                    instr_t *where, reg_id_t reg_ptr, int adjust,
+                                    instr_t *app, opnd_t ref, int ref_index, bool write,
                                     dr_pred_type_t pred)
 {
     // Check whether we can elide this address.
@@ -592,12 +682,13 @@ offline_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t
     // We allow either 0 or all 1's as the type so no need to write anything else,
     // unless a filter is in place in which case we need a PC entry.
     if (memref_needs_full_info_) {
+        per_block_t *per_block = reinterpret_cast<per_block_t *>(bb_field);
         reg_id_t reg_tmp;
         drreg_status_t res =
             drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
         DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
         adjust += insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, adjust,
-                                 instr_get_app_pc(app), 0);
+                                 instr_get_app_pc(app), 0, per_block);
         if (instr_has_multiple_different_memrefs(app)) {
             // i#2756: post-processing can't determine which memref this is, so we
             // insert a type entry.  (For instrs w/ identical memrefs, like an ALU
@@ -614,17 +705,18 @@ offline_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t
     return adjust;
 }
 
-// We stored the instr count in *bb_field in bb_analysis().
+// We stored the instr count in bb_field==per_block_t in bb_analysis().
 int
-offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
+offline_instru_t::instrument_instr(void *drcontext, void *tag, void *bb_field,
                                    instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
                                    int adjust, instr_t *app)
 {
+    per_block_t *per_block = reinterpret_cast<per_block_t *>(bb_field);
     app_pc pc;
     reg_id_t reg_tmp;
     if (!memref_needs_full_info_) {
         // We write just once per bb, if not filtering.
-        if ((ptr_uint_t)*bb_field > MAX_INSTR_COUNT)
+        if (per_block->instr_count > MAX_INSTR_COUNT)
             return adjust;
         pc = dr_fragment_app_pc(tag);
     } else {
@@ -634,10 +726,12 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
     drreg_status_t res =
         drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
-    adjust += insert_save_pc(drcontext, ilist, where, reg_ptr, reg_tmp, adjust, pc,
-                             memref_needs_full_info_ ? 1 : (uint)(ptr_uint_t)*bb_field);
+    adjust += insert_save_pc(
+        drcontext, ilist, where, reg_ptr, reg_tmp, adjust, pc,
+        memref_needs_full_info_ ? 1 : static_cast<uint>(per_block->instr_count),
+        per_block);
     if (!memref_needs_full_info_)
-        *(ptr_uint_t *)bb_field = MAX_INSTR_COUNT + 1;
+        per_block->instr_count = MAX_INSTR_COUNT + 1;
     res = drreg_unreserve_register(drcontext, ilist, where, reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
     return adjust;
@@ -656,8 +750,30 @@ void
 offline_instru_t::bb_analysis(void *drcontext, void *tag, void **bb_field,
                               instrlist_t *ilist, bool repstr_expanded)
 {
-    *bb_field = (void *)(ptr_uint_t)instru_t::count_app_instrs(ilist);
+    per_block_t *per_block =
+        reinterpret_cast<per_block_t *>(dr_thread_alloc(drcontext, sizeof(*per_block)));
+    *bb_field = per_block;
+
+    per_block->instr_count = instru_t::count_app_instrs(ilist);
+
     identify_elidable_addresses(drcontext, ilist, OFFLINE_FILE_VERSION);
+
+    app_pc tag_pc = dr_fragment_app_pc(tag);
+    if (drmodtrack_lookup(drcontext, tag_pc, nullptr, nullptr) != DRCOVLIB_SUCCESS) {
+        // For (unmodified) library code we do not need to record encodings as we
+        // rely on access to the binary during post-processing.
+        //
+        // TODO i#2062: We need to also identify modified library code and record
+        // its encodings.  The plan is to augment drmodtrack to track this for us;
+        // for now we will incorrectly use the original bits in the trace.
+        record_instr_encodings(drcontext, tag_pc, per_block, ilist);
+    }
+}
+
+void
+offline_instru_t::bb_analysis_cleanup(void *drcontext, void *bb_field)
+{
+    dr_thread_free(drcontext, bb_field, sizeof(per_block_t));
 }
 
 bool

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -297,9 +297,10 @@ online_instru_t::insert_save_type_and_size(void *drcontext, instrlist_t *ilist,
 }
 
 int
-online_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t *where,
-                                   reg_id_t reg_ptr, int adjust, instr_t *app, opnd_t ref,
-                                   int ref_index, bool write, dr_pred_type_t pred)
+online_instru_t::instrument_memref(void *drcontext, void *bb_field, instrlist_t *ilist,
+                                   instr_t *where, reg_id_t reg_ptr, int adjust,
+                                   instr_t *app, opnd_t ref, int ref_index, bool write,
+                                   dr_pred_type_t pred)
 {
     ushort type = (ushort)(write ? TRACE_TYPE_WRITE : TRACE_TYPE_READ);
     ushort size = (ushort)drutil_opnd_mem_size_in_bytes(ref, app);
@@ -336,11 +337,11 @@ online_instru_t::instrument_memref(void *drcontext, instrlist_t *ilist, instr_t 
 }
 
 int
-online_instru_t::instrument_instr(void *drcontext, void *tag, void **bb_field,
+online_instru_t::instrument_instr(void *drcontext, void *tag, void *bb_field,
                                   instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
                                   int adjust, instr_t *app)
 {
-    bool repstr_expanded = *bb_field != 0; // Avoid cl warning C4800.
+    bool repstr_expanded = bb_field != 0; // Avoid cl warning C4800.
 #ifdef AARCH64
     // Update the trace buffer pointer if we are about to exceed the maximum
     // immediate displacement allowed by OP_stur. As sizeof(trace_entry_t) = 12,
@@ -410,4 +411,10 @@ online_instru_t::bb_analysis(void *drcontext, void *tag, void **bb_field,
                              instrlist_t *ilist, bool repstr_expanded)
 {
     *bb_field = (void *)repstr_expanded;
+}
+
+void
+online_instru_t::bb_analysis_cleanup(void *drcontext, void *bb_field)
+{
+    // Nothing to do.
 }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1021,10 +1021,9 @@ private:
         std::string error = "";
         uint instr_count = in_entry->pc.instr_count;
         const instr_summary_t *instr = nullptr;
-        app_pc start_pc = modvec_()[in_entry->pc.modidx].map_seg_base +
-            (in_entry->pc.modoffs - modvec_()[in_entry->pc.modidx].seg_offs);
-        app_pc pc, decode_pc = start_pc;
         if ((in_entry->pc.modidx == 0 && in_entry->pc.modoffs == 0) ||
+            // TODO i#2062: Add raw2trace support for encoding file entries.
+            in_entry->pc.modidx == PC_MODIDX_INVALID ||
             modvec_()[in_entry->pc.modidx].map_seg_base == NULL) {
             // FIXME i#2062: add support for code not in a module (vsyscall, JIT, etc.).
             // Once that support is in we can remove the bool return value and handle
@@ -1041,12 +1040,14 @@ private:
                 instr_count, in_entry->pc.modidx, in_entry->pc.modoffs);
             *handled = false;
             return "";
-        } else {
-            impl()->log(3, "Appending %u instrs in bb " PFX " in mod %u +" PIFX " = %s\n",
-                        instr_count, (ptr_uint_t)start_pc, (uint)in_entry->pc.modidx,
-                        (ptr_uint_t)in_entry->pc.modoffs,
-                        modvec_()[in_entry->pc.modidx].path);
         }
+        app_pc start_pc = modvec_()[in_entry->pc.modidx].map_seg_base +
+            (in_entry->pc.modoffs - modvec_()[in_entry->pc.modidx].seg_offs);
+        app_pc pc, decode_pc = start_pc;
+        impl()->log(3, "Appending %u instrs in bb " PFX " in mod %u +" PIFX " = %s\n",
+                    instr_count, (ptr_uint_t)start_pc, (uint)in_entry->pc.modidx,
+                    (ptr_uint_t)in_entry->pc.modoffs,
+                    modvec_()[in_entry->pc.modidx].path);
         bool skip_icache = false;
         // This indicates that each memref has its own PC entry and that each
         // icache entry does not need to be considered a memref PC entry as well.

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1022,7 +1022,6 @@ private:
         uint instr_count = in_entry->pc.instr_count;
         const instr_summary_t *instr = nullptr;
         if ((in_entry->pc.modidx == 0 && in_entry->pc.modoffs == 0) ||
-            // TODO i#2062: Add raw2trace support for encoding file entries.
             in_entry->pc.modidx == PC_MODIDX_INVALID ||
             modvec_()[in_entry->pc.modidx].map_seg_base == NULL) {
             // FIXME i#2062: add support for code not in a module (vsyscall, JIT, etc.).

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -345,6 +345,9 @@ raw2trace_directory_t::initialize(const std::string &indir, const std::string &o
     std::string encoding_filename =
         modfile_dir + std::string(DIRSEP) + DRMEMTRACE_ENCODING_FILENAME;
     // Older traces do not have encoding files.
+    // If we had the version we could check OFFLINE_FILE_VERSION_ENCODINGS but
+    // we don't currently read that; raw2trace will check it for us.
+    // TODO i#2062: When raw2trace support is added, check the version.
     if (dr_file_exists(encoding_filename.c_str())) {
         encoding_file_ = dr_open_file(encoding_filename.c_str(), DR_FILE_READ);
         if (encoding_file_ == INVALID_FILE)

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -43,6 +43,7 @@ class raw2trace_directory_t {
 public:
     raw2trace_directory_t(unsigned int verbosity = 0)
         : modfile_bytes_(nullptr)
+        , encoding_file_(INVALID_FILE)
         , modfile_(INVALID_FILE)
         , indir_("")
         , outdir_("")
@@ -79,6 +80,7 @@ public:
     is_window_subdir(const std::string &dir);
 
     char *modfile_bytes_;
+    file_t encoding_file_;
     std::vector<std::istream *> in_files_;
     std::vector<std::ostream *> out_files_;
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3826,11 +3826,14 @@ if (BUILD_CLIENTS)
     endif ()
 
     if (NOT APPLE) # XXX i#1997: static DR not fully supported on Mac yet
+      # We specify this executable here as it uses tools.h code.
       set(tool.drcacheoff.gencode_no_reg_compat)
       add_api_exe(tool.drcacheoff.gencode
         ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/burst_gencode.cpp
         OFF ON)
       use_DynamoRIO_static_client(tool.drcacheoff.gencode drmemtrace_static)
+      target_include_directories(tool.drcacheoff.gencode PUBLIC
+        "${PROJECT_BINARY_DIR}/clients/include")
       set(tool.drcacheoff.gencode_nodr ON)
       torunonly_drcacheoff(gencode tool.drcacheoff.gencode
         "" "@-simulator_type@basic_counts" "")


### PR DESCRIPTION
Augments drmemtrace to emit the instruction encodings for non-module
code while tracing.  The instru_offline_t class emits them into a
global buffer and from there into a new file in the raw/ subdirectory.
Encodings are obtained by encoding each app or emulated instruction in
the block.

Adds a new drmemtrace interface function
drmemtrace_get_encoding_path() to obtain the path to the file where
the encodings are stored.  Adds a sanity check that the file exists to
the gencode test.

The file reader and raw2trace_directory_t are updated to be aware of
the encoding file.

Raw2trace support for parsing the encoding file will be added in a
separate commit to keep things small and incremental.

Issue: #2062