### PR TITLE
i#2062 memtrace nonmod part 2: Raw2trace parsing of encoding file

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -165,6 +165,7 @@ Further non-compatibility-affecting changes include:
    and available only on Intel processors that support the Intel@ Processor Trace
    feature.
  - Added drmemtrace_get_encoding_path().
+ - Added preliminary support for generated code to drmemtrace.
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -106,8 +106,8 @@ analyzer_multi_t::analyzer_multi_t()
                 return;
             }
             raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
-                                  nullptr, op_verbose.get_value(), op_jobs.get_value(),
-                                  op_alt_module_dir.get_value());
+                                  dir.encoding_file_, nullptr, op_verbose.get_value(),
+                                  op_jobs.get_value(), op_alt_module_dir.get_value());
             std::string error = raw2trace.do_conversion();
             if (!error.empty()) {
                 success_ = false;

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -162,7 +162,7 @@ post_process()
         std::string dir_err = dir.initialize(raw_dir, outdir);
         assert(dir_err.empty());
         raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
-                              dr_context);
+                              dir.encoding_file_, dr_context);
         std::string error = raw2trace.do_conversion();
         if (!error.empty()) {
             std::cerr << "raw2trace failed: " << error << "\n";

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -196,7 +196,7 @@ post_process()
             dir.modfile_bytes_, parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(module_mapper->get_last_error().empty());
         // Test back-compat of deprecated APIs.
-        raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_, NULL);
+        raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_);
         std::string error =
             raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(error.empty());
@@ -218,8 +218,8 @@ post_process()
     raw2trace_directory_t dir;
     std::string dir_err = dir.initialize(raw_dir, "");
     assert(dir_err.empty());
-    raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_, dr_context,
-                          0);
+    raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
+                          dir.encoding_file_, dr_context, 0);
     std::string error =
         raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
     assert(error.empty());

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -175,7 +175,7 @@ post_process(const std::string &out_subdir)
         std::string dir_err = dir.initialize(raw_dir, outdir);
         assert(dir_err.empty());
         raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
-                              dr_context,
+                              dir.encoding_file_, dr_context,
                               0
 #    ifdef WINDOWS
                               /* FIXME i#3983: Creating threads in standalone mode

--- a/clients/drcachesim/tests/offline-gencode.templatex
+++ b/clients/drcachesim/tests/offline-gencode.templatex
@@ -2,15 +2,6 @@ pre-DR init
 pre-DR start
 pre-DR detach
 all done
-pre-DR init
-pre-DR start
-pre-DR detach
-all done
-pre-DR init
-pre-DR start
-pre-DR detach
-all done
-\[drmemtrace\]: WARNING: Skipping ifetch for instructions not in a module
 Basic counts tool results:
 Total counts:
 .*

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -148,7 +148,7 @@ test_raw2trace(raw2trace_directory_t *dir)
          * raw2trace::read_and_map_modules().
          */
         raw2trace_t raw2trace(dir->modfile_bytes_, dir->in_files_, dir->out_files_,
-                              GLOBAL_DCONTEXT, 1);
+                              dir->encoding_file_, GLOBAL_DCONTEXT, 1);
         std::string error = raw2trace.do_conversion();
         if (!error.empty()) {
             std::cerr << "raw2trace failed " << error << "\n";

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -65,8 +65,8 @@
 #    error Unsupported arch
 #endif
 
-// Subclasses raw2trace_t and module_mapper_t and replaces the module loading with
-// a buffer of encoded instr_t.
+// Subclasses module_mapper_t and replaces the module loading with a
+// buffer of encoded instr_t.
 class module_mapper_test_t : public module_mapper_t {
 public:
     module_mapper_test_t(instrlist_t &instrs, void *drcontext)
@@ -89,6 +89,7 @@ private:
     byte decode_buf_[MAX_DECODE_SIZE];
 };
 
+// Subclasses raw2trace_t and replaces the module_mapper_t with our own version.
 class raw2trace_test_t : public raw2trace_t {
 public:
     raw2trace_test_t(const std::vector<std::istream *> &input,

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -65,36 +65,44 @@
 #    error Unsupported arch
 #endif
 
-// Subclasses raw2trace_t and replaces the module loading with a buffer
-// of encoded instr_t.
-class raw2trace_test_t : public raw2trace_t {
+// Subclasses raw2trace_t and module_mapper_t and replaces the module loading with
+// a buffer of encoded instr_t.
+class module_mapper_test_t : public module_mapper_t {
 public:
-    raw2trace_test_t(const std::vector<std::istream *> &input,
-                     const std::vector<std::ostream *> &output, instrlist_t &instrs,
-                     void *drcontext)
-        : raw2trace_t(nullptr, input, output, drcontext,
-                      // The sequences are small so we print everything for easier
-                      // debugging and viewing of what's going on.
-                      4)
+    module_mapper_test_t(instrlist_t &instrs, void *drcontext)
+        : module_mapper_t(nullptr)
     {
         byte *pc = instrlist_encode(drcontext, &instrs, decode_buf_, true);
         ASSERT(pc - decode_buf_ < MAX_DECODE_SIZE, "decode buffer overflow");
-        set_modvec_(&modules_);
     }
 
 protected:
-    std::string
+    void
     read_and_map_modules() override
     {
-        modules_.push_back(module_t("fake_exe", 0, decode_buf_, 0, MAX_DECODE_SIZE,
-                                    MAX_DECODE_SIZE, true));
-        return "";
+        modvec_.push_back(module_t("fake_exe", 0, decode_buf_, 0, MAX_DECODE_SIZE,
+                                   MAX_DECODE_SIZE, true));
     }
 
 private:
     static const int MAX_DECODE_SIZE = 1024;
     byte decode_buf_[MAX_DECODE_SIZE];
-    std::vector<module_t> modules_;
+};
+
+class raw2trace_test_t : public raw2trace_t {
+public:
+    raw2trace_test_t(const std::vector<std::istream *> &input,
+                     const std::vector<std::ostream *> &output, instrlist_t &instrs,
+                     void *drcontext)
+        : raw2trace_t(nullptr, input, output, INVALID_FILE, drcontext,
+                      // The sequences are small so we print everything for easier
+                      // debugging and viewing of what's going on.
+                      4)
+    {
+        module_mapper_ =
+            std::unique_ptr<module_mapper_t>(new module_mapper_test_t(instrs, drcontext));
+        set_modmap_(module_mapper_.get());
+    }
 };
 
 offline_entry_t

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -71,6 +71,8 @@ opcode_mix_t::initialize()
     std::string error = directory_.initialize_module_file(module_file_path_);
     if (!error.empty())
         return "Failed to initialize directory: " + error;
+    // Non-module instruction entries will be in the final trace (i#2062,i#5520) so
+    // we do not need the encoding file and leave it as its default INVALID_FILE.
     module_mapper_ =
         module_mapper_t::create(directory_.modfile_bytes_, nullptr, nullptr, nullptr,
                                 nullptr, knob_verbose_, knob_alt_module_dir_);

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -93,6 +93,8 @@ view_t::initialize()
         // not available.
         return "";
     }
+    // Non-module instruction entries will be in the final trace (i#2062,i#5520) so
+    // we do not need the encoding file and leave it as its default INVALID_FILE.
     module_mapper_ =
         module_mapper_t::create(directory_.modfile_bytes_, nullptr, nullptr, nullptr,
                                 nullptr, knob_verbose_, knob_alt_module_dir_);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -772,6 +772,7 @@ raw2trace_t::lookup_block_summary(void *tls, uint64 modidx, uint64 modoffs,
                                   app_pc block_start)
 {
     auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
+    // There is no sentinel available for modidx+modoffs so we use block_start for that.
     if (block_start == tdata->last_decode_block_start &&
         modidx == tdata->last_decode_modidx && modoffs == tdata->last_decode_modoffs) {
         VPRINT(5, "Using last block summary " PFX " for " PFX "\n",

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -329,9 +329,11 @@ module_mapper_t::do_encoding_parsing()
     if (*reinterpret_cast<uint64_t *>(map_start) != ENCODING_FILE_VERSION)
         return "Encoding file has invalid version";
     size_t offs = sizeof(uint64_t);
-    while (offs < map_size) {
+    while (offs < file_size) {
         encoding_entry_t *entry = reinterpret_cast<encoding_entry_t *>(map_start + offs);
-        if (offs + entry->length > map_size)
+        if (entry->length < sizeof(encoding_entry_t))
+            return "Encoding file is corrupted";
+        if (offs + entry->length > file_size)
             return "Encoding file is truncated";
         encodings_[entry->id] = entry;
         offs += entry->length;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -124,11 +124,12 @@ module_mapper_t::module_mapper_t(
     const char *module_map, const char *(*parse_cb)(const char *src, OUT void **data),
     std::string (*process_cb)(drmodtrack_info_t *info, void *data, void *user_data),
     void *process_cb_user_data, void (*free_cb)(void *data), uint verbosity,
-    const std::string &alt_module_dir)
+    const std::string &alt_module_dir, file_t encoding_file)
     : modmap_(module_map)
     , cached_user_free_(free_cb)
     , verbosity_(verbosity)
     , alt_module_dir_(alt_module_dir)
+    , encoding_file_(encoding_file)
 {
     // We mutate global state because do_module_parsing() uses drmodtrack, which
     // wants global functions. The state isn't needed past do_module_parsing(), so
@@ -145,7 +146,10 @@ module_mapper_t::module_mapper_t(
     // It is assumed to be set to 'true' initially.
     has_custom_data_global_ = true;
 
-    last_error_ = do_module_parsing();
+    if (modmap_ != nullptr)
+        last_error_ = do_module_parsing();
+    if (encoding_file_ != INVALID_FILE)
+        last_error_ += do_encoding_parsing();
 
     // capture has_custom_data_global_'s value for this instance.
     has_custom_data_ = has_custom_data_global_;
@@ -274,9 +278,9 @@ std::string
 raw2trace_t::do_module_parsing()
 {
     if (!module_mapper_) {
-        module_mapper_ = module_mapper_t::create(modmap_, user_parse_, user_process_,
-                                                 user_process_data_, user_free_,
-                                                 verbosity_, alt_module_dir_);
+        module_mapper_ = module_mapper_t::create(
+            modmap_, user_parse_, user_process_, user_process_data_, user_free_,
+            verbosity_, alt_module_dir_, encoding_file_);
     }
     return module_mapper_->get_last_error();
 }
@@ -310,6 +314,32 @@ module_mapper_t::do_module_parsing()
 }
 
 std::string
+module_mapper_t::do_encoding_parsing()
+{
+    if (encoding_file_ == INVALID_FILE)
+        return "";
+    uint64 file_size;
+    if (!dr_file_size(encoding_file_, &file_size))
+        return "Failed to obtain size of encoding file";
+    size_t map_size = (size_t)file_size;
+    byte *map_start = reinterpret_cast<byte *>(
+        dr_map_file(encoding_file_, &map_size, 0, NULL, DR_MEMPROT_READ, 0));
+    if (map_start == nullptr || map_size < file_size)
+        return "Failed to map encoding file";
+    if (*reinterpret_cast<uint64_t *>(map_start) != ENCODING_FILE_VERSION)
+        return "Encoding file has invalid version";
+    size_t offs = sizeof(uint64_t);
+    while (offs < map_size) {
+        encoding_entry_t *entry = reinterpret_cast<encoding_entry_t *>(map_start + offs);
+        if (offs + entry->length > map_size)
+            return "Encoding file is truncated";
+        encodings_[entry->id] = entry;
+        offs += entry->length;
+    }
+    return "";
+}
+
+std::string
 raw2trace_t::read_and_map_modules()
 {
     if (!module_mapper_) {
@@ -319,6 +349,7 @@ raw2trace_t::read_and_map_modules()
     }
 
     set_modvec_(&module_mapper_->get_loaded_modules());
+    set_modmap_(module_mapper_.get());
     return module_mapper_->get_last_error();
 }
 
@@ -339,6 +370,8 @@ module_mapper_t::read_and_map_modules()
         drmodtrack_info_t &info = *it;
         custom_module_data_t *custom_data = (custom_module_data_t *)info.custom;
         if (custom_data != nullptr && custom_data->contents_size > 0) {
+            // XXX i#2062: We could eliminate this raw bytes in the module data in
+            // favor of the new encoding file used for generated code.
             VPRINT(1, "Using module %d %s stored %zd-byte contents @" PFX "\n",
                    (int)modvec_.size(), info.path, custom_data->contents_size,
                    custom_data->contents);
@@ -568,6 +601,9 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
                tdata->file_type);
         if (!tdata->error.empty())
             return tdata->error;
+        if (tdata->version >= OFFLINE_FILE_VERSION_ENCODINGS &&
+            encoding_file_ == INVALID_FILE)
+            return "Expected encoding file but none was passed";
         if (tdata->saw_header) {
             tdata->error = process_header(tdata);
             if (!tdata->error.empty())
@@ -730,19 +766,23 @@ raw2trace_t::do_conversion()
 }
 
 raw2trace_t::block_summary_t *
-raw2trace_t::lookup_block_summary(void *tls, app_pc block_start)
+raw2trace_t::lookup_block_summary(void *tls, uint64 modidx, uint64 modoffs,
+                                  app_pc block_start)
 {
     auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
-    if (block_start == tdata->last_decode_block_start) {
+    if (block_start == tdata->last_decode_block_start &&
+        modidx == tdata->last_decode_modidx && modoffs == tdata->last_decode_modoffs) {
         VPRINT(5, "Using last block summary " PFX " for " PFX "\n",
                tdata->last_block_summary, tdata->last_decode_block_start);
         return tdata->last_block_summary;
     }
-    block_summary_t *ret = static_cast<block_summary_t *>(
-        hashtable_lookup(&decode_cache_[tdata->worker], block_start));
+    block_summary_t *ret = static_cast<block_summary_t *>(hashtable_lookup(
+        &decode_cache_[tdata->worker], decode_cache_key(modidx, modoffs)));
     if (ret != nullptr) {
         DEBUG_ASSERT(ret->start_pc == block_start);
         tdata->last_decode_block_start = block_start;
+        tdata->last_decode_modidx = modidx;
+        tdata->last_decode_modoffs = modoffs;
         tdata->last_block_summary = ret;
         VPRINT(5, "Caching last block summary " PFX " for " PFX "\n",
                tdata->last_block_summary, tdata->last_decode_block_start);
@@ -755,7 +795,7 @@ raw2trace_t::lookup_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
                                   app_pc block_start, int index, app_pc pc,
                                   OUT block_summary_t **block_summary)
 {
-    block_summary_t *block = lookup_block_summary(tls, block_start);
+    block_summary_t *block = lookup_block_summary(tls, modidx, modoffs, block_start);
     if (block_summary != nullptr)
         *block_summary = block;
     if (block == nullptr)
@@ -785,15 +825,24 @@ raw2trace_t::create_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
     if (block == nullptr) {
         block = new block_summary_t(block_start, instr_count);
         DEBUG_ASSERT(index >= 0 && index < static_cast<int>(block->instrs.size()));
-        hashtable_add(&decode_cache_[tdata->worker], block_start, block);
-        VPRINT(5, "Created new block summary " PFX " for " PFX "\n", block, block_start);
+        hashtable_add(&decode_cache_[tdata->worker], decode_cache_key(modidx, modoffs),
+                      block);
+        VPRINT(5,
+               "Created new block summary " PFX " for " PFX " modidx=" INT64_FORMAT_STRING
+               " modoffs=" HEX64_FORMAT_STRING " key=%p\n",
+               block, block_start, modidx, modoffs, decode_cache_key(modidx, modoffs));
         tdata->last_decode_block_start = block_start;
+        tdata->last_decode_modidx = modidx;
+        tdata->last_decode_modoffs = modoffs;
         tdata->last_block_summary = block;
     }
     instr_summary_t *desc = &block->instrs[index];
     if (!instr_summary_t::construct(dcontext_, block_start, pc, orig, desc, verbosity_)) {
-        WARN("Encountered invalid/undecodable instr @ %s+" PIFX,
-             modvec_()[static_cast<size_t>(modidx)].path, IF_NOT_X64((uint)) modoffs);
+        WARN("Encountered invalid/undecodable instr @ idx=" INT64_FORMAT_STRING
+             " offs=" INT64_FORMAT_STRING " %s",
+             modidx, modoffs,
+             modidx == PC_MODIDX_INVALID ? "<gencode>"
+                                         : modvec_()[static_cast<size_t>(modidx)].path);
         return nullptr;
     }
     return desc;
@@ -1116,14 +1165,15 @@ raw2trace_t::get_file_type(void *tls)
 
 raw2trace_t::raw2trace_t(const char *module_map,
                          const std::vector<std::istream *> &thread_files,
-                         const std::vector<std::ostream *> &out_files, void *dcontext,
-                         unsigned int verbosity, int worker_count,
-                         const std::string &alt_module_dir)
+                         const std::vector<std::ostream *> &out_files,
+                         file_t encoding_file, void *dcontext, unsigned int verbosity,
+                         int worker_count, const std::string &alt_module_dir)
     : trace_converter_t(dcontext)
     , worker_count_(worker_count)
     , user_process_(nullptr)
     , user_process_data_(nullptr)
     , modmap_(module_map)
+    , encoding_file_(encoding_file)
     , verbosity_(verbosity)
     , alt_module_dir_(alt_module_dir)
 {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -601,9 +601,9 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
                tdata->file_type);
         if (!tdata->error.empty())
             return tdata->error;
-        if (tdata->version >= OFFLINE_FILE_VERSION_ENCODINGS &&
-            encoding_file_ == INVALID_FILE)
-            return "Expected encoding file but none was passed";
+        // We do not complain if tdata->version >= OFFLINE_FILE_VERSION_ENCODINGS
+        // and encoding_file_ == INVALID_FILE since we have several tests with
+        // that setup.  We do complain during processing about unknown instructions.
         if (tdata->saw_header) {
             tdata->error = process_header(tdata);
             if (!tdata->error.empty())

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1149,8 +1149,9 @@ private:
                     impl()->get_file_type(tls));
         bool is_instr_only_trace =
             TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, impl()->get_file_type(tls));
-        uint64_t cur_pc = reinterpret_cast<uint64_t>(
-            modmap_().get_orig_pc(in_entry->pc.modidx, in_entry->pc.modoffs));
+        // Cast to unsigned pointer-sized int first to avoid sign-extending.
+        uint64_t cur_pc = static_cast<uint64_t>(reinterpret_cast<ptr_uint_t>(
+            modmap_().get_orig_pc(in_entry->pc.modidx, in_entry->pc.modoffs)));
         // Legacy traces need the offset, not the pc.
         uint64_t cur_offs = in_entry->pc.modoffs;
         std::unordered_map<reg_id_t, addr_t> reg_vals;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -433,7 +433,8 @@ public:
             return (map_pc - entry->encodings) +
                 reinterpret_cast<app_pc>(entry->start_pc);
         } else {
-            return map_pc - modvec_[modidx].map_seg_base + modvec_[modidx].orig_seg_base;
+            size_t idx = static_cast<size_t>(modidx); // Avoid win32 warnings.
+            return map_pc - modvec_[idx].map_seg_base + modvec_[idx].orig_seg_base;
         }
     }
 
@@ -447,10 +448,11 @@ public:
             encoding_entry_t *entry = it->second;
             return reinterpret_cast<app_pc>(entry->start_pc);
         } else {
+            size_t idx = static_cast<size_t>(modidx); // Avoid win32 warnings.
             // Cast to unsigned pointer-sized int first to avoid sign-extending.
             return reinterpret_cast<app_pc>(
-                       reinterpret_cast<ptr_uint_t>(modvec_[modidx].orig_seg_base)) +
-                (modoffs - modvec_[modidx].seg_offs);
+                       reinterpret_cast<ptr_uint_t>(modvec_[idx].orig_seg_base)) +
+                (modoffs - modvec_[idx].seg_offs);
         }
     }
 
@@ -464,7 +466,8 @@ public:
             encoding_entry_t *entry = it->second;
             return entry->encodings;
         } else {
-            return modvec_[modidx].map_seg_base + (modoffs - modvec_[modidx].seg_offs);
+            size_t idx = static_cast<size_t>(modidx); // Avoid win32 warnings.
+            return modvec_[idx].map_seg_base + (modoffs - modvec_[idx].seg_offs);
         }
     }
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1919,6 +1919,15 @@ private:
         {
             hashtable_delete(&table);
         }
+#else
+        // Work around a known Visual Studio issue where it complains about deleted copy
+        // constructors for unique_ptr by deleting our copies and defaulting our moves.
+        block_hashtable_t(const block_hashtable_t &) = delete;
+        block_hashtable_t &
+        operator=(const block_hashtable_t &) = delete;
+        block_hashtable_t(block_hashtable_t &&) = default;
+        block_hashtable_t &
+        operator=(block_hashtable_t &&) = default;
 #endif
         block_summary_t *
         lookup(uint64 modidx, uint64 modoffs)

--- a/clients/drcachesim/tracer/raw2trace_launcher.cpp
+++ b/clients/drcachesim/tracer/raw2trace_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -98,9 +98,9 @@ _tmain(int argc, const TCHAR *targv[])
     std::string dir_err = dir.initialize(op_indir.get_value(), op_outdir.get_value());
     if (!dir_err.empty())
         FATAL_ERROR("Directory parsing failed: %s", dir_err.c_str());
-    raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_, NULL,
-                          op_verbose.get_value(), op_jobs.get_value(),
-                          op_alt_module_dir.get_value());
+    raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
+                          dir.encoding_file_, nullptr, op_verbose.get_value(),
+                          op_jobs.get_value(), op_alt_module_dir.get_value());
     std::string error = raw2trace.do_conversion();
     if (!error.empty())
         FATAL_ERROR("Conversion failed: %s", error.c_str());

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -333,6 +333,8 @@ dump_unmasked(dcontext_t *dcontext, const char *where)
     if (dcontext == GLOBAL_DCONTEXT || dcontext == NULL)
         return;
     thread_sig_info_t *info = (thread_sig_info_t *)dcontext->signal_field;
+    if (info->sighand == NULL)
+        return;
     LOG(THREAD, LOG_ASYNCH, 3, "%s: threads_unmasked: ", where);
     for (int i = 1; i <= MAX_SIGNUM; i++) {
         LOG(THREAD, LOG_ASYNCH, 3, "[%d]=%d ", i, info->sighand->threads_unmasked[i]);
@@ -1110,9 +1112,9 @@ signal_thread_inherit(dcontext_t *dcontext, void *clone_record)
                 ? "vfork"
                 :
 #endif
-                (IF_LINUX(record->clone_sysnum == SYS_clone
-                              ? "clone"
-                              : record->clone_sysnum == SYS_clone3 ? "clone3" :)
+                (IF_LINUX(record->clone_sysnum == SYS_clone        ? "clone"
+                              : record->clone_sysnum == SYS_clone3 ? "clone3"
+                                                                   :)
                      IF_MACOS(record->clone_sysnum == SYS_bsdthread_create
                                   ? "bsdthread_create"
                                   :) "unexpected"),

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3832,8 +3832,14 @@ if (BUILD_CLIENTS)
         ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/burst_gencode.cpp
         OFF ON)
       use_DynamoRIO_static_client(tool.drcacheoff.gencode drmemtrace_static)
+      use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.gencode)
+      target_link_libraries(tool.drcacheoff.gencode drmemtrace_raw2trace
+        drmemtrace_analyzer)
       target_include_directories(tool.drcacheoff.gencode PUBLIC
-        "${PROJECT_BINARY_DIR}/clients/include")
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim"
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/common"
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/reader"
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/tracer")
       set(tool.drcacheoff.gencode_nodr ON)
       torunonly_drcacheoff(gencode tool.drcacheoff.gencode
         "" "@-simulator_type@basic_counts" "")


### PR DESCRIPTION
Adds raw2trace parsing of the encoding file used by the tracer to
store instruction encodings for generated code.  This involves the
following changes:

+ Adds encoding file parsing to module_mapper_t.
+ Changes module map queries to use new module_mapper_t interfaces instead,
  which handle generated code.
+ Changes block lookup to use the modidx,modoffs pair as the key rather than
  the absolute pc.

The changes are compatibility-breaking for raw2trace_t which now takes
an encoding file parameter in the middle of existing parameters.
Updates existing uses.

For module_mapper_t the encoding file is added last with a default
value to preserve compatibility for existing analysis tools like
opcode_mix and view.  It is assumed that encodings for generated code
will be added to the final trace file and thus these tools will not
need a module_mapper_t interface for generated code.

Augments the tool.drcacheoff.gencode test to post-process the trace
and ensure the generated code PC is observed.

Fixes a -loglevel 4 signal dump_unmaksed() crash on detach i#5618 hit
in the gencode test; confirmed the test is crash-free at loglevel 4
with the fix.

Issue: #2062
Fixes #5618