### PR TITLE
i#5621: Fix fdtable assert in standalone mode

### DIFF
--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -201,7 +201,7 @@ static std::string
 gather_trace()
 {
     if (!my_setenv("DYNAMORIO_OPTIONS",
-#ifdef LINUX
+#if defined(LINUX) && defined(X64)
                    // We pass -satisfy_w_xor_x to further stress that option
                    // interacting with standalone mode (xref i#5621).
                    "-satisfy_w_xor_x "

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -200,7 +200,13 @@ post_process()
 static std::string
 gather_trace()
 {
-    if (!my_setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline"))
+    if (!my_setenv("DYNAMORIO_OPTIONS",
+#ifdef LINUX
+                   // We pass -satisfy_w_xor_x to further stress that option
+                   // interacting with standalone mode (xref i#5621).
+                   "-satisfy_w_xor_x "
+#endif
+                   "-stderr_mask 0xc -client_lib ';;-offline"))
         std::cerr << "failed to set env var!\n";
     code_generator_t gen(false);
     gencode_start = gen.get_gencode_start();

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4205,7 +4205,7 @@ fd_table_remove(file_t fd)
         generic_hash_remove(GLOBAL_DCONTEXT, fd_table, (ptr_uint_t)fd);
         TABLE_RWLOCK(fd_table, write, unlock);
     } else {
-        ASSERT(dynamo_exited);
+        ASSERT(dynamo_exited || standalone_library);
     }
 }
 


### PR DESCRIPTION
In standalone mode after a detach with -satisfy_w_xor_x, an overactive
assert is hit.  We relax it here.

Augments the tool.drcacheoff.gencode test to cover this case.

Fixes #5621