### PR TITLE
i#5629: Fix expected output in linux.clone test.

### DIFF
--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -108,7 +108,7 @@ test_thread(bool share_sighand, bool clone_vm, bool use_clone3)
 #ifdef SYS_clone3
         child = create_thread_clone3(run_with_exit, &stack, share_sighand, clone_vm);
 #else
-        /* If SYS_clone3 is not found, we simply use SYS_clone instead, so that
+        /* If SYS_clone3 is not defined, we simply use SYS_clone instead, so that
          * the expected output is the same in both cases.
          */
         child = create_thread(run, NULL, &stack, share_sighand, clone_vm);
@@ -138,9 +138,7 @@ main()
     test_thread(true /*share_sighand*/, true /*clone_vm*/, false /*use_clone3*/);
     test_thread(true /*share_sighand*/, true /*clone_vm*/, true /*use_clone3*/);
 
-    /* We use this test in os.c to find whether the system supports clone3 or
-     * not.
-     */
+    /* Try using clone3 when it is possibly not defined. */
     int ret_failure_clone3 = make_clone3_syscall(NULL, 0, NULL);
     assert(ret_failure_clone3 == -1);
 #ifdef SYS_clone3

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -60,7 +60,7 @@ typedef unsigned long ulong;
 
 /* We define this constant so that we can try to make the clone3
  * syscall on systems where it is not available, to verify that it
- * returns ENOSYS.
+ * returns an expected response.
  */
 #define CLONE3_SYSCALL_NUM 435
 
@@ -108,8 +108,8 @@ test_thread(bool share_sighand, bool clone_vm, bool use_clone3)
 #ifdef SYS_clone3
         child = create_thread_clone3(run_with_exit, &stack, share_sighand, clone_vm);
 #else
-        /* If SYS_clone3 is not supported on the machine, we simply use SYS_clone
-         * instead, so that the expected output is the same in both cases.
+        /* If SYS_clone3 is not found, we simply use SYS_clone instead, so that
+         * the expected output is the same in both cases.
          */
         child = create_thread(run, NULL, &stack, share_sighand, clone_vm);
 #endif
@@ -144,9 +144,15 @@ main()
     int ret_failure_clone3 = make_clone3_syscall(NULL, 0, NULL);
     assert(ret_failure_clone3 == -1);
 #ifdef SYS_clone3
+    /* Though there's no guarantee, we assume that the kernel supports clone3 if
+     * SYS_clone3 is defined.
+     */
     assert(errno == EINVAL);
 #else
-    assert(errno == ENOSYS);
+    /* On some environments, we see that the kernel supports clone3 even though
+     * SYS_clone3 is not defined by glibc.
+     */
+    assert(errno == ENOSYS || errno == EINVAL);
 #endif
 }
 


### PR DESCRIPTION
Accepts EINVAL as a valid response from clone3 even if SYS_clone3
is not defined by glibc. This is to avoid incorrectly failing the
test on systems where the kernel supports clone3 but glibc version
doesn't define the SYS_clone3 constant.

Fixes: #5629