### PR TITLE
i#5383 mac a64, part 2: Fix compiler warnings

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
-          liblz4-dev clang-format-12 libunwind-dev
+          liblz4-dev clang-format-14 libunwind-dev
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Create Build Environment
       run: |
-        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt update
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -71,7 +71,7 @@ jobs:
 
     - name: Create Build Environment
       run: |
-        sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main'
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo apt update
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -71,8 +71,8 @@ jobs:
 
     - name: Create Build Environment
       run: |
-        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
         sudo apt update
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           liblz4-dev clang-format-14 libunwind-dev

--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -71,6 +71,9 @@ jobs:
 
     - name: Create Build Environment
       run: |
+        sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main'
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt update
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           liblz4-dev clang-format-14 libunwind-dev
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1835,7 +1835,10 @@ endif ()
 
 if (BUILD_CLIENTS)
   # Must be prior to api/docs
-  add_subdirectory(clients)
+  if (NOT (MACOS AND AARCH64))
+    # TODO i#5383: Add M1 drsyms libraries, needed by drcov2lcov and func_trace.
+    add_subdirectory(clients)
+  endif ()
 endif (BUILD_CLIENTS)
 
 if (BUILD_DOCS)

--- a/api/docs/code_style.dox
+++ b/api/docs/code_style.dox
@@ -41,7 +41,7 @@ maintainable.
 
 # Automated Formatting
 
-We employ automated code formatting via [`clang-format` version 12.0](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangFormat.html). The [`.clang-format` top-level file](https://github.com/DynamoRIO/dynamorio/blob/master/.clang-format) specifies the style rules for all `.h`, `.c`, and `.cpp` source code files.  Developers are expected to set up their editors to use `clang-format` when saving each file (see [the `clang-format` documentation](https://releases.llvm.org/6.0.0/tools/clang/docs/ClangFormat.html) for pointers to vim, emacs, and Visual Studio setup instructions).  Our test suite includes a format check and will fail any code whose formatting does not match the `clang-format` output.
+We employ automated code formatting via [`clang-format` version 14.0](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html). The [`.clang-format` top-level file](https://github.com/DynamoRIO/dynamorio/blob/master/.clang-format) specifies the style rules for all `.h`, `.c`, and `.cpp` source code files.  Developers are expected to set up their editors to use `clang-format` when saving each file (see [the `clang-format` documentation](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangFormat.html) for pointers to vim, emacs, and Visual Studio setup instructions).  Our test suite includes a format check and will fail any code whose formatting does not match the `clang-format` output.
 
 # Legacy Code
 

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -303,6 +303,10 @@ instru_t::get_cpu_id()
         // this should be pretty rare and we can live without it.
         return -1;
     }
+#elif defined(MACOS)
+    /* TODO i#5383: Add an M1 solution. */
+    DR_ASSERT_MSG(false, "Not implemented for M1");
+    return -1;
 #else
     uint cpu;
     if (syscall(SYS_getcpu, &cpu, NULL, NULL) < 0)

--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -60,6 +61,7 @@ read_feature_regs(uint64 isa_features[])
     MRS(ID_AA64DFR0_EL1, AA64DFR0, isa_features);
 }
 
+#    if !defined(MACOS) // TODO i#5383: Get this working on Mac. */
 static void
 get_processor_specific_info(void)
 {
@@ -86,6 +88,7 @@ get_processor_specific_info(void)
     cpu_info.features.flags_aa64mmfr1 = isa_features[AA64MMFR1];
     cpu_info.features.flags_aa64dfr0 = isa_features[AA64DFR0];
 }
+#    endif
 
 #    define LOG_FEATURE(feature)       \
         if (proc_has_feature(feature)) \

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1365,11 +1365,10 @@ mangle_direct_call(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
                    instr_t *next_instr, bool mangle_calls, uint flags)
 {
 #ifdef AARCH64
-    ptr_int_t target, retaddr;
+    ptr_int_t retaddr;
 
     ASSERT(instr_get_opcode(instr) == OP_bl);
     ASSERT(opnd_is_pc(instr_get_target(instr)));
-    target = (ptr_int_t)opnd_get_pc(instr_get_target(instr));
     retaddr = get_call_return_address(dcontext, ilist, instr);
     insert_mov_immed_ptrsz(dcontext, retaddr, opnd_create_reg(DR_REG_X30), ilist, instr,
                            NULL, NULL);

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -488,7 +488,8 @@ shared_gencode_emit(generated_code_t *gencode _IF_X86_64(bool x86_mode))
     machine_cache_sync(gencode->gen_start_pc, gencode->gen_end_pc, true);
 }
 
-static void shared_gencode_init(IF_X86_64_ELSE(gencode_mode_t gencode_mode, void))
+static void
+shared_gencode_init(IF_X86_64_ELSE(gencode_mode_t gencode_mode, void))
 {
     generated_code_t *gencode;
     ibl_branch_type_t branch_type;
@@ -610,14 +611,13 @@ arch_reset_stolen_reg(void)
 #    ifdef ARM
     dr_isa_mode_t old_mode;
 #    endif
-    dcontext_t *dcontext;
     if (DR_REG_R0 + INTERNAL_OPTION(steal_reg_at_reset) == dr_reg_stolen)
         return;
     SYSLOG_INTERNAL_INFO("swapping stolen reg from %s to %s", reg_names[dr_reg_stolen],
                          reg_names[DR_REG_R0 + INTERNAL_OPTION(steal_reg_at_reset)]);
-    dcontext = get_thread_private_dcontext();
-    ASSERT(dcontext != NULL);
 #    ifdef ARM
+    dcontext_t *dcontext = get_thread_private_dcontext();
+    ASSERT(dcontext != NULL);
     dr_set_isa_mode(dcontext, DR_ISA_ARM_THUMB, &old_mode);
 #    endif
 

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -5504,7 +5504,7 @@ recreate_fragment_done:
         *alloc_res = alloc;
     if (f_res == NULL && alloc)
         fragment_free(dcontext, f);
-    DODEBUG(ok =) dr_set_isa_mode(dcontext, old_mode, NULL);
+    DEBUG_DECLARE(ok =) dr_set_isa_mode(dcontext, old_mode, NULL);
     ASSERT(ok);
     return ilist;
 }

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -4656,7 +4656,7 @@ static void
 build_native_exec_bb(dcontext_t *dcontext, build_bb_t *bb)
 {
     instr_t *in;
-    opnd_t jmp_tgt;
+    opnd_t jmp_tgt IF_AARCH64(UNUSED);
 #if defined(X86) && defined(X64)
     bool reachable = rel32_reachable_from_vmcode(bb->start_pc);
 #endif
@@ -5294,7 +5294,7 @@ recreate_fragment_ilist(dcontext_t *dcontext, byte *pc,
     fragment_t *f;
     uint flags = 0;
     instrlist_t *ilist;
-    bool alloc = false, ok;
+    bool alloc = false;
     monitor_data_t md = {
         0,
     };
@@ -5335,7 +5335,8 @@ recreate_fragment_ilist(dcontext_t *dcontext, byte *pc,
     }
 
     /* Recreate in same mode as original fragment */
-    ok = dr_set_isa_mode(dcontext, FRAG_ISA_MODE(f->flags), &old_mode);
+    DEBUG_DECLARE(bool ok =)
+    dr_set_isa_mode(dcontext, FRAG_ISA_MODE(f->flags), &old_mode);
     ASSERT(ok);
 
     if ((f->flags & FRAG_IS_TRACE) == 0) {
@@ -5503,7 +5504,7 @@ recreate_fragment_done:
         *alloc_res = alloc;
     if (f_res == NULL && alloc)
         fragment_free(dcontext, f);
-    ok = dr_set_isa_mode(dcontext, old_mode, NULL);
+    DODEBUG(ok =) dr_set_isa_mode(dcontext, old_mode, NULL);
     ASSERT(ok);
     return ilist;
 }
@@ -7247,7 +7248,9 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
     bool coarse_elided_ubrs = false;
     dr_isa_mode_t old_mode;
     /* for decoding and get_ibl routines we need the dcontext mode set */
-    bool ok = dr_set_isa_mode(dcontext, FRAG_ISA_MODE(f->flags), &old_mode);
+    DEBUG_DECLARE(bool ok =)
+    dr_set_isa_mode(dcontext, FRAG_ISA_MODE(f->flags), &old_mode);
+    ASSERT(ok);
     /* i#1494: Decoding a code fragment from code cache, decode_fragment
      * may mess up the 32-bit/64-bit mode in -x86_to_x64 because 32-bit
      * application code is encoded as 64-bit code fragments into the code cache.
@@ -7909,7 +7912,7 @@ decode_fragment(dcontext_t *dcontext, fragment_t *f, byte *buf, /*IN/OUT*/ uint 
         instrlist_disassemble(dcontext, f->tag, ilist, THREAD);
     });
 
-    ok = dr_set_isa_mode(dcontext, old_mode, NULL);
+    DEBUG_DECLARE(ok =) dr_set_isa_mode(dcontext, old_mode, NULL);
     ASSERT(ok);
 
     if (dir_exits != NULL)

--- a/core/arch/x86/optimize.c
+++ b/core/arch/x86/optimize.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2662,7 +2662,6 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     opnd_t opnd, prop_opnd;
     instr_t *inst, *backup;
 
-    bool is_zeroing;
     /* FIXME: this is a data race!
      * and why set this for every trace?  options are static!
      * have some kind of optimize_init to set these
@@ -2694,7 +2693,6 @@ constant_propagation(dcontext_t *dcontext, app_pc tag, instrlist_t *trace)
     for (inst = instrlist_first(trace); inst != NULL; inst = instr_get_next(inst)) {
         /* backup in case results turns out to be unencodable */
         backup = NULL;
-        is_zeroing = false;
 
         inst = handle_stack(&state, inst);
         ASSERT(inst != NULL);

--- a/core/arch/x86_code.c
+++ b/core/arch/x86_code.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -275,7 +275,6 @@ new_thread_setup(priv_mcontext_t *mc)
 {
     dcontext_t *dcontext;
     void *crec;
-    int rc;
     /* this is where a new thread first touches other than the dstack,
      * so we "enter" DR here
      */
@@ -302,7 +301,8 @@ new_thread_setup(priv_mcontext_t *mc)
     set_thread_register_from_clone_record(crec);
 #    endif
 
-    rc = dynamo_thread_init(get_clone_record_dstack(crec), mc, crec, false);
+    DEBUG_DECLARE(int rc =)
+    dynamo_thread_init(get_clone_record_dstack(crec), mc, crec, false);
     ASSERT(rc != -1); /* this better be a new thread */
     dcontext = get_thread_private_dcontext();
     ASSERT(dcontext != NULL);

--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -450,9 +450,11 @@ os_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
 {
     int flags;
     byte *map;
+#if defined(LINUX) && defined(X64)
     uint pg_offs;
     ASSERT_TRUNCATE(pg_offs, uint, offs / PAGE_SIZE);
     pg_offs = (uint)(offs / PAGE_SIZE);
+#endif
 #ifdef VMX86_SERVER
     flags = MAP_PRIVATE; /* MAP_SHARED not supported yet */
 #else

--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -450,7 +450,7 @@ os_map_file(file_t f, size_t *size INOUT, uint64 offs, app_pc addr, uint prot,
 {
     int flags;
     byte *map;
-#if defined(LINUX) && defined(X64)
+#if defined(LINUX) && !defined(X64)
     uint pg_offs;
     ASSERT_TRUNCATE(pg_offs, uint, offs / PAGE_SIZE);
     pg_offs = (uint)(offs / PAGE_SIZE);

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -1322,11 +1322,7 @@ dynamo_process_exit_cleanup(void)
 {
     /* CAUTION: this should only be invoked after all app threads have stopped */
     if (!dynamo_exited && !INTERNAL_OPTION(nullcalls)) {
-        dcontext_t *dcontext;
-
         APP_EXPORT_ASSERT(dynamo_initialized, "Improper DynamoRIO initialization");
-
-        dcontext = get_thread_private_dcontext();
 
         /* we deliberately do NOT clean up d_r_initstack (which was
          * allocated using a separate mmap and so is not part of some

--- a/core/fcache.c
+++ b/core/fcache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -218,12 +218,13 @@ typedef struct _empty_slot_t {
 
 /* for -pad_jmps_shift_{bb,trace} we may have shifted the start_pc forward by up
  * to START_PC_ALIGNMENT-1 bytes, back align to get the right header pointer */
-#define FRAG_START_PADDING(f)                                                         \
-    ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags) || !PAD_JMPS_SHIFT_START((f)->flags))      \
-         ? 0                                                                          \
-         : (ASSERT(CHECK_TRUNCATE_TYPE_uint((ptr_uint_t)(                             \
-                (f)->start_pc - ALIGN_BACKWARD((f)->start_pc, START_PC_ALIGNMENT)))), \
-            (uint)((ptr_uint_t)(f)->start_pc -                                        \
+#define FRAG_START_PADDING(f)                                                      \
+    ((TEST(FRAG_IS_EMPTY_SLOT, (f)->flags) || !PAD_JMPS_SHIFT_START((f)->flags))   \
+         ? 0                                                                       \
+         : (ASSERT(CHECK_TRUNCATE_TYPE_uint(                                       \
+                (ptr_uint_t)((f)->start_pc -                                       \
+                             ALIGN_BACKWARD((f)->start_pc, START_PC_ALIGNMENT)))), \
+            (uint)((ptr_uint_t)(f)->start_pc -                                     \
                    ALIGN_BACKWARD((f)->start_pc, START_PC_ALIGNMENT))))
 
 #define FRAG_HDR_START(f) (FRAG_START(f) - HEADER_SIZE(f) - FRAG_START_PADDING(f))
@@ -4498,7 +4499,7 @@ void
 fcache_low_on_memory()
 {
     fcache_unit_t *u, *next_u;
-    size_t freed = 0;
+    DEBUG_DECLARE(size_t freed = 0;)
 
 #if 0
     dcontext_t *dcontext = get_thread_private_dcontext();
@@ -4542,7 +4543,7 @@ fcache_low_on_memory()
         u = allunits->dead;
         while (u != NULL) {
             next_u = u->next_global;
-            freed += u->size;
+            IF_DEBUG(freed += u->size;)
             fcache_really_free_unit(u, true /*on dead list*/, true /*dealloc*/);
             u = next_u;
         }

--- a/core/hashtablex.h
+++ b/core/hashtablex.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -297,8 +297,8 @@ static void HTNAME(hashtable_, NAME_KEY,
 #    endif
 
 /* get size in bytes padded for later cache alignment */
-static inline size_t HTNAME(hashtable_, NAME_KEY,
-                            _table_aligned_size)(uint table_capacity, uint flags)
+static inline size_t
+HTNAME(hashtable_, NAME_KEY, _table_aligned_size)(uint table_capacity, uint flags)
 {
     size_t size;
     /* we assume table size allows 32-bit indices */
@@ -313,8 +313,8 @@ static inline size_t HTNAME(hashtable_, NAME_KEY,
 
 #    ifdef HASHTABLE_USE_LOOKUPTABLE
 /* get size in bytes padded for later cache alignment */
-static inline size_t HTNAME(hashtable_, NAME_KEY,
-                            _lookuptable_aligned_size)(uint table_capacity)
+static inline size_t
+HTNAME(hashtable_, NAME_KEY, _lookuptable_aligned_size)(uint table_capacity)
 {
 
     return table_capacity * sizeof(AUX_ENTRY_TYPE) + proc_get_cache_line_size() -
@@ -323,11 +323,11 @@ static inline size_t HTNAME(hashtable_, NAME_KEY,
 #    endif
 
 /* callers should use either hashtable_init or hashtable_resize instead */
-static void HTNAME(hashtable_, NAME_KEY,
-                   _init_internal)(dcontext_t *dcontext,
-                                   HTNAME(, NAME_KEY, _table_t) * table, uint bits,
-                                   uint load_factor_percent, hash_function_t func,
-                                   uint hash_mask_offset _IFLOOKUP(bool use_lookup))
+static void
+HTNAME(hashtable_, NAME_KEY,
+       _init_internal)(dcontext_t *dcontext, HTNAME(, NAME_KEY, _table_t) * table,
+                       uint bits, uint load_factor_percent, hash_function_t func,
+                       uint hash_mask_offset _IFLOOKUP(bool use_lookup))
 {
     uint i;
     uint sentinel_index;
@@ -512,13 +512,14 @@ static void HTNAME(hashtable_, NAME_KEY,
     (dcontext, table _IFLOOKUP(use_lookup));
 }
 
-static void HTNAME(hashtable_, NAME_KEY,
-                   _init)(dcontext_t *dcontext, HTNAME(, NAME_KEY, _table_t) * table,
-                          uint bits, uint load_factor_percent, hash_function_t func,
-                          uint hash_offset
-                              /* FIXME: turn this bool into a HASHTABLE_ flag */
-                              _IFLOOKUP(bool use_lookup),
-                          uint table_flags _IF_DEBUG(const char *table_name))
+static void
+HTNAME(hashtable_, NAME_KEY, _init)(dcontext_t *dcontext,
+                                    HTNAME(, NAME_KEY, _table_t) * table, uint bits,
+                                    uint load_factor_percent, hash_function_t func,
+                                    uint hash_offset
+                                        /* FIXME: turn this bool into a HASHTABLE_ flag */
+                                        _IFLOOKUP(bool use_lookup),
+                                    uint table_flags _IF_DEBUG(const char *table_name))
 {
 #    ifdef DEBUG
     table->name = table_name;
@@ -542,8 +543,9 @@ static void HTNAME(hashtable_, NAME_KEY,
 }
 
 /* caller is responsible for any needed synchronization */
-static void HTNAME(hashtable_, NAME_KEY, _resize)(dcontext_t *dcontext,
-                                                  HTNAME(, NAME_KEY, _table_t) * table)
+static void
+HTNAME(hashtable_, NAME_KEY, _resize)(dcontext_t *dcontext,
+                                      HTNAME(, NAME_KEY, _table_t) * table)
 {
     HTNAME(hashtable_, NAME_KEY, _init_internal)
     (dcontext, table, table->hash_bits, table->load_factor_percent, table->hash_func,
@@ -552,10 +554,11 @@ static void HTNAME(hashtable_, NAME_KEY, _resize)(dcontext_t *dcontext,
          _IFLOOKUP(table->lookuptable != 0));
 }
 
-static inline void HTNAME(hashtable_, NAME_KEY, _free_table)(
-    dcontext_t *alloc_dc,
-    ENTRY_TYPE *table_unaligned _IFLOOKUP(byte *lookup_table_unaligned), uint flags,
-    uint capacity)
+static inline void
+HTNAME(hashtable_, NAME_KEY,
+       _free_table)(dcontext_t *alloc_dc,
+                    ENTRY_TYPE *table_unaligned _IFLOOKUP(byte *lookup_table_unaligned),
+                    uint flags, uint capacity)
 {
     if (table_unaligned != NULL) {
         TABLE_MEMOP(flags, free)
@@ -573,8 +576,9 @@ static inline void HTNAME(hashtable_, NAME_KEY, _free_table)(
 #    endif
 }
 
-static void HTNAME(hashtable_, NAME_KEY, _free)(dcontext_t *dcontext,
-                                                HTNAME(, NAME_KEY, _table_t) * table)
+static void
+HTNAME(hashtable_, NAME_KEY, _free)(dcontext_t *dcontext,
+                                    HTNAME(, NAME_KEY, _table_t) * table)
 {
     LOG(THREAD, LOG_HTABLE, 1,
         "hashtable_" KEY_STRING "_free %s table=" PFX " bits=%d size=%d "
@@ -616,10 +620,10 @@ static void HTNAME(hashtable_, NAME_KEY, _free)(dcontext_t *dcontext,
  * are expected to target a target_delete_entry.
  */
 #    ifdef DEBUG
-static inline void HTNAME(hashtable_, NAME_KEY,
-                          _check_consistency)(dcontext_t *dcontext,
-                                              HTNAME(, NAME_KEY, _table_t) * htable,
-                                              uint hindex)
+static inline void
+HTNAME(hashtable_, NAME_KEY, _check_consistency)(dcontext_t *dcontext,
+                                                 HTNAME(, NAME_KEY, _table_t) * htable,
+                                                 uint hindex)
 {
 #        ifdef HASHTABLE_USE_LOOKUPTABLE
     if (htable->lookuptable == NULL) {
@@ -675,8 +679,8 @@ static inline void HTNAME(hashtable_, NAME_KEY,
  */
 /* CHECK this routine is partially specialized, otherwise turn it into a macro */
 static /* want to inline but > limit in fragment_lookup */ ENTRY_TYPE
-    HTNAME(hashtable_, NAME_KEY, _lookup)(dcontext_t *dcontext, ptr_uint_t tag,
-                                          HTNAME(, NAME_KEY, _table_t) * htable)
+HTNAME(hashtable_, NAME_KEY, _lookup)(dcontext_t *dcontext, ptr_uint_t tag,
+                                      HTNAME(, NAME_KEY, _table_t) * htable)
 {
     ENTRY_TYPE e;
     ptr_uint_t ftag;
@@ -738,9 +742,9 @@ static /* want to inline but > limit in fragment_lookup */ ENTRY_TYPE
 }
 
 /* Convenience routine that grabs the read lock and does a lookup */
-static inline ENTRY_TYPE HTNAME(hashtable_, NAME_KEY,
-                                _rlookup)(dcontext_t *dcontext, ptr_uint_t tag,
-                                          HTNAME(, NAME_KEY, _table_t) * htable)
+static inline ENTRY_TYPE
+HTNAME(hashtable_, NAME_KEY, _rlookup)(dcontext_t *dcontext, ptr_uint_t tag,
+                                       HTNAME(, NAME_KEY, _table_t) * htable)
 {
     ENTRY_TYPE e;
     TABLE_RWLOCK(htable, read, lock);
@@ -754,9 +758,9 @@ static inline ENTRY_TYPE HTNAME(hashtable_, NAME_KEY,
  * N.B.: this routine will recursively call itself via check_table_size if the
  * table is resized
  */
-static inline bool HTNAME(hashtable_, NAME_KEY,
-                          _add)(dcontext_t *dcontext, ENTRY_TYPE e,
-                                HTNAME(, NAME_KEY, _table_t) * table)
+static inline bool
+HTNAME(hashtable_, NAME_KEY, _add)(dcontext_t *dcontext, ENTRY_TYPE e,
+                                   HTNAME(, NAME_KEY, _table_t) * table)
 {
     uint hindex;
     bool resized;
@@ -913,10 +917,10 @@ static inline bool HTNAME(hashtable_, NAME_KEY,
  * calls fragment_add_to_hashtable, which calls back, but should never
  * trigger another resize.
  */
-static bool HTNAME(hashtable_, NAME_KEY,
-                   _check_size)(dcontext_t *dcontext,
-                                HTNAME(, NAME_KEY, _table_t) * table, uint add_now,
-                                uint add_later)
+static bool
+HTNAME(hashtable_, NAME_KEY, _check_size)(dcontext_t *dcontext,
+                                          HTNAME(, NAME_KEY, _table_t) * table,
+                                          uint add_now, uint add_later)
 {
     dcontext_t *alloc_dc = FRAGMENT_TABLE_ALLOC_DC(dcontext, table->table_flags);
     uint entries;
@@ -1200,8 +1204,10 @@ static bool HTNAME(hashtable_, NAME_KEY,
 
 /* Return pointer to the record for fragment in its collision chain (table or next field)
    or NULL if not found */
-static inline ENTRY_TYPE *HTNAME(hashtable_, NAME_KEY, _lookup_for_removal)(
-    ENTRY_TYPE fr, HTNAME(, NAME_KEY, _table_t) * htable, uint *rhindex)
+static inline ENTRY_TYPE *
+HTNAME(hashtable_, NAME_KEY, _lookup_for_removal)(ENTRY_TYPE fr,
+                                                  HTNAME(, NAME_KEY, _table_t) * htable,
+                                                  uint *rhindex)
 {
     uint hindex = HASH_FUNC(ENTRY_TAG(fr), htable);
     ENTRY_TYPE *pg = &htable->table[hindex];
@@ -1224,9 +1230,9 @@ static inline ENTRY_TYPE *HTNAME(hashtable_, NAME_KEY, _lookup_for_removal)(
 
 #    ifdef HASHTABLE_USE_LOOKUPTABLE
 /* FIXME: figure out what weight function I tipped off so this is too much too inline */
-static INLINE_FORCED void HTNAME(hashtable_, NAME_KEY,
-                                 _update_lookup)(HTNAME(, NAME_KEY, _table_t) * htable,
-                                                 uint hindex)
+static INLINE_FORCED void
+HTNAME(hashtable_, NAME_KEY, _update_lookup)(HTNAME(, NAME_KEY, _table_t) * htable,
+                                             uint hindex)
 {
     if (htable->lookuptable != NULL) {
         AUX_ENTRY_SET_TO_ENTRY(htable->lookuptable[hindex], htable->table[hindex]);
@@ -1247,9 +1253,10 @@ static INLINE_FORCED void HTNAME(hashtable_, NAME_KEY,
  * FIXME: if callers need more info, could return the final hindex, or the final
  * hole.
  */
-static uint HTNAME(hashtable_, NAME_KEY,
-                   _remove_helper_open_address)(HTNAME(, NAME_KEY, _table_t) * htable,
-                                                uint hindex, ENTRY_TYPE *prevg)
+static uint
+HTNAME(hashtable_, NAME_KEY,
+       _remove_helper_open_address)(HTNAME(, NAME_KEY, _table_t) * htable, uint hindex,
+                                    ENTRY_TYPE *prevg)
 {
     bool wrapped = false;
     /* Assumptions:
@@ -1337,9 +1344,9 @@ static uint HTNAME(hashtable_, NAME_KEY,
 }
 
 /* Returns whether it copied from the start of the table to the end (wraparound). */
-static inline bool HTNAME(hashtable_, NAME_KEY,
-                          _remove_helper)(HTNAME(, NAME_KEY, _table_t) * htable,
-                                          uint hindex, ENTRY_TYPE *prevg)
+static inline bool
+HTNAME(hashtable_, NAME_KEY, _remove_helper)(HTNAME(, NAME_KEY, _table_t) * htable,
+                                             uint hindex, ENTRY_TYPE *prevg)
 {
     /* Non-trivial for open addressed scheme */
     /* just setting elements to null will make unreachable any following elements */
@@ -1361,8 +1368,9 @@ static inline bool HTNAME(hashtable_, NAME_KEY,
 /* Removes f from htable (does not delete f)
  * returns true if fragment found and removed
  */
-static inline bool HTNAME(hashtable_, NAME_KEY,
-                          _remove)(ENTRY_TYPE fr, HTNAME(, NAME_KEY, _table_t) * htable)
+static inline bool
+HTNAME(hashtable_, NAME_KEY, _remove)(ENTRY_TYPE fr,
+                                      HTNAME(, NAME_KEY, _table_t) * htable)
 {
     uint hindex;
     ENTRY_TYPE *pg;
@@ -1381,9 +1389,9 @@ static inline bool HTNAME(hashtable_, NAME_KEY,
 /* Replaces a fragment in hashtable assuming tag is preserved
  * returns true if fragment found and removed
  */
-static inline bool HTNAME(hashtable_, NAME_KEY,
-                          _replace)(ENTRY_TYPE old_e, ENTRY_TYPE new_e,
-                                    HTNAME(, NAME_KEY, _table_t) * htable)
+static inline bool
+HTNAME(hashtable_, NAME_KEY, _replace)(ENTRY_TYPE old_e, ENTRY_TYPE new_e,
+                                       HTNAME(, NAME_KEY, _table_t) * htable)
 {
     uint hindex;
     ENTRY_TYPE *pg =
@@ -1417,8 +1425,9 @@ static inline bool HTNAME(hashtable_, NAME_KEY,
 
 /* removes all entries and resets the table but keeps the same capacity */
 /* not static b/c not used by all tables */
-void HTNAME(hashtable_, NAME_KEY, _clear)(dcontext_t *dcontext,
-                                          HTNAME(, NAME_KEY, _table_t) * table)
+void
+HTNAME(hashtable_, NAME_KEY, _clear)(dcontext_t *dcontext,
+                                     HTNAME(, NAME_KEY, _table_t) * table)
 {
     uint i;
     ENTRY_TYPE e;
@@ -1466,11 +1475,11 @@ void HTNAME(hashtable_, NAME_KEY, _clear)(dcontext_t *dcontext,
  * hashtable_reset is not properly moving elements hence can't be used
  * for removing subsets, and is inefficient!
  */
-static uint HTNAME(hashtable_, NAME_KEY,
-                   _range_remove)(dcontext_t *dcontext,
-                                  HTNAME(, NAME_KEY, _table_t) * table,
-                                  ptr_uint_t tag_start, ptr_uint_t tag_end,
-                                  bool (*filter)(ENTRY_TYPE e))
+static uint
+HTNAME(hashtable_, NAME_KEY, _range_remove)(dcontext_t *dcontext,
+                                            HTNAME(, NAME_KEY, _table_t) * table,
+                                            ptr_uint_t tag_start, ptr_uint_t tag_end,
+                                            bool (*filter)(ENTRY_TYPE e))
 {
     int i;
     ENTRY_TYPE e;
@@ -1524,12 +1533,12 @@ static uint HTNAME(hashtable_, NAME_KEY,
 }
 
 /* removes all unlinked entries from table's lookup table */
-static uint HTNAME(hashtable_, NAME_KEY,
-                   _unlinked_remove)(dcontext_t *dcontext,
-                                     HTNAME(, NAME_KEY, _table_t) * table)
+static uint
+HTNAME(hashtable_, NAME_KEY, _unlinked_remove)(dcontext_t *dcontext,
+                                               HTNAME(, NAME_KEY, _table_t) * table)
 {
     int i;
-    ENTRY_TYPE e;
+    ENTRY_TYPE e UNUSED;
     uint entries_removed = 0;
 
     ASSERT(!TEST(HASHTABLE_READ_ONLY, table->table_flags));
@@ -1607,9 +1616,9 @@ static uint HTNAME(hashtable_, NAME_KEY,
 
 /* we should clean the table from entries that are not frequently used
  */
-static void HTNAME(hashtable_, NAME_KEY,
-                   _groom_table)(dcontext_t *dcontext,
-                                 HTNAME(, NAME_KEY, _table_t) * table)
+static void
+HTNAME(hashtable_, NAME_KEY, _groom_table)(dcontext_t *dcontext,
+                                           HTNAME(, NAME_KEY, _table_t) * table)
 {
     DOLOG(1, LOG_STATS, { d_r_print_timestamp(THREAD); });
     LOG(THREAD, LOG_HTABLE, 1, "hashtable_" KEY_STRING "_groom_table %s\n", table->name);
@@ -1651,9 +1660,9 @@ static void HTNAME(hashtable_, NAME_KEY,
     DOLOG(3, LOG_HTABLE, { HTNAME(hashtable_, NAME_KEY, _dump_table)(dcontext, table); });
 }
 
-static inline void HTNAME(hashtable_, NAME_KEY,
-                          _groom_helper)(dcontext_t *dcontext,
-                                         HTNAME(, NAME_KEY, _table_t) * table)
+static inline void
+HTNAME(hashtable_, NAME_KEY, _groom_helper)(dcontext_t *dcontext,
+                                            HTNAME(, NAME_KEY, _table_t) * table)
 {
     /* flush only tables caching data persistent in another table */
     ASSERT(TEST(HASHTABLE_NOT_PRIMARY_STORAGE, table->table_flags));
@@ -1683,15 +1692,15 @@ static inline void HTNAME(hashtable_, NAME_KEY,
  * indcalls_miss_stat includes misses both with and without
  * collisions.
  */
-static void HTNAME(hashtable_, NAME_KEY,
-                   _study)(dcontext_t *dcontext, HTNAME(, NAME_KEY, _table_t) * table,
-                           uint entries_inc /*amnt table->entries was pre-inced*/)
+static void
+HTNAME(hashtable_, NAME_KEY,
+       _study)(dcontext_t *dcontext, HTNAME(, NAME_KEY, _table_t) * table,
+               uint entries_inc /*amnt table->entries was pre-inced*/)
 {
     /* hashtable sparseness study */
     uint i;
     uint max = 0;
     uint num = 0, len = 0, num_collisions = 0;
-    uint colliding_frags = 0;
     uint total_len = 0;
     uint hindex;
     const char *name = table->name;
@@ -1764,7 +1773,6 @@ static void HTNAME(hashtable_, NAME_KEY,
             num++;
             if (len > 1) {
                 num_collisions++;
-                colliding_frags += len;
             }
         }
     }
@@ -1829,8 +1837,9 @@ static void HTNAME(hashtable_, NAME_KEY,
     TABLE_RWLOCK(table, read, unlock);
 }
 
-void HTNAME(hashtable_, NAME_KEY, _dump_table)(dcontext_t *dcontext,
-                                               HTNAME(, NAME_KEY, _table_t) * htable)
+void
+HTNAME(hashtable_, NAME_KEY, _dump_table)(dcontext_t *dcontext,
+                                          HTNAME(, NAME_KEY, _table_t) * htable)
 {
     uint i;
     bool track_cache_lines;
@@ -1922,9 +1931,9 @@ void HTNAME(hashtable_, NAME_KEY, _dump_table)(dcontext_t *dcontext,
 #    endif     /* DEBUG */
 
 #    if defined(DEBUG) && defined(INTERNAL)
-static void HTNAME(hashtable_, NAME_KEY,
-                   _load_statistics)(dcontext_t *dcontext,
-                                     HTNAME(, NAME_KEY, _table_t) * table)
+static void
+HTNAME(hashtable_, NAME_KEY, _load_statistics)(dcontext_t *dcontext,
+                                               HTNAME(, NAME_KEY, _table_t) * table)
 {
     LOG(THREAD, LOG_HTABLE | LOG_STATS, 1,
         "%s hashtable: %d entries, %d unlinked entries, %d capacity,"
@@ -1936,9 +1945,9 @@ static void HTNAME(hashtable_, NAME_KEY,
 
 #    ifdef HASHTABLE_STATISTICS
 #        ifdef HASHTABLE_ENTRY_STATS
-void HTNAME(hashtable_, NAME_KEY,
-            _dump_entry_stats)(dcontext_t *dcontext,
-                               HTNAME(, NAME_KEY, _table_t) * htable)
+void
+HTNAME(hashtable_, NAME_KEY, _dump_entry_stats)(dcontext_t *dcontext,
+                                                HTNAME(, NAME_KEY, _table_t) * htable)
 {
     /* mostly a copy of dump_table but printing only entries with non 0 stats */
     uint i;
@@ -1996,8 +2005,9 @@ void HTNAME(hashtable_, NAME_KEY,
 #    endif /* HASHTABLE_STATISTICS */
 
 #    ifdef HASHTABLE_SUPPORT_PERSISTENCE
-uint HTNAME(hashtable_, NAME_KEY, _persist_size)(dcontext_t *dcontext,
-                                                 HTNAME(, NAME_KEY, _table_t) * htable)
+uint
+HTNAME(hashtable_, NAME_KEY, _persist_size)(dcontext_t *dcontext,
+                                            HTNAME(, NAME_KEY, _table_t) * htable)
 {
     if (htable == NULL)
         return 0;
@@ -2013,9 +2023,9 @@ uint HTNAME(hashtable_, NAME_KEY, _persist_size)(dcontext_t *dcontext,
  * making COW and having the whole page private: case 9582).
  * Returns true iff all writes succeeded.
  */
-bool HTNAME(hashtable_, NAME_KEY, _persist)(dcontext_t *dcontext,
-                                            HTNAME(, NAME_KEY, _table_t) * htable,
-                                            file_t fd)
+bool
+HTNAME(hashtable_, NAME_KEY, _persist)(dcontext_t *dcontext,
+                                       HTNAME(, NAME_KEY, _table_t) * htable, file_t fd)
 {
     uint size;
     ASSERT(htable != NULL);
@@ -2032,10 +2042,10 @@ bool HTNAME(hashtable_, NAME_KEY, _persist)(dcontext_t *dcontext,
     return true;
 }
 
-static uint HTNAME(hashtable_, NAME_KEY,
-                   _num_unique_entries)(dcontext_t *dcontext,
-                                        HTNAME(, NAME_KEY, _table_t) * src1,
-                                        HTNAME(, NAME_KEY, _table_t) * src2)
+static uint
+HTNAME(hashtable_, NAME_KEY, _num_unique_entries)(dcontext_t *dcontext,
+                                                  HTNAME(, NAME_KEY, _table_t) * src1,
+                                                  HTNAME(, NAME_KEY, _table_t) * src2)
 {
     HTNAME(, NAME_KEY, _table_t) * big, *small;
     uint unique, i;
@@ -2073,9 +2083,10 @@ static uint HTNAME(hashtable_, NAME_KEY,
 }
 
 /* Adds all entries from src to dst */
-static void HTNAME(hashtable_, NAME_KEY,
-                   _add_all)(dcontext_t *dcontext, HTNAME(, NAME_KEY, _table_t) * dst,
-                             HTNAME(, NAME_KEY, _table_t) * src, bool check_dups)
+static void
+HTNAME(hashtable_, NAME_KEY,
+       _add_all)(dcontext_t *dcontext, HTNAME(, NAME_KEY, _table_t) * dst,
+                 HTNAME(, NAME_KEY, _table_t) * src, bool check_dups)
 {
     ENTRY_TYPE e;
     uint i;

--- a/core/heap.c
+++ b/core/heap.c
@@ -2241,7 +2241,7 @@ void
 d_r_heap_init()
 {
     int i;
-    uint prev_sz = 0;
+    DEBUG_DECLARE(uint prev_sz = 0;)
 
     LOG(GLOBAL, LOG_TOP | LOG_HEAP, 2, "Heap bucket sizes are:\n");
     /* make sure we'll preserve alignment */
@@ -2253,7 +2253,7 @@ d_r_heap_init()
         ASSERT(BLOCK_SIZES[i] > prev_sz);
         /* we assume all of our heap allocs are aligned */
         ASSERT(i == BLOCK_TYPES - 1 || ALIGNED(BLOCK_SIZES[i], HEAP_ALIGNMENT));
-        prev_sz = BLOCK_SIZES[i];
+        DODEBUG(prev_sz = BLOCK_SIZES[i];)
         LOG(GLOBAL, LOG_TOP | LOG_HEAP, 2, "\t%d bytes\n", BLOCK_SIZES[i]);
     }
 
@@ -2455,7 +2455,7 @@ heap_low_on_memory()
 {
     /* free some memory! */
     heap_unit_t *u, *next_u;
-    size_t freed = 0;
+    DEBUG_DECLARE(size_t freed = 0;)
     LOG(GLOBAL, LOG_CACHE | LOG_STATS, 1,
         "heap_low_on_memory: about to free dead list units\n");
     /* WARNING: this routine is called at arbitrary allocation failure points,
@@ -2473,7 +2473,7 @@ heap_low_on_memory()
     u = heapmgt->heap.dead;
     while (u != NULL) {
         next_u = u->next_global;
-        freed += UNIT_COMMIT_SIZE(u);
+        DODEBUG(freed += UNIT_COMMIT_SIZE(u);)
         /* FIXME: if out of committed pages only, could keep our reservations */
         LOG(GLOBAL, LOG_HEAP, 1, "\tfreeing dead unit " PFX "-" PFX " [-" PFX "]\n", u,
             UNIT_COMMIT_END(u), UNIT_RESERVED_END(u));
@@ -3595,7 +3595,6 @@ static heap_unit_t *
 heap_create_unit(thread_units_t *tu, size_t size, bool must_be_new)
 {
     heap_unit_t *u = NULL, *dead = NULL, *prev_dead = NULL;
-    bool new_unit = false;
 
     /* we do not restrict size to unit max as we have to make larger-than-max
      * units for oversized requests
@@ -3645,7 +3644,6 @@ heap_create_unit(thread_units_t *tu, size_t size, bool must_be_new)
         u = (heap_unit_t *)get_guarded_real_memory(size, commit_size,
                                                    MEMPROT_READ | MEMPROT_WRITE, false,
                                                    true, NULL, tu->which _IF_DEBUG(""));
-        new_unit = true;
         /* FIXME: handle low memory conditions by freeing units, + fcache units? */
         ASSERT(u);
         LOG(GLOBAL, LOG_HEAP, 2, "New heap unit: " PFX "-" PFX "\n", u,

--- a/core/heap.c
+++ b/core/heap.c
@@ -2253,7 +2253,7 @@ d_r_heap_init()
         ASSERT(BLOCK_SIZES[i] > prev_sz);
         /* we assume all of our heap allocs are aligned */
         ASSERT(i == BLOCK_TYPES - 1 || ALIGNED(BLOCK_SIZES[i], HEAP_ALIGNMENT));
-        DODEBUG(prev_sz = BLOCK_SIZES[i];)
+        DODEBUG(prev_sz = BLOCK_SIZES[i];);
         LOG(GLOBAL, LOG_TOP | LOG_HEAP, 2, "\t%d bytes\n", BLOCK_SIZES[i]);
     }
 
@@ -2473,7 +2473,7 @@ heap_low_on_memory()
     u = heapmgt->heap.dead;
     while (u != NULL) {
         next_u = u->next_global;
-        DODEBUG(freed += UNIT_COMMIT_SIZE(u);)
+        DODEBUG(freed += UNIT_COMMIT_SIZE(u););
         /* FIXME: if out of committed pages only, could keep our reservations */
         LOG(GLOBAL, LOG_HEAP, 1, "\tfreeing dead unit " PFX "-" PFX " [-" PFX "]\n", u,
             UNIT_COMMIT_END(u), UNIT_RESERVED_END(u));

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1323,6 +1323,7 @@ encode_opnd_b_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     return false;
 }
 
+#if 0  /* Currently unused. */
 /* h_const_sz: Operand size for half (16-bit) vector elements
  */
 static inline bool
@@ -1342,6 +1343,7 @@ encode_opnd_h_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
         return true;
     return false;
 }
+#endif /* Currently unused. */
 
 /* s_const_sz: Operand size for single (32-bit) vector element
  */
@@ -1425,6 +1427,7 @@ encode_opnd_zero_fp_const(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint 
 
 /* nzcv: flag bit specifier for conditional compare */
 
+#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_nzcv(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -1436,6 +1439,7 @@ encode_opnd_nzcv(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_int(0, 4, false, 0, 0, opnd, enc_out);
 }
+#endif /* Currently unused. */
 
 /* w0: W register or WZR at bit position 0 */
 
@@ -3443,6 +3447,7 @@ encode_bhsd_immh_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
     return encode_opnd_vector_reg(rpos, offset, opnd, enc_out);
 }
 
+#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_hsd_immh_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -3454,6 +3459,7 @@ encode_opnd_hsd_immh_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint 
 {
     return encode_hsd_immh_regx(0, enc, opcode, pc, opnd, enc_out);
 }
+#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_immh_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4087,6 +4093,7 @@ encode_scalar_size_regx(uint size_offset, int rpos, uint enc, int opcode, byte *
     return reg_written;
 }
 
+#if 0 /* Currently unused. */
 static inline bool
 decode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4099,6 +4106,7 @@ encode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
 {
     return encode_scalar_size_regx(1, rpos, enc, opcode, pc, opnd, enc_out);
 }
+#endif
 
 static inline bool
 decode_bhsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4125,6 +4133,7 @@ encode_opnd_float_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     return encode_opnd_float_reg(0, opnd, enc_out);
 }
 
+#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_hsd_size_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4136,6 +4145,7 @@ encode_opnd_hsd_size_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint 
 {
     return encode_hsd_size_regx(0, enc, opcode, pc, opnd, enc_out);
 }
+#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_size_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4161,6 +4171,7 @@ encode_opnd_float_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     return encode_opnd_float_reg(5, opnd, enc_out);
 }
 
+#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_hsd_size_reg5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4172,6 +4183,7 @@ encode_opnd_hsd_size_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint 
 {
     return encode_hsd_size_regx(5, enc, opcode, pc, opnd, enc_out);
 }
+#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_size_reg5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4209,6 +4221,7 @@ encode_opnd_float_reg16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *e
     return encode_opnd_float_reg(16, opnd, enc_out);
 }
 
+#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_hsd_size_reg16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4220,6 +4233,7 @@ encode_opnd_hsd_size_reg16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint
 {
     return encode_hsd_size_regx(16, enc, opcode, pc, opnd, enc_out);
 }
+#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_size_reg16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4312,6 +4326,7 @@ encode_opnd_dq0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 
 /* sd0: S/D register at bit position 0; bit 30 selects D reg */
 
+#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_sd0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4323,6 +4338,7 @@ encode_opnd_sd0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_sd(0, 30, opnd, enc_out);
 }
+#endif /* Currently unused. */
 
 /* dq0p1: as dq0 but add 1 mod 32 to reg number */
 
@@ -4548,6 +4564,7 @@ encode_opnd_dq16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
  *             by-element encoding; bit 30 selects D reg
  */
 
+#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4570,6 +4587,7 @@ encode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
     *enc_out = num << 16 | (uint)d << 30;
     return true;
 }
+#endif /* Currently unused. */
 
 /* dq16: D/Q register at bit position 16; bit 30 selects Q reg */
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1323,28 +1323,6 @@ encode_opnd_b_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     return false;
 }
 
-#if 0  /* Currently unused. */
-/* h_const_sz: Operand size for half (16-bit) vector elements
- */
-static inline bool
-decode_opnd_h_const_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_HALF, OPSZ_2b);
-    return true;
-}
-
-static inline bool
-encode_opnd_h_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    if (!opnd_is_immed_int(opnd))
-        return false;
-
-    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF)
-        return true;
-    return false;
-}
-#endif /* Currently unused. */
-
 /* s_const_sz: Operand size for single (32-bit) vector element
  */
 static inline bool
@@ -1424,22 +1402,6 @@ encode_opnd_zero_fp_const(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint 
         return true;
     return false;
 }
-
-/* nzcv: flag bit specifier for conditional compare */
-
-#if 0  /* Currently unused. */
-static inline bool
-decode_opnd_nzcv(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_opnd_int(0, 4, false, 0, OPSZ_4b, 0, enc, opnd);
-}
-
-static inline bool
-encode_opnd_nzcv(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    return encode_opnd_int(0, 4, false, 0, 0, opnd, enc_out);
-}
-#endif /* Currently unused. */
 
 /* w0: W register or WZR at bit position 0 */
 
@@ -3447,20 +3409,6 @@ encode_bhsd_immh_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
     return encode_opnd_vector_reg(rpos, offset, opnd, enc_out);
 }
 
-#if 0  /* Currently unused. */
-static inline bool
-decode_opnd_hsd_immh_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_hsd_immh_regx(0, enc, opcode, pc, opnd);
-}
-
-static inline bool
-encode_opnd_hsd_immh_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    return encode_hsd_immh_regx(0, enc, opcode, pc, opnd, enc_out);
-}
-#endif /* Currently unused. */
-
 static inline bool
 decode_opnd_bhsd_immh_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4093,21 +4041,6 @@ encode_scalar_size_regx(uint size_offset, int rpos, uint enc, int opcode, byte *
     return reg_written;
 }
 
-#if 0 /* Currently unused. */
-static inline bool
-decode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_scalar_size_regx(1, rpos, enc, opcode, pc, opnd);
-}
-
-static inline bool
-encode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
-                     OUT uint *enc_out)
-{
-    return encode_scalar_size_regx(1, rpos, enc, opcode, pc, opnd, enc_out);
-}
-#endif
-
 static inline bool
 decode_bhsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4133,20 +4066,6 @@ encode_opnd_float_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     return encode_opnd_float_reg(0, opnd, enc_out);
 }
 
-#if 0  /* Currently unused. */
-static inline bool
-decode_opnd_hsd_size_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_hsd_size_regx(0, enc, opcode, pc, opnd);
-}
-
-static inline bool
-encode_opnd_hsd_size_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    return encode_hsd_size_regx(0, enc, opcode, pc, opnd, enc_out);
-}
-#endif /* Currently unused. */
-
 static inline bool
 decode_opnd_bhsd_size_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4170,20 +4089,6 @@ encode_opnd_float_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
 {
     return encode_opnd_float_reg(5, opnd, enc_out);
 }
-
-#if 0  /* Currently unused. */
-static inline bool
-decode_opnd_hsd_size_reg5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_hsd_size_regx(5, enc, opcode, pc, opnd);
-}
-
-static inline bool
-encode_opnd_hsd_size_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    return encode_hsd_size_regx(5, enc, opcode, pc, opnd, enc_out);
-}
-#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_size_reg5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4220,20 +4125,6 @@ encode_opnd_float_reg16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *e
 {
     return encode_opnd_float_reg(16, opnd, enc_out);
 }
-
-#if 0  /* Currently unused. */
-static inline bool
-decode_opnd_hsd_size_reg16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_hsd_size_regx(16, enc, opcode, pc, opnd);
-}
-
-static inline bool
-encode_opnd_hsd_size_reg16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    return encode_hsd_size_regx(16, enc, opcode, pc, opnd, enc_out);
-}
-#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_size_reg16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4323,22 +4214,6 @@ encode_opnd_dq0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_dq_plus(0, 0, 30, opnd, enc_out);
 }
-
-/* sd0: S/D register at bit position 0; bit 30 selects D reg */
-
-#if 0  /* Currently unused. */
-static inline bool
-decode_opnd_sd0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_opnd_sd(0, 30, enc, opnd);
-}
-
-static inline bool
-encode_opnd_sd0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    return encode_opnd_sd(0, 30, opnd, enc_out);
-}
-#endif /* Currently unused. */
 
 /* dq0p1: as dq0 but add 1 mod 32 to reg number */
 
@@ -4559,35 +4434,6 @@ encode_opnd_dq16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
     *enc_out = num << 16 | (uint)q << 30;
     return true;
 }
-
-/* sd16_h_sz: S/D register at bit position 16 with 4 bits only, for the FP16
- *             by-element encoding; bit 30 selects D reg
- */
-
-#if 0  /* Currently unused. */
-static inline bool
-decode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    *opnd = opnd_create_reg((TEST(1U << 30, enc) ? DR_REG_D0 : DR_REG_S0) +
-                            extract_uint(enc, 16, 4));
-    return true;
-}
-
-static inline bool
-encode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    uint num;
-    bool d;
-    if (!opnd_is_reg(opnd))
-        return false;
-    d = (uint)(opnd_get_reg(opnd) - DR_REG_D0) < 16;
-    num = opnd_get_reg(opnd) - (d ? DR_REG_D0 : DR_REG_S0);
-    if (num >= 16)
-        return false;
-    *enc_out = num << 16 | (uint)d << 30;
-    return true;
-}
-#endif /* Currently unused. */
 
 /* dq16: D/Q register at bit position 16; bit 30 selects Q reg */
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1323,6 +1323,28 @@ encode_opnd_b_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     return false;
 }
 
+#if 0  /* Currently unused. */
+/* h_const_sz: Operand size for half (16-bit) vector elements
+ */
+static inline bool
+decode_opnd_h_const_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_immed_int(VECTOR_ELEM_WIDTH_HALF, OPSZ_2b);
+    return true;
+}
+
+static inline bool
+encode_opnd_h_const_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+    if (opnd_get_immed_int(opnd) == VECTOR_ELEM_WIDTH_HALF)
+        return true;
+    return false;
+}
+#endif /* Currently unused. */
+
 /* s_const_sz: Operand size for single (32-bit) vector element
  */
 static inline bool
@@ -1402,6 +1424,22 @@ encode_opnd_zero_fp_const(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint 
         return true;
     return false;
 }
+
+/* nzcv: flag bit specifier for conditional compare */
+
+#if 0  /* Currently unused. */
+static inline bool
+decode_opnd_nzcv(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_int(0, 4, false, 0, OPSZ_4b, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_nzcv(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_int(0, 4, false, 0, 0, opnd, enc_out);
+}
+#endif /* Currently unused. */
 
 /* w0: W register or WZR at bit position 0 */
 
@@ -3409,6 +3447,20 @@ encode_bhsd_immh_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
     return encode_opnd_vector_reg(rpos, offset, opnd, enc_out);
 }
 
+#if 0  /* Currently unused. */
+static inline bool
+decode_opnd_hsd_immh_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_hsd_immh_regx(0, enc, opcode, pc, opnd);
+}
+
+static inline bool
+encode_opnd_hsd_immh_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_hsd_immh_regx(0, enc, opcode, pc, opnd, enc_out);
+}
+#endif /* Currently unused. */
+
 static inline bool
 decode_opnd_bhsd_immh_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4041,6 +4093,21 @@ encode_scalar_size_regx(uint size_offset, int rpos, uint enc, int opcode, byte *
     return reg_written;
 }
 
+#if 0 /* Currently unused. */
+static inline bool
+decode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_scalar_size_regx(1, rpos, enc, opcode, pc, opnd);
+}
+
+static inline bool
+encode_hsd_size_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
+                     OUT uint *enc_out)
+{
+    return encode_scalar_size_regx(1, rpos, enc, opcode, pc, opnd, enc_out);
+}
+#endif
+
 static inline bool
 decode_bhsd_size_regx(int rpos, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4066,6 +4133,20 @@ encode_opnd_float_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
     return encode_opnd_float_reg(0, opnd, enc_out);
 }
 
+#if 0  /* Currently unused. */
+static inline bool
+decode_opnd_hsd_size_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_hsd_size_regx(0, enc, opcode, pc, opnd);
+}
+
+static inline bool
+encode_opnd_hsd_size_reg0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_hsd_size_regx(0, enc, opcode, pc, opnd, enc_out);
+}
+#endif /* Currently unused. */
+
 static inline bool
 decode_opnd_bhsd_size_reg0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -4089,6 +4170,20 @@ encode_opnd_float_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
 {
     return encode_opnd_float_reg(5, opnd, enc_out);
 }
+
+#if 0  /* Currently unused. */
+static inline bool
+decode_opnd_hsd_size_reg5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_hsd_size_regx(5, enc, opcode, pc, opnd);
+}
+
+static inline bool
+encode_opnd_hsd_size_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_hsd_size_regx(5, enc, opcode, pc, opnd, enc_out);
+}
+#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_size_reg5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4125,6 +4220,20 @@ encode_opnd_float_reg16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *e
 {
     return encode_opnd_float_reg(16, opnd, enc_out);
 }
+
+#if 0  /* Currently unused. */
+static inline bool
+decode_opnd_hsd_size_reg16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_hsd_size_regx(16, enc, opcode, pc, opnd);
+}
+
+static inline bool
+encode_opnd_hsd_size_reg16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_hsd_size_regx(16, enc, opcode, pc, opnd, enc_out);
+}
+#endif /* Currently unused. */
 
 static inline bool
 decode_opnd_bhsd_size_reg16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -4214,6 +4323,22 @@ encode_opnd_dq0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_dq_plus(0, 0, 30, opnd, enc_out);
 }
+
+/* sd0: S/D register at bit position 0; bit 30 selects D reg */
+
+#if 0  /* Currently unused. */
+static inline bool
+decode_opnd_sd0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_sd(0, 30, enc, opnd);
+}
+
+static inline bool
+encode_opnd_sd0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_sd(0, 30, opnd, enc_out);
+}
+#endif /* Currently unused. */
 
 /* dq0p1: as dq0 but add 1 mod 32 to reg number */
 
@@ -4434,6 +4559,35 @@ encode_opnd_dq16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
     *enc_out = num << 16 | (uint)q << 30;
     return true;
 }
+
+/* sd16_h_sz: S/D register at bit position 16 with 4 bits only, for the FP16
+ *             by-element encoding; bit 30 selects D reg
+ */
+
+#if 0  /* Currently unused. */
+static inline bool
+decode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg((TEST(1U << 30, enc) ? DR_REG_D0 : DR_REG_S0) +
+                            extract_uint(enc, 16, 4));
+    return true;
+}
+
+static inline bool
+encode_opnd_sd16_h_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    uint num;
+    bool d;
+    if (!opnd_is_reg(opnd))
+        return false;
+    d = (uint)(opnd_get_reg(opnd) - DR_REG_D0) < 16;
+    num = opnd_get_reg(opnd) - (d ? DR_REG_D0 : DR_REG_S0);
+    if (num >= 16)
+        return false;
+    *enc_out = num << 16 | (uint)d << 30;
+    return true;
+}
+#endif /* Currently unused. */
 
 /* dq16: D/Q register at bit position 16; bit 30 selects Q reg */
 

--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -1086,7 +1086,6 @@ internal_instr_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT,
                            dcontext_t *dcontext, instr_t *instr)
 {
     int i;
-    const instr_info_t *info;
     const char *name;
     int name_width = 6;
     bool use_size_sfx = false;
@@ -1104,10 +1103,9 @@ internal_instr_disassemble(char *buf, size_t bufsz, size_t *sofar INOUT,
     } else if (instr_opcode_valid(instr)) {
 #ifdef AARCH64
         /* We do not use instr_info_t encoding info on AArch64. */
-        info = NULL;
         name = get_opcode_name(instr_get_opcode(instr));
 #else
-        info = instr_get_instr_info(instr);
+        const instr_info_t *info = instr_get_instr_info(instr);
         name = info->name;
 #endif
     } else
@@ -1293,9 +1291,9 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
                         ? (TEST(FRAG_TEMP_PRIVATE, f->flags) ? "private temp, "
                                                              : "private, ")
                         : "")),
-            (TEST(FRAG_IS_TRACE, f->flags))
-                ? "trace, "
-                : (TEST(FRAG_IS_TRACE_HEAD, f->flags)) ? "tracehead, " : "",
+            (TEST(FRAG_IS_TRACE, f->flags))            ? "trace, "
+                : (TEST(FRAG_IS_TRACE_HEAD, f->flags)) ? "tracehead, "
+                                                       : "",
             f->size, (TEST(FRAG_CANNOT_BE_TRACE, f->flags)) ? ", cannot be trace" : "",
             (TEST(FRAG_MUST_END_TRACE, f->flags)) ? ", must end trace" : "",
             (TEST(FRAG_CANNOT_DELETE, f->flags)) ? ", cannot delete" : "");

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1490,7 +1490,7 @@ instr_decode_cti(dcontext_t *dcontext, instr_t *instr)
      */
     if (!instr_opcode_valid(instr) ||
         (instr_is_cti(instr) && !instr_operands_valid(instr))) {
-        byte *next_pc;
+        DEBUG_EXT_DECLARE(byte * next_pc;)
         DEBUG_EXT_DECLARE(int old_len = instr->length;)
         /* decode_cti() will use the dcontext mode, but we want the instr mode */
         dr_isa_mode_t old_mode;
@@ -1498,7 +1498,7 @@ instr_decode_cti(dcontext_t *dcontext, instr_t *instr)
         CLIENT_ASSERT(instr_raw_bits_valid(instr),
                       "instr_decode_cti: raw bits are invalid");
         instr_reuse(dcontext, instr);
-        next_pc = decode_cti(dcontext, instr->bytes, instr);
+        DEBUG_EXT_DECLARE(next_pc =) decode_cti(dcontext, instr->bytes, instr);
         dr_set_isa_mode(dcontext, old_mode, NULL);
         /* ok to be invalid, let caller deal with it */
         CLIENT_ASSERT(next_pc == NULL || (next_pc - instr->bytes == old_len),
@@ -1517,7 +1517,7 @@ void
 instr_decode_opcode(dcontext_t *dcontext, instr_t *instr)
 {
     if (!instr_opcode_valid(instr)) {
-        byte *next_pc;
+        DEBUG_EXT_DECLARE(byte * next_pc;)
         DEBUG_EXT_DECLARE(int old_len = instr->length;)
 #ifdef X86
         bool rip_rel_valid = instr_rip_rel_valid(instr);
@@ -1528,7 +1528,7 @@ instr_decode_opcode(dcontext_t *dcontext, instr_t *instr)
         CLIENT_ASSERT(instr_raw_bits_valid(instr),
                       "instr_decode_opcode: raw bits are invalid");
         instr_reuse(dcontext, instr);
-        next_pc = decode_opcode(dcontext, instr->bytes, instr);
+        DEBUG_EXT_DECLARE(next_pc =) decode_opcode(dcontext, instr->bytes, instr);
         dr_set_isa_mode(dcontext, old_mode, NULL);
 #ifdef X86
         /* decode_opcode sets raw bits which invalidates rip_rel, but
@@ -1550,7 +1550,7 @@ void
 instr_decode(dcontext_t *dcontext, instr_t *instr)
 {
     if (!instr_operands_valid(instr)) {
-        byte *next_pc;
+        DEBUG_EXT_DECLARE(byte * next_pc;)
         DEBUG_EXT_DECLARE(int old_len = instr->length;)
 #ifdef X86
         bool rip_rel_valid = instr_rip_rel_valid(instr);
@@ -1560,7 +1560,7 @@ instr_decode(dcontext_t *dcontext, instr_t *instr)
         dr_set_isa_mode(dcontext, instr_get_isa_mode(instr), &old_mode);
         CLIENT_ASSERT(instr_raw_bits_valid(instr), "instr_decode: raw bits are invalid");
         instr_reuse(dcontext, instr);
-        next_pc = decode(dcontext, instr_get_raw_bits(instr), instr);
+        DEBUG_EXT_DECLARE(next_pc =) decode(dcontext, instr_get_raw_bits(instr), instr);
 #ifndef NOT_DYNAMORIO_CORE_PROPER
         if (expand_should_set_translation(dcontext))
             instr_set_translation(instr, instr_get_raw_bits(instr));
@@ -3279,7 +3279,7 @@ instr_create_Ndst_Msrc_varsrc(void *drcontext, int opcode, uint fixed_dsts,
     va_list ap;
     instr_t *in = instr_build(dcontext, opcode, fixed_dsts, fixed_srcs + var_srcs);
     uint i;
-    reg_id_t prev_reg = REG_NULL;
+    DEBUG_EXT_DECLARE(reg_id_t prev_reg = REG_NULL;)
     bool check_order;
     va_start(ap, var_ord);
     for (i = 0; i < fixed_dsts; i++)
@@ -3298,7 +3298,7 @@ instr_create_Ndst_Msrc_varsrc(void *drcontext, int opcode, uint fixed_dsts,
                       "instr_create_Ndst_Msrc_varsrc: wrong register order in reglist");
         instr_set_src(in, var_ord + i, opnd_add_flags(opnd, DR_OPND_IN_LIST));
         if (check_order)
-            prev_reg = opnd_get_reg(opnd);
+            DEBUG_EXT_DECLARE(prev_reg = opnd_get_reg(opnd));
     }
     va_end(ap);
     return in;
@@ -3312,7 +3312,7 @@ instr_create_Ndst_Msrc_vardst(void *drcontext, int opcode, uint fixed_dsts,
     va_list ap;
     instr_t *in = instr_build(dcontext, opcode, fixed_dsts + var_dsts, fixed_srcs);
     uint i;
-    reg_id_t prev_reg = REG_NULL;
+    DEBUG_EXT_DECLARE(reg_id_t prev_reg = REG_NULL;)
     bool check_order;
     va_start(ap, var_ord);
     for (i = 0; i < MIN(var_ord, fixed_dsts); i++)
@@ -3331,7 +3331,7 @@ instr_create_Ndst_Msrc_vardst(void *drcontext, int opcode, uint fixed_dsts,
                       "instr_create_Ndst_Msrc_vardst: wrong register order in reglist");
         instr_set_dst(in, var_ord + i, opnd_add_flags(opnd, DR_OPND_IN_LIST));
         if (check_order)
-            prev_reg = opnd_get_reg(opnd);
+            DEBUG_EXT_DECLARE(prev_reg = opnd_get_reg(opnd));
     }
     va_end(ap);
     return in;

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1367,7 +1367,7 @@ opnd_replace_reg_resize(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
         bool found = false;
         reg_id_t new_b = ob;
         reg_id_t new_i = oi;
-        reg_id_t new_s = os;
+        IF_X86(reg_id_t new_s = os;)
         if (reg_overlap(old_reg, ob)) {
             found = true;
             new_b = reg_match_size_and_type(new_reg, reg_get_size(ob), ob);
@@ -1378,7 +1378,7 @@ opnd_replace_reg_resize(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
         }
         if (reg_overlap(old_reg, os)) {
             found = true;
-            new_s = reg_match_size_and_type(new_reg, reg_get_size(os), os);
+            IF_X86(new_s = reg_match_size_and_type(new_reg, reg_get_size(os), os);)
         }
         if (found) {
             int disp = opnd_get_disp(*opnd);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6384,9 +6384,9 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
             /* We'll clear this cache in dr_resume_all_other_threads() */
             mc_xl8 = dcontext->client_data->cur_mc;
         }
-        DODEBUG(res =) thread_get_mcontext(dcontext->thread_record, mc_xl8);
+        DEBUG_DECLARE(res =) thread_get_mcontext(dcontext->thread_record, mc_xl8);
         CLIENT_ASSERT(res, "failed to get mcontext of suspended thread");
-        DODEBUG(res =)
+        DEBUG_DECLARE(res =)
         translate_mcontext(dcontext->thread_record, mc_xl8,
                            false /*do not restore memory*/, NULL);
         CLIENT_ASSERT(res, "failed to xl8 mcontext of suspended thread");

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -185,7 +185,7 @@ typedef struct _callback_list_t {
  */
 #define call_all(vec, type, ...)                          \
     do {                                                  \
-        int dummy;                                        \
+        int dummy UNUSED;                                 \
         call_all_ret(dummy, =, , vec, type, __VA_ARGS__); \
     } while (0)
 
@@ -971,9 +971,9 @@ dr_unregister_exit_event(void (*func)(void))
     return remove_callback(&exit_callbacks, (void (*)(void))func, true);
 }
 
-void dr_register_bb_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
-                                                  instrlist_t *bb, bool for_trace,
-                                                  bool translating))
+void
+dr_register_bb_event(dr_emit_flags_t (*func)(void *drcontext, void *tag, instrlist_t *bb,
+                                             bool for_trace, bool translating))
 {
     if (!INTERNAL_OPTION(code_api)) {
         CLIENT_ASSERT(false, "asking for bb event when code_api is disabled");
@@ -983,16 +983,17 @@ void dr_register_bb_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
     add_callback(&bb_callbacks, (void (*)(void))func, true);
 }
 
-bool dr_unregister_bb_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
-                                                    instrlist_t *bb, bool for_trace,
-                                                    bool translating))
+bool
+dr_unregister_bb_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
+                                               instrlist_t *bb, bool for_trace,
+                                               bool translating))
 {
     return remove_callback(&bb_callbacks, (void (*)(void))func, true);
 }
 
-void dr_register_trace_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
-                                                     instrlist_t *trace,
-                                                     bool translating))
+void
+dr_register_trace_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
+                                                instrlist_t *trace, bool translating))
 {
     if (!INTERNAL_OPTION(code_api)) {
         CLIENT_ASSERT(false, "asking for trace event when code_api is disabled");
@@ -1002,16 +1003,16 @@ void dr_register_trace_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
     add_callback(&trace_callbacks, (void (*)(void))func, true);
 }
 
-bool dr_unregister_trace_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
-                                                       instrlist_t *trace,
-                                                       bool translating))
+bool
+dr_unregister_trace_event(dr_emit_flags_t (*func)(void *drcontext, void *tag,
+                                                  instrlist_t *trace, bool translating))
 {
     return remove_callback(&trace_callbacks, (void (*)(void))func, true);
 }
 
-void dr_register_end_trace_event(dr_custom_trace_action_t (*func)(void *drcontext,
-                                                                  void *tag,
-                                                                  void *next_tag))
+void
+dr_register_end_trace_event(dr_custom_trace_action_t (*func)(void *drcontext, void *tag,
+                                                             void *next_tag))
 {
     if (!INTERNAL_OPTION(code_api)) {
         CLIENT_ASSERT(false, "asking for end-trace event when code_api is disabled");
@@ -1021,9 +1022,9 @@ void dr_register_end_trace_event(dr_custom_trace_action_t (*func)(void *drcontex
     add_callback(&end_trace_callbacks, (void (*)(void))func, true);
 }
 
-bool dr_unregister_end_trace_event(dr_custom_trace_action_t (*func)(void *drcontext,
-                                                                    void *tag,
-                                                                    void *next_tag))
+bool
+dr_unregister_end_trace_event(dr_custom_trace_action_t (*func)(void *drcontext, void *tag,
+                                                               void *next_tag))
 {
     return remove_callback(&end_trace_callbacks, (void (*)(void))func, true);
 }
@@ -1176,14 +1177,16 @@ dr_unregister_exception_event(bool (*func)(void *drcontext, dr_exception_t *excp
     return remove_callback(&exception_callbacks, (bool (*)(void))func, true);
 }
 #else
-void dr_register_signal_event(dr_signal_action_t (*func)(void *drcontext,
-                                                         dr_siginfo_t *siginfo))
+void
+dr_register_signal_event(dr_signal_action_t (*func)(void *drcontext,
+                                                    dr_siginfo_t *siginfo))
 {
     add_callback(&signal_callbacks, (void (*)(void))func, true);
 }
 
-bool dr_unregister_signal_event(dr_signal_action_t (*func)(void *drcontext,
-                                                           dr_siginfo_t *siginfo))
+bool
+dr_unregister_signal_event(dr_signal_action_t (*func)(void *drcontext,
+                                                      dr_siginfo_t *siginfo))
 {
     return remove_callback(&signal_callbacks, (void (*)(void))func, true);
 }
@@ -6371,7 +6374,7 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
          * context translated lazily here.
          * We cache the result in cur_mc to avoid a translation cost next time.
          */
-        bool res;
+        DEBUG_DECLARE(bool res;)
         priv_mcontext_t *mc_xl8;
         if (mc != NULL)
             mc_xl8 = mc;
@@ -6381,10 +6384,11 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
             /* We'll clear this cache in dr_resume_all_other_threads() */
             mc_xl8 = dcontext->client_data->cur_mc;
         }
-        res = thread_get_mcontext(dcontext->thread_record, mc_xl8);
+        DODEBUG(res =) thread_get_mcontext(dcontext->thread_record, mc_xl8);
         CLIENT_ASSERT(res, "failed to get mcontext of suspended thread");
-        res = translate_mcontext(dcontext->thread_record, mc_xl8,
-                                 false /*do not restore memory*/, NULL);
+        DODEBUG(res =)
+        translate_mcontext(dcontext->thread_record, mc_xl8,
+                           false /*do not restore memory*/, NULL);
         CLIENT_ASSERT(res, "failed to xl8 mcontext of suspended thread");
         if (mc == NULL && !priv_mcontext_to_dr_mcontext(dmc, mc_xl8))
             return false;

--- a/core/link.c
+++ b/core/link.c
@@ -3143,7 +3143,7 @@ coarse_remove_outgoing(dcontext_t *dcontext, cache_pc stub, coarse_info_t *src_i
                     LOG(THREAD, LOG_LINKS, 4, "freeing coarse_incoming_t " PFX "\n", e);
                     NONPERSISTENT_HEAP_TYPE_FREE(GLOBAL_DCONTEXT, e, coarse_incoming_t,
                                                  ACCT_COARSE_LINK);
-                    DODEBUG(found = true;)
+                    DODEBUG(found = true;);
                     break;
                 } else
                     prev_e = e;
@@ -3690,7 +3690,7 @@ coarse_update_outgoing(dcontext_t *dcontext, cache_pc old_stub, cache_pc new_stu
                 for (e = target_info->incoming; e != NULL; e = e->next) {
                     if (e->coarse && e->in.stub_pc == old_stub) {
                         e->in.stub_pc = new_stub;
-                        DODEBUG(found = true;)
+                        DODEBUG(found = true;);
                         break;
                     }
                 }

--- a/core/link.c
+++ b/core/link.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -907,7 +907,6 @@ is_cbr_of_cbr_fallthrough(linkstub_t *l)
 void
 separate_stub_create(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
 {
-    int emit_sz;
     cache_pc stub_pc;
     ASSERT(LINKSTUB_DIRECT(l->flags));
     ASSERT(DYNAMO_OPTION(separate_private_stubs) || DYNAMO_OPTION(separate_shared_stubs));
@@ -938,7 +937,7 @@ separate_stub_create(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
         ASSERT(dl->stub_pc == EXIT_STUB_PC(dcontext, f, l));
         stub_pc = dl->stub_pc;
     }
-    emit_sz = insert_exit_stub(dcontext, f, l, stub_pc);
+    DEBUG_DECLARE(int emit_sz =) insert_exit_stub(dcontext, f, l, stub_pc);
     ASSERT(emit_sz <= SEPARATE_STUB_ALLOC_SIZE(f->flags));
     DOSTATS({
         size_t alloc_size = SEPARATE_STUB_ALLOC_SIZE(f->flags);
@@ -2511,7 +2510,6 @@ static cache_pc
 entrance_stub_create(dcontext_t *dcontext, coarse_info_t *info, fragment_t *f,
                      linkstub_t *l)
 {
-    uint emit_sz;
     cache_pc stub_pc;
     DEBUG_DECLARE(size_t stub_size = COARSE_STUB_ALLOC_SIZE(COARSE_32_FLAG(info));)
     ASSERT(DYNAMO_OPTION(coarse_units));
@@ -2524,7 +2522,7 @@ entrance_stub_create(dcontext_t *dcontext, coarse_info_t *info, fragment_t *f,
     ASSERT((cache_line_size % stub_size) == 0);
     stub_pc = (cache_pc)special_heap_alloc(info->stubs);
     ASSERT(ALIGNED(stub_pc, coarse_stub_alignment(info)));
-    emit_sz = insert_exit_stub(dcontext, f, l, stub_pc);
+    DEBUG_DECLARE(uint emit_sz =) insert_exit_stub(dcontext, f, l, stub_pc);
     LOG(THREAD, LOG_LINKS, 4,
         "created new entrance stub @" PFX " for " PFX " w/ source F%d(" PFX ")." PFX "\n",
         stub_pc, EXIT_TARGET_TAG(dcontext, f, l), f->id, f->tag, FCACHE_ENTRY_PC(f));
@@ -3131,7 +3129,7 @@ coarse_remove_outgoing(dcontext_t *dcontext, cache_pc stub, coarse_info_t *src_i
         ASSERT(target_info != NULL);
         if (target_info != src_info) {
             coarse_incoming_t *e, *prev_e = NULL;
-            bool found = false;
+            DEBUG_DECLARE(bool found = false;)
             unlink_entrance_stub(dcontext, stub, 0, src_info);
             LOG(THREAD, LOG_LINKS, 4, "    removing coarse link " PFX " -> %s " PFX "\n",
                 stub, target_info->module, target_tag);
@@ -3145,7 +3143,7 @@ coarse_remove_outgoing(dcontext_t *dcontext, cache_pc stub, coarse_info_t *src_i
                     LOG(THREAD, LOG_LINKS, 4, "freeing coarse_incoming_t " PFX "\n", e);
                     NONPERSISTENT_HEAP_TYPE_FREE(GLOBAL_DCONTEXT, e, coarse_incoming_t,
                                                  ACCT_COARSE_LINK);
-                    found = true;
+                    DODEBUG(found = true;)
                     break;
                 } else
                     prev_e = e;
@@ -3682,7 +3680,7 @@ coarse_update_outgoing(dcontext_t *dcontext, cache_pc old_stub, cache_pc new_stu
         ASSERT(target_info != NULL);
         if (target_info != src_info) {
             coarse_incoming_t *e;
-            bool found = false;
+            DEBUG_DECLARE(bool found = false;)
             LOG(THREAD, LOG_LINKS, 4,
                 "    %s coarse link [" PFX "=>" PFX "] -> %s " PFX "\n",
                 replace ? "updating" : "adding", old_stub, new_stub, target_info->module,
@@ -3692,7 +3690,7 @@ coarse_update_outgoing(dcontext_t *dcontext, cache_pc old_stub, cache_pc new_stu
                 for (e = target_info->incoming; e != NULL; e = e->next) {
                     if (e->coarse && e->in.stub_pc == old_stub) {
                         e->in.stub_pc = new_stub;
-                        found = true;
+                        DODEBUG(found = true;)
                         break;
                     }
                 }

--- a/core/module_list.c
+++ b/core/module_list.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -643,7 +643,6 @@ ensure_section_readable(app_pc module_base, app_pc seg_start, size_t seg_len,
                         uint seg_chars, OUT uint *old_prot, app_pc view_start,
                         size_t view_len)
 {
-    int ok;
     app_pc intersection_start;
     size_t intersection_len;
 
@@ -681,7 +680,8 @@ ensure_section_readable(app_pc module_base, app_pc seg_start, size_t seg_len,
                                                     * if writable */
 #else
     /* No other flags to preserve, should be no-access, so we ignore old_prot */
-    ok = os_set_protection(intersection_start, intersection_len, MEMPROT_READ);
+    DEBUG_DECLARE(int ok =)
+    os_set_protection(intersection_start, intersection_len, MEMPROT_READ);
     ASSERT(ok);
 #endif
     return false;

--- a/core/module_list.c
+++ b/core/module_list.c
@@ -672,15 +672,15 @@ ensure_section_readable(app_pc module_base, app_pc seg_start, size_t seg_len,
     SYSLOG_INTERNAL_WARNING("unreadable section @" PFX "\n", seg_start);
 #ifdef WINDOWS
     /* Preserve COW flags */
-    ok = protect_virtual_memory(intersection_start, intersection_len, PAGE_READONLY,
-                                old_prot);
+    DEBUG_DECLARE(bool ok =)
+    protect_virtual_memory(intersection_start, intersection_len, PAGE_READONLY, old_prot);
     ASSERT(ok);
     ASSERT_CURIOSITY(*old_prot == PAGE_NOACCESS ||
                      *old_prot == PAGE_WRITECOPY); /* expecting unmodifed even
                                                     * if writable */
 #else
     /* No other flags to preserve, should be no-access, so we ignore old_prot */
-    DEBUG_DECLARE(int ok =)
+    DEBUG_DECLARE(bool ok =)
     os_set_protection(intersection_start, intersection_len, MEMPROT_READ);
     ASSERT(ok);
 #endif

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -646,8 +646,7 @@ mark_trace_head(dcontext_t *dcontext_in, fragment_t *f, fragment_t *src_f,
     ASSERT(!NEED_SHARED_LOCK(f->flags) || self_owns_recursive_lock(&change_linking_lock));
 
     if (thcounter_lookup(dcontext, f->tag) == NULL) {
-    protected
-        = local_heap_protected(dcontext);
+        protected = local_heap_protected(dcontext);
         if (protected) {
             /* unprotect local heap */
             protect_local_heap(dcontext, WRITABLE);
@@ -1147,7 +1146,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
     fragment_t wrapper;
     uint i;
     /* was the trace passed through optimizations or the client interface? */
-    bool externally_mangled = false;
+    DEBUG_DECLARE(bool externally_mangled = false;)
     /* we cannot simply upgrade a basic block fragment
      * to a trace b/c traces have prefixes that basic blocks don't!
      */
@@ -1176,7 +1175,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
          */
         dr_emit_flags_t emitflags =
             instrument_trace(dcontext, tag, &md->unmangled_ilist, false /*!recreating*/);
-        externally_mangled = true;
+        DODEBUG(externally_mangled = true;)
         if (TEST(DR_EMIT_STORE_TRANSLATIONS, emitflags)) {
             /* PR 214962: let client request storage instead of recreation */
             md->trace_flags |= FRAG_HAS_TRANSLATION_INFO;
@@ -1290,7 +1289,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
 #    endif
     ) {
         optimize_trace(dcontext, tag, trace);
-        externally_mangled = true;
+        DODEBUG(externally_mangled = true;)
     }
 #endif /* INTERNAL */
 

--- a/core/monitor.c
+++ b/core/monitor.c
@@ -1175,7 +1175,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
          */
         dr_emit_flags_t emitflags =
             instrument_trace(dcontext, tag, &md->unmangled_ilist, false /*!recreating*/);
-        DODEBUG(externally_mangled = true;)
+        DODEBUG(externally_mangled = true;);
         if (TEST(DR_EMIT_STORE_TRANSLATIONS, emitflags)) {
             /* PR 214962: let client request storage instead of recreation */
             md->trace_flags |= FRAG_HAS_TRANSLATION_INFO;
@@ -1289,7 +1289,7 @@ end_and_emit_trace(dcontext_t *dcontext, fragment_t *cur_f)
 #    endif
     ) {
         optimize_trace(dcontext, tag, trace);
-        DODEBUG(externally_mangled = true;)
+        DODEBUG(externally_mangled = true;);
     }
 #endif /* INTERNAL */
 

--- a/core/options.c
+++ b/core/options.c
@@ -1127,13 +1127,14 @@ options_enable_code_api_dependences(options_t *options)
      * logic in heap_mmap_reserve_post_stack() to handle sharing the
      * tail end of a multi-64K-region stack.
      */
-    options->stack_size = MAX(options->stack_size, 56 * 1024);
+    options->stack_size = MAX(options->stack_size, ALIGN_FORWARD(56 * 1024, PAGE_SIZE));
 #ifdef UNIX
     /* We assume that clients avoid private library code, within reason, and
      * don't need as much space when handling signals.  We still raise the
      * limit a little while saving some per-thread space.
      */
-    options->signal_stack_size = MAX(options->signal_stack_size, 32 * 1024);
+    options->signal_stack_size =
+        MAX(options->signal_stack_size, ALIGN_FORWARD(32 * 1024, PAGE_SIZE));
 #endif
 
     /* For CI builds we'll disable elision by default since we
@@ -2512,7 +2513,6 @@ int
 synchronize_dynamic_options()
 {
     int updated, retval;
-    bool compatibility_fixup = false;
 
     if (!dynamo_options.dynamic_options)
         return 0;
@@ -2560,7 +2560,10 @@ synchronize_dynamic_options()
     set_dynamo_options_defaults(&temp_options);
     set_dynamo_options(&temp_options, new_option_string);
     updated = update_dynamic_options(&dynamo_options, &temp_options);
-    compatibility_fixup = check_dynamic_option_compatibility();
+#    if defined(EXPOSE_INTERNAL_OPTIONS) && defined(INTERNAL)
+    bool compatibility_fixup =
+#    endif
+        check_dynamic_option_compatibility();
     /* d_r_option_string holds a copy of the last read registry value */
     strncpy(d_r_option_string, new_option_string,
             BUFFER_SIZE_ELEMENTS(d_r_option_string));

--- a/core/options.c
+++ b/core/options.c
@@ -1115,19 +1115,21 @@ options_enable_code_api_dependences(options_t *options)
     if (!options->code_api)
         return;
 
-    /* PR 202669: larger stack size since we're saving a 512-byte
-     * buffer on the stack when saving fp state.
-     * Also, C++ RTL initialization (even when a C++
-     * client does little else) can take a lot of stack space.
-     * Furthermore, dbghelp.dll usage via drsyms has been observed
-     * to require 36KB, which is already beyond the minimum to
-     * share gencode in the same 64K alloc as the stack.
-     *
-     * XXX: if we raise this beyond 56KB we should adjust the
-     * logic in heap_mmap_reserve_post_stack() to handle sharing the
-     * tail end of a multi-64K-region stack.
-     */
+        /* PR 202669: larger stack size since we're saving a 512-byte
+         * buffer on the stack when saving fp state.
+         * Also, C++ RTL initialization (even when a C++
+         * client does little else) can take a lot of stack space.
+         * Furthermore, dbghelp.dll usage via drsyms has been observed
+         * to require 36KB, which is already beyond the minimum to
+         * share gencode in the same 64K alloc as the stack.
+         *
+         * XXX: if we raise this beyond 56KB we should adjust the
+         * logic in heap_mmap_reserve_post_stack() to handle sharing the
+         * tail end of a multi-64K-region stack.
+         */
+#ifndef NOT_DYNAMORIO_CORE /* XXX: clumsy fix for Windows */
     options->stack_size = MAX(options->stack_size, ALIGN_FORWARD(56 * 1024, PAGE_SIZE));
+#endif
 #ifdef UNIX
     /* We assume that clients avoid private library code, within reason, and
      * don't need as much space when handling signals.  We still raise the

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -833,7 +833,7 @@ OPTION_DEFAULT(uint_size, stack_size,
                 * 32KB is the max that will still allow sharing per-thread
                 * gencode in the same 64KB alloc as the stack on Windows.
                 */
-               /* XXX i#5383: Evaluate why Mac M1 needs 32K. */
+               /* Mac M1's page size is 16K. */
                IF_MACOSA64_ELSE(32 * 1024, 24 * 1024),
                "size of thread-private stacks, in KB")
 #ifdef UNIX

--- a/core/perscache.c
+++ b/core/perscache.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2006-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -4111,7 +4111,7 @@ coarse_unit_load(dcontext_t *dcontext, app_pc start, app_pc end, bool for_execut
          */
         if (DYNAMO_OPTION(persist_touch_stubs)) {
             app_pc touch_pc = rwx_pc;
-            volatile byte touch_value;
+            volatile byte touch_value UNUSED;
             for (; touch_pc < (app_pc)(map + pers->header_len + pers->data_len);
                  touch_pc += PAGE_SIZE) {
                 touch_value = *touch_pc;

--- a/core/stats.h
+++ b/core/stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2004-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -143,18 +143,18 @@ extern timestamp_t kstat_ignore_context_switch;
 
 /* ensures statement can safely use ks=stack_kstats and pv=&vars_kstats.name,
  */
-#    define KSTAT_THREAD(name, statement)                                      \
-        KSTAT_THREAD_NO_PV_START(get_thread_private_dcontext())                \
-        kstat_variable_t *pv = &cur_dcontext->thread_kstats->vars_kstats.name; \
-        UNUSED_VARIABLE(pv);                                                   \
-        statement;                                                             \
+#    define KSTAT_THREAD(name, statement)                                             \
+        KSTAT_THREAD_NO_PV_START(get_thread_private_dcontext())                       \
+        kstat_variable_t *pv UNUSED = &cur_dcontext->thread_kstats->vars_kstats.name; \
+        UNUSED_VARIABLE(pv);                                                          \
+        statement;                                                                    \
         KSTAT_THREAD_NO_PV_END()
 
-#    define KSTAT_OTHER_THREAD(dc, name, statement)                            \
-        KSTAT_THREAD_NO_PV_START(dc)                                           \
-        kstat_variable_t *pv = &cur_dcontext->thread_kstats->vars_kstats.name; \
-        UNUSED_VARIABLE(pv);                                                   \
-        statement;                                                             \
+#    define KSTAT_OTHER_THREAD(dc, name, statement)                                   \
+        KSTAT_THREAD_NO_PV_START(dc)                                                  \
+        kstat_variable_t *pv UNUSED = &cur_dcontext->thread_kstats->vars_kstats.name; \
+        UNUSED_VARIABLE(pv);                                                          \
+        statement;                                                                    \
         KSTAT_THREAD_NO_PV_END()
 
 /* makes sure we're matching start/stop */

--- a/core/synch.c
+++ b/core/synch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -673,14 +673,13 @@ void
 check_wait_at_safe_spot(dcontext_t *dcontext, thread_synch_permission_t cur_state)
 {
     thread_synch_data_t *tsd = (thread_synch_data_t *)dcontext->synch_field;
-    app_pc pc;
     byte cxt[MAX(CONTEXT_HEAP_SIZE_OPAQUE, sizeof(priv_mcontext_t))];
     bool set_context = false;
     bool set_mcontext = false;
     if (tsd->pending_synch_count == 0 || cur_state == THREAD_SYNCH_NONE)
         return;
     ASSERT(tsd->pending_synch_count >= 0);
-    pc = get_mcontext(dcontext)->pc;
+    DEBUG_DECLARE(app_pc pc = get_mcontext(dcontext)->pc;)
     LOG(THREAD, LOG_SYNCH, 2, "waiting for synch with state %d (pc " PFX ")\n", cur_state,
         pc);
     if (cur_state == THREAD_SYNCH_VALID_MCONTEXT) {
@@ -1576,7 +1575,6 @@ resume_all_threads(thread_record_t **threads, const uint num_threads)
 {
     uint i;
     thread_id_t my_tid;
-    bool res;
 
     ASSERT_OWN_MUTEX(true, &all_threads_synch_lock);
     ASSERT_OWN_MUTEX(true, &thread_initexit_lock);
@@ -1598,7 +1596,7 @@ resume_all_threads(thread_record_t **threads, const uint num_threads)
         /* This routine assumes that each thread in the array was suspended, so
          * each one has to successfully resume.
          */
-        res = os_thread_resume(threads[i]);
+        DEBUG_DECLARE(bool res =) os_thread_resume(threads[i]);
         ASSERT(res);
     }
 }
@@ -1639,7 +1637,6 @@ end_synch_with_all_threads(thread_record_t **threads, uint num_threads, bool res
 void
 translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t synch_state)
 {
-    bool res;
     /* we do not have to align priv_mcontext_t */
     priv_mcontext_t *mc = global_heap_alloc(sizeof(*mc) HEAPACCT(ACCT_OTHER));
     bool free_cxt = true;
@@ -1649,7 +1646,7 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
     /* FIXME: would like to assert that suspendcount is > 0 but how? */
     ASSERT(thread_synch_successful(tr));
 
-    res = thread_get_mcontext(tr, mc);
+    DEBUG_DECLARE(bool res =) thread_get_mcontext(tr, mc);
     ASSERT(res);
     pre_translation = (app_pc)mc->pc;
     LOG(GLOBAL, LOG_CACHE, 2, "\trecreating address for " PFX "\n", mc->pc);
@@ -1687,9 +1684,9 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
             else if (pre_translation + SYSENTER_LENGTH == vsyscall_sysenter_return_pc)
                 mc->pc = get_do_int_syscall_entry(dcontext);
             /* exit stub and subsequent fcache_return will save rest of state */
-            res = set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
-                                             synch_state _IF_X64((void *)mc)
-                                                 _IF_WINDOWS(NULL));
+            DODEBUG(res =)
+            set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
+                                       synch_state _IF_X64((void *)mc) _IF_WINDOWS(NULL));
             ASSERT(res);
             /* cxt is freed by set_synched_thread_context() or target thread */
             free_cxt = false;
@@ -1699,16 +1696,17 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
             if (INTERNAL_OPTION(steal_reg_at_reset) != 0) {
                 /* We don't want to translate, just update the stolen reg values */
                 arch_mcontext_reset_stolen_reg(dcontext, mc);
-                res = set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
-                                                 synch_state _IF_X64((void *)mc)
-                                                     _IF_WINDOWS(NULL));
+                DODEBUG(res =)
+                set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
+                                           synch_state _IF_X64((void *)mc)
+                                               _IF_WINDOWS(NULL));
                 ASSERT(res);
                 /* cxt is freed by set_synched_thread_context() or target thread */
                 free_cxt = false;
             }
         });
     } else {
-        res = translate_mcontext(tr, mc, true /*restore memory*/, NULL);
+        DODEBUG(res =) translate_mcontext(tr, mc, true /*restore memory*/, NULL);
         ASSERT(res);
         if (!thread_synch_successful(tr) || mc->pc == 0) {
             /* Better to risk failure on accessing a freed cache than
@@ -1816,9 +1814,9 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
         swap_peb_pointer(dcontext, false /*to app*/);
 #endif
         /* exit stub and subsequent fcache_return will save rest of state */
-        res =
-            set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
-                                       synch_state _IF_X64((void *)mc) _IF_WINDOWS(NULL));
+        DODEBUG(res =)
+        set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
+                                   synch_state _IF_X64((void *)mc) _IF_WINDOWS(NULL));
         ASSERT(res);
         /* cxt is freed by set_synched_thread_context() or target thread */
         free_cxt = false;

--- a/core/synch.c
+++ b/core/synch.c
@@ -1684,7 +1684,7 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
             else if (pre_translation + SYSENTER_LENGTH == vsyscall_sysenter_return_pc)
                 mc->pc = get_do_int_syscall_entry(dcontext);
             /* exit stub and subsequent fcache_return will save rest of state */
-            DODEBUG(res =)
+            DEBUG_DECLARE(res =)
             set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
                                        synch_state _IF_X64((void *)mc) _IF_WINDOWS(NULL));
             ASSERT(res);

--- a/core/synch.c
+++ b/core/synch.c
@@ -1696,7 +1696,7 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
             if (INTERNAL_OPTION(steal_reg_at_reset) != 0) {
                 /* We don't want to translate, just update the stolen reg values */
                 arch_mcontext_reset_stolen_reg(dcontext, mc);
-                DODEBUG(res =)
+                DEBUG_DECLARE(res =)
                 set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
                                            synch_state _IF_X64((void *)mc)
                                                _IF_WINDOWS(NULL));
@@ -1706,7 +1706,7 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
             }
         });
     } else {
-        DODEBUG(res =) translate_mcontext(tr, mc, true /*restore memory*/, NULL);
+        DEBUG_DECLARE(res =) translate_mcontext(tr, mc, true /*restore memory*/, NULL);
         ASSERT(res);
         if (!thread_synch_successful(tr) || mc->pc == 0) {
             /* Better to risk failure on accessing a freed cache than
@@ -1814,7 +1814,7 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
         swap_peb_pointer(dcontext, false /*to app*/);
 #endif
         /* exit stub and subsequent fcache_return will save rest of state */
-        DODEBUG(res =)
+        DEBUG_DECLARE(res =)
         set_synched_thread_context(dcontext->thread_record, mc, NULL, 0,
                                    synch_state _IF_X64((void *)mc) _IF_WINDOWS(NULL));
         ASSERT(res);

--- a/core/translate.c
+++ b/core/translate.c
@@ -1504,7 +1504,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
                 (byte *)f->start_pc + f->size, mcontext, just_pc, f->flags);
             STATS_INC(recreate_via_app_ilist);
         }
-        DODEBUG(ok =) dr_set_isa_mode(tdcontext, old_mode, NULL);
+        DEBUG_DECLARE(ok =) dr_set_isa_mode(tdcontext, old_mode, NULL);
         ASSERT(ok);
 
         if (!just_pc)

--- a/core/translate.c
+++ b/core/translate.c
@@ -1371,7 +1371,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
         cache_pc cti_pc;
         instrlist_t *ilist = NULL;
         fragment_t *f = owning_f;
-        bool alloc = false, ok;
+        bool alloc = false;
         dr_isa_mode_t old_mode;
 #ifdef WINDOWS
         bool swap_peb = false;
@@ -1481,7 +1481,8 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
         }
 
         /* Recreate in same mode as original fragment */
-        ok = dr_set_isa_mode(tdcontext, FRAG_ISA_MODE(f->flags), &old_mode);
+        DEBUG_DECLARE(bool ok =)
+        dr_set_isa_mode(tdcontext, FRAG_ISA_MODE(f->flags), &old_mode);
         ASSERT(ok);
 
         /* now recreate the state */
@@ -1503,7 +1504,7 @@ recreate_app_state_internal(dcontext_t *tdcontext, priv_mcontext_t *mcontext,
                 (byte *)f->start_pc + f->size, mcontext, just_pc, f->flags);
             STATS_INC(recreate_via_app_ilist);
         }
-        ok = dr_set_isa_mode(tdcontext, old_mode, NULL);
+        DODEBUG(ok =) dr_set_isa_mode(tdcontext, old_mode, NULL);
         ASSERT(ok);
 
         if (!just_pc)
@@ -1916,11 +1917,11 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
     priv_mcontext_t mc;
     bool res;
     cache_pc cpc;
-    instr_t *in, *prev_in = NULL;
+    instr_t *in;
     static const reg_t STRESS_XSP_INIT = 0x08000000; /* arbitrary */
     bool success_so_far = true;
     bool inside_mangle_region = false;
-    bool inside_mangle_epilogue = false;
+    IF_X86(bool inside_mangle_epilogue = false;)
     uint spill_ibreg_outstanding_offs = UINT_MAX;
     reg_id_t reg;
     bool spill;
@@ -1956,13 +1957,12 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
             /* reset */
             LOG(THREAD, LOG_INTERP, 3, "  out of mangling region\n");
             inside_mangle_region = false;
-            inside_mangle_epilogue = false;
+            IF_X86(inside_mangle_epilogue = false;)
             xsp_adjust = 0;
             success_so_far = true;
             spill_ibreg_outstanding_offs = UINT_MAX;
             /* go ahead and fall through and ensure we succeed w/ 0 xsp adjust */
         }
-        prev_in = in;
 
         if (instr_is_our_mangling(in)) {
             if (!inside_mangle_region) {
@@ -1973,7 +1973,7 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
                                        instr_is_our_mangling_epilogue(in),
                                    false)) {
                 LOG(THREAD, LOG_INTERP, 3, "  entering mangling epilogue\n");
-                inside_mangle_epilogue = true;
+                IF_X86(inside_mangle_epilogue = true;)
             } else {
                 ASSERT(!TEST(FRAG_IS_TRACE, f->flags) ||
                        IF_X86(instr_is_our_mangling_epilogue(in) ||)

--- a/core/unix/native_elf.c
+++ b/core/unix/native_elf.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -716,7 +716,7 @@ static app_pc
 special_ret_stub_create(dcontext_t *dcontext, app_pc tgt)
 {
     instrlist_t ilist;
-    app_pc stub_pc, pc;
+    app_pc stub_pc;
 
     /* alloc and encode special ret stub */
     stub_pc = special_heap_alloc(ret_stub_heap);
@@ -735,7 +735,7 @@ special_ret_stub_create(dcontext_t *dcontext, app_pc tgt)
     APP(&ilist,
         XINST_CREATE_jump(dcontext,
                           opnd_create_pc(get_native_ret_ibl_xfer_entry(dcontext))));
-    pc = instrlist_encode(dcontext, &ilist, stub_pc, false);
+    instrlist_encode(dcontext, &ilist, stub_pc, false);
     instrlist_clear(dcontext, &ilist);
 
     return (app_pc)native_module_htable_add(native_ret_table, ret_stub_heap,

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3569,7 +3569,6 @@ os_heap_commit(void *p, size_t size, uint prot, heap_error_code_t *error_code)
 void
 os_heap_decommit(void *p, size_t size, heap_error_code_t *error_code)
 {
-    int rc;
     ASSERT(error_code != NULL);
 
     if (!dynamo_exited)
@@ -3577,14 +3576,12 @@ os_heap_decommit(void *p, size_t size, heap_error_code_t *error_code)
 
     *error_code = HEAP_ERROR_SUCCESS;
     /* FIXME: for now do nothing since os_heap_reserve has in fact committed the memory */
-    rc = 0;
     /* TODO:
            p = mmap_syscall(p, size, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
        we should either do a mremap()
        or we can do a munmap() followed 'quickly' by a mmap() -
        also see above the comment that os_heap_reserve() in fact is not so lightweight
     */
-    ASSERT(rc == 0);
 }
 
 bool
@@ -4702,7 +4699,7 @@ void
 os_syslog(syslog_event_type_t priority, uint message_id, uint substitutions_num,
           va_list args)
 {
-    int native_priority;
+    int native_priority UNUSED;
     switch (priority) {
     case SYSLOG_INFORMATION: native_priority = LOG_INFO; break;
     case SYSLOG_WARNING: native_priority = LOG_WARNING; break;
@@ -4959,7 +4956,6 @@ make_copy_on_writable(byte *pc, size_t size)
 void
 make_unwritable(byte *pc, size_t size)
 {
-    long res;
     app_pc start_page = (app_pc)PAGE_START(pc);
     size_t prot_size = (size == 0) ? PAGE_SIZE : size;
     uint prot = PROT_EXEC | PROT_READ;
@@ -4981,7 +4977,7 @@ make_unwritable(byte *pc, size_t size)
     /* inc stats before making unwritable, in case messing w/ data segment */
     STATS_INC(protection_change_calls);
     STATS_ADD(protection_change_pages, size / PAGE_SIZE);
-    res = mprotect_syscall((void *)start_page, prot_size, prot);
+    DEBUG_DECLARE(long res =) mprotect_syscall((void *)start_page, prot_size, prot);
     LOG(THREAD_GET, LOG_VMAREAS, 3, "make_unwritable: pc " PFX " -> " PFX "-" PFX "\n",
         pc, start_page, start_page + prot_size);
     ASSERT(res == 0);
@@ -6039,7 +6035,7 @@ handle_execve(dcontext_t *dcontext)
      */
     char *fname;
     bool x64 = IF_X64_ELSE(true, false);
-    bool expect_to_fail = false;
+    bool expect_to_fail UNUSED = false;
     bool should_inject;
     file_t file;
     char *inject_library_path;
@@ -7229,7 +7225,7 @@ pre_system_call(dcontext_t *dcontext)
         size_t len = (size_t)sys_param(dcontext, 1);
         uint prot = (uint)sys_param(dcontext, 2);
         uint old_memprot = MEMPROT_NONE, new_memprot;
-        bool exists = true;
+        bool exists UNUSED = true;
         /* save params in case an undo is needed in post_system_call */
         dcontext->sys_param0 = (reg_t)addr;
         dcontext->sys_param1 = len;
@@ -9384,7 +9380,6 @@ get_dynamo_library_bounds(void)
      * count it is so is_in_dynamo_dll() can be the only exception to the
      * never-execute-from-DR-areas list rule
      */
-    int res;
     app_pc check_start, check_end;
     bool do_memquery = true;
 #ifdef STATIC_LIBRARY
@@ -9436,10 +9431,11 @@ get_dynamo_library_bounds(void)
 #endif /* STATIC_LIBRARY */
 
     if (do_memquery) {
-        res = memquery_library_bounds(
-            NULL, &check_start, &check_end, dynamorio_library_path,
-            BUFFER_SIZE_ELEMENTS(dynamorio_library_path), dynamorio_libname_buf,
-            BUFFER_SIZE_ELEMENTS(dynamorio_libname_buf));
+        DEBUG_DECLARE(int res =)
+        memquery_library_bounds(NULL, &check_start, &check_end, dynamorio_library_path,
+                                BUFFER_SIZE_ELEMENTS(dynamorio_library_path),
+                                dynamorio_libname_buf,
+                                BUFFER_SIZE_ELEMENTS(dynamorio_libname_buf));
         ASSERT(res > 0);
 #ifndef STATIC_LIBRARY
         dynamorio_libname = IF_UNIT_TEST_ELSE(UNIT_TEST_EXE_NAME, dynamorio_libname_buf);
@@ -9846,7 +9842,7 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules)
             DODEBUG({ map_type = "ELF SO"; });
         } else if (TEST(MEMPROT_READ, iter->prot) &&
                    module_is_header(iter->vm_start, size)) {
-            size_t image_size = size;
+            DEBUG_DECLARE(size_t image_size = size;)
             app_pc mod_base, mod_first_end, mod_max_end;
             char *exec_match;
             bool found_exec = false;
@@ -9869,7 +9865,7 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules)
                                             true, /* i#1589: ld.so relocated .dynamic */
                                             &mod_base, &mod_first_end, &mod_max_end, NULL,
                                             NULL)) {
-                image_size = mod_max_end - mod_base;
+                DODEBUG(image_size = mod_max_end - mod_base;)
             } else {
                 ASSERT_NOT_REACHED();
             }

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -9865,7 +9865,7 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules)
                                             true, /* i#1589: ld.so relocated .dynamic */
                                             &mod_base, &mod_first_end, &mod_max_end, NULL,
                                             NULL)) {
-                DODEBUG(image_size = mod_max_end - mod_base;)
+                DODEBUG(image_size = mod_max_end - mod_base;);
             } else {
                 ASSERT_NOT_REACHED();
             }

--- a/core/unix/pcprofile.c
+++ b/core/unix/pcprofile.c
@@ -159,7 +159,6 @@ pcprofile_thread_init(dcontext_t *dcontext, bool shared_itimer, void *parent_inf
 void
 pcprofile_thread_exit(dcontext_t *dcontext)
 {
-    int size;
     thread_pc_info_t *info = (thread_pc_info_t *)dcontext->pcprofile_field;
     /* don't want any alarms while holding lock for printing results
      * (see notes under pcprofile_cache_flush below)
@@ -167,7 +166,7 @@ pcprofile_thread_exit(dcontext_t *dcontext)
     set_itimer_callback(dcontext, ITIMER_VIRTUAL, 0, NULL, NULL);
 
     pcprofile_results(info);
-    size = HASHTABLE_SIZE(HASH_BITS) * sizeof(pc_profile_entry_t *);
+    DEBUG_DECLARE(int size = HASHTABLE_SIZE(HASH_BITS) * sizeof(pc_profile_entry_t *);)
     pcprofile_reset(info); /* special heap so no fast path */
 #ifdef DEBUG
     /* for non-debug we do fast exit path and don't free local heap */

--- a/core/unix/preload.c
+++ b/core/unix/preload.c
@@ -146,7 +146,6 @@ _init(int argc, char *arg0, ...)
 _init(int argc, char **argv, char **envp)
 {
 #endif
-    int init;
     const char *name;
 #if VERBOSE_INIT_FINI
     fprintf(stderr, "preload initialized\n");
@@ -177,7 +176,10 @@ _init(int argc, char **argv, char **envp)
     /* FIXME i#287/PR 546544: now load DYNAMORIO_AUTOINJECT DR .so
      * and only LD_PRELOAD the preload lib itself
      */
-    init = dynamorio_app_init();
+#    if VERBOSE
+    int init =
+#    endif
+        dynamorio_app_init();
     pf("dynamorio_app_init() returned %d\n", init);
     dynamorio_app_take_over();
     pf("dynamo started\n");

--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -321,7 +321,6 @@ rseq_analyze_instructions(rseq_region_t *info)
     instr_init(GLOBAL_DCONTEXT, &instr);
     app_pc pc = info->start;
     int i;
-    bool reached_cti = false;
     memset(info->reg_written, 0, sizeof(info->reg_written));
     while (pc < info->end) {
         instr_reset(GLOBAL_DCONTEXT, &instr);
@@ -348,8 +347,6 @@ rseq_analyze_instructions(rseq_region_t *info)
                                         "Rseq sequence contains a call");
             ASSERT_NOT_REACHED();
         }
-        if (instr_is_cti(&instr))
-            reached_cti = true;
         /* We potentially need to preserve any register written anywhere inside
          * the sequence.  We can't limit ourselves to registers clearly live on
          * input, since code *after* the sequence could read them.  We do disallow

--- a/core/unix/stackdump.c
+++ b/core/unix/stackdump.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -223,7 +223,6 @@ d_r_stackdump(void)
         int fd;
         const char *argv[16];
         int i;
-        int execve_errno;
 
         /* Open a temporary file for the input: the "where" command */
         fp = os_open(tmp_name, OS_OPEN_REQUIRE_NEW | OS_OPEN_WRITE);
@@ -280,7 +279,8 @@ d_r_stackdump(void)
         argv[i++] = exec_name;
         argv[i++] = core_name;
         argv[i++] = NULL;
-        execve_errno = execve_syscall("/usr/bin/env", argv, our_environ);
+        DEBUG_DECLARE(int execve_errno =)
+        execve_syscall("/usr/bin/env", argv, our_environ);
         SYSLOG_INTERNAL_ERROR("ERROR: execve failed for debugger: %d", -execve_errno);
         exit_process_syscall(1);
     } else if (pid == -1) {

--- a/core/unix/tls_macos.c
+++ b/core/unix/tls_macos.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2013-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -272,11 +272,10 @@ tls_thread_free(tls_type_t tls_type, int index)
 {
 #ifdef X64
     byte **tls_swap_slot;
-    os_local_state_t *os_tls;
     ASSERT(tls_type == TLS_TYPE_SLOT);
     tls_swap_slot = get_app_tls_swap_slot_addr();
     ASSERT(tls_swap_slot != NULL);
-    os_tls = (os_local_state_t *)*tls_swap_slot;
+    DEBUG_DECLARE(os_local_state_t *os_tls = (os_local_state_t *)*tls_swap_slot;)
     ASSERT(os_tls->self == os_tls);
     *tls_swap_slot = TLS_SLOT_VAL_EXITED;
 #else

--- a/core/utils.c
+++ b/core/utils.c
@@ -1864,12 +1864,9 @@ d_r_notify(syslog_event_type_t priority, bool internal, bool synch,
            const char *fmt, ...)
 {
     char msgbuf[MAX_LOG_LENGTH];
-    int size;
     va_list ap;
     va_start(ap, fmt);
-    /* FIXME : the vsnprintf call is not needed in the most common case where
-     * we are going to just os_syslog, but it gets pretty ugly to do that */
-    size = vsnprintf(msgbuf, sizeof(msgbuf), fmt, ap);
+    vsnprintf(msgbuf, sizeof(msgbuf), fmt, ap);
     NULL_TERMINATE_BUFFER(msgbuf); /* always NULL terminate */
     /* not a good idea to assert here since we'll just die and lose original message,
      * so we don't check size return value and just go ahead and truncate
@@ -2656,7 +2653,7 @@ create_log_dir(int dir_type)
 {
 #ifdef UNIX
     char *pre_execve = getenv(DYNAMORIO_VAR_EXECVE_LOGDIR);
-    bool sharing_logdir = false;
+    DEBUG_DECLARE(bool sharing_logdir = false;)
 #endif
     /* synchronize */
     acquire_recursive_lock(&logdir_mutex);
@@ -2670,7 +2667,7 @@ create_log_dir(int dir_type)
         if (IS_STRING_OPTION_EMPTY(logdir) &&
             (get_config_val_ex(DYNAMORIO_VAR_LOGDIR, NULL, &is_env) == NULL || is_env)) {
             /* use same dir as pre-execve! */
-            sharing_logdir = true;
+            DODEBUG(sharing_logdir = true;)
             strncpy(logdir, pre_execve, BUFFER_SIZE_ELEMENTS(logdir));
             NULL_TERMINATE_BUFFER(logdir); /* if max no null */
             logdir_initialized = true;

--- a/core/utils.c
+++ b/core/utils.c
@@ -1866,6 +1866,9 @@ d_r_notify(syslog_event_type_t priority, bool internal, bool synch,
     char msgbuf[MAX_LOG_LENGTH];
     va_list ap;
     va_start(ap, fmt);
+    /* XXX: the vsnprintf call is not needed in the most common case where
+     * we are going to just os_syslog, but it gets pretty ugly to do that
+     */
     vsnprintf(msgbuf, sizeof(msgbuf), fmt, ap);
     NULL_TERMINATE_BUFFER(msgbuf); /* always NULL terminate */
     /* not a good idea to assert here since we'll just die and lose original message,

--- a/core/utils.c
+++ b/core/utils.c
@@ -2667,7 +2667,7 @@ create_log_dir(int dir_type)
         if (IS_STRING_OPTION_EMPTY(logdir) &&
             (get_config_val_ex(DYNAMORIO_VAR_LOGDIR, NULL, &is_env) == NULL || is_env)) {
             /* use same dir as pre-execve! */
-            DODEBUG(sharing_logdir = true;)
+            DODEBUG(sharing_logdir = true;);
             strncpy(logdir, pre_execve, BUFFER_SIZE_ELEMENTS(logdir));
             NULL_TERMINATE_BUFFER(logdir); /* if max no null */
             logdir_initialized = true;

--- a/core/utils.h
+++ b/core/utils.h
@@ -1567,15 +1567,21 @@ enum { LONGJMP_EXCEPTION = 1 };
 
 #include "stats.h"
 
+#ifdef UNIX
+#    define UNUSED __attribute__((unused))
+#else
+#    define UNUSED
+#endif
+
 /* Use to shut up the compiler about an unused variable when the
  * alternative is a painful modification of more src code. Our
  * standard is to use this macro just after the variable is declared
  * and to use it judiciously.
  */
-#define UNUSED_VARIABLE(pv)           \
-    {                                 \
-        void *unused_pv = (void *)pv; \
-        unused_pv = NULL;             \
+#define UNUSED_VARIABLE(pv)                  \
+    {                                        \
+        void *unused_pv UNUSED = (void *)pv; \
+        unused_pv = NULL;                    \
     }
 
 /* Both release and debug builds share these common stats macros */
@@ -1935,11 +1941,11 @@ enum { LONGJMP_EXCEPTION = 1 };
  * exception flags and messing up our code (i#1213).
  */
 
-#define PRESERVE_FLOATING_POINT_STATE_START()                   \
-    {                                                           \
-        byte fpstate_buf[MAX_FP_STATE_SIZE];                    \
-        byte *fpstate = (byte *)ALIGN_FORWARD(fpstate_buf, 16); \
-        size_t fpstate_junk = proc_save_fpstate(fpstate);       \
+#define PRESERVE_FLOATING_POINT_STATE_START()                    \
+    {                                                            \
+        byte fpstate_buf[MAX_FP_STATE_SIZE];                     \
+        byte *fpstate = (byte *)ALIGN_FORWARD(fpstate_buf, 16);  \
+        size_t fpstate_junk UNUSED = proc_save_fpstate(fpstate); \
         dr_fpu_exception_init()
 
 #define PRESERVE_FLOATING_POINT_STATE_END() \

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -3047,7 +3047,6 @@ get_coarse_info_internal(app_pc addr, bool init, bool have_shvm_lock)
     vm_area_t area_copy = {
         0,
     };
-    bool is_coarse = false;
     bool add_to_shared = false;
     bool reset_unit = false;
     /* FIXME perf opt: have a last_area */
@@ -3057,7 +3056,7 @@ get_coarse_info_internal(app_pc addr, bool init, bool have_shvm_lock)
         ASSERT(area != NULL);
         /* The custom field is initialized to 0 in add_vm_area */
         coarse = (coarse_info_t *)area->custom.client;
-        is_coarse = TEST(FRAG_COARSE_GRAIN, area->frag_flags);
+        DEBUG_DECLARE(bool is_coarse = TEST(FRAG_COARSE_GRAIN, area->frag_flags);)
         /* We always create coarse_info_t up front in add_executable_vm_area */
         ASSERT((is_coarse && coarse != NULL) || (!is_coarse && coarse == NULL));
         if (init && coarse != NULL && TEST(PERSCACHE_CODE_INVALID, coarse->flags)) {
@@ -3228,10 +3227,9 @@ app_pc
 is_executable_area_writable_overlap(app_pc start, app_pc end)
 {
     app_pc match_start = NULL;
-    bool writable;
     d_r_read_lock(&executable_areas->lock);
-    writable = executable_areas_match_flags(start, end, NULL, &match_start,
-                                            false /* EXISTS */, VM_MADE_READONLY, 0);
+    executable_areas_match_flags(start, end, NULL, &match_start, false /* EXISTS */,
+                                 VM_MADE_READONLY, 0);
     d_r_read_unlock(&executable_areas->lock);
     return match_start;
 }
@@ -7379,7 +7377,9 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     uint frag_flags = 0;
     uint vm_flags = 0;
     bool ok;
+#ifdef PROGRAM_SHEPHERDING
     bool shared_to_private = false;
+#endif
     /* used for new area */
     app_pc base_pc = 0;
     size_t size = 0; /* set only for unknown areas */
@@ -7433,8 +7433,10 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
     } else {
         DODEBUG({ new_area_prefix = "new vm area for thread: "; });
         data = (thread_data_t *)dcontext->vm_areas_field;
+#ifdef PROGRAM_SHEPHERDING
         if (DYNAMO_OPTION(shared_bbs) && TEST(FRAG_SHARED, *flags))
             shared_to_private = true;
+#endif
     }
 
     LOG(THREAD, LOG_INTERP | LOG_VMAREAS, 4, "check_thread_vm_area: pc = " PFX "\n", pc);
@@ -8428,7 +8430,6 @@ remove_shared_vmlist(dcontext_t *dcontext, void *vmlist, fragment_t *f,
     fragment_t *entry = (fragment_t *)vmlist;
     fragment_t *next;
     bool remove;
-    bool ok;
     uint check_flags = 0;
     app_pc pc;
     LOG(THREAD, LOG_VMAREAS, 4, "\tremoving shared vm data for F%d(" PFX ")\n", f->id,
@@ -8446,7 +8447,8 @@ remove_shared_vmlist(dcontext_t *dcontext, void *vmlist, fragment_t *f,
         remove = (local_vmlist != NULL && FRAG_PREV(entry) == entry &&
                   !TEST(FRAG_COARSE_GRAIN, f->flags));
         if (remove) {
-            ok = lookup_addr(&shared_data->areas, FRAG_PC(entry), &area);
+            DEBUG_DECLARE(bool ok =)
+            lookup_addr(&shared_data->areas, FRAG_PC(entry), &area);
             ASSERT(ok && area != NULL);
             if (TEST(FRAG_COARSE_GRAIN, area->frag_flags)) {
                 /* Case 9806: do NOT remove the coarse area even if this
@@ -8472,8 +8474,9 @@ remove_shared_vmlist(dcontext_t *dcontext, void *vmlist, fragment_t *f,
             /* add area to local and add local heap also entry */
             if (DYNAMO_OPTION(shared_bbs))
                 check_flags = f->flags | FRAG_SHARED; /*indicator to NOT use global*/
-            ok = check_thread_vm_area(dcontext, pc, f->tag, local_vmlist, &check_flags,
-                                      NULL, false /*xfer should not matter now*/);
+            DEBUG_DECLARE(bool ok =)
+            check_thread_vm_area(dcontext, pc, f->tag, local_vmlist, &check_flags, NULL,
+                                 false /*xfer should not matter now*/);
             ASSERT(ok);
         }
         entry = next;
@@ -9027,7 +9030,8 @@ vm_area_clean_fraglist(dcontext_t *dcontext, vm_area_t *area)
 void
 vm_area_remove_fragment(dcontext_t *dcontext, fragment_t *f)
 {
-    fragment_t *entry, *next, *match;
+    fragment_t *entry, *next;
+    DEBUG_DECLARE(fragment_t * match;)
     /* must grab lock across whole thing since alsos can be changed
      * by vm_area_clean_fraglist()
      */
@@ -9038,11 +9042,11 @@ vm_area_remove_fragment(dcontext_t *dcontext, fragment_t *f)
     if (!multi) {
         LOG(THREAD, LOG_VMAREAS, 4, "vm_area_remove_fragment: F%d tag=" PFX "\n", f->id,
             f->tag);
-        match = f;
+        DODEBUG(match = f;)
     } else {
         /* we do get called for multi-entries from vm_area_destroy_list */
         LOG(THREAD, LOG_VMAREAS, 4, "vm_area_remove_fragment: entry " PFX "\n", f);
-        match = FRAG_FRAG(f);
+        DODEBUG(match = FRAG_FRAG(f);)
     }
     ASSERT(FRAG_PREV(f) != NULL); /* prev wraps around, should never be null */
 
@@ -10532,9 +10536,9 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
     /* FIXME: for Linux, this is all happening inside signal handler...
      * flushing could take a while, and signals are blocked the entire time!
      */
-    app_pc base_pc, flush_start = NULL, next_pc;
+    app_pc base_pc, flush_start = NULL;
     app_pc instr_size_pc;
-    size_t size, flush_size = 0, instr_size;
+    size_t size, flush_size = 0;
     uint opnd_size = 0;
     uint prot;
     overlap_info_t info = { 0, /* init to 0 so info.overlap is false */ };
@@ -10633,10 +10637,11 @@ handle_modified_code(dcontext_t *dcontext, cache_pc instr_cache_pc, app_pc instr
      * (FIXME case 7393).
      */
     instr_size_pc = (instr_cache_pc == NULL) ? instr_app_pc : instr_cache_pc;
-    next_pc = decode_memory_reference_size(dcontext, instr_size_pc, &opnd_size);
+    DEBUG_DECLARE(app_pc next_pc =)
+    decode_memory_reference_size(dcontext, instr_size_pc, &opnd_size);
     ASSERT(next_pc != NULL);
     ASSERT(opnd_size != 0);
-    instr_size = next_pc - instr_size_pc;
+    DEBUG_DECLARE(size_t instr_size = next_pc - instr_size_pc;)
     /* FIXME case 7492: if write crosses page boundary, the reported faulting
      * target for win32 will be in the middle of the instr's target (win32
      * reports the first unwritable byte).  (On Linux we're fine as we calculate

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -9042,11 +9042,11 @@ vm_area_remove_fragment(dcontext_t *dcontext, fragment_t *f)
     if (!multi) {
         LOG(THREAD, LOG_VMAREAS, 4, "vm_area_remove_fragment: F%d tag=" PFX "\n", f->id,
             f->tag);
-        DODEBUG(match = f;)
+        DODEBUG(match = f;);
     } else {
         /* we do get called for multi-entries from vm_area_destroy_list */
         LOG(THREAD, LOG_VMAREAS, 4, "vm_area_remove_fragment: entry " PFX "\n", f);
-        DODEBUG(match = FRAG_FRAG(f);)
+        DODEBUG(match = FRAG_FRAG(f););
     }
     ASSERT(FRAG_PREV(f) != NULL); /* prev wraps around, should never be null */
 

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -107,7 +107,7 @@ typedef struct {
     bool enable_dup;              /* Denotes whether to duplicate blocks. */
     bool enable_dynamic_handling; /* Denotes whether to dynamically generate cases. */
 #if !defined(RISCV64)
-    bool are_flags_dead;      /* Denotes whether flags are dead at the start of a bb. */
+    bool are_flags_dead; /* Denotes whether flags are dead at the start of a bb. */
 #endif
     bool is_scratch_reg_dead; /* Denotes whether DRBBDUP_SCRATCH_REG is dead at start. */
     reg_id_t scratch_reg;
@@ -1540,12 +1540,12 @@ drbbdup_instrument_dups(void *drcontext, void *tag, instrlist_t *bb, instr_t *in
             drbbdup_insert_dispatch_end(drcontext, tag, bb, next_instr, manager);
         } else {
             /* We have reached the start of a new bb version (not the last one). */
-            bool found = false;
+            IF_DEBUG(bool found = false;)
             int i;
             for (i = pt->case_index + 1; i < opts.non_default_case_limit; i++) {
                 drbbdup_case = &manager->cases[i];
                 if (drbbdup_case->is_defined) {
-                    found = true;
+                    IF_DEBUG(found = true;)
                     break;
                 }
             }

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2021 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2022 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,9 +52,11 @@
 #ifdef DEBUG
 #    define ASSERT(x, msg) DR_ASSERT_MSG(x, msg)
 #    define LOG(dc, mask, level, ...) dr_log(dc, mask, level, __VA_ARGS__)
+#    define IF_DEBUG(x) x
 #else
 #    define ASSERT(x, msg)            /* nothing */
 #    define LOG(dc, mask, level, ...) /* nothing */
+#    define IF_DEBUG(x)               /* nothing */
 #endif
 
 #ifdef WINDOWS
@@ -2039,7 +2041,8 @@ drreg_event_restore_state_without_ilist(void *drcontext, bool restore_memory,
     reg_id_t aflags_reg = DR_REG_NULL;
     reg_id_t reg;
     instr_t inst;
-    byte *prev_pc, *pc = info->fragment_info.cache_start_pc;
+    IF_DEBUG(byte * prev_pc;)
+    byte *pc = info->fragment_info.cache_start_pc;
     uint offs;
     bool spill;
     uint slot;
@@ -2053,7 +2056,7 @@ drreg_event_restore_state_without_ilist(void *drcontext, bool restore_memory,
     instr_init(drcontext, &inst);
     while (pc < info->raw_mcontext->pc) {
         instr_reset(drcontext, &inst);
-        prev_pc = pc;
+        IF_DEBUG(prev_pc = pc;)
         pc = decode(drcontext, pc, &inst);
         if (is_our_spill_or_restore(drcontext, &inst, &spill, &reg, &slot, &offs)) {
             LOG(drcontext, DR_LOG_ALL, 3,

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -223,8 +223,8 @@ endif ()
 # However, there's no simple way to do that.  For now we punt until someone
 # changes one of those.
 #
-# Prefer named version 12.0 from apt.llvm.org.
-find_program(CLANG_FORMAT_DIFF clang-format-diff-12 DOC "clang-format-diff")
+# Prefer named version 14.0 from apt.llvm.org.
+find_program(CLANG_FORMAT_DIFF clang-format-diff-14 DOC "clang-format-diff")
 if (NOT CLANG_FORMAT_DIFF)
   find_program(CLANG_FORMAT_DIFF clang-format-diff DOC "clang-format-diff")
 endif ()

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1186,12 +1186,12 @@ _tmain(int argc, TCHAR *targv[])
     int exitcode;
 #if defined(DRRUN) || defined(DRINJECT)
     char *pidfile = NULL;
-    bool showstats = false;
-    bool showmem = false;
     bool force_injection = false;
     bool inject = true;
     int limit = 0; /* in seconds */
 #    ifdef WINDOWS
+    bool showstats = false;
+    bool showmem = false;
     time_t start_time, end_time;
 #    else
     bool use_ptrace = false;
@@ -1207,9 +1207,11 @@ _tmain(int argc, TCHAR *targv[])
     bool exit0 = false;
 #endif
     char *drlib_path = NULL;
+#if defined(DRCONFIG) || defined(DRRUN)
     char *drlib_alt_path = NULL;
-    char custom_dll[MAXIMUM_PATH];
     char custom_alt_dll[MAXIMUM_PATH];
+#endif
+    char custom_dll[MAXIMUM_PATH];
     char *dr_toolconfig_dir = NULL;
     char custom_toolconfig_dir[MAXIMUM_PATH];
     int i;
@@ -1328,15 +1330,18 @@ _tmain(int argc, TCHAR *targv[])
             continue;
         }
 #if defined(DRRUN) || defined(DRINJECT)
+#    ifdef WINDOWS
         else if (strcmp(argv[i], "-stats") == 0) {
             showstats = true;
             continue;
         } else if (strcmp(argv[i], "-mem") == 0) {
             showmem = true;
             continue;
-        } else if (strcmp(argv[i], "-no_inject") == 0 ||
-                   /* support old drinjectx param name */
-                   strcmp(argv[i], "-noinject") == 0 || strcmp(argv[i], "-static") == 0) {
+        }
+#    endif
+        else if (strcmp(argv[i], "-no_inject") == 0 ||
+                 /* support old drinjectx param name */
+                 strcmp(argv[i], "-noinject") == 0 || strcmp(argv[i], "-static") == 0) {
             DR_dll_not_needed = true;
             inject = false;
             continue;
@@ -1540,12 +1545,16 @@ _tmain(int argc, TCHAR *targv[])
             get_absolute_path(argv[++i], custom_dll, BUFFER_SIZE_ELEMENTS(custom_dll));
             NULL_TERMINATE_BUFFER(custom_dll);
             drlib_path = custom_dll;
-        } else if (strcmp(argv[i], "-use_alt_dll") == 0) {
+        }
+#if defined(DRCONFIG) || defined(DRRUN)
+        else if (strcmp(argv[i], "-use_alt_dll") == 0) {
             get_absolute_path(argv[++i], custom_alt_dll,
                               BUFFER_SIZE_ELEMENTS(custom_alt_dll));
             NULL_TERMINATE_BUFFER(custom_alt_dll);
             drlib_alt_path = custom_alt_dll;
-        } else if (strcmp(argv[i], "-tool_dir") == 0) {
+        }
+#endif
+        else if (strcmp(argv[i], "-tool_dir") == 0) {
             get_absolute_path(argv[++i], custom_toolconfig_dir,
                               BUFFER_SIZE_ELEMENTS(custom_toolconfig_dir));
             NULL_TERMINATE_BUFFER(custom_toolconfig_dir);


### PR DESCRIPTION
Fixes many unused-variable warnings when building the core and
extension libraries.  This enables a config without tests or docs to
build.  The drsyms libraries are missing so clients/ is not yet built.

Issue: #5383