### PR TITLE
i#5538 memtrace seek, part 2: Remove redundant "virtual" keywords

### DIFF
--- a/clients/drcachesim/common/archive_ostream.h
+++ b/clients/drcachesim/common/archive_ostream.h
@@ -42,7 +42,7 @@
 
 class archive_ostream_t : public std::ostream {
 public:
-    archive_ostream_t(std::basic_streambuf<char, std::char_traits<char>> *buf)
+    explicit archive_ostream_t(std::basic_streambuf<char, std::char_traits<char>> *buf)
         : std::ostream(buf)
     {
     }

--- a/clients/drcachesim/common/gzip_ostream.h
+++ b/clients/drcachesim/common/gzip_ostream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -51,7 +51,7 @@
  */
 class gzip_streambuf_t : public std::basic_streambuf<char, std::char_traits<char>> {
 public:
-    gzip_streambuf_t(const std::string &path)
+    explicit gzip_streambuf_t(const std::string &path)
     {
         file_ = gzopen(path.c_str(), "wb");
         if (file_ != nullptr) {
@@ -60,14 +60,14 @@ public:
             setp(buf_, buf_ + buffer_size_ - 1);
         }
     }
-    virtual ~gzip_streambuf_t() override
+    ~gzip_streambuf_t() override
     {
         sync();
         delete[] buf_;
         if (file_ != nullptr)
             gzclose(file_);
     }
-    virtual int
+    int
     overflow(int extra_char) override
     {
         if (file_ == nullptr)
@@ -86,7 +86,7 @@ public:
         setp(buf_, buf_ + buffer_size_ - 1);
         return res;
     }
-    virtual int
+    int
     sync() override
     {
         return overflow(traits_type::eof());
@@ -106,7 +106,7 @@ public:
         if (!rdbuf())
             setstate(std::ios::badbit);
     }
-    virtual ~gzip_ostream_t() override
+    ~gzip_ostream_t() override
     {
         delete rdbuf();
     }

--- a/clients/drcachesim/common/zipfile_ostream.h
+++ b/clients/drcachesim/common/zipfile_ostream.h
@@ -49,7 +49,7 @@
 // pptr().
 class zipfile_streambuf_t : public std::basic_streambuf<char, std::char_traits<char>> {
 public:
-    zipfile_streambuf_t(const std::string &path)
+    explicit zipfile_streambuf_t(const std::string &path)
     {
         zip_ = zipOpen2_64(path.c_str(), APPEND_STATUS_CREATE, nullptr, nullptr);
         if (zip_ == nullptr)
@@ -60,7 +60,7 @@ public:
         setp(buf_, buf_ + buffer_size_ - 1);
         // Caller should invoke open_new_component() for first component.
     }
-    virtual ~zipfile_streambuf_t() override
+    ~zipfile_streambuf_t() override
     {
         sync();
         delete[] buf_;
@@ -75,7 +75,7 @@ public:
 #endif
         }
     }
-    virtual int
+    int
     overflow(int extra_char) override
     {
         if (zip_ == nullptr)
@@ -93,7 +93,7 @@ public:
         setp(buf_, buf_ + buffer_size_ - 1);
         return res;
     }
-    virtual int
+    int
     sync() override
     {
         return overflow(traits_type::eof());
@@ -133,7 +133,7 @@ public:
         if (!rdbuf())
             setstate(std::ios::badbit);
     }
-    virtual ~zipfile_ostream_t() override
+    ~zipfile_ostream_t() override
     {
         delete rdbuf();
     }


### PR DESCRIPTION
Cleans up the drmemtrace i/o classes by removing redundant "virtual"
keywords and adding missing "explicit" constructor qualifiers.

Issue: #5538