### PR TITLE
i#5636: Fix elided duplicate timestamps

### DIFF
--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -143,7 +143,9 @@ private:
     addr_t prev_instr_addr_ = 0;
     int bundle_idx_ = 0;
     std::unordered_map<memref_tid_t, memref_pid_t> tid2pid_;
-    uint64_t last_timestamp_ = 0;
+    uint64_t cur_instr_count_ = 0;
+    uint64_t chunk_instr_count_ = 0;
+    uint64_t last_timestamp_instr_count_ = 0;
     bool skip_next_cpu_ = false;
 };
 


### PR DESCRIPTION
PR #5633 added code to skip the duplicate timestamps at the top of each chunk: but its logic assumed there would never be two legitimate timestamps with identical values.  That does happen, in particular in our online-drcachesim tests on Windows.  This resulted in the invariant_checker not seeing some timestamp entries, causing its exception for non-fetched instrs across thread switches to not apply and resulting in invariant error reports.

We fix this by skipping the first timestamp in each chunk by instruction count instead.  We'll want the insruction and chunk counts for #5538 and I was about to add those fields in any case.

Fixes #5636