### PR TITLE
i#5498: Fix drutil_insert_get_mem_addr for w28 index

### DIFF
--- a/ext/drutil/drutil.c
+++ b/ext/drutil/drutil.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * Copyright (c) 2022      Arm Limited   All rights reserved.
  * **********************************************************/
@@ -459,7 +459,7 @@ drutil_insert_get_mem_addr_arm(void *drcontext, instrlist_t *bb, instr_t *where,
              * before replace_stolen_reg() call.
              */
             if (is_index_32bit_stolen)
-                index = reg_64_to_32(stolen);
+                index = reg_64_to_32(index);
 #    endif
         }
         if (index == REG_NULL && opnd_get_disp(memref) != 0) {


### PR DESCRIPTION
The fix in PR #5511 for drutil_insert_get_mem_addr() on a w28 index register failed to use the application value in a temp register and resulted in an incorrect recorded address.  The test added in that PR failed to actually check the value and so failed to catch the error.

Here we augment the test to check the value by passing the recorded address and the operand to a clean call.  This new test fails for the w28 case.  With the included fix, it now passes.

Fixes #5498