### PR TITLE
Rename formal parameter to report_to_false.

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -58,10 +58,10 @@ public:
 protected:
     void
     report_if_false(per_shard_t *shard, bool condition,
-                    const std::string &message) override
+                    const std::string &invariant_name) override
     {
         if (!condition) {
-            errors.push_back(message);
+            errors.push_back(invariant_name);
             error_tids.push_back(shard->tid);
             error_refs.push_back(shard->ref_count);
         }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -57,11 +57,11 @@ invariant_checker_t::~invariant_checker_t()
 
 void
 invariant_checker_t::report_if_false(per_shard_t *shard, bool condition,
-                                     const std::string &message)
+                                     const std::string &invariant_name)
 {
     if (!condition) {
         std::cerr << "Trace invariant failure in T" << shard->tid << " at ref # "
-                  << shard->ref_count << ": " << message << "\n";
+                  << shard->ref_count << ": " << invariant_name << "\n";
         abort();
     }
 }

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -109,7 +109,8 @@ protected:
     // We provide this for subclasses to run these invariants with custom
     // failure reporting.
     virtual void
-    report_if_false(per_shard_t *shard, bool condition, const std::string &message);
+    report_if_false(per_shard_t *shard, bool condition,
+                    const std::string &invariant_name);
 
     // The keys here are int for parallel, tid for serial.
     std::unordered_map<memref_tid_t, std::unique_ptr<per_shard_t>> shard_map_;


### PR DESCRIPTION
Clarifies that the string parameter to report_to_false is supposed to be the invariant name.