### PR TITLE
i#5651: Switch DR's suspend signal to SIGILL with sigqueueinfo

### DIFF
--- a/api/docs/debugging.dox
+++ b/api/docs/debugging.dox
@@ -82,7 +82,7 @@ On Linux, DR sends itself a SIGILL signal during initialization, in order to mea
 
 Additionally, DR uses various "safe read" strategies where it may raise a SIGSEGV or SIGBUS while examining application memory.  Load symbols and look for `safe_read` variants on the call stack (such as `safe_read_tls_magic`, `safe_read_asm_pre`, `safe_read_fast`) to identify these.  Just like with the init-time SIGILL, simply continue past these.
 
-One final signal used by DR is SIGSTKFLT (SIGFPE on MacOS), which is sent to other threads to suspend or terminate them.
+One final signal used by DR is SIGPWR (SIGFPE on MacOS), which is sent to other threads to suspend or terminate them.
 
 ## Attaching
 

--- a/api/docs/debugging.dox
+++ b/api/docs/debugging.dox
@@ -78,11 +78,9 @@ the shared library that identifies the debug file.
 
 ## Expected Signals
 
-On Linux, DR sends itself a SIGILL signal during initialization, in order to measure the size of the signal frame used by the kernel.  If you are under gdb, simply continue past this signal.
+On Linux, DR sends itself a SIGILL signal during initialization, in order to measure the size of the signal frame used by the kernel.  If you are under gdb, simply continue past this signal.  SIGILL (SIGFPE on MacOS; SIGSTKFLT inside QEMU) is also sent to other threads to suspend or terminate them later on during execution.
 
 Additionally, DR uses various "safe read" strategies where it may raise a SIGSEGV or SIGBUS while examining application memory.  Load symbols and look for `safe_read` variants on the call stack (such as `safe_read_tls_magic`, `safe_read_asm_pre`, `safe_read_fast`) to identify these.  Just like with the init-time SIGILL, simply continue past these.
-
-One final signal used by DR is SIGPWR (SIGFPE on MacOS), which is sent to other threads to suspend or terminate them.
 
 ## Attaching
 

--- a/api/docs/debugging.dox
+++ b/api/docs/debugging.dox
@@ -78,7 +78,7 @@ the shared library that identifies the debug file.
 
 ## Expected Signals
 
-On Linux, DR sends itself a SIGILL signal during initialization, in order to measure the size of the signal frame used by the kernel.  If you are under gdb, simply continue past this signal.  SIGILL (SIGFPE on MacOS; SIGSTKFLT inside QEMU) is also sent to other threads to suspend or terminate them later on during execution.
+On Linux, DR sends itself a SIGILL signal during initialization, in order to measure the size of the signal frame used by the kernel.  If you are under gdb, simply continue past this signal.  SIGILL (SIGFPE on MacOS; SIGSTKFLT inside QEMU where the others crash QEMU (but note the poor support for SIGSTKFLT in gdb)) is also sent to other threads when attaching to a multi-threaded application and to suspend or terminate them later on during execution.
 
 Additionally, DR uses various "safe read" strategies where it may raise a SIGSEGV or SIGBUS while examining application memory.  Load symbols and look for `safe_read` variants on the call stack (such as `safe_read_tls_magic`, `safe_read_asm_pre`, `safe_read_fast`) to identify these.  Just like with the init-time SIGILL, simply continue past these.
 

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -928,6 +928,7 @@ typedef enum {
  */
 enum {
     NUDGE_IS_INTERNAL = 0x01, /* nudge is internally generated */
+    NUDGE_IS_SUSPEND = 0x02,  /* This is an internal SUSPEND_SIGNAL. */
 #ifdef WINDOWS
     NUDGE_NUDGER_FREE_STACK = 0x02, /* nudger will free the nudge thread's stack so the
                                      * nudge thread itself shouldn't */

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -923,13 +923,14 @@ typedef enum {
 #define NUDGE_ARG_VERSION_1 1
 #define NUDGE_ARG_CURRENT_VERSION NUDGE_ARG_VERSION_1
 
-/* nudge_arg_t flags
- * On Linux only 2 bits for these
+/* nudge_arg_t bitfield flags.
+ * On UNIX we only have space for 2 bits for these.
  */
 enum {
-    NUDGE_IS_INTERNAL = 0x01, /* nudge is internally generated */
-    NUDGE_IS_SUSPEND = 0x02,  /* This is an internal SUSPEND_SIGNAL. */
-#ifdef WINDOWS
+    NUDGE_IS_INTERNAL = 0x01, /* The nudge is internally generated. */
+#ifdef UNIX
+    NUDGE_IS_SUSPEND = 0x02, /* This is an internal SUSPEND_SIGNAL. */
+#else
     NUDGE_NUDGER_FREE_STACK = 0x02, /* nudger will free the nudge thread's stack so the
                                      * nudge thread itself shouldn't */
     NUDGE_FREE_ARG = 0x04,          /* nudge arg is in a separate allocation and should
@@ -953,9 +954,9 @@ typedef struct {
     uint flags : 2;
     int ignored2; /* siginfo_t.si_code: has meaning to kernel so we avoid using */
 #else
-    uint version;           /* version number for future proofing */
-    uint nudge_action_mask; /* drawn from NUDGE_DEFS above */
-    uint flags;             /* flags drawn from above enum */
+    uint version;                   /* version number for future proofing */
+    uint nudge_action_mask;         /* drawn from NUDGE_DEFS above */
+    uint flags;                     /* flags drawn from above enum */
 #endif
     client_id_t client_id; /* unique ID identifying client */
     uint64 client_arg;     /* argument for a client nudge */

--- a/core/unix/nudgesig.c
+++ b/core/unix/nudgesig.c
@@ -67,7 +67,8 @@ create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask, uint f
     arg->client_arg = client_arg;
 
     /* ensure nudge_arg_t overlays how we expect it to */
-    if (info->si_signo != NUDGESIG_SIGNUM || info->si_code != SI_QUEUE)
+    if (info->si_signo != NUDGESIG_SIGNUM || info->si_code != SI_QUEUE ||
+        info->si_errno == 0)
         return false;
 
     return true;

--- a/core/unix/nudgesig.c
+++ b/core/unix/nudgesig.c
@@ -62,6 +62,9 @@ create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask, uint f
     arg = (nudge_arg_t *)info;
     arg->version = NUDGE_ARG_CURRENT_VERSION;
     arg->nudge_action_mask = action_mask;
+    /* We only have 2 bits for flags. */
+    if (flags >= 4)
+        return false;
     arg->flags = flags;
     arg->client_id = client_id;
     arg->client_arg = client_arg;

--- a/core/unix/nudgesig.c
+++ b/core/unix/nudgesig.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -50,7 +50,7 @@
 
 /* shared with tools/nudgeunix.c */
 bool
-create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask,
+create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask, uint flags,
                             client_id_t client_id, uint64 client_arg)
 {
     nudge_arg_t *arg;
@@ -62,7 +62,7 @@ create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask,
     arg = (nudge_arg_t *)info;
     arg->version = NUDGE_ARG_CURRENT_VERSION;
     arg->nudge_action_mask = action_mask;
-    arg->flags = 0;
+    arg->flags = flags;
     arg->client_id = client_id;
     arg->client_arg = client_arg;
 
@@ -80,7 +80,7 @@ send_nudge_signal(process_id_t pid, uint action_mask, client_id_t client_id,
 {
     kernel_siginfo_t info;
     int res;
-    if (!create_nudge_signal_payload(&info, action_mask, client_id, client_arg))
+    if (!create_nudge_signal_payload(&info, action_mask, 0, client_id, client_arg))
         return false;
     res = dynamorio_syscall(SYS_rt_sigqueueinfo, 3, pid, NUDGESIG_SIGNUM, &info);
     return (res >= 0);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -900,6 +900,13 @@ detect_unsupported_syscalls()
     ASSERT(sigqueue_errno == -ENOSYS || sigqueue_errno == -EINVAL ||
            sigqueue_errno == -EFAULT);
     is_sigqueueinfo_enosys = sigqueue_errno == -ENOSYS;
+    if (!IS_STRING_OPTION_EMPTY(xarch_root)) {
+        /* XXX i#5651: QEMU clears si_errno when we send our payload!
+         * For now we pretend this syscall doesn't work, to get basic apps
+         * working under QEMU.
+         */
+        is_sigqueueinfo_enosys = true;
+    }
 }
 #endif
 
@@ -950,6 +957,10 @@ d_r_os_init(void)
 
 #ifdef VMX86_SERVER
     vmk_init();
+#endif
+
+#if defined(LINUX)
+    detect_unsupported_syscalls();
 #endif
 
     /* The signal we use to suspend threads.
@@ -1023,9 +1034,6 @@ d_r_os_init(void)
 #endif
 #ifdef MACOS64
     tls_process_init();
-#endif
-#if defined(LINUX)
-    detect_unsupported_syscalls();
 #endif
 }
 

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -514,7 +514,10 @@ typedef int *(*errno_loc_t)(void);
 #ifdef LINUX
 /* Stores whether clone3 is unsupported on the system we're running on. */
 static bool is_clone3_enosys = false;
+static bool is_sigqueueinfo_enosys = false;
 #endif
+
+int suspend_signum;
 
 static errno_loc_t
 get_libc_errno_location(bool do_init)
@@ -892,8 +895,19 @@ detect_unsupported_syscalls()
         dynamorio_syscall(SYS_clone3, 2, NULL /*clone_args*/, 0 /*clone_args_size*/);
     ASSERT(clone3_errno == -ENOSYS || clone3_errno == -EINVAL);
     is_clone3_enosys = clone3_errno == -ENOSYS;
+    int sigqueue_errno = dynamorio_syscall(SYS_rt_tgsigqueueinfo, 4, get_process_id(),
+                                           get_sys_thread_id(), -1, NULL);
+    ASSERT(sigqueue_errno == -ENOSYS || sigqueue_errno == -EINVAL ||
+           sigqueue_errno == -EFAULT);
+    is_sigqueueinfo_enosys = sigqueue_errno == -ENOSYS;
 }
 #endif
+
+bool
+is_sigqueue_supported(void)
+{
+    return IF_LINUX_ELSE(!is_sigqueueinfo_enosys, false);
+}
 
 /* os-specific initializations */
 void
@@ -936,6 +950,27 @@ d_r_os_init(void)
 
 #ifdef VMX86_SERVER
     vmk_init();
+#endif
+
+    /* The signal we use to suspend threads.
+     * We choose a normally-synchronous signal for a lower chance that the app has
+     * blocked it when we attach to an already-running app.
+     * On Linux where we have SYS_rt_sigqueueinfo we use
+     * SIGILL and share with nudges, distinguishing via the NUDGE_IS_SUSPEND flag.
+     * (For pre-2.6.31 Linux kernels without SYS_rt_sigqueueinfo nudges are not
+     * supported so there are no collisions there).
+     * (We initially used SIGSTKFLT but gdb has poor support for it.)
+     * Unfortunately, QEMU crashes when we send SIGILL or SIGFPE to its thread trying
+     * to take it over, so we are forced to dynamically vary the number and we switch
+     * to SIGSTKFLT for QEMU where we live with the lack of gdb support.
+     */
+    suspend_signum = IF_MACOS_ELSE(SIGFPE, NUDGESIG_SIGNUM);
+#ifdef LINUX
+    if (!IS_STRING_OPTION_EMPTY(xarch_root)) {
+        /* We assume we're under QEMU. */
+        LOG(GLOBAL, LOG_TOP | LOG_ASYNCH, 1, "switching suspend signal to SIGSTKFLT\n");
+        suspend_signum = SIGSTKFLT;
+    }
 #endif
 
     d_r_signal_init();
@@ -3620,7 +3655,6 @@ thread_signal(process_id_t pid, thread_id_t tid, int signum)
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
 #else
-    /* FIXME: for non-NPTL use SYS_kill */
     /* Note that the pid is equivalent to the thread group id.
      * However, we can have threads sharing address space but not pid
      * (if created via CLONE_VM but not CLONE_THREAD), so make sure to
@@ -3642,7 +3676,9 @@ thread_signal_queue(process_id_t pid, thread_id_t tid, int signum, void *value)
     info.si_signo = signum;
     info.si_code = SI_QUEUE;
     info.si_value.sival_ptr = value;
-    /* SYS_rt_sigqueueinfo is on 2.6.31+ so we expect failure on older kernels. */
+    /* SYS_rt_sigqueueinfo is on 2.6.31+ so we expect failure on older kernels.
+     * The caller can use is_sigqueue_supported() to check.
+     */
     return dynamorio_syscall(SYS_rt_tgsigqueueinfo, 4, pid, tid, signum, &info) == 0;
 #endif
 }
@@ -3714,6 +3750,34 @@ os_thread_sleep(uint64 milliseconds)
 #endif
 }
 
+/* For an unknown thread, pass tr==NULL.  Always pass pid and tid. */
+static bool
+send_suspend_signal(thread_record_t *tr, pid_t pid, thread_id_t tid)
+{
+#ifdef MACOS
+    if (tr != NULL)
+        return known_thread_signal(tr, SUSPEND_SIGNAL);
+    else
+        return thread_signal(pid, tid, SUSPEND_SIGNAL);
+#else
+    if (is_sigqueueinfo_enosys) {
+        /* We won't be able to distinguish a suspend from a nudge, but we don't
+         * support nudges on old Linux kernels anyway (<2.6.31).
+         */
+        if (tr != NULL)
+            return known_thread_signal(tr, SUSPEND_SIGNAL);
+        else
+            return thread_signal(pid, tid, SUSPEND_SIGNAL);
+    }
+    kernel_siginfo_t info;
+    if (!create_nudge_signal_payload(&info, 0, NUDGE_IS_SUSPEND, 0, 0))
+        return false;
+    ptr_int_t res =
+        dynamorio_syscall(SYS_rt_tgsigqueueinfo, 4, pid, tid, SUSPEND_SIGNAL, &info);
+    return (res >= 0);
+#endif
+}
+
 bool
 os_thread_suspend(thread_record_t *tr)
 {
@@ -3736,7 +3800,7 @@ os_thread_suspend(thread_record_t *tr)
          * to match Windows behavior.
          */
         ASSERT(ksynch_get_value(&ostd->suspended) == 0);
-        if (!known_thread_signal(tr, SUSPEND_SIGNAL)) {
+        if (!send_suspend_signal(tr, tr->pid, tr->id)) {
             ostd->suspend_count--;
             d_r_mutex_unlock(&ostd->suspend_lock);
             return false;
@@ -3824,7 +3888,7 @@ os_thread_terminate(thread_record_t *tr)
     /* Even if the thread is currently suspended, it's simpler to send it
      * another signal than to resume it.
      */
-    return known_thread_signal(tr, SUSPEND_SIGNAL);
+    return send_suspend_signal(tr, tr->pid, tr->id);
 }
 
 bool
@@ -10703,7 +10767,7 @@ os_take_over_all_unknown_threads(dcontext_t *dcontext)
 
         /* Signal the other threads. */
         for (i = 0; i < threads_to_signal; i++) {
-            thread_signal(get_process_id(), records[i].tid, SUSPEND_SIGNAL);
+            send_suspend_signal(NULL, get_process_id(), records[i].tid);
         }
         d_r_mutex_unlock(&thread_initexit_lock);
 

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -88,13 +88,14 @@
  * We choose a normally-synchronous signal for a lower chance that the app has
  * blocked it when we attach to an already-running app.
  * SIGFPE is a good choice, but when running under QEMU, QEMU crashes
- * when we send it, so we use SIGSTKFLT (which does not exist on Mac:
- * there we use SIGFPE).
+ * when we send it, so we use SIGPWR (which does not exist on Mac:
+ * there we use SIGFPE).  (We initially used SIGSTKFLT but gdb has poor support
+ * for it.)
  * We could conceivably make this a variable controlled by a runtime option,
  * but it has a number of limitations, and the checks for it being user-sent
  * would need to be flexible: it doesn't seem worth the complexity at this point.
  */
-#define SUSPEND_SIGNAL IF_MACOS_ELSE(SIGFPE, SIGSTKFLT)
+#define SUSPEND_SIGNAL IF_MACOS_ELSE(SIGFPE, SIGPWR)
 
 #ifdef MACOS
 /* While there is no clone system call, we use the same clone flags to share

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -85,17 +85,10 @@
 #define MACHINE_TLS_IS_DR_TLS IF_X86_ELSE(INTERNAL_OPTION(mangle_app_seg), true)
 
 /* The signal we use to suspend threads.
- * We choose a normally-synchronous signal for a lower chance that the app has
- * blocked it when we attach to an already-running app.
- * SIGFPE is a good choice, but when running under QEMU, QEMU crashes
- * when we send it, so we use SIGPWR (which does not exist on Mac:
- * there we use SIGFPE).  (We initially used SIGSTKFLT but gdb has poor support
- * for it.)
- * We could conceivably make this a variable controlled by a runtime option,
- * but it has a number of limitations, and the checks for it being user-sent
- * would need to be flexible: it doesn't seem worth the complexity at this point.
+ * It may equal NUDGESIG_SIGNUM.
  */
-#define SUSPEND_SIGNAL IF_MACOS_ELSE(SIGFPE, SIGPWR)
+extern int suspend_signum;
+#define SUSPEND_SIGNAL suspend_signum
 
 #ifdef MACOS
 /* While there is no clone system call, we use the same clone flags to share
@@ -278,6 +271,9 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules);
 
 bool
 is_sigreturn_syscall_number(int sysnum);
+
+bool
+is_sigqueue_supported(void);
 
 /* in signal.c */
 struct _kernel_sigaction_t;
@@ -469,7 +465,7 @@ init_android_version(void);
 
 /* in nudgesig.c */
 bool
-create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask,
+create_nudge_signal_payload(kernel_siginfo_t *info OUT, uint action_mask, uint flags,
                             client_id_t client_id, uint64 client_arg);
 
 #ifdef X86

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -6030,7 +6030,11 @@ main_signal_handler_C(byte *xsp)
             }
             /* else, don't deliver to app */
             break;
-        } else if (sig == NUDGESIG_SIGNUM) {
+        }
+        /* This might be the same signal as SUSPEND_SIGNAL in which case this else() won't
+         * be entered (and handle_suspend_signal() will handle nudges too).
+         */
+        else if (sig == NUDGESIG_SIGNUM) {
             if (handle_nudge_signal(dcontext, siginfo, ucxt))
                 record_pending_signal(dcontext, sig, ucxt, frame, false, NULL);
             /* else, don't deliver to app */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5993,23 +5993,6 @@ main_signal_handler_C(byte *xsp)
         break;
     }
 
-    /* PR 212090: the signal we use to suspend threads */
-    case SUSPEND_SIGNAL:
-        if (handle_suspend_signal(dcontext, siginfo, ucxt, frame)) {
-            /* i#1921: see comment above */
-            ASSERT(tr == NULL || tr->under_dynamo_control || IS_CLIENT_THREAD(dcontext));
-            record_pending_signal(dcontext, sig, ucxt, frame, false, NULL);
-        }
-        /* else, don't deliver to app */
-        break;
-
-    /* i#61/PR 211530: the signal we use for nudges */
-    case NUDGESIG_SIGNUM:
-        if (handle_nudge_signal(dcontext, siginfo, ucxt))
-            record_pending_signal(dcontext, sig, ucxt, frame, false, NULL);
-        /* else, don't deliver to app */
-        break;
-
     case SIGALRM:
     case SIGVTALRM:
     case SIGPROF:
@@ -6037,6 +6020,22 @@ main_signal_handler_C(byte *xsp)
 #endif
 
     default: {
+        /* Handle nudges and suspends, which may use the same signal. */
+        if (sig == SUSPEND_SIGNAL) {
+            if (handle_suspend_signal(dcontext, siginfo, ucxt, frame)) {
+                /* i#1921: see comment above */
+                ASSERT(tr == NULL || tr->under_dynamo_control ||
+                       IS_CLIENT_THREAD(dcontext));
+                record_pending_signal(dcontext, sig, ucxt, frame, false, NULL);
+            }
+            /* else, don't deliver to app */
+            break;
+        } else if (sig == NUDGESIG_SIGNUM) {
+            if (handle_nudge_signal(dcontext, siginfo, ucxt))
+                record_pending_signal(dcontext, sig, ucxt, frame, false, NULL);
+            /* else, don't deliver to app */
+            break;
+        }
         record_pending_signal(dcontext, sig, ucxt, frame, false, NULL);
         break;
     }
@@ -8329,6 +8328,39 @@ sig_detach(dcontext_t *dcontext, sigframe_rt_t *frame, KSYNCH_TYPE *detached)
     ASSERT_NOT_REACHED();
 }
 
+static bool
+is_signal_for_us(kernel_siginfo_t *siginfo)
+{
+    /* Distinguish a nudge/suspend from an app signal.
+     * On Linux with SYS_rt_tgsigqueueinfo support, it is much easier, since an
+     * app using libc sigqueue()
+     * will never have its signal mistaken as libc does not expose the kernel_siginfo_t
+     * and always passes 0 for si_errno, so we're only worried beyond our
+     * si_code check about an app using a raw syscall that is deliberately
+     * trying to fool us.
+     * While there is a lot of padding space in kernel_siginfo_t, the kernel doesn't
+     * copy it through on SYS_rt_sigqueueinfo so we don't have room for any
+     * dedicated magic numbers.  The client id could function as a magic
+     * number for client nudges, but I don't think we want to kill the app
+     * if an external nudger types the client id wrong.
+     */
+    LOG(THREAD_GET, LOG_ASYNCH, 2, "%s T%d: sig=%d code=%d errno=%d\n", __FUNCTION__,
+        get_sys_thread_id(), siginfo->si_signo, siginfo->si_code, siginfo->si_errno);
+    if (siginfo->si_signo != NUDGESIG_SIGNUM)
+        return false;
+    if (is_sigqueue_supported()) {
+        if (siginfo->si_code != SI_QUEUE || siginfo->si_errno == 0)
+            return false;
+    } else {
+        /* Distinguish from a synchronous app signal by looking for
+         * si_code where <=0 means user-sent.
+         */
+        if (siginfo->si_code > 0)
+            return false;
+    }
+    return true;
+}
+
 /* Returns whether to pass on to app */
 static bool
 handle_suspend_signal(dcontext_t *dcontext, kernel_siginfo_t *siginfo,
@@ -8339,14 +8371,19 @@ handle_suspend_signal(dcontext_t *dcontext, kernel_siginfo_t *siginfo,
     sig_full_cxt_t sc_full;
     ASSERT(ostd != NULL);
 
-    /* Distinguish up front from a synchronous app signal by looking for
-     * si_code where <=0 means user-sent.
-     * We distinguish further below from the rare case of an app sending
-     * SUSPEND_SIGNAL asynchronously by looking for our particular state settings
-     * that correspond to the use of this signal by DR..
-     */
-    if (siginfo->si_code > 0 || siginfo->si_signo != SUSPEND_SIGNAL)
+    if (!is_signal_for_us(siginfo))
         return true; /* pass to app */
+
+    if (is_sigqueue_supported() && SUSPEND_SIGNAL == NUDGESIG_SIGNUM) {
+        nudge_arg_t *arg = (nudge_arg_t *)siginfo;
+        if (!TEST(NUDGE_IS_SUSPEND, arg->flags))
+            return handle_nudge_signal(dcontext, siginfo, ucxt);
+    }
+
+    /* We distinguish from an app signal further below from the rare case of an
+     * app sending SUSPEND_SIGNAL asynchronously by looking for our particular
+     * state settings that correspond to the use of this signal by DR.
+     */
 
     if (ostd->terminate) {
         /* PR 297902: exit this thread, without using the dstack */
@@ -8493,25 +8530,8 @@ handle_nudge_signal(dcontext_t *dcontext, kernel_siginfo_t *siginfo,
     instr_t instr;
     char buf[MAX_INSTR_LENGTH];
 
-    /* Distinguish a nudge from an app signal.  An app using libc sigqueue()
-     * will never have its signal mistaken as libc does not expose the kernel_siginfo_t
-     * and always passes 0 for si_errno, so we're only worried beyond our
-     * si_code check about an app using a raw syscall that is deliberately
-     * trying to fool us.
-     * While there is a lot of padding space in kernel_siginfo_t, the kernel doesn't
-     * copy it through on SYS_rt_sigqueueinfo so we don't have room for any
-     * dedicated magic numbers.  The client id could function as a magic
-     * number for client nudges, but I don't think we want to kill the app
-     * if an external nudger types the client id wrong.
-     */
-    LOG(THREAD, LOG_ASYNCH, 2, "%s: sig=%d code=%d errno=%d\n", __FUNCTION__,
-        siginfo->si_signo, siginfo->si_code, siginfo->si_errno);
-    if (siginfo->si_signo !=
-        NUDGESIG_SIGNUM
-            /* PR 477454: remove the IF_NOT_VMX86 once we have nudge-arg support */
-            IF_NOT_VMX86(|| siginfo->si_code != SI_QUEUE || siginfo->si_errno == 0)) {
+    if (!is_signal_for_us(siginfo))
         return true; /* pass to app */
-    }
 #ifndef VMX86_SERVER
     DODEBUG({
         if (TEST(NUDGE_GENERIC(client), arg->nudge_action_mask) &&
@@ -8535,7 +8555,8 @@ handle_nudge_signal(dcontext_t *dcontext, kernel_siginfo_t *siginfo,
      * from a real illegal instr: though si_code for that should not be
      * SI_QUEUE.  It's possible a nudge happened to come at a bad instr before
      * it faulted, or maybe the instr after a syscall or other wait spot is
-     * illegal, but we'll live with that risk.
+     * illegal, but we'll live with that risk for nudges; we do not do this for
+     * suspend signals.
      */
     ASSERT(NUDGESIG_SIGNUM == SIGILL); /* else this check makes no sense */
     instr_init(dcontext, &instr);

--- a/core/unix/signal_linux_x86.c
+++ b/core/unix/signal_linux_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -57,6 +57,9 @@
 static size_t xstate_size;
 static bool xstate_has_extra_fields;
 
+/* We use this early enough during init that we assume there is no confusion
+ * with NUDGESIG_SIGNUM or SUSPEND_SIGNAL as DR's main handler is not set up yet.
+ */
 #define XSTATE_QUERY_SIG SIGILL
 
 /**** floating point support ********************************************/

--- a/libutil/dr_config.c
+++ b/libutil/dr_config.c
@@ -91,7 +91,7 @@ d_r_snprintf_wide(wchar_t *s, size_t max, const wchar_t *fmt, ...);
 
 extern bool
 create_nudge_signal_payload(siginfo_t *info OUT, uint action_mask, client_id_t client_id,
-                            uint64 client_arg);
+                            uint flags, uint64 client_arg);
 #endif
 
 /* The minimum option size is 3, e.g., "-x ".  Note that we need the
@@ -2090,7 +2090,7 @@ dr_nudge_pid(process_id_t process_id, client_id_t client_id, uint64 arg, uint ti
     siginfo_t info;
     int res;
     /* construct the payload */
-    if (!create_nudge_signal_payload(&info, NUDGE_GENERIC(client), client_id, arg))
+    if (!create_nudge_signal_payload(&info, NUDGE_GENERIC(client), 0, client_id, arg))
         return DR_FAILURE;
     /* send the nudge */
     res = syscall(SYS_rt_sigqueueinfo, process_id, NUDGESIG_SIGNUM, &info);

--- a/suite/tests/api/detach_signal.cpp
+++ b/suite/tests/api/detach_signal.cpp
@@ -64,7 +64,7 @@
 #ifdef MACOS
 #    define DR_SUSPEND_SIGNAL SIGFPE /* DR's takeover signal. */
 #else
-#    define DR_SUSPEND_SIGNAL SIGSTKFLT /* DR's takeover signal. */
+#    define DR_SUSPEND_SIGNAL SIGPWR /* DR's takeover signal. */
 #endif
 
 static volatile bool sideline_exit = false;

--- a/suite/tests/api/detach_signal.cpp
+++ b/suite/tests/api/detach_signal.cpp
@@ -64,7 +64,7 @@
 #ifdef MACOS
 #    define DR_SUSPEND_SIGNAL SIGFPE /* DR's takeover signal. */
 #else
-#    define DR_SUSPEND_SIGNAL SIGPWR /* DR's takeover signal. */
+#    define DR_SUSPEND_SIGNAL SIGILL /* DR's takeover signal. */
 #endif
 
 static volatile bool sideline_exit = false;

--- a/tools/nudgeunix.c
+++ b/tools/nudgeunix.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.    All rights reserved.
+ * Copyright (c) 2012-2022 Google, Inc.    All rights reserved.
  * Copyright (c) 2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -50,7 +50,7 @@
 
 extern bool
 create_nudge_signal_payload(siginfo_t *info OUT, uint action_mask, client_id_t client_id,
-                            uint64 client_arg);
+                            uint flags, uint64 client_arg);
 
 static const char *usage_str =
     "usage: drnudgeunix [-help] [-v] [-pid <pid>] [-type <type>] [-client <ID> <arg>]\n"
@@ -140,7 +140,7 @@ main(int argc, const char *argv[])
         return usage();
 
     /* construct the payload */
-    success = create_nudge_signal_payload(&info, action_mask, client_id, client_arg);
+    success = create_nudge_signal_payload(&info, action_mask, 0, client_id, client_arg);
     assert(success); /* failure means kernel's sigqueueinfo has changed */
 
     /* send the nudge */


### PR DESCRIPTION
Switches the signal DR uses to suspend threads from SIGSTKFLT, which is not supported in gdb, to SIGPWR.  SIGPWR is similarly obscure and never used on Linux, but is supported by gdb, and does not cause QEMU to fail.

Fixes #5651