### PR TITLE
i#5659: Handle multiple app copies in rseq mangling

### DIFF
--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -99,7 +99,9 @@ typedef struct _rseq_region_t {
     bool reg_written[DR_NUM_GPR_REGS];
 } rseq_region_t;
 
-/* We need to store potentially multiple rseq_cs per fragment. */
+/* We need to store potentially multiple rseq_cs per fragment when clients
+ * make multiple copies of the app code (e.g., drbbdup).
+ */
 typedef struct _rseq_cs_record_t {
     struct rseq_cs rcs;
     void *alloc_ptr;

--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -99,7 +99,14 @@ typedef struct _rseq_region_t {
     bool reg_written[DR_NUM_GPR_REGS];
 } rseq_region_t;
 
-/* We need to store a struct rseq_cs per fragment_t.  To avoid the cost of adding a
+/* We need to store potentially multiple rseq_cs per fragment. */
+typedef struct _rseq_cs_record_t {
+    struct rseq_cs rcs;
+    void *alloc_ptr;
+    struct _rseq_cs_record_t *next;
+} rseq_cs_record_t;
+
+/* We need to store an rseq_cs_record_t per fragment_t.  To avoid the cost of adding a
  * pointer field to every fragment_t, and the complexity of another subclass like
  * trace_t, we store them externally in a hashtable.  The FRAG_HAS_RSEQ_ENDPOINT flag
  * avoids the hashtable lookup on every fragment.
@@ -128,13 +135,18 @@ rseq_area_dup(void *data)
 static inline size_t
 rseq_cs_alloc_size(void)
 {
-    return sizeof(struct rseq) + __alignof(struct rseq_cs);
+    return sizeof(rseq_cs_record_t) + __alignof(struct rseq_cs);
 }
 
 static void
 rseq_cs_free(dcontext_t *dcontext, void *data)
 {
-    global_heap_free(data, rseq_cs_alloc_size() HEAPACCT(ACCT_OTHER));
+    rseq_cs_record_t *record = (rseq_cs_record_t *)data;
+    do {
+        void *tofree = record->alloc_ptr;
+        record = record->next;
+        global_heap_free(tofree, rseq_cs_alloc_size() HEAPACCT(ACCT_OTHER));
+    } while (record != NULL);
 }
 
 void
@@ -244,15 +256,26 @@ void
 rseq_record_rseq_cs(byte *rseq_cs_alloc, fragment_t *f, cache_pc start, cache_pc end,
                     cache_pc abort)
 {
-    struct rseq_cs *target =
-        (struct rseq_cs *)ALIGN_FORWARD(rseq_cs_alloc, __alignof(struct rseq_cs));
+    rseq_cs_record_t *record =
+        (rseq_cs_record_t *)ALIGN_FORWARD(rseq_cs_alloc, __alignof(struct rseq_cs));
+    record->alloc_ptr = rseq_cs_alloc;
+    record->next = NULL;
+    struct rseq_cs *target = &record->rcs;
     target->version = 0;
     target->flags = 0;
     target->start_ip = (ptr_uint_t)start;
     target->post_commit_offset = (ptr_uint_t)(end - start);
     target->abort_ip = (ptr_uint_t)abort;
     TABLE_RWLOCK(rseq_cs_table, write, lock);
-    generic_hash_add(GLOBAL_DCONTEXT, rseq_cs_table, (ptr_uint_t)f, rseq_cs_alloc);
+    rseq_cs_record_t *existing =
+        generic_hash_lookup(GLOBAL_DCONTEXT, rseq_cs_table, (ptr_uint_t)f);
+    if (existing != NULL) {
+        while (existing->next != NULL)
+            existing = existing->next;
+        existing->next = record;
+    } else {
+        generic_hash_add(GLOBAL_DCONTEXT, rseq_cs_table, (ptr_uint_t)f, record);
+    }
     TABLE_RWLOCK(rseq_cs_table, write, unlock);
 }
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3818,7 +3818,10 @@ if (BUILD_CLIENTS)
     endif ()
 
     if (LINUX AND X64 AND HAVE_RSEQ)
-      torunonly_drcacheoff(rseq linux.rseq ""
+      torunonly_drcacheoff(rseq linux.rseq
+        # Run with -trace_after_instrs to ensure we test the
+        # drbbdup + rseq combo (i#5658, i#5659).
+        "-trace_after_instrs 5K"
         "@${test_mode_flag}@-test_mode_name@rseq_app" "")
     endif ()
 
@@ -4673,6 +4676,8 @@ if (UNIX)
     tobuild_api(api.rseq linux/rseq.c "" "" OFF ON OFF)
     link_with_pthread(api.rseq)
     append_property_list(TARGET api.rseq COMPILE_DEFINITIONS "RSEQ_TEST_ATTACH")
+    use_DynamoRIO_static_client(api.rseq drmemtrace_static)
+    use_DynamoRIO_drmemtrace_tracer(api.rseq)
     set(api.rseq_expectbase rseq_client)
     # Test non-compliant code with our workaround flag.
     tobuild_ops(linux.rseq_disable linux/rseq_disable.c "-disable_rseq" "")

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -39,6 +39,7 @@
 #    include "thread.h"
 #    include "condvar.h"
 #    include <stdatomic.h>
+#    include "drmemtrace/drmemtrace.h"
 #endif
 #ifndef LINUX
 #    error Only Linux is supported.
@@ -180,12 +181,11 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         "5:\n\t"
         "movq $0, %[rseq_tls]\n\t"
         /* clang-format on */
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ id ] "=m"(id),
-          [ completions ] "=m"(completions), [ restarts ] "=m"(restarts),
-          [ force_restart_write ] "=m"(force_restart)
-        : [ cpu_id ] "m"(rseq_tls.cpu_id),
-          [ cpu_id_uninit ] "i"(RSEQ_CPU_ID_UNINITIALIZED),
-          [ force_restart ] "m"(force_restart)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id),
+          [completions] "=m"(completions), [restarts] "=m"(restarts),
+          [force_restart_write] "=m"(force_restart)
+        : [cpu_id] "m"(rseq_tls.cpu_id), [cpu_id_uninit] "i"(RSEQ_CPU_ID_UNINITIALIZED),
+          [force_restart] "m"(force_restart)
         : "rax", "memory");
 #elif defined(AARCH64)
     __asm__ __volatile__(
@@ -246,12 +246,11 @@ test_rseq_call_once(bool force_restart_in, int *completions_out, int *restarts_o
         "5:\n\t"
         "str xzr, %[rseq_tls]\n\t"
         /* clang-format on */
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ id ] "=m"(id),
-          [ completions ] "=m"(completions), [ restarts ] "=m"(restarts),
-          [ force_restart_write ] "=m"(force_restart)
-        : [ cpu_id ] "m"(rseq_tls.cpu_id),
-          [ cpu_id_uninit ] "i"(RSEQ_CPU_ID_UNINITIALIZED),
-          [ force_restart ] "m"(force_restart)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id),
+          [completions] "=m"(completions), [restarts] "=m"(restarts),
+          [force_restart_write] "=m"(force_restart)
+        : [cpu_id] "m"(rseq_tls.cpu_id), [cpu_id_uninit] "i"(RSEQ_CPU_ID_UNINITIALIZED),
+          [force_restart] "m"(force_restart)
         : "x0", "x1", "memory");
 #else
 #    error Unsupported arch
@@ -340,10 +339,10 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         "movq $0, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ id ] "=m"(id),
-          [ completions ] "=m"(completions), [ restarts ] "=m"(restarts),
-          [ force_restart_write ] "=m"(force_restart)
-        : [ cpu_id ] "m"(rseq_tls.cpu_id), [ force_restart ] "m"(force_restart)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id),
+          [completions] "=m"(completions), [restarts] "=m"(restarts),
+          [force_restart_write] "=m"(force_restart)
+        : [cpu_id] "m"(rseq_tls.cpu_id), [force_restart] "m"(force_restart)
         : "rax", "rcx", "memory");
 #elif defined(AARCH64)
     __asm__ __volatile__(
@@ -410,10 +409,10 @@ test_rseq_branches_once(bool force_restart, int *completions_out, int *restarts_
         "str xzr, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ id ] "=m"(id),
-          [ completions ] "=m"(completions), [ restarts ] "=m"(restarts),
-          [ force_restart_write ] "=m"(force_restart)
-        : [ cpu_id ] "m"(rseq_tls.cpu_id), [ force_restart ] "m"(force_restart)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id),
+          [completions] "=m"(completions), [restarts] "=m"(restarts),
+          [force_restart_write] "=m"(force_restart)
+        : [cpu_id] "m"(rseq_tls.cpu_id), [force_restart] "m"(force_restart)
         : "x0", "x1", "memory");
 #else
 #    error Unsupported arch
@@ -493,7 +492,7 @@ test_rseq_native_fault(void)
         "movq $0, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ restarts ] "=m"(restarts)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [restarts] "=m"(restarts)
         :
         : "rax", "rcx", "xmm0", "xmm1", "memory");
 #elif defined(AARCH64)
@@ -547,7 +546,7 @@ test_rseq_native_fault(void)
         "str xzr, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ restarts ] "=m"(restarts)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [restarts] "=m"(restarts)
         :
         : "x0", "x1", "q0", "q1", "memory");
 #else
@@ -633,9 +632,9 @@ test_rseq_native_abort(void)
         "movq $0, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ restarts ] "=m"(restarts)
-        : [ cpu_mask_size ] "i"(sizeof(cpu_set_t)),
-          [ sysnum_setaffinity ] "i"(SYS_sched_setaffinity)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [restarts] "=m"(restarts)
+        : [cpu_mask_size] "i"(sizeof(cpu_set_t)),
+          [sysnum_setaffinity] "i"(SYS_sched_setaffinity)
         : "rax", "rcx", "rdx", "xmm0", "xmm1", "memory");
 #    elif defined(AARCH64)
     __asm__ __volatile__(
@@ -706,9 +705,9 @@ test_rseq_native_abort(void)
         "str xzr, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ restarts ] "=m"(restarts)
-        : [ cpu_mask_size ] "i"(sizeof(cpu_set_t)),
-          [ sysnum_setaffinity ] "i"(SYS_sched_setaffinity)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [restarts] "=m"(restarts)
+        : [cpu_mask_size] "i"(sizeof(cpu_set_t)),
+          [sysnum_setaffinity] "i"(SYS_sched_setaffinity)
         : "x0", "x1", "x2", "x8", "q0", "q1", "memory");
 #    else
 #        error Unsupported arch
@@ -770,8 +769,8 @@ test_rseq_writeback_store(void)
         "str xzr, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ id ] "=m"(id), [ index ] "=g"(index)
-        : [ cpu_id ] "m"(rseq_tls.cpu_id)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [id] "=m"(id), [index] "=g"(index)
+        : [cpu_id] "m"(rseq_tls.cpu_id)
         : "x0", "x1", "x2", "x28", "memory");
     assert(id != RSEQ_CPU_ID_UNINITIALIZED);
 }
@@ -837,8 +836,8 @@ rseq_thread_loop(void *arg)
         "movq $0, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ zero ] "=m"(zero)
-        : [ exit_requested ] "m"(exit_requested)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [zero] "=m"(zero)
+        : [exit_requested] "m"(exit_requested)
         : "rax", "memory");
 #    elif defined(AARCH64)
     __asm__ __volatile__(
@@ -888,8 +887,8 @@ rseq_thread_loop(void *arg)
         "str xzr, %[rseq_tls]\n\t"
         /* clang-format on */
 
-        : [ rseq_tls ] "=m"(rseq_tls.rseq_cs), [ zero ] "=m"(zero)
-        : [ exit_requested ] "m"(exit_requested)
+        : [rseq_tls] "=m"(rseq_tls.rseq_cs), [zero] "=m"(zero)
+        : [exit_requested] "m"(exit_requested)
         : "x0", "x1", "memory");
 #    else
 #        error Unsupported arch
@@ -948,6 +947,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 {
     /* Ensure DR_XFER_RSEQ_ABORT is rasied. */
     dr_register_kernel_xfer_event(kernel_xfer_event);
+    drmemtrace_client_main(id, argc, argv);
 }
 #endif /* RSEQ_TEST_ATTACH */
 

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -959,6 +959,10 @@ main()
     int res = syscall(SYS_rseq, &rseq_tls, sizeof(rseq_tls), 0, RSEQ_SIG);
     if (res == 0) {
 #ifdef RSEQ_TEST_ATTACH
+        /* Set -offline to avoid trying to open a pipe to a missing reader. */
+        if (setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline'",
+                   1 /*override*/) != 0)
+            return 1;
         /* Create a thread that sits in the rseq region, to test attaching and detaching
          * from inside the region.
          */


### PR DESCRIPTION
Adds support for multiple app copies in rseq mangling finalization's search for labels to fill in code cache PC's.

Adds support for multiple rseq regions in one fragment_t by expanding the stored rseq_cs per fragment to become a list.

Adds "-trace_after_instrs 5K" to the tool.drcacheoff.rseq test to exercise rseq with drbbdup.

Augments the attach/detach api.rseq test to use drmemtrace, which with the forthcoming #2039 mode switches also hits this multi-rseq case.

Fixes #5659