### PR TITLE
i#5658: Add register barrier at rseq endpoints

### DIFF
--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3968,6 +3968,12 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     bb->end_pc = bb->cur_pc;
     BBPRINT(bb, 3, "end_pc = " PFX "\n\n", bb->end_pc);
 
+    if (TEST(FRAG_HAS_RSEQ_ENDPOINT, bb->flags)) {
+        instr_t *label = INSTR_CREATE_label(dcontext);
+        instr_set_note(label, (void *)DR_NOTE_REG_BARRIER);
+        instrlist_meta_preinsert(bb->ilist, bb->instr, label);
+    }
+
     /* We could put this in check_new_page_jmp where it already checks
      * for native_exec overlap, but selfmod ubrs don't even call that routine
      */

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -931,11 +931,8 @@ mangle_rseq_insert_native_sequence(dcontext_t *dcontext, instrlist_t *ilist,
     RSTATS_INC(num_rseq_native_calls_inserted);
     instr_t *insert_at = *next_instr;
 
-    /* We assume that by making this a block end, clients will restore app state
-     * before this native invocation.
-     * TODO i#2350: Take some further action to better guarantee this in the face
-     * of future drreg optimizations, etc.  Do we need new interface features, or
-     * do we live with a fake app jump or sthg?
+    /* We've already inserted a DR_NOTE_REG_BARRIER label to ensure that clients will
+     * restore app state before this native invocation.
      */
 
     /* Create a scratch register. Use slot 1 to avoid conflict with segment
@@ -1358,7 +1355,8 @@ mangle_rseq(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     int len = instr_length(dcontext, instr);
     if (pc + len >= end) {
         ilist->flags |= INSTR_RSEQ_ENDPOINT;
-        *flags |= FRAG_HAS_RSEQ_ENDPOINT;
+        /* We should already have this flag set by the bb builder. */
+        ASSERT(TEST(FRAG_HAS_RSEQ_ENDPOINT, *flags));
         if (pc + len != end) {
             REPORT_FATAL_ERROR_AND_EXIT(
                 RSEQ_BEHAVIOR_UNSUPPORTED, 3, get_application_name(),

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -849,6 +849,11 @@ enum {
     /** Identifies the end of a clean call. */
     /* This is used to allow instrumentation pre-and-post a clean call for i#4128. */
     DR_NOTE_CLEAN_CALL_END,
+    /**
+     * Identifies a point at which clients should restore all registers to
+     * their application values, as required for DR's internal block mangling.
+     */
+    DR_NOTE_REG_BARRIER,
 };
 
 /**

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -8298,6 +8298,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
             if (xfer && (entered_rseq || exited_rseq || pc == next_boundary)) {
                 LOG(THREAD, LOG_VMAREAS | LOG_INTERP, 3,
                     "Stopping bb at rseq boundary " PFX "\n", pc);
+                if (exited_rseq)
+                    *flags |= FRAG_HAS_RSEQ_ENDPOINT;
                 result = false;
             }
         }


### PR DESCRIPTION
Adds a new label DR_NOTE_REG_BARRIER at each rseq endpoint which is read by drreg and treated as a barrier where all app values are brought back into their registers.  This ensures the native rseq copy has the right input values for cases such as drbbdup where with multiple app block copies registers might not be restored until after the final block instr.

Augments the tool.drcacheoff.rseq test to load from enough registers (on x86 at least) to force drreg to use one of them, reproducing the crash.  With the fix, the crash disappears.

Fixes #5658