### PR TITLE
i#5658 rseq drreg: Put native sequence by barrier

### DIFF
--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3972,6 +3972,10 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     if (TEST(FRAG_HAS_RSEQ_ENDPOINT, bb->flags)) {
         instr_t *label = INSTR_CREATE_label(dcontext);
         instr_set_note(label, (void *)DR_NOTE_REG_BARRIER);
+        /* We want the label after the final rseq instruction.  We've
+         * truncated the block after that instruction so bb->instr may
+         * be NULL so we append.
+         */
         instrlist_meta_append(bb->ilist, label);
     }
 #endif

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3972,7 +3972,7 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
     if (TEST(FRAG_HAS_RSEQ_ENDPOINT, bb->flags)) {
         instr_t *label = INSTR_CREATE_label(dcontext);
         instr_set_note(label, (void *)DR_NOTE_REG_BARRIER);
-        instrlist_meta_preinsert(bb->ilist, bb->instr, label);
+        instrlist_meta_append(bb->ilist, label);
     }
 #endif
 


### PR DESCRIPTION
Fixes PR #5663 which fixed drreg restoration for drbbdup but broke it for non-drbbdup.  bb->instr was NULL so the preinsert was an append, and the label as the last instruction moved the drreg restore point to after the native sequence!

Here, we explicitly append to avoid confusion, and we move the native sequence to the point of the barrier instead of at the final app instr, which is where the registers are actually native.

Tested on larger apps using rseq which reliably crashed without this fix.  This fix also seems to fully fix drbbdup usage with drmemtrace for #2039.

Issue: #5658, #2039