### PR TITLE
i#2039 trace trim, part 2: Add open_file with tid

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -172,6 +172,7 @@ Further non-compatibility-affecting changes include:
  - Added dr_register_post_attach_event(), dr_unregister_post_attach_event(),
    dr_register_pre_detach_event(), and dr_unregister_pre_detach_event().
  - Added insruction encodings to drmemtrace offline traces.
+ - Added drmemtrace_replace_file_ops_ex().
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -671,6 +671,7 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcacheoff.burst_replaceall)
     use_DynamoRIO_extension(tool.drcacheoff.burst_replaceall drcontainers)
     use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.burst_replaceall)
+    link_with_pthread(tool.drcacheoff.burst_replaceall)
 
     add_executable(tool.drcacheoff.burst_malloc tests/burst_malloc.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_malloc)

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -49,6 +49,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <set>
+#ifdef WINDOWS
+#    include <process.h>
+#endif
 
 static void *finished;
 static constexpr int num_threads = 3;

--- a/clients/drcachesim/tests/offline-burst_replaceall.templatex
+++ b/clients/drcachesim/tests/offline-burst_replaceall.templatex
@@ -8,5 +8,9 @@ all done
 Basic counts tool results:
 Total counts:
 .*
+#ifdef WINDOWS
+           1 total threads
+#else
            4 total threads
+#endif
 .*

--- a/clients/drcachesim/tests/offline-burst_replaceall.templatex
+++ b/clients/drcachesim/tests/offline-burst_replaceall.templatex
@@ -5,28 +5,8 @@ pre-DR detach
 processing [0-9]* buffers
 creating module file .*
 all done
-Cache simulation results:
-Core #0 \(1 thread\(s\)\)
-  L1I stats:
-    Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*
-    Compulsory misses:            *[0-9,\.]*
-    Invalidations:                *0
-.*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
-    Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*
-    Compulsory misses:            *[0-9,\.]*
-    Invalidations:                *0
-.*   Miss rate:                        [0-3][,\.]..%
-Core #1 \(0 thread\(s\)\)
-Core #2 \(0 thread\(s\)\)
-Core #3 \(0 thread\(s\)\)
-LL stats:
-    Hits:                         *[0-9,\.]*
-    Misses:                       *[0-9,\.]*
-    Compulsory misses:            *[0-9,\.]*
-    Invalidations:                *0
-.*   Local miss rate:        *[0-9,.]*%
-    Child hits:                   *[0-9,\.]*
-    Total miss rate:                  [0-1][,\.]..%
+Basic counts tool results:
+Total counts:
+.*
+           4 total threads
+.*

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -86,6 +86,26 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[]);
 typedef file_t (*drmemtrace_open_file_func_t)(const char *fname, uint mode_flags);
 
 /**
+ * Function for extended file open.
+ * The file access mode is set by the \p mode_flags argument which is drawn from
+ * the DR_FILE_* defines ORed together.  Returns INVALID_FILE if unsuccessful.
+ * The example behavior is described in dr_open_file();
+ *
+ * @param[in] fname       The filename to open.
+ * @param[in] mode_flags  The DR_FILE_* flags for file open.
+ * @param[in] thread_id   The application thread id targeted by this file.
+ *   For special files (drmemtrace_get_modlist_path(), drmemtrace_get_funclist_path(),
+ *   drmemtrace_get_encoding_path(), or PT files), this will be 0.
+ * @param[in] window_id   The tracing window id for this file.
+ *   For special files (drmemtrace_get_modlist_path(), drmemtrace_get_funclist_path(),
+ *   drmemtrace_get_encoding_path(), or PT files), this will be -1.
+ *
+ * \return the opened file id.
+ */
+typedef file_t (*drmemtrace_open_file_ex_func_t)(const char *fname, uint mode_flags,
+                                                 thread_id_t thread_id, int64 window_id);
+
+/**
  * Function for file read.
  * Reads up to \p count bytes from file \p file into \p buf.
  * Returns the actual number read.
@@ -148,6 +168,18 @@ drmemtrace_replace_file_ops(drmemtrace_open_file_func_t open_file_func,
                             drmemtrace_write_file_func_t write_file_func,
                             drmemtrace_close_file_func_t close_file_func,
                             drmemtrace_create_dir_func_t create_dir_func);
+
+DR_EXPORT
+/**
+ * Identical to drmemtrace_replace_file_ops() except its file open function takes
+ * two extra parameters.
+ */
+drmemtrace_status_t
+drmemtrace_replace_file_ops_ex(drmemtrace_open_file_ex_func_t open_file_ex_func,
+                               drmemtrace_read_file_func_t read_file_func,
+                               drmemtrace_write_file_func_t write_file_func,
+                               drmemtrace_close_file_func_t close_file_func,
+                               drmemtrace_create_dir_func_t create_dir_func);
 
 /**
  * Function for buffer handoff.  Rather than writing a buffer to a

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -373,7 +373,8 @@ open_new_thread_file(void *drcontext, ptr_int_t window_num)
                                    suffix, DRX_FILE_SKIP_OPEN, buf,
                                    BUFFER_SIZE_ELEMENTS(buf));
         NULL_TERMINATE_BUFFER(buf);
-        file_t new_file = file_ops_func.open_file(buf, flags);
+        file_t new_file = file_ops_func.call_open_file(
+            buf, flags, dr_get_thread_id(drcontext), window_num);
         if (new_file == INVALID_FILE)
             continue;
         if (new_file == data->file)

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -183,6 +183,7 @@ enum {
 struct file_ops_func_t {
     file_ops_func_t()
         : open_file(dr_open_file)
+        , open_file_ex(nullptr)
         , read_file(dr_read_file)
         , write_file(dr_write_file)
         , close_file(dr_close_file)
@@ -192,7 +193,21 @@ struct file_ops_func_t {
         , exit_arg(nullptr)
     {
     }
+    file_t
+    call_open_file(const char *fname, uint mode_flags, thread_id_t thread_id,
+                   int64 window_id)
+    {
+        if (open_file_ex != nullptr)
+            return open_file_ex(fname, mode_flags, thread_id, window_id);
+        return open_file(fname, mode_flags);
+    }
+    file_t
+    open_file_special(const char *fname, uint mode_flags)
+    {
+        return call_open_file(fname, mode_flags, 0, -1);
+    }
     drmemtrace_open_file_func_t open_file;
+    drmemtrace_open_file_ex_func_t open_file_ex;
     drmemtrace_read_file_func_t read_file;
     drmemtrace_write_file_func_t write_file;
     drmemtrace_close_file_func_t close_file;

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -201,8 +201,9 @@ struct file_ops_func_t {
             return open_file_ex(fname, mode_flags, thread_id, window_id);
         return open_file(fname, mode_flags);
     }
+    // For process-wide files.
     file_t
-    open_file_special(const char *fname, uint mode_flags)
+    open_process_file(const char *fname, uint mode_flags)
     {
         return call_open_file(fname, mode_flags, 0, -1);
     }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3882,6 +3882,7 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.burst_replaceall_nodr ON)
       torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall ""
         "@-simulator_type@basic_counts" "")
+      unset(tool.drcacheoff.burst_replaceall_rawtemp) # use preprocessor
 
       if (X64 AND UNIX)
         set(tool.drcacheoff.burst_noreach_nodr ON)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3844,7 +3844,8 @@ if (BUILD_CLIENTS)
 
     if (AARCH64)
       set(tool.drcacheoff.burst_aarch64_sys_nodr ON)
-      torunonly_drcacheoff(burst_aarch64_sys tool.drcacheoff.burst_aarch64_sys "" "@-simulator_type@basic_counts" "")
+      torunonly_drcacheoff(burst_aarch64_sys tool.drcacheoff.burst_aarch64_sys ""
+        "@-simulator_type@basic_counts" "")
     endif ()
 
     if (NOT APPLE) # XXX i#1997: static DR not fully supported on Mac yet
@@ -3879,7 +3880,8 @@ if (BUILD_CLIENTS)
       torunonly_drcacheoff(burst_replace tool.drcacheoff.burst_replace "" "" "")
 
       set(tool.drcacheoff.burst_replaceall_nodr ON)
-      torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall "" "" "")
+      torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall ""
+        "@-simulator_type@basic_counts" "")
 
       if (X64 AND UNIX)
         set(tool.drcacheoff.burst_noreach_nodr ON)


### PR DESCRIPTION
Adds drmemtrace_replace_file_ex_ops() with an expanded file opening function which takes in the thread id and window id, to better support the external file opener with delayed opens due to nop mode and windows.

Adds a test of the function to burst_replaceall.  Adds additional threads to the test and checks that the tid for each thread was seen.

Issue: #2039