### PR TITLE
i#5683: Detect bb truncation in drstatecmp

### DIFF
--- a/clients/drcachesim/tests/drstatecmp-delay-simple.templatex
+++ b/clients/drcachesim/tests/drstatecmp-delay-simple.templatex
@@ -1,5 +1,5 @@
 Hit delay threshold: enabling tracing.
-Exiting process after ~1.... references.
+Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)

--- a/clients/drcachesim/tests/offline-drstatecmp-delay-simple.templatex
+++ b/clients/drcachesim/tests/offline-drstatecmp-delay-simple.templatex
@@ -1,0 +1,4 @@
+Hit delay threshold: enabling tracing.
+Hello, world!
+Basic counts tool results:
+.*

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4102,8 +4102,10 @@ if (BUILD_CLIENTS)
       endif ()
     endif ()
     if (NOT WIN32)
-      torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}
-        "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
+      if (NOT ANDROID) # Pipes not working on Android yet (i#1874)
+        torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}
+          "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
+      endif ()
       torunonly_drcacheoff(drstatecmp-delay-simple ${ci_shared_app}
         "-trace_after_instrs 20000 -enable_drstatecmp"
         "@-simulator_type@basic_counts" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3470,14 +3470,6 @@ if (BUILD_CLIENTS)
         "-simulator_type miss_analyzer -miss_count_threshold 5000 -miss_frac_threshold 0.25" "")
     endif ()
 
-    # Stress-test drcachesim with drstatecmp checks.
-    if (AARCH64)
-      torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app "-trace_after_instrs 10M -enable_drstatecmp" "" "")
-    endif ()
-    if (NOT WIN32)
-      torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app} "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
-    endif (NOT WIN32)
-
     # Test other analysis tools
     macro (torunonly_simtool testname exetgt sim_ops app_args)
       torunonly_ci(tool.${testname} ${exetgt} drcachesim
@@ -4101,6 +4093,18 @@ if (BUILD_CLIENTS)
     set(tool.drcacheoff.legacy-int-offs_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
   endif ()
+
+    # Stress-test drcachesim with drstatecmp checks.
+    if (AARCH64)
+      torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app "-trace_after_instrs 10M -enable_drstatecmp" "" "")
+    endif ()
+    if (NOT WIN32)
+      torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}
+        "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
+      torunonly_drcacheoff(drstatecmp-delay-simple ${ci_shared_app}
+        "-trace_after_instrs 20000 -enable_drstatecmp"
+        "@-simulator_type@basic_counts" "")
+    endif (NOT WIN32)
 
   if (proc_supports_pt)
     if (BUILD_PT_TRACER AND BUILD_PT_POST_PROCESSOR)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4096,7 +4096,10 @@ if (BUILD_CLIENTS)
 
     # Stress-test drcachesim with drstatecmp checks.
     if (AARCH64)
-      torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app "-trace_after_instrs 10M -enable_drstatecmp" "" "")
+      if (NOT ANDROID) # Pipes not working on Android yet (i#1874)
+        torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app
+          "-trace_after_instrs 10M -enable_drstatecmp" "" "")
+      endif ()
     endif ()
     if (NOT WIN32)
       torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4036,6 +4036,19 @@ if (BUILD_CLIENTS)
         "${prefetch_analyzer_path}@-trace_dir@${testname_full}.*.dir/trace")
     endif ()
 
+    # Stress-test drcachesim with drstatecmp checks.
+    if (AARCH64)
+      torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app
+        "-trace_after_instrs 10M -enable_drstatecmp" "" "")
+    endif ()
+    if (NOT WIN32)
+      torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}
+        "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
+      torunonly_drcacheoff(drstatecmp-delay-simple ${ci_shared_app}
+        "-trace_after_instrs 20000 -enable_drstatecmp"
+        "@-simulator_type@basic_counts" "")
+    endif (NOT WIN32)
+
   endif (NOT ANDROID)
 
   # Test using our exported drmemtrace analysis framework (i#2006).
@@ -4093,23 +4106,6 @@ if (BUILD_CLIENTS)
     set(tool.drcacheoff.legacy-int-offs_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
   endif ()
-
-    # Stress-test drcachesim with drstatecmp checks.
-    if (AARCH64)
-      if (NOT ANDROID) # Pipes not working on Android yet (i#1874)
-        torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app
-          "-trace_after_instrs 10M -enable_drstatecmp" "" "")
-      endif ()
-    endif ()
-    if (NOT WIN32)
-      if (NOT ANDROID) # Pipes not working on Android yet (i#1874)
-        torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}
-          "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
-      endif ()
-      torunonly_drcacheoff(drstatecmp-delay-simple ${ci_shared_app}
-        "-trace_after_instrs 20000 -enable_drstatecmp"
-        "@-simulator_type@basic_counts" "")
-    endif (NOT WIN32)
 
   if (proc_supports_pt)
     if (BUILD_PT_TRACER AND BUILD_PT_POST_PROCESSOR)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4047,7 +4047,7 @@ if (BUILD_CLIENTS)
     endif ()
     if (NOT WIN32)
       torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}
-        "-trace_after_instrs 20000 -exit_after_tracing 10000 -enable_drstatecmp" "")
+        "-trace_after_instrs 20000 -enable_drstatecmp" "")
       torunonly_drcacheoff(drstatecmp-delay-simple ${ci_shared_app}
         "-trace_after_instrs 20000 -enable_drstatecmp"
         "@-simulator_type@basic_counts" "")


### PR DESCRIPTION
Checks for block truncation in drstatecmp so it can use the post-app2app ilist instead of incorrectly using the untruncated version in its state comparison.

Adds a test of drcachesim offline that fails with a false positive without this fix.

Fixes #5683