### PR TITLE
i#5520 memtrace encodings: Fix pdf path

### DIFF
--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -50,7 +50,7 @@ online and offline.
 
 \b News: There are some new features coming to drmemtrace traces:
 embedded instruction encodings and fast seeking.  Please see the
-[slides introducing these features](new-features-encodings-seek.pdf).
+[slides introducing these features](docs/new-features-encodings-seek.pdf).
 
  - \subpage sec_drcachesim
  - \subpage sec_drcachesim_format


### PR DESCRIPTION
We have perma-links to redirect our html pages to the root directory, but other files are in the docs/ directory.

Issue: #5520