### PR TITLE
i#5688: Fix uninitialized state restore field

### DIFF
--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -682,7 +682,8 @@ typedef struct _dr_fault_fragment_info_t {
     /**
      * The start address of the code fragment inside the code cache at
      * the exception/signal/translation interruption point. NULL for interruption
-     * not in the code cache.  Clients are cautioned when examining
+     * not in the code cache (in which case generally only unusual cases of clients
+     * changing memory require restoration).  Clients are cautioned when examining
      * code cache instructions to not rely on any details of code
      * inserted other than their own.
      */
@@ -706,7 +707,8 @@ typedef struct _dr_fault_fragment_info_t {
      * When the recreated ilist is not available, this is set to NULL. This
      * may happen when a client returns #DR_EMIT_STORE_TRANSLATIONS, or for
      * DR internal reasons when the app code may not be consistent: for pending
-     * deletion or self-modifying fragments.
+     * deletion or self-modifying fragments.  It will also be NULL for non-code-cache
+     * cases where \p cache_start_pc is also NULL.
      */
     instrlist_t *ilist;
 } dr_fault_fragment_info_t;

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1900,6 +1900,7 @@ instrument_restore_nonfcache_state_prealloc(dcontext_t *dcontext, bool restore_m
     client_info.fragment_info.cache_start_pc = NULL;
     client_info.fragment_info.is_trace = false;
     client_info.fragment_info.app_code_consistent = true;
+    client_info.fragment_info.ilist = NULL;
     bool res = instrument_restore_state(dcontext, restore_memory, &client_info);
     dr_mcontext_to_priv_mcontext(mcontext, client_mcontext);
     return res;


### PR DESCRIPTION
instrument_restore_nonfcache_state_prealloc() was creating a dr_restore_state_info_t structure but leaving its fragment_info.ilist field unintialized.  We fix that here.

Tested on the forthcoming drbbdup state restore event (#5686) which crashed walking the bogus ilist without this fix.

Fixes #5688