### PR TITLE
i#5434: Remove reliance on SIGSTKSZ and related defines

### DIFF
--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -509,6 +509,8 @@ const reg_id_t syscall_regparms[MAX_SYSCALL_ARGS] = {
  */
 static size_t page_size = 0;
 
+static size_t auxv_minsigstksz = 0;
+
 /* Return true if size is a multiple of the page size.
  * XXX: This function may be called when DynamoRIO is in a fragile state, or not
  * yet relocated, so keep this self-contained and do not use global variables or
@@ -577,6 +579,18 @@ os_page_size(void)
     return size;
 }
 
+/* With SIGSTKSZ now in sysconf and an auxv var AT_MINSIGSTKSZ we avoid
+ * using the defines and try to lookup the min value in os_page_size_init().
+ */
+size_t
+os_minsigstksz(void)
+{
+#define MINSIGSTKSZ_DEFAULT 2048
+    if (auxv_minsigstksz == 0)
+        return MINSIGSTKSZ_DEFAULT;
+    return auxv_minsigstksz;
+}
+
 void
 os_page_size_init(const char **env, bool env_followed_by_auxv)
 {
@@ -595,12 +609,18 @@ os_page_size_init(const char **env, bool env_followed_by_auxv)
         /* Skip environment. */
         while (*env != 0)
             ++env;
-        /* Look for AT_PAGESZ in the auxiliary vector. */
+        /* Look for AT_PAGESZ and other values in the auxiliary vector. */
         for (auxv = (ELF_AUXV_TYPE *)(env + 1); auxv->a_type != AT_NULL; auxv++) {
             if (auxv->a_type == AT_PAGESZ) {
                 os_set_page_size(auxv->a_un.a_val);
                 break;
             }
+#    ifdef AT_MINSIGSTKSZ
+            else if (auxv->a_type == AT_MINSIGSTKSZ) {
+                auxv_minsigstksz = auxv->a_un.a_val;
+                break;
+            }
+#    endif
         }
     }
 #endif /* LINUX */

--- a/core/drlibc/drlibc_unix.c
+++ b/core/drlibc/drlibc_unix.c
@@ -585,7 +585,11 @@ os_page_size(void)
 size_t
 os_minsigstksz(void)
 {
-#define MINSIGSTKSZ_DEFAULT 2048
+#ifdef AARCH64
+#    define MINSIGSTKSZ_DEFAULT 5120
+#else
+#    define MINSIGSTKSZ_DEFAULT 2048
+#endif
     if (auxv_minsigstksz == 0)
         return MINSIGSTKSZ_DEFAULT;
     return auxv_minsigstksz;

--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -452,8 +452,11 @@ get_dynamorio_library_path(void);
 size_t
 os_page_size(void);
 #ifdef UNIX
+/* This also tries to set other auxv values. */
 void
 os_page_size_init(const char **env, bool env_followed_by_auxv);
+size_t
+os_minsigstksz(void);
 #endif
 bool
 get_memory_info(const byte *pc, byte **base_pc, size_t *size, uint *prot);

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -61,7 +61,6 @@
 #    endif
 #    include <ucontext.h>
 #    include <unistd.h>
-#    include <linux/version.h>
 #    include "../../core/unix/os_public.h"
 #    ifdef X64
 /* XCode 10.1 (probably others too) toolchain wants _STRUCT_MCONTEXT
@@ -90,10 +89,13 @@
 #undef PFX
 #define PFX "0x" PFMT
 
-#if defined(UNIX) && defined(AARCH64) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+#ifdef LINUX
+#    include <linux/version.h>
+#    if defined(AARCH64) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
 /* SIGSTKSZ was incorrectly defined in Linux releases before 4.3. */
-#    undef SIGSTKSZ
-#    define SIGSTKSZ 16384
+#        undef SIGSTKSZ
+#        define SIGSTKSZ 16384
+#    endif
 #endif
 
 #ifdef __cplusplus

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -61,6 +61,7 @@
 #    endif
 #    include <ucontext.h>
 #    include <unistd.h>
+#    include <linux/version.h>
 #    include "../../core/unix/os_public.h"
 #    ifdef X64
 /* XCode 10.1 (probably others too) toolchain wants _STRUCT_MCONTEXT
@@ -89,7 +90,7 @@
 #undef PFX
 #define PFX "0x" PFMT
 
-#if defined(AARCH64) && SIGSTKSZ < 16384
+#if defined(UNIX) && defined(AARCH64) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
 /* SIGSTKSZ was incorrectly defined in Linux releases before 4.3. */
 #    undef SIGSTKSZ
 #    define SIGSTKSZ 16384


### PR DESCRIPTION
SIGSTKSZ and MINSIGSTKSZ are moving away from being constants. SIGSTKSZ is now a call to sysconf().

This was causing a build error building our tests, which is fixed using the suggestion from Stanislaw Kardach.

For the core, we eliminate the constants to avoid invoking libc.  We look for AT_MINSIGSTKSIZE in our existing auxv search code and if not found we fall back to a hardcoded value.

Co-authored-by: Stanislaw Kardach <kda@semihalf.com>
Fixes #5434