### PR TITLE
Add initialization of emulation_info to exclude unavoidable DR_ASSERT.

### DIFF
--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -132,12 +132,12 @@ private:
         // instead of the pop into pc which assumes the entry pushed lr?
         instrlist_append(ilist, INSTR_CREATE_bx(dc, opnd_create_reg(DR_REG_LR)));
 #else
-#ifdef X86
+#    ifdef X86
         instrlist_append(ilist,
                          INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_RCX),
                                           opnd_create_reg(DR_REG_RCX)));
         instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));
-#endif
+#    endif
         instrlist_append(ilist, XINST_CREATE_return(dc));
 #endif
 

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -134,7 +134,7 @@ private:
 #else
         instrlist_append(ilist,
                          INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_RCX),
-                                            opnd_create_reg(DR_REG_RCX)));
+                                          opnd_create_reg(DR_REG_RCX)));
         instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));        
         instrlist_append(ilist, XINST_CREATE_return(dc));
 #endif

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -133,7 +133,7 @@ private:
         instrlist_append(ilist, INSTR_CREATE_bx(dc, opnd_create_reg(DR_REG_LR)));
 #else
 #    ifdef X86
-        // Zero-iter rep-movs loop for testing emulation-marked code 
+        // Zero-iter rep-movs loop for testing emulation-marked code
         // written to the encoding file.
         instrlist_append(ilist,
                          INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_XCX),

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -135,7 +135,7 @@ private:
         instrlist_append(ilist,
                          INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_RCX),
                                           opnd_create_reg(DR_REG_RCX)));
-        instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));        
+        instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));
         instrlist_append(ilist, XINST_CREATE_return(dc));
 #endif
 

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -133,11 +133,14 @@ private:
         instrlist_append(ilist, INSTR_CREATE_bx(dc, opnd_create_reg(DR_REG_LR)));
 #else
 #    ifdef X86
+        // Zero-iter rep-movs loop for testing emulation-marked code 
+        // written to the encoding file.
         instrlist_append(ilist,
-                         INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_RCX),
-                                          opnd_create_reg(DR_REG_RCX)));
+                         INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_XCX),
+                                          opnd_create_reg(DR_REG_XCX)));
         instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));
 #    endif
+        
         instrlist_append(ilist, XINST_CREATE_return(dc));
 #endif
 

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -140,7 +140,7 @@ private:
                                           opnd_create_reg(DR_REG_XCX)));
         instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));
 #    endif
-        
+
         instrlist_append(ilist, XINST_CREATE_return(dc));
 #endif
 

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -132,10 +132,12 @@ private:
         // instead of the pop into pc which assumes the entry pushed lr?
         instrlist_append(ilist, INSTR_CREATE_bx(dc, opnd_create_reg(DR_REG_LR)));
 #else
+#ifdef X86
         instrlist_append(ilist,
                          INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_RCX),
                                           opnd_create_reg(DR_REG_RCX)));
         instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));
+#endif
         instrlist_append(ilist, XINST_CREATE_return(dc));
 #endif
 

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -132,6 +132,10 @@ private:
         // instead of the pop into pc which assumes the entry pushed lr?
         instrlist_append(ilist, INSTR_CREATE_bx(dc, opnd_create_reg(DR_REG_LR)));
 #else
+        instrlist_append(ilist,
+                         INSTR_CREATE_xor(dc, opnd_create_reg(DR_REG_RCX),
+                                            opnd_create_reg(DR_REG_RCX)));
+        instrlist_append(ilist, INSTR_CREATE_rep_movs_1(dc));        
         instrlist_append(ilist, XINST_CREATE_return(dc));
 #endif
 

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -476,7 +476,7 @@ offline_instru_t::record_instr_encodings(void *drcontext, app_pc tag_pc,
     for (instr_t *instr = instrlist_first(ilist); instr != NULL;
          instr = instr_get_next(instr)) {
         instr_t *to_copy = nullptr;
-        emulated_instr_t emulation_info = {};
+        emulated_instr_t emulation_info = { sizeof(emulation_info), 0 };
         if (in_emulation_region) {
             if (drmgr_is_emulation_end(instr))
                 in_emulation_region = false;


### PR DESCRIPTION
Default initialization produces DR_ASSERT each time because drmgr_get_emulated_instr_data retruns false in this case
```
        ...
        } else if (drmgr_is_emulation_start(instr)) {
            bool ok = drmgr_get_emulated_instr_data(instr, &emulation_info);
            DR_ASSERT(ok);
        ...
```
```
DR_EXPORT
bool
drmgr_get_emulated_instr_data(instr_t *instr, emulated_instr_t *emulated)
{
    ASSERT(instr_is_label(instr), "emulation instruction does not have a label");
    ASSERT(drmgr_is_emulation_start(instr), "instruction is not a start emulation label");

    if (emulated->size < offsetof(emulated_instr_t, flags))
        return false;
   ...
```