### PR TITLE
Fix EVEX-prefixed vsqrtss/vsqrtsd merge operand sizes

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -9320,10 +9320,10 @@ const instr_info_t evex_Wb_extensions[][4] = {
     {OP_vsqrtpd, 0x660f5140, "vsqrtpd", Ved, xx, KEb, Wed, xx, mrm|evex|ttfv, x, modx[119][0]},
     {MOD_EXT, 0x660f5150, "(mod ext 119)", xx, xx, xx, xx, xx, mrm|evex, x, 119},
   }, { /* evex_W_ext 266 */
-    {OP_vsqrtss, 0xf30f5100, "vsqrtss", Vdq, xx, KE1b, Hdq, Wss, mrm|evex|ttt1s, x, tevexwb[266][1]},
-    {OP_vsqrtss, 0xf30f5110, "vsqrtss", Vdq, xx, KE1b, Hdq, Uss, mrm|evex|er|ttt1s, x, END_LIST},
-    {OP_vsqrtsd, 0xf20f5140, "vsqrtsd", Vdq, xx, KE1b, Hdq, Wsd, mrm|evex|ttt1s, x, tevexwb[266][3]},
-    {OP_vsqrtsd, 0xf20f5150, "vsqrtsd", Vdq, xx, KE1b, Hdq, Usd, mrm|evex|er|ttt1s, x, END_LIST},
+    {OP_vsqrtss, 0xf30f5100, "vsqrtss", Vdq, xx, KE1b, H12_dq, Wss, mrm|evex|ttt1s, x, tevexwb[266][1]},
+    {OP_vsqrtss, 0xf30f5110, "vsqrtss", Vdq, xx, KE1b, H12_dq, Uss, mrm|evex|er|ttt1s, x, END_LIST},
+    {OP_vsqrtsd, 0xf20f5140, "vsqrtsd", Vdq, xx, KE1b, Hsd, Wsd, mrm|evex|ttt1s, x, tevexwb[266][3]},
+    {OP_vsqrtsd, 0xf20f5150, "vsqrtsd", Vdq, xx, KE1b, Hsd, Usd, mrm|evex|er|ttt1s, x, END_LIST},
   }, { /* evex_W_ext 267 */
     {OP_vpdpbusd, 0x66385008, "vpdpbusd", Ve, xx, KEd, He, We, mrm|evex|ttfv|reqp, x, tevexwb[267][1]},
     {OP_vpdpbusd, 0x66385018, "vpdpbusd", Ve, xx, KEd, He, Md, mrm|evex|ttfv|reqp, x, END_LIST},

--- a/suite/tests/api/ir_x86_4args_avx512_evex_mask_C.h
+++ b/suite/tests/api/ir_x86_4args_avx512_evex_mask_C.h
@@ -1944,21 +1944,21 @@ OPCODE(vpmadd52luq_zhik7zhild, vpmadd52luq, vpmadd52luq_mask, X64_ONLY, REGARG(Z
 OPCODE(vpmadd52luq_zhik7zhibcst, vpmadd52luq, vpmadd52luq_mask, X64_ONLY, REGARG(ZMM16),
        REGARG(K7), REGARG(ZMM17), MEMARG(OPSZ_8))
 OPCODE(vsqrtss_xlok0xloxlo, vsqrtss, vsqrtss_mask, 0, REGARG(XMM0), REGARG(K0),
-       REGARG(XMM1), REGARG_PARTIAL(XMM2, OPSZ_4))
+       REGARG_PARTIAL(XMM1, OPSZ_12), REGARG_PARTIAL(XMM2, OPSZ_4))
 OPCODE(vsqrtss_xlok0xlomem, vsqrtss, vsqrtss_mask, 0, REGARG(XMM0), REGARG(K0),
-       REGARG(XMM1), MEMARG(OPSZ_4))
+       REGARG_PARTIAL(XMM1, OPSZ_12), MEMARG(OPSZ_4))
 OPCODE(vsqrtss_xhik7xhixhi, vsqrtss, vsqrtss_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
-       REGARG(XMM17), REGARG_PARTIAL(XMM18, OPSZ_4))
+       REGARG_PARTIAL(XMM17, OPSZ_12), REGARG_PARTIAL(XMM18, OPSZ_4))
 OPCODE(vsqrtss_xhik7xhimem, vsqrtss, vsqrtss_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
-       REGARG(XMM17), MEMARG(OPSZ_4))
+       REGARG_PARTIAL(XMM17, OPSZ_12), MEMARG(OPSZ_4))
 OPCODE(vsqrtsd_xlok0xloxlo, vsqrtsd, vsqrtsd_mask, 0, REGARG(XMM0), REGARG(K0),
-       REGARG(XMM1), REGARG_PARTIAL(XMM2, OPSZ_8))
+       REGARG_PARTIAL(XMM1, OPSZ_8), REGARG_PARTIAL(XMM2, OPSZ_8))
 OPCODE(vsqrtsd_xlok0xlomem, vsqrtsd, vsqrtsd_mask, 0, REGARG(XMM0), REGARG(K0),
-       REGARG(XMM1), MEMARG(OPSZ_8))
+       REGARG_PARTIAL(XMM1, OPSZ_8), MEMARG(OPSZ_8))
 OPCODE(vsqrtsd_xhik7xhixhi, vsqrtsd, vsqrtsd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
-       REGARG(XMM17), REGARG_PARTIAL(XMM18, OPSZ_8))
+       REGARG_PARTIAL(XMM17, OPSZ_8), REGARG_PARTIAL(XMM18, OPSZ_8))
 OPCODE(vsqrtsd_xhik7xhimem, vsqrtsd, vsqrtsd_mask, X64_ONLY, REGARG(XMM16), REGARG(K7),
-       REGARG(XMM17), MEMARG(OPSZ_8))
+       REGARG_PARTIAL(XMM17, OPSZ_8), MEMARG(OPSZ_8))
 /* AVX512 VNNI */
 OPCODE(vpdpbusd_zhik7zhizhi, vpdpbusd, vpdpbusd_mask, X64_ONLY, REGARG(ZMM0), REGARG(K3),
        REGARG(ZMM24), REGARG(ZMM31))


### PR DESCRIPTION
The EVEX-prefixed vsqrtss/vsqrtsd entries should take three-quarter and half width merge operands respectively, like their VEX-prefixed counterparts.

This was an oversight when I wrote #4739.