### PR TITLE
i#2039 trace trim, part 3: Add nop mode to drmemtrace

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -178,6 +178,7 @@ Further non-compatibility-affecting changes include:
    dr_register_pre_detach_event(), and dr_unregister_pre_detach_event().
  - Added insruction encodings to drmemtrace offline traces.
  - Added drmemtrace_replace_file_ops_ex().
+ - Added -align_endpoints to drmemtrace to avoid uneven attach/detach periods.
 
 The changes between version 9.0.1 and 9.0.0 include the following compatibility
 changes:

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -288,7 +288,7 @@ droption_t<bytesize_t> op_max_global_trace_refs(
 droption_t<bool> op_align_endpoints(
     // XXX i#2039,i#5686: Make this true by default (and maybe remove it altogether) once
     // robustness issues with drbbdup are fixed (restore state for scatter/gather and
-    // other libs; yet-diagnosed other state restore issues).
+    // other libs; yet-undiagnosed other state restore issues).
     DROPTION_SCOPE_CLIENT, "align_endpoints", false,
     "Nop tracing when partially attached or detached",
     "When using attach/detach to trace a burst, the attach and detach processes are "

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -285,6 +285,19 @@ droption_t<bytesize_t> op_max_global_trace_refs(
     "This is similar to -exit_after_tracing but without terminating the process."
     "The reference count is approximate.");
 
+droption_t<bool> op_align_endpoints(
+    // XXX i#2039,i#5686: Make this true by default (and maybe remove it altogether) once
+    // robustness issues with drbbdup are fixed (restore state for scatter/gather and
+    // other libs; yet-diagnosed other state restore issues).
+    DROPTION_SCOPE_CLIENT, "align_endpoints", false,
+    "Nop tracing when partially attached or detached",
+    "When using attach/detach to trace a burst, the attach and detach processes are "
+    "staggered, with the set of threads producing trace data incrementally growing or "
+    "shrinking.  This results in uneven thread activity at the start and end of the "
+    "burst.  If this option is enabled, tracing is nop-ed until fully attached to "
+    "all threads and is nop-ed as soon as detach starts, eliminating the unevenness. "
+    "This also allows omitting threads that did nothing during the burst.");
+
 droption_t<bytesize_t> op_trace_after_instrs(
     DROPTION_SCOPE_CLIENT, "trace_after_instrs", 0,
     "Do not start tracing until N instructions",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -92,6 +92,7 @@ extern droption_t<unsigned int> op_virt2phys_freq;
 extern droption_t<bool> op_cpu_scheduling;
 extern droption_t<bytesize_t> op_max_trace_size;
 extern droption_t<bytesize_t> op_max_global_trace_refs;
+extern droption_t<bool> op_align_endpoints;
 extern droption_t<bytesize_t> op_trace_after_instrs;
 extern droption_t<bytesize_t> op_trace_for_instrs;
 extern droption_t<bytesize_t> op_retrace_every_instrs;

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -196,7 +196,8 @@ post_process()
             dir.modfile_bytes_, parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(module_mapper->get_last_error().empty());
         // Test back-compat of deprecated APIs.
-        raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_, {});
+        raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
+                              dir.out_archives_);
         std::string error =
             raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
         assert(error.empty());

--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -53,9 +53,12 @@
 #include "../../../suite/tests/condvar.h"
 
 static const int num_threads = 8;
+static const int num_idle_threads = 4;
 static const int burst_owner = 4;
 static bool finished[num_threads];
+static void *burst_owner_starting;
 static void *burst_owner_finished;
+static void *idle_should_exit;
 
 bool
 my_setenv(const char *var, const char *value)
@@ -105,6 +108,11 @@ void *
     assert(res == 0);
 #endif
 
+    if (idx != burst_owner)
+        wait_cond_var(burst_owner_starting);
+    else
+        signal_cond_var(burst_owner_starting);
+
     /* We use an outer loop to test re-attaching (i#2157). */
     for (int j = 0; j < reattach_iters; ++j) {
         if (idx == burst_owner) {
@@ -153,32 +161,60 @@ void *
     return 0;
 }
 
+#ifdef WINDOWS
+unsigned int __stdcall
+#else
+void *
+#endif
+    idle_thread_func(void *arg)
+{
+    wait_cond_var(idle_should_exit);
+    return 0;
+}
+
 int
 main(int argc, const char *argv[])
 {
 #ifdef UNIX
     pthread_t thread[num_threads];
+    pthread_t idle_thread[num_threads];
 #else
     uintptr_t thread[num_threads];
+    uintptr_t idle_thread[num_threads];
 #endif
 
-    /* While the start/stop thread only runs 4 iters, the other threads end up
-     * running more and their trace files get up to 65MB or more, with the
-     * merged result several GB's: too much for a test.  We thus cap each thread.
-     */
-    if (!my_setenv("DYNAMORIO_OPTIONS",
-                   // We set -disable_traces to help stress state recreation
-                   // in drbbdup with prefixes on every block.
-                   "-stderr_mask 0xc -disable_traces -client_lib ';;"
-                   "-offline -max_trace_size 256K'"))
+    // While the start/stop thread only runs 4 iters, the other threads end up
+    // running more and their trace files get up to 65MB or more, with the
+    // merged result several GB's: too much for a test.  We thus cap each thread.
+    // We set -disable_traces to help stress state recreation
+    // in drbbdup with prefixes on every block.
+    std::string ops = std::string(
+        "-stderr_mask 0xc -disable_traces -client_lib ';;-offline -align_endpoints "
+        "-max_trace_size 256K ");
+    /* Support passing in extra tracer options. */
+    for (int i = 1; i < argc; ++i)
+        ops += std::string(argv[i]) + " ";
+    ops += "'";
+    if (!my_setenv("DYNAMORIO_OPTIONS", ops.c_str()))
         std::cerr << "failed to set env var!\n";
 
+    burst_owner_starting = create_cond_var();
     burst_owner_finished = create_cond_var();
     for (uint i = 0; i < num_threads; i++) {
 #ifdef UNIX
         pthread_create(&thread[i], NULL, thread_func, (void *)(uintptr_t)i);
 #else
         thread[i] = _beginthreadex(NULL, 0, thread_func, (void *)(uintptr_t)i, 0, NULL);
+#endif
+    }
+    // Now create some threads that do nothing to test -align_endpoints omitting them.
+    idle_should_exit = create_cond_var();
+    for (uint i = 0; i < num_idle_threads; i++) {
+#ifdef UNIX
+        pthread_create(&idle_thread[i], NULL, idle_thread_func, (void *)(uintptr_t)i);
+#else
+        idle_thread[i] =
+            _beginthreadex(NULL, 0, idle_thread_func, (void *)(uintptr_t)i, 0, NULL);
 #endif
     }
     for (uint i = 0; i < num_threads; i++) {
@@ -192,7 +228,17 @@ main(int argc, const char *argv[])
         if (!finished[i])
             std::cerr << "thread " << i << " failed to finish\n";
     }
+    signal_cond_var(idle_should_exit);
+    for (uint i = 0; i < num_idle_threads; i++) {
+#ifdef UNIX
+        pthread_join(idle_thread[i], NULL);
+#else
+        WaitForSingleObject((HANDLE)idle_thread[i], INFINITE);
+#endif
+    }
     std::cerr << "all done\n";
+    destroy_cond_var(burst_owner_starting);
     destroy_cond_var(burst_owner_finished);
+    destroy_cond_var(idle_should_exit);
     return 0;
 }

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -6,6 +6,7 @@ create dir .*
 open file .*
 open file .*
 pre-DR start
+open file .*
 0: writing [0-9]+ bytes .*
 1: writing [0-9]+ bytes .*
 restore the write file function

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -5,14 +5,18 @@ create dir .*
 create dir .*
 open file .*
 open file .*
-pre-DR start
 open file .*
+open file .*
+pre-DR start
 0: writing [0-9]+ bytes .*
 1: writing [0-9]+ bytes .*
 restore the write file function
 pre-DR detach
 close file .*
 2: writing [0-9]+ bytes .*
+3: writing [0-9]+ bytes .*
+close file .*
+close file .*
 close file .*
 all done
 Cache simulation results:

--- a/clients/drcachesim/tests/offline-burst_threads_counts.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads_counts.templatex
@@ -21,5 +21,5 @@ Total counts:
      .* total data stores
      .* total icache flushes
      .* total dcache flushes
-           [2-8] total threads
+          [ 1][0-9] total threads
 .*

--- a/clients/drcachesim/tests/offline-burst_threads_counts.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads_counts.templatex
@@ -1,0 +1,25 @@
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+pre-DR init
+pre-DR start
+pre-DR detach
+all done
+Basic counts tool results:
+Total counts:
+     .* total \(fetched\) instructions
+     .* total unique \(fetched\) instructions
+     .* total non-fetched instructions
+     .* total prefetches
+     .* total data loads
+     .* total data stores
+     .* total icache flushes
+     .* total dcache flushes
+           [2-8] total threads
+.*

--- a/clients/drcachesim/tracer/instr_counter.cpp
+++ b/clients/drcachesim/tracer/instr_counter.cpp
@@ -116,7 +116,7 @@ hit_instr_count_threshold(app_pc next_pc)
     }
 #endif
     dr_mutex_lock(mutex);
-    if (tracing_disabled.load(std::memory_order_acquire) == BBDUP_MODE_TRACE) {
+    if (tracing_mode.load(std::memory_order_acquire) == BBDUP_MODE_TRACE) {
         // Another thread already changed the mode.
         dr_mutex_unlock(mutex);
         return;
@@ -141,8 +141,8 @@ hit_instr_count_threshold(app_pc next_pc)
     // portably safe to take the address of std::atomic, so we rely on our mutex.
     instr_count = 0;
 #endif
-    DR_ASSERT(tracing_disabled.load(std::memory_order_acquire) == BBDUP_MODE_COUNT);
-    tracing_disabled.store(BBDUP_MODE_TRACE, std::memory_order_release);
+    DR_ASSERT(tracing_mode.load(std::memory_order_acquire) == BBDUP_MODE_COUNT);
+    tracing_mode.store(BBDUP_MODE_TRACE, std::memory_order_release);
     dr_mutex_unlock(mutex);
 }
 

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -912,7 +912,7 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
     if (op_offline.get_value() && data->file == INVALID_FILE) {
         // We've delayed opening a new window file to avoid an empty final file.
         DR_ASSERT(has_tracing_windows() || op_trace_after_instrs.get_value() > 0 ||
-                  attached_to_process);
+                  attached_midway);
         open_new_thread_file(drcontext, get_local_window(data));
     }
 

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -138,8 +138,8 @@ reached_traced_instrs_threshold(void *drcontext)
     tracing_window.fetch_add(1, std::memory_order_release);
     // We delay creating a new ouput dir until tracing is enabled again, to avoid
     // an empty final dir.
-    DR_ASSERT(tracing_disabled.load(std::memory_order_acquire) == BBDUP_MODE_TRACE);
-    tracing_disabled.store(BBDUP_MODE_COUNT, std::memory_order_release);
+    DR_ASSERT(tracing_mode.load(std::memory_order_acquire) == BBDUP_MODE_TRACE);
+    tracing_mode.store(BBDUP_MODE_COUNT, std::memory_order_release);
     cur_window_instr_count.store(0, std::memory_order_release);
     dr_mutex_unlock(mutex);
 }
@@ -911,7 +911,8 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
 
     if (op_offline.get_value() && data->file == INVALID_FILE) {
         // We've delayed opening a new window file to avoid an empty final file.
-        DR_ASSERT(has_tracing_windows() || op_trace_after_instrs.get_value() > 0);
+        DR_ASSERT(has_tracing_windows() || op_trace_after_instrs.get_value() > 0 ||
+                  attached_to_process);
         open_new_thread_file(drcontext, get_local_window(data));
     }
 
@@ -1087,7 +1088,7 @@ init_thread_io(void *drcontext)
         set_local_window(drcontext, tracing_window.load(std::memory_order_acquire));
 
     if (op_offline.get_value()) {
-        if (tracing_disabled.load(std::memory_order_acquire) == BBDUP_MODE_TRACE) {
+        if (tracing_mode.load(std::memory_order_acquire) == BBDUP_MODE_TRACE) {
             open_new_thread_file(drcontext, get_local_window(data));
         }
         if (!has_tracing_windows()) {
@@ -1115,8 +1116,15 @@ exit_thread_io(void *drcontext)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
 
-    if (tracing_disabled.load(std::memory_order_acquire) == BBDUP_MODE_TRACE ||
-        !op_split_windows.get_value()) {
+    if (tracing_mode.load(std::memory_order_acquire) == BBDUP_MODE_TRACE ||
+        (has_tracing_windows() && !op_split_windows.get_value()) ||
+        // For attach we switch to BBDUP_MODE_NOP but still need to finalize
+        // each thread.  However, we omit threads that did nothing the entire time
+        // we were attached.
+        (align_attach_detach_endpoints() &&
+         (data->bytes_written > 0 ||
+          BUF_PTR(data->seg_base) - data->buf_base >
+              static_cast<ssize_t>(data->init_header_size + buf_hdr_slots_size)))) {
         BUF_PTR(data->seg_base) += instru->append_thread_exit(
             BUF_PTR(data->seg_base), dr_get_thread_id(drcontext));
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -156,12 +156,19 @@ size_t buf_hdr_slots_size;
 static bool (*should_trace_thread_cb)(thread_id_t tid, void *user_data);
 static void *trace_thread_cb_user_data;
 static bool thread_filtering_enabled;
+bool attached_to_process;
+
+static bool
+bbdup_instr_counting_enabled()
+{
+    return op_trace_after_instrs.get_value() > 0 || op_trace_for_instrs.get_value() > 0 ||
+        op_retrace_every_instrs.get_value() > 0;
+}
 
 static bool
 bbdup_duplication_enabled()
 {
-    return op_trace_after_instrs.get_value() > 0 || op_trace_for_instrs.get_value() > 0 ||
-        op_retrace_every_instrs.get_value() > 0;
+    return attached_to_process || bbdup_instr_counting_enabled();
 }
 
 std::atomic<ptr_int_t> tracing_window;
@@ -198,7 +205,7 @@ instru_notify(uint level, const char *fmt, ...)
 /* This holds one of the BBDUP_MODE_ enum values, but drbbdup requires that it
  * be pointer-sized.
  */
-std::atomic<ptr_int_t> tracing_disabled;
+std::atomic<ptr_int_t> tracing_mode;
 
 static dr_emit_flags_t
 event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
@@ -235,9 +242,15 @@ event_bb_setup(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
     DR_ASSERT(enable_dups != NULL && enable_dynamic_handling != NULL);
     if (bbdup_duplication_enabled()) {
         *enable_dups = true;
-        drbbdup_status_t res =
-            drbbdup_register_case_encoding(drbbdup_ctx, BBDUP_MODE_COUNT);
-        DR_ASSERT(res == DRBBDUP_SUCCESS);
+        drbbdup_status_t res;
+        if (align_attach_detach_endpoints()) {
+            res = drbbdup_register_case_encoding(drbbdup_ctx, BBDUP_MODE_NOP);
+            DR_ASSERT(res == DRBBDUP_SUCCESS);
+        }
+        if (bbdup_instr_counting_enabled()) {
+            res = drbbdup_register_case_encoding(drbbdup_ctx, BBDUP_MODE_COUNT);
+            DR_ASSERT(res == DRBBDUP_SUCCESS);
+        }
     } else {
         /* Tracing is always on, so we have just one type of instrumentation and
          * do not need block duplication.
@@ -276,6 +289,10 @@ event_bb_analyze_case(void *drcontext, void *tag, instrlist_t *bb, bool for_trac
     } else if (mode == BBDUP_MODE_COUNT) {
         return event_inscount_bb_analysis(drcontext, tag, bb, for_trace, translating,
                                           analysis_data);
+    } else if (mode == BBDUP_MODE_FUNC_ONLY) {
+        return DR_EMIT_DEFAULT;
+    } else if (mode == BBDUP_MODE_NOP) {
+        return DR_EMIT_DEFAULT;
     } else
         DR_ASSERT(false);
     return DR_EMIT_DEFAULT;
@@ -288,6 +305,10 @@ event_bb_analyze_case_cleanup(void *drcontext, uintptr_t mode, void *user_data,
     if (mode == BBDUP_MODE_TRACE)
         event_bb_analysis_cleanup(drcontext, analysis_data);
     else if (mode == BBDUP_MODE_COUNT)
+        ; /* no cleanup needed */
+    else if (mode == BBDUP_MODE_FUNC_ONLY)
+        ; /* no cleanup needed */
+    else if (mode == BBDUP_MODE_NOP)
         ; /* no cleanup needed */
     else
         DR_ASSERT(false);
@@ -303,9 +324,17 @@ event_app_instruction_case(void *drcontext, void *tag, instrlist_t *bb, instr_t 
         return event_app_instruction(drcontext, tag, bb, instr, where, for_trace,
                                      translating, orig_analysis_data, analysis_data);
     } else if (mode == BBDUP_MODE_COUNT) {
+        // This includes func_trace_disabled_instrument_event() for drwrap cleanup.
         return event_inscount_app_instruction(drcontext, tag, bb, instr, where, for_trace,
                                               translating, orig_analysis_data,
                                               analysis_data);
+    } else if (mode == BBDUP_MODE_FUNC_ONLY) {
+        return func_trace_enabled_instrument_event(drcontext, tag, bb, instr, where,
+                                                   for_trace, translating, NULL);
+    } else if (mode == BBDUP_MODE_NOP) {
+        // We still need drwrap to clean up b/c we're using intrusive optimizations.
+        return func_trace_disabled_instrument_event(drcontext, tag, bb, instr, where,
+                                                    for_trace, translating, NULL);
     } else
         DR_ASSERT(false);
     return DR_EMIT_DEFAULT;
@@ -337,20 +366,21 @@ instrumentation_drbbdup_init()
     opts.analyze_case_ex = event_bb_analyze_case;
     opts.destroy_case_analysis = event_bb_analyze_case_cleanup;
     opts.instrument_instr_ex = event_app_instruction_case;
-    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&tracing_disabled, OPSZ_PTR);
+    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&tracing_mode, OPSZ_PTR);
     opts.atomic_load_encoding = true;
-    if (bbdup_duplication_enabled())
-        opts.non_default_case_limit = 1;
-    else {
-        // Save memory by asking drbbdup to not keep per-block bookkeeping.
-        opts.non_default_case_limit = 0;
-    }
+    // Save memory by asking drbbdup to not keep per-block bookkeeping
+    // unless we need it (the cases below).
+    opts.non_default_case_limit = 0;
+    if (align_attach_detach_endpoints())
+        ++opts.non_default_case_limit; // BBDUP_MODE_NOP.
+    if (bbdup_instr_counting_enabled())
+        ++opts.non_default_case_limit; // BBDUP_MODE_COUNT.
     // Save per-thread heap for a feature we do not need.
     opts.never_enable_dynamic_handling = true;
     drbbdup_status_t res = drbbdup_init(&opts);
     DR_ASSERT(res == DRBBDUP_SUCCESS);
     /* We just want barriers and atomic ops: no locks b/c they are not safe. */
-    DR_ASSERT(tracing_disabled.is_lock_free());
+    DR_ASSERT(tracing_mode.is_lock_free());
 }
 
 static void
@@ -364,12 +394,38 @@ instrumentation_init()
         DR_ASSERT(false);
     dr_register_filter_syscall_event(event_filter_syscall);
 
-    if (op_trace_after_instrs.get_value() != 0)
-        tracing_disabled.store(BBDUP_MODE_COUNT, std::memory_order_release);
+    if (align_attach_detach_endpoints())
+        tracing_mode.store(BBDUP_MODE_NOP, std::memory_order_release);
+    else if (op_trace_after_instrs.get_value() != 0)
+        tracing_mode.store(BBDUP_MODE_COUNT, std::memory_order_release);
 
 #ifdef DELAYED_CHECK_INLINED
     drx_init();
 #endif
+}
+
+static void
+event_post_attach()
+{
+    DR_ASSERT(attached_to_process);
+    if (!align_attach_detach_endpoints())
+        return;
+    if (op_trace_after_instrs.get_value() != 0) {
+        NOTIFY(1, "Switching to counting mode after attach\n");
+        tracing_mode.store(BBDUP_MODE_COUNT, std::memory_order_release);
+    } else {
+        NOTIFY(1, "Switching to tracing mode after attach\n");
+        tracing_mode.store(BBDUP_MODE_TRACE, std::memory_order_release);
+    }
+}
+
+static void
+event_pre_detach()
+{
+    if (align_attach_detach_endpoints()) {
+        NOTIFY(1, "Switching to no-tracing mode during detach\n");
+        tracing_mode.store(BBDUP_MODE_NOP, std::memory_order_release);
+    }
 }
 
 /***************************************************************************
@@ -1233,7 +1289,7 @@ static bool
 event_pre_syscall(void *drcontext, int sysnum)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
-    if (tracing_disabled.load(std::memory_order_acquire) != BBDUP_MODE_TRACE)
+    if (tracing_mode.load(std::memory_order_acquire) != BBDUP_MODE_TRACE)
         return true;
     if (BUF_PTR(data->seg_base) == NULL)
         return true; /* This thread was filtered out. */
@@ -1278,7 +1334,7 @@ event_post_syscall(void *drcontext, int sysnum)
 #ifdef BUILD_PT_TRACER
     if (!op_offline.get_value() || !op_enable_kernel_tracing.get_value())
         return;
-    if (tracing_disabled.load(std::memory_order_acquire) != BBDUP_MODE_TRACE)
+    if (tracing_mode.load(std::memory_order_acquire) != BBDUP_MODE_TRACE)
         return;
     if (!syscall_pt_trace_t::is_syscall_pt_trace_enabled(sysnum))
         return;
@@ -1313,7 +1369,7 @@ event_kernel_xfer(void *drcontext, const dr_kernel_xfer_info_t *info)
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
     trace_marker_type_t marker_type;
     uintptr_t marker_val = 0;
-    if (tracing_disabled.load(std::memory_order_acquire) != BBDUP_MODE_TRACE)
+    if (tracing_mode.load(std::memory_order_acquire) != BBDUP_MODE_TRACE)
         return;
     if (BUF_PTR(data->seg_base) == NULL)
         return; /* This thread was filtered out. */
@@ -1914,7 +1970,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     event_inscount_init();
     init_io();
 
-    DR_ASSERT(std::atomic_is_lock_free(&tracing_disabled));
+    DR_ASSERT(std::atomic_is_lock_free(&tracing_mode));
     DR_ASSERT(std::atomic_is_lock_free(&tracing_window));
 
     drreg_init_and_fill_vector(&scratch_reserve_vec, true);
@@ -1998,6 +2054,9 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
 #ifdef UNIX
     dr_register_fork_init_event(fork_init);
 #endif
+    attached_to_process = dr_register_post_attach_event(event_post_attach);
+    dr_register_pre_detach_event(event_pre_detach);
+
     /* We need our thread exit event to run *before* drmodtrack's as we may
      * need to translate physical addresses for the thread's final buffer.
      */

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -152,7 +152,7 @@ is_first_nonlabel(void *drcontext, instr_t *instr);
 
 extern std::atomic<ptr_int_t> tracing_mode;
 extern std::atomic<ptr_int_t> tracing_window;
-extern bool attached_to_process;
+extern bool attached_midway;
 
 /* We have multiple modes.  While just 2 results in a more efficient dispatch,
  * the power of extra modes justifies the extra overhead.
@@ -163,10 +163,10 @@ extern bool attached_to_process;
  * lower-cost than counting.
  */
 enum {
-    BBDUP_MODE_TRACE = 0,
-    BBDUP_MODE_COUNT = 1,
-    BBDUP_MODE_FUNC_ONLY = 2,
-    BBDUP_MODE_NOP = 3,
+    BBDUP_MODE_TRACE = 0,     /* Full address tracing. */
+    BBDUP_MODE_COUNT = 1,     /* Instr counting for delayed tracing or trace windows. */
+    BBDUP_MODE_FUNC_ONLY = 2, /* Function tracing during no-full-trace periods. */
+    BBDUP_MODE_NOP = 3,       /* No tracing or counting for pre-attach or post-detach. */
 };
 
 #if defined(X86_64) || defined(AARCH64)
@@ -259,7 +259,7 @@ has_tracing_windows()
 static inline bool
 align_attach_detach_endpoints()
 {
-    return attached_to_process && op_align_endpoints.get_value();
+    return attached_midway && op_align_endpoints.get_value();
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -150,21 +150,23 @@ extern void *mutex;
 bool
 is_first_nonlabel(void *drcontext, instr_t *instr);
 
-extern std::atomic<ptr_int_t> tracing_disabled;
+extern std::atomic<ptr_int_t> tracing_mode;
 extern std::atomic<ptr_int_t> tracing_window;
+extern bool attached_to_process;
 
-/* We have two modes: count instructions only, and full trace.
+/* We have multiple modes.  While just 2 results in a more efficient dispatch,
+ * the power of extra modes justifies the extra overhead.
  *
- * XXX i#3995: To implement -max_trace_size with drbbdup cases (with thread-private
- * encodings), or support nudges enabling tracing, or have a single -trace_for_instrs
- * transition to something lower-cost than counting, we will likely add a 3rd mode that
- * has zero instrumentation.  We also would use the 3rd mode for just -trace_for_instrs
- * with no -retrace_every_instrs.  For now we have just 2 as the case dispatch is more
- * efficient that way.
+ * TODO i#3995: Use the new BBDUP_MODE_NOP to implement -max_trace_size with drbbdup
+ * cases (with thread-private encodings), to support nudges enabling tracing, and to
+ * have a single -trace_for_instrs with no -retrace_every_instrs transition to something
+ * lower-cost than counting.
  */
 enum {
     BBDUP_MODE_TRACE = 0,
     BBDUP_MODE_COUNT = 1,
+    BBDUP_MODE_FUNC_ONLY = 2,
+    BBDUP_MODE_NOP = 3,
 };
 
 #if defined(X86_64) || defined(AARCH64)
@@ -252,6 +254,12 @@ has_tracing_windows()
     // since we rely on having window numbers for the end-of-block buffer output check
     // used for a single-window transition away from tracing.
     return op_trace_for_instrs.get_value() > 0 || op_retrace_every_instrs.get_value() > 0;
+}
+
+static inline bool
+align_attach_detach_endpoints()
+{
+    return attached_to_process && op_align_endpoints.get_value();
 }
 
 } // namespace drmemtrace

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3902,6 +3902,12 @@ if (BUILD_CLIENTS)
           # We test cpu_scheduling for offline traces here.
           "" "@-cpu_scheduling" "")
 
+        set(tool.drcacheoff.burst_threads_counts_nodr ON)
+        torunonly_drcacheoff(burst_threads_counts tool.drcacheoff.burst_threads
+          "" "@-simulator_type@basic_counts"
+          # This test uses the same app as the one above, so set a new dir name.
+          "-subdir_prefix drmemtrace.tool.drcacheoff.burst_threads_counts")
+
         set(tool.drcacheoff.burst_malloc_nodr ON)
         torunonly_drcacheoff(burst_malloc tool.drcacheoff.burst_malloc
           "" "@-simulator_type@basic_counts" "")


### PR DESCRIPTION
Adds a new drbbdup mode to drmemtrace which performs zero instrumentation (except drwrap cleanup).  This mode is used when attaching for the period prior to full control of all threads and when detaching prior to starting to let threads go native, to avoid uneven thread instrumentation during these incremental staggered processes. The mode is initially under an off-by-default new option -align_endpoints while drbbdup stability is being worked on (i#5686).

Threads that did nothing during the trace-mode period are now omitted from the trace.

Adds a test by adding 4 idle threads to burst_threads and ensuring they do not show up in the trace.

Alignment itself was tested manually by running larger applications and analyzing the timestamp ranges in the trace.

Fixes the burst_replace test to work properly with .zip output (the output regex still matched despite a printed error from raw2trace, it seems).

Timestamps during detach require further work as they inaccurately imply executing after tracing mode was turned off.  The next part will address this issue.

Issue: #2039, #5686