### PR TITLE
Add full module path in debug log

### DIFF
--- a/core/module_list.c
+++ b/core/module_list.c
@@ -233,7 +233,8 @@ module_list_remove_mapping(module_area_t *ma, app_pc map_start, app_pc map_end)
     ASSERT(os_get_module_info_write_locked());
     vmvector_remove(loaded_module_areas, map_start, map_end);
     LOG(GLOBAL, LOG_INTERP | LOG_VMAREAS, 2,
-        "\tmodule %s segment [" PFX "," PFX "] removed\n",
+        "\tmodule %s %s segment [" PFX "," PFX "] removed\n",
+        ma->full_path == NULL ? "<no path>" : ma->full_path,
         (GET_MODULE_NAME(&ma->names) == NULL) ? "<no name>" : GET_MODULE_NAME(&ma->names),
         map_start, map_end);
 }
@@ -260,7 +261,8 @@ module_list_add(app_pc base, size_t view_size, bool at_map,
         ASSERT(ma != NULL);
 
         LOG(GLOBAL, LOG_INTERP | LOG_VMAREAS, 1,
-            "module %s |%s| [" PFX "," PFX "] added\n",
+            "module %s %s |%s| [" PFX "," PFX "] added\n",
+            ma->full_path == NULL ? "<no path>" : ma->full_path,
             (GET_MODULE_NAME(&ma->names) == NULL) ? "<no name>"
                                                   : GET_MODULE_NAME(&ma->names),
             ma->names.file_name == NULL ? "<no file>" : ma->names.file_name, base,


### PR DESCRIPTION
It is useful to have the full module path in debug case.
For example, if we have some issue in address in basic block we could try to map it on source code (addr2line tool) to investigate the issue.
