### PR TITLE
i#5538 memtrace seek, part 5: Add schedule index files

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -65,17 +65,6 @@ analyzer_t::analyzer_t()
     /* Nothing else: child class needs to initialize. */
 }
 
-#if defined(HAS_SNAPPY) || defined(HAS_ZIP)
-static bool
-ends_with(const std::string &str, const std::string &with)
-{
-    size_t pos = str.rfind(with);
-    if (pos == std::string::npos)
-        return false;
-    return (pos + with.size() == str.size());
-}
-#endif
-
 static std::unique_ptr<reader_t>
 get_reader(const std::string &path, int verbosity)
 {
@@ -98,6 +87,11 @@ get_reader(const std::string &path, int verbosity)
             return nullptr;
         }
         for (; iter != end; ++iter) {
+            const std::string fname = *iter;
+            if (fname == "." || fname == ".." ||
+                starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
+                fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
+                continue;
 #    ifdef HAS_SNAPPY
             if (ends_with(*iter, ".sz")) {
                 return std::unique_ptr<reader_t>(
@@ -141,7 +135,9 @@ analyzer_t::init_file_reader(const std::string &trace_path, int verbosity)
         }
         for (; iter != end; ++iter) {
             const std::string fname = *iter;
-            if (fname == "." || fname == "..")
+            if (fname == "." || fname == ".." ||
+                starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
+                fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
                 continue;
             const std::string path = trace_path + DIRSEP + fname;
             std::unique_ptr<reader_t> reader = get_reader(path, verbosity);

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -187,7 +187,7 @@ analyzer_multi_t::create_analysis_tools()
     if (op_test_mode.get_value()) {
         if (op_offline.get_value()) {
             // TODO i#5538: Locate and open the schedule files and pass to the
-            // reader(s) for seeking.  For now we only read them for this test.
+            // reader(s) for seeking. For now we only read them for this test.
             std::string tracedir =
                 raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
             if (directory_iterator_t::is_directory(tracedir)) {

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -115,7 +115,17 @@ analyzer_multi_t::analyzer_multi_t()
                 error_string_ = "raw2trace failed: " + error;
             }
         }
-        tracedir = raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
+    }
+    // Create the tools after post-processing so we have the schedule files for
+    // test_mode.
+    if (!create_analysis_tools()) {
+        success_ = false;
+        error_string_ = "Failed to create analysis tool: " + error_string_;
+        return;
+    }
+    if (!op_indir.get_value().empty()) {
+        std::string tracedir =
+            raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
         if (!init_file_reader(tracedir, op_verbose.get_value()))
             success_ = false;
     } else if (op_infile.get_value().empty()) {
@@ -138,13 +148,6 @@ analyzer_multi_t::analyzer_multi_t()
         // Legacy file.
         if (!init_file_reader(op_infile.get_value(), op_verbose.get_value()))
             success_ = false;
-    }
-    // Create the tools after post-processing so we have the schedule files for
-    // test_mode.
-    if (!create_analysis_tools()) {
-        success_ = false;
-        error_string_ = "Failed to create analysis tool: " + error_string_;
-        return;
     }
     // We can't call serial_trace_iter_->init() here as it blocks for ipc_reader_t.
 }

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -40,7 +40,11 @@
 #include "tracer/raw2trace.h"
 #include "reader/file_reader.h"
 #ifdef HAS_ZLIB
+#    include "common/gzip_istream.h"
 #    include "reader/compressed_file_reader.h"
+#endif
+#ifdef HAS_ZIP
+#    include "common/zipfile_istream.h"
 #endif
 #include "reader/ipc_reader.h"
 #include "tools/invariant_checker.h"
@@ -56,11 +60,6 @@ analyzer_multi_t::analyzer_multi_t()
         parallel_ = false;
     if (!op_indir.get_value().empty() || !op_infile.get_value().empty())
         op_offline.set_value(true); // Some tools check this on post-proc runs.
-    if (!create_analysis_tools()) {
-        success_ = false;
-        error_string_ = "Failed to create analysis tool: " + error_string_;
-        return;
-    }
     // XXX: add a "required" flag to droption to avoid needing this here
     if (op_indir.get_value().empty() && op_infile.get_value().empty() &&
         op_ipc_name.get_value().empty()) {
@@ -107,7 +106,8 @@ analyzer_multi_t::analyzer_multi_t()
             }
             raw2trace_t raw2trace(
                 dir.modfile_bytes_, dir.in_files_, dir.out_files_, dir.out_archives_,
-                dir.encoding_file_, nullptr, op_verbose.get_value(), op_jobs.get_value(),
+                dir.encoding_file_, dir.serial_schedule_file_, dir.cpu_schedule_file_,
+                nullptr, op_verbose.get_value(), op_jobs.get_value(),
                 op_alt_module_dir.get_value(), op_chunk_instr_count.get_value());
             std::string error = raw2trace.do_conversion();
             if (!error.empty()) {
@@ -138,6 +138,13 @@ analyzer_multi_t::analyzer_multi_t()
         // Legacy file.
         if (!init_file_reader(op_infile.get_value(), op_verbose.get_value()))
             success_ = false;
+    }
+    // Create the tools after post-processing so we have the schedule files for
+    // test_mode.
+    if (!create_analysis_tools()) {
+        success_ = false;
+        error_string_ = "Failed to create analysis tool: " + error_string_;
+        return;
     }
     // We can't call serial_trace_iter_->init() here as it blocks for ipc_reader_t.
 }
@@ -173,9 +180,45 @@ analyzer_multi_t::create_analysis_tools()
     }
     num_tools_ = 1;
     if (op_test_mode.get_value()) {
-        tools_[1] =
-            new invariant_checker_t(op_offline.get_value(), op_verbose.get_value(),
-                                    op_test_mode_name.get_value());
+        // TODO i#5538: Locate and open the schedule files and pass to the
+        // reader(s) for seeking.  For now we only read them for this test.
+        std::string tracedir =
+            raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
+        if (directory_iterator_t::is_directory(tracedir)) {
+            directory_iterator_t end;
+            directory_iterator_t iter(tracedir);
+            if (!iter) {
+                error_string_ = "Failed to list directory: " + iter.error_string();
+                return false;
+            }
+            for (; iter != end; ++iter) {
+                const std::string fname = *iter;
+                const std::string fpath = tracedir + DIRSEP + fname;
+                if (starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME)) {
+                    if (ends_with(fname, ".gz")) {
+#ifdef HAS_ZLIB
+                        serial_schedule_file_ =
+                            std::unique_ptr<std::istream>(new gzip_istream_t(fpath));
+#endif
+                    } else {
+                        serial_schedule_file_ = std::unique_ptr<std::istream>(
+                            new std::ifstream(fpath, std::ifstream::binary));
+                    }
+                    if (serial_schedule_file_ && !*serial_schedule_file_) {
+                        error_string_ = "Failed to open serial schedule file " + fpath;
+                        return false;
+                    }
+                } else if (fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME) {
+#ifdef HAS_ZIP
+                    cpu_schedule_file_ =
+                        std::unique_ptr<std::istream>(new zipfile_istream_t(fpath));
+#endif
+                }
+            }
+        }
+        tools_[1] = new invariant_checker_t(
+            op_offline.get_value(), op_verbose.get_value(), op_test_mode_name.get_value(),
+            serial_schedule_file_.get(), cpu_schedule_file_.get());
         if (tools_[1] == NULL)
             return false;
         if (!!*tools_[1])

--- a/clients/drcachesim/analyzer_multi.h
+++ b/clients/drcachesim/analyzer_multi.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -51,6 +51,9 @@ protected:
     create_analysis_tools();
     void
     destroy_analysis_tools();
+
+    std::unique_ptr<std::istream> serial_schedule_file_;
+    std::unique_ptr<std::istream> cpu_schedule_file_;
 
     static const int max_num_tools_ = 8;
 };

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -693,6 +693,25 @@ struct _encoding_entry_t {
 } END_PACKED_STRUCTURE;
 typedef struct _encoding_entry_t encoding_entry_t;
 
+// A thread schedule file is a series of these records.
+// There is no version number here: we increase the version number in
+// the trace files when we change the format of this file.
+START_PACKED_STRUCTURE
+struct schedule_entry_t {
+    schedule_entry_t(uint64_t thread, uint64_t timestamp, uint64_t cpu,
+                     uint64_t instr_count)
+        : thread(thread)
+        , timestamp(timestamp)
+        , cpu(cpu)
+        , instr_count(instr_count)
+    {
+    }
+    uint64_t thread;
+    uint64_t timestamp;
+    uint64_t cpu;
+    uint64_t instr_count;
+} END_PACKED_STRUCTURE;
+
 /**
  * The name of the file in -offline mode where module data is written.
  * Its creation can be customized using drmemtrace_custom_module_data()
@@ -713,5 +732,18 @@ typedef struct _encoding_entry_t encoding_entry_t;
  * are written.  Use drmemtrace_get_encoding_path() to obtain the full path.
  */
 #define DRMEMTRACE_ENCODING_FILENAME "encodings.bin"
+
+/**
+ * The base name of the file in -offline mode where the serial thread schedule
+ * is written during post-processing.  A compression suffix may be appended.
+ */
+#define DRMEMTRACE_SERIAL_SCHEDULE_FILENAME "serial_schedule.bin"
+
+/**
+ * The name of the archive file in -offline mode where the cpu thread schedule
+ * is written during post-processing.  A separate sub-archive is written for
+ * each cpu.
+ */
+#define DRMEMTRACE_CPU_SCHEDULE_FILENAME "cpu_schedule.bin.zip"
 
 #endif /* _TRACE_ENTRY_H_ */

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -82,7 +82,7 @@
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif
@@ -147,6 +147,24 @@ to_hex_string(T integer)
     sstream << "0x" << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex
             << integer;
     return sstream.str();
+}
+
+static inline bool
+ends_with(const std::string &str, const std::string &with)
+{
+    size_t pos = str.rfind(with);
+    if (pos == std::string::npos)
+        return false;
+    return (pos + with.size() == str.size());
+}
+
+static inline bool
+starts_with(const std::string &str, const std::string &with)
+{
+    size_t pos = str.find(with);
+    if (pos == std::string::npos)
+        return false;
+    return pos == 0;
 }
 
 #endif /* _UTILS_H_ */

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -82,7 +82,7 @@
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif

--- a/clients/drcachesim/common/zipfile_istream.h
+++ b/clients/drcachesim/common/zipfile_istream.h
@@ -1,0 +1,128 @@
+/* **********************************************************
+ * Copyright (c) 2018-2022 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* zipfile_istream_t: provides a std::istream interface for reading components
+ * of a zipfile.  It provides a continuous stream that cycles through all
+ * components.
+ * Supports only limited seeking within the current internal buffer.
+ */
+
+#ifndef _ZIPFILE_ISTREAM_H_
+#define _ZIPFILE_ISTREAM_H_ 1
+
+#ifndef HAS_ZIP
+#    error HAS_ZIP is required
+#endif
+#include <fstream>
+#include <zlib.h>
+#include "minizip/unzip.h"
+
+/* We need to override the stream buffer class which is where the file
+ * reads happen.  The stream buffer base class reads from eback()..egptr()
+ * with the next to read at gptr().
+ */
+class zipfile_istreambuf_t : public std::basic_streambuf<char, std::char_traits<char>> {
+public:
+    zipfile_istreambuf_t(const std::string &path)
+    {
+        file_ = unzOpen(path.c_str());
+        if (file_ != nullptr && unzGoToFirstFile(file_) == UNZ_OK &&
+            unzOpenCurrentFile(file_) == UNZ_OK) {
+            buf_ = new char[buffer_size_];
+        }
+    }
+    ~zipfile_istreambuf_t() override
+    {
+        delete[] buf_;
+        if (file_ != nullptr)
+            unzClose(file_);
+    }
+    int
+    underflow() override
+    {
+        if (file_ == nullptr)
+            return traits_type::eof();
+        if (gptr() == egptr()) {
+            int len = unzReadCurrentFile(file_, buf_, buffer_size_);
+            if (len == 0) {
+                if (unzCloseCurrentFile(file_) != UNZ_OK)
+                    return traits_type::eof();
+                if (unzGoToNextFile(file_) != UNZ_OK) {
+                    // We treat errors just like real eof UNZ_END_OF_LIST_OF_FILE.
+                    return traits_type::eof();
+                }
+                if (unzOpenCurrentFile(file_) != UNZ_OK)
+                    return traits_type::eof();
+                len = unzReadCurrentFile(file_, buf_, buffer_size_);
+            }
+            if (len <= 0)
+                return traits_type::eof();
+            setg(buf_, buf_, buf_ + len);
+        }
+        return *gptr();
+    }
+    std::iostream::pos_type
+    seekoff(std::iostream::off_type off, std::ios_base::seekdir dir,
+            std::ios_base::openmode which = std::ios_base::in) override
+    {
+        if (dir == std::ios_base::cur &&
+            ((off >= 0 && gptr() + off < egptr()) ||
+             (off < 0 && gptr() + off >= eback())))
+            gbump(off);
+        else {
+            // Unsupported!
+            return -1;
+        }
+        return gptr() - eback();
+    }
+
+private:
+    static const int buffer_size_ = 4096;
+    unzFile file_ = nullptr;
+    char *buf_ = nullptr;
+};
+
+class zipfile_istream_t : public std::istream {
+public:
+    explicit zipfile_istream_t(const std::string &path)
+        : std::istream(new zipfile_istreambuf_t(path))
+    {
+        if (!rdbuf())
+            setstate(std::ios::badbit);
+    }
+    virtual ~zipfile_istream_t() override
+    {
+        delete rdbuf();
+    }
+};
+
+#endif /* _ZIPFILE_ISTREAM_H_ */

--- a/clients/drcachesim/common/zipfile_istream.h
+++ b/clients/drcachesim/common/zipfile_istream.h
@@ -31,9 +31,8 @@
  */
 
 /* zipfile_istream_t: provides a std::istream interface for reading components
- * of a zipfile.  It provides a continuous stream that cycles through all
- * components.
- * Supports only limited seeking within the current internal buffer.
+ * of a zipfile. It provides a continuous stream that cycles through all
+ * components. Supports only limited seeking within the current internal buffer.
  */
 
 #ifndef _ZIPFILE_ISTREAM_H_

--- a/clients/drcachesim/common/zipfile_ostream.h
+++ b/clients/drcachesim/common/zipfile_ostream.h
@@ -68,7 +68,8 @@ public:
             return;
         // We do not bother with the zipfile comment: it doesn't seem to show
         // up when I do set it anyway ("unzip -z" prints the .zip path instead).
-        if (zipCloseFileInZip(zip_) != ZIP_OK || zipClose(zip_, nullptr) != ZIP_OK) {
+        if ((!first_component_ && zipCloseFileInZip(zip_) != ZIP_OK) ||
+            zipClose(zip_, nullptr) != ZIP_OK) {
 #ifdef DEBUG
             // Let's at least have something visible in debug build.
             std::cerr << "zipfile_ostream failed to close zipfile\n";

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -46,6 +46,7 @@
 #include "memref.h"
 #include "directory_iterator.h"
 #include "trace_entry.h"
+#include "common/utils.h"
 
 #ifndef ZHEX64_FORMAT_STRING
 /* We avoid dr_defines.h to keep this code separated and simpler for using with
@@ -128,7 +129,9 @@ protected:
             }
             for (; iter != end; ++iter) {
                 std::string fname = *iter;
-                if (fname == "." || fname == "..")
+                if (fname == "." || fname == ".." ||
+                    starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
+                    fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
                     continue;
                 // Skip the auxiliary files.
                 if (fname == DRMEMTRACE_MODULE_LIST_FILENAME ||

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -46,7 +46,7 @@
 #include "memref.h"
 #include "directory_iterator.h"
 #include "trace_entry.h"
-#include "common/utils.h"
+#include "utils.h"
 
 #ifndef ZHEX64_FORMAT_STRING
 /* We avoid dr_defines.h to keep this code separated and simpler for using with

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -162,7 +162,9 @@ post_process()
         std::string dir_err = dir.initialize(raw_dir, outdir);
         assert(dir_err.empty());
         raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
-                              dir.out_archives_, dir.encoding_file_, dr_context);
+                              dir.out_archives_, dir.encoding_file_,
+                              dir.serial_schedule_file_, dir.cpu_schedule_file_,
+                              dr_context);
         std::string error = raw2trace.do_conversion();
         if (!error.empty()) {
             std::cerr << "raw2trace failed: " << error << "\n";

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -234,7 +234,9 @@ post_process()
         std::string dir_err = dir.initialize(raw_dir, outdir);
         assert(dir_err.empty());
         raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
-                              dir.out_archives_, dir.encoding_file_, dr_context);
+                              dir.out_archives_, dir.encoding_file_,
+                              dir.serial_schedule_file_, dir.cpu_schedule_file_,
+                              dr_context);
         std::string error = raw2trace.do_conversion();
         if (!error.empty()) {
             std::cerr << "raw2trace failed: " << error << "\n";

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -220,7 +220,9 @@ post_process()
     std::string dir_err = dir.initialize(raw_dir, "");
     assert(dir_err.empty());
     raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
-                          dir.out_archives_, dir.encoding_file_, dr_context, 0);
+                          dir.out_archives_, dir.encoding_file_,
+                          dir.serial_schedule_file_, dir.cpu_schedule_file_, dr_context,
+                          0);
     std::string error =
         raw2trace.handle_custom_data(parse_cb, process_cb, MAGIC_VALUE, free_cb);
     assert(error.empty());

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -175,7 +175,9 @@ post_process(const std::string &out_subdir)
         std::string dir_err = dir.initialize(raw_dir, outdir);
         assert(dir_err.empty());
         raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
-                              dir.out_archives_, dir.encoding_file_, dr_context,
+                              dir.out_archives_, dir.encoding_file_,
+                              dir.serial_schedule_file_, dir.cpu_schedule_file_,
+                              dr_context,
                               0
 #    ifdef WINDOWS
                               /* FIXME i#3983: Creating threads in standalone mode

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -62,8 +62,8 @@ protected:
     {
         if (!condition) {
             errors.push_back(invariant_name);
-            error_tids.push_back(shard->tid);
-            error_refs.push_back(shard->ref_count);
+            error_tids.push_back(shard->tid_);
+            error_refs.push_back(shard->ref_count_);
         }
     }
 };

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -148,8 +148,9 @@ test_raw2trace(raw2trace_directory_t *dir)
          * raw2trace::read_and_map_modules().
          */
         raw2trace_t raw2trace(dir->modfile_bytes_, dir->in_files_, dir->out_files_,
-                              dir->out_archives_, dir->encoding_file_, GLOBAL_DCONTEXT,
-                              1);
+                              dir->out_archives_, dir->encoding_file_,
+                              dir->serial_schedule_file_, dir->cpu_schedule_file_,
+                              GLOBAL_DCONTEXT, 1);
         std::string error = raw2trace.do_conversion();
         if (!error.empty()) {
             std::cerr << "raw2trace failed " << error << "\n";

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -96,7 +96,8 @@ public:
     raw2trace_test_t(const std::vector<std::istream *> &input,
                      const std::vector<std::ostream *> &output, instrlist_t &instrs,
                      void *drcontext)
-        : raw2trace_t(nullptr, input, output, {}, INVALID_FILE, drcontext,
+        : raw2trace_t(nullptr, input, output, {}, INVALID_FILE, nullptr, nullptr,
+                      drcontext,
                       // The sequences are small so we print everything for easier
                       // debugging and viewing of what's going on.
                       4)

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -32,6 +32,7 @@
 
 #include "invariant_checker.h"
 #include "invariant_checker_create.h"
+#include <algorithm>
 #include <iostream>
 #include <string.h>
 
@@ -42,10 +43,14 @@ invariant_checker_create(bool offline, unsigned int verbose)
 }
 
 invariant_checker_t::invariant_checker_t(bool offline, unsigned int verbose,
-                                         std::string test_name)
+                                         std::string test_name,
+                                         std::istream *serial_schedule_file,
+                                         std::istream *cpu_schedule_file)
     : knob_offline_(offline)
     , knob_verbose_(verbose)
     , knob_test_name_(test_name)
+    , serial_schedule_file_(serial_schedule_file)
+    , cpu_schedule_file_(cpu_schedule_file)
 {
     if (knob_test_name_ == "kernel_xfer_app" || knob_test_name_ == "rseq_app")
         has_annotations_ = true;
@@ -60,8 +65,8 @@ invariant_checker_t::report_if_false(per_shard_t *shard, bool condition,
                                      const std::string &invariant_name)
 {
     if (!condition) {
-        std::cerr << "Trace invariant failure in T" << shard->tid << " at ref # "
-                  << shard->ref_count << ": " << invariant_name << "\n";
+        std::cerr << "Trace invariant failure in T" << shard->tid_ << " at ref # "
+                  << shard->ref_count_ << ": " << invariant_name << "\n";
         abort();
     }
 }
@@ -92,16 +97,16 @@ std::string
 invariant_checker_t::parallel_shard_error(void *shard_data)
 {
     per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
-    return shard->error;
+    return shard->error_;
 }
 
 bool
 invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
-    ++shard->ref_count;
-    if (shard->tid == -1 && memref.data.tid != 0)
-        shard->tid = memref.data.tid;
+    ++shard->ref_count_;
+    if (shard->tid_ == -1 && memref.data.tid != 0)
+        shard->tid_ = memref.data.tid;
     // XXX i#5538: Have the infrastructure provide a common instr and record count.
     if (type_is_instr(memref.instr.type))
         ++shard->instr_count_;
@@ -379,11 +384,20 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
+        shard->last_timestamp_ = memref.marker.marker_value;
         shard->saw_timestamp_but_no_instr_ = true;
         if (knob_verbose_ >= 3) {
             std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: "
                       << " timestamp " << memref.marker.marker_value << "\n";
         }
+    }
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID) {
+        shard->sched_.emplace_back(shard->tid_, shard->last_timestamp_,
+                                   memref.marker.marker_value, shard->instr_count_);
+        shard->cpu2sched_[memref.marker.marker_value].emplace_back(
+            shard->tid_, shard->last_timestamp_, memref.marker.marker_value,
+            shard->instr_count_);
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         // Ignore timestamp, etc. markers which show up at signal delivery boundaries
@@ -435,15 +449,80 @@ invariant_checker_t::process_memref(const memref_t &memref)
     } else
         per_shard = lookup->second.get();
     if (!parallel_shard_memref(reinterpret_cast<void *>(per_shard), memref)) {
-        error_string_ = per_shard->error;
+        error_string_ = per_shard->error_;
         return false;
     }
     return true;
 }
 
+void
+invariant_checker_t::check_schedule_data()
+{
+    if (serial_schedule_file_ == nullptr && cpu_schedule_file_ == nullptr)
+        return;
+    // Check that the scheduling data in the files written by raw2trace match
+    // the data in the trace.
+    per_shard_t global;
+    std::vector<schedule_entry_t> serial;
+    std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
+    for (auto &shard_keyval : shard_map_) {
+        serial.insert(serial.end(), shard_keyval.second->sched_.begin(),
+                      shard_keyval.second->sched_.end());
+        for (auto &keyval : shard_keyval.second->cpu2sched_) {
+            auto &vec = cpu2sched[keyval.first];
+            vec.insert(vec.end(), keyval.second.begin(), keyval.second.end());
+        }
+    }
+    std::sort(serial.begin(), serial.end(),
+              [](const schedule_entry_t &l, const schedule_entry_t &r) {
+                  return l.timestamp < r.timestamp;
+              });
+    if (serial_schedule_file_ != nullptr) {
+        schedule_entry_t next(0, 0, 0, 0);
+        while (
+            serial_schedule_file_->read(reinterpret_cast<char *>(&next), sizeof(next))) {
+            report_if_false(&global,
+                            memcmp(&serial[global.ref_count_], &next, sizeof(next)) == 0,
+                            "Serial schedule entry does not match trace");
+            ++global.ref_count_;
+        }
+        report_if_false(&global, global.ref_count_ == serial.size(),
+                        "Serial schedule entry count does not match trace");
+    }
+    if (cpu_schedule_file_ == nullptr)
+        return;
+    std::unordered_map<uint64_t, uint64_t> cpu2idx;
+    for (auto &keyval : cpu2sched) {
+        std::sort(keyval.second.begin(), keyval.second.end(),
+                  [](const schedule_entry_t &l, const schedule_entry_t &r) {
+                      return l.timestamp < r.timestamp;
+                  });
+        cpu2idx[keyval.first] = 0;
+    }
+    // The zipfile reader will form a continuous stream from all elements in the
+    // archive.  We figure out which cpu each one is from on the fly.
+    schedule_entry_t next(0, 0, 0, 0);
+    while (cpu_schedule_file_->read(reinterpret_cast<char *>(&next), sizeof(next))) {
+        global.ref_count_ = next.instr_count;
+        global.tid_ = next.thread;
+        report_if_false(
+            &global,
+            memcmp(&cpu2sched[next.cpu][cpu2idx[next.cpu]], &next, sizeof(next)) == 0,
+            "Cpu schedule entry does not match trace");
+        ++cpu2idx[next.cpu];
+    }
+    for (auto &keyval : cpu2sched) {
+        global.ref_count_ = 0;
+        global.tid_ = keyval.first;
+        report_if_false(&global, cpu2idx[keyval.first] == keyval.second.size(),
+                        "Cpu schedule entry count does not match trace");
+    }
+}
+
 bool
 invariant_checker_t::print_results()
 {
+    check_schedule_data();
     std::cerr << "Trace invariant checks passed\n";
     return true;
 }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -482,7 +482,8 @@ invariant_checker_t::check_schedule_data()
         while (
             serial_schedule_file_->read(reinterpret_cast<char *>(&next), sizeof(next))) {
             report_if_false(&global,
-                            memcmp(&serial[global.ref_count_], &next, sizeof(next)) == 0,
+                            memcmp(&serial[static_cast<size_t>(global.ref_count_)], &next,
+                                   sizeof(next)) == 0,
                             "Serial schedule entry does not match trace");
             ++global.ref_count_;
         }
@@ -507,7 +508,8 @@ invariant_checker_t::check_schedule_data()
         global.tid_ = next.thread;
         report_if_false(
             &global,
-            memcmp(&cpu2sched[next.cpu][cpu2idx[next.cpu]], &next, sizeof(next)) == 0,
+            memcmp(&cpu2sched[next.cpu][static_cast<size_t>(cpu2idx[next.cpu])], &next,
+                   sizeof(next)) == 0,
             "Cpu schedule entry does not match trace");
         ++cpu2idx[next.cpu];
     }

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -39,8 +39,9 @@
 #include "drutil.h"
 #include "instru.h"
 #include "../common/trace_entry.h"
-#include <limits.h> /* for USHRT_MAX */
-#include <stddef.h> /* for offsetof */
+#include <limits.h>  /* for USHRT_MAX */
+#include <stddef.h>  /* for offsetof */
+#include <algorithm> /* for std::min */
 
 #define MAX_IMM_DISP_STUR 255
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -809,7 +809,7 @@ raw2trace_t::aggregate_and_write_schedule_files()
                   return l.timestamp < r.timestamp;
               });
     if (serial_schedule_file_ != nullptr) {
-        if (!serial_schedule_file_->write(reinterpret_cast<const char *>(&serial[0]),
+        if (!serial_schedule_file_->write(reinterpret_cast<const char *>(serial.data()),
                                           serial.size() * sizeof(serial[0])))
             return "Failed to write to serial schedule file";
     }
@@ -825,8 +825,9 @@ raw2trace_t::aggregate_and_write_schedule_files()
         std::string err = cpu_schedule_file_->open_new_component(stream.str());
         if (!err.empty())
             return err;
-        if (!cpu_schedule_file_->write(reinterpret_cast<const char *>(&keyval.second[0]),
-                                       keyval.second.size() * sizeof(keyval.second[0])))
+        if (!cpu_schedule_file_->write(
+                reinterpret_cast<const char *>(keyval.second.data()),
+                keyval.second.size() * sizeof(keyval.second[0])))
             return "Failed to write to cpu schedule file";
     }
     return "";

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -781,9 +781,54 @@ raw2trace_t::do_conversion()
             count_elided_ += tdata.count_elided;
         }
     }
+    error = aggregate_and_write_schedule_files();
+    if (!error.empty())
+        return error;
     VPRINT(1, "Reconstructed " UINT64_FORMAT_STRING " elided addresses.\n",
            count_elided_);
     VPRINT(1, "Successfully converted %zu thread files\n", thread_data_.size());
+    return "";
+}
+
+std::string
+raw2trace_t::aggregate_and_write_schedule_files()
+{
+    if (serial_schedule_file_ == nullptr && cpu_schedule_file_ == nullptr)
+        return "";
+    std::vector<schedule_entry_t> serial;
+    std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
+    for (auto &tdata : thread_data_) {
+        serial.insert(serial.end(), tdata.sched.begin(), tdata.sched.end());
+        for (auto &keyval : tdata.cpu2sched) {
+            auto &vec = cpu2sched[keyval.first];
+            vec.insert(vec.end(), keyval.second.begin(), keyval.second.end());
+        }
+    }
+    std::sort(serial.begin(), serial.end(),
+              [](const schedule_entry_t &l, const schedule_entry_t &r) {
+                  return l.timestamp < r.timestamp;
+              });
+    if (serial_schedule_file_ != nullptr) {
+        if (!serial_schedule_file_->write(reinterpret_cast<const char *>(&serial[0]),
+                                          serial.size() * sizeof(serial[0])))
+            return "Failed to write to serial schedule file";
+    }
+    if (cpu_schedule_file_ == nullptr)
+        return "";
+    for (auto &keyval : cpu2sched) {
+        std::sort(keyval.second.begin(), keyval.second.end(),
+                  [](const schedule_entry_t &l, const schedule_entry_t &r) {
+                      return l.timestamp < r.timestamp;
+                  });
+        std::ostringstream stream;
+        stream << keyval.first;
+        std::string err = cpu_schedule_file_->open_new_component(stream.str());
+        if (!err.empty())
+            return err;
+        if (!cpu_schedule_file_->write(reinterpret_cast<const char *>(&keyval.second[0]),
+                                       keyval.second.size() * sizeof(keyval.second[0])))
+            return "Failed to write to cpu schedule file";
+    }
     return "";
 }
 
@@ -1133,6 +1178,8 @@ raw2trace_t::emit_new_chunk_header(raw2trace_thread_data_t *tdata)
     buf += trace_metadata_writer_t::write_marker(buf, TRACE_MARKER_TYPE_CPU_ID,
                                                  tdata->last_cpu_);
     CHECK((uint)(buf - buf_base) < WRITE_BUFFER_SIZE, "Too many entries");
+    // We write directly to avoid recursion issues; these duplicated headers do not
+    // need to go into the schedule file.
     if (!tdata->out_file->write((char *)buf_base, buf - buf_base))
         return "Failed to write to output file";
     return "";
@@ -1201,8 +1248,15 @@ raw2trace_t::write(void *tls, const trace_entry_t *start, const trace_entry_t *e
             if (it->type == TRACE_TYPE_MARKER) {
                 if (it->size == TRACE_MARKER_TYPE_TIMESTAMP)
                     tdata->last_timestamp_ = it->addr;
-                else if (it->size == TRACE_MARKER_TYPE_CPU_ID)
+                else if (it->size == TRACE_MARKER_TYPE_CPU_ID) {
                     tdata->last_cpu_ = static_cast<uint>(it->addr);
+                    tdata->sched.emplace_back(tdata->tid, tdata->last_timestamp_,
+                                              tdata->last_cpu_,
+                                              tdata->cur_chunk_instr_count);
+                    tdata->cpu2sched[it->addr].emplace_back(
+                        tdata->tid, tdata->last_timestamp_, tdata->last_cpu_,
+                        tdata->cur_chunk_instr_count);
+                }
                 continue;
             }
             if (!type_is_instr(static_cast<trace_type_t>(it->type)))
@@ -1346,15 +1400,18 @@ raw2trace_t::raw2trace_t(const char *module_map,
                          const std::vector<std::istream *> &thread_files,
                          const std::vector<std::ostream *> &out_files,
                          const std::vector<archive_ostream_t *> &out_archives,
-                         file_t encoding_file, void *dcontext, unsigned int verbosity,
-                         int worker_count, const std::string &alt_module_dir,
-                         uint64_t chunk_instr_count)
+                         file_t encoding_file, std::ostream *serial_schedule_file,
+                         archive_ostream_t *cpu_schedule_file, void *dcontext,
+                         unsigned int verbosity, int worker_count,
+                         const std::string &alt_module_dir, uint64_t chunk_instr_count)
     : trace_converter_t(dcontext)
     , worker_count_(worker_count)
     , user_process_(nullptr)
     , user_process_data_(nullptr)
     , modmap_(module_map)
     , encoding_file_(encoding_file)
+    , serial_schedule_file_(serial_schedule_file)
+    , cpu_schedule_file_(cpu_schedule_file)
     , verbosity_(verbosity)
     , alt_module_dir_(alt_module_dir)
     , chunk_instr_count_(chunk_instr_count)

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1947,6 +1947,8 @@ protected:
 
     std::unique_ptr<module_mapper_t> module_mapper_;
 
+    std::vector<std::unique_ptr<raw2trace_thread_data_t>> thread_data_;
+
 private:
     friend class trace_converter_t<raw2trace_t>;
 
@@ -2025,8 +2027,6 @@ private:
 
     std::string
     emit_new_chunk_header(raw2trace_thread_data_t *tdata);
-
-    std::vector<raw2trace_thread_data_t> thread_data_;
 
     int worker_count_;
     std::vector<std::vector<raw2trace_thread_data_t *>> worker_tasks_;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1736,13 +1736,15 @@ class raw2trace_t : public trace_converter_t<raw2trace_t> {
 public:
     // Only one of out_files and out_archives should be non-empty: archives support fast
     // seeking and are preferred but require zlib.
-    // module_map, encoding_file, thread_files, and out_files are all owned and
-    // opened/closed by the caller.  module_map is not a string and can contain binary
-    // data.
+    // module_map, encoding_file, serial_schedule_file, cpu_schedule_file, thread_files,
+    // and out_files are all owned and opened/closed by the caller.  module_map is not a
+    // string and can contain binary data.
     raw2trace_t(const char *module_map, const std::vector<std::istream *> &thread_files,
                 const std::vector<std::ostream *> &out_files,
                 const std::vector<archive_ostream_t *> &out_archives,
-                file_t encoding_file = INVALID_FILE, void *dcontext = nullptr,
+                file_t encoding_file = INVALID_FILE,
+                std::ostream *serial_schedule_file = nullptr,
+                archive_ostream_t *cpu_schedule_file = nullptr, void *dcontext = nullptr,
                 unsigned int verbosity = 0, int worker_count = -1,
                 const std::string &alt_module_dir = "",
                 uint64_t chunk_instr_count = 10 * 1000 * 1000);
@@ -1917,6 +1919,9 @@ protected:
 
         std::set<app_pc> encoding_emitted;
         app_pc last_encoding_emitted = nullptr;
+
+        std::vector<schedule_entry_t> sched;
+        std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
     };
 
     virtual std::string
@@ -1928,6 +1933,9 @@ protected:
     // thread, both for correct ordering and correct synchronization.
     std::string
     process_next_thread_buffer(raw2trace_thread_data_t *tdata, OUT bool *end_of_record);
+
+    std::string
+    aggregate_and_write_schedule_files();
 
     std::string
     write_footer(void *tls);
@@ -2119,6 +2127,8 @@ private:
 
     const char *modmap_;
     file_t encoding_file_ = INVALID_FILE;
+    std::ostream *serial_schedule_file_ = nullptr;
+    archive_ostream_t *cpu_schedule_file_ = nullptr;
 
     unsigned int verbosity_ = 0;
 

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -85,8 +85,8 @@ public:
     std::vector<std::istream *> in_files_;
     std::vector<std::ostream *> out_files_;
     std::vector<archive_ostream_t *> out_archives_;
-    std::ostream *serial_schedule_file_;
-    archive_ostream_t *cpu_schedule_file_;
+    std::ostream *serial_schedule_file_ = nullptr;
+    archive_ostream_t *cpu_schedule_file_ = nullptr;
 
 private:
     std::string

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -85,6 +85,8 @@ public:
     std::vector<std::istream *> in_files_;
     std::vector<std::ostream *> out_files_;
     std::vector<archive_ostream_t *> out_archives_;
+    std::ostream *serial_schedule_file_;
+    archive_ostream_t *cpu_schedule_file_;
 
 private:
     std::string
@@ -93,6 +95,10 @@ private:
     open_thread_files();
     std::string
     open_thread_log_file(const char *basename);
+    std::string
+    open_serial_schedule_file();
+    std::string
+    open_cpu_schedule_file();
     file_t modfile_;
     std::string indir_;
     std::string outdir_;

--- a/clients/drcachesim/tracer/raw2trace_launcher.cpp
+++ b/clients/drcachesim/tracer/raw2trace_launcher.cpp
@@ -110,8 +110,9 @@ _tmain(int argc, const TCHAR *targv[])
         FATAL_ERROR("Directory parsing failed: %s", dir_err.c_str());
     raw2trace_t raw2trace(
         dir.modfile_bytes_, dir.in_files_, dir.out_files_, dir.out_archives_,
-        dir.encoding_file_, nullptr, op_verbose.get_value(), op_jobs.get_value(),
-        op_alt_module_dir.get_value(), op_chunk_instr_count.get_value());
+        dir.encoding_file_, dir.serial_schedule_file_, dir.cpu_schedule_file_, nullptr,
+        op_verbose.get_value(), op_jobs.get_value(), op_alt_module_dir.get_value(),
+        op_chunk_instr_count.get_value());
     std::string error = raw2trace.do_conversion();
     if (!error.empty())
         FATAL_ERROR("Conversion failed: %s", error.c_str());


### PR DESCRIPTION
Adds two new files generated by raw2trace, each containing 4-entry records of <tid, timestamp, cpuid, instr_count>.  These are used to take a global or per-cpu target instruction count and determine the corresponding instruction count within each software thread, for seeking within each trace file.  One file is globally sorted by timestamp, and the other is a zip file with a separate component for each cpuid holding entries sorted by timestamp for that cpu.

Adds new invariant_checker tests for each file by passing them in for test_mode.  The invariant_checker re-constructs the same sorted sequences using the trace data and confirms it matches the data in the files.  This involves adding a new zipfile_stream_t interface for a simple continuous stream of each zipfile component in turn.

Issue: #5538