### PR TITLE
i#5538 memtrace seek, part 6: Virtualize raw2trace_thread_data

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1878,6 +1878,10 @@ protected:
             , last_block_summary(nullptr)
         {
         }
+        // Support subclasses extending this struct.
+        virtual ~raw2trace_thread_data_t()
+        {
+        }
 
         int index;
         thread_id_t tid;


### PR DESCRIPTION
Adds a missing piece from part 5 PR #5713 where raw2trace's thread_data_ was indirected to support a subclass extending it. However, its destructor was not virtual, which prevented such extension.  We address that here.

Issue: #5538