### PR TITLE
i#5716: Fix ignored warmup_refs

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -421,7 +421,7 @@ cache_simulator_t::process_memref(const memref_t &memref)
         return true;
 
     // The references after warmup and simulated ones are dropped.
-    if (check_warmed_up() && knobs_.sim_refs == 0)
+    if (is_warmed_up_ && knobs_.sim_refs == 0)
         return true;
 
     // Both warmup and simulated references are simulated.
@@ -654,9 +654,9 @@ cache_simulator_t::create_cache(const std::string &policy)
     if (policy == REPLACE_POLICY_NON_SPECIFIED || // default LRU
         policy == REPLACE_POLICY_LRU)             // set to LRU
         return new cache_lru_t;
-    if (policy == REPLACE_POLICY_LFU) // set to LFU
+    if (policy == REPLACE_POLICY_LFU)             // set to LFU
         return new cache_t;
-    if (policy == REPLACE_POLICY_FIFO) // set to FIFO
+    if (policy == REPLACE_POLICY_FIFO)            // set to FIFO
         return new cache_fifo_t;
 
     // undefined replacement policy

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -654,9 +654,9 @@ cache_simulator_t::create_cache(const std::string &policy)
     if (policy == REPLACE_POLICY_NON_SPECIFIED || // default LRU
         policy == REPLACE_POLICY_LRU)             // set to LRU
         return new cache_lru_t;
-    if (policy == REPLACE_POLICY_LFU)             // set to LFU
+    if (policy == REPLACE_POLICY_LFU) // set to LFU
         return new cache_t;
-    if (policy == REPLACE_POLICY_FIFO)            // set to FIFO
+    if (policy == REPLACE_POLICY_FIFO) // set to FIFO
         return new cache_fifo_t;
 
     // undefined replacement policy

--- a/clients/drcachesim/tests/warmup-valid.templatex
+++ b/clients/drcachesim/tests/warmup-valid.templatex
@@ -4,7 +4,7 @@ Cache simulation results:
 Core #0 \(1 thread\(s\)\)
   L1I stats:
     Warmup hits:                  *[0-9,\.]*
-    Warmup misses:                *[0-9,\.]*
+    Warmup misses:                *[1-9][0-9,\.]*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*


### PR DESCRIPTION
Fixes a bug where drcachesim under-counts warmup_refs and ignores the warmup completely if it is an even number due to incorrectly calling the checking routine when it should just check the warmed-up state flag.

Updates the warmup template to require non-zero icache warmup misses (before it allowed any values including zero) to properly fail without this fix.

Fixes #5716