### PR TITLE
i#5722: Fix linker warning on bbdup asm

### DIFF
--- a/suite/tests/client-interface/drbbdup-empty-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-empty-bb-test.asm
@@ -34,8 +34,8 @@
 // Must include nop instructions as they are assumed by the test.
 
 .section .text
-        .global main
-main:
+        .global _start
+_start:
         or eax,eax
         nop
         nop

--- a/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-label-bb-test.asm
@@ -34,8 +34,8 @@
 // Must include nop instructions as they are assumed by the test.
 
 .section .text
-        .global main
-main:
+        .global _start
+_start:
         or eax,eax
         nop
         nop

--- a/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
+++ b/suite/tests/client-interface/drbbdup-meta-nop-bb-test.asm
@@ -34,8 +34,8 @@
 // Must include nop instructions as they are assumed by the test.
 
 .section .text
-        .global main
-main:
+        .global _start
+_start:
         or eax,eax
         nop
         nop


### PR DESCRIPTION
Replaces the incorrect "main" with "_start" in the bbdup asm tests to eliminate a linker warning.

Fixes #5722