### PR TITLE
Exclude 2nd write on 2nd thead exit call

### DIFF
--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1145,8 +1145,9 @@ exit_thread_io(void *drcontext)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
 
-#ifdef LINUX
+#ifdef UNIX
     /**
+     * i#2384:
      * On Linux, the thread exit event may be invoked twice for the same thread
      * if that thread is alive during a process fork, but doesn't call the fork
      * itself.  The first time the event callback is executed from the fork child


### PR DESCRIPTION
On java examples we have double calling thread exit callbacks but data->file could be already closed.
Write file operation is fail on write attempt and it is asserted.

