### PR TITLE
i#5675 record filter: Add filter that toggles at given instr count

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -137,6 +137,7 @@ add_exported_library(drmemtrace_view STATIC tools/view.cpp)
 add_exported_library(drmemtrace_func_view STATIC tools/func_view.cpp)
 add_exported_library(drmemtrace_record_filter STATIC
   tools/filter/record_filter.cpp
+  tools/filter/toggle_filter.h
   tools/filter/null_filter.h)
 configure_DynamoRIO_standalone(drmemtrace_opcode_mix)
 configure_DynamoRIO_standalone(drmemtrace_view)

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -37,6 +37,7 @@
 #include "droption.h"
 #include "tools/basic_counts.h"
 #include "tools/filter/null_filter.h"
+#include "tools/filter/toggle_filter.h"
 #include "tools/filter/record_filter.h"
 
 #include <vector>
@@ -66,6 +67,37 @@ static droption_t<std::string> op_tmp_output_dir(
     "[Required] Output directory for the filtered trace",
     "Specifies the directory where the filtered trace will be written.");
 
+class test_record_filter_t : public dynamorio::drmemtrace::record_filter_t {
+public:
+    test_record_filter_t(const std::vector<record_filter_func_t *> &filters)
+        : record_filter_t("", filters,
+                          /*verbose=*/0)
+    {
+    }
+    std::vector<trace_entry_t>
+    get_output_entries()
+    {
+        return output;
+    }
+
+protected:
+    bool
+    write_trace_entry(dynamorio::drmemtrace::record_filter_t::per_shard_t *shard,
+                      const trace_entry_t &entry) override
+    {
+        output.push_back(entry);
+        return true;
+    }
+    std::unique_ptr<std::ostream>
+    get_writer(per_shard_t *per_shard, memtrace_stream_t *shard_stream) override
+    {
+        return nullptr;
+    }
+
+private:
+    std::vector<trace_entry_t> output;
+};
+
 static bool
 local_create_dir(const char *dir)
 {
@@ -94,7 +126,116 @@ get_basic_counts(const std::string &trace_dir)
     return counts;
 }
 
-bool
+static void
+print_entry(trace_entry_t entry)
+{
+    fprintf(stderr, "%d:%d:%ld", entry.type, entry.size, entry.addr);
+}
+
+static bool
+test_toggle_filter()
+{
+    struct expected_output {
+        trace_entry_t entry;
+        bool in_half[2];
+    };
+
+    std::vector<struct expected_output> entries = {
+        /* Trace shard header. */
+        { { TRACE_TYPE_HEADER, 0, 1 }, { true, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION, 2 }, { true, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE, 3 }, { true, true } },
+        { { TRACE_TYPE_THREAD, 0, 4 }, { true, true } },
+        { { TRACE_TYPE_PID, 0, 5 }, { true, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 6 }, { true, true } },
+        /* Unit header. */
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, 7 }, { true, false } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, 8 }, { true, false } },
+        { { TRACE_TYPE_INSTR, 4, 9 }, { true, false } },
+        { { TRACE_TYPE_WRITE, 4, 10 }, { true, false } },
+        { { TRACE_TYPE_INSTR, 4, 11 }, { true, false } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, 12 }, { true, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS, 13 }, { true, true } },
+        { { TRACE_TYPE_READ, 4, 14 }, { true, false } },
+        { { TRACE_TYPE_INSTR, 4, 15 }, { true, false } },
+        /* Unit header. */
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, 16 }, { true, false } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, 17 }, { true, false } },
+        /* Unit header. */
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, 18 }, { true, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, 19 }, { true, true } },
+        { { TRACE_TYPE_INSTR, 4, 20 }, { true, false } },
+        /* First half supposed to end here. */
+        { { TRACE_TYPE_INSTR, 4, 21 }, { false, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, 22 }, { false, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE, 23 },
+          { false, true } },
+        { { TRACE_TYPE_READ, 4, 24 }, { false, true } },
+        { { TRACE_TYPE_WRITE, 4, 25 }, { false, true } },
+        /* Unit header. */
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, 26 }, { false, true } },
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, 27 }, { false, true } },
+        { { TRACE_TYPE_INSTR, 4, 28 }, { false, true } },
+        { { TRACE_TYPE_READ, 4, 29 }, { false, true } },
+        { { TRACE_TYPE_WRITE, 4, 30 }, { false, true } },
+        /* Trace shard footer. */
+        { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_FOOTER, 31 }, { true, true } },
+        { { TRACE_TYPE_FOOTER, 0, 32 }, { true, true } },
+    };
+
+    /* Check each half. */
+    for (int k = 0; k < 2; ++k) {
+        dynamorio::drmemtrace::record_filter_t::record_filter_func_t *toggle_filter =
+            new dynamorio::drmemtrace::toggle_filter_t(5, k == 0);
+        test_record_filter_t *record_filter = new test_record_filter_t({ toggle_filter });
+        void *shard_data = record_filter->parallel_shard_init_stream(0, nullptr, nullptr);
+        for (int i = 0; i < (int)entries.size(); ++i) {
+            if (!record_filter->parallel_shard_memref(shard_data, entries[i].entry)) {
+                fprintf(stderr, "Filtering failed\n");
+                return false;
+            }
+        }
+        if (!record_filter->parallel_shard_exit(shard_data)) {
+            fprintf(stderr, "Filtering exit failed\n");
+            return false;
+        }
+        std::vector<trace_entry_t> half = record_filter->get_output_entries();
+        delete record_filter;
+        delete toggle_filter;
+        int j = 0;
+        for (int i = 0; i < (int)entries.size(); ++i) {
+            if (entries[i].in_half[k]) {
+                if (j >= (int)half.size()) {
+                    fprintf(stderr, "Too few entries in filtered half %d. Expected: ", k);
+                    print_entry(entries[i].entry);
+                    fprintf(stderr, "\n");
+                    return false;
+                }
+                if (memcmp(&half[j], &entries[i].entry, sizeof(trace_entry_t)) != 0) {
+                    fprintf(stderr, "Wrong filter result for half %d. Expected: ", k);
+                    print_entry(entries[i].entry);
+                    fprintf(stderr, ", got: ");
+                    print_entry(half[j]);
+                    fprintf(stderr, "\n");
+                    return false;
+                }
+                ++j;
+            }
+        }
+        if (j < (int)half.size()) {
+            fprintf(stderr, "Got %d extra entries in filtered half %d. Next one: ",
+                    (int)half.size() - j, k);
+            print_entry(half[j]);
+            fprintf(stderr, "\n");
+            return false;
+        }
+    }
+    fprintf(stderr, "test_toggle_filter passed\n");
+    return true;
+}
+
+// Tests I/O for the record_filter.
+static bool
 test_null_filter()
 {
     std::string output_dir = op_tmp_output_dir.get_value() + DIRSEP + "null_filter";
@@ -143,7 +284,7 @@ main(int argc, const char *argv[])
         FATAL_ERROR("Usage error: %s\nUsage:\n%s", parse_err.c_str(),
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
-    if (!test_null_filter())
+    if (!test_toggle_filter() || !test_null_filter())
         return 1;
     fprintf(stderr, "All done!\n");
     return 0;

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -80,16 +80,18 @@ record_filter_t::parallel_shard_supported()
 }
 
 std::unique_ptr<std::ostream>
-record_filter_t::get_writer(const std::string &path)
+record_filter_t::get_writer(per_shard_t *per_shard, memtrace_stream_t *shard_stream)
 {
+    per_shard->output_path = output_dir_ + DIRSEP + shard_stream->get_stream_name();
 #ifdef HAS_ZLIB
-    if (ends_with(path, ".gz")) {
-        VPRINT(this, 3, "Using the gzip writer for %s\n", path.c_str());
-        return std::unique_ptr<std::ostream>(new gzip_ostream_t(path));
+    if (ends_with(per_shard->output_path, ".gz")) {
+        VPRINT(this, 3, "Using the gzip writer for %s\n", per_shard->output_path.c_str());
+        return std::unique_ptr<std::ostream>(new gzip_ostream_t(per_shard->output_path));
     }
 #endif
-    VPRINT(this, 3, "Using the default writer for %s\n", path.c_str());
-    return std::unique_ptr<std::ostream>(new std::ofstream(path, std::ofstream::binary));
+    VPRINT(this, 3, "Using the default writer for %s\n", per_shard->output_path.c_str());
+    return std::unique_ptr<std::ostream>(
+        new std::ofstream(per_shard->output_path, std::ofstream::binary));
 }
 
 void *
@@ -97,14 +99,15 @@ record_filter_t::parallel_shard_init_stream(int shard_index, void *worker_data,
                                             memtrace_stream_t *shard_stream)
 {
     auto per_shard = new per_shard_t;
-    per_shard->output_path = output_dir_ + DIRSEP + shard_stream->get_stream_name();
-    per_shard->writer = get_writer(per_shard->output_path);
+    per_shard->writer = get_writer(per_shard, shard_stream);
     if (!per_shard->writer) {
         per_shard->error = "Could not open a writer for " + per_shard->output_path;
         success_ = false;
     }
+    per_shard->in_shard_header = true;
     for (record_filter_func_t *f : filters_) {
-        filter_shard_data_.push_back(f->parallel_shard_init());
+        per_shard->filter_shard_data.push_back(f->parallel_shard_init());
+        per_shard->filter_stop.push_back(false);
     }
     return reinterpret_cast<void *>(per_shard);
 }
@@ -112,12 +115,13 @@ record_filter_t::parallel_shard_init_stream(int shard_index, void *worker_data,
 bool
 record_filter_t::parallel_shard_exit(void *shard_data)
 {
+    per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     bool res = true;
     for (int i = 0; i < (int)filters_.size(); ++i) {
-        if (!filters_[i]->parallel_shard_exit(filter_shard_data_[i]))
+        if (!filters_[i]->parallel_shard_exit(per_shard->filter_shard_data[i]))
             res = false;
     }
-    delete reinterpret_cast<per_shard_t *>(shard_data);
+    delete per_shard;
     return res;
 }
 
@@ -129,22 +133,95 @@ record_filter_t::parallel_shard_error(void *shard_data)
 }
 
 bool
+record_filter_t::write_trace_entry(per_shard_t *shard, const trace_entry_t &entry)
+{
+    if (!shard->writer->write((char *)&entry, sizeof(entry))) {
+        shard->error = "Failed to write to output file " + shard->output_path;
+        success_ = false;
+        return false;
+    }
+    ++shard->output_entry_count;
+    return true;
+}
+
+bool
 record_filter_t::parallel_shard_memref(void *shard_data, const trace_entry_t &entry)
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
+    ++per_shard->input_entry_count;
     bool output = true;
+    bool all_stop = true;
     for (int i = 0; i < (int)filters_.size(); ++i) {
-        if (!filters_[i]->parallel_shard_filter(entry, filter_shard_data_[i]))
+        bool stop = false;
+        if (!filters_[i]->parallel_shard_filter(entry, per_shard->filter_shard_data[i],
+                                                &stop))
             output = false;
+        if (stop)
+            per_shard->filter_stop[i] = true;
+        all_stop = all_stop && per_shard->filter_stop[i];
+    }
+
+    // Everything before the timestamp marker in the first unit header is part of the
+    // trace shard's header.
+    if (entry.type == TRACE_TYPE_MARKER && entry.size == TRACE_MARKER_TYPE_TIMESTAMP) {
+        per_shard->in_shard_header = false;
+    }
+
+    // We output everything in the trace shard's header.
+    if (per_shard->in_shard_header) {
+        output = true;
+    }
+
+    // Keep track of the last omitted unit header so that we can output it if and when
+    // we output a trace_entry_t from this unit.
+    if (!output && entry.type == TRACE_TYPE_MARKER) {
+        switch (entry.size) {
+        case TRACE_MARKER_TYPE_TIMESTAMP:
+            // No need to remember the previous unit's header anymore. We're in the
+            // next unit now.
+            per_shard->last_filtered_unit_header.clear();
+            ANNOTATE_FALLTHROUGH;
+        case TRACE_MARKER_TYPE_WINDOW_ID:
+        case TRACE_MARKER_TYPE_CPU_ID:
+            per_shard->last_filtered_unit_header.push_back(entry);
+        }
+    }
+
+    // Since we're outputing something from this unit, output its header.
+    if (output) {
+        for (trace_entry_t &entry : per_shard->last_filtered_unit_header) {
+            if (!write_trace_entry(per_shard, entry))
+                return false;
+        }
+        per_shard->last_filtered_unit_header.clear();
+    }
+
+    if (!output) {
+        if (entry.type == TRACE_TYPE_FOOTER ||
+            (entry.type == TRACE_TYPE_MARKER &&
+             entry.size == TRACE_MARKER_TYPE_CHUNK_FOOTER)) {
+            output = true;
+        } else if (!all_stop && entry.type == TRACE_TYPE_MARKER) {
+            // Markers that may be required for future instr/memrefs, therefore
+            // must be retained if there's a chance we'll output more entries
+            // later. These are not really tied to a unit header, so to save
+            // space we do not output their unit's header unless some other
+            // instr/memref is output for that unit header. We decided against
+            // buffering them since there may be many of these.
+            switch (entry.size) {
+            case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS:
+            case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE:
+            case TRACE_MARKER_TYPE_VIRTUAL_ADDRESS:
+            case TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT:
+            case TRACE_MARKER_TYPE_CHUNK_FOOTER: output = true;
+            }
+        }
     }
     // XXX i#5675: Currently we support writing to a single output file, but we may
     // want to write to multiple in the same run; e.g. splitting a trace. For now,
     // we can simply run the tool multiple times, but it can be made more efficient.
-    if (output && !per_shard->writer->write((char *)&entry, sizeof(entry))) {
-        per_shard->error = "Failed to write to output file " + per_shard->output_path;
-        success_ = false;
+    if (output && !write_trace_entry(per_shard, entry))
         return false;
-    }
     return true;
 }
 

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -73,9 +73,16 @@ public:
          * trace. \p shard_data is same as what was returned by
          * parallel_shard_init(). The given \p entry is included in the result
          * trace iff all provided #record_filter_func_t return true.
+         * The user should set *\p stop to true to indicate that the trace
+         * should be truncated at the current point (plus necessary entries
+         * like the footer etc). This helps the record_filter tool omit
+         * auxillary entries like encodings and v2p entries, which are
+         * otherwise emitted always. Setting *\p stop to false is undefined
+         * behavior.
          */
         virtual bool
-        parallel_shard_filter(const trace_entry_t &entry, void *shard_data) = 0;
+        parallel_shard_filter(const trace_entry_t &entry, void *shard_data,
+                              bool *stop) = 0;
         /**
          * Invoked when all #trace_entry_t in a shard have been processed
          * by parallel_shard_filter(). \p shard_data is same as what was
@@ -105,19 +112,29 @@ public:
     std::string
     parallel_shard_error(void *shard_data) override;
 
-private:
+protected:
     struct per_shard_t {
         std::string output_path;
         std::unique_ptr<std::ostream> writer;
         std::string error;
+        std::vector<void *> filter_shard_data;
+        std::vector<bool> filter_stop;
+        /* We want to always output everything in the trace header. */
+        bool in_shard_header;
+        std::vector<trace_entry_t> last_filtered_unit_header;
+        uint64_t input_entry_count;
+        uint64_t output_entry_count;
     };
 
-    std::unique_ptr<std::ostream>
-    get_writer(const std::string &path);
+private:
+    virtual bool
+    write_trace_entry(per_shard_t *shard, const trace_entry_t &entry);
+
+    virtual std::unique_ptr<std::ostream>
+    get_writer(per_shard_t *per_shard, memtrace_stream_t *shard_stream);
 
     std::string output_dir_;
     std::vector<record_filter_func_t *> filters_;
-    std::vector<void *> filter_shard_data_;
     unsigned int verbosity_;
     const char *output_prefix_ = "[record_filter]";
 };

--- a/clients/drcachesim/tools/filter/toggle_filter.h
+++ b/clients/drcachesim/tools/filter/toggle_filter.h
@@ -30,34 +30,64 @@
  * DAMAGE.
  */
 
-#ifndef _NULL_FILTER_H_
-#define _NULL_FILTER_H_ 1
+#ifndef _TOGGLE_FILTER_H_
+#define _TOGGLE_FILTER_H_ 1
 
 #include "record_filter.h"
 
 namespace dynamorio {
 namespace drmemtrace {
 
-class null_filter_t : public record_filter_t::record_filter_func_t {
+/**
+ * Filter that starts off either enabled (outputting all entries) or
+ * disabled (skipping all entries), and toggles its behavior when the
+ * given instruction count is reached.
+ */
+class toggle_filter_t : public record_filter_t::record_filter_func_t {
 public:
+    toggle_filter_t(uint64 instr_count_toggle, bool enable_write)
+        : instr_count_toggle_(instr_count_toggle)
+        , enable_write_(enable_write)
+    {
+    }
     void *
     parallel_shard_init() override
     {
-        return nullptr;
+        auto per_shard = new per_shard_t;
+        per_shard->instr_count = 0;
+        return per_shard;
     }
     bool
     parallel_shard_filter(const trace_entry_t &entry, void *shard_data,
                           bool *stop) override
     {
-        return true;
+        per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
+        if (type_is_instr((trace_type_t)entry.type)) {
+            ++per_shard->instr_count;
+            if (per_shard->instr_count == instr_count_toggle_) {
+                enable_write_ = !enable_write_;
+                if (!enable_write_) {
+                    *stop = true;
+                }
+            }
+        }
+        return enable_write_;
     }
     bool
     parallel_shard_exit(void *shard_data) override
     {
+        delete reinterpret_cast<per_shard_t *>(shard_data);
         return true;
     }
+
+private:
+    struct per_shard_t {
+        uint64 instr_count;
+    };
+    uint64 instr_count_toggle_;
+    bool enable_write_;
 };
 
 } // namespace drmemtrace
 } // namespace dynamorio
-#endif /* _NULL_FILTER_H_ */
+#endif /* _TOGGLE_FILTER_H_ */


### PR DESCRIPTION
toggle_filter_t starts off either enabled (outputting all entries) or disabled (not outputting any entries), and then toggles when the given instr count is reached.

Adds logic to record_filter that ensures that essential trace entries, like the shard header, unit header, and footers, are not skipped.

Adds a test for toggle filter.

Issue: #5675