### PR TITLE
Use trace entry string names in diagnostics

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -177,6 +177,7 @@ set(raw2trace_srcs
   tracer/instru_online.cpp
   tracer/instru_offline.cpp
   reader/reader.cpp
+  common/trace_entry.cpp
   )
 if (libsnappy)
   set(raw2trace_srcs ${raw2trace_srcs}

--- a/clients/drcachesim/common/trace_entry.cpp
+++ b/clients/drcachesim/common/trace_entry.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -80,4 +80,5 @@ const char *const trace_type_names[] = {
     "prefetch_write_l2_nt",
     "prefetch_write_l3",
     "prefetch_write_l3_nt",
+    "encoding",
 };

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -103,8 +103,9 @@ file_reader_t<gzip_reader_t>::read_next_thread_entry(size_t thread_index,
 {
     if (!read_next_thread_entry_common(&input_files_[thread_index], entry, eof))
         return false;
-    VPRINT(this, 4, "Read from thread #%zd file: type=%d, size=%d, addr=%zu\n",
-           thread_index, entry->type, entry->size, entry->addr);
+    VPRINT(this, 4, "Read from thread #%zd file: type=%s (%d), size=%d, addr=%zu\n",
+           thread_index, trace_type_names[entry->type], entry->type, entry->size,
+           entry->addr);
     return true;
 }
 
@@ -156,8 +157,9 @@ record_file_reader_t<gzip_reader_t>::read_next_entry()
 {
     if (!read_next_thread_entry_common(input_file_, &cur_entry_, &eof_))
         return false;
-    VPRINT(this, 4, "Read from file: type=%d, size=%d, addr=%zu\n", cur_entry_.type,
-           cur_entry_.size, cur_entry_.addr);
+    VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",
+           trace_type_names[cur_entry_.type], cur_entry_.type, cur_entry_.size,
+           cur_entry_.addr);
     return true;
 }
 

--- a/clients/drcachesim/reader/file_reader.cpp
+++ b/clients/drcachesim/reader/file_reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -66,8 +66,9 @@ file_reader_t<std::ifstream *>::read_next_thread_entry(size_t thread_index,
         *eof = input_files_[thread_index]->eof();
         return false;
     }
-    VPRINT(this, 4, "Read from thread #%zd file: type=%d, size=%d, addr=%zu\n",
-           thread_index, entry->type, entry->size, entry->addr);
+    VPRINT(this, 4, "Read from thread #%zd file: type=%s (%d), size=%d, addr=%zu\n",
+           thread_index, trace_type_names[entry->type], entry->type, entry->size,
+           entry->addr);
     return true;
 }
 

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -66,7 +66,8 @@ reader_t::operator++()
             // We've already presented the thread exit entry to the analyzer.
             continue;
         }
-        VPRINT(this, 4, "RECV: type=%d, size=%d, addr=0x%zx\n", input_entry_->type,
+        VPRINT(this, 4, "RECV: type=%s (%d), size=%d, addr=0x%zx\n",
+               trace_type_names[input_entry_->type], input_entry_->type,
                input_entry_->size, input_entry_->addr);
         if (process_input_entry())
             break;
@@ -196,7 +197,8 @@ reader_t::process_input_entry()
             // XXX i#3320: Diagnostics to track down the elusive remaining case of
             // this assert on Appveyor.  We'll remove and replace with just the
             // assert once we have a fix.
-            ERRMSG("Invalid trace entry type %d before a bundle\n", cur_ref_.instr.type);
+            ERRMSG("Invalid trace entry type %s (%d) before a bundle\n",
+                   trace_type_names[cur_ref_.instr.type], cur_ref_.instr.type);
             assert(type_is_instr(cur_ref_.instr.type) ||
                    cur_ref_.instr.type == TRACE_TYPE_INSTR_NO_FETCH);
         }
@@ -289,7 +291,8 @@ reader_t::process_input_entry()
             chunk_instr_count_ = cur_ref_.marker.marker_value;
         break;
     default:
-        ERRMSG("Unknown trace entry type %d\n", input_entry_->type);
+        ERRMSG("Unknown trace entry type %s (%d)\n", trace_type_names[input_entry_->type],
+               input_entry_->type);
         assert(false);
         at_eof_ = true; // bail
         break;

--- a/clients/drcachesim/reader/record_file_reader.cpp
+++ b/clients/drcachesim/reader/record_file_reader.cpp
@@ -63,8 +63,9 @@ record_file_reader_t<std::ifstream>::read_next_entry()
 {
     if (!input_file_->read((char *)&cur_entry_, sizeof(cur_entry_)))
         return false;
-    VPRINT(this, 4, "Read from file: type=%d, size=%d, addr=%zu\n", cur_entry_.type,
-           cur_entry_.size, cur_entry_.addr);
+    VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",
+           trace_type_names[cur_entry_.type], cur_entry_.type, cur_entry_.size,
+           cur_entry_.addr);
     return true;
 }
 

--- a/clients/drcachesim/reader/snappy_file_reader.cpp
+++ b/clients/drcachesim/reader/snappy_file_reader.cpp
@@ -234,8 +234,9 @@ file_reader_t<snappy_reader_t>::read_next_thread_entry(size_t thread_index,
         *eof = input_files_[thread_index].eof();
         return false;
     }
-    VPRINT(this, 4, "Read from thread #%zd file: type=%d, size=%d, addr=%zu\n",
-           thread_index, entry->type, entry->size, entry->addr);
+    VPRINT(this, 4, "Read from thread #%zd file: type=%s (%d), size=%d, addr=%zu\n",
+           thread_index, trace_type_names[entry->type], entry->type, entry->size,
+           entry->addr);
     return true;
 }
 

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -117,8 +117,9 @@ file_reader_t<zipfile_reader_t>::read_next_thread_entry(size_t thread_index,
     }
     *entry = *zipfile->cur_buf;
     ++zipfile->cur_buf;
-    VPRINT(this, 4, "Read from thread #%zd: type=%d, size=%d, addr=%zu\n", thread_index,
-           entry->type, entry->size, entry->addr);
+    VPRINT(this, 4, "Read from thread #%zd: type=%s (%d), size=%d, addr=%zu\n",
+           thread_index, trace_type_names[entry->type], entry->type, entry->size,
+           entry->addr);
     return true;
 }
 

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -763,7 +763,8 @@ process_entry_for_physaddr(void *drcontext, per_thread_t *data, size_t header_si
     addr_t phys = 0;
     bool success = data->physaddr.virtual2physical(drcontext, virt, &phys, &from_cache);
     ASSERT(emitted != NULL && skip != NULL, "invalid input parameters");
-    NOTIFY(4, "%s: type=%2d virt=%p phys=%p\n", __FUNCTION__, type, virt, phys);
+    NOTIFY(4, "%s: type=%s (%2d) virt=%p phys=%p\n", __FUNCTION__, trace_type_names[type],
+           type, virt, phys);
     if (!success) {
         // XXX i#1735: Unfortunately this happens; currently we use the virtual
         // address and continue.
@@ -772,8 +773,8 @@ process_entry_for_physaddr(void *drcontext, per_thread_t *data, size_t header_si
         // - wild access (NULL or very large bogus address) by app
         // - page is swapped out (unlikely since we're querying *after* the
         //   the app just accessed, but could happen)
-        NOTIFY(1, "virtual2physical translation failure for type=%2d addr=%p\n", type,
-               virt);
+        NOTIFY(1, "virtual2physical translation failure for type=%s (%2d) addr=%p\n",
+               trace_type_names[type], type, virt);
         phys = virt;
     }
     // We keep the main entries as virtual but add markers showing
@@ -881,8 +882,8 @@ process_buffer_for_physaddr(void *drcontext, per_thread_t *data, size_t header_s
         }
         if (ALIGN_BACKWARD(virt + mem_ref_size - 1 /*open-ended*/, page_size) !=
             virt_page) {
-            NOTIFY(2, "Emitting physaddr for next page %p for type=%2d, addr=%p\n",
-                   virt_page + page_size, type, virt);
+            NOTIFY(2, "Emitting physaddr for next page %p for type=%s (%2d), addr=%p\n",
+                   virt_page + page_size, trace_type_names[type], type, virt);
             v2p_ptr =
                 process_entry_for_physaddr(drcontext, data, header_size, v2p_ptr, mem_ref,
                                            virt_page + page_size, type, &emitted, &skip);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1141,8 +1141,9 @@ raw2trace_t::append_delayed_branch(void *tls)
                        entry.addr, tdata->index);
             } else {
                 VPRINT(4,
-                       "Appending delayed branch tagalong entry type %d for thread %d\n",
-                       entry.type, tdata->index);
+                       "Appending delayed branch tagalong entry type %s (%d) for thread "
+                       "%d\n",
+                       trace_type_names[entry.type], entry.type, tdata->index);
             }
         }
     }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1643,7 +1643,8 @@ private:
             have_type = true;
             buf->type = in_entry->extended.valueB;
             buf->size = in_entry->extended.valueA;
-            impl()->log(4, "Found type entry type %d size %d\n", buf->type, buf->size);
+            impl()->log(4, "Found type entry type %s (%d) size %d\n",
+                        trace_type_names[buf->type], buf->type, buf->size);
             in_entry = impl()->get_next_entry(tls);
             if (in_entry == nullptr)
                 return "Trace ends mid-block";
@@ -1704,8 +1705,9 @@ private:
             // We stored only the base reg, as an optimization.
             buf->addr += opnd_get_disp(memref.opnd);
         }
-        impl()->log(4, "Appended memref type %d size %d to " PFX "\n", buf->type,
-                    buf->size, (ptr_uint_t)buf->addr);
+        impl()->log(4, "Appended memref type %s (%d) size %d to " PFX "\n",
+                    trace_type_names[buf->type], buf->type, buf->size,
+                    (ptr_uint_t)buf->addr);
 
 #ifdef AARCH64
         // TODO i#4400: Following is a workaround to correctly represent DC ZVA in


### PR DESCRIPTION
Updates numerous diagnostics to use the string name instead of just the enum value for trace entry types.