### PR TITLE
Ignore bb with null instruction count

### DIFF
--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -736,7 +736,8 @@ offline_instru_t::instrument_instr(void *drcontext, void *tag, void *bb_field,
     reg_id_t reg_tmp;
     if (!memref_needs_full_info_) {
         // We write just once per bb, if not filtering.
-        if (per_block->instr_count > MAX_INSTR_COUNT)
+        if (per_block->instr_count > MAX_INSTR_COUNT ||
+            per_block->instr_count == 0)
             return adjust;
         pc = dr_fragment_app_pc(tag);
     } else {


### PR DESCRIPTION
In general I have bb with one jmp instruction on java workload
```
TAG  0x0000000000000000
 +0    m4 @0x00007f9f6ecbbc50  65 48 89 0c 25 d8 00 mov    %rcx -> %gs:0x000000d8[8byte]
                               00 00
 +9    m4 @0x00007f9f6ecba030  65 48 8b 0c 25 38 01 mov    %gs:0x00000138[8byte] -> %rcx
                               00 00
 +18   L3 @0x00007f9f6ecbc868  eb fe                jmp    $0x00007f9f65087e50
END 0x0000000000000000
```
In this case `instru_t::count_app_instrs` return the null counts of instructions in list

So, we have assert in converter phase
`append_bb_entries`
```
...
        if (instr_count == 0) {
            // L0 filtering adds a PC entry with a count of 0 prior to each memref.
            skip_icache = true;
            instr_count = 1;
            // We should have set a flag to avoid peeking forward on instr entries
            // based on OFFLINE_FILE_TYPE_FILTERED and
            // OFFLINE_FILE_TYPE_IFILTERED.
            DR_ASSERT(instrs_are_separate);
...
```

Could I just ignore such bb?
Thx, Kirill