### PR TITLE
i#3044: AArch64 sve codec: add abs, cnot, neg, sabd, smax, smin and uabd

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -40,11 +40,13 @@
 
 # Instruction definitions:
 
+00000100xx010110101xxxxxxxxxxxxx  n   6    SVE      abs  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
 00000100xx1xxxxx000000xxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000100xx000000000xxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10000011xxxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx011010000xxxxxxxxxxxxx  n   21   SVE      and             z0 : p10_lo z0 z5 bhsd_sz
 00000100xx011011000xxxxxxxxxxxxx  n   29   SVE      bic             z0 : p10_lo z0 z5 bhsd_sz
+00000100xx011011101xxxxxxxxxxxxx  n   793  SVE     cnot  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
 00000101xx01xxxx00xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_zer simm8_5 lsl shift1
 00000101xx01xxxx01xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_mrg simm8_5 lsl shift1
 00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor             z0 : p10_lo z0 z5 bhsd_sz
@@ -59,8 +61,14 @@
 00000100xx0xxxxx111xxxxxxxxxxxxx  n   788  SVE      msb  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_16 z_size_bhsd_5
 00000100xx010000000xxxxxxxxxxxxx  n   321  SVE      mul  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx110000110xxxxxxxxxxxxx  n   321  SVE      mul  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
+00000100xx010111101xxxxxxxxxxxxx  n   323  SVE      neg  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
 00000100xx011000000xxxxxxxxxxxxx  n   327  SVE      orr             z0 : p10_lo z0 z5 bhsd_sz
 001001010101000011xxxx0xxxx00000  w   786  SVE    ptest                : p10 p_b_5
+00000100xx001100000xxxxxxxxxxxxx  n   349  SVE     sabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
+00000100xx001000000xxxxxxxxxxxxx  n   386  SVE     smax  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
+00100101xx101000110xxxxxxxxxxxxx  n   386  SVE     smax  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
+00000100xx001010000xxxxxxxxxxxxx  n   390  SVE     smin  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
+00100101xx101010110xxxxxxxxxxxxx  n   390  SVE     smin  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
 00000100xx010010000xxxxxxxxxxxxx  n   399  SVE    smulh  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx1xxxxx000100xxxxxxxxxx  n   403  SVE    sqadd             z0 : z5 z16 bhsd_sz
 00100101xx10010011xxxxxxxxxxxxxx  n   403  SVE    sqadd  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
@@ -74,6 +82,7 @@
 00000100xx1xxxxx000001xxxxxxxxxx  n   470  SVE      sub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000100xx000011000xxxxxxxxxxxxx  n   784  SVE     subr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10001111xxxxxxxxxxxxxx  n   784  SVE     subr  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
+00000100xx001101000xxxxxxxxxxxxx  n   499  SVE     uabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx010011000xxxxxxxxxxxxx  n   528  SVE    umulh  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx1xxxxx000101xxxxxxxxxx  n   531  SVE    uqadd             z0 : z5 z16 bhsd_sz
 00100101xx10010111xxxxxxxxxxxxxx  n   531  SVE    uqadd  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -5421,4 +5421,137 @@
  */
 #define INSTR_CREATE_ftssel_sve(dc, Zd, Zn, Zm) \
     instr_create_1dst_2src(dc, OP_ftssel, Zd, Zn, Zm)
+
+/**
+ * Creates an ABS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ABS     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zn   The source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_abs_sve_pred(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_abs, Zd, Pg, Zn)
+
+/**
+ * Creates a CNOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    CNOT    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zn   The source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_cnot_sve_pred(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_cnot, Zd, Pg, Zn)
+
+/**
+ * Creates a NEG instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    NEG     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zn   The source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_neg_sve_pred(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_neg, Zd, Pg, Zn)
+
+/**
+ * Creates a SABD instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zm   The second source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_sabd_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_sabd, Zdn, Pg, Zdn, Zm)
+
+/**
+ * Creates a SMAX instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SMAX    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zm   The second source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_smax_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_smax, Zdn, Pg, Zdn, Zm)
+
+/**
+ * Creates a SMAX instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SMAX    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable)
+ * \param simm   The signed immediate imm
+ */
+#define INSTR_CREATE_smax_sve(dc, Zdn, simm) \
+    instr_create_1dst_2src(dc, OP_smax, Zdn, Zdn, simm)
+
+/**
+ * Creates a SMIN instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SMIN    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zm   The second source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_smin_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_smin, Zdn, Pg, Zdn, Zm)
+
+/**
+ * Creates a SMIN instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SMIN    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable)
+ * \param simm   The signed immediate imm
+ */
+#define INSTR_CREATE_smin_sve(dc, Zdn, simm) \
+    instr_create_1dst_2src(dc, OP_smin, Zdn, Zdn, simm)
+
+/**
+ * Creates an UABD instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zm   The second source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_uabd_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_uabd, Zdn, Pg, Zdn, Zm)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -49,6 +49,72 @@
 # and white-space sensitive.
 
 # Tests:
+# ABS     <Zd>.<T>, <Pg>/M, <Zn>.<T> (ABS-Z.P.Z-_)
+0416a000 : abs z0.b, p0/M, z0.b                      : abs    %p0/m %z0.b -> %z0.b
+0416a482 : abs z2.b, p1/M, z4.b                      : abs    %p1/m %z4.b -> %z2.b
+0416a8c4 : abs z4.b, p2/M, z6.b                      : abs    %p2/m %z6.b -> %z4.b
+0416a906 : abs z6.b, p2/M, z8.b                      : abs    %p2/m %z8.b -> %z6.b
+0416ad48 : abs z8.b, p3/M, z10.b                     : abs    %p3/m %z10.b -> %z8.b
+0416ad8a : abs z10.b, p3/M, z12.b                    : abs    %p3/m %z12.b -> %z10.b
+0416b1cc : abs z12.b, p4/M, z14.b                    : abs    %p4/m %z14.b -> %z12.b
+0416b20e : abs z14.b, p4/M, z16.b                    : abs    %p4/m %z16.b -> %z14.b
+0416b650 : abs z16.b, p5/M, z18.b                    : abs    %p5/m %z18.b -> %z16.b
+0416b671 : abs z17.b, p5/M, z19.b                    : abs    %p5/m %z19.b -> %z17.b
+0416b6b3 : abs z19.b, p5/M, z21.b                    : abs    %p5/m %z21.b -> %z19.b
+0416baf5 : abs z21.b, p6/M, z23.b                    : abs    %p6/m %z23.b -> %z21.b
+0416bb37 : abs z23.b, p6/M, z25.b                    : abs    %p6/m %z25.b -> %z23.b
+0416bf79 : abs z25.b, p7/M, z27.b                    : abs    %p7/m %z27.b -> %z25.b
+0416bfbb : abs z27.b, p7/M, z29.b                    : abs    %p7/m %z29.b -> %z27.b
+0416bfff : abs z31.b, p7/M, z31.b                    : abs    %p7/m %z31.b -> %z31.b
+0456a000 : abs z0.h, p0/M, z0.h                      : abs    %p0/m %z0.h -> %z0.h
+0456a482 : abs z2.h, p1/M, z4.h                      : abs    %p1/m %z4.h -> %z2.h
+0456a8c4 : abs z4.h, p2/M, z6.h                      : abs    %p2/m %z6.h -> %z4.h
+0456a906 : abs z6.h, p2/M, z8.h                      : abs    %p2/m %z8.h -> %z6.h
+0456ad48 : abs z8.h, p3/M, z10.h                     : abs    %p3/m %z10.h -> %z8.h
+0456ad8a : abs z10.h, p3/M, z12.h                    : abs    %p3/m %z12.h -> %z10.h
+0456b1cc : abs z12.h, p4/M, z14.h                    : abs    %p4/m %z14.h -> %z12.h
+0456b20e : abs z14.h, p4/M, z16.h                    : abs    %p4/m %z16.h -> %z14.h
+0456b650 : abs z16.h, p5/M, z18.h                    : abs    %p5/m %z18.h -> %z16.h
+0456b671 : abs z17.h, p5/M, z19.h                    : abs    %p5/m %z19.h -> %z17.h
+0456b6b3 : abs z19.h, p5/M, z21.h                    : abs    %p5/m %z21.h -> %z19.h
+0456baf5 : abs z21.h, p6/M, z23.h                    : abs    %p6/m %z23.h -> %z21.h
+0456bb37 : abs z23.h, p6/M, z25.h                    : abs    %p6/m %z25.h -> %z23.h
+0456bf79 : abs z25.h, p7/M, z27.h                    : abs    %p7/m %z27.h -> %z25.h
+0456bfbb : abs z27.h, p7/M, z29.h                    : abs    %p7/m %z29.h -> %z27.h
+0456bfff : abs z31.h, p7/M, z31.h                    : abs    %p7/m %z31.h -> %z31.h
+0496a000 : abs z0.s, p0/M, z0.s                      : abs    %p0/m %z0.s -> %z0.s
+0496a482 : abs z2.s, p1/M, z4.s                      : abs    %p1/m %z4.s -> %z2.s
+0496a8c4 : abs z4.s, p2/M, z6.s                      : abs    %p2/m %z6.s -> %z4.s
+0496a906 : abs z6.s, p2/M, z8.s                      : abs    %p2/m %z8.s -> %z6.s
+0496ad48 : abs z8.s, p3/M, z10.s                     : abs    %p3/m %z10.s -> %z8.s
+0496ad8a : abs z10.s, p3/M, z12.s                    : abs    %p3/m %z12.s -> %z10.s
+0496b1cc : abs z12.s, p4/M, z14.s                    : abs    %p4/m %z14.s -> %z12.s
+0496b20e : abs z14.s, p4/M, z16.s                    : abs    %p4/m %z16.s -> %z14.s
+0496b650 : abs z16.s, p5/M, z18.s                    : abs    %p5/m %z18.s -> %z16.s
+0496b671 : abs z17.s, p5/M, z19.s                    : abs    %p5/m %z19.s -> %z17.s
+0496b6b3 : abs z19.s, p5/M, z21.s                    : abs    %p5/m %z21.s -> %z19.s
+0496baf5 : abs z21.s, p6/M, z23.s                    : abs    %p6/m %z23.s -> %z21.s
+0496bb37 : abs z23.s, p6/M, z25.s                    : abs    %p6/m %z25.s -> %z23.s
+0496bf79 : abs z25.s, p7/M, z27.s                    : abs    %p7/m %z27.s -> %z25.s
+0496bfbb : abs z27.s, p7/M, z29.s                    : abs    %p7/m %z29.s -> %z27.s
+0496bfff : abs z31.s, p7/M, z31.s                    : abs    %p7/m %z31.s -> %z31.s
+04d6a000 : abs z0.d, p0/M, z0.d                      : abs    %p0/m %z0.d -> %z0.d
+04d6a482 : abs z2.d, p1/M, z4.d                      : abs    %p1/m %z4.d -> %z2.d
+04d6a8c4 : abs z4.d, p2/M, z6.d                      : abs    %p2/m %z6.d -> %z4.d
+04d6a906 : abs z6.d, p2/M, z8.d                      : abs    %p2/m %z8.d -> %z6.d
+04d6ad48 : abs z8.d, p3/M, z10.d                     : abs    %p3/m %z10.d -> %z8.d
+04d6ad8a : abs z10.d, p3/M, z12.d                    : abs    %p3/m %z12.d -> %z10.d
+04d6b1cc : abs z12.d, p4/M, z14.d                    : abs    %p4/m %z14.d -> %z12.d
+04d6b20e : abs z14.d, p4/M, z16.d                    : abs    %p4/m %z16.d -> %z14.d
+04d6b650 : abs z16.d, p5/M, z18.d                    : abs    %p5/m %z18.d -> %z16.d
+04d6b671 : abs z17.d, p5/M, z19.d                    : abs    %p5/m %z19.d -> %z17.d
+04d6b6b3 : abs z19.d, p5/M, z21.d                    : abs    %p5/m %z21.d -> %z19.d
+04d6baf5 : abs z21.d, p6/M, z23.d                    : abs    %p6/m %z23.d -> %z21.d
+04d6bb37 : abs z23.d, p6/M, z25.d                    : abs    %p6/m %z25.d -> %z23.d
+04d6bf79 : abs z25.d, p7/M, z27.d                    : abs    %p7/m %z27.d -> %z25.d
+04d6bfbb : abs z27.d, p7/M, z29.d                    : abs    %p7/m %z29.d -> %z27.d
+04d6bfff : abs z31.d, p7/M, z31.d                    : abs    %p7/m %z31.d -> %z31.d
+
 # ADD     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (ADD-Z.P.ZZ-_)
 04000000 : add z0.b, p0/M, z0.b, z0.b                : add    %p0/m %z0.b %z0.b -> %z0.b
 04000482 : add z2.b, p1/M, z2.b, z4.b                : add    %p1/m %z2.b %z4.b -> %z2.b
@@ -256,6 +322,72 @@
 045b0b02 : bic z2.h, p2/m, z2.h, z24.h              : bic    %p2 %z2 %z24 $0x01 -> %z2
 049b0b02 : bic z2.s, p2/m, z2.s, z24.s              : bic    %p2 %z2 %z24 $0x02 -> %z2
 04db0b02 : bic z2.d, p2/m, z2.d, z24.d              : bic    %p2 %z2 %z24 $0x03 -> %z2
+
+# CNOT    <Zd>.<T>, <Pg>/M, <Zn>.<T> (CNOT-Z.P.Z-_)
+041ba000 : cnot z0.b, p0/M, z0.b                     : cnot   %p0/m %z0.b -> %z0.b
+041ba482 : cnot z2.b, p1/M, z4.b                     : cnot   %p1/m %z4.b -> %z2.b
+041ba8c4 : cnot z4.b, p2/M, z6.b                     : cnot   %p2/m %z6.b -> %z4.b
+041ba906 : cnot z6.b, p2/M, z8.b                     : cnot   %p2/m %z8.b -> %z6.b
+041bad48 : cnot z8.b, p3/M, z10.b                    : cnot   %p3/m %z10.b -> %z8.b
+041bad8a : cnot z10.b, p3/M, z12.b                   : cnot   %p3/m %z12.b -> %z10.b
+041bb1cc : cnot z12.b, p4/M, z14.b                   : cnot   %p4/m %z14.b -> %z12.b
+041bb20e : cnot z14.b, p4/M, z16.b                   : cnot   %p4/m %z16.b -> %z14.b
+041bb650 : cnot z16.b, p5/M, z18.b                   : cnot   %p5/m %z18.b -> %z16.b
+041bb671 : cnot z17.b, p5/M, z19.b                   : cnot   %p5/m %z19.b -> %z17.b
+041bb6b3 : cnot z19.b, p5/M, z21.b                   : cnot   %p5/m %z21.b -> %z19.b
+041bbaf5 : cnot z21.b, p6/M, z23.b                   : cnot   %p6/m %z23.b -> %z21.b
+041bbb37 : cnot z23.b, p6/M, z25.b                   : cnot   %p6/m %z25.b -> %z23.b
+041bbf79 : cnot z25.b, p7/M, z27.b                   : cnot   %p7/m %z27.b -> %z25.b
+041bbfbb : cnot z27.b, p7/M, z29.b                   : cnot   %p7/m %z29.b -> %z27.b
+041bbfff : cnot z31.b, p7/M, z31.b                   : cnot   %p7/m %z31.b -> %z31.b
+045ba000 : cnot z0.h, p0/M, z0.h                     : cnot   %p0/m %z0.h -> %z0.h
+045ba482 : cnot z2.h, p1/M, z4.h                     : cnot   %p1/m %z4.h -> %z2.h
+045ba8c4 : cnot z4.h, p2/M, z6.h                     : cnot   %p2/m %z6.h -> %z4.h
+045ba906 : cnot z6.h, p2/M, z8.h                     : cnot   %p2/m %z8.h -> %z6.h
+045bad48 : cnot z8.h, p3/M, z10.h                    : cnot   %p3/m %z10.h -> %z8.h
+045bad8a : cnot z10.h, p3/M, z12.h                   : cnot   %p3/m %z12.h -> %z10.h
+045bb1cc : cnot z12.h, p4/M, z14.h                   : cnot   %p4/m %z14.h -> %z12.h
+045bb20e : cnot z14.h, p4/M, z16.h                   : cnot   %p4/m %z16.h -> %z14.h
+045bb650 : cnot z16.h, p5/M, z18.h                   : cnot   %p5/m %z18.h -> %z16.h
+045bb671 : cnot z17.h, p5/M, z19.h                   : cnot   %p5/m %z19.h -> %z17.h
+045bb6b3 : cnot z19.h, p5/M, z21.h                   : cnot   %p5/m %z21.h -> %z19.h
+045bbaf5 : cnot z21.h, p6/M, z23.h                   : cnot   %p6/m %z23.h -> %z21.h
+045bbb37 : cnot z23.h, p6/M, z25.h                   : cnot   %p6/m %z25.h -> %z23.h
+045bbf79 : cnot z25.h, p7/M, z27.h                   : cnot   %p7/m %z27.h -> %z25.h
+045bbfbb : cnot z27.h, p7/M, z29.h                   : cnot   %p7/m %z29.h -> %z27.h
+045bbfff : cnot z31.h, p7/M, z31.h                   : cnot   %p7/m %z31.h -> %z31.h
+049ba000 : cnot z0.s, p0/M, z0.s                     : cnot   %p0/m %z0.s -> %z0.s
+049ba482 : cnot z2.s, p1/M, z4.s                     : cnot   %p1/m %z4.s -> %z2.s
+049ba8c4 : cnot z4.s, p2/M, z6.s                     : cnot   %p2/m %z6.s -> %z4.s
+049ba906 : cnot z6.s, p2/M, z8.s                     : cnot   %p2/m %z8.s -> %z6.s
+049bad48 : cnot z8.s, p3/M, z10.s                    : cnot   %p3/m %z10.s -> %z8.s
+049bad8a : cnot z10.s, p3/M, z12.s                   : cnot   %p3/m %z12.s -> %z10.s
+049bb1cc : cnot z12.s, p4/M, z14.s                   : cnot   %p4/m %z14.s -> %z12.s
+049bb20e : cnot z14.s, p4/M, z16.s                   : cnot   %p4/m %z16.s -> %z14.s
+049bb650 : cnot z16.s, p5/M, z18.s                   : cnot   %p5/m %z18.s -> %z16.s
+049bb671 : cnot z17.s, p5/M, z19.s                   : cnot   %p5/m %z19.s -> %z17.s
+049bb6b3 : cnot z19.s, p5/M, z21.s                   : cnot   %p5/m %z21.s -> %z19.s
+049bbaf5 : cnot z21.s, p6/M, z23.s                   : cnot   %p6/m %z23.s -> %z21.s
+049bbb37 : cnot z23.s, p6/M, z25.s                   : cnot   %p6/m %z25.s -> %z23.s
+049bbf79 : cnot z25.s, p7/M, z27.s                   : cnot   %p7/m %z27.s -> %z25.s
+049bbfbb : cnot z27.s, p7/M, z29.s                   : cnot   %p7/m %z29.s -> %z27.s
+049bbfff : cnot z31.s, p7/M, z31.s                   : cnot   %p7/m %z31.s -> %z31.s
+04dba000 : cnot z0.d, p0/M, z0.d                     : cnot   %p0/m %z0.d -> %z0.d
+04dba482 : cnot z2.d, p1/M, z4.d                     : cnot   %p1/m %z4.d -> %z2.d
+04dba8c4 : cnot z4.d, p2/M, z6.d                     : cnot   %p2/m %z6.d -> %z4.d
+04dba906 : cnot z6.d, p2/M, z8.d                     : cnot   %p2/m %z8.d -> %z6.d
+04dbad48 : cnot z8.d, p3/M, z10.d                    : cnot   %p3/m %z10.d -> %z8.d
+04dbad8a : cnot z10.d, p3/M, z12.d                   : cnot   %p3/m %z12.d -> %z10.d
+04dbb1cc : cnot z12.d, p4/M, z14.d                   : cnot   %p4/m %z14.d -> %z12.d
+04dbb20e : cnot z14.d, p4/M, z16.d                   : cnot   %p4/m %z16.d -> %z14.d
+04dbb650 : cnot z16.d, p5/M, z18.d                   : cnot   %p5/m %z18.d -> %z16.d
+04dbb671 : cnot z17.d, p5/M, z19.d                   : cnot   %p5/m %z19.d -> %z17.d
+04dbb6b3 : cnot z19.d, p5/M, z21.d                   : cnot   %p5/m %z21.d -> %z19.d
+04dbbaf5 : cnot z21.d, p6/M, z23.d                   : cnot   %p6/m %z23.d -> %z21.d
+04dbbb37 : cnot z23.d, p6/M, z25.d                   : cnot   %p6/m %z25.d -> %z23.d
+04dbbf79 : cnot z25.d, p7/M, z27.d                   : cnot   %p7/m %z27.d -> %z25.d
+04dbbfbb : cnot z27.d, p7/M, z29.d                   : cnot   %p7/m %z29.d -> %z27.d
+04dbbfff : cnot z31.d, p7/M, z31.d                   : cnot   %p7/m %z31.d -> %z31.d
 
 # CPY     <Zd>.<T>, <Pg>/Z, #<imm>, <shift> (CPY-Z.O.I-_)
 05101000 : cpy z0.b, p0/Z, #-0x80, lsl #0            : cpy    %p0/z $0x80 lsl $0x00 -> %z0.b
@@ -1008,6 +1140,72 @@
 25f0cbfb : mul z27.d, z27.d, #0x5f                   : mul    %z27.d $0x5f -> %z27.d
 25f0cfff : mul z31.d, z31.d, #0x7f                   : mul    %z31.d $0x7f -> %z31.d
 
+# NEG     <Zd>.<T>, <Pg>/M, <Zn>.<T> (NEG-Z.P.Z-_)
+0417a000 : neg z0.b, p0/M, z0.b                      : neg    %p0/m %z0.b -> %z0.b
+0417a482 : neg z2.b, p1/M, z4.b                      : neg    %p1/m %z4.b -> %z2.b
+0417a8c4 : neg z4.b, p2/M, z6.b                      : neg    %p2/m %z6.b -> %z4.b
+0417a906 : neg z6.b, p2/M, z8.b                      : neg    %p2/m %z8.b -> %z6.b
+0417ad48 : neg z8.b, p3/M, z10.b                     : neg    %p3/m %z10.b -> %z8.b
+0417ad8a : neg z10.b, p3/M, z12.b                    : neg    %p3/m %z12.b -> %z10.b
+0417b1cc : neg z12.b, p4/M, z14.b                    : neg    %p4/m %z14.b -> %z12.b
+0417b20e : neg z14.b, p4/M, z16.b                    : neg    %p4/m %z16.b -> %z14.b
+0417b650 : neg z16.b, p5/M, z18.b                    : neg    %p5/m %z18.b -> %z16.b
+0417b671 : neg z17.b, p5/M, z19.b                    : neg    %p5/m %z19.b -> %z17.b
+0417b6b3 : neg z19.b, p5/M, z21.b                    : neg    %p5/m %z21.b -> %z19.b
+0417baf5 : neg z21.b, p6/M, z23.b                    : neg    %p6/m %z23.b -> %z21.b
+0417bb37 : neg z23.b, p6/M, z25.b                    : neg    %p6/m %z25.b -> %z23.b
+0417bf79 : neg z25.b, p7/M, z27.b                    : neg    %p7/m %z27.b -> %z25.b
+0417bfbb : neg z27.b, p7/M, z29.b                    : neg    %p7/m %z29.b -> %z27.b
+0417bfff : neg z31.b, p7/M, z31.b                    : neg    %p7/m %z31.b -> %z31.b
+0457a000 : neg z0.h, p0/M, z0.h                      : neg    %p0/m %z0.h -> %z0.h
+0457a482 : neg z2.h, p1/M, z4.h                      : neg    %p1/m %z4.h -> %z2.h
+0457a8c4 : neg z4.h, p2/M, z6.h                      : neg    %p2/m %z6.h -> %z4.h
+0457a906 : neg z6.h, p2/M, z8.h                      : neg    %p2/m %z8.h -> %z6.h
+0457ad48 : neg z8.h, p3/M, z10.h                     : neg    %p3/m %z10.h -> %z8.h
+0457ad8a : neg z10.h, p3/M, z12.h                    : neg    %p3/m %z12.h -> %z10.h
+0457b1cc : neg z12.h, p4/M, z14.h                    : neg    %p4/m %z14.h -> %z12.h
+0457b20e : neg z14.h, p4/M, z16.h                    : neg    %p4/m %z16.h -> %z14.h
+0457b650 : neg z16.h, p5/M, z18.h                    : neg    %p5/m %z18.h -> %z16.h
+0457b671 : neg z17.h, p5/M, z19.h                    : neg    %p5/m %z19.h -> %z17.h
+0457b6b3 : neg z19.h, p5/M, z21.h                    : neg    %p5/m %z21.h -> %z19.h
+0457baf5 : neg z21.h, p6/M, z23.h                    : neg    %p6/m %z23.h -> %z21.h
+0457bb37 : neg z23.h, p6/M, z25.h                    : neg    %p6/m %z25.h -> %z23.h
+0457bf79 : neg z25.h, p7/M, z27.h                    : neg    %p7/m %z27.h -> %z25.h
+0457bfbb : neg z27.h, p7/M, z29.h                    : neg    %p7/m %z29.h -> %z27.h
+0457bfff : neg z31.h, p7/M, z31.h                    : neg    %p7/m %z31.h -> %z31.h
+0497a000 : neg z0.s, p0/M, z0.s                      : neg    %p0/m %z0.s -> %z0.s
+0497a482 : neg z2.s, p1/M, z4.s                      : neg    %p1/m %z4.s -> %z2.s
+0497a8c4 : neg z4.s, p2/M, z6.s                      : neg    %p2/m %z6.s -> %z4.s
+0497a906 : neg z6.s, p2/M, z8.s                      : neg    %p2/m %z8.s -> %z6.s
+0497ad48 : neg z8.s, p3/M, z10.s                     : neg    %p3/m %z10.s -> %z8.s
+0497ad8a : neg z10.s, p3/M, z12.s                    : neg    %p3/m %z12.s -> %z10.s
+0497b1cc : neg z12.s, p4/M, z14.s                    : neg    %p4/m %z14.s -> %z12.s
+0497b20e : neg z14.s, p4/M, z16.s                    : neg    %p4/m %z16.s -> %z14.s
+0497b650 : neg z16.s, p5/M, z18.s                    : neg    %p5/m %z18.s -> %z16.s
+0497b671 : neg z17.s, p5/M, z19.s                    : neg    %p5/m %z19.s -> %z17.s
+0497b6b3 : neg z19.s, p5/M, z21.s                    : neg    %p5/m %z21.s -> %z19.s
+0497baf5 : neg z21.s, p6/M, z23.s                    : neg    %p6/m %z23.s -> %z21.s
+0497bb37 : neg z23.s, p6/M, z25.s                    : neg    %p6/m %z25.s -> %z23.s
+0497bf79 : neg z25.s, p7/M, z27.s                    : neg    %p7/m %z27.s -> %z25.s
+0497bfbb : neg z27.s, p7/M, z29.s                    : neg    %p7/m %z29.s -> %z27.s
+0497bfff : neg z31.s, p7/M, z31.s                    : neg    %p7/m %z31.s -> %z31.s
+04d7a000 : neg z0.d, p0/M, z0.d                      : neg    %p0/m %z0.d -> %z0.d
+04d7a482 : neg z2.d, p1/M, z4.d                      : neg    %p1/m %z4.d -> %z2.d
+04d7a8c4 : neg z4.d, p2/M, z6.d                      : neg    %p2/m %z6.d -> %z4.d
+04d7a906 : neg z6.d, p2/M, z8.d                      : neg    %p2/m %z8.d -> %z6.d
+04d7ad48 : neg z8.d, p3/M, z10.d                     : neg    %p3/m %z10.d -> %z8.d
+04d7ad8a : neg z10.d, p3/M, z12.d                    : neg    %p3/m %z12.d -> %z10.d
+04d7b1cc : neg z12.d, p4/M, z14.d                    : neg    %p4/m %z14.d -> %z12.d
+04d7b20e : neg z14.d, p4/M, z16.d                    : neg    %p4/m %z16.d -> %z14.d
+04d7b650 : neg z16.d, p5/M, z18.d                    : neg    %p5/m %z18.d -> %z16.d
+04d7b671 : neg z17.d, p5/M, z19.d                    : neg    %p5/m %z19.d -> %z17.d
+04d7b6b3 : neg z19.d, p5/M, z21.d                    : neg    %p5/m %z21.d -> %z19.d
+04d7baf5 : neg z21.d, p6/M, z23.d                    : neg    %p6/m %z23.d -> %z21.d
+04d7bb37 : neg z23.d, p6/M, z25.d                    : neg    %p6/m %z25.d -> %z23.d
+04d7bf79 : neg z25.d, p7/M, z27.d                    : neg    %p7/m %z27.d -> %z25.d
+04d7bfbb : neg z27.d, p7/M, z29.d                    : neg    %p7/m %z29.d -> %z27.d
+04d7bfff : neg z31.d, p7/M, z31.d                    : neg    %p7/m %z31.d -> %z31.d
+
 04181da2 : orr z2.b, p7/m, z2.b, z13.b              : orr    %p7 %z2 %z13 $0x00 -> %z2
 04581da2 : orr z2.h, p7/m, z2.h, z13.h              : orr    %p7 %z2 %z13 $0x01 -> %z2
 04981da2 : orr z2.s, p7/m, z2.s, z13.s              : orr    %p7 %z2 %z13 $0x02 -> %z2
@@ -1030,6 +1228,336 @@
 2550ed80 : ptest p11, p12.b                          : ptest  %p11 %p12.b
 2550f1a0 : ptest p12, p13.b                          : ptest  %p12 %p13.b
 2550f9c0 : ptest p14, p14.b                          : ptest  %p14 %p14.b
+
+# SABD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SABD-Z.P.ZZ-_)
+040c0000 : sabd z0.b, p0/M, z0.b, z0.b               : sabd   %p0/m %z0.b %z0.b -> %z0.b
+040c0482 : sabd z2.b, p1/M, z2.b, z4.b               : sabd   %p1/m %z2.b %z4.b -> %z2.b
+040c08c4 : sabd z4.b, p2/M, z4.b, z6.b               : sabd   %p2/m %z4.b %z6.b -> %z4.b
+040c0906 : sabd z6.b, p2/M, z6.b, z8.b               : sabd   %p2/m %z6.b %z8.b -> %z6.b
+040c0d48 : sabd z8.b, p3/M, z8.b, z10.b              : sabd   %p3/m %z8.b %z10.b -> %z8.b
+040c0d8a : sabd z10.b, p3/M, z10.b, z12.b            : sabd   %p3/m %z10.b %z12.b -> %z10.b
+040c11cc : sabd z12.b, p4/M, z12.b, z14.b            : sabd   %p4/m %z12.b %z14.b -> %z12.b
+040c120e : sabd z14.b, p4/M, z14.b, z16.b            : sabd   %p4/m %z14.b %z16.b -> %z14.b
+040c1650 : sabd z16.b, p5/M, z16.b, z18.b            : sabd   %p5/m %z16.b %z18.b -> %z16.b
+040c1671 : sabd z17.b, p5/M, z17.b, z19.b            : sabd   %p5/m %z17.b %z19.b -> %z17.b
+040c16b3 : sabd z19.b, p5/M, z19.b, z21.b            : sabd   %p5/m %z19.b %z21.b -> %z19.b
+040c1af5 : sabd z21.b, p6/M, z21.b, z23.b            : sabd   %p6/m %z21.b %z23.b -> %z21.b
+040c1b37 : sabd z23.b, p6/M, z23.b, z25.b            : sabd   %p6/m %z23.b %z25.b -> %z23.b
+040c1f79 : sabd z25.b, p7/M, z25.b, z27.b            : sabd   %p7/m %z25.b %z27.b -> %z25.b
+040c1fbb : sabd z27.b, p7/M, z27.b, z29.b            : sabd   %p7/m %z27.b %z29.b -> %z27.b
+040c1fff : sabd z31.b, p7/M, z31.b, z31.b            : sabd   %p7/m %z31.b %z31.b -> %z31.b
+044c0000 : sabd z0.h, p0/M, z0.h, z0.h               : sabd   %p0/m %z0.h %z0.h -> %z0.h
+044c0482 : sabd z2.h, p1/M, z2.h, z4.h               : sabd   %p1/m %z2.h %z4.h -> %z2.h
+044c08c4 : sabd z4.h, p2/M, z4.h, z6.h               : sabd   %p2/m %z4.h %z6.h -> %z4.h
+044c0906 : sabd z6.h, p2/M, z6.h, z8.h               : sabd   %p2/m %z6.h %z8.h -> %z6.h
+044c0d48 : sabd z8.h, p3/M, z8.h, z10.h              : sabd   %p3/m %z8.h %z10.h -> %z8.h
+044c0d8a : sabd z10.h, p3/M, z10.h, z12.h            : sabd   %p3/m %z10.h %z12.h -> %z10.h
+044c11cc : sabd z12.h, p4/M, z12.h, z14.h            : sabd   %p4/m %z12.h %z14.h -> %z12.h
+044c120e : sabd z14.h, p4/M, z14.h, z16.h            : sabd   %p4/m %z14.h %z16.h -> %z14.h
+044c1650 : sabd z16.h, p5/M, z16.h, z18.h            : sabd   %p5/m %z16.h %z18.h -> %z16.h
+044c1671 : sabd z17.h, p5/M, z17.h, z19.h            : sabd   %p5/m %z17.h %z19.h -> %z17.h
+044c16b3 : sabd z19.h, p5/M, z19.h, z21.h            : sabd   %p5/m %z19.h %z21.h -> %z19.h
+044c1af5 : sabd z21.h, p6/M, z21.h, z23.h            : sabd   %p6/m %z21.h %z23.h -> %z21.h
+044c1b37 : sabd z23.h, p6/M, z23.h, z25.h            : sabd   %p6/m %z23.h %z25.h -> %z23.h
+044c1f79 : sabd z25.h, p7/M, z25.h, z27.h            : sabd   %p7/m %z25.h %z27.h -> %z25.h
+044c1fbb : sabd z27.h, p7/M, z27.h, z29.h            : sabd   %p7/m %z27.h %z29.h -> %z27.h
+044c1fff : sabd z31.h, p7/M, z31.h, z31.h            : sabd   %p7/m %z31.h %z31.h -> %z31.h
+048c0000 : sabd z0.s, p0/M, z0.s, z0.s               : sabd   %p0/m %z0.s %z0.s -> %z0.s
+048c0482 : sabd z2.s, p1/M, z2.s, z4.s               : sabd   %p1/m %z2.s %z4.s -> %z2.s
+048c08c4 : sabd z4.s, p2/M, z4.s, z6.s               : sabd   %p2/m %z4.s %z6.s -> %z4.s
+048c0906 : sabd z6.s, p2/M, z6.s, z8.s               : sabd   %p2/m %z6.s %z8.s -> %z6.s
+048c0d48 : sabd z8.s, p3/M, z8.s, z10.s              : sabd   %p3/m %z8.s %z10.s -> %z8.s
+048c0d8a : sabd z10.s, p3/M, z10.s, z12.s            : sabd   %p3/m %z10.s %z12.s -> %z10.s
+048c11cc : sabd z12.s, p4/M, z12.s, z14.s            : sabd   %p4/m %z12.s %z14.s -> %z12.s
+048c120e : sabd z14.s, p4/M, z14.s, z16.s            : sabd   %p4/m %z14.s %z16.s -> %z14.s
+048c1650 : sabd z16.s, p5/M, z16.s, z18.s            : sabd   %p5/m %z16.s %z18.s -> %z16.s
+048c1671 : sabd z17.s, p5/M, z17.s, z19.s            : sabd   %p5/m %z17.s %z19.s -> %z17.s
+048c16b3 : sabd z19.s, p5/M, z19.s, z21.s            : sabd   %p5/m %z19.s %z21.s -> %z19.s
+048c1af5 : sabd z21.s, p6/M, z21.s, z23.s            : sabd   %p6/m %z21.s %z23.s -> %z21.s
+048c1b37 : sabd z23.s, p6/M, z23.s, z25.s            : sabd   %p6/m %z23.s %z25.s -> %z23.s
+048c1f79 : sabd z25.s, p7/M, z25.s, z27.s            : sabd   %p7/m %z25.s %z27.s -> %z25.s
+048c1fbb : sabd z27.s, p7/M, z27.s, z29.s            : sabd   %p7/m %z27.s %z29.s -> %z27.s
+048c1fff : sabd z31.s, p7/M, z31.s, z31.s            : sabd   %p7/m %z31.s %z31.s -> %z31.s
+04cc0000 : sabd z0.d, p0/M, z0.d, z0.d               : sabd   %p0/m %z0.d %z0.d -> %z0.d
+04cc0482 : sabd z2.d, p1/M, z2.d, z4.d               : sabd   %p1/m %z2.d %z4.d -> %z2.d
+04cc08c4 : sabd z4.d, p2/M, z4.d, z6.d               : sabd   %p2/m %z4.d %z6.d -> %z4.d
+04cc0906 : sabd z6.d, p2/M, z6.d, z8.d               : sabd   %p2/m %z6.d %z8.d -> %z6.d
+04cc0d48 : sabd z8.d, p3/M, z8.d, z10.d              : sabd   %p3/m %z8.d %z10.d -> %z8.d
+04cc0d8a : sabd z10.d, p3/M, z10.d, z12.d            : sabd   %p3/m %z10.d %z12.d -> %z10.d
+04cc11cc : sabd z12.d, p4/M, z12.d, z14.d            : sabd   %p4/m %z12.d %z14.d -> %z12.d
+04cc120e : sabd z14.d, p4/M, z14.d, z16.d            : sabd   %p4/m %z14.d %z16.d -> %z14.d
+04cc1650 : sabd z16.d, p5/M, z16.d, z18.d            : sabd   %p5/m %z16.d %z18.d -> %z16.d
+04cc1671 : sabd z17.d, p5/M, z17.d, z19.d            : sabd   %p5/m %z17.d %z19.d -> %z17.d
+04cc16b3 : sabd z19.d, p5/M, z19.d, z21.d            : sabd   %p5/m %z19.d %z21.d -> %z19.d
+04cc1af5 : sabd z21.d, p6/M, z21.d, z23.d            : sabd   %p6/m %z21.d %z23.d -> %z21.d
+04cc1b37 : sabd z23.d, p6/M, z23.d, z25.d            : sabd   %p6/m %z23.d %z25.d -> %z23.d
+04cc1f79 : sabd z25.d, p7/M, z25.d, z27.d            : sabd   %p7/m %z25.d %z27.d -> %z25.d
+04cc1fbb : sabd z27.d, p7/M, z27.d, z29.d            : sabd   %p7/m %z27.d %z29.d -> %z27.d
+04cc1fff : sabd z31.d, p7/M, z31.d, z31.d            : sabd   %p7/m %z31.d %z31.d -> %z31.d
+
+# SMAX    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SMAX-Z.P.ZZ-_)
+04080000 : smax z0.b, p0/M, z0.b, z0.b               : smax   %p0/m %z0.b %z0.b -> %z0.b
+04080482 : smax z2.b, p1/M, z2.b, z4.b               : smax   %p1/m %z2.b %z4.b -> %z2.b
+040808c4 : smax z4.b, p2/M, z4.b, z6.b               : smax   %p2/m %z4.b %z6.b -> %z4.b
+04080906 : smax z6.b, p2/M, z6.b, z8.b               : smax   %p2/m %z6.b %z8.b -> %z6.b
+04080d48 : smax z8.b, p3/M, z8.b, z10.b              : smax   %p3/m %z8.b %z10.b -> %z8.b
+04080d8a : smax z10.b, p3/M, z10.b, z12.b            : smax   %p3/m %z10.b %z12.b -> %z10.b
+040811cc : smax z12.b, p4/M, z12.b, z14.b            : smax   %p4/m %z12.b %z14.b -> %z12.b
+0408120e : smax z14.b, p4/M, z14.b, z16.b            : smax   %p4/m %z14.b %z16.b -> %z14.b
+04081650 : smax z16.b, p5/M, z16.b, z18.b            : smax   %p5/m %z16.b %z18.b -> %z16.b
+04081671 : smax z17.b, p5/M, z17.b, z19.b            : smax   %p5/m %z17.b %z19.b -> %z17.b
+040816b3 : smax z19.b, p5/M, z19.b, z21.b            : smax   %p5/m %z19.b %z21.b -> %z19.b
+04081af5 : smax z21.b, p6/M, z21.b, z23.b            : smax   %p6/m %z21.b %z23.b -> %z21.b
+04081b37 : smax z23.b, p6/M, z23.b, z25.b            : smax   %p6/m %z23.b %z25.b -> %z23.b
+04081f79 : smax z25.b, p7/M, z25.b, z27.b            : smax   %p7/m %z25.b %z27.b -> %z25.b
+04081fbb : smax z27.b, p7/M, z27.b, z29.b            : smax   %p7/m %z27.b %z29.b -> %z27.b
+04081fff : smax z31.b, p7/M, z31.b, z31.b            : smax   %p7/m %z31.b %z31.b -> %z31.b
+04480000 : smax z0.h, p0/M, z0.h, z0.h               : smax   %p0/m %z0.h %z0.h -> %z0.h
+04480482 : smax z2.h, p1/M, z2.h, z4.h               : smax   %p1/m %z2.h %z4.h -> %z2.h
+044808c4 : smax z4.h, p2/M, z4.h, z6.h               : smax   %p2/m %z4.h %z6.h -> %z4.h
+04480906 : smax z6.h, p2/M, z6.h, z8.h               : smax   %p2/m %z6.h %z8.h -> %z6.h
+04480d48 : smax z8.h, p3/M, z8.h, z10.h              : smax   %p3/m %z8.h %z10.h -> %z8.h
+04480d8a : smax z10.h, p3/M, z10.h, z12.h            : smax   %p3/m %z10.h %z12.h -> %z10.h
+044811cc : smax z12.h, p4/M, z12.h, z14.h            : smax   %p4/m %z12.h %z14.h -> %z12.h
+0448120e : smax z14.h, p4/M, z14.h, z16.h            : smax   %p4/m %z14.h %z16.h -> %z14.h
+04481650 : smax z16.h, p5/M, z16.h, z18.h            : smax   %p5/m %z16.h %z18.h -> %z16.h
+04481671 : smax z17.h, p5/M, z17.h, z19.h            : smax   %p5/m %z17.h %z19.h -> %z17.h
+044816b3 : smax z19.h, p5/M, z19.h, z21.h            : smax   %p5/m %z19.h %z21.h -> %z19.h
+04481af5 : smax z21.h, p6/M, z21.h, z23.h            : smax   %p6/m %z21.h %z23.h -> %z21.h
+04481b37 : smax z23.h, p6/M, z23.h, z25.h            : smax   %p6/m %z23.h %z25.h -> %z23.h
+04481f79 : smax z25.h, p7/M, z25.h, z27.h            : smax   %p7/m %z25.h %z27.h -> %z25.h
+04481fbb : smax z27.h, p7/M, z27.h, z29.h            : smax   %p7/m %z27.h %z29.h -> %z27.h
+04481fff : smax z31.h, p7/M, z31.h, z31.h            : smax   %p7/m %z31.h %z31.h -> %z31.h
+04880000 : smax z0.s, p0/M, z0.s, z0.s               : smax   %p0/m %z0.s %z0.s -> %z0.s
+04880482 : smax z2.s, p1/M, z2.s, z4.s               : smax   %p1/m %z2.s %z4.s -> %z2.s
+048808c4 : smax z4.s, p2/M, z4.s, z6.s               : smax   %p2/m %z4.s %z6.s -> %z4.s
+04880906 : smax z6.s, p2/M, z6.s, z8.s               : smax   %p2/m %z6.s %z8.s -> %z6.s
+04880d48 : smax z8.s, p3/M, z8.s, z10.s              : smax   %p3/m %z8.s %z10.s -> %z8.s
+04880d8a : smax z10.s, p3/M, z10.s, z12.s            : smax   %p3/m %z10.s %z12.s -> %z10.s
+048811cc : smax z12.s, p4/M, z12.s, z14.s            : smax   %p4/m %z12.s %z14.s -> %z12.s
+0488120e : smax z14.s, p4/M, z14.s, z16.s            : smax   %p4/m %z14.s %z16.s -> %z14.s
+04881650 : smax z16.s, p5/M, z16.s, z18.s            : smax   %p5/m %z16.s %z18.s -> %z16.s
+04881671 : smax z17.s, p5/M, z17.s, z19.s            : smax   %p5/m %z17.s %z19.s -> %z17.s
+048816b3 : smax z19.s, p5/M, z19.s, z21.s            : smax   %p5/m %z19.s %z21.s -> %z19.s
+04881af5 : smax z21.s, p6/M, z21.s, z23.s            : smax   %p6/m %z21.s %z23.s -> %z21.s
+04881b37 : smax z23.s, p6/M, z23.s, z25.s            : smax   %p6/m %z23.s %z25.s -> %z23.s
+04881f79 : smax z25.s, p7/M, z25.s, z27.s            : smax   %p7/m %z25.s %z27.s -> %z25.s
+04881fbb : smax z27.s, p7/M, z27.s, z29.s            : smax   %p7/m %z27.s %z29.s -> %z27.s
+04881fff : smax z31.s, p7/M, z31.s, z31.s            : smax   %p7/m %z31.s %z31.s -> %z31.s
+04c80000 : smax z0.d, p0/M, z0.d, z0.d               : smax   %p0/m %z0.d %z0.d -> %z0.d
+04c80482 : smax z2.d, p1/M, z2.d, z4.d               : smax   %p1/m %z2.d %z4.d -> %z2.d
+04c808c4 : smax z4.d, p2/M, z4.d, z6.d               : smax   %p2/m %z4.d %z6.d -> %z4.d
+04c80906 : smax z6.d, p2/M, z6.d, z8.d               : smax   %p2/m %z6.d %z8.d -> %z6.d
+04c80d48 : smax z8.d, p3/M, z8.d, z10.d              : smax   %p3/m %z8.d %z10.d -> %z8.d
+04c80d8a : smax z10.d, p3/M, z10.d, z12.d            : smax   %p3/m %z10.d %z12.d -> %z10.d
+04c811cc : smax z12.d, p4/M, z12.d, z14.d            : smax   %p4/m %z12.d %z14.d -> %z12.d
+04c8120e : smax z14.d, p4/M, z14.d, z16.d            : smax   %p4/m %z14.d %z16.d -> %z14.d
+04c81650 : smax z16.d, p5/M, z16.d, z18.d            : smax   %p5/m %z16.d %z18.d -> %z16.d
+04c81671 : smax z17.d, p5/M, z17.d, z19.d            : smax   %p5/m %z17.d %z19.d -> %z17.d
+04c816b3 : smax z19.d, p5/M, z19.d, z21.d            : smax   %p5/m %z19.d %z21.d -> %z19.d
+04c81af5 : smax z21.d, p6/M, z21.d, z23.d            : smax   %p6/m %z21.d %z23.d -> %z21.d
+04c81b37 : smax z23.d, p6/M, z23.d, z25.d            : smax   %p6/m %z23.d %z25.d -> %z23.d
+04c81f79 : smax z25.d, p7/M, z25.d, z27.d            : smax   %p7/m %z25.d %z27.d -> %z25.d
+04c81fbb : smax z27.d, p7/M, z27.d, z29.d            : smax   %p7/m %z27.d %z29.d -> %z27.d
+04c81fff : smax z31.d, p7/M, z31.d, z31.d            : smax   %p7/m %z31.d %z31.d -> %z31.d
+
+# SMAX    <Zdn>.<T>, <Zdn>.<T>, #<imm> (SMAX-Z.ZI-_)
+2528d000 : smax z0.b, z0.b, #-0x80                   : smax   %z0.b $0x80 -> %z0.b
+2528d202 : smax z2.b, z2.b, #-0x70                   : smax   %z2.b $0x90 -> %z2.b
+2528d404 : smax z4.b, z4.b, #-0x60                   : smax   %z4.b $0xa0 -> %z4.b
+2528d606 : smax z6.b, z6.b, #-0x50                   : smax   %z6.b $0xb0 -> %z6.b
+2528d808 : smax z8.b, z8.b, #-0x40                   : smax   %z8.b $0xc0 -> %z8.b
+2528da0a : smax z10.b, z10.b, #-0x30                 : smax   %z10.b $0xd0 -> %z10.b
+2528dc0c : smax z12.b, z12.b, #-0x20                 : smax   %z12.b $0xe0 -> %z12.b
+2528de0e : smax z14.b, z14.b, #-0x10                 : smax   %z14.b $0xf0 -> %z14.b
+2528c010 : smax z16.b, z16.b, #0x0                   : smax   %z16.b $0x00 -> %z16.b
+2528c1f1 : smax z17.b, z17.b, #0xf                   : smax   %z17.b $0x0f -> %z17.b
+2528c3f3 : smax z19.b, z19.b, #0x1f                  : smax   %z19.b $0x1f -> %z19.b
+2528c5f5 : smax z21.b, z21.b, #0x2f                  : smax   %z21.b $0x2f -> %z21.b
+2528c7f7 : smax z23.b, z23.b, #0x3f                  : smax   %z23.b $0x3f -> %z23.b
+2528c9f9 : smax z25.b, z25.b, #0x4f                  : smax   %z25.b $0x4f -> %z25.b
+2528cbfb : smax z27.b, z27.b, #0x5f                  : smax   %z27.b $0x5f -> %z27.b
+2528cfff : smax z31.b, z31.b, #0x7f                  : smax   %z31.b $0x7f -> %z31.b
+2568d000 : smax z0.h, z0.h, #-0x80                   : smax   %z0.h $0x80 -> %z0.h
+2568d202 : smax z2.h, z2.h, #-0x70                   : smax   %z2.h $0x90 -> %z2.h
+2568d404 : smax z4.h, z4.h, #-0x60                   : smax   %z4.h $0xa0 -> %z4.h
+2568d606 : smax z6.h, z6.h, #-0x50                   : smax   %z6.h $0xb0 -> %z6.h
+2568d808 : smax z8.h, z8.h, #-0x40                   : smax   %z8.h $0xc0 -> %z8.h
+2568da0a : smax z10.h, z10.h, #-0x30                 : smax   %z10.h $0xd0 -> %z10.h
+2568dc0c : smax z12.h, z12.h, #-0x20                 : smax   %z12.h $0xe0 -> %z12.h
+2568de0e : smax z14.h, z14.h, #-0x10                 : smax   %z14.h $0xf0 -> %z14.h
+2568c010 : smax z16.h, z16.h, #0x0                   : smax   %z16.h $0x00 -> %z16.h
+2568c1f1 : smax z17.h, z17.h, #0xf                   : smax   %z17.h $0x0f -> %z17.h
+2568c3f3 : smax z19.h, z19.h, #0x1f                  : smax   %z19.h $0x1f -> %z19.h
+2568c5f5 : smax z21.h, z21.h, #0x2f                  : smax   %z21.h $0x2f -> %z21.h
+2568c7f7 : smax z23.h, z23.h, #0x3f                  : smax   %z23.h $0x3f -> %z23.h
+2568c9f9 : smax z25.h, z25.h, #0x4f                  : smax   %z25.h $0x4f -> %z25.h
+2568cbfb : smax z27.h, z27.h, #0x5f                  : smax   %z27.h $0x5f -> %z27.h
+2568cfff : smax z31.h, z31.h, #0x7f                  : smax   %z31.h $0x7f -> %z31.h
+25a8d000 : smax z0.s, z0.s, #-0x80                   : smax   %z0.s $0x80 -> %z0.s
+25a8d202 : smax z2.s, z2.s, #-0x70                   : smax   %z2.s $0x90 -> %z2.s
+25a8d404 : smax z4.s, z4.s, #-0x60                   : smax   %z4.s $0xa0 -> %z4.s
+25a8d606 : smax z6.s, z6.s, #-0x50                   : smax   %z6.s $0xb0 -> %z6.s
+25a8d808 : smax z8.s, z8.s, #-0x40                   : smax   %z8.s $0xc0 -> %z8.s
+25a8da0a : smax z10.s, z10.s, #-0x30                 : smax   %z10.s $0xd0 -> %z10.s
+25a8dc0c : smax z12.s, z12.s, #-0x20                 : smax   %z12.s $0xe0 -> %z12.s
+25a8de0e : smax z14.s, z14.s, #-0x10                 : smax   %z14.s $0xf0 -> %z14.s
+25a8c010 : smax z16.s, z16.s, #0x0                   : smax   %z16.s $0x00 -> %z16.s
+25a8c1f1 : smax z17.s, z17.s, #0xf                   : smax   %z17.s $0x0f -> %z17.s
+25a8c3f3 : smax z19.s, z19.s, #0x1f                  : smax   %z19.s $0x1f -> %z19.s
+25a8c5f5 : smax z21.s, z21.s, #0x2f                  : smax   %z21.s $0x2f -> %z21.s
+25a8c7f7 : smax z23.s, z23.s, #0x3f                  : smax   %z23.s $0x3f -> %z23.s
+25a8c9f9 : smax z25.s, z25.s, #0x4f                  : smax   %z25.s $0x4f -> %z25.s
+25a8cbfb : smax z27.s, z27.s, #0x5f                  : smax   %z27.s $0x5f -> %z27.s
+25a8cfff : smax z31.s, z31.s, #0x7f                  : smax   %z31.s $0x7f -> %z31.s
+25e8d000 : smax z0.d, z0.d, #-0x80                   : smax   %z0.d $0x80 -> %z0.d
+25e8d202 : smax z2.d, z2.d, #-0x70                   : smax   %z2.d $0x90 -> %z2.d
+25e8d404 : smax z4.d, z4.d, #-0x60                   : smax   %z4.d $0xa0 -> %z4.d
+25e8d606 : smax z6.d, z6.d, #-0x50                   : smax   %z6.d $0xb0 -> %z6.d
+25e8d808 : smax z8.d, z8.d, #-0x40                   : smax   %z8.d $0xc0 -> %z8.d
+25e8da0a : smax z10.d, z10.d, #-0x30                 : smax   %z10.d $0xd0 -> %z10.d
+25e8dc0c : smax z12.d, z12.d, #-0x20                 : smax   %z12.d $0xe0 -> %z12.d
+25e8de0e : smax z14.d, z14.d, #-0x10                 : smax   %z14.d $0xf0 -> %z14.d
+25e8c010 : smax z16.d, z16.d, #0x0                   : smax   %z16.d $0x00 -> %z16.d
+25e8c1f1 : smax z17.d, z17.d, #0xf                   : smax   %z17.d $0x0f -> %z17.d
+25e8c3f3 : smax z19.d, z19.d, #0x1f                  : smax   %z19.d $0x1f -> %z19.d
+25e8c5f5 : smax z21.d, z21.d, #0x2f                  : smax   %z21.d $0x2f -> %z21.d
+25e8c7f7 : smax z23.d, z23.d, #0x3f                  : smax   %z23.d $0x3f -> %z23.d
+25e8c9f9 : smax z25.d, z25.d, #0x4f                  : smax   %z25.d $0x4f -> %z25.d
+25e8cbfb : smax z27.d, z27.d, #0x5f                  : smax   %z27.d $0x5f -> %z27.d
+25e8cfff : smax z31.d, z31.d, #0x7f                  : smax   %z31.d $0x7f -> %z31.d
+
+# SMIN    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SMIN-Z.P.ZZ-_)
+040a0000 : smin z0.b, p0/M, z0.b, z0.b               : smin   %p0/m %z0.b %z0.b -> %z0.b
+040a0482 : smin z2.b, p1/M, z2.b, z4.b               : smin   %p1/m %z2.b %z4.b -> %z2.b
+040a08c4 : smin z4.b, p2/M, z4.b, z6.b               : smin   %p2/m %z4.b %z6.b -> %z4.b
+040a0906 : smin z6.b, p2/M, z6.b, z8.b               : smin   %p2/m %z6.b %z8.b -> %z6.b
+040a0d48 : smin z8.b, p3/M, z8.b, z10.b              : smin   %p3/m %z8.b %z10.b -> %z8.b
+040a0d8a : smin z10.b, p3/M, z10.b, z12.b            : smin   %p3/m %z10.b %z12.b -> %z10.b
+040a11cc : smin z12.b, p4/M, z12.b, z14.b            : smin   %p4/m %z12.b %z14.b -> %z12.b
+040a120e : smin z14.b, p4/M, z14.b, z16.b            : smin   %p4/m %z14.b %z16.b -> %z14.b
+040a1650 : smin z16.b, p5/M, z16.b, z18.b            : smin   %p5/m %z16.b %z18.b -> %z16.b
+040a1671 : smin z17.b, p5/M, z17.b, z19.b            : smin   %p5/m %z17.b %z19.b -> %z17.b
+040a16b3 : smin z19.b, p5/M, z19.b, z21.b            : smin   %p5/m %z19.b %z21.b -> %z19.b
+040a1af5 : smin z21.b, p6/M, z21.b, z23.b            : smin   %p6/m %z21.b %z23.b -> %z21.b
+040a1b37 : smin z23.b, p6/M, z23.b, z25.b            : smin   %p6/m %z23.b %z25.b -> %z23.b
+040a1f79 : smin z25.b, p7/M, z25.b, z27.b            : smin   %p7/m %z25.b %z27.b -> %z25.b
+040a1fbb : smin z27.b, p7/M, z27.b, z29.b            : smin   %p7/m %z27.b %z29.b -> %z27.b
+040a1fff : smin z31.b, p7/M, z31.b, z31.b            : smin   %p7/m %z31.b %z31.b -> %z31.b
+044a0000 : smin z0.h, p0/M, z0.h, z0.h               : smin   %p0/m %z0.h %z0.h -> %z0.h
+044a0482 : smin z2.h, p1/M, z2.h, z4.h               : smin   %p1/m %z2.h %z4.h -> %z2.h
+044a08c4 : smin z4.h, p2/M, z4.h, z6.h               : smin   %p2/m %z4.h %z6.h -> %z4.h
+044a0906 : smin z6.h, p2/M, z6.h, z8.h               : smin   %p2/m %z6.h %z8.h -> %z6.h
+044a0d48 : smin z8.h, p3/M, z8.h, z10.h              : smin   %p3/m %z8.h %z10.h -> %z8.h
+044a0d8a : smin z10.h, p3/M, z10.h, z12.h            : smin   %p3/m %z10.h %z12.h -> %z10.h
+044a11cc : smin z12.h, p4/M, z12.h, z14.h            : smin   %p4/m %z12.h %z14.h -> %z12.h
+044a120e : smin z14.h, p4/M, z14.h, z16.h            : smin   %p4/m %z14.h %z16.h -> %z14.h
+044a1650 : smin z16.h, p5/M, z16.h, z18.h            : smin   %p5/m %z16.h %z18.h -> %z16.h
+044a1671 : smin z17.h, p5/M, z17.h, z19.h            : smin   %p5/m %z17.h %z19.h -> %z17.h
+044a16b3 : smin z19.h, p5/M, z19.h, z21.h            : smin   %p5/m %z19.h %z21.h -> %z19.h
+044a1af5 : smin z21.h, p6/M, z21.h, z23.h            : smin   %p6/m %z21.h %z23.h -> %z21.h
+044a1b37 : smin z23.h, p6/M, z23.h, z25.h            : smin   %p6/m %z23.h %z25.h -> %z23.h
+044a1f79 : smin z25.h, p7/M, z25.h, z27.h            : smin   %p7/m %z25.h %z27.h -> %z25.h
+044a1fbb : smin z27.h, p7/M, z27.h, z29.h            : smin   %p7/m %z27.h %z29.h -> %z27.h
+044a1fff : smin z31.h, p7/M, z31.h, z31.h            : smin   %p7/m %z31.h %z31.h -> %z31.h
+048a0000 : smin z0.s, p0/M, z0.s, z0.s               : smin   %p0/m %z0.s %z0.s -> %z0.s
+048a0482 : smin z2.s, p1/M, z2.s, z4.s               : smin   %p1/m %z2.s %z4.s -> %z2.s
+048a08c4 : smin z4.s, p2/M, z4.s, z6.s               : smin   %p2/m %z4.s %z6.s -> %z4.s
+048a0906 : smin z6.s, p2/M, z6.s, z8.s               : smin   %p2/m %z6.s %z8.s -> %z6.s
+048a0d48 : smin z8.s, p3/M, z8.s, z10.s              : smin   %p3/m %z8.s %z10.s -> %z8.s
+048a0d8a : smin z10.s, p3/M, z10.s, z12.s            : smin   %p3/m %z10.s %z12.s -> %z10.s
+048a11cc : smin z12.s, p4/M, z12.s, z14.s            : smin   %p4/m %z12.s %z14.s -> %z12.s
+048a120e : smin z14.s, p4/M, z14.s, z16.s            : smin   %p4/m %z14.s %z16.s -> %z14.s
+048a1650 : smin z16.s, p5/M, z16.s, z18.s            : smin   %p5/m %z16.s %z18.s -> %z16.s
+048a1671 : smin z17.s, p5/M, z17.s, z19.s            : smin   %p5/m %z17.s %z19.s -> %z17.s
+048a16b3 : smin z19.s, p5/M, z19.s, z21.s            : smin   %p5/m %z19.s %z21.s -> %z19.s
+048a1af5 : smin z21.s, p6/M, z21.s, z23.s            : smin   %p6/m %z21.s %z23.s -> %z21.s
+048a1b37 : smin z23.s, p6/M, z23.s, z25.s            : smin   %p6/m %z23.s %z25.s -> %z23.s
+048a1f79 : smin z25.s, p7/M, z25.s, z27.s            : smin   %p7/m %z25.s %z27.s -> %z25.s
+048a1fbb : smin z27.s, p7/M, z27.s, z29.s            : smin   %p7/m %z27.s %z29.s -> %z27.s
+048a1fff : smin z31.s, p7/M, z31.s, z31.s            : smin   %p7/m %z31.s %z31.s -> %z31.s
+04ca0000 : smin z0.d, p0/M, z0.d, z0.d               : smin   %p0/m %z0.d %z0.d -> %z0.d
+04ca0482 : smin z2.d, p1/M, z2.d, z4.d               : smin   %p1/m %z2.d %z4.d -> %z2.d
+04ca08c4 : smin z4.d, p2/M, z4.d, z6.d               : smin   %p2/m %z4.d %z6.d -> %z4.d
+04ca0906 : smin z6.d, p2/M, z6.d, z8.d               : smin   %p2/m %z6.d %z8.d -> %z6.d
+04ca0d48 : smin z8.d, p3/M, z8.d, z10.d              : smin   %p3/m %z8.d %z10.d -> %z8.d
+04ca0d8a : smin z10.d, p3/M, z10.d, z12.d            : smin   %p3/m %z10.d %z12.d -> %z10.d
+04ca11cc : smin z12.d, p4/M, z12.d, z14.d            : smin   %p4/m %z12.d %z14.d -> %z12.d
+04ca120e : smin z14.d, p4/M, z14.d, z16.d            : smin   %p4/m %z14.d %z16.d -> %z14.d
+04ca1650 : smin z16.d, p5/M, z16.d, z18.d            : smin   %p5/m %z16.d %z18.d -> %z16.d
+04ca1671 : smin z17.d, p5/M, z17.d, z19.d            : smin   %p5/m %z17.d %z19.d -> %z17.d
+04ca16b3 : smin z19.d, p5/M, z19.d, z21.d            : smin   %p5/m %z19.d %z21.d -> %z19.d
+04ca1af5 : smin z21.d, p6/M, z21.d, z23.d            : smin   %p6/m %z21.d %z23.d -> %z21.d
+04ca1b37 : smin z23.d, p6/M, z23.d, z25.d            : smin   %p6/m %z23.d %z25.d -> %z23.d
+04ca1f79 : smin z25.d, p7/M, z25.d, z27.d            : smin   %p7/m %z25.d %z27.d -> %z25.d
+04ca1fbb : smin z27.d, p7/M, z27.d, z29.d            : smin   %p7/m %z27.d %z29.d -> %z27.d
+04ca1fff : smin z31.d, p7/M, z31.d, z31.d            : smin   %p7/m %z31.d %z31.d -> %z31.d
+
+# SMIN    <Zdn>.<T>, <Zdn>.<T>, #<imm> (SMIN-Z.ZI-_)
+252ad000 : smin z0.b, z0.b, #-0x80                   : smin   %z0.b $0x80 -> %z0.b
+252ad202 : smin z2.b, z2.b, #-0x70                   : smin   %z2.b $0x90 -> %z2.b
+252ad404 : smin z4.b, z4.b, #-0x60                   : smin   %z4.b $0xa0 -> %z4.b
+252ad606 : smin z6.b, z6.b, #-0x50                   : smin   %z6.b $0xb0 -> %z6.b
+252ad808 : smin z8.b, z8.b, #-0x40                   : smin   %z8.b $0xc0 -> %z8.b
+252ada0a : smin z10.b, z10.b, #-0x30                 : smin   %z10.b $0xd0 -> %z10.b
+252adc0c : smin z12.b, z12.b, #-0x20                 : smin   %z12.b $0xe0 -> %z12.b
+252ade0e : smin z14.b, z14.b, #-0x10                 : smin   %z14.b $0xf0 -> %z14.b
+252ac010 : smin z16.b, z16.b, #0x0                   : smin   %z16.b $0x00 -> %z16.b
+252ac1f1 : smin z17.b, z17.b, #0xf                   : smin   %z17.b $0x0f -> %z17.b
+252ac3f3 : smin z19.b, z19.b, #0x1f                  : smin   %z19.b $0x1f -> %z19.b
+252ac5f5 : smin z21.b, z21.b, #0x2f                  : smin   %z21.b $0x2f -> %z21.b
+252ac7f7 : smin z23.b, z23.b, #0x3f                  : smin   %z23.b $0x3f -> %z23.b
+252ac9f9 : smin z25.b, z25.b, #0x4f                  : smin   %z25.b $0x4f -> %z25.b
+252acbfb : smin z27.b, z27.b, #0x5f                  : smin   %z27.b $0x5f -> %z27.b
+252acfff : smin z31.b, z31.b, #0x7f                  : smin   %z31.b $0x7f -> %z31.b
+256ad000 : smin z0.h, z0.h, #-0x80                   : smin   %z0.h $0x80 -> %z0.h
+256ad202 : smin z2.h, z2.h, #-0x70                   : smin   %z2.h $0x90 -> %z2.h
+256ad404 : smin z4.h, z4.h, #-0x60                   : smin   %z4.h $0xa0 -> %z4.h
+256ad606 : smin z6.h, z6.h, #-0x50                   : smin   %z6.h $0xb0 -> %z6.h
+256ad808 : smin z8.h, z8.h, #-0x40                   : smin   %z8.h $0xc0 -> %z8.h
+256ada0a : smin z10.h, z10.h, #-0x30                 : smin   %z10.h $0xd0 -> %z10.h
+256adc0c : smin z12.h, z12.h, #-0x20                 : smin   %z12.h $0xe0 -> %z12.h
+256ade0e : smin z14.h, z14.h, #-0x10                 : smin   %z14.h $0xf0 -> %z14.h
+256ac010 : smin z16.h, z16.h, #0x0                   : smin   %z16.h $0x00 -> %z16.h
+256ac1f1 : smin z17.h, z17.h, #0xf                   : smin   %z17.h $0x0f -> %z17.h
+256ac3f3 : smin z19.h, z19.h, #0x1f                  : smin   %z19.h $0x1f -> %z19.h
+256ac5f5 : smin z21.h, z21.h, #0x2f                  : smin   %z21.h $0x2f -> %z21.h
+256ac7f7 : smin z23.h, z23.h, #0x3f                  : smin   %z23.h $0x3f -> %z23.h
+256ac9f9 : smin z25.h, z25.h, #0x4f                  : smin   %z25.h $0x4f -> %z25.h
+256acbfb : smin z27.h, z27.h, #0x5f                  : smin   %z27.h $0x5f -> %z27.h
+256acfff : smin z31.h, z31.h, #0x7f                  : smin   %z31.h $0x7f -> %z31.h
+25aad000 : smin z0.s, z0.s, #-0x80                   : smin   %z0.s $0x80 -> %z0.s
+25aad202 : smin z2.s, z2.s, #-0x70                   : smin   %z2.s $0x90 -> %z2.s
+25aad404 : smin z4.s, z4.s, #-0x60                   : smin   %z4.s $0xa0 -> %z4.s
+25aad606 : smin z6.s, z6.s, #-0x50                   : smin   %z6.s $0xb0 -> %z6.s
+25aad808 : smin z8.s, z8.s, #-0x40                   : smin   %z8.s $0xc0 -> %z8.s
+25aada0a : smin z10.s, z10.s, #-0x30                 : smin   %z10.s $0xd0 -> %z10.s
+25aadc0c : smin z12.s, z12.s, #-0x20                 : smin   %z12.s $0xe0 -> %z12.s
+25aade0e : smin z14.s, z14.s, #-0x10                 : smin   %z14.s $0xf0 -> %z14.s
+25aac010 : smin z16.s, z16.s, #0x0                   : smin   %z16.s $0x00 -> %z16.s
+25aac1f1 : smin z17.s, z17.s, #0xf                   : smin   %z17.s $0x0f -> %z17.s
+25aac3f3 : smin z19.s, z19.s, #0x1f                  : smin   %z19.s $0x1f -> %z19.s
+25aac5f5 : smin z21.s, z21.s, #0x2f                  : smin   %z21.s $0x2f -> %z21.s
+25aac7f7 : smin z23.s, z23.s, #0x3f                  : smin   %z23.s $0x3f -> %z23.s
+25aac9f9 : smin z25.s, z25.s, #0x4f                  : smin   %z25.s $0x4f -> %z25.s
+25aacbfb : smin z27.s, z27.s, #0x5f                  : smin   %z27.s $0x5f -> %z27.s
+25aacfff : smin z31.s, z31.s, #0x7f                  : smin   %z31.s $0x7f -> %z31.s
+25ead000 : smin z0.d, z0.d, #-0x80                   : smin   %z0.d $0x80 -> %z0.d
+25ead202 : smin z2.d, z2.d, #-0x70                   : smin   %z2.d $0x90 -> %z2.d
+25ead404 : smin z4.d, z4.d, #-0x60                   : smin   %z4.d $0xa0 -> %z4.d
+25ead606 : smin z6.d, z6.d, #-0x50                   : smin   %z6.d $0xb0 -> %z6.d
+25ead808 : smin z8.d, z8.d, #-0x40                   : smin   %z8.d $0xc0 -> %z8.d
+25eada0a : smin z10.d, z10.d, #-0x30                 : smin   %z10.d $0xd0 -> %z10.d
+25eadc0c : smin z12.d, z12.d, #-0x20                 : smin   %z12.d $0xe0 -> %z12.d
+25eade0e : smin z14.d, z14.d, #-0x10                 : smin   %z14.d $0xf0 -> %z14.d
+25eac010 : smin z16.d, z16.d, #0x0                   : smin   %z16.d $0x00 -> %z16.d
+25eac1f1 : smin z17.d, z17.d, #0xf                   : smin   %z17.d $0x0f -> %z17.d
+25eac3f3 : smin z19.d, z19.d, #0x1f                  : smin   %z19.d $0x1f -> %z19.d
+25eac5f5 : smin z21.d, z21.d, #0x2f                  : smin   %z21.d $0x2f -> %z21.d
+25eac7f7 : smin z23.d, z23.d, #0x3f                  : smin   %z23.d $0x3f -> %z23.d
+25eac9f9 : smin z25.d, z25.d, #0x4f                  : smin   %z25.d $0x4f -> %z25.d
+25eacbfb : smin z27.d, z27.d, #0x5f                  : smin   %z27.d $0x5f -> %z27.d
+25eacfff : smin z31.d, z31.d, #0x7f                  : smin   %z31.d $0x7f -> %z31.d
 
 # SMULH   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SMULH-Z.P.ZZ-_)
 04120000 : smulh z0.b, p0/M, z0.b, z0.b              : smulh  %p0/m %z0.b %z0.b -> %z0.b
@@ -1690,6 +2218,72 @@
 25e3d9f8 : subr z24.d, z24.d, #0xcf, lsl #0          : subr   %z24.d $0xcf lsl $0x00 -> %z24.d
 25e3dbfa : subr z26.d, z26.d, #0xdf, lsl #0          : subr   %z26.d $0xdf lsl $0x00 -> %z26.d
 25e3dffe : subr z30.d, z30.d, #0xff, lsl #0          : subr   %z30.d $0xff lsl $0x00 -> %z30.d
+
+# UABD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (UABD-Z.P.ZZ-_)
+040d0000 : uabd z0.b, p0/M, z0.b, z0.b               : uabd   %p0/m %z0.b %z0.b -> %z0.b
+040d0482 : uabd z2.b, p1/M, z2.b, z4.b               : uabd   %p1/m %z2.b %z4.b -> %z2.b
+040d08c4 : uabd z4.b, p2/M, z4.b, z6.b               : uabd   %p2/m %z4.b %z6.b -> %z4.b
+040d0906 : uabd z6.b, p2/M, z6.b, z8.b               : uabd   %p2/m %z6.b %z8.b -> %z6.b
+040d0d48 : uabd z8.b, p3/M, z8.b, z10.b              : uabd   %p3/m %z8.b %z10.b -> %z8.b
+040d0d8a : uabd z10.b, p3/M, z10.b, z12.b            : uabd   %p3/m %z10.b %z12.b -> %z10.b
+040d11cc : uabd z12.b, p4/M, z12.b, z14.b            : uabd   %p4/m %z12.b %z14.b -> %z12.b
+040d120e : uabd z14.b, p4/M, z14.b, z16.b            : uabd   %p4/m %z14.b %z16.b -> %z14.b
+040d1650 : uabd z16.b, p5/M, z16.b, z18.b            : uabd   %p5/m %z16.b %z18.b -> %z16.b
+040d1671 : uabd z17.b, p5/M, z17.b, z19.b            : uabd   %p5/m %z17.b %z19.b -> %z17.b
+040d16b3 : uabd z19.b, p5/M, z19.b, z21.b            : uabd   %p5/m %z19.b %z21.b -> %z19.b
+040d1af5 : uabd z21.b, p6/M, z21.b, z23.b            : uabd   %p6/m %z21.b %z23.b -> %z21.b
+040d1b37 : uabd z23.b, p6/M, z23.b, z25.b            : uabd   %p6/m %z23.b %z25.b -> %z23.b
+040d1f79 : uabd z25.b, p7/M, z25.b, z27.b            : uabd   %p7/m %z25.b %z27.b -> %z25.b
+040d1fbb : uabd z27.b, p7/M, z27.b, z29.b            : uabd   %p7/m %z27.b %z29.b -> %z27.b
+040d1fff : uabd z31.b, p7/M, z31.b, z31.b            : uabd   %p7/m %z31.b %z31.b -> %z31.b
+044d0000 : uabd z0.h, p0/M, z0.h, z0.h               : uabd   %p0/m %z0.h %z0.h -> %z0.h
+044d0482 : uabd z2.h, p1/M, z2.h, z4.h               : uabd   %p1/m %z2.h %z4.h -> %z2.h
+044d08c4 : uabd z4.h, p2/M, z4.h, z6.h               : uabd   %p2/m %z4.h %z6.h -> %z4.h
+044d0906 : uabd z6.h, p2/M, z6.h, z8.h               : uabd   %p2/m %z6.h %z8.h -> %z6.h
+044d0d48 : uabd z8.h, p3/M, z8.h, z10.h              : uabd   %p3/m %z8.h %z10.h -> %z8.h
+044d0d8a : uabd z10.h, p3/M, z10.h, z12.h            : uabd   %p3/m %z10.h %z12.h -> %z10.h
+044d11cc : uabd z12.h, p4/M, z12.h, z14.h            : uabd   %p4/m %z12.h %z14.h -> %z12.h
+044d120e : uabd z14.h, p4/M, z14.h, z16.h            : uabd   %p4/m %z14.h %z16.h -> %z14.h
+044d1650 : uabd z16.h, p5/M, z16.h, z18.h            : uabd   %p5/m %z16.h %z18.h -> %z16.h
+044d1671 : uabd z17.h, p5/M, z17.h, z19.h            : uabd   %p5/m %z17.h %z19.h -> %z17.h
+044d16b3 : uabd z19.h, p5/M, z19.h, z21.h            : uabd   %p5/m %z19.h %z21.h -> %z19.h
+044d1af5 : uabd z21.h, p6/M, z21.h, z23.h            : uabd   %p6/m %z21.h %z23.h -> %z21.h
+044d1b37 : uabd z23.h, p6/M, z23.h, z25.h            : uabd   %p6/m %z23.h %z25.h -> %z23.h
+044d1f79 : uabd z25.h, p7/M, z25.h, z27.h            : uabd   %p7/m %z25.h %z27.h -> %z25.h
+044d1fbb : uabd z27.h, p7/M, z27.h, z29.h            : uabd   %p7/m %z27.h %z29.h -> %z27.h
+044d1fff : uabd z31.h, p7/M, z31.h, z31.h            : uabd   %p7/m %z31.h %z31.h -> %z31.h
+048d0000 : uabd z0.s, p0/M, z0.s, z0.s               : uabd   %p0/m %z0.s %z0.s -> %z0.s
+048d0482 : uabd z2.s, p1/M, z2.s, z4.s               : uabd   %p1/m %z2.s %z4.s -> %z2.s
+048d08c4 : uabd z4.s, p2/M, z4.s, z6.s               : uabd   %p2/m %z4.s %z6.s -> %z4.s
+048d0906 : uabd z6.s, p2/M, z6.s, z8.s               : uabd   %p2/m %z6.s %z8.s -> %z6.s
+048d0d48 : uabd z8.s, p3/M, z8.s, z10.s              : uabd   %p3/m %z8.s %z10.s -> %z8.s
+048d0d8a : uabd z10.s, p3/M, z10.s, z12.s            : uabd   %p3/m %z10.s %z12.s -> %z10.s
+048d11cc : uabd z12.s, p4/M, z12.s, z14.s            : uabd   %p4/m %z12.s %z14.s -> %z12.s
+048d120e : uabd z14.s, p4/M, z14.s, z16.s            : uabd   %p4/m %z14.s %z16.s -> %z14.s
+048d1650 : uabd z16.s, p5/M, z16.s, z18.s            : uabd   %p5/m %z16.s %z18.s -> %z16.s
+048d1671 : uabd z17.s, p5/M, z17.s, z19.s            : uabd   %p5/m %z17.s %z19.s -> %z17.s
+048d16b3 : uabd z19.s, p5/M, z19.s, z21.s            : uabd   %p5/m %z19.s %z21.s -> %z19.s
+048d1af5 : uabd z21.s, p6/M, z21.s, z23.s            : uabd   %p6/m %z21.s %z23.s -> %z21.s
+048d1b37 : uabd z23.s, p6/M, z23.s, z25.s            : uabd   %p6/m %z23.s %z25.s -> %z23.s
+048d1f79 : uabd z25.s, p7/M, z25.s, z27.s            : uabd   %p7/m %z25.s %z27.s -> %z25.s
+048d1fbb : uabd z27.s, p7/M, z27.s, z29.s            : uabd   %p7/m %z27.s %z29.s -> %z27.s
+048d1fff : uabd z31.s, p7/M, z31.s, z31.s            : uabd   %p7/m %z31.s %z31.s -> %z31.s
+04cd0000 : uabd z0.d, p0/M, z0.d, z0.d               : uabd   %p0/m %z0.d %z0.d -> %z0.d
+04cd0482 : uabd z2.d, p1/M, z2.d, z4.d               : uabd   %p1/m %z2.d %z4.d -> %z2.d
+04cd08c4 : uabd z4.d, p2/M, z4.d, z6.d               : uabd   %p2/m %z4.d %z6.d -> %z4.d
+04cd0906 : uabd z6.d, p2/M, z6.d, z8.d               : uabd   %p2/m %z6.d %z8.d -> %z6.d
+04cd0d48 : uabd z8.d, p3/M, z8.d, z10.d              : uabd   %p3/m %z8.d %z10.d -> %z8.d
+04cd0d8a : uabd z10.d, p3/M, z10.d, z12.d            : uabd   %p3/m %z10.d %z12.d -> %z10.d
+04cd11cc : uabd z12.d, p4/M, z12.d, z14.d            : uabd   %p4/m %z12.d %z14.d -> %z12.d
+04cd120e : uabd z14.d, p4/M, z14.d, z16.d            : uabd   %p4/m %z14.d %z16.d -> %z14.d
+04cd1650 : uabd z16.d, p5/M, z16.d, z18.d            : uabd   %p5/m %z16.d %z18.d -> %z16.d
+04cd1671 : uabd z17.d, p5/M, z17.d, z19.d            : uabd   %p5/m %z17.d %z19.d -> %z17.d
+04cd16b3 : uabd z19.d, p5/M, z19.d, z21.d            : uabd   %p5/m %z19.d %z21.d -> %z19.d
+04cd1af5 : uabd z21.d, p6/M, z21.d, z23.d            : uabd   %p6/m %z21.d %z23.d -> %z21.d
+04cd1b37 : uabd z23.d, p6/M, z23.d, z25.d            : uabd   %p6/m %z23.d %z25.d -> %z23.d
+04cd1f79 : uabd z25.d, p7/M, z25.d, z27.d            : uabd   %p7/m %z25.d %z27.d -> %z25.d
+04cd1fbb : uabd z27.d, p7/M, z27.d, z29.d            : uabd   %p7/m %z27.d %z29.d -> %z27.d
+04cd1fff : uabd z31.d, p7/M, z31.d, z31.d            : uabd   %p7/m %z31.d %z31.d -> %z31.d
 
 # UMULH   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (UMULH-Z.P.ZZ-_)
 04130000 : umulh z0.b, p0/M, z0.b, z0.b              : umulh  %p0/m %z0.b %z0.b -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -2387,6 +2387,640 @@ TEST_INSTR(ftssel_sve)
 
     return success;
 }
+
+TEST_INSTR(abs_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing ABS     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
+    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "abs    %p0/m %z0.b -> %z0.b",   "abs    %p2/m %z7.b -> %z5.b",
+        "abs    %p3/m %z12.b -> %z10.b", "abs    %p5/m %z18.b -> %z16.b",
+        "abs    %p6/m %z23.b -> %z21.b", "abs    %p7/m %z31.b -> %z31.b",
+    };
+    TEST_LOOP(abs, abs_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pg_0_0[i], true),
+              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1));
+
+    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "abs    %p0/m %z0.h -> %z0.h",   "abs    %p2/m %z7.h -> %z5.h",
+        "abs    %p3/m %z12.h -> %z10.h", "abs    %p5/m %z18.h -> %z16.h",
+        "abs    %p6/m %z23.h -> %z21.h", "abs    %p7/m %z31.h -> %z31.h",
+    };
+    TEST_LOOP(abs, abs_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_1[i], true),
+              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2));
+
+    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "abs    %p0/m %z0.s -> %z0.s",   "abs    %p2/m %z7.s -> %z5.s",
+        "abs    %p3/m %z12.s -> %z10.s", "abs    %p5/m %z18.s -> %z16.s",
+        "abs    %p6/m %z23.s -> %z21.s", "abs    %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(abs, abs_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_2[i], true),
+              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4));
+
+    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_3[6] = {
+        "abs    %p0/m %z0.d -> %z0.d",   "abs    %p2/m %z7.d -> %z5.d",
+        "abs    %p3/m %z12.d -> %z10.d", "abs    %p5/m %z18.d -> %z16.d",
+        "abs    %p6/m %z23.d -> %z21.d", "abs    %p7/m %z31.d -> %z31.d",
+    };
+    TEST_LOOP(abs, abs_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_3[i], true),
+              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8));
+
+    return success;
+}
+
+TEST_INSTR(cnot_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing CNOT    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
+    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "cnot   %p0/m %z0.b -> %z0.b",   "cnot   %p2/m %z7.b -> %z5.b",
+        "cnot   %p3/m %z12.b -> %z10.b", "cnot   %p5/m %z18.b -> %z16.b",
+        "cnot   %p6/m %z23.b -> %z21.b", "cnot   %p7/m %z31.b -> %z31.b",
+    };
+    TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pg_0_0[i], true),
+              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1));
+
+    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "cnot   %p0/m %z0.h -> %z0.h",   "cnot   %p2/m %z7.h -> %z5.h",
+        "cnot   %p3/m %z12.h -> %z10.h", "cnot   %p5/m %z18.h -> %z16.h",
+        "cnot   %p6/m %z23.h -> %z21.h", "cnot   %p7/m %z31.h -> %z31.h",
+    };
+    TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_1[i], true),
+              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2));
+
+    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "cnot   %p0/m %z0.s -> %z0.s",   "cnot   %p2/m %z7.s -> %z5.s",
+        "cnot   %p3/m %z12.s -> %z10.s", "cnot   %p5/m %z18.s -> %z16.s",
+        "cnot   %p6/m %z23.s -> %z21.s", "cnot   %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_2[i], true),
+              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4));
+
+    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_3[6] = {
+        "cnot   %p0/m %z0.d -> %z0.d",   "cnot   %p2/m %z7.d -> %z5.d",
+        "cnot   %p3/m %z12.d -> %z10.d", "cnot   %p5/m %z18.d -> %z16.d",
+        "cnot   %p6/m %z23.d -> %z21.d", "cnot   %p7/m %z31.d -> %z31.d",
+    };
+    TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_3[i], true),
+              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8));
+
+    return success;
+}
+
+TEST_INSTR(neg_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing NEG     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
+    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "neg    %p0/m %z0.b -> %z0.b",   "neg    %p2/m %z7.b -> %z5.b",
+        "neg    %p3/m %z12.b -> %z10.b", "neg    %p5/m %z18.b -> %z16.b",
+        "neg    %p6/m %z23.b -> %z21.b", "neg    %p7/m %z31.b -> %z31.b",
+    };
+    TEST_LOOP(neg, neg_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pg_0_0[i], true),
+              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1));
+
+    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "neg    %p0/m %z0.h -> %z0.h",   "neg    %p2/m %z7.h -> %z5.h",
+        "neg    %p3/m %z12.h -> %z10.h", "neg    %p5/m %z18.h -> %z16.h",
+        "neg    %p6/m %z23.h -> %z21.h", "neg    %p7/m %z31.h -> %z31.h",
+    };
+    TEST_LOOP(neg, neg_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_1[i], true),
+              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2));
+
+    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "neg    %p0/m %z0.s -> %z0.s",   "neg    %p2/m %z7.s -> %z5.s",
+        "neg    %p3/m %z12.s -> %z10.s", "neg    %p5/m %z18.s -> %z16.s",
+        "neg    %p6/m %z23.s -> %z21.s", "neg    %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(neg, neg_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_2[i], true),
+              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4));
+
+    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_3[6] = {
+        "neg    %p0/m %z0.d -> %z0.d",   "neg    %p2/m %z7.d -> %z5.d",
+        "neg    %p3/m %z12.d -> %z10.d", "neg    %p5/m %z18.d -> %z16.d",
+        "neg    %p6/m %z23.d -> %z21.d", "neg    %p7/m %z31.d -> %z31.d",
+    };
+    TEST_LOOP(neg, neg_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_3[i], true),
+              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8));
+
+    return success;
+}
+
+TEST_INSTR(sabd_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "sabd   %p0/m %z0.b %z0.b -> %z0.b",    "sabd   %p2/m %z5.b %z7.b -> %z5.b",
+        "sabd   %p3/m %z10.b %z12.b -> %z10.b", "sabd   %p5/m %z16.b %z18.b -> %z16.b",
+        "sabd   %p6/m %z21.b %z23.b -> %z21.b", "sabd   %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pg_0_0[i], true),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+
+    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "sabd   %p0/m %z0.h %z0.h -> %z0.h",    "sabd   %p2/m %z5.h %z7.h -> %z5.h",
+        "sabd   %p3/m %z10.h %z12.h -> %z10.h", "sabd   %p5/m %z16.h %z18.h -> %z16.h",
+        "sabd   %p6/m %z21.h %z23.h -> %z21.h", "sabd   %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_1[i], true),
+              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+
+    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "sabd   %p0/m %z0.s %z0.s -> %z0.s",    "sabd   %p2/m %z5.s %z7.s -> %z5.s",
+        "sabd   %p3/m %z10.s %z12.s -> %z10.s", "sabd   %p5/m %z16.s %z18.s -> %z16.s",
+        "sabd   %p6/m %z21.s %z23.s -> %z21.s", "sabd   %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_2[i], true),
+              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+
+    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_3[6] = {
+        "sabd   %p0/m %z0.d %z0.d -> %z0.d",    "sabd   %p2/m %z5.d %z7.d -> %z5.d",
+        "sabd   %p3/m %z10.d %z12.d -> %z10.d", "sabd   %p5/m %z16.d %z18.d -> %z16.d",
+        "sabd   %p6/m %z21.d %z23.d -> %z21.d", "sabd   %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_3[i], true),
+              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
+
+    return success;
+}
+
+TEST_INSTR(smax_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SMAX    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "smax   %p0/m %z0.b %z0.b -> %z0.b",    "smax   %p2/m %z5.b %z7.b -> %z5.b",
+        "smax   %p3/m %z10.b %z12.b -> %z10.b", "smax   %p5/m %z16.b %z18.b -> %z16.b",
+        "smax   %p6/m %z21.b %z23.b -> %z21.b", "smax   %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(smax, smax_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pg_0_0[i], true),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+
+    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "smax   %p0/m %z0.h %z0.h -> %z0.h",    "smax   %p2/m %z5.h %z7.h -> %z5.h",
+        "smax   %p3/m %z10.h %z12.h -> %z10.h", "smax   %p5/m %z16.h %z18.h -> %z16.h",
+        "smax   %p6/m %z21.h %z23.h -> %z21.h", "smax   %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(smax, smax_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_1[i], true),
+              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+
+    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "smax   %p0/m %z0.s %z0.s -> %z0.s",    "smax   %p2/m %z5.s %z7.s -> %z5.s",
+        "smax   %p3/m %z10.s %z12.s -> %z10.s", "smax   %p5/m %z16.s %z18.s -> %z16.s",
+        "smax   %p6/m %z21.s %z23.s -> %z21.s", "smax   %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(smax, smax_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_2[i], true),
+              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+
+    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_3[6] = {
+        "smax   %p0/m %z0.d %z0.d -> %z0.d",    "smax   %p2/m %z5.d %z7.d -> %z5.d",
+        "smax   %p3/m %z10.d %z12.d -> %z10.d", "smax   %p5/m %z16.d %z18.d -> %z16.d",
+        "smax   %p6/m %z21.d %z23.d -> %z21.d", "smax   %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(smax, smax_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_3[i], true),
+              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
+
+    return success;
+}
+
+TEST_INSTR(smax_sve)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SMAX    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm> */
+    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_0[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_0[6] = {
+        "smax   %z0.b $0x80 -> %z0.b",   "smax   %z5.b $0xab -> %z5.b",
+        "smax   %z10.b $0xd6 -> %z10.b", "smax   %z16.b $0x01 -> %z16.b",
+        "smax   %z21.b $0x2b -> %z21.b", "smax   %z31.b $0x7f -> %z31.b",
+    };
+    TEST_LOOP(smax, smax_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_immed_int(imm8_0_0[i], OPSZ_1));
+
+    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_1[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_1[6] = {
+        "smax   %z0.h $0x80 -> %z0.h",   "smax   %z5.h $0xab -> %z5.h",
+        "smax   %z10.h $0xd6 -> %z10.h", "smax   %z16.h $0x01 -> %z16.h",
+        "smax   %z21.h $0x2b -> %z21.h", "smax   %z31.h $0x7f -> %z31.h",
+    };
+    TEST_LOOP(smax, smax_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_immed_int(imm8_0_1[i], OPSZ_1));
+
+    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_2[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_2[6] = {
+        "smax   %z0.s $0x80 -> %z0.s",   "smax   %z5.s $0xab -> %z5.s",
+        "smax   %z10.s $0xd6 -> %z10.s", "smax   %z16.s $0x01 -> %z16.s",
+        "smax   %z21.s $0x2b -> %z21.s", "smax   %z31.s $0x7f -> %z31.s",
+    };
+    TEST_LOOP(smax, smax_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_immed_int(imm8_0_2[i], OPSZ_1));
+
+    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_3[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_3[6] = {
+        "smax   %z0.d $0x80 -> %z0.d",   "smax   %z5.d $0xab -> %z5.d",
+        "smax   %z10.d $0xd6 -> %z10.d", "smax   %z16.d $0x01 -> %z16.d",
+        "smax   %z21.d $0x2b -> %z21.d", "smax   %z31.d $0x7f -> %z31.d",
+    };
+    TEST_LOOP(smax, smax_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_immed_int(imm8_0_3[i], OPSZ_1));
+
+    return success;
+}
+
+TEST_INSTR(smin_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SMIN    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "smin   %p0/m %z0.b %z0.b -> %z0.b",    "smin   %p2/m %z5.b %z7.b -> %z5.b",
+        "smin   %p3/m %z10.b %z12.b -> %z10.b", "smin   %p5/m %z16.b %z18.b -> %z16.b",
+        "smin   %p6/m %z21.b %z23.b -> %z21.b", "smin   %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(smin, smin_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pg_0_0[i], true),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+
+    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "smin   %p0/m %z0.h %z0.h -> %z0.h",    "smin   %p2/m %z5.h %z7.h -> %z5.h",
+        "smin   %p3/m %z10.h %z12.h -> %z10.h", "smin   %p5/m %z16.h %z18.h -> %z16.h",
+        "smin   %p6/m %z21.h %z23.h -> %z21.h", "smin   %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(smin, smin_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_1[i], true),
+              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+
+    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "smin   %p0/m %z0.s %z0.s -> %z0.s",    "smin   %p2/m %z5.s %z7.s -> %z5.s",
+        "smin   %p3/m %z10.s %z12.s -> %z10.s", "smin   %p5/m %z16.s %z18.s -> %z16.s",
+        "smin   %p6/m %z21.s %z23.s -> %z21.s", "smin   %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(smin, smin_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_2[i], true),
+              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+
+    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_3[6] = {
+        "smin   %p0/m %z0.d %z0.d -> %z0.d",    "smin   %p2/m %z5.d %z7.d -> %z5.d",
+        "smin   %p3/m %z10.d %z12.d -> %z10.d", "smin   %p5/m %z16.d %z18.d -> %z16.d",
+        "smin   %p6/m %z21.d %z23.d -> %z21.d", "smin   %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(smin, smin_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_3[i], true),
+              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
+
+    return success;
+}
+
+TEST_INSTR(smin_sve)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing SMIN    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm> */
+    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_0[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_0[6] = {
+        "smin   %z0.b $0x80 -> %z0.b",   "smin   %z5.b $0xab -> %z5.b",
+        "smin   %z10.b $0xd6 -> %z10.b", "smin   %z16.b $0x01 -> %z16.b",
+        "smin   %z21.b $0x2b -> %z21.b", "smin   %z31.b $0x7f -> %z31.b",
+    };
+    TEST_LOOP(smin, smin_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_immed_int(imm8_0_0[i], OPSZ_1));
+
+    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_1[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_1[6] = {
+        "smin   %z0.h $0x80 -> %z0.h",   "smin   %z5.h $0xab -> %z5.h",
+        "smin   %z10.h $0xd6 -> %z10.h", "smin   %z16.h $0x01 -> %z16.h",
+        "smin   %z21.h $0x2b -> %z21.h", "smin   %z31.h $0x7f -> %z31.h",
+    };
+    TEST_LOOP(smin, smin_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_immed_int(imm8_0_1[i], OPSZ_1));
+
+    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_2[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_2[6] = {
+        "smin   %z0.s $0x80 -> %z0.s",   "smin   %z5.s $0xab -> %z5.s",
+        "smin   %z10.s $0xd6 -> %z10.s", "smin   %z16.s $0x01 -> %z16.s",
+        "smin   %z21.s $0x2b -> %z21.s", "smin   %z31.s $0x7f -> %z31.s",
+    };
+    TEST_LOOP(smin, smin_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_immed_int(imm8_0_2[i], OPSZ_1));
+
+    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    int imm8_0_3[6] = { -128, -85, -42, 1, 43, 127 };
+    const char *expected_0_3[6] = {
+        "smin   %z0.d $0x80 -> %z0.d",   "smin   %z5.d $0xab -> %z5.d",
+        "smin   %z10.d $0xd6 -> %z10.d", "smin   %z16.d $0x01 -> %z16.d",
+        "smin   %z21.d $0x2b -> %z21.d", "smin   %z31.d $0x7f -> %z31.d",
+    };
+    TEST_LOOP(smin, smin_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_immed_int(imm8_0_3[i], OPSZ_1));
+
+    return success;
+}
+
+TEST_INSTR(uabd_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing UABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "uabd   %p0/m %z0.b %z0.b -> %z0.b",    "uabd   %p2/m %z5.b %z7.b -> %z5.b",
+        "uabd   %p3/m %z10.b %z12.b -> %z10.b", "uabd   %p5/m %z16.b %z18.b -> %z16.b",
+        "uabd   %p6/m %z21.b %z23.b -> %z21.b", "uabd   %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pg_0_0[i], true),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+
+    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "uabd   %p0/m %z0.h %z0.h -> %z0.h",    "uabd   %p2/m %z5.h %z7.h -> %z5.h",
+        "uabd   %p3/m %z10.h %z12.h -> %z10.h", "uabd   %p5/m %z16.h %z18.h -> %z16.h",
+        "uabd   %p6/m %z21.h %z23.h -> %z21.h", "uabd   %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_1[i], true),
+              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+
+    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "uabd   %p0/m %z0.s %z0.s -> %z0.s",    "uabd   %p2/m %z5.s %z7.s -> %z5.s",
+        "uabd   %p3/m %z10.s %z12.s -> %z10.s", "uabd   %p5/m %z16.s %z18.s -> %z16.s",
+        "uabd   %p6/m %z21.s %z23.s -> %z21.s", "uabd   %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_2[i], true),
+              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+
+    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    const char *expected_0_3[6] = {
+        "uabd   %p0/m %z0.d %z0.d -> %z0.d",    "uabd   %p2/m %z5.d %z7.d -> %z5.d",
+        "uabd   %p3/m %z10.d %z12.d -> %z10.d", "uabd   %p5/m %z16.d %z18.d -> %z16.d",
+        "uabd   %p6/m %z21.d %z23.d -> %z21.d", "uabd   %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_3[i], true),
+              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
+
+    return success;
+}
 int
 main(int argc, char *argv[])
 {
@@ -2436,6 +3070,16 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ftmad_sve);
     RUN_INSTR_TEST(ftsmul_sve);
     RUN_INSTR_TEST(ftssel_sve);
+
+    RUN_INSTR_TEST(abs_sve_pred);
+    RUN_INSTR_TEST(cnot_sve_pred);
+    RUN_INSTR_TEST(neg_sve_pred);
+    RUN_INSTR_TEST(sabd_sve_pred);
+    RUN_INSTR_TEST(smax_sve_pred);
+    RUN_INSTR_TEST(smax_sve);
+    RUN_INSTR_TEST(smin_sve_pred);
+    RUN_INSTR_TEST(smin_sve);
+    RUN_INSTR_TEST(uabd_sve_pred);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
ABS     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
CNOT    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
NEG     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
SABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
SMAX    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
SMAX    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>
SMIN    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
SMIN    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>
UABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
```
issues: #3044