### PR TITLE
i#3044 AArch64 SVE codec: add FACGE, FACGT

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1284,8 +1284,8 @@ encode_single_sized(opnd_size_t vec_size, uint pos_start, aarch64_reg_offset bit
 }
 
 static inline bool
-decode_sized_z(uint pos_start, uint size_start, uint min_size, uint max_size, uint enc,
-               byte *pc, OUT opnd_t *opnd)
+decode_sized_base(uint pos_start, uint size_start, uint min_size, uint max_size,
+                  reg_id_t base_reg, uint enc, byte *pc, OUT opnd_t *opnd)
 {
     aarch64_reg_offset bit_size = extract_uint(enc, size_start, 2);
     if (bit_size < min_size)
@@ -1293,19 +1293,18 @@ decode_sized_z(uint pos_start, uint size_start, uint min_size, uint max_size, ui
     if (bit_size > max_size)
         return false;
 
-    return decode_single_sized(DR_REG_Z0, pos_start, 5, bit_size, enc, opnd);
+    return decode_single_sized(base_reg, pos_start, 5, bit_size, enc, opnd);
 }
 
 static inline bool
-encode_sized_z(uint pos_start, uint size_start, uint min_size, uint max_size, opnd_t opnd,
-               OUT uint *enc_out)
+encode_sized_base(uint pos_start, uint size_start, uint min_size, uint max_size,
+                  opnd_size_t vec_size, opnd_t opnd, OUT uint *enc_out)
 {
     if (!opnd_is_element_vector_reg(opnd))
         return false;
 
     aarch64_reg_offset size;
     uint reg_number;
-    opnd_size_t vec_size = OPSZ_SCALABLE;
 
     switch (opnd_get_vector_element_size(opnd)) {
     case OPSZ_1: size = BYTE_REG; break;
@@ -1326,6 +1325,38 @@ encode_sized_z(uint pos_start, uint size_start, uint min_size, uint max_size, op
 
     *enc_out |= (size << size_start) | (reg_number << pos_start);
     return true;
+}
+
+static inline bool
+decode_sized_z(uint pos_start, uint size_start, uint min_size, uint max_size, uint enc,
+               byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_base(pos_start, size_start, min_size, max_size, DR_REG_Z0, enc,
+                             pc, opnd);
+}
+
+static inline bool
+encode_sized_z(uint pos_start, uint size_start, uint min_size, uint max_size, opnd_t opnd,
+               OUT uint *enc_out)
+{
+    return encode_sized_base(pos_start, size_start, min_size, max_size, OPSZ_SCALABLE,
+                             opnd, enc_out);
+}
+
+static inline bool
+decode_sized_p(uint pos_start, uint size_start, uint min_size, uint max_size, uint enc,
+               byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_base(pos_start, size_start, min_size, max_size, DR_REG_P0, enc,
+                             pc, opnd);
+}
+
+static inline bool
+encode_sized_p(uint pos_start, uint size_start, uint min_size, uint max_size, opnd_t opnd,
+               OUT uint *enc_out)
+{
+    return encode_sized_base(pos_start, size_start, min_size, max_size,
+                             OPSZ_SCALABLE_PRED, opnd, enc_out);
 }
 
 /*******************************************************************************
@@ -4382,6 +4413,18 @@ encode_bhsd_size_regx(int rpos, uint enc, int opcode, byte *pc, opnd_t opnd,
                       OUT uint *enc_out)
 {
     return encode_scalar_size_regx(0, rpos, enc, opcode, pc, opnd, enc_out);
+}
+
+static inline bool
+decode_opnd_p_size_hsd_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_p(0, 22, HALF_REG, DOUBLE_REG, enc, pc, opnd);
+}
+
+static inline bool
+encode_opnd_p_size_hsd_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_sized_p(0, 22, HALF_REG, DOUBLE_REG, opnd, enc_out);
 }
 
 static inline bool

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -50,6 +50,8 @@
 00000101xx01xxxx00xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_zer simm8_5 lsl shift1
 00000101xx01xxxx01xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_mrg simm8_5 lsl shift1
 00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor             z0 : p10_lo z0 z5 bhsd_sz
+01100101xx0xxxxx110xxxxxxxx1xxxx  n   96   SVE    facge   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
+01100101xx0xxxxx111xxxxxxxx1xxxx  n   97   SVE    facgt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 00000100xx100000101110xxxxxxxxxx  n   789  SVE    fexpa   z_size_hsd_0 : z_size_hsd_5
 01100101xx010xxx100000xxxxxxxxxx  n   790  SVE    ftmad   z_size_hsd_0 : z_size_hsd_0 z_size_hsd_5 imm3
 01100101xx0xxxxx000011xxxxxxxxxx  n   791  SVE   ftsmul   z_size_hsd_0 : z_size_hsd_5 z_size_hsd_16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -5554,4 +5554,36 @@
  */
 #define INSTR_CREATE_uabd_sve_pred(dc, Zdn, Pg, Zm) \
     instr_create_1dst_3src(dc, OP_uabd, Zdn, Pg, Zdn, Zm)
+
+/**
+ * Creates a FACGE instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FACGE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zn   The first source vector register, Z (Scalable)
+ * \param Zm   The second source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_facge_sve_pred(dc, Pd, Pg, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_facge, Pd, Pg, Zn, Zm)
+
+/**
+ * Creates a FACGT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FACGT   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate)
+ * \param Pg   The governing predicate register, P (Predicate)
+ * \param Zn   The first source vector register, Z (Scalable)
+ * \param Zm   The second source vector register, Z (Scalable)
+ */
+#define INSTR_CREATE_facgt_sve_pred(dc, Pd, Pg, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_facgt, Pd, Pg, Zn, Zm)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -200,6 +200,7 @@
 --------xx----------------------  bd_sz      # element width of a vector (8<<bd_sz)
 --------xx----------------------  shift3     # shift type for add/sub (shifted register)
 --------xx----------------------  shift4     # shift type for logical (shifted register)
+--------xx------------------xxxx  p_size_hsd_0     # sve predicate vector reg, elsz depending on size
 --------xx-----------------xxxxx  float_reg0  # H, S or D register
 --------xx-----------------xxxxx  hsd_size_reg0    # hsd register, depending on size opcode
 --------xx-----------------xxxxx  bhsd_size_reg0   # bhsd register, depending on size opcode

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -726,6 +726,106 @@
 04fdb39b : ftssel z27.d, z28.d, z29.d                : ftssel %z28.d %z29.d -> %z27.d
 04ffb3ff : ftssel z31.d, z31.d, z31.d                : ftssel %z31.d %z31.d -> %z31.d
 
+# FACGE   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (FACGE-P.P.ZZ-_)
+6540c010 : facge p0.h, p0/Z, z0.h, z0.h              : facge  %p0/z %z0.h %z0.h -> %p0.h
+6545c491 : facge p1.h, p1/Z, z4.h, z5.h              : facge  %p1/z %z4.h %z5.h -> %p1.h
+6547c8d2 : facge p2.h, p2/Z, z6.h, z7.h              : facge  %p2/z %z6.h %z7.h -> %p2.h
+6549c913 : facge p3.h, p2/Z, z8.h, z9.h              : facge  %p2/z %z8.h %z9.h -> %p3.h
+654bcd54 : facge p4.h, p3/Z, z10.h, z11.h            : facge  %p3/z %z10.h %z11.h -> %p4.h
+654dcd95 : facge p5.h, p3/Z, z12.h, z13.h            : facge  %p3/z %z12.h %z13.h -> %p5.h
+654fd1d6 : facge p6.h, p4/Z, z14.h, z15.h            : facge  %p4/z %z14.h %z15.h -> %p6.h
+6551d217 : facge p7.h, p4/Z, z16.h, z17.h            : facge  %p4/z %z16.h %z17.h -> %p7.h
+6553d658 : facge p8.h, p5/Z, z18.h, z19.h            : facge  %p5/z %z18.h %z19.h -> %p8.h
+6554d678 : facge p8.h, p5/Z, z19.h, z20.h            : facge  %p5/z %z19.h %z20.h -> %p8.h
+6556d6b9 : facge p9.h, p5/Z, z21.h, z22.h            : facge  %p5/z %z21.h %z22.h -> %p9.h
+6558dafa : facge p10.h, p6/Z, z23.h, z24.h           : facge  %p6/z %z23.h %z24.h -> %p10.h
+655adb3b : facge p11.h, p6/Z, z25.h, z26.h           : facge  %p6/z %z25.h %z26.h -> %p11.h
+655cdf7c : facge p12.h, p7/Z, z27.h, z28.h           : facge  %p7/z %z27.h %z28.h -> %p12.h
+655edfbd : facge p13.h, p7/Z, z29.h, z30.h           : facge  %p7/z %z29.h %z30.h -> %p13.h
+655fdfff : facge p15.h, p7/Z, z31.h, z31.h           : facge  %p7/z %z31.h %z31.h -> %p15.h
+6580c010 : facge p0.s, p0/Z, z0.s, z0.s              : facge  %p0/z %z0.s %z0.s -> %p0.s
+6585c491 : facge p1.s, p1/Z, z4.s, z5.s              : facge  %p1/z %z4.s %z5.s -> %p1.s
+6587c8d2 : facge p2.s, p2/Z, z6.s, z7.s              : facge  %p2/z %z6.s %z7.s -> %p2.s
+6589c913 : facge p3.s, p2/Z, z8.s, z9.s              : facge  %p2/z %z8.s %z9.s -> %p3.s
+658bcd54 : facge p4.s, p3/Z, z10.s, z11.s            : facge  %p3/z %z10.s %z11.s -> %p4.s
+658dcd95 : facge p5.s, p3/Z, z12.s, z13.s            : facge  %p3/z %z12.s %z13.s -> %p5.s
+658fd1d6 : facge p6.s, p4/Z, z14.s, z15.s            : facge  %p4/z %z14.s %z15.s -> %p6.s
+6591d217 : facge p7.s, p4/Z, z16.s, z17.s            : facge  %p4/z %z16.s %z17.s -> %p7.s
+6593d658 : facge p8.s, p5/Z, z18.s, z19.s            : facge  %p5/z %z18.s %z19.s -> %p8.s
+6594d678 : facge p8.s, p5/Z, z19.s, z20.s            : facge  %p5/z %z19.s %z20.s -> %p8.s
+6596d6b9 : facge p9.s, p5/Z, z21.s, z22.s            : facge  %p5/z %z21.s %z22.s -> %p9.s
+6598dafa : facge p10.s, p6/Z, z23.s, z24.s           : facge  %p6/z %z23.s %z24.s -> %p10.s
+659adb3b : facge p11.s, p6/Z, z25.s, z26.s           : facge  %p6/z %z25.s %z26.s -> %p11.s
+659cdf7c : facge p12.s, p7/Z, z27.s, z28.s           : facge  %p7/z %z27.s %z28.s -> %p12.s
+659edfbd : facge p13.s, p7/Z, z29.s, z30.s           : facge  %p7/z %z29.s %z30.s -> %p13.s
+659fdfff : facge p15.s, p7/Z, z31.s, z31.s           : facge  %p7/z %z31.s %z31.s -> %p15.s
+65c0c010 : facge p0.d, p0/Z, z0.d, z0.d              : facge  %p0/z %z0.d %z0.d -> %p0.d
+65c5c491 : facge p1.d, p1/Z, z4.d, z5.d              : facge  %p1/z %z4.d %z5.d -> %p1.d
+65c7c8d2 : facge p2.d, p2/Z, z6.d, z7.d              : facge  %p2/z %z6.d %z7.d -> %p2.d
+65c9c913 : facge p3.d, p2/Z, z8.d, z9.d              : facge  %p2/z %z8.d %z9.d -> %p3.d
+65cbcd54 : facge p4.d, p3/Z, z10.d, z11.d            : facge  %p3/z %z10.d %z11.d -> %p4.d
+65cdcd95 : facge p5.d, p3/Z, z12.d, z13.d            : facge  %p3/z %z12.d %z13.d -> %p5.d
+65cfd1d6 : facge p6.d, p4/Z, z14.d, z15.d            : facge  %p4/z %z14.d %z15.d -> %p6.d
+65d1d217 : facge p7.d, p4/Z, z16.d, z17.d            : facge  %p4/z %z16.d %z17.d -> %p7.d
+65d3d658 : facge p8.d, p5/Z, z18.d, z19.d            : facge  %p5/z %z18.d %z19.d -> %p8.d
+65d4d678 : facge p8.d, p5/Z, z19.d, z20.d            : facge  %p5/z %z19.d %z20.d -> %p8.d
+65d6d6b9 : facge p9.d, p5/Z, z21.d, z22.d            : facge  %p5/z %z21.d %z22.d -> %p9.d
+65d8dafa : facge p10.d, p6/Z, z23.d, z24.d           : facge  %p6/z %z23.d %z24.d -> %p10.d
+65dadb3b : facge p11.d, p6/Z, z25.d, z26.d           : facge  %p6/z %z25.d %z26.d -> %p11.d
+65dcdf7c : facge p12.d, p7/Z, z27.d, z28.d           : facge  %p7/z %z27.d %z28.d -> %p12.d
+65dedfbd : facge p13.d, p7/Z, z29.d, z30.d           : facge  %p7/z %z29.d %z30.d -> %p13.d
+65dfdfff : facge p15.d, p7/Z, z31.d, z31.d           : facge  %p7/z %z31.d %z31.d -> %p15.d
+
+# FACGT   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (FACGT-P.P.ZZ-_)
+6540e010 : facgt p0.h, p0/Z, z0.h, z0.h              : facgt  %p0/z %z0.h %z0.h -> %p0.h
+6545e491 : facgt p1.h, p1/Z, z4.h, z5.h              : facgt  %p1/z %z4.h %z5.h -> %p1.h
+6547e8d2 : facgt p2.h, p2/Z, z6.h, z7.h              : facgt  %p2/z %z6.h %z7.h -> %p2.h
+6549e913 : facgt p3.h, p2/Z, z8.h, z9.h              : facgt  %p2/z %z8.h %z9.h -> %p3.h
+654bed54 : facgt p4.h, p3/Z, z10.h, z11.h            : facgt  %p3/z %z10.h %z11.h -> %p4.h
+654ded95 : facgt p5.h, p3/Z, z12.h, z13.h            : facgt  %p3/z %z12.h %z13.h -> %p5.h
+654ff1d6 : facgt p6.h, p4/Z, z14.h, z15.h            : facgt  %p4/z %z14.h %z15.h -> %p6.h
+6551f217 : facgt p7.h, p4/Z, z16.h, z17.h            : facgt  %p4/z %z16.h %z17.h -> %p7.h
+6553f658 : facgt p8.h, p5/Z, z18.h, z19.h            : facgt  %p5/z %z18.h %z19.h -> %p8.h
+6554f678 : facgt p8.h, p5/Z, z19.h, z20.h            : facgt  %p5/z %z19.h %z20.h -> %p8.h
+6556f6b9 : facgt p9.h, p5/Z, z21.h, z22.h            : facgt  %p5/z %z21.h %z22.h -> %p9.h
+6558fafa : facgt p10.h, p6/Z, z23.h, z24.h           : facgt  %p6/z %z23.h %z24.h -> %p10.h
+655afb3b : facgt p11.h, p6/Z, z25.h, z26.h           : facgt  %p6/z %z25.h %z26.h -> %p11.h
+655cff7c : facgt p12.h, p7/Z, z27.h, z28.h           : facgt  %p7/z %z27.h %z28.h -> %p12.h
+655effbd : facgt p13.h, p7/Z, z29.h, z30.h           : facgt  %p7/z %z29.h %z30.h -> %p13.h
+655fffff : facgt p15.h, p7/Z, z31.h, z31.h           : facgt  %p7/z %z31.h %z31.h -> %p15.h
+6580e010 : facgt p0.s, p0/Z, z0.s, z0.s              : facgt  %p0/z %z0.s %z0.s -> %p0.s
+6585e491 : facgt p1.s, p1/Z, z4.s, z5.s              : facgt  %p1/z %z4.s %z5.s -> %p1.s
+6587e8d2 : facgt p2.s, p2/Z, z6.s, z7.s              : facgt  %p2/z %z6.s %z7.s -> %p2.s
+6589e913 : facgt p3.s, p2/Z, z8.s, z9.s              : facgt  %p2/z %z8.s %z9.s -> %p3.s
+658bed54 : facgt p4.s, p3/Z, z10.s, z11.s            : facgt  %p3/z %z10.s %z11.s -> %p4.s
+658ded95 : facgt p5.s, p3/Z, z12.s, z13.s            : facgt  %p3/z %z12.s %z13.s -> %p5.s
+658ff1d6 : facgt p6.s, p4/Z, z14.s, z15.s            : facgt  %p4/z %z14.s %z15.s -> %p6.s
+6591f217 : facgt p7.s, p4/Z, z16.s, z17.s            : facgt  %p4/z %z16.s %z17.s -> %p7.s
+6593f658 : facgt p8.s, p5/Z, z18.s, z19.s            : facgt  %p5/z %z18.s %z19.s -> %p8.s
+6594f678 : facgt p8.s, p5/Z, z19.s, z20.s            : facgt  %p5/z %z19.s %z20.s -> %p8.s
+6596f6b9 : facgt p9.s, p5/Z, z21.s, z22.s            : facgt  %p5/z %z21.s %z22.s -> %p9.s
+6598fafa : facgt p10.s, p6/Z, z23.s, z24.s           : facgt  %p6/z %z23.s %z24.s -> %p10.s
+659afb3b : facgt p11.s, p6/Z, z25.s, z26.s           : facgt  %p6/z %z25.s %z26.s -> %p11.s
+659cff7c : facgt p12.s, p7/Z, z27.s, z28.s           : facgt  %p7/z %z27.s %z28.s -> %p12.s
+659effbd : facgt p13.s, p7/Z, z29.s, z30.s           : facgt  %p7/z %z29.s %z30.s -> %p13.s
+659fffff : facgt p15.s, p7/Z, z31.s, z31.s           : facgt  %p7/z %z31.s %z31.s -> %p15.s
+65c0e010 : facgt p0.d, p0/Z, z0.d, z0.d              : facgt  %p0/z %z0.d %z0.d -> %p0.d
+65c5e491 : facgt p1.d, p1/Z, z4.d, z5.d              : facgt  %p1/z %z4.d %z5.d -> %p1.d
+65c7e8d2 : facgt p2.d, p2/Z, z6.d, z7.d              : facgt  %p2/z %z6.d %z7.d -> %p2.d
+65c9e913 : facgt p3.d, p2/Z, z8.d, z9.d              : facgt  %p2/z %z8.d %z9.d -> %p3.d
+65cbed54 : facgt p4.d, p3/Z, z10.d, z11.d            : facgt  %p3/z %z10.d %z11.d -> %p4.d
+65cded95 : facgt p5.d, p3/Z, z12.d, z13.d            : facgt  %p3/z %z12.d %z13.d -> %p5.d
+65cff1d6 : facgt p6.d, p4/Z, z14.d, z15.d            : facgt  %p4/z %z14.d %z15.d -> %p6.d
+65d1f217 : facgt p7.d, p4/Z, z16.d, z17.d            : facgt  %p4/z %z16.d %z17.d -> %p7.d
+65d3f658 : facgt p8.d, p5/Z, z18.d, z19.d            : facgt  %p5/z %z18.d %z19.d -> %p8.d
+65d4f678 : facgt p8.d, p5/Z, z19.d, z20.d            : facgt  %p5/z %z19.d %z20.d -> %p8.d
+65d6f6b9 : facgt p9.d, p5/Z, z21.d, z22.d            : facgt  %p5/z %z21.d %z22.d -> %p9.d
+65d8fafa : facgt p10.d, p6/Z, z23.d, z24.d           : facgt  %p6/z %z23.d %z24.d -> %p10.d
+65dafb3b : facgt p11.d, p6/Z, z25.d, z26.d           : facgt  %p6/z %z25.d %z26.d -> %p11.d
+65dcff7c : facgt p12.d, p7/Z, z27.d, z28.d           : facgt  %p7/z %z27.d %z28.d -> %p12.d
+65deffbd : facgt p13.d, p7/Z, z29.d, z30.d           : facgt  %p7/z %z29.d %z30.d -> %p13.d
+65dfffff : facgt p15.d, p7/Z, z31.d, z31.d           : facgt  %p7/z %z31.d %z31.d -> %p15.d
+
 # MAD     <Zdn>.<T>, <Pg>/M, <Zm>.<T>, <Za>.<T> (MAD-Z.P.ZZZ-_)
 0400c000 : mad z0.b, p0/M, z0.b, z0.b                : mad    %p0/m %z0.b %z0.b %z0.b -> %z0.b
 0404c4a2 : mad z2.b, p1/M, z4.b, z5.b                : mad    %p1/m %z2.b %z4.b %z5.b -> %z2.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -3021,6 +3021,141 @@ TEST_INSTR(uabd_sve_pred)
 
     return success;
 }
+
+TEST_INSTR(facge_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FACGE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
+    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
+                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
+                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "facge  %p0/z %z0.h %z0.h -> %p0.h",    "facge  %p2/z %z7.h %z8.h -> %p2.h",
+        "facge  %p3/z %z12.h %z13.h -> %p5.h",  "facge  %p5/z %z18.h %z19.h -> %p8.h",
+        "facge  %p6/z %z23.h %z24.h -> %p10.h", "facge  %p7/z %z31.h %z31.h -> %p15.h",
+    };
+    TEST_LOOP(facge, facge_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_0[i], false),
+              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+
+    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
+                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
+                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "facge  %p0/z %z0.s %z0.s -> %p0.s",    "facge  %p2/z %z7.s %z8.s -> %p2.s",
+        "facge  %p3/z %z12.s %z13.s -> %p5.s",  "facge  %p5/z %z18.s %z19.s -> %p8.s",
+        "facge  %p6/z %z23.s %z24.s -> %p10.s", "facge  %p7/z %z31.s %z31.s -> %p15.s",
+    };
+    TEST_LOOP(facge, facge_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_1[i], false),
+              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+
+    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
+                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
+                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "facge  %p0/z %z0.d %z0.d -> %p0.d",    "facge  %p2/z %z7.d %z8.d -> %p2.d",
+        "facge  %p3/z %z12.d %z13.d -> %p5.d",  "facge  %p5/z %z18.d %z19.d -> %p8.d",
+        "facge  %p6/z %z23.d %z24.d -> %p10.d", "facge  %p7/z %z31.d %z31.d -> %p15.d",
+    };
+    TEST_LOOP(facge, facge_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_2[i], false),
+              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
+
+    return success;
+}
+
+TEST_INSTR(facgt_sve_pred)
+{
+    bool success = true;
+    instr_t *instr;
+    byte *pc;
+
+    /* Testing FACGT   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
+    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
+                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
+                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
+    const char *expected_0_0[6] = {
+        "facgt  %p0/z %z0.h %z0.h -> %p0.h",    "facgt  %p2/z %z7.h %z8.h -> %p2.h",
+        "facgt  %p3/z %z12.h %z13.h -> %p5.h",  "facgt  %p5/z %z18.h %z19.h -> %p8.h",
+        "facgt  %p6/z %z23.h %z24.h -> %p10.h", "facgt  %p7/z %z31.h %z31.h -> %p15.h",
+    };
+    TEST_LOOP(facgt, facgt_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pg_0_0[i], false),
+              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+
+    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
+                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
+                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
+    const char *expected_0_1[6] = {
+        "facgt  %p0/z %z0.s %z0.s -> %p0.s",    "facgt  %p2/z %z7.s %z8.s -> %p2.s",
+        "facgt  %p3/z %z12.s %z13.s -> %p5.s",  "facgt  %p5/z %z18.s %z19.s -> %p8.s",
+        "facgt  %p6/z %z23.s %z24.s -> %p10.s", "facgt  %p7/z %z31.s %z31.s -> %p15.s",
+    };
+    TEST_LOOP(facgt, facgt_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
+              opnd_create_predicate_reg(Pg_0_1[i], false),
+              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+
+    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
+                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
+                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
+    const char *expected_0_2[6] = {
+        "facgt  %p0/z %z0.d %z0.d -> %p0.d",    "facgt  %p2/z %z7.d %z8.d -> %p2.d",
+        "facgt  %p3/z %z12.d %z13.d -> %p5.d",  "facgt  %p5/z %z18.d %z19.d -> %p8.d",
+        "facgt  %p6/z %z23.d %z24.d -> %p10.d", "facgt  %p7/z %z31.d %z31.d -> %p15.d",
+    };
+    TEST_LOOP(facgt, facgt_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
+              opnd_create_predicate_reg(Pg_0_2[i], false),
+              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
+
+    return success;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -3080,6 +3215,9 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(smin_sve_pred);
     RUN_INSTR_TEST(smin_sve);
     RUN_INSTR_TEST(uabd_sve_pred);
+
+    RUN_INSTR_TEST(facge_sve_pred);
+    RUN_INSTR_TEST(facgt_sve_pred);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
FACGE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
FACGT   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
```

issue: #3044