### PR TITLE
i#5744: AArch64 codec: adds LDAPR, LDAPRB, LDAPRH

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -154,6 +154,7 @@ proc_init_arch(void)
             cpu_info.features.flags_aa64dfr0);
         LOG_FEATURE(FEATURE_SPE);
         LOG_FEATURE(FEATURE_PAUTH);
+        LOG_FEATURE(FEATURE_LRCPC);
     });
 #    endif
 #endif
@@ -175,7 +176,8 @@ proc_has_feature(feature_bit_t f)
     if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
         f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR ||
         f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4 || f == FEATURE_SHA512 ||
-        f == FEATURE_SHA3 || f == FEATURE_RAS || f == FEATURE_SPE || f == FEATURE_PAUTH)
+        f == FEATURE_SHA3 || f == FEATURE_RAS || f == FEATURE_SPE || f == FEATURE_PAUTH ||
+        f == FEATURE_LRCPC)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -348,6 +348,7 @@ typedef enum {
     FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 0),   /**< Limited order regions (AArch64) */
     FEATURE_SPE = DEF_FEAT(AA64DFR0, 8, 1, 0),    /**< Profiling extension (AArch64) */
     FEATURE_PAUTH = DEF_FEAT(AA64ISAR1, 8, 1, 0), /**< PAuth extension (AArch64) */
+    FEATURE_LRCPC = DEF_FEAT(AA64ISAR1, 20, 1, 0), /**< LDAPR, LDAPRB, LDAPRH (AArch64) */
 } feature_bit_t;
 #endif
 #ifdef RISCV64

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -345,9 +345,9 @@ typedef enum {
     FEATURE_FP16 = DEF_FEAT(AA64PFR0, 4, 1, 1),      /**< Half-precision FP (AArch64) */
     FEATURE_RAS = DEF_FEAT(AA64PFR0, 7, 1, 0),       /**< RAS extension (AArch64) */
     FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 0),       /**< Scalable Vectors (AArch64) */
-    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 0),   /**< Limited order regions (AArch64) */
-    FEATURE_SPE = DEF_FEAT(AA64DFR0, 8, 1, 0),    /**< Profiling extension (AArch64) */
-    FEATURE_PAUTH = DEF_FEAT(AA64ISAR1, 8, 1, 0), /**< PAuth extension (AArch64) */
+    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 0),    /**< Limited order regions (AArch64) */
+    FEATURE_SPE = DEF_FEAT(AA64DFR0, 8, 1, 0),     /**< Profiling extension (AArch64) */
+    FEATURE_PAUTH = DEF_FEAT(AA64ISAR1, 8, 1, 0),  /**< PAuth extension (AArch64) */
     FEATURE_LRCPC = DEF_FEAT(AA64ISAR1, 20, 1, 0), /**< LDAPR, LDAPRB, LDAPRH (AArch64) */
 } feature_bit_t;
 #endif

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1028,21 +1028,21 @@ encode_opnd_q0p(int add, opnd_t opnd, OUT uint *enc_out)
 /* rn: used for many integer register operands where bit 31 specifies W or X */
 
 static inline bool
-decode_opnd_rn(bool is_sp, int pos, uint enc, OUT opnd_t *opnd)
+decode_opnd_rn(bool is_sp, int pos, int sz_bit, uint enc, OUT opnd_t *opnd)
 {
     *opnd = opnd_create_reg(
-        decode_reg(extract_uint(enc, pos, 5), TEST(1U << 31, enc), is_sp));
+        decode_reg(extract_uint(enc, pos, 5), TEST(1U << sz_bit, enc), is_sp));
     return true;
 }
 
 static inline bool
-encode_opnd_rn(bool is_sp, int pos, opnd_t opnd, OUT uint *enc_out)
+encode_opnd_rn(bool is_sp, int pos, int sz_bit, opnd_t opnd, OUT uint *enc_out)
 {
     uint num;
     bool is_x;
     if (!opnd_is_reg(opnd) || !encode_reg(&num, &is_x, opnd_get_reg(opnd), is_sp))
         return false;
-    *enc_out = (uint)is_x << 31 | num << pos;
+    *enc_out = (uint)is_x << sz_bit | num << pos;
     return true;
 }
 
@@ -4688,6 +4688,20 @@ encode_opnd_index3(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
     return encode_opnd_index(3, opnd, enc_out);
 }
 
+/* wx0_30: X/W register at bit position 0; bit 30 selects X or W reg */
+
+static inline bool
+decode_opnd_wx0_30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_rn(false, 0, 30, enc, opnd);
+}
+
+static inline bool
+encode_opnd_wx0_30(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_rn(false, 0, 30, opnd, enc_out);
+}
+
 /* dq0: D/Q register at bit position 0; bit 30 selects Q reg */
 
 static inline bool
@@ -5203,13 +5217,13 @@ encode_opnd_memlit(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
 static inline bool
 decode_opnd_wx0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_opnd_rn(false, 0, enc, opnd);
+    return decode_opnd_rn(false, 0, 31, enc, opnd);
 }
 
 static inline bool
 encode_opnd_wx0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    return encode_opnd_rn(false, 0, opnd, enc_out);
+    return encode_opnd_rn(false, 0, 31, opnd, enc_out);
 }
 
 /* wx0sp: W/X register or WSP/XSP at bit position 0; bit 31 selects X reg */
@@ -5217,13 +5231,13 @@ encode_opnd_wx0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_wx0sp(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_opnd_rn(true, 0, enc, opnd);
+    return decode_opnd_rn(true, 0, 31, enc, opnd);
 }
 
 static inline bool
 encode_opnd_wx0sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    return encode_opnd_rn(true, 0, opnd, enc_out);
+    return encode_opnd_rn(true, 0, 31, opnd, enc_out);
 }
 
 /* wx5: W/X register or WZR/XZR at bit position 5; bit 31 selects X reg */
@@ -5231,13 +5245,13 @@ encode_opnd_wx0sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
 static inline bool
 decode_opnd_wx5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_opnd_rn(false, 5, enc, opnd);
+    return decode_opnd_rn(false, 5, 31, enc, opnd);
 }
 
 static inline bool
 encode_opnd_wx5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    return encode_opnd_rn(false, 5, opnd, enc_out);
+    return encode_opnd_rn(false, 5, 31, opnd, enc_out);
 }
 
 /* wx5sp: W/X register or WSP/XSP at bit position 5; bit 31 selects X reg */
@@ -5245,13 +5259,13 @@ encode_opnd_wx5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_wx5sp(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_opnd_rn(true, 5, enc, opnd);
+    return decode_opnd_rn(true, 5, 31, enc, opnd);
 }
 
 static inline bool
 encode_opnd_wx5sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    return encode_opnd_rn(true, 5, opnd, enc_out);
+    return encode_opnd_rn(true, 5, 31, opnd, enc_out);
 }
 
 /* wx10: W/X register or WZR/XZR at bit position 10; bit 31 selects X reg */
@@ -5259,13 +5273,13 @@ encode_opnd_wx5sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
 static inline bool
 decode_opnd_wx10(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_opnd_rn(false, 10, enc, opnd);
+    return decode_opnd_rn(false, 10, 31, enc, opnd);
 }
 
 static inline bool
 encode_opnd_wx10(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    return encode_opnd_rn(false, 10, opnd, enc_out);
+    return encode_opnd_rn(false, 10, 31, opnd, enc_out);
 }
 
 /* wx16: W/X register or WZR/XZR at bit position 16; bit 31 selects X reg */
@@ -5273,13 +5287,13 @@ encode_opnd_wx10(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 static inline bool
 decode_opnd_wx16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_opnd_rn(false, 16, enc, opnd);
+    return decode_opnd_rn(false, 16, 31, enc, opnd);
 }
 
 static inline bool
 encode_opnd_wx16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    return encode_opnd_rn(false, 16, opnd, enc_out);
+    return encode_opnd_rn(false, 16, 31, opnd, enc_out);
 }
 
 /*******************************************************************************
@@ -5377,14 +5391,14 @@ decode_opnds_ccm(uint enc, dcontext_t *dcontext, byte *pc, instr_t *instr, int o
 
     /* Rn */
     opnd_t rn;
-    if (!decode_opnd_rn(false, 5, enc, &rn))
+    if (!decode_opnd_rn(false, 5, 31, enc, &rn))
         return false;
     instr_set_src(instr, 0, rn);
 
     opnd_t rm;
     if (TEST(1U << 11, enc)) /* imm5 */
         instr_set_src(instr, 1, opnd_create_immed_int(extract_uint(enc, 16, 5), OPSZ_5b));
-    else if (!decode_opnd_rn(false, 16, enc, &rm)) /* Rm */
+    else if (!decode_opnd_rn(false, 16, 31, enc, &rm)) /* Rm */
         return false;
     else
         instr_set_src(instr, 1, rm);
@@ -5404,7 +5418,7 @@ encode_opnds_ccm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     uint rm_imm5 = 0;
     uint imm5_flag = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 3 &&
-        encode_opnd_rn(false, 5, instr_get_src(instr, 0), &rn) && /* Rn */
+        encode_opnd_rn(false, 5, 31, instr_get_src(instr, 0), &rn) && /* Rn */
         opnd_is_immed_int(instr_get_src(instr, 2)) &&             /* nzcv */
         (uint)(instr_get_predicate(instr) - DR_PRED_EQ) < 16) {   /* cond */
         uint nzcv = opnd_get_immed_int(instr_get_src(instr, 2));
@@ -5413,7 +5427,7 @@ encode_opnds_ccm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
             rm_imm5 = opnd_get_immed_int(instr_get_src(instr, 1)) << 16;
             imm5_flag = 1;
         } else if (opnd_is_reg(instr_get_src(instr, 1))) { /* Rm */
-            encode_opnd_rn(false, 16, instr_get_src(instr, 1), &rm_imm5);
+            encode_opnd_rn(false, 16, 31, instr_get_src(instr, 1), &rm_imm5);
         } else
             return ENCFAIL;
         return (enc | nzcv | rn | (imm5_flag << 11) | rm_imm5 | (cond << 12));
@@ -5442,7 +5456,7 @@ encode_opnds_cbz(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     uint rt, off;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 2 &&
         encode_pc_off(&off, 19, pc, instr, instr_get_src(instr, 0), di) &&
-        encode_opnd_rn(false, 0, instr_get_src(instr, 1), &rt))
+        encode_opnd_rn(false, 0, 31, instr_get_src(instr, 1), &rt))
         return (enc | off << 5 | rt);
     return ENCFAIL;
 }
@@ -5489,8 +5503,8 @@ encode_opnds_logic_imm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     if (srcs < 2 || srcs > 3 || instr_num_dsts(instr) != 1)
         return ENCFAIL;
     opnd_val = instr_get_src(instr, 1);
-    if (!encode_opnd_rn(opcode != OP_ands, 0, instr_get_dst(instr, 0), &rd) ||
-        !encode_opnd_rn(false, 5, instr_get_src(instr, 0), &rn) ||
+    if (!encode_opnd_rn(opcode != OP_ands, 0, 31, instr_get_dst(instr, 0), &rd) ||
+        !encode_opnd_rn(false, 5, 31, instr_get_src(instr, 0), &rn) ||
         TEST(1U << 31, rd ^ rn) || !opnd_is_immed_int(opnd_val))
         return ENCFAIL;
     imm_val = opnd_get_immed_int(opnd_val);

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5419,8 +5419,8 @@ encode_opnds_ccm(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
     uint imm5_flag = 0;
     if (instr_num_dsts(instr) == 0 && instr_num_srcs(instr) == 3 &&
         encode_opnd_rn(false, 5, 31, instr_get_src(instr, 0), &rn) && /* Rn */
-        opnd_is_immed_int(instr_get_src(instr, 2)) &&             /* nzcv */
-        (uint)(instr_get_predicate(instr) - DR_PRED_EQ) < 16) {   /* cond */
+        opnd_is_immed_int(instr_get_src(instr, 2)) &&                 /* nzcv */
+        (uint)(instr_get_predicate(instr) - DR_PRED_EQ) < 16) {       /* cond */
         uint nzcv = opnd_get_immed_int(instr_get_src(instr, 2));
         uint cond = instr_get_predicate(instr) - DR_PRED_EQ;
         if (opnd_is_immed_int(instr_get_src(instr, 1))) { /* imm5 */

--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -46,6 +46,9 @@
 1101011100111111000010xxxxxxxxxx  n   782  PAUTH   blraa  impx30 : x5 x0
 1101011000111111000010xxxxx11111  n   682  PAUTH  blraaz  impx30 : x5
 1101011100011111000010xxxxxxxxxx  n   683  PAUTH    braa         : x5 x0
+1x11100010111111110000xxxxxxxxxx  n   794  LRCPC   ldapr  wx0_30 : mem0
+0011100010111111110000xxxxxxxxxx  n   795  LRCPC  ldaprb      w0 : mem0
+0111100010111111110000xxxxxxxxxx  n   796  LRCPC  ldaprh      w0 : mem0
 1101101011000001000010xxxxxxxxxx  n   687  PAUTH   pacda         : x0 x5
 1101101011000001000000xxxxxxxxxx  n   688  PAUTH   pacia         : x0 x5
 1101101011000001000001xxxxxxxxxx  n   689  PAUTH   pacib         : x0 x5

--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -46,9 +46,9 @@
 1101011100111111000010xxxxxxxxxx  n   782  PAUTH   blraa  impx30 : x5 x0
 1101011000111111000010xxxxx11111  n   682  PAUTH  blraaz  impx30 : x5
 1101011100011111000010xxxxxxxxxx  n   683  PAUTH    braa         : x5 x0
-1x11100010111111110000xxxxxxxxxx  n   794  LRCPC   ldapr  wx0_30 : mem0
-0011100010111111110000xxxxxxxxxx  n   795  LRCPC  ldaprb      w0 : mem0
-0111100010111111110000xxxxxxxxxx  n   796  LRCPC  ldaprh      w0 : mem0
+1x11100010111111110000xxxxxxxxxx  n   796  LRCPC   ldapr  wx0_30 : mem0
+0011100010111111110000xxxxxxxxxx  n   797  LRCPC  ldaprb      w0 : mem0
+0111100010111111110000xxxxxxxxxx  n   798  LRCPC  ldaprh      w0 : mem0
 1101101011000001000010xxxxxxxxxx  n   687  PAUTH   pacda         : x0 x5
 1101101011000001000000xxxxxxxxxx  n   688  PAUTH   pacia         : x0 x5
 1101101011000001000001xxxxxxxxxx  n   689  PAUTH   pacib         : x0 x5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -4469,6 +4469,49 @@
 #define INSTR_CREATE_stllrh(dc, Rt, Rn) instr_create_1dst_1src(dc, OP_stllrh, Rt, Rn)
 
 /**
+ * Creates a LDAPR load-acquire instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDAPR <Wt>, [<Xn|SP> {,#0}]
+ *    LDAPR <Xt>, [<Xn|SP> {,#0}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rt   The destination register, W (Word, 32 bits) or X (Extended, 64 bits).
+ * \param mem  The source memory address operand.
+ */
+#define INSTR_CREATE_ldapr(dc, Rt, mem) \
+    instr_create_1dst_1src((dc), OP_ldapr, (Rt), (mem))
+
+/**
+ * Creates a LDAPRB load-acquire byte instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDAPRB <Wt>, [<Xn|SP> {,#0}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rt   The destination register, W (Word, 32 bits).
+ * \param mem  The source memory address operand.
+ */
+#define INSTR_CREATE_ldaprb(dc, Rt, mem) \
+    instr_create_1dst_1src((dc), OP_ldaprb, (Rt), (mem))
+
+/**
+ * Creates a LDAPRH load-acquire half-word instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDAPRH <Wt>, [<Xn|SP> {,#0}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rt   The destination register, W (Word, 32 bits).
+ * \param mem  The source memory address operand.
+ */
+#define INSTR_CREATE_ldaprh(dc, Rt, mem) \
+    instr_create_1dst_1src((dc), OP_ldaprh, (Rt), (mem))
+
+/**
  * Creates a SM3PARTW1 instruction.
  *
  * This macro is used to encode the forms:

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -220,6 +220,7 @@
 -?--------------------xxxxx-----  mem0p      # gets size from 30; no offset, pair
 -?---------xxxxx????------------  x16imm     # computes immed from 30 and 15:12
 -x------------------------------  index3     # index of D subreg in Q: 0-1
+-x-------------------------xxxxx  wx0_30     # X register if bit 30 is set, else W
 -x-------------------------xxxxx  dq0        # Q register if bit 30 is set, else D
 -x-------------------------xxxxx  sd0        # D register if bit 30 is set, else S
 -x-------------------------xxxxx  dq0p1      # ... add 1

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -380,6 +380,38 @@ test_ldar(void *dc)
     test_instr_encoding(dc, OP_ldarh, instr);
 }
 
+/* TODO: Add this to a new suite/tests/api/ir_aarch64_v83.c file */
+static void
+test_ldapr(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    /* LDAPR <Wt>, [<Xn|SP>{,#0}] */
+    instr = INSTR_CREATE_ldapr(
+        dc, opnd_create_reg(DR_REG_W0),
+        opnd_create_base_disp_aarch64(DR_REG_X1, DR_REG_NULL, 0, false, 0, 0, OPSZ_4));
+    test_instr_encoding(dc, OP_ldapr, instr);
+
+    /* LDAPR <Xt>, [<Xn|SP>{,#0}] */
+    instr = INSTR_CREATE_ldapr(
+        dc, opnd_create_reg(DR_REG_X2),
+        opnd_create_base_disp_aarch64(DR_REG_X3, DR_REG_NULL, 0, false, 0, 0, OPSZ_8));
+    test_instr_encoding(dc, OP_ldapr, instr);
+
+    /* LDAPRB <Wt>, [<Xn|SP>{,#0}] */
+    instr = INSTR_CREATE_ldaprb(
+        dc, opnd_create_reg(DR_REG_W4),
+        opnd_create_base_disp_aarch64(DR_REG_X5, DR_REG_NULL, 0, false, 0, 0, OPSZ_1));
+    test_instr_encoding(dc, OP_ldaprb, instr);
+
+    /* LDAPRH <Wt>, [<Xn|SP>{,#0}] */
+    instr = INSTR_CREATE_ldaprh(
+        dc, opnd_create_reg(DR_REG_W6),
+        opnd_create_base_disp_aarch64(DR_REG_X7, DR_REG_NULL, 0, false, 0, 0, OPSZ_2));
+    test_instr_encoding(dc, OP_ldaprh, instr);
+}
+
 static void
 ld2_simdfp_multiple_structures_no_offset(void *dc)
 {
@@ -7028,6 +7060,9 @@ main(int argc, char *argv[])
 
     test_ldar(dcontext);
     print("test_ldar complete\n");
+
+    test_ldapr(dcontext);
+    print("test_ldapr complete\n");
 
     test_ldur_stur(dcontext);
     print("test_ldur_stur complete\n");

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -35,6 +35,11 @@ ldar   (%x1)[8byte] -> %x0
 ldarb  (%x1)[1byte] -> %w0
 ldarh  (%x1)[2byte] -> %w0
 test_ldar complete
+ldapr  (%x1)[4byte] -> %w0
+ldapr  (%x3)[8byte] -> %x2
+ldaprb (%x5)[1byte] -> %w4
+ldaprh (%x7)[2byte] -> %w6
+test_ldapr complete
 ldur   (%x0)[1byte] -> %b0
 ldur   +0xff(%x1)[1byte] -> %b1
 ldur   (%x2)[2byte] -> %h2


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following:
LDAPR <Wt>, [<Xn|SP> {,#0}]
LDAPR <Xt>, [<Xn|SP> {,#0}]
LDAPRB <Wt>, [<Xn|SP> {,#0}]
LDAPRH <Wt>, [<Xn|SP> {,#0}]

It also adds FEATURE_LRCPC which introduces these 3 instructions supporting the weaker release consistency processor consistent (RCpc) model that enables the reordering of a store-Release followed by a load-acquire to a different address.

Issues: #5744, #4847