### PR TITLE
i#4393: AArch64 decode: Reduce boilerplate for IR tests

### DIFF
--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -47,21 +47,22 @@ static byte buf[8192];
                        : 0))
 #endif
 
-#define TEST_INSTR(instruction_name) void test_instr_##instruction_name(void *dc, instr_t *instr, bool *psuccess)
+#define TEST_INSTR(instruction_name) \
+    void test_instr_##instruction_name(void *dc, instr_t *instr, bool *psuccess)
 
-#define RUN_INSTR_TEST(instruction_name)                   \
-    test_result = true; \
+#define RUN_INSTR_TEST(instruction_name)                          \
+    test_result = true;                                           \
     test_instr_##instruction_name(dcontext, instr, &test_result); \
-    if (test_result == false) {                            \
-        print("test for " #instruction_name " failed.\n"); \
-        result = false;                                    \
+    if (test_result == false) {                                   \
+        print("test for " #instruction_name " failed.\n");        \
+        result = false;                                           \
     }
 
 #define TEST_LOOP(opcode, create_name, number, expected, args...)   \
     for (int i = 0; i < number; i++) {                              \
         instr = INSTR_CREATE_##create_name(dc, args);               \
         if (!test_instr_encoding(dc, OP_##opcode, instr, expected)) \
-            *psuccess = false;                                        \
+            *psuccess = false;                                      \
     }
 
 static bool
@@ -131,7 +132,7 @@ const reg_id_t Zn_six_offset_3[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
 const reg_id_t Pn_half_six_offset_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
                                            DR_REG_P5, DR_REG_P6, DR_REG_P7 };
 const reg_id_t Pn_six_offset_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                                     DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+                                      DR_REG_P8, DR_REG_P10, DR_REG_P15 };
 const reg_id_t Pn_six_offset_1[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
                                       DR_REG_P9, DR_REG_P11, DR_REG_P15 };
 const reg_id_t Pn_six_offset_2[6] = { DR_REG_P0,  DR_REG_P4,  DR_REG_P7,

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -47,10 +47,11 @@ static byte buf[8192];
                        : 0))
 #endif
 
-#define TEST_INSTR(instruction_name) bool test_instr_##instruction_name(void *dc)
+#define TEST_INSTR(instruction_name) void test_instr_##instruction_name(void *dc, instr_t *instr, bool *psuccess)
 
 #define RUN_INSTR_TEST(instruction_name)                   \
-    test_result = test_instr_##instruction_name(dcontext); \
+    test_result = true; \
+    test_instr_##instruction_name(dcontext, instr, &test_result); \
     if (test_result == false) {                            \
         print("test for " #instruction_name " failed.\n"); \
         result = false;                                    \
@@ -60,7 +61,7 @@ static byte buf[8192];
     for (int i = 0; i < number; i++) {                              \
         instr = INSTR_CREATE_##create_name(dc, args);               \
         if (!test_instr_encoding(dc, OP_##opcode, instr, expected)) \
-            success = false;                                        \
+            *psuccess = false;                                        \
     }
 
 static bool
@@ -118,3 +119,20 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
 
     return result;
 }
+
+const reg_id_t Zn_six_offset_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
+                                      DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
+const reg_id_t Zn_six_offset_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
+                                      DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
+const reg_id_t Zn_six_offset_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
+                                      DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
+const reg_id_t Zn_six_offset_3[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
+                                      DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
+const reg_id_t Pn_half_six_offset_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
+                                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
+const reg_id_t Pn_six_offset_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
+                                     DR_REG_P8, DR_REG_P10, DR_REG_P15 };
+const reg_id_t Pn_six_offset_1[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
+                                      DR_REG_P9, DR_REG_P11, DR_REG_P15 };
+const reg_id_t Pn_six_offset_2[6] = { DR_REG_P0,  DR_REG_P4,  DR_REG_P7,
+                                      DR_REG_P10, DR_REG_P12, DR_REG_P15 };

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -50,1470 +50,1021 @@
 
 TEST_INSTR(add_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing ADD     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "add    %p0/m %z0.b %z0.b -> %z0.b",    "add    %p2/m %z5.b %z7.b -> %z5.b",
-        "add    %p3/m %z10.b %z12.b -> %z10.b", "add    %p4/m %z15.b %z17.b -> %z15.b",
-        "add    %p5/m %z20.b %z22.b -> %z20.b", "add    %p6/m %z30.b %z30.b -> %z30.b",
+        "add    %p3/m %z10.b %z12.b -> %z10.b", "add    %p5/m %z16.b %z18.b -> %z16.b",
+        "add    %p6/m %z21.b %z23.b -> %z21.b", "add    %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(add, add_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "add    %p0/m %z0.h %z0.h -> %z0.h",    "add    %p2/m %z5.h %z7.h -> %z5.h",
-        "add    %p3/m %z10.h %z12.h -> %z10.h", "add    %p4/m %z15.h %z17.h -> %z15.h",
-        "add    %p5/m %z20.h %z22.h -> %z20.h", "add    %p6/m %z30.h %z30.h -> %z30.h",
+        "add    %p3/m %z10.h %z12.h -> %z10.h", "add    %p5/m %z16.h %z18.h -> %z16.h",
+        "add    %p6/m %z21.h %z23.h -> %z21.h", "add    %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(add, add_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "add    %p0/m %z0.s %z0.s -> %z0.s",    "add    %p2/m %z5.s %z7.s -> %z5.s",
-        "add    %p3/m %z10.s %z12.s -> %z10.s", "add    %p4/m %z15.s %z17.s -> %z15.s",
-        "add    %p5/m %z20.s %z22.s -> %z20.s", "add    %p6/m %z30.s %z30.s -> %z30.s",
+        "add    %p3/m %z10.s %z12.s -> %z10.s", "add    %p5/m %z16.s %z18.s -> %z16.s",
+        "add    %p6/m %z21.s %z23.s -> %z21.s", "add    %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(add, add_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "add    %p0/m %z0.d %z0.d -> %z0.d",    "add    %p2/m %z5.d %z7.d -> %z5.d",
-        "add    %p3/m %z10.d %z12.d -> %z10.d", "add    %p4/m %z15.d %z17.d -> %z15.d",
-        "add    %p5/m %z20.d %z22.d -> %z20.d", "add    %p6/m %z30.d %z30.d -> %z30.d",
+        "add    %p3/m %z10.d %z12.d -> %z10.d", "add    %p5/m %z16.d %z18.d -> %z16.d",
+        "add    %p6/m %z21.d %z23.d -> %z21.d", "add    %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(add, add_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(add_sve_shift)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing ADD     <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>, <shift> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "add    %z0.b $0x00 lsl $0x00 -> %z0.b",
         "add    %z5.b $0x2b lsl $0x00 -> %z5.b",
         "add    %z10.b $0x56 lsl $0x00 -> %z10.b",
-        "add    %z15.b $0x81 lsl $0x00 -> %z15.b",
-        "add    %z20.b $0xab lsl $0x00 -> %z20.b",
-        "add    %z30.b $0xff lsl $0x00 -> %z30.b",
+        "add    %z16.b $0x81 lsl $0x00 -> %z16.b",
+        "add    %z21.b $0xab lsl $0x00 -> %z21.b",
+        "add    %z31.b $0xff lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(add, add_sve_shift, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_1[6] = {
         "add    %z0.h $0x00 lsl $0x08 -> %z0.h",
         "add    %z5.h $0x2b lsl $0x08 -> %z5.h",
         "add    %z10.h $0x56 lsl $0x08 -> %z10.h",
-        "add    %z15.h $0x81 lsl $0x08 -> %z15.h",
-        "add    %z20.h $0xab lsl $0x00 -> %z20.h",
-        "add    %z30.h $0xff lsl $0x00 -> %z30.h",
+        "add    %z16.h $0x81 lsl $0x08 -> %z16.h",
+        "add    %z21.h $0xab lsl $0x00 -> %z21.h",
+        "add    %z31.h $0xff lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(add, add_sve_shift, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_2[6] = {
         "add    %z0.s $0x00 lsl $0x08 -> %z0.s",
         "add    %z5.s $0x2b lsl $0x08 -> %z5.s",
         "add    %z10.s $0x56 lsl $0x08 -> %z10.s",
-        "add    %z15.s $0x81 lsl $0x08 -> %z15.s",
-        "add    %z20.s $0xab lsl $0x00 -> %z20.s",
-        "add    %z30.s $0xff lsl $0x00 -> %z30.s",
+        "add    %z16.s $0x81 lsl $0x08 -> %z16.s",
+        "add    %z21.s $0xab lsl $0x00 -> %z21.s",
+        "add    %z31.s $0xff lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(add, add_sve_shift, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_3[6] = {
         "add    %z0.d $0x00 lsl $0x08 -> %z0.d",
         "add    %z5.d $0x2b lsl $0x08 -> %z5.d",
         "add    %z10.d $0x56 lsl $0x08 -> %z10.d",
-        "add    %z15.d $0x81 lsl $0x08 -> %z15.d",
-        "add    %z20.d $0xab lsl $0x00 -> %z20.d",
-        "add    %z30.d $0xff lsl $0x00 -> %z30.d",
+        "add    %z16.d $0x81 lsl $0x08 -> %z16.d",
+        "add    %z21.d $0xab lsl $0x00 -> %z21.d",
+        "add    %z31.d $0xff lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(add, add_sve_shift, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(add_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing ADD     <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "add    %z0.b %z0.b -> %z0.b",    "add    %z6.b %z7.b -> %z5.b",
-        "add    %z11.b %z12.b -> %z10.b", "add    %z16.b %z17.b -> %z15.b",
-        "add    %z21.b %z22.b -> %z20.b", "add    %z30.b %z30.b -> %z30.b",
+        "add    %z11.b %z12.b -> %z10.b", "add    %z17.b %z18.b -> %z16.b",
+        "add    %z22.b %z23.b -> %z21.b", "add    %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(add, add_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "add    %z0.h %z0.h -> %z0.h",    "add    %z6.h %z7.h -> %z5.h",
-        "add    %z11.h %z12.h -> %z10.h", "add    %z16.h %z17.h -> %z15.h",
-        "add    %z21.h %z22.h -> %z20.h", "add    %z30.h %z30.h -> %z30.h",
+        "add    %z11.h %z12.h -> %z10.h", "add    %z17.h %z18.h -> %z16.h",
+        "add    %z22.h %z23.h -> %z21.h", "add    %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(add, add_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "add    %z0.s %z0.s -> %z0.s",    "add    %z6.s %z7.s -> %z5.s",
-        "add    %z11.s %z12.s -> %z10.s", "add    %z16.s %z17.s -> %z15.s",
-        "add    %z21.s %z22.s -> %z20.s", "add    %z30.s %z30.s -> %z30.s",
+        "add    %z11.s %z12.s -> %z10.s", "add    %z17.s %z18.s -> %z16.s",
+        "add    %z22.s %z23.s -> %z21.s", "add    %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(add, add_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "add    %z0.d %z0.d -> %z0.d",    "add    %z6.d %z7.d -> %z5.d",
-        "add    %z11.d %z12.d -> %z10.d", "add    %z16.d %z17.d -> %z15.d",
-        "add    %z21.d %z22.d -> %z20.d", "add    %z30.d %z30.d -> %z30.d",
+        "add    %z11.d %z12.d -> %z10.d", "add    %z17.d %z18.d -> %z16.d",
+        "add    %z22.d %z23.d -> %z21.d", "add    %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(add, add_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(zip2_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing ZIP2    <Zd>.Q, <Zn>.Q, <Zm>.Q */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "zip2   %z0.q %z0.q -> %z0.q",    "zip2   %z6.q %z7.q -> %z5.q",
-        "zip2   %z11.q %z12.q -> %z10.q", "zip2   %z16.q %z17.q -> %z15.q",
-        "zip2   %z21.q %z22.q -> %z20.q", "zip2   %z30.q %z30.q -> %z30.q",
+        "zip2   %z11.q %z12.q -> %z10.q", "zip2   %z17.q %z18.q -> %z16.q",
+        "zip2   %z22.q %z23.q -> %z21.q", "zip2   %z31.q %z31.q -> %z31.q",
     };
     TEST_LOOP(zip2, zip2_vector, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_16));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
 TEST_INSTR(movprfx_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing MOVPRFX <Zd>, <Zn> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "movprfx %z0 -> %z0",   "movprfx %z6 -> %z5",   "movprfx %z11 -> %z10",
-        "movprfx %z16 -> %z15", "movprfx %z21 -> %z20", "movprfx %z30 -> %z30",
+        "movprfx %z17 -> %z16", "movprfx %z22 -> %z21", "movprfx %z31 -> %z31",
     };
-    TEST_LOOP(movprfx, movprfx_vector, 6, expected_0_0[i], opnd_create_reg(Zd_0_0[i]),
-              opnd_create_reg(Zn_0_0[i]));
-
-    return success;
+    TEST_LOOP(movprfx, movprfx_vector, 6, expected_0_0[i],
+              opnd_create_reg(Zn_six_offset_0[i]), opnd_create_reg(Zn_six_offset_1[i]));
 }
 
 TEST_INSTR(sqadd_sve_shift)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SQADD   <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>, <shift> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "sqadd  %z0.b $0x00 lsl $0x00 -> %z0.b",
         "sqadd  %z5.b $0x2b lsl $0x00 -> %z5.b",
         "sqadd  %z10.b $0x56 lsl $0x00 -> %z10.b",
-        "sqadd  %z15.b $0x81 lsl $0x00 -> %z15.b",
-        "sqadd  %z20.b $0xab lsl $0x00 -> %z20.b",
-        "sqadd  %z30.b $0xff lsl $0x00 -> %z30.b",
+        "sqadd  %z16.b $0x81 lsl $0x00 -> %z16.b",
+        "sqadd  %z21.b $0xab lsl $0x00 -> %z21.b",
+        "sqadd  %z31.b $0xff lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(sqadd, sqadd_sve_shift, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_1[6] = {
         "sqadd  %z0.h $0x00 lsl $0x08 -> %z0.h",
         "sqadd  %z5.h $0x2b lsl $0x08 -> %z5.h",
         "sqadd  %z10.h $0x56 lsl $0x08 -> %z10.h",
-        "sqadd  %z15.h $0x81 lsl $0x08 -> %z15.h",
-        "sqadd  %z20.h $0xab lsl $0x00 -> %z20.h",
-        "sqadd  %z30.h $0xff lsl $0x00 -> %z30.h",
+        "sqadd  %z16.h $0x81 lsl $0x08 -> %z16.h",
+        "sqadd  %z21.h $0xab lsl $0x00 -> %z21.h",
+        "sqadd  %z31.h $0xff lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(sqadd, sqadd_sve_shift, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_2[6] = {
         "sqadd  %z0.s $0x00 lsl $0x08 -> %z0.s",
         "sqadd  %z5.s $0x2b lsl $0x08 -> %z5.s",
         "sqadd  %z10.s $0x56 lsl $0x08 -> %z10.s",
-        "sqadd  %z15.s $0x81 lsl $0x08 -> %z15.s",
-        "sqadd  %z20.s $0xab lsl $0x00 -> %z20.s",
-        "sqadd  %z30.s $0xff lsl $0x00 -> %z30.s",
+        "sqadd  %z16.s $0x81 lsl $0x08 -> %z16.s",
+        "sqadd  %z21.s $0xab lsl $0x00 -> %z21.s",
+        "sqadd  %z31.s $0xff lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(sqadd, sqadd_sve_shift, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_3[6] = {
         "sqadd  %z0.d $0x00 lsl $0x08 -> %z0.d",
         "sqadd  %z5.d $0x2b lsl $0x08 -> %z5.d",
         "sqadd  %z10.d $0x56 lsl $0x08 -> %z10.d",
-        "sqadd  %z15.d $0x81 lsl $0x08 -> %z15.d",
-        "sqadd  %z20.d $0xab lsl $0x00 -> %z20.d",
-        "sqadd  %z30.d $0xff lsl $0x00 -> %z30.d",
+        "sqadd  %z16.d $0x81 lsl $0x08 -> %z16.d",
+        "sqadd  %z21.d $0xab lsl $0x00 -> %z21.d",
+        "sqadd  %z31.d $0xff lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(sqadd, sqadd_sve_shift, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(sqadd_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SQADD   <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "sqadd  %z0.b %z0.b -> %z0.b",    "sqadd  %z6.b %z7.b -> %z5.b",
-        "sqadd  %z11.b %z12.b -> %z10.b", "sqadd  %z16.b %z17.b -> %z15.b",
-        "sqadd  %z21.b %z22.b -> %z20.b", "sqadd  %z30.b %z30.b -> %z30.b",
+        "sqadd  %z11.b %z12.b -> %z10.b", "sqadd  %z17.b %z18.b -> %z16.b",
+        "sqadd  %z22.b %z23.b -> %z21.b", "sqadd  %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(sqadd, sqadd_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "sqadd  %z0.h %z0.h -> %z0.h",    "sqadd  %z6.h %z7.h -> %z5.h",
-        "sqadd  %z11.h %z12.h -> %z10.h", "sqadd  %z16.h %z17.h -> %z15.h",
-        "sqadd  %z21.h %z22.h -> %z20.h", "sqadd  %z30.h %z30.h -> %z30.h",
+        "sqadd  %z11.h %z12.h -> %z10.h", "sqadd  %z17.h %z18.h -> %z16.h",
+        "sqadd  %z22.h %z23.h -> %z21.h", "sqadd  %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(sqadd, sqadd_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "sqadd  %z0.s %z0.s -> %z0.s",    "sqadd  %z6.s %z7.s -> %z5.s",
-        "sqadd  %z11.s %z12.s -> %z10.s", "sqadd  %z16.s %z17.s -> %z15.s",
-        "sqadd  %z21.s %z22.s -> %z20.s", "sqadd  %z30.s %z30.s -> %z30.s",
+        "sqadd  %z11.s %z12.s -> %z10.s", "sqadd  %z17.s %z18.s -> %z16.s",
+        "sqadd  %z22.s %z23.s -> %z21.s", "sqadd  %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(sqadd, sqadd_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "sqadd  %z0.d %z0.d -> %z0.d",    "sqadd  %z6.d %z7.d -> %z5.d",
-        "sqadd  %z11.d %z12.d -> %z10.d", "sqadd  %z16.d %z17.d -> %z15.d",
-        "sqadd  %z21.d %z22.d -> %z20.d", "sqadd  %z30.d %z30.d -> %z30.d",
+        "sqadd  %z11.d %z12.d -> %z10.d", "sqadd  %z17.d %z18.d -> %z16.d",
+        "sqadd  %z22.d %z23.d -> %z21.d", "sqadd  %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(sqadd, sqadd_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(sqsub_sve_shift)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SQSUB   <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>, <shift> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "sqsub  %z0.b $0x00 lsl $0x00 -> %z0.b",
         "sqsub  %z5.b $0x2b lsl $0x00 -> %z5.b",
         "sqsub  %z10.b $0x56 lsl $0x00 -> %z10.b",
-        "sqsub  %z15.b $0x81 lsl $0x00 -> %z15.b",
-        "sqsub  %z20.b $0xab lsl $0x00 -> %z20.b",
-        "sqsub  %z30.b $0xff lsl $0x00 -> %z30.b",
+        "sqsub  %z16.b $0x81 lsl $0x00 -> %z16.b",
+        "sqsub  %z21.b $0xab lsl $0x00 -> %z21.b",
+        "sqsub  %z31.b $0xff lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(sqsub, sqsub_sve_shift, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_1[6] = {
         "sqsub  %z0.h $0x00 lsl $0x08 -> %z0.h",
         "sqsub  %z5.h $0x2b lsl $0x08 -> %z5.h",
         "sqsub  %z10.h $0x56 lsl $0x08 -> %z10.h",
-        "sqsub  %z15.h $0x81 lsl $0x08 -> %z15.h",
-        "sqsub  %z20.h $0xab lsl $0x00 -> %z20.h",
-        "sqsub  %z30.h $0xff lsl $0x00 -> %z30.h",
+        "sqsub  %z16.h $0x81 lsl $0x08 -> %z16.h",
+        "sqsub  %z21.h $0xab lsl $0x00 -> %z21.h",
+        "sqsub  %z31.h $0xff lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(sqsub, sqsub_sve_shift, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_2[6] = {
         "sqsub  %z0.s $0x00 lsl $0x08 -> %z0.s",
         "sqsub  %z5.s $0x2b lsl $0x08 -> %z5.s",
         "sqsub  %z10.s $0x56 lsl $0x08 -> %z10.s",
-        "sqsub  %z15.s $0x81 lsl $0x08 -> %z15.s",
-        "sqsub  %z20.s $0xab lsl $0x00 -> %z20.s",
-        "sqsub  %z30.s $0xff lsl $0x00 -> %z30.s",
+        "sqsub  %z16.s $0x81 lsl $0x08 -> %z16.s",
+        "sqsub  %z21.s $0xab lsl $0x00 -> %z21.s",
+        "sqsub  %z31.s $0xff lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(sqsub, sqsub_sve_shift, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_3[6] = {
         "sqsub  %z0.d $0x00 lsl $0x08 -> %z0.d",
         "sqsub  %z5.d $0x2b lsl $0x08 -> %z5.d",
         "sqsub  %z10.d $0x56 lsl $0x08 -> %z10.d",
-        "sqsub  %z15.d $0x81 lsl $0x08 -> %z15.d",
-        "sqsub  %z20.d $0xab lsl $0x00 -> %z20.d",
-        "sqsub  %z30.d $0xff lsl $0x00 -> %z30.d",
+        "sqsub  %z16.d $0x81 lsl $0x08 -> %z16.d",
+        "sqsub  %z21.d $0xab lsl $0x00 -> %z21.d",
+        "sqsub  %z31.d $0xff lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(sqsub, sqsub_sve_shift, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(sqsub_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SQSUB   <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "sqsub  %z0.b %z0.b -> %z0.b",    "sqsub  %z6.b %z7.b -> %z5.b",
-        "sqsub  %z11.b %z12.b -> %z10.b", "sqsub  %z16.b %z17.b -> %z15.b",
-        "sqsub  %z21.b %z22.b -> %z20.b", "sqsub  %z30.b %z30.b -> %z30.b",
+        "sqsub  %z11.b %z12.b -> %z10.b", "sqsub  %z17.b %z18.b -> %z16.b",
+        "sqsub  %z22.b %z23.b -> %z21.b", "sqsub  %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(sqsub, sqsub_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "sqsub  %z0.h %z0.h -> %z0.h",    "sqsub  %z6.h %z7.h -> %z5.h",
-        "sqsub  %z11.h %z12.h -> %z10.h", "sqsub  %z16.h %z17.h -> %z15.h",
-        "sqsub  %z21.h %z22.h -> %z20.h", "sqsub  %z30.h %z30.h -> %z30.h",
+        "sqsub  %z11.h %z12.h -> %z10.h", "sqsub  %z17.h %z18.h -> %z16.h",
+        "sqsub  %z22.h %z23.h -> %z21.h", "sqsub  %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(sqsub, sqsub_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "sqsub  %z0.s %z0.s -> %z0.s",    "sqsub  %z6.s %z7.s -> %z5.s",
-        "sqsub  %z11.s %z12.s -> %z10.s", "sqsub  %z16.s %z17.s -> %z15.s",
-        "sqsub  %z21.s %z22.s -> %z20.s", "sqsub  %z30.s %z30.s -> %z30.s",
+        "sqsub  %z11.s %z12.s -> %z10.s", "sqsub  %z17.s %z18.s -> %z16.s",
+        "sqsub  %z22.s %z23.s -> %z21.s", "sqsub  %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(sqsub, sqsub_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "sqsub  %z0.d %z0.d -> %z0.d",    "sqsub  %z6.d %z7.d -> %z5.d",
-        "sqsub  %z11.d %z12.d -> %z10.d", "sqsub  %z16.d %z17.d -> %z15.d",
-        "sqsub  %z21.d %z22.d -> %z20.d", "sqsub  %z30.d %z30.d -> %z30.d",
+        "sqsub  %z11.d %z12.d -> %z10.d", "sqsub  %z17.d %z18.d -> %z16.d",
+        "sqsub  %z22.d %z23.d -> %z21.d", "sqsub  %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(sqsub, sqsub_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(sub_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SUB     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "sub    %p0/m %z0.b %z0.b -> %z0.b",    "sub    %p2/m %z5.b %z7.b -> %z5.b",
-        "sub    %p3/m %z10.b %z12.b -> %z10.b", "sub    %p4/m %z15.b %z17.b -> %z15.b",
-        "sub    %p5/m %z20.b %z22.b -> %z20.b", "sub    %p6/m %z30.b %z30.b -> %z30.b",
+        "sub    %p3/m %z10.b %z12.b -> %z10.b", "sub    %p5/m %z16.b %z18.b -> %z16.b",
+        "sub    %p6/m %z21.b %z23.b -> %z21.b", "sub    %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(sub, sub_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "sub    %p0/m %z0.h %z0.h -> %z0.h",    "sub    %p2/m %z5.h %z7.h -> %z5.h",
-        "sub    %p3/m %z10.h %z12.h -> %z10.h", "sub    %p4/m %z15.h %z17.h -> %z15.h",
-        "sub    %p5/m %z20.h %z22.h -> %z20.h", "sub    %p6/m %z30.h %z30.h -> %z30.h",
+        "sub    %p3/m %z10.h %z12.h -> %z10.h", "sub    %p5/m %z16.h %z18.h -> %z16.h",
+        "sub    %p6/m %z21.h %z23.h -> %z21.h", "sub    %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(sub, sub_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "sub    %p0/m %z0.s %z0.s -> %z0.s",    "sub    %p2/m %z5.s %z7.s -> %z5.s",
-        "sub    %p3/m %z10.s %z12.s -> %z10.s", "sub    %p4/m %z15.s %z17.s -> %z15.s",
-        "sub    %p5/m %z20.s %z22.s -> %z20.s", "sub    %p6/m %z30.s %z30.s -> %z30.s",
+        "sub    %p3/m %z10.s %z12.s -> %z10.s", "sub    %p5/m %z16.s %z18.s -> %z16.s",
+        "sub    %p6/m %z21.s %z23.s -> %z21.s", "sub    %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(sub, sub_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "sub    %p0/m %z0.d %z0.d -> %z0.d",    "sub    %p2/m %z5.d %z7.d -> %z5.d",
-        "sub    %p3/m %z10.d %z12.d -> %z10.d", "sub    %p4/m %z15.d %z17.d -> %z15.d",
-        "sub    %p5/m %z20.d %z22.d -> %z20.d", "sub    %p6/m %z30.d %z30.d -> %z30.d",
+        "sub    %p3/m %z10.d %z12.d -> %z10.d", "sub    %p5/m %z16.d %z18.d -> %z16.d",
+        "sub    %p6/m %z21.d %z23.d -> %z21.d", "sub    %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(sub, sub_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(sub_sve_shift)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SUB     <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>, <shift> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "sub    %z0.b $0x00 lsl $0x00 -> %z0.b",
         "sub    %z5.b $0x2b lsl $0x00 -> %z5.b",
         "sub    %z10.b $0x56 lsl $0x00 -> %z10.b",
-        "sub    %z15.b $0x81 lsl $0x00 -> %z15.b",
-        "sub    %z20.b $0xab lsl $0x00 -> %z20.b",
-        "sub    %z30.b $0xff lsl $0x00 -> %z30.b",
+        "sub    %z16.b $0x81 lsl $0x00 -> %z16.b",
+        "sub    %z21.b $0xab lsl $0x00 -> %z21.b",
+        "sub    %z31.b $0xff lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(sub, sub_sve_shift, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_1[6] = {
         "sub    %z0.h $0x00 lsl $0x08 -> %z0.h",
         "sub    %z5.h $0x2b lsl $0x08 -> %z5.h",
         "sub    %z10.h $0x56 lsl $0x08 -> %z10.h",
-        "sub    %z15.h $0x81 lsl $0x08 -> %z15.h",
-        "sub    %z20.h $0xab lsl $0x00 -> %z20.h",
-        "sub    %z30.h $0xff lsl $0x00 -> %z30.h",
+        "sub    %z16.h $0x81 lsl $0x08 -> %z16.h",
+        "sub    %z21.h $0xab lsl $0x00 -> %z21.h",
+        "sub    %z31.h $0xff lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(sub, sub_sve_shift, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_2[6] = {
         "sub    %z0.s $0x00 lsl $0x08 -> %z0.s",
         "sub    %z5.s $0x2b lsl $0x08 -> %z5.s",
         "sub    %z10.s $0x56 lsl $0x08 -> %z10.s",
-        "sub    %z15.s $0x81 lsl $0x08 -> %z15.s",
-        "sub    %z20.s $0xab lsl $0x00 -> %z20.s",
-        "sub    %z30.s $0xff lsl $0x00 -> %z30.s",
+        "sub    %z16.s $0x81 lsl $0x08 -> %z16.s",
+        "sub    %z21.s $0xab lsl $0x00 -> %z21.s",
+        "sub    %z31.s $0xff lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(sub, sub_sve_shift, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_3[6] = {
         "sub    %z0.d $0x00 lsl $0x08 -> %z0.d",
         "sub    %z5.d $0x2b lsl $0x08 -> %z5.d",
         "sub    %z10.d $0x56 lsl $0x08 -> %z10.d",
-        "sub    %z15.d $0x81 lsl $0x08 -> %z15.d",
-        "sub    %z20.d $0xab lsl $0x00 -> %z20.d",
-        "sub    %z30.d $0xff lsl $0x00 -> %z30.d",
+        "sub    %z16.d $0x81 lsl $0x08 -> %z16.d",
+        "sub    %z21.d $0xab lsl $0x00 -> %z21.d",
+        "sub    %z31.d $0xff lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(sub, sub_sve_shift, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(sub_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SUB     <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "sub    %z0.b %z0.b -> %z0.b",    "sub    %z6.b %z7.b -> %z5.b",
-        "sub    %z11.b %z12.b -> %z10.b", "sub    %z16.b %z17.b -> %z15.b",
-        "sub    %z21.b %z22.b -> %z20.b", "sub    %z30.b %z30.b -> %z30.b",
+        "sub    %z11.b %z12.b -> %z10.b", "sub    %z17.b %z18.b -> %z16.b",
+        "sub    %z22.b %z23.b -> %z21.b", "sub    %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(sub, sub_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "sub    %z0.h %z0.h -> %z0.h",    "sub    %z6.h %z7.h -> %z5.h",
-        "sub    %z11.h %z12.h -> %z10.h", "sub    %z16.h %z17.h -> %z15.h",
-        "sub    %z21.h %z22.h -> %z20.h", "sub    %z30.h %z30.h -> %z30.h",
+        "sub    %z11.h %z12.h -> %z10.h", "sub    %z17.h %z18.h -> %z16.h",
+        "sub    %z22.h %z23.h -> %z21.h", "sub    %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(sub, sub_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "sub    %z0.s %z0.s -> %z0.s",    "sub    %z6.s %z7.s -> %z5.s",
-        "sub    %z11.s %z12.s -> %z10.s", "sub    %z16.s %z17.s -> %z15.s",
-        "sub    %z21.s %z22.s -> %z20.s", "sub    %z30.s %z30.s -> %z30.s",
+        "sub    %z11.s %z12.s -> %z10.s", "sub    %z17.s %z18.s -> %z16.s",
+        "sub    %z22.s %z23.s -> %z21.s", "sub    %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(sub, sub_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "sub    %z0.d %z0.d -> %z0.d",    "sub    %z6.d %z7.d -> %z5.d",
-        "sub    %z11.d %z12.d -> %z10.d", "sub    %z16.d %z17.d -> %z15.d",
-        "sub    %z21.d %z22.d -> %z20.d", "sub    %z30.d %z30.d -> %z30.d",
+        "sub    %z11.d %z12.d -> %z10.d", "sub    %z17.d %z18.d -> %z16.d",
+        "sub    %z22.d %z23.d -> %z21.d", "sub    %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(sub, sub_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(subr_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SUBR    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "subr   %p0/m %z0.b %z0.b -> %z0.b",    "subr   %p2/m %z5.b %z7.b -> %z5.b",
-        "subr   %p3/m %z10.b %z12.b -> %z10.b", "subr   %p4/m %z15.b %z17.b -> %z15.b",
-        "subr   %p5/m %z20.b %z22.b -> %z20.b", "subr   %p6/m %z30.b %z30.b -> %z30.b",
+        "subr   %p3/m %z10.b %z12.b -> %z10.b", "subr   %p5/m %z16.b %z18.b -> %z16.b",
+        "subr   %p6/m %z21.b %z23.b -> %z21.b", "subr   %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(subr, subr_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "subr   %p0/m %z0.h %z0.h -> %z0.h",    "subr   %p2/m %z5.h %z7.h -> %z5.h",
-        "subr   %p3/m %z10.h %z12.h -> %z10.h", "subr   %p4/m %z15.h %z17.h -> %z15.h",
-        "subr   %p5/m %z20.h %z22.h -> %z20.h", "subr   %p6/m %z30.h %z30.h -> %z30.h",
+        "subr   %p3/m %z10.h %z12.h -> %z10.h", "subr   %p5/m %z16.h %z18.h -> %z16.h",
+        "subr   %p6/m %z21.h %z23.h -> %z21.h", "subr   %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(subr, subr_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "subr   %p0/m %z0.s %z0.s -> %z0.s",    "subr   %p2/m %z5.s %z7.s -> %z5.s",
-        "subr   %p3/m %z10.s %z12.s -> %z10.s", "subr   %p4/m %z15.s %z17.s -> %z15.s",
-        "subr   %p5/m %z20.s %z22.s -> %z20.s", "subr   %p6/m %z30.s %z30.s -> %z30.s",
+        "subr   %p3/m %z10.s %z12.s -> %z10.s", "subr   %p5/m %z16.s %z18.s -> %z16.s",
+        "subr   %p6/m %z21.s %z23.s -> %z21.s", "subr   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(subr, subr_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P4, DR_REG_P5, DR_REG_P6 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "subr   %p0/m %z0.d %z0.d -> %z0.d",    "subr   %p2/m %z5.d %z7.d -> %z5.d",
-        "subr   %p3/m %z10.d %z12.d -> %z10.d", "subr   %p4/m %z15.d %z17.d -> %z15.d",
-        "subr   %p5/m %z20.d %z22.d -> %z20.d", "subr   %p6/m %z30.d %z30.d -> %z30.d",
+        "subr   %p3/m %z10.d %z12.d -> %z10.d", "subr   %p5/m %z16.d %z18.d -> %z16.d",
+        "subr   %p6/m %z21.d %z23.d -> %z21.d", "subr   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(subr, subr_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(subr_sve_shift)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SUBR    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>, <shift> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "subr   %z0.b $0x00 lsl $0x00 -> %z0.b",
         "subr   %z5.b $0x2b lsl $0x00 -> %z5.b",
         "subr   %z10.b $0x56 lsl $0x00 -> %z10.b",
-        "subr   %z15.b $0x81 lsl $0x00 -> %z15.b",
-        "subr   %z20.b $0xab lsl $0x00 -> %z20.b",
-        "subr   %z30.b $0xff lsl $0x00 -> %z30.b",
+        "subr   %z16.b $0x81 lsl $0x00 -> %z16.b",
+        "subr   %z21.b $0xab lsl $0x00 -> %z21.b",
+        "subr   %z31.b $0xff lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(subr, subr_sve_shift, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_1[6] = {
         "subr   %z0.h $0x00 lsl $0x08 -> %z0.h",
         "subr   %z5.h $0x2b lsl $0x08 -> %z5.h",
         "subr   %z10.h $0x56 lsl $0x08 -> %z10.h",
-        "subr   %z15.h $0x81 lsl $0x08 -> %z15.h",
-        "subr   %z20.h $0xab lsl $0x00 -> %z20.h",
-        "subr   %z30.h $0xff lsl $0x00 -> %z30.h",
+        "subr   %z16.h $0x81 lsl $0x08 -> %z16.h",
+        "subr   %z21.h $0xab lsl $0x00 -> %z21.h",
+        "subr   %z31.h $0xff lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(subr, subr_sve_shift, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_2[6] = {
         "subr   %z0.s $0x00 lsl $0x08 -> %z0.s",
         "subr   %z5.s $0x2b lsl $0x08 -> %z5.s",
         "subr   %z10.s $0x56 lsl $0x08 -> %z10.s",
-        "subr   %z15.s $0x81 lsl $0x08 -> %z15.s",
-        "subr   %z20.s $0xab lsl $0x00 -> %z20.s",
-        "subr   %z30.s $0xff lsl $0x00 -> %z30.s",
+        "subr   %z16.s $0x81 lsl $0x08 -> %z16.s",
+        "subr   %z21.s $0xab lsl $0x00 -> %z21.s",
+        "subr   %z31.s $0xff lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(subr, subr_sve_shift, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_3[6] = {
         "subr   %z0.d $0x00 lsl $0x08 -> %z0.d",
         "subr   %z5.d $0x2b lsl $0x08 -> %z5.d",
         "subr   %z10.d $0x56 lsl $0x08 -> %z10.d",
-        "subr   %z15.d $0x81 lsl $0x08 -> %z15.d",
-        "subr   %z20.d $0xab lsl $0x00 -> %z20.d",
-        "subr   %z30.d $0xff lsl $0x00 -> %z30.d",
+        "subr   %z16.d $0x81 lsl $0x08 -> %z16.d",
+        "subr   %z21.d $0xab lsl $0x00 -> %z21.d",
+        "subr   %z31.d $0xff lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(subr, subr_sve_shift, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(uqadd_sve_shift)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UQADD   <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>, <shift> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "uqadd  %z0.b $0x00 lsl $0x00 -> %z0.b",
         "uqadd  %z5.b $0x2b lsl $0x00 -> %z5.b",
         "uqadd  %z10.b $0x56 lsl $0x00 -> %z10.b",
-        "uqadd  %z15.b $0x81 lsl $0x00 -> %z15.b",
-        "uqadd  %z20.b $0xab lsl $0x00 -> %z20.b",
-        "uqadd  %z30.b $0xff lsl $0x00 -> %z30.b",
+        "uqadd  %z16.b $0x81 lsl $0x00 -> %z16.b",
+        "uqadd  %z21.b $0xab lsl $0x00 -> %z21.b",
+        "uqadd  %z31.b $0xff lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(uqadd, uqadd_sve_shift, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_1[6] = {
         "uqadd  %z0.h $0x00 lsl $0x08 -> %z0.h",
         "uqadd  %z5.h $0x2b lsl $0x08 -> %z5.h",
         "uqadd  %z10.h $0x56 lsl $0x08 -> %z10.h",
-        "uqadd  %z15.h $0x81 lsl $0x08 -> %z15.h",
-        "uqadd  %z20.h $0xab lsl $0x00 -> %z20.h",
-        "uqadd  %z30.h $0xff lsl $0x00 -> %z30.h",
+        "uqadd  %z16.h $0x81 lsl $0x08 -> %z16.h",
+        "uqadd  %z21.h $0xab lsl $0x00 -> %z21.h",
+        "uqadd  %z31.h $0xff lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(uqadd, uqadd_sve_shift, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_2[6] = {
         "uqadd  %z0.s $0x00 lsl $0x08 -> %z0.s",
         "uqadd  %z5.s $0x2b lsl $0x08 -> %z5.s",
         "uqadd  %z10.s $0x56 lsl $0x08 -> %z10.s",
-        "uqadd  %z15.s $0x81 lsl $0x08 -> %z15.s",
-        "uqadd  %z20.s $0xab lsl $0x00 -> %z20.s",
-        "uqadd  %z30.s $0xff lsl $0x00 -> %z30.s",
+        "uqadd  %z16.s $0x81 lsl $0x08 -> %z16.s",
+        "uqadd  %z21.s $0xab lsl $0x00 -> %z21.s",
+        "uqadd  %z31.s $0xff lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(uqadd, uqadd_sve_shift, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_3[6] = {
         "uqadd  %z0.d $0x00 lsl $0x08 -> %z0.d",
         "uqadd  %z5.d $0x2b lsl $0x08 -> %z5.d",
         "uqadd  %z10.d $0x56 lsl $0x08 -> %z10.d",
-        "uqadd  %z15.d $0x81 lsl $0x08 -> %z15.d",
-        "uqadd  %z20.d $0xab lsl $0x00 -> %z20.d",
-        "uqadd  %z30.d $0xff lsl $0x00 -> %z30.d",
+        "uqadd  %z16.d $0x81 lsl $0x08 -> %z16.d",
+        "uqadd  %z21.d $0xab lsl $0x00 -> %z21.d",
+        "uqadd  %z31.d $0xff lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(uqadd, uqadd_sve_shift, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(uqadd_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UQADD   <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "uqadd  %z0.b %z0.b -> %z0.b",    "uqadd  %z6.b %z7.b -> %z5.b",
-        "uqadd  %z11.b %z12.b -> %z10.b", "uqadd  %z16.b %z17.b -> %z15.b",
-        "uqadd  %z21.b %z22.b -> %z20.b", "uqadd  %z30.b %z30.b -> %z30.b",
+        "uqadd  %z11.b %z12.b -> %z10.b", "uqadd  %z17.b %z18.b -> %z16.b",
+        "uqadd  %z22.b %z23.b -> %z21.b", "uqadd  %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(uqadd, uqadd_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "uqadd  %z0.h %z0.h -> %z0.h",    "uqadd  %z6.h %z7.h -> %z5.h",
-        "uqadd  %z11.h %z12.h -> %z10.h", "uqadd  %z16.h %z17.h -> %z15.h",
-        "uqadd  %z21.h %z22.h -> %z20.h", "uqadd  %z30.h %z30.h -> %z30.h",
+        "uqadd  %z11.h %z12.h -> %z10.h", "uqadd  %z17.h %z18.h -> %z16.h",
+        "uqadd  %z22.h %z23.h -> %z21.h", "uqadd  %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(uqadd, uqadd_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "uqadd  %z0.s %z0.s -> %z0.s",    "uqadd  %z6.s %z7.s -> %z5.s",
-        "uqadd  %z11.s %z12.s -> %z10.s", "uqadd  %z16.s %z17.s -> %z15.s",
-        "uqadd  %z21.s %z22.s -> %z20.s", "uqadd  %z30.s %z30.s -> %z30.s",
+        "uqadd  %z11.s %z12.s -> %z10.s", "uqadd  %z17.s %z18.s -> %z16.s",
+        "uqadd  %z22.s %z23.s -> %z21.s", "uqadd  %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(uqadd, uqadd_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "uqadd  %z0.d %z0.d -> %z0.d",    "uqadd  %z6.d %z7.d -> %z5.d",
-        "uqadd  %z11.d %z12.d -> %z10.d", "uqadd  %z16.d %z17.d -> %z15.d",
-        "uqadd  %z21.d %z22.d -> %z20.d", "uqadd  %z30.d %z30.d -> %z30.d",
+        "uqadd  %z11.d %z12.d -> %z10.d", "uqadd  %z17.d %z18.d -> %z16.d",
+        "uqadd  %z22.d %z23.d -> %z21.d", "uqadd  %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(uqadd, uqadd_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(uqsub_sve_shift)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UQSUB   <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>, <shift> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "uqsub  %z0.b $0x00 lsl $0x00 -> %z0.b",
         "uqsub  %z5.b $0x2b lsl $0x00 -> %z5.b",
         "uqsub  %z10.b $0x56 lsl $0x00 -> %z10.b",
-        "uqsub  %z15.b $0x81 lsl $0x00 -> %z15.b",
-        "uqsub  %z20.b $0xab lsl $0x00 -> %z20.b",
-        "uqsub  %z30.b $0xff lsl $0x00 -> %z30.b",
+        "uqsub  %z16.b $0x81 lsl $0x00 -> %z16.b",
+        "uqsub  %z21.b $0xab lsl $0x00 -> %z21.b",
+        "uqsub  %z31.b $0xff lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(uqsub, uqsub_sve_shift, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_1[6] = {
         "uqsub  %z0.h $0x00 lsl $0x08 -> %z0.h",
         "uqsub  %z5.h $0x2b lsl $0x08 -> %z5.h",
         "uqsub  %z10.h $0x56 lsl $0x08 -> %z10.h",
-        "uqsub  %z15.h $0x81 lsl $0x08 -> %z15.h",
-        "uqsub  %z20.h $0xab lsl $0x00 -> %z20.h",
-        "uqsub  %z30.h $0xff lsl $0x00 -> %z30.h",
+        "uqsub  %z16.h $0x81 lsl $0x08 -> %z16.h",
+        "uqsub  %z21.h $0xab lsl $0x00 -> %z21.h",
+        "uqsub  %z31.h $0xff lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(uqsub, uqsub_sve_shift, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_2[6] = {
         "uqsub  %z0.s $0x00 lsl $0x08 -> %z0.s",
         "uqsub  %z5.s $0x2b lsl $0x08 -> %z5.s",
         "uqsub  %z10.s $0x56 lsl $0x08 -> %z10.s",
-        "uqsub  %z15.s $0x81 lsl $0x08 -> %z15.s",
-        "uqsub  %z20.s $0xab lsl $0x00 -> %z20.s",
-        "uqsub  %z30.s $0xff lsl $0x00 -> %z30.s",
+        "uqsub  %z16.s $0x81 lsl $0x08 -> %z16.s",
+        "uqsub  %z21.s $0xab lsl $0x00 -> %z21.s",
+        "uqsub  %z31.s $0xff lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(uqsub, uqsub_sve_shift, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
     const char *expected_0_3[6] = {
         "uqsub  %z0.d $0x00 lsl $0x08 -> %z0.d",
         "uqsub  %z5.d $0x2b lsl $0x08 -> %z5.d",
         "uqsub  %z10.d $0x56 lsl $0x08 -> %z10.d",
-        "uqsub  %z15.d $0x81 lsl $0x08 -> %z15.d",
-        "uqsub  %z20.d $0xab lsl $0x00 -> %z20.d",
-        "uqsub  %z30.d $0xff lsl $0x00 -> %z30.d",
+        "uqsub  %z16.d $0x81 lsl $0x08 -> %z16.d",
+        "uqsub  %z21.d $0xab lsl $0x00 -> %z21.d",
+        "uqsub  %z31.d $0xff lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(uqsub, uqsub_sve_shift, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(uqsub_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UQSUB   <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_0[6] = {
         "uqsub  %z0.b %z0.b -> %z0.b",    "uqsub  %z6.b %z7.b -> %z5.b",
-        "uqsub  %z11.b %z12.b -> %z10.b", "uqsub  %z16.b %z17.b -> %z15.b",
-        "uqsub  %z21.b %z22.b -> %z20.b", "uqsub  %z30.b %z30.b -> %z30.b",
+        "uqsub  %z11.b %z12.b -> %z10.b", "uqsub  %z17.b %z18.b -> %z16.b",
+        "uqsub  %z22.b %z23.b -> %z21.b", "uqsub  %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(uqsub, uqsub_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_1[6] = {
         "uqsub  %z0.h %z0.h -> %z0.h",    "uqsub  %z6.h %z7.h -> %z5.h",
-        "uqsub  %z11.h %z12.h -> %z10.h", "uqsub  %z16.h %z17.h -> %z15.h",
-        "uqsub  %z21.h %z22.h -> %z20.h", "uqsub  %z30.h %z30.h -> %z30.h",
+        "uqsub  %z11.h %z12.h -> %z10.h", "uqsub  %z17.h %z18.h -> %z16.h",
+        "uqsub  %z22.h %z23.h -> %z21.h", "uqsub  %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(uqsub, uqsub_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_2[6] = {
         "uqsub  %z0.s %z0.s -> %z0.s",    "uqsub  %z6.s %z7.s -> %z5.s",
-        "uqsub  %z11.s %z12.s -> %z10.s", "uqsub  %z16.s %z17.s -> %z15.s",
-        "uqsub  %z21.s %z22.s -> %z20.s", "uqsub  %z30.s %z30.s -> %z30.s",
+        "uqsub  %z11.s %z12.s -> %z10.s", "uqsub  %z17.s %z18.s -> %z16.s",
+        "uqsub  %z22.s %z23.s -> %z21.s", "uqsub  %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(uqsub, uqsub_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z30 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z30 };
     const char *expected_0_3[6] = {
         "uqsub  %z0.d %z0.d -> %z0.d",    "uqsub  %z6.d %z7.d -> %z5.d",
-        "uqsub  %z11.d %z12.d -> %z10.d", "uqsub  %z16.d %z17.d -> %z15.d",
-        "uqsub  %z21.d %z22.d -> %z20.d", "uqsub  %z30.d %z30.d -> %z30.d",
+        "uqsub  %z11.d %z12.d -> %z10.d", "uqsub  %z17.d %z18.d -> %z16.d",
+        "uqsub  %z22.d %z23.d -> %z21.d", "uqsub  %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(uqsub, uqsub_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(cpy_sve_shift_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing CPY     <Zd>.<Ts>, <Pg>/Z, #<imm>, <shift> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_0_0[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_0_0[6] = {
         "cpy    %p0/z $0x80 lsl $0x00 -> %z0.b",
         "cpy    %p3/z $0xac lsl $0x00 -> %z5.b",
         "cpy    %p6/z $0xd7 lsl $0x00 -> %z10.b",
-        "cpy    %p8/z $0x02 lsl $0x00 -> %z15.b",
-        "cpy    %p10/z $0x2c lsl $0x00 -> %z20.b",
-        "cpy    %p14/z $0x7f lsl $0x00 -> %z30.b",
+        "cpy    %p9/z $0x02 lsl $0x00 -> %z16.b",
+        "cpy    %p11/z $0x2c lsl $0x00 -> %z21.b",
+        "cpy    %p15/z $0x7f lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
               opnd_create_immed_int(imm8_0_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_0_1[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_0_1[6] = { 8, 0, 0, 0, 8, 0 };
     const char *expected_0_1[6] = {
         "cpy    %p0/z $0x80 lsl $0x08 -> %z0.h",
         "cpy    %p3/z $0xac lsl $0x00 -> %z5.h",
         "cpy    %p6/z $0xd7 lsl $0x00 -> %z10.h",
-        "cpy    %p8/z $0x02 lsl $0x00 -> %z15.h",
-        "cpy    %p10/z $0x2c lsl $0x08 -> %z20.h",
-        "cpy    %p14/z $0x7f lsl $0x00 -> %z30.h",
+        "cpy    %p9/z $0x02 lsl $0x00 -> %z16.h",
+        "cpy    %p11/z $0x2c lsl $0x08 -> %z21.h",
+        "cpy    %p15/z $0x7f lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
               opnd_create_immed_int(imm8_0_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_0_2[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_0_2[6] = { 8, 0, 0, 0, 8, 0 };
     const char *expected_0_2[6] = {
         "cpy    %p0/z $0x80 lsl $0x08 -> %z0.s",
         "cpy    %p3/z $0xac lsl $0x00 -> %z5.s",
         "cpy    %p6/z $0xd7 lsl $0x00 -> %z10.s",
-        "cpy    %p8/z $0x02 lsl $0x00 -> %z15.s",
-        "cpy    %p10/z $0x2c lsl $0x08 -> %z20.s",
-        "cpy    %p14/z $0x7f lsl $0x00 -> %z30.s",
+        "cpy    %p9/z $0x02 lsl $0x00 -> %z16.s",
+        "cpy    %p11/z $0x2c lsl $0x08 -> %z21.s",
+        "cpy    %p15/z $0x7f lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
               opnd_create_immed_int(imm8_0_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_0_3[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_0_3[6] = { 8, 0, 0, 0, 8, 0 };
     const char *expected_0_3[6] = {
         "cpy    %p0/z $0x80 lsl $0x08 -> %z0.d",
         "cpy    %p3/z $0xac lsl $0x00 -> %z5.d",
         "cpy    %p6/z $0xd7 lsl $0x00 -> %z10.d",
-        "cpy    %p8/z $0x02 lsl $0x00 -> %z15.d",
-        "cpy    %p10/z $0x2c lsl $0x08 -> %z20.d",
-        "cpy    %p14/z $0x7f lsl $0x00 -> %z30.d",
+        "cpy    %p9/z $0x02 lsl $0x00 -> %z16.d",
+        "cpy    %p11/z $0x2c lsl $0x08 -> %z21.d",
+        "cpy    %p15/z $0x7f lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
               opnd_create_immed_int(imm8_0_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
 
     /* Testing CPY     <Zd>.<Ts>, <Pg>/M, #<imm>, <shift> */
-    reg_id_t Zd_1_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_1_0[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_1_0[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_1_0[6] = { 0, 0, 0, 0, 0, 0 };
     const char *expected_1_0[6] = {
         "cpy    %p0/m $0x80 lsl $0x00 -> %z0.b",
         "cpy    %p3/m $0xac lsl $0x00 -> %z5.b",
         "cpy    %p6/m $0xd7 lsl $0x00 -> %z10.b",
-        "cpy    %p8/m $0x02 lsl $0x00 -> %z15.b",
-        "cpy    %p10/m $0x2c lsl $0x00 -> %z20.b",
-        "cpy    %p14/m $0x7f lsl $0x00 -> %z30.b",
+        "cpy    %p9/m $0x02 lsl $0x00 -> %z16.b",
+        "cpy    %p11/m $0x2c lsl $0x00 -> %z21.b",
+        "cpy    %p15/m $0x7f lsl $0x00 -> %z31.b",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_1_0[i],
-              opnd_create_reg_element_vector(Zd_1_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_1_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], true),
               opnd_create_immed_int(imm8_1_0[i], OPSZ_1),
               opnd_create_immed_uint(shift_1_0[i], OPSZ_1b));
 
-    reg_id_t Zd_1_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_1_1[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_1_1[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_1_1[6] = { 8, 0, 0, 0, 8, 0 };
     const char *expected_1_1[6] = {
         "cpy    %p0/m $0x80 lsl $0x08 -> %z0.h",
         "cpy    %p3/m $0xac lsl $0x00 -> %z5.h",
         "cpy    %p6/m $0xd7 lsl $0x00 -> %z10.h",
-        "cpy    %p8/m $0x02 lsl $0x00 -> %z15.h",
-        "cpy    %p10/m $0x2c lsl $0x08 -> %z20.h",
-        "cpy    %p14/m $0x7f lsl $0x00 -> %z30.h",
+        "cpy    %p9/m $0x02 lsl $0x00 -> %z16.h",
+        "cpy    %p11/m $0x2c lsl $0x08 -> %z21.h",
+        "cpy    %p15/m $0x7f lsl $0x00 -> %z31.h",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_1_1[i],
-              opnd_create_reg_element_vector(Zd_1_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_1_1[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], true),
               opnd_create_immed_int(imm8_1_1[i], OPSZ_1),
               opnd_create_immed_uint(shift_1_1[i], OPSZ_1b));
 
-    reg_id_t Zd_1_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_1_2[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_1_2[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_1_2[6] = { 8, 0, 0, 0, 8, 0 };
     const char *expected_1_2[6] = {
         "cpy    %p0/m $0x80 lsl $0x08 -> %z0.s",
         "cpy    %p3/m $0xac lsl $0x00 -> %z5.s",
         "cpy    %p6/m $0xd7 lsl $0x00 -> %z10.s",
-        "cpy    %p8/m $0x02 lsl $0x00 -> %z15.s",
-        "cpy    %p10/m $0x2c lsl $0x08 -> %z20.s",
-        "cpy    %p14/m $0x7f lsl $0x00 -> %z30.s",
+        "cpy    %p9/m $0x02 lsl $0x00 -> %z16.s",
+        "cpy    %p11/m $0x2c lsl $0x08 -> %z21.s",
+        "cpy    %p15/m $0x7f lsl $0x00 -> %z31.s",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_1_2[i],
-              opnd_create_reg_element_vector(Zd_1_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_1_2[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], true),
               opnd_create_immed_int(imm8_1_2[i], OPSZ_1),
               opnd_create_immed_uint(shift_1_2[i], OPSZ_1b));
 
-    reg_id_t Zd_1_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z15, DR_REG_Z20, DR_REG_Z30 };
-    reg_id_t Pg_1_3[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     int imm8_1_3[6] = { -128, -84, -41, 2, 44, 127 };
     uint shift_1_3[6] = { 8, 0, 0, 0, 8, 0 };
     const char *expected_1_3[6] = {
         "cpy    %p0/m $0x80 lsl $0x08 -> %z0.d",
         "cpy    %p3/m $0xac lsl $0x00 -> %z5.d",
         "cpy    %p6/m $0xd7 lsl $0x00 -> %z10.d",
-        "cpy    %p8/m $0x02 lsl $0x00 -> %z15.d",
-        "cpy    %p10/m $0x2c lsl $0x08 -> %z20.d",
-        "cpy    %p14/m $0x7f lsl $0x00 -> %z30.d",
+        "cpy    %p9/m $0x02 lsl $0x00 -> %z16.d",
+        "cpy    %p11/m $0x2c lsl $0x08 -> %z21.d",
+        "cpy    %p15/m $0x7f lsl $0x00 -> %z31.d",
     };
     TEST_LOOP(cpy, cpy_sve_shift_pred, 6, expected_1_3[i],
-              opnd_create_reg_element_vector(Zd_1_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_1_3[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], true),
               opnd_create_immed_int(imm8_1_3[i], OPSZ_1),
               opnd_create_immed_uint(shift_1_3[i], OPSZ_1b));
-
-    return success;
 }
 
 TEST_INSTR(ptest_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing PTEST   <Pg>, <Pn>.B */
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P5,
-                           DR_REG_P7, DR_REG_P9, DR_REG_P14 };
-    reg_id_t Pn_0_0[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P14 };
     const char *expected_0_0[6] = {
-        "ptest  %p0 %p0.b", "ptest  %p2 %p3.b",  "ptest  %p5 %p6.b",
-        "ptest  %p7 %p8.b", "ptest  %p9 %p10.b", "ptest  %p14 %p14.b",
+        "ptest  %p0 %p0.b", "ptest  %p2 %p3.b",   "ptest  %p5 %p6.b",
+        "ptest  %p8 %p9.b", "ptest  %p10 %p11.b", "ptest  %p15 %p15.b",
     };
-    TEST_LOOP(ptest, ptest_sve_pred, 6, expected_0_0[i], opnd_create_reg(Pg_0_0[i]),
-              opnd_create_reg_element_vector(Pn_0_0[i], OPSZ_1));
-
-    return success;
+    TEST_LOOP(ptest, ptest_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg(Pn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 }
 
 TEST_INSTR(mad_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing MAD     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "mad    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
         "mad    %p2/m %z5.b %z7.b %z8.b -> %z5.b",
@@ -1523,19 +1074,11 @@ TEST_INSTR(mad_sve_pred)
         "mad    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Za_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "mad    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
         "mad    %p2/m %z5.h %z7.h %z8.h -> %z5.h",
@@ -1545,19 +1088,11 @@ TEST_INSTR(mad_sve_pred)
         "mad    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Za_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "mad    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
         "mad    %p2/m %z5.s %z7.s %z8.s -> %z5.s",
@@ -1567,19 +1102,11 @@ TEST_INSTR(mad_sve_pred)
         "mad    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Za_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_3[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "mad    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
         "mad    %p2/m %z5.d %z7.d %z8.d -> %z5.d",
@@ -1589,29 +1116,15 @@ TEST_INSTR(mad_sve_pred)
         "mad    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Za_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(mla_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing MLA     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zda_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "mla    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
         "mla    %p2/m %z7.b %z8.b %z5.b -> %z5.b",
@@ -1621,19 +1134,11 @@ TEST_INSTR(mla_sve_pred)
         "mla    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zda_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    reg_id_t Zda_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "mla    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
         "mla    %p2/m %z7.h %z8.h %z5.h -> %z5.h",
@@ -1643,19 +1148,11 @@ TEST_INSTR(mla_sve_pred)
         "mla    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zda_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Zda_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "mla    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
         "mla    %p2/m %z7.s %z8.s %z5.s -> %z5.s",
@@ -1665,19 +1162,11 @@ TEST_INSTR(mla_sve_pred)
         "mla    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zda_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Zda_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "mla    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
         "mla    %p2/m %z7.d %z8.d %z5.d -> %z5.d",
@@ -1687,29 +1176,15 @@ TEST_INSTR(mla_sve_pred)
         "mla    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zda_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(mls_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing MLS     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zda_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "mls    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
         "mls    %p2/m %z7.b %z8.b %z5.b -> %z5.b",
@@ -1719,19 +1194,11 @@ TEST_INSTR(mls_sve_pred)
         "mls    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zda_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    reg_id_t Zda_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "mls    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
         "mls    %p2/m %z7.h %z8.h %z5.h -> %z5.h",
@@ -1741,19 +1208,11 @@ TEST_INSTR(mls_sve_pred)
         "mls    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zda_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Zda_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "mls    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
         "mls    %p2/m %z7.s %z8.s %z5.s -> %z5.s",
@@ -1763,19 +1222,11 @@ TEST_INSTR(mls_sve_pred)
         "mls    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zda_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Zda_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "mls    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
         "mls    %p2/m %z7.d %z8.d %z5.d -> %z5.d",
@@ -1785,29 +1236,15 @@ TEST_INSTR(mls_sve_pred)
         "mls    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zda_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(msb_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing MSB     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "msb    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
         "msb    %p2/m %z5.b %z7.b %z8.b -> %z5.b",
@@ -1817,19 +1254,11 @@ TEST_INSTR(msb_sve_pred)
         "msb    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1),
-              opnd_create_reg_element_vector(Za_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "msb    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
         "msb    %p2/m %z5.h %z7.h %z8.h -> %z5.h",
@@ -1839,19 +1268,11 @@ TEST_INSTR(msb_sve_pred)
         "msb    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2),
-              opnd_create_reg_element_vector(Za_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "msb    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
         "msb    %p2/m %z5.s %z7.s %z8.s -> %z5.s",
@@ -1861,19 +1282,11 @@ TEST_INSTR(msb_sve_pred)
         "msb    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4),
-              opnd_create_reg_element_vector(Za_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Za_0_3[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "msb    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
         "msb    %p2/m %z5.d %z7.d %z8.d -> %z5.d",
@@ -1883,97 +1296,59 @@ TEST_INSTR(msb_sve_pred)
         "msb    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8),
-              opnd_create_reg_element_vector(Za_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(mul_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing MUL     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "mul    %p0/m %z0.b %z0.b -> %z0.b",    "mul    %p2/m %z5.b %z7.b -> %z5.b",
         "mul    %p3/m %z10.b %z12.b -> %z10.b", "mul    %p5/m %z16.b %z18.b -> %z16.b",
         "mul    %p6/m %z21.b %z23.b -> %z21.b", "mul    %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(mul, mul_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "mul    %p0/m %z0.h %z0.h -> %z0.h",    "mul    %p2/m %z5.h %z7.h -> %z5.h",
         "mul    %p3/m %z10.h %z12.h -> %z10.h", "mul    %p5/m %z16.h %z18.h -> %z16.h",
         "mul    %p6/m %z21.h %z23.h -> %z21.h", "mul    %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(mul, mul_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "mul    %p0/m %z0.s %z0.s -> %z0.s",    "mul    %p2/m %z5.s %z7.s -> %z5.s",
         "mul    %p3/m %z10.s %z12.s -> %z10.s", "mul    %p5/m %z16.s %z18.s -> %z16.s",
         "mul    %p6/m %z21.s %z23.s -> %z21.s", "mul    %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(mul, mul_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "mul    %p0/m %z0.d %z0.d -> %z0.d",    "mul    %p2/m %z5.d %z7.d -> %z5.d",
         "mul    %p3/m %z10.d %z12.d -> %z10.d", "mul    %p5/m %z16.d %z18.d -> %z16.d",
         "mul    %p6/m %z21.d %z23.d -> %z21.d", "mul    %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(mul, mul_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(mul_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing MUL     <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_0[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_0[6] = {
         "mul    %z0.b $0x80 -> %z0.b",   "mul    %z5.b $0xab -> %z5.b",
@@ -1981,11 +1356,9 @@ TEST_INSTR(mul_sve)
         "mul    %z21.b $0x2b -> %z21.b", "mul    %z31.b $0x7f -> %z31.b",
     };
     TEST_LOOP(mul, mul_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_int(imm8_0_0[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_1[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_1[6] = {
         "mul    %z0.h $0x80 -> %z0.h",   "mul    %z5.h $0xab -> %z5.h",
@@ -1993,11 +1366,9 @@ TEST_INSTR(mul_sve)
         "mul    %z21.h $0x2b -> %z21.h", "mul    %z31.h $0x7f -> %z31.h",
     };
     TEST_LOOP(mul, mul_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_int(imm8_0_1[i], OPSZ_1));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_2[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_2[6] = {
         "mul    %z0.s $0x80 -> %z0.s",   "mul    %z5.s $0xab -> %z5.s",
@@ -2005,11 +1376,9 @@ TEST_INSTR(mul_sve)
         "mul    %z21.s $0x2b -> %z21.s", "mul    %z31.s $0x7f -> %z31.s",
     };
     TEST_LOOP(mul, mul_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_int(imm8_0_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_3[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_3[6] = {
         "mul    %z0.d $0x80 -> %z0.d",   "mul    %z5.d $0xab -> %z5.d",
@@ -2017,217 +1386,129 @@ TEST_INSTR(mul_sve)
         "mul    %z21.d $0x2b -> %z21.d", "mul    %z31.d $0x7f -> %z31.d",
     };
     TEST_LOOP(mul, mul_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_int(imm8_0_3[i], OPSZ_1));
-
-    return success;
 }
 
 TEST_INSTR(smulh_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SMULH   <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "smulh  %p0/m %z0.b %z0.b -> %z0.b",    "smulh  %p2/m %z5.b %z7.b -> %z5.b",
         "smulh  %p3/m %z10.b %z12.b -> %z10.b", "smulh  %p5/m %z16.b %z18.b -> %z16.b",
         "smulh  %p6/m %z21.b %z23.b -> %z21.b", "smulh  %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(smulh, smulh_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "smulh  %p0/m %z0.h %z0.h -> %z0.h",    "smulh  %p2/m %z5.h %z7.h -> %z5.h",
         "smulh  %p3/m %z10.h %z12.h -> %z10.h", "smulh  %p5/m %z16.h %z18.h -> %z16.h",
         "smulh  %p6/m %z21.h %z23.h -> %z21.h", "smulh  %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(smulh, smulh_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "smulh  %p0/m %z0.s %z0.s -> %z0.s",    "smulh  %p2/m %z5.s %z7.s -> %z5.s",
         "smulh  %p3/m %z10.s %z12.s -> %z10.s", "smulh  %p5/m %z16.s %z18.s -> %z16.s",
         "smulh  %p6/m %z21.s %z23.s -> %z21.s", "smulh  %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(smulh, smulh_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "smulh  %p0/m %z0.d %z0.d -> %z0.d",    "smulh  %p2/m %z5.d %z7.d -> %z5.d",
         "smulh  %p3/m %z10.d %z12.d -> %z10.d", "smulh  %p5/m %z16.d %z18.d -> %z16.d",
         "smulh  %p6/m %z21.d %z23.d -> %z21.d", "smulh  %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(smulh, smulh_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(umulh_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UMULH   <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "umulh  %p0/m %z0.b %z0.b -> %z0.b",    "umulh  %p2/m %z5.b %z7.b -> %z5.b",
         "umulh  %p3/m %z10.b %z12.b -> %z10.b", "umulh  %p5/m %z16.b %z18.b -> %z16.b",
         "umulh  %p6/m %z21.b %z23.b -> %z21.b", "umulh  %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(umulh, umulh_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "umulh  %p0/m %z0.h %z0.h -> %z0.h",    "umulh  %p2/m %z5.h %z7.h -> %z5.h",
         "umulh  %p3/m %z10.h %z12.h -> %z10.h", "umulh  %p5/m %z16.h %z18.h -> %z16.h",
         "umulh  %p6/m %z21.h %z23.h -> %z21.h", "umulh  %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(umulh, umulh_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "umulh  %p0/m %z0.s %z0.s -> %z0.s",    "umulh  %p2/m %z5.s %z7.s -> %z5.s",
         "umulh  %p3/m %z10.s %z12.s -> %z10.s", "umulh  %p5/m %z16.s %z18.s -> %z16.s",
         "umulh  %p6/m %z21.s %z23.s -> %z21.s", "umulh  %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(umulh, umulh_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "umulh  %p0/m %z0.d %z0.d -> %z0.d",    "umulh  %p2/m %z5.d %z7.d -> %z5.d",
         "umulh  %p3/m %z10.d %z12.d -> %z10.d", "umulh  %p5/m %z16.d %z18.d -> %z16.d",
         "umulh  %p6/m %z21.d %z23.d -> %z21.d", "umulh  %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(umulh, umulh_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fexpa_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FEXPA   <Zd>.<Ts>, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fexpa  %z0.h -> %z0.h",   "fexpa  %z6.h -> %z5.h",   "fexpa  %z11.h -> %z10.h",
         "fexpa  %z17.h -> %z16.h", "fexpa  %z22.h -> %z21.h", "fexpa  %z31.h -> %z31.h",
     };
     TEST_LOOP(fexpa, fexpa_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fexpa  %z0.s -> %z0.s",   "fexpa  %z6.s -> %z5.s",   "fexpa  %z11.s -> %z10.s",
         "fexpa  %z17.s -> %z16.s", "fexpa  %z22.s -> %z21.s", "fexpa  %z31.s -> %z31.s",
     };
     TEST_LOOP(fexpa, fexpa_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fexpa  %z0.d -> %z0.d",   "fexpa  %z6.d -> %z5.d",   "fexpa  %z11.d -> %z10.d",
         "fexpa  %z17.d -> %z16.d", "fexpa  %z22.d -> %z21.d", "fexpa  %z31.d -> %z31.d",
     };
     TEST_LOOP(fexpa, fexpa_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8));
 }
 
 TEST_INSTR(ftmad_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FTMAD   <Zdn>.<Ts>, <Zdn>.<Ts>, <Zm>.<Ts>, #<imm> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
     uint imm3_0_0[6] = { 0, 3, 4, 6, 7, 7 };
     const char *expected_0_0[6] = {
         "ftmad  %z0.h %z0.h $0x00 -> %z0.h",    "ftmad  %z5.h %z6.h $0x03 -> %z5.h",
@@ -2235,14 +1516,10 @@ TEST_INSTR(ftmad_sve)
         "ftmad  %z21.h %z22.h $0x07 -> %z21.h", "ftmad  %z31.h %z31.h $0x07 -> %z31.h",
     };
     TEST_LOOP(ftmad, ftmad_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
               opnd_create_immed_uint(imm3_0_0[i], OPSZ_3b));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
     uint imm3_0_1[6] = { 0, 3, 4, 6, 7, 7 };
     const char *expected_0_1[6] = {
         "ftmad  %z0.s %z0.s $0x00 -> %z0.s",    "ftmad  %z5.s %z6.s $0x03 -> %z5.s",
@@ -2250,14 +1527,10 @@ TEST_INSTR(ftmad_sve)
         "ftmad  %z21.s %z22.s $0x07 -> %z21.s", "ftmad  %z31.s %z31.s $0x07 -> %z31.s",
     };
     TEST_LOOP(ftmad, ftmad_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
               opnd_create_immed_uint(imm3_0_1[i], OPSZ_3b));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
     uint imm3_0_2[6] = { 0, 3, 4, 6, 7, 7 };
     const char *expected_0_2[6] = {
         "ftmad  %z0.d %z0.d $0x00 -> %z0.d",    "ftmad  %z5.d %z6.d $0x03 -> %z5.d",
@@ -2265,508 +1538,302 @@ TEST_INSTR(ftmad_sve)
         "ftmad  %z21.d %z22.d $0x07 -> %z21.d", "ftmad  %z31.d %z31.d $0x07 -> %z31.d",
     };
     TEST_LOOP(ftmad, ftmad_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
               opnd_create_immed_uint(imm3_0_2[i], OPSZ_3b));
-
-    return success;
 }
 
 TEST_INSTR(ftsmul_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FTSMUL  <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "ftsmul %z0.h %z0.h -> %z0.h",    "ftsmul %z6.h %z7.h -> %z5.h",
         "ftsmul %z11.h %z12.h -> %z10.h", "ftsmul %z17.h %z18.h -> %z16.h",
         "ftsmul %z22.h %z23.h -> %z21.h", "ftsmul %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(ftsmul, ftsmul_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "ftsmul %z0.s %z0.s -> %z0.s",    "ftsmul %z6.s %z7.s -> %z5.s",
         "ftsmul %z11.s %z12.s -> %z10.s", "ftsmul %z17.s %z18.s -> %z16.s",
         "ftsmul %z22.s %z23.s -> %z21.s", "ftsmul %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(ftsmul, ftsmul_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "ftsmul %z0.d %z0.d -> %z0.d",    "ftsmul %z6.d %z7.d -> %z5.d",
         "ftsmul %z11.d %z12.d -> %z10.d", "ftsmul %z17.d %z18.d -> %z16.d",
         "ftsmul %z22.d %z23.d -> %z21.d", "ftsmul %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(ftsmul, ftsmul_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(ftssel_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FTSSEL  <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "ftssel %z0.h %z0.h -> %z0.h",    "ftssel %z6.h %z7.h -> %z5.h",
         "ftssel %z11.h %z12.h -> %z10.h", "ftssel %z17.h %z18.h -> %z16.h",
         "ftssel %z22.h %z23.h -> %z21.h", "ftssel %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(ftssel, ftssel_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "ftssel %z0.s %z0.s -> %z0.s",    "ftssel %z6.s %z7.s -> %z5.s",
         "ftssel %z11.s %z12.s -> %z10.s", "ftssel %z17.s %z18.s -> %z16.s",
         "ftssel %z22.s %z23.s -> %z21.s", "ftssel %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(ftssel, ftssel_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,
-                           DR_REG_Z17, DR_REG_Z22, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "ftssel %z0.d %z0.d -> %z0.d",    "ftssel %z6.d %z7.d -> %z5.d",
         "ftssel %z11.d %z12.d -> %z10.d", "ftssel %z17.d %z18.d -> %z16.d",
         "ftssel %z22.d %z23.d -> %z21.d", "ftssel %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(ftssel, ftssel_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(abs_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing ABS     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "abs    %p0/m %z0.b -> %z0.b",   "abs    %p2/m %z7.b -> %z5.b",
         "abs    %p3/m %z12.b -> %z10.b", "abs    %p5/m %z18.b -> %z16.b",
         "abs    %p6/m %z23.b -> %z21.b", "abs    %p7/m %z31.b -> %z31.b",
     };
     TEST_LOOP(abs, abs_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "abs    %p0/m %z0.h -> %z0.h",   "abs    %p2/m %z7.h -> %z5.h",
         "abs    %p3/m %z12.h -> %z10.h", "abs    %p5/m %z18.h -> %z16.h",
         "abs    %p6/m %z23.h -> %z21.h", "abs    %p7/m %z31.h -> %z31.h",
     };
     TEST_LOOP(abs, abs_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "abs    %p0/m %z0.s -> %z0.s",   "abs    %p2/m %z7.s -> %z5.s",
         "abs    %p3/m %z12.s -> %z10.s", "abs    %p5/m %z18.s -> %z16.s",
         "abs    %p6/m %z23.s -> %z21.s", "abs    %p7/m %z31.s -> %z31.s",
     };
     TEST_LOOP(abs, abs_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "abs    %p0/m %z0.d -> %z0.d",   "abs    %p2/m %z7.d -> %z5.d",
         "abs    %p3/m %z12.d -> %z10.d", "abs    %p5/m %z18.d -> %z16.d",
         "abs    %p6/m %z23.d -> %z21.d", "abs    %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(abs, abs_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(cnot_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing CNOT    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "cnot   %p0/m %z0.b -> %z0.b",   "cnot   %p2/m %z7.b -> %z5.b",
         "cnot   %p3/m %z12.b -> %z10.b", "cnot   %p5/m %z18.b -> %z16.b",
         "cnot   %p6/m %z23.b -> %z21.b", "cnot   %p7/m %z31.b -> %z31.b",
     };
     TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "cnot   %p0/m %z0.h -> %z0.h",   "cnot   %p2/m %z7.h -> %z5.h",
         "cnot   %p3/m %z12.h -> %z10.h", "cnot   %p5/m %z18.h -> %z16.h",
         "cnot   %p6/m %z23.h -> %z21.h", "cnot   %p7/m %z31.h -> %z31.h",
     };
     TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "cnot   %p0/m %z0.s -> %z0.s",   "cnot   %p2/m %z7.s -> %z5.s",
         "cnot   %p3/m %z12.s -> %z10.s", "cnot   %p5/m %z18.s -> %z16.s",
         "cnot   %p6/m %z23.s -> %z21.s", "cnot   %p7/m %z31.s -> %z31.s",
     };
     TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "cnot   %p0/m %z0.d -> %z0.d",   "cnot   %p2/m %z7.d -> %z5.d",
         "cnot   %p3/m %z12.d -> %z10.d", "cnot   %p5/m %z18.d -> %z16.d",
         "cnot   %p6/m %z23.d -> %z21.d", "cnot   %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(cnot, cnot_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(neg_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing NEG     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "neg    %p0/m %z0.b -> %z0.b",   "neg    %p2/m %z7.b -> %z5.b",
         "neg    %p3/m %z12.b -> %z10.b", "neg    %p5/m %z18.b -> %z16.b",
         "neg    %p6/m %z23.b -> %z21.b", "neg    %p7/m %z31.b -> %z31.b",
     };
     TEST_LOOP(neg, neg_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "neg    %p0/m %z0.h -> %z0.h",   "neg    %p2/m %z7.h -> %z5.h",
         "neg    %p3/m %z12.h -> %z10.h", "neg    %p5/m %z18.h -> %z16.h",
         "neg    %p6/m %z23.h -> %z21.h", "neg    %p7/m %z31.h -> %z31.h",
     };
     TEST_LOOP(neg, neg_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "neg    %p0/m %z0.s -> %z0.s",   "neg    %p2/m %z7.s -> %z5.s",
         "neg    %p3/m %z12.s -> %z10.s", "neg    %p5/m %z18.s -> %z16.s",
         "neg    %p6/m %z23.s -> %z21.s", "neg    %p7/m %z31.s -> %z31.s",
     };
     TEST_LOOP(neg, neg_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "neg    %p0/m %z0.d -> %z0.d",   "neg    %p2/m %z7.d -> %z5.d",
         "neg    %p3/m %z12.d -> %z10.d", "neg    %p5/m %z18.d -> %z16.d",
         "neg    %p6/m %z23.d -> %z21.d", "neg    %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(neg, neg_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zd_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zn_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(sabd_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "sabd   %p0/m %z0.b %z0.b -> %z0.b",    "sabd   %p2/m %z5.b %z7.b -> %z5.b",
         "sabd   %p3/m %z10.b %z12.b -> %z10.b", "sabd   %p5/m %z16.b %z18.b -> %z16.b",
         "sabd   %p6/m %z21.b %z23.b -> %z21.b", "sabd   %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "sabd   %p0/m %z0.h %z0.h -> %z0.h",    "sabd   %p2/m %z5.h %z7.h -> %z5.h",
         "sabd   %p3/m %z10.h %z12.h -> %z10.h", "sabd   %p5/m %z16.h %z18.h -> %z16.h",
         "sabd   %p6/m %z21.h %z23.h -> %z21.h", "sabd   %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "sabd   %p0/m %z0.s %z0.s -> %z0.s",    "sabd   %p2/m %z5.s %z7.s -> %z5.s",
         "sabd   %p3/m %z10.s %z12.s -> %z10.s", "sabd   %p5/m %z16.s %z18.s -> %z16.s",
         "sabd   %p6/m %z21.s %z23.s -> %z21.s", "sabd   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "sabd   %p0/m %z0.d %z0.d -> %z0.d",    "sabd   %p2/m %z5.d %z7.d -> %z5.d",
         "sabd   %p3/m %z10.d %z12.d -> %z10.d", "sabd   %p5/m %z16.d %z18.d -> %z16.d",
         "sabd   %p6/m %z21.d %z23.d -> %z21.d", "sabd   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(sabd, sabd_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(smax_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SMAX    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "smax   %p0/m %z0.b %z0.b -> %z0.b",    "smax   %p2/m %z5.b %z7.b -> %z5.b",
         "smax   %p3/m %z10.b %z12.b -> %z10.b", "smax   %p5/m %z16.b %z18.b -> %z16.b",
         "smax   %p6/m %z21.b %z23.b -> %z21.b", "smax   %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(smax, smax_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "smax   %p0/m %z0.h %z0.h -> %z0.h",    "smax   %p2/m %z5.h %z7.h -> %z5.h",
         "smax   %p3/m %z10.h %z12.h -> %z10.h", "smax   %p5/m %z16.h %z18.h -> %z16.h",
         "smax   %p6/m %z21.h %z23.h -> %z21.h", "smax   %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(smax, smax_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "smax   %p0/m %z0.s %z0.s -> %z0.s",    "smax   %p2/m %z5.s %z7.s -> %z5.s",
         "smax   %p3/m %z10.s %z12.s -> %z10.s", "smax   %p5/m %z16.s %z18.s -> %z16.s",
         "smax   %p6/m %z21.s %z23.s -> %z21.s", "smax   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(smax, smax_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "smax   %p0/m %z0.d %z0.d -> %z0.d",    "smax   %p2/m %z5.d %z7.d -> %z5.d",
         "smax   %p3/m %z10.d %z12.d -> %z10.d", "smax   %p5/m %z16.d %z18.d -> %z16.d",
         "smax   %p6/m %z21.d %z23.d -> %z21.d", "smax   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(smax, smax_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(smax_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SMAX    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_0[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_0[6] = {
         "smax   %z0.b $0x80 -> %z0.b",   "smax   %z5.b $0xab -> %z5.b",
@@ -2774,11 +1841,9 @@ TEST_INSTR(smax_sve)
         "smax   %z21.b $0x2b -> %z21.b", "smax   %z31.b $0x7f -> %z31.b",
     };
     TEST_LOOP(smax, smax_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_int(imm8_0_0[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_1[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_1[6] = {
         "smax   %z0.h $0x80 -> %z0.h",   "smax   %z5.h $0xab -> %z5.h",
@@ -2786,11 +1851,9 @@ TEST_INSTR(smax_sve)
         "smax   %z21.h $0x2b -> %z21.h", "smax   %z31.h $0x7f -> %z31.h",
     };
     TEST_LOOP(smax, smax_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_int(imm8_0_1[i], OPSZ_1));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_2[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_2[6] = {
         "smax   %z0.s $0x80 -> %z0.s",   "smax   %z5.s $0xab -> %z5.s",
@@ -2798,11 +1861,9 @@ TEST_INSTR(smax_sve)
         "smax   %z21.s $0x2b -> %z21.s", "smax   %z31.s $0x7f -> %z31.s",
     };
     TEST_LOOP(smax, smax_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_int(imm8_0_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_3[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_3[6] = {
         "smax   %z0.d $0x80 -> %z0.d",   "smax   %z5.d $0xab -> %z5.d",
@@ -2810,95 +1871,57 @@ TEST_INSTR(smax_sve)
         "smax   %z21.d $0x2b -> %z21.d", "smax   %z31.d $0x7f -> %z31.d",
     };
     TEST_LOOP(smax, smax_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_int(imm8_0_3[i], OPSZ_1));
-
-    return success;
 }
 
 TEST_INSTR(smin_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SMIN    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "smin   %p0/m %z0.b %z0.b -> %z0.b",    "smin   %p2/m %z5.b %z7.b -> %z5.b",
         "smin   %p3/m %z10.b %z12.b -> %z10.b", "smin   %p5/m %z16.b %z18.b -> %z16.b",
         "smin   %p6/m %z21.b %z23.b -> %z21.b", "smin   %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(smin, smin_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "smin   %p0/m %z0.h %z0.h -> %z0.h",    "smin   %p2/m %z5.h %z7.h -> %z5.h",
         "smin   %p3/m %z10.h %z12.h -> %z10.h", "smin   %p5/m %z16.h %z18.h -> %z16.h",
         "smin   %p6/m %z21.h %z23.h -> %z21.h", "smin   %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(smin, smin_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "smin   %p0/m %z0.s %z0.s -> %z0.s",    "smin   %p2/m %z5.s %z7.s -> %z5.s",
         "smin   %p3/m %z10.s %z12.s -> %z10.s", "smin   %p5/m %z16.s %z18.s -> %z16.s",
         "smin   %p6/m %z21.s %z23.s -> %z21.s", "smin   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(smin, smin_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "smin   %p0/m %z0.d %z0.d -> %z0.d",    "smin   %p2/m %z5.d %z7.d -> %z5.d",
         "smin   %p3/m %z10.d %z12.d -> %z10.d", "smin   %p5/m %z16.d %z18.d -> %z16.d",
         "smin   %p6/m %z21.d %z23.d -> %z21.d", "smin   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(smin, smin_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(smin_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SMIN    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_0[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_0[6] = {
         "smin   %z0.b $0x80 -> %z0.b",   "smin   %z5.b $0xab -> %z5.b",
@@ -2906,11 +1929,9 @@ TEST_INSTR(smin_sve)
         "smin   %z21.b $0x2b -> %z21.b", "smin   %z31.b $0x7f -> %z31.b",
     };
     TEST_LOOP(smin, smin_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_int(imm8_0_0[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_1[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_1[6] = {
         "smin   %z0.h $0x80 -> %z0.h",   "smin   %z5.h $0xab -> %z5.h",
@@ -2918,11 +1939,9 @@ TEST_INSTR(smin_sve)
         "smin   %z21.h $0x2b -> %z21.h", "smin   %z31.h $0x7f -> %z31.h",
     };
     TEST_LOOP(smin, smin_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_int(imm8_0_1[i], OPSZ_1));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_2[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_2[6] = {
         "smin   %z0.s $0x80 -> %z0.s",   "smin   %z5.s $0xab -> %z5.s",
@@ -2930,11 +1949,9 @@ TEST_INSTR(smin_sve)
         "smin   %z21.s $0x2b -> %z21.s", "smin   %z31.s $0x7f -> %z31.s",
     };
     TEST_LOOP(smin, smin_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_int(imm8_0_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     int imm8_0_3[6] = { -128, -85, -42, 1, 43, 127 };
     const char *expected_0_3[6] = {
         "smin   %z0.d $0x80 -> %z0.d",   "smin   %z5.d $0xab -> %z5.d",
@@ -2942,471 +1959,271 @@ TEST_INSTR(smin_sve)
         "smin   %z21.d $0x2b -> %z21.d", "smin   %z31.d $0x7f -> %z31.d",
     };
     TEST_LOOP(smin, smin_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_int(imm8_0_3[i], OPSZ_1));
-
-    return success;
 }
 
 TEST_INSTR(uabd_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UABD    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "uabd   %p0/m %z0.b %z0.b -> %z0.b",    "uabd   %p2/m %z5.b %z7.b -> %z5.b",
         "uabd   %p3/m %z10.b %z12.b -> %z10.b", "uabd   %p5/m %z16.b %z18.b -> %z16.b",
         "uabd   %p6/m %z21.b %z23.b -> %z21.b", "uabd   %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "uabd   %p0/m %z0.h %z0.h -> %z0.h",    "uabd   %p2/m %z5.h %z7.h -> %z5.h",
         "uabd   %p3/m %z10.h %z12.h -> %z10.h", "uabd   %p5/m %z16.h %z18.h -> %z16.h",
         "uabd   %p6/m %z21.h %z23.h -> %z21.h", "uabd   %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "uabd   %p0/m %z0.s %z0.s -> %z0.s",    "uabd   %p2/m %z5.s %z7.s -> %z5.s",
         "uabd   %p3/m %z10.s %z12.s -> %z10.s", "uabd   %p5/m %z16.s %z18.s -> %z16.s",
         "uabd   %p6/m %z21.s %z23.s -> %z21.s", "uabd   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "uabd   %p0/m %z0.d %z0.d -> %z0.d",    "uabd   %p2/m %z5.d %z7.d -> %z5.d",
         "uabd   %p3/m %z10.d %z12.d -> %z10.d", "uabd   %p5/m %z16.d %z18.d -> %z16.d",
         "uabd   %p6/m %z21.d %z23.d -> %z21.d", "uabd   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(uabd, uabd_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(facge_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FACGE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "facge  %p0/z %z0.h %z0.h -> %p0.h",    "facge  %p2/z %z7.h %z8.h -> %p2.h",
         "facge  %p3/z %z12.h %z13.h -> %p5.h",  "facge  %p5/z %z18.h %z19.h -> %p8.h",
         "facge  %p6/z %z23.h %z24.h -> %p10.h", "facge  %p7/z %z31.h %z31.h -> %p15.h",
     };
     TEST_LOOP(facge, facge_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "facge  %p0/z %z0.s %z0.s -> %p0.s",    "facge  %p2/z %z7.s %z8.s -> %p2.s",
         "facge  %p3/z %z12.s %z13.s -> %p5.s",  "facge  %p5/z %z18.s %z19.s -> %p8.s",
         "facge  %p6/z %z23.s %z24.s -> %p10.s", "facge  %p7/z %z31.s %z31.s -> %p15.s",
     };
     TEST_LOOP(facge, facge_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "facge  %p0/z %z0.d %z0.d -> %p0.d",    "facge  %p2/z %z7.d %z8.d -> %p2.d",
         "facge  %p3/z %z12.d %z13.d -> %p5.d",  "facge  %p5/z %z18.d %z19.d -> %p8.d",
         "facge  %p6/z %z23.d %z24.d -> %p10.d", "facge  %p7/z %z31.d %z31.d -> %p15.d",
     };
     TEST_LOOP(facge, facge_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(facgt_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FACGT   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "facgt  %p0/z %z0.h %z0.h -> %p0.h",    "facgt  %p2/z %z7.h %z8.h -> %p2.h",
         "facgt  %p3/z %z12.h %z13.h -> %p5.h",  "facgt  %p5/z %z18.h %z19.h -> %p8.h",
         "facgt  %p6/z %z23.h %z24.h -> %p10.h", "facgt  %p7/z %z31.h %z31.h -> %p15.h",
     };
     TEST_LOOP(facgt, facgt_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "facgt  %p0/z %z0.s %z0.s -> %p0.s",    "facgt  %p2/z %z7.s %z8.s -> %p2.s",
         "facgt  %p3/z %z12.s %z13.s -> %p5.s",  "facgt  %p5/z %z18.s %z19.s -> %p8.s",
         "facgt  %p6/z %z23.s %z24.s -> %p10.s", "facgt  %p7/z %z31.s %z31.s -> %p15.s",
     };
     TEST_LOOP(facgt, facgt_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "facgt  %p0/z %z0.d %z0.d -> %p0.d",    "facgt  %p2/z %z7.d %z8.d -> %p2.d",
         "facgt  %p3/z %z12.d %z13.d -> %p5.d",  "facgt  %p5/z %z18.d %z19.d -> %p8.d",
         "facgt  %p6/z %z23.d %z24.d -> %p10.d", "facgt  %p7/z %z31.d %z31.d -> %p15.d",
     };
     TEST_LOOP(facgt, facgt_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(sdiv_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SDIV    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "sdiv   %p0/m %z0.s %z0.s -> %z0.s",    "sdiv   %p2/m %z5.s %z7.s -> %z5.s",
         "sdiv   %p3/m %z10.s %z12.s -> %z10.s", "sdiv   %p5/m %z16.s %z18.s -> %z16.s",
         "sdiv   %p6/m %z21.s %z23.s -> %z21.s", "sdiv   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(sdiv, sdiv_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "sdiv   %p0/m %z0.d %z0.d -> %z0.d",    "sdiv   %p2/m %z5.d %z7.d -> %z5.d",
         "sdiv   %p3/m %z10.d %z12.d -> %z10.d", "sdiv   %p5/m %z16.d %z18.d -> %z16.d",
         "sdiv   %p6/m %z21.d %z23.d -> %z21.d", "sdiv   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(sdiv, sdiv_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(sdivr_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SDIVR   <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "sdivr  %p0/m %z0.s %z0.s -> %z0.s",    "sdivr  %p2/m %z5.s %z7.s -> %z5.s",
         "sdivr  %p3/m %z10.s %z12.s -> %z10.s", "sdivr  %p5/m %z16.s %z18.s -> %z16.s",
         "sdivr  %p6/m %z21.s %z23.s -> %z21.s", "sdivr  %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(sdivr, sdivr_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "sdivr  %p0/m %z0.d %z0.d -> %z0.d",    "sdivr  %p2/m %z5.d %z7.d -> %z5.d",
         "sdivr  %p3/m %z10.d %z12.d -> %z10.d", "sdivr  %p5/m %z16.d %z18.d -> %z16.d",
         "sdivr  %p6/m %z21.d %z23.d -> %z21.d", "sdivr  %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(sdivr, sdivr_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(udiv_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UDIV    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "udiv   %p0/m %z0.s %z0.s -> %z0.s",    "udiv   %p2/m %z5.s %z7.s -> %z5.s",
         "udiv   %p3/m %z10.s %z12.s -> %z10.s", "udiv   %p5/m %z16.s %z18.s -> %z16.s",
         "udiv   %p6/m %z21.s %z23.s -> %z21.s", "udiv   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(udiv, udiv_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "udiv   %p0/m %z0.d %z0.d -> %z0.d",    "udiv   %p2/m %z5.d %z7.d -> %z5.d",
         "udiv   %p3/m %z10.d %z12.d -> %z10.d", "udiv   %p5/m %z16.d %z18.d -> %z16.d",
         "udiv   %p6/m %z21.d %z23.d -> %z21.d", "udiv   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(udiv, udiv_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(udivr_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UDIVR   <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "udivr  %p0/m %z0.s %z0.s -> %z0.s",    "udivr  %p2/m %z5.s %z7.s -> %z5.s",
         "udivr  %p3/m %z10.s %z12.s -> %z10.s", "udivr  %p5/m %z16.s %z18.s -> %z16.s",
         "udivr  %p6/m %z21.s %z23.s -> %z21.s", "udivr  %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(udivr, udivr_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "udivr  %p0/m %z0.d %z0.d -> %z0.d",    "udivr  %p2/m %z5.d %z7.d -> %z5.d",
         "udivr  %p3/m %z10.d %z12.d -> %z10.d", "udivr  %p5/m %z16.d %z18.d -> %z16.d",
         "udivr  %p6/m %z21.d %z23.d -> %z21.d", "udivr  %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(udivr, udivr_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(umax_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UMAX    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "umax   %p0/m %z0.b %z0.b -> %z0.b",    "umax   %p2/m %z5.b %z7.b -> %z5.b",
         "umax   %p3/m %z10.b %z12.b -> %z10.b", "umax   %p5/m %z16.b %z18.b -> %z16.b",
         "umax   %p6/m %z21.b %z23.b -> %z21.b", "umax   %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(umax, umax_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "umax   %p0/m %z0.h %z0.h -> %z0.h",    "umax   %p2/m %z5.h %z7.h -> %z5.h",
         "umax   %p3/m %z10.h %z12.h -> %z10.h", "umax   %p5/m %z16.h %z18.h -> %z16.h",
         "umax   %p6/m %z21.h %z23.h -> %z21.h", "umax   %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(umax, umax_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "umax   %p0/m %z0.s %z0.s -> %z0.s",    "umax   %p2/m %z5.s %z7.s -> %z5.s",
         "umax   %p3/m %z10.s %z12.s -> %z10.s", "umax   %p5/m %z16.s %z18.s -> %z16.s",
         "umax   %p6/m %z21.s %z23.s -> %z21.s", "umax   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(umax, umax_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "umax   %p0/m %z0.d %z0.d -> %z0.d",    "umax   %p2/m %z5.d %z7.d -> %z5.d",
         "umax   %p3/m %z10.d %z12.d -> %z10.d", "umax   %p5/m %z16.d %z18.d -> %z16.d",
         "umax   %p6/m %z21.d %z23.d -> %z21.d", "umax   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(umax, umax_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(umax_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UMAX    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_0[6] = {
         "umax   %z0.b $0x00 -> %z0.b",   "umax   %z5.b $0x2b -> %z5.b",
@@ -3414,11 +2231,9 @@ TEST_INSTR(umax_sve)
         "umax   %z21.b $0xab -> %z21.b", "umax   %z31.b $0xff -> %z31.b",
     };
     TEST_LOOP(umax, umax_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_1[6] = {
         "umax   %z0.h $0x00 -> %z0.h",   "umax   %z5.h $0x2b -> %z5.h",
@@ -3426,11 +2241,9 @@ TEST_INSTR(umax_sve)
         "umax   %z21.h $0xab -> %z21.h", "umax   %z31.h $0xff -> %z31.h",
     };
     TEST_LOOP(umax, umax_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_2[6] = {
         "umax   %z0.s $0x00 -> %z0.s",   "umax   %z5.s $0x2b -> %z5.s",
@@ -3438,11 +2251,9 @@ TEST_INSTR(umax_sve)
         "umax   %z21.s $0xab -> %z21.s", "umax   %z31.s $0xff -> %z31.s",
     };
     TEST_LOOP(umax, umax_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_3[6] = {
         "umax   %z0.d $0x00 -> %z0.d",   "umax   %z5.d $0x2b -> %z5.d",
@@ -3450,95 +2261,57 @@ TEST_INSTR(umax_sve)
         "umax   %z21.d $0xab -> %z21.d", "umax   %z31.d $0xff -> %z31.d",
     };
     TEST_LOOP(umax, umax_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1));
-
-    return success;
 }
 
 TEST_INSTR(umin_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UMIN    <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "umin   %p0/m %z0.b %z0.b -> %z0.b",    "umin   %p2/m %z5.b %z7.b -> %z5.b",
         "umin   %p3/m %z10.b %z12.b -> %z10.b", "umin   %p5/m %z16.b %z18.b -> %z16.b",
         "umin   %p6/m %z21.b %z23.b -> %z21.b", "umin   %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(umin, umin_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "umin   %p0/m %z0.h %z0.h -> %z0.h",    "umin   %p2/m %z5.h %z7.h -> %z5.h",
         "umin   %p3/m %z10.h %z12.h -> %z10.h", "umin   %p5/m %z16.h %z18.h -> %z16.h",
         "umin   %p6/m %z21.h %z23.h -> %z21.h", "umin   %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(umin, umin_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "umin   %p0/m %z0.s %z0.s -> %z0.s",    "umin   %p2/m %z5.s %z7.s -> %z5.s",
         "umin   %p3/m %z10.s %z12.s -> %z10.s", "umin   %p5/m %z16.s %z18.s -> %z16.s",
         "umin   %p6/m %z21.s %z23.s -> %z21.s", "umin   %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(umin, umin_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_3[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zm_0_3[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_3[6] = {
         "umin   %p0/m %z0.d %z0.d -> %z0.d",    "umin   %p2/m %z5.d %z7.d -> %z5.d",
         "umin   %p3/m %z10.d %z12.d -> %z10.d", "umin   %p5/m %z16.d %z18.d -> %z16.d",
         "umin   %p6/m %z21.d %z23.d -> %z21.d", "umin   %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(umin, umin_sve_pred, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_3[i], true),
-              opnd_create_reg_element_vector(Zm_0_3[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(umin_sve)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UMIN    <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm> */
-    reg_id_t Zdn_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_0[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_0[6] = {
         "umin   %z0.b $0x00 -> %z0.b",   "umin   %z5.b $0x2b -> %z5.b",
@@ -3546,11 +2319,9 @@ TEST_INSTR(umin_sve)
         "umin   %z21.b $0xab -> %z21.b", "umin   %z31.b $0xff -> %z31.b",
     };
     TEST_LOOP(umin, umin_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zdn_0_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
               opnd_create_immed_uint(imm8_0_0[i], OPSZ_1));
 
-    reg_id_t Zdn_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_1[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_1[6] = {
         "umin   %z0.h $0x00 -> %z0.h",   "umin   %z5.h $0x2b -> %z5.h",
@@ -3558,11 +2329,9 @@ TEST_INSTR(umin_sve)
         "umin   %z21.h $0xab -> %z21.h", "umin   %z31.h $0xff -> %z31.h",
     };
     TEST_LOOP(umin, umin_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zdn_0_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_immed_uint(imm8_0_1[i], OPSZ_1));
 
-    reg_id_t Zdn_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_2[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_2[6] = {
         "umin   %z0.s $0x00 -> %z0.s",   "umin   %z5.s $0x2b -> %z5.s",
@@ -3570,11 +2339,9 @@ TEST_INSTR(umin_sve)
         "umin   %z21.s $0xab -> %z21.s", "umin   %z31.s $0xff -> %z31.s",
     };
     TEST_LOOP(umin, umin_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zdn_0_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_immed_uint(imm8_0_2[i], OPSZ_1));
 
-    reg_id_t Zdn_0_3[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                            DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
     uint imm8_0_3[6] = { 0, 43, 86, 129, 171, 255 };
     const char *expected_0_3[6] = {
         "umin   %z0.d $0x00 -> %z0.d",   "umin   %z5.d $0x2b -> %z5.d",
@@ -3582,277 +2349,157 @@ TEST_INSTR(umin_sve)
         "umin   %z21.d $0xab -> %z21.d", "umin   %z31.d $0xff -> %z31.d",
     };
     TEST_LOOP(umin, umin_sve, 6, expected_0_3[i],
-              opnd_create_reg_element_vector(Zdn_0_3[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_immed_uint(imm8_0_3[i], OPSZ_1));
-
-    return success;
 }
 
 TEST_INSTR(sxtb_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SXTB    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "sxtb   %p0/m %z0.h -> %z0.h",   "sxtb   %p2/m %z7.h -> %z5.h",
         "sxtb   %p3/m %z12.h -> %z10.h", "sxtb   %p5/m %z18.h -> %z16.h",
         "sxtb   %p6/m %z23.h -> %z21.h", "sxtb   %p7/m %z31.h -> %z31.h",
     };
     TEST_LOOP(sxtb, sxtb_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "sxtb   %p0/m %z0.s -> %z0.s",   "sxtb   %p2/m %z7.s -> %z5.s",
         "sxtb   %p3/m %z12.s -> %z10.s", "sxtb   %p5/m %z18.s -> %z16.s",
         "sxtb   %p6/m %z23.s -> %z21.s", "sxtb   %p7/m %z31.s -> %z31.s",
     };
     TEST_LOOP(sxtb, sxtb_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "sxtb   %p0/m %z0.d -> %z0.d",   "sxtb   %p2/m %z7.d -> %z5.d",
         "sxtb   %p3/m %z12.d -> %z10.d", "sxtb   %p5/m %z18.d -> %z16.d",
         "sxtb   %p6/m %z23.d -> %z21.d", "sxtb   %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(sxtb, sxtb_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(sxth_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SXTH    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "sxth   %p0/m %z0.s -> %z0.s",   "sxth   %p2/m %z7.s -> %z5.s",
         "sxth   %p3/m %z12.s -> %z10.s", "sxth   %p5/m %z18.s -> %z16.s",
         "sxth   %p6/m %z23.s -> %z21.s", "sxth   %p7/m %z31.s -> %z31.s",
     };
     TEST_LOOP(sxth, sxth_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "sxth   %p0/m %z0.d -> %z0.d",   "sxth   %p2/m %z7.d -> %z5.d",
         "sxth   %p3/m %z12.d -> %z10.d", "sxth   %p5/m %z18.d -> %z16.d",
         "sxth   %p6/m %z23.d -> %z21.d", "sxth   %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(sxth, sxth_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(sxtw_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing SXTW    <Zd>.D, <Pg>/M, <Zn>.D */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "sxtw   %p0/m %z0.d -> %z0.d",   "sxtw   %p2/m %z7.d -> %z5.d",
         "sxtw   %p3/m %z12.d -> %z10.d", "sxtw   %p5/m %z18.d -> %z16.d",
         "sxtw   %p6/m %z23.d -> %z21.d", "sxtw   %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(sxtw, sxtw_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(uxtb_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UXTB    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "uxtb   %p0/m %z0.h -> %z0.h",   "uxtb   %p2/m %z7.h -> %z5.h",
         "uxtb   %p3/m %z12.h -> %z10.h", "uxtb   %p5/m %z18.h -> %z16.h",
         "uxtb   %p6/m %z23.h -> %z21.h", "uxtb   %p7/m %z31.h -> %z31.h",
     };
     TEST_LOOP(uxtb, uxtb_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "uxtb   %p0/m %z0.s -> %z0.s",   "uxtb   %p2/m %z7.s -> %z5.s",
         "uxtb   %p3/m %z12.s -> %z10.s", "uxtb   %p5/m %z18.s -> %z16.s",
         "uxtb   %p6/m %z23.s -> %z21.s", "uxtb   %p7/m %z31.s -> %z31.s",
     };
     TEST_LOOP(uxtb, uxtb_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_2[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "uxtb   %p0/m %z0.d -> %z0.d",   "uxtb   %p2/m %z7.d -> %z5.d",
         "uxtb   %p3/m %z12.d -> %z10.d", "uxtb   %p5/m %z18.d -> %z16.d",
         "uxtb   %p6/m %z23.d -> %z21.d", "uxtb   %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(uxtb, uxtb_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], true),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(uxth_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UXTH    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "uxth   %p0/m %z0.s -> %z0.s",   "uxth   %p2/m %z7.s -> %z5.s",
         "uxth   %p3/m %z12.s -> %z10.s", "uxth   %p5/m %z18.s -> %z16.s",
         "uxth   %p6/m %z23.s -> %z21.s", "uxth   %p7/m %z31.s -> %z31.s",
     };
     TEST_LOOP(uxth, uxth_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_4));
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Zd_0_1[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "uxth   %p0/m %z0.d -> %z0.d",   "uxth   %p2/m %z7.d -> %z5.d",
         "uxth   %p3/m %z12.d -> %z10.d", "uxth   %p5/m %z18.d -> %z16.d",
         "uxth   %p6/m %z23.d -> %z21.d", "uxth   %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(uxth, uxth_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zd_0_1[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_1[i], true),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(uxtw_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing UXTW    <Zd>.D, <Pg>/M, <Zn>.D */
-    reg_id_t Zd_0_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
-                           DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "uxtw   %p0/m %z0.d -> %z0.d",   "uxtw   %p2/m %z7.d -> %z5.d",
         "uxtw   %p3/m %z12.d -> %z10.d", "uxtw   %p5/m %z18.d -> %z16.d",
         "uxtw   %p6/m %z23.d -> %z21.d", "uxtw   %p7/m %z31.d -> %z31.d",
     };
     TEST_LOOP(uxtw, uxtw_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zd_0_0[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_0[i], true),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmeq_sve_zero_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMEQ   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, #0.0 */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmeq  %p0/z %z0.h $0.000000 -> %p0.h",
         "fcmeq  %p2/z %z7.h $0.000000 -> %p2.h",
@@ -3862,16 +2509,10 @@ TEST_INSTR(fcmeq_sve_zero_pred)
         "fcmeq  %p7/z %z31.h $0.000000 -> %p15.h",
     };
     TEST_LOOP(fcmeq, fcmeq_sve_zero_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmeq  %p0/z %z0.s $0.000000 -> %p0.s",
         "fcmeq  %p2/z %z7.s $0.000000 -> %p2.s",
@@ -3881,16 +2522,10 @@ TEST_INSTR(fcmeq_sve_zero_pred)
         "fcmeq  %p7/z %z31.s $0.000000 -> %p15.s",
     };
     TEST_LOOP(fcmeq, fcmeq_sve_zero_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmeq  %p0/z %z0.d $0.000000 -> %p0.d",
         "fcmeq  %p2/z %z7.d $0.000000 -> %p2.d",
@@ -3900,93 +2535,51 @@ TEST_INSTR(fcmeq_sve_zero_pred)
         "fcmeq  %p7/z %z31.d $0.000000 -> %p15.d",
     };
     TEST_LOOP(fcmeq, fcmeq_sve_zero_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmeq_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMEQ   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmeq  %p0/z %z0.h %z0.h -> %p0.h",    "fcmeq  %p2/z %z7.h %z8.h -> %p2.h",
         "fcmeq  %p3/z %z12.h %z13.h -> %p5.h",  "fcmeq  %p5/z %z18.h %z19.h -> %p8.h",
         "fcmeq  %p6/z %z23.h %z24.h -> %p10.h", "fcmeq  %p7/z %z31.h %z31.h -> %p15.h",
     };
     TEST_LOOP(fcmeq, fcmeq_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmeq  %p0/z %z0.s %z0.s -> %p0.s",    "fcmeq  %p2/z %z7.s %z8.s -> %p2.s",
         "fcmeq  %p3/z %z12.s %z13.s -> %p5.s",  "fcmeq  %p5/z %z18.s %z19.s -> %p8.s",
         "fcmeq  %p6/z %z23.s %z24.s -> %p10.s", "fcmeq  %p7/z %z31.s %z31.s -> %p15.s",
     };
     TEST_LOOP(fcmeq, fcmeq_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmeq  %p0/z %z0.d %z0.d -> %p0.d",    "fcmeq  %p2/z %z7.d %z8.d -> %p2.d",
         "fcmeq  %p3/z %z12.d %z13.d -> %p5.d",  "fcmeq  %p5/z %z18.d %z19.d -> %p8.d",
         "fcmeq  %p6/z %z23.d %z24.d -> %p10.d", "fcmeq  %p7/z %z31.d %z31.d -> %p15.d",
     };
     TEST_LOOP(fcmeq, fcmeq_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmge_sve_zero_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMGE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, #0.0 */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmge  %p0/z %z0.h $0.000000 -> %p0.h",
         "fcmge  %p2/z %z7.h $0.000000 -> %p2.h",
@@ -3996,16 +2589,10 @@ TEST_INSTR(fcmge_sve_zero_pred)
         "fcmge  %p7/z %z31.h $0.000000 -> %p15.h",
     };
     TEST_LOOP(fcmge, fcmge_sve_zero_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmge  %p0/z %z0.s $0.000000 -> %p0.s",
         "fcmge  %p2/z %z7.s $0.000000 -> %p2.s",
@@ -4015,16 +2602,10 @@ TEST_INSTR(fcmge_sve_zero_pred)
         "fcmge  %p7/z %z31.s $0.000000 -> %p15.s",
     };
     TEST_LOOP(fcmge, fcmge_sve_zero_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmge  %p0/z %z0.d $0.000000 -> %p0.d",
         "fcmge  %p2/z %z7.d $0.000000 -> %p2.d",
@@ -4034,93 +2615,51 @@ TEST_INSTR(fcmge_sve_zero_pred)
         "fcmge  %p7/z %z31.d $0.000000 -> %p15.d",
     };
     TEST_LOOP(fcmge, fcmge_sve_zero_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmge_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMGE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmge  %p0/z %z0.h %z0.h -> %p0.h",    "fcmge  %p2/z %z7.h %z8.h -> %p2.h",
         "fcmge  %p3/z %z12.h %z13.h -> %p5.h",  "fcmge  %p5/z %z18.h %z19.h -> %p8.h",
         "fcmge  %p6/z %z23.h %z24.h -> %p10.h", "fcmge  %p7/z %z31.h %z31.h -> %p15.h",
     };
     TEST_LOOP(fcmge, fcmge_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmge  %p0/z %z0.s %z0.s -> %p0.s",    "fcmge  %p2/z %z7.s %z8.s -> %p2.s",
         "fcmge  %p3/z %z12.s %z13.s -> %p5.s",  "fcmge  %p5/z %z18.s %z19.s -> %p8.s",
         "fcmge  %p6/z %z23.s %z24.s -> %p10.s", "fcmge  %p7/z %z31.s %z31.s -> %p15.s",
     };
     TEST_LOOP(fcmge, fcmge_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmge  %p0/z %z0.d %z0.d -> %p0.d",    "fcmge  %p2/z %z7.d %z8.d -> %p2.d",
         "fcmge  %p3/z %z12.d %z13.d -> %p5.d",  "fcmge  %p5/z %z18.d %z19.d -> %p8.d",
         "fcmge  %p6/z %z23.d %z24.d -> %p10.d", "fcmge  %p7/z %z31.d %z31.d -> %p15.d",
     };
     TEST_LOOP(fcmge, fcmge_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmgt_sve_zero_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMGT   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, #0.0 */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmgt  %p0/z %z0.h $0.000000 -> %p0.h",
         "fcmgt  %p2/z %z7.h $0.000000 -> %p2.h",
@@ -4130,16 +2669,10 @@ TEST_INSTR(fcmgt_sve_zero_pred)
         "fcmgt  %p7/z %z31.h $0.000000 -> %p15.h",
     };
     TEST_LOOP(fcmgt, fcmgt_sve_zero_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmgt  %p0/z %z0.s $0.000000 -> %p0.s",
         "fcmgt  %p2/z %z7.s $0.000000 -> %p2.s",
@@ -4149,16 +2682,10 @@ TEST_INSTR(fcmgt_sve_zero_pred)
         "fcmgt  %p7/z %z31.s $0.000000 -> %p15.s",
     };
     TEST_LOOP(fcmgt, fcmgt_sve_zero_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmgt  %p0/z %z0.d $0.000000 -> %p0.d",
         "fcmgt  %p2/z %z7.d $0.000000 -> %p2.d",
@@ -4168,93 +2695,51 @@ TEST_INSTR(fcmgt_sve_zero_pred)
         "fcmgt  %p7/z %z31.d $0.000000 -> %p15.d",
     };
     TEST_LOOP(fcmgt, fcmgt_sve_zero_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmgt_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMGT   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmgt  %p0/z %z0.h %z0.h -> %p0.h",    "fcmgt  %p2/z %z7.h %z8.h -> %p2.h",
         "fcmgt  %p3/z %z12.h %z13.h -> %p5.h",  "fcmgt  %p5/z %z18.h %z19.h -> %p8.h",
         "fcmgt  %p6/z %z23.h %z24.h -> %p10.h", "fcmgt  %p7/z %z31.h %z31.h -> %p15.h",
     };
     TEST_LOOP(fcmgt, fcmgt_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmgt  %p0/z %z0.s %z0.s -> %p0.s",    "fcmgt  %p2/z %z7.s %z8.s -> %p2.s",
         "fcmgt  %p3/z %z12.s %z13.s -> %p5.s",  "fcmgt  %p5/z %z18.s %z19.s -> %p8.s",
         "fcmgt  %p6/z %z23.s %z24.s -> %p10.s", "fcmgt  %p7/z %z31.s %z31.s -> %p15.s",
     };
     TEST_LOOP(fcmgt, fcmgt_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmgt  %p0/z %z0.d %z0.d -> %p0.d",    "fcmgt  %p2/z %z7.d %z8.d -> %p2.d",
         "fcmgt  %p3/z %z12.d %z13.d -> %p5.d",  "fcmgt  %p5/z %z18.d %z19.d -> %p8.d",
         "fcmgt  %p6/z %z23.d %z24.d -> %p10.d", "fcmgt  %p7/z %z31.d %z31.d -> %p15.d",
     };
     TEST_LOOP(fcmgt, fcmgt_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmle_sve_zero_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMLE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, #0.0 */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmle  %p0/z %z0.h $0.000000 -> %p0.h",
         "fcmle  %p2/z %z7.h $0.000000 -> %p2.h",
@@ -4264,16 +2749,10 @@ TEST_INSTR(fcmle_sve_zero_pred)
         "fcmle  %p7/z %z31.h $0.000000 -> %p15.h",
     };
     TEST_LOOP(fcmle, fcmle_sve_zero_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmle  %p0/z %z0.s $0.000000 -> %p0.s",
         "fcmle  %p2/z %z7.s $0.000000 -> %p2.s",
@@ -4283,16 +2762,10 @@ TEST_INSTR(fcmle_sve_zero_pred)
         "fcmle  %p7/z %z31.s $0.000000 -> %p15.s",
     };
     TEST_LOOP(fcmle, fcmle_sve_zero_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmle  %p0/z %z0.d $0.000000 -> %p0.d",
         "fcmle  %p2/z %z7.d $0.000000 -> %p2.d",
@@ -4302,26 +2775,14 @@ TEST_INSTR(fcmle_sve_zero_pred)
         "fcmle  %p7/z %z31.d $0.000000 -> %p15.d",
     };
     TEST_LOOP(fcmle, fcmle_sve_zero_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmlt_sve_zero_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMLT   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, #0.0 */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmlt  %p0/z %z0.h $0.000000 -> %p0.h",
         "fcmlt  %p2/z %z7.h $0.000000 -> %p2.h",
@@ -4331,16 +2792,10 @@ TEST_INSTR(fcmlt_sve_zero_pred)
         "fcmlt  %p7/z %z31.h $0.000000 -> %p15.h",
     };
     TEST_LOOP(fcmlt, fcmlt_sve_zero_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmlt  %p0/z %z0.s $0.000000 -> %p0.s",
         "fcmlt  %p2/z %z7.s $0.000000 -> %p2.s",
@@ -4350,16 +2805,10 @@ TEST_INSTR(fcmlt_sve_zero_pred)
         "fcmlt  %p7/z %z31.s $0.000000 -> %p15.s",
     };
     TEST_LOOP(fcmlt, fcmlt_sve_zero_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmlt  %p0/z %z0.d $0.000000 -> %p0.d",
         "fcmlt  %p2/z %z7.d $0.000000 -> %p2.d",
@@ -4369,26 +2818,14 @@ TEST_INSTR(fcmlt_sve_zero_pred)
         "fcmlt  %p7/z %z31.d $0.000000 -> %p15.d",
     };
     TEST_LOOP(fcmlt, fcmlt_sve_zero_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmne_sve_zero_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMNE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, #0.0 */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmne  %p0/z %z0.h $0.000000 -> %p0.h",
         "fcmne  %p2/z %z7.h $0.000000 -> %p2.h",
@@ -4398,16 +2835,10 @@ TEST_INSTR(fcmne_sve_zero_pred)
         "fcmne  %p7/z %z31.h $0.000000 -> %p15.h",
     };
     TEST_LOOP(fcmne, fcmne_sve_zero_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmne  %p0/z %z0.s $0.000000 -> %p0.s",
         "fcmne  %p2/z %z7.s $0.000000 -> %p2.s",
@@ -4417,16 +2848,10 @@ TEST_INSTR(fcmne_sve_zero_pred)
         "fcmne  %p7/z %z31.s $0.000000 -> %p15.s",
     };
     TEST_LOOP(fcmne, fcmne_sve_zero_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmne  %p0/z %z0.d $0.000000 -> %p0.d",
         "fcmne  %p2/z %z7.d $0.000000 -> %p2.d",
@@ -4436,145 +2861,83 @@ TEST_INSTR(fcmne_sve_zero_pred)
         "fcmne  %p7/z %z31.d $0.000000 -> %p15.d",
     };
     TEST_LOOP(fcmne, fcmne_sve_zero_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmne_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMNE   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmne  %p0/z %z0.h %z0.h -> %p0.h",    "fcmne  %p2/z %z7.h %z8.h -> %p2.h",
         "fcmne  %p3/z %z12.h %z13.h -> %p5.h",  "fcmne  %p5/z %z18.h %z19.h -> %p8.h",
         "fcmne  %p6/z %z23.h %z24.h -> %p10.h", "fcmne  %p7/z %z31.h %z31.h -> %p15.h",
     };
     TEST_LOOP(fcmne, fcmne_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmne  %p0/z %z0.s %z0.s -> %p0.s",    "fcmne  %p2/z %z7.s %z8.s -> %p2.s",
         "fcmne  %p3/z %z12.s %z13.s -> %p5.s",  "fcmne  %p5/z %z18.s %z19.s -> %p8.s",
         "fcmne  %p6/z %z23.s %z24.s -> %p10.s", "fcmne  %p7/z %z31.s %z31.s -> %p15.s",
     };
     TEST_LOOP(fcmne, fcmne_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmne  %p0/z %z0.d %z0.d -> %p0.d",    "fcmne  %p2/z %z7.d %z8.d -> %p2.d",
         "fcmne  %p3/z %z12.d %z13.d -> %p5.d",  "fcmne  %p5/z %z18.d %z19.d -> %p8.d",
         "fcmne  %p6/z %z23.d %z24.d -> %p10.d", "fcmne  %p7/z %z31.d %z31.d -> %p15.d",
     };
     TEST_LOOP(fcmne, fcmne_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 TEST_INSTR(fcmuo_sve_pred)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
-
     /* Testing FCMUO   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
-    reg_id_t Pd_0_0[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_0[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_0[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_0[6] = {
         "fcmuo  %p0/z %z0.h %z0.h -> %p0.h",    "fcmuo  %p2/z %z7.h %z8.h -> %p2.h",
         "fcmuo  %p3/z %z12.h %z13.h -> %p5.h",  "fcmuo  %p5/z %z18.h %z19.h -> %p8.h",
         "fcmuo  %p6/z %z23.h %z24.h -> %p10.h", "fcmuo  %p7/z %z31.h %z31.h -> %p15.h",
     };
     TEST_LOOP(fcmuo, fcmuo_sve_pred, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Pd_0_0[i], OPSZ_2),
-              opnd_create_predicate_reg(Pg_0_0[i], false),
-              opnd_create_reg_element_vector(Zn_0_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    reg_id_t Pd_0_1[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_1[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_1[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_1[6] = {
         "fcmuo  %p0/z %z0.s %z0.s -> %p0.s",    "fcmuo  %p2/z %z7.s %z8.s -> %p2.s",
         "fcmuo  %p3/z %z12.s %z13.s -> %p5.s",  "fcmuo  %p5/z %z18.s %z19.s -> %p8.s",
         "fcmuo  %p6/z %z23.s %z24.s -> %p10.s", "fcmuo  %p7/z %z31.s %z31.s -> %p15.s",
     };
     TEST_LOOP(fcmuo, fcmuo_sve_pred, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Pd_0_1[i], OPSZ_4),
-              opnd_create_predicate_reg(Pg_0_1[i], false),
-              opnd_create_reg_element_vector(Zn_0_1[i], OPSZ_4),
-              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4));
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    reg_id_t Pd_0_2[6] = { DR_REG_P0, DR_REG_P2,  DR_REG_P5,
-                           DR_REG_P8, DR_REG_P10, DR_REG_P15 };
-    reg_id_t Pg_0_2[6] = { DR_REG_P0, DR_REG_P2, DR_REG_P3,
-                           DR_REG_P5, DR_REG_P6, DR_REG_P7 };
-    reg_id_t Zn_0_2[6] = { DR_REG_Z0,  DR_REG_Z7,  DR_REG_Z12,
-                           DR_REG_Z18, DR_REG_Z23, DR_REG_Z31 };
-    reg_id_t Zm_0_2[6] = { DR_REG_Z0,  DR_REG_Z8,  DR_REG_Z13,
-                           DR_REG_Z19, DR_REG_Z24, DR_REG_Z31 };
     const char *expected_0_2[6] = {
         "fcmuo  %p0/z %z0.d %z0.d -> %p0.d",    "fcmuo  %p2/z %z7.d %z8.d -> %p2.d",
         "fcmuo  %p3/z %z12.d %z13.d -> %p5.d",  "fcmuo  %p5/z %z18.d %z19.d -> %p8.d",
         "fcmuo  %p6/z %z23.d %z24.d -> %p10.d", "fcmuo  %p7/z %z31.d %z31.d -> %p15.d",
     };
     TEST_LOOP(fcmuo, fcmuo_sve_pred, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Pd_0_2[i], OPSZ_8),
-              opnd_create_predicate_reg(Pg_0_2[i], false),
-              opnd_create_reg_element_vector(Zn_0_2[i], OPSZ_8),
-              opnd_create_reg_element_vector(Zm_0_2[i], OPSZ_8));
-
-    return success;
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
 
 int
@@ -4587,6 +2950,7 @@ main(int argc, char *argv[])
 #endif
     bool result = true;
     bool test_result;
+    instr_t *instr;
 
     RUN_INSTR_TEST(add_sve_pred);
     RUN_INSTR_TEST(add_sve_shift);

--- a/suite/tests/api/ir_aarch64_v81.c
+++ b/suite/tests/api/ir_aarch64_v81.c
@@ -50,9 +50,6 @@
 
 TEST_INSTR(sqrdmlsh_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     opnd_t elsz;
     reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -69,7 +66,7 @@ TEST_INSTR(sqrdmlsh_vector)
                                              opnd_create_reg(Rn_0[i]),
                                              opnd_create_reg(Rm_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     reg_id_t Rd_1[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -86,7 +83,7 @@ TEST_INSTR(sqrdmlsh_vector)
                                              opnd_create_reg(Rn_1[i]),
                                              opnd_create_reg(Rm_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     reg_id_t Rd_2[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -103,7 +100,7 @@ TEST_INSTR(sqrdmlsh_vector)
                                              opnd_create_reg(Rn_2[i]),
                                              opnd_create_reg(Rm_2[i]), elsz);
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
 
     reg_id_t Rd_3[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -120,17 +117,13 @@ TEST_INSTR(sqrdmlsh_vector)
                                              opnd_create_reg(Rn_3[i]),
                                              opnd_create_reg(Rm_3[i]), elsz);
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_3[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(sqrdmlsh_scalar_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     opnd_t elsz;
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -148,7 +141,7 @@ TEST_INSTR(sqrdmlsh_scalar_idx)
             dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
             opnd_create_reg(Rm_0[i]), opnd_create_immed_uint(index_0[i], OPSZ_0), elsz);
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     reg_id_t Rd_1[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -166,17 +159,13 @@ TEST_INSTR(sqrdmlsh_scalar_idx)
             dc, opnd_create_reg(Rd_1[i]), opnd_create_reg(Rn_1[i]),
             opnd_create_reg(Rm_1[i]), opnd_create_immed_uint(index_1[i], OPSZ_0), elsz);
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(sqrdmlsh_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
     reg_id_t Rn_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -191,7 +180,7 @@ TEST_INSTR(sqrdmlsh_scalar)
                                              opnd_create_reg(Rn_0[i]),
                                              opnd_create_reg(Rm_0[i]));
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     reg_id_t Rd_1[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -207,17 +196,13 @@ TEST_INSTR(sqrdmlsh_scalar)
                                              opnd_create_reg(Rn_1[i]),
                                              opnd_create_reg(Rm_1[i]));
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(ldlar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing LDLAR   <Wt>, [<Xn|SP>] */
     reg_id_t Rt_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -232,7 +217,7 @@ TEST_INSTR(ldlar)
             dc, opnd_create_reg(Rt_0_0[i]),
             opnd_create_base_disp(Rn_0_0[i], DR_REG_NULL, 0, 0, OPSZ_4));
         if (!test_instr_encoding(dc, OP_ldlar, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing LDLAR   <Xt>, [<Xn|SP>] */
@@ -248,17 +233,13 @@ TEST_INSTR(ldlar)
             dc, opnd_create_reg(Rt_1_0[i]),
             opnd_create_base_disp(Rn_1_0[i], DR_REG_NULL, 0, 0, OPSZ_8));
         if (!test_instr_encoding(dc, OP_ldlar, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(ldlarb)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing LDLARB  <Wt>, [<Xn|SP>] */
     reg_id_t Rt_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -273,17 +254,13 @@ TEST_INSTR(ldlarb)
             dc, opnd_create_reg(Rt_0_0[i]),
             opnd_create_base_disp(Rn_0_0[i], DR_REG_NULL, 0, 0, OPSZ_1));
         if (!test_instr_encoding(dc, OP_ldlarb, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(ldlarh)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing LDLARH  <Wt>, [<Xn|SP>] */
     reg_id_t Rt_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -298,17 +275,13 @@ TEST_INSTR(ldlarh)
             dc, opnd_create_reg(Rt_0_0[i]),
             opnd_create_base_disp(Rn_0_0[i], DR_REG_NULL, 0, 0, OPSZ_2));
         if (!test_instr_encoding(dc, OP_ldlarh, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(stllr)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing STLLR   <Wt>, [<Xn|SP>] */
     reg_id_t Rt_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -323,7 +296,7 @@ TEST_INSTR(stllr)
             dc, opnd_create_reg(Rt_0_0[i]),
             opnd_create_base_disp(Rn_0_0[i], DR_REG_NULL, 0, 0, OPSZ_4));
         if (!test_instr_encoding(dc, OP_stllr, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing STLLR   <Xt>, [<Xn|SP>] */
@@ -339,17 +312,13 @@ TEST_INSTR(stllr)
             dc, opnd_create_reg(Rt_1_0[i]),
             opnd_create_base_disp(Rn_1_0[i], DR_REG_NULL, 0, 0, OPSZ_8));
         if (!test_instr_encoding(dc, OP_stllr, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(stllrb)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing STLLRB  <Wt>, [<Xn|SP>] */
     reg_id_t Rt_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -364,17 +333,13 @@ TEST_INSTR(stllrb)
             dc, opnd_create_reg(Rt_0_0[i]),
             opnd_create_base_disp(Rn_0_0[i], DR_REG_NULL, 0, 0, OPSZ_1));
         if (!test_instr_encoding(dc, OP_stllrb, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 TEST_INSTR(stllrh)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing STLLRH  <Wt>, [<Xn|SP>] */
     reg_id_t Rt_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -389,10 +354,9 @@ TEST_INSTR(stllrh)
             dc, opnd_create_reg(Rt_0_0[i]),
             opnd_create_base_disp(Rn_0_0[i], DR_REG_NULL, 0, 0, OPSZ_2));
         if (!test_instr_encoding(dc, OP_stllrh, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
-    return success;
 }
 
 int
@@ -405,6 +369,7 @@ main(int argc, char *argv[])
 #endif
     bool result = true;
     bool test_result;
+    instr_t *instr;
 
     RUN_INSTR_TEST(sqrdmlsh_scalar);
     RUN_INSTR_TEST(sqrdmlsh_scalar_idx);

--- a/suite/tests/api/ir_aarch64_v81.c
+++ b/suite/tests/api/ir_aarch64_v81.c
@@ -119,7 +119,6 @@ TEST_INSTR(sqrdmlsh_vector)
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_3[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(sqrdmlsh_scalar_idx)
@@ -161,7 +160,6 @@ TEST_INSTR(sqrdmlsh_scalar_idx)
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_1[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(sqrdmlsh_scalar)
@@ -198,7 +196,6 @@ TEST_INSTR(sqrdmlsh_scalar)
         if (!test_instr_encoding(dc, OP_sqrdmlsh, instr, expected_1[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(ldlar)
@@ -235,7 +232,6 @@ TEST_INSTR(ldlar)
         if (!test_instr_encoding(dc, OP_ldlar, instr, expected_1_0[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(ldlarb)
@@ -256,7 +252,6 @@ TEST_INSTR(ldlarb)
         if (!test_instr_encoding(dc, OP_ldlarb, instr, expected_0_0[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(ldlarh)
@@ -277,7 +272,6 @@ TEST_INSTR(ldlarh)
         if (!test_instr_encoding(dc, OP_ldlarh, instr, expected_0_0[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(stllr)
@@ -314,7 +308,6 @@ TEST_INSTR(stllr)
         if (!test_instr_encoding(dc, OP_stllr, instr, expected_1_0[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(stllrb)
@@ -335,7 +328,6 @@ TEST_INSTR(stllrb)
         if (!test_instr_encoding(dc, OP_stllrb, instr, expected_0_0[i]))
             *psuccess = false;
     }
-
 }
 
 TEST_INSTR(stllrh)
@@ -356,7 +348,6 @@ TEST_INSTR(stllrh)
         if (!test_instr_encoding(dc, OP_stllrh, instr, expected_0_0[i]))
             *psuccess = false;
     }
-
 }
 
 int

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -54,9 +54,6 @@
 
 TEST_INSTR(fcvtas_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTAS  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -72,7 +69,7 @@ TEST_INSTR(fcvtas_vector)
         instr = INSTR_CREATE_fcvtas_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtas, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTAS  <Vd>.4H, <Vn>.4H */
@@ -88,17 +85,12 @@ TEST_INSTR(fcvtas_vector)
         instr = INSTR_CREATE_fcvtas_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtas, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtas_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTAS  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -112,7 +104,7 @@ TEST_INSTR(fcvtas_scalar)
         instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtas, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTAS  <Xd>, <Hn> */
@@ -126,7 +118,7 @@ TEST_INSTR(fcvtas_scalar)
         instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtas, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTAS  <Hd>, <Hn> */
@@ -140,10 +132,8 @@ TEST_INSTR(fcvtas_scalar)
         instr = INSTR_CREATE_fcvtas_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtas, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -152,9 +142,6 @@ TEST_INSTR(fcvtas_scalar)
 
 TEST_INSTR(fcvtau_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTAU  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -170,7 +157,7 @@ TEST_INSTR(fcvtau_vector)
         instr = INSTR_CREATE_fcvtau_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtau, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTAU  <Vd>.4H, <Vn>.4H */
@@ -186,17 +173,12 @@ TEST_INSTR(fcvtau_vector)
         instr = INSTR_CREATE_fcvtau_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtau, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtau_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTAU  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -210,7 +192,7 @@ TEST_INSTR(fcvtau_scalar)
         instr = INSTR_CREATE_fcvtau_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtau, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTAU  <Xd>, <Hn> */
@@ -224,7 +206,7 @@ TEST_INSTR(fcvtau_scalar)
         instr = INSTR_CREATE_fcvtau_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtau, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTAU  <Hd>, <Hn> */
@@ -238,10 +220,8 @@ TEST_INSTR(fcvtau_scalar)
         instr = INSTR_CREATE_fcvtau_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtau, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -250,9 +230,6 @@ TEST_INSTR(fcvtau_scalar)
 
 TEST_INSTR(fcvtms_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTMS  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -268,7 +245,7 @@ TEST_INSTR(fcvtms_vector)
         instr = INSTR_CREATE_fcvtms_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtms, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTMS  <Vd>.4H, <Vn>.4H */
@@ -284,17 +261,12 @@ TEST_INSTR(fcvtms_vector)
         instr = INSTR_CREATE_fcvtms_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtms, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtms_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTMS  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -308,7 +280,7 @@ TEST_INSTR(fcvtms_scalar)
         instr = INSTR_CREATE_fcvtms_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtms, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTMS  <Xd>, <Hn> */
@@ -322,7 +294,7 @@ TEST_INSTR(fcvtms_scalar)
         instr = INSTR_CREATE_fcvtms_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtms, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTMS  <Hd>, <Hn> */
@@ -336,10 +308,8 @@ TEST_INSTR(fcvtms_scalar)
         instr = INSTR_CREATE_fcvtms_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtms, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -348,9 +318,6 @@ TEST_INSTR(fcvtms_scalar)
 
 TEST_INSTR(fcvtmu_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTMU  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -366,7 +333,7 @@ TEST_INSTR(fcvtmu_vector)
         instr = INSTR_CREATE_fcvtmu_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTMU  <Vd>.4H, <Vn>.4H */
@@ -382,17 +349,12 @@ TEST_INSTR(fcvtmu_vector)
         instr = INSTR_CREATE_fcvtmu_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtmu_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTMU  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -406,7 +368,7 @@ TEST_INSTR(fcvtmu_scalar)
         instr = INSTR_CREATE_fcvtmu_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTMU  <Xd>, <Hn> */
@@ -420,7 +382,7 @@ TEST_INSTR(fcvtmu_scalar)
         instr = INSTR_CREATE_fcvtmu_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTMU  <Hd>, <Hn> */
@@ -434,10 +396,8 @@ TEST_INSTR(fcvtmu_scalar)
         instr = INSTR_CREATE_fcvtmu_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtmu, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -446,9 +406,6 @@ TEST_INSTR(fcvtmu_scalar)
 
 TEST_INSTR(fcvtns_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTNS  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -464,7 +421,7 @@ TEST_INSTR(fcvtns_vector)
         instr = INSTR_CREATE_fcvtns_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtns, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTNS  <Vd>.4H, <Vn>.4H */
@@ -480,17 +437,12 @@ TEST_INSTR(fcvtns_vector)
         instr = INSTR_CREATE_fcvtns_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtns, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtns_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTNS  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -504,7 +456,7 @@ TEST_INSTR(fcvtns_scalar)
         instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtns, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTNS  <Xd>, <Hn> */
@@ -518,7 +470,7 @@ TEST_INSTR(fcvtns_scalar)
         instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtns, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTNS  <Hd>, <Hn> */
@@ -532,10 +484,8 @@ TEST_INSTR(fcvtns_scalar)
         instr = INSTR_CREATE_fcvtns_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtns, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -544,9 +494,6 @@ TEST_INSTR(fcvtns_scalar)
 
 TEST_INSTR(fcvtnu_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTNU  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -562,7 +509,7 @@ TEST_INSTR(fcvtnu_vector)
         instr = INSTR_CREATE_fcvtnu_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTNU  <Vd>.4H, <Vn>.4H */
@@ -578,17 +525,12 @@ TEST_INSTR(fcvtnu_vector)
         instr = INSTR_CREATE_fcvtnu_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtnu_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTNU  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -602,7 +544,7 @@ TEST_INSTR(fcvtnu_scalar)
         instr = INSTR_CREATE_fcvtnu_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTNU  <Xd>, <Hn> */
@@ -616,7 +558,7 @@ TEST_INSTR(fcvtnu_scalar)
         instr = INSTR_CREATE_fcvtnu_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTNU  <Hd>, <Hn> */
@@ -630,10 +572,8 @@ TEST_INSTR(fcvtnu_scalar)
         instr = INSTR_CREATE_fcvtnu_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtnu, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -642,9 +582,6 @@ TEST_INSTR(fcvtnu_scalar)
 
 TEST_INSTR(fcvtps_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTPS  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -660,7 +597,7 @@ TEST_INSTR(fcvtps_vector)
         instr = INSTR_CREATE_fcvtps_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtps, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTPS  <Vd>.4H, <Vn>.4H */
@@ -676,17 +613,12 @@ TEST_INSTR(fcvtps_vector)
         instr = INSTR_CREATE_fcvtps_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtps, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtps_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTPS  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -700,7 +632,7 @@ TEST_INSTR(fcvtps_scalar)
         instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtps, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTPS  <Xd>, <Hn> */
@@ -714,7 +646,7 @@ TEST_INSTR(fcvtps_scalar)
         instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtps, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTPS  <Hd>, <Hn> */
@@ -728,10 +660,8 @@ TEST_INSTR(fcvtps_scalar)
         instr = INSTR_CREATE_fcvtps_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtps, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -740,9 +670,6 @@ TEST_INSTR(fcvtps_scalar)
 
 TEST_INSTR(fcvtpu_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTPU  <Vd>.8H, <Vn>.8H */
     opnd_t elsz;
@@ -758,7 +685,7 @@ TEST_INSTR(fcvtpu_vector)
         instr = INSTR_CREATE_fcvtpu_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtpu, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTPU  <Vd>.4H, <Vn>.4H */
@@ -774,17 +701,12 @@ TEST_INSTR(fcvtpu_vector)
         instr = INSTR_CREATE_fcvtpu_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_fcvtpu, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fcvtpu_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FCVTPU  <Wd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -798,7 +720,7 @@ TEST_INSTR(fcvtpu_scalar)
         instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtpu, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTPU  <Xd>, <Hn> */
@@ -812,7 +734,7 @@ TEST_INSTR(fcvtpu_scalar)
         instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtpu, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FCVTPU  <Hd>, <Hn> */
@@ -826,10 +748,8 @@ TEST_INSTR(fcvtpu_scalar)
         instr = INSTR_CREATE_fcvtpu_scalar(dc, opnd_create_reg(Rd_2[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtpu, instr, expected_2[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -838,9 +758,6 @@ TEST_INSTR(fcvtpu_scalar)
 
 TEST_INSTR(fcvtzs_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCVTZS  <Hd>.<Ts>, <Hn>.<Ts> */
 
@@ -857,7 +774,7 @@ TEST_INSTR(fcvtzs_vector)
         instr = INSTR_CREATE_fcvtzs_vector(dc, opnd_create_reg(Rd_0_0[i]),
                                            opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZS  <Hd>.8H, <Hn>.8H */
@@ -873,16 +790,11 @@ TEST_INSTR(fcvtzs_vector)
         instr = INSTR_CREATE_fcvtzs_vector(dc, opnd_create_reg(Rd_0_1[i]),
                                            opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_0_1[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(fcvtzs_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCVTZS  <Wd>, <Hn> */
     reg_id_t Rd_1_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -896,7 +808,7 @@ TEST_INSTR(fcvtzs_scalar)
         instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(Rd_1_0[i]),
                                            opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZS  <Xd>, <Hn> */
@@ -911,7 +823,7 @@ TEST_INSTR(fcvtzs_scalar)
         instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(Rd_4_0[i]),
                                            opnd_create_reg(Rn_4_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_4_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZS  <Wd>, <Hn>, #<fbits> */
@@ -928,7 +840,7 @@ TEST_INSTR(fcvtzs_scalar)
             dc, opnd_create_reg(Rd_10_0[i]), opnd_create_reg(Rn_10_0[i]),
             opnd_create_immed_uint(scale_10_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_10_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZS  <Xd>, <Hn>, #<fbits> */
@@ -945,7 +857,7 @@ TEST_INSTR(fcvtzs_scalar)
             dc, opnd_create_reg(Rd_11_0[i]), opnd_create_reg(Rn_11_0[i]),
             opnd_create_immed_uint(scale_11_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_11_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZS  <Hd>, <Hn> */
@@ -960,10 +872,8 @@ TEST_INSTR(fcvtzs_scalar)
         instr = INSTR_CREATE_fcvtzs_scalar(dc, opnd_create_reg(Rd_12_0[i]),
                                            opnd_create_reg(Rn_12_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_12_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 /*
  * FCVTZU
@@ -971,9 +881,6 @@ TEST_INSTR(fcvtzs_scalar)
 
 TEST_INSTR(fcvtzu_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCVTZU  <Hd>.<Ts>, <Hn>.<Ts> */
 
@@ -990,7 +897,7 @@ TEST_INSTR(fcvtzu_vector)
         instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(Rd_0_0[i]),
                                            opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZU  <Hd>.8H, <Hn>.8H */
@@ -1006,16 +913,11 @@ TEST_INSTR(fcvtzu_vector)
         instr = INSTR_CREATE_fcvtzu_vector(dc, opnd_create_reg(Rd_0_1[i]),
                                            opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_0_1[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(fcvtzu_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCVTZU  <Wd>, <Hn> */
     reg_id_t Rd_1_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -1029,7 +931,7 @@ TEST_INSTR(fcvtzu_scalar)
         instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(Rd_1_0[i]),
                                            opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZU  <Xd>, <Hn> */
@@ -1044,7 +946,7 @@ TEST_INSTR(fcvtzu_scalar)
         instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(Rd_4_0[i]),
                                            opnd_create_reg(Rn_4_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_4_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZU  <Wd>, <Hn>, #<fbits> */
@@ -1061,7 +963,7 @@ TEST_INSTR(fcvtzu_scalar)
             dc, opnd_create_reg(Rd_10_0[i]), opnd_create_reg(Rn_10_0[i]),
             opnd_create_immed_uint(scale_10_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_10_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZU  <Xd>, <Hn>, #<fbits> */
@@ -1078,7 +980,7 @@ TEST_INSTR(fcvtzu_scalar)
             dc, opnd_create_reg(Rd_11_0[i]), opnd_create_reg(Rn_11_0[i]),
             opnd_create_immed_uint(scale_11_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_11_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCVTZU  <Hd>, <Hn> */
@@ -1093,10 +995,8 @@ TEST_INSTR(fcvtzu_scalar)
         instr = INSTR_CREATE_fcvtzu_scalar(dc, opnd_create_reg(Rd_12_0[i]),
                                            opnd_create_reg(Rn_12_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_12_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 /*
  * FRINTA
@@ -1104,9 +1004,6 @@ TEST_INSTR(fcvtzu_scalar)
 
 TEST_INSTR(frinta_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTA  <Hd>.8H, <Hn>.8H */
     opnd_t elsz;
@@ -1122,7 +1019,7 @@ TEST_INSTR(frinta_vector)
         instr = INSTR_CREATE_frinta_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_frinta, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FRINTA  <Hd>.4H, <Hn>.4H */
@@ -1138,17 +1035,12 @@ TEST_INSTR(frinta_vector)
         instr = INSTR_CREATE_frinta_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_frinta, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(frinta_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTA  <Hd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -1162,10 +1054,8 @@ TEST_INSTR(frinta_scalar)
         instr = INSTR_CREATE_frinta_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_frinta, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -1174,9 +1064,6 @@ TEST_INSTR(frinta_scalar)
 
 TEST_INSTR(frinti_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTI  <Hd>.8H, <Hn>.8H */
     opnd_t elsz;
@@ -1192,7 +1079,7 @@ TEST_INSTR(frinti_vector)
         instr = INSTR_CREATE_frinti_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_frinti, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FRINTI  <Hd>.4H, <Hn>.4H */
@@ -1208,17 +1095,12 @@ TEST_INSTR(frinti_vector)
         instr = INSTR_CREATE_frinti_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_frinti, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(frinti_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTI  <Hd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -1232,10 +1114,8 @@ TEST_INSTR(frinti_scalar)
         instr = INSTR_CREATE_frinti_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_frinti, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -1244,9 +1124,6 @@ TEST_INSTR(frinti_scalar)
 
 TEST_INSTR(frintm_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTM  <Hd>.8H, <Hn>.8H */
     opnd_t elsz;
@@ -1262,7 +1139,7 @@ TEST_INSTR(frintm_vector)
         instr = INSTR_CREATE_frintm_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintm, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FRINTM  <Hd>.4H, <Hn>.4H */
@@ -1278,17 +1155,12 @@ TEST_INSTR(frintm_vector)
         instr = INSTR_CREATE_frintm_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintm, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(frintm_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTM  <Hd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -1302,10 +1174,8 @@ TEST_INSTR(frintm_scalar)
         instr = INSTR_CREATE_frintm_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_frintm, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -1314,9 +1184,6 @@ TEST_INSTR(frintm_scalar)
 
 TEST_INSTR(frintn_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTN  <Hd>.8H, <Hn>.8H */
     opnd_t elsz;
@@ -1332,7 +1199,7 @@ TEST_INSTR(frintn_vector)
         instr = INSTR_CREATE_frintn_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintn, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FRINTN  <Hd>.4H, <Hn>.4H */
@@ -1348,17 +1215,12 @@ TEST_INSTR(frintn_vector)
         instr = INSTR_CREATE_frintn_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintn, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(frintn_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTN  <Hd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -1372,10 +1234,8 @@ TEST_INSTR(frintn_scalar)
         instr = INSTR_CREATE_frintn_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_frintn, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -1384,9 +1244,6 @@ TEST_INSTR(frintn_scalar)
 
 TEST_INSTR(frintp_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTP  <Hd>.8H, <Hn>.8H */
     opnd_t elsz;
@@ -1402,7 +1259,7 @@ TEST_INSTR(frintp_vector)
         instr = INSTR_CREATE_frintp_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintp, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FRINTP  <Hd>.4H, <Hn>.4H */
@@ -1418,17 +1275,12 @@ TEST_INSTR(frintp_vector)
         instr = INSTR_CREATE_frintp_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintp, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(frintp_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTP  <Hd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -1442,10 +1294,8 @@ TEST_INSTR(frintp_scalar)
         instr = INSTR_CREATE_frintp_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_frintp, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -1454,9 +1304,6 @@ TEST_INSTR(frintp_scalar)
 
 TEST_INSTR(frintx_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTX  <Hd>.8H, <Hn>.8H */
     opnd_t elsz;
@@ -1472,7 +1319,7 @@ TEST_INSTR(frintx_vector)
         instr = INSTR_CREATE_frintx_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintx, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FRINTX  <Hd>.4H, <Hn>.4H */
@@ -1488,17 +1335,12 @@ TEST_INSTR(frintx_vector)
         instr = INSTR_CREATE_frintx_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintx, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(frintx_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTX  <Hd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -1512,10 +1354,8 @@ TEST_INSTR(frintx_scalar)
         instr = INSTR_CREATE_frintx_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_frintx, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -1524,9 +1364,6 @@ TEST_INSTR(frintx_scalar)
 
 TEST_INSTR(frintz_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTZ  <Hd>.8H, <Hn>.8H */
     opnd_t elsz;
@@ -1542,7 +1379,7 @@ TEST_INSTR(frintz_vector)
         instr = INSTR_CREATE_frintz_vector(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintz, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* FRINTZ  <Hd>.4H, <Hn>.4H */
@@ -1558,17 +1395,12 @@ TEST_INSTR(frintz_vector)
         instr = INSTR_CREATE_frintz_vector(dc, opnd_create_reg(Rd_1[i]),
                                            opnd_create_reg(Rn_1[i]), elsz);
         if (!test_instr_encoding(dc, OP_frintz, instr, expected_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(frintz_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FRINTZ  <Hd>, <Hn> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -1582,10 +1414,8 @@ TEST_INSTR(frintz_scalar)
         instr = INSTR_CREATE_frintz_scalar(dc, opnd_create_reg(Rd_0[i]),
                                            opnd_create_reg(Rn_0[i]));
         if (!test_instr_encoding(dc, OP_frintz, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 /*
@@ -1594,9 +1424,6 @@ TEST_INSTR(frintz_scalar)
 
 TEST_INSTR(fmlal_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMLAL   <Sd>.<Ts>, <Hn>.<Tb>, <Hm>.<Tb> */
     reg_id_t Rd_0_0[6] = { DR_REG_D0,  DR_REG_D5,  DR_REG_D10,
@@ -1626,15 +1453,10 @@ TEST_INSTR(fmlal_vector)
     };
     TEST_LOOP(fmlal, fmlal_vector, 6, expected_0_1[i], opnd_create_reg(Rd_0_1[i]),
               opnd_create_reg(Rn_0_1[i]), opnd_create_reg(Rm_0_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fmlal_vector_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMLAL   <Sd>.<Ts>, <Hn>.<Tb>, <Hm>.H[<index>] */
     reg_id_t Rd_0_0[6] = { DR_REG_D0,  DR_REG_D5,  DR_REG_D10,
@@ -1674,15 +1496,10 @@ TEST_INSTR(fmlal_vector_idx)
     TEST_LOOP(fmlal, fmlal_vector_idx, 6, expected_0_1[i], opnd_create_reg(Rd_0_1[i]),
               opnd_create_reg(Rn_0_1[i]), opnd_create_reg(Rm_0_1[i]),
               opnd_create_immed_uint(index_0_1[i], OPSZ_0));
-
-    return success;
 }
 
 TEST_INSTR(fmlal2_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMLAL2  <Sd>.<Ts>, <Hn>.<Tb>, <Hm>.<Tb> */
     reg_id_t Rd_0_0[6] = { DR_REG_D0,  DR_REG_D5,  DR_REG_D10,
@@ -1712,15 +1529,10 @@ TEST_INSTR(fmlal2_vector)
     };
     TEST_LOOP(fmlal2, fmlal2_vector, 6, expected_0_1[i], opnd_create_reg(Rd_0_1[i]),
               opnd_create_reg(Rn_0_1[i]), opnd_create_reg(Rm_0_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fmlal2_vector_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMLAL2  <Sd>.<Ts>, <Hn>.<Tb>, <Hm>.H[<index>] */
     reg_id_t Rd_0_0[6] = { DR_REG_D0,  DR_REG_D5,  DR_REG_D10,
@@ -1760,8 +1572,6 @@ TEST_INSTR(fmlal2_vector_idx)
     TEST_LOOP(fmlal2, fmlal2_vector_idx, 6, expected_0_1[i], opnd_create_reg(Rd_0_1[i]),
               opnd_create_reg(Rn_0_1[i]), opnd_create_reg(Rm_0_1[i]),
               opnd_create_immed_uint(index_0_1[i], OPSZ_0));
-
-    return success;
 }
 
 /*
@@ -1770,9 +1580,6 @@ TEST_INSTR(fmlal2_vector_idx)
 
 TEST_INSTR(fmlsl_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FMLSL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb> */
 
@@ -1799,15 +1606,10 @@ TEST_INSTR(fmlsl_vector)
     };
     TEST_LOOP(fmlsl, fmlsl_vector, 3, expected_1[i], opnd_create_reg(Rd_1[i]),
               opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fmlsl_vector_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FMLSL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
     reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -1822,8 +1624,6 @@ TEST_INSTR(fmlsl_vector_idx)
     TEST_LOOP(fmlsl, fmlsl_vector_idx, 3, expected_0[i], opnd_create_reg(Rd_0[i]),
               opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]),
               OPND_CREATE_INT(index[i]));
-
-    return success;
 }
 
 /*
@@ -1832,9 +1632,6 @@ TEST_INSTR(fmlsl_vector_idx)
 
 TEST_INSTR(fmlsl2_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FMLSL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb> */
 
@@ -1861,15 +1658,10 @@ TEST_INSTR(fmlsl2_vector)
     };
     TEST_LOOP(fmlsl2, fmlsl2_vector, 3, expected_1[i], opnd_create_reg(Rd_1[i]),
               opnd_create_reg(Rn_1[i]), opnd_create_reg(Rm_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fmlsl2_vector_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* FMLSL2 <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.H[<index>] */
     reg_id_t Rd_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -1884,15 +1676,10 @@ TEST_INSTR(fmlsl2_vector_idx)
     TEST_LOOP(fmlsl2, fmlsl2_vector_idx, 3, expected_0[i], opnd_create_reg(Rd_0[i]),
               opnd_create_reg(Rn_0[i]), opnd_create_reg(Rm_0[i]),
               OPND_CREATE_INT(index[i]));
-
-    return success;
 }
 
 TEST_INSTR(sm3partw1_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM3PARTW1 <Sd>.4S, <Sn>.4S, <Sm>.4S */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -1909,17 +1696,12 @@ TEST_INSTR(sm3partw1_vector)
                                               opnd_create_reg(Rn_0_0[i]),
                                               opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sm3partw1, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm3partw2_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM3PARTW2 <Sd>.4S, <Sn>.4S, <Sm>.4S */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -1936,17 +1718,12 @@ TEST_INSTR(sm3partw2_vector)
                                               opnd_create_reg(Rn_0_0[i]),
                                               opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sm3partw2, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm3ss1_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM3SS1  <Sd>.4S, <Sn>.4S, <Sm>.4S, <Sa>.4S */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -1964,17 +1741,12 @@ TEST_INSTR(sm3ss1_vector)
             dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
             opnd_create_reg(Rm_0_0[i]), opnd_create_reg(Ra_0_0[i]), Ra_elsz);
         if (!test_instr_encoding(dc, OP_sm3ss1, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm3tt1a_vector_indexed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM3TT1A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -1993,17 +1765,12 @@ TEST_INSTR(sm3tt1a_vector_indexed)
             opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
             Rm_elsz);
         if (!test_instr_encoding(dc, OP_sm3tt1a, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm3tt1b_vector_indexed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM3TT1B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2022,17 +1789,12 @@ TEST_INSTR(sm3tt1b_vector_indexed)
             opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
             Rm_elsz);
         if (!test_instr_encoding(dc, OP_sm3tt1b, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm3tt2a_vector_indexed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM3TT2A <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2051,17 +1813,12 @@ TEST_INSTR(sm3tt2a_vector_indexed)
             opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
             Rm_elsz);
         if (!test_instr_encoding(dc, OP_sm3tt2a, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm3tt2b_vector_indexed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM3TT2B <Sd>.4S, <Sn>.4S, <Sm>.S[<index>] */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2080,17 +1837,12 @@ TEST_INSTR(sm3tt2b_vector_indexed)
             opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(imm2_0_0[i], OPSZ_0),
             Rm_elsz);
         if (!test_instr_encoding(dc, OP_sm3tt2b, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm4e_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM4E    <Sd>.4S, <Sn>.4S */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2105,17 +1857,12 @@ TEST_INSTR(sm4e_vector)
         instr = INSTR_CREATE_sm4e_vector(dc, opnd_create_reg(Rd_0_0[i]),
                                          opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_sm4e, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sm4ekey_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SM4EKEY <Sd>.4S, <Sn>.4S, <Sm>.4S */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2132,17 +1879,12 @@ TEST_INSTR(sm4ekey_vector)
                                             opnd_create_reg(Rn_0_0[i]),
                                             opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sm4ekey, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sha512h)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SHA512H <Qd>, <Qn>, <Dm>.2D */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2159,16 +1901,11 @@ TEST_INSTR(sha512h)
                                      opnd_create_reg(Rn_0_0[i]),
                                      opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sha512h, instr, expected_0_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(sha512h2)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SHA512H2 <Qd>, <Qn>, <Dm>.2D */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2185,16 +1922,11 @@ TEST_INSTR(sha512h2)
                                       opnd_create_reg(Rn_0_0[i]),
                                       opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sha512h2, instr, expected_0_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(sha512su0)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SHA512SU0 <Dd>.2D, <Dn>.2D */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2209,16 +1941,11 @@ TEST_INSTR(sha512su0)
         instr = INSTR_CREATE_sha512su0(dc, opnd_create_reg(Rd_0_0[i]),
                                        opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_sha512su0, instr, expected_0_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(sha512su1)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SHA512SU1 <Dd>.2D, <Dn>.2D, <Dm>.2D */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2235,16 +1962,11 @@ TEST_INSTR(sha512su1)
                                        opnd_create_reg(Rn_0_0[i]),
                                        opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sha512su1, instr, expected_0_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(bcax)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing BCAX    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2261,17 +1983,12 @@ TEST_INSTR(bcax)
             INSTR_CREATE_bcax(dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
                               opnd_create_reg(Rm_0_0[i]), opnd_create_reg(Ra_0_0[i]));
         if (!test_instr_encoding(dc, OP_bcax, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(eor3)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing EOR3    <Bd>.16B, <Bn>.16B, <Bm>.16B, <Ba>.16B */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2288,46 +2005,31 @@ TEST_INSTR(eor3)
             INSTR_CREATE_eor3(dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
                               opnd_create_reg(Rm_0_0[i]), opnd_create_reg(Ra_0_0[i]));
         if (!test_instr_encoding(dc, OP_eor3, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(esb)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing ESB      */
     const char *expected_0_0[1] = { "esb" };
     instr = INSTR_CREATE_esb(dc);
     if (!test_instr_encoding(dc, OP_esb, instr, expected_0_0[0]))
-        success = false;
-
-    return success;
+        *psuccess = false;
 }
 
 TEST_INSTR(psb)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing PSB      */
     const char *expected_0_0[1] = { "psb" };
     instr = INSTR_CREATE_psb_csync(dc);
     if (!test_instr_encoding(dc, OP_psb, instr, expected_0_0[0]))
-        success = false;
-    return success;
-}
+        *psuccess = false;}
 
 TEST_INSTR(fsqrt_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FSQRT   <Hd>.<Ts>, <Hn>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -2342,7 +2044,7 @@ TEST_INSTR(fsqrt_vector)
         instr = INSTR_CREATE_fsqrt_vector(dc, opnd_create_reg(Rd_0_0[i]),
                                           opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
     reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
@@ -2356,16 +2058,11 @@ TEST_INSTR(fsqrt_vector)
         instr = INSTR_CREATE_fsqrt_vector(dc, opnd_create_reg(Rd_0_1[i]),
                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_0_1[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(fsqrt_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FSQRT   <Hd>, <Hn> */
     reg_id_t Rd_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2379,16 +2076,11 @@ TEST_INSTR(fsqrt_scalar)
         instr = INSTR_CREATE_fsqrt_scalar(dc, opnd_create_reg(Rd_1_0[i]),
                                           opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_1_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(scvtf_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SCVTF   <Hd>.<Ts>, <Hn>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -2403,7 +2095,7 @@ TEST_INSTR(scvtf_vector)
         instr = INSTR_CREATE_scvtf_vector(dc, opnd_create_reg(Rd_0_0[i]),
                                           opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
     reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
@@ -2417,16 +2109,11 @@ TEST_INSTR(scvtf_vector)
         instr = INSTR_CREATE_scvtf_vector(dc, opnd_create_reg(Rd_0_1[i]),
                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0_1[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(scvtf_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SCVTF   <Hd>, <Wn> */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2440,7 +2127,7 @@ TEST_INSTR(scvtf_scalar)
         instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(Rd_0_0[i]),
                                           opnd_create_reg(Rn_0_0[i]));
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing SCVTF   <Hd>, <Xn> */
@@ -2455,16 +2142,11 @@ TEST_INSTR(scvtf_scalar)
         instr = INSTR_CREATE_scvtf_scalar(dc, opnd_create_reg(Rd_1_0[i]),
                                           opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_1_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(scvtf_scalar_fixed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SCVTF   <Hd>, <Wn>, #<imm> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2480,7 +2162,7 @@ TEST_INSTR(scvtf_scalar_fixed)
                                                 opnd_create_reg(Rn_0[i]),
                                                 OPND_CREATE_INT(scale_0[i]));
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing SCVTF   <Hd>, <Xn>, #<imm> */
@@ -2497,16 +2179,11 @@ TEST_INSTR(scvtf_scalar_fixed)
                                                 opnd_create_reg(Rn_1[i]),
                                                 OPND_CREATE_INT(scale_1[i]));
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_1[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(ucvtf_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing UCVTF   <Hd>.<Ts>, <Hn>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -2521,7 +2198,7 @@ TEST_INSTR(ucvtf_vector)
         instr = INSTR_CREATE_ucvtf_vector(dc, opnd_create_reg(Rd_0_0[i]),
                                           opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
     reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
@@ -2535,16 +2212,11 @@ TEST_INSTR(ucvtf_vector)
         instr = INSTR_CREATE_ucvtf_vector(dc, opnd_create_reg(Rd_0_1[i]),
                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0_1[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(ucvtf_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing UCVTF   <Hd>, <Wn> */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2558,7 +2230,7 @@ TEST_INSTR(ucvtf_scalar)
         instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(Rd_0_0[i]),
                                           opnd_create_reg(Rn_0_0[i]));
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing UCVTF   <Hd>, <Xn> */
@@ -2573,16 +2245,11 @@ TEST_INSTR(ucvtf_scalar)
         instr = INSTR_CREATE_ucvtf_scalar(dc, opnd_create_reg(Rd_1_0[i]),
                                           opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_1_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(ucvtf_scalar_fixed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing UCVTF   <Hd>, <Wn>, #<imm> */
     reg_id_t Rd_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2598,7 +2265,7 @@ TEST_INSTR(ucvtf_scalar_fixed)
                                                 opnd_create_reg(Rn_0[i]),
                                                 OPND_CREATE_INT(scale_0[i]));
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing UCVTF   <Hd>, <Xn>, #<imm> */
@@ -2615,16 +2282,11 @@ TEST_INSTR(ucvtf_scalar_fixed)
                                                 opnd_create_reg(Rn_1[i]),
                                                 OPND_CREATE_INT(scale_1[i]));
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_1[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(rax1)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing RAX1    <Dd>.2D, <Dn>.2D, <Dm>.2D */
     reg_id_t Rd_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2639,16 +2301,11 @@ TEST_INSTR(rax1)
         instr = INSTR_CREATE_rax1(dc, opnd_create_reg(Rd_0[i]), opnd_create_reg(Rn_0[i]),
                                   opnd_create_reg(Rm_0[i]));
         if (!test_instr_encoding(dc, OP_rax1, instr, expected_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(xar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing XAR     <Dd>.2D, <Dn>.2D, <Dm>.2D, #<imm> */
     reg_id_t Rd_0_0[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
@@ -2665,16 +2322,11 @@ TEST_INSTR(xar)
                                  opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
                                  opnd_create_immed_uint(imm6_0_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_xar, instr, expected_0_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(fccmp)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     /* Testing FCCMP   <Dn>, <Dm>, #<imm>, <cond> */
     reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
@@ -2690,7 +2342,7 @@ TEST_INSTR(fccmp)
             dc, opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
             opnd_create_immed_uint(nzcv_0_0[i], OPSZ_0), condition_code_0_0[i]);
         if (!test_instr_encoding(dc, OP_fccmp, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCCMP   <Hn>, <Hm>, #<imm>, <cond> */
     reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2707,7 +2359,7 @@ TEST_INSTR(fccmp)
             dc, opnd_create_reg(Rn_1_0[i]), opnd_create_reg(Rm_1_0[i]),
             opnd_create_immed_uint(nzcv_1_0[i], OPSZ_0), condition_code_1_0[i]);
         if (!test_instr_encoding(dc, OP_fccmp, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCCMP   <Sn>, <Sm>, #<imm>, <cond> */
     reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -2724,15 +2376,10 @@ TEST_INSTR(fccmp)
             dc, opnd_create_reg(Rn_2_0[i]), opnd_create_reg(Rm_2_0[i]),
             opnd_create_immed_uint(nzcv_2_0[i], OPSZ_0), condition_code_2_0[i]);
         if (!test_instr_encoding(dc, OP_fccmp, instr, expected_2_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 TEST_INSTR(fccmpe)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     /* Testing FCCMPE  <Dn>, <Dm>, #<imm>, <cond> */
     reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     reg_id_t Rm_0_0[3] = { DR_REG_D0, DR_REG_D11, DR_REG_D31 };
@@ -2748,7 +2395,7 @@ TEST_INSTR(fccmpe)
             dc, opnd_create_reg(Rn_0_0[i]), opnd_create_reg(Rm_0_0[i]),
             opnd_create_immed_uint(nzcv_0_0[i], OPSZ_0), condition_code_0_0[i]);
         if (!test_instr_encoding(dc, OP_fccmpe, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCCMPE  <Hn>, <Hm>, #<imm>, <cond> */
     reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2765,7 +2412,7 @@ TEST_INSTR(fccmpe)
             dc, opnd_create_reg(Rn_1_0[i]), opnd_create_reg(Rm_1_0[i]),
             opnd_create_immed_uint(nzcv_1_0[i], OPSZ_0), condition_code_1_0[i]);
         if (!test_instr_encoding(dc, OP_fccmpe, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCCMPE  <Sn>, <Sm>, #<imm>, <cond> */
     reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -2782,15 +2429,10 @@ TEST_INSTR(fccmpe)
             dc, opnd_create_reg(Rn_2_0[i]), opnd_create_reg(Rm_2_0[i]),
             opnd_create_immed_uint(nzcv_2_0[i], OPSZ_0), condition_code_2_0[i]);
         if (!test_instr_encoding(dc, OP_fccmpe, instr, expected_2_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 TEST_INSTR(fcmp)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     /* Testing FCMP    <Dn>, #0.0 */
     reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     const char *expected_0_0[3] = {
@@ -2801,7 +2443,7 @@ TEST_INSTR(fcmp)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fcmp_zero(dc, opnd_create_reg(Rn_0_0[i]));
         if (!test_instr_encoding(dc, OP_fcmp, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMP    <Hn>, #0.0 */
     reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2813,7 +2455,7 @@ TEST_INSTR(fcmp)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fcmp_zero(dc, opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_fcmp, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMP    <Sn>, #0.0 */
     reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -2825,7 +2467,7 @@ TEST_INSTR(fcmp)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fcmp_zero(dc, opnd_create_reg(Rn_2_0[i]));
         if (!test_instr_encoding(dc, OP_fcmp, instr, expected_2_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMP    <Dn>, <Dm> */
     reg_id_t Rn_3_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -2839,7 +2481,7 @@ TEST_INSTR(fcmp)
         instr =
             INSTR_CREATE_fcmp(dc, opnd_create_reg(Rn_3_0[i]), opnd_create_reg(Rm_3_0[i]));
         if (!test_instr_encoding(dc, OP_fcmp, instr, expected_3_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMP    <Hn>, <Hm> */
     reg_id_t Rn_4_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2853,7 +2495,7 @@ TEST_INSTR(fcmp)
         instr =
             INSTR_CREATE_fcmp(dc, opnd_create_reg(Rn_4_0[i]), opnd_create_reg(Rm_4_0[i]));
         if (!test_instr_encoding(dc, OP_fcmp, instr, expected_4_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMP    <Sn>, <Sm> */
     reg_id_t Rn_5_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -2867,15 +2509,10 @@ TEST_INSTR(fcmp)
         instr =
             INSTR_CREATE_fcmp(dc, opnd_create_reg(Rn_5_0[i]), opnd_create_reg(Rm_5_0[i]));
         if (!test_instr_encoding(dc, OP_fcmp, instr, expected_5_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 TEST_INSTR(fcmpe)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     /* Testing FCMPE   <Dn>, #0.0 */
     reg_id_t Rn_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
     const char *expected_0_0[3] = {
@@ -2886,7 +2523,7 @@ TEST_INSTR(fcmpe)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fcmpe_zero(dc, opnd_create_reg(Rn_0_0[i]));
         if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMPE   <Hn>, #0.0 */
     reg_id_t Rn_1_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2898,7 +2535,7 @@ TEST_INSTR(fcmpe)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fcmpe_zero(dc, opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMPE   <Sn>, #0.0 */
     reg_id_t Rn_2_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -2910,7 +2547,7 @@ TEST_INSTR(fcmpe)
     for (int i = 0; i < 3; i++) {
         instr = INSTR_CREATE_fcmpe_zero(dc, opnd_create_reg(Rn_2_0[i]));
         if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_2_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMPE   <Dn>, <Dm> */
     reg_id_t Rn_3_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -2924,7 +2561,7 @@ TEST_INSTR(fcmpe)
         instr = INSTR_CREATE_fcmpe(dc, opnd_create_reg(Rn_3_0[i]),
                                    opnd_create_reg(Rm_3_0[i]));
         if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_3_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMPE   <Hn>, <Hm> */
     reg_id_t Rn_4_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -2938,7 +2575,7 @@ TEST_INSTR(fcmpe)
         instr = INSTR_CREATE_fcmpe(dc, opnd_create_reg(Rn_4_0[i]),
                                    opnd_create_reg(Rm_4_0[i]));
         if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_4_0[i]))
-            success = false;
+            *psuccess = false;
     }
     /* Testing FCMPE   <Sn>, <Sm> */
     reg_id_t Rn_5_0[3] = { DR_REG_S0, DR_REG_S10, DR_REG_S31 };
@@ -2952,16 +2589,11 @@ TEST_INSTR(fcmpe)
         instr = INSTR_CREATE_fcmpe(dc, opnd_create_reg(Rn_5_0[i]),
                                    opnd_create_reg(Rm_5_0[i]));
         if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_5_0[i]))
-            success = false;
-    }
-    return success;
-}
+            *psuccess = false;
+    }}
 
 TEST_INSTR(fcsel)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCSEL   <Dd>, <Dn>, <Dm>, <cond> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -2978,7 +2610,7 @@ TEST_INSTR(fcsel)
             INSTR_CREATE_fcsel(dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
                                opnd_create_reg(Rm_0_0[i]), condition_code_0_0[i]);
         if (!test_instr_encoding(dc, OP_fcsel, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCSEL   <Hd>, <Hn>, <Hm>, <cond> */
@@ -2996,7 +2628,7 @@ TEST_INSTR(fcsel)
             INSTR_CREATE_fcsel(dc, opnd_create_reg(Rd_1_0[i]), opnd_create_reg(Rn_1_0[i]),
                                opnd_create_reg(Rm_1_0[i]), condition_code_1_0[i]);
         if (!test_instr_encoding(dc, OP_fcsel, instr, expected_1_0[i]))
-            success = false;
+            *psuccess = false;
     }
 
     /* Testing FCSEL   <Sd>, <Sn>, <Sm>, <cond> */
@@ -3014,17 +2646,12 @@ TEST_INSTR(fcsel)
             INSTR_CREATE_fcsel(dc, opnd_create_reg(Rd_2_0[i]), opnd_create_reg(Rn_2_0[i]),
                                opnd_create_reg(Rm_2_0[i]), condition_code_2_0[i]);
         if (!test_instr_encoding(dc, OP_fcsel, instr, expected_2_0[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sdot_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3040,7 +2667,7 @@ TEST_INSTR(sdot_vector)
                                          opnd_create_reg(Rn_0_0[i]),
                                          opnd_create_reg(Rm_0_0[i]));
         if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
     reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
@@ -3055,17 +2682,12 @@ TEST_INSTR(sdot_vector)
                                          opnd_create_reg(Rn_0_1[i]),
                                          opnd_create_reg(Rm_0_1[i]));
         if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(sdot_vector_indexed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing SDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>] */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3082,7 +2704,7 @@ TEST_INSTR(sdot_vector_indexed)
             dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
             opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(index_0_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
     reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
@@ -3098,17 +2720,12 @@ TEST_INSTR(sdot_vector_indexed)
             dc, opnd_create_reg(Rd_0_1[i]), opnd_create_reg(Rn_0_1[i]),
             opnd_create_reg(Rm_0_1[i]), opnd_create_immed_uint(index_0_1[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_sdot, instr, expected_0_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(udot_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.<Tb> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3124,7 +2741,7 @@ TEST_INSTR(udot_vector)
                                          opnd_create_reg(Rn_0_0[i]),
                                          opnd_create_reg(Rm_0_0[i]));
         if (!test_instr_encoding(dc, OP_udot, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
     reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
@@ -3139,17 +2756,12 @@ TEST_INSTR(udot_vector)
                                          opnd_create_reg(Rn_0_1[i]),
                                          opnd_create_reg(Rm_0_1[i]));
         if (!test_instr_encoding(dc, OP_udot, instr, expected_0_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(udot_vector_indexed)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing UDOT    <Sd>.<Ts>, <Bn>.<Tb>, <Bm>.4B[<index>] */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3166,7 +2778,7 @@ TEST_INSTR(udot_vector_indexed)
             dc, opnd_create_reg(Rd_0_0[i]), opnd_create_reg(Rn_0_0[i]),
             opnd_create_reg(Rm_0_0[i]), opnd_create_immed_uint(index_0_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_udot, instr, expected_0_0[i]))
-            success = false;
+            *psuccess = false;
     }
     reg_id_t Rd_0_1[3] = { DR_REG_Q0, DR_REG_Q10, DR_REG_Q31 };
     reg_id_t Rn_0_1[3] = { DR_REG_Q0, DR_REG_Q11, DR_REG_Q31 };
@@ -3182,17 +2794,12 @@ TEST_INSTR(udot_vector_indexed)
             dc, opnd_create_reg(Rd_0_1[i]), opnd_create_reg(Rn_0_1[i]),
             opnd_create_reg(Rm_0_1[i]), opnd_create_immed_uint(index_0_1[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_udot, instr, expected_0_1[i]))
-            success = false;
+            *psuccess = false;
     }
-
-    return success;
 }
 
 TEST_INSTR(fmov)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMOV    <Wd>, <Hn> */
     reg_id_t Rd_0_0[3] = { DR_REG_W0, DR_REG_W10, DR_REG_W30 };
@@ -3237,15 +2844,10 @@ TEST_INSTR(fmov)
     };
     TEST_LOOP(fmov, fmov_general, 3, expected_3_0[i], opnd_create_reg(Rd_3_0[i]),
               opnd_create_reg(Rn_3_0[i]));
-
-    return success;
 }
 
 TEST_INSTR(fmulx_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3308,15 +2910,10 @@ TEST_INSTR(fmulx_vector)
     };
     TEST_LOOP(fmulx, fmulx_vector, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmulx_vector_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMULX   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.H[<index>] */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3433,15 +3030,10 @@ TEST_INSTR(fmulx_vector_idx)
     TEST_LOOP(fmulx, fmulx_vector_idx, 3, expected_3_1[i], opnd_create_reg(Rd_3_1[i]),
               opnd_create_reg(Rn_3_1[i]), opnd_create_reg(Rm_3_1[i]),
               opnd_create_immed_uint(index_3_1[i], OPSZ_0), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmulx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FMULX   <Hd>, <Hn>, <Hm> */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -3477,15 +3069,10 @@ TEST_INSTR(fmulx)
     };
     TEST_LOOP(fmulx, fmulx, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(facge_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FACGE   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3548,15 +3135,10 @@ TEST_INSTR(facge_vector)
     };
     TEST_LOOP(facge, facge_vector, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(facge)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FACGE   <Hd>, <Hn>, <Hm> */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -3592,15 +3174,10 @@ TEST_INSTR(facge)
     };
     TEST_LOOP(facge, facge, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(facgt_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FACGT   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3663,15 +3240,10 @@ TEST_INSTR(facgt_vector)
     };
     TEST_LOOP(facgt, facgt_vector, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(facgt)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FACGT   <Hd>, <Hn>, <Hm> */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -3707,15 +3279,10 @@ TEST_INSTR(facgt)
     };
     TEST_LOOP(facgt, facgt, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(faddp_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FADDP   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3778,15 +3345,10 @@ TEST_INSTR(faddp_vector)
     };
     TEST_LOOP(faddp, faddp_vector, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(faddp_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FADDP   <Hd>, <Hn>.2H */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -3822,15 +3384,10 @@ TEST_INSTR(faddp_scalar)
     };
     TEST_LOOP(faddp, faddp_scalar, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fcmeq_vector_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMEQ   <Hd>.<Ts>, <Hn>.<Ts>, #0 */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3888,15 +3445,10 @@ TEST_INSTR(fcmeq_vector_zero)
     };
     TEST_LOOP(fcmeq, fcmeq_vector_zero, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fcmeq_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMEQ   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
     reg_id_t Rd_0_0[3] = { DR_REG_D0, DR_REG_D10, DR_REG_D31 };
@@ -3959,15 +3511,10 @@ TEST_INSTR(fcmeq_vector)
     };
     TEST_LOOP(fcmeq, fcmeq_vector, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fcmeq_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMEQ   <Hd>, <Hn>, #0 */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -4000,15 +3547,10 @@ TEST_INSTR(fcmeq_zero)
     };
     TEST_LOOP(fcmeq, fcmeq_zero, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fcmeq)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMEQ   <Hd>, <Hn>, <Hm> */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -4044,15 +3586,10 @@ TEST_INSTR(fcmeq)
     };
     TEST_LOOP(fcmeq, fcmeq, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fcmgt_vector_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FCMGT   <Hd>.<Ts>, <Hn>.<Ts>, #0 */
@@ -4111,15 +3648,10 @@ TEST_INSTR(fcmgt_vector_zero)
     };
     TEST_LOOP(fcmgt, fcmgt_vector_zero, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fcmgt_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FCMGT   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -4183,15 +3715,10 @@ TEST_INSTR(fcmgt_vector)
     };
     TEST_LOOP(fcmgt, fcmgt_vector, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fcmgt_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMGT   <Hd>, <Hn>, #0 */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -4224,15 +3751,10 @@ TEST_INSTR(fcmgt_zero)
     };
     TEST_LOOP(fcmgt, fcmgt_zero, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fcmgt)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMGT   <Hd>, <Hn>, <Hm> */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -4268,15 +3790,10 @@ TEST_INSTR(fcmgt)
     };
     TEST_LOOP(fcmgt, fcmgt, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fcmle_vector_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FCMLE   <Hd>.<Ts>, <Hn>.<Ts>, #0 */
@@ -4335,15 +3852,10 @@ TEST_INSTR(fcmle_vector_zero)
     };
     TEST_LOOP(fcmle, fcmle_vector_zero, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fcmle_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMLE   <Hd>, <Hn>, #0 */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -4376,15 +3888,10 @@ TEST_INSTR(fcmle_zero)
     };
     TEST_LOOP(fcmle, fcmle_zero, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fcmlt_vector_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FCMLT   <Hd>.<Ts>, <Hn>.<Ts>, #0 */
@@ -4443,15 +3950,10 @@ TEST_INSTR(fcmlt_vector_zero)
     };
     TEST_LOOP(fcmlt, fcmlt_vector_zero, 3, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fcmlt_zero)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FCMLT   <Hd>, <Hn>, #0 */
     reg_id_t Rd_0_0[3] = { DR_REG_H0, DR_REG_H10, DR_REG_H31 };
@@ -4484,15 +3986,10 @@ TEST_INSTR(fcmlt_zero)
     };
     TEST_LOOP(fcmlt, fcmlt_zero, 3, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(fmaxnmp_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMAXNMP <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -4571,15 +4068,10 @@ TEST_INSTR(fmaxnmp_vector)
     };
     TEST_LOOP(fmaxnmp, fmaxnmp_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmaxnmp_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FMAXNMP <Hd>, <Hn>.2H */
@@ -4622,15 +4114,10 @@ TEST_INSTR(fmaxnmp_scalar)
     };
     TEST_LOOP(fmaxnmp, fmaxnmp_scalar, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmaxp_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMAXP   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -4709,15 +4196,10 @@ TEST_INSTR(fmaxp_vector)
     };
     TEST_LOOP(fmaxp, fmaxp_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmaxp_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FMAXP   <Hd>, <Hn>.2H */
@@ -4760,15 +4242,10 @@ TEST_INSTR(fmaxp_scalar)
     };
     TEST_LOOP(fmaxp, fmaxp_scalar, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fminnmp_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMINNMP <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -4847,15 +4324,10 @@ TEST_INSTR(fminnmp_vector)
     };
     TEST_LOOP(fminnmp, fminnmp_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fminnmp_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FMINNMP <Hd>, <Hn>.2H */
@@ -4898,15 +4370,10 @@ TEST_INSTR(fminnmp_scalar)
     };
     TEST_LOOP(fminnmp, fminnmp_scalar, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fminnmv_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FMINNMV <Hd>, <Hn>.<Ts> */
@@ -4949,15 +4416,10 @@ TEST_INSTR(fminnmv_vector)
     };
     TEST_LOOP(fminnmv, fminnmv_vector, 6, expected_1_0[i], opnd_create_reg(Rd_1_0[i]),
               opnd_create_reg(Rn_1_0[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fminp_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMINP   <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -5036,15 +4498,10 @@ TEST_INSTR(fminp_vector)
     };
     TEST_LOOP(fminp, fminp_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fminp_scalar)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FMINP   <Hd>, <Hn>.2H */
@@ -5087,15 +4544,10 @@ TEST_INSTR(fminp_scalar)
     };
     TEST_LOOP(fminp, fminp_scalar, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmla_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMLA    <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -5174,15 +4626,10 @@ TEST_INSTR(fmla_vector)
     };
     TEST_LOOP(fmla, fmla_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmla_vector_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMLA    <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.H[<index>] */
@@ -5348,15 +4795,10 @@ TEST_INSTR(fmla_vector_idx)
     TEST_LOOP(fmla, fmla_vector_idx, 6, expected_3_1[i], opnd_create_reg(Rd_3_1[i]),
               opnd_create_reg(Rn_3_1[i]), opnd_create_reg(Rm_3_1[i]),
               opnd_create_immed_uint(index_3_1[i], OPSZ_0), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmls_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMLS    <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -5435,15 +4877,10 @@ TEST_INSTR(fmls_vector)
     };
     TEST_LOOP(fmls, fmls_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(fmls_vector_idx)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FMLS    <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.H[<index>] */
@@ -5609,15 +5046,10 @@ TEST_INSTR(fmls_vector_idx)
     TEST_LOOP(fmls, fmls_vector_idx, 6, expected_3_1[i], opnd_create_reg(Rd_3_1[i]),
               opnd_create_reg(Rn_3_1[i]), opnd_create_reg(Rm_3_1[i]),
               opnd_create_immed_uint(index_3_1[i], OPSZ_0), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(frecpe_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FRECPE  <Hd>.<Ts>, <Hn>.<Ts> */
@@ -5686,15 +5118,10 @@ TEST_INSTR(frecpe_vector)
     };
     TEST_LOOP(frecpe, frecpe_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(frecpe)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FRECPE  <Hd>, <Hn> */
     reg_id_t Rd_0_0[6] = { DR_REG_H0,  DR_REG_H5,  DR_REG_H10,
@@ -5730,15 +5157,10 @@ TEST_INSTR(frecpe)
     };
     TEST_LOOP(frecpe, frecpe, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(frecps_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FRECPS  <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -5817,15 +5239,10 @@ TEST_INSTR(frecps_vector)
     };
     TEST_LOOP(frecps, frecps_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(frecps)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FRECPS  <Hd>, <Hn>, <Hm> */
     reg_id_t Rd_0_0[6] = { DR_REG_H0,  DR_REG_H5,  DR_REG_H10,
@@ -5870,15 +5287,10 @@ TEST_INSTR(frecps)
     };
     TEST_LOOP(frecps, frecps, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(frsqrte_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rn_elsz;
 
     /* Testing FRSQRTE <Hd>.<Ts>, <Hn>.<Ts> */
@@ -5947,15 +5359,10 @@ TEST_INSTR(frsqrte_vector)
     };
     TEST_LOOP(frsqrte, frsqrte_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), Rn_elsz);
-
-    return success;
 }
 
 TEST_INSTR(frsqrte)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FRSQRTE <Hd>, <Hn> */
     reg_id_t Rd_0_0[6] = { DR_REG_H0,  DR_REG_H5,  DR_REG_H10,
@@ -5991,15 +5398,10 @@ TEST_INSTR(frsqrte)
     };
     TEST_LOOP(frsqrte, frsqrte, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]));
-
-    return success;
 }
 
 TEST_INSTR(frsqrts_vector)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
     opnd_t Rm_elsz;
 
     /* Testing FRSQRTS <Hd>.<Ts>, <Hn>.<Ts>, <Hm>.<Ts> */
@@ -6078,15 +5480,10 @@ TEST_INSTR(frsqrts_vector)
     };
     TEST_LOOP(frsqrts, frsqrts_vector, 6, expected_1_2[i], opnd_create_reg(Rd_1_2[i]),
               opnd_create_reg(Rn_1_2[i]), opnd_create_reg(Rm_1_2[i]), Rm_elsz);
-
-    return success;
 }
 
 TEST_INSTR(frsqrts)
 {
-    bool success = true;
-    instr_t *instr;
-    byte *pc;
 
     /* Testing FRSQRTS <Hd>, <Hn>, <Hm> */
     reg_id_t Rd_0_0[6] = { DR_REG_H0,  DR_REG_H5,  DR_REG_H10,
@@ -6131,8 +5528,6 @@ TEST_INSTR(frsqrts)
     };
     TEST_LOOP(frsqrts, frsqrts, 6, expected_1_1[i], opnd_create_reg(Rd_1_1[i]),
               opnd_create_reg(Rn_1_1[i]), opnd_create_reg(Rm_1_1[i]));
-
-    return success;
 }
 
 int
@@ -6145,6 +5540,7 @@ main(int argc, char *argv[])
 #endif
     bool result = true;
     bool test_result;
+    instr_t *instr;
 
     RUN_INSTR_TEST(fcvtas_vector);
     RUN_INSTR_TEST(fcvtas_scalar);

--- a/suite/tests/api/ir_aarch64_v82.c
+++ b/suite/tests/api/ir_aarch64_v82.c
@@ -791,7 +791,8 @@ TEST_INSTR(fcvtzs_vector)
                                            opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_0_1[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(fcvtzs_scalar)
 {
@@ -873,7 +874,8 @@ TEST_INSTR(fcvtzs_scalar)
                                            opnd_create_reg(Rn_12_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzs, instr, expected_12_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 /*
  * FCVTZU
@@ -914,7 +916,8 @@ TEST_INSTR(fcvtzu_vector)
                                            opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_0_1[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(fcvtzu_scalar)
 {
@@ -996,7 +999,8 @@ TEST_INSTR(fcvtzu_scalar)
                                            opnd_create_reg(Rn_12_0[i]));
         if (!test_instr_encoding(dc, OP_fcvtzu, instr, expected_12_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 /*
  * FRINTA
@@ -1902,7 +1906,8 @@ TEST_INSTR(sha512h)
                                      opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sha512h, instr, expected_0_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(sha512h2)
 {
@@ -1923,7 +1928,8 @@ TEST_INSTR(sha512h2)
                                       opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sha512h2, instr, expected_0_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(sha512su0)
 {
@@ -1942,7 +1948,8 @@ TEST_INSTR(sha512su0)
                                        opnd_create_reg(Rn_0_0[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_sha512su0, instr, expected_0_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(sha512su1)
 {
@@ -1963,7 +1970,8 @@ TEST_INSTR(sha512su1)
                                        opnd_create_reg(Rm_0_0[i]), Rm_elsz);
         if (!test_instr_encoding(dc, OP_sha512su1, instr, expected_0_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(bcax)
 {
@@ -2026,7 +2034,8 @@ TEST_INSTR(psb)
     const char *expected_0_0[1] = { "psb" };
     instr = INSTR_CREATE_psb_csync(dc);
     if (!test_instr_encoding(dc, OP_psb, instr, expected_0_0[0]))
-        *psuccess = false;}
+        *psuccess = false;
+}
 
 TEST_INSTR(fsqrt_vector)
 {
@@ -2059,7 +2068,8 @@ TEST_INSTR(fsqrt_vector)
                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_0_1[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(fsqrt_scalar)
 {
@@ -2077,7 +2087,8 @@ TEST_INSTR(fsqrt_scalar)
                                           opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_fsqrt, instr, expected_1_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(scvtf_vector)
 {
@@ -2110,7 +2121,8 @@ TEST_INSTR(scvtf_vector)
                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_0_1[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(scvtf_scalar)
 {
@@ -2143,7 +2155,8 @@ TEST_INSTR(scvtf_scalar)
                                           opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_1_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(scvtf_scalar_fixed)
 {
@@ -2180,7 +2193,8 @@ TEST_INSTR(scvtf_scalar_fixed)
                                                 OPND_CREATE_INT(scale_1[i]));
         if (!test_instr_encoding(dc, OP_scvtf, instr, expected_1[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(ucvtf_vector)
 {
@@ -2213,7 +2227,8 @@ TEST_INSTR(ucvtf_vector)
                                           opnd_create_reg(Rn_0_1[i]), Rn_elsz);
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_0_1[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(ucvtf_scalar)
 {
@@ -2246,7 +2261,8 @@ TEST_INSTR(ucvtf_scalar)
                                           opnd_create_reg(Rn_1_0[i]));
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_1_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(ucvtf_scalar_fixed)
 {
@@ -2283,7 +2299,8 @@ TEST_INSTR(ucvtf_scalar_fixed)
                                                 OPND_CREATE_INT(scale_1[i]));
         if (!test_instr_encoding(dc, OP_ucvtf, instr, expected_1[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(rax1)
 {
@@ -2302,7 +2319,8 @@ TEST_INSTR(rax1)
                                   opnd_create_reg(Rm_0[i]));
         if (!test_instr_encoding(dc, OP_rax1, instr, expected_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(xar)
 {
@@ -2323,7 +2341,8 @@ TEST_INSTR(xar)
                                  opnd_create_immed_uint(imm6_0_0[i], OPSZ_0));
         if (!test_instr_encoding(dc, OP_xar, instr, expected_0_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(fccmp)
 {
@@ -2377,7 +2396,8 @@ TEST_INSTR(fccmp)
             opnd_create_immed_uint(nzcv_2_0[i], OPSZ_0), condition_code_2_0[i]);
         if (!test_instr_encoding(dc, OP_fccmp, instr, expected_2_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 TEST_INSTR(fccmpe)
 {
     /* Testing FCCMPE  <Dn>, <Dm>, #<imm>, <cond> */
@@ -2430,7 +2450,8 @@ TEST_INSTR(fccmpe)
             opnd_create_immed_uint(nzcv_2_0[i], OPSZ_0), condition_code_2_0[i]);
         if (!test_instr_encoding(dc, OP_fccmpe, instr, expected_2_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 TEST_INSTR(fcmp)
 {
     /* Testing FCMP    <Dn>, #0.0 */
@@ -2510,7 +2531,8 @@ TEST_INSTR(fcmp)
             INSTR_CREATE_fcmp(dc, opnd_create_reg(Rn_5_0[i]), opnd_create_reg(Rm_5_0[i]));
         if (!test_instr_encoding(dc, OP_fcmp, instr, expected_5_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 TEST_INSTR(fcmpe)
 {
     /* Testing FCMPE   <Dn>, #0.0 */
@@ -2590,7 +2612,8 @@ TEST_INSTR(fcmpe)
                                    opnd_create_reg(Rm_5_0[i]));
         if (!test_instr_encoding(dc, OP_fcmpe, instr, expected_5_0[i]))
             *psuccess = false;
-    }}
+    }
+}
 
 TEST_INSTR(fcsel)
 {


### PR DESCRIPTION
This patch modifies the testing macros to reduce the need to
instantiate variables in each test.

It also predefines some lists of registers that are commonly
used

issues: #4393