### PR TITLE
i#2039 trace trim, part 5: Drop early data

### DIFF
--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -412,6 +412,8 @@ offline_instru_t::refresh_unit_header_timestamp(byte *buf_ptr, uint64 min_timest
     offline_entry_t *stamp = reinterpret_cast<offline_entry_t *>(buf_ptr);
     DR_ASSERT(stamp->timestamp.type == OFFLINE_TYPE_TIMESTAMP);
     if (stamp->timestamp.usec < min_timestamp) {
+        log_(2, "%s: replacing " UINT64_FORMAT_STRING " with " UINT64_FORMAT_STRING "\n",
+             __FUNCTION__, stamp->timestamp.usec, min_timestamp);
         stamp->timestamp.usec = min_timestamp;
         return true;
     }

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -918,7 +918,6 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
     // the first buffer.
     if (data->has_thread_header && op_offline.get_value())
         header_size += data->init_header_size;
-    data->has_thread_header = false;
 
     if (align_attach_detach_endpoints()) {
         // This is the attach counterpart to instru_t::set_frozen_timestamp(): we place
@@ -927,11 +926,19 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
         // tracing.  (Switching back to timestamps at buffer output is actually
         // worse as we then have the identical frozen timestamp for all the flushes
         // during detach, plus they are all on the same cpu too.)
+        uint64 min_timestamp = attached_timestamp.load(std::memory_order_acquire);
+        if (min_timestamp == 0) {
+            // This data is too early: we drop it.
+            BUF_PTR(data->seg_base) = data->buf_base + header_size;
+            return;
+        }
         size_t stamp_offs =
             header_size > buf_hdr_slots_size ? header_size - buf_hdr_slots_size : 0;
-        uint64 min_timestamp = attached_timestamp.load(std::memory_order_acquire);
         instru->refresh_unit_header_timestamp(data->buf_base + stamp_offs, min_timestamp);
     }
+
+    // Clear after we know we're not dropping for align_attach_detach_endpoints.
+    data->has_thread_header = false;
 
     buf_ptr = BUF_PTR(data->seg_base);
     // We may get called with nothing to write: e.g., on a syscall for

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -929,6 +929,7 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
         uint64 min_timestamp = attached_timestamp.load(std::memory_order_acquire);
         if (min_timestamp == 0) {
             // This data is too early: we drop it.
+            NOTIFY(1, "Dropping too-early data for T%zd\n", dr_get_thread_id(drcontext));
             BUF_PTR(data->seg_base) = data->buf_base + header_size;
             return;
         }

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -416,7 +416,9 @@ event_post_attach()
     DR_ASSERT(attached_midway);
     if (!align_attach_detach_endpoints())
         return;
-    attached_timestamp.store(instru_t::get_timestamp(), std::memory_order_release);
+    uint64 timestamp = instru_t::get_timestamp();
+    attached_timestamp.store(timestamp, std::memory_order_release);
+    NOTIFY(1, "Fully-attached timestamp is " UINT64_FORMAT_STRING "\n", timestamp);
     if (op_trace_after_instrs.get_value() != 0) {
         NOTIFY(1, "Switching to counting mode after attach\n");
         tracing_mode.store(BBDUP_MODE_COUNT, std::memory_order_release);


### PR DESCRIPTION
Part 4 added a minimum timestamp, but it only works for data that is not actually emitted until we are fully attached.  For data emitted before that point, we'll use a too-early timestamp.  We solve that here by dropping such data.

Tested on a large app where these changes solve gaps at the start of the trace due to an early timestamp in one thread.

Issue: #2039