### PR TITLE
i#5767: Disable zlib on windows package builds

### DIFF
--- a/make/package.cmake
+++ b/make/package.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2021 Google, Inc.    All rights reserved.
+# Copyright (c) 2011-2022 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -164,6 +164,7 @@ set(base_cache "
   BUILD_NUMBER:STRING=${arg_build}
   UNIQUE_BUILD_NUMBER:STRING=${arg_ubuild}
   BUILD_PACKAGE:BOOL=ON
+  AUTOMATED_TESTING:BOOL=ON
   ${arg_cacheappend}
   ")
 

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -114,6 +114,10 @@ if (arg_automated_ci)
     # to be off, ruining the samples for interactive use.
     set(build_tests "")
     message("Detected a cron package build: disabling running of tests")
+    # We want the same Github Actions settings for building as we have for continuous
+    # testing so we set AUTOMATED_TESTING.
+    set(base_cache "${base_cache}
+AUTOMATED_TESTING:BOOL=ON")
   else ()
     # Disable -msgbox_mask by default to avoid hangs on cases where DR hits errors
     # prior to option parsing.


### PR DESCRIPTION
Works around issues with strawberry perl zlib on GA CI package builders by disabling zlib by setting AUTOMATED_TESTING for package builds, just like we're doing for testing on GA CI.

Issue: #5767