### PR TITLE
i#5675: Fix data race in record_filter.

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -341,7 +341,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(
         VPRINT(this, 1, "Worker %d starting on trace shard %d\n", tdata->worker,
                tdata->index);
         if (!tdata->iter->init()) {
-            tdata->error = "Failed to read from trace" + tdata->trace_file;
+            tdata->error = "Failed to read from trace: " + tdata->trace_file;
             return;
         }
         std::vector<void *> shard_data(num_tools_);

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -128,6 +128,7 @@ bool
 record_filter_t::parallel_shard_exit(void *shard_data)
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
+    std::lock_guard<std::mutex> guard(shard_exit_mutex_);
     input_entry_count_ += per_shard->input_entry_count;
     output_entry_count_ += per_shard->output_entry_count;
     bool res = true;

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -67,8 +67,6 @@ record_filter_t::record_filter_t(
     , filters_(std::move(filters))
     , stop_timestamp_(stop_timestamp)
     , verbosity_(verbose)
-    , input_entry_count_(0)
-    , output_entry_count_(0)
 {
     UNUSED(verbosity_);
     UNUSED(output_prefix_);
@@ -76,6 +74,9 @@ record_filter_t::record_filter_t(
 
 record_filter_t::~record_filter_t()
 {
+    for (auto &iter : shard_map_) {
+        delete iter.second;
+    }
 }
 
 bool
@@ -121,6 +122,8 @@ record_filter_t::parallel_shard_init_stream(int shard_index, void *worker_data,
             success_ = false;
         }
     }
+    std::lock_guard<std::mutex> guard(shard_map_mutex_);
+    shard_map_[shard_index] = per_shard;
     return reinterpret_cast<void *>(per_shard);
 }
 
@@ -128,17 +131,15 @@ bool
 record_filter_t::parallel_shard_exit(void *shard_data)
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
-    {
-        std::lock_guard<std::mutex> guard(shard_exit_mutex_);
-        input_entry_count_ += per_shard->input_entry_count;
-        output_entry_count_ += per_shard->output_entry_count;
-    }
     bool res = true;
     for (int i = 0; i < static_cast<int>(filters_.size()); ++i) {
         if (!filters_[i]->parallel_shard_exit(per_shard->filter_shard_data[i]))
             res = false;
     }
-    delete per_shard;
+    // Destroy the writer since we do not need it anymore. This also makes sure
+    // that data is written out to the file; curiously, a simple flush doesn't
+    // do it.
+    per_shard->writer.reset(nullptr);
     return res;
 }
 
@@ -231,8 +232,14 @@ record_filter_t::process_memref(const trace_entry_t &memref)
 bool
 record_filter_t::print_results()
 {
-    std::cerr << "Output " << output_entry_count_ << " entries from "
-              << input_entry_count_ << " entries.\n";
+    uint64_t input_entry_count = 0;
+    uint64_t output_entry_count = 0;
+    for (const auto &shard : shard_map_) {
+        input_entry_count += shard.second->input_entry_count;
+        output_entry_count += shard.second->output_entry_count;
+    }
+    std::cerr << "Output " << output_entry_count << " entries from " << input_entry_count
+              << " entries.\n";
     return true;
 }
 

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -128,9 +128,11 @@ bool
 record_filter_t::parallel_shard_exit(void *shard_data)
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
-    std::lock_guard<std::mutex> guard(shard_exit_mutex_);
-    input_entry_count_ += per_shard->input_entry_count;
-    output_entry_count_ += per_shard->output_entry_count;
+    {
+        std::lock_guard<std::mutex> guard(shard_exit_mutex_);
+        input_entry_count_ += per_shard->input_entry_count;
+        output_entry_count_ += per_shard->output_entry_count;
+    }
     bool res = true;
     for (int i = 0; i < static_cast<int>(filters_.size()); ++i) {
         if (!filters_[i]->parallel_shard_exit(per_shard->filter_shard_data[i]))

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -131,6 +131,7 @@ protected:
         memtrace_stream_t *shard_stream;
         bool enabled;
     };
+    // In parallel operation the keys are "shard indices": just ints.
     std::unordered_map<memref_tid_t, per_shard_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init. In all other accesses
     // to shard_map (print_results) we are single-threaded.

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -35,6 +35,7 @@
 
 #include "analysis_tool.h"
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace dynamorio {
@@ -142,6 +143,7 @@ private:
     uint64_t stop_timestamp_;
     unsigned int verbosity_;
     const char *output_prefix_ = "[record_filter]";
+    std::mutex shard_exit_mutex_;
 
 protected:
     uint64_t input_entry_count_;

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -36,6 +36,7 @@
 #include "analysis_tool.h"
 #include <memory>
 #include <mutex>
+#include <unordered_map>
 #include <vector>
 
 namespace dynamorio {
@@ -130,6 +131,10 @@ protected:
         memtrace_stream_t *shard_stream;
         bool enabled;
     };
+    std::unordered_map<memref_tid_t, per_shard_t *> shard_map_;
+    // This mutex is only needed in parallel_shard_init. In all other accesses
+    // to shard_map (print_results) we are single-threaded.
+    std::mutex shard_map_mutex_;
 
 private:
     virtual bool
@@ -143,11 +148,6 @@ private:
     uint64_t stop_timestamp_;
     unsigned int verbosity_;
     const char *output_prefix_ = "[record_filter]";
-    std::mutex shard_exit_mutex_;
-
-protected:
-    uint64_t input_entry_count_;
-    uint64_t output_entry_count_;
 };
 
 } // namespace drmemtrace


### PR DESCRIPTION
Fixes a race in updating input_entry_count_ and output_entry_count_
in parallel_shard_exit in the record_filter analyzer.

Moves aggregation logic to print_results instead. Like other analyzers,
we now keep track of all shard data pointers and free them in the
destructor instead. We destroy the writer object in parallel_shard_exit
itself though, for symmetry with how it's created (in parallel_shard_stream_init)
and so that users don't have to destroy the record_filter_t object itself
for output files to be written out.

Issue: #5675