### PR TITLE
i#2039 trace trim, part 7: Fix filtered refresh

### DIFF
--- a/api/docs/debug_memtrace.dox
+++ b/api/docs/debug_memtrace.dox
@@ -75,6 +75,8 @@ Cheat sheet:
 - a* is an arm iflush
 - c2* is a marker
 - c203* is a cpu id
+- c20a* is the cache line size
+- c212* is the page size
 - c200* is kernel event; c201* is kernel xfer
 
 ## Viewing post-processed files

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -938,9 +938,6 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
         instru->refresh_unit_header_timestamp(data->buf_base + stamp_offs, min_timestamp);
     }
 
-    // Clear after we know we're not dropping for align_attach_detach_endpoints.
-    data->has_thread_header = false;
-
     buf_ptr = BUF_PTR(data->seg_base);
     // We may get called with nothing to write: e.g., on a syscall for
     // -L0I_filter and -L0D_filter.
@@ -960,6 +957,9 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
                            dr_get_thread_id(drcontext), window);
         return;
     }
+
+    // Clear after we know we're not dropping the data for non-size-cap reasons.
+    data->has_thread_header = false;
 
     bool window_changed = false;
     if (has_tracing_windows() &&


### PR DESCRIPTION
Fixes an issue with refreshing the timestamp when filtering is on where the first (extended) header flag was cleared on a filter-discarded buffer.

Tested by running "ctest -V --repeat-until-fail 100 -R burst_threadL0filter". Previously it failed on the 3rd test; now all 100 pass.

Issue: #2039