### PR TITLE
i#5675 record filter: Adjust trace file type

### DIFF
--- a/clients/drcachesim/tools/filter/cache_filter.cpp
+++ b/clients/drcachesim/tools/filter/cache_filter.cpp
@@ -76,6 +76,15 @@ cache_filter_t::parallel_shard_init(memtrace_stream_t *shard_stream)
     }
     return per_shard;
 }
+void
+cache_filter_t::parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
+                                                 bool partial_trace_filter)
+{
+    if (filter_instrs_)
+        entry.addr |= OFFLINE_FILE_TYPE_IFILTERED;
+    if (filter_data_)
+        entry.addr |= OFFLINE_FILE_TYPE_DFILTERED;
+}
 bool
 cache_filter_t::parallel_shard_filter(const trace_entry_t &entry, void *shard_data)
 {

--- a/clients/drcachesim/tools/filter/cache_filter.h
+++ b/clients/drcachesim/tools/filter/cache_filter.h
@@ -50,12 +50,10 @@ public:
     {
     }
     void *
-    parallel_shard_init(memtrace_stream_t *shard_stream) override;
-    void
-    parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
-                                     bool partial_trace_filter) override;
+    parallel_shard_init(memtrace_stream_t *shard_stream,
+                        bool partial_trace_filter) override;
     bool
-    parallel_shard_filter(const trace_entry_t &entry, void *shard_data) override;
+    parallel_shard_filter(trace_entry_t &entry, void *shard_data) override;
     bool
     parallel_shard_exit(void *shard_data) override;
 

--- a/clients/drcachesim/tools/filter/cache_filter.h
+++ b/clients/drcachesim/tools/filter/cache_filter.h
@@ -51,6 +51,9 @@ public:
     }
     void *
     parallel_shard_init(memtrace_stream_t *shard_stream) override;
+    void
+    parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
+                                     bool partial_trace_filter) override;
     bool
     parallel_shard_filter(const trace_entry_t &entry, void *shard_data) override;
     bool

--- a/clients/drcachesim/tools/filter/null_filter.h
+++ b/clients/drcachesim/tools/filter/null_filter.h
@@ -45,6 +45,11 @@ public:
     {
         return nullptr;
     }
+    void
+    parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
+                                     bool partial_trace_filter) override
+    {
+    }
     bool
     parallel_shard_filter(const trace_entry_t &entry, void *shard_data) override
     {

--- a/clients/drcachesim/tools/filter/null_filter.h
+++ b/clients/drcachesim/tools/filter/null_filter.h
@@ -41,17 +41,13 @@ namespace drmemtrace {
 class null_filter_t : public record_filter_t::record_filter_func_t {
 public:
     void *
-    parallel_shard_init(memtrace_stream_t *shard_stream) override
+    parallel_shard_init(memtrace_stream_t *shard_stream,
+                        bool partial_trace_filter) override
     {
         return nullptr;
     }
-    void
-    parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
-                                     bool partial_trace_filter) override
-    {
-    }
     bool
-    parallel_shard_filter(const trace_entry_t &entry, void *shard_data) override
+    parallel_shard_filter(trace_entry_t &entry, void *shard_data) override
     {
         return true;
     }

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -115,7 +115,8 @@ record_filter_t::parallel_shard_init_stream(int shard_index, void *worker_data,
         success_ = false;
     }
     for (auto &f : filters_) {
-        per_shard->filter_shard_data.push_back(f->parallel_shard_init(shard_stream));
+        per_shard->filter_shard_data.push_back(
+            f->parallel_shard_init(shard_stream, stop_timestamp_ != 0));
         if (f->get_error_string() != "") {
             per_shard->error =
                 "Failure in initializing filter function " + f->get_error_string();
@@ -168,12 +169,6 @@ record_filter_t::parallel_shard_memref(void *shard_data, const trace_entry_t &in
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     ++per_shard->input_entry_count;
     trace_entry_t entry = input_entry;
-    if (entry.type == TRACE_TYPE_MARKER && entry.size == TRACE_MARKER_TYPE_FILETYPE) {
-        for (int i = 0; i < static_cast<int>(filters_.size()); ++i) {
-            filters_[i]->parallel_shard_process_file_type(
-                entry, per_shard->filter_shard_data[i], stop_timestamp_ != 0);
-        }
-    }
     bool output = true;
     if (per_shard->enabled && stop_timestamp_ != 0 &&
         per_shard->shard_stream->get_last_timestamp() >= stop_timestamp_) {

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -70,6 +70,18 @@ public:
         virtual void *
         parallel_shard_init(memtrace_stream_t *shard_stream) = 0;
         /**
+         * Invoked for the TRACE_TYPE_MARKER entry of type
+         * TRACE_MARKER_TYPE_FILETYPE. This routine can make changes to the file
+         * type described by the marker, based on the type of entries it filters out.
+         * The passed marker is not guaranteed to be the original one in the trace
+         * if other filter tools are present, and may include changes made by other
+         * tools. \p partial_trace_filter is set if the trace will be filtered only
+         * partially, e.g. due to stop_timestamp.
+         */
+        virtual void
+        parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
+                                         bool partial_trace_filter) = 0;
+        /**
          * Invoked for each #trace_entry_t in the shard. It returns
          * whether or not this \p entry should be included in the result
          * trace. \p shard_data is same as what was returned by

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -66,30 +66,25 @@ public:
          * any entry. The returned pointer is passed to all invocations of
          * parallel_shard_filter() and parallel_shard_exit().
          * This routine can be used to initialize state for each shard.
+         * \p partial_trace_filter denotes whether the trace will be filtered
+         * only partially, e.g. due to stop_timestamp.
          */
         virtual void *
-        parallel_shard_init(memtrace_stream_t *shard_stream) = 0;
-        /**
-         * Invoked for the TRACE_TYPE_MARKER entry of type
-         * TRACE_MARKER_TYPE_FILETYPE. This routine can make changes to the file
-         * type described by the marker, based on the type of entries it filters out.
-         * The passed marker is not guaranteed to be the original one in the trace
-         * if other filter tools are present, and may include changes made by other
-         * tools. \p partial_trace_filter is set if the trace will be filtered only
-         * partially, e.g. due to stop_timestamp.
-         */
-        virtual void
-        parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
-                                         bool partial_trace_filter) = 0;
+        parallel_shard_init(memtrace_stream_t *shard_stream,
+                            bool partial_trace_filter) = 0;
         /**
          * Invoked for each #trace_entry_t in the shard. It returns
          * whether or not this \p entry should be included in the result
          * trace. \p shard_data is same as what was returned by
          * parallel_shard_init(). The given \p entry is included in the result
-         * trace iff all provided #record_filter_func_t return true.
+         * trace iff all provided #record_filter_func_t return true. The
+         * \p entry parameter can also be modified by the record_filter_func_t.
+         * The passed \p entry is not guaranteed to be the original one from
+         * the trace if other filter tools are present, and may include changes
+         * made by other tools.
          */
         virtual bool
-        parallel_shard_filter(const trace_entry_t &entry, void *shard_data) = 0;
+        parallel_shard_filter(trace_entry_t &entry, void *shard_data) = 0;
         /**
          * Invoked when all #trace_entry_t in a shard have been processed
          * by parallel_shard_filter(). \p shard_data is same as what was

--- a/clients/drcachesim/tools/filter/type_filter.h
+++ b/clients/drcachesim/tools/filter/type_filter.h
@@ -78,29 +78,33 @@ public:
         }
     }
     void *
-    parallel_shard_init(memtrace_stream_t *shard_stream) override
+    parallel_shard_init(memtrace_stream_t *shard_stream,
+                        bool partial_trace_filter) override
     {
-        return nullptr;
-    }
-    void
-    parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
-                                     bool partial_trace_filter) override
-    {
-        if (TESTANY(entry.addr, OFFLINE_FILE_TYPE_ENCODINGS) && !partial_trace_filter &&
-            remove_trace_types_.find(TRACE_TYPE_ENCODING) != remove_trace_types_.end()) {
-            entry.addr &= ~OFFLINE_FILE_TYPE_ENCODINGS;
-        }
-        for (trace_type_t type : remove_trace_types_) {
-            // Not modifying file type for filtering of prefetch/flush entries.
-            if (type_is_instr(type))
-                entry.addr |= OFFLINE_FILE_TYPE_IFILTERED;
-            else if (type == TRACE_TYPE_READ || type == TRACE_TYPE_WRITE)
-                entry.addr |= OFFLINE_FILE_TYPE_DFILTERED;
-        }
+        per_shard_t *per_shard = new per_shard_t;
+        per_shard->partial_trace_filter = partial_trace_filter;
+        return per_shard;
     }
     bool
-    parallel_shard_filter(const trace_entry_t &entry, void *shard_data) override
+    parallel_shard_filter(trace_entry_t &entry, void *shard_data) override
     {
+        per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
+        if (entry.type == TRACE_TYPE_MARKER && entry.size == TRACE_MARKER_TYPE_FILETYPE) {
+            if (TESTANY(entry.addr, OFFLINE_FILE_TYPE_ENCODINGS) &&
+                !per_shard->partial_trace_filter &&
+                remove_trace_types_.find(TRACE_TYPE_ENCODING) !=
+                    remove_trace_types_.end()) {
+                entry.addr &= ~OFFLINE_FILE_TYPE_ENCODINGS;
+            }
+            for (trace_type_t type : remove_trace_types_) {
+                // Not modifying file type for filtering of prefetch/flush entries.
+                if (type_is_instr(type))
+                    entry.addr |= OFFLINE_FILE_TYPE_IFILTERED;
+                else if (type == TRACE_TYPE_READ || type == TRACE_TYPE_WRITE)
+                    entry.addr |= OFFLINE_FILE_TYPE_DFILTERED;
+            }
+            return true;
+        }
         if (remove_trace_types_.find(static_cast<trace_type_t>(entry.type)) !=
             remove_trace_types_.end()) {
             return false;
@@ -114,10 +118,16 @@ public:
     bool
     parallel_shard_exit(void *shard_data) override
     {
+        per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
+        delete per_shard;
         return true;
     }
 
 private:
+    struct per_shard_t {
+        bool partial_trace_filter;
+    };
+
     std::unordered_set<trace_type_t> remove_trace_types_;
     std::unordered_set<trace_marker_type_t> remove_marker_types_;
 };

--- a/clients/drcachesim/tools/filter/type_filter.h
+++ b/clients/drcachesim/tools/filter/type_filter.h
@@ -82,6 +82,22 @@ public:
     {
         return nullptr;
     }
+    void
+    parallel_shard_process_file_type(trace_entry_t &entry, void *shard_data,
+                                     bool partial_trace_filter) override
+    {
+        if (TESTANY(entry.addr, OFFLINE_FILE_TYPE_ENCODINGS) && !partial_trace_filter &&
+            remove_trace_types_.find(TRACE_TYPE_ENCODING) != remove_trace_types_.end()) {
+            entry.addr &= ~OFFLINE_FILE_TYPE_ENCODINGS;
+        }
+        for (trace_type_t type : remove_trace_types_) {
+            // Not modifying file type for filtering of prefetch/flush entries.
+            if (type_is_instr(type))
+                entry.addr |= OFFLINE_FILE_TYPE_IFILTERED;
+            else if (type == TRACE_TYPE_READ || type == TRACE_TYPE_WRITE)
+                entry.addr |= OFFLINE_FILE_TYPE_DFILTERED;
+        }
+    }
     bool
     parallel_shard_filter(const trace_entry_t &entry, void *shard_data) override
     {


### PR DESCRIPTION
Adjusts the trace's file type based on the entries being filtered out.

Removes the const property for the trace_entry_t argument to
parallel_shard_filter, which allows record_filter_func_t to modify the entry.

Tests operation in the record_filter_unit_tests.

Issue: #5675