### PR TITLE
i#3044: AArch64 SVE codec: add RDFFR[S] SETFFR WRFFR

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1566,6 +1566,20 @@ encode_opnd_nzcv(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 /* w0: W register or WZR at bit position 0 */
 
 static inline bool
+decode_opnd_p_b_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_P0, 0, 4, BYTE_REG, enc, opnd);
+}
+
+static inline bool
+encode_opnd_p_b_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_predicate_reg(opnd))
+        return false;
+    return encode_single_sized(OPSZ_SCALABLE_PRED, 0, BYTE_REG, opnd, enc_out);
+}
+
+static inline bool
 decode_opnd_w0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     return decode_opnd_wxn(false, false, 0, enc, opnd);
@@ -1861,6 +1875,21 @@ encode_opnd_p_b_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
     if (!opnd_is_predicate_reg(opnd))
         return false;
     return encode_single_sized(OPSZ_SCALABLE_PRED, 5, BYTE_REG, opnd, enc_out);
+}
+
+static inline bool
+decode_opnd_p5_zer(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_predicate_reg(DR_REG_P0 + extract_uint(enc, 5, 4), false);
+    return true;
+}
+
+static inline bool
+encode_opnd_p5_zer(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_predicate_zero(opnd))
+        return false;
+    return encode_opnd_p(5, 15, opnd, enc_out);
 }
 
 /* w5: W register or WZR at bit position 5 */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -103,9 +103,13 @@
 00000100xx010111101xxxxxxxxxxxxx  n   323  SVE      neg  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
 00000100xx011000000xxxxxxxxxxxxx  n   327  SVE      orr             z0 : p10_lo z0 z5 bhsd_sz
 001001010101000011xxxx0xxxx00000  w   786  SVE    ptest                : p10 p_b_5
+0010010100011001111100000000xxxx  n   817  SVE    rdffr          p_b_0 :
+00100101000110001111000xxxx0xxxx  n   817  SVE    rdffr          p_b_0 : p5_zer
+00100101010110001111000xxxx0xxxx  w   818  SVE   rdffrs          p_b_0 : p5_zer
 00000100xx001100000xxxxxxxxxxxxx  n   349  SVE     sabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx010100000xxxxxxxxxxxxx  n   363  SVE     sdiv    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
 00000100xx010110000xxxxxxxxxxxxx  n   794  SVE    sdivr    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
+00100101001011001001000000000000  n   819  SVE   setffr                :
 00000100xx001000000xxxxxxxxxxxxx  n   386  SVE     smax  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx101000110xxxxxxxxxxxxx  n   386  SVE     smax  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
 00000100xx001010000xxxxxxxxxxxxx  n   390  SVE     smin  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
@@ -143,4 +147,5 @@
 00000100xx010001101xxxxxxxxxxxxx  n   802  SVE     uxtb   z_size_hsd_0 : p10_mrg_lo z_size_hsd_5
 00000100xx010011101xxxxxxxxxxxxx  n   803  SVE     uxth    z_size_sd_0 : p10_mrg_lo z_size_sd_5
 0000010011010101101xxxxxxxxxxxxx  n   804  SVE     uxtw          z_d_0 : p10_mrg_lo z_d_5
+00100101001010001001000xxxx00000  n   820  SVE    wrffr                : p_b_5
 00000101101xxxxx000001xxxxxxxxxx  n   566  SVE     zip2          z_q_0 : z_q_5 z_q_16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -6365,4 +6365,67 @@
  */
 #define INSTR_CREATE_cmpne_sve_pred(dc, Pd, Pg, Zn, Zm) \
     instr_create_1dst_3src(dc, OP_cmpne, Pd, Pg, Zn, Zm)
+
+/**
+ * Creates a SETFFR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SETFFR
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_setffr_sve(dc) instr_create_0dst_0src(dc, OP_setffr)
+
+/**
+ * Creates a RDFFR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RDFFR   <Pd>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate)
+ */
+#define INSTR_CREATE_rdffr_sve(dc, Pd) instr_create_1dst_0src(dc, OP_rdffr, Pd)
+
+/**
+ * Creates a RDFFR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RDFFR   <Pd>.B, <Pg>/Z
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate)
+ * \param Pg   The governing predicate register, P (Predicate)
+ */
+#define INSTR_CREATE_rdffr_sve_pred(dc, Pd, Pg) \
+    instr_create_1dst_1src(dc, OP_rdffr, Pd, Pg)
+
+/**
+ * Creates a RDFFRS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RDFFRS  <Pd>.B, <Pg>/Z
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate)
+ * \param Pg   The governing predicate register, P (Predicate)
+ */
+#define INSTR_CREATE_rdffrs_sve_pred(dc, Pd, Pg) \
+    instr_create_1dst_1src(dc, OP_rdffrs, Pd, Pg)
+
+/**
+ * Creates a WRFFR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    WRFFR   <Pn>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pn   The source predicate register, P (Predicate)
+ */
+#define INSTR_CREATE_wrffr_sve(dc, Pn) instr_create_0dst_1src(dc, OP_wrffr, Pn)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -74,6 +74,7 @@
 --------------------------------  vindex_D1  # An implicit index, at index 1
 --------------------------------  zero_fp_const # A constant zero operand
 ----------------------------xxxx  nzcv       # flag bit specifier for CCMN, CCMP
+----------------------------xxxx  p_b_0      # P register with a byte element size
 ---------------------------xxxxx  w0         # W register (or WZR)
 ---------------------------xxxxx  w0p0       # even-numbered W register (or WZR)
 ---------------------------xxxxx  w0p1       # ... add 1
@@ -95,6 +96,7 @@
 ---------------------------xxxxx  prfop      # prefetch operation
 ------------------------xxx-----  op2        # 3 bit immediate from 5-7
 -----------------------xxxx-----  p_b_5      # P register with a byte element size
+-----------------------xxxx-----  p5_zer     # P register, zeroing
 ----------------------xxxxx-----  w5         # W register (or WZR)
 ----------------------xxxxx-----  x5         # X register (or XZR)
 ----------------------xxxxx-----  x5sp       # X register or XSP

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -3435,6 +3435,60 @@
 2550f1a0 : ptest p12, p13.b                          : ptest  %p12 %p13.b
 2550f9c0 : ptest p14, p14.b                          : ptest  %p14 %p14.b
 
+# RDFFR   <Pd>.B (RDFFR-P.F-_)
+2519f000 : rdffr p0.b                                : rdffr   -> %p0.b
+2519f001 : rdffr p1.b                                : rdffr   -> %p1.b
+2519f002 : rdffr p2.b                                : rdffr   -> %p2.b
+2519f003 : rdffr p3.b                                : rdffr   -> %p3.b
+2519f004 : rdffr p4.b                                : rdffr   -> %p4.b
+2519f005 : rdffr p5.b                                : rdffr   -> %p5.b
+2519f006 : rdffr p6.b                                : rdffr   -> %p6.b
+2519f007 : rdffr p7.b                                : rdffr   -> %p7.b
+2519f008 : rdffr p8.b                                : rdffr   -> %p8.b
+2519f009 : rdffr p9.b                                : rdffr   -> %p9.b
+2519f00a : rdffr p10.b                               : rdffr   -> %p10.b
+2519f00b : rdffr p11.b                               : rdffr   -> %p11.b
+2519f00c : rdffr p12.b                               : rdffr   -> %p12.b
+2519f00d : rdffr p13.b                               : rdffr   -> %p13.b
+2519f00e : rdffr p14.b                               : rdffr   -> %p14.b
+2519f00f : rdffr p15.b                               : rdffr   -> %p15.b
+
+# RDFFR   <Pd>.B, <Pg>/Z (RDFFR-P.P.F-_)
+2518f000 : rdffr p0.b, p0/Z                          : rdffr  %p0/z -> %p0.b
+2518f041 : rdffr p1.b, p2/Z                          : rdffr  %p2/z -> %p1.b
+2518f062 : rdffr p2.b, p3/Z                          : rdffr  %p3/z -> %p2.b
+2518f083 : rdffr p3.b, p4/Z                          : rdffr  %p4/z -> %p3.b
+2518f0a4 : rdffr p4.b, p5/Z                          : rdffr  %p5/z -> %p4.b
+2518f0c5 : rdffr p5.b, p6/Z                          : rdffr  %p6/z -> %p5.b
+2518f0e6 : rdffr p6.b, p7/Z                          : rdffr  %p7/z -> %p6.b
+2518f107 : rdffr p7.b, p8/Z                          : rdffr  %p8/z -> %p7.b
+2518f128 : rdffr p8.b, p9/Z                          : rdffr  %p9/z -> %p8.b
+2518f128 : rdffr p8.b, p9/Z                          : rdffr  %p9/z -> %p8.b
+2518f149 : rdffr p9.b, p10/Z                         : rdffr  %p10/z -> %p9.b
+2518f16a : rdffr p10.b, p11/Z                        : rdffr  %p11/z -> %p10.b
+2518f18b : rdffr p11.b, p12/Z                        : rdffr  %p12/z -> %p11.b
+2518f1ac : rdffr p12.b, p13/Z                        : rdffr  %p13/z -> %p12.b
+2518f1cd : rdffr p13.b, p14/Z                        : rdffr  %p14/z -> %p13.b
+2518f1ef : rdffr p15.b, p15/Z                        : rdffr  %p15/z -> %p15.b
+
+# RDFFRS  <Pd>.B, <Pg>/Z (RDFFRS-P.P.F-_)
+2558f000 : rdffrs p0.b, p0/Z                         : rdffrs %p0/z -> %p0.b
+2558f041 : rdffrs p1.b, p2/Z                         : rdffrs %p2/z -> %p1.b
+2558f062 : rdffrs p2.b, p3/Z                         : rdffrs %p3/z -> %p2.b
+2558f083 : rdffrs p3.b, p4/Z                         : rdffrs %p4/z -> %p3.b
+2558f0a4 : rdffrs p4.b, p5/Z                         : rdffrs %p5/z -> %p4.b
+2558f0c5 : rdffrs p5.b, p6/Z                         : rdffrs %p6/z -> %p5.b
+2558f0e6 : rdffrs p6.b, p7/Z                         : rdffrs %p7/z -> %p6.b
+2558f107 : rdffrs p7.b, p8/Z                         : rdffrs %p8/z -> %p7.b
+2558f128 : rdffrs p8.b, p9/Z                         : rdffrs %p9/z -> %p8.b
+2558f128 : rdffrs p8.b, p9/Z                         : rdffrs %p9/z -> %p8.b
+2558f149 : rdffrs p9.b, p10/Z                        : rdffrs %p10/z -> %p9.b
+2558f16a : rdffrs p10.b, p11/Z                       : rdffrs %p11/z -> %p10.b
+2558f18b : rdffrs p11.b, p12/Z                       : rdffrs %p12/z -> %p11.b
+2558f1ac : rdffrs p12.b, p13/Z                       : rdffrs %p13/z -> %p12.b
+2558f1cd : rdffrs p13.b, p14/Z                       : rdffrs %p14/z -> %p13.b
+2558f1ef : rdffrs p15.b, p15/Z                       : rdffrs %p15/z -> %p15.b
+
 # SABD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SABD-Z.P.ZZ-_)
 040c0000 : sabd z0.b, p0/M, z0.b, z0.b               : sabd   %p0/m %z0.b %z0.b -> %z0.b
 040c0482 : sabd z2.b, p1/M, z2.b, z4.b               : sabd   %p1/m %z2.b %z4.b -> %z2.b
@@ -3568,6 +3622,9 @@
 04d61f79 : sdivr z25.d, p7/M, z25.d, z27.d           : sdivr  %p7/m %z25.d %z27.d -> %z25.d
 04d61fbb : sdivr z27.d, p7/M, z27.d, z29.d           : sdivr  %p7/m %z27.d %z29.d -> %z27.d
 04d61fff : sdivr z31.d, p7/M, z31.d, z31.d           : sdivr  %p7/m %z31.d %z31.d -> %z31.d
+
+# SETFFR   (SETFFR-F-_)
+252c9000 : setffr                                    : setffr
 
 # SMAX    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SMAX-Z.P.ZZ-_)
 04080000 : smax z0.b, p0/M, z0.b, z0.b               : smax   %p0/m %z0.b %z0.b -> %z0.b
@@ -5424,6 +5481,24 @@
 04d5bf79 : uxtw z25.d, p7/M, z27.d                   : uxtw   %p7/m %z27.d -> %z25.d
 04d5bfbb : uxtw z27.d, p7/M, z29.d                   : uxtw   %p7/m %z29.d -> %z27.d
 04d5bfff : uxtw z31.d, p7/M, z31.d                   : uxtw   %p7/m %z31.d -> %z31.d
+
+# WRFFR   <Pn>.B (WRFFR-F.P-_)
+25289000 : wrffr p0.b                                : wrffr  %p0.b
+25289020 : wrffr p1.b                                : wrffr  %p1.b
+25289040 : wrffr p2.b                                : wrffr  %p2.b
+25289060 : wrffr p3.b                                : wrffr  %p3.b
+25289080 : wrffr p4.b                                : wrffr  %p4.b
+252890a0 : wrffr p5.b                                : wrffr  %p5.b
+252890c0 : wrffr p6.b                                : wrffr  %p6.b
+252890e0 : wrffr p7.b                                : wrffr  %p7.b
+25289100 : wrffr p8.b                                : wrffr  %p8.b
+25289100 : wrffr p8.b                                : wrffr  %p8.b
+25289120 : wrffr p9.b                                : wrffr  %p9.b
+25289140 : wrffr p10.b                               : wrffr  %p10.b
+25289160 : wrffr p11.b                               : wrffr  %p11.b
+25289180 : wrffr p12.b                               : wrffr  %p12.b
+252891a0 : wrffr p13.b                               : wrffr  %p13.b
+252891e0 : wrffr p15.b                               : wrffr  %p15.b
 
 # ZIP2    <Zd>.Q, <Zn>.Q, <Zm>.Q (ZIP2-Z.ZZ-Q)
 05a00400 : zip2 z0.q, z0.q, z0.q                     : zip2   %z0.q %z0.q -> %z0.q

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -58,6 +58,11 @@ static byte buf[8192];
         result = false;                                           \
     }
 
+#define TEST_NO_OPNDS(opcode, create_name, expected)    \
+    instr = INSTR_CREATE_##create_name(dc);                     \
+    if (!test_instr_encoding(dc, OP_##opcode, instr, expected)) \
+        *psuccess = false;
+
 #define TEST_LOOP(opcode, create_name, number, expected, args...)   \
     for (int i = 0; i < number; i++) {                              \
         instr = INSTR_CREATE_##create_name(dc, args);               \

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -58,7 +58,7 @@ static byte buf[8192];
         result = false;                                           \
     }
 
-#define TEST_NO_OPNDS(opcode, create_name, expected)    \
+#define TEST_NO_OPNDS(opcode, create_name, expected)            \
     instr = INSTR_CREATE_##create_name(dc);                     \
     if (!test_instr_encoding(dc, OP_##opcode, instr, expected)) \
         *psuccess = false;

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -4119,6 +4119,60 @@ TEST_INSTR(cmpne_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
 }
+
+TEST_INSTR(rdffr_sve)
+{
+    /* Testing RDFFR   <Pd>.B */
+    const char *expected_0_0[6] = {
+        "rdffr   -> %p0.b", "rdffr   -> %p2.b",  "rdffr   -> %p5.b",
+        "rdffr   -> %p8.b", "rdffr   -> %p10.b", "rdffr   -> %p15.b",
+    };
+    TEST_LOOP(rdffr, rdffr_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1));
+}
+
+TEST_INSTR(rdffr_sve_pred)
+{
+    /* Testing RDFFR   <Pd>.B, <Pg>/Z */
+    const char *expected_0_0[6] = {
+        "rdffr  %p0/z -> %p0.b", "rdffr  %p3/z -> %p2.b",   "rdffr  %p6/z -> %p5.b",
+        "rdffr  %p9/z -> %p8.b", "rdffr  %p11/z -> %p10.b", "rdffr  %p15/z -> %p15.b",
+    };
+    TEST_LOOP(rdffr, rdffr_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false));
+}
+
+TEST_INSTR(rdffrs_sve_pred)
+{
+    /* Testing RDFFRS  <Pd>.B, <Pg>/Z */
+    const char *expected_0_0[6] = {
+        "rdffrs %p0/z -> %p0.b", "rdffrs %p3/z -> %p2.b",   "rdffrs %p6/z -> %p5.b",
+        "rdffrs %p9/z -> %p8.b", "rdffrs %p11/z -> %p10.b", "rdffrs %p15/z -> %p15.b",
+    };
+    TEST_LOOP(rdffrs, rdffrs_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false));
+}
+
+TEST_INSTR(wrffr_sve)
+{
+
+    /* Testing WRFFR   <Pn>.B */
+    const char *expected_0_0[6] = {
+        "wrffr  %p0.b", "wrffr  %p2.b",  "wrffr  %p5.b",
+        "wrffr  %p8.b", "wrffr  %p10.b", "wrffr  %p15.b",
+    };
+    TEST_LOOP(wrffr, wrffr_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1));
+}
+
+TEST_INSTR(setffr_sve)
+{
+    /* Testing SETFFR */
+    TEST_NO_OPNDS(setffr, setffr_sve, "setffr");
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -4231,6 +4285,12 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(cmplt_sve_pred);
     RUN_INSTR_TEST(cmpne_sve_pred_simm);
     RUN_INSTR_TEST(cmpne_sve_pred);
+
+    RUN_INSTR_TEST(rdffr_sve_pred);
+    RUN_INSTR_TEST(rdffr_sve);
+    RUN_INSTR_TEST(rdffrs_sve_pred);
+    RUN_INSTR_TEST(setffr_sve);
+    RUN_INSTR_TEST(wrffr_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to decode and encode the following instructions:
RDFFR <Pd>.B
RDFFR <Pd>.B, <Pg>/Z
RDFFRS <Pd>.B, <Pg>/Z
SETFFR
WRFFR <Pn>.B

The First Fault register is currently not part of the machine state (mcxtx_api.h). Handling of the FFR in the core and the API will be added in later patches.

Issue: #3044