### PR TITLE
i#5771 mangle mrs ctr.el0 for aarch64

### DIFF
--- a/core/dispatch.c
+++ b/core/dispatch.c
@@ -941,9 +941,13 @@ dispatch_enter_dynamorio(dcontext_t *dcontext)
             app_pc begin = (app_pc)dcontext->local_state->spill_space.r2;
             app_pc end = (app_pc)dcontext->local_state->spill_space.r3;
             dcontext->next_tag = (app_pc)dcontext->local_state->spill_space.r4;
-            flush_fragments_from_region(dcontext, begin, end - begin, true,
-                                        NULL /*flush_completion_callback*/,
-                                        NULL /*user_data*/);
+            if (end > begin) {
+              flush_fragments_from_region(dcontext, begin, end - begin, true,
+                                          NULL /*flush_completion_callback*/,
+                                          NULL /*user_data*/);
+            } else {
+              LOG(THREAD, LOG_DISPATCH, 2, "WARNING: skip selfmod region from %llx to %llx, size %d\n", begin, end, end-begin);
+            }
         }
 #endif
 

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -288,6 +288,10 @@ instr_is_icache_op(instr_t *instr)
         return true; /* ic ivau, xT */
     if (opc == OP_isb)
         return true; /* isb */
+    if (opc == OP_mrs &&
+        opnd_is_reg(instr_get_src(instr, 0)) &&
+        opnd_get_reg(instr_get_src(instr, 0)) == DR_REG_CTR_EL0) /* mrs ctr_el0 */
+        return true;
     return false;
 }
 


### PR DESCRIPTION
ic_ivau is not required for new aarch64 hardware. Dynamorio depends this instruction to detect self modify code region. So the region may be skipped in new hardware.

This fix mangle "mrs ctr.el0" to disable DIC, so ic_ivau can be executed.

JVM sometimes flush empty stubs, check the range before flush fragments

Fix: #5771