### PR TITLE
i#3044 AArch64 SVE codec: Add unconstrained predicate count instructions

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4655,6 +4655,31 @@ decode_opnd_bhsd_size_reg5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 }
 
 static inline bool
+decode_opnd_p_size_bhsd_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_p(5, 22, BYTE_REG, DOUBLE_REG, enc, pc, opnd);
+}
+
+static inline bool
+encode_opnd_p_size_bhsd_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_sized_p(5, 22, BYTE_REG, DOUBLE_REG, opnd, enc_out);
+}
+
+static inline bool
+decode_opnd_p_size_hsd_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_p(5, 22, HALF_REG, DOUBLE_REG, enc, pc, opnd);
+}
+
+static inline bool
+encode_opnd_p_size_hsd_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_sized_p(5, 22, HALF_REG, DOUBLE_REG, opnd, enc_out);
+}
+
+
+static inline bool
 encode_opnd_bhsd_size_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_bhsd_size_regx(5, enc, opcode, pc, opnd, enc_out);

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4678,7 +4678,6 @@ encode_opnd_p_size_hsd_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *
     return encode_sized_p(5, 22, HALF_REG, DOUBLE_REG, opnd, enc_out);
 }
 
-
 static inline bool
 encode_opnd_bhsd_size_reg5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -73,8 +73,11 @@
 00100100xx0xxxxx001xxxxxxxx1xxxx  w   816  SVE    cmpne   p_size_bhs_0 : p10_zer_lo z_size_bhs_5 z_d_16
 00100100xx0xxxxx101xxxxxxxx1xxxx  w   816  SVE    cmpne  p_size_bhsd_0 : p10_zer_lo z_size_bhsd_5 z_size_bhsd_16
 00000100xx011011101xxxxxxxxxxxxx  n   793  SVE     cnot  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
+00100101xx10000010xxxx0xxxxxxxxx  n   821  SVE     cntp             x0 : p10 p_size_bhsd_5
 00000101xx01xxxx00xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_zer simm8_5 lsl shift1
 00000101xx01xxxx01xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_mrg simm8_5 lsl shift1
+00100101xx1011011000100xxxxxxxxx  n   822  SVE     decp             x0 : p_size_bhsd_5 x0
+00100101xx1011011000000xxxxxxxxx  n   822  SVE     decp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor             z0 : p10_lo z0 z5 bhsd_sz
 01100101xx0xxxxx110xxxxxxxx1xxxx  n   96   SVE    facge   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx0xxxxx111xxxxxxxx1xxxx  n   97   SVE    facgt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
@@ -93,6 +96,8 @@
 01100101xx010xxx100000xxxxxxxxxx  n   790  SVE    ftmad   z_size_hsd_0 : z_size_hsd_0 z_size_hsd_5 imm3
 01100101xx0xxxxx000011xxxxxxxxxx  n   791  SVE   ftsmul   z_size_hsd_0 : z_size_hsd_5 z_size_hsd_16
 00000100xx1xxxxx101100xxxxxxxxxx  n   792  SVE   ftssel   z_size_hsd_0 : z_size_hsd_5 z_size_hsd_16
+00100101xx1011001000100xxxxxxxxx  n   823  SVE     incp             x0 : p_size_bhsd_5 x0
+00100101xx1011001000000xxxxxxxxx  n   823  SVE     incp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 00000100xx0xxxxx110xxxxxxxxxxxxx  n   787  SVE      mad  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_16 z_size_bhsd_5
 00000100xx0xxxxx010xxxxxxxxxxxxx  n   312  SVE      mla  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16 z_size_bhsd_0
 00000100xx0xxxxx011xxxxxxxxxxxxx  n   313  SVE      mls  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16 z_size_bhsd_0
@@ -118,6 +123,12 @@
 00000100xx1xxxxx000100xxxxxxxxxx  n   403  SVE    sqadd             z0 : z5 z16 bhsd_sz
 00100101xx10010011xxxxxxxxxxxxxx  n   403  SVE    sqadd  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000100xxxxxxxxxx  n   403  SVE    sqadd  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+00100101xx1010101000100xxxxxxxxx  n   824  SVE   sqdecp             x0 : p_size_bhsd_5 w0
+00100101xx1010101000110xxxxxxxxx  n   824  SVE   sqdecp             x0 : p_size_bhsd_5 x0
+00100101xx1010101000000xxxxxxxxx  n   824  SVE   sqdecp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1010001000100xxxxxxxxx  n   825  SVE   sqincp             x0 : p_size_bhsd_5 w0
+00100101xx1010001000110xxxxxxxxx  n   825  SVE   sqincp             x0 : p_size_bhsd_5 x0
+00100101xx1010001000000xxxxxxxxx  n   825  SVE   sqincp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub             z0 : z5 z16 bhsd_sz
 00100101xx10011011xxxxxxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
@@ -141,6 +152,12 @@
 00000100xx1xxxxx000101xxxxxxxxxx  n   531  SVE    uqadd             z0 : z5 z16 bhsd_sz
 00100101xx10010111xxxxxxxxxxxxxx  n   531  SVE    uqadd  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000101xxxxxxxxxx  n   531  SVE    uqadd  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+00100101xx1010111000100xxxxxxxxx  n   826  SVE   uqdecp             w0 : p_size_bhsd_5 w0
+00100101xx1010111000110xxxxxxxxx  n   826  SVE   uqdecp             x0 : p_size_bhsd_5 x0
+00100101xx1010111000000xxxxxxxxx  n   826  SVE   uqdecp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1010011000100xxxxxxxxx  n   827  SVE   uqincp             w0 : p_size_bhsd_5 w0
+00100101xx1010011000110xxxxxxxxx  n   827  SVE   uqincp             x0 : p_size_bhsd_5 x0
+00100101xx1010011000000xxxxxxxxx  n   827  SVE   uqincp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 00000100xx1xxxxx000111xxxxxxxxxx  n   538  SVE    uqsub             z0 : z5 z16 bhsd_sz
 00100101xx10011111xxxxxxxxxxxxxx  n   538  SVE    uqsub  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000111xxxxxxxxxx  n   538  SVE    uqsub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -6428,4 +6428,219 @@
  * \param Pn   The source predicate register, P (Predicate)
  */
 #define INSTR_CREATE_wrffr_sve(dc, Pn) instr_create_0dst_1src(dc, OP_wrffr, Pn)
+
+/**
+ * Creates a CNTP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    CNTP    <Xd>, <Pg>, <Pn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The destination  register, X (Extended, 64 bits).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_cntp_sve_pred(dc, Rd, Pg, Pn) \
+    instr_create_1dst_2src(dc, OP_cntp, Rd, Pg, Pn)
+
+/**
+ * Creates a DECP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    DECP    <Xdn>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The second source and destination  register, X (Extended, 64 bits).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_decp_sve(dc, Rdn, Pm) \
+    instr_create_1dst_2src(dc, OP_decp, Rdn, Pm, Rdn)
+
+/**
+ * Creates a DECP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    DECP    <Zdn>.<Ts>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The second source and destination vector register, Z (Scalable).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_decp_sve_vector(dc, Zdn, Pm) \
+    instr_create_1dst_2src(dc, OP_decp, Zdn, Pm, Zdn)
+
+/**
+ * Creates an INCP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    INCP    <Xdn>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The second source and destination  register, X (Extended, 64 bits).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_incp_sve(dc, Rdn, Pm) \
+    instr_create_1dst_2src(dc, OP_incp, Rdn, Pm, Rdn)
+
+/**
+ * Creates an INCP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    INCP    <Zdn>.<Ts>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The second source and destination vector register, Z (Scalable).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_incp_sve_vector(dc, Zdn, Pm) \
+    instr_create_1dst_2src(dc, OP_incp, Zdn, Pm, Zdn)
+
+/**
+ * Creates a SQDECP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SQDECP  <Xdn>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The source and destination register, X (Extended, 64 bits).
+ * \param Pm   The source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_sqdecp_sve(dc, Rdn, Pm) \
+    instr_create_1dst_2src(dc, OP_sqdecp, Rdn, Pm, Rdn)
+
+/**
+ * Creates a SQDECP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SQDECP  <Xdn>, <Pm>.<Ts>, <Wdn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The second source and destination  register, X (Extended, 64 bits).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_sqdecp_sve_wide(dc, Rdn, Pm)  \
+    instr_create_1dst_2src(dc, OP_sqdecp, Rdn, Pm, \
+                           opnd_create_reg(opnd_get_reg(Rdn) - DR_REG_X0 + DR_REG_W0))
+
+/**
+ * Creates a SQDECP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The second source and destination vector register, Z (Scalable).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_sqdecp_sve_vector(dc, Zdn, Pm) \
+    instr_create_1dst_2src(dc, OP_sqdecp, Zdn, Pm, Zdn)
+
+/**
+ * Creates a SQINCP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SQINCP  <Xdn>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The second source and destination  register, X (Extended, 64 bits).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_sqincp_sve(dc, Rdn, Pm) \
+    instr_create_1dst_2src(dc, OP_sqincp, Rdn, Pm, Rdn)
+
+/**
+ * Creates a SQINCP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SQINCP  <Xdn>, <Pm>.<Ts>, <Wdn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The second source and destination  register, X (Extended, 64 bits).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_sqincp_sve_wide(dc, Rdn, Pm)  \
+    instr_create_1dst_2src(dc, OP_sqincp, Rdn, Pm, \
+                           opnd_create_reg(opnd_get_reg(Rdn) - DR_REG_X0 + DR_REG_W0))
+
+/**
+ * Creates a SQINCP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The second source and destination vector register, Z (Scalable).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_sqincp_sve_vector(dc, Zdn, Pm) \
+    instr_create_1dst_2src(dc, OP_sqincp, Zdn, Pm, Zdn)
+
+/**
+ * Creates an UQDECP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UQDECP  <Wdn>, <Pm>.<Ts>
+ *    UQDECP  <Xdn>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The second source and destination  register. Can be X (Extended, 64 bits)
+ * or W (Word, 32 bits). \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_uqdecp_sve(dc, Rdn, Pm) \
+    instr_create_1dst_2src(dc, OP_uqdecp, Rdn, Pm, Rdn)
+
+/**
+ * Creates an UQDECP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The second source and destination vector register, Z (Scalable).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_uqdecp_sve_vector(dc, Zdn, Pm) \
+    instr_create_1dst_2src(dc, OP_uqdecp, Zdn, Pm, Zdn)
+
+/**
+ * Creates an UQINCP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UQINCP  <Wdn>, <Pm>.<Ts>
+ *    UQINCP  <Xdn>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rdn   The second source and destination  register. Can be X (Extended, 64 bits)
+ * or W (Word, 32 bits). \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_uqincp_sve(dc, Rdn, Pm) \
+    instr_create_1dst_2src(dc, OP_uqincp, Rdn, Pm, Rdn)
+
+/**
+ * Creates an UQINCP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The second source and destination vector register, Z (Scalable).
+ * \param Pm   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_uqincp_sve_vector(dc, Zdn, Pm) \
+    instr_create_1dst_2src(dc, OP_uqincp, Zdn, Pm, Zdn)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -218,6 +218,8 @@
 --------xx------------xxxxx-----  float_reg5  # H, S or D register
 --------xx------------xxxxx-----  hsd_size_reg5    # hsd register, depending on size opcode
 --------xx------------xxxxx-----  bhsd_size_reg5   # bhsd register, depending on size opcode
+--------xx------------xxxxx-----  p_size_bhsd_5    # sve predicate vector reg, elsz depending on size
+--------xx------------xxxxx-----  p_size_hsd_5     # sve predicate vector reg, elsz depending on size
 --------xx------------xxxxx-----  z_size_bhsd_5    # sve vector reg, elsz depending on size
 --------xx------------xxxxx-----  z_size_bhs_5     # sve vector reg, elsz depending on size
 --------xx------------xxxxx-----  z_size_hsd_5     # sve vector reg, elsz depending on size

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -1945,6 +1945,72 @@
 04dbbfbb : cnot z27.d, p7/M, z29.d                   : cnot   %p7/m %z29.d -> %z27.d
 04dbbfff : cnot z31.d, p7/M, z31.d                   : cnot   %p7/m %z31.d -> %z31.d
 
+# CNTP    <Xd>, <Pg>, <Pn>.<T> (CNTP-R.P.P-_)
+25208000 : cntp x0, p0, p0.b                         : cntp   %p0 %p0.b -> %x0
+25208862 : cntp x2, p2, p3.b                         : cntp   %p2 %p3.b -> %x2
+25208c84 : cntp x4, p3, p4.b                         : cntp   %p3 %p4.b -> %x4
+252090a6 : cntp x6, p4, p5.b                         : cntp   %p4 %p5.b -> %x6
+252094c8 : cntp x8, p5, p6.b                         : cntp   %p5 %p6.b -> %x8
+252098e9 : cntp x9, p6, p7.b                         : cntp   %p6 %p7.b -> %x9
+25209d0b : cntp x11, p7, p8.b                        : cntp   %p7 %p8.b -> %x11
+2520a12d : cntp x13, p8, p9.b                        : cntp   %p8 %p9.b -> %x13
+2520a54f : cntp x15, p9, p10.b                       : cntp   %p9 %p10.b -> %x15
+2520a551 : cntp x17, p9, p10.b                       : cntp   %p9 %p10.b -> %x17
+2520a973 : cntp x19, p10, p11.b                      : cntp   %p10 %p11.b -> %x19
+2520ad95 : cntp x21, p11, p12.b                      : cntp   %p11 %p12.b -> %x21
+2520b1b6 : cntp x22, p12, p13.b                      : cntp   %p12 %p13.b -> %x22
+2520b5d8 : cntp x24, p13, p14.b                      : cntp   %p13 %p14.b -> %x24
+2520b9fa : cntp x26, p14, p15.b                      : cntp   %p14 %p15.b -> %x26
+2520bdfe : cntp x30, p15, p15.b                      : cntp   %p15 %p15.b -> %x30
+25608000 : cntp x0, p0, p0.h                         : cntp   %p0 %p0.h -> %x0
+25608862 : cntp x2, p2, p3.h                         : cntp   %p2 %p3.h -> %x2
+25608c84 : cntp x4, p3, p4.h                         : cntp   %p3 %p4.h -> %x4
+256090a6 : cntp x6, p4, p5.h                         : cntp   %p4 %p5.h -> %x6
+256094c8 : cntp x8, p5, p6.h                         : cntp   %p5 %p6.h -> %x8
+256098e9 : cntp x9, p6, p7.h                         : cntp   %p6 %p7.h -> %x9
+25609d0b : cntp x11, p7, p8.h                        : cntp   %p7 %p8.h -> %x11
+2560a12d : cntp x13, p8, p9.h                        : cntp   %p8 %p9.h -> %x13
+2560a54f : cntp x15, p9, p10.h                       : cntp   %p9 %p10.h -> %x15
+2560a551 : cntp x17, p9, p10.h                       : cntp   %p9 %p10.h -> %x17
+2560a973 : cntp x19, p10, p11.h                      : cntp   %p10 %p11.h -> %x19
+2560ad95 : cntp x21, p11, p12.h                      : cntp   %p11 %p12.h -> %x21
+2560b1b6 : cntp x22, p12, p13.h                      : cntp   %p12 %p13.h -> %x22
+2560b5d8 : cntp x24, p13, p14.h                      : cntp   %p13 %p14.h -> %x24
+2560b9fa : cntp x26, p14, p15.h                      : cntp   %p14 %p15.h -> %x26
+2560bdfe : cntp x30, p15, p15.h                      : cntp   %p15 %p15.h -> %x30
+25a08000 : cntp x0, p0, p0.s                         : cntp   %p0 %p0.s -> %x0
+25a08862 : cntp x2, p2, p3.s                         : cntp   %p2 %p3.s -> %x2
+25a08c84 : cntp x4, p3, p4.s                         : cntp   %p3 %p4.s -> %x4
+25a090a6 : cntp x6, p4, p5.s                         : cntp   %p4 %p5.s -> %x6
+25a094c8 : cntp x8, p5, p6.s                         : cntp   %p5 %p6.s -> %x8
+25a098e9 : cntp x9, p6, p7.s                         : cntp   %p6 %p7.s -> %x9
+25a09d0b : cntp x11, p7, p8.s                        : cntp   %p7 %p8.s -> %x11
+25a0a12d : cntp x13, p8, p9.s                        : cntp   %p8 %p9.s -> %x13
+25a0a54f : cntp x15, p9, p10.s                       : cntp   %p9 %p10.s -> %x15
+25a0a551 : cntp x17, p9, p10.s                       : cntp   %p9 %p10.s -> %x17
+25a0a973 : cntp x19, p10, p11.s                      : cntp   %p10 %p11.s -> %x19
+25a0ad95 : cntp x21, p11, p12.s                      : cntp   %p11 %p12.s -> %x21
+25a0b1b6 : cntp x22, p12, p13.s                      : cntp   %p12 %p13.s -> %x22
+25a0b5d8 : cntp x24, p13, p14.s                      : cntp   %p13 %p14.s -> %x24
+25a0b9fa : cntp x26, p14, p15.s                      : cntp   %p14 %p15.s -> %x26
+25a0bdfe : cntp x30, p15, p15.s                      : cntp   %p15 %p15.s -> %x30
+25e08000 : cntp x0, p0, p0.d                         : cntp   %p0 %p0.d -> %x0
+25e08862 : cntp x2, p2, p3.d                         : cntp   %p2 %p3.d -> %x2
+25e08c84 : cntp x4, p3, p4.d                         : cntp   %p3 %p4.d -> %x4
+25e090a6 : cntp x6, p4, p5.d                         : cntp   %p4 %p5.d -> %x6
+25e094c8 : cntp x8, p5, p6.d                         : cntp   %p5 %p6.d -> %x8
+25e098e9 : cntp x9, p6, p7.d                         : cntp   %p6 %p7.d -> %x9
+25e09d0b : cntp x11, p7, p8.d                        : cntp   %p7 %p8.d -> %x11
+25e0a12d : cntp x13, p8, p9.d                        : cntp   %p8 %p9.d -> %x13
+25e0a54f : cntp x15, p9, p10.d                       : cntp   %p9 %p10.d -> %x15
+25e0a551 : cntp x17, p9, p10.d                       : cntp   %p9 %p10.d -> %x17
+25e0a973 : cntp x19, p10, p11.d                      : cntp   %p10 %p11.d -> %x19
+25e0ad95 : cntp x21, p11, p12.d                      : cntp   %p11 %p12.d -> %x21
+25e0b1b6 : cntp x22, p12, p13.d                      : cntp   %p12 %p13.d -> %x22
+25e0b5d8 : cntp x24, p13, p14.d                      : cntp   %p13 %p14.d -> %x24
+25e0b9fa : cntp x26, p14, p15.d                      : cntp   %p14 %p15.d -> %x26
+25e0bdfe : cntp x30, p15, p15.d                      : cntp   %p15 %p15.d -> %x30
+
 # CPY     <Zd>.<T>, <Pg>/Z, #<imm>, <shift> (CPY-Z.O.I-_)
 05101000 : cpy z0.b, p0/Z, #-0x80, lsl #0            : cpy    %p0/z $0x80 lsl $0x00 -> %z0.b
 05121202 : cpy z2.b, p2/Z, #-0x70, lsl #0            : cpy    %p2/z $0x90 lsl $0x00 -> %z2.b
@@ -2076,6 +2142,122 @@
 05dc49f8 : cpy z24.d, p12/M, #0x4f, lsl #0           : cpy    %p12/m $0x4f lsl $0x00 -> %z24.d
 05dd4bfa : cpy z26.d, p13/M, #0x5f, lsl #0           : cpy    %p13/m $0x5f lsl $0x00 -> %z26.d
 05de4ffe : cpy z30.d, p14/M, #0x7f, lsl #0           : cpy    %p14/m $0x7f lsl $0x00 -> %z30.d
+
+# DECP    <Xdn>, <Pm>.<T> (DECP-R.P.R-_)
+252d8800 : decp x0, p0.b                             : decp   %p0.b %x0 -> %x0
+252d8842 : decp x2, p2.b                             : decp   %p2.b %x2 -> %x2
+252d8864 : decp x4, p3.b                             : decp   %p3.b %x4 -> %x4
+252d8886 : decp x6, p4.b                             : decp   %p4.b %x6 -> %x6
+252d88a8 : decp x8, p5.b                             : decp   %p5.b %x8 -> %x8
+252d88c9 : decp x9, p6.b                             : decp   %p6.b %x9 -> %x9
+252d88eb : decp x11, p7.b                            : decp   %p7.b %x11 -> %x11
+252d890d : decp x13, p8.b                            : decp   %p8.b %x13 -> %x13
+252d892f : decp x15, p9.b                            : decp   %p9.b %x15 -> %x15
+252d8931 : decp x17, p9.b                            : decp   %p9.b %x17 -> %x17
+252d8953 : decp x19, p10.b                           : decp   %p10.b %x19 -> %x19
+252d8975 : decp x21, p11.b                           : decp   %p11.b %x21 -> %x21
+252d8996 : decp x22, p12.b                           : decp   %p12.b %x22 -> %x22
+252d89b8 : decp x24, p13.b                           : decp   %p13.b %x24 -> %x24
+252d89da : decp x26, p14.b                           : decp   %p14.b %x26 -> %x26
+252d89fe : decp x30, p15.b                           : decp   %p15.b %x30 -> %x30
+256d8800 : decp x0, p0.h                             : decp   %p0.h %x0 -> %x0
+256d8842 : decp x2, p2.h                             : decp   %p2.h %x2 -> %x2
+256d8864 : decp x4, p3.h                             : decp   %p3.h %x4 -> %x4
+256d8886 : decp x6, p4.h                             : decp   %p4.h %x6 -> %x6
+256d88a8 : decp x8, p5.h                             : decp   %p5.h %x8 -> %x8
+256d88c9 : decp x9, p6.h                             : decp   %p6.h %x9 -> %x9
+256d88eb : decp x11, p7.h                            : decp   %p7.h %x11 -> %x11
+256d890d : decp x13, p8.h                            : decp   %p8.h %x13 -> %x13
+256d892f : decp x15, p9.h                            : decp   %p9.h %x15 -> %x15
+256d8931 : decp x17, p9.h                            : decp   %p9.h %x17 -> %x17
+256d8953 : decp x19, p10.h                           : decp   %p10.h %x19 -> %x19
+256d8975 : decp x21, p11.h                           : decp   %p11.h %x21 -> %x21
+256d8996 : decp x22, p12.h                           : decp   %p12.h %x22 -> %x22
+256d89b8 : decp x24, p13.h                           : decp   %p13.h %x24 -> %x24
+256d89da : decp x26, p14.h                           : decp   %p14.h %x26 -> %x26
+256d89fe : decp x30, p15.h                           : decp   %p15.h %x30 -> %x30
+25ad8800 : decp x0, p0.s                             : decp   %p0.s %x0 -> %x0
+25ad8842 : decp x2, p2.s                             : decp   %p2.s %x2 -> %x2
+25ad8864 : decp x4, p3.s                             : decp   %p3.s %x4 -> %x4
+25ad8886 : decp x6, p4.s                             : decp   %p4.s %x6 -> %x6
+25ad88a8 : decp x8, p5.s                             : decp   %p5.s %x8 -> %x8
+25ad88c9 : decp x9, p6.s                             : decp   %p6.s %x9 -> %x9
+25ad88eb : decp x11, p7.s                            : decp   %p7.s %x11 -> %x11
+25ad890d : decp x13, p8.s                            : decp   %p8.s %x13 -> %x13
+25ad892f : decp x15, p9.s                            : decp   %p9.s %x15 -> %x15
+25ad8931 : decp x17, p9.s                            : decp   %p9.s %x17 -> %x17
+25ad8953 : decp x19, p10.s                           : decp   %p10.s %x19 -> %x19
+25ad8975 : decp x21, p11.s                           : decp   %p11.s %x21 -> %x21
+25ad8996 : decp x22, p12.s                           : decp   %p12.s %x22 -> %x22
+25ad89b8 : decp x24, p13.s                           : decp   %p13.s %x24 -> %x24
+25ad89da : decp x26, p14.s                           : decp   %p14.s %x26 -> %x26
+25ad89fe : decp x30, p15.s                           : decp   %p15.s %x30 -> %x30
+25ed8800 : decp x0, p0.d                             : decp   %p0.d %x0 -> %x0
+25ed8842 : decp x2, p2.d                             : decp   %p2.d %x2 -> %x2
+25ed8864 : decp x4, p3.d                             : decp   %p3.d %x4 -> %x4
+25ed8886 : decp x6, p4.d                             : decp   %p4.d %x6 -> %x6
+25ed88a8 : decp x8, p5.d                             : decp   %p5.d %x8 -> %x8
+25ed88c9 : decp x9, p6.d                             : decp   %p6.d %x9 -> %x9
+25ed88eb : decp x11, p7.d                            : decp   %p7.d %x11 -> %x11
+25ed890d : decp x13, p8.d                            : decp   %p8.d %x13 -> %x13
+25ed892f : decp x15, p9.d                            : decp   %p9.d %x15 -> %x15
+25ed8931 : decp x17, p9.d                            : decp   %p9.d %x17 -> %x17
+25ed8953 : decp x19, p10.d                           : decp   %p10.d %x19 -> %x19
+25ed8975 : decp x21, p11.d                           : decp   %p11.d %x21 -> %x21
+25ed8996 : decp x22, p12.d                           : decp   %p12.d %x22 -> %x22
+25ed89b8 : decp x24, p13.d                           : decp   %p13.d %x24 -> %x24
+25ed89da : decp x26, p14.d                           : decp   %p14.d %x26 -> %x26
+25ed89fe : decp x30, p15.d                           : decp   %p15.d %x30 -> %x30
+
+# DECP    <Zdn>.<T>, <Pm>.<T> (DECP-Z.P.Z-_)
+256d8000 : decp z0.h, p0                             : decp   %p0.h %z0.h -> %z0.h
+256d8042 : decp z2.h, p2                             : decp   %p2.h %z2.h -> %z2.h
+256d8064 : decp z4.h, p3                             : decp   %p3.h %z4.h -> %z4.h
+256d8086 : decp z6.h, p4                             : decp   %p4.h %z6.h -> %z6.h
+256d80a8 : decp z8.h, p5                             : decp   %p5.h %z8.h -> %z8.h
+256d80ca : decp z10.h, p6                            : decp   %p6.h %z10.h -> %z10.h
+256d80ec : decp z12.h, p7                            : decp   %p7.h %z12.h -> %z12.h
+256d810e : decp z14.h, p8                            : decp   %p8.h %z14.h -> %z14.h
+256d8130 : decp z16.h, p9                            : decp   %p9.h %z16.h -> %z16.h
+256d8131 : decp z17.h, p9                            : decp   %p9.h %z17.h -> %z17.h
+256d8153 : decp z19.h, p10                           : decp   %p10.h %z19.h -> %z19.h
+256d8175 : decp z21.h, p11                           : decp   %p11.h %z21.h -> %z21.h
+256d8197 : decp z23.h, p12                           : decp   %p12.h %z23.h -> %z23.h
+256d81b9 : decp z25.h, p13                           : decp   %p13.h %z25.h -> %z25.h
+256d81db : decp z27.h, p14                           : decp   %p14.h %z27.h -> %z27.h
+256d81ff : decp z31.h, p15                           : decp   %p15.h %z31.h -> %z31.h
+25ad8000 : decp z0.s, p0                             : decp   %p0.s %z0.s -> %z0.s
+25ad8042 : decp z2.s, p2                             : decp   %p2.s %z2.s -> %z2.s
+25ad8064 : decp z4.s, p3                             : decp   %p3.s %z4.s -> %z4.s
+25ad8086 : decp z6.s, p4                             : decp   %p4.s %z6.s -> %z6.s
+25ad80a8 : decp z8.s, p5                             : decp   %p5.s %z8.s -> %z8.s
+25ad80ca : decp z10.s, p6                            : decp   %p6.s %z10.s -> %z10.s
+25ad80ec : decp z12.s, p7                            : decp   %p7.s %z12.s -> %z12.s
+25ad810e : decp z14.s, p8                            : decp   %p8.s %z14.s -> %z14.s
+25ad8130 : decp z16.s, p9                            : decp   %p9.s %z16.s -> %z16.s
+25ad8131 : decp z17.s, p9                            : decp   %p9.s %z17.s -> %z17.s
+25ad8153 : decp z19.s, p10                           : decp   %p10.s %z19.s -> %z19.s
+25ad8175 : decp z21.s, p11                           : decp   %p11.s %z21.s -> %z21.s
+25ad8197 : decp z23.s, p12                           : decp   %p12.s %z23.s -> %z23.s
+25ad81b9 : decp z25.s, p13                           : decp   %p13.s %z25.s -> %z25.s
+25ad81db : decp z27.s, p14                           : decp   %p14.s %z27.s -> %z27.s
+25ad81ff : decp z31.s, p15                           : decp   %p15.s %z31.s -> %z31.s
+25ed8000 : decp z0.d, p0                             : decp   %p0.d %z0.d -> %z0.d
+25ed8042 : decp z2.d, p2                             : decp   %p2.d %z2.d -> %z2.d
+25ed8064 : decp z4.d, p3                             : decp   %p3.d %z4.d -> %z4.d
+25ed8086 : decp z6.d, p4                             : decp   %p4.d %z6.d -> %z6.d
+25ed80a8 : decp z8.d, p5                             : decp   %p5.d %z8.d -> %z8.d
+25ed80ca : decp z10.d, p6                            : decp   %p6.d %z10.d -> %z10.d
+25ed80ec : decp z12.d, p7                            : decp   %p7.d %z12.d -> %z12.d
+25ed810e : decp z14.d, p8                            : decp   %p8.d %z14.d -> %z14.d
+25ed8130 : decp z16.d, p9                            : decp   %p9.d %z16.d -> %z16.d
+25ed8131 : decp z17.d, p9                            : decp   %p9.d %z17.d -> %z17.d
+25ed8153 : decp z19.d, p10                           : decp   %p10.d %z19.d -> %z19.d
+25ed8175 : decp z21.d, p11                           : decp   %p11.d %z21.d -> %z21.d
+25ed8197 : decp z23.d, p12                           : decp   %p12.d %z23.d -> %z23.d
+25ed81b9 : decp z25.d, p13                           : decp   %p13.d %z25.d -> %z25.d
+25ed81db : decp z27.d, p14                           : decp   %p14.d %z27.d -> %z27.d
+25ed81ff : decp z31.d, p15                           : decp   %p15.d %z31.d -> %z31.d
 
 0419105d : eor z29.b, p4/m, z29.b, z2.b             : eor    %p4 %z29 %z2 $0x00 -> %z29
 0459105d : eor z29.h, p4/m, z29.h, z2.h             : eor    %p4 %z29 %z2 $0x01 -> %z29
@@ -2931,6 +3113,122 @@
 04fbb359 : ftssel z25.d, z26.d, z27.d                : ftssel %z26.d %z27.d -> %z25.d
 04fdb39b : ftssel z27.d, z28.d, z29.d                : ftssel %z28.d %z29.d -> %z27.d
 04ffb3ff : ftssel z31.d, z31.d, z31.d                : ftssel %z31.d %z31.d -> %z31.d
+
+# INCP    <Xdn>, <Pm>.<T> (INCP-R.P.R-_)
+252c8800 : incp x0, p0.b                             : incp   %p0.b %x0 -> %x0
+252c8842 : incp x2, p2.b                             : incp   %p2.b %x2 -> %x2
+252c8864 : incp x4, p3.b                             : incp   %p3.b %x4 -> %x4
+252c8886 : incp x6, p4.b                             : incp   %p4.b %x6 -> %x6
+252c88a8 : incp x8, p5.b                             : incp   %p5.b %x8 -> %x8
+252c88c9 : incp x9, p6.b                             : incp   %p6.b %x9 -> %x9
+252c88eb : incp x11, p7.b                            : incp   %p7.b %x11 -> %x11
+252c890d : incp x13, p8.b                            : incp   %p8.b %x13 -> %x13
+252c892f : incp x15, p9.b                            : incp   %p9.b %x15 -> %x15
+252c8931 : incp x17, p9.b                            : incp   %p9.b %x17 -> %x17
+252c8953 : incp x19, p10.b                           : incp   %p10.b %x19 -> %x19
+252c8975 : incp x21, p11.b                           : incp   %p11.b %x21 -> %x21
+252c8996 : incp x22, p12.b                           : incp   %p12.b %x22 -> %x22
+252c89b8 : incp x24, p13.b                           : incp   %p13.b %x24 -> %x24
+252c89da : incp x26, p14.b                           : incp   %p14.b %x26 -> %x26
+252c89fe : incp x30, p15.b                           : incp   %p15.b %x30 -> %x30
+256c8800 : incp x0, p0.h                             : incp   %p0.h %x0 -> %x0
+256c8842 : incp x2, p2.h                             : incp   %p2.h %x2 -> %x2
+256c8864 : incp x4, p3.h                             : incp   %p3.h %x4 -> %x4
+256c8886 : incp x6, p4.h                             : incp   %p4.h %x6 -> %x6
+256c88a8 : incp x8, p5.h                             : incp   %p5.h %x8 -> %x8
+256c88c9 : incp x9, p6.h                             : incp   %p6.h %x9 -> %x9
+256c88eb : incp x11, p7.h                            : incp   %p7.h %x11 -> %x11
+256c890d : incp x13, p8.h                            : incp   %p8.h %x13 -> %x13
+256c892f : incp x15, p9.h                            : incp   %p9.h %x15 -> %x15
+256c8931 : incp x17, p9.h                            : incp   %p9.h %x17 -> %x17
+256c8953 : incp x19, p10.h                           : incp   %p10.h %x19 -> %x19
+256c8975 : incp x21, p11.h                           : incp   %p11.h %x21 -> %x21
+256c8996 : incp x22, p12.h                           : incp   %p12.h %x22 -> %x22
+256c89b8 : incp x24, p13.h                           : incp   %p13.h %x24 -> %x24
+256c89da : incp x26, p14.h                           : incp   %p14.h %x26 -> %x26
+256c89fe : incp x30, p15.h                           : incp   %p15.h %x30 -> %x30
+25ac8800 : incp x0, p0.s                             : incp   %p0.s %x0 -> %x0
+25ac8842 : incp x2, p2.s                             : incp   %p2.s %x2 -> %x2
+25ac8864 : incp x4, p3.s                             : incp   %p3.s %x4 -> %x4
+25ac8886 : incp x6, p4.s                             : incp   %p4.s %x6 -> %x6
+25ac88a8 : incp x8, p5.s                             : incp   %p5.s %x8 -> %x8
+25ac88c9 : incp x9, p6.s                             : incp   %p6.s %x9 -> %x9
+25ac88eb : incp x11, p7.s                            : incp   %p7.s %x11 -> %x11
+25ac890d : incp x13, p8.s                            : incp   %p8.s %x13 -> %x13
+25ac892f : incp x15, p9.s                            : incp   %p9.s %x15 -> %x15
+25ac8931 : incp x17, p9.s                            : incp   %p9.s %x17 -> %x17
+25ac8953 : incp x19, p10.s                           : incp   %p10.s %x19 -> %x19
+25ac8975 : incp x21, p11.s                           : incp   %p11.s %x21 -> %x21
+25ac8996 : incp x22, p12.s                           : incp   %p12.s %x22 -> %x22
+25ac89b8 : incp x24, p13.s                           : incp   %p13.s %x24 -> %x24
+25ac89da : incp x26, p14.s                           : incp   %p14.s %x26 -> %x26
+25ac89fe : incp x30, p15.s                           : incp   %p15.s %x30 -> %x30
+25ec8800 : incp x0, p0.d                             : incp   %p0.d %x0 -> %x0
+25ec8842 : incp x2, p2.d                             : incp   %p2.d %x2 -> %x2
+25ec8864 : incp x4, p3.d                             : incp   %p3.d %x4 -> %x4
+25ec8886 : incp x6, p4.d                             : incp   %p4.d %x6 -> %x6
+25ec88a8 : incp x8, p5.d                             : incp   %p5.d %x8 -> %x8
+25ec88c9 : incp x9, p6.d                             : incp   %p6.d %x9 -> %x9
+25ec88eb : incp x11, p7.d                            : incp   %p7.d %x11 -> %x11
+25ec890d : incp x13, p8.d                            : incp   %p8.d %x13 -> %x13
+25ec892f : incp x15, p9.d                            : incp   %p9.d %x15 -> %x15
+25ec8931 : incp x17, p9.d                            : incp   %p9.d %x17 -> %x17
+25ec8953 : incp x19, p10.d                           : incp   %p10.d %x19 -> %x19
+25ec8975 : incp x21, p11.d                           : incp   %p11.d %x21 -> %x21
+25ec8996 : incp x22, p12.d                           : incp   %p12.d %x22 -> %x22
+25ec89b8 : incp x24, p13.d                           : incp   %p13.d %x24 -> %x24
+25ec89da : incp x26, p14.d                           : incp   %p14.d %x26 -> %x26
+25ec89fe : incp x30, p15.d                           : incp   %p15.d %x30 -> %x30
+
+# INCP    <Zdn>.<T>, <Pm>.<T> (INCP-Z.P.Z-_)
+256c8000 : incp z0.h, p0                             : incp   %p0.h %z0.h -> %z0.h
+256c8042 : incp z2.h, p2                             : incp   %p2.h %z2.h -> %z2.h
+256c8064 : incp z4.h, p3                             : incp   %p3.h %z4.h -> %z4.h
+256c8086 : incp z6.h, p4                             : incp   %p4.h %z6.h -> %z6.h
+256c80a8 : incp z8.h, p5                             : incp   %p5.h %z8.h -> %z8.h
+256c80ca : incp z10.h, p6                            : incp   %p6.h %z10.h -> %z10.h
+256c80ec : incp z12.h, p7                            : incp   %p7.h %z12.h -> %z12.h
+256c810e : incp z14.h, p8                            : incp   %p8.h %z14.h -> %z14.h
+256c8130 : incp z16.h, p9                            : incp   %p9.h %z16.h -> %z16.h
+256c8131 : incp z17.h, p9                            : incp   %p9.h %z17.h -> %z17.h
+256c8153 : incp z19.h, p10                           : incp   %p10.h %z19.h -> %z19.h
+256c8175 : incp z21.h, p11                           : incp   %p11.h %z21.h -> %z21.h
+256c8197 : incp z23.h, p12                           : incp   %p12.h %z23.h -> %z23.h
+256c81b9 : incp z25.h, p13                           : incp   %p13.h %z25.h -> %z25.h
+256c81db : incp z27.h, p14                           : incp   %p14.h %z27.h -> %z27.h
+256c81ff : incp z31.h, p15                           : incp   %p15.h %z31.h -> %z31.h
+25ac8000 : incp z0.s, p0                             : incp   %p0.s %z0.s -> %z0.s
+25ac8042 : incp z2.s, p2                             : incp   %p2.s %z2.s -> %z2.s
+25ac8064 : incp z4.s, p3                             : incp   %p3.s %z4.s -> %z4.s
+25ac8086 : incp z6.s, p4                             : incp   %p4.s %z6.s -> %z6.s
+25ac80a8 : incp z8.s, p5                             : incp   %p5.s %z8.s -> %z8.s
+25ac80ca : incp z10.s, p6                            : incp   %p6.s %z10.s -> %z10.s
+25ac80ec : incp z12.s, p7                            : incp   %p7.s %z12.s -> %z12.s
+25ac810e : incp z14.s, p8                            : incp   %p8.s %z14.s -> %z14.s
+25ac8130 : incp z16.s, p9                            : incp   %p9.s %z16.s -> %z16.s
+25ac8131 : incp z17.s, p9                            : incp   %p9.s %z17.s -> %z17.s
+25ac8153 : incp z19.s, p10                           : incp   %p10.s %z19.s -> %z19.s
+25ac8175 : incp z21.s, p11                           : incp   %p11.s %z21.s -> %z21.s
+25ac8197 : incp z23.s, p12                           : incp   %p12.s %z23.s -> %z23.s
+25ac81b9 : incp z25.s, p13                           : incp   %p13.s %z25.s -> %z25.s
+25ac81db : incp z27.s, p14                           : incp   %p14.s %z27.s -> %z27.s
+25ac81ff : incp z31.s, p15                           : incp   %p15.s %z31.s -> %z31.s
+25ec8000 : incp z0.d, p0                             : incp   %p0.d %z0.d -> %z0.d
+25ec8042 : incp z2.d, p2                             : incp   %p2.d %z2.d -> %z2.d
+25ec8064 : incp z4.d, p3                             : incp   %p3.d %z4.d -> %z4.d
+25ec8086 : incp z6.d, p4                             : incp   %p4.d %z6.d -> %z6.d
+25ec80a8 : incp z8.d, p5                             : incp   %p5.d %z8.d -> %z8.d
+25ec80ca : incp z10.d, p6                            : incp   %p6.d %z10.d -> %z10.d
+25ec80ec : incp z12.d, p7                            : incp   %p7.d %z12.d -> %z12.d
+25ec810e : incp z14.d, p8                            : incp   %p8.d %z14.d -> %z14.d
+25ec8130 : incp z16.d, p9                            : incp   %p9.d %z16.d -> %z16.d
+25ec8131 : incp z17.d, p9                            : incp   %p9.d %z17.d -> %z17.d
+25ec8153 : incp z19.d, p10                           : incp   %p10.d %z19.d -> %z19.d
+25ec8175 : incp z21.d, p11                           : incp   %p11.d %z21.d -> %z21.d
+25ec8197 : incp z23.d, p12                           : incp   %p12.d %z23.d -> %z23.d
+25ec81b9 : incp z25.d, p13                           : incp   %p13.d %z25.d -> %z25.d
+25ec81db : incp z27.d, p14                           : incp   %p14.d %z27.d -> %z27.d
+25ec81ff : incp z31.d, p15                           : incp   %p15.d %z31.d -> %z31.d
 
 # MAD     <Zdn>.<T>, <Pg>/M, <Zm>.<T>, <Za>.<T> (MAD-Z.P.ZZZ-_)
 0400c000 : mad z0.b, p0/M, z0.b, z0.b                : mad    %p0/m %z0.b %z0.b %z0.b -> %z0.b
@@ -4087,6 +4385,370 @@
 04fa1338 : sqadd z24.d, z25.d, z26.d                 : sqadd  %z25.d %z26.d -> %z24.d
 04fc137a : sqadd z26.d, z27.d, z28.d                 : sqadd  %z27.d %z28.d -> %z26.d
 04fe13de : sqadd z30.d, z30.d, z30.d                 : sqadd  %z30.d %z30.d -> %z30.d
+
+# SQDECP  <Xdn>, <Pm>.<T>, <Wdn> (SQDECP-R.P.R-SX)
+252a8800 : sqdecp x0, p0.b, w0                       : sqdecp %p0.b %w0 -> %x0
+252a8842 : sqdecp x2, p2.b, w2                       : sqdecp %p2.b %w2 -> %x2
+252a8864 : sqdecp x4, p3.b, w4                       : sqdecp %p3.b %w4 -> %x4
+252a8886 : sqdecp x6, p4.b, w6                       : sqdecp %p4.b %w6 -> %x6
+252a88a8 : sqdecp x8, p5.b, w8                       : sqdecp %p5.b %w8 -> %x8
+252a88c9 : sqdecp x9, p6.b, w9                       : sqdecp %p6.b %w9 -> %x9
+252a88eb : sqdecp x11, p7.b, w11                     : sqdecp %p7.b %w11 -> %x11
+252a890d : sqdecp x13, p8.b, w13                     : sqdecp %p8.b %w13 -> %x13
+252a892f : sqdecp x15, p9.b, w15                     : sqdecp %p9.b %w15 -> %x15
+252a8931 : sqdecp x17, p9.b, w17                     : sqdecp %p9.b %w17 -> %x17
+252a8953 : sqdecp x19, p10.b, w19                    : sqdecp %p10.b %w19 -> %x19
+252a8975 : sqdecp x21, p11.b, w21                    : sqdecp %p11.b %w21 -> %x21
+252a8996 : sqdecp x22, p12.b, w22                    : sqdecp %p12.b %w22 -> %x22
+252a89b8 : sqdecp x24, p13.b, w24                    : sqdecp %p13.b %w24 -> %x24
+252a89da : sqdecp x26, p14.b, w26                    : sqdecp %p14.b %w26 -> %x26
+252a89fe : sqdecp x30, p15.b, w30                    : sqdecp %p15.b %w30 -> %x30
+256a8800 : sqdecp x0, p0.h, w0                       : sqdecp %p0.h %w0 -> %x0
+256a8842 : sqdecp x2, p2.h, w2                       : sqdecp %p2.h %w2 -> %x2
+256a8864 : sqdecp x4, p3.h, w4                       : sqdecp %p3.h %w4 -> %x4
+256a8886 : sqdecp x6, p4.h, w6                       : sqdecp %p4.h %w6 -> %x6
+256a88a8 : sqdecp x8, p5.h, w8                       : sqdecp %p5.h %w8 -> %x8
+256a88c9 : sqdecp x9, p6.h, w9                       : sqdecp %p6.h %w9 -> %x9
+256a88eb : sqdecp x11, p7.h, w11                     : sqdecp %p7.h %w11 -> %x11
+256a890d : sqdecp x13, p8.h, w13                     : sqdecp %p8.h %w13 -> %x13
+256a892f : sqdecp x15, p9.h, w15                     : sqdecp %p9.h %w15 -> %x15
+256a8931 : sqdecp x17, p9.h, w17                     : sqdecp %p9.h %w17 -> %x17
+256a8953 : sqdecp x19, p10.h, w19                    : sqdecp %p10.h %w19 -> %x19
+256a8975 : sqdecp x21, p11.h, w21                    : sqdecp %p11.h %w21 -> %x21
+256a8996 : sqdecp x22, p12.h, w22                    : sqdecp %p12.h %w22 -> %x22
+256a89b8 : sqdecp x24, p13.h, w24                    : sqdecp %p13.h %w24 -> %x24
+256a89da : sqdecp x26, p14.h, w26                    : sqdecp %p14.h %w26 -> %x26
+256a89fe : sqdecp x30, p15.h, w30                    : sqdecp %p15.h %w30 -> %x30
+25aa8800 : sqdecp x0, p0.s, w0                       : sqdecp %p0.s %w0 -> %x0
+25aa8842 : sqdecp x2, p2.s, w2                       : sqdecp %p2.s %w2 -> %x2
+25aa8864 : sqdecp x4, p3.s, w4                       : sqdecp %p3.s %w4 -> %x4
+25aa8886 : sqdecp x6, p4.s, w6                       : sqdecp %p4.s %w6 -> %x6
+25aa88a8 : sqdecp x8, p5.s, w8                       : sqdecp %p5.s %w8 -> %x8
+25aa88c9 : sqdecp x9, p6.s, w9                       : sqdecp %p6.s %w9 -> %x9
+25aa88eb : sqdecp x11, p7.s, w11                     : sqdecp %p7.s %w11 -> %x11
+25aa890d : sqdecp x13, p8.s, w13                     : sqdecp %p8.s %w13 -> %x13
+25aa892f : sqdecp x15, p9.s, w15                     : sqdecp %p9.s %w15 -> %x15
+25aa8931 : sqdecp x17, p9.s, w17                     : sqdecp %p9.s %w17 -> %x17
+25aa8953 : sqdecp x19, p10.s, w19                    : sqdecp %p10.s %w19 -> %x19
+25aa8975 : sqdecp x21, p11.s, w21                    : sqdecp %p11.s %w21 -> %x21
+25aa8996 : sqdecp x22, p12.s, w22                    : sqdecp %p12.s %w22 -> %x22
+25aa89b8 : sqdecp x24, p13.s, w24                    : sqdecp %p13.s %w24 -> %x24
+25aa89da : sqdecp x26, p14.s, w26                    : sqdecp %p14.s %w26 -> %x26
+25aa89fe : sqdecp x30, p15.s, w30                    : sqdecp %p15.s %w30 -> %x30
+25ea8800 : sqdecp x0, p0.d, w0                       : sqdecp %p0.d %w0 -> %x0
+25ea8842 : sqdecp x2, p2.d, w2                       : sqdecp %p2.d %w2 -> %x2
+25ea8864 : sqdecp x4, p3.d, w4                       : sqdecp %p3.d %w4 -> %x4
+25ea8886 : sqdecp x6, p4.d, w6                       : sqdecp %p4.d %w6 -> %x6
+25ea88a8 : sqdecp x8, p5.d, w8                       : sqdecp %p5.d %w8 -> %x8
+25ea88c9 : sqdecp x9, p6.d, w9                       : sqdecp %p6.d %w9 -> %x9
+25ea88eb : sqdecp x11, p7.d, w11                     : sqdecp %p7.d %w11 -> %x11
+25ea890d : sqdecp x13, p8.d, w13                     : sqdecp %p8.d %w13 -> %x13
+25ea892f : sqdecp x15, p9.d, w15                     : sqdecp %p9.d %w15 -> %x15
+25ea8931 : sqdecp x17, p9.d, w17                     : sqdecp %p9.d %w17 -> %x17
+25ea8953 : sqdecp x19, p10.d, w19                    : sqdecp %p10.d %w19 -> %x19
+25ea8975 : sqdecp x21, p11.d, w21                    : sqdecp %p11.d %w21 -> %x21
+25ea8996 : sqdecp x22, p12.d, w22                    : sqdecp %p12.d %w22 -> %x22
+25ea89b8 : sqdecp x24, p13.d, w24                    : sqdecp %p13.d %w24 -> %x24
+25ea89da : sqdecp x26, p14.d, w26                    : sqdecp %p14.d %w26 -> %x26
+25ea89fe : sqdecp x30, p15.d, w30                    : sqdecp %p15.d %w30 -> %x30
+
+# SQDECP  <Xdn>, <Pm>.<T> (SQDECP-R.P.R-X)
+252a8c00 : sqdecp x0, p0.b                           : sqdecp %p0.b %x0 -> %x0
+252a8c42 : sqdecp x2, p2.b                           : sqdecp %p2.b %x2 -> %x2
+252a8c64 : sqdecp x4, p3.b                           : sqdecp %p3.b %x4 -> %x4
+252a8c86 : sqdecp x6, p4.b                           : sqdecp %p4.b %x6 -> %x6
+252a8ca8 : sqdecp x8, p5.b                           : sqdecp %p5.b %x8 -> %x8
+252a8cc9 : sqdecp x9, p6.b                           : sqdecp %p6.b %x9 -> %x9
+252a8ceb : sqdecp x11, p7.b                          : sqdecp %p7.b %x11 -> %x11
+252a8d0d : sqdecp x13, p8.b                          : sqdecp %p8.b %x13 -> %x13
+252a8d2f : sqdecp x15, p9.b                          : sqdecp %p9.b %x15 -> %x15
+252a8d31 : sqdecp x17, p9.b                          : sqdecp %p9.b %x17 -> %x17
+252a8d53 : sqdecp x19, p10.b                         : sqdecp %p10.b %x19 -> %x19
+252a8d75 : sqdecp x21, p11.b                         : sqdecp %p11.b %x21 -> %x21
+252a8d96 : sqdecp x22, p12.b                         : sqdecp %p12.b %x22 -> %x22
+252a8db8 : sqdecp x24, p13.b                         : sqdecp %p13.b %x24 -> %x24
+252a8dda : sqdecp x26, p14.b                         : sqdecp %p14.b %x26 -> %x26
+252a8dfe : sqdecp x30, p15.b                         : sqdecp %p15.b %x30 -> %x30
+256a8c00 : sqdecp x0, p0.h                           : sqdecp %p0.h %x0 -> %x0
+256a8c42 : sqdecp x2, p2.h                           : sqdecp %p2.h %x2 -> %x2
+256a8c64 : sqdecp x4, p3.h                           : sqdecp %p3.h %x4 -> %x4
+256a8c86 : sqdecp x6, p4.h                           : sqdecp %p4.h %x6 -> %x6
+256a8ca8 : sqdecp x8, p5.h                           : sqdecp %p5.h %x8 -> %x8
+256a8cc9 : sqdecp x9, p6.h                           : sqdecp %p6.h %x9 -> %x9
+256a8ceb : sqdecp x11, p7.h                          : sqdecp %p7.h %x11 -> %x11
+256a8d0d : sqdecp x13, p8.h                          : sqdecp %p8.h %x13 -> %x13
+256a8d2f : sqdecp x15, p9.h                          : sqdecp %p9.h %x15 -> %x15
+256a8d31 : sqdecp x17, p9.h                          : sqdecp %p9.h %x17 -> %x17
+256a8d53 : sqdecp x19, p10.h                         : sqdecp %p10.h %x19 -> %x19
+256a8d75 : sqdecp x21, p11.h                         : sqdecp %p11.h %x21 -> %x21
+256a8d96 : sqdecp x22, p12.h                         : sqdecp %p12.h %x22 -> %x22
+256a8db8 : sqdecp x24, p13.h                         : sqdecp %p13.h %x24 -> %x24
+256a8dda : sqdecp x26, p14.h                         : sqdecp %p14.h %x26 -> %x26
+256a8dfe : sqdecp x30, p15.h                         : sqdecp %p15.h %x30 -> %x30
+25aa8c00 : sqdecp x0, p0.s                           : sqdecp %p0.s %x0 -> %x0
+25aa8c42 : sqdecp x2, p2.s                           : sqdecp %p2.s %x2 -> %x2
+25aa8c64 : sqdecp x4, p3.s                           : sqdecp %p3.s %x4 -> %x4
+25aa8c86 : sqdecp x6, p4.s                           : sqdecp %p4.s %x6 -> %x6
+25aa8ca8 : sqdecp x8, p5.s                           : sqdecp %p5.s %x8 -> %x8
+25aa8cc9 : sqdecp x9, p6.s                           : sqdecp %p6.s %x9 -> %x9
+25aa8ceb : sqdecp x11, p7.s                          : sqdecp %p7.s %x11 -> %x11
+25aa8d0d : sqdecp x13, p8.s                          : sqdecp %p8.s %x13 -> %x13
+25aa8d2f : sqdecp x15, p9.s                          : sqdecp %p9.s %x15 -> %x15
+25aa8d31 : sqdecp x17, p9.s                          : sqdecp %p9.s %x17 -> %x17
+25aa8d53 : sqdecp x19, p10.s                         : sqdecp %p10.s %x19 -> %x19
+25aa8d75 : sqdecp x21, p11.s                         : sqdecp %p11.s %x21 -> %x21
+25aa8d96 : sqdecp x22, p12.s                         : sqdecp %p12.s %x22 -> %x22
+25aa8db8 : sqdecp x24, p13.s                         : sqdecp %p13.s %x24 -> %x24
+25aa8dda : sqdecp x26, p14.s                         : sqdecp %p14.s %x26 -> %x26
+25aa8dfe : sqdecp x30, p15.s                         : sqdecp %p15.s %x30 -> %x30
+25ea8c00 : sqdecp x0, p0.d                           : sqdecp %p0.d %x0 -> %x0
+25ea8c42 : sqdecp x2, p2.d                           : sqdecp %p2.d %x2 -> %x2
+25ea8c64 : sqdecp x4, p3.d                           : sqdecp %p3.d %x4 -> %x4
+25ea8c86 : sqdecp x6, p4.d                           : sqdecp %p4.d %x6 -> %x6
+25ea8ca8 : sqdecp x8, p5.d                           : sqdecp %p5.d %x8 -> %x8
+25ea8cc9 : sqdecp x9, p6.d                           : sqdecp %p6.d %x9 -> %x9
+25ea8ceb : sqdecp x11, p7.d                          : sqdecp %p7.d %x11 -> %x11
+25ea8d0d : sqdecp x13, p8.d                          : sqdecp %p8.d %x13 -> %x13
+25ea8d2f : sqdecp x15, p9.d                          : sqdecp %p9.d %x15 -> %x15
+25ea8d31 : sqdecp x17, p9.d                          : sqdecp %p9.d %x17 -> %x17
+25ea8d53 : sqdecp x19, p10.d                         : sqdecp %p10.d %x19 -> %x19
+25ea8d75 : sqdecp x21, p11.d                         : sqdecp %p11.d %x21 -> %x21
+25ea8d96 : sqdecp x22, p12.d                         : sqdecp %p12.d %x22 -> %x22
+25ea8db8 : sqdecp x24, p13.d                         : sqdecp %p13.d %x24 -> %x24
+25ea8dda : sqdecp x26, p14.d                         : sqdecp %p14.d %x26 -> %x26
+25ea8dfe : sqdecp x30, p15.d                         : sqdecp %p15.d %x30 -> %x30
+
+# SQDECP  <Zdn>.<T>, <Pm>.<T> (SQDECP-Z.P.Z-_)
+256a8000 : sqdecp z0.h, p0                           : sqdecp %p0.h %z0.h -> %z0.h
+256a8042 : sqdecp z2.h, p2                           : sqdecp %p2.h %z2.h -> %z2.h
+256a8064 : sqdecp z4.h, p3                           : sqdecp %p3.h %z4.h -> %z4.h
+256a8086 : sqdecp z6.h, p4                           : sqdecp %p4.h %z6.h -> %z6.h
+256a80a8 : sqdecp z8.h, p5                           : sqdecp %p5.h %z8.h -> %z8.h
+256a80ca : sqdecp z10.h, p6                          : sqdecp %p6.h %z10.h -> %z10.h
+256a80ec : sqdecp z12.h, p7                          : sqdecp %p7.h %z12.h -> %z12.h
+256a810e : sqdecp z14.h, p8                          : sqdecp %p8.h %z14.h -> %z14.h
+256a8130 : sqdecp z16.h, p9                          : sqdecp %p9.h %z16.h -> %z16.h
+256a8131 : sqdecp z17.h, p9                          : sqdecp %p9.h %z17.h -> %z17.h
+256a8153 : sqdecp z19.h, p10                         : sqdecp %p10.h %z19.h -> %z19.h
+256a8175 : sqdecp z21.h, p11                         : sqdecp %p11.h %z21.h -> %z21.h
+256a8197 : sqdecp z23.h, p12                         : sqdecp %p12.h %z23.h -> %z23.h
+256a81b9 : sqdecp z25.h, p13                         : sqdecp %p13.h %z25.h -> %z25.h
+256a81db : sqdecp z27.h, p14                         : sqdecp %p14.h %z27.h -> %z27.h
+256a81ff : sqdecp z31.h, p15                         : sqdecp %p15.h %z31.h -> %z31.h
+25aa8000 : sqdecp z0.s, p0                           : sqdecp %p0.s %z0.s -> %z0.s
+25aa8042 : sqdecp z2.s, p2                           : sqdecp %p2.s %z2.s -> %z2.s
+25aa8064 : sqdecp z4.s, p3                           : sqdecp %p3.s %z4.s -> %z4.s
+25aa8086 : sqdecp z6.s, p4                           : sqdecp %p4.s %z6.s -> %z6.s
+25aa80a8 : sqdecp z8.s, p5                           : sqdecp %p5.s %z8.s -> %z8.s
+25aa80ca : sqdecp z10.s, p6                          : sqdecp %p6.s %z10.s -> %z10.s
+25aa80ec : sqdecp z12.s, p7                          : sqdecp %p7.s %z12.s -> %z12.s
+25aa810e : sqdecp z14.s, p8                          : sqdecp %p8.s %z14.s -> %z14.s
+25aa8130 : sqdecp z16.s, p9                          : sqdecp %p9.s %z16.s -> %z16.s
+25aa8131 : sqdecp z17.s, p9                          : sqdecp %p9.s %z17.s -> %z17.s
+25aa8153 : sqdecp z19.s, p10                         : sqdecp %p10.s %z19.s -> %z19.s
+25aa8175 : sqdecp z21.s, p11                         : sqdecp %p11.s %z21.s -> %z21.s
+25aa8197 : sqdecp z23.s, p12                         : sqdecp %p12.s %z23.s -> %z23.s
+25aa81b9 : sqdecp z25.s, p13                         : sqdecp %p13.s %z25.s -> %z25.s
+25aa81db : sqdecp z27.s, p14                         : sqdecp %p14.s %z27.s -> %z27.s
+25aa81ff : sqdecp z31.s, p15                         : sqdecp %p15.s %z31.s -> %z31.s
+25ea8000 : sqdecp z0.d, p0                           : sqdecp %p0.d %z0.d -> %z0.d
+25ea8042 : sqdecp z2.d, p2                           : sqdecp %p2.d %z2.d -> %z2.d
+25ea8064 : sqdecp z4.d, p3                           : sqdecp %p3.d %z4.d -> %z4.d
+25ea8086 : sqdecp z6.d, p4                           : sqdecp %p4.d %z6.d -> %z6.d
+25ea80a8 : sqdecp z8.d, p5                           : sqdecp %p5.d %z8.d -> %z8.d
+25ea80ca : sqdecp z10.d, p6                          : sqdecp %p6.d %z10.d -> %z10.d
+25ea80ec : sqdecp z12.d, p7                          : sqdecp %p7.d %z12.d -> %z12.d
+25ea810e : sqdecp z14.d, p8                          : sqdecp %p8.d %z14.d -> %z14.d
+25ea8130 : sqdecp z16.d, p9                          : sqdecp %p9.d %z16.d -> %z16.d
+25ea8131 : sqdecp z17.d, p9                          : sqdecp %p9.d %z17.d -> %z17.d
+25ea8153 : sqdecp z19.d, p10                         : sqdecp %p10.d %z19.d -> %z19.d
+25ea8175 : sqdecp z21.d, p11                         : sqdecp %p11.d %z21.d -> %z21.d
+25ea8197 : sqdecp z23.d, p12                         : sqdecp %p12.d %z23.d -> %z23.d
+25ea81b9 : sqdecp z25.d, p13                         : sqdecp %p13.d %z25.d -> %z25.d
+25ea81db : sqdecp z27.d, p14                         : sqdecp %p14.d %z27.d -> %z27.d
+25ea81ff : sqdecp z31.d, p15                         : sqdecp %p15.d %z31.d -> %z31.d
+
+# SQINCP  <Xdn>, <Pm>.<T>, <Wdn> (SQINCP-R.P.R-SX)
+25288800 : sqincp x0, p0.b, w0                           : sqincp %p0.b %w0 -> %x0
+25288842 : sqincp x2, p2.b, w2                           : sqincp %p2.b %w2 -> %x2
+25288864 : sqincp x4, p3.b, w4                           : sqincp %p3.b %w4 -> %x4
+25288886 : sqincp x6, p4.b, w6                           : sqincp %p4.b %w6 -> %x6
+252888a8 : sqincp x8, p5.b, w8                           : sqincp %p5.b %w8 -> %x8
+252888c9 : sqincp x9, p6.b, w9                           : sqincp %p6.b %w9 -> %x9
+252888eb : sqincp x11, p7.b, w11                          : sqincp %p7.b %w11 -> %x11
+2528890d : sqincp x13, p8.b, w13                          : sqincp %p8.b %w13 -> %x13
+2528892f : sqincp x15, p9.b, w15                          : sqincp %p9.b %w15 -> %x15
+25288931 : sqincp x17, p9.b, w17                          : sqincp %p9.b %w17 -> %x17
+25288953 : sqincp x19, p10.b, w19                         : sqincp %p10.b %w19 -> %x19
+25288975 : sqincp x21, p11.b, w21                         : sqincp %p11.b %w21 -> %x21
+25288996 : sqincp x22, p12.b, w22                         : sqincp %p12.b %w22 -> %x22
+252889b8 : sqincp x24, p13.b, w24                         : sqincp %p13.b %w24 -> %x24
+252889da : sqincp x26, p14.b, w26                         : sqincp %p14.b %w26 -> %x26
+252889fe : sqincp x30, p15.b, w30                         : sqincp %p15.b %w30 -> %x30
+25688800 : sqincp x0, p0.h, w0                           : sqincp %p0.h %w0 -> %x0
+25688842 : sqincp x2, p2.h, w2                           : sqincp %p2.h %w2 -> %x2
+25688864 : sqincp x4, p3.h, w4                           : sqincp %p3.h %w4 -> %x4
+25688886 : sqincp x6, p4.h, w6                           : sqincp %p4.h %w6 -> %x6
+256888a8 : sqincp x8, p5.h, w8                           : sqincp %p5.h %w8 -> %x8
+256888c9 : sqincp x9, p6.h, w9                           : sqincp %p6.h %w9 -> %x9
+256888eb : sqincp x11, p7.h, w11                          : sqincp %p7.h %w11 -> %x11
+2568890d : sqincp x13, p8.h, w13                          : sqincp %p8.h %w13 -> %x13
+2568892f : sqincp x15, p9.h, w15                          : sqincp %p9.h %w15 -> %x15
+25688931 : sqincp x17, p9.h, w17                          : sqincp %p9.h %w17 -> %x17
+25688953 : sqincp x19, p10.h, w19                         : sqincp %p10.h %w19 -> %x19
+25688975 : sqincp x21, p11.h, w21                         : sqincp %p11.h %w21 -> %x21
+25688996 : sqincp x22, p12.h, w22                         : sqincp %p12.h %w22 -> %x22
+256889b8 : sqincp x24, p13.h, w24                         : sqincp %p13.h %w24 -> %x24
+256889da : sqincp x26, p14.h, w26                         : sqincp %p14.h %w26 -> %x26
+256889fe : sqincp x30, p15.h, w30                         : sqincp %p15.h %w30 -> %x30
+25a88800 : sqincp x0, p0.s, w0                           : sqincp %p0.s %w0 -> %x0
+25a88842 : sqincp x2, p2.s, w2                           : sqincp %p2.s %w2 -> %x2
+25a88864 : sqincp x4, p3.s, w4                           : sqincp %p3.s %w4 -> %x4
+25a88886 : sqincp x6, p4.s, w6                           : sqincp %p4.s %w6 -> %x6
+25a888a8 : sqincp x8, p5.s, w8                           : sqincp %p5.s %w8 -> %x8
+25a888c9 : sqincp x9, p6.s, w9                           : sqincp %p6.s %w9 -> %x9
+25a888eb : sqincp x11, p7.s, w11                          : sqincp %p7.s %w11 -> %x11
+25a8890d : sqincp x13, p8.s, w13                          : sqincp %p8.s %w13 -> %x13
+25a8892f : sqincp x15, p9.s, w15                          : sqincp %p9.s %w15 -> %x15
+25a88931 : sqincp x17, p9.s, w17                          : sqincp %p9.s %w17 -> %x17
+25a88953 : sqincp x19, p10.s, w19                         : sqincp %p10.s %w19 -> %x19
+25a88975 : sqincp x21, p11.s, w21                         : sqincp %p11.s %w21 -> %x21
+25a88996 : sqincp x22, p12.s, w22                         : sqincp %p12.s %w22 -> %x22
+25a889b8 : sqincp x24, p13.s, w24                         : sqincp %p13.s %w24 -> %x24
+25a889da : sqincp x26, p14.s, w26                         : sqincp %p14.s %w26 -> %x26
+25a889fe : sqincp x30, p15.s, w30                         : sqincp %p15.s %w30 -> %x30
+25e88800 : sqincp x0, p0.d, w0                           : sqincp %p0.d %w0 -> %x0
+25e88842 : sqincp x2, p2.d, w2                           : sqincp %p2.d %w2 -> %x2
+25e88864 : sqincp x4, p3.d, w4                           : sqincp %p3.d %w4 -> %x4
+25e88886 : sqincp x6, p4.d, w6                           : sqincp %p4.d %w6 -> %x6
+25e888a8 : sqincp x8, p5.d, w8                           : sqincp %p5.d %w8 -> %x8
+25e888c9 : sqincp x9, p6.d, w9                           : sqincp %p6.d %w9 -> %x9
+25e888eb : sqincp x11, p7.d, w11                          : sqincp %p7.d %w11 -> %x11
+25e8890d : sqincp x13, p8.d, w13                          : sqincp %p8.d %w13 -> %x13
+25e8892f : sqincp x15, p9.d, w15                          : sqincp %p9.d %w15 -> %x15
+25e88931 : sqincp x17, p9.d, w17                          : sqincp %p9.d %w17 -> %x17
+25e88953 : sqincp x19, p10.d, w19                         : sqincp %p10.d %w19 -> %x19
+25e88975 : sqincp x21, p11.d, w21                         : sqincp %p11.d %w21 -> %x21
+25e88996 : sqincp x22, p12.d, w22                         : sqincp %p12.d %w22 -> %x22
+25e889b8 : sqincp x24, p13.d, w24                         : sqincp %p13.d %w24 -> %x24
+25e889da : sqincp x26, p14.d, w26                         : sqincp %p14.d %w26 -> %x26
+25e889fe : sqincp x30, p15.d, w30                         : sqincp %p15.d %w30 -> %x30
+
+# SQINCP  <Xdn>, <Pm>.<T> (SQINCP-R.P.R-X)
+25288c00 : sqincp x0, p0.b                           : sqincp %p0.b %x0 -> %x0
+25288c42 : sqincp x2, p2.b                           : sqincp %p2.b %x2 -> %x2
+25288c64 : sqincp x4, p3.b                           : sqincp %p3.b %x4 -> %x4
+25288c86 : sqincp x6, p4.b                           : sqincp %p4.b %x6 -> %x6
+25288ca8 : sqincp x8, p5.b                           : sqincp %p5.b %x8 -> %x8
+25288cc9 : sqincp x9, p6.b                           : sqincp %p6.b %x9 -> %x9
+25288ceb : sqincp x11, p7.b                          : sqincp %p7.b %x11 -> %x11
+25288d0d : sqincp x13, p8.b                          : sqincp %p8.b %x13 -> %x13
+25288d2f : sqincp x15, p9.b                          : sqincp %p9.b %x15 -> %x15
+25288d31 : sqincp x17, p9.b                          : sqincp %p9.b %x17 -> %x17
+25288d53 : sqincp x19, p10.b                         : sqincp %p10.b %x19 -> %x19
+25288d75 : sqincp x21, p11.b                         : sqincp %p11.b %x21 -> %x21
+25288d96 : sqincp x22, p12.b                         : sqincp %p12.b %x22 -> %x22
+25288db8 : sqincp x24, p13.b                         : sqincp %p13.b %x24 -> %x24
+25288dda : sqincp x26, p14.b                         : sqincp %p14.b %x26 -> %x26
+25288dfe : sqincp x30, p15.b                         : sqincp %p15.b %x30 -> %x30
+25688c00 : sqincp x0, p0.h                           : sqincp %p0.h %x0 -> %x0
+25688c42 : sqincp x2, p2.h                           : sqincp %p2.h %x2 -> %x2
+25688c64 : sqincp x4, p3.h                           : sqincp %p3.h %x4 -> %x4
+25688c86 : sqincp x6, p4.h                           : sqincp %p4.h %x6 -> %x6
+25688ca8 : sqincp x8, p5.h                           : sqincp %p5.h %x8 -> %x8
+25688cc9 : sqincp x9, p6.h                           : sqincp %p6.h %x9 -> %x9
+25688ceb : sqincp x11, p7.h                          : sqincp %p7.h %x11 -> %x11
+25688d0d : sqincp x13, p8.h                          : sqincp %p8.h %x13 -> %x13
+25688d2f : sqincp x15, p9.h                          : sqincp %p9.h %x15 -> %x15
+25688d31 : sqincp x17, p9.h                          : sqincp %p9.h %x17 -> %x17
+25688d53 : sqincp x19, p10.h                         : sqincp %p10.h %x19 -> %x19
+25688d75 : sqincp x21, p11.h                         : sqincp %p11.h %x21 -> %x21
+25688d96 : sqincp x22, p12.h                         : sqincp %p12.h %x22 -> %x22
+25688db8 : sqincp x24, p13.h                         : sqincp %p13.h %x24 -> %x24
+25688dda : sqincp x26, p14.h                         : sqincp %p14.h %x26 -> %x26
+25688dfe : sqincp x30, p15.h                         : sqincp %p15.h %x30 -> %x30
+25a88c00 : sqincp x0, p0.s                           : sqincp %p0.s %x0 -> %x0
+25a88c42 : sqincp x2, p2.s                           : sqincp %p2.s %x2 -> %x2
+25a88c64 : sqincp x4, p3.s                           : sqincp %p3.s %x4 -> %x4
+25a88c86 : sqincp x6, p4.s                           : sqincp %p4.s %x6 -> %x6
+25a88ca8 : sqincp x8, p5.s                           : sqincp %p5.s %x8 -> %x8
+25a88cc9 : sqincp x9, p6.s                           : sqincp %p6.s %x9 -> %x9
+25a88ceb : sqincp x11, p7.s                          : sqincp %p7.s %x11 -> %x11
+25a88d0d : sqincp x13, p8.s                          : sqincp %p8.s %x13 -> %x13
+25a88d2f : sqincp x15, p9.s                          : sqincp %p9.s %x15 -> %x15
+25a88d31 : sqincp x17, p9.s                          : sqincp %p9.s %x17 -> %x17
+25a88d53 : sqincp x19, p10.s                         : sqincp %p10.s %x19 -> %x19
+25a88d75 : sqincp x21, p11.s                         : sqincp %p11.s %x21 -> %x21
+25a88d96 : sqincp x22, p12.s                         : sqincp %p12.s %x22 -> %x22
+25a88db8 : sqincp x24, p13.s                         : sqincp %p13.s %x24 -> %x24
+25a88dda : sqincp x26, p14.s                         : sqincp %p14.s %x26 -> %x26
+25a88dfe : sqincp x30, p15.s                         : sqincp %p15.s %x30 -> %x30
+25e88c00 : sqincp x0, p0.d                           : sqincp %p0.d %x0 -> %x0
+25e88c42 : sqincp x2, p2.d                           : sqincp %p2.d %x2 -> %x2
+25e88c64 : sqincp x4, p3.d                           : sqincp %p3.d %x4 -> %x4
+25e88c86 : sqincp x6, p4.d                           : sqincp %p4.d %x6 -> %x6
+25e88ca8 : sqincp x8, p5.d                           : sqincp %p5.d %x8 -> %x8
+25e88cc9 : sqincp x9, p6.d                           : sqincp %p6.d %x9 -> %x9
+25e88ceb : sqincp x11, p7.d                          : sqincp %p7.d %x11 -> %x11
+25e88d0d : sqincp x13, p8.d                          : sqincp %p8.d %x13 -> %x13
+25e88d2f : sqincp x15, p9.d                          : sqincp %p9.d %x15 -> %x15
+25e88d31 : sqincp x17, p9.d                          : sqincp %p9.d %x17 -> %x17
+25e88d53 : sqincp x19, p10.d                         : sqincp %p10.d %x19 -> %x19
+25e88d75 : sqincp x21, p11.d                         : sqincp %p11.d %x21 -> %x21
+25e88d96 : sqincp x22, p12.d                         : sqincp %p12.d %x22 -> %x22
+25e88db8 : sqincp x24, p13.d                         : sqincp %p13.d %x24 -> %x24
+25e88dda : sqincp x26, p14.d                         : sqincp %p14.d %x26 -> %x26
+25e88dfe : sqincp x30, p15.d                         : sqincp %p15.d %x30 -> %x30
+
+# SQINCP  <Zdn>.<T>, <Pm>.<T> (SQINCP-Z.P.Z-_)
+25688000 : sqincp z0.h, p0                           : sqincp %p0.h %z0.h -> %z0.h
+25688042 : sqincp z2.h, p2                           : sqincp %p2.h %z2.h -> %z2.h
+25688064 : sqincp z4.h, p3                           : sqincp %p3.h %z4.h -> %z4.h
+25688086 : sqincp z6.h, p4                           : sqincp %p4.h %z6.h -> %z6.h
+256880a8 : sqincp z8.h, p5                           : sqincp %p5.h %z8.h -> %z8.h
+256880ca : sqincp z10.h, p6                          : sqincp %p6.h %z10.h -> %z10.h
+256880ec : sqincp z12.h, p7                          : sqincp %p7.h %z12.h -> %z12.h
+2568810e : sqincp z14.h, p8                          : sqincp %p8.h %z14.h -> %z14.h
+25688130 : sqincp z16.h, p9                          : sqincp %p9.h %z16.h -> %z16.h
+25688131 : sqincp z17.h, p9                          : sqincp %p9.h %z17.h -> %z17.h
+25688153 : sqincp z19.h, p10                         : sqincp %p10.h %z19.h -> %z19.h
+25688175 : sqincp z21.h, p11                         : sqincp %p11.h %z21.h -> %z21.h
+25688197 : sqincp z23.h, p12                         : sqincp %p12.h %z23.h -> %z23.h
+256881b9 : sqincp z25.h, p13                         : sqincp %p13.h %z25.h -> %z25.h
+256881db : sqincp z27.h, p14                         : sqincp %p14.h %z27.h -> %z27.h
+256881ff : sqincp z31.h, p15                         : sqincp %p15.h %z31.h -> %z31.h
+25a88000 : sqincp z0.s, p0                           : sqincp %p0.s %z0.s -> %z0.s
+25a88042 : sqincp z2.s, p2                           : sqincp %p2.s %z2.s -> %z2.s
+25a88064 : sqincp z4.s, p3                           : sqincp %p3.s %z4.s -> %z4.s
+25a88086 : sqincp z6.s, p4                           : sqincp %p4.s %z6.s -> %z6.s
+25a880a8 : sqincp z8.s, p5                           : sqincp %p5.s %z8.s -> %z8.s
+25a880ca : sqincp z10.s, p6                          : sqincp %p6.s %z10.s -> %z10.s
+25a880ec : sqincp z12.s, p7                          : sqincp %p7.s %z12.s -> %z12.s
+25a8810e : sqincp z14.s, p8                          : sqincp %p8.s %z14.s -> %z14.s
+25a88130 : sqincp z16.s, p9                          : sqincp %p9.s %z16.s -> %z16.s
+25a88131 : sqincp z17.s, p9                          : sqincp %p9.s %z17.s -> %z17.s
+25a88153 : sqincp z19.s, p10                         : sqincp %p10.s %z19.s -> %z19.s
+25a88175 : sqincp z21.s, p11                         : sqincp %p11.s %z21.s -> %z21.s
+25a88197 : sqincp z23.s, p12                         : sqincp %p12.s %z23.s -> %z23.s
+25a881b9 : sqincp z25.s, p13                         : sqincp %p13.s %z25.s -> %z25.s
+25a881db : sqincp z27.s, p14                         : sqincp %p14.s %z27.s -> %z27.s
+25a881ff : sqincp z31.s, p15                         : sqincp %p15.s %z31.s -> %z31.s
+25e88000 : sqincp z0.d, p0                           : sqincp %p0.d %z0.d -> %z0.d
+25e88042 : sqincp z2.d, p2                           : sqincp %p2.d %z2.d -> %z2.d
+25e88064 : sqincp z4.d, p3                           : sqincp %p3.d %z4.d -> %z4.d
+25e88086 : sqincp z6.d, p4                           : sqincp %p4.d %z6.d -> %z6.d
+25e880a8 : sqincp z8.d, p5                           : sqincp %p5.d %z8.d -> %z8.d
+25e880ca : sqincp z10.d, p6                          : sqincp %p6.d %z10.d -> %z10.d
+25e880ec : sqincp z12.d, p7                          : sqincp %p7.d %z12.d -> %z12.d
+25e8810e : sqincp z14.d, p8                          : sqincp %p8.d %z14.d -> %z14.d
+25e88130 : sqincp z16.d, p9                          : sqincp %p9.d %z16.d -> %z16.d
+25e88131 : sqincp z17.d, p9                          : sqincp %p9.d %z17.d -> %z17.d
+25e88153 : sqincp z19.d, p10                         : sqincp %p10.d %z19.d -> %z19.d
+25e88175 : sqincp z21.d, p11                         : sqincp %p11.d %z21.d -> %z21.d
+25e88197 : sqincp z23.d, p12                         : sqincp %p12.d %z23.d -> %z23.d
+25e881b9 : sqincp z25.d, p13                         : sqincp %p13.d %z25.d -> %z25.d
+25e881db : sqincp z27.d, p14                         : sqincp %p14.d %z27.d -> %z27.d
+25e881ff : sqincp z31.d, p15                         : sqincp %p15.d %z31.d -> %z31.d
 
 # SQSUB   <Zdn>.<T>, <Zdn>.<T>, #<imm>, <shift> (SQSUB-Z.ZI-_)
 2526c000 : sqsub z0.b, z0.b, #0x0, lsl #0            : sqsub  %z0.b $0x00 lsl $0x00 -> %z0.b
@@ -5247,6 +5909,370 @@
 04fa1738 : uqadd z24.d, z25.d, z26.d                 : uqadd  %z25.d %z26.d -> %z24.d
 04fc177a : uqadd z26.d, z27.d, z28.d                 : uqadd  %z27.d %z28.d -> %z26.d
 04fe17de : uqadd z30.d, z30.d, z30.d                 : uqadd  %z30.d %z30.d -> %z30.d
+
+# UQDECP  <Wdn>, <Pm>.<T> (UQDECP-R.P.R-UW)
+252b8800 : uqdecp w0, p0.b                           : uqdecp %p0.b %w0 -> %w0
+252b8842 : uqdecp w2, p2.b                           : uqdecp %p2.b %w2 -> %w2
+252b8864 : uqdecp w4, p3.b                           : uqdecp %p3.b %w4 -> %w4
+252b8886 : uqdecp w6, p4.b                           : uqdecp %p4.b %w6 -> %w6
+252b88a8 : uqdecp w8, p5.b                           : uqdecp %p5.b %w8 -> %w8
+252b88c9 : uqdecp w9, p6.b                           : uqdecp %p6.b %w9 -> %w9
+252b88eb : uqdecp w11, p7.b                          : uqdecp %p7.b %w11 -> %w11
+252b890d : uqdecp w13, p8.b                          : uqdecp %p8.b %w13 -> %w13
+252b892f : uqdecp w15, p9.b                          : uqdecp %p9.b %w15 -> %w15
+252b8931 : uqdecp w17, p9.b                          : uqdecp %p9.b %w17 -> %w17
+252b8953 : uqdecp w19, p10.b                         : uqdecp %p10.b %w19 -> %w19
+252b8975 : uqdecp w21, p11.b                         : uqdecp %p11.b %w21 -> %w21
+252b8996 : uqdecp w22, p12.b                         : uqdecp %p12.b %w22 -> %w22
+252b89b8 : uqdecp w24, p13.b                         : uqdecp %p13.b %w24 -> %w24
+252b89da : uqdecp w26, p14.b                         : uqdecp %p14.b %w26 -> %w26
+252b89fe : uqdecp w30, p15.b                         : uqdecp %p15.b %w30 -> %w30
+256b8800 : uqdecp w0, p0.h                           : uqdecp %p0.h %w0 -> %w0
+256b8842 : uqdecp w2, p2.h                           : uqdecp %p2.h %w2 -> %w2
+256b8864 : uqdecp w4, p3.h                           : uqdecp %p3.h %w4 -> %w4
+256b8886 : uqdecp w6, p4.h                           : uqdecp %p4.h %w6 -> %w6
+256b88a8 : uqdecp w8, p5.h                           : uqdecp %p5.h %w8 -> %w8
+256b88c9 : uqdecp w9, p6.h                           : uqdecp %p6.h %w9 -> %w9
+256b88eb : uqdecp w11, p7.h                          : uqdecp %p7.h %w11 -> %w11
+256b890d : uqdecp w13, p8.h                          : uqdecp %p8.h %w13 -> %w13
+256b892f : uqdecp w15, p9.h                          : uqdecp %p9.h %w15 -> %w15
+256b8931 : uqdecp w17, p9.h                          : uqdecp %p9.h %w17 -> %w17
+256b8953 : uqdecp w19, p10.h                         : uqdecp %p10.h %w19 -> %w19
+256b8975 : uqdecp w21, p11.h                         : uqdecp %p11.h %w21 -> %w21
+256b8996 : uqdecp w22, p12.h                         : uqdecp %p12.h %w22 -> %w22
+256b89b8 : uqdecp w24, p13.h                         : uqdecp %p13.h %w24 -> %w24
+256b89da : uqdecp w26, p14.h                         : uqdecp %p14.h %w26 -> %w26
+256b89fe : uqdecp w30, p15.h                         : uqdecp %p15.h %w30 -> %w30
+25ab8800 : uqdecp w0, p0.s                           : uqdecp %p0.s %w0 -> %w0
+25ab8842 : uqdecp w2, p2.s                           : uqdecp %p2.s %w2 -> %w2
+25ab8864 : uqdecp w4, p3.s                           : uqdecp %p3.s %w4 -> %w4
+25ab8886 : uqdecp w6, p4.s                           : uqdecp %p4.s %w6 -> %w6
+25ab88a8 : uqdecp w8, p5.s                           : uqdecp %p5.s %w8 -> %w8
+25ab88c9 : uqdecp w9, p6.s                           : uqdecp %p6.s %w9 -> %w9
+25ab88eb : uqdecp w11, p7.s                          : uqdecp %p7.s %w11 -> %w11
+25ab890d : uqdecp w13, p8.s                          : uqdecp %p8.s %w13 -> %w13
+25ab892f : uqdecp w15, p9.s                          : uqdecp %p9.s %w15 -> %w15
+25ab8931 : uqdecp w17, p9.s                          : uqdecp %p9.s %w17 -> %w17
+25ab8953 : uqdecp w19, p10.s                         : uqdecp %p10.s %w19 -> %w19
+25ab8975 : uqdecp w21, p11.s                         : uqdecp %p11.s %w21 -> %w21
+25ab8996 : uqdecp w22, p12.s                         : uqdecp %p12.s %w22 -> %w22
+25ab89b8 : uqdecp w24, p13.s                         : uqdecp %p13.s %w24 -> %w24
+25ab89da : uqdecp w26, p14.s                         : uqdecp %p14.s %w26 -> %w26
+25ab89fe : uqdecp w30, p15.s                         : uqdecp %p15.s %w30 -> %w30
+25eb8800 : uqdecp w0, p0.d                           : uqdecp %p0.d %w0 -> %w0
+25eb8842 : uqdecp w2, p2.d                           : uqdecp %p2.d %w2 -> %w2
+25eb8864 : uqdecp w4, p3.d                           : uqdecp %p3.d %w4 -> %w4
+25eb8886 : uqdecp w6, p4.d                           : uqdecp %p4.d %w6 -> %w6
+25eb88a8 : uqdecp w8, p5.d                           : uqdecp %p5.d %w8 -> %w8
+25eb88c9 : uqdecp w9, p6.d                           : uqdecp %p6.d %w9 -> %w9
+25eb88eb : uqdecp w11, p7.d                          : uqdecp %p7.d %w11 -> %w11
+25eb890d : uqdecp w13, p8.d                          : uqdecp %p8.d %w13 -> %w13
+25eb892f : uqdecp w15, p9.d                          : uqdecp %p9.d %w15 -> %w15
+25eb8931 : uqdecp w17, p9.d                          : uqdecp %p9.d %w17 -> %w17
+25eb8953 : uqdecp w19, p10.d                         : uqdecp %p10.d %w19 -> %w19
+25eb8975 : uqdecp w21, p11.d                         : uqdecp %p11.d %w21 -> %w21
+25eb8996 : uqdecp w22, p12.d                         : uqdecp %p12.d %w22 -> %w22
+25eb89b8 : uqdecp w24, p13.d                         : uqdecp %p13.d %w24 -> %w24
+25eb89da : uqdecp w26, p14.d                         : uqdecp %p14.d %w26 -> %w26
+25eb89fe : uqdecp w30, p15.d                         : uqdecp %p15.d %w30 -> %w30
+
+# UQDECP  <Xdn>, <Pm>.<T> (UQDECP-R.P.R-X)
+252b8c00 : uqdecp x0, p0.b                           : uqdecp %p0.b %x0 -> %x0
+252b8c42 : uqdecp x2, p2.b                           : uqdecp %p2.b %x2 -> %x2
+252b8c64 : uqdecp x4, p3.b                           : uqdecp %p3.b %x4 -> %x4
+252b8c86 : uqdecp x6, p4.b                           : uqdecp %p4.b %x6 -> %x6
+252b8ca8 : uqdecp x8, p5.b                           : uqdecp %p5.b %x8 -> %x8
+252b8cc9 : uqdecp x9, p6.b                           : uqdecp %p6.b %x9 -> %x9
+252b8ceb : uqdecp x11, p7.b                          : uqdecp %p7.b %x11 -> %x11
+252b8d0d : uqdecp x13, p8.b                          : uqdecp %p8.b %x13 -> %x13
+252b8d2f : uqdecp x15, p9.b                          : uqdecp %p9.b %x15 -> %x15
+252b8d31 : uqdecp x17, p9.b                          : uqdecp %p9.b %x17 -> %x17
+252b8d53 : uqdecp x19, p10.b                         : uqdecp %p10.b %x19 -> %x19
+252b8d75 : uqdecp x21, p11.b                         : uqdecp %p11.b %x21 -> %x21
+252b8d96 : uqdecp x22, p12.b                         : uqdecp %p12.b %x22 -> %x22
+252b8db8 : uqdecp x24, p13.b                         : uqdecp %p13.b %x24 -> %x24
+252b8dda : uqdecp x26, p14.b                         : uqdecp %p14.b %x26 -> %x26
+252b8dfe : uqdecp x30, p15.b                         : uqdecp %p15.b %x30 -> %x30
+256b8c00 : uqdecp x0, p0.h                           : uqdecp %p0.h %x0 -> %x0
+256b8c42 : uqdecp x2, p2.h                           : uqdecp %p2.h %x2 -> %x2
+256b8c64 : uqdecp x4, p3.h                           : uqdecp %p3.h %x4 -> %x4
+256b8c86 : uqdecp x6, p4.h                           : uqdecp %p4.h %x6 -> %x6
+256b8ca8 : uqdecp x8, p5.h                           : uqdecp %p5.h %x8 -> %x8
+256b8cc9 : uqdecp x9, p6.h                           : uqdecp %p6.h %x9 -> %x9
+256b8ceb : uqdecp x11, p7.h                          : uqdecp %p7.h %x11 -> %x11
+256b8d0d : uqdecp x13, p8.h                          : uqdecp %p8.h %x13 -> %x13
+256b8d2f : uqdecp x15, p9.h                          : uqdecp %p9.h %x15 -> %x15
+256b8d31 : uqdecp x17, p9.h                          : uqdecp %p9.h %x17 -> %x17
+256b8d53 : uqdecp x19, p10.h                         : uqdecp %p10.h %x19 -> %x19
+256b8d75 : uqdecp x21, p11.h                         : uqdecp %p11.h %x21 -> %x21
+256b8d96 : uqdecp x22, p12.h                         : uqdecp %p12.h %x22 -> %x22
+256b8db8 : uqdecp x24, p13.h                         : uqdecp %p13.h %x24 -> %x24
+256b8dda : uqdecp x26, p14.h                         : uqdecp %p14.h %x26 -> %x26
+256b8dfe : uqdecp x30, p15.h                         : uqdecp %p15.h %x30 -> %x30
+25ab8c00 : uqdecp x0, p0.s                           : uqdecp %p0.s %x0 -> %x0
+25ab8c42 : uqdecp x2, p2.s                           : uqdecp %p2.s %x2 -> %x2
+25ab8c64 : uqdecp x4, p3.s                           : uqdecp %p3.s %x4 -> %x4
+25ab8c86 : uqdecp x6, p4.s                           : uqdecp %p4.s %x6 -> %x6
+25ab8ca8 : uqdecp x8, p5.s                           : uqdecp %p5.s %x8 -> %x8
+25ab8cc9 : uqdecp x9, p6.s                           : uqdecp %p6.s %x9 -> %x9
+25ab8ceb : uqdecp x11, p7.s                          : uqdecp %p7.s %x11 -> %x11
+25ab8d0d : uqdecp x13, p8.s                          : uqdecp %p8.s %x13 -> %x13
+25ab8d2f : uqdecp x15, p9.s                          : uqdecp %p9.s %x15 -> %x15
+25ab8d31 : uqdecp x17, p9.s                          : uqdecp %p9.s %x17 -> %x17
+25ab8d53 : uqdecp x19, p10.s                         : uqdecp %p10.s %x19 -> %x19
+25ab8d75 : uqdecp x21, p11.s                         : uqdecp %p11.s %x21 -> %x21
+25ab8d96 : uqdecp x22, p12.s                         : uqdecp %p12.s %x22 -> %x22
+25ab8db8 : uqdecp x24, p13.s                         : uqdecp %p13.s %x24 -> %x24
+25ab8dda : uqdecp x26, p14.s                         : uqdecp %p14.s %x26 -> %x26
+25ab8dfe : uqdecp x30, p15.s                         : uqdecp %p15.s %x30 -> %x30
+25eb8c00 : uqdecp x0, p0.d                           : uqdecp %p0.d %x0 -> %x0
+25eb8c42 : uqdecp x2, p2.d                           : uqdecp %p2.d %x2 -> %x2
+25eb8c64 : uqdecp x4, p3.d                           : uqdecp %p3.d %x4 -> %x4
+25eb8c86 : uqdecp x6, p4.d                           : uqdecp %p4.d %x6 -> %x6
+25eb8ca8 : uqdecp x8, p5.d                           : uqdecp %p5.d %x8 -> %x8
+25eb8cc9 : uqdecp x9, p6.d                           : uqdecp %p6.d %x9 -> %x9
+25eb8ceb : uqdecp x11, p7.d                          : uqdecp %p7.d %x11 -> %x11
+25eb8d0d : uqdecp x13, p8.d                          : uqdecp %p8.d %x13 -> %x13
+25eb8d2f : uqdecp x15, p9.d                          : uqdecp %p9.d %x15 -> %x15
+25eb8d31 : uqdecp x17, p9.d                          : uqdecp %p9.d %x17 -> %x17
+25eb8d53 : uqdecp x19, p10.d                         : uqdecp %p10.d %x19 -> %x19
+25eb8d75 : uqdecp x21, p11.d                         : uqdecp %p11.d %x21 -> %x21
+25eb8d96 : uqdecp x22, p12.d                         : uqdecp %p12.d %x22 -> %x22
+25eb8db8 : uqdecp x24, p13.d                         : uqdecp %p13.d %x24 -> %x24
+25eb8dda : uqdecp x26, p14.d                         : uqdecp %p14.d %x26 -> %x26
+25eb8dfe : uqdecp x30, p15.d                         : uqdecp %p15.d %x30 -> %x30
+
+# UQDECP  <Zdn>.<T>, <Pm>.<T> (UQDECP-Z.P.Z-_)
+256b8000 : uqdecp z0.h, p0                           : uqdecp %p0.h %z0.h -> %z0.h
+256b8042 : uqdecp z2.h, p2                           : uqdecp %p2.h %z2.h -> %z2.h
+256b8064 : uqdecp z4.h, p3                           : uqdecp %p3.h %z4.h -> %z4.h
+256b8086 : uqdecp z6.h, p4                           : uqdecp %p4.h %z6.h -> %z6.h
+256b80a8 : uqdecp z8.h, p5                           : uqdecp %p5.h %z8.h -> %z8.h
+256b80ca : uqdecp z10.h, p6                          : uqdecp %p6.h %z10.h -> %z10.h
+256b80ec : uqdecp z12.h, p7                          : uqdecp %p7.h %z12.h -> %z12.h
+256b810e : uqdecp z14.h, p8                          : uqdecp %p8.h %z14.h -> %z14.h
+256b8130 : uqdecp z16.h, p9                          : uqdecp %p9.h %z16.h -> %z16.h
+256b8131 : uqdecp z17.h, p9                          : uqdecp %p9.h %z17.h -> %z17.h
+256b8153 : uqdecp z19.h, p10                         : uqdecp %p10.h %z19.h -> %z19.h
+256b8175 : uqdecp z21.h, p11                         : uqdecp %p11.h %z21.h -> %z21.h
+256b8197 : uqdecp z23.h, p12                         : uqdecp %p12.h %z23.h -> %z23.h
+256b81b9 : uqdecp z25.h, p13                         : uqdecp %p13.h %z25.h -> %z25.h
+256b81db : uqdecp z27.h, p14                         : uqdecp %p14.h %z27.h -> %z27.h
+256b81ff : uqdecp z31.h, p15                         : uqdecp %p15.h %z31.h -> %z31.h
+25ab8000 : uqdecp z0.s, p0                           : uqdecp %p0.s %z0.s -> %z0.s
+25ab8042 : uqdecp z2.s, p2                           : uqdecp %p2.s %z2.s -> %z2.s
+25ab8064 : uqdecp z4.s, p3                           : uqdecp %p3.s %z4.s -> %z4.s
+25ab8086 : uqdecp z6.s, p4                           : uqdecp %p4.s %z6.s -> %z6.s
+25ab80a8 : uqdecp z8.s, p5                           : uqdecp %p5.s %z8.s -> %z8.s
+25ab80ca : uqdecp z10.s, p6                          : uqdecp %p6.s %z10.s -> %z10.s
+25ab80ec : uqdecp z12.s, p7                          : uqdecp %p7.s %z12.s -> %z12.s
+25ab810e : uqdecp z14.s, p8                          : uqdecp %p8.s %z14.s -> %z14.s
+25ab8130 : uqdecp z16.s, p9                          : uqdecp %p9.s %z16.s -> %z16.s
+25ab8131 : uqdecp z17.s, p9                          : uqdecp %p9.s %z17.s -> %z17.s
+25ab8153 : uqdecp z19.s, p10                         : uqdecp %p10.s %z19.s -> %z19.s
+25ab8175 : uqdecp z21.s, p11                         : uqdecp %p11.s %z21.s -> %z21.s
+25ab8197 : uqdecp z23.s, p12                         : uqdecp %p12.s %z23.s -> %z23.s
+25ab81b9 : uqdecp z25.s, p13                         : uqdecp %p13.s %z25.s -> %z25.s
+25ab81db : uqdecp z27.s, p14                         : uqdecp %p14.s %z27.s -> %z27.s
+25ab81ff : uqdecp z31.s, p15                         : uqdecp %p15.s %z31.s -> %z31.s
+25eb8000 : uqdecp z0.d, p0                           : uqdecp %p0.d %z0.d -> %z0.d
+25eb8042 : uqdecp z2.d, p2                           : uqdecp %p2.d %z2.d -> %z2.d
+25eb8064 : uqdecp z4.d, p3                           : uqdecp %p3.d %z4.d -> %z4.d
+25eb8086 : uqdecp z6.d, p4                           : uqdecp %p4.d %z6.d -> %z6.d
+25eb80a8 : uqdecp z8.d, p5                           : uqdecp %p5.d %z8.d -> %z8.d
+25eb80ca : uqdecp z10.d, p6                          : uqdecp %p6.d %z10.d -> %z10.d
+25eb80ec : uqdecp z12.d, p7                          : uqdecp %p7.d %z12.d -> %z12.d
+25eb810e : uqdecp z14.d, p8                          : uqdecp %p8.d %z14.d -> %z14.d
+25eb8130 : uqdecp z16.d, p9                          : uqdecp %p9.d %z16.d -> %z16.d
+25eb8131 : uqdecp z17.d, p9                          : uqdecp %p9.d %z17.d -> %z17.d
+25eb8153 : uqdecp z19.d, p10                         : uqdecp %p10.d %z19.d -> %z19.d
+25eb8175 : uqdecp z21.d, p11                         : uqdecp %p11.d %z21.d -> %z21.d
+25eb8197 : uqdecp z23.d, p12                         : uqdecp %p12.d %z23.d -> %z23.d
+25eb81b9 : uqdecp z25.d, p13                         : uqdecp %p13.d %z25.d -> %z25.d
+25eb81db : uqdecp z27.d, p14                         : uqdecp %p14.d %z27.d -> %z27.d
+25eb81ff : uqdecp z31.d, p15                         : uqdecp %p15.d %z31.d -> %z31.d
+
+# UQINCP  <Wdn>, <Pm>.<T> (UQINCP-R.P.R-UW)
+25298800 : uqincp w0, p0.b                           : uqincp %p0.b %w0 -> %w0
+25298842 : uqincp w2, p2.b                           : uqincp %p2.b %w2 -> %w2
+25298864 : uqincp w4, p3.b                           : uqincp %p3.b %w4 -> %w4
+25298886 : uqincp w6, p4.b                           : uqincp %p4.b %w6 -> %w6
+252988a8 : uqincp w8, p5.b                           : uqincp %p5.b %w8 -> %w8
+252988c9 : uqincp w9, p6.b                           : uqincp %p6.b %w9 -> %w9
+252988eb : uqincp w11, p7.b                          : uqincp %p7.b %w11 -> %w11
+2529890d : uqincp w13, p8.b                          : uqincp %p8.b %w13 -> %w13
+2529892f : uqincp w15, p9.b                          : uqincp %p9.b %w15 -> %w15
+25298931 : uqincp w17, p9.b                          : uqincp %p9.b %w17 -> %w17
+25298953 : uqincp w19, p10.b                         : uqincp %p10.b %w19 -> %w19
+25298975 : uqincp w21, p11.b                         : uqincp %p11.b %w21 -> %w21
+25298996 : uqincp w22, p12.b                         : uqincp %p12.b %w22 -> %w22
+252989b8 : uqincp w24, p13.b                         : uqincp %p13.b %w24 -> %w24
+252989da : uqincp w26, p14.b                         : uqincp %p14.b %w26 -> %w26
+252989fe : uqincp w30, p15.b                         : uqincp %p15.b %w30 -> %w30
+25698800 : uqincp w0, p0.h                           : uqincp %p0.h %w0 -> %w0
+25698842 : uqincp w2, p2.h                           : uqincp %p2.h %w2 -> %w2
+25698864 : uqincp w4, p3.h                           : uqincp %p3.h %w4 -> %w4
+25698886 : uqincp w6, p4.h                           : uqincp %p4.h %w6 -> %w6
+256988a8 : uqincp w8, p5.h                           : uqincp %p5.h %w8 -> %w8
+256988c9 : uqincp w9, p6.h                           : uqincp %p6.h %w9 -> %w9
+256988eb : uqincp w11, p7.h                          : uqincp %p7.h %w11 -> %w11
+2569890d : uqincp w13, p8.h                          : uqincp %p8.h %w13 -> %w13
+2569892f : uqincp w15, p9.h                          : uqincp %p9.h %w15 -> %w15
+25698931 : uqincp w17, p9.h                          : uqincp %p9.h %w17 -> %w17
+25698953 : uqincp w19, p10.h                         : uqincp %p10.h %w19 -> %w19
+25698975 : uqincp w21, p11.h                         : uqincp %p11.h %w21 -> %w21
+25698996 : uqincp w22, p12.h                         : uqincp %p12.h %w22 -> %w22
+256989b8 : uqincp w24, p13.h                         : uqincp %p13.h %w24 -> %w24
+256989da : uqincp w26, p14.h                         : uqincp %p14.h %w26 -> %w26
+256989fe : uqincp w30, p15.h                         : uqincp %p15.h %w30 -> %w30
+25a98800 : uqincp w0, p0.s                           : uqincp %p0.s %w0 -> %w0
+25a98842 : uqincp w2, p2.s                           : uqincp %p2.s %w2 -> %w2
+25a98864 : uqincp w4, p3.s                           : uqincp %p3.s %w4 -> %w4
+25a98886 : uqincp w6, p4.s                           : uqincp %p4.s %w6 -> %w6
+25a988a8 : uqincp w8, p5.s                           : uqincp %p5.s %w8 -> %w8
+25a988c9 : uqincp w9, p6.s                           : uqincp %p6.s %w9 -> %w9
+25a988eb : uqincp w11, p7.s                          : uqincp %p7.s %w11 -> %w11
+25a9890d : uqincp w13, p8.s                          : uqincp %p8.s %w13 -> %w13
+25a9892f : uqincp w15, p9.s                          : uqincp %p9.s %w15 -> %w15
+25a98931 : uqincp w17, p9.s                          : uqincp %p9.s %w17 -> %w17
+25a98953 : uqincp w19, p10.s                         : uqincp %p10.s %w19 -> %w19
+25a98975 : uqincp w21, p11.s                         : uqincp %p11.s %w21 -> %w21
+25a98996 : uqincp w22, p12.s                         : uqincp %p12.s %w22 -> %w22
+25a989b8 : uqincp w24, p13.s                         : uqincp %p13.s %w24 -> %w24
+25a989da : uqincp w26, p14.s                         : uqincp %p14.s %w26 -> %w26
+25a989fe : uqincp w30, p15.s                         : uqincp %p15.s %w30 -> %w30
+25e98800 : uqincp w0, p0.d                           : uqincp %p0.d %w0 -> %w0
+25e98842 : uqincp w2, p2.d                           : uqincp %p2.d %w2 -> %w2
+25e98864 : uqincp w4, p3.d                           : uqincp %p3.d %w4 -> %w4
+25e98886 : uqincp w6, p4.d                           : uqincp %p4.d %w6 -> %w6
+25e988a8 : uqincp w8, p5.d                           : uqincp %p5.d %w8 -> %w8
+25e988c9 : uqincp w9, p6.d                           : uqincp %p6.d %w9 -> %w9
+25e988eb : uqincp w11, p7.d                          : uqincp %p7.d %w11 -> %w11
+25e9890d : uqincp w13, p8.d                          : uqincp %p8.d %w13 -> %w13
+25e9892f : uqincp w15, p9.d                          : uqincp %p9.d %w15 -> %w15
+25e98931 : uqincp w17, p9.d                          : uqincp %p9.d %w17 -> %w17
+25e98953 : uqincp w19, p10.d                         : uqincp %p10.d %w19 -> %w19
+25e98975 : uqincp w21, p11.d                         : uqincp %p11.d %w21 -> %w21
+25e98996 : uqincp w22, p12.d                         : uqincp %p12.d %w22 -> %w22
+25e989b8 : uqincp w24, p13.d                         : uqincp %p13.d %w24 -> %w24
+25e989da : uqincp w26, p14.d                         : uqincp %p14.d %w26 -> %w26
+25e989fe : uqincp w30, p15.d                         : uqincp %p15.d %w30 -> %w30
+
+# UQINCP  <Xdn>, <Pm>.<T> (UQINCP-R.P.R-X)
+25298c00 : uqincp x0, p0.b                           : uqincp %p0.b %x0 -> %x0
+25298c42 : uqincp x2, p2.b                           : uqincp %p2.b %x2 -> %x2
+25298c64 : uqincp x4, p3.b                           : uqincp %p3.b %x4 -> %x4
+25298c86 : uqincp x6, p4.b                           : uqincp %p4.b %x6 -> %x6
+25298ca8 : uqincp x8, p5.b                           : uqincp %p5.b %x8 -> %x8
+25298cc9 : uqincp x9, p6.b                           : uqincp %p6.b %x9 -> %x9
+25298ceb : uqincp x11, p7.b                          : uqincp %p7.b %x11 -> %x11
+25298d0d : uqincp x13, p8.b                          : uqincp %p8.b %x13 -> %x13
+25298d2f : uqincp x15, p9.b                          : uqincp %p9.b %x15 -> %x15
+25298d31 : uqincp x17, p9.b                          : uqincp %p9.b %x17 -> %x17
+25298d53 : uqincp x19, p10.b                         : uqincp %p10.b %x19 -> %x19
+25298d75 : uqincp x21, p11.b                         : uqincp %p11.b %x21 -> %x21
+25298d96 : uqincp x22, p12.b                         : uqincp %p12.b %x22 -> %x22
+25298db8 : uqincp x24, p13.b                         : uqincp %p13.b %x24 -> %x24
+25298dda : uqincp x26, p14.b                         : uqincp %p14.b %x26 -> %x26
+25298dfe : uqincp x30, p15.b                         : uqincp %p15.b %x30 -> %x30
+25698c00 : uqincp x0, p0.h                           : uqincp %p0.h %x0 -> %x0
+25698c42 : uqincp x2, p2.h                           : uqincp %p2.h %x2 -> %x2
+25698c64 : uqincp x4, p3.h                           : uqincp %p3.h %x4 -> %x4
+25698c86 : uqincp x6, p4.h                           : uqincp %p4.h %x6 -> %x6
+25698ca8 : uqincp x8, p5.h                           : uqincp %p5.h %x8 -> %x8
+25698cc9 : uqincp x9, p6.h                           : uqincp %p6.h %x9 -> %x9
+25698ceb : uqincp x11, p7.h                          : uqincp %p7.h %x11 -> %x11
+25698d0d : uqincp x13, p8.h                          : uqincp %p8.h %x13 -> %x13
+25698d2f : uqincp x15, p9.h                          : uqincp %p9.h %x15 -> %x15
+25698d31 : uqincp x17, p9.h                          : uqincp %p9.h %x17 -> %x17
+25698d53 : uqincp x19, p10.h                         : uqincp %p10.h %x19 -> %x19
+25698d75 : uqincp x21, p11.h                         : uqincp %p11.h %x21 -> %x21
+25698d96 : uqincp x22, p12.h                         : uqincp %p12.h %x22 -> %x22
+25698db8 : uqincp x24, p13.h                         : uqincp %p13.h %x24 -> %x24
+25698dda : uqincp x26, p14.h                         : uqincp %p14.h %x26 -> %x26
+25698dfe : uqincp x30, p15.h                         : uqincp %p15.h %x30 -> %x30
+25a98c00 : uqincp x0, p0.s                           : uqincp %p0.s %x0 -> %x0
+25a98c42 : uqincp x2, p2.s                           : uqincp %p2.s %x2 -> %x2
+25a98c64 : uqincp x4, p3.s                           : uqincp %p3.s %x4 -> %x4
+25a98c86 : uqincp x6, p4.s                           : uqincp %p4.s %x6 -> %x6
+25a98ca8 : uqincp x8, p5.s                           : uqincp %p5.s %x8 -> %x8
+25a98cc9 : uqincp x9, p6.s                           : uqincp %p6.s %x9 -> %x9
+25a98ceb : uqincp x11, p7.s                          : uqincp %p7.s %x11 -> %x11
+25a98d0d : uqincp x13, p8.s                          : uqincp %p8.s %x13 -> %x13
+25a98d2f : uqincp x15, p9.s                          : uqincp %p9.s %x15 -> %x15
+25a98d31 : uqincp x17, p9.s                          : uqincp %p9.s %x17 -> %x17
+25a98d53 : uqincp x19, p10.s                         : uqincp %p10.s %x19 -> %x19
+25a98d75 : uqincp x21, p11.s                         : uqincp %p11.s %x21 -> %x21
+25a98d96 : uqincp x22, p12.s                         : uqincp %p12.s %x22 -> %x22
+25a98db8 : uqincp x24, p13.s                         : uqincp %p13.s %x24 -> %x24
+25a98dda : uqincp x26, p14.s                         : uqincp %p14.s %x26 -> %x26
+25a98dfe : uqincp x30, p15.s                         : uqincp %p15.s %x30 -> %x30
+25e98c00 : uqincp x0, p0.d                           : uqincp %p0.d %x0 -> %x0
+25e98c42 : uqincp x2, p2.d                           : uqincp %p2.d %x2 -> %x2
+25e98c64 : uqincp x4, p3.d                           : uqincp %p3.d %x4 -> %x4
+25e98c86 : uqincp x6, p4.d                           : uqincp %p4.d %x6 -> %x6
+25e98ca8 : uqincp x8, p5.d                           : uqincp %p5.d %x8 -> %x8
+25e98cc9 : uqincp x9, p6.d                           : uqincp %p6.d %x9 -> %x9
+25e98ceb : uqincp x11, p7.d                          : uqincp %p7.d %x11 -> %x11
+25e98d0d : uqincp x13, p8.d                          : uqincp %p8.d %x13 -> %x13
+25e98d2f : uqincp x15, p9.d                          : uqincp %p9.d %x15 -> %x15
+25e98d31 : uqincp x17, p9.d                          : uqincp %p9.d %x17 -> %x17
+25e98d53 : uqincp x19, p10.d                         : uqincp %p10.d %x19 -> %x19
+25e98d75 : uqincp x21, p11.d                         : uqincp %p11.d %x21 -> %x21
+25e98d96 : uqincp x22, p12.d                         : uqincp %p12.d %x22 -> %x22
+25e98db8 : uqincp x24, p13.d                         : uqincp %p13.d %x24 -> %x24
+25e98dda : uqincp x26, p14.d                         : uqincp %p14.d %x26 -> %x26
+25e98dfe : uqincp x30, p15.d                         : uqincp %p15.d %x30 -> %x30
+
+# UQINCP  <Zdn>.<T>, <Pm>.<T> (UQINCP-Z.P.Z-_)
+25698000 : uqincp z0.h, p0                           : uqincp %p0.h %z0.h -> %z0.h
+25698042 : uqincp z2.h, p2                           : uqincp %p2.h %z2.h -> %z2.h
+25698064 : uqincp z4.h, p3                           : uqincp %p3.h %z4.h -> %z4.h
+25698086 : uqincp z6.h, p4                           : uqincp %p4.h %z6.h -> %z6.h
+256980a8 : uqincp z8.h, p5                           : uqincp %p5.h %z8.h -> %z8.h
+256980ca : uqincp z10.h, p6                          : uqincp %p6.h %z10.h -> %z10.h
+256980ec : uqincp z12.h, p7                          : uqincp %p7.h %z12.h -> %z12.h
+2569810e : uqincp z14.h, p8                          : uqincp %p8.h %z14.h -> %z14.h
+25698130 : uqincp z16.h, p9                          : uqincp %p9.h %z16.h -> %z16.h
+25698131 : uqincp z17.h, p9                          : uqincp %p9.h %z17.h -> %z17.h
+25698153 : uqincp z19.h, p10                         : uqincp %p10.h %z19.h -> %z19.h
+25698175 : uqincp z21.h, p11                         : uqincp %p11.h %z21.h -> %z21.h
+25698197 : uqincp z23.h, p12                         : uqincp %p12.h %z23.h -> %z23.h
+256981b9 : uqincp z25.h, p13                         : uqincp %p13.h %z25.h -> %z25.h
+256981db : uqincp z27.h, p14                         : uqincp %p14.h %z27.h -> %z27.h
+256981ff : uqincp z31.h, p15                         : uqincp %p15.h %z31.h -> %z31.h
+25a98000 : uqincp z0.s, p0                           : uqincp %p0.s %z0.s -> %z0.s
+25a98042 : uqincp z2.s, p2                           : uqincp %p2.s %z2.s -> %z2.s
+25a98064 : uqincp z4.s, p3                           : uqincp %p3.s %z4.s -> %z4.s
+25a98086 : uqincp z6.s, p4                           : uqincp %p4.s %z6.s -> %z6.s
+25a980a8 : uqincp z8.s, p5                           : uqincp %p5.s %z8.s -> %z8.s
+25a980ca : uqincp z10.s, p6                          : uqincp %p6.s %z10.s -> %z10.s
+25a980ec : uqincp z12.s, p7                          : uqincp %p7.s %z12.s -> %z12.s
+25a9810e : uqincp z14.s, p8                          : uqincp %p8.s %z14.s -> %z14.s
+25a98130 : uqincp z16.s, p9                          : uqincp %p9.s %z16.s -> %z16.s
+25a98131 : uqincp z17.s, p9                          : uqincp %p9.s %z17.s -> %z17.s
+25a98153 : uqincp z19.s, p10                         : uqincp %p10.s %z19.s -> %z19.s
+25a98175 : uqincp z21.s, p11                         : uqincp %p11.s %z21.s -> %z21.s
+25a98197 : uqincp z23.s, p12                         : uqincp %p12.s %z23.s -> %z23.s
+25a981b9 : uqincp z25.s, p13                         : uqincp %p13.s %z25.s -> %z25.s
+25a981db : uqincp z27.s, p14                         : uqincp %p14.s %z27.s -> %z27.s
+25a981ff : uqincp z31.s, p15                         : uqincp %p15.s %z31.s -> %z31.s
+25e98000 : uqincp z0.d, p0                           : uqincp %p0.d %z0.d -> %z0.d
+25e98042 : uqincp z2.d, p2                           : uqincp %p2.d %z2.d -> %z2.d
+25e98064 : uqincp z4.d, p3                           : uqincp %p3.d %z4.d -> %z4.d
+25e98086 : uqincp z6.d, p4                           : uqincp %p4.d %z6.d -> %z6.d
+25e980a8 : uqincp z8.d, p5                           : uqincp %p5.d %z8.d -> %z8.d
+25e980ca : uqincp z10.d, p6                          : uqincp %p6.d %z10.d -> %z10.d
+25e980ec : uqincp z12.d, p7                          : uqincp %p7.d %z12.d -> %z12.d
+25e9810e : uqincp z14.d, p8                          : uqincp %p8.d %z14.d -> %z14.d
+25e98130 : uqincp z16.d, p9                          : uqincp %p9.d %z16.d -> %z16.d
+25e98131 : uqincp z17.d, p9                          : uqincp %p9.d %z17.d -> %z17.d
+25e98153 : uqincp z19.d, p10                         : uqincp %p10.d %z19.d -> %z19.d
+25e98175 : uqincp z21.d, p11                         : uqincp %p11.d %z21.d -> %z21.d
+25e98197 : uqincp z23.d, p12                         : uqincp %p12.d %z23.d -> %z23.d
+25e981b9 : uqincp z25.d, p13                         : uqincp %p13.d %z25.d -> %z25.d
+25e981db : uqincp z27.d, p14                         : uqincp %p14.d %z27.d -> %z27.d
+25e981ff : uqincp z31.d, p15                         : uqincp %p15.d %z31.d -> %z31.d
 
 # UQSUB   <Zdn>.<T>, <Zdn>.<T>, #<imm>, <shift> (UQSUB-Z.ZI-_)
 2527c000 : uqsub z0.b, z0.b, #0x0, lsl #0            : uqsub  %z0.b $0x00 lsl $0x00 -> %z0.b

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -82,7 +82,8 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
     char *buf = malloc(buflen);
 
     if (instr_get_opcode(instr) != opcode) {
-        print("incorrect opcode for instr %s: %s\n\n", opcode, instr_get_opcode(instr));
+        print("incorrect opcode for instr %s: %s\n\n", decode_opcode_name(opcode),
+              decode_opcode_name(instr_get_opcode(instr)));
         instr_destroy(dc, instr);
         return false;
     }
@@ -142,3 +143,7 @@ const reg_id_t Pn_six_offset_1[6] = { DR_REG_P0, DR_REG_P3,  DR_REG_P6,
                                       DR_REG_P9, DR_REG_P11, DR_REG_P15 };
 const reg_id_t Pn_six_offset_2[6] = { DR_REG_P0,  DR_REG_P4,  DR_REG_P7,
                                       DR_REG_P10, DR_REG_P12, DR_REG_P15 };
+const reg_id_t Xn_six_offset_0[6] = { DR_REG_X0,  DR_REG_X5,  DR_REG_X10,
+                                      DR_REG_X15, DR_REG_X20, DR_REG_X30 };
+const reg_id_t Wn_six_offset_0[6] = { DR_REG_W0,  DR_REG_W5,  DR_REG_W10,
+                                      DR_REG_W15, DR_REG_W20, DR_REG_W30 };

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -4173,6 +4173,600 @@ TEST_INSTR(setffr_sve)
     TEST_NO_OPNDS(setffr, setffr_sve, "setffr");
 }
 
+TEST_INSTR(cntp_sve_pred)
+{
+
+    /* Testing CNTP    <Xd>, <Pg>, <Pn>.<Ts> */
+    const char *expected_0_0[6] = {
+        "cntp   %p0 %p0.b -> %x0",    "cntp   %p3 %p4.b -> %x5",
+        "cntp   %p6 %p7.b -> %x10",   "cntp   %p9 %p10.b -> %x15",
+        "cntp   %p11 %p12.b -> %x20", "cntp   %p15 %p15.b -> %x30",
+    };
+    TEST_LOOP(cntp, cntp_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg(Xn_six_offset_0[i]), opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "cntp   %p0 %p0.h -> %x0",    "cntp   %p3 %p4.h -> %x5",
+        "cntp   %p6 %p7.h -> %x10",   "cntp   %p9 %p10.h -> %x15",
+        "cntp   %p11 %p12.h -> %x20", "cntp   %p15 %p15.h -> %x30",
+    };
+    TEST_LOOP(cntp, cntp_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg(Xn_six_offset_0[i]), opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "cntp   %p0 %p0.s -> %x0",    "cntp   %p3 %p4.s -> %x5",
+        "cntp   %p6 %p7.s -> %x10",   "cntp   %p9 %p10.s -> %x15",
+        "cntp   %p11 %p12.s -> %x20", "cntp   %p15 %p15.s -> %x30",
+    };
+    TEST_LOOP(cntp, cntp_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg(Xn_six_offset_0[i]), opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "cntp   %p0 %p0.d -> %x0",    "cntp   %p3 %p4.d -> %x5",
+        "cntp   %p6 %p7.d -> %x10",   "cntp   %p9 %p10.d -> %x15",
+        "cntp   %p11 %p12.d -> %x20", "cntp   %p15 %p15.d -> %x30",
+    };
+    TEST_LOOP(cntp, cntp_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg(Xn_six_offset_0[i]), opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(decp_sve)
+{
+
+    /* Testing DECP    <Xdn>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "decp   %p0.b %x0 -> %x0",    "decp   %p3.b %x5 -> %x5",
+        "decp   %p6.b %x10 -> %x10",  "decp   %p9.b %x15 -> %x15",
+        "decp   %p11.b %x20 -> %x20", "decp   %p15.b %x30 -> %x30",
+    };
+    TEST_LOOP(decp, decp_sve, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "decp   %p0.h %x0 -> %x0",    "decp   %p3.h %x5 -> %x5",
+        "decp   %p6.h %x10 -> %x10",  "decp   %p9.h %x15 -> %x15",
+        "decp   %p11.h %x20 -> %x20", "decp   %p15.h %x30 -> %x30",
+    };
+    TEST_LOOP(decp, decp_sve, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "decp   %p0.s %x0 -> %x0",    "decp   %p3.s %x5 -> %x5",
+        "decp   %p6.s %x10 -> %x10",  "decp   %p9.s %x15 -> %x15",
+        "decp   %p11.s %x20 -> %x20", "decp   %p15.s %x30 -> %x30",
+    };
+    TEST_LOOP(decp, decp_sve, 6, expected_0_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "decp   %p0.d %x0 -> %x0",    "decp   %p3.d %x5 -> %x5",
+        "decp   %p6.d %x10 -> %x10",  "decp   %p9.d %x15 -> %x15",
+        "decp   %p11.d %x20 -> %x20", "decp   %p15.d %x30 -> %x30",
+    };
+    TEST_LOOP(decp, decp_sve, 6, expected_0_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(decp_sve_vector)
+{
+
+    /* Testing DECP    <Zdn>.<Ts>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "decp   %p0.h %z0.h -> %z0.h",    "decp   %p3.h %z5.h -> %z5.h",
+        "decp   %p6.h %z10.h -> %z10.h",  "decp   %p9.h %z16.h -> %z16.h",
+        "decp   %p11.h %z21.h -> %z21.h", "decp   %p15.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(decp, decp_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_1[6] = {
+        "decp   %p0.s %z0.s -> %z0.s",    "decp   %p3.s %z5.s -> %z5.s",
+        "decp   %p6.s %z10.s -> %z10.s",  "decp   %p9.s %z16.s -> %z16.s",
+        "decp   %p11.s %z21.s -> %z21.s", "decp   %p15.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(decp, decp_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_2[6] = {
+        "decp   %p0.d %z0.d -> %z0.d",    "decp   %p3.d %z5.d -> %z5.d",
+        "decp   %p6.d %z10.d -> %z10.d",  "decp   %p9.d %z16.d -> %z16.d",
+        "decp   %p11.d %z21.d -> %z21.d", "decp   %p15.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(decp, decp_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(incp_sve)
+{
+
+    /* Testing INCP    <Xdn>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "incp   %p0.b %x0 -> %x0",    "incp   %p3.b %x5 -> %x5",
+        "incp   %p6.b %x10 -> %x10",  "incp   %p9.b %x15 -> %x15",
+        "incp   %p11.b %x20 -> %x20", "incp   %p15.b %x30 -> %x30",
+    };
+    TEST_LOOP(incp, incp_sve, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "incp   %p0.h %x0 -> %x0",    "incp   %p3.h %x5 -> %x5",
+        "incp   %p6.h %x10 -> %x10",  "incp   %p9.h %x15 -> %x15",
+        "incp   %p11.h %x20 -> %x20", "incp   %p15.h %x30 -> %x30",
+    };
+    TEST_LOOP(incp, incp_sve, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "incp   %p0.s %x0 -> %x0",    "incp   %p3.s %x5 -> %x5",
+        "incp   %p6.s %x10 -> %x10",  "incp   %p9.s %x15 -> %x15",
+        "incp   %p11.s %x20 -> %x20", "incp   %p15.s %x30 -> %x30",
+    };
+    TEST_LOOP(incp, incp_sve, 6, expected_0_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "incp   %p0.d %x0 -> %x0",    "incp   %p3.d %x5 -> %x5",
+        "incp   %p6.d %x10 -> %x10",  "incp   %p9.d %x15 -> %x15",
+        "incp   %p11.d %x20 -> %x20", "incp   %p15.d %x30 -> %x30",
+    };
+    TEST_LOOP(incp, incp_sve, 6, expected_0_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(incp_sve_vector)
+{
+
+    /* Testing INCP    <Zdn>.<Ts>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "incp   %p0.h %z0.h -> %z0.h",    "incp   %p3.h %z5.h -> %z5.h",
+        "incp   %p6.h %z10.h -> %z10.h",  "incp   %p9.h %z16.h -> %z16.h",
+        "incp   %p11.h %z21.h -> %z21.h", "incp   %p15.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(incp, incp_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_1[6] = {
+        "incp   %p0.s %z0.s -> %z0.s",    "incp   %p3.s %z5.s -> %z5.s",
+        "incp   %p6.s %z10.s -> %z10.s",  "incp   %p9.s %z16.s -> %z16.s",
+        "incp   %p11.s %z21.s -> %z21.s", "incp   %p15.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(incp, incp_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_2[6] = {
+        "incp   %p0.d %z0.d -> %z0.d",    "incp   %p3.d %z5.d -> %z5.d",
+        "incp   %p6.d %z10.d -> %z10.d",  "incp   %p9.d %z16.d -> %z16.d",
+        "incp   %p11.d %z21.d -> %z21.d", "incp   %p15.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(incp, incp_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(sqdecp_sve)
+{
+
+    /* Testing SQDECP  <Xdn>, <Pm>.<Ts>, <Wdn> */
+    const char *expected_0_0[6] = {
+        "sqdecp %p0.b %w0 -> %x0",    "sqdecp %p3.b %w5 -> %x5",
+        "sqdecp %p6.b %w10 -> %x10",  "sqdecp %p9.b %w15 -> %x15",
+        "sqdecp %p11.b %w20 -> %x20", "sqdecp %p15.b %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_0[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "sqdecp %p0.h %w0 -> %x0",    "sqdecp %p3.h %w5 -> %x5",
+        "sqdecp %p6.h %w10 -> %x10",  "sqdecp %p9.h %w15 -> %x15",
+        "sqdecp %p11.h %w20 -> %x20", "sqdecp %p15.h %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_1[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "sqdecp %p0.s %w0 -> %x0",    "sqdecp %p3.s %w5 -> %x5",
+        "sqdecp %p6.s %w10 -> %x10",  "sqdecp %p9.s %w15 -> %x15",
+        "sqdecp %p11.s %w20 -> %x20", "sqdecp %p15.s %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_2[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "sqdecp %p0.d %w0 -> %x0",    "sqdecp %p3.d %w5 -> %x5",
+        "sqdecp %p6.d %w10 -> %x10",  "sqdecp %p9.d %w15 -> %x15",
+        "sqdecp %p11.d %w20 -> %x20", "sqdecp %p15.d %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_3[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+
+    /* Testing SQDECP  <Xdn>, <Pm>.<Ts> */
+    const char *expected_1_0[6] = {
+        "sqdecp %p0.b %x0 -> %x0",    "sqdecp %p3.b %x5 -> %x5",
+        "sqdecp %p6.b %x10 -> %x10",  "sqdecp %p9.b %x15 -> %x15",
+        "sqdecp %p11.b %x20 -> %x20", "sqdecp %p15.b %x30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_1_1[6] = {
+        "sqdecp %p0.h %x0 -> %x0",    "sqdecp %p3.h %x5 -> %x5",
+        "sqdecp %p6.h %x10 -> %x10",  "sqdecp %p9.h %x15 -> %x15",
+        "sqdecp %p11.h %x20 -> %x20", "sqdecp %p15.h %x30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_1_2[6] = {
+        "sqdecp %p0.s %x0 -> %x0",    "sqdecp %p3.s %x5 -> %x5",
+        "sqdecp %p6.s %x10 -> %x10",  "sqdecp %p9.s %x15 -> %x15",
+        "sqdecp %p11.s %x20 -> %x20", "sqdecp %p15.s %x30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_1_3[6] = {
+        "sqdecp %p0.d %x0 -> %x0",    "sqdecp %p3.d %x5 -> %x5",
+        "sqdecp %p6.d %x10 -> %x10",  "sqdecp %p9.d %x15 -> %x15",
+        "sqdecp %p11.d %x20 -> %x20", "sqdecp %p15.d %x30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(sqdecp_sve_vector)
+{
+
+    /* Testing SQDECP  <Zdn>.<Ts>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "sqdecp %p0.h %z0.h -> %z0.h",    "sqdecp %p3.h %z5.h -> %z5.h",
+        "sqdecp %p6.h %z10.h -> %z10.h",  "sqdecp %p9.h %z16.h -> %z16.h",
+        "sqdecp %p11.h %z21.h -> %z21.h", "sqdecp %p15.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_1[6] = {
+        "sqdecp %p0.s %z0.s -> %z0.s",    "sqdecp %p3.s %z5.s -> %z5.s",
+        "sqdecp %p6.s %z10.s -> %z10.s",  "sqdecp %p9.s %z16.s -> %z16.s",
+        "sqdecp %p11.s %z21.s -> %z21.s", "sqdecp %p15.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_2[6] = {
+        "sqdecp %p0.d %z0.d -> %z0.d",    "sqdecp %p3.d %z5.d -> %z5.d",
+        "sqdecp %p6.d %z10.d -> %z10.d",  "sqdecp %p9.d %z16.d -> %z16.d",
+        "sqdecp %p11.d %z21.d -> %z21.d", "sqdecp %p15.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(sqincp_sve)
+{
+
+    /* Testing SQINCP  <Xdn>, <Pm>.<Ts>, <Wdn> */
+    const char *expected_0_0[6] = {
+        "sqincp %p0.b %w0 -> %x0",    "sqincp %p3.b %w5 -> %x5",
+        "sqincp %p6.b %w10 -> %x10",  "sqincp %p9.b %w15 -> %x15",
+        "sqincp %p11.b %w20 -> %x20", "sqincp %p15.b %w30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve_wide, 6, expected_0_0[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "sqincp %p0.h %w0 -> %x0",    "sqincp %p3.h %w5 -> %x5",
+        "sqincp %p6.h %w10 -> %x10",  "sqincp %p9.h %w15 -> %x15",
+        "sqincp %p11.h %w20 -> %x20", "sqincp %p15.h %w30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve_wide, 6, expected_0_1[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "sqincp %p0.s %w0 -> %x0",    "sqincp %p3.s %w5 -> %x5",
+        "sqincp %p6.s %w10 -> %x10",  "sqincp %p9.s %w15 -> %x15",
+        "sqincp %p11.s %w20 -> %x20", "sqincp %p15.s %w30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve_wide, 6, expected_0_2[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "sqincp %p0.d %w0 -> %x0",    "sqincp %p3.d %w5 -> %x5",
+        "sqincp %p6.d %w10 -> %x10",  "sqincp %p9.d %w15 -> %x15",
+        "sqincp %p11.d %w20 -> %x20", "sqincp %p15.d %w30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve_wide, 6, expected_0_3[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+
+    /* Testing SQINCP  <Xdn>, <Pm>.<Ts> */
+    const char *expected_1_0[6] = {
+        "sqincp %p0.b %x0 -> %x0",    "sqincp %p3.b %x5 -> %x5",
+        "sqincp %p6.b %x10 -> %x10",  "sqincp %p9.b %x15 -> %x15",
+        "sqincp %p11.b %x20 -> %x20", "sqincp %p15.b %x30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_1_1[6] = {
+        "sqincp %p0.h %x0 -> %x0",    "sqincp %p3.h %x5 -> %x5",
+        "sqincp %p6.h %x10 -> %x10",  "sqincp %p9.h %x15 -> %x15",
+        "sqincp %p11.h %x20 -> %x20", "sqincp %p15.h %x30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_1_2[6] = {
+        "sqincp %p0.s %x0 -> %x0",    "sqincp %p3.s %x5 -> %x5",
+        "sqincp %p6.s %x10 -> %x10",  "sqincp %p9.s %x15 -> %x15",
+        "sqincp %p11.s %x20 -> %x20", "sqincp %p15.s %x30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_1_3[6] = {
+        "sqincp %p0.d %x0 -> %x0",    "sqincp %p3.d %x5 -> %x5",
+        "sqincp %p6.d %x10 -> %x10",  "sqincp %p9.d %x15 -> %x15",
+        "sqincp %p11.d %x20 -> %x20", "sqincp %p15.d %x30 -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(sqincp_sve_vector)
+{
+
+    /* Testing SQINCP  <Zdn>.<Ts>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "sqincp %p0.h %z0.h -> %z0.h",    "sqincp %p3.h %z5.h -> %z5.h",
+        "sqincp %p6.h %z10.h -> %z10.h",  "sqincp %p9.h %z16.h -> %z16.h",
+        "sqincp %p11.h %z21.h -> %z21.h", "sqincp %p15.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_1[6] = {
+        "sqincp %p0.s %z0.s -> %z0.s",    "sqincp %p3.s %z5.s -> %z5.s",
+        "sqincp %p6.s %z10.s -> %z10.s",  "sqincp %p9.s %z16.s -> %z16.s",
+        "sqincp %p11.s %z21.s -> %z21.s", "sqincp %p15.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_2[6] = {
+        "sqincp %p0.d %z0.d -> %z0.d",    "sqincp %p3.d %z5.d -> %z5.d",
+        "sqincp %p6.d %z10.d -> %z10.d",  "sqincp %p9.d %z16.d -> %z16.d",
+        "sqincp %p11.d %z21.d -> %z21.d", "sqincp %p15.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(uqdecp_sve)
+{
+
+    /* Testing UQDECP  <Wdn>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "uqdecp %p0.b %w0 -> %w0",    "uqdecp %p3.b %w5 -> %w5",
+        "uqdecp %p6.b %w10 -> %w10",  "uqdecp %p9.b %w15 -> %w15",
+        "uqdecp %p11.b %w20 -> %w20", "uqdecp %p15.b %w30 -> %w30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_0[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "uqdecp %p0.h %w0 -> %w0",    "uqdecp %p3.h %w5 -> %w5",
+        "uqdecp %p6.h %w10 -> %w10",  "uqdecp %p9.h %w15 -> %w15",
+        "uqdecp %p11.h %w20 -> %w20", "uqdecp %p15.h %w30 -> %w30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_1[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "uqdecp %p0.s %w0 -> %w0",    "uqdecp %p3.s %w5 -> %w5",
+        "uqdecp %p6.s %w10 -> %w10",  "uqdecp %p9.s %w15 -> %w15",
+        "uqdecp %p11.s %w20 -> %w20", "uqdecp %p15.s %w30 -> %w30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_2[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "uqdecp %p0.d %w0 -> %w0",    "uqdecp %p3.d %w5 -> %w5",
+        "uqdecp %p6.d %w10 -> %w10",  "uqdecp %p9.d %w15 -> %w15",
+        "uqdecp %p11.d %w20 -> %w20", "uqdecp %p15.d %w30 -> %w30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_3[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+
+    /* Testing UQDECP  <Xdn>, <Pm>.<Ts> */
+    const char *expected_1_0[6] = {
+        "uqdecp %p0.b %x0 -> %x0",    "uqdecp %p3.b %x5 -> %x5",
+        "uqdecp %p6.b %x10 -> %x10",  "uqdecp %p9.b %x15 -> %x15",
+        "uqdecp %p11.b %x20 -> %x20", "uqdecp %p15.b %x30 -> %x30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_1_1[6] = {
+        "uqdecp %p0.h %x0 -> %x0",    "uqdecp %p3.h %x5 -> %x5",
+        "uqdecp %p6.h %x10 -> %x10",  "uqdecp %p9.h %x15 -> %x15",
+        "uqdecp %p11.h %x20 -> %x20", "uqdecp %p15.h %x30 -> %x30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_1_2[6] = {
+        "uqdecp %p0.s %x0 -> %x0",    "uqdecp %p3.s %x5 -> %x5",
+        "uqdecp %p6.s %x10 -> %x10",  "uqdecp %p9.s %x15 -> %x15",
+        "uqdecp %p11.s %x20 -> %x20", "uqdecp %p15.s %x30 -> %x30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_1_3[6] = {
+        "uqdecp %p0.d %x0 -> %x0",    "uqdecp %p3.d %x5 -> %x5",
+        "uqdecp %p6.d %x10 -> %x10",  "uqdecp %p9.d %x15 -> %x15",
+        "uqdecp %p11.d %x20 -> %x20", "uqdecp %p15.d %x30 -> %x30",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(uqdecp_sve_vector)
+{
+
+    /* Testing UQDECP  <Zdn>.<Ts>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "uqdecp %p0.h %z0.h -> %z0.h",    "uqdecp %p3.h %z5.h -> %z5.h",
+        "uqdecp %p6.h %z10.h -> %z10.h",  "uqdecp %p9.h %z16.h -> %z16.h",
+        "uqdecp %p11.h %z21.h -> %z21.h", "uqdecp %p15.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_1[6] = {
+        "uqdecp %p0.s %z0.s -> %z0.s",    "uqdecp %p3.s %z5.s -> %z5.s",
+        "uqdecp %p6.s %z10.s -> %z10.s",  "uqdecp %p9.s %z16.s -> %z16.s",
+        "uqdecp %p11.s %z21.s -> %z21.s", "uqdecp %p15.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_2[6] = {
+        "uqdecp %p0.d %z0.d -> %z0.d",    "uqdecp %p3.d %z5.d -> %z5.d",
+        "uqdecp %p6.d %z10.d -> %z10.d",  "uqdecp %p9.d %z16.d -> %z16.d",
+        "uqdecp %p11.d %z21.d -> %z21.d", "uqdecp %p15.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(uqincp_sve)
+{
+
+    /* Testing UQINCP  <Wdn>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "uqincp %p0.b %w0 -> %w0",    "uqincp %p3.b %w5 -> %w5",
+        "uqincp %p6.b %w10 -> %w10",  "uqincp %p9.b %w15 -> %w15",
+        "uqincp %p11.b %w20 -> %w20", "uqincp %p15.b %w30 -> %w30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_0[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "uqincp %p0.h %w0 -> %w0",    "uqincp %p3.h %w5 -> %w5",
+        "uqincp %p6.h %w10 -> %w10",  "uqincp %p9.h %w15 -> %w15",
+        "uqincp %p11.h %w20 -> %w20", "uqincp %p15.h %w30 -> %w30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_1[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "uqincp %p0.s %w0 -> %w0",    "uqincp %p3.s %w5 -> %w5",
+        "uqincp %p6.s %w10 -> %w10",  "uqincp %p9.s %w15 -> %w15",
+        "uqincp %p11.s %w20 -> %w20", "uqincp %p15.s %w30 -> %w30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_2[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "uqincp %p0.d %w0 -> %w0",    "uqincp %p3.d %w5 -> %w5",
+        "uqincp %p6.d %w10 -> %w10",  "uqincp %p9.d %w15 -> %w15",
+        "uqincp %p11.d %w20 -> %w20", "uqincp %p15.d %w30 -> %w30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_3[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+
+    /* Testing UQINCP  <Xdn>, <Pm>.<Ts> */
+    const char *expected_1_0[6] = {
+        "uqincp %p0.b %x0 -> %x0",    "uqincp %p3.b %x5 -> %x5",
+        "uqincp %p6.b %x10 -> %x10",  "uqincp %p9.b %x15 -> %x15",
+        "uqincp %p11.b %x20 -> %x20", "uqincp %p15.b %x30 -> %x30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *expected_1_1[6] = {
+        "uqincp %p0.h %x0 -> %x0",    "uqincp %p3.h %x5 -> %x5",
+        "uqincp %p6.h %x10 -> %x10",  "uqincp %p9.h %x15 -> %x15",
+        "uqincp %p11.h %x20 -> %x20", "uqincp %p15.h %x30 -> %x30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_1_2[6] = {
+        "uqincp %p0.s %x0 -> %x0",    "uqincp %p3.s %x5 -> %x5",
+        "uqincp %p6.s %x10 -> %x10",  "uqincp %p9.s %x15 -> %x15",
+        "uqincp %p11.s %x20 -> %x20", "uqincp %p15.s %x30 -> %x30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_1_3[6] = {
+        "uqincp %p0.d %x0 -> %x0",    "uqincp %p3.d %x5 -> %x5",
+        "uqincp %p6.d %x10 -> %x10",  "uqincp %p9.d %x15 -> %x15",
+        "uqincp %p11.d %x20 -> %x20", "uqincp %p15.d %x30 -> %x30",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(uqincp_sve_vector)
+{
+
+    /* Testing UQINCP  <Zdn>.<Ts>, <Pm>.<Ts> */
+    const char *expected_0_0[6] = {
+        "uqincp %p0.h %z0.h -> %z0.h",    "uqincp %p3.h %z5.h -> %z5.h",
+        "uqincp %p6.h %z10.h -> %z10.h",  "uqincp %p9.h %z16.h -> %z16.h",
+        "uqincp %p11.h %z21.h -> %z21.h", "uqincp %p15.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *expected_0_1[6] = {
+        "uqincp %p0.s %z0.s -> %z0.s",    "uqincp %p3.s %z5.s -> %z5.s",
+        "uqincp %p6.s %z10.s -> %z10.s",  "uqincp %p9.s %z16.s -> %z16.s",
+        "uqincp %p11.s %z21.s -> %z21.s", "uqincp %p15.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *expected_0_2[6] = {
+        "uqincp %p0.d %z0.d -> %z0.d",    "uqincp %p3.d %z5.d -> %z5.d",
+        "uqincp %p6.d %z10.d -> %z10.d",  "uqincp %p9.d %z16.d -> %z16.d",
+        "uqincp %p11.d %z21.d -> %z21.d", "uqincp %p15.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
 int
 main(int argc, char *argv[])
 {
@@ -4291,6 +4885,20 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(rdffrs_sve_pred);
     RUN_INSTR_TEST(setffr_sve);
     RUN_INSTR_TEST(wrffr_sve);
+
+    RUN_INSTR_TEST(cntp_sve_pred);
+    RUN_INSTR_TEST(decp_sve);
+    RUN_INSTR_TEST(decp_sve);
+    RUN_INSTR_TEST(incp_sve);
+    RUN_INSTR_TEST(incp_sve);
+    RUN_INSTR_TEST(sqdecp_sve);
+    RUN_INSTR_TEST(sqdecp_sve);
+    RUN_INSTR_TEST(sqincp_sve);
+    RUN_INSTR_TEST(sqincp_sve);
+    RUN_INSTR_TEST(uqdecp_sve);
+    RUN_INSTR_TEST(uqdecp_sve);
+    RUN_INSTR_TEST(uqincp_sve);
+    RUN_INSTR_TEST(uqincp_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
CNTP    <Xd>, <Pg>, <Pn>.<Ts>
DECP    <Xdn>, <Pm>.<Ts>
DECP    <Zdn>.<Ts>, <Pm>.<Ts>
INCP    <Xdn>, <Pm>.<Ts>
INCP    <Zdn>.<Ts>, <Pm>.<Ts>
SQDECP  <Xdn>, <Pm>.<Ts>, <Wdn>
SQDECP  <Xdn>, <Pm>.<Ts>
SQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
SQINCP  <Xdn>, <Pm>.<Ts>, <Wdn>
SQINCP  <Xdn>, <Pm>.<Ts>
SQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
UQDECP  <Wdn>, <Pm>.<Ts>
UQDECP  <Xdn>, <Pm>.<Ts>
UQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
UQINCP  <Wdn>, <Pm>.<Ts>
UQINCP  <Xdn>, <Pm>.<Ts>
UQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
```

issues: #3044
