### PR TITLE
i#3044 AArch64 SVE codec: add AND, BIC, EOR, ORN, ORR (imm)

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -707,9 +707,10 @@ extract_imm13_size(uint enc)
     /* For the remaining, invert the value and find the index of the highest high bit
      */
     int index;
-    if (!highest_bit_set(~value, 0, 6, &index))
+    if (!highest_bit_set(~value, 0, 6, &index)) {
         /* Reserved */
         return NOT_A_REG;
+    }
 
     switch (index) {
     case 5: return SINGLE_REG;

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -201,9 +201,9 @@ static inline bool
 try_encode_int(OUT uint *bits, int len, int scale, ptr_int_t val)
 {
     /* If any of lowest 'scale' bits are set, or 'val' is out of range, fail. */
-    if (((ptr_uint_t)val & ((1U << scale) - 1)) != 0 ||
-        val < -((ptr_int_t)1 << (len + scale - 1)) ||
-        val >= (ptr_int_t)1 << (len + scale - 1))
+    const ptr_int_t range_val = ((ptr_int_t)1 << (len + scale)) - 1;
+    if (((ptr_uint_t)val & ((1U << scale) - 1)) != 0 || val < -range_val ||
+        val >= range_val)
         return false;
     *bits = (ptr_uint_t)val >> scale & ((1U << len) - 1);
     return true;
@@ -691,6 +691,36 @@ multistruct_regcount(uint enc)
     }
     ASSERT(false);
     return 0;
+}
+
+/* Extracts the size from an imm13 field.  Returns NOT_A_REG if the read value is invalid.
+ */
+static aarch64_reg_offset
+extract_imm13_size(uint enc)
+{
+    const ptr_uint_t value = extract_uint(enc, 5, 13);
+
+    /* Bit 12 is high iff type is a double */
+    if (TEST(1 << 12, value))
+        return DOUBLE_REG;
+
+    /* For the remaining, invert the value and find the index of the highest high bit
+     */
+    int index;
+    if (!highest_bit_set(~value, 0, 6, &index))
+        /* Reserved */
+        return NOT_A_REG;
+
+    switch (index) {
+    case 5: return SINGLE_REG;
+    case 4: return HALF_REG;
+    case 3:
+    case 2:
+    case 1: return BYTE_REG;
+    default:
+        /* Reserved */
+        return NOT_A_REG;
+    }
 }
 
 /*******************************************************************************
@@ -2607,6 +2637,87 @@ encode_opnd_imm16_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_o
     uint enc_value;
     encode_opnd_int(0, 16, false, false, 0, opnd, &enc_value);
     *enc_out = enc_value;
+    return true;
+}
+
+/* z_imm13_bhsd_0: sve vector reg, elsz depending on size value encoded within an 13 bit
+ * immediate from 5-17 */
+static inline bool
+decode_opnd_z_imm13_bhsd_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_Z0, 0, 5, extract_imm13_size(enc), enc, opnd);
+}
+
+static inline bool
+encode_opnd_z_imm13_bhsd_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_single_sized(OPSZ_SCALABLE, 0, extract_imm13_size(enc), opnd, enc_out);
+}
+
+/* imm13_const: Const value within an 13 bit immediate from 5-17 */
+static inline bool
+decode_opnd_imm13_const(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    const ptr_uint_t imm_enc = extract_uint(enc, 5, 13);
+    ptr_uint_t imm_val = decode_bitmask(imm_enc);
+    if (imm_val == 0)
+        return false;
+
+    /* The const field is always 64 bits, consisting of a repeating register-wide
+     * subfields. However this is not the value the compiler has written, so chop off the
+     * excess.
+     */
+    opnd_size_t opnd_size;
+    switch (extract_imm13_size(enc)) {
+    case BYTE_REG:
+        opnd_size = OPSZ_1;
+        imm_val = BITS(imm_val, 7, 0);
+        break;
+    case HALF_REG:
+        opnd_size = OPSZ_2;
+        imm_val = BITS(imm_val, 15, 0);
+        break;
+    case SINGLE_REG:
+        opnd_size = OPSZ_4;
+        imm_val = BITS(imm_val, 31, 0);
+        break;
+    case DOUBLE_REG: opnd_size = OPSZ_8; break;
+    default: return false;
+    }
+
+    *opnd = opnd_create_immed_int(imm_val, opnd_size);
+    return true;
+}
+
+static inline bool
+encode_opnd_imm13_const(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+    ptr_uint_t imm_val = opnd_get_immed_int(opnd);
+
+    /* The encoding process expects repeating register-wide subfields in the bitmask
+     * encoding input, so we need to add in the repeating subfields we removed in the
+     * decoder.
+     */
+    const int width = opnd_size_in_bits(opnd_get_size(opnd));
+    if (width == 0)
+        return false;
+
+    if (width != 64) {
+        const ptr_uint_t subfield = imm_val & (((ptr_uint_t)1 << width) - 1);
+        for (int i = 0; i < 64; i += width) {
+            imm_val <<= width;
+            imm_val |= subfield;
+        }
+    }
+
+    uint imm_enc;
+    if (!try_encode_int(&imm_enc, 13, 0, encode_bitmask(imm_val)))
+        return false;
+
+    *enc_out = (ptr_uint_t)imm_enc << 5;
     return true;
 }
 

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -45,6 +45,7 @@
 00000100xx000000000xxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10000011xxxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx011010000xxxxxxxxxxxxx  n   21   SVE      and             z0 : p10_lo z0 z5 bhsd_sz
+00000101100000xxxxxxxxxxxxxxxxxx  n   21   SVE      and z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 00000100xx011011000xxxxxxxxxxxxx  n   29   SVE      bic             z0 : p10_lo z0 z5 bhsd_sz
 00100101xx0xxxxx100xxxxxxxx0xxxx  w   807  SVE    cmpeq  p_size_bhsd_0 : p10_zer_lo z_size_bhsd_5 simm5
 00100100xx0xxxxx001xxxxxxxx0xxxx  w   807  SVE    cmpeq   p_size_bhs_0 : p10_zer_lo z_size_bhs_5 z_d_16
@@ -79,6 +80,7 @@
 00100101xx1011011000100xxxxxxxxx  n   822  SVE     decp             x0 : p_size_bhsd_5 x0
 00100101xx1011011000000xxxxxxxxx  n   822  SVE     decp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor             z0 : p10_lo z0 z5 bhsd_sz
+00000101010000xxxxxxxxxxxxxxxxxx  n   90   SVE      eor z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 01100101xx0xxxxx110xxxxxxxx1xxxx  n   96   SVE    facge   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx0xxxxx111xxxxxxxx1xxxx  n   97   SVE    facgt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx010010001xxxxxxxx0xxxx  n   102  SVE    fcmeq   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
@@ -107,6 +109,7 @@
 00100101xx110000110xxxxxxxxxxxxx  n   321  SVE      mul  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
 00000100xx010111101xxxxxxxxxxxxx  n   323  SVE      neg  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
 00000100xx011000000xxxxxxxxxxxxx  n   327  SVE      orr             z0 : p10_lo z0 z5 bhsd_sz
+00000101000000xxxxxxxxxxxxxxxxxx  n   327  SVE      orr z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010101000011xxxx0xxxx00000  w   786  SVE    ptest                : p10 p_b_5
 0010010100011001111100000000xxxx  n   817  SVE    rdffr          p_b_0 :
 00100101000110001111000xxxx0xxxx  n   817  SVE    rdffr          p_b_0 : p5_zer

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -6643,4 +6643,75 @@
  */
 #define INSTR_CREATE_uqincp_sve_vector(dc, Zdn, Pm) \
     instr_create_1dst_2src(dc, OP_uqincp, Zdn, Pm, Zdn)
+
+/**
+ * Creates an AND instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AND     <Zdn>.<T>, <Zdn>.<T>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param imm   The immediate logicalImm
+ */
+#define INSTR_CREATE_and_sve_imm(dc, Zdn, imm) \
+    instr_create_1dst_2src(dc, OP_and, Zdn, Zdn, imm)
+
+/**
+ * Creates a BIC instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BIC     <Zdn>.<T>, <Zdn>.<T>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param imm   The immediate logicalImm
+ */
+#define INSTR_CREATE_bic_sve_imm(dc, Zdn, imm) \
+    instr_create_1dst_2src(dc, OP_and, Zdn, Zdn, opnd_invert_immed_int(imm))
+
+/**
+ * Creates an EOR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EOR     <Zdn>.<T>, <Zdn>.<T>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param imm   The immediate logicalImm
+ */
+#define INSTR_CREATE_eor_sve_imm(dc, Zdn, imm) \
+    instr_create_1dst_2src(dc, OP_eor, Zdn, Zdn, imm)
+
+/**
+ * Creates an ORR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORR     <Zdn>.<T>, <Zdn>.<T>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param imm   The immediate logicalImm
+ */
+#define INSTR_CREATE_orr_sve_imm(dc, Zdn, imm) \
+    instr_create_1dst_2src(dc, OP_orr, Zdn, Zdn, imm)
+
+/**
+ * Creates an ORN instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORN     <Zdn>.<T>, <Zdn>.<T>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param imm   The immediate logicalImm
+ */
+#define INSTR_CREATE_orn_sve_imm(dc, Zdn, imm) \
+    instr_create_1dst_2src(dc, OP_orr, Zdn, Zdn, opnd_invert_immed_int(imm))
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -137,6 +137,8 @@
 ----------------xxxx------------  cond       # condition for CCMN, CCMP
 ----------------xxxxxx----------  scale      # encoding of #fbits value in scale field
 ----------------xxxxxxxxxxxxxxxx  imm16_0    # imm16 at position 0
+--------------?------??????xxxxx  z_imm13_bhsd_0 # sve vector reg, elsz depending on size value encoded within an 13 bit immediate from 5-17
+--------------xxxxxxxxxxxxx-----  imm13_const # Const value within a 13 bit immediate from 5-17
 -------------xxx----------------  imm3       # 3 bit immediate from 16-18
 -------------xxx--------xxx-----  pstate     # Pstate encoded in op1:op2
 -------------xxx------xxxxx-----  fpimm8     # floating-point immediate for vector fmov

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1937,6 +1937,14 @@ opnd_create_immed_int64(int64 i, opnd_size_t data_size);
 
 DR_API
 /**
+ * Performs a bitwise NOT operation on the integer value in \p opnd, but only on the LSB
+ * bits provided by opnd_size_in_bits(opnd). \p opnd must carry an immed integer.
+ */
+opnd_t
+opnd_invert_immed_int(opnd_t opnd);
+
+DR_API
+/**
  * Returns an immediate float operand with value \p f.
  * The caller's code should use proc_save_fpstate() or be inside a
  * clean call that has requested to preserve the floating-point state.

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -384,6 +384,24 @@ opnd_create_immed_int64(int64 i, opnd_size_t size)
     return opnd;
 }
 
+opnd_t
+opnd_invert_immed_int(opnd_t opnd)
+{
+    CLIENT_ASSERT(opnd.kind == IMMED_INTEGER_kind, "opnd_invert_immed_int: invalid kind");
+
+    const int bit_size = opnd_size_in_bits(opnd.size);
+    const uint64 mask =
+        (bit_size < 64) ? ((uint64)1 << opnd_size_in_bits(opnd.size)) - 1 : ~((uint64)0);
+    if (opnd.aux.flags & DR_OPND_MULTI_PART) {
+        opnd.value.immed_int_multi_part.low &= mask;
+        opnd.value.immed_int_multi_part.high &= mask >> 32;
+    } else {
+        opnd.value.immed_int = ~opnd.value.immed_int & mask;
+    }
+
+    return opnd;
+}
+
 bool
 opnd_is_immed_int64(opnd_t opnd)
 {

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -318,6 +318,68 @@
 049a06ff : and z31.s, p1/m, z31.s, z23.s            : and    %p1 %z31 %z23 $0x02 -> %z31
 04da06ff : and z31.d, p1/m, z31.d, z23.d            : and    %p1 %z31 %z23 $0x03 -> %z31
 
+# AND   <Zdn>.<T>, <Zdn>.<T>, #<const> (AND-Z.ZI-_)
+058006a0 : and z0.b, z0.b, #0x3f                    : and    %z0.b $0x3f -> %z0.b
+05800604 : and z4.b, z4.b, #0x01                    : and    %z4.b $0x01 -> %z4.b
+05803e06 : and z6.b, z6.b, #0x02                    : and    %z6.b $0x02 -> %z6.b
+05803608 : and z8.b, z8.b, #0x04                    : and    %z8.b $0x04 -> %z8.b
+05802e0a : and z10.b, z10.b, #0x08                  : and    %z10.b $0x08 -> %z10.b
+0580260c : and z12.b, z12.b, #0x10                  : and    %z12.b $0x10 -> %z12.b
+05801e0e : and z14.b, z14.b, #0x20                  : and    %z14.b $0x20 -> %z14.b
+05800630 : and z16.b, z16.b, #0x03                  : and    %z16.b $0x03 -> %z16.b
+05800652 : and z18.b, z18.b, #0x07                  : and    %z18.b $0x07 -> %z18.b
+05800674 : and z20.b, z20.b, #0x0f                  : and    %z20.b $0x0f -> %z20.b
+05800696 : and z22.b, z22.b, #0x1f                  : and    %z22.b $0x1f -> %z22.b
+05803e98 : and z24.b, z24.b, #0x3e                  : and    %z24.b $0x3e -> %z24.b
+0580367a : and z26.b, z26.b, #0x3c                  : and    %z26.b $0x3c -> %z26.b
+05802e5c : and z28.b, z28.b, #0x38                  : and    %z28.b $0x38 -> %z28.b
+0580263f : and z31.b, z31.b, #0x30                  : and    %z31.b $0x30 -> %z31.b
+058004a0 : and z0.h, z0.h, #0x3f                    : and    %z0.h $0x003f -> %z0.h
+05800404 : and z4.h, z4.h, #0x01                    : and    %z4.h $0x0001 -> %z4.h
+05807c06 : and z6.h, z6.h, #0x02                    : and    %z6.h $0x0002 -> %z6.h
+05807408 : and z8.h, z8.h, #0x04                    : and    %z8.h $0x0004 -> %z8.h
+05806c0a : and z10.h, z10.h, #0x08                  : and    %z10.h $0x0008 -> %z10.h
+0580640c : and z12.h, z12.h, #0x10                  : and    %z12.h $0x0010 -> %z12.h
+05805c0e : and z14.h, z14.h, #0x20                  : and    %z14.h $0x0020 -> %z14.h
+05800430 : and z16.h, z16.h, #0x03                  : and    %z16.h $0x0003 -> %z16.h
+05800452 : and z18.h, z18.h, #0x07                  : and    %z18.h $0x0007 -> %z18.h
+05800474 : and z20.h, z20.h, #0x0f                  : and    %z20.h $0x000f -> %z20.h
+05800496 : and z22.h, z22.h, #0x1f                  : and    %z22.h $0x001f -> %z22.h
+05807c98 : and z24.h, z24.h, #0x3e                  : and    %z24.h $0x003e -> %z24.h
+0580747a : and z26.h, z26.h, #0x3c                  : and    %z26.h $0x003c -> %z26.h
+05806c5c : and z28.h, z28.h, #0x38                  : and    %z28.h $0x0038 -> %z28.h
+0580643f : and z31.h, z31.h, #0x30                  : and    %z31.h $0x0030 -> %z31.h
+058000a0 : and z0.s, z0.s, #0x3f                    : and    %z0.s $0x0000003f -> %z0.s
+05800004 : and z4.s, z4.s, #0x01                    : and    %z4.s $0x00000001 -> %z4.s
+0580f806 : and z6.s, z6.s, #0x02                    : and    %z6.s $0x00000002 -> %z6.s
+0580f008 : and z8.s, z8.s, #0x04                    : and    %z8.s $0x00000004 -> %z8.s
+0580e80a : and z10.s, z10.s, #0x08                  : and    %z10.s $0x00000008 -> %z10.s
+0580e00c : and z12.s, z12.s, #0x10                  : and    %z12.s $0x00000010 -> %z12.s
+0580d80e : and z14.s, z14.s, #0x20                  : and    %z14.s $0x00000020 -> %z14.s
+05800030 : and z16.s, z16.s, #0x03                  : and    %z16.s $0x00000003 -> %z16.s
+05800052 : and z18.s, z18.s, #0x07                  : and    %z18.s $0x00000007 -> %z18.s
+05800074 : and z20.s, z20.s, #0x0f                  : and    %z20.s $0x0000000f -> %z20.s
+05800096 : and z22.s, z22.s, #0x1f                  : and    %z22.s $0x0000001f -> %z22.s
+0580f898 : and z24.s, z24.s, #0x3e                  : and    %z24.s $0x0000003e -> %z24.s
+0580f07a : and z26.s, z26.s, #0x3c                  : and    %z26.s $0x0000003c -> %z26.s
+0580e85c : and z28.s, z28.s, #0x38                  : and    %z28.s $0x00000038 -> %z28.s
+0580e03f : and z31.s, z31.s, #0x30                  : and    %z31.s $0x00000030 -> %z31.s
+058200a0 : and z0.d, z0.d, #0x3f                    : and    %z0.d $0x000000000000003f -> %z0.d
+05820004 : and z4.d, z4.d, #0x01                    : and    %z4.d $0x0000000000000001 -> %z4.d
+0583f806 : and z6.d, z6.d, #0x02                    : and    %z6.d $0x0000000000000002 -> %z6.d
+0583f008 : and z8.d, z8.d, #0x04                    : and    %z8.d $0x0000000000000004 -> %z8.d
+0583e80a : and z10.d, z10.d, #0x08                  : and    %z10.d $0x0000000000000008 -> %z10.d
+0583e00c : and z12.d, z12.d, #0x10                  : and    %z12.d $0x0000000000000010 -> %z12.d
+0583d80e : and z14.d, z14.d, #0x20                  : and    %z14.d $0x0000000000000020 -> %z14.d
+05820030 : and z16.d, z16.d, #0x03                  : and    %z16.d $0x0000000000000003 -> %z16.d
+05820052 : and z18.d, z18.d, #0x07                  : and    %z18.d $0x0000000000000007 -> %z18.d
+05820074 : and z20.d, z20.d, #0x0f                  : and    %z20.d $0x000000000000000f -> %z20.d
+05820096 : and z22.d, z22.d, #0x1f                  : and    %z22.d $0x000000000000001f -> %z22.d
+0583f898 : and z24.d, z24.d, #0x3e                  : and    %z24.d $0x000000000000003e -> %z24.d
+0583f07a : and z26.d, z26.d, #0x3c                  : and    %z26.d $0x000000000000003c -> %z26.d
+0583e85c : and z28.d, z28.d, #0x38                  : and    %z28.d $0x0000000000000038 -> %z28.d
+0583e03f : and z31.d, z31.d, #0x30                  : and    %z31.d $0x0000000000000030 -> %z31.d
+
 041b0b02 : bic z2.b, p2/m, z2.b, z24.b              : bic    %p2 %z2 %z24 $0x00 -> %z2
 045b0b02 : bic z2.h, p2/m, z2.h, z24.h              : bic    %p2 %z2 %z24 $0x01 -> %z2
 049b0b02 : bic z2.s, p2/m, z2.s, z24.s              : bic    %p2 %z2 %z24 $0x02 -> %z2
@@ -2264,6 +2326,68 @@
 0499105d : eor z29.s, p4/m, z29.s, z2.s             : eor    %p4 %z29 %z2 $0x02 -> %z29
 04d9105d : eor z29.d, p4/m, z29.d, z2.d             : eor    %p4 %z29 %z2 $0x03 -> %z29
 
+# EOR   <Zdn>.<T>, <Zdn>.<T>, #<const> (EOR-Z.ZI-_)
+054006a0 : eor z0.b, z0.b, #0x3f                    : eor    %z0.b $0x3f -> %z0.b
+05400604 : eor z4.b, z4.b, #0x01                    : eor    %z4.b $0x01 -> %z4.b
+05403e06 : eor z6.b, z6.b, #0x02                    : eor    %z6.b $0x02 -> %z6.b
+05403608 : eor z8.b, z8.b, #0x04                    : eor    %z8.b $0x04 -> %z8.b
+05402e0a : eor z10.b, z10.b, #0x08                  : eor    %z10.b $0x08 -> %z10.b
+0540260c : eor z12.b, z12.b, #0x10                  : eor    %z12.b $0x10 -> %z12.b
+05401e0e : eor z14.b, z14.b, #0x20                  : eor    %z14.b $0x20 -> %z14.b
+05400630 : eor z16.b, z16.b, #0x03                  : eor    %z16.b $0x03 -> %z16.b
+05400652 : eor z18.b, z18.b, #0x07                  : eor    %z18.b $0x07 -> %z18.b
+05400674 : eor z20.b, z20.b, #0x0f                  : eor    %z20.b $0x0f -> %z20.b
+05400696 : eor z22.b, z22.b, #0x1f                  : eor    %z22.b $0x1f -> %z22.b
+05403e98 : eor z24.b, z24.b, #0x3e                  : eor    %z24.b $0x3e -> %z24.b
+0540367a : eor z26.b, z26.b, #0x3c                  : eor    %z26.b $0x3c -> %z26.b
+05402e5c : eor z28.b, z28.b, #0x38                  : eor    %z28.b $0x38 -> %z28.b
+0540263f : eor z31.b, z31.b, #0x30                  : eor    %z31.b $0x30 -> %z31.b
+054004a0 : eor z0.h, z0.h, #0x3f                    : eor    %z0.h $0x003f -> %z0.h
+05400404 : eor z4.h, z4.h, #0x01                    : eor    %z4.h $0x0001 -> %z4.h
+05407c06 : eor z6.h, z6.h, #0x02                    : eor    %z6.h $0x0002 -> %z6.h
+05407408 : eor z8.h, z8.h, #0x04                    : eor    %z8.h $0x0004 -> %z8.h
+05406c0a : eor z10.h, z10.h, #0x08                  : eor    %z10.h $0x0008 -> %z10.h
+0540640c : eor z12.h, z12.h, #0x10                  : eor    %z12.h $0x0010 -> %z12.h
+05405c0e : eor z14.h, z14.h, #0x20                  : eor    %z14.h $0x0020 -> %z14.h
+05400430 : eor z16.h, z16.h, #0x03                  : eor    %z16.h $0x0003 -> %z16.h
+05400452 : eor z18.h, z18.h, #0x07                  : eor    %z18.h $0x0007 -> %z18.h
+05400474 : eor z20.h, z20.h, #0x0f                  : eor    %z20.h $0x000f -> %z20.h
+05400496 : eor z22.h, z22.h, #0x1f                  : eor    %z22.h $0x001f -> %z22.h
+05407c98 : eor z24.h, z24.h, #0x3e                  : eor    %z24.h $0x003e -> %z24.h
+0540747a : eor z26.h, z26.h, #0x3c                  : eor    %z26.h $0x003c -> %z26.h
+05406c5c : eor z28.h, z28.h, #0x38                  : eor    %z28.h $0x0038 -> %z28.h
+0540643f : eor z31.h, z31.h, #0x30                  : eor    %z31.h $0x0030 -> %z31.h
+054000a0 : eor z0.s, z0.s, #0x3f                    : eor    %z0.s $0x0000003f -> %z0.s
+05400004 : eor z4.s, z4.s, #0x01                    : eor    %z4.s $0x00000001 -> %z4.s
+0540f806 : eor z6.s, z6.s, #0x02                    : eor    %z6.s $0x00000002 -> %z6.s
+0540f008 : eor z8.s, z8.s, #0x04                    : eor    %z8.s $0x00000004 -> %z8.s
+0540e80a : eor z10.s, z10.s, #0x08                  : eor    %z10.s $0x00000008 -> %z10.s
+0540e00c : eor z12.s, z12.s, #0x10                  : eor    %z12.s $0x00000010 -> %z12.s
+0540d80e : eor z14.s, z14.s, #0x20                  : eor    %z14.s $0x00000020 -> %z14.s
+05400030 : eor z16.s, z16.s, #0x03                  : eor    %z16.s $0x00000003 -> %z16.s
+05400052 : eor z18.s, z18.s, #0x07                  : eor    %z18.s $0x00000007 -> %z18.s
+05400074 : eor z20.s, z20.s, #0x0f                  : eor    %z20.s $0x0000000f -> %z20.s
+05400096 : eor z22.s, z22.s, #0x1f                  : eor    %z22.s $0x0000001f -> %z22.s
+0540f898 : eor z24.s, z24.s, #0x3e                  : eor    %z24.s $0x0000003e -> %z24.s
+0540f07a : eor z26.s, z26.s, #0x3c                  : eor    %z26.s $0x0000003c -> %z26.s
+0540e85c : eor z28.s, z28.s, #0x38                  : eor    %z28.s $0x00000038 -> %z28.s
+0540e03f : eor z31.s, z31.s, #0x30                  : eor    %z31.s $0x00000030 -> %z31.s
+054200a0 : eor z0.d, z0.d, #0x3f                    : eor    %z0.d $0x000000000000003f -> %z0.d
+05420004 : eor z4.d, z4.d, #0x01                    : eor    %z4.d $0x0000000000000001 -> %z4.d
+0543f806 : eor z6.d, z6.d, #0x02                    : eor    %z6.d $0x0000000000000002 -> %z6.d
+0543f008 : eor z8.d, z8.d, #0x04                    : eor    %z8.d $0x0000000000000004 -> %z8.d
+0543e80a : eor z10.d, z10.d, #0x08                  : eor    %z10.d $0x0000000000000008 -> %z10.d
+0543e00c : eor z12.d, z12.d, #0x10                  : eor    %z12.d $0x0000000000000010 -> %z12.d
+0543d80e : eor z14.d, z14.d, #0x20                  : eor    %z14.d $0x0000000000000020 -> %z14.d
+05420030 : eor z16.d, z16.d, #0x03                  : eor    %z16.d $0x0000000000000003 -> %z16.d
+05420052 : eor z18.d, z18.d, #0x07                  : eor    %z18.d $0x0000000000000007 -> %z18.d
+05420074 : eor z20.d, z20.d, #0x0f                  : eor    %z20.d $0x000000000000000f -> %z20.d
+05420096 : eor z22.d, z22.d, #0x1f                  : eor    %z22.d $0x000000000000001f -> %z22.d
+0543f898 : eor z24.d, z24.d, #0x3e                  : eor    %z24.d $0x000000000000003e -> %z24.d
+0543f07a : eor z26.d, z26.d, #0x3c                  : eor    %z26.d $0x000000000000003c -> %z26.d
+0543e85c : eor z28.d, z28.d, #0x38                  : eor    %z28.d $0x0000000000000038 -> %z28.d
+0543e03f : eor z31.d, z31.d, #0x30                  : eor    %z31.d $0x0000000000000030 -> %z31.d
+
 # FACGE   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (FACGE-P.P.ZZ-_)
 6540c010 : facge p0.h, p0/Z, z0.h, z0.h              : facge  %p0/z %z0.h %z0.h -> %p0.h
 6545c491 : facge p1.h, p1/Z, z4.h, z5.h              : facge  %p1/z %z4.h %z5.h -> %p1.h
@@ -3714,6 +3838,68 @@
 04581da2 : orr z2.h, p7/m, z2.h, z13.h              : orr    %p7 %z2 %z13 $0x01 -> %z2
 04981da2 : orr z2.s, p7/m, z2.s, z13.s              : orr    %p7 %z2 %z13 $0x02 -> %z2
 04d81da2 : orr z2.d, p7/m, z2.d, z13.d              : orr    %p7 %z2 %z13 $0x03 -> %z2
+
+# ORR   <Zdn>.<T>, <Zdn>.<T>, #<const> (ORR-Z.ZI-_)
+050006a0 : orr z0.b, z0.b, #0x3f                    : orr    %z0.b $0x3f -> %z0.b
+05000604 : orr z4.b, z4.b, #0x01                    : orr    %z4.b $0x01 -> %z4.b
+05003e06 : orr z6.b, z6.b, #0x02                    : orr    %z6.b $0x02 -> %z6.b
+05003608 : orr z8.b, z8.b, #0x04                    : orr    %z8.b $0x04 -> %z8.b
+05002e0a : orr z10.b, z10.b, #0x08                  : orr    %z10.b $0x08 -> %z10.b
+0500260c : orr z12.b, z12.b, #0x10                  : orr    %z12.b $0x10 -> %z12.b
+05001e0e : orr z14.b, z14.b, #0x20                  : orr    %z14.b $0x20 -> %z14.b
+05000630 : orr z16.b, z16.b, #0x03                  : orr    %z16.b $0x03 -> %z16.b
+05000652 : orr z18.b, z18.b, #0x07                  : orr    %z18.b $0x07 -> %z18.b
+05000674 : orr z20.b, z20.b, #0x0f                  : orr    %z20.b $0x0f -> %z20.b
+05000696 : orr z22.b, z22.b, #0x1f                  : orr    %z22.b $0x1f -> %z22.b
+05003e98 : orr z24.b, z24.b, #0x3e                  : orr    %z24.b $0x3e -> %z24.b
+0500367a : orr z26.b, z26.b, #0x3c                  : orr    %z26.b $0x3c -> %z26.b
+05002e5c : orr z28.b, z28.b, #0x38                  : orr    %z28.b $0x38 -> %z28.b
+0500263f : orr z31.b, z31.b, #0x30                  : orr    %z31.b $0x30 -> %z31.b
+050004a0 : orr z0.h, z0.h, #0x3f                    : orr    %z0.h $0x003f -> %z0.h
+05000404 : orr z4.h, z4.h, #0x01                    : orr    %z4.h $0x0001 -> %z4.h
+05007c06 : orr z6.h, z6.h, #0x02                    : orr    %z6.h $0x0002 -> %z6.h
+05007408 : orr z8.h, z8.h, #0x04                    : orr    %z8.h $0x0004 -> %z8.h
+05006c0a : orr z10.h, z10.h, #0x08                  : orr    %z10.h $0x0008 -> %z10.h
+0500640c : orr z12.h, z12.h, #0x10                  : orr    %z12.h $0x0010 -> %z12.h
+05005c0e : orr z14.h, z14.h, #0x20                  : orr    %z14.h $0x0020 -> %z14.h
+05000430 : orr z16.h, z16.h, #0x03                  : orr    %z16.h $0x0003 -> %z16.h
+05000452 : orr z18.h, z18.h, #0x07                  : orr    %z18.h $0x0007 -> %z18.h
+05000474 : orr z20.h, z20.h, #0x0f                  : orr    %z20.h $0x000f -> %z20.h
+05000496 : orr z22.h, z22.h, #0x1f                  : orr    %z22.h $0x001f -> %z22.h
+05007c98 : orr z24.h, z24.h, #0x3e                  : orr    %z24.h $0x003e -> %z24.h
+0500747a : orr z26.h, z26.h, #0x3c                  : orr    %z26.h $0x003c -> %z26.h
+05006c5c : orr z28.h, z28.h, #0x38                  : orr    %z28.h $0x0038 -> %z28.h
+0500643f : orr z31.h, z31.h, #0x30                  : orr    %z31.h $0x0030 -> %z31.h
+050000a0 : orr z0.s, z0.s, #0x3f                    : orr    %z0.s $0x0000003f -> %z0.s
+05000004 : orr z4.s, z4.s, #0x01                    : orr    %z4.s $0x00000001 -> %z4.s
+0500f806 : orr z6.s, z6.s, #0x02                    : orr    %z6.s $0x00000002 -> %z6.s
+0500f008 : orr z8.s, z8.s, #0x04                    : orr    %z8.s $0x00000004 -> %z8.s
+0500e80a : orr z10.s, z10.s, #0x08                  : orr    %z10.s $0x00000008 -> %z10.s
+0500e00c : orr z12.s, z12.s, #0x10                  : orr    %z12.s $0x00000010 -> %z12.s
+0500d80e : orr z14.s, z14.s, #0x20                  : orr    %z14.s $0x00000020 -> %z14.s
+05000030 : orr z16.s, z16.s, #0x03                  : orr    %z16.s $0x00000003 -> %z16.s
+05000052 : orr z18.s, z18.s, #0x07                  : orr    %z18.s $0x00000007 -> %z18.s
+05000074 : orr z20.s, z20.s, #0x0f                  : orr    %z20.s $0x0000000f -> %z20.s
+05000096 : orr z22.s, z22.s, #0x1f                  : orr    %z22.s $0x0000001f -> %z22.s
+0500f898 : orr z24.s, z24.s, #0x3e                  : orr    %z24.s $0x0000003e -> %z24.s
+0500f07a : orr z26.s, z26.s, #0x3c                  : orr    %z26.s $0x0000003c -> %z26.s
+0500e85c : orr z28.s, z28.s, #0x38                  : orr    %z28.s $0x00000038 -> %z28.s
+0500e03f : orr z31.s, z31.s, #0x30                  : orr    %z31.s $0x00000030 -> %z31.s
+050200a0 : orr z0.d, z0.d, #0x3f                    : orr    %z0.d $0x000000000000003f -> %z0.d
+05020004 : orr z4.d, z4.d, #0x01                    : orr    %z4.d $0x0000000000000001 -> %z4.d
+0503f806 : orr z6.d, z6.d, #0x02                    : orr    %z6.d $0x0000000000000002 -> %z6.d
+0503f008 : orr z8.d, z8.d, #0x04                    : orr    %z8.d $0x0000000000000004 -> %z8.d
+0503e80a : orr z10.d, z10.d, #0x08                  : orr    %z10.d $0x0000000000000008 -> %z10.d
+0503e00c : orr z12.d, z12.d, #0x10                  : orr    %z12.d $0x0000000000000010 -> %z12.d
+0503d80e : orr z14.d, z14.d, #0x20                  : orr    %z14.d $0x0000000000000020 -> %z14.d
+05020030 : orr z16.d, z16.d, #0x03                  : orr    %z16.d $0x0000000000000003 -> %z16.d
+05020052 : orr z18.d, z18.d, #0x07                  : orr    %z18.d $0x0000000000000007 -> %z18.d
+05020074 : orr z20.d, z20.d, #0x0f                  : orr    %z20.d $0x000000000000000f -> %z20.d
+05020096 : orr z22.d, z22.d, #0x1f                  : orr    %z22.d $0x000000000000001f -> %z22.d
+0503f898 : orr z24.d, z24.d, #0x3e                  : orr    %z24.d $0x000000000000003e -> %z24.d
+0503f07a : orr z26.d, z26.d, #0x3c                  : orr    %z26.d $0x000000000000003c -> %z26.d
+0503e85c : orr z28.d, z28.d, #0x38                  : orr    %z28.d $0x0000000000000038 -> %z28.d
+0503e03f : orr z31.d, z31.d, #0x30                  : orr    %z31.d $0x0000000000000030 -> %z31.d
 
 # PTEST   <Pg>, <Pn>.B (PTEST-.P.P-_)
 2550c000 : ptest p0, p0.b                            : ptest  %p0 %p0.b

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -117,7 +117,7 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
         print("but expected:\n");
         print("   %s\n", expected);
         print("Encoded as:\n");
-        print("   %08x\n\n", pc);
+        print("   0x%08x\n\n", *((int *)pc));
         result = false;
     }
 

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -4767,6 +4767,227 @@ TEST_INSTR(uqincp_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
+
+TEST_INSTR(and_sve_imm)
+{
+    /* Testing AND     <Zdn>.<T>, <Zdn>.<T>, #<imm> */
+    int imm13[6] = { 1, 4, 8, 16, 32, 63 };
+    const char *expected_0[6] = {
+        "and    %z0.b $0x01 -> %z0.b",   "and    %z5.b $0x04 -> %z5.b",
+        "and    %z10.b $0x08 -> %z10.b", "and    %z16.b $0x10 -> %z16.b",
+        "and    %z21.b $0x20 -> %z21.b", "and    %z31.b $0x3f -> %z31.b",
+    };
+    TEST_LOOP(and, and_sve_imm, 6, expected_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm13[i], OPSZ_1));
+
+    const char *expected_1[6] = {
+        "and    %z0.h $0x0001 -> %z0.h",   "and    %z5.h $0x0004 -> %z5.h",
+        "and    %z10.h $0x0008 -> %z10.h", "and    %z16.h $0x0010 -> %z16.h",
+        "and    %z21.h $0x0020 -> %z21.h", "and    %z31.h $0x003f -> %z31.h",
+    };
+    TEST_LOOP(and, and_sve_imm, 6, expected_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm13[i], OPSZ_2));
+
+    const char *expected_2[6] = {
+        "and    %z0.s $0x00000001 -> %z0.s",   "and    %z5.s $0x00000004 -> %z5.s",
+        "and    %z10.s $0x00000008 -> %z10.s", "and    %z16.s $0x00000010 -> %z16.s",
+        "and    %z21.s $0x00000020 -> %z21.s", "and    %z31.s $0x0000003f -> %z31.s",
+    };
+    TEST_LOOP(and, and_sve_imm, 6, expected_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm13[i], OPSZ_4));
+
+    const char *expected_3[6] = {
+        "and    %z0.d $0x0000000000000001 -> %z0.d",
+        "and    %z5.d $0x0000000000000004 -> %z5.d",
+        "and    %z10.d $0x0000000000000008 -> %z10.d",
+        "and    %z16.d $0x0000000000000010 -> %z16.d",
+        "and    %z21.d $0x0000000000000020 -> %z21.d",
+        "and    %z31.d $0x000000000000003f -> %z31.d",
+    };
+    TEST_LOOP(and, and_sve_imm, 6, expected_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm13[i], OPSZ_8));
+}
+
+TEST_INSTR(bic_sve_imm)
+{
+    /* Testing BIC     <Zdn>.<T>, <Zdn>.<T>, #<imm> */
+    int imm13[6] = { 1, 4, 8, 16, 32, 63 };
+    const char *expected_0[6] = {
+        "and    %z0.b $0xfe -> %z0.b",   "and    %z5.b $0xfb -> %z5.b",
+        "and    %z10.b $0xf7 -> %z10.b", "and    %z16.b $0xef -> %z16.b",
+        "and    %z21.b $0xdf -> %z21.b", "and    %z31.b $0xc0 -> %z31.b",
+    };
+    TEST_LOOP(and, bic_sve_imm, 6, expected_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm13[i], OPSZ_1));
+
+    const char *expected_1[6] = {
+        "and    %z0.h $0xfffe -> %z0.h",   "and    %z5.h $0xfffb -> %z5.h",
+        "and    %z10.h $0xfff7 -> %z10.h", "and    %z16.h $0xffef -> %z16.h",
+        "and    %z21.h $0xffdf -> %z21.h", "and    %z31.h $0xffc0 -> %z31.h",
+    };
+    TEST_LOOP(and, bic_sve_imm, 6, expected_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm13[i], OPSZ_2));
+
+    const char *expected_2[6] = {
+        "and    %z0.s $0xfffffffe -> %z0.s",   "and    %z5.s $0xfffffffb -> %z5.s",
+        "and    %z10.s $0xfffffff7 -> %z10.s", "and    %z16.s $0xffffffef -> %z16.s",
+        "and    %z21.s $0xffffffdf -> %z21.s", "and    %z31.s $0xffffffc0 -> %z31.s",
+    };
+    TEST_LOOP(and, bic_sve_imm, 6, expected_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm13[i], OPSZ_4));
+
+    const char *expected_3[6] = {
+        "and    %z0.d $0xfffffffffffffffe -> %z0.d",
+        "and    %z5.d $0xfffffffffffffffb -> %z5.d",
+        "and    %z10.d $0xfffffffffffffff7 -> %z10.d",
+        "and    %z16.d $0xffffffffffffffef -> %z16.d",
+        "and    %z21.d $0xffffffffffffffdf -> %z21.d",
+        "and    %z31.d $0xffffffffffffffc0 -> %z31.d",
+    };
+    TEST_LOOP(and, bic_sve_imm, 6, expected_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm13[i], OPSZ_8));
+}
+
+TEST_INSTR(eor_sve_imm)
+{
+    /* Testing EOR     <Zdn>.<T>, <Zdn>.<T>, #<imm> */
+    int imm13[6] = { 1, 4, 8, 16, 32, 63 };
+    const char *expected_0[6] = {
+        "eor    %z0.b $0x01 -> %z0.b",   "eor    %z5.b $0x04 -> %z5.b",
+        "eor    %z10.b $0x08 -> %z10.b", "eor    %z16.b $0x10 -> %z16.b",
+        "eor    %z21.b $0x20 -> %z21.b", "eor    %z31.b $0x3f -> %z31.b",
+    };
+    TEST_LOOP(eor, eor_sve_imm, 6, expected_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm13[i], OPSZ_1));
+
+    const char *expected_1[6] = {
+        "eor    %z0.h $0x0001 -> %z0.h",   "eor    %z5.h $0x0004 -> %z5.h",
+        "eor    %z10.h $0x0008 -> %z10.h", "eor    %z16.h $0x0010 -> %z16.h",
+        "eor    %z21.h $0x0020 -> %z21.h", "eor    %z31.h $0x003f -> %z31.h",
+    };
+    TEST_LOOP(eor, eor_sve_imm, 6, expected_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm13[i], OPSZ_2));
+
+    const char *expected_2[6] = {
+        "eor    %z0.s $0x00000001 -> %z0.s",   "eor    %z5.s $0x00000004 -> %z5.s",
+        "eor    %z10.s $0x00000008 -> %z10.s", "eor    %z16.s $0x00000010 -> %z16.s",
+        "eor    %z21.s $0x00000020 -> %z21.s", "eor    %z31.s $0x0000003f -> %z31.s",
+    };
+    TEST_LOOP(eor, eor_sve_imm, 6, expected_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm13[i], OPSZ_4));
+
+    const char *expected_3[6] = {
+        "eor    %z0.d $0x0000000000000001 -> %z0.d",
+        "eor    %z5.d $0x0000000000000004 -> %z5.d",
+        "eor    %z10.d $0x0000000000000008 -> %z10.d",
+        "eor    %z16.d $0x0000000000000010 -> %z16.d",
+        "eor    %z21.d $0x0000000000000020 -> %z21.d",
+        "eor    %z31.d $0x000000000000003f -> %z31.d",
+    };
+    TEST_LOOP(eor, eor_sve_imm, 6, expected_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm13[i], OPSZ_8));
+}
+
+TEST_INSTR(orr_sve_imm)
+{
+    /* Testing ORR     <Zdn>.<T>, <Zdn>.<T>, #<imm> */
+    int imm13[6] = { 1, 4, 8, 16, 32, 63 };
+    const char *expected_0[6] = {
+        "orr    %z0.b $0x01 -> %z0.b",   "orr    %z5.b $0x04 -> %z5.b",
+        "orr    %z10.b $0x08 -> %z10.b", "orr    %z16.b $0x10 -> %z16.b",
+        "orr    %z21.b $0x20 -> %z21.b", "orr    %z31.b $0x3f -> %z31.b",
+    };
+    TEST_LOOP(orr, orr_sve_imm, 6, expected_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm13[i], OPSZ_1));
+
+    const char *expected_1[6] = {
+        "orr    %z0.h $0x0001 -> %z0.h",   "orr    %z5.h $0x0004 -> %z5.h",
+        "orr    %z10.h $0x0008 -> %z10.h", "orr    %z16.h $0x0010 -> %z16.h",
+        "orr    %z21.h $0x0020 -> %z21.h", "orr    %z31.h $0x003f -> %z31.h",
+    };
+    TEST_LOOP(orr, orr_sve_imm, 6, expected_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm13[i], OPSZ_2));
+
+    const char *expected_2[6] = {
+        "orr    %z0.s $0x00000001 -> %z0.s",   "orr    %z5.s $0x00000004 -> %z5.s",
+        "orr    %z10.s $0x00000008 -> %z10.s", "orr    %z16.s $0x00000010 -> %z16.s",
+        "orr    %z21.s $0x00000020 -> %z21.s", "orr    %z31.s $0x0000003f -> %z31.s",
+    };
+    TEST_LOOP(orr, orr_sve_imm, 6, expected_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm13[i], OPSZ_4));
+
+    const char *expected_3[6] = {
+        "orr    %z0.d $0x0000000000000001 -> %z0.d",
+        "orr    %z5.d $0x0000000000000004 -> %z5.d",
+        "orr    %z10.d $0x0000000000000008 -> %z10.d",
+        "orr    %z16.d $0x0000000000000010 -> %z16.d",
+        "orr    %z21.d $0x0000000000000020 -> %z21.d",
+        "orr    %z31.d $0x000000000000003f -> %z31.d",
+    };
+    TEST_LOOP(orr, orr_sve_imm, 6, expected_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm13[i], OPSZ_8));
+}
+
+TEST_INSTR(orn_sve_imm)
+{
+    /* Testing ORN     <Zdn>.<T>, <Zdn>.<T>, #<imm> */
+    int imm13[6] = { 1, 4, 8, 16, 32, 63 };
+    const char *expected_0[6] = {
+        "orr    %z0.b $0xfe -> %z0.b",   "orr    %z5.b $0xfb -> %z5.b",
+        "orr    %z10.b $0xf7 -> %z10.b", "orr    %z16.b $0xef -> %z16.b",
+        "orr    %z21.b $0xdf -> %z21.b", "orr    %z31.b $0xc0 -> %z31.b",
+    };
+    TEST_LOOP(orr, orn_sve_imm, 6, expected_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm13[i], OPSZ_1));
+
+    const char *expected_1[6] = {
+        "orr    %z0.h $0xfffe -> %z0.h",   "orr    %z5.h $0xfffb -> %z5.h",
+        "orr    %z10.h $0xfff7 -> %z10.h", "orr    %z16.h $0xffef -> %z16.h",
+        "orr    %z21.h $0xffdf -> %z21.h", "orr    %z31.h $0xffc0 -> %z31.h",
+    };
+    TEST_LOOP(orr, orn_sve_imm, 6, expected_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm13[i], OPSZ_2));
+
+    const char *expected_2[6] = {
+        "orr    %z0.s $0xfffffffe -> %z0.s",   "orr    %z5.s $0xfffffffb -> %z5.s",
+        "orr    %z10.s $0xfffffff7 -> %z10.s", "orr    %z16.s $0xffffffef -> %z16.s",
+        "orr    %z21.s $0xffffffdf -> %z21.s", "orr    %z31.s $0xffffffc0 -> %z31.s",
+    };
+    TEST_LOOP(orr, orn_sve_imm, 6, expected_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm13[i], OPSZ_4));
+
+    const char *expected_3[6] = {
+        "orr    %z0.d $0xfffffffffffffffe -> %z0.d",
+        "orr    %z5.d $0xfffffffffffffffb -> %z5.d",
+        "orr    %z10.d $0xfffffffffffffff7 -> %z10.d",
+        "orr    %z16.d $0xffffffffffffffef -> %z16.d",
+        "orr    %z21.d $0xffffffffffffffdf -> %z21.d",
+        "orr    %z31.d $0xffffffffffffffc0 -> %z31.d",
+    };
+    TEST_LOOP(orr, orn_sve_imm, 6, expected_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm13[i], OPSZ_8));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -4899,6 +5120,12 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(uqdecp_sve);
     RUN_INSTR_TEST(uqincp_sve);
     RUN_INSTR_TEST(uqincp_sve);
+
+    RUN_INSTR_TEST(and_sve_imm);
+    RUN_INSTR_TEST(bic_sve_imm);
+    RUN_INSTR_TEST(eor_sve_imm);
+    RUN_INSTR_TEST(orr_sve_imm);
+    RUN_INSTR_TEST(orn_sve_imm);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/opnd-a64.c
+++ b/suite/tests/api/opnd-a64.c
@@ -231,12 +231,67 @@ test_opnd_compute_address()
     printf("location: %ld\n", (reg_t)loc);
 }
 
+static void
+test_opnd_invert_immed_int()
+{
+    // 1 bit test
+    opnd_t opnd = opnd_invert_immed_int(opnd_create_immed_int(1, OPSZ_1b));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0, OPSZ_1b));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+
+    // 3 bit test
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0b001, OPSZ_3b));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0b101, OPSZ_3b));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+
+    // 1 byte test
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0x33, OPSZ_1));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0xf0, OPSZ_1));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+
+    // 4 byte test
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0x33333333, OPSZ_4));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0xf0f0f0f0, OPSZ_4));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+
+// 8 byte test
+#ifdef X64
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0xf0f0f0f033333333, OPSZ_8));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+    opnd = opnd_invert_immed_int(opnd_create_immed_int(0x33333333f0f0f0f0, OPSZ_8));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int(opnd));
+#else
+    opnd = opnd_invert_immed_int(opnd_create_immed_int64(0xf0f0f0f033333333, OPSZ_8));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int64(opnd));
+    opnd = opnd_invert_immed_int(opnd_create_immed_int64(0x33333333f0f0f0f0, OPSZ_8));
+    printf("opnd size: %d, value: 0x%lx\n", opnd_size_in_bits(opnd_get_size(opnd)),
+           opnd_get_immed_int64(opnd));
+#endif
+}
+
 int
 main(int argc, char *argv[])
 {
     test_get_size();
 
     test_opnd_compute_address();
+
+    test_opnd_invert_immed_int();
 
     printf("all done\n");
     return 0;

--- a/suite/tests/api/opnd-a64.expect
+++ b/suite/tests/api/opnd-a64.expect
@@ -17,4 +17,14 @@ location: 248
 location: 192
 location: 252
 location: 224
+opnd size: 1, value: 0x0
+opnd size: 1, value: 0x1
+opnd size: 3, value: 0x6
+opnd size: 3, value: 0x2
+opnd size: 8, value: 0xcc
+opnd size: 8, value: 0xf
+opnd size: 32, value: 0xcccccccc
+opnd size: 32, value: 0xf0f0f0f
+opnd size: 64, value: 0xf0f0f0fcccccccc
+opnd size: 64, value: 0xcccccccc0f0f0f0f
 all done


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
AND     <Zdn>.<T>, <Zdn>.<T>, #<const>
BIC     <Zdn>.<T>, <Zdn>.<T>, #<const>
EOR     <Zdn>.<T>, <Zdn>.<T>, #<const>
ORN     <Zdn>.<T>, <Zdn>.<T>, #<const>
ORR     <Zdn>.<T>, <Zdn>.<T>, #<const>
```

Issue #3044