### PR TITLE
i#3044 AArch64 SVE codec:  Add predicate logical operations

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -2361,6 +2361,22 @@ encode_opnd_p10(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_p(10, 15, opnd, enc_out);
 }
 
+/* p10_zer: SVE predicate registers p0-p15, zeroing */
+static inline bool
+decode_opnd_p10_zer(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_predicate_reg(DR_REG_P0 + extract_uint(enc, 10, 4), false);
+    return true;
+}
+
+static inline bool
+encode_opnd_p10_zer(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_predicate_zero(opnd))
+        return false;
+    return encode_opnd_p(10, 15, opnd, enc_out);
+}
+
 /* cmode_s_sz: Operand for 32 bit elements' shift amount */
 
 static inline bool
@@ -3048,6 +3064,21 @@ encode_opnd_p16_zer(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_o
     if (!opnd_is_predicate_zero(opnd))
         return false;
     return encode_opnd_p(16, 15, opnd, enc_out);
+}
+
+/* p_b_16: P register with a byte element size */
+static inline bool
+decode_opnd_p_b_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_P0, 16, 4, BYTE_REG, enc, opnd);
+}
+
+static inline bool
+encode_opnd_p_b_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_predicate_reg(opnd))
+        return false;
+    return encode_single_sized(OPSZ_SCALABLE_PRED, 16, BYTE_REG, opnd, enc_out);
 }
 
 /* sysreg: system register, operand of MRS/MSR */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -45,8 +45,14 @@
 00000100xx000000000xxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10000011xxxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx011010000xxxxxxxxxxxxx  n   21   SVE      and             z0 : p10_lo z0 z5 bhsd_sz
-00000101100000xxxxxxxxxxxxxxxxxx  n   21   SVE      and z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
+00000101100000xxxxxxxxxxxxxxxxxx  n   21   SVE      and  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
+001001010000xxxx01xxxx0xxxx0xxxx  n   21   SVE      and          p_b_0 : p10_zer p_b_5 p_b_16
+00000100001xxxxx001100xxxxxxxxxx  n   21   SVE      and          z_d_0 : z_d_5 z_d_16
+001001010100xxxx01xxxx0xxxx0xxxx  w   22   SVE     ands          p_b_0 : p10_zer p_b_5 p_b_16
 00000100xx011011000xxxxxxxxxxxxx  n   29   SVE      bic             z0 : p10_lo z0 z5 bhsd_sz
+001001010000xxxx01xxxx0xxxx1xxxx  n   29   SVE      bic          p_b_0 : p10_zer p_b_5 p_b_16
+00000100111xxxxx001100xxxxxxxxxx  n   29   SVE      bic          z_d_0 : z_d_5 z_d_16
+001001010100xxxx01xxxx0xxxx1xxxx  w   30   SVE     bics          p_b_0 : p10_zer p_b_5 p_b_16
 00100101xx0xxxxx100xxxxxxxx0xxxx  w   807  SVE    cmpeq  p_size_bhsd_0 : p10_zer_lo z_size_bhsd_5 simm5
 00100100xx0xxxxx001xxxxxxxx0xxxx  w   807  SVE    cmpeq   p_size_bhs_0 : p10_zer_lo z_size_bhs_5 z_d_16
 00100100xx0xxxxx101xxxxxxxx0xxxx  w   807  SVE    cmpeq  p_size_bhsd_0 : p10_zer_lo z_size_bhsd_5 z_size_bhsd_16
@@ -80,7 +86,10 @@
 00100101xx1011011000100xxxxxxxxx  n   822  SVE     decp             x0 : p_size_bhsd_5 x0
 00100101xx1011011000000xxxxxxxxx  n   822  SVE     decp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor             z0 : p10_lo z0 z5 bhsd_sz
-00000101010000xxxxxxxxxxxxxxxxxx  n   90   SVE      eor z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
+00000101010000xxxxxxxxxxxxxxxxxx  n   90   SVE      eor  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
+001001010000xxxx01xxxx1xxxx0xxxx  n   90   SVE      eor          p_b_0 : p10_zer p_b_5 p_b_16
+00000100101xxxxx001100xxxxxxxxxx  n   90   SVE      eor          z_d_0 : z_d_5 z_d_16
+001001010100xxxx01xxxx1xxxx0xxxx  w   828  SVE     eors          p_b_0 : p10_zer p_b_5 p_b_16
 01100101xx0xxxxx110xxxxxxxx1xxxx  n   96   SVE    facge   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx0xxxxx111xxxxxxxx1xxxx  n   97   SVE    facgt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx010010001xxxxxxxx0xxxx  n   102  SVE    fcmeq   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
@@ -107,9 +116,19 @@
 00000100xx0xxxxx111xxxxxxxxxxxxx  n   788  SVE      msb  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_16 z_size_bhsd_5
 00000100xx010000000xxxxxxxxxxxxx  n   321  SVE      mul  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx110000110xxxxxxxxxxxxx  n   321  SVE      mul  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
+001001011000xxxx01xxxx1xxxx1xxxx  n   829  SVE     nand          p_b_0 : p10_zer p_b_5 p_b_16
+001001011100xxxx01xxxx1xxxx1xxxx  w   830  SVE    nands          p_b_0 : p10_zer p_b_5 p_b_16
 00000100xx010111101xxxxxxxxxxxxx  n   323  SVE      neg  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
+001001011000xxxx01xxxx1xxxx0xxxx  n   831  SVE      nor          p_b_0 : p10_zer p_b_5 p_b_16
+001001011100xxxx01xxxx1xxxx0xxxx  w   832  SVE     nors          p_b_0 : p10_zer p_b_5 p_b_16
+00000100xx011110101xxxxxxxxxxxxx  n   325  SVE      not  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
+001001011000xxxx01xxxx0xxxx1xxxx  n   326  SVE      orn          p_b_0 : p10_zer p_b_5 p_b_16
+001001011100xxxx01xxxx0xxxx1xxxx  w   833  SVE     orns          p_b_0 : p10_zer p_b_5 p_b_16
 00000100xx011000000xxxxxxxxxxxxx  n   327  SVE      orr             z0 : p10_lo z0 z5 bhsd_sz
-00000101000000xxxxxxxxxxxxxxxxxx  n   327  SVE      orr z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
+00000101000000xxxxxxxxxxxxxxxxxx  n   327  SVE      orr  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
+001001011000xxxx01xxxx0xxxx0xxxx  n   327  SVE      orr          p_b_0 : p10_zer p_b_5 p_b_16
+00000100011xxxxx001100xxxxxxxxxx  n   327  SVE      orr          z_d_0 : z_d_5 z_d_16
+001001011100xxxx01xxxx0xxxx0xxxx  w   834  SVE     orrs          p_b_0 : p10_zer p_b_5 p_b_16
 001001010101000011xxxx0xxxx00000  w   786  SVE    ptest                : p10 p_b_5
 0010010100011001111100000000xxxx  n   817  SVE    rdffr          p_b_0 :
 00100101000110001111000xxxx0xxxx  n   817  SVE    rdffr          p_b_0 : p5_zer

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -6714,4 +6714,303 @@
 #define INSTR_CREATE_orn_sve_imm(dc, Zdn, imm) \
     instr_create_1dst_2src(dc, OP_orr, Zdn, Zdn, opnd_invert_immed_int(imm))
 
+/**
+ * Creates an AND instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AND     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_and_sve_pred_b(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_and, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates an AND instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AND     <Zd>.D, <Zn>.D, <Zm>.D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_and_sve(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_and, Zd, Zn, Zm)
+
+/**
+ * Creates an ANDS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ANDS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_ands_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_ands, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a BIC instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BIC     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_bic_sve_pred_b(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_bic, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a BIC instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BIC     <Zd>.D, <Zn>.D, <Zm>.D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_bic_sve(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_bic, Zd, Zn, Zm)
+
+/**
+ * Creates a BICS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BICS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_bics_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_bics, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates an EOR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_eor_sve_pred_b(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_eor, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates an EOR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EOR     <Zd>.D, <Zn>.D, <Zm>.D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_eor_sve(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_eor, Zd, Zn, Zm)
+
+/**
+ * Creates an EORS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_eors_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_eors, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a NAND instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    NAND    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_nand_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_nand, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a NANDS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    NANDS   <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_nands_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_nands, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a NOR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    NOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_nor_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_nor, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a NORS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    NORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_nors_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_nors, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a NOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    NOT     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_not_sve_pred_vec(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_not, Zd, Pg, Zn)
+
+/**
+ * Creates an ORN instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORN     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_orn_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_orn, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates an ORNS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORNS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_orns_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_orns, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates an ORR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_orr_sve_pred_b(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_orr, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates an ORR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORR     <Zd>.D, <Zn>.D, <Zm>.D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_orr_sve(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_orr, Zd, Zn, Zm)
+
+/**
+ * Creates an ORRS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORRS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_orrs_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_orrs, Pd, Pg, Pn, Pm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -123,6 +123,7 @@
 ------------------x-------------  shift1     # LSL #0 or #8 depending on bit 13
 ------------------xx------------  imm2idx    # imm from 13-12, used as an index
 ------------------xxxx----------  p10        # SVE predicate registers p0-p15
+------------------xxxx----------  p10_zer    # SVE predicate registers p0-p15, zeroing
 -----------------xx-------------  cmode_s_sz # Vector shift for 32 bit elements
 -----------------xx-------------  len        # imm2 len
 -----------------xxxx-----------  imm4idx    # imm4 from 11-14
@@ -146,6 +147,7 @@
 -------------xxx------xxxxx-----  exp_imm8   # expanded immediate from 16:18 and 5:9
 ------------xxxx----------------  p16_mrg    # merging P register at position 16
 ------------xxxx----------------  p16_zer    # zeroing P register at position 16
+------------xxxx----------------  p_b_16     # P register with a byte element size at position 16
 ------------xxxxxxxxxxxxxxx-----  sysreg     # operand of MRS
 -----------?????----------------  bh_imm5_sz # Size encoded as least significant bit in imm5
 -----------?????----------------  bhs_imm5_sz # Size encoded as least significant bit in imm5

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -380,10 +380,118 @@
 0583e85c : and z28.d, z28.d, #0x38                  : and    %z28.d $0x0000000000000038 -> %z28.d
 0583e03f : and z31.d, z31.d, #0x30                  : and    %z31.d $0x0000000000000030 -> %z31.d
 
+# AND     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (AND-P.P.PP-Z)
+25004000 : and p0.b, p0/Z, p0.b, p0.b                : and    %p0/z %p0.b %p0.b -> %p0.b
+25044861 : and p1.b, p2/Z, p3.b, p4.b                : and    %p2/z %p3.b %p4.b -> %p1.b
+25054c82 : and p2.b, p3/Z, p4.b, p5.b                : and    %p3/z %p4.b %p5.b -> %p2.b
+250650a3 : and p3.b, p4/Z, p5.b, p6.b                : and    %p4/z %p5.b %p6.b -> %p3.b
+250754c4 : and p4.b, p5/Z, p6.b, p7.b                : and    %p5/z %p6.b %p7.b -> %p4.b
+250858e5 : and p5.b, p6/Z, p7.b, p8.b                : and    %p6/z %p7.b %p8.b -> %p5.b
+25095d06 : and p6.b, p7/Z, p8.b, p9.b                : and    %p7/z %p8.b %p9.b -> %p6.b
+250a6127 : and p7.b, p8/Z, p9.b, p10.b               : and    %p8/z %p9.b %p10.b -> %p7.b
+250b6548 : and p8.b, p9/Z, p10.b, p11.b              : and    %p9/z %p10.b %p11.b -> %p8.b
+250b6548 : and p8.b, p9/Z, p10.b, p11.b              : and    %p9/z %p10.b %p11.b -> %p8.b
+250c6969 : and p9.b, p10/Z, p11.b, p12.b             : and    %p10/z %p11.b %p12.b -> %p9.b
+250d6d8a : and p10.b, p11/Z, p12.b, p13.b            : and    %p11/z %p12.b %p13.b -> %p10.b
+250e71ab : and p11.b, p12/Z, p13.b, p14.b            : and    %p12/z %p13.b %p14.b -> %p11.b
+250f75cc : and p12.b, p13/Z, p14.b, p15.b            : and    %p13/z %p14.b %p15.b -> %p12.b
+250079ed : and p13.b, p14/Z, p15.b, p0.b             : and    %p14/z %p15.b %p0.b -> %p13.b
+250f7def : and p15.b, p15/Z, p15.b, p15.b            : and    %p15/z %p15.b %p15.b -> %p15.b
+
+# AND     <Zd>.D, <Zn>.D, <Zm>.D (AND-Z.ZZ-_)
+04203000 : and z0.d, z0.d, z0.d                      : and    %z0.d %z0.d -> %z0.d
+04243062 : and z2.d, z3.d, z4.d                      : and    %z3.d %z4.d -> %z2.d
+042630a4 : and z4.d, z5.d, z6.d                      : and    %z5.d %z6.d -> %z4.d
+042830e6 : and z6.d, z7.d, z8.d                      : and    %z7.d %z8.d -> %z6.d
+042a3128 : and z8.d, z9.d, z10.d                     : and    %z9.d %z10.d -> %z8.d
+042c316a : and z10.d, z11.d, z12.d                   : and    %z11.d %z12.d -> %z10.d
+042e31ac : and z12.d, z13.d, z14.d                   : and    %z13.d %z14.d -> %z12.d
+043031ee : and z14.d, z15.d, z16.d                   : and    %z15.d %z16.d -> %z14.d
+04323230 : and z16.d, z17.d, z18.d                   : and    %z17.d %z18.d -> %z16.d
+04333251 : and z17.d, z18.d, z19.d                   : and    %z18.d %z19.d -> %z17.d
+04353293 : and z19.d, z20.d, z21.d                   : and    %z20.d %z21.d -> %z19.d
+043732d5 : and z21.d, z22.d, z23.d                   : and    %z22.d %z23.d -> %z21.d
+04393317 : and z23.d, z24.d, z25.d                   : and    %z24.d %z25.d -> %z23.d
+043b3359 : and z25.d, z26.d, z27.d                   : and    %z26.d %z27.d -> %z25.d
+043d339b : and z27.d, z28.d, z29.d                   : and    %z28.d %z29.d -> %z27.d
+043f33ff : and z31.d, z31.d, z31.d                   : and    %z31.d %z31.d -> %z31.d
+
+# ANDS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (ANDS-P.P.PP-Z)
+25404000 : ands p0.b, p0/Z, p0.b, p0.b               : ands   %p0/z %p0.b %p0.b -> %p0.b
+25444861 : ands p1.b, p2/Z, p3.b, p4.b               : ands   %p2/z %p3.b %p4.b -> %p1.b
+25454c82 : ands p2.b, p3/Z, p4.b, p5.b               : ands   %p3/z %p4.b %p5.b -> %p2.b
+254650a3 : ands p3.b, p4/Z, p5.b, p6.b               : ands   %p4/z %p5.b %p6.b -> %p3.b
+254754c4 : ands p4.b, p5/Z, p6.b, p7.b               : ands   %p5/z %p6.b %p7.b -> %p4.b
+254858e5 : ands p5.b, p6/Z, p7.b, p8.b               : ands   %p6/z %p7.b %p8.b -> %p5.b
+25495d06 : ands p6.b, p7/Z, p8.b, p9.b               : ands   %p7/z %p8.b %p9.b -> %p6.b
+254a6127 : ands p7.b, p8/Z, p9.b, p10.b              : ands   %p8/z %p9.b %p10.b -> %p7.b
+254b6548 : ands p8.b, p9/Z, p10.b, p11.b             : ands   %p9/z %p10.b %p11.b -> %p8.b
+254b6548 : ands p8.b, p9/Z, p10.b, p11.b             : ands   %p9/z %p10.b %p11.b -> %p8.b
+254c6969 : ands p9.b, p10/Z, p11.b, p12.b            : ands   %p10/z %p11.b %p12.b -> %p9.b
+254d6d8a : ands p10.b, p11/Z, p12.b, p13.b           : ands   %p11/z %p12.b %p13.b -> %p10.b
+254e71ab : ands p11.b, p12/Z, p13.b, p14.b           : ands   %p12/z %p13.b %p14.b -> %p11.b
+254f75cc : ands p12.b, p13/Z, p14.b, p15.b           : ands   %p13/z %p14.b %p15.b -> %p12.b
+254079ed : ands p13.b, p14/Z, p15.b, p0.b            : ands   %p14/z %p15.b %p0.b -> %p13.b
+254f7def : ands p15.b, p15/Z, p15.b, p15.b           : ands   %p15/z %p15.b %p15.b -> %p15.b
+
 041b0b02 : bic z2.b, p2/m, z2.b, z24.b              : bic    %p2 %z2 %z24 $0x00 -> %z2
 045b0b02 : bic z2.h, p2/m, z2.h, z24.h              : bic    %p2 %z2 %z24 $0x01 -> %z2
 049b0b02 : bic z2.s, p2/m, z2.s, z24.s              : bic    %p2 %z2 %z24 $0x02 -> %z2
 04db0b02 : bic z2.d, p2/m, z2.d, z24.d              : bic    %p2 %z2 %z24 $0x03 -> %z2
+
+# BIC     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (BIC-P.P.PP-Z)
+25004010 : bic p0.b, p0/Z, p0.b, p0.b                : bic    %p0/z %p0.b %p0.b -> %p0.b
+25044871 : bic p1.b, p2/Z, p3.b, p4.b                : bic    %p2/z %p3.b %p4.b -> %p1.b
+25054c92 : bic p2.b, p3/Z, p4.b, p5.b                : bic    %p3/z %p4.b %p5.b -> %p2.b
+250650b3 : bic p3.b, p4/Z, p5.b, p6.b                : bic    %p4/z %p5.b %p6.b -> %p3.b
+250754d4 : bic p4.b, p5/Z, p6.b, p7.b                : bic    %p5/z %p6.b %p7.b -> %p4.b
+250858f5 : bic p5.b, p6/Z, p7.b, p8.b                : bic    %p6/z %p7.b %p8.b -> %p5.b
+25095d16 : bic p6.b, p7/Z, p8.b, p9.b                : bic    %p7/z %p8.b %p9.b -> %p6.b
+250a6137 : bic p7.b, p8/Z, p9.b, p10.b               : bic    %p8/z %p9.b %p10.b -> %p7.b
+250b6558 : bic p8.b, p9/Z, p10.b, p11.b              : bic    %p9/z %p10.b %p11.b -> %p8.b
+250b6558 : bic p8.b, p9/Z, p10.b, p11.b              : bic    %p9/z %p10.b %p11.b -> %p8.b
+250c6979 : bic p9.b, p10/Z, p11.b, p12.b             : bic    %p10/z %p11.b %p12.b -> %p9.b
+250d6d9a : bic p10.b, p11/Z, p12.b, p13.b            : bic    %p11/z %p12.b %p13.b -> %p10.b
+250e71bb : bic p11.b, p12/Z, p13.b, p14.b            : bic    %p12/z %p13.b %p14.b -> %p11.b
+250f75dc : bic p12.b, p13/Z, p14.b, p15.b            : bic    %p13/z %p14.b %p15.b -> %p12.b
+250079fd : bic p13.b, p14/Z, p15.b, p0.b             : bic    %p14/z %p15.b %p0.b -> %p13.b
+250f7dff : bic p15.b, p15/Z, p15.b, p15.b            : bic    %p15/z %p15.b %p15.b -> %p15.b
+
+# BIC     <Zd>.D, <Zn>.D, <Zm>.D (BIC-Z.ZZ-_)
+04e03000 : bic z0.d, z0.d, z0.d                      : bic    %z0.d %z0.d -> %z0.d
+04e43062 : bic z2.d, z3.d, z4.d                      : bic    %z3.d %z4.d -> %z2.d
+04e630a4 : bic z4.d, z5.d, z6.d                      : bic    %z5.d %z6.d -> %z4.d
+04e830e6 : bic z6.d, z7.d, z8.d                      : bic    %z7.d %z8.d -> %z6.d
+04ea3128 : bic z8.d, z9.d, z10.d                     : bic    %z9.d %z10.d -> %z8.d
+04ec316a : bic z10.d, z11.d, z12.d                   : bic    %z11.d %z12.d -> %z10.d
+04ee31ac : bic z12.d, z13.d, z14.d                   : bic    %z13.d %z14.d -> %z12.d
+04f031ee : bic z14.d, z15.d, z16.d                   : bic    %z15.d %z16.d -> %z14.d
+04f23230 : bic z16.d, z17.d, z18.d                   : bic    %z17.d %z18.d -> %z16.d
+04f33251 : bic z17.d, z18.d, z19.d                   : bic    %z18.d %z19.d -> %z17.d
+04f53293 : bic z19.d, z20.d, z21.d                   : bic    %z20.d %z21.d -> %z19.d
+04f732d5 : bic z21.d, z22.d, z23.d                   : bic    %z22.d %z23.d -> %z21.d
+04f93317 : bic z23.d, z24.d, z25.d                   : bic    %z24.d %z25.d -> %z23.d
+04fb3359 : bic z25.d, z26.d, z27.d                   : bic    %z26.d %z27.d -> %z25.d
+04fd339b : bic z27.d, z28.d, z29.d                   : bic    %z28.d %z29.d -> %z27.d
+04ff33ff : bic z31.d, z31.d, z31.d                   : bic    %z31.d %z31.d -> %z31.d
+
+# BICS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (BICS-P.P.PP-Z)
+25404010 : bics p0.b, p0/Z, p0.b, p0.b               : bics   %p0/z %p0.b %p0.b -> %p0.b
+25444871 : bics p1.b, p2/Z, p3.b, p4.b               : bics   %p2/z %p3.b %p4.b -> %p1.b
+25454c92 : bics p2.b, p3/Z, p4.b, p5.b               : bics   %p3/z %p4.b %p5.b -> %p2.b
+254650b3 : bics p3.b, p4/Z, p5.b, p6.b               : bics   %p4/z %p5.b %p6.b -> %p3.b
+254754d4 : bics p4.b, p5/Z, p6.b, p7.b               : bics   %p5/z %p6.b %p7.b -> %p4.b
+254858f5 : bics p5.b, p6/Z, p7.b, p8.b               : bics   %p6/z %p7.b %p8.b -> %p5.b
+25495d16 : bics p6.b, p7/Z, p8.b, p9.b               : bics   %p7/z %p8.b %p9.b -> %p6.b
+254a6137 : bics p7.b, p8/Z, p9.b, p10.b              : bics   %p8/z %p9.b %p10.b -> %p7.b
+254b6558 : bics p8.b, p9/Z, p10.b, p11.b             : bics   %p9/z %p10.b %p11.b -> %p8.b
+254b6558 : bics p8.b, p9/Z, p10.b, p11.b             : bics   %p9/z %p10.b %p11.b -> %p8.b
+254c6979 : bics p9.b, p10/Z, p11.b, p12.b            : bics   %p10/z %p11.b %p12.b -> %p9.b
+254d6d9a : bics p10.b, p11/Z, p12.b, p13.b           : bics   %p11/z %p12.b %p13.b -> %p10.b
+254e71bb : bics p11.b, p12/Z, p13.b, p14.b           : bics   %p12/z %p13.b %p14.b -> %p11.b
+254f75dc : bics p12.b, p13/Z, p14.b, p15.b           : bics   %p13/z %p14.b %p15.b -> %p12.b
+254079fd : bics p13.b, p14/Z, p15.b, p0.b            : bics   %p14/z %p15.b %p0.b -> %p13.b
+254f7dff : bics p15.b, p15/Z, p15.b, p15.b           : bics   %p15/z %p15.b %p15.b -> %p15.b
 
 # CMPEQ   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, #<imm> (CMPEQ-P.P.ZI-_)
 25108000 : cmpeq p0.b, p0/Z, z0.b, #-0x10            : cmpeq  %p0/z %z0.b $0xf0 -> %p0.b
@@ -2388,6 +2496,60 @@
 0543e85c : eor z28.d, z28.d, #0x38                  : eor    %z28.d $0x0000000000000038 -> %z28.d
 0543e03f : eor z31.d, z31.d, #0x30                  : eor    %z31.d $0x0000000000000030 -> %z31.d
 
+# EOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (EOR-P.P.PP-Z)
+25004200 : eor p0.b, p0/Z, p0.b, p0.b                : eor    %p0/z %p0.b %p0.b -> %p0.b
+25044a61 : eor p1.b, p2/Z, p3.b, p4.b                : eor    %p2/z %p3.b %p4.b -> %p1.b
+25054e82 : eor p2.b, p3/Z, p4.b, p5.b                : eor    %p3/z %p4.b %p5.b -> %p2.b
+250652a3 : eor p3.b, p4/Z, p5.b, p6.b                : eor    %p4/z %p5.b %p6.b -> %p3.b
+250756c4 : eor p4.b, p5/Z, p6.b, p7.b                : eor    %p5/z %p6.b %p7.b -> %p4.b
+25085ae5 : eor p5.b, p6/Z, p7.b, p8.b                : eor    %p6/z %p7.b %p8.b -> %p5.b
+25095f06 : eor p6.b, p7/Z, p8.b, p9.b                : eor    %p7/z %p8.b %p9.b -> %p6.b
+250a6327 : eor p7.b, p8/Z, p9.b, p10.b               : eor    %p8/z %p9.b %p10.b -> %p7.b
+250b6748 : eor p8.b, p9/Z, p10.b, p11.b              : eor    %p9/z %p10.b %p11.b -> %p8.b
+250b6748 : eor p8.b, p9/Z, p10.b, p11.b              : eor    %p9/z %p10.b %p11.b -> %p8.b
+250c6b69 : eor p9.b, p10/Z, p11.b, p12.b             : eor    %p10/z %p11.b %p12.b -> %p9.b
+250d6f8a : eor p10.b, p11/Z, p12.b, p13.b            : eor    %p11/z %p12.b %p13.b -> %p10.b
+250e73ab : eor p11.b, p12/Z, p13.b, p14.b            : eor    %p12/z %p13.b %p14.b -> %p11.b
+250f77cc : eor p12.b, p13/Z, p14.b, p15.b            : eor    %p13/z %p14.b %p15.b -> %p12.b
+25007bed : eor p13.b, p14/Z, p15.b, p0.b             : eor    %p14/z %p15.b %p0.b -> %p13.b
+250f7fef : eor p15.b, p15/Z, p15.b, p15.b            : eor    %p15/z %p15.b %p15.b -> %p15.b
+
+# EOR     <Zd>.D, <Zn>.D, <Zm>.D (EOR-Z.ZZ-_)
+04a03000 : eor z0.d, z0.d, z0.d                      : eor    %z0.d %z0.d -> %z0.d
+04a43062 : eor z2.d, z3.d, z4.d                      : eor    %z3.d %z4.d -> %z2.d
+04a630a4 : eor z4.d, z5.d, z6.d                      : eor    %z5.d %z6.d -> %z4.d
+04a830e6 : eor z6.d, z7.d, z8.d                      : eor    %z7.d %z8.d -> %z6.d
+04aa3128 : eor z8.d, z9.d, z10.d                     : eor    %z9.d %z10.d -> %z8.d
+04ac316a : eor z10.d, z11.d, z12.d                   : eor    %z11.d %z12.d -> %z10.d
+04ae31ac : eor z12.d, z13.d, z14.d                   : eor    %z13.d %z14.d -> %z12.d
+04b031ee : eor z14.d, z15.d, z16.d                   : eor    %z15.d %z16.d -> %z14.d
+04b23230 : eor z16.d, z17.d, z18.d                   : eor    %z17.d %z18.d -> %z16.d
+04b33251 : eor z17.d, z18.d, z19.d                   : eor    %z18.d %z19.d -> %z17.d
+04b53293 : eor z19.d, z20.d, z21.d                   : eor    %z20.d %z21.d -> %z19.d
+04b732d5 : eor z21.d, z22.d, z23.d                   : eor    %z22.d %z23.d -> %z21.d
+04b93317 : eor z23.d, z24.d, z25.d                   : eor    %z24.d %z25.d -> %z23.d
+04bb3359 : eor z25.d, z26.d, z27.d                   : eor    %z26.d %z27.d -> %z25.d
+04bd339b : eor z27.d, z28.d, z29.d                   : eor    %z28.d %z29.d -> %z27.d
+04bf33ff : eor z31.d, z31.d, z31.d                   : eor    %z31.d %z31.d -> %z31.d
+
+# EORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (EORS-P.P.PP-Z)
+25404200 : eors p0.b, p0/Z, p0.b, p0.b               : eors   %p0/z %p0.b %p0.b -> %p0.b
+25444a61 : eors p1.b, p2/Z, p3.b, p4.b               : eors   %p2/z %p3.b %p4.b -> %p1.b
+25454e82 : eors p2.b, p3/Z, p4.b, p5.b               : eors   %p3/z %p4.b %p5.b -> %p2.b
+254652a3 : eors p3.b, p4/Z, p5.b, p6.b               : eors   %p4/z %p5.b %p6.b -> %p3.b
+254756c4 : eors p4.b, p5/Z, p6.b, p7.b               : eors   %p5/z %p6.b %p7.b -> %p4.b
+25485ae5 : eors p5.b, p6/Z, p7.b, p8.b               : eors   %p6/z %p7.b %p8.b -> %p5.b
+25495f06 : eors p6.b, p7/Z, p8.b, p9.b               : eors   %p7/z %p8.b %p9.b -> %p6.b
+254a6327 : eors p7.b, p8/Z, p9.b, p10.b              : eors   %p8/z %p9.b %p10.b -> %p7.b
+254b6748 : eors p8.b, p9/Z, p10.b, p11.b             : eors   %p9/z %p10.b %p11.b -> %p8.b
+254b6748 : eors p8.b, p9/Z, p10.b, p11.b             : eors   %p9/z %p10.b %p11.b -> %p8.b
+254c6b69 : eors p9.b, p10/Z, p11.b, p12.b            : eors   %p10/z %p11.b %p12.b -> %p9.b
+254d6f8a : eors p10.b, p11/Z, p12.b, p13.b           : eors   %p11/z %p12.b %p13.b -> %p10.b
+254e73ab : eors p11.b, p12/Z, p13.b, p14.b           : eors   %p12/z %p13.b %p14.b -> %p11.b
+254f77cc : eors p12.b, p13/Z, p14.b, p15.b           : eors   %p13/z %p14.b %p15.b -> %p12.b
+25407bed : eors p13.b, p14/Z, p15.b, p0.b            : eors   %p14/z %p15.b %p0.b -> %p13.b
+254f7fef : eors p15.b, p15/Z, p15.b, p15.b           : eors   %p15/z %p15.b %p15.b -> %p15.b
+
 # FACGE   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (FACGE-P.P.ZZ-_)
 6540c010 : facge p0.h, p0/Z, z0.h, z0.h              : facge  %p0/z %z0.h %z0.h -> %p0.h
 6545c491 : facge p1.h, p1/Z, z4.h, z5.h              : facge  %p1/z %z4.h %z5.h -> %p1.h
@@ -3768,6 +3930,42 @@
 25f0cbfb : mul z27.d, z27.d, #0x5f                   : mul    %z27.d $0x5f -> %z27.d
 25f0cfff : mul z31.d, z31.d, #0x7f                   : mul    %z31.d $0x7f -> %z31.d
 
+# NAND    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (NAND-P.P.PP-Z)
+25804210 : nand p0.b, p0/Z, p0.b, p0.b               : nand   %p0/z %p0.b %p0.b -> %p0.b
+25844a71 : nand p1.b, p2/Z, p3.b, p4.b               : nand   %p2/z %p3.b %p4.b -> %p1.b
+25854e92 : nand p2.b, p3/Z, p4.b, p5.b               : nand   %p3/z %p4.b %p5.b -> %p2.b
+258652b3 : nand p3.b, p4/Z, p5.b, p6.b               : nand   %p4/z %p5.b %p6.b -> %p3.b
+258756d4 : nand p4.b, p5/Z, p6.b, p7.b               : nand   %p5/z %p6.b %p7.b -> %p4.b
+25885af5 : nand p5.b, p6/Z, p7.b, p8.b               : nand   %p6/z %p7.b %p8.b -> %p5.b
+25895f16 : nand p6.b, p7/Z, p8.b, p9.b               : nand   %p7/z %p8.b %p9.b -> %p6.b
+258a6337 : nand p7.b, p8/Z, p9.b, p10.b              : nand   %p8/z %p9.b %p10.b -> %p7.b
+258b6758 : nand p8.b, p9/Z, p10.b, p11.b             : nand   %p9/z %p10.b %p11.b -> %p8.b
+258b6758 : nand p8.b, p9/Z, p10.b, p11.b             : nand   %p9/z %p10.b %p11.b -> %p8.b
+258c6b79 : nand p9.b, p10/Z, p11.b, p12.b            : nand   %p10/z %p11.b %p12.b -> %p9.b
+258d6f9a : nand p10.b, p11/Z, p12.b, p13.b           : nand   %p11/z %p12.b %p13.b -> %p10.b
+258e73bb : nand p11.b, p12/Z, p13.b, p14.b           : nand   %p12/z %p13.b %p14.b -> %p11.b
+258f77dc : nand p12.b, p13/Z, p14.b, p15.b           : nand   %p13/z %p14.b %p15.b -> %p12.b
+25807bfd : nand p13.b, p14/Z, p15.b, p0.b            : nand   %p14/z %p15.b %p0.b -> %p13.b
+258f7fff : nand p15.b, p15/Z, p15.b, p15.b           : nand   %p15/z %p15.b %p15.b -> %p15.b
+
+# NANDS   <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (NANDS-P.P.PP-Z)
+25c04210 : nands p0.b, p0/Z, p0.b, p0.b              : nands  %p0/z %p0.b %p0.b -> %p0.b
+25c44a71 : nands p1.b, p2/Z, p3.b, p4.b              : nands  %p2/z %p3.b %p4.b -> %p1.b
+25c54e92 : nands p2.b, p3/Z, p4.b, p5.b              : nands  %p3/z %p4.b %p5.b -> %p2.b
+25c652b3 : nands p3.b, p4/Z, p5.b, p6.b              : nands  %p4/z %p5.b %p6.b -> %p3.b
+25c756d4 : nands p4.b, p5/Z, p6.b, p7.b              : nands  %p5/z %p6.b %p7.b -> %p4.b
+25c85af5 : nands p5.b, p6/Z, p7.b, p8.b              : nands  %p6/z %p7.b %p8.b -> %p5.b
+25c95f16 : nands p6.b, p7/Z, p8.b, p9.b              : nands  %p7/z %p8.b %p9.b -> %p6.b
+25ca6337 : nands p7.b, p8/Z, p9.b, p10.b             : nands  %p8/z %p9.b %p10.b -> %p7.b
+25cb6758 : nands p8.b, p9/Z, p10.b, p11.b            : nands  %p9/z %p10.b %p11.b -> %p8.b
+25cb6758 : nands p8.b, p9/Z, p10.b, p11.b            : nands  %p9/z %p10.b %p11.b -> %p8.b
+25cc6b79 : nands p9.b, p10/Z, p11.b, p12.b           : nands  %p10/z %p11.b %p12.b -> %p9.b
+25cd6f9a : nands p10.b, p11/Z, p12.b, p13.b          : nands  %p11/z %p12.b %p13.b -> %p10.b
+25ce73bb : nands p11.b, p12/Z, p13.b, p14.b          : nands  %p12/z %p13.b %p14.b -> %p11.b
+25cf77dc : nands p12.b, p13/Z, p14.b, p15.b          : nands  %p13/z %p14.b %p15.b -> %p12.b
+25c07bfd : nands p13.b, p14/Z, p15.b, p0.b           : nands  %p14/z %p15.b %p0.b -> %p13.b
+25cf7fff : nands p15.b, p15/Z, p15.b, p15.b          : nands  %p15/z %p15.b %p15.b -> %p15.b
+
 # NEG     <Zd>.<T>, <Pg>/M, <Zn>.<T> (NEG-Z.P.Z-_)
 0417a000 : neg z0.b, p0/M, z0.b                      : neg    %p0/m %z0.b -> %z0.b
 0417a482 : neg z2.b, p1/M, z4.b                      : neg    %p1/m %z4.b -> %z2.b
@@ -3833,6 +4031,144 @@
 04d7bf79 : neg z25.d, p7/M, z27.d                    : neg    %p7/m %z27.d -> %z25.d
 04d7bfbb : neg z27.d, p7/M, z29.d                    : neg    %p7/m %z29.d -> %z27.d
 04d7bfff : neg z31.d, p7/M, z31.d                    : neg    %p7/m %z31.d -> %z31.d
+
+# NOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (NOR-P.P.PP-Z)
+25804200 : nor p0.b, p0/Z, p0.b, p0.b                : nor    %p0/z %p0.b %p0.b -> %p0.b
+25844a61 : nor p1.b, p2/Z, p3.b, p4.b                : nor    %p2/z %p3.b %p4.b -> %p1.b
+25854e82 : nor p2.b, p3/Z, p4.b, p5.b                : nor    %p3/z %p4.b %p5.b -> %p2.b
+258652a3 : nor p3.b, p4/Z, p5.b, p6.b                : nor    %p4/z %p5.b %p6.b -> %p3.b
+258756c4 : nor p4.b, p5/Z, p6.b, p7.b                : nor    %p5/z %p6.b %p7.b -> %p4.b
+25885ae5 : nor p5.b, p6/Z, p7.b, p8.b                : nor    %p6/z %p7.b %p8.b -> %p5.b
+25895f06 : nor p6.b, p7/Z, p8.b, p9.b                : nor    %p7/z %p8.b %p9.b -> %p6.b
+258a6327 : nor p7.b, p8/Z, p9.b, p10.b               : nor    %p8/z %p9.b %p10.b -> %p7.b
+258b6748 : nor p8.b, p9/Z, p10.b, p11.b              : nor    %p9/z %p10.b %p11.b -> %p8.b
+258b6748 : nor p8.b, p9/Z, p10.b, p11.b              : nor    %p9/z %p10.b %p11.b -> %p8.b
+258c6b69 : nor p9.b, p10/Z, p11.b, p12.b             : nor    %p10/z %p11.b %p12.b -> %p9.b
+258d6f8a : nor p10.b, p11/Z, p12.b, p13.b            : nor    %p11/z %p12.b %p13.b -> %p10.b
+258e73ab : nor p11.b, p12/Z, p13.b, p14.b            : nor    %p12/z %p13.b %p14.b -> %p11.b
+258f77cc : nor p12.b, p13/Z, p14.b, p15.b            : nor    %p13/z %p14.b %p15.b -> %p12.b
+25807bed : nor p13.b, p14/Z, p15.b, p0.b             : nor    %p14/z %p15.b %p0.b -> %p13.b
+258f7fef : nor p15.b, p15/Z, p15.b, p15.b            : nor    %p15/z %p15.b %p15.b -> %p15.b
+
+# NORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (NORS-P.P.PP-Z)
+25c04200 : nors p0.b, p0/Z, p0.b, p0.b               : nors   %p0/z %p0.b %p0.b -> %p0.b
+25c44a61 : nors p1.b, p2/Z, p3.b, p4.b               : nors   %p2/z %p3.b %p4.b -> %p1.b
+25c54e82 : nors p2.b, p3/Z, p4.b, p5.b               : nors   %p3/z %p4.b %p5.b -> %p2.b
+25c652a3 : nors p3.b, p4/Z, p5.b, p6.b               : nors   %p4/z %p5.b %p6.b -> %p3.b
+25c756c4 : nors p4.b, p5/Z, p6.b, p7.b               : nors   %p5/z %p6.b %p7.b -> %p4.b
+25c85ae5 : nors p5.b, p6/Z, p7.b, p8.b               : nors   %p6/z %p7.b %p8.b -> %p5.b
+25c95f06 : nors p6.b, p7/Z, p8.b, p9.b               : nors   %p7/z %p8.b %p9.b -> %p6.b
+25ca6327 : nors p7.b, p8/Z, p9.b, p10.b              : nors   %p8/z %p9.b %p10.b -> %p7.b
+25cb6748 : nors p8.b, p9/Z, p10.b, p11.b             : nors   %p9/z %p10.b %p11.b -> %p8.b
+25cb6748 : nors p8.b, p9/Z, p10.b, p11.b             : nors   %p9/z %p10.b %p11.b -> %p8.b
+25cc6b69 : nors p9.b, p10/Z, p11.b, p12.b            : nors   %p10/z %p11.b %p12.b -> %p9.b
+25cd6f8a : nors p10.b, p11/Z, p12.b, p13.b           : nors   %p11/z %p12.b %p13.b -> %p10.b
+25ce73ab : nors p11.b, p12/Z, p13.b, p14.b           : nors   %p12/z %p13.b %p14.b -> %p11.b
+25cf77cc : nors p12.b, p13/Z, p14.b, p15.b           : nors   %p13/z %p14.b %p15.b -> %p12.b
+25c07bed : nors p13.b, p14/Z, p15.b, p0.b            : nors   %p14/z %p15.b %p0.b -> %p13.b
+25cf7fef : nors p15.b, p15/Z, p15.b, p15.b           : nors   %p15/z %p15.b %p15.b -> %p15.b
+
+# NOT     <Zd>.<T>, <Pg>/M, <Zn>.<T> (NOT-Z.P.Z-_)
+041ea000 : not z0.b, p0/M, z0.b                      : not    %p0/m %z0.b -> %z0.b
+041ea482 : not z2.b, p1/M, z4.b                      : not    %p1/m %z4.b -> %z2.b
+041ea8c4 : not z4.b, p2/M, z6.b                      : not    %p2/m %z6.b -> %z4.b
+041ea906 : not z6.b, p2/M, z8.b                      : not    %p2/m %z8.b -> %z6.b
+041ead48 : not z8.b, p3/M, z10.b                     : not    %p3/m %z10.b -> %z8.b
+041ead8a : not z10.b, p3/M, z12.b                    : not    %p3/m %z12.b -> %z10.b
+041eb1cc : not z12.b, p4/M, z14.b                    : not    %p4/m %z14.b -> %z12.b
+041eb20e : not z14.b, p4/M, z16.b                    : not    %p4/m %z16.b -> %z14.b
+041eb650 : not z16.b, p5/M, z18.b                    : not    %p5/m %z18.b -> %z16.b
+041eb671 : not z17.b, p5/M, z19.b                    : not    %p5/m %z19.b -> %z17.b
+041eb6b3 : not z19.b, p5/M, z21.b                    : not    %p5/m %z21.b -> %z19.b
+041ebaf5 : not z21.b, p6/M, z23.b                    : not    %p6/m %z23.b -> %z21.b
+041ebb37 : not z23.b, p6/M, z25.b                    : not    %p6/m %z25.b -> %z23.b
+041ebf79 : not z25.b, p7/M, z27.b                    : not    %p7/m %z27.b -> %z25.b
+041ebfbb : not z27.b, p7/M, z29.b                    : not    %p7/m %z29.b -> %z27.b
+041ebfff : not z31.b, p7/M, z31.b                    : not    %p7/m %z31.b -> %z31.b
+045ea000 : not z0.h, p0/M, z0.h                      : not    %p0/m %z0.h -> %z0.h
+045ea482 : not z2.h, p1/M, z4.h                      : not    %p1/m %z4.h -> %z2.h
+045ea8c4 : not z4.h, p2/M, z6.h                      : not    %p2/m %z6.h -> %z4.h
+045ea906 : not z6.h, p2/M, z8.h                      : not    %p2/m %z8.h -> %z6.h
+045ead48 : not z8.h, p3/M, z10.h                     : not    %p3/m %z10.h -> %z8.h
+045ead8a : not z10.h, p3/M, z12.h                    : not    %p3/m %z12.h -> %z10.h
+045eb1cc : not z12.h, p4/M, z14.h                    : not    %p4/m %z14.h -> %z12.h
+045eb20e : not z14.h, p4/M, z16.h                    : not    %p4/m %z16.h -> %z14.h
+045eb650 : not z16.h, p5/M, z18.h                    : not    %p5/m %z18.h -> %z16.h
+045eb671 : not z17.h, p5/M, z19.h                    : not    %p5/m %z19.h -> %z17.h
+045eb6b3 : not z19.h, p5/M, z21.h                    : not    %p5/m %z21.h -> %z19.h
+045ebaf5 : not z21.h, p6/M, z23.h                    : not    %p6/m %z23.h -> %z21.h
+045ebb37 : not z23.h, p6/M, z25.h                    : not    %p6/m %z25.h -> %z23.h
+045ebf79 : not z25.h, p7/M, z27.h                    : not    %p7/m %z27.h -> %z25.h
+045ebfbb : not z27.h, p7/M, z29.h                    : not    %p7/m %z29.h -> %z27.h
+045ebfff : not z31.h, p7/M, z31.h                    : not    %p7/m %z31.h -> %z31.h
+049ea000 : not z0.s, p0/M, z0.s                      : not    %p0/m %z0.s -> %z0.s
+049ea482 : not z2.s, p1/M, z4.s                      : not    %p1/m %z4.s -> %z2.s
+049ea8c4 : not z4.s, p2/M, z6.s                      : not    %p2/m %z6.s -> %z4.s
+049ea906 : not z6.s, p2/M, z8.s                      : not    %p2/m %z8.s -> %z6.s
+049ead48 : not z8.s, p3/M, z10.s                     : not    %p3/m %z10.s -> %z8.s
+049ead8a : not z10.s, p3/M, z12.s                    : not    %p3/m %z12.s -> %z10.s
+049eb1cc : not z12.s, p4/M, z14.s                    : not    %p4/m %z14.s -> %z12.s
+049eb20e : not z14.s, p4/M, z16.s                    : not    %p4/m %z16.s -> %z14.s
+049eb650 : not z16.s, p5/M, z18.s                    : not    %p5/m %z18.s -> %z16.s
+049eb671 : not z17.s, p5/M, z19.s                    : not    %p5/m %z19.s -> %z17.s
+049eb6b3 : not z19.s, p5/M, z21.s                    : not    %p5/m %z21.s -> %z19.s
+049ebaf5 : not z21.s, p6/M, z23.s                    : not    %p6/m %z23.s -> %z21.s
+049ebb37 : not z23.s, p6/M, z25.s                    : not    %p6/m %z25.s -> %z23.s
+049ebf79 : not z25.s, p7/M, z27.s                    : not    %p7/m %z27.s -> %z25.s
+049ebfbb : not z27.s, p7/M, z29.s                    : not    %p7/m %z29.s -> %z27.s
+049ebfff : not z31.s, p7/M, z31.s                    : not    %p7/m %z31.s -> %z31.s
+04dea000 : not z0.d, p0/M, z0.d                      : not    %p0/m %z0.d -> %z0.d
+04dea482 : not z2.d, p1/M, z4.d                      : not    %p1/m %z4.d -> %z2.d
+04dea8c4 : not z4.d, p2/M, z6.d                      : not    %p2/m %z6.d -> %z4.d
+04dea906 : not z6.d, p2/M, z8.d                      : not    %p2/m %z8.d -> %z6.d
+04dead48 : not z8.d, p3/M, z10.d                     : not    %p3/m %z10.d -> %z8.d
+04dead8a : not z10.d, p3/M, z12.d                    : not    %p3/m %z12.d -> %z10.d
+04deb1cc : not z12.d, p4/M, z14.d                    : not    %p4/m %z14.d -> %z12.d
+04deb20e : not z14.d, p4/M, z16.d                    : not    %p4/m %z16.d -> %z14.d
+04deb650 : not z16.d, p5/M, z18.d                    : not    %p5/m %z18.d -> %z16.d
+04deb671 : not z17.d, p5/M, z19.d                    : not    %p5/m %z19.d -> %z17.d
+04deb6b3 : not z19.d, p5/M, z21.d                    : not    %p5/m %z21.d -> %z19.d
+04debaf5 : not z21.d, p6/M, z23.d                    : not    %p6/m %z23.d -> %z21.d
+04debb37 : not z23.d, p6/M, z25.d                    : not    %p6/m %z25.d -> %z23.d
+04debf79 : not z25.d, p7/M, z27.d                    : not    %p7/m %z27.d -> %z25.d
+04debfbb : not z27.d, p7/M, z29.d                    : not    %p7/m %z29.d -> %z27.d
+04debfff : not z31.d, p7/M, z31.d                    : not    %p7/m %z31.d -> %z31.d
+
+# ORN     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (ORN-P.P.PP-Z)
+25804010 : orn p0.b, p0/Z, p0.b, p0.b                : orn    %p0/z %p0.b %p0.b -> %p0.b
+25844871 : orn p1.b, p2/Z, p3.b, p4.b                : orn    %p2/z %p3.b %p4.b -> %p1.b
+25854c92 : orn p2.b, p3/Z, p4.b, p5.b                : orn    %p3/z %p4.b %p5.b -> %p2.b
+258650b3 : orn p3.b, p4/Z, p5.b, p6.b                : orn    %p4/z %p5.b %p6.b -> %p3.b
+258754d4 : orn p4.b, p5/Z, p6.b, p7.b                : orn    %p5/z %p6.b %p7.b -> %p4.b
+258858f5 : orn p5.b, p6/Z, p7.b, p8.b                : orn    %p6/z %p7.b %p8.b -> %p5.b
+25895d16 : orn p6.b, p7/Z, p8.b, p9.b                : orn    %p7/z %p8.b %p9.b -> %p6.b
+258a6137 : orn p7.b, p8/Z, p9.b, p10.b               : orn    %p8/z %p9.b %p10.b -> %p7.b
+258b6558 : orn p8.b, p9/Z, p10.b, p11.b              : orn    %p9/z %p10.b %p11.b -> %p8.b
+258b6558 : orn p8.b, p9/Z, p10.b, p11.b              : orn    %p9/z %p10.b %p11.b -> %p8.b
+258c6979 : orn p9.b, p10/Z, p11.b, p12.b             : orn    %p10/z %p11.b %p12.b -> %p9.b
+258d6d9a : orn p10.b, p11/Z, p12.b, p13.b            : orn    %p11/z %p12.b %p13.b -> %p10.b
+258e71bb : orn p11.b, p12/Z, p13.b, p14.b            : orn    %p12/z %p13.b %p14.b -> %p11.b
+258f75dc : orn p12.b, p13/Z, p14.b, p15.b            : orn    %p13/z %p14.b %p15.b -> %p12.b
+258079fd : orn p13.b, p14/Z, p15.b, p0.b             : orn    %p14/z %p15.b %p0.b -> %p13.b
+258f7dff : orn p15.b, p15/Z, p15.b, p15.b            : orn    %p15/z %p15.b %p15.b -> %p15.b
+
+# ORNS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (ORNS-P.P.PP-Z)
+25c04010 : orns p0.b, p0/Z, p0.b, p0.b               : orns   %p0/z %p0.b %p0.b -> %p0.b
+25c44871 : orns p1.b, p2/Z, p3.b, p4.b               : orns   %p2/z %p3.b %p4.b -> %p1.b
+25c54c92 : orns p2.b, p3/Z, p4.b, p5.b               : orns   %p3/z %p4.b %p5.b -> %p2.b
+25c650b3 : orns p3.b, p4/Z, p5.b, p6.b               : orns   %p4/z %p5.b %p6.b -> %p3.b
+25c754d4 : orns p4.b, p5/Z, p6.b, p7.b               : orns   %p5/z %p6.b %p7.b -> %p4.b
+25c858f5 : orns p5.b, p6/Z, p7.b, p8.b               : orns   %p6/z %p7.b %p8.b -> %p5.b
+25c95d16 : orns p6.b, p7/Z, p8.b, p9.b               : orns   %p7/z %p8.b %p9.b -> %p6.b
+25ca6137 : orns p7.b, p8/Z, p9.b, p10.b              : orns   %p8/z %p9.b %p10.b -> %p7.b
+25cb6558 : orns p8.b, p9/Z, p10.b, p11.b             : orns   %p9/z %p10.b %p11.b -> %p8.b
+25cb6558 : orns p8.b, p9/Z, p10.b, p11.b             : orns   %p9/z %p10.b %p11.b -> %p8.b
+25cc6979 : orns p9.b, p10/Z, p11.b, p12.b            : orns   %p10/z %p11.b %p12.b -> %p9.b
+25cd6d9a : orns p10.b, p11/Z, p12.b, p13.b           : orns   %p11/z %p12.b %p13.b -> %p10.b
+25ce71bb : orns p11.b, p12/Z, p13.b, p14.b           : orns   %p12/z %p13.b %p14.b -> %p11.b
+25cf75dc : orns p12.b, p13/Z, p14.b, p15.b           : orns   %p13/z %p14.b %p15.b -> %p12.b
+25c079fd : orns p13.b, p14/Z, p15.b, p0.b            : orns   %p14/z %p15.b %p0.b -> %p13.b
+25cf7dff : orns p15.b, p15/Z, p15.b, p15.b           : orns   %p15/z %p15.b %p15.b -> %p15.b
 
 04181da2 : orr z2.b, p7/m, z2.b, z13.b              : orr    %p7 %z2 %z13 $0x00 -> %z2
 04581da2 : orr z2.h, p7/m, z2.h, z13.h              : orr    %p7 %z2 %z13 $0x01 -> %z2
@@ -3900,6 +4236,60 @@
 0503f07a : orr z26.d, z26.d, #0x3c                  : orr    %z26.d $0x000000000000003c -> %z26.d
 0503e85c : orr z28.d, z28.d, #0x38                  : orr    %z28.d $0x0000000000000038 -> %z28.d
 0503e03f : orr z31.d, z31.d, #0x30                  : orr    %z31.d $0x0000000000000030 -> %z31.d
+
+# ORR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (ORR-P.P.PP-Z)
+25804000 : orr p0.b, p0/Z, p0.b, p0.b                : orr    %p0/z %p0.b %p0.b -> %p0.b
+25844861 : orr p1.b, p2/Z, p3.b, p4.b                : orr    %p2/z %p3.b %p4.b -> %p1.b
+25854c82 : orr p2.b, p3/Z, p4.b, p5.b                : orr    %p3/z %p4.b %p5.b -> %p2.b
+258650a3 : orr p3.b, p4/Z, p5.b, p6.b                : orr    %p4/z %p5.b %p6.b -> %p3.b
+258754c4 : orr p4.b, p5/Z, p6.b, p7.b                : orr    %p5/z %p6.b %p7.b -> %p4.b
+258858e5 : orr p5.b, p6/Z, p7.b, p8.b                : orr    %p6/z %p7.b %p8.b -> %p5.b
+25895d06 : orr p6.b, p7/Z, p8.b, p9.b                : orr    %p7/z %p8.b %p9.b -> %p6.b
+258a6127 : orr p7.b, p8/Z, p9.b, p10.b               : orr    %p8/z %p9.b %p10.b -> %p7.b
+258b6548 : orr p8.b, p9/Z, p10.b, p11.b              : orr    %p9/z %p10.b %p11.b -> %p8.b
+258b6548 : orr p8.b, p9/Z, p10.b, p11.b              : orr    %p9/z %p10.b %p11.b -> %p8.b
+258c6969 : orr p9.b, p10/Z, p11.b, p12.b             : orr    %p10/z %p11.b %p12.b -> %p9.b
+258d6d8a : orr p10.b, p11/Z, p12.b, p13.b            : orr    %p11/z %p12.b %p13.b -> %p10.b
+258e71ab : orr p11.b, p12/Z, p13.b, p14.b            : orr    %p12/z %p13.b %p14.b -> %p11.b
+258f75cc : orr p12.b, p13/Z, p14.b, p15.b            : orr    %p13/z %p14.b %p15.b -> %p12.b
+258079ed : orr p13.b, p14/Z, p15.b, p0.b             : orr    %p14/z %p15.b %p0.b -> %p13.b
+258f7def : orr p15.b, p15/Z, p15.b, p15.b            : orr    %p15/z %p15.b %p15.b -> %p15.b
+
+# ORR     <Zd>.D, <Zn>.D, <Zm>.D (ORR-Z.ZZ-_)
+04603000 : orr z0.d, z0.d, z0.d                      : orr    %z0.d %z0.d -> %z0.d
+04643062 : orr z2.d, z3.d, z4.d                      : orr    %z3.d %z4.d -> %z2.d
+046630a4 : orr z4.d, z5.d, z6.d                      : orr    %z5.d %z6.d -> %z4.d
+046830e6 : orr z6.d, z7.d, z8.d                      : orr    %z7.d %z8.d -> %z6.d
+046a3128 : orr z8.d, z9.d, z10.d                     : orr    %z9.d %z10.d -> %z8.d
+046c316a : orr z10.d, z11.d, z12.d                   : orr    %z11.d %z12.d -> %z10.d
+046e31ac : orr z12.d, z13.d, z14.d                   : orr    %z13.d %z14.d -> %z12.d
+047031ee : orr z14.d, z15.d, z16.d                   : orr    %z15.d %z16.d -> %z14.d
+04723230 : orr z16.d, z17.d, z18.d                   : orr    %z17.d %z18.d -> %z16.d
+04733251 : orr z17.d, z18.d, z19.d                   : orr    %z18.d %z19.d -> %z17.d
+04753293 : orr z19.d, z20.d, z21.d                   : orr    %z20.d %z21.d -> %z19.d
+047732d5 : orr z21.d, z22.d, z23.d                   : orr    %z22.d %z23.d -> %z21.d
+04793317 : orr z23.d, z24.d, z25.d                   : orr    %z24.d %z25.d -> %z23.d
+047b3359 : orr z25.d, z26.d, z27.d                   : orr    %z26.d %z27.d -> %z25.d
+047d339b : orr z27.d, z28.d, z29.d                   : orr    %z28.d %z29.d -> %z27.d
+047f33ff : orr z31.d, z31.d, z31.d                   : orr    %z31.d %z31.d -> %z31.d
+
+# ORRS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B (ORRS-P.P.PP-Z)
+25c04000 : orrs p0.b, p0/Z, p0.b, p0.b               : orrs   %p0/z %p0.b %p0.b -> %p0.b
+25c44861 : orrs p1.b, p2/Z, p3.b, p4.b               : orrs   %p2/z %p3.b %p4.b -> %p1.b
+25c54c82 : orrs p2.b, p3/Z, p4.b, p5.b               : orrs   %p3/z %p4.b %p5.b -> %p2.b
+25c650a3 : orrs p3.b, p4/Z, p5.b, p6.b               : orrs   %p4/z %p5.b %p6.b -> %p3.b
+25c754c4 : orrs p4.b, p5/Z, p6.b, p7.b               : orrs   %p5/z %p6.b %p7.b -> %p4.b
+25c858e5 : orrs p5.b, p6/Z, p7.b, p8.b               : orrs   %p6/z %p7.b %p8.b -> %p5.b
+25c95d06 : orrs p6.b, p7/Z, p8.b, p9.b               : orrs   %p7/z %p8.b %p9.b -> %p6.b
+25ca6127 : orrs p7.b, p8/Z, p9.b, p10.b              : orrs   %p8/z %p9.b %p10.b -> %p7.b
+25cb6548 : orrs p8.b, p9/Z, p10.b, p11.b             : orrs   %p9/z %p10.b %p11.b -> %p8.b
+25cb6548 : orrs p8.b, p9/Z, p10.b, p11.b             : orrs   %p9/z %p10.b %p11.b -> %p8.b
+25cc6969 : orrs p9.b, p10/Z, p11.b, p12.b            : orrs   %p10/z %p11.b %p12.b -> %p9.b
+25cd6d8a : orrs p10.b, p11/Z, p12.b, p13.b           : orrs   %p11/z %p12.b %p13.b -> %p10.b
+25ce71ab : orrs p11.b, p12/Z, p13.b, p14.b           : orrs   %p12/z %p13.b %p14.b -> %p11.b
+25cf75cc : orrs p12.b, p13/Z, p14.b, p15.b           : orrs   %p13/z %p14.b %p15.b -> %p12.b
+25c079ed : orrs p13.b, p14/Z, p15.b, p0.b            : orrs   %p14/z %p15.b %p0.b -> %p13.b
+25cf7def : orrs p15.b, p15/Z, p15.b, p15.b           : orrs   %p15/z %p15.b %p15.b -> %p15.b
 
 # PTEST   <Pg>, <Pn>.B (PTEST-.P.P-_)
 2550c000 : ptest p0, p0.b                            : ptest  %p0 %p0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -4988,6 +4988,363 @@ TEST_INSTR(orn_sve_imm)
               opnd_create_immed_int(imm13[i], OPSZ_8));
 }
 
+TEST_INSTR(and_sve_pred_b)
+{
+
+    /* Testing AND     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "and    %p0/z %p0.b %p0.b -> %p0.b",     "and    %p3/z %p4.b %p5.b -> %p2.b",
+        "and    %p6/z %p7.b %p8.b -> %p5.b",     "and    %p9/z %p10.b %p11.b -> %p8.b",
+        "and    %p11/z %p12.b %p13.b -> %p10.b", "and    %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(and, and_sve_pred_b, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(and_sve)
+{
+
+    /* Testing AND     <Zd>.D, <Zn>.D, <Zm>.D */
+    const char *expected_0_0[6] = {
+        "and    %z0.d %z0.d -> %z0.d",    "and    %z6.d %z7.d -> %z5.d",
+        "and    %z11.d %z12.d -> %z10.d", "and    %z17.d %z18.d -> %z16.d",
+        "and    %z22.d %z23.d -> %z21.d", "and    %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(and, and_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(ands_sve_pred)
+{
+
+    /* Testing ANDS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "ands   %p0/z %p0.b %p0.b -> %p0.b",     "ands   %p3/z %p4.b %p5.b -> %p2.b",
+        "ands   %p6/z %p7.b %p8.b -> %p5.b",     "ands   %p9/z %p10.b %p11.b -> %p8.b",
+        "ands   %p11/z %p12.b %p13.b -> %p10.b", "ands   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(ands, ands_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(bic_sve_pred_b)
+{
+
+    /* Testing BIC     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "bic    %p0/z %p0.b %p0.b -> %p0.b",     "bic    %p3/z %p4.b %p5.b -> %p2.b",
+        "bic    %p6/z %p7.b %p8.b -> %p5.b",     "bic    %p9/z %p10.b %p11.b -> %p8.b",
+        "bic    %p11/z %p12.b %p13.b -> %p10.b", "bic    %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(bic, bic_sve_pred_b, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(bic_sve)
+{
+
+    /* Testing BIC     <Zd>.D, <Zn>.D, <Zm>.D */
+    const char *expected_0_0[6] = {
+        "bic    %z0.d %z0.d -> %z0.d",    "bic    %z6.d %z7.d -> %z5.d",
+        "bic    %z11.d %z12.d -> %z10.d", "bic    %z17.d %z18.d -> %z16.d",
+        "bic    %z22.d %z23.d -> %z21.d", "bic    %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(bic, bic_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(bics_sve_pred)
+{
+
+    /* Testing BICS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "bics   %p0/z %p0.b %p0.b -> %p0.b",     "bics   %p3/z %p4.b %p5.b -> %p2.b",
+        "bics   %p6/z %p7.b %p8.b -> %p5.b",     "bics   %p9/z %p10.b %p11.b -> %p8.b",
+        "bics   %p11/z %p12.b %p13.b -> %p10.b", "bics   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(bics, bics_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(eor_sve_pred_b)
+{
+
+    /* Testing EOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "eor    %p0/z %p0.b %p0.b -> %p0.b",     "eor    %p3/z %p4.b %p5.b -> %p2.b",
+        "eor    %p6/z %p7.b %p8.b -> %p5.b",     "eor    %p9/z %p10.b %p11.b -> %p8.b",
+        "eor    %p11/z %p12.b %p13.b -> %p10.b", "eor    %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(eor, eor_sve_pred_b, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(eor_sve)
+{
+
+    /* Testing EOR     <Zd>.D, <Zn>.D, <Zm>.D */
+    const char *expected_0_0[6] = {
+        "eor    %z0.d %z0.d -> %z0.d",    "eor    %z6.d %z7.d -> %z5.d",
+        "eor    %z11.d %z12.d -> %z10.d", "eor    %z17.d %z18.d -> %z16.d",
+        "eor    %z22.d %z23.d -> %z21.d", "eor    %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(eor, eor_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(eors_sve_pred)
+{
+
+    /* Testing EORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "eors   %p0/z %p0.b %p0.b -> %p0.b",     "eors   %p3/z %p4.b %p5.b -> %p2.b",
+        "eors   %p6/z %p7.b %p8.b -> %p5.b",     "eors   %p9/z %p10.b %p11.b -> %p8.b",
+        "eors   %p11/z %p12.b %p13.b -> %p10.b", "eors   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(eors, eors_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(nand_sve_pred)
+{
+
+    /* Testing NAND    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "nand   %p0/z %p0.b %p0.b -> %p0.b",     "nand   %p3/z %p4.b %p5.b -> %p2.b",
+        "nand   %p6/z %p7.b %p8.b -> %p5.b",     "nand   %p9/z %p10.b %p11.b -> %p8.b",
+        "nand   %p11/z %p12.b %p13.b -> %p10.b", "nand   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(nand, nand_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(nands_sve_pred)
+{
+
+    /* Testing NANDS   <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "nands  %p0/z %p0.b %p0.b -> %p0.b",     "nands  %p3/z %p4.b %p5.b -> %p2.b",
+        "nands  %p6/z %p7.b %p8.b -> %p5.b",     "nands  %p9/z %p10.b %p11.b -> %p8.b",
+        "nands  %p11/z %p12.b %p13.b -> %p10.b", "nands  %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(nands, nands_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(nor_sve_pred)
+{
+
+    /* Testing NOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "nor    %p0/z %p0.b %p0.b -> %p0.b",     "nor    %p3/z %p4.b %p5.b -> %p2.b",
+        "nor    %p6/z %p7.b %p8.b -> %p5.b",     "nor    %p9/z %p10.b %p11.b -> %p8.b",
+        "nor    %p11/z %p12.b %p13.b -> %p10.b", "nor    %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(nor, nor_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(nors_sve_pred)
+{
+
+    /* Testing NORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "nors   %p0/z %p0.b %p0.b -> %p0.b",     "nors   %p3/z %p4.b %p5.b -> %p2.b",
+        "nors   %p6/z %p7.b %p8.b -> %p5.b",     "nors   %p9/z %p10.b %p11.b -> %p8.b",
+        "nors   %p11/z %p12.b %p13.b -> %p10.b", "nors   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(nors, nors_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(not_sve_pred_vec)
+{
+
+    /* Testing NOT     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
+    const char *expected_0_0[6] = {
+        "not    %p0/m %z0.b -> %z0.b",   "not    %p2/m %z7.b -> %z5.b",
+        "not    %p3/m %z12.b -> %z10.b", "not    %p5/m %z18.b -> %z16.b",
+        "not    %p6/m %z23.b -> %z21.b", "not    %p7/m %z31.b -> %z31.b",
+    };
+    TEST_LOOP(not, not_sve_pred_vec, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *expected_0_1[6] = {
+        "not    %p0/m %z0.h -> %z0.h",   "not    %p2/m %z7.h -> %z5.h",
+        "not    %p3/m %z12.h -> %z10.h", "not    %p5/m %z18.h -> %z16.h",
+        "not    %p6/m %z23.h -> %z21.h", "not    %p7/m %z31.h -> %z31.h",
+    };
+    TEST_LOOP(not, not_sve_pred_vec, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *expected_0_2[6] = {
+        "not    %p0/m %z0.s -> %z0.s",   "not    %p2/m %z7.s -> %z5.s",
+        "not    %p3/m %z12.s -> %z10.s", "not    %p5/m %z18.s -> %z16.s",
+        "not    %p6/m %z23.s -> %z21.s", "not    %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(not, not_sve_pred_vec, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *expected_0_3[6] = {
+        "not    %p0/m %z0.d -> %z0.d",   "not    %p2/m %z7.d -> %z5.d",
+        "not    %p3/m %z12.d -> %z10.d", "not    %p5/m %z18.d -> %z16.d",
+        "not    %p6/m %z23.d -> %z21.d", "not    %p7/m %z31.d -> %z31.d",
+    };
+    TEST_LOOP(not, not_sve_pred_vec, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(orn_sve_pred)
+{
+
+    /* Testing ORN     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "orn    %p0/z %p0.b %p0.b -> %p0.b",     "orn    %p3/z %p4.b %p5.b -> %p2.b",
+        "orn    %p6/z %p7.b %p8.b -> %p5.b",     "orn    %p9/z %p10.b %p11.b -> %p8.b",
+        "orn    %p11/z %p12.b %p13.b -> %p10.b", "orn    %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(orn, orn_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(orns_sve_pred)
+{
+
+    /* Testing ORNS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "orns   %p0/z %p0.b %p0.b -> %p0.b",     "orns   %p3/z %p4.b %p5.b -> %p2.b",
+        "orns   %p6/z %p7.b %p8.b -> %p5.b",     "orns   %p9/z %p10.b %p11.b -> %p8.b",
+        "orns   %p11/z %p12.b %p13.b -> %p10.b", "orns   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(orns, orns_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(orr_sve_pred_b)
+{
+
+    /* Testing ORR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "orr    %p0/z %p0.b %p0.b -> %p0.b",     "orr    %p3/z %p4.b %p5.b -> %p2.b",
+        "orr    %p6/z %p7.b %p8.b -> %p5.b",     "orr    %p9/z %p10.b %p11.b -> %p8.b",
+        "orr    %p11/z %p12.b %p13.b -> %p10.b", "orr    %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(orr, orr_sve_pred_b, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(orr_sve)
+{
+
+    /* Testing ORR     <Zd>.D, <Zn>.D, <Zm>.D */
+    const char *expected_0_0[6] = {
+        "orr    %z0.d %z0.d -> %z0.d",    "orr    %z6.d %z7.d -> %z5.d",
+        "orr    %z11.d %z12.d -> %z10.d", "orr    %z17.d %z18.d -> %z16.d",
+        "orr    %z22.d %z23.d -> %z21.d", "orr    %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(orr, orr_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(orrs_sve_pred)
+{
+
+    /* Testing ORRS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B */
+    reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                           DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *expected_0_0[6] = {
+        "orrs   %p0/z %p0.b %p0.b -> %p0.b",     "orrs   %p3/z %p4.b %p5.b -> %p2.b",
+        "orrs   %p6/z %p7.b %p8.b -> %p5.b",     "orrs   %p9/z %p10.b %p11.b -> %p8.b",
+        "orrs   %p11/z %p12.b %p13.b -> %p10.b", "orrs   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(orrs, orrs_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -5126,6 +5483,26 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(eor_sve_imm);
     RUN_INSTR_TEST(orr_sve_imm);
     RUN_INSTR_TEST(orn_sve_imm);
+
+    RUN_INSTR_TEST(and_sve_pred_b);
+    RUN_INSTR_TEST(and_sve);
+    RUN_INSTR_TEST(ands_sve_pred);
+    RUN_INSTR_TEST(bic_sve_pred_b);
+    RUN_INSTR_TEST(bic_sve);
+    RUN_INSTR_TEST(bics_sve_pred);
+    RUN_INSTR_TEST(eor_sve_pred_b);
+    RUN_INSTR_TEST(eor_sve);
+    RUN_INSTR_TEST(eors_sve_pred);
+    RUN_INSTR_TEST(nand_sve_pred);
+    RUN_INSTR_TEST(nands_sve_pred);
+    RUN_INSTR_TEST(nor_sve_pred);
+    RUN_INSTR_TEST(nors_sve_pred);
+    RUN_INSTR_TEST(not_sve_pred_vec);
+    RUN_INSTR_TEST(orn_sve_pred);
+    RUN_INSTR_TEST(orns_sve_pred);
+    RUN_INSTR_TEST(orr_sve_pred_b);
+    RUN_INSTR_TEST(orr_sve);
+    RUN_INSTR_TEST(orrs_sve_pred);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
AND     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
AND     <Zd>.D, <Zn>.D, <Zm>.D
ANDS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
BIC     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
BIC     <Zd>.D, <Zn>.D, <Zm>.D
BICS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
EOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
EOR     <Zd>.D, <Zn>.D, <Zm>.D
EORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
NAND    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
NANDS   <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
NOR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
NORS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
NOT     <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
ORN     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
ORNS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
ORR     <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
ORR     <Zd>.D, <Zn>.D, <Zm>.D
ORRS    <Pd>.B, <Pg>/Z, <Pn>.B, <Pm>.B
```
Issue #3044