### PR TITLE
i#5733, i#5734: Minor fixes in tests

### DIFF
--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -128,9 +128,9 @@ public:
 /**
  * Implementation of memtrace_stream_t useful for mocks in tests.
  */
-class test_memtrace_stream_t : public memtrace_stream_t {
+class default_memtrace_stream_t : public memtrace_stream_t {
 public:
-    virtual ~test_memtrace_stream_t()
+    virtual ~default_memtrace_stream_t()
     {
     }
     uint64_t

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -130,15 +130,15 @@ public:
  */
 class default_memtrace_stream_t : public memtrace_stream_t {
 public:
-    virtual ~default_memtrace_stream_t()
-    {
-    }
     default_memtrace_stream_t()
         : record_ordinal_(nullptr)
     {
     }
     default_memtrace_stream_t(uint64_t *record_ordinal)
         : record_ordinal_(record_ordinal)
+    {
+    }
+    virtual ~default_memtrace_stream_t()
     {
     }
     uint64_t

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -133,10 +133,20 @@ public:
     virtual ~default_memtrace_stream_t()
     {
     }
+    default_memtrace_stream_t()
+        : record_ordinal_(nullptr)
+    {
+    }
+    default_memtrace_stream_t(uint64_t *record_ordinal)
+        : record_ordinal_(record_ordinal)
+    {
+    }
     uint64_t
     get_record_ordinal() const override
     {
-        return 0;
+        if (record_ordinal_ == nullptr)
+            return 0;
+        return *record_ordinal_;
     }
     uint64_t
     get_instruction_ordinal() const override
@@ -178,5 +188,8 @@ public:
     {
         return 0;
     }
+
+private:
+    uint64_t *record_ordinal_;
 };
 #endif /* _MEMTRACE_STREAM_H_ */

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -102,7 +102,7 @@ private:
     std::vector<trace_entry_t> output;
 };
 
-class local_stream_t : public test_memtrace_stream_t {
+class local_stream_t : public default_memtrace_stream_t {
 public:
     uint64_t
     get_last_timestamp() const override

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -120,7 +120,7 @@ public:
 std::string
 run_test_helper(view_t &view, const std::vector<memref_t> &memrefs)
 {
-    class local_stream_t : public test_memtrace_stream_t {
+    class local_stream_t : public default_memtrace_stream_t {
     public:
         local_stream_t(view_t &view, const std::vector<memref_t> &memrefs)
             : view_(view)

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -549,6 +549,7 @@ invariant_checker_t::check_schedule_data()
     // Check that the scheduling data in the files written by raw2trace match
     // the data in the trace.
     per_shard_t global;
+    // Use a synthetic stream object to allow report_if_false to work normally.
     auto stream = std::unique_ptr<memtrace_stream_t>(new default_memtrace_stream_t());
     global.stream = stream.get();
     std::vector<schedule_entry_t> serial;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -550,7 +550,8 @@ invariant_checker_t::check_schedule_data()
     // the data in the trace.
     per_shard_t global;
     // Use a synthetic stream object to allow report_if_false to work normally.
-    auto stream = std::unique_ptr<memtrace_stream_t>(new default_memtrace_stream_t());
+    auto stream = std::unique_ptr<memtrace_stream_t>(
+        new default_memtrace_stream_t(&global.ref_count_));
     global.stream = stream.get();
     std::vector<schedule_entry_t> serial;
     std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -71,10 +71,11 @@ void
 invariant_checker_t::report_if_false(per_shard_t *shard, bool condition,
                                      const std::string &invariant_name)
 {
+    uint64_t ref_count = shard->stream == nullptr ? shard->ref_count_
+                                                  : shard->stream->get_record_ordinal();
     if (!condition) {
         std::cerr << "Trace invariant failure in T" << shard->tid_ << " at ref # "
-                  << shard->stream->get_record_ordinal() << ": " << invariant_name
-                  << "\n";
+                  << ref_count << ": " << invariant_name << "\n";
         abort();
     }
 }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -71,11 +71,10 @@ void
 invariant_checker_t::report_if_false(per_shard_t *shard, bool condition,
                                      const std::string &invariant_name)
 {
-    uint64_t ref_count = shard->stream == nullptr ? shard->ref_count_
-                                                  : shard->stream->get_record_ordinal();
     if (!condition) {
         std::cerr << "Trace invariant failure in T" << shard->tid_ << " at ref # "
-                  << ref_count << ": " << invariant_name << "\n";
+                  << shard->stream->get_record_ordinal() << ": " << invariant_name
+                  << "\n";
         abort();
     }
 }
@@ -550,6 +549,8 @@ invariant_checker_t::check_schedule_data()
     // Check that the scheduling data in the files written by raw2trace match
     // the data in the trace.
     per_shard_t global;
+    auto stream = std::unique_ptr<memtrace_stream_t>(new default_memtrace_stream_t());
+    global.stream = stream.get();
     std::vector<schedule_entry_t> serial;
     std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
     for (auto &shard_keyval : shard_map_) {

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -1037,7 +1037,8 @@ main()
     if (register_rseq()) {
 #ifdef RSEQ_TEST_ATTACH
         /* Set -offline to avoid trying to open a pipe to a missing reader. */
-        if (setenv("DYNAMORIO_OPTIONS", "-stderr_mask 0xc -client_lib ';;-offline'",
+        if (setenv("DYNAMORIO_OPTIONS",
+                   "-stderr_mask 0xc -client_lib ';;-offline -max_trace_size 256K'",
                    1 /*override*/) != 0)
             return 1;
         /* Create a thread that sits in the rseq region, to test attaching and detaching


### PR DESCRIPTION
Adds -max_trace_size to api.rseq to avoid generating too much trace data,
which may cause us to run out of disk space. The issue on varying run times
(and therefore trace data) is not reproducing now on the Jenkins machine,
but with this change, the trace size comes down to 512K from 130M+ which
is better.

Fixes an issue in the invariant checker that causes a SIGSEGV crash during
error reporting when there's no shard stream available. This came up in the
tool.drcacheoff.rseq test during the `check_schedule_data` checks that
happen at the very end in `print_results` of the invariant checker, where
we do not have the shard stream anymore. The invariant error itself is yet
to be debugged (i#5734).

Issue: #5733, #5734