### PR TITLE
i3044 AArch64 SVE codec: Add TBL, DUP, INSR

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -61,7 +61,7 @@ decode_bitmask(uint enc)
     if (TEST(1U << 12, enc)) {
         if (len == 63)
             return 0;
-        x = ((ptr_uint_t)1 << (len + 1)) - 1;
+        x = MASK(len + 1);
         return x >> pos | x << 1 << (63 - pos);
     } else {
         uint i, t = 32;
@@ -73,7 +73,7 @@ decode_bitmask(uint enc)
         x = len & (t - 1);
         if (x == t - 1)
             return 0;
-        x = ((ptr_uint_t)1 << (x + 1)) - 1;
+        x = MASK(x + 1);
         pos &= t - 1;
         x = x >> pos | x << (t - pos);
         for (i = 2; i < 64; i *= 2) {
@@ -98,34 +98,34 @@ encode_bitmask(ptr_uint_t x)
     if (x == 0)
         return -1;
 
-    if (x >> 2 == (x & (((ptr_uint_t)1 << (64 - 2)) - 1)))
-        rep = 2, x &= ((ptr_uint_t)1 << 2) - 1;
-    else if (x >> 4 == (x & (((ptr_uint_t)1 << (64 - 4)) - 1)))
-        rep = 4, x &= ((ptr_uint_t)1 << 4) - 1;
-    else if (x >> 8 == (x & (((ptr_uint_t)1 << (64 - 8)) - 1)))
-        rep = 8, x &= ((ptr_uint_t)1 << 8) - 1;
-    else if (x >> 16 == (x & (((ptr_uint_t)1 << (64 - 16)) - 1)))
-        rep = 16, x &= ((ptr_uint_t)1 << 16) - 1;
-    else if (x >> 32 == (x & (((ptr_uint_t)1 << (64 - 32)) - 1)))
-        rep = 32, x &= ((ptr_uint_t)1 << 32) - 1;
+    if (x >> 2 == (x & MASK(64 - 2)))
+        rep = 2, x &= MASK(2);
+    else if (x >> 4 == (x & MASK(64 - 4)))
+        rep = 4, x &= MASK(4);
+    else if (x >> 8 == (x & MASK(64 - 8)))
+        rep = 8, x &= MASK(8);
+    else if (x >> 16 == (x & MASK(64 - 16)))
+        rep = 16, x &= MASK(16);
+    else if (x >> 32 == (x & MASK(64 - 32)))
+        rep = 32, x &= MASK(32);
     else
         rep = 64;
 
     pos = 0;
-    (x & (((ptr_uint_t)1 << 32) - 1)) != 0 ? 0 : (x >>= 32, pos += 32);
-    (x & (((ptr_uint_t)1 << 16) - 1)) != 0 ? 0 : (x >>= 16, pos += 16);
-    (x & (((ptr_uint_t)1 << 8) - 1)) != 0 ? 0 : (x >>= 8, pos += 8);
-    (x & (((ptr_uint_t)1 << 4) - 1)) != 0 ? 0 : (x >>= 4, pos += 4);
-    (x & (((ptr_uint_t)1 << 2) - 1)) != 0 ? 0 : (x >>= 2, pos += 2);
-    (x & (((ptr_uint_t)1 << 1) - 1)) != 0 ? 0 : (x >>= 1, pos += 1);
+    (x & MASK(32)) != 0 ? 0 : (x >>= 32, pos += 32);
+    (x & MASK(16)) != 0 ? 0 : (x >>= 16, pos += 16);
+    (x & MASK(8)) != 0 ? 0 : (x >>= 8, pos += 8);
+    (x & MASK(4)) != 0 ? 0 : (x >>= 4, pos += 4);
+    (x & MASK(2)) != 0 ? 0 : (x >>= 2, pos += 2);
+    (x & MASK(1)) != 0 ? 0 : (x >>= 1, pos += 1);
 
     len = 0;
-    (~x & (((ptr_uint_t)1 << 32) - 1)) != 0 ? 0 : (x >>= 32, len += 32);
-    (~x & (((ptr_uint_t)1 << 16) - 1)) != 0 ? 0 : (x >>= 16, len += 16);
-    (~x & (((ptr_uint_t)1 << 8) - 1)) != 0 ? 0 : (x >>= 8, len += 8);
-    (~x & (((ptr_uint_t)1 << 4) - 1)) != 0 ? 0 : (x >>= 4, len += 4);
-    (~x & (((ptr_uint_t)1 << 2) - 1)) != 0 ? 0 : (x >>= 2, len += 2);
-    (~x & (((ptr_uint_t)1 << 1) - 1)) != 0 ? 0 : (x >>= 1, len += 1);
+    (~x & MASK(32)) != 0 ? 0 : (x >>= 32, len += 32);
+    (~x & MASK(16)) != 0 ? 0 : (x >>= 16, len += 16);
+    (~x & MASK(8)) != 0 ? 0 : (x >>= 8, len += 8);
+    (~x & MASK(4)) != 0 ? 0 : (x >>= 4, len += 4);
+    (~x & MASK(2)) != 0 ? 0 : (x >>= 2, len += 2);
+    (~x & MASK(1)) != 0 ? 0 : (x >>= 1, len += 1);
 
     if (x != 0)
         return -1;
@@ -141,8 +141,7 @@ encode_bitmask(ptr_uint_t x)
 static inline ptr_int_t
 extract_int(uint enc, int pos, int len)
 {
-    uint u = ((enc >> pos & (((uint)1 << (len - 1)) - 1)) -
-              (enc >> pos & ((uint)1 << (len - 1))));
+    uint u = ((enc >> pos & MASK(len - 1)) - (enc >> pos & ((uint)1 << (len - 1))));
     return u << 1 < u ? -(ptr_int_t)~u - 1 : u;
 }
 
@@ -151,7 +150,7 @@ static inline ptr_uint_t
 extract_uint(uint enc, int pos, int len)
 {
     /* pos starts at bit 0 and len includes pos bit as part of its length. */
-    return enc >> pos & (((uint)1 << len) - 1);
+    return enc >> pos & MASK(len);
 }
 
 /* Find the highest bit set in subfield, relative to the starting position. */
@@ -201,11 +200,10 @@ static inline bool
 try_encode_int(OUT uint *bits, int len, int scale, ptr_int_t val)
 {
     /* If any of lowest 'scale' bits are set, or 'val' is out of range, fail. */
-    const ptr_int_t range_val = ((ptr_int_t)1 << (len + scale)) - 1;
-    if (((ptr_uint_t)val & ((1U << scale) - 1)) != 0 || val < -range_val ||
-        val >= range_val)
+    const ptr_int_t range_val = MASK(len + scale);
+    if (((ptr_uint_t)val & MASK(scale)) != 0 || val < -range_val || val >= range_val)
         return false;
-    *bits = (ptr_uint_t)val >> scale & ((1U << len) - 1);
+    *bits = (ptr_uint_t)val >> scale & MASK(len);
     return true;
 }
 
@@ -724,6 +722,24 @@ extract_imm13_size(uint enc)
     }
 }
 
+/* Extracts the operand size from a tsz field */
+static opnd_size_t
+extract_tsz_size(uint enc)
+{
+    int lbs;
+    if (!lowest_bit_set(enc, 16, 5, &lbs))
+        return OPSZ_NA;
+
+    switch (lbs) {
+    case 0: return OPSZ_1;
+    case 1: return OPSZ_2;
+    case 2: return OPSZ_4;
+    case 3: return OPSZ_8;
+    case 4: return OPSZ_16;
+    default: return OPSZ_NA;
+    }
+}
+
 /*******************************************************************************
  * Pairs of functions for decoding and encoding a generalised type of operand.
  */
@@ -861,7 +877,7 @@ encode_opnd_int(int pos, int len, bool signd, int scale, dr_opnd_flags_t flags,
     if (!opnd_is_immed_int(opnd) || (opnd_get_flags(opnd) & flags) != flags)
         return false;
     val = opnd_get_immed_int(opnd);
-    if ((val & (((ptr_uint_t)1 << scale) - 1)) != 0)
+    if ((val & MASK(scale)) != 0)
         return false;
     if ((val + (signd ? ((ptr_uint_t)1 << (len + scale - 1)) : 0)) >> (len + scale) != 0)
         return false;
@@ -958,7 +974,7 @@ encode_opnd_mem7_postindex(bool post, uint enc, opnd_t opnd, OUT uint *enc_out)
     if (disp == 0 && opnd.value.base_disp.pre_index == post)
         return false;
     if (post ? disp != 0
-             : ((uint)disp & ((1 << scale) - 1)) != 0 ||
+             : ((uint)disp & MASK(scale)) != 0 ||
                 (uint)disp + (0x40 << scale) >= (0x80 << scale))
         return false;
     *enc_out = xn << 5 | ((uint)disp >> scale & 0x7f) << 15;
@@ -2802,7 +2818,7 @@ encode_opnd_imm13_const(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *e
         return false;
 
     if (width != 64) {
-        const ptr_uint_t subfield = imm_val & (((ptr_uint_t)1 << width) - 1);
+        const ptr_uint_t subfield = imm_val & MASK(width);
         for (int i = 0; i < 64; i += width) {
             imm_val <<= width;
             imm_val |= subfield;
@@ -3297,6 +3313,58 @@ encode_opnd_bhsd_imm5_sz(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *
     return imm5_sz_encode(VECTOR_ELEM_WIDTH_DOUBLE, false, opnd, enc_out);
 }
 
+static inline bool
+decode_z_tsz_bhsdq_base(uint enc, uint pos, OUT opnd_t *opnd)
+{
+    const opnd_size_t size = extract_tsz_size(enc);
+    if (size == OPSZ_NA)
+        return false;
+
+    *opnd = opnd_create_reg_element_vector(DR_REG_Z0 + extract_uint(enc, pos, 5), size);
+    return true;
+}
+
+static inline bool
+encode_z_tsz_bhsdq_base(opnd_t opnd, uint pos, OUT uint *enc_out)
+{
+    if (!opnd_is_element_vector_reg(opnd))
+        return false;
+
+    opnd_size_t vec_size = OPSZ_SCALABLE;
+    uint reg_number;
+    if (!encode_vreg(&vec_size, &reg_number, opnd))
+        return false;
+
+    *enc_out |= reg_number << pos;
+    return true;
+}
+
+/* z_tsz_bhsdq_0: Z register with size encoded in tsz field */
+static inline bool
+decode_opnd_z_tsz_bhsdq_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_z_tsz_bhsdq_base(enc, 0, opnd);
+}
+
+static inline bool
+encode_opnd_z_tsz_bhsdq_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_z_tsz_bhsdq_base(opnd, 0, enc_out);
+}
+
+/* z_tsz_bhsdq_5: Z register with size encoded in tsz field */
+static inline bool
+decode_opnd_z_tsz_bhsdq_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_z_tsz_bhsdq_base(enc, 5, opnd);
+}
+
+static inline bool
+encode_opnd_z_tsz_bhsdq_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_z_tsz_bhsdq_base(opnd, 5, enc_out);
+}
+
 /* wx5_imm5: bits 5-9 is a GPR whose width is dependent on information in
    an imm5 from bits 16-20
 */
@@ -3429,7 +3497,7 @@ encode_opnd_imm5_idx(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_
 
     index = opnd_get_immed_int(opnd);
     uint min_index = 0;
-    uint max_index = (1 << opnd_size_in_bits(index_size)) - 1;
+    uint max_index = MASK(opnd_size_in_bits(index_size));
 
     if (index < min_index || index > max_index)
         return false;
@@ -3745,7 +3813,7 @@ encode_opnd_instr(int bit_pos, opnd_t opnd, byte *start_pc, instr_t *containing_
     // We expect truncation; instrlist_insert_mov_instr_addr splits the instr's
     // encoded address into INSTR_kind operands in multiple mov instructions in the
     // ilist, each representing a 2-byte portion of the complete address.
-    val &= ((1 << bits) - 1);
+    val &= MASK(bits);
 
     ASSERT((*enc_out & (val << bit_pos)) == 0);
     *enc_out |= (val << bit_pos);
@@ -4416,23 +4484,62 @@ encode_opnd_immhb_fxp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
     return immhb_shf_encode(enc, opcode, pc, opnd, enc_out, 1);
 }
 
-/* r_size_wx_0: GPR scalar register, register size, W or X depending on size bits */
 static inline bool
-decode_opnd_r_size_wx_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+decode_wx_size_reg(uint enc, bool is_sp, uint pos, OUT opnd_t *opnd)
 {
     const bool is_x = extract_uint(enc, 22, 2) == 0b11;
-    return decode_opnd_wxn(is_x, false, 0, enc, opnd);
+    return decode_opnd_wxn(is_x, is_sp, pos, enc, opnd);
 }
 
 static inline bool
-encode_opnd_r_size_wx_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+encode_wx_size_reg(bool is_sp, uint pos, opnd_t opnd, OUT uint *enc_out)
 {
     if (!opnd_is_reg(opnd))
         return false;
 
     const reg_id_t reg = opnd_get_reg(opnd);
-    const bool is_x = (DR_REG_X0 <= reg && reg <= DR_REG_X30) || (reg == DR_REG_XZR);
-    return encode_opnd_wxn(is_x, false, 0, opnd, enc_out);
+    const bool is_x = (DR_REG_X0 <= reg && reg <= DR_REG_X30) ||
+        (is_sp ? (reg == DR_REG_XSP) : (reg == DR_REG_XZR));
+    return encode_opnd_wxn(is_x, is_sp, pos, opnd, enc_out);
+}
+
+/* wx_size_reg0_zr: GPR scalar register, register size, W or X depending on size bits */
+static inline bool
+decode_opnd_wx_size_0_zr(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_wx_size_reg(enc, false, 0, opnd);
+}
+
+static inline bool
+encode_opnd_wx_size_0_zr(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_wx_size_reg(false, 0, opnd, enc_out);
+}
+
+/* wx_size_reg5_sp: GPR scalar register, register size, W or X depending on size bits */
+static inline bool
+decode_opnd_wx_size_5_sp(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_wx_size_reg(enc, true, 5, opnd);
+}
+
+static inline bool
+encode_opnd_wx_size_5_sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_wx_size_reg(true, 5, opnd, enc_out);
+}
+
+/* wx_size_reg5_zr: GPR scalar register, register size, W or X depending on size bits */
+static inline bool
+decode_opnd_wx_size_5_zr(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_wx_size_reg(enc, false, 5, opnd);
+}
+
+static inline bool
+encode_opnd_wx_size_5_zr(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_wx_size_reg(false, 5, opnd, enc_out);
 }
 
 /* fpimm13: floating-point immediate for scalar fmov */
@@ -5069,6 +5176,59 @@ static inline bool
 encode_opnd_z_size_hsd_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_sized_z(16, 22, HALF_REG, DOUBLE_REG, opnd, enc_out);
+}
+
+/* imm2_tsz_index: Index encoded in imm2:tsz */
+static inline bool
+decode_opnd_imm2_tsz_index(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    /* The size in tsz determines how many MSB bits are available for the imm's value */
+    const opnd_size_t size = extract_tsz_size(enc);
+    if (size == OPSZ_NA)
+        return false;
+
+    /* Just used as a cheap log2 */
+    int size_lbs;
+    if (!lowest_bit_set(opnd_size_in_bytes(size), 0, 5, &size_lbs))
+        return false;
+
+    /* The immediate's value is derived from imm:tsz, but the number of higher bits used
+     * in tsz varies depending on the size which is indicated by the lowest bit set in tsz
+     */
+    const ptr_uint_t tsz = extract_uint(enc, 16, 5);
+    const ptr_uint_t imm = extract_uint(enc, 22, 2);
+
+    const uint offset = size_lbs + 1;
+    const ptr_uint_t tsz_field = tsz >> offset;
+    const ptr_uint_t imm_field = imm << (5 - offset);
+    const opnd_size_t imm_size = OPSZ_7b - offset;
+
+    *opnd = opnd_create_immed_uint(imm_field | tsz_field, imm_size);
+    return true;
+}
+
+static inline bool
+encode_opnd_imm2_tsz_index(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_immed_int(opnd))
+        return false;
+
+    const ptr_uint_t value = opnd_get_immed_int(opnd);
+    const opnd_size_t size = opnd_get_size(opnd);
+    if (size == OPSZ_NA)
+        return false;
+
+    /* The immediate's value and size are encoded in the imm:tsz fields. The position of
+     * the lowest bit set in tsz indicates the size, and the remaining upper bits set the
+     * lower bits of the immediate's value (imm field sets the two upper bits)
+     */
+    const uint offset = size - OPSZ_2b;
+    const uint tsz_value =
+        ((0b10000 >> offset) | ((value & MASK(offset + 1)) << (5 - offset))) & 0b11111;
+    const uint imm_value = (value >> offset) & 0b11;
+
+    *enc_out = (imm_value << 22) | (tsz_value << 16);
+    return true;
 }
 
 /* mem0p: as mem0, but a pair of registers, so double size */

--- a/core/ir/aarch64/codec.h
+++ b/core/ir/aarch64/codec.h
@@ -52,8 +52,9 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr);
 uint
 encode_common(byte *pc, instr_t *i, decode_info_t *di);
 
-#define BITS(_enc, bitmax, bitmin)    \
-    ((((uint32)(_enc)) >> (bitmin)) & \
-     (uint32)((1ULL << ((bitmax) - (bitmin) + 1)) - 1ULL))
+#define MASK(size) ((1ULL << (size)) - 1ULL)
+
+#define BITS(_enc, bitmax, bitmin) \
+    ((((uint32)(_enc)) >> (bitmin)) & (uint32)MASK((bitmax) - (bitmin) + 1))
 
 #endif /* CODEC_H */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -65,11 +65,11 @@
 001001010100xxxx11xxxx0xxxx0xxxx  w   874  SVE   brkpas          p_b_0 : p10_zer p_b_5 p_b_16
 001001010000xxxx11xxxx0xxxx1xxxx  n   875  SVE    brkpb          p_b_0 : p10_zer p_b_5 p_b_16
 001001010100xxxx11xxxx0xxxx1xxxx  w   876  SVE   brkpbs          p_b_0 : p10_zer p_b_5 p_b_16
-00000101xx110000101xxxxxxxxxxxxx  n   835  SVE   clasta    r_size_wx_0 : p10_lo r_size_wx_0 z_size_bhsd_5
-00000101xx101010100xxxxxxxxxxxxx  n   835  SVE   clasta  bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
+00000101xx110000101xxxxxxxxxxxxx  n   835  SVE   clasta   wx_size_0_zr : p10_lo wx_size_0_zr z_size_bhsd_5
+00000101xx101010100xxxxxxxxxxxxx  n   835  SVE   clasta bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
 00000101xx101000100xxxxxxxxxxxxx  n   835  SVE   clasta  z_size_bhsd_0 : p10_lo z_size_bhsd_0 z_size_bhsd_5
-00000101xx110001101xxxxxxxxxxxxx  n   836  SVE   clastb    r_size_wx_0 : p10_lo r_size_wx_0 z_size_bhsd_5
-00000101xx101011100xxxxxxxxxxxxx  n   836  SVE   clastb  bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
+00000101xx110001101xxxxxxxxxxxxx  n   836  SVE   clastb   wx_size_0_zr : p10_lo wx_size_0_zr z_size_bhsd_5
+00000101xx101011100xxxxxxxxxxxxx  n   836  SVE   clastb bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
 00000101xx101001100xxxxxxxxxxxxx  n   836  SVE   clastb  z_size_bhsd_0 : p10_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx0xxxxx100xxxxxxxx0xxxx  w   807  SVE    cmpeq  p_size_bhsd_0 : p10_zer_lo z_size_bhsd_5 simm5
 00100100xx0xxxxx001xxxxxxxx0xxxx  w   807  SVE    cmpeq   p_size_bhs_0 : p10_zer_lo z_size_bhs_5 z_d_16
@@ -115,6 +115,9 @@
 00100101xx1011011000000xxxxxxxxx  n   822  SVE     decp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 000001001011xxxx111001xxxxxxxxxx  n   847  SVE     decw             x0 : x0 pred_constr mul imm4_16p1
 000001001011xxxx110001xxxxxxxxxx  n   847  SVE     decw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
+00100101xx11100011xxxxxxxxxxxxxx  n   88   SVE      dup  z_size_bhsd_0 : simm8_5 lsl shift1
+00000101xx1xxxxx001000xxxxxxxxxx  n   88   SVE      dup  z_tsz_bhsdq_0 : z_tsz_bhsdq_5 imm2_tsz_index
+00000101xx100000001110xxxxxxxxxx  n   88   SVE      dup  z_size_bhsd_0 : wx_size_5_sp
 00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor             z0 : p10_lo z0 z5 bhsd_sz
 00000101010000xxxxxxxxxxxxxxxxxx  n   90   SVE      eor  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010000xxxx01xxxx1xxxx0xxxx  n   90   SVE      eor          p_b_0 : p10_zer p_b_5 p_b_16
@@ -146,10 +149,12 @@
 00100101xx1011001000000xxxxxxxxx  n   823  SVE     incp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
 000001001011xxxx111000xxxxxxxxxx  n   851  SVE     incw             x0 : x0 pred_constr mul imm4_16p1
 000001001011xxxx110000xxxxxxxxxx  n   851  SVE     incw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
-00000101xx100000101xxxxxxxxxxxxx  n   837  SVE    lasta    r_size_wx_0 : p10_lo z_size_bhsd_5
-00000101xx100010100xxxxxxxxxxxxx  n   837  SVE    lasta  bhsd_size_reg0 : p10_lo z_size_bhsd_5
-00000101xx100001101xxxxxxxxxxxxx  n   838  SVE    lastb    r_size_wx_0 : p10_lo z_size_bhsd_5
-00000101xx100011100xxxxxxxxxxxxx  n   838  SVE    lastb  bhsd_size_reg0 : p10_lo z_size_bhsd_5
+00000101xx100100001110xxxxxxxxxx  n   881  SVE     insr  z_size_bhsd_0 : z_size_bhsd_0 wx_size_5_zr
+00000101xx110100001110xxxxxxxxxx  n   881  SVE     insr  z_size_bhsd_0 : z_size_bhsd_0 bhsd_size_reg5
+00000101xx100000101xxxxxxxxxxxxx  n   837  SVE    lasta wx_size_0_zr : p10_lo z_size_bhsd_5
+00000101xx100010100xxxxxxxxxxxxx  n   837  SVE    lasta bhsd_size_reg0 : p10_lo z_size_bhsd_5
+00000101xx100001101xxxxxxxxxxxxx  n   838  SVE    lastb wx_size_0_zr : p10_lo z_size_bhsd_5
+00000101xx100011100xxxxxxxxxxxxx  n   838  SVE    lastb bhsd_size_reg0 : p10_lo z_size_bhsd_5
 00000100xx0xxxxx110xxxxxxxxxxxxx  n   787  SVE      mad  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_16 z_size_bhsd_5
 00000100xx0xxxxx010xxxxxxxxxxxxx  n   312  SVE      mla  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16 z_size_bhsd_0
 00000100xx0xxxxx011xxxxxxxxxxxxx  n   313  SVE      mls  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16 z_size_bhsd_0
@@ -226,6 +231,7 @@
 00000100xx010000101xxxxxxxxxxxxx  n   799  SVE     sxtb   z_size_hsd_0 : p10_mrg_lo z_size_hsd_5
 00000100xx010010101xxxxxxxxxxxxx  n   800  SVE     sxth    z_size_sd_0 : p10_mrg_lo z_size_sd_5
 0000010011010100101xxxxxxxxxxxxx  n   801  SVE     sxtw          z_d_0 : p10_mrg_lo z_d_5
+00000101xx1xxxxx001100xxxxxxxxxx  n   490  SVE      tbl  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000100xx001101000xxxxxxxxxxxxx  n   499  SVE     uabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx010101000xxxxxxxxxxxxx  n   511  SVE     udiv    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
 00000100xx010111000xxxxxxxxxxxxx  n   795  SVE    udivr    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -8282,4 +8282,99 @@
  */
 #define INSTR_CREATE_whilelt_sve(dc, Pd, Rn, Rm) \
     instr_create_1dst_2src(dc, OP_whilelt, Pd, Rn, Rm)
+
+/**
+ * Creates a TBL instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    TBL     <Zd>.<Ts>, { <Zn>.<Ts> }, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_tbl_sve(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_tbl, Zd, Zn, Zm)
+
+/**
+ * Creates a DUP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    DUP     <Zd>.<Ts>, #<simm>, <shift>
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd    The destination vector register, Z (Scalable).
+ * \param simm  The signed immediate imm.
+ * \param shift Left shift to apply to the immediate, defaulting to LSL #0.  Can
+ * be 0 or 8
+ */
+#define INSTR_CREATE_dup_sve_shift(dc, Zd, simm, shift) \
+    instr_create_1dst_3src(dc, OP_dup, Zd, simm, OPND_CREATE_LSL(), shift)
+
+/**
+ * Creates a DUP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    DUP     <Zd>.<Ts>, <Zn>.<Ts>[<index>]
+ * \endverbatim
+ * \param dc     The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd     The destination vector register, Z (Scalable).
+ * \param Zn     The source vector register, Z (Scalable).
+ * \param index  Immediate index of source vector.  The operand size must match the
+ * encoded field size, which depends on the element size of Zd and Zn; OPSZ_6b for byte,
+ * OPSZ_5b for halfword, OPSZ_4b for singleword, OPSZ_3b for doubleword, and OPSZ_2b for
+ * quadword.
+ */
+#define INSTR_CREATE_dup_sve_idx(dc, Zd, Zn, index) \
+    instr_create_1dst_2src(dc, OP_dup, Zd, Zn, index)
+
+/**
+ * Creates a DUP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    DUP     <Zd>.<Ts>, <R><n|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Rn   The source vector register. Can be X (Extended, 64 bits) or W
+ *             (Word, 32 bits).
+ */
+#define INSTR_CREATE_dup_sve_scalar(dc, Zd, Rn) instr_create_1dst_1src(dc, OP_dup, Zd, Rn)
+
+/**
+ * Creates a INSR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    INSR    <Zdn>.<T>, <R><m>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The second source and destination vector register, Z (Scalable).
+ * \param Rm   The source vector register. Can be X (Extended, 64 bits) or W
+ *             (Word, 32 bits).
+ */
+#define INSTR_CREATE_insr_sve_scalar(dc, Zd, Rm) \
+    instr_create_1dst_2src(dc, OP_insr, Zd, Zd, Rm)
+
+/**
+ * Creates an INSR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    INSR    <Zdn>.<Ts>, <V><m>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The second source and destination vector register, Z (Scalable).
+ * \param Vm   The first source register. Can be S (singleword, 32 bits), B
+ *             (byte, 8 bits), D (doubleword, 64 bits) or H
+ *             (halfword, 16 bits).
+ */
+#define INSTR_CREATE_insr_sve_simd_fp(dc, Zdn, Vm) \
+    instr_create_1dst_2src(dc, OP_insr, Zdn, Zdn, Vm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -158,6 +158,8 @@
 -----------?????----------------  bh_imm5_sz # Size encoded as least significant bit in imm5
 -----------?????----------------  bhs_imm5_sz # Size encoded as least significant bit in imm5
 -----------?????----------------  bhsd_imm5_sz # Size encoded as least significant bit in imm5
+-----------?????-----------xxxxx  z_tsz_bhsdq_0   # Z register with size encoded in tsz field
+-----------?????------xxxxx-----  z_tsz_bhsdq_5   # Z register with size encoded in tsz field
 -----------?????------xxxxx-----  wx5_imm5   # reg 5-9 d or q is inferred from bits 16:20
 -----------xxxxx----------------  imm5       # 5 bit immediate from 16-20
 -----------xxxxx----------------  simm5      # Signed 5 bit immediate from 16-20
@@ -208,7 +210,9 @@
 ---------++++xxx----------------  immhb_shf  # encoding of #shift value in immh:immb fields
 ---------++++xxx----------------  immhb_0shf # encoding of #shift value in zero-indexed immh:immb fields
 ---------++++xxx----------------  immhb_fxp  # encoding of #fbits value in immh:immb fields
---------??-----------------xxxxx  r_size_wx_0      # GPR scalar register, elsz depending on size
+--------??-----------------xxxxx  wx_size_0_zr # GPR scalar register, register size, W or X depending on size bits
+--------??------------xxxxx-----  wx_size_5_sp # GPR scalar register, register size, W or X depending on size bits
+--------??------------xxxxx-----  wx_size_5_zr # GPR scalar register, register size, W or X depending on size bits
 --------??-xxxxxxxx-------------  fpimm13    # floating-point immediate for scalar fmov
 --------xx----------------------  b_sz       # element width of a vector (8<<b_sz)
 --------xx----------------------  hs_sz      # element width of a vector (8<<hs_sz)
@@ -241,6 +245,7 @@
 --------xx-xxxxx----------------  bhsd_size_reg16  # bhsd register, depending on size opcode
 --------xx-xxxxx----------------  z_size_bhsd_16   # sve vector reg, elsz depending on size
 --------xx-xxxxx----------------  z_size_hsd_16    # sve vector reg, elsz depending on size
+--------xx-xxxxx----------------  imm2_tsz_index   # Index encoded in imm2:tsz
 -?--------------------xxxxx-----  mem0p      # gets size from 30; no offset, pair
 -?---------xxxxx????------------  x16imm     # computes immed from 30 and 15:12
 -x------------------------------  index3     # index of D subreg in Q: 0-1

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -3477,6 +3477,220 @@
 04bec7dd : decw z29.s, MUL3, MUL #15                 : decw   %z29.s MUL3 mul $0x0f -> %z29.s
 04bfc7ff : decw z31.s, ALL, MUL #16                  : decw   %z31.s ALL mul $0x10 -> %z31.s
 
+# DUP     <Zd>.<T>, #<imm>, <shift> (DUP-Z.I-_)
+2538d000 : dup z0.b, #-0x80, lsl #0                  : dup    $0x80 lsl $0x00 -> %z0.b
+2538d202 : dup z2.b, #-0x70, lsl #0                  : dup    $0x90 lsl $0x00 -> %z2.b
+2538d404 : dup z4.b, #-0x60, lsl #0                  : dup    $0xa0 lsl $0x00 -> %z4.b
+2538d606 : dup z6.b, #-0x50, lsl #0                  : dup    $0xb0 lsl $0x00 -> %z6.b
+2538d808 : dup z8.b, #-0x40, lsl #0                  : dup    $0xc0 lsl $0x00 -> %z8.b
+2538da0a : dup z10.b, #-0x30, lsl #0                 : dup    $0xd0 lsl $0x00 -> %z10.b
+2538dc0c : dup z12.b, #-0x20, lsl #0                 : dup    $0xe0 lsl $0x00 -> %z12.b
+2538de0e : dup z14.b, #-0x10, lsl #0                 : dup    $0xf0 lsl $0x00 -> %z14.b
+2538c010 : dup z16.b, #0x0, lsl #0                   : dup    $0x00 lsl $0x00 -> %z16.b
+2538c1f1 : dup z17.b, #0xf, lsl #0                   : dup    $0x0f lsl $0x00 -> %z17.b
+2538c3f3 : dup z19.b, #0x1f, lsl #0                  : dup    $0x1f lsl $0x00 -> %z19.b
+2538c5f5 : dup z21.b, #0x2f, lsl #0                  : dup    $0x2f lsl $0x00 -> %z21.b
+2538c7f7 : dup z23.b, #0x3f, lsl #0                  : dup    $0x3f lsl $0x00 -> %z23.b
+2538c9f9 : dup z25.b, #0x4f, lsl #0                  : dup    $0x4f lsl $0x00 -> %z25.b
+2538cbfb : dup z27.b, #0x5f, lsl #0                  : dup    $0x5f lsl $0x00 -> %z27.b
+2538cfff : dup z31.b, #0x7f, lsl #0                  : dup    $0x7f lsl $0x00 -> %z31.b
+2578f000 : dup z0.h, #-0x80, lsl #8                  : dup    $0x80 lsl $0x08 -> %z0.h
+2578f202 : dup z2.h, #-0x70, lsl #8                  : dup    $0x90 lsl $0x08 -> %z2.h
+2578f404 : dup z4.h, #-0x60, lsl #8                  : dup    $0xa0 lsl $0x08 -> %z4.h
+2578f606 : dup z6.h, #-0x50, lsl #8                  : dup    $0xb0 lsl $0x08 -> %z6.h
+2578f808 : dup z8.h, #-0x40, lsl #8                  : dup    $0xc0 lsl $0x08 -> %z8.h
+2578fa0a : dup z10.h, #-0x30, lsl #8                 : dup    $0xd0 lsl $0x08 -> %z10.h
+2578fc0c : dup z12.h, #-0x20, lsl #8                 : dup    $0xe0 lsl $0x08 -> %z12.h
+2578fe0e : dup z14.h, #-0x10, lsl #8                 : dup    $0xf0 lsl $0x08 -> %z14.h
+2578e010 : dup z16.h, #0x0, lsl #8                   : dup    $0x00 lsl $0x08 -> %z16.h
+2578c1f1 : dup z17.h, #0xf, lsl #0                   : dup    $0x0f lsl $0x00 -> %z17.h
+2578c3f3 : dup z19.h, #0x1f, lsl #0                  : dup    $0x1f lsl $0x00 -> %z19.h
+2578c5f5 : dup z21.h, #0x2f, lsl #0                  : dup    $0x2f lsl $0x00 -> %z21.h
+2578c7f7 : dup z23.h, #0x3f, lsl #0                  : dup    $0x3f lsl $0x00 -> %z23.h
+2578c9f9 : dup z25.h, #0x4f, lsl #0                  : dup    $0x4f lsl $0x00 -> %z25.h
+2578cbfb : dup z27.h, #0x5f, lsl #0                  : dup    $0x5f lsl $0x00 -> %z27.h
+2578cfff : dup z31.h, #0x7f, lsl #0                  : dup    $0x7f lsl $0x00 -> %z31.h
+25b8f000 : dup z0.s, #-0x80, lsl #8                  : dup    $0x80 lsl $0x08 -> %z0.s
+25b8f202 : dup z2.s, #-0x70, lsl #8                  : dup    $0x90 lsl $0x08 -> %z2.s
+25b8f404 : dup z4.s, #-0x60, lsl #8                  : dup    $0xa0 lsl $0x08 -> %z4.s
+25b8f606 : dup z6.s, #-0x50, lsl #8                  : dup    $0xb0 lsl $0x08 -> %z6.s
+25b8f808 : dup z8.s, #-0x40, lsl #8                  : dup    $0xc0 lsl $0x08 -> %z8.s
+25b8fa0a : dup z10.s, #-0x30, lsl #8                 : dup    $0xd0 lsl $0x08 -> %z10.s
+25b8fc0c : dup z12.s, #-0x20, lsl #8                 : dup    $0xe0 lsl $0x08 -> %z12.s
+25b8fe0e : dup z14.s, #-0x10, lsl #8                 : dup    $0xf0 lsl $0x08 -> %z14.s
+25b8e010 : dup z16.s, #0x0, lsl #8                   : dup    $0x00 lsl $0x08 -> %z16.s
+25b8c1f1 : dup z17.s, #0xf, lsl #0                   : dup    $0x0f lsl $0x00 -> %z17.s
+25b8c3f3 : dup z19.s, #0x1f, lsl #0                  : dup    $0x1f lsl $0x00 -> %z19.s
+25b8c5f5 : dup z21.s, #0x2f, lsl #0                  : dup    $0x2f lsl $0x00 -> %z21.s
+25b8c7f7 : dup z23.s, #0x3f, lsl #0                  : dup    $0x3f lsl $0x00 -> %z23.s
+25b8c9f9 : dup z25.s, #0x4f, lsl #0                  : dup    $0x4f lsl $0x00 -> %z25.s
+25b8cbfb : dup z27.s, #0x5f, lsl #0                  : dup    $0x5f lsl $0x00 -> %z27.s
+25b8cfff : dup z31.s, #0x7f, lsl #0                  : dup    $0x7f lsl $0x00 -> %z31.s
+25f8f000 : dup z0.d, #-0x80, lsl #8                  : dup    $0x80 lsl $0x08 -> %z0.d
+25f8f202 : dup z2.d, #-0x70, lsl #8                  : dup    $0x90 lsl $0x08 -> %z2.d
+25f8f404 : dup z4.d, #-0x60, lsl #8                  : dup    $0xa0 lsl $0x08 -> %z4.d
+25f8f606 : dup z6.d, #-0x50, lsl #8                  : dup    $0xb0 lsl $0x08 -> %z6.d
+25f8f808 : dup z8.d, #-0x40, lsl #8                  : dup    $0xc0 lsl $0x08 -> %z8.d
+25f8fa0a : dup z10.d, #-0x30, lsl #8                 : dup    $0xd0 lsl $0x08 -> %z10.d
+25f8fc0c : dup z12.d, #-0x20, lsl #8                 : dup    $0xe0 lsl $0x08 -> %z12.d
+25f8fe0e : dup z14.d, #-0x10, lsl #8                 : dup    $0xf0 lsl $0x08 -> %z14.d
+25f8e010 : dup z16.d, #0x0, lsl #8                   : dup    $0x00 lsl $0x08 -> %z16.d
+25f8c1f1 : dup z17.d, #0xf, lsl #0                   : dup    $0x0f lsl $0x00 -> %z17.d
+25f8c3f3 : dup z19.d, #0x1f, lsl #0                  : dup    $0x1f lsl $0x00 -> %z19.d
+25f8c5f5 : dup z21.d, #0x2f, lsl #0                  : dup    $0x2f lsl $0x00 -> %z21.d
+25f8c7f7 : dup z23.d, #0x3f, lsl #0                  : dup    $0x3f lsl $0x00 -> %z23.d
+25f8c9f9 : dup z25.d, #0x4f, lsl #0                  : dup    $0x4f lsl $0x00 -> %z25.d
+25f8cbfb : dup z27.d, #0x5f, lsl #0                  : dup    $0x5f lsl $0x00 -> %z27.d
+25f8cfff : dup z31.d, #0x7f, lsl #0                  : dup    $0x7f lsl $0x00 -> %z31.d
+
+# DUP     <Zd>.<Ts>, <Zn>.<Ts>[<index>] (DUP-Z.Zi-_)
+05212000 : dup z0.b, z0.b[0]            : dup    %z0.b $0x00 -> %z0.b
+05292042 : dup z2.b, z2.b[4]            : dup    %z2.b $0x04 -> %z2.b
+05312084 : dup z4.b, z4.b[8]            : dup    %z4.b $0x08 -> %z4.b
+053920c6 : dup z6.b, z6.b[12]           : dup    %z6.b $0x0c -> %z6.b
+05612108 : dup z8.b, z8.b[16]           : dup    %z8.b $0x10 -> %z8.b
+056b214a : dup z10.b, z10.b[21]         : dup    %z10.b $0x15 -> %z10.b
+0573218c : dup z12.b, z12.b[25]         : dup    %z12.b $0x19 -> %z12.b
+057b21ce : dup z14.b, z14.b[29]         : dup    %z14.b $0x1d -> %z14.b
+05a32210 : dup z16.b, z16.b[33]         : dup    %z16.b $0x21 -> %z16.b
+05ab2231 : dup z17.b, z17.b[37]         : dup    %z17.b $0x25 -> %z17.b
+05b52273 : dup z19.b, z19.b[42]         : dup    %z19.b $0x2a -> %z19.b
+05bd22b5 : dup z21.b, z21.b[46]         : dup    %z21.b $0x2e -> %z21.b
+05e522f7 : dup z23.b, z23.b[50]         : dup    %z23.b $0x32 -> %z23.b
+05ed2339 : dup z25.b, z25.b[54]         : dup    %z25.b $0x36 -> %z25.b
+05f5237b : dup z27.b, z27.b[58]         : dup    %z27.b $0x3a -> %z27.b
+05ff23ff : dup z31.b, z31.b[63]         : dup    %z31.b $0x3f -> %z31.b
+05222000 : dup z0.h, z0.h[0]            : dup    %z0.h $0x00 -> %z0.h
+052a2042 : dup z2.h, z2.h[2]            : dup    %z2.h $0x02 -> %z2.h
+05322084 : dup z4.h, z4.h[4]            : dup    %z4.h $0x04 -> %z4.h
+053a20c6 : dup z6.h, z6.h[6]            : dup    %z6.h $0x06 -> %z6.h
+05622108 : dup z8.h, z8.h[8]            : dup    %z8.h $0x08 -> %z8.h
+056a214a : dup z10.h, z10.h[10]         : dup    %z10.h $0x0a -> %z10.h
+0572218c : dup z12.h, z12.h[12]         : dup    %z12.h $0x0c -> %z12.h
+057a21ce : dup z14.h, z14.h[14]         : dup    %z14.h $0x0e -> %z14.h
+05a22210 : dup z16.h, z16.h[16]         : dup    %z16.h $0x10 -> %z16.h
+05aa2231 : dup z17.h, z17.h[18]         : dup    %z17.h $0x12 -> %z17.h
+05b22273 : dup z19.h, z19.h[20]         : dup    %z19.h $0x14 -> %z19.h
+05ba22b5 : dup z21.h, z21.h[22]         : dup    %z21.h $0x16 -> %z21.h
+05e222f7 : dup z23.h, z23.h[24]         : dup    %z23.h $0x18 -> %z23.h
+05ea2339 : dup z25.h, z25.h[26]         : dup    %z25.h $0x1a -> %z25.h
+05f2237b : dup z27.h, z27.h[28]         : dup    %z27.h $0x1c -> %z27.h
+05fe23ff : dup z31.h, z31.h[31]         : dup    %z31.h $0x1f -> %z31.h
+05242000 : dup z0.s, z0.s[0]            : dup    %z0.s $0x00 -> %z0.s
+052c2042 : dup z2.s, z2.s[1]            : dup    %z2.s $0x01 -> %z2.s
+05342084 : dup z4.s, z4.s[2]            : dup    %z4.s $0x02 -> %z4.s
+053c20c6 : dup z6.s, z6.s[3]            : dup    %z6.s $0x03 -> %z6.s
+05642108 : dup z8.s, z8.s[4]            : dup    %z8.s $0x04 -> %z8.s
+056c214a : dup z10.s, z10.s[5]          : dup    %z10.s $0x05 -> %z10.s
+0574218c : dup z12.s, z12.s[6]          : dup    %z12.s $0x06 -> %z12.s
+057c21ce : dup z14.s, z14.s[7]          : dup    %z14.s $0x07 -> %z14.s
+05a42210 : dup z16.s, z16.s[8]          : dup    %z16.s $0x08 -> %z16.s
+05ac2231 : dup z17.s, z17.s[9]          : dup    %z17.s $0x09 -> %z17.s
+05b42273 : dup z19.s, z19.s[10]         : dup    %z19.s $0x0a -> %z19.s
+05bc22b5 : dup z21.s, z21.s[11]         : dup    %z21.s $0x0b -> %z21.s
+05e422f7 : dup z23.s, z23.s[12]         : dup    %z23.s $0x0c -> %z23.s
+05ec2339 : dup z25.s, z25.s[13]         : dup    %z25.s $0x0d -> %z25.s
+05f4237b : dup z27.s, z27.s[14]         : dup    %z27.s $0x0e -> %z27.s
+05fc23ff : dup z31.s, z31.s[15]         : dup    %z31.s $0x0f -> %z31.s
+05282000 : dup z0.d, z0.d[0]            : dup    %z0.d $0x00 -> %z0.d
+05282042 : dup z2.d, z2.d[0]            : dup    %z2.d $0x00 -> %z2.d
+05382084 : dup z4.d, z4.d[1]            : dup    %z4.d $0x01 -> %z4.d
+053820c6 : dup z6.d, z6.d[1]            : dup    %z6.d $0x01 -> %z6.d
+05682108 : dup z8.d, z8.d[2]            : dup    %z8.d $0x02 -> %z8.d
+0568214a : dup z10.d, z10.d[2]          : dup    %z10.d $0x02 -> %z10.d
+0578218c : dup z12.d, z12.d[3]          : dup    %z12.d $0x03 -> %z12.d
+057821ce : dup z14.d, z14.d[3]          : dup    %z14.d $0x03 -> %z14.d
+05a82210 : dup z16.d, z16.d[4]          : dup    %z16.d $0x04 -> %z16.d
+05a82231 : dup z17.d, z17.d[4]          : dup    %z17.d $0x04 -> %z17.d
+05b82273 : dup z19.d, z19.d[5]          : dup    %z19.d $0x05 -> %z19.d
+05b822b5 : dup z21.d, z21.d[5]          : dup    %z21.d $0x05 -> %z21.d
+05e822f7 : dup z23.d, z23.d[6]          : dup    %z23.d $0x06 -> %z23.d
+05e82339 : dup z25.d, z25.d[6]          : dup    %z25.d $0x06 -> %z25.d
+05f8237b : dup z27.d, z27.d[7]          : dup    %z27.d $0x07 -> %z27.d
+05f823ff : dup z31.d, z31.d[7]          : dup    %z31.d $0x07 -> %z31.d
+05302000 : dup z0.q, z0.q[0]            : dup    %z0.q $0x00 -> %z0.q
+05302042 : dup z2.q, z2.q[0]            : dup    %z2.q $0x00 -> %z2.q
+05302084 : dup z4.q, z4.q[0]            : dup    %z4.q $0x00 -> %z4.q
+053020c6 : dup z6.q, z6.q[0]            : dup    %z6.q $0x00 -> %z6.q
+05702108 : dup z8.q, z8.q[1]            : dup    %z8.q $0x01 -> %z8.q
+0570214a : dup z10.q, z10.q[1]          : dup    %z10.q $0x01 -> %z10.q
+0570218c : dup z12.q, z12.q[1]          : dup    %z12.q $0x01 -> %z12.q
+057021ce : dup z14.q, z14.q[1]          : dup    %z14.q $0x01 -> %z14.q
+05b02210 : dup z16.q, z16.q[2]          : dup    %z16.q $0x02 -> %z16.q
+05b02231 : dup z17.q, z17.q[2]          : dup    %z17.q $0x02 -> %z17.q
+05b02273 : dup z19.q, z19.q[2]          : dup    %z19.q $0x02 -> %z19.q
+05b022b5 : dup z21.q, z21.q[2]          : dup    %z21.q $0x02 -> %z21.q
+05f022f7 : dup z23.q, z23.q[3]          : dup    %z23.q $0x03 -> %z23.q
+05f02339 : dup z25.q, z25.q[3]          : dup    %z25.q $0x03 -> %z25.q
+05f0237b : dup z27.q, z27.q[3]          : dup    %z27.q $0x03 -> %z27.q
+05f023ff : dup z31.q, z31.q[3]          : dup    %z31.q $0x03 -> %z31.q
+
+# DUP     <Zd>.<Ts>, <R><n|SP> (DUP-Z.R-_)
+05203800 : dup z0.b, w0            : dup    %w0 -> %z0.b
+05203842 : dup z2.b, w2            : dup    %w2 -> %z2.b
+05203884 : dup z4.b, w4            : dup    %w4 -> %z4.b
+052038c6 : dup z6.b, w6            : dup    %w6 -> %z6.b
+05203908 : dup z8.b, w8            : dup    %w8 -> %z8.b
+0520394a : dup z10.b, w10          : dup    %w10 -> %z10.b
+0520398c : dup z12.b, w12          : dup    %w12 -> %z12.b
+052039ce : dup z14.b, w14          : dup    %w14 -> %z14.b
+05203a10 : dup z16.b, w16          : dup    %w16 -> %z16.b
+05203a31 : dup z17.b, w17          : dup    %w17 -> %z17.b
+05203a73 : dup z19.b, w19          : dup    %w19 -> %z19.b
+05203ab5 : dup z21.b, w21          : dup    %w21 -> %z21.b
+05203af7 : dup z23.b, w23          : dup    %w23 -> %z23.b
+05203b39 : dup z25.b, w25          : dup    %w25 -> %z25.b
+05203b7b : dup z27.b, w27          : dup    %w27 -> %z27.b
+05203bff : dup z31.b, wsp          : dup    %wsp -> %z31.b
+05603800 : dup z0.h, w0            : dup    %w0 -> %z0.h
+05603842 : dup z2.h, w2            : dup    %w2 -> %z2.h
+05603884 : dup z4.h, w4            : dup    %w4 -> %z4.h
+056038c6 : dup z6.h, w6            : dup    %w6 -> %z6.h
+05603908 : dup z8.h, w8            : dup    %w8 -> %z8.h
+0560394a : dup z10.h, w10          : dup    %w10 -> %z10.h
+0560398c : dup z12.h, w12          : dup    %w12 -> %z12.h
+056039ce : dup z14.h, w14          : dup    %w14 -> %z14.h
+05603a10 : dup z16.h, w16          : dup    %w16 -> %z16.h
+05603a31 : dup z17.h, w17          : dup    %w17 -> %z17.h
+05603a73 : dup z19.h, w19          : dup    %w19 -> %z19.h
+05603ab5 : dup z21.h, w21          : dup    %w21 -> %z21.h
+05603af7 : dup z23.h, w23          : dup    %w23 -> %z23.h
+05603b39 : dup z25.h, w25          : dup    %w25 -> %z25.h
+05603b7b : dup z27.h, w27          : dup    %w27 -> %z27.h
+05603bff : dup z31.h, wsp          : dup    %wsp -> %z31.h
+05a03800 : dup z0.s, w0            : dup    %w0 -> %z0.s
+05a03842 : dup z2.s, w2            : dup    %w2 -> %z2.s
+05a03884 : dup z4.s, w4            : dup    %w4 -> %z4.s
+05a038c6 : dup z6.s, w6            : dup    %w6 -> %z6.s
+05a03908 : dup z8.s, w8            : dup    %w8 -> %z8.s
+05a0394a : dup z10.s, w10          : dup    %w10 -> %z10.s
+05a0398c : dup z12.s, w12          : dup    %w12 -> %z12.s
+05a039ce : dup z14.s, w14          : dup    %w14 -> %z14.s
+05a03a10 : dup z16.s, w16          : dup    %w16 -> %z16.s
+05a03a31 : dup z17.s, w17          : dup    %w17 -> %z17.s
+05a03a73 : dup z19.s, w19          : dup    %w19 -> %z19.s
+05a03ab5 : dup z21.s, w21          : dup    %w21 -> %z21.s
+05a03af7 : dup z23.s, w23          : dup    %w23 -> %z23.s
+05a03b39 : dup z25.s, w25          : dup    %w25 -> %z25.s
+05a03b7b : dup z27.s, w27          : dup    %w27 -> %z27.s
+05a03bff : dup z31.s, wsp          : dup    %wsp -> %z31.s
+05e03800 : dup z0.d, x0            : dup    %x0 -> %z0.d
+05e03842 : dup z2.d, x2            : dup    %x2 -> %z2.d
+05e03884 : dup z4.d, x4            : dup    %x4 -> %z4.d
+05e038c6 : dup z6.d, x6            : dup    %x6 -> %z6.d
+05e03908 : dup z8.d, x8            : dup    %x8 -> %z8.d
+05e0394a : dup z10.d, x10          : dup    %x10 -> %z10.d
+05e0398c : dup z12.d, x12          : dup    %x12 -> %z12.d
+05e039ce : dup z14.d, x14          : dup    %x14 -> %z14.d
+05e03a10 : dup z16.d, x16          : dup    %x16 -> %z16.d
+05e03a31 : dup z17.d, x17          : dup    %x17 -> %z17.d
+05e03a73 : dup z19.d, x19          : dup    %x19 -> %z19.d
+05e03ab5 : dup z21.d, x21          : dup    %x21 -> %z21.d
+05e03af7 : dup z23.d, x23          : dup    %x23 -> %z23.d
+05e03b39 : dup z25.d, x25          : dup    %x25 -> %z25.d
+05e03b7b : dup z27.d, x27          : dup    %x27 -> %z27.d
+05e03bff : dup z31.d, sp           : dup    %sp -> %z31.d
+
 0419105d : eor z29.b, p4/m, z29.b, z2.b             : eor    %p4 %z29 %z2 $0x00 -> %z29
 0459105d : eor z29.h, p4/m, z29.h, z2.h             : eor    %p4 %z29 %z2 $0x01 -> %z29
 0499105d : eor z29.s, p4/m, z29.s, z2.s             : eor    %p4 %z29 %z2 $0x02 -> %z29
@@ -4801,6 +5015,138 @@
 04bec3bc : incw z28.s, MUL4, MUL #15                 : incw   %z28.s MUL4 mul $0x0f -> %z28.s
 04bec3dd : incw z29.s, MUL3, MUL #15                 : incw   %z29.s MUL3 mul $0x0f -> %z29.s
 04bfc3ff : incw z31.s, ALL, MUL #16                  : incw   %z31.s ALL mul $0x10 -> %z31.s
+
+# INSR    <Zdn>.<T>, <R><m> (INSR-Z.R-_)
+05243800 : insr z0.b, w0            : insr   %z0.b %w0 -> %z0.b
+05243842 : insr z2.b, w2            : insr   %z2.b %w2 -> %z2.b
+05243884 : insr z4.b, w4            : insr   %z4.b %w4 -> %z4.b
+052438c6 : insr z6.b, w6            : insr   %z6.b %w6 -> %z6.b
+05243908 : insr z8.b, w8            : insr   %z8.b %w8 -> %z8.b
+0524394a : insr z10.b, w10          : insr   %z10.b %w10 -> %z10.b
+0524398c : insr z12.b, w12          : insr   %z12.b %w12 -> %z12.b
+052439ce : insr z14.b, w14          : insr   %z14.b %w14 -> %z14.b
+05243a10 : insr z16.b, w16          : insr   %z16.b %w16 -> %z16.b
+05243a31 : insr z17.b, w17          : insr   %z17.b %w17 -> %z17.b
+05243a73 : insr z19.b, w19          : insr   %z19.b %w19 -> %z19.b
+05243ab5 : insr z21.b, w21          : insr   %z21.b %w21 -> %z21.b
+05243af7 : insr z23.b, w23          : insr   %z23.b %w23 -> %z23.b
+05243b39 : insr z25.b, w25          : insr   %z25.b %w25 -> %z25.b
+05243b7b : insr z27.b, w27          : insr   %z27.b %w27 -> %z27.b
+05243bff : insr z31.b, wzr          : insr   %z31.b %wzr -> %z31.b
+05643800 : insr z0.h, w0            : insr   %z0.h %w0 -> %z0.h
+05643842 : insr z2.h, w2            : insr   %z2.h %w2 -> %z2.h
+05643884 : insr z4.h, w4            : insr   %z4.h %w4 -> %z4.h
+056438c6 : insr z6.h, w6            : insr   %z6.h %w6 -> %z6.h
+05643908 : insr z8.h, w8            : insr   %z8.h %w8 -> %z8.h
+0564394a : insr z10.h, w10          : insr   %z10.h %w10 -> %z10.h
+0564398c : insr z12.h, w12          : insr   %z12.h %w12 -> %z12.h
+056439ce : insr z14.h, w14          : insr   %z14.h %w14 -> %z14.h
+05643a10 : insr z16.h, w16          : insr   %z16.h %w16 -> %z16.h
+05643a31 : insr z17.h, w17          : insr   %z17.h %w17 -> %z17.h
+05643a73 : insr z19.h, w19          : insr   %z19.h %w19 -> %z19.h
+05643ab5 : insr z21.h, w21          : insr   %z21.h %w21 -> %z21.h
+05643af7 : insr z23.h, w23          : insr   %z23.h %w23 -> %z23.h
+05643b39 : insr z25.h, w25          : insr   %z25.h %w25 -> %z25.h
+05643b7b : insr z27.h, w27          : insr   %z27.h %w27 -> %z27.h
+05643bff : insr z31.h, wzr          : insr   %z31.h %wzr -> %z31.h
+05a43800 : insr z0.s, w0            : insr   %z0.s %w0 -> %z0.s
+05a43842 : insr z2.s, w2            : insr   %z2.s %w2 -> %z2.s
+05a43884 : insr z4.s, w4            : insr   %z4.s %w4 -> %z4.s
+05a438c6 : insr z6.s, w6            : insr   %z6.s %w6 -> %z6.s
+05a43908 : insr z8.s, w8            : insr   %z8.s %w8 -> %z8.s
+05a4394a : insr z10.s, w10          : insr   %z10.s %w10 -> %z10.s
+05a4398c : insr z12.s, w12          : insr   %z12.s %w12 -> %z12.s
+05a439ce : insr z14.s, w14          : insr   %z14.s %w14 -> %z14.s
+05a43a10 : insr z16.s, w16          : insr   %z16.s %w16 -> %z16.s
+05a43a31 : insr z17.s, w17          : insr   %z17.s %w17 -> %z17.s
+05a43a73 : insr z19.s, w19          : insr   %z19.s %w19 -> %z19.s
+05a43ab5 : insr z21.s, w21          : insr   %z21.s %w21 -> %z21.s
+05a43af7 : insr z23.s, w23          : insr   %z23.s %w23 -> %z23.s
+05a43b39 : insr z25.s, w25          : insr   %z25.s %w25 -> %z25.s
+05a43b7b : insr z27.s, w27          : insr   %z27.s %w27 -> %z27.s
+05a43bff : insr z31.s, wzr          : insr   %z31.s %wzr -> %z31.s
+05e43800 : insr z0.d, x0            : insr   %z0.d %x0 -> %z0.d
+05e43842 : insr z2.d, x2            : insr   %z2.d %x2 -> %z2.d
+05e43884 : insr z4.d, x4            : insr   %z4.d %x4 -> %z4.d
+05e438c6 : insr z6.d, x6            : insr   %z6.d %x6 -> %z6.d
+05e43908 : insr z8.d, x8            : insr   %z8.d %x8 -> %z8.d
+05e4394a : insr z10.d, x10          : insr   %z10.d %x10 -> %z10.d
+05e4398c : insr z12.d, x12          : insr   %z12.d %x12 -> %z12.d
+05e439ce : insr z14.d, x14          : insr   %z14.d %x14 -> %z14.d
+05e43a10 : insr z16.d, x16          : insr   %z16.d %x16 -> %z16.d
+05e43a31 : insr z17.d, x17          : insr   %z17.d %x17 -> %z17.d
+05e43a73 : insr z19.d, x19          : insr   %z19.d %x19 -> %z19.d
+05e43ab5 : insr z21.d, x21          : insr   %z21.d %x21 -> %z21.d
+05e43af7 : insr z23.d, x23          : insr   %z23.d %x23 -> %z23.d
+05e43b39 : insr z25.d, x25          : insr   %z25.d %x25 -> %z25.d
+05e43b7b : insr z27.d, x27          : insr   %z27.d %x27 -> %z27.d
+05e43bff : insr z31.d, xzr          : insr   %z31.d %xzr -> %z31.d
+
+# INSR    <Zdn>.<T>, <V><m> (INSR-Z.V-_)
+05343800 : insr z0.b, b0            : insr   %z0.b %b0 -> %z0.b
+05343862 : insr z2.b, b3            : insr   %z2.b %b3 -> %z2.b
+053438a4 : insr z4.b, b5            : insr   %z4.b %b5 -> %z4.b
+053438e6 : insr z6.b, b7            : insr   %z6.b %b7 -> %z6.b
+05343928 : insr z8.b, b9            : insr   %z8.b %b9 -> %z8.b
+0534396a : insr z10.b, b11          : insr   %z10.b %b11 -> %z10.b
+053439ac : insr z12.b, b13          : insr   %z12.b %b13 -> %z12.b
+053439ee : insr z14.b, b15          : insr   %z14.b %b15 -> %z14.b
+05343a30 : insr z16.b, b17          : insr   %z16.b %b17 -> %z16.b
+05343a51 : insr z17.b, b18          : insr   %z17.b %b18 -> %z17.b
+05343a93 : insr z19.b, b20          : insr   %z19.b %b20 -> %z19.b
+05343ad5 : insr z21.b, b22          : insr   %z21.b %b22 -> %z21.b
+05343b17 : insr z23.b, b24          : insr   %z23.b %b24 -> %z23.b
+05343b59 : insr z25.b, b26          : insr   %z25.b %b26 -> %z25.b
+05343b9b : insr z27.b, b28          : insr   %z27.b %b28 -> %z27.b
+05343bff : insr z31.b, b31          : insr   %z31.b %b31 -> %z31.b
+05743800 : insr z0.h, h0            : insr   %z0.h %h0 -> %z0.h
+05743862 : insr z2.h, h3            : insr   %z2.h %h3 -> %z2.h
+057438a4 : insr z4.h, h5            : insr   %z4.h %h5 -> %z4.h
+057438e6 : insr z6.h, h7            : insr   %z6.h %h7 -> %z6.h
+05743928 : insr z8.h, h9            : insr   %z8.h %h9 -> %z8.h
+0574396a : insr z10.h, h11          : insr   %z10.h %h11 -> %z10.h
+057439ac : insr z12.h, h13          : insr   %z12.h %h13 -> %z12.h
+057439ee : insr z14.h, h15          : insr   %z14.h %h15 -> %z14.h
+05743a30 : insr z16.h, h17          : insr   %z16.h %h17 -> %z16.h
+05743a51 : insr z17.h, h18          : insr   %z17.h %h18 -> %z17.h
+05743a93 : insr z19.h, h20          : insr   %z19.h %h20 -> %z19.h
+05743ad5 : insr z21.h, h22          : insr   %z21.h %h22 -> %z21.h
+05743b17 : insr z23.h, h24          : insr   %z23.h %h24 -> %z23.h
+05743b59 : insr z25.h, h26          : insr   %z25.h %h26 -> %z25.h
+05743b9b : insr z27.h, h28          : insr   %z27.h %h28 -> %z27.h
+05743bff : insr z31.h, h31          : insr   %z31.h %h31 -> %z31.h
+05b43800 : insr z0.s, s0            : insr   %z0.s %s0 -> %z0.s
+05b43862 : insr z2.s, s3            : insr   %z2.s %s3 -> %z2.s
+05b438a4 : insr z4.s, s5            : insr   %z4.s %s5 -> %z4.s
+05b438e6 : insr z6.s, s7            : insr   %z6.s %s7 -> %z6.s
+05b43928 : insr z8.s, s9            : insr   %z8.s %s9 -> %z8.s
+05b4396a : insr z10.s, s11          : insr   %z10.s %s11 -> %z10.s
+05b439ac : insr z12.s, s13          : insr   %z12.s %s13 -> %z12.s
+05b439ee : insr z14.s, s15          : insr   %z14.s %s15 -> %z14.s
+05b43a30 : insr z16.s, s17          : insr   %z16.s %s17 -> %z16.s
+05b43a51 : insr z17.s, s18          : insr   %z17.s %s18 -> %z17.s
+05b43a93 : insr z19.s, s20          : insr   %z19.s %s20 -> %z19.s
+05b43ad5 : insr z21.s, s22          : insr   %z21.s %s22 -> %z21.s
+05b43b17 : insr z23.s, s24          : insr   %z23.s %s24 -> %z23.s
+05b43b59 : insr z25.s, s26          : insr   %z25.s %s26 -> %z25.s
+05b43b9b : insr z27.s, s28          : insr   %z27.s %s28 -> %z27.s
+05b43bff : insr z31.s, s31          : insr   %z31.s %s31 -> %z31.s
+05f43800 : insr z0.d, d0            : insr   %z0.d %d0 -> %z0.d
+05f43862 : insr z2.d, d3            : insr   %z2.d %d3 -> %z2.d
+05f438a4 : insr z4.d, d5            : insr   %z4.d %d5 -> %z4.d
+05f438e6 : insr z6.d, d7            : insr   %z6.d %d7 -> %z6.d
+05f43928 : insr z8.d, d9            : insr   %z8.d %d9 -> %z8.d
+05f4396a : insr z10.d, d11          : insr   %z10.d %d11 -> %z10.d
+05f439ac : insr z12.d, d13          : insr   %z12.d %d13 -> %z12.d
+05f439ee : insr z14.d, d15          : insr   %z14.d %d15 -> %z14.d
+05f43a30 : insr z16.d, d17          : insr   %z16.d %d17 -> %z16.d
+05f43a51 : insr z17.d, d18          : insr   %z17.d %d18 -> %z17.d
+05f43a93 : insr z19.d, d20          : insr   %z19.d %d20 -> %z19.d
+05f43ad5 : insr z21.d, d22          : insr   %z21.d %d22 -> %z21.d
+05f43b17 : insr z23.d, d24          : insr   %z23.d %d24 -> %z23.d
+05f43b59 : insr z25.d, d26          : insr   %z25.d %d26 -> %z25.d
+05f43b9b : insr z27.d, d28          : insr   %z27.d %d28 -> %z27.d
+05f43bff : insr z31.d, d31          : insr   %z31.d %d31 -> %z31.d
 
 # LASTA <R><d>, <Pg>, <Zn>.<T> (LASTA-R.P.Z-_)
 0520a000 : lasta w0, p0, z0.b          : lasta  %p0 %z0.b -> %w0
@@ -8187,6 +8533,72 @@
 04d4bf79 : sxtw z25.d, p7/M, z27.d                   : sxtw   %p7/m %z27.d -> %z25.d
 04d4bfbb : sxtw z27.d, p7/M, z29.d                   : sxtw   %p7/m %z29.d -> %z27.d
 04d4bfff : sxtw z31.d, p7/M, z31.d                   : sxtw   %p7/m %z31.d -> %z31.d
+
+# TBL     <Zd>.<T>, { <Zn>.<T> }, <Zm>.<T> (TBL-Z.ZZ-1)
+05203000 : tbl z0.b, z0.b, z0.b                      : tbl    %z0.b %z0.b -> %z0.b
+05243062 : tbl z2.b, z3.b, z4.b                      : tbl    %z3.b %z4.b -> %z2.b
+052630a4 : tbl z4.b, z5.b, z6.b                      : tbl    %z5.b %z6.b -> %z4.b
+052830e6 : tbl z6.b, z7.b, z8.b                      : tbl    %z7.b %z8.b -> %z6.b
+052a3128 : tbl z8.b, z9.b, z10.b                     : tbl    %z9.b %z10.b -> %z8.b
+052c316a : tbl z10.b, z11.b, z12.b                   : tbl    %z11.b %z12.b -> %z10.b
+052e31ac : tbl z12.b, z13.b, z14.b                   : tbl    %z13.b %z14.b -> %z12.b
+053031ee : tbl z14.b, z15.b, z16.b                   : tbl    %z15.b %z16.b -> %z14.b
+05323230 : tbl z16.b, z17.b, z18.b                   : tbl    %z17.b %z18.b -> %z16.b
+05333251 : tbl z17.b, z18.b, z19.b                   : tbl    %z18.b %z19.b -> %z17.b
+05353293 : tbl z19.b, z20.b, z21.b                   : tbl    %z20.b %z21.b -> %z19.b
+053732d5 : tbl z21.b, z22.b, z23.b                   : tbl    %z22.b %z23.b -> %z21.b
+05393317 : tbl z23.b, z24.b, z25.b                   : tbl    %z24.b %z25.b -> %z23.b
+053b3359 : tbl z25.b, z26.b, z27.b                   : tbl    %z26.b %z27.b -> %z25.b
+053d339b : tbl z27.b, z28.b, z29.b                   : tbl    %z28.b %z29.b -> %z27.b
+053f33ff : tbl z31.b, z31.b, z31.b                   : tbl    %z31.b %z31.b -> %z31.b
+05603000 : tbl z0.h, z0.h, z0.h                      : tbl    %z0.h %z0.h -> %z0.h
+05643062 : tbl z2.h, z3.h, z4.h                      : tbl    %z3.h %z4.h -> %z2.h
+056630a4 : tbl z4.h, z5.h, z6.h                      : tbl    %z5.h %z6.h -> %z4.h
+056830e6 : tbl z6.h, z7.h, z8.h                      : tbl    %z7.h %z8.h -> %z6.h
+056a3128 : tbl z8.h, z9.h, z10.h                     : tbl    %z9.h %z10.h -> %z8.h
+056c316a : tbl z10.h, z11.h, z12.h                   : tbl    %z11.h %z12.h -> %z10.h
+056e31ac : tbl z12.h, z13.h, z14.h                   : tbl    %z13.h %z14.h -> %z12.h
+057031ee : tbl z14.h, z15.h, z16.h                   : tbl    %z15.h %z16.h -> %z14.h
+05723230 : tbl z16.h, z17.h, z18.h                   : tbl    %z17.h %z18.h -> %z16.h
+05733251 : tbl z17.h, z18.h, z19.h                   : tbl    %z18.h %z19.h -> %z17.h
+05753293 : tbl z19.h, z20.h, z21.h                   : tbl    %z20.h %z21.h -> %z19.h
+057732d5 : tbl z21.h, z22.h, z23.h                   : tbl    %z22.h %z23.h -> %z21.h
+05793317 : tbl z23.h, z24.h, z25.h                   : tbl    %z24.h %z25.h -> %z23.h
+057b3359 : tbl z25.h, z26.h, z27.h                   : tbl    %z26.h %z27.h -> %z25.h
+057d339b : tbl z27.h, z28.h, z29.h                   : tbl    %z28.h %z29.h -> %z27.h
+057f33ff : tbl z31.h, z31.h, z31.h                   : tbl    %z31.h %z31.h -> %z31.h
+05a03000 : tbl z0.s, z0.s, z0.s                      : tbl    %z0.s %z0.s -> %z0.s
+05a43062 : tbl z2.s, z3.s, z4.s                      : tbl    %z3.s %z4.s -> %z2.s
+05a630a4 : tbl z4.s, z5.s, z6.s                      : tbl    %z5.s %z6.s -> %z4.s
+05a830e6 : tbl z6.s, z7.s, z8.s                      : tbl    %z7.s %z8.s -> %z6.s
+05aa3128 : tbl z8.s, z9.s, z10.s                     : tbl    %z9.s %z10.s -> %z8.s
+05ac316a : tbl z10.s, z11.s, z12.s                   : tbl    %z11.s %z12.s -> %z10.s
+05ae31ac : tbl z12.s, z13.s, z14.s                   : tbl    %z13.s %z14.s -> %z12.s
+05b031ee : tbl z14.s, z15.s, z16.s                   : tbl    %z15.s %z16.s -> %z14.s
+05b23230 : tbl z16.s, z17.s, z18.s                   : tbl    %z17.s %z18.s -> %z16.s
+05b33251 : tbl z17.s, z18.s, z19.s                   : tbl    %z18.s %z19.s -> %z17.s
+05b53293 : tbl z19.s, z20.s, z21.s                   : tbl    %z20.s %z21.s -> %z19.s
+05b732d5 : tbl z21.s, z22.s, z23.s                   : tbl    %z22.s %z23.s -> %z21.s
+05b93317 : tbl z23.s, z24.s, z25.s                   : tbl    %z24.s %z25.s -> %z23.s
+05bb3359 : tbl z25.s, z26.s, z27.s                   : tbl    %z26.s %z27.s -> %z25.s
+05bd339b : tbl z27.s, z28.s, z29.s                   : tbl    %z28.s %z29.s -> %z27.s
+05bf33ff : tbl z31.s, z31.s, z31.s                   : tbl    %z31.s %z31.s -> %z31.s
+05e03000 : tbl z0.d, z0.d, z0.d                      : tbl    %z0.d %z0.d -> %z0.d
+05e43062 : tbl z2.d, z3.d, z4.d                      : tbl    %z3.d %z4.d -> %z2.d
+05e630a4 : tbl z4.d, z5.d, z6.d                      : tbl    %z5.d %z6.d -> %z4.d
+05e830e6 : tbl z6.d, z7.d, z8.d                      : tbl    %z7.d %z8.d -> %z6.d
+05ea3128 : tbl z8.d, z9.d, z10.d                     : tbl    %z9.d %z10.d -> %z8.d
+05ec316a : tbl z10.d, z11.d, z12.d                   : tbl    %z11.d %z12.d -> %z10.d
+05ee31ac : tbl z12.d, z13.d, z14.d                   : tbl    %z13.d %z14.d -> %z12.d
+05f031ee : tbl z14.d, z15.d, z16.d                   : tbl    %z15.d %z16.d -> %z14.d
+05f23230 : tbl z16.d, z17.d, z18.d                   : tbl    %z17.d %z18.d -> %z16.d
+05f33251 : tbl z17.d, z18.d, z19.d                   : tbl    %z18.d %z19.d -> %z17.d
+05f53293 : tbl z19.d, z20.d, z21.d                   : tbl    %z20.d %z21.d -> %z19.d
+05f732d5 : tbl z21.d, z22.d, z23.d                   : tbl    %z22.d %z23.d -> %z21.d
+05f93317 : tbl z23.d, z24.d, z25.d                   : tbl    %z24.d %z25.d -> %z23.d
+05fb3359 : tbl z25.d, z26.d, z27.d                   : tbl    %z26.d %z27.d -> %z25.d
+05fd339b : tbl z27.d, z28.d, z29.d                   : tbl    %z28.d %z29.d -> %z27.d
+05ff33ff : tbl z31.d, z31.d, z31.d                   : tbl    %z31.d %z31.d -> %z31.d
 
 # UABD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (UABD-Z.P.ZZ-_)
 040d0000 : uabd z0.b, p0/M, z0.b, z0.b               : uabd   %p0/m %z0.b %z0.b -> %z0.b

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -147,10 +147,14 @@ const reg_id_t Xn_six_offset_0[6] = { DR_REG_X0,  DR_REG_X5,  DR_REG_X10,
                                       DR_REG_X15, DR_REG_X20, DR_REG_X30 };
 const reg_id_t Xn_six_offset_1_zr[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
                                          DR_REG_X16, DR_REG_X21, DR_REG_XZR };
+const reg_id_t Xn_six_offset_1_sp[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
+                                         DR_REG_X16, DR_REG_X21, DR_REG_XSP };
 const reg_id_t Wn_six_offset_0[6] = { DR_REG_W0,  DR_REG_W5,  DR_REG_W10,
                                       DR_REG_W15, DR_REG_W20, DR_REG_W30 };
 const reg_id_t Wn_six_offset_1_zr[6] = { DR_REG_W0,  DR_REG_W6,  DR_REG_W11,
                                          DR_REG_W16, DR_REG_W21, DR_REG_WZR };
+const reg_id_t Wn_six_offset_1_sp[6] = { DR_REG_W0,  DR_REG_W6,  DR_REG_W11,
+                                         DR_REG_W16, DR_REG_W21, DR_REG_WSP };
 const reg_id_t Vdn_b_six_offset_0[6] = { DR_REG_B0,  DR_REG_B5,  DR_REG_B10,
                                          DR_REG_B16, DR_REG_B21, DR_REG_B31 };
 const reg_id_t Vdn_h_six_offset_0[6] = { DR_REG_H0,  DR_REG_H5,  DR_REG_H10,

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -7672,6 +7672,281 @@ TEST_INSTR(whilelt_sve)
               opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
               opnd_create_reg(Rn_0_7[i]), opnd_create_reg(Rm_0_7[i]));
 }
+
+TEST_INSTR(tbl_sve)
+{
+
+    /* Testing TBL     <Zd>.<Ts>, { <Zn>.<Ts> }, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "tbl    %z0.b %z0.b -> %z0.b",    "tbl    %z6.b %z7.b -> %z5.b",
+        "tbl    %z11.b %z12.b -> %z10.b", "tbl    %z17.b %z18.b -> %z16.b",
+        "tbl    %z22.b %z23.b -> %z21.b", "tbl    %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(tbl, tbl_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "tbl    %z0.h %z0.h -> %z0.h",    "tbl    %z6.h %z7.h -> %z5.h",
+        "tbl    %z11.h %z12.h -> %z10.h", "tbl    %z17.h %z18.h -> %z16.h",
+        "tbl    %z22.h %z23.h -> %z21.h", "tbl    %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(tbl, tbl_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "tbl    %z0.s %z0.s -> %z0.s",    "tbl    %z6.s %z7.s -> %z5.s",
+        "tbl    %z11.s %z12.s -> %z10.s", "tbl    %z17.s %z18.s -> %z16.s",
+        "tbl    %z22.s %z23.s -> %z21.s", "tbl    %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(tbl, tbl_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "tbl    %z0.d %z0.d -> %z0.d",    "tbl    %z6.d %z7.d -> %z5.d",
+        "tbl    %z11.d %z12.d -> %z10.d", "tbl    %z17.d %z18.d -> %z16.d",
+        "tbl    %z22.d %z23.d -> %z21.d", "tbl    %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(tbl, tbl_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(dup_sve_shift)
+{
+
+    /* Testing DUP     <Zd>.<Ts>, #<imm>, <shift> */
+    static const int imm8_0_0[6] = { -128, -85, -42, 1, 43, 127 };
+    static const uint shift_0_0[6] = { 0, 0, 0, 0, 0, 0 };
+    const char *const expected_0_0[6] = {
+        "dup    $0x80 lsl $0x00 -> %z0.b",  "dup    $0xab lsl $0x00 -> %z5.b",
+        "dup    $0xd6 lsl $0x00 -> %z10.b", "dup    $0x01 lsl $0x00 -> %z16.b",
+        "dup    $0x2b lsl $0x00 -> %z21.b", "dup    $0x7f lsl $0x00 -> %z31.b",
+    };
+    TEST_LOOP(dup, dup_sve_shift, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm8_0_0[i], OPSZ_1),
+              opnd_create_immed_uint(shift_0_0[i], OPSZ_1b));
+
+    static const int imm8_0_1[6] = { -128, -85, -42, 1, 43, 127 };
+    static const uint shift_0_1[6] = { 8, 8, 8, 8, 0, 0 };
+    const char *const expected_0_1[6] = {
+        "dup    $0x80 lsl $0x08 -> %z0.h",  "dup    $0xab lsl $0x08 -> %z5.h",
+        "dup    $0xd6 lsl $0x08 -> %z10.h", "dup    $0x01 lsl $0x08 -> %z16.h",
+        "dup    $0x2b lsl $0x00 -> %z21.h", "dup    $0x7f lsl $0x00 -> %z31.h",
+    };
+    TEST_LOOP(dup, dup_sve_shift, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm8_0_1[i], OPSZ_1),
+              opnd_create_immed_uint(shift_0_1[i], OPSZ_1b));
+
+    static const int imm8_0_2[6] = { -128, -85, -42, 1, 43, 127 };
+    static const uint shift_0_2[6] = { 8, 8, 8, 8, 0, 0 };
+    const char *const expected_0_2[6] = {
+        "dup    $0x80 lsl $0x08 -> %z0.s",  "dup    $0xab lsl $0x08 -> %z5.s",
+        "dup    $0xd6 lsl $0x08 -> %z10.s", "dup    $0x01 lsl $0x08 -> %z16.s",
+        "dup    $0x2b lsl $0x00 -> %z21.s", "dup    $0x7f lsl $0x00 -> %z31.s",
+    };
+    TEST_LOOP(dup, dup_sve_shift, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm8_0_2[i], OPSZ_1),
+              opnd_create_immed_uint(shift_0_2[i], OPSZ_1b));
+
+    static const int imm8_0_3[6] = { -128, -85, -42, 1, 43, 127 };
+    static const uint shift_0_3[6] = { 8, 8, 8, 8, 0, 0 };
+    const char *const expected_0_3[6] = {
+        "dup    $0x80 lsl $0x08 -> %z0.d",  "dup    $0xab lsl $0x08 -> %z5.d",
+        "dup    $0xd6 lsl $0x08 -> %z10.d", "dup    $0x01 lsl $0x08 -> %z16.d",
+        "dup    $0x2b lsl $0x00 -> %z21.d", "dup    $0x7f lsl $0x00 -> %z31.d",
+    };
+    TEST_LOOP(dup, dup_sve_shift, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm8_0_3[i], OPSZ_1),
+              opnd_create_immed_uint(shift_0_3[i], OPSZ_1b));
+}
+
+TEST_INSTR(dup_sve_idx)
+{
+
+    /* Testing DUP     <Zd>.<Ts>, <Zn>.<Ts>[<index>] */
+    static const uint imm2_0_0[6] = { 0, 2, 3, 0, 0, 3 };
+    const char *const expected_0_0[6] = {
+        "dup    %z0.q $0x00 -> %z0.q",   "dup    %z6.q $0x02 -> %z5.q",
+        "dup    %z11.q $0x03 -> %z10.q", "dup    %z17.q $0x00 -> %z16.q",
+        "dup    %z22.q $0x00 -> %z21.q", "dup    %z31.q $0x03 -> %z31.q",
+    };
+    TEST_LOOP(dup, dup_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_immed_uint(imm2_0_0[i], OPSZ_2b));
+
+    static const uint imm2_0_1[6] = { 0, 3, 4, 6, 7, 7 };
+    const char *const expected_0_1[6] = {
+        "dup    %z0.d $0x00 -> %z0.d",   "dup    %z6.d $0x03 -> %z5.d",
+        "dup    %z11.d $0x04 -> %z10.d", "dup    %z17.d $0x06 -> %z16.d",
+        "dup    %z22.d $0x07 -> %z21.d", "dup    %z31.d $0x07 -> %z31.d",
+    };
+    TEST_LOOP(dup, dup_sve_idx, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
+              opnd_create_immed_uint(imm2_0_1[i], OPSZ_3b));
+
+    static const uint imm2_0_2[6] = { 0, 4, 7, 10, 12, 15 };
+    const char *const expected_0_2[6] = {
+        "dup    %z0.s $0x00 -> %z0.s",   "dup    %z6.s $0x04 -> %z5.s",
+        "dup    %z11.s $0x07 -> %z10.s", "dup    %z17.s $0x0a -> %z16.s",
+        "dup    %z22.s $0x0c -> %z21.s", "dup    %z31.s $0x0f -> %z31.s",
+    };
+    TEST_LOOP(dup, dup_sve_idx, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_immed_uint(imm2_0_2[i], OPSZ_4b));
+
+    static const uint imm2_0_3[6] = { 0, 7, 12, 18, 23, 31 };
+    const char *const expected_0_3[6] = {
+        "dup    %z0.h $0x00 -> %z0.h",   "dup    %z6.h $0x07 -> %z5.h",
+        "dup    %z11.h $0x0c -> %z10.h", "dup    %z17.h $0x12 -> %z16.h",
+        "dup    %z22.h $0x17 -> %z21.h", "dup    %z31.h $0x1f -> %z31.h",
+    };
+    TEST_LOOP(dup, dup_sve_idx, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_immed_uint(imm2_0_3[i], OPSZ_5b));
+
+    static const uint imm2_0_4[6] = { 0, 12, 23, 34, 44, 63 };
+    const char *const expected_0_4[6] = {
+        "dup    %z0.b $0x00 -> %z0.b",   "dup    %z6.b $0x0c -> %z5.b",
+        "dup    %z11.b $0x17 -> %z10.b", "dup    %z17.b $0x22 -> %z16.b",
+        "dup    %z22.b $0x2c -> %z21.b", "dup    %z31.b $0x3f -> %z31.b",
+    };
+    TEST_LOOP(dup, dup_sve_idx, 6, expected_0_4[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_immed_uint(imm2_0_4[i], OPSZ_6b));
+}
+
+TEST_INSTR(dup_sve_scalar)
+{
+    /* Testing DUP     <Zd>.<Ts>, <R><n|SP> */
+    const char *const expected_0_0[6] = {
+        "dup    %w0 -> %z0.b",   "dup    %w6 -> %z5.b",   "dup    %w11 -> %z10.b",
+        "dup    %w16 -> %z16.b", "dup    %w21 -> %z21.b", "dup    %wsp -> %z31.b",
+    };
+    TEST_LOOP(dup, dup_sve_scalar, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Wn_six_offset_1_sp[i]));
+
+    const char *const expected_0_1[6] = {
+        "dup    %w0 -> %z0.h",   "dup    %w6 -> %z5.h",   "dup    %w11 -> %z10.h",
+        "dup    %w16 -> %z16.h", "dup    %w21 -> %z21.h", "dup    %wsp -> %z31.h",
+    };
+    TEST_LOOP(dup, dup_sve_scalar, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Wn_six_offset_1_sp[i]));
+
+    const char *const expected_0_2[6] = {
+        "dup    %w0 -> %z0.s",   "dup    %w6 -> %z5.s",   "dup    %w11 -> %z10.s",
+        "dup    %w16 -> %z16.s", "dup    %w21 -> %z21.s", "dup    %wsp -> %z31.s",
+    };
+    TEST_LOOP(dup, dup_sve_scalar, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Wn_six_offset_1_sp[i]));
+
+    const char *const expected_0_3[6] = {
+        "dup    %x0 -> %z0.d",   "dup    %x6 -> %z5.d",   "dup    %x11 -> %z10.d",
+        "dup    %x16 -> %z16.d", "dup    %x21 -> %z21.d", "dup    %sp -> %z31.d",
+    };
+    TEST_LOOP(dup, dup_sve_scalar, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(insr_sve_scalar)
+{
+    /* Testing INSR    <Zdn>.<T>, <R><m> */
+    const char *const expected_0_0[6] = {
+        "insr   %z0.b %w0 -> %z0.b",    "insr   %z5.b %w6 -> %z5.b",
+        "insr   %z10.b %w11 -> %z10.b", "insr   %z16.b %w16 -> %z16.b",
+        "insr   %z21.b %w21 -> %z21.b", "insr   %z31.b %wzr -> %z31.b",
+    };
+    TEST_LOOP(insr, insr_sve_scalar, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Wn_six_offset_1_zr[i]));
+
+    const char *const expected_0_1[6] = {
+        "insr   %z0.h %w0 -> %z0.h",    "insr   %z5.h %w6 -> %z5.h",
+        "insr   %z10.h %w11 -> %z10.h", "insr   %z16.h %w16 -> %z16.h",
+        "insr   %z21.h %w21 -> %z21.h", "insr   %z31.h %wzr -> %z31.h",
+    };
+    TEST_LOOP(insr, insr_sve_scalar, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Wn_six_offset_1_zr[i]));
+
+    const char *const expected_0_2[6] = {
+        "insr   %z0.s %w0 -> %z0.s",    "insr   %z5.s %w6 -> %z5.s",
+        "insr   %z10.s %w11 -> %z10.s", "insr   %z16.s %w16 -> %z16.s",
+        "insr   %z21.s %w21 -> %z21.s", "insr   %z31.s %wzr -> %z31.s",
+    };
+    TEST_LOOP(insr, insr_sve_scalar, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Wn_six_offset_1_zr[i]));
+
+    const char *const expected_0_3[6] = {
+        "insr   %z0.d %x0 -> %z0.d",    "insr   %z5.d %x6 -> %z5.d",
+        "insr   %z10.d %x11 -> %z10.d", "insr   %z16.d %x16 -> %z16.d",
+        "insr   %z21.d %x21 -> %z21.d", "insr   %z31.d %xzr -> %z31.d",
+    };
+    TEST_LOOP(insr, insr_sve_scalar, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1_zr[i]));
+}
+
+TEST_INSTR(insr_sve_simd_fp)
+{
+    /* Testing INSR    <Zdn>.<Ts>, <V><m> */
+    const char *const expected_0_0[6] = {
+        "insr   %z0.b %b0 -> %z0.b",    "insr   %z5.b %b5 -> %z5.b",
+        "insr   %z10.b %b10 -> %z10.b", "insr   %z16.b %b16 -> %z16.b",
+        "insr   %z21.b %b21 -> %z21.b", "insr   %z31.b %b31 -> %z31.b",
+    };
+    TEST_LOOP(insr, insr_sve_simd_fp, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Vdn_b_six_offset_0[i]));
+
+    const char *const expected_0_1[6] = {
+        "insr   %z0.h %h0 -> %z0.h",    "insr   %z5.h %h5 -> %z5.h",
+        "insr   %z10.h %h10 -> %z10.h", "insr   %z16.h %h16 -> %z16.h",
+        "insr   %z21.h %h21 -> %z21.h", "insr   %z31.h %h31 -> %z31.h",
+    };
+    TEST_LOOP(insr, insr_sve_simd_fp, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Vdn_h_six_offset_0[i]));
+
+    const char *const expected_0_2[6] = {
+        "insr   %z0.s %s0 -> %z0.s",    "insr   %z5.s %s5 -> %z5.s",
+        "insr   %z10.s %s10 -> %z10.s", "insr   %z16.s %s16 -> %z16.s",
+        "insr   %z21.s %s21 -> %z21.s", "insr   %z31.s %s31 -> %z31.s",
+    };
+    TEST_LOOP(insr, insr_sve_simd_fp, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Vdn_s_six_offset_0[i]));
+
+    const char *const expected_0_3[6] = {
+        "insr   %z0.d %d0 -> %z0.d",    "insr   %z5.d %d5 -> %z5.d",
+        "insr   %z10.d %d10 -> %z10.d", "insr   %z16.d %d16 -> %z16.d",
+        "insr   %z21.d %d21 -> %z21.d", "insr   %z31.d %d31 -> %z31.d",
+    };
+    TEST_LOOP(insr, insr_sve_simd_fp, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Vdn_d_six_offset_0[i]));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -7912,6 +8187,13 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(whilelo_sve);
     RUN_INSTR_TEST(whilels_sve);
     RUN_INSTR_TEST(whilelt_sve);
+
+    RUN_INSTR_TEST(tbl_sve);
+    RUN_INSTR_TEST(dup_sve_shift);
+    RUN_INSTR_TEST(dup_sve_idx);
+    RUN_INSTR_TEST(dup_sve_scalar);
+    RUN_INSTR_TEST(insr_sve_scalar);
+    RUN_INSTR_TEST(insr_sve_simd_fp);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
TBL     <Zd>.<Ts>, { <Zn>.<Ts> }, <Zm>.<Ts>
DUP     <Zd>.<Ts>, #<imm>, <shift>
DUP     <Zd>.<Ts>, <Zn>.<Ts>[<index>]
DUP     <Zd>.<Ts>, <R><n|SP>
INSR    <Zdn>.<T>, <R><m>
INSR    <Zdn>.<Ts>, <V><m>
```

Issue #3044