### PR TITLE
i#3044 AArch64 SVE codec: Add EXT (Des.), SPLICE (Des.)

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1836,6 +1836,18 @@ encode_opnd_z0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 }
 
 static inline bool
+decode_opnd_z_b_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_Z0, 0, 5, BYTE_REG, enc, opnd);
+}
+
+static inline bool
+encode_opnd_z_b_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_single_sized(OPSZ_SCALABLE, 0, BYTE_REG, opnd, enc_out);
+}
+
+static inline bool
 decode_opnd_z_h_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     return decode_single_sized(DR_REG_Z0, 0, 5, HALF_REG, enc, opnd);
@@ -2105,6 +2117,18 @@ static inline bool
 encode_opnd_z5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_vector_reg(5, Z_REG, opnd, enc_out);
+}
+
+static inline bool
+decode_opnd_z_b_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_Z0, 5, 5, BYTE_REG, enc, opnd);
+}
+
+static inline bool
+encode_opnd_z_b_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_single_sized(OPSZ_SCALABLE, 5, BYTE_REG, opnd, enc_out);
 }
 
 static inline bool
@@ -3703,6 +3727,29 @@ static inline bool
 encode_opnd_s16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_vector_reg(16, 2, opnd, enc_out);
+}
+
+/* imm8_10: 8 bit imm at pos 10, split across 20:16 and 12:10. */
+
+static inline bool
+decode_opnd_imm8_10(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    const ptr_uint_t lo = extract_uint(enc, 10, 3);
+    const ptr_uint_t hi = extract_uint(enc, 16, 5) << 3;
+
+    *opnd = opnd_create_immed_uint(hi | lo, OPSZ_1);
+    return true;
+}
+
+static inline bool
+encode_opnd_imm8_10(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    uint imm;
+    if (!try_encode_imm(&imm, 8, opnd))
+        return false;
+
+    *enc_out = (BITS(imm, 7, 3) << 16) | (BITS(imm, 2, 0) << 10);
+    return true;
 }
 
 /* imm7: 7-bit immediate from bits 14-20 */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -123,6 +123,7 @@
 001001010000xxxx01xxxx1xxxx0xxxx  n   90   SVE      eor          p_b_0 : p10_zer p_b_5 p_b_16
 00000100101xxxxx001100xxxxxxxxxx  n   90   SVE      eor          z_d_0 : z_d_5 z_d_16
 001001010100xxxx01xxxx1xxxx0xxxx  w   828  SVE     eors          p_b_0 : p10_zer p_b_5 p_b_16
+00000101001xxxxx000xxxxxxxxxxxxx  n   92   SVE      ext          z_b_0 : z_b_0 z_b_5 imm8_10
 01100101xx0xxxxx110xxxxxxxx1xxxx  n   96   SVE    facge   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx0xxxxx111xxxxxxxx1xxxx  n   97   SVE    facgt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx010010001xxxxxxxx0xxxx  n   102  SVE    fcmeq   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
@@ -188,6 +189,7 @@
 00000100xx001010000xxxxxxxxxxxxx  n   390  SVE     smin  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx101010110xxxxxxxxxxxxx  n   390  SVE     smin  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
 00000100xx010010000xxxxxxxxxxxxx  n   399  SVE    smulh  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
+00000101xx101100100xxxxxxxxxxxxx  n   882  SVE   splice  z_size_bhsd_0 : p10_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx1xxxxx000100xxxxxxxxxx  n   403  SVE    sqadd             z0 : z5 z16 bhsd_sz
 00100101xx10010011xxxxxxxxxxxxxx  n   403  SVE    sqadd  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000100xxxxxxxxxx  n   403  SVE    sqadd  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -8377,4 +8377,34 @@
 #define INSTR_CREATE_insr_sve_simd_fp(dc, Zdn, Vm) \
     instr_create_1dst_2src(dc, OP_insr, Zdn, Zdn, Vm)
 
+/**
+ * Creates an EXT instruction (destructive).
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EXT     <Zdn>.B, <Zdn>.B, <Zm>.B, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn  The first source and destination vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ * \param imm  The immediate imm.
+ */
+#define INSTR_CREATE_ext_sve(dc, Zdn, Zm, imm) \
+    instr_create_1dst_3src(dc, OP_ext, Zdn, Zdn, Zm, imm)
+
+/**
+ * Creates a SPLICE instruction (destructive).
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SPLICE  <Zdn>.<Ts>, <Pv>, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn  The second source and destination vector register, Z (Scalable).
+ * \param Pv   The first source predicate register, P (Predicate).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_splice_sve(dc, Zdn, Pv, Zm) \
+    instr_create_1dst_3src(dc, OP_splice, Zdn, Pv, Zdn, Zm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -89,6 +89,7 @@
 ---------------------------xxxxx  d0         # D register
 ---------------------------xxxxx  q0         # Q register
 ---------------------------xxxxx  z0         # Z register
+---------------------------xxxxx  z_b_0      # Z register with b size elements
 ---------------------------xxxxx  z_h_0      # Z register with h size elements
 ---------------------------xxxxx  z_s_0      # Z register with s size elements
 ---------------------------xxxxx  z_d_0      # Z register with d size elements
@@ -109,6 +110,7 @@
 ----------------------xxxxx-----  d5         # D register
 ----------------------xxxxx-----  q5         # Q register
 ----------------------xxxxx-----  z5         # Z register
+----------------------xxxxx-----  z_b_5      # Z register with b size elements
 ----------------------xxxxx-----  z_d_5      # Z register with d size elements
 ----------------------xxxxx-----  z_q_5      # Z register with q size elements
 ----------------------xxxxx-----  mem9qpost  # size is 16 bytes; post-index
@@ -180,6 +182,7 @@
 -----------xxxxx----------------  b16        # B register
 -----------xxxxx----------------  h16        # H register
 -----------xxxxx----------------  s16        # S register
+-----------xxxxx---xxx----------  imm8_10    # 8 bit imm at pos 10, split across 20:16 and 12:10
 -----------xxxxxxx--------------  imm7       # 7 bit immediate from 14-20
 -----------xxxxxxxxx------------  mem9off    # immed offset for mem9/mem9post
 -----------xxxxxxxxx--xxxxx-----  mem9q      # size is 16 bytes

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -3812,6 +3812,24 @@
 25407bed : eors p13.b, p14/Z, p15.b, p0.b            : eors   %p14/z %p15.b %p0.b -> %p13.b
 254f7fef : eors p15.b, p15/Z, p15.b, p15.b           : eors   %p15/z %p15.b %p15.b -> %p15.b
 
+# EXT     <Zdn>.B, <Zdn>.B, <Zm>.B, #<imm> (EXT-Z.ZI-Des)
+05200000 : ext z0.b, z0.b, z0.b, #0x0                : ext    %z0.b %z0.b $0x00 -> %z0.b
+05220062 : ext z2.b, z2.b, z3.b, #0x10               : ext    %z2.b %z3.b $0x10 -> %z2.b
+052400a4 : ext z4.b, z4.b, z5.b, #0x20               : ext    %z4.b %z5.b $0x20 -> %z4.b
+052600e6 : ext z6.b, z6.b, z7.b, #0x30               : ext    %z6.b %z7.b $0x30 -> %z6.b
+05280128 : ext z8.b, z8.b, z9.b, #0x40               : ext    %z8.b %z9.b $0x40 -> %z8.b
+052a016a : ext z10.b, z10.b, z11.b, #0x50            : ext    %z10.b %z11.b $0x50 -> %z10.b
+052c01ac : ext z12.b, z12.b, z13.b, #0x60            : ext    %z12.b %z13.b $0x60 -> %z12.b
+052e01ee : ext z14.b, z14.b, z15.b, #0x70            : ext    %z14.b %z15.b $0x70 -> %z14.b
+05300230 : ext z16.b, z16.b, z17.b, #0x80            : ext    %z16.b %z17.b $0x80 -> %z16.b
+05311e51 : ext z17.b, z17.b, z18.b, #0x8f            : ext    %z17.b %z18.b $0x8f -> %z17.b
+05331e93 : ext z19.b, z19.b, z20.b, #0x9f            : ext    %z19.b %z20.b $0x9f -> %z19.b
+05351ed5 : ext z21.b, z21.b, z22.b, #0xaf            : ext    %z21.b %z22.b $0xaf -> %z21.b
+05371f17 : ext z23.b, z23.b, z24.b, #0xbf            : ext    %z23.b %z24.b $0xbf -> %z23.b
+05391f59 : ext z25.b, z25.b, z26.b, #0xcf            : ext    %z25.b %z26.b $0xcf -> %z25.b
+053b1f9b : ext z27.b, z27.b, z28.b, #0xdf            : ext    %z27.b %z28.b $0xdf -> %z27.b
+053f1fff : ext z31.b, z31.b, z31.b, #0xff            : ext    %z31.b %z31.b $0xff -> %z31.b
+
 # FACGE   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (FACGE-P.P.ZZ-_)
 6540c010 : facge p0.h, p0/Z, z0.h, z0.h              : facge  %p0/z %z0.h %z0.h -> %p0.h
 6545c491 : facge p1.h, p1/Z, z4.h, z5.h              : facge  %p1/z %z4.h %z5.h -> %p1.h
@@ -6725,6 +6743,72 @@
 04d21f79 : smulh z25.d, p7/M, z25.d, z27.d           : smulh  %p7/m %z25.d %z27.d -> %z25.d
 04d21fbb : smulh z27.d, p7/M, z27.d, z29.d           : smulh  %p7/m %z27.d %z29.d -> %z27.d
 04d21fff : smulh z31.d, p7/M, z31.d, z31.d           : smulh  %p7/m %z31.d %z31.d -> %z31.d
+
+# SPLICE  <Zdn>.<T>, <Pv>, <Zdn>.<T>, <Zm>.<T> (SPLICE-Z.P.ZZ-Des)
+052c8000 : splice z0.b, p0, z0.b, z0.b               : splice %p0 %z0.b %z0.b -> %z0.b
+052c8482 : splice z2.b, p1, z2.b, z4.b               : splice %p1 %z2.b %z4.b -> %z2.b
+052c88c4 : splice z4.b, p2, z4.b, z6.b               : splice %p2 %z4.b %z6.b -> %z4.b
+052c8906 : splice z6.b, p2, z6.b, z8.b               : splice %p2 %z6.b %z8.b -> %z6.b
+052c8d48 : splice z8.b, p3, z8.b, z10.b              : splice %p3 %z8.b %z10.b -> %z8.b
+052c8d8a : splice z10.b, p3, z10.b, z12.b            : splice %p3 %z10.b %z12.b -> %z10.b
+052c91cc : splice z12.b, p4, z12.b, z14.b            : splice %p4 %z12.b %z14.b -> %z12.b
+052c920e : splice z14.b, p4, z14.b, z16.b            : splice %p4 %z14.b %z16.b -> %z14.b
+052c9650 : splice z16.b, p5, z16.b, z18.b            : splice %p5 %z16.b %z18.b -> %z16.b
+052c9671 : splice z17.b, p5, z17.b, z19.b            : splice %p5 %z17.b %z19.b -> %z17.b
+052c96b3 : splice z19.b, p5, z19.b, z21.b            : splice %p5 %z19.b %z21.b -> %z19.b
+052c9af5 : splice z21.b, p6, z21.b, z23.b            : splice %p6 %z21.b %z23.b -> %z21.b
+052c9b37 : splice z23.b, p6, z23.b, z25.b            : splice %p6 %z23.b %z25.b -> %z23.b
+052c9f79 : splice z25.b, p7, z25.b, z27.b            : splice %p7 %z25.b %z27.b -> %z25.b
+052c9fbb : splice z27.b, p7, z27.b, z29.b            : splice %p7 %z27.b %z29.b -> %z27.b
+052c9fff : splice z31.b, p7, z31.b, z31.b            : splice %p7 %z31.b %z31.b -> %z31.b
+056c8000 : splice z0.h, p0, z0.h, z0.h               : splice %p0 %z0.h %z0.h -> %z0.h
+056c8482 : splice z2.h, p1, z2.h, z4.h               : splice %p1 %z2.h %z4.h -> %z2.h
+056c88c4 : splice z4.h, p2, z4.h, z6.h               : splice %p2 %z4.h %z6.h -> %z4.h
+056c8906 : splice z6.h, p2, z6.h, z8.h               : splice %p2 %z6.h %z8.h -> %z6.h
+056c8d48 : splice z8.h, p3, z8.h, z10.h              : splice %p3 %z8.h %z10.h -> %z8.h
+056c8d8a : splice z10.h, p3, z10.h, z12.h            : splice %p3 %z10.h %z12.h -> %z10.h
+056c91cc : splice z12.h, p4, z12.h, z14.h            : splice %p4 %z12.h %z14.h -> %z12.h
+056c920e : splice z14.h, p4, z14.h, z16.h            : splice %p4 %z14.h %z16.h -> %z14.h
+056c9650 : splice z16.h, p5, z16.h, z18.h            : splice %p5 %z16.h %z18.h -> %z16.h
+056c9671 : splice z17.h, p5, z17.h, z19.h            : splice %p5 %z17.h %z19.h -> %z17.h
+056c96b3 : splice z19.h, p5, z19.h, z21.h            : splice %p5 %z19.h %z21.h -> %z19.h
+056c9af5 : splice z21.h, p6, z21.h, z23.h            : splice %p6 %z21.h %z23.h -> %z21.h
+056c9b37 : splice z23.h, p6, z23.h, z25.h            : splice %p6 %z23.h %z25.h -> %z23.h
+056c9f79 : splice z25.h, p7, z25.h, z27.h            : splice %p7 %z25.h %z27.h -> %z25.h
+056c9fbb : splice z27.h, p7, z27.h, z29.h            : splice %p7 %z27.h %z29.h -> %z27.h
+056c9fff : splice z31.h, p7, z31.h, z31.h            : splice %p7 %z31.h %z31.h -> %z31.h
+05ac8000 : splice z0.s, p0, z0.s, z0.s               : splice %p0 %z0.s %z0.s -> %z0.s
+05ac8482 : splice z2.s, p1, z2.s, z4.s               : splice %p1 %z2.s %z4.s -> %z2.s
+05ac88c4 : splice z4.s, p2, z4.s, z6.s               : splice %p2 %z4.s %z6.s -> %z4.s
+05ac8906 : splice z6.s, p2, z6.s, z8.s               : splice %p2 %z6.s %z8.s -> %z6.s
+05ac8d48 : splice z8.s, p3, z8.s, z10.s              : splice %p3 %z8.s %z10.s -> %z8.s
+05ac8d8a : splice z10.s, p3, z10.s, z12.s            : splice %p3 %z10.s %z12.s -> %z10.s
+05ac91cc : splice z12.s, p4, z12.s, z14.s            : splice %p4 %z12.s %z14.s -> %z12.s
+05ac920e : splice z14.s, p4, z14.s, z16.s            : splice %p4 %z14.s %z16.s -> %z14.s
+05ac9650 : splice z16.s, p5, z16.s, z18.s            : splice %p5 %z16.s %z18.s -> %z16.s
+05ac9671 : splice z17.s, p5, z17.s, z19.s            : splice %p5 %z17.s %z19.s -> %z17.s
+05ac96b3 : splice z19.s, p5, z19.s, z21.s            : splice %p5 %z19.s %z21.s -> %z19.s
+05ac9af5 : splice z21.s, p6, z21.s, z23.s            : splice %p6 %z21.s %z23.s -> %z21.s
+05ac9b37 : splice z23.s, p6, z23.s, z25.s            : splice %p6 %z23.s %z25.s -> %z23.s
+05ac9f79 : splice z25.s, p7, z25.s, z27.s            : splice %p7 %z25.s %z27.s -> %z25.s
+05ac9fbb : splice z27.s, p7, z27.s, z29.s            : splice %p7 %z27.s %z29.s -> %z27.s
+05ac9fff : splice z31.s, p7, z31.s, z31.s            : splice %p7 %z31.s %z31.s -> %z31.s
+05ec8000 : splice z0.d, p0, z0.d, z0.d               : splice %p0 %z0.d %z0.d -> %z0.d
+05ec8482 : splice z2.d, p1, z2.d, z4.d               : splice %p1 %z2.d %z4.d -> %z2.d
+05ec88c4 : splice z4.d, p2, z4.d, z6.d               : splice %p2 %z4.d %z6.d -> %z4.d
+05ec8906 : splice z6.d, p2, z6.d, z8.d               : splice %p2 %z6.d %z8.d -> %z6.d
+05ec8d48 : splice z8.d, p3, z8.d, z10.d              : splice %p3 %z8.d %z10.d -> %z8.d
+05ec8d8a : splice z10.d, p3, z10.d, z12.d            : splice %p3 %z10.d %z12.d -> %z10.d
+05ec91cc : splice z12.d, p4, z12.d, z14.d            : splice %p4 %z12.d %z14.d -> %z12.d
+05ec920e : splice z14.d, p4, z14.d, z16.d            : splice %p4 %z14.d %z16.d -> %z14.d
+05ec9650 : splice z16.d, p5, z16.d, z18.d            : splice %p5 %z16.d %z18.d -> %z16.d
+05ec9671 : splice z17.d, p5, z17.d, z19.d            : splice %p5 %z17.d %z19.d -> %z17.d
+05ec96b3 : splice z19.d, p5, z19.d, z21.d            : splice %p5 %z19.d %z21.d -> %z19.d
+05ec9af5 : splice z21.d, p6, z21.d, z23.d            : splice %p6 %z21.d %z23.d -> %z21.d
+05ec9b37 : splice z23.d, p6, z23.d, z25.d            : splice %p6 %z23.d %z25.d -> %z23.d
+05ec9f79 : splice z25.d, p7, z25.d, z27.d            : splice %p7 %z25.d %z27.d -> %z25.d
+05ec9fbb : splice z27.d, p7, z27.d, z29.d            : splice %p7 %z27.d %z29.d -> %z27.d
+05ec9fff : splice z31.d, p7, z31.d, z31.d            : splice %p7 %z31.d %z31.d -> %z31.d
 
 # SQADD   <Zdn>.<T>, <Zdn>.<T>, #<imm>, <shift> (SQADD-Z.ZI-_)
 2524c000 : sqadd z0.b, z0.b, #0x0, lsl #0            : sqadd  %z0.b $0x00 lsl $0x00 -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -7947,6 +7947,65 @@ TEST_INSTR(insr_sve_simd_fp)
               opnd_create_reg(Vdn_d_six_offset_0[i]));
 }
 
+TEST_INSTR(ext_sve)
+{
+    /* Testing EXT     <Zdn>.B, <Zdn>.B, <Zm>.B, #<imm> */
+    static const uint imm8_0_0[6] = { 0, 44, 87, 130, 172, 255 };
+    const char *const expected_0_0[6] = {
+        "ext    %z0.b %z0.b $0x00 -> %z0.b",    "ext    %z5.b %z6.b $0x2c -> %z5.b",
+        "ext    %z10.b %z11.b $0x57 -> %z10.b", "ext    %z16.b %z17.b $0x82 -> %z16.b",
+        "ext    %z21.b %z22.b $0xac -> %z21.b", "ext    %z31.b %z31.b $0xff -> %z31.b",
+    };
+    TEST_LOOP(ext, ext_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_immed_uint(imm8_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(splice_sve)
+{
+    /* Testing SPLICE  <Zdn>.<Ts>, <Pv>, <Zdn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "splice %p0 %z0.b %z0.b -> %z0.b",    "splice %p2 %z5.b %z7.b -> %z5.b",
+        "splice %p3 %z10.b %z12.b -> %z10.b", "splice %p5 %z16.b %z18.b -> %z16.b",
+        "splice %p6 %z21.b %z23.b -> %z21.b", "splice %p7 %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(splice, splice_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "splice %p0 %z0.h %z0.h -> %z0.h",    "splice %p2 %z5.h %z7.h -> %z5.h",
+        "splice %p3 %z10.h %z12.h -> %z10.h", "splice %p5 %z16.h %z18.h -> %z16.h",
+        "splice %p6 %z21.h %z23.h -> %z21.h", "splice %p7 %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(splice, splice_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "splice %p0 %z0.s %z0.s -> %z0.s",    "splice %p2 %z5.s %z7.s -> %z5.s",
+        "splice %p3 %z10.s %z12.s -> %z10.s", "splice %p5 %z16.s %z18.s -> %z16.s",
+        "splice %p6 %z21.s %z23.s -> %z21.s", "splice %p7 %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(splice, splice_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "splice %p0 %z0.d %z0.d -> %z0.d",    "splice %p2 %z5.d %z7.d -> %z5.d",
+        "splice %p3 %z10.d %z12.d -> %z10.d", "splice %p5 %z16.d %z18.d -> %z16.d",
+        "splice %p6 %z21.d %z23.d -> %z21.d", "splice %p7 %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(splice, splice_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -8194,6 +8253,9 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(dup_sve_scalar);
     RUN_INSTR_TEST(insr_sve_scalar);
     RUN_INSTR_TEST(insr_sve_simd_fp);
+
+    RUN_INSTR_TEST(ext_sve);
+    RUN_INSTR_TEST(splice_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
EXT     <Zdn>.B, <Zdn>.B, <Zm>.B, #<imm>
SPLICE  <Zdn>.<Ts>, <Pv>, <Zdn>.<Ts>, <Zm>.<Ts>
```
Issue #3044