### PR TITLE
i#3044 AArch64 SVE codec: Add REV, REVB, REVH, REVW, COMPACT

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -104,6 +104,7 @@
 000001000110xxxx111000xxxxxxxxxx  n   845  SVE     cnth             x0 : pred_constr mul imm4_16p1
 00100101xx10000010xxxx0xxxxxxxxx  n   821  SVE     cntp             x0 : p10 p_size_bhsd_5
 000001001010xxxx111000xxxxxxxxxx  n   846  SVE     cntw             x0 : pred_constr mul imm4_16p1
+00000101xx100001100xxxxxxxxxxxxx  n   886  SVE  compact    z_size_sd_0 : p10_lo z_size_sd_5
 00000101xx01xxxx00xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_zer simm8_5 lsl shift1
 00000101xx01xxxx01xxxxxxxxxxxxxx  n   785  SVE      cpy  z_size_bhsd_0 : p16_mrg simm8_5 lsl shift1
 000001000011xxxx111001xxxxxxxxxx  n   840  SVE     decb             x0 : x0 pred_constr mul imm4_16p1
@@ -180,6 +181,11 @@
 0010010100011001111100000000xxxx  n   817  SVE    rdffr          p_b_0 :
 00100101000110001111000xxxx0xxxx  n   817  SVE    rdffr          p_b_0 : p5_zer
 00100101010110001111000xxxx0xxxx  w   818  SVE   rdffrs          p_b_0 : p5_zer
+00000101xx1101000100000xxxx0xxxx  n   337  SVE      rev  p_size_bhsd_0 : p_size_bhsd_5
+00000101xx111000001110xxxxxxxxxx  n   337  SVE      rev  z_size_bhsd_0 : z_size_bhsd_5
+00000101xx100100100xxxxxxxxxxxxx  n   883  SVE     revb   z_size_hsd_0 : p10_mrg_lo z_size_hsd_5
+00000101xx100101100xxxxxxxxxxxxx  n   884  SVE     revh    z_size_sd_0 : p10_mrg_lo z_size_sd_5
+0000010111100110100xxxxxxxxxxxxx  n   885  SVE     revw          z_d_0 : p10_mrg_lo z_d_5
 00000100xx001100000xxxxxxxxxxxxx  n   349  SVE     sabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx010100000xxxxxxxxxxxxx  n   363  SVE     sdiv    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
 00000100xx010110000xxxxxxxxxxxxx  n   794  SVE    sdivr    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -8407,4 +8407,89 @@
 #define INSTR_CREATE_splice_sve(dc, Zdn, Pv, Zm) \
     instr_create_1dst_3src(dc, OP_splice, Zdn, Pv, Zdn, Zm)
 
+/**
+ * Creates a REV instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    REV     <Pd>.<Ts>, <Pn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pn   The source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_rev_sve_pred(dc, Pd, Pn) instr_create_1dst_1src(dc, OP_rev, Pd, Pn)
+
+/**
+ * Creates a REV instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    REV     <Zd>.<Ts>, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_rev_sve(dc, Zd, Zn) instr_create_1dst_1src(dc, OP_rev, Zd, Zn)
+
+/**
+ * Creates a REVB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    REVB    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_revb_sve(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_revb, Zd, Pg, Zn)
+
+/**
+ * Creates a REVH instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    REVH    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_revh_sve(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_revh, Zd, Pg, Zn)
+
+/**
+ * Creates a REVW instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    REVW    <Zd>.D, <Pg>/M, <Zn>.D
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_revw_sve(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_revw, Zd, Pg, Zn)
+
+/**
+ * Creates a COMPACT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    COMPACT <Zd>.<Ts>, <Pg>, <Zn>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_compact_sve(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_compact, Zd, Pg, Zn)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -2991,6 +2991,40 @@
 04aee3dc : cntw x28, MUL3, MUL #15                   : cntw   MUL3 mul $0x0f -> %x28
 04afe3fe : cntw x30, ALL, MUL #16                    : cntw   ALL mul $0x10 -> %x30
 
+# COMPACT <Zd>.<T>, <Pg>, <Zn>.<T> (COMPACT-Z.P.Z-_)
+05a18000 : compact z0.s, p0, z0.s                    : compact %p0 %z0.s -> %z0.s
+05a18482 : compact z2.s, p1, z4.s                    : compact %p1 %z4.s -> %z2.s
+05a188c4 : compact z4.s, p2, z6.s                    : compact %p2 %z6.s -> %z4.s
+05a18906 : compact z6.s, p2, z8.s                    : compact %p2 %z8.s -> %z6.s
+05a18d48 : compact z8.s, p3, z10.s                   : compact %p3 %z10.s -> %z8.s
+05a18d8a : compact z10.s, p3, z12.s                  : compact %p3 %z12.s -> %z10.s
+05a191cc : compact z12.s, p4, z14.s                  : compact %p4 %z14.s -> %z12.s
+05a1920e : compact z14.s, p4, z16.s                  : compact %p4 %z16.s -> %z14.s
+05a19650 : compact z16.s, p5, z18.s                  : compact %p5 %z18.s -> %z16.s
+05a19671 : compact z17.s, p5, z19.s                  : compact %p5 %z19.s -> %z17.s
+05a196b3 : compact z19.s, p5, z21.s                  : compact %p5 %z21.s -> %z19.s
+05a19af5 : compact z21.s, p6, z23.s                  : compact %p6 %z23.s -> %z21.s
+05a19b37 : compact z23.s, p6, z25.s                  : compact %p6 %z25.s -> %z23.s
+05a19f79 : compact z25.s, p7, z27.s                  : compact %p7 %z27.s -> %z25.s
+05a19fbb : compact z27.s, p7, z29.s                  : compact %p7 %z29.s -> %z27.s
+05a19fff : compact z31.s, p7, z31.s                  : compact %p7 %z31.s -> %z31.s
+05e18000 : compact z0.d, p0, z0.d                    : compact %p0 %z0.d -> %z0.d
+05e18482 : compact z2.d, p1, z4.d                    : compact %p1 %z4.d -> %z2.d
+05e188c4 : compact z4.d, p2, z6.d                    : compact %p2 %z6.d -> %z4.d
+05e18906 : compact z6.d, p2, z8.d                    : compact %p2 %z8.d -> %z6.d
+05e18d48 : compact z8.d, p3, z10.d                   : compact %p3 %z10.d -> %z8.d
+05e18d8a : compact z10.d, p3, z12.d                  : compact %p3 %z12.d -> %z10.d
+05e191cc : compact z12.d, p4, z14.d                  : compact %p4 %z14.d -> %z12.d
+05e1920e : compact z14.d, p4, z16.d                  : compact %p4 %z16.d -> %z14.d
+05e19650 : compact z16.d, p5, z18.d                  : compact %p5 %z18.d -> %z16.d
+05e19671 : compact z17.d, p5, z19.d                  : compact %p5 %z19.d -> %z17.d
+05e196b3 : compact z19.d, p5, z21.d                  : compact %p5 %z21.d -> %z19.d
+05e19af5 : compact z21.d, p6, z23.d                  : compact %p6 %z23.d -> %z21.d
+05e19b37 : compact z23.d, p6, z25.d                  : compact %p6 %z25.d -> %z23.d
+05e19f79 : compact z25.d, p7, z27.d                  : compact %p7 %z27.d -> %z25.d
+05e19fbb : compact z27.d, p7, z29.d                  : compact %p7 %z29.d -> %z27.d
+05e19fff : compact z31.d, p7, z31.d                  : compact %p7 %z31.d -> %z31.d
+
 # CPY     <Zd>.<T>, <Pg>/Z, #<imm>, <shift> (CPY-Z.O.I-_)
 05101000 : cpy z0.b, p0/Z, #-0x80, lsl #0            : cpy    %p0/z $0x80 lsl $0x00 -> %z0.b
 05121202 : cpy z2.b, p2/Z, #-0x70, lsl #0            : cpy    %p2/z $0x90 lsl $0x00 -> %z2.b
@@ -6276,6 +6310,240 @@
 2558f1ac : rdffrs p12.b, p13/Z                       : rdffrs %p13/z -> %p12.b
 2558f1cd : rdffrs p13.b, p14/Z                       : rdffrs %p14/z -> %p13.b
 2558f1ef : rdffrs p15.b, p15/Z                       : rdffrs %p15/z -> %p15.b
+
+# REV     <Pd>.<T>, <Pn>.<T> (REV-P.P-_)
+05344000 : rev p0.b, p0.b                            : rev    %p0.b -> %p0.b
+05344041 : rev p1.b, p2.b                            : rev    %p2.b -> %p1.b
+05344062 : rev p2.b, p3.b                            : rev    %p3.b -> %p2.b
+05344083 : rev p3.b, p4.b                            : rev    %p4.b -> %p3.b
+053440a4 : rev p4.b, p5.b                            : rev    %p5.b -> %p4.b
+053440c5 : rev p5.b, p6.b                            : rev    %p6.b -> %p5.b
+053440e6 : rev p6.b, p7.b                            : rev    %p7.b -> %p6.b
+05344107 : rev p7.b, p8.b                            : rev    %p8.b -> %p7.b
+05344128 : rev p8.b, p9.b                            : rev    %p9.b -> %p8.b
+05344128 : rev p8.b, p9.b                            : rev    %p9.b -> %p8.b
+05344149 : rev p9.b, p10.b                           : rev    %p10.b -> %p9.b
+0534416a : rev p10.b, p11.b                          : rev    %p11.b -> %p10.b
+0534418b : rev p11.b, p12.b                          : rev    %p12.b -> %p11.b
+053441ac : rev p12.b, p13.b                          : rev    %p13.b -> %p12.b
+053441cd : rev p13.b, p14.b                          : rev    %p14.b -> %p13.b
+053441ef : rev p15.b, p15.b                          : rev    %p15.b -> %p15.b
+05744000 : rev p0.h, p0.h                            : rev    %p0.h -> %p0.h
+05744041 : rev p1.h, p2.h                            : rev    %p2.h -> %p1.h
+05744062 : rev p2.h, p3.h                            : rev    %p3.h -> %p2.h
+05744083 : rev p3.h, p4.h                            : rev    %p4.h -> %p3.h
+057440a4 : rev p4.h, p5.h                            : rev    %p5.h -> %p4.h
+057440c5 : rev p5.h, p6.h                            : rev    %p6.h -> %p5.h
+057440e6 : rev p6.h, p7.h                            : rev    %p7.h -> %p6.h
+05744107 : rev p7.h, p8.h                            : rev    %p8.h -> %p7.h
+05744128 : rev p8.h, p9.h                            : rev    %p9.h -> %p8.h
+05744128 : rev p8.h, p9.h                            : rev    %p9.h -> %p8.h
+05744149 : rev p9.h, p10.h                           : rev    %p10.h -> %p9.h
+0574416a : rev p10.h, p11.h                          : rev    %p11.h -> %p10.h
+0574418b : rev p11.h, p12.h                          : rev    %p12.h -> %p11.h
+057441ac : rev p12.h, p13.h                          : rev    %p13.h -> %p12.h
+057441cd : rev p13.h, p14.h                          : rev    %p14.h -> %p13.h
+057441ef : rev p15.h, p15.h                          : rev    %p15.h -> %p15.h
+05b44000 : rev p0.s, p0.s                            : rev    %p0.s -> %p0.s
+05b44041 : rev p1.s, p2.s                            : rev    %p2.s -> %p1.s
+05b44062 : rev p2.s, p3.s                            : rev    %p3.s -> %p2.s
+05b44083 : rev p3.s, p4.s                            : rev    %p4.s -> %p3.s
+05b440a4 : rev p4.s, p5.s                            : rev    %p5.s -> %p4.s
+05b440c5 : rev p5.s, p6.s                            : rev    %p6.s -> %p5.s
+05b440e6 : rev p6.s, p7.s                            : rev    %p7.s -> %p6.s
+05b44107 : rev p7.s, p8.s                            : rev    %p8.s -> %p7.s
+05b44128 : rev p8.s, p9.s                            : rev    %p9.s -> %p8.s
+05b44128 : rev p8.s, p9.s                            : rev    %p9.s -> %p8.s
+05b44149 : rev p9.s, p10.s                           : rev    %p10.s -> %p9.s
+05b4416a : rev p10.s, p11.s                          : rev    %p11.s -> %p10.s
+05b4418b : rev p11.s, p12.s                          : rev    %p12.s -> %p11.s
+05b441ac : rev p12.s, p13.s                          : rev    %p13.s -> %p12.s
+05b441cd : rev p13.s, p14.s                          : rev    %p14.s -> %p13.s
+05b441ef : rev p15.s, p15.s                          : rev    %p15.s -> %p15.s
+05f44000 : rev p0.d, p0.d                            : rev    %p0.d -> %p0.d
+05f44041 : rev p1.d, p2.d                            : rev    %p2.d -> %p1.d
+05f44062 : rev p2.d, p3.d                            : rev    %p3.d -> %p2.d
+05f44083 : rev p3.d, p4.d                            : rev    %p4.d -> %p3.d
+05f440a4 : rev p4.d, p5.d                            : rev    %p5.d -> %p4.d
+05f440c5 : rev p5.d, p6.d                            : rev    %p6.d -> %p5.d
+05f440e6 : rev p6.d, p7.d                            : rev    %p7.d -> %p6.d
+05f44107 : rev p7.d, p8.d                            : rev    %p8.d -> %p7.d
+05f44128 : rev p8.d, p9.d                            : rev    %p9.d -> %p8.d
+05f44128 : rev p8.d, p9.d                            : rev    %p9.d -> %p8.d
+05f44149 : rev p9.d, p10.d                           : rev    %p10.d -> %p9.d
+05f4416a : rev p10.d, p11.d                          : rev    %p11.d -> %p10.d
+05f4418b : rev p11.d, p12.d                          : rev    %p12.d -> %p11.d
+05f441ac : rev p12.d, p13.d                          : rev    %p13.d -> %p12.d
+05f441cd : rev p13.d, p14.d                          : rev    %p14.d -> %p13.d
+05f441ef : rev p15.d, p15.d                          : rev    %p15.d -> %p15.d
+
+# REV     <Zd>.<T>, <Zn>.<T> (REV-Z.Z-_)
+05383800 : rev z0.b, z0.b                            : rev    %z0.b -> %z0.b
+05383862 : rev z2.b, z3.b                            : rev    %z3.b -> %z2.b
+053838a4 : rev z4.b, z5.b                            : rev    %z5.b -> %z4.b
+053838e6 : rev z6.b, z7.b                            : rev    %z7.b -> %z6.b
+05383928 : rev z8.b, z9.b                            : rev    %z9.b -> %z8.b
+0538396a : rev z10.b, z11.b                          : rev    %z11.b -> %z10.b
+053839ac : rev z12.b, z13.b                          : rev    %z13.b -> %z12.b
+053839ee : rev z14.b, z15.b                          : rev    %z15.b -> %z14.b
+05383a30 : rev z16.b, z17.b                          : rev    %z17.b -> %z16.b
+05383a51 : rev z17.b, z18.b                          : rev    %z18.b -> %z17.b
+05383a93 : rev z19.b, z20.b                          : rev    %z20.b -> %z19.b
+05383ad5 : rev z21.b, z22.b                          : rev    %z22.b -> %z21.b
+05383b17 : rev z23.b, z24.b                          : rev    %z24.b -> %z23.b
+05383b59 : rev z25.b, z26.b                          : rev    %z26.b -> %z25.b
+05383b9b : rev z27.b, z28.b                          : rev    %z28.b -> %z27.b
+05383bff : rev z31.b, z31.b                          : rev    %z31.b -> %z31.b
+05783800 : rev z0.h, z0.h                            : rev    %z0.h -> %z0.h
+05783862 : rev z2.h, z3.h                            : rev    %z3.h -> %z2.h
+057838a4 : rev z4.h, z5.h                            : rev    %z5.h -> %z4.h
+057838e6 : rev z6.h, z7.h                            : rev    %z7.h -> %z6.h
+05783928 : rev z8.h, z9.h                            : rev    %z9.h -> %z8.h
+0578396a : rev z10.h, z11.h                          : rev    %z11.h -> %z10.h
+057839ac : rev z12.h, z13.h                          : rev    %z13.h -> %z12.h
+057839ee : rev z14.h, z15.h                          : rev    %z15.h -> %z14.h
+05783a30 : rev z16.h, z17.h                          : rev    %z17.h -> %z16.h
+05783a51 : rev z17.h, z18.h                          : rev    %z18.h -> %z17.h
+05783a93 : rev z19.h, z20.h                          : rev    %z20.h -> %z19.h
+05783ad5 : rev z21.h, z22.h                          : rev    %z22.h -> %z21.h
+05783b17 : rev z23.h, z24.h                          : rev    %z24.h -> %z23.h
+05783b59 : rev z25.h, z26.h                          : rev    %z26.h -> %z25.h
+05783b9b : rev z27.h, z28.h                          : rev    %z28.h -> %z27.h
+05783bff : rev z31.h, z31.h                          : rev    %z31.h -> %z31.h
+05b83800 : rev z0.s, z0.s                            : rev    %z0.s -> %z0.s
+05b83862 : rev z2.s, z3.s                            : rev    %z3.s -> %z2.s
+05b838a4 : rev z4.s, z5.s                            : rev    %z5.s -> %z4.s
+05b838e6 : rev z6.s, z7.s                            : rev    %z7.s -> %z6.s
+05b83928 : rev z8.s, z9.s                            : rev    %z9.s -> %z8.s
+05b8396a : rev z10.s, z11.s                          : rev    %z11.s -> %z10.s
+05b839ac : rev z12.s, z13.s                          : rev    %z13.s -> %z12.s
+05b839ee : rev z14.s, z15.s                          : rev    %z15.s -> %z14.s
+05b83a30 : rev z16.s, z17.s                          : rev    %z17.s -> %z16.s
+05b83a51 : rev z17.s, z18.s                          : rev    %z18.s -> %z17.s
+05b83a93 : rev z19.s, z20.s                          : rev    %z20.s -> %z19.s
+05b83ad5 : rev z21.s, z22.s                          : rev    %z22.s -> %z21.s
+05b83b17 : rev z23.s, z24.s                          : rev    %z24.s -> %z23.s
+05b83b59 : rev z25.s, z26.s                          : rev    %z26.s -> %z25.s
+05b83b9b : rev z27.s, z28.s                          : rev    %z28.s -> %z27.s
+05b83bff : rev z31.s, z31.s                          : rev    %z31.s -> %z31.s
+05f83800 : rev z0.d, z0.d                            : rev    %z0.d -> %z0.d
+05f83862 : rev z2.d, z3.d                            : rev    %z3.d -> %z2.d
+05f838a4 : rev z4.d, z5.d                            : rev    %z5.d -> %z4.d
+05f838e6 : rev z6.d, z7.d                            : rev    %z7.d -> %z6.d
+05f83928 : rev z8.d, z9.d                            : rev    %z9.d -> %z8.d
+05f8396a : rev z10.d, z11.d                          : rev    %z11.d -> %z10.d
+05f839ac : rev z12.d, z13.d                          : rev    %z13.d -> %z12.d
+05f839ee : rev z14.d, z15.d                          : rev    %z15.d -> %z14.d
+05f83a30 : rev z16.d, z17.d                          : rev    %z17.d -> %z16.d
+05f83a51 : rev z17.d, z18.d                          : rev    %z18.d -> %z17.d
+05f83a93 : rev z19.d, z20.d                          : rev    %z20.d -> %z19.d
+05f83ad5 : rev z21.d, z22.d                          : rev    %z22.d -> %z21.d
+05f83b17 : rev z23.d, z24.d                          : rev    %z24.d -> %z23.d
+05f83b59 : rev z25.d, z26.d                          : rev    %z26.d -> %z25.d
+05f83b9b : rev z27.d, z28.d                          : rev    %z28.d -> %z27.d
+05f83bff : rev z31.d, z31.d                          : rev    %z31.d -> %z31.d
+
+# REVB    <Zd>.<T>, <Pg>/M, <Zn>.<T> (REVB-Z.Z-_)
+05648000 : revb z0.h, p0/M, z0.h                     : revb   %p0/m %z0.h -> %z0.h
+05648482 : revb z2.h, p1/M, z4.h                     : revb   %p1/m %z4.h -> %z2.h
+056488c4 : revb z4.h, p2/M, z6.h                     : revb   %p2/m %z6.h -> %z4.h
+05648906 : revb z6.h, p2/M, z8.h                     : revb   %p2/m %z8.h -> %z6.h
+05648d48 : revb z8.h, p3/M, z10.h                    : revb   %p3/m %z10.h -> %z8.h
+05648d8a : revb z10.h, p3/M, z12.h                   : revb   %p3/m %z12.h -> %z10.h
+056491cc : revb z12.h, p4/M, z14.h                   : revb   %p4/m %z14.h -> %z12.h
+0564920e : revb z14.h, p4/M, z16.h                   : revb   %p4/m %z16.h -> %z14.h
+05649650 : revb z16.h, p5/M, z18.h                   : revb   %p5/m %z18.h -> %z16.h
+05649671 : revb z17.h, p5/M, z19.h                   : revb   %p5/m %z19.h -> %z17.h
+056496b3 : revb z19.h, p5/M, z21.h                   : revb   %p5/m %z21.h -> %z19.h
+05649af5 : revb z21.h, p6/M, z23.h                   : revb   %p6/m %z23.h -> %z21.h
+05649b37 : revb z23.h, p6/M, z25.h                   : revb   %p6/m %z25.h -> %z23.h
+05649f79 : revb z25.h, p7/M, z27.h                   : revb   %p7/m %z27.h -> %z25.h
+05649fbb : revb z27.h, p7/M, z29.h                   : revb   %p7/m %z29.h -> %z27.h
+05649fff : revb z31.h, p7/M, z31.h                   : revb   %p7/m %z31.h -> %z31.h
+05a48000 : revb z0.s, p0/M, z0.s                     : revb   %p0/m %z0.s -> %z0.s
+05a48482 : revb z2.s, p1/M, z4.s                     : revb   %p1/m %z4.s -> %z2.s
+05a488c4 : revb z4.s, p2/M, z6.s                     : revb   %p2/m %z6.s -> %z4.s
+05a48906 : revb z6.s, p2/M, z8.s                     : revb   %p2/m %z8.s -> %z6.s
+05a48d48 : revb z8.s, p3/M, z10.s                    : revb   %p3/m %z10.s -> %z8.s
+05a48d8a : revb z10.s, p3/M, z12.s                   : revb   %p3/m %z12.s -> %z10.s
+05a491cc : revb z12.s, p4/M, z14.s                   : revb   %p4/m %z14.s -> %z12.s
+05a4920e : revb z14.s, p4/M, z16.s                   : revb   %p4/m %z16.s -> %z14.s
+05a49650 : revb z16.s, p5/M, z18.s                   : revb   %p5/m %z18.s -> %z16.s
+05a49671 : revb z17.s, p5/M, z19.s                   : revb   %p5/m %z19.s -> %z17.s
+05a496b3 : revb z19.s, p5/M, z21.s                   : revb   %p5/m %z21.s -> %z19.s
+05a49af5 : revb z21.s, p6/M, z23.s                   : revb   %p6/m %z23.s -> %z21.s
+05a49b37 : revb z23.s, p6/M, z25.s                   : revb   %p6/m %z25.s -> %z23.s
+05a49f79 : revb z25.s, p7/M, z27.s                   : revb   %p7/m %z27.s -> %z25.s
+05a49fbb : revb z27.s, p7/M, z29.s                   : revb   %p7/m %z29.s -> %z27.s
+05a49fff : revb z31.s, p7/M, z31.s                   : revb   %p7/m %z31.s -> %z31.s
+05e48000 : revb z0.d, p0/M, z0.d                     : revb   %p0/m %z0.d -> %z0.d
+05e48482 : revb z2.d, p1/M, z4.d                     : revb   %p1/m %z4.d -> %z2.d
+05e488c4 : revb z4.d, p2/M, z6.d                     : revb   %p2/m %z6.d -> %z4.d
+05e48906 : revb z6.d, p2/M, z8.d                     : revb   %p2/m %z8.d -> %z6.d
+05e48d48 : revb z8.d, p3/M, z10.d                    : revb   %p3/m %z10.d -> %z8.d
+05e48d8a : revb z10.d, p3/M, z12.d                   : revb   %p3/m %z12.d -> %z10.d
+05e491cc : revb z12.d, p4/M, z14.d                   : revb   %p4/m %z14.d -> %z12.d
+05e4920e : revb z14.d, p4/M, z16.d                   : revb   %p4/m %z16.d -> %z14.d
+05e49650 : revb z16.d, p5/M, z18.d                   : revb   %p5/m %z18.d -> %z16.d
+05e49671 : revb z17.d, p5/M, z19.d                   : revb   %p5/m %z19.d -> %z17.d
+05e496b3 : revb z19.d, p5/M, z21.d                   : revb   %p5/m %z21.d -> %z19.d
+05e49af5 : revb z21.d, p6/M, z23.d                   : revb   %p6/m %z23.d -> %z21.d
+05e49b37 : revb z23.d, p6/M, z25.d                   : revb   %p6/m %z25.d -> %z23.d
+05e49f79 : revb z25.d, p7/M, z27.d                   : revb   %p7/m %z27.d -> %z25.d
+05e49fbb : revb z27.d, p7/M, z29.d                   : revb   %p7/m %z29.d -> %z27.d
+05e49fff : revb z31.d, p7/M, z31.d                   : revb   %p7/m %z31.d -> %z31.d
+
+# REVH    <Zd>.<T>, <Pg>/M, <Zn>.<T> (REVH-Z.Z-_)
+05a58000 : revh z0.s, p0/M, z0.s                     : revh   %p0/m %z0.s -> %z0.s
+05a58482 : revh z2.s, p1/M, z4.s                     : revh   %p1/m %z4.s -> %z2.s
+05a588c4 : revh z4.s, p2/M, z6.s                     : revh   %p2/m %z6.s -> %z4.s
+05a58906 : revh z6.s, p2/M, z8.s                     : revh   %p2/m %z8.s -> %z6.s
+05a58d48 : revh z8.s, p3/M, z10.s                    : revh   %p3/m %z10.s -> %z8.s
+05a58d8a : revh z10.s, p3/M, z12.s                   : revh   %p3/m %z12.s -> %z10.s
+05a591cc : revh z12.s, p4/M, z14.s                   : revh   %p4/m %z14.s -> %z12.s
+05a5920e : revh z14.s, p4/M, z16.s                   : revh   %p4/m %z16.s -> %z14.s
+05a59650 : revh z16.s, p5/M, z18.s                   : revh   %p5/m %z18.s -> %z16.s
+05a59671 : revh z17.s, p5/M, z19.s                   : revh   %p5/m %z19.s -> %z17.s
+05a596b3 : revh z19.s, p5/M, z21.s                   : revh   %p5/m %z21.s -> %z19.s
+05a59af5 : revh z21.s, p6/M, z23.s                   : revh   %p6/m %z23.s -> %z21.s
+05a59b37 : revh z23.s, p6/M, z25.s                   : revh   %p6/m %z25.s -> %z23.s
+05a59f79 : revh z25.s, p7/M, z27.s                   : revh   %p7/m %z27.s -> %z25.s
+05a59fbb : revh z27.s, p7/M, z29.s                   : revh   %p7/m %z29.s -> %z27.s
+05a59fff : revh z31.s, p7/M, z31.s                   : revh   %p7/m %z31.s -> %z31.s
+05e58000 : revh z0.d, p0/M, z0.d                     : revh   %p0/m %z0.d -> %z0.d
+05e58482 : revh z2.d, p1/M, z4.d                     : revh   %p1/m %z4.d -> %z2.d
+05e588c4 : revh z4.d, p2/M, z6.d                     : revh   %p2/m %z6.d -> %z4.d
+05e58906 : revh z6.d, p2/M, z8.d                     : revh   %p2/m %z8.d -> %z6.d
+05e58d48 : revh z8.d, p3/M, z10.d                    : revh   %p3/m %z10.d -> %z8.d
+05e58d8a : revh z10.d, p3/M, z12.d                   : revh   %p3/m %z12.d -> %z10.d
+05e591cc : revh z12.d, p4/M, z14.d                   : revh   %p4/m %z14.d -> %z12.d
+05e5920e : revh z14.d, p4/M, z16.d                   : revh   %p4/m %z16.d -> %z14.d
+05e59650 : revh z16.d, p5/M, z18.d                   : revh   %p5/m %z18.d -> %z16.d
+05e59671 : revh z17.d, p5/M, z19.d                   : revh   %p5/m %z19.d -> %z17.d
+05e596b3 : revh z19.d, p5/M, z21.d                   : revh   %p5/m %z21.d -> %z19.d
+05e59af5 : revh z21.d, p6/M, z23.d                   : revh   %p6/m %z23.d -> %z21.d
+05e59b37 : revh z23.d, p6/M, z25.d                   : revh   %p6/m %z25.d -> %z23.d
+05e59f79 : revh z25.d, p7/M, z27.d                   : revh   %p7/m %z27.d -> %z25.d
+05e59fbb : revh z27.d, p7/M, z29.d                   : revh   %p7/m %z29.d -> %z27.d
+05e59fff : revh z31.d, p7/M, z31.d                   : revh   %p7/m %z31.d -> %z31.d
+
+# REVW    <Zd>.D, <Pg>/M, <Zn>.D (REVW-Z.Z-_)
+05e68000 : revw z0.d, p0/M, z0.d                     : revw   %p0/m %z0.d -> %z0.d
+05e68482 : revw z2.d, p1/M, z4.d                     : revw   %p1/m %z4.d -> %z2.d
+05e688c4 : revw z4.d, p2/M, z6.d                     : revw   %p2/m %z6.d -> %z4.d
+05e68906 : revw z6.d, p2/M, z8.d                     : revw   %p2/m %z8.d -> %z6.d
+05e68d48 : revw z8.d, p3/M, z10.d                    : revw   %p3/m %z10.d -> %z8.d
+05e68d8a : revw z10.d, p3/M, z12.d                   : revw   %p3/m %z12.d -> %z10.d
+05e691cc : revw z12.d, p4/M, z14.d                   : revw   %p4/m %z14.d -> %z12.d
+05e6920e : revw z14.d, p4/M, z16.d                   : revw   %p4/m %z16.d -> %z14.d
+05e69650 : revw z16.d, p5/M, z18.d                   : revw   %p5/m %z18.d -> %z16.d
+05e69671 : revw z17.d, p5/M, z19.d                   : revw   %p5/m %z19.d -> %z17.d
+05e696b3 : revw z19.d, p5/M, z21.d                   : revw   %p5/m %z21.d -> %z19.d
+05e69af5 : revw z21.d, p6/M, z23.d                   : revw   %p6/m %z23.d -> %z21.d
+05e69b37 : revw z23.d, p6/M, z25.d                   : revw   %p6/m %z25.d -> %z23.d
+05e69f79 : revw z25.d, p7/M, z27.d                   : revw   %p7/m %z27.d -> %z25.d
+05e69fbb : revw z27.d, p7/M, z29.d                   : revw   %p7/m %z29.d -> %z27.d
+05e69fff : revw z31.d, p7/M, z31.d                   : revw   %p7/m %z31.d -> %z31.d
 
 # SABD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SABD-Z.P.ZZ-_)
 040c0000 : sabd z0.b, p0/M, z0.b, z0.b               : sabd   %p0/m %z0.b %z0.b -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -8006,6 +8006,174 @@ TEST_INSTR(splice_sve)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
+TEST_INSTR(rev_sve_pred)
+{
+    /* Testing REV     <Pd>.<Ts>, <Pn>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "rev    %p0.b -> %p0.b", "rev    %p3.b -> %p2.b",   "rev    %p6.b -> %p5.b",
+        "rev    %p9.b -> %p8.b", "rev    %p11.b -> %p10.b", "rev    %p15.b -> %p15.b",
+    };
+    TEST_LOOP(rev, rev_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "rev    %p0.h -> %p0.h", "rev    %p3.h -> %p2.h",   "rev    %p6.h -> %p5.h",
+        "rev    %p9.h -> %p8.h", "rev    %p11.h -> %p10.h", "rev    %p15.h -> %p15.h",
+    };
+    TEST_LOOP(rev, rev_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "rev    %p0.s -> %p0.s", "rev    %p3.s -> %p2.s",   "rev    %p6.s -> %p5.s",
+        "rev    %p9.s -> %p8.s", "rev    %p11.s -> %p10.s", "rev    %p15.s -> %p15.s",
+    };
+    TEST_LOOP(rev, rev_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "rev    %p0.d -> %p0.d", "rev    %p3.d -> %p2.d",   "rev    %p6.d -> %p5.d",
+        "rev    %p9.d -> %p8.d", "rev    %p11.d -> %p10.d", "rev    %p15.d -> %p15.d",
+    };
+    TEST_LOOP(rev, rev_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(rev_sve)
+{
+    /* Testing REV     <Zd>.<Ts>, <Zn>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "rev    %z0.b -> %z0.b",   "rev    %z6.b -> %z5.b",   "rev    %z11.b -> %z10.b",
+        "rev    %z17.b -> %z16.b", "rev    %z22.b -> %z21.b", "rev    %z31.b -> %z31.b",
+    };
+    TEST_LOOP(rev, rev_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "rev    %z0.h -> %z0.h",   "rev    %z6.h -> %z5.h",   "rev    %z11.h -> %z10.h",
+        "rev    %z17.h -> %z16.h", "rev    %z22.h -> %z21.h", "rev    %z31.h -> %z31.h",
+    };
+    TEST_LOOP(rev, rev_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "rev    %z0.s -> %z0.s",   "rev    %z6.s -> %z5.s",   "rev    %z11.s -> %z10.s",
+        "rev    %z17.s -> %z16.s", "rev    %z22.s -> %z21.s", "rev    %z31.s -> %z31.s",
+    };
+    TEST_LOOP(rev, rev_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "rev    %z0.d -> %z0.d",   "rev    %z6.d -> %z5.d",   "rev    %z11.d -> %z10.d",
+        "rev    %z17.d -> %z16.d", "rev    %z22.d -> %z21.d", "rev    %z31.d -> %z31.d",
+    };
+    TEST_LOOP(rev, rev_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(revb_sve)
+{
+    /* Testing REVB    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "revb   %p0/m %z0.h -> %z0.h",   "revb   %p2/m %z7.h -> %z5.h",
+        "revb   %p3/m %z12.h -> %z10.h", "revb   %p5/m %z18.h -> %z16.h",
+        "revb   %p6/m %z23.h -> %z21.h", "revb   %p7/m %z31.h -> %z31.h",
+    };
+    TEST_LOOP(revb, revb_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *const expected_0_1[6] = {
+        "revb   %p0/m %z0.s -> %z0.s",   "revb   %p2/m %z7.s -> %z5.s",
+        "revb   %p3/m %z12.s -> %z10.s", "revb   %p5/m %z18.s -> %z16.s",
+        "revb   %p6/m %z23.s -> %z21.s", "revb   %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(revb, revb_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_2[6] = {
+        "revb   %p0/m %z0.d -> %z0.d",   "revb   %p2/m %z7.d -> %z5.d",
+        "revb   %p3/m %z12.d -> %z10.d", "revb   %p5/m %z18.d -> %z16.d",
+        "revb   %p6/m %z23.d -> %z21.d", "revb   %p7/m %z31.d -> %z31.d",
+    };
+    TEST_LOOP(revb, revb_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(revh_sve)
+{
+    /* Testing REVH    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "revh   %p0/m %z0.s -> %z0.s",   "revh   %p2/m %z7.s -> %z5.s",
+        "revh   %p3/m %z12.s -> %z10.s", "revh   %p5/m %z18.s -> %z16.s",
+        "revh   %p6/m %z23.s -> %z21.s", "revh   %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(revh, revh_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_1[6] = {
+        "revh   %p0/m %z0.d -> %z0.d",   "revh   %p2/m %z7.d -> %z5.d",
+        "revh   %p3/m %z12.d -> %z10.d", "revh   %p5/m %z18.d -> %z16.d",
+        "revh   %p6/m %z23.d -> %z21.d", "revh   %p7/m %z31.d -> %z31.d",
+    };
+    TEST_LOOP(revh, revh_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(revw_sve)
+{
+    /* Testing REVW    <Zd>.D, <Pg>/M, <Zn>.D */
+    const char *const expected_0_0[6] = {
+        "revw   %p0/m %z0.d -> %z0.d",   "revw   %p2/m %z7.d -> %z5.d",
+        "revw   %p3/m %z12.d -> %z10.d", "revw   %p5/m %z18.d -> %z16.d",
+        "revw   %p6/m %z23.d -> %z21.d", "revw   %p7/m %z31.d -> %z31.d",
+    };
+    TEST_LOOP(revw, revw_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(compact_sve)
+{
+    /* Testing COMPACT <Zd>.<Ts>, <Pg>, <Zn>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "compact %p0 %z0.s -> %z0.s",   "compact %p2 %z7.s -> %z5.s",
+        "compact %p3 %z12.s -> %z10.s", "compact %p5 %z18.s -> %z16.s",
+        "compact %p6 %z23.s -> %z21.s", "compact %p7 %z31.s -> %z31.s",
+    };
+    TEST_LOOP(compact, compact_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_1[6] = {
+        "compact %p0 %z0.d -> %z0.d",   "compact %p2 %z7.d -> %z5.d",
+        "compact %p3 %z12.d -> %z10.d", "compact %p5 %z18.d -> %z16.d",
+        "compact %p6 %z23.d -> %z21.d", "compact %p7 %z31.d -> %z31.d",
+    };
+    TEST_LOOP(compact, compact_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -8256,6 +8424,14 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(ext_sve);
     RUN_INSTR_TEST(splice_sve);
+
+    RUN_INSTR_TEST(rev_sve_pred);
+    RUN_INSTR_TEST(rev_sve);
+    RUN_INSTR_TEST(revb_sve);
+    RUN_INSTR_TEST(revh_sve);
+    RUN_INSTR_TEST(revw_sve);
+
+    RUN_INSTR_TEST(compact_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
REV     <Pd>.<Ts>, <Pn>.<Ts>
REV     <Zd>.<Ts>, <Zn>.<Ts>
REVB    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
REVH    <Zd>.<Ts>, <Pg>/M, <Zn>.<Ts>
REVW    <Zd>.D, <Pg>/M, <Zn>.D
COMPACT <Zd>.<Ts>, <Pg>, <Zn>.<Ts>
```

Issue #3044