### PR TITLE
i#3044 AArch64 SVE codec: Add DUPM, EON

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -121,6 +121,7 @@
 00100101xx11100011xxxxxxxxxxxxxx  n   88   SVE      dup  z_size_bhsd_0 : simm8_5 lsl shift1
 00000101xx1xxxxx001000xxxxxxxxxx  n   88   SVE      dup  z_tsz_bhsdq_0 : z_tsz_bhsdq_5 imm2_tsz_index
 00000101xx100000001110xxxxxxxxxx  n   88   SVE      dup  z_size_bhsd_0 : wx_size_5_sp
+00000101110000xxxxxxxxxxxxxxxxxx  n   893  SVE     dupm  z_imm13_bhsd_0 : imm13_const
 00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor             z0 : p10_lo z0 z5 bhsd_sz
 00000101010000xxxxxxxxxxxxxxxxxx  n   90   SVE      eor  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010000xxxx01xxxx1xxxx0xxxx  n   90   SVE      eor          p_b_0 : p10_zer p_b_5 p_b_16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -6675,7 +6675,8 @@
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zdn   The first source and destination vector register, Z (Scalable).
- * \param imm   The immediate logicalImm
+ * \param imm   The immediate logicalImm.  The 13 bit immediate defining a 64, 32, 16 or 8
+ * bit mask of 2, 4, 8, 16, 32 or 64 bit fields.
  */
 #define INSTR_CREATE_and_sve_imm(dc, Zdn, imm) \
     instr_create_1dst_2src(dc, OP_and, Zdn, Zdn, imm)
@@ -6689,7 +6690,8 @@
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zdn   The first source and destination vector register, Z (Scalable).
- * \param imm   The immediate logicalImm
+ * \param imm   The immediate logicalImm.  The 13 bit immediate defining a 64, 32, 16 or 8
+ * bit mask of 2, 4, 8, 16, 32 or 64 bit fields.
  */
 #define INSTR_CREATE_bic_sve_imm(dc, Zdn, imm) \
     instr_create_1dst_2src(dc, OP_and, Zdn, Zdn, opnd_invert_immed_int(imm))
@@ -6703,7 +6705,8 @@
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zdn   The first source and destination vector register, Z (Scalable).
- * \param imm   The immediate logicalImm
+ * \param imm   The immediate logicalImm.  The 13 bit immediate defining a 64, 32, 16 or 8
+ * bit mask of 2, 4, 8, 16, 32 or 64 bit fields.
  */
 #define INSTR_CREATE_eor_sve_imm(dc, Zdn, imm) \
     instr_create_1dst_2src(dc, OP_eor, Zdn, Zdn, imm)
@@ -6717,7 +6720,8 @@
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zdn   The first source and destination vector register, Z (Scalable).
- * \param imm   The immediate logicalImm
+ * \param imm   The immediate logicalImm.  The 13 bit immediate defining a 64, 32, 16 or 8
+ * bit mask of 2, 4, 8, 16, 32 or 64 bit fields.
  */
 #define INSTR_CREATE_orr_sve_imm(dc, Zdn, imm) \
     instr_create_1dst_2src(dc, OP_orr, Zdn, Zdn, imm)
@@ -6731,7 +6735,8 @@
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zdn   The first source and destination vector register, Z (Scalable).
- * \param imm   The immediate logicalImm
+ * \param imm   The immediate logicalImm.  The 13 bit immediate defining a 64, 32, 16 or 8
+ * bit mask of 2, 4, 8, 16, 32 or 64 bit fields.
  */
 #define INSTR_CREATE_orn_sve_imm(dc, Zdn, imm) \
     instr_create_1dst_2src(dc, OP_orr, Zdn, Zdn, opnd_invert_immed_int(imm))
@@ -8783,5 +8788,34 @@
  */
 #define INSTR_CREATE_trn2_sve_vector(dc, Zd, Zn, Zm) \
     instr_create_1dst_2src(dc, OP_trn2, Zd, Zn, Zm)
+
+/**
+ * Creates a DUPM instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    DUPM    <Zd>.<Ts>, #<const>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param imm  The immediate logicalImm.  The 13 bit immediate defining a 64, 32, 16 or 8
+ * bit mask of 2, 4, 8, 16, 32 or 64 bit fields.
+ */
+#define INSTR_CREATE_dupm_sve(dc, Zd, imm) instr_create_1dst_1src(dc, OP_dupm, Zd, imm)
+
+/**
+ * Creates an EON instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EON     <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param imm   The immediate logicalImm.  The 13 bit immediate defining a 64, 32, 16 or 8
+ * bit mask of 2, 4, 8, 16, 32 or 64 bit fields.
+ */
+#define INSTR_CREATE_eon_sve_imm(dc, Zdn, imm) \
+    instr_create_1dst_2src(dc, OP_eor, Zdn, Zdn, opnd_invert_immed_int(imm))
 
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -3857,6 +3857,68 @@
 05e03b7b : dup z27.d, x27          : dup    %x27 -> %z27.d
 05e03bff : dup z31.d, sp           : dup    %sp -> %z31.d
 
+# DUP   <Zdn>.<T>, #<const> (DUPM-Z.I-_)
+05c006a0 : dupm z0.b, #0x3f                   : dupm   $0x3f -> %z0.b
+05c00604 : dupm z4.b, #0x01                   : dupm   $0x01 -> %z4.b
+05c03e06 : dupm z6.b, #0x02                   : dupm   $0x02 -> %z6.b
+05c03608 : dupm z8.b, #0x04                   : dupm   $0x04 -> %z8.b
+05c02e0a : dupm z10.b, #0x08                  : dupm   $0x08 -> %z10.b
+05c0260c : dupm z12.b, #0x10                  : dupm   $0x10 -> %z12.b
+05c01e0e : dupm z14.b, #0x20                  : dupm   $0x20 -> %z14.b
+05c00630 : dupm z16.b, #0x03                  : dupm   $0x03 -> %z16.b
+05c00652 : dupm z18.b, #0x07                  : dupm   $0x07 -> %z18.b
+05c00674 : dupm z20.b, #0x0f                  : dupm   $0x0f -> %z20.b
+05c00696 : dupm z22.b, #0x1f                  : dupm   $0x1f -> %z22.b
+05c03e98 : dupm z24.b, #0x3e                  : dupm   $0x3e -> %z24.b
+05c0367a : dupm z26.b, #0x3c                  : dupm   $0x3c -> %z26.b
+05c02e5c : dupm z28.b, #0x38                  : dupm   $0x38 -> %z28.b
+05c0263f : dupm z31.b, #0x30                  : dupm   $0x30 -> %z31.b
+05c004a0 : dupm z0.h, #0x3f                   : dupm   $0x003f -> %z0.h
+05c00404 : dupm z4.h, #0x01                   : dupm   $0x0001 -> %z4.h
+05c07c06 : dupm z6.h, #0x02                   : dupm   $0x0002 -> %z6.h
+05c07408 : dupm z8.h, #0x04                   : dupm   $0x0004 -> %z8.h
+05c06c0a : dupm z10.h, #0x08                  : dupm   $0x0008 -> %z10.h
+05c0640c : dupm z12.h, #0x10                  : dupm   $0x0010 -> %z12.h
+05c05c0e : dupm z14.h, #0x20                  : dupm   $0x0020 -> %z14.h
+05c00430 : dupm z16.h, #0x03                  : dupm   $0x0003 -> %z16.h
+05c00452 : dupm z18.h, #0x07                  : dupm   $0x0007 -> %z18.h
+05c00474 : dupm z20.h, #0x0f                  : dupm   $0x000f -> %z20.h
+05c00496 : dupm z22.h, #0x1f                  : dupm   $0x001f -> %z22.h
+05c07c98 : dupm z24.h, #0x3e                  : dupm   $0x003e -> %z24.h
+05c0747a : dupm z26.h, #0x3c                  : dupm   $0x003c -> %z26.h
+05c06c5c : dupm z28.h, #0x38                  : dupm   $0x0038 -> %z28.h
+05c0643f : dupm z31.h, #0x30                  : dupm   $0x0030 -> %z31.h
+05c000a0 : dupm z0.s, #0x3f                   : dupm   $0x0000003f -> %z0.s
+05c00004 : dupm z4.s, #0x01                   : dupm   $0x00000001 -> %z4.s
+05c0f806 : dupm z6.s, #0x02                   : dupm   $0x00000002 -> %z6.s
+05c0f008 : dupm z8.s, #0x04                   : dupm   $0x00000004 -> %z8.s
+05c0e80a : dupm z10.s, #0x08                  : dupm   $0x00000008 -> %z10.s
+05c0e00c : dupm z12.s, #0x10                  : dupm   $0x00000010 -> %z12.s
+05c0d80e : dupm z14.s, #0x20                  : dupm   $0x00000020 -> %z14.s
+05c00030 : dupm z16.s, #0x03                  : dupm   $0x00000003 -> %z16.s
+05c00052 : dupm z18.s, #0x07                  : dupm   $0x00000007 -> %z18.s
+05c00074 : dupm z20.s, #0x0f                  : dupm   $0x0000000f -> %z20.s
+05c00096 : dupm z22.s, #0x1f                  : dupm   $0x0000001f -> %z22.s
+05c0f898 : dupm z24.s, #0x3e                  : dupm   $0x0000003e -> %z24.s
+05c0f07a : dupm z26.s, #0x3c                  : dupm   $0x0000003c -> %z26.s
+05c0e85c : dupm z28.s, #0x38                  : dupm   $0x00000038 -> %z28.s
+05c0e03f : dupm z31.s, #0x30                  : dupm   $0x00000030 -> %z31.s
+05c200a0 : dupm z0.d, #0x3f                   : dupm   $0x000000000000003f -> %z0.d
+05c20004 : dupm z4.d, #0x01                   : dupm   $0x0000000000000001 -> %z4.d
+05c3f806 : dupm z6.d, #0x02                   : dupm   $0x0000000000000002 -> %z6.d
+05c3f008 : dupm z8.d, #0x04                   : dupm   $0x0000000000000004 -> %z8.d
+05c3e80a : dupm z10.d, #0x08                  : dupm   $0x0000000000000008 -> %z10.d
+05c3e00c : dupm z12.d, #0x10                  : dupm   $0x0000000000000010 -> %z12.d
+05c3d80e : dupm z14.d, #0x20                  : dupm   $0x0000000000000020 -> %z14.d
+05c20030 : dupm z16.d, #0x03                  : dupm   $0x0000000000000003 -> %z16.d
+05c20052 : dupm z18.d, #0x07                  : dupm   $0x0000000000000007 -> %z18.d
+05c20074 : dupm z20.d, #0x0f                  : dupm   $0x000000000000000f -> %z20.d
+05c20096 : dupm z22.d, #0x1f                  : dupm   $0x000000000000001f -> %z22.d
+05c3f898 : dupm z24.d, #0x3e                  : dupm   $0x000000000000003e -> %z24.d
+05c3f07a : dupm z26.d, #0x3c                  : dupm   $0x000000000000003c -> %z26.d
+05c3e85c : dupm z28.d, #0x38                  : dupm   $0x0000000000000038 -> %z28.d
+05c3e03f : dupm z31.d, #0x30                  : dupm   $0x0000000000000030 -> %z31.d
+
 0419105d : eor z29.b, p4/m, z29.b, z2.b             : eor    %p4 %z29 %z2 $0x00 -> %z29
 0459105d : eor z29.h, p4/m, z29.h, z2.h             : eor    %p4 %z29 %z2 $0x01 -> %z29
 0499105d : eor z29.s, p4/m, z29.s, z2.s             : eor    %p4 %z29 %z2 $0x02 -> %z29

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -8987,6 +8987,90 @@ TEST_INSTR(trn2_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
+TEST_INSTR(dupm_sve)
+{
+    /* Testing DUPM    <Zd>.<Ts>, #<const> */
+    int imm13[6] = { 1, 4, 8, 16, 32, 63 };
+    const char *expected_0[6] = {
+        "dupm   $0x01 -> %z0.b",  "dupm   $0x04 -> %z5.b",  "dupm   $0x08 -> %z10.b",
+        "dupm   $0x10 -> %z16.b", "dupm   $0x20 -> %z21.b", "dupm   $0x3f -> %z31.b",
+    };
+    TEST_LOOP(dupm, dupm_sve, 6, expected_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm13[i], OPSZ_1));
+
+    const char *expected_1[6] = {
+        "dupm   $0x0001 -> %z0.h",  "dupm   $0x0004 -> %z5.h",
+        "dupm   $0x0008 -> %z10.h", "dupm   $0x0010 -> %z16.h",
+        "dupm   $0x0020 -> %z21.h", "dupm   $0x003f -> %z31.h",
+    };
+    TEST_LOOP(dupm, dupm_sve, 6, expected_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm13[i], OPSZ_2));
+
+    const char *expected_2[6] = {
+        "dupm   $0x00000001 -> %z0.s",  "dupm   $0x00000004 -> %z5.s",
+        "dupm   $0x00000008 -> %z10.s", "dupm   $0x00000010 -> %z16.s",
+        "dupm   $0x00000020 -> %z21.s", "dupm   $0x0000003f -> %z31.s",
+    };
+    TEST_LOOP(dupm, dupm_sve, 6, expected_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm13[i], OPSZ_4));
+
+    const char *expected_3[6] = {
+        "dupm   $0x0000000000000001 -> %z0.d",  "dupm   $0x0000000000000004 -> %z5.d",
+        "dupm   $0x0000000000000008 -> %z10.d", "dupm   $0x0000000000000010 -> %z16.d",
+        "dupm   $0x0000000000000020 -> %z21.d", "dupm   $0x000000000000003f -> %z31.d",
+    };
+    TEST_LOOP(dupm, dupm_sve, 6, expected_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm13[i], OPSZ_8));
+}
+
+TEST_INSTR(eon_sve_imm)
+{
+    /* Testing EON     <Zdn>.<T>, <Zdn>.<T>, #<imm> */
+    int imm13[6] = { 1, 4, 8, 16, 32, 63 };
+    const char *expected_0[6] = {
+        "eor    %z0.b $0xfe -> %z0.b",   "eor    %z5.b $0xfb -> %z5.b",
+        "eor    %z10.b $0xf7 -> %z10.b", "eor    %z16.b $0xef -> %z16.b",
+        "eor    %z21.b $0xdf -> %z21.b", "eor    %z31.b $0xc0 -> %z31.b",
+    };
+    TEST_LOOP(eor, eon_sve_imm, 6, expected_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_int(imm13[i], OPSZ_1));
+
+    const char *expected_1[6] = {
+        "eor    %z0.h $0xfffe -> %z0.h",   "eor    %z5.h $0xfffb -> %z5.h",
+        "eor    %z10.h $0xfff7 -> %z10.h", "eor    %z16.h $0xffef -> %z16.h",
+        "eor    %z21.h $0xffdf -> %z21.h", "eor    %z31.h $0xffc0 -> %z31.h",
+    };
+    TEST_LOOP(eor, eon_sve_imm, 6, expected_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_int(imm13[i], OPSZ_2));
+
+    const char *expected_2[6] = {
+        "eor    %z0.s $0xfffffffe -> %z0.s",   "eor    %z5.s $0xfffffffb -> %z5.s",
+        "eor    %z10.s $0xfffffff7 -> %z10.s", "eor    %z16.s $0xffffffef -> %z16.s",
+        "eor    %z21.s $0xffffffdf -> %z21.s", "eor    %z31.s $0xffffffc0 -> %z31.s",
+    };
+    TEST_LOOP(eor, eon_sve_imm, 6, expected_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_int(imm13[i], OPSZ_4));
+
+    const char *expected_3[6] = {
+        "eor    %z0.d $0xfffffffffffffffe -> %z0.d",
+        "eor    %z5.d $0xfffffffffffffffb -> %z5.d",
+        "eor    %z10.d $0xfffffffffffffff7 -> %z10.d",
+        "eor    %z16.d $0xffffffffffffffef -> %z16.d",
+        "eor    %z21.d $0xffffffffffffffdf -> %z21.d",
+        "eor    %z31.d $0xffffffffffffffc0 -> %z31.d",
+    };
+    TEST_LOOP(eor, eon_sve_imm, 6, expected_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_int(imm13[i], OPSZ_8));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -9268,6 +9352,9 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(trn1_sve_vector);
     RUN_INSTR_TEST(trn2_sve_pred);
     RUN_INSTR_TEST(trn2_sve_vector);
+
+    RUN_INSTR_TEST(dupm_sve);
+    RUN_INSTR_TEST(eon_sve_imm);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
DUPM    <Zd>.<Ts>, #<const>
EON     <Zdn>.<Ts>, <Zdn>.<Ts>, #<imm>
```

Issue #3044