### PR TITLE
i#3044 AArch64 SVE codec: Add MOV, MOVS, PFALSE, PFIRST, PTRUE, PTRUES, SEL

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -2048,6 +2048,23 @@ encode_opnd_p_b_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out
     return encode_single_sized(OPSZ_SCALABLE_PRED, 5, BYTE_REG, opnd, enc_out);
 }
 
+/* p5: P register */
+
+static inline bool
+decode_opnd_p5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg(DR_REG_P0 + extract_uint(enc, 5, 4));
+    return true;
+}
+
+static inline bool
+encode_opnd_p5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    if (!opnd_is_predicate_reg(opnd))
+        return false;
+    return encode_opnd_p(5, 15, opnd, enc_out);
+}
+
 static inline bool
 decode_opnd_p5_zer(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -66,10 +66,10 @@
 001001010000xxxx11xxxx0xxxx1xxxx  n   875  SVE    brkpb          p_b_0 : p10_zer p_b_5 p_b_16
 001001010100xxxx11xxxx0xxxx1xxxx  w   876  SVE   brkpbs          p_b_0 : p10_zer p_b_5 p_b_16
 00000101xx110000101xxxxxxxxxxxxx  n   835  SVE   clasta   wx_size_0_zr : p10_lo wx_size_0_zr z_size_bhsd_5
-00000101xx101010100xxxxxxxxxxxxx  n   835  SVE   clasta bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
+00000101xx101010100xxxxxxxxxxxxx  n   835  SVE   clasta  bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
 00000101xx101000100xxxxxxxxxxxxx  n   835  SVE   clasta  z_size_bhsd_0 : p10_lo z_size_bhsd_0 z_size_bhsd_5
 00000101xx110001101xxxxxxxxxxxxx  n   836  SVE   clastb   wx_size_0_zr : p10_lo wx_size_0_zr z_size_bhsd_5
-00000101xx101011100xxxxxxxxxxxxx  n   836  SVE   clastb bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
+00000101xx101011100xxxxxxxxxxxxx  n   836  SVE   clastb  bhsd_size_reg0 : p10_lo bhsd_size_reg0 z_size_bhsd_5
 00000101xx101001100xxxxxxxxxxxxx  n   836  SVE   clastb  z_size_bhsd_0 : p10_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx0xxxxx100xxxxxxxx0xxxx  w   807  SVE    cmpeq  p_size_bhsd_0 : p10_zer_lo z_size_bhsd_5 simm5
 00100100xx0xxxxx001xxxxxxxx0xxxx  w   807  SVE    cmpeq   p_size_bhs_0 : p10_zer_lo z_size_bhs_5 z_d_16
@@ -156,10 +156,10 @@
 000001001011xxxx110000xxxxxxxxxx  n   851  SVE     incw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
 00000101xx100100001110xxxxxxxxxx  n   881  SVE     insr  z_size_bhsd_0 : z_size_bhsd_0 wx_size_5_zr
 00000101xx110100001110xxxxxxxxxx  n   881  SVE     insr  z_size_bhsd_0 : z_size_bhsd_0 bhsd_size_reg5
-00000101xx100000101xxxxxxxxxxxxx  n   837  SVE    lasta wx_size_0_zr : p10_lo z_size_bhsd_5
-00000101xx100010100xxxxxxxxxxxxx  n   837  SVE    lasta bhsd_size_reg0 : p10_lo z_size_bhsd_5
-00000101xx100001101xxxxxxxxxxxxx  n   838  SVE    lastb wx_size_0_zr : p10_lo z_size_bhsd_5
-00000101xx100011100xxxxxxxxxxxxx  n   838  SVE    lastb bhsd_size_reg0 : p10_lo z_size_bhsd_5
+00000101xx100000101xxxxxxxxxxxxx  n   837  SVE    lasta   wx_size_0_zr : p10_lo z_size_bhsd_5
+00000101xx100010100xxxxxxxxxxxxx  n   837  SVE    lasta  bhsd_size_reg0 : p10_lo z_size_bhsd_5
+00000101xx100001101xxxxxxxxxxxxx  n   838  SVE    lastb   wx_size_0_zr : p10_lo z_size_bhsd_5
+00000101xx100011100xxxxxxxxxxxxx  n   838  SVE    lastb  bhsd_size_reg0 : p10_lo z_size_bhsd_5
 1000010110xxxxxx000xxxxxxxx0xxxx  n   227  SVE      ldr             p0 : svemem_gpr_simm9_vl
 1000010110xxxxxx010xxxxxxxxxxxxx  n   227  SVE      ldr             z0 : svemem_gpr_simm9_vl
 00000100xx0xxxxx110xxxxxxxxxxxxx  n   787  SVE      mad  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_16 z_size_bhsd_5
@@ -182,7 +182,11 @@
 001001011000xxxx01xxxx0xxxx0xxxx  n   327  SVE      orr          p_b_0 : p10_zer p_b_5 p_b_16
 00000100011xxxxx001100xxxxxxxxxx  n   327  SVE      orr          z_d_0 : z_d_5 z_d_16
 001001011100xxxx01xxxx0xxxx0xxxx  w   834  SVE     orrs          p_b_0 : p10_zer p_b_5 p_b_16
+0010010100011000111001000000xxxx  n   894  SVE   pfalse          p_b_0 :
+00100101010110001100000xxxx0xxxx  w   895  SVE   pfirst          p_b_0 : p5 p_b_0
 001001010101000011xxxx0xxxx00000  w   786  SVE    ptest                : p10 p_b_5
+00100101xx011000111000xxxxx0xxxx  n   897  SVE    ptrue  p_size_bhsd_0 : pred_constr
+00100101xx011001111000xxxxx0xxxx  w   898  SVE   ptrues  p_size_bhsd_0 : pred_constr
 00000101001100010100000xxxx0xxxx  n   887  SVE  punpkhi          p_h_0 : p_b_5
 00000101001100000100000xxxx0xxxx  n   888  SVE  punpklo          p_h_0 : p_b_5
 0010010100011001111100000000xxxx  n   817  SVE    rdffr          p_b_0 :
@@ -196,6 +200,8 @@
 00000100xx001100000xxxxxxxxxxxxx  n   349  SVE     sabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx010100000xxxxxxxxxxxxx  n   363  SVE     sdiv    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
 00000100xx010110000xxxxxxxxxxxxx  n   794  SVE    sdivr    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
+001001010000xxxx01xxxx1xxxx1xxxx  n   896  SVE      sel          p_b_0 : p10 p_b_5 p_b_16
+00000101xx1xxxxx11xxxxxxxxxxxxxx  n   896  SVE      sel  z_size_bhsd_0 : p10 z_size_bhsd_5 z_size_bhsd_16
 00100101001011001001000000000000  n   819  SVE   setffr                :
 00000100xx001000000xxxxxxxxxxxxx  n   386  SVE     smax  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx101000110xxxxxxxxxxxxx  n   386  SVE     smax  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
@@ -237,8 +243,8 @@
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub             z0 : z5 z16 bhsd_sz
 00100101xx10011011xxxxxxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
-1110010110xxxxxx000xxxxxxxx0xxxx  n   457  SVE      str svemem_gpr_simm9_vl : p0
-1110010110xxxxxx010xxxxxxxxxxxxx  n   457  SVE      str svemem_gpr_simm9_vl : z0
+1110010110xxxxxx000xxxxxxxx0xxxx  n   457  SVE      str  svemem_gpr_simm9_vl : p0
+1110010110xxxxxx010xxxxxxxxxxxxx  n   457  SVE      str  svemem_gpr_simm9_vl : z0
 00000100xx1xxxxx000001xxxxxxxxxx  n   470  SVE      sub             z0 : z5 z16 bhsd_sz
 00000100xx000001000xxxxxxxxxxxxx  n   470  SVE      sub  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10000111xxxxxxxxxxxxxx  n   470  SVE      sub  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -8818,4 +8818,120 @@
 #define INSTR_CREATE_eon_sve_imm(dc, Zdn, imm) \
     instr_create_1dst_2src(dc, OP_eor, Zdn, Zdn, opnd_invert_immed_int(imm))
 
+/**
+ * Creates a PFALSE instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PFALSE  <Pd>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_pfalse_sve(dc, Pd) instr_create_1dst_0src(dc, OP_pfalse, Pd)
+
+/**
+ * Creates a PFIRST instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PFIRST  <Pdn>.B, <Pg>, <Pdn>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pdn   The source and destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_pfirst_sve(dc, Pdn, Pg) \
+    instr_create_1dst_2src(dc, OP_pfirst, Pdn, Pg, Pdn)
+
+/**
+ * Creates a SEL instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SEL     <Pd>.B, <Pg>, <Pn>.B, <Pm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ * \param Pm   The second source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_sel_sve_pred(dc, Pd, Pg, Pn, Pm) \
+    instr_create_1dst_3src(dc, OP_sel, Pd, Pg, Pn, Pm)
+
+/**
+ * Creates a SEL instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SEL     <Zd>.<Ts>, <Pv>, <Zn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Pv   The first source predicate register, P (Predicate).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_sel_sve_vector(dc, Zd, Pv, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_sel, Zd, Pv, Zn, Zm)
+
+/**
+ * Creates an MOV instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    MOV     <Pd>.B, <Pn>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_mov_sve_pred(dc, Pd, Pn) \
+    instr_create_1dst_3src(dc, OP_orr, Pd,    \
+                           opnd_create_predicate_reg(opnd_get_reg(Pn), false), Pn, Pn)
+
+/**
+ * Creates an MOVS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    MOVS    <Pd>.B, <Pg>/Z, <Pn>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register, P (Predicate).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Pn   The first source predicate register, P (Predicate).
+ */
+#define INSTR_CREATE_movs_sve_pred(dc, Pd, Pg, Pn) \
+    instr_create_1dst_3src(dc, OP_ands, Pd, Pg, Pn, Pn)
+
+/**
+ * Creates a PTRUE instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PTRUE   <Pd>.<Ts>{, <pattern>}
+ * \endverbatim
+ * \param dc        The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd        The destination predicate register, P (Predicate).
+ * \param pattern   The predicate constraint, see #dr_pred_constr_type_t.
+ */
+#define INSTR_CREATE_ptrue_sve(dc, Pd, pattern) \
+    instr_create_1dst_1src(dc, OP_ptrue, Pd, pattern)
+
+/**
+ * Creates a PTRUES instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PTRUES  <Pd>.<Ts>{, <pattern>}
+ * \endverbatim
+ * \param dc        The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd        The destination predicate register, P (Predicate).
+ * \param pattern   The predicate constraint, see #dr_pred_constr_type_t.
+ */
+#define INSTR_CREATE_ptrues_sve(dc, Pd, pattern) \
+    instr_create_1dst_1src(dc, OP_ptrues, Pd, pattern)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -102,6 +102,7 @@
 ---------------------------xxxxx  prfop      # prefetch operation
 ------------------------xxx-----  op2        # 3 bit immediate from 5-7
 -----------------------xxxx-----  p_b_5      # P register with a byte element size
+-----------------------xxxx-----  p5         # P register
 -----------------------xxxx-----  p5_zer     # P register, zeroing
 ----------------------xxxxx-----  w5         # W register (or WZR)
 ----------------------xxxxx-----  x5         # X register (or XZR)

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -6532,6 +6532,42 @@
 25c079ed : orrs p13.b, p14/Z, p15.b, p0.b            : orrs   %p14/z %p15.b %p0.b -> %p13.b
 25cf7def : orrs p15.b, p15/Z, p15.b, p15.b           : orrs   %p15/z %p15.b %p15.b -> %p15.b
 
+# PFALSE  <Pd>.B (PFALSE-P-_)
+2518e400 : pfalse p0.b                               : pfalse  -> %p0.b
+2518e401 : pfalse p1.b                               : pfalse  -> %p1.b
+2518e402 : pfalse p2.b                               : pfalse  -> %p2.b
+2518e403 : pfalse p3.b                               : pfalse  -> %p3.b
+2518e404 : pfalse p4.b                               : pfalse  -> %p4.b
+2518e405 : pfalse p5.b                               : pfalse  -> %p5.b
+2518e406 : pfalse p6.b                               : pfalse  -> %p6.b
+2518e407 : pfalse p7.b                               : pfalse  -> %p7.b
+2518e408 : pfalse p8.b                               : pfalse  -> %p8.b
+2518e408 : pfalse p8.b                               : pfalse  -> %p8.b
+2518e409 : pfalse p9.b                               : pfalse  -> %p9.b
+2518e40a : pfalse p10.b                              : pfalse  -> %p10.b
+2518e40b : pfalse p11.b                              : pfalse  -> %p11.b
+2518e40c : pfalse p12.b                              : pfalse  -> %p12.b
+2518e40d : pfalse p13.b                              : pfalse  -> %p13.b
+2518e40f : pfalse p15.b                              : pfalse  -> %p15.b
+
+# PFIRST  <Pdn>.B, <Pg>, <Pdn>.B (PFIRST-P.P.P-_)
+2558c000 : pfirst p0.b, p0, p0.b                     : pfirst %p0 %p0.b -> %p0.b
+2558c041 : pfirst p1.b, p2, p1.b                     : pfirst %p2 %p1.b -> %p1.b
+2558c062 : pfirst p2.b, p3, p2.b                     : pfirst %p3 %p2.b -> %p2.b
+2558c083 : pfirst p3.b, p4, p3.b                     : pfirst %p4 %p3.b -> %p3.b
+2558c0a4 : pfirst p4.b, p5, p4.b                     : pfirst %p5 %p4.b -> %p4.b
+2558c0c5 : pfirst p5.b, p6, p5.b                     : pfirst %p6 %p5.b -> %p5.b
+2558c0e6 : pfirst p6.b, p7, p6.b                     : pfirst %p7 %p6.b -> %p6.b
+2558c107 : pfirst p7.b, p8, p7.b                     : pfirst %p8 %p7.b -> %p7.b
+2558c128 : pfirst p8.b, p9, p8.b                     : pfirst %p9 %p8.b -> %p8.b
+2558c128 : pfirst p8.b, p9, p8.b                     : pfirst %p9 %p8.b -> %p8.b
+2558c149 : pfirst p9.b, p10, p9.b                    : pfirst %p10 %p9.b -> %p9.b
+2558c16a : pfirst p10.b, p11, p10.b                  : pfirst %p11 %p10.b -> %p10.b
+2558c18b : pfirst p11.b, p12, p11.b                  : pfirst %p12 %p11.b -> %p11.b
+2558c1ac : pfirst p12.b, p13, p12.b                  : pfirst %p13 %p12.b -> %p12.b
+2558c1cd : pfirst p13.b, p14, p13.b                  : pfirst %p14 %p13.b -> %p13.b
+2558c1ef : pfirst p15.b, p15, p15.b                  : pfirst %p15 %p15.b -> %p15.b
+
 # PTEST   <Pg>, <Pn>.B (PTEST-.P.P-_)
 2550c000 : ptest p0, p0.b                            : ptest  %p0 %p0.b
 2550c440 : ptest p1, p2.b                            : ptest  %p1 %p2.b
@@ -6549,6 +6585,266 @@
 2550ed80 : ptest p11, p12.b                          : ptest  %p11 %p12.b
 2550f1a0 : ptest p12, p13.b                          : ptest  %p12 %p13.b
 2550f9c0 : ptest p14, p14.b                          : ptest  %p14 %p14.b
+
+# PTRUE   <Pd>.<T>{, <pattern>} (PTRUE-P.S-_)
+2518e000 : ptrue p0.b, POW2                          : ptrue  POW2 -> %p0.b
+2518e020 : ptrue p0.b, VL1                           : ptrue  VL1 -> %p0.b
+2518e041 : ptrue p1.b, VL2                           : ptrue  VL2 -> %p1.b
+2518e061 : ptrue p1.b, VL3                           : ptrue  VL3 -> %p1.b
+2518e082 : ptrue p2.b, VL4                           : ptrue  VL4 -> %p2.b
+2518e0a2 : ptrue p2.b, VL5                           : ptrue  VL5 -> %p2.b
+2518e0c3 : ptrue p3.b, VL6                           : ptrue  VL6 -> %p3.b
+2518e0e3 : ptrue p3.b, VL7                           : ptrue  VL7 -> %p3.b
+2518e104 : ptrue p4.b, VL8                           : ptrue  VL8 -> %p4.b
+2518e124 : ptrue p4.b, VL16                          : ptrue  VL16 -> %p4.b
+2518e145 : ptrue p5.b, VL32                          : ptrue  VL32 -> %p5.b
+2518e165 : ptrue p5.b, VL64                          : ptrue  VL64 -> %p5.b
+2518e186 : ptrue p6.b, VL128                         : ptrue  VL128 -> %p6.b
+2518e1a6 : ptrue p6.b, VL256                         : ptrue  VL256 -> %p6.b
+2518e1c7 : ptrue p7.b, 14                            : ptrue  $0x0e -> %p7.b
+2518e1e7 : ptrue p7.b, 15                            : ptrue  $0x0f -> %p7.b
+2518e208 : ptrue p8.b, 16                            : ptrue  $0x10 -> %p8.b
+2518e228 : ptrue p8.b, 17                            : ptrue  $0x11 -> %p8.b
+2518e248 : ptrue p8.b, 18                            : ptrue  $0x12 -> %p8.b
+2518e269 : ptrue p9.b, 19                            : ptrue  $0x13 -> %p9.b
+2518e289 : ptrue p9.b, 20                            : ptrue  $0x14 -> %p9.b
+2518e2aa : ptrue p10.b, 21                           : ptrue  $0x15 -> %p10.b
+2518e2ca : ptrue p10.b, 22                           : ptrue  $0x16 -> %p10.b
+2518e2eb : ptrue p11.b, 23                           : ptrue  $0x17 -> %p11.b
+2518e30b : ptrue p11.b, 24                           : ptrue  $0x18 -> %p11.b
+2518e32c : ptrue p12.b, 25                           : ptrue  $0x19 -> %p12.b
+2518e34c : ptrue p12.b, 26                           : ptrue  $0x1a -> %p12.b
+2518e36d : ptrue p13.b, 27                           : ptrue  $0x1b -> %p13.b
+2518e38d : ptrue p13.b, 28                           : ptrue  $0x1c -> %p13.b
+2518e3ae : ptrue p14.b, MUL4                         : ptrue  MUL4 -> %p14.b
+2518e3ce : ptrue p14.b, MUL3                         : ptrue  MUL3 -> %p14.b
+2518e3ef : ptrue p15.b, ALL                          : ptrue  ALL -> %p15.b
+2558e000 : ptrue p0.h, POW2                          : ptrue  POW2 -> %p0.h
+2558e020 : ptrue p0.h, VL1                           : ptrue  VL1 -> %p0.h
+2558e041 : ptrue p1.h, VL2                           : ptrue  VL2 -> %p1.h
+2558e061 : ptrue p1.h, VL3                           : ptrue  VL3 -> %p1.h
+2558e082 : ptrue p2.h, VL4                           : ptrue  VL4 -> %p2.h
+2558e0a2 : ptrue p2.h, VL5                           : ptrue  VL5 -> %p2.h
+2558e0c3 : ptrue p3.h, VL6                           : ptrue  VL6 -> %p3.h
+2558e0e3 : ptrue p3.h, VL7                           : ptrue  VL7 -> %p3.h
+2558e104 : ptrue p4.h, VL8                           : ptrue  VL8 -> %p4.h
+2558e124 : ptrue p4.h, VL16                          : ptrue  VL16 -> %p4.h
+2558e145 : ptrue p5.h, VL32                          : ptrue  VL32 -> %p5.h
+2558e165 : ptrue p5.h, VL64                          : ptrue  VL64 -> %p5.h
+2558e186 : ptrue p6.h, VL128                         : ptrue  VL128 -> %p6.h
+2558e1a6 : ptrue p6.h, VL256                         : ptrue  VL256 -> %p6.h
+2558e1c7 : ptrue p7.h, 14                            : ptrue  $0x0e -> %p7.h
+2558e1e7 : ptrue p7.h, 15                            : ptrue  $0x0f -> %p7.h
+2558e208 : ptrue p8.h, 16                            : ptrue  $0x10 -> %p8.h
+2558e228 : ptrue p8.h, 17                            : ptrue  $0x11 -> %p8.h
+2558e248 : ptrue p8.h, 18                            : ptrue  $0x12 -> %p8.h
+2558e269 : ptrue p9.h, 19                            : ptrue  $0x13 -> %p9.h
+2558e289 : ptrue p9.h, 20                            : ptrue  $0x14 -> %p9.h
+2558e2aa : ptrue p10.h, 21                           : ptrue  $0x15 -> %p10.h
+2558e2ca : ptrue p10.h, 22                           : ptrue  $0x16 -> %p10.h
+2558e2eb : ptrue p11.h, 23                           : ptrue  $0x17 -> %p11.h
+2558e30b : ptrue p11.h, 24                           : ptrue  $0x18 -> %p11.h
+2558e32c : ptrue p12.h, 25                           : ptrue  $0x19 -> %p12.h
+2558e34c : ptrue p12.h, 26                           : ptrue  $0x1a -> %p12.h
+2558e36d : ptrue p13.h, 27                           : ptrue  $0x1b -> %p13.h
+2558e38d : ptrue p13.h, 28                           : ptrue  $0x1c -> %p13.h
+2558e3ae : ptrue p14.h, MUL4                         : ptrue  MUL4 -> %p14.h
+2558e3ce : ptrue p14.h, MUL3                         : ptrue  MUL3 -> %p14.h
+2558e3ef : ptrue p15.h, ALL                          : ptrue  ALL -> %p15.h
+2598e000 : ptrue p0.s, POW2                          : ptrue  POW2 -> %p0.s
+2598e020 : ptrue p0.s, VL1                           : ptrue  VL1 -> %p0.s
+2598e041 : ptrue p1.s, VL2                           : ptrue  VL2 -> %p1.s
+2598e061 : ptrue p1.s, VL3                           : ptrue  VL3 -> %p1.s
+2598e082 : ptrue p2.s, VL4                           : ptrue  VL4 -> %p2.s
+2598e0a2 : ptrue p2.s, VL5                           : ptrue  VL5 -> %p2.s
+2598e0c3 : ptrue p3.s, VL6                           : ptrue  VL6 -> %p3.s
+2598e0e3 : ptrue p3.s, VL7                           : ptrue  VL7 -> %p3.s
+2598e104 : ptrue p4.s, VL8                           : ptrue  VL8 -> %p4.s
+2598e124 : ptrue p4.s, VL16                          : ptrue  VL16 -> %p4.s
+2598e145 : ptrue p5.s, VL32                          : ptrue  VL32 -> %p5.s
+2598e165 : ptrue p5.s, VL64                          : ptrue  VL64 -> %p5.s
+2598e186 : ptrue p6.s, VL128                         : ptrue  VL128 -> %p6.s
+2598e1a6 : ptrue p6.s, VL256                         : ptrue  VL256 -> %p6.s
+2598e1c7 : ptrue p7.s, 14                            : ptrue  $0x0e -> %p7.s
+2598e1e7 : ptrue p7.s, 15                            : ptrue  $0x0f -> %p7.s
+2598e208 : ptrue p8.s, 16                            : ptrue  $0x10 -> %p8.s
+2598e228 : ptrue p8.s, 17                            : ptrue  $0x11 -> %p8.s
+2598e248 : ptrue p8.s, 18                            : ptrue  $0x12 -> %p8.s
+2598e269 : ptrue p9.s, 19                            : ptrue  $0x13 -> %p9.s
+2598e289 : ptrue p9.s, 20                            : ptrue  $0x14 -> %p9.s
+2598e2aa : ptrue p10.s, 21                           : ptrue  $0x15 -> %p10.s
+2598e2ca : ptrue p10.s, 22                           : ptrue  $0x16 -> %p10.s
+2598e2eb : ptrue p11.s, 23                           : ptrue  $0x17 -> %p11.s
+2598e30b : ptrue p11.s, 24                           : ptrue  $0x18 -> %p11.s
+2598e32c : ptrue p12.s, 25                           : ptrue  $0x19 -> %p12.s
+2598e34c : ptrue p12.s, 26                           : ptrue  $0x1a -> %p12.s
+2598e36d : ptrue p13.s, 27                           : ptrue  $0x1b -> %p13.s
+2598e38d : ptrue p13.s, 28                           : ptrue  $0x1c -> %p13.s
+2598e3ae : ptrue p14.s, MUL4                         : ptrue  MUL4 -> %p14.s
+2598e3ce : ptrue p14.s, MUL3                         : ptrue  MUL3 -> %p14.s
+2598e3ef : ptrue p15.s, ALL                          : ptrue  ALL -> %p15.s
+25d8e000 : ptrue p0.d, POW2                          : ptrue  POW2 -> %p0.d
+25d8e020 : ptrue p0.d, VL1                           : ptrue  VL1 -> %p0.d
+25d8e041 : ptrue p1.d, VL2                           : ptrue  VL2 -> %p1.d
+25d8e061 : ptrue p1.d, VL3                           : ptrue  VL3 -> %p1.d
+25d8e082 : ptrue p2.d, VL4                           : ptrue  VL4 -> %p2.d
+25d8e0a2 : ptrue p2.d, VL5                           : ptrue  VL5 -> %p2.d
+25d8e0c3 : ptrue p3.d, VL6                           : ptrue  VL6 -> %p3.d
+25d8e0e3 : ptrue p3.d, VL7                           : ptrue  VL7 -> %p3.d
+25d8e104 : ptrue p4.d, VL8                           : ptrue  VL8 -> %p4.d
+25d8e124 : ptrue p4.d, VL16                          : ptrue  VL16 -> %p4.d
+25d8e145 : ptrue p5.d, VL32                          : ptrue  VL32 -> %p5.d
+25d8e165 : ptrue p5.d, VL64                          : ptrue  VL64 -> %p5.d
+25d8e186 : ptrue p6.d, VL128                         : ptrue  VL128 -> %p6.d
+25d8e1a6 : ptrue p6.d, VL256                         : ptrue  VL256 -> %p6.d
+25d8e1c7 : ptrue p7.d, 14                            : ptrue  $0x0e -> %p7.d
+25d8e1e7 : ptrue p7.d, 15                            : ptrue  $0x0f -> %p7.d
+25d8e208 : ptrue p8.d, 16                            : ptrue  $0x10 -> %p8.d
+25d8e228 : ptrue p8.d, 17                            : ptrue  $0x11 -> %p8.d
+25d8e248 : ptrue p8.d, 18                            : ptrue  $0x12 -> %p8.d
+25d8e269 : ptrue p9.d, 19                            : ptrue  $0x13 -> %p9.d
+25d8e289 : ptrue p9.d, 20                            : ptrue  $0x14 -> %p9.d
+25d8e2aa : ptrue p10.d, 21                           : ptrue  $0x15 -> %p10.d
+25d8e2ca : ptrue p10.d, 22                           : ptrue  $0x16 -> %p10.d
+25d8e2eb : ptrue p11.d, 23                           : ptrue  $0x17 -> %p11.d
+25d8e30b : ptrue p11.d, 24                           : ptrue  $0x18 -> %p11.d
+25d8e32c : ptrue p12.d, 25                           : ptrue  $0x19 -> %p12.d
+25d8e34c : ptrue p12.d, 26                           : ptrue  $0x1a -> %p12.d
+25d8e36d : ptrue p13.d, 27                           : ptrue  $0x1b -> %p13.d
+25d8e38d : ptrue p13.d, 28                           : ptrue  $0x1c -> %p13.d
+25d8e3ae : ptrue p14.d, MUL4                         : ptrue  MUL4 -> %p14.d
+25d8e3ce : ptrue p14.d, MUL3                         : ptrue  MUL3 -> %p14.d
+25d8e3ef : ptrue p15.d, ALL                          : ptrue  ALL -> %p15.d
+
+# PTRUES  <Pd>.<T>{, <pattern>} (PTRUES-P.S-_)
+2519e000 : ptrues p0.b, POW2                         : ptrues POW2 -> %p0.b
+2519e020 : ptrues p0.b, VL1                          : ptrues VL1 -> %p0.b
+2519e041 : ptrues p1.b, VL2                          : ptrues VL2 -> %p1.b
+2519e061 : ptrues p1.b, VL3                          : ptrues VL3 -> %p1.b
+2519e082 : ptrues p2.b, VL4                          : ptrues VL4 -> %p2.b
+2519e0a2 : ptrues p2.b, VL5                          : ptrues VL5 -> %p2.b
+2519e0c3 : ptrues p3.b, VL6                          : ptrues VL6 -> %p3.b
+2519e0e3 : ptrues p3.b, VL7                          : ptrues VL7 -> %p3.b
+2519e104 : ptrues p4.b, VL8                          : ptrues VL8 -> %p4.b
+2519e124 : ptrues p4.b, VL16                         : ptrues VL16 -> %p4.b
+2519e145 : ptrues p5.b, VL32                         : ptrues VL32 -> %p5.b
+2519e165 : ptrues p5.b, VL64                         : ptrues VL64 -> %p5.b
+2519e186 : ptrues p6.b, VL128                        : ptrues VL128 -> %p6.b
+2519e1a6 : ptrues p6.b, VL256                        : ptrues VL256 -> %p6.b
+2519e1c7 : ptrues p7.b, 14                           : ptrues $0x0e -> %p7.b
+2519e1e7 : ptrues p7.b, 15                           : ptrues $0x0f -> %p7.b
+2519e208 : ptrues p8.b, 16                           : ptrues $0x10 -> %p8.b
+2519e228 : ptrues p8.b, 17                           : ptrues $0x11 -> %p8.b
+2519e248 : ptrues p8.b, 18                           : ptrues $0x12 -> %p8.b
+2519e269 : ptrues p9.b, 19                           : ptrues $0x13 -> %p9.b
+2519e289 : ptrues p9.b, 20                           : ptrues $0x14 -> %p9.b
+2519e2aa : ptrues p10.b, 21                          : ptrues $0x15 -> %p10.b
+2519e2ca : ptrues p10.b, 22                          : ptrues $0x16 -> %p10.b
+2519e2eb : ptrues p11.b, 23                          : ptrues $0x17 -> %p11.b
+2519e30b : ptrues p11.b, 24                          : ptrues $0x18 -> %p11.b
+2519e32c : ptrues p12.b, 25                          : ptrues $0x19 -> %p12.b
+2519e34c : ptrues p12.b, 26                          : ptrues $0x1a -> %p12.b
+2519e36d : ptrues p13.b, 27                          : ptrues $0x1b -> %p13.b
+2519e38d : ptrues p13.b, 28                          : ptrues $0x1c -> %p13.b
+2519e3ae : ptrues p14.b, MUL4                        : ptrues MUL4 -> %p14.b
+2519e3ce : ptrues p14.b, MUL3                        : ptrues MUL3 -> %p14.b
+2519e3ef : ptrues p15.b, ALL                         : ptrues ALL -> %p15.b
+2559e000 : ptrues p0.h, POW2                         : ptrues POW2 -> %p0.h
+2559e020 : ptrues p0.h, VL1                          : ptrues VL1 -> %p0.h
+2559e041 : ptrues p1.h, VL2                          : ptrues VL2 -> %p1.h
+2559e061 : ptrues p1.h, VL3                          : ptrues VL3 -> %p1.h
+2559e082 : ptrues p2.h, VL4                          : ptrues VL4 -> %p2.h
+2559e0a2 : ptrues p2.h, VL5                          : ptrues VL5 -> %p2.h
+2559e0c3 : ptrues p3.h, VL6                          : ptrues VL6 -> %p3.h
+2559e0e3 : ptrues p3.h, VL7                          : ptrues VL7 -> %p3.h
+2559e104 : ptrues p4.h, VL8                          : ptrues VL8 -> %p4.h
+2559e124 : ptrues p4.h, VL16                         : ptrues VL16 -> %p4.h
+2559e145 : ptrues p5.h, VL32                         : ptrues VL32 -> %p5.h
+2559e165 : ptrues p5.h, VL64                         : ptrues VL64 -> %p5.h
+2559e186 : ptrues p6.h, VL128                        : ptrues VL128 -> %p6.h
+2559e1a6 : ptrues p6.h, VL256                        : ptrues VL256 -> %p6.h
+2559e1c7 : ptrues p7.h, 14                           : ptrues $0x0e -> %p7.h
+2559e1e7 : ptrues p7.h, 15                           : ptrues $0x0f -> %p7.h
+2559e208 : ptrues p8.h, 16                           : ptrues $0x10 -> %p8.h
+2559e228 : ptrues p8.h, 17                           : ptrues $0x11 -> %p8.h
+2559e248 : ptrues p8.h, 18                           : ptrues $0x12 -> %p8.h
+2559e269 : ptrues p9.h, 19                           : ptrues $0x13 -> %p9.h
+2559e289 : ptrues p9.h, 20                           : ptrues $0x14 -> %p9.h
+2559e2aa : ptrues p10.h, 21                          : ptrues $0x15 -> %p10.h
+2559e2ca : ptrues p10.h, 22                          : ptrues $0x16 -> %p10.h
+2559e2eb : ptrues p11.h, 23                          : ptrues $0x17 -> %p11.h
+2559e30b : ptrues p11.h, 24                          : ptrues $0x18 -> %p11.h
+2559e32c : ptrues p12.h, 25                          : ptrues $0x19 -> %p12.h
+2559e34c : ptrues p12.h, 26                          : ptrues $0x1a -> %p12.h
+2559e36d : ptrues p13.h, 27                          : ptrues $0x1b -> %p13.h
+2559e38d : ptrues p13.h, 28                          : ptrues $0x1c -> %p13.h
+2559e3ae : ptrues p14.h, MUL4                        : ptrues MUL4 -> %p14.h
+2559e3ce : ptrues p14.h, MUL3                        : ptrues MUL3 -> %p14.h
+2559e3ef : ptrues p15.h, ALL                         : ptrues ALL -> %p15.h
+2599e000 : ptrues p0.s, POW2                         : ptrues POW2 -> %p0.s
+2599e020 : ptrues p0.s, VL1                          : ptrues VL1 -> %p0.s
+2599e041 : ptrues p1.s, VL2                          : ptrues VL2 -> %p1.s
+2599e061 : ptrues p1.s, VL3                          : ptrues VL3 -> %p1.s
+2599e082 : ptrues p2.s, VL4                          : ptrues VL4 -> %p2.s
+2599e0a2 : ptrues p2.s, VL5                          : ptrues VL5 -> %p2.s
+2599e0c3 : ptrues p3.s, VL6                          : ptrues VL6 -> %p3.s
+2599e0e3 : ptrues p3.s, VL7                          : ptrues VL7 -> %p3.s
+2599e104 : ptrues p4.s, VL8                          : ptrues VL8 -> %p4.s
+2599e124 : ptrues p4.s, VL16                         : ptrues VL16 -> %p4.s
+2599e145 : ptrues p5.s, VL32                         : ptrues VL32 -> %p5.s
+2599e165 : ptrues p5.s, VL64                         : ptrues VL64 -> %p5.s
+2599e186 : ptrues p6.s, VL128                        : ptrues VL128 -> %p6.s
+2599e1a6 : ptrues p6.s, VL256                        : ptrues VL256 -> %p6.s
+2599e1c7 : ptrues p7.s, 14                           : ptrues $0x0e -> %p7.s
+2599e1e7 : ptrues p7.s, 15                           : ptrues $0x0f -> %p7.s
+2599e208 : ptrues p8.s, 16                           : ptrues $0x10 -> %p8.s
+2599e228 : ptrues p8.s, 17                           : ptrues $0x11 -> %p8.s
+2599e248 : ptrues p8.s, 18                           : ptrues $0x12 -> %p8.s
+2599e269 : ptrues p9.s, 19                           : ptrues $0x13 -> %p9.s
+2599e289 : ptrues p9.s, 20                           : ptrues $0x14 -> %p9.s
+2599e2aa : ptrues p10.s, 21                          : ptrues $0x15 -> %p10.s
+2599e2ca : ptrues p10.s, 22                          : ptrues $0x16 -> %p10.s
+2599e2eb : ptrues p11.s, 23                          : ptrues $0x17 -> %p11.s
+2599e30b : ptrues p11.s, 24                          : ptrues $0x18 -> %p11.s
+2599e32c : ptrues p12.s, 25                          : ptrues $0x19 -> %p12.s
+2599e34c : ptrues p12.s, 26                          : ptrues $0x1a -> %p12.s
+2599e36d : ptrues p13.s, 27                          : ptrues $0x1b -> %p13.s
+2599e38d : ptrues p13.s, 28                          : ptrues $0x1c -> %p13.s
+2599e3ae : ptrues p14.s, MUL4                        : ptrues MUL4 -> %p14.s
+2599e3ce : ptrues p14.s, MUL3                        : ptrues MUL3 -> %p14.s
+2599e3ef : ptrues p15.s, ALL                         : ptrues ALL -> %p15.s
+25d9e000 : ptrues p0.d, POW2                         : ptrues POW2 -> %p0.d
+25d9e020 : ptrues p0.d, VL1                          : ptrues VL1 -> %p0.d
+25d9e041 : ptrues p1.d, VL2                          : ptrues VL2 -> %p1.d
+25d9e061 : ptrues p1.d, VL3                          : ptrues VL3 -> %p1.d
+25d9e082 : ptrues p2.d, VL4                          : ptrues VL4 -> %p2.d
+25d9e0a2 : ptrues p2.d, VL5                          : ptrues VL5 -> %p2.d
+25d9e0c3 : ptrues p3.d, VL6                          : ptrues VL6 -> %p3.d
+25d9e0e3 : ptrues p3.d, VL7                          : ptrues VL7 -> %p3.d
+25d9e104 : ptrues p4.d, VL8                          : ptrues VL8 -> %p4.d
+25d9e124 : ptrues p4.d, VL16                         : ptrues VL16 -> %p4.d
+25d9e145 : ptrues p5.d, VL32                         : ptrues VL32 -> %p5.d
+25d9e165 : ptrues p5.d, VL64                         : ptrues VL64 -> %p5.d
+25d9e186 : ptrues p6.d, VL128                        : ptrues VL128 -> %p6.d
+25d9e1a6 : ptrues p6.d, VL256                        : ptrues VL256 -> %p6.d
+25d9e1c7 : ptrues p7.d, 14                           : ptrues $0x0e -> %p7.d
+25d9e1e7 : ptrues p7.d, 15                           : ptrues $0x0f -> %p7.d
+25d9e208 : ptrues p8.d, 16                           : ptrues $0x10 -> %p8.d
+25d9e228 : ptrues p8.d, 17                           : ptrues $0x11 -> %p8.d
+25d9e248 : ptrues p8.d, 18                           : ptrues $0x12 -> %p8.d
+25d9e269 : ptrues p9.d, 19                           : ptrues $0x13 -> %p9.d
+25d9e289 : ptrues p9.d, 20                           : ptrues $0x14 -> %p9.d
+25d9e2aa : ptrues p10.d, 21                          : ptrues $0x15 -> %p10.d
+25d9e2ca : ptrues p10.d, 22                          : ptrues $0x16 -> %p10.d
+25d9e2eb : ptrues p11.d, 23                          : ptrues $0x17 -> %p11.d
+25d9e30b : ptrues p11.d, 24                          : ptrues $0x18 -> %p11.d
+25d9e32c : ptrues p12.d, 25                          : ptrues $0x19 -> %p12.d
+25d9e34c : ptrues p12.d, 26                          : ptrues $0x1a -> %p12.d
+25d9e36d : ptrues p13.d, 27                          : ptrues $0x1b -> %p13.d
+25d9e38d : ptrues p13.d, 28                          : ptrues $0x1c -> %p13.d
+25d9e3ae : ptrues p14.d, MUL4                        : ptrues MUL4 -> %p14.d
+25d9e3ce : ptrues p14.d, MUL3                        : ptrues MUL3 -> %p14.d
+25d9e3ef : ptrues p15.d, ALL                         : ptrues ALL -> %p15.d
 
 # PUNPKHI <Pd>.H, <Pn>.B (PUNPKHI-P.P-_)
 05314000 : punpkhi p0.h, p0.b                        : punpkhi %p0.b -> %p0.h
@@ -7007,6 +7303,90 @@
 04d61f79 : sdivr z25.d, p7/M, z25.d, z27.d           : sdivr  %p7/m %z25.d %z27.d -> %z25.d
 04d61fbb : sdivr z27.d, p7/M, z27.d, z29.d           : sdivr  %p7/m %z27.d %z29.d -> %z27.d
 04d61fff : sdivr z31.d, p7/M, z31.d, z31.d           : sdivr  %p7/m %z31.d %z31.d -> %z31.d
+
+# SEL     <Pd>.B, <Pg>, <Pn>.B, <Pm>.B (SEL-P.P.PP-_)
+25004210 : sel p0.b, p0, p0.b, p0.b                  : sel    %p0 %p0.b %p0.b -> %p0.b
+25044a71 : sel p1.b, p2, p3.b, p4.b                  : sel    %p2 %p3.b %p4.b -> %p1.b
+25054e92 : sel p2.b, p3, p4.b, p5.b                  : sel    %p3 %p4.b %p5.b -> %p2.b
+250652b3 : sel p3.b, p4, p5.b, p6.b                  : sel    %p4 %p5.b %p6.b -> %p3.b
+250756d4 : sel p4.b, p5, p6.b, p7.b                  : sel    %p5 %p6.b %p7.b -> %p4.b
+25085af5 : sel p5.b, p6, p7.b, p8.b                  : sel    %p6 %p7.b %p8.b -> %p5.b
+25095f16 : sel p6.b, p7, p8.b, p9.b                  : sel    %p7 %p8.b %p9.b -> %p6.b
+250a6337 : sel p7.b, p8, p9.b, p10.b                 : sel    %p8 %p9.b %p10.b -> %p7.b
+250b6758 : sel p8.b, p9, p10.b, p11.b                : sel    %p9 %p10.b %p11.b -> %p8.b
+250b6758 : sel p8.b, p9, p10.b, p11.b                : sel    %p9 %p10.b %p11.b -> %p8.b
+250c6b79 : sel p9.b, p10, p11.b, p12.b               : sel    %p10 %p11.b %p12.b -> %p9.b
+250d6f9a : sel p10.b, p11, p12.b, p13.b              : sel    %p11 %p12.b %p13.b -> %p10.b
+250e73bb : sel p11.b, p12, p13.b, p14.b              : sel    %p12 %p13.b %p14.b -> %p11.b
+250f77dc : sel p12.b, p13, p14.b, p15.b              : sel    %p13 %p14.b %p15.b -> %p12.b
+25007bfd : sel p13.b, p14, p15.b, p0.b               : sel    %p14 %p15.b %p0.b -> %p13.b
+250f7fff : sel p15.b, p15, p15.b, p15.b              : sel    %p15 %p15.b %p15.b -> %p15.b
+
+# SEL     <Zd>.<T>, <Pv>, <Zn>.<T>, <Zm>.<T> (SEL-Z.P.ZZ-_)
+0520c000 : sel z0.b, p0, z0.b, z0.b                  : sel    %p0 %z0.b %z0.b -> %z0.b
+0525c882 : sel z2.b, p2, z4.b, z5.b                  : sel    %p2 %z4.b %z5.b -> %z2.b
+0527ccc4 : sel z4.b, p3, z6.b, z7.b                  : sel    %p3 %z6.b %z7.b -> %z4.b
+0529d106 : sel z6.b, p4, z8.b, z9.b                  : sel    %p4 %z8.b %z9.b -> %z6.b
+052bd548 : sel z8.b, p5, z10.b, z11.b                : sel    %p5 %z10.b %z11.b -> %z8.b
+052dd98a : sel z10.b, p6, z12.b, z13.b               : sel    %p6 %z12.b %z13.b -> %z10.b
+052fddcc : sel z12.b, p7, z14.b, z15.b               : sel    %p7 %z14.b %z15.b -> %z12.b
+0531e20e : sel z14.b, p8, z16.b, z17.b               : sel    %p8 %z16.b %z17.b -> %z14.b
+0533e650 : sel z16.b, p9, z18.b, z19.b               : sel    %p9 %z18.b %z19.b -> %z16.b
+0534e671 : sel z17.b, p9, z19.b, z20.b               : sel    %p9 %z19.b %z20.b -> %z17.b
+0536eab3 : sel z19.b, p10, z21.b, z22.b              : sel    %p10 %z21.b %z22.b -> %z19.b
+0538eef5 : sel z21.b, p11, z23.b, z24.b              : sel    %p11 %z23.b %z24.b -> %z21.b
+053af337 : sel z23.b, p12, z25.b, z26.b              : sel    %p12 %z25.b %z26.b -> %z23.b
+053cf779 : sel z25.b, p13, z27.b, z28.b              : sel    %p13 %z27.b %z28.b -> %z25.b
+053efbbb : sel z27.b, p14, z29.b, z30.b              : sel    %p14 %z29.b %z30.b -> %z27.b
+053fffff : sel z31.b, p15, z31.b, z31.b              : sel    %p15 %z31.b %z31.b -> %z31.b
+0560c000 : sel z0.h, p0, z0.h, z0.h                  : sel    %p0 %z0.h %z0.h -> %z0.h
+0565c882 : sel z2.h, p2, z4.h, z5.h                  : sel    %p2 %z4.h %z5.h -> %z2.h
+0567ccc4 : sel z4.h, p3, z6.h, z7.h                  : sel    %p3 %z6.h %z7.h -> %z4.h
+0569d106 : sel z6.h, p4, z8.h, z9.h                  : sel    %p4 %z8.h %z9.h -> %z6.h
+056bd548 : sel z8.h, p5, z10.h, z11.h                : sel    %p5 %z10.h %z11.h -> %z8.h
+056dd98a : sel z10.h, p6, z12.h, z13.h               : sel    %p6 %z12.h %z13.h -> %z10.h
+056fddcc : sel z12.h, p7, z14.h, z15.h               : sel    %p7 %z14.h %z15.h -> %z12.h
+0571e20e : sel z14.h, p8, z16.h, z17.h               : sel    %p8 %z16.h %z17.h -> %z14.h
+0573e650 : sel z16.h, p9, z18.h, z19.h               : sel    %p9 %z18.h %z19.h -> %z16.h
+0574e671 : sel z17.h, p9, z19.h, z20.h               : sel    %p9 %z19.h %z20.h -> %z17.h
+0576eab3 : sel z19.h, p10, z21.h, z22.h              : sel    %p10 %z21.h %z22.h -> %z19.h
+0578eef5 : sel z21.h, p11, z23.h, z24.h              : sel    %p11 %z23.h %z24.h -> %z21.h
+057af337 : sel z23.h, p12, z25.h, z26.h              : sel    %p12 %z25.h %z26.h -> %z23.h
+057cf779 : sel z25.h, p13, z27.h, z28.h              : sel    %p13 %z27.h %z28.h -> %z25.h
+057efbbb : sel z27.h, p14, z29.h, z30.h              : sel    %p14 %z29.h %z30.h -> %z27.h
+057fffff : sel z31.h, p15, z31.h, z31.h              : sel    %p15 %z31.h %z31.h -> %z31.h
+05a0c000 : sel z0.s, p0, z0.s, z0.s                  : sel    %p0 %z0.s %z0.s -> %z0.s
+05a5c882 : sel z2.s, p2, z4.s, z5.s                  : sel    %p2 %z4.s %z5.s -> %z2.s
+05a7ccc4 : sel z4.s, p3, z6.s, z7.s                  : sel    %p3 %z6.s %z7.s -> %z4.s
+05a9d106 : sel z6.s, p4, z8.s, z9.s                  : sel    %p4 %z8.s %z9.s -> %z6.s
+05abd548 : sel z8.s, p5, z10.s, z11.s                : sel    %p5 %z10.s %z11.s -> %z8.s
+05add98a : sel z10.s, p6, z12.s, z13.s               : sel    %p6 %z12.s %z13.s -> %z10.s
+05afddcc : sel z12.s, p7, z14.s, z15.s               : sel    %p7 %z14.s %z15.s -> %z12.s
+05b1e20e : sel z14.s, p8, z16.s, z17.s               : sel    %p8 %z16.s %z17.s -> %z14.s
+05b3e650 : sel z16.s, p9, z18.s, z19.s               : sel    %p9 %z18.s %z19.s -> %z16.s
+05b4e671 : sel z17.s, p9, z19.s, z20.s               : sel    %p9 %z19.s %z20.s -> %z17.s
+05b6eab3 : sel z19.s, p10, z21.s, z22.s              : sel    %p10 %z21.s %z22.s -> %z19.s
+05b8eef5 : sel z21.s, p11, z23.s, z24.s              : sel    %p11 %z23.s %z24.s -> %z21.s
+05baf337 : sel z23.s, p12, z25.s, z26.s              : sel    %p12 %z25.s %z26.s -> %z23.s
+05bcf779 : sel z25.s, p13, z27.s, z28.s              : sel    %p13 %z27.s %z28.s -> %z25.s
+05befbbb : sel z27.s, p14, z29.s, z30.s              : sel    %p14 %z29.s %z30.s -> %z27.s
+05bfffff : sel z31.s, p15, z31.s, z31.s              : sel    %p15 %z31.s %z31.s -> %z31.s
+05e0c000 : sel z0.d, p0, z0.d, z0.d                  : sel    %p0 %z0.d %z0.d -> %z0.d
+05e5c882 : sel z2.d, p2, z4.d, z5.d                  : sel    %p2 %z4.d %z5.d -> %z2.d
+05e7ccc4 : sel z4.d, p3, z6.d, z7.d                  : sel    %p3 %z6.d %z7.d -> %z4.d
+05e9d106 : sel z6.d, p4, z8.d, z9.d                  : sel    %p4 %z8.d %z9.d -> %z6.d
+05ebd548 : sel z8.d, p5, z10.d, z11.d                : sel    %p5 %z10.d %z11.d -> %z8.d
+05edd98a : sel z10.d, p6, z12.d, z13.d               : sel    %p6 %z12.d %z13.d -> %z10.d
+05efddcc : sel z12.d, p7, z14.d, z15.d               : sel    %p7 %z14.d %z15.d -> %z12.d
+05f1e20e : sel z14.d, p8, z16.d, z17.d               : sel    %p8 %z16.d %z17.d -> %z14.d
+05f3e650 : sel z16.d, p9, z18.d, z19.d               : sel    %p9 %z18.d %z19.d -> %z16.d
+05f4e671 : sel z17.d, p9, z19.d, z20.d               : sel    %p9 %z19.d %z20.d -> %z17.d
+05f6eab3 : sel z19.d, p10, z21.d, z22.d              : sel    %p10 %z21.d %z22.d -> %z19.d
+05f8eef5 : sel z21.d, p11, z23.d, z24.d              : sel    %p11 %z23.d %z24.d -> %z21.d
+05faf337 : sel z23.d, p12, z25.d, z26.d              : sel    %p12 %z25.d %z26.d -> %z23.d
+05fcf779 : sel z25.d, p13, z27.d, z28.d              : sel    %p13 %z27.d %z28.d -> %z25.d
+05fefbbb : sel z27.d, p14, z29.d, z30.d              : sel    %p14 %z29.d %z30.d -> %z27.d
+05ffffff : sel z31.d, p15, z31.d, z31.d              : sel    %p15 %z31.d %z31.d -> %z31.d
 
 # SETFFR   (SETFFR-F-_)
 252c9000 : setffr                                    : setffr

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -9071,6 +9071,227 @@ TEST_INSTR(eon_sve_imm)
               opnd_create_immed_int(imm13[i], OPSZ_8));
 }
 
+TEST_INSTR(pfalse_sve)
+{
+    /* Testing PFALSE  <Pd>.B */
+    const char *const expected_0_0[6] = {
+        "pfalse  -> %p0.b", "pfalse  -> %p2.b",  "pfalse  -> %p5.b",
+        "pfalse  -> %p8.b", "pfalse  -> %p10.b", "pfalse  -> %p15.b",
+    };
+    TEST_LOOP(pfalse, pfalse_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1));
+}
+
+TEST_INSTR(pfirst_sve)
+{
+    /* Testing PFIRST  <Pdn>.B, <Pg>, <Pdn>.B */
+    const char *const expected_0_0[6] = {
+        "pfirst %p0 %p0.b -> %p0.b",    "pfirst %p3 %p2.b -> %p2.b",
+        "pfirst %p6 %p5.b -> %p5.b",    "pfirst %p9 %p8.b -> %p8.b",
+        "pfirst %p11 %p10.b -> %p10.b", "pfirst %p15 %p15.b -> %p15.b",
+    };
+    TEST_LOOP(pfirst, pfirst_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_six_offset_1[i]));
+}
+
+TEST_INSTR(sel_sve_pred)
+{
+    /* Testing SEL     <Pd>.B, <Pg>, <Pn>.B, <Pm>.B */
+    static const reg_id_t Pm_0_0[6] = { DR_REG_P0,  DR_REG_P5,  DR_REG_P8,
+                                        DR_REG_P11, DR_REG_P13, DR_REG_P15 };
+    const char *const expected_0_0[6] = {
+        "sel    %p0 %p0.b %p0.b -> %p0.b",     "sel    %p3 %p4.b %p5.b -> %p2.b",
+        "sel    %p6 %p7.b %p8.b -> %p5.b",     "sel    %p9 %p10.b %p11.b -> %p8.b",
+        "sel    %p11 %p12.b %p13.b -> %p10.b", "sel    %p15 %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(sel, sel_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pm_0_0[i], OPSZ_1));
+}
+
+TEST_INSTR(sel_sve_vector)
+{
+    /* Testing SEL     <Zd>.<Ts>, <Pv>, <Zn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "sel    %p0 %z0.b %z0.b -> %z0.b",     "sel    %p3 %z7.b %z8.b -> %z5.b",
+        "sel    %p6 %z12.b %z13.b -> %z10.b",  "sel    %p9 %z18.b %z19.b -> %z16.b",
+        "sel    %p11 %z23.b %z24.b -> %z21.b", "sel    %p15 %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(sel, sel_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "sel    %p0 %z0.h %z0.h -> %z0.h",     "sel    %p3 %z7.h %z8.h -> %z5.h",
+        "sel    %p6 %z12.h %z13.h -> %z10.h",  "sel    %p9 %z18.h %z19.h -> %z16.h",
+        "sel    %p11 %z23.h %z24.h -> %z21.h", "sel    %p15 %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(sel, sel_sve_vector, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "sel    %p0 %z0.s %z0.s -> %z0.s",     "sel    %p3 %z7.s %z8.s -> %z5.s",
+        "sel    %p6 %z12.s %z13.s -> %z10.s",  "sel    %p9 %z18.s %z19.s -> %z16.s",
+        "sel    %p11 %z23.s %z24.s -> %z21.s", "sel    %p15 %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(sel, sel_sve_vector, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "sel    %p0 %z0.d %z0.d -> %z0.d",     "sel    %p3 %z7.d %z8.d -> %z5.d",
+        "sel    %p6 %z12.d %z13.d -> %z10.d",  "sel    %p9 %z18.d %z19.d -> %z16.d",
+        "sel    %p11 %z23.d %z24.d -> %z21.d", "sel    %p15 %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(sel, sel_sve_vector, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_six_offset_1[i]),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8));
+}
+
+TEST_INSTR(mov_sve_pred)
+{
+    /* Testing MOV     <Pd>.B, <Pn>.B */
+    const char *expected_0_0[6] = {
+        "orr    %p0/z %p0.b %p0.b -> %p0.b",     "orr    %p4/z %p4.b %p4.b -> %p2.b",
+        "orr    %p7/z %p7.b %p7.b -> %p5.b",     "orr    %p10/z %p10.b %p10.b -> %p8.b",
+        "orr    %p12/z %p12.b %p12.b -> %p10.b", "orr    %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(orr, mov_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1));
+}
+
+TEST_INSTR(movs_sve_pred)
+{
+
+    /* Testing MOVS    <Pd>.B, <Pg>/Z, <Pn>.B */
+    const char *expected_0_0[6] = {
+        "ands   %p0/z %p0.b %p0.b -> %p0.b",     "ands   %p3/z %p4.b %p4.b -> %p2.b",
+        "ands   %p6/z %p7.b %p7.b -> %p5.b",     "ands   %p9/z %p10.b %p10.b -> %p8.b",
+        "ands   %p11/z %p12.b %p12.b -> %p10.b", "ands   %p15/z %p15.b %p15.b -> %p15.b",
+    };
+    TEST_LOOP(ands, movs_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_six_offset_1[i], false),
+              opnd_create_reg_element_vector(Pn_six_offset_2[i], OPSZ_1));
+}
+
+TEST_INSTR(ptrue_sve)
+{
+    /* Testing PTRUE   <Pd>.<Ts>{, <pattern>} */
+    static const dr_pred_constr_type_t pattern_0_0[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_0[6] = {
+        "ptrue  POW2 -> %p0.b",  "ptrue  VL6 -> %p2.b",    "ptrue  VL64 -> %p5.b",
+        "ptrue  $0x11 -> %p8.b", "ptrue  $0x16 -> %p10.b", "ptrue  ALL -> %p15.b",
+    };
+    TEST_LOOP(ptrue, ptrue_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_pred_constr(pattern_0_0[i]));
+
+    static const dr_pred_constr_type_t pattern_0_1[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_1[6] = {
+        "ptrue  POW2 -> %p0.h",  "ptrue  VL6 -> %p2.h",    "ptrue  VL64 -> %p5.h",
+        "ptrue  $0x11 -> %p8.h", "ptrue  $0x16 -> %p10.h", "ptrue  ALL -> %p15.h",
+    };
+    TEST_LOOP(ptrue, ptrue_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_pred_constr(pattern_0_1[i]));
+
+    static const dr_pred_constr_type_t pattern_0_2[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_2[6] = {
+        "ptrue  POW2 -> %p0.s",  "ptrue  VL6 -> %p2.s",    "ptrue  VL64 -> %p5.s",
+        "ptrue  $0x11 -> %p8.s", "ptrue  $0x16 -> %p10.s", "ptrue  ALL -> %p15.s",
+    };
+    TEST_LOOP(ptrue, ptrue_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_pred_constr(pattern_0_2[i]));
+
+    static const dr_pred_constr_type_t pattern_0_3[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_3[6] = {
+        "ptrue  POW2 -> %p0.d",  "ptrue  VL6 -> %p2.d",    "ptrue  VL64 -> %p5.d",
+        "ptrue  $0x11 -> %p8.d", "ptrue  $0x16 -> %p10.d", "ptrue  ALL -> %p15.d",
+    };
+    TEST_LOOP(ptrue, ptrue_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_pred_constr(pattern_0_3[i]));
+}
+
+TEST_INSTR(ptrues_sve)
+{
+    /* Testing PTRUES  <Pd>.<Ts>{, <pattern>} */
+    static const dr_pred_constr_type_t pattern_0_0[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_0[6] = {
+        "ptrues POW2 -> %p0.b",  "ptrues VL6 -> %p2.b",    "ptrues VL64 -> %p5.b",
+        "ptrues $0x11 -> %p8.b", "ptrues $0x16 -> %p10.b", "ptrues ALL -> %p15.b",
+    };
+    TEST_LOOP(ptrues, ptrues_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_immed_pred_constr(pattern_0_0[i]));
+
+    static const dr_pred_constr_type_t pattern_0_1[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_1[6] = {
+        "ptrues POW2 -> %p0.h",  "ptrues VL6 -> %p2.h",    "ptrues VL64 -> %p5.h",
+        "ptrues $0x11 -> %p8.h", "ptrues $0x16 -> %p10.h", "ptrues ALL -> %p15.h",
+    };
+    TEST_LOOP(ptrues, ptrues_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_immed_pred_constr(pattern_0_1[i]));
+
+    static const dr_pred_constr_type_t pattern_0_2[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_2[6] = {
+        "ptrues POW2 -> %p0.s",  "ptrues VL6 -> %p2.s",    "ptrues VL64 -> %p5.s",
+        "ptrues $0x11 -> %p8.s", "ptrues $0x16 -> %p10.s", "ptrues ALL -> %p15.s",
+    };
+    TEST_LOOP(ptrues, ptrues_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_immed_pred_constr(pattern_0_2[i]));
+
+    static const dr_pred_constr_type_t pattern_0_3[6] = {
+        DR_PRED_CONSTR_POW2,     DR_PRED_CONSTR_VL6,      DR_PRED_CONSTR_VL64,
+        DR_PRED_CONSTR_UIMM5_17, DR_PRED_CONSTR_UIMM5_22, DR_PRED_CONSTR_ALL
+    };
+    const char *const expected_0_3[6] = {
+        "ptrues POW2 -> %p0.d",  "ptrues VL6 -> %p2.d",    "ptrues VL64 -> %p5.d",
+        "ptrues $0x11 -> %p8.d", "ptrues $0x16 -> %p10.d", "ptrues ALL -> %p15.d",
+    };
+    TEST_LOOP(ptrues, ptrues_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_immed_pred_constr(pattern_0_3[i]));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -9355,6 +9576,15 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(dupm_sve);
     RUN_INSTR_TEST(eon_sve_imm);
+
+    RUN_INSTR_TEST(pfalse_sve);
+    RUN_INSTR_TEST(pfirst_sve);
+    RUN_INSTR_TEST(sel_sve_pred);
+    RUN_INSTR_TEST(sel_sve_vector);
+    RUN_INSTR_TEST(mov_sve_pred);
+    RUN_INSTR_TEST(movs_sve_pred);
+    RUN_INSTR_TEST(ptrue_sve);
+    RUN_INSTR_TEST(ptrues_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries
to encode the following variants:
```
PFALSE  <Pd>.B
PFIRST  <Pdn>.B, <Pg>, <Pdn>.B
SEL     <Pd>.B, <Pg>, <Pn>.B, <Pm>.B
SEL     <Zd>.<Ts>, <Pv>, <Zn>.<Ts>, <Zm>.<Ts>
MOV     <Pd>.B, <Pn>.B
MOVS    <Pd>.B, <Pg>/Z, <Pn>.B
PTRUE   <Pd>.<Ts>{, <pattern>}
PTRUES  <Pd>.<Ts>{, <pattern>}
```

Issue #3044