### PR TITLE
i#4393 AArch64 codec: Refactor fpimm8 codec

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4838,7 +4838,7 @@ encode_opnd_z_tb_bhs_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
 /* fpimm13: floating-point immediate for scalar fmov */
 
 static inline bool
-decode_opnd_fpimm13(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+decode_opnd_fpimm8_13(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     uint a = extract_uint(enc, 20, 1);
     uint b = extract_uint(enc, 19, 1);
@@ -4853,7 +4853,7 @@ decode_opnd_fpimm13(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 }
 
 static inline bool
-encode_opnd_fpimm13(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+encode_opnd_fpimm8_13(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     if (opnd_is_immed_float(opnd)) {
         ASSERT(extract_uint(enc, 22, 1) == 0); /* 32 bit floating point */

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -692,6 +692,9 @@ multistruct_regcount(uint enc)
     return 0;
 }
 
+static bool
+decode_fpimm8_single(uint a, uint b, uint c, uint defgh, OUT opnd_t *opnd);
+
 static inline bool
 decode_fpimm8_half(uint a, uint b, uint c, uint defgh, OUT opnd_t *opnd)
 {
@@ -779,6 +782,9 @@ decode_fpimm8_double(uint64_t a, uint64_t b, uint64_t c, uint64_t defgh, OUT opn
 
     return true;
 }
+
+static bool
+encode_fpimm8_single(opnd_t opnd, uint abc_offset, uint defgh_offset, OUT uint *enc_out);
 
 static inline bool
 encode_fpimm8_half(opnd_t opnd, uint abc_offset, uint defgh_offset, OUT uint *enc_out)

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -692,6 +692,231 @@ multistruct_regcount(uint enc)
     return 0;
 }
 
+static inline bool
+decode_fpimm8_half(uint a, uint b, uint c, uint defgh, OUT opnd_t *opnd)
+{
+    /* See Arm Architecture Reference Manual
+     *
+     * Half-precision (v8.2)
+     * --------------
+     *
+     * imm16 = imm8<7>:NOT(imm8<6>):Replicate(imm8<6>,2):imm8<5:0>:Zeros(6);
+     *         a:~b:bb:cdefgh:000000
+     */
+#ifdef HAVE_HALF_FLOAT
+    union {
+        __fp16 f;
+        uint16_t i;
+    } fpv;
+
+    const uint not_b = b == 0 ? 1 : 0;
+    const uint bb = ((b == 0) ? 0 : 0x3);
+
+    const uint16_t imm16 =
+        (a << 15) | (not_b << 14) | (bb << 12) | (c << 11) | (defgh << 6);
+    fpv.i = imm16;
+
+    *opnd = opnd_create_immed_float(fpv.f);
+
+    return true;
+#else
+    /* For off-line encode on platforms which do not support 16 bit (half-precision) FP.
+     */
+    return decode_fpimm8_single(a, b, c, defgh, opnd);
+#endif
+}
+
+static inline bool
+decode_fpimm8_single(uint a, uint b, uint c, uint defgh, OUT opnd_t *opnd)
+{
+    /* See Arm Architecture Reference Manual
+     *
+     * Single-precision
+     * ----------------
+     * imm32 = imm8<7>:NOT(imm8<6>):Replicate(imm8<6>,5):imm8<5:0>:Zeros(19);
+     *         a:~b:bbbbb:cdefgh:0000000000000000000
+     */
+    union {
+        float f;
+        uint32_t i;
+    } fpv;
+
+    const uint not_b = b == 0 ? 1 : 0;
+    const uint bbbbb = ((b == 0) ? 0 : 0x1f);
+
+    const uint32_t imm32 =
+        (a << 31) | (not_b << 30) | (bbbbb << 25) | (c << 24) | (defgh << 19);
+    fpv.i = imm32;
+
+    *opnd = opnd_create_immed_float(fpv.f);
+
+    return true;
+}
+
+static inline bool
+decode_fpimm8_double(uint64_t a, uint64_t b, uint64_t c, uint64_t defgh, OUT opnd_t *opnd)
+{
+    /* See Arm Architecture Reference Manual
+     *
+     * Double-precision
+     * ----------------
+     * imm64 = imm8<7>:NOT(imm8<6>):Replicate(imm8<6>,8):imm8<5:0>:Zeros(48);
+     *         a:~b:bbbbbbbb:cdefgh:000000000000000000000000000000000000000000000000
+     */
+    union {
+        double d;
+        uint64_t i;
+    } fpv;
+
+    const uint64_t not_b = b == 0 ? 1 : 0;
+    const uint64_t bbbbbbbb = ((b == 0) ? 0 : 0xff);
+
+    const uint64_t imm64 =
+        (a << 63) | (not_b << 62) | (bbbbbbbb << 54) | (c << 53) | (defgh << 48);
+    fpv.i = imm64;
+
+    *opnd = opnd_create_immed_double(fpv.d);
+
+    return true;
+}
+
+static inline bool
+encode_fpimm8_half(opnd_t opnd, uint abc_offset, uint defgh_offset, OUT uint *enc_out)
+{
+    /* Based on the IEEE 754-2008 standard but with Arm-specific details that
+     * are left open by the standard. See Arm Architecture Reference Manual.
+     *
+     * Half-precision example
+     *   __   ________
+     * S/exp\/fraction\
+     *  _
+     * abbbcdefgh000000
+     * 0011110000000000 = 1.0
+     *    _
+     *   abbb cdef gh00 0000
+     */
+#ifdef HAVE_HALF_FLOAT
+#    if !defined(DR_HOST_NOT_TARGET) && !defined(STANDALONE_DECODER)
+    CLIENT_ASSERT(proc_has_feature(FEATURE_FP16),
+                  "half-precision floating-point not supported on this host");
+#    endif
+    if (!opnd_is_immed_float(opnd))
+        return false;
+
+    union {
+        __fp16 f;
+        uint16_t i;
+    } fpv;
+    fpv.f = opnd_get_immed_float(opnd);
+
+    const uint16_t imm = fpv.i;
+    const uint a = extract_uint(imm, 15, 1);
+    const uint b = extract_uint(imm, 12, 1);
+    const uint c = extract_uint(imm, 11, 1);
+    const uint abc = (a << 2) | (b << 1) | c;
+
+    const uint defgh = extract_uint(imm, 6, 5);
+
+    /* Check whether the operand value could be accuratly represented by decoding it again
+     * and checking the decoded value against the original value.
+     */
+    opnd_t decoded_value;
+    if (!decode_fpimm8_half(a, b, c, defgh, &decoded_value) ||
+        (opnd_get_immed_float(decoded_value) != fpv.f)) {
+        return false;
+    }
+
+    *enc_out = (abc << abc_offset) | (defgh << defgh_offset);
+    return true;
+#else
+    /* For off-line encode on platforms which do not support 16 bit (half-precision) FP.
+     */
+    return encode_fpimm8_single(opnd, abc_offset, defgh_offset, enc_out);
+#endif
+}
+
+static inline bool
+encode_fpimm8_single(opnd_t opnd, uint abc_offset, uint defgh_offset, OUT uint *enc_out)
+{
+    /*
+     * From the Architecture Reference Manual, 8 bit immediate abcdefgh maps to
+     * floats:
+     *
+     *   3332 2222 2222 1111 1111 11
+     *   1098 7654 3210 9876 5432 1098 7654 3210
+     *    _
+     *   abbb bbbc defg h000 0000 0000 0000 0000
+     */
+    if (!opnd_is_immed_float(opnd)) {
+        return false;
+    }
+    union {
+        float f;
+        uint32_t i;
+    } fpv;
+    fpv.f = opnd_get_immed_float(opnd);
+
+    const uint32_t imm = fpv.i;
+    const uint a = extract_uint(imm, 31, 1);
+    const uint b = extract_uint(imm, 28, 1);
+    const uint c = extract_uint(imm, 24, 1);
+    const uint abc = (a << 2) | (b << 1) | c;
+
+    const uint defgh = extract_uint(imm, 19, 5);
+
+    /* Check whether the operand value could be accuratly represented by decoding it again
+     * and checking the decoded value against the original value.
+     */
+    opnd_t decoded_value;
+    if (!decode_fpimm8_single(a, b, c, defgh, &decoded_value) ||
+        (opnd_get_immed_float(decoded_value) != fpv.f)) {
+        return false;
+    }
+
+    *enc_out = (abc << abc_offset) | (defgh << defgh_offset);
+    return true;
+}
+
+static inline bool
+encode_fpimm8_double(opnd_t opnd, uint64_t abc_offset, uint64_t defgh_offset,
+                     OUT uint *enc_out)
+{
+    /* 6666 5555 5555 5544 44444444 33333333 33322222 22221111 111111
+     * 3210 9876 5432 1098 76543210 98765432 10987654 32109876 54321098 76543210
+     *  _
+     * abbb bbbb bbcd efgh 00000000 00000000 00000000 00000000 00000000 00000000
+     */
+    if (!opnd_is_immed_double(opnd)) {
+        return false;
+    }
+
+    union {
+        double d;
+        uint64_t i;
+    } fpv;
+    fpv.d = opnd_get_immed_double(opnd);
+
+    const uint64_t imm = fpv.i;
+    const uint64_t a = (imm >> 63) & 0x1;
+    const uint64_t b = (imm >> 60) & 0x1;
+    const uint64_t c = (imm >> 53) & 0x1;
+    const uint64_t abc = (a << 2) | (b << 1) | c;
+
+    const uint64_t defgh = (imm >> 48) & 0x1f;
+
+    /* Check whether the operand value could be accuratly represented by decoding it again
+     * and checking the decoded value against the original value.
+     */
+    opnd_t decoded_value;
+    if (!decode_fpimm8_double(a, b, c, defgh, &decoded_value) ||
+        (opnd_get_immed_double(decoded_value) != fpv.d)) {
+        return false;
+    }
+
+    *enc_out = (abc << abc_offset) | (defgh << defgh_offset);
+    return true;
+}
+
 /* Extracts the size from an imm13 field.  Returns NOT_A_REG if the read value is invalid.
  */
 static aarch64_reg_offset
@@ -3013,139 +3238,18 @@ encode_opnd_pstate(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
 static inline bool
 decode_opnd_fpimm8(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    /* See Arm Architecture Reference Manual
-     *
-     * Immediate is encoded as 8 bits. Bits 5->9 and 16->18. LSB is bit 5:
-     * imm8 = a:b:c:d:e:f:g:h (LSB)
-     *
-     * Half-precision (v8.2)
-     * --------------
-     *
-     * imm16 = imm8<7>:NOT(imm8<6>):Replicate(imm8<6>,2):imm8<5:0>:Zeros(6);
-     *         a:~b:bb:cdefgh:000000
-     *
-     * datasize = if Q == '1' then 128 else 64;
-     * imm = Replicate(imm16, datasize DIV 16);
-     *     = imm16:imm16:imm16:imm16                         (Q=0 -> 64)
-     *     = imm16:imm16:imm16:imm16:imm16:imm16:imm16:imm16 (Q=1 -> 128)
-     *
-     * Single-precision (TODO)
-     * ----------------
-     * Assume cmode = 1111 and op = 0
-     *
-     * imm32 = imm8<7>:NOT(imm8<6>):Replicate(imm8<6>,5):imm8<5:0>:Zeros(19);
-     *         a:~b:bbbbb:cdefgh:0000000000000000000
-     *
-     * imm64 = Replicate(imm32, 2);
-     *       = a:~b:bbbbb:cdefgh:0000000000000000000 a:~b:bbbbb:cdefgh:0000000000000000000
-     *
-     * datasize = if Q == '1' then 128 else 64;
-     * imm = Replicate(imm64, datasize DIV 64);
-     *     = imm64       (Q=0)
-     *     = imm64:imm64 (Q=1)
-     */
-    union {
-#ifdef HAVE_HALF_FLOAT
-        __fp16 f;
-        uint16_t i;
-#else
-        /* For platforms on which 16 bit (half-precision) FP is not yet available. */
-        float f;
-        uint32_t i;
-#endif
-    } fpv;
+    const uint a = extract_uint(enc, 18, 1);
+    const uint b = extract_uint(enc, 17, 1);
+    const uint c = extract_uint(enc, 16, 1);
+    const uint defgh = extract_uint(enc, 5, 5);
 
-    int abc = extract_uint(enc, 16, 3);
-    int defgh = extract_uint(enc, 5, 5);
-
-    uint a = (abc & 0x4);
-    uint b = (abc & 0x2);
-    uint not_b = b == 0 ? 1 : 0;
-
-#ifdef HAVE_HALF_FLOAT
-    uint bb = ((b == 0) ? 0 : 0x3);
-#else
-    uint bbbbb = ((b == 0) ? 0 : 0x1f);
-#endif
-
-    uint cdefgh = ((abc & 0x1) << 5) | (defgh & 0x1f);
-
-#ifdef HAVE_HALF_FLOAT
-    uint16_t imm16 = (a << 13) | (not_b << 14) | (bb << 12) | (cdefgh << 6);
-    fpv.i = imm16;
-#else
-    uint32_t imm32 = (a << 29) | (not_b << 30) | (bbbbb << 25) | (cdefgh << 19);
-    fpv.i = imm32;
-#endif
-    *opnd = opnd_create_immed_float(fpv.f);
-
-    return true;
+    return decode_fpimm8_half(a, b, c, defgh, opnd);
 }
 
 static inline bool
 encode_opnd_fpimm8(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    /* Based on the IEEE 754-2008 standard but with Arm-specific details that
-     * are left open by the standard. See Arm Architecture Reference Manual.
-     *
-     * Half-precision example
-     *   __   ________
-     * S/exp\/fraction\
-     *  _
-     * abbbcdefgh000000
-     * 0011110000000000 = 1.0
-     *    _
-     *   abbb cdef gh00 0000
-     * 0x8    0    0    0     a
-     * 0x1    0    0    0     b
-     * 0x0    8    0    0     c
-     * 0x0    7    c    0     defgh
-     */
-    union {
-#ifdef HAVE_HALF_FLOAT
-        __fp16 f;
-        uint16_t i;
-#else
-        /* For platforms on which 16 bit (half-precision) FP is not yet available. */
-        float f;
-        uint32_t i;
-#endif
-    } fpv;
-
-    if (!opnd_is_immed_float(opnd))
-        return false;
-
-    fpv.f = opnd_get_immed_float(opnd);
-#ifdef HAVE_HALF_FLOAT
-    uint16_t imm = fpv.i;
-    uint a = (imm & 0x8000);
-    uint b = (imm & 0x1000);
-    uint c = (imm & 0x800);
-    uint defgh = (imm & 0x7c0);
-
-    /* 3332 2222 2222 1111 1111 11
-     * 1098 7654 3210 9876 5432 1098 7654 3210
-     * ---- ---- ---- -abc ---- --de fgh- ----   immediate encoding
-     *          0x8000 |<-3|  | ||
-     *          0x1000  |<-5--| ||
-     *           0x800   |<--5--||
-     *           0x7c0           |>
-     */
-    *enc_out = (a << 3) | (b << 5) | (c << 5) | (defgh >> 1);
-#else
-    /* 3332 2222 2222 1111 1111 11
-     * 1098 7654 3210 9876 5432 1098 7654 3210
-     *  _
-     * abbb bbbc defg h000 0000 0000 0000 0000
-     */
-    uint32_t imm = fpv.i;
-    uint a = (imm & 0x80000000);
-    uint b = (imm & 0x10000000);
-    uint c = (imm & 0x1000000);
-    uint defgh = (imm & 0xf80000);
-    *enc_out = (a >> 13) | (b >> 11) | (c >> 8) | (defgh >> 14);
-#endif
-    return true;
+    return encode_fpimm8_half(opnd, 16, 5, enc_out);
 }
 
 /* imm8: an 8 bit uint stitched together from 2 parts of bits 16-18 and 5-9*/
@@ -4730,136 +4834,30 @@ encode_opnd_z_tb_bhs_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *en
 static inline bool
 decode_opnd_fpimm13(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    /*
-     * From the Architecture Reference Manual, 8 bit immediate abcdefgh maps to
-     * floats:
-     *
-     * 3332 2222 2222 1111 1111 11
-     * 1098 7654 3210 9876 5432 1098 7654 3210
-     *  _                            abcd efgh <- 8 bit immediate mapped to
-     * abbb bbbc defg h000 0000 0000 0000 0000 <- 32 bit float
-     *
-     *   abcd efgh  Masks
-     * 0x1    0     a
-     * 0x4    0     b
-     * 0x2    0     c
-     * 0x1    F     defgh
-     */
+    uint a = extract_uint(enc, 20, 1);
+    uint b = extract_uint(enc, 19, 1);
+    uint c = extract_uint(enc, 18, 1);
+    uint defgh = extract_uint(enc, 13, 5);
+
     if (extract_uint(enc, 22, 1) == 0) { /* 32 bits */
-        union {
-            float f;
-            uint32_t i;
-        } fpv;
-
-        uint32_t imm = extract_uint(enc, 13, 8);
-
-        uint32_t a = imm & 0x80;
-        uint32_t b = imm & 0x40;
-        uint32_t not_b = ((b == 0) ? 1 : 0);
-        uint32_t bbbbb = ((b == 0) ? 0 : 0x1f);
-        uint32_t c = imm & 0x20;
-        uint32_t defgh = imm & 0x1f;
-
-        uint32_t imm32 =
-            (a << 24) | (not_b << 30) | (bbbbb << 25) | (c << 19) | (defgh << 19);
-
-        fpv.i = imm32;
-        *opnd = opnd_create_immed_float(fpv.f);
+        return decode_fpimm8_single(a, b, c, defgh, opnd);
     } else { /* 64 bits */
-        /* 6666 5555 5555 5544 44444444 33333333 33322222 22221111 111111
-         * 3210 9876 5432 1098 76543210 98765432 10987654 32109876 54321098 76543210
-         *  _                                                               abcdefgh
-         * abbb bbbb bbcd efgh 00000000 00000000 00000000 00000000 00000000 00000000
-         */
-        union {
-            double d;
-            uint64_t i;
-        } fpv;
-
-        uint64_t imm = extract_uint(enc, 13, 8);
-
-        uint64_t a = imm & 0x80;
-        uint64_t b = imm & 0x40;
-        uint64_t not_b = ((b == 0) ? 1 : 0);
-        uint64_t bbbbbbbb = ((b == 0) ? 0 : 0xff);
-        uint64_t c = imm & 0x20;
-        uint64_t defgh = imm & 0x1f;
-
-        uint64_t imm64 =
-            (a << 56) | (not_b << 62) | (bbbbbbbb << 54) | (c << 48) | (defgh << 48);
-
-        fpv.i = imm64;
-        *opnd = opnd_create_immed_double(fpv.d);
+        return decode_fpimm8_double(a, b, c, defgh, opnd);
     }
-    return true;
 }
 
 static inline bool
 encode_opnd_fpimm13(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    /*
-     * From the Architecture Reference Manual, 8 bit immediate abcdefgh maps to
-     * floats:
-     *
-     *   3332 2222 2222 1111 1111 11
-     *   1098 7654 3210 9876 5432 1098 7654 3210
-     *    _
-     *   abbb bbbc defg h000 0000 0000 0000 0000
-     * 0x8    0    0    0    0    0    0    0    a
-     * 0x1    0    0    0    0    0    0    0    b
-     * 0x0    1    0    0    0    0    0    0    c
-     * 0x0    0    f    8    0    0    0    0    defgh
-     */
     if (opnd_is_immed_float(opnd)) {
         ASSERT(extract_uint(enc, 22, 1) == 0); /* 32 bit floating point */
-        union {
-            float f;
-            uint32_t i;
-        } fpv;
-        fpv.f = opnd_get_immed_float(opnd);
-        uint32_t imm = fpv.i;
-
-        uint a = (imm & 0x80000000);
-        uint b = (imm & 0x10000000);
-        uint c = (imm & 0x01000000);
-        uint defgh = (imm & 0x00f80000);
-
-        /* 3332 2222 2222 1111 1111 11
-         * 1098 7654 3210 9876 5432 1098 7654 3210
-         * ---- ---- ---a bcde fgh- ---- ---- ----   immediate encoding
-         * |-----11---->|           0x80000000 a
-         *    |-----9---->|         0x10000000 b
-         *         |---6-->|        0x01000000 c
-         *           |--6-->|       0x00f80000 defgh
-         */
-        *enc_out = (a >> 11) | (b >> 9) | (c >> 6) | (defgh >> 6);
+        return encode_fpimm8_single(opnd, 18, 13, enc_out);
     } else if (opnd_is_immed_double(opnd)) {
         ASSERT(extract_uint(enc, 22, 1) == 1); /* 64 bit floating point */
-        /* 6666 5555 5555 5544 44444444 33333333 33322222 22221111 111111
-         * 3210 9876 5432 1098 76543210 98765432 10987654 32109876 54321098 76543210
-         *  _
-         * abbb bbbb bbcd efgh 00000000 00000000 00000000 00000000 00000000 00000000
-         *
-         * ---- ---- ---a bcde fgh----- -------- immediate encoding
-         */
-        union {
-            double d;
-            uint64_t i;
-        } fpv;
-        fpv.d = opnd_get_immed_double(opnd);
-        uint64_t imm = fpv.i;
-
-        uint64_t a = (imm & 0x8000000000000000);
-        uint64_t b = (imm & 0x1000000000000000);
-        uint64_t c = (imm & 0x0020000000000000);
-        uint64_t defgh = (imm & 0x001f000000000000);
-
-        *enc_out =
-            (((a >> 11) | (b >> 9) | (c >> 3) | (defgh >> 3)) & 0xffffffff00000000) >> 32;
-    } else
+        return encode_fpimm8_double(opnd, 18, 13, enc_out);
+    } else {
         return false;
-
-    return true;
+    }
 }
 
 /* b_sz: Vector element width for SIMD instructions. */

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -407,8 +407,8 @@ x001111001011001xxxxxxxxxxxxxxxx  n   126  BASE     fcvtzu            wx0 : d5 s
 0x0011101x1xxxxx110011xxxxxxxxxx  n   144  BASE       fmls            dq0 : dq0 dq5 dq16 sd_sz
 0101111110xxxxxx0101x0xxxxxxxxxx  n   144  BASE       fmls             s0 : s0 s5 dq16 vindex_SD sd_sz
 0101111111xxxxxx0101x0xxxxxxxxxx  n   144  BASE       fmls             d0 : d0 d5 dq16 vindex_SD sd_sz
-00011110001xxxxxxxx10000000xxxxx  n   147  BASE       fmov             s0 : fpimm13
-00011110011xxxxxxxx10000000xxxxx  n   147  BASE       fmov             d0 : fpimm13
+00011110001xxxxxxxx10000000xxxxx  n   147  BASE       fmov             s0 : fpimm8_13
+00011110011xxxxxxxx10000000xxxxx  n   147  BASE       fmov             d0 : fpimm8_13
 0001111000100111000000xxxxxxxxxx  n   147  BASE       fmov             s0 : w5
 1001111001100111000000xxxxxxxxxx  n   147  BASE       fmov             d0 : x5
 1001111010101111000000xxxxxxxxxx  n   147  BASE       fmov   q0 vindex_D1 : x5 d_const_sz

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -150,7 +150,7 @@ x001111011100001000000xxxxxxxxxx  n   120  FP16    fcvtnu  wx0 : h5
 0x00111110xxxxxx0100x0xxxxxxxxxx  n   145  FHM      fmlsl  dq0 : dq0 sd5 dq16_h_sz vindex_H h_sz
 0x101110101xxxxx110011xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 sd16 h_sz
 0x10111110xxxxxx1100x0xxxxxxxxxx  n   146  FHM     fmlsl2  dq0 : dq0 sd5 dq16_h_sz vindex_H h_sz
-00011110111xxxxxxxx10000000xxxxx  n   147  FP16      fmov   h0 : fpimm13
+00011110111xxxxxxxx10000000xxxxx  n   147  FP16      fmov   h0 : fpimm8_13
 0001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : w5
 1001111011100111000000xxxxxxxxxx  n   147  FP16      fmov   h0 : x5
 0001111011100110000000xxxxxxxxxx  n   147  FP16      fmov   w0 : h5

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -221,7 +221,7 @@
 --------??------------xxxxx-----  wx_size_5_sp # GPR scalar register, register size, W or X depending on size bits
 --------??------------xxxxx-----  wx_size_5_zr # GPR scalar register, register size, W or X depending on size bits
 --------??------------xxxxx-----  z_tb_bhs_5 # sve vector reg, elsz depending on size Tb
---------??-xxxxxxxx-------------  fpimm13    # floating-point immediate for scalar fmov
+--------??-xxxxxxxx-------------  fpimm8_13  # floating-point immediate for scalar fmov
 --------xx----------------------  b_sz       # element width of a vector (8<<b_sz)
 --------xx----------------------  hs_sz      # element width of a vector (8<<hs_sz)
 --------xx----------------------  bhs_sz     # element width of a vector (8<<bhs_sz)


### PR DESCRIPTION
This pulls out code for encoding and decoding 8-bit floating-point immedate values into helper functions that can be re-used for future instructions with similar operands.

Issues: #4393, #2626