### PR TITLE
i#3044 AArch64 SVE codec: Add LD1R broadcast instructions

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4235,6 +4235,92 @@ encode_opnd_vindex_H(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_
     return true;
 }
 
+static inline bool
+decode_svememx6_5(uint enc, aarch64_reg_offset offset, OUT opnd_t *opnd)
+{
+    const uint scale = 1 << offset;
+    *opnd = create_base_imm(enc, extract_uint(enc, 16, 6) * scale, scale);
+    return true;
+}
+
+static inline bool
+encode_svememx6_5(aarch64_reg_offset offset, opnd_t opnd, OUT uint *enc_out)
+{
+    uint xn;
+    if (!is_base_imm(opnd, &xn))
+        return false;
+
+    const uint scale = 1 << offset;
+    if (opnd_size_in_bytes(opnd_get_size(opnd)) != scale)
+        return false;
+
+    const int disp = opnd_get_disp(opnd);
+    CLIENT_ASSERT((disp % scale) == 0, "Disp is not a multiple of the scale");
+
+    const int enc_disp = disp / scale;
+    CLIENT_ASSERT((enc_disp >= 0) && (enc_disp < 64),
+                  "Encoded disp must be less than 64");
+
+    *enc_out = (enc_disp << 16) | (xn << 5);
+    return true;
+}
+
+/* memz6_b_5: vector memory reg with 6 bit imm for byte value */
+
+static inline bool
+decode_opnd_svememx6_b_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_svememx6_5(enc, BYTE_REG, opnd);
+}
+
+static inline bool
+encode_opnd_svememx6_b_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_svememx6_5(BYTE_REG, opnd, enc_out);
+}
+
+/* memz6_h_5: vector memory reg with 6 bit imm for half value */
+
+static inline bool
+decode_opnd_svememx6_h_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_svememx6_5(enc, HALF_REG, opnd);
+}
+
+static inline bool
+encode_opnd_svememx6_h_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_svememx6_5(HALF_REG, opnd, enc_out);
+}
+
+/* memz6_s_5: vector memory reg with 6 bit imm for single value */
+
+static inline bool
+decode_opnd_svememx6_s_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_svememx6_5(enc, SINGLE_REG, opnd);
+}
+
+static inline bool
+encode_opnd_svememx6_s_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_svememx6_5(SINGLE_REG, opnd, enc_out);
+}
+
+/* memz6_d_5: vector memory reg with 6 bit imm for double value */
+
+static inline bool
+decode_opnd_svememx6_d_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_svememx6_5(enc, DOUBLE_REG, opnd);
+}
+
+static inline bool
+encode_opnd_svememx6_d_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_svememx6_5(DOUBLE_REG, opnd, enc_out);
+}
+
 /* svemem_gpr_simm9_vl: 9 bit signed immediate offset added to base register
  * defined in bits 5 to 9.
  */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -171,6 +171,22 @@
 00000101xx100010100xxxxxxxxxxxxx  n   837  SVE    lasta  bhsd_size_reg0 : p10_lo z_size_bhsd_5
 00000101xx100001101xxxxxxxxxxxxx  n   838  SVE    lastb   wx_size_0_zr : p10_lo z_size_bhsd_5
 00000101xx100011100xxxxxxxxxxxxx  n   838  SVE    lastb  bhsd_size_reg0 : p10_lo z_size_bhsd_5
+1000010001xxxxxx101xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_h_0 : svememx6_b_5 p10_zer_lo
+1000010001xxxxxx110xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_s_0 : svememx6_b_5 p10_zer_lo
+1000010001xxxxxx111xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_d_0 : svememx6_b_5 p10_zer_lo
+1000010001xxxxxx100xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_b_0 : svememx6_b_5 p10_zer_lo
+1000010111xxxxxx111xxxxxxxxxxxxx  n   909  SVE    ld1rd          z_d_0 : svememx6_d_5 p10_zer_lo
+1000010011xxxxxx101xxxxxxxxxxxxx  n   910  SVE    ld1rh          z_h_0 : svememx6_h_5 p10_zer_lo
+1000010011xxxxxx110xxxxxxxxxxxxx  n   910  SVE    ld1rh          z_s_0 : svememx6_h_5 p10_zer_lo
+1000010011xxxxxx111xxxxxxxxxxxxx  n   910  SVE    ld1rh          z_d_0 : svememx6_h_5 p10_zer_lo
+1000010111xxxxxx110xxxxxxxxxxxxx  n   911  SVE   ld1rsb          z_h_0 : svememx6_b_5 p10_zer_lo
+1000010111xxxxxx101xxxxxxxxxxxxx  n   911  SVE   ld1rsb          z_s_0 : svememx6_b_5 p10_zer_lo
+1000010111xxxxxx100xxxxxxxxxxxxx  n   911  SVE   ld1rsb          z_d_0 : svememx6_b_5 p10_zer_lo
+1000010101xxxxxx101xxxxxxxxxxxxx  n   912  SVE   ld1rsh          z_s_0 : svememx6_h_5 p10_zer_lo
+1000010101xxxxxx100xxxxxxxxxxxxx  n   912  SVE   ld1rsh          z_d_0 : svememx6_h_5 p10_zer_lo
+1000010011xxxxxx100xxxxxxxxxxxxx  n   913  SVE   ld1rsw          z_d_0 : svememx6_s_5 p10_zer_lo
+1000010101xxxxxx110xxxxxxxxxxxxx  n   914  SVE    ld1rw          z_s_0 : svememx6_s_5 p10_zer_lo
+1000010101xxxxxx111xxxxxxxxxxxxx  n   914  SVE    ld1rw          z_d_0 : svememx6_s_5 p10_zer_lo
 1000010110xxxxxx000xxxxxxxx0xxxx  n   227  SVE      ldr             p0 : svemem_gpr_simm9_vl
 1000010110xxxxxx010xxxxxxxxxxxxx  n   227  SVE      ldr             z0 : svemem_gpr_simm9_vl
 00000100xx000011100xxxxxxxxxxxxx  n   902  SVE      lsl  z_tszl8_bhsd_0 : p10_mrg_lo z_tszl8_bhsd_0 tszl8_imm3_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -9258,4 +9258,139 @@
  */
 #define INSTR_CREATE_fdup_sve(dc, Zd, imm) instr_create_1dst_1src(dc, OP_fdup, Zd, imm)
 
+/**
+ * Creates a LD1RB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RB   { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm6,
+ *             OPSZ_1)
+ */
+#define INSTR_CREATE_ld1rb_sve(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rb, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1RH instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RH   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm6,
+ *             OPSZ_2)
+ */
+#define INSTR_CREATE_ld1rh_sve(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rh, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1RW instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RW   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm6,
+ *             OPSZ_4)
+ */
+#define INSTR_CREATE_ld1rw_sve(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rw, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1RD instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RD   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm6,
+ *             OPSZ_8)
+ */
+#define INSTR_CREATE_ld1rd_sve(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rd, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1RSB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RSB  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RSB  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RSB  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm6,
+ *             OPSZ_1)
+ */
+#define INSTR_CREATE_ld1rsb_sve(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rsb, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1RSH instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RSH  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ *    LD1RSH  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm6,
+ *             OPSZ_2)
+ */
+#define INSTR_CREATE_ld1rsh_sve(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rsh, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1RSW instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RSW  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm6,
+ *             OPSZ_4)
+ */
+#define INSTR_CREATE_ld1rsw_sve(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rsw, Zt, Rn, Pg)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -198,6 +198,10 @@
 ----------?xxxxx--?-??----------  x16immvr   # computes immed from 21, 13 and 11:10
 ----------?xxxxx???-??----------  x16immvs   # computes immed from 21, 15:13 and 11:10
 ----------xx--------x-----------  vindex_H   # Index for vector with half elements (0-7)
+----------xxxxxx------xxxxx-----  svememx6_b_5    # vector memory reg with 6 bit imm for byte value
+----------xxxxxx------xxxxx-----  svememx6_h_5    # vector memory reg with 6 bit imm for half value
+----------xxxxxx------xxxxx-----  svememx6_s_5    # vector memory reg with 6 bit imm for single value
+----------xxxxxx------xxxxx-----  svememx6_d_5    # vector memory reg with 6 bit imm for double value
 ----------xxxxxx---xxxxxxxx-----  svemem_gpr_simm9_vl # imm offset and base reg for SVE ld/st
 ----------xxxxxxxxxxxx----------  imm12      # immediate for ADD/SUB
 ----------xxxxxxxxxxxxxxxxx-----  mem12q     # size is 16 bytes

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -6386,6 +6386,294 @@
 05e39fbd : lastb d29, p7, z29.d        : lastb  %p7 %z29.d -> %d29
 05e39fff : lastb d31, p7, z31.d        : lastb  %p7 %z31.d -> %d31
 
+# LD1RB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RB-Z.P.BI-U16)
+8440a000 : ld1rb z0.h, p0/Z, [x0, #0]                : ld1rb  (%x0)[1byte] %p0/z -> %z0.h
+8444a482 : ld1rb z2.h, p1/Z, [x4, #4]                : ld1rb  +0x04(%x4)[1byte] %p1/z -> %z2.h
+8448a8c4 : ld1rb z4.h, p2/Z, [x6, #8]                : ld1rb  +0x08(%x6)[1byte] %p2/z -> %z4.h
+844ca906 : ld1rb z6.h, p2/Z, [x8, #12]               : ld1rb  +0x0c(%x8)[1byte] %p2/z -> %z6.h
+8450ad48 : ld1rb z8.h, p3/Z, [x10, #16]              : ld1rb  +0x10(%x10)[1byte] %p3/z -> %z8.h
+8454ad6a : ld1rb z10.h, p3/Z, [x11, #20]             : ld1rb  +0x14(%x11)[1byte] %p3/z -> %z10.h
+8458b1ac : ld1rb z12.h, p4/Z, [x13, #24]             : ld1rb  +0x18(%x13)[1byte] %p4/z -> %z12.h
+845cb1ee : ld1rb z14.h, p4/Z, [x15, #28]             : ld1rb  +0x1c(%x15)[1byte] %p4/z -> %z14.h
+8460b630 : ld1rb z16.h, p5/Z, [x17, #32]             : ld1rb  +0x20(%x17)[1byte] %p5/z -> %z16.h
+8463b671 : ld1rb z17.h, p5/Z, [x19, #35]             : ld1rb  +0x23(%x19)[1byte] %p5/z -> %z17.h
+8467b6b3 : ld1rb z19.h, p5/Z, [x21, #39]             : ld1rb  +0x27(%x21)[1byte] %p5/z -> %z19.h
+846bbaf5 : ld1rb z21.h, p6/Z, [x23, #43]             : ld1rb  +0x2b(%x23)[1byte] %p6/z -> %z21.h
+846fbb17 : ld1rb z23.h, p6/Z, [x24, #47]             : ld1rb  +0x2f(%x24)[1byte] %p6/z -> %z23.h
+8473bf59 : ld1rb z25.h, p7/Z, [x26, #51]             : ld1rb  +0x33(%x26)[1byte] %p7/z -> %z25.h
+8477bf9b : ld1rb z27.h, p7/Z, [x28, #55]             : ld1rb  +0x37(%x28)[1byte] %p7/z -> %z27.h
+847fbfff : ld1rb z31.h, p7/Z, [sp, #63]              : ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.h
+
+# LD1RB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RB-Z.P.BI-U32)
+8440c000 : ld1rb z0.s, p0/Z, [x0, #0]                : ld1rb  (%x0)[1byte] %p0/z -> %z0.s
+8444c482 : ld1rb z2.s, p1/Z, [x4, #4]                : ld1rb  +0x04(%x4)[1byte] %p1/z -> %z2.s
+8448c8c4 : ld1rb z4.s, p2/Z, [x6, #8]                : ld1rb  +0x08(%x6)[1byte] %p2/z -> %z4.s
+844cc906 : ld1rb z6.s, p2/Z, [x8, #12]               : ld1rb  +0x0c(%x8)[1byte] %p2/z -> %z6.s
+8450cd48 : ld1rb z8.s, p3/Z, [x10, #16]              : ld1rb  +0x10(%x10)[1byte] %p3/z -> %z8.s
+8454cd6a : ld1rb z10.s, p3/Z, [x11, #20]             : ld1rb  +0x14(%x11)[1byte] %p3/z -> %z10.s
+8458d1ac : ld1rb z12.s, p4/Z, [x13, #24]             : ld1rb  +0x18(%x13)[1byte] %p4/z -> %z12.s
+845cd1ee : ld1rb z14.s, p4/Z, [x15, #28]             : ld1rb  +0x1c(%x15)[1byte] %p4/z -> %z14.s
+8460d630 : ld1rb z16.s, p5/Z, [x17, #32]             : ld1rb  +0x20(%x17)[1byte] %p5/z -> %z16.s
+8463d671 : ld1rb z17.s, p5/Z, [x19, #35]             : ld1rb  +0x23(%x19)[1byte] %p5/z -> %z17.s
+8467d6b3 : ld1rb z19.s, p5/Z, [x21, #39]             : ld1rb  +0x27(%x21)[1byte] %p5/z -> %z19.s
+846bdaf5 : ld1rb z21.s, p6/Z, [x23, #43]             : ld1rb  +0x2b(%x23)[1byte] %p6/z -> %z21.s
+846fdb17 : ld1rb z23.s, p6/Z, [x24, #47]             : ld1rb  +0x2f(%x24)[1byte] %p6/z -> %z23.s
+8473df59 : ld1rb z25.s, p7/Z, [x26, #51]             : ld1rb  +0x33(%x26)[1byte] %p7/z -> %z25.s
+8477df9b : ld1rb z27.s, p7/Z, [x28, #55]             : ld1rb  +0x37(%x28)[1byte] %p7/z -> %z27.s
+847fdfff : ld1rb z31.s, p7/Z, [sp, #63]              : ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.s
+
+# LD1RB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RB-Z.P.BI-U64)
+8440e000 : ld1rb z0.d, p0/Z, [x0, #0]                : ld1rb  (%x0)[1byte] %p0/z -> %z0.d
+8444e482 : ld1rb z2.d, p1/Z, [x4, #4]                : ld1rb  +0x04(%x4)[1byte] %p1/z -> %z2.d
+8448e8c4 : ld1rb z4.d, p2/Z, [x6, #8]                : ld1rb  +0x08(%x6)[1byte] %p2/z -> %z4.d
+844ce906 : ld1rb z6.d, p2/Z, [x8, #12]               : ld1rb  +0x0c(%x8)[1byte] %p2/z -> %z6.d
+8450ed48 : ld1rb z8.d, p3/Z, [x10, #16]              : ld1rb  +0x10(%x10)[1byte] %p3/z -> %z8.d
+8454ed6a : ld1rb z10.d, p3/Z, [x11, #20]             : ld1rb  +0x14(%x11)[1byte] %p3/z -> %z10.d
+8458f1ac : ld1rb z12.d, p4/Z, [x13, #24]             : ld1rb  +0x18(%x13)[1byte] %p4/z -> %z12.d
+845cf1ee : ld1rb z14.d, p4/Z, [x15, #28]             : ld1rb  +0x1c(%x15)[1byte] %p4/z -> %z14.d
+8460f630 : ld1rb z16.d, p5/Z, [x17, #32]             : ld1rb  +0x20(%x17)[1byte] %p5/z -> %z16.d
+8463f671 : ld1rb z17.d, p5/Z, [x19, #35]             : ld1rb  +0x23(%x19)[1byte] %p5/z -> %z17.d
+8467f6b3 : ld1rb z19.d, p5/Z, [x21, #39]             : ld1rb  +0x27(%x21)[1byte] %p5/z -> %z19.d
+846bfaf5 : ld1rb z21.d, p6/Z, [x23, #43]             : ld1rb  +0x2b(%x23)[1byte] %p6/z -> %z21.d
+846ffb17 : ld1rb z23.d, p6/Z, [x24, #47]             : ld1rb  +0x2f(%x24)[1byte] %p6/z -> %z23.d
+8473ff59 : ld1rb z25.d, p7/Z, [x26, #51]             : ld1rb  +0x33(%x26)[1byte] %p7/z -> %z25.d
+8477ff9b : ld1rb z27.d, p7/Z, [x28, #55]             : ld1rb  +0x37(%x28)[1byte] %p7/z -> %z27.d
+847fffff : ld1rb z31.d, p7/Z, [sp, #63]              : ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.d
+
+# LD1RB   { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RB-Z.P.BI-U8)
+84408000 : ld1rb z0.b, p0/Z, [x0, #0]                : ld1rb  (%x0)[1byte] %p0/z -> %z0.b
+84448482 : ld1rb z2.b, p1/Z, [x4, #4]                : ld1rb  +0x04(%x4)[1byte] %p1/z -> %z2.b
+844888c4 : ld1rb z4.b, p2/Z, [x6, #8]                : ld1rb  +0x08(%x6)[1byte] %p2/z -> %z4.b
+844c8906 : ld1rb z6.b, p2/Z, [x8, #12]               : ld1rb  +0x0c(%x8)[1byte] %p2/z -> %z6.b
+84508d48 : ld1rb z8.b, p3/Z, [x10, #16]              : ld1rb  +0x10(%x10)[1byte] %p3/z -> %z8.b
+84548d6a : ld1rb z10.b, p3/Z, [x11, #20]             : ld1rb  +0x14(%x11)[1byte] %p3/z -> %z10.b
+845891ac : ld1rb z12.b, p4/Z, [x13, #24]             : ld1rb  +0x18(%x13)[1byte] %p4/z -> %z12.b
+845c91ee : ld1rb z14.b, p4/Z, [x15, #28]             : ld1rb  +0x1c(%x15)[1byte] %p4/z -> %z14.b
+84609630 : ld1rb z16.b, p5/Z, [x17, #32]             : ld1rb  +0x20(%x17)[1byte] %p5/z -> %z16.b
+84639671 : ld1rb z17.b, p5/Z, [x19, #35]             : ld1rb  +0x23(%x19)[1byte] %p5/z -> %z17.b
+846796b3 : ld1rb z19.b, p5/Z, [x21, #39]             : ld1rb  +0x27(%x21)[1byte] %p5/z -> %z19.b
+846b9af5 : ld1rb z21.b, p6/Z, [x23, #43]             : ld1rb  +0x2b(%x23)[1byte] %p6/z -> %z21.b
+846f9b17 : ld1rb z23.b, p6/Z, [x24, #47]             : ld1rb  +0x2f(%x24)[1byte] %p6/z -> %z23.b
+84739f59 : ld1rb z25.b, p7/Z, [x26, #51]             : ld1rb  +0x33(%x26)[1byte] %p7/z -> %z25.b
+84779f9b : ld1rb z27.b, p7/Z, [x28, #55]             : ld1rb  +0x37(%x28)[1byte] %p7/z -> %z27.b
+847f9fff : ld1rb z31.b, p7/Z, [sp, #63]              : ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.b
+
+# LD1RD   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RD-Z.P.BI-U64)
+85c0e000 : ld1rd z0.d, p0/Z, [x0, #0]                : ld1rd  (%x0)[8byte] %p0/z -> %z0.d
+85c4e482 : ld1rd z2.d, p1/Z, [x4, #32]               : ld1rd  +0x20(%x4)[8byte] %p1/z -> %z2.d
+85c8e8c4 : ld1rd z4.d, p2/Z, [x6, #64]               : ld1rd  +0x40(%x6)[8byte] %p2/z -> %z4.d
+85cce906 : ld1rd z6.d, p2/Z, [x8, #96]               : ld1rd  +0x60(%x8)[8byte] %p2/z -> %z6.d
+85d0ed48 : ld1rd z8.d, p3/Z, [x10, #128]             : ld1rd  +0x80(%x10)[8byte] %p3/z -> %z8.d
+85d4ed6a : ld1rd z10.d, p3/Z, [x11, #160]            : ld1rd  +0xa0(%x11)[8byte] %p3/z -> %z10.d
+85d8f1ac : ld1rd z12.d, p4/Z, [x13, #192]            : ld1rd  +0xc0(%x13)[8byte] %p4/z -> %z12.d
+85dcf1ee : ld1rd z14.d, p4/Z, [x15, #224]            : ld1rd  +0xe0(%x15)[8byte] %p4/z -> %z14.d
+85e0f630 : ld1rd z16.d, p5/Z, [x17, #256]            : ld1rd  +0x0100(%x17)[8byte] %p5/z -> %z16.d
+85e3f671 : ld1rd z17.d, p5/Z, [x19, #280]            : ld1rd  +0x0118(%x19)[8byte] %p5/z -> %z17.d
+85e7f6b3 : ld1rd z19.d, p5/Z, [x21, #312]            : ld1rd  +0x0138(%x21)[8byte] %p5/z -> %z19.d
+85ebfaf5 : ld1rd z21.d, p6/Z, [x23, #344]            : ld1rd  +0x0158(%x23)[8byte] %p6/z -> %z21.d
+85effb17 : ld1rd z23.d, p6/Z, [x24, #376]            : ld1rd  +0x0178(%x24)[8byte] %p6/z -> %z23.d
+85f3ff59 : ld1rd z25.d, p7/Z, [x26, #408]            : ld1rd  +0x0198(%x26)[8byte] %p7/z -> %z25.d
+85f7ff9b : ld1rd z27.d, p7/Z, [x28, #440]            : ld1rd  +0x01b8(%x28)[8byte] %p7/z -> %z27.d
+85ffffff : ld1rd z31.d, p7/Z, [sp, #504]             : ld1rd  +0x01f8(%sp)[8byte] %p7/z -> %z31.d
+
+# LD1RH   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RH-Z.P.BI-U16)
+84c0a000 : ld1rh z0.h, p0/Z, [x0, #0]                : ld1rh  (%x0)[2byte] %p0/z -> %z0.h
+84c4a482 : ld1rh z2.h, p1/Z, [x4, #8]                : ld1rh  +0x08(%x4)[2byte] %p1/z -> %z2.h
+84c8a8c4 : ld1rh z4.h, p2/Z, [x6, #16]               : ld1rh  +0x10(%x6)[2byte] %p2/z -> %z4.h
+84cca906 : ld1rh z6.h, p2/Z, [x8, #24]               : ld1rh  +0x18(%x8)[2byte] %p2/z -> %z6.h
+84d0ad48 : ld1rh z8.h, p3/Z, [x10, #32]              : ld1rh  +0x20(%x10)[2byte] %p3/z -> %z8.h
+84d4ad6a : ld1rh z10.h, p3/Z, [x11, #40]             : ld1rh  +0x28(%x11)[2byte] %p3/z -> %z10.h
+84d8b1ac : ld1rh z12.h, p4/Z, [x13, #48]             : ld1rh  +0x30(%x13)[2byte] %p4/z -> %z12.h
+84dcb1ee : ld1rh z14.h, p4/Z, [x15, #56]             : ld1rh  +0x38(%x15)[2byte] %p4/z -> %z14.h
+84e0b630 : ld1rh z16.h, p5/Z, [x17, #64]             : ld1rh  +0x40(%x17)[2byte] %p5/z -> %z16.h
+84e3b671 : ld1rh z17.h, p5/Z, [x19, #70]             : ld1rh  +0x46(%x19)[2byte] %p5/z -> %z17.h
+84e7b6b3 : ld1rh z19.h, p5/Z, [x21, #78]             : ld1rh  +0x4e(%x21)[2byte] %p5/z -> %z19.h
+84ebbaf5 : ld1rh z21.h, p6/Z, [x23, #86]             : ld1rh  +0x56(%x23)[2byte] %p6/z -> %z21.h
+84efbb17 : ld1rh z23.h, p6/Z, [x24, #94]             : ld1rh  +0x5e(%x24)[2byte] %p6/z -> %z23.h
+84f3bf59 : ld1rh z25.h, p7/Z, [x26, #102]            : ld1rh  +0x66(%x26)[2byte] %p7/z -> %z25.h
+84f7bf9b : ld1rh z27.h, p7/Z, [x28, #110]            : ld1rh  +0x6e(%x28)[2byte] %p7/z -> %z27.h
+84ffbfff : ld1rh z31.h, p7/Z, [sp, #126]             : ld1rh  +0x7e(%sp)[2byte] %p7/z -> %z31.h
+
+# LD1RH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RH-Z.P.BI-U32)
+84c0c000 : ld1rh z0.s, p0/Z, [x0, #0]                : ld1rh  (%x0)[2byte] %p0/z -> %z0.s
+84c4c482 : ld1rh z2.s, p1/Z, [x4, #8]                : ld1rh  +0x08(%x4)[2byte] %p1/z -> %z2.s
+84c8c8c4 : ld1rh z4.s, p2/Z, [x6, #16]               : ld1rh  +0x10(%x6)[2byte] %p2/z -> %z4.s
+84ccc906 : ld1rh z6.s, p2/Z, [x8, #24]               : ld1rh  +0x18(%x8)[2byte] %p2/z -> %z6.s
+84d0cd48 : ld1rh z8.s, p3/Z, [x10, #32]              : ld1rh  +0x20(%x10)[2byte] %p3/z -> %z8.s
+84d4cd6a : ld1rh z10.s, p3/Z, [x11, #40]             : ld1rh  +0x28(%x11)[2byte] %p3/z -> %z10.s
+84d8d1ac : ld1rh z12.s, p4/Z, [x13, #48]             : ld1rh  +0x30(%x13)[2byte] %p4/z -> %z12.s
+84dcd1ee : ld1rh z14.s, p4/Z, [x15, #56]             : ld1rh  +0x38(%x15)[2byte] %p4/z -> %z14.s
+84e0d630 : ld1rh z16.s, p5/Z, [x17, #64]             : ld1rh  +0x40(%x17)[2byte] %p5/z -> %z16.s
+84e3d671 : ld1rh z17.s, p5/Z, [x19, #70]             : ld1rh  +0x46(%x19)[2byte] %p5/z -> %z17.s
+84e7d6b3 : ld1rh z19.s, p5/Z, [x21, #78]             : ld1rh  +0x4e(%x21)[2byte] %p5/z -> %z19.s
+84ebdaf5 : ld1rh z21.s, p6/Z, [x23, #86]             : ld1rh  +0x56(%x23)[2byte] %p6/z -> %z21.s
+84efdb17 : ld1rh z23.s, p6/Z, [x24, #94]             : ld1rh  +0x5e(%x24)[2byte] %p6/z -> %z23.s
+84f3df59 : ld1rh z25.s, p7/Z, [x26, #102]            : ld1rh  +0x66(%x26)[2byte] %p7/z -> %z25.s
+84f7df9b : ld1rh z27.s, p7/Z, [x28, #110]            : ld1rh  +0x6e(%x28)[2byte] %p7/z -> %z27.s
+84ffdfff : ld1rh z31.s, p7/Z, [sp, #126]             : ld1rh  +0x7e(%sp)[2byte] %p7/z -> %z31.s
+
+# LD1RH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RH-Z.P.BI-U64)
+84c0e000 : ld1rh z0.d, p0/Z, [x0, #0]                : ld1rh  (%x0)[2byte] %p0/z -> %z0.d
+84c4e482 : ld1rh z2.d, p1/Z, [x4, #8]                : ld1rh  +0x08(%x4)[2byte] %p1/z -> %z2.d
+84c8e8c4 : ld1rh z4.d, p2/Z, [x6, #16]               : ld1rh  +0x10(%x6)[2byte] %p2/z -> %z4.d
+84cce906 : ld1rh z6.d, p2/Z, [x8, #24]               : ld1rh  +0x18(%x8)[2byte] %p2/z -> %z6.d
+84d0ed48 : ld1rh z8.d, p3/Z, [x10, #32]              : ld1rh  +0x20(%x10)[2byte] %p3/z -> %z8.d
+84d4ed6a : ld1rh z10.d, p3/Z, [x11, #40]             : ld1rh  +0x28(%x11)[2byte] %p3/z -> %z10.d
+84d8f1ac : ld1rh z12.d, p4/Z, [x13, #48]             : ld1rh  +0x30(%x13)[2byte] %p4/z -> %z12.d
+84dcf1ee : ld1rh z14.d, p4/Z, [x15, #56]             : ld1rh  +0x38(%x15)[2byte] %p4/z -> %z14.d
+84e0f630 : ld1rh z16.d, p5/Z, [x17, #64]             : ld1rh  +0x40(%x17)[2byte] %p5/z -> %z16.d
+84e3f671 : ld1rh z17.d, p5/Z, [x19, #70]             : ld1rh  +0x46(%x19)[2byte] %p5/z -> %z17.d
+84e7f6b3 : ld1rh z19.d, p5/Z, [x21, #78]             : ld1rh  +0x4e(%x21)[2byte] %p5/z -> %z19.d
+84ebfaf5 : ld1rh z21.d, p6/Z, [x23, #86]             : ld1rh  +0x56(%x23)[2byte] %p6/z -> %z21.d
+84effb17 : ld1rh z23.d, p6/Z, [x24, #94]             : ld1rh  +0x5e(%x24)[2byte] %p6/z -> %z23.d
+84f3ff59 : ld1rh z25.d, p7/Z, [x26, #102]            : ld1rh  +0x66(%x26)[2byte] %p7/z -> %z25.d
+84f7ff9b : ld1rh z27.d, p7/Z, [x28, #110]            : ld1rh  +0x6e(%x28)[2byte] %p7/z -> %z27.d
+84ffffff : ld1rh z31.d, p7/Z, [sp, #126]             : ld1rh  +0x7e(%sp)[2byte] %p7/z -> %z31.d
+
+# LD1RSB  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RSB-Z.P.BI-S16)
+85c0c000 : ld1rsb z0.h, p0/Z, [x0, #0]               : ld1rsb (%x0)[1byte] %p0/z -> %z0.h
+85c4c482 : ld1rsb z2.h, p1/Z, [x4, #4]               : ld1rsb +0x04(%x4)[1byte] %p1/z -> %z2.h
+85c8c8c4 : ld1rsb z4.h, p2/Z, [x6, #8]               : ld1rsb +0x08(%x6)[1byte] %p2/z -> %z4.h
+85ccc906 : ld1rsb z6.h, p2/Z, [x8, #12]              : ld1rsb +0x0c(%x8)[1byte] %p2/z -> %z6.h
+85d0cd48 : ld1rsb z8.h, p3/Z, [x10, #16]             : ld1rsb +0x10(%x10)[1byte] %p3/z -> %z8.h
+85d4cd6a : ld1rsb z10.h, p3/Z, [x11, #20]            : ld1rsb +0x14(%x11)[1byte] %p3/z -> %z10.h
+85d8d1ac : ld1rsb z12.h, p4/Z, [x13, #24]            : ld1rsb +0x18(%x13)[1byte] %p4/z -> %z12.h
+85dcd1ee : ld1rsb z14.h, p4/Z, [x15, #28]            : ld1rsb +0x1c(%x15)[1byte] %p4/z -> %z14.h
+85e0d630 : ld1rsb z16.h, p5/Z, [x17, #32]            : ld1rsb +0x20(%x17)[1byte] %p5/z -> %z16.h
+85e3d671 : ld1rsb z17.h, p5/Z, [x19, #35]            : ld1rsb +0x23(%x19)[1byte] %p5/z -> %z17.h
+85e7d6b3 : ld1rsb z19.h, p5/Z, [x21, #39]            : ld1rsb +0x27(%x21)[1byte] %p5/z -> %z19.h
+85ebdaf5 : ld1rsb z21.h, p6/Z, [x23, #43]            : ld1rsb +0x2b(%x23)[1byte] %p6/z -> %z21.h
+85efdb17 : ld1rsb z23.h, p6/Z, [x24, #47]            : ld1rsb +0x2f(%x24)[1byte] %p6/z -> %z23.h
+85f3df59 : ld1rsb z25.h, p7/Z, [x26, #51]            : ld1rsb +0x33(%x26)[1byte] %p7/z -> %z25.h
+85f7df9b : ld1rsb z27.h, p7/Z, [x28, #55]            : ld1rsb +0x37(%x28)[1byte] %p7/z -> %z27.h
+85ffdfff : ld1rsb z31.h, p7/Z, [sp, #63]             : ld1rsb +0x3f(%sp)[1byte] %p7/z -> %z31.h
+
+# LD1RSB  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RSB-Z.P.BI-S32)
+85c0a000 : ld1rsb z0.s, p0/Z, [x0, #0]               : ld1rsb (%x0)[1byte] %p0/z -> %z0.s
+85c4a482 : ld1rsb z2.s, p1/Z, [x4, #4]               : ld1rsb +0x04(%x4)[1byte] %p1/z -> %z2.s
+85c8a8c4 : ld1rsb z4.s, p2/Z, [x6, #8]               : ld1rsb +0x08(%x6)[1byte] %p2/z -> %z4.s
+85cca906 : ld1rsb z6.s, p2/Z, [x8, #12]              : ld1rsb +0x0c(%x8)[1byte] %p2/z -> %z6.s
+85d0ad48 : ld1rsb z8.s, p3/Z, [x10, #16]             : ld1rsb +0x10(%x10)[1byte] %p3/z -> %z8.s
+85d4ad6a : ld1rsb z10.s, p3/Z, [x11, #20]            : ld1rsb +0x14(%x11)[1byte] %p3/z -> %z10.s
+85d8b1ac : ld1rsb z12.s, p4/Z, [x13, #24]            : ld1rsb +0x18(%x13)[1byte] %p4/z -> %z12.s
+85dcb1ee : ld1rsb z14.s, p4/Z, [x15, #28]            : ld1rsb +0x1c(%x15)[1byte] %p4/z -> %z14.s
+85e0b630 : ld1rsb z16.s, p5/Z, [x17, #32]            : ld1rsb +0x20(%x17)[1byte] %p5/z -> %z16.s
+85e3b671 : ld1rsb z17.s, p5/Z, [x19, #35]            : ld1rsb +0x23(%x19)[1byte] %p5/z -> %z17.s
+85e7b6b3 : ld1rsb z19.s, p5/Z, [x21, #39]            : ld1rsb +0x27(%x21)[1byte] %p5/z -> %z19.s
+85ebbaf5 : ld1rsb z21.s, p6/Z, [x23, #43]            : ld1rsb +0x2b(%x23)[1byte] %p6/z -> %z21.s
+85efbb17 : ld1rsb z23.s, p6/Z, [x24, #47]            : ld1rsb +0x2f(%x24)[1byte] %p6/z -> %z23.s
+85f3bf59 : ld1rsb z25.s, p7/Z, [x26, #51]            : ld1rsb +0x33(%x26)[1byte] %p7/z -> %z25.s
+85f7bf9b : ld1rsb z27.s, p7/Z, [x28, #55]            : ld1rsb +0x37(%x28)[1byte] %p7/z -> %z27.s
+85ffbfff : ld1rsb z31.s, p7/Z, [sp, #63]             : ld1rsb +0x3f(%sp)[1byte] %p7/z -> %z31.s
+
+# LD1RSB  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RSB-Z.P.BI-S64)
+85c08000 : ld1rsb z0.d, p0/Z, [x0, #0]               : ld1rsb (%x0)[1byte] %p0/z -> %z0.d
+85c48482 : ld1rsb z2.d, p1/Z, [x4, #4]               : ld1rsb +0x04(%x4)[1byte] %p1/z -> %z2.d
+85c888c4 : ld1rsb z4.d, p2/Z, [x6, #8]               : ld1rsb +0x08(%x6)[1byte] %p2/z -> %z4.d
+85cc8906 : ld1rsb z6.d, p2/Z, [x8, #12]              : ld1rsb +0x0c(%x8)[1byte] %p2/z -> %z6.d
+85d08d48 : ld1rsb z8.d, p3/Z, [x10, #16]             : ld1rsb +0x10(%x10)[1byte] %p3/z -> %z8.d
+85d48d6a : ld1rsb z10.d, p3/Z, [x11, #20]            : ld1rsb +0x14(%x11)[1byte] %p3/z -> %z10.d
+85d891ac : ld1rsb z12.d, p4/Z, [x13, #24]            : ld1rsb +0x18(%x13)[1byte] %p4/z -> %z12.d
+85dc91ee : ld1rsb z14.d, p4/Z, [x15, #28]            : ld1rsb +0x1c(%x15)[1byte] %p4/z -> %z14.d
+85e09630 : ld1rsb z16.d, p5/Z, [x17, #32]            : ld1rsb +0x20(%x17)[1byte] %p5/z -> %z16.d
+85e39671 : ld1rsb z17.d, p5/Z, [x19, #35]            : ld1rsb +0x23(%x19)[1byte] %p5/z -> %z17.d
+85e796b3 : ld1rsb z19.d, p5/Z, [x21, #39]            : ld1rsb +0x27(%x21)[1byte] %p5/z -> %z19.d
+85eb9af5 : ld1rsb z21.d, p6/Z, [x23, #43]            : ld1rsb +0x2b(%x23)[1byte] %p6/z -> %z21.d
+85ef9b17 : ld1rsb z23.d, p6/Z, [x24, #47]            : ld1rsb +0x2f(%x24)[1byte] %p6/z -> %z23.d
+85f39f59 : ld1rsb z25.d, p7/Z, [x26, #51]            : ld1rsb +0x33(%x26)[1byte] %p7/z -> %z25.d
+85f79f9b : ld1rsb z27.d, p7/Z, [x28, #55]            : ld1rsb +0x37(%x28)[1byte] %p7/z -> %z27.d
+85ff9fff : ld1rsb z31.d, p7/Z, [sp, #63]             : ld1rsb +0x3f(%sp)[1byte] %p7/z -> %z31.d
+
+# LD1RSH  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RSH-Z.P.BI-S32)
+8540a000 : ld1rsh z0.s, p0/Z, [x0, #0]               : ld1rsh (%x0)[2byte] %p0/z -> %z0.s
+8544a482 : ld1rsh z2.s, p1/Z, [x4, #8]               : ld1rsh +0x08(%x4)[2byte] %p1/z -> %z2.s
+8548a8c4 : ld1rsh z4.s, p2/Z, [x6, #16]              : ld1rsh +0x10(%x6)[2byte] %p2/z -> %z4.s
+854ca906 : ld1rsh z6.s, p2/Z, [x8, #24]              : ld1rsh +0x18(%x8)[2byte] %p2/z -> %z6.s
+8550ad48 : ld1rsh z8.s, p3/Z, [x10, #32]             : ld1rsh +0x20(%x10)[2byte] %p3/z -> %z8.s
+8554ad6a : ld1rsh z10.s, p3/Z, [x11, #40]            : ld1rsh +0x28(%x11)[2byte] %p3/z -> %z10.s
+8558b1ac : ld1rsh z12.s, p4/Z, [x13, #48]            : ld1rsh +0x30(%x13)[2byte] %p4/z -> %z12.s
+855cb1ee : ld1rsh z14.s, p4/Z, [x15, #56]            : ld1rsh +0x38(%x15)[2byte] %p4/z -> %z14.s
+8560b630 : ld1rsh z16.s, p5/Z, [x17, #64]            : ld1rsh +0x40(%x17)[2byte] %p5/z -> %z16.s
+8563b671 : ld1rsh z17.s, p5/Z, [x19, #70]            : ld1rsh +0x46(%x19)[2byte] %p5/z -> %z17.s
+8567b6b3 : ld1rsh z19.s, p5/Z, [x21, #78]            : ld1rsh +0x4e(%x21)[2byte] %p5/z -> %z19.s
+856bbaf5 : ld1rsh z21.s, p6/Z, [x23, #86]            : ld1rsh +0x56(%x23)[2byte] %p6/z -> %z21.s
+856fbb17 : ld1rsh z23.s, p6/Z, [x24, #94]            : ld1rsh +0x5e(%x24)[2byte] %p6/z -> %z23.s
+8573bf59 : ld1rsh z25.s, p7/Z, [x26, #102]           : ld1rsh +0x66(%x26)[2byte] %p7/z -> %z25.s
+8577bf9b : ld1rsh z27.s, p7/Z, [x28, #110]           : ld1rsh +0x6e(%x28)[2byte] %p7/z -> %z27.s
+857fbfff : ld1rsh z31.s, p7/Z, [sp, #126]            : ld1rsh +0x7e(%sp)[2byte] %p7/z -> %z31.s
+
+# LD1RSH  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RSH-Z.P.BI-S64)
+85408000 : ld1rsh z0.d, p0/Z, [x0, #0]               : ld1rsh (%x0)[2byte] %p0/z -> %z0.d
+85448482 : ld1rsh z2.d, p1/Z, [x4, #8]               : ld1rsh +0x08(%x4)[2byte] %p1/z -> %z2.d
+854888c4 : ld1rsh z4.d, p2/Z, [x6, #16]              : ld1rsh +0x10(%x6)[2byte] %p2/z -> %z4.d
+854c8906 : ld1rsh z6.d, p2/Z, [x8, #24]              : ld1rsh +0x18(%x8)[2byte] %p2/z -> %z6.d
+85508d48 : ld1rsh z8.d, p3/Z, [x10, #32]             : ld1rsh +0x20(%x10)[2byte] %p3/z -> %z8.d
+85548d6a : ld1rsh z10.d, p3/Z, [x11, #40]            : ld1rsh +0x28(%x11)[2byte] %p3/z -> %z10.d
+855891ac : ld1rsh z12.d, p4/Z, [x13, #48]            : ld1rsh +0x30(%x13)[2byte] %p4/z -> %z12.d
+855c91ee : ld1rsh z14.d, p4/Z, [x15, #56]            : ld1rsh +0x38(%x15)[2byte] %p4/z -> %z14.d
+85609630 : ld1rsh z16.d, p5/Z, [x17, #64]            : ld1rsh +0x40(%x17)[2byte] %p5/z -> %z16.d
+85639671 : ld1rsh z17.d, p5/Z, [x19, #70]            : ld1rsh +0x46(%x19)[2byte] %p5/z -> %z17.d
+856796b3 : ld1rsh z19.d, p5/Z, [x21, #78]            : ld1rsh +0x4e(%x21)[2byte] %p5/z -> %z19.d
+856b9af5 : ld1rsh z21.d, p6/Z, [x23, #86]            : ld1rsh +0x56(%x23)[2byte] %p6/z -> %z21.d
+856f9b17 : ld1rsh z23.d, p6/Z, [x24, #94]            : ld1rsh +0x5e(%x24)[2byte] %p6/z -> %z23.d
+85739f59 : ld1rsh z25.d, p7/Z, [x26, #102]           : ld1rsh +0x66(%x26)[2byte] %p7/z -> %z25.d
+85779f9b : ld1rsh z27.d, p7/Z, [x28, #110]           : ld1rsh +0x6e(%x28)[2byte] %p7/z -> %z27.d
+857f9fff : ld1rsh z31.d, p7/Z, [sp, #126]            : ld1rsh +0x7e(%sp)[2byte] %p7/z -> %z31.d
+
+# LD1RSW  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RSW-Z.P.BI-S64)
+84c08000 : ld1rsw z0.d, p0/Z, [x0, #0]               : ld1rsw (%x0)[4byte] %p0/z -> %z0.d
+84c48482 : ld1rsw z2.d, p1/Z, [x4, #16]              : ld1rsw +0x10(%x4)[4byte] %p1/z -> %z2.d
+84c888c4 : ld1rsw z4.d, p2/Z, [x6, #32]              : ld1rsw +0x20(%x6)[4byte] %p2/z -> %z4.d
+84cc8906 : ld1rsw z6.d, p2/Z, [x8, #48]              : ld1rsw +0x30(%x8)[4byte] %p2/z -> %z6.d
+84d08d48 : ld1rsw z8.d, p3/Z, [x10, #64]             : ld1rsw +0x40(%x10)[4byte] %p3/z -> %z8.d
+84d48d6a : ld1rsw z10.d, p3/Z, [x11, #80]            : ld1rsw +0x50(%x11)[4byte] %p3/z -> %z10.d
+84d891ac : ld1rsw z12.d, p4/Z, [x13, #96]            : ld1rsw +0x60(%x13)[4byte] %p4/z -> %z12.d
+84dc91ee : ld1rsw z14.d, p4/Z, [x15, #112]           : ld1rsw +0x70(%x15)[4byte] %p4/z -> %z14.d
+84e09630 : ld1rsw z16.d, p5/Z, [x17, #128]           : ld1rsw +0x80(%x17)[4byte] %p5/z -> %z16.d
+84e39671 : ld1rsw z17.d, p5/Z, [x19, #140]           : ld1rsw +0x8c(%x19)[4byte] %p5/z -> %z17.d
+84e796b3 : ld1rsw z19.d, p5/Z, [x21, #156]           : ld1rsw +0x9c(%x21)[4byte] %p5/z -> %z19.d
+84eb9af5 : ld1rsw z21.d, p6/Z, [x23, #172]           : ld1rsw +0xac(%x23)[4byte] %p6/z -> %z21.d
+84ef9b17 : ld1rsw z23.d, p6/Z, [x24, #188]           : ld1rsw +0xbc(%x24)[4byte] %p6/z -> %z23.d
+84f39f59 : ld1rsw z25.d, p7/Z, [x26, #204]           : ld1rsw +0xcc(%x26)[4byte] %p7/z -> %z25.d
+84f79f9b : ld1rsw z27.d, p7/Z, [x28, #220]           : ld1rsw +0xdc(%x28)[4byte] %p7/z -> %z27.d
+84ff9fff : ld1rsw z31.d, p7/Z, [sp, #252]            : ld1rsw +0xfc(%sp)[4byte] %p7/z -> %z31.d
+
+# LD1RW   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RW-Z.P.BI-U32)
+8540c000 : ld1rw z0.s, p0/Z, [x0, #0]                : ld1rw  (%x0)[4byte] %p0/z -> %z0.s
+8544c482 : ld1rw z2.s, p1/Z, [x4, #16]               : ld1rw  +0x10(%x4)[4byte] %p1/z -> %z2.s
+8548c8c4 : ld1rw z4.s, p2/Z, [x6, #32]               : ld1rw  +0x20(%x6)[4byte] %p2/z -> %z4.s
+854cc906 : ld1rw z6.s, p2/Z, [x8, #48]               : ld1rw  +0x30(%x8)[4byte] %p2/z -> %z6.s
+8550cd48 : ld1rw z8.s, p3/Z, [x10, #64]              : ld1rw  +0x40(%x10)[4byte] %p3/z -> %z8.s
+8554cd6a : ld1rw z10.s, p3/Z, [x11, #80]             : ld1rw  +0x50(%x11)[4byte] %p3/z -> %z10.s
+8558d1ac : ld1rw z12.s, p4/Z, [x13, #96]             : ld1rw  +0x60(%x13)[4byte] %p4/z -> %z12.s
+855cd1ee : ld1rw z14.s, p4/Z, [x15, #112]            : ld1rw  +0x70(%x15)[4byte] %p4/z -> %z14.s
+8560d630 : ld1rw z16.s, p5/Z, [x17, #128]            : ld1rw  +0x80(%x17)[4byte] %p5/z -> %z16.s
+8563d671 : ld1rw z17.s, p5/Z, [x19, #140]            : ld1rw  +0x8c(%x19)[4byte] %p5/z -> %z17.s
+8567d6b3 : ld1rw z19.s, p5/Z, [x21, #156]            : ld1rw  +0x9c(%x21)[4byte] %p5/z -> %z19.s
+856bdaf5 : ld1rw z21.s, p6/Z, [x23, #172]            : ld1rw  +0xac(%x23)[4byte] %p6/z -> %z21.s
+856fdb17 : ld1rw z23.s, p6/Z, [x24, #188]            : ld1rw  +0xbc(%x24)[4byte] %p6/z -> %z23.s
+8573df59 : ld1rw z25.s, p7/Z, [x26, #204]            : ld1rw  +0xcc(%x26)[4byte] %p7/z -> %z25.s
+8577df9b : ld1rw z27.s, p7/Z, [x28, #220]            : ld1rw  +0xdc(%x28)[4byte] %p7/z -> %z27.s
+857fdfff : ld1rw z31.s, p7/Z, [sp, #252]             : ld1rw  +0xfc(%sp)[4byte] %p7/z -> %z31.s
+
+# LD1RW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RW-Z.P.BI-U64)
+8540e000 : ld1rw z0.d, p0/Z, [x0, #0]                : ld1rw  (%x0)[4byte] %p0/z -> %z0.d
+8544e482 : ld1rw z2.d, p1/Z, [x4, #16]               : ld1rw  +0x10(%x4)[4byte] %p1/z -> %z2.d
+8548e8c4 : ld1rw z4.d, p2/Z, [x6, #32]               : ld1rw  +0x20(%x6)[4byte] %p2/z -> %z4.d
+854ce906 : ld1rw z6.d, p2/Z, [x8, #48]               : ld1rw  +0x30(%x8)[4byte] %p2/z -> %z6.d
+8550ed48 : ld1rw z8.d, p3/Z, [x10, #64]              : ld1rw  +0x40(%x10)[4byte] %p3/z -> %z8.d
+8554ed6a : ld1rw z10.d, p3/Z, [x11, #80]             : ld1rw  +0x50(%x11)[4byte] %p3/z -> %z10.d
+8558f1ac : ld1rw z12.d, p4/Z, [x13, #96]             : ld1rw  +0x60(%x13)[4byte] %p4/z -> %z12.d
+855cf1ee : ld1rw z14.d, p4/Z, [x15, #112]            : ld1rw  +0x70(%x15)[4byte] %p4/z -> %z14.d
+8560f630 : ld1rw z16.d, p5/Z, [x17, #128]            : ld1rw  +0x80(%x17)[4byte] %p5/z -> %z16.d
+8563f671 : ld1rw z17.d, p5/Z, [x19, #140]            : ld1rw  +0x8c(%x19)[4byte] %p5/z -> %z17.d
+8567f6b3 : ld1rw z19.d, p5/Z, [x21, #156]            : ld1rw  +0x9c(%x21)[4byte] %p5/z -> %z19.d
+856bfaf5 : ld1rw z21.d, p6/Z, [x23, #172]            : ld1rw  +0xac(%x23)[4byte] %p6/z -> %z21.d
+856ffb17 : ld1rw z23.d, p6/Z, [x24, #188]            : ld1rw  +0xbc(%x24)[4byte] %p6/z -> %z23.d
+8573ff59 : ld1rw z25.d, p7/Z, [x26, #204]            : ld1rw  +0xcc(%x26)[4byte] %p7/z -> %z25.d
+8577ff9b : ld1rw z27.d, p7/Z, [x28, #220]            : ld1rw  +0xdc(%x28)[4byte] %p7/z -> %z27.d
+857fffff : ld1rw z31.d, p7/Z, [sp, #252]             : ld1rw  +0xfc(%sp)[4byte] %p7/z -> %z31.d
+
 # LDR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
 858043c0 : ldr z0, [x30]                            : ldr    (%x30)[32byte] -> %z0
 858057a1 : ldr z1, [x29, #5, mul vl]                : ldr    +0x05(%x29)[32byte] -> %z1

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -151,6 +151,8 @@ const reg_id_t Xn_six_offset_1_zr[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
                                          DR_REG_X16, DR_REG_X21, DR_REG_XZR };
 const reg_id_t Xn_six_offset_1_sp[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
                                          DR_REG_X16, DR_REG_X21, DR_REG_XSP };
+const reg_id_t Xn_six_offset_2_sp[6] = { DR_REG_X0,  DR_REG_X7,  DR_REG_X12,
+                                         DR_REG_X17, DR_REG_X22, DR_REG_SP };
 const reg_id_t Wn_six_offset_0[6] = { DR_REG_W0,  DR_REG_W5,  DR_REG_W10,
                                       DR_REG_W15, DR_REG_W20, DR_REG_W30 };
 const reg_id_t Wn_six_offset_1_zr[6] = { DR_REG_W0,  DR_REG_W6,  DR_REG_W11,

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -10172,6 +10172,283 @@ TEST_INSTR(fdup_sve)
               opnd_create_immed_double(imm8[i]));
 }
 
+TEST_INSTR(ld1rb_sve)
+{
+    /* Testing LD1RB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_0_0[6] = { 0, 13, 24, 35, 45, 63 };
+    const char *const expected_0_0[6] = {
+        "ld1rb  (%x0)[1byte] %p0/z -> %z0.h",
+        "ld1rb  +0x0d(%x7)[1byte] %p2/z -> %z5.h",
+        "ld1rb  +0x18(%x12)[1byte] %p3/z -> %z10.h",
+        "ld1rb  +0x23(%x17)[1byte] %p5/z -> %z16.h",
+        "ld1rb  +0x2d(%x22)[1byte] %p6/z -> %z21.h",
+        "ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.h",
+    };
+    TEST_LOOP(ld1rb, ld1rb_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_0_0[i],
+                                    OPSZ_1));
+
+    /* Testing LD1RB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_1_0[6] = { 0, 13, 24, 35, 45, 63 };
+    const char *const expected_1_0[6] = {
+        "ld1rb  (%x0)[1byte] %p0/z -> %z0.s",
+        "ld1rb  +0x0d(%x7)[1byte] %p2/z -> %z5.s",
+        "ld1rb  +0x18(%x12)[1byte] %p3/z -> %z10.s",
+        "ld1rb  +0x23(%x17)[1byte] %p5/z -> %z16.s",
+        "ld1rb  +0x2d(%x22)[1byte] %p6/z -> %z21.s",
+        "ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1rb, ld1rb_sve, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_1_0[i],
+                                    OPSZ_1));
+
+    /* Testing LD1RB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_2_0[6] = { 0, 13, 24, 35, 45, 63 };
+    const char *const expected_2_0[6] = {
+        "ld1rb  (%x0)[1byte] %p0/z -> %z0.d",
+        "ld1rb  +0x0d(%x7)[1byte] %p2/z -> %z5.d",
+        "ld1rb  +0x18(%x12)[1byte] %p3/z -> %z10.d",
+        "ld1rb  +0x23(%x17)[1byte] %p5/z -> %z16.d",
+        "ld1rb  +0x2d(%x22)[1byte] %p6/z -> %z21.d",
+        "ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1rb, ld1rb_sve, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_2_0[i],
+                                    OPSZ_1));
+
+    /* Testing LD1RB   { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_3_0[6] = { 0, 13, 24, 35, 45, 63 };
+    const char *const expected_3_0[6] = {
+        "ld1rb  (%x0)[1byte] %p0/z -> %z0.b",
+        "ld1rb  +0x0d(%x7)[1byte] %p2/z -> %z5.b",
+        "ld1rb  +0x18(%x12)[1byte] %p3/z -> %z10.b",
+        "ld1rb  +0x23(%x17)[1byte] %p5/z -> %z16.b",
+        "ld1rb  +0x2d(%x22)[1byte] %p6/z -> %z21.b",
+        "ld1rb  +0x3f(%sp)[1byte] %p7/z -> %z31.b",
+    };
+    TEST_LOOP(ld1rb, ld1rb_sve, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_3_0[i],
+                                    OPSZ_1));
+}
+
+TEST_INSTR(ld1rh_sve)
+{
+    /* Testing LD1RH   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_0_0[6] = { 0, 26, 48, 70, 90, 126 };
+    const char *const expected_0_0[6] = {
+        "ld1rh  (%x0)[2byte] %p0/z -> %z0.h",
+        "ld1rh  +0x1a(%x7)[2byte] %p2/z -> %z5.h",
+        "ld1rh  +0x30(%x12)[2byte] %p3/z -> %z10.h",
+        "ld1rh  +0x46(%x17)[2byte] %p5/z -> %z16.h",
+        "ld1rh  +0x5a(%x22)[2byte] %p6/z -> %z21.h",
+        "ld1rh  +0x7e(%sp)[2byte] %p7/z -> %z31.h",
+    };
+    TEST_LOOP(ld1rh, ld1rh_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_0_0[i],
+                                    OPSZ_2));
+
+    /* Testing LD1RH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_1_0[6] = { 0, 26, 48, 70, 90, 126 };
+    const char *const expected_1_0[6] = {
+        "ld1rh  (%x0)[2byte] %p0/z -> %z0.s",
+        "ld1rh  +0x1a(%x7)[2byte] %p2/z -> %z5.s",
+        "ld1rh  +0x30(%x12)[2byte] %p3/z -> %z10.s",
+        "ld1rh  +0x46(%x17)[2byte] %p5/z -> %z16.s",
+        "ld1rh  +0x5a(%x22)[2byte] %p6/z -> %z21.s",
+        "ld1rh  +0x7e(%sp)[2byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1rh, ld1rh_sve, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_1_0[i],
+                                    OPSZ_2));
+
+    /* Testing LD1RH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_2_0[6] = { 0, 26, 48, 70, 90, 126 };
+    const char *const expected_2_0[6] = {
+        "ld1rh  (%x0)[2byte] %p0/z -> %z0.d",
+        "ld1rh  +0x1a(%x7)[2byte] %p2/z -> %z5.d",
+        "ld1rh  +0x30(%x12)[2byte] %p3/z -> %z10.d",
+        "ld1rh  +0x46(%x17)[2byte] %p5/z -> %z16.d",
+        "ld1rh  +0x5a(%x22)[2byte] %p6/z -> %z21.d",
+        "ld1rh  +0x7e(%sp)[2byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1rh, ld1rh_sve, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_2_0[i],
+                                    OPSZ_2));
+}
+
+TEST_INSTR(ld1rw_sve)
+{
+    /* Testing LD1RW   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_0_0[6] = { 0, 52, 96, 140, 180, 252 };
+    const char *const expected_0_0[6] = {
+        "ld1rw  (%x0)[4byte] %p0/z -> %z0.s",
+        "ld1rw  +0x34(%x7)[4byte] %p2/z -> %z5.s",
+        "ld1rw  +0x60(%x12)[4byte] %p3/z -> %z10.s",
+        "ld1rw  +0x8c(%x17)[4byte] %p5/z -> %z16.s",
+        "ld1rw  +0xb4(%x22)[4byte] %p6/z -> %z21.s",
+        "ld1rw  +0xfc(%sp)[4byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1rw, ld1rw_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_0_0[i],
+                                    OPSZ_4));
+
+    /* Testing LD1RW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_1_0[6] = { 0, 52, 96, 140, 180, 252 };
+    const char *const expected_1_0[6] = {
+        "ld1rw  (%x0)[4byte] %p0/z -> %z0.d",
+        "ld1rw  +0x34(%x7)[4byte] %p2/z -> %z5.d",
+        "ld1rw  +0x60(%x12)[4byte] %p3/z -> %z10.d",
+        "ld1rw  +0x8c(%x17)[4byte] %p5/z -> %z16.d",
+        "ld1rw  +0xb4(%x22)[4byte] %p6/z -> %z21.d",
+        "ld1rw  +0xfc(%sp)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1rw, ld1rw_sve, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_1_0[i],
+                                    OPSZ_4));
+}
+
+TEST_INSTR(ld1rd_sve)
+{
+    /* Testing LD1RD   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_0_0[6] = { 0, 104, 192, 280, 360, 504 };
+    const char *const expected_0_0[6] = {
+        "ld1rd  (%x0)[8byte] %p0/z -> %z0.d",
+        "ld1rd  +0x68(%x7)[8byte] %p2/z -> %z5.d",
+        "ld1rd  +0xc0(%x12)[8byte] %p3/z -> %z10.d",
+        "ld1rd  +0x0118(%x17)[8byte] %p5/z -> %z16.d",
+        "ld1rd  +0x0168(%x22)[8byte] %p6/z -> %z21.d",
+        "ld1rd  +0x01f8(%sp)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1rd, ld1rd_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_0_0[i],
+                                    OPSZ_8));
+}
+
+TEST_INSTR(ld1rsb_sve)
+{
+    /* Testing LD1RSB  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_0_0[6] = { 0, 13, 24, 35, 45, 63 };
+    const char *const expected_0_0[6] = {
+        "ld1rsb (%x0)[1byte] %p0/z -> %z0.h",
+        "ld1rsb +0x0d(%x7)[1byte] %p2/z -> %z5.h",
+        "ld1rsb +0x18(%x12)[1byte] %p3/z -> %z10.h",
+        "ld1rsb +0x23(%x17)[1byte] %p5/z -> %z16.h",
+        "ld1rsb +0x2d(%x22)[1byte] %p6/z -> %z21.h",
+        "ld1rsb +0x3f(%sp)[1byte] %p7/z -> %z31.h",
+    };
+    TEST_LOOP(ld1rsb, ld1rsb_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_0_0[i],
+                                    OPSZ_1));
+
+    /* Testing LD1RSB  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_1_0[6] = { 0, 13, 24, 35, 45, 63 };
+    const char *const expected_1_0[6] = {
+        "ld1rsb (%x0)[1byte] %p0/z -> %z0.s",
+        "ld1rsb +0x0d(%x7)[1byte] %p2/z -> %z5.s",
+        "ld1rsb +0x18(%x12)[1byte] %p3/z -> %z10.s",
+        "ld1rsb +0x23(%x17)[1byte] %p5/z -> %z16.s",
+        "ld1rsb +0x2d(%x22)[1byte] %p6/z -> %z21.s",
+        "ld1rsb +0x3f(%sp)[1byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1rsb, ld1rsb_sve, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_1_0[i],
+                                    OPSZ_1));
+
+    /* Testing LD1RSB  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_2_0[6] = { 0, 13, 24, 35, 45, 63 };
+    const char *const expected_2_0[6] = {
+        "ld1rsb (%x0)[1byte] %p0/z -> %z0.d",
+        "ld1rsb +0x0d(%x7)[1byte] %p2/z -> %z5.d",
+        "ld1rsb +0x18(%x12)[1byte] %p3/z -> %z10.d",
+        "ld1rsb +0x23(%x17)[1byte] %p5/z -> %z16.d",
+        "ld1rsb +0x2d(%x22)[1byte] %p6/z -> %z21.d",
+        "ld1rsb +0x3f(%sp)[1byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1rsb, ld1rsb_sve, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_2_0[i],
+                                    OPSZ_1));
+}
+
+TEST_INSTR(ld1rsh_sve)
+{
+    /* Testing LD1RSH  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_0_0[6] = { 0, 26, 48, 70, 90, 126 };
+    const char *const expected_0_0[6] = {
+        "ld1rsh (%x0)[2byte] %p0/z -> %z0.s",
+        "ld1rsh +0x1a(%x7)[2byte] %p2/z -> %z5.s",
+        "ld1rsh +0x30(%x12)[2byte] %p3/z -> %z10.s",
+        "ld1rsh +0x46(%x17)[2byte] %p5/z -> %z16.s",
+        "ld1rsh +0x5a(%x22)[2byte] %p6/z -> %z21.s",
+        "ld1rsh +0x7e(%sp)[2byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1rsh, ld1rsh_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_0_0[i],
+                                    OPSZ_2));
+
+    /* Testing LD1RSH  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_1_0[6] = { 0, 26, 48, 70, 90, 126 };
+    const char *const expected_1_0[6] = {
+        "ld1rsh (%x0)[2byte] %p0/z -> %z0.d",
+        "ld1rsh +0x1a(%x7)[2byte] %p2/z -> %z5.d",
+        "ld1rsh +0x30(%x12)[2byte] %p3/z -> %z10.d",
+        "ld1rsh +0x46(%x17)[2byte] %p5/z -> %z16.d",
+        "ld1rsh +0x5a(%x22)[2byte] %p6/z -> %z21.d",
+        "ld1rsh +0x7e(%sp)[2byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1rsh, ld1rsh_sve, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_1_0[i],
+                                    OPSZ_2));
+}
+
+TEST_INSTR(ld1rsw_sve)
+{
+    /* Testing LD1RSW  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] */
+    static const uint imm6_0_0[6] = { 0, 52, 96, 140, 180, 252 };
+    const char *const expected_0_0[6] = {
+        "ld1rsw (%x0)[4byte] %p0/z -> %z0.d",
+        "ld1rsw +0x34(%x7)[4byte] %p2/z -> %z5.d",
+        "ld1rsw +0x60(%x12)[4byte] %p3/z -> %z10.d",
+        "ld1rsw +0x8c(%x17)[4byte] %p5/z -> %z16.d",
+        "ld1rsw +0xb4(%x22)[4byte] %p6/z -> %z21.d",
+        "ld1rsw +0xfc(%sp)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1rsw, ld1rsw_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm6_0_0[i],
+                                    OPSZ_4));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -10489,6 +10766,14 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(fcpy_sve_pred);
     RUN_INSTR_TEST(fdup_sve);
+
+    RUN_INSTR_TEST(ld1rb_sve);
+    RUN_INSTR_TEST(ld1rh_sve);
+    RUN_INSTR_TEST(ld1rw_sve);
+    RUN_INSTR_TEST(ld1rd_sve);
+    RUN_INSTR_TEST(ld1rsb_sve);
+    RUN_INSTR_TEST(ld1rsh_sve);
+    RUN_INSTR_TEST(ld1rsw_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
LD1RB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RB   { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RH   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RW   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RD   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RSB  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RSB  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RSB  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RSH  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RSH  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
LD1RSW  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<pimm>}]
```

Issue #3044