### PR TITLE
i#5686 bbdup xl8: Modify xl8 params for other libs

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2016-2022 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -5555,7 +5555,7 @@ tsz_imm3_decode(uint imm3_pos, uint tszl_pos, bool one_indexed, uint enc, int op
     case 1: shift_size = OPSZ_4b; break;
     case 2: shift_size = OPSZ_5b; break;
     case 3: shift_size = OPSZ_6b; break;
-    default: ASSERT_NOT_REACHED();
+    default: ASSERT_NOT_REACHED(); shift_size = OPSZ_NA;
     }
 
     uint value;

--- a/ext/drbbdup/drbbdup.h
+++ b/ext/drbbdup/drbbdup.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020-2022 Google, Inc.   All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -382,7 +382,9 @@ enum {
     /** Priority of drbbdup's app2app stage. */
     DRMGR_PRIORITY_APP2APP_DRBBDUP = 6500,
     /** Priority of drbbdup's insert stage. */
-    DRMGR_PRIORITY_INSERT_DRBBDUP = -6500
+    DRMGR_PRIORITY_INSERT_DRBBDUP = -6500,
+    /** Priority of drbbdup's restore state event. */
+    DRMGR_PRIORITY_RESTORE_DRBBDUP = -99900,
 };
 
 /**
@@ -394,6 +396,11 @@ enum {
  * Name of drbbdup insert priority.
  */
 #define DRMGR_PRIORITY_INSERT_NAME_DRBBDUP "drbbdup_insert"
+
+/**
+ * Name of drbbdup restore state priority.
+ */
+#define DRMGR_PRIORITY_RESTORE_NAME_DRBBDUP "drbbdup_restore"
 
 DR_EXPORT
 /**

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2022 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2023 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -2960,6 +2960,8 @@ drx_restore_state_scatter_gather(
             break;
         if (instr_is_scatter(&params.inst))
             break;
+        dr_log(drcontext, DR_LOG_ALL, 3, "%s @%p state=%d\n", __FUNCTION__,
+               params.prev_pc, params.detect_state);
         if ((*state_machine_func)(drcontext, &params))
             break;
     }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2022 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2023 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2016-2022 ARM Limited.    All rights reserved.
 # **********************************************************
@@ -654,7 +654,9 @@ function(tobuild_ci test source client_ops dr_ops exe_ops)
         set_target_properties(${test} PROPERTIES COMPILE_FLAGS "${tst_flags}")
       endif ()
     else ()
-      set(${test}_realtest ${ci_shared_app} PARENT_SCOPE)
+      if (NOT DEFINED ${test}_realtest)
+        set(${test}_realtest ${ci_shared_app} PARENT_SCOPE)
+      endif ()
     endif ()
   endif ()
 
@@ -1666,6 +1668,20 @@ function(optimize target)
     append_property_string(TARGET ${target} COMPILE_FLAGS "/Ox /GL")
   endif (UNIX)
 endfunction(optimize)
+
+macro(set_avx_flags target)
+  if (proc_supports_avx512)
+    if (TARGET ${target}) # Support calling on non-exe target.
+      append_property_string(TARGET ${target} COMPILE_FLAGS "${CFLAGS_AVX512}")
+    endif ()
+    set(${target}_runavx512 1)
+  elseif (proc_supports_avx)
+    if (TARGET ${target}) # Support calling on non-exe target.
+      append_property_string(TARGET ${target} COMPILE_FLAGS "${CFLAGS_AVX}")
+    endif ()
+    set(${target}_runavx 1)
+  endif ()
+endmacro(set_avx_flags)
 
 ###########################################################################
 
@@ -2731,13 +2747,20 @@ if (X86)
     use_DynamoRIO_extension(client.drx-scattergather.dll drmgr)
     use_DynamoRIO_extension(client.drx-scattergather.dll drx)
     use_DynamoRIO_extension(client.drx-scattergather.dll drreg)
-    if (proc_supports_avx512)
-      append_property_string(TARGET client.drx-scattergather COMPILE_FLAGS "${CFLAGS_AVX512}")
-      set(client.drx-scattergather_runavx512 1)
-    elseif (proc_supports_avx)
-      append_property_string(TARGET client.drx-scattergather COMPILE_FLAGS "${CFLAGS_AVX}")
-      set(client.drx-scattergather_runavx 1)
-    endif ()
+    set_avx_flags(client.drx-scattergather)
+
+    # Our scattergather drbbdup test uses the same app as the base test.
+    set(client.drx-scattergather-bbdup_realtest client.drx-scattergather)
+    set(client.drx-scattergather-bbdup_expectbase "drx-scattergather")
+    tobuild_ci(client.drx-scattergather-bbdup client-interface/drx-scattergather-bbdup.c
+      "" "" "")
+    target_include_directories(client.drx-scattergather PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/client-interface)
+    use_DynamoRIO_extension(client.drx-scattergather-bbdup.dll drmgr)
+    use_DynamoRIO_extension(client.drx-scattergather-bbdup.dll drx)
+    use_DynamoRIO_extension(client.drx-scattergather-bbdup.dll drreg)
+    use_DynamoRIO_extension(client.drx-scattergather-bbdup.dll drbbdup)
+    set_avx_flags(client.drx-scattergather-bbdup)
 
     if (X64 AND UNIX)
       if (proc_supports_avx)
@@ -2745,10 +2768,7 @@ if (X86)
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_scattergather.asm
           "-early_inject" "")
         append_pure_asm_app_link_flags(allasm_scattergather)
-        if (proc_supports_avx512)
-          append_property_string(TARGET allasm_scattergather COMPILE_FLAGS "${CFLAGS_AVX512}")
-          set(allasm_scattergather_runavx512 1)
-        endif (proc_supports_avx512)
+        set_avx_flags(allasm_scattergather)
       endif (proc_supports_avx)
       add_exe(allasm_repstr
         ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/allasm_repstr.asm
@@ -2955,13 +2975,7 @@ if (LINUX AND X64) # Will take extra work to port to 32-bit.
   link_with_pthread(api.detach_state)
   set_source_files_properties(detach_state.c_asm.asm APPEND_LIST PROPERTIES
     OBJECT_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/api/detach_state_shared.h")
-  if (proc_supports_avx512)
-    append_property_string(TARGET api.detach_state COMPILE_FLAGS "${CFLAGS_AVX512}")
-    set(api.detach_state_runavx512 1)
-  elseif (proc_supports_avx)
-    append_property_string(TARGET api.detach_state COMPILE_FLAGS "${CFLAGS_AVX}")
-    set(api.detach_state_runavx 1)
-  endif ()
+  set_avx_flags(api.detach_state)
 endif ()
 if (UNIX)
   if (X64) # TODO i#4664: Fix crash in vsyscall hook under native threads.
@@ -4552,9 +4566,8 @@ if (UNIX)
   # FIXME i#58: port test to MacOS
   if (NOT ARM AND NOT AARCH64 AND NOT APPLE)
     tobuild(linux.sigcontext linux/sigcontext.c)
+    set_avx_flags(linux.sigcontext)
     if (proc_supports_avx512)
-      append_property_string(TARGET linux.sigcontext COMPILE_FLAGS "${CFLAGS_AVX512}")
-      set(linux.sigcontext_runavx512 1)
       if (CLANG)
         append_property_string(TARGET linux.sigcontext COMPILE_FLAGS
           "-mllvm -x86-use-vzeroupper=0")
@@ -4562,9 +4575,6 @@ if (UNIX)
         append_property_string(TARGET linux.sigcontext COMPILE_FLAGS
           "-mno-vzeroupper")
       endif ()
-    elseif (proc_supports_avx)
-      append_property_string(TARGET linux.sigcontext COMPILE_FLAGS "${CFLAGS_AVX}")
-      set(linux.sigcontext_runavx 1)
     endif ()
   endif ()
   if (NOT APPLE)

--- a/suite/tests/client-interface/drx-scattergather-bbdup.dll.c
+++ b/suite/tests/client-interface/drx-scattergather-bbdup.dll.c
@@ -163,9 +163,10 @@ event_bb_analyze_case(void *drcontext, void *tag, instrlist_t *bb, bool for_trac
     } else if (mode == INSTRU_MODE_EXPAND) {
         return event_bb_analysis(drcontext, tag, bb, for_trace, translating,
                                  analysis_data);
-    } else
+    } else {
         DR_ASSERT(false);
-    return DR_EMIT_DEFAULT;
+        return DR_EMIT_DEFAULT;
+    }
 }
 
 static void

--- a/suite/tests/client-interface/drx-scattergather-bbdup.dll.c
+++ b/suite/tests/client-interface/drx-scattergather-bbdup.dll.c
@@ -37,6 +37,7 @@
 #include "drmgr.h"
 #include "drreg.h"
 #include "drx.h"
+#include "drbbdup.h"
 #include "drx-scattergather-shared.h"
 #include <limits.h>
 
@@ -45,6 +46,8 @@ static uint64 global_sg_count;
 static void
 event_exit(void)
 {
+    drbbdup_status_t res = drbbdup_exit();
+    CHECK(res == DRBBDUP_SUCCESS, "drbbdup exit failed");
     drx_exit();
     drreg_exit();
     drmgr_exit();
@@ -67,26 +70,52 @@ static app_pc mask_clobber_test_avx512_scatter_pc = (app_pc)INT_MAX;
 static app_pc mask_update_test_avx512_scatter_pc = (app_pc)INT_MAX;
 static app_pc mask_update_test_avx2_gather_pc = (app_pc)INT_MAX;
 
+static ptr_int_t instru_mode;
+enum {
+    INSTRU_MODE_EXPAND = 0,
+    INSTRU_MODE_NOP = 1,
+};
+
+static uintptr_t
+event_bb_setup(void *drbbdup_ctx, void *drcontext, void *tag, instrlist_t *bb,
+               bool *enable_dups, bool *enable_dynamic_handling, void *user_data)
+{
+    *enable_dups = true;
+    drbbdup_status_t res;
+    res = drbbdup_register_case_encoding(drbbdup_ctx, INSTRU_MODE_NOP);
+    CHECK(res == DRBBDUP_SUCCESS, "register case failed");
+    *enable_dynamic_handling = false;
+    return INSTRU_MODE_EXPAND;
+}
+
+static void
+event_bb_retrieve_mode(void *drcontext, void *tag, instrlist_t *bb, instr_t *where,
+                       void *user_data, void *orig_analysis_data)
+{
+    /* Nop. */
+}
+
 static dr_emit_flags_t
 event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
-                      bool for_trace, bool translating, void *user_data)
+                      instr_t *where, bool for_trace, bool translating,
+                      void *orig_analysis_data, void *user_data)
 {
     uint num_instrs;
     if (user_data == NULL)
         return DR_EMIT_DEFAULT;
     num_instrs = *(uint *)user_data;
-    if (drmgr_is_last_instr(drcontext, instr))
-        dr_thread_free(drcontext, user_data, sizeof(uint));
-    if (!drmgr_is_first_instr(drcontext, instr))
+    bool first = false;
+    if (drbbdup_is_first_instr(drcontext, instr, &first) != DRBBDUP_SUCCESS || !first)
         return DR_EMIT_DEFAULT;
-    dr_insert_clean_call(drcontext, bb, instrlist_first_app(bb), (void *)inscount,
-                         false /* save fpstate */, 1, OPND_CREATE_INT32(num_instrs));
-    return DR_EMIT_DEFAULT;
+    dr_insert_clean_call(drcontext, bb, where, (void *)inscount, false /* save fpstate */,
+                         1, OPND_CREATE_INT32(num_instrs));
+    /* We stress test the non-recreate path. */
+    return DR_EMIT_DEFAULT; // NOCHECK STORE_TRANSLATIONS;
 }
 
 static dr_emit_flags_t
 event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
-                  bool translating, void *user_data)
+                  bool translating, void **user_data)
 {
     uint num_sg_instrs = 0;
     bool is_emulation = false;
@@ -118,8 +147,53 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
         if (!instr_is_app(instr))
             continue;
     }
-    uint *num_instr_data = (uint *)user_data;
+    *user_data = (uint *)dr_thread_alloc(drcontext, sizeof(uint));
+    uint *num_instr_data = (uint *)*user_data;
     *num_instr_data = num_sg_instrs;
+    return DR_EMIT_DEFAULT;
+}
+
+static dr_emit_flags_t
+event_bb_analyze_case(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
+                      bool translating, uintptr_t mode, void *user_data,
+                      void *orig_analysis_data, void **analysis_data)
+{
+    if (mode == INSTRU_MODE_NOP) {
+        return DR_EMIT_DEFAULT;
+    } else if (mode == INSTRU_MODE_EXPAND) {
+        return event_bb_analysis(drcontext, tag, bb, for_trace, translating,
+                                 analysis_data);
+    } else
+        DR_ASSERT(false);
+    return DR_EMIT_DEFAULT;
+}
+
+static void
+event_bb_analyze_case_cleanup(void *drcontext, uintptr_t mode, void *user_data,
+                              void *orig_analysis_data, void *analysis_data)
+{
+    if (mode == INSTRU_MODE_NOP) {
+        /* No cleanup needed. */
+    } else if (mode == INSTRU_MODE_EXPAND) {
+        dr_thread_free(drcontext, analysis_data, sizeof(uint));
+    } else
+        DR_ASSERT(false);
+}
+
+static dr_emit_flags_t
+event_app_instruction_case(void *drcontext, void *tag, instrlist_t *bb, instr_t *instr,
+                           instr_t *where, bool for_trace, bool translating,
+                           uintptr_t mode, void *user_data, void *orig_analysis_data,
+                           void *analysis_data)
+{
+    if (mode == INSTRU_MODE_NOP) {
+        return DR_EMIT_DEFAULT;
+    }
+    if (mode == INSTRU_MODE_EXPAND) {
+        return event_app_instruction(drcontext, tag, bb, instr, where, for_trace,
+                                     translating, orig_analysis_data, analysis_data);
+    } else
+        DR_ASSERT(false);
     return DR_EMIT_DEFAULT;
 }
 
@@ -169,7 +243,7 @@ search_for_next_gather_pc(void *drcontext, instr_t *start_instr)
 
 static dr_emit_flags_t
 event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
-                 bool translating, void **user_data)
+                 bool translating)
 {
     instr_t *instr;
     bool expanded = false;
@@ -306,14 +380,14 @@ event_bb_app2app(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
             break;
         }
     }
-    *user_data = (uint *)dr_thread_alloc(drcontext, sizeof(uint));
     return DR_EMIT_DEFAULT;
 }
 
 DR_EXPORT void
 dr_init(client_id_t id)
 {
-    drmgr_priority_t priority = { sizeof(priority), "drx-scattergather", NULL, NULL, 0 };
+    drmgr_priority_t priority = { sizeof(priority), "drx-scattergather-bbdup", NULL, NULL,
+                                  0 };
     drreg_options_t ops = { sizeof(ops), 2 /*max slots needed*/, false };
     drreg_status_t res;
     bool ok = drmgr_init();
@@ -323,7 +397,26 @@ dr_init(client_id_t id)
     res = drreg_init(&ops);
     CHECK(res == DRREG_SUCCESS, "drreg_init failed");
     dr_register_exit_event(event_exit);
-    ok = drmgr_register_bb_instrumentation_ex_event(event_bb_app2app, event_bb_analysis,
-                                                    event_app_instruction, NULL, NULL);
-    CHECK(ok, "drmgr register bb failed");
+
+    drbbdup_options_t opts = {
+        sizeof(opts),
+    };
+    opts.struct_size = sizeof(drbbdup_options_t);
+    opts.set_up_bb_dups = event_bb_setup;
+    opts.insert_encode = event_bb_retrieve_mode;
+    opts.analyze_case_ex = event_bb_analyze_case;
+    opts.destroy_case_analysis = event_bb_analyze_case_cleanup;
+    opts.instrument_instr_ex = event_app_instruction_case;
+    opts.runtime_case_opnd = OPND_CREATE_ABSMEM(&instru_mode, OPSZ_PTR);
+    opts.atomic_load_encoding = true;
+    opts.non_default_case_limit = 1;
+
+    drbbdup_status_t bbdup_res = drbbdup_init(&opts);
+    CHECK(bbdup_res == DRBBDUP_SUCCESS, "drbbdup init failed");
+
+    drmgr_priority_t pri_pre_bbdup = { sizeof(drmgr_priority_t),
+                                       "drx-scattergather-bbdup-app2app", NULL, NULL,
+                                       DRMGR_PRIORITY_APP2APP_DRBBDUP - 1 };
+    ok = drmgr_register_bb_app2app_event(event_bb_app2app, &pri_pre_bbdup);
+    CHECK(ok, "drmgr register app2app failed");
 }


### PR DESCRIPTION
Moves the drbbdup restore state event to a very early priority and has it modify the restore state parameters to focus on the containing copy of the block where the restore resides.  It modifies the instruction list and the cache start pc.

Adds a new test drx-scattergather-bbdup by adding drbbdup to the existing drx-scattergather test.  This test fails to restore without the fix described above, due to the scatter/gather expansion restore state machine getting confused across multiple copies.

Does not augment drbbdup's restore to handle the no-ilist case: leaves that for the general #3801 mechanism.

Issue: #5686