### PR TITLE
i#5833: Fix print_to_buffer full-buffer return error

### DIFF
--- a/core/utils.c
+++ b/core/utils.c
@@ -1796,8 +1796,8 @@ vprint_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, const char *fmt,
      * to clobber a char, just like for -1 being returned when the written chars do
      * not all fit.
      */
-    *sofar += (len == -1 || len == (bufsz - *sofar) ? (bufsz - *sofar - 1)
-                                                    : (len < 0 ? 0 : len));
+    *sofar += (len == -1 || len == (ssize_t)(bufsz - *sofar) ? (bufsz - *sofar - 1)
+                                                             : (len < 0 ? 0 : len));
     /* be paranoid: though usually many calls in a row and could delay until end */
     buf[bufsz - 1] = '\0';
     return ok;

--- a/core/utils.c
+++ b/core/utils.c
@@ -1791,7 +1791,13 @@ vprint_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, const char *fmt,
     len = d_r_vsnprintf(buf + *sofar, bufsz - *sofar, fmt, ap);
     /* we support appending an empty string (len==0) */
     ok = (len >= 0 && len < (ssize_t)(bufsz - *sofar));
-    *sofar += (len == -1 ? (bufsz - *sofar - 1) : (len < 0 ? 0 : len));
+    /* If the written chars filled up the max size exactly, that max size is returned
+     * without a final null by d_r_vsnprintf().  Since we guarantee a null, we have
+     * to clobber a char, just like for -1 being returned when the written chars do
+     * not all fit.
+     */
+    *sofar += (len == -1 || len == (bufsz - *sofar) ? (bufsz - *sofar - 1)
+                                                    : (len < 0 ? 0 : len));
     /* be paranoid: though usually many calls in a row and could delay until end */
     buf[bufsz - 1] = '\0';
     return ok;

--- a/core/utils.c
+++ b/core/utils.c
@@ -1779,6 +1779,9 @@ print_file(file_t f, const char *fmt, ...)
  * Returns false if there was not room for the string plus a null,
  * but still prints the maximum that will fit plus a null.
  */
+/* XXX: This is duplicated in ir/decodlib.c's print_to_buffer.
+ * Could we move this into io.c to share it with decodelib?
+ */
 static bool
 vprint_to_buffer(char *buf, size_t bufsz, size_t *sofar INOUT, const char *fmt,
                  va_list ap)


### PR DESCRIPTION
Fixes a bug where print_to_buffer() does not correctly handle d_r_vsnprintf()'s return value for the case where the max size is filled up exactly with no room for a null.  This bug showed up in the exported disassemble_to_buffer().

Adds tests of these corner cases in disassemble_to_buffer() to api.ir.

Fixes #5833