### PR TITLE
i#3044 AArch64 SVE codec: Add vector address calculations

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -2003,6 +2003,20 @@ encode_opnd_x0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_wxn(true, false, 0, opnd, enc_out);
 }
 
+/* x0: X register or SP at bit position 0 */
+
+static inline bool
+decode_opnd_x0sp(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_wxn(/*is_x=*/true, /*is_sp=*/true, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_x0sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_wxn(/*is_x=*/true, /*is_sp=*/true, 0, opnd, enc_out);
+}
+
 /* memx0: memory operand with no offset used as memref for SYS */
 
 static inline bool
@@ -2546,6 +2560,20 @@ static inline bool
 encode_opnd_simm5_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_int(5, 5, true, 0, 0, opnd, enc_out);
+}
+
+/* simm6_5: Signed 6 bit immediate from 5-10 */
+
+static inline bool
+decode_opnd_simm6_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_int(5, 6, true, 0, OPSZ_6b, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_simm6_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_int(5, 6, true, 0, 0, opnd, enc_out);
 }
 
 /* vmsz: B/H/S/D for load/store multiple structures */
@@ -3820,6 +3848,20 @@ static inline bool
 encode_opnd_x16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_wxn(true, false, 16, opnd, enc_out);
+}
+
+/* x16sp: X register or SP at bit position 16 */
+
+static inline bool
+decode_opnd_x16sp(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_wxn(/*is_x=*/true, /*is_sp=*/true, 16, enc, opnd);
+}
+
+static inline bool
+encode_opnd_x16sp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_wxn(/*is_x=*/true, /*is_sp=*/true, 16, opnd, enc_out);
 }
 
 /* x16p0: even-numbered X register or XZR at bit position 16 */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -44,8 +44,8 @@
 00000100xx1xxxxx000000xxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000100xx000000000xxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10000011xxxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
-00000100011xxxxx01010xxxxxxxxxxx  n   926  SVE    addpl           x0sp : x16sp simm6_5
-00000100001xxxxx01010xxxxxxxxxxx  n   927  SVE    addvl           x0sp : x16sp simm6_5
+00000100011xxxxx01010xxxxxxxxxxx  n   934  SVE    addpl           x0sp : x16sp simm6_5
+00000100001xxxxx01010xxxxxxxxxxx  n   935  SVE    addvl           x0sp : x16sp simm6_5
 00000100xx011010000xxxxxxxxxxxxx  n   21   SVE      and             z0 : p10_lo z0 z5 bhsd_sz
 00000101100000xxxxxxxxxxxxxxxxxx  n   21   SVE      and  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010000xxxx01xxxx0xxxx0xxxx  n   21   SVE      and          p_b_0 : p10_zer p_b_5 p_b_16
@@ -348,7 +348,7 @@
 0010010100011001111100000000xxxx  n   817  SVE    rdffr          p_b_0 :
 00100101000110001111000xxxx0xxxx  n   817  SVE    rdffr          p_b_0 : p5_zer
 00100101010110001111000xxxx0xxxx  w   818  SVE   rdffrs          p_b_0 : p5_zer
-000001001011111101010xxxxxxxxxxx  n   928  SVE     rdvl             x0 : simm6_5
+000001001011111101010xxxxxxxxxxx  n   936  SVE     rdvl             x0 : simm6_5
 00000101xx1101000100000xxxx0xxxx  n   337  SVE      rev  p_size_bhsd_0 : p_size_bhsd_5
 00000101xx111000001110xxxxxxxxxx  n   337  SVE      rev  z_size_bhsd_0 : z_size_bhsd_5
 00000101xx100100100xxxxxxxxxxxxx  n   883  SVE     revb   z_size_hsd_0 : p10_mrg_lo z_size_hsd_5

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -44,6 +44,8 @@
 00000100xx1xxxxx000000xxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000100xx000000000xxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10000011xxxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
+00000100011xxxxx01010xxxxxxxxxxx  n   926  SVE    addpl           x0sp : x16sp simm6_5
+00000100001xxxxx01010xxxxxxxxxxx  n   927  SVE    addvl           x0sp : x16sp simm6_5
 00000100xx011010000xxxxxxxxxxxxx  n   21   SVE      and             z0 : p10_lo z0 z5 bhsd_sz
 00000101100000xxxxxxxxxxxxxxxxxx  n   21   SVE      and  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010000xxxx01xxxx0xxxx0xxxx  n   21   SVE      and          p_b_0 : p10_zer p_b_5 p_b_16
@@ -298,6 +300,7 @@
 0010010100011001111100000000xxxx  n   817  SVE    rdffr          p_b_0 :
 00100101000110001111000xxxx0xxxx  n   817  SVE    rdffr          p_b_0 : p5_zer
 00100101010110001111000xxxx0xxxx  w   818  SVE   rdffrs          p_b_0 : p5_zer
+000001001011111101010xxxxxxxxxxx  n   928  SVE     rdvl             x0 : simm6_5
 00000101xx1101000100000xxxx0xxxx  n   337  SVE      rev  p_size_bhsd_0 : p_size_bhsd_5
 00000101xx111000001110xxxxxxxxxx  n   337  SVE      rev  z_size_bhsd_0 : z_size_bhsd_5
 00000101xx100100100xxxxxxxxxxxxx  n   883  SVE     revb   z_size_hsd_0 : p10_mrg_lo z_size_hsd_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -9930,6 +9930,7 @@
 #define INSTR_CREATE_pnext_sve(dc, Pdn, Pv) \
     instr_create_1dst_2src(dc, OP_pnext, Pdn, Pv, Pdn)
 
+/**
  * Creates a FABD instruction.
  *
  * This macro is used to encode the forms:

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -9930,4 +9930,47 @@
 #define INSTR_CREATE_pnext_sve(dc, Pdn, Pv) \
     instr_create_1dst_2src(dc, OP_pnext, Pdn, Pv, Pdn)
 
+/**
+ * Creates an ADDPL instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ADDPL   <Xd|SP>, <Xn|SP>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The destination  register, X (Extended, 64 bits).
+ * \param Rn   The first source  register, X (Extended, 64 bits).
+ * \param simm   The signed immediate imm.
+ */
+#define INSTR_CREATE_addpl(dc, Rd, Rn, simm) \
+    instr_create_1dst_2src(dc, OP_addpl, Rd, Rn, simm)
+
+/**
+ * Creates an ADDVL instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ADDVL   <Xd|SP>, <Xn|SP>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The destination  register, X (Extended, 64 bits).
+ * \param Rn   The first source  register, X (Extended, 64 bits).
+ * \param simm   The signed immediate imm.
+ */
+#define INSTR_CREATE_addvl(dc, Rd, Rn, simm) \
+    instr_create_1dst_2src(dc, OP_addvl, Rd, Rn, simm)
+
+/**
+ * Creates a RDVL instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RDVL    <Xd>, #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The destination  register, X (Extended, 64 bits).
+ * \param simm   The signed immediate imm.
+ */
+#define INSTR_CREATE_rdvl(dc, Rd, simm) instr_create_1dst_1src(dc, OP_rdvl, Rd, simm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -82,6 +82,7 @@
 ---------------------------xxxxx  w0p0       # even-numbered W register (or WZR)
 ---------------------------xxxxx  w0p1       # ... add 1
 ---------------------------xxxxx  x0         # X register (or XZR)
+---------------------------xxxxx  x0sp       # X register (or SP)
 ---------------------------xxxxx  memx0      # X register used as memref for SYS
 ---------------------------xxxxx  x0p0       # even-numbered X register (or XZR)
 ---------------------------xxxxx  x0p1       # ... add 1
@@ -121,6 +122,7 @@
 ----------------------xxxxx-----  mem9qpost  # size is 16 bytes; post-index
 ----------------------xxxxx-----  pred_constr  # pattern operand
 ----------------------xxxxx-----  simm5_5    # Signed 5 bit immediate from 5 - 9
+---------------------xxxxxx-----  simm6_5    # Signed 6 bit immediate from 5 - 10
 --------------------xx----------  vmsz       # B/H/S/D for load/store multiple structures
 --------------------xxxx--------  imm4       # option for CLREX, DSB, DMB, ISB, MSR
                                              # CRm field for SYS and SYSL
@@ -178,6 +180,7 @@
 -----------xxxxx----------------  w16p0      # even-numbered W register (or WZR)
 -----------xxxxx----------------  w16p1      # ... add 1
 -----------xxxxx----------------  x16        # X register (or XZR)
+-----------xxxxx----------------  x16sp      # X register (or SP)
 -----------xxxxx----------------  x16p0      # even-numbered X register (or XZR)
 -----------xxxxx----------------  x16p1      # ... add 1
 -----------xxxxx----------------  d16        # D register

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -313,6 +313,42 @@
 04fc037a : add z26.d, z27.d, z28.d                   : add    %z27.d %z28.d -> %z26.d
 04fe03de : add z30.d, z30.d, z30.d                   : add    %z30.d %z30.d -> %z30.d
 
+# ADDPL   <Xd|SP>, <Xn|SP>, #<imm> (ADDPL-R.RI-_)
+04605400 : addpl x0, x0, #-0x20                      : addpl  %x0 $0xe0 -> %x0
+04635482 : addpl x2, x3, #-0x1c                      : addpl  %x3 $0xe4 -> %x2
+04655504 : addpl x4, x5, #-0x18                      : addpl  %x5 $0xe8 -> %x4
+04675586 : addpl x6, x7, #-0x14                      : addpl  %x7 $0xec -> %x6
+04695608 : addpl x8, x9, #-0x10                      : addpl  %x9 $0xf0 -> %x8
+046a5689 : addpl x9, x10, #-0xc                      : addpl  %x10 $0xf4 -> %x9
+046c570b : addpl x11, x12, #-0x8                     : addpl  %x12 $0xf8 -> %x11
+046e578d : addpl x13, x14, #-0x4                     : addpl  %x14 $0xfc -> %x13
+0470500f : addpl x15, x16, #0x0                      : addpl  %x16 $0x00 -> %x15
+04725071 : addpl x17, x18, #0x3                      : addpl  %x18 $0x03 -> %x17
+047450f3 : addpl x19, x20, #0x7                      : addpl  %x20 $0x07 -> %x19
+04765175 : addpl x21, x22, #0xb                      : addpl  %x22 $0x0b -> %x21
+047751f6 : addpl x22, x23, #0xf                      : addpl  %x23 $0x0f -> %x22
+04795278 : addpl x24, x25, #0x13                     : addpl  %x25 $0x13 -> %x24
+047b52fa : addpl x26, x27, #0x17                     : addpl  %x27 $0x17 -> %x26
+047f53ff : addpl sp, sp, #0x1f                       : addpl  %sp $0x1f -> %sp
+
+# ADDVL   <Xd|SP>, <Xn|SP>, #<imm> (ADDVL-R.RI-_)
+04205400 : addvl x0, x0, #-0x20                      : addvl  %x0 $0xe0 -> %x0
+04235482 : addvl x2, x3, #-0x1c                      : addvl  %x3 $0xe4 -> %x2
+04255504 : addvl x4, x5, #-0x18                      : addvl  %x5 $0xe8 -> %x4
+04275586 : addvl x6, x7, #-0x14                      : addvl  %x7 $0xec -> %x6
+04295608 : addvl x8, x9, #-0x10                      : addvl  %x9 $0xf0 -> %x8
+042a5689 : addvl x9, x10, #-0xc                      : addvl  %x10 $0xf4 -> %x9
+042c570b : addvl x11, x12, #-0x8                     : addvl  %x12 $0xf8 -> %x11
+042e578d : addvl x13, x14, #-0x4                     : addvl  %x14 $0xfc -> %x13
+0430500f : addvl x15, x16, #0x0                      : addvl  %x16 $0x00 -> %x15
+04325071 : addvl x17, x18, #0x3                      : addvl  %x18 $0x03 -> %x17
+043450f3 : addvl x19, x20, #0x7                      : addvl  %x20 $0x07 -> %x19
+04365175 : addvl x21, x22, #0xb                      : addvl  %x22 $0x0b -> %x21
+043751f6 : addvl x22, x23, #0xf                      : addvl  %x23 $0x0f -> %x22
+04395278 : addvl x24, x25, #0x13                     : addvl  %x25 $0x13 -> %x24
+043b52fa : addvl x26, x27, #0x17                     : addvl  %x27 $0x17 -> %x26
+043f53ff : addvl sp, sp, #0x1f                       : addvl  %sp $0x1f -> %sp
+
 041a06ff : and z31.b, p1/m, z31.b, z23.b            : and    %p1 %z31 %z23 $0x00 -> %z31
 045a06ff : and z31.h, p1/m, z31.h, z23.h            : and    %p1 %z31 %z23 $0x01 -> %z31
 049a06ff : and z31.s, p1/m, z31.s, z23.s            : and    %p1 %z31 %z23 $0x02 -> %z31
@@ -10481,6 +10517,24 @@
 2558f1ac : rdffrs p12.b, p13/Z                       : rdffrs %p13/z -> %p12.b
 2558f1cd : rdffrs p13.b, p14/Z                       : rdffrs %p14/z -> %p13.b
 2558f1ef : rdffrs p15.b, p15/Z                       : rdffrs %p15/z -> %p15.b
+
+# RDVL    <Xd>, #<imm> (RDVL-R.I-_)
+04bf5400 : rdvl x0, #-0x20                           : rdvl   $0xe0 -> %x0
+04bf5482 : rdvl x2, #-0x1c                           : rdvl   $0xe4 -> %x2
+04bf5504 : rdvl x4, #-0x18                           : rdvl   $0xe8 -> %x4
+04bf5586 : rdvl x6, #-0x14                           : rdvl   $0xec -> %x6
+04bf5608 : rdvl x8, #-0x10                           : rdvl   $0xf0 -> %x8
+04bf5689 : rdvl x9, #-0xc                            : rdvl   $0xf4 -> %x9
+04bf570b : rdvl x11, #-0x8                           : rdvl   $0xf8 -> %x11
+04bf578d : rdvl x13, #-0x4                           : rdvl   $0xfc -> %x13
+04bf500f : rdvl x15, #0x0                            : rdvl   $0x00 -> %x15
+04bf5071 : rdvl x17, #0x3                            : rdvl   $0x03 -> %x17
+04bf50f3 : rdvl x19, #0x7                            : rdvl   $0x07 -> %x19
+04bf5175 : rdvl x21, #0xb                            : rdvl   $0x0b -> %x21
+04bf51f6 : rdvl x22, #0xf                            : rdvl   $0x0f -> %x22
+04bf5278 : rdvl x24, #0x13                           : rdvl   $0x13 -> %x24
+04bf52fa : rdvl x26, #0x17                           : rdvl   $0x17 -> %x26
+04bf53fe : rdvl x30, #0x1f                           : rdvl   $0x1f -> %x30
 
 # REV     <Pd>.<T>, <Pn>.<T> (REV-P.P-_)
 05344000 : rev p0.b, p0.b                            : rev    %p0.b -> %p0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -12009,6 +12009,52 @@ TEST_INSTR(pnext_sve)
               opnd_create_reg(Pn_six_offset_1[i]));
 }
 
+TEST_INSTR(addpl)
+{
+    /* Testing ADDPL   <Xd|SP>, <Xn|SP>, #<imm> */
+    static const reg_id_t Rd_0_0[6] = { DR_REG_X0,  DR_REG_X5,  DR_REG_X10,
+                                        DR_REG_X15, DR_REG_X20, DR_REG_SP };
+    static const reg_id_t Rn_0_0[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
+                                        DR_REG_X16, DR_REG_X21, DR_REG_SP };
+    static const int imm6_0_0[6] = { -32, -20, -9, 2, 12, 31 };
+    const char *const expected_0_0[6] = {
+        "addpl  %x0 $0xe0 -> %x0",   "addpl  %x6 $0xec -> %x5",
+        "addpl  %x11 $0xf7 -> %x10", "addpl  %x16 $0x02 -> %x15",
+        "addpl  %x21 $0x0c -> %x20", "addpl  %sp $0x1f -> %sp",
+    };
+    TEST_LOOP(addpl, addpl, 6, expected_0_0[i], opnd_create_reg(Rd_0_0[i]),
+              opnd_create_reg(Rn_0_0[i]), opnd_create_immed_int(imm6_0_0[i], OPSZ_6b));
+}
+
+TEST_INSTR(addvl)
+{
+    /* Testing ADDVL   <Xd|SP>, <Xn|SP>, #<imm> */
+    static const reg_id_t Rd_0_0[6] = { DR_REG_X0,  DR_REG_X5,  DR_REG_X10,
+                                        DR_REG_X15, DR_REG_X20, DR_REG_SP };
+    static const reg_id_t Rn_0_0[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
+                                        DR_REG_X16, DR_REG_X21, DR_REG_SP };
+    static const int imm6_0_0[6] = { -32, -20, -9, 2, 12, 31 };
+    const char *const expected_0_0[6] = {
+        "addvl  %x0 $0xe0 -> %x0",   "addvl  %x6 $0xec -> %x5",
+        "addvl  %x11 $0xf7 -> %x10", "addvl  %x16 $0x02 -> %x15",
+        "addvl  %x21 $0x0c -> %x20", "addvl  %sp $0x1f -> %sp",
+    };
+    TEST_LOOP(addvl, addvl, 6, expected_0_0[i], opnd_create_reg(Rd_0_0[i]),
+              opnd_create_reg(Rn_0_0[i]), opnd_create_immed_int(imm6_0_0[i], OPSZ_6b));
+}
+
+TEST_INSTR(rdvl)
+{
+    /* Testing RDVL    <Xd>, #<imm> */
+    static const int imm6_0_0[6] = { -32, -21, -10, 1, 11, 31 };
+    const char *const expected_0_0[6] = {
+        "rdvl   $0xe0 -> %x0",  "rdvl   $0xeb -> %x5",  "rdvl   $0xf6 -> %x10",
+        "rdvl   $0x01 -> %x15", "rdvl   $0x0b -> %x20", "rdvl   $0x1f -> %x30",
+    };
+    TEST_LOOP(rdvl, rdvl, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_immed_int(imm6_0_0[i], OPSZ_6b));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -12368,6 +12414,10 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ctermeq);
     RUN_INSTR_TEST(ctermne);
     RUN_INSTR_TEST(pnext_sve);
+
+    RUN_INSTR_TEST(addpl);
+    RUN_INSTR_TEST(addvl);
+    RUN_INSTR_TEST(rdvl);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -14099,7 +14099,6 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(fmul_sve_vector);
     RUN_INSTR_TEST(fmul_sve_idx);
 
-
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER
     dr_standalone_exit();


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
ADDPL   <Xd|SP>, <Xn|SP>, #<imm>
ADDVL   <Xd|SP>, <Xn|SP>, #<imm>
RDVL    <Xd>, #<imm>
```
Support for ADR instructions will be added in a later commit.

Issues: #3044