### PR TITLE
i#1799: Remove old clang workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2022 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2023 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2018 Arm Limited          All rights reserved.
 # **********************************************************
@@ -661,6 +661,9 @@ if (UNIX)
   identify_clang(CMAKE_COMPILER_IS_CLANG)
   if (CMAKE_COMPILER_IS_CLANG)
     set(CLANG 1)
+    if ("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS "9.0")
+      message(FATAL_ERROR "clang < 9.0 is not supported")
+    endif ()
   endif (CMAKE_COMPILER_IS_CLANG)
 
   if (CYGWIN)

--- a/core/lib/dr_annotations_asm.h
+++ b/core/lib/dr_annotations_asm.h
@@ -1,5 +1,5 @@
 /* ******************************************************
- * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2023 Google, Inc.  All rights reserved.
  * ******************************************************/
 
 /*
@@ -81,11 +81,10 @@
 #    endif
 #endif
 
-#if !defined(DYNAMORIO_ANNOTATIONS_X86) || defined(__clang__)
+#if !defined(DYNAMORIO_ANNOTATIONS_X86)
 /* TODO i#1672: Add annotation support to AArchXX.
  * For now, we provide a fallback so we can build the annotation-concurrency
  * app for use with drcachesim tests.
- * We do the same for clang, which has no "asm goto".
  */
 #    define DR_ANNOTATION_OR_NATIVE(annotation, native_version, ...) /* Nothing. */
 #    define DR_DECLARE_ANNOTATION(return_type, annotation, parameters) \

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2004,8 +2004,7 @@ tobuild(common.getretaddr common/getretaddr.c)
 if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
   # XXX i#1287: implement for MacOS
   # We do not support -no_early_inject on Android (i#1873).
-  # FIXME i#1799: clang does not support "asm goto".
-  if (NOT APPLE AND NOT ANDROID AND ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
+  if (NOT APPLE AND NOT ANDROID AND ANNOTATIONS)
     # XXX i#1651: we don't support -native_exec combined with -early_inject so
     # for now we pass -no_early_inject to all of these tests.
     tobuild_appdll(common.nativeexec common/nativeexec.c)
@@ -2241,8 +2240,7 @@ else (UNIX)
   set(annotation_test_args_shorter
     "client.annotation-concurrency.appdll.dll" "A" "4" "64" "3")
 endif (UNIX)
-# FIXME i#1799: clang does not support "asm goto"
-if (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
+if (ANNOTATIONS)
   set(DynamoRIO_USE_LIBC OFF)
   tobuild_ci(client.annotation-concurrency client-interface/annotation-concurrency.c
     "" "" "${annotation_test_args}")
@@ -2358,7 +2356,7 @@ if (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
     client.annotation-detection-opt annotation-detection.native
     client-interface/annotation-detection.c "")
   set(DynamoRIO_USE_LIBC ON)
-else (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
+else (ANNOTATIONS)
   # We build the client.annotation-concurrency app even if we have no annotation
   # support, since it is used in drcachesim tests.
   add_exe(client.annotation-concurrency
@@ -2370,7 +2368,7 @@ else (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
     client-interface/annotation-concurrency.c)
   append_property_string(TARGET client.annotation-concurrency.appdll COMPILE_FLAGS
     "-DANNOTATIONS_DISABLED")
-endif (ANNOTATIONS AND NOT CMAKE_COMPILER_IS_CLANG)
+endif (ANNOTATIONS)
 
 if (UNIX)
   # XXX i#1246: Make partial_module_map work for Windows as well.


### PR DESCRIPTION
Removes the workarounds disabling annotation code and tests for clang as old versions before 9 did not support "asm goto".  We simply do not support such old clang versions any more.

Adds a top-level check that fails the build up front for clang < 9.0.

Fixes #1799