### PR TITLE
i#5538 memtrace seek, part 11: Fix omitted header problems

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2022 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2023 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -699,7 +699,7 @@ if (BUILD_TESTS)
     add_test(NAME tool.drcachesim.invariant_checker_test
              COMMAND tool.drcachesim.invariant_checker_test)
 
-    add_executable(tool.drcacheoff.view_test tests/view_test.cpp)
+    add_executable(tool.drcacheoff.view_test tests/view_test.cpp reader/file_reader.cpp)
     configure_DynamoRIO_standalone(tool.drcacheoff.view_test)
     add_win32_flags(tool.drcacheoff.view_test)
     target_link_libraries(tool.drcacheoff.view_test drmemtrace_view drmemtrace_raw2trace)

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -361,10 +361,12 @@ protected:
         return true;
     }
 
+    // Protected for access by mock_file_reader_t.
+    std::vector<T> input_files_;
+
 private:
     std::string input_path_;
     std::vector<std::string> input_path_list_;
-    std::vector<T> input_files_;
     trace_entry_t entry_copy_;
     // The current thread we're processing is "index".  If it's set to input_files_.size()
     // that means we need to pick a new thread.

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,7 @@
 #include <assert.h>
 #include <iterator>
 #include <unordered_map>
+#include <unordered_set>
 // For exporting we avoid "../common" and rely on -I.
 #include "memref.h"
 #include "memtrace_stream.h"
@@ -204,7 +205,7 @@ protected:
     uint64_t cur_ref_count_ = 0;
     int64_t suppress_ref_count_ = -1;
     uint64_t cur_instr_count_ = 0;
-    uint64_t last_timestamp_instr_count_ = 0;
+    std::unordered_set<memref_tid_t> skip_chunk_header_;
     uint64_t last_timestamp_ = 0;
     trace_entry_t *input_entry_ = nullptr;
     // Remember top-level headers for the memtrace_stream_t interface.
@@ -228,7 +229,6 @@ private:
     addr_t prev_instr_addr_ = 0;
     int bundle_idx_ = 0;
     std::unordered_map<memref_tid_t, memref_pid_t> tid2pid_;
-    bool skip_next_cpu_ = false;
     bool expect_no_encodings_ = true;
     encoding_info_t last_encoding_;
     std::unordered_map<addr_t, encoding_info_t> encodings_;

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2022 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2023 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -34,11 +34,14 @@
 
 #include <algorithm>
 #include <iostream>
+#include <regex>
+#include <string>
 #include <vector>
 
 #include "../tools/view.h"
 #include "../common/memref.h"
 #include "../tracer/raw2trace.h"
+#include "../reader/file_reader.h"
 #include "memref_gen.h"
 
 #undef ASSERT
@@ -57,6 +60,34 @@
             return false;             \
         }                             \
     } while (0)
+
+// These are for our mock serial reader and must in the same namespace
+// as file_reader_t's declaration.
+template <> file_reader_t<std::vector<trace_entry_t>>::~file_reader_t()
+{
+}
+
+template <>
+bool
+file_reader_t<std::vector<trace_entry_t>>::is_complete()
+{
+    return false;
+}
+
+template <>
+bool
+file_reader_t<std::vector<trace_entry_t>>::open_single_file(const std::string &path)
+{
+    return true;
+}
+
+template <>
+bool
+file_reader_t<std::vector<trace_entry_t>>::read_next_thread_entry(
+    size_t thread_index, OUT trace_entry_t *entry, OUT bool *eof)
+{
+    return false;
+}
 
 namespace {
 
@@ -382,13 +413,243 @@ run_limit_tests(void *drcontext)
     instrlist_clear_and_destroy(drcontext, ilist);
     return res;
 }
+
+/***************************************************************************
+ * Serial reader mock.
+ */
+
+class mock_file_reader_t : public file_reader_t<std::vector<trace_entry_t>> {
+public:
+    mock_file_reader_t()
+    {
+    }
+    mock_file_reader_t(const std::vector<std::vector<trace_entry_t>> &entries)
+        : file_reader_t(std::vector<std::string>(1, "non-empty"))
+    {
+        input_files_ = entries;
+        pos_.resize(input_files_.size(), 0);
+        init();
+    }
+    bool
+    read_next_thread_entry(size_t thread_index, OUT trace_entry_t *entry,
+                           OUT bool *eof) override
+    {
+        if (pos_[thread_index] >= input_files_[thread_index].size()) {
+            *eof = true;
+            return false;
+        }
+        *entry = input_files_[thread_index][pos_[thread_index]];
+        ++pos_[thread_index];
+        return true;
+    }
+
+private:
+    std::vector<size_t> pos_;
+};
+
+std::string
+run_serial_test_helper(view_t &view,
+                       const std::vector<std::vector<trace_entry_t>> &entries)
+{
+    class local_stream_t : public default_memtrace_stream_t {
+    public:
+        local_stream_t(view_t &view,
+                       const std::vector<std::vector<trace_entry_t>> &entries)
+            : view_(view)
+            , entries_(entries)
+        {
+        }
+
+        std::string
+        run()
+        {
+            view_.initialize_stream(this);
+            // Capture cerr.
+            std::stringstream capture;
+            std::streambuf *prior = std::cerr.rdbuf(capture.rdbuf());
+            // Run the tool.
+            mock_file_reader_t serial(entries_);
+            mock_file_reader_t end;
+            for (; serial != end; ++serial) {
+                const memref_t memref = *serial;
+                ++ref_count_;
+                if (type_is_instr(memref.instr.type))
+                    ++instr_count_;
+                if (!view_.process_memref(memref))
+                    std::cout << "Hit error: " << view_.get_error_string() << "\n";
+            }
+            // Return the result.
+            std::string res = capture.str();
+            std::cerr.rdbuf(prior);
+            return res;
+        }
+
+        uint64_t
+        get_record_ordinal() const override
+        {
+            return ref_count_;
+        }
+        uint64_t
+        get_instruction_ordinal() const override
+        {
+            return instr_count_;
+        }
+
+    private:
+        view_t &view_;
+        const std::vector<std::vector<trace_entry_t>> &entries_;
+        uint64_t ref_count_ = 0;
+        uint64_t instr_count_ = 0;
+    };
+
+    local_stream_t stream(view, entries);
+    return stream.run();
+}
+
+/***************************************************************************/
+
+bool
+run_single_thread_chunk_test(void *drcontext)
+{
+    const memref_tid_t t1 = 3;
+    std::vector<std::vector<trace_entry_t>> entries = { {
+        { TRACE_TYPE_HEADER, 0, { 0x1 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION, { 3 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE, { 0 } },
+        { TRACE_TYPE_THREAD, 0, { t1 } },
+        { TRACE_TYPE_PID, 0, { t1 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, { 64 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT, { 2 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 1002 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 2 } },
+        { TRACE_TYPE_INSTR, 4, { 42 } },
+        { TRACE_TYPE_INSTR, 4, { 42 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_FOOTER, { 0 } },
+        // We're testing that the reader hides this duplicate timestamp
+        // at the start of a chunk.
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 1002 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 3 } },
+        { TRACE_TYPE_INSTR, 4, { 42 } },
+    } };
+    const char *expect = R"DELIM(        1        0: T3 <marker: version 3>
+        2        0: T3 <marker: filetype 0x0>
+        3        0: T3 <marker: cache line size 64>
+        4        0: T3 <marker: chunk instruction count 2>
+        5        0: T3 <marker: timestamp 1002>
+        6        0: T3 <marker: tid 3 on core 2>
+        7        1: T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+        8        2: T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+        9        2: T3 <marker: chunk footer #0>
+       10        3: T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+)DELIM";
+    instrlist_t *ilist_unused = nullptr;
+    view_nomod_test_t view(drcontext, *ilist_unused, 0, 0, 0);
+    std::string res = run_serial_test_helper(view, entries);
+    // Make 64-bit match our 32-bit expect string.
+    res = std::regex_replace(res, std::regex("0x000000000000002a"), "0x0000002a");
+    if (res != expect) {
+        std::cerr << "Output mismatch: got |" << res << "| expected |" << expect << "|\n";
+        return false;
+    }
+    return true;
+}
+
+bool
+run_serial_chunk_test(void *drcontext)
+{
+    // We ensure headers are not omitted incorrectly, which they were
+    // in the first implementation of the reader skipping dup headers:
+    // i#/5538#issuecomment-1407235283
+    const memref_tid_t t1 = 3;
+    const memref_tid_t t2 = 7;
+    std::vector<std::vector<trace_entry_t>> entries = {
+        {
+            { TRACE_TYPE_HEADER, 0, { 0x1 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION, { 3 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE, { 0 } },
+            { TRACE_TYPE_THREAD, 0, { t1 } },
+            { TRACE_TYPE_PID, 0, { t1 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, { 64 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT, { 20 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 1001 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 2 } },
+            { TRACE_TYPE_INSTR, 4, { 42 } },
+            { TRACE_TYPE_INSTR, 4, { 42 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 1003 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 3 } },
+            { TRACE_TYPE_INSTR, 4, { 42 } },
+        },
+        {
+            { TRACE_TYPE_HEADER, 0, { 0x1 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION, { 3 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE, { 0 } },
+            { TRACE_TYPE_THREAD, 0, { t2 } },
+            { TRACE_TYPE_PID, 0, { t2 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, { 64 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT, { 2 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 1002 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 2 } },
+            { TRACE_TYPE_INSTR, 4, { 42 } },
+            { TRACE_TYPE_INSTR, 4, { 42 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 1004 } },
+            { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 3 } },
+            { TRACE_TYPE_INSTR, 4, { 42 } },
+        }
+    };
+    const char *expect =
+        R"DELIM(        1        0: T3 <marker: version 3>
+        2        0: T3 <marker: filetype 0x0>
+        3        0: T3 <marker: cache line size 64>
+        4        0: T3 <marker: chunk instruction count 20>
+------------------------------------------------------------
+        5        0: T7 <marker: version 3>
+        6        0: T7 <marker: filetype 0x0>
+        7        0: T7 <marker: cache line size 64>
+        8        0: T7 <marker: chunk instruction count 2>
+------------------------------------------------------------
+        9        0: T3 <marker: timestamp 1001>
+       10        0: T3 <marker: tid 3 on core 2>
+       11        1: T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+       12        2: T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+------------------------------------------------------------
+       13        2: T7 <marker: timestamp 1002>
+       14        2: T7 <marker: tid 7 on core 2>
+       15        3: T7 ifetch       4 byte(s) @ 0x0000002a non-branch
+       16        4: T7 ifetch       4 byte(s) @ 0x0000002a non-branch
+------------------------------------------------------------
+       17        4: T3 <marker: timestamp 1003>
+       18        4: T3 <marker: tid 3 on core 3>
+       19        5: T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+------------------------------------------------------------
+       20        5: T7 <marker: timestamp 1004>
+       21        5: T7 <marker: tid 7 on core 3>
+       22        6: T7 ifetch       4 byte(s) @ 0x0000002a non-branch
+)DELIM";
+    instrlist_t *ilist_unused = nullptr;
+    view_nomod_test_t view(drcontext, *ilist_unused, 0, 0, 0);
+    std::string res = run_serial_test_helper(view, entries);
+    // Make 64-bit match our 32-bit expect string.
+    res = std::regex_replace(res, std::regex("0x000000000000002a"), "0x0000002a");
+    if (res != expect) {
+        std::cerr << "Output mismatch: got |" << res << "| expected |" << expect << "|\n";
+        return false;
+    }
+    return true;
+}
+
+bool
+run_chunk_tests(void *drcontext)
+{
+    return run_single_thread_chunk_test(drcontext) && run_serial_chunk_test(drcontext);
+}
+
 } // namespace
 
 int
 main(int argc, const char *argv[])
 {
     void *drcontext = dr_standalone_init();
-    if (run_limit_tests(drcontext)) {
+    if (run_limit_tests(drcontext) && run_chunk_tests(drcontext)) {
         std::cerr << "view_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -187,21 +187,21 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             // We delay printing until we know the tid.
             if (trace_version_ == -1) {
                 trace_version_ = static_cast<int>(memref.marker.marker_value);
-                version_record_ord_ = memstream->get_record_ordinal();
             } else if (trace_version_ != static_cast<int>(memref.marker.marker_value)) {
                 error_string_ = std::string("Version mismatch across files");
                 return false;
             }
+            version_record_ord_ = memstream->get_record_ordinal();
             return true; // Do not count toward -sim_refs yet b/c we don't have tid.
         case TRACE_MARKER_TYPE_FILETYPE:
             // We delay printing until we know the tid.
             if (filetype_ == -1) {
                 filetype_ = static_cast<intptr_t>(memref.marker.marker_value);
-                filetype_record_ord_ = memstream->get_record_ordinal();
             } else if (filetype_ != static_cast<intptr_t>(memref.marker.marker_value)) {
                 error_string_ = std::string("Filetype mismatch across files");
                 return false;
             }
+            filetype_record_ord_ = memstream->get_record_ordinal();
             if (TESTANY(OFFLINE_FILE_TYPE_ARCH_ALL, memref.marker.marker_value) &&
                 !TESTANY(build_target_arch_type(), memref.marker.marker_value)) {
                 error_string_ = std::string("Architecture mismatch: trace recorded on ") +


### PR DESCRIPTION
Fixes a bug where reader_t's detection of duplicated timestamp,cpuid headers at the start of a chunk assumed single-threaded mode.  We switch to using a simple per-tid chunk footer trigger.

Adds a test to view_test via a new serial mock which takes in trace_entry_t and allows testing of the interleaving code.  Tests both proper chunk header elision as well as replicating the bug where elision should not happen.

The test revealed a separate bug in the view tool where the version and filetype ordinals, for delaying, were not updated on new threads. That is fixed here as well as otherwise the new tests fail.

Issue: #5538