### PR TITLE
i#3044 AArch64 SVE tests: Update list of registers used for tests

### DIFF
--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -130,11 +130,11 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
 const reg_id_t Xn_six_offset_0[6] = { DR_REG_X0,  DR_REG_X5,  DR_REG_X10,
                                       DR_REG_X15, DR_REG_X20, DR_REG_X30 };
 const reg_id_t Xn_six_offset_1[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
-                                      DR_REG_X17, DR_REG_X22, DR_REG_X30 };
-const reg_id_t Xn_six_offset_2[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X11,
                                       DR_REG_X16, DR_REG_X21, DR_REG_X30 };
-const reg_id_t Xn_six_offset_3[6] = { DR_REG_X0,  DR_REG_X7,  DR_REG_X12,
+const reg_id_t Xn_six_offset_2[6] = { DR_REG_X0,  DR_REG_X7,  DR_REG_X12,
                                       DR_REG_X17, DR_REG_X22, DR_REG_X30 };
+const reg_id_t Xn_six_offset_3[6] = { DR_REG_X0,  DR_REG_X8,  DR_REG_X13,
+                                      DR_REG_X18, DR_REG_X23, DR_REG_X30 };
 const reg_id_t Zn_six_offset_0[6] = { DR_REG_Z0,  DR_REG_Z5,  DR_REG_Z10,
                                       DR_REG_Z16, DR_REG_Z21, DR_REG_Z31 };
 const reg_id_t Zn_six_offset_1[6] = { DR_REG_Z0,  DR_REG_Z6,  DR_REG_Z11,

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -8376,8 +8376,8 @@ TEST_INSTR(ldr)
     int simm_0[6] = { 0, 255, -256, 127, -128, -1 };
     const char *expected_0[6] = {
         "ldr    (%x0)[32byte] -> %z0",          "ldr    +0xff(%x6)[32byte] -> %z6",
-        "ldr    -0x0100(%x11)[32byte] -> %z11", "ldr    +0x7f(%x17)[32byte] -> %z17",
-        "ldr    -0x80(%x22)[32byte] -> %z22",   "ldr    -0x01(%x30)[32byte] -> %z31",
+        "ldr    -0x0100(%x11)[32byte] -> %z11", "ldr    +0x7f(%x16)[32byte] -> %z17",
+        "ldr    -0x80(%x21)[32byte] -> %z22",   "ldr    -0x01(%x30)[32byte] -> %z31",
     };
     TEST_LOOP(ldr, ldr, 6, expected_0[i], opnd_create_reg(Zn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,
@@ -8387,8 +8387,8 @@ TEST_INSTR(ldr)
     int simm_1[6] = { 0, 255, -256, 127, -128, -1 };
     const char *expected_1[6] = {
         "ldr    (%x0)[32byte] -> %p0",         "ldr    +0xff(%x6)[32byte] -> %p3",
-        "ldr    -0x0100(%x11)[32byte] -> %p6", "ldr    +0x7f(%x17)[32byte] -> %p9",
-        "ldr    -0x80(%x22)[32byte] -> %p11",  "ldr    -0x01(%x30)[32byte] -> %p15",
+        "ldr    -0x0100(%x11)[32byte] -> %p6", "ldr    +0x7f(%x16)[32byte] -> %p9",
+        "ldr    -0x80(%x21)[32byte] -> %p11",  "ldr    -0x01(%x30)[32byte] -> %p15",
     };
     TEST_LOOP(ldr, ldr, 6, expected_1[i], opnd_create_reg(Pn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,
@@ -11216,9 +11216,9 @@ TEST_INSTR(index_sve)
               opnd_create_reg(Wn_six_offset_2[i]));
 
     const char *const expected_1_3[6] = {
-        "index  $0xf0 %x0 -> %z0.d",   "index  $0xf6 %x7 -> %z5.d",
-        "index  $0xfb %x12 -> %z10.d", "index  $0x01 %x17 -> %z16.d",
-        "index  $0x06 %x22 -> %z21.d", "index  $0x0f %x30 -> %z31.d",
+        "index  $0xf0 %x0 -> %z0.d",   "index  $0xf6 %x8 -> %z5.d",
+        "index  $0xfb %x13 -> %z10.d", "index  $0x01 %x18 -> %z16.d",
+        "index  $0x06 %x23 -> %z21.d", "index  $0x0f %x30 -> %z31.d",
     };
     TEST_LOOP(index, index_sve, 6, expected_1_3[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -11257,9 +11257,9 @@ TEST_INSTR(index_sve)
               opnd_create_immed_int(imm5b[i], OPSZ_5b));
 
     const char *const expected_2_3[6] = {
-        "index  %x0 $0xf0 -> %z0.d",   "index  %x6 $0xf7 -> %z5.d",
-        "index  %x11 $0xfc -> %z10.d", "index  %x16 $0x02 -> %z16.d",
-        "index  %x21 $0x07 -> %z21.d", "index  %x30 $0x0f -> %z31.d",
+        "index  %x0 $0xf0 -> %z0.d",   "index  %x7 $0xf7 -> %z5.d",
+        "index  %x12 $0xfc -> %z10.d", "index  %x17 $0x02 -> %z16.d",
+        "index  %x22 $0x07 -> %z21.d", "index  %x30 $0x0f -> %z31.d",
     };
     TEST_LOOP(index, index_sve, 6, expected_2_3[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -11295,9 +11295,9 @@ TEST_INSTR(index_sve)
               opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
 
     const char *const expected_3_3[6] = {
-        "index  %x0 %x0 -> %z0.d",    "index  %x6 %x7 -> %z5.d",
-        "index  %x11 %x12 -> %z10.d", "index  %x16 %x17 -> %z16.d",
-        "index  %x21 %x22 -> %z21.d", "index  %x30 %x30 -> %z31.d",
+        "index  %x0 %x0 -> %z0.d",    "index  %x7 %x8 -> %z5.d",
+        "index  %x12 %x13 -> %z10.d", "index  %x17 %x18 -> %z16.d",
+        "index  %x22 %x23 -> %z21.d", "index  %x30 %x30 -> %z31.d",
     };
     TEST_LOOP(index, index_sve, 6, expected_3_3[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -11948,7 +11948,7 @@ TEST_INSTR(ctermeq)
         "ctermeq %x15 %x16", "ctermeq %x20 %x21", "ctermeq %x30 %x30",
     };
     TEST_LOOP(ctermeq, ctermeq, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg(Xn_six_offset_2[i]));
+              opnd_create_reg(Xn_six_offset_1[i]));
 }
 
 TEST_INSTR(ctermne)
@@ -11966,7 +11966,7 @@ TEST_INSTR(ctermne)
         "ctermne %x15 %x16", "ctermne %x20 %x21", "ctermne %x30 %x30",
     };
     TEST_LOOP(ctermne, ctermne, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg(Xn_six_offset_2[i]));
+              opnd_create_reg(Xn_six_offset_1[i]));
 }
 
 TEST_INSTR(pnext_sve)


### PR DESCRIPTION
This patch changes the values of the registers used in the ir_aarch64 tests so that they better defend against transposition of operands

Issue: #3044