### PR TITLE
i#5845: Fix format string type for drcov bb count

### DIFF
--- a/ext/drcovlib/drcovlib.c
+++ b/ext/drcovlib/drcovlib.c
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2023 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -139,7 +139,14 @@ bb_table_print(void *drcontext, per_thread_t *data)
         ASSERT(false, "invalid log file");
         return;
     }
-    dr_fprintf(data->log, "BB Table: %u bbs\n", drtable_num_entries(data->bb_table));
+    /* We do not support >32U-bit-max (~4 billion) blocks.
+     * drcov2lcov would need a number of changes to support this.
+     * We have a debug-build check here.
+     */
+    ASSERT(drtable_num_entries(data->bb_table) <= UINT_MAX,
+           "block count exceeds 32-bit max");
+    dr_fprintf(data->log, "BB Table: %u bbs\n",
+               (uint)drtable_num_entries(data->bb_table));
     if (TEST(DRCOVLIB_DUMP_AS_TEXT, options.flags)) {
         dr_fprintf(data->log, "module id, start, size:\n");
         drtable_iterate(data->bb_table, data, bb_table_entry_print);


### PR DESCRIPTION
The drcov bb count was being printed as a 32-bit integer but passed a 64-bit value for x64/aarch64 builds.  We fix that here to pass a 32-bit value with an overflow check (we do not support >4G blocks in drcov's post-processing today).

Unfortunately there is not a simple way to make a test.  I experimented and actually failed to get the original bug to cause any visible problem even with subsequent specifiers in that same format string, with today's va_list accessors.  Making a test of millions or billions of blocks is non-trivial: the easiest way is to dynamically generate the code, but that is not a great test for drcov in general where we want source lines to map back to; plus it will take a while to run which is not great in the CI suite.

Fixes #5845