### PR TITLE
i#3044 AArch64 SVE Codec: Update release dox for API changes

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -197,6 +197,9 @@ Further non-compatibility-affecting changes include:
    headers.
  - Added #record_analyzer_t and #record_analysis_tool_t for analyzing the
    sequence of #trace_entry_t exactly as present in a stored offline trace.
+ - Added opnd_size_to_shift_amount() and opnd_create_base_disp_shift_aarch64()
+   for explicitly specifying shift amounts in the creation of operands for
+   AArch64 memory addresses.
 
 **************************************************
 <hr>


### PR DESCRIPTION
Added the new opnd_size_to_shift_amount() and opnd_create_base_disp_shift_aarch64() functions.

Issue #3044