### PR TITLE
i#3044 AArch64 SVE codec: v8.3 complex number instructions

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -162,12 +162,16 @@
 0110010101000000001xxxxxxxxxxxxx  n   918  SVE    faddv             h0 : p10_lo z_size_hsd_5
 0110010110000000001xxxxxxxxxxxxx  n   918  SVE    faddv             s0 : p10_lo z_size_hsd_5
 0110010111000000001xxxxxxxxxxxxx  n   918  SVE    faddv             d0 : p10_lo z_size_hsd_5
+01100100xx00000x100xxxxxxxxxxxxx  n   944  SVE    fcadd   z_size_hsd_0 : p10_mrg_lo z_size_hsd_0 z_size_hsd_5 imm1_ew_16
 01100101xx010010001xxxxxxxx0xxxx  n   102  SVE    fcmeq   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
 01100101xx0xxxxx011xxxxxxxx0xxxx  n   102  SVE    fcmeq   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx010000001xxxxxxxx0xxxx  n   103  SVE    fcmge   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
 01100101xx0xxxxx010xxxxxxxx0xxxx  n   103  SVE    fcmge   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
 01100101xx010000001xxxxxxxx1xxxx  n   104  SVE    fcmgt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
 01100101xx0xxxxx010xxxxxxxx1xxxx  n   104  SVE    fcmgt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 z_size_hsd_16
+01100100xx0xxxxx0xxxxxxxxxxxxxxx  n   945  SVE    fcmla   z_size_hsd_0 : z_size_hsd_0 p10_mrg_lo z_size_hsd_5 z_size_hsd_16 imm2_nesw_13
+01100100101xxxxx0001xxxxxxxxxxxx  n   945  SVE    fcmla          z_h_0 : z_h_0 z_h_5 z3_h_16 i2_index_19 imm2_nesw_10
+01100100111xxxxx0001xxxxxxxxxxxx  n   945  SVE    fcmla          z_s_0 : z_s_0 z_s_5 z4_s_16 i1_index_20 imm2_nesw_10
 01100101xx010001001xxxxxxxx1xxxx  n   105  SVE    fcmle   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
 01100101xx010001001xxxxxxxx0xxxx  n   106  SVE    fcmlt   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const
 01100101xx010011001xxxxxxxx0xxxx  n   805  SVE    fcmne   p_size_hsd_0 : p10_zer_lo z_size_hsd_5 zero_fp_const

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -10751,4 +10751,55 @@
 #define INSTR_CREATE_ldff1w_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldff1w, Zt, Rn, Pg)
 
+/**
+ * Creates a FCADD instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCADD   <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>, <rot>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn  The first source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zm   The second source vector register, Z (Scalable).
+ * \param rot  The immediate rot, must be 90 or 270.
+ */
+#define INSTR_CREATE_fcadd_sve_pred(dc, Zdn, Pg, Zm, rot) \
+    instr_create_1dst_4src(dc, OP_fcadd, Zdn, Pg, Zdn, Zm, rot)
+
+/**
+ * Creates a FCMLA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCMLA   <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts>, <rot>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ * \param rot  The immediate rot, must be 0, 90, 180, or 270.
+ */
+#define INSTR_CREATE_fcmla_sve_vector(dc, Zda, Pg, Zn, Zm, rot) \
+    instr_create_1dst_5src(dc, OP_fcmla, Zda, Zda, Pg, Zn, Zm, rot)
+
+/**
+ * Creates a FCMLA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FCMLA   <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <rot>
+ *    FCMLA   <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <rot>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ * \param imm  The immediate imm representing index of a Real and Imaginary pair
+ * \param rot  The immediate rot, must be 0, 90, 180, or 270.
+ */
+#define INSTR_CREATE_fcmla_sve_idx(dc, Zda, Zn, Zm, imm, rot) \
+    instr_create_1dst_5src(dc, OP_fcmla, Zda, Zda, Zn, Zm, imm, rot)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -127,6 +127,7 @@
 ----------------------xxxxx-----  simm5_5    # Signed 5 bit immediate from 5 - 9
 ---------------------xxxxxx-----  simm6_5    # Signed 6 bit immediate from 5 - 10
 --------------------xx----------  vmsz       # B/H/S/D for load/store multiple structures
+--------------------xx----------  imm2_nesw_10 # 2 bit symbolised imm, representing 0, 90, 180, or 270
 --------------------xxxx--------  imm4       # option for CLREX, DSB, DMB, ISB, MSR
                                              # CRm field for SYS and SYSL
 -------------------x------------  cmode4_s_sz_msl # MSL bit for 32 bit element shifts
@@ -143,6 +144,7 @@
 ------------------xxxx----------  p10_mrg    # SVE predicate registers p0-p15, merging
 ------------------xxxx----------  p10_zer    # SVE predicate registers p0-p15, zeroing
 -----------------xx-------------  cmode_s_sz # Vector shift for 32 bit elements
+-----------------xx-------------  imm2_nesw_13 # 2 bit symbolised imm, representing 0, 90, 180, or 270
 -----------------xx-------------  len        # imm2 len
 -----------------xxxx-----------  imm4idx    # imm4 from 11-14
 -----------------xxxxx----------  w10        # W register (or WZR)
@@ -156,6 +158,7 @@
 ----------------xxxx------------  cond       # condition for CCMN, CCMP
 ----------------xxxxxx----------  scale      # encoding of #fbits value in scale field
 ----------------xxxxxxxxxxxxxxxx  imm16_0    # imm16 at position 0
+---------------x----------------  imm1_ew_16 # 1 bit symbolised imm, representing 90 or 270
 --------------?------??????xxxxx  z_imm13_bhsd_0 # sve vector reg, elsz depending on size value encoded within an 13 bit immediate from 5-17
 --------------xxxxxxxxxxxxx-----  imm13_const # Const value within a 13 bit immediate from 5-17
 -------------xxx----------------  imm3       # 3 bit immediate from 16-18
@@ -169,6 +172,7 @@
 ------------xxxx----------------  p16_zer    # zeroing P register at position 16
 ------------xxxx----------------  p_b_16     # P register with a byte element size at position 16
 ------------xxxx----------------  imm4_16p1  # 4bit imm at 19-16, plus 1
+------------xxxx----------------  z4_s_16     # Z0-15 register with s size elements at position 16
 ------------xxxx----------------  z4_d_16     # Z0-15 register with d size elements at position 16
 ------------xxxxxxxxxxxxxxx-----  sysreg     # operand of MRS
 -----------?????----------------  bh_imm5_sz # Size encoded as least significant bit in imm5

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -5372,6 +5372,56 @@
 65c03fbb : faddv d27, p7, z29.d                      : faddv  %p7 %z29.d -> %d27
 65c03fff : faddv d31, p7, z31.d                      : faddv  %p7 %z31.d -> %d31
 
+# FCADD   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>, <const> (FCADD-Z.P.ZZ-_)
+64408000 : fcadd z0.h, p0/M, z0.h, z0.h, #0x5a       : fcadd  %p0/m %z0.h %z0.h $0x005a -> %z0.h
+64408482 : fcadd z2.h, p1/M, z2.h, z4.h, #0x5a       : fcadd  %p1/m %z2.h %z4.h $0x005a -> %z2.h
+644088c4 : fcadd z4.h, p2/M, z4.h, z6.h, #0x5a       : fcadd  %p2/m %z4.h %z6.h $0x005a -> %z4.h
+64408906 : fcadd z6.h, p2/M, z6.h, z8.h, #0x5a       : fcadd  %p2/m %z6.h %z8.h $0x005a -> %z6.h
+64408d48 : fcadd z8.h, p3/M, z8.h, z10.h, #0x5a      : fcadd  %p3/m %z8.h %z10.h $0x005a -> %z8.h
+64408d8a : fcadd z10.h, p3/M, z10.h, z12.h, #0x5a    : fcadd  %p3/m %z10.h %z12.h $0x005a -> %z10.h
+644091cc : fcadd z12.h, p4/M, z12.h, z14.h, #0x5a    : fcadd  %p4/m %z12.h %z14.h $0x005a -> %z12.h
+6440920e : fcadd z14.h, p4/M, z14.h, z16.h, #0x5a    : fcadd  %p4/m %z14.h %z16.h $0x005a -> %z14.h
+64409650 : fcadd z16.h, p5/M, z16.h, z18.h, #0x5a    : fcadd  %p5/m %z16.h %z18.h $0x005a -> %z16.h
+64419671 : fcadd z17.h, p5/M, z17.h, z19.h, #0x10e   : fcadd  %p5/m %z17.h %z19.h $0x010e -> %z17.h
+644196b3 : fcadd z19.h, p5/M, z19.h, z21.h, #0x10e   : fcadd  %p5/m %z19.h %z21.h $0x010e -> %z19.h
+64419af5 : fcadd z21.h, p6/M, z21.h, z23.h, #0x10e   : fcadd  %p6/m %z21.h %z23.h $0x010e -> %z21.h
+64419b37 : fcadd z23.h, p6/M, z23.h, z25.h, #0x10e   : fcadd  %p6/m %z23.h %z25.h $0x010e -> %z23.h
+64419f79 : fcadd z25.h, p7/M, z25.h, z27.h, #0x10e   : fcadd  %p7/m %z25.h %z27.h $0x010e -> %z25.h
+64419fbb : fcadd z27.h, p7/M, z27.h, z29.h, #0x10e   : fcadd  %p7/m %z27.h %z29.h $0x010e -> %z27.h
+64419fff : fcadd z31.h, p7/M, z31.h, z31.h, #0x10e   : fcadd  %p7/m %z31.h %z31.h $0x010e -> %z31.h
+64808000 : fcadd z0.s, p0/M, z0.s, z0.s, #0x5a       : fcadd  %p0/m %z0.s %z0.s $0x005a -> %z0.s
+64808482 : fcadd z2.s, p1/M, z2.s, z4.s, #0x5a       : fcadd  %p1/m %z2.s %z4.s $0x005a -> %z2.s
+648088c4 : fcadd z4.s, p2/M, z4.s, z6.s, #0x5a       : fcadd  %p2/m %z4.s %z6.s $0x005a -> %z4.s
+64808906 : fcadd z6.s, p2/M, z6.s, z8.s, #0x5a       : fcadd  %p2/m %z6.s %z8.s $0x005a -> %z6.s
+64808d48 : fcadd z8.s, p3/M, z8.s, z10.s, #0x5a      : fcadd  %p3/m %z8.s %z10.s $0x005a -> %z8.s
+64808d8a : fcadd z10.s, p3/M, z10.s, z12.s, #0x5a    : fcadd  %p3/m %z10.s %z12.s $0x005a -> %z10.s
+648091cc : fcadd z12.s, p4/M, z12.s, z14.s, #0x5a    : fcadd  %p4/m %z12.s %z14.s $0x005a -> %z12.s
+6480920e : fcadd z14.s, p4/M, z14.s, z16.s, #0x5a    : fcadd  %p4/m %z14.s %z16.s $0x005a -> %z14.s
+64809650 : fcadd z16.s, p5/M, z16.s, z18.s, #0x5a    : fcadd  %p5/m %z16.s %z18.s $0x005a -> %z16.s
+64819671 : fcadd z17.s, p5/M, z17.s, z19.s, #0x10e   : fcadd  %p5/m %z17.s %z19.s $0x010e -> %z17.s
+648196b3 : fcadd z19.s, p5/M, z19.s, z21.s, #0x10e   : fcadd  %p5/m %z19.s %z21.s $0x010e -> %z19.s
+64819af5 : fcadd z21.s, p6/M, z21.s, z23.s, #0x10e   : fcadd  %p6/m %z21.s %z23.s $0x010e -> %z21.s
+64819b37 : fcadd z23.s, p6/M, z23.s, z25.s, #0x10e   : fcadd  %p6/m %z23.s %z25.s $0x010e -> %z23.s
+64819f79 : fcadd z25.s, p7/M, z25.s, z27.s, #0x10e   : fcadd  %p7/m %z25.s %z27.s $0x010e -> %z25.s
+64819fbb : fcadd z27.s, p7/M, z27.s, z29.s, #0x10e   : fcadd  %p7/m %z27.s %z29.s $0x010e -> %z27.s
+64819fff : fcadd z31.s, p7/M, z31.s, z31.s, #0x10e   : fcadd  %p7/m %z31.s %z31.s $0x010e -> %z31.s
+64c08000 : fcadd z0.d, p0/M, z0.d, z0.d, #0x5a       : fcadd  %p0/m %z0.d %z0.d $0x005a -> %z0.d
+64c08482 : fcadd z2.d, p1/M, z2.d, z4.d, #0x5a       : fcadd  %p1/m %z2.d %z4.d $0x005a -> %z2.d
+64c088c4 : fcadd z4.d, p2/M, z4.d, z6.d, #0x5a       : fcadd  %p2/m %z4.d %z6.d $0x005a -> %z4.d
+64c08906 : fcadd z6.d, p2/M, z6.d, z8.d, #0x5a       : fcadd  %p2/m %z6.d %z8.d $0x005a -> %z6.d
+64c08d48 : fcadd z8.d, p3/M, z8.d, z10.d, #0x5a      : fcadd  %p3/m %z8.d %z10.d $0x005a -> %z8.d
+64c08d8a : fcadd z10.d, p3/M, z10.d, z12.d, #0x5a    : fcadd  %p3/m %z10.d %z12.d $0x005a -> %z10.d
+64c091cc : fcadd z12.d, p4/M, z12.d, z14.d, #0x5a    : fcadd  %p4/m %z12.d %z14.d $0x005a -> %z12.d
+64c0920e : fcadd z14.d, p4/M, z14.d, z16.d, #0x5a    : fcadd  %p4/m %z14.d %z16.d $0x005a -> %z14.d
+64c09650 : fcadd z16.d, p5/M, z16.d, z18.d, #0x5a    : fcadd  %p5/m %z16.d %z18.d $0x005a -> %z16.d
+64c19671 : fcadd z17.d, p5/M, z17.d, z19.d, #0x10e   : fcadd  %p5/m %z17.d %z19.d $0x010e -> %z17.d
+64c196b3 : fcadd z19.d, p5/M, z19.d, z21.d, #0x10e   : fcadd  %p5/m %z19.d %z21.d $0x010e -> %z19.d
+64c19af5 : fcadd z21.d, p6/M, z21.d, z23.d, #0x10e   : fcadd  %p6/m %z21.d %z23.d $0x010e -> %z21.d
+64c19b37 : fcadd z23.d, p6/M, z23.d, z25.d, #0x10e   : fcadd  %p6/m %z23.d %z25.d $0x010e -> %z23.d
+64c19f79 : fcadd z25.d, p7/M, z25.d, z27.d, #0x10e   : fcadd  %p7/m %z25.d %z27.d $0x010e -> %z25.d
+64c19fbb : fcadd z27.d, p7/M, z27.d, z29.d, #0x10e   : fcadd  %p7/m %z27.d %z29.d $0x010e -> %z27.d
+64c19fff : fcadd z31.d, p7/M, z31.d, z31.d, #0x10e   : fcadd  %p7/m %z31.d %z31.d $0x010e -> %z31.d
+
 # FCMEQ   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, #0.0 (FCMEQ-P.P.Z0-_)
 65522000 : fcmeq p0.h, p0/Z, z0.h, #0.0              : fcmeq  %p0/z %z0.h $0.000000 -> %p0.h
 65522481 : fcmeq p1.h, p1/Z, z4.h, #0.0              : fcmeq  %p1/z %z4.h $0.000000 -> %p1.h
@@ -5671,6 +5721,92 @@
 65dc5f7c : fcmgt p12.d, p7/Z, z27.d, z28.d           : fcmgt  %p7/z %z27.d %z28.d -> %p12.d
 65de5fbd : fcmgt p13.d, p7/Z, z29.d, z30.d           : fcmgt  %p7/z %z29.d %z30.d -> %p13.d
 65df5fff : fcmgt p15.d, p7/Z, z31.d, z31.d           : fcmgt  %p7/z %z31.d %z31.d -> %p15.d
+
+# FCMLA   <Zda>.<T>, <Pg>/M, <Zn>.<T>, <Zm>.<T>, <const> (FCMLA-Z.P.ZZZ-_)
+64400000 : fcmla z0.h, p0/M, z0.h, z0.h, #0x0        : fcmla  %z0.h %p0/m %z0.h %z0.h $0x0000 -> %z0.h
+64450482 : fcmla z2.h, p1/M, z4.h, z5.h, #0x0        : fcmla  %z2.h %p1/m %z4.h %z5.h $0x0000 -> %z2.h
+644708c4 : fcmla z4.h, p2/M, z6.h, z7.h, #0x0        : fcmla  %z4.h %p2/m %z6.h %z7.h $0x0000 -> %z4.h
+64492906 : fcmla z6.h, p2/M, z8.h, z9.h, #0x5a       : fcmla  %z6.h %p2/m %z8.h %z9.h $0x005a -> %z6.h
+644b2d48 : fcmla z8.h, p3/M, z10.h, z11.h, #0x5a     : fcmla  %z8.h %p3/m %z10.h %z11.h $0x005a -> %z8.h
+644d2d8a : fcmla z10.h, p3/M, z12.h, z13.h, #0x5a    : fcmla  %z10.h %p3/m %z12.h %z13.h $0x005a -> %z10.h
+644f31cc : fcmla z12.h, p4/M, z14.h, z15.h, #0x5a    : fcmla  %z12.h %p4/m %z14.h %z15.h $0x005a -> %z12.h
+6451320e : fcmla z14.h, p4/M, z16.h, z17.h, #0x5a    : fcmla  %z14.h %p4/m %z16.h %z17.h $0x005a -> %z14.h
+64535650 : fcmla z16.h, p5/M, z18.h, z19.h, #0xb4    : fcmla  %z16.h %p5/m %z18.h %z19.h $0x00b4 -> %z16.h
+64545671 : fcmla z17.h, p5/M, z19.h, z20.h, #0xb4    : fcmla  %z17.h %p5/m %z19.h %z20.h $0x00b4 -> %z17.h
+645656b3 : fcmla z19.h, p5/M, z21.h, z22.h, #0xb4    : fcmla  %z19.h %p5/m %z21.h %z22.h $0x00b4 -> %z19.h
+64585af5 : fcmla z21.h, p6/M, z23.h, z24.h, #0xb4    : fcmla  %z21.h %p6/m %z23.h %z24.h $0x00b4 -> %z21.h
+645a5b37 : fcmla z23.h, p6/M, z25.h, z26.h, #0xb4    : fcmla  %z23.h %p6/m %z25.h %z26.h $0x00b4 -> %z23.h
+645c5f79 : fcmla z25.h, p7/M, z27.h, z28.h, #0xb4    : fcmla  %z25.h %p7/m %z27.h %z28.h $0x00b4 -> %z25.h
+645e7fbb : fcmla z27.h, p7/M, z29.h, z30.h, #0x10e   : fcmla  %z27.h %p7/m %z29.h %z30.h $0x010e -> %z27.h
+645f7fff : fcmla z31.h, p7/M, z31.h, z31.h, #0x10e   : fcmla  %z31.h %p7/m %z31.h %z31.h $0x010e -> %z31.h
+64800000 : fcmla z0.s, p0/M, z0.s, z0.s, #0x0        : fcmla  %z0.s %p0/m %z0.s %z0.s $0x0000 -> %z0.s
+64850482 : fcmla z2.s, p1/M, z4.s, z5.s, #0x0        : fcmla  %z2.s %p1/m %z4.s %z5.s $0x0000 -> %z2.s
+648708c4 : fcmla z4.s, p2/M, z6.s, z7.s, #0x0        : fcmla  %z4.s %p2/m %z6.s %z7.s $0x0000 -> %z4.s
+64892906 : fcmla z6.s, p2/M, z8.s, z9.s, #0x5a       : fcmla  %z6.s %p2/m %z8.s %z9.s $0x005a -> %z6.s
+648b2d48 : fcmla z8.s, p3/M, z10.s, z11.s, #0x5a     : fcmla  %z8.s %p3/m %z10.s %z11.s $0x005a -> %z8.s
+648d2d8a : fcmla z10.s, p3/M, z12.s, z13.s, #0x5a    : fcmla  %z10.s %p3/m %z12.s %z13.s $0x005a -> %z10.s
+648f31cc : fcmla z12.s, p4/M, z14.s, z15.s, #0x5a    : fcmla  %z12.s %p4/m %z14.s %z15.s $0x005a -> %z12.s
+6491320e : fcmla z14.s, p4/M, z16.s, z17.s, #0x5a    : fcmla  %z14.s %p4/m %z16.s %z17.s $0x005a -> %z14.s
+64935650 : fcmla z16.s, p5/M, z18.s, z19.s, #0xb4    : fcmla  %z16.s %p5/m %z18.s %z19.s $0x00b4 -> %z16.s
+64945671 : fcmla z17.s, p5/M, z19.s, z20.s, #0xb4    : fcmla  %z17.s %p5/m %z19.s %z20.s $0x00b4 -> %z17.s
+649656b3 : fcmla z19.s, p5/M, z21.s, z22.s, #0xb4    : fcmla  %z19.s %p5/m %z21.s %z22.s $0x00b4 -> %z19.s
+64985af5 : fcmla z21.s, p6/M, z23.s, z24.s, #0xb4    : fcmla  %z21.s %p6/m %z23.s %z24.s $0x00b4 -> %z21.s
+649a5b37 : fcmla z23.s, p6/M, z25.s, z26.s, #0xb4    : fcmla  %z23.s %p6/m %z25.s %z26.s $0x00b4 -> %z23.s
+649c5f79 : fcmla z25.s, p7/M, z27.s, z28.s, #0xb4    : fcmla  %z25.s %p7/m %z27.s %z28.s $0x00b4 -> %z25.s
+649e7fbb : fcmla z27.s, p7/M, z29.s, z30.s, #0x10e   : fcmla  %z27.s %p7/m %z29.s %z30.s $0x010e -> %z27.s
+649f7fff : fcmla z31.s, p7/M, z31.s, z31.s, #0x10e   : fcmla  %z31.s %p7/m %z31.s %z31.s $0x010e -> %z31.s
+64c00000 : fcmla z0.d, p0/M, z0.d, z0.d, #0x0        : fcmla  %z0.d %p0/m %z0.d %z0.d $0x0000 -> %z0.d
+64c50482 : fcmla z2.d, p1/M, z4.d, z5.d, #0x0        : fcmla  %z2.d %p1/m %z4.d %z5.d $0x0000 -> %z2.d
+64c708c4 : fcmla z4.d, p2/M, z6.d, z7.d, #0x0        : fcmla  %z4.d %p2/m %z6.d %z7.d $0x0000 -> %z4.d
+64c92906 : fcmla z6.d, p2/M, z8.d, z9.d, #0x5a       : fcmla  %z6.d %p2/m %z8.d %z9.d $0x005a -> %z6.d
+64cb2d48 : fcmla z8.d, p3/M, z10.d, z11.d, #0x5a     : fcmla  %z8.d %p3/m %z10.d %z11.d $0x005a -> %z8.d
+64cd2d8a : fcmla z10.d, p3/M, z12.d, z13.d, #0x5a    : fcmla  %z10.d %p3/m %z12.d %z13.d $0x005a -> %z10.d
+64cf31cc : fcmla z12.d, p4/M, z14.d, z15.d, #0x5a    : fcmla  %z12.d %p4/m %z14.d %z15.d $0x005a -> %z12.d
+64d1320e : fcmla z14.d, p4/M, z16.d, z17.d, #0x5a    : fcmla  %z14.d %p4/m %z16.d %z17.d $0x005a -> %z14.d
+64d35650 : fcmla z16.d, p5/M, z18.d, z19.d, #0xb4    : fcmla  %z16.d %p5/m %z18.d %z19.d $0x00b4 -> %z16.d
+64d45671 : fcmla z17.d, p5/M, z19.d, z20.d, #0xb4    : fcmla  %z17.d %p5/m %z19.d %z20.d $0x00b4 -> %z17.d
+64d656b3 : fcmla z19.d, p5/M, z21.d, z22.d, #0xb4    : fcmla  %z19.d %p5/m %z21.d %z22.d $0x00b4 -> %z19.d
+64d85af5 : fcmla z21.d, p6/M, z23.d, z24.d, #0xb4    : fcmla  %z21.d %p6/m %z23.d %z24.d $0x00b4 -> %z21.d
+64da5b37 : fcmla z23.d, p6/M, z25.d, z26.d, #0xb4    : fcmla  %z23.d %p6/m %z25.d %z26.d $0x00b4 -> %z23.d
+64dc5f79 : fcmla z25.d, p7/M, z27.d, z28.d, #0xb4    : fcmla  %z25.d %p7/m %z27.d %z28.d $0x00b4 -> %z25.d
+64de7fbb : fcmla z27.d, p7/M, z29.d, z30.d, #0x10e   : fcmla  %z27.d %p7/m %z29.d %z30.d $0x010e -> %z27.d
+64df7fff : fcmla z31.d, p7/M, z31.d, z31.d, #0x10e   : fcmla  %z31.d %p7/m %z31.d %z31.d $0x010e -> %z31.d
+
+# FCMLA   <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const> (FCMLA-Z.ZZZi-H)
+64a01000 : fcmla z0.h, z0.h, z0.h[0], #0x0           : fcmla  %z0.h %z0.h %z0.h $0x00 $0x0000 -> %z0.h
+64a21062 : fcmla z2.h, z3.h, z2.h[0], #0x0           : fcmla  %z2.h %z3.h %z2.h $0x00 $0x0000 -> %z2.h
+64a310a4 : fcmla z4.h, z5.h, z3.h[0], #0x0           : fcmla  %z4.h %z5.h %z3.h $0x00 $0x0000 -> %z4.h
+64ab14e6 : fcmla z6.h, z7.h, z3.h[1], #0x5a          : fcmla  %z6.h %z7.h %z3.h $0x01 $0x005a -> %z6.h
+64ac1528 : fcmla z8.h, z9.h, z4.h[1], #0x5a          : fcmla  %z8.h %z9.h %z4.h $0x01 $0x005a -> %z8.h
+64ac156a : fcmla z10.h, z11.h, z4.h[1], #0x5a        : fcmla  %z10.h %z11.h %z4.h $0x01 $0x005a -> %z10.h
+64ad15ac : fcmla z12.h, z13.h, z5.h[1], #0x5a        : fcmla  %z12.h %z13.h %z5.h $0x01 $0x005a -> %z12.h
+64ad15ee : fcmla z14.h, z15.h, z5.h[1], #0x5a        : fcmla  %z14.h %z15.h %z5.h $0x01 $0x005a -> %z14.h
+64b61a30 : fcmla z16.h, z17.h, z6.h[2], #0xb4        : fcmla  %z16.h %z17.h %z6.h $0x02 $0x00b4 -> %z16.h
+64b61a51 : fcmla z17.h, z18.h, z6.h[2], #0xb4        : fcmla  %z17.h %z18.h %z6.h $0x02 $0x00b4 -> %z17.h
+64b61a93 : fcmla z19.h, z20.h, z6.h[2], #0xb4        : fcmla  %z19.h %z20.h %z6.h $0x02 $0x00b4 -> %z19.h
+64b71ad5 : fcmla z21.h, z22.h, z7.h[2], #0xb4        : fcmla  %z21.h %z22.h %z7.h $0x02 $0x00b4 -> %z21.h
+64b71b17 : fcmla z23.h, z24.h, z7.h[2], #0xb4        : fcmla  %z23.h %z24.h %z7.h $0x02 $0x00b4 -> %z23.h
+64b01b59 : fcmla z25.h, z26.h, z0.h[2], #0xb4        : fcmla  %z25.h %z26.h %z0.h $0x02 $0x00b4 -> %z25.h
+64b81f9b : fcmla z27.h, z28.h, z0.h[3], #0x10e       : fcmla  %z27.h %z28.h %z0.h $0x03 $0x010e -> %z27.h
+64bf1fff : fcmla z31.h, z31.h, z7.h[3], #0x10e       : fcmla  %z31.h %z31.h %z7.h $0x03 $0x010e -> %z31.h
+
+# FCMLA   <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const> (FCMLA-Z.ZZZi-S)
+64e01000 : fcmla z0.s, z0.s, z0.s[0], #0x0           : fcmla  %z0.s %z0.s %z0.s $0x00 $0x0000 -> %z0.s
+64e31062 : fcmla z2.s, z3.s, z3.s[0], #0x0           : fcmla  %z2.s %z3.s %z3.s $0x00 $0x0000 -> %z2.s
+64e410a4 : fcmla z4.s, z5.s, z4.s[0], #0x0           : fcmla  %z4.s %z5.s %z4.s $0x00 $0x0000 -> %z4.s
+64e514e6 : fcmla z6.s, z7.s, z5.s[0], #0x5a          : fcmla  %z6.s %z7.s %z5.s $0x00 $0x005a -> %z6.s
+64e61528 : fcmla z8.s, z9.s, z6.s[0], #0x5a          : fcmla  %z8.s %z9.s %z6.s $0x00 $0x005a -> %z8.s
+64e7156a : fcmla z10.s, z11.s, z7.s[0], #0x5a        : fcmla  %z10.s %z11.s %z7.s $0x00 $0x005a -> %z10.s
+64e815ac : fcmla z12.s, z13.s, z8.s[0], #0x5a        : fcmla  %z12.s %z13.s %z8.s $0x00 $0x005a -> %z12.s
+64e915ee : fcmla z14.s, z15.s, z9.s[0], #0x5a        : fcmla  %z14.s %z15.s %z9.s $0x00 $0x005a -> %z14.s
+64ea1a30 : fcmla z16.s, z17.s, z10.s[0], #0xb4       : fcmla  %z16.s %z17.s %z10.s $0x00 $0x00b4 -> %z16.s
+64fa1a51 : fcmla z17.s, z18.s, z10.s[1], #0xb4       : fcmla  %z17.s %z18.s %z10.s $0x01 $0x00b4 -> %z17.s
+64fb1a93 : fcmla z19.s, z20.s, z11.s[1], #0xb4       : fcmla  %z19.s %z20.s %z11.s $0x01 $0x00b4 -> %z19.s
+64fc1ad5 : fcmla z21.s, z22.s, z12.s[1], #0xb4       : fcmla  %z21.s %z22.s %z12.s $0x01 $0x00b4 -> %z21.s
+64fd1b17 : fcmla z23.s, z24.s, z13.s[1], #0xb4       : fcmla  %z23.s %z24.s %z13.s $0x01 $0x00b4 -> %z23.s
+64fe1b59 : fcmla z25.s, z26.s, z14.s[1], #0xb4       : fcmla  %z25.s %z26.s %z14.s $0x01 $0x00b4 -> %z25.s
+64ff1f9b : fcmla z27.s, z28.s, z15.s[1], #0x10e      : fcmla  %z27.s %z28.s %z15.s $0x01 $0x010e -> %z27.s
+64ff1fff : fcmla z31.s, z31.s, z15.s[1], #0x10e      : fcmla  %z31.s %z31.s %z15.s $0x01 $0x010e -> %z31.s
 
 # FCMLE   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, #0.0 (FCMLE-P.P.Z0-_)
 65512010 : fcmle p0.h, p0/Z, z0.h, #0.0              : fcmle  %p0/z %z0.h $0.000000 -> %p0.h

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -13962,6 +13962,145 @@ TEST_INSTR(ldff1w_sve_pred)
                                                   0, 0, OPSZ_16, 2));
 }
 
+TEST_INSTR(fcadd_sve_pred)
+{
+    /* Testing FCADD   <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>, <const> */
+    static const uint rot_0_0[6] = { 90, 270, 270, 270, 90, 270 };
+    const char *const expected_0_0[6] = {
+        "fcadd  %p0/m %z0.h %z0.h $0x005a -> %z0.h",
+        "fcadd  %p2/m %z5.h %z7.h $0x010e -> %z5.h",
+        "fcadd  %p3/m %z10.h %z12.h $0x010e -> %z10.h",
+        "fcadd  %p5/m %z16.h %z18.h $0x010e -> %z16.h",
+        "fcadd  %p6/m %z21.h %z23.h $0x005a -> %z21.h",
+        "fcadd  %p7/m %z31.h %z31.h $0x010e -> %z31.h",
+    };
+    TEST_LOOP(fcadd, fcadd_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    const char *const expected_0_1[6] = {
+        "fcadd  %p0/m %z0.s %z0.s $0x005a -> %z0.s",
+        "fcadd  %p2/m %z5.s %z7.s $0x010e -> %z5.s",
+        "fcadd  %p3/m %z10.s %z12.s $0x010e -> %z10.s",
+        "fcadd  %p5/m %z16.s %z18.s $0x010e -> %z16.s",
+        "fcadd  %p6/m %z21.s %z23.s $0x005a -> %z21.s",
+        "fcadd  %p7/m %z31.s %z31.s $0x010e -> %z31.s",
+    };
+    TEST_LOOP(fcadd, fcadd_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "fcadd  %p0/m %z0.d %z0.d $0x005a -> %z0.d",
+        "fcadd  %p2/m %z5.d %z7.d $0x010e -> %z5.d",
+        "fcadd  %p3/m %z10.d %z12.d $0x010e -> %z10.d",
+        "fcadd  %p5/m %z16.d %z18.d $0x010e -> %z16.d",
+        "fcadd  %p6/m %z21.d %z23.d $0x005a -> %z21.d",
+        "fcadd  %p7/m %z31.d %z31.d $0x010e -> %z31.d",
+    };
+    TEST_LOOP(fcadd, fcadd_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+}
+
+TEST_INSTR(fcmla_sve_vector)
+{
+    /* Testing FCMLA   <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts>, <const> */
+    static const uint rot_0_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_0_0[6] = {
+        "fcmla  %z0.h %p0/m %z0.h %z0.h $0x0000 -> %z0.h",
+        "fcmla  %z5.h %p2/m %z7.h %z8.h $0x0000 -> %z5.h",
+        "fcmla  %z10.h %p3/m %z12.h %z13.h $0x005a -> %z10.h",
+        "fcmla  %z16.h %p5/m %z18.h %z19.h $0x00b4 -> %z16.h",
+        "fcmla  %z21.h %p6/m %z23.h %z24.h $0x00b4 -> %z21.h",
+        "fcmla  %z31.h %p7/m %z31.h %z31.h $0x010e -> %z31.h",
+    };
+    TEST_LOOP(fcmla, fcmla_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    const char *const expected_0_1[6] = {
+        "fcmla  %z0.s %p0/m %z0.s %z0.s $0x0000 -> %z0.s",
+        "fcmla  %z5.s %p2/m %z7.s %z8.s $0x0000 -> %z5.s",
+        "fcmla  %z10.s %p3/m %z12.s %z13.s $0x005a -> %z10.s",
+        "fcmla  %z16.s %p5/m %z18.s %z19.s $0x00b4 -> %z16.s",
+        "fcmla  %z21.s %p6/m %z23.s %z24.s $0x00b4 -> %z21.s",
+        "fcmla  %z31.s %p7/m %z31.s %z31.s $0x010e -> %z31.s",
+    };
+    TEST_LOOP(fcmla, fcmla_sve_vector, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "fcmla  %z0.d %p0/m %z0.d %z0.d $0x0000 -> %z0.d",
+        "fcmla  %z5.d %p2/m %z7.d %z8.d $0x0000 -> %z5.d",
+        "fcmla  %z10.d %p3/m %z12.d %z13.d $0x005a -> %z10.d",
+        "fcmla  %z16.d %p5/m %z18.d %z19.d $0x00b4 -> %z16.d",
+        "fcmla  %z21.d %p6/m %z23.d %z24.d $0x00b4 -> %z21.d",
+        "fcmla  %z31.d %p7/m %z31.d %z31.d $0x010e -> %z31.d",
+    };
+    TEST_LOOP(fcmla, fcmla_sve_vector, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_8),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+}
+
+TEST_INSTR(fcmla_sve_idx)
+{
+    /* Testing FCMLA   <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const> */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_0_0[6] = { 0, 3, 0, 1, 1, 3 };
+    static const uint rot_0_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_0_0[6] = {
+        "fcmla  %z0.h %z0.h %z0.h $0x00 $0x0000 -> %z0.h",
+        "fcmla  %z5.h %z6.h %z3.h $0x03 $0x0000 -> %z5.h",
+        "fcmla  %z10.h %z11.h %z4.h $0x00 $0x005a -> %z10.h",
+        "fcmla  %z16.h %z17.h %z6.h $0x01 $0x00b4 -> %z16.h",
+        "fcmla  %z21.h %z22.h %z7.h $0x01 $0x00b4 -> %z21.h",
+        "fcmla  %z31.h %z31.h %z7.h $0x03 $0x010e -> %z31.h",
+    };
+    TEST_LOOP(fcmla, fcmla_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_immed_uint(i2_0_0[i], OPSZ_2b),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    /* Testing FCMLA   <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const> */
+    static const reg_id_t Zm_0_1[6] = { DR_REG_Z0,  DR_REG_Z4,  DR_REG_Z7,
+                                        DR_REG_Z10, DR_REG_Z12, DR_REG_Z15 };
+    static const uint i1_0_0[6] = { 0, 1, 1, 1, 0, 1 };
+    const char *const expected_0_1[6] = {
+        "fcmla  %z0.s %z0.s %z0.s $0x00 $0x0000 -> %z0.s",
+        "fcmla  %z5.s %z6.s %z4.s $0x01 $0x0000 -> %z5.s",
+        "fcmla  %z10.s %z11.s %z7.s $0x01 $0x005a -> %z10.s",
+        "fcmla  %z16.s %z17.s %z10.s $0x01 $0x00b4 -> %z16.s",
+        "fcmla  %z21.s %z22.s %z12.s $0x00 $0x00b4 -> %z21.s",
+        "fcmla  %z31.s %z31.s %z15.s $0x01 $0x010e -> %z31.s",
+    };
+    TEST_LOOP(fcmla, fcmla_sve_idx, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zm_0_1[i], OPSZ_4),
+              opnd_create_immed_uint(i1_0_0[i], OPSZ_1b),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -14376,6 +14515,12 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ldff1sh_sve_pred);
     RUN_INSTR_TEST(ldff1sw_sve_pred);
     RUN_INSTR_TEST(ldff1w_sve_pred);
+
+    RUN_INSTR_TEST(fcadd_sve_pred);
+
+    RUN_INSTR_TEST(fcmla_sve_vector);
+    RUN_INSTR_TEST(fcmla_sve_idx);
+    RUN_INSTR_TEST(fcmla_sve_idx);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
FCADD   <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>, <const>
FCMLA   <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts>, <const>
FCMLA   <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const>
FCMLA   <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const>
```

Issue #3044