### PR TITLE
i#3044 AArch64 SVE codec: Add single gpr memory load/stores

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4272,6 +4272,64 @@ encode_opnd_s16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_vector_reg(16, 2, opnd, enc_out);
 }
 
+static inline bool
+svemem_gprs_per_element_decode(uint bytes_per_element, aarch64_reg_offset element_size,
+                               uint shift_amount, uint enc, int opcode, byte *pc,
+                               OUT opnd_t *opnd)
+{
+    ASSERT(element_size >= BYTE_REG && element_size <= DOUBLE_REG);
+    ASSERT(bytes_per_element <= (1 << element_size));
+
+    const uint elements = get_elements_in_sve_vector(element_size);
+    const opnd_size_t mem_transfer = opnd_size_from_bytes(bytes_per_element * elements);
+
+    *opnd = opnd_create_base_disp_shift_aarch64(
+        decode_reg(extract_uint(enc, 5, 5), true, true),
+        decode_reg(extract_uint(enc, 16, 5), true, false), DR_EXTEND_UXTX,
+        shift_amount != 0, 0, 0, mem_transfer, shift_amount);
+    return true;
+}
+
+static inline bool
+svemem_gprs_per_element_encode(uint bytes_per_element, aarch64_reg_offset element_size,
+                               uint shift_amount, uint enc, int opcode, byte *pc,
+                               opnd_t opnd, OUT uint *enc_out)
+{
+    ASSERT(element_size >= BYTE_REG && element_size <= DOUBLE_REG);
+    ASSERT(bytes_per_element <= (1 << element_size));
+
+    const uint elements = get_elements_in_sve_vector(element_size);
+    const opnd_size_t mem_transfer = opnd_size_from_bytes(bytes_per_element * elements);
+
+    if (!opnd_is_base_disp(opnd) || opnd_get_size(opnd) != mem_transfer ||
+                    opnd_get_disp(opnd) != 0)
+        return false;
+
+    uint rn, rm;
+    bool is_x_register;
+    IF_RETURN_FALSE(!encode_reg(&rn, &is_x_register, opnd_get_base(opnd), true) ||
+                    !is_x_register)
+    IF_RETURN_FALSE(!encode_reg(&rm, &is_x_register, opnd_get_index(opnd), false) ||
+                    !is_x_register)
+
+    *enc_out = rn << 5 | rm << 16;
+    return true;
+}
+
+static inline bool
+decode_opnd_svemem_gprs_b1(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return svemem_gprs_per_element_decode(1, BYTE_REG, 0, enc, opcode, pc, opnd);
+}
+
+static inline bool
+encode_opnd_svemem_gprs_b1(uint enc, int opcode, byte *pc, opnd_t opnd,
+                             OUT uint *enc_out)
+{
+    return svemem_gprs_per_element_encode(1, BYTE_REG, 0, enc, opcode, pc, opnd,
+                                          enc_out);
+}
+
 /* imm8_10: 8 bit imm at pos 10, split across 20:16 and 12:10. */
 
 static inline bool
@@ -6170,53 +6228,39 @@ dtype_is_signed(uint dtype)
 
 /* svemem_gpr: GPR offset and base reg for SVE ld/st */
 
-static inline bool
-decode_opnd_svemem_gpr_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+static inline void
+sizes_from_dtype(const uint enc, aarch64_reg_offset *insz, aarch64_reg_offset *elsz)
 {
     uint dtype = extract_uint(enc, 21, 4);
     if (dtype_is_signed(dtype))
         dtype = ~dtype;
 
-    const aarch64_reg_offset insz = BITS(dtype, 3, 2);
-    const aarch64_reg_offset elsz = BITS(dtype, 1, 0);
+    *insz = BITS(dtype, 3, 2);
+    *elsz = BITS(dtype, 1, 0);
+}
 
-    const uint elements = get_elements_in_sve_vector(elsz);
-    const opnd_size_t mem_transfer = opnd_size_from_bytes((1 << insz) * elements);
-    const opnd_size_t insz_opsz = get_opnd_size_from_offset(insz);
+static inline bool
+decode_opnd_svemem_gpr_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    aarch64_reg_offset insz, elsz;
+    sizes_from_dtype(enc, &insz, &elsz);
 
-    const reg_id_t rn = decode_reg(extract_uint(enc, 5, 5), true, true);
-    const reg_id_t rm = decode_reg(extract_uint(enc, 16, 5), true, false);
+    const uint shift_amount = opnd_size_to_shift_amount(get_opnd_size_from_offset(insz));
 
-    /* The byte load type does not use offset scaling, so set to zero in those cases */
-    *opnd = opnd_create_base_disp_shift_aarch64(rn, rm, DR_EXTEND_UXTX, insz != BYTE_REG,
-                                                0, 0, mem_transfer,
-                                                opnd_size_to_shift_amount(insz_opsz));
-    return true;
+    return svemem_gprs_per_element_decode(1 << insz, elsz, shift_amount, enc, opcode, pc,
+                                          opnd);
 }
 
 static inline bool
 encode_opnd_svemem_gpr_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    uint dtype = extract_uint(enc, 21, 4);
-    if (dtype_is_signed(dtype))
-        dtype = ~dtype;
+    aarch64_reg_offset insz, elsz;
+    sizes_from_dtype(enc, &insz, &elsz);
 
-    const aarch64_reg_offset insz = BITS(dtype, 3, 2);
-    const aarch64_reg_offset elsz = BITS(dtype, 1, 0);
+    const uint shift_amount = opnd_size_to_shift_amount(get_opnd_size_from_offset(insz));
 
-    const uint elements = get_elements_in_sve_vector(elsz);
-    const opnd_size_t mem_transfer = opnd_size_from_bytes((1 << insz) * elements);
-
-    IF_RETURN_FALSE(!opnd_is_base_disp(opnd) || (opnd_get_size(opnd) != mem_transfer) ||
-                    (opnd_get_disp(opnd) != 0))
-
-    uint rn, rm;
-    bool is_x;
-    IF_RETURN_FALSE(!encode_reg(&rn, &is_x, opnd_get_base(opnd), true) || !is_x)
-    IF_RETURN_FALSE(!encode_reg(&rm, &is_x, opnd_get_index(opnd), false) || !is_x)
-
-    *enc_out = (rm << 16) | (rn << 5);
-    return true;
+    return svemem_gprs_per_element_encode(1 << insz, elsz, shift_amount, enc, opcode, pc,
+                                          opnd, enc_out);
 }
 
 /* mem0p: as mem0, but a pair of registers, so double size */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -284,6 +284,10 @@
 00000101xx100010100xxxxxxxxxxxxx  n   837  SVE    lasta  bhsd_size_reg0 : p10_lo z_size_bhsd_5
 00000101xx100001101xxxxxxxxxxxxx  n   838  SVE    lastb   wx_size_0_zr : p10_lo z_size_bhsd_5
 00000101xx100011100xxxxxxxxxxxxx  n   838  SVE    lastb  bhsd_size_reg0 : p10_lo z_size_bhsd_5
+10100100001xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_h_0 : svemem_gpr_5 p10_zer_lo
+10100100010xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_s_0 : svemem_gpr_5 p10_zer_lo
+10100100011xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_d_0 : svemem_gpr_5 p10_zer_lo
+10100100000xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_b_0 : svemem_gpr_5 p10_zer_lo
 1000010001xxxxxx101xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_h_0 : svememx6_b_5 p10_zer_lo
 1000010001xxxxxx110xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_s_0 : svememx6_b_5 p10_zer_lo
 1000010001xxxxxx111xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_d_0 : svememx6_b_5 p10_zer_lo
@@ -292,6 +296,8 @@
 1000010011xxxxxx101xxxxxxxxxxxxx  n   910  SVE    ld1rh          z_h_0 : svememx6_h_5 p10_zer_lo
 1000010011xxxxxx110xxxxxxxxxxxxx  n   910  SVE    ld1rh          z_s_0 : svememx6_h_5 p10_zer_lo
 1000010011xxxxxx111xxxxxxxxxxxxx  n   910  SVE    ld1rh          z_d_0 : svememx6_h_5 p10_zer_lo
+10100100001xxxxx000xxxxxxxxxxxxx  n   947  SVE   ld1rob          z_b_0 : svemem_gprs_b1 p10_zer_lo
+10100100000xxxxx000xxxxxxxxxxxxx  n   948  SVE   ld1rqb          z_b_0 : svemem_gprs_b1 p10_zer_lo
 1000010111xxxxxx110xxxxxxxxxxxxx  n   911  SVE   ld1rsb          z_h_0 : svememx6_b_5 p10_zer_lo
 1000010111xxxxxx101xxxxxxxxxxxxx  n   911  SVE   ld1rsb          z_s_0 : svememx6_b_5 p10_zer_lo
 1000010111xxxxxx100xxxxxxxxxxxxx  n   911  SVE   ld1rsb          z_d_0 : svememx6_b_5 p10_zer_lo
@@ -300,6 +306,9 @@
 1000010011xxxxxx100xxxxxxxxxxxxx  n   913  SVE   ld1rsw          z_d_0 : svememx6_s_5 p10_zer_lo
 1000010101xxxxxx110xxxxxxxxxxxxx  n   914  SVE    ld1rw          z_s_0 : svememx6_s_5 p10_zer_lo
 1000010101xxxxxx111xxxxxxxxxxxxx  n   914  SVE    ld1rw          z_d_0 : svememx6_s_5 p10_zer_lo
+10100101110xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_h_0 : svemem_gpr_5 p10_zer_lo
+10100101101xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_s_0 : svemem_gpr_5 p10_zer_lo
+10100101100xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_d_0 : svemem_gpr_5 p10_zer_lo
 10100100001xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_h_0 : svemem_gpr_5 p10_zer_lo
 10100100010xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_s_0 : svemem_gpr_5 p10_zer_lo
 10100100011xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_d_0 : svemem_gpr_5 p10_zer_lo
@@ -316,6 +325,7 @@
 10100100100xxxxx011xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_5 p10_zer_lo
 10100101010xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_s_0 : svemem_gpr_5 p10_zer_lo
 10100101011xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_5 p10_zer_lo
+10100100000xxxxx110xxxxxxxxxxxxx  n   950  SVE   ldnt1b          z_b_0 : svemem_gprs_b1 p10_zer_lo
 1000010110xxxxxx000xxxxxxxx0xxxx  n   227  SVE      ldr             p0 : svemem_gpr_simm9_vl
 1000010110xxxxxx010xxxxxxxxxxxxx  n   227  SVE      ldr             z0 : svemem_gpr_simm9_vl
 00000100xx000011100xxxxxxxxxxxxx  n   902  SVE      lsl  z_tszl8_bhsd_0 : p10_mrg_lo z_tszl8_bhsd_0 tszl8_imm3_5
@@ -436,6 +446,11 @@
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub             z0 : z5 z16 bhsd_sz
 00100101xx10011011xxxxxxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+11100100000xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_b_0 p10_lo
+11100100001xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_h_0 p10_lo
+11100100010xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_s_0 p10_lo
+11100100011xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_d_0 p10_lo
+11100100000xxxxx011xxxxxxxxxxxxx  n   952  SVE   stnt1b  svemem_gprs_b1 : z_b_0 p10_lo
 1110010110xxxxxx000xxxxxxxx0xxxx  n   457  SVE      str  svemem_gpr_simm9_vl : p0
 1110010110xxxxxx010xxxxxxxxxxxxx  n   457  SVE      str  svemem_gpr_simm9_vl : z0
 00000100xx1xxxxx000001xxxxxxxxxx  n   470  SVE      sub             z0 : z5 z16 bhsd_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -10752,6 +10752,7 @@
     instr_create_1dst_2src(dc, OP_ldff1w, Zt, Rn, Pg)
 
 /**
+
  * Creates a FCADD instruction.
  *
  * This macro is used to encode the forms:
@@ -10801,5 +10802,136 @@
  */
 #define INSTR_CREATE_fcmla_sve_idx(dc, Zda, Zn, Zm, imm, rot) \
     instr_create_1dst_5src(dc, OP_fcmla, Zda, Zda, Zn, Zm, imm, rot)
+
+/*
+ * Creates a LD1B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ *    LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ *    LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ *    LD1B    { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ld1b_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1b, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1ROB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1ROB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ld1rob_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rob, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1RQB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1RQB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ld1rqb_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1rqb, Zt, Rn, Pg)
+
+/**
+ * Creates a LD1SB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ *    LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ *    LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ld1sb_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ld1sb, Zt, Rn, Pg)
+
+/**
+ * Creates a LDNT1B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ldnt1b_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_ldnt1b, Zt, Rn, Pg)
+
+/**
+ * Creates a ST1B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ST1B    { <Zt>.<Ts> }, <Pg>, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The first source vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The second source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_st1b_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_st1b, Rn, Zt, Pg)
+
+/**
+ * Creates a STNT1B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The first source vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The second source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_stnt1b_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_2src(dc, OP_stnt1b, Rn, Zt, Pg)
 
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -203,6 +203,7 @@
 -----------xxxxx----------------  b16        # B register
 -----------xxxxx----------------  h16        # H register
 -----------xxxxx----------------  s16        # S register
+-----------xxxxx------xxxxx-----  svemem_gprs_b1  # memory reg from Rm and Rn fields transferring 1 bytes per element
 -----------xxxxx---xxx----------  imm8_10    # 8 bit imm at pos 10, split across 20:16 and 12:10
 -----------xxxxxxx--------------  imm7       # 7 bit immediate from 14-20
 -----------xxxxxxxxx------------  mem9off    # immed offset for mem9/mem9post

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -10144,6 +10144,78 @@
 05e39fbd : lastb d29, p7, z29.d        : lastb  %p7 %z29.d -> %d29
 05e39fff : lastb d31, p7, z31.d        : lastb  %p7 %z31.d -> %d31
 
+# LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1B-Z.P.BR-U16)
+a4204000 : ld1b z0.h, p0/Z, [x0, x0]                 : ld1b   (%x0,%x0)[16byte] %p0/z -> %z0.h
+a4254482 : ld1b z2.h, p1/Z, [x4, x5]                 : ld1b   (%x4,%x5)[16byte] %p1/z -> %z2.h
+a42748c4 : ld1b z4.h, p2/Z, [x6, x7]                 : ld1b   (%x6,%x7)[16byte] %p2/z -> %z4.h
+a4294906 : ld1b z6.h, p2/Z, [x8, x9]                 : ld1b   (%x8,%x9)[16byte] %p2/z -> %z6.h
+a42b4d48 : ld1b z8.h, p3/Z, [x10, x11]               : ld1b   (%x10,%x11)[16byte] %p3/z -> %z8.h
+a42c4d6a : ld1b z10.h, p3/Z, [x11, x12]              : ld1b   (%x11,%x12)[16byte] %p3/z -> %z10.h
+a42e51ac : ld1b z12.h, p4/Z, [x13, x14]              : ld1b   (%x13,%x14)[16byte] %p4/z -> %z12.h
+a43051ee : ld1b z14.h, p4/Z, [x15, x16]              : ld1b   (%x15,%x16)[16byte] %p4/z -> %z14.h
+a4325630 : ld1b z16.h, p5/Z, [x17, x18]              : ld1b   (%x17,%x18)[16byte] %p5/z -> %z16.h
+a4345671 : ld1b z17.h, p5/Z, [x19, x20]              : ld1b   (%x19,%x20)[16byte] %p5/z -> %z17.h
+a43656b3 : ld1b z19.h, p5/Z, [x21, x22]              : ld1b   (%x21,%x22)[16byte] %p5/z -> %z19.h
+a4385af5 : ld1b z21.h, p6/Z, [x23, x24]              : ld1b   (%x23,%x24)[16byte] %p6/z -> %z21.h
+a4395b17 : ld1b z23.h, p6/Z, [x24, x25]              : ld1b   (%x24,%x25)[16byte] %p6/z -> %z23.h
+a43b5f59 : ld1b z25.h, p7/Z, [x26, x27]              : ld1b   (%x26,%x27)[16byte] %p7/z -> %z25.h
+a43d5f9b : ld1b z27.h, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[16byte] %p7/z -> %z27.h
+a43e5fff : ld1b z31.h, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[16byte] %p7/z -> %z31.h
+
+# LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1B-Z.P.BR-U32)
+a4404000 : ld1b z0.s, p0/Z, [x0, x0]                 : ld1b   (%x0,%x0)[8byte] %p0/z -> %z0.s
+a4454482 : ld1b z2.s, p1/Z, [x4, x5]                 : ld1b   (%x4,%x5)[8byte] %p1/z -> %z2.s
+a44748c4 : ld1b z4.s, p2/Z, [x6, x7]                 : ld1b   (%x6,%x7)[8byte] %p2/z -> %z4.s
+a4494906 : ld1b z6.s, p2/Z, [x8, x9]                 : ld1b   (%x8,%x9)[8byte] %p2/z -> %z6.s
+a44b4d48 : ld1b z8.s, p3/Z, [x10, x11]               : ld1b   (%x10,%x11)[8byte] %p3/z -> %z8.s
+a44c4d6a : ld1b z10.s, p3/Z, [x11, x12]              : ld1b   (%x11,%x12)[8byte] %p3/z -> %z10.s
+a44e51ac : ld1b z12.s, p4/Z, [x13, x14]              : ld1b   (%x13,%x14)[8byte] %p4/z -> %z12.s
+a45051ee : ld1b z14.s, p4/Z, [x15, x16]              : ld1b   (%x15,%x16)[8byte] %p4/z -> %z14.s
+a4525630 : ld1b z16.s, p5/Z, [x17, x18]              : ld1b   (%x17,%x18)[8byte] %p5/z -> %z16.s
+a4545671 : ld1b z17.s, p5/Z, [x19, x20]              : ld1b   (%x19,%x20)[8byte] %p5/z -> %z17.s
+a45656b3 : ld1b z19.s, p5/Z, [x21, x22]              : ld1b   (%x21,%x22)[8byte] %p5/z -> %z19.s
+a4585af5 : ld1b z21.s, p6/Z, [x23, x24]              : ld1b   (%x23,%x24)[8byte] %p6/z -> %z21.s
+a4595b17 : ld1b z23.s, p6/Z, [x24, x25]              : ld1b   (%x24,%x25)[8byte] %p6/z -> %z23.s
+a45b5f59 : ld1b z25.s, p7/Z, [x26, x27]              : ld1b   (%x26,%x27)[8byte] %p7/z -> %z25.s
+a45d5f9b : ld1b z27.s, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[8byte] %p7/z -> %z27.s
+a45e5fff : ld1b z31.s, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[8byte] %p7/z -> %z31.s
+
+# LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1B-Z.P.BR-U64)
+a4604000 : ld1b z0.d, p0/Z, [x0, x0]                 : ld1b   (%x0,%x0)[4byte] %p0/z -> %z0.d
+a4654482 : ld1b z2.d, p1/Z, [x4, x5]                 : ld1b   (%x4,%x5)[4byte] %p1/z -> %z2.d
+a46748c4 : ld1b z4.d, p2/Z, [x6, x7]                 : ld1b   (%x6,%x7)[4byte] %p2/z -> %z4.d
+a4694906 : ld1b z6.d, p2/Z, [x8, x9]                 : ld1b   (%x8,%x9)[4byte] %p2/z -> %z6.d
+a46b4d48 : ld1b z8.d, p3/Z, [x10, x11]               : ld1b   (%x10,%x11)[4byte] %p3/z -> %z8.d
+a46c4d6a : ld1b z10.d, p3/Z, [x11, x12]              : ld1b   (%x11,%x12)[4byte] %p3/z -> %z10.d
+a46e51ac : ld1b z12.d, p4/Z, [x13, x14]              : ld1b   (%x13,%x14)[4byte] %p4/z -> %z12.d
+a47051ee : ld1b z14.d, p4/Z, [x15, x16]              : ld1b   (%x15,%x16)[4byte] %p4/z -> %z14.d
+a4725630 : ld1b z16.d, p5/Z, [x17, x18]              : ld1b   (%x17,%x18)[4byte] %p5/z -> %z16.d
+a4745671 : ld1b z17.d, p5/Z, [x19, x20]              : ld1b   (%x19,%x20)[4byte] %p5/z -> %z17.d
+a47656b3 : ld1b z19.d, p5/Z, [x21, x22]              : ld1b   (%x21,%x22)[4byte] %p5/z -> %z19.d
+a4785af5 : ld1b z21.d, p6/Z, [x23, x24]              : ld1b   (%x23,%x24)[4byte] %p6/z -> %z21.d
+a4795b17 : ld1b z23.d, p6/Z, [x24, x25]              : ld1b   (%x24,%x25)[4byte] %p6/z -> %z23.d
+a47b5f59 : ld1b z25.d, p7/Z, [x26, x27]              : ld1b   (%x26,%x27)[4byte] %p7/z -> %z25.d
+a47d5f9b : ld1b z27.d, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[4byte] %p7/z -> %z27.d
+a47e5fff : ld1b z31.d, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[4byte] %p7/z -> %z31.d
+
+# LD1B    { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1B-Z.P.BR-U8)
+a4004000 : ld1b z0.b, p0/Z, [x0, x0]                 : ld1b   (%x0,%x0)[32byte] %p0/z -> %z0.b
+a4054482 : ld1b z2.b, p1/Z, [x4, x5]                 : ld1b   (%x4,%x5)[32byte] %p1/z -> %z2.b
+a40748c4 : ld1b z4.b, p2/Z, [x6, x7]                 : ld1b   (%x6,%x7)[32byte] %p2/z -> %z4.b
+a4094906 : ld1b z6.b, p2/Z, [x8, x9]                 : ld1b   (%x8,%x9)[32byte] %p2/z -> %z6.b
+a40b4d48 : ld1b z8.b, p3/Z, [x10, x11]               : ld1b   (%x10,%x11)[32byte] %p3/z -> %z8.b
+a40c4d6a : ld1b z10.b, p3/Z, [x11, x12]              : ld1b   (%x11,%x12)[32byte] %p3/z -> %z10.b
+a40e51ac : ld1b z12.b, p4/Z, [x13, x14]              : ld1b   (%x13,%x14)[32byte] %p4/z -> %z12.b
+a41051ee : ld1b z14.b, p4/Z, [x15, x16]              : ld1b   (%x15,%x16)[32byte] %p4/z -> %z14.b
+a4125630 : ld1b z16.b, p5/Z, [x17, x18]              : ld1b   (%x17,%x18)[32byte] %p5/z -> %z16.b
+a4145671 : ld1b z17.b, p5/Z, [x19, x20]              : ld1b   (%x19,%x20)[32byte] %p5/z -> %z17.b
+a41656b3 : ld1b z19.b, p5/Z, [x21, x22]              : ld1b   (%x21,%x22)[32byte] %p5/z -> %z19.b
+a4185af5 : ld1b z21.b, p6/Z, [x23, x24]              : ld1b   (%x23,%x24)[32byte] %p6/z -> %z21.b
+a4195b17 : ld1b z23.b, p6/Z, [x24, x25]              : ld1b   (%x24,%x25)[32byte] %p6/z -> %z23.b
+a41b5f59 : ld1b z25.b, p7/Z, [x26, x27]              : ld1b   (%x26,%x27)[32byte] %p7/z -> %z25.b
+a41d5f9b : ld1b z27.b, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[32byte] %p7/z -> %z27.b
+a41e5fff : ld1b z31.b, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[32byte] %p7/z -> %z31.b
+
 # LD1RB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RB-Z.P.BI-U16)
 8440a000 : ld1rb z0.h, p0/Z, [x0, #0]                : ld1rb  (%x0)[1byte] %p0/z -> %z0.h
 8444a482 : ld1rb z2.h, p1/Z, [x4, #4]                : ld1rb  +0x04(%x4)[1byte] %p1/z -> %z2.h
@@ -10288,6 +10360,42 @@
 84f7ff9b : ld1rh z27.d, p7/Z, [x28, #110]            : ld1rh  +0x6e(%x28)[2byte] %p7/z -> %z27.d
 84ffffff : ld1rh z31.d, p7/Z, [sp, #126]             : ld1rh  +0x7e(%sp)[2byte] %p7/z -> %z31.d
 
+# LD1ROB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1ROB-Z.P.BR-Contiguous)
+a4200000 : ld1rob z0.b, p0/Z, [x0, x0]               : ld1rob (%x0,%x0)[32byte] %p0/z -> %z0.b
+a4250482 : ld1rob z2.b, p1/Z, [x4, x5]               : ld1rob (%x4,%x5)[32byte] %p1/z -> %z2.b
+a42708c4 : ld1rob z4.b, p2/Z, [x6, x7]               : ld1rob (%x6,%x7)[32byte] %p2/z -> %z4.b
+a4290906 : ld1rob z6.b, p2/Z, [x8, x9]               : ld1rob (%x8,%x9)[32byte] %p2/z -> %z6.b
+a42b0d48 : ld1rob z8.b, p3/Z, [x10, x11]             : ld1rob (%x10,%x11)[32byte] %p3/z -> %z8.b
+a42c0d6a : ld1rob z10.b, p3/Z, [x11, x12]            : ld1rob (%x11,%x12)[32byte] %p3/z -> %z10.b
+a42e11ac : ld1rob z12.b, p4/Z, [x13, x14]            : ld1rob (%x13,%x14)[32byte] %p4/z -> %z12.b
+a43011ee : ld1rob z14.b, p4/Z, [x15, x16]            : ld1rob (%x15,%x16)[32byte] %p4/z -> %z14.b
+a4321630 : ld1rob z16.b, p5/Z, [x17, x18]            : ld1rob (%x17,%x18)[32byte] %p5/z -> %z16.b
+a4341671 : ld1rob z17.b, p5/Z, [x19, x20]            : ld1rob (%x19,%x20)[32byte] %p5/z -> %z17.b
+a43616b3 : ld1rob z19.b, p5/Z, [x21, x22]            : ld1rob (%x21,%x22)[32byte] %p5/z -> %z19.b
+a4381af5 : ld1rob z21.b, p6/Z, [x23, x24]            : ld1rob (%x23,%x24)[32byte] %p6/z -> %z21.b
+a4391b17 : ld1rob z23.b, p6/Z, [x24, x25]            : ld1rob (%x24,%x25)[32byte] %p6/z -> %z23.b
+a43b1f59 : ld1rob z25.b, p7/Z, [x26, x27]            : ld1rob (%x26,%x27)[32byte] %p7/z -> %z25.b
+a43d1f9b : ld1rob z27.b, p7/Z, [x28, x29]            : ld1rob (%x28,%x29)[32byte] %p7/z -> %z27.b
+a43e1fff : ld1rob z31.b, p7/Z, [sp, x30]             : ld1rob (%sp,%x30)[32byte] %p7/z -> %z31.b
+
+# LD1RQB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1RQB-Z.P.BR-Contiguous)
+a4000000 : ld1rqb z0.b, p0/Z, [x0, x0]               : ld1rqb (%x0,%x0)[32byte] %p0/z -> %z0.b
+a4050482 : ld1rqb z2.b, p1/Z, [x4, x5]               : ld1rqb (%x4,%x5)[32byte] %p1/z -> %z2.b
+a40708c4 : ld1rqb z4.b, p2/Z, [x6, x7]               : ld1rqb (%x6,%x7)[32byte] %p2/z -> %z4.b
+a4090906 : ld1rqb z6.b, p2/Z, [x8, x9]               : ld1rqb (%x8,%x9)[32byte] %p2/z -> %z6.b
+a40b0d48 : ld1rqb z8.b, p3/Z, [x10, x11]             : ld1rqb (%x10,%x11)[32byte] %p3/z -> %z8.b
+a40c0d6a : ld1rqb z10.b, p3/Z, [x11, x12]            : ld1rqb (%x11,%x12)[32byte] %p3/z -> %z10.b
+a40e11ac : ld1rqb z12.b, p4/Z, [x13, x14]            : ld1rqb (%x13,%x14)[32byte] %p4/z -> %z12.b
+a41011ee : ld1rqb z14.b, p4/Z, [x15, x16]            : ld1rqb (%x15,%x16)[32byte] %p4/z -> %z14.b
+a4121630 : ld1rqb z16.b, p5/Z, [x17, x18]            : ld1rqb (%x17,%x18)[32byte] %p5/z -> %z16.b
+a4141671 : ld1rqb z17.b, p5/Z, [x19, x20]            : ld1rqb (%x19,%x20)[32byte] %p5/z -> %z17.b
+a41616b3 : ld1rqb z19.b, p5/Z, [x21, x22]            : ld1rqb (%x21,%x22)[32byte] %p5/z -> %z19.b
+a4181af5 : ld1rqb z21.b, p6/Z, [x23, x24]            : ld1rqb (%x23,%x24)[32byte] %p6/z -> %z21.b
+a4191b17 : ld1rqb z23.b, p6/Z, [x24, x25]            : ld1rqb (%x24,%x25)[32byte] %p6/z -> %z23.b
+a41b1f59 : ld1rqb z25.b, p7/Z, [x26, x27]            : ld1rqb (%x26,%x27)[32byte] %p7/z -> %z25.b
+a41d1f9b : ld1rqb z27.b, p7/Z, [x28, x29]            : ld1rqb (%x28,%x29)[32byte] %p7/z -> %z27.b
+a41e1fff : ld1rqb z31.b, p7/Z, [sp, x30]             : ld1rqb (%sp,%x30)[32byte] %p7/z -> %z31.b
+
 # LD1RSB  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RSB-Z.P.BI-S16)
 85c0c000 : ld1rsb z0.h, p0/Z, [x0, #0]               : ld1rsb (%x0)[1byte] %p0/z -> %z0.h
 85c4c482 : ld1rsb z2.h, p1/Z, [x4, #4]               : ld1rsb +0x04(%x4)[1byte] %p1/z -> %z2.h
@@ -10431,6 +10539,60 @@
 8573ff59 : ld1rw z25.d, p7/Z, [x26, #204]            : ld1rw  +0xcc(%x26)[4byte] %p7/z -> %z25.d
 8577ff9b : ld1rw z27.d, p7/Z, [x28, #220]            : ld1rw  +0xdc(%x28)[4byte] %p7/z -> %z27.d
 857fffff : ld1rw z31.d, p7/Z, [sp, #252]             : ld1rw  +0xfc(%sp)[4byte] %p7/z -> %z31.d
+
+# LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1SB-Z.P.BR-S16)
+a5c04000 : ld1sb z0.h, p0/Z, [x0, x0]                : ld1sb  (%x0,%x0)[16byte] %p0/z -> %z0.h
+a5c54482 : ld1sb z2.h, p1/Z, [x4, x5]                : ld1sb  (%x4,%x5)[16byte] %p1/z -> %z2.h
+a5c748c4 : ld1sb z4.h, p2/Z, [x6, x7]                : ld1sb  (%x6,%x7)[16byte] %p2/z -> %z4.h
+a5c94906 : ld1sb z6.h, p2/Z, [x8, x9]                : ld1sb  (%x8,%x9)[16byte] %p2/z -> %z6.h
+a5cb4d48 : ld1sb z8.h, p3/Z, [x10, x11]              : ld1sb  (%x10,%x11)[16byte] %p3/z -> %z8.h
+a5cc4d6a : ld1sb z10.h, p3/Z, [x11, x12]             : ld1sb  (%x11,%x12)[16byte] %p3/z -> %z10.h
+a5ce51ac : ld1sb z12.h, p4/Z, [x13, x14]             : ld1sb  (%x13,%x14)[16byte] %p4/z -> %z12.h
+a5d051ee : ld1sb z14.h, p4/Z, [x15, x16]             : ld1sb  (%x15,%x16)[16byte] %p4/z -> %z14.h
+a5d25630 : ld1sb z16.h, p5/Z, [x17, x18]             : ld1sb  (%x17,%x18)[16byte] %p5/z -> %z16.h
+a5d45671 : ld1sb z17.h, p5/Z, [x19, x20]             : ld1sb  (%x19,%x20)[16byte] %p5/z -> %z17.h
+a5d656b3 : ld1sb z19.h, p5/Z, [x21, x22]             : ld1sb  (%x21,%x22)[16byte] %p5/z -> %z19.h
+a5d85af5 : ld1sb z21.h, p6/Z, [x23, x24]             : ld1sb  (%x23,%x24)[16byte] %p6/z -> %z21.h
+a5d95b17 : ld1sb z23.h, p6/Z, [x24, x25]             : ld1sb  (%x24,%x25)[16byte] %p6/z -> %z23.h
+a5db5f59 : ld1sb z25.h, p7/Z, [x26, x27]             : ld1sb  (%x26,%x27)[16byte] %p7/z -> %z25.h
+a5dd5f9b : ld1sb z27.h, p7/Z, [x28, x29]             : ld1sb  (%x28,%x29)[16byte] %p7/z -> %z27.h
+a5de5fff : ld1sb z31.h, p7/Z, [sp, x30]              : ld1sb  (%sp,%x30)[16byte] %p7/z -> %z31.h
+
+# LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1SB-Z.P.BR-S32)
+a5a04000 : ld1sb z0.s, p0/Z, [x0, x0]                : ld1sb  (%x0,%x0)[8byte] %p0/z -> %z0.s
+a5a54482 : ld1sb z2.s, p1/Z, [x4, x5]                : ld1sb  (%x4,%x5)[8byte] %p1/z -> %z2.s
+a5a748c4 : ld1sb z4.s, p2/Z, [x6, x7]                : ld1sb  (%x6,%x7)[8byte] %p2/z -> %z4.s
+a5a94906 : ld1sb z6.s, p2/Z, [x8, x9]                : ld1sb  (%x8,%x9)[8byte] %p2/z -> %z6.s
+a5ab4d48 : ld1sb z8.s, p3/Z, [x10, x11]              : ld1sb  (%x10,%x11)[8byte] %p3/z -> %z8.s
+a5ac4d6a : ld1sb z10.s, p3/Z, [x11, x12]             : ld1sb  (%x11,%x12)[8byte] %p3/z -> %z10.s
+a5ae51ac : ld1sb z12.s, p4/Z, [x13, x14]             : ld1sb  (%x13,%x14)[8byte] %p4/z -> %z12.s
+a5b051ee : ld1sb z14.s, p4/Z, [x15, x16]             : ld1sb  (%x15,%x16)[8byte] %p4/z -> %z14.s
+a5b25630 : ld1sb z16.s, p5/Z, [x17, x18]             : ld1sb  (%x17,%x18)[8byte] %p5/z -> %z16.s
+a5b45671 : ld1sb z17.s, p5/Z, [x19, x20]             : ld1sb  (%x19,%x20)[8byte] %p5/z -> %z17.s
+a5b656b3 : ld1sb z19.s, p5/Z, [x21, x22]             : ld1sb  (%x21,%x22)[8byte] %p5/z -> %z19.s
+a5b85af5 : ld1sb z21.s, p6/Z, [x23, x24]             : ld1sb  (%x23,%x24)[8byte] %p6/z -> %z21.s
+a5b95b17 : ld1sb z23.s, p6/Z, [x24, x25]             : ld1sb  (%x24,%x25)[8byte] %p6/z -> %z23.s
+a5bb5f59 : ld1sb z25.s, p7/Z, [x26, x27]             : ld1sb  (%x26,%x27)[8byte] %p7/z -> %z25.s
+a5bd5f9b : ld1sb z27.s, p7/Z, [x28, x29]             : ld1sb  (%x28,%x29)[8byte] %p7/z -> %z27.s
+a5be5fff : ld1sb z31.s, p7/Z, [sp, x30]              : ld1sb  (%sp,%x30)[8byte] %p7/z -> %z31.s
+
+# LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1SB-Z.P.BR-S64)
+a5804000 : ld1sb z0.d, p0/Z, [x0, x0]                : ld1sb  (%x0,%x0)[4byte] %p0/z -> %z0.d
+a5854482 : ld1sb z2.d, p1/Z, [x4, x5]                : ld1sb  (%x4,%x5)[4byte] %p1/z -> %z2.d
+a58748c4 : ld1sb z4.d, p2/Z, [x6, x7]                : ld1sb  (%x6,%x7)[4byte] %p2/z -> %z4.d
+a5894906 : ld1sb z6.d, p2/Z, [x8, x9]                : ld1sb  (%x8,%x9)[4byte] %p2/z -> %z6.d
+a58b4d48 : ld1sb z8.d, p3/Z, [x10, x11]              : ld1sb  (%x10,%x11)[4byte] %p3/z -> %z8.d
+a58c4d6a : ld1sb z10.d, p3/Z, [x11, x12]             : ld1sb  (%x11,%x12)[4byte] %p3/z -> %z10.d
+a58e51ac : ld1sb z12.d, p4/Z, [x13, x14]             : ld1sb  (%x13,%x14)[4byte] %p4/z -> %z12.d
+a59051ee : ld1sb z14.d, p4/Z, [x15, x16]             : ld1sb  (%x15,%x16)[4byte] %p4/z -> %z14.d
+a5925630 : ld1sb z16.d, p5/Z, [x17, x18]             : ld1sb  (%x17,%x18)[4byte] %p5/z -> %z16.d
+a5945671 : ld1sb z17.d, p5/Z, [x19, x20]             : ld1sb  (%x19,%x20)[4byte] %p5/z -> %z17.d
+a59656b3 : ld1sb z19.d, p5/Z, [x21, x22]             : ld1sb  (%x21,%x22)[4byte] %p5/z -> %z19.d
+a5985af5 : ld1sb z21.d, p6/Z, [x23, x24]             : ld1sb  (%x23,%x24)[4byte] %p6/z -> %z21.d
+a5995b17 : ld1sb z23.d, p6/Z, [x24, x25]             : ld1sb  (%x24,%x25)[4byte] %p6/z -> %z23.d
+a59b5f59 : ld1sb z25.d, p7/Z, [x26, x27]             : ld1sb  (%x26,%x27)[4byte] %p7/z -> %z25.d
+a59d5f9b : ld1sb z27.d, p7/Z, [x28, x29]             : ld1sb  (%x28,%x29)[4byte] %p7/z -> %z27.d
+a59e5fff : ld1sb z31.d, p7/Z, [sp, x30]              : ld1sb  (%sp,%x30)[4byte] %p7/z -> %z31.d
 
 # LDFF1B  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, <Xm>}] (LDFF1B-Z.P.BR-U16)
 a4206000 : ldff1b z0.h, p0/Z, [x0, x0]               : ldff1b (%x0,%x0)[16byte] %p0/z -> %z0.h
@@ -10719,6 +10881,24 @@ a5797b17 : ldff1w z23.d, p6/Z, [x24, x25, LSL #2]    : ldff1w (%x24,%x25,lsl #2)
 a57b7f59 : ldff1w z25.d, p7/Z, [x26, x27, LSL #2]    : ldff1w (%x26,%x27,lsl #2)[16byte] %p7/z -> %z25.d
 a57d7f9b : ldff1w z27.d, p7/Z, [x28, x29, LSL #2]    : ldff1w (%x28,%x29,lsl #2)[16byte] %p7/z -> %z27.d
 a57e7fff : ldff1w z31.d, p7/Z, [sp, x30, LSL #2]     : ldff1w (%sp,%x30,lsl #2)[16byte] %p7/z -> %z31.d
+
+# LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LDNT1B-Z.P.BR-Contiguous)
+a400c000 : ldnt1b z0.b, p0/Z, [x0, x0]               : ldnt1b (%x0,%x0)[32byte] %p0/z -> %z0.b
+a405c482 : ldnt1b z2.b, p1/Z, [x4, x5]               : ldnt1b (%x4,%x5)[32byte] %p1/z -> %z2.b
+a407c8c4 : ldnt1b z4.b, p2/Z, [x6, x7]               : ldnt1b (%x6,%x7)[32byte] %p2/z -> %z4.b
+a409c906 : ldnt1b z6.b, p2/Z, [x8, x9]               : ldnt1b (%x8,%x9)[32byte] %p2/z -> %z6.b
+a40bcd48 : ldnt1b z8.b, p3/Z, [x10, x11]             : ldnt1b (%x10,%x11)[32byte] %p3/z -> %z8.b
+a40ccd6a : ldnt1b z10.b, p3/Z, [x11, x12]            : ldnt1b (%x11,%x12)[32byte] %p3/z -> %z10.b
+a40ed1ac : ldnt1b z12.b, p4/Z, [x13, x14]            : ldnt1b (%x13,%x14)[32byte] %p4/z -> %z12.b
+a410d1ee : ldnt1b z14.b, p4/Z, [x15, x16]            : ldnt1b (%x15,%x16)[32byte] %p4/z -> %z14.b
+a412d630 : ldnt1b z16.b, p5/Z, [x17, x18]            : ldnt1b (%x17,%x18)[32byte] %p5/z -> %z16.b
+a414d671 : ldnt1b z17.b, p5/Z, [x19, x20]            : ldnt1b (%x19,%x20)[32byte] %p5/z -> %z17.b
+a416d6b3 : ldnt1b z19.b, p5/Z, [x21, x22]            : ldnt1b (%x21,%x22)[32byte] %p5/z -> %z19.b
+a418daf5 : ldnt1b z21.b, p6/Z, [x23, x24]            : ldnt1b (%x23,%x24)[32byte] %p6/z -> %z21.b
+a419db17 : ldnt1b z23.b, p6/Z, [x24, x25]            : ldnt1b (%x24,%x25)[32byte] %p6/z -> %z23.b
+a41bdf59 : ldnt1b z25.b, p7/Z, [x26, x27]            : ldnt1b (%x26,%x27)[32byte] %p7/z -> %z25.b
+a41ddf9b : ldnt1b z27.b, p7/Z, [x28, x29]            : ldnt1b (%x28,%x29)[32byte] %p7/z -> %z27.b
+a41edfff : ldnt1b z31.b, p7/Z, [sp, x30]             : ldnt1b (%sp,%x30)[32byte] %p7/z -> %z31.b
 
 # LDR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
 858043c0 : ldr z0, [x30]                            : ldr    (%x30)[32byte] -> %z0
@@ -15606,6 +15786,90 @@ a57e7fff : ldff1w z31.d, p7/Z, [sp, x30, LSL #2]     : ldff1w (%sp,%x30,lsl #2)[
 04fa1b38 : sqsub z24.d, z25.d, z26.d                 : sqsub  %z25.d %z26.d -> %z24.d
 04fc1b7a : sqsub z26.d, z27.d, z28.d                 : sqsub  %z27.d %z28.d -> %z26.d
 04fe1bde : sqsub z30.d, z30.d, z30.d                 : sqsub  %z30.d %z30.d -> %z30.d
+
+# ST1B    { <Zt>.<T> }, <Pg>, [<Xn|SP>, <Xm>] (ST1B-Z.P.BR-_)
+e4004000 : st1b z0.b, p0, [x0, x0]                   : st1b   %z0.b %p0 -> (%x0,%x0)[32byte]
+e4054482 : st1b z2.b, p1, [x4, x5]                   : st1b   %z2.b %p1 -> (%x4,%x5)[32byte]
+e40748c4 : st1b z4.b, p2, [x6, x7]                   : st1b   %z4.b %p2 -> (%x6,%x7)[32byte]
+e4094906 : st1b z6.b, p2, [x8, x9]                   : st1b   %z6.b %p2 -> (%x8,%x9)[32byte]
+e40b4d48 : st1b z8.b, p3, [x10, x11]                 : st1b   %z8.b %p3 -> (%x10,%x11)[32byte]
+e40c4d6a : st1b z10.b, p3, [x11, x12]                : st1b   %z10.b %p3 -> (%x11,%x12)[32byte]
+e40e51ac : st1b z12.b, p4, [x13, x14]                : st1b   %z12.b %p4 -> (%x13,%x14)[32byte]
+e41051ee : st1b z14.b, p4, [x15, x16]                : st1b   %z14.b %p4 -> (%x15,%x16)[32byte]
+e4125630 : st1b z16.b, p5, [x17, x18]                : st1b   %z16.b %p5 -> (%x17,%x18)[32byte]
+e4145671 : st1b z17.b, p5, [x19, x20]                : st1b   %z17.b %p5 -> (%x19,%x20)[32byte]
+e41656b3 : st1b z19.b, p5, [x21, x22]                : st1b   %z19.b %p5 -> (%x21,%x22)[32byte]
+e4185af5 : st1b z21.b, p6, [x23, x24]                : st1b   %z21.b %p6 -> (%x23,%x24)[32byte]
+e4195b17 : st1b z23.b, p6, [x24, x25]                : st1b   %z23.b %p6 -> (%x24,%x25)[32byte]
+e41b5f59 : st1b z25.b, p7, [x26, x27]                : st1b   %z25.b %p7 -> (%x26,%x27)[32byte]
+e41d5f9b : st1b z27.b, p7, [x28, x29]                : st1b   %z27.b %p7 -> (%x28,%x29)[32byte]
+e41e5fff : st1b z31.b, p7, [sp, x30]                 : st1b   %z31.b %p7 -> (%sp,%x30)[32byte]
+e4204000 : st1b z0.h, p0, [x0, x0]                   : st1b   %z0.h %p0 -> (%x0,%x0)[16byte]
+e4254482 : st1b z2.h, p1, [x4, x5]                   : st1b   %z2.h %p1 -> (%x4,%x5)[16byte]
+e42748c4 : st1b z4.h, p2, [x6, x7]                   : st1b   %z4.h %p2 -> (%x6,%x7)[16byte]
+e4294906 : st1b z6.h, p2, [x8, x9]                   : st1b   %z6.h %p2 -> (%x8,%x9)[16byte]
+e42b4d48 : st1b z8.h, p3, [x10, x11]                 : st1b   %z8.h %p3 -> (%x10,%x11)[16byte]
+e42c4d6a : st1b z10.h, p3, [x11, x12]                : st1b   %z10.h %p3 -> (%x11,%x12)[16byte]
+e42e51ac : st1b z12.h, p4, [x13, x14]                : st1b   %z12.h %p4 -> (%x13,%x14)[16byte]
+e43051ee : st1b z14.h, p4, [x15, x16]                : st1b   %z14.h %p4 -> (%x15,%x16)[16byte]
+e4325630 : st1b z16.h, p5, [x17, x18]                : st1b   %z16.h %p5 -> (%x17,%x18)[16byte]
+e4345671 : st1b z17.h, p5, [x19, x20]                : st1b   %z17.h %p5 -> (%x19,%x20)[16byte]
+e43656b3 : st1b z19.h, p5, [x21, x22]                : st1b   %z19.h %p5 -> (%x21,%x22)[16byte]
+e4385af5 : st1b z21.h, p6, [x23, x24]                : st1b   %z21.h %p6 -> (%x23,%x24)[16byte]
+e4395b17 : st1b z23.h, p6, [x24, x25]                : st1b   %z23.h %p6 -> (%x24,%x25)[16byte]
+e43b5f59 : st1b z25.h, p7, [x26, x27]                : st1b   %z25.h %p7 -> (%x26,%x27)[16byte]
+e43d5f9b : st1b z27.h, p7, [x28, x29]                : st1b   %z27.h %p7 -> (%x28,%x29)[16byte]
+e43e5fff : st1b z31.h, p7, [sp, x30]                 : st1b   %z31.h %p7 -> (%sp,%x30)[16byte]
+e4404000 : st1b z0.s, p0, [x0, x0]                   : st1b   %z0.s %p0 -> (%x0,%x0)[8byte]
+e4454482 : st1b z2.s, p1, [x4, x5]                   : st1b   %z2.s %p1 -> (%x4,%x5)[8byte]
+e44748c4 : st1b z4.s, p2, [x6, x7]                   : st1b   %z4.s %p2 -> (%x6,%x7)[8byte]
+e4494906 : st1b z6.s, p2, [x8, x9]                   : st1b   %z6.s %p2 -> (%x8,%x9)[8byte]
+e44b4d48 : st1b z8.s, p3, [x10, x11]                 : st1b   %z8.s %p3 -> (%x10,%x11)[8byte]
+e44c4d6a : st1b z10.s, p3, [x11, x12]                : st1b   %z10.s %p3 -> (%x11,%x12)[8byte]
+e44e51ac : st1b z12.s, p4, [x13, x14]                : st1b   %z12.s %p4 -> (%x13,%x14)[8byte]
+e45051ee : st1b z14.s, p4, [x15, x16]                : st1b   %z14.s %p4 -> (%x15,%x16)[8byte]
+e4525630 : st1b z16.s, p5, [x17, x18]                : st1b   %z16.s %p5 -> (%x17,%x18)[8byte]
+e4545671 : st1b z17.s, p5, [x19, x20]                : st1b   %z17.s %p5 -> (%x19,%x20)[8byte]
+e45656b3 : st1b z19.s, p5, [x21, x22]                : st1b   %z19.s %p5 -> (%x21,%x22)[8byte]
+e4585af5 : st1b z21.s, p6, [x23, x24]                : st1b   %z21.s %p6 -> (%x23,%x24)[8byte]
+e4595b17 : st1b z23.s, p6, [x24, x25]                : st1b   %z23.s %p6 -> (%x24,%x25)[8byte]
+e45b5f59 : st1b z25.s, p7, [x26, x27]                : st1b   %z25.s %p7 -> (%x26,%x27)[8byte]
+e45d5f9b : st1b z27.s, p7, [x28, x29]                : st1b   %z27.s %p7 -> (%x28,%x29)[8byte]
+e45e5fff : st1b z31.s, p7, [sp, x30]                 : st1b   %z31.s %p7 -> (%sp,%x30)[8byte]
+e4604000 : st1b z0.d, p0, [x0, x0]                   : st1b   %z0.d %p0 -> (%x0,%x0)[4byte]
+e4654482 : st1b z2.d, p1, [x4, x5]                   : st1b   %z2.d %p1 -> (%x4,%x5)[4byte]
+e46748c4 : st1b z4.d, p2, [x6, x7]                   : st1b   %z4.d %p2 -> (%x6,%x7)[4byte]
+e4694906 : st1b z6.d, p2, [x8, x9]                   : st1b   %z6.d %p2 -> (%x8,%x9)[4byte]
+e46b4d48 : st1b z8.d, p3, [x10, x11]                 : st1b   %z8.d %p3 -> (%x10,%x11)[4byte]
+e46c4d6a : st1b z10.d, p3, [x11, x12]                : st1b   %z10.d %p3 -> (%x11,%x12)[4byte]
+e46e51ac : st1b z12.d, p4, [x13, x14]                : st1b   %z12.d %p4 -> (%x13,%x14)[4byte]
+e47051ee : st1b z14.d, p4, [x15, x16]                : st1b   %z14.d %p4 -> (%x15,%x16)[4byte]
+e4725630 : st1b z16.d, p5, [x17, x18]                : st1b   %z16.d %p5 -> (%x17,%x18)[4byte]
+e4745671 : st1b z17.d, p5, [x19, x20]                : st1b   %z17.d %p5 -> (%x19,%x20)[4byte]
+e47656b3 : st1b z19.d, p5, [x21, x22]                : st1b   %z19.d %p5 -> (%x21,%x22)[4byte]
+e4785af5 : st1b z21.d, p6, [x23, x24]                : st1b   %z21.d %p6 -> (%x23,%x24)[4byte]
+e4795b17 : st1b z23.d, p6, [x24, x25]                : st1b   %z23.d %p6 -> (%x24,%x25)[4byte]
+e47b5f59 : st1b z25.d, p7, [x26, x27]                : st1b   %z25.d %p7 -> (%x26,%x27)[4byte]
+e47d5f9b : st1b z27.d, p7, [x28, x29]                : st1b   %z27.d %p7 -> (%x28,%x29)[4byte]
+e47e5fff : st1b z31.d, p7, [sp, x30]                 : st1b   %z31.d %p7 -> (%sp,%x30)[4byte]
+
+# STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>] (STNT1B-Z.P.BR-Contiguous)
+e4006000 : stnt1b z0.b, p0, [x0, x0]                 : stnt1b %z0.b %p0 -> (%x0,%x0)[32byte]
+e4056482 : stnt1b z2.b, p1, [x4, x5]                 : stnt1b %z2.b %p1 -> (%x4,%x5)[32byte]
+e40768c4 : stnt1b z4.b, p2, [x6, x7]                 : stnt1b %z4.b %p2 -> (%x6,%x7)[32byte]
+e4096906 : stnt1b z6.b, p2, [x8, x9]                 : stnt1b %z6.b %p2 -> (%x8,%x9)[32byte]
+e40b6d48 : stnt1b z8.b, p3, [x10, x11]               : stnt1b %z8.b %p3 -> (%x10,%x11)[32byte]
+e40c6d6a : stnt1b z10.b, p3, [x11, x12]              : stnt1b %z10.b %p3 -> (%x11,%x12)[32byte]
+e40e71ac : stnt1b z12.b, p4, [x13, x14]              : stnt1b %z12.b %p4 -> (%x13,%x14)[32byte]
+e41071ee : stnt1b z14.b, p4, [x15, x16]              : stnt1b %z14.b %p4 -> (%x15,%x16)[32byte]
+e4127630 : stnt1b z16.b, p5, [x17, x18]              : stnt1b %z16.b %p5 -> (%x17,%x18)[32byte]
+e4147671 : stnt1b z17.b, p5, [x19, x20]              : stnt1b %z17.b %p5 -> (%x19,%x20)[32byte]
+e41676b3 : stnt1b z19.b, p5, [x21, x22]              : stnt1b %z19.b %p5 -> (%x21,%x22)[32byte]
+e4187af5 : stnt1b z21.b, p6, [x23, x24]              : stnt1b %z21.b %p6 -> (%x23,%x24)[32byte]
+e4197b17 : stnt1b z23.b, p6, [x24, x25]              : stnt1b %z23.b %p6 -> (%x24,%x25)[32byte]
+e41b7f59 : stnt1b z25.b, p7, [x26, x27]              : stnt1b %z25.b %p7 -> (%x26,%x27)[32byte]
+e41d7f9b : stnt1b z27.b, p7, [x28, x29]              : stnt1b %z27.b %p7 -> (%x28,%x29)[32byte]
+e41e7fff : stnt1b z31.b, p7, [sp, x30]               : stnt1b %z31.b %p7 -> (%sp,%x30)[32byte]
 
 # STR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
 e58043c0 : str z0, [x30]                            : str    %z0 -> (%x30)[32byte]

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -14101,6 +14101,256 @@ TEST_INSTR(fcmla_sve_idx)
               opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
 }
 
+TEST_INSTR(ld1b_sve_pred)
+{
+
+    /* Testing LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ld1b   (%x0,%x0)[16byte] %p0/z -> %z0.h",
+        "ld1b   (%x7,%x8)[16byte] %p2/z -> %z5.h",
+        "ld1b   (%x12,%x13)[16byte] %p3/z -> %z10.h",
+        "ld1b   (%x17,%x18)[16byte] %p5/z -> %z16.h",
+        "ld1b   (%x22,%x23)[16byte] %p6/z -> %z21.h",
+        "ld1b   (%sp,%x30)[16byte] %p7/z -> %z31.h",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_16));
+
+    /* Testing LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_1_0[6] = {
+        "ld1b   (%x0,%x0)[8byte] %p0/z -> %z0.s",
+        "ld1b   (%x7,%x8)[8byte] %p2/z -> %z5.s",
+        "ld1b   (%x12,%x13)[8byte] %p3/z -> %z10.s",
+        "ld1b   (%x17,%x18)[8byte] %p5/z -> %z16.s",
+        "ld1b   (%x22,%x23)[8byte] %p6/z -> %z21.s",
+        "ld1b   (%sp,%x30)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_8));
+
+    /* Testing LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_2_0[6] = {
+        "ld1b   (%x0,%x0)[4byte] %p0/z -> %z0.d",
+        "ld1b   (%x7,%x8)[4byte] %p2/z -> %z5.d",
+        "ld1b   (%x12,%x13)[4byte] %p3/z -> %z10.d",
+        "ld1b   (%x17,%x18)[4byte] %p5/z -> %z16.d",
+        "ld1b   (%x22,%x23)[4byte] %p6/z -> %z21.d",
+        "ld1b   (%sp,%x30)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4));
+
+    /* Testing LD1B    { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_3_0[6] = {
+        "ld1b   (%x0,%x0)[32byte] %p0/z -> %z0.b",
+        "ld1b   (%x7,%x8)[32byte] %p2/z -> %z5.b",
+        "ld1b   (%x12,%x13)[32byte] %p3/z -> %z10.b",
+        "ld1b   (%x17,%x18)[32byte] %p5/z -> %z16.b",
+        "ld1b   (%x22,%x23)[32byte] %p6/z -> %z21.b",
+        "ld1b   (%sp,%x30)[32byte] %p7/z -> %z31.b",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
+}
+
+TEST_INSTR(ld1rob_sve_pred)
+{
+
+    /* Testing LD1ROB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ld1rob (%x0,%x0)[32byte] %p0/z -> %z0.b",
+        "ld1rob (%x7,%x8)[32byte] %p2/z -> %z5.b",
+        "ld1rob (%x12,%x13)[32byte] %p3/z -> %z10.b",
+        "ld1rob (%x17,%x18)[32byte] %p5/z -> %z16.b",
+        "ld1rob (%x22,%x23)[32byte] %p6/z -> %z21.b",
+        "ld1rob (%sp,%x30)[32byte] %p7/z -> %z31.b",
+    };
+    TEST_LOOP(ld1rob, ld1rob_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
+}
+
+TEST_INSTR(ld1rqb_sve_pred)
+{
+
+    /* Testing LD1RQB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ld1rqb (%x0,%x0)[32byte] %p0/z -> %z0.b",
+        "ld1rqb (%x7,%x8)[32byte] %p2/z -> %z5.b",
+        "ld1rqb (%x12,%x13)[32byte] %p3/z -> %z10.b",
+        "ld1rqb (%x17,%x18)[32byte] %p5/z -> %z16.b",
+        "ld1rqb (%x22,%x23)[32byte] %p6/z -> %z21.b",
+        "ld1rqb (%sp,%x30)[32byte] %p7/z -> %z31.b",
+    };
+    TEST_LOOP(ld1rqb, ld1rqb_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
+}
+
+TEST_INSTR(ld1sb_sve_pred)
+{
+
+    /* Testing LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ld1sb  (%x0,%x0)[16byte] %p0/z -> %z0.h",
+        "ld1sb  (%x7,%x8)[16byte] %p2/z -> %z5.h",
+        "ld1sb  (%x12,%x13)[16byte] %p3/z -> %z10.h",
+        "ld1sb  (%x17,%x18)[16byte] %p5/z -> %z16.h",
+        "ld1sb  (%x22,%x23)[16byte] %p6/z -> %z21.h",
+        "ld1sb  (%sp,%x30)[16byte] %p7/z -> %z31.h",
+    };
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_16));
+
+    /* Testing LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_1_0[6] = {
+        "ld1sb  (%x0,%x0)[8byte] %p0/z -> %z0.s",
+        "ld1sb  (%x7,%x8)[8byte] %p2/z -> %z5.s",
+        "ld1sb  (%x12,%x13)[8byte] %p3/z -> %z10.s",
+        "ld1sb  (%x17,%x18)[8byte] %p5/z -> %z16.s",
+        "ld1sb  (%x22,%x23)[8byte] %p6/z -> %z21.s",
+        "ld1sb  (%sp,%x30)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_8));
+
+    /* Testing LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_2_0[6] = {
+        "ld1sb  (%x0,%x0)[4byte] %p0/z -> %z0.d",
+        "ld1sb  (%x7,%x8)[4byte] %p2/z -> %z5.d",
+        "ld1sb  (%x12,%x13)[4byte] %p3/z -> %z10.d",
+        "ld1sb  (%x17,%x18)[4byte] %p5/z -> %z16.d",
+        "ld1sb  (%x22,%x23)[4byte] %p6/z -> %z21.d",
+        "ld1sb  (%sp,%x30)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4));
+}
+
+TEST_INSTR(ldnt1b_sve_pred)
+{
+
+    /* Testing LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ldnt1b (%x0,%x0)[32byte] %p0/z -> %z0.b",
+        "ldnt1b (%x7,%x8)[32byte] %p2/z -> %z5.b",
+        "ldnt1b (%x12,%x13)[32byte] %p3/z -> %z10.b",
+        "ldnt1b (%x17,%x18)[32byte] %p5/z -> %z16.b",
+        "ldnt1b (%x22,%x23)[32byte] %p6/z -> %z21.b",
+        "ldnt1b (%sp,%x30)[32byte] %p7/z -> %z31.b",
+    };
+    TEST_LOOP(ldnt1b, ldnt1b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
+}
+
+TEST_INSTR(st1b_sve_pred)
+{
+
+    /* Testing ST1B    { <Zt>.<Ts> }, <Pg>, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "st1b   %z0.b %p0 -> (%x0,%x0)[32byte]",
+        "st1b   %z5.b %p2 -> (%x7,%x8)[32byte]",
+        "st1b   %z10.b %p3 -> (%x12,%x13)[32byte]",
+        "st1b   %z16.b %p5 -> (%x17,%x18)[32byte]",
+        "st1b   %z21.b %p6 -> (%x22,%x23)[32byte]",
+        "st1b   %z31.b %p7 -> (%sp,%x30)[32byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
+
+    const char *const expected_0_1[6] = {
+        "st1b   %z0.h %p0 -> (%x0,%x0)[16byte]",
+        "st1b   %z5.h %p2 -> (%x7,%x8)[16byte]",
+        "st1b   %z10.h %p3 -> (%x12,%x13)[16byte]",
+        "st1b   %z16.h %p5 -> (%x17,%x18)[16byte]",
+        "st1b   %z21.h %p6 -> (%x22,%x23)[16byte]",
+        "st1b   %z31.h %p7 -> (%sp,%x30)[16byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_16));
+
+    const char *const expected_0_2[6] = {
+        "st1b   %z0.s %p0 -> (%x0,%x0)[8byte]",
+        "st1b   %z5.s %p2 -> (%x7,%x8)[8byte]",
+        "st1b   %z10.s %p3 -> (%x12,%x13)[8byte]",
+        "st1b   %z16.s %p5 -> (%x17,%x18)[8byte]",
+        "st1b   %z21.s %p6 -> (%x22,%x23)[8byte]",
+        "st1b   %z31.s %p7 -> (%sp,%x30)[8byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_8));
+
+    const char *const expected_0_3[6] = {
+        "st1b   %z0.d %p0 -> (%x0,%x0)[4byte]",
+        "st1b   %z5.d %p2 -> (%x7,%x8)[4byte]",
+        "st1b   %z10.d %p3 -> (%x12,%x13)[4byte]",
+        "st1b   %z16.d %p5 -> (%x17,%x18)[4byte]",
+        "st1b   %z21.d %p6 -> (%x22,%x23)[4byte]",
+        "st1b   %z31.d %p7 -> (%sp,%x30)[4byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4));
+}
+
+TEST_INSTR(stnt1b_sve_pred)
+{
+
+    /* Testing STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "stnt1b %z0.b %p0 -> (%x0,%x0)[32byte]",
+        "stnt1b %z5.b %p2 -> (%x7,%x8)[32byte]",
+        "stnt1b %z10.b %p3 -> (%x12,%x13)[32byte]",
+        "stnt1b %z16.b %p5 -> (%x17,%x18)[32byte]",
+        "stnt1b %z21.b %p6 -> (%x22,%x23)[32byte]",
+        "stnt1b %z31.b %p7 -> (%sp,%x30)[32byte]",
+    };
+    TEST_LOOP(stnt1b, stnt1b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -14521,6 +14771,14 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(fcmla_sve_vector);
     RUN_INSTR_TEST(fcmla_sve_idx);
     RUN_INSTR_TEST(fcmla_sve_idx);
+
+    RUN_INSTR_TEST(ld1b_sve_pred);
+    RUN_INSTR_TEST(ld1rob_sve_pred);
+    RUN_INSTR_TEST(ld1rqb_sve_pred);
+    RUN_INSTR_TEST(ld1sb_sve_pred);
+    RUN_INSTR_TEST(ldnt1b_sve_pred);
+    RUN_INSTR_TEST(st1b_sve_pred);
+    RUN_INSTR_TEST(stnt1b_sve_pred);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1B    { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1ROB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1RQB  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>]
LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
ST1B    { <Zt>.<Ts> }, <Pg>, [<Xn|SP>, <Xm>]
STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>]
```
issues: #3044