### PR TITLE
i#3044 AArch64 SVE codec: v8.6 BFloat16 and matrix multiply instructions

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -59,6 +59,16 @@ read_feature_regs(uint64 isa_features[])
     MRS(ID_AA64PFR0_EL1, AA64PFR0, isa_features);
     MRS(ID_AA64MMFR1_EL1, AA64MMFR1, isa_features);
     MRS(ID_AA64DFR0_EL1, AA64DFR0, isa_features);
+
+    /* TODO i#3044: Can't use the MRS macro with id_aa64zfr0_el1 as current GCC
+     * binutils assembler fails to recognise it without -march=armv9-a+bf16+i8mm
+     * build option.
+     */
+    asm(".inst 0xd5380480\n" /* mrs x0, id_aa64zfr0_el1 */
+        "mov %0, x0"
+        : "=r"(isa_features[AA64ZFR0])
+        :
+        : "x0");
 }
 
 #    if !defined(MACOS) // TODO i#5383: Get this working on Mac. */
@@ -78,8 +88,8 @@ get_processor_specific_info(void)
     }
 
     /* Reads instruction attribute and preocessor feature registers
-     * ID_AA64ISAR0_EL1, ID_AA64ISAR1_EL1, ID_AA64PFR0_EL1, ID_AA64MMFR1_EL1
-     * and ID_AA64DFR0_EL1.
+     * ID_AA64ISAR0_EL1, ID_AA64ISAR1_EL1, ID_AA64PFR0_EL1, ID_AA64MMFR1_EL1,
+     * ID_AA64DFR0_EL1, ID_AA64ZFR0_EL1.
      */
     read_feature_regs(isa_features);
     cpu_info.features.flags_aa64isar0 = isa_features[AA64ISAR0];
@@ -87,6 +97,7 @@ get_processor_specific_info(void)
     cpu_info.features.flags_aa64pfr0 = isa_features[AA64PFR0];
     cpu_info.features.flags_aa64mmfr1 = isa_features[AA64MMFR1];
     cpu_info.features.flags_aa64dfr0 = isa_features[AA64DFR0];
+    cpu_info.features.flags_aa64zfr0 = isa_features[AA64ZFR0];
 
 #        if !defined(DR_HOST_NOT_TARGET) && defined(SVE)
     /* TODO i#3044: Vector length will be set by reading value from h/w. */
@@ -163,6 +174,11 @@ proc_init_arch(void)
         LOG_FEATURE(FEATURE_SPE);
         LOG_FEATURE(FEATURE_PAUTH);
         LOG_FEATURE(FEATURE_LRCPC);
+
+        LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64ZFR0_EL1 = 0x%016lx\n",
+            cpu_info.features.flags_aa64zfr0);
+        LOG_FEATURE(FEATURE_BF16);
+        LOG_FEATURE(FEATURE_I8MM);
     });
 #    endif
 #endif
@@ -185,7 +201,7 @@ proc_has_feature(feature_bit_t f)
         f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR ||
         f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4 || f == FEATURE_SHA512 ||
         f == FEATURE_SHA3 || f == FEATURE_RAS || f == FEATURE_SPE || f == FEATURE_PAUTH ||
-        f == FEATURE_LRCPC)
+        f == FEATURE_LRCPC || f == FEATURE_BF16 || f == FEATURE_I8MM)
         return true;
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;
@@ -212,6 +228,10 @@ proc_has_feature(feature_bit_t f)
         }
         case AA64DFR0: {
             freg_val = cpu_info.features.flags_aa64dfr0;
+            break;
+        }
+        case AA64ZFR0: {
+            freg_val = cpu_info.features.flags_aa64zfr0;
             break;
         }
         default: CLIENT_ASSERT(false, "proc_has_feature: feature register index error");

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -179,13 +179,15 @@ typedef struct {
     uint64 flags_aa64pfr0;  /**< AArch64 feature flags stored in ID_AA64PFR0_EL1 */
     uint64 flags_aa64mmfr1; /**< AArch64 feature flags stored in ID_AA64MMFR1_EL1 */
     uint64 flags_aa64dfr0;  /**< AArch64 feature flags stored in ID_AA64DFR0_EL1 */
+    uint64 flags_aa64zfr0;  /**< AArch64 feature flags stored in ID_AA64ZFR0_EL1 */
 } features_t;
 typedef enum {
     AA64ISAR0 = 0,
     AA64ISAR1 = 1,
     AA64PFR0 = 2,
     AA64MMFR1 = 3,
-    AA64DFR0 = 4
+    AA64DFR0 = 4,
+    AA64ZFR0 = 5,
 } feature_reg_idx_t;
 #endif
 #ifdef RISCV64
@@ -345,10 +347,12 @@ typedef enum {
     FEATURE_FP16 = DEF_FEAT(AA64PFR0, 4, 1, 1),      /**< Half-precision FP (AArch64) */
     FEATURE_RAS = DEF_FEAT(AA64PFR0, 7, 1, 0),       /**< RAS extension (AArch64) */
     FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 0),       /**< Scalable Vectors (AArch64) */
-    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 0),    /**< Limited order regions (AArch64) */
-    FEATURE_SPE = DEF_FEAT(AA64DFR0, 8, 1, 0),     /**< Profiling extension (AArch64) */
-    FEATURE_PAUTH = DEF_FEAT(AA64ISAR1, 8, 1, 0),  /**< PAuth extension (AArch64) */
-    FEATURE_LRCPC = DEF_FEAT(AA64ISAR1, 20, 1, 0), /**< LDAPR, LDAPRB, LDAPRH (AArch64) */
+    FEATURE_LOR = DEF_FEAT(AA64MMFR1, 4, 1, 0),   /**< Limited order regions (AArch64) */
+    FEATURE_SPE = DEF_FEAT(AA64DFR0, 8, 1, 0),    /**< Profiling extension (AArch64) */
+    FEATURE_PAUTH = DEF_FEAT(AA64ISAR1, 2, 1, 0), /**< PAuth extension (AArch64) */
+    FEATURE_LRCPC = DEF_FEAT(AA64ISAR1, 5, 1, 0), /**< LDAPR, LDAPRB, LDAPRH (AArch64) */
+    FEATURE_BF16 = DEF_FEAT(AA64ZFR0, 5, 1, 0),   /**< SVE BFloat16 */
+    FEATURE_I8MM = DEF_FEAT(AA64ZFR0, 11, 1, 0),  /**< SVE Int8 matrix multiplication */
 } feature_bit_t;
 #endif
 #ifdef RISCV64

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -3420,6 +3420,23 @@ encode_opnd_imm3(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_int(16, 3, false, 0, 0, opnd, enc_out);
 }
 
+/* z3_b_16: Z0-7 register with b size elements at position 16 */
+
+static inline bool
+decode_opnd_z3_b_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_Z0, 16, 3, BYTE_REG, enc, opnd);
+}
+
+static inline bool
+encode_opnd_z3_b_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    const reg_id_t reg = opnd_get_reg(opnd);
+    IF_RETURN_FALSE((reg < DR_REG_Z0) || (reg > DR_REG_Z7))
+
+    return encode_single_sized(OPSZ_SCALABLE, 16, BYTE_REG, opnd, enc_out);
+}
+
 /* z3_h_16: Z0-7 register with h size elements at position 16 */
 
 static inline bool
@@ -3947,6 +3964,27 @@ encode_opnd_i2_index_19(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *e
     return true;
 }
 
+/* i3_index_11: Index value from 20:19,11 */
+
+static inline bool
+decode_opnd_i3_index_11(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    const uint i3h = extract_uint(enc, 19, 2) << 1;
+    const uint i3l = extract_uint(enc, 11, 1);
+    *opnd = opnd_create_immed_uint(i3h | i3l, OPSZ_3b);
+    return true;
+}
+
+static inline bool
+encode_opnd_i3_index_11(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    IF_RETURN_FALSE(!opnd_is_immed_int(opnd))
+
+    const uint value = (uint)opnd_get_immed_int(opnd);
+    *enc_out = (BITS(value, 2, 1) << 19) | (BITS(value, 0, 0) << 11);
+    return true;
+}
+
 /* imm5: 5 bit immediate from 16-20 */
 
 static inline bool
@@ -4200,6 +4238,34 @@ static inline bool
 encode_opnd_z16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_vector_reg(16, Z_REG, opnd, enc_out);
+}
+
+/* z_b_16: Z register with b size elements. */
+
+static inline bool
+decode_opnd_z_b_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_Z0, 16, 5, BYTE_REG, enc, opnd);
+}
+
+static inline bool
+encode_opnd_z_b_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_single_sized(OPSZ_SCALABLE, 16, BYTE_REG, opnd, enc_out);
+}
+
+/* z_h_16: Z register with h size elements. */
+
+static inline bool
+decode_opnd_z_h_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_Z0, 16, 5, HALF_REG, enc, opnd);
+}
+
+static inline bool
+encode_opnd_z_h_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_single_sized(OPSZ_SCALABLE, 16, HALF_REG, opnd, enc_out);
 }
 
 /* z_q_16: Z register with d size elements. */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -62,6 +62,14 @@
 00000100xx1xxxxx100000xxxxxxxxxx  n   899  SVE      asr   z_size_bhs_0 : z_size_bhs_5 z_d_16
 00000100xx000100100xxxxxxxxxxxxx  n   900  SVE     asrd  z_tszl8_bhsd_0 : p10_mrg_lo z_tszl8_bhsd_0 tszl8_imm3_5p1
 00000100xx010100100xxxxxxxxxxxxx  n   901  SVE     asrr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
+0110010110001010101xxxxxxxxxxxxx  n   953  BF16   bfcvt          z_h_0 : p10_mrg_lo z_s_5
+01100100011xxxxx100000xxxxxxxxxx  n   954  BF16   bfdot          z_s_0 : z_s_0 z_h_5 z_h_16
+01100100011xxxxx010000xxxxxxxxxx  n   954  BF16   bfdot          z_s_0 : z_s_0 z_h_5 z3_h_16 i2_index_19
+01100100111xxxxx100000xxxxxxxxxx  n   955  BF16 bfmlalb          z_s_0 : z_s_0 z_h_5 z_h_16
+01100100111xxxxx0100x0xxxxxxxxxx  n   955  BF16 bfmlalb          z_s_0 : z_s_0 z_h_5 z3_h_16 i3_index_11
+01100100111xxxxx100001xxxxxxxxxx  n   956  BF16 bfmlalt          z_s_0 : z_s_0 z_h_5 z_h_16
+01100100111xxxxx0100x1xxxxxxxxxx  n   956  BF16 bfmlalt          z_s_0 : z_s_0 z_h_5 z3_h_16 i3_index_11
+01100100011xxxxx111001xxxxxxxxxx  n   957  BF16  bfmmla          z_s_0 : z_s_0 z_h_5 z_h_16
 00000100xx011011000xxxxxxxxxxxxx  n   29   SVE      bic             z0 : p10_lo z0 z5 bhsd_sz
 001001010000xxxx01xxxx0xxxx1xxxx  n   29   SVE      bic          p_b_0 : p10_zer p_b_5 p_b_16
 00000100111xxxxx001100xxxxxxxxxx  n   29   SVE      bic          z_d_0 : z_d_5 z_d_16
@@ -410,6 +418,7 @@
 0000010001001010001xxxxxxxxxxxxx  n   392  SVE    sminv             h0 : p10_lo z_size_bhsd_5
 0000010010001010001xxxxxxxxxxxxx  n   392  SVE    sminv             s0 : p10_lo z_size_bhsd_5
 0000010011001010001xxxxxxxxxxxxx  n   392  SVE    sminv             d0 : p10_lo z_size_bhsd_5
+01000101000xxxxx100110xxxxxxxxxx  n   958  I8MM   smmla          z_s_0 : z_s_0 z_b_5 z_b_16
 00000100xx010010000xxxxxxxxxxxxx  n   399  SVE    smulh  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000101xx101100100xxxxxxxxxxxxx  n   882  SVE   splice  z_size_bhsd_0 : p10_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx1xxxxx000100xxxxxxxxxx  n   403  SVE    sqadd             z0 : z5 z16 bhsd_sz
@@ -459,6 +468,7 @@
 00000100xx1xxxxx000001xxxxxxxxxx  n   470  SVE      sub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000100xx000011000xxxxxxxxxxxxx  n   784  SVE     subr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx10001111xxxxxxxxxxxxxx  n   784  SVE     subr  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
+01000100101xxxxx000111xxxxxxxxxx  n   959  I8MM   sudot          z_s_0 : z_s_0 z_b_5 z3_b_16 i2_index_19
 00000101xx110001001110xxxxxxxxxx  n   889  SVE  sunpkhi   z_size_hsd_0 : z_tb_bhs_5
 00000101xx110000001110xxxxxxxxxx  n   890  SVE  sunpklo   z_size_hsd_0 : z_tb_bhs_5
 00000100xx010000101xxxxxxxxxxxxx  n   799  SVE     sxtb   z_size_hsd_0 : p10_mrg_lo z_size_hsd_5
@@ -492,6 +502,7 @@
 0000010001001011001xxxxxxxxxxxxx  n   521  SVE    uminv             h0 : p10_lo z_size_bhsd_5
 0000010010001011001xxxxxxxxxxxxx  n   521  SVE    uminv             s0 : p10_lo z_size_bhsd_5
 0000010011001011001xxxxxxxxxxxxx  n   521  SVE    uminv             d0 : p10_lo z_size_bhsd_5
+01000101110xxxxx100110xxxxxxxxxx  n   960  I8MM   ummla          z_s_0 : z_s_0 z_b_5 z_b_16
 00000100xx010011000xxxxxxxxxxxxx  n   528  SVE    umulh  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx1xxxxx000101xxxxxxxxxx  n   531  SVE    uqadd             z0 : z5 z16 bhsd_sz
 00100101xx10010111xxxxxxxxxxxxxx  n   531  SVE    uqadd  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
@@ -527,6 +538,9 @@
 00000100xx1xxxxx000111xxxxxxxxxx  n   538  SVE    uqsub             z0 : z5 z16 bhsd_sz
 00100101xx10011111xxxxxxxxxxxxxx  n   538  SVE    uqsub  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000111xxxxxxxxxx  n   538  SVE    uqsub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+01000100100xxxxx011110xxxxxxxxxx  n   961  I8MM   usdot          z_s_0 : z_s_0 z_b_5 z_b_16
+01000100101xxxxx000110xxxxxxxxxx  n   961  I8MM   usdot          z_s_0 : z_s_0 z_b_5 z3_b_16 i2_index_19
+01000101100xxxxx100110xxxxxxxxxx  n   962  I8MM  usmmla          z_s_0 : z_s_0 z_b_5 z_b_16
 00000101xx110011001110xxxxxxxxxx  n   891  SVE  uunpkhi   z_size_hsd_0 : z_tb_bhs_5
 00000101xx110010001110xxxxxxxxxx  n   892  SVE  uunpklo   z_size_hsd_0 : z_tb_bhs_5
 00000100xx010001101xxxxxxxxxxxxx  n   802  SVE     uxtb   z_size_hsd_0 : p10_mrg_lo z_size_hsd_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -10934,4 +10934,219 @@
 #define INSTR_CREATE_stnt1b_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_stnt1b, Rn, Zt, Pg)
 
+/**
+ * Creates a BFCVT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFCVT   <Zd>.H, <Pg>/M, <Zn>.S
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_bfcvt_sve_pred(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_bfcvt, Zd, Pg, Zn)
+
+/**
+ * Creates a BFDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFDOT   <Zda>.S, <Zn>.H, <Zm>.H
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_bfdot_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_bfdot, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates a BFDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFDOT   <Zda>.S, <Zn>.H, <Zm>.H[<index>]
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Zn    The second source vector register, Z (Scalable).
+ * \param Zm    The third source vector register, Z (Scalable).
+ * \param index The immediate index
+ */
+#define INSTR_CREATE_bfdot_sve_idx(dc, Zda, Zn, Zm, index) \
+    instr_create_1dst_4src(dc, OP_bfdot, Zda, Zda, Zn, Zm, index)
+
+/**
+ * Creates a BFMLALB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFMLALB <Zda>.S, <Zn>.H, <Zm>.H
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_bfmlalb_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_bfmlalb, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates a BFMLALB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFMLALB <Zda>.S, <Zn>.H, <Zm>.H[<index>]
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Zn    The second source vector register, Z (Scalable).
+ * \param Zm    The third source vector register, Z (Scalable).
+ * \param index The immediate index
+ */
+#define INSTR_CREATE_bfmlalb_sve_idx(dc, Zda, Zn, Zm, index) \
+    instr_create_1dst_4src(dc, OP_bfmlalb, Zda, Zda, Zn, Zm, index)
+
+/**
+ * Creates a BFMLALT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFMLALT <Zda>.S, <Zn>.H, <Zm>.H
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_bfmlalt_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_bfmlalt, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates a BFMLALT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFMLALT <Zda>.S, <Zn>.H, <Zm>.H[<index>]
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Zn    The second source vector register, Z (Scalable).
+ * \param Zm    The third source vector register, Z (Scalable).
+ * \param index The immediate index
+ */
+#define INSTR_CREATE_bfmlalt_sve_idx(dc, Zda, Zn, Zm, index) \
+    instr_create_1dst_4src(dc, OP_bfmlalt, Zda, Zda, Zn, Zm, index)
+
+/**
+ * Creates a BFMMLA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFMMLA  <Zda>.S, <Zn>.H, <Zm>.H
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_bfmmla_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_bfmmla, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates a SMMLA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SMMLA   <Zda>.S, <Zn>.B, <Zm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_smmla_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_smmla, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates a SUDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SUDOT   <Zda>.S, <Zn>.B, <Zm>.B[<index>]
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Zn    The second source vector register, Z (Scalable).
+ * \param Zm    The third source vector register, Z (Scalable).
+ * \param index The immediate index
+ */
+#define INSTR_CREATE_sudot_sve_idx(dc, Zda, Zn, Zm, index) \
+    instr_create_1dst_4src(dc, OP_sudot, Zda, Zda, Zn, Zm, index)
+
+/**
+ * Creates an UMMLA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UMMLA   <Zda>.S, <Zn>.B, <Zm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_ummla_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_ummla, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates an USDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    USDOT   <Zda>.S, <Zn>.B, <Zm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_usdot_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_usdot, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates an USDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    USDOT   <Zda>.S, <Zn>.B, <Zm>.B[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ * \param index The immediate index
+ */
+#define INSTR_CREATE_usdot_sve_idx(dc, Zda, Zn, Zm, index) \
+    instr_create_1dst_4src(dc, OP_usdot, Zda, Zda, Zn, Zm, index)
+
+/**
+ * Creates an USMMLA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    USMMLA  <Zda>.S, <Zn>.B, <Zm>.B
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_usmmla_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_usmmla, Zda, Zda, Zn, Zm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -162,6 +162,7 @@
 --------------?------??????xxxxx  z_imm13_bhsd_0 # sve vector reg, elsz depending on size value encoded within an 13 bit immediate from 5-17
 --------------xxxxxxxxxxxxx-----  imm13_const # Const value within a 13 bit immediate from 5-17
 -------------xxx----------------  imm3       # 3 bit immediate from 16-18
+-------------xxx----------------  z3_b_16    # Z0-7 register with b size elements at position 16
 -------------xxx----------------  z3_h_16    # Z0-7 register with h size elements at position 16
 -------------xxx----------------  z3_s_16    # Z0-7 register with s size elements at position 16
 -------------xxx--------xxx-----  pstate     # Pstate encoded in op1:op2
@@ -183,6 +184,7 @@
 -----------?????------xxxxx-----  wx5_imm5   # reg 5-9 d or q is inferred from bits 16:20
 -----------x--------------------  i1_index_20 # Index value from 20
 -----------xx-------------------  i2_index_19 # Index value from 20:19
+-----------xx-------x-----------  i3_index_11 # Index value from 20:19,11
 -----------xxxxx----------------  imm5       # 5 bit immediate from 16-20
 -----------xxxxx----------------  simm5      # Signed 5 bit immediate from 16-20
 -----------xxxxx----------------  bhs_imm5_sz_s # Size encoded as least significant bit in imm5
@@ -198,6 +200,8 @@
 -----------xxxxx----------------  d16        # D register
 -----------xxxxx----------------  q16        # Q register
 -----------xxxxx----------------  z16        # Z register
+-----------xxxxx----------------  z_b_16     # Z register with b size elements
+-----------xxxxx----------------  z_h_16     # Z register with h size elements
 -----------xxxxx----------------  z_d_16     # Z register with d size elements
 -----------xxxxx----------------  z_q_16     # Z register with q size elements
 -----------xxxxx----------------  b16        # B register

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -966,6 +966,150 @@
 04d49fbb : asrr z27.d, p7/M, z27.d, z29.d            : asrr   %p7/m %z27.d %z29.d -> %z27.d
 04d49fff : asrr z31.d, p7/M, z31.d, z31.d            : asrr   %p7/m %z31.d %z31.d -> %z31.d
 
+# BFCVT   <Zd>.H, <Pg>/M, <Zn>.S (BFCVT-Z.P.Z-S2BF)
+658aa000 : bfcvt z0.h, p0/M, z0.s                    : bfcvt  %p0/m %z0.s -> %z0.h
+658aa482 : bfcvt z2.h, p1/M, z4.s                    : bfcvt  %p1/m %z4.s -> %z2.h
+658aa8c4 : bfcvt z4.h, p2/M, z6.s                    : bfcvt  %p2/m %z6.s -> %z4.h
+658aa906 : bfcvt z6.h, p2/M, z8.s                    : bfcvt  %p2/m %z8.s -> %z6.h
+658aad48 : bfcvt z8.h, p3/M, z10.s                   : bfcvt  %p3/m %z10.s -> %z8.h
+658aad8a : bfcvt z10.h, p3/M, z12.s                  : bfcvt  %p3/m %z12.s -> %z10.h
+658ab1cc : bfcvt z12.h, p4/M, z14.s                  : bfcvt  %p4/m %z14.s -> %z12.h
+658ab20e : bfcvt z14.h, p4/M, z16.s                  : bfcvt  %p4/m %z16.s -> %z14.h
+658ab650 : bfcvt z16.h, p5/M, z18.s                  : bfcvt  %p5/m %z18.s -> %z16.h
+658ab671 : bfcvt z17.h, p5/M, z19.s                  : bfcvt  %p5/m %z19.s -> %z17.h
+658ab6b3 : bfcvt z19.h, p5/M, z21.s                  : bfcvt  %p5/m %z21.s -> %z19.h
+658abaf5 : bfcvt z21.h, p6/M, z23.s                  : bfcvt  %p6/m %z23.s -> %z21.h
+658abb37 : bfcvt z23.h, p6/M, z25.s                  : bfcvt  %p6/m %z25.s -> %z23.h
+658abf79 : bfcvt z25.h, p7/M, z27.s                  : bfcvt  %p7/m %z27.s -> %z25.h
+658abfbb : bfcvt z27.h, p7/M, z29.s                  : bfcvt  %p7/m %z29.s -> %z27.h
+658abfff : bfcvt z31.h, p7/M, z31.s                  : bfcvt  %p7/m %z31.s -> %z31.h
+
+# BFDOT   <Zda>.S, <Zn>.H, <Zm>.H (BFDOT-Z.ZZZ-_)
+64608000 : bfdot z0.s, z0.h, z0.h                    : bfdot  %z0.s %z0.h %z0.h -> %z0.s
+64648062 : bfdot z2.s, z3.h, z4.h                    : bfdot  %z2.s %z3.h %z4.h -> %z2.s
+646680a4 : bfdot z4.s, z5.h, z6.h                    : bfdot  %z4.s %z5.h %z6.h -> %z4.s
+646880e6 : bfdot z6.s, z7.h, z8.h                    : bfdot  %z6.s %z7.h %z8.h -> %z6.s
+646a8128 : bfdot z8.s, z9.h, z10.h                   : bfdot  %z8.s %z9.h %z10.h -> %z8.s
+646c816a : bfdot z10.s, z11.h, z12.h                 : bfdot  %z10.s %z11.h %z12.h -> %z10.s
+646e81ac : bfdot z12.s, z13.h, z14.h                 : bfdot  %z12.s %z13.h %z14.h -> %z12.s
+647081ee : bfdot z14.s, z15.h, z16.h                 : bfdot  %z14.s %z15.h %z16.h -> %z14.s
+64728230 : bfdot z16.s, z17.h, z18.h                 : bfdot  %z16.s %z17.h %z18.h -> %z16.s
+64738251 : bfdot z17.s, z18.h, z19.h                 : bfdot  %z17.s %z18.h %z19.h -> %z17.s
+64758293 : bfdot z19.s, z20.h, z21.h                 : bfdot  %z19.s %z20.h %z21.h -> %z19.s
+647782d5 : bfdot z21.s, z22.h, z23.h                 : bfdot  %z21.s %z22.h %z23.h -> %z21.s
+64798317 : bfdot z23.s, z24.h, z25.h                 : bfdot  %z23.s %z24.h %z25.h -> %z23.s
+647b8359 : bfdot z25.s, z26.h, z27.h                 : bfdot  %z25.s %z26.h %z27.h -> %z25.s
+647d839b : bfdot z27.s, z28.h, z29.h                 : bfdot  %z27.s %z28.h %z29.h -> %z27.s
+647f83ff : bfdot z31.s, z31.h, z31.h                 : bfdot  %z31.s %z31.h %z31.h -> %z31.s
+
+# BFDOT   <Zda>.S, <Zn>.H, <Zm>.H[<imm>] (BFDOT-Z.ZZZi-_)
+64604000 : bfdot z0.s, z0.h, z0.h[0]                 : bfdot  %z0.s %z0.h %z0.h $0x00 -> %z0.s
+64624062 : bfdot z2.s, z3.h, z2.h[0]                 : bfdot  %z2.s %z3.h %z2.h $0x00 -> %z2.s
+646340a4 : bfdot z4.s, z5.h, z3.h[0]                 : bfdot  %z4.s %z5.h %z3.h $0x00 -> %z4.s
+646b40e6 : bfdot z6.s, z7.h, z3.h[1]                 : bfdot  %z6.s %z7.h %z3.h $0x01 -> %z6.s
+646c4128 : bfdot z8.s, z9.h, z4.h[1]                 : bfdot  %z8.s %z9.h %z4.h $0x01 -> %z8.s
+646c416a : bfdot z10.s, z11.h, z4.h[1]               : bfdot  %z10.s %z11.h %z4.h $0x01 -> %z10.s
+646d41ac : bfdot z12.s, z13.h, z5.h[1]               : bfdot  %z12.s %z13.h %z5.h $0x01 -> %z12.s
+646d41ee : bfdot z14.s, z15.h, z5.h[1]               : bfdot  %z14.s %z15.h %z5.h $0x01 -> %z14.s
+64764230 : bfdot z16.s, z17.h, z6.h[2]               : bfdot  %z16.s %z17.h %z6.h $0x02 -> %z16.s
+64764251 : bfdot z17.s, z18.h, z6.h[2]               : bfdot  %z17.s %z18.h %z6.h $0x02 -> %z17.s
+64764293 : bfdot z19.s, z20.h, z6.h[2]               : bfdot  %z19.s %z20.h %z6.h $0x02 -> %z19.s
+647742d5 : bfdot z21.s, z22.h, z7.h[2]               : bfdot  %z21.s %z22.h %z7.h $0x02 -> %z21.s
+64774317 : bfdot z23.s, z24.h, z7.h[2]               : bfdot  %z23.s %z24.h %z7.h $0x02 -> %z23.s
+64704359 : bfdot z25.s, z26.h, z0.h[2]               : bfdot  %z25.s %z26.h %z0.h $0x02 -> %z25.s
+6478439b : bfdot z27.s, z28.h, z0.h[3]               : bfdot  %z27.s %z28.h %z0.h $0x03 -> %z27.s
+647f43ff : bfdot z31.s, z31.h, z7.h[3]               : bfdot  %z31.s %z31.h %z7.h $0x03 -> %z31.s
+
+# BFMLALB <Zda>.S, <Zn>.H, <Zm>.H (BFMLALB-Z.ZZZ-_)
+64e08000 : bfmlalb z0.s, z0.h, z0.h                  : bfmlalb %z0.s %z0.h %z0.h -> %z0.s
+64e48062 : bfmlalb z2.s, z3.h, z4.h                  : bfmlalb %z2.s %z3.h %z4.h -> %z2.s
+64e680a4 : bfmlalb z4.s, z5.h, z6.h                  : bfmlalb %z4.s %z5.h %z6.h -> %z4.s
+64e880e6 : bfmlalb z6.s, z7.h, z8.h                  : bfmlalb %z6.s %z7.h %z8.h -> %z6.s
+64ea8128 : bfmlalb z8.s, z9.h, z10.h                 : bfmlalb %z8.s %z9.h %z10.h -> %z8.s
+64ec816a : bfmlalb z10.s, z11.h, z12.h               : bfmlalb %z10.s %z11.h %z12.h -> %z10.s
+64ee81ac : bfmlalb z12.s, z13.h, z14.h               : bfmlalb %z12.s %z13.h %z14.h -> %z12.s
+64f081ee : bfmlalb z14.s, z15.h, z16.h               : bfmlalb %z14.s %z15.h %z16.h -> %z14.s
+64f28230 : bfmlalb z16.s, z17.h, z18.h               : bfmlalb %z16.s %z17.h %z18.h -> %z16.s
+64f38251 : bfmlalb z17.s, z18.h, z19.h               : bfmlalb %z17.s %z18.h %z19.h -> %z17.s
+64f58293 : bfmlalb z19.s, z20.h, z21.h               : bfmlalb %z19.s %z20.h %z21.h -> %z19.s
+64f782d5 : bfmlalb z21.s, z22.h, z23.h               : bfmlalb %z21.s %z22.h %z23.h -> %z21.s
+64f98317 : bfmlalb z23.s, z24.h, z25.h               : bfmlalb %z23.s %z24.h %z25.h -> %z23.s
+64fb8359 : bfmlalb z25.s, z26.h, z27.h               : bfmlalb %z25.s %z26.h %z27.h -> %z25.s
+64fd839b : bfmlalb z27.s, z28.h, z29.h               : bfmlalb %z27.s %z28.h %z29.h -> %z27.s
+64ff83ff : bfmlalb z31.s, z31.h, z31.h               : bfmlalb %z31.s %z31.h %z31.h -> %z31.s
+
+# BFMLALB <Zda>.S, <Zn>.H, <Zm>.H[<imm>] (BFMLALB-Z.ZZZi-_)
+64e04000 : bfmlalb z0.s, z0.h, z0.h[0]               : bfmlalb %z0.s %z0.h %z0.h $0x00 -> %z0.s
+64e24062 : bfmlalb z2.s, z3.h, z2.h[0]               : bfmlalb %z2.s %z3.h %z2.h $0x00 -> %z2.s
+64e348a4 : bfmlalb z4.s, z5.h, z3.h[1]               : bfmlalb %z4.s %z5.h %z3.h $0x01 -> %z4.s
+64e348e6 : bfmlalb z6.s, z7.h, z3.h[1]               : bfmlalb %z6.s %z7.h %z3.h $0x01 -> %z6.s
+64ec4128 : bfmlalb z8.s, z9.h, z4.h[2]               : bfmlalb %z8.s %z9.h %z4.h $0x02 -> %z8.s
+64ec416a : bfmlalb z10.s, z11.h, z4.h[2]             : bfmlalb %z10.s %z11.h %z4.h $0x02 -> %z10.s
+64ed49ac : bfmlalb z12.s, z13.h, z5.h[3]             : bfmlalb %z12.s %z13.h %z5.h $0x03 -> %z12.s
+64ed49ee : bfmlalb z14.s, z15.h, z5.h[3]             : bfmlalb %z14.s %z15.h %z5.h $0x03 -> %z14.s
+64f64230 : bfmlalb z16.s, z17.h, z6.h[4]             : bfmlalb %z16.s %z17.h %z6.h $0x04 -> %z16.s
+64f64251 : bfmlalb z17.s, z18.h, z6.h[4]             : bfmlalb %z17.s %z18.h %z6.h $0x04 -> %z17.s
+64f64293 : bfmlalb z19.s, z20.h, z6.h[4]             : bfmlalb %z19.s %z20.h %z6.h $0x04 -> %z19.s
+64f74ad5 : bfmlalb z21.s, z22.h, z7.h[5]             : bfmlalb %z21.s %z22.h %z7.h $0x05 -> %z21.s
+64f74b17 : bfmlalb z23.s, z24.h, z7.h[5]             : bfmlalb %z23.s %z24.h %z7.h $0x05 -> %z23.s
+64f84359 : bfmlalb z25.s, z26.h, z0.h[6]             : bfmlalb %z25.s %z26.h %z0.h $0x06 -> %z25.s
+64f8439b : bfmlalb z27.s, z28.h, z0.h[6]             : bfmlalb %z27.s %z28.h %z0.h $0x06 -> %z27.s
+64ff4bff : bfmlalb z31.s, z31.h, z7.h[7]             : bfmlalb %z31.s %z31.h %z7.h $0x07 -> %z31.s
+
+# BFMLALT <Zda>.S, <Zn>.H, <Zm>.H (BFMLALT-Z.ZZZ-_)
+64e08400 : bfmlalt z0.s, z0.h, z0.h                  : bfmlalt %z0.s %z0.h %z0.h -> %z0.s
+64e48462 : bfmlalt z2.s, z3.h, z4.h                  : bfmlalt %z2.s %z3.h %z4.h -> %z2.s
+64e684a4 : bfmlalt z4.s, z5.h, z6.h                  : bfmlalt %z4.s %z5.h %z6.h -> %z4.s
+64e884e6 : bfmlalt z6.s, z7.h, z8.h                  : bfmlalt %z6.s %z7.h %z8.h -> %z6.s
+64ea8528 : bfmlalt z8.s, z9.h, z10.h                 : bfmlalt %z8.s %z9.h %z10.h -> %z8.s
+64ec856a : bfmlalt z10.s, z11.h, z12.h               : bfmlalt %z10.s %z11.h %z12.h -> %z10.s
+64ee85ac : bfmlalt z12.s, z13.h, z14.h               : bfmlalt %z12.s %z13.h %z14.h -> %z12.s
+64f085ee : bfmlalt z14.s, z15.h, z16.h               : bfmlalt %z14.s %z15.h %z16.h -> %z14.s
+64f28630 : bfmlalt z16.s, z17.h, z18.h               : bfmlalt %z16.s %z17.h %z18.h -> %z16.s
+64f38651 : bfmlalt z17.s, z18.h, z19.h               : bfmlalt %z17.s %z18.h %z19.h -> %z17.s
+64f58693 : bfmlalt z19.s, z20.h, z21.h               : bfmlalt %z19.s %z20.h %z21.h -> %z19.s
+64f786d5 : bfmlalt z21.s, z22.h, z23.h               : bfmlalt %z21.s %z22.h %z23.h -> %z21.s
+64f98717 : bfmlalt z23.s, z24.h, z25.h               : bfmlalt %z23.s %z24.h %z25.h -> %z23.s
+64fb8759 : bfmlalt z25.s, z26.h, z27.h               : bfmlalt %z25.s %z26.h %z27.h -> %z25.s
+64fd879b : bfmlalt z27.s, z28.h, z29.h               : bfmlalt %z27.s %z28.h %z29.h -> %z27.s
+64ff87ff : bfmlalt z31.s, z31.h, z31.h               : bfmlalt %z31.s %z31.h %z31.h -> %z31.s
+
+# BFMLALT <Zda>.S, <Zn>.H, <Zm>.H[<imm>] (BFMLALT-Z.ZZZi-_)
+64e04400 : bfmlalt z0.s, z0.h, z0.h[0]               : bfmlalt %z0.s %z0.h %z0.h $0x00 -> %z0.s
+64e24462 : bfmlalt z2.s, z3.h, z2.h[0]               : bfmlalt %z2.s %z3.h %z2.h $0x00 -> %z2.s
+64e34ca4 : bfmlalt z4.s, z5.h, z3.h[1]               : bfmlalt %z4.s %z5.h %z3.h $0x01 -> %z4.s
+64e34ce6 : bfmlalt z6.s, z7.h, z3.h[1]               : bfmlalt %z6.s %z7.h %z3.h $0x01 -> %z6.s
+64ec4528 : bfmlalt z8.s, z9.h, z4.h[2]               : bfmlalt %z8.s %z9.h %z4.h $0x02 -> %z8.s
+64ec456a : bfmlalt z10.s, z11.h, z4.h[2]             : bfmlalt %z10.s %z11.h %z4.h $0x02 -> %z10.s
+64ed4dac : bfmlalt z12.s, z13.h, z5.h[3]             : bfmlalt %z12.s %z13.h %z5.h $0x03 -> %z12.s
+64ed4dee : bfmlalt z14.s, z15.h, z5.h[3]             : bfmlalt %z14.s %z15.h %z5.h $0x03 -> %z14.s
+64f64630 : bfmlalt z16.s, z17.h, z6.h[4]             : bfmlalt %z16.s %z17.h %z6.h $0x04 -> %z16.s
+64f64651 : bfmlalt z17.s, z18.h, z6.h[4]             : bfmlalt %z17.s %z18.h %z6.h $0x04 -> %z17.s
+64f64693 : bfmlalt z19.s, z20.h, z6.h[4]             : bfmlalt %z19.s %z20.h %z6.h $0x04 -> %z19.s
+64f74ed5 : bfmlalt z21.s, z22.h, z7.h[5]             : bfmlalt %z21.s %z22.h %z7.h $0x05 -> %z21.s
+64f74f17 : bfmlalt z23.s, z24.h, z7.h[5]             : bfmlalt %z23.s %z24.h %z7.h $0x05 -> %z23.s
+64f84759 : bfmlalt z25.s, z26.h, z0.h[6]             : bfmlalt %z25.s %z26.h %z0.h $0x06 -> %z25.s
+64f8479b : bfmlalt z27.s, z28.h, z0.h[6]             : bfmlalt %z27.s %z28.h %z0.h $0x06 -> %z27.s
+64ff4fff : bfmlalt z31.s, z31.h, z7.h[7]             : bfmlalt %z31.s %z31.h %z7.h $0x07 -> %z31.s
+
+# BFMMLA  <Zda>.S, <Zn>.H, <Zm>.H (BFMMLA-Z.ZZZ-_)
+6460e400 : bfmmla z0.s, z0.h, z0.h                   : bfmmla %z0.s %z0.h %z0.h -> %z0.s
+6464e462 : bfmmla z2.s, z3.h, z4.h                   : bfmmla %z2.s %z3.h %z4.h -> %z2.s
+6466e4a4 : bfmmla z4.s, z5.h, z6.h                   : bfmmla %z4.s %z5.h %z6.h -> %z4.s
+6468e4e6 : bfmmla z6.s, z7.h, z8.h                   : bfmmla %z6.s %z7.h %z8.h -> %z6.s
+646ae528 : bfmmla z8.s, z9.h, z10.h                  : bfmmla %z8.s %z9.h %z10.h -> %z8.s
+646ce56a : bfmmla z10.s, z11.h, z12.h                : bfmmla %z10.s %z11.h %z12.h -> %z10.s
+646ee5ac : bfmmla z12.s, z13.h, z14.h                : bfmmla %z12.s %z13.h %z14.h -> %z12.s
+6470e5ee : bfmmla z14.s, z15.h, z16.h                : bfmmla %z14.s %z15.h %z16.h -> %z14.s
+6472e630 : bfmmla z16.s, z17.h, z18.h                : bfmmla %z16.s %z17.h %z18.h -> %z16.s
+6473e651 : bfmmla z17.s, z18.h, z19.h                : bfmmla %z17.s %z18.h %z19.h -> %z17.s
+6475e693 : bfmmla z19.s, z20.h, z21.h                : bfmmla %z19.s %z20.h %z21.h -> %z19.s
+6477e6d5 : bfmmla z21.s, z22.h, z23.h                : bfmmla %z21.s %z22.h %z23.h -> %z21.s
+6479e717 : bfmmla z23.s, z24.h, z25.h                : bfmmla %z23.s %z24.h %z25.h -> %z23.s
+647be759 : bfmmla z25.s, z26.h, z27.h                : bfmmla %z25.s %z26.h %z27.h -> %z25.s
+647de79b : bfmmla z27.s, z28.h, z29.h                : bfmmla %z27.s %z28.h %z29.h -> %z27.s
+647fe7ff : bfmmla z31.s, z31.h, z31.h                : bfmmla %z31.s %z31.h %z31.h -> %z31.s
+
 041b0b02 : bic z2.b, p2/m, z2.b, z24.b              : bic    %p2 %z2 %z24 $0x00 -> %z2
 045b0b02 : bic z2.h, p2/m, z2.h, z24.h              : bic    %p2 %z2 %z24 $0x01 -> %z2
 049b0b02 : bic z2.s, p2/m, z2.s, z24.s              : bic    %p2 %z2 %z24 $0x02 -> %z2
@@ -14279,6 +14423,24 @@ a41edfff : ldnt1b z31.b, p7/Z, [sp, x30]             : ldnt1b (%sp,%x30)[32byte]
 04ca3fbb : sminv d27, p7, z29.d                      : sminv  %p7 %z29.d -> %d27
 04ca3fff : sminv d31, p7, z31.d                      : sminv  %p7 %z31.d -> %d31
 
+# SMMLA   <Zda>.S, <Zn>.B, <Zm>.B (SMMLA-Z.ZZZ-_)
+45009800 : smmla z0.s, z0.b, z0.b                    : smmla  %z0.s %z0.b %z0.b -> %z0.s
+45049862 : smmla z2.s, z3.b, z4.b                    : smmla  %z2.s %z3.b %z4.b -> %z2.s
+450698a4 : smmla z4.s, z5.b, z6.b                    : smmla  %z4.s %z5.b %z6.b -> %z4.s
+450898e6 : smmla z6.s, z7.b, z8.b                    : smmla  %z6.s %z7.b %z8.b -> %z6.s
+450a9928 : smmla z8.s, z9.b, z10.b                   : smmla  %z8.s %z9.b %z10.b -> %z8.s
+450c996a : smmla z10.s, z11.b, z12.b                 : smmla  %z10.s %z11.b %z12.b -> %z10.s
+450e99ac : smmla z12.s, z13.b, z14.b                 : smmla  %z12.s %z13.b %z14.b -> %z12.s
+451099ee : smmla z14.s, z15.b, z16.b                 : smmla  %z14.s %z15.b %z16.b -> %z14.s
+45129a30 : smmla z16.s, z17.b, z18.b                 : smmla  %z16.s %z17.b %z18.b -> %z16.s
+45139a51 : smmla z17.s, z18.b, z19.b                 : smmla  %z17.s %z18.b %z19.b -> %z17.s
+45159a93 : smmla z19.s, z20.b, z21.b                 : smmla  %z19.s %z20.b %z21.b -> %z19.s
+45179ad5 : smmla z21.s, z22.b, z23.b                 : smmla  %z21.s %z22.b %z23.b -> %z21.s
+45199b17 : smmla z23.s, z24.b, z25.b                 : smmla  %z23.s %z24.b %z25.b -> %z23.s
+451b9b59 : smmla z25.s, z26.b, z27.b                 : smmla  %z25.s %z26.b %z27.b -> %z25.s
+451d9b9b : smmla z27.s, z28.b, z29.b                 : smmla  %z27.s %z28.b %z29.b -> %z27.s
+451f9bff : smmla z31.s, z31.b, z31.b                 : smmla  %z31.s %z31.b %z31.b -> %z31.s
+
 # SMULH   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SMULH-Z.P.ZZ-_)
 04120000 : smulh z0.b, p0/M, z0.b, z0.b              : smulh  %p0/m %z0.b %z0.b -> %z0.b
 04120482 : smulh z2.b, p1/M, z2.b, z4.b              : smulh  %p1/m %z2.b %z4.b -> %z2.b
@@ -16301,6 +16463,24 @@ e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x4b(%x15)
 25e3dbfa : subr z26.d, z26.d, #0xdf, lsl #0          : subr   %z26.d $0xdf lsl $0x00 -> %z26.d
 25e3dffe : subr z30.d, z30.d, #0xff, lsl #0          : subr   %z30.d $0xff lsl $0x00 -> %z30.d
 
+# SUDOT   <Zda>.S, <Zn>.B, <Zm>.B[<imm>] (SUDOT-Z.ZZZi-S)
+44a01c00 : sudot z0.s, z0.b, z0.b[0]                 : sudot  %z0.s %z0.b %z0.b $0x00 -> %z0.s
+44a21c62 : sudot z2.s, z3.b, z2.b[0]                 : sudot  %z2.s %z3.b %z2.b $0x00 -> %z2.s
+44a31ca4 : sudot z4.s, z5.b, z3.b[0]                 : sudot  %z4.s %z5.b %z3.b $0x00 -> %z4.s
+44ab1ce6 : sudot z6.s, z7.b, z3.b[1]                 : sudot  %z6.s %z7.b %z3.b $0x01 -> %z6.s
+44ac1d28 : sudot z8.s, z9.b, z4.b[1]                 : sudot  %z8.s %z9.b %z4.b $0x01 -> %z8.s
+44ac1d6a : sudot z10.s, z11.b, z4.b[1]               : sudot  %z10.s %z11.b %z4.b $0x01 -> %z10.s
+44ad1dac : sudot z12.s, z13.b, z5.b[1]               : sudot  %z12.s %z13.b %z5.b $0x01 -> %z12.s
+44ad1dee : sudot z14.s, z15.b, z5.b[1]               : sudot  %z14.s %z15.b %z5.b $0x01 -> %z14.s
+44b61e30 : sudot z16.s, z17.b, z6.b[2]               : sudot  %z16.s %z17.b %z6.b $0x02 -> %z16.s
+44b61e51 : sudot z17.s, z18.b, z6.b[2]               : sudot  %z17.s %z18.b %z6.b $0x02 -> %z17.s
+44b61e93 : sudot z19.s, z20.b, z6.b[2]               : sudot  %z19.s %z20.b %z6.b $0x02 -> %z19.s
+44b71ed5 : sudot z21.s, z22.b, z7.b[2]               : sudot  %z21.s %z22.b %z7.b $0x02 -> %z21.s
+44b71f17 : sudot z23.s, z24.b, z7.b[2]               : sudot  %z23.s %z24.b %z7.b $0x02 -> %z23.s
+44b01f59 : sudot z25.s, z26.b, z0.b[2]               : sudot  %z25.s %z26.b %z0.b $0x02 -> %z25.s
+44b81f9b : sudot z27.s, z28.b, z0.b[3]               : sudot  %z27.s %z28.b %z0.b $0x03 -> %z27.s
+44bf1fff : sudot z31.s, z31.b, z7.b[3]               : sudot  %z31.s %z31.b %z7.b $0x03 -> %z31.s
+
 # SUNPKHI <Zd>.<T>, <Zn>.<Tb> (SUNPKHI-Z.Z-_)
 05713800 : sunpkhi z0.h, z0.b                        : sunpkhi %z0.b -> %z0.h
 05713862 : sunpkhi z2.h, z3.b                        : sunpkhi %z3.b -> %z2.h
@@ -17554,6 +17734,24 @@ e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x4b(%x15)
 04cb3f79 : uminv d25, p7, z27.d                      : uminv  %p7 %z27.d -> %d25
 04cb3fbb : uminv d27, p7, z29.d                      : uminv  %p7 %z29.d -> %d27
 04cb3fff : uminv d31, p7, z31.d                      : uminv  %p7 %z31.d -> %d31
+
+# UMMLA   <Zda>.S, <Zn>.B, <Zm>.B (UMMLA-Z.ZZZ-_)
+45c09800 : ummla z0.s, z0.b, z0.b                    : ummla  %z0.s %z0.b %z0.b -> %z0.s
+45c49862 : ummla z2.s, z3.b, z4.b                    : ummla  %z2.s %z3.b %z4.b -> %z2.s
+45c698a4 : ummla z4.s, z5.b, z6.b                    : ummla  %z4.s %z5.b %z6.b -> %z4.s
+45c898e6 : ummla z6.s, z7.b, z8.b                    : ummla  %z6.s %z7.b %z8.b -> %z6.s
+45ca9928 : ummla z8.s, z9.b, z10.b                   : ummla  %z8.s %z9.b %z10.b -> %z8.s
+45cc996a : ummla z10.s, z11.b, z12.b                 : ummla  %z10.s %z11.b %z12.b -> %z10.s
+45ce99ac : ummla z12.s, z13.b, z14.b                 : ummla  %z12.s %z13.b %z14.b -> %z12.s
+45d099ee : ummla z14.s, z15.b, z16.b                 : ummla  %z14.s %z15.b %z16.b -> %z14.s
+45d29a30 : ummla z16.s, z17.b, z18.b                 : ummla  %z16.s %z17.b %z18.b -> %z16.s
+45d39a51 : ummla z17.s, z18.b, z19.b                 : ummla  %z17.s %z18.b %z19.b -> %z17.s
+45d59a93 : ummla z19.s, z20.b, z21.b                 : ummla  %z19.s %z20.b %z21.b -> %z19.s
+45d79ad5 : ummla z21.s, z22.b, z23.b                 : ummla  %z21.s %z22.b %z23.b -> %z21.s
+45d99b17 : ummla z23.s, z24.b, z25.b                 : ummla  %z23.s %z24.b %z25.b -> %z23.s
+45db9b59 : ummla z25.s, z26.b, z27.b                 : ummla  %z25.s %z26.b %z27.b -> %z25.s
+45dd9b9b : ummla z27.s, z28.b, z29.b                 : ummla  %z27.s %z28.b %z29.b -> %z27.s
+45df9bff : ummla z31.s, z31.b, z31.b                 : ummla  %z31.s %z31.b %z31.b -> %z31.s
 
 # UMULH   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (UMULH-Z.P.ZZ-_)
 04130000 : umulh z0.b, p0/M, z0.b, z0.b              : umulh  %p0/m %z0.b %z0.b -> %z0.b
@@ -18996,6 +19194,60 @@ e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x4b(%x15)
 04fa1f38 : uqsub z24.d, z25.d, z26.d                 : uqsub  %z25.d %z26.d -> %z24.d
 04fc1f7a : uqsub z26.d, z27.d, z28.d                 : uqsub  %z27.d %z28.d -> %z26.d
 04fe1fde : uqsub z30.d, z30.d, z30.d                 : uqsub  %z30.d %z30.d -> %z30.d
+
+# USDOT   <Zda>.S, <Zn>.B, <Zm>.B (USDOT-Z.ZZZ-S)
+44807800 : usdot z0.s, z0.b, z0.b                    : usdot  %z0.s %z0.b %z0.b -> %z0.s
+44847862 : usdot z2.s, z3.b, z4.b                    : usdot  %z2.s %z3.b %z4.b -> %z2.s
+448678a4 : usdot z4.s, z5.b, z6.b                    : usdot  %z4.s %z5.b %z6.b -> %z4.s
+448878e6 : usdot z6.s, z7.b, z8.b                    : usdot  %z6.s %z7.b %z8.b -> %z6.s
+448a7928 : usdot z8.s, z9.b, z10.b                   : usdot  %z8.s %z9.b %z10.b -> %z8.s
+448c796a : usdot z10.s, z11.b, z12.b                 : usdot  %z10.s %z11.b %z12.b -> %z10.s
+448e79ac : usdot z12.s, z13.b, z14.b                 : usdot  %z12.s %z13.b %z14.b -> %z12.s
+449079ee : usdot z14.s, z15.b, z16.b                 : usdot  %z14.s %z15.b %z16.b -> %z14.s
+44927a30 : usdot z16.s, z17.b, z18.b                 : usdot  %z16.s %z17.b %z18.b -> %z16.s
+44937a51 : usdot z17.s, z18.b, z19.b                 : usdot  %z17.s %z18.b %z19.b -> %z17.s
+44957a93 : usdot z19.s, z20.b, z21.b                 : usdot  %z19.s %z20.b %z21.b -> %z19.s
+44977ad5 : usdot z21.s, z22.b, z23.b                 : usdot  %z21.s %z22.b %z23.b -> %z21.s
+44997b17 : usdot z23.s, z24.b, z25.b                 : usdot  %z23.s %z24.b %z25.b -> %z23.s
+449b7b59 : usdot z25.s, z26.b, z27.b                 : usdot  %z25.s %z26.b %z27.b -> %z25.s
+449d7b9b : usdot z27.s, z28.b, z29.b                 : usdot  %z27.s %z28.b %z29.b -> %z27.s
+449f7bff : usdot z31.s, z31.b, z31.b                 : usdot  %z31.s %z31.b %z31.b -> %z31.s
+
+# USDOT   <Zda>.S, <Zn>.B, <Zm>.B[<imm>] (USDOT-Z.ZZZi-S)
+44a01800 : usdot z0.s, z0.b, z0.b[0]                 : usdot  %z0.s %z0.b %z0.b $0x00 -> %z0.s
+44a21862 : usdot z2.s, z3.b, z2.b[0]                 : usdot  %z2.s %z3.b %z2.b $0x00 -> %z2.s
+44a318a4 : usdot z4.s, z5.b, z3.b[0]                 : usdot  %z4.s %z5.b %z3.b $0x00 -> %z4.s
+44ab18e6 : usdot z6.s, z7.b, z3.b[1]                 : usdot  %z6.s %z7.b %z3.b $0x01 -> %z6.s
+44ac1928 : usdot z8.s, z9.b, z4.b[1]                 : usdot  %z8.s %z9.b %z4.b $0x01 -> %z8.s
+44ac196a : usdot z10.s, z11.b, z4.b[1]               : usdot  %z10.s %z11.b %z4.b $0x01 -> %z10.s
+44ad19ac : usdot z12.s, z13.b, z5.b[1]               : usdot  %z12.s %z13.b %z5.b $0x01 -> %z12.s
+44ad19ee : usdot z14.s, z15.b, z5.b[1]               : usdot  %z14.s %z15.b %z5.b $0x01 -> %z14.s
+44b61a30 : usdot z16.s, z17.b, z6.b[2]               : usdot  %z16.s %z17.b %z6.b $0x02 -> %z16.s
+44b61a51 : usdot z17.s, z18.b, z6.b[2]               : usdot  %z17.s %z18.b %z6.b $0x02 -> %z17.s
+44b61a93 : usdot z19.s, z20.b, z6.b[2]               : usdot  %z19.s %z20.b %z6.b $0x02 -> %z19.s
+44b71ad5 : usdot z21.s, z22.b, z7.b[2]               : usdot  %z21.s %z22.b %z7.b $0x02 -> %z21.s
+44b71b17 : usdot z23.s, z24.b, z7.b[2]               : usdot  %z23.s %z24.b %z7.b $0x02 -> %z23.s
+44b01b59 : usdot z25.s, z26.b, z0.b[2]               : usdot  %z25.s %z26.b %z0.b $0x02 -> %z25.s
+44b81b9b : usdot z27.s, z28.b, z0.b[3]               : usdot  %z27.s %z28.b %z0.b $0x03 -> %z27.s
+44bf1bff : usdot z31.s, z31.b, z7.b[3]               : usdot  %z31.s %z31.b %z7.b $0x03 -> %z31.s
+
+# USMMLA  <Zda>.S, <Zn>.B, <Zm>.B (USMMLA-Z.ZZZ-_)
+45809800 : usmmla z0.s, z0.b, z0.b                   : usmmla %z0.s %z0.b %z0.b -> %z0.s
+45849862 : usmmla z2.s, z3.b, z4.b                   : usmmla %z2.s %z3.b %z4.b -> %z2.s
+458698a4 : usmmla z4.s, z5.b, z6.b                   : usmmla %z4.s %z5.b %z6.b -> %z4.s
+458898e6 : usmmla z6.s, z7.b, z8.b                   : usmmla %z6.s %z7.b %z8.b -> %z6.s
+458a9928 : usmmla z8.s, z9.b, z10.b                  : usmmla %z8.s %z9.b %z10.b -> %z8.s
+458c996a : usmmla z10.s, z11.b, z12.b                : usmmla %z10.s %z11.b %z12.b -> %z10.s
+458e99ac : usmmla z12.s, z13.b, z14.b                : usmmla %z12.s %z13.b %z14.b -> %z12.s
+459099ee : usmmla z14.s, z15.b, z16.b                : usmmla %z14.s %z15.b %z16.b -> %z14.s
+45929a30 : usmmla z16.s, z17.b, z18.b                : usmmla %z16.s %z17.b %z18.b -> %z16.s
+45939a51 : usmmla z17.s, z18.b, z19.b                : usmmla %z17.s %z18.b %z19.b -> %z17.s
+45959a93 : usmmla z19.s, z20.b, z21.b                : usmmla %z19.s %z20.b %z21.b -> %z19.s
+45979ad5 : usmmla z21.s, z22.b, z23.b                : usmmla %z21.s %z22.b %z23.b -> %z21.s
+45999b17 : usmmla z23.s, z24.b, z25.b                : usmmla %z23.s %z24.b %z25.b -> %z23.s
+459b9b59 : usmmla z25.s, z26.b, z27.b                : usmmla %z25.s %z26.b %z27.b -> %z25.s
+459d9b9b : usmmla z27.s, z28.b, z29.b                : usmmla %z27.s %z28.b %z29.b -> %z27.s
+459f9bff : usmmla z31.s, z31.b, z31.b                : usmmla %z31.s %z31.b %z31.b -> %z31.s
 
 # UUNPKHI <Zd>.<T>, <Zn>.<Tb> (UUNPKHI-Z.Z-_)
 05733800 : uunpkhi z0.h, z0.b                        : uunpkhi %z0.b -> %z0.h

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -14351,6 +14351,245 @@ TEST_INSTR(stnt1b_sve_pred)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
 }
 
+TEST_INSTR(bfcvt_sve_pred)
+{
+    /* Testing BFCVT   <Zd>.H, <Pg>/M, <Zn>.S */
+    const char *const expected_0_0[6] = {
+        "bfcvt  %p0/m %z0.s -> %z0.h",   "bfcvt  %p2/m %z7.s -> %z5.h",
+        "bfcvt  %p3/m %z12.s -> %z10.h", "bfcvt  %p5/m %z18.s -> %z16.h",
+        "bfcvt  %p6/m %z23.s -> %z21.h", "bfcvt  %p7/m %z31.s -> %z31.h",
+    };
+    TEST_LOOP(bfcvt, bfcvt_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+}
+
+TEST_INSTR(bfdot_sve)
+{
+    /* Testing BFDOT   <Zda>.S, <Zn>.H, <Zm>.H */
+    const char *const expected_0_0[6] = {
+        "bfdot  %z0.s %z0.h %z0.h -> %z0.s",     "bfdot  %z5.s %z6.h %z7.h -> %z5.s",
+        "bfdot  %z10.s %z11.h %z12.h -> %z10.s", "bfdot  %z16.s %z17.h %z18.h -> %z16.s",
+        "bfdot  %z21.s %z22.h %z23.h -> %z21.s", "bfdot  %z31.s %z31.h %z31.h -> %z31.s",
+    };
+    TEST_LOOP(bfdot, bfdot_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+}
+
+TEST_INSTR(bfdot_sve_idx)
+{
+    /* Testing BFDOT   <Zda>.S, <Zn>.H, <Zm>.H[<index>] */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_0_0[6] = { 0, 3, 0, 1, 1, 3 };
+    const char *const expected_0_0[6] = {
+        "bfdot  %z0.s %z0.h %z0.h $0x00 -> %z0.s",
+        "bfdot  %z5.s %z6.h %z3.h $0x03 -> %z5.s",
+        "bfdot  %z10.s %z11.h %z4.h $0x00 -> %z10.s",
+        "bfdot  %z16.s %z17.h %z6.h $0x01 -> %z16.s",
+        "bfdot  %z21.s %z22.h %z7.h $0x01 -> %z21.s",
+        "bfdot  %z31.s %z31.h %z7.h $0x03 -> %z31.s",
+    };
+    TEST_LOOP(bfdot, bfdot_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_immed_uint(i2_0_0[i], OPSZ_2b));
+}
+
+TEST_INSTR(bfmlalb_sve)
+{
+    /* Testing BFMLALB <Zda>.S, <Zn>.H, <Zm>.H */
+    const char *const expected_0_0[6] = {
+        "bfmlalb %z0.s %z0.h %z0.h -> %z0.s",
+        "bfmlalb %z5.s %z6.h %z7.h -> %z5.s",
+        "bfmlalb %z10.s %z11.h %z12.h -> %z10.s",
+        "bfmlalb %z16.s %z17.h %z18.h -> %z16.s",
+        "bfmlalb %z21.s %z22.h %z23.h -> %z21.s",
+        "bfmlalb %z31.s %z31.h %z31.h -> %z31.s",
+    };
+    TEST_LOOP(bfmlalb, bfmlalb_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+}
+
+TEST_INSTR(bfmlalb_sve_idx)
+{
+    /* Testing BFMLALB <Zda>.S, <Zn>.H, <Zm>.H[<index>] */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i3_0_0[6] = { 0, 4, 5, 7, 0, 7 };
+    const char *const expected_0_0[6] = {
+        "bfmlalb %z0.s %z0.h %z0.h $0x00 -> %z0.s",
+        "bfmlalb %z5.s %z6.h %z3.h $0x04 -> %z5.s",
+        "bfmlalb %z10.s %z11.h %z4.h $0x05 -> %z10.s",
+        "bfmlalb %z16.s %z17.h %z6.h $0x07 -> %z16.s",
+        "bfmlalb %z21.s %z22.h %z7.h $0x00 -> %z21.s",
+        "bfmlalb %z31.s %z31.h %z7.h $0x07 -> %z31.s",
+    };
+    TEST_LOOP(bfmlalb, bfmlalb_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_immed_uint(i3_0_0[i], OPSZ_3b));
+}
+
+TEST_INSTR(bfmlalt_sve)
+{
+    /* Testing BFMLALT <Zda>.S, <Zn>.H, <Zm>.H */
+    const char *const expected_0_0[6] = {
+        "bfmlalt %z0.s %z0.h %z0.h -> %z0.s",
+        "bfmlalt %z5.s %z6.h %z7.h -> %z5.s",
+        "bfmlalt %z10.s %z11.h %z12.h -> %z10.s",
+        "bfmlalt %z16.s %z17.h %z18.h -> %z16.s",
+        "bfmlalt %z21.s %z22.h %z23.h -> %z21.s",
+        "bfmlalt %z31.s %z31.h %z31.h -> %z31.s",
+    };
+    TEST_LOOP(bfmlalt, bfmlalt_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+}
+
+TEST_INSTR(bfmlalt_sve_idx)
+{
+    /* Testing BFMLALT <Zda>.S, <Zn>.H, <Zm>.H[<index>] */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i3_0_0[6] = { 0, 4, 5, 7, 0, 7 };
+    const char *const expected_0_0[6] = {
+        "bfmlalt %z0.s %z0.h %z0.h $0x00 -> %z0.s",
+        "bfmlalt %z5.s %z6.h %z3.h $0x04 -> %z5.s",
+        "bfmlalt %z10.s %z11.h %z4.h $0x05 -> %z10.s",
+        "bfmlalt %z16.s %z17.h %z6.h $0x07 -> %z16.s",
+        "bfmlalt %z21.s %z22.h %z7.h $0x00 -> %z21.s",
+        "bfmlalt %z31.s %z31.h %z7.h $0x07 -> %z31.s",
+    };
+    TEST_LOOP(bfmlalt, bfmlalt_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_immed_uint(i3_0_0[i], OPSZ_3b));
+}
+
+TEST_INSTR(bfmmla_sve)
+{
+    /* Testing BFMMLA  <Zda>.S, <Zn>.H, <Zm>.H */
+    const char *const expected_0_0[6] = {
+        "bfmmla %z0.s %z0.h %z0.h -> %z0.s",     "bfmmla %z5.s %z6.h %z7.h -> %z5.s",
+        "bfmmla %z10.s %z11.h %z12.h -> %z10.s", "bfmmla %z16.s %z17.h %z18.h -> %z16.s",
+        "bfmmla %z21.s %z22.h %z23.h -> %z21.s", "bfmmla %z31.s %z31.h %z31.h -> %z31.s",
+    };
+    TEST_LOOP(bfmmla, bfmmla_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+}
+
+TEST_INSTR(smmla_sve)
+{
+
+    /* Testing SMMLA   <Zda>.S, <Zn>.B, <Zm>.B */
+    const char *const expected_0_0[6] = {
+        "smmla  %z0.s %z0.b %z0.b -> %z0.s",     "smmla  %z5.s %z6.b %z7.b -> %z5.s",
+        "smmla  %z10.s %z11.b %z12.b -> %z10.s", "smmla  %z16.s %z17.b %z18.b -> %z16.s",
+        "smmla  %z21.s %z22.b %z23.b -> %z21.s", "smmla  %z31.s %z31.b %z31.b -> %z31.s",
+    };
+    TEST_LOOP(smmla, smmla_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+}
+
+TEST_INSTR(sudot_sve_idx)
+{
+    /* Testing SUDOT   <Zda>.S, <Zn>.B, <Zm>.B[<index>] */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_0_0[6] = { 0, 3, 0, 1, 1, 3 };
+    const char *const expected_0_0[6] = {
+        "sudot  %z0.s %z0.b %z0.b $0x00 -> %z0.s",
+        "sudot  %z5.s %z6.b %z3.b $0x03 -> %z5.s",
+        "sudot  %z10.s %z11.b %z4.b $0x00 -> %z10.s",
+        "sudot  %z16.s %z17.b %z6.b $0x01 -> %z16.s",
+        "sudot  %z21.s %z22.b %z7.b $0x01 -> %z21.s",
+        "sudot  %z31.s %z31.b %z7.b $0x03 -> %z31.s",
+    };
+    TEST_LOOP(sudot, sudot_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1),
+              opnd_create_immed_uint(i2_0_0[i], OPSZ_2b));
+}
+
+TEST_INSTR(ummla_sve)
+{
+    /* Testing UMMLA   <Zda>.S, <Zn>.B, <Zm>.B */
+    const char *const expected_0_0[6] = {
+        "ummla  %z0.s %z0.b %z0.b -> %z0.s",     "ummla  %z5.s %z6.b %z7.b -> %z5.s",
+        "ummla  %z10.s %z11.b %z12.b -> %z10.s", "ummla  %z16.s %z17.b %z18.b -> %z16.s",
+        "ummla  %z21.s %z22.b %z23.b -> %z21.s", "ummla  %z31.s %z31.b %z31.b -> %z31.s",
+    };
+    TEST_LOOP(ummla, ummla_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+}
+
+TEST_INSTR(usdot_sve)
+{
+    /* Testing USDOT   <Zda>.S, <Zn>.B, <Zm>.B */
+    const char *const expected_0_0[6] = {
+        "usdot  %z0.s %z0.b %z0.b -> %z0.s",     "usdot  %z5.s %z6.b %z7.b -> %z5.s",
+        "usdot  %z10.s %z11.b %z12.b -> %z10.s", "usdot  %z16.s %z17.b %z18.b -> %z16.s",
+        "usdot  %z21.s %z22.b %z23.b -> %z21.s", "usdot  %z31.s %z31.b %z31.b -> %z31.s",
+    };
+    TEST_LOOP(usdot, usdot_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+}
+
+TEST_INSTR(usdot_sve_idx)
+{
+    /* Testing USDOT   <Zda>.S, <Zn>.B, <Zm>.B[<index>] */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_0_0[6] = { 0, 3, 0, 1, 1, 3 };
+    const char *const expected_0_0[6] = {
+        "usdot  %z0.s %z0.b %z0.b $0x00 -> %z0.s",
+        "usdot  %z5.s %z6.b %z3.b $0x03 -> %z5.s",
+        "usdot  %z10.s %z11.b %z4.b $0x00 -> %z10.s",
+        "usdot  %z16.s %z17.b %z6.b $0x01 -> %z16.s",
+        "usdot  %z21.s %z22.b %z7.b $0x01 -> %z21.s",
+        "usdot  %z31.s %z31.b %z7.b $0x03 -> %z31.s",
+    };
+    TEST_LOOP(usdot, usdot_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_1),
+              opnd_create_immed_uint(i2_0_0[i], OPSZ_2b));
+}
+
+TEST_INSTR(usmmla_sve)
+{
+
+    /* Testing USMMLA  <Zda>.S, <Zn>.B, <Zm>.B */
+    const char *const expected_0_0[6] = {
+        "usmmla %z0.s %z0.b %z0.b -> %z0.s",     "usmmla %z5.s %z6.b %z7.b -> %z5.s",
+        "usmmla %z10.s %z11.b %z12.b -> %z10.s", "usmmla %z16.s %z17.b %z18.b -> %z16.s",
+        "usmmla %z21.s %z22.b %z23.b -> %z21.s", "usmmla %z31.s %z31.b %z31.b -> %z31.s",
+    };
+    TEST_LOOP(usmmla, usmmla_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -14770,7 +15009,6 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(fcmla_sve_vector);
     RUN_INSTR_TEST(fcmla_sve_idx);
-    RUN_INSTR_TEST(fcmla_sve_idx);
 
     RUN_INSTR_TEST(ld1b_sve_pred);
     RUN_INSTR_TEST(ld1rob_sve_pred);
@@ -14779,6 +15017,22 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ldnt1b_sve_pred);
     RUN_INSTR_TEST(st1b_sve_pred);
     RUN_INSTR_TEST(stnt1b_sve_pred);
+
+    RUN_INSTR_TEST(bfcvt_sve_pred);
+    RUN_INSTR_TEST(bfdot_sve);
+    RUN_INSTR_TEST(bfdot_sve_idx);
+    RUN_INSTR_TEST(bfmlalb_sve);
+    RUN_INSTR_TEST(bfmlalb_sve_idx);
+    RUN_INSTR_TEST(bfmlalt_sve);
+    RUN_INSTR_TEST(bfmlalt_sve_idx);
+    RUN_INSTR_TEST(bfmmla_sve);
+
+    RUN_INSTR_TEST(smmla_sve);
+    RUN_INSTR_TEST(sudot_sve_idx);
+    RUN_INSTR_TEST(ummla_sve);
+    RUN_INSTR_TEST(usdot_sve);
+    RUN_INSTR_TEST(usdot_sve_idx);
+    RUN_INSTR_TEST(usmmla_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
BFCVT   <Zd>.H, <Pg>/M, <Zn>.S
BFDOT   <Zda>.S, <Zn>.H, <Zm>.H
BFDOT   <Zda>.S, <Zn>.H, <Zm>.H[<index>]
BFMLALB <Zda>.S, <Zn>.H, <Zm>.H
BFMLALB <Zda>.S, <Zn>.H, <Zm>.H[<index>]
BFMLALT <Zda>.S, <Zn>.H, <Zm>.H
BFMLALT <Zda>.S, <Zn>.H, <Zm>.H[<index>]
BFMMLA  <Zda>.S, <Zn>.H, <Zm>.H
SMMLA   <Zda>.S, <Zn>.B, <Zm>.B
SUDOT   <Zda>.S, <Zn>.B, <Zm>.B[<index>]
UMMLA   <Zda>.S, <Zn>.B, <Zm>.B
USDOT   <Zda>.S, <Zn>.B, <Zm>.B
USDOT   <Zda>.S, <Zn>.B, <Zm>.B[<index>]
USMMLA  <Zda>.S, <Zn>.B, <Zm>.B
```

Issue #3044