### PR TITLE
i#3044 AArch64 SVE codec: Add ADR instructions

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -90,7 +90,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.90.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -102,7 +102,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.90.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -194,7 +194,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.90.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -282,7 +282,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.90.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -370,7 +370,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.90.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -450,7 +450,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.90.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -535,7 +535,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER="9.90.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export VERSION_NUMBER="9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))"
           export PREFIX="cronbuild-"
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 
 # N.B.: When updating this, update all the default versions in ci-package.yml
 # and ci-docs.yml.  We should find a way to share (xref i#1565).
-set(VERSION_NUMBER_DEFAULT "9.90.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "9.91.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -142,6 +142,10 @@ changes:
  - Reduced the value of #DR_NOTE_FIRST_RESERVED.  This is not expected to cause
    problems unless clients are directly choosing high note values without using
    drmgr_reserve_note_range().
+ - Changed the values of the AArch64 DR_REG_Z* constants so that Z registers can be
+   used in base+disp operands in SVE scatter/gather instructions. This breaks binary
+   compatibility for clients built against an older version of opnd_api.h, but source
+   code compatibility is unchanged.
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -200,6 +200,9 @@ Further non-compatibility-affecting changes include:
  - Added opnd_size_to_shift_amount() and opnd_create_base_disp_shift_aarch64()
    for explicitly specifying shift amounts in the creation of operands for
    AArch64 memory addresses.
+ - Added opnd_create_vector_base_disp_aarch64() and reg_is_z() for creating
+   memory address operands that use SVE Z registers with a specified element
+   size.
 
 **************************************************
 <hr>

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -801,6 +801,10 @@ d_r_arch_init(void)
         }
 #endif
     }
+
+    /* Ensure addressing registers fit into base+disp operand base and index fields. */
+    IF_AARCHXX(ASSERT_BITFIELD_TRUNCATE(REG_SPECIFIER_BITS, DR_REG_MAX_ADDRESSING_REG));
+
     mangle_init();
 }
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5277,11 +5277,8 @@ encode_opnd_z_sz_sd(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_o
 static inline bool
 decode_opnd_z_sz_sd(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    if (TEST(1u << 22, enc)) {
-        return decode_single_sized(DR_REG_Z0, 0, 5, DOUBLE_REG, enc, opnd);
-    } else {
-        return decode_single_sized(DR_REG_Z0, 0, 5, SINGLE_REG, enc, opnd);
-    }
+    const aarch64_reg_offset element_size = TEST(1u << 22, enc) ? DOUBLE_REG : SINGLE_REG;
+    return decode_single_sized(DR_REG_Z0, DR_REG_Z31, 0, 5, element_size, 0, enc, opnd);
 }
 
 /* dq5_sz: D/Q register at bit position 5; bit 22 selects Q reg */

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -46,6 +46,9 @@
 00100101xx10000011xxxxxxxxxxxxxx  n   9    SVE      add  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100011xxxxx01010xxxxxxxxxxx  n   934  SVE    addpl           x0sp : x16sp simm6_5
 00000100001xxxxx01010xxxxxxxxxxx  n   935  SVE    addvl           x0sp : x16sp simm6_5
+00000100001xxxxx1010xxxxxxxxxxxx  n   15   SVE      adr          z_d_0 : svemem_vec_vec_idx
+00000100011xxxxx1010xxxxxxxxxxxx  n   15   SVE      adr          z_d_0 : svemem_vec_vec_idx
+000001001x1xxxxx1010xxxxxxxxxxxx  n   15   SVE      adr        z_sz_sd : svemem_vec_vec_idx
 00000100xx011010000xxxxxxxxxxxxx  n   21   SVE      and             z0 : p10_lo z0 z5 bhsd_sz
 00000101100000xxxxxxxxxxxxxxxxxx  n   21   SVE      and  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010000xxxx01xxxx0xxxx0xxxx  n   21   SVE      and          p_b_0 : p10_zer p_b_5 p_b_16

--- a/core/ir/aarch64/encode.c
+++ b/core/ir/aarch64/encode.c
@@ -57,6 +57,11 @@ const char *const reg_names[] = {
     "w20", "w21", "w22", "w23", "w24", "w25", "w26", "w27", "w28", "w29",
     "w30", "wsp", "wzr",
 
+    "z0",  "z1",  "z2",  "z3",  "z4",  "z5",  "z6",  "z7",  "z8",  "z9",
+    "z10", "z11", "z12", "z13", "z14", "z15", "z16", "z17", "z18", "z19",
+    "z20", "z21", "z22", "z23", "z24", "z25", "z26", "z27", "z28", "z29",
+    "z30", "z31",
+
     "q0",  "q1",  "q2",  "q3",  "q4",  "q5",  "q6",  "q7",  "q8",  "q9",
     "q10", "q11", "q12", "q13", "q14", "q15", "q16", "q17", "q18", "q19",
     "q20", "q21", "q22", "q23", "q24", "q25", "q26", "q27", "q28", "q29",
@@ -109,11 +114,6 @@ const char *const reg_names[] = {
     "pmevtyper28_el0", "pmevtyper29_el0", "pmevtyper30_el0", "pmccfiltr_el0",
     "spsr_irq", "spsr_abt", "spsr_und", "spsr_fiq", "tpidr_el0", "tpidrro_el0",
 
-    "z0",  "z1",  "z2",  "z3",  "z4",  "z5",  "z6",  "z7",  "z8",  "z9",
-    "z10", "z11", "z12", "z13", "z14", "z15", "z16", "z17", "z18", "z19",
-    "z20", "z21", "z22", "z23", "z24", "z25", "z26", "z27", "z28", "z29",
-    "z30", "z31",
-
     "p0",  "p1",  "p2",  "p3",  "p4",  "p5",  "p6",  "p7",  "p8",  "p9",
     "p10", "p11", "p12", "p13", "p14", "p15",
 
@@ -137,18 +137,19 @@ const reg_id_t dr_reg_fixer[] = { REG_NULL,
                                       XREGS /* W0-WSP */
 #undef XREGS
 
-#define QREGS                                                                            \
-    DR_REG_Q0, DR_REG_Q1, DR_REG_Q2, DR_REG_Q3, DR_REG_Q4, DR_REG_Q5, DR_REG_Q6,         \
-        DR_REG_Q7, DR_REG_Q8, DR_REG_Q9, DR_REG_Q10, DR_REG_Q11, DR_REG_Q12, DR_REG_Q13, \
-        DR_REG_Q14, DR_REG_Q15, DR_REG_Q16, DR_REG_Q17, DR_REG_Q18, DR_REG_Q19,          \
-        DR_REG_Q20, DR_REG_Q21, DR_REG_Q22, DR_REG_Q23, DR_REG_Q24, DR_REG_Q25,          \
-        DR_REG_Q26, DR_REG_Q27, DR_REG_Q28, DR_REG_Q29, DR_REG_Q30, DR_REG_Q31,
-                                          QREGS                 /* Q0-Q31*/
-                                              QREGS             /* D0-D31 */
-                                                  QREGS         /* S0-S31 */
-                                                      QREGS     /* H0-H31 */
-                                                          QREGS /* B0-B31 */
-#undef QREGS
+#define ZREGS                                                                            \
+    DR_REG_Z0, DR_REG_Z1, DR_REG_Z2, DR_REG_Z3, DR_REG_Z4, DR_REG_Z5, DR_REG_Z6,         \
+        DR_REG_Z7, DR_REG_Z8, DR_REG_Z9, DR_REG_Z10, DR_REG_Z11, DR_REG_Z12, DR_REG_Z13, \
+        DR_REG_Z14, DR_REG_Z15, DR_REG_Z16, DR_REG_Z17, DR_REG_Z18, DR_REG_Z19,          \
+        DR_REG_Z20, DR_REG_Z21, DR_REG_Z22, DR_REG_Z23, DR_REG_Z24, DR_REG_Z25,          \
+        DR_REG_Z26, DR_REG_Z27, DR_REG_Z28, DR_REG_Z29, DR_REG_Z30, DR_REG_Z31,
+                                          ZREGS                     /* Z0-Z31 */
+                                              ZREGS                 /* Q0-Q31*/
+                                                  ZREGS             /* D0-D31 */
+                                                      ZREGS         /* S0-S31 */
+                                                          ZREGS     /* H0-H31 */
+                                                              ZREGS /* B0-B31 */
+#undef ZREGS
 
     DR_REG_NZCV, DR_REG_FPCR, DR_REG_FPSR,
     DR_REG_MDCCSR_EL0, DR_REG_DBGDTR_EL0, DR_REG_DBGDTRRX_EL0, DR_REG_SP_EL0,
@@ -185,7 +186,13 @@ const reg_id_t dr_reg_fixer[] = { REG_NULL,
     DR_REG_PMEVTYPER26_EL0, DR_REG_PMEVTYPER27_EL0, DR_REG_PMEVTYPER28_EL0,
     DR_REG_PMEVTYPER29_EL0, DR_REG_PMEVTYPER30_EL0, DR_REG_PMCCFILTR_EL0,
     DR_REG_SPSR_IRQ, DR_REG_SPSR_ABT, DR_REG_SPSR_UND, DR_REG_SPSR_FIQ,
-    DR_REG_TPIDR_EL0, DR_REG_TPIDRRO_EL0
+    DR_REG_TPIDR_EL0, DR_REG_TPIDRRO_EL0,
+
+    DR_REG_P0, DR_REG_P1, DR_REG_P2, DR_REG_P3, DR_REG_P4, DR_REG_P5,
+    DR_REG_P6, DR_REG_P7, DR_REG_P8, DR_REG_P9, DR_REG_P10, DR_REG_P11,
+    DR_REG_P12, DR_REG_P13, DR_REG_P14, DR_REG_P15,
+
+    DR_REG_CNTVCT_EL0,
 };
 /* clang-format on */
 

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -442,6 +442,12 @@ reg_is_fp(reg_id_t reg)
 }
 
 bool
+reg_is_z(reg_id_t reg)
+{
+    return DR_REG_Z0 <= reg && reg <= DR_REG_Z31;
+}
+
+bool
 instr_is_nop(instr_t *instr)
 {
     uint opc = instr_get_opcode(instr);

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -11230,12 +11230,12 @@
  * \param Zd   The destination vector register, Z (Scalable).
  * \param Zn   The first source vector base register with a register offset,
  *             constructed with one of:
- *             opnd_create_vector_base_disp_aarch64(Zn, Zm, OPSZ_8,
- *                                                  DR_EXTEND_SXTW, 0, 0, 0, OPSZ_0, shift_amount)
- *             opnd_create_vector_base_disp_aarch64(Zn, Zm, OPSZ_8,
- *                                                  DR_EXTEND_UXTW, 0, 0, 0, OPSZ_0, shift_amount)
- *             opnd_create_vector_base_disp_aarch64(Zn, Zm, elsz,
- *                                                  DR_EXTEND_UXTX, 0, 0, 0, OPSZ_0, shift_amount)
+ *             opnd_create_vector_base_disp_aarch64(Zn, Zm, OPSZ_8, DR_EXTEND_SXTW,
+ *                                                  0, 0, 0, OPSZ_0, shift_amount)
+ *             opnd_create_vector_base_disp_aarch64(Zn, Zm, OPSZ_8, DR_EXTEND_UXTW,
+ *                                                  0, 0, 0, OPSZ_0, shift_amount)
+ *             opnd_create_vector_base_disp_aarch64(Zn, Zm, elsz, DR_EXTEND_UXTX,
+ *                                                  0, 0, 0, OPSZ_0, shift_amount)
  */
 #define INSTR_CREATE_adr_sve(dc, Zd, Zn) instr_create_1dst_1src(dc, OP_adr, Zd, Zn)
 

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -11217,4 +11217,26 @@
 #define INSTR_CREATE_prfw_sve_pred(dc, prfop, Pg, Rn) \
     instr_create_0dst_3src(dc, OP_prfw, prfop, Pg, Rn)
 
+/*
+ * Creates an ADR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ADR     <Zd>.D, [<Zn>.D, <Zm>.D, SXTW <amount>]
+ *    ADR     <Zd>.D, [<Zn>.D, <Zm>.D, UXTW <amount>]
+ *    ADR     <Zd>.<Ts>, [<Zn>.<Ts>, <Zm>.<Ts>, <extend> <amount>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector base register with a register offset,
+ *             constructed with one of:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Zm, OPSZ_8,
+ *                                                  DR_EXTEND_SXTW, 0, 0, 0, OPSZ_0, shift_amount)
+ *             opnd_create_vector_base_disp_aarch64(Zn, Zm, OPSZ_8,
+ *                                                  DR_EXTEND_UXTW, 0, 0, 0, OPSZ_0, shift_amount)
+ *             opnd_create_vector_base_disp_aarch64(Zn, Zm, elsz,
+ *                                                  DR_EXTEND_UXTX, 0, 0, 0, OPSZ_0, shift_amount)
+ */
+#define INSTR_CREATE_adr_sve(dc, Zd, Zn) instr_create_1dst_1src(dc, OP_adr, Zd, Zn)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -242,6 +242,7 @@
                                              # elements, depending on bit 22 (sz)
 ---------x----------------------  sd_sz      # element width of FP vector reg for single or double
 ---------x----------------------  hs_fsz      # element width of FP vector reg for half or single
+---------x-----------------xxxxx  z_sz_sd    # SVE vector reg, elsz depending on sz
 ---------x------------xxxxx-----  dq5_sz     # as dqx, but depending on the sz bit rather than the Q bit
 ---------x------------xxxxx-----  wx_sz_5    # W/X register (or WZR/XZR) with size indicated in bit 22
 ---------x-xx-------------------  i3_index_19 # Index value from 22, 20:19
@@ -258,6 +259,7 @@
 --------??-??--------------xxxxx  z_tszl19_bhsd_0 # z element register mediated by the tszl and tszh fields
 --------??-??---------xxxxx-----  z_tszl19_bhsd_5 # z element register mediated by the tszl and tszh fields
 --------??-xxxxx----------------  wx_size_16_zr # GPR scalar register, register size, W or X depending on size bits
+--------??-xxxxx----xxxxxxx-----  svemem_vec_vec_idx # SVE memory address [<Zn>.<T>, <Zm>.<T>{, <mod> <amount>}]
 --------??-xxxxxxxx-------------  fpimm8_13  # floating-point immediate for scalar fmov
 --------xx----------------------  b_sz       # element width of a vector (8<<b_sz)
 --------xx----------------------  hs_sz      # element width of a vector (8<<hs_sz)

--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -1369,9 +1369,9 @@ common_disassemble_fragment(dcontext_t *dcontext, fragment_t *f_in, file_t outfi
                         ? (TEST(FRAG_TEMP_PRIVATE, f->flags) ? "private temp, "
                                                              : "private, ")
                         : "")),
-            (TEST(FRAG_IS_TRACE, f->flags))
-                ? "trace, "
-                : (TEST(FRAG_IS_TRACE_HEAD, f->flags)) ? "tracehead, " : "",
+            (TEST(FRAG_IS_TRACE, f->flags))            ? "trace, "
+                : (TEST(FRAG_IS_TRACE_HEAD, f->flags)) ? "tracehead, "
+                                                       : "",
             f->size, (TEST(FRAG_CANNOT_BE_TRACE, f->flags)) ? ", cannot be trace" : "",
             (TEST(FRAG_MUST_END_TRACE, f->flags)) ? ", must end trace" : "",
             (TEST(FRAG_CANNOT_DELETE, f->flags)) ? ", cannot delete" : "");

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -650,6 +650,54 @@ enum {
     DR_REG_R15,                               /**< The "r15" register. */
 #    endif
 
+#    ifdef AARCH64
+    /* SVE vector registers */
+    DR_REG_Z0,  /**< The "z0" register. */
+    DR_REG_Z1,  /**< The "z1" register. */
+    DR_REG_Z2,  /**< The "z2" register. */
+    DR_REG_Z3,  /**< The "z3" register. */
+    DR_REG_Z4,  /**< The "z4" register. */
+    DR_REG_Z5,  /**< The "z5" register. */
+    DR_REG_Z6,  /**< The "z6" register. */
+    DR_REG_Z7,  /**< The "z7" register. */
+    DR_REG_Z8,  /**< The "z8" register. */
+    DR_REG_Z9,  /**< The "z9" register. */
+    DR_REG_Z10, /**< The "z10" register. */
+    DR_REG_Z11, /**< The "z11" register. */
+    DR_REG_Z12, /**< The "z12" register. */
+    DR_REG_Z13, /**< The "z13" register. */
+    DR_REG_Z14, /**< The "z14" register. */
+    DR_REG_Z15, /**< The "z15" register. */
+    DR_REG_Z16, /**< The "z16" register. */
+    DR_REG_Z17, /**< The "z17" register. */
+    DR_REG_Z18, /**< The "z18" register. */
+    DR_REG_Z19, /**< The "z19" register. */
+    DR_REG_Z20, /**< The "z20" register. */
+    DR_REG_Z21, /**< The "z21" register. */
+    DR_REG_Z22, /**< The "z22" register. */
+    DR_REG_Z23, /**< The "z23" register. */
+    DR_REG_Z24, /**< The "z24" register. */
+    DR_REG_Z25, /**< The "z25" register. */
+    DR_REG_Z26, /**< The "z26" register. */
+    DR_REG_Z27, /**< The "z27" register. */
+    DR_REG_Z28, /**< The "z28" register. */
+    DR_REG_Z29, /**< The "z29" register. */
+    DR_REG_Z30, /**< The "z30" register. */
+    DR_REG_Z31, /**< The "z31" register. */
+#    endif
+
+/* All registers that can be used in address operands must be before this point.
+ *
+ * Base+disp operands do not store the full reg_id_t value, only the lower
+ * REG_SPECIFIER_BITS, so any register used in addressing must be less than
+ * 1 << REG_SPECIFIER_BITS. This is checked in d_r_arch_init().
+ */
+#    if defined(AARCH64)
+    DR_REG_MAX_ADDRESSING_REG = DR_REG_Z31,
+#    else
+    DR_REG_MAX_ADDRESSING_REG = DR_REG_R15,
+#    endif
+
     /* 128-bit SIMD registers */
     DR_REG_Q0,  /**< The "q0" register. */
     DR_REG_Q1,  /**< The "q1" register. */
@@ -973,40 +1021,6 @@ enum {
     DR_REG_TPIDRURO, /**< User Read-Only Thread ID Register */
 
 #    ifdef AARCH64
-    /* SVE vector registers */
-    DR_REG_Z0,  /**< The "z0" register. */
-    DR_REG_Z1,  /**< The "z1" register. */
-    DR_REG_Z2,  /**< The "z2" register. */
-    DR_REG_Z3,  /**< The "z3" register. */
-    DR_REG_Z4,  /**< The "z4" register. */
-    DR_REG_Z5,  /**< The "z5" register. */
-    DR_REG_Z6,  /**< The "z6" register. */
-    DR_REG_Z7,  /**< The "z7" register. */
-    DR_REG_Z8,  /**< The "z8" register. */
-    DR_REG_Z9,  /**< The "z9" register. */
-    DR_REG_Z10, /**< The "z10" register. */
-    DR_REG_Z11, /**< The "z11" register. */
-    DR_REG_Z12, /**< The "z12" register. */
-    DR_REG_Z13, /**< The "z13" register. */
-    DR_REG_Z14, /**< The "z14" register. */
-    DR_REG_Z15, /**< The "z15" register. */
-    DR_REG_Z16, /**< The "z16" register. */
-    DR_REG_Z17, /**< The "z17" register. */
-    DR_REG_Z18, /**< The "z18" register. */
-    DR_REG_Z19, /**< The "z19" register. */
-    DR_REG_Z20, /**< The "z20" register. */
-    DR_REG_Z21, /**< The "z21" register. */
-    DR_REG_Z22, /**< The "z22" register. */
-    DR_REG_Z23, /**< The "z23" register. */
-    DR_REG_Z24, /**< The "z24" register. */
-    DR_REG_Z25, /**< The "z25" register. */
-    DR_REG_Z26, /**< The "z26" register. */
-    DR_REG_Z27, /**< The "z27" register. */
-    DR_REG_Z28, /**< The "z28" register. */
-    DR_REG_Z29, /**< The "z29" register. */
-    DR_REG_Z30, /**< The "z30" register. */
-    DR_REG_Z31, /**< The "z31" register. */
-
     /* SVE predicate registers */
     DR_REG_P0,  /**< The "p0" register. */
     DR_REG_P1,  /**< The "p1" register. */
@@ -1858,6 +1872,10 @@ struct _opnd_t {
             byte /*bool*/ scaled : 1;
             /* Shift offset amount */
             byte /*uint*/ scaled_value : 3;
+            /* Indicates the element size for vector base and index registers.
+             * This is ignored if the base and index registers are scalar registers.
+             */
+            byte /*enum*/ element_size : 1;
 #    elif defined(ARM)
             byte /*dr_shift_type_t*/ shift_type : 3;
             byte shift_amount_minus_1 : 5; /* 1..31 so we store (val - 1) */
@@ -2271,6 +2289,28 @@ opnd_t
 opnd_create_base_disp_aarch64(reg_id_t base_reg, reg_id_t index_reg,
                               dr_extend_type_t extend_type, bool scaled, int disp,
                               dr_opnd_flags_t flags, opnd_size_t size);
+
+DR_API
+/**
+ * Same as opnd_create_base_disp_shift_aarch64 but creates an operand that uses vector
+ * registers for the base and/or index.
+ * At least one of \p base_reg and \p index_reg should be a vector register.
+ * \p element_size indicates the element size for any vector registers used and must be
+ * one of:
+ *     OPSZ_4 (single, 32-bit)
+ *     OPSZ_8 (double, 64-bit)
+ *
+ * TODO i#3044: WARNING this function may change during SVE development of
+ * DynamoRIO. The function will be considered stable when this warning has been
+ * removed.
+ *
+ * \note AArch64-only.
+ */
+opnd_t
+opnd_create_vector_base_disp_aarch64(reg_id_t base_reg, reg_id_t index_reg,
+                                     opnd_size_t element_size,
+                                     dr_extend_type_t extend_type, bool scaled, int disp,
+                                     dr_opnd_flags_t flags, opnd_size_t size, uint shift);
 #endif
 
 DR_API
@@ -3145,6 +3185,16 @@ DR_API
  */
 bool
 reg_is_32bit(reg_id_t reg);
+
+#if defined(AARCH64)
+DR_API
+/**
+ * Assumes that \p reg is a DR_REG_ constant.
+ * Returns true iff it refers to a Z (SVE scalable vector) register.
+ */
+bool
+reg_is_z(reg_id_t reg);
+#endif
 
 DR_API
 /**

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1873,6 +1873,11 @@ struct _opnd_t {
             /* Shift offset amount */
             byte /*uint*/ scaled_value : 3;
             /* Indicates the element size for vector base and index registers.
+             * Only 2 element sizes are used for vector base/index registers in SVE:
+             *     Single (OPSZ_4)
+             *     Double (OPSZ_8)
+             * so we only need one bit to store the value (see ELEMENT_SIZE_* enum in
+             * opnd_shared.c).
              * This is ignored if the base and index registers are scalar registers.
              */
             byte /*enum*/ element_size : 1;

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -632,22 +632,22 @@ enum {
     DR_REG_WZR, /**< The "wzr" zero pseudo-register. */
 #    else
     /* 32-bit general purpose */
-    DR_REG_R0,                                /**< The "r0" register. */
-    DR_REG_R1,                                /**< The "r1" register. */
-    DR_REG_R2,                                /**< The "r2" register. */
-    DR_REG_R3,                                /**< The "r3" register. */
-    DR_REG_R4,                                /**< The "r4" register. */
-    DR_REG_R5,                                /**< The "r5" register. */
-    DR_REG_R6,                                /**< The "r6" register. */
-    DR_REG_R7,                                /**< The "r7" register. */
-    DR_REG_R8,                                /**< The "r8" register. */
-    DR_REG_R9,                                /**< The "r9" register. */
-    DR_REG_R10,                               /**< The "r10" register. */
-    DR_REG_R11,                               /**< The "r11" register. */
-    DR_REG_R12,                               /**< The "r12" register. */
-    DR_REG_R13,                               /**< The "r13" register. */
-    DR_REG_R14,                               /**< The "r14" register. */
-    DR_REG_R15,                               /**< The "r15" register. */
+    DR_REG_R0,  /**< The "r0" register. */
+    DR_REG_R1,  /**< The "r1" register. */
+    DR_REG_R2,  /**< The "r2" register. */
+    DR_REG_R3,  /**< The "r3" register. */
+    DR_REG_R4,  /**< The "r4" register. */
+    DR_REG_R5,  /**< The "r5" register. */
+    DR_REG_R6,  /**< The "r6" register. */
+    DR_REG_R7,  /**< The "r7" register. */
+    DR_REG_R8,  /**< The "r8" register. */
+    DR_REG_R9,  /**< The "r9" register. */
+    DR_REG_R10, /**< The "r10" register. */
+    DR_REG_R11, /**< The "r11" register. */
+    DR_REG_R12, /**< The "r12" register. */
+    DR_REG_R13, /**< The "r13" register. */
+    DR_REG_R14, /**< The "r14" register. */
+    DR_REG_R15, /**< The "r15" register. */
 #    endif
 
 #    ifdef AARCH64

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -349,6 +349,268 @@
 043b52fa : addvl x26, x27, #0x17                     : addvl  %x27 $0x17 -> %x26
 043f53ff : addvl sp, sp, #0x1f                       : addvl  %sp $0x1f -> %sp
 
+# ADR     <Zd>.D, [<Zn>.D, <Zm>.D, SXTW <amount>] (ADR-Z.AZ-D.s32.scaled)
+0420a000 : adr z0.d, [z0.d, z0.d, SXTW]              : adr    (%z0.d,%z0.d,sxtw) -> %z0.d
+0424a062 : adr z2.d, [z3.d, z4.d, SXTW]              : adr    (%z3.d,%z4.d,sxtw) -> %z2.d
+0426a0a4 : adr z4.d, [z5.d, z6.d, SXTW]              : adr    (%z5.d,%z6.d,sxtw) -> %z4.d
+0428a0e6 : adr z6.d, [z7.d, z8.d, SXTW]              : adr    (%z7.d,%z8.d,sxtw) -> %z6.d
+042aa128 : adr z8.d, [z9.d, z10.d, SXTW]             : adr    (%z9.d,%z10.d,sxtw) -> %z8.d
+042ca16a : adr z10.d, [z11.d, z12.d, SXTW]           : adr    (%z11.d,%z12.d,sxtw) -> %z10.d
+042ea1ac : adr z12.d, [z13.d, z14.d, SXTW]           : adr    (%z13.d,%z14.d,sxtw) -> %z12.d
+0430a1ee : adr z14.d, [z15.d, z16.d, SXTW]           : adr    (%z15.d,%z16.d,sxtw) -> %z14.d
+0432a230 : adr z16.d, [z17.d, z18.d, SXTW]           : adr    (%z17.d,%z18.d,sxtw) -> %z16.d
+0433a251 : adr z17.d, [z18.d, z19.d, SXTW]           : adr    (%z18.d,%z19.d,sxtw) -> %z17.d
+0435a293 : adr z19.d, [z20.d, z21.d, SXTW]           : adr    (%z20.d,%z21.d,sxtw) -> %z19.d
+0437a2d5 : adr z21.d, [z22.d, z23.d, SXTW]           : adr    (%z22.d,%z23.d,sxtw) -> %z21.d
+0439a317 : adr z23.d, [z24.d, z25.d, SXTW]           : adr    (%z24.d,%z25.d,sxtw) -> %z23.d
+043ba359 : adr z25.d, [z26.d, z27.d, SXTW]           : adr    (%z26.d,%z27.d,sxtw) -> %z25.d
+043da39b : adr z27.d, [z28.d, z29.d, SXTW]           : adr    (%z28.d,%z29.d,sxtw) -> %z27.d
+043fa3ff : adr z31.d, [z31.d, z31.d, SXTW]           : adr    (%z31.d,%z31.d,sxtw) -> %z31.d
+0420a400 : adr z0.d, [z0.d, z0.d, SXTW #1]           : adr    (%z0.d,%z0.d,sxtw #1) -> %z0.d
+0424a462 : adr z2.d, [z3.d, z4.d, SXTW #1]           : adr    (%z3.d,%z4.d,sxtw #1) -> %z2.d
+0426a4a4 : adr z4.d, [z5.d, z6.d, SXTW #1]           : adr    (%z5.d,%z6.d,sxtw #1) -> %z4.d
+0428a4e6 : adr z6.d, [z7.d, z8.d, SXTW #1]           : adr    (%z7.d,%z8.d,sxtw #1) -> %z6.d
+042aa528 : adr z8.d, [z9.d, z10.d, SXTW #1]          : adr    (%z9.d,%z10.d,sxtw #1) -> %z8.d
+042ca56a : adr z10.d, [z11.d, z12.d, SXTW #1]        : adr    (%z11.d,%z12.d,sxtw #1) -> %z10.d
+042ea5ac : adr z12.d, [z13.d, z14.d, SXTW #1]        : adr    (%z13.d,%z14.d,sxtw #1) -> %z12.d
+0430a5ee : adr z14.d, [z15.d, z16.d, SXTW #1]        : adr    (%z15.d,%z16.d,sxtw #1) -> %z14.d
+0432a630 : adr z16.d, [z17.d, z18.d, SXTW #1]        : adr    (%z17.d,%z18.d,sxtw #1) -> %z16.d
+0433a651 : adr z17.d, [z18.d, z19.d, SXTW #1]        : adr    (%z18.d,%z19.d,sxtw #1) -> %z17.d
+0435a693 : adr z19.d, [z20.d, z21.d, SXTW #1]        : adr    (%z20.d,%z21.d,sxtw #1) -> %z19.d
+0437a6d5 : adr z21.d, [z22.d, z23.d, SXTW #1]        : adr    (%z22.d,%z23.d,sxtw #1) -> %z21.d
+0439a717 : adr z23.d, [z24.d, z25.d, SXTW #1]        : adr    (%z24.d,%z25.d,sxtw #1) -> %z23.d
+043ba759 : adr z25.d, [z26.d, z27.d, SXTW #1]        : adr    (%z26.d,%z27.d,sxtw #1) -> %z25.d
+043da79b : adr z27.d, [z28.d, z29.d, SXTW #1]        : adr    (%z28.d,%z29.d,sxtw #1) -> %z27.d
+043fa7ff : adr z31.d, [z31.d, z31.d, SXTW #1]        : adr    (%z31.d,%z31.d,sxtw #1) -> %z31.d
+0420a800 : adr z0.d, [z0.d, z0.d, SXTW #2]           : adr    (%z0.d,%z0.d,sxtw #2) -> %z0.d
+0424a862 : adr z2.d, [z3.d, z4.d, SXTW #2]           : adr    (%z3.d,%z4.d,sxtw #2) -> %z2.d
+0426a8a4 : adr z4.d, [z5.d, z6.d, SXTW #2]           : adr    (%z5.d,%z6.d,sxtw #2) -> %z4.d
+0428a8e6 : adr z6.d, [z7.d, z8.d, SXTW #2]           : adr    (%z7.d,%z8.d,sxtw #2) -> %z6.d
+042aa928 : adr z8.d, [z9.d, z10.d, SXTW #2]          : adr    (%z9.d,%z10.d,sxtw #2) -> %z8.d
+042ca96a : adr z10.d, [z11.d, z12.d, SXTW #2]        : adr    (%z11.d,%z12.d,sxtw #2) -> %z10.d
+042ea9ac : adr z12.d, [z13.d, z14.d, SXTW #2]        : adr    (%z13.d,%z14.d,sxtw #2) -> %z12.d
+0430a9ee : adr z14.d, [z15.d, z16.d, SXTW #2]        : adr    (%z15.d,%z16.d,sxtw #2) -> %z14.d
+0432aa30 : adr z16.d, [z17.d, z18.d, SXTW #2]        : adr    (%z17.d,%z18.d,sxtw #2) -> %z16.d
+0433aa51 : adr z17.d, [z18.d, z19.d, SXTW #2]        : adr    (%z18.d,%z19.d,sxtw #2) -> %z17.d
+0435aa93 : adr z19.d, [z20.d, z21.d, SXTW #2]        : adr    (%z20.d,%z21.d,sxtw #2) -> %z19.d
+0437aad5 : adr z21.d, [z22.d, z23.d, SXTW #2]        : adr    (%z22.d,%z23.d,sxtw #2) -> %z21.d
+0439ab17 : adr z23.d, [z24.d, z25.d, SXTW #2]        : adr    (%z24.d,%z25.d,sxtw #2) -> %z23.d
+043bab59 : adr z25.d, [z26.d, z27.d, SXTW #2]        : adr    (%z26.d,%z27.d,sxtw #2) -> %z25.d
+043dab9b : adr z27.d, [z28.d, z29.d, SXTW #2]        : adr    (%z28.d,%z29.d,sxtw #2) -> %z27.d
+043fabff : adr z31.d, [z31.d, z31.d, SXTW #2]        : adr    (%z31.d,%z31.d,sxtw #2) -> %z31.d
+0420ac00 : adr z0.d, [z0.d, z0.d, SXTW #3]           : adr    (%z0.d,%z0.d,sxtw #3) -> %z0.d
+0424ac62 : adr z2.d, [z3.d, z4.d, SXTW #3]           : adr    (%z3.d,%z4.d,sxtw #3) -> %z2.d
+0426aca4 : adr z4.d, [z5.d, z6.d, SXTW #3]           : adr    (%z5.d,%z6.d,sxtw #3) -> %z4.d
+0428ace6 : adr z6.d, [z7.d, z8.d, SXTW #3]           : adr    (%z7.d,%z8.d,sxtw #3) -> %z6.d
+042aad28 : adr z8.d, [z9.d, z10.d, SXTW #3]          : adr    (%z9.d,%z10.d,sxtw #3) -> %z8.d
+042cad6a : adr z10.d, [z11.d, z12.d, SXTW #3]        : adr    (%z11.d,%z12.d,sxtw #3) -> %z10.d
+042eadac : adr z12.d, [z13.d, z14.d, SXTW #3]        : adr    (%z13.d,%z14.d,sxtw #3) -> %z12.d
+0430adee : adr z14.d, [z15.d, z16.d, SXTW #3]        : adr    (%z15.d,%z16.d,sxtw #3) -> %z14.d
+0432ae30 : adr z16.d, [z17.d, z18.d, SXTW #3]        : adr    (%z17.d,%z18.d,sxtw #3) -> %z16.d
+0433ae51 : adr z17.d, [z18.d, z19.d, SXTW #3]        : adr    (%z18.d,%z19.d,sxtw #3) -> %z17.d
+0435ae93 : adr z19.d, [z20.d, z21.d, SXTW #3]        : adr    (%z20.d,%z21.d,sxtw #3) -> %z19.d
+0437aed5 : adr z21.d, [z22.d, z23.d, SXTW #3]        : adr    (%z22.d,%z23.d,sxtw #3) -> %z21.d
+0439af17 : adr z23.d, [z24.d, z25.d, SXTW #3]        : adr    (%z24.d,%z25.d,sxtw #3) -> %z23.d
+043baf59 : adr z25.d, [z26.d, z27.d, SXTW #3]        : adr    (%z26.d,%z27.d,sxtw #3) -> %z25.d
+043daf9b : adr z27.d, [z28.d, z29.d, SXTW #3]        : adr    (%z28.d,%z29.d,sxtw #3) -> %z27.d
+043fafff : adr z31.d, [z31.d, z31.d, SXTW #3]        : adr    (%z31.d,%z31.d,sxtw #3) -> %z31.d
+
+# ADR     <Zd>.D, [<Zn>.D, <Zm>.D, UXTW <amount>] (ADR-Z.AZ-D.u32.scaled)
+0460a000 : adr z0.d, [z0.d, z0.d, UXTW]              : adr    (%z0.d,%z0.d,uxtw) -> %z0.d
+0464a062 : adr z2.d, [z3.d, z4.d, UXTW]              : adr    (%z3.d,%z4.d,uxtw) -> %z2.d
+0466a0a4 : adr z4.d, [z5.d, z6.d, UXTW]              : adr    (%z5.d,%z6.d,uxtw) -> %z4.d
+0468a0e6 : adr z6.d, [z7.d, z8.d, UXTW]              : adr    (%z7.d,%z8.d,uxtw) -> %z6.d
+046aa128 : adr z8.d, [z9.d, z10.d, UXTW]             : adr    (%z9.d,%z10.d,uxtw) -> %z8.d
+046ca16a : adr z10.d, [z11.d, z12.d, UXTW]           : adr    (%z11.d,%z12.d,uxtw) -> %z10.d
+046ea1ac : adr z12.d, [z13.d, z14.d, UXTW]           : adr    (%z13.d,%z14.d,uxtw) -> %z12.d
+0470a1ee : adr z14.d, [z15.d, z16.d, UXTW]           : adr    (%z15.d,%z16.d,uxtw) -> %z14.d
+0472a230 : adr z16.d, [z17.d, z18.d, UXTW]           : adr    (%z17.d,%z18.d,uxtw) -> %z16.d
+0473a251 : adr z17.d, [z18.d, z19.d, UXTW]           : adr    (%z18.d,%z19.d,uxtw) -> %z17.d
+0475a293 : adr z19.d, [z20.d, z21.d, UXTW]           : adr    (%z20.d,%z21.d,uxtw) -> %z19.d
+0477a2d5 : adr z21.d, [z22.d, z23.d, UXTW]           : adr    (%z22.d,%z23.d,uxtw) -> %z21.d
+0479a317 : adr z23.d, [z24.d, z25.d, UXTW]           : adr    (%z24.d,%z25.d,uxtw) -> %z23.d
+047ba359 : adr z25.d, [z26.d, z27.d, UXTW]           : adr    (%z26.d,%z27.d,uxtw) -> %z25.d
+047da39b : adr z27.d, [z28.d, z29.d, UXTW]           : adr    (%z28.d,%z29.d,uxtw) -> %z27.d
+047fa3ff : adr z31.d, [z31.d, z31.d, UXTW]           : adr    (%z31.d,%z31.d,uxtw) -> %z31.d
+0460a400 : adr z0.d, [z0.d, z0.d, UXTW #1]           : adr    (%z0.d,%z0.d,uxtw #1) -> %z0.d
+0464a462 : adr z2.d, [z3.d, z4.d, UXTW #1]           : adr    (%z3.d,%z4.d,uxtw #1) -> %z2.d
+0466a4a4 : adr z4.d, [z5.d, z6.d, UXTW #1]           : adr    (%z5.d,%z6.d,uxtw #1) -> %z4.d
+0468a4e6 : adr z6.d, [z7.d, z8.d, UXTW #1]           : adr    (%z7.d,%z8.d,uxtw #1) -> %z6.d
+046aa528 : adr z8.d, [z9.d, z10.d, UXTW #1]          : adr    (%z9.d,%z10.d,uxtw #1) -> %z8.d
+046ca56a : adr z10.d, [z11.d, z12.d, UXTW #1]        : adr    (%z11.d,%z12.d,uxtw #1) -> %z10.d
+046ea5ac : adr z12.d, [z13.d, z14.d, UXTW #1]        : adr    (%z13.d,%z14.d,uxtw #1) -> %z12.d
+0470a5ee : adr z14.d, [z15.d, z16.d, UXTW #1]        : adr    (%z15.d,%z16.d,uxtw #1) -> %z14.d
+0472a630 : adr z16.d, [z17.d, z18.d, UXTW #1]        : adr    (%z17.d,%z18.d,uxtw #1) -> %z16.d
+0473a651 : adr z17.d, [z18.d, z19.d, UXTW #1]        : adr    (%z18.d,%z19.d,uxtw #1) -> %z17.d
+0475a693 : adr z19.d, [z20.d, z21.d, UXTW #1]        : adr    (%z20.d,%z21.d,uxtw #1) -> %z19.d
+0477a6d5 : adr z21.d, [z22.d, z23.d, UXTW #1]        : adr    (%z22.d,%z23.d,uxtw #1) -> %z21.d
+0479a717 : adr z23.d, [z24.d, z25.d, UXTW #1]        : adr    (%z24.d,%z25.d,uxtw #1) -> %z23.d
+047ba759 : adr z25.d, [z26.d, z27.d, UXTW #1]        : adr    (%z26.d,%z27.d,uxtw #1) -> %z25.d
+047da79b : adr z27.d, [z28.d, z29.d, UXTW #1]        : adr    (%z28.d,%z29.d,uxtw #1) -> %z27.d
+047fa7ff : adr z31.d, [z31.d, z31.d, UXTW #1]        : adr    (%z31.d,%z31.d,uxtw #1) -> %z31.d
+0460a800 : adr z0.d, [z0.d, z0.d, UXTW #2]           : adr    (%z0.d,%z0.d,uxtw #2) -> %z0.d
+0464a862 : adr z2.d, [z3.d, z4.d, UXTW #2]           : adr    (%z3.d,%z4.d,uxtw #2) -> %z2.d
+0466a8a4 : adr z4.d, [z5.d, z6.d, UXTW #2]           : adr    (%z5.d,%z6.d,uxtw #2) -> %z4.d
+0468a8e6 : adr z6.d, [z7.d, z8.d, UXTW #2]           : adr    (%z7.d,%z8.d,uxtw #2) -> %z6.d
+046aa928 : adr z8.d, [z9.d, z10.d, UXTW #2]          : adr    (%z9.d,%z10.d,uxtw #2) -> %z8.d
+046ca96a : adr z10.d, [z11.d, z12.d, UXTW #2]        : adr    (%z11.d,%z12.d,uxtw #2) -> %z10.d
+046ea9ac : adr z12.d, [z13.d, z14.d, UXTW #2]        : adr    (%z13.d,%z14.d,uxtw #2) -> %z12.d
+0470a9ee : adr z14.d, [z15.d, z16.d, UXTW #2]        : adr    (%z15.d,%z16.d,uxtw #2) -> %z14.d
+0472aa30 : adr z16.d, [z17.d, z18.d, UXTW #2]        : adr    (%z17.d,%z18.d,uxtw #2) -> %z16.d
+0473aa51 : adr z17.d, [z18.d, z19.d, UXTW #2]        : adr    (%z18.d,%z19.d,uxtw #2) -> %z17.d
+0475aa93 : adr z19.d, [z20.d, z21.d, UXTW #2]        : adr    (%z20.d,%z21.d,uxtw #2) -> %z19.d
+0477aad5 : adr z21.d, [z22.d, z23.d, UXTW #2]        : adr    (%z22.d,%z23.d,uxtw #2) -> %z21.d
+0479ab17 : adr z23.d, [z24.d, z25.d, UXTW #2]        : adr    (%z24.d,%z25.d,uxtw #2) -> %z23.d
+047bab59 : adr z25.d, [z26.d, z27.d, UXTW #2]        : adr    (%z26.d,%z27.d,uxtw #2) -> %z25.d
+047dab9b : adr z27.d, [z28.d, z29.d, UXTW #2]        : adr    (%z28.d,%z29.d,uxtw #2) -> %z27.d
+047fabff : adr z31.d, [z31.d, z31.d, UXTW #2]        : adr    (%z31.d,%z31.d,uxtw #2) -> %z31.d
+0460ac00 : adr z0.d, [z0.d, z0.d, UXTW #3]           : adr    (%z0.d,%z0.d,uxtw #3) -> %z0.d
+0464ac62 : adr z2.d, [z3.d, z4.d, UXTW #3]           : adr    (%z3.d,%z4.d,uxtw #3) -> %z2.d
+0466aca4 : adr z4.d, [z5.d, z6.d, UXTW #3]           : adr    (%z5.d,%z6.d,uxtw #3) -> %z4.d
+0468ace6 : adr z6.d, [z7.d, z8.d, UXTW #3]           : adr    (%z7.d,%z8.d,uxtw #3) -> %z6.d
+046aad28 : adr z8.d, [z9.d, z10.d, UXTW #3]          : adr    (%z9.d,%z10.d,uxtw #3) -> %z8.d
+046cad6a : adr z10.d, [z11.d, z12.d, UXTW #3]        : adr    (%z11.d,%z12.d,uxtw #3) -> %z10.d
+046eadac : adr z12.d, [z13.d, z14.d, UXTW #3]        : adr    (%z13.d,%z14.d,uxtw #3) -> %z12.d
+0470adee : adr z14.d, [z15.d, z16.d, UXTW #3]        : adr    (%z15.d,%z16.d,uxtw #3) -> %z14.d
+0472ae30 : adr z16.d, [z17.d, z18.d, UXTW #3]        : adr    (%z17.d,%z18.d,uxtw #3) -> %z16.d
+0473ae51 : adr z17.d, [z18.d, z19.d, UXTW #3]        : adr    (%z18.d,%z19.d,uxtw #3) -> %z17.d
+0475ae93 : adr z19.d, [z20.d, z21.d, UXTW #3]        : adr    (%z20.d,%z21.d,uxtw #3) -> %z19.d
+0477aed5 : adr z21.d, [z22.d, z23.d, UXTW #3]        : adr    (%z22.d,%z23.d,uxtw #3) -> %z21.d
+0479af17 : adr z23.d, [z24.d, z25.d, UXTW #3]        : adr    (%z24.d,%z25.d,uxtw #3) -> %z23.d
+047baf59 : adr z25.d, [z26.d, z27.d, UXTW #3]        : adr    (%z26.d,%z27.d,uxtw #3) -> %z25.d
+047daf9b : adr z27.d, [z28.d, z29.d, UXTW #3]        : adr    (%z28.d,%z29.d,uxtw #3) -> %z27.d
+047fafff : adr z31.d, [z31.d, z31.d, UXTW #3]        : adr    (%z31.d,%z31.d,uxtw #3) -> %z31.d
+
+# ADR     <Zd>.<T>, [<Zn>.<T>, <Zm>.<T>, <extend> <amount>] (ADR-Z.AZ-SD.same.scaled)
+04a0a000 : adr z0.s, [z0.s, z0.s]                    : adr    (%z0.s,%z0.s) -> %z0.s
+04a4a062 : adr z2.s, [z3.s, z4.s]                    : adr    (%z3.s,%z4.s) -> %z2.s
+04a6a0a4 : adr z4.s, [z5.s, z6.s]                    : adr    (%z5.s,%z6.s) -> %z4.s
+04a8a0e6 : adr z6.s, [z7.s, z8.s]                    : adr    (%z7.s,%z8.s) -> %z6.s
+04aaa128 : adr z8.s, [z9.s, z10.s]                   : adr    (%z9.s,%z10.s) -> %z8.s
+04aca16a : adr z10.s, [z11.s, z12.s]                 : adr    (%z11.s,%z12.s) -> %z10.s
+04aea1ac : adr z12.s, [z13.s, z14.s]                 : adr    (%z13.s,%z14.s) -> %z12.s
+04b0a1ee : adr z14.s, [z15.s, z16.s]                 : adr    (%z15.s,%z16.s) -> %z14.s
+04b2a230 : adr z16.s, [z17.s, z18.s]                 : adr    (%z17.s,%z18.s) -> %z16.s
+04b3a251 : adr z17.s, [z18.s, z19.s]                 : adr    (%z18.s,%z19.s) -> %z17.s
+04b5a293 : adr z19.s, [z20.s, z21.s]                 : adr    (%z20.s,%z21.s) -> %z19.s
+04b7a2d5 : adr z21.s, [z22.s, z23.s]                 : adr    (%z22.s,%z23.s) -> %z21.s
+04b9a317 : adr z23.s, [z24.s, z25.s]                 : adr    (%z24.s,%z25.s) -> %z23.s
+04bba359 : adr z25.s, [z26.s, z27.s]                 : adr    (%z26.s,%z27.s) -> %z25.s
+04bda39b : adr z27.s, [z28.s, z29.s]                 : adr    (%z28.s,%z29.s) -> %z27.s
+04bfa3ff : adr z31.s, [z31.s, z31.s]                 : adr    (%z31.s,%z31.s) -> %z31.s
+04a0a400 : adr z0.s, [z0.s, z0.s, LSL #1]            : adr    (%z0.s,%z0.s,lsl #1) -> %z0.s
+04a4a462 : adr z2.s, [z3.s, z4.s, LSL #1]            : adr    (%z3.s,%z4.s,lsl #1) -> %z2.s
+04a6a4a4 : adr z4.s, [z5.s, z6.s, LSL #1]            : adr    (%z5.s,%z6.s,lsl #1) -> %z4.s
+04a8a4e6 : adr z6.s, [z7.s, z8.s, LSL #1]            : adr    (%z7.s,%z8.s,lsl #1) -> %z6.s
+04aaa528 : adr z8.s, [z9.s, z10.s, LSL #1]           : adr    (%z9.s,%z10.s,lsl #1) -> %z8.s
+04aca56a : adr z10.s, [z11.s, z12.s, LSL #1]         : adr    (%z11.s,%z12.s,lsl #1) -> %z10.s
+04aea5ac : adr z12.s, [z13.s, z14.s, LSL #1]         : adr    (%z13.s,%z14.s,lsl #1) -> %z12.s
+04b0a5ee : adr z14.s, [z15.s, z16.s, LSL #1]         : adr    (%z15.s,%z16.s,lsl #1) -> %z14.s
+04b2a630 : adr z16.s, [z17.s, z18.s, LSL #1]         : adr    (%z17.s,%z18.s,lsl #1) -> %z16.s
+04b3a651 : adr z17.s, [z18.s, z19.s, LSL #1]         : adr    (%z18.s,%z19.s,lsl #1) -> %z17.s
+04b5a693 : adr z19.s, [z20.s, z21.s, LSL #1]         : adr    (%z20.s,%z21.s,lsl #1) -> %z19.s
+04b7a6d5 : adr z21.s, [z22.s, z23.s, LSL #1]         : adr    (%z22.s,%z23.s,lsl #1) -> %z21.s
+04b9a717 : adr z23.s, [z24.s, z25.s, LSL #1]         : adr    (%z24.s,%z25.s,lsl #1) -> %z23.s
+04bba759 : adr z25.s, [z26.s, z27.s, LSL #1]         : adr    (%z26.s,%z27.s,lsl #1) -> %z25.s
+04bda79b : adr z27.s, [z28.s, z29.s, LSL #1]         : adr    (%z28.s,%z29.s,lsl #1) -> %z27.s
+04bfa7ff : adr z31.s, [z31.s, z31.s, LSL #1]         : adr    (%z31.s,%z31.s,lsl #1) -> %z31.s
+04a0a800 : adr z0.s, [z0.s, z0.s, LSL #2]            : adr    (%z0.s,%z0.s,lsl #2) -> %z0.s
+04a4a862 : adr z2.s, [z3.s, z4.s, LSL #2]            : adr    (%z3.s,%z4.s,lsl #2) -> %z2.s
+04a6a8a4 : adr z4.s, [z5.s, z6.s, LSL #2]            : adr    (%z5.s,%z6.s,lsl #2) -> %z4.s
+04a8a8e6 : adr z6.s, [z7.s, z8.s, LSL #2]            : adr    (%z7.s,%z8.s,lsl #2) -> %z6.s
+04aaa928 : adr z8.s, [z9.s, z10.s, LSL #2]           : adr    (%z9.s,%z10.s,lsl #2) -> %z8.s
+04aca96a : adr z10.s, [z11.s, z12.s, LSL #2]         : adr    (%z11.s,%z12.s,lsl #2) -> %z10.s
+04aea9ac : adr z12.s, [z13.s, z14.s, LSL #2]         : adr    (%z13.s,%z14.s,lsl #2) -> %z12.s
+04b0a9ee : adr z14.s, [z15.s, z16.s, LSL #2]         : adr    (%z15.s,%z16.s,lsl #2) -> %z14.s
+04b2aa30 : adr z16.s, [z17.s, z18.s, LSL #2]         : adr    (%z17.s,%z18.s,lsl #2) -> %z16.s
+04b3aa51 : adr z17.s, [z18.s, z19.s, LSL #2]         : adr    (%z18.s,%z19.s,lsl #2) -> %z17.s
+04b5aa93 : adr z19.s, [z20.s, z21.s, LSL #2]         : adr    (%z20.s,%z21.s,lsl #2) -> %z19.s
+04b7aad5 : adr z21.s, [z22.s, z23.s, LSL #2]         : adr    (%z22.s,%z23.s,lsl #2) -> %z21.s
+04b9ab17 : adr z23.s, [z24.s, z25.s, LSL #2]         : adr    (%z24.s,%z25.s,lsl #2) -> %z23.s
+04bbab59 : adr z25.s, [z26.s, z27.s, LSL #2]         : adr    (%z26.s,%z27.s,lsl #2) -> %z25.s
+04bdab9b : adr z27.s, [z28.s, z29.s, LSL #2]         : adr    (%z28.s,%z29.s,lsl #2) -> %z27.s
+04bfabff : adr z31.s, [z31.s, z31.s, LSL #2]         : adr    (%z31.s,%z31.s,lsl #2) -> %z31.s
+04a0ac00 : adr z0.s, [z0.s, z0.s, LSL #3]            : adr    (%z0.s,%z0.s,lsl #3) -> %z0.s
+04a4ac62 : adr z2.s, [z3.s, z4.s, LSL #3]            : adr    (%z3.s,%z4.s,lsl #3) -> %z2.s
+04a6aca4 : adr z4.s, [z5.s, z6.s, LSL #3]            : adr    (%z5.s,%z6.s,lsl #3) -> %z4.s
+04a8ace6 : adr z6.s, [z7.s, z8.s, LSL #3]            : adr    (%z7.s,%z8.s,lsl #3) -> %z6.s
+04aaad28 : adr z8.s, [z9.s, z10.s, LSL #3]           : adr    (%z9.s,%z10.s,lsl #3) -> %z8.s
+04acad6a : adr z10.s, [z11.s, z12.s, LSL #3]         : adr    (%z11.s,%z12.s,lsl #3) -> %z10.s
+04aeadac : adr z12.s, [z13.s, z14.s, LSL #3]         : adr    (%z13.s,%z14.s,lsl #3) -> %z12.s
+04b0adee : adr z14.s, [z15.s, z16.s, LSL #3]         : adr    (%z15.s,%z16.s,lsl #3) -> %z14.s
+04b2ae30 : adr z16.s, [z17.s, z18.s, LSL #3]         : adr    (%z17.s,%z18.s,lsl #3) -> %z16.s
+04b3ae51 : adr z17.s, [z18.s, z19.s, LSL #3]         : adr    (%z18.s,%z19.s,lsl #3) -> %z17.s
+04b5ae93 : adr z19.s, [z20.s, z21.s, LSL #3]         : adr    (%z20.s,%z21.s,lsl #3) -> %z19.s
+04b7aed5 : adr z21.s, [z22.s, z23.s, LSL #3]         : adr    (%z22.s,%z23.s,lsl #3) -> %z21.s
+04b9af17 : adr z23.s, [z24.s, z25.s, LSL #3]         : adr    (%z24.s,%z25.s,lsl #3) -> %z23.s
+04bbaf59 : adr z25.s, [z26.s, z27.s, LSL #3]         : adr    (%z26.s,%z27.s,lsl #3) -> %z25.s
+04bdaf9b : adr z27.s, [z28.s, z29.s, LSL #3]         : adr    (%z28.s,%z29.s,lsl #3) -> %z27.s
+04bfafff : adr z31.s, [z31.s, z31.s, LSL #3]         : adr    (%z31.s,%z31.s,lsl #3) -> %z31.s
+04e0a000 : adr z0.d, [z0.d, z0.d]                    : adr    (%z0.d,%z0.d) -> %z0.d
+04e4a062 : adr z2.d, [z3.d, z4.d]                    : adr    (%z3.d,%z4.d) -> %z2.d
+04e6a0a4 : adr z4.d, [z5.d, z6.d]                    : adr    (%z5.d,%z6.d) -> %z4.d
+04e8a0e6 : adr z6.d, [z7.d, z8.d]                    : adr    (%z7.d,%z8.d) -> %z6.d
+04eaa128 : adr z8.d, [z9.d, z10.d]                   : adr    (%z9.d,%z10.d) -> %z8.d
+04eca16a : adr z10.d, [z11.d, z12.d]                 : adr    (%z11.d,%z12.d) -> %z10.d
+04eea1ac : adr z12.d, [z13.d, z14.d]                 : adr    (%z13.d,%z14.d) -> %z12.d
+04f0a1ee : adr z14.d, [z15.d, z16.d]                 : adr    (%z15.d,%z16.d) -> %z14.d
+04f2a230 : adr z16.d, [z17.d, z18.d]                 : adr    (%z17.d,%z18.d) -> %z16.d
+04f3a251 : adr z17.d, [z18.d, z19.d]                 : adr    (%z18.d,%z19.d) -> %z17.d
+04f5a293 : adr z19.d, [z20.d, z21.d]                 : adr    (%z20.d,%z21.d) -> %z19.d
+04f7a2d5 : adr z21.d, [z22.d, z23.d]                 : adr    (%z22.d,%z23.d) -> %z21.d
+04f9a317 : adr z23.d, [z24.d, z25.d]                 : adr    (%z24.d,%z25.d) -> %z23.d
+04fba359 : adr z25.d, [z26.d, z27.d]                 : adr    (%z26.d,%z27.d) -> %z25.d
+04fda39b : adr z27.d, [z28.d, z29.d]                 : adr    (%z28.d,%z29.d) -> %z27.d
+04ffa3ff : adr z31.d, [z31.d, z31.d]                 : adr    (%z31.d,%z31.d) -> %z31.d
+04e0a400 : adr z0.d, [z0.d, z0.d, LSL #1]            : adr    (%z0.d,%z0.d,lsl #1) -> %z0.d
+04e4a462 : adr z2.d, [z3.d, z4.d, LSL #1]            : adr    (%z3.d,%z4.d,lsl #1) -> %z2.d
+04e6a4a4 : adr z4.d, [z5.d, z6.d, LSL #1]            : adr    (%z5.d,%z6.d,lsl #1) -> %z4.d
+04e8a4e6 : adr z6.d, [z7.d, z8.d, LSL #1]            : adr    (%z7.d,%z8.d,lsl #1) -> %z6.d
+04eaa528 : adr z8.d, [z9.d, z10.d, LSL #1]           : adr    (%z9.d,%z10.d,lsl #1) -> %z8.d
+04eca56a : adr z10.d, [z11.d, z12.d, LSL #1]         : adr    (%z11.d,%z12.d,lsl #1) -> %z10.d
+04eea5ac : adr z12.d, [z13.d, z14.d, LSL #1]         : adr    (%z13.d,%z14.d,lsl #1) -> %z12.d
+04f0a5ee : adr z14.d, [z15.d, z16.d, LSL #1]         : adr    (%z15.d,%z16.d,lsl #1) -> %z14.d
+04f2a630 : adr z16.d, [z17.d, z18.d, LSL #1]         : adr    (%z17.d,%z18.d,lsl #1) -> %z16.d
+04f3a651 : adr z17.d, [z18.d, z19.d, LSL #1]         : adr    (%z18.d,%z19.d,lsl #1) -> %z17.d
+04f5a693 : adr z19.d, [z20.d, z21.d, LSL #1]         : adr    (%z20.d,%z21.d,lsl #1) -> %z19.d
+04f7a6d5 : adr z21.d, [z22.d, z23.d, LSL #1]         : adr    (%z22.d,%z23.d,lsl #1) -> %z21.d
+04f9a717 : adr z23.d, [z24.d, z25.d, LSL #1]         : adr    (%z24.d,%z25.d,lsl #1) -> %z23.d
+04fba759 : adr z25.d, [z26.d, z27.d, LSL #1]         : adr    (%z26.d,%z27.d,lsl #1) -> %z25.d
+04fda79b : adr z27.d, [z28.d, z29.d, LSL #1]         : adr    (%z28.d,%z29.d,lsl #1) -> %z27.d
+04ffa7ff : adr z31.d, [z31.d, z31.d, LSL #1]         : adr    (%z31.d,%z31.d,lsl #1) -> %z31.d
+04e0a800 : adr z0.d, [z0.d, z0.d, LSL #2]            : adr    (%z0.d,%z0.d,lsl #2) -> %z0.d
+04e4a862 : adr z2.d, [z3.d, z4.d, LSL #2]            : adr    (%z3.d,%z4.d,lsl #2) -> %z2.d
+04e6a8a4 : adr z4.d, [z5.d, z6.d, LSL #2]            : adr    (%z5.d,%z6.d,lsl #2) -> %z4.d
+04e8a8e6 : adr z6.d, [z7.d, z8.d, LSL #2]            : adr    (%z7.d,%z8.d,lsl #2) -> %z6.d
+04eaa928 : adr z8.d, [z9.d, z10.d, LSL #2]           : adr    (%z9.d,%z10.d,lsl #2) -> %z8.d
+04eca96a : adr z10.d, [z11.d, z12.d, LSL #2]         : adr    (%z11.d,%z12.d,lsl #2) -> %z10.d
+04eea9ac : adr z12.d, [z13.d, z14.d, LSL #2]         : adr    (%z13.d,%z14.d,lsl #2) -> %z12.d
+04f0a9ee : adr z14.d, [z15.d, z16.d, LSL #2]         : adr    (%z15.d,%z16.d,lsl #2) -> %z14.d
+04f2aa30 : adr z16.d, [z17.d, z18.d, LSL #2]         : adr    (%z17.d,%z18.d,lsl #2) -> %z16.d
+04f3aa51 : adr z17.d, [z18.d, z19.d, LSL #2]         : adr    (%z18.d,%z19.d,lsl #2) -> %z17.d
+04f5aa93 : adr z19.d, [z20.d, z21.d, LSL #2]         : adr    (%z20.d,%z21.d,lsl #2) -> %z19.d
+04f7aad5 : adr z21.d, [z22.d, z23.d, LSL #2]         : adr    (%z22.d,%z23.d,lsl #2) -> %z21.d
+04f9ab17 : adr z23.d, [z24.d, z25.d, LSL #2]         : adr    (%z24.d,%z25.d,lsl #2) -> %z23.d
+04fbab59 : adr z25.d, [z26.d, z27.d, LSL #2]         : adr    (%z26.d,%z27.d,lsl #2) -> %z25.d
+04fdab9b : adr z27.d, [z28.d, z29.d, LSL #2]         : adr    (%z28.d,%z29.d,lsl #2) -> %z27.d
+04ffabff : adr z31.d, [z31.d, z31.d, LSL #2]         : adr    (%z31.d,%z31.d,lsl #2) -> %z31.d
+04e0ac00 : adr z0.d, [z0.d, z0.d, LSL #3]            : adr    (%z0.d,%z0.d,lsl #3) -> %z0.d
+04e4ac62 : adr z2.d, [z3.d, z4.d, LSL #3]            : adr    (%z3.d,%z4.d,lsl #3) -> %z2.d
+04e6aca4 : adr z4.d, [z5.d, z6.d, LSL #3]            : adr    (%z5.d,%z6.d,lsl #3) -> %z4.d
+04e8ace6 : adr z6.d, [z7.d, z8.d, LSL #3]            : adr    (%z7.d,%z8.d,lsl #3) -> %z6.d
+04eaad28 : adr z8.d, [z9.d, z10.d, LSL #3]           : adr    (%z9.d,%z10.d,lsl #3) -> %z8.d
+04ecad6a : adr z10.d, [z11.d, z12.d, LSL #3]         : adr    (%z11.d,%z12.d,lsl #3) -> %z10.d
+04eeadac : adr z12.d, [z13.d, z14.d, LSL #3]         : adr    (%z13.d,%z14.d,lsl #3) -> %z12.d
+04f0adee : adr z14.d, [z15.d, z16.d, LSL #3]         : adr    (%z15.d,%z16.d,lsl #3) -> %z14.d
+04f2ae30 : adr z16.d, [z17.d, z18.d, LSL #3]         : adr    (%z17.d,%z18.d,lsl #3) -> %z16.d
+04f3ae51 : adr z17.d, [z18.d, z19.d, LSL #3]         : adr    (%z18.d,%z19.d,lsl #3) -> %z17.d
+04f5ae93 : adr z19.d, [z20.d, z21.d, LSL #3]         : adr    (%z20.d,%z21.d,lsl #3) -> %z19.d
+04f7aed5 : adr z21.d, [z22.d, z23.d, LSL #3]         : adr    (%z22.d,%z23.d,lsl #3) -> %z21.d
+04f9af17 : adr z23.d, [z24.d, z25.d, LSL #3]         : adr    (%z24.d,%z25.d,lsl #3) -> %z23.d
+04fbaf59 : adr z25.d, [z26.d, z27.d, LSL #3]         : adr    (%z26.d,%z27.d,lsl #3) -> %z25.d
+04fdaf9b : adr z27.d, [z28.d, z29.d, LSL #3]         : adr    (%z28.d,%z29.d,lsl #3) -> %z27.d
+04ffafff : adr z31.d, [z31.d, z31.d, LSL #3]         : adr    (%z31.d,%z31.d,lsl #3) -> %z31.d
+
 041a06ff : and z31.b, p1/m, z31.b, z23.b            : and    %p1 %z31 %z23 $0x00 -> %z31
 045a06ff : and z31.h, p1/m, z31.h, z23.h            : and    %p1 %z31 %z23 $0x01 -> %z31
 049a06ff : and z31.s, p1/m, z31.s, z23.s            : and    %p1 %z31 %z23 $0x02 -> %z31

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -14666,6 +14666,236 @@ TEST_INSTR(prfw_sve_pred)
                                     OPSZ_0));
 }
 
+TEST_INSTR(adr_sve)
+{
+    /* Testing ADR     <Zd>.D, [<Zn>.D, <Zm>.D, SXTW <amount>] */
+    const char *const expected_0_0[6] = {
+        "adr    (%z0.d,%z0.d,sxtw) -> %z0.d",
+        "adr    (%z6.d,%z7.d,sxtw) -> %z5.d",
+        "adr    (%z11.d,%z12.d,sxtw) -> %z10.d",
+        "adr    (%z17.d,%z18.d,sxtw) -> %z16.d",
+        "adr    (%z22.d,%z23.d,sxtw) -> %z21.d",
+        "adr    (%z31.d,%z31.d,sxtw) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_SXTW, false, 0, 0,
+                                                   OPSZ_0, 0));
+
+    const char *const expected_0_1[6] = {
+        "adr    (%z0.d,%z0.d,sxtw #1) -> %z0.d",
+        "adr    (%z6.d,%z7.d,sxtw #1) -> %z5.d",
+        "adr    (%z11.d,%z12.d,sxtw #1) -> %z10.d",
+        "adr    (%z17.d,%z18.d,sxtw #1) -> %z16.d",
+        "adr    (%z22.d,%z23.d,sxtw #1) -> %z21.d",
+        "adr    (%z31.d,%z31.d,sxtw #1) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_SXTW, true, 0, 0,
+                                                   OPSZ_0, 1));
+
+    const char *const expected_0_2[6] = {
+        "adr    (%z0.d,%z0.d,sxtw #2) -> %z0.d",
+        "adr    (%z6.d,%z7.d,sxtw #2) -> %z5.d",
+        "adr    (%z11.d,%z12.d,sxtw #2) -> %z10.d",
+        "adr    (%z17.d,%z18.d,sxtw #2) -> %z16.d",
+        "adr    (%z22.d,%z23.d,sxtw #2) -> %z21.d",
+        "adr    (%z31.d,%z31.d,sxtw #2) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_SXTW, true, 0, 0,
+                                                   OPSZ_0, 2));
+
+    const char *const expected_0_3[6] = {
+        "adr    (%z0.d,%z0.d,sxtw #3) -> %z0.d",
+        "adr    (%z6.d,%z7.d,sxtw #3) -> %z5.d",
+        "adr    (%z11.d,%z12.d,sxtw #3) -> %z10.d",
+        "adr    (%z17.d,%z18.d,sxtw #3) -> %z16.d",
+        "adr    (%z22.d,%z23.d,sxtw #3) -> %z21.d",
+        "adr    (%z31.d,%z31.d,sxtw #3) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_SXTW, true, 0, 0,
+                                                   OPSZ_0, 3));
+
+    /* Testing ADR     <Zd>.D, [<Zn>.D, <Zm>.D, UXTW <amount>] */
+    const char *const expected_1_0[6] = {
+        "adr    (%z0.d,%z0.d,uxtw) -> %z0.d",
+        "adr    (%z6.d,%z7.d,uxtw) -> %z5.d",
+        "adr    (%z11.d,%z12.d,uxtw) -> %z10.d",
+        "adr    (%z17.d,%z18.d,uxtw) -> %z16.d",
+        "adr    (%z22.d,%z23.d,uxtw) -> %z21.d",
+        "adr    (%z31.d,%z31.d,uxtw) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTW, false, 0, 0,
+                                                   OPSZ_0, 0));
+
+    const char *const expected_1_1[6] = {
+        "adr    (%z0.d,%z0.d,uxtw #1) -> %z0.d",
+        "adr    (%z6.d,%z7.d,uxtw #1) -> %z5.d",
+        "adr    (%z11.d,%z12.d,uxtw #1) -> %z10.d",
+        "adr    (%z17.d,%z18.d,uxtw #1) -> %z16.d",
+        "adr    (%z22.d,%z23.d,uxtw #1) -> %z21.d",
+        "adr    (%z31.d,%z31.d,uxtw #1) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_1_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTW, true, 0, 0,
+                                                   OPSZ_0, 1));
+
+    const char *const expected_1_2[6] = {
+        "adr    (%z0.d,%z0.d,uxtw #2) -> %z0.d",
+        "adr    (%z6.d,%z7.d,uxtw #2) -> %z5.d",
+        "adr    (%z11.d,%z12.d,uxtw #2) -> %z10.d",
+        "adr    (%z17.d,%z18.d,uxtw #2) -> %z16.d",
+        "adr    (%z22.d,%z23.d,uxtw #2) -> %z21.d",
+        "adr    (%z31.d,%z31.d,uxtw #2) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_1_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTW, true, 0, 0,
+                                                   OPSZ_0, 2));
+
+    const char *const expected_1_3[6] = {
+        "adr    (%z0.d,%z0.d,uxtw #3) -> %z0.d",
+        "adr    (%z6.d,%z7.d,uxtw #3) -> %z5.d",
+        "adr    (%z11.d,%z12.d,uxtw #3) -> %z10.d",
+        "adr    (%z17.d,%z18.d,uxtw #3) -> %z16.d",
+        "adr    (%z22.d,%z23.d,uxtw #3) -> %z21.d",
+        "adr    (%z31.d,%z31.d,uxtw #3) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_1_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTW, true, 0, 0,
+                                                   OPSZ_0, 3));
+
+    /* Testing ADR     <Zd>.<Ts>, [<Zn>.<Ts>, <Zm>.<Ts>, <extend> <amount>] */
+    const char *const expected_2_0[6] = {
+        "adr    (%z0.s,%z0.s) -> %z0.s",
+        "adr    (%z6.s,%z7.s) -> %z5.s",
+        "adr    (%z11.s,%z12.s) -> %z10.s",
+        "adr    (%z17.s,%z18.s) -> %z16.s",
+        "adr    (%z22.s,%z23.s) -> %z21.s",
+        "adr    (%z31.s,%z31.s) -> %z31.s",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, false, 0, 0,
+                                                   OPSZ_0, 0));
+
+    const char *const expected_2_1[6] = {
+        "adr    (%z0.s,%z0.s,lsl #1) -> %z0.s",
+        "adr    (%z6.s,%z7.s,lsl #1) -> %z5.s",
+        "adr    (%z11.s,%z12.s,lsl #1) -> %z10.s",
+        "adr    (%z17.s,%z18.s,lsl #1) -> %z16.s",
+        "adr    (%z22.s,%z23.s,lsl #1) -> %z21.s",
+        "adr    (%z31.s,%z31.s,lsl #1) -> %z31.s",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, true, 0, 0,
+                                                   OPSZ_0, 1));
+
+    const char *const expected_2_2[6] = {
+        "adr    (%z0.s,%z0.s,lsl #2) -> %z0.s",
+        "adr    (%z6.s,%z7.s,lsl #2) -> %z5.s",
+        "adr    (%z11.s,%z12.s,lsl #2) -> %z10.s",
+        "adr    (%z17.s,%z18.s,lsl #2) -> %z16.s",
+        "adr    (%z22.s,%z23.s,lsl #2) -> %z21.s",
+        "adr    (%z31.s,%z31.s,lsl #2) -> %z31.s",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, true, 0, 0,
+                                                   OPSZ_0, 2));
+
+    const char *const expected_2_3[6] = {
+        "adr    (%z0.s,%z0.s,lsl #3) -> %z0.s",
+        "adr    (%z6.s,%z7.s,lsl #3) -> %z5.s",
+        "adr    (%z11.s,%z12.s,lsl #3) -> %z10.s",
+        "adr    (%z17.s,%z18.s,lsl #3) -> %z16.s",
+        "adr    (%z22.s,%z23.s,lsl #3) -> %z21.s",
+        "adr    (%z31.s,%z31.s,lsl #3) -> %z31.s",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, true, 0, 0,
+                                                   OPSZ_0, 3));
+
+    const char *const expected_2_4[6] = {
+        "adr    (%z0.d,%z0.d) -> %z0.d",
+        "adr    (%z6.d,%z7.d) -> %z5.d",
+        "adr    (%z11.d,%z12.d) -> %z10.d",
+        "adr    (%z17.d,%z18.d) -> %z16.d",
+        "adr    (%z22.d,%z23.d) -> %z21.d",
+        "adr    (%z31.d,%z31.d) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_4[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, false, 0, 0,
+                                                   OPSZ_0, 0));
+
+    const char *const expected_2_5[6] = {
+        "adr    (%z0.d,%z0.d,lsl #1) -> %z0.d",
+        "adr    (%z6.d,%z7.d,lsl #1) -> %z5.d",
+        "adr    (%z11.d,%z12.d,lsl #1) -> %z10.d",
+        "adr    (%z17.d,%z18.d,lsl #1) -> %z16.d",
+        "adr    (%z22.d,%z23.d,lsl #1) -> %z21.d",
+        "adr    (%z31.d,%z31.d,lsl #1) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_5[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, true, 0, 0,
+                                                   OPSZ_0, 1));
+
+    const char *const expected_2_6[6] = {
+        "adr    (%z0.d,%z0.d,lsl #2) -> %z0.d",
+        "adr    (%z6.d,%z7.d,lsl #2) -> %z5.d",
+        "adr    (%z11.d,%z12.d,lsl #2) -> %z10.d",
+        "adr    (%z17.d,%z18.d,lsl #2) -> %z16.d",
+        "adr    (%z22.d,%z23.d,lsl #2) -> %z21.d",
+        "adr    (%z31.d,%z31.d,lsl #2) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_6[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, true, 0, 0,
+                                                   OPSZ_0, 2));
+
+    const char *const expected_2_7[6] = {
+        "adr    (%z0.d,%z0.d,lsl #3) -> %z0.d",
+        "adr    (%z6.d,%z7.d,lsl #3) -> %z5.d",
+        "adr    (%z11.d,%z12.d,lsl #3) -> %z10.d",
+        "adr    (%z17.d,%z18.d,lsl #3) -> %z16.d",
+        "adr    (%z22.d,%z23.d,lsl #3) -> %z21.d",
+        "adr    (%z31.d,%z31.d,lsl #3) -> %z31.d",
+    };
+    TEST_LOOP(adr, adr_sve, 6, expected_2_7[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_1[i], Zn_six_offset_2[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, true, 0, 0,
+                                                   OPSZ_0, 3));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -15028,6 +15258,7 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(addpl);
     RUN_INSTR_TEST(addvl);
+    RUN_INSTR_TEST(adr_sve);
     RUN_INSTR_TEST(rdvl);
 
     RUN_INSTR_TEST(fabd_sve);

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -14670,12 +14670,9 @@ TEST_INSTR(adr_sve)
 {
     /* Testing ADR     <Zd>.D, [<Zn>.D, <Zm>.D, SXTW <amount>] */
     const char *const expected_0_0[6] = {
-        "adr    (%z0.d,%z0.d,sxtw) -> %z0.d",
-        "adr    (%z6.d,%z7.d,sxtw) -> %z5.d",
-        "adr    (%z11.d,%z12.d,sxtw) -> %z10.d",
-        "adr    (%z17.d,%z18.d,sxtw) -> %z16.d",
-        "adr    (%z22.d,%z23.d,sxtw) -> %z21.d",
-        "adr    (%z31.d,%z31.d,sxtw) -> %z31.d",
+        "adr    (%z0.d,%z0.d,sxtw) -> %z0.d",    "adr    (%z6.d,%z7.d,sxtw) -> %z5.d",
+        "adr    (%z11.d,%z12.d,sxtw) -> %z10.d", "adr    (%z17.d,%z18.d,sxtw) -> %z16.d",
+        "adr    (%z22.d,%z23.d,sxtw) -> %z21.d", "adr    (%z31.d,%z31.d,sxtw) -> %z31.d",
     };
     TEST_LOOP(adr, adr_sve, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -14727,12 +14724,9 @@ TEST_INSTR(adr_sve)
 
     /* Testing ADR     <Zd>.D, [<Zn>.D, <Zm>.D, UXTW <amount>] */
     const char *const expected_1_0[6] = {
-        "adr    (%z0.d,%z0.d,uxtw) -> %z0.d",
-        "adr    (%z6.d,%z7.d,uxtw) -> %z5.d",
-        "adr    (%z11.d,%z12.d,uxtw) -> %z10.d",
-        "adr    (%z17.d,%z18.d,uxtw) -> %z16.d",
-        "adr    (%z22.d,%z23.d,uxtw) -> %z21.d",
-        "adr    (%z31.d,%z31.d,uxtw) -> %z31.d",
+        "adr    (%z0.d,%z0.d,uxtw) -> %z0.d",    "adr    (%z6.d,%z7.d,uxtw) -> %z5.d",
+        "adr    (%z11.d,%z12.d,uxtw) -> %z10.d", "adr    (%z17.d,%z18.d,uxtw) -> %z16.d",
+        "adr    (%z22.d,%z23.d,uxtw) -> %z21.d", "adr    (%z31.d,%z31.d,uxtw) -> %z31.d",
     };
     TEST_LOOP(adr, adr_sve, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -14784,12 +14778,9 @@ TEST_INSTR(adr_sve)
 
     /* Testing ADR     <Zd>.<Ts>, [<Zn>.<Ts>, <Zm>.<Ts>, <extend> <amount>] */
     const char *const expected_2_0[6] = {
-        "adr    (%z0.s,%z0.s) -> %z0.s",
-        "adr    (%z6.s,%z7.s) -> %z5.s",
-        "adr    (%z11.s,%z12.s) -> %z10.s",
-        "adr    (%z17.s,%z18.s) -> %z16.s",
-        "adr    (%z22.s,%z23.s) -> %z21.s",
-        "adr    (%z31.s,%z31.s) -> %z31.s",
+        "adr    (%z0.s,%z0.s) -> %z0.s",    "adr    (%z6.s,%z7.s) -> %z5.s",
+        "adr    (%z11.s,%z12.s) -> %z10.s", "adr    (%z17.s,%z18.s) -> %z16.s",
+        "adr    (%z22.s,%z23.s) -> %z21.s", "adr    (%z31.s,%z31.s) -> %z31.s",
     };
     TEST_LOOP(adr, adr_sve, 6, expected_2_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
@@ -14840,12 +14831,9 @@ TEST_INSTR(adr_sve)
                                                    OPSZ_0, 3));
 
     const char *const expected_2_4[6] = {
-        "adr    (%z0.d,%z0.d) -> %z0.d",
-        "adr    (%z6.d,%z7.d) -> %z5.d",
-        "adr    (%z11.d,%z12.d) -> %z10.d",
-        "adr    (%z17.d,%z18.d) -> %z16.d",
-        "adr    (%z22.d,%z23.d) -> %z21.d",
-        "adr    (%z31.d,%z31.d) -> %z31.d",
+        "adr    (%z0.d,%z0.d) -> %z0.d",    "adr    (%z6.d,%z7.d) -> %z5.d",
+        "adr    (%z11.d,%z12.d) -> %z10.d", "adr    (%z17.d,%z18.d) -> %z16.d",
+        "adr    (%z22.d,%z23.d) -> %z21.d", "adr    (%z31.d,%z31.d) -> %z31.d",
     };
     TEST_LOOP(adr, adr_sve, 6, expected_2_4[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
ADR     <Zd>.D, [<Zn>.D, <Zm>.D, SXTW <amount>]
ADR     <Zd>.D, [<Zn>.D, <Zm>.D, UXTW <amount>]
ADR     <Zd>.<Ts>, [<Zn>.<Ts>, <Zm>.<Ts>, <extend> <amount>]
```

and the required changes to support the use of vector registers in base+disp adress operands.

This required two main changes:

1) Adding element size to base disp operand

 ADR uses Z vector registers for the base and index register so we
 need to be able to specify the element size in the operand.

 This adds an element size field to base+disp operands (AArch64
 only). The following sizes are supported:
     OPSZ_4: Single
     OPSZ_8: Double

 For example, the memory operand for:
```
     adr z0.d, [z1.d, z2.d, lsl 2]
```

 could be created with the call:
```
  opnd_create_vector_base_disp_aarch64(DR_REG_Z1, DR_REG_Z2,
                                       OPSZ_8, // Element size
                                       DR_EXTEND_UXTX, // LSL
                                       true, 0, 0,
                                       OPSZ_0, // Transfers 0 bytes
                                       2); // Shift amount
```
 This will also be needed for SVE scatter/gather instructions.

2) Move DR_REG_Z* < 256

 opnd_t only stores the first 8 bits of the reg_id_t values for the base
 and index, so in order to use a Z register in an address operand we need
 to make sure the DR_REG_Z* constants are < 256.

 While I was there I also added the Z and P registers and one system
 register to the dr_reg_fixer array as they were previously missing.
 The B, H, S, D, Q registers have been changed to map to the Z registers
 because they overlap with the lower 128 bits of the Z registers.

Issues: #3044