### PR TITLE
i#4489 drcachesim: support any cache associativity

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -145,37 +145,41 @@ droption_t<unsigned int> op_num_cores(DROPTION_SCOPE_FRONTEND, "cores", 4,
 droption_t<unsigned int> op_line_size(
     DROPTION_SCOPE_FRONTEND, "line_size", 64, "Cache line size",
     "Specifies the cache line size, which is assumed to be identical for L1 and L2 "
-    "caches.  Must be a power of 2.");
+    "caches.  Must be at least 4 and a power of 2.");
 
-droption_t<bytesize_t> op_L1I_size(
-    DROPTION_SCOPE_FRONTEND, "L1I_size", 32 * 1024U, "Instruction cache total size",
-    "Specifies the total size of each L1 instruction cache.  Must be a power of 2 "
-    "and a multiple of -line_size.");
+droption_t<bytesize_t>
+    op_L1I_size(DROPTION_SCOPE_FRONTEND, "L1I_size", 32 * 1024U,
+                "Instruction cache total size",
+                "Specifies the total size of each L1 instruction cache."
+                " L1I_size/L1I_assoc must be a power of 2 and a multiple of -line_size.");
 
 droption_t<bytesize_t>
     op_L1D_size(DROPTION_SCOPE_FRONTEND, "L1D_size", bytesize_t(32 * 1024),
                 "Data cache total size",
-                "Specifies the total size of each L1 data cache.  Must be a power of 2 "
-                "and a multiple of -line_size.");
+                "Specifies the total size of each L1 data cache."
+                " L1D_size/L1D_assoc must be a power of 2 and a multiple of -line_size.");
 
 droption_t<unsigned int> op_L1I_assoc(
     DROPTION_SCOPE_FRONTEND, "L1I_assoc", 8, "Instruction cache associativity",
-    "Specifies the associativity of each L1 instruction cache.  Must be a power of 2.");
+    "Specifies the associativity of each L1 instruction cache."
+    " L1I_size/L1I_assoc must be a power of 2 and a multiple of -line_size.");
 
 droption_t<unsigned int> op_L1D_assoc(
     DROPTION_SCOPE_FRONTEND, "L1D_assoc", 8, "Data cache associativity",
-    "Specifies the associativity of each L1 data cache.  Must be a power of 2.");
+    "Specifies the associativity of each L1 data cache."
+    " L1D_size/L1D_assoc must be a power of 2 and a multiple of -line_size.");
 
 droption_t<bytesize_t> op_LL_size(DROPTION_SCOPE_FRONTEND, "LL_size", 8 * 1024 * 1024,
                                   "Last-level cache total size",
                                   "Specifies the total size of the unified last-level "
-                                  "(L2) cache.  Must be a power of 2 "
-                                  "and a multiple of -line_size.");
+                                  "(L2) cache."
+                                  " LL_size/LL_assoc must be a power of 2"
+                                  " and a multiple of -line_size.");
 
 droption_t<unsigned int>
     op_LL_assoc(DROPTION_SCOPE_FRONTEND, "LL_assoc", 16, "Last-level cache associativity",
                 "Specifies the associativity of the unified last-level (L2) cache.  "
-                "Must be a power of 2.");
+                " LL_size/LL_assoc must be a power of 2 and a multiple of -line_size.");
 
 droption_t<std::string> op_LL_miss_file(
     DROPTION_SCOPE_FRONTEND, "LL_miss_file", "",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -150,36 +150,37 @@ droption_t<unsigned int> op_line_size(
 droption_t<bytesize_t>
     op_L1I_size(DROPTION_SCOPE_FRONTEND, "L1I_size", 32 * 1024U,
                 "Instruction cache total size",
-                "Specifies the total size of each L1 instruction cache."
-                " L1I_size/L1I_assoc must be a power of 2 and a multiple of -line_size.");
+                "Specifies the total size of each L1 instruction cache. "
+                "L1I_size/L1I_assoc must be a power of 2 and a multiple of line_size.");
 
 droption_t<bytesize_t>
     op_L1D_size(DROPTION_SCOPE_FRONTEND, "L1D_size", bytesize_t(32 * 1024),
                 "Data cache total size",
-                "Specifies the total size of each L1 data cache."
-                " L1D_size/L1D_assoc must be a power of 2 and a multiple of -line_size.");
+                "Specifies the total size of each L1 data cache. "
+                "L1D_size/L1D_assoc must be a power of 2 and a multiple of line_size.");
 
-droption_t<unsigned int> op_L1I_assoc(
-    DROPTION_SCOPE_FRONTEND, "L1I_assoc", 8, "Instruction cache associativity",
-    "Specifies the associativity of each L1 instruction cache."
-    " L1I_size/L1I_assoc must be a power of 2 and a multiple of -line_size.");
+droption_t<unsigned int>
+    op_L1I_assoc(DROPTION_SCOPE_FRONTEND, "L1I_assoc", 8,
+                 "Instruction cache associativity",
+                 "Specifies the associativity of each L1 instruction cache. "
+                 "L1I_size/L1I_assoc must be a power of 2 and a multiple of line_size.");
 
-droption_t<unsigned int> op_L1D_assoc(
-    DROPTION_SCOPE_FRONTEND, "L1D_assoc", 8, "Data cache associativity",
-    "Specifies the associativity of each L1 data cache."
-    " L1D_size/L1D_assoc must be a power of 2 and a multiple of -line_size.");
+droption_t<unsigned int>
+    op_L1D_assoc(DROPTION_SCOPE_FRONTEND, "L1D_assoc", 8, "Data cache associativity",
+                 "Specifies the associativity of each L1 data cache. "
+                 "L1D_size/L1D_assoc must be a power of 2 and a multiple of line_size.");
 
 droption_t<bytesize_t> op_LL_size(DROPTION_SCOPE_FRONTEND, "LL_size", 8 * 1024 * 1024,
                                   "Last-level cache total size",
                                   "Specifies the total size of the unified last-level "
-                                  "(L2) cache."
-                                  " LL_size/LL_assoc must be a power of 2"
-                                  " and a multiple of -line_size.");
+                                  "(L2) cache. "
+                                  "LL_size/LL_assoc must be a power of 2 "
+                                  "and a multiple of line_size.");
 
 droption_t<unsigned int>
     op_LL_assoc(DROPTION_SCOPE_FRONTEND, "LL_assoc", 16, "Last-level cache associativity",
-                "Specifies the associativity of the unified last-level (L2) cache.  "
-                " LL_size/LL_assoc must be a power of 2 and a multiple of -line_size.");
+                "Specifies the associativity of the unified last-level (L2) cache. "
+                "LL_size/LL_assoc must be a power of 2 and a multiple of line_size.");
 
 droption_t<std::string> op_LL_miss_file(
     DROPTION_SCOPE_FRONTEND, "LL_miss_file", "",
@@ -202,7 +203,7 @@ droption_t<bool> op_L0I_filter(
     "Filter out first-level instruction cache hits during tracing",
     "Filters out instruction hits in a 'zero-level' cache during tracing itself, "
     "shrinking the final trace to only contain instructions that miss in this initial "
-    "cache.  This cache is direct-mapped with size equal to -L0I_size.  It uses virtual "
+    "cache.  This cache is direct-mapped with size equal to L0I_size.  It uses virtual "
     "addresses regardless of -use_physical. The dynamic (pre-filtered) per-thread "
     "instruction count is tracked and supplied via a "
     "#TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at thread buffer boundaries and at "
@@ -213,21 +214,21 @@ droption_t<bool> op_L0D_filter(
     "Filter out first-level data cache hits during tracing",
     "Filters out data hits in a 'zero-level' cache during tracing itself, shrinking the "
     "final trace to only contain data accesses that miss in this initial cache.  This "
-    "cache is direct-mapped with size equal to -L0D_size.  It uses virtual addresses "
+    "cache is direct-mapped with size equal to L0D_size.  It uses virtual addresses "
     "regardless of -use_physical. ");
 
 droption_t<bytesize_t> op_L0I_size(
     DROPTION_SCOPE_CLIENT, "L0I_size", 32 * 1024U,
     "If -L0I_filter, filter out instruction hits during tracing",
-    "Specifies the size of the 'zero-level' instruction cache for -L0I_filter.  "
-    "Must be a power of 2 and a multiple of -line_size, unless it is set to 0, "
+    "Specifies the size of the 'zero-level' instruction cache for L0I_filter.  "
+    "Must be a power of 2 and a multiple of line_size, unless it is set to 0, "
     "which disables instruction fetch entries from appearing in the trace.");
 
 droption_t<bytesize_t> op_L0D_size(
     DROPTION_SCOPE_CLIENT, "L0D_size", 32 * 1024U,
     "If -L0D_filter, filter out data hits during tracing",
-    "Specifies the size of the 'zero-level' data cache for -L0D_filter.  "
-    "Must be a power of 2 and a multiple of -line_size, unless it is set to 0, "
+    "Specifies the size of the 'zero-level' data cache for L0D_filter.  "
+    "Must be a power of 2 and a multiple of line_size, unless it is set to 0, "
     "which disables data entries from appearing in the trace.");
 
 droption_t<bool> op_instr_only_trace(

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -228,21 +228,19 @@ config_reader_t::configure_cache(cache_params_t &cache)
                 ERRMSG("Unusable cache size %s\n", size_str.c_str());
                 return false;
             }
-            if (cache.size <= 0 || !IS_POWER_OF_2(cache.size)) {
-                ERRMSG("Cache size (%llu) must be >0 and a power of 2\n",
-                       (unsigned long long)cache.size);
+            if (cache.size <= 0) {
+                ERRMSG("Cache size (%llu) must be >0\n", (unsigned long long)cache.size);
                 return false;
             }
         } else if (param == "assoc") {
-            // Cache associativity_. Must be a power of 2.
+            // Cache associativity_.
             if (!(*fin_ >> cache.assoc)) {
                 ERRMSG("Error reading cache assoc from "
                        "the configuration file\n");
                 return false;
             }
-            if (cache.assoc <= 0 || !IS_POWER_OF_2(cache.assoc)) {
-                ERRMSG("Cache associativity (%u) must be >0 and a power of 2\n",
-                       cache.assoc);
+            if (cache.assoc <= 0) {
+                ERRMSG("Cache associativity (%u) must be >0\n", cache.assoc);
                 return false;
             }
         } else if (param == "inclusive") {

--- a/clients/drcachesim/simulator/cache.cpp
+++ b/clients/drcachesim/simulator/cache.cpp
@@ -40,6 +40,9 @@ cache_t::init(int associativity, int line_size, int total_size, caching_device_t
               bool coherent_cache, int id, snoop_filter_t *snoop_filter,
               const std::vector<caching_device_t *> &children)
 {
+    // Check line_size here to avoid divide-by-0.
+    if (line_size < 1)
+        return false;
     // convert total_size to num_blocks to fit for caching_device_t::init
     int num_lines = total_size / line_size;
 

--- a/clients/drcachesim/simulator/cache.cpp
+++ b/clients/drcachesim/simulator/cache.cpp
@@ -40,7 +40,7 @@ cache_t::init(int associativity, int line_size, int total_size, caching_device_t
               bool coherent_cache, int id, snoop_filter_t *snoop_filter,
               const std::vector<caching_device_t *> &children)
 {
-    // Check line_size here to avoid divide-by-0.
+    // Check line_size to avoid divide-by-0.
     if (line_size < 1)
         return false;
     // convert total_size to num_blocks to fit for caching_device_t::init

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -57,7 +57,7 @@ cache_fifo_t::init(int associativity, int block_size, int total_size,
     // Create a replacement pointer for each set, and
     // initialize it to point to the first block.
     for (int i = 0; i < blocks_per_set_; i++) {
-        get_caching_device_block(i << assoc_bits_, 0).counter_ = 1;
+        get_caching_device_block(i * associativity_, 0).counter_ = 1;
     }
     return true;
 }

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -56,7 +56,7 @@ cache_fifo_t::init(int associativity, int block_size, int total_size,
 
     // Create a replacement pointer for each set, and
     // initialize it to point to the first block.
-    for (int i = 0; i < blocks_per_set_; i++) {
+    for (int i = 0; i < blocks_per_way_; i++) {
         get_caching_device_block(i * associativity_, 0).counter_ = 1;
     }
     return true;

--- a/clients/drcachesim/simulator/cache_lru.cpp
+++ b/clients/drcachesim/simulator/cache_lru.cpp
@@ -56,7 +56,7 @@ cache_lru_t::init(int associativity, int block_size, int total_size,
     // Initialize line counters with 0, 1, 2, ..., associativity - 1.
     for (int i = 0; i < blocks_per_set_; i++) {
         for (int way = 0; way < associativity_; ++way) {
-            get_caching_device_block(i << assoc_bits_, way).counter_ = way;
+            get_caching_device_block(i * associativity_, way).counter_ = way;
         }
     }
     return true;

--- a/clients/drcachesim/simulator/cache_lru.cpp
+++ b/clients/drcachesim/simulator/cache_lru.cpp
@@ -54,7 +54,7 @@ cache_lru_t::init(int associativity, int block_size, int total_size,
         return false;
 
     // Initialize line counters with 0, 1, 2, ..., associativity - 1.
-    for (int i = 0; i < blocks_per_set_; i++) {
+    for (int i = 0; i < blocks_per_way_; i++) {
         for (int way = 0; way < associativity_; ++way) {
             get_caching_device_block(i * associativity_, way).counter_ = way;
         }

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -108,8 +108,8 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
                    new cache_stats_t((int)knobs_.line_size, knobs_.LL_miss_file,
                                      warmup_enabled_))) {
         error_string_ =
-            "Usage error: failed to initialize LL cache.  Ensure sizes and "
-            "associativity are powers of 2, that the total size is a multiple "
+            "Usage error: failed to initialize LL cache.  Ensure size divided by "
+            "associativity is a power of 2, that the total size is a multiple "
             "of the line size, and that any miss file path is writable.";
         success_ = false;
         return;
@@ -155,7 +155,7 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
                 false /*inclusive*/, knobs_.model_coherence, (2 * i) + 1,
                 snoop_filter_)) {
             error_string_ = "Usage error: failed to initialize L1 caches.  Ensure sizes "
-                            "and associativity are powers of 2 "
+                            "divided by associativities are powers of 2 "
                             "and that the total sizes are multiples of the line size.";
             success_ = false;
             return;
@@ -654,9 +654,9 @@ cache_simulator_t::create_cache(const std::string &policy)
     if (policy == REPLACE_POLICY_NON_SPECIFIED || // default LRU
         policy == REPLACE_POLICY_LRU)             // set to LRU
         return new cache_lru_t;
-    if (policy == REPLACE_POLICY_LFU) // set to LFU
+    if (policy == REPLACE_POLICY_LFU)             // set to LFU
         return new cache_t;
-    if (policy == REPLACE_POLICY_FIFO) // set to FIFO
+    if (policy == REPLACE_POLICY_FIFO)            // set to FIFO
         return new cache_fifo_t;
 
     // undefined replacement policy

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -654,9 +654,9 @@ cache_simulator_t::create_cache(const std::string &policy)
     if (policy == REPLACE_POLICY_NON_SPECIFIED || // default LRU
         policy == REPLACE_POLICY_LRU)             // set to LRU
         return new cache_lru_t;
-    if (policy == REPLACE_POLICY_LFU)             // set to LFU
+    if (policy == REPLACE_POLICY_LFU) // set to LFU
         return new cache_t;
-    if (policy == REPLACE_POLICY_FIFO)            // set to FIFO
+    if (policy == REPLACE_POLICY_FIFO) // set to FIFO
         return new cache_fifo_t;
 
     // undefined replacement policy

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -65,10 +65,11 @@ caching_device_t::init(int associativity, int block_size, int num_blocks,
                        int id, snoop_filter_t *snoop_filter,
                        const std::vector<caching_device_t *> &children)
 {
-    if (!IS_POWER_OF_2(associativity) || !IS_POWER_OF_2(block_size) ||
-        !IS_POWER_OF_2(num_blocks) ||
-        // Assuming caching device block size is at least 4 bytes
-        block_size < 4)
+    // Assume cache has nonzero capacity.
+    if (associativity < 1 || num_blocks < 1)
+        return false;
+    // Assume caching device block size is at least 4 bytes.
+    if (!IS_POWER_OF_2(block_size) || block_size < 4)
         return false;
     if (stats == NULL)
         return false; // A stats must be provided for perf: avoid conditional code
@@ -79,10 +80,14 @@ caching_device_t::init(int associativity, int block_size, int num_blocks,
     num_blocks_ = num_blocks;
     loaded_blocks_ = 0;
     blocks_per_set_ = num_blocks_ / associativity;
-    assoc_bits_ = compute_log2(associativity_);
-    block_size_bits_ = compute_log2(block_size);
+    // Make sure num_blocks_ is evenly divisible by associativity
+    if (blocks_per_set_ * associativity_ != num_blocks_)
+        return false;
     blocks_per_set_mask_ = blocks_per_set_ - 1;
-    if (assoc_bits_ == -1 || block_size_bits_ == -1 || !IS_POWER_OF_2(blocks_per_set_))
+    block_size_bits_ = compute_log2(block_size);
+    // Non-power-of-two associativities and total cache sizes are allowed, so
+    // long as the number blocks per cache way is a power of two.
+    if (block_size_bits_ == -1 || !IS_POWER_OF_2(blocks_per_set_))
         return false;
     parent_ = parent;
     stats_ = stats;

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -79,15 +79,15 @@ caching_device_t::init(int associativity, int block_size, int num_blocks,
     block_size_ = block_size;
     num_blocks_ = num_blocks;
     loaded_blocks_ = 0;
-    blocks_per_set_ = num_blocks_ / associativity;
+    blocks_per_way_ = num_blocks_ / associativity;
     // Make sure num_blocks_ is evenly divisible by associativity
-    if (blocks_per_set_ * associativity_ != num_blocks_)
+    if (blocks_per_way_ * associativity_ != num_blocks_)
         return false;
-    blocks_per_set_mask_ = blocks_per_set_ - 1;
+    blocks_per_way_mask_ = blocks_per_way_ - 1;
     block_size_bits_ = compute_log2(block_size);
     // Non-power-of-two associativities and total cache sizes are allowed, so
     // long as the number blocks per cache way is a power of two.
-    if (block_size_bits_ == -1 || !IS_POWER_OF_2(blocks_per_set_))
+    if (block_size_bits_ == -1 || !IS_POWER_OF_2(blocks_per_way_))
         return false;
     parent_ = parent;
     stats_ = stats;

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -142,7 +142,7 @@ protected:
     inline int
     compute_block_idx(addr_t tag) const
     {
-        return (tag & blocks_per_set_mask_) << assoc_bits_;
+        return (tag & blocks_per_set_mask_) * associativity_;
     }
     inline caching_device_block_t &
     get_caching_device_block(int block_idx, int way) const
@@ -181,8 +181,8 @@ protected:
     init_blocks() = 0;
 
     int associativity_;
-    int block_size_;
-    int num_blocks_;
+    int block_size_; // Also known as line length.
+    int num_blocks_; // Total number of lines in cache = size / block_size.
     bool coherent_cache_;
     // This is an index into snoop filter's array of caches.
     int id_;
@@ -206,7 +206,6 @@ protected:
     int blocks_per_set_;
     // Optimization fields for fast bit operations
     int blocks_per_set_mask_;
-    int assoc_bits_;
     int block_size_bits_;
 
     caching_device_stats_t *stats_;

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -142,7 +142,7 @@ protected:
     inline int
     compute_block_idx(addr_t tag) const
     {
-        return (tag & blocks_per_set_mask_) * associativity_;
+        return (tag & blocks_per_way_mask_) * associativity_;
     }
     inline caching_device_block_t &
     get_caching_device_block(int block_idx, int way) const
@@ -203,9 +203,9 @@ protected:
     // an extended block class which has its own member variables cannot be indexed
     // correctly by base class pointers.
     caching_device_block_t **blocks_;
-    int blocks_per_set_;
+    int blocks_per_way_;
     // Optimization fields for fast bit operations
-    int blocks_per_set_mask_;
+    int blocks_per_way_mask_;
     int block_size_bits_;
 
     caching_device_stats_t *stats_;

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -423,8 +423,7 @@ unit_test_cache_size()
 
     for (int cache_size_kb : TEST_SIZES_KB) {
         int cache_size = cache_size_kb * 1024;
-        bool size_is_po2 = (cache_size_kb & (cache_size_kb - 1)) == 0;
-        int associativity = size_is_po2 ? 2 : 3;
+        int associativity = IS_POWER_OF_2(cache_size_kb) ? 2 : 3;
         // Access a buffer of increasing size, make sure hits + misses are expected.
         for (int buffer_size = cache_size / 2; buffer_size < cache_size * 2;
              buffer_size *= 2) {
@@ -510,26 +509,26 @@ void
 unit_test_cache_bad_configs()
 {
     // Safe values we aren't testing.
-    const int safe_assoc = 1;
-    const int safe_line_size = 32;
-    const int safe_cache_size = 1024;
+    static constexpr int SAFE_ASSOC = 1;
+    static constexpr int SAFE_LINE_SIZE = 32;
+    static constexpr int SAFE_CACHE_SIZE = 1024;
 
     // Setup the cache to test.
     cache_t cache;
-    caching_device_stats_t stats(/*miss_file=*/"", safe_line_size);
+    caching_device_stats_t stats(/*miss_file=*/"", SAFE_LINE_SIZE);
 
     // 0 values are bad for any of these parameters.
     std::cerr << "Testing 0 parameters.\n";
-    assert(!cache.init(0, safe_line_size, safe_cache_size, /*parent=*/nullptr, &stats));
-    assert(!cache.init(safe_assoc, 0, safe_cache_size, /*parent=*/nullptr, &stats));
-    assert(!cache.init(safe_assoc, safe_line_size, 0, /*parent=*/nullptr, &stats));
+    assert(!cache.init(0, SAFE_LINE_SIZE, SAFE_CACHE_SIZE, /*parent=*/nullptr, &stats));
+    assert(!cache.init(SAFE_ASSOC, 0, SAFE_CACHE_SIZE, /*parent=*/nullptr, &stats));
+    assert(!cache.init(SAFE_ASSOC, SAFE_LINE_SIZE, 0, /*parent=*/nullptr, &stats));
 
     // Test other bad line sizes: <4 and/or non-power-of-two.
     std::cerr << "Testing bad line size parameters.\n";
-    assert(!cache.init(safe_assoc, 1, safe_cache_size, /*parent=*/nullptr, &stats));
-    assert(!cache.init(safe_assoc, 2, safe_cache_size, /*parent=*/nullptr, &stats));
-    assert(!cache.init(safe_assoc, 7, safe_cache_size, /*parent=*/nullptr, &stats));
-    assert(!cache.init(safe_assoc, 65, safe_cache_size, /*parent=*/nullptr, &stats));
+    assert(!cache.init(SAFE_ASSOC, 1, SAFE_CACHE_SIZE, /*parent=*/nullptr, &stats));
+    assert(!cache.init(SAFE_ASSOC, 2, SAFE_CACHE_SIZE, /*parent=*/nullptr, &stats));
+    assert(!cache.init(SAFE_ASSOC, 7, SAFE_CACHE_SIZE, /*parent=*/nullptr, &stats));
+    assert(!cache.init(SAFE_ASSOC, 65, SAFE_CACHE_SIZE, /*parent=*/nullptr, &stats));
 
     // Size, associativity, and line_size are related.  The requirement is that
     // size/associativity is a power-of-two, and >= line_size, so try some
@@ -539,10 +538,10 @@ unit_test_cache_bad_configs()
         int assoc;
         int size;
     } bad_combinations[] = {
-        { 3, 1024 }, { 4, 768 }, { 64, 64 }, { 16, 8 * safe_line_size }
+        { 3, 1024 }, { 4, 768 }, { 64, 64 }, { 16, 8 * SAFE_LINE_SIZE }
     };
     for (const auto &combo : bad_combinations) {
-        assert(!cache.init(combo.assoc, safe_line_size, combo.size, /*parent=*/nullptr,
+        assert(!cache.init(combo.assoc, SAFE_LINE_SIZE, combo.size, /*parent=*/nullptr,
                            &stats));
     }
 }


### PR DESCRIPTION
Remove restriction that cache associativity and size must be a power-of-two.  Updated requirement is that size / associativity must be a power-of-two.  Added tests for newly supported sizes, and for the updated cache.init() parameter checkers.

Issue: #4489
Fixes: #4996