### PR TITLE
i#3044 AArch64 SVE codec: Add multi gpr memory load/stores

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -200,6 +200,9 @@ Further non-compatibility-affecting changes include:
  - Added opnd_size_to_shift_amount() and opnd_create_base_disp_shift_aarch64()
    for explicitly specifying shift amounts in the creation of operands for
    AArch64 memory addresses.
+ - Added opnd_create_increment_reg() to create a register from an existing
+   register whose register number is incremented by some amount, wrapping
+   at the max register number for that register.
 
 **************************************************
 <hr>

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -292,10 +292,10 @@
 00000101xx100010100xxxxxxxxxxxxx  n   837  SVE    lasta  bhsd_size_reg0 : p10_lo z_size_bhsd_5
 00000101xx100001101xxxxxxxxxxxxx  n   838  SVE    lastb   wx_size_0_zr : p10_lo z_size_bhsd_5
 00000101xx100011100xxxxxxxxxxxxx  n   838  SVE    lastb  bhsd_size_reg0 : p10_lo z_size_bhsd_5
-10100100001xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_h_0 : svemem_gpr_5 p10_zer_lo
-10100100010xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_s_0 : svemem_gpr_5 p10_zer_lo
-10100100011xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100100000xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_b_0 : svemem_gpr_5 p10_zer_lo
+10100100001xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_h_0 : svemem_gpr_shf p10_zer_lo
+10100100010xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_s_0 : svemem_gpr_shf p10_zer_lo
+10100100011xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100100000xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_b_0 : svemem_gpr_shf p10_zer_lo
 1000010001xxxxxx101xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_h_0 : svememx6_b_5 p10_zer_lo
 1000010001xxxxxx110xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_s_0 : svememx6_b_5 p10_zer_lo
 1000010001xxxxxx111xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_d_0 : svememx6_b_5 p10_zer_lo
@@ -314,25 +314,28 @@
 1000010011xxxxxx100xxxxxxxxxxxxx  n   913  SVE   ld1rsw          z_d_0 : svememx6_s_5 p10_zer_lo
 1000010101xxxxxx110xxxxxxxxxxxxx  n   914  SVE    ld1rw          z_s_0 : svememx6_s_5 p10_zer_lo
 1000010101xxxxxx111xxxxxxxxxxxxx  n   914  SVE    ld1rw          z_d_0 : svememx6_s_5 p10_zer_lo
-10100101110xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_h_0 : svemem_gpr_5 p10_zer_lo
-10100101101xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_s_0 : svemem_gpr_5 p10_zer_lo
-10100101100xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100100001xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_h_0 : svemem_gpr_5 p10_zer_lo
-10100100010xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_s_0 : svemem_gpr_5 p10_zer_lo
-10100100011xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100100000xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_b_0 : svemem_gpr_5 p10_zer_lo
-10100101111xxxxx011xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100100101xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_h_0 : svemem_gpr_5 p10_zer_lo
-10100100110xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_s_0 : svemem_gpr_5 p10_zer_lo
-10100100111xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100101110xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_h_0 : svemem_gpr_5 p10_zer_lo
-10100101101xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_s_0 : svemem_gpr_5 p10_zer_lo
-10100101100xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100101001xxxxx011xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_s_0 : svemem_gpr_5 p10_zer_lo
-10100101000xxxxx011xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100100100xxxxx011xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_5 p10_zer_lo
-10100101010xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_s_0 : svemem_gpr_5 p10_zer_lo
-10100101011xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_5 p10_zer_lo
+10100101110xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_h_0 : svemem_gpr_shf p10_zer_lo
+10100101101xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_s_0 : svemem_gpr_shf p10_zer_lo
+10100101100xxxxx010xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100100001xxxxx110xxxxxxxxxxxxx  n   967  SVE     ld2b  z_b_0 z_msz_bhsd_0p1 : svemem_gprs_bhsdx p10_zer_lo
+10100100010xxxxx110xxxxxxxxxxxxx  n   968  SVE     ld3b  z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 : svemem_gprs_bhsdx p10_zer_lo
+10100100011xxxxx110xxxxxxxxxxxxx  n   969  SVE     ld4b  z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 z_msz_bhsd_0p3 : svemem_gprs_bhsdx p10_zer_lo
+10100100001xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_h_0 : svemem_gpr_shf p10_zer_lo
+10100100010xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_s_0 : svemem_gpr_shf p10_zer_lo
+10100100011xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100100000xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_b_0 : svemem_gpr_shf p10_zer_lo
+10100101111xxxxx011xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100100101xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_h_0 : svemem_gpr_shf p10_zer_lo
+10100100110xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_s_0 : svemem_gpr_shf p10_zer_lo
+10100100111xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100101110xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_h_0 : svemem_gpr_shf p10_zer_lo
+10100101101xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_s_0 : svemem_gpr_shf p10_zer_lo
+10100101100xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100101001xxxxx011xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_s_0 : svemem_gpr_shf p10_zer_lo
+10100101000xxxxx011xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100100100xxxxx011xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_shf p10_zer_lo
+10100101010xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_s_0 : svemem_gpr_shf p10_zer_lo
+10100101011xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_shf p10_zer_lo
 10100100000xxxxx110xxxxxxxxxxxxx  n   950  SVE   ldnt1b          z_b_0 : svemem_gprs_b1 p10_zer_lo
 1000010110xxxxxx000xxxxxxxx0xxxx  n   227  SVE      ldr             p0 : svemem_gpr_simm9_vl
 1000010110xxxxxx010xxxxxxxxxxxxx  n   227  SVE      ldr             z0 : svemem_gpr_simm9_vl
@@ -459,10 +462,13 @@
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub             z0 : z5 z16 bhsd_sz
 00100101xx10011011xxxxxxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_0 imm8_5 lsl shift1
 00000100xx1xxxxx000110xxxxxxxxxx  n   425  SVE    sqsub  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
-11100100000xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_b_0 p10_lo
-11100100001xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_h_0 p10_lo
-11100100010xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_s_0 p10_lo
-11100100011xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b   svemem_gpr_5 : z_d_0 p10_lo
+11100100000xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_gpr_shf : z_b_0 p10_lo
+11100100001xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_gpr_shf : z_h_0 p10_lo
+11100100010xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_gpr_shf : z_s_0 p10_lo
+11100100011xxxxx010xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_gpr_shf : z_d_0 p10_lo
+11100100001xxxxx011xxxxxxxxxxxxx  n   970  SVE     st2b  svemem_gprs_bhsdx : z_b_0 z_msz_bhsd_0p1 p10_lo
+11100100010xxxxx011xxxxxxxxxxxxx  n   971  SVE     st3b  svemem_gprs_bhsdx : z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 p10_lo
+11100100011xxxxx011xxxxxxxxxxxxx  n   972  SVE     st4b  svemem_gprs_bhsdx : z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 z_msz_bhsd_0p3 p10_lo
 11100100000xxxxx011xxxxxxxxxxxxx  n   952  SVE   stnt1b  svemem_gprs_b1 : z_b_0 p10_lo
 1110010110xxxxxx000xxxxxxxx0xxxx  n   457  SVE      str  svemem_gpr_simm9_vl : p0
 1110010110xxxxxx010xxxxxxxxxxxxx  n   457  SVE      str  svemem_gpr_simm9_vl : z0

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -11217,4 +11217,118 @@
 #define INSTR_CREATE_prfw_sve_pred(dc, prfop, Pg, Rn) \
     instr_create_0dst_3src(dc, OP_prfw, prfop, Pg, Rn)
 
+/*
+ * Creates a LD2B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD2B    { <Zt1>.B, <Zt2>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ld2b_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_2dst_2src(dc, OP_ld2b, Zt, opnd_create_increment_reg(Zt, 1), Rn, Pg)
+
+/**
+ * Creates a LD3B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ld3b_sve_pred(dc, Zt, Pg, Rn)                            \
+    instr_create_3dst_2src(dc, OP_ld3b, Zt, opnd_create_increment_reg(Zt, 1), \
+                           opnd_create_increment_reg(Zt, 2), Rn, Pg)
+
+/**
+ * Creates a LD4B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The first source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_ld4b_sve_pred(dc, Zt, Pg, Rn)                            \
+    instr_create_4dst_2src(dc, OP_ld4b, Zt, opnd_create_increment_reg(Zt, 1), \
+                           opnd_create_increment_reg(Zt, 2),                  \
+                           opnd_create_increment_reg(Zt, 3), Rn, Pg)
+
+/**
+ * Creates a ST2B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ST2B    { <Zt1>.B, <Zt2>.B }, <Pg>, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The first source vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The second source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_st2b_sve_pred(dc, Zt, Pg, Rn) \
+    instr_create_1dst_3src(dc, OP_st2b, Rn, Zt, opnd_create_increment_reg(Zt, 1), Pg)
+
+/**
+ * Creates a ST3B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The first source vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The second source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_st3b_sve_pred(dc, Zt, Pg, Rn)                                \
+    instr_create_1dst_4src(dc, OP_st3b, Rn, Zt, opnd_create_increment_reg(Zt, 1), \
+                           opnd_create_increment_reg(Zt, 2), Pg)
+
+/**
+ * Creates a ST4B instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>, <Xm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The first source vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Rn   The second source base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp_aarch64(Rn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
+ */
+#define INSTR_CREATE_st4b_sve_pred(dc, Zt, Pg, Rn)                                \
+    instr_create_1dst_5src(dc, OP_st4b, Rn, Zt, opnd_create_increment_reg(Zt, 1), \
+                           opnd_create_increment_reg(Zt, 2),                      \
+                           opnd_create_increment_reg(Zt, 3), Pg)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -246,6 +246,7 @@
 ---------x------------xxxxx-----  wx_sz_5    # W/X register (or WZR/XZR) with size indicated in bit 22
 ---------x-xx-------------------  i3_index_19 # Index value from 22, 20:19
 ---------x-xxxxx----------------  wx_sz_16   # W/X register (or WZR/XZR) with size indicated in bit 22
+---------xx----------------xxxxx  z_size21_bhsd_0  # sve vector reg, elsz depending on size21
 ---------++++xxx----------------  immhb_shf  # encoding of #shift value in immh:immb fields
 ---------++++xxx----------------  immhb_0shf # encoding of #shift value in zero-indexed immh:immb fields
 ---------++++xxx----------------  immhb_fxp  # encoding of #fbits value in immh:immb fields
@@ -297,7 +298,11 @@
 --------xx-xxxxx----------------  z_size_bhsd_16   # sve vector reg, elsz depending on size
 --------xx-xxxxx----------------  z_size_hsd_16    # sve vector reg, elsz depending on size
 --------xx-xxxxx----------------  imm2_tsz_index   # Index encoded in imm2:tsz
--------????xxxxx------xxxxx-----  svemem_gpr_5   # GPR offset and base reg for SVE ld/st
+-------????xxxxx------xxxxx-----  svemem_gpr_shf   # GPR offset and base reg for SVE ld/st, with optional shift
+-------????xxxxx------xxxxx-----  svemem_gprs_bhsdx  # memory reg from Rm and Rn fields transferring x bytes per element
+-------xx------------------xxxxx  z_msz_bhsd_0p1  # z register with element size determined by msz, plus 1
+-------xx------------------xxxxx  z_msz_bhsd_0p2  # z register with element size determined by msz, plus 2
+-------xx------------------xxxxx  z_msz_bhsd_0p3  # z register with element size determined by msz, plus 3
 -?--------------------xxxxx-----  mem0p      # gets size from 30; no offset, pair
 -?---------xxxxx????------------  x16imm     # computes immed from 30 and 15:12
 -x------------------------------  index3     # index of D subreg in Q: 0-1

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -3270,7 +3270,7 @@ opnd_replace_reg(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg);
 
 DR_API
 /**
- * Creates a reg incremented  from an exiting \p opndby the \p increment value,
+ * Creates a reg incremented from an existing \p opnd by the \p increment value,
  * modulo the reg size.
  * Returns the new reg.
  */

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -3270,6 +3270,15 @@ opnd_replace_reg(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg);
 
 DR_API
 /**
+ * Creates a reg incremented  from an exiting \p opndby the \p increment value,
+ * modulo the reg size.
+ * Returns the new reg.
+ */
+opnd_t
+opnd_create_increment_reg(opnd_t opnd, uint increment);
+
+DR_API
+/**
  * Replaces all instances of \p old_reg (or any size variant) in \p *opnd
  * with \p new_reg.  Resizes \p new_reg to match sub-full-size uses of \p old_reg.
  * Returns whether it replaced anything.

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1395,7 +1395,7 @@ opnd_create_increment_reg(opnd_t opnd, uint increment)
     reg_id_t reg = opnd.value.reg_and_element_size.reg;
     reg_id_t min_reg = DR_REG_INVALID;
     reg_id_t max_reg = DR_REG_INVALID;
-
+#ifdef AARCH64
     if (reg >= DR_REG_W0 && reg <= DR_REG_W30) {
         min_reg = DR_REG_W0;
         max_reg = DR_REG_W30;
@@ -1424,7 +1424,7 @@ opnd_create_increment_reg(opnd_t opnd, uint increment)
         min_reg = DR_REG_P0;
         max_reg = DR_REG_P15;
     }
-
+#endif
     CLIENT_ASSERT(min_reg != DR_REG_INVALID && max_reg != DR_REG_INVALID,
                   "opnd_create_increment_reg: reg not incrementable");
 

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1425,7 +1425,7 @@ opnd_create_increment_reg(opnd_t opnd, uint increment)
         max_reg = DR_REG_P15;
     }
 #else
-    ASSERT_NOT_IMPLEMENTED()
+    ASSERT_NOT_IMPLEMENTED(false);
 #endif
 
     CLIENT_ASSERT(min_reg != DR_REG_INVALID && max_reg != DR_REG_INVALID,

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1424,7 +1424,10 @@ opnd_create_increment_reg(opnd_t opnd, uint increment)
         min_reg = DR_REG_P0;
         max_reg = DR_REG_P15;
     }
+#else
+    ASSERT_NOT_IMPLEMENTED()
 #endif
+
     CLIENT_ASSERT(min_reg != DR_REG_INVALID && max_reg != DR_REG_INVALID,
                   "opnd_create_increment_reg: reg not incrementable");
 

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1386,6 +1386,59 @@ opnd_replace_reg(opnd_t *opnd, reg_id_t old_reg, reg_id_t new_reg)
     }
 }
 
+opnd_t
+opnd_create_increment_reg(opnd_t opnd, uint increment)
+{
+    opnd_t inc_opnd DR_IF_DEBUG(= { 0 }); /* FIXME: Needed until i#417 is fixed. */
+    CLIENT_ASSERT(opnd_is_reg(opnd), "opnd_create_increment_reg: not a register");
+
+    reg_id_t reg = opnd.value.reg_and_element_size.reg;
+    reg_id_t min_reg = DR_REG_INVALID;
+    reg_id_t max_reg = DR_REG_INVALID;
+
+    if (reg >= DR_REG_W0 && reg <= DR_REG_W30) {
+        min_reg = DR_REG_W0;
+        max_reg = DR_REG_W30;
+    } else if (reg >= DR_REG_X0 && reg <= DR_REG_X30) {
+        min_reg = DR_REG_X0;
+        max_reg = DR_REG_X30;
+    } else if (reg >= DR_REG_B0 && reg <= DR_REG_B31) {
+        min_reg = DR_REG_B0;
+        max_reg = DR_REG_B31;
+    } else if (reg >= DR_REG_H0 && reg <= DR_REG_H31) {
+        min_reg = DR_REG_H0;
+        max_reg = DR_REG_H31;
+    } else if (reg >= DR_REG_S0 && reg <= DR_REG_S31) {
+        min_reg = DR_REG_S0;
+        max_reg = DR_REG_S31;
+    } else if (reg >= DR_REG_D0 && reg <= DR_REG_D31) {
+        min_reg = DR_REG_D0;
+        max_reg = DR_REG_D31;
+    } else if (reg >= DR_REG_Q0 && reg <= DR_REG_Q31) {
+        min_reg = DR_REG_Q0;
+        max_reg = DR_REG_Q31;
+    } else if (reg >= DR_REG_Z0 && reg <= DR_REG_Z31) {
+        min_reg = DR_REG_Z0;
+        max_reg = DR_REG_Z31;
+    } else if (reg >= DR_REG_P0 && reg <= DR_REG_P15) {
+        min_reg = DR_REG_P0;
+        max_reg = DR_REG_P15;
+    }
+
+    CLIENT_ASSERT(min_reg != DR_REG_INVALID && max_reg != DR_REG_INVALID,
+                  "opnd_create_increment_reg: reg not incrementable");
+
+    reg_id_t new_reg = (reg - min_reg + increment) % (max_reg - min_reg + 1) + min_reg;
+
+    inc_opnd.kind = REG_kind;
+    inc_opnd.value.reg_and_element_size.reg = new_reg;
+    inc_opnd.value.reg_and_element_size.element_size =
+        opnd.value.reg_and_element_size.element_size;
+    inc_opnd.size = opnd.size; /* indicates full size of reg */
+    inc_opnd.aux.flags = opnd.aux.flags;
+    return inc_opnd;
+}
+
 static reg_id_t
 reg_match_size_and_type(reg_id_t new_reg, opnd_size_t size, reg_id_t old_reg)
 {

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -10738,6 +10738,60 @@ a59b5f59 : ld1sb z25.d, p7/Z, [x26, x27]             : ld1sb  (%x26,%x27)[4byte]
 a59d5f9b : ld1sb z27.d, p7/Z, [x28, x29]             : ld1sb  (%x28,%x29)[4byte] %p7/z -> %z27.d
 a59e5fff : ld1sb z31.d, p7/Z, [sp, x30]              : ld1sb  (%sp,%x30)[4byte] %p7/z -> %z31.d
 
+# LD2B    { <Zt1>.B, <Zt2>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD2B-Z.P.BR-Contiguous)
+a420c000 : ld2b {z0.b, z1.b}, p0/Z, [x0, x0]         : ld2b   (%x0,%x0)[64byte] %p0/z -> %z0.b %z1.b
+a425c482 : ld2b {z2.b, z3.b}, p1/Z, [x4, x5]         : ld2b   (%x4,%x5)[64byte] %p1/z -> %z2.b %z3.b
+a427c8c4 : ld2b {z4.b, z5.b}, p2/Z, [x6, x7]         : ld2b   (%x6,%x7)[64byte] %p2/z -> %z4.b %z5.b
+a429c906 : ld2b {z6.b, z7.b}, p2/Z, [x8, x9]         : ld2b   (%x8,%x9)[64byte] %p2/z -> %z6.b %z7.b
+a42bcd48 : ld2b {z8.b, z9.b}, p3/Z, [x10, x11]       : ld2b   (%x10,%x11)[64byte] %p3/z -> %z8.b %z9.b
+a42ccd6a : ld2b {z10.b, z11.b}, p3/Z, [x11, x12]     : ld2b   (%x11,%x12)[64byte] %p3/z -> %z10.b %z11.b
+a42ed1ac : ld2b {z12.b, z13.b}, p4/Z, [x13, x14]     : ld2b   (%x13,%x14)[64byte] %p4/z -> %z12.b %z13.b
+a430d1ee : ld2b {z14.b, z15.b}, p4/Z, [x15, x16]     : ld2b   (%x15,%x16)[64byte] %p4/z -> %z14.b %z15.b
+a432d630 : ld2b {z16.b, z17.b}, p5/Z, [x17, x18]     : ld2b   (%x17,%x18)[64byte] %p5/z -> %z16.b %z17.b
+a434d671 : ld2b {z17.b, z18.b}, p5/Z, [x19, x20]     : ld2b   (%x19,%x20)[64byte] %p5/z -> %z17.b %z18.b
+a436d6b3 : ld2b {z19.b, z20.b}, p5/Z, [x21, x22]     : ld2b   (%x21,%x22)[64byte] %p5/z -> %z19.b %z20.b
+a438daf5 : ld2b {z21.b, z22.b}, p6/Z, [x23, x24]     : ld2b   (%x23,%x24)[64byte] %p6/z -> %z21.b %z22.b
+a439db17 : ld2b {z23.b, z24.b}, p6/Z, [x24, x25]     : ld2b   (%x24,%x25)[64byte] %p6/z -> %z23.b %z24.b
+a43bdf59 : ld2b {z25.b, z26.b}, p7/Z, [x26, x27]     : ld2b   (%x26,%x27)[64byte] %p7/z -> %z25.b %z26.b
+a43ddf9b : ld2b {z27.b, z28.b}, p7/Z, [x28, x29]     : ld2b   (%x28,%x29)[64byte] %p7/z -> %z27.b %z28.b
+a43edfff : ld2b {z31.b, z0.b}, p7/Z, [sp, x30]       : ld2b   (%sp,%x30)[64byte] %p7/z -> %z31.b %z0.b
+
+# LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD3B-Z.P.BR-Contiguous)
+a440c000 : ld3b {z0.b, z1.b, z2.b}, p0/Z, [x0, x0]   : ld3b   (%x0,%x0)[96byte] %p0/z -> %z0.b %z1.b %z2.b
+a445c482 : ld3b {z2.b, z3.b, z4.b}, p1/Z, [x4, x5]   : ld3b   (%x4,%x5)[96byte] %p1/z -> %z2.b %z3.b %z4.b
+a447c8c4 : ld3b {z4.b, z5.b, z6.b}, p2/Z, [x6, x7]   : ld3b   (%x6,%x7)[96byte] %p2/z -> %z4.b %z5.b %z6.b
+a449c906 : ld3b {z6.b, z7.b, z8.b}, p2/Z, [x8, x9]   : ld3b   (%x8,%x9)[96byte] %p2/z -> %z6.b %z7.b %z8.b
+a44bcd48 : ld3b {z8.b, z9.b, z10.b}, p3/Z, [x10, x11] : ld3b   (%x10,%x11)[96byte] %p3/z -> %z8.b %z9.b %z10.b
+a44ccd6a : ld3b {z10.b, z11.b, z12.b}, p3/Z, [x11, x12] : ld3b   (%x11,%x12)[96byte] %p3/z -> %z10.b %z11.b %z12.b
+a44ed1ac : ld3b {z12.b, z13.b, z14.b}, p4/Z, [x13, x14] : ld3b   (%x13,%x14)[96byte] %p4/z -> %z12.b %z13.b %z14.b
+a450d1ee : ld3b {z14.b, z15.b, z16.b}, p4/Z, [x15, x16] : ld3b   (%x15,%x16)[96byte] %p4/z -> %z14.b %z15.b %z16.b
+a452d630 : ld3b {z16.b, z17.b, z18.b}, p5/Z, [x17, x18] : ld3b   (%x17,%x18)[96byte] %p5/z -> %z16.b %z17.b %z18.b
+a454d671 : ld3b {z17.b, z18.b, z19.b}, p5/Z, [x19, x20] : ld3b   (%x19,%x20)[96byte] %p5/z -> %z17.b %z18.b %z19.b
+a456d6b3 : ld3b {z19.b, z20.b, z21.b}, p5/Z, [x21, x22] : ld3b   (%x21,%x22)[96byte] %p5/z -> %z19.b %z20.b %z21.b
+a458daf5 : ld3b {z21.b, z22.b, z23.b}, p6/Z, [x23, x24] : ld3b   (%x23,%x24)[96byte] %p6/z -> %z21.b %z22.b %z23.b
+a459db17 : ld3b {z23.b, z24.b, z25.b}, p6/Z, [x24, x25] : ld3b   (%x24,%x25)[96byte] %p6/z -> %z23.b %z24.b %z25.b
+a45bdf59 : ld3b {z25.b, z26.b, z27.b}, p7/Z, [x26, x27] : ld3b   (%x26,%x27)[96byte] %p7/z -> %z25.b %z26.b %z27.b
+a45ddf9b : ld3b {z27.b, z28.b, z29.b}, p7/Z, [x28, x29] : ld3b   (%x28,%x29)[96byte] %p7/z -> %z27.b %z28.b %z29.b
+a45edfff : ld3b {z31.b, z0.b, z1.b}, p7/Z, [sp, x30] : ld3b   (%sp,%x30)[96byte] %p7/z -> %z31.b %z0.b %z1.b
+
+# LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD4B-Z.P.BR-Contiguous)
+a460c000 : ld4b {z0.b, z1.b, z2.b, z3.b}, p0/Z, [x0, x0] : ld4b   (%x0,%x0)[128byte] %p0/z -> %z0.b %z1.b %z2.b %z3.b
+a465c482 : ld4b {z2.b, z3.b, z4.b, z5.b}, p1/Z, [x4, x5] : ld4b   (%x4,%x5)[128byte] %p1/z -> %z2.b %z3.b %z4.b %z5.b
+a467c8c4 : ld4b {z4.b, z5.b, z6.b, z7.b}, p2/Z, [x6, x7] : ld4b   (%x6,%x7)[128byte] %p2/z -> %z4.b %z5.b %z6.b %z7.b
+a469c906 : ld4b {z6.b, z7.b, z8.b, z9.b}, p2/Z, [x8, x9] : ld4b   (%x8,%x9)[128byte] %p2/z -> %z6.b %z7.b %z8.b %z9.b
+a46bcd48 : ld4b {z8.b, z9.b, z10.b, z11.b}, p3/Z, [x10, x11] : ld4b   (%x10,%x11)[128byte] %p3/z -> %z8.b %z9.b %z10.b %z11.b
+a46ccd6a : ld4b {z10.b, z11.b, z12.b, z13.b}, p3/Z, [x11, x12] : ld4b   (%x11,%x12)[128byte] %p3/z -> %z10.b %z11.b %z12.b %z13.b
+a46ed1ac : ld4b {z12.b, z13.b, z14.b, z15.b}, p4/Z, [x13, x14] : ld4b   (%x13,%x14)[128byte] %p4/z -> %z12.b %z13.b %z14.b %z15.b
+a470d1ee : ld4b {z14.b, z15.b, z16.b, z17.b}, p4/Z, [x15, x16] : ld4b   (%x15,%x16)[128byte] %p4/z -> %z14.b %z15.b %z16.b %z17.b
+a472d630 : ld4b {z16.b, z17.b, z18.b, z19.b}, p5/Z, [x17, x18] : ld4b   (%x17,%x18)[128byte] %p5/z -> %z16.b %z17.b %z18.b %z19.b
+a474d671 : ld4b {z17.b, z18.b, z19.b, z20.b}, p5/Z, [x19, x20] : ld4b   (%x19,%x20)[128byte] %p5/z -> %z17.b %z18.b %z19.b %z20.b
+a476d6b3 : ld4b {z19.b, z20.b, z21.b, z22.b}, p5/Z, [x21, x22] : ld4b   (%x21,%x22)[128byte] %p5/z -> %z19.b %z20.b %z21.b %z22.b
+a478daf5 : ld4b {z21.b, z22.b, z23.b, z24.b}, p6/Z, [x23, x24] : ld4b   (%x23,%x24)[128byte] %p6/z -> %z21.b %z22.b %z23.b %z24.b
+a479db17 : ld4b {z23.b, z24.b, z25.b, z26.b}, p6/Z, [x24, x25] : ld4b   (%x24,%x25)[128byte] %p6/z -> %z23.b %z24.b %z25.b %z26.b
+a47bdf59 : ld4b {z25.b, z26.b, z27.b, z28.b}, p7/Z, [x26, x27] : ld4b   (%x26,%x27)[128byte] %p7/z -> %z25.b %z26.b %z27.b %z28.b
+a47ddf9b : ld4b {z27.b, z28.b, z29.b, z30.b}, p7/Z, [x28, x29] : ld4b   (%x28,%x29)[128byte] %p7/z -> %z27.b %z28.b %z29.b %z30.b
+a47edfff : ld4b {z31.b, z0.b, z1.b, z2.b}, p7/Z, [sp, x30] : ld4b   (%sp,%x30)[128byte] %p7/z -> %z31.b %z0.b %z1.b %z2.b
+
 # LDFF1B  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, <Xm>}] (LDFF1B-Z.P.BR-U16)
 a4206000 : ldff1b z0.h, p0/Z, [x0, x0]               : ldff1b (%x0,%x0)[16byte] %p0/z -> %z0.h
 a4256482 : ldff1b z2.h, p1/Z, [x4, x5]               : ldff1b (%x4,%x5)[16byte] %p1/z -> %z2.h
@@ -16086,6 +16140,60 @@ e4795b17 : st1b z23.d, p6, [x24, x25]                : st1b   %z23.d %p6 -> (%x2
 e47b5f59 : st1b z25.d, p7, [x26, x27]                : st1b   %z25.d %p7 -> (%x26,%x27)[4byte]
 e47d5f9b : st1b z27.d, p7, [x28, x29]                : st1b   %z27.d %p7 -> (%x28,%x29)[4byte]
 e47e5fff : st1b z31.d, p7, [sp, x30]                 : st1b   %z31.d %p7 -> (%sp,%x30)[4byte]
+
+# ST2B    { <Zt1>.B, <Zt2>.B }, <Pg>, [<Xn|SP>, <Xm>] (ST2B-Z.P.BR-Contiguous)
+e4206000 : st2b {z0.b, z1.b}, p0, [x0, x0]           : st2b   %z0.b %z1.b %p0 -> (%x0,%x0)[64byte]
+e4256482 : st2b {z2.b, z3.b}, p1, [x4, x5]           : st2b   %z2.b %z3.b %p1 -> (%x4,%x5)[64byte]
+e42768c4 : st2b {z4.b, z5.b}, p2, [x6, x7]           : st2b   %z4.b %z5.b %p2 -> (%x6,%x7)[64byte]
+e4296906 : st2b {z6.b, z7.b}, p2, [x8, x9]           : st2b   %z6.b %z7.b %p2 -> (%x8,%x9)[64byte]
+e42b6d48 : st2b {z8.b, z9.b}, p3, [x10, x11]         : st2b   %z8.b %z9.b %p3 -> (%x10,%x11)[64byte]
+e42c6d6a : st2b {z10.b, z11.b}, p3, [x11, x12]       : st2b   %z10.b %z11.b %p3 -> (%x11,%x12)[64byte]
+e42e71ac : st2b {z12.b, z13.b}, p4, [x13, x14]       : st2b   %z12.b %z13.b %p4 -> (%x13,%x14)[64byte]
+e43071ee : st2b {z14.b, z15.b}, p4, [x15, x16]       : st2b   %z14.b %z15.b %p4 -> (%x15,%x16)[64byte]
+e4327630 : st2b {z16.b, z17.b}, p5, [x17, x18]       : st2b   %z16.b %z17.b %p5 -> (%x17,%x18)[64byte]
+e4347671 : st2b {z17.b, z18.b}, p5, [x19, x20]       : st2b   %z17.b %z18.b %p5 -> (%x19,%x20)[64byte]
+e43676b3 : st2b {z19.b, z20.b}, p5, [x21, x22]       : st2b   %z19.b %z20.b %p5 -> (%x21,%x22)[64byte]
+e4387af5 : st2b {z21.b, z22.b}, p6, [x23, x24]       : st2b   %z21.b %z22.b %p6 -> (%x23,%x24)[64byte]
+e4397b17 : st2b {z23.b, z24.b}, p6, [x24, x25]       : st2b   %z23.b %z24.b %p6 -> (%x24,%x25)[64byte]
+e43b7f59 : st2b {z25.b, z26.b}, p7, [x26, x27]       : st2b   %z25.b %z26.b %p7 -> (%x26,%x27)[64byte]
+e43d7f9b : st2b {z27.b, z28.b}, p7, [x28, x29]       : st2b   %z27.b %z28.b %p7 -> (%x28,%x29)[64byte]
+e43e7fff : st2b {z31.b, z0.b}, p7, [sp, x30]         : st2b   %z31.b %z0.b %p7 -> (%sp,%x30)[64byte]
+
+# ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>, <Xm>] (ST3B-Z.P.BR-Contiguous)
+e4406000 : st3b {z0.b, z1.b, z2.b}, p0, [x0, x0]     : st3b   %z0.b %z1.b %z2.b %p0 -> (%x0,%x0)[96byte]
+e4456482 : st3b {z2.b, z3.b, z4.b}, p1, [x4, x5]     : st3b   %z2.b %z3.b %z4.b %p1 -> (%x4,%x5)[96byte]
+e44768c4 : st3b {z4.b, z5.b, z6.b}, p2, [x6, x7]     : st3b   %z4.b %z5.b %z6.b %p2 -> (%x6,%x7)[96byte]
+e4496906 : st3b {z6.b, z7.b, z8.b}, p2, [x8, x9]     : st3b   %z6.b %z7.b %z8.b %p2 -> (%x8,%x9)[96byte]
+e44b6d48 : st3b {z8.b, z9.b, z10.b}, p3, [x10, x11]  : st3b   %z8.b %z9.b %z10.b %p3 -> (%x10,%x11)[96byte]
+e44c6d6a : st3b {z10.b, z11.b, z12.b}, p3, [x11, x12] : st3b   %z10.b %z11.b %z12.b %p3 -> (%x11,%x12)[96byte]
+e44e71ac : st3b {z12.b, z13.b, z14.b}, p4, [x13, x14] : st3b   %z12.b %z13.b %z14.b %p4 -> (%x13,%x14)[96byte]
+e45071ee : st3b {z14.b, z15.b, z16.b}, p4, [x15, x16] : st3b   %z14.b %z15.b %z16.b %p4 -> (%x15,%x16)[96byte]
+e4527630 : st3b {z16.b, z17.b, z18.b}, p5, [x17, x18] : st3b   %z16.b %z17.b %z18.b %p5 -> (%x17,%x18)[96byte]
+e4547671 : st3b {z17.b, z18.b, z19.b}, p5, [x19, x20] : st3b   %z17.b %z18.b %z19.b %p5 -> (%x19,%x20)[96byte]
+e45676b3 : st3b {z19.b, z20.b, z21.b}, p5, [x21, x22] : st3b   %z19.b %z20.b %z21.b %p5 -> (%x21,%x22)[96byte]
+e4587af5 : st3b {z21.b, z22.b, z23.b}, p6, [x23, x24] : st3b   %z21.b %z22.b %z23.b %p6 -> (%x23,%x24)[96byte]
+e4597b17 : st3b {z23.b, z24.b, z25.b}, p6, [x24, x25] : st3b   %z23.b %z24.b %z25.b %p6 -> (%x24,%x25)[96byte]
+e45b7f59 : st3b {z25.b, z26.b, z27.b}, p7, [x26, x27] : st3b   %z25.b %z26.b %z27.b %p7 -> (%x26,%x27)[96byte]
+e45d7f9b : st3b {z27.b, z28.b, z29.b}, p7, [x28, x29] : st3b   %z27.b %z28.b %z29.b %p7 -> (%x28,%x29)[96byte]
+e45e7fff : st3b {z31.b, z0.b, z1.b}, p7, [sp, x30]   : st3b   %z31.b %z0.b %z1.b %p7 -> (%sp,%x30)[96byte]
+
+# ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>, <Xm>] (ST4B-Z.P.BR-Contiguous)
+e4606000 : st4b {z0.b, z1.b, z2.b, z3.b}, p0, [x0, x0] : st4b   %z0.b %z1.b %z2.b %z3.b %p0 -> (%x0,%x0)[128byte]
+e4656482 : st4b {z2.b, z3.b, z4.b, z5.b}, p1, [x4, x5] : st4b   %z2.b %z3.b %z4.b %z5.b %p1 -> (%x4,%x5)[128byte]
+e46768c4 : st4b {z4.b, z5.b, z6.b, z7.b}, p2, [x6, x7] : st4b   %z4.b %z5.b %z6.b %z7.b %p2 -> (%x6,%x7)[128byte]
+e4696906 : st4b {z6.b, z7.b, z8.b, z9.b}, p2, [x8, x9] : st4b   %z6.b %z7.b %z8.b %z9.b %p2 -> (%x8,%x9)[128byte]
+e46b6d48 : st4b {z8.b, z9.b, z10.b, z11.b}, p3, [x10, x11] : st4b   %z8.b %z9.b %z10.b %z11.b %p3 -> (%x10,%x11)[128byte]
+e46c6d6a : st4b {z10.b, z11.b, z12.b, z13.b}, p3, [x11, x12] : st4b   %z10.b %z11.b %z12.b %z13.b %p3 -> (%x11,%x12)[128byte]
+e46e71ac : st4b {z12.b, z13.b, z14.b, z15.b}, p4, [x13, x14] : st4b   %z12.b %z13.b %z14.b %z15.b %p4 -> (%x13,%x14)[128byte]
+e47071ee : st4b {z14.b, z15.b, z16.b, z17.b}, p4, [x15, x16] : st4b   %z14.b %z15.b %z16.b %z17.b %p4 -> (%x15,%x16)[128byte]
+e4727630 : st4b {z16.b, z17.b, z18.b, z19.b}, p5, [x17, x18] : st4b   %z16.b %z17.b %z18.b %z19.b %p5 -> (%x17,%x18)[128byte]
+e4747671 : st4b {z17.b, z18.b, z19.b, z20.b}, p5, [x19, x20] : st4b   %z17.b %z18.b %z19.b %z20.b %p5 -> (%x19,%x20)[128byte]
+e47676b3 : st4b {z19.b, z20.b, z21.b, z22.b}, p5, [x21, x22] : st4b   %z19.b %z20.b %z21.b %z22.b %p5 -> (%x21,%x22)[128byte]
+e4787af5 : st4b {z21.b, z22.b, z23.b, z24.b}, p6, [x23, x24] : st4b   %z21.b %z22.b %z23.b %z24.b %p6 -> (%x23,%x24)[128byte]
+e4797b17 : st4b {z23.b, z24.b, z25.b, z26.b}, p6, [x24, x25] : st4b   %z23.b %z24.b %z25.b %z26.b %p6 -> (%x24,%x25)[128byte]
+e47b7f59 : st4b {z25.b, z26.b, z27.b, z28.b}, p7, [x26, x27] : st4b   %z25.b %z26.b %z27.b %z28.b %p7 -> (%x26,%x27)[128byte]
+e47d7f9b : st4b {z27.b, z28.b, z29.b, z30.b}, p7, [x28, x29] : st4b   %z27.b %z28.b %z29.b %z30.b %p7 -> (%x28,%x29)[128byte]
+e47e7fff : st4b {z31.b, z0.b, z1.b, z2.b}, p7, [sp, x30] : st4b   %z31.b %z0.b %z1.b %z2.b %p7 -> (%sp,%x30)[128byte]
 
 # STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>] (STNT1B-Z.P.BR-Contiguous)
 e4006000 : stnt1b z0.b, p0, [x0, x0]                 : stnt1b %z0.b %p0 -> (%x0,%x0)[32byte]

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -14666,6 +14666,120 @@ TEST_INSTR(prfw_sve_pred)
                                     OPSZ_0));
 }
 
+TEST_INSTR(ld2b_sve_pred)
+{
+
+    /* Testing LD2B    { <Zt1>.B, <Zt2>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ld2b   (%x0,%x0)[64byte] %p0/z -> %z0.b %z1.b",
+        "ld2b   (%x7,%x8)[64byte] %p2/z -> %z5.b %z6.b",
+        "ld2b   (%x12,%x13)[64byte] %p3/z -> %z10.b %z11.b",
+        "ld2b   (%x17,%x18)[64byte] %p5/z -> %z16.b %z17.b",
+        "ld2b   (%x22,%x23)[64byte] %p6/z -> %z21.b %z22.b",
+        "ld2b   (%sp,%x30)[64byte] %p7/z -> %z31.b %z0.b",
+    };
+    TEST_LOOP(ld2b, ld2b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_64));
+}
+
+TEST_INSTR(ld3b_sve_pred)
+{
+
+    /* Testing LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ld3b   (%x0,%x0)[96byte] %p0/z -> %z0.b %z1.b %z2.b",
+        "ld3b   (%x7,%x8)[96byte] %p2/z -> %z5.b %z6.b %z7.b",
+        "ld3b   (%x12,%x13)[96byte] %p3/z -> %z10.b %z11.b %z12.b",
+        "ld3b   (%x17,%x18)[96byte] %p5/z -> %z16.b %z17.b %z18.b",
+        "ld3b   (%x22,%x23)[96byte] %p6/z -> %z21.b %z22.b %z23.b",
+        "ld3b   (%sp,%x30)[96byte] %p7/z -> %z31.b %z0.b %z1.b",
+    };
+    TEST_LOOP(ld3b, ld3b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_96));
+}
+
+TEST_INSTR(ld4b_sve_pred)
+{
+
+    /* Testing LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "ld4b   (%x0,%x0)[128byte] %p0/z -> %z0.b %z1.b %z2.b %z3.b",
+        "ld4b   (%x7,%x8)[128byte] %p2/z -> %z5.b %z6.b %z7.b %z8.b",
+        "ld4b   (%x12,%x13)[128byte] %p3/z -> %z10.b %z11.b %z12.b %z13.b",
+        "ld4b   (%x17,%x18)[128byte] %p5/z -> %z16.b %z17.b %z18.b %z19.b",
+        "ld4b   (%x22,%x23)[128byte] %p6/z -> %z21.b %z22.b %z23.b %z24.b",
+        "ld4b   (%sp,%x30)[128byte] %p7/z -> %z31.b %z0.b %z1.b %z2.b",
+    };
+    TEST_LOOP(ld4b, ld4b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_128));
+}
+
+TEST_INSTR(st2b_sve_pred)
+{
+
+    /* Testing ST2B    { <Zt1>.B, <Zt2>.B }, <Pg>, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "st2b   %z0.b %z1.b %p0 -> (%x0,%x0)[64byte]",
+        "st2b   %z5.b %z6.b %p2 -> (%x7,%x8)[64byte]",
+        "st2b   %z10.b %z11.b %p3 -> (%x12,%x13)[64byte]",
+        "st2b   %z16.b %z17.b %p5 -> (%x17,%x18)[64byte]",
+        "st2b   %z21.b %z22.b %p6 -> (%x22,%x23)[64byte]",
+        "st2b   %z31.b %z0.b %p7 -> (%sp,%x30)[64byte]",
+    };
+    TEST_LOOP(st2b, st2b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_64));
+}
+
+TEST_INSTR(st3b_sve_pred)
+{
+
+    /* Testing ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "st3b   %z0.b %z1.b %z2.b %p0 -> (%x0,%x0)[96byte]",
+        "st3b   %z5.b %z6.b %z7.b %p2 -> (%x7,%x8)[96byte]",
+        "st3b   %z10.b %z11.b %z12.b %p3 -> (%x12,%x13)[96byte]",
+        "st3b   %z16.b %z17.b %z18.b %p5 -> (%x17,%x18)[96byte]",
+        "st3b   %z21.b %z22.b %z23.b %p6 -> (%x22,%x23)[96byte]",
+        "st3b   %z31.b %z0.b %z1.b %p7 -> (%sp,%x30)[96byte]",
+    };
+    TEST_LOOP(st3b, st3b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_96));
+}
+
+TEST_INSTR(st4b_sve_pred)
+{
+
+    /* Testing ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>, <Xm>] */
+    const char *const expected_0_0[6] = {
+        "st4b   %z0.b %z1.b %z2.b %z3.b %p0 -> (%x0,%x0)[128byte]",
+        "st4b   %z5.b %z6.b %z7.b %z8.b %p2 -> (%x7,%x8)[128byte]",
+        "st4b   %z10.b %z11.b %z12.b %z13.b %p3 -> (%x12,%x13)[128byte]",
+        "st4b   %z16.b %z17.b %z18.b %z19.b %p5 -> (%x17,%x18)[128byte]",
+        "st4b   %z21.b %z22.b %z23.b %z24.b %p6 -> (%x22,%x23)[128byte]",
+        "st4b   %z31.b %z0.b %z1.b %z2.b %p7 -> (%sp,%x30)[128byte]",
+    };
+    TEST_LOOP(st4b, st4b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], Xn_six_offset_3[i],
+                                            DR_EXTEND_UXTX, 0, 0, 0, OPSZ_128));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -15114,6 +15228,13 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(prfd_sve_pred);
     RUN_INSTR_TEST(prfh_sve_pred);
     RUN_INSTR_TEST(prfw_sve_pred);
+
+    RUN_INSTR_TEST(ld2b_sve_pred);
+    RUN_INSTR_TEST(ld3b_sve_pred);
+    RUN_INSTR_TEST(ld4b_sve_pred);
+    RUN_INSTR_TEST(st2b_sve_pred);
+    RUN_INSTR_TEST(st3b_sve_pred);
+    RUN_INSTR_TEST(st4b_sve_pred);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
LD2B    { <Zt1>.B, <Zt2>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
ST2B    { <Zt1>.B, <Zt2>.B }, <Pg>, [<Xn|SP>, <Xm>]
ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>, <Xm>]
ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>, <Xm>]
```
issue: #3044