### PR TITLE
i#2626 Finish AArch64 encoder/decoder: Preparations for v8.6 and SVE2

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1,6 +1,6 @@
 /* **********************************************************
  * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
- * Copyright (c) 2016-2022 ARM Limited. All rights reserved.
+ * Copyright (c) 2016-2023 ARM Limited. All rights reserved.
  * **********************************************************/
 
 /*
@@ -7606,15 +7606,22 @@ encode_opnds_tbz(byte *pc, instr_t *instr, uint enc, decode_info_t *di)
  * v8.0. The decode/encode logic is chained together into a pipeline with v8.0
  * calling v8.1, which calls v8.2 and so on, returning from the decode/encode
  * functions as soon as a match is found.
+ *
+ * The includes must be ordered newest to oldest so that the codec function
+ * declarations are before they are attempted to be used.
  */
 #include "opnd_decode_funcs.h"
 #include "opnd_encode_funcs.h"
+#include "decode_gen_sve2.h"
 #include "decode_gen_sve.h"
+#include "decode_gen_v86.h"
 #include "decode_gen_v83.h"
 #include "decode_gen_v82.h"
 #include "decode_gen_v81.h"
 #include "decode_gen_v80.h"
+#include "encode_gen_sve2.h"
 #include "encode_gen_sve.h"
+#include "encode_gen_v86.h"
 #include "encode_gen_v83.h"
 #include "encode_gen_v82.h"
 #include "encode_gen_v81.h"

--- a/core/ir/aarch64/codec.py
+++ b/core/ir/aarch64/codec.py
@@ -2,7 +2,7 @@
 
 # **********************************************************
 # Copyright (c) 2021 Google, Inc.   All rights reserved.
-# Copyright (c) 2016 - 2022 ARM Limited. All rights reserved.
+# Copyright (c) 2016 - 2023 ARM Limited. All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -690,11 +690,11 @@ def main():
     output_dir = sys.argv[2]
 
     # The Arm AArch64's architecture versions supported by the DynamoRIO codec.
-    # Currently, v8.0 is fully supported, while v8.1, v8.2 and SVE are
-    # partially supported. The null terminator element at the end is required
-    # by some generator functions to correctly generate links between each
-    # version's decode/encode logic.
-    isa_versions = ['v80', 'v81', 'v82', 'v83', 'sve', '']
+    # Currently, v8.0 is fully supported, while v8.1, v8.2, v8.3, v8.6, SVE,
+    # and SBE2 are partially supported. The null terminator element at the end
+    # is required by some generator functions to correctly generate links
+    # between each version's decode/encode logic.
+    isa_versions = ['v80', 'v81', 'v82', 'v83', 'v86', 'sve', 'sve2', '']
 
     # Read the instruction operand definitions. Used by the codec when
     # generating code to decode and encode instructions.

--- a/core/ir/aarch64/codec_sve2.txt
+++ b/core/ir/aarch64/codec_sve2.txt
@@ -1,0 +1,37 @@
+# **********************************************************
+# Copyright (c) 2023 ARM Limited. All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of ARM Limited nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# This file defines instruction encodings for SVE2 instructions.
+
+# See header comments in codec_v80.txt and opnd_defs.txt to understand how
+# instructions are defined for the purposes of decode and encode code
+# generation.
+
+# Instruction definitions:

--- a/core/ir/aarch64/codec_v86.txt
+++ b/core/ir/aarch64/codec_v86.txt
@@ -1,0 +1,37 @@
+# **********************************************************
+# Copyright (c) 2023 ARM Limited. All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of ARM Limited nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# This file defines instruction encodings for v8.6 instructions.
+
+# See header comments in codec_v80.txt and opnd_defs.txt to understand how
+# instructions are defined for the purposes of decode and encode code
+# generation.
+
+# Instruction definitions:

--- a/core/ir/aarch64/codecsort.py
+++ b/core/ir/aarch64/codecsort.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # ***********************************************************
-# Copyright (c) 2021-2022 Arm Limited    All rights reserved.
+# Copyright (c) 2021-2023 Arm Limited    All rights reserved.
 # ***********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -132,31 +132,32 @@ def main():
     handle_enums([instr for finstrs in file_instrs.values() for instr in finstrs])
 
     for codec_file, instrs in file_instrs.items():
-        # Scan for some max lengths for formatting
-        instr_length = max(len(i.opcode) for i in instrs)
-        pre_colon = max(
-            len(i.opndtypes.split(":")[0].strip())
-            for i in instrs
-            if ":" in i.opndtypes
-            and len(i.opndtypes.split(":")[0].strip()) < 14)
-
         new_lines = []
 
-        for instr in instrs:
-            new_lines.append(
-                "{pattern}  {nzcv:<3} {enum:<4} {feat:<4} {opcode_pad}{opcode}  {opand_pad}{opand}".format(
-                    enum=instr.enum,
-                    feat=instr.feat,
-                    pattern=instr.pattern,
-                    nzcv=instr.nzcv,
-                    opcode_pad=(instr_length - len(instr.opcode)) * " ",
-                    opcode=instr.opcode,
-                    opand_pad=(pre_colon - len(instr.opndtypes.split(":")[0].strip())) * " ",
-                    opand="{} : {}".format(
-                        instr.opndtypes.split(":")[0].strip(),
-                        instr.opndtypes.split(":")[1].strip()) if ":" in instr.opndtypes
-                    else instr.opndtypes
-                    ).strip())
+        if instrs:
+            # Scan for some max lengths for formatting
+            instr_length = max(len(i.opcode) for i in instrs)
+            pre_colon = max(
+                len(i.opndtypes.split(":")[0].strip())
+                for i in instrs
+                if ":" in i.opndtypes
+                and len(i.opndtypes.split(":")[0].strip()) < 14)
+
+            for instr in instrs:
+                new_lines.append(
+                    "{pattern}  {nzcv:<3} {enum:<4} {feat:<4} {opcode_pad}{opcode}  {opand_pad}{opand}".format(
+                        enum=instr.enum,
+                        feat=instr.feat,
+                        pattern=instr.pattern,
+                        nzcv=instr.nzcv,
+                        opcode_pad=(instr_length - len(instr.opcode)) * " ",
+                        opcode=instr.opcode,
+                        opand_pad=(pre_colon - len(instr.opndtypes.split(":")[0].strip())) * " ",
+                        opand="{} : {}".format(
+                            instr.opndtypes.split(":")[0].strip(),
+                            instr.opndtypes.split(":")[1].strip()) if ":" in instr.opndtypes
+                        else instr.opndtypes
+                        ).strip())
 
         header = []
         with open(codec_file, "r") as lines:

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1,6 +1,6 @@
 /* **********************************************************
  * Copyright (c) 2011-2022 Google, Inc. All rights reserved.
- * Copyright (c) 2016-2018 ARM Limited. All rights reserved.
+ * Copyright (c) 2016-2023 ARM Limited. All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc. All rights reserved.
  * **********************************************************/
 

--- a/make/CMake_aarch64_gen_codec.cmake
+++ b/make/CMake_aarch64_gen_codec.cmake
@@ -43,11 +43,17 @@ set(AARCH64_CODEC_GEN_SRCS
   ${PROJECT_BINARY_DIR}/decode_gen_v80.h
   ${PROJECT_BINARY_DIR}/decode_gen_v81.h
   ${PROJECT_BINARY_DIR}/decode_gen_v82.h
+  ${PROJECT_BINARY_DIR}/decode_gen_v83.h
+  ${PROJECT_BINARY_DIR}/decode_gen_v86.h
   ${PROJECT_BINARY_DIR}/decode_gen_sve.h
+  ${PROJECT_BINARY_DIR}/decode_gen_sve2.h
   ${PROJECT_BINARY_DIR}/encode_gen_v80.h
   ${PROJECT_BINARY_DIR}/encode_gen_v81.h
   ${PROJECT_BINARY_DIR}/encode_gen_v82.h
+  ${PROJECT_BINARY_DIR}/encode_gen_v83.h
+  ${PROJECT_BINARY_DIR}/encode_gen_v86.h
   ${PROJECT_BINARY_DIR}/encode_gen_sve.h
+  ${PROJECT_BINARY_DIR}/encode_gen_sve2.h
   ${PROJECT_BINARY_DIR}/opcode_names.h
 )
 set_source_files_properties(${AARCH64_CODEC_GEN_SRCS} PROPERTIES GENERATED true)
@@ -75,7 +81,10 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v80.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v81.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v82.txt
+          ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v83.txt
+          ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v86.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_sve.txt
+          ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_sve2.txt
   COMMAND ${PYTHON_EXECUTABLE}
   ARGS ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec.py
        ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}

--- a/make/aarch64_check_codec_order.py
+++ b/make/aarch64_check_codec_order.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # **********************************************************
-# Copyright (c) 2022 Arm Limited    All rights reserved.
+# Copyright (c) 2022-2023 Arm Limited    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -101,9 +101,9 @@ def main():
     print('  OK!')
 
     # The Arm AArch64's architecture versions supported by the DynamoRIO codec.
-    # Currently, v8.0 is fully supported, while v8.1, v8.2 and SVE are partially
-    # supported.
-    isa_versions = ['v80', 'v81', 'v82', 'sve']
+    # Currently, v8.0 is fully supported, while v8.1, v8.2, v8.3, v8.6, SVE,
+    # and SVE2 are partially supported.
+    isa_versions = ['v80', 'v81', 'v82', 'v83', 'v86', 'sve', 'sve2']
 
     codecsort_py = os.path.join(src_dir, "codecsort.py")
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1878,7 +1878,9 @@ if (NOT ANDROID)
     tobuild_api(api.ir_negative api/ir_aarch64_negative.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_v81 api/ir_aarch64_v81.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_v82 api/ir_aarch64_v82.c "" "" OFF OFF OFF)
+    tobuild_api(api.ir_v86 api/ir_aarch64_v86.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_sve api/ir_aarch64_sve.c "" "" OFF OFF OFF)
+    tobuild_api(api.ir_sve2 api/ir_aarch64_sve2.c "" "" OFF OFF OFF)
   endif (AARCH64)
 endif ()
 
@@ -2950,8 +2952,12 @@ elseif (AARCH64)
   add_api_exe(api.dis-a64 api/dis-a64.c OFF OFF)
   torunonly_api(api.dis-a64 api.dis-a64 api/dis-a64.c ""
     "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64.txt" OFF OFF)
+  torunonly_api(api.dis-a64-v86 api.dis-a64 api/dis-a64.c ""
+    "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64-v86.txt" OFF OFF)
   torunonly_api(api.dis-a64-sve api.dis-a64 api/dis-a64.c ""
     "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64-sve.txt" OFF OFF)
+  torunonly_api(api.dis-a64-sve2 api.dis-a64 api/dis-a64.c ""
+    "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64-sve2.txt" OFF OFF)
   add_api_exe(api.reenc-a64 api/reenc-a64.c OFF OFF)
   tobuild_api(api.opnd api/opnd-a64.c "" "" OFF OFF OFF)
 elseif (X86)

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2022 ARM Limited. All rights reserved.
+# Copyright (c) 2022-2023 ARM Limited. All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without

--- a/suite/tests/api/dis-a64-sve2.txt
+++ b/suite/tests/api/dis-a64-sve2.txt
@@ -1,0 +1,34 @@
+# **********************************************************
+# Copyright (c) 2023 ARM Limited. All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of ARM Limited nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# Test data for DynamoRIO's AArch64 SVE2 encoder, decoder and disassembler.
+# See dis-a64-sve.txt for the formatting.
+
+# Tests:

--- a/suite/tests/api/dis-a64-v86.txt
+++ b/suite/tests/api/dis-a64-v86.txt
@@ -1,0 +1,34 @@
+# **********************************************************
+# Copyright (c) 2023 ARM Limited. All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of ARM Limited nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# Test data for DynamoRIO's AArch64 v8.6 encoder, decoder and disassembler.
+# See dis-a64-sve.txt for the formatting.
+
+# Tests:

--- a/suite/tests/api/ir_aarch64_sve2.c
+++ b/suite/tests/api/ir_aarch64_sve2.c
@@ -1,0 +1,62 @@
+/* **********************************************************
+ * Copyright (c) 2023 ARM Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Define DR_FAST_IR to verify that everything compiles when we call the inline
+ * versions of these routines.
+ */
+#ifndef STANDALONE_DECODER
+#    define DR_FAST_IR 1
+#endif
+
+/* Uses the DR API, using DR as a standalone library, rather than
+ * being a client library working with DR on a target program.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "tools.h"
+
+#include "ir_aarch64.h"
+
+int
+main(int argc, char *argv[])
+{
+    bool result = true;
+
+    print("All SVE2 tests complete.\n");
+#ifndef STANDALONE_DECODER
+    dr_standalone_exit();
+#endif
+    if (result)
+        return 0;
+    return 1;
+}

--- a/suite/tests/api/ir_aarch64_sve2.expect
+++ b/suite/tests/api/ir_aarch64_sve2.expect
@@ -1,0 +1,1 @@
+All SVE2 tests complete.

--- a/suite/tests/api/ir_aarch64_v86.c
+++ b/suite/tests/api/ir_aarch64_v86.c
@@ -47,7 +47,6 @@
 
 #include "ir_aarch64.h"
 
-
 int
 main(int argc, char *argv[])
 {

--- a/suite/tests/api/ir_aarch64_v86.c
+++ b/suite/tests/api/ir_aarch64_v86.c
@@ -1,0 +1,63 @@
+/* **********************************************************
+ * Copyright (c) 2023 ARM Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Define DR_FAST_IR to verify that everything compiles when we call the inline
+ * versions of these routines.
+ */
+#ifndef STANDALONE_DECODER
+#    define DR_FAST_IR 1
+#endif
+
+/* Uses the DR API, using DR as a standalone library, rather than
+ * being a client library working with DR on a target program.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "tools.h"
+
+#include "ir_aarch64.h"
+
+
+int
+main(int argc, char *argv[])
+{
+    bool result = true;
+
+    print("All v8.6 tests complete.\n");
+#ifndef STANDALONE_DECODER
+    dr_standalone_exit();
+#endif
+    if (result)
+        return 0;
+    return 1;
+}

--- a/suite/tests/api/ir_aarch64_v86.expect
+++ b/suite/tests/api/ir_aarch64_v86.expect
@@ -1,0 +1,1 @@
+All v8.6 tests complete.


### PR DESCRIPTION
* Updating the build and test system backends to support v8.6 and SVE2
* Added v8.3 to the codec checking scripts, as it seems to have been missed

Issue #2626