### PR TITLE
i#5843 scheduler: Add memtrace scheduler and refactor analyzer

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -209,6 +209,8 @@ Further non-compatibility-affecting changes include:
  - Added a new #dynamorio::drmemtrace::scheduler_tmpl_t interface providing scheduling
    of drmemtrace offline files onto configurable output streams, meant for use by
    microarchitectural simulators.
+ - Added a #memtrace_stream_t interface for drmemtrace analysis tools to
+   query key attributes of each input trace.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -144,7 +144,7 @@ changes:
    drmgr_reserve_note_range().
  - Removed the drcachesim external iterator analyzer interface.  Users should instead
    use the new #dynamorio::drmemtrace::scheduler_tmpl_t interface for direct control
-   over iteration.
+   over iteration.  See \ref sec_drcachesim_sched for example code.
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -142,6 +142,9 @@ changes:
  - Reduced the value of #DR_NOTE_FIRST_RESERVED.  This is not expected to cause
    problems unless clients are directly choosing high note values without using
    drmgr_reserve_note_range().
+ - Removed the drcachesim external iterator analyzer interface.  Users should instead
+   use the new #dynamorio::drmemtrace::scheduler_tmpl_t interface for direct control
+   over iteration.
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.
@@ -203,6 +206,9 @@ Further non-compatibility-affecting changes include:
  - Added opnd_create_increment_reg() to create a register from an existing
    register whose register number is incremented by some amount, wrapping
    at the max register number for that register.
+ - Added a new #dynamorio::drmemtrace::scheduler_tmpl_t interface providing scheduling
+   of drmemtrace offline files onto configurable output streams, meant for use by
+   microarchitectural simulators.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -224,8 +224,11 @@ if (liblz4)
   target_link_libraries(drmemtrace_raw2trace lz4)
 endif ()
 
+# XXX: We should link in drmemtrace_analyzer instead of re-building its
+# source files.
 set(drcachesim_srcs
   launcher.cpp
+  scheduler/scheduler.cpp
   analyzer.cpp
   analyzer_multi.cpp
   ${client_and_sim_srcs}
@@ -267,10 +270,12 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/simulator)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/common)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/reader)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/tracer)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/scheduler)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_exported_library(drmemtrace_analyzer STATIC
   analyzer.cpp
+  scheduler/scheduler.cpp
   common/trace_entry.cpp
   reader/reader.cpp
   reader/config_reader.cpp
@@ -306,6 +311,7 @@ install_client_nonDR_header(drmemtrace simulator/tlb_simulator_create.h)
 install_client_nonDR_header(drmemtrace tools/view_create.h)
 install_client_nonDR_header(drmemtrace tools/func_view_create.h)
 install_client_nonDR_header(drmemtrace tracer/raw2trace.h)
+install_client_nonDR_header(drmemtrace scheduler/scheduler.h)
 
 # We show one example of how to create a standalone analyzer of trace
 # files that does not need to link with DR.
@@ -652,6 +658,13 @@ if (BUILD_TESTS)
   use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drcovlib_static)
   add_test(NAME tool.drcacheoff.raw2trace_unit_tests
     COMMAND tool.drcacheoff.raw2trace_unit_tests)
+
+  add_executable(tool.scheduler.unit_tests tests/scheduler_unit_tests.cpp
+    tests/scheduler_unit_tests.cpp)
+  target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer)
+  add_win32_flags(tool.scheduler.unit_tests)
+  add_test(NAME tool.scheduler.unit_tests
+           COMMAND tool.scheduler.unit_tests)
 
   # XXX i#5675: add tests for other environments. Currently, the repository does not have
   # a checked-in post-processed trace for x86-32 or AArchXX.

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -216,17 +216,18 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler_common(
 template <typename RecordType, typename ReaderType>
 analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t(
     const std::string &trace_path, analysis_tool_tmpl_t<RecordType> **tools,
-    int num_tools, int worker_count, uint64_t skip_instrs)
+    int num_tools, int worker_count, uint64_t skip_instrs, int verbosity)
     : success_(true)
     , num_tools_(num_tools)
     , tools_(tools)
     , parallel_(true)
     , worker_count_(worker_count)
     , skip_instrs_(skip_instrs)
+    , verbosity_(verbosity)
 {
     // The scheduler will call reader_t::init() for each input file.  We assume
     // that won't block (analyzer_multi_t separates out IPC readers).
-    if (!init_scheduler(trace_path)) {
+    if (!init_scheduler(trace_path, verbosity)) {
         success_ = false;
         error_string_ = "Failed to create scheduler";
         return;

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -191,17 +191,14 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler_common(
     typename sched_type_t::scheduler_options_t sched_ops;
     int output_count;
     if (parallel_) {
-        sched_ops.how_split = sched_type_t::STREAM_BY_INPUT_SHARD;
-        sched_ops.strategy = sched_type_t::SCHEDULE_RUN_TO_COMPLETION;
+        sched_ops = sched_type_t::make_scheduler_parallel_ops(verbosity_);
         if (worker_count_ <= 0)
             worker_count_ = std::thread::hardware_concurrency();
     } else {
-        sched_ops.how_split = sched_type_t::STREAM_BY_SYNTHETIC_CPU;
-        sched_ops.strategy = sched_type_t::SCHEDULE_INTERLEAVE_AS_RECORDED;
+        sched_ops = sched_type_t::make_scheduler_serial_ops(verbosity_);
         worker_count_ = 1;
     }
     output_count = worker_count_;
-    sched_ops.verbosity = verbosity_;
     if (scheduler_.init(sched_inputs, output_count, sched_ops) !=
         sched_type_t::STATUS_SUCCESS) {
         ERRMSG("Failed to initialize scheduler: %s\n",

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -161,11 +161,13 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
         ERRMSG("Readers are empty\n");
         return false;
     }
+    std::vector<typename sched_type_t::input_reader_t> readers;
+    // With no modifiers or only_threads the tid doesn't matter.
+    readers.emplace_back(std::move(reader), std::move(reader_end), /*tid=*/1);
     std::vector<typename sched_type_t::range_t> regions;
     if (skip_instrs_ > 0)
         regions.emplace_back(skip_instrs_, 0);
-    typename sched_type_t::input_workload_t workload(std::move(reader),
-                                                     std::move(reader_end), regions);
+    typename sched_type_t::input_workload_t workload(std::move(readers), regions);
     return init_scheduler_common(workload);
 }
 

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -187,11 +187,11 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler_common(
     typename sched_type_t::scheduler_options_t sched_ops;
     int output_count;
     if (parallel_) {
-        sched_ops = sched_type_t::make_scheduler_parallel_ops(verbosity_);
+        sched_ops = sched_type_t::make_scheduler_parallel_options(verbosity_);
         if (worker_count_ <= 0)
             worker_count_ = std::thread::hardware_concurrency();
     } else {
-        sched_ops = sched_type_t::make_scheduler_serial_ops(verbosity_);
+        sched_ops = sched_type_t::make_scheduler_serial_options(verbosity_);
         worker_count_ = 1;
     }
     output_count = worker_count_;

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -170,7 +170,6 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
         }
         sched_inputs[0].reader = std::move(reader);
         sched_inputs[0].reader_end = std::move(reader_end);
-        sched_inputs[0].reader_tid = 1; // Any positive value will do.
     }
     typename sched_type_t::scheduler_options_t sched_ops;
     int output_count;

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -340,7 +340,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *w
                 // to this parallel model we can hit dup tids!  We'll need a different
                 // shard index solution.
                 shard_data[tid][i] = tools_[i]->parallel_shard_init_stream(
-                    tid, user_worker_data[i], worker->stream);
+                    static_cast<int>(tid), user_worker_data[i], worker->stream);
             }
         }
         for (int i = 0; i < num_tools_; ++i) {

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -30,6 +30,7 @@
  * DAMAGE.
  */
 
+#include <inttypes.h>
 #include <iostream>
 #include <thread>
 #include "analysis_tool.h"
@@ -64,63 +65,28 @@ typedef dynamorio::drmemtrace::record_file_reader_t<std::ifstream>
  */
 
 template <>
-std::unique_ptr<reader_t>
-analyzer_t::get_default_reader()
+bool
+analyzer_t::serial_mode_supported()
 {
-    return std::unique_ptr<default_file_reader_t>(new default_file_reader_t());
-}
-
-template <>
-std::unique_ptr<reader_t>
-analyzer_t::get_reader(const std::string &path, int verbosity)
-{
-#if defined(HAS_SNAPPY) || defined(HAS_ZIP)
-#    ifdef HAS_SNAPPY
-    if (ends_with(path, ".sz"))
-        return std::unique_ptr<reader_t>(new snappy_file_reader_t(path, verbosity));
-#    endif
-#    ifdef HAS_ZIP
-    if (ends_with(path, ".zip"))
-        return std::unique_ptr<reader_t>(new zipfile_file_reader_t(path, verbosity));
-#    endif
-    // If path is a directory, and any file in it ends in .sz, return a snappy reader.
-    if (directory_iterator_t::is_directory(path)) {
-        directory_iterator_t end;
-        directory_iterator_t iter(path);
-        if (!iter) {
-            ERRMSG("Failed to list directory %s: %s", path.c_str(),
-                   iter.error_string().c_str());
-            return nullptr;
-        }
-        for (; iter != end; ++iter) {
-            const std::string fname = *iter;
-            if (fname == "." || fname == ".." ||
-                starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
-                fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
-                continue;
-#    ifdef HAS_SNAPPY
-            if (ends_with(*iter, ".sz")) {
-                return std::unique_ptr<reader_t>(
-                    new snappy_file_reader_t(path, verbosity));
-            }
-#    endif
-#    ifdef HAS_ZIP
-            if (ends_with(*iter, ".zip")) {
-                return std::unique_ptr<reader_t>(
-                    new zipfile_file_reader_t(path, verbosity));
-            }
-#    endif
-        }
-    }
-#endif
-    // No snappy/zlib support, or didn't find a .sz/.zip file.
-    return std::unique_ptr<reader_t>(new default_file_reader_t(path, verbosity));
+    return true;
 }
 
 template <>
 bool
-analyzer_t::serial_mode_supported()
+analyzer_t::record_has_tid(memref_t record, memref_tid_t &tid)
 {
+    // All memref_t records have tids (after PR #5739 changed the reader).
+    tid = record.marker.tid;
+    return true;
+}
+
+template <>
+bool
+analyzer_t::record_is_thread_exit(memref_t record, memref_tid_t &tid)
+{
+    if (record.exit.type != TRACE_TYPE_THREAD_EXIT)
+        return false;
+    tid = record.exit.tid;
     return true;
 }
 
@@ -129,30 +95,33 @@ analyzer_t::serial_mode_supported()
  */
 
 template <>
-std::unique_ptr<dynamorio::drmemtrace::record_reader_t>
-record_analyzer_t::get_default_reader()
+bool
+record_analyzer_t::serial_mode_supported()
 {
-    return std::unique_ptr<default_record_file_reader_t>(
-        new default_record_file_reader_t());
-}
-
-template <>
-std::unique_ptr<dynamorio::drmemtrace::record_reader_t>
-record_analyzer_t::get_reader(const std::string &path, int verbosity)
-{
-    // TODO i#5675: Add support for other file formats, particularly
-    // .zip files.
-    return std::unique_ptr<dynamorio::drmemtrace::record_reader_t>(
-        new default_record_file_reader_t(path, verbosity));
+    // TODO i#5727,i#5843: Once we move serial interleaving from file_reader_t into
+    // the scheduler we can support serial mode for record files as we won't need
+    // to implement interleaving inside record_file_reader_t.
+    return false;
 }
 
 template <>
 bool
-record_analyzer_t::serial_mode_supported()
+record_analyzer_t::record_has_tid(trace_entry_t record, memref_tid_t &tid)
 {
-    // TODO i#5727: Add support in record_file_reader_t to interleave
-    // multiple traces and create a single trace stream.
-    return false;
+    if (record.type != TRACE_TYPE_THREAD)
+        return false;
+    tid = static_cast<memref_tid_t>(record.addr);
+    return true;
+}
+
+template <>
+bool
+record_analyzer_t::record_is_thread_exit(trace_entry_t record, memref_tid_t &tid)
+{
+    if (record.type != TRACE_TYPE_THREAD_EXIT)
+        return false;
+    tid = static_cast<memref_tid_t>(record.addr);
+    return true;
 }
 
 /********************************************************************
@@ -172,66 +141,62 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t()
 
 template <typename RecordType, typename ReaderType>
 bool
-analyzer_tmpl_t<RecordType, ReaderType>::init_file_reader(const std::string &trace_path,
-                                                          int verbosity)
+analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
+    const std::string &trace_path, std::unique_ptr<ReaderType> reader,
+    std::unique_ptr<ReaderType> reader_end, int verbosity)
 {
     verbosity_ = verbosity;
-    if (trace_path.empty()) {
-        ERRMSG("Trace file name is empty\n");
-        return false;
-    }
     for (int i = 0; i < num_tools_; ++i) {
         if (parallel_ && !tools_[i]->parallel_shard_supported()) {
             parallel_ = false;
             break;
         }
     }
-    if (parallel_ && directory_iterator_t::is_directory(trace_path)) {
-        directory_iterator_t end;
-        directory_iterator_t iter(trace_path);
-        if (!iter) {
-            ERRMSG("Failed to list directory %s: %s", trace_path.c_str(),
-                   iter.error_string().c_str());
+    std::vector<typename sched_type_t::input_workload_t> sched_inputs;
+    if (skip_instrs_ > 0) {
+        std::vector<typename sched_type_t::range_t> regions;
+        regions.emplace_back(skip_instrs_, 0);
+        sched_inputs.emplace_back(trace_path, regions);
+    } else {
+        sched_inputs.emplace_back(trace_path);
+    }
+    if (!trace_path.empty()) {
+        if (!!reader || !!reader_end)
+            return false;
+    } else if (trace_path.empty()) {
+        if (!reader || !reader_end) {
+            ERRMSG("Trace file name is empty\n");
             return false;
         }
-        for (; iter != end; ++iter) {
-            const std::string fname = *iter;
-            if (fname == "." || fname == ".." ||
-                starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
-                fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
-                continue;
-            const std::string path = trace_path + DIRSEP + fname;
-            std::unique_ptr<ReaderType> reader = get_reader(path, verbosity);
-            if (!reader) {
-                return false;
-            }
-            thread_data_.push_back(analyzer_shard_data_t(
-                static_cast<int>(thread_data_.size()), std::move(reader), path));
-            VPRINT(this, 2, "Opened reader for %s\n", path.c_str());
-        }
-        // Like raw2trace, we use a simple round-robin static work assigment.  This
-        // could be improved later with dynamic work queue for better load balancing.
+        sched_inputs[0].reader = std::move(reader);
+        sched_inputs[0].reader_end = std::move(reader_end);
+        sched_inputs[0].reader_tid = 1; // Any positive value will do.
+    }
+    typename sched_type_t::scheduler_options_t sched_ops;
+    int output_count;
+    if (parallel_) {
+        sched_ops.how_split = sched_type_t::STREAM_BY_INPUT_SHARD;
+        sched_ops.strategy = sched_type_t::SCHEDULE_RUN_TO_COMPLETION;
         if (worker_count_ <= 0)
             worker_count_ = std::thread::hardware_concurrency();
-        worker_tasks_.resize(worker_count_);
-        int worker = 0;
-        for (size_t i = 0; i < thread_data_.size(); ++i) {
-            VPRINT(this, 2, "Worker %d assigned trace shard %zd\n", worker, i);
-            worker_tasks_[worker].push_back(&thread_data_[i]);
-            thread_data_[i].worker = worker;
-            worker = (worker + 1) % worker_count_;
-        }
     } else {
-        parallel_ = false;
-        serial_trace_iter_ = get_reader(trace_path, verbosity);
-        if (!serial_trace_iter_) {
-            return false;
-        }
-        VPRINT(this, 2, "Opened serial reader for %s\n", trace_path.c_str());
+        sched_ops.how_split = sched_type_t::STREAM_BY_SYNTHETIC_CPU;
+        sched_ops.strategy = sched_type_t::SCHEDULE_INTERLEAVE_AS_RECORDED;
+        worker_count_ = 1;
     }
-    // It's ok if trace_end_ is a different type from serial_trace_iter_, they
-    // will still compare true if both at EOF.
-    trace_end_ = get_default_reader();
+    output_count = worker_count_;
+    sched_ops.verbosity = verbosity_;
+    if (scheduler_.init(sched_inputs, output_count, sched_ops) !=
+        sched_type_t::STATUS_SUCCESS) {
+        ERRMSG("Failed to initialize scheduler: %s\n",
+               scheduler_.get_error_string().c_str());
+        return false;
+    }
+
+    for (int i = 0; i < worker_count_; ++i) {
+        worker_data_.push_back(analyzer_worker_data_t(i, scheduler_.get_stream(i)));
+    }
+
     return true;
 }
 
@@ -246,9 +211,11 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t(
     , worker_count_(worker_count)
     , skip_instrs_(skip_instrs)
 {
-    if (!init_file_reader(trace_path)) {
+    // The scheduler will call reader_t::init() for each input file.  We assume
+    // that won't block (analyzer_multi_t separates out IPC readers).
+    if (!init_scheduler(trace_path)) {
         success_ = false;
-        error_string_ = "Failed to create reader";
+        error_string_ = "Failed to create scheduler";
         return;
     }
     for (int i = 0; i < num_tools; ++i) {
@@ -259,26 +226,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t(
                 error_string_ += ": " + tools_[i]->get_error_string();
             return;
         }
-        const std::string error = tools_[i]->initialize_stream(serial_trace_iter_.get());
-        if (!error.empty()) {
-            success_ = false;
-            error_string_ = "Tool failed to initialize: " + error;
-            return;
-        }
     }
-}
-
-template <typename RecordType, typename ReaderType>
-analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t(const std::string &trace_path)
-    : success_(true)
-    , num_tools_(0)
-    , tools_(NULL)
-    // This external-iterator interface does not support parallel analysis.
-    , parallel_(false)
-    , worker_count_(0)
-{
-    if (!init_file_reader(trace_path))
-        success_ = false;
 }
 
 // Work around clang-format bug: no newline after return type for single-char operator.
@@ -307,85 +255,102 @@ analyzer_tmpl_t<RecordType, ReaderType>::get_error_string()
     return error_string_;
 }
 
-// Used only for serial iteration.
-template <typename RecordType, typename ReaderType>
-bool
-analyzer_tmpl_t<RecordType, ReaderType>::start_reading()
-{
-    if (!serial_mode_supported()) {
-        ERRMSG("Serial mode not supported by this analyzer\n");
-        return false;
-    }
-    if (!serial_trace_iter_->init()) {
-        ERRMSG("Failed to read from trace\n");
-        return false;
-    }
-    return true;
-}
-
 template <typename RecordType, typename ReaderType>
 void
-analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(
-    std::vector<analyzer_shard_data_t *> *tasks)
+analyzer_tmpl_t<RecordType, ReaderType>::process_serial(analyzer_worker_data_t &worker)
 {
-    if (tasks->empty()) {
-        VPRINT(this, 1, "Worker has no tasks\n");
-        return;
+    std::vector<void *> user_worker_data(num_tools_);
+    std::unordered_map<memref_tid_t, std::vector<void *>> shard_data;
+
+    for (int i = 0; i < num_tools_; ++i) {
+        worker.error = tools_[i]->initialize_stream(worker.stream);
+        if (!worker.error.empty())
+            return;
     }
-    VPRINT(this, 1, "Worker %d assigned %zd task(s)\n", (*tasks)[0]->worker,
-           tasks->size());
-    std::vector<void *> worker_data(num_tools_);
-    for (int i = 0; i < num_tools_; ++i)
-        worker_data[i] = tools_[i]->parallel_worker_init((*tasks)[0]->worker);
-    for (analyzer_shard_data_t *tdata : *tasks) {
-        VPRINT(this, 1, "Worker %d starting on trace shard %d\n", tdata->worker,
-               tdata->index);
-        if (!tdata->iter->init()) {
-            tdata->error = "Failed to read from trace: " + tdata->trace_file;
+    while (true) {
+        RecordType record;
+        typename sched_type_t::stream_status_t status =
+            worker.stream->next_record(record);
+        if (status != sched_type_t::STATUS_OK) {
+            if (status != sched_type_t::STATUS_EOF) {
+                worker.error =
+                    "Failed to read from trace: " + worker.stream->get_stream_name();
+            }
             return;
         }
-        std::vector<void *> shard_data(num_tools_);
         for (int i = 0; i < num_tools_; ++i) {
-            shard_data[i] = tools_[i]->parallel_shard_init_stream(
-                tdata->index, worker_data[i], tdata->iter.get());
-        }
-        VPRINT(this, 1, "shard_data[0] is %p\n", shard_data[0]);
-        if (skip_instrs_ > 0) {
-            // We skip in each thread.
-            // TODO i#5538: Add top-level header data to memtrace_stream_t for
-            // access by tools, since we're skipping it here.  We considered
-            // not skipping until we see the 1st timestamp but the stream access
-            // approach has other benefits and seems cleaner.
-            (*tdata->iter) = (*tdata->iter).skip_instructions(skip_instrs_);
-        }
-        for (; *tdata->iter != *trace_end_; ++(*tdata->iter)) {
-            const RecordType &entry = **tdata->iter;
-            for (int i = 0; i < num_tools_; ++i) {
-                if (!tools_[i]->parallel_shard_memref(shard_data[i], entry)) {
-                    tdata->error = tools_[i]->parallel_shard_error(shard_data[i]);
-                    VPRINT(this, 1,
-                           "Worker %d hit shard memref error %s on trace shard %d\n",
-                           tdata->worker, tdata->error.c_str(), tdata->index);
-                    return;
-                }
-            }
-        }
-        VPRINT(this, 1, "Worker %d finished trace shard %d\n", tdata->worker,
-               tdata->index);
-        for (int i = 0; i < num_tools_; ++i) {
-            if (!tools_[i]->parallel_shard_exit(shard_data[i])) {
-                tdata->error = tools_[i]->parallel_shard_error(shard_data[i]);
-                VPRINT(this, 1, "Worker %d hit shard exit error %s on trace shard %d\n",
-                       tdata->worker, tdata->error.c_str(), tdata->index);
+            if (!tools_[i]->process_memref(record)) {
+                worker.error = tools_[i]->get_error_string();
+                VPRINT(this, 1, "Worker %d hit memref error %s on trace shard %s\n",
+                       worker.index, worker.error.c_str(),
+                       worker.stream->get_stream_name().c_str());
                 return;
             }
         }
     }
+}
+
+template <typename RecordType, typename ReaderType>
+void
+analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *worker)
+{
+    std::vector<void *> user_worker_data(num_tools_);
+    std::unordered_map<memref_tid_t, std::vector<void *>> shard_data;
+
+    for (int i = 0; i < num_tools_; ++i)
+        user_worker_data[i] = tools_[i]->parallel_worker_init(worker->index);
+    while (true) {
+        RecordType record;
+        typename sched_type_t::stream_status_t status =
+            worker->stream->next_record(record);
+        if (status != sched_type_t::STATUS_OK) {
+            if (status != sched_type_t::STATUS_EOF) {
+                worker->error =
+                    "Failed to read from trace: " + worker->stream->get_stream_name();
+            }
+            return;
+        }
+        memref_tid_t tid;
+        if (record_has_tid(record, tid)) {
+            if (shard_data.find(tid) == shard_data.end()) {
+                VPRINT(this, 1, "Worker %d starting on trace shard %" PRId64 "\n",
+                       worker->index, tid);
+                shard_data[tid].resize(num_tools_);
+                for (int i = 0; i < num_tools_; ++i) {
+                    shard_data[tid][i] = tools_[i]->parallel_shard_init_stream(
+                        shard_data.size(), user_worker_data[i], worker->stream);
+                }
+            }
+        }
+        for (int i = 0; i < num_tools_; ++i) {
+            if (!tools_[i]->parallel_shard_memref(shard_data[tid][i], record)) {
+                worker->error = tools_[i]->parallel_shard_error(shard_data[tid][i]);
+                VPRINT(this, 1, "Worker %d hit shard memref error %s on trace shard %s\n",
+                       worker->index, worker->error.c_str(),
+                       worker->stream->get_stream_name().c_str());
+                return;
+            }
+        }
+        if (record_is_thread_exit(record, tid)) {
+            VPRINT(this, 1, "Worker %d finished trace shard %s\n", worker->index,
+                   worker->stream->get_stream_name().c_str());
+            for (int i = 0; i < num_tools_; ++i) {
+                if (!tools_[i]->parallel_shard_exit(shard_data[tid][i])) {
+                    worker->error = tools_[i]->parallel_shard_error(shard_data[tid][i]);
+                    VPRINT(this, 1,
+                           "Worker %d hit shard exit error %s on trace shard %s\n",
+                           worker->index, worker->error.c_str(),
+                           worker->stream->get_stream_name().c_str());
+                    return;
+                }
+            }
+        }
+    }
     for (int i = 0; i < num_tools_; ++i) {
-        const std::string error = tools_[i]->parallel_worker_exit(worker_data[i]);
+        const std::string error = tools_[i]->parallel_worker_exit(user_worker_data[i]);
         if (!error.empty()) {
-            (*tasks)[0]->error = error;
-            VPRINT(this, 1, "Worker %d hit worker exit error %s\n", (*tasks)[0]->worker,
+            worker->error = error;
+            VPRINT(this, 1, "Worker %d hit worker exit error %s\n", worker->index,
                    error.c_str());
             return;
         }
@@ -398,41 +363,30 @@ analyzer_tmpl_t<RecordType, ReaderType>::run()
 {
     // XXX i#3286: Add a %-completed progress message by looking at the file sizes.
     if (!parallel_) {
-        if (!start_reading())
-            return false;
-        if (skip_instrs_ > 0) {
-            // TODO i#5538: Add top-level header data to memtrace_stream_t; see above.
-            (*serial_trace_iter_) = (*serial_trace_iter_).skip_instructions(skip_instrs_);
-        }
-        for (; *serial_trace_iter_ != *trace_end_; ++(*serial_trace_iter_)) {
-            const RecordType entry = **serial_trace_iter_;
-            for (int i = 0; i < num_tools_; ++i) {
-                // We short-circuit and exit on an error to avoid confusion over
-                // the results and avoid wasted continued work.
-                if (!tools_[i]->process_memref(entry)) {
-                    error_string_ = tools_[i]->get_error_string();
-                    return false;
-                }
-            }
-        }
+        process_serial(worker_data_[0]);
         return true;
     }
     if (worker_count_ <= 0) {
         error_string_ = "Invalid worker count: must be > 0";
         return false;
     }
+    for (int i = 0; i < num_tools_; ++i) {
+        error_string_ = tools_[i]->initialize_stream(nullptr);
+        if (!error_string_.empty())
+            return false;
+    }
     std::vector<std::thread> threads;
     VPRINT(this, 1, "Creating %d worker threads\n", worker_count_);
     threads.reserve(worker_count_);
     for (int i = 0; i < worker_count_; ++i) {
         threads.emplace_back(
-            std::thread(&analyzer_tmpl_t::process_tasks, this, &worker_tasks_[i]));
+            std::thread(&analyzer_tmpl_t::process_tasks, this, &worker_data_[i]));
     }
     for (std::thread &thread : threads)
         thread.join();
-    for (auto &tdata : thread_data_) {
-        if (!tdata.error.empty()) {
-            error_string_ = tdata.error;
+    for (auto &worker : worker_data_) {
+        if (!worker.error.empty()) {
+            error_string_ = worker.error;
             return false;
         }
     }
@@ -457,24 +411,6 @@ analyzer_tmpl_t<RecordType, ReaderType>::print_stats()
         }
     }
     return true;
-}
-
-// XXX i#3287: Figure out how to support parallel operation with this external
-// iterator interface.
-template <typename RecordType, typename ReaderType>
-ReaderType &
-analyzer_tmpl_t<RecordType, ReaderType>::begin()
-{
-    if (!start_reading())
-        return *trace_end_;
-    return *serial_trace_iter_;
-}
-
-template <typename RecordType, typename ReaderType>
-ReaderType &
-analyzer_tmpl_t<RecordType, ReaderType>::end()
-{
-    return *trace_end_;
 }
 
 template class analyzer_tmpl_t<memref_t, reader_t>;

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -318,7 +318,8 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *w
                 shard_data[tid].resize(num_tools_);
                 for (int i = 0; i < num_tools_; ++i) {
                     shard_data[tid][i] = tools_[i]->parallel_shard_init_stream(
-                        shard_data.size(), user_worker_data[i], worker->stream);
+                        static_cast<int>(shard_data.size()), user_worker_data[i],
+                        worker->stream);
                 }
             }
         }

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -139,13 +139,17 @@ protected:
         operator=(const analyzer_worker_data_t &) = delete;
     };
 
-    // Either trace_path must be non-empty, or both reader and reader_end must be set.
+    bool
+    init_scheduler(const std::string &trace_path, int verbosity = 0);
+
     bool
     init_scheduler(
-        const std::string &trace_path,
         std::unique_ptr<ReaderType> reader = std::unique_ptr<ReaderType>(nullptr),
         std::unique_ptr<ReaderType> reader_end = std::unique_ptr<ReaderType>(nullptr),
         int verbosity = 0);
+
+    bool
+    init_scheduler_common(typename sched_type_t::input_workload_t &workload);
 
     // Used for std::thread so we need an rvalue (so no &worker).
     void

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -162,7 +162,7 @@ protected:
     record_has_tid(RecordType record, memref_tid_t &tid);
 
     bool
-    record_is_thread_exit(RecordType record, memref_tid_t &tid);
+    record_is_thread_final(RecordType record);
 
     bool success_;
     scheduler_tmpl_t<RecordType, ReaderType> scheduler_;

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -103,7 +103,7 @@ public:
      */
     analyzer_tmpl_t(const std::string &trace_path,
                     analysis_tool_tmpl_t<RecordType> **tools, int num_tools,
-                    int worker_count = 0, uint64_t skip_instrs = 0);
+                    int worker_count = 0, uint64_t skip_instrs = 0, int verbosity = 0);
     /** Launches the analysis process. */
     virtual bool
     run();
@@ -174,9 +174,9 @@ protected:
     analysis_tool_tmpl_t<RecordType> **tools_;
     bool parallel_;
     int worker_count_;
-    int verbosity_ = 0;
     const char *output_prefix_ = "[analyzer]";
     uint64_t skip_instrs_ = 0;
+    int verbosity_ = 0;
 
 private:
     bool

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -129,8 +129,7 @@ analyzer_multi_t::analyzer_multi_t()
     if (!op_indir.get_value().empty()) {
         std::string tracedir =
             raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
-        if (!init_scheduler(tracedir, std::unique_ptr<reader_t>(nullptr),
-                            std::unique_ptr<reader_t>(nullptr), op_verbose.get_value()))
+        if (!init_scheduler(tracedir, op_verbose.get_value()))
             success_ = false;
     } else if (op_infile.get_value().empty()) {
         // XXX i#3323: Add parallel analysis support for online tools.
@@ -138,14 +137,12 @@ analyzer_multi_t::analyzer_multi_t()
         auto reader = std::unique_ptr<reader_t>(
             new ipc_reader_t(op_ipc_name.get_value().c_str(), op_verbose.get_value()));
         auto end = std::unique_ptr<reader_t>(new ipc_reader_t());
-        if (!init_scheduler("", std::move(reader), std::move(end),
-                            op_verbose.get_value())) {
+        if (!init_scheduler(std::move(reader), std::move(end), op_verbose.get_value())) {
             success_ = false;
         }
     } else {
         // Legacy file.
-        if (!init_scheduler(op_infile.get_value(), std::unique_ptr<reader_t>(nullptr),
-                            std::unique_ptr<reader_t>(nullptr), op_verbose.get_value()))
+        if (!init_scheduler(op_infile.get_value(), op_verbose.get_value()))
             success_ = false;
     }
     if (!init_analysis_tools()) {

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -129,27 +129,23 @@ analyzer_multi_t::analyzer_multi_t()
     if (!op_indir.get_value().empty()) {
         std::string tracedir =
             raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
-        if (!init_file_reader(tracedir, op_verbose.get_value()))
+        if (!init_scheduler(tracedir, std::unique_ptr<reader_t>(nullptr),
+                            std::unique_ptr<reader_t>(nullptr), op_verbose.get_value()))
             success_ = false;
     } else if (op_infile.get_value().empty()) {
         // XXX i#3323: Add parallel analysis support for online tools.
         parallel_ = false;
-        serial_trace_iter_ = std::unique_ptr<reader_t>(
+        auto reader = std::unique_ptr<reader_t>(
             new ipc_reader_t(op_ipc_name.get_value().c_str(), op_verbose.get_value()));
-        trace_end_ = std::unique_ptr<reader_t>(new ipc_reader_t());
-        if (!*serial_trace_iter_) {
+        auto end = std::unique_ptr<reader_t>(new ipc_reader_t());
+        if (!init_scheduler("", std::move(reader), std::move(end),
+                            op_verbose.get_value())) {
             success_ = false;
-#ifdef UNIX
-            // This is the most likely cause of the error.
-            // XXX: Even better would be to propagate the mkfifo errno here.
-            error_string_ = "try removing stale pipe file " +
-                reinterpret_cast<ipc_reader_t *>(serial_trace_iter_.get())
-                    ->get_stream_name();
-#endif
         }
     } else {
         // Legacy file.
-        if (!init_file_reader(op_infile.get_value(), op_verbose.get_value()))
+        if (!init_scheduler(op_infile.get_value(), std::unique_ptr<reader_t>(nullptr),
+                            std::unique_ptr<reader_t>(nullptr), op_verbose.get_value()))
             success_ = false;
     }
     if (!init_analysis_tools()) {
@@ -189,6 +185,7 @@ analyzer_multi_t::create_analysis_tools()
         if (op_offline.get_value()) {
             // TODO i#5538: Locate and open the schedule files and pass to the
             // reader(s) for seeking. For now we only read them for this test.
+            // TODO i#5843: Move this code into scheduler_t.
             std::string tracedir =
                 raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
             if (directory_iterator_t::is_directory(tracedir)) {
@@ -244,22 +241,7 @@ analyzer_multi_t::create_analysis_tools()
 bool
 analyzer_multi_t::init_analysis_tools()
 {
-    std::string tool_error = tools_[0]->initialize_stream(serial_trace_iter_.get());
-    if (!tool_error.empty()) {
-        error_string_ = "Tool failed to initialize: " + tool_error;
-        delete tools_[0];
-        tools_[0] = NULL;
-        return false;
-    }
-    if (op_test_mode.get_value()) {
-        tools_[1]->initialize_stream(serial_trace_iter_.get());
-        if (!*tools_[1]) {
-            error_string_ = tools_[1]->get_error_string();
-            delete tools_[1];
-            tools_[1] = NULL;
-            return false;
-        }
-    }
+    // initialize_stream() is now called from analyzer_t::run().
     return true;
 }
 

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -129,7 +129,7 @@ public:
      * Returns whether the current record was synthesized and inserted into the record
      * stream and was not present in the original stream.  This is true for timestamp
      * and cpuid headers duplicated after skipping ahead, as well as cpuid markers
-     * inserted for synthetic schedules.  Such records do not cound toward the record
+     * inserted for synthetic schedules.  Such records do not count toward the record
      * count and get_record_ordinal() will return the value of the prior record.
      */
     virtual bool

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -64,6 +64,7 @@ public:
     /**
      * Returns the count of #memref_t records from the start of the trace to this point.
      * This includes records skipped over and not presented to any tool.
+     * It does not include synthetic records (see is_record_synthetic()).
      */
     virtual uint64_t
     get_record_ordinal() const = 0;
@@ -123,6 +124,19 @@ public:
      */
     virtual uint64_t
     get_page_size() const = 0;
+
+    /**
+     * Returns whether the current record was synthesized and inserted into the record
+     * stream and was not present in the original stream.  This is true for timestamp
+     * and cpuid headers duplicated after skipping ahead, as well as cpuid markers
+     * inserted for synthetic schedules.  Such records do not cound toward the record
+     * count and get_record_ordinal() will return the value of the prior record.
+     */
+    virtual bool
+    is_record_synthetic() const
+    {
+        return false;
+    }
 };
 
 /**

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+
+// XXX: DR should export this
+#define INVALID_THREAD_ID 0
 
 // XXX: perhaps we should use a C++-ish stream approach instead
 // This cannot be named ERROR as that conflicts with Windows headers.

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1490,11 +1490,9 @@ tool framework's "external iterator" interface:
                         scheduler.get_error_string().c_str());
         }
         auto *stream = scheduler.get_stream(0);
-        while (true) {
-            memref_t record;
-            scheduler_t::stream_status_t status = stream->next_record(record);
-            if (status == scheduler_t::STATUS_EOF)
-                break;
+        memref_t record;
+        for (scheduler_t::stream_status_t status = stream->next_record(record);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(record)) {
             if (status != scheduler_t::STATUS_OK)
                 FATAL_ERROR("scheduler failed to advance: %d", status);
             if (!my_tool->process_memref(record)) {

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1481,25 +1481,25 @@ serves as an example of how to replace the now-removed old analysis
 tool framework's "external iterator" interface:
 
 \code
-        scheduler_t scheduler;
-        std::vector<scheduler_t::input_workload_t> sched_inputs;
-        sched_inputs.emplace_back(trace_directory);
-        if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
-            scheduler_t::STATUS_SUCCESS) {
-            FATAL_ERROR("failed to initialize scheduler: %s",
-                        scheduler.get_error_string().c_str());
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(trace_directory);
+    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) !=
+        scheduler_t::STATUS_SUCCESS) {
+        FATAL_ERROR("failed to initialize scheduler: %s",
+                    scheduler.get_error_string().c_str());
+    }
+    auto *stream = scheduler.get_stream(0);
+    memref_t record;
+    for (scheduler_t::stream_status_t status = stream->next_record(record);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(record)) {
+        if (status != scheduler_t::STATUS_OK)
+            FATAL_ERROR("scheduler failed to advance: %d", status);
+        if (!my_tool->process_memref(record)) {
+            FATAL_ERROR("tool failed to process entire trace: %s",
+                        my_tool->get_error_string().c_str());
         }
-        auto *stream = scheduler.get_stream(0);
-        memref_t record;
-        for (scheduler_t::stream_status_t status = stream->next_record(record);
-             status != scheduler_t::STATUS_EOF; status = stream->next_record(record)) {
-            if (status != scheduler_t::STATUS_OK)
-                FATAL_ERROR("scheduler failed to advance: %d", status);
-            if (!my_tool->process_memref(record)) {
-                FATAL_ERROR("tool failed to process entire trace: %s",
-                            my_tool->get_error_string().c_str());
-            }
-        }
+    }
 \endcode
 
 ****************************************************************************

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1484,10 +1484,8 @@ tool framework's "external iterator" interface:
         scheduler_t scheduler;
         std::vector<scheduler_t::input_workload_t> sched_inputs;
         sched_inputs.emplace_back(trace_directory);
-        scheduler_t::scheduler_options_t sched_ops(
-            scheduler_t::STREAM_BY_SYNTHETIC_CPU,
-            scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
-        if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS) {
+        if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
+            scheduler_t::STATUS_SUCCESS) {
             FATAL_ERROR("failed to initialize scheduler: %s",
                         scheduler.get_error_string().c_str());
         }

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -1464,6 +1464,47 @@ be created using the basic_counts_tool_create(), opcode_mix_tool_create(),
 histogram_tool_create(), reuse_distance_tool_create(), reuse_time_tool_create(),
 view_tool_create(), cache_simulator_create(), tlb_simulator_create(), and
 func_view_create() functions.
+
+\section sec_drcachesim_sched Scheduler
+
+In addition to the analysis tool framework, which targets running
+multiple tools at once either in parallel across all traced threads or
+in a serial fashion, we provide a scheduler which will map inputs to a
+given set of outputs in a specified manner.  This allows a tool such
+as a core simulator, or just a tool wanting its own control over
+advancing the trace stream (unlike the analysis tool framework where
+the framework controls the iteration), to request the next trace
+record for each output on its own.
+
+Here is a simple example of a single-output, serial stream.  This also
+serves as an example of how to replace the now-removed old analysis
+tool framework's "external iterator" interface:
+
+\code
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(trace_directory);
+        scheduler_t::scheduler_options_t sched_ops(
+            scheduler_t::STREAM_BY_SYNTHETIC_CPU,
+            scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
+        if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS) {
+            FATAL_ERROR("failed to initialize scheduler: %s",
+                        scheduler.get_error_string().c_str());
+        }
+        auto *stream = scheduler.get_stream(0);
+        while (true) {
+            memref_t record;
+            scheduler_t::stream_status_t status = stream->next_record(record);
+            if (status == scheduler_t::STATUS_EOF)
+                break;
+            if (status != scheduler_t::STATUS_OK)
+                FATAL_ERROR("scheduler failed to advance: %d", status);
+            if (!my_tool->process_memref(record)) {
+                FATAL_ERROR("tool failed to process entire trace: %s",
+                            my_tool->get_error_string().c_str());
+            }
+        }
+\endcode
 
 ****************************************************************************
 \page sec_drcachesim_ops Simulator Parameters

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -346,8 +346,16 @@ protected:
     skip_thread_instructions(size_t thread_index, uint64_t instruction_count,
                              OUT bool *eof)
     {
+        // TODO i#5538,i#5843: Once we move interleaving code from file_reader_t
+        // into scheduler_t, remove these _thread variants: read_next_thread_entry()
+        // and skip_thread_instructions().  Use reader_t::skip_instructions() here
+        // (don't override).
+
         // Default implementation for file types that have no fast seeking and must do a
         // linear walk.
+        // FIXME i#5538,i#5843: This is broken as it goes too far: see how
+        // reader_t::skip_instructions() does it.  We'll fix when we refactor (see
+        // comment at top of function).
         uint64_t stop_count_ = cur_instr_count_ + instruction_count + 1;
         while (cur_instr_count_ < stop_count_) {
             if (!read_next_thread_entry(thread_index, &entry_copy_, eof))
@@ -372,6 +380,9 @@ private:
     // that means we need to pick a new thread.
     size_t index_;
     size_t thread_count_;
+    // TODO i#5843: Once we move interleaving code from file_reader_t into scheduler_t
+    // these will all become singleton as one class instance here will have just one
+    // thread.  We can merge queues_ here into the new reader_t::queue_.
     std::vector<std::queue<trace_entry_t>> queues_;
     std::vector<trace_entry_t> tids_;
     std::vector<trace_entry_t> timestamps_;

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -321,7 +321,7 @@ reader_t::process_input_entry()
             --suppress_ref_count_;
         } else {
             if (suppress_ref_count_ == 0) {
-                // Ensure get_record_ordinal() ignores it.
+                // Ensure is_record_synthetic() ignores it.
                 suppress_ref_count_ = -1;
             }
             ++cur_ref_count_;

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -47,7 +47,7 @@ reader_t::operator*()
 }
 
 trace_entry_t *
-reader_t::read_next_queue_or_entry()
+reader_t::read_next_entry_or_queue()
 {
     if (!queue_.empty()) {
         local_entry_ = queue_.front();
@@ -63,7 +63,7 @@ reader_t::operator++()
     // We bail if we get a partial read, or EOF, or any error.
     while (true) {
         if (bundle_idx_ == 0 /*not in instr bundle*/)
-            input_entry_ = read_next_queue_or_entry();
+            input_entry_ = read_next_entry_or_queue();
         if (input_entry_ == NULL) {
             if (!at_eof_) {
                 ERRMSG("Trace is truncated\n");
@@ -364,7 +364,7 @@ reader_t::skip_instructions(uint64_t instruction_count)
         // too-far instr.
         if (input_entry_ != nullptr) // Only at start: and we checked for skipping 0.
             local_entry_ = *input_entry_;
-        input_entry_ = read_next_queue_or_entry();
+        input_entry_ = read_next_entry_or_queue();
         if (input_entry_ == nullptr) {
             if (!at_eof_) {
                 ERRMSG("Trace is truncated\n");

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -191,6 +191,7 @@ protected:
     virtual trace_entry_t *
     read_next_entry_or_queue();
     // Replaces the just-read record with the prior record, supplied here.
+    // Separated into a virtual method for overriding in test mock readers.
     virtual void
     use_prev(trace_entry_t *prev);
     // This reads the next entry from the single stream of entries

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -189,7 +189,7 @@ protected:
     // This first checks the local queue before calling read_next_entry().
     // in timestamp order.
     virtual trace_entry_t *
-    read_next_queue_or_entry();
+    read_next_entry_or_queue();
     // Replaces the just-read record with the prior record, supplied here.
     virtual void
     use_prev(trace_entry_t *prev);
@@ -225,8 +225,11 @@ protected:
     uint64_t cache_line_size_ = 0;
     uint64_t chunk_instr_count_ = 0;
     uint64_t page_size_ = 0;
+    // We need to read ahead when skipping to include post-instr records.
+    // We store into this queue records already read from the input but not
+    // yet returned to the iterator.
     std::queue<trace_entry_t> queue_;
-    trace_entry_t local_entry_;
+    trace_entry_t local_entry_; // For use in returning a queue entry.
 
 private:
     struct encoding_info_t {

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -138,8 +138,6 @@ public:
     uint64_t
     get_record_ordinal() const override
     {
-        if (suppress_ref_count_ >= 0)
-            return 0;
         return cur_ref_count_;
     }
     uint64_t
@@ -176,6 +174,11 @@ public:
     get_page_size() const override
     {
         return page_size_;
+    }
+    bool
+    is_record_synthetic() const override
+    {
+        return suppress_ref_count_ >= 0;
     }
 
 protected:

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -39,6 +39,7 @@
 
 #include <assert.h>
 #include <iterator>
+#include <queue>
 #include <unordered_map>
 #include <unordered_set>
 // For exporting we avoid "../common" and rely on -I.
@@ -182,6 +183,13 @@ protected:
     // in timestamp order.
     virtual trace_entry_t *
     read_next_entry() = 0;
+    // This first checks the local queue before calling read_next_entry().
+    // in timestamp order.
+    virtual trace_entry_t *
+    read_next_queue_or_entry();
+    // Replaces the just-read record with the prior record, supplied here.
+    virtual void
+    use_prev(trace_entry_t *prev);
     // This reads the next entry from the single stream of entries
     // from the specified thread.  If it returns false it will set *eof to distinguish
     // end-of-file from an error.
@@ -214,6 +222,8 @@ protected:
     uint64_t cache_line_size_ = 0;
     uint64_t chunk_instr_count_ = 0;
     uint64_t page_size_ = 0;
+    std::queue<trace_entry_t> queue_;
+    trace_entry_t local_entry_;
 
 private:
     struct encoding_info_t {

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -188,6 +188,7 @@ file_reader_t<zipfile_reader_t>::skip_thread_instructions(size_t thread_index,
     }
     // We have to linearly walk the last mile.
     bool prev_was_record_ord = false;
+    bool found_real_timestamp = false;
     while (cur_instr_count_ < stop_count_) { // End condition is never reached.
         if (!read_next_thread_entry(thread_index, &entry_copy_, eof))
             return false;
@@ -209,11 +210,13 @@ file_reader_t<zipfile_reader_t>::skip_thread_instructions(size_t thread_index,
             } else if (entry_copy_.size == TRACE_MARKER_TYPE_TIMESTAMP) {
                 timestamp = entry_copy_;
                 if (prev_was_record_ord)
-                    --cur_ref_count_;
+                    --cur_ref_count_; // Invisible to ordinals.
+                else
+                    found_real_timestamp = true;
             } else if (entry_copy_.size == TRACE_MARKER_TYPE_CPU_ID) {
                 cpu = entry_copy_;
                 if (prev_was_record_ord)
-                    --cur_ref_count_;
+                    --cur_ref_count_; // Invisible to ordinals.
             } else
                 prev_was_record_ord = false;
         } else
@@ -226,11 +229,24 @@ file_reader_t<zipfile_reader_t>::skip_thread_instructions(size_t thread_index,
         // Insert the two markers.
         trace_entry_t instr = entry_copy_;
         entry_copy_ = timestamp;
-        // These synthetic entries are not real records in the unskipped trace, so we
-        // do not associate record counts with them.
-        suppress_ref_count_ = 2;
+        if (!found_real_timestamp) {
+            // These synthetic entries are not real records in the unskipped trace, so we
+            // do not associate record counts with them.
+            suppress_ref_count_ = 1;
+            if (cpu.type == TRACE_TYPE_MARKER)
+                ++suppress_ref_count_;
+        } else {
+            // These are not invisible but we already counted them in the loop above
+            // so we need to avoid a double-count.
+            VPRINT(this, 4, "Found real timestamp: walking back ord from %" PRIu64 "\n",
+                   cur_ref_count_);
+            --cur_ref_count_;
+            if (cpu.type == TRACE_TYPE_MARKER)
+                --cur_ref_count_;
+        }
         process_input_entry();
-        queues_[thread_index].push(cpu);
+        if (cpu.type == TRACE_TYPE_MARKER)
+            queues_[thread_index].push(cpu);
         queues_[thread_index].push(instr);
     } else {
         // We missed the markers somehow; fall back to just process the instr.

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -571,6 +571,13 @@ scheduler_tmpl_t<RecordType, ReaderType>::get_input_name(int output_ordinal)
 }
 
 template <typename RecordType, typename ReaderType>
+int
+scheduler_tmpl_t<RecordType, ReaderType>::get_input_ordinal(int output_ordinal)
+{
+    return outputs_[output_ordinal].cur_input;
+}
+
+template <typename RecordType, typename ReaderType>
 bool
 scheduler_tmpl_t<RecordType, ReaderType>::is_record_synthetic(int output_ordinal)
 {

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -652,10 +652,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::advance_region_of_interest(int output_
         stream.chunk_instr_count_ = input.reader->get_chunk_instr_count();
         stream.page_size_ = input.reader->get_page_size();
     }
-    if (input.cur_region > 0) {
-        // We let the user know we've skipped.
-        input.queue.push(create_region_separator_marker(input.tid, input.cur_region));
-    }
+    // We let the user know we've skipped.  There's no discontinuity for the
+    // first one but we insert a marker anyway to be consistent.
+    input.queue.push(create_region_separator_marker(input.tid, input.cur_region));
     return sched_type_t::STATUS_SKIPPED;
 }
 

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -630,7 +630,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::advance_region_of_interest(int output_
            cur_instr, cur_range.start_instruction);
     // We assume the queue contains no instrs (else our query of input.reader's
     // instr ordinal would include them and so be incorrect) and that we should
-    // this skip it all.
+    // thus skip it all.
     while (!input.queue.empty())
         input.queue.pop();
     uint64_t input_start_ref = input.reader->get_record_ordinal();
@@ -704,16 +704,15 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(int output_ordinal)
             // the same output_ordinal will not be accessed by two different threads
             // simultaneously in this mode, allowing us to support a lock-free
             // parallel-friendly increment here.
-            ++outputs_[output_ordinal].input_indices_index;
-            if (outputs_[output_ordinal].input_indices_index >=
+            int indices_index = ++outputs_[output_ordinal].input_indices_index;
+            if (indices_index >=
                 static_cast<int>(outputs_[output_ordinal].input_indices.size())) {
                 VPRINT(this, 2, "next_record[%d]: all at eof\n", output_ordinal);
                 return sched_type_t::STATUS_EOF;
             }
-            index = outputs_[output_ordinal]
-                        .input_indices[outputs_[output_ordinal].input_indices_index];
+            index = outputs_[output_ordinal].input_indices[indices_index];
             VPRINT(this, 2, "next_record[%d]: advancing to local index %d == input #%d\n",
-                   output_ordinal, outputs_[output_ordinal].input_indices_index, index);
+                   output_ordinal, indices_index, index);
             // reader_t::at_eof_ is true until init() is called.
             if (inputs_[index].needs_init) {
                 inputs_[index].reader->init();

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -653,8 +653,12 @@ scheduler_tmpl_t<RecordType, ReaderType>::advance_region_of_interest(int output_
         stream.page_size_ = input.reader->get_page_size();
     }
     // We let the user know we've skipped.  There's no discontinuity for the
-    // first one but we insert a marker anyway to be consistent.
-    input.queue.push(create_region_separator_marker(input.tid, input.cur_region));
+    // first one so we do not insert a marker there (if we do want to insert one,
+    // we need to update the view tool to handle a window marker as the very
+    // first entry).
+    if (input.cur_region > 0) {
+        input.queue.push(create_region_separator_marker(input.tid, input.cur_region));
+    }
     return sched_type_t::STATUS_SKIPPED;
 }
 

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -714,6 +714,11 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(int output_ordinal)
                         .input_indices[outputs_[output_ordinal].input_indices_index];
             VPRINT(this, 2, "next_record[%d]: advancing to local index %d == input #%d\n",
                    output_ordinal, outputs_[output_ordinal].input_indices_index, index);
+            // reader_t::at_eof_ is true until init() is called.
+            if (inputs_[index].needs_init) {
+                inputs_[index].reader->init();
+                inputs_[index].needs_init = false;
+            }
         }
         if (inputs_[index].at_eof ||
             *inputs_[index].reader == *inputs_[index].reader_end) {

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1,0 +1,660 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "scheduler.h"
+#include "reader/file_reader.h"
+#ifdef HAS_ZLIB
+#    include "reader/compressed_file_reader.h"
+#endif
+#ifdef HAS_ZIP
+#    include "reader/zipfile_file_reader.h"
+#endif
+#ifdef HAS_SNAPPY
+#    include "reader/snappy_file_reader.h"
+#endif
+#include "directory_iterator.h"
+#include "common/utils.h"
+
+#undef VPRINT
+#ifdef DEBUG
+#    define VPRINT(obj, level, ...)                            \
+        do {                                                   \
+            if ((obj)->verbosity_ >= (level)) {                \
+                fprintf(stderr, "%s ", (obj)->output_prefix_); \
+                fprintf(stderr, __VA_ARGS__);                  \
+            }                                                  \
+        } while (0)
+#    define VDO(obj, level, statement)        \
+        do {                                  \
+            if ((obj)->verbosity_ >= (level)) \
+                statement                     \
+        } while (0)
+#else
+#    define VPRINT(reader, level, ...)  /* Nothing. */
+#    define VDO(obj, level, statementx) /* Nothing. */
+#endif
+
+namespace dynamorio {
+namespace drmemtrace {
+
+#ifdef HAS_ZLIB
+// Even if the file is uncompressed, zlib's gzip interface is faster than
+// file_reader_t's fstream in our measurements, so we always use it when
+// available.
+typedef compressed_file_reader_t default_file_reader_t;
+typedef compressed_record_file_reader_t default_record_file_reader_t;
+#else
+typedef file_reader_t<std::ifstream *> default_file_reader_t;
+typedef dynamorio::drmemtrace::record_file_reader_t<std::ifstream>
+    default_record_file_reader_t;
+#endif
+
+/****************************************************************
+ * Specializations for scheduler_tmpl_t<reader_t>, aka scheduler_t.
+ */
+
+template <>
+std::unique_ptr<reader_t>
+scheduler_tmpl_t<memref_t, reader_t>::get_default_reader()
+{
+    return std::unique_ptr<default_file_reader_t>(new default_file_reader_t());
+}
+
+template <>
+std::unique_ptr<reader_t>
+scheduler_tmpl_t<memref_t, reader_t>::get_reader(const std::string &path, int verbosity)
+{
+#if defined(HAS_SNAPPY) || defined(HAS_ZIP)
+#    ifdef HAS_SNAPPY
+    if (ends_with(path, ".sz"))
+        return std::unique_ptr<reader_t>(new snappy_file_reader_t(path, verbosity));
+#    endif
+#    ifdef HAS_ZIP
+    if (ends_with(path, ".zip"))
+        return std::unique_ptr<reader_t>(new zipfile_file_reader_t(path, verbosity));
+#    endif
+    // If path is a directory, and any file in it ends in .sz, return a snappy reader.
+    if (directory_iterator_t::is_directory(path)) {
+        directory_iterator_t end;
+        directory_iterator_t iter(path);
+        if (!iter) {
+            error_string_ =
+                "Failed to list directory " + path + ": " + iter.error_string() + ". ";
+            return nullptr;
+        }
+        for (; iter != end; ++iter) {
+            const std::string fname = *iter;
+            if (fname == "." || fname == ".." ||
+                starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
+                fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
+                continue;
+#    ifdef HAS_SNAPPY
+            if (ends_with(*iter, ".sz")) {
+                return std::unique_ptr<reader_t>(
+                    new snappy_file_reader_t(path, verbosity));
+            }
+#    endif
+#    ifdef HAS_ZIP
+            if (ends_with(*iter, ".zip")) {
+                return std::unique_ptr<reader_t>(
+                    new zipfile_file_reader_t(path, verbosity));
+            }
+#    endif
+        }
+    }
+#endif
+    // No snappy/zlib support, or didn't find a .sz/.zip file.
+    return std::unique_ptr<reader_t>(new default_file_reader_t(path, verbosity));
+}
+
+template <>
+bool
+scheduler_tmpl_t<memref_t, reader_t>::record_type_has_tid(memref_t record,
+                                                          memref_tid_t &tid)
+{
+    if (record.marker.tid == INVALID_THREAD_ID)
+        return false;
+    tid = record.marker.tid;
+    return true;
+}
+
+template <>
+bool
+scheduler_tmpl_t<memref_t, reader_t>::record_type_is_instr(memref_t record)
+{
+    return type_is_instr(record.instr.type);
+}
+
+template <>
+bool
+scheduler_tmpl_t<memref_t, reader_t>::record_type_is_marker(memref_t record,
+                                                            trace_marker_type_t &type,
+                                                            uintptr_t &value)
+{
+    if (record.marker.type != TRACE_TYPE_MARKER)
+        return false;
+    type = record.marker.marker_type;
+    value = record.marker.marker_value;
+    return true;
+}
+
+template <>
+memref_t
+scheduler_tmpl_t<memref_t, reader_t>::create_region_separator_marker(memref_tid_t tid,
+                                                                     uintptr_t value)
+{
+    memref_t record = {};
+    record.marker.type = TRACE_TYPE_MARKER;
+    record.marker.marker_type = TRACE_MARKER_TYPE_WINDOW_ID;
+    record.marker.marker_value = value;
+    record.marker.tid = tid;
+    return record;
+}
+
+template <>
+void
+scheduler_tmpl_t<memref_t, reader_t>::print_record(const memref_t &record)
+{
+    fprintf(stderr, "tid=%" PRId64 " type=%d", record.instr.tid, record.instr.type);
+    if (type_is_instr(record.instr.type))
+        fprintf(stderr, " pc=0x%zx size=%zu", record.instr.addr, record.instr.size);
+    fprintf(stderr, "\n");
+}
+
+/******************************************************************************
+ * Specializations for scheduler_tmpl_t<record_reader_t>, aka record_scheduler_t.
+ */
+
+template <>
+std::unique_ptr<dynamorio::drmemtrace::record_reader_t>
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::get_default_reader()
+{
+    return std::unique_ptr<default_record_file_reader_t>(
+        new default_record_file_reader_t());
+}
+
+template <>
+std::unique_ptr<dynamorio::drmemtrace::record_reader_t>
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::get_reader(const std::string &path,
+                                                             int verbosity)
+{
+    // TODO i#5675: Add support for other file formats, particularly
+    // .zip files.
+    return std::unique_ptr<dynamorio::drmemtrace::record_reader_t>(
+        new default_record_file_reader_t(path, verbosity));
+}
+
+template <>
+bool
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::record_type_has_tid(
+    trace_entry_t record, memref_tid_t &tid)
+{
+    if (record.type != TRACE_TYPE_THREAD)
+        return false;
+    tid = static_cast<memref_tid_t>(record.addr);
+    return true;
+}
+
+template <>
+bool
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::record_type_is_instr(
+    trace_entry_t record)
+{
+    return type_is_instr(static_cast<trace_type_t>(record.type));
+}
+
+template <>
+bool
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::record_type_is_marker(
+    trace_entry_t record, trace_marker_type_t &type, uintptr_t &value)
+{
+    if (record.type != TRACE_TYPE_MARKER)
+        return false;
+    type = static_cast<trace_marker_type_t>(record.size);
+    value = record.addr;
+    return true;
+}
+
+template <>
+trace_entry_t
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::create_region_separator_marker(
+    memref_tid_t tid, uintptr_t value)
+{
+    // We ignore the tid.
+    trace_entry_t record;
+    record.type = TRACE_TYPE_MARKER;
+    record.size = TRACE_MARKER_TYPE_WINDOW_ID;
+    record.addr = value;
+    return record;
+}
+
+template <>
+void
+scheduler_tmpl_t<trace_entry_t, record_reader_t>::print_record(
+    const trace_entry_t &record)
+{
+    fprintf(stderr, "type=%d\n", record.type);
+}
+
+/***************************************************************************
+ * Scheduled stream.
+ */
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::stream_t::next_record(RecordType &record)
+{
+    sched_type_t::stream_status_t res = scheduler_->next_record(ordinal_, record);
+    if (res != sched_type_t::STATUS_OK)
+        return res;
+    // Update our memtrace_stream_t state.
+    ++cur_ref_count_;
+    if (scheduler_->record_type_is_instr(record))
+        ++cur_instr_count_;
+    trace_marker_type_t marker_type;
+    uintptr_t marker_value;
+    if (scheduler_->record_type_is_marker(record, marker_type, marker_value)) {
+        switch (marker_type) {
+        case TRACE_MARKER_TYPE_TIMESTAMP: last_timestamp_ = marker_value; break;
+        case TRACE_MARKER_TYPE_VERSION: version_ = marker_value; break;
+        case TRACE_MARKER_TYPE_FILETYPE: filetype_ = marker_value; break;
+        case TRACE_MARKER_TYPE_CACHE_LINE_SIZE: cache_line_size_ = marker_value; break;
+        case TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT:
+            chunk_instr_count_ = marker_value;
+            break;
+        case TRACE_MARKER_TYPE_PAGE_SIZE: page_size_ = marker_value; break;
+        default: // No action needed.
+            break;
+        }
+    }
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::stream_t::report_time(uint64_t cur_time)
+{
+    return sched_type_t::STATUS_NOT_IMPLEMENTED;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::stream_t::start_speculation(
+    addr_t start_address)
+{
+    return sched_type_t::STATUS_NOT_IMPLEMENTED;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::stream_t::stop_speculation()
+{
+    return sched_type_t::STATUS_NOT_IMPLEMENTED;
+}
+
+/***************************************************************************
+ * Scheduler.
+ */
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::init(
+    std::vector<input_workload_t> &workload_inputs, int output_count,
+    scheduler_options_t options)
+{
+    // workload_inputs is not const so we can std::move readers out of it.
+    for (auto &workload : workload_inputs) {
+        if (workload.struct_size != sizeof(input_workload_t))
+            return STATUS_ERROR_INVALID_PARAMETER;
+        std::vector<memref_tid_t> workload_tids;
+        if (workload.path.empty()) {
+            if (!workload.reader || !workload.reader_end)
+                return STATUS_ERROR_INVALID_PARAMETER;
+            inputs_[workload.reader_tid].reader = std::move(workload.reader);
+            inputs_[workload.reader_tid].reader_end = std::move(workload.reader_end);
+            inputs_[workload.reader_tid].tid = workload.reader_tid;
+            inputs_[workload.reader_tid].needs_init = true;
+            workload_tids.push_back(workload.reader_tid);
+        } else {
+            if (!!workload.reader || !!workload.reader_end)
+                return STATUS_ERROR_INVALID_PARAMETER;
+            sched_type_t::scheduler_status_t res =
+                open_readers(workload.path, workload_tids);
+            if (res != STATUS_SUCCESS)
+                return res;
+        }
+        for (const auto &modifiers : workload.thread_modifiers) {
+            if (modifiers.struct_size != sizeof(input_thread_info_t))
+                return STATUS_ERROR_INVALID_PARAMETER;
+            const std::vector<memref_tid_t> *which_tids;
+            if (modifiers.tids.empty())
+                which_tids = &workload_tids;
+            else
+                which_tids = &modifiers.tids;
+            // We assume the overhead of copying the modifiers for every thread is
+            // not high and the simplified code is worthwhile.
+            for (memref_tid_t tid : *which_tids) {
+                if (inputs_.find(tid) == inputs_.end())
+                    return STATUS_ERROR_INVALID_PARAMETER;
+                inputs_[tid].tid = tid;
+                inputs_[tid].binding = modifiers.output_binding;
+                if (!inputs_[tid].binding.empty()) {
+                    // TODO i#5843: Implement bindings.
+                    return STATUS_ERROR_NOT_IMPLEMENTED;
+                }
+                inputs_[tid].priority = modifiers.priority;
+                if (inputs_[tid].priority != 0) {
+                    // TODO i#5843: Implement priorities.
+                    return STATUS_ERROR_NOT_IMPLEMENTED;
+                }
+                for (const auto &range : modifiers.regions_of_interest) {
+                    if (range.start_instruction == 0 ||
+                        (range.stop_instruction < range.start_instruction &&
+                         range.stop_instruction != 0))
+                        return STATUS_ERROR_INVALID_PARAMETER;
+                }
+                inputs_[tid].regions_of_interest = modifiers.regions_of_interest;
+            }
+        }
+    }
+    outputs_.reserve(output_count);
+    for (int i = 0; i < output_count; i++) {
+        outputs_.emplace_back(this, i, verbosity_);
+    }
+    options_ = options;
+    verbosity_ = options_.verbosity;
+    if (options_.consider_input_dependencies) {
+        // TODO i#5843: Implement dependency analysis and use it to inform input stream
+        // preemption.  Probably we would take offline analysis results as an input.
+        return STATUS_ERROR_NOT_IMPLEMENTED;
+    }
+    if (options_.how_split == STREAM_BY_INPUT_SHARD) {
+        // This mode is pure parallel with dependencies between threads ignored.
+        if (options_.strategy != SCHEDULE_RUN_TO_COMPLETION)
+            return STATUS_ERROR_INVALID_PARAMETER;
+        // Assign the inputs up front to avoid locks once we're in parallel mode.
+        // We use a simple round-robin static assignment for now.
+        size_t count = 0;
+        for (const auto &entry : inputs_) {
+            size_t index = count % output_count;
+            if (outputs_[index].tids_.empty())
+                outputs_[index].cur_input_tid = entry.first;
+            outputs_[index].tids_.push_back(entry.first);
+            ++count;
+        }
+    } else if (options_.how_split == STREAM_BY_SYNTHETIC_CPU) {
+        // TODO i#5843: Implement scheduling onto synthetic cores.
+        // Initially we only support analyzer_t's serial mode.
+        if (output_count != 1 || options_.strategy != SCHEDULE_INTERLEAVE_AS_RECORDED)
+            return STATUS_ERROR_NOT_IMPLEMENTED;
+    } else if (options_.how_split == STREAM_BY_RECORDED_CPU) {
+        // TODO i#5843,i#5694: Implement cpu-oriented iteration.
+        return STATUS_ERROR_NOT_IMPLEMENTED;
+    } else
+        return STATUS_ERROR_INVALID_PARAMETER;
+    return STATUS_SUCCESS;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::open_reader(
+    const std::string &path, std::vector<memref_tid_t> &workload_tids)
+{
+    if (path.empty() || directory_iterator_t::is_directory(path))
+        return STATUS_ERROR_INVALID_PARAMETER;
+    std::unique_ptr<ReaderType> reader = get_reader(path, verbosity_);
+    if (!reader || !reader->init()) {
+        error_string_ += "Failed to open " + path;
+        return STATUS_ERROR_FILE_OPEN_FAILED;
+    }
+    // We need the tid up front.  Rather than assume it's still part of the filename, we
+    // read the first record (we generalize to read until we find the first but we
+    // expect it to be the first after PR #5739 changed the order file_reader_t passes
+    // them to reader_t) to find it.
+    std::unique_ptr<ReaderType> reader_end = get_default_reader();
+    memref_tid_t tid = INVALID_THREAD_ID;
+    while (reader != reader_end) {
+        RecordType record = **reader;
+        if (record_type_has_tid(record, tid))
+            break;
+        inputs_[tid].queue.push(record);
+        ++(*reader);
+    }
+    if (tid == INVALID_THREAD_ID) {
+        error_string_ = "Failed to read " + path;
+        return STATUS_ERROR_FILE_READ_FAILED;
+    }
+    VPRINT(this, 2, "Opened reader for tid %" PRId64 " %s\n", tid, path.c_str());
+    inputs_[tid].reader = std::move(reader);
+    inputs_[tid].reader_end = std::move(reader_end);
+    workload_tids.push_back(tid);
+    return sched_type_t::STATUS_SUCCESS;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::open_readers(
+    const std::string &path, std::vector<memref_tid_t> &workload_tids)
+{
+    if (options_.how_split == STREAM_BY_SYNTHETIC_CPU &&
+        options_.strategy != SCHEDULE_INTERLEAVE_AS_RECORDED) {
+        // TODO i#5843: Move the interleaving-by-timestamp code from
+        // file_reader_t into this scheduler.  For now we leverage the
+        // file_reader_t code and use a synthetic tid.
+        std::unique_ptr<ReaderType> reader = get_reader(path, verbosity_);
+        std::unique_ptr<ReaderType> reader_end = get_default_reader();
+        if (!reader || !reader_end || !reader->init()) {
+            error_string_ += "Failed to open " + path;
+            return STATUS_ERROR_FILE_OPEN_FAILED;
+        }
+        memref_tid_t tid = 1;
+        inputs_[tid].reader = std::move(reader);
+        inputs_[tid].reader_end = std::move(reader_end);
+        workload_tids.push_back(tid);
+        return sched_type_t::STATUS_SUCCESS;
+    }
+
+    if (!directory_iterator_t::is_directory(path))
+        return open_reader(path, workload_tids);
+    directory_iterator_t end;
+    directory_iterator_t iter(path);
+    if (!iter) {
+        error_string_ = "Failed to list directory " + path + ": " + iter.error_string();
+        return sched_type_t::STATUS_ERROR_FILE_OPEN_FAILED;
+    }
+    for (; iter != end; ++iter) {
+        const std::string fname = *iter;
+        if (fname == "." || fname == ".." ||
+            starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
+            fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
+            continue;
+        const std::string file = path + DIRSEP + fname;
+        sched_type_t::scheduler_status_t res = open_reader(file, workload_tids);
+        if (res != sched_type_t::STATUS_SUCCESS)
+            return res;
+    }
+    return sched_type_t::STATUS_SUCCESS;
+}
+
+template <typename RecordType, typename ReaderType>
+std::string
+scheduler_tmpl_t<RecordType, ReaderType>::get_input_name(int output_ordinal)
+{
+    memref_tid_t tid = outputs_[output_ordinal].cur_input_tid;
+    if (tid == 0)
+        return "";
+    return inputs_[tid].reader->get_stream_name();
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::advance_region_of_interest(input_info_t &input)
+{
+    uint64_t cur_instr = input.reader->get_instruction_ordinal();
+    auto &cur_range = input.regions_of_interest[input.cur_region];
+    if (cur_range.stop_instruction != 0 && cur_instr > cur_range.stop_instruction) {
+        ++input.cur_region;
+        VPRINT(this, 2, "at %" PRId64 " instrs: advancing to ROI #%d\n", cur_instr,
+               input.cur_region);
+        if (input.cur_region >= static_cast<int>(input.regions_of_interest.size())) {
+            input.at_eof = true;
+            return sched_type_t::STATUS_EOF;
+        }
+        cur_range = input.regions_of_interest[input.cur_region];
+    }
+    if (cur_instr < cur_range.start_instruction) {
+        VPRINT(this, 2, "skipping from %" PRId64 " to %" PRId64 " instrs for ROI\n",
+               cur_instr, cur_range.start_instruction);
+        // We assume the queue contains no instrs (else our query of input.reader's
+        // instr ordinal would include them and so be incorrect) and that we should
+        // this skip it all.
+        while (!input.queue.empty())
+            input.queue.pop();
+        input.reader->skip_instructions(cur_range.start_instruction - cur_instr);
+        if (*input.reader == *input.reader_end) {
+            // Raise error because the input region is out of bounds.
+            input.at_eof = true;
+            return sched_type_t::STATUS_REGION_INVALID;
+        }
+        if (input.cur_region > 0) {
+            // We let the user know we've skipped.
+            input.queue.push(create_region_separator_marker(input.tid, input.cur_region));
+        }
+    }
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::next_record(int output_ordinal,
+                                                      RecordType &record)
+{
+    if (!(options_.how_split == STREAM_BY_INPUT_SHARD &&
+          options_.strategy == SCHEDULE_RUN_TO_COMPLETION) &&
+        !(options_.how_split == STREAM_BY_SYNTHETIC_CPU &&
+          options_.strategy == SCHEDULE_INTERLEAVE_AS_RECORDED)) {
+        // TODO i#5843: Implement instr/time quanta.
+        // TODO i#5843: Implement recorded-cpu scheduling.
+        // These will require locks and central coordination.
+        return sched_type_t::STATUS_NOT_IMPLEMENTED;
+    }
+    input_info_t *input;
+    if (options_.how_split == STREAM_BY_INPUT_SHARD) {
+        memref_tid_t tid = outputs_[output_ordinal].cur_input_tid;
+        while (true) {
+            if (tid == INVALID_THREAD_ID) {
+                // We're just starting, or done with the prior thread; take the next one
+                // that was pre-allocated to this output (pre-allocated to avoid locks).
+                // Invariant: the same output_ordinal will not be accessed by two
+                // different threads simultaneously in this mode, allowing us to support a
+                // lock-free parallel-friendly increment here.
+                ++outputs_[output_ordinal].cur_tids_index_;
+                if (outputs_[output_ordinal].cur_tids_index_ >=
+                    static_cast<ssize_t>(outputs_[output_ordinal].tids_.size())) {
+                    VPRINT(this, 2, "next_record[%d]: all at eof\n", output_ordinal);
+                    return sched_type_t::STATUS_EOF;
+                }
+                tid = outputs_[output_ordinal]
+                          .tids_[outputs_[output_ordinal].cur_tids_index_];
+                VPRINT(this, 2,
+                       "next_record[%d]: advancing to index %zd == tid %" PRId64 "\n",
+                       output_ordinal, outputs_[output_ordinal].cur_tids_index_, tid);
+            }
+            if (inputs_[tid].at_eof || *inputs_[tid].reader == *inputs_[tid].reader_end) {
+                VPRINT(this, 2, "next_record[%d]: index %zd == tid %" PRId64 " at eof\n",
+                       output_ordinal, outputs_[output_ordinal].cur_tids_index_, tid);
+                tid = INVALID_THREAD_ID;
+                inputs_[tid].at_eof = true;
+                // Loop and pick next thread.
+            } else if (!inputs_[tid].regions_of_interest.empty()) {
+                sched_type_t::stream_status_t res =
+                    advance_region_of_interest(inputs_[tid]);
+                if (res == sched_type_t::STATUS_EOF) {
+                    VPRINT(this, 2,
+                           "next_record[%d]: index %zd == tid %" PRId64 " beyond ROI\n",
+                           output_ordinal, outputs_[output_ordinal].cur_tids_index_, tid);
+                    tid = INVALID_THREAD_ID;
+                    // Loop and pick next thread.
+                } else if (res != sched_type_t::STATUS_OK)
+                    return res;
+                else
+                    break;
+            } else
+                break;
+        }
+        outputs_[output_ordinal].cur_input_tid = tid;
+        input = &inputs_[tid];
+    } else {
+        // Currently file_reader_t is interleaving for us so we have just one input.
+        // TODO i#5843: Move interleaving logic to here (and split it into a separate
+        // function).
+        if (inputs_.size() > 1)
+            return sched_type_t::STATUS_NOT_IMPLEMENTED;
+        for (auto &entry : inputs_) {
+            input = &entry.second;
+        }
+    }
+    if (input->needs_init) {
+        // We pay the cost of this conditional to support ipc_reader_t::init() which
+        // blocks and must be called right before reading its first record.
+        // The user can't call init() when it accesses the output streams because
+        // it std::moved the reader to us; we can't call it between our own init()
+        // and here as we have no control point in between, and our init() is too
+        // early as the user may have other work after that.
+        input->reader->init();
+        input->needs_init = false;
+    }
+    if (!input->regions_of_interest.empty()) {
+        sched_type_t::stream_status_t res = advance_region_of_interest(*input);
+        if (res != sched_type_t::STATUS_OK)
+            return res;
+    }
+    if (!input->queue.empty()) {
+        record = input->queue.front();
+        input->queue.pop();
+    } else {
+        if (*input->reader == *input->reader_end)
+            return sched_type_t::STATUS_EOF;
+        record = **input->reader;
+        ++(*input->reader);
+    }
+    VPRINT(this, 4, "next_record[%d]: ", output_ordinal);
+    VDO(this, 4, print_record(record););
+
+    return sched_type_t::STATUS_OK;
+}
+
+template class scheduler_tmpl_t<memref_t, reader_t>;
+template class scheduler_tmpl_t<trace_entry_t, dynamorio::drmemtrace::record_reader_t>;
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -480,7 +480,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::open_readers(
     const std::string &path, std::vector<memref_tid_t> &workload_tids)
 {
     if (options_.how_split == STREAM_BY_SYNTHETIC_CPU &&
-        options_.strategy != SCHEDULE_INTERLEAVE_AS_RECORDED) {
+        options_.strategy == SCHEDULE_INTERLEAVE_AS_RECORDED) {
         // TODO i#5843: Move the interleaving-by-timestamp code from
         // file_reader_t into this scheduler.  For now we leverage the
         // file_reader_t code and use a synthetic tid.

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -276,7 +276,7 @@ scheduler_tmpl_t<trace_entry_t, record_reader_t>::create_thread_exit(memref_tid_
     trace_entry_t record;
     record.type = TRACE_TYPE_THREAD_EXIT;
     record.size = sizeof(tid);
-    record.addr = tid;
+    record.addr = static_cast<addr_t>(tid);
     return record;
 }
 
@@ -379,7 +379,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
         if (workload.path.empty()) {
             if (!workload.reader || !workload.reader_end)
                 return STATUS_ERROR_INVALID_PARAMETER;
-            int index = inputs_.size();
+            int index = static_cast<int>(inputs_.size());
             inputs_.emplace_back();
             input_info_t &input = inputs_.back();
             input.index = index;
@@ -489,7 +489,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::open_reader(
         error_string_ += "Failed to open " + path;
         return STATUS_ERROR_FILE_OPEN_FAILED;
     }
-    int index = inputs_.size();
+    int index = static_cast<int>(inputs_.size());
     inputs_.emplace_back();
     input_info_t &input = inputs_.back();
     input.index = index;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -579,6 +579,16 @@ scheduler_tmpl_t<RecordType, ReaderType>::get_input_name(int output_ordinal)
 }
 
 template <typename RecordType, typename ReaderType>
+bool
+scheduler_tmpl_t<RecordType, ReaderType>::is_record_synthetic(int output_ordinal)
+{
+    int index = outputs_[output_ordinal].cur_input;
+    if (index < 0)
+        return false;
+    return inputs_[index].reader->is_record_synthetic();
+}
+
+template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::advance_region_of_interest(int output_ordinal,
                                                                      RecordType &record,

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -285,7 +285,8 @@ void
 scheduler_tmpl_t<trace_entry_t, record_reader_t>::print_record(
     const trace_entry_t &record)
 {
-    fprintf(stderr, "type=%d\n", record.type);
+    fprintf(stderr, "type=%d size=%d addr=0x%zx\n", record.type, record.size,
+            record.addr);
 }
 
 /***************************************************************************
@@ -441,7 +442,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
     for (int i = 0; i < output_count; i++) {
         outputs_.emplace_back(this, i, verbosity_);
     }
-    if (options_.consider_input_dependencies) {
+    if (options_.dependency_flags != DEPENDENCY_IGNORE) {
         // TODO i#5843: Implement dependency analysis and use it to inform input stream
         // preemption.  Probably we would take offline analysis results as an input.
         return STATUS_ERROR_NOT_IMPLEMENTED;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -167,6 +167,8 @@ public:
 
     /** Specifies an input that is already opened by a reader. */
     struct input_reader_t {
+        /** Creates an empty reader. */
+        input_reader_t() = default;
         /** Creates a reader entry. */
         input_reader_t(std::unique_ptr<ReaderType> reader,
                        std::unique_ptr<ReaderType> end, memref_tid_t tid)
@@ -186,7 +188,7 @@ public:
          * This is used to in the 'thread_modifiers' field of 'input_workload_t'
          * to refer to this input.
          */
-        memref_tid_t tid;
+        memref_tid_t tid = INVALID_THREAD_ID;
     };
 
     /** Specifies the input workloads to be scheduled. */
@@ -248,6 +250,15 @@ public:
 
         /** Scheduling modifiers for the threads in this workload. */
         std::vector<input_thread_info_t> thread_modifiers;
+
+        // Work around a known Visual Studio issue where it complains about deleted copy
+        // constructors for unique_ptr by deleting our copies and defaulting our moves.
+        input_workload_t(const input_workload_t &) = delete;
+        input_workload_t &
+        operator=(const input_workload_t &) = delete;
+        input_workload_t(input_workload_t &&) = default;
+        input_workload_t &
+        operator=(input_workload_t &&) = default;
     };
 
     /** Controls how inputs are mapped to outputs. */

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -345,6 +345,21 @@ public:
         int verbosity = 0;
     };
 
+    /** Constructs options for a parallel run-to-completion schedule. */
+    static scheduler_options_t
+    make_scheduler_parallel_ops(int verbosity = 0)
+    {
+        return scheduler_options_t(sched_type_t::STREAM_BY_INPUT_SHARD,
+                                   sched_type_t::SCHEDULE_RUN_TO_COMPLETION, verbosity);
+    }
+    /** Constructs options for a serial as-recorded schedule. */
+    static scheduler_options_t
+    make_scheduler_serial_ops(int verbosity = 0)
+    {
+        return scheduler_options_t(sched_type_t::STREAM_BY_SYNTHETIC_CPU,
+                                   sched_type_t::SCHEDULE_INTERLEAVE_AS_RECORDED,
+                                   verbosity);
+    }
     /**
      * Represents a stream of RecordType trace records derived from a
      * subset of a set of input recorded traces.  Provides more

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -357,7 +357,7 @@ public:
         /** Size of the struct for binary-compatible additions. */
         size_t struct_size = sizeof(scheduler_options_t);
         /** The mapping of inputs to outputs. */
-        mapping_t mapping = MAP_TO_RECORDED_OUTPUT;
+        mapping_t mapping = MAP_TO_ANY_OUTPUT;
         /** How inter-input dependencies are handled. */
         inter_input_dependency_t deps = DEPENDENCY_IGNORE;
         /** Optional flags affecting scheduler behavior. */
@@ -379,14 +379,14 @@ public:
 
     /** Constructs options for a parallel no-inter-input-dependencies schedule. */
     static scheduler_options_t
-    make_scheduler_parallel_ops(int verbosity = 0)
+    make_scheduler_parallel_options(int verbosity = 0)
     {
         return scheduler_options_t(sched_type_t::MAP_TO_CONSISTENT_OUTPUT,
                                    sched_type_t::DEPENDENCY_IGNORE, verbosity);
     }
     /** Constructs options for a serial as-recorded schedule. */
     static scheduler_options_t
-    make_scheduler_serial_ops(int verbosity = 0)
+    make_scheduler_serial_options(int verbosity = 0)
     {
         return scheduler_options_t(sched_type_t::MAP_TO_RECORDED_OUTPUT,
                                    sched_type_t::DEPENDENCY_TIMESTAMPS, verbosity);

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -441,6 +441,9 @@ public:
         uint64_t cache_line_size_ = 0;
         uint64_t chunk_instr_count_ = 0;
         uint64_t page_size_ = 0;
+
+        // Let the outer class update our state.
+        friend class scheduler_tmpl_t<RecordType, ReaderType>;
     };
 
     scheduler_tmpl_t()
@@ -487,6 +490,7 @@ protected:
         std::vector<range_t> regions_of_interest;
         int cur_region = 0;
         bool needs_init = false;
+        bool needs_advance = false;
         bool at_eof = false;
     };
 
@@ -517,10 +521,10 @@ protected:
     get_reader(const std::string &path, int verbosity);
 
     stream_status_t
-    next_record(int output_ordinal, RecordType &record);
+    next_record(int output_ordinal, RecordType &record, input_info_t *&input);
 
     stream_status_t
-    advance_region_of_interest(input_info_t &input);
+    advance_region_of_interest(int output_ordinal, input_info_t &input);
 
     bool
     record_type_has_tid(RecordType record, memref_tid_t &tid);

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -501,7 +501,7 @@ protected:
         // For static schedules we can populate this up front and avoid needing a
         // lock for dynamically finding the next input, keeping things parallel.
         std::vector<memref_tid_t> tids_;
-        ssize_t cur_tids_index_ = 0;
+        int cur_tids_index_ = 0;
     };
 
     scheduler_status_t

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1,0 +1,562 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Scheduler of traced software threads onto simulated cpus. */
+
+#ifndef _DRMEMTRACE_SCHEDULER_H_
+#define _DRMEMTRACE_SCHEDULER_H_ 1
+
+/**
+ * @file drmemtrace/scheduler.h
+ * @brief DrMemtrace top-level trace scheduler.
+ */
+
+#include <assert.h>
+#include <queue>
+#include <set>
+#include <unordered_map>
+#include <vector>
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "reader.h"
+#include "record_file_reader.h"
+#include "utils.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+/**
+ * Schedules traced software threads onto simulated cpus.
+ * Takes in a set of recorded traces and maps them onto a new set of output
+ * streams, typically representing simulated cpus.
+ *
+ * This is a templated class to support not just operating over #memref_t inputs
+ * read by #reader_t, but also over #trace_entry_t records read by
+ * #dynamorio::drmemtrace::record_reader_t.
+ */
+template <typename RecordType, typename ReaderType> class scheduler_tmpl_t {
+public:
+    /**
+     * Status codes used by non-stream member functions.
+     * get_error_string() provides additional information such was which input file
+     * path failed.
+     */
+    enum scheduler_status_t {
+        STATUS_SUCCESS,                 /**< Success. */
+        STATUS_ERROR_INVALID_PARAMETER, /**< Error: invalid parameter. */
+        STATUS_ERROR_FILE_OPEN_FAILED,  /**< Error: file open failed. */
+        STATUS_ERROR_FILE_READ_FAILED,  /**< Error: file read failed. */
+        STATUS_ERROR_NOT_IMPLEMENTED,   /**< Error: not implemented. */
+    };
+
+    /**
+     * Status codes used by stream member functions.
+     * get_error_string() provides additional information such was which input file
+     * path failed.
+     */
+    enum stream_status_t {
+        STATUS_OK,      /**< Stream is healthy and can continue to advance. */
+        STATUS_EOF,     /**< Stream is at its end. */
+        STATUS_IDLE,    /**< No records at this time. */
+        STATUS_WAIT,    /**< Wait for other streams before advancing can continue. */
+        STATUS_INVALID, /**< Error condition. */
+        STATUS_REGION_INVALID,  /**< Input region is out of bounds. */
+        STATUS_NOT_IMPLEMENTED, /**< Feature not implemented. */
+    };
+
+    /** A bounded sequence of instructions. */
+    struct range_t {
+        /** Convenience constructor. */
+        range_t(uint64_t start, uint64_t stop)
+            : start_instruction(start)
+            , stop_instruction(stop)
+        {
+        }
+        /**
+         * The starting point as a trace instruction ordinal.  These ordinals
+         * begin at 1, so a 'start_instruction' value of 0 is invalid.
+         */
+        uint64_t start_instruction;
+        /** The ending point.  A stop value of 0 means the end of the trace. */
+        uint64_t stop_instruction;
+    };
+
+    /**
+     * Specifies details about one set of input trace files, each representing a
+     * software thread.
+     */
+    struct input_thread_info_t {
+        /** Convenience constructor for common usage. */
+        explicit input_thread_info_t(std::vector<range_t> regions)
+            : struct_size(sizeof(input_thread_info_t))
+            , regions_of_interest(regions)
+        {
+        }
+        size_t struct_size; /**< Size of the struct for binary-compatible additions. */
+        /**
+         * Which threads the details in this structure apply to.
+         * If empty, the details apply to all threads in the
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::input_workload_t.
+         */
+        std::vector<memref_tid_t> tids;
+        /**
+         * Limits these threads to this set of output streams.  They will not
+         * be scheduled on any other output streams.
+         */
+        std::set<int> output_binding;
+        /**
+         * Relative priority for scheduling.  The default is 0.
+         */
+        // TODO i#5843: Decide and document whether these priorities are strict
+        // and higher will starve lower or whether they are looser.
+        int priority = 0;
+        /**
+         * If non-empty, all input records outside of these ranges are skipped: it is as
+         * though the input were constructed by concatenating these ranges together.  A
+         * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between ranges (with a value
+         * equal to the range ordinal) to notify the client of the discontinuity (but
+         * not before the first range).
+         */
+        std::vector<range_t> regions_of_interest;
+    };
+
+    /** Specifies the input workloads to be scheduled. */
+    struct input_workload_t {
+        /**
+         * Create a workload coming from a directory of many trace files or from
+         * a single trace file.
+         */
+        explicit input_workload_t(const std::string &trace_path)
+            : path(trace_path)
+        {
+        }
+        /** Create a workload with a pre-initialized reader. */
+        explicit input_workload_t(std::unique_ptr<ReaderType> reader,
+                                  std::unique_ptr<ReaderType> reader_end,
+                                  memref_tid_t reader_tid)
+            : reader(std::move(reader))
+            , reader_end(std::move(reader_end))
+            , reader_tid(reader_tid)
+        {
+        }
+        /**
+         * Create a workload coming from a directory of many trace files or from
+         * a single trace file where each trace file uses the given regions of interest.
+         */
+        input_workload_t(const std::string &trace_path,
+                         std::vector<range_t> regions_of_interest)
+            : struct_size(sizeof(input_workload_t))
+            , path(trace_path)
+        {
+            thread_modifiers.push_back(input_thread_info_t(regions_of_interest));
+        }
+        /** Size of the struct for binary-compatible additions. */
+        size_t struct_size = sizeof(input_workload_t);
+        /**
+         * A directory of trace files or a single trace file.
+         * A reader will be opened for each input file and its init() function
+         * will be called; that function will not block (variants where it
+         * does block, such as for IPC, should leave 'path' empty and use 'reader'
+         * below instead).
+         */
+        std::string path;
+        /**
+         * An alternative to passing in a path and having the scheduler open the file(s)
+         * there is to directly pass in a reader, reader_end, and a thread id for that
+         * reader.  These are only considered if 'path' is empty.  The scheduler will
+         * call the init() function for 'reader' at the time of the first access to
+         * it through an output stream (supporting IPC readers whose init() blocks).
+         */
+        std::unique_ptr<ReaderType> reader;
+        /** The end reader for 'reader'. */
+        std::unique_ptr<ReaderType> reader_end;
+        /** The thread identifier for 'reader'. */
+        memref_tid_t reader_tid = INVALID_THREAD_ID;
+
+        /** Scheduling modifiers for the threads in this workload. */
+        std::vector<input_thread_info_t> thread_modifiers;
+    };
+
+    /** Controls the primary mode of the scheduler regarding the input streams. */
+    enum stream_type_t {
+        /**
+         * Each input stream is mapped without interleaving directly onto a single
+         * output stream (i.e., no input will appear on more than one output),
+         * supporting parallel analysis.  The only strategy supported here is
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULE_RUN_TO_COMPLETION.
+         */
+        STREAM_BY_INPUT_SHARD,
+        /**
+         * Each input stream is assumed to contain markers indicating how it was
+         * originally scheduled.  This recorded schedule is replayed.  This requires an
+         * output stream count equal to the number of cores occupied by the input stream
+         * set.  The only strategy supported here is
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULE_INTERLEAVE_AS_RECORDED.
+         */
+        STREAM_BY_RECORDED_CPU,
+        /**
+         * The input streams are scheduling using a new synthetic schedule onto the
+         * output streams.  Any input markers indicating how the software threads were
+         * originally scheduled during tracing are ignored.
+         */
+        STREAM_BY_SYNTHETIC_CPU,
+    };
+
+    /** Controls the output of the scheduler. */
+    enum schedule_strategy_t {
+        /**
+         * Runs each input stream to completion without interleaving it with other
+         * inputs.  Ignores inter-input dependences.
+         */
+        SCHEDULE_RUN_TO_COMPLETION,
+        /**
+         * Interleaves and schedules the inputs exactly as they were recorded,
+         * following the markers in the input streams.
+         * This requires an output stream count equal to the number of cores
+         * occupied by the input stream set.
+         * The only stream type supported here is
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::STREAM_BY_RECORDED_CPU.
+         */
+        SCHEDULE_INTERLEAVE_AS_RECORDED,
+        // TODO i#5843: Can we get doxygen to link references without the
+        // fully-qualified name?  These are so long I had to omit the
+        // 'quantum_duration' to stay in the vera++-checked line limit.
+        /**
+         * Uses a synthetic schedule with pre-emption of an input to be replaced
+         * by another input on a given output stream when it uses up its
+         * quantum which is measured using instruction counts.
+         * The quantum size is specified by the `quantum_duration` field of
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::scheduler_options_t.
+         */
+        SCHEDULE_BY_INSTRUCTION_QUANTUM,
+        /**
+         * Uses a synthetic schedule with pre-emption of an input to be replaced
+         * by another input on a given output stream when it uses up its
+         * quantum which is measured using the user's notion of time.
+         * This notion of time must be supplied by the user by calling
+         * dynamorio::drmemtrace::scheduler_tmpl_t::stream_t::report_time()
+         * periodically.
+         * The quantum size is specified by the `quantum_duration` field of
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::scheduler_options_t.
+         */
+        SCHEDULE_BY_TIME_QUANTUM,
+    };
+
+    /** Flags controlling aspects of the scheduler beyond the core scheduling. */
+    enum scheduler_flags_t {
+        /** Default behavior. */
+        SCHEDULER_DEFAULTS = 0,
+        // TODO i#5843: Decide and then describe whether the physaddr is in every
+        // record or obtained via an API call.
+        /**
+         * Whether physical addresses should be provided in addition to virtual
+         * addresses.
+         */
+        SCHEDULER_PROVIDE_PHYSICAL_ADDRESSES = 0x1,
+        /**
+         * Specifies that speculation should supply just NOP instructions.
+         */
+        SCHEDULER_SPECULATE_NOPS = 0x2,
+        // TODO i#5843: Add more speculation flags for other strategies.
+    };
+
+    /**
+     * Collects the parameters specifying how the scheduler should behave, outside
+     * of the workload inputs and the output count.
+     */
+    struct scheduler_options_t {
+        /** Constructs a default set of options. */
+        scheduler_options_t()
+        {
+        }
+        /** Constructs a set of options with the given type and strategy. */
+        scheduler_options_t(stream_type_t stream_type, schedule_strategy_t strategy)
+            : how_split(stream_type)
+            , strategy(strategy)
+        {
+        }
+
+        /** Size of the struct for binary-compatible additions. */
+        size_t struct_size = sizeof(scheduler_options_t);
+        /** The base mode of the scheduler with respect to input streams. */
+        stream_type_t how_split = STREAM_BY_SYNTHETIC_CPU;
+        /** The scheduling strategy. */
+        schedule_strategy_t strategy = SCHEDULE_BY_INSTRUCTION_QUANTUM;
+        /** Optional flags affecting scheduler behavior. */
+        scheduler_flags_t flags = SCHEDULER_DEFAULTS;
+        /**
+         * The scheduling quantum duration for preemption.  The units are either
+         * instructions or user-controlled time, depending on whether
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULE_BY_INSTRUCTION_QUANTUM
+         * or
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULE_BY_TIME_QUANTUM
+         * is set.
+         */
+        uint64_t quantum_duration = 10 * 1000 * 1000;
+        /**
+         * Whether input stream inter-dependencies should be considered when preempting
+         * input streams.
+         */
+        bool consider_input_dependencies = false;
+        /**
+         * If > 0, diagnostic messages are printed to stderr.  Higher values produce
+         * more frequent diagnostics.
+         */
+        int verbosity = 0;
+    };
+
+    /**
+     * Represents a stream of RecordType trace records derived from a
+     * subset of a set of input recorded traces.  Provides more
+     * information about the record stream using the #memtrace_stream_t
+     * API.
+     */
+    class stream_t : public memtrace_stream_t {
+    public:
+        // TODO i#5843: Add Doxygen comments to all the remaining public elements
+        // below this line.
+        stream_t(scheduler_tmpl_t<RecordType, ReaderType> *scheduler, int ordinal,
+                 int verbosity = 0)
+            : scheduler_(scheduler)
+            , ordinal_(ordinal)
+            , verbosity_(verbosity)
+        {
+        }
+
+        virtual ~stream_t()
+        {
+        }
+
+        virtual stream_status_t
+        next_record(RecordType &record);
+
+        // This is unitless: it just needs to be called regularly and consistently.
+        virtual stream_status_t
+        report_time(uint64_t cur_time);
+
+        // These can be "nested"; only one stop_speculation call is needed to resume
+        // the paused stream.
+        virtual stream_status_t
+        start_speculation(addr_t start_address);
+
+        // Returns STATUS_INVALID if there was no prior start_speculation() call.
+        virtual stream_status_t
+        stop_speculation();
+
+        // memtrace_stream_t interface:
+
+        uint64_t
+        get_record_ordinal() const override
+        {
+            return cur_ref_count_;
+        }
+        uint64_t
+        get_instruction_ordinal() const override
+        {
+            return cur_instr_count_;
+        }
+        std::string
+        get_stream_name() const override
+        {
+            return scheduler_->get_input_name(ordinal_);
+        }
+        uint64_t
+        get_last_timestamp() const override
+        {
+            return last_timestamp_;
+        }
+        uint64_t
+        get_version() const override
+        {
+            return version_;
+        }
+        uint64_t
+        get_filetype() const override
+        {
+            return filetype_;
+        }
+        uint64_t
+        get_cache_line_size() const override
+        {
+            return cache_line_size_;
+        }
+        uint64_t
+        get_chunk_instr_count() const override
+        {
+            return chunk_instr_count_;
+        }
+        uint64_t
+        get_page_size() const override
+        {
+            return page_size_;
+        }
+
+        // Supplied for better error messages from the client.
+        std::string
+        get_source_file() const
+        {
+            return cur_src_path_;
+        }
+
+    protected:
+        scheduler_tmpl_t<RecordType, ReaderType> *scheduler_ = nullptr;
+        int ordinal_ = -1;
+        int verbosity_ = 0;
+        uint64_t cur_ref_count_ = 0;
+        uint64_t cur_instr_count_ = 0;
+        uint64_t last_timestamp_ = 0;
+        std::string cur_src_path_;
+        // Remember top-level headers for the memtrace_stream_t interface.
+        uint64_t version_ = 0;
+        uint64_t filetype_ = 0;
+        uint64_t cache_line_size_ = 0;
+        uint64_t chunk_instr_count_ = 0;
+        uint64_t page_size_ = 0;
+    };
+
+    scheduler_tmpl_t()
+    {
+    }
+    scheduler_tmpl_t(int verbosity)
+        : verbosity_(verbosity)
+    {
+    }
+    virtual ~scheduler_tmpl_t()
+    {
+    }
+
+    virtual scheduler_status_t
+    init(std::vector<input_workload_t> &workload_inputs, int output_count,
+         scheduler_options_t options);
+
+    virtual stream_t *
+    get_stream(int ordinal)
+    {
+        if (ordinal < 0 || ordinal >= static_cast<int>(outputs_.size()))
+            return nullptr;
+        return &outputs_[ordinal].stream;
+    }
+
+    std::string
+    get_error_string()
+    {
+        return error_string_;
+    }
+
+protected:
+    typedef scheduler_tmpl_t<RecordType, ReaderType> sched_type_t;
+
+    struct input_info_t {
+        std::unique_ptr<ReaderType> reader;
+        std::unique_ptr<ReaderType> reader_end;
+        memref_tid_t tid;
+        // If non-empty these records should be returned before incrementing
+        // the reader.
+        std::queue<RecordType> queue;
+        std::set<int> binding;
+        int priority = 0;
+        std::vector<range_t> regions_of_interest;
+        int cur_region = 0;
+        bool needs_init = false;
+        bool at_eof = false;
+    };
+
+    struct output_info_t {
+        output_info_t(scheduler_tmpl_t<RecordType, ReaderType> *scheduler, int ordinal,
+                      int verbosity = 0)
+            : stream(scheduler, ordinal, verbosity)
+        {
+        }
+        stream_t stream;
+        memref_tid_t cur_input_tid = INVALID_THREAD_ID;
+        // For static schedules we can populate this up front and avoid needing a
+        // lock for dynamically finding the next input, keeping things parallel.
+        std::vector<memref_tid_t> tids_;
+        ssize_t cur_tids_index_ = 0;
+    };
+
+    scheduler_status_t
+    open_readers(const std::string &path, std::vector<memref_tid_t> &workload_tids);
+
+    scheduler_status_t
+    open_reader(const std::string &path, std::vector<memref_tid_t> &workload_tids);
+
+    std::unique_ptr<ReaderType>
+    get_default_reader();
+
+    std::unique_ptr<ReaderType>
+    get_reader(const std::string &path, int verbosity);
+
+    stream_status_t
+    next_record(int output_ordinal, RecordType &record);
+
+    stream_status_t
+    advance_region_of_interest(input_info_t &input);
+
+    bool
+    record_type_has_tid(RecordType record, memref_tid_t &tid);
+
+    bool
+    record_type_is_instr(RecordType record);
+
+    bool
+    record_type_is_marker(RecordType record, trace_marker_type_t &type, uintptr_t &value);
+
+    RecordType
+    create_region_separator_marker(memref_tid_t tid, uintptr_t value);
+
+    void
+    print_record(const RecordType &record);
+
+    std::string
+    get_input_name(int output_ordinal);
+
+    // This has the same value as scheduler_options_t.verbosity (for use in VPRINT).
+    int verbosity_ = 0;
+    const char *output_prefix_ = "[scheduler]";
+    std::string error_string_;
+    scheduler_options_t options_;
+    std::unordered_map<memref_tid_t, input_info_t> inputs_;
+    std::vector<output_info_t> outputs_;
+};
+
+/** See #dynamorio::drmemtrace::scheduler_tmpl_t. */
+typedef scheduler_tmpl_t<memref_t, reader_t> scheduler_t;
+
+/** See #dynamorio::drmemtrace::scheduler_tmpl_t. */
+typedef scheduler_tmpl_t<trace_entry_t, dynamorio::drmemtrace::record_reader_t>
+    record_scheduler_t;
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _DRMEMTRACE_SCHEDULER_H_ */

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -91,6 +91,7 @@ public:
         STATUS_INVALID,         /**< Error condition. */
         STATUS_REGION_INVALID,  /**< Input region is out of bounds. */
         STATUS_NOT_IMPLEMENTED, /**< Feature not implemented. */
+        STATUS_SKIPPED,         /**< Used for internal scheduler purposes. */
     };
 
     /** A bounded sequence of instructions. */
@@ -455,10 +456,6 @@ public:
     scheduler_tmpl_t()
     {
     }
-    scheduler_tmpl_t(int verbosity)
-        : verbosity_(verbosity)
-    {
-    }
     virtual ~scheduler_tmpl_t()
     {
     }
@@ -502,6 +499,7 @@ protected:
         bool has_modifier = false;
         bool needs_init = false;
         bool needs_advance = false;
+        bool needs_roi = true;
         bool at_eof = false;
     };
 
@@ -537,7 +535,11 @@ protected:
     next_record(int output_ordinal, RecordType &record, input_info_t *&input);
 
     stream_status_t
-    advance_region_of_interest(int output_ordinal, input_info_t &input);
+    advance_region_of_interest(int output_ordinal, RecordType &record,
+                               input_info_t &input);
+
+    stream_status_t
+    pick_next_input(int output_ordinal);
 
     bool
     record_type_has_tid(RecordType record, memref_tid_t &tid);
@@ -550,6 +552,9 @@ protected:
 
     RecordType
     create_region_separator_marker(memref_tid_t tid, uintptr_t value);
+
+    RecordType
+    create_thread_exit(memref_tid_t tid);
 
     void
     print_record(const RecordType &record);

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -111,8 +111,9 @@ public:
     };
 
     /**
-     * Specifies details about one set of input trace files, each representing a
-     * software thread.
+     * Specifies details about one set of input trace files from one workload,
+     * each input file representing a single software thread.
+     * It is assumed that there is no thread id duplication within one workload.
      */
     struct input_thread_info_t {
         /** Convenience constructor for common usage. */
@@ -549,6 +550,8 @@ protected:
     const char *output_prefix_ = "[scheduler]";
     std::string error_string_;
     scheduler_options_t options_;
+    // TODO i#5843: We can have dup tids across workloads so we need a different
+    // index here for multi-workload support.
     std::unordered_map<memref_tid_t, input_info_t> inputs_;
     std::vector<output_info_t> outputs_;
 };

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -446,6 +446,16 @@ public:
             return scheduler_->get_input_name(ordinal_);
         }
         /**
+         * Returns a name for the current input stream feeding this output stream. For
+         * stored offline traces, this is the base name of the trace on disk. For online
+         * traces, this is the name of the pipe.
+         */
+        int
+        get_input_stream_ordinal()
+        {
+            return scheduler_->get_input_ordinal(ordinal_);
+        }
+        /**
          * Returns the value of the last seen #TRACE_MARKER_TYPE_TIMESTAMP marker.
          */
         uint64_t
@@ -664,6 +674,11 @@ protected:
     // the 'output_ordinal'-th output stream.
     std::string
     get_input_name(int output_ordinal);
+
+    // Returns the input ordinal value for the current input stream scheduled on
+    // the 'output_ordinal'-th output stream.
+    int
+    get_input_ordinal(int output_ordinal);
 
     // Returns whether the current record for the current input stream scheduled on
     // the 'output_ordinal'-th output stream is synthetic.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -154,19 +154,9 @@ public:
 
     /** Specifies the input workloads to be scheduled. */
     struct input_workload_t {
-        /**
-         * Create a workload coming from a directory of many trace files or from
-         * a single trace file.
-         */
-        explicit input_workload_t(const std::string &trace_path)
-            : path(trace_path)
-        {
-        }
-        /** Create a workload with a pre-initialized reader. */
-        explicit input_workload_t(std::unique_ptr<ReaderType> reader,
-                                  std::unique_ptr<ReaderType> reader_end)
-            : reader(std::move(reader))
-            , reader_end(std::move(reader_end))
+        /** Create an empty workload.  This is not a valid final input. */
+        input_workload_t()
+            : struct_size(sizeof(input_workload_t))
         {
         }
         /**
@@ -174,11 +164,26 @@ public:
          * a single trace file where each trace file uses the given regions of interest.
          */
         input_workload_t(const std::string &trace_path,
-                         std::vector<range_t> regions_of_interest)
+                         std::vector<range_t> regions_of_interest = {})
             : struct_size(sizeof(input_workload_t))
             , path(trace_path)
         {
-            thread_modifiers.push_back(input_thread_info_t(regions_of_interest));
+            if (!regions_of_interest.empty())
+                thread_modifiers.push_back(input_thread_info_t(regions_of_interest));
+        }
+        /**
+         * Create a workload with a pre-initialized reader which uses the given
+         * regions of interest.
+         */
+        input_workload_t(std::unique_ptr<ReaderType> reader,
+                         std::unique_ptr<ReaderType> reader_end,
+                         std::vector<range_t> regions_of_interest = {})
+            : struct_size(sizeof(input_workload_t))
+            , reader(std::move(reader))
+            , reader_end(std::move(reader_end))
+        {
+            if (!regions_of_interest.empty())
+                thread_modifiers.push_back(input_thread_info_t(regions_of_interest));
         }
         /** Size of the struct for binary-compatible additions. */
         size_t struct_size = sizeof(input_workload_t);

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -34,7 +34,7 @@
  * a "burst" of execution in the middle of the application.  It then detaches.
  * It then post-processes the acquired trace and confirms various assertions.
  */
-#include "analyzer.h"
+#include "scheduler.h"
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
 #include "tracer/instru.h"
@@ -53,6 +53,8 @@
                    : 0))
 #define ASSERT_NOT_REACHED() ASSERT_MSG(false, "Shouldn't be reached")
 #define ALIGNED(x, alignment) ((((ptr_uint_t)x) & ((alignment)-1)) == 0)
+
+using namespace dynamorio::drmemtrace;
 
 /*******************************************************************************
  * Begin application code.
@@ -219,9 +221,14 @@ main(int argc, const char *argv[])
     std::string trace_dir = gather_trace();
 
     void *dr_context = dr_standalone_init();
-    analyzer_t analyzer(trace_dir);
-    if (!analyzer) {
-        std::cerr << "Failed to initialize iterator " << analyzer.get_error_string()
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(trace_dir);
+    scheduler_t::scheduler_options_t sched_ops(
+        scheduler_t::STREAM_BY_SYNTHETIC_CPU,
+        scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
+    if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS) {
+        std::cerr << "Failed to initialize scheduler " << scheduler.get_error_string()
                   << "\n";
     }
     bool found_cache_line_size_marker = false;
@@ -229,8 +236,13 @@ main(int argc, const char *argv[])
     int dc_zva_instr_count = 0;
     int dc_zva_memref_count = 0;
     addr_t last_dc_zva_pc = 0;
-    for (reader_t &iter = analyzer.begin(); iter != analyzer.end(); ++iter) {
-        memref_t memref = *iter;
+    auto *stream = scheduler.get_stream(0);
+    while (true) {
+        memref_t memref;
+        scheduler_t::stream_status_t status = stream->next_record(memref);
+        if (status == scheduler_t::STATUS_EOF)
+            break;
+        assert(status == scheduler_t::STATUS_OK);
         if (memref.marker.type == TRACE_TYPE_MARKER &&
             memref.marker.marker_type == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {
             found_cache_line_size_marker = true;

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -235,11 +235,9 @@ main(int argc, const char *argv[])
     int dc_zva_memref_count = 0;
     addr_t last_dc_zva_pc = 0;
     auto *stream = scheduler.get_stream(0);
-    while (true) {
-        memref_t memref;
-        scheduler_t::stream_status_t status = stream->next_record(memref);
-        if (status == scheduler_t::STATUS_EOF)
-            break;
+    memref_t memref;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
         assert(status == scheduler_t::STATUS_OK);
         if (memref.marker.type == TRACE_TYPE_MARKER &&
             memref.marker.marker_type == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -224,7 +224,7 @@ main(int argc, const char *argv[])
     scheduler_t scheduler;
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(trace_dir);
-    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
+    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) !=
         scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler " << scheduler.get_error_string()
                   << "\n";

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -224,10 +224,8 @@ main(int argc, const char *argv[])
     scheduler_t scheduler;
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(trace_dir);
-    scheduler_t::scheduler_options_t sched_ops(
-        scheduler_t::STREAM_BY_SYNTHETIC_CPU,
-        scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
-    if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS) {
+    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
+        scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler " << scheduler.get_error_string()
                   << "\n";
     }

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -283,7 +283,7 @@ look_for_gencode(std::string trace_dir)
     scheduler_t scheduler;
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(trace_dir);
-    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
+    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) !=
         scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler " << scheduler.get_error_string()
                   << "\n";

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -283,10 +283,8 @@ look_for_gencode(std::string trace_dir)
     scheduler_t scheduler;
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(trace_dir);
-    scheduler_t::scheduler_options_t sched_ops(
-        scheduler_t::STREAM_BY_SYNTHETIC_CPU,
-        scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
-    if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS) {
+    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
+        scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler " << scheduler.get_error_string()
                   << "\n";
     }

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -295,11 +295,9 @@ look_for_gencode(std::string trace_dir)
     dr_set_isa_mode(dr_context, DR_ISA_ARM_A32, nullptr);
 #endif
     auto *stream = scheduler.get_stream(0);
-    while (true) {
-        memref_t memref;
-        scheduler_t::stream_status_t status = stream->next_record(memref);
-        if (status == scheduler_t::STATUS_EOF)
-            break;
+    memref_t memref;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
         assert(status == scheduler_t::STATUS_OK);
         if (memref.marker.type == TRACE_TYPE_MARKER &&
             memref.marker.marker_type == TRACE_MARKER_TYPE_FILETYPE &&

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,13 +41,15 @@
 #include "drmemtrace/drmemtrace.h"
 #include "drmemtrace/raw2trace.h"
 #include "raw2trace_directory.h"
-#include "analyzer.h"
+#include "scheduler.h"
 #include <assert.h>
 #include <fstream>
 #include <iostream>
 #include <string>
 #undef ALIGN_FORWARD // Conflicts with drcachesim utils.h.
 #include "tools.h"   // Included after system headers to avoid printf warning.
+
+using namespace dynamorio::drmemtrace;
 
 namespace {
 
@@ -278,9 +280,15 @@ static int
 look_for_gencode(std::string trace_dir)
 {
     void *dr_context = dr_standalone_init();
-    analyzer_t analyzer(trace_dir);
-    if (!analyzer) {
-        std::cerr << "Failed to initialize: " << analyzer.get_error_string() << "\n";
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(trace_dir);
+    scheduler_t::scheduler_options_t sched_ops(
+        scheduler_t::STREAM_BY_SYNTHETIC_CPU,
+        scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
+    if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS) {
+        std::cerr << "Failed to initialize scheduler " << scheduler.get_error_string()
+                  << "\n";
     }
     bool found_magic1 = false, found_magic2 = false;
     bool have_instr_encodings = false;
@@ -288,8 +296,13 @@ look_for_gencode(std::string trace_dir)
     // DR will auto-switch locally to Thumb for LSB=1 but not to ARM so we start as ARM.
     dr_set_isa_mode(dr_context, DR_ISA_ARM_A32, nullptr);
 #endif
-    for (reader_t &iter = analyzer.begin(); iter != analyzer.end(); ++iter) {
-        memref_t memref = *iter;
+    auto *stream = scheduler.get_stream(0);
+    while (true) {
+        memref_t memref;
+        scheduler_t::stream_status_t status = stream->next_record(memref);
+        if (status == scheduler_t::STATUS_EOF)
+            break;
+        assert(status == scheduler_t::STATUS_OK);
         if (memref.marker.type == TRACE_TYPE_MARKER &&
             memref.marker.marker_type == TRACE_MARKER_TYPE_FILETYPE &&
             TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, memref.marker.marker_value)) {

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -231,7 +231,7 @@ main(int argc, const char *argv[])
     std::vector<scheduler_t::input_workload_t> sched_opt_inputs;
     sched_opt_inputs.emplace_back(dir_opt);
     if (scheduler_opt.init(sched_opt_inputs, 1,
-                           scheduler_t::make_scheduler_serial_ops()) !=
+                           scheduler_t::make_scheduler_serial_options()) !=
         scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler " << scheduler_opt.get_error_string()
                   << "\n";
@@ -241,7 +241,7 @@ main(int argc, const char *argv[])
     std::vector<scheduler_t::input_workload_t> sched_noopt_inputs;
     sched_noopt_inputs.emplace_back(dir_noopt);
     if (scheduler_noopt.init(sched_noopt_inputs, 1,
-                             scheduler_t::make_scheduler_serial_ops()) !=
+                             scheduler_t::make_scheduler_serial_options()) !=
         scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler "
                   << scheduler_noopt.get_error_string() << "\n";

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -227,14 +227,11 @@ main(int argc, const char *argv[])
     // Now compare the two traces using external iterators and a custom tool.
     void *dr_context = dr_standalone_init();
 
-    scheduler_t::scheduler_options_t sched_ops(
-        scheduler_t::STREAM_BY_SYNTHETIC_CPU,
-        scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
-
     scheduler_t scheduler_opt;
     std::vector<scheduler_t::input_workload_t> sched_opt_inputs;
     sched_opt_inputs.emplace_back(dir_opt);
-    if (scheduler_opt.init(sched_opt_inputs, 1, sched_ops) !=
+    if (scheduler_opt.init(sched_opt_inputs, 1,
+                           scheduler_t::make_scheduler_serial_ops()) !=
         scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler " << scheduler_opt.get_error_string()
                   << "\n";
@@ -243,7 +240,8 @@ main(int argc, const char *argv[])
     scheduler_t scheduler_noopt;
     std::vector<scheduler_t::input_workload_t> sched_noopt_inputs;
     sched_noopt_inputs.emplace_back(dir_noopt);
-    if (scheduler_noopt.init(sched_noopt_inputs, 1, sched_ops) !=
+    if (scheduler_noopt.init(sched_noopt_inputs, 1,
+                             scheduler_t::make_scheduler_serial_ops()) !=
         scheduler_t::STATUS_SUCCESS) {
         std::cerr << "Failed to initialize scheduler "
                   << scheduler_noopt.get_error_string() << "\n";

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -254,25 +254,26 @@ main(int argc, const char *argv[])
     int64 entry_count = 0;
     while (true) {
         memref_t memref_opt;
-        scheduler_t::stream_status_t status = stream_opt->next_record(memref_opt);
-        if (status == scheduler_t::STATUS_EOF)
-            break;
-        assert(status == scheduler_t::STATUS_OK);
         memref_t memref_noopt;
-        status = stream_noopt->next_record(memref_noopt);
-        if (status == scheduler_t::STATUS_EOF)
+        scheduler_t::stream_status_t status_opt = stream_opt->next_record(memref_opt);
+        scheduler_t::stream_status_t status_noopt =
+            stream_noopt->next_record(memref_noopt);
+        if (status_opt == scheduler_t::STATUS_EOF) {
+            assert(status_noopt == scheduler_t::STATUS_EOF);
             break;
-        assert(status == scheduler_t::STATUS_OK);
+        }
+        assert(status_opt == scheduler_t::STATUS_OK &&
+               status_noopt == scheduler_t::STATUS_OK);
         if (memref_opt.marker.type != memref_noopt.marker.type) {
             // Allow a header from a trace buffer filling up at a different
             // point in optimized vs unoptimized.
             while (memref_opt.marker.type == TRACE_TYPE_MARKER) {
-                status = stream_opt->next_record(memref_opt);
-                assert(status == scheduler_t::STATUS_OK);
+                status_opt = stream_opt->next_record(memref_opt);
+                assert(status_opt == scheduler_t::STATUS_OK);
             }
             while (memref_noopt.marker.type == TRACE_TYPE_MARKER) {
-                status = stream_noopt->next_record(memref_noopt);
-                assert(status == scheduler_t::STATUS_OK);
+                status_noopt = stream_noopt->next_record(memref_noopt);
+                assert(status_noopt == scheduler_t::STATUS_OK);
             }
         }
         std::string error =

--- a/clients/drcachesim/tests/offline-skip2.expect
+++ b/clients/drcachesim/tests/offline-skip2.expect
@@ -1,9 +1,6 @@
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-          86          62:      296231 <marker: timestamp 13319413770947383>
-          86          62:      296231 <marker: tid 296231 on core 10>
-          87          63:      296231 ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
           88          63:      296231 <marker: timestamp 13319413770947393>
           89          63:      296231 <marker: tid 296231 on core 10>
           90          64:      296231 ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
@@ -12,8 +9,11 @@ Output format:
           93          67:      296231 ifetch       7 byte(s) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    $0x0000000000000001 -> %rdi
           94          68:      296231 ifetch       8 byte(s) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
           94          68:      296231                                             00
+          95          69:      296231 ifetch       7 byte(s) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    $0x000000000000000d -> %rdx
+          96          70:      296231 ifetch       5 byte(s) @ 0x0000000000401021 b8 01 00 00 00       mov    $0x00000001 -> %eax
+          97          71:      296231 ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
 View tool results:
-              6 : total instructions
+              8 : total instructions
 
 ===========================================================================
 Trace invariant checks passed

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -263,27 +263,32 @@ test_regions()
         assert(status == scheduler_t::STATUS_OK);
         switch (ordinal) {
         case 0:
-            assert(type_is_instr(memref.instr.type));
-            assert(memref.instr.addr == 2);
-            break;
-        case 1:
             assert(memref.marker.type == TRACE_TYPE_MARKER);
             assert(memref.marker.marker_type == TRACE_MARKER_TYPE_WINDOW_ID);
             assert(memref.marker.marker_value == 1);
             break;
-        case 2:
+        case 1:
             assert(type_is_instr(memref.instr.type));
-            assert(memref.instr.addr == 6);
+            assert(memref.instr.addr == 2);
+            break;
+        case 2:
+            assert(memref.marker.type == TRACE_TYPE_MARKER);
+            assert(memref.marker.marker_type == TRACE_MARKER_TYPE_WINDOW_ID);
+            assert(memref.marker.marker_value == 1);
             break;
         case 3:
             assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr == 6);
+            break;
+        case 4:
+            assert(type_is_instr(memref.instr.type));
             assert(memref.instr.addr == 7);
             break;
-        default: assert(ordinal == 4); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
+        default: assert(ordinal == 5); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
         }
         ++ordinal;
     }
-    assert(ordinal == 5);
+    assert(ordinal == 6);
 }
 
 } // namespace

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1,0 +1,292 @@
+/* **********************************************************
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#undef NDEBUG
+#include <assert.h>
+#include <iostream>
+#include <vector>
+
+#include "scheduler.h"
+
+using namespace dynamorio::drmemtrace;
+
+namespace {
+
+// A mock reader that iterates over a vector of records.
+class mock_reader_t : public reader_t {
+public:
+    mock_reader_t() = default;
+    explicit mock_reader_t(const std::vector<memref_t> &trace)
+        : trace_(trace)
+    {
+    }
+    bool
+    init() override
+    {
+        process_input_entry();
+        return true;
+    }
+    const memref_t &
+    operator*() override
+    {
+        return trace_[index_];
+    }
+    bool
+    operator==(const reader_t &rhs) const override
+    {
+        const auto &mock = reinterpret_cast<const mock_reader_t &>(rhs);
+        return (index_ == trace_.size()) == (mock.index_ == mock.trace_.size());
+    }
+    bool
+    operator!=(const reader_t &rhs) const override
+    {
+        const auto &mock = reinterpret_cast<const mock_reader_t &>(rhs);
+        return (index_ == trace_.size()) != (mock.index_ == mock.trace_.size());
+    }
+    reader_t &
+    operator++() override
+    {
+        ++index_;
+        process_input_entry();
+        return *this;
+    }
+    bool
+    process_input_entry() override
+    {
+        if (index_ < trace_.size() && type_is_instr(trace_[index_].instr.type))
+            ++cur_instr_count_;
+        return true;
+    }
+    trace_entry_t *
+    read_next_entry() override
+    {
+        // We need this to work just well enough for reader_t::skip_instructions
+        // to identify instr entries.
+        ++index_;
+        if (index_ >= trace_.size())
+            return nullptr;
+        trace_entry_.type = trace_[index_].instr.type;
+        trace_entry_.size = trace_[index_].instr.size;
+        trace_entry_.addr = trace_[index_].instr.addr;
+        return &trace_entry_;
+    }
+    void
+    use_prev(trace_entry_t *prev) override
+    {
+        --index_;
+    }
+    bool
+    read_next_thread_entry(size_t thread_index, OUT trace_entry_t *entry,
+                           OUT bool *eof) override
+    {
+        return true;
+    }
+    std::string
+    get_stream_name() const override
+    {
+        return "";
+    }
+
+private:
+    std::vector<memref_t> trace_;
+    int index_ = 0;
+    trace_entry_t trace_entry_;
+};
+
+static memref_t
+make_instr(memref_tid_t tid, addr_t pc)
+{
+    memref_t memref;
+    memref.instr.pid = 0;
+    memref.instr.tid = tid;
+    memref.instr.type = TRACE_TYPE_INSTR;
+    memref.instr.addr = pc;
+    memref.instr.size = 1;
+    return memref;
+}
+
+static memref_t
+make_exit(memref_tid_t tid)
+{
+    memref_t memref;
+    memref.exit.type = TRACE_TYPE_THREAD_EXIT;
+    memref.exit.tid = tid;
+    return memref;
+}
+
+static void
+test_parallel()
+{
+    std::vector<memref_t> input_sequence = {
+        make_instr(0, 1),
+        make_instr(0, 2),
+        make_exit(0),
+    };
+    static constexpr int NUM_INPUTS = 3;
+    static constexpr int NUM_OUTPUTS = 2;
+    std::vector<memref_t> inputs[NUM_INPUTS];
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    for (int i = 0; i < NUM_INPUTS; i++) {
+        memref_tid_t tid = 100 + i;
+        inputs[i] = input_sequence;
+        for (auto &record : inputs[i])
+            record.instr.tid = tid;
+        std::unique_ptr<reader_t> input =
+            std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[i]));
+        std::unique_ptr<reader_t> end =
+            std::unique_ptr<mock_reader_t>(new mock_reader_t());
+        sched_inputs.emplace_back(std::move(input), std::move(end), tid);
+    }
+    scheduler_t::scheduler_options_t sched_ops(scheduler_t::STREAM_BY_INPUT_SHARD,
+                                               scheduler_t::SCHEDULE_RUN_TO_COMPLETION);
+    scheduler_t scheduler(/*verbosity=*/4);
+    if (scheduler.init(sched_inputs, NUM_OUTPUTS, sched_ops) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    std::unordered_map<memref_tid_t, int> tid2stream;
+    int count = 0;
+    for (int i = 0; i < NUM_OUTPUTS; i++) {
+        auto *stream = scheduler.get_stream(i);
+        while (true) {
+            memref_t memref;
+            scheduler_t::stream_status_t status = stream->next_record(memref);
+            if (status == scheduler_t::STATUS_EOF)
+                break;
+            assert(status == scheduler_t::STATUS_OK);
+            ++count;
+            // Ensure one input thread is only in one output stream.
+            if (tid2stream.find(memref.instr.tid) == tid2stream.end())
+                tid2stream[memref.instr.tid] = i;
+            else
+                assert(tid2stream[memref.instr.tid] == i);
+        }
+    }
+    assert(count == input_sequence.size() * NUM_INPUTS);
+}
+
+static void
+test_param_checks()
+{
+    std::unique_ptr<reader_t> input =
+        std::unique_ptr<mock_reader_t>(new mock_reader_t(std::vector<memref_t>()));
+    std::unique_ptr<reader_t> end = std::unique_ptr<mock_reader_t>(new mock_reader_t());
+    std::vector<scheduler_t::range_t> regions;
+    // Instr counts are 1-based so 0 is an invalid start.
+    regions.emplace_back(0, 2);
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(input), std::move(end), 1);
+    sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
+    scheduler_t::scheduler_options_t sched_ops(
+        scheduler_t::STREAM_BY_SYNTHETIC_CPU,
+        scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
+    assert(scheduler.init(sched_inputs, 1, sched_ops) ==
+           scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+
+    // Test stop > start.
+    sched_inputs[0].thread_modifiers[0].regions_of_interest[0].start_instruction = 2;
+    sched_inputs[0].thread_modifiers[0].regions_of_interest[0].stop_instruction = 1;
+    assert(scheduler.init(sched_inputs, 1, sched_ops) ==
+           scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+}
+
+static void
+test_regions()
+{
+    std::vector<memref_t> memrefs = {
+        make_instr(1, 1), make_instr(1, 2), // Region 1 is just this instr.
+        make_instr(1, 3), make_instr(1, 4),
+        make_instr(1, 5), make_instr(1, 6), // Region 2 starts here.
+        make_instr(1, 7),                   // Region 2 ends here.
+        make_instr(1, 8), make_exit(1),
+    };
+    std::unique_ptr<reader_t> input =
+        std::unique_ptr<mock_reader_t>(new mock_reader_t(memrefs));
+    std::unique_ptr<reader_t> end = std::unique_ptr<mock_reader_t>(new mock_reader_t());
+
+    std::vector<scheduler_t::range_t> regions;
+    // Instr counts are 1-based.
+    regions.emplace_back(2, 2);
+    regions.emplace_back(6, 7);
+
+    scheduler_t scheduler(/*verbosity=*/4);
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(input), std::move(end), 1);
+    sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
+    scheduler_t::scheduler_options_t sched_ops(
+        scheduler_t::STREAM_BY_SYNTHETIC_CPU,
+        scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
+    if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    int ordinal = 0;
+    auto *stream = scheduler.get_stream(0);
+    while (true) {
+        memref_t memref;
+        scheduler_t::stream_status_t status = stream->next_record(memref);
+        if (status == scheduler_t::STATUS_EOF)
+            break;
+        assert(status == scheduler_t::STATUS_OK);
+        switch (ordinal) {
+        case 0:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr = 2);
+            break;
+        case 1:
+            assert(memref.marker.type == TRACE_TYPE_MARKER);
+            assert(memref.marker.marker_type == TRACE_MARKER_TYPE_WINDOW_ID);
+            assert(memref.marker.marker_value == 1);
+            break;
+        case 2:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr = 6);
+            break;
+        case 3:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr = 7);
+            break;
+        default: assert(ordinal == 4); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
+        }
+        ++ordinal;
+    }
+    assert(ordinal == 4);
+}
+
+} // namespace
+
+int
+main(int argc, const char *argv[])
+{
+    test_parallel();
+    test_param_checks();
+    test_regions();
+    return 0;
+}

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -263,32 +263,27 @@ test_regions()
         assert(status == scheduler_t::STATUS_OK);
         switch (ordinal) {
         case 0:
-            assert(memref.marker.type == TRACE_TYPE_MARKER);
-            assert(memref.marker.marker_type == TRACE_MARKER_TYPE_WINDOW_ID);
-            assert(memref.marker.marker_value == 1);
-            break;
-        case 1:
             assert(type_is_instr(memref.instr.type));
             assert(memref.instr.addr == 2);
             break;
-        case 2:
+        case 1:
             assert(memref.marker.type == TRACE_TYPE_MARKER);
             assert(memref.marker.marker_type == TRACE_MARKER_TYPE_WINDOW_ID);
             assert(memref.marker.marker_value == 1);
             break;
-        case 3:
+        case 2:
             assert(type_is_instr(memref.instr.type));
             assert(memref.instr.addr == 6);
             break;
-        case 4:
+        case 3:
             assert(type_is_instr(memref.instr.type));
             assert(memref.instr.addr == 7);
             break;
-        default: assert(ordinal == 5); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
+        default: assert(ordinal == 4); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
         }
         ++ordinal;
     }
-    assert(ordinal == 6);
+    assert(ordinal == 5);
 }
 
 } // namespace

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -179,11 +179,9 @@ test_parallel()
     int count = 0;
     for (int i = 0; i < NUM_OUTPUTS; i++) {
         auto *stream = scheduler.get_stream(i);
-        while (true) {
-            memref_t memref;
-            scheduler_t::stream_status_t status = stream->next_record(memref);
-            if (status == scheduler_t::STATUS_EOF)
-                break;
+        memref_t memref;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
             assert(status == scheduler_t::STATUS_OK);
             ++count;
             // Ensure one input thread is only in one output stream.
@@ -259,11 +257,9 @@ test_regions()
         assert(false);
     int ordinal = 0;
     auto *stream = scheduler.get_stream(0);
-    while (true) {
-        memref_t memref;
-        scheduler_t::stream_status_t status = stream->next_record(memref);
-        if (status == scheduler_t::STATUS_EOF)
-            break;
+    memref_t memref;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
         assert(status == scheduler_t::STATUS_OK);
         switch (ordinal) {
         case 0:

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -164,7 +164,7 @@ test_parallel()
             std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[i]));
         std::unique_ptr<reader_t> end =
             std::unique_ptr<mock_reader_t>(new mock_reader_t());
-        sched_inputs.emplace_back(std::move(input), std::move(end), tid);
+        sched_inputs.emplace_back(std::move(input), std::move(end));
     }
     scheduler_t::scheduler_options_t sched_ops(scheduler_t::STREAM_BY_INPUT_SHARD,
                                                scheduler_t::SCHEDULE_RUN_TO_COMPLETION);
@@ -204,7 +204,7 @@ test_param_checks()
     regions.emplace_back(0, 2);
     scheduler_t scheduler;
     std::vector<scheduler_t::input_workload_t> sched_inputs;
-    sched_inputs.emplace_back(std::move(input), std::move(end), 1);
+    sched_inputs.emplace_back(std::move(input), std::move(end));
     sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
     scheduler_t::scheduler_options_t sched_ops(
         scheduler_t::STREAM_BY_SYNTHETIC_CPU,
@@ -240,7 +240,7 @@ test_regions()
 
     scheduler_t scheduler(/*verbosity=*/4);
     std::vector<scheduler_t::input_workload_t> sched_inputs;
-    sched_inputs.emplace_back(std::move(input), std::move(end), 1);
+    sched_inputs.emplace_back(std::move(input), std::move(end));
     sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
     scheduler_t::scheduler_options_t sched_ops(
         scheduler_t::STREAM_BY_SYNTHETIC_CPU,

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -226,11 +226,17 @@ static void
 test_regions()
 {
     std::vector<memref_t> memrefs = {
-        make_instr(1, 1), make_instr(1, 2), // Region 1 is just this instr.
-        make_instr(1, 3), make_instr(1, 4),
-        make_instr(1, 5), make_instr(1, 6), // Region 2 starts here.
-        make_instr(1, 7),                   // Region 2 ends here.
-        make_instr(1, 8), make_exit(1),
+        /* clang-format off */
+        make_instr(1, 1),
+        make_instr(1, 2), // Region 1 is just this instr.
+        make_instr(1, 3),
+        make_instr(1, 4),
+        make_instr(1, 5),
+        make_instr(1, 6), // Region 2 starts here.
+        make_instr(1, 7), // Region 2 ends here.
+        make_instr(1, 8),
+        make_exit(1),
+        /* clang-format on */
     };
     std::unique_ptr<reader_t> input =
         std::unique_ptr<mock_reader_t>(new mock_reader_t(memrefs));
@@ -262,7 +268,7 @@ test_regions()
         switch (ordinal) {
         case 0:
             assert(type_is_instr(memref.instr.type));
-            assert(memref.instr.addr = 2);
+            assert(memref.instr.addr == 2);
             break;
         case 1:
             assert(memref.marker.type == TRACE_TYPE_MARKER);
@@ -271,11 +277,11 @@ test_regions()
             break;
         case 2:
             assert(type_is_instr(memref.instr.type));
-            assert(memref.instr.addr = 6);
+            assert(memref.instr.addr == 6);
             break;
         case 3:
             assert(type_is_instr(memref.instr.type));
-            assert(memref.instr.addr = 7);
+            assert(memref.instr.addr == 7);
             break;
         default: assert(ordinal == 4); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
         }

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -169,7 +169,7 @@ test_parallel()
     }
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS,
-                       scheduler_t::make_scheduler_parallel_ops(/*verbosity=*/4)) !=
+                       scheduler_t::make_scheduler_parallel_options(/*verbosity=*/4)) !=
         scheduler_t::STATUS_SUCCESS)
         assert(false);
     std::unordered_map<memref_tid_t, int> tid2stream;
@@ -204,14 +204,16 @@ test_param_checks()
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(std::move(readers));
     sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
-    assert(scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) ==
-           scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+    assert(
+        scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) ==
+        scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
 
     // Test stop > start.
     sched_inputs[0].thread_modifiers[0].regions_of_interest[0].start_instruction = 2;
     sched_inputs[0].thread_modifiers[0].regions_of_interest[0].stop_instruction = 1;
-    assert(scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) ==
-           scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+    assert(
+        scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) ==
+        scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
 }
 
 static void
@@ -244,7 +246,7 @@ test_regions()
     sched_inputs.emplace_back(std::move(readers));
     sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
     if (scheduler.init(sched_inputs, 1,
-                       scheduler_t::make_scheduler_serial_ops(/*verbosity=*/4)) !=
+                       scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
         scheduler_t::STATUS_SUCCESS)
         assert(false);
     int ordinal = 0;

--- a/clients/drcachesim/tests/skip_unit_tests.cpp
+++ b/clients/drcachesim/tests/skip_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -111,9 +111,9 @@ test_skip_initial()
         //    Output format:
         //    <--record#-> <--instr#->: <---tid---> <record details>
         //    ------------------------------------------------------------
-        //               0          49:     3854659 <marker: timestamp 13312570674112282>
-        //               0          49:     3854659 <marker: tid 3854659 on core 3>
-        //              62          50:     3854659 ifetch    2 byte(s) @ 0x0000000401 ...
+        //              69          49:     3854659 <marker: timestamp 13312570674112282>
+        //              70          49:     3854659 <marker: tid 3854659 on core 3>
+        //              71          50:     3854659 ifetch    2 byte(s) @ 0x0000000401 ...
         //                                   d9                jnz    $0x000000000040100b
         std::string line;
         // First we expect "Output format:"
@@ -126,22 +126,18 @@ test_skip_initial()
         std::getline(res_stream, line, '\n');
         CHECK(starts_with(line, "------"), "missing divider line");
         // Next we expect the timestamp entry with the instruction count before
-        // a colon: "        0       49: T3854659 <marker: timestamp 13312570674112282>"
-        // We expect the count to equal the -skip_instrs value, with a 0 ref count.
+        // a colon: "       69       49: T3854659 <marker: timestamp 13312570674112282>"
+        // We expect the count to equal the -skip_instrs value.
         std::getline(res_stream, line, '\n');
         std::stringstream expect_stream;
         expect_stream << skip_instrs << ":";
-        CHECK(skip_instrs == 0 || line.find(" 0 ") != std::string::npos,
-              "bad ref ordinal");
         CHECK(line.find(expect_stream.str()) != std::string::npos, "bad instr ordinal");
         CHECK(skip_instrs == 0 || line.find("timestamp") != std::string::npos,
               "missing timestamp");
-        // Next we expect the cpuid entry, with a 0 ref count too.
+        // Next we expect the cpuid entry.
         std::getline(res_stream, line, '\n');
         CHECK(skip_instrs == 0 || line.find("on core") != std::string::npos,
               "missing cpuid");
-        CHECK(skip_instrs == 0 || line.find(" 0 ") != std::string::npos,
-              "bad ref ordinal");
         // Next we expect the target instruction fetch.
         std::getline(res_stream, line, '\n');
         CHECK(skip_instrs == 0 || line.find("ifetch") != std::string::npos,

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -135,11 +135,9 @@ _tmain(int argc, const TCHAR *targv[])
                         scheduler.get_error_string().c_str());
         }
         auto *stream = scheduler.get_stream(0);
-        while (true) {
-            memref_t record;
-            scheduler_t::stream_status_t status = stream->next_record(record);
-            if (status == scheduler_t::STATUS_EOF)
-                break;
+        memref_t record;
+        for (scheduler_t::stream_status_t status = stream->next_record(record);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(record)) {
             if (status != scheduler_t::STATUS_OK)
                 FATAL_ERROR("scheduler failed to advance: %d", status);
             if (!tool1->process_memref(record)) {

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -129,10 +129,8 @@ _tmain(int argc, const TCHAR *targv[])
         scheduler_t scheduler;
         std::vector<scheduler_t::input_workload_t> sched_inputs;
         sched_inputs.emplace_back(op_trace_dir.get_value());
-        scheduler_t::scheduler_options_t sched_ops(
-            scheduler_t::STREAM_BY_SYNTHETIC_CPU,
-            scheduler_t::SCHEDULE_INTERLEAVE_AS_RECORDED);
-        if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS) {
+        if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
+            scheduler_t::STATUS_SUCCESS) {
             FATAL_ERROR("failed to initialize scheduler: %s",
                         scheduler.get_error_string().c_str());
         }

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -131,7 +131,7 @@ _tmain(int argc, const TCHAR *targv[])
         std::vector<scheduler_t::input_workload_t> sched_inputs;
         sched_inputs.emplace_back(op_trace_dir.get_value());
         if (scheduler.init(sched_inputs, 1,
-                           scheduler_t::make_scheduler_serial_ops(
+                           scheduler_t::make_scheduler_serial_options(
                                op_verbose.get_value())) != scheduler_t::STATUS_SUCCESS) {
             FATAL_ERROR("failed to initialize scheduler: %s",
                         scheduler.get_error_string().c_str());

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -111,7 +111,8 @@ _tmain(int argc, const TCHAR *targv[])
         // We use this launcher to run tests as well:
         tools.push_back(&tool2);
     }
-    analyzer_t analyzer(op_trace_dir.get_value(), &tools[0], (int)tools.size());
+    analyzer_t analyzer(op_trace_dir.get_value(), &tools[0], (int)tools.size(), 0, 0,
+                        op_verbose.get_value());
     if (!analyzer) {
         FATAL_ERROR("failed to initialize analyzer: %s",
                     analyzer.get_error_string().c_str());
@@ -129,8 +130,9 @@ _tmain(int argc, const TCHAR *targv[])
         scheduler_t scheduler;
         std::vector<scheduler_t::input_workload_t> sched_inputs;
         sched_inputs.emplace_back(op_trace_dir.get_value());
-        if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_ops()) !=
-            scheduler_t::STATUS_SUCCESS) {
+        if (scheduler.init(sched_inputs, 1,
+                           scheduler_t::make_scheduler_serial_ops(
+                               op_verbose.get_value())) != scheduler_t::STATUS_SUCCESS) {
             FATAL_ERROR("failed to initialize scheduler: %s",
                         scheduler.get_error_string().c_str());
         }

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -369,6 +369,9 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             std::cerr << "<marker: record ordinal 0x" << std::hex
                       << memref.marker.marker_value << std::dec << ">\n";
             break;
+        case TRACE_MARKER_TYPE_WINDOW_ID:
+            // Handled above.
+            break;
         default:
             std::cerr << "<marker: type " << memref.marker.marker_type << "; value "
                       << memref.marker.marker_value << ">\n";

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -55,6 +55,7 @@
 #include "instru.h"
 #include "archive_ostream.h"
 #include "reader.h"
+#include "utils.h"
 #include <fstream>
 #include "hashtable.h"
 #include <vector>
@@ -607,9 +608,6 @@ struct trace_header_t {
     uint64 timestamp;
     size_t cache_line_size;
 };
-
-// XXX: DR should export this
-#define INVALID_THREAD_ID 0
 
 /* XXX i#4062: We are no longer using this split interface.
  * Should we refactor and merge trace_converter_t into raw2trace_t for simpler code?

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3900,7 +3900,8 @@ if (BUILD_CLIENTS)
         "${PROJECT_SOURCE_DIR}/clients/drcachesim"
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/common"
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/reader"
-        "${PROJECT_SOURCE_DIR}/clients/drcachesim/tracer")
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/tracer"
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/scheduler")
       set(tool.drcacheoff.gencode_nodr ON)
       torunonly_drcacheoff(gencode tool.drcacheoff.gencode
         "" "@-simulator_type@opcode_mix" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3769,10 +3769,18 @@ if (BUILD_CLIENTS)
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.allasm_x86_64.trace.zip")
       torunonly_api(tool.drcacheoff.skip "${drcachesim_path}" "offline-skip" ""
         # Test invariants with global headers after skipping instrs.
-        "-simulator_type;view;-infile;${zip_path};${test_mode_flag};-skip_instrs;63;-sim_refs;10"
+        # Here the skip does not find real headers and we expect synthetic.
+        "-simulator_type;view;-infile;${zip_path};${test_mode_flag};-skip_instrs;62;-sim_refs;10"
         OFF OFF)
       set(tool.drcacheoff.skip_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.skip_rawtemp ON) # no preprocessor
+      torunonly_api(tool.drcacheoff.skip2 "${drcachesim_path}" "offline-skip2" ""
+        # Test invariants with global headers after skipping instrs.
+        # Here the skip finds real headers and we expect no synthetic.
+        "-simulator_type;view;-infile;${zip_path};${test_mode_flag};-skip_instrs;63;-sim_refs;10"
+        OFF OFF)
+      set(tool.drcacheoff.skip2_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      set(tool.drcacheoff.skip2_rawtemp ON) # no preprocessor
 
       # Ensure -cpu_scheduling follows thread migrations.
       # We have a checked-in trace with a migration.


### PR DESCRIPTION
Adds a new scheduler component to drmemtrace which provides flexibility in combining input traces and is meant to supply key features for simulation of traces.

This first stage adds a base scheduler which only supports the two analyzer modes: parallel software thread streams or a single serial stream.

The input file opening code and the input-to-worker code is moved from the analyzer to the scheduler.  The analyzer now has to look at the tid fields in the stream records to identify shards to tools, but the input-to-worker does belong in the scheduler.

Removes the analyzer external iterator interface; tools should instead use the scheduler directly.  Updates histogram_launcher and two tests to do this.

Adds a new scheduler unit test with a mocked reader that takes vectors of records, containing some initial sanity tests.

The scheduler takes in either file paths and opens its own readers for those, or it can be passed readers.  This latter interface is used for online IPC readers, as well as for the unit test using a mocked reader.  The IPC reader requires a delayed init() call which is handled by paying for a flag check on each stream advance.

To support -skip_instrs, region-of-interest code is implemented here. However, it requires fixing a problem in reader_t::skip_instructions() by adding a queue and a new use-prior-record method.  (The queue can be merged with the file_reader_t queue later.)  It might be nicer to separate that out but that would leave -skip_instrs not working.

Future work includes moving the serial mode interleaving from the file reader to the scheduler, and then adding new scheduling and simulation features.

Issue: #5843