### PR TITLE
i#5734: disable rseq test on AArch64 runners

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -329,7 +329,8 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|tool.drcachesim.delay-simple' => 1, # i#2892
                                    'code_api|tool.drcachesim.invariants' => 1, # i#2892
                                    'code_api|tool.drcacheoff.simple' => 1,
-                                   'code_api|tool.histogram.gzip' => 1);
+                                   'code_api|tool.histogram.gzip' => 1,
+                                   );
             # FIXME i#2417: fix flaky/regressed AArch64 tests
             %ignore_failures_64 = ('code_api|linux.sigsuspend' => 1,
                                    'code_api|pthreads.pthreads_exit' => 1,
@@ -341,6 +342,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|client.attach_test' => 1, # i#5740
                                    'code_api|client.attach_blocking' => 1, # i#5740
                                    'code_api|tool.drcacheoff.invariant_checker' => 1, # i#5724
+                                   'code_api|tool.drcacheoff.rseq' => 1 # i#5734
                                    );
             if ($is_32) {
                 $issue_no = "#2416";


### PR DESCRIPTION
The rseq test fails on various different machines, and in different contexts including during postcommit on the test runner, but not on precommit. Ignoring this by default due to the flakiness

issue: #5734