### PR TITLE
i#5507: AArch64 testing: Mark windows-zlib as flaky and extend timeouts

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -342,7 +342,8 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|client.attach_test' => 1, # i#5740
                                    'code_api|client.attach_blocking' => 1, # i#5740
                                    'code_api|tool.drcacheoff.invariant_checker' => 1, # i#5724
-                                   'code_api|tool.drcacheoff.rseq' => 1 # i#5734
+                                   'code_api|tool.drcacheoff.rseq' => 1, # i#5734
+                                   'code_api|tool.drcacheoff.windows-zlib' => 1, # i#5507
                                    );
             if ($is_32) {
                 $issue_no = "#2416";

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4630,7 +4630,6 @@ if (UNIX)
 
     tobuild(linux.sigmask linux/sigmask.c)
     link_with_pthread(linux.sigmask)
-    set(linux.sigmask_timeout 180)
     # Sanity check that this option works.
     torunonly(linux.sigmask-noalarm linux.sigmask linux/sigmask.c
       "-no_reroute_alarm_signals" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4099,6 +4099,7 @@ if (BUILD_CLIENTS)
     if (AARCH64)
       torunonly_drcachesim(drstatecmp-fuzz drstatecmp-fuzz-app
         "-trace_after_instrs 10M -enable_drstatecmp" "" "")
+      set(tool.drcachesim.drstatecmp-fuzz_timeout 180)
     endif ()
     if (NOT WIN32)
       torunonly_drcachesim(drstatecmp-delay-simple ${ci_shared_app}
@@ -4626,6 +4627,7 @@ if (UNIX)
 
     tobuild(linux.sigmask linux/sigmask.c)
     link_with_pthread(linux.sigmask)
+    set(linux.sigmask_timeout 180)
     # Sanity check that this option works.
     torunonly(linux.sigmask-noalarm linux.sigmask linux/sigmask.c
       "-no_reroute_alarm_signals" "")


### PR DESCRIPTION
Windows-zlib fails about 5% of the time for currently unknown reasons. A reproducer has been submitted to the associated ticket and this patch marks it as flaky.

The patch also increases the timeouts of drstatecmp_fuzz which were slightly exceeding them.

issue: #5507
