### PR TITLE
i#3044 AArch64 SVE codec: Add memory scalar+vector 32-bit offset

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -304,13 +304,21 @@
 11000100001xxxxx110xxxxxxxxxxxxx  n   946  SVE     ld1b          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 10000100001xxxxx110xxxxxxxxxxxxx  n   946  SVE     ld1b          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000100010xxxxx110xxxxxxxxxxxxx  n   946  SVE     ld1b          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001000x0xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001000x0xxxxx010xxxxxxxxxxxxx  n   946  SVE     ld1b          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 11000101101xxxxx110xxxxxxxxxxxxx  n   975  SVE     ld1d          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000101111xxxxx110xxxxxxxxxxxxx  n   975  SVE     ld1d          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000101110xxxxx110xxxxxxxxxxxxx  n   975  SVE     ld1d          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001011x1xxxxx010xxxxxxxxxxxxx  n   975  SVE     ld1d          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001011x0xxxxx010xxxxxxxxxxxxx  n   975  SVE     ld1d          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
 10000100101xxxxx110xxxxxxxxxxxxx  n   976  SVE     ld1h          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000100101xxxxx110xxxxxxxxxxxxx  n   976  SVE     ld1h          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000100111xxxxx110xxxxxxxxxxxxx  n   976  SVE     ld1h          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000100110xxxxx110xxxxxxxxxxxxx  n   976  SVE     ld1h          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001001x1xxxxx010xxxxxxxxxxxxx  n   976  SVE     ld1h          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001001x0xxxxx010xxxxxxxxxxxxx  n   976  SVE     ld1h          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x1xxxxx010xxxxxxxxxxxxx  n   976  SVE     ld1h          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x0xxxxx010xxxxxxxxxxxxx  n   976  SVE     ld1h          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 1000010001xxxxxx101xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_h_0 : svememx6_b_5 p10_zer_lo
 1000010001xxxxxx110xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_s_0 : svememx6_b_5 p10_zer_lo
 1000010001xxxxxx111xxxxxxxxxxxxx  n   908  SVE    ld1rb          z_d_0 : svememx6_b_5 p10_zer_lo
@@ -335,17 +343,29 @@
 10000100001xxxxx100xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000100001xxxxx100xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000100010xxxxx100xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001000x0xxxxx000xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001000x0xxxxx000xxxxxxxxxxxxx  n   949  SVE    ld1sb          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 10000100101xxxxx100xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000100101xxxxx100xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000100111xxxxx100xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000100110xxxxx100xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001001x1xxxxx000xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001001x0xxxxx000xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x1xxxxx000xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x0xxxxx000xxxxxxxxxxxxx  n   977  SVE    ld1sh          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 11000101001xxxxx100xxxxxxxxxxxxx  n   978  SVE    ld1sw          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000101011xxxxx100xxxxxxxxxxxxx  n   978  SVE    ld1sw          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000101010xxxxx100xxxxxxxxxxxxx  n   978  SVE    ld1sw          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001010x1xxxxx000xxxxxxxxxxxxx  n   978  SVE    ld1sw          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001010x0xxxxx000xxxxxxxxxxxxx  n   978  SVE    ld1sw          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
 10000101001xxxxx110xxxxxxxxxxxxx  n   979  SVE     ld1w          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000101001xxxxx110xxxxxxxxxxxxx  n   979  SVE     ld1w          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000101011xxxxx110xxxxxxxxxxxxx  n   979  SVE     ld1w          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000101010xxxxx110xxxxxxxxxxxxx  n   979  SVE     ld1w          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001010x1xxxxx010xxxxxxxxxxxxx  n   979  SVE     ld1w          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001010x0xxxxx010xxxxxxxxxxxxx  n   979  SVE     ld1w          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001010x1xxxxx010xxxxxxxxxxxxx  n   979  SVE     ld1w          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001010x0xxxxx010xxxxxxxxxxxxx  n   979  SVE     ld1w          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100100001xxxxx110xxxxxxxxxxxxx  n   967  SVE     ld2b  z_b_0 z_msz_bhsd_0p1 : svemem_gprs_bhsdx p10_zer_lo
 10100100010xxxxx110xxxxxxxxxxxxx  n   968  SVE     ld3b  z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 : svemem_gprs_bhsdx p10_zer_lo
 10100100011xxxxx110xxxxxxxxxxxxx  n   969  SVE     ld4b  z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 z_msz_bhsd_0p3 : svemem_gprs_bhsdx p10_zer_lo
@@ -356,10 +376,14 @@
 10000100001xxxxx111xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000100001xxxxx111xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000100010xxxxx111xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001000x0xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001000x0xxxxx011xxxxxxxxxxxxx  n   937  SVE   ldff1b          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100101111xxxxx011xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_gpr_shf p10_zer_lo
 11000101101xxxxx111xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000101111xxxxx111xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000101110xxxxx111xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001011x1xxxxx011xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001011x0xxxxx011xxxxxxxxxxxxx  n   938  SVE   ldff1d          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100100101xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_h_0 : svemem_gpr_shf p10_zer_lo
 10100100110xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_s_0 : svemem_gpr_shf p10_zer_lo
 10100100111xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_gpr_shf p10_zer_lo
@@ -367,28 +391,44 @@
 11000100101xxxxx111xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000100111xxxxx111xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000100110xxxxx111xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001001x1xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001001x0xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x1xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x0xxxxx011xxxxxxxxxxxxx  n   939  SVE   ldff1h          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100101110xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_h_0 : svemem_gpr_shf p10_zer_lo
 10100101101xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_s_0 : svemem_gpr_shf p10_zer_lo
 10100101100xxxxx011xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_d_0 : svemem_gpr_shf p10_zer_lo
 10000100001xxxxx101xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000100001xxxxx101xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000100010xxxxx101xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001000x0xxxxx001xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001000x0xxxxx001xxxxxxxxxxxxx  n   940  SVE  ldff1sb          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100101001xxxxx011xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_s_0 : svemem_gpr_shf p10_zer_lo
 10100101000xxxxx011xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_gpr_shf p10_zer_lo
 10000100101xxxxx101xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000100101xxxxx101xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000100111xxxxx101xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000100110xxxxx101xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001001x1xxxxx001xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001001x0xxxxx001xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x1xxxxx001xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001001x0xxxxx001xxxxxxxxxxxxx  n   941  SVE  ldff1sh          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100100100xxxxx011xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_shf p10_zer_lo
 11000101001xxxxx101xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000101011xxxxx101xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000101010xxxxx101xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001010x1xxxxx001xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001010x0xxxxx001xxxxxxxxxxxxx  n   942  SVE  ldff1sw          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100101010xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_s_0 : svemem_gpr_shf p10_zer_lo
 10100101011xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_shf p10_zer_lo
 10000101001xxxxx111xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_s_0 : svemem_vec_s_imm5 p10_zer_lo
 11000101001xxxxx111xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_vec_d_imm5 p10_zer_lo
 11000101011xxxxx111xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_vec64 p10_zer_lo
 11000101010xxxxx111xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_vec64 p10_zer_lo
+110001010x1xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+110001010x0xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_d_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001010x1xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
+100001010x0xxxxx011xxxxxxxxxxxxx  n   943  SVE   ldff1w          z_s_0 : svemem_gpr_vec32_ld p10_zer_lo
 10100100000xxxxx110xxxxxxxxxxxxx  n   950  SVE   ldnt1b          z_b_0 : svemem_gprs_b1 p10_zer_lo
 1000010110xxxxxx000xxxxxxxx0xxxx  n   227  SVE      ldr             p0 : svemem_gpr_simm9_vl
 1000010110xxxxxx010xxxxxxxxxxxxx  n   227  SVE      ldr             z0 : svemem_gpr_simm9_vl
@@ -437,18 +477,26 @@
 10000100000xxxxx111xxxxxxxx0xxxx  n   963  SVE     prfb                : prfop4 p10_lo svemem_vec_s_imm5
 11000100000xxxxx111xxxxxxxx0xxxx  n   963  SVE     prfb                : prfop4 p10_lo svemem_vec_d_imm5
 11000100011xxxxx100xxxxxxxx0xxxx  n   963  SVE     prfb                : prfop4 p10_lo sveprf_gpr_vec64
+110001000x1xxxxx000xxxxxxxx0xxxx  n   963  SVE     prfb                : prfop4 p10_lo sveprf_gpr_vec32
+100001000x1xxxxx000xxxxxxxx0xxxx  n   963  SVE     prfb                : prfop4 p10_lo sveprf_gpr_vec32
 1000010111xxxxxx011xxxxxxxx0xxxx  n   964  SVE     prfd                : prfop4 p10_lo svemem_gpr_simm6_vl
 10000101100xxxxx111xxxxxxxx0xxxx  n   964  SVE     prfd                : prfop4 p10_lo svemem_vec_s_imm5
 11000101100xxxxx111xxxxxxxx0xxxx  n   964  SVE     prfd                : prfop4 p10_lo svemem_vec_d_imm5
 11000100011xxxxx111xxxxxxxx0xxxx  n   964  SVE     prfd                : prfop4 p10_lo sveprf_gpr_vec64
+110001000x1xxxxx011xxxxxxxx0xxxx  n   964  SVE     prfd                : prfop4 p10_lo sveprf_gpr_vec32
+100001000x1xxxxx011xxxxxxxx0xxxx  n   964  SVE     prfd                : prfop4 p10_lo sveprf_gpr_vec32
 1000010111xxxxxx001xxxxxxxx0xxxx  n   965  SVE     prfh                : prfop4 p10_lo svemem_gpr_simm6_vl
 10000100100xxxxx111xxxxxxxx0xxxx  n   965  SVE     prfh                : prfop4 p10_lo svemem_vec_s_imm5
 11000100100xxxxx111xxxxxxxx0xxxx  n   965  SVE     prfh                : prfop4 p10_lo svemem_vec_d_imm5
 11000100011xxxxx101xxxxxxxx0xxxx  n   965  SVE     prfh                : prfop4 p10_lo sveprf_gpr_vec64
+110001000x1xxxxx001xxxxxxxx0xxxx  n   965  SVE     prfh                : prfop4 p10_lo sveprf_gpr_vec32
+100001000x1xxxxx001xxxxxxxx0xxxx  n   965  SVE     prfh                : prfop4 p10_lo sveprf_gpr_vec32
 1000010111xxxxxx010xxxxxxxx0xxxx  n   966  SVE     prfw                : prfop4 p10_lo svemem_gpr_simm6_vl
 10000101000xxxxx111xxxxxxxx0xxxx  n   966  SVE     prfw                : prfop4 p10_lo svemem_vec_s_imm5
 11000101000xxxxx111xxxxxxxx0xxxx  n   966  SVE     prfw                : prfop4 p10_lo svemem_vec_d_imm5
 11000100011xxxxx110xxxxxxxx0xxxx  n   966  SVE     prfw                : prfop4 p10_lo sveprf_gpr_vec64
+110001000x1xxxxx010xxxxxxxx0xxxx  n   966  SVE     prfw                : prfop4 p10_lo sveprf_gpr_vec32
+100001000x1xxxxx010xxxxxxxx0xxxx  n   966  SVE     prfw                : prfop4 p10_lo sveprf_gpr_vec32
 001001010101000011xxxx0xxxx00000  w   786  SVE    ptest                : p10 p_b_5
 00100101xx011000111000xxxxx0xxxx  n   897  SVE    ptrue  p_size_bhsd_0 : pred_constr
 00100101xx011001111000xxxxx0xxxx  w   898  SVE   ptrues  p_size_bhsd_0 : pred_constr
@@ -534,17 +582,29 @@
 11100100011xxxxx101xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_vec_s_imm5 : z_s_0 p10_lo
 11100100010xxxxx101xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_vec_d_imm5 : z_d_0 p10_lo
 11100100000xxxxx101xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_gpr_vec64 : z_d_0 p10_lo
+11100100000xxxxx1x0xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_gpr_vec32_st : z_d_0 p10_lo
+11100100010xxxxx1x0xxxxxxxxxxxxx  n   951  SVE     st1b  svemem_gpr_vec32_st : z_s_0 p10_lo
 11100101110xxxxx101xxxxxxxxxxxxx  n   981  SVE     st1d  svemem_vec_d_imm5 : z_d_0 p10_lo
 11100101101xxxxx101xxxxxxxxxxxxx  n   981  SVE     st1d  svemem_gpr_vec64 : z_d_0 p10_lo
 11100101100xxxxx101xxxxxxxxxxxxx  n   981  SVE     st1d  svemem_gpr_vec64 : z_d_0 p10_lo
+11100101101xxxxx1x0xxxxxxxxxxxxx  n   981  SVE     st1d  svemem_gpr_vec32_st : z_d_0 p10_lo
+11100101100xxxxx1x0xxxxxxxxxxxxx  n   981  SVE     st1d  svemem_gpr_vec32_st : z_d_0 p10_lo
 11100100111xxxxx101xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_vec_s_imm5 : z_s_0 p10_lo
 11100100110xxxxx101xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_vec_d_imm5 : z_d_0 p10_lo
 11100100101xxxxx101xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_gpr_vec64 : z_d_0 p10_lo
 11100100100xxxxx101xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_gpr_vec64 : z_d_0 p10_lo
+11100100101xxxxx1x0xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_gpr_vec32_st : z_d_0 p10_lo
+11100100100xxxxx1x0xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_gpr_vec32_st : z_d_0 p10_lo
+11100100111xxxxx1x0xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_gpr_vec32_st : z_s_0 p10_lo
+11100100110xxxxx1x0xxxxxxxxxxxxx  n   980  SVE     st1h  svemem_gpr_vec32_st : z_s_0 p10_lo
 11100101011xxxxx101xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_vec_s_imm5 : z_s_0 p10_lo
 11100101010xxxxx101xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_vec_d_imm5 : z_d_0 p10_lo
 11100101001xxxxx101xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_gpr_vec64 : z_d_0 p10_lo
 11100101000xxxxx101xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_gpr_vec64 : z_d_0 p10_lo
+11100101001xxxxx1x0xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_gpr_vec32_st : z_d_0 p10_lo
+11100101000xxxxx1x0xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_gpr_vec32_st : z_d_0 p10_lo
+11100101011xxxxx1x0xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_gpr_vec32_st : z_s_0 p10_lo
+11100101010xxxxx1x0xxxxxxxxxxxxx  n   982  SVE     st1w  svemem_gpr_vec32_st : z_s_0 p10_lo
 11100100001xxxxx011xxxxxxxxxxxxx  n   970  SVE     st2b  svemem_gprs_bhsdx : z_b_0 z_msz_bhsd_0p1 p10_lo
 11100100010xxxxx011xxxxxxxxxxxxx  n   971  SVE     st3b  svemem_gprs_bhsdx : z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 p10_lo
 11100100011xxxxx011xxxxxxxxxxxxx  n   972  SVE     st4b  svemem_gprs_bhsdx : z_b_0 z_msz_bhsd_0p1 z_msz_bhsd_0p2 z_msz_bhsd_0p3 p10_lo

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -10954,6 +10954,8 @@
  *    LDFF1B  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, #<imm>}]
  *    LDFF1B  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LDFF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LDFF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LDFF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -10970,6 +10972,13 @@
  *             0, 0, imm5, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
  */
 #define INSTR_CREATE_ldff1b_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldff1b, Zt, Rn, Pg)
@@ -10983,6 +10992,8 @@
  *    LDFF1D  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #3]
  *    LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3]
+ *    LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11001,6 +11012,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #3] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 3)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_ldff1d_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldff1d, Zt, Rn, Pg)
@@ -11017,6 +11034,10 @@
  *    LDFF1H  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #1]
  *    LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
+ *    LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
+ *    LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11038,6 +11059,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_ldff1h_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldff1h, Zt, Rn, Pg)
@@ -11053,6 +11086,8 @@
  *    LDFF1SB { <Zt>.S }, <Pg>/Z, [<Zn>.S{, #<imm>}]
  *    LDFF1SB { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LDFF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LDFF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LDFF1SB { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11070,6 +11105,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
  */
 #define INSTR_CREATE_ldff1sb_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldff1sb, Zt, Rn, Pg)
@@ -11085,6 +11126,10 @@
  *    LDFF1SH { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #1]
  *    LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
+ *    LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
+ *    LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11106,6 +11151,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_ldff1sh_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldff1sh, Zt, Rn, Pg)
@@ -11119,6 +11176,10 @@
  *    LDFF1SW { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #2]
  *    LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2]
+ *    LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2]
+ *    LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11137,6 +11198,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #2] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #2] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 8), 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 8), 0)
  */
 #define INSTR_CREATE_ldff1sw_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldff1sw, Zt, Rn, Pg)
@@ -11233,6 +11306,8 @@
  *    LD1B    { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LD1B    { <Zt>.S }, <Pg>/Z, [<Zn>.S{, #<imm>}]
  *    LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11251,6 +11326,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
  */
 #define INSTR_CREATE_ld1b_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ld1b, Zt, Rn, Pg)
@@ -11302,6 +11383,8 @@
  *    LD1SB   { <Zt>.S }, <Pg>/Z, [<Zn>.S{, #<imm>}]
  *    LD1SB   { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11320,6 +11403,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
  */
 #define INSTR_CREATE_ld1sb_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ld1sb, Zt, Rn, Pg)
@@ -11351,6 +11440,8 @@
  *    ST1B    { <Zt>.S }, <Pg>, [<Zn>.S{, #<imm>}]
  *    ST1B    { <Zt>.D }, <Pg>, [<Zn>.D{, #<imm>}]
  *    ST1B    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D]
+ *    ST1B    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
+ *    ST1B    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -11369,6 +11460,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 64), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
  */
 #define INSTR_CREATE_st1b_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_st1b, Rn, Zt, Pg)
@@ -11615,6 +11712,8 @@
  *    PRFB    <prfop>, <Pg>, [<Zn>.D{, #<imm>}]
  *    PRFB    <prfop>, <Pg>, [<Zn>.S{, #<imm>}]
  *    PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D]
+ *    PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
+ *    PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param prfop The prefetch operation.
@@ -11632,6 +11731,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, OPSZ_0, 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, OPSZ_0, 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, OPSZ_0, 0)
  */
 #define INSTR_CREATE_prfb_sve_pred(dc, prfop, Pg, Rn) \
     instr_create_0dst_3src(dc, OP_prfb, prfop, Pg, Rn)
@@ -11645,6 +11750,8 @@
  *    PRFD    <prfop>, <Pg>, [<Zn>.D{, #<imm>}]
  *    PRFD    <prfop>, <Pg>, [<Zn>.S{, #<imm>}]
  *    PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, LSL #3]
+ *    PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3]
+ *    PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #3]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param prfop The prefetch operation.
@@ -11662,6 +11769,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             true, 0, OPSZ_0, 3)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, OPSZ_0, 3)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, OPSZ_0, 3)
  */
 #define INSTR_CREATE_prfd_sve_pred(dc, prfop, Pg, Rn) \
     instr_create_0dst_3src(dc, OP_prfd, prfop, Pg, Rn)
@@ -11675,6 +11788,8 @@
  *    PRFH    <prfop>, <Pg>, [<Zn>.D{, #<imm>}]
  *    PRFH    <prfop>, <Pg>, [<Zn>.S{, #<imm>}]
  *    PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, LSL #1]
+ *    PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1]
+ *    PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param prfop The prefetch operation.
@@ -11692,6 +11807,12 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             true, 0, OPSZ_0, 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, OPSZ_0, 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, OPSZ_0, 1)
  */
 #define INSTR_CREATE_prfh_sve_pred(dc, prfop, Pg, Rn) \
     instr_create_0dst_3src(dc, OP_prfh, prfop, Pg, Rn)
@@ -11705,6 +11826,8 @@
  *    PRFW    <prfop>, <Pg>, [<Zn>.D{, #<imm>}]
  *    PRFW    <prfop>, <Pg>, [<Zn>.S{, #<imm>}]
  *    PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, LSL #2]
+ *    PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2]
+ *    PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param prfop The prefetch operation.
@@ -11721,6 +11844,12 @@
  *             0, 0, imm5, 0, OPSZ_0, 0)
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
+ *             true, 0, OPSZ_0, 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, OPSZ_0, 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
  *             true, 0, OPSZ_0, 2)
  */
 #define INSTR_CREATE_prfw_sve_pred(dc, prfop, Pg, Rn) \
@@ -11871,6 +12000,10 @@
  *    LD1H    { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #1]
  *    LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
+ *    LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
+ *    LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11889,6 +12022,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_ld1h_sve_pred(dc, Zt, Pg, Zn) \
     instr_create_1dst_2src(dc, OP_ld1h, Zt, Zn, Pg)
@@ -11902,6 +12047,10 @@
  *    LD1SH   { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #1]
  *    LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
+ *    LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
+ *    LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11920,6 +12069,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_ld1sh_sve_pred(dc, Zt, Pg, Zn) \
     instr_create_1dst_2src(dc, OP_ld1sh, Zt, Zn, Pg)
@@ -11933,6 +12094,10 @@
  *    LD1W    { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #2]
  *    LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2]
+ *    LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
+ *    LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2]
+ *    LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11951,6 +12116,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #2] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #2] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 8), 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 8), 0)
  */
 #define INSTR_CREATE_ld1w_sve_pred(dc, Zt, Pg, Zn) \
     instr_create_1dst_2src(dc, OP_ld1w, Zt, Zn, Pg)
@@ -11963,6 +12140,8 @@
  *    LD1D    { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]
  *    LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, LSL #3]
  *    LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]
+ *    LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3]
+ *    LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11977,6 +12156,12 @@
  *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 3)
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #3] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 3)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_ld1d_sve_pred(dc, Zt, Pg, Zn) \
@@ -12010,6 +12195,10 @@
  *    ST1H    { <Zt>.D }, <Pg>, [<Zn>.D{, #<imm>}]
  *    ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, LSL #1]
  *    ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D]
+ *    ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1]
+ *    ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
+ *    ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1]
+ *    ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -12028,6 +12217,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 32), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #1] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 1)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_st1h_sve_pred(dc, Zt, Pg, Zn) \
     instr_create_1dst_2src(dc, OP_st1h, Zn, Zt, Pg)
@@ -12041,6 +12242,10 @@
  *    ST1W    { <Zt>.D }, <Pg>, [<Zn>.D{, #<imm>}]
  *    ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, LSL #2]
  *    ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D]
+ *    ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2]
+ *    ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
+ *    ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2]
+ *    ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -12059,6 +12264,18 @@
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #2] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\> #2] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 8), 2)
+ *             For the [\<Xn|SP\>, \<Zm\>.S, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_4, extend,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 8), 0)
  */
 #define INSTR_CREATE_st1w_sve_pred(dc, Zt, Pg, Zn) \
     instr_create_1dst_2src(dc, OP_st1w, Zn, Zt, Pg)
@@ -12071,6 +12288,8 @@
  *    ST1D    { <Zt>.D }, <Pg>, [<Zn>.D{, #<imm>}]
  *    ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, LSL #3]
  *    ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D]
+ *    ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3]
+ *    ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -12085,6 +12304,12 @@
  *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 3)
  *             For the [\<Xn|SP\>, \<Zm\>.D] variant:
  *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, DR_EXTEND_UXTX,
+ *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\> #3] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
+ *             true, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 3)
+ *             For the [\<Xn|SP\>, \<Zm\>.D, \<extend\>] variant:
+ *             opnd_create_vector_base_disp_aarch64(Xn, Zm, OPSZ_8, extend,
  *             0, 0, opnd_size_from_bytes(dr_get_sve_vl() / 16), 0)
  */
 #define INSTR_CREATE_st1d_sve_pred(dc, Zt, Pg, Zn) \

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -311,6 +311,7 @@
 -------??-?xxxxx------xxxxx-----  svemem_gpr_vec64 # SVE memory address (64-bit offset) [<Xn|SP>, <Zm>.D{, <mod>}]
 -------????xxxxx------xxxxx-----  svemem_gpr_shf   # GPR offset and base reg for SVE ld/st, with optional shift
 -------????xxxxx------xxxxx-----  svemem_gprs_bhsdx  # memory reg from Rm and Rn fields transferring x bytes per element
+-------????xxxxx-x----xxxxx-----  svemem_gpr_vec32_st # SVE memory address (32-bit offset) [<Xn|SP>, <Zm>.<T>, <mod> <amount>]
 -------xx------------------xxxxx  z_msz_bhsd_0p1  # z register with element size determined by msz, plus 1
 -------xx------------------xxxxx  z_msz_bhsd_0p2  # z register with element size determined by msz, plus 2
 -------xx------------------xxxxx  z_msz_bhsd_0p3  # z register with element size determined by msz, plus 3
@@ -346,6 +347,8 @@
 ??---------xxxxxxxxx--xxxxx-----  mem9       # gets size from 31:30
 ??---------xxxxxxxxx--xxxxx-----  memreg     # register offset, gets size from 31:30
 ??--------xxxxxxxxxxxxxxxxx-----  mem12      # gets size from 31:30
+??-------x-xxxxx-??---xxxxx-----  sveprf_gpr_vec32 # SVE prefetch memory address (32-bit offset) [<Xn|SP>, <Zm>.<T>, <mod>{ <amount>}]
+??-----??x?xxxxx------xxxxx-----  svemem_gpr_vec32_ld # SVE memory address (32-bit offset) [<Xn|SP>, <Zm>.<T>, <mod> <amount>]
 ??---?----------------xxxxx-----  mem7post   # gets size from 31:30 and 26; post-index
 ??---?----xxxxxxx---------------  mem7off    # gets size from 31:30 and 26
 ??---?----xxxxxxx-----xxxxx-----  mem7       # gets size from 31:30 and 26

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -10676,6 +10676,74 @@ c45cdf59 : ld1b z25.d, p7/Z, [x26, z28.d]            : ld1b   (%x26,%z28.d)[4byt
 c45edf9b : ld1b z27.d, p7/Z, [x28, z30.d]            : ld1b   (%x28,%z30.d)[4byte] %p7/z -> %z27.d
 c45fdfff : ld1b z31.d, p7/Z, [sp, z31.d]             : ld1b   (%sp,%z31.d)[4byte] %p7/z -> %z31.d
 
+# LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1B-Z.P.BZ-D.x32.unscaled)
+c4004000 : ld1b z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1b   (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d
+c4054482 : ld1b z2.d, p1/Z, [x4, z5.d, UXTW]         : ld1b   (%x4,%z5.d,uxtw)[4byte] %p1/z -> %z2.d
+c40748c4 : ld1b z4.d, p2/Z, [x6, z7.d, UXTW]         : ld1b   (%x6,%z7.d,uxtw)[4byte] %p2/z -> %z4.d
+c4094906 : ld1b z6.d, p2/Z, [x8, z9.d, UXTW]         : ld1b   (%x8,%z9.d,uxtw)[4byte] %p2/z -> %z6.d
+c40b4d48 : ld1b z8.d, p3/Z, [x10, z11.d, UXTW]       : ld1b   (%x10,%z11.d,uxtw)[4byte] %p3/z -> %z8.d
+c40d4d6a : ld1b z10.d, p3/Z, [x11, z13.d, UXTW]      : ld1b   (%x11,%z13.d,uxtw)[4byte] %p3/z -> %z10.d
+c40f51ac : ld1b z12.d, p4/Z, [x13, z15.d, UXTW]      : ld1b   (%x13,%z15.d,uxtw)[4byte] %p4/z -> %z12.d
+c41151ee : ld1b z14.d, p4/Z, [x15, z17.d, UXTW]      : ld1b   (%x15,%z17.d,uxtw)[4byte] %p4/z -> %z14.d
+c4135630 : ld1b z16.d, p5/Z, [x17, z19.d, UXTW]      : ld1b   (%x17,%z19.d,uxtw)[4byte] %p5/z -> %z16.d
+c4145671 : ld1b z17.d, p5/Z, [x19, z20.d, UXTW]      : ld1b   (%x19,%z20.d,uxtw)[4byte] %p5/z -> %z17.d
+c41656b3 : ld1b z19.d, p5/Z, [x21, z22.d, UXTW]      : ld1b   (%x21,%z22.d,uxtw)[4byte] %p5/z -> %z19.d
+c4185af5 : ld1b z21.d, p6/Z, [x23, z24.d, UXTW]      : ld1b   (%x23,%z24.d,uxtw)[4byte] %p6/z -> %z21.d
+c41a5b17 : ld1b z23.d, p6/Z, [x24, z26.d, UXTW]      : ld1b   (%x24,%z26.d,uxtw)[4byte] %p6/z -> %z23.d
+c41c5f59 : ld1b z25.d, p7/Z, [x26, z28.d, UXTW]      : ld1b   (%x26,%z28.d,uxtw)[4byte] %p7/z -> %z25.d
+c41e5f9b : ld1b z27.d, p7/Z, [x28, z30.d, UXTW]      : ld1b   (%x28,%z30.d,uxtw)[4byte] %p7/z -> %z27.d
+c41f5fff : ld1b z31.d, p7/Z, [sp, z31.d, UXTW]       : ld1b   (%sp,%z31.d,uxtw)[4byte] %p7/z -> %z31.d
+c4404000 : ld1b z0.d, p0/Z, [x0, z0.d, SXTW]         : ld1b   (%x0,%z0.d,sxtw)[4byte] %p0/z -> %z0.d
+c4454482 : ld1b z2.d, p1/Z, [x4, z5.d, SXTW]         : ld1b   (%x4,%z5.d,sxtw)[4byte] %p1/z -> %z2.d
+c44748c4 : ld1b z4.d, p2/Z, [x6, z7.d, SXTW]         : ld1b   (%x6,%z7.d,sxtw)[4byte] %p2/z -> %z4.d
+c4494906 : ld1b z6.d, p2/Z, [x8, z9.d, SXTW]         : ld1b   (%x8,%z9.d,sxtw)[4byte] %p2/z -> %z6.d
+c44b4d48 : ld1b z8.d, p3/Z, [x10, z11.d, SXTW]       : ld1b   (%x10,%z11.d,sxtw)[4byte] %p3/z -> %z8.d
+c44d4d6a : ld1b z10.d, p3/Z, [x11, z13.d, SXTW]      : ld1b   (%x11,%z13.d,sxtw)[4byte] %p3/z -> %z10.d
+c44f51ac : ld1b z12.d, p4/Z, [x13, z15.d, SXTW]      : ld1b   (%x13,%z15.d,sxtw)[4byte] %p4/z -> %z12.d
+c45151ee : ld1b z14.d, p4/Z, [x15, z17.d, SXTW]      : ld1b   (%x15,%z17.d,sxtw)[4byte] %p4/z -> %z14.d
+c4535630 : ld1b z16.d, p5/Z, [x17, z19.d, SXTW]      : ld1b   (%x17,%z19.d,sxtw)[4byte] %p5/z -> %z16.d
+c4545671 : ld1b z17.d, p5/Z, [x19, z20.d, SXTW]      : ld1b   (%x19,%z20.d,sxtw)[4byte] %p5/z -> %z17.d
+c45656b3 : ld1b z19.d, p5/Z, [x21, z22.d, SXTW]      : ld1b   (%x21,%z22.d,sxtw)[4byte] %p5/z -> %z19.d
+c4585af5 : ld1b z21.d, p6/Z, [x23, z24.d, SXTW]      : ld1b   (%x23,%z24.d,sxtw)[4byte] %p6/z -> %z21.d
+c45a5b17 : ld1b z23.d, p6/Z, [x24, z26.d, SXTW]      : ld1b   (%x24,%z26.d,sxtw)[4byte] %p6/z -> %z23.d
+c45c5f59 : ld1b z25.d, p7/Z, [x26, z28.d, SXTW]      : ld1b   (%x26,%z28.d,sxtw)[4byte] %p7/z -> %z25.d
+c45e5f9b : ld1b z27.d, p7/Z, [x28, z30.d, SXTW]      : ld1b   (%x28,%z30.d,sxtw)[4byte] %p7/z -> %z27.d
+c45f5fff : ld1b z31.d, p7/Z, [sp, z31.d, SXTW]       : ld1b   (%sp,%z31.d,sxtw)[4byte] %p7/z -> %z31.d
+
+# LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LD1B-Z.P.BZ-S.x32.unscaled)
+84004000 : ld1b z0.s, p0/Z, [x0, z0.s, UXTW]         : ld1b   (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s
+84054482 : ld1b z2.s, p1/Z, [x4, z5.s, UXTW]         : ld1b   (%x4,%z5.s,uxtw)[8byte] %p1/z -> %z2.s
+840748c4 : ld1b z4.s, p2/Z, [x6, z7.s, UXTW]         : ld1b   (%x6,%z7.s,uxtw)[8byte] %p2/z -> %z4.s
+84094906 : ld1b z6.s, p2/Z, [x8, z9.s, UXTW]         : ld1b   (%x8,%z9.s,uxtw)[8byte] %p2/z -> %z6.s
+840b4d48 : ld1b z8.s, p3/Z, [x10, z11.s, UXTW]       : ld1b   (%x10,%z11.s,uxtw)[8byte] %p3/z -> %z8.s
+840d4d6a : ld1b z10.s, p3/Z, [x11, z13.s, UXTW]      : ld1b   (%x11,%z13.s,uxtw)[8byte] %p3/z -> %z10.s
+840f51ac : ld1b z12.s, p4/Z, [x13, z15.s, UXTW]      : ld1b   (%x13,%z15.s,uxtw)[8byte] %p4/z -> %z12.s
+841151ee : ld1b z14.s, p4/Z, [x15, z17.s, UXTW]      : ld1b   (%x15,%z17.s,uxtw)[8byte] %p4/z -> %z14.s
+84135630 : ld1b z16.s, p5/Z, [x17, z19.s, UXTW]      : ld1b   (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s
+84145671 : ld1b z17.s, p5/Z, [x19, z20.s, UXTW]      : ld1b   (%x19,%z20.s,uxtw)[8byte] %p5/z -> %z17.s
+841656b3 : ld1b z19.s, p5/Z, [x21, z22.s, UXTW]      : ld1b   (%x21,%z22.s,uxtw)[8byte] %p5/z -> %z19.s
+84185af5 : ld1b z21.s, p6/Z, [x23, z24.s, UXTW]      : ld1b   (%x23,%z24.s,uxtw)[8byte] %p6/z -> %z21.s
+841a5b17 : ld1b z23.s, p6/Z, [x24, z26.s, UXTW]      : ld1b   (%x24,%z26.s,uxtw)[8byte] %p6/z -> %z23.s
+841c5f59 : ld1b z25.s, p7/Z, [x26, z28.s, UXTW]      : ld1b   (%x26,%z28.s,uxtw)[8byte] %p7/z -> %z25.s
+841e5f9b : ld1b z27.s, p7/Z, [x28, z30.s, UXTW]      : ld1b   (%x28,%z30.s,uxtw)[8byte] %p7/z -> %z27.s
+841f5fff : ld1b z31.s, p7/Z, [sp, z31.s, UXTW]       : ld1b   (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s
+84404000 : ld1b z0.s, p0/Z, [x0, z0.s, SXTW]         : ld1b   (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s
+84454482 : ld1b z2.s, p1/Z, [x4, z5.s, SXTW]         : ld1b   (%x4,%z5.s,sxtw)[8byte] %p1/z -> %z2.s
+844748c4 : ld1b z4.s, p2/Z, [x6, z7.s, SXTW]         : ld1b   (%x6,%z7.s,sxtw)[8byte] %p2/z -> %z4.s
+84494906 : ld1b z6.s, p2/Z, [x8, z9.s, SXTW]         : ld1b   (%x8,%z9.s,sxtw)[8byte] %p2/z -> %z6.s
+844b4d48 : ld1b z8.s, p3/Z, [x10, z11.s, SXTW]       : ld1b   (%x10,%z11.s,sxtw)[8byte] %p3/z -> %z8.s
+844d4d6a : ld1b z10.s, p3/Z, [x11, z13.s, SXTW]      : ld1b   (%x11,%z13.s,sxtw)[8byte] %p3/z -> %z10.s
+844f51ac : ld1b z12.s, p4/Z, [x13, z15.s, SXTW]      : ld1b   (%x13,%z15.s,sxtw)[8byte] %p4/z -> %z12.s
+845151ee : ld1b z14.s, p4/Z, [x15, z17.s, SXTW]      : ld1b   (%x15,%z17.s,sxtw)[8byte] %p4/z -> %z14.s
+84535630 : ld1b z16.s, p5/Z, [x17, z19.s, SXTW]      : ld1b   (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s
+84545671 : ld1b z17.s, p5/Z, [x19, z20.s, SXTW]      : ld1b   (%x19,%z20.s,sxtw)[8byte] %p5/z -> %z17.s
+845656b3 : ld1b z19.s, p5/Z, [x21, z22.s, SXTW]      : ld1b   (%x21,%z22.s,sxtw)[8byte] %p5/z -> %z19.s
+84585af5 : ld1b z21.s, p6/Z, [x23, z24.s, SXTW]      : ld1b   (%x23,%z24.s,sxtw)[8byte] %p6/z -> %z21.s
+845a5b17 : ld1b z23.s, p6/Z, [x24, z26.s, SXTW]      : ld1b   (%x24,%z26.s,sxtw)[8byte] %p6/z -> %z23.s
+845c5f59 : ld1b z25.s, p7/Z, [x26, z28.s, SXTW]      : ld1b   (%x26,%z28.s,sxtw)[8byte] %p7/z -> %z25.s
+845e5f9b : ld1b z27.s, p7/Z, [x28, z30.s, SXTW]      : ld1b   (%x28,%z30.s,sxtw)[8byte] %p7/z -> %z27.s
+845f5fff : ld1b z31.s, p7/Z, [sp, z31.s, SXTW]       : ld1b   (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s
+
 # LD1D    { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<pimm>}] (LD1D-Z.P.AI-D)
 c5a0c000 : ld1d z0.d, p0/Z, [z0.d, #0]               : ld1d   (%z0.d)[32byte] %p0/z -> %z0.d
 c5a2c482 : ld1d z2.d, p1/Z, [z4.d, #16]              : ld1d   +0x10(%z4.d)[32byte] %p1/z -> %z2.d
@@ -10729,6 +10797,74 @@ c5dadb17 : ld1d z23.d, p6/Z, [x24, z26.d]            : ld1d   (%x24,%z26.d)[32by
 c5dcdf59 : ld1d z25.d, p7/Z, [x26, z28.d]            : ld1d   (%x26,%z28.d)[32byte] %p7/z -> %z25.d
 c5dedf9b : ld1d z27.d, p7/Z, [x28, z30.d]            : ld1d   (%x28,%z30.d)[32byte] %p7/z -> %z27.d
 c5dfdfff : ld1d z31.d, p7/Z, [sp, z31.d]             : ld1d   (%sp,%z31.d)[32byte] %p7/z -> %z31.d
+
+# LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3] (LD1D-Z.P.BZ-D.x32.scaled)
+c5a04000 : ld1d z0.d, p0/Z, [x0, z0.d, UXTW #3]      : ld1d   (%x0,%z0.d,uxtw #3)[32byte] %p0/z -> %z0.d
+c5a54482 : ld1d z2.d, p1/Z, [x4, z5.d, UXTW #3]      : ld1d   (%x4,%z5.d,uxtw #3)[32byte] %p1/z -> %z2.d
+c5a748c4 : ld1d z4.d, p2/Z, [x6, z7.d, UXTW #3]      : ld1d   (%x6,%z7.d,uxtw #3)[32byte] %p2/z -> %z4.d
+c5a94906 : ld1d z6.d, p2/Z, [x8, z9.d, UXTW #3]      : ld1d   (%x8,%z9.d,uxtw #3)[32byte] %p2/z -> %z6.d
+c5ab4d48 : ld1d z8.d, p3/Z, [x10, z11.d, UXTW #3]    : ld1d   (%x10,%z11.d,uxtw #3)[32byte] %p3/z -> %z8.d
+c5ad4d6a : ld1d z10.d, p3/Z, [x11, z13.d, UXTW #3]   : ld1d   (%x11,%z13.d,uxtw #3)[32byte] %p3/z -> %z10.d
+c5af51ac : ld1d z12.d, p4/Z, [x13, z15.d, UXTW #3]   : ld1d   (%x13,%z15.d,uxtw #3)[32byte] %p4/z -> %z12.d
+c5b151ee : ld1d z14.d, p4/Z, [x15, z17.d, UXTW #3]   : ld1d   (%x15,%z17.d,uxtw #3)[32byte] %p4/z -> %z14.d
+c5b35630 : ld1d z16.d, p5/Z, [x17, z19.d, UXTW #3]   : ld1d   (%x17,%z19.d,uxtw #3)[32byte] %p5/z -> %z16.d
+c5b45671 : ld1d z17.d, p5/Z, [x19, z20.d, UXTW #3]   : ld1d   (%x19,%z20.d,uxtw #3)[32byte] %p5/z -> %z17.d
+c5b656b3 : ld1d z19.d, p5/Z, [x21, z22.d, UXTW #3]   : ld1d   (%x21,%z22.d,uxtw #3)[32byte] %p5/z -> %z19.d
+c5b85af5 : ld1d z21.d, p6/Z, [x23, z24.d, UXTW #3]   : ld1d   (%x23,%z24.d,uxtw #3)[32byte] %p6/z -> %z21.d
+c5ba5b17 : ld1d z23.d, p6/Z, [x24, z26.d, UXTW #3]   : ld1d   (%x24,%z26.d,uxtw #3)[32byte] %p6/z -> %z23.d
+c5bc5f59 : ld1d z25.d, p7/Z, [x26, z28.d, UXTW #3]   : ld1d   (%x26,%z28.d,uxtw #3)[32byte] %p7/z -> %z25.d
+c5be5f9b : ld1d z27.d, p7/Z, [x28, z30.d, UXTW #3]   : ld1d   (%x28,%z30.d,uxtw #3)[32byte] %p7/z -> %z27.d
+c5bf5fff : ld1d z31.d, p7/Z, [sp, z31.d, UXTW #3]    : ld1d   (%sp,%z31.d,uxtw #3)[32byte] %p7/z -> %z31.d
+c5e04000 : ld1d z0.d, p0/Z, [x0, z0.d, SXTW #3]      : ld1d   (%x0,%z0.d,sxtw #3)[32byte] %p0/z -> %z0.d
+c5e54482 : ld1d z2.d, p1/Z, [x4, z5.d, SXTW #3]      : ld1d   (%x4,%z5.d,sxtw #3)[32byte] %p1/z -> %z2.d
+c5e748c4 : ld1d z4.d, p2/Z, [x6, z7.d, SXTW #3]      : ld1d   (%x6,%z7.d,sxtw #3)[32byte] %p2/z -> %z4.d
+c5e94906 : ld1d z6.d, p2/Z, [x8, z9.d, SXTW #3]      : ld1d   (%x8,%z9.d,sxtw #3)[32byte] %p2/z -> %z6.d
+c5eb4d48 : ld1d z8.d, p3/Z, [x10, z11.d, SXTW #3]    : ld1d   (%x10,%z11.d,sxtw #3)[32byte] %p3/z -> %z8.d
+c5ed4d6a : ld1d z10.d, p3/Z, [x11, z13.d, SXTW #3]   : ld1d   (%x11,%z13.d,sxtw #3)[32byte] %p3/z -> %z10.d
+c5ef51ac : ld1d z12.d, p4/Z, [x13, z15.d, SXTW #3]   : ld1d   (%x13,%z15.d,sxtw #3)[32byte] %p4/z -> %z12.d
+c5f151ee : ld1d z14.d, p4/Z, [x15, z17.d, SXTW #3]   : ld1d   (%x15,%z17.d,sxtw #3)[32byte] %p4/z -> %z14.d
+c5f35630 : ld1d z16.d, p5/Z, [x17, z19.d, SXTW #3]   : ld1d   (%x17,%z19.d,sxtw #3)[32byte] %p5/z -> %z16.d
+c5f45671 : ld1d z17.d, p5/Z, [x19, z20.d, SXTW #3]   : ld1d   (%x19,%z20.d,sxtw #3)[32byte] %p5/z -> %z17.d
+c5f656b3 : ld1d z19.d, p5/Z, [x21, z22.d, SXTW #3]   : ld1d   (%x21,%z22.d,sxtw #3)[32byte] %p5/z -> %z19.d
+c5f85af5 : ld1d z21.d, p6/Z, [x23, z24.d, SXTW #3]   : ld1d   (%x23,%z24.d,sxtw #3)[32byte] %p6/z -> %z21.d
+c5fa5b17 : ld1d z23.d, p6/Z, [x24, z26.d, SXTW #3]   : ld1d   (%x24,%z26.d,sxtw #3)[32byte] %p6/z -> %z23.d
+c5fc5f59 : ld1d z25.d, p7/Z, [x26, z28.d, SXTW #3]   : ld1d   (%x26,%z28.d,sxtw #3)[32byte] %p7/z -> %z25.d
+c5fe5f9b : ld1d z27.d, p7/Z, [x28, z30.d, SXTW #3]   : ld1d   (%x28,%z30.d,sxtw #3)[32byte] %p7/z -> %z27.d
+c5ff5fff : ld1d z31.d, p7/Z, [sp, z31.d, SXTW #3]    : ld1d   (%sp,%z31.d,sxtw #3)[32byte] %p7/z -> %z31.d
+
+# LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1D-Z.P.BZ-D.x32.unscaled)
+c5804000 : ld1d z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1d   (%x0,%z0.d,uxtw)[32byte] %p0/z -> %z0.d
+c5854482 : ld1d z2.d, p1/Z, [x4, z5.d, UXTW]         : ld1d   (%x4,%z5.d,uxtw)[32byte] %p1/z -> %z2.d
+c58748c4 : ld1d z4.d, p2/Z, [x6, z7.d, UXTW]         : ld1d   (%x6,%z7.d,uxtw)[32byte] %p2/z -> %z4.d
+c5894906 : ld1d z6.d, p2/Z, [x8, z9.d, UXTW]         : ld1d   (%x8,%z9.d,uxtw)[32byte] %p2/z -> %z6.d
+c58b4d48 : ld1d z8.d, p3/Z, [x10, z11.d, UXTW]       : ld1d   (%x10,%z11.d,uxtw)[32byte] %p3/z -> %z8.d
+c58d4d6a : ld1d z10.d, p3/Z, [x11, z13.d, UXTW]      : ld1d   (%x11,%z13.d,uxtw)[32byte] %p3/z -> %z10.d
+c58f51ac : ld1d z12.d, p4/Z, [x13, z15.d, UXTW]      : ld1d   (%x13,%z15.d,uxtw)[32byte] %p4/z -> %z12.d
+c59151ee : ld1d z14.d, p4/Z, [x15, z17.d, UXTW]      : ld1d   (%x15,%z17.d,uxtw)[32byte] %p4/z -> %z14.d
+c5935630 : ld1d z16.d, p5/Z, [x17, z19.d, UXTW]      : ld1d   (%x17,%z19.d,uxtw)[32byte] %p5/z -> %z16.d
+c5945671 : ld1d z17.d, p5/Z, [x19, z20.d, UXTW]      : ld1d   (%x19,%z20.d,uxtw)[32byte] %p5/z -> %z17.d
+c59656b3 : ld1d z19.d, p5/Z, [x21, z22.d, UXTW]      : ld1d   (%x21,%z22.d,uxtw)[32byte] %p5/z -> %z19.d
+c5985af5 : ld1d z21.d, p6/Z, [x23, z24.d, UXTW]      : ld1d   (%x23,%z24.d,uxtw)[32byte] %p6/z -> %z21.d
+c59a5b17 : ld1d z23.d, p6/Z, [x24, z26.d, UXTW]      : ld1d   (%x24,%z26.d,uxtw)[32byte] %p6/z -> %z23.d
+c59c5f59 : ld1d z25.d, p7/Z, [x26, z28.d, UXTW]      : ld1d   (%x26,%z28.d,uxtw)[32byte] %p7/z -> %z25.d
+c59e5f9b : ld1d z27.d, p7/Z, [x28, z30.d, UXTW]      : ld1d   (%x28,%z30.d,uxtw)[32byte] %p7/z -> %z27.d
+c59f5fff : ld1d z31.d, p7/Z, [sp, z31.d, UXTW]       : ld1d   (%sp,%z31.d,uxtw)[32byte] %p7/z -> %z31.d
+c5c04000 : ld1d z0.d, p0/Z, [x0, z0.d, SXTW]         : ld1d   (%x0,%z0.d,sxtw)[32byte] %p0/z -> %z0.d
+c5c54482 : ld1d z2.d, p1/Z, [x4, z5.d, SXTW]         : ld1d   (%x4,%z5.d,sxtw)[32byte] %p1/z -> %z2.d
+c5c748c4 : ld1d z4.d, p2/Z, [x6, z7.d, SXTW]         : ld1d   (%x6,%z7.d,sxtw)[32byte] %p2/z -> %z4.d
+c5c94906 : ld1d z6.d, p2/Z, [x8, z9.d, SXTW]         : ld1d   (%x8,%z9.d,sxtw)[32byte] %p2/z -> %z6.d
+c5cb4d48 : ld1d z8.d, p3/Z, [x10, z11.d, SXTW]       : ld1d   (%x10,%z11.d,sxtw)[32byte] %p3/z -> %z8.d
+c5cd4d6a : ld1d z10.d, p3/Z, [x11, z13.d, SXTW]      : ld1d   (%x11,%z13.d,sxtw)[32byte] %p3/z -> %z10.d
+c5cf51ac : ld1d z12.d, p4/Z, [x13, z15.d, SXTW]      : ld1d   (%x13,%z15.d,sxtw)[32byte] %p4/z -> %z12.d
+c5d151ee : ld1d z14.d, p4/Z, [x15, z17.d, SXTW]      : ld1d   (%x15,%z17.d,sxtw)[32byte] %p4/z -> %z14.d
+c5d35630 : ld1d z16.d, p5/Z, [x17, z19.d, SXTW]      : ld1d   (%x17,%z19.d,sxtw)[32byte] %p5/z -> %z16.d
+c5d45671 : ld1d z17.d, p5/Z, [x19, z20.d, SXTW]      : ld1d   (%x19,%z20.d,sxtw)[32byte] %p5/z -> %z17.d
+c5d656b3 : ld1d z19.d, p5/Z, [x21, z22.d, SXTW]      : ld1d   (%x21,%z22.d,sxtw)[32byte] %p5/z -> %z19.d
+c5d85af5 : ld1d z21.d, p6/Z, [x23, z24.d, SXTW]      : ld1d   (%x23,%z24.d,sxtw)[32byte] %p6/z -> %z21.d
+c5da5b17 : ld1d z23.d, p6/Z, [x24, z26.d, SXTW]      : ld1d   (%x24,%z26.d,sxtw)[32byte] %p6/z -> %z23.d
+c5dc5f59 : ld1d z25.d, p7/Z, [x26, z28.d, SXTW]      : ld1d   (%x26,%z28.d,sxtw)[32byte] %p7/z -> %z25.d
+c5de5f9b : ld1d z27.d, p7/Z, [x28, z30.d, SXTW]      : ld1d   (%x28,%z30.d,sxtw)[32byte] %p7/z -> %z27.d
+c5df5fff : ld1d z31.d, p7/Z, [sp, z31.d, SXTW]       : ld1d   (%sp,%z31.d,sxtw)[32byte] %p7/z -> %z31.d
 
 # LD1H    { <Zt>.S }, <Pg>/Z, [<Zn>.S{, #<pimm>}] (LD1H-Z.P.AI-S)
 84a0c000 : ld1h z0.s, p0/Z, [z0.s, #0]               : ld1h   (%z0.s)[16byte] %p0/z -> %z0.s
@@ -10801,6 +10937,142 @@ c4dadb17 : ld1h z23.d, p6/Z, [x24, z26.d]            : ld1h   (%x24,%z26.d)[8byt
 c4dcdf59 : ld1h z25.d, p7/Z, [x26, z28.d]            : ld1h   (%x26,%z28.d)[8byte] %p7/z -> %z25.d
 c4dedf9b : ld1h z27.d, p7/Z, [x28, z30.d]            : ld1h   (%x28,%z30.d)[8byte] %p7/z -> %z27.d
 c4dfdfff : ld1h z31.d, p7/Z, [sp, z31.d]             : ld1h   (%sp,%z31.d)[8byte] %p7/z -> %z31.d
+
+# LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] (LD1H-Z.P.BZ-D.x32.scaled)
+c4a04000 : ld1h z0.d, p0/Z, [x0, z0.d, UXTW #1]      : ld1h   (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d
+c4a54482 : ld1h z2.d, p1/Z, [x4, z5.d, UXTW #1]      : ld1h   (%x4,%z5.d,uxtw #1)[8byte] %p1/z -> %z2.d
+c4a748c4 : ld1h z4.d, p2/Z, [x6, z7.d, UXTW #1]      : ld1h   (%x6,%z7.d,uxtw #1)[8byte] %p2/z -> %z4.d
+c4a94906 : ld1h z6.d, p2/Z, [x8, z9.d, UXTW #1]      : ld1h   (%x8,%z9.d,uxtw #1)[8byte] %p2/z -> %z6.d
+c4ab4d48 : ld1h z8.d, p3/Z, [x10, z11.d, UXTW #1]    : ld1h   (%x10,%z11.d,uxtw #1)[8byte] %p3/z -> %z8.d
+c4ad4d6a : ld1h z10.d, p3/Z, [x11, z13.d, UXTW #1]   : ld1h   (%x11,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d
+c4af51ac : ld1h z12.d, p4/Z, [x13, z15.d, UXTW #1]   : ld1h   (%x13,%z15.d,uxtw #1)[8byte] %p4/z -> %z12.d
+c4b151ee : ld1h z14.d, p4/Z, [x15, z17.d, UXTW #1]   : ld1h   (%x15,%z17.d,uxtw #1)[8byte] %p4/z -> %z14.d
+c4b35630 : ld1h z16.d, p5/Z, [x17, z19.d, UXTW #1]   : ld1h   (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d
+c4b45671 : ld1h z17.d, p5/Z, [x19, z20.d, UXTW #1]   : ld1h   (%x19,%z20.d,uxtw #1)[8byte] %p5/z -> %z17.d
+c4b656b3 : ld1h z19.d, p5/Z, [x21, z22.d, UXTW #1]   : ld1h   (%x21,%z22.d,uxtw #1)[8byte] %p5/z -> %z19.d
+c4b85af5 : ld1h z21.d, p6/Z, [x23, z24.d, UXTW #1]   : ld1h   (%x23,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d
+c4ba5b17 : ld1h z23.d, p6/Z, [x24, z26.d, UXTW #1]   : ld1h   (%x24,%z26.d,uxtw #1)[8byte] %p6/z -> %z23.d
+c4bc5f59 : ld1h z25.d, p7/Z, [x26, z28.d, UXTW #1]   : ld1h   (%x26,%z28.d,uxtw #1)[8byte] %p7/z -> %z25.d
+c4be5f9b : ld1h z27.d, p7/Z, [x28, z30.d, UXTW #1]   : ld1h   (%x28,%z30.d,uxtw #1)[8byte] %p7/z -> %z27.d
+c4bf5fff : ld1h z31.d, p7/Z, [sp, z31.d, UXTW #1]    : ld1h   (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d
+c4e04000 : ld1h z0.d, p0/Z, [x0, z0.d, SXTW #1]      : ld1h   (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d
+c4e54482 : ld1h z2.d, p1/Z, [x4, z5.d, SXTW #1]      : ld1h   (%x4,%z5.d,sxtw #1)[8byte] %p1/z -> %z2.d
+c4e748c4 : ld1h z4.d, p2/Z, [x6, z7.d, SXTW #1]      : ld1h   (%x6,%z7.d,sxtw #1)[8byte] %p2/z -> %z4.d
+c4e94906 : ld1h z6.d, p2/Z, [x8, z9.d, SXTW #1]      : ld1h   (%x8,%z9.d,sxtw #1)[8byte] %p2/z -> %z6.d
+c4eb4d48 : ld1h z8.d, p3/Z, [x10, z11.d, SXTW #1]    : ld1h   (%x10,%z11.d,sxtw #1)[8byte] %p3/z -> %z8.d
+c4ed4d6a : ld1h z10.d, p3/Z, [x11, z13.d, SXTW #1]   : ld1h   (%x11,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d
+c4ef51ac : ld1h z12.d, p4/Z, [x13, z15.d, SXTW #1]   : ld1h   (%x13,%z15.d,sxtw #1)[8byte] %p4/z -> %z12.d
+c4f151ee : ld1h z14.d, p4/Z, [x15, z17.d, SXTW #1]   : ld1h   (%x15,%z17.d,sxtw #1)[8byte] %p4/z -> %z14.d
+c4f35630 : ld1h z16.d, p5/Z, [x17, z19.d, SXTW #1]   : ld1h   (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d
+c4f45671 : ld1h z17.d, p5/Z, [x19, z20.d, SXTW #1]   : ld1h   (%x19,%z20.d,sxtw #1)[8byte] %p5/z -> %z17.d
+c4f656b3 : ld1h z19.d, p5/Z, [x21, z22.d, SXTW #1]   : ld1h   (%x21,%z22.d,sxtw #1)[8byte] %p5/z -> %z19.d
+c4f85af5 : ld1h z21.d, p6/Z, [x23, z24.d, SXTW #1]   : ld1h   (%x23,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d
+c4fa5b17 : ld1h z23.d, p6/Z, [x24, z26.d, SXTW #1]   : ld1h   (%x24,%z26.d,sxtw #1)[8byte] %p6/z -> %z23.d
+c4fc5f59 : ld1h z25.d, p7/Z, [x26, z28.d, SXTW #1]   : ld1h   (%x26,%z28.d,sxtw #1)[8byte] %p7/z -> %z25.d
+c4fe5f9b : ld1h z27.d, p7/Z, [x28, z30.d, SXTW #1]   : ld1h   (%x28,%z30.d,sxtw #1)[8byte] %p7/z -> %z27.d
+c4ff5fff : ld1h z31.d, p7/Z, [sp, z31.d, SXTW #1]    : ld1h   (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d
+
+# LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1H-Z.P.BZ-D.x32.unscaled)
+c4804000 : ld1h z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1h   (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d
+c4854482 : ld1h z2.d, p1/Z, [x4, z5.d, UXTW]         : ld1h   (%x4,%z5.d,uxtw)[8byte] %p1/z -> %z2.d
+c48748c4 : ld1h z4.d, p2/Z, [x6, z7.d, UXTW]         : ld1h   (%x6,%z7.d,uxtw)[8byte] %p2/z -> %z4.d
+c4894906 : ld1h z6.d, p2/Z, [x8, z9.d, UXTW]         : ld1h   (%x8,%z9.d,uxtw)[8byte] %p2/z -> %z6.d
+c48b4d48 : ld1h z8.d, p3/Z, [x10, z11.d, UXTW]       : ld1h   (%x10,%z11.d,uxtw)[8byte] %p3/z -> %z8.d
+c48d4d6a : ld1h z10.d, p3/Z, [x11, z13.d, UXTW]      : ld1h   (%x11,%z13.d,uxtw)[8byte] %p3/z -> %z10.d
+c48f51ac : ld1h z12.d, p4/Z, [x13, z15.d, UXTW]      : ld1h   (%x13,%z15.d,uxtw)[8byte] %p4/z -> %z12.d
+c49151ee : ld1h z14.d, p4/Z, [x15, z17.d, UXTW]      : ld1h   (%x15,%z17.d,uxtw)[8byte] %p4/z -> %z14.d
+c4935630 : ld1h z16.d, p5/Z, [x17, z19.d, UXTW]      : ld1h   (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d
+c4945671 : ld1h z17.d, p5/Z, [x19, z20.d, UXTW]      : ld1h   (%x19,%z20.d,uxtw)[8byte] %p5/z -> %z17.d
+c49656b3 : ld1h z19.d, p5/Z, [x21, z22.d, UXTW]      : ld1h   (%x21,%z22.d,uxtw)[8byte] %p5/z -> %z19.d
+c4985af5 : ld1h z21.d, p6/Z, [x23, z24.d, UXTW]      : ld1h   (%x23,%z24.d,uxtw)[8byte] %p6/z -> %z21.d
+c49a5b17 : ld1h z23.d, p6/Z, [x24, z26.d, UXTW]      : ld1h   (%x24,%z26.d,uxtw)[8byte] %p6/z -> %z23.d
+c49c5f59 : ld1h z25.d, p7/Z, [x26, z28.d, UXTW]      : ld1h   (%x26,%z28.d,uxtw)[8byte] %p7/z -> %z25.d
+c49e5f9b : ld1h z27.d, p7/Z, [x28, z30.d, UXTW]      : ld1h   (%x28,%z30.d,uxtw)[8byte] %p7/z -> %z27.d
+c49f5fff : ld1h z31.d, p7/Z, [sp, z31.d, UXTW]       : ld1h   (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d
+c4c04000 : ld1h z0.d, p0/Z, [x0, z0.d, SXTW]         : ld1h   (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d
+c4c54482 : ld1h z2.d, p1/Z, [x4, z5.d, SXTW]         : ld1h   (%x4,%z5.d,sxtw)[8byte] %p1/z -> %z2.d
+c4c748c4 : ld1h z4.d, p2/Z, [x6, z7.d, SXTW]         : ld1h   (%x6,%z7.d,sxtw)[8byte] %p2/z -> %z4.d
+c4c94906 : ld1h z6.d, p2/Z, [x8, z9.d, SXTW]         : ld1h   (%x8,%z9.d,sxtw)[8byte] %p2/z -> %z6.d
+c4cb4d48 : ld1h z8.d, p3/Z, [x10, z11.d, SXTW]       : ld1h   (%x10,%z11.d,sxtw)[8byte] %p3/z -> %z8.d
+c4cd4d6a : ld1h z10.d, p3/Z, [x11, z13.d, SXTW]      : ld1h   (%x11,%z13.d,sxtw)[8byte] %p3/z -> %z10.d
+c4cf51ac : ld1h z12.d, p4/Z, [x13, z15.d, SXTW]      : ld1h   (%x13,%z15.d,sxtw)[8byte] %p4/z -> %z12.d
+c4d151ee : ld1h z14.d, p4/Z, [x15, z17.d, SXTW]      : ld1h   (%x15,%z17.d,sxtw)[8byte] %p4/z -> %z14.d
+c4d35630 : ld1h z16.d, p5/Z, [x17, z19.d, SXTW]      : ld1h   (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d
+c4d45671 : ld1h z17.d, p5/Z, [x19, z20.d, SXTW]      : ld1h   (%x19,%z20.d,sxtw)[8byte] %p5/z -> %z17.d
+c4d656b3 : ld1h z19.d, p5/Z, [x21, z22.d, SXTW]      : ld1h   (%x21,%z22.d,sxtw)[8byte] %p5/z -> %z19.d
+c4d85af5 : ld1h z21.d, p6/Z, [x23, z24.d, SXTW]      : ld1h   (%x23,%z24.d,sxtw)[8byte] %p6/z -> %z21.d
+c4da5b17 : ld1h z23.d, p6/Z, [x24, z26.d, SXTW]      : ld1h   (%x24,%z26.d,sxtw)[8byte] %p6/z -> %z23.d
+c4dc5f59 : ld1h z25.d, p7/Z, [x26, z28.d, SXTW]      : ld1h   (%x26,%z28.d,sxtw)[8byte] %p7/z -> %z25.d
+c4de5f9b : ld1h z27.d, p7/Z, [x28, z30.d, SXTW]      : ld1h   (%x28,%z30.d,sxtw)[8byte] %p7/z -> %z27.d
+c4df5fff : ld1h z31.d, p7/Z, [sp, z31.d, SXTW]       : ld1h   (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d
+
+# LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] (LD1H-Z.P.BZ-S.x32.scaled)
+84a04000 : ld1h z0.s, p0/Z, [x0, z0.s, UXTW #1]      : ld1h   (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s
+84a54482 : ld1h z2.s, p1/Z, [x4, z5.s, UXTW #1]      : ld1h   (%x4,%z5.s,uxtw #1)[16byte] %p1/z -> %z2.s
+84a748c4 : ld1h z4.s, p2/Z, [x6, z7.s, UXTW #1]      : ld1h   (%x6,%z7.s,uxtw #1)[16byte] %p2/z -> %z4.s
+84a94906 : ld1h z6.s, p2/Z, [x8, z9.s, UXTW #1]      : ld1h   (%x8,%z9.s,uxtw #1)[16byte] %p2/z -> %z6.s
+84ab4d48 : ld1h z8.s, p3/Z, [x10, z11.s, UXTW #1]    : ld1h   (%x10,%z11.s,uxtw #1)[16byte] %p3/z -> %z8.s
+84ad4d6a : ld1h z10.s, p3/Z, [x11, z13.s, UXTW #1]   : ld1h   (%x11,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s
+84af51ac : ld1h z12.s, p4/Z, [x13, z15.s, UXTW #1]   : ld1h   (%x13,%z15.s,uxtw #1)[16byte] %p4/z -> %z12.s
+84b151ee : ld1h z14.s, p4/Z, [x15, z17.s, UXTW #1]   : ld1h   (%x15,%z17.s,uxtw #1)[16byte] %p4/z -> %z14.s
+84b35630 : ld1h z16.s, p5/Z, [x17, z19.s, UXTW #1]   : ld1h   (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s
+84b45671 : ld1h z17.s, p5/Z, [x19, z20.s, UXTW #1]   : ld1h   (%x19,%z20.s,uxtw #1)[16byte] %p5/z -> %z17.s
+84b656b3 : ld1h z19.s, p5/Z, [x21, z22.s, UXTW #1]   : ld1h   (%x21,%z22.s,uxtw #1)[16byte] %p5/z -> %z19.s
+84b85af5 : ld1h z21.s, p6/Z, [x23, z24.s, UXTW #1]   : ld1h   (%x23,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s
+84ba5b17 : ld1h z23.s, p6/Z, [x24, z26.s, UXTW #1]   : ld1h   (%x24,%z26.s,uxtw #1)[16byte] %p6/z -> %z23.s
+84bc5f59 : ld1h z25.s, p7/Z, [x26, z28.s, UXTW #1]   : ld1h   (%x26,%z28.s,uxtw #1)[16byte] %p7/z -> %z25.s
+84be5f9b : ld1h z27.s, p7/Z, [x28, z30.s, UXTW #1]   : ld1h   (%x28,%z30.s,uxtw #1)[16byte] %p7/z -> %z27.s
+84bf5fff : ld1h z31.s, p7/Z, [sp, z31.s, UXTW #1]    : ld1h   (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s
+84e04000 : ld1h z0.s, p0/Z, [x0, z0.s, SXTW #1]      : ld1h   (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s
+84e54482 : ld1h z2.s, p1/Z, [x4, z5.s, SXTW #1]      : ld1h   (%x4,%z5.s,sxtw #1)[16byte] %p1/z -> %z2.s
+84e748c4 : ld1h z4.s, p2/Z, [x6, z7.s, SXTW #1]      : ld1h   (%x6,%z7.s,sxtw #1)[16byte] %p2/z -> %z4.s
+84e94906 : ld1h z6.s, p2/Z, [x8, z9.s, SXTW #1]      : ld1h   (%x8,%z9.s,sxtw #1)[16byte] %p2/z -> %z6.s
+84eb4d48 : ld1h z8.s, p3/Z, [x10, z11.s, SXTW #1]    : ld1h   (%x10,%z11.s,sxtw #1)[16byte] %p3/z -> %z8.s
+84ed4d6a : ld1h z10.s, p3/Z, [x11, z13.s, SXTW #1]   : ld1h   (%x11,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s
+84ef51ac : ld1h z12.s, p4/Z, [x13, z15.s, SXTW #1]   : ld1h   (%x13,%z15.s,sxtw #1)[16byte] %p4/z -> %z12.s
+84f151ee : ld1h z14.s, p4/Z, [x15, z17.s, SXTW #1]   : ld1h   (%x15,%z17.s,sxtw #1)[16byte] %p4/z -> %z14.s
+84f35630 : ld1h z16.s, p5/Z, [x17, z19.s, SXTW #1]   : ld1h   (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s
+84f45671 : ld1h z17.s, p5/Z, [x19, z20.s, SXTW #1]   : ld1h   (%x19,%z20.s,sxtw #1)[16byte] %p5/z -> %z17.s
+84f656b3 : ld1h z19.s, p5/Z, [x21, z22.s, SXTW #1]   : ld1h   (%x21,%z22.s,sxtw #1)[16byte] %p5/z -> %z19.s
+84f85af5 : ld1h z21.s, p6/Z, [x23, z24.s, SXTW #1]   : ld1h   (%x23,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s
+84fa5b17 : ld1h z23.s, p6/Z, [x24, z26.s, SXTW #1]   : ld1h   (%x24,%z26.s,sxtw #1)[16byte] %p6/z -> %z23.s
+84fc5f59 : ld1h z25.s, p7/Z, [x26, z28.s, SXTW #1]   : ld1h   (%x26,%z28.s,sxtw #1)[16byte] %p7/z -> %z25.s
+84fe5f9b : ld1h z27.s, p7/Z, [x28, z30.s, SXTW #1]   : ld1h   (%x28,%z30.s,sxtw #1)[16byte] %p7/z -> %z27.s
+84ff5fff : ld1h z31.s, p7/Z, [sp, z31.s, SXTW #1]    : ld1h   (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s
+
+# LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LD1H-Z.P.BZ-S.x32.unscaled)
+84804000 : ld1h z0.s, p0/Z, [x0, z0.s, UXTW]         : ld1h   (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s
+84854482 : ld1h z2.s, p1/Z, [x4, z5.s, UXTW]         : ld1h   (%x4,%z5.s,uxtw)[16byte] %p1/z -> %z2.s
+848748c4 : ld1h z4.s, p2/Z, [x6, z7.s, UXTW]         : ld1h   (%x6,%z7.s,uxtw)[16byte] %p2/z -> %z4.s
+84894906 : ld1h z6.s, p2/Z, [x8, z9.s, UXTW]         : ld1h   (%x8,%z9.s,uxtw)[16byte] %p2/z -> %z6.s
+848b4d48 : ld1h z8.s, p3/Z, [x10, z11.s, UXTW]       : ld1h   (%x10,%z11.s,uxtw)[16byte] %p3/z -> %z8.s
+848d4d6a : ld1h z10.s, p3/Z, [x11, z13.s, UXTW]      : ld1h   (%x11,%z13.s,uxtw)[16byte] %p3/z -> %z10.s
+848f51ac : ld1h z12.s, p4/Z, [x13, z15.s, UXTW]      : ld1h   (%x13,%z15.s,uxtw)[16byte] %p4/z -> %z12.s
+849151ee : ld1h z14.s, p4/Z, [x15, z17.s, UXTW]      : ld1h   (%x15,%z17.s,uxtw)[16byte] %p4/z -> %z14.s
+84935630 : ld1h z16.s, p5/Z, [x17, z19.s, UXTW]      : ld1h   (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s
+84945671 : ld1h z17.s, p5/Z, [x19, z20.s, UXTW]      : ld1h   (%x19,%z20.s,uxtw)[16byte] %p5/z -> %z17.s
+849656b3 : ld1h z19.s, p5/Z, [x21, z22.s, UXTW]      : ld1h   (%x21,%z22.s,uxtw)[16byte] %p5/z -> %z19.s
+84985af5 : ld1h z21.s, p6/Z, [x23, z24.s, UXTW]      : ld1h   (%x23,%z24.s,uxtw)[16byte] %p6/z -> %z21.s
+849a5b17 : ld1h z23.s, p6/Z, [x24, z26.s, UXTW]      : ld1h   (%x24,%z26.s,uxtw)[16byte] %p6/z -> %z23.s
+849c5f59 : ld1h z25.s, p7/Z, [x26, z28.s, UXTW]      : ld1h   (%x26,%z28.s,uxtw)[16byte] %p7/z -> %z25.s
+849e5f9b : ld1h z27.s, p7/Z, [x28, z30.s, UXTW]      : ld1h   (%x28,%z30.s,uxtw)[16byte] %p7/z -> %z27.s
+849f5fff : ld1h z31.s, p7/Z, [sp, z31.s, UXTW]       : ld1h   (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s
+84c04000 : ld1h z0.s, p0/Z, [x0, z0.s, SXTW]         : ld1h   (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s
+84c54482 : ld1h z2.s, p1/Z, [x4, z5.s, SXTW]         : ld1h   (%x4,%z5.s,sxtw)[16byte] %p1/z -> %z2.s
+84c748c4 : ld1h z4.s, p2/Z, [x6, z7.s, SXTW]         : ld1h   (%x6,%z7.s,sxtw)[16byte] %p2/z -> %z4.s
+84c94906 : ld1h z6.s, p2/Z, [x8, z9.s, SXTW]         : ld1h   (%x8,%z9.s,sxtw)[16byte] %p2/z -> %z6.s
+84cb4d48 : ld1h z8.s, p3/Z, [x10, z11.s, SXTW]       : ld1h   (%x10,%z11.s,sxtw)[16byte] %p3/z -> %z8.s
+84cd4d6a : ld1h z10.s, p3/Z, [x11, z13.s, SXTW]      : ld1h   (%x11,%z13.s,sxtw)[16byte] %p3/z -> %z10.s
+84cf51ac : ld1h z12.s, p4/Z, [x13, z15.s, SXTW]      : ld1h   (%x13,%z15.s,sxtw)[16byte] %p4/z -> %z12.s
+84d151ee : ld1h z14.s, p4/Z, [x15, z17.s, SXTW]      : ld1h   (%x15,%z17.s,sxtw)[16byte] %p4/z -> %z14.s
+84d35630 : ld1h z16.s, p5/Z, [x17, z19.s, SXTW]      : ld1h   (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s
+84d45671 : ld1h z17.s, p5/Z, [x19, z20.s, SXTW]      : ld1h   (%x19,%z20.s,sxtw)[16byte] %p5/z -> %z17.s
+84d656b3 : ld1h z19.s, p5/Z, [x21, z22.s, SXTW]      : ld1h   (%x21,%z22.s,sxtw)[16byte] %p5/z -> %z19.s
+84d85af5 : ld1h z21.s, p6/Z, [x23, z24.s, SXTW]      : ld1h   (%x23,%z24.s,sxtw)[16byte] %p6/z -> %z21.s
+84da5b17 : ld1h z23.s, p6/Z, [x24, z26.s, SXTW]      : ld1h   (%x24,%z26.s,sxtw)[16byte] %p6/z -> %z23.s
+84dc5f59 : ld1h z25.s, p7/Z, [x26, z28.s, SXTW]      : ld1h   (%x26,%z28.s,sxtw)[16byte] %p7/z -> %z25.s
+84de5f9b : ld1h z27.s, p7/Z, [x28, z30.s, SXTW]      : ld1h   (%x28,%z30.s,sxtw)[16byte] %p7/z -> %z27.s
+84df5fff : ld1h z31.s, p7/Z, [sp, z31.s, SXTW]       : ld1h   (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s
 
 # LD1RB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<pimm>}] (LD1RB-Z.P.BI-U16)
 8440a000 : ld1rb z0.h, p0/Z, [x0, #0]                : ld1rb  (%x0)[1byte] %p0/z -> %z0.h
@@ -11288,6 +11560,74 @@ c45c9f59 : ld1sb z25.d, p7/Z, [x26, z28.d]           : ld1sb  (%x26,%z28.d)[4byt
 c45e9f9b : ld1sb z27.d, p7/Z, [x28, z30.d]           : ld1sb  (%x28,%z30.d)[4byte] %p7/z -> %z27.d
 c45f9fff : ld1sb z31.d, p7/Z, [sp, z31.d]            : ld1sb  (%sp,%z31.d)[4byte] %p7/z -> %z31.d
 
+# LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1SB-Z.P.BZ-D.x32.unscaled)
+c4000000 : ld1sb z0.d, p0/Z, [x0, z0.d, UXTW]        : ld1sb  (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d
+c4050482 : ld1sb z2.d, p1/Z, [x4, z5.d, UXTW]        : ld1sb  (%x4,%z5.d,uxtw)[4byte] %p1/z -> %z2.d
+c40708c4 : ld1sb z4.d, p2/Z, [x6, z7.d, UXTW]        : ld1sb  (%x6,%z7.d,uxtw)[4byte] %p2/z -> %z4.d
+c4090906 : ld1sb z6.d, p2/Z, [x8, z9.d, UXTW]        : ld1sb  (%x8,%z9.d,uxtw)[4byte] %p2/z -> %z6.d
+c40b0d48 : ld1sb z8.d, p3/Z, [x10, z11.d, UXTW]      : ld1sb  (%x10,%z11.d,uxtw)[4byte] %p3/z -> %z8.d
+c40d0d6a : ld1sb z10.d, p3/Z, [x11, z13.d, UXTW]     : ld1sb  (%x11,%z13.d,uxtw)[4byte] %p3/z -> %z10.d
+c40f11ac : ld1sb z12.d, p4/Z, [x13, z15.d, UXTW]     : ld1sb  (%x13,%z15.d,uxtw)[4byte] %p4/z -> %z12.d
+c41111ee : ld1sb z14.d, p4/Z, [x15, z17.d, UXTW]     : ld1sb  (%x15,%z17.d,uxtw)[4byte] %p4/z -> %z14.d
+c4131630 : ld1sb z16.d, p5/Z, [x17, z19.d, UXTW]     : ld1sb  (%x17,%z19.d,uxtw)[4byte] %p5/z -> %z16.d
+c4141671 : ld1sb z17.d, p5/Z, [x19, z20.d, UXTW]     : ld1sb  (%x19,%z20.d,uxtw)[4byte] %p5/z -> %z17.d
+c41616b3 : ld1sb z19.d, p5/Z, [x21, z22.d, UXTW]     : ld1sb  (%x21,%z22.d,uxtw)[4byte] %p5/z -> %z19.d
+c4181af5 : ld1sb z21.d, p6/Z, [x23, z24.d, UXTW]     : ld1sb  (%x23,%z24.d,uxtw)[4byte] %p6/z -> %z21.d
+c41a1b17 : ld1sb z23.d, p6/Z, [x24, z26.d, UXTW]     : ld1sb  (%x24,%z26.d,uxtw)[4byte] %p6/z -> %z23.d
+c41c1f59 : ld1sb z25.d, p7/Z, [x26, z28.d, UXTW]     : ld1sb  (%x26,%z28.d,uxtw)[4byte] %p7/z -> %z25.d
+c41e1f9b : ld1sb z27.d, p7/Z, [x28, z30.d, UXTW]     : ld1sb  (%x28,%z30.d,uxtw)[4byte] %p7/z -> %z27.d
+c41f1fff : ld1sb z31.d, p7/Z, [sp, z31.d, UXTW]      : ld1sb  (%sp,%z31.d,uxtw)[4byte] %p7/z -> %z31.d
+c4400000 : ld1sb z0.d, p0/Z, [x0, z0.d, SXTW]        : ld1sb  (%x0,%z0.d,sxtw)[4byte] %p0/z -> %z0.d
+c4450482 : ld1sb z2.d, p1/Z, [x4, z5.d, SXTW]        : ld1sb  (%x4,%z5.d,sxtw)[4byte] %p1/z -> %z2.d
+c44708c4 : ld1sb z4.d, p2/Z, [x6, z7.d, SXTW]        : ld1sb  (%x6,%z7.d,sxtw)[4byte] %p2/z -> %z4.d
+c4490906 : ld1sb z6.d, p2/Z, [x8, z9.d, SXTW]        : ld1sb  (%x8,%z9.d,sxtw)[4byte] %p2/z -> %z6.d
+c44b0d48 : ld1sb z8.d, p3/Z, [x10, z11.d, SXTW]      : ld1sb  (%x10,%z11.d,sxtw)[4byte] %p3/z -> %z8.d
+c44d0d6a : ld1sb z10.d, p3/Z, [x11, z13.d, SXTW]     : ld1sb  (%x11,%z13.d,sxtw)[4byte] %p3/z -> %z10.d
+c44f11ac : ld1sb z12.d, p4/Z, [x13, z15.d, SXTW]     : ld1sb  (%x13,%z15.d,sxtw)[4byte] %p4/z -> %z12.d
+c45111ee : ld1sb z14.d, p4/Z, [x15, z17.d, SXTW]     : ld1sb  (%x15,%z17.d,sxtw)[4byte] %p4/z -> %z14.d
+c4531630 : ld1sb z16.d, p5/Z, [x17, z19.d, SXTW]     : ld1sb  (%x17,%z19.d,sxtw)[4byte] %p5/z -> %z16.d
+c4541671 : ld1sb z17.d, p5/Z, [x19, z20.d, SXTW]     : ld1sb  (%x19,%z20.d,sxtw)[4byte] %p5/z -> %z17.d
+c45616b3 : ld1sb z19.d, p5/Z, [x21, z22.d, SXTW]     : ld1sb  (%x21,%z22.d,sxtw)[4byte] %p5/z -> %z19.d
+c4581af5 : ld1sb z21.d, p6/Z, [x23, z24.d, SXTW]     : ld1sb  (%x23,%z24.d,sxtw)[4byte] %p6/z -> %z21.d
+c45a1b17 : ld1sb z23.d, p6/Z, [x24, z26.d, SXTW]     : ld1sb  (%x24,%z26.d,sxtw)[4byte] %p6/z -> %z23.d
+c45c1f59 : ld1sb z25.d, p7/Z, [x26, z28.d, SXTW]     : ld1sb  (%x26,%z28.d,sxtw)[4byte] %p7/z -> %z25.d
+c45e1f9b : ld1sb z27.d, p7/Z, [x28, z30.d, SXTW]     : ld1sb  (%x28,%z30.d,sxtw)[4byte] %p7/z -> %z27.d
+c45f1fff : ld1sb z31.d, p7/Z, [sp, z31.d, SXTW]      : ld1sb  (%sp,%z31.d,sxtw)[4byte] %p7/z -> %z31.d
+
+# LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LD1SB-Z.P.BZ-S.x32.unscaled)
+84000000 : ld1sb z0.s, p0/Z, [x0, z0.s, UXTW]        : ld1sb  (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s
+84050482 : ld1sb z2.s, p1/Z, [x4, z5.s, UXTW]        : ld1sb  (%x4,%z5.s,uxtw)[8byte] %p1/z -> %z2.s
+840708c4 : ld1sb z4.s, p2/Z, [x6, z7.s, UXTW]        : ld1sb  (%x6,%z7.s,uxtw)[8byte] %p2/z -> %z4.s
+84090906 : ld1sb z6.s, p2/Z, [x8, z9.s, UXTW]        : ld1sb  (%x8,%z9.s,uxtw)[8byte] %p2/z -> %z6.s
+840b0d48 : ld1sb z8.s, p3/Z, [x10, z11.s, UXTW]      : ld1sb  (%x10,%z11.s,uxtw)[8byte] %p3/z -> %z8.s
+840d0d6a : ld1sb z10.s, p3/Z, [x11, z13.s, UXTW]     : ld1sb  (%x11,%z13.s,uxtw)[8byte] %p3/z -> %z10.s
+840f11ac : ld1sb z12.s, p4/Z, [x13, z15.s, UXTW]     : ld1sb  (%x13,%z15.s,uxtw)[8byte] %p4/z -> %z12.s
+841111ee : ld1sb z14.s, p4/Z, [x15, z17.s, UXTW]     : ld1sb  (%x15,%z17.s,uxtw)[8byte] %p4/z -> %z14.s
+84131630 : ld1sb z16.s, p5/Z, [x17, z19.s, UXTW]     : ld1sb  (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s
+84141671 : ld1sb z17.s, p5/Z, [x19, z20.s, UXTW]     : ld1sb  (%x19,%z20.s,uxtw)[8byte] %p5/z -> %z17.s
+841616b3 : ld1sb z19.s, p5/Z, [x21, z22.s, UXTW]     : ld1sb  (%x21,%z22.s,uxtw)[8byte] %p5/z -> %z19.s
+84181af5 : ld1sb z21.s, p6/Z, [x23, z24.s, UXTW]     : ld1sb  (%x23,%z24.s,uxtw)[8byte] %p6/z -> %z21.s
+841a1b17 : ld1sb z23.s, p6/Z, [x24, z26.s, UXTW]     : ld1sb  (%x24,%z26.s,uxtw)[8byte] %p6/z -> %z23.s
+841c1f59 : ld1sb z25.s, p7/Z, [x26, z28.s, UXTW]     : ld1sb  (%x26,%z28.s,uxtw)[8byte] %p7/z -> %z25.s
+841e1f9b : ld1sb z27.s, p7/Z, [x28, z30.s, UXTW]     : ld1sb  (%x28,%z30.s,uxtw)[8byte] %p7/z -> %z27.s
+841f1fff : ld1sb z31.s, p7/Z, [sp, z31.s, UXTW]      : ld1sb  (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s
+84400000 : ld1sb z0.s, p0/Z, [x0, z0.s, SXTW]        : ld1sb  (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s
+84450482 : ld1sb z2.s, p1/Z, [x4, z5.s, SXTW]        : ld1sb  (%x4,%z5.s,sxtw)[8byte] %p1/z -> %z2.s
+844708c4 : ld1sb z4.s, p2/Z, [x6, z7.s, SXTW]        : ld1sb  (%x6,%z7.s,sxtw)[8byte] %p2/z -> %z4.s
+84490906 : ld1sb z6.s, p2/Z, [x8, z9.s, SXTW]        : ld1sb  (%x8,%z9.s,sxtw)[8byte] %p2/z -> %z6.s
+844b0d48 : ld1sb z8.s, p3/Z, [x10, z11.s, SXTW]      : ld1sb  (%x10,%z11.s,sxtw)[8byte] %p3/z -> %z8.s
+844d0d6a : ld1sb z10.s, p3/Z, [x11, z13.s, SXTW]     : ld1sb  (%x11,%z13.s,sxtw)[8byte] %p3/z -> %z10.s
+844f11ac : ld1sb z12.s, p4/Z, [x13, z15.s, SXTW]     : ld1sb  (%x13,%z15.s,sxtw)[8byte] %p4/z -> %z12.s
+845111ee : ld1sb z14.s, p4/Z, [x15, z17.s, SXTW]     : ld1sb  (%x15,%z17.s,sxtw)[8byte] %p4/z -> %z14.s
+84531630 : ld1sb z16.s, p5/Z, [x17, z19.s, SXTW]     : ld1sb  (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s
+84541671 : ld1sb z17.s, p5/Z, [x19, z20.s, SXTW]     : ld1sb  (%x19,%z20.s,sxtw)[8byte] %p5/z -> %z17.s
+845616b3 : ld1sb z19.s, p5/Z, [x21, z22.s, SXTW]     : ld1sb  (%x21,%z22.s,sxtw)[8byte] %p5/z -> %z19.s
+84581af5 : ld1sb z21.s, p6/Z, [x23, z24.s, SXTW]     : ld1sb  (%x23,%z24.s,sxtw)[8byte] %p6/z -> %z21.s
+845a1b17 : ld1sb z23.s, p6/Z, [x24, z26.s, SXTW]     : ld1sb  (%x24,%z26.s,sxtw)[8byte] %p6/z -> %z23.s
+845c1f59 : ld1sb z25.s, p7/Z, [x26, z28.s, SXTW]     : ld1sb  (%x26,%z28.s,sxtw)[8byte] %p7/z -> %z25.s
+845e1f9b : ld1sb z27.s, p7/Z, [x28, z30.s, SXTW]     : ld1sb  (%x28,%z30.s,sxtw)[8byte] %p7/z -> %z27.s
+845f1fff : ld1sb z31.s, p7/Z, [sp, z31.s, SXTW]      : ld1sb  (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s
+
 # LD1SH   { <Zt>.S }, <Pg>/Z, [<Zn>.S{, #<pimm>}] (LD1SH-Z.P.AI-S)
 84a08000 : ld1sh z0.s, p0/Z, [z0.s, #0]              : ld1sh  (%z0.s)[16byte] %p0/z -> %z0.s
 84a28482 : ld1sh z2.s, p1/Z, [z4.s, #4]              : ld1sh  +0x04(%z4.s)[16byte] %p1/z -> %z2.s
@@ -11360,6 +11700,142 @@ c4dc9f59 : ld1sh z25.d, p7/Z, [x26, z28.d]           : ld1sh  (%x26,%z28.d)[8byt
 c4de9f9b : ld1sh z27.d, p7/Z, [x28, z30.d]           : ld1sh  (%x28,%z30.d)[8byte] %p7/z -> %z27.d
 c4df9fff : ld1sh z31.d, p7/Z, [sp, z31.d]            : ld1sh  (%sp,%z31.d)[8byte] %p7/z -> %z31.d
 
+# LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] (LD1SH-Z.P.BZ-D.x32.scaled)
+c4a00000 : ld1sh z0.d, p0/Z, [x0, z0.d, UXTW #1]     : ld1sh  (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d
+c4a50482 : ld1sh z2.d, p1/Z, [x4, z5.d, UXTW #1]     : ld1sh  (%x4,%z5.d,uxtw #1)[8byte] %p1/z -> %z2.d
+c4a708c4 : ld1sh z4.d, p2/Z, [x6, z7.d, UXTW #1]     : ld1sh  (%x6,%z7.d,uxtw #1)[8byte] %p2/z -> %z4.d
+c4a90906 : ld1sh z6.d, p2/Z, [x8, z9.d, UXTW #1]     : ld1sh  (%x8,%z9.d,uxtw #1)[8byte] %p2/z -> %z6.d
+c4ab0d48 : ld1sh z8.d, p3/Z, [x10, z11.d, UXTW #1]   : ld1sh  (%x10,%z11.d,uxtw #1)[8byte] %p3/z -> %z8.d
+c4ad0d6a : ld1sh z10.d, p3/Z, [x11, z13.d, UXTW #1]  : ld1sh  (%x11,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d
+c4af11ac : ld1sh z12.d, p4/Z, [x13, z15.d, UXTW #1]  : ld1sh  (%x13,%z15.d,uxtw #1)[8byte] %p4/z -> %z12.d
+c4b111ee : ld1sh z14.d, p4/Z, [x15, z17.d, UXTW #1]  : ld1sh  (%x15,%z17.d,uxtw #1)[8byte] %p4/z -> %z14.d
+c4b31630 : ld1sh z16.d, p5/Z, [x17, z19.d, UXTW #1]  : ld1sh  (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d
+c4b41671 : ld1sh z17.d, p5/Z, [x19, z20.d, UXTW #1]  : ld1sh  (%x19,%z20.d,uxtw #1)[8byte] %p5/z -> %z17.d
+c4b616b3 : ld1sh z19.d, p5/Z, [x21, z22.d, UXTW #1]  : ld1sh  (%x21,%z22.d,uxtw #1)[8byte] %p5/z -> %z19.d
+c4b81af5 : ld1sh z21.d, p6/Z, [x23, z24.d, UXTW #1]  : ld1sh  (%x23,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d
+c4ba1b17 : ld1sh z23.d, p6/Z, [x24, z26.d, UXTW #1]  : ld1sh  (%x24,%z26.d,uxtw #1)[8byte] %p6/z -> %z23.d
+c4bc1f59 : ld1sh z25.d, p7/Z, [x26, z28.d, UXTW #1]  : ld1sh  (%x26,%z28.d,uxtw #1)[8byte] %p7/z -> %z25.d
+c4be1f9b : ld1sh z27.d, p7/Z, [x28, z30.d, UXTW #1]  : ld1sh  (%x28,%z30.d,uxtw #1)[8byte] %p7/z -> %z27.d
+c4bf1fff : ld1sh z31.d, p7/Z, [sp, z31.d, UXTW #1]   : ld1sh  (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d
+c4e00000 : ld1sh z0.d, p0/Z, [x0, z0.d, SXTW #1]     : ld1sh  (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d
+c4e50482 : ld1sh z2.d, p1/Z, [x4, z5.d, SXTW #1]     : ld1sh  (%x4,%z5.d,sxtw #1)[8byte] %p1/z -> %z2.d
+c4e708c4 : ld1sh z4.d, p2/Z, [x6, z7.d, SXTW #1]     : ld1sh  (%x6,%z7.d,sxtw #1)[8byte] %p2/z -> %z4.d
+c4e90906 : ld1sh z6.d, p2/Z, [x8, z9.d, SXTW #1]     : ld1sh  (%x8,%z9.d,sxtw #1)[8byte] %p2/z -> %z6.d
+c4eb0d48 : ld1sh z8.d, p3/Z, [x10, z11.d, SXTW #1]   : ld1sh  (%x10,%z11.d,sxtw #1)[8byte] %p3/z -> %z8.d
+c4ed0d6a : ld1sh z10.d, p3/Z, [x11, z13.d, SXTW #1]  : ld1sh  (%x11,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d
+c4ef11ac : ld1sh z12.d, p4/Z, [x13, z15.d, SXTW #1]  : ld1sh  (%x13,%z15.d,sxtw #1)[8byte] %p4/z -> %z12.d
+c4f111ee : ld1sh z14.d, p4/Z, [x15, z17.d, SXTW #1]  : ld1sh  (%x15,%z17.d,sxtw #1)[8byte] %p4/z -> %z14.d
+c4f31630 : ld1sh z16.d, p5/Z, [x17, z19.d, SXTW #1]  : ld1sh  (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d
+c4f41671 : ld1sh z17.d, p5/Z, [x19, z20.d, SXTW #1]  : ld1sh  (%x19,%z20.d,sxtw #1)[8byte] %p5/z -> %z17.d
+c4f616b3 : ld1sh z19.d, p5/Z, [x21, z22.d, SXTW #1]  : ld1sh  (%x21,%z22.d,sxtw #1)[8byte] %p5/z -> %z19.d
+c4f81af5 : ld1sh z21.d, p6/Z, [x23, z24.d, SXTW #1]  : ld1sh  (%x23,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d
+c4fa1b17 : ld1sh z23.d, p6/Z, [x24, z26.d, SXTW #1]  : ld1sh  (%x24,%z26.d,sxtw #1)[8byte] %p6/z -> %z23.d
+c4fc1f59 : ld1sh z25.d, p7/Z, [x26, z28.d, SXTW #1]  : ld1sh  (%x26,%z28.d,sxtw #1)[8byte] %p7/z -> %z25.d
+c4fe1f9b : ld1sh z27.d, p7/Z, [x28, z30.d, SXTW #1]  : ld1sh  (%x28,%z30.d,sxtw #1)[8byte] %p7/z -> %z27.d
+c4ff1fff : ld1sh z31.d, p7/Z, [sp, z31.d, SXTW #1]   : ld1sh  (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d
+
+# LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1SH-Z.P.BZ-D.x32.unscaled)
+c4800000 : ld1sh z0.d, p0/Z, [x0, z0.d, UXTW]        : ld1sh  (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d
+c4850482 : ld1sh z2.d, p1/Z, [x4, z5.d, UXTW]        : ld1sh  (%x4,%z5.d,uxtw)[8byte] %p1/z -> %z2.d
+c48708c4 : ld1sh z4.d, p2/Z, [x6, z7.d, UXTW]        : ld1sh  (%x6,%z7.d,uxtw)[8byte] %p2/z -> %z4.d
+c4890906 : ld1sh z6.d, p2/Z, [x8, z9.d, UXTW]        : ld1sh  (%x8,%z9.d,uxtw)[8byte] %p2/z -> %z6.d
+c48b0d48 : ld1sh z8.d, p3/Z, [x10, z11.d, UXTW]      : ld1sh  (%x10,%z11.d,uxtw)[8byte] %p3/z -> %z8.d
+c48d0d6a : ld1sh z10.d, p3/Z, [x11, z13.d, UXTW]     : ld1sh  (%x11,%z13.d,uxtw)[8byte] %p3/z -> %z10.d
+c48f11ac : ld1sh z12.d, p4/Z, [x13, z15.d, UXTW]     : ld1sh  (%x13,%z15.d,uxtw)[8byte] %p4/z -> %z12.d
+c49111ee : ld1sh z14.d, p4/Z, [x15, z17.d, UXTW]     : ld1sh  (%x15,%z17.d,uxtw)[8byte] %p4/z -> %z14.d
+c4931630 : ld1sh z16.d, p5/Z, [x17, z19.d, UXTW]     : ld1sh  (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d
+c4941671 : ld1sh z17.d, p5/Z, [x19, z20.d, UXTW]     : ld1sh  (%x19,%z20.d,uxtw)[8byte] %p5/z -> %z17.d
+c49616b3 : ld1sh z19.d, p5/Z, [x21, z22.d, UXTW]     : ld1sh  (%x21,%z22.d,uxtw)[8byte] %p5/z -> %z19.d
+c4981af5 : ld1sh z21.d, p6/Z, [x23, z24.d, UXTW]     : ld1sh  (%x23,%z24.d,uxtw)[8byte] %p6/z -> %z21.d
+c49a1b17 : ld1sh z23.d, p6/Z, [x24, z26.d, UXTW]     : ld1sh  (%x24,%z26.d,uxtw)[8byte] %p6/z -> %z23.d
+c49c1f59 : ld1sh z25.d, p7/Z, [x26, z28.d, UXTW]     : ld1sh  (%x26,%z28.d,uxtw)[8byte] %p7/z -> %z25.d
+c49e1f9b : ld1sh z27.d, p7/Z, [x28, z30.d, UXTW]     : ld1sh  (%x28,%z30.d,uxtw)[8byte] %p7/z -> %z27.d
+c49f1fff : ld1sh z31.d, p7/Z, [sp, z31.d, UXTW]      : ld1sh  (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d
+c4c00000 : ld1sh z0.d, p0/Z, [x0, z0.d, SXTW]        : ld1sh  (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d
+c4c50482 : ld1sh z2.d, p1/Z, [x4, z5.d, SXTW]        : ld1sh  (%x4,%z5.d,sxtw)[8byte] %p1/z -> %z2.d
+c4c708c4 : ld1sh z4.d, p2/Z, [x6, z7.d, SXTW]        : ld1sh  (%x6,%z7.d,sxtw)[8byte] %p2/z -> %z4.d
+c4c90906 : ld1sh z6.d, p2/Z, [x8, z9.d, SXTW]        : ld1sh  (%x8,%z9.d,sxtw)[8byte] %p2/z -> %z6.d
+c4cb0d48 : ld1sh z8.d, p3/Z, [x10, z11.d, SXTW]      : ld1sh  (%x10,%z11.d,sxtw)[8byte] %p3/z -> %z8.d
+c4cd0d6a : ld1sh z10.d, p3/Z, [x11, z13.d, SXTW]     : ld1sh  (%x11,%z13.d,sxtw)[8byte] %p3/z -> %z10.d
+c4cf11ac : ld1sh z12.d, p4/Z, [x13, z15.d, SXTW]     : ld1sh  (%x13,%z15.d,sxtw)[8byte] %p4/z -> %z12.d
+c4d111ee : ld1sh z14.d, p4/Z, [x15, z17.d, SXTW]     : ld1sh  (%x15,%z17.d,sxtw)[8byte] %p4/z -> %z14.d
+c4d31630 : ld1sh z16.d, p5/Z, [x17, z19.d, SXTW]     : ld1sh  (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d
+c4d41671 : ld1sh z17.d, p5/Z, [x19, z20.d, SXTW]     : ld1sh  (%x19,%z20.d,sxtw)[8byte] %p5/z -> %z17.d
+c4d616b3 : ld1sh z19.d, p5/Z, [x21, z22.d, SXTW]     : ld1sh  (%x21,%z22.d,sxtw)[8byte] %p5/z -> %z19.d
+c4d81af5 : ld1sh z21.d, p6/Z, [x23, z24.d, SXTW]     : ld1sh  (%x23,%z24.d,sxtw)[8byte] %p6/z -> %z21.d
+c4da1b17 : ld1sh z23.d, p6/Z, [x24, z26.d, SXTW]     : ld1sh  (%x24,%z26.d,sxtw)[8byte] %p6/z -> %z23.d
+c4dc1f59 : ld1sh z25.d, p7/Z, [x26, z28.d, SXTW]     : ld1sh  (%x26,%z28.d,sxtw)[8byte] %p7/z -> %z25.d
+c4de1f9b : ld1sh z27.d, p7/Z, [x28, z30.d, SXTW]     : ld1sh  (%x28,%z30.d,sxtw)[8byte] %p7/z -> %z27.d
+c4df1fff : ld1sh z31.d, p7/Z, [sp, z31.d, SXTW]      : ld1sh  (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d
+
+# LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] (LD1SH-Z.P.BZ-S.x32.scaled)
+84a00000 : ld1sh z0.s, p0/Z, [x0, z0.s, UXTW #1]     : ld1sh  (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s
+84a50482 : ld1sh z2.s, p1/Z, [x4, z5.s, UXTW #1]     : ld1sh  (%x4,%z5.s,uxtw #1)[16byte] %p1/z -> %z2.s
+84a708c4 : ld1sh z4.s, p2/Z, [x6, z7.s, UXTW #1]     : ld1sh  (%x6,%z7.s,uxtw #1)[16byte] %p2/z -> %z4.s
+84a90906 : ld1sh z6.s, p2/Z, [x8, z9.s, UXTW #1]     : ld1sh  (%x8,%z9.s,uxtw #1)[16byte] %p2/z -> %z6.s
+84ab0d48 : ld1sh z8.s, p3/Z, [x10, z11.s, UXTW #1]   : ld1sh  (%x10,%z11.s,uxtw #1)[16byte] %p3/z -> %z8.s
+84ad0d6a : ld1sh z10.s, p3/Z, [x11, z13.s, UXTW #1]  : ld1sh  (%x11,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s
+84af11ac : ld1sh z12.s, p4/Z, [x13, z15.s, UXTW #1]  : ld1sh  (%x13,%z15.s,uxtw #1)[16byte] %p4/z -> %z12.s
+84b111ee : ld1sh z14.s, p4/Z, [x15, z17.s, UXTW #1]  : ld1sh  (%x15,%z17.s,uxtw #1)[16byte] %p4/z -> %z14.s
+84b31630 : ld1sh z16.s, p5/Z, [x17, z19.s, UXTW #1]  : ld1sh  (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s
+84b41671 : ld1sh z17.s, p5/Z, [x19, z20.s, UXTW #1]  : ld1sh  (%x19,%z20.s,uxtw #1)[16byte] %p5/z -> %z17.s
+84b616b3 : ld1sh z19.s, p5/Z, [x21, z22.s, UXTW #1]  : ld1sh  (%x21,%z22.s,uxtw #1)[16byte] %p5/z -> %z19.s
+84b81af5 : ld1sh z21.s, p6/Z, [x23, z24.s, UXTW #1]  : ld1sh  (%x23,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s
+84ba1b17 : ld1sh z23.s, p6/Z, [x24, z26.s, UXTW #1]  : ld1sh  (%x24,%z26.s,uxtw #1)[16byte] %p6/z -> %z23.s
+84bc1f59 : ld1sh z25.s, p7/Z, [x26, z28.s, UXTW #1]  : ld1sh  (%x26,%z28.s,uxtw #1)[16byte] %p7/z -> %z25.s
+84be1f9b : ld1sh z27.s, p7/Z, [x28, z30.s, UXTW #1]  : ld1sh  (%x28,%z30.s,uxtw #1)[16byte] %p7/z -> %z27.s
+84bf1fff : ld1sh z31.s, p7/Z, [sp, z31.s, UXTW #1]   : ld1sh  (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s
+84e00000 : ld1sh z0.s, p0/Z, [x0, z0.s, SXTW #1]     : ld1sh  (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s
+84e50482 : ld1sh z2.s, p1/Z, [x4, z5.s, SXTW #1]     : ld1sh  (%x4,%z5.s,sxtw #1)[16byte] %p1/z -> %z2.s
+84e708c4 : ld1sh z4.s, p2/Z, [x6, z7.s, SXTW #1]     : ld1sh  (%x6,%z7.s,sxtw #1)[16byte] %p2/z -> %z4.s
+84e90906 : ld1sh z6.s, p2/Z, [x8, z9.s, SXTW #1]     : ld1sh  (%x8,%z9.s,sxtw #1)[16byte] %p2/z -> %z6.s
+84eb0d48 : ld1sh z8.s, p3/Z, [x10, z11.s, SXTW #1]   : ld1sh  (%x10,%z11.s,sxtw #1)[16byte] %p3/z -> %z8.s
+84ed0d6a : ld1sh z10.s, p3/Z, [x11, z13.s, SXTW #1]  : ld1sh  (%x11,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s
+84ef11ac : ld1sh z12.s, p4/Z, [x13, z15.s, SXTW #1]  : ld1sh  (%x13,%z15.s,sxtw #1)[16byte] %p4/z -> %z12.s
+84f111ee : ld1sh z14.s, p4/Z, [x15, z17.s, SXTW #1]  : ld1sh  (%x15,%z17.s,sxtw #1)[16byte] %p4/z -> %z14.s
+84f31630 : ld1sh z16.s, p5/Z, [x17, z19.s, SXTW #1]  : ld1sh  (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s
+84f41671 : ld1sh z17.s, p5/Z, [x19, z20.s, SXTW #1]  : ld1sh  (%x19,%z20.s,sxtw #1)[16byte] %p5/z -> %z17.s
+84f616b3 : ld1sh z19.s, p5/Z, [x21, z22.s, SXTW #1]  : ld1sh  (%x21,%z22.s,sxtw #1)[16byte] %p5/z -> %z19.s
+84f81af5 : ld1sh z21.s, p6/Z, [x23, z24.s, SXTW #1]  : ld1sh  (%x23,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s
+84fa1b17 : ld1sh z23.s, p6/Z, [x24, z26.s, SXTW #1]  : ld1sh  (%x24,%z26.s,sxtw #1)[16byte] %p6/z -> %z23.s
+84fc1f59 : ld1sh z25.s, p7/Z, [x26, z28.s, SXTW #1]  : ld1sh  (%x26,%z28.s,sxtw #1)[16byte] %p7/z -> %z25.s
+84fe1f9b : ld1sh z27.s, p7/Z, [x28, z30.s, SXTW #1]  : ld1sh  (%x28,%z30.s,sxtw #1)[16byte] %p7/z -> %z27.s
+84ff1fff : ld1sh z31.s, p7/Z, [sp, z31.s, SXTW #1]   : ld1sh  (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s
+
+# LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LD1SH-Z.P.BZ-S.x32.unscaled)
+84800000 : ld1sh z0.s, p0/Z, [x0, z0.s, UXTW]        : ld1sh  (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s
+84850482 : ld1sh z2.s, p1/Z, [x4, z5.s, UXTW]        : ld1sh  (%x4,%z5.s,uxtw)[16byte] %p1/z -> %z2.s
+848708c4 : ld1sh z4.s, p2/Z, [x6, z7.s, UXTW]        : ld1sh  (%x6,%z7.s,uxtw)[16byte] %p2/z -> %z4.s
+84890906 : ld1sh z6.s, p2/Z, [x8, z9.s, UXTW]        : ld1sh  (%x8,%z9.s,uxtw)[16byte] %p2/z -> %z6.s
+848b0d48 : ld1sh z8.s, p3/Z, [x10, z11.s, UXTW]      : ld1sh  (%x10,%z11.s,uxtw)[16byte] %p3/z -> %z8.s
+848d0d6a : ld1sh z10.s, p3/Z, [x11, z13.s, UXTW]     : ld1sh  (%x11,%z13.s,uxtw)[16byte] %p3/z -> %z10.s
+848f11ac : ld1sh z12.s, p4/Z, [x13, z15.s, UXTW]     : ld1sh  (%x13,%z15.s,uxtw)[16byte] %p4/z -> %z12.s
+849111ee : ld1sh z14.s, p4/Z, [x15, z17.s, UXTW]     : ld1sh  (%x15,%z17.s,uxtw)[16byte] %p4/z -> %z14.s
+84931630 : ld1sh z16.s, p5/Z, [x17, z19.s, UXTW]     : ld1sh  (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s
+84941671 : ld1sh z17.s, p5/Z, [x19, z20.s, UXTW]     : ld1sh  (%x19,%z20.s,uxtw)[16byte] %p5/z -> %z17.s
+849616b3 : ld1sh z19.s, p5/Z, [x21, z22.s, UXTW]     : ld1sh  (%x21,%z22.s,uxtw)[16byte] %p5/z -> %z19.s
+84981af5 : ld1sh z21.s, p6/Z, [x23, z24.s, UXTW]     : ld1sh  (%x23,%z24.s,uxtw)[16byte] %p6/z -> %z21.s
+849a1b17 : ld1sh z23.s, p6/Z, [x24, z26.s, UXTW]     : ld1sh  (%x24,%z26.s,uxtw)[16byte] %p6/z -> %z23.s
+849c1f59 : ld1sh z25.s, p7/Z, [x26, z28.s, UXTW]     : ld1sh  (%x26,%z28.s,uxtw)[16byte] %p7/z -> %z25.s
+849e1f9b : ld1sh z27.s, p7/Z, [x28, z30.s, UXTW]     : ld1sh  (%x28,%z30.s,uxtw)[16byte] %p7/z -> %z27.s
+849f1fff : ld1sh z31.s, p7/Z, [sp, z31.s, UXTW]      : ld1sh  (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s
+84c00000 : ld1sh z0.s, p0/Z, [x0, z0.s, SXTW]        : ld1sh  (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s
+84c50482 : ld1sh z2.s, p1/Z, [x4, z5.s, SXTW]        : ld1sh  (%x4,%z5.s,sxtw)[16byte] %p1/z -> %z2.s
+84c708c4 : ld1sh z4.s, p2/Z, [x6, z7.s, SXTW]        : ld1sh  (%x6,%z7.s,sxtw)[16byte] %p2/z -> %z4.s
+84c90906 : ld1sh z6.s, p2/Z, [x8, z9.s, SXTW]        : ld1sh  (%x8,%z9.s,sxtw)[16byte] %p2/z -> %z6.s
+84cb0d48 : ld1sh z8.s, p3/Z, [x10, z11.s, SXTW]      : ld1sh  (%x10,%z11.s,sxtw)[16byte] %p3/z -> %z8.s
+84cd0d6a : ld1sh z10.s, p3/Z, [x11, z13.s, SXTW]     : ld1sh  (%x11,%z13.s,sxtw)[16byte] %p3/z -> %z10.s
+84cf11ac : ld1sh z12.s, p4/Z, [x13, z15.s, SXTW]     : ld1sh  (%x13,%z15.s,sxtw)[16byte] %p4/z -> %z12.s
+84d111ee : ld1sh z14.s, p4/Z, [x15, z17.s, SXTW]     : ld1sh  (%x15,%z17.s,sxtw)[16byte] %p4/z -> %z14.s
+84d31630 : ld1sh z16.s, p5/Z, [x17, z19.s, SXTW]     : ld1sh  (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s
+84d41671 : ld1sh z17.s, p5/Z, [x19, z20.s, SXTW]     : ld1sh  (%x19,%z20.s,sxtw)[16byte] %p5/z -> %z17.s
+84d616b3 : ld1sh z19.s, p5/Z, [x21, z22.s, SXTW]     : ld1sh  (%x21,%z22.s,sxtw)[16byte] %p5/z -> %z19.s
+84d81af5 : ld1sh z21.s, p6/Z, [x23, z24.s, SXTW]     : ld1sh  (%x23,%z24.s,sxtw)[16byte] %p6/z -> %z21.s
+84da1b17 : ld1sh z23.s, p6/Z, [x24, z26.s, SXTW]     : ld1sh  (%x24,%z26.s,sxtw)[16byte] %p6/z -> %z23.s
+84dc1f59 : ld1sh z25.s, p7/Z, [x26, z28.s, SXTW]     : ld1sh  (%x26,%z28.s,sxtw)[16byte] %p7/z -> %z25.s
+84de1f9b : ld1sh z27.s, p7/Z, [x28, z30.s, SXTW]     : ld1sh  (%x28,%z30.s,sxtw)[16byte] %p7/z -> %z27.s
+84df1fff : ld1sh z31.s, p7/Z, [sp, z31.s, SXTW]      : ld1sh  (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s
+
 # LD1SW   { <Zt>.D }, <Pg>/Z, [<Zn>.D{, #<pimm>}] (LD1SW-Z.P.AI-D)
 c5208000 : ld1sw z0.d, p0/Z, [z0.d, #0]              : ld1sw  (%z0.d)[16byte] %p0/z -> %z0.d
 c5228482 : ld1sw z2.d, p1/Z, [z4.d, #8]              : ld1sw  +0x08(%z4.d)[16byte] %p1/z -> %z2.d
@@ -11413,6 +11889,74 @@ c55a9b17 : ld1sw z23.d, p6/Z, [x24, z26.d]           : ld1sw  (%x24,%z26.d)[16by
 c55c9f59 : ld1sw z25.d, p7/Z, [x26, z28.d]           : ld1sw  (%x26,%z28.d)[16byte] %p7/z -> %z25.d
 c55e9f9b : ld1sw z27.d, p7/Z, [x28, z30.d]           : ld1sw  (%x28,%z30.d)[16byte] %p7/z -> %z27.d
 c55f9fff : ld1sw z31.d, p7/Z, [sp, z31.d]            : ld1sw  (%sp,%z31.d)[16byte] %p7/z -> %z31.d
+
+# LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] (LD1SW-Z.P.BZ-D.x32.scaled)
+c5200000 : ld1sw z0.d, p0/Z, [x0, z0.d, UXTW #2]     : ld1sw  (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d
+c5250482 : ld1sw z2.d, p1/Z, [x4, z5.d, UXTW #2]     : ld1sw  (%x4,%z5.d,uxtw #2)[16byte] %p1/z -> %z2.d
+c52708c4 : ld1sw z4.d, p2/Z, [x6, z7.d, UXTW #2]     : ld1sw  (%x6,%z7.d,uxtw #2)[16byte] %p2/z -> %z4.d
+c5290906 : ld1sw z6.d, p2/Z, [x8, z9.d, UXTW #2]     : ld1sw  (%x8,%z9.d,uxtw #2)[16byte] %p2/z -> %z6.d
+c52b0d48 : ld1sw z8.d, p3/Z, [x10, z11.d, UXTW #2]   : ld1sw  (%x10,%z11.d,uxtw #2)[16byte] %p3/z -> %z8.d
+c52d0d6a : ld1sw z10.d, p3/Z, [x11, z13.d, UXTW #2]  : ld1sw  (%x11,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d
+c52f11ac : ld1sw z12.d, p4/Z, [x13, z15.d, UXTW #2]  : ld1sw  (%x13,%z15.d,uxtw #2)[16byte] %p4/z -> %z12.d
+c53111ee : ld1sw z14.d, p4/Z, [x15, z17.d, UXTW #2]  : ld1sw  (%x15,%z17.d,uxtw #2)[16byte] %p4/z -> %z14.d
+c5331630 : ld1sw z16.d, p5/Z, [x17, z19.d, UXTW #2]  : ld1sw  (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d
+c5341671 : ld1sw z17.d, p5/Z, [x19, z20.d, UXTW #2]  : ld1sw  (%x19,%z20.d,uxtw #2)[16byte] %p5/z -> %z17.d
+c53616b3 : ld1sw z19.d, p5/Z, [x21, z22.d, UXTW #2]  : ld1sw  (%x21,%z22.d,uxtw #2)[16byte] %p5/z -> %z19.d
+c5381af5 : ld1sw z21.d, p6/Z, [x23, z24.d, UXTW #2]  : ld1sw  (%x23,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d
+c53a1b17 : ld1sw z23.d, p6/Z, [x24, z26.d, UXTW #2]  : ld1sw  (%x24,%z26.d,uxtw #2)[16byte] %p6/z -> %z23.d
+c53c1f59 : ld1sw z25.d, p7/Z, [x26, z28.d, UXTW #2]  : ld1sw  (%x26,%z28.d,uxtw #2)[16byte] %p7/z -> %z25.d
+c53e1f9b : ld1sw z27.d, p7/Z, [x28, z30.d, UXTW #2]  : ld1sw  (%x28,%z30.d,uxtw #2)[16byte] %p7/z -> %z27.d
+c53f1fff : ld1sw z31.d, p7/Z, [sp, z31.d, UXTW #2]   : ld1sw  (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d
+c5600000 : ld1sw z0.d, p0/Z, [x0, z0.d, SXTW #2]     : ld1sw  (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d
+c5650482 : ld1sw z2.d, p1/Z, [x4, z5.d, SXTW #2]     : ld1sw  (%x4,%z5.d,sxtw #2)[16byte] %p1/z -> %z2.d
+c56708c4 : ld1sw z4.d, p2/Z, [x6, z7.d, SXTW #2]     : ld1sw  (%x6,%z7.d,sxtw #2)[16byte] %p2/z -> %z4.d
+c5690906 : ld1sw z6.d, p2/Z, [x8, z9.d, SXTW #2]     : ld1sw  (%x8,%z9.d,sxtw #2)[16byte] %p2/z -> %z6.d
+c56b0d48 : ld1sw z8.d, p3/Z, [x10, z11.d, SXTW #2]   : ld1sw  (%x10,%z11.d,sxtw #2)[16byte] %p3/z -> %z8.d
+c56d0d6a : ld1sw z10.d, p3/Z, [x11, z13.d, SXTW #2]  : ld1sw  (%x11,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d
+c56f11ac : ld1sw z12.d, p4/Z, [x13, z15.d, SXTW #2]  : ld1sw  (%x13,%z15.d,sxtw #2)[16byte] %p4/z -> %z12.d
+c57111ee : ld1sw z14.d, p4/Z, [x15, z17.d, SXTW #2]  : ld1sw  (%x15,%z17.d,sxtw #2)[16byte] %p4/z -> %z14.d
+c5731630 : ld1sw z16.d, p5/Z, [x17, z19.d, SXTW #2]  : ld1sw  (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d
+c5741671 : ld1sw z17.d, p5/Z, [x19, z20.d, SXTW #2]  : ld1sw  (%x19,%z20.d,sxtw #2)[16byte] %p5/z -> %z17.d
+c57616b3 : ld1sw z19.d, p5/Z, [x21, z22.d, SXTW #2]  : ld1sw  (%x21,%z22.d,sxtw #2)[16byte] %p5/z -> %z19.d
+c5781af5 : ld1sw z21.d, p6/Z, [x23, z24.d, SXTW #2]  : ld1sw  (%x23,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d
+c57a1b17 : ld1sw z23.d, p6/Z, [x24, z26.d, SXTW #2]  : ld1sw  (%x24,%z26.d,sxtw #2)[16byte] %p6/z -> %z23.d
+c57c1f59 : ld1sw z25.d, p7/Z, [x26, z28.d, SXTW #2]  : ld1sw  (%x26,%z28.d,sxtw #2)[16byte] %p7/z -> %z25.d
+c57e1f9b : ld1sw z27.d, p7/Z, [x28, z30.d, SXTW #2]  : ld1sw  (%x28,%z30.d,sxtw #2)[16byte] %p7/z -> %z27.d
+c57f1fff : ld1sw z31.d, p7/Z, [sp, z31.d, SXTW #2]   : ld1sw  (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d
+
+# LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1SW-Z.P.BZ-D.x32.unscaled)
+c5000000 : ld1sw z0.d, p0/Z, [x0, z0.d, UXTW]        : ld1sw  (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d
+c5050482 : ld1sw z2.d, p1/Z, [x4, z5.d, UXTW]        : ld1sw  (%x4,%z5.d,uxtw)[16byte] %p1/z -> %z2.d
+c50708c4 : ld1sw z4.d, p2/Z, [x6, z7.d, UXTW]        : ld1sw  (%x6,%z7.d,uxtw)[16byte] %p2/z -> %z4.d
+c5090906 : ld1sw z6.d, p2/Z, [x8, z9.d, UXTW]        : ld1sw  (%x8,%z9.d,uxtw)[16byte] %p2/z -> %z6.d
+c50b0d48 : ld1sw z8.d, p3/Z, [x10, z11.d, UXTW]      : ld1sw  (%x10,%z11.d,uxtw)[16byte] %p3/z -> %z8.d
+c50d0d6a : ld1sw z10.d, p3/Z, [x11, z13.d, UXTW]     : ld1sw  (%x11,%z13.d,uxtw)[16byte] %p3/z -> %z10.d
+c50f11ac : ld1sw z12.d, p4/Z, [x13, z15.d, UXTW]     : ld1sw  (%x13,%z15.d,uxtw)[16byte] %p4/z -> %z12.d
+c51111ee : ld1sw z14.d, p4/Z, [x15, z17.d, UXTW]     : ld1sw  (%x15,%z17.d,uxtw)[16byte] %p4/z -> %z14.d
+c5131630 : ld1sw z16.d, p5/Z, [x17, z19.d, UXTW]     : ld1sw  (%x17,%z19.d,uxtw)[16byte] %p5/z -> %z16.d
+c5141671 : ld1sw z17.d, p5/Z, [x19, z20.d, UXTW]     : ld1sw  (%x19,%z20.d,uxtw)[16byte] %p5/z -> %z17.d
+c51616b3 : ld1sw z19.d, p5/Z, [x21, z22.d, UXTW]     : ld1sw  (%x21,%z22.d,uxtw)[16byte] %p5/z -> %z19.d
+c5181af5 : ld1sw z21.d, p6/Z, [x23, z24.d, UXTW]     : ld1sw  (%x23,%z24.d,uxtw)[16byte] %p6/z -> %z21.d
+c51a1b17 : ld1sw z23.d, p6/Z, [x24, z26.d, UXTW]     : ld1sw  (%x24,%z26.d,uxtw)[16byte] %p6/z -> %z23.d
+c51c1f59 : ld1sw z25.d, p7/Z, [x26, z28.d, UXTW]     : ld1sw  (%x26,%z28.d,uxtw)[16byte] %p7/z -> %z25.d
+c51e1f9b : ld1sw z27.d, p7/Z, [x28, z30.d, UXTW]     : ld1sw  (%x28,%z30.d,uxtw)[16byte] %p7/z -> %z27.d
+c51f1fff : ld1sw z31.d, p7/Z, [sp, z31.d, UXTW]      : ld1sw  (%sp,%z31.d,uxtw)[16byte] %p7/z -> %z31.d
+c5400000 : ld1sw z0.d, p0/Z, [x0, z0.d, SXTW]        : ld1sw  (%x0,%z0.d,sxtw)[16byte] %p0/z -> %z0.d
+c5450482 : ld1sw z2.d, p1/Z, [x4, z5.d, SXTW]        : ld1sw  (%x4,%z5.d,sxtw)[16byte] %p1/z -> %z2.d
+c54708c4 : ld1sw z4.d, p2/Z, [x6, z7.d, SXTW]        : ld1sw  (%x6,%z7.d,sxtw)[16byte] %p2/z -> %z4.d
+c5490906 : ld1sw z6.d, p2/Z, [x8, z9.d, SXTW]        : ld1sw  (%x8,%z9.d,sxtw)[16byte] %p2/z -> %z6.d
+c54b0d48 : ld1sw z8.d, p3/Z, [x10, z11.d, SXTW]      : ld1sw  (%x10,%z11.d,sxtw)[16byte] %p3/z -> %z8.d
+c54d0d6a : ld1sw z10.d, p3/Z, [x11, z13.d, SXTW]     : ld1sw  (%x11,%z13.d,sxtw)[16byte] %p3/z -> %z10.d
+c54f11ac : ld1sw z12.d, p4/Z, [x13, z15.d, SXTW]     : ld1sw  (%x13,%z15.d,sxtw)[16byte] %p4/z -> %z12.d
+c55111ee : ld1sw z14.d, p4/Z, [x15, z17.d, SXTW]     : ld1sw  (%x15,%z17.d,sxtw)[16byte] %p4/z -> %z14.d
+c5531630 : ld1sw z16.d, p5/Z, [x17, z19.d, SXTW]     : ld1sw  (%x17,%z19.d,sxtw)[16byte] %p5/z -> %z16.d
+c5541671 : ld1sw z17.d, p5/Z, [x19, z20.d, SXTW]     : ld1sw  (%x19,%z20.d,sxtw)[16byte] %p5/z -> %z17.d
+c55616b3 : ld1sw z19.d, p5/Z, [x21, z22.d, SXTW]     : ld1sw  (%x21,%z22.d,sxtw)[16byte] %p5/z -> %z19.d
+c5581af5 : ld1sw z21.d, p6/Z, [x23, z24.d, SXTW]     : ld1sw  (%x23,%z24.d,sxtw)[16byte] %p6/z -> %z21.d
+c55a1b17 : ld1sw z23.d, p6/Z, [x24, z26.d, SXTW]     : ld1sw  (%x24,%z26.d,sxtw)[16byte] %p6/z -> %z23.d
+c55c1f59 : ld1sw z25.d, p7/Z, [x26, z28.d, SXTW]     : ld1sw  (%x26,%z28.d,sxtw)[16byte] %p7/z -> %z25.d
+c55e1f9b : ld1sw z27.d, p7/Z, [x28, z30.d, SXTW]     : ld1sw  (%x28,%z30.d,sxtw)[16byte] %p7/z -> %z27.d
+c55f1fff : ld1sw z31.d, p7/Z, [sp, z31.d, SXTW]      : ld1sw  (%sp,%z31.d,sxtw)[16byte] %p7/z -> %z31.d
 
 # LD1W    { <Zt>.S }, <Pg>/Z, [<Zn>.S{, #<pimm>}] (LD1W-Z.P.AI-S)
 8520c000 : ld1w z0.s, p0/Z, [z0.s, #0]               : ld1w   (%z0.s)[32byte] %p0/z -> %z0.s
@@ -11485,6 +12029,142 @@ c55adb17 : ld1w z23.d, p6/Z, [x24, z26.d]            : ld1w   (%x24,%z26.d)[16by
 c55cdf59 : ld1w z25.d, p7/Z, [x26, z28.d]            : ld1w   (%x26,%z28.d)[16byte] %p7/z -> %z25.d
 c55edf9b : ld1w z27.d, p7/Z, [x28, z30.d]            : ld1w   (%x28,%z30.d)[16byte] %p7/z -> %z27.d
 c55fdfff : ld1w z31.d, p7/Z, [sp, z31.d]             : ld1w   (%sp,%z31.d)[16byte] %p7/z -> %z31.d
+
+# LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] (LD1W-Z.P.BZ-D.x32.scaled)
+c5204000 : ld1w z0.d, p0/Z, [x0, z0.d, UXTW #2]      : ld1w   (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d
+c5254482 : ld1w z2.d, p1/Z, [x4, z5.d, UXTW #2]      : ld1w   (%x4,%z5.d,uxtw #2)[16byte] %p1/z -> %z2.d
+c52748c4 : ld1w z4.d, p2/Z, [x6, z7.d, UXTW #2]      : ld1w   (%x6,%z7.d,uxtw #2)[16byte] %p2/z -> %z4.d
+c5294906 : ld1w z6.d, p2/Z, [x8, z9.d, UXTW #2]      : ld1w   (%x8,%z9.d,uxtw #2)[16byte] %p2/z -> %z6.d
+c52b4d48 : ld1w z8.d, p3/Z, [x10, z11.d, UXTW #2]    : ld1w   (%x10,%z11.d,uxtw #2)[16byte] %p3/z -> %z8.d
+c52d4d6a : ld1w z10.d, p3/Z, [x11, z13.d, UXTW #2]   : ld1w   (%x11,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d
+c52f51ac : ld1w z12.d, p4/Z, [x13, z15.d, UXTW #2]   : ld1w   (%x13,%z15.d,uxtw #2)[16byte] %p4/z -> %z12.d
+c53151ee : ld1w z14.d, p4/Z, [x15, z17.d, UXTW #2]   : ld1w   (%x15,%z17.d,uxtw #2)[16byte] %p4/z -> %z14.d
+c5335630 : ld1w z16.d, p5/Z, [x17, z19.d, UXTW #2]   : ld1w   (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d
+c5345671 : ld1w z17.d, p5/Z, [x19, z20.d, UXTW #2]   : ld1w   (%x19,%z20.d,uxtw #2)[16byte] %p5/z -> %z17.d
+c53656b3 : ld1w z19.d, p5/Z, [x21, z22.d, UXTW #2]   : ld1w   (%x21,%z22.d,uxtw #2)[16byte] %p5/z -> %z19.d
+c5385af5 : ld1w z21.d, p6/Z, [x23, z24.d, UXTW #2]   : ld1w   (%x23,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d
+c53a5b17 : ld1w z23.d, p6/Z, [x24, z26.d, UXTW #2]   : ld1w   (%x24,%z26.d,uxtw #2)[16byte] %p6/z -> %z23.d
+c53c5f59 : ld1w z25.d, p7/Z, [x26, z28.d, UXTW #2]   : ld1w   (%x26,%z28.d,uxtw #2)[16byte] %p7/z -> %z25.d
+c53e5f9b : ld1w z27.d, p7/Z, [x28, z30.d, UXTW #2]   : ld1w   (%x28,%z30.d,uxtw #2)[16byte] %p7/z -> %z27.d
+c53f5fff : ld1w z31.d, p7/Z, [sp, z31.d, UXTW #2]    : ld1w   (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d
+c5604000 : ld1w z0.d, p0/Z, [x0, z0.d, SXTW #2]      : ld1w   (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d
+c5654482 : ld1w z2.d, p1/Z, [x4, z5.d, SXTW #2]      : ld1w   (%x4,%z5.d,sxtw #2)[16byte] %p1/z -> %z2.d
+c56748c4 : ld1w z4.d, p2/Z, [x6, z7.d, SXTW #2]      : ld1w   (%x6,%z7.d,sxtw #2)[16byte] %p2/z -> %z4.d
+c5694906 : ld1w z6.d, p2/Z, [x8, z9.d, SXTW #2]      : ld1w   (%x8,%z9.d,sxtw #2)[16byte] %p2/z -> %z6.d
+c56b4d48 : ld1w z8.d, p3/Z, [x10, z11.d, SXTW #2]    : ld1w   (%x10,%z11.d,sxtw #2)[16byte] %p3/z -> %z8.d
+c56d4d6a : ld1w z10.d, p3/Z, [x11, z13.d, SXTW #2]   : ld1w   (%x11,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d
+c56f51ac : ld1w z12.d, p4/Z, [x13, z15.d, SXTW #2]   : ld1w   (%x13,%z15.d,sxtw #2)[16byte] %p4/z -> %z12.d
+c57151ee : ld1w z14.d, p4/Z, [x15, z17.d, SXTW #2]   : ld1w   (%x15,%z17.d,sxtw #2)[16byte] %p4/z -> %z14.d
+c5735630 : ld1w z16.d, p5/Z, [x17, z19.d, SXTW #2]   : ld1w   (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d
+c5745671 : ld1w z17.d, p5/Z, [x19, z20.d, SXTW #2]   : ld1w   (%x19,%z20.d,sxtw #2)[16byte] %p5/z -> %z17.d
+c57656b3 : ld1w z19.d, p5/Z, [x21, z22.d, SXTW #2]   : ld1w   (%x21,%z22.d,sxtw #2)[16byte] %p5/z -> %z19.d
+c5785af5 : ld1w z21.d, p6/Z, [x23, z24.d, SXTW #2]   : ld1w   (%x23,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d
+c57a5b17 : ld1w z23.d, p6/Z, [x24, z26.d, SXTW #2]   : ld1w   (%x24,%z26.d,sxtw #2)[16byte] %p6/z -> %z23.d
+c57c5f59 : ld1w z25.d, p7/Z, [x26, z28.d, SXTW #2]   : ld1w   (%x26,%z28.d,sxtw #2)[16byte] %p7/z -> %z25.d
+c57e5f9b : ld1w z27.d, p7/Z, [x28, z30.d, SXTW #2]   : ld1w   (%x28,%z30.d,sxtw #2)[16byte] %p7/z -> %z27.d
+c57f5fff : ld1w z31.d, p7/Z, [sp, z31.d, SXTW #2]    : ld1w   (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d
+
+# LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1W-Z.P.BZ-D.x32.unscaled)
+c5004000 : ld1w z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1w   (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d
+c5054482 : ld1w z2.d, p1/Z, [x4, z5.d, UXTW]         : ld1w   (%x4,%z5.d,uxtw)[16byte] %p1/z -> %z2.d
+c50748c4 : ld1w z4.d, p2/Z, [x6, z7.d, UXTW]         : ld1w   (%x6,%z7.d,uxtw)[16byte] %p2/z -> %z4.d
+c5094906 : ld1w z6.d, p2/Z, [x8, z9.d, UXTW]         : ld1w   (%x8,%z9.d,uxtw)[16byte] %p2/z -> %z6.d
+c50b4d48 : ld1w z8.d, p3/Z, [x10, z11.d, UXTW]       : ld1w   (%x10,%z11.d,uxtw)[16byte] %p3/z -> %z8.d
+c50d4d6a : ld1w z10.d, p3/Z, [x11, z13.d, UXTW]      : ld1w   (%x11,%z13.d,uxtw)[16byte] %p3/z -> %z10.d
+c50f51ac : ld1w z12.d, p4/Z, [x13, z15.d, UXTW]      : ld1w   (%x13,%z15.d,uxtw)[16byte] %p4/z -> %z12.d
+c51151ee : ld1w z14.d, p4/Z, [x15, z17.d, UXTW]      : ld1w   (%x15,%z17.d,uxtw)[16byte] %p4/z -> %z14.d
+c5135630 : ld1w z16.d, p5/Z, [x17, z19.d, UXTW]      : ld1w   (%x17,%z19.d,uxtw)[16byte] %p5/z -> %z16.d
+c5145671 : ld1w z17.d, p5/Z, [x19, z20.d, UXTW]      : ld1w   (%x19,%z20.d,uxtw)[16byte] %p5/z -> %z17.d
+c51656b3 : ld1w z19.d, p5/Z, [x21, z22.d, UXTW]      : ld1w   (%x21,%z22.d,uxtw)[16byte] %p5/z -> %z19.d
+c5185af5 : ld1w z21.d, p6/Z, [x23, z24.d, UXTW]      : ld1w   (%x23,%z24.d,uxtw)[16byte] %p6/z -> %z21.d
+c51a5b17 : ld1w z23.d, p6/Z, [x24, z26.d, UXTW]      : ld1w   (%x24,%z26.d,uxtw)[16byte] %p6/z -> %z23.d
+c51c5f59 : ld1w z25.d, p7/Z, [x26, z28.d, UXTW]      : ld1w   (%x26,%z28.d,uxtw)[16byte] %p7/z -> %z25.d
+c51e5f9b : ld1w z27.d, p7/Z, [x28, z30.d, UXTW]      : ld1w   (%x28,%z30.d,uxtw)[16byte] %p7/z -> %z27.d
+c51f5fff : ld1w z31.d, p7/Z, [sp, z31.d, UXTW]       : ld1w   (%sp,%z31.d,uxtw)[16byte] %p7/z -> %z31.d
+c5404000 : ld1w z0.d, p0/Z, [x0, z0.d, SXTW]         : ld1w   (%x0,%z0.d,sxtw)[16byte] %p0/z -> %z0.d
+c5454482 : ld1w z2.d, p1/Z, [x4, z5.d, SXTW]         : ld1w   (%x4,%z5.d,sxtw)[16byte] %p1/z -> %z2.d
+c54748c4 : ld1w z4.d, p2/Z, [x6, z7.d, SXTW]         : ld1w   (%x6,%z7.d,sxtw)[16byte] %p2/z -> %z4.d
+c5494906 : ld1w z6.d, p2/Z, [x8, z9.d, SXTW]         : ld1w   (%x8,%z9.d,sxtw)[16byte] %p2/z -> %z6.d
+c54b4d48 : ld1w z8.d, p3/Z, [x10, z11.d, SXTW]       : ld1w   (%x10,%z11.d,sxtw)[16byte] %p3/z -> %z8.d
+c54d4d6a : ld1w z10.d, p3/Z, [x11, z13.d, SXTW]      : ld1w   (%x11,%z13.d,sxtw)[16byte] %p3/z -> %z10.d
+c54f51ac : ld1w z12.d, p4/Z, [x13, z15.d, SXTW]      : ld1w   (%x13,%z15.d,sxtw)[16byte] %p4/z -> %z12.d
+c55151ee : ld1w z14.d, p4/Z, [x15, z17.d, SXTW]      : ld1w   (%x15,%z17.d,sxtw)[16byte] %p4/z -> %z14.d
+c5535630 : ld1w z16.d, p5/Z, [x17, z19.d, SXTW]      : ld1w   (%x17,%z19.d,sxtw)[16byte] %p5/z -> %z16.d
+c5545671 : ld1w z17.d, p5/Z, [x19, z20.d, SXTW]      : ld1w   (%x19,%z20.d,sxtw)[16byte] %p5/z -> %z17.d
+c55656b3 : ld1w z19.d, p5/Z, [x21, z22.d, SXTW]      : ld1w   (%x21,%z22.d,sxtw)[16byte] %p5/z -> %z19.d
+c5585af5 : ld1w z21.d, p6/Z, [x23, z24.d, SXTW]      : ld1w   (%x23,%z24.d,sxtw)[16byte] %p6/z -> %z21.d
+c55a5b17 : ld1w z23.d, p6/Z, [x24, z26.d, SXTW]      : ld1w   (%x24,%z26.d,sxtw)[16byte] %p6/z -> %z23.d
+c55c5f59 : ld1w z25.d, p7/Z, [x26, z28.d, SXTW]      : ld1w   (%x26,%z28.d,sxtw)[16byte] %p7/z -> %z25.d
+c55e5f9b : ld1w z27.d, p7/Z, [x28, z30.d, SXTW]      : ld1w   (%x28,%z30.d,sxtw)[16byte] %p7/z -> %z27.d
+c55f5fff : ld1w z31.d, p7/Z, [sp, z31.d, SXTW]       : ld1w   (%sp,%z31.d,sxtw)[16byte] %p7/z -> %z31.d
+
+# LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2] (LD1W-Z.P.BZ-S.x32.scaled)
+85204000 : ld1w z0.s, p0/Z, [x0, z0.s, UXTW #2]      : ld1w   (%x0,%z0.s,uxtw #2)[32byte] %p0/z -> %z0.s
+85254482 : ld1w z2.s, p1/Z, [x4, z5.s, UXTW #2]      : ld1w   (%x4,%z5.s,uxtw #2)[32byte] %p1/z -> %z2.s
+852748c4 : ld1w z4.s, p2/Z, [x6, z7.s, UXTW #2]      : ld1w   (%x6,%z7.s,uxtw #2)[32byte] %p2/z -> %z4.s
+85294906 : ld1w z6.s, p2/Z, [x8, z9.s, UXTW #2]      : ld1w   (%x8,%z9.s,uxtw #2)[32byte] %p2/z -> %z6.s
+852b4d48 : ld1w z8.s, p3/Z, [x10, z11.s, UXTW #2]    : ld1w   (%x10,%z11.s,uxtw #2)[32byte] %p3/z -> %z8.s
+852d4d6a : ld1w z10.s, p3/Z, [x11, z13.s, UXTW #2]   : ld1w   (%x11,%z13.s,uxtw #2)[32byte] %p3/z -> %z10.s
+852f51ac : ld1w z12.s, p4/Z, [x13, z15.s, UXTW #2]   : ld1w   (%x13,%z15.s,uxtw #2)[32byte] %p4/z -> %z12.s
+853151ee : ld1w z14.s, p4/Z, [x15, z17.s, UXTW #2]   : ld1w   (%x15,%z17.s,uxtw #2)[32byte] %p4/z -> %z14.s
+85335630 : ld1w z16.s, p5/Z, [x17, z19.s, UXTW #2]   : ld1w   (%x17,%z19.s,uxtw #2)[32byte] %p5/z -> %z16.s
+85345671 : ld1w z17.s, p5/Z, [x19, z20.s, UXTW #2]   : ld1w   (%x19,%z20.s,uxtw #2)[32byte] %p5/z -> %z17.s
+853656b3 : ld1w z19.s, p5/Z, [x21, z22.s, UXTW #2]   : ld1w   (%x21,%z22.s,uxtw #2)[32byte] %p5/z -> %z19.s
+85385af5 : ld1w z21.s, p6/Z, [x23, z24.s, UXTW #2]   : ld1w   (%x23,%z24.s,uxtw #2)[32byte] %p6/z -> %z21.s
+853a5b17 : ld1w z23.s, p6/Z, [x24, z26.s, UXTW #2]   : ld1w   (%x24,%z26.s,uxtw #2)[32byte] %p6/z -> %z23.s
+853c5f59 : ld1w z25.s, p7/Z, [x26, z28.s, UXTW #2]   : ld1w   (%x26,%z28.s,uxtw #2)[32byte] %p7/z -> %z25.s
+853e5f9b : ld1w z27.s, p7/Z, [x28, z30.s, UXTW #2]   : ld1w   (%x28,%z30.s,uxtw #2)[32byte] %p7/z -> %z27.s
+853f5fff : ld1w z31.s, p7/Z, [sp, z31.s, UXTW #2]    : ld1w   (%sp,%z31.s,uxtw #2)[32byte] %p7/z -> %z31.s
+85604000 : ld1w z0.s, p0/Z, [x0, z0.s, SXTW #2]      : ld1w   (%x0,%z0.s,sxtw #2)[32byte] %p0/z -> %z0.s
+85654482 : ld1w z2.s, p1/Z, [x4, z5.s, SXTW #2]      : ld1w   (%x4,%z5.s,sxtw #2)[32byte] %p1/z -> %z2.s
+856748c4 : ld1w z4.s, p2/Z, [x6, z7.s, SXTW #2]      : ld1w   (%x6,%z7.s,sxtw #2)[32byte] %p2/z -> %z4.s
+85694906 : ld1w z6.s, p2/Z, [x8, z9.s, SXTW #2]      : ld1w   (%x8,%z9.s,sxtw #2)[32byte] %p2/z -> %z6.s
+856b4d48 : ld1w z8.s, p3/Z, [x10, z11.s, SXTW #2]    : ld1w   (%x10,%z11.s,sxtw #2)[32byte] %p3/z -> %z8.s
+856d4d6a : ld1w z10.s, p3/Z, [x11, z13.s, SXTW #2]   : ld1w   (%x11,%z13.s,sxtw #2)[32byte] %p3/z -> %z10.s
+856f51ac : ld1w z12.s, p4/Z, [x13, z15.s, SXTW #2]   : ld1w   (%x13,%z15.s,sxtw #2)[32byte] %p4/z -> %z12.s
+857151ee : ld1w z14.s, p4/Z, [x15, z17.s, SXTW #2]   : ld1w   (%x15,%z17.s,sxtw #2)[32byte] %p4/z -> %z14.s
+85735630 : ld1w z16.s, p5/Z, [x17, z19.s, SXTW #2]   : ld1w   (%x17,%z19.s,sxtw #2)[32byte] %p5/z -> %z16.s
+85745671 : ld1w z17.s, p5/Z, [x19, z20.s, SXTW #2]   : ld1w   (%x19,%z20.s,sxtw #2)[32byte] %p5/z -> %z17.s
+857656b3 : ld1w z19.s, p5/Z, [x21, z22.s, SXTW #2]   : ld1w   (%x21,%z22.s,sxtw #2)[32byte] %p5/z -> %z19.s
+85785af5 : ld1w z21.s, p6/Z, [x23, z24.s, SXTW #2]   : ld1w   (%x23,%z24.s,sxtw #2)[32byte] %p6/z -> %z21.s
+857a5b17 : ld1w z23.s, p6/Z, [x24, z26.s, SXTW #2]   : ld1w   (%x24,%z26.s,sxtw #2)[32byte] %p6/z -> %z23.s
+857c5f59 : ld1w z25.s, p7/Z, [x26, z28.s, SXTW #2]   : ld1w   (%x26,%z28.s,sxtw #2)[32byte] %p7/z -> %z25.s
+857e5f9b : ld1w z27.s, p7/Z, [x28, z30.s, SXTW #2]   : ld1w   (%x28,%z30.s,sxtw #2)[32byte] %p7/z -> %z27.s
+857f5fff : ld1w z31.s, p7/Z, [sp, z31.s, SXTW #2]    : ld1w   (%sp,%z31.s,sxtw #2)[32byte] %p7/z -> %z31.s
+
+# LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LD1W-Z.P.BZ-S.x32.unscaled)
+85004000 : ld1w z0.s, p0/Z, [x0, z0.s, UXTW]         : ld1w   (%x0,%z0.s,uxtw)[32byte] %p0/z -> %z0.s
+85054482 : ld1w z2.s, p1/Z, [x4, z5.s, UXTW]         : ld1w   (%x4,%z5.s,uxtw)[32byte] %p1/z -> %z2.s
+850748c4 : ld1w z4.s, p2/Z, [x6, z7.s, UXTW]         : ld1w   (%x6,%z7.s,uxtw)[32byte] %p2/z -> %z4.s
+85094906 : ld1w z6.s, p2/Z, [x8, z9.s, UXTW]         : ld1w   (%x8,%z9.s,uxtw)[32byte] %p2/z -> %z6.s
+850b4d48 : ld1w z8.s, p3/Z, [x10, z11.s, UXTW]       : ld1w   (%x10,%z11.s,uxtw)[32byte] %p3/z -> %z8.s
+850d4d6a : ld1w z10.s, p3/Z, [x11, z13.s, UXTW]      : ld1w   (%x11,%z13.s,uxtw)[32byte] %p3/z -> %z10.s
+850f51ac : ld1w z12.s, p4/Z, [x13, z15.s, UXTW]      : ld1w   (%x13,%z15.s,uxtw)[32byte] %p4/z -> %z12.s
+851151ee : ld1w z14.s, p4/Z, [x15, z17.s, UXTW]      : ld1w   (%x15,%z17.s,uxtw)[32byte] %p4/z -> %z14.s
+85135630 : ld1w z16.s, p5/Z, [x17, z19.s, UXTW]      : ld1w   (%x17,%z19.s,uxtw)[32byte] %p5/z -> %z16.s
+85145671 : ld1w z17.s, p5/Z, [x19, z20.s, UXTW]      : ld1w   (%x19,%z20.s,uxtw)[32byte] %p5/z -> %z17.s
+851656b3 : ld1w z19.s, p5/Z, [x21, z22.s, UXTW]      : ld1w   (%x21,%z22.s,uxtw)[32byte] %p5/z -> %z19.s
+85185af5 : ld1w z21.s, p6/Z, [x23, z24.s, UXTW]      : ld1w   (%x23,%z24.s,uxtw)[32byte] %p6/z -> %z21.s
+851a5b17 : ld1w z23.s, p6/Z, [x24, z26.s, UXTW]      : ld1w   (%x24,%z26.s,uxtw)[32byte] %p6/z -> %z23.s
+851c5f59 : ld1w z25.s, p7/Z, [x26, z28.s, UXTW]      : ld1w   (%x26,%z28.s,uxtw)[32byte] %p7/z -> %z25.s
+851e5f9b : ld1w z27.s, p7/Z, [x28, z30.s, UXTW]      : ld1w   (%x28,%z30.s,uxtw)[32byte] %p7/z -> %z27.s
+851f5fff : ld1w z31.s, p7/Z, [sp, z31.s, UXTW]       : ld1w   (%sp,%z31.s,uxtw)[32byte] %p7/z -> %z31.s
+85404000 : ld1w z0.s, p0/Z, [x0, z0.s, SXTW]         : ld1w   (%x0,%z0.s,sxtw)[32byte] %p0/z -> %z0.s
+85454482 : ld1w z2.s, p1/Z, [x4, z5.s, SXTW]         : ld1w   (%x4,%z5.s,sxtw)[32byte] %p1/z -> %z2.s
+854748c4 : ld1w z4.s, p2/Z, [x6, z7.s, SXTW]         : ld1w   (%x6,%z7.s,sxtw)[32byte] %p2/z -> %z4.s
+85494906 : ld1w z6.s, p2/Z, [x8, z9.s, SXTW]         : ld1w   (%x8,%z9.s,sxtw)[32byte] %p2/z -> %z6.s
+854b4d48 : ld1w z8.s, p3/Z, [x10, z11.s, SXTW]       : ld1w   (%x10,%z11.s,sxtw)[32byte] %p3/z -> %z8.s
+854d4d6a : ld1w z10.s, p3/Z, [x11, z13.s, SXTW]      : ld1w   (%x11,%z13.s,sxtw)[32byte] %p3/z -> %z10.s
+854f51ac : ld1w z12.s, p4/Z, [x13, z15.s, SXTW]      : ld1w   (%x13,%z15.s,sxtw)[32byte] %p4/z -> %z12.s
+855151ee : ld1w z14.s, p4/Z, [x15, z17.s, SXTW]      : ld1w   (%x15,%z17.s,sxtw)[32byte] %p4/z -> %z14.s
+85535630 : ld1w z16.s, p5/Z, [x17, z19.s, SXTW]      : ld1w   (%x17,%z19.s,sxtw)[32byte] %p5/z -> %z16.s
+85545671 : ld1w z17.s, p5/Z, [x19, z20.s, SXTW]      : ld1w   (%x19,%z20.s,sxtw)[32byte] %p5/z -> %z17.s
+855656b3 : ld1w z19.s, p5/Z, [x21, z22.s, SXTW]      : ld1w   (%x21,%z22.s,sxtw)[32byte] %p5/z -> %z19.s
+85585af5 : ld1w z21.s, p6/Z, [x23, z24.s, SXTW]      : ld1w   (%x23,%z24.s,sxtw)[32byte] %p6/z -> %z21.s
+855a5b17 : ld1w z23.s, p6/Z, [x24, z26.s, SXTW]      : ld1w   (%x24,%z26.s,sxtw)[32byte] %p6/z -> %z23.s
+855c5f59 : ld1w z25.s, p7/Z, [x26, z28.s, SXTW]      : ld1w   (%x26,%z28.s,sxtw)[32byte] %p7/z -> %z25.s
+855e5f9b : ld1w z27.s, p7/Z, [x28, z30.s, SXTW]      : ld1w   (%x28,%z30.s,sxtw)[32byte] %p7/z -> %z27.s
+855f5fff : ld1w z31.s, p7/Z, [sp, z31.s, SXTW]       : ld1w   (%sp,%z31.s,sxtw)[32byte] %p7/z -> %z31.s
 
 # LDFF1B  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, <Xm>}] (LDFF1B-Z.P.BR-U16)
 a4206000 : ldff1b z0.h, p0/Z, [x0, x0]               : ldff1b (%x0,%x0)[16byte] %p0/z -> %z0.h
@@ -11594,6 +12274,92 @@ c439ff79 : ldff1b z25.d, p7/Z, [z27.d, #25]          : ldff1b +0x19(%z27.d)[4byt
 c43bffbb : ldff1b z27.d, p7/Z, [z29.d, #27]          : ldff1b +0x1b(%z29.d)[4byte] %p7/z -> %z27.d
 c43fffff : ldff1b z31.d, p7/Z, [z31.d, #31]          : ldff1b +0x1f(%z31.d)[4byte] %p7/z -> %z31.d
 
+# LDFF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D] (LDFF1B-Z.P.BZ-D.64.unscaled)
+c440e000 : ldff1b z0.d, p0/Z, [x0, z0.d]             : ldff1b (%x0,%z0.d)[4byte] %p0/z -> %z0.d
+c445e482 : ldff1b z2.d, p1/Z, [x4, z5.d]             : ldff1b (%x4,%z5.d)[4byte] %p1/z -> %z2.d
+c447e8c4 : ldff1b z4.d, p2/Z, [x6, z7.d]             : ldff1b (%x6,%z7.d)[4byte] %p2/z -> %z4.d
+c449e906 : ldff1b z6.d, p2/Z, [x8, z9.d]             : ldff1b (%x8,%z9.d)[4byte] %p2/z -> %z6.d
+c44bed48 : ldff1b z8.d, p3/Z, [x10, z11.d]           : ldff1b (%x10,%z11.d)[4byte] %p3/z -> %z8.d
+c44ded6a : ldff1b z10.d, p3/Z, [x11, z13.d]          : ldff1b (%x11,%z13.d)[4byte] %p3/z -> %z10.d
+c44ff1ac : ldff1b z12.d, p4/Z, [x13, z15.d]          : ldff1b (%x13,%z15.d)[4byte] %p4/z -> %z12.d
+c451f1ee : ldff1b z14.d, p4/Z, [x15, z17.d]          : ldff1b (%x15,%z17.d)[4byte] %p4/z -> %z14.d
+c453f630 : ldff1b z16.d, p5/Z, [x17, z19.d]          : ldff1b (%x17,%z19.d)[4byte] %p5/z -> %z16.d
+c454f671 : ldff1b z17.d, p5/Z, [x19, z20.d]          : ldff1b (%x19,%z20.d)[4byte] %p5/z -> %z17.d
+c456f6b3 : ldff1b z19.d, p5/Z, [x21, z22.d]          : ldff1b (%x21,%z22.d)[4byte] %p5/z -> %z19.d
+c458faf5 : ldff1b z21.d, p6/Z, [x23, z24.d]          : ldff1b (%x23,%z24.d)[4byte] %p6/z -> %z21.d
+c45afb17 : ldff1b z23.d, p6/Z, [x24, z26.d]          : ldff1b (%x24,%z26.d)[4byte] %p6/z -> %z23.d
+c45cff59 : ldff1b z25.d, p7/Z, [x26, z28.d]          : ldff1b (%x26,%z28.d)[4byte] %p7/z -> %z25.d
+c45eff9b : ldff1b z27.d, p7/Z, [x28, z30.d]          : ldff1b (%x28,%z30.d)[4byte] %p7/z -> %z27.d
+c45fffff : ldff1b z31.d, p7/Z, [sp, z31.d]           : ldff1b (%sp,%z31.d)[4byte] %p7/z -> %z31.d
+
+# LDFF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LDFF1B-Z.P.BZ-D.x32.unscaled)
+c4006000 : ldff1b z0.d, p0/Z, [x0, z0.d, UXTW]       : ldff1b (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d
+c4056482 : ldff1b z2.d, p1/Z, [x4, z5.d, UXTW]       : ldff1b (%x4,%z5.d,uxtw)[4byte] %p1/z -> %z2.d
+c40768c4 : ldff1b z4.d, p2/Z, [x6, z7.d, UXTW]       : ldff1b (%x6,%z7.d,uxtw)[4byte] %p2/z -> %z4.d
+c4096906 : ldff1b z6.d, p2/Z, [x8, z9.d, UXTW]       : ldff1b (%x8,%z9.d,uxtw)[4byte] %p2/z -> %z6.d
+c40b6d48 : ldff1b z8.d, p3/Z, [x10, z11.d, UXTW]     : ldff1b (%x10,%z11.d,uxtw)[4byte] %p3/z -> %z8.d
+c40d6d6a : ldff1b z10.d, p3/Z, [x11, z13.d, UXTW]    : ldff1b (%x11,%z13.d,uxtw)[4byte] %p3/z -> %z10.d
+c40f71ac : ldff1b z12.d, p4/Z, [x13, z15.d, UXTW]    : ldff1b (%x13,%z15.d,uxtw)[4byte] %p4/z -> %z12.d
+c41171ee : ldff1b z14.d, p4/Z, [x15, z17.d, UXTW]    : ldff1b (%x15,%z17.d,uxtw)[4byte] %p4/z -> %z14.d
+c4137630 : ldff1b z16.d, p5/Z, [x17, z19.d, UXTW]    : ldff1b (%x17,%z19.d,uxtw)[4byte] %p5/z -> %z16.d
+c4147671 : ldff1b z17.d, p5/Z, [x19, z20.d, UXTW]    : ldff1b (%x19,%z20.d,uxtw)[4byte] %p5/z -> %z17.d
+c41676b3 : ldff1b z19.d, p5/Z, [x21, z22.d, UXTW]    : ldff1b (%x21,%z22.d,uxtw)[4byte] %p5/z -> %z19.d
+c4187af5 : ldff1b z21.d, p6/Z, [x23, z24.d, UXTW]    : ldff1b (%x23,%z24.d,uxtw)[4byte] %p6/z -> %z21.d
+c41a7b17 : ldff1b z23.d, p6/Z, [x24, z26.d, UXTW]    : ldff1b (%x24,%z26.d,uxtw)[4byte] %p6/z -> %z23.d
+c41c7f59 : ldff1b z25.d, p7/Z, [x26, z28.d, UXTW]    : ldff1b (%x26,%z28.d,uxtw)[4byte] %p7/z -> %z25.d
+c41e7f9b : ldff1b z27.d, p7/Z, [x28, z30.d, UXTW]    : ldff1b (%x28,%z30.d,uxtw)[4byte] %p7/z -> %z27.d
+c41f7fff : ldff1b z31.d, p7/Z, [sp, z31.d, UXTW]     : ldff1b (%sp,%z31.d,uxtw)[4byte] %p7/z -> %z31.d
+c4406000 : ldff1b z0.d, p0/Z, [x0, z0.d, SXTW]       : ldff1b (%x0,%z0.d,sxtw)[4byte] %p0/z -> %z0.d
+c4456482 : ldff1b z2.d, p1/Z, [x4, z5.d, SXTW]       : ldff1b (%x4,%z5.d,sxtw)[4byte] %p1/z -> %z2.d
+c44768c4 : ldff1b z4.d, p2/Z, [x6, z7.d, SXTW]       : ldff1b (%x6,%z7.d,sxtw)[4byte] %p2/z -> %z4.d
+c4496906 : ldff1b z6.d, p2/Z, [x8, z9.d, SXTW]       : ldff1b (%x8,%z9.d,sxtw)[4byte] %p2/z -> %z6.d
+c44b6d48 : ldff1b z8.d, p3/Z, [x10, z11.d, SXTW]     : ldff1b (%x10,%z11.d,sxtw)[4byte] %p3/z -> %z8.d
+c44d6d6a : ldff1b z10.d, p3/Z, [x11, z13.d, SXTW]    : ldff1b (%x11,%z13.d,sxtw)[4byte] %p3/z -> %z10.d
+c44f71ac : ldff1b z12.d, p4/Z, [x13, z15.d, SXTW]    : ldff1b (%x13,%z15.d,sxtw)[4byte] %p4/z -> %z12.d
+c45171ee : ldff1b z14.d, p4/Z, [x15, z17.d, SXTW]    : ldff1b (%x15,%z17.d,sxtw)[4byte] %p4/z -> %z14.d
+c4537630 : ldff1b z16.d, p5/Z, [x17, z19.d, SXTW]    : ldff1b (%x17,%z19.d,sxtw)[4byte] %p5/z -> %z16.d
+c4547671 : ldff1b z17.d, p5/Z, [x19, z20.d, SXTW]    : ldff1b (%x19,%z20.d,sxtw)[4byte] %p5/z -> %z17.d
+c45676b3 : ldff1b z19.d, p5/Z, [x21, z22.d, SXTW]    : ldff1b (%x21,%z22.d,sxtw)[4byte] %p5/z -> %z19.d
+c4587af5 : ldff1b z21.d, p6/Z, [x23, z24.d, SXTW]    : ldff1b (%x23,%z24.d,sxtw)[4byte] %p6/z -> %z21.d
+c45a7b17 : ldff1b z23.d, p6/Z, [x24, z26.d, SXTW]    : ldff1b (%x24,%z26.d,sxtw)[4byte] %p6/z -> %z23.d
+c45c7f59 : ldff1b z25.d, p7/Z, [x26, z28.d, SXTW]    : ldff1b (%x26,%z28.d,sxtw)[4byte] %p7/z -> %z25.d
+c45e7f9b : ldff1b z27.d, p7/Z, [x28, z30.d, SXTW]    : ldff1b (%x28,%z30.d,sxtw)[4byte] %p7/z -> %z27.d
+c45f7fff : ldff1b z31.d, p7/Z, [sp, z31.d, SXTW]     : ldff1b (%sp,%z31.d,sxtw)[4byte] %p7/z -> %z31.d
+
+# LDFF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LDFF1B-Z.P.BZ-S.x32.unscaled)
+84006000 : ldff1b z0.s, p0/Z, [x0, z0.s, UXTW]       : ldff1b (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s
+84056482 : ldff1b z2.s, p1/Z, [x4, z5.s, UXTW]       : ldff1b (%x4,%z5.s,uxtw)[8byte] %p1/z -> %z2.s
+840768c4 : ldff1b z4.s, p2/Z, [x6, z7.s, UXTW]       : ldff1b (%x6,%z7.s,uxtw)[8byte] %p2/z -> %z4.s
+84096906 : ldff1b z6.s, p2/Z, [x8, z9.s, UXTW]       : ldff1b (%x8,%z9.s,uxtw)[8byte] %p2/z -> %z6.s
+840b6d48 : ldff1b z8.s, p3/Z, [x10, z11.s, UXTW]     : ldff1b (%x10,%z11.s,uxtw)[8byte] %p3/z -> %z8.s
+840d6d6a : ldff1b z10.s, p3/Z, [x11, z13.s, UXTW]    : ldff1b (%x11,%z13.s,uxtw)[8byte] %p3/z -> %z10.s
+840f71ac : ldff1b z12.s, p4/Z, [x13, z15.s, UXTW]    : ldff1b (%x13,%z15.s,uxtw)[8byte] %p4/z -> %z12.s
+841171ee : ldff1b z14.s, p4/Z, [x15, z17.s, UXTW]    : ldff1b (%x15,%z17.s,uxtw)[8byte] %p4/z -> %z14.s
+84137630 : ldff1b z16.s, p5/Z, [x17, z19.s, UXTW]    : ldff1b (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s
+84147671 : ldff1b z17.s, p5/Z, [x19, z20.s, UXTW]    : ldff1b (%x19,%z20.s,uxtw)[8byte] %p5/z -> %z17.s
+841676b3 : ldff1b z19.s, p5/Z, [x21, z22.s, UXTW]    : ldff1b (%x21,%z22.s,uxtw)[8byte] %p5/z -> %z19.s
+84187af5 : ldff1b z21.s, p6/Z, [x23, z24.s, UXTW]    : ldff1b (%x23,%z24.s,uxtw)[8byte] %p6/z -> %z21.s
+841a7b17 : ldff1b z23.s, p6/Z, [x24, z26.s, UXTW]    : ldff1b (%x24,%z26.s,uxtw)[8byte] %p6/z -> %z23.s
+841c7f59 : ldff1b z25.s, p7/Z, [x26, z28.s, UXTW]    : ldff1b (%x26,%z28.s,uxtw)[8byte] %p7/z -> %z25.s
+841e7f9b : ldff1b z27.s, p7/Z, [x28, z30.s, UXTW]    : ldff1b (%x28,%z30.s,uxtw)[8byte] %p7/z -> %z27.s
+841f7fff : ldff1b z31.s, p7/Z, [sp, z31.s, UXTW]     : ldff1b (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s
+84406000 : ldff1b z0.s, p0/Z, [x0, z0.s, SXTW]       : ldff1b (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s
+84456482 : ldff1b z2.s, p1/Z, [x4, z5.s, SXTW]       : ldff1b (%x4,%z5.s,sxtw)[8byte] %p1/z -> %z2.s
+844768c4 : ldff1b z4.s, p2/Z, [x6, z7.s, SXTW]       : ldff1b (%x6,%z7.s,sxtw)[8byte] %p2/z -> %z4.s
+84496906 : ldff1b z6.s, p2/Z, [x8, z9.s, SXTW]       : ldff1b (%x8,%z9.s,sxtw)[8byte] %p2/z -> %z6.s
+844b6d48 : ldff1b z8.s, p3/Z, [x10, z11.s, SXTW]     : ldff1b (%x10,%z11.s,sxtw)[8byte] %p3/z -> %z8.s
+844d6d6a : ldff1b z10.s, p3/Z, [x11, z13.s, SXTW]    : ldff1b (%x11,%z13.s,sxtw)[8byte] %p3/z -> %z10.s
+844f71ac : ldff1b z12.s, p4/Z, [x13, z15.s, SXTW]    : ldff1b (%x13,%z15.s,sxtw)[8byte] %p4/z -> %z12.s
+845171ee : ldff1b z14.s, p4/Z, [x15, z17.s, SXTW]    : ldff1b (%x15,%z17.s,sxtw)[8byte] %p4/z -> %z14.s
+84537630 : ldff1b z16.s, p5/Z, [x17, z19.s, SXTW]    : ldff1b (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s
+84547671 : ldff1b z17.s, p5/Z, [x19, z20.s, SXTW]    : ldff1b (%x19,%z20.s,sxtw)[8byte] %p5/z -> %z17.s
+845676b3 : ldff1b z19.s, p5/Z, [x21, z22.s, SXTW]    : ldff1b (%x21,%z22.s,sxtw)[8byte] %p5/z -> %z19.s
+84587af5 : ldff1b z21.s, p6/Z, [x23, z24.s, SXTW]    : ldff1b (%x23,%z24.s,sxtw)[8byte] %p6/z -> %z21.s
+845a7b17 : ldff1b z23.s, p6/Z, [x24, z26.s, SXTW]    : ldff1b (%x24,%z26.s,sxtw)[8byte] %p6/z -> %z23.s
+845c7f59 : ldff1b z25.s, p7/Z, [x26, z28.s, SXTW]    : ldff1b (%x26,%z28.s,sxtw)[8byte] %p7/z -> %z25.s
+845e7f9b : ldff1b z27.s, p7/Z, [x28, z30.s, SXTW]    : ldff1b (%x28,%z30.s,sxtw)[8byte] %p7/z -> %z27.s
+845f7fff : ldff1b z31.s, p7/Z, [sp, z31.s, SXTW]     : ldff1b (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s
+
 # LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, <Xm>, LSL #3}] (LDFF1D-Z.P.BR-U64)
 a5e06000 : ldff1d z0.d, p0/Z, [x0, x0, LSL #3]       : ldff1d (%x0,%x0,lsl #3)[32byte] %p0/z -> %z0.d
 a5e56482 : ldff1d z2.d, p1/Z, [x4, x5, LSL #3]       : ldff1d (%x4,%x5,lsl #3)[32byte] %p1/z -> %z2.d
@@ -11665,6 +12431,74 @@ c5dafb17 : ldff1d z23.d, p6/Z, [x24, z26.d]          : ldff1d (%x24,%z26.d)[32by
 c5dcff59 : ldff1d z25.d, p7/Z, [x26, z28.d]          : ldff1d (%x26,%z28.d)[32byte] %p7/z -> %z25.d
 c5deff9b : ldff1d z27.d, p7/Z, [x28, z30.d]          : ldff1d (%x28,%z30.d)[32byte] %p7/z -> %z27.d
 c5dfffff : ldff1d z31.d, p7/Z, [sp, z31.d]           : ldff1d (%sp,%z31.d)[32byte] %p7/z -> %z31.d
+
+# LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3] (LDFF1D-Z.P.BZ-D.x32.scaled)
+c5a06000 : ldff1d z0.d, p0/Z, [x0, z0.d, UXTW #3]    : ldff1d (%x0,%z0.d,uxtw #3)[32byte] %p0/z -> %z0.d
+c5a56482 : ldff1d z2.d, p1/Z, [x4, z5.d, UXTW #3]    : ldff1d (%x4,%z5.d,uxtw #3)[32byte] %p1/z -> %z2.d
+c5a768c4 : ldff1d z4.d, p2/Z, [x6, z7.d, UXTW #3]    : ldff1d (%x6,%z7.d,uxtw #3)[32byte] %p2/z -> %z4.d
+c5a96906 : ldff1d z6.d, p2/Z, [x8, z9.d, UXTW #3]    : ldff1d (%x8,%z9.d,uxtw #3)[32byte] %p2/z -> %z6.d
+c5ab6d48 : ldff1d z8.d, p3/Z, [x10, z11.d, UXTW #3]  : ldff1d (%x10,%z11.d,uxtw #3)[32byte] %p3/z -> %z8.d
+c5ad6d6a : ldff1d z10.d, p3/Z, [x11, z13.d, UXTW #3] : ldff1d (%x11,%z13.d,uxtw #3)[32byte] %p3/z -> %z10.d
+c5af71ac : ldff1d z12.d, p4/Z, [x13, z15.d, UXTW #3] : ldff1d (%x13,%z15.d,uxtw #3)[32byte] %p4/z -> %z12.d
+c5b171ee : ldff1d z14.d, p4/Z, [x15, z17.d, UXTW #3] : ldff1d (%x15,%z17.d,uxtw #3)[32byte] %p4/z -> %z14.d
+c5b37630 : ldff1d z16.d, p5/Z, [x17, z19.d, UXTW #3] : ldff1d (%x17,%z19.d,uxtw #3)[32byte] %p5/z -> %z16.d
+c5b47671 : ldff1d z17.d, p5/Z, [x19, z20.d, UXTW #3] : ldff1d (%x19,%z20.d,uxtw #3)[32byte] %p5/z -> %z17.d
+c5b676b3 : ldff1d z19.d, p5/Z, [x21, z22.d, UXTW #3] : ldff1d (%x21,%z22.d,uxtw #3)[32byte] %p5/z -> %z19.d
+c5b87af5 : ldff1d z21.d, p6/Z, [x23, z24.d, UXTW #3] : ldff1d (%x23,%z24.d,uxtw #3)[32byte] %p6/z -> %z21.d
+c5ba7b17 : ldff1d z23.d, p6/Z, [x24, z26.d, UXTW #3] : ldff1d (%x24,%z26.d,uxtw #3)[32byte] %p6/z -> %z23.d
+c5bc7f59 : ldff1d z25.d, p7/Z, [x26, z28.d, UXTW #3] : ldff1d (%x26,%z28.d,uxtw #3)[32byte] %p7/z -> %z25.d
+c5be7f9b : ldff1d z27.d, p7/Z, [x28, z30.d, UXTW #3] : ldff1d (%x28,%z30.d,uxtw #3)[32byte] %p7/z -> %z27.d
+c5bf7fff : ldff1d z31.d, p7/Z, [sp, z31.d, UXTW #3]  : ldff1d (%sp,%z31.d,uxtw #3)[32byte] %p7/z -> %z31.d
+c5e06000 : ldff1d z0.d, p0/Z, [x0, z0.d, SXTW #3]    : ldff1d (%x0,%z0.d,sxtw #3)[32byte] %p0/z -> %z0.d
+c5e56482 : ldff1d z2.d, p1/Z, [x4, z5.d, SXTW #3]    : ldff1d (%x4,%z5.d,sxtw #3)[32byte] %p1/z -> %z2.d
+c5e768c4 : ldff1d z4.d, p2/Z, [x6, z7.d, SXTW #3]    : ldff1d (%x6,%z7.d,sxtw #3)[32byte] %p2/z -> %z4.d
+c5e96906 : ldff1d z6.d, p2/Z, [x8, z9.d, SXTW #3]    : ldff1d (%x8,%z9.d,sxtw #3)[32byte] %p2/z -> %z6.d
+c5eb6d48 : ldff1d z8.d, p3/Z, [x10, z11.d, SXTW #3]  : ldff1d (%x10,%z11.d,sxtw #3)[32byte] %p3/z -> %z8.d
+c5ed6d6a : ldff1d z10.d, p3/Z, [x11, z13.d, SXTW #3] : ldff1d (%x11,%z13.d,sxtw #3)[32byte] %p3/z -> %z10.d
+c5ef71ac : ldff1d z12.d, p4/Z, [x13, z15.d, SXTW #3] : ldff1d (%x13,%z15.d,sxtw #3)[32byte] %p4/z -> %z12.d
+c5f171ee : ldff1d z14.d, p4/Z, [x15, z17.d, SXTW #3] : ldff1d (%x15,%z17.d,sxtw #3)[32byte] %p4/z -> %z14.d
+c5f37630 : ldff1d z16.d, p5/Z, [x17, z19.d, SXTW #3] : ldff1d (%x17,%z19.d,sxtw #3)[32byte] %p5/z -> %z16.d
+c5f47671 : ldff1d z17.d, p5/Z, [x19, z20.d, SXTW #3] : ldff1d (%x19,%z20.d,sxtw #3)[32byte] %p5/z -> %z17.d
+c5f676b3 : ldff1d z19.d, p5/Z, [x21, z22.d, SXTW #3] : ldff1d (%x21,%z22.d,sxtw #3)[32byte] %p5/z -> %z19.d
+c5f87af5 : ldff1d z21.d, p6/Z, [x23, z24.d, SXTW #3] : ldff1d (%x23,%z24.d,sxtw #3)[32byte] %p6/z -> %z21.d
+c5fa7b17 : ldff1d z23.d, p6/Z, [x24, z26.d, SXTW #3] : ldff1d (%x24,%z26.d,sxtw #3)[32byte] %p6/z -> %z23.d
+c5fc7f59 : ldff1d z25.d, p7/Z, [x26, z28.d, SXTW #3] : ldff1d (%x26,%z28.d,sxtw #3)[32byte] %p7/z -> %z25.d
+c5fe7f9b : ldff1d z27.d, p7/Z, [x28, z30.d, SXTW #3] : ldff1d (%x28,%z30.d,sxtw #3)[32byte] %p7/z -> %z27.d
+c5ff7fff : ldff1d z31.d, p7/Z, [sp, z31.d, SXTW #3]  : ldff1d (%sp,%z31.d,sxtw #3)[32byte] %p7/z -> %z31.d
+
+# LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LDFF1D-Z.P.BZ-D.x32.unscaled)
+c5806000 : ldff1d z0.d, p0/Z, [x0, z0.d, UXTW]       : ldff1d (%x0,%z0.d,uxtw)[32byte] %p0/z -> %z0.d
+c5856482 : ldff1d z2.d, p1/Z, [x4, z5.d, UXTW]       : ldff1d (%x4,%z5.d,uxtw)[32byte] %p1/z -> %z2.d
+c58768c4 : ldff1d z4.d, p2/Z, [x6, z7.d, UXTW]       : ldff1d (%x6,%z7.d,uxtw)[32byte] %p2/z -> %z4.d
+c5896906 : ldff1d z6.d, p2/Z, [x8, z9.d, UXTW]       : ldff1d (%x8,%z9.d,uxtw)[32byte] %p2/z -> %z6.d
+c58b6d48 : ldff1d z8.d, p3/Z, [x10, z11.d, UXTW]     : ldff1d (%x10,%z11.d,uxtw)[32byte] %p3/z -> %z8.d
+c58d6d6a : ldff1d z10.d, p3/Z, [x11, z13.d, UXTW]    : ldff1d (%x11,%z13.d,uxtw)[32byte] %p3/z -> %z10.d
+c58f71ac : ldff1d z12.d, p4/Z, [x13, z15.d, UXTW]    : ldff1d (%x13,%z15.d,uxtw)[32byte] %p4/z -> %z12.d
+c59171ee : ldff1d z14.d, p4/Z, [x15, z17.d, UXTW]    : ldff1d (%x15,%z17.d,uxtw)[32byte] %p4/z -> %z14.d
+c5937630 : ldff1d z16.d, p5/Z, [x17, z19.d, UXTW]    : ldff1d (%x17,%z19.d,uxtw)[32byte] %p5/z -> %z16.d
+c5947671 : ldff1d z17.d, p5/Z, [x19, z20.d, UXTW]    : ldff1d (%x19,%z20.d,uxtw)[32byte] %p5/z -> %z17.d
+c59676b3 : ldff1d z19.d, p5/Z, [x21, z22.d, UXTW]    : ldff1d (%x21,%z22.d,uxtw)[32byte] %p5/z -> %z19.d
+c5987af5 : ldff1d z21.d, p6/Z, [x23, z24.d, UXTW]    : ldff1d (%x23,%z24.d,uxtw)[32byte] %p6/z -> %z21.d
+c59a7b17 : ldff1d z23.d, p6/Z, [x24, z26.d, UXTW]    : ldff1d (%x24,%z26.d,uxtw)[32byte] %p6/z -> %z23.d
+c59c7f59 : ldff1d z25.d, p7/Z, [x26, z28.d, UXTW]    : ldff1d (%x26,%z28.d,uxtw)[32byte] %p7/z -> %z25.d
+c59e7f9b : ldff1d z27.d, p7/Z, [x28, z30.d, UXTW]    : ldff1d (%x28,%z30.d,uxtw)[32byte] %p7/z -> %z27.d
+c59f7fff : ldff1d z31.d, p7/Z, [sp, z31.d, UXTW]     : ldff1d (%sp,%z31.d,uxtw)[32byte] %p7/z -> %z31.d
+c5c06000 : ldff1d z0.d, p0/Z, [x0, z0.d, SXTW]       : ldff1d (%x0,%z0.d,sxtw)[32byte] %p0/z -> %z0.d
+c5c56482 : ldff1d z2.d, p1/Z, [x4, z5.d, SXTW]       : ldff1d (%x4,%z5.d,sxtw)[32byte] %p1/z -> %z2.d
+c5c768c4 : ldff1d z4.d, p2/Z, [x6, z7.d, SXTW]       : ldff1d (%x6,%z7.d,sxtw)[32byte] %p2/z -> %z4.d
+c5c96906 : ldff1d z6.d, p2/Z, [x8, z9.d, SXTW]       : ldff1d (%x8,%z9.d,sxtw)[32byte] %p2/z -> %z6.d
+c5cb6d48 : ldff1d z8.d, p3/Z, [x10, z11.d, SXTW]     : ldff1d (%x10,%z11.d,sxtw)[32byte] %p3/z -> %z8.d
+c5cd6d6a : ldff1d z10.d, p3/Z, [x11, z13.d, SXTW]    : ldff1d (%x11,%z13.d,sxtw)[32byte] %p3/z -> %z10.d
+c5cf71ac : ldff1d z12.d, p4/Z, [x13, z15.d, SXTW]    : ldff1d (%x13,%z15.d,sxtw)[32byte] %p4/z -> %z12.d
+c5d171ee : ldff1d z14.d, p4/Z, [x15, z17.d, SXTW]    : ldff1d (%x15,%z17.d,sxtw)[32byte] %p4/z -> %z14.d
+c5d37630 : ldff1d z16.d, p5/Z, [x17, z19.d, SXTW]    : ldff1d (%x17,%z19.d,sxtw)[32byte] %p5/z -> %z16.d
+c5d47671 : ldff1d z17.d, p5/Z, [x19, z20.d, SXTW]    : ldff1d (%x19,%z20.d,sxtw)[32byte] %p5/z -> %z17.d
+c5d676b3 : ldff1d z19.d, p5/Z, [x21, z22.d, SXTW]    : ldff1d (%x21,%z22.d,sxtw)[32byte] %p5/z -> %z19.d
+c5d87af5 : ldff1d z21.d, p6/Z, [x23, z24.d, SXTW]    : ldff1d (%x23,%z24.d,sxtw)[32byte] %p6/z -> %z21.d
+c5da7b17 : ldff1d z23.d, p6/Z, [x24, z26.d, SXTW]    : ldff1d (%x24,%z26.d,sxtw)[32byte] %p6/z -> %z23.d
+c5dc7f59 : ldff1d z25.d, p7/Z, [x26, z28.d, SXTW]    : ldff1d (%x26,%z28.d,sxtw)[32byte] %p7/z -> %z25.d
+c5de7f9b : ldff1d z27.d, p7/Z, [x28, z30.d, SXTW]    : ldff1d (%x28,%z30.d,sxtw)[32byte] %p7/z -> %z27.d
+c5df7fff : ldff1d z31.d, p7/Z, [sp, z31.d, SXTW]     : ldff1d (%sp,%z31.d,sxtw)[32byte] %p7/z -> %z31.d
 
 # LDFF1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, <Xm>, LSL #1}] (LDFF1H-Z.P.BR-U16)
 a4a06000 : ldff1h z0.h, p0/Z, [x0, x0, LSL #1]       : ldff1h (%x0,%x0,lsl #1)[32byte] %p0/z -> %z0.h
@@ -11792,6 +12626,142 @@ c4dcff59 : ldff1h z25.d, p7/Z, [x26, z28.d]          : ldff1h (%x26,%z28.d)[8byt
 c4deff9b : ldff1h z27.d, p7/Z, [x28, z30.d]          : ldff1h (%x28,%z30.d)[8byte] %p7/z -> %z27.d
 c4dfffff : ldff1h z31.d, p7/Z, [sp, z31.d]           : ldff1h (%sp,%z31.d)[8byte] %p7/z -> %z31.d
 
+# LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] (LDFF1H-Z.P.BZ-D.x32.scaled)
+c4a06000 : ldff1h z0.d, p0/Z, [x0, z0.d, UXTW #1]    : ldff1h (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d
+c4a56482 : ldff1h z2.d, p1/Z, [x4, z5.d, UXTW #1]    : ldff1h (%x4,%z5.d,uxtw #1)[8byte] %p1/z -> %z2.d
+c4a768c4 : ldff1h z4.d, p2/Z, [x6, z7.d, UXTW #1]    : ldff1h (%x6,%z7.d,uxtw #1)[8byte] %p2/z -> %z4.d
+c4a96906 : ldff1h z6.d, p2/Z, [x8, z9.d, UXTW #1]    : ldff1h (%x8,%z9.d,uxtw #1)[8byte] %p2/z -> %z6.d
+c4ab6d48 : ldff1h z8.d, p3/Z, [x10, z11.d, UXTW #1]  : ldff1h (%x10,%z11.d,uxtw #1)[8byte] %p3/z -> %z8.d
+c4ad6d6a : ldff1h z10.d, p3/Z, [x11, z13.d, UXTW #1] : ldff1h (%x11,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d
+c4af71ac : ldff1h z12.d, p4/Z, [x13, z15.d, UXTW #1] : ldff1h (%x13,%z15.d,uxtw #1)[8byte] %p4/z -> %z12.d
+c4b171ee : ldff1h z14.d, p4/Z, [x15, z17.d, UXTW #1] : ldff1h (%x15,%z17.d,uxtw #1)[8byte] %p4/z -> %z14.d
+c4b37630 : ldff1h z16.d, p5/Z, [x17, z19.d, UXTW #1] : ldff1h (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d
+c4b47671 : ldff1h z17.d, p5/Z, [x19, z20.d, UXTW #1] : ldff1h (%x19,%z20.d,uxtw #1)[8byte] %p5/z -> %z17.d
+c4b676b3 : ldff1h z19.d, p5/Z, [x21, z22.d, UXTW #1] : ldff1h (%x21,%z22.d,uxtw #1)[8byte] %p5/z -> %z19.d
+c4b87af5 : ldff1h z21.d, p6/Z, [x23, z24.d, UXTW #1] : ldff1h (%x23,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d
+c4ba7b17 : ldff1h z23.d, p6/Z, [x24, z26.d, UXTW #1] : ldff1h (%x24,%z26.d,uxtw #1)[8byte] %p6/z -> %z23.d
+c4bc7f59 : ldff1h z25.d, p7/Z, [x26, z28.d, UXTW #1] : ldff1h (%x26,%z28.d,uxtw #1)[8byte] %p7/z -> %z25.d
+c4be7f9b : ldff1h z27.d, p7/Z, [x28, z30.d, UXTW #1] : ldff1h (%x28,%z30.d,uxtw #1)[8byte] %p7/z -> %z27.d
+c4bf7fff : ldff1h z31.d, p7/Z, [sp, z31.d, UXTW #1]  : ldff1h (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d
+c4e06000 : ldff1h z0.d, p0/Z, [x0, z0.d, SXTW #1]    : ldff1h (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d
+c4e56482 : ldff1h z2.d, p1/Z, [x4, z5.d, SXTW #1]    : ldff1h (%x4,%z5.d,sxtw #1)[8byte] %p1/z -> %z2.d
+c4e768c4 : ldff1h z4.d, p2/Z, [x6, z7.d, SXTW #1]    : ldff1h (%x6,%z7.d,sxtw #1)[8byte] %p2/z -> %z4.d
+c4e96906 : ldff1h z6.d, p2/Z, [x8, z9.d, SXTW #1]    : ldff1h (%x8,%z9.d,sxtw #1)[8byte] %p2/z -> %z6.d
+c4eb6d48 : ldff1h z8.d, p3/Z, [x10, z11.d, SXTW #1]  : ldff1h (%x10,%z11.d,sxtw #1)[8byte] %p3/z -> %z8.d
+c4ed6d6a : ldff1h z10.d, p3/Z, [x11, z13.d, SXTW #1] : ldff1h (%x11,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d
+c4ef71ac : ldff1h z12.d, p4/Z, [x13, z15.d, SXTW #1] : ldff1h (%x13,%z15.d,sxtw #1)[8byte] %p4/z -> %z12.d
+c4f171ee : ldff1h z14.d, p4/Z, [x15, z17.d, SXTW #1] : ldff1h (%x15,%z17.d,sxtw #1)[8byte] %p4/z -> %z14.d
+c4f37630 : ldff1h z16.d, p5/Z, [x17, z19.d, SXTW #1] : ldff1h (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d
+c4f47671 : ldff1h z17.d, p5/Z, [x19, z20.d, SXTW #1] : ldff1h (%x19,%z20.d,sxtw #1)[8byte] %p5/z -> %z17.d
+c4f676b3 : ldff1h z19.d, p5/Z, [x21, z22.d, SXTW #1] : ldff1h (%x21,%z22.d,sxtw #1)[8byte] %p5/z -> %z19.d
+c4f87af5 : ldff1h z21.d, p6/Z, [x23, z24.d, SXTW #1] : ldff1h (%x23,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d
+c4fa7b17 : ldff1h z23.d, p6/Z, [x24, z26.d, SXTW #1] : ldff1h (%x24,%z26.d,sxtw #1)[8byte] %p6/z -> %z23.d
+c4fc7f59 : ldff1h z25.d, p7/Z, [x26, z28.d, SXTW #1] : ldff1h (%x26,%z28.d,sxtw #1)[8byte] %p7/z -> %z25.d
+c4fe7f9b : ldff1h z27.d, p7/Z, [x28, z30.d, SXTW #1] : ldff1h (%x28,%z30.d,sxtw #1)[8byte] %p7/z -> %z27.d
+c4ff7fff : ldff1h z31.d, p7/Z, [sp, z31.d, SXTW #1]  : ldff1h (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d
+
+# LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LDFF1H-Z.P.BZ-D.x32.unscaled)
+c4806000 : ldff1h z0.d, p0/Z, [x0, z0.d, UXTW]       : ldff1h (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d
+c4856482 : ldff1h z2.d, p1/Z, [x4, z5.d, UXTW]       : ldff1h (%x4,%z5.d,uxtw)[8byte] %p1/z -> %z2.d
+c48768c4 : ldff1h z4.d, p2/Z, [x6, z7.d, UXTW]       : ldff1h (%x6,%z7.d,uxtw)[8byte] %p2/z -> %z4.d
+c4896906 : ldff1h z6.d, p2/Z, [x8, z9.d, UXTW]       : ldff1h (%x8,%z9.d,uxtw)[8byte] %p2/z -> %z6.d
+c48b6d48 : ldff1h z8.d, p3/Z, [x10, z11.d, UXTW]     : ldff1h (%x10,%z11.d,uxtw)[8byte] %p3/z -> %z8.d
+c48d6d6a : ldff1h z10.d, p3/Z, [x11, z13.d, UXTW]    : ldff1h (%x11,%z13.d,uxtw)[8byte] %p3/z -> %z10.d
+c48f71ac : ldff1h z12.d, p4/Z, [x13, z15.d, UXTW]    : ldff1h (%x13,%z15.d,uxtw)[8byte] %p4/z -> %z12.d
+c49171ee : ldff1h z14.d, p4/Z, [x15, z17.d, UXTW]    : ldff1h (%x15,%z17.d,uxtw)[8byte] %p4/z -> %z14.d
+c4937630 : ldff1h z16.d, p5/Z, [x17, z19.d, UXTW]    : ldff1h (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d
+c4947671 : ldff1h z17.d, p5/Z, [x19, z20.d, UXTW]    : ldff1h (%x19,%z20.d,uxtw)[8byte] %p5/z -> %z17.d
+c49676b3 : ldff1h z19.d, p5/Z, [x21, z22.d, UXTW]    : ldff1h (%x21,%z22.d,uxtw)[8byte] %p5/z -> %z19.d
+c4987af5 : ldff1h z21.d, p6/Z, [x23, z24.d, UXTW]    : ldff1h (%x23,%z24.d,uxtw)[8byte] %p6/z -> %z21.d
+c49a7b17 : ldff1h z23.d, p6/Z, [x24, z26.d, UXTW]    : ldff1h (%x24,%z26.d,uxtw)[8byte] %p6/z -> %z23.d
+c49c7f59 : ldff1h z25.d, p7/Z, [x26, z28.d, UXTW]    : ldff1h (%x26,%z28.d,uxtw)[8byte] %p7/z -> %z25.d
+c49e7f9b : ldff1h z27.d, p7/Z, [x28, z30.d, UXTW]    : ldff1h (%x28,%z30.d,uxtw)[8byte] %p7/z -> %z27.d
+c49f7fff : ldff1h z31.d, p7/Z, [sp, z31.d, UXTW]     : ldff1h (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d
+c4c06000 : ldff1h z0.d, p0/Z, [x0, z0.d, SXTW]       : ldff1h (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d
+c4c56482 : ldff1h z2.d, p1/Z, [x4, z5.d, SXTW]       : ldff1h (%x4,%z5.d,sxtw)[8byte] %p1/z -> %z2.d
+c4c768c4 : ldff1h z4.d, p2/Z, [x6, z7.d, SXTW]       : ldff1h (%x6,%z7.d,sxtw)[8byte] %p2/z -> %z4.d
+c4c96906 : ldff1h z6.d, p2/Z, [x8, z9.d, SXTW]       : ldff1h (%x8,%z9.d,sxtw)[8byte] %p2/z -> %z6.d
+c4cb6d48 : ldff1h z8.d, p3/Z, [x10, z11.d, SXTW]     : ldff1h (%x10,%z11.d,sxtw)[8byte] %p3/z -> %z8.d
+c4cd6d6a : ldff1h z10.d, p3/Z, [x11, z13.d, SXTW]    : ldff1h (%x11,%z13.d,sxtw)[8byte] %p3/z -> %z10.d
+c4cf71ac : ldff1h z12.d, p4/Z, [x13, z15.d, SXTW]    : ldff1h (%x13,%z15.d,sxtw)[8byte] %p4/z -> %z12.d
+c4d171ee : ldff1h z14.d, p4/Z, [x15, z17.d, SXTW]    : ldff1h (%x15,%z17.d,sxtw)[8byte] %p4/z -> %z14.d
+c4d37630 : ldff1h z16.d, p5/Z, [x17, z19.d, SXTW]    : ldff1h (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d
+c4d47671 : ldff1h z17.d, p5/Z, [x19, z20.d, SXTW]    : ldff1h (%x19,%z20.d,sxtw)[8byte] %p5/z -> %z17.d
+c4d676b3 : ldff1h z19.d, p5/Z, [x21, z22.d, SXTW]    : ldff1h (%x21,%z22.d,sxtw)[8byte] %p5/z -> %z19.d
+c4d87af5 : ldff1h z21.d, p6/Z, [x23, z24.d, SXTW]    : ldff1h (%x23,%z24.d,sxtw)[8byte] %p6/z -> %z21.d
+c4da7b17 : ldff1h z23.d, p6/Z, [x24, z26.d, SXTW]    : ldff1h (%x24,%z26.d,sxtw)[8byte] %p6/z -> %z23.d
+c4dc7f59 : ldff1h z25.d, p7/Z, [x26, z28.d, SXTW]    : ldff1h (%x26,%z28.d,sxtw)[8byte] %p7/z -> %z25.d
+c4de7f9b : ldff1h z27.d, p7/Z, [x28, z30.d, SXTW]    : ldff1h (%x28,%z30.d,sxtw)[8byte] %p7/z -> %z27.d
+c4df7fff : ldff1h z31.d, p7/Z, [sp, z31.d, SXTW]     : ldff1h (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d
+
+# LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] (LDFF1H-Z.P.BZ-S.x32.scaled)
+84a06000 : ldff1h z0.s, p0/Z, [x0, z0.s, UXTW #1]    : ldff1h (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s
+84a56482 : ldff1h z2.s, p1/Z, [x4, z5.s, UXTW #1]    : ldff1h (%x4,%z5.s,uxtw #1)[16byte] %p1/z -> %z2.s
+84a768c4 : ldff1h z4.s, p2/Z, [x6, z7.s, UXTW #1]    : ldff1h (%x6,%z7.s,uxtw #1)[16byte] %p2/z -> %z4.s
+84a96906 : ldff1h z6.s, p2/Z, [x8, z9.s, UXTW #1]    : ldff1h (%x8,%z9.s,uxtw #1)[16byte] %p2/z -> %z6.s
+84ab6d48 : ldff1h z8.s, p3/Z, [x10, z11.s, UXTW #1]  : ldff1h (%x10,%z11.s,uxtw #1)[16byte] %p3/z -> %z8.s
+84ad6d6a : ldff1h z10.s, p3/Z, [x11, z13.s, UXTW #1] : ldff1h (%x11,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s
+84af71ac : ldff1h z12.s, p4/Z, [x13, z15.s, UXTW #1] : ldff1h (%x13,%z15.s,uxtw #1)[16byte] %p4/z -> %z12.s
+84b171ee : ldff1h z14.s, p4/Z, [x15, z17.s, UXTW #1] : ldff1h (%x15,%z17.s,uxtw #1)[16byte] %p4/z -> %z14.s
+84b37630 : ldff1h z16.s, p5/Z, [x17, z19.s, UXTW #1] : ldff1h (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s
+84b47671 : ldff1h z17.s, p5/Z, [x19, z20.s, UXTW #1] : ldff1h (%x19,%z20.s,uxtw #1)[16byte] %p5/z -> %z17.s
+84b676b3 : ldff1h z19.s, p5/Z, [x21, z22.s, UXTW #1] : ldff1h (%x21,%z22.s,uxtw #1)[16byte] %p5/z -> %z19.s
+84b87af5 : ldff1h z21.s, p6/Z, [x23, z24.s, UXTW #1] : ldff1h (%x23,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s
+84ba7b17 : ldff1h z23.s, p6/Z, [x24, z26.s, UXTW #1] : ldff1h (%x24,%z26.s,uxtw #1)[16byte] %p6/z -> %z23.s
+84bc7f59 : ldff1h z25.s, p7/Z, [x26, z28.s, UXTW #1] : ldff1h (%x26,%z28.s,uxtw #1)[16byte] %p7/z -> %z25.s
+84be7f9b : ldff1h z27.s, p7/Z, [x28, z30.s, UXTW #1] : ldff1h (%x28,%z30.s,uxtw #1)[16byte] %p7/z -> %z27.s
+84bf7fff : ldff1h z31.s, p7/Z, [sp, z31.s, UXTW #1]  : ldff1h (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s
+84e06000 : ldff1h z0.s, p0/Z, [x0, z0.s, SXTW #1]    : ldff1h (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s
+84e56482 : ldff1h z2.s, p1/Z, [x4, z5.s, SXTW #1]    : ldff1h (%x4,%z5.s,sxtw #1)[16byte] %p1/z -> %z2.s
+84e768c4 : ldff1h z4.s, p2/Z, [x6, z7.s, SXTW #1]    : ldff1h (%x6,%z7.s,sxtw #1)[16byte] %p2/z -> %z4.s
+84e96906 : ldff1h z6.s, p2/Z, [x8, z9.s, SXTW #1]    : ldff1h (%x8,%z9.s,sxtw #1)[16byte] %p2/z -> %z6.s
+84eb6d48 : ldff1h z8.s, p3/Z, [x10, z11.s, SXTW #1]  : ldff1h (%x10,%z11.s,sxtw #1)[16byte] %p3/z -> %z8.s
+84ed6d6a : ldff1h z10.s, p3/Z, [x11, z13.s, SXTW #1] : ldff1h (%x11,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s
+84ef71ac : ldff1h z12.s, p4/Z, [x13, z15.s, SXTW #1] : ldff1h (%x13,%z15.s,sxtw #1)[16byte] %p4/z -> %z12.s
+84f171ee : ldff1h z14.s, p4/Z, [x15, z17.s, SXTW #1] : ldff1h (%x15,%z17.s,sxtw #1)[16byte] %p4/z -> %z14.s
+84f37630 : ldff1h z16.s, p5/Z, [x17, z19.s, SXTW #1] : ldff1h (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s
+84f47671 : ldff1h z17.s, p5/Z, [x19, z20.s, SXTW #1] : ldff1h (%x19,%z20.s,sxtw #1)[16byte] %p5/z -> %z17.s
+84f676b3 : ldff1h z19.s, p5/Z, [x21, z22.s, SXTW #1] : ldff1h (%x21,%z22.s,sxtw #1)[16byte] %p5/z -> %z19.s
+84f87af5 : ldff1h z21.s, p6/Z, [x23, z24.s, SXTW #1] : ldff1h (%x23,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s
+84fa7b17 : ldff1h z23.s, p6/Z, [x24, z26.s, SXTW #1] : ldff1h (%x24,%z26.s,sxtw #1)[16byte] %p6/z -> %z23.s
+84fc7f59 : ldff1h z25.s, p7/Z, [x26, z28.s, SXTW #1] : ldff1h (%x26,%z28.s,sxtw #1)[16byte] %p7/z -> %z25.s
+84fe7f9b : ldff1h z27.s, p7/Z, [x28, z30.s, SXTW #1] : ldff1h (%x28,%z30.s,sxtw #1)[16byte] %p7/z -> %z27.s
+84ff7fff : ldff1h z31.s, p7/Z, [sp, z31.s, SXTW #1]  : ldff1h (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s
+
+# LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LDFF1H-Z.P.BZ-S.x32.unscaled)
+84806000 : ldff1h z0.s, p0/Z, [x0, z0.s, UXTW]       : ldff1h (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s
+84856482 : ldff1h z2.s, p1/Z, [x4, z5.s, UXTW]       : ldff1h (%x4,%z5.s,uxtw)[16byte] %p1/z -> %z2.s
+848768c4 : ldff1h z4.s, p2/Z, [x6, z7.s, UXTW]       : ldff1h (%x6,%z7.s,uxtw)[16byte] %p2/z -> %z4.s
+84896906 : ldff1h z6.s, p2/Z, [x8, z9.s, UXTW]       : ldff1h (%x8,%z9.s,uxtw)[16byte] %p2/z -> %z6.s
+848b6d48 : ldff1h z8.s, p3/Z, [x10, z11.s, UXTW]     : ldff1h (%x10,%z11.s,uxtw)[16byte] %p3/z -> %z8.s
+848d6d6a : ldff1h z10.s, p3/Z, [x11, z13.s, UXTW]    : ldff1h (%x11,%z13.s,uxtw)[16byte] %p3/z -> %z10.s
+848f71ac : ldff1h z12.s, p4/Z, [x13, z15.s, UXTW]    : ldff1h (%x13,%z15.s,uxtw)[16byte] %p4/z -> %z12.s
+849171ee : ldff1h z14.s, p4/Z, [x15, z17.s, UXTW]    : ldff1h (%x15,%z17.s,uxtw)[16byte] %p4/z -> %z14.s
+84937630 : ldff1h z16.s, p5/Z, [x17, z19.s, UXTW]    : ldff1h (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s
+84947671 : ldff1h z17.s, p5/Z, [x19, z20.s, UXTW]    : ldff1h (%x19,%z20.s,uxtw)[16byte] %p5/z -> %z17.s
+849676b3 : ldff1h z19.s, p5/Z, [x21, z22.s, UXTW]    : ldff1h (%x21,%z22.s,uxtw)[16byte] %p5/z -> %z19.s
+84987af5 : ldff1h z21.s, p6/Z, [x23, z24.s, UXTW]    : ldff1h (%x23,%z24.s,uxtw)[16byte] %p6/z -> %z21.s
+849a7b17 : ldff1h z23.s, p6/Z, [x24, z26.s, UXTW]    : ldff1h (%x24,%z26.s,uxtw)[16byte] %p6/z -> %z23.s
+849c7f59 : ldff1h z25.s, p7/Z, [x26, z28.s, UXTW]    : ldff1h (%x26,%z28.s,uxtw)[16byte] %p7/z -> %z25.s
+849e7f9b : ldff1h z27.s, p7/Z, [x28, z30.s, UXTW]    : ldff1h (%x28,%z30.s,uxtw)[16byte] %p7/z -> %z27.s
+849f7fff : ldff1h z31.s, p7/Z, [sp, z31.s, UXTW]     : ldff1h (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s
+84c06000 : ldff1h z0.s, p0/Z, [x0, z0.s, SXTW]       : ldff1h (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s
+84c56482 : ldff1h z2.s, p1/Z, [x4, z5.s, SXTW]       : ldff1h (%x4,%z5.s,sxtw)[16byte] %p1/z -> %z2.s
+84c768c4 : ldff1h z4.s, p2/Z, [x6, z7.s, SXTW]       : ldff1h (%x6,%z7.s,sxtw)[16byte] %p2/z -> %z4.s
+84c96906 : ldff1h z6.s, p2/Z, [x8, z9.s, SXTW]       : ldff1h (%x8,%z9.s,sxtw)[16byte] %p2/z -> %z6.s
+84cb6d48 : ldff1h z8.s, p3/Z, [x10, z11.s, SXTW]     : ldff1h (%x10,%z11.s,sxtw)[16byte] %p3/z -> %z8.s
+84cd6d6a : ldff1h z10.s, p3/Z, [x11, z13.s, SXTW]    : ldff1h (%x11,%z13.s,sxtw)[16byte] %p3/z -> %z10.s
+84cf71ac : ldff1h z12.s, p4/Z, [x13, z15.s, SXTW]    : ldff1h (%x13,%z15.s,sxtw)[16byte] %p4/z -> %z12.s
+84d171ee : ldff1h z14.s, p4/Z, [x15, z17.s, SXTW]    : ldff1h (%x15,%z17.s,sxtw)[16byte] %p4/z -> %z14.s
+84d37630 : ldff1h z16.s, p5/Z, [x17, z19.s, SXTW]    : ldff1h (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s
+84d47671 : ldff1h z17.s, p5/Z, [x19, z20.s, SXTW]    : ldff1h (%x19,%z20.s,sxtw)[16byte] %p5/z -> %z17.s
+84d676b3 : ldff1h z19.s, p5/Z, [x21, z22.s, SXTW]    : ldff1h (%x21,%z22.s,sxtw)[16byte] %p5/z -> %z19.s
+84d87af5 : ldff1h z21.s, p6/Z, [x23, z24.s, SXTW]    : ldff1h (%x23,%z24.s,sxtw)[16byte] %p6/z -> %z21.s
+84da7b17 : ldff1h z23.s, p6/Z, [x24, z26.s, SXTW]    : ldff1h (%x24,%z26.s,sxtw)[16byte] %p6/z -> %z23.s
+84dc7f59 : ldff1h z25.s, p7/Z, [x26, z28.s, SXTW]    : ldff1h (%x26,%z28.s,sxtw)[16byte] %p7/z -> %z25.s
+84de7f9b : ldff1h z27.s, p7/Z, [x28, z30.s, SXTW]    : ldff1h (%x28,%z30.s,sxtw)[16byte] %p7/z -> %z27.s
+84df7fff : ldff1h z31.s, p7/Z, [sp, z31.s, SXTW]     : ldff1h (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s
+
 # LDFF1SB { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, <Xm>}] (LDFF1SB-Z.P.BR-S16)
 a5c06000 : ldff1sb z0.h, p0/Z, [x0, x0]              : ldff1sb (%x0,%x0)[16byte] %p0/z -> %z0.h
 a5c56482 : ldff1sb z2.h, p1/Z, [x4, x5]              : ldff1sb (%x4,%x5)[16byte] %p1/z -> %z2.h
@@ -11899,6 +12869,74 @@ c45abb17 : ldff1sb z23.d, p6/Z, [x24, z26.d]         : ldff1sb (%x24,%z26.d)[4by
 c45cbf59 : ldff1sb z25.d, p7/Z, [x26, z28.d]         : ldff1sb (%x26,%z28.d)[4byte] %p7/z -> %z25.d
 c45ebf9b : ldff1sb z27.d, p7/Z, [x28, z30.d]         : ldff1sb (%x28,%z30.d)[4byte] %p7/z -> %z27.d
 c45fbfff : ldff1sb z31.d, p7/Z, [sp, z31.d]          : ldff1sb (%sp,%z31.d)[4byte] %p7/z -> %z31.d
+
+# LDFF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LDFF1SB-Z.P.BZ-D.x32.unscaled)
+c4002000 : ldff1sb z0.d, p0/Z, [x0, z0.d, UXTW]      : ldff1sb (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d
+c4052482 : ldff1sb z2.d, p1/Z, [x4, z5.d, UXTW]      : ldff1sb (%x4,%z5.d,uxtw)[4byte] %p1/z -> %z2.d
+c40728c4 : ldff1sb z4.d, p2/Z, [x6, z7.d, UXTW]      : ldff1sb (%x6,%z7.d,uxtw)[4byte] %p2/z -> %z4.d
+c4092906 : ldff1sb z6.d, p2/Z, [x8, z9.d, UXTW]      : ldff1sb (%x8,%z9.d,uxtw)[4byte] %p2/z -> %z6.d
+c40b2d48 : ldff1sb z8.d, p3/Z, [x10, z11.d, UXTW]    : ldff1sb (%x10,%z11.d,uxtw)[4byte] %p3/z -> %z8.d
+c40d2d6a : ldff1sb z10.d, p3/Z, [x11, z13.d, UXTW]   : ldff1sb (%x11,%z13.d,uxtw)[4byte] %p3/z -> %z10.d
+c40f31ac : ldff1sb z12.d, p4/Z, [x13, z15.d, UXTW]   : ldff1sb (%x13,%z15.d,uxtw)[4byte] %p4/z -> %z12.d
+c41131ee : ldff1sb z14.d, p4/Z, [x15, z17.d, UXTW]   : ldff1sb (%x15,%z17.d,uxtw)[4byte] %p4/z -> %z14.d
+c4133630 : ldff1sb z16.d, p5/Z, [x17, z19.d, UXTW]   : ldff1sb (%x17,%z19.d,uxtw)[4byte] %p5/z -> %z16.d
+c4143671 : ldff1sb z17.d, p5/Z, [x19, z20.d, UXTW]   : ldff1sb (%x19,%z20.d,uxtw)[4byte] %p5/z -> %z17.d
+c41636b3 : ldff1sb z19.d, p5/Z, [x21, z22.d, UXTW]   : ldff1sb (%x21,%z22.d,uxtw)[4byte] %p5/z -> %z19.d
+c4183af5 : ldff1sb z21.d, p6/Z, [x23, z24.d, UXTW]   : ldff1sb (%x23,%z24.d,uxtw)[4byte] %p6/z -> %z21.d
+c41a3b17 : ldff1sb z23.d, p6/Z, [x24, z26.d, UXTW]   : ldff1sb (%x24,%z26.d,uxtw)[4byte] %p6/z -> %z23.d
+c41c3f59 : ldff1sb z25.d, p7/Z, [x26, z28.d, UXTW]   : ldff1sb (%x26,%z28.d,uxtw)[4byte] %p7/z -> %z25.d
+c41e3f9b : ldff1sb z27.d, p7/Z, [x28, z30.d, UXTW]   : ldff1sb (%x28,%z30.d,uxtw)[4byte] %p7/z -> %z27.d
+c41f3fff : ldff1sb z31.d, p7/Z, [sp, z31.d, UXTW]    : ldff1sb (%sp,%z31.d,uxtw)[4byte] %p7/z -> %z31.d
+c4402000 : ldff1sb z0.d, p0/Z, [x0, z0.d, SXTW]      : ldff1sb (%x0,%z0.d,sxtw)[4byte] %p0/z -> %z0.d
+c4452482 : ldff1sb z2.d, p1/Z, [x4, z5.d, SXTW]      : ldff1sb (%x4,%z5.d,sxtw)[4byte] %p1/z -> %z2.d
+c44728c4 : ldff1sb z4.d, p2/Z, [x6, z7.d, SXTW]      : ldff1sb (%x6,%z7.d,sxtw)[4byte] %p2/z -> %z4.d
+c4492906 : ldff1sb z6.d, p2/Z, [x8, z9.d, SXTW]      : ldff1sb (%x8,%z9.d,sxtw)[4byte] %p2/z -> %z6.d
+c44b2d48 : ldff1sb z8.d, p3/Z, [x10, z11.d, SXTW]    : ldff1sb (%x10,%z11.d,sxtw)[4byte] %p3/z -> %z8.d
+c44d2d6a : ldff1sb z10.d, p3/Z, [x11, z13.d, SXTW]   : ldff1sb (%x11,%z13.d,sxtw)[4byte] %p3/z -> %z10.d
+c44f31ac : ldff1sb z12.d, p4/Z, [x13, z15.d, SXTW]   : ldff1sb (%x13,%z15.d,sxtw)[4byte] %p4/z -> %z12.d
+c45131ee : ldff1sb z14.d, p4/Z, [x15, z17.d, SXTW]   : ldff1sb (%x15,%z17.d,sxtw)[4byte] %p4/z -> %z14.d
+c4533630 : ldff1sb z16.d, p5/Z, [x17, z19.d, SXTW]   : ldff1sb (%x17,%z19.d,sxtw)[4byte] %p5/z -> %z16.d
+c4543671 : ldff1sb z17.d, p5/Z, [x19, z20.d, SXTW]   : ldff1sb (%x19,%z20.d,sxtw)[4byte] %p5/z -> %z17.d
+c45636b3 : ldff1sb z19.d, p5/Z, [x21, z22.d, SXTW]   : ldff1sb (%x21,%z22.d,sxtw)[4byte] %p5/z -> %z19.d
+c4583af5 : ldff1sb z21.d, p6/Z, [x23, z24.d, SXTW]   : ldff1sb (%x23,%z24.d,sxtw)[4byte] %p6/z -> %z21.d
+c45a3b17 : ldff1sb z23.d, p6/Z, [x24, z26.d, SXTW]   : ldff1sb (%x24,%z26.d,sxtw)[4byte] %p6/z -> %z23.d
+c45c3f59 : ldff1sb z25.d, p7/Z, [x26, z28.d, SXTW]   : ldff1sb (%x26,%z28.d,sxtw)[4byte] %p7/z -> %z25.d
+c45e3f9b : ldff1sb z27.d, p7/Z, [x28, z30.d, SXTW]   : ldff1sb (%x28,%z30.d,sxtw)[4byte] %p7/z -> %z27.d
+c45f3fff : ldff1sb z31.d, p7/Z, [sp, z31.d, SXTW]    : ldff1sb (%sp,%z31.d,sxtw)[4byte] %p7/z -> %z31.d
+
+# LDFF1SB { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LDFF1SB-Z.P.BZ-S.x32.unscaled)
+84002000 : ldff1sb z0.s, p0/Z, [x0, z0.s, UXTW]      : ldff1sb (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s
+84052482 : ldff1sb z2.s, p1/Z, [x4, z5.s, UXTW]      : ldff1sb (%x4,%z5.s,uxtw)[8byte] %p1/z -> %z2.s
+840728c4 : ldff1sb z4.s, p2/Z, [x6, z7.s, UXTW]      : ldff1sb (%x6,%z7.s,uxtw)[8byte] %p2/z -> %z4.s
+84092906 : ldff1sb z6.s, p2/Z, [x8, z9.s, UXTW]      : ldff1sb (%x8,%z9.s,uxtw)[8byte] %p2/z -> %z6.s
+840b2d48 : ldff1sb z8.s, p3/Z, [x10, z11.s, UXTW]    : ldff1sb (%x10,%z11.s,uxtw)[8byte] %p3/z -> %z8.s
+840d2d6a : ldff1sb z10.s, p3/Z, [x11, z13.s, UXTW]   : ldff1sb (%x11,%z13.s,uxtw)[8byte] %p3/z -> %z10.s
+840f31ac : ldff1sb z12.s, p4/Z, [x13, z15.s, UXTW]   : ldff1sb (%x13,%z15.s,uxtw)[8byte] %p4/z -> %z12.s
+841131ee : ldff1sb z14.s, p4/Z, [x15, z17.s, UXTW]   : ldff1sb (%x15,%z17.s,uxtw)[8byte] %p4/z -> %z14.s
+84133630 : ldff1sb z16.s, p5/Z, [x17, z19.s, UXTW]   : ldff1sb (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s
+84143671 : ldff1sb z17.s, p5/Z, [x19, z20.s, UXTW]   : ldff1sb (%x19,%z20.s,uxtw)[8byte] %p5/z -> %z17.s
+841636b3 : ldff1sb z19.s, p5/Z, [x21, z22.s, UXTW]   : ldff1sb (%x21,%z22.s,uxtw)[8byte] %p5/z -> %z19.s
+84183af5 : ldff1sb z21.s, p6/Z, [x23, z24.s, UXTW]   : ldff1sb (%x23,%z24.s,uxtw)[8byte] %p6/z -> %z21.s
+841a3b17 : ldff1sb z23.s, p6/Z, [x24, z26.s, UXTW]   : ldff1sb (%x24,%z26.s,uxtw)[8byte] %p6/z -> %z23.s
+841c3f59 : ldff1sb z25.s, p7/Z, [x26, z28.s, UXTW]   : ldff1sb (%x26,%z28.s,uxtw)[8byte] %p7/z -> %z25.s
+841e3f9b : ldff1sb z27.s, p7/Z, [x28, z30.s, UXTW]   : ldff1sb (%x28,%z30.s,uxtw)[8byte] %p7/z -> %z27.s
+841f3fff : ldff1sb z31.s, p7/Z, [sp, z31.s, UXTW]    : ldff1sb (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s
+84402000 : ldff1sb z0.s, p0/Z, [x0, z0.s, SXTW]      : ldff1sb (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s
+84452482 : ldff1sb z2.s, p1/Z, [x4, z5.s, SXTW]      : ldff1sb (%x4,%z5.s,sxtw)[8byte] %p1/z -> %z2.s
+844728c4 : ldff1sb z4.s, p2/Z, [x6, z7.s, SXTW]      : ldff1sb (%x6,%z7.s,sxtw)[8byte] %p2/z -> %z4.s
+84492906 : ldff1sb z6.s, p2/Z, [x8, z9.s, SXTW]      : ldff1sb (%x8,%z9.s,sxtw)[8byte] %p2/z -> %z6.s
+844b2d48 : ldff1sb z8.s, p3/Z, [x10, z11.s, SXTW]    : ldff1sb (%x10,%z11.s,sxtw)[8byte] %p3/z -> %z8.s
+844d2d6a : ldff1sb z10.s, p3/Z, [x11, z13.s, SXTW]   : ldff1sb (%x11,%z13.s,sxtw)[8byte] %p3/z -> %z10.s
+844f31ac : ldff1sb z12.s, p4/Z, [x13, z15.s, SXTW]   : ldff1sb (%x13,%z15.s,sxtw)[8byte] %p4/z -> %z12.s
+845131ee : ldff1sb z14.s, p4/Z, [x15, z17.s, SXTW]   : ldff1sb (%x15,%z17.s,sxtw)[8byte] %p4/z -> %z14.s
+84533630 : ldff1sb z16.s, p5/Z, [x17, z19.s, SXTW]   : ldff1sb (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s
+84543671 : ldff1sb z17.s, p5/Z, [x19, z20.s, SXTW]   : ldff1sb (%x19,%z20.s,sxtw)[8byte] %p5/z -> %z17.s
+845636b3 : ldff1sb z19.s, p5/Z, [x21, z22.s, SXTW]   : ldff1sb (%x21,%z22.s,sxtw)[8byte] %p5/z -> %z19.s
+84583af5 : ldff1sb z21.s, p6/Z, [x23, z24.s, SXTW]   : ldff1sb (%x23,%z24.s,sxtw)[8byte] %p6/z -> %z21.s
+845a3b17 : ldff1sb z23.s, p6/Z, [x24, z26.s, SXTW]   : ldff1sb (%x24,%z26.s,sxtw)[8byte] %p6/z -> %z23.s
+845c3f59 : ldff1sb z25.s, p7/Z, [x26, z28.s, SXTW]   : ldff1sb (%x26,%z28.s,sxtw)[8byte] %p7/z -> %z25.s
+845e3f9b : ldff1sb z27.s, p7/Z, [x28, z30.s, SXTW]   : ldff1sb (%x28,%z30.s,sxtw)[8byte] %p7/z -> %z27.s
+845f3fff : ldff1sb z31.s, p7/Z, [sp, z31.s, SXTW]    : ldff1sb (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s
 
 # LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, <Xm>, LSL #1}] (LDFF1SH-Z.P.BR-S32)
 a5206000 : ldff1sh z0.s, p0/Z, [x0, x0, LSL #1]      : ldff1sh (%x0,%x0,lsl #1)[16byte] %p0/z -> %z0.s
@@ -12008,6 +13046,142 @@ c4dcbf59 : ldff1sh z25.d, p7/Z, [x26, z28.d]         : ldff1sh (%x26,%z28.d)[8by
 c4debf9b : ldff1sh z27.d, p7/Z, [x28, z30.d]         : ldff1sh (%x28,%z30.d)[8byte] %p7/z -> %z27.d
 c4dfbfff : ldff1sh z31.d, p7/Z, [sp, z31.d]          : ldff1sh (%sp,%z31.d)[8byte] %p7/z -> %z31.d
 
+# LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] (LDFF1SH-Z.P.BZ-D.x32.scaled)
+c4a02000 : ldff1sh z0.d, p0/Z, [x0, z0.d, UXTW #1]   : ldff1sh (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d
+c4a52482 : ldff1sh z2.d, p1/Z, [x4, z5.d, UXTW #1]   : ldff1sh (%x4,%z5.d,uxtw #1)[8byte] %p1/z -> %z2.d
+c4a728c4 : ldff1sh z4.d, p2/Z, [x6, z7.d, UXTW #1]   : ldff1sh (%x6,%z7.d,uxtw #1)[8byte] %p2/z -> %z4.d
+c4a92906 : ldff1sh z6.d, p2/Z, [x8, z9.d, UXTW #1]   : ldff1sh (%x8,%z9.d,uxtw #1)[8byte] %p2/z -> %z6.d
+c4ab2d48 : ldff1sh z8.d, p3/Z, [x10, z11.d, UXTW #1] : ldff1sh (%x10,%z11.d,uxtw #1)[8byte] %p3/z -> %z8.d
+c4ad2d6a : ldff1sh z10.d, p3/Z, [x11, z13.d, UXTW #1] : ldff1sh (%x11,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d
+c4af31ac : ldff1sh z12.d, p4/Z, [x13, z15.d, UXTW #1] : ldff1sh (%x13,%z15.d,uxtw #1)[8byte] %p4/z -> %z12.d
+c4b131ee : ldff1sh z14.d, p4/Z, [x15, z17.d, UXTW #1] : ldff1sh (%x15,%z17.d,uxtw #1)[8byte] %p4/z -> %z14.d
+c4b33630 : ldff1sh z16.d, p5/Z, [x17, z19.d, UXTW #1] : ldff1sh (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d
+c4b43671 : ldff1sh z17.d, p5/Z, [x19, z20.d, UXTW #1] : ldff1sh (%x19,%z20.d,uxtw #1)[8byte] %p5/z -> %z17.d
+c4b636b3 : ldff1sh z19.d, p5/Z, [x21, z22.d, UXTW #1] : ldff1sh (%x21,%z22.d,uxtw #1)[8byte] %p5/z -> %z19.d
+c4b83af5 : ldff1sh z21.d, p6/Z, [x23, z24.d, UXTW #1] : ldff1sh (%x23,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d
+c4ba3b17 : ldff1sh z23.d, p6/Z, [x24, z26.d, UXTW #1] : ldff1sh (%x24,%z26.d,uxtw #1)[8byte] %p6/z -> %z23.d
+c4bc3f59 : ldff1sh z25.d, p7/Z, [x26, z28.d, UXTW #1] : ldff1sh (%x26,%z28.d,uxtw #1)[8byte] %p7/z -> %z25.d
+c4be3f9b : ldff1sh z27.d, p7/Z, [x28, z30.d, UXTW #1] : ldff1sh (%x28,%z30.d,uxtw #1)[8byte] %p7/z -> %z27.d
+c4bf3fff : ldff1sh z31.d, p7/Z, [sp, z31.d, UXTW #1] : ldff1sh (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d
+c4e02000 : ldff1sh z0.d, p0/Z, [x0, z0.d, SXTW #1]   : ldff1sh (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d
+c4e52482 : ldff1sh z2.d, p1/Z, [x4, z5.d, SXTW #1]   : ldff1sh (%x4,%z5.d,sxtw #1)[8byte] %p1/z -> %z2.d
+c4e728c4 : ldff1sh z4.d, p2/Z, [x6, z7.d, SXTW #1]   : ldff1sh (%x6,%z7.d,sxtw #1)[8byte] %p2/z -> %z4.d
+c4e92906 : ldff1sh z6.d, p2/Z, [x8, z9.d, SXTW #1]   : ldff1sh (%x8,%z9.d,sxtw #1)[8byte] %p2/z -> %z6.d
+c4eb2d48 : ldff1sh z8.d, p3/Z, [x10, z11.d, SXTW #1] : ldff1sh (%x10,%z11.d,sxtw #1)[8byte] %p3/z -> %z8.d
+c4ed2d6a : ldff1sh z10.d, p3/Z, [x11, z13.d, SXTW #1] : ldff1sh (%x11,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d
+c4ef31ac : ldff1sh z12.d, p4/Z, [x13, z15.d, SXTW #1] : ldff1sh (%x13,%z15.d,sxtw #1)[8byte] %p4/z -> %z12.d
+c4f131ee : ldff1sh z14.d, p4/Z, [x15, z17.d, SXTW #1] : ldff1sh (%x15,%z17.d,sxtw #1)[8byte] %p4/z -> %z14.d
+c4f33630 : ldff1sh z16.d, p5/Z, [x17, z19.d, SXTW #1] : ldff1sh (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d
+c4f43671 : ldff1sh z17.d, p5/Z, [x19, z20.d, SXTW #1] : ldff1sh (%x19,%z20.d,sxtw #1)[8byte] %p5/z -> %z17.d
+c4f636b3 : ldff1sh z19.d, p5/Z, [x21, z22.d, SXTW #1] : ldff1sh (%x21,%z22.d,sxtw #1)[8byte] %p5/z -> %z19.d
+c4f83af5 : ldff1sh z21.d, p6/Z, [x23, z24.d, SXTW #1] : ldff1sh (%x23,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d
+c4fa3b17 : ldff1sh z23.d, p6/Z, [x24, z26.d, SXTW #1] : ldff1sh (%x24,%z26.d,sxtw #1)[8byte] %p6/z -> %z23.d
+c4fc3f59 : ldff1sh z25.d, p7/Z, [x26, z28.d, SXTW #1] : ldff1sh (%x26,%z28.d,sxtw #1)[8byte] %p7/z -> %z25.d
+c4fe3f9b : ldff1sh z27.d, p7/Z, [x28, z30.d, SXTW #1] : ldff1sh (%x28,%z30.d,sxtw #1)[8byte] %p7/z -> %z27.d
+c4ff3fff : ldff1sh z31.d, p7/Z, [sp, z31.d, SXTW #1] : ldff1sh (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d
+
+# LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LDFF1SH-Z.P.BZ-D.x32.unscaled)
+c4802000 : ldff1sh z0.d, p0/Z, [x0, z0.d, UXTW]      : ldff1sh (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d
+c4852482 : ldff1sh z2.d, p1/Z, [x4, z5.d, UXTW]      : ldff1sh (%x4,%z5.d,uxtw)[8byte] %p1/z -> %z2.d
+c48728c4 : ldff1sh z4.d, p2/Z, [x6, z7.d, UXTW]      : ldff1sh (%x6,%z7.d,uxtw)[8byte] %p2/z -> %z4.d
+c4892906 : ldff1sh z6.d, p2/Z, [x8, z9.d, UXTW]      : ldff1sh (%x8,%z9.d,uxtw)[8byte] %p2/z -> %z6.d
+c48b2d48 : ldff1sh z8.d, p3/Z, [x10, z11.d, UXTW]    : ldff1sh (%x10,%z11.d,uxtw)[8byte] %p3/z -> %z8.d
+c48d2d6a : ldff1sh z10.d, p3/Z, [x11, z13.d, UXTW]   : ldff1sh (%x11,%z13.d,uxtw)[8byte] %p3/z -> %z10.d
+c48f31ac : ldff1sh z12.d, p4/Z, [x13, z15.d, UXTW]   : ldff1sh (%x13,%z15.d,uxtw)[8byte] %p4/z -> %z12.d
+c49131ee : ldff1sh z14.d, p4/Z, [x15, z17.d, UXTW]   : ldff1sh (%x15,%z17.d,uxtw)[8byte] %p4/z -> %z14.d
+c4933630 : ldff1sh z16.d, p5/Z, [x17, z19.d, UXTW]   : ldff1sh (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d
+c4943671 : ldff1sh z17.d, p5/Z, [x19, z20.d, UXTW]   : ldff1sh (%x19,%z20.d,uxtw)[8byte] %p5/z -> %z17.d
+c49636b3 : ldff1sh z19.d, p5/Z, [x21, z22.d, UXTW]   : ldff1sh (%x21,%z22.d,uxtw)[8byte] %p5/z -> %z19.d
+c4983af5 : ldff1sh z21.d, p6/Z, [x23, z24.d, UXTW]   : ldff1sh (%x23,%z24.d,uxtw)[8byte] %p6/z -> %z21.d
+c49a3b17 : ldff1sh z23.d, p6/Z, [x24, z26.d, UXTW]   : ldff1sh (%x24,%z26.d,uxtw)[8byte] %p6/z -> %z23.d
+c49c3f59 : ldff1sh z25.d, p7/Z, [x26, z28.d, UXTW]   : ldff1sh (%x26,%z28.d,uxtw)[8byte] %p7/z -> %z25.d
+c49e3f9b : ldff1sh z27.d, p7/Z, [x28, z30.d, UXTW]   : ldff1sh (%x28,%z30.d,uxtw)[8byte] %p7/z -> %z27.d
+c49f3fff : ldff1sh z31.d, p7/Z, [sp, z31.d, UXTW]    : ldff1sh (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d
+c4c02000 : ldff1sh z0.d, p0/Z, [x0, z0.d, SXTW]      : ldff1sh (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d
+c4c52482 : ldff1sh z2.d, p1/Z, [x4, z5.d, SXTW]      : ldff1sh (%x4,%z5.d,sxtw)[8byte] %p1/z -> %z2.d
+c4c728c4 : ldff1sh z4.d, p2/Z, [x6, z7.d, SXTW]      : ldff1sh (%x6,%z7.d,sxtw)[8byte] %p2/z -> %z4.d
+c4c92906 : ldff1sh z6.d, p2/Z, [x8, z9.d, SXTW]      : ldff1sh (%x8,%z9.d,sxtw)[8byte] %p2/z -> %z6.d
+c4cb2d48 : ldff1sh z8.d, p3/Z, [x10, z11.d, SXTW]    : ldff1sh (%x10,%z11.d,sxtw)[8byte] %p3/z -> %z8.d
+c4cd2d6a : ldff1sh z10.d, p3/Z, [x11, z13.d, SXTW]   : ldff1sh (%x11,%z13.d,sxtw)[8byte] %p3/z -> %z10.d
+c4cf31ac : ldff1sh z12.d, p4/Z, [x13, z15.d, SXTW]   : ldff1sh (%x13,%z15.d,sxtw)[8byte] %p4/z -> %z12.d
+c4d131ee : ldff1sh z14.d, p4/Z, [x15, z17.d, SXTW]   : ldff1sh (%x15,%z17.d,sxtw)[8byte] %p4/z -> %z14.d
+c4d33630 : ldff1sh z16.d, p5/Z, [x17, z19.d, SXTW]   : ldff1sh (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d
+c4d43671 : ldff1sh z17.d, p5/Z, [x19, z20.d, SXTW]   : ldff1sh (%x19,%z20.d,sxtw)[8byte] %p5/z -> %z17.d
+c4d636b3 : ldff1sh z19.d, p5/Z, [x21, z22.d, SXTW]   : ldff1sh (%x21,%z22.d,sxtw)[8byte] %p5/z -> %z19.d
+c4d83af5 : ldff1sh z21.d, p6/Z, [x23, z24.d, SXTW]   : ldff1sh (%x23,%z24.d,sxtw)[8byte] %p6/z -> %z21.d
+c4da3b17 : ldff1sh z23.d, p6/Z, [x24, z26.d, SXTW]   : ldff1sh (%x24,%z26.d,sxtw)[8byte] %p6/z -> %z23.d
+c4dc3f59 : ldff1sh z25.d, p7/Z, [x26, z28.d, SXTW]   : ldff1sh (%x26,%z28.d,sxtw)[8byte] %p7/z -> %z25.d
+c4de3f9b : ldff1sh z27.d, p7/Z, [x28, z30.d, SXTW]   : ldff1sh (%x28,%z30.d,sxtw)[8byte] %p7/z -> %z27.d
+c4df3fff : ldff1sh z31.d, p7/Z, [sp, z31.d, SXTW]    : ldff1sh (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d
+
+# LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] (LDFF1SH-Z.P.BZ-S.x32.scaled)
+84a02000 : ldff1sh z0.s, p0/Z, [x0, z0.s, UXTW #1]   : ldff1sh (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s
+84a52482 : ldff1sh z2.s, p1/Z, [x4, z5.s, UXTW #1]   : ldff1sh (%x4,%z5.s,uxtw #1)[16byte] %p1/z -> %z2.s
+84a728c4 : ldff1sh z4.s, p2/Z, [x6, z7.s, UXTW #1]   : ldff1sh (%x6,%z7.s,uxtw #1)[16byte] %p2/z -> %z4.s
+84a92906 : ldff1sh z6.s, p2/Z, [x8, z9.s, UXTW #1]   : ldff1sh (%x8,%z9.s,uxtw #1)[16byte] %p2/z -> %z6.s
+84ab2d48 : ldff1sh z8.s, p3/Z, [x10, z11.s, UXTW #1] : ldff1sh (%x10,%z11.s,uxtw #1)[16byte] %p3/z -> %z8.s
+84ad2d6a : ldff1sh z10.s, p3/Z, [x11, z13.s, UXTW #1] : ldff1sh (%x11,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s
+84af31ac : ldff1sh z12.s, p4/Z, [x13, z15.s, UXTW #1] : ldff1sh (%x13,%z15.s,uxtw #1)[16byte] %p4/z -> %z12.s
+84b131ee : ldff1sh z14.s, p4/Z, [x15, z17.s, UXTW #1] : ldff1sh (%x15,%z17.s,uxtw #1)[16byte] %p4/z -> %z14.s
+84b33630 : ldff1sh z16.s, p5/Z, [x17, z19.s, UXTW #1] : ldff1sh (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s
+84b43671 : ldff1sh z17.s, p5/Z, [x19, z20.s, UXTW #1] : ldff1sh (%x19,%z20.s,uxtw #1)[16byte] %p5/z -> %z17.s
+84b636b3 : ldff1sh z19.s, p5/Z, [x21, z22.s, UXTW #1] : ldff1sh (%x21,%z22.s,uxtw #1)[16byte] %p5/z -> %z19.s
+84b83af5 : ldff1sh z21.s, p6/Z, [x23, z24.s, UXTW #1] : ldff1sh (%x23,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s
+84ba3b17 : ldff1sh z23.s, p6/Z, [x24, z26.s, UXTW #1] : ldff1sh (%x24,%z26.s,uxtw #1)[16byte] %p6/z -> %z23.s
+84bc3f59 : ldff1sh z25.s, p7/Z, [x26, z28.s, UXTW #1] : ldff1sh (%x26,%z28.s,uxtw #1)[16byte] %p7/z -> %z25.s
+84be3f9b : ldff1sh z27.s, p7/Z, [x28, z30.s, UXTW #1] : ldff1sh (%x28,%z30.s,uxtw #1)[16byte] %p7/z -> %z27.s
+84bf3fff : ldff1sh z31.s, p7/Z, [sp, z31.s, UXTW #1] : ldff1sh (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s
+84e02000 : ldff1sh z0.s, p0/Z, [x0, z0.s, SXTW #1]   : ldff1sh (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s
+84e52482 : ldff1sh z2.s, p1/Z, [x4, z5.s, SXTW #1]   : ldff1sh (%x4,%z5.s,sxtw #1)[16byte] %p1/z -> %z2.s
+84e728c4 : ldff1sh z4.s, p2/Z, [x6, z7.s, SXTW #1]   : ldff1sh (%x6,%z7.s,sxtw #1)[16byte] %p2/z -> %z4.s
+84e92906 : ldff1sh z6.s, p2/Z, [x8, z9.s, SXTW #1]   : ldff1sh (%x8,%z9.s,sxtw #1)[16byte] %p2/z -> %z6.s
+84eb2d48 : ldff1sh z8.s, p3/Z, [x10, z11.s, SXTW #1] : ldff1sh (%x10,%z11.s,sxtw #1)[16byte] %p3/z -> %z8.s
+84ed2d6a : ldff1sh z10.s, p3/Z, [x11, z13.s, SXTW #1] : ldff1sh (%x11,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s
+84ef31ac : ldff1sh z12.s, p4/Z, [x13, z15.s, SXTW #1] : ldff1sh (%x13,%z15.s,sxtw #1)[16byte] %p4/z -> %z12.s
+84f131ee : ldff1sh z14.s, p4/Z, [x15, z17.s, SXTW #1] : ldff1sh (%x15,%z17.s,sxtw #1)[16byte] %p4/z -> %z14.s
+84f33630 : ldff1sh z16.s, p5/Z, [x17, z19.s, SXTW #1] : ldff1sh (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s
+84f43671 : ldff1sh z17.s, p5/Z, [x19, z20.s, SXTW #1] : ldff1sh (%x19,%z20.s,sxtw #1)[16byte] %p5/z -> %z17.s
+84f636b3 : ldff1sh z19.s, p5/Z, [x21, z22.s, SXTW #1] : ldff1sh (%x21,%z22.s,sxtw #1)[16byte] %p5/z -> %z19.s
+84f83af5 : ldff1sh z21.s, p6/Z, [x23, z24.s, SXTW #1] : ldff1sh (%x23,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s
+84fa3b17 : ldff1sh z23.s, p6/Z, [x24, z26.s, SXTW #1] : ldff1sh (%x24,%z26.s,sxtw #1)[16byte] %p6/z -> %z23.s
+84fc3f59 : ldff1sh z25.s, p7/Z, [x26, z28.s, SXTW #1] : ldff1sh (%x26,%z28.s,sxtw #1)[16byte] %p7/z -> %z25.s
+84fe3f9b : ldff1sh z27.s, p7/Z, [x28, z30.s, SXTW #1] : ldff1sh (%x28,%z30.s,sxtw #1)[16byte] %p7/z -> %z27.s
+84ff3fff : ldff1sh z31.s, p7/Z, [sp, z31.s, SXTW #1] : ldff1sh (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s
+
+# LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LDFF1SH-Z.P.BZ-S.x32.unscaled)
+84802000 : ldff1sh z0.s, p0/Z, [x0, z0.s, UXTW]      : ldff1sh (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s
+84852482 : ldff1sh z2.s, p1/Z, [x4, z5.s, UXTW]      : ldff1sh (%x4,%z5.s,uxtw)[16byte] %p1/z -> %z2.s
+848728c4 : ldff1sh z4.s, p2/Z, [x6, z7.s, UXTW]      : ldff1sh (%x6,%z7.s,uxtw)[16byte] %p2/z -> %z4.s
+84892906 : ldff1sh z6.s, p2/Z, [x8, z9.s, UXTW]      : ldff1sh (%x8,%z9.s,uxtw)[16byte] %p2/z -> %z6.s
+848b2d48 : ldff1sh z8.s, p3/Z, [x10, z11.s, UXTW]    : ldff1sh (%x10,%z11.s,uxtw)[16byte] %p3/z -> %z8.s
+848d2d6a : ldff1sh z10.s, p3/Z, [x11, z13.s, UXTW]   : ldff1sh (%x11,%z13.s,uxtw)[16byte] %p3/z -> %z10.s
+848f31ac : ldff1sh z12.s, p4/Z, [x13, z15.s, UXTW]   : ldff1sh (%x13,%z15.s,uxtw)[16byte] %p4/z -> %z12.s
+849131ee : ldff1sh z14.s, p4/Z, [x15, z17.s, UXTW]   : ldff1sh (%x15,%z17.s,uxtw)[16byte] %p4/z -> %z14.s
+84933630 : ldff1sh z16.s, p5/Z, [x17, z19.s, UXTW]   : ldff1sh (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s
+84943671 : ldff1sh z17.s, p5/Z, [x19, z20.s, UXTW]   : ldff1sh (%x19,%z20.s,uxtw)[16byte] %p5/z -> %z17.s
+849636b3 : ldff1sh z19.s, p5/Z, [x21, z22.s, UXTW]   : ldff1sh (%x21,%z22.s,uxtw)[16byte] %p5/z -> %z19.s
+84983af5 : ldff1sh z21.s, p6/Z, [x23, z24.s, UXTW]   : ldff1sh (%x23,%z24.s,uxtw)[16byte] %p6/z -> %z21.s
+849a3b17 : ldff1sh z23.s, p6/Z, [x24, z26.s, UXTW]   : ldff1sh (%x24,%z26.s,uxtw)[16byte] %p6/z -> %z23.s
+849c3f59 : ldff1sh z25.s, p7/Z, [x26, z28.s, UXTW]   : ldff1sh (%x26,%z28.s,uxtw)[16byte] %p7/z -> %z25.s
+849e3f9b : ldff1sh z27.s, p7/Z, [x28, z30.s, UXTW]   : ldff1sh (%x28,%z30.s,uxtw)[16byte] %p7/z -> %z27.s
+849f3fff : ldff1sh z31.s, p7/Z, [sp, z31.s, UXTW]    : ldff1sh (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s
+84c02000 : ldff1sh z0.s, p0/Z, [x0, z0.s, SXTW]      : ldff1sh (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s
+84c52482 : ldff1sh z2.s, p1/Z, [x4, z5.s, SXTW]      : ldff1sh (%x4,%z5.s,sxtw)[16byte] %p1/z -> %z2.s
+84c728c4 : ldff1sh z4.s, p2/Z, [x6, z7.s, SXTW]      : ldff1sh (%x6,%z7.s,sxtw)[16byte] %p2/z -> %z4.s
+84c92906 : ldff1sh z6.s, p2/Z, [x8, z9.s, SXTW]      : ldff1sh (%x8,%z9.s,sxtw)[16byte] %p2/z -> %z6.s
+84cb2d48 : ldff1sh z8.s, p3/Z, [x10, z11.s, SXTW]    : ldff1sh (%x10,%z11.s,sxtw)[16byte] %p3/z -> %z8.s
+84cd2d6a : ldff1sh z10.s, p3/Z, [x11, z13.s, SXTW]   : ldff1sh (%x11,%z13.s,sxtw)[16byte] %p3/z -> %z10.s
+84cf31ac : ldff1sh z12.s, p4/Z, [x13, z15.s, SXTW]   : ldff1sh (%x13,%z15.s,sxtw)[16byte] %p4/z -> %z12.s
+84d131ee : ldff1sh z14.s, p4/Z, [x15, z17.s, SXTW]   : ldff1sh (%x15,%z17.s,sxtw)[16byte] %p4/z -> %z14.s
+84d33630 : ldff1sh z16.s, p5/Z, [x17, z19.s, SXTW]   : ldff1sh (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s
+84d43671 : ldff1sh z17.s, p5/Z, [x19, z20.s, SXTW]   : ldff1sh (%x19,%z20.s,sxtw)[16byte] %p5/z -> %z17.s
+84d636b3 : ldff1sh z19.s, p5/Z, [x21, z22.s, SXTW]   : ldff1sh (%x21,%z22.s,sxtw)[16byte] %p5/z -> %z19.s
+84d83af5 : ldff1sh z21.s, p6/Z, [x23, z24.s, SXTW]   : ldff1sh (%x23,%z24.s,sxtw)[16byte] %p6/z -> %z21.s
+84da3b17 : ldff1sh z23.s, p6/Z, [x24, z26.s, SXTW]   : ldff1sh (%x24,%z26.s,sxtw)[16byte] %p6/z -> %z23.s
+84dc3f59 : ldff1sh z25.s, p7/Z, [x26, z28.s, SXTW]   : ldff1sh (%x26,%z28.s,sxtw)[16byte] %p7/z -> %z25.s
+84de3f9b : ldff1sh z27.s, p7/Z, [x28, z30.s, SXTW]   : ldff1sh (%x28,%z30.s,sxtw)[16byte] %p7/z -> %z27.s
+84df3fff : ldff1sh z31.s, p7/Z, [sp, z31.s, SXTW]    : ldff1sh (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s
+
 # LDFF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, <Xm>, LSL #2}] (LDFF1SW-Z.P.BR-S64)
 a4806000 : ldff1sw z0.d, p0/Z, [x0, x0, LSL #2]      : ldff1sw (%x0,%x0,lsl #2)[16byte] %p0/z -> %z0.d
 a4856482 : ldff1sw z2.d, p1/Z, [x4, x5, LSL #2]      : ldff1sw (%x4,%x5,lsl #2)[16byte] %p1/z -> %z2.d
@@ -12079,6 +13253,74 @@ c55abb17 : ldff1sw z23.d, p6/Z, [x24, z26.d]         : ldff1sw (%x24,%z26.d)[16b
 c55cbf59 : ldff1sw z25.d, p7/Z, [x26, z28.d]         : ldff1sw (%x26,%z28.d)[16byte] %p7/z -> %z25.d
 c55ebf9b : ldff1sw z27.d, p7/Z, [x28, z30.d]         : ldff1sw (%x28,%z30.d)[16byte] %p7/z -> %z27.d
 c55fbfff : ldff1sw z31.d, p7/Z, [sp, z31.d]          : ldff1sw (%sp,%z31.d)[16byte] %p7/z -> %z31.d
+
+# LDFF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] (LDFF1SW-Z.P.BZ-D.x32.scaled)
+c5202000 : ldff1sw z0.d, p0/Z, [x0, z0.d, UXTW #2]   : ldff1sw (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d
+c5252482 : ldff1sw z2.d, p1/Z, [x4, z5.d, UXTW #2]   : ldff1sw (%x4,%z5.d,uxtw #2)[16byte] %p1/z -> %z2.d
+c52728c4 : ldff1sw z4.d, p2/Z, [x6, z7.d, UXTW #2]   : ldff1sw (%x6,%z7.d,uxtw #2)[16byte] %p2/z -> %z4.d
+c5292906 : ldff1sw z6.d, p2/Z, [x8, z9.d, UXTW #2]   : ldff1sw (%x8,%z9.d,uxtw #2)[16byte] %p2/z -> %z6.d
+c52b2d48 : ldff1sw z8.d, p3/Z, [x10, z11.d, UXTW #2] : ldff1sw (%x10,%z11.d,uxtw #2)[16byte] %p3/z -> %z8.d
+c52d2d6a : ldff1sw z10.d, p3/Z, [x11, z13.d, UXTW #2] : ldff1sw (%x11,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d
+c52f31ac : ldff1sw z12.d, p4/Z, [x13, z15.d, UXTW #2] : ldff1sw (%x13,%z15.d,uxtw #2)[16byte] %p4/z -> %z12.d
+c53131ee : ldff1sw z14.d, p4/Z, [x15, z17.d, UXTW #2] : ldff1sw (%x15,%z17.d,uxtw #2)[16byte] %p4/z -> %z14.d
+c5333630 : ldff1sw z16.d, p5/Z, [x17, z19.d, UXTW #2] : ldff1sw (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d
+c5343671 : ldff1sw z17.d, p5/Z, [x19, z20.d, UXTW #2] : ldff1sw (%x19,%z20.d,uxtw #2)[16byte] %p5/z -> %z17.d
+c53636b3 : ldff1sw z19.d, p5/Z, [x21, z22.d, UXTW #2] : ldff1sw (%x21,%z22.d,uxtw #2)[16byte] %p5/z -> %z19.d
+c5383af5 : ldff1sw z21.d, p6/Z, [x23, z24.d, UXTW #2] : ldff1sw (%x23,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d
+c53a3b17 : ldff1sw z23.d, p6/Z, [x24, z26.d, UXTW #2] : ldff1sw (%x24,%z26.d,uxtw #2)[16byte] %p6/z -> %z23.d
+c53c3f59 : ldff1sw z25.d, p7/Z, [x26, z28.d, UXTW #2] : ldff1sw (%x26,%z28.d,uxtw #2)[16byte] %p7/z -> %z25.d
+c53e3f9b : ldff1sw z27.d, p7/Z, [x28, z30.d, UXTW #2] : ldff1sw (%x28,%z30.d,uxtw #2)[16byte] %p7/z -> %z27.d
+c53f3fff : ldff1sw z31.d, p7/Z, [sp, z31.d, UXTW #2] : ldff1sw (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d
+c5602000 : ldff1sw z0.d, p0/Z, [x0, z0.d, SXTW #2]   : ldff1sw (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d
+c5652482 : ldff1sw z2.d, p1/Z, [x4, z5.d, SXTW #2]   : ldff1sw (%x4,%z5.d,sxtw #2)[16byte] %p1/z -> %z2.d
+c56728c4 : ldff1sw z4.d, p2/Z, [x6, z7.d, SXTW #2]   : ldff1sw (%x6,%z7.d,sxtw #2)[16byte] %p2/z -> %z4.d
+c5692906 : ldff1sw z6.d, p2/Z, [x8, z9.d, SXTW #2]   : ldff1sw (%x8,%z9.d,sxtw #2)[16byte] %p2/z -> %z6.d
+c56b2d48 : ldff1sw z8.d, p3/Z, [x10, z11.d, SXTW #2] : ldff1sw (%x10,%z11.d,sxtw #2)[16byte] %p3/z -> %z8.d
+c56d2d6a : ldff1sw z10.d, p3/Z, [x11, z13.d, SXTW #2] : ldff1sw (%x11,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d
+c56f31ac : ldff1sw z12.d, p4/Z, [x13, z15.d, SXTW #2] : ldff1sw (%x13,%z15.d,sxtw #2)[16byte] %p4/z -> %z12.d
+c57131ee : ldff1sw z14.d, p4/Z, [x15, z17.d, SXTW #2] : ldff1sw (%x15,%z17.d,sxtw #2)[16byte] %p4/z -> %z14.d
+c5733630 : ldff1sw z16.d, p5/Z, [x17, z19.d, SXTW #2] : ldff1sw (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d
+c5743671 : ldff1sw z17.d, p5/Z, [x19, z20.d, SXTW #2] : ldff1sw (%x19,%z20.d,sxtw #2)[16byte] %p5/z -> %z17.d
+c57636b3 : ldff1sw z19.d, p5/Z, [x21, z22.d, SXTW #2] : ldff1sw (%x21,%z22.d,sxtw #2)[16byte] %p5/z -> %z19.d
+c5783af5 : ldff1sw z21.d, p6/Z, [x23, z24.d, SXTW #2] : ldff1sw (%x23,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d
+c57a3b17 : ldff1sw z23.d, p6/Z, [x24, z26.d, SXTW #2] : ldff1sw (%x24,%z26.d,sxtw #2)[16byte] %p6/z -> %z23.d
+c57c3f59 : ldff1sw z25.d, p7/Z, [x26, z28.d, SXTW #2] : ldff1sw (%x26,%z28.d,sxtw #2)[16byte] %p7/z -> %z25.d
+c57e3f9b : ldff1sw z27.d, p7/Z, [x28, z30.d, SXTW #2] : ldff1sw (%x28,%z30.d,sxtw #2)[16byte] %p7/z -> %z27.d
+c57f3fff : ldff1sw z31.d, p7/Z, [sp, z31.d, SXTW #2] : ldff1sw (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d
+
+# LDFF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LDFF1SW-Z.P.BZ-D.x32.unscaled)
+c5002000 : ldff1sw z0.d, p0/Z, [x0, z0.d, UXTW]      : ldff1sw (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d
+c5052482 : ldff1sw z2.d, p1/Z, [x4, z5.d, UXTW]      : ldff1sw (%x4,%z5.d,uxtw)[16byte] %p1/z -> %z2.d
+c50728c4 : ldff1sw z4.d, p2/Z, [x6, z7.d, UXTW]      : ldff1sw (%x6,%z7.d,uxtw)[16byte] %p2/z -> %z4.d
+c5092906 : ldff1sw z6.d, p2/Z, [x8, z9.d, UXTW]      : ldff1sw (%x8,%z9.d,uxtw)[16byte] %p2/z -> %z6.d
+c50b2d48 : ldff1sw z8.d, p3/Z, [x10, z11.d, UXTW]    : ldff1sw (%x10,%z11.d,uxtw)[16byte] %p3/z -> %z8.d
+c50d2d6a : ldff1sw z10.d, p3/Z, [x11, z13.d, UXTW]   : ldff1sw (%x11,%z13.d,uxtw)[16byte] %p3/z -> %z10.d
+c50f31ac : ldff1sw z12.d, p4/Z, [x13, z15.d, UXTW]   : ldff1sw (%x13,%z15.d,uxtw)[16byte] %p4/z -> %z12.d
+c51131ee : ldff1sw z14.d, p4/Z, [x15, z17.d, UXTW]   : ldff1sw (%x15,%z17.d,uxtw)[16byte] %p4/z -> %z14.d
+c5133630 : ldff1sw z16.d, p5/Z, [x17, z19.d, UXTW]   : ldff1sw (%x17,%z19.d,uxtw)[16byte] %p5/z -> %z16.d
+c5143671 : ldff1sw z17.d, p5/Z, [x19, z20.d, UXTW]   : ldff1sw (%x19,%z20.d,uxtw)[16byte] %p5/z -> %z17.d
+c51636b3 : ldff1sw z19.d, p5/Z, [x21, z22.d, UXTW]   : ldff1sw (%x21,%z22.d,uxtw)[16byte] %p5/z -> %z19.d
+c5183af5 : ldff1sw z21.d, p6/Z, [x23, z24.d, UXTW]   : ldff1sw (%x23,%z24.d,uxtw)[16byte] %p6/z -> %z21.d
+c51a3b17 : ldff1sw z23.d, p6/Z, [x24, z26.d, UXTW]   : ldff1sw (%x24,%z26.d,uxtw)[16byte] %p6/z -> %z23.d
+c51c3f59 : ldff1sw z25.d, p7/Z, [x26, z28.d, UXTW]   : ldff1sw (%x26,%z28.d,uxtw)[16byte] %p7/z -> %z25.d
+c51e3f9b : ldff1sw z27.d, p7/Z, [x28, z30.d, UXTW]   : ldff1sw (%x28,%z30.d,uxtw)[16byte] %p7/z -> %z27.d
+c51f3fff : ldff1sw z31.d, p7/Z, [sp, z31.d, UXTW]    : ldff1sw (%sp,%z31.d,uxtw)[16byte] %p7/z -> %z31.d
+c5402000 : ldff1sw z0.d, p0/Z, [x0, z0.d, SXTW]      : ldff1sw (%x0,%z0.d,sxtw)[16byte] %p0/z -> %z0.d
+c5452482 : ldff1sw z2.d, p1/Z, [x4, z5.d, SXTW]      : ldff1sw (%x4,%z5.d,sxtw)[16byte] %p1/z -> %z2.d
+c54728c4 : ldff1sw z4.d, p2/Z, [x6, z7.d, SXTW]      : ldff1sw (%x6,%z7.d,sxtw)[16byte] %p2/z -> %z4.d
+c5492906 : ldff1sw z6.d, p2/Z, [x8, z9.d, SXTW]      : ldff1sw (%x8,%z9.d,sxtw)[16byte] %p2/z -> %z6.d
+c54b2d48 : ldff1sw z8.d, p3/Z, [x10, z11.d, SXTW]    : ldff1sw (%x10,%z11.d,sxtw)[16byte] %p3/z -> %z8.d
+c54d2d6a : ldff1sw z10.d, p3/Z, [x11, z13.d, SXTW]   : ldff1sw (%x11,%z13.d,sxtw)[16byte] %p3/z -> %z10.d
+c54f31ac : ldff1sw z12.d, p4/Z, [x13, z15.d, SXTW]   : ldff1sw (%x13,%z15.d,sxtw)[16byte] %p4/z -> %z12.d
+c55131ee : ldff1sw z14.d, p4/Z, [x15, z17.d, SXTW]   : ldff1sw (%x15,%z17.d,sxtw)[16byte] %p4/z -> %z14.d
+c5533630 : ldff1sw z16.d, p5/Z, [x17, z19.d, SXTW]   : ldff1sw (%x17,%z19.d,sxtw)[16byte] %p5/z -> %z16.d
+c5543671 : ldff1sw z17.d, p5/Z, [x19, z20.d, SXTW]   : ldff1sw (%x19,%z20.d,sxtw)[16byte] %p5/z -> %z17.d
+c55636b3 : ldff1sw z19.d, p5/Z, [x21, z22.d, SXTW]   : ldff1sw (%x21,%z22.d,sxtw)[16byte] %p5/z -> %z19.d
+c5583af5 : ldff1sw z21.d, p6/Z, [x23, z24.d, SXTW]   : ldff1sw (%x23,%z24.d,sxtw)[16byte] %p6/z -> %z21.d
+c55a3b17 : ldff1sw z23.d, p6/Z, [x24, z26.d, SXTW]   : ldff1sw (%x24,%z26.d,sxtw)[16byte] %p6/z -> %z23.d
+c55c3f59 : ldff1sw z25.d, p7/Z, [x26, z28.d, SXTW]   : ldff1sw (%x26,%z28.d,sxtw)[16byte] %p7/z -> %z25.d
+c55e3f9b : ldff1sw z27.d, p7/Z, [x28, z30.d, SXTW]   : ldff1sw (%x28,%z30.d,sxtw)[16byte] %p7/z -> %z27.d
+c55f3fff : ldff1sw z31.d, p7/Z, [sp, z31.d, SXTW]    : ldff1sw (%sp,%z31.d,sxtw)[16byte] %p7/z -> %z31.d
 
 # LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, <Xm>, LSL #2}] (LDFF1W-Z.P.BR-U32)
 a5406000 : ldff1w z0.s, p0/Z, [x0, x0, LSL #2]       : ldff1w (%x0,%x0,lsl #2)[32byte] %p0/z -> %z0.s
@@ -12187,6 +13429,142 @@ c55afb17 : ldff1w z23.d, p6/Z, [x24, z26.d]          : ldff1w (%x24,%z26.d)[16by
 c55cff59 : ldff1w z25.d, p7/Z, [x26, z28.d]          : ldff1w (%x26,%z28.d)[16byte] %p7/z -> %z25.d
 c55eff9b : ldff1w z27.d, p7/Z, [x28, z30.d]          : ldff1w (%x28,%z30.d)[16byte] %p7/z -> %z27.d
 c55fffff : ldff1w z31.d, p7/Z, [sp, z31.d]           : ldff1w (%sp,%z31.d)[16byte] %p7/z -> %z31.d
+
+# LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] (LDFF1W-Z.P.BZ-D.x32.scaled)
+c5206000 : ldff1w z0.d, p0/Z, [x0, z0.d, UXTW #2]    : ldff1w (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d
+c5256482 : ldff1w z2.d, p1/Z, [x4, z5.d, UXTW #2]    : ldff1w (%x4,%z5.d,uxtw #2)[16byte] %p1/z -> %z2.d
+c52768c4 : ldff1w z4.d, p2/Z, [x6, z7.d, UXTW #2]    : ldff1w (%x6,%z7.d,uxtw #2)[16byte] %p2/z -> %z4.d
+c5296906 : ldff1w z6.d, p2/Z, [x8, z9.d, UXTW #2]    : ldff1w (%x8,%z9.d,uxtw #2)[16byte] %p2/z -> %z6.d
+c52b6d48 : ldff1w z8.d, p3/Z, [x10, z11.d, UXTW #2]  : ldff1w (%x10,%z11.d,uxtw #2)[16byte] %p3/z -> %z8.d
+c52d6d6a : ldff1w z10.d, p3/Z, [x11, z13.d, UXTW #2] : ldff1w (%x11,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d
+c52f71ac : ldff1w z12.d, p4/Z, [x13, z15.d, UXTW #2] : ldff1w (%x13,%z15.d,uxtw #2)[16byte] %p4/z -> %z12.d
+c53171ee : ldff1w z14.d, p4/Z, [x15, z17.d, UXTW #2] : ldff1w (%x15,%z17.d,uxtw #2)[16byte] %p4/z -> %z14.d
+c5337630 : ldff1w z16.d, p5/Z, [x17, z19.d, UXTW #2] : ldff1w (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d
+c5347671 : ldff1w z17.d, p5/Z, [x19, z20.d, UXTW #2] : ldff1w (%x19,%z20.d,uxtw #2)[16byte] %p5/z -> %z17.d
+c53676b3 : ldff1w z19.d, p5/Z, [x21, z22.d, UXTW #2] : ldff1w (%x21,%z22.d,uxtw #2)[16byte] %p5/z -> %z19.d
+c5387af5 : ldff1w z21.d, p6/Z, [x23, z24.d, UXTW #2] : ldff1w (%x23,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d
+c53a7b17 : ldff1w z23.d, p6/Z, [x24, z26.d, UXTW #2] : ldff1w (%x24,%z26.d,uxtw #2)[16byte] %p6/z -> %z23.d
+c53c7f59 : ldff1w z25.d, p7/Z, [x26, z28.d, UXTW #2] : ldff1w (%x26,%z28.d,uxtw #2)[16byte] %p7/z -> %z25.d
+c53e7f9b : ldff1w z27.d, p7/Z, [x28, z30.d, UXTW #2] : ldff1w (%x28,%z30.d,uxtw #2)[16byte] %p7/z -> %z27.d
+c53f7fff : ldff1w z31.d, p7/Z, [sp, z31.d, UXTW #2]  : ldff1w (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d
+c5606000 : ldff1w z0.d, p0/Z, [x0, z0.d, SXTW #2]    : ldff1w (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d
+c5656482 : ldff1w z2.d, p1/Z, [x4, z5.d, SXTW #2]    : ldff1w (%x4,%z5.d,sxtw #2)[16byte] %p1/z -> %z2.d
+c56768c4 : ldff1w z4.d, p2/Z, [x6, z7.d, SXTW #2]    : ldff1w (%x6,%z7.d,sxtw #2)[16byte] %p2/z -> %z4.d
+c5696906 : ldff1w z6.d, p2/Z, [x8, z9.d, SXTW #2]    : ldff1w (%x8,%z9.d,sxtw #2)[16byte] %p2/z -> %z6.d
+c56b6d48 : ldff1w z8.d, p3/Z, [x10, z11.d, SXTW #2]  : ldff1w (%x10,%z11.d,sxtw #2)[16byte] %p3/z -> %z8.d
+c56d6d6a : ldff1w z10.d, p3/Z, [x11, z13.d, SXTW #2] : ldff1w (%x11,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d
+c56f71ac : ldff1w z12.d, p4/Z, [x13, z15.d, SXTW #2] : ldff1w (%x13,%z15.d,sxtw #2)[16byte] %p4/z -> %z12.d
+c57171ee : ldff1w z14.d, p4/Z, [x15, z17.d, SXTW #2] : ldff1w (%x15,%z17.d,sxtw #2)[16byte] %p4/z -> %z14.d
+c5737630 : ldff1w z16.d, p5/Z, [x17, z19.d, SXTW #2] : ldff1w (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d
+c5747671 : ldff1w z17.d, p5/Z, [x19, z20.d, SXTW #2] : ldff1w (%x19,%z20.d,sxtw #2)[16byte] %p5/z -> %z17.d
+c57676b3 : ldff1w z19.d, p5/Z, [x21, z22.d, SXTW #2] : ldff1w (%x21,%z22.d,sxtw #2)[16byte] %p5/z -> %z19.d
+c5787af5 : ldff1w z21.d, p6/Z, [x23, z24.d, SXTW #2] : ldff1w (%x23,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d
+c57a7b17 : ldff1w z23.d, p6/Z, [x24, z26.d, SXTW #2] : ldff1w (%x24,%z26.d,sxtw #2)[16byte] %p6/z -> %z23.d
+c57c7f59 : ldff1w z25.d, p7/Z, [x26, z28.d, SXTW #2] : ldff1w (%x26,%z28.d,sxtw #2)[16byte] %p7/z -> %z25.d
+c57e7f9b : ldff1w z27.d, p7/Z, [x28, z30.d, SXTW #2] : ldff1w (%x28,%z30.d,sxtw #2)[16byte] %p7/z -> %z27.d
+c57f7fff : ldff1w z31.d, p7/Z, [sp, z31.d, SXTW #2]  : ldff1w (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d
+
+# LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LDFF1W-Z.P.BZ-D.x32.unscaled)
+c5006000 : ldff1w z0.d, p0/Z, [x0, z0.d, UXTW]       : ldff1w (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d
+c5056482 : ldff1w z2.d, p1/Z, [x4, z5.d, UXTW]       : ldff1w (%x4,%z5.d,uxtw)[16byte] %p1/z -> %z2.d
+c50768c4 : ldff1w z4.d, p2/Z, [x6, z7.d, UXTW]       : ldff1w (%x6,%z7.d,uxtw)[16byte] %p2/z -> %z4.d
+c5096906 : ldff1w z6.d, p2/Z, [x8, z9.d, UXTW]       : ldff1w (%x8,%z9.d,uxtw)[16byte] %p2/z -> %z6.d
+c50b6d48 : ldff1w z8.d, p3/Z, [x10, z11.d, UXTW]     : ldff1w (%x10,%z11.d,uxtw)[16byte] %p3/z -> %z8.d
+c50d6d6a : ldff1w z10.d, p3/Z, [x11, z13.d, UXTW]    : ldff1w (%x11,%z13.d,uxtw)[16byte] %p3/z -> %z10.d
+c50f71ac : ldff1w z12.d, p4/Z, [x13, z15.d, UXTW]    : ldff1w (%x13,%z15.d,uxtw)[16byte] %p4/z -> %z12.d
+c51171ee : ldff1w z14.d, p4/Z, [x15, z17.d, UXTW]    : ldff1w (%x15,%z17.d,uxtw)[16byte] %p4/z -> %z14.d
+c5137630 : ldff1w z16.d, p5/Z, [x17, z19.d, UXTW]    : ldff1w (%x17,%z19.d,uxtw)[16byte] %p5/z -> %z16.d
+c5147671 : ldff1w z17.d, p5/Z, [x19, z20.d, UXTW]    : ldff1w (%x19,%z20.d,uxtw)[16byte] %p5/z -> %z17.d
+c51676b3 : ldff1w z19.d, p5/Z, [x21, z22.d, UXTW]    : ldff1w (%x21,%z22.d,uxtw)[16byte] %p5/z -> %z19.d
+c5187af5 : ldff1w z21.d, p6/Z, [x23, z24.d, UXTW]    : ldff1w (%x23,%z24.d,uxtw)[16byte] %p6/z -> %z21.d
+c51a7b17 : ldff1w z23.d, p6/Z, [x24, z26.d, UXTW]    : ldff1w (%x24,%z26.d,uxtw)[16byte] %p6/z -> %z23.d
+c51c7f59 : ldff1w z25.d, p7/Z, [x26, z28.d, UXTW]    : ldff1w (%x26,%z28.d,uxtw)[16byte] %p7/z -> %z25.d
+c51e7f9b : ldff1w z27.d, p7/Z, [x28, z30.d, UXTW]    : ldff1w (%x28,%z30.d,uxtw)[16byte] %p7/z -> %z27.d
+c51f7fff : ldff1w z31.d, p7/Z, [sp, z31.d, UXTW]     : ldff1w (%sp,%z31.d,uxtw)[16byte] %p7/z -> %z31.d
+c5406000 : ldff1w z0.d, p0/Z, [x0, z0.d, SXTW]       : ldff1w (%x0,%z0.d,sxtw)[16byte] %p0/z -> %z0.d
+c5456482 : ldff1w z2.d, p1/Z, [x4, z5.d, SXTW]       : ldff1w (%x4,%z5.d,sxtw)[16byte] %p1/z -> %z2.d
+c54768c4 : ldff1w z4.d, p2/Z, [x6, z7.d, SXTW]       : ldff1w (%x6,%z7.d,sxtw)[16byte] %p2/z -> %z4.d
+c5496906 : ldff1w z6.d, p2/Z, [x8, z9.d, SXTW]       : ldff1w (%x8,%z9.d,sxtw)[16byte] %p2/z -> %z6.d
+c54b6d48 : ldff1w z8.d, p3/Z, [x10, z11.d, SXTW]     : ldff1w (%x10,%z11.d,sxtw)[16byte] %p3/z -> %z8.d
+c54d6d6a : ldff1w z10.d, p3/Z, [x11, z13.d, SXTW]    : ldff1w (%x11,%z13.d,sxtw)[16byte] %p3/z -> %z10.d
+c54f71ac : ldff1w z12.d, p4/Z, [x13, z15.d, SXTW]    : ldff1w (%x13,%z15.d,sxtw)[16byte] %p4/z -> %z12.d
+c55171ee : ldff1w z14.d, p4/Z, [x15, z17.d, SXTW]    : ldff1w (%x15,%z17.d,sxtw)[16byte] %p4/z -> %z14.d
+c5537630 : ldff1w z16.d, p5/Z, [x17, z19.d, SXTW]    : ldff1w (%x17,%z19.d,sxtw)[16byte] %p5/z -> %z16.d
+c5547671 : ldff1w z17.d, p5/Z, [x19, z20.d, SXTW]    : ldff1w (%x19,%z20.d,sxtw)[16byte] %p5/z -> %z17.d
+c55676b3 : ldff1w z19.d, p5/Z, [x21, z22.d, SXTW]    : ldff1w (%x21,%z22.d,sxtw)[16byte] %p5/z -> %z19.d
+c5587af5 : ldff1w z21.d, p6/Z, [x23, z24.d, SXTW]    : ldff1w (%x23,%z24.d,sxtw)[16byte] %p6/z -> %z21.d
+c55a7b17 : ldff1w z23.d, p6/Z, [x24, z26.d, SXTW]    : ldff1w (%x24,%z26.d,sxtw)[16byte] %p6/z -> %z23.d
+c55c7f59 : ldff1w z25.d, p7/Z, [x26, z28.d, SXTW]    : ldff1w (%x26,%z28.d,sxtw)[16byte] %p7/z -> %z25.d
+c55e7f9b : ldff1w z27.d, p7/Z, [x28, z30.d, SXTW]    : ldff1w (%x28,%z30.d,sxtw)[16byte] %p7/z -> %z27.d
+c55f7fff : ldff1w z31.d, p7/Z, [sp, z31.d, SXTW]     : ldff1w (%sp,%z31.d,sxtw)[16byte] %p7/z -> %z31.d
+
+# LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2] (LDFF1W-Z.P.BZ-S.x32.scaled)
+85206000 : ldff1w z0.s, p0/Z, [x0, z0.s, UXTW #2]    : ldff1w (%x0,%z0.s,uxtw #2)[32byte] %p0/z -> %z0.s
+85256482 : ldff1w z2.s, p1/Z, [x4, z5.s, UXTW #2]    : ldff1w (%x4,%z5.s,uxtw #2)[32byte] %p1/z -> %z2.s
+852768c4 : ldff1w z4.s, p2/Z, [x6, z7.s, UXTW #2]    : ldff1w (%x6,%z7.s,uxtw #2)[32byte] %p2/z -> %z4.s
+85296906 : ldff1w z6.s, p2/Z, [x8, z9.s, UXTW #2]    : ldff1w (%x8,%z9.s,uxtw #2)[32byte] %p2/z -> %z6.s
+852b6d48 : ldff1w z8.s, p3/Z, [x10, z11.s, UXTW #2]  : ldff1w (%x10,%z11.s,uxtw #2)[32byte] %p3/z -> %z8.s
+852d6d6a : ldff1w z10.s, p3/Z, [x11, z13.s, UXTW #2] : ldff1w (%x11,%z13.s,uxtw #2)[32byte] %p3/z -> %z10.s
+852f71ac : ldff1w z12.s, p4/Z, [x13, z15.s, UXTW #2] : ldff1w (%x13,%z15.s,uxtw #2)[32byte] %p4/z -> %z12.s
+853171ee : ldff1w z14.s, p4/Z, [x15, z17.s, UXTW #2] : ldff1w (%x15,%z17.s,uxtw #2)[32byte] %p4/z -> %z14.s
+85337630 : ldff1w z16.s, p5/Z, [x17, z19.s, UXTW #2] : ldff1w (%x17,%z19.s,uxtw #2)[32byte] %p5/z -> %z16.s
+85347671 : ldff1w z17.s, p5/Z, [x19, z20.s, UXTW #2] : ldff1w (%x19,%z20.s,uxtw #2)[32byte] %p5/z -> %z17.s
+853676b3 : ldff1w z19.s, p5/Z, [x21, z22.s, UXTW #2] : ldff1w (%x21,%z22.s,uxtw #2)[32byte] %p5/z -> %z19.s
+85387af5 : ldff1w z21.s, p6/Z, [x23, z24.s, UXTW #2] : ldff1w (%x23,%z24.s,uxtw #2)[32byte] %p6/z -> %z21.s
+853a7b17 : ldff1w z23.s, p6/Z, [x24, z26.s, UXTW #2] : ldff1w (%x24,%z26.s,uxtw #2)[32byte] %p6/z -> %z23.s
+853c7f59 : ldff1w z25.s, p7/Z, [x26, z28.s, UXTW #2] : ldff1w (%x26,%z28.s,uxtw #2)[32byte] %p7/z -> %z25.s
+853e7f9b : ldff1w z27.s, p7/Z, [x28, z30.s, UXTW #2] : ldff1w (%x28,%z30.s,uxtw #2)[32byte] %p7/z -> %z27.s
+853f7fff : ldff1w z31.s, p7/Z, [sp, z31.s, UXTW #2]  : ldff1w (%sp,%z31.s,uxtw #2)[32byte] %p7/z -> %z31.s
+85606000 : ldff1w z0.s, p0/Z, [x0, z0.s, SXTW #2]    : ldff1w (%x0,%z0.s,sxtw #2)[32byte] %p0/z -> %z0.s
+85656482 : ldff1w z2.s, p1/Z, [x4, z5.s, SXTW #2]    : ldff1w (%x4,%z5.s,sxtw #2)[32byte] %p1/z -> %z2.s
+856768c4 : ldff1w z4.s, p2/Z, [x6, z7.s, SXTW #2]    : ldff1w (%x6,%z7.s,sxtw #2)[32byte] %p2/z -> %z4.s
+85696906 : ldff1w z6.s, p2/Z, [x8, z9.s, SXTW #2]    : ldff1w (%x8,%z9.s,sxtw #2)[32byte] %p2/z -> %z6.s
+856b6d48 : ldff1w z8.s, p3/Z, [x10, z11.s, SXTW #2]  : ldff1w (%x10,%z11.s,sxtw #2)[32byte] %p3/z -> %z8.s
+856d6d6a : ldff1w z10.s, p3/Z, [x11, z13.s, SXTW #2] : ldff1w (%x11,%z13.s,sxtw #2)[32byte] %p3/z -> %z10.s
+856f71ac : ldff1w z12.s, p4/Z, [x13, z15.s, SXTW #2] : ldff1w (%x13,%z15.s,sxtw #2)[32byte] %p4/z -> %z12.s
+857171ee : ldff1w z14.s, p4/Z, [x15, z17.s, SXTW #2] : ldff1w (%x15,%z17.s,sxtw #2)[32byte] %p4/z -> %z14.s
+85737630 : ldff1w z16.s, p5/Z, [x17, z19.s, SXTW #2] : ldff1w (%x17,%z19.s,sxtw #2)[32byte] %p5/z -> %z16.s
+85747671 : ldff1w z17.s, p5/Z, [x19, z20.s, SXTW #2] : ldff1w (%x19,%z20.s,sxtw #2)[32byte] %p5/z -> %z17.s
+857676b3 : ldff1w z19.s, p5/Z, [x21, z22.s, SXTW #2] : ldff1w (%x21,%z22.s,sxtw #2)[32byte] %p5/z -> %z19.s
+85787af5 : ldff1w z21.s, p6/Z, [x23, z24.s, SXTW #2] : ldff1w (%x23,%z24.s,sxtw #2)[32byte] %p6/z -> %z21.s
+857a7b17 : ldff1w z23.s, p6/Z, [x24, z26.s, SXTW #2] : ldff1w (%x24,%z26.s,sxtw #2)[32byte] %p6/z -> %z23.s
+857c7f59 : ldff1w z25.s, p7/Z, [x26, z28.s, SXTW #2] : ldff1w (%x26,%z28.s,sxtw #2)[32byte] %p7/z -> %z25.s
+857e7f9b : ldff1w z27.s, p7/Z, [x28, z30.s, SXTW #2] : ldff1w (%x28,%z30.s,sxtw #2)[32byte] %p7/z -> %z27.s
+857f7fff : ldff1w z31.s, p7/Z, [sp, z31.s, SXTW #2]  : ldff1w (%sp,%z31.s,sxtw #2)[32byte] %p7/z -> %z31.s
+
+# LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LDFF1W-Z.P.BZ-S.x32.unscaled)
+85006000 : ldff1w z0.s, p0/Z, [x0, z0.s, UXTW]       : ldff1w (%x0,%z0.s,uxtw)[32byte] %p0/z -> %z0.s
+85056482 : ldff1w z2.s, p1/Z, [x4, z5.s, UXTW]       : ldff1w (%x4,%z5.s,uxtw)[32byte] %p1/z -> %z2.s
+850768c4 : ldff1w z4.s, p2/Z, [x6, z7.s, UXTW]       : ldff1w (%x6,%z7.s,uxtw)[32byte] %p2/z -> %z4.s
+85096906 : ldff1w z6.s, p2/Z, [x8, z9.s, UXTW]       : ldff1w (%x8,%z9.s,uxtw)[32byte] %p2/z -> %z6.s
+850b6d48 : ldff1w z8.s, p3/Z, [x10, z11.s, UXTW]     : ldff1w (%x10,%z11.s,uxtw)[32byte] %p3/z -> %z8.s
+850d6d6a : ldff1w z10.s, p3/Z, [x11, z13.s, UXTW]    : ldff1w (%x11,%z13.s,uxtw)[32byte] %p3/z -> %z10.s
+850f71ac : ldff1w z12.s, p4/Z, [x13, z15.s, UXTW]    : ldff1w (%x13,%z15.s,uxtw)[32byte] %p4/z -> %z12.s
+851171ee : ldff1w z14.s, p4/Z, [x15, z17.s, UXTW]    : ldff1w (%x15,%z17.s,uxtw)[32byte] %p4/z -> %z14.s
+85137630 : ldff1w z16.s, p5/Z, [x17, z19.s, UXTW]    : ldff1w (%x17,%z19.s,uxtw)[32byte] %p5/z -> %z16.s
+85147671 : ldff1w z17.s, p5/Z, [x19, z20.s, UXTW]    : ldff1w (%x19,%z20.s,uxtw)[32byte] %p5/z -> %z17.s
+851676b3 : ldff1w z19.s, p5/Z, [x21, z22.s, UXTW]    : ldff1w (%x21,%z22.s,uxtw)[32byte] %p5/z -> %z19.s
+85187af5 : ldff1w z21.s, p6/Z, [x23, z24.s, UXTW]    : ldff1w (%x23,%z24.s,uxtw)[32byte] %p6/z -> %z21.s
+851a7b17 : ldff1w z23.s, p6/Z, [x24, z26.s, UXTW]    : ldff1w (%x24,%z26.s,uxtw)[32byte] %p6/z -> %z23.s
+851c7f59 : ldff1w z25.s, p7/Z, [x26, z28.s, UXTW]    : ldff1w (%x26,%z28.s,uxtw)[32byte] %p7/z -> %z25.s
+851e7f9b : ldff1w z27.s, p7/Z, [x28, z30.s, UXTW]    : ldff1w (%x28,%z30.s,uxtw)[32byte] %p7/z -> %z27.s
+851f7fff : ldff1w z31.s, p7/Z, [sp, z31.s, UXTW]     : ldff1w (%sp,%z31.s,uxtw)[32byte] %p7/z -> %z31.s
+85406000 : ldff1w z0.s, p0/Z, [x0, z0.s, SXTW]       : ldff1w (%x0,%z0.s,sxtw)[32byte] %p0/z -> %z0.s
+85456482 : ldff1w z2.s, p1/Z, [x4, z5.s, SXTW]       : ldff1w (%x4,%z5.s,sxtw)[32byte] %p1/z -> %z2.s
+854768c4 : ldff1w z4.s, p2/Z, [x6, z7.s, SXTW]       : ldff1w (%x6,%z7.s,sxtw)[32byte] %p2/z -> %z4.s
+85496906 : ldff1w z6.s, p2/Z, [x8, z9.s, SXTW]       : ldff1w (%x8,%z9.s,sxtw)[32byte] %p2/z -> %z6.s
+854b6d48 : ldff1w z8.s, p3/Z, [x10, z11.s, SXTW]     : ldff1w (%x10,%z11.s,sxtw)[32byte] %p3/z -> %z8.s
+854d6d6a : ldff1w z10.s, p3/Z, [x11, z13.s, SXTW]    : ldff1w (%x11,%z13.s,sxtw)[32byte] %p3/z -> %z10.s
+854f71ac : ldff1w z12.s, p4/Z, [x13, z15.s, SXTW]    : ldff1w (%x13,%z15.s,sxtw)[32byte] %p4/z -> %z12.s
+855171ee : ldff1w z14.s, p4/Z, [x15, z17.s, SXTW]    : ldff1w (%x15,%z17.s,sxtw)[32byte] %p4/z -> %z14.s
+85537630 : ldff1w z16.s, p5/Z, [x17, z19.s, SXTW]    : ldff1w (%x17,%z19.s,sxtw)[32byte] %p5/z -> %z16.s
+85547671 : ldff1w z17.s, p5/Z, [x19, z20.s, SXTW]    : ldff1w (%x19,%z20.s,sxtw)[32byte] %p5/z -> %z17.s
+855676b3 : ldff1w z19.s, p5/Z, [x21, z22.s, SXTW]    : ldff1w (%x21,%z22.s,sxtw)[32byte] %p5/z -> %z19.s
+85587af5 : ldff1w z21.s, p6/Z, [x23, z24.s, SXTW]    : ldff1w (%x23,%z24.s,sxtw)[32byte] %p6/z -> %z21.s
+855a7b17 : ldff1w z23.s, p6/Z, [x24, z26.s, SXTW]    : ldff1w (%x24,%z26.s,sxtw)[32byte] %p6/z -> %z23.s
+855c7f59 : ldff1w z25.s, p7/Z, [x26, z28.s, SXTW]    : ldff1w (%x26,%z28.s,sxtw)[32byte] %p7/z -> %z25.s
+855e7f9b : ldff1w z27.s, p7/Z, [x28, z30.s, SXTW]    : ldff1w (%x28,%z30.s,sxtw)[32byte] %p7/z -> %z27.s
+855f7fff : ldff1w z31.s, p7/Z, [sp, z31.s, SXTW]     : ldff1w (%sp,%z31.s,sxtw)[32byte] %p7/z -> %z31.s
 
 # LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LDNT1B-Z.P.BR-Contiguous)
 a400c000 : ldnt1b z0.b, p0/Z, [x0, x0]               : ldnt1b (%x0,%x0)[32byte] %p0/z -> %z0.b
@@ -14178,6 +15556,74 @@ c47c9f4d : prfb PSTL3STRM, p7, [x26, z28.d]          : prfb   $0x0d %p7 (%x26,%z
 c47e9f8e : prfb 14, p7, [x28, z30.d]                 : prfb   $0x0e %p7 (%x28,%z30.d)
 c47f9fef : prfb 15, p7, [sp, z31.d]                  : prfb   $0x0f %p7 (%sp,%z31.d)
 
+# PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] (PRFB-I.P.BZ-D.x32.scaled)
+c4200000 : prfb PLDL1KEEP, p0, [x0, z0.d, UXTW]      : prfb   $0x00 %p0 (%x0,%z0.d,uxtw)
+c4250481 : prfb PLDL1STRM, p1, [x4, z5.d, UXTW]      : prfb   $0x01 %p1 (%x4,%z5.d,uxtw)
+c42708c2 : prfb PLDL2KEEP, p2, [x6, z7.d, UXTW]      : prfb   $0x02 %p2 (%x6,%z7.d,uxtw)
+c4290903 : prfb PLDL2STRM, p2, [x8, z9.d, UXTW]      : prfb   $0x03 %p2 (%x8,%z9.d,uxtw)
+c42b0d44 : prfb PLDL3KEEP, p3, [x10, z11.d, UXTW]    : prfb   $0x04 %p3 (%x10,%z11.d,uxtw)
+c42d0d65 : prfb PLDL3STRM, p3, [x11, z13.d, UXTW]    : prfb   $0x05 %p3 (%x11,%z13.d,uxtw)
+c42f11a6 : prfb 6, p4, [x13, z15.d, UXTW]            : prfb   $0x06 %p4 (%x13,%z15.d,uxtw)
+c43111e7 : prfb 7, p4, [x15, z17.d, UXTW]            : prfb   $0x07 %p4 (%x15,%z17.d,uxtw)
+c4331628 : prfb PSTL1KEEP, p5, [x17, z19.d, UXTW]    : prfb   $0x08 %p5 (%x17,%z19.d,uxtw)
+c4341669 : prfb PSTL1STRM, p5, [x19, z20.d, UXTW]    : prfb   $0x09 %p5 (%x19,%z20.d,uxtw)
+c43616aa : prfb PSTL2KEEP, p5, [x21, z22.d, UXTW]    : prfb   $0x0a %p5 (%x21,%z22.d,uxtw)
+c4381aeb : prfb PSTL2STRM, p6, [x23, z24.d, UXTW]    : prfb   $0x0b %p6 (%x23,%z24.d,uxtw)
+c43a1b0c : prfb PSTL3KEEP, p6, [x24, z26.d, UXTW]    : prfb   $0x0c %p6 (%x24,%z26.d,uxtw)
+c43c1f4d : prfb PSTL3STRM, p7, [x26, z28.d, UXTW]    : prfb   $0x0d %p7 (%x26,%z28.d,uxtw)
+c43e1f8e : prfb 14, p7, [x28, z30.d, UXTW]           : prfb   $0x0e %p7 (%x28,%z30.d,uxtw)
+c43f1fef : prfb 15, p7, [sp, z31.d, UXTW]            : prfb   $0x0f %p7 (%sp,%z31.d,uxtw)
+c4600000 : prfb PLDL1KEEP, p0, [x0, z0.d, SXTW]      : prfb   $0x00 %p0 (%x0,%z0.d,sxtw)
+c4650481 : prfb PLDL1STRM, p1, [x4, z5.d, SXTW]      : prfb   $0x01 %p1 (%x4,%z5.d,sxtw)
+c46708c2 : prfb PLDL2KEEP, p2, [x6, z7.d, SXTW]      : prfb   $0x02 %p2 (%x6,%z7.d,sxtw)
+c4690903 : prfb PLDL2STRM, p2, [x8, z9.d, SXTW]      : prfb   $0x03 %p2 (%x8,%z9.d,sxtw)
+c46b0d44 : prfb PLDL3KEEP, p3, [x10, z11.d, SXTW]    : prfb   $0x04 %p3 (%x10,%z11.d,sxtw)
+c46d0d65 : prfb PLDL3STRM, p3, [x11, z13.d, SXTW]    : prfb   $0x05 %p3 (%x11,%z13.d,sxtw)
+c46f11a6 : prfb 6, p4, [x13, z15.d, SXTW]            : prfb   $0x06 %p4 (%x13,%z15.d,sxtw)
+c47111e7 : prfb 7, p4, [x15, z17.d, SXTW]            : prfb   $0x07 %p4 (%x15,%z17.d,sxtw)
+c4731628 : prfb PSTL1KEEP, p5, [x17, z19.d, SXTW]    : prfb   $0x08 %p5 (%x17,%z19.d,sxtw)
+c4741669 : prfb PSTL1STRM, p5, [x19, z20.d, SXTW]    : prfb   $0x09 %p5 (%x19,%z20.d,sxtw)
+c47616aa : prfb PSTL2KEEP, p5, [x21, z22.d, SXTW]    : prfb   $0x0a %p5 (%x21,%z22.d,sxtw)
+c4781aeb : prfb PSTL2STRM, p6, [x23, z24.d, SXTW]    : prfb   $0x0b %p6 (%x23,%z24.d,sxtw)
+c47a1b0c : prfb PSTL3KEEP, p6, [x24, z26.d, SXTW]    : prfb   $0x0c %p6 (%x24,%z26.d,sxtw)
+c47c1f4d : prfb PSTL3STRM, p7, [x26, z28.d, SXTW]    : prfb   $0x0d %p7 (%x26,%z28.d,sxtw)
+c47e1f8e : prfb 14, p7, [x28, z30.d, SXTW]           : prfb   $0x0e %p7 (%x28,%z30.d,sxtw)
+c47f1fef : prfb 15, p7, [sp, z31.d, SXTW]            : prfb   $0x0f %p7 (%sp,%z31.d,sxtw)
+
+# PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] (PRFB-I.P.BZ-S.x32.scaled)
+84200000 : prfb PLDL1KEEP, p0, [x0, z0.s, UXTW]      : prfb   $0x00 %p0 (%x0,%z0.s,uxtw)
+84250481 : prfb PLDL1STRM, p1, [x4, z5.s, UXTW]      : prfb   $0x01 %p1 (%x4,%z5.s,uxtw)
+842708c2 : prfb PLDL2KEEP, p2, [x6, z7.s, UXTW]      : prfb   $0x02 %p2 (%x6,%z7.s,uxtw)
+84290903 : prfb PLDL2STRM, p2, [x8, z9.s, UXTW]      : prfb   $0x03 %p2 (%x8,%z9.s,uxtw)
+842b0d44 : prfb PLDL3KEEP, p3, [x10, z11.s, UXTW]    : prfb   $0x04 %p3 (%x10,%z11.s,uxtw)
+842d0d65 : prfb PLDL3STRM, p3, [x11, z13.s, UXTW]    : prfb   $0x05 %p3 (%x11,%z13.s,uxtw)
+842f11a6 : prfb 6, p4, [x13, z15.s, UXTW]            : prfb   $0x06 %p4 (%x13,%z15.s,uxtw)
+843111e7 : prfb 7, p4, [x15, z17.s, UXTW]            : prfb   $0x07 %p4 (%x15,%z17.s,uxtw)
+84331628 : prfb PSTL1KEEP, p5, [x17, z19.s, UXTW]    : prfb   $0x08 %p5 (%x17,%z19.s,uxtw)
+84341669 : prfb PSTL1STRM, p5, [x19, z20.s, UXTW]    : prfb   $0x09 %p5 (%x19,%z20.s,uxtw)
+843616aa : prfb PSTL2KEEP, p5, [x21, z22.s, UXTW]    : prfb   $0x0a %p5 (%x21,%z22.s,uxtw)
+84381aeb : prfb PSTL2STRM, p6, [x23, z24.s, UXTW]    : prfb   $0x0b %p6 (%x23,%z24.s,uxtw)
+843a1b0c : prfb PSTL3KEEP, p6, [x24, z26.s, UXTW]    : prfb   $0x0c %p6 (%x24,%z26.s,uxtw)
+843c1f4d : prfb PSTL3STRM, p7, [x26, z28.s, UXTW]    : prfb   $0x0d %p7 (%x26,%z28.s,uxtw)
+843e1f8e : prfb 14, p7, [x28, z30.s, UXTW]           : prfb   $0x0e %p7 (%x28,%z30.s,uxtw)
+843f1fef : prfb 15, p7, [sp, z31.s, UXTW]            : prfb   $0x0f %p7 (%sp,%z31.s,uxtw)
+84600000 : prfb PLDL1KEEP, p0, [x0, z0.s, SXTW]      : prfb   $0x00 %p0 (%x0,%z0.s,sxtw)
+84650481 : prfb PLDL1STRM, p1, [x4, z5.s, SXTW]      : prfb   $0x01 %p1 (%x4,%z5.s,sxtw)
+846708c2 : prfb PLDL2KEEP, p2, [x6, z7.s, SXTW]      : prfb   $0x02 %p2 (%x6,%z7.s,sxtw)
+84690903 : prfb PLDL2STRM, p2, [x8, z9.s, SXTW]      : prfb   $0x03 %p2 (%x8,%z9.s,sxtw)
+846b0d44 : prfb PLDL3KEEP, p3, [x10, z11.s, SXTW]    : prfb   $0x04 %p3 (%x10,%z11.s,sxtw)
+846d0d65 : prfb PLDL3STRM, p3, [x11, z13.s, SXTW]    : prfb   $0x05 %p3 (%x11,%z13.s,sxtw)
+846f11a6 : prfb 6, p4, [x13, z15.s, SXTW]            : prfb   $0x06 %p4 (%x13,%z15.s,sxtw)
+847111e7 : prfb 7, p4, [x15, z17.s, SXTW]            : prfb   $0x07 %p4 (%x15,%z17.s,sxtw)
+84731628 : prfb PSTL1KEEP, p5, [x17, z19.s, SXTW]    : prfb   $0x08 %p5 (%x17,%z19.s,sxtw)
+84741669 : prfb PSTL1STRM, p5, [x19, z20.s, SXTW]    : prfb   $0x09 %p5 (%x19,%z20.s,sxtw)
+847616aa : prfb PSTL2KEEP, p5, [x21, z22.s, SXTW]    : prfb   $0x0a %p5 (%x21,%z22.s,sxtw)
+84781aeb : prfb PSTL2STRM, p6, [x23, z24.s, SXTW]    : prfb   $0x0b %p6 (%x23,%z24.s,sxtw)
+847a1b0c : prfb PSTL3KEEP, p6, [x24, z26.s, SXTW]    : prfb   $0x0c %p6 (%x24,%z26.s,sxtw)
+847c1f4d : prfb PSTL3STRM, p7, [x26, z28.s, SXTW]    : prfb   $0x0d %p7 (%x26,%z28.s,sxtw)
+847e1f8e : prfb 14, p7, [x28, z30.s, SXTW]           : prfb   $0x0e %p7 (%x28,%z30.s,sxtw)
+847f1fef : prfb 15, p7, [sp, z31.s, SXTW]            : prfb   $0x0f %p7 (%sp,%z31.s,sxtw)
+
 # PRFD    <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}] (PRFD-I.P.BI-S)
 85e06000 : prfd PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfd   $0x00 %p0 -0x20(%x0)
 85e46481 : prfd PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfd   $0x01 %p1 -0x1c(%x4)
@@ -14249,6 +15695,74 @@ c47afb0c : prfd PSTL3KEEP, p6, [x24, z26.d, LSL #3]  : prfd   $0x0c %p6 (%x24,%z
 c47cff4d : prfd PSTL3STRM, p7, [x26, z28.d, LSL #3]  : prfd   $0x0d %p7 (%x26,%z28.d,lsl #3)
 c47eff8e : prfd 14, p7, [x28, z30.d, LSL #3]         : prfd   $0x0e %p7 (%x28,%z30.d,lsl #3)
 c47fffef : prfd 15, p7, [sp, z31.d, LSL #3]          : prfd   $0x0f %p7 (%sp,%z31.d,lsl #3)
+
+# PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3] (PRFD-I.P.BZ-D.x32.scaled)
+c4206000 : prfd PLDL1KEEP, p0, [x0, z0.d, UXTW #3]   : prfd   $0x00 %p0 (%x0,%z0.d,uxtw #3)
+c4256481 : prfd PLDL1STRM, p1, [x4, z5.d, UXTW #3]   : prfd   $0x01 %p1 (%x4,%z5.d,uxtw #3)
+c42768c2 : prfd PLDL2KEEP, p2, [x6, z7.d, UXTW #3]   : prfd   $0x02 %p2 (%x6,%z7.d,uxtw #3)
+c4296903 : prfd PLDL2STRM, p2, [x8, z9.d, UXTW #3]   : prfd   $0x03 %p2 (%x8,%z9.d,uxtw #3)
+c42b6d44 : prfd PLDL3KEEP, p3, [x10, z11.d, UXTW #3] : prfd   $0x04 %p3 (%x10,%z11.d,uxtw #3)
+c42d6d65 : prfd PLDL3STRM, p3, [x11, z13.d, UXTW #3] : prfd   $0x05 %p3 (%x11,%z13.d,uxtw #3)
+c42f71a6 : prfd 6, p4, [x13, z15.d, UXTW #3]         : prfd   $0x06 %p4 (%x13,%z15.d,uxtw #3)
+c43171e7 : prfd 7, p4, [x15, z17.d, UXTW #3]         : prfd   $0x07 %p4 (%x15,%z17.d,uxtw #3)
+c4337628 : prfd PSTL1KEEP, p5, [x17, z19.d, UXTW #3] : prfd   $0x08 %p5 (%x17,%z19.d,uxtw #3)
+c4347669 : prfd PSTL1STRM, p5, [x19, z20.d, UXTW #3] : prfd   $0x09 %p5 (%x19,%z20.d,uxtw #3)
+c43676aa : prfd PSTL2KEEP, p5, [x21, z22.d, UXTW #3] : prfd   $0x0a %p5 (%x21,%z22.d,uxtw #3)
+c4387aeb : prfd PSTL2STRM, p6, [x23, z24.d, UXTW #3] : prfd   $0x0b %p6 (%x23,%z24.d,uxtw #3)
+c43a7b0c : prfd PSTL3KEEP, p6, [x24, z26.d, UXTW #3] : prfd   $0x0c %p6 (%x24,%z26.d,uxtw #3)
+c43c7f4d : prfd PSTL3STRM, p7, [x26, z28.d, UXTW #3] : prfd   $0x0d %p7 (%x26,%z28.d,uxtw #3)
+c43e7f8e : prfd 14, p7, [x28, z30.d, UXTW #3]        : prfd   $0x0e %p7 (%x28,%z30.d,uxtw #3)
+c43f7fef : prfd 15, p7, [sp, z31.d, UXTW #3]         : prfd   $0x0f %p7 (%sp,%z31.d,uxtw #3)
+c4606000 : prfd PLDL1KEEP, p0, [x0, z0.d, SXTW #3]   : prfd   $0x00 %p0 (%x0,%z0.d,sxtw #3)
+c4656481 : prfd PLDL1STRM, p1, [x4, z5.d, SXTW #3]   : prfd   $0x01 %p1 (%x4,%z5.d,sxtw #3)
+c46768c2 : prfd PLDL2KEEP, p2, [x6, z7.d, SXTW #3]   : prfd   $0x02 %p2 (%x6,%z7.d,sxtw #3)
+c4696903 : prfd PLDL2STRM, p2, [x8, z9.d, SXTW #3]   : prfd   $0x03 %p2 (%x8,%z9.d,sxtw #3)
+c46b6d44 : prfd PLDL3KEEP, p3, [x10, z11.d, SXTW #3] : prfd   $0x04 %p3 (%x10,%z11.d,sxtw #3)
+c46d6d65 : prfd PLDL3STRM, p3, [x11, z13.d, SXTW #3] : prfd   $0x05 %p3 (%x11,%z13.d,sxtw #3)
+c46f71a6 : prfd 6, p4, [x13, z15.d, SXTW #3]         : prfd   $0x06 %p4 (%x13,%z15.d,sxtw #3)
+c47171e7 : prfd 7, p4, [x15, z17.d, SXTW #3]         : prfd   $0x07 %p4 (%x15,%z17.d,sxtw #3)
+c4737628 : prfd PSTL1KEEP, p5, [x17, z19.d, SXTW #3] : prfd   $0x08 %p5 (%x17,%z19.d,sxtw #3)
+c4747669 : prfd PSTL1STRM, p5, [x19, z20.d, SXTW #3] : prfd   $0x09 %p5 (%x19,%z20.d,sxtw #3)
+c47676aa : prfd PSTL2KEEP, p5, [x21, z22.d, SXTW #3] : prfd   $0x0a %p5 (%x21,%z22.d,sxtw #3)
+c4787aeb : prfd PSTL2STRM, p6, [x23, z24.d, SXTW #3] : prfd   $0x0b %p6 (%x23,%z24.d,sxtw #3)
+c47a7b0c : prfd PSTL3KEEP, p6, [x24, z26.d, SXTW #3] : prfd   $0x0c %p6 (%x24,%z26.d,sxtw #3)
+c47c7f4d : prfd PSTL3STRM, p7, [x26, z28.d, SXTW #3] : prfd   $0x0d %p7 (%x26,%z28.d,sxtw #3)
+c47e7f8e : prfd 14, p7, [x28, z30.d, SXTW #3]        : prfd   $0x0e %p7 (%x28,%z30.d,sxtw #3)
+c47f7fef : prfd 15, p7, [sp, z31.d, SXTW #3]         : prfd   $0x0f %p7 (%sp,%z31.d,sxtw #3)
+
+# PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #3] (PRFD-I.P.BZ-S.x32.scaled)
+84206000 : prfd PLDL1KEEP, p0, [x0, z0.s, UXTW #3]   : prfd   $0x00 %p0 (%x0,%z0.s,uxtw #3)
+84256481 : prfd PLDL1STRM, p1, [x4, z5.s, UXTW #3]   : prfd   $0x01 %p1 (%x4,%z5.s,uxtw #3)
+842768c2 : prfd PLDL2KEEP, p2, [x6, z7.s, UXTW #3]   : prfd   $0x02 %p2 (%x6,%z7.s,uxtw #3)
+84296903 : prfd PLDL2STRM, p2, [x8, z9.s, UXTW #3]   : prfd   $0x03 %p2 (%x8,%z9.s,uxtw #3)
+842b6d44 : prfd PLDL3KEEP, p3, [x10, z11.s, UXTW #3] : prfd   $0x04 %p3 (%x10,%z11.s,uxtw #3)
+842d6d65 : prfd PLDL3STRM, p3, [x11, z13.s, UXTW #3] : prfd   $0x05 %p3 (%x11,%z13.s,uxtw #3)
+842f71a6 : prfd 6, p4, [x13, z15.s, UXTW #3]         : prfd   $0x06 %p4 (%x13,%z15.s,uxtw #3)
+843171e7 : prfd 7, p4, [x15, z17.s, UXTW #3]         : prfd   $0x07 %p4 (%x15,%z17.s,uxtw #3)
+84337628 : prfd PSTL1KEEP, p5, [x17, z19.s, UXTW #3] : prfd   $0x08 %p5 (%x17,%z19.s,uxtw #3)
+84347669 : prfd PSTL1STRM, p5, [x19, z20.s, UXTW #3] : prfd   $0x09 %p5 (%x19,%z20.s,uxtw #3)
+843676aa : prfd PSTL2KEEP, p5, [x21, z22.s, UXTW #3] : prfd   $0x0a %p5 (%x21,%z22.s,uxtw #3)
+84387aeb : prfd PSTL2STRM, p6, [x23, z24.s, UXTW #3] : prfd   $0x0b %p6 (%x23,%z24.s,uxtw #3)
+843a7b0c : prfd PSTL3KEEP, p6, [x24, z26.s, UXTW #3] : prfd   $0x0c %p6 (%x24,%z26.s,uxtw #3)
+843c7f4d : prfd PSTL3STRM, p7, [x26, z28.s, UXTW #3] : prfd   $0x0d %p7 (%x26,%z28.s,uxtw #3)
+843e7f8e : prfd 14, p7, [x28, z30.s, UXTW #3]        : prfd   $0x0e %p7 (%x28,%z30.s,uxtw #3)
+843f7fef : prfd 15, p7, [sp, z31.s, UXTW #3]         : prfd   $0x0f %p7 (%sp,%z31.s,uxtw #3)
+84606000 : prfd PLDL1KEEP, p0, [x0, z0.s, SXTW #3]   : prfd   $0x00 %p0 (%x0,%z0.s,sxtw #3)
+84656481 : prfd PLDL1STRM, p1, [x4, z5.s, SXTW #3]   : prfd   $0x01 %p1 (%x4,%z5.s,sxtw #3)
+846768c2 : prfd PLDL2KEEP, p2, [x6, z7.s, SXTW #3]   : prfd   $0x02 %p2 (%x6,%z7.s,sxtw #3)
+84696903 : prfd PLDL2STRM, p2, [x8, z9.s, SXTW #3]   : prfd   $0x03 %p2 (%x8,%z9.s,sxtw #3)
+846b6d44 : prfd PLDL3KEEP, p3, [x10, z11.s, SXTW #3] : prfd   $0x04 %p3 (%x10,%z11.s,sxtw #3)
+846d6d65 : prfd PLDL3STRM, p3, [x11, z13.s, SXTW #3] : prfd   $0x05 %p3 (%x11,%z13.s,sxtw #3)
+846f71a6 : prfd 6, p4, [x13, z15.s, SXTW #3]         : prfd   $0x06 %p4 (%x13,%z15.s,sxtw #3)
+847171e7 : prfd 7, p4, [x15, z17.s, SXTW #3]         : prfd   $0x07 %p4 (%x15,%z17.s,sxtw #3)
+84737628 : prfd PSTL1KEEP, p5, [x17, z19.s, SXTW #3] : prfd   $0x08 %p5 (%x17,%z19.s,sxtw #3)
+84747669 : prfd PSTL1STRM, p5, [x19, z20.s, SXTW #3] : prfd   $0x09 %p5 (%x19,%z20.s,sxtw #3)
+847676aa : prfd PSTL2KEEP, p5, [x21, z22.s, SXTW #3] : prfd   $0x0a %p5 (%x21,%z22.s,sxtw #3)
+84787aeb : prfd PSTL2STRM, p6, [x23, z24.s, SXTW #3] : prfd   $0x0b %p6 (%x23,%z24.s,sxtw #3)
+847a7b0c : prfd PSTL3KEEP, p6, [x24, z26.s, SXTW #3] : prfd   $0x0c %p6 (%x24,%z26.s,sxtw #3)
+847c7f4d : prfd PSTL3STRM, p7, [x26, z28.s, SXTW #3] : prfd   $0x0d %p7 (%x26,%z28.s,sxtw #3)
+847e7f8e : prfd 14, p7, [x28, z30.s, SXTW #3]        : prfd   $0x0e %p7 (%x28,%z30.s,sxtw #3)
+847f7fef : prfd 15, p7, [sp, z31.s, SXTW #3]         : prfd   $0x0f %p7 (%sp,%z31.s,sxtw #3)
 
 # PRFH    <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}] (PRFH-I.P.BI-S)
 85e02000 : prfh PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfh   $0x00 %p0 -0x20(%x0)
@@ -14322,6 +15836,74 @@ c47cbf4d : prfh PSTL3STRM, p7, [x26, z28.d, LSL #1]  : prfh   $0x0d %p7 (%x26,%z
 c47ebf8e : prfh 14, p7, [x28, z30.d, LSL #1]         : prfh   $0x0e %p7 (%x28,%z30.d,lsl #1)
 c47fbfef : prfh 15, p7, [sp, z31.d, LSL #1]          : prfh   $0x0f %p7 (%sp,%z31.d,lsl #1)
 
+# PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1] (PRFH-I.P.BZ-D.x32.scaled)
+c4202000 : prfh PLDL1KEEP, p0, [x0, z0.d, UXTW #1]   : prfh   $0x00 %p0 (%x0,%z0.d,uxtw #1)
+c4252481 : prfh PLDL1STRM, p1, [x4, z5.d, UXTW #1]   : prfh   $0x01 %p1 (%x4,%z5.d,uxtw #1)
+c42728c2 : prfh PLDL2KEEP, p2, [x6, z7.d, UXTW #1]   : prfh   $0x02 %p2 (%x6,%z7.d,uxtw #1)
+c4292903 : prfh PLDL2STRM, p2, [x8, z9.d, UXTW #1]   : prfh   $0x03 %p2 (%x8,%z9.d,uxtw #1)
+c42b2d44 : prfh PLDL3KEEP, p3, [x10, z11.d, UXTW #1] : prfh   $0x04 %p3 (%x10,%z11.d,uxtw #1)
+c42d2d65 : prfh PLDL3STRM, p3, [x11, z13.d, UXTW #1] : prfh   $0x05 %p3 (%x11,%z13.d,uxtw #1)
+c42f31a6 : prfh 6, p4, [x13, z15.d, UXTW #1]         : prfh   $0x06 %p4 (%x13,%z15.d,uxtw #1)
+c43131e7 : prfh 7, p4, [x15, z17.d, UXTW #1]         : prfh   $0x07 %p4 (%x15,%z17.d,uxtw #1)
+c4333628 : prfh PSTL1KEEP, p5, [x17, z19.d, UXTW #1] : prfh   $0x08 %p5 (%x17,%z19.d,uxtw #1)
+c4343669 : prfh PSTL1STRM, p5, [x19, z20.d, UXTW #1] : prfh   $0x09 %p5 (%x19,%z20.d,uxtw #1)
+c43636aa : prfh PSTL2KEEP, p5, [x21, z22.d, UXTW #1] : prfh   $0x0a %p5 (%x21,%z22.d,uxtw #1)
+c4383aeb : prfh PSTL2STRM, p6, [x23, z24.d, UXTW #1] : prfh   $0x0b %p6 (%x23,%z24.d,uxtw #1)
+c43a3b0c : prfh PSTL3KEEP, p6, [x24, z26.d, UXTW #1] : prfh   $0x0c %p6 (%x24,%z26.d,uxtw #1)
+c43c3f4d : prfh PSTL3STRM, p7, [x26, z28.d, UXTW #1] : prfh   $0x0d %p7 (%x26,%z28.d,uxtw #1)
+c43e3f8e : prfh 14, p7, [x28, z30.d, UXTW #1]        : prfh   $0x0e %p7 (%x28,%z30.d,uxtw #1)
+c43f3fef : prfh 15, p7, [sp, z31.d, UXTW #1]         : prfh   $0x0f %p7 (%sp,%z31.d,uxtw #1)
+c4602000 : prfh PLDL1KEEP, p0, [x0, z0.d, SXTW #1]   : prfh   $0x00 %p0 (%x0,%z0.d,sxtw #1)
+c4652481 : prfh PLDL1STRM, p1, [x4, z5.d, SXTW #1]   : prfh   $0x01 %p1 (%x4,%z5.d,sxtw #1)
+c46728c2 : prfh PLDL2KEEP, p2, [x6, z7.d, SXTW #1]   : prfh   $0x02 %p2 (%x6,%z7.d,sxtw #1)
+c4692903 : prfh PLDL2STRM, p2, [x8, z9.d, SXTW #1]   : prfh   $0x03 %p2 (%x8,%z9.d,sxtw #1)
+c46b2d44 : prfh PLDL3KEEP, p3, [x10, z11.d, SXTW #1] : prfh   $0x04 %p3 (%x10,%z11.d,sxtw #1)
+c46d2d65 : prfh PLDL3STRM, p3, [x11, z13.d, SXTW #1] : prfh   $0x05 %p3 (%x11,%z13.d,sxtw #1)
+c46f31a6 : prfh 6, p4, [x13, z15.d, SXTW #1]         : prfh   $0x06 %p4 (%x13,%z15.d,sxtw #1)
+c47131e7 : prfh 7, p4, [x15, z17.d, SXTW #1]         : prfh   $0x07 %p4 (%x15,%z17.d,sxtw #1)
+c4733628 : prfh PSTL1KEEP, p5, [x17, z19.d, SXTW #1] : prfh   $0x08 %p5 (%x17,%z19.d,sxtw #1)
+c4743669 : prfh PSTL1STRM, p5, [x19, z20.d, SXTW #1] : prfh   $0x09 %p5 (%x19,%z20.d,sxtw #1)
+c47636aa : prfh PSTL2KEEP, p5, [x21, z22.d, SXTW #1] : prfh   $0x0a %p5 (%x21,%z22.d,sxtw #1)
+c4783aeb : prfh PSTL2STRM, p6, [x23, z24.d, SXTW #1] : prfh   $0x0b %p6 (%x23,%z24.d,sxtw #1)
+c47a3b0c : prfh PSTL3KEEP, p6, [x24, z26.d, SXTW #1] : prfh   $0x0c %p6 (%x24,%z26.d,sxtw #1)
+c47c3f4d : prfh PSTL3STRM, p7, [x26, z28.d, SXTW #1] : prfh   $0x0d %p7 (%x26,%z28.d,sxtw #1)
+c47e3f8e : prfh 14, p7, [x28, z30.d, SXTW #1]        : prfh   $0x0e %p7 (%x28,%z30.d,sxtw #1)
+c47f3fef : prfh 15, p7, [sp, z31.d, SXTW #1]         : prfh   $0x0f %p7 (%sp,%z31.d,sxtw #1)
+
+# PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1] (PRFH-I.P.BZ-S.x32.scaled)
+84202000 : prfh PLDL1KEEP, p0, [x0, z0.s, UXTW #1]   : prfh   $0x00 %p0 (%x0,%z0.s,uxtw #1)
+84252481 : prfh PLDL1STRM, p1, [x4, z5.s, UXTW #1]   : prfh   $0x01 %p1 (%x4,%z5.s,uxtw #1)
+842728c2 : prfh PLDL2KEEP, p2, [x6, z7.s, UXTW #1]   : prfh   $0x02 %p2 (%x6,%z7.s,uxtw #1)
+84292903 : prfh PLDL2STRM, p2, [x8, z9.s, UXTW #1]   : prfh   $0x03 %p2 (%x8,%z9.s,uxtw #1)
+842b2d44 : prfh PLDL3KEEP, p3, [x10, z11.s, UXTW #1] : prfh   $0x04 %p3 (%x10,%z11.s,uxtw #1)
+842d2d65 : prfh PLDL3STRM, p3, [x11, z13.s, UXTW #1] : prfh   $0x05 %p3 (%x11,%z13.s,uxtw #1)
+842f31a6 : prfh 6, p4, [x13, z15.s, UXTW #1]         : prfh   $0x06 %p4 (%x13,%z15.s,uxtw #1)
+843131e7 : prfh 7, p4, [x15, z17.s, UXTW #1]         : prfh   $0x07 %p4 (%x15,%z17.s,uxtw #1)
+84333628 : prfh PSTL1KEEP, p5, [x17, z19.s, UXTW #1] : prfh   $0x08 %p5 (%x17,%z19.s,uxtw #1)
+84343669 : prfh PSTL1STRM, p5, [x19, z20.s, UXTW #1] : prfh   $0x09 %p5 (%x19,%z20.s,uxtw #1)
+843636aa : prfh PSTL2KEEP, p5, [x21, z22.s, UXTW #1] : prfh   $0x0a %p5 (%x21,%z22.s,uxtw #1)
+84383aeb : prfh PSTL2STRM, p6, [x23, z24.s, UXTW #1] : prfh   $0x0b %p6 (%x23,%z24.s,uxtw #1)
+843a3b0c : prfh PSTL3KEEP, p6, [x24, z26.s, UXTW #1] : prfh   $0x0c %p6 (%x24,%z26.s,uxtw #1)
+843c3f4d : prfh PSTL3STRM, p7, [x26, z28.s, UXTW #1] : prfh   $0x0d %p7 (%x26,%z28.s,uxtw #1)
+843e3f8e : prfh 14, p7, [x28, z30.s, UXTW #1]        : prfh   $0x0e %p7 (%x28,%z30.s,uxtw #1)
+843f3fef : prfh 15, p7, [sp, z31.s, UXTW #1]         : prfh   $0x0f %p7 (%sp,%z31.s,uxtw #1)
+84602000 : prfh PLDL1KEEP, p0, [x0, z0.s, SXTW #1]   : prfh   $0x00 %p0 (%x0,%z0.s,sxtw #1)
+84652481 : prfh PLDL1STRM, p1, [x4, z5.s, SXTW #1]   : prfh   $0x01 %p1 (%x4,%z5.s,sxtw #1)
+846728c2 : prfh PLDL2KEEP, p2, [x6, z7.s, SXTW #1]   : prfh   $0x02 %p2 (%x6,%z7.s,sxtw #1)
+84692903 : prfh PLDL2STRM, p2, [x8, z9.s, SXTW #1]   : prfh   $0x03 %p2 (%x8,%z9.s,sxtw #1)
+846b2d44 : prfh PLDL3KEEP, p3, [x10, z11.s, SXTW #1] : prfh   $0x04 %p3 (%x10,%z11.s,sxtw #1)
+846d2d65 : prfh PLDL3STRM, p3, [x11, z13.s, SXTW #1] : prfh   $0x05 %p3 (%x11,%z13.s,sxtw #1)
+846f31a6 : prfh 6, p4, [x13, z15.s, SXTW #1]         : prfh   $0x06 %p4 (%x13,%z15.s,sxtw #1)
+847131e7 : prfh 7, p4, [x15, z17.s, SXTW #1]         : prfh   $0x07 %p4 (%x15,%z17.s,sxtw #1)
+84733628 : prfh PSTL1KEEP, p5, [x17, z19.s, SXTW #1] : prfh   $0x08 %p5 (%x17,%z19.s,sxtw #1)
+84743669 : prfh PSTL1STRM, p5, [x19, z20.s, SXTW #1] : prfh   $0x09 %p5 (%x19,%z20.s,sxtw #1)
+847636aa : prfh PSTL2KEEP, p5, [x21, z22.s, SXTW #1] : prfh   $0x0a %p5 (%x21,%z22.s,sxtw #1)
+84783aeb : prfh PSTL2STRM, p6, [x23, z24.s, SXTW #1] : prfh   $0x0b %p6 (%x23,%z24.s,sxtw #1)
+847a3b0c : prfh PSTL3KEEP, p6, [x24, z26.s, SXTW #1] : prfh   $0x0c %p6 (%x24,%z26.s,sxtw #1)
+847c3f4d : prfh PSTL3STRM, p7, [x26, z28.s, SXTW #1] : prfh   $0x0d %p7 (%x26,%z28.s,sxtw #1)
+847e3f8e : prfh 14, p7, [x28, z30.s, SXTW #1]        : prfh   $0x0e %p7 (%x28,%z30.s,sxtw #1)
+847f3fef : prfh 15, p7, [sp, z31.s, SXTW #1]         : prfh   $0x0f %p7 (%sp,%z31.s,sxtw #1)
+
 # PRFW    <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}] (PRFW-I.P.BI-S)
 85e04000 : prfw PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfw   $0x00 %p0 -0x20(%x0)
 85e44481 : prfw PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfw   $0x01 %p1 -0x1c(%x4)
@@ -14393,6 +15975,74 @@ c47adb0c : prfw PSTL3KEEP, p6, [x24, z26.d, LSL #2]  : prfw   $0x0c %p6 (%x24,%z
 c47cdf4d : prfw PSTL3STRM, p7, [x26, z28.d, LSL #2]  : prfw   $0x0d %p7 (%x26,%z28.d,lsl #2)
 c47edf8e : prfw 14, p7, [x28, z30.d, LSL #2]         : prfw   $0x0e %p7 (%x28,%z30.d,lsl #2)
 c47fdfef : prfw 15, p7, [sp, z31.d, LSL #2]          : prfw   $0x0f %p7 (%sp,%z31.d,lsl #2)
+
+# PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2] (PRFW-I.P.BZ-D.x32.scaled)
+c4204000 : prfw PLDL1KEEP, p0, [x0, z0.d, UXTW #2]   : prfw   $0x00 %p0 (%x0,%z0.d,uxtw #2)
+c4254481 : prfw PLDL1STRM, p1, [x4, z5.d, UXTW #2]   : prfw   $0x01 %p1 (%x4,%z5.d,uxtw #2)
+c42748c2 : prfw PLDL2KEEP, p2, [x6, z7.d, UXTW #2]   : prfw   $0x02 %p2 (%x6,%z7.d,uxtw #2)
+c4294903 : prfw PLDL2STRM, p2, [x8, z9.d, UXTW #2]   : prfw   $0x03 %p2 (%x8,%z9.d,uxtw #2)
+c42b4d44 : prfw PLDL3KEEP, p3, [x10, z11.d, UXTW #2] : prfw   $0x04 %p3 (%x10,%z11.d,uxtw #2)
+c42d4d65 : prfw PLDL3STRM, p3, [x11, z13.d, UXTW #2] : prfw   $0x05 %p3 (%x11,%z13.d,uxtw #2)
+c42f51a6 : prfw 6, p4, [x13, z15.d, UXTW #2]         : prfw   $0x06 %p4 (%x13,%z15.d,uxtw #2)
+c43151e7 : prfw 7, p4, [x15, z17.d, UXTW #2]         : prfw   $0x07 %p4 (%x15,%z17.d,uxtw #2)
+c4335628 : prfw PSTL1KEEP, p5, [x17, z19.d, UXTW #2] : prfw   $0x08 %p5 (%x17,%z19.d,uxtw #2)
+c4345669 : prfw PSTL1STRM, p5, [x19, z20.d, UXTW #2] : prfw   $0x09 %p5 (%x19,%z20.d,uxtw #2)
+c43656aa : prfw PSTL2KEEP, p5, [x21, z22.d, UXTW #2] : prfw   $0x0a %p5 (%x21,%z22.d,uxtw #2)
+c4385aeb : prfw PSTL2STRM, p6, [x23, z24.d, UXTW #2] : prfw   $0x0b %p6 (%x23,%z24.d,uxtw #2)
+c43a5b0c : prfw PSTL3KEEP, p6, [x24, z26.d, UXTW #2] : prfw   $0x0c %p6 (%x24,%z26.d,uxtw #2)
+c43c5f4d : prfw PSTL3STRM, p7, [x26, z28.d, UXTW #2] : prfw   $0x0d %p7 (%x26,%z28.d,uxtw #2)
+c43e5f8e : prfw 14, p7, [x28, z30.d, UXTW #2]        : prfw   $0x0e %p7 (%x28,%z30.d,uxtw #2)
+c43f5fef : prfw 15, p7, [sp, z31.d, UXTW #2]         : prfw   $0x0f %p7 (%sp,%z31.d,uxtw #2)
+c4604000 : prfw PLDL1KEEP, p0, [x0, z0.d, SXTW #2]   : prfw   $0x00 %p0 (%x0,%z0.d,sxtw #2)
+c4654481 : prfw PLDL1STRM, p1, [x4, z5.d, SXTW #2]   : prfw   $0x01 %p1 (%x4,%z5.d,sxtw #2)
+c46748c2 : prfw PLDL2KEEP, p2, [x6, z7.d, SXTW #2]   : prfw   $0x02 %p2 (%x6,%z7.d,sxtw #2)
+c4694903 : prfw PLDL2STRM, p2, [x8, z9.d, SXTW #2]   : prfw   $0x03 %p2 (%x8,%z9.d,sxtw #2)
+c46b4d44 : prfw PLDL3KEEP, p3, [x10, z11.d, SXTW #2] : prfw   $0x04 %p3 (%x10,%z11.d,sxtw #2)
+c46d4d65 : prfw PLDL3STRM, p3, [x11, z13.d, SXTW #2] : prfw   $0x05 %p3 (%x11,%z13.d,sxtw #2)
+c46f51a6 : prfw 6, p4, [x13, z15.d, SXTW #2]         : prfw   $0x06 %p4 (%x13,%z15.d,sxtw #2)
+c47151e7 : prfw 7, p4, [x15, z17.d, SXTW #2]         : prfw   $0x07 %p4 (%x15,%z17.d,sxtw #2)
+c4735628 : prfw PSTL1KEEP, p5, [x17, z19.d, SXTW #2] : prfw   $0x08 %p5 (%x17,%z19.d,sxtw #2)
+c4745669 : prfw PSTL1STRM, p5, [x19, z20.d, SXTW #2] : prfw   $0x09 %p5 (%x19,%z20.d,sxtw #2)
+c47656aa : prfw PSTL2KEEP, p5, [x21, z22.d, SXTW #2] : prfw   $0x0a %p5 (%x21,%z22.d,sxtw #2)
+c4785aeb : prfw PSTL2STRM, p6, [x23, z24.d, SXTW #2] : prfw   $0x0b %p6 (%x23,%z24.d,sxtw #2)
+c47a5b0c : prfw PSTL3KEEP, p6, [x24, z26.d, SXTW #2] : prfw   $0x0c %p6 (%x24,%z26.d,sxtw #2)
+c47c5f4d : prfw PSTL3STRM, p7, [x26, z28.d, SXTW #2] : prfw   $0x0d %p7 (%x26,%z28.d,sxtw #2)
+c47e5f8e : prfw 14, p7, [x28, z30.d, SXTW #2]        : prfw   $0x0e %p7 (%x28,%z30.d,sxtw #2)
+c47f5fef : prfw 15, p7, [sp, z31.d, SXTW #2]         : prfw   $0x0f %p7 (%sp,%z31.d,sxtw #2)
+
+# PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2] (PRFW-I.P.BZ-S.x32.scaled)
+84204000 : prfw PLDL1KEEP, p0, [x0, z0.s, UXTW #2]   : prfw   $0x00 %p0 (%x0,%z0.s,uxtw #2)
+84254481 : prfw PLDL1STRM, p1, [x4, z5.s, UXTW #2]   : prfw   $0x01 %p1 (%x4,%z5.s,uxtw #2)
+842748c2 : prfw PLDL2KEEP, p2, [x6, z7.s, UXTW #2]   : prfw   $0x02 %p2 (%x6,%z7.s,uxtw #2)
+84294903 : prfw PLDL2STRM, p2, [x8, z9.s, UXTW #2]   : prfw   $0x03 %p2 (%x8,%z9.s,uxtw #2)
+842b4d44 : prfw PLDL3KEEP, p3, [x10, z11.s, UXTW #2] : prfw   $0x04 %p3 (%x10,%z11.s,uxtw #2)
+842d4d65 : prfw PLDL3STRM, p3, [x11, z13.s, UXTW #2] : prfw   $0x05 %p3 (%x11,%z13.s,uxtw #2)
+842f51a6 : prfw 6, p4, [x13, z15.s, UXTW #2]         : prfw   $0x06 %p4 (%x13,%z15.s,uxtw #2)
+843151e7 : prfw 7, p4, [x15, z17.s, UXTW #2]         : prfw   $0x07 %p4 (%x15,%z17.s,uxtw #2)
+84335628 : prfw PSTL1KEEP, p5, [x17, z19.s, UXTW #2] : prfw   $0x08 %p5 (%x17,%z19.s,uxtw #2)
+84345669 : prfw PSTL1STRM, p5, [x19, z20.s, UXTW #2] : prfw   $0x09 %p5 (%x19,%z20.s,uxtw #2)
+843656aa : prfw PSTL2KEEP, p5, [x21, z22.s, UXTW #2] : prfw   $0x0a %p5 (%x21,%z22.s,uxtw #2)
+84385aeb : prfw PSTL2STRM, p6, [x23, z24.s, UXTW #2] : prfw   $0x0b %p6 (%x23,%z24.s,uxtw #2)
+843a5b0c : prfw PSTL3KEEP, p6, [x24, z26.s, UXTW #2] : prfw   $0x0c %p6 (%x24,%z26.s,uxtw #2)
+843c5f4d : prfw PSTL3STRM, p7, [x26, z28.s, UXTW #2] : prfw   $0x0d %p7 (%x26,%z28.s,uxtw #2)
+843e5f8e : prfw 14, p7, [x28, z30.s, UXTW #2]        : prfw   $0x0e %p7 (%x28,%z30.s,uxtw #2)
+843f5fef : prfw 15, p7, [sp, z31.s, UXTW #2]         : prfw   $0x0f %p7 (%sp,%z31.s,uxtw #2)
+84604000 : prfw PLDL1KEEP, p0, [x0, z0.s, SXTW #2]   : prfw   $0x00 %p0 (%x0,%z0.s,sxtw #2)
+84654481 : prfw PLDL1STRM, p1, [x4, z5.s, SXTW #2]   : prfw   $0x01 %p1 (%x4,%z5.s,sxtw #2)
+846748c2 : prfw PLDL2KEEP, p2, [x6, z7.s, SXTW #2]   : prfw   $0x02 %p2 (%x6,%z7.s,sxtw #2)
+84694903 : prfw PLDL2STRM, p2, [x8, z9.s, SXTW #2]   : prfw   $0x03 %p2 (%x8,%z9.s,sxtw #2)
+846b4d44 : prfw PLDL3KEEP, p3, [x10, z11.s, SXTW #2] : prfw   $0x04 %p3 (%x10,%z11.s,sxtw #2)
+846d4d65 : prfw PLDL3STRM, p3, [x11, z13.s, SXTW #2] : prfw   $0x05 %p3 (%x11,%z13.s,sxtw #2)
+846f51a6 : prfw 6, p4, [x13, z15.s, SXTW #2]         : prfw   $0x06 %p4 (%x13,%z15.s,sxtw #2)
+847151e7 : prfw 7, p4, [x15, z17.s, SXTW #2]         : prfw   $0x07 %p4 (%x15,%z17.s,sxtw #2)
+84735628 : prfw PSTL1KEEP, p5, [x17, z19.s, SXTW #2] : prfw   $0x08 %p5 (%x17,%z19.s,sxtw #2)
+84745669 : prfw PSTL1STRM, p5, [x19, z20.s, SXTW #2] : prfw   $0x09 %p5 (%x19,%z20.s,sxtw #2)
+847656aa : prfw PSTL2KEEP, p5, [x21, z22.s, SXTW #2] : prfw   $0x0a %p5 (%x21,%z22.s,sxtw #2)
+84785aeb : prfw PSTL2STRM, p6, [x23, z24.s, SXTW #2] : prfw   $0x0b %p6 (%x23,%z24.s,sxtw #2)
+847a5b0c : prfw PSTL3KEEP, p6, [x24, z26.s, SXTW #2] : prfw   $0x0c %p6 (%x24,%z26.s,sxtw #2)
+847c5f4d : prfw PSTL3STRM, p7, [x26, z28.s, SXTW #2] : prfw   $0x0d %p7 (%x26,%z28.s,sxtw #2)
+847e5f8e : prfw 14, p7, [x28, z30.s, SXTW #2]        : prfw   $0x0e %p7 (%x28,%z30.s,sxtw #2)
+847f5fef : prfw 15, p7, [sp, z31.s, SXTW #2]         : prfw   $0x0f %p7 (%sp,%z31.s,sxtw #2)
 
 # PTEST   <Pg>, <Pn>.B (PTEST-.P.P-_)
 2550c000 : ptest p0, p0.b                            : ptest  %p0 %p0.b
@@ -17573,6 +19223,74 @@ e41cbf59 : st1b z25.d, p7, [x26, z28.d]              : st1b   %z25.d %p7 -> (%x2
 e41ebf9b : st1b z27.d, p7, [x28, z30.d]              : st1b   %z27.d %p7 -> (%x28,%z30.d)[4byte]
 e41fbfff : st1b z31.d, p7, [sp, z31.d]               : st1b   %z31.d %p7 -> (%sp,%z31.d)[4byte]
 
+# ST1B    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] (ST1B-Z.P.BZ-D.x32.unscaled)
+e4008000 : st1b z0.d, p0, [x0, z0.d, UXTW]           : st1b   %z0.d %p0 -> (%x0,%z0.d,uxtw)[4byte]
+e4058482 : st1b z2.d, p1, [x4, z5.d, UXTW]           : st1b   %z2.d %p1 -> (%x4,%z5.d,uxtw)[4byte]
+e40788c4 : st1b z4.d, p2, [x6, z7.d, UXTW]           : st1b   %z4.d %p2 -> (%x6,%z7.d,uxtw)[4byte]
+e4098906 : st1b z6.d, p2, [x8, z9.d, UXTW]           : st1b   %z6.d %p2 -> (%x8,%z9.d,uxtw)[4byte]
+e40b8d48 : st1b z8.d, p3, [x10, z11.d, UXTW]         : st1b   %z8.d %p3 -> (%x10,%z11.d,uxtw)[4byte]
+e40d8d6a : st1b z10.d, p3, [x11, z13.d, UXTW]        : st1b   %z10.d %p3 -> (%x11,%z13.d,uxtw)[4byte]
+e40f91ac : st1b z12.d, p4, [x13, z15.d, UXTW]        : st1b   %z12.d %p4 -> (%x13,%z15.d,uxtw)[4byte]
+e41191ee : st1b z14.d, p4, [x15, z17.d, UXTW]        : st1b   %z14.d %p4 -> (%x15,%z17.d,uxtw)[4byte]
+e4139630 : st1b z16.d, p5, [x17, z19.d, UXTW]        : st1b   %z16.d %p5 -> (%x17,%z19.d,uxtw)[4byte]
+e4149671 : st1b z17.d, p5, [x19, z20.d, UXTW]        : st1b   %z17.d %p5 -> (%x19,%z20.d,uxtw)[4byte]
+e41696b3 : st1b z19.d, p5, [x21, z22.d, UXTW]        : st1b   %z19.d %p5 -> (%x21,%z22.d,uxtw)[4byte]
+e4189af5 : st1b z21.d, p6, [x23, z24.d, UXTW]        : st1b   %z21.d %p6 -> (%x23,%z24.d,uxtw)[4byte]
+e41a9b17 : st1b z23.d, p6, [x24, z26.d, UXTW]        : st1b   %z23.d %p6 -> (%x24,%z26.d,uxtw)[4byte]
+e41c9f59 : st1b z25.d, p7, [x26, z28.d, UXTW]        : st1b   %z25.d %p7 -> (%x26,%z28.d,uxtw)[4byte]
+e41e9f9b : st1b z27.d, p7, [x28, z30.d, UXTW]        : st1b   %z27.d %p7 -> (%x28,%z30.d,uxtw)[4byte]
+e41f9fff : st1b z31.d, p7, [sp, z31.d, UXTW]         : st1b   %z31.d %p7 -> (%sp,%z31.d,uxtw)[4byte]
+e400c000 : st1b z0.d, p0, [x0, z0.d, SXTW]           : st1b   %z0.d %p0 -> (%x0,%z0.d,sxtw)[4byte]
+e405c482 : st1b z2.d, p1, [x4, z5.d, SXTW]           : st1b   %z2.d %p1 -> (%x4,%z5.d,sxtw)[4byte]
+e407c8c4 : st1b z4.d, p2, [x6, z7.d, SXTW]           : st1b   %z4.d %p2 -> (%x6,%z7.d,sxtw)[4byte]
+e409c906 : st1b z6.d, p2, [x8, z9.d, SXTW]           : st1b   %z6.d %p2 -> (%x8,%z9.d,sxtw)[4byte]
+e40bcd48 : st1b z8.d, p3, [x10, z11.d, SXTW]         : st1b   %z8.d %p3 -> (%x10,%z11.d,sxtw)[4byte]
+e40dcd6a : st1b z10.d, p3, [x11, z13.d, SXTW]        : st1b   %z10.d %p3 -> (%x11,%z13.d,sxtw)[4byte]
+e40fd1ac : st1b z12.d, p4, [x13, z15.d, SXTW]        : st1b   %z12.d %p4 -> (%x13,%z15.d,sxtw)[4byte]
+e411d1ee : st1b z14.d, p4, [x15, z17.d, SXTW]        : st1b   %z14.d %p4 -> (%x15,%z17.d,sxtw)[4byte]
+e413d630 : st1b z16.d, p5, [x17, z19.d, SXTW]        : st1b   %z16.d %p5 -> (%x17,%z19.d,sxtw)[4byte]
+e414d671 : st1b z17.d, p5, [x19, z20.d, SXTW]        : st1b   %z17.d %p5 -> (%x19,%z20.d,sxtw)[4byte]
+e416d6b3 : st1b z19.d, p5, [x21, z22.d, SXTW]        : st1b   %z19.d %p5 -> (%x21,%z22.d,sxtw)[4byte]
+e418daf5 : st1b z21.d, p6, [x23, z24.d, SXTW]        : st1b   %z21.d %p6 -> (%x23,%z24.d,sxtw)[4byte]
+e41adb17 : st1b z23.d, p6, [x24, z26.d, SXTW]        : st1b   %z23.d %p6 -> (%x24,%z26.d,sxtw)[4byte]
+e41cdf59 : st1b z25.d, p7, [x26, z28.d, SXTW]        : st1b   %z25.d %p7 -> (%x26,%z28.d,sxtw)[4byte]
+e41edf9b : st1b z27.d, p7, [x28, z30.d, SXTW]        : st1b   %z27.d %p7 -> (%x28,%z30.d,sxtw)[4byte]
+e41fdfff : st1b z31.d, p7, [sp, z31.d, SXTW]         : st1b   %z31.d %p7 -> (%sp,%z31.d,sxtw)[4byte]
+
+# ST1B    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] (ST1B-Z.P.BZ-S.x32.unscaled)
+e4408000 : st1b z0.s, p0, [x0, z0.s, UXTW]           : st1b   %z0.s %p0 -> (%x0,%z0.s,uxtw)[8byte]
+e4458482 : st1b z2.s, p1, [x4, z5.s, UXTW]           : st1b   %z2.s %p1 -> (%x4,%z5.s,uxtw)[8byte]
+e44788c4 : st1b z4.s, p2, [x6, z7.s, UXTW]           : st1b   %z4.s %p2 -> (%x6,%z7.s,uxtw)[8byte]
+e4498906 : st1b z6.s, p2, [x8, z9.s, UXTW]           : st1b   %z6.s %p2 -> (%x8,%z9.s,uxtw)[8byte]
+e44b8d48 : st1b z8.s, p3, [x10, z11.s, UXTW]         : st1b   %z8.s %p3 -> (%x10,%z11.s,uxtw)[8byte]
+e44d8d6a : st1b z10.s, p3, [x11, z13.s, UXTW]        : st1b   %z10.s %p3 -> (%x11,%z13.s,uxtw)[8byte]
+e44f91ac : st1b z12.s, p4, [x13, z15.s, UXTW]        : st1b   %z12.s %p4 -> (%x13,%z15.s,uxtw)[8byte]
+e45191ee : st1b z14.s, p4, [x15, z17.s, UXTW]        : st1b   %z14.s %p4 -> (%x15,%z17.s,uxtw)[8byte]
+e4539630 : st1b z16.s, p5, [x17, z19.s, UXTW]        : st1b   %z16.s %p5 -> (%x17,%z19.s,uxtw)[8byte]
+e4549671 : st1b z17.s, p5, [x19, z20.s, UXTW]        : st1b   %z17.s %p5 -> (%x19,%z20.s,uxtw)[8byte]
+e45696b3 : st1b z19.s, p5, [x21, z22.s, UXTW]        : st1b   %z19.s %p5 -> (%x21,%z22.s,uxtw)[8byte]
+e4589af5 : st1b z21.s, p6, [x23, z24.s, UXTW]        : st1b   %z21.s %p6 -> (%x23,%z24.s,uxtw)[8byte]
+e45a9b17 : st1b z23.s, p6, [x24, z26.s, UXTW]        : st1b   %z23.s %p6 -> (%x24,%z26.s,uxtw)[8byte]
+e45c9f59 : st1b z25.s, p7, [x26, z28.s, UXTW]        : st1b   %z25.s %p7 -> (%x26,%z28.s,uxtw)[8byte]
+e45e9f9b : st1b z27.s, p7, [x28, z30.s, UXTW]        : st1b   %z27.s %p7 -> (%x28,%z30.s,uxtw)[8byte]
+e45f9fff : st1b z31.s, p7, [sp, z31.s, UXTW]         : st1b   %z31.s %p7 -> (%sp,%z31.s,uxtw)[8byte]
+e440c000 : st1b z0.s, p0, [x0, z0.s, SXTW]           : st1b   %z0.s %p0 -> (%x0,%z0.s,sxtw)[8byte]
+e445c482 : st1b z2.s, p1, [x4, z5.s, SXTW]           : st1b   %z2.s %p1 -> (%x4,%z5.s,sxtw)[8byte]
+e447c8c4 : st1b z4.s, p2, [x6, z7.s, SXTW]           : st1b   %z4.s %p2 -> (%x6,%z7.s,sxtw)[8byte]
+e449c906 : st1b z6.s, p2, [x8, z9.s, SXTW]           : st1b   %z6.s %p2 -> (%x8,%z9.s,sxtw)[8byte]
+e44bcd48 : st1b z8.s, p3, [x10, z11.s, SXTW]         : st1b   %z8.s %p3 -> (%x10,%z11.s,sxtw)[8byte]
+e44dcd6a : st1b z10.s, p3, [x11, z13.s, SXTW]        : st1b   %z10.s %p3 -> (%x11,%z13.s,sxtw)[8byte]
+e44fd1ac : st1b z12.s, p4, [x13, z15.s, SXTW]        : st1b   %z12.s %p4 -> (%x13,%z15.s,sxtw)[8byte]
+e451d1ee : st1b z14.s, p4, [x15, z17.s, SXTW]        : st1b   %z14.s %p4 -> (%x15,%z17.s,sxtw)[8byte]
+e453d630 : st1b z16.s, p5, [x17, z19.s, SXTW]        : st1b   %z16.s %p5 -> (%x17,%z19.s,sxtw)[8byte]
+e454d671 : st1b z17.s, p5, [x19, z20.s, SXTW]        : st1b   %z17.s %p5 -> (%x19,%z20.s,sxtw)[8byte]
+e456d6b3 : st1b z19.s, p5, [x21, z22.s, SXTW]        : st1b   %z19.s %p5 -> (%x21,%z22.s,sxtw)[8byte]
+e458daf5 : st1b z21.s, p6, [x23, z24.s, SXTW]        : st1b   %z21.s %p6 -> (%x23,%z24.s,sxtw)[8byte]
+e45adb17 : st1b z23.s, p6, [x24, z26.s, SXTW]        : st1b   %z23.s %p6 -> (%x24,%z26.s,sxtw)[8byte]
+e45cdf59 : st1b z25.s, p7, [x26, z28.s, SXTW]        : st1b   %z25.s %p7 -> (%x26,%z28.s,sxtw)[8byte]
+e45edf9b : st1b z27.s, p7, [x28, z30.s, SXTW]        : st1b   %z27.s %p7 -> (%x28,%z30.s,sxtw)[8byte]
+e45fdfff : st1b z31.s, p7, [sp, z31.s, SXTW]         : st1b   %z31.s %p7 -> (%sp,%z31.s,sxtw)[8byte]
+
 # ST1D    { <Zt>.D }, <Pg>, [<Zn>.D{, #<pimm>}] (ST1D-Z.P.AI-D)
 e5c0a000 : st1d z0.d, p0, [z0.d, #0]                 : st1d   %z0.d %p0 -> (%z0.d)[32byte]
 e5c2a482 : st1d z2.d, p1, [z4.d, #16]                : st1d   %z2.d %p1 -> +0x10(%z4.d)[32byte]
@@ -17626,6 +19344,74 @@ e59abb17 : st1d z23.d, p6, [x24, z26.d]              : st1d   %z23.d %p6 -> (%x2
 e59cbf59 : st1d z25.d, p7, [x26, z28.d]              : st1d   %z25.d %p7 -> (%x26,%z28.d)[32byte]
 e59ebf9b : st1d z27.d, p7, [x28, z30.d]              : st1d   %z27.d %p7 -> (%x28,%z30.d)[32byte]
 e59fbfff : st1d z31.d, p7, [sp, z31.d]               : st1d   %z31.d %p7 -> (%sp,%z31.d)[32byte]
+
+# ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3] (ST1D-Z.P.BZ-D.x32.scaled)
+e5a08000 : st1d z0.d, p0, [x0, z0.d, UXTW #3]        : st1d   %z0.d %p0 -> (%x0,%z0.d,uxtw #3)[32byte]
+e5a58482 : st1d z2.d, p1, [x4, z5.d, UXTW #3]        : st1d   %z2.d %p1 -> (%x4,%z5.d,uxtw #3)[32byte]
+e5a788c4 : st1d z4.d, p2, [x6, z7.d, UXTW #3]        : st1d   %z4.d %p2 -> (%x6,%z7.d,uxtw #3)[32byte]
+e5a98906 : st1d z6.d, p2, [x8, z9.d, UXTW #3]        : st1d   %z6.d %p2 -> (%x8,%z9.d,uxtw #3)[32byte]
+e5ab8d48 : st1d z8.d, p3, [x10, z11.d, UXTW #3]      : st1d   %z8.d %p3 -> (%x10,%z11.d,uxtw #3)[32byte]
+e5ad8d6a : st1d z10.d, p3, [x11, z13.d, UXTW #3]     : st1d   %z10.d %p3 -> (%x11,%z13.d,uxtw #3)[32byte]
+e5af91ac : st1d z12.d, p4, [x13, z15.d, UXTW #3]     : st1d   %z12.d %p4 -> (%x13,%z15.d,uxtw #3)[32byte]
+e5b191ee : st1d z14.d, p4, [x15, z17.d, UXTW #3]     : st1d   %z14.d %p4 -> (%x15,%z17.d,uxtw #3)[32byte]
+e5b39630 : st1d z16.d, p5, [x17, z19.d, UXTW #3]     : st1d   %z16.d %p5 -> (%x17,%z19.d,uxtw #3)[32byte]
+e5b49671 : st1d z17.d, p5, [x19, z20.d, UXTW #3]     : st1d   %z17.d %p5 -> (%x19,%z20.d,uxtw #3)[32byte]
+e5b696b3 : st1d z19.d, p5, [x21, z22.d, UXTW #3]     : st1d   %z19.d %p5 -> (%x21,%z22.d,uxtw #3)[32byte]
+e5b89af5 : st1d z21.d, p6, [x23, z24.d, UXTW #3]     : st1d   %z21.d %p6 -> (%x23,%z24.d,uxtw #3)[32byte]
+e5ba9b17 : st1d z23.d, p6, [x24, z26.d, UXTW #3]     : st1d   %z23.d %p6 -> (%x24,%z26.d,uxtw #3)[32byte]
+e5bc9f59 : st1d z25.d, p7, [x26, z28.d, UXTW #3]     : st1d   %z25.d %p7 -> (%x26,%z28.d,uxtw #3)[32byte]
+e5be9f9b : st1d z27.d, p7, [x28, z30.d, UXTW #3]     : st1d   %z27.d %p7 -> (%x28,%z30.d,uxtw #3)[32byte]
+e5bf9fff : st1d z31.d, p7, [sp, z31.d, UXTW #3]      : st1d   %z31.d %p7 -> (%sp,%z31.d,uxtw #3)[32byte]
+e5a0c000 : st1d z0.d, p0, [x0, z0.d, SXTW #3]        : st1d   %z0.d %p0 -> (%x0,%z0.d,sxtw #3)[32byte]
+e5a5c482 : st1d z2.d, p1, [x4, z5.d, SXTW #3]        : st1d   %z2.d %p1 -> (%x4,%z5.d,sxtw #3)[32byte]
+e5a7c8c4 : st1d z4.d, p2, [x6, z7.d, SXTW #3]        : st1d   %z4.d %p2 -> (%x6,%z7.d,sxtw #3)[32byte]
+e5a9c906 : st1d z6.d, p2, [x8, z9.d, SXTW #3]        : st1d   %z6.d %p2 -> (%x8,%z9.d,sxtw #3)[32byte]
+e5abcd48 : st1d z8.d, p3, [x10, z11.d, SXTW #3]      : st1d   %z8.d %p3 -> (%x10,%z11.d,sxtw #3)[32byte]
+e5adcd6a : st1d z10.d, p3, [x11, z13.d, SXTW #3]     : st1d   %z10.d %p3 -> (%x11,%z13.d,sxtw #3)[32byte]
+e5afd1ac : st1d z12.d, p4, [x13, z15.d, SXTW #3]     : st1d   %z12.d %p4 -> (%x13,%z15.d,sxtw #3)[32byte]
+e5b1d1ee : st1d z14.d, p4, [x15, z17.d, SXTW #3]     : st1d   %z14.d %p4 -> (%x15,%z17.d,sxtw #3)[32byte]
+e5b3d630 : st1d z16.d, p5, [x17, z19.d, SXTW #3]     : st1d   %z16.d %p5 -> (%x17,%z19.d,sxtw #3)[32byte]
+e5b4d671 : st1d z17.d, p5, [x19, z20.d, SXTW #3]     : st1d   %z17.d %p5 -> (%x19,%z20.d,sxtw #3)[32byte]
+e5b6d6b3 : st1d z19.d, p5, [x21, z22.d, SXTW #3]     : st1d   %z19.d %p5 -> (%x21,%z22.d,sxtw #3)[32byte]
+e5b8daf5 : st1d z21.d, p6, [x23, z24.d, SXTW #3]     : st1d   %z21.d %p6 -> (%x23,%z24.d,sxtw #3)[32byte]
+e5badb17 : st1d z23.d, p6, [x24, z26.d, SXTW #3]     : st1d   %z23.d %p6 -> (%x24,%z26.d,sxtw #3)[32byte]
+e5bcdf59 : st1d z25.d, p7, [x26, z28.d, SXTW #3]     : st1d   %z25.d %p7 -> (%x26,%z28.d,sxtw #3)[32byte]
+e5bedf9b : st1d z27.d, p7, [x28, z30.d, SXTW #3]     : st1d   %z27.d %p7 -> (%x28,%z30.d,sxtw #3)[32byte]
+e5bfdfff : st1d z31.d, p7, [sp, z31.d, SXTW #3]      : st1d   %z31.d %p7 -> (%sp,%z31.d,sxtw #3)[32byte]
+
+# ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] (ST1D-Z.P.BZ-D.x32.unscaled)
+e5808000 : st1d z0.d, p0, [x0, z0.d, UXTW]           : st1d   %z0.d %p0 -> (%x0,%z0.d,uxtw)[32byte]
+e5858482 : st1d z2.d, p1, [x4, z5.d, UXTW]           : st1d   %z2.d %p1 -> (%x4,%z5.d,uxtw)[32byte]
+e58788c4 : st1d z4.d, p2, [x6, z7.d, UXTW]           : st1d   %z4.d %p2 -> (%x6,%z7.d,uxtw)[32byte]
+e5898906 : st1d z6.d, p2, [x8, z9.d, UXTW]           : st1d   %z6.d %p2 -> (%x8,%z9.d,uxtw)[32byte]
+e58b8d48 : st1d z8.d, p3, [x10, z11.d, UXTW]         : st1d   %z8.d %p3 -> (%x10,%z11.d,uxtw)[32byte]
+e58d8d6a : st1d z10.d, p3, [x11, z13.d, UXTW]        : st1d   %z10.d %p3 -> (%x11,%z13.d,uxtw)[32byte]
+e58f91ac : st1d z12.d, p4, [x13, z15.d, UXTW]        : st1d   %z12.d %p4 -> (%x13,%z15.d,uxtw)[32byte]
+e59191ee : st1d z14.d, p4, [x15, z17.d, UXTW]        : st1d   %z14.d %p4 -> (%x15,%z17.d,uxtw)[32byte]
+e5939630 : st1d z16.d, p5, [x17, z19.d, UXTW]        : st1d   %z16.d %p5 -> (%x17,%z19.d,uxtw)[32byte]
+e5949671 : st1d z17.d, p5, [x19, z20.d, UXTW]        : st1d   %z17.d %p5 -> (%x19,%z20.d,uxtw)[32byte]
+e59696b3 : st1d z19.d, p5, [x21, z22.d, UXTW]        : st1d   %z19.d %p5 -> (%x21,%z22.d,uxtw)[32byte]
+e5989af5 : st1d z21.d, p6, [x23, z24.d, UXTW]        : st1d   %z21.d %p6 -> (%x23,%z24.d,uxtw)[32byte]
+e59a9b17 : st1d z23.d, p6, [x24, z26.d, UXTW]        : st1d   %z23.d %p6 -> (%x24,%z26.d,uxtw)[32byte]
+e59c9f59 : st1d z25.d, p7, [x26, z28.d, UXTW]        : st1d   %z25.d %p7 -> (%x26,%z28.d,uxtw)[32byte]
+e59e9f9b : st1d z27.d, p7, [x28, z30.d, UXTW]        : st1d   %z27.d %p7 -> (%x28,%z30.d,uxtw)[32byte]
+e59f9fff : st1d z31.d, p7, [sp, z31.d, UXTW]         : st1d   %z31.d %p7 -> (%sp,%z31.d,uxtw)[32byte]
+e580c000 : st1d z0.d, p0, [x0, z0.d, SXTW]           : st1d   %z0.d %p0 -> (%x0,%z0.d,sxtw)[32byte]
+e585c482 : st1d z2.d, p1, [x4, z5.d, SXTW]           : st1d   %z2.d %p1 -> (%x4,%z5.d,sxtw)[32byte]
+e587c8c4 : st1d z4.d, p2, [x6, z7.d, SXTW]           : st1d   %z4.d %p2 -> (%x6,%z7.d,sxtw)[32byte]
+e589c906 : st1d z6.d, p2, [x8, z9.d, SXTW]           : st1d   %z6.d %p2 -> (%x8,%z9.d,sxtw)[32byte]
+e58bcd48 : st1d z8.d, p3, [x10, z11.d, SXTW]         : st1d   %z8.d %p3 -> (%x10,%z11.d,sxtw)[32byte]
+e58dcd6a : st1d z10.d, p3, [x11, z13.d, SXTW]        : st1d   %z10.d %p3 -> (%x11,%z13.d,sxtw)[32byte]
+e58fd1ac : st1d z12.d, p4, [x13, z15.d, SXTW]        : st1d   %z12.d %p4 -> (%x13,%z15.d,sxtw)[32byte]
+e591d1ee : st1d z14.d, p4, [x15, z17.d, SXTW]        : st1d   %z14.d %p4 -> (%x15,%z17.d,sxtw)[32byte]
+e593d630 : st1d z16.d, p5, [x17, z19.d, SXTW]        : st1d   %z16.d %p5 -> (%x17,%z19.d,sxtw)[32byte]
+e594d671 : st1d z17.d, p5, [x19, z20.d, SXTW]        : st1d   %z17.d %p5 -> (%x19,%z20.d,sxtw)[32byte]
+e596d6b3 : st1d z19.d, p5, [x21, z22.d, SXTW]        : st1d   %z19.d %p5 -> (%x21,%z22.d,sxtw)[32byte]
+e598daf5 : st1d z21.d, p6, [x23, z24.d, SXTW]        : st1d   %z21.d %p6 -> (%x23,%z24.d,sxtw)[32byte]
+e59adb17 : st1d z23.d, p6, [x24, z26.d, SXTW]        : st1d   %z23.d %p6 -> (%x24,%z26.d,sxtw)[32byte]
+e59cdf59 : st1d z25.d, p7, [x26, z28.d, SXTW]        : st1d   %z25.d %p7 -> (%x26,%z28.d,sxtw)[32byte]
+e59edf9b : st1d z27.d, p7, [x28, z30.d, SXTW]        : st1d   %z27.d %p7 -> (%x28,%z30.d,sxtw)[32byte]
+e59fdfff : st1d z31.d, p7, [sp, z31.d, SXTW]         : st1d   %z31.d %p7 -> (%sp,%z31.d,sxtw)[32byte]
 
 # ST1H    { <Zt>.S }, <Pg>, [<Zn>.S{, #<pimm>}] (ST1H-Z.P.AI-S)
 e4e0a000 : st1h z0.s, p0, [z0.s, #0]                 : st1h   %z0.s %p0 -> (%z0.s)[16byte]
@@ -17681,6 +19467,160 @@ e4bcbf59 : st1h z25.d, p7, [x26, z28.d, LSL #1]      : st1h   %z25.d %p7 -> (%x2
 e4bebf9b : st1h z27.d, p7, [x28, z30.d, LSL #1]      : st1h   %z27.d %p7 -> (%x28,%z30.d,lsl #1)[8byte]
 e4bfbfff : st1h z31.d, p7, [sp, z31.d, LSL #1]       : st1h   %z31.d %p7 -> (%sp,%z31.d,lsl #1)[8byte]
 
+# ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D] (ST1H-Z.P.BZ-D.64.unscaled)
+e480a000 : st1h z0.d, p0, [x0, z0.d]                 : st1h   %z0.d %p0 -> (%x0,%z0.d)[8byte]
+e485a482 : st1h z2.d, p1, [x4, z5.d]                 : st1h   %z2.d %p1 -> (%x4,%z5.d)[8byte]
+e487a8c4 : st1h z4.d, p2, [x6, z7.d]                 : st1h   %z4.d %p2 -> (%x6,%z7.d)[8byte]
+e489a906 : st1h z6.d, p2, [x8, z9.d]                 : st1h   %z6.d %p2 -> (%x8,%z9.d)[8byte]
+e48bad48 : st1h z8.d, p3, [x10, z11.d]               : st1h   %z8.d %p3 -> (%x10,%z11.d)[8byte]
+e48dad6a : st1h z10.d, p3, [x11, z13.d]              : st1h   %z10.d %p3 -> (%x11,%z13.d)[8byte]
+e48fb1ac : st1h z12.d, p4, [x13, z15.d]              : st1h   %z12.d %p4 -> (%x13,%z15.d)[8byte]
+e491b1ee : st1h z14.d, p4, [x15, z17.d]              : st1h   %z14.d %p4 -> (%x15,%z17.d)[8byte]
+e493b630 : st1h z16.d, p5, [x17, z19.d]              : st1h   %z16.d %p5 -> (%x17,%z19.d)[8byte]
+e494b671 : st1h z17.d, p5, [x19, z20.d]              : st1h   %z17.d %p5 -> (%x19,%z20.d)[8byte]
+e496b6b3 : st1h z19.d, p5, [x21, z22.d]              : st1h   %z19.d %p5 -> (%x21,%z22.d)[8byte]
+e498baf5 : st1h z21.d, p6, [x23, z24.d]              : st1h   %z21.d %p6 -> (%x23,%z24.d)[8byte]
+e49abb17 : st1h z23.d, p6, [x24, z26.d]              : st1h   %z23.d %p6 -> (%x24,%z26.d)[8byte]
+e49cbf59 : st1h z25.d, p7, [x26, z28.d]              : st1h   %z25.d %p7 -> (%x26,%z28.d)[8byte]
+e49ebf9b : st1h z27.d, p7, [x28, z30.d]              : st1h   %z27.d %p7 -> (%x28,%z30.d)[8byte]
+e49fbfff : st1h z31.d, p7, [sp, z31.d]               : st1h   %z31.d %p7 -> (%sp,%z31.d)[8byte]
+
+# ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1] (ST1H-Z.P.BZ-D.x32.scaled)
+e4a08000 : st1h z0.d, p0, [x0, z0.d, UXTW #1]        : st1h   %z0.d %p0 -> (%x0,%z0.d,uxtw #1)[8byte]
+e4a58482 : st1h z2.d, p1, [x4, z5.d, UXTW #1]        : st1h   %z2.d %p1 -> (%x4,%z5.d,uxtw #1)[8byte]
+e4a788c4 : st1h z4.d, p2, [x6, z7.d, UXTW #1]        : st1h   %z4.d %p2 -> (%x6,%z7.d,uxtw #1)[8byte]
+e4a98906 : st1h z6.d, p2, [x8, z9.d, UXTW #1]        : st1h   %z6.d %p2 -> (%x8,%z9.d,uxtw #1)[8byte]
+e4ab8d48 : st1h z8.d, p3, [x10, z11.d, UXTW #1]      : st1h   %z8.d %p3 -> (%x10,%z11.d,uxtw #1)[8byte]
+e4ad8d6a : st1h z10.d, p3, [x11, z13.d, UXTW #1]     : st1h   %z10.d %p3 -> (%x11,%z13.d,uxtw #1)[8byte]
+e4af91ac : st1h z12.d, p4, [x13, z15.d, UXTW #1]     : st1h   %z12.d %p4 -> (%x13,%z15.d,uxtw #1)[8byte]
+e4b191ee : st1h z14.d, p4, [x15, z17.d, UXTW #1]     : st1h   %z14.d %p4 -> (%x15,%z17.d,uxtw #1)[8byte]
+e4b39630 : st1h z16.d, p5, [x17, z19.d, UXTW #1]     : st1h   %z16.d %p5 -> (%x17,%z19.d,uxtw #1)[8byte]
+e4b49671 : st1h z17.d, p5, [x19, z20.d, UXTW #1]     : st1h   %z17.d %p5 -> (%x19,%z20.d,uxtw #1)[8byte]
+e4b696b3 : st1h z19.d, p5, [x21, z22.d, UXTW #1]     : st1h   %z19.d %p5 -> (%x21,%z22.d,uxtw #1)[8byte]
+e4b89af5 : st1h z21.d, p6, [x23, z24.d, UXTW #1]     : st1h   %z21.d %p6 -> (%x23,%z24.d,uxtw #1)[8byte]
+e4ba9b17 : st1h z23.d, p6, [x24, z26.d, UXTW #1]     : st1h   %z23.d %p6 -> (%x24,%z26.d,uxtw #1)[8byte]
+e4bc9f59 : st1h z25.d, p7, [x26, z28.d, UXTW #1]     : st1h   %z25.d %p7 -> (%x26,%z28.d,uxtw #1)[8byte]
+e4be9f9b : st1h z27.d, p7, [x28, z30.d, UXTW #1]     : st1h   %z27.d %p7 -> (%x28,%z30.d,uxtw #1)[8byte]
+e4bf9fff : st1h z31.d, p7, [sp, z31.d, UXTW #1]      : st1h   %z31.d %p7 -> (%sp,%z31.d,uxtw #1)[8byte]
+e4a0c000 : st1h z0.d, p0, [x0, z0.d, SXTW #1]        : st1h   %z0.d %p0 -> (%x0,%z0.d,sxtw #1)[8byte]
+e4a5c482 : st1h z2.d, p1, [x4, z5.d, SXTW #1]        : st1h   %z2.d %p1 -> (%x4,%z5.d,sxtw #1)[8byte]
+e4a7c8c4 : st1h z4.d, p2, [x6, z7.d, SXTW #1]        : st1h   %z4.d %p2 -> (%x6,%z7.d,sxtw #1)[8byte]
+e4a9c906 : st1h z6.d, p2, [x8, z9.d, SXTW #1]        : st1h   %z6.d %p2 -> (%x8,%z9.d,sxtw #1)[8byte]
+e4abcd48 : st1h z8.d, p3, [x10, z11.d, SXTW #1]      : st1h   %z8.d %p3 -> (%x10,%z11.d,sxtw #1)[8byte]
+e4adcd6a : st1h z10.d, p3, [x11, z13.d, SXTW #1]     : st1h   %z10.d %p3 -> (%x11,%z13.d,sxtw #1)[8byte]
+e4afd1ac : st1h z12.d, p4, [x13, z15.d, SXTW #1]     : st1h   %z12.d %p4 -> (%x13,%z15.d,sxtw #1)[8byte]
+e4b1d1ee : st1h z14.d, p4, [x15, z17.d, SXTW #1]     : st1h   %z14.d %p4 -> (%x15,%z17.d,sxtw #1)[8byte]
+e4b3d630 : st1h z16.d, p5, [x17, z19.d, SXTW #1]     : st1h   %z16.d %p5 -> (%x17,%z19.d,sxtw #1)[8byte]
+e4b4d671 : st1h z17.d, p5, [x19, z20.d, SXTW #1]     : st1h   %z17.d %p5 -> (%x19,%z20.d,sxtw #1)[8byte]
+e4b6d6b3 : st1h z19.d, p5, [x21, z22.d, SXTW #1]     : st1h   %z19.d %p5 -> (%x21,%z22.d,sxtw #1)[8byte]
+e4b8daf5 : st1h z21.d, p6, [x23, z24.d, SXTW #1]     : st1h   %z21.d %p6 -> (%x23,%z24.d,sxtw #1)[8byte]
+e4badb17 : st1h z23.d, p6, [x24, z26.d, SXTW #1]     : st1h   %z23.d %p6 -> (%x24,%z26.d,sxtw #1)[8byte]
+e4bcdf59 : st1h z25.d, p7, [x26, z28.d, SXTW #1]     : st1h   %z25.d %p7 -> (%x26,%z28.d,sxtw #1)[8byte]
+e4bedf9b : st1h z27.d, p7, [x28, z30.d, SXTW #1]     : st1h   %z27.d %p7 -> (%x28,%z30.d,sxtw #1)[8byte]
+e4bfdfff : st1h z31.d, p7, [sp, z31.d, SXTW #1]      : st1h   %z31.d %p7 -> (%sp,%z31.d,sxtw #1)[8byte]
+
+# ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] (ST1H-Z.P.BZ-D.x32.unscaled)
+e4808000 : st1h z0.d, p0, [x0, z0.d, UXTW]           : st1h   %z0.d %p0 -> (%x0,%z0.d,uxtw)[8byte]
+e4858482 : st1h z2.d, p1, [x4, z5.d, UXTW]           : st1h   %z2.d %p1 -> (%x4,%z5.d,uxtw)[8byte]
+e48788c4 : st1h z4.d, p2, [x6, z7.d, UXTW]           : st1h   %z4.d %p2 -> (%x6,%z7.d,uxtw)[8byte]
+e4898906 : st1h z6.d, p2, [x8, z9.d, UXTW]           : st1h   %z6.d %p2 -> (%x8,%z9.d,uxtw)[8byte]
+e48b8d48 : st1h z8.d, p3, [x10, z11.d, UXTW]         : st1h   %z8.d %p3 -> (%x10,%z11.d,uxtw)[8byte]
+e48d8d6a : st1h z10.d, p3, [x11, z13.d, UXTW]        : st1h   %z10.d %p3 -> (%x11,%z13.d,uxtw)[8byte]
+e48f91ac : st1h z12.d, p4, [x13, z15.d, UXTW]        : st1h   %z12.d %p4 -> (%x13,%z15.d,uxtw)[8byte]
+e49191ee : st1h z14.d, p4, [x15, z17.d, UXTW]        : st1h   %z14.d %p4 -> (%x15,%z17.d,uxtw)[8byte]
+e4939630 : st1h z16.d, p5, [x17, z19.d, UXTW]        : st1h   %z16.d %p5 -> (%x17,%z19.d,uxtw)[8byte]
+e4949671 : st1h z17.d, p5, [x19, z20.d, UXTW]        : st1h   %z17.d %p5 -> (%x19,%z20.d,uxtw)[8byte]
+e49696b3 : st1h z19.d, p5, [x21, z22.d, UXTW]        : st1h   %z19.d %p5 -> (%x21,%z22.d,uxtw)[8byte]
+e4989af5 : st1h z21.d, p6, [x23, z24.d, UXTW]        : st1h   %z21.d %p6 -> (%x23,%z24.d,uxtw)[8byte]
+e49a9b17 : st1h z23.d, p6, [x24, z26.d, UXTW]        : st1h   %z23.d %p6 -> (%x24,%z26.d,uxtw)[8byte]
+e49c9f59 : st1h z25.d, p7, [x26, z28.d, UXTW]        : st1h   %z25.d %p7 -> (%x26,%z28.d,uxtw)[8byte]
+e49e9f9b : st1h z27.d, p7, [x28, z30.d, UXTW]        : st1h   %z27.d %p7 -> (%x28,%z30.d,uxtw)[8byte]
+e49f9fff : st1h z31.d, p7, [sp, z31.d, UXTW]         : st1h   %z31.d %p7 -> (%sp,%z31.d,uxtw)[8byte]
+e480c000 : st1h z0.d, p0, [x0, z0.d, SXTW]           : st1h   %z0.d %p0 -> (%x0,%z0.d,sxtw)[8byte]
+e485c482 : st1h z2.d, p1, [x4, z5.d, SXTW]           : st1h   %z2.d %p1 -> (%x4,%z5.d,sxtw)[8byte]
+e487c8c4 : st1h z4.d, p2, [x6, z7.d, SXTW]           : st1h   %z4.d %p2 -> (%x6,%z7.d,sxtw)[8byte]
+e489c906 : st1h z6.d, p2, [x8, z9.d, SXTW]           : st1h   %z6.d %p2 -> (%x8,%z9.d,sxtw)[8byte]
+e48bcd48 : st1h z8.d, p3, [x10, z11.d, SXTW]         : st1h   %z8.d %p3 -> (%x10,%z11.d,sxtw)[8byte]
+e48dcd6a : st1h z10.d, p3, [x11, z13.d, SXTW]        : st1h   %z10.d %p3 -> (%x11,%z13.d,sxtw)[8byte]
+e48fd1ac : st1h z12.d, p4, [x13, z15.d, SXTW]        : st1h   %z12.d %p4 -> (%x13,%z15.d,sxtw)[8byte]
+e491d1ee : st1h z14.d, p4, [x15, z17.d, SXTW]        : st1h   %z14.d %p4 -> (%x15,%z17.d,sxtw)[8byte]
+e493d630 : st1h z16.d, p5, [x17, z19.d, SXTW]        : st1h   %z16.d %p5 -> (%x17,%z19.d,sxtw)[8byte]
+e494d671 : st1h z17.d, p5, [x19, z20.d, SXTW]        : st1h   %z17.d %p5 -> (%x19,%z20.d,sxtw)[8byte]
+e496d6b3 : st1h z19.d, p5, [x21, z22.d, SXTW]        : st1h   %z19.d %p5 -> (%x21,%z22.d,sxtw)[8byte]
+e498daf5 : st1h z21.d, p6, [x23, z24.d, SXTW]        : st1h   %z21.d %p6 -> (%x23,%z24.d,sxtw)[8byte]
+e49adb17 : st1h z23.d, p6, [x24, z26.d, SXTW]        : st1h   %z23.d %p6 -> (%x24,%z26.d,sxtw)[8byte]
+e49cdf59 : st1h z25.d, p7, [x26, z28.d, SXTW]        : st1h   %z25.d %p7 -> (%x26,%z28.d,sxtw)[8byte]
+e49edf9b : st1h z27.d, p7, [x28, z30.d, SXTW]        : st1h   %z27.d %p7 -> (%x28,%z30.d,sxtw)[8byte]
+e49fdfff : st1h z31.d, p7, [sp, z31.d, SXTW]         : st1h   %z31.d %p7 -> (%sp,%z31.d,sxtw)[8byte]
+
+# ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1] (ST1H-Z.P.BZ-S.x32.scaled)
+e4e08000 : st1h z0.s, p0, [x0, z0.s, UXTW #1]        : st1h   %z0.s %p0 -> (%x0,%z0.s,uxtw #1)[16byte]
+e4e58482 : st1h z2.s, p1, [x4, z5.s, UXTW #1]        : st1h   %z2.s %p1 -> (%x4,%z5.s,uxtw #1)[16byte]
+e4e788c4 : st1h z4.s, p2, [x6, z7.s, UXTW #1]        : st1h   %z4.s %p2 -> (%x6,%z7.s,uxtw #1)[16byte]
+e4e98906 : st1h z6.s, p2, [x8, z9.s, UXTW #1]        : st1h   %z6.s %p2 -> (%x8,%z9.s,uxtw #1)[16byte]
+e4eb8d48 : st1h z8.s, p3, [x10, z11.s, UXTW #1]      : st1h   %z8.s %p3 -> (%x10,%z11.s,uxtw #1)[16byte]
+e4ed8d6a : st1h z10.s, p3, [x11, z13.s, UXTW #1]     : st1h   %z10.s %p3 -> (%x11,%z13.s,uxtw #1)[16byte]
+e4ef91ac : st1h z12.s, p4, [x13, z15.s, UXTW #1]     : st1h   %z12.s %p4 -> (%x13,%z15.s,uxtw #1)[16byte]
+e4f191ee : st1h z14.s, p4, [x15, z17.s, UXTW #1]     : st1h   %z14.s %p4 -> (%x15,%z17.s,uxtw #1)[16byte]
+e4f39630 : st1h z16.s, p5, [x17, z19.s, UXTW #1]     : st1h   %z16.s %p5 -> (%x17,%z19.s,uxtw #1)[16byte]
+e4f49671 : st1h z17.s, p5, [x19, z20.s, UXTW #1]     : st1h   %z17.s %p5 -> (%x19,%z20.s,uxtw #1)[16byte]
+e4f696b3 : st1h z19.s, p5, [x21, z22.s, UXTW #1]     : st1h   %z19.s %p5 -> (%x21,%z22.s,uxtw #1)[16byte]
+e4f89af5 : st1h z21.s, p6, [x23, z24.s, UXTW #1]     : st1h   %z21.s %p6 -> (%x23,%z24.s,uxtw #1)[16byte]
+e4fa9b17 : st1h z23.s, p6, [x24, z26.s, UXTW #1]     : st1h   %z23.s %p6 -> (%x24,%z26.s,uxtw #1)[16byte]
+e4fc9f59 : st1h z25.s, p7, [x26, z28.s, UXTW #1]     : st1h   %z25.s %p7 -> (%x26,%z28.s,uxtw #1)[16byte]
+e4fe9f9b : st1h z27.s, p7, [x28, z30.s, UXTW #1]     : st1h   %z27.s %p7 -> (%x28,%z30.s,uxtw #1)[16byte]
+e4ff9fff : st1h z31.s, p7, [sp, z31.s, UXTW #1]      : st1h   %z31.s %p7 -> (%sp,%z31.s,uxtw #1)[16byte]
+e4e0c000 : st1h z0.s, p0, [x0, z0.s, SXTW #1]        : st1h   %z0.s %p0 -> (%x0,%z0.s,sxtw #1)[16byte]
+e4e5c482 : st1h z2.s, p1, [x4, z5.s, SXTW #1]        : st1h   %z2.s %p1 -> (%x4,%z5.s,sxtw #1)[16byte]
+e4e7c8c4 : st1h z4.s, p2, [x6, z7.s, SXTW #1]        : st1h   %z4.s %p2 -> (%x6,%z7.s,sxtw #1)[16byte]
+e4e9c906 : st1h z6.s, p2, [x8, z9.s, SXTW #1]        : st1h   %z6.s %p2 -> (%x8,%z9.s,sxtw #1)[16byte]
+e4ebcd48 : st1h z8.s, p3, [x10, z11.s, SXTW #1]      : st1h   %z8.s %p3 -> (%x10,%z11.s,sxtw #1)[16byte]
+e4edcd6a : st1h z10.s, p3, [x11, z13.s, SXTW #1]     : st1h   %z10.s %p3 -> (%x11,%z13.s,sxtw #1)[16byte]
+e4efd1ac : st1h z12.s, p4, [x13, z15.s, SXTW #1]     : st1h   %z12.s %p4 -> (%x13,%z15.s,sxtw #1)[16byte]
+e4f1d1ee : st1h z14.s, p4, [x15, z17.s, SXTW #1]     : st1h   %z14.s %p4 -> (%x15,%z17.s,sxtw #1)[16byte]
+e4f3d630 : st1h z16.s, p5, [x17, z19.s, SXTW #1]     : st1h   %z16.s %p5 -> (%x17,%z19.s,sxtw #1)[16byte]
+e4f4d671 : st1h z17.s, p5, [x19, z20.s, SXTW #1]     : st1h   %z17.s %p5 -> (%x19,%z20.s,sxtw #1)[16byte]
+e4f6d6b3 : st1h z19.s, p5, [x21, z22.s, SXTW #1]     : st1h   %z19.s %p5 -> (%x21,%z22.s,sxtw #1)[16byte]
+e4f8daf5 : st1h z21.s, p6, [x23, z24.s, SXTW #1]     : st1h   %z21.s %p6 -> (%x23,%z24.s,sxtw #1)[16byte]
+e4fadb17 : st1h z23.s, p6, [x24, z26.s, SXTW #1]     : st1h   %z23.s %p6 -> (%x24,%z26.s,sxtw #1)[16byte]
+e4fcdf59 : st1h z25.s, p7, [x26, z28.s, SXTW #1]     : st1h   %z25.s %p7 -> (%x26,%z28.s,sxtw #1)[16byte]
+e4fedf9b : st1h z27.s, p7, [x28, z30.s, SXTW #1]     : st1h   %z27.s %p7 -> (%x28,%z30.s,sxtw #1)[16byte]
+e4ffdfff : st1h z31.s, p7, [sp, z31.s, SXTW #1]      : st1h   %z31.s %p7 -> (%sp,%z31.s,sxtw #1)[16byte]
+
+# ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] (ST1H-Z.P.BZ-S.x32.unscaled)
+e4c08000 : st1h z0.s, p0, [x0, z0.s, UXTW]           : st1h   %z0.s %p0 -> (%x0,%z0.s,uxtw)[16byte]
+e4c58482 : st1h z2.s, p1, [x4, z5.s, UXTW]           : st1h   %z2.s %p1 -> (%x4,%z5.s,uxtw)[16byte]
+e4c788c4 : st1h z4.s, p2, [x6, z7.s, UXTW]           : st1h   %z4.s %p2 -> (%x6,%z7.s,uxtw)[16byte]
+e4c98906 : st1h z6.s, p2, [x8, z9.s, UXTW]           : st1h   %z6.s %p2 -> (%x8,%z9.s,uxtw)[16byte]
+e4cb8d48 : st1h z8.s, p3, [x10, z11.s, UXTW]         : st1h   %z8.s %p3 -> (%x10,%z11.s,uxtw)[16byte]
+e4cd8d6a : st1h z10.s, p3, [x11, z13.s, UXTW]        : st1h   %z10.s %p3 -> (%x11,%z13.s,uxtw)[16byte]
+e4cf91ac : st1h z12.s, p4, [x13, z15.s, UXTW]        : st1h   %z12.s %p4 -> (%x13,%z15.s,uxtw)[16byte]
+e4d191ee : st1h z14.s, p4, [x15, z17.s, UXTW]        : st1h   %z14.s %p4 -> (%x15,%z17.s,uxtw)[16byte]
+e4d39630 : st1h z16.s, p5, [x17, z19.s, UXTW]        : st1h   %z16.s %p5 -> (%x17,%z19.s,uxtw)[16byte]
+e4d49671 : st1h z17.s, p5, [x19, z20.s, UXTW]        : st1h   %z17.s %p5 -> (%x19,%z20.s,uxtw)[16byte]
+e4d696b3 : st1h z19.s, p5, [x21, z22.s, UXTW]        : st1h   %z19.s %p5 -> (%x21,%z22.s,uxtw)[16byte]
+e4d89af5 : st1h z21.s, p6, [x23, z24.s, UXTW]        : st1h   %z21.s %p6 -> (%x23,%z24.s,uxtw)[16byte]
+e4da9b17 : st1h z23.s, p6, [x24, z26.s, UXTW]        : st1h   %z23.s %p6 -> (%x24,%z26.s,uxtw)[16byte]
+e4dc9f59 : st1h z25.s, p7, [x26, z28.s, UXTW]        : st1h   %z25.s %p7 -> (%x26,%z28.s,uxtw)[16byte]
+e4de9f9b : st1h z27.s, p7, [x28, z30.s, UXTW]        : st1h   %z27.s %p7 -> (%x28,%z30.s,uxtw)[16byte]
+e4df9fff : st1h z31.s, p7, [sp, z31.s, UXTW]         : st1h   %z31.s %p7 -> (%sp,%z31.s,uxtw)[16byte]
+e4c0c000 : st1h z0.s, p0, [x0, z0.s, SXTW]           : st1h   %z0.s %p0 -> (%x0,%z0.s,sxtw)[16byte]
+e4c5c482 : st1h z2.s, p1, [x4, z5.s, SXTW]           : st1h   %z2.s %p1 -> (%x4,%z5.s,sxtw)[16byte]
+e4c7c8c4 : st1h z4.s, p2, [x6, z7.s, SXTW]           : st1h   %z4.s %p2 -> (%x6,%z7.s,sxtw)[16byte]
+e4c9c906 : st1h z6.s, p2, [x8, z9.s, SXTW]           : st1h   %z6.s %p2 -> (%x8,%z9.s,sxtw)[16byte]
+e4cbcd48 : st1h z8.s, p3, [x10, z11.s, SXTW]         : st1h   %z8.s %p3 -> (%x10,%z11.s,sxtw)[16byte]
+e4cdcd6a : st1h z10.s, p3, [x11, z13.s, SXTW]        : st1h   %z10.s %p3 -> (%x11,%z13.s,sxtw)[16byte]
+e4cfd1ac : st1h z12.s, p4, [x13, z15.s, SXTW]        : st1h   %z12.s %p4 -> (%x13,%z15.s,sxtw)[16byte]
+e4d1d1ee : st1h z14.s, p4, [x15, z17.s, SXTW]        : st1h   %z14.s %p4 -> (%x15,%z17.s,sxtw)[16byte]
+e4d3d630 : st1h z16.s, p5, [x17, z19.s, SXTW]        : st1h   %z16.s %p5 -> (%x17,%z19.s,sxtw)[16byte]
+e4d4d671 : st1h z17.s, p5, [x19, z20.s, SXTW]        : st1h   %z17.s %p5 -> (%x19,%z20.s,sxtw)[16byte]
+e4d6d6b3 : st1h z19.s, p5, [x21, z22.s, SXTW]        : st1h   %z19.s %p5 -> (%x21,%z22.s,sxtw)[16byte]
+e4d8daf5 : st1h z21.s, p6, [x23, z24.s, SXTW]        : st1h   %z21.s %p6 -> (%x23,%z24.s,sxtw)[16byte]
+e4dadb17 : st1h z23.s, p6, [x24, z26.s, SXTW]        : st1h   %z23.s %p6 -> (%x24,%z26.s,sxtw)[16byte]
+e4dcdf59 : st1h z25.s, p7, [x26, z28.s, SXTW]        : st1h   %z25.s %p7 -> (%x26,%z28.s,sxtw)[16byte]
+e4dedf9b : st1h z27.s, p7, [x28, z30.s, SXTW]        : st1h   %z27.s %p7 -> (%x28,%z30.s,sxtw)[16byte]
+e4dfdfff : st1h z31.s, p7, [sp, z31.s, SXTW]         : st1h   %z31.s %p7 -> (%sp,%z31.s,sxtw)[16byte]
+
 # ST1W    { <Zt>.S }, <Pg>, [<Zn>.S{, #<pimm>}] (ST1W-Z.P.AI-S)
 e560a000 : st1w z0.s, p0, [z0.s, #0]                 : st1w   %z0.s %p0 -> (%z0.s)[32byte]
 e562a482 : st1w z2.s, p1, [z4.s, #8]                 : st1w   %z2.s %p1 -> +0x08(%z4.s)[32byte]
@@ -17734,6 +19674,160 @@ e53abb17 : st1w z23.d, p6, [x24, z26.d, LSL #2]      : st1w   %z23.d %p6 -> (%x2
 e53cbf59 : st1w z25.d, p7, [x26, z28.d, LSL #2]      : st1w   %z25.d %p7 -> (%x26,%z28.d,lsl #2)[16byte]
 e53ebf9b : st1w z27.d, p7, [x28, z30.d, LSL #2]      : st1w   %z27.d %p7 -> (%x28,%z30.d,lsl #2)[16byte]
 e53fbfff : st1w z31.d, p7, [sp, z31.d, LSL #2]       : st1w   %z31.d %p7 -> (%sp,%z31.d,lsl #2)[16byte]
+
+# ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D] (ST1W-Z.P.BZ-D.64.unscaled)
+e500a000 : st1w z0.d, p0, [x0, z0.d]                 : st1w   %z0.d %p0 -> (%x0,%z0.d)[16byte]
+e505a482 : st1w z2.d, p1, [x4, z5.d]                 : st1w   %z2.d %p1 -> (%x4,%z5.d)[16byte]
+e507a8c4 : st1w z4.d, p2, [x6, z7.d]                 : st1w   %z4.d %p2 -> (%x6,%z7.d)[16byte]
+e509a906 : st1w z6.d, p2, [x8, z9.d]                 : st1w   %z6.d %p2 -> (%x8,%z9.d)[16byte]
+e50bad48 : st1w z8.d, p3, [x10, z11.d]               : st1w   %z8.d %p3 -> (%x10,%z11.d)[16byte]
+e50dad6a : st1w z10.d, p3, [x11, z13.d]              : st1w   %z10.d %p3 -> (%x11,%z13.d)[16byte]
+e50fb1ac : st1w z12.d, p4, [x13, z15.d]              : st1w   %z12.d %p4 -> (%x13,%z15.d)[16byte]
+e511b1ee : st1w z14.d, p4, [x15, z17.d]              : st1w   %z14.d %p4 -> (%x15,%z17.d)[16byte]
+e513b630 : st1w z16.d, p5, [x17, z19.d]              : st1w   %z16.d %p5 -> (%x17,%z19.d)[16byte]
+e514b671 : st1w z17.d, p5, [x19, z20.d]              : st1w   %z17.d %p5 -> (%x19,%z20.d)[16byte]
+e516b6b3 : st1w z19.d, p5, [x21, z22.d]              : st1w   %z19.d %p5 -> (%x21,%z22.d)[16byte]
+e518baf5 : st1w z21.d, p6, [x23, z24.d]              : st1w   %z21.d %p6 -> (%x23,%z24.d)[16byte]
+e51abb17 : st1w z23.d, p6, [x24, z26.d]              : st1w   %z23.d %p6 -> (%x24,%z26.d)[16byte]
+e51cbf59 : st1w z25.d, p7, [x26, z28.d]              : st1w   %z25.d %p7 -> (%x26,%z28.d)[16byte]
+e51ebf9b : st1w z27.d, p7, [x28, z30.d]              : st1w   %z27.d %p7 -> (%x28,%z30.d)[16byte]
+e51fbfff : st1w z31.d, p7, [sp, z31.d]               : st1w   %z31.d %p7 -> (%sp,%z31.d)[16byte]
+
+# ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2] (ST1W-Z.P.BZ-D.x32.scaled)
+e5208000 : st1w z0.d, p0, [x0, z0.d, UXTW #2]        : st1w   %z0.d %p0 -> (%x0,%z0.d,uxtw #2)[16byte]
+e5258482 : st1w z2.d, p1, [x4, z5.d, UXTW #2]        : st1w   %z2.d %p1 -> (%x4,%z5.d,uxtw #2)[16byte]
+e52788c4 : st1w z4.d, p2, [x6, z7.d, UXTW #2]        : st1w   %z4.d %p2 -> (%x6,%z7.d,uxtw #2)[16byte]
+e5298906 : st1w z6.d, p2, [x8, z9.d, UXTW #2]        : st1w   %z6.d %p2 -> (%x8,%z9.d,uxtw #2)[16byte]
+e52b8d48 : st1w z8.d, p3, [x10, z11.d, UXTW #2]      : st1w   %z8.d %p3 -> (%x10,%z11.d,uxtw #2)[16byte]
+e52d8d6a : st1w z10.d, p3, [x11, z13.d, UXTW #2]     : st1w   %z10.d %p3 -> (%x11,%z13.d,uxtw #2)[16byte]
+e52f91ac : st1w z12.d, p4, [x13, z15.d, UXTW #2]     : st1w   %z12.d %p4 -> (%x13,%z15.d,uxtw #2)[16byte]
+e53191ee : st1w z14.d, p4, [x15, z17.d, UXTW #2]     : st1w   %z14.d %p4 -> (%x15,%z17.d,uxtw #2)[16byte]
+e5339630 : st1w z16.d, p5, [x17, z19.d, UXTW #2]     : st1w   %z16.d %p5 -> (%x17,%z19.d,uxtw #2)[16byte]
+e5349671 : st1w z17.d, p5, [x19, z20.d, UXTW #2]     : st1w   %z17.d %p5 -> (%x19,%z20.d,uxtw #2)[16byte]
+e53696b3 : st1w z19.d, p5, [x21, z22.d, UXTW #2]     : st1w   %z19.d %p5 -> (%x21,%z22.d,uxtw #2)[16byte]
+e5389af5 : st1w z21.d, p6, [x23, z24.d, UXTW #2]     : st1w   %z21.d %p6 -> (%x23,%z24.d,uxtw #2)[16byte]
+e53a9b17 : st1w z23.d, p6, [x24, z26.d, UXTW #2]     : st1w   %z23.d %p6 -> (%x24,%z26.d,uxtw #2)[16byte]
+e53c9f59 : st1w z25.d, p7, [x26, z28.d, UXTW #2]     : st1w   %z25.d %p7 -> (%x26,%z28.d,uxtw #2)[16byte]
+e53e9f9b : st1w z27.d, p7, [x28, z30.d, UXTW #2]     : st1w   %z27.d %p7 -> (%x28,%z30.d,uxtw #2)[16byte]
+e53f9fff : st1w z31.d, p7, [sp, z31.d, UXTW #2]      : st1w   %z31.d %p7 -> (%sp,%z31.d,uxtw #2)[16byte]
+e520c000 : st1w z0.d, p0, [x0, z0.d, SXTW #2]        : st1w   %z0.d %p0 -> (%x0,%z0.d,sxtw #2)[16byte]
+e525c482 : st1w z2.d, p1, [x4, z5.d, SXTW #2]        : st1w   %z2.d %p1 -> (%x4,%z5.d,sxtw #2)[16byte]
+e527c8c4 : st1w z4.d, p2, [x6, z7.d, SXTW #2]        : st1w   %z4.d %p2 -> (%x6,%z7.d,sxtw #2)[16byte]
+e529c906 : st1w z6.d, p2, [x8, z9.d, SXTW #2]        : st1w   %z6.d %p2 -> (%x8,%z9.d,sxtw #2)[16byte]
+e52bcd48 : st1w z8.d, p3, [x10, z11.d, SXTW #2]      : st1w   %z8.d %p3 -> (%x10,%z11.d,sxtw #2)[16byte]
+e52dcd6a : st1w z10.d, p3, [x11, z13.d, SXTW #2]     : st1w   %z10.d %p3 -> (%x11,%z13.d,sxtw #2)[16byte]
+e52fd1ac : st1w z12.d, p4, [x13, z15.d, SXTW #2]     : st1w   %z12.d %p4 -> (%x13,%z15.d,sxtw #2)[16byte]
+e531d1ee : st1w z14.d, p4, [x15, z17.d, SXTW #2]     : st1w   %z14.d %p4 -> (%x15,%z17.d,sxtw #2)[16byte]
+e533d630 : st1w z16.d, p5, [x17, z19.d, SXTW #2]     : st1w   %z16.d %p5 -> (%x17,%z19.d,sxtw #2)[16byte]
+e534d671 : st1w z17.d, p5, [x19, z20.d, SXTW #2]     : st1w   %z17.d %p5 -> (%x19,%z20.d,sxtw #2)[16byte]
+e536d6b3 : st1w z19.d, p5, [x21, z22.d, SXTW #2]     : st1w   %z19.d %p5 -> (%x21,%z22.d,sxtw #2)[16byte]
+e538daf5 : st1w z21.d, p6, [x23, z24.d, SXTW #2]     : st1w   %z21.d %p6 -> (%x23,%z24.d,sxtw #2)[16byte]
+e53adb17 : st1w z23.d, p6, [x24, z26.d, SXTW #2]     : st1w   %z23.d %p6 -> (%x24,%z26.d,sxtw #2)[16byte]
+e53cdf59 : st1w z25.d, p7, [x26, z28.d, SXTW #2]     : st1w   %z25.d %p7 -> (%x26,%z28.d,sxtw #2)[16byte]
+e53edf9b : st1w z27.d, p7, [x28, z30.d, SXTW #2]     : st1w   %z27.d %p7 -> (%x28,%z30.d,sxtw #2)[16byte]
+e53fdfff : st1w z31.d, p7, [sp, z31.d, SXTW #2]      : st1w   %z31.d %p7 -> (%sp,%z31.d,sxtw #2)[16byte]
+
+# ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] (ST1W-Z.P.BZ-D.x32.unscaled)
+e5008000 : st1w z0.d, p0, [x0, z0.d, UXTW]           : st1w   %z0.d %p0 -> (%x0,%z0.d,uxtw)[16byte]
+e5058482 : st1w z2.d, p1, [x4, z5.d, UXTW]           : st1w   %z2.d %p1 -> (%x4,%z5.d,uxtw)[16byte]
+e50788c4 : st1w z4.d, p2, [x6, z7.d, UXTW]           : st1w   %z4.d %p2 -> (%x6,%z7.d,uxtw)[16byte]
+e5098906 : st1w z6.d, p2, [x8, z9.d, UXTW]           : st1w   %z6.d %p2 -> (%x8,%z9.d,uxtw)[16byte]
+e50b8d48 : st1w z8.d, p3, [x10, z11.d, UXTW]         : st1w   %z8.d %p3 -> (%x10,%z11.d,uxtw)[16byte]
+e50d8d6a : st1w z10.d, p3, [x11, z13.d, UXTW]        : st1w   %z10.d %p3 -> (%x11,%z13.d,uxtw)[16byte]
+e50f91ac : st1w z12.d, p4, [x13, z15.d, UXTW]        : st1w   %z12.d %p4 -> (%x13,%z15.d,uxtw)[16byte]
+e51191ee : st1w z14.d, p4, [x15, z17.d, UXTW]        : st1w   %z14.d %p4 -> (%x15,%z17.d,uxtw)[16byte]
+e5139630 : st1w z16.d, p5, [x17, z19.d, UXTW]        : st1w   %z16.d %p5 -> (%x17,%z19.d,uxtw)[16byte]
+e5149671 : st1w z17.d, p5, [x19, z20.d, UXTW]        : st1w   %z17.d %p5 -> (%x19,%z20.d,uxtw)[16byte]
+e51696b3 : st1w z19.d, p5, [x21, z22.d, UXTW]        : st1w   %z19.d %p5 -> (%x21,%z22.d,uxtw)[16byte]
+e5189af5 : st1w z21.d, p6, [x23, z24.d, UXTW]        : st1w   %z21.d %p6 -> (%x23,%z24.d,uxtw)[16byte]
+e51a9b17 : st1w z23.d, p6, [x24, z26.d, UXTW]        : st1w   %z23.d %p6 -> (%x24,%z26.d,uxtw)[16byte]
+e51c9f59 : st1w z25.d, p7, [x26, z28.d, UXTW]        : st1w   %z25.d %p7 -> (%x26,%z28.d,uxtw)[16byte]
+e51e9f9b : st1w z27.d, p7, [x28, z30.d, UXTW]        : st1w   %z27.d %p7 -> (%x28,%z30.d,uxtw)[16byte]
+e51f9fff : st1w z31.d, p7, [sp, z31.d, UXTW]         : st1w   %z31.d %p7 -> (%sp,%z31.d,uxtw)[16byte]
+e500c000 : st1w z0.d, p0, [x0, z0.d, SXTW]           : st1w   %z0.d %p0 -> (%x0,%z0.d,sxtw)[16byte]
+e505c482 : st1w z2.d, p1, [x4, z5.d, SXTW]           : st1w   %z2.d %p1 -> (%x4,%z5.d,sxtw)[16byte]
+e507c8c4 : st1w z4.d, p2, [x6, z7.d, SXTW]           : st1w   %z4.d %p2 -> (%x6,%z7.d,sxtw)[16byte]
+e509c906 : st1w z6.d, p2, [x8, z9.d, SXTW]           : st1w   %z6.d %p2 -> (%x8,%z9.d,sxtw)[16byte]
+e50bcd48 : st1w z8.d, p3, [x10, z11.d, SXTW]         : st1w   %z8.d %p3 -> (%x10,%z11.d,sxtw)[16byte]
+e50dcd6a : st1w z10.d, p3, [x11, z13.d, SXTW]        : st1w   %z10.d %p3 -> (%x11,%z13.d,sxtw)[16byte]
+e50fd1ac : st1w z12.d, p4, [x13, z15.d, SXTW]        : st1w   %z12.d %p4 -> (%x13,%z15.d,sxtw)[16byte]
+e511d1ee : st1w z14.d, p4, [x15, z17.d, SXTW]        : st1w   %z14.d %p4 -> (%x15,%z17.d,sxtw)[16byte]
+e513d630 : st1w z16.d, p5, [x17, z19.d, SXTW]        : st1w   %z16.d %p5 -> (%x17,%z19.d,sxtw)[16byte]
+e514d671 : st1w z17.d, p5, [x19, z20.d, SXTW]        : st1w   %z17.d %p5 -> (%x19,%z20.d,sxtw)[16byte]
+e516d6b3 : st1w z19.d, p5, [x21, z22.d, SXTW]        : st1w   %z19.d %p5 -> (%x21,%z22.d,sxtw)[16byte]
+e518daf5 : st1w z21.d, p6, [x23, z24.d, SXTW]        : st1w   %z21.d %p6 -> (%x23,%z24.d,sxtw)[16byte]
+e51adb17 : st1w z23.d, p6, [x24, z26.d, SXTW]        : st1w   %z23.d %p6 -> (%x24,%z26.d,sxtw)[16byte]
+e51cdf59 : st1w z25.d, p7, [x26, z28.d, SXTW]        : st1w   %z25.d %p7 -> (%x26,%z28.d,sxtw)[16byte]
+e51edf9b : st1w z27.d, p7, [x28, z30.d, SXTW]        : st1w   %z27.d %p7 -> (%x28,%z30.d,sxtw)[16byte]
+e51fdfff : st1w z31.d, p7, [sp, z31.d, SXTW]         : st1w   %z31.d %p7 -> (%sp,%z31.d,sxtw)[16byte]
+
+# ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2] (ST1W-Z.P.BZ-S.x32.scaled)
+e5608000 : st1w z0.s, p0, [x0, z0.s, UXTW #2]        : st1w   %z0.s %p0 -> (%x0,%z0.s,uxtw #2)[32byte]
+e5658482 : st1w z2.s, p1, [x4, z5.s, UXTW #2]        : st1w   %z2.s %p1 -> (%x4,%z5.s,uxtw #2)[32byte]
+e56788c4 : st1w z4.s, p2, [x6, z7.s, UXTW #2]        : st1w   %z4.s %p2 -> (%x6,%z7.s,uxtw #2)[32byte]
+e5698906 : st1w z6.s, p2, [x8, z9.s, UXTW #2]        : st1w   %z6.s %p2 -> (%x8,%z9.s,uxtw #2)[32byte]
+e56b8d48 : st1w z8.s, p3, [x10, z11.s, UXTW #2]      : st1w   %z8.s %p3 -> (%x10,%z11.s,uxtw #2)[32byte]
+e56d8d6a : st1w z10.s, p3, [x11, z13.s, UXTW #2]     : st1w   %z10.s %p3 -> (%x11,%z13.s,uxtw #2)[32byte]
+e56f91ac : st1w z12.s, p4, [x13, z15.s, UXTW #2]     : st1w   %z12.s %p4 -> (%x13,%z15.s,uxtw #2)[32byte]
+e57191ee : st1w z14.s, p4, [x15, z17.s, UXTW #2]     : st1w   %z14.s %p4 -> (%x15,%z17.s,uxtw #2)[32byte]
+e5739630 : st1w z16.s, p5, [x17, z19.s, UXTW #2]     : st1w   %z16.s %p5 -> (%x17,%z19.s,uxtw #2)[32byte]
+e5749671 : st1w z17.s, p5, [x19, z20.s, UXTW #2]     : st1w   %z17.s %p5 -> (%x19,%z20.s,uxtw #2)[32byte]
+e57696b3 : st1w z19.s, p5, [x21, z22.s, UXTW #2]     : st1w   %z19.s %p5 -> (%x21,%z22.s,uxtw #2)[32byte]
+e5789af5 : st1w z21.s, p6, [x23, z24.s, UXTW #2]     : st1w   %z21.s %p6 -> (%x23,%z24.s,uxtw #2)[32byte]
+e57a9b17 : st1w z23.s, p6, [x24, z26.s, UXTW #2]     : st1w   %z23.s %p6 -> (%x24,%z26.s,uxtw #2)[32byte]
+e57c9f59 : st1w z25.s, p7, [x26, z28.s, UXTW #2]     : st1w   %z25.s %p7 -> (%x26,%z28.s,uxtw #2)[32byte]
+e57e9f9b : st1w z27.s, p7, [x28, z30.s, UXTW #2]     : st1w   %z27.s %p7 -> (%x28,%z30.s,uxtw #2)[32byte]
+e57f9fff : st1w z31.s, p7, [sp, z31.s, UXTW #2]      : st1w   %z31.s %p7 -> (%sp,%z31.s,uxtw #2)[32byte]
+e560c000 : st1w z0.s, p0, [x0, z0.s, SXTW #2]        : st1w   %z0.s %p0 -> (%x0,%z0.s,sxtw #2)[32byte]
+e565c482 : st1w z2.s, p1, [x4, z5.s, SXTW #2]        : st1w   %z2.s %p1 -> (%x4,%z5.s,sxtw #2)[32byte]
+e567c8c4 : st1w z4.s, p2, [x6, z7.s, SXTW #2]        : st1w   %z4.s %p2 -> (%x6,%z7.s,sxtw #2)[32byte]
+e569c906 : st1w z6.s, p2, [x8, z9.s, SXTW #2]        : st1w   %z6.s %p2 -> (%x8,%z9.s,sxtw #2)[32byte]
+e56bcd48 : st1w z8.s, p3, [x10, z11.s, SXTW #2]      : st1w   %z8.s %p3 -> (%x10,%z11.s,sxtw #2)[32byte]
+e56dcd6a : st1w z10.s, p3, [x11, z13.s, SXTW #2]     : st1w   %z10.s %p3 -> (%x11,%z13.s,sxtw #2)[32byte]
+e56fd1ac : st1w z12.s, p4, [x13, z15.s, SXTW #2]     : st1w   %z12.s %p4 -> (%x13,%z15.s,sxtw #2)[32byte]
+e571d1ee : st1w z14.s, p4, [x15, z17.s, SXTW #2]     : st1w   %z14.s %p4 -> (%x15,%z17.s,sxtw #2)[32byte]
+e573d630 : st1w z16.s, p5, [x17, z19.s, SXTW #2]     : st1w   %z16.s %p5 -> (%x17,%z19.s,sxtw #2)[32byte]
+e574d671 : st1w z17.s, p5, [x19, z20.s, SXTW #2]     : st1w   %z17.s %p5 -> (%x19,%z20.s,sxtw #2)[32byte]
+e576d6b3 : st1w z19.s, p5, [x21, z22.s, SXTW #2]     : st1w   %z19.s %p5 -> (%x21,%z22.s,sxtw #2)[32byte]
+e578daf5 : st1w z21.s, p6, [x23, z24.s, SXTW #2]     : st1w   %z21.s %p6 -> (%x23,%z24.s,sxtw #2)[32byte]
+e57adb17 : st1w z23.s, p6, [x24, z26.s, SXTW #2]     : st1w   %z23.s %p6 -> (%x24,%z26.s,sxtw #2)[32byte]
+e57cdf59 : st1w z25.s, p7, [x26, z28.s, SXTW #2]     : st1w   %z25.s %p7 -> (%x26,%z28.s,sxtw #2)[32byte]
+e57edf9b : st1w z27.s, p7, [x28, z30.s, SXTW #2]     : st1w   %z27.s %p7 -> (%x28,%z30.s,sxtw #2)[32byte]
+e57fdfff : st1w z31.s, p7, [sp, z31.s, SXTW #2]      : st1w   %z31.s %p7 -> (%sp,%z31.s,sxtw #2)[32byte]
+
+# ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] (ST1W-Z.P.BZ-S.x32.unscaled)
+e5408000 : st1w z0.s, p0, [x0, z0.s, UXTW]           : st1w   %z0.s %p0 -> (%x0,%z0.s,uxtw)[32byte]
+e5458482 : st1w z2.s, p1, [x4, z5.s, UXTW]           : st1w   %z2.s %p1 -> (%x4,%z5.s,uxtw)[32byte]
+e54788c4 : st1w z4.s, p2, [x6, z7.s, UXTW]           : st1w   %z4.s %p2 -> (%x6,%z7.s,uxtw)[32byte]
+e5498906 : st1w z6.s, p2, [x8, z9.s, UXTW]           : st1w   %z6.s %p2 -> (%x8,%z9.s,uxtw)[32byte]
+e54b8d48 : st1w z8.s, p3, [x10, z11.s, UXTW]         : st1w   %z8.s %p3 -> (%x10,%z11.s,uxtw)[32byte]
+e54d8d6a : st1w z10.s, p3, [x11, z13.s, UXTW]        : st1w   %z10.s %p3 -> (%x11,%z13.s,uxtw)[32byte]
+e54f91ac : st1w z12.s, p4, [x13, z15.s, UXTW]        : st1w   %z12.s %p4 -> (%x13,%z15.s,uxtw)[32byte]
+e55191ee : st1w z14.s, p4, [x15, z17.s, UXTW]        : st1w   %z14.s %p4 -> (%x15,%z17.s,uxtw)[32byte]
+e5539630 : st1w z16.s, p5, [x17, z19.s, UXTW]        : st1w   %z16.s %p5 -> (%x17,%z19.s,uxtw)[32byte]
+e5549671 : st1w z17.s, p5, [x19, z20.s, UXTW]        : st1w   %z17.s %p5 -> (%x19,%z20.s,uxtw)[32byte]
+e55696b3 : st1w z19.s, p5, [x21, z22.s, UXTW]        : st1w   %z19.s %p5 -> (%x21,%z22.s,uxtw)[32byte]
+e5589af5 : st1w z21.s, p6, [x23, z24.s, UXTW]        : st1w   %z21.s %p6 -> (%x23,%z24.s,uxtw)[32byte]
+e55a9b17 : st1w z23.s, p6, [x24, z26.s, UXTW]        : st1w   %z23.s %p6 -> (%x24,%z26.s,uxtw)[32byte]
+e55c9f59 : st1w z25.s, p7, [x26, z28.s, UXTW]        : st1w   %z25.s %p7 -> (%x26,%z28.s,uxtw)[32byte]
+e55e9f9b : st1w z27.s, p7, [x28, z30.s, UXTW]        : st1w   %z27.s %p7 -> (%x28,%z30.s,uxtw)[32byte]
+e55f9fff : st1w z31.s, p7, [sp, z31.s, UXTW]         : st1w   %z31.s %p7 -> (%sp,%z31.s,uxtw)[32byte]
+e540c000 : st1w z0.s, p0, [x0, z0.s, SXTW]           : st1w   %z0.s %p0 -> (%x0,%z0.s,sxtw)[32byte]
+e545c482 : st1w z2.s, p1, [x4, z5.s, SXTW]           : st1w   %z2.s %p1 -> (%x4,%z5.s,sxtw)[32byte]
+e547c8c4 : st1w z4.s, p2, [x6, z7.s, SXTW]           : st1w   %z4.s %p2 -> (%x6,%z7.s,sxtw)[32byte]
+e549c906 : st1w z6.s, p2, [x8, z9.s, SXTW]           : st1w   %z6.s %p2 -> (%x8,%z9.s,sxtw)[32byte]
+e54bcd48 : st1w z8.s, p3, [x10, z11.s, SXTW]         : st1w   %z8.s %p3 -> (%x10,%z11.s,sxtw)[32byte]
+e54dcd6a : st1w z10.s, p3, [x11, z13.s, SXTW]        : st1w   %z10.s %p3 -> (%x11,%z13.s,sxtw)[32byte]
+e54fd1ac : st1w z12.s, p4, [x13, z15.s, SXTW]        : st1w   %z12.s %p4 -> (%x13,%z15.s,sxtw)[32byte]
+e551d1ee : st1w z14.s, p4, [x15, z17.s, SXTW]        : st1w   %z14.s %p4 -> (%x15,%z17.s,sxtw)[32byte]
+e553d630 : st1w z16.s, p5, [x17, z19.s, SXTW]        : st1w   %z16.s %p5 -> (%x17,%z19.s,sxtw)[32byte]
+e554d671 : st1w z17.s, p5, [x19, z20.s, SXTW]        : st1w   %z17.s %p5 -> (%x19,%z20.s,sxtw)[32byte]
+e556d6b3 : st1w z19.s, p5, [x21, z22.s, SXTW]        : st1w   %z19.s %p5 -> (%x21,%z22.s,sxtw)[32byte]
+e558daf5 : st1w z21.s, p6, [x23, z24.s, SXTW]        : st1w   %z21.s %p6 -> (%x23,%z24.s,sxtw)[32byte]
+e55adb17 : st1w z23.s, p6, [x24, z26.s, SXTW]        : st1w   %z23.s %p6 -> (%x24,%z26.s,sxtw)[32byte]
+e55cdf59 : st1w z25.s, p7, [x26, z28.s, SXTW]        : st1w   %z25.s %p7 -> (%x26,%z28.s,sxtw)[32byte]
+e55edf9b : st1w z27.s, p7, [x28, z30.s, SXTW]        : st1w   %z27.s %p7 -> (%x28,%z30.s,sxtw)[32byte]
+e55fdfff : st1w z31.s, p7, [sp, z31.s, SXTW]         : st1w   %z31.s %p7 -> (%sp,%z31.s,sxtw)[32byte]
 
 # STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>] (STNT1B-Z.P.BR-Contiguous)
 e4006000 : stnt1b z0.b, p0, [x0, x0]                 : stnt1b %z0.b %p0 -> (%x0,%x0)[32byte]
@@ -22188,4 +24282,3 @@ e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x4b(%x15)
 05ee45ac : zip2 p12.d, p13.d, p14.d                  : zip2   %p13.d %p14.d -> %p12.d
 05ef45cd : zip2 p13.d, p14.d, p15.d                  : zip2   %p14.d %p15.d -> %p13.d
 05ef45ef : zip2 p15.d, p15.d, p15.d                  : zip2   %p15.d %p15.d -> %p15.d
-

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -13802,6 +13802,68 @@ TEST_INSTR(ldff1b_sve_pred)
               opnd_create_vector_base_disp_aarch64(Xn_six_offset_2_sp[i],
                                                    Zn_six_offset_3[i], OPSZ_8,
                                                    DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4, 0));
+
+    /* Testing LDFF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ldff1b (%x0,%z0.d)[4byte] %p0/z -> %z0.d",
+        "ldff1b (%x7,%z8.d)[4byte] %p2/z -> %z5.d",
+        "ldff1b (%x12,%z13.d)[4byte] %p3/z -> %z10.d",
+        "ldff1b (%x17,%z19.d)[4byte] %p5/z -> %z16.d",
+        "ldff1b (%x22,%z24.d)[4byte] %p6/z -> %z21.d",
+        "ldff1b (%sp,%z31.d)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1b, ldff1b_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Xn_six_offset_2_sp[i],
+                                                   Zn_six_offset_3[i], OPSZ_8,
+                                                   DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4, 0));
+
+    const char *const expected_6_1[6] = {
+        "ldff1b (%x0,%z0.d)[4byte] %p0/z -> %z0.d",
+        "ldff1b (%x7,%z8.d)[4byte] %p2/z -> %z5.d",
+        "ldff1b (%x12,%z13.d)[4byte] %p3/z -> %z10.d",
+        "ldff1b (%x17,%z19.d)[4byte] %p5/z -> %z16.d",
+        "ldff1b (%x22,%z24.d)[4byte] %p6/z -> %z21.d",
+        "ldff1b (%sp,%z31.d)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1b, ldff1b_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Xn_six_offset_2_sp[i],
+                                                   Zn_six_offset_3[i], OPSZ_8,
+                                                   DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4, 0));
+
+    /* Testing LDFF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_7_0[6] = {
+        "ldff1b (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s",
+        "ldff1b (%x7,%z8.s,uxtw)[8byte] %p2/z -> %z5.s",
+        "ldff1b (%x12,%z13.s,uxtw)[8byte] %p3/z -> %z10.s",
+        "ldff1b (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s",
+        "ldff1b (%x22,%z24.s,uxtw)[8byte] %p6/z -> %z21.s",
+        "ldff1b (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1b, ldff1b_sve_pred, 6, expected_7_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_7_1[6] = {
+        "ldff1b (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s",
+        "ldff1b (%x7,%z8.s,sxtw)[8byte] %p2/z -> %z5.s",
+        "ldff1b (%x12,%z13.s,sxtw)[8byte] %p3/z -> %z10.s",
+        "ldff1b (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s",
+        "ldff1b (%x22,%z24.s,sxtw)[8byte] %p6/z -> %z21.s",
+        "ldff1b (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1b, ldff1b_sve_pred, 6, expected_7_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
 }
 
 TEST_INSTR(ldff1d_sve_pred)
@@ -13869,6 +13931,68 @@ TEST_INSTR(ldff1d_sve_pred)
               opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_32, 0));
+
+    /* Testing LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3] */
+    const char *const expected_4_0[6] = {
+        "ldff1d (%x0,%z0.d,uxtw #3)[32byte] %p0/z -> %z0.d",
+        "ldff1d (%x7,%z8.d,uxtw #3)[32byte] %p2/z -> %z5.d",
+        "ldff1d (%x12,%z13.d,uxtw #3)[32byte] %p3/z -> %z10.d",
+        "ldff1d (%x17,%z19.d,uxtw #3)[32byte] %p5/z -> %z16.d",
+        "ldff1d (%x22,%z24.d,uxtw #3)[32byte] %p6/z -> %z21.d",
+        "ldff1d (%sp,%z31.d,uxtw #3)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1d, ldff1d_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_32, 3));
+
+    const char *const expected_4_1[6] = {
+        "ldff1d (%x0,%z0.d,sxtw #3)[32byte] %p0/z -> %z0.d",
+        "ldff1d (%x7,%z8.d,sxtw #3)[32byte] %p2/z -> %z5.d",
+        "ldff1d (%x12,%z13.d,sxtw #3)[32byte] %p3/z -> %z10.d",
+        "ldff1d (%x17,%z19.d,sxtw #3)[32byte] %p5/z -> %z16.d",
+        "ldff1d (%x22,%z24.d,sxtw #3)[32byte] %p6/z -> %z21.d",
+        "ldff1d (%sp,%z31.d,sxtw #3)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1d, ldff1d_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_32, 3));
+
+    /* Testing LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_5_0[6] = {
+        "ldff1d (%x0,%z0.d,uxtw)[32byte] %p0/z -> %z0.d",
+        "ldff1d (%x7,%z8.d,uxtw)[32byte] %p2/z -> %z5.d",
+        "ldff1d (%x12,%z13.d,uxtw)[32byte] %p3/z -> %z10.d",
+        "ldff1d (%x17,%z19.d,uxtw)[32byte] %p5/z -> %z16.d",
+        "ldff1d (%x22,%z24.d,uxtw)[32byte] %p6/z -> %z21.d",
+        "ldff1d (%sp,%z31.d,uxtw)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1d, ldff1d_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_32, 0));
+
+    const char *const expected_5_1[6] = {
+        "ldff1d (%x0,%z0.d,sxtw)[32byte] %p0/z -> %z0.d",
+        "ldff1d (%x7,%z8.d,sxtw)[32byte] %p2/z -> %z5.d",
+        "ldff1d (%x12,%z13.d,sxtw)[32byte] %p3/z -> %z10.d",
+        "ldff1d (%x17,%z19.d,sxtw)[32byte] %p5/z -> %z16.d",
+        "ldff1d (%x22,%z24.d,sxtw)[32byte] %p6/z -> %z21.d",
+        "ldff1d (%sp,%z31.d,sxtw)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1d, ldff1d_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
                   false, 0, 0, OPSZ_32, 0));
 }
 
@@ -13986,6 +14110,130 @@ TEST_INSTR(ldff1h_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] */
+    const char *const expected_6_0[6] = {
+        "ldff1h (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d",
+        "ldff1h (%x7,%z8.d,uxtw #1)[8byte] %p2/z -> %z5.d",
+        "ldff1h (%x12,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d",
+        "ldff1h (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d",
+        "ldff1h (%x22,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d",
+        "ldff1h (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    const char *const expected_6_1[6] = {
+        "ldff1h (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d",
+        "ldff1h (%x7,%z8.d,sxtw #1)[8byte] %p2/z -> %z5.d",
+        "ldff1h (%x12,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d",
+        "ldff1h (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d",
+        "ldff1h (%x22,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d",
+        "ldff1h (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    /* Testing LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_7_0[6] = {
+        "ldff1h (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d",
+        "ldff1h (%x7,%z8.d,uxtw)[8byte] %p2/z -> %z5.d",
+        "ldff1h (%x12,%z13.d,uxtw)[8byte] %p3/z -> %z10.d",
+        "ldff1h (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d",
+        "ldff1h (%x22,%z24.d,uxtw)[8byte] %p6/z -> %z21.d",
+        "ldff1h (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_7_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_7_1[6] = {
+        "ldff1h (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d",
+        "ldff1h (%x7,%z8.d,sxtw)[8byte] %p2/z -> %z5.d",
+        "ldff1h (%x12,%z13.d,sxtw)[8byte] %p3/z -> %z10.d",
+        "ldff1h (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d",
+        "ldff1h (%x22,%z24.d,sxtw)[8byte] %p6/z -> %z21.d",
+        "ldff1h (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_7_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] */
+    const char *const expected_8_0[6] = {
+        "ldff1h (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s",
+        "ldff1h (%x7,%z8.s,uxtw #1)[16byte] %p2/z -> %z5.s",
+        "ldff1h (%x12,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s",
+        "ldff1h (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s",
+        "ldff1h (%x22,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s",
+        "ldff1h (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_8_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    const char *const expected_8_1[6] = {
+        "ldff1h (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s",
+        "ldff1h (%x7,%z8.s,sxtw #1)[16byte] %p2/z -> %z5.s",
+        "ldff1h (%x12,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s",
+        "ldff1h (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s",
+        "ldff1h (%x22,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s",
+        "ldff1h (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_8_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    /* Testing LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_9_0[6] = {
+        "ldff1h (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s",
+        "ldff1h (%x7,%z8.s,uxtw)[16byte] %p2/z -> %z5.s",
+        "ldff1h (%x12,%z13.s,uxtw)[16byte] %p3/z -> %z10.s",
+        "ldff1h (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s",
+        "ldff1h (%x22,%z24.s,uxtw)[16byte] %p6/z -> %z21.s",
+        "ldff1h (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_9_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_9_1[6] = {
+        "ldff1h (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s",
+        "ldff1h (%x7,%z8.s,sxtw)[16byte] %p2/z -> %z5.s",
+        "ldff1h (%x12,%z13.s,sxtw)[16byte] %p3/z -> %z10.s",
+        "ldff1h (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s",
+        "ldff1h (%x22,%z24.s,sxtw)[16byte] %p6/z -> %z21.s",
+        "ldff1h (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1h, ldff1h_sve_pred, 6, expected_9_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
 }
 
 TEST_INSTR(ldff1sb_sve_pred)
@@ -14083,6 +14331,68 @@ TEST_INSTR(ldff1sb_sve_pred)
               opnd_create_vector_base_disp_aarch64(Xn_six_offset_2_sp[i],
                                                    Zn_six_offset_3[i], OPSZ_8,
                                                    DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4, 0));
+
+    /* Testing LDFF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_5_0[6] = {
+        "ldff1sb (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d",
+        "ldff1sb (%x7,%z8.d,uxtw)[4byte] %p2/z -> %z5.d",
+        "ldff1sb (%x12,%z13.d,uxtw)[4byte] %p3/z -> %z10.d",
+        "ldff1sb (%x17,%z19.d,uxtw)[4byte] %p5/z -> %z16.d",
+        "ldff1sb (%x22,%z24.d,uxtw)[4byte] %p6/z -> %z21.d",
+        "ldff1sb (%sp,%z31.d,uxtw)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sb, ldff1sb_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    const char *const expected_5_1[6] = {
+        "ldff1sb (%x0,%z0.d,sxtw)[4byte] %p0/z -> %z0.d",
+        "ldff1sb (%x7,%z8.d,sxtw)[4byte] %p2/z -> %z5.d",
+        "ldff1sb (%x12,%z13.d,sxtw)[4byte] %p3/z -> %z10.d",
+        "ldff1sb (%x17,%z19.d,sxtw)[4byte] %p5/z -> %z16.d",
+        "ldff1sb (%x22,%z24.d,sxtw)[4byte] %p6/z -> %z21.d",
+        "ldff1sb (%sp,%z31.d,sxtw)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sb, ldff1sb_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    /* Testing LDFF1SB { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ldff1sb (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s",
+        "ldff1sb (%x7,%z8.s,uxtw)[8byte] %p2/z -> %z5.s",
+        "ldff1sb (%x12,%z13.s,uxtw)[8byte] %p3/z -> %z10.s",
+        "ldff1sb (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s",
+        "ldff1sb (%x22,%z24.s,uxtw)[8byte] %p6/z -> %z21.s",
+        "ldff1sb (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1sb, ldff1sb_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_6_1[6] = {
+        "ldff1sb (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s",
+        "ldff1sb (%x7,%z8.s,sxtw)[8byte] %p2/z -> %z5.s",
+        "ldff1sb (%x12,%z13.s,sxtw)[8byte] %p3/z -> %z10.s",
+        "ldff1sb (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s",
+        "ldff1sb (%x22,%z24.s,sxtw)[8byte] %p6/z -> %z21.s",
+        "ldff1sb (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1sb, ldff1sb_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
 }
 
 TEST_INSTR(ldff1sh_sve_pred)
@@ -14183,6 +14493,130 @@ TEST_INSTR(ldff1sh_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] */
+    const char *const expected_5_0[6] = {
+        "ldff1sh (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d",
+        "ldff1sh (%x7,%z8.d,uxtw #1)[8byte] %p2/z -> %z5.d",
+        "ldff1sh (%x12,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d",
+        "ldff1sh (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d",
+        "ldff1sh (%x22,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d",
+        "ldff1sh (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    const char *const expected_5_1[6] = {
+        "ldff1sh (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d",
+        "ldff1sh (%x7,%z8.d,sxtw #1)[8byte] %p2/z -> %z5.d",
+        "ldff1sh (%x12,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d",
+        "ldff1sh (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d",
+        "ldff1sh (%x22,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d",
+        "ldff1sh (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    /* Testing LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ldff1sh (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d",
+        "ldff1sh (%x7,%z8.d,uxtw)[8byte] %p2/z -> %z5.d",
+        "ldff1sh (%x12,%z13.d,uxtw)[8byte] %p3/z -> %z10.d",
+        "ldff1sh (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d",
+        "ldff1sh (%x22,%z24.d,uxtw)[8byte] %p6/z -> %z21.d",
+        "ldff1sh (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_6_1[6] = {
+        "ldff1sh (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d",
+        "ldff1sh (%x7,%z8.d,sxtw)[8byte] %p2/z -> %z5.d",
+        "ldff1sh (%x12,%z13.d,sxtw)[8byte] %p3/z -> %z10.d",
+        "ldff1sh (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d",
+        "ldff1sh (%x22,%z24.d,sxtw)[8byte] %p6/z -> %z21.d",
+        "ldff1sh (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] */
+    const char *const expected_7_0[6] = {
+        "ldff1sh (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s",
+        "ldff1sh (%x7,%z8.s,uxtw #1)[16byte] %p2/z -> %z5.s",
+        "ldff1sh (%x12,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s",
+        "ldff1sh (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s",
+        "ldff1sh (%x22,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s",
+        "ldff1sh (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_7_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    const char *const expected_7_1[6] = {
+        "ldff1sh (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s",
+        "ldff1sh (%x7,%z8.s,sxtw #1)[16byte] %p2/z -> %z5.s",
+        "ldff1sh (%x12,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s",
+        "ldff1sh (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s",
+        "ldff1sh (%x22,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s",
+        "ldff1sh (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_7_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    /* Testing LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_8_0[6] = {
+        "ldff1sh (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s",
+        "ldff1sh (%x7,%z8.s,uxtw)[16byte] %p2/z -> %z5.s",
+        "ldff1sh (%x12,%z13.s,uxtw)[16byte] %p3/z -> %z10.s",
+        "ldff1sh (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s",
+        "ldff1sh (%x22,%z24.s,uxtw)[16byte] %p6/z -> %z21.s",
+        "ldff1sh (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_8_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_8_1[6] = {
+        "ldff1sh (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s",
+        "ldff1sh (%x7,%z8.s,sxtw)[16byte] %p2/z -> %z5.s",
+        "ldff1sh (%x12,%z13.s,sxtw)[16byte] %p3/z -> %z10.s",
+        "ldff1sh (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s",
+        "ldff1sh (%x22,%z24.s,sxtw)[16byte] %p6/z -> %z21.s",
+        "ldff1sh (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1sh, ldff1sh_sve_pred, 6, expected_8_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
 }
 
 TEST_INSTR(ldff1sw_sve_pred)
@@ -14250,6 +14684,68 @@ TEST_INSTR(ldff1sw_sve_pred)
               opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_16, 0));
+
+    /* Testing LDFF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] */
+    const char *const expected_4_0[6] = {
+        "ldff1sw (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d",
+        "ldff1sw (%x7,%z8.d,uxtw #2)[16byte] %p2/z -> %z5.d",
+        "ldff1sw (%x12,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d",
+        "ldff1sw (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d",
+        "ldff1sw (%x22,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d",
+        "ldff1sw (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sw, ldff1sw_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    const char *const expected_4_1[6] = {
+        "ldff1sw (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d",
+        "ldff1sw (%x7,%z8.d,sxtw #2)[16byte] %p2/z -> %z5.d",
+        "ldff1sw (%x12,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d",
+        "ldff1sw (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d",
+        "ldff1sw (%x22,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d",
+        "ldff1sw (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sw, ldff1sw_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    /* Testing LDFF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_5_0[6] = {
+        "ldff1sw (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d",
+        "ldff1sw (%x7,%z8.d,uxtw)[16byte] %p2/z -> %z5.d",
+        "ldff1sw (%x12,%z13.d,uxtw)[16byte] %p3/z -> %z10.d",
+        "ldff1sw (%x17,%z19.d,uxtw)[16byte] %p5/z -> %z16.d",
+        "ldff1sw (%x22,%z24.d,uxtw)[16byte] %p6/z -> %z21.d",
+        "ldff1sw (%sp,%z31.d,uxtw)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sw, ldff1sw_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_5_1[6] = {
+        "ldff1sw (%x0,%z0.d,sxtw)[16byte] %p0/z -> %z0.d",
+        "ldff1sw (%x7,%z8.d,sxtw)[16byte] %p2/z -> %z5.d",
+        "ldff1sw (%x12,%z13.d,sxtw)[16byte] %p3/z -> %z10.d",
+        "ldff1sw (%x17,%z19.d,sxtw)[16byte] %p5/z -> %z16.d",
+        "ldff1sw (%x22,%z24.d,sxtw)[16byte] %p6/z -> %z21.d",
+        "ldff1sw (%sp,%z31.d,sxtw)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1sw, ldff1sw_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
                   false, 0, 0, OPSZ_16, 0));
 }
 
@@ -14351,6 +14847,130 @@ TEST_INSTR(ldff1w_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_16, 0));
+
+    /* Testing LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] */
+    const char *const expected_5_0[6] = {
+        "ldff1w (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d",
+        "ldff1w (%x7,%z8.d,uxtw #2)[16byte] %p2/z -> %z5.d",
+        "ldff1w (%x12,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d",
+        "ldff1w (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d",
+        "ldff1w (%x22,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d",
+        "ldff1w (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    const char *const expected_5_1[6] = {
+        "ldff1w (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d",
+        "ldff1w (%x7,%z8.d,sxtw #2)[16byte] %p2/z -> %z5.d",
+        "ldff1w (%x12,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d",
+        "ldff1w (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d",
+        "ldff1w (%x22,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d",
+        "ldff1w (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    /* Testing LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ldff1w (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d",
+        "ldff1w (%x7,%z8.d,uxtw)[16byte] %p2/z -> %z5.d",
+        "ldff1w (%x12,%z13.d,uxtw)[16byte] %p3/z -> %z10.d",
+        "ldff1w (%x17,%z19.d,uxtw)[16byte] %p5/z -> %z16.d",
+        "ldff1w (%x22,%z24.d,uxtw)[16byte] %p6/z -> %z21.d",
+        "ldff1w (%sp,%z31.d,uxtw)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_6_1[6] = {
+        "ldff1w (%x0,%z0.d,sxtw)[16byte] %p0/z -> %z0.d",
+        "ldff1w (%x7,%z8.d,sxtw)[16byte] %p2/z -> %z5.d",
+        "ldff1w (%x12,%z13.d,sxtw)[16byte] %p3/z -> %z10.d",
+        "ldff1w (%x17,%z19.d,sxtw)[16byte] %p5/z -> %z16.d",
+        "ldff1w (%x22,%z24.d,sxtw)[16byte] %p6/z -> %z21.d",
+        "ldff1w (%sp,%z31.d,sxtw)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    /* Testing LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2] */
+    const char *const expected_7_0[6] = {
+        "ldff1w (%x0,%z0.s,uxtw #2)[32byte] %p0/z -> %z0.s",
+        "ldff1w (%x7,%z8.s,uxtw #2)[32byte] %p2/z -> %z5.s",
+        "ldff1w (%x12,%z13.s,uxtw #2)[32byte] %p3/z -> %z10.s",
+        "ldff1w (%x17,%z19.s,uxtw #2)[32byte] %p5/z -> %z16.s",
+        "ldff1w (%x22,%z24.s,uxtw #2)[32byte] %p6/z -> %z21.s",
+        "ldff1w (%sp,%z31.s,uxtw #2)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_7_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_32, 2));
+
+    const char *const expected_7_1[6] = {
+        "ldff1w (%x0,%z0.s,sxtw #2)[32byte] %p0/z -> %z0.s",
+        "ldff1w (%x7,%z8.s,sxtw #2)[32byte] %p2/z -> %z5.s",
+        "ldff1w (%x12,%z13.s,sxtw #2)[32byte] %p3/z -> %z10.s",
+        "ldff1w (%x17,%z19.s,sxtw #2)[32byte] %p5/z -> %z16.s",
+        "ldff1w (%x22,%z24.s,sxtw #2)[32byte] %p6/z -> %z21.s",
+        "ldff1w (%sp,%z31.s,sxtw #2)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_7_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_32, 2));
+
+    /* Testing LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_8_0[6] = {
+        "ldff1w (%x0,%z0.s,uxtw)[32byte] %p0/z -> %z0.s",
+        "ldff1w (%x7,%z8.s,uxtw)[32byte] %p2/z -> %z5.s",
+        "ldff1w (%x12,%z13.s,uxtw)[32byte] %p3/z -> %z10.s",
+        "ldff1w (%x17,%z19.s,uxtw)[32byte] %p5/z -> %z16.s",
+        "ldff1w (%x22,%z24.s,uxtw)[32byte] %p6/z -> %z21.s",
+        "ldff1w (%sp,%z31.s,uxtw)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_8_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_32, 0));
+
+    const char *const expected_8_1[6] = {
+        "ldff1w (%x0,%z0.s,sxtw)[32byte] %p0/z -> %z0.s",
+        "ldff1w (%x7,%z8.s,sxtw)[32byte] %p2/z -> %z5.s",
+        "ldff1w (%x12,%z13.s,sxtw)[32byte] %p3/z -> %z10.s",
+        "ldff1w (%x17,%z19.s,sxtw)[32byte] %p5/z -> %z16.s",
+        "ldff1w (%x22,%z24.s,sxtw)[32byte] %p6/z -> %z21.s",
+        "ldff1w (%sp,%z31.s,sxtw)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldff1w, ldff1w_sve_pred, 6, expected_8_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_32, 0));
 }
 
 TEST_INSTR(fcadd_sve_pred)
@@ -14602,6 +15222,68 @@ TEST_INSTR(ld1b_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_4, 0));
+
+    /* Testing LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ld1b   (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d",
+        "ld1b   (%x7,%z8.d,uxtw)[4byte] %p2/z -> %z5.d",
+        "ld1b   (%x12,%z13.d,uxtw)[4byte] %p3/z -> %z10.d",
+        "ld1b   (%x17,%z19.d,uxtw)[4byte] %p5/z -> %z16.d",
+        "ld1b   (%x22,%z24.d,uxtw)[4byte] %p6/z -> %z21.d",
+        "ld1b   (%sp,%z31.d,uxtw)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    const char *const expected_6_1[6] = {
+        "ld1b   (%x0,%z0.d,sxtw)[4byte] %p0/z -> %z0.d",
+        "ld1b   (%x7,%z8.d,sxtw)[4byte] %p2/z -> %z5.d",
+        "ld1b   (%x12,%z13.d,sxtw)[4byte] %p3/z -> %z10.d",
+        "ld1b   (%x17,%z19.d,sxtw)[4byte] %p5/z -> %z16.d",
+        "ld1b   (%x22,%z24.d,sxtw)[4byte] %p6/z -> %z21.d",
+        "ld1b   (%sp,%z31.d,sxtw)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    /* Testing LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_7_0[6] = {
+        "ld1b   (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s",
+        "ld1b   (%x7,%z8.s,uxtw)[8byte] %p2/z -> %z5.s",
+        "ld1b   (%x12,%z13.s,uxtw)[8byte] %p3/z -> %z10.s",
+        "ld1b   (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s",
+        "ld1b   (%x22,%z24.s,uxtw)[8byte] %p6/z -> %z21.s",
+        "ld1b   (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_7_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_7_1[6] = {
+        "ld1b   (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s",
+        "ld1b   (%x7,%z8.s,sxtw)[8byte] %p2/z -> %z5.s",
+        "ld1b   (%x12,%z13.s,sxtw)[8byte] %p3/z -> %z10.s",
+        "ld1b   (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s",
+        "ld1b   (%x22,%z24.s,sxtw)[8byte] %p6/z -> %z21.s",
+        "ld1b   (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_7_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
 }
 
 TEST_INSTR(ld1rob_sve_pred)
@@ -14738,6 +15420,68 @@ TEST_INSTR(ld1sb_sve_pred)
               opnd_create_vector_base_disp_aarch64(Xn_six_offset_2_sp[i],
                                                    Zn_six_offset_3[i], OPSZ_8,
                                                    DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4, 0));
+
+    /* Testing LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_5_0[6] = {
+        "ld1sb  (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d",
+        "ld1sb  (%x7,%z8.d,uxtw)[4byte] %p2/z -> %z5.d",
+        "ld1sb  (%x12,%z13.d,uxtw)[4byte] %p3/z -> %z10.d",
+        "ld1sb  (%x17,%z19.d,uxtw)[4byte] %p5/z -> %z16.d",
+        "ld1sb  (%x22,%z24.d,uxtw)[4byte] %p6/z -> %z21.d",
+        "ld1sb  (%sp,%z31.d,uxtw)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    const char *const expected_5_1[6] = {
+        "ld1sb  (%x0,%z0.d,sxtw)[4byte] %p0/z -> %z0.d",
+        "ld1sb  (%x7,%z8.d,sxtw)[4byte] %p2/z -> %z5.d",
+        "ld1sb  (%x12,%z13.d,sxtw)[4byte] %p3/z -> %z10.d",
+        "ld1sb  (%x17,%z19.d,sxtw)[4byte] %p5/z -> %z16.d",
+        "ld1sb  (%x22,%z24.d,sxtw)[4byte] %p6/z -> %z21.d",
+        "ld1sb  (%sp,%z31.d,sxtw)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    /* Testing LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ld1sb  (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s",
+        "ld1sb  (%x7,%z8.s,uxtw)[8byte] %p2/z -> %z5.s",
+        "ld1sb  (%x12,%z13.s,uxtw)[8byte] %p3/z -> %z10.s",
+        "ld1sb  (%x17,%z19.s,uxtw)[8byte] %p5/z -> %z16.s",
+        "ld1sb  (%x22,%z24.s,uxtw)[8byte] %p6/z -> %z21.s",
+        "ld1sb  (%sp,%z31.s,uxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_6_1[6] = {
+        "ld1sb  (%x0,%z0.s,sxtw)[8byte] %p0/z -> %z0.s",
+        "ld1sb  (%x7,%z8.s,sxtw)[8byte] %p2/z -> %z5.s",
+        "ld1sb  (%x12,%z13.s,sxtw)[8byte] %p3/z -> %z10.s",
+        "ld1sb  (%x17,%z19.s,sxtw)[8byte] %p5/z -> %z16.s",
+        "ld1sb  (%x22,%z24.s,sxtw)[8byte] %p6/z -> %z21.s",
+        "ld1sb  (%sp,%z31.s,sxtw)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
 }
 
 TEST_INSTR(ldnt1b_sve_pred)
@@ -14866,6 +15610,68 @@ TEST_INSTR(st1b_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_4, 0));
+
+    /* Testing ST1B    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_3_0[6] = {
+        "st1b   %z0.d %p0 -> (%x0,%z0.d,uxtw)[4byte]",
+        "st1b   %z5.d %p2 -> (%x7,%z8.d,uxtw)[4byte]",
+        "st1b   %z10.d %p3 -> (%x12,%z13.d,uxtw)[4byte]",
+        "st1b   %z16.d %p5 -> (%x17,%z19.d,uxtw)[4byte]",
+        "st1b   %z21.d %p6 -> (%x22,%z24.d,uxtw)[4byte]",
+        "st1b   %z31.d %p7 -> (%sp,%z31.d,uxtw)[4byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    const char *const expected_3_1[6] = {
+        "st1b   %z0.d %p0 -> (%x0,%z0.d,sxtw)[4byte]",
+        "st1b   %z5.d %p2 -> (%x7,%z8.d,sxtw)[4byte]",
+        "st1b   %z10.d %p3 -> (%x12,%z13.d,sxtw)[4byte]",
+        "st1b   %z16.d %p5 -> (%x17,%z19.d,sxtw)[4byte]",
+        "st1b   %z21.d %p6 -> (%x22,%z24.d,sxtw)[4byte]",
+        "st1b   %z31.d %p7 -> (%sp,%z31.d,sxtw)[4byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_4, 0));
+
+    /* Testing ST1B    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_4_0[6] = {
+        "st1b   %z0.s %p0 -> (%x0,%z0.s,uxtw)[8byte]",
+        "st1b   %z5.s %p2 -> (%x7,%z8.s,uxtw)[8byte]",
+        "st1b   %z10.s %p3 -> (%x12,%z13.s,uxtw)[8byte]",
+        "st1b   %z16.s %p5 -> (%x17,%z19.s,uxtw)[8byte]",
+        "st1b   %z21.s %p6 -> (%x22,%z24.s,uxtw)[8byte]",
+        "st1b   %z31.s %p7 -> (%sp,%z31.s,uxtw)[8byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_4_1[6] = {
+        "st1b   %z0.s %p0 -> (%x0,%z0.s,sxtw)[8byte]",
+        "st1b   %z5.s %p2 -> (%x7,%z8.s,sxtw)[8byte]",
+        "st1b   %z10.s %p3 -> (%x12,%z13.s,sxtw)[8byte]",
+        "st1b   %z16.s %p5 -> (%x17,%z19.s,sxtw)[8byte]",
+        "st1b   %z21.s %p6 -> (%x22,%z24.s,sxtw)[8byte]",
+        "st1b   %z31.s %p7 -> (%sp,%z31.s,sxtw)[8byte]",
+    };
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
 }
 
 TEST_INSTR(stnt1b_sve_pred)
@@ -15182,6 +15988,56 @@ TEST_INSTR(prfb_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_0, 0));
+
+    /* Testing PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_3_0[6] = {
+        "prfb   $0x00 %p0 (%x0,%z0.d,uxtw)",   "prfb   $0x02 %p2 (%x7,%z8.d,uxtw)",
+        "prfb   $0x05 %p3 (%x12,%z13.d,uxtw)", "prfb   $0x08 %p5 (%x17,%z19.d,uxtw)",
+        "prfb   $0x0a %p6 (%x22,%z24.d,uxtw)", "prfb   $0x0f %p7 (%sp,%z31.d,uxtw)",
+    };
+    TEST_LOOP(prfb, prfb_sve_pred, 6, expected_3_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_0, 0));
+
+    const char *const expected_3_1[6] = {
+        "prfb   $0x00 %p0 (%x0,%z0.d,sxtw)",   "prfb   $0x02 %p2 (%x7,%z8.d,sxtw)",
+        "prfb   $0x05 %p3 (%x12,%z13.d,sxtw)", "prfb   $0x08 %p5 (%x17,%z19.d,sxtw)",
+        "prfb   $0x0a %p6 (%x22,%z24.d,sxtw)", "prfb   $0x0f %p7 (%sp,%z31.d,sxtw)",
+    };
+    TEST_LOOP(prfb, prfb_sve_pred, 6, expected_3_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_0, 0));
+
+    /* Testing PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_4_0[6] = {
+        "prfb   $0x00 %p0 (%x0,%z0.s,uxtw)",   "prfb   $0x02 %p2 (%x7,%z8.s,uxtw)",
+        "prfb   $0x05 %p3 (%x12,%z13.s,uxtw)", "prfb   $0x08 %p5 (%x17,%z19.s,uxtw)",
+        "prfb   $0x0a %p6 (%x22,%z24.s,uxtw)", "prfb   $0x0f %p7 (%sp,%z31.s,uxtw)",
+    };
+    TEST_LOOP(prfb, prfb_sve_pred, 6, expected_4_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_0, 0));
+
+    const char *const expected_4_1[6] = {
+        "prfb   $0x00 %p0 (%x0,%z0.s,sxtw)",   "prfb   $0x02 %p2 (%x7,%z8.s,sxtw)",
+        "prfb   $0x05 %p3 (%x12,%z13.s,sxtw)", "prfb   $0x08 %p5 (%x17,%z19.s,sxtw)",
+        "prfb   $0x0a %p6 (%x22,%z24.s,sxtw)", "prfb   $0x0f %p7 (%sp,%z31.s,sxtw)",
+    };
+    TEST_LOOP(prfb, prfb_sve_pred, 6, expected_4_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_0, 0));
 }
 
 TEST_INSTR(prfd_sve_pred)
@@ -15239,6 +16095,68 @@ TEST_INSTR(prfd_sve_pred)
               opnd_create_reg(Pn_half_six_offset_0[i]),
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX, true,
+                  0, 0, OPSZ_0, 3));
+
+    /* Testing PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3] */
+    const char *const expected_3_0[6] = {
+        "prfd   $0x00 %p0 (%x0,%z0.d,uxtw #3)",
+        "prfd   $0x02 %p2 (%x7,%z8.d,uxtw #3)",
+        "prfd   $0x05 %p3 (%x12,%z13.d,uxtw #3)",
+        "prfd   $0x08 %p5 (%x17,%z19.d,uxtw #3)",
+        "prfd   $0x0a %p6 (%x22,%z24.d,uxtw #3)",
+        "prfd   $0x0f %p7 (%sp,%z31.d,uxtw #3)",
+    };
+    TEST_LOOP(prfd, prfd_sve_pred, 6, expected_3_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_0, 3));
+
+    const char *const expected_3_1[6] = {
+        "prfd   $0x00 %p0 (%x0,%z0.d,sxtw #3)",
+        "prfd   $0x02 %p2 (%x7,%z8.d,sxtw #3)",
+        "prfd   $0x05 %p3 (%x12,%z13.d,sxtw #3)",
+        "prfd   $0x08 %p5 (%x17,%z19.d,sxtw #3)",
+        "prfd   $0x0a %p6 (%x22,%z24.d,sxtw #3)",
+        "prfd   $0x0f %p7 (%sp,%z31.d,sxtw #3)",
+    };
+    TEST_LOOP(prfd, prfd_sve_pred, 6, expected_3_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_0, 3));
+
+    /* Testing PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #3] */
+    const char *const expected_4_0[6] = {
+        "prfd   $0x00 %p0 (%x0,%z0.s,uxtw #3)",
+        "prfd   $0x02 %p2 (%x7,%z8.s,uxtw #3)",
+        "prfd   $0x05 %p3 (%x12,%z13.s,uxtw #3)",
+        "prfd   $0x08 %p5 (%x17,%z19.s,uxtw #3)",
+        "prfd   $0x0a %p6 (%x22,%z24.s,uxtw #3)",
+        "prfd   $0x0f %p7 (%sp,%z31.s,uxtw #3)",
+    };
+    TEST_LOOP(prfd, prfd_sve_pred, 6, expected_4_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_0, 3));
+
+    const char *const expected_4_1[6] = {
+        "prfd   $0x00 %p0 (%x0,%z0.s,sxtw #3)",
+        "prfd   $0x02 %p2 (%x7,%z8.s,sxtw #3)",
+        "prfd   $0x05 %p3 (%x12,%z13.s,sxtw #3)",
+        "prfd   $0x08 %p5 (%x17,%z19.s,sxtw #3)",
+        "prfd   $0x0a %p6 (%x22,%z24.s,sxtw #3)",
+        "prfd   $0x0f %p7 (%sp,%z31.s,sxtw #3)",
+    };
+    TEST_LOOP(prfd, prfd_sve_pred, 6, expected_4_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
                   0, 0, OPSZ_0, 3));
 }
 
@@ -15299,6 +16217,68 @@ TEST_INSTR(prfh_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX, true,
                   0, 0, OPSZ_0, 1));
+
+    /* Testing PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1] */
+    const char *const expected_3_0[6] = {
+        "prfh   $0x00 %p0 (%x0,%z0.d,uxtw #1)",
+        "prfh   $0x02 %p2 (%x7,%z8.d,uxtw #1)",
+        "prfh   $0x05 %p3 (%x12,%z13.d,uxtw #1)",
+        "prfh   $0x08 %p5 (%x17,%z19.d,uxtw #1)",
+        "prfh   $0x0a %p6 (%x22,%z24.d,uxtw #1)",
+        "prfh   $0x0f %p7 (%sp,%z31.d,uxtw #1)",
+    };
+    TEST_LOOP(prfh, prfh_sve_pred, 6, expected_3_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_0, 1));
+
+    const char *const expected_3_1[6] = {
+        "prfh   $0x00 %p0 (%x0,%z0.d,sxtw #1)",
+        "prfh   $0x02 %p2 (%x7,%z8.d,sxtw #1)",
+        "prfh   $0x05 %p3 (%x12,%z13.d,sxtw #1)",
+        "prfh   $0x08 %p5 (%x17,%z19.d,sxtw #1)",
+        "prfh   $0x0a %p6 (%x22,%z24.d,sxtw #1)",
+        "prfh   $0x0f %p7 (%sp,%z31.d,sxtw #1)",
+    };
+    TEST_LOOP(prfh, prfh_sve_pred, 6, expected_3_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_0, 1));
+
+    /* Testing PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1] */
+    const char *const expected_4_0[6] = {
+        "prfh   $0x00 %p0 (%x0,%z0.s,uxtw #1)",
+        "prfh   $0x02 %p2 (%x7,%z8.s,uxtw #1)",
+        "prfh   $0x05 %p3 (%x12,%z13.s,uxtw #1)",
+        "prfh   $0x08 %p5 (%x17,%z19.s,uxtw #1)",
+        "prfh   $0x0a %p6 (%x22,%z24.s,uxtw #1)",
+        "prfh   $0x0f %p7 (%sp,%z31.s,uxtw #1)",
+    };
+    TEST_LOOP(prfh, prfh_sve_pred, 6, expected_4_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_0, 1));
+
+    const char *const expected_4_1[6] = {
+        "prfh   $0x00 %p0 (%x0,%z0.s,sxtw #1)",
+        "prfh   $0x02 %p2 (%x7,%z8.s,sxtw #1)",
+        "prfh   $0x05 %p3 (%x12,%z13.s,sxtw #1)",
+        "prfh   $0x08 %p5 (%x17,%z19.s,sxtw #1)",
+        "prfh   $0x0a %p6 (%x22,%z24.s,sxtw #1)",
+        "prfh   $0x0f %p7 (%sp,%z31.s,sxtw #1)",
+    };
+    TEST_LOOP(prfh, prfh_sve_pred, 6, expected_4_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_0, 1));
 }
 
 TEST_INSTR(prfw_sve_pred)
@@ -15357,6 +16337,68 @@ TEST_INSTR(prfw_sve_pred)
               opnd_create_reg(Pn_half_six_offset_0[i]),
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX, true,
+                  0, 0, OPSZ_0, 2));
+
+    /* Testing PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2] */
+    const char *const expected_3_0[6] = {
+        "prfw   $0x00 %p0 (%x0,%z0.d,uxtw #2)",
+        "prfw   $0x02 %p2 (%x7,%z8.d,uxtw #2)",
+        "prfw   $0x05 %p3 (%x12,%z13.d,uxtw #2)",
+        "prfw   $0x08 %p5 (%x17,%z19.d,uxtw #2)",
+        "prfw   $0x0a %p6 (%x22,%z24.d,uxtw #2)",
+        "prfw   $0x0f %p7 (%sp,%z31.d,uxtw #2)",
+    };
+    TEST_LOOP(prfw, prfw_sve_pred, 6, expected_3_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_0, 2));
+
+    const char *const expected_3_1[6] = {
+        "prfw   $0x00 %p0 (%x0,%z0.d,sxtw #2)",
+        "prfw   $0x02 %p2 (%x7,%z8.d,sxtw #2)",
+        "prfw   $0x05 %p3 (%x12,%z13.d,sxtw #2)",
+        "prfw   $0x08 %p5 (%x17,%z19.d,sxtw #2)",
+        "prfw   $0x0a %p6 (%x22,%z24.d,sxtw #2)",
+        "prfw   $0x0f %p7 (%sp,%z31.d,sxtw #2)",
+    };
+    TEST_LOOP(prfw, prfw_sve_pred, 6, expected_3_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_0, 2));
+
+    /* Testing PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2] */
+    const char *const expected_4_0[6] = {
+        "prfw   $0x00 %p0 (%x0,%z0.s,uxtw #2)",
+        "prfw   $0x02 %p2 (%x7,%z8.s,uxtw #2)",
+        "prfw   $0x05 %p3 (%x12,%z13.s,uxtw #2)",
+        "prfw   $0x08 %p5 (%x17,%z19.s,uxtw #2)",
+        "prfw   $0x0a %p6 (%x22,%z24.s,uxtw #2)",
+        "prfw   $0x0f %p7 (%sp,%z31.s,uxtw #2)",
+    };
+    TEST_LOOP(prfw, prfw_sve_pred, 6, expected_4_0[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_0, 2));
+
+    const char *const expected_4_1[6] = {
+        "prfw   $0x00 %p0 (%x0,%z0.s,sxtw #2)",
+        "prfw   $0x02 %p2 (%x7,%z8.s,sxtw #2)",
+        "prfw   $0x05 %p3 (%x12,%z13.s,sxtw #2)",
+        "prfw   $0x08 %p5 (%x17,%z19.s,sxtw #2)",
+        "prfw   $0x0a %p6 (%x22,%z24.s,sxtw #2)",
+        "prfw   $0x0f %p7 (%sp,%z31.s,sxtw #2)",
+    };
+    TEST_LOOP(prfw, prfw_sve_pred, 6, expected_4_1[i],
+              opnd_create_immed_uint(prfop[i], OPSZ_4b),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
                   0, 0, OPSZ_0, 2));
 }
 
@@ -15758,6 +16800,130 @@ TEST_INSTR(ld1h_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] */
+    const char *const expected_3_0[6] = {
+        "ld1h   (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d",
+        "ld1h   (%x7,%z8.d,uxtw #1)[8byte] %p2/z -> %z5.d",
+        "ld1h   (%x12,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d",
+        "ld1h   (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d",
+        "ld1h   (%x22,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d",
+        "ld1h   (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    const char *const expected_3_1[6] = {
+        "ld1h   (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d",
+        "ld1h   (%x7,%z8.d,sxtw #1)[8byte] %p2/z -> %z5.d",
+        "ld1h   (%x12,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d",
+        "ld1h   (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d",
+        "ld1h   (%x22,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d",
+        "ld1h   (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    /* Testing LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_4_0[6] = {
+        "ld1h   (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d",
+        "ld1h   (%x7,%z8.d,uxtw)[8byte] %p2/z -> %z5.d",
+        "ld1h   (%x12,%z13.d,uxtw)[8byte] %p3/z -> %z10.d",
+        "ld1h   (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d",
+        "ld1h   (%x22,%z24.d,uxtw)[8byte] %p6/z -> %z21.d",
+        "ld1h   (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_4_1[6] = {
+        "ld1h   (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d",
+        "ld1h   (%x7,%z8.d,sxtw)[8byte] %p2/z -> %z5.d",
+        "ld1h   (%x12,%z13.d,sxtw)[8byte] %p3/z -> %z10.d",
+        "ld1h   (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d",
+        "ld1h   (%x22,%z24.d,sxtw)[8byte] %p6/z -> %z21.d",
+        "ld1h   (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] */
+    const char *const expected_5_0[6] = {
+        "ld1h   (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s",
+        "ld1h   (%x7,%z8.s,uxtw #1)[16byte] %p2/z -> %z5.s",
+        "ld1h   (%x12,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s",
+        "ld1h   (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s",
+        "ld1h   (%x22,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s",
+        "ld1h   (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    const char *const expected_5_1[6] = {
+        "ld1h   (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s",
+        "ld1h   (%x7,%z8.s,sxtw #1)[16byte] %p2/z -> %z5.s",
+        "ld1h   (%x12,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s",
+        "ld1h   (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s",
+        "ld1h   (%x22,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s",
+        "ld1h   (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    /* Testing LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ld1h   (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s",
+        "ld1h   (%x7,%z8.s,uxtw)[16byte] %p2/z -> %z5.s",
+        "ld1h   (%x12,%z13.s,uxtw)[16byte] %p3/z -> %z10.s",
+        "ld1h   (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s",
+        "ld1h   (%x22,%z24.s,uxtw)[16byte] %p6/z -> %z21.s",
+        "ld1h   (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_6_1[6] = {
+        "ld1h   (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s",
+        "ld1h   (%x7,%z8.s,sxtw)[16byte] %p2/z -> %z5.s",
+        "ld1h   (%x12,%z13.s,sxtw)[16byte] %p3/z -> %z10.s",
+        "ld1h   (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s",
+        "ld1h   (%x22,%z24.s,sxtw)[16byte] %p6/z -> %z21.s",
+        "ld1h   (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
 }
 
 TEST_INSTR(ld1sh_sve_pred)
@@ -15826,6 +16992,130 @@ TEST_INSTR(ld1sh_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1] */
+    const char *const expected_3_0[6] = {
+        "ld1sh  (%x0,%z0.d,uxtw #1)[8byte] %p0/z -> %z0.d",
+        "ld1sh  (%x7,%z8.d,uxtw #1)[8byte] %p2/z -> %z5.d",
+        "ld1sh  (%x12,%z13.d,uxtw #1)[8byte] %p3/z -> %z10.d",
+        "ld1sh  (%x17,%z19.d,uxtw #1)[8byte] %p5/z -> %z16.d",
+        "ld1sh  (%x22,%z24.d,uxtw #1)[8byte] %p6/z -> %z21.d",
+        "ld1sh  (%sp,%z31.d,uxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    const char *const expected_3_1[6] = {
+        "ld1sh  (%x0,%z0.d,sxtw #1)[8byte] %p0/z -> %z0.d",
+        "ld1sh  (%x7,%z8.d,sxtw #1)[8byte] %p2/z -> %z5.d",
+        "ld1sh  (%x12,%z13.d,sxtw #1)[8byte] %p3/z -> %z10.d",
+        "ld1sh  (%x17,%z19.d,sxtw #1)[8byte] %p5/z -> %z16.d",
+        "ld1sh  (%x22,%z24.d,sxtw #1)[8byte] %p6/z -> %z21.d",
+        "ld1sh  (%sp,%z31.d,sxtw #1)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    /* Testing LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_4_0[6] = {
+        "ld1sh  (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d",
+        "ld1sh  (%x7,%z8.d,uxtw)[8byte] %p2/z -> %z5.d",
+        "ld1sh  (%x12,%z13.d,uxtw)[8byte] %p3/z -> %z10.d",
+        "ld1sh  (%x17,%z19.d,uxtw)[8byte] %p5/z -> %z16.d",
+        "ld1sh  (%x22,%z24.d,uxtw)[8byte] %p6/z -> %z21.d",
+        "ld1sh  (%sp,%z31.d,uxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_4_1[6] = {
+        "ld1sh  (%x0,%z0.d,sxtw)[8byte] %p0/z -> %z0.d",
+        "ld1sh  (%x7,%z8.d,sxtw)[8byte] %p2/z -> %z5.d",
+        "ld1sh  (%x12,%z13.d,sxtw)[8byte] %p3/z -> %z10.d",
+        "ld1sh  (%x17,%z19.d,sxtw)[8byte] %p5/z -> %z16.d",
+        "ld1sh  (%x22,%z24.d,sxtw)[8byte] %p6/z -> %z21.d",
+        "ld1sh  (%sp,%z31.d,sxtw)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    /* Testing LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1] */
+    const char *const expected_5_0[6] = {
+        "ld1sh  (%x0,%z0.s,uxtw #1)[16byte] %p0/z -> %z0.s",
+        "ld1sh  (%x7,%z8.s,uxtw #1)[16byte] %p2/z -> %z5.s",
+        "ld1sh  (%x12,%z13.s,uxtw #1)[16byte] %p3/z -> %z10.s",
+        "ld1sh  (%x17,%z19.s,uxtw #1)[16byte] %p5/z -> %z16.s",
+        "ld1sh  (%x22,%z24.s,uxtw #1)[16byte] %p6/z -> %z21.s",
+        "ld1sh  (%sp,%z31.s,uxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    const char *const expected_5_1[6] = {
+        "ld1sh  (%x0,%z0.s,sxtw #1)[16byte] %p0/z -> %z0.s",
+        "ld1sh  (%x7,%z8.s,sxtw #1)[16byte] %p2/z -> %z5.s",
+        "ld1sh  (%x12,%z13.s,sxtw #1)[16byte] %p3/z -> %z10.s",
+        "ld1sh  (%x17,%z19.s,sxtw #1)[16byte] %p5/z -> %z16.s",
+        "ld1sh  (%x22,%z24.s,sxtw #1)[16byte] %p6/z -> %z21.s",
+        "ld1sh  (%sp,%z31.s,sxtw #1)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    /* Testing LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ld1sh  (%x0,%z0.s,uxtw)[16byte] %p0/z -> %z0.s",
+        "ld1sh  (%x7,%z8.s,uxtw)[16byte] %p2/z -> %z5.s",
+        "ld1sh  (%x12,%z13.s,uxtw)[16byte] %p3/z -> %z10.s",
+        "ld1sh  (%x17,%z19.s,uxtw)[16byte] %p5/z -> %z16.s",
+        "ld1sh  (%x22,%z24.s,uxtw)[16byte] %p6/z -> %z21.s",
+        "ld1sh  (%sp,%z31.s,uxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_6_1[6] = {
+        "ld1sh  (%x0,%z0.s,sxtw)[16byte] %p0/z -> %z0.s",
+        "ld1sh  (%x7,%z8.s,sxtw)[16byte] %p2/z -> %z5.s",
+        "ld1sh  (%x12,%z13.s,sxtw)[16byte] %p3/z -> %z10.s",
+        "ld1sh  (%x17,%z19.s,sxtw)[16byte] %p5/z -> %z16.s",
+        "ld1sh  (%x22,%z24.s,sxtw)[16byte] %p6/z -> %z21.s",
+        "ld1sh  (%sp,%z31.s,sxtw)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
 }
 
 TEST_INSTR(ld1w_sve_pred)
@@ -15893,6 +17183,130 @@ TEST_INSTR(ld1w_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_16, 0));
+
+    /* Testing LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] */
+    const char *const expected_3_0[6] = {
+        "ld1w   (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d",
+        "ld1w   (%x7,%z8.d,uxtw #2)[16byte] %p2/z -> %z5.d",
+        "ld1w   (%x12,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d",
+        "ld1w   (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d",
+        "ld1w   (%x22,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d",
+        "ld1w   (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    const char *const expected_3_1[6] = {
+        "ld1w   (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d",
+        "ld1w   (%x7,%z8.d,sxtw #2)[16byte] %p2/z -> %z5.d",
+        "ld1w   (%x12,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d",
+        "ld1w   (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d",
+        "ld1w   (%x22,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d",
+        "ld1w   (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    /* Testing LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_4_0[6] = {
+        "ld1w   (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d",
+        "ld1w   (%x7,%z8.d,uxtw)[16byte] %p2/z -> %z5.d",
+        "ld1w   (%x12,%z13.d,uxtw)[16byte] %p3/z -> %z10.d",
+        "ld1w   (%x17,%z19.d,uxtw)[16byte] %p5/z -> %z16.d",
+        "ld1w   (%x22,%z24.d,uxtw)[16byte] %p6/z -> %z21.d",
+        "ld1w   (%sp,%z31.d,uxtw)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_4_1[6] = {
+        "ld1w   (%x0,%z0.d,sxtw)[16byte] %p0/z -> %z0.d",
+        "ld1w   (%x7,%z8.d,sxtw)[16byte] %p2/z -> %z5.d",
+        "ld1w   (%x12,%z13.d,sxtw)[16byte] %p3/z -> %z10.d",
+        "ld1w   (%x17,%z19.d,sxtw)[16byte] %p5/z -> %z16.d",
+        "ld1w   (%x22,%z24.d,sxtw)[16byte] %p6/z -> %z21.d",
+        "ld1w   (%sp,%z31.d,sxtw)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    /* Testing LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2] */
+    const char *const expected_5_0[6] = {
+        "ld1w   (%x0,%z0.s,uxtw #2)[32byte] %p0/z -> %z0.s",
+        "ld1w   (%x7,%z8.s,uxtw #2)[32byte] %p2/z -> %z5.s",
+        "ld1w   (%x12,%z13.s,uxtw #2)[32byte] %p3/z -> %z10.s",
+        "ld1w   (%x17,%z19.s,uxtw #2)[32byte] %p5/z -> %z16.s",
+        "ld1w   (%x22,%z24.s,uxtw #2)[32byte] %p6/z -> %z21.s",
+        "ld1w   (%sp,%z31.s,uxtw #2)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_32, 2));
+
+    const char *const expected_5_1[6] = {
+        "ld1w   (%x0,%z0.s,sxtw #2)[32byte] %p0/z -> %z0.s",
+        "ld1w   (%x7,%z8.s,sxtw #2)[32byte] %p2/z -> %z5.s",
+        "ld1w   (%x12,%z13.s,sxtw #2)[32byte] %p3/z -> %z10.s",
+        "ld1w   (%x17,%z19.s,sxtw #2)[32byte] %p5/z -> %z16.s",
+        "ld1w   (%x22,%z24.s,sxtw #2)[32byte] %p6/z -> %z21.s",
+        "ld1w   (%sp,%z31.s,sxtw #2)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_32, 2));
+
+    /* Testing LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_6_0[6] = {
+        "ld1w   (%x0,%z0.s,uxtw)[32byte] %p0/z -> %z0.s",
+        "ld1w   (%x7,%z8.s,uxtw)[32byte] %p2/z -> %z5.s",
+        "ld1w   (%x12,%z13.s,uxtw)[32byte] %p3/z -> %z10.s",
+        "ld1w   (%x17,%z19.s,uxtw)[32byte] %p5/z -> %z16.s",
+        "ld1w   (%x22,%z24.s,uxtw)[32byte] %p6/z -> %z21.s",
+        "ld1w   (%sp,%z31.s,uxtw)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_32, 0));
+
+    const char *const expected_6_1[6] = {
+        "ld1w   (%x0,%z0.s,sxtw)[32byte] %p0/z -> %z0.s",
+        "ld1w   (%x7,%z8.s,sxtw)[32byte] %p2/z -> %z5.s",
+        "ld1w   (%x12,%z13.s,sxtw)[32byte] %p3/z -> %z10.s",
+        "ld1w   (%x17,%z19.s,sxtw)[32byte] %p5/z -> %z16.s",
+        "ld1w   (%x22,%z24.s,sxtw)[32byte] %p6/z -> %z21.s",
+        "ld1w   (%sp,%z31.s,sxtw)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_32, 0));
 }
 
 TEST_INSTR(ld1d_sve_pred)
@@ -15945,6 +17359,68 @@ TEST_INSTR(ld1d_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_32, 0));
+
+    /* Testing LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3] */
+    const char *const expected_3_0[6] = {
+        "ld1d   (%x0,%z0.d,uxtw #3)[32byte] %p0/z -> %z0.d",
+        "ld1d   (%x7,%z8.d,uxtw #3)[32byte] %p2/z -> %z5.d",
+        "ld1d   (%x12,%z13.d,uxtw #3)[32byte] %p3/z -> %z10.d",
+        "ld1d   (%x17,%z19.d,uxtw #3)[32byte] %p5/z -> %z16.d",
+        "ld1d   (%x22,%z24.d,uxtw #3)[32byte] %p6/z -> %z21.d",
+        "ld1d   (%sp,%z31.d,uxtw #3)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1d, ld1d_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_32, 3));
+
+    const char *const expected_3_1[6] = {
+        "ld1d   (%x0,%z0.d,sxtw #3)[32byte] %p0/z -> %z0.d",
+        "ld1d   (%x7,%z8.d,sxtw #3)[32byte] %p2/z -> %z5.d",
+        "ld1d   (%x12,%z13.d,sxtw #3)[32byte] %p3/z -> %z10.d",
+        "ld1d   (%x17,%z19.d,sxtw #3)[32byte] %p5/z -> %z16.d",
+        "ld1d   (%x22,%z24.d,sxtw #3)[32byte] %p6/z -> %z21.d",
+        "ld1d   (%sp,%z31.d,sxtw #3)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1d, ld1d_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_32, 3));
+
+    /* Testing LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_4_0[6] = {
+        "ld1d   (%x0,%z0.d)[32byte] %p0/z -> %z0.d",
+        "ld1d   (%x7,%z8.d)[32byte] %p2/z -> %z5.d",
+        "ld1d   (%x12,%z13.d)[32byte] %p3/z -> %z10.d",
+        "ld1d   (%x17,%z19.d)[32byte] %p5/z -> %z16.d",
+        "ld1d   (%x22,%z24.d)[32byte] %p6/z -> %z21.d",
+        "ld1d   (%sp,%z31.d)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1d, ld1d_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_32, 0));
+
+    const char *const expected_4_1[6] = {
+        "ld1d   (%x0,%z0.d)[32byte] %p0/z -> %z0.d",
+        "ld1d   (%x7,%z8.d)[32byte] %p2/z -> %z5.d",
+        "ld1d   (%x12,%z13.d)[32byte] %p3/z -> %z10.d",
+        "ld1d   (%x17,%z19.d)[32byte] %p5/z -> %z16.d",
+        "ld1d   (%x22,%z24.d)[32byte] %p6/z -> %z21.d",
+        "ld1d   (%sp,%z31.d)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1d, ld1d_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_32, 0));
 }
 
 TEST_INSTR(ld1sw_sve_pred)
@@ -15992,6 +17468,68 @@ TEST_INSTR(ld1sw_sve_pred)
         "ld1sw  (%sp,%z31.d)[16byte] %p7/z -> %z31.d",
     };
     TEST_LOOP(ld1sw, ld1sw_sve_pred, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_16, 0));
+
+    /* Testing LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2] */
+    const char *const expected_3_0[6] = {
+        "ld1sw  (%x0,%z0.d,uxtw #2)[16byte] %p0/z -> %z0.d",
+        "ld1sw  (%x7,%z8.d,uxtw #2)[16byte] %p2/z -> %z5.d",
+        "ld1sw  (%x12,%z13.d,uxtw #2)[16byte] %p3/z -> %z10.d",
+        "ld1sw  (%x17,%z19.d,uxtw #2)[16byte] %p5/z -> %z16.d",
+        "ld1sw  (%x22,%z24.d,uxtw #2)[16byte] %p6/z -> %z21.d",
+        "ld1sw  (%sp,%z31.d,uxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sw, ld1sw_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    const char *const expected_3_1[6] = {
+        "ld1sw  (%x0,%z0.d,sxtw #2)[16byte] %p0/z -> %z0.d",
+        "ld1sw  (%x7,%z8.d,sxtw #2)[16byte] %p2/z -> %z5.d",
+        "ld1sw  (%x12,%z13.d,sxtw #2)[16byte] %p3/z -> %z10.d",
+        "ld1sw  (%x17,%z19.d,sxtw #2)[16byte] %p5/z -> %z16.d",
+        "ld1sw  (%x22,%z24.d,sxtw #2)[16byte] %p6/z -> %z21.d",
+        "ld1sw  (%sp,%z31.d,sxtw #2)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sw, ld1sw_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    /* Testing LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_4_0[6] = {
+        "ld1sw  (%x0,%z0.d)[16byte] %p0/z -> %z0.d",
+        "ld1sw  (%x7,%z8.d)[16byte] %p2/z -> %z5.d",
+        "ld1sw  (%x12,%z13.d)[16byte] %p3/z -> %z10.d",
+        "ld1sw  (%x17,%z19.d)[16byte] %p5/z -> %z16.d",
+        "ld1sw  (%x22,%z24.d)[16byte] %p6/z -> %z21.d",
+        "ld1sw  (%sp,%z31.d)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sw, ld1sw_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_4_1[6] = {
+        "ld1sw  (%x0,%z0.d)[16byte] %p0/z -> %z0.d",
+        "ld1sw  (%x7,%z8.d)[16byte] %p2/z -> %z5.d",
+        "ld1sw  (%x12,%z13.d)[16byte] %p3/z -> %z10.d",
+        "ld1sw  (%x17,%z19.d)[16byte] %p5/z -> %z16.d",
+        "ld1sw  (%x22,%z24.d)[16byte] %p6/z -> %z21.d",
+        "ld1sw  (%sp,%z31.d)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ld1sw, ld1sw_sve_pred, 6, expected_4_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
               opnd_create_vector_base_disp_aarch64(
@@ -16065,6 +17603,130 @@ TEST_INSTR(st1h_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_8, 0));
+
+    /* Testing ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1] */
+    const char *const expected_3_0[6] = {
+        "st1h   %z0.d %p0 -> (%x0,%z0.d,uxtw #1)[8byte]",
+        "st1h   %z5.d %p2 -> (%x7,%z8.d,uxtw #1)[8byte]",
+        "st1h   %z10.d %p3 -> (%x12,%z13.d,uxtw #1)[8byte]",
+        "st1h   %z16.d %p5 -> (%x17,%z19.d,uxtw #1)[8byte]",
+        "st1h   %z21.d %p6 -> (%x22,%z24.d,uxtw #1)[8byte]",
+        "st1h   %z31.d %p7 -> (%sp,%z31.d,uxtw #1)[8byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    const char *const expected_3_1[6] = {
+        "st1h   %z0.d %p0 -> (%x0,%z0.d,sxtw #1)[8byte]",
+        "st1h   %z5.d %p2 -> (%x7,%z8.d,sxtw #1)[8byte]",
+        "st1h   %z10.d %p3 -> (%x12,%z13.d,sxtw #1)[8byte]",
+        "st1h   %z16.d %p5 -> (%x17,%z19.d,sxtw #1)[8byte]",
+        "st1h   %z21.d %p6 -> (%x22,%z24.d,sxtw #1)[8byte]",
+        "st1h   %z31.d %p7 -> (%sp,%z31.d,sxtw #1)[8byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_8, 1));
+
+    /* Testing ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_4_0[6] = {
+        "st1h   %z0.d %p0 -> (%x0,%z0.d,uxtw)[8byte]",
+        "st1h   %z5.d %p2 -> (%x7,%z8.d,uxtw)[8byte]",
+        "st1h   %z10.d %p3 -> (%x12,%z13.d,uxtw)[8byte]",
+        "st1h   %z16.d %p5 -> (%x17,%z19.d,uxtw)[8byte]",
+        "st1h   %z21.d %p6 -> (%x22,%z24.d,uxtw)[8byte]",
+        "st1h   %z31.d %p7 -> (%sp,%z31.d,uxtw)[8byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    const char *const expected_4_1[6] = {
+        "st1h   %z0.d %p0 -> (%x0,%z0.d,sxtw)[8byte]",
+        "st1h   %z5.d %p2 -> (%x7,%z8.d,sxtw)[8byte]",
+        "st1h   %z10.d %p3 -> (%x12,%z13.d,sxtw)[8byte]",
+        "st1h   %z16.d %p5 -> (%x17,%z19.d,sxtw)[8byte]",
+        "st1h   %z21.d %p6 -> (%x22,%z24.d,sxtw)[8byte]",
+        "st1h   %z31.d %p7 -> (%sp,%z31.d,sxtw)[8byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_8, 0));
+
+    /* Testing ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1] */
+    const char *const expected_5_0[6] = {
+        "st1h   %z0.s %p0 -> (%x0,%z0.s,uxtw #1)[16byte]",
+        "st1h   %z5.s %p2 -> (%x7,%z8.s,uxtw #1)[16byte]",
+        "st1h   %z10.s %p3 -> (%x12,%z13.s,uxtw #1)[16byte]",
+        "st1h   %z16.s %p5 -> (%x17,%z19.s,uxtw #1)[16byte]",
+        "st1h   %z21.s %p6 -> (%x22,%z24.s,uxtw #1)[16byte]",
+        "st1h   %z31.s %p7 -> (%sp,%z31.s,uxtw #1)[16byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    const char *const expected_5_1[6] = {
+        "st1h   %z0.s %p0 -> (%x0,%z0.s,sxtw #1)[16byte]",
+        "st1h   %z5.s %p2 -> (%x7,%z8.s,sxtw #1)[16byte]",
+        "st1h   %z10.s %p3 -> (%x12,%z13.s,sxtw #1)[16byte]",
+        "st1h   %z16.s %p5 -> (%x17,%z19.s,sxtw #1)[16byte]",
+        "st1h   %z21.s %p6 -> (%x22,%z24.s,sxtw #1)[16byte]",
+        "st1h   %z31.s %p7 -> (%sp,%z31.s,sxtw #1)[16byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 1));
+
+    /* Testing ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_6_0[6] = {
+        "st1h   %z0.s %p0 -> (%x0,%z0.s,uxtw)[16byte]",
+        "st1h   %z5.s %p2 -> (%x7,%z8.s,uxtw)[16byte]",
+        "st1h   %z10.s %p3 -> (%x12,%z13.s,uxtw)[16byte]",
+        "st1h   %z16.s %p5 -> (%x17,%z19.s,uxtw)[16byte]",
+        "st1h   %z21.s %p6 -> (%x22,%z24.s,uxtw)[16byte]",
+        "st1h   %z31.s %p7 -> (%sp,%z31.s,uxtw)[16byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_6_1[6] = {
+        "st1h   %z0.s %p0 -> (%x0,%z0.s,sxtw)[16byte]",
+        "st1h   %z5.s %p2 -> (%x7,%z8.s,sxtw)[16byte]",
+        "st1h   %z10.s %p3 -> (%x12,%z13.s,sxtw)[16byte]",
+        "st1h   %z16.s %p5 -> (%x17,%z19.s,sxtw)[16byte]",
+        "st1h   %z21.s %p6 -> (%x22,%z24.s,sxtw)[16byte]",
+        "st1h   %z31.s %p7 -> (%sp,%z31.s,sxtw)[16byte]",
+    };
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
 }
 
 TEST_INSTR(st1w_sve_pred)
@@ -16133,6 +17795,130 @@ TEST_INSTR(st1w_sve_pred)
               opnd_create_vector_base_disp_aarch64(
                   Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
                   false, 0, 0, OPSZ_16, 0));
+
+    /* Testing ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2] */
+    const char *const expected_4_0[6] = {
+        "st1w   %z0.d %p0 -> (%x0,%z0.d,uxtw #2)[16byte]",
+        "st1w   %z5.d %p2 -> (%x7,%z8.d,uxtw #2)[16byte]",
+        "st1w   %z10.d %p3 -> (%x12,%z13.d,uxtw #2)[16byte]",
+        "st1w   %z16.d %p5 -> (%x17,%z19.d,uxtw #2)[16byte]",
+        "st1w   %z21.d %p6 -> (%x22,%z24.d,uxtw #2)[16byte]",
+        "st1w   %z31.d %p7 -> (%sp,%z31.d,uxtw #2)[16byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    const char *const expected_4_1[6] = {
+        "st1w   %z0.d %p0 -> (%x0,%z0.d,sxtw #2)[16byte]",
+        "st1w   %z5.d %p2 -> (%x7,%z8.d,sxtw #2)[16byte]",
+        "st1w   %z10.d %p3 -> (%x12,%z13.d,sxtw #2)[16byte]",
+        "st1w   %z16.d %p5 -> (%x17,%z19.d,sxtw #2)[16byte]",
+        "st1w   %z21.d %p6 -> (%x22,%z24.d,sxtw #2)[16byte]",
+        "st1w   %z31.d %p7 -> (%sp,%z31.d,sxtw #2)[16byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_4_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_16, 2));
+
+    /* Testing ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_5_0[6] = {
+        "st1w   %z0.d %p0 -> (%x0,%z0.d,uxtw)[16byte]",
+        "st1w   %z5.d %p2 -> (%x7,%z8.d,uxtw)[16byte]",
+        "st1w   %z10.d %p3 -> (%x12,%z13.d,uxtw)[16byte]",
+        "st1w   %z16.d %p5 -> (%x17,%z19.d,uxtw)[16byte]",
+        "st1w   %z21.d %p6 -> (%x22,%z24.d,uxtw)[16byte]",
+        "st1w   %z31.d %p7 -> (%sp,%z31.d,uxtw)[16byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    const char *const expected_5_1[6] = {
+        "st1w   %z0.d %p0 -> (%x0,%z0.d,sxtw)[16byte]",
+        "st1w   %z5.d %p2 -> (%x7,%z8.d,sxtw)[16byte]",
+        "st1w   %z10.d %p3 -> (%x12,%z13.d,sxtw)[16byte]",
+        "st1w   %z16.d %p5 -> (%x17,%z19.d,sxtw)[16byte]",
+        "st1w   %z21.d %p6 -> (%x22,%z24.d,sxtw)[16byte]",
+        "st1w   %z31.d %p7 -> (%sp,%z31.d,sxtw)[16byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_16, 0));
+
+    /* Testing ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2] */
+    const char *const expected_6_0[6] = {
+        "st1w   %z0.s %p0 -> (%x0,%z0.s,uxtw #2)[32byte]",
+        "st1w   %z5.s %p2 -> (%x7,%z8.s,uxtw #2)[32byte]",
+        "st1w   %z10.s %p3 -> (%x12,%z13.s,uxtw #2)[32byte]",
+        "st1w   %z16.s %p5 -> (%x17,%z19.s,uxtw #2)[32byte]",
+        "st1w   %z21.s %p6 -> (%x22,%z24.s,uxtw #2)[32byte]",
+        "st1w   %z31.s %p7 -> (%sp,%z31.s,uxtw #2)[32byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_6_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_32, 2));
+
+    const char *const expected_6_1[6] = {
+        "st1w   %z0.s %p0 -> (%x0,%z0.s,sxtw #2)[32byte]",
+        "st1w   %z5.s %p2 -> (%x7,%z8.s,sxtw #2)[32byte]",
+        "st1w   %z10.s %p3 -> (%x12,%z13.s,sxtw #2)[32byte]",
+        "st1w   %z16.s %p5 -> (%x17,%z19.s,sxtw #2)[32byte]",
+        "st1w   %z21.s %p6 -> (%x22,%z24.s,sxtw #2)[32byte]",
+        "st1w   %z31.s %p7 -> (%sp,%z31.s,sxtw #2)[32byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_6_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_32, 2));
+
+    /* Testing ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] */
+    const char *const expected_7_0[6] = {
+        "st1w   %z0.s %p0 -> (%x0,%z0.s,uxtw)[32byte]",
+        "st1w   %z5.s %p2 -> (%x7,%z8.s,uxtw)[32byte]",
+        "st1w   %z10.s %p3 -> (%x12,%z13.s,uxtw)[32byte]",
+        "st1w   %z16.s %p5 -> (%x17,%z19.s,uxtw)[32byte]",
+        "st1w   %z21.s %p6 -> (%x22,%z24.s,uxtw)[32byte]",
+        "st1w   %z31.s %p7 -> (%sp,%z31.s,uxtw)[32byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_7_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_UXTW,
+                  false, 0, 0, OPSZ_32, 0));
+
+    const char *const expected_7_1[6] = {
+        "st1w   %z0.s %p0 -> (%x0,%z0.s,sxtw)[32byte]",
+        "st1w   %z5.s %p2 -> (%x7,%z8.s,sxtw)[32byte]",
+        "st1w   %z10.s %p3 -> (%x12,%z13.s,sxtw)[32byte]",
+        "st1w   %z16.s %p5 -> (%x17,%z19.s,sxtw)[32byte]",
+        "st1w   %z21.s %p6 -> (%x22,%z24.s,sxtw)[32byte]",
+        "st1w   %z31.s %p7 -> (%sp,%z31.s,sxtw)[32byte]",
+    };
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_7_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_4, DR_EXTEND_SXTW,
+                  false, 0, 0, OPSZ_32, 0));
 }
 
 TEST_INSTR(st1d_sve_pred)
@@ -16180,6 +17966,68 @@ TEST_INSTR(st1d_sve_pred)
         "st1d   %z31.d %p7 -> (%sp,%z31.d)[32byte]",
     };
     TEST_LOOP(st1d, st1d_sve_pred, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_32, 0));
+
+    /* Testing ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3] */
+    const char *const expected_3_0[6] = {
+        "st1d   %z0.d %p0 -> (%x0,%z0.d,uxtw #3)[32byte]",
+        "st1d   %z5.d %p2 -> (%x7,%z8.d,uxtw #3)[32byte]",
+        "st1d   %z10.d %p3 -> (%x12,%z13.d,uxtw #3)[32byte]",
+        "st1d   %z16.d %p5 -> (%x17,%z19.d,uxtw #3)[32byte]",
+        "st1d   %z21.d %p6 -> (%x22,%z24.d,uxtw #3)[32byte]",
+        "st1d   %z31.d %p7 -> (%sp,%z31.d,uxtw #3)[32byte]",
+    };
+    TEST_LOOP(st1d, st1d_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTW, true,
+                  0, 0, OPSZ_32, 3));
+
+    const char *const expected_3_1[6] = {
+        "st1d   %z0.d %p0 -> (%x0,%z0.d,sxtw #3)[32byte]",
+        "st1d   %z5.d %p2 -> (%x7,%z8.d,sxtw #3)[32byte]",
+        "st1d   %z10.d %p3 -> (%x12,%z13.d,sxtw #3)[32byte]",
+        "st1d   %z16.d %p5 -> (%x17,%z19.d,sxtw #3)[32byte]",
+        "st1d   %z21.d %p6 -> (%x22,%z24.d,sxtw #3)[32byte]",
+        "st1d   %z31.d %p7 -> (%sp,%z31.d,sxtw #3)[32byte]",
+    };
+    TEST_LOOP(st1d, st1d_sve_pred, 6, expected_3_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_SXTW, true,
+                  0, 0, OPSZ_32, 3));
+
+    /* Testing ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] */
+    const char *const expected_4_0[6] = {
+        "st1d   %z0.d %p0 -> (%x0,%z0.d)[32byte]",
+        "st1d   %z5.d %p2 -> (%x7,%z8.d)[32byte]",
+        "st1d   %z10.d %p3 -> (%x12,%z13.d)[32byte]",
+        "st1d   %z16.d %p5 -> (%x17,%z19.d)[32byte]",
+        "st1d   %z21.d %p6 -> (%x22,%z24.d)[32byte]",
+        "st1d   %z31.d %p7 -> (%sp,%z31.d)[32byte]",
+    };
+    TEST_LOOP(st1d, st1d_sve_pred, 6, expected_4_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(
+                  Xn_six_offset_2_sp[i], Zn_six_offset_3[i], OPSZ_8, DR_EXTEND_UXTX,
+                  false, 0, 0, OPSZ_32, 0));
+
+    const char *const expected_4_1[6] = {
+        "st1d   %z0.d %p0 -> (%x0,%z0.d)[32byte]",
+        "st1d   %z5.d %p2 -> (%x7,%z8.d)[32byte]",
+        "st1d   %z10.d %p3 -> (%x12,%z13.d)[32byte]",
+        "st1d   %z16.d %p5 -> (%x17,%z19.d)[32byte]",
+        "st1d   %z21.d %p6 -> (%x22,%z24.d)[32byte]",
+        "st1d   %z31.d %p7 -> (%sp,%z31.d)[32byte]",
+    };
+    TEST_LOOP(st1d, st1d_sve_pred, 6, expected_4_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg(Pn_half_six_offset_0[i]),
               opnd_create_vector_base_disp_aarch64(


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3]
LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2]
LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2]
LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2]
LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LDFF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LDFF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #3]
LDFF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
LDFF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
LDFF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LDFF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LDFF1SB { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #1]
LDFF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #1]
LDFF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
LDFF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2]
LDFF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend> #2]
LDFF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>]
LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend> #2]
LDFF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>]
PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
PRFB    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3]
PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #3]
PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1]
PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1]
PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2]
PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2]
ST1B    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
ST1B    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3]
ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1]
ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #1]
ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2]
ST1W    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>]
ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2]
ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>]
```

Issue: #3044