### PR TITLE
i#3044 AArch64 SVE codec:  SVE processor feature fix

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -208,36 +208,32 @@ proc_has_feature(feature_bit_t f)
     uint64 freg_val = 0;
 
     feature_reg_idx_t feat_reg = GET_FEAT_REG(f);
-    if (feat_reg >= AA64ISAR0 && feat_reg <= AA64DFR0) {
-        switch (feat_reg) {
-        case AA64ISAR0: {
-            freg_val = cpu_info.features.flags_aa64isar0;
-            break;
-        }
-        case AA64ISAR1: {
-            freg_val = cpu_info.features.flags_aa64isar1;
-            break;
-        }
-        case AA64PFR0: {
-            freg_val = cpu_info.features.flags_aa64pfr0;
-            break;
-        }
-        case AA64MMFR1: {
-            freg_val = cpu_info.features.flags_aa64mmfr1;
-            break;
-        }
-        case AA64DFR0: {
-            freg_val = cpu_info.features.flags_aa64dfr0;
-            break;
-        }
-        case AA64ZFR0: {
-            freg_val = cpu_info.features.flags_aa64zfr0;
-            break;
-        }
-        default: CLIENT_ASSERT(false, "proc_has_feature: feature register index error");
-        }
-    } else {
-        CLIENT_ASSERT(false, "proc_has_feature: invalid feature register");
+    switch (feat_reg) {
+    case AA64ISAR0: {
+        freg_val = cpu_info.features.flags_aa64isar0;
+        break;
+    }
+    case AA64ISAR1: {
+        freg_val = cpu_info.features.flags_aa64isar1;
+        break;
+    }
+    case AA64PFR0: {
+        freg_val = cpu_info.features.flags_aa64pfr0;
+        break;
+    }
+    case AA64MMFR1: {
+        freg_val = cpu_info.features.flags_aa64mmfr1;
+        break;
+    }
+    case AA64DFR0: {
+        freg_val = cpu_info.features.flags_aa64dfr0;
+        break;
+    }
+    case AA64ZFR0: {
+        freg_val = cpu_info.features.flags_aa64zfr0;
+        break;
+    }
+    default: CLIENT_ASSERT(false, "proc_has_feature: invalid feature register");
     }
 
     /* Compare the nibble value in the feature register with the input


### PR DESCRIPTION
Attempting to read the ID_AA64ZFR0_EL1 outside of the unit tests resulted in a CLIENT_ASSERT failure on supporting hardware.

Issue #3044