### PR TITLE
i#5843 scheduler: Move timestamp ordering into scheduler

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -175,7 +175,7 @@ scheduler_tmpl_t<memref_t, reader_t>::record_type_is_marker(memref_t record,
 template <>
 bool
 scheduler_tmpl_t<memref_t, reader_t>::record_type_is_timestamp(memref_t record,
-                                                               uint64_t &value)
+                                                               uintptr_t &value)
 {
     if (record.marker.type != TRACE_TYPE_MARKER ||
         record.marker.marker_type != TRACE_MARKER_TYPE_TIMESTAMP)

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -747,7 +747,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(int output_ordinal)
                     if (!inputs_[i].at_eof && inputs_[i].next_timestamp > 0 &&
                         inputs_[i].next_timestamp < min_time) {
                         min_time = inputs_[i].next_timestamp;
-                        index = i;
+                        index = static_cast<int>(i);
                     }
                 }
                 if (index < 0)

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -645,12 +645,17 @@ protected:
         {
         }
         stream_t stream;
+        // This is an index into the inputs_ vector so -1 is an invalid value.
+        // This is set to >=0 for all non-empty outputs during init().
         int cur_input = -1;
         // For static schedules we can populate this up front and avoid needing a
         // lock for dynamically finding the next input, keeping things parallel.
         std::vector<int> input_indices;
         int input_indices_index = 0;
     };
+
+    scheduler_status_t
+    get_initial_timestamps();
 
     // Opens up all the readers for each file in 'path' which may be a directory.
     // Returns a map of the thread id of each file to its index in inputs_.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -41,7 +41,7 @@
  */
 
 #include <assert.h>
-#include <queue>
+#include <deque>
 #include <set>
 #include <unordered_map>
 #include <vector>
@@ -624,7 +624,8 @@ protected:
         memref_tid_t tid = INVALID_THREAD_ID;
         // If non-empty these records should be returned before incrementing the reader.
         // This is used for read-ahead and inserting synthetic records.
-        std::queue<RecordType> queue;
+        // We use a deque so we can iterate over it.
+        std::deque<RecordType> queue;
         std::set<int> binding;
         int priority = 0;
         std::vector<range_t> regions_of_interest;
@@ -634,6 +635,7 @@ protected:
         bool needs_advance = false;
         bool needs_roi = true;
         bool at_eof = false;
+        uint64_t next_timestamp = 0;
     };
 
     struct output_info_t {
@@ -694,6 +696,10 @@ protected:
     // If the given record is a marker, returns true and its fields.
     bool
     record_type_is_marker(RecordType record, trace_marker_type_t &type, uintptr_t &value);
+
+    // If the given record is a timestamp, returns true and its fields.
+    bool
+    record_type_is_timestamp(RecordType record, uintptr_t &value);
 
     // Creates the marker we insert between regions of interest.
     RecordType

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -635,7 +635,7 @@ protected:
         bool needs_advance = false;
         bool needs_roi = true;
         bool at_eof = false;
-        uint64_t next_timestamp = 0;
+        uintptr_t next_timestamp = 0;
     };
 
     struct output_info_t {

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -145,6 +145,85 @@ make_exit(memref_tid_t tid)
     return memref;
 }
 
+static memref_t
+make_version(memref_tid_t tid, int version)
+{
+    memref_t memref;
+    memref.marker.tid = tid;
+    memref.marker.type = TRACE_TYPE_MARKER;
+    memref.marker.marker_type = TRACE_MARKER_TYPE_VERSION;
+    memref.marker.marker_value = version;
+    return memref;
+}
+
+static memref_t
+make_timestamp(memref_tid_t tid, uint64_t timestamp)
+{
+    memref_t memref;
+    memref.marker.tid = tid;
+    memref.marker.type = TRACE_TYPE_MARKER;
+    memref.marker.marker_type = TRACE_MARKER_TYPE_TIMESTAMP;
+    memref.marker.marker_value = timestamp;
+    return memref;
+}
+
+static void
+test_serial()
+{
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr memref_tid_t TID_B = 99;
+    std::vector<memref_t> refs_A = {
+        /* clang-format off */
+        // Include a header to test the scheduler queuing it.
+        make_version(TID_A, 4),
+        // Each timestamp is followed by an instr whose PC==time.
+        make_timestamp(TID_A, 10),
+        make_instr(TID_A, 10),
+        make_timestamp(TID_A, 30),
+        make_instr(TID_A, 30),
+        make_timestamp(TID_A, 50),
+        make_instr(TID_A, 50),
+        make_exit(TID_A),
+        /* clang-format on */
+    };
+    std::vector<memref_t> refs_B = {
+        /* clang-format off */
+        make_version(TID_B, 4),
+        make_timestamp(TID_B, 20),
+        make_instr(TID_B, 20),
+        make_timestamp(TID_B, 40),
+        make_instr(TID_B, 40),
+        make_timestamp(TID_B, 60),
+        make_instr(TID_B, 60),
+        make_exit(TID_B),
+        /* clang-format on */
+    };
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_A)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_B)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_B);
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(readers));
+    if (scheduler.init(sched_inputs, 1,
+                       scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    auto *stream = scheduler.get_stream(0);
+    memref_t memref;
+    uint64_t last_timestamp = 0;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+        assert(status == scheduler_t::STATUS_OK);
+        if (memref.marker.type == TRACE_TYPE_MARKER &&
+            memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
+            assert(memref.marker.marker_value > last_timestamp);
+            last_timestamp = memref.marker.marker_value;
+        }
+    }
+}
+
 static void
 test_parallel()
 {
@@ -245,9 +324,12 @@ test_regions()
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(std::move(readers));
     sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
+    // Since reader_t::skip_instructions() is unfinished and does not repeat timestamps,
+    // we can't use the serial options as it will fail without timestamps.
     if (scheduler.init(sched_inputs, 1,
-                       scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
-        scheduler_t::STATUS_SUCCESS)
+                       scheduler_t::scheduler_options_t(
+                           scheduler_t::MAP_TO_ANY_OUTPUT, scheduler_t::DEPENDENCY_IGNORE,
+                           /*verbosity=*/4)) != scheduler_t::STATUS_SUCCESS)
         assert(false);
     int ordinal = 0;
     auto *stream = scheduler.get_stream(0);
@@ -285,6 +367,7 @@ test_regions()
 int
 main(int argc, const char *argv[])
 {
+    test_serial();
     test_parallel();
     test_param_checks();
     test_regions();


### PR DESCRIPTION
Implements timestamp ordering in scheduler_t rather than relying on the old implementation inside file_reader_t.

Adds a sanity test.

Removing the file_reader_t code, along with eliminating the thread-as-sub-reader API routines, will be done as a separate refactoring.

Issue: #5843