### PR TITLE
i#5437 glibc2.34-35: 32-bit workaround for SIGFPE

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -250,7 +250,76 @@ jobs:
           on ${{github.event_name}} at ${{github.ref}}
         body: |
           Github Actions CI workflow run FAILED!
-          Workflow: ${{github.workflow}}/x86-64
+          Workflow: ${{github.workflow}}/x86-64-ubuntu22
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action CI
+
+  # Ubuntu22 64-bit Linux build with gcc and run tests.
+  # XXX: A matrix could combine this with the 20.04 but our auto-cancel
+  # step cancels the 2nd job so we need to solve that first.
+  x86-32-ubuntu22:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
+    - run: git fetch --no-tags --depth=1 origin master
+
+    # Install multilib for non-cross-compiling Linux build.
+    - name: Create Build Environment
+      run: |
+        sudo apt update
+        sudo add-apt-repository 'deb [arch=i386] http://us.archive.ubuntu.com/ubuntu focal main'
+        apt download libunwind8:i386 libunwind-dev:i386 liblzma5:i386
+        mkdir ../extract
+        for i in *.deb; do dpkg-deb -x $i ../extract; done
+        sudo rsync -av ../extract/usr/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
+        sudo rsync -av ../extract/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
+        sudo rsync -av ../extract/usr/include/i386-linux-gnu/ /usr/include/
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+
+    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
+    - name: Setup newer cmake
+      uses: jwlawson/actions-setup-cmake@v1.8
+      with:
+        cmake-version: '3.19.7'
+
+    - name: Run Suite
+      working-directory: ${{ github.workspace }}
+      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
+      env:
+        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
+        CI_TRIGGER: ${{ github.event_name }}
+        CI_BRANCH: ${{ github.ref }}
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/x86-32-ubuntu22
           Repository: ${{github.repository}}
           Branch ref: ${{github.ref}}
           SHA: ${{github.sha}}

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -283,6 +283,8 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt update
+        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
+          liblz4-dev g++-multilib libunwind-dev
         sudo add-apt-repository 'deb [arch=i386] http://us.archive.ubuntu.com/ubuntu focal main'
         apt download libunwind8:i386 libunwind-dev:i386 liblzma5:i386
         mkdir ../extract

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -718,7 +718,8 @@ privload_os_finalize(privmod_t *privmod)
     LOG(GLOBAL, LOG_LOADER, 2, "%s: calling %s\n", __FUNCTION__, LIBC_GET_VERSION_NAME);
     const char *ver = (*libc_ver)();
     LOG(GLOBAL, LOG_LOADER, 2, "%s: libc version is |%s|\n", __FUNCTION__, ver);
-    if ((ver[0] == '\0' || ver[0] < '2') || ver[1] != '.' || ver[2] < '3' || ver[3] < '4')
+    if ((ver[0] == '\0' || ver[0] < '2') || ver[1] != '.' || ver[2] < '3' ||
+        (ver[2] == '3' && ver[3] < '4'))
         return;
     if (privmod_ld_linux == NULL) {
         SYSLOG_INTERNAL_WARNING("glibc 2.34+ i#5437 workaround failed: missed ld");
@@ -731,8 +732,16 @@ privload_os_finalize(privmod_t *privmod)
         SYSLOG_INTERNAL_WARNING("glibc 2.34+ i#5437 workaround failed: missed glro");
         return;
     }
-#    define GLRO_dl_tls_static_size_OFFS IF_X64_ELSE(0x2a8, 0x31c)
-#    define GLRO_dl_tls_static_align_OFFS IF_X64_ELSE(0x2b0, 0x320)
+#    ifdef X64
+    const int GLRO_dl_tls_static_size_OFFS = 0x2a8;
+    const int GLRO_dl_tls_static_align_OFFS = 0x2b0;
+#    else
+    // The offsets changed between 2.35 and 2.36.
+    const int GLRO_dl_tls_static_size_OFFS =
+        (ver[2] == '3' && ver[3] == '5') ? 0x328 : 0x31c;
+    const int GLRO_dl_tls_static_align_OFFS =
+        (ver[2] == '3' && ver[3] == '5') ? 0x32c : 0x320;
+#    endif
     size_t val = 4096, written;
     if (!safe_write_ex(glro + GLRO_dl_tls_static_size_OFFS, sizeof(val), &val,
                        &written) ||

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -731,8 +731,8 @@ privload_os_finalize(privmod_t *privmod)
         SYSLOG_INTERNAL_WARNING("glibc 2.34+ i#5437 workaround failed: missed glro");
         return;
     }
-#    define GLRO_dl_tls_static_size_OFFS 0x2a8
-#    define GLRO_dl_tls_static_align_OFFS 0x2b0
+#    define GLRO_dl_tls_static_size_OFFS IF_X64_ELSE(0x2a8, 0x31c)
+#    define GLRO_dl_tls_static_align_OFFS IF_X64_ELSE(0x2b0, 0x320)
     size_t val = 4096, written;
     if (!safe_write_ex(glro + GLRO_dl_tls_static_size_OFFS, sizeof(val), &val,
                        &written) ||


### PR DESCRIPTION
Adds the same workaround for the SIGFPE in glibc 2.34+ __libc_early_init() as for 64-bit in PR #5695: we hardcode the 32-bit offsets of the two globals written by the workaround.

Tested on glibc 2.34 where every libc-using client crashes with SIGFPE but they work with this fix.

Adds an Ubuntu22 GA CI 32-bit run.

Issue: #5437