### PR TITLE
i#5909: handle empty input vector in print_histogram

### DIFF
--- a/clients/drcachesim/tests/reuse_distance_test.cpp
+++ b/clients/drcachesim/tests/reuse_distance_test.cpp
@@ -287,6 +287,32 @@ reuse_distance_limit_test()
     }
 }
 
+// Test print_histogram with empty input vector.
+void
+print_histogram_empty_test()
+{
+    std::cerr << "print_histogram_empty_test()\n";
+
+    // Create a reuse_distance test object.
+    reuse_distance_knobs_t knobs;
+    knobs.verbose = 2;
+    reuse_distance_test_t reuse_distance(knobs);
+
+    // Create an empty histogram vector.
+    std::vector<std::pair<int_least64_t, int_least64_t>> sorted;
+
+    // Make sure print_histogram handles this case without crashing.
+    std::stringstream output_string;
+    reuse_distance.print_histogram(output_string, /*count=*/0, sorted);
+
+    // If the title string is in the output, that's good enough.
+    std::vector<std::string> expected_strings = {
+        "Reuse distance histogram:",
+    };
+    bool test_passes = find_strings_in_stream(expected_strings, output_string);
+    assert(test_passes);
+}
+
 // Test print_histogram with multiplier of 1.0 (no geometric scaling).
 void
 print_histogram_mult_1p0_test()
@@ -367,6 +393,7 @@ print_histogram_mult_1p2_test()
 int
 main(int argc, const char *argv[])
 {
+    print_histogram_empty_test();
     print_histogram_mult_1p0_test();
     print_histogram_mult_1p2_test();
     simple_reuse_distance_test();

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -341,7 +341,7 @@ reuse_distance_t::print_histogram(
     }
     out << std::setw(12) << "Count"
         << "  Percent  Cumulative\n";
-    int_least64_t max_distance = sorted.back().first;
+    int_least64_t max_distance = sorted.empty() ? 0 : sorted.back().first;
     double cum_percent = 0;
     int_least64_t bin_count = 0;
     int_least64_t bin_size = 1;
@@ -360,7 +360,8 @@ reuse_distance_t::print_histogram(
                 bin_count += it->second;
                 last_bin = false;
             }
-            double percent = bin_count / static_cast<double>(total_count);
+            double percent =
+                total_count > 0 ? bin_count / static_cast<double>(total_count) : 0.0;
             cum_percent += percent;
             // Don't output empty bins.
             if (bin_count > 0) {


### PR DESCRIPTION
Avoids trying to read from an empty vector.
Adds a unit test for this corner case.

Fixes #5909