### PR TITLE
Updates debug printing macro to include if().

### DIFF
--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -52,11 +52,12 @@ reuse_distance_t::reuse_distance_t(const reuse_distance_knobs_t &knobs)
     : knobs_(knobs)
     , line_size_bits_(compute_log2((int)knobs_.line_size))
 {
-    if (DEBUG_VERBOSE(2)) {
-        std::cerr << "cache line size " << knobs_.line_size << ", "
-                  << "reuse distance threshold " << knobs_.distance_threshold
-                  << ", distance limit " << knobs_.distance_limit << std::endl;
-    }
+    reuse_distance_t::knob_verbose = knobs.verbose;
+    IF_DEBUG_VERBOSE(2,
+                     std::cerr << "cache line size " << knobs_.line_size << ", "
+                               << "reuse distance threshold " << knobs_.distance_threshold
+                               << ", distance limit " << knobs_.distance_limit
+                               << std::endl);
 }
 
 reuse_distance_t::~reuse_distance_t()
@@ -108,7 +109,7 @@ bool
 reuse_distance_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     shard_data_t *shard = reinterpret_cast<shard_data_t *>(shard_data);
-    if (DEBUG_VERBOSE(3)) {
+    IF_DEBUG_VERBOSE(3, {
         std::cerr << " ::" << memref.data.pid << "." << memref.data.tid
                   << ":: " << trace_type_names[memref.data.type];
         if (memref.data.type != TRACE_TYPE_THREAD_EXIT) {
@@ -118,7 +119,7 @@ reuse_distance_t::parallel_shard_memref(void *shard_data, const memref_t &memref
             std::cerr << (void *)memref.data.addr << " x" << memref.data.size;
         }
         std::cerr << std::endl;
-    }
+    });
     if (memref.data.type == TRACE_TYPE_THREAD_EXIT) {
         shard->tid = memref.exit.tid;
         return true;
@@ -166,9 +167,7 @@ reuse_distance_t::parallel_shard_memref(void *shard_data, const memref_t &memref
                 shard->dist_map.insert(std::pair<int_least64_t, int_least64_t>(dist, 1));
             else
                 ++dist_it->second;
-            if (DEBUG_VERBOSE(3)) {
-                std::cerr << "Distance is " << std::dec << dist << "\n";
-            }
+            IF_DEBUG_VERBOSE(3, std::cerr << "Distance is " << std::dec << dist << "\n");
         }
     }
     return true;

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -56,8 +56,7 @@ reuse_distance_t::reuse_distance_t(const reuse_distance_knobs_t &knobs)
     IF_DEBUG_VERBOSE(2,
                      std::cerr << "cache line size " << knobs_.line_size << ", "
                                << "reuse distance threshold " << knobs_.distance_threshold
-                               << ", distance limit " << knobs_.distance_limit
-                               << std::endl);
+                               << ", distance limit " << knobs_.distance_limit << "\n");
 }
 
 reuse_distance_t::~reuse_distance_t()
@@ -118,7 +117,7 @@ reuse_distance_t::parallel_shard_memref(void *shard_data, const memref_t &memref
                 std::cerr << (void *)memref.data.pc << " ";
             std::cerr << (void *)memref.data.addr << " x" << memref.data.size;
         }
-        std::cerr << std::endl;
+        std::cerr << "\n";
     });
     if (memref.data.type == TRACE_TYPE_THREAD_EXIT) {
         shard->tid = memref.exit.tid;

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -86,6 +86,8 @@ public:
     parallel_shard_error(void *shard_data) override;
 
     // Global value for use in non-member code.
+    // XXX: Change to an instance variable so multiple instances can have
+    // different verbosities.
     static unsigned int knob_verbose;
 
 protected:

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -49,13 +49,18 @@
 #include "memref.h"
 
 // We see noticeable overhead in release build with an if() that directly
-// checks knob_verbose, so for debug-only uses we turn it into something the
-// compiler can remove for better performance without going so far as ifdef-ing
-// big code chunks and impairing readability.
+// checks knob_verbose, so for non-debug uses we eliminate it entirely.
+// Example usage:
+//   IF_DEBUG_VERBOSE(1, std::cerr << "This code was executed.\n")
 #ifdef DEBUG
-#    define DEBUG_VERBOSE(level) (reuse_distance_t::knob_verbose >= (level))
+#    define IF_DEBUG_VERBOSE(level, action)                  \
+        do {                                                 \
+            if (reuse_distance_t::knob_verbose >= (level)) { \
+                action;                                      \
+            }                                                \
+        } while (0)
 #else
-#    define DEBUG_VERBOSE(level) (false)
+#    define IF_DEBUG_VERBOSE(level, action)
 #endif
 
 struct line_ref_t;
@@ -257,8 +262,7 @@ struct line_ref_list_t {
     void
     add_to_front(line_ref_t *ref)
     {
-        if (DEBUG_VERBOSE(3))
-            std::cerr << "Add tag 0x" << std::hex << ref->tag << "\n";
+        IF_DEBUG_VERBOSE(3, std::cerr << "Add tag 0x" << std::hex << ref->tag << "\n");
         // update head_
         ref->next = head_;
         if (head_ != NULL)
@@ -285,8 +289,9 @@ struct line_ref_list_t {
         }
         if (count >= 2 * skip_distance_ - 1) {
             assert(skip != NULL);
-            if (DEBUG_VERBOSE(3))
-                std::cerr << "New skip node for tag 0x" << std::hex << skip->tag << "\n";
+            IF_DEBUG_VERBOSE(3,
+                             std::cerr << "New skip node for tag 0x" << std::hex
+                                       << skip->tag << "\n");
             skip->depth = skip_distance_ - 1;
             if (node != NULL) {
                 assert(node->prev_skip == NULL);
@@ -298,8 +303,7 @@ struct line_ref_list_t {
         // Update skip list depths.
         for (; node != NULL; node = node->next_skip)
             ++node->depth;
-        if (DEBUG_VERBOSE(3))
-            print_list();
+        IF_DEBUG_VERBOSE(3, print_list());
     }
 
     // Remove the last entry from the distance list.
@@ -312,9 +316,8 @@ struct line_ref_list_t {
         assert(tail_->next == NULL);
         assert(tail_->prev != NULL);
 
-        if (DEBUG_VERBOSE(3)) {
-            std::cerr << "Prune tag 0x" << std::hex << tail_->tag << "\n";
-        }
+        IF_DEBUG_VERBOSE(3,
+                         std::cerr << "Prune tag 0x" << std::hex << tail_->tag << "\n");
 
         line_ref_t *new_tail = tail_->prev;
         new_tail->next = NULL;
@@ -340,8 +343,8 @@ struct line_ref_list_t {
     int_least64_t
     move_to_front(line_ref_t *ref)
     {
-        if (DEBUG_VERBOSE(3))
-            std::cerr << "Move tag 0x" << std::hex << ref->tag << " to front\n";
+        IF_DEBUG_VERBOSE(
+            3, std::cerr << "Move tag 0x" << std::hex << ref->tag << " to front\n");
         line_ref_t *prev;
         line_ref_t *next;
 
@@ -369,20 +372,21 @@ struct line_ref_list_t {
         else
             --dist; // Don't count self.
 
-        if (DEBUG_VERBOSE(0) && verify_skip_) {
-            // Compute reuse distance with a full list walk as a sanity check.
-            // This is a debug-only option, so we guard with DEBUG_VERBOSE(0).
-            // Yes, the option check branch shows noticeable overhead without it.
-            int_least64_t brute_dist = 0;
-            for (prev = head_; prev != ref; prev = prev->next)
-                ++brute_dist;
-            if (brute_dist != dist) {
-                std::cerr << "Mismatch!  Brute=" << std::dec << brute_dist
-                          << " vs skip=" << dist << "\n";
-                print_list();
-                assert(false);
-            }
-        }
+        IF_DEBUG_VERBOSE(
+            0, if (verify_skip_) {
+                // Compute reuse distance with a full list walk as a sanity check.
+                // This is a debug-only option, so we guard with IF_DEBUG_VERBOSE(0).
+                // Yes, the option check branch shows noticeable overhead without it.
+                int_least64_t brute_dist = 0;
+                for (prev = head_; prev != ref; prev = prev->next)
+                    ++brute_dist;
+                if (brute_dist != dist) {
+                    std::cerr << "Mismatch!  Brute=" << std::dec << brute_dist
+                              << " vs skip=" << dist << "\n";
+                    print_list();
+                    assert(false);
+                }
+            });
 
         // Shift skip nodes between where ref was and head one earlier to
         // maintain spacing.  This means their depths remain the same.
@@ -409,8 +413,7 @@ struct line_ref_list_t {
         head_ = ref;
         head_->time_stamp = cur_time_++;
 
-        if (DEBUG_VERBOSE(3))
-            print_list();
+        IF_DEBUG_VERBOSE(3, print_list());
         // XXX: we should keep a running mean of the distance, and adjust
         // knob_reuse_skip_dist to stay close to the mean, for best performance.
         return dist;


### PR DESCRIPTION
The old DEBUG_VERSOSE(level) macro returns a condition that can be evaluated at runtime for debug actions.  When not in DEBUG mode, the condition always evaluates to false, resulting in unreachable code the compiler will hopefully eliminate, but may cause a warning.

The new IF_DEBUG_VERBOSE(level, action) macro includes the condition evaluation to perform <action> when the condition is met in DEBUG mode.  When not in DEBUG mode, all code including the condition is eliminated, leaving nothing to the compiler.