### PR TITLE
Add input stream queries

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -672,7 +672,8 @@ if (BUILD_TESTS)
   target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer)
   add_win32_flags(tool.scheduler.unit_tests)
   add_test(NAME tool.scheduler.unit_tests
-           COMMAND tool.scheduler.unit_tests)
+    COMMAND tool.scheduler.unit_tests
+    ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
 
   # XXX i#5675: add tests for other environments. Currently, the repository does not have
   # a checked-in post-processed trace for x86-32 or AArchXX.

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -597,9 +597,11 @@ scheduler_tmpl_t<RecordType, ReaderType>::open_reader(
         error_string_ = "Failed to read " + path;
         return STATUS_ERROR_FILE_READ_FAILED;
     }
-    if (!only_threads.empty() && only_threads.find(tid) == only_threads.end())
+    if (!only_threads.empty() && only_threads.find(tid) == only_threads.end()) {
+        inputs_.pop_back();
         return sched_type_t::STATUS_SUCCESS;
-    VPRINT(this, 2, "Opened reader for tid %" PRId64 " %s\n", tid, path.c_str());
+    }
+    VPRINT(this, 1, "Opened reader for tid %" PRId64 " %s\n", tid, path.c_str());
     input.tid = tid;
     input.reader = std::move(reader);
     input.reader_end = std::move(reader_end);

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -604,6 +604,24 @@ public:
         return &outputs_[ordinal].stream;
     }
 
+    /** Returns the number of input streams. */
+    virtual int
+    get_input_stream_count()
+    {
+        return static_cast<int>(inputs_.size());
+    }
+
+    /**
+     * Returns the name (from get_stream_name()) of the 'ordinal'-th input stream.
+     */
+    virtual std::string
+    get_input_stream_name(int ordinal)
+    {
+        if (ordinal < 0 || ordinal >= static_cast<int>(inputs_.size()))
+            return nullptr;
+        return inputs_[ordinal].reader->get_stream_name();
+    }
+
     /** Returns a string further describing an error code. */
     std::string
     get_error_string()


### PR DESCRIPTION
Adds get_input_stream_count() and get_input_stream_name() to the scheduler_t drmemtrace interface.

Adds a test of these to the scheduler unit tests which uses real files and also serves as a test of only_threads for real files, whose code paths are different enough it had a bug which we fix here as well.

Issue: #5843