### PR TITLE
i#2626 Finish AArch64 encoder/decoder: ARMv8.4-CondM

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -198,13 +198,40 @@ proc_has_feature(feature_bit_t f)
      * support all features.
      */
 #    if defined(BUILD_TESTS)
-    if (f == FEATURE_LSE || f == FEATURE_RDM || f == FEATURE_FP16 ||
-        f == FEATURE_DotProd || f == FEATURE_SVE || f == FEATURE_LOR ||
-        f == FEATURE_FHM || f == FEATURE_SM3 || f == FEATURE_SM4 || f == FEATURE_SHA512 ||
-        f == FEATURE_SHA3 || f == FEATURE_RAS || f == FEATURE_SPE || f == FEATURE_PAUTH ||
-        f == FEATURE_LRCPC || f == FEATURE_LRCPC2 || f == FEATURE_BF16 ||
-        f == FEATURE_I8MM)
+    switch (f)
+    {
+    case FEATURE_LSE:
+    case FEATURE_RDM:
+    case FEATURE_FP16:
+    case FEATURE_DotProd:
+    case FEATURE_SVE:
+    case FEATURE_LOR:
+    case FEATURE_FHM:
+    case FEATURE_SM3:
+    case FEATURE_SM4:
+    case FEATURE_SHA512:
+    case FEATURE_SHA3:
+    case FEATURE_RAS:
+    case FEATURE_SPE:
+    case FEATURE_PAUTH:
+    case FEATURE_LRCPC:
+    case FEATURE_LRCPC2:
+    case FEATURE_BF16:
+    case FEATURE_I8MM:
+    case FEATURE_FlagM:
         return true;
+
+    case FEATURE_AESX:
+    case FEATURE_PMULL:
+    case FEATURE_SHA1:
+    case FEATURE_SHA256:
+    case FEATURE_CRC32:
+    case FEATURE_FlagM2:
+    case FEATURE_RNG:
+    case FEATURE_DPB:
+    case FEATURE_DPB2:
+        break;
+    }
 #    endif
     ushort feat_nibble, feat_val, freg_nibble, feat_nsflag;
     uint64 freg_val = 0;

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1915,7 +1915,6 @@ encode_opnd_zero_fp_const(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint 
 
 /* nzcv: flag bit specifier for conditional compare */
 
-#if 0  /* Currently unused. */
 static inline bool
 decode_opnd_nzcv(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
@@ -1927,7 +1926,6 @@ encode_opnd_nzcv(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_opnd_int(0, 4, false, 0, 0, opnd, enc_out);
 }
-#endif /* Currently unused. */
 
 /* p0: SVE predicate register at bit position 0; P0-P15 */
 
@@ -4579,7 +4577,21 @@ encode_opnd_sveprf_gpr_vec64(uint enc, int opcode, byte *pc, opnd_t opnd,
         encode_svemem_gpr_vec(enc, DOUBLE_REG, msz, msz > 0, opnd, enc_out);
 }
 
-/* imm7: 7-bit immediate from bits 14-20 */
+/* imm6: 6-bit immediate from bits 20:15 */
+
+static inline bool
+decode_opnd_imm6_15(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_int(15, 6, false, 0, OPSZ_6b, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_imm6_15(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_int(15, 6, false, 0, 0, opnd, enc_out);
+}
+
+/* imm7: 7-bit immediate from bits 20:14 */
 
 static inline bool
 decode_opnd_imm7(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -676,7 +676,9 @@ x0011011000xxxxx0xxxxxxxxxxxxxxx  n   311  BASE       madd            wx0 : wx5 
 110100101xxxxxxxxxxxxxxxxxxxxxxx  n   317  BASE       movz             x0 : imm16 lsl imm16sh
 110101010011xxxxxxxxxxxxxxxxxxxx  er  318  BASE        mrs             x0 : sysreg
 110101010001xxxxxxxxxxxxxxxxxxxx  ew  319  BASE        msr            msr
-1101010100000xxx0100xxxxxxx11111  ew  319  BASE        msr                : pstate imm4
+11010101000000000100xxxx10111111  ew  319  BASE        msr                : pstate imm4
+11010101000000110100xxxx11011111  ew  319  BASE        msr                : pstate imm4
+11010101000000110100xxxx11111111  ew  319  BASE        msr                : pstate imm4
 x0011011000xxxxx1xxxxxxxxxxxxxxx  n   320  BASE       msub            wx0 : wx5 wx16 wx10
 0x001110xx1xxxxx100111xxxxxxxxxx  n   321  BASE        mul            dq0 : dq5 dq16 bhs_sz
 0x001111xxxxxxxx1000x0xxxxxxxxxx  n   321  BASE        mul            dq0 : dq5 dq16_h_sz vindex_H hs_sz

--- a/core/ir/aarch64/codec_v84.txt
+++ b/core/ir/aarch64/codec_v84.txt
@@ -36,6 +36,7 @@
 
 # Instruction definitions:
 
+11010101000000000100^^^^00011111  rw  1023 FlagM    cfinv         :
 1x011001010xxxxxxxxx00xxxxxxxxxx  n   1014 LRCPC2   ldapur  wx0_30 : mem9
 00011001010xxxxxxxxx00xxxxxxxxxx  n   1015 LRCPC2  ldapurb      w0 : mem9
 01011001010xxxxxxxxx00xxxxxxxxxx  n   1016 LRCPC2  ldapurh      w0 : mem9
@@ -44,6 +45,9 @@
 01011001100xxxxxxxxx00xxxxxxxxxx  n   1018 LRCPC2 ldapursh      x0 : mem9
 01011001110xxxxxxxxx00xxxxxxxxxx  n   1018 LRCPC2 ldapursh      w0 : mem9
 10011001100xxxxxxxxx00xxxxxxxxxx  n   1019 LRCPC2 ldapursw      x0 : mem9
+10111010000xxxxxx00001xxxxx0xxxx  w   1024 FlagM     rmif         : x5 imm6_15 nzcv
+0011101000000000010010xxxxx01101  w   1025 FlagM   setf16         : w5
+0011101000000000000010xxxxx01101  w   1026 FlagM    setf8         : w5
 1x011001000xxxxxxxxx00xxxxxxxxxx  n   1020 LRCPC2    stlur    mem9 : wx0_30
 00011001000xxxxxxxxx00xxxxxxxxxx  n   1021 LRCPC2   stlurb    mem9 : w0
 01011001000xxxxxxxxx00xxxxxxxxxx  n   1022 LRCPC2   stlurh    mem9 : w0

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -13355,4 +13355,54 @@
  */
 #define INSTR_CREATE_stlurh(dc, Rt, mem) instr_create_1dst_1src(dc, OP_stlurh, mem, Rt)
 
+/**
+ * Creates a CFINV instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    CFINV
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_cfinv(dc) instr_create_0dst_0src(dc, OP_cfinv)
+
+/**
+ * Creates a RMIF instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RMIF    <Xn>, #<shift>, #<mask>
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn    The source  register, X (Extended, 64 bits).
+ * \param shift The immediate shift.
+ * \param mask  The immediate mask.
+ */
+#define INSTR_CREATE_rmif(dc, Rn, shift, mask) \
+    instr_create_0dst_3src(dc, OP_rmif, Rn, shift, mask)
+
+/**
+ * Creates a SETF16 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SETF16  <Wn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The source  register, W (Word, 32 bits).
+ */
+#define INSTR_CREATE_setf16(dc, Rn) instr_create_0dst_1src(dc, OP_setf16, Rn)
+
+/**
+ * Creates a SETF8 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SETF8   <Wn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The source  register, W (Word, 32 bits).
+ */
+#define INSTR_CREATE_setf8(dc, Rn) instr_create_0dst_1src(dc, OP_setf8, Rn)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -74,7 +74,7 @@
 --------------------------------  d_const_sz # as above, but for double width
 --------------------------------  vindex_D1  # An implicit index, at index 1
 --------------------------------  zero_fp_const # A constant zero operand
-----------------------------xxxx  nzcv       # flag bit specifier for CCMN, CCMP
+----------------------------xxxx  nzcv       # flag bit specifier for CCMN, CCMP, RMIF
 ----------------------------xxxx  p0         # SVE predicate registers p0-p15
 ----------------------------xxxx  p_b_0      # P register with a byte element size
 ----------------------------xxxx  p_h_0      # P register with a halfword element size
@@ -214,7 +214,8 @@
 -----------xxxxx------xxxxx-----  svemem_gprs_b1  # memory reg from Rm and Rn fields transferring 1 bytes per element
 -----------xxxxx---xxx----------  imm8_10    # 8 bit imm at pos 10, split across 20:16 and 12:10
 -----------xxxxx-??---xxxxx-----  sveprf_gpr_vec64 # SVE prefetch memory address (64-bit offset) [<Xn|SP>, <Zm>.D{, <mod> <amount>}]
------------xxxxxxx--------------  imm7       # 7 bit immediate from 14-20
+-----------xxxxxx---------------  imm6_15    # 6 bit immediate from 20:15
+-----------xxxxxxx--------------  imm7       # 7 bit immediate from 20:14
 -----------xxxxxxxxx------------  mem9off    # immed offset for mem9/mem9post
 -----------xxxxxxxxx--xxxxx-----  mem9q      # size is 16 bytes
 -----------xxxxxxxxx--xxxxx-----  prf9       # size is 0 bytes (prefetch variant of mem9)

--- a/suite/tests/api/dis-a64-v84.txt
+++ b/suite/tests/api/dis-a64-v84.txt
@@ -32,6 +32,9 @@
 # See dis-a64-sve.txt for the formatting.
 
 # Tests:
+# CFINV    (CFINV--flags)
+d5004f1f : cfinv                                     : cfinv
+
 # LDAPUR    <Wt>, [<Xn|SP>{, #<simm>}]
 99500020 : ldapur w0, [x1, #-256]                    : ldapur -0x0100(%x1)[4byte] -> %w0
 99510041 : ldapur w1, [x2, #-240]                    : ldapur -0xf0(%x2)[4byte] -> %w1
@@ -66,73 +69,39 @@
 994ef3fe : ldapur w30, [sp, #239]                    : ldapur +0xef(%sp)[4byte] -> %w30
 994ff01f : ldapur wzr, [x0, #255]                    : ldapur +0xff(%x0)[4byte] -> %wzr
 
-# LDAPURSB  <Wt>, [<Xn|SP>{, #<simm>}]
-19d00020 : ldapursb w0, [x1, #-256]                  : ldapursb -0x0100(%x1)[1byte] -> %w0
-19d10041 : ldapursb w1, [x2, #-240]                  : ldapursb -0xf0(%x2)[1byte] -> %w1
-19d21062 : ldapursb w2, [x3, #-223]                  : ldapursb -0xdf(%x3)[1byte] -> %w2
-19d31083 : ldapursb w3, [x4, #-207]                  : ldapursb -0xcf(%x4)[1byte] -> %w3
-19d420a4 : ldapursb w4, [x5, #-190]                  : ldapursb -0xbe(%x5)[1byte] -> %w4
-19d520c5 : ldapursb w5, [x6, #-174]                  : ldapursb -0xae(%x6)[1byte] -> %w5
-19d630e6 : ldapursb w6, [x7, #-157]                  : ldapursb -0x9d(%x7)[1byte] -> %w6
-19d73107 : ldapursb w7, [x8, #-141]                  : ldapursb -0x8d(%x8)[1byte] -> %w7
-19d84128 : ldapursb w8, [x9, #-124]                  : ldapursb -0x7c(%x9)[1byte] -> %w8
-19d94149 : ldapursb w9, [x10, #-108]                 : ldapursb -0x6c(%x10)[1byte] -> %w9
-19da516a : ldapursb w10, [x11, #-91]                 : ldapursb -0x5b(%x11)[1byte] -> %w10
-19db518b : ldapursb w11, [x12, #-75]                 : ldapursb -0x4b(%x12)[1byte] -> %w11
-19dc61ac : ldapursb w12, [x13, #-58]                 : ldapursb -0x3a(%x13)[1byte] -> %w12
-19dd61cd : ldapursb w13, [x14, #-42]                 : ldapursb -0x2a(%x14)[1byte] -> %w13
-19de71ee : ldapursb w14, [x15, #-25]                 : ldapursb -0x19(%x15)[1byte] -> %w14
-19df720f : ldapursb w15, [x16, #-9]                  : ldapursb -0x09(%x16)[1byte] -> %w15
-19c00230 : ldapursb w16, [x17]                       : ldapursb (%x17)[1byte] -> %w16
-19c18251 : ldapursb w17, [x18, #24]                  : ldapursb +0x18(%x18)[1byte] -> %w17
-19c29272 : ldapursb w18, [x19, #41]                  : ldapursb +0x29(%x19)[1byte] -> %w18
-19c39293 : ldapursb w19, [x20, #57]                  : ldapursb +0x39(%x20)[1byte] -> %w19
-19c4a2b4 : ldapursb w20, [x21, #74]                  : ldapursb +0x4a(%x21)[1byte] -> %w20
-19c5a2d5 : ldapursb w21, [x22, #90]                  : ldapursb +0x5a(%x22)[1byte] -> %w21
-19c6b2f6 : ldapursb w22, [x23, #107]                 : ldapursb +0x6b(%x23)[1byte] -> %w22
-19c7b317 : ldapursb w23, [x24, #123]                 : ldapursb +0x7b(%x24)[1byte] -> %w23
-19c8c338 : ldapursb w24, [x25, #140]                 : ldapursb +0x8c(%x25)[1byte] -> %w24
-19c9c359 : ldapursb w25, [x26, #156]                 : ldapursb +0x9c(%x26)[1byte] -> %w25
-19cad37a : ldapursb w26, [x27, #173]                 : ldapursb +0xad(%x27)[1byte] -> %w26
-19cbd39b : ldapursb w27, [x28, #189]                 : ldapursb +0xbd(%x28)[1byte] -> %w27
-19cce3bc : ldapursb w28, [x29, #206]                 : ldapursb +0xce(%x29)[1byte] -> %w28
-19cde3dd : ldapursb w29, [x30, #222]                 : ldapursb +0xde(%x30)[1byte] -> %w29
-19cef3fe : ldapursb w30, [sp, #239]                  : ldapursb +0xef(%sp)[1byte] -> %w30
-19cff01f : ldapursb wzr, [x0, #255]                  : ldapursb +0xff(%x0)[1byte] -> %wzr
-
-# LDAPURSH  <Wt>, [<Xn|SP>{, #<simm>}]
-59d00020 : ldapursh w0, [x1, #-256]                  : ldapursh -0x0100(%x1)[2byte] -> %w0
-59d10041 : ldapursh w1, [x2, #-240]                  : ldapursh -0xf0(%x2)[2byte] -> %w1
-59d21062 : ldapursh w2, [x3, #-223]                  : ldapursh -0xdf(%x3)[2byte] -> %w2
-59d31083 : ldapursh w3, [x4, #-207]                  : ldapursh -0xcf(%x4)[2byte] -> %w3
-59d420a4 : ldapursh w4, [x5, #-190]                  : ldapursh -0xbe(%x5)[2byte] -> %w4
-59d520c5 : ldapursh w5, [x6, #-174]                  : ldapursh -0xae(%x6)[2byte] -> %w5
-59d630e6 : ldapursh w6, [x7, #-157]                  : ldapursh -0x9d(%x7)[2byte] -> %w6
-59d73107 : ldapursh w7, [x8, #-141]                  : ldapursh -0x8d(%x8)[2byte] -> %w7
-59d84128 : ldapursh w8, [x9, #-124]                  : ldapursh -0x7c(%x9)[2byte] -> %w8
-59d94149 : ldapursh w9, [x10, #-108]                 : ldapursh -0x6c(%x10)[2byte] -> %w9
-59da516a : ldapursh w10, [x11, #-91]                 : ldapursh -0x5b(%x11)[2byte] -> %w10
-59db518b : ldapursh w11, [x12, #-75]                 : ldapursh -0x4b(%x12)[2byte] -> %w11
-59dc61ac : ldapursh w12, [x13, #-58]                 : ldapursh -0x3a(%x13)[2byte] -> %w12
-59dd61cd : ldapursh w13, [x14, #-42]                 : ldapursh -0x2a(%x14)[2byte] -> %w13
-59de71ee : ldapursh w14, [x15, #-25]                 : ldapursh -0x19(%x15)[2byte] -> %w14
-59df720f : ldapursh w15, [x16, #-9]                  : ldapursh -0x09(%x16)[2byte] -> %w15
-59c00230 : ldapursh w16, [x17]                       : ldapursh (%x17)[2byte] -> %w16
-59c18251 : ldapursh w17, [x18, #24]                  : ldapursh +0x18(%x18)[2byte] -> %w17
-59c29272 : ldapursh w18, [x19, #41]                  : ldapursh +0x29(%x19)[2byte] -> %w18
-59c39293 : ldapursh w19, [x20, #57]                  : ldapursh +0x39(%x20)[2byte] -> %w19
-59c4a2b4 : ldapursh w20, [x21, #74]                  : ldapursh +0x4a(%x21)[2byte] -> %w20
-59c5a2d5 : ldapursh w21, [x22, #90]                  : ldapursh +0x5a(%x22)[2byte] -> %w21
-59c6b2f6 : ldapursh w22, [x23, #107]                 : ldapursh +0x6b(%x23)[2byte] -> %w22
-59c7b317 : ldapursh w23, [x24, #123]                 : ldapursh +0x7b(%x24)[2byte] -> %w23
-59c8c338 : ldapursh w24, [x25, #140]                 : ldapursh +0x8c(%x25)[2byte] -> %w24
-59c9c359 : ldapursh w25, [x26, #156]                 : ldapursh +0x9c(%x26)[2byte] -> %w25
-59cad37a : ldapursh w26, [x27, #173]                 : ldapursh +0xad(%x27)[2byte] -> %w26
-59cbd39b : ldapursh w27, [x28, #189]                 : ldapursh +0xbd(%x28)[2byte] -> %w27
-59cce3bc : ldapursh w28, [x29, #206]                 : ldapursh +0xce(%x29)[2byte] -> %w28
-59cde3dd : ldapursh w29, [x30, #222]                 : ldapursh +0xde(%x30)[2byte] -> %w29
-59cef3fe : ldapursh w30, [sp, #239]                  : ldapursh +0xef(%sp)[2byte] -> %w30
-59cff01f : ldapursh wzr, [x0, #255]                  : ldapursh +0xff(%x0)[2byte] -> %wzr
+# LDAPUR    <Xt>, [<Xn|SP>{, #<simm>}]
+d9500020 : ldapur x0, [x1, #-256]                    : ldapur -0x0100(%x1)[8byte] -> %x0
+d9510041 : ldapur x1, [x2, #-240]                    : ldapur -0xf0(%x2)[8byte] -> %x1
+d9521062 : ldapur x2, [x3, #-223]                    : ldapur -0xdf(%x3)[8byte] -> %x2
+d9531083 : ldapur x3, [x4, #-207]                    : ldapur -0xcf(%x4)[8byte] -> %x3
+d95420a4 : ldapur x4, [x5, #-190]                    : ldapur -0xbe(%x5)[8byte] -> %x4
+d95520c5 : ldapur x5, [x6, #-174]                    : ldapur -0xae(%x6)[8byte] -> %x5
+d95630e6 : ldapur x6, [x7, #-157]                    : ldapur -0x9d(%x7)[8byte] -> %x6
+d9573107 : ldapur x7, [x8, #-141]                    : ldapur -0x8d(%x8)[8byte] -> %x7
+d9584128 : ldapur x8, [x9, #-124]                    : ldapur -0x7c(%x9)[8byte] -> %x8
+d9594149 : ldapur x9, [x10, #-108]                   : ldapur -0x6c(%x10)[8byte] -> %x9
+d95a516a : ldapur x10, [x11, #-91]                   : ldapur -0x5b(%x11)[8byte] -> %x10
+d95b518b : ldapur x11, [x12, #-75]                   : ldapur -0x4b(%x12)[8byte] -> %x11
+d95c61ac : ldapur x12, [x13, #-58]                   : ldapur -0x3a(%x13)[8byte] -> %x12
+d95d61cd : ldapur x13, [x14, #-42]                   : ldapur -0x2a(%x14)[8byte] -> %x13
+d95e71ee : ldapur x14, [x15, #-25]                   : ldapur -0x19(%x15)[8byte] -> %x14
+d95f720f : ldapur x15, [x16, #-9]                    : ldapur -0x09(%x16)[8byte] -> %x15
+d9400230 : ldapur x16, [x17]                         : ldapur (%x17)[8byte] -> %x16
+d9418251 : ldapur x17, [x18, #24]                    : ldapur +0x18(%x18)[8byte] -> %x17
+d9429272 : ldapur x18, [x19, #41]                    : ldapur +0x29(%x19)[8byte] -> %x18
+d9439293 : ldapur x19, [x20, #57]                    : ldapur +0x39(%x20)[8byte] -> %x19
+d944a2b4 : ldapur x20, [x21, #74]                    : ldapur +0x4a(%x21)[8byte] -> %x20
+d945a2d5 : ldapur x21, [x22, #90]                    : ldapur +0x5a(%x22)[8byte] -> %x21
+d946b2f6 : ldapur x22, [x23, #107]                   : ldapur +0x6b(%x23)[8byte] -> %x22
+d947b317 : ldapur x23, [x24, #123]                   : ldapur +0x7b(%x24)[8byte] -> %x23
+d948c338 : ldapur x24, [x25, #140]                   : ldapur +0x8c(%x25)[8byte] -> %x24
+d949c359 : ldapur x25, [x26, #156]                   : ldapur +0x9c(%x26)[8byte] -> %x25
+d94ad37a : ldapur x26, [x27, #173]                   : ldapur +0xad(%x27)[8byte] -> %x26
+d94bd39b : ldapur x27, [x28, #189]                   : ldapur +0xbd(%x28)[8byte] -> %x27
+d94ce3bc : ldapur x28, [x29, #206]                   : ldapur +0xce(%x29)[8byte] -> %x28
+d94de3dd : ldapur x29, [x30, #222]                   : ldapur +0xde(%x30)[8byte] -> %x29
+d94ef3fe : ldapur x30, [sp, #239]                    : ldapur +0xef(%sp)[8byte] -> %x30
+d94ff01f : ldapur xzr, [x0, #255]                    : ldapur +0xff(%x0)[8byte] -> %xzr
 
 # LDAPURB   <Wt>, [<Xn|SP>{, #<simm>}]
 19500020 : ldapurb w0, [x1, #-256]                   : ldapurb -0x0100(%x1)[1byte] -> %w0
@@ -202,141 +171,39 @@
 594ef3fe : ldapurh w30, [sp, #239]                   : ldapurh +0xef(%sp)[2byte] -> %w30
 594ff01f : ldapurh wzr, [x0, #255]                   : ldapurh +0xff(%x0)[2byte] -> %wzr
 
-# STLUR     <Wt>, [<Xn|SP>{, #<simm>}]
-99100020 : stlur w0, [x1, #-256]                     : stlur  %w0 -> -0x0100(%x1)[4byte]
-99110041 : stlur w1, [x2, #-240]                     : stlur  %w1 -> -0xf0(%x2)[4byte]
-99121062 : stlur w2, [x3, #-223]                     : stlur  %w2 -> -0xdf(%x3)[4byte]
-99131083 : stlur w3, [x4, #-207]                     : stlur  %w3 -> -0xcf(%x4)[4byte]
-991420a4 : stlur w4, [x5, #-190]                     : stlur  %w4 -> -0xbe(%x5)[4byte]
-991520c5 : stlur w5, [x6, #-174]                     : stlur  %w5 -> -0xae(%x6)[4byte]
-991630e6 : stlur w6, [x7, #-157]                     : stlur  %w6 -> -0x9d(%x7)[4byte]
-99173107 : stlur w7, [x8, #-141]                     : stlur  %w7 -> -0x8d(%x8)[4byte]
-99184128 : stlur w8, [x9, #-124]                     : stlur  %w8 -> -0x7c(%x9)[4byte]
-99194149 : stlur w9, [x10, #-108]                    : stlur  %w9 -> -0x6c(%x10)[4byte]
-991a516a : stlur w10, [x11, #-91]                    : stlur  %w10 -> -0x5b(%x11)[4byte]
-991b518b : stlur w11, [x12, #-75]                    : stlur  %w11 -> -0x4b(%x12)[4byte]
-991c61ac : stlur w12, [x13, #-58]                    : stlur  %w12 -> -0x3a(%x13)[4byte]
-991d61cd : stlur w13, [x14, #-42]                    : stlur  %w13 -> -0x2a(%x14)[4byte]
-991e71ee : stlur w14, [x15, #-25]                    : stlur  %w14 -> -0x19(%x15)[4byte]
-991f720f : stlur w15, [x16, #-9]                     : stlur  %w15 -> -0x09(%x16)[4byte]
-99000230 : stlur w16, [x17]                          : stlur  %w16 -> (%x17)[4byte]
-99018251 : stlur w17, [x18, #24]                     : stlur  %w17 -> +0x18(%x18)[4byte]
-99029272 : stlur w18, [x19, #41]                     : stlur  %w18 -> +0x29(%x19)[4byte]
-99039293 : stlur w19, [x20, #57]                     : stlur  %w19 -> +0x39(%x20)[4byte]
-9904a2b4 : stlur w20, [x21, #74]                     : stlur  %w20 -> +0x4a(%x21)[4byte]
-9905a2d5 : stlur w21, [x22, #90]                     : stlur  %w21 -> +0x5a(%x22)[4byte]
-9906b2f6 : stlur w22, [x23, #107]                    : stlur  %w22 -> +0x6b(%x23)[4byte]
-9907b317 : stlur w23, [x24, #123]                    : stlur  %w23 -> +0x7b(%x24)[4byte]
-9908c338 : stlur w24, [x25, #140]                    : stlur  %w24 -> +0x8c(%x25)[4byte]
-9909c359 : stlur w25, [x26, #156]                    : stlur  %w25 -> +0x9c(%x26)[4byte]
-990ad37a : stlur w26, [x27, #173]                    : stlur  %w26 -> +0xad(%x27)[4byte]
-990bd39b : stlur w27, [x28, #189]                    : stlur  %w27 -> +0xbd(%x28)[4byte]
-990ce3bc : stlur w28, [x29, #206]                    : stlur  %w28 -> +0xce(%x29)[4byte]
-990de3dd : stlur w29, [x30, #222]                    : stlur  %w29 -> +0xde(%x30)[4byte]
-990ef3fe : stlur w30, [sp, #239]                     : stlur  %w30 -> +0xef(%sp)[4byte]
-990ff01f : stlur wzr, [x0, #255]                     : stlur  %wzr -> +0xff(%x0)[4byte]
-
-# STLURB    <Wt>, [<Xn|SP>{, #<simm>}]
-19100020 : stlurb w0, [x1, #-256]                    : stlurb %w0 -> -0x0100(%x1)[1byte]
-19110041 : stlurb w1, [x2, #-240]                    : stlurb %w1 -> -0xf0(%x2)[1byte]
-19121062 : stlurb w2, [x3, #-223]                    : stlurb %w2 -> -0xdf(%x3)[1byte]
-19131083 : stlurb w3, [x4, #-207]                    : stlurb %w3 -> -0xcf(%x4)[1byte]
-191420a4 : stlurb w4, [x5, #-190]                    : stlurb %w4 -> -0xbe(%x5)[1byte]
-191520c5 : stlurb w5, [x6, #-174]                    : stlurb %w5 -> -0xae(%x6)[1byte]
-191630e6 : stlurb w6, [x7, #-157]                    : stlurb %w6 -> -0x9d(%x7)[1byte]
-19173107 : stlurb w7, [x8, #-141]                    : stlurb %w7 -> -0x8d(%x8)[1byte]
-19184128 : stlurb w8, [x9, #-124]                    : stlurb %w8 -> -0x7c(%x9)[1byte]
-19194149 : stlurb w9, [x10, #-108]                   : stlurb %w9 -> -0x6c(%x10)[1byte]
-191a516a : stlurb w10, [x11, #-91]                   : stlurb %w10 -> -0x5b(%x11)[1byte]
-191b518b : stlurb w11, [x12, #-75]                   : stlurb %w11 -> -0x4b(%x12)[1byte]
-191c61ac : stlurb w12, [x13, #-58]                   : stlurb %w12 -> -0x3a(%x13)[1byte]
-191d61cd : stlurb w13, [x14, #-42]                   : stlurb %w13 -> -0x2a(%x14)[1byte]
-191e71ee : stlurb w14, [x15, #-25]                   : stlurb %w14 -> -0x19(%x15)[1byte]
-191f720f : stlurb w15, [x16, #-9]                    : stlurb %w15 -> -0x09(%x16)[1byte]
-19000230 : stlurb w16, [x17]                         : stlurb %w16 -> (%x17)[1byte]
-19018251 : stlurb w17, [x18, #24]                    : stlurb %w17 -> +0x18(%x18)[1byte]
-19029272 : stlurb w18, [x19, #41]                    : stlurb %w18 -> +0x29(%x19)[1byte]
-19039293 : stlurb w19, [x20, #57]                    : stlurb %w19 -> +0x39(%x20)[1byte]
-1904a2b4 : stlurb w20, [x21, #74]                    : stlurb %w20 -> +0x4a(%x21)[1byte]
-1905a2d5 : stlurb w21, [x22, #90]                    : stlurb %w21 -> +0x5a(%x22)[1byte]
-1906b2f6 : stlurb w22, [x23, #107]                   : stlurb %w22 -> +0x6b(%x23)[1byte]
-1907b317 : stlurb w23, [x24, #123]                   : stlurb %w23 -> +0x7b(%x24)[1byte]
-1908c338 : stlurb w24, [x25, #140]                   : stlurb %w24 -> +0x8c(%x25)[1byte]
-1909c359 : stlurb w25, [x26, #156]                   : stlurb %w25 -> +0x9c(%x26)[1byte]
-190ad37a : stlurb w26, [x27, #173]                   : stlurb %w26 -> +0xad(%x27)[1byte]
-190bd39b : stlurb w27, [x28, #189]                   : stlurb %w27 -> +0xbd(%x28)[1byte]
-190ce3bc : stlurb w28, [x29, #206]                   : stlurb %w28 -> +0xce(%x29)[1byte]
-190de3dd : stlurb w29, [x30, #222]                   : stlurb %w29 -> +0xde(%x30)[1byte]
-190ef3fe : stlurb w30, [sp, #239]                    : stlurb %w30 -> +0xef(%sp)[1byte]
-190ff01f : stlurb wzr, [x0, #255]                    : stlurb %wzr -> +0xff(%x0)[1byte]
-
-# STLURH    <Wt>, [<Xn|SP>{, #<simm>}]
-59100020 : stlurh w0, [x1, #-256]                    : stlurh %w0 -> -0x0100(%x1)[2byte]
-59110041 : stlurh w1, [x2, #-240]                    : stlurh %w1 -> -0xf0(%x2)[2byte]
-59121062 : stlurh w2, [x3, #-223]                    : stlurh %w2 -> -0xdf(%x3)[2byte]
-59131083 : stlurh w3, [x4, #-207]                    : stlurh %w3 -> -0xcf(%x4)[2byte]
-591420a4 : stlurh w4, [x5, #-190]                    : stlurh %w4 -> -0xbe(%x5)[2byte]
-591520c5 : stlurh w5, [x6, #-174]                    : stlurh %w5 -> -0xae(%x6)[2byte]
-591630e6 : stlurh w6, [x7, #-157]                    : stlurh %w6 -> -0x9d(%x7)[2byte]
-59173107 : stlurh w7, [x8, #-141]                    : stlurh %w7 -> -0x8d(%x8)[2byte]
-59184128 : stlurh w8, [x9, #-124]                    : stlurh %w8 -> -0x7c(%x9)[2byte]
-59194149 : stlurh w9, [x10, #-108]                   : stlurh %w9 -> -0x6c(%x10)[2byte]
-591a516a : stlurh w10, [x11, #-91]                   : stlurh %w10 -> -0x5b(%x11)[2byte]
-591b518b : stlurh w11, [x12, #-75]                   : stlurh %w11 -> -0x4b(%x12)[2byte]
-591c61ac : stlurh w12, [x13, #-58]                   : stlurh %w12 -> -0x3a(%x13)[2byte]
-591d61cd : stlurh w13, [x14, #-42]                   : stlurh %w13 -> -0x2a(%x14)[2byte]
-591e71ee : stlurh w14, [x15, #-25]                   : stlurh %w14 -> -0x19(%x15)[2byte]
-591f720f : stlurh w15, [x16, #-9]                    : stlurh %w15 -> -0x09(%x16)[2byte]
-59000230 : stlurh w16, [x17]                         : stlurh %w16 -> (%x17)[2byte]
-59018251 : stlurh w17, [x18, #24]                    : stlurh %w17 -> +0x18(%x18)[2byte]
-59029272 : stlurh w18, [x19, #41]                    : stlurh %w18 -> +0x29(%x19)[2byte]
-59039293 : stlurh w19, [x20, #57]                    : stlurh %w19 -> +0x39(%x20)[2byte]
-5904a2b4 : stlurh w20, [x21, #74]                    : stlurh %w20 -> +0x4a(%x21)[2byte]
-5905a2d5 : stlurh w21, [x22, #90]                    : stlurh %w21 -> +0x5a(%x22)[2byte]
-5906b2f6 : stlurh w22, [x23, #107]                   : stlurh %w22 -> +0x6b(%x23)[2byte]
-5907b317 : stlurh w23, [x24, #123]                   : stlurh %w23 -> +0x7b(%x24)[2byte]
-5908c338 : stlurh w24, [x25, #140]                   : stlurh %w24 -> +0x8c(%x25)[2byte]
-5909c359 : stlurh w25, [x26, #156]                   : stlurh %w25 -> +0x9c(%x26)[2byte]
-590ad37a : stlurh w26, [x27, #173]                   : stlurh %w26 -> +0xad(%x27)[2byte]
-590bd39b : stlurh w27, [x28, #189]                   : stlurh %w27 -> +0xbd(%x28)[2byte]
-590ce3bc : stlurh w28, [x29, #206]                   : stlurh %w28 -> +0xce(%x29)[2byte]
-590de3dd : stlurh w29, [x30, #222]                   : stlurh %w29 -> +0xde(%x30)[2byte]
-590ef3fe : stlurh w30, [sp, #239]                    : stlurh %w30 -> +0xef(%sp)[2byte]
-590ff01f : stlurh wzr, [x0, #255]                    : stlurh %wzr -> +0xff(%x0)[2byte]
-
-# LDAPUR    <Xt>, [<Xn|SP>{, #<simm>}]
-d9500020 : ldapur x0, [x1, #-256]                    : ldapur -0x0100(%x1)[8byte] -> %x0
-d9510041 : ldapur x1, [x2, #-240]                    : ldapur -0xf0(%x2)[8byte] -> %x1
-d9521062 : ldapur x2, [x3, #-223]                    : ldapur -0xdf(%x3)[8byte] -> %x2
-d9531083 : ldapur x3, [x4, #-207]                    : ldapur -0xcf(%x4)[8byte] -> %x3
-d95420a4 : ldapur x4, [x5, #-190]                    : ldapur -0xbe(%x5)[8byte] -> %x4
-d95520c5 : ldapur x5, [x6, #-174]                    : ldapur -0xae(%x6)[8byte] -> %x5
-d95630e6 : ldapur x6, [x7, #-157]                    : ldapur -0x9d(%x7)[8byte] -> %x6
-d9573107 : ldapur x7, [x8, #-141]                    : ldapur -0x8d(%x8)[8byte] -> %x7
-d9584128 : ldapur x8, [x9, #-124]                    : ldapur -0x7c(%x9)[8byte] -> %x8
-d9594149 : ldapur x9, [x10, #-108]                   : ldapur -0x6c(%x10)[8byte] -> %x9
-d95a516a : ldapur x10, [x11, #-91]                   : ldapur -0x5b(%x11)[8byte] -> %x10
-d95b518b : ldapur x11, [x12, #-75]                   : ldapur -0x4b(%x12)[8byte] -> %x11
-d95c61ac : ldapur x12, [x13, #-58]                   : ldapur -0x3a(%x13)[8byte] -> %x12
-d95d61cd : ldapur x13, [x14, #-42]                   : ldapur -0x2a(%x14)[8byte] -> %x13
-d95e71ee : ldapur x14, [x15, #-25]                   : ldapur -0x19(%x15)[8byte] -> %x14
-d95f720f : ldapur x15, [x16, #-9]                    : ldapur -0x09(%x16)[8byte] -> %x15
-d9400230 : ldapur x16, [x17]                         : ldapur (%x17)[8byte] -> %x16
-d9418251 : ldapur x17, [x18, #24]                    : ldapur +0x18(%x18)[8byte] -> %x17
-d9429272 : ldapur x18, [x19, #41]                    : ldapur +0x29(%x19)[8byte] -> %x18
-d9439293 : ldapur x19, [x20, #57]                    : ldapur +0x39(%x20)[8byte] -> %x19
-d944a2b4 : ldapur x20, [x21, #74]                    : ldapur +0x4a(%x21)[8byte] -> %x20
-d945a2d5 : ldapur x21, [x22, #90]                    : ldapur +0x5a(%x22)[8byte] -> %x21
-d946b2f6 : ldapur x22, [x23, #107]                   : ldapur +0x6b(%x23)[8byte] -> %x22
-d947b317 : ldapur x23, [x24, #123]                   : ldapur +0x7b(%x24)[8byte] -> %x23
-d948c338 : ldapur x24, [x25, #140]                   : ldapur +0x8c(%x25)[8byte] -> %x24
-d949c359 : ldapur x25, [x26, #156]                   : ldapur +0x9c(%x26)[8byte] -> %x25
-d94ad37a : ldapur x26, [x27, #173]                   : ldapur +0xad(%x27)[8byte] -> %x26
-d94bd39b : ldapur x27, [x28, #189]                   : ldapur +0xbd(%x28)[8byte] -> %x27
-d94ce3bc : ldapur x28, [x29, #206]                   : ldapur +0xce(%x29)[8byte] -> %x28
-d94de3dd : ldapur x29, [x30, #222]                   : ldapur +0xde(%x30)[8byte] -> %x29
-d94ef3fe : ldapur x30, [sp, #239]                    : ldapur +0xef(%sp)[8byte] -> %x30
-d94ff01f : ldapur xzr, [x0, #255]                    : ldapur +0xff(%x0)[8byte] -> %xzr
+# LDAPURSB  <Wt>, [<Xn|SP>{, #<simm>}]
+19d00020 : ldapursb w0, [x1, #-256]                  : ldapursb -0x0100(%x1)[1byte] -> %w0
+19d10041 : ldapursb w1, [x2, #-240]                  : ldapursb -0xf0(%x2)[1byte] -> %w1
+19d21062 : ldapursb w2, [x3, #-223]                  : ldapursb -0xdf(%x3)[1byte] -> %w2
+19d31083 : ldapursb w3, [x4, #-207]                  : ldapursb -0xcf(%x4)[1byte] -> %w3
+19d420a4 : ldapursb w4, [x5, #-190]                  : ldapursb -0xbe(%x5)[1byte] -> %w4
+19d520c5 : ldapursb w5, [x6, #-174]                  : ldapursb -0xae(%x6)[1byte] -> %w5
+19d630e6 : ldapursb w6, [x7, #-157]                  : ldapursb -0x9d(%x7)[1byte] -> %w6
+19d73107 : ldapursb w7, [x8, #-141]                  : ldapursb -0x8d(%x8)[1byte] -> %w7
+19d84128 : ldapursb w8, [x9, #-124]                  : ldapursb -0x7c(%x9)[1byte] -> %w8
+19d94149 : ldapursb w9, [x10, #-108]                 : ldapursb -0x6c(%x10)[1byte] -> %w9
+19da516a : ldapursb w10, [x11, #-91]                 : ldapursb -0x5b(%x11)[1byte] -> %w10
+19db518b : ldapursb w11, [x12, #-75]                 : ldapursb -0x4b(%x12)[1byte] -> %w11
+19dc61ac : ldapursb w12, [x13, #-58]                 : ldapursb -0x3a(%x13)[1byte] -> %w12
+19dd61cd : ldapursb w13, [x14, #-42]                 : ldapursb -0x2a(%x14)[1byte] -> %w13
+19de71ee : ldapursb w14, [x15, #-25]                 : ldapursb -0x19(%x15)[1byte] -> %w14
+19df720f : ldapursb w15, [x16, #-9]                  : ldapursb -0x09(%x16)[1byte] -> %w15
+19c00230 : ldapursb w16, [x17]                       : ldapursb (%x17)[1byte] -> %w16
+19c18251 : ldapursb w17, [x18, #24]                  : ldapursb +0x18(%x18)[1byte] -> %w17
+19c29272 : ldapursb w18, [x19, #41]                  : ldapursb +0x29(%x19)[1byte] -> %w18
+19c39293 : ldapursb w19, [x20, #57]                  : ldapursb +0x39(%x20)[1byte] -> %w19
+19c4a2b4 : ldapursb w20, [x21, #74]                  : ldapursb +0x4a(%x21)[1byte] -> %w20
+19c5a2d5 : ldapursb w21, [x22, #90]                  : ldapursb +0x5a(%x22)[1byte] -> %w21
+19c6b2f6 : ldapursb w22, [x23, #107]                 : ldapursb +0x6b(%x23)[1byte] -> %w22
+19c7b317 : ldapursb w23, [x24, #123]                 : ldapursb +0x7b(%x24)[1byte] -> %w23
+19c8c338 : ldapursb w24, [x25, #140]                 : ldapursb +0x8c(%x25)[1byte] -> %w24
+19c9c359 : ldapursb w25, [x26, #156]                 : ldapursb +0x9c(%x26)[1byte] -> %w25
+19cad37a : ldapursb w26, [x27, #173]                 : ldapursb +0xad(%x27)[1byte] -> %w26
+19cbd39b : ldapursb w27, [x28, #189]                 : ldapursb +0xbd(%x28)[1byte] -> %w27
+19cce3bc : ldapursb w28, [x29, #206]                 : ldapursb +0xce(%x29)[1byte] -> %w28
+19cde3dd : ldapursb w29, [x30, #222]                 : ldapursb +0xde(%x30)[1byte] -> %w29
+19cef3fe : ldapursb w30, [sp, #239]                  : ldapursb +0xef(%sp)[1byte] -> %w30
+19cff01f : ldapursb wzr, [x0, #255]                  : ldapursb +0xff(%x0)[1byte] -> %wzr
 
 # LDAPURSB  <Xt>, [<Xn|SP>{, #<simm>}]
 19900020 : ldapursb x0, [x1, #-256]                  : ldapursb -0x0100(%x1)[1byte] -> %x0
@@ -371,6 +238,40 @@ d94ff01f : ldapur xzr, [x0, #255]                    : ldapur +0xff(%x0)[8byte] 
 198de3dd : ldapursb x29, [x30, #222]                 : ldapursb +0xde(%x30)[1byte] -> %x29
 198ef3fe : ldapursb x30, [sp, #239]                  : ldapursb +0xef(%sp)[1byte] -> %x30
 198ff01f : ldapursb xzr, [x0, #255]                  : ldapursb +0xff(%x0)[1byte] -> %xzr
+
+# LDAPURSH  <Wt>, [<Xn|SP>{, #<simm>}]
+59d00020 : ldapursh w0, [x1, #-256]                  : ldapursh -0x0100(%x1)[2byte] -> %w0
+59d10041 : ldapursh w1, [x2, #-240]                  : ldapursh -0xf0(%x2)[2byte] -> %w1
+59d21062 : ldapursh w2, [x3, #-223]                  : ldapursh -0xdf(%x3)[2byte] -> %w2
+59d31083 : ldapursh w3, [x4, #-207]                  : ldapursh -0xcf(%x4)[2byte] -> %w3
+59d420a4 : ldapursh w4, [x5, #-190]                  : ldapursh -0xbe(%x5)[2byte] -> %w4
+59d520c5 : ldapursh w5, [x6, #-174]                  : ldapursh -0xae(%x6)[2byte] -> %w5
+59d630e6 : ldapursh w6, [x7, #-157]                  : ldapursh -0x9d(%x7)[2byte] -> %w6
+59d73107 : ldapursh w7, [x8, #-141]                  : ldapursh -0x8d(%x8)[2byte] -> %w7
+59d84128 : ldapursh w8, [x9, #-124]                  : ldapursh -0x7c(%x9)[2byte] -> %w8
+59d94149 : ldapursh w9, [x10, #-108]                 : ldapursh -0x6c(%x10)[2byte] -> %w9
+59da516a : ldapursh w10, [x11, #-91]                 : ldapursh -0x5b(%x11)[2byte] -> %w10
+59db518b : ldapursh w11, [x12, #-75]                 : ldapursh -0x4b(%x12)[2byte] -> %w11
+59dc61ac : ldapursh w12, [x13, #-58]                 : ldapursh -0x3a(%x13)[2byte] -> %w12
+59dd61cd : ldapursh w13, [x14, #-42]                 : ldapursh -0x2a(%x14)[2byte] -> %w13
+59de71ee : ldapursh w14, [x15, #-25]                 : ldapursh -0x19(%x15)[2byte] -> %w14
+59df720f : ldapursh w15, [x16, #-9]                  : ldapursh -0x09(%x16)[2byte] -> %w15
+59c00230 : ldapursh w16, [x17]                       : ldapursh (%x17)[2byte] -> %w16
+59c18251 : ldapursh w17, [x18, #24]                  : ldapursh +0x18(%x18)[2byte] -> %w17
+59c29272 : ldapursh w18, [x19, #41]                  : ldapursh +0x29(%x19)[2byte] -> %w18
+59c39293 : ldapursh w19, [x20, #57]                  : ldapursh +0x39(%x20)[2byte] -> %w19
+59c4a2b4 : ldapursh w20, [x21, #74]                  : ldapursh +0x4a(%x21)[2byte] -> %w20
+59c5a2d5 : ldapursh w21, [x22, #90]                  : ldapursh +0x5a(%x22)[2byte] -> %w21
+59c6b2f6 : ldapursh w22, [x23, #107]                 : ldapursh +0x6b(%x23)[2byte] -> %w22
+59c7b317 : ldapursh w23, [x24, #123]                 : ldapursh +0x7b(%x24)[2byte] -> %w23
+59c8c338 : ldapursh w24, [x25, #140]                 : ldapursh +0x8c(%x25)[2byte] -> %w24
+59c9c359 : ldapursh w25, [x26, #156]                 : ldapursh +0x9c(%x26)[2byte] -> %w25
+59cad37a : ldapursh w26, [x27, #173]                 : ldapursh +0xad(%x27)[2byte] -> %w26
+59cbd39b : ldapursh w27, [x28, #189]                 : ldapursh +0xbd(%x28)[2byte] -> %w27
+59cce3bc : ldapursh w28, [x29, #206]                 : ldapursh +0xce(%x29)[2byte] -> %w28
+59cde3dd : ldapursh w29, [x30, #222]                 : ldapursh +0xde(%x30)[2byte] -> %w29
+59cef3fe : ldapursh w30, [sp, #239]                  : ldapursh +0xef(%sp)[2byte] -> %w30
+59cff01f : ldapursh wzr, [x0, #255]                  : ldapursh +0xff(%x0)[2byte] -> %wzr
 
 # LDAPURSH  <Xt>, [<Xn|SP>{, #<simm>}]
 59900020 : ldapursh x0, [x1, #-256]                  : ldapursh -0x0100(%x1)[2byte] -> %x0
@@ -440,6 +341,94 @@ d94ff01f : ldapur xzr, [x0, #255]                    : ldapur +0xff(%x0)[8byte] 
 998ef3fe : ldapursw x30, [sp, #239]                  : ldapursw +0xef(%sp)[4byte] -> %x30
 998ff01f : ldapursw xzr, [x0, #255]                  : ldapursw +0xff(%x0)[4byte] -> %xzr
 
+# RMIF    <Xn>, #<imm1>, #<imm2> (RMIF-RII-flags)
+ba000400 : rmif x0, #0x0, #0x0                       : rmif   %x0 $0x00 $0x00
+ba020441 : rmif x2, #0x4, #0x1                       : rmif   %x2 $0x04 $0x01
+ba040482 : rmif x4, #0x8, #0x2                       : rmif   %x4 $0x08 $0x02
+ba0604c3 : rmif x6, #0xc, #0x3                       : rmif   %x6 $0x0c $0x03
+ba080504 : rmif x8, #0x10, #0x4                      : rmif   %x8 $0x10 $0x04
+ba0a0525 : rmif x9, #0x14, #0x5                      : rmif   %x9 $0x14 $0x05
+ba0c0566 : rmif x11, #0x18, #0x6                     : rmif   %x11 $0x18 $0x06
+ba0e05a7 : rmif x13, #0x1c, #0x7                     : rmif   %x13 $0x1c $0x07
+ba1005e8 : rmif x15, #0x20, #0x8                     : rmif   %x15 $0x20 $0x08
+ba118628 : rmif x17, #0x23, #0x8                     : rmif   %x17 $0x23 $0x08
+ba138669 : rmif x19, #0x27, #0x9                     : rmif   %x19 $0x27 $0x09
+ba1586aa : rmif x21, #0x2b, #0xa                     : rmif   %x21 $0x2b $0x0a
+ba1786cb : rmif x22, #0x2f, #0xb                     : rmif   %x22 $0x2f $0x0b
+ba19870c : rmif x24, #0x33, #0xc                     : rmif   %x24 $0x33 $0x0c
+ba1b874d : rmif x26, #0x37, #0xd                     : rmif   %x26 $0x37 $0x0d
+ba1f87cf : rmif x30, #0x3f, #0xf                     : rmif   %x30 $0x3f $0x0f
+
+# SETF16  <Wn> (SETF16-R-flags)
+3a00480d : setf16 w0                                 : setf16 %w0
+3a00484d : setf16 w2                                 : setf16 %w2
+3a00488d : setf16 w4                                 : setf16 %w4
+3a0048cd : setf16 w6                                 : setf16 %w6
+3a00490d : setf16 w8                                 : setf16 %w8
+3a00492d : setf16 w9                                 : setf16 %w9
+3a00496d : setf16 w11                                : setf16 %w11
+3a0049ad : setf16 w13                                : setf16 %w13
+3a0049ed : setf16 w15                                : setf16 %w15
+3a004a2d : setf16 w17                                : setf16 %w17
+3a004a6d : setf16 w19                                : setf16 %w19
+3a004aad : setf16 w21                                : setf16 %w21
+3a004acd : setf16 w22                                : setf16 %w22
+3a004b0d : setf16 w24                                : setf16 %w24
+3a004b4d : setf16 w26                                : setf16 %w26
+3a004bcd : setf16 w30                                : setf16 %w30
+
+# SETF8   <Wn> (SETF8-R-flags)
+3a00080d : setf8 w0                                  : setf8  %w0
+3a00084d : setf8 w2                                  : setf8  %w2
+3a00088d : setf8 w4                                  : setf8  %w4
+3a0008cd : setf8 w6                                  : setf8  %w6
+3a00090d : setf8 w8                                  : setf8  %w8
+3a00092d : setf8 w9                                  : setf8  %w9
+3a00096d : setf8 w11                                 : setf8  %w11
+3a0009ad : setf8 w13                                 : setf8  %w13
+3a0009ed : setf8 w15                                 : setf8  %w15
+3a000a2d : setf8 w17                                 : setf8  %w17
+3a000a6d : setf8 w19                                 : setf8  %w19
+3a000aad : setf8 w21                                 : setf8  %w21
+3a000acd : setf8 w22                                 : setf8  %w22
+3a000b0d : setf8 w24                                 : setf8  %w24
+3a000b4d : setf8 w26                                 : setf8  %w26
+3a000bcd : setf8 w30                                 : setf8  %w30
+
+# STLUR     <Wt>, [<Xn|SP>{, #<simm>}]
+99100020 : stlur w0, [x1, #-256]                     : stlur  %w0 -> -0x0100(%x1)[4byte]
+99110041 : stlur w1, [x2, #-240]                     : stlur  %w1 -> -0xf0(%x2)[4byte]
+99121062 : stlur w2, [x3, #-223]                     : stlur  %w2 -> -0xdf(%x3)[4byte]
+99131083 : stlur w3, [x4, #-207]                     : stlur  %w3 -> -0xcf(%x4)[4byte]
+991420a4 : stlur w4, [x5, #-190]                     : stlur  %w4 -> -0xbe(%x5)[4byte]
+991520c5 : stlur w5, [x6, #-174]                     : stlur  %w5 -> -0xae(%x6)[4byte]
+991630e6 : stlur w6, [x7, #-157]                     : stlur  %w6 -> -0x9d(%x7)[4byte]
+99173107 : stlur w7, [x8, #-141]                     : stlur  %w7 -> -0x8d(%x8)[4byte]
+99184128 : stlur w8, [x9, #-124]                     : stlur  %w8 -> -0x7c(%x9)[4byte]
+99194149 : stlur w9, [x10, #-108]                    : stlur  %w9 -> -0x6c(%x10)[4byte]
+991a516a : stlur w10, [x11, #-91]                    : stlur  %w10 -> -0x5b(%x11)[4byte]
+991b518b : stlur w11, [x12, #-75]                    : stlur  %w11 -> -0x4b(%x12)[4byte]
+991c61ac : stlur w12, [x13, #-58]                    : stlur  %w12 -> -0x3a(%x13)[4byte]
+991d61cd : stlur w13, [x14, #-42]                    : stlur  %w13 -> -0x2a(%x14)[4byte]
+991e71ee : stlur w14, [x15, #-25]                    : stlur  %w14 -> -0x19(%x15)[4byte]
+991f720f : stlur w15, [x16, #-9]                     : stlur  %w15 -> -0x09(%x16)[4byte]
+99000230 : stlur w16, [x17]                          : stlur  %w16 -> (%x17)[4byte]
+99018251 : stlur w17, [x18, #24]                     : stlur  %w17 -> +0x18(%x18)[4byte]
+99029272 : stlur w18, [x19, #41]                     : stlur  %w18 -> +0x29(%x19)[4byte]
+99039293 : stlur w19, [x20, #57]                     : stlur  %w19 -> +0x39(%x20)[4byte]
+9904a2b4 : stlur w20, [x21, #74]                     : stlur  %w20 -> +0x4a(%x21)[4byte]
+9905a2d5 : stlur w21, [x22, #90]                     : stlur  %w21 -> +0x5a(%x22)[4byte]
+9906b2f6 : stlur w22, [x23, #107]                    : stlur  %w22 -> +0x6b(%x23)[4byte]
+9907b317 : stlur w23, [x24, #123]                    : stlur  %w23 -> +0x7b(%x24)[4byte]
+9908c338 : stlur w24, [x25, #140]                    : stlur  %w24 -> +0x8c(%x25)[4byte]
+9909c359 : stlur w25, [x26, #156]                    : stlur  %w25 -> +0x9c(%x26)[4byte]
+990ad37a : stlur w26, [x27, #173]                    : stlur  %w26 -> +0xad(%x27)[4byte]
+990bd39b : stlur w27, [x28, #189]                    : stlur  %w27 -> +0xbd(%x28)[4byte]
+990ce3bc : stlur w28, [x29, #206]                    : stlur  %w28 -> +0xce(%x29)[4byte]
+990de3dd : stlur w29, [x30, #222]                    : stlur  %w29 -> +0xde(%x30)[4byte]
+990ef3fe : stlur w30, [sp, #239]                     : stlur  %w30 -> +0xef(%sp)[4byte]
+990ff01f : stlur wzr, [x0, #255]                     : stlur  %wzr -> +0xff(%x0)[4byte]
+
 # STLUR     <Xt>, [<Xn|SP>{, #<simm>}]
 d9100020 : stlur x0, [x1, #-256]                     : stlur  %x0 -> -0x0100(%x1)[8byte]
 d9110041 : stlur x1, [x2, #-240]                     : stlur  %x1 -> -0xf0(%x2)[8byte]
@@ -473,4 +462,72 @@ d90ce3bc : stlur x28, [x29, #206]                    : stlur  %x28 -> +0xce(%x29
 d90de3dd : stlur x29, [x30, #222]                    : stlur  %x29 -> +0xde(%x30)[8byte]
 d90ef3fe : stlur x30, [sp, #239]                     : stlur  %x30 -> +0xef(%sp)[8byte]
 d90ff01f : stlur xzr, [x0, #255]                     : stlur  %xzr -> +0xff(%x0)[8byte]
+
+# STLURB    <Wt>, [<Xn|SP>{, #<simm>}]
+19100020 : stlurb w0, [x1, #-256]                    : stlurb %w0 -> -0x0100(%x1)[1byte]
+19110041 : stlurb w1, [x2, #-240]                    : stlurb %w1 -> -0xf0(%x2)[1byte]
+19121062 : stlurb w2, [x3, #-223]                    : stlurb %w2 -> -0xdf(%x3)[1byte]
+19131083 : stlurb w3, [x4, #-207]                    : stlurb %w3 -> -0xcf(%x4)[1byte]
+191420a4 : stlurb w4, [x5, #-190]                    : stlurb %w4 -> -0xbe(%x5)[1byte]
+191520c5 : stlurb w5, [x6, #-174]                    : stlurb %w5 -> -0xae(%x6)[1byte]
+191630e6 : stlurb w6, [x7, #-157]                    : stlurb %w6 -> -0x9d(%x7)[1byte]
+19173107 : stlurb w7, [x8, #-141]                    : stlurb %w7 -> -0x8d(%x8)[1byte]
+19184128 : stlurb w8, [x9, #-124]                    : stlurb %w8 -> -0x7c(%x9)[1byte]
+19194149 : stlurb w9, [x10, #-108]                   : stlurb %w9 -> -0x6c(%x10)[1byte]
+191a516a : stlurb w10, [x11, #-91]                   : stlurb %w10 -> -0x5b(%x11)[1byte]
+191b518b : stlurb w11, [x12, #-75]                   : stlurb %w11 -> -0x4b(%x12)[1byte]
+191c61ac : stlurb w12, [x13, #-58]                   : stlurb %w12 -> -0x3a(%x13)[1byte]
+191d61cd : stlurb w13, [x14, #-42]                   : stlurb %w13 -> -0x2a(%x14)[1byte]
+191e71ee : stlurb w14, [x15, #-25]                   : stlurb %w14 -> -0x19(%x15)[1byte]
+191f720f : stlurb w15, [x16, #-9]                    : stlurb %w15 -> -0x09(%x16)[1byte]
+19000230 : stlurb w16, [x17]                         : stlurb %w16 -> (%x17)[1byte]
+19018251 : stlurb w17, [x18, #24]                    : stlurb %w17 -> +0x18(%x18)[1byte]
+19029272 : stlurb w18, [x19, #41]                    : stlurb %w18 -> +0x29(%x19)[1byte]
+19039293 : stlurb w19, [x20, #57]                    : stlurb %w19 -> +0x39(%x20)[1byte]
+1904a2b4 : stlurb w20, [x21, #74]                    : stlurb %w20 -> +0x4a(%x21)[1byte]
+1905a2d5 : stlurb w21, [x22, #90]                    : stlurb %w21 -> +0x5a(%x22)[1byte]
+1906b2f6 : stlurb w22, [x23, #107]                   : stlurb %w22 -> +0x6b(%x23)[1byte]
+1907b317 : stlurb w23, [x24, #123]                   : stlurb %w23 -> +0x7b(%x24)[1byte]
+1908c338 : stlurb w24, [x25, #140]                   : stlurb %w24 -> +0x8c(%x25)[1byte]
+1909c359 : stlurb w25, [x26, #156]                   : stlurb %w25 -> +0x9c(%x26)[1byte]
+190ad37a : stlurb w26, [x27, #173]                   : stlurb %w26 -> +0xad(%x27)[1byte]
+190bd39b : stlurb w27, [x28, #189]                   : stlurb %w27 -> +0xbd(%x28)[1byte]
+190ce3bc : stlurb w28, [x29, #206]                   : stlurb %w28 -> +0xce(%x29)[1byte]
+190de3dd : stlurb w29, [x30, #222]                   : stlurb %w29 -> +0xde(%x30)[1byte]
+190ef3fe : stlurb w30, [sp, #239]                    : stlurb %w30 -> +0xef(%sp)[1byte]
+190ff01f : stlurb wzr, [x0, #255]                    : stlurb %wzr -> +0xff(%x0)[1byte]
+
+# STLURH    <Wt>, [<Xn|SP>{, #<simm>}]
+59100020 : stlurh w0, [x1, #-256]                    : stlurh %w0 -> -0x0100(%x1)[2byte]
+59110041 : stlurh w1, [x2, #-240]                    : stlurh %w1 -> -0xf0(%x2)[2byte]
+59121062 : stlurh w2, [x3, #-223]                    : stlurh %w2 -> -0xdf(%x3)[2byte]
+59131083 : stlurh w3, [x4, #-207]                    : stlurh %w3 -> -0xcf(%x4)[2byte]
+591420a4 : stlurh w4, [x5, #-190]                    : stlurh %w4 -> -0xbe(%x5)[2byte]
+591520c5 : stlurh w5, [x6, #-174]                    : stlurh %w5 -> -0xae(%x6)[2byte]
+591630e6 : stlurh w6, [x7, #-157]                    : stlurh %w6 -> -0x9d(%x7)[2byte]
+59173107 : stlurh w7, [x8, #-141]                    : stlurh %w7 -> -0x8d(%x8)[2byte]
+59184128 : stlurh w8, [x9, #-124]                    : stlurh %w8 -> -0x7c(%x9)[2byte]
+59194149 : stlurh w9, [x10, #-108]                   : stlurh %w9 -> -0x6c(%x10)[2byte]
+591a516a : stlurh w10, [x11, #-91]                   : stlurh %w10 -> -0x5b(%x11)[2byte]
+591b518b : stlurh w11, [x12, #-75]                   : stlurh %w11 -> -0x4b(%x12)[2byte]
+591c61ac : stlurh w12, [x13, #-58]                   : stlurh %w12 -> -0x3a(%x13)[2byte]
+591d61cd : stlurh w13, [x14, #-42]                   : stlurh %w13 -> -0x2a(%x14)[2byte]
+591e71ee : stlurh w14, [x15, #-25]                   : stlurh %w14 -> -0x19(%x15)[2byte]
+591f720f : stlurh w15, [x16, #-9]                    : stlurh %w15 -> -0x09(%x16)[2byte]
+59000230 : stlurh w16, [x17]                         : stlurh %w16 -> (%x17)[2byte]
+59018251 : stlurh w17, [x18, #24]                    : stlurh %w17 -> +0x18(%x18)[2byte]
+59029272 : stlurh w18, [x19, #41]                    : stlurh %w18 -> +0x29(%x19)[2byte]
+59039293 : stlurh w19, [x20, #57]                    : stlurh %w19 -> +0x39(%x20)[2byte]
+5904a2b4 : stlurh w20, [x21, #74]                    : stlurh %w20 -> +0x4a(%x21)[2byte]
+5905a2d5 : stlurh w21, [x22, #90]                    : stlurh %w21 -> +0x5a(%x22)[2byte]
+5906b2f6 : stlurh w22, [x23, #107]                   : stlurh %w22 -> +0x6b(%x23)[2byte]
+5907b317 : stlurh w23, [x24, #123]                   : stlurh %w23 -> +0x7b(%x24)[2byte]
+5908c338 : stlurh w24, [x25, #140]                   : stlurh %w24 -> +0x8c(%x25)[2byte]
+5909c359 : stlurh w25, [x26, #156]                   : stlurh %w25 -> +0x9c(%x26)[2byte]
+590ad37a : stlurh w26, [x27, #173]                   : stlurh %w26 -> +0xad(%x27)[2byte]
+590bd39b : stlurh w27, [x28, #189]                   : stlurh %w27 -> +0xbd(%x28)[2byte]
+590ce3bc : stlurh w28, [x29, #206]                   : stlurh %w28 -> +0xce(%x29)[2byte]
+590de3dd : stlurh w29, [x30, #222]                   : stlurh %w29 -> +0xde(%x30)[2byte]
+590ef3fe : stlurh w30, [sp, #239]                    : stlurh %w30 -> +0xef(%sp)[2byte]
+590ff01f : stlurh wzr, [x0, #255]                    : stlurh %wzr -> +0xff(%x0)[2byte]
 

--- a/suite/tests/api/ir_aarch64_v84.c
+++ b/suite/tests/api/ir_aarch64_v84.c
@@ -231,6 +231,46 @@ TEST_INSTR(stlurh)
         opnd_create_base_disp(Xn_six_offset_1_sp[i], DR_REG_NULL, 0, simm[i], OPSZ_2));
 }
 
+TEST_INSTR(cfinv)
+{
+    /* Testing CFINV */
+    TEST_NO_OPNDS(cfinv, cfinv, "cfinv");
+}
+
+TEST_INSTR(rmif)
+{
+    /* Testing RMIF    <Xn>, #<imm1>, #<imm2> */
+    static const uint imm6_0_0[6] = { 0, 11, 22, 33, 43, 63 };
+    static const uint mask_0_0[6] = { 0, 4, 7, 10, 12, 15 };
+    const char *const expected_0_0[6] = {
+        "rmif   %x0 $0x00 $0x00",  "rmif   %x5 $0x0b $0x04",  "rmif   %x10 $0x16 $0x07",
+        "rmif   %x15 $0x21 $0x0a", "rmif   %x20 $0x2b $0x0c", "rmif   %x30 $0x3f $0x0f",
+    };
+    TEST_LOOP(rmif, rmif, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_immed_uint(imm6_0_0[i], OPSZ_6b),
+              opnd_create_immed_uint(mask_0_0[i], OPSZ_4b));
+}
+
+TEST_INSTR(setf16)
+{
+    /* Testing SETF16  <Wn> */
+    const char *const expected_0_0[6] = {
+        "setf16 %w0",  "setf16 %w5",  "setf16 %w10",
+        "setf16 %w15", "setf16 %w20", "setf16 %w30",
+    };
+    TEST_LOOP(setf16, setf16, 6, expected_0_0[i], opnd_create_reg(Wn_six_offset_0[i]));
+}
+
+TEST_INSTR(setf8)
+{
+    /* Testing SETF8   <Wn> */
+    const char *const expected_0_0[6] = {
+        "setf8  %w0",  "setf8  %w5",  "setf8  %w10",
+        "setf8  %w15", "setf8  %w20", "setf8  %w30",
+    };
+    TEST_LOOP(setf8, setf8, 6, expected_0_0[i], opnd_create_reg(Wn_six_offset_0[i]));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -253,6 +293,12 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(stlur);
     RUN_INSTR_TEST(stlurb);
     RUN_INSTR_TEST(stlurh);
+
+    /* ARMv4-CondM */
+    RUN_INSTR_TEST(cfinv);
+    RUN_INSTR_TEST(rmif);
+    RUN_INSTR_TEST(setf16);
+    RUN_INSTR_TEST(setf8);
 
     print("All v8.4 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
CFINV
RMIF    <Xn>, #<imm1>, #<imm2>
SETF16  <Wn>
SETF8   <Wn>
```

Issue: #2626