### PR TITLE
Skip vera++ checks for build directory

### DIFF
--- a/third_party/vera++/use_vera++.cmake
+++ b/third_party/vera++/use_vera++.cmake
@@ -113,6 +113,7 @@ function(add_vera_targets_for_dynamorio)
         NOT s MATCHES "/third_party/" AND
         # Somehow on Travis vera checks build-dir files.
         NOT s MATCHES "/build_" AND
+        NOT s MATCHES ${CMAKE_CURRENT_BINARY_DIR} AND
         NOT s MATCHES "/install/" AND
         # We check out drmemory for package builds.
         NOT s MATCHES "/drmemory/")


### PR DESCRIPTION
vera++ complains for various files in the build directory when it is a sub-directory of the source directory.

Our documentation suggests creating a `build` directory inside the source directory, so this flow must work.