### PR TITLE
i#5934 Add 'Duplicate syscalls with the same PC' invariant check

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -67,6 +67,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'pull_request' }}
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -134,6 +134,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'pull_request' }}
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -134,9 +134,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'pull_request' }}
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -67,9 +67,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'pull_request' }}
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 
@@ -136,9 +133,6 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'pull_request' }}
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
 
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -137,6 +137,9 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'pull_request' }}
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+
     - name: Fetch Sources
       run: git fetch --no-tags --depth=1 origin master
 

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -464,52 +464,6 @@ check_function_markers()
 bool
 check_repeated_syscall_with_same_pc()
 {
-    // Negative: syscalls with the same PC.
-#if defined(X86_64) || defined(X86_32) || defined(ARM_64)
-    {
-        std::vector<memref_t> memrefs = {
-            gen_instr(1, 1),
-#    if defined(X86_64) || defined(X86_32)
-            gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
-#    elif defined(ARM_64)
-            gen_syscall_encoded(1, 2, 0xd4000001),
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, 2, 0xd4000001),
-#    else
-        // TODO i#5871: Add AArch32 (and RISC-V) encodings.
-#    endif
-        };
-        if (!run_checker(memrefs, true, 1, 5, "Repeated syscall instrs with the same PC",
-                         "Failed to catch repeated syscall instrs with the same PC"))
-            return false;
-    }
-    // Positive test: syscalls with different PCs.
-    {
-        std::vector<memref_t> memrefs = {
-            gen_instr(1, 1),
-#    if defined(X86_64) || defined(X86_32)
-            gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, 4, { 0x0f, 0x05 }),
-#    elif defined(ARM_64)
-            gen_syscall_encoded(1, 2, 0xd4000001),
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, 6, 0xd4000001),
-#    else
-        // TODO i#5871: Add AArch32 (and RISC-V) encodings.
-#    endif
-        };
-        if (!run_checker(memrefs, false)) {
-            return false;
-        }
-    }
-#endif
     return true;
 }
 

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -464,39 +464,52 @@ check_function_markers()
 bool
 check_repeated_syscall_with_same_pc()
 {
-      // Negative: syscalls with the same PC.
+    // Negative: syscalls with the same PC.
+#if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
         std::vector<memref_t> memrefs = {
             gen_instr(1, 1),
 #    if defined(X86_64) || defined(X86_32)
-            gen_syscall_encoded(1, 2, { 0x0f, 0x05 } ),
-            gen_syscall_encoded(1, 2, { 0x0f, 0x05 } ),
+            gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
 #    elif defined(ARM_64)
-            gen_branch_encoded(1, 2, 0x14000e0e),
-            gen_branch_encoded(1, 2, 0x14000e0e),
-#    endif
+            gen_syscall_encoded(1, 2, 0xd4000001),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_syscall_encoded(1, 2, 0xd4000001),
+#    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
+#    endif
         };
-        if (!run_checker(memrefs, true, 1, 3, "Repeated syscall instrs with the same PC",
+        if (!run_checker(memrefs, true, 1, 5, "Repeated syscall instrs with the same PC",
                          "Failed to catch repeated syscall instrs with the same PC"))
             return false;
     }
     // Positive test: syscalls with different PCs.
     {
         std::vector<memref_t> memrefs = {
+            gen_instr(1, 1),
 #    if defined(X86_64) || defined(X86_32)
             gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 4, { 0x0f, 0x05 }),
 #    elif defined(ARM_64)
-            gen_branch_encoded(1, 2, 0x14000e0e),
-            gen_branch_encoded(1, 4, 0x14000e0e),
-#    endif
+            gen_syscall_encoded(1, 2, 0xd4000001),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_syscall_encoded(1, 6, 0xd4000001),
+#    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
+#    endif
         };
         if (!run_checker(memrefs, false)) {
             return false;
         }
     }
+#endif
     return true;
 }
 

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -530,7 +530,8 @@ int
 main(int argc, const char *argv[])
 {
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
-        check_kernel_xfer() && check_rseq() && check_function_markers()) {
+        check_kernel_xfer() && check_rseq() && check_function_markers() &&
+        check_repeated_syscall_with_same_pc()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -464,6 +464,7 @@ check_function_markers()
 bool
 check_repeated_syscall_with_same_pc()
 {
+#ifdef UNIX
     // Negative: syscalls with the same PC.
 #if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
@@ -509,6 +510,7 @@ check_repeated_syscall_with_same_pc()
             return false;
         }
     }
+#endif
 #endif
     return true;
 }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -466,6 +466,7 @@ check_repeated_syscall_with_same_pc()
 {
     constexpr addr_t ADDR_ONE = 0x7fcf3b9dd9e9;
     constexpr addr_t ADDR_TWO = 0x7fcf3b9dd9eb;
+    constexpr addr_t ADDR_THREE = 0x7fcf3b9dd9ed;
     // Negative: syscalls with the same PC.
 #if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
@@ -477,17 +478,19 @@ check_repeated_syscall_with_same_pc()
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
+            gen_instr_encoded(1 /*tid*/, ADDR_TWO /*pc*/, { 0x01 }),
 #    elif defined(ARM_64)
             gen_instr_encoded(1 /*tid*/, 0 /*pc*/, 0x01),
             gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
+            gen_instr_encoded(1 /*tid*/, ADDR_TWO /*pc*/, 0x01),
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
         };
-        if (!run_checker(memrefs, true, 1, 6, "Repeated syscall instrs with the same PC",
+        if (!run_checker(memrefs, true, 1, 7, "Repeated syscall instrs with the same PC",
                          "Failed to catch repeated syscall instrs with the same PC"))
             return false;
     }
@@ -502,12 +505,14 @@ check_repeated_syscall_with_same_pc()
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(1, ADDR_TWO, { 0x0f, 0x05 }),
+            gen_instr_encoded(1 /*tid*/, ADDR_THREE /*pc*/, { 0x01 }),
 #    elif defined(ARM_64)
             gen_instr_encoded(1 /*tid*/, 0 /*pc*/, 0x01),
             gen_instr_encoded(1, ADDR_ONE, 0xd4000001, 2),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(1, ADDR_TWO, 0xd4000001, 2),
+            gen_instr_encoded(1 /*tid*/, ADDR_THREE /*pc*/, 0x01),
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -465,32 +465,30 @@ bool
 check_repeated_syscall_with_same_pc()
 {
     constexpr addr_t ADDR_ONE = 0x7fcf3b9dd9e9;
-    constexpr addr_t ADDR_TWO = 0x7fcf3b9dd9eb;
-    constexpr addr_t ADDR_THREE = 0x7fcf3b9dd9ed;
     // Negative: syscalls with the same PC.
 #if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
-            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, { 0x01 }),
-            gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
+            gen_instr_encoded(0, { 0x01 }),
+            gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
-            gen_instr_encoded(1 /*tid*/, ADDR_TWO /*pc*/, { 0x01 }),
+            gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
 #    elif defined(ARM_64)
-            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, 0x01),
-            gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
+            gen_instr_encoded(0, 0x01),
+            gen_instr_encoded(ADDR_ONE,
+                              0xd4000001), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
-            gen_instr_encoded(1 /*tid*/, ADDR_TWO /*pc*/, 0x01),
+            gen_instr_encoded(ADDR_ONE,
+                              0xd4000001), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
         };
-        if (!run_checker(memrefs, true, 1, 7, "Repeated syscall instrs with the same PC",
+        if (!run_checker(memrefs, true, 1, 6, "Repeated syscall instrs with the same PC",
                          "Failed to catch repeated syscall instrs with the same PC"))
             return false;
     }
@@ -500,19 +498,20 @@ check_repeated_syscall_with_same_pc()
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
-            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, { 0x01 }),
-            gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
+            gen_instr_encoded(0, { 0x01 }),
+            gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(1, ADDR_TWO, { 0x0f, 0x05 }),
-            gen_instr_encoded(1 /*tid*/, ADDR_THREE /*pc*/, { 0x01 }),
+            gen_instr_encoded(ADDR_ONE + 2,
+                              { 0x0f, 0x05 }), // 0x7fcf3b9dd9eb: 0f 05    syscall
 #    elif defined(ARM_64)
-            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, 0x01),
-            gen_instr_encoded(1, ADDR_ONE, 0xd4000001, 2),
+            gen_instr_encoded(0, 0x01),
+            gen_instr_encoded(ADDR_ONE, 0xd4000001,
+                              2), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(1, ADDR_TWO, 0xd4000001, 2),
-            gen_instr_encoded(1 /*tid*/, ADDR_THREE /*pc*/, 0x01),
+            gen_instr_encoded(ADDR_ONE + 4, 0xd4000001,
+                              2), // 0x7fcf3b9dd9eb: 0xd4000001 svc #0x0
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
@@ -531,8 +530,7 @@ int
 main(int argc, const char *argv[])
 {
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
-        check_kernel_xfer() && check_rseq() && check_function_markers() &&
-        check_repeated_syscall_with_same_pc()) {
+        check_kernel_xfer() && check_rseq() && check_function_markers()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -215,10 +215,8 @@ check_sane_control_flow()
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
             // 0x74 is "je" with the 2nd byte the offset.
-            gen_instr_encoded(0x71019dba, { 0x20 }),
             gen_branch_encoded(1, 0x71019dbc, { 0x74, 0x32 }),
 #    elif defined(ARM_64)
-            gen_instr_encoded(0x71019db9, 0x20),
             // 71019dbc:   540001a1        b.ne    71019df0 <__executable_start+0x19df0>
             gen_branch_encoded(1, 0x71019dbc, 0x540001a1),
 #    else
@@ -473,13 +471,11 @@ check_repeated_syscall_with_same_pc()
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
-            gen_instr_encoded(0, { 0x01 }),
             gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
 #    elif defined(ARM_64)
-            gen_instr_encoded(0, 0x01),
             gen_instr_encoded(ADDR_ONE,
                               0xd4000001), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
@@ -490,7 +486,7 @@ check_repeated_syscall_with_same_pc()
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
         };
-        if (!run_checker(memrefs, true, 1, 6, "Repeated syscall instrs with the same PC",
+        if (!run_checker(memrefs, true, 1, 5, "Repeated syscall instrs with the same PC",
                          "Failed to catch repeated syscall instrs with the same PC"))
             return false;
     }
@@ -500,16 +496,14 @@ check_repeated_syscall_with_same_pc()
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
-            gen_instr_encoded(0, { 0x01 }),
             gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR_ONE + 2,
                               { 0x0f, 0x05 }), // 0x7fcf3b9dd9eb: 0f 05    syscall
 #    elif defined(ARM_64)
-            gen_instr_encoded(0, 0x01),
             gen_instr_encoded(ADDR_ONE, 0xd4000001,
-                              2), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
+                              2),          // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR_ONE + 4, 0xd4000001,

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -466,23 +466,23 @@ check_repeated_syscall_with_same_pc()
 {
 #ifdef UNIX
     // Negative: syscalls with the same PC.
-#if defined(X86_64) || defined(X86_32) || defined(ARM_64)
+#    if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
         std::vector<memref_t> memrefs = {
             gen_instr(1, 1),
-#    if defined(X86_64) || defined(X86_32)
+#        if defined(X86_64) || defined(X86_32)
             gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
-#    elif defined(ARM_64)
+#        elif defined(ARM_64)
             gen_syscall_encoded(1, 2, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 2, 0xd4000001),
-#    else
+#        else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
-#    endif
+#        endif
         };
         if (!run_checker(memrefs, true, 1, 5, "Repeated syscall instrs with the same PC",
                          "Failed to catch repeated syscall instrs with the same PC"))
@@ -492,25 +492,25 @@ check_repeated_syscall_with_same_pc()
     {
         std::vector<memref_t> memrefs = {
             gen_instr(1, 1),
-#    if defined(X86_64) || defined(X86_32)
+#        if defined(X86_64) || defined(X86_32)
             gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 4, { 0x0f, 0x05 }),
-#    elif defined(ARM_64)
+#        elif defined(ARM_64)
             gen_syscall_encoded(1, 2, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 6, 0xd4000001),
-#    else
+#        else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
-#    endif
+#        endif
         };
         if (!run_checker(memrefs, false)) {
             return false;
         }
     }
-#endif
+#    endif
 #endif
     return true;
 }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -464,25 +464,24 @@ check_function_markers()
 bool
 check_repeated_syscall_with_same_pc()
 {
-#ifdef UNIX
     // Negative: syscalls with the same PC.
-#    if defined(X86_64) || defined(X86_32) || defined(ARM_64)
+#if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
         std::vector<memref_t> memrefs = {
             gen_instr(1, 1),
-#        if defined(X86_64) || defined(X86_32)
+#    if defined(X86_64) || defined(X86_32)
             gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
-#        elif defined(ARM_64)
+#    elif defined(ARM_64)
             gen_syscall_encoded(1, 2, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 2, 0xd4000001),
-#        else
+#    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
-#        endif
+#    endif
         };
         if (!run_checker(memrefs, true, 1, 5, "Repeated syscall instrs with the same PC",
                          "Failed to catch repeated syscall instrs with the same PC"))
@@ -492,25 +491,24 @@ check_repeated_syscall_with_same_pc()
     {
         std::vector<memref_t> memrefs = {
             gen_instr(1, 1),
-#        if defined(X86_64) || defined(X86_32)
+#    if defined(X86_64) || defined(X86_32)
             gen_syscall_encoded(1, 2, { 0x0f, 0x05 }),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 4, { 0x0f, 0x05 }),
-#        elif defined(ARM_64)
+#    elif defined(ARM_64)
             gen_syscall_encoded(1, 2, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, 6, 0xd4000001),
-#        else
+#    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
-#        endif
+#    endif
         };
         if (!run_checker(memrefs, false)) {
             return false;
         }
     }
-#    endif
 #endif
     return true;
 }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -215,8 +215,10 @@ check_sane_control_flow()
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
             // 0x74 is "je" with the 2nd byte the offset.
+            gen_instr_encoded(0x71019dba, { 0x20 }),
             gen_branch_encoded(1, 0x71019dbc, { 0x74, 0x32 }),
 #    elif defined(ARM_64)
+            gen_instr_encoded(0x71019db9, 0x20),
             // 71019dbc:   540001a1        b.ne    71019df0 <__executable_start+0x19df0>
             gen_branch_encoded(1, 0x71019dbc, 0x540001a1),
 #    else

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -478,6 +478,7 @@ check_repeated_syscall_with_same_pc()
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
 #    elif defined(ARM_64)
+            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, 0x01),
             gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
@@ -503,10 +504,10 @@ check_repeated_syscall_with_same_pc()
             gen_instr_encoded(1, ADDR_TWO, { 0x0f, 0x05 }),
 #    elif defined(ARM_64)
             gen_instr_encoded(1 /*tid*/, 0 /*pc*/, 0x01),
-            gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
+            gen_instr_encoded(1, ADDR_ONE, 0xd4000001, 2),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(1, ADDR_TWO + 2, 0xd4000001),
+            gen_instr_encoded(1, ADDR_TWO, 0xd4000001, 2),
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -464,7 +464,7 @@ check_function_markers()
 }
 
 bool
-check_double_syscall_with_same_pc()
+check_duplicate_syscall_with_same_pc()
 {
     constexpr addr_t ADDR = 0x7fcf3b9dd9e9;
     // Negative: syscalls with the same PC.
@@ -488,7 +488,7 @@ check_double_syscall_with_same_pc()
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
         };
-        if (!run_checker(memrefs, true, 1, 5, "Double syscall instrs with the same PC",
+        if (!run_checker(memrefs, true, 1, 5, "Duplicate syscall instrs with the same PC",
                          "Failed to catch double syscall instrs with the same PC"))
             return false;
     }
@@ -528,7 +528,7 @@ main(int argc, const char *argv[])
 {
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
         check_kernel_xfer() && check_rseq() && check_function_markers() &&
-        check_double_syscall_with_same_pc()) {
+        check_duplicate_syscall_with_same_pc()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -466,30 +466,22 @@ check_repeated_syscall_with_same_pc()
 {
     constexpr addr_t ADDR_ONE = 0x7fcf3b9dd9e9;
     constexpr addr_t ADDR_TWO = 0x7fcf3b9dd9eb;
-    const std::vector<char> encoding = { 0x01 };
-    // TODO i#5949: Add generic function for creating encoded instrs.
-    memref_t encoded_instr =
-        gen_instr_type(TRACE_TYPE_INSTR, 1 /*tid*/, 0 /*pc*/, 1 /*size*/);
-    encoded_instr.instr.type = TRACE_TYPE_INSTR;
-    memcpy(encoded_instr.instr.encoding, &encoding, sizeof(encoding));
-    encoded_instr.instr.encoding_is_new = true;
-
     // Negative: syscalls with the same PC.
 #if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
-            encoded_instr,
 #    if defined(X86_64) || defined(X86_32)
-            gen_syscall_encoded(1, ADDR_ONE),
+            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, { 0x01 }),
+            gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, ADDR_ONE),
+            gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
 #    elif defined(ARM_64)
-            gen_syscall_encoded(1, ADDR_ONE),
+            gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, ADDR_ONE)
+            gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
@@ -503,17 +495,18 @@ check_repeated_syscall_with_same_pc()
     {
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
-            encoded_instr,
 #    if defined(X86_64) || defined(X86_32)
-            gen_syscall_encoded(1, ADDR_ONE),
+            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, { 0x01 }),
+            gen_instr_encoded(1, ADDR_ONE, { 0x0f, 0x05 }),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, ADDR_TWO),
+            gen_instr_encoded(1, ADDR_TWO, { 0x0f, 0x05 }),
 #    elif defined(ARM_64)
-            gen_syscall_encoded(1, ADDR_ONE),
+            gen_instr_encoded(1 /*tid*/, 0 /*pc*/, 0x01),
+            gen_instr_encoded(1, ADDR_ONE, 0xd4000001),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, ADDR_TWO + 2),
+            gen_instr_encoded(1, ADDR_TWO + 2, 0xd4000001),
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -503,7 +503,7 @@ check_repeated_syscall_with_same_pc()
                               { 0x0f, 0x05 }), // 0x7fcf3b9dd9eb: 0f 05    syscall
 #    elif defined(ARM_64)
             gen_instr_encoded(ADDR_ONE, 0xd4000001,
-                              2),          // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
+                              2), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR_ONE + 4, 0xd4000001,

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -464,32 +464,32 @@ check_function_markers()
 }
 
 bool
-check_repeated_syscall_with_same_pc()
+check_double_syscall_with_same_pc()
 {
-    constexpr addr_t ADDR_ONE = 0x7fcf3b9dd9e9;
+    constexpr addr_t ADDR = 0x7fcf3b9dd9e9;
     // Negative: syscalls with the same PC.
 #if defined(X86_64) || defined(X86_32) || defined(ARM_64)
     {
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
-            gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
+            gen_instr_encoded(ADDR, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
+            gen_instr_encoded(ADDR, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
 #    elif defined(ARM_64)
-            gen_instr_encoded(ADDR_ONE,
+            gen_instr_encoded(ADDR,
                               0xd4000001), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(ADDR_ONE,
+            gen_instr_encoded(ADDR,
                               0xd4000001), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
         };
-        if (!run_checker(memrefs, true, 1, 5, "Repeated syscall instrs with the same PC",
-                         "Failed to catch repeated syscall instrs with the same PC"))
+        if (!run_checker(memrefs, true, 1, 5, "Double syscall instrs with the same PC",
+                         "Failed to catch double syscall instrs with the same PC"))
             return false;
     }
 
@@ -498,17 +498,16 @@ check_repeated_syscall_with_same_pc()
         std::vector<memref_t> memrefs = {
             gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
-            gen_instr_encoded(ADDR_ONE, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
+            gen_instr_encoded(ADDR, { 0x0f, 0x05 }), // 0x7fcf3b9dd9e9: 0f 05 syscall
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(ADDR_ONE + 2,
-                              { 0x0f, 0x05 }), // 0x7fcf3b9dd9eb: 0f 05    syscall
+            gen_instr_encoded(ADDR + 2, { 0x0f, 0x05 }), // 0x7fcf3b9dd9eb: 0f 05 syscall
 #    elif defined(ARM_64)
-            gen_instr_encoded(ADDR_ONE, 0xd4000001,
+            gen_instr_encoded(ADDR, 0xd4000001,
                               2), // 0x7fcf3b9dd9e9: 0xd4000001 svc #0x0
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_instr_encoded(ADDR_ONE + 4, 0xd4000001,
+            gen_instr_encoded(ADDR + 4, 0xd4000001,
                               2), // 0x7fcf3b9dd9eb: 0xd4000001 svc #0x0
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
@@ -529,7 +528,7 @@ main(int argc, const char *argv[])
 {
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
         check_kernel_xfer() && check_rseq() && check_function_markers() &&
-        check_repeated_syscall_with_same_pc()) {
+        check_double_syscall_with_same_pc()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -489,7 +489,7 @@ check_duplicate_syscall_with_same_pc()
 #    endif
         };
         if (!run_checker(memrefs, true, 1, 5, "Duplicate syscall instrs with the same PC",
-                         "Failed to catch double syscall instrs with the same PC"))
+                         "Failed to catch duplicate syscall instrs with the same PC"))
             return false;
     }
 

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -216,13 +216,14 @@ check_sane_control_flow()
 #    if defined(X86_64) || defined(X86_32)
             // 0x74 is "je" with the 2nd byte the offset.
             gen_branch_encoded(1, 0x71019dbc, { 0x74, 0x32 }),
+            gen_instr_encoded(0x71019ded, { 0x01 }),
 #    elif defined(ARM_64)
             // 71019dbc:   540001a1        b.ne    71019df0 <__executable_start+0x19df0>
             gen_branch_encoded(1, 0x71019dbc, 0x540001a1),
+            gen_instr_encoded(0x71019ded, 0x01),
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
-            gen_instr(1, 20),
         };
 
         if (!run_checker(memrefs, true, 1, 3,

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -502,6 +502,7 @@ check_repeated_syscall_with_same_pc()
     // Positive test: syscalls with different PCs.
     {
         std::vector<memref_t> memrefs = {
+            gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
             encoded_instr,
 #    if defined(X86_64) || defined(X86_32)
             gen_syscall_encoded(1, ADDR_ONE),
@@ -512,7 +513,7 @@ check_repeated_syscall_with_same_pc()
             gen_syscall_encoded(1, ADDR_ONE),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_syscall_encoded(1, ADDR_TWO),
+            gen_syscall_encoded(1, ADDR_TWO + 2),
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -486,7 +486,7 @@ check_repeated_syscall_with_same_pc()
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, ADDR_ONE),
 #    elif defined(ARM_64)
-            gen_syscall_encoded(1, ADDR_ONE)
+            gen_syscall_encoded(1, ADDR_ONE),
             gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_syscall_encoded(1, ADDR_ONE)

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -99,7 +99,6 @@ inline memref_t
 gen_instr_encoded(addr_t pc, const std::vector<char> &encoding, memref_tid_t tid = 1)
 {
     memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, encoding.size());
-    memref.instr.size = encoding.size();
     memcpy(memref.instr.encoding, encoding.data(), encoding.size());
     memref.instr.encoding_is_new = true;
     return memref;

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -100,7 +100,7 @@ gen_syscall_encoded(memref_tid_t tid, addr_t pc)
 inline memref_t
 gen_syscall_encoded(memref_tid_t tid, addr_t pc)
 {
-    const std::vector<char>encoding = { 0x0f, 0x05 };
+    const std::vector<char> encoding = { 0x0f, 0x05 };
     memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
     memref.instr.size = encoding.size();
     memcpy(memref.instr.encoding, encoding.data(), encoding.size());

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -76,6 +76,15 @@ gen_branch(memref_tid_t tid, addr_t pc)
 #if defined(ARM_64) || defined(ARM_32)
 // Variant for aarchxx encodings.
 inline memref_t
+gen_instr_encoded(memref_tid_t tid, addr_t pc, int encoding, size_t size = 1)
+{
+    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, size);
+    memcpy(memref.instr.encoding, &encoding, sizeof(encoding));
+    memref.instr.encoding_is_new = true;
+    return memref;
+}
+
+inline memref_t
 gen_branch_encoded(memref_tid_t tid, addr_t pc, int encoding)
 {
     memref_t memref = gen_instr_type(TRACE_TYPE_INSTR_CONDITIONAL_JUMP, tid, pc);
@@ -85,23 +94,12 @@ gen_branch_encoded(memref_tid_t tid, addr_t pc, int encoding)
     return memref;
 }
 
-inline memref_t
-gen_syscall_encoded(memref_tid_t tid, addr_t pc)
-{
-    constexpr int encoding = 0xd4000001;
-    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
-    memref.instr.size = 4;
-    memcpy(memref.instr.encoding, &encoding, sizeof(encoding));
-    memref.instr.encoding_is_new = true;
-    return memref;
-}
-
 #elif defined(X86_64) || defined(X86_32)
 inline memref_t
-gen_syscall_encoded(memref_tid_t tid, addr_t pc)
+gen_instr_encoded(memref_tid_t tid, addr_t pc, const std::vector<char> encoding,
+                  size_t size = 1)
 {
-    const std::vector<char> encoding = { 0x0f, 0x05 };
-    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
+    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, size);
     memref.instr.size = encoding.size();
     memcpy(memref.instr.encoding, encoding.data(), encoding.size());
     memref.instr.encoding_is_new = true;

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -76,9 +76,9 @@ gen_branch(memref_tid_t tid, addr_t pc)
 #if defined(ARM_64) || defined(ARM_32)
 // Variant for aarchxx encodings.
 inline memref_t
-gen_instr_encoded(memref_tid_t tid, addr_t pc, int encoding, size_t size = 1)
+gen_instr_encoded(addr_t pc, int encoding, memref_tid_t tid = 1)
 {
-    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, size);
+    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, 4);
     memcpy(memref.instr.encoding, &encoding, sizeof(encoding));
     memref.instr.encoding_is_new = true;
     return memref;
@@ -96,7 +96,7 @@ gen_branch_encoded(memref_tid_t tid, addr_t pc, int encoding)
 
 #elif defined(X86_64) || defined(X86_32)
 inline memref_t
-gen_instr_encoded(memref_tid_t tid, addr_t pc, const std::vector<char> encoding,
+gen_instr_encoded(addr_t pc, const std::vector<char> encoding, memref_tid_t tid = 1,
                   size_t size = 1)
 {
     memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, size);

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -96,10 +96,9 @@ gen_branch_encoded(memref_tid_t tid, addr_t pc, int encoding)
 
 #elif defined(X86_64) || defined(X86_32)
 inline memref_t
-gen_instr_encoded(addr_t pc, const std::vector<char> encoding, memref_tid_t tid = 1,
-                  size_t size = 1)
+gen_instr_encoded(addr_t pc, const std::vector<char> encoding, memref_tid_t tid = 1)
 {
-    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, size);
+    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, encoding.size());
     memref.instr.size = encoding.size();
     memcpy(memref.instr.encoding, encoding.data(), encoding.size());
     memref.instr.encoding_is_new = true;

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -86,8 +86,9 @@ gen_branch_encoded(memref_tid_t tid, addr_t pc, int encoding)
 }
 
 inline memref_t
-gen_syscall_encoded(memref_tid_t tid, addr_t pc, int encoding)
+gen_syscall_encoded(memref_tid_t tid, addr_t pc)
 {
+    constexpr int encoding = 0xd4000001;
     memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
     memref.instr.size = 4;
     memcpy(memref.instr.encoding, &encoding, sizeof(encoding));
@@ -97,8 +98,9 @@ gen_syscall_encoded(memref_tid_t tid, addr_t pc, int encoding)
 
 #elif defined(X86_64) || defined(X86_32)
 inline memref_t
-gen_syscall_encoded(memref_tid_t tid, addr_t pc, const std::vector<char> &encoding)
+gen_syscall_encoded(memref_tid_t tid, addr_t pc)
 {
+    const std::vector<char>encoding = { 0x0f, 0x05 };
     memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
     memref.instr.size = encoding.size();
     memcpy(memref.instr.encoding, encoding.data(), encoding.size());

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -84,7 +84,28 @@ gen_branch_encoded(memref_tid_t tid, addr_t pc, int encoding)
     memref.instr.encoding_is_new = true;
     return memref;
 }
+
+inline memref_t
+gen_syscall_encoded(memref_tid_t tid, addr_t pc, int encoding)
+{
+    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
+    memref.instr.size = 4;
+    memcpy(memref.instr.encoding, &encoding, sizeof(encoding));
+    memref.instr.encoding_is_new = true;
+    return memref;
+}
+
 #elif defined(X86_64) || defined(X86_32)
+inline memref_t
+gen_syscall_encoded(memref_tid_t tid, addr_t pc, const std::vector<char> &encoding)
+{
+    memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc);
+    memref.instr.size = encoding.size();
+    memcpy(memref.instr.encoding, encoding.data(), encoding.size());
+    memref.instr.encoding_is_new = true;
+    return memref;
+}
+
 // Variant for x86 encodings.
 inline memref_t
 gen_branch_encoded(memref_tid_t tid, addr_t pc, const std::vector<char> &encoding)

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -96,7 +96,7 @@ gen_branch_encoded(memref_tid_t tid, addr_t pc, int encoding)
 
 #elif defined(X86_64) || defined(X86_32)
 inline memref_t
-gen_instr_encoded(addr_t pc, const std::vector<char> encoding, memref_tid_t tid = 1)
+gen_instr_encoded(addr_t pc, const std::vector<char> &encoding, memref_tid_t tid = 1)
 {
     memref_t memref = gen_instr_type(TRACE_TYPE_INSTR, tid, pc, encoding.size());
     memref.instr.size = encoding.size();

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -340,7 +340,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
         bool expect_encoding = TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_);
         std::unique_ptr<instr_t> cur_instr_decoded = nullptr;
-        if (expect_encoding) {
+        if (expect_encoding && memref.instr.encoding_is_new) {
             cur_instr_decoded.reset(new instr_t);
             instr_init(GLOBAL_DCONTEXT, cur_instr_decoded.get());
             app_pc next_pc = nullptr;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -339,9 +339,10 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||
         memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
         bool expect_encoding = TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_);
-        std::unique_ptr<instr_t> cur_instr_decoded(new instr_t());
+        std::unique_ptr<instr_t> cur_instr_decoded = nullptr;
         app_pc next_pc = nullptr;
         if (expect_encoding) {
+            cur_instr_decoded = std::unique_ptr<instr_t>(new instr_t);
             instr_init(GLOBAL_DCONTEXT, cur_instr_decoded.get());
             const app_pc decode_pc = const_cast<app_pc>(memref.instr.encoding);
             next_pc = decode_from_copy(GLOBAL_DCONTEXT, decode_pc,

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -340,14 +340,13 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
         bool expect_encoding = TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_);
         std::unique_ptr<instr_t> cur_instr_decoded = nullptr;
-        app_pc next_pc = nullptr;
         if (expect_encoding) {
-            cur_instr_decoded = std::unique_ptr<instr_t>(new instr_t);
+            cur_instr_decoded.reset(new instr_t);
             instr_init(GLOBAL_DCONTEXT, cur_instr_decoded.get());
-            const app_pc decode_pc = const_cast<app_pc>(memref.instr.encoding);
-            next_pc = decode_from_copy(GLOBAL_DCONTEXT, decode_pc,
-                                       reinterpret_cast<app_pc>(memref.instr.addr),
-                                       cur_instr_decoded.get());
+            app_pc next_pc = nullptr;
+            next_pc = decode_from_copy(
+                GLOBAL_DCONTEXT, const_cast<app_pc>(memref.instr.encoding),
+                reinterpret_cast<app_pc>(memref.instr.addr), cur_instr_decoded.get());
             if (next_pc == nullptr) {
                 instr_free(GLOBAL_DCONTEXT, cur_instr_decoded.get());
                 cur_instr_decoded.reset(nullptr);
@@ -505,6 +504,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
 #endif
         shard->prev_instr_ = memref;
         if (cur_instr_decoded != nullptr) {
+            if (shard->prev_instr_decoded_ != nullptr)
+                instr_free(GLOBAL_DCONTEXT, shard->prev_instr_decoded_.get());
             shard->prev_instr_decoded_ = std::move(cur_instr_decoded);
         }
         shard->saw_kernel_xfer_after_prev_instr_ = false;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -339,14 +339,13 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||
         memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
         bool expect_encoding = TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_);
-        addr_t trace_pc = memref.instr.addr;
         std::unique_ptr<instr_t> cur_instr_decoded(new instr_t());
         app_pc next_pc = nullptr;
         if (TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_)) {
             instr_init(GLOBAL_DCONTEXT, cur_instr_decoded.get());
             const app_pc decode_pc = const_cast<app_pc>(memref.instr.encoding);
             next_pc = decode_from_copy(GLOBAL_DCONTEXT, decode_pc,
-                                       reinterpret_cast<app_pc>(trace_pc),
+                                       reinterpret_cast<app_pc>(memref.instr.addr),
                                        cur_instr_decoded.get());
             if (next_pc == nullptr) {
                 instr_free(GLOBAL_DCONTEXT, cur_instr_decoded.get());
@@ -391,17 +390,19 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // by markers.
         bool have_cond_branch_target = false;
         addr_t cond_branch_target = 0;
-        if (type_is_instr_direct_branch(memref.instr.type) && expect_encoding) {
+        if (shard->prev_instr_.instr.addr != 0 /*first*/ &&
+            type_is_instr_direct_branch(shard->prev_instr_.instr.type) &&
+            expect_encoding) {
             // We do not bother to support legacy traces without encodings.
-            if (memref.instr.encoding_is_new)
-                shard->branch_target_cache.erase(trace_pc);
-            auto cached = shard->branch_target_cache.find(trace_pc);
+            if (shard->prev_instr_.instr.encoding_is_new)
+                shard->branch_target_cache.erase(shard->prev_instr_.instr.addr);
+            auto cached = shard->branch_target_cache.find(shard->prev_instr_.instr.addr);
             if (cached != shard->branch_target_cache.end()) {
                 have_cond_branch_target = true;
                 cond_branch_target = cached->second;
             } else {
-                if (cur_instr_decoded == nullptr ||
-                    !opnd_is_pc(instr_get_target(cur_instr_decoded.get()))) {
+                if (shard->prev_instr_decoded_ == nullptr ||
+                    !opnd_is_pc(instr_get_target(shard->prev_instr_decoded_.get()))) {
                     // Neither condition should happen but they could on an invalid
                     // encoding from raw2trace or the reader so we report an
                     // invariant rather than asserting.
@@ -409,17 +410,18 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                 } else {
                     have_cond_branch_target = true;
                     cond_branch_target = reinterpret_cast<addr_t>(
-                        opnd_get_pc(instr_get_target(cur_instr_decoded.get())));
-                    shard->branch_target_cache[trace_pc] = cond_branch_target;
+                        opnd_get_pc(instr_get_target(shard->prev_instr_decoded_.get())));
+                    shard->branch_target_cache[shard->prev_instr_.instr.addr] =
+                        cond_branch_target;
                 }
             }
         }
         bool saw_repeated_syscall_instrs_with_same_pc = false;
-        if (shard->prev_instr_.instr.addr != 0 /*first*/ &&
+        if (cur_instr_decoded != nullptr && shard->prev_instr_decoded_ != nullptr &&
+            shard->prev_instr_.instr.addr != 0 /*first*/ &&
             instr_is_syscall(cur_instr_decoded.get()) &&
             memref.instr.addr == shard->prev_instr_.instr.addr &&
-            instr_is_syscall(shard->prev_instr_decoded_) &&
-            cur_instr_decoded != nullptr && shard->prev_instr_decoded_ != nullptr) {
+            instr_is_syscall(shard->prev_instr_decoded_.get())) {
             // Set this flag so that repeated syscalls are not
             // double reporeted as other PC discontinuity below.
             saw_repeated_syscall_instrs_with_same_pc = true;
@@ -502,7 +504,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
 #endif
         shard->prev_instr_ = memref;
         if (cur_instr_decoded != nullptr) {
-            shard->prev_instr_decoded_ = cur_instr_decoded.get();
+            shard->prev_instr_decoded_ = std::move(cur_instr_decoded);
         }
         shard->saw_kernel_xfer_after_prev_instr_ = false;
         // Clear prev_xfer_marker_ on an instr (not a memref which could come between an

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -341,7 +341,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         bool expect_encoding = TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_);
         std::unique_ptr<instr_t> cur_instr_decoded(new instr_t());
         app_pc next_pc = nullptr;
-        if (TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_)) {
+        if (expect_encoding) {
             instr_init(GLOBAL_DCONTEXT, cur_instr_decoded.get());
             const app_pc decode_pc = const_cast<app_pc>(memref.instr.encoding);
             next_pc = decode_from_copy(GLOBAL_DCONTEXT, decode_pc,
@@ -349,7 +349,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                                        cur_instr_decoded.get());
             if (next_pc == nullptr) {
                 instr_free(GLOBAL_DCONTEXT, cur_instr_decoded.get());
-                cur_instr_decoded = nullptr;
+                cur_instr_decoded.reset(nullptr);
             }
         }
         if (knob_verbose_ >= 3) {

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -692,7 +692,7 @@ invariant_checker_t::check_for_pc_discontinuity(
                        instr_is_syscall(cur_instr_decoded.get()) &&
                        memref.instr.addr == shard->prev_instr_.instr.addr &&
                        instr_is_syscall(shard->prev_instr_decoded_.get())) {
-                error_msg = "Double syscall instrs with the same PC";
+                error_msg = "Duplicate syscall instrs with the same PC";
             } else {
                 error_msg = "Non-explicit control flow has no marker";
             }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -415,10 +415,6 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         bool saw_repeated_syscall_instrs_with_same_pc = false;
         if (shard->prev_instr_.instr.addr != 0 /*first*/) {
             if (next_pc != nullptr) {
-                if (instr_is_syscall(&cur_instr_decoded))
-                    std::cerr << "Curr instr decoded is syscall\n";
-                if (instr_is_syscall(shard->prev_instr_decoded_))
-                    std::cerr << "Prev instr decoded is syscall\n";
                 if (instr_is_syscall(&cur_instr_decoded) &&
                     memref.instr.addr == shard->prev_instr_.instr.addr &&
                     instr_is_syscall(shard->prev_instr_decoded_)) {

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -140,9 +140,8 @@ protected:
     // for such violations.
     std::string
     check_for_pc_discontinuity(per_shard_t *shard, const memref_t &memref,
-                               const bool saw_repeated_syscall_instrs_with_same_pc,
-                               const bool have_cond_branch_target,
-                               const addr_t cond_branch_target);
+                               const std::unique_ptr<instr_t> &cur_instr_decoded,
+                               const bool expect_encoding);
 
     // The keys here are int for parallel, tid for serial.
     std::unordered_map<memref_tid_t, std::unique_ptr<per_shard_t>> shard_map_;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -37,6 +37,7 @@
 #define _INVARIANT_CHECKER_H_ 1
 
 #include "analysis_tool.h"
+#include "dr_api.h"
 #include "memref.h"
 #include <memory>
 #include <mutex>
@@ -88,6 +89,7 @@ protected:
         bool prev_instr_was_syscall_ = false;
         memref_t prev_entry_ = {};
         memref_t prev_instr_ = {};
+        instr_t *prev_instr_decoded_ = nullptr;
         memref_t prev_xfer_marker_ = {}; // Cleared on seeing an instr.
         memref_t last_xfer_marker_ = {}; // Not cleared: just the prior xfer marker.
         addr_t last_retaddr_ = 0;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -97,6 +97,7 @@ protected:
         int instrs_until_interrupt_ = -1;
         int memrefs_until_interrupt_ = -1;
 #endif
+        bool saw_double_syscall_instrs_with_same_pc_ = false;
         bool saw_kernel_xfer_after_prev_instr_ = false;
         bool saw_timestamp_but_no_instr_ = false;
         bool found_cache_line_size_marker_ = false;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -83,6 +83,9 @@ protected:
             last_xfer_marker_.marker.marker_type = TRACE_MARKER_TYPE_VERSION;
         }
         memtrace_stream_t *stream = nullptr;
+
+        addr_t prev_instr_addr_ = 0;
+        bool prev_instr_was_syscall_ = false;
         memref_t prev_entry_ = {};
         memref_t prev_instr_ = {};
         memref_t prev_xfer_marker_ = {}; // Cleared on seeing an instr.

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -85,8 +85,6 @@ protected:
         }
         memtrace_stream_t *stream = nullptr;
 
-        addr_t prev_instr_addr_ = 0;
-        bool prev_instr_was_syscall_ = false;
         memref_t prev_entry_ = {};
         memref_t prev_instr_ = {};
         instr_t *prev_instr_decoded_ = nullptr;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -87,7 +87,7 @@ protected:
 
         memref_t prev_entry_ = {};
         memref_t prev_instr_ = {};
-        instr_t *prev_instr_decoded_ = nullptr;
+        std::unique_ptr<instr_t> prev_instr_decoded_ = nullptr;
         memref_t prev_xfer_marker_ = {}; // Cleared on seeing an instr.
         memref_t last_xfer_marker_ = {}; // Not cleared: just the prior xfer marker.
         addr_t last_retaddr_ = 0;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -97,7 +97,6 @@ protected:
         int instrs_until_interrupt_ = -1;
         int memrefs_until_interrupt_ = -1;
 #endif
-        bool prev_instr_was_syscall_ = false;
         bool saw_kernel_xfer_after_prev_instr_ = false;
         bool saw_timestamp_but_no_instr_ = false;
         bool found_cache_line_size_marker_ = false;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -97,7 +97,7 @@ protected:
         int instrs_until_interrupt_ = -1;
         int memrefs_until_interrupt_ = -1;
 #endif
-        bool saw_double_syscall_instrs_with_same_pc_ = false;
+        bool prev_instr_was_syscall_ = false;
         bool saw_kernel_xfer_after_prev_instr_ = false;
         bool saw_timestamp_but_no_instr_ = false;
         bool found_cache_line_size_marker_ = false;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -84,7 +84,6 @@ protected:
             last_xfer_marker_.marker.marker_type = TRACE_MARKER_TYPE_VERSION;
         }
         memtrace_stream_t *stream = nullptr;
-
         memref_t prev_entry_ = {};
         memref_t prev_instr_ = {};
         std::unique_ptr<instr_t> prev_instr_decoded_ = nullptr;


### PR DESCRIPTION
Adds a dedicated invariant check for duplicate syscalls that have the same PC and reported as 'Non-explicit control flow has no marker'.

Tested with an app that has the 'Non-explicit control flow has no marker' error for duplicate syscalls and after this change, most of the errors classified in that original error type are now reported as 'Duplicate syscall instrs with the same PC'.

Issue: #5934