### PR TITLE
i#2626 Finish AArch64 encoder/decoder: AUTI*

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1712,7 +1712,44 @@ encode_sized_p(uint pos_start, uint size_start, uint min_size, uint max_size, op
  * previous section.
  */
 
-/* impx30: implicit X30 operand, used by BLR */
+static inline bool
+encode_implicit_register(reg_id_t reg, opnd_t opnd, OUT uint *enc_out)
+{
+    *enc_out = 0;
+    return opnd_is_reg(opnd) && opnd_get_reg(opnd) == reg;
+}
+
+/* impx16: implicit X16 operand */
+
+static inline bool
+decode_opnd_impx16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg(DR_REG_X16);
+    return true;
+}
+
+static inline bool
+encode_opnd_impx16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_implicit_register(DR_REG_X16, opnd, enc_out);
+}
+
+/* impx17: implicit X17 operand */
+
+static inline bool
+decode_opnd_impx17(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg(DR_REG_X17);
+    return true;
+}
+
+static inline bool
+encode_opnd_impx17(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_implicit_register(DR_REG_X17, opnd, enc_out);
+}
+
+/* impx30: implicit X30 operand */
 
 static inline bool
 decode_opnd_impx30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
@@ -1724,10 +1761,22 @@ decode_opnd_impx30(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 static inline bool
 encode_opnd_impx30(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
-    if (!opnd_is_reg(opnd) || opnd_get_reg(opnd) != DR_REG_X30)
-        return false;
-    *enc_out = 0;
+    return encode_implicit_register(DR_REG_X30, opnd, enc_out);
+}
+
+/* impsp: implicit SP operand */
+
+static inline bool
+decode_opnd_impsp(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    *opnd = opnd_create_reg(DR_REG_SP);
     return true;
+}
+
+static inline bool
+encode_opnd_impsp(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_implicit_register(DR_REG_SP, opnd, enc_out);
 }
 
 /* lsl: constant LSL for ADD/MOV, no encoding bits */

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -152,8 +152,6 @@ x0001010xx0xxxxxxxxxxxxxxxxxxxxx  n   21   BASE        and            wx0 : wx5 
 x11100100xxxxxxxxxxxxxxxxxxxxxxx  w   22   BASE       ands      logic_imm
 x1101010xx0xxxxxxxxxxxxxxxxxxxxx  w   22   BASE       ands            wx0 : wx5 wx16 shift4 imm6
 x0011010110xxxxx001010xxxxxxxxxx  n   23   BASE       asrv            wx0 : wx5 wx16
-11010101000000110010000110011111  n   24   BASE  autia1716                :
-11010101000000110010000111011111  n   25   BASE  autib1716                :
 000101xxxxxxxxxxxxxxxxxxxxxxxxxx  n   26   BASE          b              b
 01010100xxxxxxxxxxxxxxxxxxx0xxxx  r   27   BASE      bcond          bcond
 0011001100xxxxxxxxxxxxxxxxxxxxxx  n   28   BASE        bfm             w0 : w0 w5 immr imms

--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -41,26 +41,35 @@
 
 # Instruction definitions:
 
-1101101011000001000110xxxxxxxxxx  n   1027 PAUTH   autda      x0 : x0 x5sp
-1101101011000001000111xxxxxxxxxx  n   690  PAUTH   autdb      x0 : x0 x5sp
-110110101100000100111011111xxxxx  n   1028 PAUTH  autdza      x0 : x0
-110110101100000100111111111xxxxx  n   1029 PAUTH  autdzb      x0 : x0
-11010101000000110010001111111111  n   681  PAUTH autibsp         :
-1101011100111111000010xxxxxxxxxx  n   782  PAUTH   blraa  impx30 : x5 x0
-1101011000111111000010xxxxx11111  n   682  PAUTH  blraaz  impx30 : x5
-1101011100011111000010xxxxxxxxxx  n   683  PAUTH    braa         : x5 x0
-0x101110xx0xxxxx111x01xxxxxxxxxx  n   944  BASE   fcadd     dq0 : dq0 dq5 dq16 imm1_ew_12 hs_sz
-0x101110xx0xxxxx110xx1xxxxxxxxxx  n   945  BASE   fcmla     dq0 : dq0 dq5 dq16 imm2_nesw_11 hs_sz
-0x101111xxxxxxxx0xx1x0xxxxxxxxxx  n   945  BASE   fcmla     dq0 : dq0 dq5 dq16 vindex_HS_2lane imm2_nesw_13 hs_sz
-1x11100010111111110000xxxxxxxxxx  n   796  LRCPC   ldapr  wx0_30 : mem0
-0011100010111111110000xxxxxxxxxx  n   797  LRCPC  ldaprb      w0 : mem0
-0111100010111111110000xxxxxxxxxx  n   798  LRCPC  ldaprh      w0 : mem0
-1101101011000001000010xxxxxxxxxx  n   687  PAUTH   pacda         : x0 x5
-1101101011000001000000xxxxxxxxxx  n   688  PAUTH   pacia         : x0 x5
-1101101011000001000001xxxxxxxxxx  n   689  PAUTH   pacib         : x0 x5
-11010101000000110010001101111111  n   680  PAUTH pacibsp         :
-110110101100000100100011111xxxxx  n   684  PAUTH  paciza         : x0
-11010110010111110000101111111111  n   679  PAUTH    reta         :
-11010110010111110000111111111111  n   679  PAUTH    reta         :
-110110101100000101000111111xxxxx  n   686  PAUTH   xpacd         : x0
-110110101100000101000011111xxxxx  n   685  PAUTH   xpaci         : x0
+1101101011000001000110xxxxxxxxxx  n   1027 PAUTH     autda      x0 : x0 x5sp
+1101101011000001000111xxxxxxxxxx  n   690  PAUTH     autdb      x0 : x0 x5sp
+110110101100000100111011111xxxxx  n   1028 PAUTH    autdza      x0 : x0
+110110101100000100111111111xxxxx  n   1029 PAUTH    autdzb      x0 : x0
+1101101011000001000100xxxxxxxxxx  n   1030 PAUTH     autia      x0 : x0 x5sp
+11010101000000110010000110011111  n   24   PAUTH autia1716  impx17 : impx17 impx16
+11010101000000110010001110111111  n   1031 PAUTH   autiasp  impx30 : impx30 impsp
+11010101000000110010001110011111  n   1032 PAUTH    autiaz  impx30 : impx30
+1101101011000001000101xxxxxxxxxx  n   1033 PAUTH     autib      x0 : x0 x5sp
+11010101000000110010000111011111  n   25   PAUTH autib1716  impx17 : impx17 impx16
+11010101000000110010001111111111  n   681  PAUTH   autibsp  impx30 : impx30 impsp
+11010101000000110010001111011111  n   1034 PAUTH    autibz  impx30 : impx30
+110110101100000100110011111xxxxx  n   1035 PAUTH    autiza      x0 : x0
+110110101100000100110111111xxxxx  n   1036 PAUTH    autizb      x0 : x0
+1101011100111111000010xxxxxxxxxx  n   782  PAUTH     blraa  impx30 : x5 x0
+1101011000111111000010xxxxx11111  n   682  PAUTH    blraaz  impx30 : x5
+1101011100011111000010xxxxxxxxxx  n   683  PAUTH      braa         : x5 x0
+0x101110xx0xxxxx111x01xxxxxxxxxx  n   944  BASE     fcadd     dq0 : dq0 dq5 dq16 imm1_ew_12 hs_sz
+0x101110xx0xxxxx110xx1xxxxxxxxxx  n   945  BASE     fcmla     dq0 : dq0 dq5 dq16 imm2_nesw_11 hs_sz
+0x101111xxxxxxxx0xx1x0xxxxxxxxxx  n   945  BASE     fcmla     dq0 : dq0 dq5 dq16 vindex_HS_2lane imm2_nesw_13 hs_sz
+1x11100010111111110000xxxxxxxxxx  n   796  LRCPC     ldapr  wx0_30 : mem0
+0011100010111111110000xxxxxxxxxx  n   797  LRCPC    ldaprb      w0 : mem0
+0111100010111111110000xxxxxxxxxx  n   798  LRCPC    ldaprh      w0 : mem0
+1101101011000001000010xxxxxxxxxx  n   687  PAUTH     pacda         : x0 x5
+1101101011000001000000xxxxxxxxxx  n   688  PAUTH     pacia         : x0 x5
+1101101011000001000001xxxxxxxxxx  n   689  PAUTH     pacib         : x0 x5
+11010101000000110010001101111111  n   680  PAUTH   pacibsp         :
+110110101100000100100011111xxxxx  n   684  PAUTH    paciza         : x0
+11010110010111110000101111111111  n   679  PAUTH      reta         :
+11010110010111110000111111111111  n   679  PAUTH      reta         :
+110110101100000101000111111xxxxx  n   686  PAUTH     xpacd         : x0
+110110101100000101000011111xxxxx  n   685  PAUTH     xpaci         : x0

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -13457,4 +13457,134 @@
  */
 #define INSTR_CREATE_autdzb(dc, Rd) instr_create_1dst_1src(dc, OP_autdzb, Rd, Rd)
 
+/**
+ * Creates an AUTIA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIA   <Xd>, <Xn|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination  register, X (Extended, 64
+ *             bits).
+ * \param Rn   The second source  register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_autia(dc, Rd, Rn) instr_create_1dst_2src(dc, OP_autia, Rd, Rd, Rn)
+
+/**
+ * Creates an AUTIA1716 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIA1716
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_autia1716(dc)                                        \
+    instr_create_1dst_2src(dc, OP_autia1716, opnd_create_reg(DR_REG_X17), \
+                           opnd_create_reg(DR_REG_X17), opnd_create_reg(DR_REG_X16))
+
+/**
+ * Creates an AUTIASP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIASP
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_autiasp(dc)                                        \
+    instr_create_1dst_2src(dc, OP_autiasp, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_X30), opnd_create_reg(DR_REG_SP))
+
+/**
+ * Creates an AUTIAZ instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIAZ
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_autiaz(dc)                                        \
+    instr_create_1dst_1src(dc, OP_autiaz, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_X30))
+
+/**
+ * Creates an AUTIB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIB   <Xd>, <Xn|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination  register, X (Extended, 64
+ *             bits).
+ * \param Rn   The second source  register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_autib(dc, Rd, Rn) instr_create_1dst_2src(dc, OP_autib, Rd, Rd, Rn)
+
+/**
+ * Creates an AUTIB1716 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIB1716
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_autib1716(dc)                                        \
+    instr_create_1dst_2src(dc, OP_autib1716, opnd_create_reg(DR_REG_X17), \
+                           opnd_create_reg(DR_REG_X17), opnd_create_reg(DR_REG_X16))
+
+/**
+ * Creates an AUTIBSP instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIBSP
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_autibsp(dc)                                        \
+    instr_create_1dst_2src(dc, OP_autibsp, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_X30), opnd_create_reg(DR_REG_SP))
+
+/**
+ * Creates an AUTIBZ instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIBZ
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_autibz(dc)                                        \
+    instr_create_1dst_1src(dc, OP_autibz, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_X30))
+
+/**
+ * Creates an AUTIZA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIZA  <Xd>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The source and destination  register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_autiza(dc, Rd) instr_create_1dst_1src(dc, OP_autiza, Rd, Rd)
+
+/**
+ * Creates an AUTIZB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AUTIZB  <Xd>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The source and destination  register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_autizb(dc, Rd) instr_create_1dst_1src(dc, OP_autizb, Rd, Rd)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -63,7 +63,10 @@
 #   0xx0  32(s) 0,8,16,24
 #   110x  32(s) 8,16 (MSL, shifting ones)
 
+--------------------------------  impx16     # implicit X16 operand
+--------------------------------  impx17     # implicit X17 operand
 --------------------------------  impx30     # implicit X30 operand
+--------------------------------  impsp      # implicit SP operand
 --------------------------------  lsl        # implicit LSL for ADD/MOV (immediate)
 --------------------------------  mul        # implicit MUL
 --------------------------------  h_sz       # element width of FP vector reg, used to

--- a/suite/tests/api/dis-a64-v83.txt
+++ b/suite/tests/api/dis-a64-v83.txt
@@ -104,6 +104,96 @@ dac13ff8 : autdzb x24                                : autdzb %x24 -> %x24
 dac13ffa : autdzb x26                                : autdzb %x26 -> %x26
 dac13ffe : autdzb x30                                : autdzb %x30 -> %x30
 
+# AUTIA1716  (AUTIA1716-R-auth)
+d503219f : autia1716                                 : autia1716 %x17 %x16 -> %x17
+
+# AUTIA   <Xd>, <Xn|SP> (AUTIA-R.R-auth)
+dac11000 : autia x0, x0                              : autia  %x0 %x0 -> %x0
+dac11062 : autia x2, x3                              : autia  %x2 %x3 -> %x2
+dac110a4 : autia x4, x5                              : autia  %x4 %x5 -> %x4
+dac110e6 : autia x6, x7                              : autia  %x6 %x7 -> %x6
+dac11128 : autia x8, x9                              : autia  %x8 %x9 -> %x8
+dac11149 : autia x9, x10                             : autia  %x9 %x10 -> %x9
+dac1118b : autia x11, x12                            : autia  %x11 %x12 -> %x11
+dac111cd : autia x13, x14                            : autia  %x13 %x14 -> %x13
+dac1120f : autia x15, x16                            : autia  %x15 %x16 -> %x15
+dac11251 : autia x17, x18                            : autia  %x17 %x18 -> %x17
+dac11293 : autia x19, x20                            : autia  %x19 %x20 -> %x19
+dac112d5 : autia x21, x22                            : autia  %x21 %x22 -> %x21
+dac112f6 : autia x22, x23                            : autia  %x22 %x23 -> %x22
+dac11338 : autia x24, x25                            : autia  %x24 %x25 -> %x24
+dac1137a : autia x26, x27                            : autia  %x26 %x27 -> %x26
+dac113fe : autia x30, sp                             : autia  %x30 %sp -> %x30
+
+# AUTIASP  (AUTIASP-R-auth)
+d50323bf : autiasp                                   : autiasp %x30 %sp -> %x30
+
+# AUTIAZ   (AUTIAZ-R-auth)
+d503239f : autiaz                                    : autiaz %x30 -> %x30
+
+# AUTIB1716  (AUTIB1716-R-auth)
+d50321df : autib1716                                 : autib1716 %x17 %x16 -> %x17
+
+# AUTIB   <Xd>, <Xn|SP> (AUTIB-R.R-auth)
+dac11400 : autib x0, x0                              : autib  %x0 %x0 -> %x0
+dac11462 : autib x2, x3                              : autib  %x2 %x3 -> %x2
+dac114a4 : autib x4, x5                              : autib  %x4 %x5 -> %x4
+dac114e6 : autib x6, x7                              : autib  %x6 %x7 -> %x6
+dac11528 : autib x8, x9                              : autib  %x8 %x9 -> %x8
+dac11549 : autib x9, x10                             : autib  %x9 %x10 -> %x9
+dac1158b : autib x11, x12                            : autib  %x11 %x12 -> %x11
+dac115cd : autib x13, x14                            : autib  %x13 %x14 -> %x13
+dac1160f : autib x15, x16                            : autib  %x15 %x16 -> %x15
+dac11651 : autib x17, x18                            : autib  %x17 %x18 -> %x17
+dac11693 : autib x19, x20                            : autib  %x19 %x20 -> %x19
+dac116d5 : autib x21, x22                            : autib  %x21 %x22 -> %x21
+dac116f6 : autib x22, x23                            : autib  %x22 %x23 -> %x22
+dac11738 : autib x24, x25                            : autib  %x24 %x25 -> %x24
+dac1177a : autib x26, x27                            : autib  %x26 %x27 -> %x26
+dac117fe : autib x30, sp                             : autib  %x30 %sp -> %x30
+
+# AUTIBSP  (AUTIBSP-R-auth)
+d50323ff : autibsp                                   : autibsp %x30 %sp -> %x30
+
+# AUTIBZ   (AUTIBZ-R-auth)
+d50323df : autibz                                    : autibz %x30 -> %x30
+
+# AUTIZA  <Xd> (AUTIZA-R-auth)
+dac133e0 : autiza x0                                 : autiza %x0 -> %x0
+dac133e2 : autiza x2                                 : autiza %x2 -> %x2
+dac133e4 : autiza x4                                 : autiza %x4 -> %x4
+dac133e6 : autiza x6                                 : autiza %x6 -> %x6
+dac133e8 : autiza x8                                 : autiza %x8 -> %x8
+dac133e9 : autiza x9                                 : autiza %x9 -> %x9
+dac133eb : autiza x11                                : autiza %x11 -> %x11
+dac133ed : autiza x13                                : autiza %x13 -> %x13
+dac133ef : autiza x15                                : autiza %x15 -> %x15
+dac133f1 : autiza x17                                : autiza %x17 -> %x17
+dac133f3 : autiza x19                                : autiza %x19 -> %x19
+dac133f5 : autiza x21                                : autiza %x21 -> %x21
+dac133f6 : autiza x22                                : autiza %x22 -> %x22
+dac133f8 : autiza x24                                : autiza %x24 -> %x24
+dac133fa : autiza x26                                : autiza %x26 -> %x26
+dac133fe : autiza x30                                : autiza %x30 -> %x30
+
+# AUTIZB  <Xd> (AUTIZB-R-auth)
+dac137e0 : autizb x0                                 : autizb %x0 -> %x0
+dac137e2 : autizb x2                                 : autizb %x2 -> %x2
+dac137e4 : autizb x4                                 : autizb %x4 -> %x4
+dac137e6 : autizb x6                                 : autizb %x6 -> %x6
+dac137e8 : autizb x8                                 : autizb %x8 -> %x8
+dac137e9 : autizb x9                                 : autizb %x9 -> %x9
+dac137eb : autizb x11                                : autizb %x11 -> %x11
+dac137ed : autizb x13                                : autizb %x13 -> %x13
+dac137ef : autizb x15                                : autizb %x15 -> %x15
+dac137f1 : autizb x17                                : autizb %x17 -> %x17
+dac137f3 : autizb x19                                : autizb %x19 -> %x19
+dac137f5 : autizb x21                                : autizb %x21 -> %x21
+dac137f6 : autizb x22                                : autizb %x22 -> %x22
+dac137f8 : autizb x24                                : autizb %x24 -> %x24
+dac137fa : autizb x26                                : autizb %x26 -> %x26
+dac137fe : autizb x30                                : autizb %x30 -> %x30
+
 # FCADD   <Vd>.<T>, <Vn>.<T>, <Vm>.<T>, <imm> (FCADD-Q.QQ-Vec)
 2e40e400 : fcadd v0.4h, v0.4h, v0.4h, #0x5a          : fcadd  %d0 %d0 %d0 $0x005a $0x01 -> %d0
 2e44e462 : fcadd v2.4h, v3.4h, v4.4h, #0x5a          : fcadd  %d2 %d3 %d4 $0x005a $0x01 -> %d2

--- a/suite/tests/api/ir_aarch64_v83.c
+++ b/suite/tests/api/ir_aarch64_v83.c
@@ -262,6 +262,60 @@ TEST_INSTR(autdzb)
     TEST_LOOP(autdzb, autdzb, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
 }
 
+TEST_INSTR(autia)
+{
+    /* Testing AUTIA   <Xd>, <Xn|SP> */
+    const char *const expected_0_0[6] = {
+        "autia  %x0 %x0 -> %x0",    "autia  %x5 %x6 -> %x5",
+        "autia  %x10 %x11 -> %x10", "autia  %x15 %x16 -> %x15",
+        "autia  %x20 %x21 -> %x20", "autia  %x30 %sp -> %x30",
+    };
+    TEST_LOOP(autia, autia, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(pauth_hints)
+{
+    TEST_NO_OPNDS(autia1716, autia1716, "autia1716 %x17 %x16 -> %x17");
+    TEST_NO_OPNDS(autiasp, autiasp, "autiasp %x30 %sp -> %x30");
+    TEST_NO_OPNDS(autiaz, autiaz, "autiaz %x30 -> %x30");
+    TEST_NO_OPNDS(autib1716, autib1716, "autib1716 %x17 %x16 -> %x17");
+    TEST_NO_OPNDS(autibsp, autibsp, "autibsp %x30 %sp -> %x30");
+    TEST_NO_OPNDS(autibz, autibz, "autibz %x30 -> %x30");
+}
+
+TEST_INSTR(autib)
+{
+    /* Testing AUTIB   <Xd>, <Xn|SP> */
+    const char *const expected_0_0[6] = {
+        "autib  %x0 %x0 -> %x0",    "autib  %x5 %x6 -> %x5",
+        "autib  %x10 %x11 -> %x10", "autib  %x15 %x16 -> %x15",
+        "autib  %x20 %x21 -> %x20", "autib  %x30 %sp -> %x30",
+    };
+    TEST_LOOP(autib, autib, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(autiza)
+{
+    /* Testing AUTIZA  <Xd> */
+    const char *const expected_0_0[6] = {
+        "autiza %x0 -> %x0",   "autiza %x5 -> %x5",   "autiza %x10 -> %x10",
+        "autiza %x15 -> %x15", "autiza %x20 -> %x20", "autiza %x30 -> %x30",
+    };
+    TEST_LOOP(autiza, autiza, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
+TEST_INSTR(autizb)
+{
+    /* Testing AUTIZB  <Xd> */
+    const char *const expected_0_0[6] = {
+        "autizb %x0 -> %x0",   "autizb %x5 -> %x5",   "autizb %x10 -> %x10",
+        "autizb %x15 -> %x15", "autizb %x20 -> %x20", "autizb %x30 -> %x30",
+    };
+    TEST_LOOP(autizb, autizb, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -283,6 +337,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(autdb);
     RUN_INSTR_TEST(autdza);
     RUN_INSTR_TEST(autdzb);
+    RUN_INSTR_TEST(pauth_hints);
+    RUN_INSTR_TEST(autia);
+    RUN_INSTR_TEST(autib);
+    RUN_INSTR_TEST(autiza);
+    RUN_INSTR_TEST(autizb);
 
     print("All v8.3 tests complete.");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
AUTIA   <Xd>, <Xn|SP>
AUTIB   <Xd>, <Xn|SP>
AUTIA1716
AUTIB1716
AUTIASP
AUTIBSP
AUTIAZ
AUTIBZ
AUTIZA  <Xd>
AUTIZB  <Xd>
```

Issues: #2626, #5623