### PR TITLE
i#5724 chunk bounds: Fix incorrect instruction counts

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -106,6 +106,39 @@ public:
             std::unique_ptr<module_mapper_t>(new module_mapper_test_t(instrs, drcontext));
         set_modmap_(module_mapper_.get());
     }
+    raw2trace_test_t(const std::vector<std::istream *> &input,
+                     const std::vector<archive_ostream_t *> &output, instrlist_t &instrs,
+                     void *drcontext, uint64_t chunk_instr_count = 10 * 1000 * 1000)
+        : raw2trace_t(nullptr, input, {}, output, INVALID_FILE, nullptr, nullptr,
+                      drcontext,
+                      // The sequences are small so we print everything for easier
+                      // debugging and viewing of what's going on.
+                      4, /*worker_count=*/-1, /*alt_module_dir=*/"", chunk_instr_count)
+    {
+        module_mapper_ =
+            std::unique_ptr<module_mapper_t>(new module_mapper_test_t(instrs, drcontext));
+        set_modmap_(module_mapper_.get());
+    }
+};
+
+class archive_ostream_test_t : public archive_ostream_t {
+public:
+    archive_ostream_test_t()
+        : archive_ostream_t(new std::basic_stringbuf<char, std::char_traits<char>>)
+    {
+    }
+    std::string
+    open_new_component(const std::string &name) override
+    {
+        return "";
+    }
+    std::string
+    str()
+    {
+        return reinterpret_cast<std::basic_stringbuf<char, std::char_traits<char>> *>(
+                   rdbuf())
+            ->str();
+    }
 };
 
 offline_entry_t
@@ -619,13 +652,145 @@ test_marker_delays(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
 }
 
+bool
+test_chunk_boundaries(void *drcontext)
+{
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    // Test i#5724 where a chunk boundary between consecutive branches results
+    // in an incorrect count and a missing encoding entry.
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *jmp2 = XINST_CREATE_jump(drcontext, opnd_create_instr(move2));
+    instr_t *jmp1 = XINST_CREATE_jump(drcontext, opnd_create_instr(jmp2));
+    instr_t *move3 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instrlist_append(ilist, nop);
+    // Block 1.
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, jmp1);
+    // Block 2.
+    instrlist_append(ilist, jmp2);
+    // Block 3.
+    instrlist_append(ilist, move2);
+    instrlist_append(ilist, move3);
+
+    size_t offs_nop = 0;
+    size_t offs_move1 = offs_nop + instr_length(drcontext, nop);
+    size_t offs_jmp1 = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_jmp2 = offs_jmp1 + instr_length(drcontext, jmp1);
+    size_t offs_move2 = offs_jmp2 + instr_length(drcontext, jmp2);
+
+    // Now we synthesize our raw trace itself, including a valid header sequence.
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_block(offs_jmp2, 1));
+    raw.push_back(make_block(offs_move2, 2));
+    // TODO i#5724: Add repeats of the same instrs to test re-emitting encodings
+    // in new chunks.
+    raw.push_back(make_exit());
+    // We need an istream so we use istringstream.
+    std::ostringstream raw_out;
+    for (const auto &entry : raw) {
+        std::string as_string(reinterpret_cast<const char *>(&entry),
+                              reinterpret_cast<const char *>(&entry + 1));
+        raw_out << as_string;
+    }
+    std::istringstream raw_in(raw_out.str());
+    std::vector<std::istream *> input;
+    input.push_back(&raw_in);
+    // We need an archive_ostream to enable chunking.
+    archive_ostream_test_t result_stream;
+    std::vector<archive_ostream_t *> output;
+    output.push_back(&result_stream);
+
+    // Run raw2trace with our subclass supplying our decodings.
+    // Use a chunk instr count of 2 to split the 2 jumps.
+    raw2trace_test_t raw2trace(input, output, *ilist, drcontext, 2);
+    std::string error = raw2trace.do_conversion();
+    CHECK(error.empty(), error);
+    instrlist_clear_and_destroy(drcontext, ilist);
+
+    // Now check the results.
+    std::string result = result_stream.str();
+    char *start = &result[0];
+    char *end = start + result.size();
+    CHECK(result.size() % sizeof(trace_entry_t) == 0,
+          "output is not a multiple of trace_entry_t");
+    std::vector<trace_entry_t> entries;
+    while (start < end) {
+        entries.push_back(*reinterpret_cast<trace_entry_t *>(start));
+        start += sizeof(trace_entry_t);
+    }
+    int idx = 0;
+    for (const auto &entry : entries) {
+        std::cout << idx << " type: " << entry.type << " size: " << entry.size
+                  << " val: " << entry.addr << "\n";
+        ++idx;
+    }
+    idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        // Block 1.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+        // An extra encoding entry is needed.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+        check_entry(entries, idx, TRACE_TYPE_INSTR_DIRECT_JUMP, -1) &&
+        // Chunk should split the two jumps.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_FOOTER) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RECORD_ORDINAL) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        // Block 2.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+        // An extra encoding entry is needed.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+        check_entry(entries, idx, TRACE_TYPE_INSTR_DIRECT_JUMP, -1) &&
+        // Block 3.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
+        // Second chunk split.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_FOOTER) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RECORD_ORDINAL) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
 int
 main(int argc, const char *argv[])
 {
 
     void *drcontext = dr_standalone_init();
     if (!test_branch_delays(drcontext) || !test_marker_placement(drcontext) ||
-        !test_marker_delays(drcontext))
+        !test_marker_delays(drcontext) || !test_chunk_boundaries(drcontext))
         return 1;
     return 0;
 }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1273,13 +1273,15 @@ raw2trace_t::write(void *tls, const trace_entry_t *start, const trace_entry_t *e
                 }
                 continue;
             }
-            if (!type_is_instr(static_cast<trace_type_t>(it->type)))
-                continue;
             // We wait until we're past the final instr to write, to ensure we
-            // get all its memrefs.  (We will put function markers for entry in the
+            // get all its memrefs, by not stopping until we hit an instr or an
+            // encoding.  (We will put function markers for entry in the
             // prior chunk too: we live with that.)
-            if (tdata->cur_chunk_instr_count++ >= chunk_instr_count_) {
-                DEBUG_ASSERT(tdata->cur_chunk_instr_count - 1 == chunk_instr_count_);
+            if (!type_is_instr(static_cast<trace_type_t>(it->type)) &&
+                it->type != TRACE_TYPE_ENCODING)
+                continue;
+            if (tdata->cur_chunk_instr_count >= chunk_instr_count_) {
+                DEBUG_ASSERT(tdata->cur_chunk_instr_count == chunk_instr_count_);
                 if (!tdata->out_file->write(reinterpret_cast<const char *>(start),
                                             reinterpret_cast<const char *>(it) -
                                                 reinterpret_cast<const char *>(start)))
@@ -1288,7 +1290,13 @@ raw2trace_t::write(void *tls, const trace_entry_t *start, const trace_entry_t *e
                 if (!error.empty())
                     return error;
                 start = it;
+                DEBUG_ASSERT(tdata->cur_chunk_instr_count == 0);
+                // TODO i#5724: We need to re-emit encodings for "it" and any further
+                // instrs in this buffer: have a callback passed in which constructs
+                // an encoding from an instr record?
             }
+            if (type_is_instr(static_cast<trace_type_t>(it->type)))
+                ++tdata->cur_chunk_instr_count;
         }
     }
     if (!tdata->out_file->write(reinterpret_cast<const char *>(start),

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4044,7 +4044,7 @@ if (BUILD_CLIENTS)
 
     torunonly_drcacheoff(invariant_checker ${ci_shared_app}
       # We pass a small instr count to test multiple chunks in a zipfile.
-      "" "@-chunk_instr_count@10K@-simulator_type@invariant_checker" "")
+      "" "@-chunk_instr_count@1000@-simulator_type@invariant_checker" "")
 
     # Test the standalone histogram tool.
     # ${ci_shared_app} is already used for an offline test, so we run other apps


### PR DESCRIPTION
Fixes a too-long chunk after a prior chunk splits up consecutive delayed branches in the same buffer.

Avoids placing wasted encodings at the end of a chunk.

Adds a unit test, and reduces the chunk size for the larger test which causes the original problem to reproduce much more reliably.

Still to fix is to re-emit encodings for the second consecutive branch after the boundary.

Issue: #5724