### PR TITLE
i#2626 Finish AArch64 encoder/decoder: B[L]RA*

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1460,8 +1460,12 @@ mangle_indirect_call(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             XINST_CREATE_move(dcontext, opnd_create_reg(IBL_TARGET_REG),
                               instr_get_target(instr)));
     }
-    if (opc == OP_blraaz) {
-        // TODO i#5623: Add the other OP_blra* opcodes and handle them here.
+    switch (opc)
+    {
+    case OP_blraa:
+    case OP_blrab:
+    case OP_blraaz:
+    case OP_blrabz:
         PRE(ilist, instr, INSTR_CREATE_xpaci(dcontext, opnd_create_reg(IBL_TARGET_REG)));
     }
     insert_mov_immed_ptrsz(dcontext, get_call_return_address(dcontext, ilist, instr),
@@ -1527,8 +1531,8 @@ mangle_indirect_jump(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
 {
     int opc = instr_get_opcode(instr);
 #ifdef AARCH64
-    // TODO i#5623: Add the other OP_brra* and OP_reta* opcodes and handle them here.
-    ASSERT(opc == OP_br || opc == OP_ret || opc == OP_reta || opc == OP_braa);
+    ASSERT((instr_branch_type(instr) == (LINK_INDIRECT | LINK_JMP)) ||
+           (instr_branch_type(instr) == (LINK_INDIRECT | LINK_RETURN)));
     PRE(ilist, instr,
         instr_create_save_to_tls(dcontext, IBL_TARGET_REG, IBL_TARGET_SLOT));
     opnd_t target = instr_get_target(instr);
@@ -1543,8 +1547,14 @@ mangle_indirect_jump(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             XINST_CREATE_move(dcontext, opnd_create_reg(IBL_TARGET_REG), target));
     }
 
-    if (opc == OP_reta || opc == OP_braa) {
-        // TODO i#5623: Add the other OP_brra* and OP_reta* opcodes and handle them here.
+    switch (opc)
+    {
+    // TODO i#5623: Add the other OP_reta* opcodes and handle them here.
+    case OP_reta:
+    case OP_braa:
+    case OP_brab:
+    case OP_braaz:
+    case OP_brabz:
         PRE(ilist, instr, INSTR_CREATE_xpaci(dcontext, opnd_create_reg(IBL_TARGET_REG)));
     }
 

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1460,8 +1460,7 @@ mangle_indirect_call(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             XINST_CREATE_move(dcontext, opnd_create_reg(IBL_TARGET_REG),
                               instr_get_target(instr)));
     }
-    switch (opc)
-    {
+    switch (opc) {
     case OP_blraa:
     case OP_blrab:
     case OP_blraaz:
@@ -1547,8 +1546,7 @@ mangle_indirect_jump(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
             XINST_CREATE_move(dcontext, opnd_create_reg(IBL_TARGET_REG), target));
     }
 
-    switch (opc)
-    {
+    switch (opc) {
     // TODO i#5623: Add the other OP_reta* opcodes and handle them here.
     case OP_reta:
     case OP_braa:

--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -55,9 +55,14 @@
 11010101000000110010001111011111  n   1034 PAUTH    autibz  impx30 : impx30
 110110101100000100110011111xxxxx  n   1035 PAUTH    autiza      x0 : x0
 110110101100000100110111111xxxxx  n   1036 PAUTH    autizb      x0 : x0
-1101011100111111000010xxxxxxxxxx  n   782  PAUTH     blraa  impx30 : x5 x0
+1101011100111111000010xxxxxxxxxx  n   782  PAUTH     blraa  impx30 : x5 x0sp
 1101011000111111000010xxxxx11111  n   682  PAUTH    blraaz  impx30 : x5
-1101011100011111000010xxxxxxxxxx  n   683  PAUTH      braa         : x5 x0
+1101011100111111000011xxxxxxxxxx  n   1037 PAUTH     blrab  impx30 : x5 x0sp
+1101011000111111000011xxxxx11111  n   1038 PAUTH    blrabz  impx30 : x5
+1101011100011111000010xxxxxxxxxx  n   683  PAUTH      braa         : x5 x0sp
+1101011000011111000010xxxxx11111  n   1039 PAUTH     braaz         : x5
+1101011100011111000011xxxxxxxxxx  n   1040 PAUTH      brab         : x5 x0sp
+1101011000011111000011xxxxx11111  n   1041 PAUTH     brabz         : x5
 0x101110xx0xxxxx111x01xxxxxxxxxx  n   944  BASE     fcadd     dq0 : dq0 dq5 dq16 imm1_ew_12 hs_sz
 0x101110xx0xxxxx110xx1xxxxxxxxxx  n   945  BASE     fcmla     dq0 : dq0 dq5 dq16 imm2_nesw_11 hs_sz
 0x101111xxxxxxxx0xx1x0xxxxxxxxxx  n   945  BASE     fcmla     dq0 : dq0 dq5 dq16 vindex_HS_2lane imm2_nesw_13 hs_sz

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -80,11 +80,16 @@ instr_branch_type(instr_t *cti_instr)
     case OP_tbnz:
     case OP_tbz: return LINK_DIRECT | LINK_JMP;
     case OP_bl: return LINK_DIRECT | LINK_CALL;
-    // TODO i#5623: Add the other OP_blra*, OP_brra*, and OP_reta* opcodes.
+    case OP_blraa:
+    case OP_blrab:
     case OP_blraaz:
+    case OP_blrabz:
     case OP_blr: return LINK_INDIRECT | LINK_CALL;
     case OP_br:
-    case OP_braa: return LINK_INDIRECT | LINK_JMP;
+    case OP_braa:
+    case OP_brab:
+    case OP_braaz:
+    case OP_brabz: return LINK_INDIRECT | LINK_JMP;
     case OP_ret:
     case OP_reta: return LINK_INDIRECT | LINK_RETURN;
     }
@@ -109,8 +114,15 @@ bool
 instr_is_call_arch(instr_t *instr)
 {
     int opc = instr->opcode; /* caller ensures opcode is valid */
-    // TODO i#5623: Add the other OP_blra* opcodes.
-    return (opc == OP_bl || opc == OP_blr || opc == OP_blraaz);
+    switch (opc) {
+    case OP_bl:
+    case OP_blr:
+    case OP_blraa:
+    case OP_blrab:
+    case OP_blraaz:
+    case OP_blrabz: return true;
+    default: return false;
+    }
 }
 
 bool
@@ -131,8 +143,14 @@ bool
 instr_is_call_indirect(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    // TODO i#5623: Add the other OP_blra* opcodes.
-    return (opc == OP_blr || opc == OP_blraaz);
+    switch (opc) {
+    case OP_blr:
+    case OP_blraa:
+    case OP_blrab:
+    case OP_blraaz:
+    case OP_blrabz: return true;
+    default: return false;
+    }
 }
 
 bool
@@ -156,9 +174,22 @@ bool
 instr_is_mbr_arch(instr_t *instr)
 {
     int opc = instr->opcode; /* caller ensures opcode is valid */
-    // TODO i#5623: Add the other OP_blra*, OP_brra*, and OP_reta* opcodes.
-    return (opc == OP_blr || opc == OP_blraaz || opc == OP_br || opc == OP_braa ||
-            opc == OP_ret || opc == OP_reta);
+    // TODO i#5623: Add the other OP_reta* opcodes.
+    switch (opc) {
+    case OP_blr:
+    case OP_br:
+    case OP_braa:
+    case OP_brab:
+    case OP_braaz:
+    case OP_brabz:
+    case OP_blraa:
+    case OP_blrab:
+    case OP_blraaz:
+    case OP_blrabz:
+    case OP_ret:
+    case OP_reta: return true;
+    default: return false;
+    }
 }
 
 bool

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -13587,4 +13587,108 @@
  */
 #define INSTR_CREATE_autizb(dc, Rd) instr_create_1dst_1src(dc, OP_autizb, Rd, Rd)
 
+/**
+ * Creates a BLRAA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BLRAA   <Xn>, <Xm|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register, X (Extended, 64 bits).
+ * \param Rm   The second source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_blraa(dc, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_blraa, opnd_create_reg(DR_REG_X30), Rn, Rm)
+
+/**
+ * Creates a BLRAAZ instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BLRAAZ  <Xn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_blraaz(dc, Rn) \
+    instr_create_1dst_1src(dc, OP_blraaz, opnd_create_reg(DR_REG_X30), Rn)
+
+/**
+ * Creates a BLRAB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BLRAB   <Xn>, <Xm|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register, X (Extended, 64 bits).
+ * \param Rm   The second source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_blrab(dc, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_blrab, opnd_create_reg(DR_REG_X30), Rn, Rm)
+
+/**
+ * Creates a BLRABZ instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BLRABZ  <Xn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_blrabz(dc, Rn) \
+    instr_create_1dst_1src(dc, OP_blrabz, opnd_create_reg(DR_REG_X30), Rn)
+
+/**
+ * Creates a BRAA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BRAA    <Xn>, <Xm|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register, X (Extended, 64 bits).
+ * \param Rm   The second source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_braa(dc, Rn, Rm) instr_create_0dst_2src(dc, OP_braa, Rn, Rm)
+
+/**
+ * Creates a BRAAZ instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BRAAZ   <Xn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_braaz(dc, Rn) instr_create_0dst_1src(dc, OP_braaz, Rn)
+
+/**
+ * Creates a BRAB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BRAB    <Xn>, <Xm|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The first source register, X (Extended, 64 bits).
+ * \param Rm   The second source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_brab(dc, Rn, Rm) instr_create_0dst_2src(dc, OP_brab, Rn, Rm)
+
+/**
+ * Creates a BRABZ instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BRABZ   <Xn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rn   The source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_brabz(dc, Rn) instr_create_0dst_1src(dc, OP_brabz, Rn)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-v83.txt
+++ b/suite/tests/api/dis-a64-v83.txt
@@ -194,6 +194,150 @@ dac137f8 : autizb x24                                : autizb %x24 -> %x24
 dac137fa : autizb x26                                : autizb %x26 -> %x26
 dac137fe : autizb x30                                : autizb %x30 -> %x30
 
+# BLRAA   <Xn>, <Xm|SP> (BLRAA-R.R-auth)
+d73f0800 : blraa x0, x0                              : blraa  %x0 %x0 -> %x30
+d73f0843 : blraa x2, x3                              : blraa  %x2 %x3 -> %x30
+d73f0885 : blraa x4, x5                              : blraa  %x4 %x5 -> %x30
+d73f08c7 : blraa x6, x7                              : blraa  %x6 %x7 -> %x30
+d73f0909 : blraa x8, x9                              : blraa  %x8 %x9 -> %x30
+d73f092a : blraa x9, x10                             : blraa  %x9 %x10 -> %x30
+d73f096c : blraa x11, x12                            : blraa  %x11 %x12 -> %x30
+d73f09ae : blraa x13, x14                            : blraa  %x13 %x14 -> %x30
+d73f09f0 : blraa x15, x16                            : blraa  %x15 %x16 -> %x30
+d73f0a32 : blraa x17, x18                            : blraa  %x17 %x18 -> %x30
+d73f0a74 : blraa x19, x20                            : blraa  %x19 %x20 -> %x30
+d73f0ab6 : blraa x21, x22                            : blraa  %x21 %x22 -> %x30
+d73f0ad7 : blraa x22, x23                            : blraa  %x22 %x23 -> %x30
+d73f0b19 : blraa x24, x25                            : blraa  %x24 %x25 -> %x30
+d73f0b5b : blraa x26, x27                            : blraa  %x26 %x27 -> %x30
+d73f0bdf : blraa x30, sp                             : blraa  %x30 %sp -> %x30
+
+# BLRAAZ  <Xn> (BLRAAZ-R.R-auth)
+d63f081f : blraaz x0                                 : blraaz %x0 -> %x30
+d63f085f : blraaz x2                                 : blraaz %x2 -> %x30
+d63f089f : blraaz x4                                 : blraaz %x4 -> %x30
+d63f08df : blraaz x6                                 : blraaz %x6 -> %x30
+d63f091f : blraaz x8                                 : blraaz %x8 -> %x30
+d63f093f : blraaz x9                                 : blraaz %x9 -> %x30
+d63f097f : blraaz x11                                : blraaz %x11 -> %x30
+d63f09bf : blraaz x13                                : blraaz %x13 -> %x30
+d63f09ff : blraaz x15                                : blraaz %x15 -> %x30
+d63f0a3f : blraaz x17                                : blraaz %x17 -> %x30
+d63f0a7f : blraaz x19                                : blraaz %x19 -> %x30
+d63f0abf : blraaz x21                                : blraaz %x21 -> %x30
+d63f0adf : blraaz x22                                : blraaz %x22 -> %x30
+d63f0b1f : blraaz x24                                : blraaz %x24 -> %x30
+d63f0b5f : blraaz x26                                : blraaz %x26 -> %x30
+d63f0bdf : blraaz x30                                : blraaz %x30 -> %x30
+
+# BLRAB   <Xn>, <Xm|SP> (BLRAB-R.R-auth)
+d73f0c00 : blrab x0, x0                              : blrab  %x0 %x0 -> %x30
+d73f0c43 : blrab x2, x3                              : blrab  %x2 %x3 -> %x30
+d73f0c85 : blrab x4, x5                              : blrab  %x4 %x5 -> %x30
+d73f0cc7 : blrab x6, x7                              : blrab  %x6 %x7 -> %x30
+d73f0d09 : blrab x8, x9                              : blrab  %x8 %x9 -> %x30
+d73f0d2a : blrab x9, x10                             : blrab  %x9 %x10 -> %x30
+d73f0d6c : blrab x11, x12                            : blrab  %x11 %x12 -> %x30
+d73f0dae : blrab x13, x14                            : blrab  %x13 %x14 -> %x30
+d73f0df0 : blrab x15, x16                            : blrab  %x15 %x16 -> %x30
+d73f0e32 : blrab x17, x18                            : blrab  %x17 %x18 -> %x30
+d73f0e74 : blrab x19, x20                            : blrab  %x19 %x20 -> %x30
+d73f0eb6 : blrab x21, x22                            : blrab  %x21 %x22 -> %x30
+d73f0ed7 : blrab x22, x23                            : blrab  %x22 %x23 -> %x30
+d73f0f19 : blrab x24, x25                            : blrab  %x24 %x25 -> %x30
+d73f0f5b : blrab x26, x27                            : blrab  %x26 %x27 -> %x30
+d73f0fdf : blrab x30, sp                             : blrab  %x30 %sp -> %x30
+
+# BLRABZ  <Xn> (BLRABZ-R.R-auth)
+d63f0c1f : blrabz x0                                 : blrabz %x0 -> %x30
+d63f0c5f : blrabz x2                                 : blrabz %x2 -> %x30
+d63f0c9f : blrabz x4                                 : blrabz %x4 -> %x30
+d63f0cdf : blrabz x6                                 : blrabz %x6 -> %x30
+d63f0d1f : blrabz x8                                 : blrabz %x8 -> %x30
+d63f0d3f : blrabz x9                                 : blrabz %x9 -> %x30
+d63f0d7f : blrabz x11                                : blrabz %x11 -> %x30
+d63f0dbf : blrabz x13                                : blrabz %x13 -> %x30
+d63f0dff : blrabz x15                                : blrabz %x15 -> %x30
+d63f0e3f : blrabz x17                                : blrabz %x17 -> %x30
+d63f0e7f : blrabz x19                                : blrabz %x19 -> %x30
+d63f0ebf : blrabz x21                                : blrabz %x21 -> %x30
+d63f0edf : blrabz x22                                : blrabz %x22 -> %x30
+d63f0f1f : blrabz x24                                : blrabz %x24 -> %x30
+d63f0f5f : blrabz x26                                : blrabz %x26 -> %x30
+d63f0fdf : blrabz x30                                : blrabz %x30 -> %x30
+
+# BRAA    <Xn>, <Xm|SP> (BRAA-R.R-auth)
+d71f0800 : braa x0, x0                               : braa   %x0 %x0
+d71f0843 : braa x2, x3                               : braa   %x2 %x3
+d71f0885 : braa x4, x5                               : braa   %x4 %x5
+d71f08c7 : braa x6, x7                               : braa   %x6 %x7
+d71f0909 : braa x8, x9                               : braa   %x8 %x9
+d71f092a : braa x9, x10                              : braa   %x9 %x10
+d71f096c : braa x11, x12                             : braa   %x11 %x12
+d71f09ae : braa x13, x14                             : braa   %x13 %x14
+d71f09f0 : braa x15, x16                             : braa   %x15 %x16
+d71f0a32 : braa x17, x18                             : braa   %x17 %x18
+d71f0a74 : braa x19, x20                             : braa   %x19 %x20
+d71f0ab6 : braa x21, x22                             : braa   %x21 %x22
+d71f0ad7 : braa x22, x23                             : braa   %x22 %x23
+d71f0b19 : braa x24, x25                             : braa   %x24 %x25
+d71f0b5b : braa x26, x27                             : braa   %x26 %x27
+d71f0bdf : braa x30, sp                              : braa   %x30 %sp
+
+# BRAAZ   <Xn> (BRAAZ-R.R-auth)
+d61f081f : braaz x0                                  : braaz  %x0
+d61f085f : braaz x2                                  : braaz  %x2
+d61f089f : braaz x4                                  : braaz  %x4
+d61f08df : braaz x6                                  : braaz  %x6
+d61f091f : braaz x8                                  : braaz  %x8
+d61f093f : braaz x9                                  : braaz  %x9
+d61f097f : braaz x11                                 : braaz  %x11
+d61f09bf : braaz x13                                 : braaz  %x13
+d61f09ff : braaz x15                                 : braaz  %x15
+d61f0a3f : braaz x17                                 : braaz  %x17
+d61f0a7f : braaz x19                                 : braaz  %x19
+d61f0abf : braaz x21                                 : braaz  %x21
+d61f0adf : braaz x22                                 : braaz  %x22
+d61f0b1f : braaz x24                                 : braaz  %x24
+d61f0b5f : braaz x26                                 : braaz  %x26
+d61f0bdf : braaz x30                                 : braaz  %x30
+
+# BRAB    <Xn>, <Xm|SP> (BRAB-R.R-auth)
+d71f0c00 : brab x0, x0                               : brab   %x0 %x0
+d71f0c43 : brab x2, x3                               : brab   %x2 %x3
+d71f0c85 : brab x4, x5                               : brab   %x4 %x5
+d71f0cc7 : brab x6, x7                               : brab   %x6 %x7
+d71f0d09 : brab x8, x9                               : brab   %x8 %x9
+d71f0d2a : brab x9, x10                              : brab   %x9 %x10
+d71f0d6c : brab x11, x12                             : brab   %x11 %x12
+d71f0dae : brab x13, x14                             : brab   %x13 %x14
+d71f0df0 : brab x15, x16                             : brab   %x15 %x16
+d71f0e32 : brab x17, x18                             : brab   %x17 %x18
+d71f0e74 : brab x19, x20                             : brab   %x19 %x20
+d71f0eb6 : brab x21, x22                             : brab   %x21 %x22
+d71f0ed7 : brab x22, x23                             : brab   %x22 %x23
+d71f0f19 : brab x24, x25                             : brab   %x24 %x25
+d71f0f5b : brab x26, x27                             : brab   %x26 %x27
+d71f0fdf : brab x30, sp                              : brab   %x30 %sp
+
+# BRABZ   <Xn> (BRABZ-R.R-auth)
+d61f0c1f : brabz x0                                  : brabz  %x0
+d61f0c5f : brabz x2                                  : brabz  %x2
+d61f0c9f : brabz x4                                  : brabz  %x4
+d61f0cdf : brabz x6                                  : brabz  %x6
+d61f0d1f : brabz x8                                  : brabz  %x8
+d61f0d3f : brabz x9                                  : brabz  %x9
+d61f0d7f : brabz x11                                 : brabz  %x11
+d61f0dbf : brabz x13                                 : brabz  %x13
+d61f0dff : brabz x15                                 : brabz  %x15
+d61f0e3f : brabz x17                                 : brabz  %x17
+d61f0e7f : brabz x19                                 : brabz  %x19
+d61f0ebf : brabz x21                                 : brabz  %x21
+d61f0edf : brabz x22                                 : brabz  %x22
+d61f0f1f : brabz x24                                 : brabz  %x24
+d61f0f5f : brabz x26                                 : brabz  %x26
+d61f0fdf : brabz x30                                 : brabz  %x30
+
 # FCADD   <Vd>.<T>, <Vn>.<T>, <Vm>.<T>, <imm> (FCADD-Q.QQ-Vec)
 2e40e400 : fcadd v0.4h, v0.4h, v0.4h, #0x5a          : fcadd  %d0 %d0 %d0 $0x005a $0x01 -> %d0
 2e44e462 : fcadd v2.4h, v3.4h, v4.4h, #0x5a          : fcadd  %d2 %d3 %d4 $0x005a $0x01 -> %d2

--- a/suite/tests/api/ir_aarch64_v83.c
+++ b/suite/tests/api/ir_aarch64_v83.c
@@ -316,6 +316,92 @@ TEST_INSTR(autizb)
     TEST_LOOP(autizb, autizb, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
 }
 
+TEST_INSTR(blraa)
+{
+    /* Testing BLRAA   <Xn>, <Xm|SP> */
+    const char *const expected_0_0[6] = {
+        "blraa  %x0 %x0 -> %x30",   "blraa  %x5 %x6 -> %x30",
+        "blraa  %x10 %x11 -> %x30", "blraa  %x15 %x16 -> %x30",
+        "blraa  %x20 %x21 -> %x30", "blraa  %x30 %sp -> %x30",
+    };
+    TEST_LOOP(blraa, blraa, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(blraaz)
+{
+    /* Testing BLRAAZ  <Xn> */
+    const char *const expected_0_0[6] = {
+        "blraaz %x0 -> %x30",  "blraaz %x5 -> %x30",  "blraaz %x10 -> %x30",
+        "blraaz %x15 -> %x30", "blraaz %x20 -> %x30", "blraaz %x30 -> %x30",
+    };
+    TEST_LOOP(blraaz, blraaz, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
+TEST_INSTR(blrab)
+{
+    /* Testing BLRAB   <Xn>, <Xm|SP> */
+    const char *const expected_0_0[6] = {
+        "blrab  %x0 %x0 -> %x30",   "blrab  %x5 %x6 -> %x30",
+        "blrab  %x10 %x11 -> %x30", "blrab  %x15 %x16 -> %x30",
+        "blrab  %x20 %x21 -> %x30", "blrab  %x30 %sp -> %x30",
+    };
+    TEST_LOOP(blrab, blrab, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(blrabz)
+{
+    /* Testing BLRABZ  <Xn> */
+    const char *const expected_0_0[6] = {
+        "blrabz %x0 -> %x30",  "blrabz %x5 -> %x30",  "blrabz %x10 -> %x30",
+        "blrabz %x15 -> %x30", "blrabz %x20 -> %x30", "blrabz %x30 -> %x30",
+    };
+    TEST_LOOP(blrabz, blrabz, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
+TEST_INSTR(braa)
+{
+    /* Testing BRAA    <Xn>, <Xm|SP> */
+    const char *const expected_0_0[6] = {
+        "braa   %x0 %x0",   "braa   %x5 %x6",   "braa   %x10 %x11",
+        "braa   %x15 %x16", "braa   %x20 %x21", "braa   %x30 %sp",
+    };
+    TEST_LOOP(braa, braa, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(braaz)
+{
+    /* Testing BRAAZ   <Xn> */
+    const char *const expected_0_0[6] = {
+        "braaz  %x0",  "braaz  %x5",  "braaz  %x10",
+        "braaz  %x15", "braaz  %x20", "braaz  %x30",
+    };
+    TEST_LOOP(braaz, braaz, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
+TEST_INSTR(brab)
+{
+    /* Testing BRAB    <Xn>, <Xm|SP> */
+    const char *const expected_0_0[6] = {
+        "brab   %x0 %x0",   "brab   %x5 %x6",   "brab   %x10 %x11",
+        "brab   %x15 %x16", "brab   %x20 %x21", "brab   %x30 %sp",
+    };
+    TEST_LOOP(brab, brab, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(brabz)
+{
+    /* Testing BRABZ   <Xn> */
+    const char *const expected_0_0[6] = {
+        "brabz  %x0",  "brabz  %x5",  "brabz  %x10",
+        "brabz  %x15", "brabz  %x20", "brabz  %x30",
+    };
+    TEST_LOOP(brabz, brabz, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -342,6 +428,14 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(autib);
     RUN_INSTR_TEST(autiza);
     RUN_INSTR_TEST(autizb);
+    RUN_INSTR_TEST(blraa);
+    RUN_INSTR_TEST(blraaz);
+    RUN_INSTR_TEST(blrab);
+    RUN_INSTR_TEST(blrabz);
+    RUN_INSTR_TEST(braa);
+    RUN_INSTR_TEST(braaz);
+    RUN_INSTR_TEST(brab);
+    RUN_INSTR_TEST(brabz);
 
     print("All v8.3 tests complete.");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
BLRAA   <Xn>, <Xm|SP>
BLRAB   <Xn>, <Xm|SP>
BRAA    <Xn>, <Xm|SP>
BRAB    <Xn>, <Xm|SP>
BLRAAZ  <Xn>
BLRABZ  <Xn>
BRAAZ   <Xn>
BRABZ   <Xn>
```

Issues: #2626, #5623