### PR TITLE
i#2626 Finish AArch64 encoder/decoder: PACD*

### DIFF
--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -69,7 +69,11 @@
 1x11100010111111110000xxxxxxxxxx  n   796  LRCPC     ldapr  wx0_30 : mem0
 0011100010111111110000xxxxxxxxxx  n   797  LRCPC    ldaprb      w0 : mem0
 0111100010111111110000xxxxxxxxxx  n   798  LRCPC    ldaprh      w0 : mem0
-1101101011000001000010xxxxxxxxxx  n   687  PAUTH     pacda         : x0 x5
+1101101011000001000010xxxxxxxxxx  n   687  PAUTH     pacda      x0 : x0 x5sp
+1101101011000001000011xxxxxxxxxx  n   1042 PAUTH     pacdb      x0 : x0 x5sp
+110110101100000100101011111xxxxx  n   1043 PAUTH    pacdza      x0 : x0
+110110101100000100101111111xxxxx  n   1044 PAUTH    pacdzb      x0 : x0
+10011010110xxxxx001100xxxxxxxxxx  n   1045 PAUTH     pacga      x0 : x5 x16sp
 1101101011000001000000xxxxxxxxxx  n   688  PAUTH     pacia         : x0 x5
 1101101011000001000001xxxxxxxxxx  n   689  PAUTH     pacib         : x0 x5
 11010101000000110010001101111111  n   680  PAUTH   pacibsp         :

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -13691,4 +13691,69 @@
  */
 #define INSTR_CREATE_brabz(dc, Rn) instr_create_0dst_1src(dc, OP_brabz, Rn)
 
+/**
+ * Creates a PACDA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PACDA   <Xd>, <Xn|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination register, X (Extended, 64 bits).
+ * \param Rn   The second source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_pacda(dc, Rd, Rn) instr_create_1dst_2src(dc, OP_pacda, Rd, Rd, Rn)
+
+/**
+ * Creates a PACDB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PACDB   <Xd>, <Xn|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The first source and destination register, X (Extended, 64 bits).
+ * \param Rn   The second source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_pacdb(dc, Rd, Rn) instr_create_1dst_2src(dc, OP_pacdb, Rd, Rd, Rn)
+
+/**
+ * Creates a PACDZA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PACDZA  <Xd>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The source and destination register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_pacdza(dc, Rd) instr_create_1dst_1src(dc, OP_pacdza, Rd, Rd)
+
+/**
+ * Creates a PACDZB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PACDZB  <Xd>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The source and destination register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_pacdzb(dc, Rd) instr_create_1dst_1src(dc, OP_pacdzb, Rd, Rd)
+
+/**
+ * Creates a PACGA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    PACGA   <Xd>, <Xn>, <Xm|SP>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The destination register, X (Extended, 64 bits).
+ * \param Rn   The first source register, X (Extended, 64 bits).
+ * \param Rm   The second source register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_pacga(dc, Rd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_pacga, Rd, Rn, Rm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-v83.txt
+++ b/suite/tests/api/dis-a64-v83.txt
@@ -519,3 +519,94 @@ d61f0fdf : brabz x30                                 : brabz  %x30
 6f9b5b59 : fcmla v25.4s, v26.4s, v27.s[1], #0xb4     : fcmla  %q25 %q26 %q27 $0x01 $0x00b4 $0x02 -> %q25
 6f9d7b9b : fcmla v27.4s, v28.4s, v29.s[1], #0x10e    : fcmla  %q27 %q28 %q29 $0x01 $0x010e $0x02 -> %q27
 6f9f7bff : fcmla v31.4s, v31.4s, v31.s[1], #0x10e    : fcmla  %q31 %q31 %q31 $0x01 $0x010e $0x02 -> %q31
+
+# PACDA   <Xd>, <Xn|SP> (PACDA-R.R-auth)
+dac10800 : pacda x0, x0                              : pacda  %x0 %x0 -> %x0
+dac10862 : pacda x2, x3                              : pacda  %x2 %x3 -> %x2
+dac108a4 : pacda x4, x5                              : pacda  %x4 %x5 -> %x4
+dac108e6 : pacda x6, x7                              : pacda  %x6 %x7 -> %x6
+dac10928 : pacda x8, x9                              : pacda  %x8 %x9 -> %x8
+dac10949 : pacda x9, x10                             : pacda  %x9 %x10 -> %x9
+dac1098b : pacda x11, x12                            : pacda  %x11 %x12 -> %x11
+dac109cd : pacda x13, x14                            : pacda  %x13 %x14 -> %x13
+dac10a0f : pacda x15, x16                            : pacda  %x15 %x16 -> %x15
+dac10a51 : pacda x17, x18                            : pacda  %x17 %x18 -> %x17
+dac10a93 : pacda x19, x20                            : pacda  %x19 %x20 -> %x19
+dac10ad5 : pacda x21, x22                            : pacda  %x21 %x22 -> %x21
+dac10af6 : pacda x22, x23                            : pacda  %x22 %x23 -> %x22
+dac10b38 : pacda x24, x25                            : pacda  %x24 %x25 -> %x24
+dac10b7a : pacda x26, x27                            : pacda  %x26 %x27 -> %x26
+dac10bfe : pacda x30, sp                             : pacda  %x30 %sp -> %x30
+
+# PACDB   <Xd>, <Xn|SP> (PACDB-R.R-auth)
+dac10c00 : pacdb x0, x0                              : pacdb  %x0 %x0 -> %x0
+dac10c62 : pacdb x2, x3                              : pacdb  %x2 %x3 -> %x2
+dac10ca4 : pacdb x4, x5                              : pacdb  %x4 %x5 -> %x4
+dac10ce6 : pacdb x6, x7                              : pacdb  %x6 %x7 -> %x6
+dac10d28 : pacdb x8, x9                              : pacdb  %x8 %x9 -> %x8
+dac10d49 : pacdb x9, x10                             : pacdb  %x9 %x10 -> %x9
+dac10d8b : pacdb x11, x12                            : pacdb  %x11 %x12 -> %x11
+dac10dcd : pacdb x13, x14                            : pacdb  %x13 %x14 -> %x13
+dac10e0f : pacdb x15, x16                            : pacdb  %x15 %x16 -> %x15
+dac10e51 : pacdb x17, x18                            : pacdb  %x17 %x18 -> %x17
+dac10e93 : pacdb x19, x20                            : pacdb  %x19 %x20 -> %x19
+dac10ed5 : pacdb x21, x22                            : pacdb  %x21 %x22 -> %x21
+dac10ef6 : pacdb x22, x23                            : pacdb  %x22 %x23 -> %x22
+dac10f38 : pacdb x24, x25                            : pacdb  %x24 %x25 -> %x24
+dac10f7a : pacdb x26, x27                            : pacdb  %x26 %x27 -> %x26
+dac10ffe : pacdb x30, sp                             : pacdb  %x30 %sp -> %x30
+
+# PACDZA  <Xd> (PACDZA-R-auth)
+dac12be0 : pacdza x0                                 : pacdza %x0 -> %x0
+dac12be2 : pacdza x2                                 : pacdza %x2 -> %x2
+dac12be4 : pacdza x4                                 : pacdza %x4 -> %x4
+dac12be6 : pacdza x6                                 : pacdza %x6 -> %x6
+dac12be8 : pacdza x8                                 : pacdza %x8 -> %x8
+dac12be9 : pacdza x9                                 : pacdza %x9 -> %x9
+dac12beb : pacdza x11                                : pacdza %x11 -> %x11
+dac12bed : pacdza x13                                : pacdza %x13 -> %x13
+dac12bef : pacdza x15                                : pacdza %x15 -> %x15
+dac12bf1 : pacdza x17                                : pacdza %x17 -> %x17
+dac12bf3 : pacdza x19                                : pacdza %x19 -> %x19
+dac12bf5 : pacdza x21                                : pacdza %x21 -> %x21
+dac12bf6 : pacdza x22                                : pacdza %x22 -> %x22
+dac12bf8 : pacdza x24                                : pacdza %x24 -> %x24
+dac12bfa : pacdza x26                                : pacdza %x26 -> %x26
+dac12bfe : pacdza x30                                : pacdza %x30 -> %x30
+
+# PACDZB  <Xd> (PACDZB-R-auth)
+dac12fe0 : pacdzb x0                                 : pacdzb %x0 -> %x0
+dac12fe2 : pacdzb x2                                 : pacdzb %x2 -> %x2
+dac12fe4 : pacdzb x4                                 : pacdzb %x4 -> %x4
+dac12fe6 : pacdzb x6                                 : pacdzb %x6 -> %x6
+dac12fe8 : pacdzb x8                                 : pacdzb %x8 -> %x8
+dac12fe9 : pacdzb x9                                 : pacdzb %x9 -> %x9
+dac12feb : pacdzb x11                                : pacdzb %x11 -> %x11
+dac12fed : pacdzb x13                                : pacdzb %x13 -> %x13
+dac12fef : pacdzb x15                                : pacdzb %x15 -> %x15
+dac12ff1 : pacdzb x17                                : pacdzb %x17 -> %x17
+dac12ff3 : pacdzb x19                                : pacdzb %x19 -> %x19
+dac12ff5 : pacdzb x21                                : pacdzb %x21 -> %x21
+dac12ff6 : pacdzb x22                                : pacdzb %x22 -> %x22
+dac12ff8 : pacdzb x24                                : pacdzb %x24 -> %x24
+dac12ffa : pacdzb x26                                : pacdzb %x26 -> %x26
+dac12ffe : pacdzb x30                                : pacdzb %x30 -> %x30
+
+# PACGA   <Xd>, <Xn>, <Xm|SP> (PACGA-R.RR-auth)
+9ac03000 : pacga x0, x0, x0                          : pacga  %x0 %x0 -> %x0
+9ac43062 : pacga x2, x3, x4                          : pacga  %x3 %x4 -> %x2
+9ac630a4 : pacga x4, x5, x6                          : pacga  %x5 %x6 -> %x4
+9ac830e6 : pacga x6, x7, x8                          : pacga  %x7 %x8 -> %x6
+9aca3128 : pacga x8, x9, x10                         : pacga  %x9 %x10 -> %x8
+9acb3149 : pacga x9, x10, x11                        : pacga  %x10 %x11 -> %x9
+9acd318b : pacga x11, x12, x13                       : pacga  %x12 %x13 -> %x11
+9acf31cd : pacga x13, x14, x15                       : pacga  %x14 %x15 -> %x13
+9ad1320f : pacga x15, x16, x17                       : pacga  %x16 %x17 -> %x15
+9ad33251 : pacga x17, x18, x19                       : pacga  %x18 %x19 -> %x17
+9ad53293 : pacga x19, x20, x21                       : pacga  %x20 %x21 -> %x19
+9ad732d5 : pacga x21, x22, x23                       : pacga  %x22 %x23 -> %x21
+9ad832f6 : pacga x22, x23, x24                       : pacga  %x23 %x24 -> %x22
+9ada3338 : pacga x24, x25, x26                       : pacga  %x25 %x26 -> %x24
+9adc337a : pacga x26, x27, x28                       : pacga  %x27 %x28 -> %x26
+9adf33de : pacga x30, x30, sp                        : pacga  %x30 %sp -> %x30
+

--- a/suite/tests/api/ir_aarch64_v83.c
+++ b/suite/tests/api/ir_aarch64_v83.c
@@ -402,6 +402,64 @@ TEST_INSTR(brabz)
     TEST_LOOP(brabz, brabz, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
 }
 
+TEST_INSTR(pacda)
+{
+
+    /* Testing PACDA   <Xd>, <Xn|SP> */
+    const char *const expected_0_0[6] = {
+        "pacda  %x0 %x0 -> %x0",    "pacda  %x5 %x6 -> %x5",
+        "pacda  %x10 %x11 -> %x10", "pacda  %x15 %x16 -> %x15",
+        "pacda  %x20 %x21 -> %x20", "pacda  %x30 %sp -> %x30",
+    };
+    TEST_LOOP(pacda, pacda, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(pacdb)
+{
+    /* Testing PACDB   <Xd>, <Xn|SP> */
+    const char *const expected_0_0[6] = {
+        "pacdb  %x0 %x0 -> %x0",    "pacdb  %x5 %x6 -> %x5",
+        "pacdb  %x10 %x11 -> %x10", "pacdb  %x15 %x16 -> %x15",
+        "pacdb  %x20 %x21 -> %x20", "pacdb  %x30 %sp -> %x30",
+    };
+    TEST_LOOP(pacdb, pacdb, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1_sp[i]));
+}
+
+TEST_INSTR(pacdza)
+{
+    /* Testing PACDZA  <Xd> */
+    const char *const expected_0_0[6] = {
+        "pacdza %x0 -> %x0",   "pacdza %x5 -> %x5",   "pacdza %x10 -> %x10",
+        "pacdza %x15 -> %x15", "pacdza %x20 -> %x20", "pacdza %x30 -> %x30",
+    };
+    TEST_LOOP(pacdza, pacdza, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
+TEST_INSTR(pacdzb)
+{
+    /* Testing PACDZB  <Xd> */
+    const char *const expected_0_0[6] = {
+        "pacdzb %x0 -> %x0",   "pacdzb %x5 -> %x5",   "pacdzb %x10 -> %x10",
+        "pacdzb %x15 -> %x15", "pacdzb %x20 -> %x20", "pacdzb %x30 -> %x30",
+    };
+    TEST_LOOP(pacdzb, pacdzb, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
+}
+
+TEST_INSTR(pacga)
+{
+    /* Testing PACGA   <Xd>, <Xn>, <Xm|SP> */
+    const char *const expected_0_0[6] = {
+        "pacga  %x0 %x0 -> %x0",    "pacga  %x6 %x7 -> %x5",
+        "pacga  %x11 %x12 -> %x10", "pacga  %x16 %x17 -> %x15",
+        "pacga  %x21 %x22 -> %x20", "pacga  %x30 %sp -> %x30",
+    };
+    TEST_LOOP(pacga, pacga, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg(Xn_six_offset_1[i]),
+              opnd_create_reg(Xn_six_offset_2_sp[i]));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -436,6 +494,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(braaz);
     RUN_INSTR_TEST(brab);
     RUN_INSTR_TEST(brabz);
+    RUN_INSTR_TEST(pacda);
+    RUN_INSTR_TEST(pacdb);
+    RUN_INSTR_TEST(pacdza);
+    RUN_INSTR_TEST(pacdzb);
+    RUN_INSTR_TEST(pacga);
 
     print("All v8.3 tests complete.");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
PACDA   <Xd>, <Xn|SP>
PACDB   <Xd>, <Xn|SP>
PACDZA  <Xd>
PACDZB  <Xd>
PACGA   <Xd>, <Xn>, <Xm|SP>
```

Issues: #2626, #5623