### PR TITLE
i#2626 Finish AArch64 encoder/decoder: LDRA*

### DIFF
--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -41,50 +41,54 @@
 
 # Instruction definitions:
 
-1101101011000001000110xxxxxxxxxx  n   1027 PAUTH     autda      x0 : x0 x5sp
-1101101011000001000111xxxxxxxxxx  n   690  PAUTH     autdb      x0 : x0 x5sp
-110110101100000100111011111xxxxx  n   1028 PAUTH    autdza      x0 : x0
-110110101100000100111111111xxxxx  n   1029 PAUTH    autdzb      x0 : x0
-1101101011000001000100xxxxxxxxxx  n   1030 PAUTH     autia      x0 : x0 x5sp
-11010101000000110010000110011111  n   24   PAUTH autia1716  impx17 : impx17 impx16
-11010101000000110010001110111111  n   1031 PAUTH   autiasp  impx30 : impx30 impsp
-11010101000000110010001110011111  n   1032 PAUTH    autiaz  impx30 : impx30
-1101101011000001000101xxxxxxxxxx  n   1033 PAUTH     autib      x0 : x0 x5sp
-11010101000000110010000111011111  n   25   PAUTH autib1716  impx17 : impx17 impx16
-11010101000000110010001111111111  n   681  PAUTH   autibsp  impx30 : impx30 impsp
-11010101000000110010001111011111  n   1034 PAUTH    autibz  impx30 : impx30
-110110101100000100110011111xxxxx  n   1035 PAUTH    autiza      x0 : x0
-110110101100000100110111111xxxxx  n   1036 PAUTH    autizb      x0 : x0
-1101011100111111000010xxxxxxxxxx  n   782  PAUTH     blraa  impx30 : x5 x0sp
-1101011000111111000010xxxxx11111  n   682  PAUTH    blraaz  impx30 : x5
-1101011100111111000011xxxxxxxxxx  n   1037 PAUTH     blrab  impx30 : x5 x0sp
-1101011000111111000011xxxxx11111  n   1038 PAUTH    blrabz  impx30 : x5
-1101011100011111000010xxxxxxxxxx  n   683  PAUTH      braa         : x5 x0sp
-1101011000011111000010xxxxx11111  n   1039 PAUTH     braaz         : x5
-1101011100011111000011xxxxxxxxxx  n   1040 PAUTH      brab         : x5 x0sp
-1101011000011111000011xxxxx11111  n   1041 PAUTH     brabz         : x5
-0x101110xx0xxxxx111x01xxxxxxxxxx  n   944  BASE     fcadd     dq0 : dq0 dq5 dq16 imm1_ew_12 hs_sz
-0x101110xx0xxxxx110xx1xxxxxxxxxx  n   945  BASE     fcmla     dq0 : dq0 dq5 dq16 imm2_nesw_11 hs_sz
-0x101111xxxxxxxx0xx1x0xxxxxxxxxx  n   945  BASE     fcmla     dq0 : dq0 dq5 dq16 vindex_HS_2lane imm2_nesw_13 hs_sz
-1x11100010111111110000xxxxxxxxxx  n   796  LRCPC     ldapr  wx0_30 : mem0
-0011100010111111110000xxxxxxxxxx  n   797  LRCPC    ldaprb      w0 : mem0
-0111100010111111110000xxxxxxxxxx  n   798  LRCPC    ldaprh      w0 : mem0
-1101101011000001000010xxxxxxxxxx  n   687  PAUTH     pacda      x0 : x0 x5sp
-1101101011000001000011xxxxxxxxxx  n   1042 PAUTH     pacdb      x0 : x0 x5sp
-110110101100000100101011111xxxxx  n   1043 PAUTH    pacdza      x0 : x0
-110110101100000100101111111xxxxx  n   1044 PAUTH    pacdzb      x0 : x0
-10011010110xxxxx001100xxxxxxxxxx  n   1045 PAUTH     pacga      x0 : x5 x16sp
-1101101011000001000000xxxxxxxxxx  n   688  PAUTH     pacia      x0 : x0 x5sp
-11010101000000110010000100011111  n   1046 PAUTH pacia1716  impx17 : impx17 impx16
-11010101000000110010001100111111  n   1047 PAUTH   paciasp  impx30 : impx30 impsp
-11010101000000110010001100011111  n   1048 PAUTH    paciaz  impx30 : impx30
-1101101011000001000001xxxxxxxxxx  n   689  PAUTH     pacib      x0 : x0 x5sp
-11010101000000110010000101011111  n   1049 PAUTH pacib1716  impx17 : impx17 impx16
-11010101000000110010001101111111  n   680  PAUTH   pacibsp  impx30 : impx30 impsp
-11010101000000110010001101011111  n   1050 PAUTH    pacibz  impx30 : impx30
-110110101100000100100011111xxxxx  n   684  PAUTH    paciza      x0 : x0
-110110101100000100100111111xxxxx  n   1051 PAUTH    pacizb      x0 : x0
-11010110010111110000101111111111  n   679  PAUTH      reta         :
-11010110010111110000111111111111  n   679  PAUTH      reta         :
-110110101100000101000111111xxxxx  n   686  PAUTH     xpacd         : x0
-110110101100000101000011111xxxxx  n   685  PAUTH     xpaci         : x0
+1101101011000001000110xxxxxxxxxx  n   1027 PAUTH     autda       x0 : x0 x5sp
+1101101011000001000111xxxxxxxxxx  n   690  PAUTH     autdb       x0 : x0 x5sp
+110110101100000100111011111xxxxx  n   1028 PAUTH    autdza       x0 : x0
+110110101100000100111111111xxxxx  n   1029 PAUTH    autdzb       x0 : x0
+1101101011000001000100xxxxxxxxxx  n   1030 PAUTH     autia       x0 : x0 x5sp
+11010101000000110010000110011111  n   24   PAUTH autia1716   impx17 : impx17 impx16
+11010101000000110010001110111111  n   1031 PAUTH   autiasp   impx30 : impx30 impsp
+11010101000000110010001110011111  n   1032 PAUTH    autiaz   impx30 : impx30
+1101101011000001000101xxxxxxxxxx  n   1033 PAUTH     autib       x0 : x0 x5sp
+11010101000000110010000111011111  n   25   PAUTH autib1716   impx17 : impx17 impx16
+11010101000000110010001111111111  n   681  PAUTH   autibsp   impx30 : impx30 impsp
+11010101000000110010001111011111  n   1034 PAUTH    autibz   impx30 : impx30
+110110101100000100110011111xxxxx  n   1035 PAUTH    autiza       x0 : x0
+110110101100000100110111111xxxxx  n   1036 PAUTH    autizb       x0 : x0
+1101011100111111000010xxxxxxxxxx  n   782  PAUTH     blraa   impx30 : x5 x0sp
+1101011000111111000010xxxxx11111  n   682  PAUTH    blraaz   impx30 : x5
+1101011100111111000011xxxxxxxxxx  n   1037 PAUTH     blrab   impx30 : x5 x0sp
+1101011000111111000011xxxxx11111  n   1038 PAUTH    blrabz   impx30 : x5
+1101011100011111000010xxxxxxxxxx  n   683  PAUTH      braa          : x5 x0sp
+1101011000011111000010xxxxx11111  n   1039 PAUTH     braaz          : x5
+1101011100011111000011xxxxxxxxxx  n   1040 PAUTH      brab          : x5 x0sp
+1101011000011111000011xxxxx11111  n   1041 PAUTH     brabz          : x5
+0x101110xx0xxxxx111x01xxxxxxxxxx  n   944  BASE     fcadd      dq0 : dq0 dq5 dq16 imm1_ew_12 hs_sz
+0x101110xx0xxxxx110xx1xxxxxxxxxx  n   945  BASE     fcmla      dq0 : dq0 dq5 dq16 imm2_nesw_11 hs_sz
+0x101111xxxxxxxx0xx1x0xxxxxxxxxx  n   945  BASE     fcmla      dq0 : dq0 dq5 dq16 vindex_HS_2lane imm2_nesw_13 hs_sz
+1x11100010111111110000xxxxxxxxxx  n   796  LRCPC     ldapr   wx0_30 : mem0
+0011100010111111110000xxxxxxxxxx  n   797  LRCPC    ldaprb       w0 : mem0
+0111100010111111110000xxxxxxxxxx  n   798  LRCPC    ldaprh       w0 : mem0
+111110000x1xxxxxxxxx11xxxxxxxxxx  n   1052 PAUTH     ldraa  x0 x5sp : mem_s_imm9 x5sp mem_s_imm9_off
+111110000x1xxxxxxxxx01xxxxxxxxxx  n   1052 PAUTH     ldraa       x0 : mem_s_imm9
+111110001x1xxxxxxxxx11xxxxxxxxxx  n   1053 PAUTH     ldrab  x0 x5sp : mem_s_imm9 x5sp mem_s_imm9_off
+111110001x1xxxxxxxxx01xxxxxxxxxx  n   1053 PAUTH     ldrab       x0 : mem_s_imm9
+1101101011000001000010xxxxxxxxxx  n   687  PAUTH     pacda       x0 : x0 x5sp
+1101101011000001000011xxxxxxxxxx  n   1042 PAUTH     pacdb       x0 : x0 x5sp
+110110101100000100101011111xxxxx  n   1043 PAUTH    pacdza       x0 : x0
+110110101100000100101111111xxxxx  n   1044 PAUTH    pacdzb       x0 : x0
+10011010110xxxxx001100xxxxxxxxxx  n   1045 PAUTH     pacga       x0 : x5 x16sp
+1101101011000001000000xxxxxxxxxx  n   688  PAUTH     pacia       x0 : x0 x5sp
+11010101000000110010000100011111  n   1046 PAUTH pacia1716   impx17 : impx17 impx16
+11010101000000110010001100111111  n   1047 PAUTH   paciasp   impx30 : impx30 impsp
+11010101000000110010001100011111  n   1048 PAUTH    paciaz   impx30 : impx30
+1101101011000001000001xxxxxxxxxx  n   689  PAUTH     pacib       x0 : x0 x5sp
+11010101000000110010000101011111  n   1049 PAUTH pacib1716   impx17 : impx17 impx16
+11010101000000110010001101111111  n   680  PAUTH   pacibsp   impx30 : impx30 impsp
+11010101000000110010001101011111  n   1050 PAUTH    pacibz   impx30 : impx30
+110110101100000100100011111xxxxx  n   684  PAUTH    paciza       x0 : x0
+110110101100000100100111111xxxxx  n   1051 PAUTH    pacizb       x0 : x0
+11010110010111110000101111111111  n   679  PAUTH      reta          :
+11010110010111110000111111111111  n   679  PAUTH      reta          :
+110110101100000101000111111xxxxx  n   686  PAUTH     xpacd          : x0
+110110101100000101000011111xxxxx  n   685  PAUTH     xpaci          : x0

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -13886,4 +13886,68 @@
  */
 #define INSTR_CREATE_pacizb(dc, Rd) instr_create_1dst_1src(dc, OP_pacizb, Rd, Rd)
 
+/**
+ * Creates a LDRAA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDRAA   <Xt>, [<Xn|SP>, #<simm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rt   The destination  register, X (Extended, 64 bits).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, simm, OPSZ_8)
+ */
+#define INSTR_CREATE_ldraa(dc, Rt, Rn) instr_create_1dst_1src(dc, OP_ldraa, Rt, Rn)
+
+/**
+ * Creates a LDRAA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDRAA   <Xt>, [<Xn|SP>, #<simm>]!
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rt   The destination register, X (Extended, 64 bits).
+ * \param Xn   The base register.
+ * \param Rn   The base register with an immediate offset, constructed with the function:
+ *             opnd_create_base_disp(Xn, DR_REG_NULL, 0, simm, OPSZ_8)
+ * \param simm The immediate offset.
+ */
+#define INSTR_CREATE_ldraa_imm(dc, Rt, Xn, Rn, simm) \
+    instr_create_2dst_3src(dc, OP_ldraa, Rt, Xn, Rn, Xn, simm)
+
+/**
+ * Creates a LDRAB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDRAB   <Xt>, [<Xn|SP>, #<simm>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rt   The destination  register, X (Extended, 64 bits).
+ * \param Rn   The first source base register with an immediate offset,
+ *             constructed with the function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, simm, OPSZ_8)
+ */
+#define INSTR_CREATE_ldrab(dc, Rt, Rn) instr_create_1dst_1src(dc, OP_ldrab, Rt, Rn)
+
+/**
+ * Creates a LDRAB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LDRAB   <Xt>, [<Xn|SP>, #<simm>]!
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rt   The destination register, X (Extended, 64 bits).
+ * \param Xn   The base register.
+ * \param Rn   The base register with an immediate offset, constructed with the function:
+ *             opnd_create_base_disp(Xn, DR_REG_NULL, 0, simm, OPSZ_8)
+ * \param simm The immediate offset.
+ */
+#define INSTR_CREATE_ldrab_imm(dc, Rt, Xn, Rn, simm) \
+    instr_create_2dst_3src(dc, OP_ldrab, Rt, Xn, Rn, Xn, simm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -260,6 +260,7 @@
 ---------x------------xxxxx-----  wx_sz_5    # W/X register (or WZR/XZR) with size indicated in bit 22
 ---------x-xx-------------------  i3_index_19 # Index value from 22, 20:19
 ---------x-xxxxx----------------  wx_sz_16   # W/X register (or WZR/XZR) with size indicated in bit 22
+---------x-xxxxxxxxx------------  mem_s_imm9_off # The offset part of memory address reg+offset mem_s_imm9
 ---------xx----------------xxxxx  z_size21_hsd_0  # sve vector reg, elsz depending on size21
 ---------xx----------------xxxxx  z_size21_bhsd_0  # sve vector reg, elsz depending on size21
 ---------++++xxx----------------  immhb_shf  # encoding of #shift value in immh:immb fields
@@ -361,6 +362,7 @@
 ??---------xxxxxxxxx--xxxxx-----  memreg     # register offset, gets size from 31:30
 ??--------xxxxxxxxxxxxxxxxx-----  mem12      # gets size from 31:30
 ??-------x-xxxxx-??---xxxxx-----  sveprf_gpr_vec32 # SVE prefetch memory address (32-bit offset) [<Xn|SP>, <Zm>.<T>, <mod>{ <amount>}]
+??-------x-xxxxxxxxx?-xxxxx-----  mem_s_imm9 # Memory address reg+offset S:imm9, gets size from 31:30
 ??-----??x?xxxxx------xxxxx-----  svemem_gpr_vec32_ld # SVE memory address (32-bit offset) [<Xn|SP>, <Zm>.<T>, <mod> <amount>]
 ??---?----------------xxxxx-----  mem7post   # gets size from 31:30 and 26; post-index
 ??---?----xxxxxxx---------------  mem7off    # gets size from 31:30 and 26

--- a/suite/tests/api/dis-a64-v83.txt
+++ b/suite/tests/api/dis-a64-v83.txt
@@ -520,6 +520,78 @@ d61f0fdf : brabz x30                                 : brabz  %x30
 6f9d7b9b : fcmla v27.4s, v28.4s, v29.s[1], #0x10e    : fcmla  %q27 %q28 %q29 $0x01 $0x010e $0x02 -> %q27
 6f9f7bff : fcmla v31.4s, v31.4s, v31.s[1], #0x10e    : fcmla  %q31 %q31 %q31 $0x01 $0x010e $0x02 -> %q31
 
+# LDRAA   <Xt>, [<Xn|SP>, #<simm>] (LDRAA-R.RI-auth_offset)
+f8600400 : ldraa x0, [x0, #-4096]                    : ldraa  -0x1000(%x0)[8byte] -> %x0
+f8640462 : ldraa x2, [x3, #-3584]                    : ldraa  -0x0e00(%x3)[8byte] -> %x2
+f86804a4 : ldraa x4, [x5, #-3072]                    : ldraa  -0x0c00(%x5)[8byte] -> %x4
+f86c04e6 : ldraa x6, [x7, #-2560]                    : ldraa  -0x0a00(%x7)[8byte] -> %x6
+f8700528 : ldraa x8, [x9, #-2048]                    : ldraa  -0x0800(%x9)[8byte] -> %x8
+f8740549 : ldraa x9, [x10, #-1536]                   : ldraa  -0x0600(%x10)[8byte] -> %x9
+f878058b : ldraa x11, [x12, #-1024]                  : ldraa  -0x0400(%x12)[8byte] -> %x11
+f87c05cd : ldraa x13, [x14, #-512]                   : ldraa  -0x0200(%x14)[8byte] -> %x13
+f820060f : ldraa x15, [x16, #0]                      : ldraa  (%x16)[8byte] -> %x15
+f823f651 : ldraa x17, [x18, #504]                    : ldraa  +0x01f8(%x18)[8byte] -> %x17
+f827f693 : ldraa x19, [x20, #1016]                   : ldraa  +0x03f8(%x20)[8byte] -> %x19
+f82bf6d5 : ldraa x21, [x22, #1528]                   : ldraa  +0x05f8(%x22)[8byte] -> %x21
+f82ff6f6 : ldraa x22, [x23, #2040]                   : ldraa  +0x07f8(%x23)[8byte] -> %x22
+f833f738 : ldraa x24, [x25, #2552]                   : ldraa  +0x09f8(%x25)[8byte] -> %x24
+f837f77a : ldraa x26, [x27, #3064]                   : ldraa  +0x0bf8(%x27)[8byte] -> %x26
+f83ff7fe : ldraa x30, [sp, #4088]                    : ldraa  +0x0ff8(%sp)[8byte] -> %x30
+
+# LDRAA   <Xt>, [<Xn|SP>, #<simm>]! (LDRAA-R.RI-auth_immpre)
+f8600c00 : ldraa x0, [x0, #-4096]!                   : ldraa  -0x1000(%x0)[8byte] %x0 $0xfffffffffffff000 -> %x0 %x0
+f8640c62 : ldraa x2, [x3, #-3584]!                   : ldraa  -0x0e00(%x3)[8byte] %x3 $0xfffffffffffff200 -> %x2 %x3
+f8680ca4 : ldraa x4, [x5, #-3072]!                   : ldraa  -0x0c00(%x5)[8byte] %x5 $0xfffffffffffff400 -> %x4 %x5
+f86c0ce6 : ldraa x6, [x7, #-2560]!                   : ldraa  -0x0a00(%x7)[8byte] %x7 $0xfffffffffffff600 -> %x6 %x7
+f8700d28 : ldraa x8, [x9, #-2048]!                   : ldraa  -0x0800(%x9)[8byte] %x9 $0xfffffffffffff800 -> %x8 %x9
+f8740d49 : ldraa x9, [x10, #-1536]!                  : ldraa  -0x0600(%x10)[8byte] %x10 $0xfffffffffffffa00 -> %x9 %x10
+f8780d8b : ldraa x11, [x12, #-1024]!                 : ldraa  -0x0400(%x12)[8byte] %x12 $0xfffffffffffffc00 -> %x11 %x12
+f87c0dcd : ldraa x13, [x14, #-512]!                  : ldraa  -0x0200(%x14)[8byte] %x14 $0xfffffffffffffe00 -> %x13 %x14
+f8200e0f : ldraa x15, [x16, #0]!                     : ldraa  (%x16)[8byte] %x16 $0x0000000000000000 -> %x15 %x16
+f823fe51 : ldraa x17, [x18, #504]!                   : ldraa  +0x01f8(%x18)[8byte] %x18 $0x00000000000001f8 -> %x17 %x18
+f827fe93 : ldraa x19, [x20, #1016]!                  : ldraa  +0x03f8(%x20)[8byte] %x20 $0x00000000000003f8 -> %x19 %x20
+f82bfed5 : ldraa x21, [x22, #1528]!                  : ldraa  +0x05f8(%x22)[8byte] %x22 $0x00000000000005f8 -> %x21 %x22
+f82ffef6 : ldraa x22, [x23, #2040]!                  : ldraa  +0x07f8(%x23)[8byte] %x23 $0x00000000000007f8 -> %x22 %x23
+f833ff38 : ldraa x24, [x25, #2552]!                  : ldraa  +0x09f8(%x25)[8byte] %x25 $0x00000000000009f8 -> %x24 %x25
+f837ff7a : ldraa x26, [x27, #3064]!                  : ldraa  +0x0bf8(%x27)[8byte] %x27 $0x0000000000000bf8 -> %x26 %x27
+f83ffffe : ldraa x30, [sp, #4088]!                   : ldraa  +0x0ff8(%sp)[8byte] %sp $0x0000000000000ff8 -> %x30 %sp
+
+# LDRAB   <Xt>, [<Xn|SP>, #<simm>] (LDRAB-R.RI-auth_offset)
+f8e00400 : ldrab x0, [x0, #-4096]                    : ldrab  -0x1000(%x0)[8byte] -> %x0
+f8e40462 : ldrab x2, [x3, #-3584]                    : ldrab  -0x0e00(%x3)[8byte] -> %x2
+f8e804a4 : ldrab x4, [x5, #-3072]                    : ldrab  -0x0c00(%x5)[8byte] -> %x4
+f8ec04e6 : ldrab x6, [x7, #-2560]                    : ldrab  -0x0a00(%x7)[8byte] -> %x6
+f8f00528 : ldrab x8, [x9, #-2048]                    : ldrab  -0x0800(%x9)[8byte] -> %x8
+f8f40549 : ldrab x9, [x10, #-1536]                   : ldrab  -0x0600(%x10)[8byte] -> %x9
+f8f8058b : ldrab x11, [x12, #-1024]                  : ldrab  -0x0400(%x12)[8byte] -> %x11
+f8fc05cd : ldrab x13, [x14, #-512]                   : ldrab  -0x0200(%x14)[8byte] -> %x13
+f8a0060f : ldrab x15, [x16, #0]                      : ldrab  (%x16)[8byte] -> %x15
+f8a3f651 : ldrab x17, [x18, #504]                    : ldrab  +0x01f8(%x18)[8byte] -> %x17
+f8a7f693 : ldrab x19, [x20, #1016]                   : ldrab  +0x03f8(%x20)[8byte] -> %x19
+f8abf6d5 : ldrab x21, [x22, #1528]                   : ldrab  +0x05f8(%x22)[8byte] -> %x21
+f8aff6f6 : ldrab x22, [x23, #2040]                   : ldrab  +0x07f8(%x23)[8byte] -> %x22
+f8b3f738 : ldrab x24, [x25, #2552]                   : ldrab  +0x09f8(%x25)[8byte] -> %x24
+f8b7f77a : ldrab x26, [x27, #3064]                   : ldrab  +0x0bf8(%x27)[8byte] -> %x26
+f8bff7fe : ldrab x30, [sp, #4088]                    : ldrab  +0x0ff8(%sp)[8byte] -> %x30
+
+# LDRAB   <Xt>, [<Xn|SP>, #<simm>]! (LDRAB-R.RI-auth_immpre)
+f8e00c00 : ldrab x0, [x0, #-4096]!                   : ldrab  -0x1000(%x0)[8byte] %x0 $0xfffffffffffff000 -> %x0 %x0
+f8e40c62 : ldrab x2, [x3, #-3584]!                   : ldrab  -0x0e00(%x3)[8byte] %x3 $0xfffffffffffff200 -> %x2 %x3
+f8e80ca4 : ldrab x4, [x5, #-3072]!                   : ldrab  -0x0c00(%x5)[8byte] %x5 $0xfffffffffffff400 -> %x4 %x5
+f8ec0ce6 : ldrab x6, [x7, #-2560]!                   : ldrab  -0x0a00(%x7)[8byte] %x7 $0xfffffffffffff600 -> %x6 %x7
+f8f00d28 : ldrab x8, [x9, #-2048]!                   : ldrab  -0x0800(%x9)[8byte] %x9 $0xfffffffffffff800 -> %x8 %x9
+f8f40d49 : ldrab x9, [x10, #-1536]!                  : ldrab  -0x0600(%x10)[8byte] %x10 $0xfffffffffffffa00 -> %x9 %x10
+f8f80d8b : ldrab x11, [x12, #-1024]!                 : ldrab  -0x0400(%x12)[8byte] %x12 $0xfffffffffffffc00 -> %x11 %x12
+f8fc0dcd : ldrab x13, [x14, #-512]!                  : ldrab  -0x0200(%x14)[8byte] %x14 $0xfffffffffffffe00 -> %x13 %x14
+f8a00e0f : ldrab x15, [x16, #0]!                     : ldrab  (%x16)[8byte] %x16 $0x0000000000000000 -> %x15 %x16
+f8a3fe51 : ldrab x17, [x18, #504]!                   : ldrab  +0x01f8(%x18)[8byte] %x18 $0x00000000000001f8 -> %x17 %x18
+f8a7fe93 : ldrab x19, [x20, #1016]!                  : ldrab  +0x03f8(%x20)[8byte] %x20 $0x00000000000003f8 -> %x19 %x20
+f8abfed5 : ldrab x21, [x22, #1528]!                  : ldrab  +0x05f8(%x22)[8byte] %x22 $0x00000000000005f8 -> %x21 %x22
+f8affef6 : ldrab x22, [x23, #2040]!                  : ldrab  +0x07f8(%x23)[8byte] %x23 $0x00000000000007f8 -> %x22 %x23
+f8b3ff38 : ldrab x24, [x25, #2552]!                  : ldrab  +0x09f8(%x25)[8byte] %x25 $0x00000000000009f8 -> %x24 %x25
+f8b7ff7a : ldrab x26, [x27, #3064]!                  : ldrab  +0x0bf8(%x27)[8byte] %x27 $0x0000000000000bf8 -> %x26 %x27
+f8bffffe : ldrab x30, [sp, #4088]!                   : ldrab  +0x0ff8(%sp)[8byte] %sp $0x0000000000000ff8 -> %x30 %sp
+
 # PACDA   <Xd>, <Xn|SP> (PACDA-R.R-auth)
 dac10800 : pacda x0, x0                              : pacda  %x0 %x0 -> %x0
 dac10862 : pacda x2, x3                              : pacda  %x2 %x3 -> %x2

--- a/suite/tests/api/ir_aarch64_v83.c
+++ b/suite/tests/api/ir_aarch64_v83.c
@@ -510,6 +510,63 @@ TEST_INSTR(pacizb)
     TEST_LOOP(pacizb, pacizb, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
 }
 
+TEST_INSTR(ldraa)
+{
+    /* Testing LDRAA   <Xt>, [<Xn|SP>, #<simm>]! */
+    static const int simm[6] = { -4096, -2720, -1352, 16, 1376, 4088 };
+    const char *const expected_0_0[6] = {
+        "ldraa  -0x1000(%x0)[8byte] %x0 $0xfffffffffffff000 -> %x0 %x0",
+        "ldraa  -0x0aa0(%x6)[8byte] %x6 $0xfffffffffffff560 -> %x5 %x6",
+        "ldraa  -0x0548(%x11)[8byte] %x11 $0xfffffffffffffab8 -> %x10 %x11",
+        "ldraa  +0x10(%x16)[8byte] %x16 $0x0000000000000010 -> %x15 %x16",
+        "ldraa  +0x0560(%x21)[8byte] %x21 $0x0000000000000560 -> %x20 %x21",
+        "ldraa  +0x0ff8(%sp)[8byte] %sp $0x0000000000000ff8 -> %x30 %sp",
+    };
+    TEST_LOOP(
+        ldraa, ldraa_imm, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+        opnd_create_reg(Xn_six_offset_1_sp[i]),
+        opnd_create_base_disp(Xn_six_offset_1_sp[i], DR_REG_NULL, 0, simm[i], OPSZ_8),
+        opnd_create_immed_uint(simm[i], OPSZ_PTR));
+
+    /* Testing LDRAA   <Xt>, [<Xn|SP>, #<simm>] */
+    const char *const expected_1_0[6] = {
+        "ldraa  -0x1000(%x0)[8byte] -> %x0",   "ldraa  -0x0aa0(%x6)[8byte] -> %x5",
+        "ldraa  -0x0548(%x11)[8byte] -> %x10", "ldraa  +0x10(%x16)[8byte] -> %x15",
+        "ldraa  +0x0560(%x21)[8byte] -> %x20", "ldraa  +0x0ff8(%sp)[8byte] -> %x30",
+    };
+    TEST_LOOP(
+        ldraa, ldraa, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+        opnd_create_base_disp(Xn_six_offset_1_sp[i], DR_REG_NULL, 0, simm[i], OPSZ_8));
+}
+
+TEST_INSTR(ldrab)
+{
+    /* Testing LDRAB   <Xt>, [<Xn|SP>, #<simm>]! */
+    static const int simm[6] = { -4096, -2720, -1352, 16, 1376, 4088 };
+    const char *const expected_0_0[6] = {
+        "ldrab  -0x1000(%x0)[8byte] %x0 $0xfffffffffffff000 -> %x0 %x0",
+        "ldrab  -0x0aa0(%x6)[8byte] %x6 $0xfffffffffffff560 -> %x5 %x6",
+        "ldrab  -0x0548(%x11)[8byte] %x11 $0xfffffffffffffab8 -> %x10 %x11",
+        "ldrab  +0x10(%x16)[8byte] %x16 $0x0000000000000010 -> %x15 %x16",
+        "ldrab  +0x0560(%x21)[8byte] %x21 $0x0000000000000560 -> %x20 %x21",
+        "ldrab  +0x0ff8(%sp)[8byte] %sp $0x0000000000000ff8 -> %x30 %sp",
+    };
+    TEST_LOOP(
+        ldrab, ldrab_imm, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+        opnd_create_reg(Xn_six_offset_1_sp[i]),
+        opnd_create_base_disp(Xn_six_offset_1_sp[i], DR_REG_NULL, 0, simm[i], OPSZ_8),
+        opnd_create_immed_uint(simm[i], OPSZ_PTR));
+
+    /* Testing LDRAB   <Xt>, [<Xn|SP>, #<simm>] */
+    const char *const expected_1_0[6] = {
+        "ldrab  -0x1000(%x0)[8byte] -> %x0",   "ldrab  -0x0aa0(%x6)[8byte] -> %x5",
+        "ldrab  -0x0548(%x11)[8byte] -> %x10", "ldrab  +0x10(%x16)[8byte] -> %x15",
+        "ldrab  +0x0560(%x21)[8byte] -> %x20", "ldrab  +0x0ff8(%sp)[8byte] -> %x30",
+    };
+    TEST_LOOP(
+        ldrab, ldrab, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+        opnd_create_base_disp(Xn_six_offset_1_sp[i], DR_REG_NULL, 0, simm[i], OPSZ_8));
+}
 int
 main(int argc, char *argv[])
 {
@@ -553,6 +610,8 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(pacib);
     RUN_INSTR_TEST(paciza);
     RUN_INSTR_TEST(pacizb);
+    RUN_INSTR_TEST(ldraa);
+    RUN_INSTR_TEST(ldrab);
 
     print("All v8.3 tests complete.");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
LDRAA   <Xt>, [<Xn|SP>, #<simm>]!
LDRAA   <Xt>, [<Xn|SP>, #<simm>]
LDRAB   <Xt>, [<Xn|SP>, #<simm>]!
LDRAB   <Xt>, [<Xn|SP>, #<simm>]
```

Issues: #2626, #5623