### PR TITLE
i#2626 Finish AArch64 encoder/decoder: *RETA*

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -90,7 +90,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -102,7 +102,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -194,7 +194,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -282,7 +282,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -370,7 +370,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -450,7 +450,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -535,7 +535,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER="9.91.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export VERSION_NUMBER="9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))"
           export PREFIX="cronbuild-"
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 
 # N.B.: When updating this, update all the default versions in ci-package.yml
 # and ci-docs.yml.  We should find a way to share (xref i#1565).
-set(VERSION_NUMBER_DEFAULT "9.91.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "9.92.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -152,6 +152,10 @@ changes:
  - Refactored the drmemtrace reader and file reader classes to better fit the
    new scheduler model: now each reader owns just one single stream of records
    with all multi-stream interleaving owned by the scheduler.
+ - Replaced the AArch64 OP_reta with OP_retaa and OP_retab. "reta" is not a real
+   AArch64 instruction and "reta" entries in the AArch64 codec were being used to
+   decode "retaa" and "retab". These instructions will now encode and decode correctly
+   as "retaa" and "retab".
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -1547,8 +1547,8 @@ mangle_indirect_jump(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
     }
 
     switch (opc) {
-    // TODO i#5623: Add the other OP_reta* opcodes and handle them here.
-    case OP_reta:
+    case OP_retaa:
+    case OP_retab:
     case OP_braa:
     case OP_brab:
     case OP_braaz:

--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -32,13 +32,6 @@
 # instructions are defined for the purposes of decode and encode code
 # generation.
 
-# TODO i#5623: Add the complete set of pointer authentication instructions,
-# along with whatever else is in v8.3.  For now we only include
-# instructions needed for initial M1 support.
-
-# TODO i#5623: Add the INSTR_CREATE_ macros for the opcodes below and
-# add tests for these.
-
 # Instruction definitions:
 
 1101101011000001000110xxxxxxxxxx  n   1027 PAUTH     autda       x0 : x0 x5sp
@@ -63,6 +56,8 @@
 1101011000011111000010xxxxx11111  n   1039 PAUTH     braaz          : x5
 1101011100011111000011xxxxxxxxxx  n   1040 PAUTH      brab          : x5 x0sp
 1101011000011111000011xxxxx11111  n   1041 PAUTH     brabz          : x5
+11010110100111110000101111111111  n   1054 PAUTH    eretaa          : impx30 impsp
+11010110100111110000111111111111  n   1055 PAUTH    eretab          : impx30 impsp
 0x101110xx0xxxxx111x01xxxxxxxxxx  n   944  BASE     fcadd      dq0 : dq0 dq5 dq16 imm1_ew_12 hs_sz
 0x101110xx0xxxxx110xx1xxxxxxxxxx  n   945  BASE     fcmla      dq0 : dq0 dq5 dq16 imm2_nesw_11 hs_sz
 0x101111xxxxxxxx0xx1x0xxxxxxxxxx  n   945  BASE     fcmla      dq0 : dq0 dq5 dq16 vindex_HS_2lane imm2_nesw_13 hs_sz
@@ -88,8 +83,8 @@
 11010101000000110010001101011111  n   1050 PAUTH    pacibz   impx30 : impx30
 110110101100000100100011111xxxxx  n   684  PAUTH    paciza       x0 : x0
 110110101100000100100111111xxxxx  n   1051 PAUTH    pacizb       x0 : x0
-11010110010111110000101111111111  n   679  PAUTH      reta          :
-11010110010111110000111111111111  n   679  PAUTH      reta          :
+11010110010111110000101111111111  n   679  PAUTH     retaa          : impx30 impsp
+11010110010111110000111111111111  n   1056 PAUTH     retab          : impx30 impsp
 110110101100000101000111111xxxxx  n   686  PAUTH     xpacd       x0 : x0
 110110101100000101000011111xxxxx  n   685  PAUTH     xpaci       x0 : x0
 11010101000000110010000011111111  n   561  PAUTH   xpaclri   impx30 : impx30

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -91,7 +91,8 @@ instr_branch_type(instr_t *cti_instr)
     case OP_braaz:
     case OP_brabz: return LINK_INDIRECT | LINK_JMP;
     case OP_ret:
-    case OP_reta: return LINK_INDIRECT | LINK_RETURN;
+    case OP_retaa:
+    case OP_retab: return LINK_INDIRECT | LINK_RETURN;
     }
     CLIENT_ASSERT(false, "instr_branch_type: unknown opcode");
     return LINK_INDIRECT;
@@ -157,8 +158,7 @@ bool
 instr_is_return(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    // TODO i#5623: Add the other OP_brra* and OP_reta* opcodes.
-    return (opc == OP_ret || opc == OP_reta);
+    return (opc == OP_ret || opc == OP_retaa || opc == OP_retab);
 }
 
 bool
@@ -174,7 +174,6 @@ bool
 instr_is_mbr_arch(instr_t *instr)
 {
     int opc = instr->opcode; /* caller ensures opcode is valid */
-    // TODO i#5623: Add the other OP_reta* opcodes.
     switch (opc) {
     case OP_blr:
     case OP_br:
@@ -187,7 +186,8 @@ instr_is_mbr_arch(instr_t *instr)
     case OP_blraaz:
     case OP_blrabz:
     case OP_ret:
-    case OP_reta: return true;
+    case OP_retaa:
+    case OP_retab: return true;
     default: return false;
     }
 }

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -13980,4 +13980,56 @@
     instr_create_1dst_1src(dc, OP_xpaclri, opnd_create_reg(DR_REG_X30), \
                            opnd_create_reg(DR_REG_X30))
 
+/**
+ * Creates an ERETAA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ERETAA
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_eretaa(dc)                                        \
+    instr_create_0dst_2src(dc, OP_eretaa, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_SP))
+
+/**
+ * Creates an ERETAB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ERETAB
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_eretab(dc)                                        \
+    instr_create_0dst_2src(dc, OP_eretab, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_SP))
+
+/**
+ * Creates a RETAA instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RETAA
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_retaa(dc)                                        \
+    instr_create_0dst_2src(dc, OP_retaa, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_SP))
+
+/**
+ * Creates a RETAB instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    RETAB
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_retab(dc)                                        \
+    instr_create_0dst_2src(dc, OP_retab, opnd_create_reg(DR_REG_X30), \
+                           opnd_create_reg(DR_REG_SP))
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-v83.txt
+++ b/suite/tests/api/dis-a64-v83.txt
@@ -338,6 +338,12 @@ d61f0f1f : brabz x24                                 : brabz  %x24
 d61f0f5f : brabz x26                                 : brabz  %x26
 d61f0fdf : brabz x30                                 : brabz  %x30
 
+# ERETAA   (ERETAA-R-auth)
+d69f0bff : eretaa                                    : eretaa %x30 %sp
+
+# ERETAB   (ERETAB-R-auth)
+d69f0fff : eretab                                    : eretab %x30 %sp
+
 # FCADD   <Vd>.<T>, <Vn>.<T>, <Vm>.<T>, <imm> (FCADD-Q.QQ-Vec)
 2e40e400 : fcadd v0.4h, v0.4h, v0.4h, #0x5a          : fcadd  %d0 %d0 %d0 $0x005a $0x01 -> %d0
 2e44e462 : fcadd v2.4h, v3.4h, v4.4h, #0x5a          : fcadd  %d2 %d3 %d4 $0x005a $0x01 -> %d2
@@ -771,6 +777,12 @@ dac127f6 : pacizb x22                                : pacizb %x22 -> %x22
 dac127f8 : pacizb x24                                : pacizb %x24 -> %x24
 dac127fa : pacizb x26                                : pacizb %x26 -> %x26
 dac127fe : pacizb x30                                : pacizb %x30 -> %x30
+
+# RETAA    (RETAA-R-auth)
+d65f0bff : retaa                                     : retaa  %x30 %sp
+
+# RETAB    (RETAB-R-auth)
+d65f0fff : retab                                     : retab  %x30 %sp
 
 # XPACD   <Xd> (XPACD-R-auth)
 dac147e0 : xpacd x0                                  : xpacd  %x0 -> %x0

--- a/suite/tests/api/ir_aarch64_v83.c
+++ b/suite/tests/api/ir_aarch64_v83.c
@@ -289,6 +289,10 @@ TEST_INSTR(pauth_hints)
     TEST_NO_OPNDS(pacibsp, pacibsp, "pacibsp %x30 %sp -> %x30");
     TEST_NO_OPNDS(pacibz, pacibz, "pacibz %x30 -> %x30");
     TEST_NO_OPNDS(xpaclri, xpaclri, "xpaclri %x30 -> %x30");
+    TEST_NO_OPNDS(eretaa, eretaa, "eretaa %x30 %sp");
+    TEST_NO_OPNDS(eretab, eretab, "eretab %x30 %sp");
+    TEST_NO_OPNDS(retaa, retaa, "retaa  %x30 %sp");
+    TEST_NO_OPNDS(retab, retab, "retab  %x30 %sp");
 }
 
 TEST_INSTR(autib)


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
ERETAA
ERETAB
RETAA
RETAB

Issues: #2626, #5623