### PR TITLE
i#5934 dup syscall: Skip extraneous syscall in raw2trace.

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -936,7 +936,7 @@ test_duplicate_syscalls(void *drcontext)
     instr_t *move1 =
         XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
     // XXX: Adding an XINST_CREATE_syscall macro will simplify this but there are
-    // complexities (xref create_syscall_instr());
+    // complexities (xref create_syscall_instr()).
 #ifdef X86
     instr_t *sys = INSTR_CREATE_syscall(drcontext);
 #elif defined(AARCHXX)

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -935,12 +935,16 @@ test_duplicate_syscalls(void *drcontext)
     instr_t *nop = XINST_CREATE_nop(drcontext);
     instr_t *move1 =
         XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    // XXX: Adding an XINST_CREATE_syscall macro will simplify this but there are
+    // complexities (xref create_syscall_instr());
 #ifdef X86
     instr_t *sys = INSTR_CREATE_syscall(drcontext);
 #elif defined(AARCHXX)
     instr_t *sys = INSTR_CREATE_svc(drcontext, opnd_create_immed_int((sbyte)0x0, OPSZ_1));
-#else
+#elif defined(RISCV64)
     instr_t *sys = INSTR_CREATE_ecall(drcontext);
+#else
+    #error Unsupported architecture.
 #endif
     instr_t *move2 =
         XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -1025,17 +1025,9 @@ test_duplicate_syscalls(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
         // The move1 instr.
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
-#ifdef X86_32
-        // An extra encoding entry is needed.
-        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
-#endif
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         // The sys instr.
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
-#ifdef X86_32
-        // An extra encoding entry is needed.
-        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
-#endif
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         // Prev block ends.
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -944,7 +944,7 @@ test_duplicate_syscalls(void *drcontext)
 #elif defined(RISCV64)
     instr_t *sys = INSTR_CREATE_ecall(drcontext);
 #else
-    #error Unsupported architecture.
+#    error Unsupported architecture.
 #endif
     instr_t *move2 =
         XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -938,7 +938,7 @@ test_duplicate_syscalls(void *drcontext)
 #ifdef X86
     instr_t *sys = INSTR_CREATE_syscall(drcontext);
 #elif defined(AARCHXX)
-    instr_t *sys = INSTR_CREATE_svc(drcontext, 1);
+    instr_t *sys = INSTR_CREATE_svc(drcontext, opnd_create_immed_int((sbyte)0x0, OPSZ_1));
 #else
     instr_t *sys = INSTR_CREATE_ecall(drcontext);
 #endif

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1036,6 +1036,8 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
         desc->packed_ |= kIsFlushMask;
     if (instr_is_cti(instr))
         desc->packed_ |= kIsCtiMask;
+    // XXX i#5949: This has some OS-specific behavior that should be preserved
+    // even when decoding a trace collected on a different platform.
     if (instr_is_syscall(instr))
         desc->packed_ |= kIsSyscallMask;
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -764,6 +764,7 @@ raw2trace_t::do_conversion()
             if (!error.empty())
                 return error;
             count_elided_ += thread_data_[i]->count_elided;
+            count_duplicate_syscall_ += thread_data_[i]->count_duplicate_syscall;
         }
     } else {
         // The files can be converted concurrently.
@@ -780,11 +781,14 @@ raw2trace_t::do_conversion()
             if (!tdata->error.empty())
                 return tdata->error;
             count_elided_ += tdata->count_elided;
+            count_duplicate_syscall_ += tdata->count_duplicate_syscall;
         }
     }
     error = aggregate_and_write_schedule_files();
     if (!error.empty())
         return error;
+    VPRINT(1, "Omitted " UINT64_FORMAT_STRING " duplicate system calls.\n",
+           count_duplicate_syscall_);
     VPRINT(1, "Reconstructed " UINT64_FORMAT_STRING " elided addresses.\n",
            count_elided_);
     VPRINT(1, "Successfully converted %zu thread files\n", thread_data_.size());
@@ -1032,6 +1036,8 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
         desc->packed_ |= kIsFlushMask;
     if (instr_is_cti(instr))
         desc->packed_ |= kIsCtiMask;
+    if (instr_is_syscall(instr))
+        desc->packed_ |= kIsSyscallMask;
 
 #ifdef AARCH64
     bool is_dc_zva = instru_t::is_aarch64_dc_zva_instr(instr);
@@ -1488,6 +1494,20 @@ raw2trace_t::log_instruction(uint level, app_pc decode_pc, app_pc orig_pc)
 }
 
 void
+raw2trace_t::set_last_pc_if_syscall(void *tls, app_pc value)
+{
+    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
+    tdata->last_pc_if_syscall_ = value;
+}
+
+app_pc
+raw2trace_t::get_last_pc_if_syscall(void *tls)
+{
+    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
+    return tdata->last_pc_if_syscall_;
+}
+
+void
 raw2trace_t::set_prev_instr_rep_string(void *tls, bool value)
 {
     auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
@@ -1704,6 +1724,7 @@ raw2trace_t::add_to_statistic(void *tls, raw2trace_statistic_t stat, int value)
     auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     switch (stat) {
     case RAW2TRACE_STAT_COUNT_ELIDED: tdata->count_elided += value; break;
+    case RAW2TRACE_STAT_DUPLICATE_SYSCALL: tdata->count_duplicate_syscall += value; break;
     default: DR_ASSERT(false);
     }
 }
@@ -1713,6 +1734,7 @@ raw2trace_t::get_statistic(raw2trace_statistic_t stat)
 {
     switch (stat) {
     case RAW2TRACE_STAT_COUNT_ELIDED: return count_elided_;
+    case RAW2TRACE_STAT_DUPLICATE_SYSCALL: return count_duplicate_syscall_;
     default: DR_ASSERT(false); return 0;
     }
 }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -98,6 +98,7 @@
 
 typedef enum {
     RAW2TRACE_STAT_COUNT_ELIDED,
+    RAW2TRACE_STAT_DUPLICATE_SYSCALL
 } raw2trace_statistic_t;
 
 struct module_t {
@@ -278,6 +279,11 @@ private:
     {
         return TESTANY(kIsScatterOrGatherMask, packed_);
     }
+    bool
+    is_syscall() const
+    {
+        return TESTANY(kIsSyscallMask, packed_);
+    }
 
     const memref_summary_t &
     mem_src_at(size_t pos) const
@@ -312,6 +318,8 @@ private:
     static const int kIsAarch64DcZvaMask = 0x0020;
 
     static const int kIsScatterOrGatherMask = 0x0040;
+
+    static const int kIsSyscallMask = 0x0080;
 
     instr_summary_t(const instr_summary_t &other) = delete;
     instr_summary_t &
@@ -1273,6 +1281,18 @@ private:
                 if (!error.empty())
                     return error;
             }
+            // TODO i#5934: This is a workaround for the trace invariant error triggered
+            // by consecutive duplicate system call instructions. Remove this when the
+            // error is fixed in the drmemtrace tracer.
+            if (instr->is_syscall() && impl()->get_last_pc_if_syscall(tls) == pc &&
+                instr_count == 1) {
+                impl()->add_to_statistic(tls, RAW2TRACE_STAT_DUPLICATE_SYSCALL, 1);
+                impl()->log(
+                    3, "Found block with duplicate system call instruction. Skipping.");
+                // Since this instr is in its own block, we're done.
+                break;
+            }
+
             // XXX i#1729: make bundles via lazy accum until hit memref/end, if
             // we don't need encodings.
             buf->type = instr->type();
@@ -1293,6 +1313,10 @@ private:
                 }
             } else
                 impl()->set_prev_instr_rep_string(tls, false);
+            if (instr->is_syscall())
+                impl()->set_last_pc_if_syscall(tls, pc);
+            else
+                impl()->set_last_pc_if_syscall(tls, 0);
             buf->size = (ushort)(skip_icache ? 0 : instr->length());
             buf->addr = (addr_t)orig_pc;
             ++buf;
@@ -1918,6 +1942,7 @@ protected:
             , last_decode_modidx(0)
             , last_decode_modoffs(0)
             , last_block_summary(nullptr)
+            , last_pc_if_syscall_(0)
         {
         }
         // Support subclasses extending this struct.
@@ -1960,6 +1985,7 @@ protected:
 
         // Statistics on the processing.
         uint64 count_elided = 0;
+        uint64 count_duplicate_syscall = 0;
 
         uint64 cur_chunk_instr_count = 0;
         uint64 cur_chunk_ref_count = 0;
@@ -1967,6 +1993,7 @@ protected:
         uint64 chunk_count_ = 0;
         uint64 last_timestamp_ = 0;
         uint last_cpu_ = 0;
+        app_pc last_pc_if_syscall_;
 
         std::set<app_pc> encoding_emitted;
         app_pc last_encoding_emitted = nullptr;
@@ -1995,6 +2022,7 @@ protected:
     open_new_chunk(raw2trace_thread_data_t *tdata);
 
     uint64 count_elided_ = 0;
+    uint64 count_duplicate_syscall_ = 0;
 
     std::unique_ptr<module_mapper_t> module_mapper_;
 
@@ -2054,6 +2082,10 @@ private:
                             int instr_count, int index, app_pc pc, app_pc orig,
                             bool write, int memop_index, bool use_remembered_base,
                             bool remember_base);
+    void
+    set_last_pc_if_syscall(void *tls, app_pc value);
+    app_pc
+    get_last_pc_if_syscall(void *tls);
     void
     set_prev_instr_rep_string(void *tls, bool value);
     bool


### PR DESCRIPTION
Skips emitting to the final trace the 1-instr duplicate system call block which
has the same pc as the immediately previous system call instr. This will serve
as a workaround until we root-cause and fix the underlying issue in the
drmemtrace tracer.

Adds a unit test for this scenario.

Tested on a proprietary app trace known to have duplicate syscall errors that
this fixes all instances of such errors.

Issue: #5934