### PR TITLE
i#5946: Check whether dynamic info is set in os_module_data_t before using it

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1955,6 +1955,14 @@ instrument_module_load_trigger(app_pc pc)
         if (ma != NULL && !TEST(MODULE_LOAD_EVENT, ma->flags)) {
             /* switch to write lock */
             os_get_module_info_unlock();
+
+            /* i#3385: re-initialize dynamic information, because it failed
+             * during the first flat-mmap that loaded the module.
+             */
+            if (!ma->os_data.have_dynamic_info) {
+                os_module_update_dynamic_info(ma->start, ma->end - ma->start, false);
+            }
+
             os_get_module_info_write_lock();
             ma = module_pc_lookup(pc);
             if (ma != NULL && !TEST(MODULE_LOAD_EVENT, ma->flags)) {

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1958,7 +1958,7 @@ instrument_module_load_trigger(app_pc pc)
 #ifdef LINUX
             /* i#3385: re-try to initialize dynamic information, because
              * it failed during the first flat-mmap that loaded the module.
-             * We doesn't perfrom this if there are no clients, assuming
+             * We don't perform this if there are no clients, assuming
              * DynamoRIO doesn't use os_module_data_t information itself.
              */
             if (!ma->os_data.have_dynamic_info) {

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1960,6 +1960,9 @@ instrument_module_load_trigger(app_pc pc)
              * it failed during the first flat-mmap that loaded the module.
              * We don't perform this if there are no clients, assuming
              * DynamoRIO doesn't use os_module_data_t information itself.
+             *
+             * XXX: add a regression test later. See PR #5947 for how to
+             * reproduce this situation.
              */
             if (!ma->os_data.have_dynamic_info) {
                 os_module_update_dynamic_info(ma->start, ma->end - ma->start, false);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1955,7 +1955,7 @@ instrument_module_load_trigger(app_pc pc)
         if (ma != NULL && !TEST(MODULE_LOAD_EVENT, ma->flags)) {
             /* switch to write lock */
             os_get_module_info_unlock();
-
+#ifdef LINUX
             /* i#3385: re-try to initialize dynamic information, because
              * it failed during the first flat-mmap that loaded the module.
              * We doesn't perfrom this if there are no clients, assuming
@@ -1964,7 +1964,7 @@ instrument_module_load_trigger(app_pc pc)
             if (!ma->os_data.have_dynamic_info) {
                 os_module_update_dynamic_info(ma->start, ma->end - ma->start, false);
             }
-
+#endif
             os_get_module_info_write_lock();
             ma = module_pc_lookup(pc);
             if (ma != NULL && !TEST(MODULE_LOAD_EVENT, ma->flags)) {

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1956,8 +1956,10 @@ instrument_module_load_trigger(app_pc pc)
             /* switch to write lock */
             os_get_module_info_unlock();
 
-            /* i#3385: re-initialize dynamic information, because it failed
-             * during the first flat-mmap that loaded the module.
+            /* i#3385: re-try to initialize dynamic information, because
+             * it failed during the first flat-mmap that loaded the module.
+             * We doesn't perfrom this if there are no clients, assuming
+             * DynamoRIO doesn't use os_module_data_t information itself.
              */
             if (!ma->os_data.have_dynamic_info) {
                 os_module_update_dynamic_info(ma->start, ma->end - ma->start, false);

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -307,7 +307,13 @@ module_fill_os_data(ELF_PROGRAM_HEADER_TYPE *prog_hdr, /* PT_DYNAMIC entry */
 
                 /* test string readability while still in try/except
                  * in case we screwed up somewhere or module is
-                 * malformed/only partially mapped */
+                 * malformed/only partially mapped.
+                 *
+                 * i#3385: strlen failes here in case when .dynstr is
+                 * placed in the end of segment (thus soname is not mapped
+                 * at the moment). We'll try to re-init module data again
+                 * in instrument_module_load_trigger() at first execution.
+                 */
                 if (*soname != NULL && strlen(*soname) == -1) {
                     ASSERT_NOT_REACHED();
                 }

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -309,7 +309,7 @@ module_fill_os_data(ELF_PROGRAM_HEADER_TYPE *prog_hdr, /* PT_DYNAMIC entry */
                  * in case we screwed up somewhere or module is
                  * malformed/only partially mapped.
                  *
-                 * i#3385: strlen failes here in case when .dynstr is
+                 * i#3385: strlen fails here in case when .dynstr is
                  * placed in the end of segment (thus soname is not mapped
                  * at the moment). We'll try to re-init module data again
                  * in instrument_module_load_trigger() at first execution.


### PR DESCRIPTION
This PR tries to fix #5946 by performing extra check for dynamic info was initialized in os_module_data_t during module load.

The error is triggered when loaded ELF module have a specific program sections order: `.dynstr`  should be placed in the end. In such case it wouldn't be mapped at the moment of os_module_data_t initialization.
If DR-client would try to use module data later (via dr_get_proc_address for example), DR will crash.

_How to reproduce for testing:_
1) You need a target program with dynamic linking to the shared library (example: )
2) Shared library ELF should have late .dynstr section. This could be achieved by using `patchelf` utility: after a compilation of libtest.so object you need to run `patchelf --set-rpath '$ORIGIN' libtest.so`. To check program sections displacement run `readelf -l libtest.so`
3) The crash is triggered when DR client uses uninitialized os_module_data_t. The easiest way is to call dr_get_proc_address() in module_load_event handler.

Test example with compiled binaries and source code: [example.tar.gz](https://github.com/DynamoRIO/dynamorio/files/11200545/example.tar.gz).
Tested on ubuntu20.04/ubuntu22.04 with clang-14 and patchelf >=0.10