### PR TITLE
i#2626 Finish AArch64 encoder/decoder: FJCVTS

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -158,6 +158,7 @@ proc_init_arch(void)
             cpu_info.features.flags_aa64isar1);
         LOG_FEATURE(FEATURE_DPB);
         LOG_FEATURE(FEATURE_DPB2);
+        LOG_FEATURE(FEATURE_JSCVT);
 
         LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64PFR0_EL1 = 0x%016lx\n",
             cpu_info.features.flags_aa64pfr0);
@@ -217,7 +218,8 @@ proc_has_feature(feature_bit_t f)
     case FEATURE_LRCPC2:
     case FEATURE_BF16:
     case FEATURE_I8MM:
-    case FEATURE_FlagM: return true;
+    case FEATURE_FlagM:
+    case FEATURE_JSCVT: return true;
 
     case FEATURE_AESX:
     case FEATURE_PMULL:

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -344,6 +344,7 @@ typedef enum {
     FEATURE_RNG = DEF_FEAT(AA64ISAR0, 15, 1, 0),     /**< RNDR, RNDRRS (AArch64) */
     FEATURE_DPB = DEF_FEAT(AA64ISAR1, 0, 1, 0),      /**< DC CVAP (AArch64) */
     FEATURE_DPB2 = DEF_FEAT(AA64ISAR1, 0, 2, 0),     /**< DC CVAP, DC CVADP (AArch64) */
+    FEATURE_JSCVT = DEF_FEAT(AA64ISAR1, 3, 1, 0),    /**< FJCVTZS (AArch64) */
     FEATURE_FP16 = DEF_FEAT(AA64PFR0, 4, 1, 1),      /**< Half-precision FP (AArch64) */
     FEATURE_RAS = DEF_FEAT(AA64PFR0, 7, 1, 0),       /**< RAS extension (AArch64) */
     FEATURE_SVE = DEF_FEAT(AA64PFR0, 8, 1, 0),       /**< Scalable Vectors (AArch64) */

--- a/core/ir/aarch64/codec_v83.txt
+++ b/core/ir/aarch64/codec_v83.txt
@@ -61,6 +61,7 @@
 0x101110xx0xxxxx111x01xxxxxxxxxx  n   944  BASE     fcadd      dq0 : dq0 dq5 dq16 imm1_ew_12 hs_sz
 0x101110xx0xxxxx110xx1xxxxxxxxxx  n   945  BASE     fcmla      dq0 : dq0 dq5 dq16 imm2_nesw_11 hs_sz
 0x101111xxxxxxxx0xx1x0xxxxxxxxxx  n   945  BASE     fcmla      dq0 : dq0 dq5 dq16 vindex_HS_2lane imm2_nesw_13 hs_sz
+0001111001111110000000xxxxxxxxxx  n   1057 JSCVT   fjcvtzs       w0 : d5
 1x11100010111111110000xxxxxxxxxx  n   796  LRCPC     ldapr   wx0_30 : mem0
 0011100010111111110000xxxxxxxxxx  n   797  LRCPC    ldaprb       w0 : mem0
 0111100010111111110000xxxxxxxxxx  n   798  LRCPC    ldaprh       w0 : mem0

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -14032,4 +14032,17 @@
     instr_create_0dst_2src(dc, OP_retab, opnd_create_reg(DR_REG_X30), \
                            opnd_create_reg(DR_REG_SP))
 
+/**
+ * Creates a FJCVTZS instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    FJCVTZS <Wd>, <Dn>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rd   The destination register, W (Word, 32 bits).
+ * \param Rn   The source register, D (doubleword, 64 bits).
+ */
+#define INSTR_CREATE_fjcvtzs(dc, Rd, Rn) instr_create_1dst_1src(dc, OP_fjcvtzs, Rd, Rn)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-v83.txt
+++ b/suite/tests/api/dis-a64-v83.txt
@@ -526,6 +526,24 @@ d69f0fff : eretab                                    : eretab %x30 %sp
 6f9d7b9b : fcmla v27.4s, v28.4s, v29.s[1], #0x10e    : fcmla  %q27 %q28 %q29 $0x01 $0x010e $0x02 -> %q27
 6f9f7bff : fcmla v31.4s, v31.4s, v31.s[1], #0x10e    : fcmla  %q31 %q31 %q31 $0x01 $0x010e $0x02 -> %q31
 
+# FJCVTZS <Wd>, <Dn> (FJCVTZS-R.V-32H_float2int)
+1e7e0000 : fjcvtzs w0, d0                            : fjcvtzs %d0 -> %w0
+1e7e0062 : fjcvtzs w2, d3                            : fjcvtzs %d3 -> %w2
+1e7e00a4 : fjcvtzs w4, d5                            : fjcvtzs %d5 -> %w4
+1e7e00e6 : fjcvtzs w6, d7                            : fjcvtzs %d7 -> %w6
+1e7e0128 : fjcvtzs w8, d9                            : fjcvtzs %d9 -> %w8
+1e7e0169 : fjcvtzs w9, d11                           : fjcvtzs %d11 -> %w9
+1e7e01ab : fjcvtzs w11, d13                          : fjcvtzs %d13 -> %w11
+1e7e01ed : fjcvtzs w13, d15                          : fjcvtzs %d15 -> %w13
+1e7e022f : fjcvtzs w15, d17                          : fjcvtzs %d17 -> %w15
+1e7e0251 : fjcvtzs w17, d18                          : fjcvtzs %d18 -> %w17
+1e7e0293 : fjcvtzs w19, d20                          : fjcvtzs %d20 -> %w19
+1e7e02d5 : fjcvtzs w21, d22                          : fjcvtzs %d22 -> %w21
+1e7e0316 : fjcvtzs w22, d24                          : fjcvtzs %d24 -> %w22
+1e7e0358 : fjcvtzs w24, d26                          : fjcvtzs %d26 -> %w24
+1e7e039a : fjcvtzs w26, d28                          : fjcvtzs %d28 -> %w26
+1e7e03fe : fjcvtzs w30, d31                          : fjcvtzs %d31 -> %w30
+
 # LDRAA   <Xt>, [<Xn|SP>, #<simm>] (LDRAA-R.RI-auth_offset)
 f8600400 : ldraa x0, [x0, #-4096]                    : ldraa  -0x1000(%x0)[8byte] -> %x0
 f8640462 : ldraa x2, [x3, #-3584]                    : ldraa  -0x0e00(%x3)[8byte] -> %x2

--- a/suite/tests/api/ir_aarch64_v83.c
+++ b/suite/tests/api/ir_aarch64_v83.c
@@ -593,6 +593,17 @@ TEST_INSTR(xpaci)
     TEST_LOOP(xpaci, xpaci, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]));
 }
 
+TEST_INSTR(fjcvtzs)
+{
+    /* Testing FJCVTZS <Wd>, <Dn> */
+    const char *const expected_0_0[6] = {
+        "fjcvtzs %d0 -> %w0",   "fjcvtzs %d6 -> %w5",   "fjcvtzs %d11 -> %w10",
+        "fjcvtzs %d17 -> %w15", "fjcvtzs %d22 -> %w20", "fjcvtzs %d31 -> %w30",
+    };
+    TEST_LOOP(fjcvtzs, fjcvtzs, 6, expected_0_0[i], opnd_create_reg(Wn_six_offset_0[i]),
+              opnd_create_reg(Vdn_d_six_offset_1[i]));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -640,6 +651,9 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ldrab);
     RUN_INSTR_TEST(xpacd);
     RUN_INSTR_TEST(xpaci);
+
+    /* FEAT_JSCVT */
+    RUN_INSTR_TEST(fjcvtzs);
 
     print("All v8.3 tests complete.");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
FJCVTZS <Wd>, <Dn>
```

Issue: #2626