### PR TITLE
i#5950: Stop skipping at footer

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -288,8 +288,13 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_serial(analyzer_worker_data_t &
             worker.stream->next_record(record);
         if (status != sched_type_t::STATUS_OK) {
             if (status != sched_type_t::STATUS_EOF) {
-                worker.error =
-                    "Failed to read from trace: " + worker.stream->get_stream_name();
+                if (status == sched_type_t::STATUS_REGION_INVALID) {
+                    worker.error =
+                        "Too-far -skip_instrs for: " + worker.stream->get_stream_name();
+                } else {
+                    worker.error =
+                        "Failed to read from trace: " + worker.stream->get_stream_name();
+                }
             }
             return;
         }
@@ -320,8 +325,13 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *w
          status != sched_type_t::STATUS_EOF;
          status = worker->stream->next_record(record)) {
         if (status != sched_type_t::STATUS_OK) {
-            worker->error =
-                "Failed to read from trace: " + worker->stream->get_stream_name();
+            if (status == sched_type_t::STATUS_REGION_INVALID) {
+                worker->error =
+                    "Too-far -skip_instrs for: " + worker->stream->get_stream_name();
+            } else {
+                worker->error =
+                    "Failed to read from trace: " + worker->stream->get_stream_name();
+            }
             return;
         }
         int shard_index = worker->stream->get_input_stream_ordinal();

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -395,8 +395,9 @@ reader_t::skip_instructions_with_timestamp(uint64_t stop_instruction_count)
         if (input_entry_ != nullptr) // Only at start: and we checked for skipping 0.
             entry_copy_ = *input_entry_;
         trace_entry_t *next = read_next_entry();
-        if (next == nullptr) {
-            VPRINT(this, 1, "Failed to read next entry\n");
+        if (next == nullptr || next->type == TRACE_TYPE_FOOTER) {
+            VPRINT(this, 1,
+                   next == nullptr ? "Failed to read next entry\n" : "Hit EOF\n");
             at_eof_ = true;
             return *this;
         }

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -592,7 +592,8 @@ test_regions_too_far()
                          std::unique_ptr<mock_reader_t>(new mock_reader_t()), 1);
 
     std::vector<scheduler_t::range_t> regions;
-    regions.emplace_back(4, 0);
+    // Start beyond the last instruction.
+    regions.emplace_back(3, 0);
 
     scheduler_t scheduler;
     std::vector<scheduler_t::input_workload_t> sched_inputs;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -101,6 +101,14 @@ make_exit(memref_tid_t tid)
 }
 
 static trace_entry_t
+make_footer()
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_FOOTER;
+    return entry;
+}
+
+static trace_entry_t
 make_version(int version)
 {
     trace_entry_t entry;
@@ -563,11 +571,51 @@ test_regions_start()
 }
 
 static void
+test_regions_too_far()
+{
+    std::cerr << "\n----------------\nTesting region going too far\n";
+    std::vector<trace_entry_t> memrefs = {
+        /* clang-format off */
+        make_thread(1),
+        make_pid(1),
+        make_marker(TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+        make_timestamp(10),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        make_instr(1),
+        make_instr(2),
+        make_exit(1),
+        make_footer(),
+        /* clang-format on */
+    };
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(memrefs)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), 1);
+
+    std::vector<scheduler_t::range_t> regions;
+    regions.emplace_back(4, 0);
+
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(readers));
+    sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
+    if (scheduler.init(sched_inputs, 1,
+                       scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    int ordinal = 0;
+    auto *stream = scheduler.get_stream(0);
+    memref_t memref;
+    scheduler_t::stream_status_t status = stream->next_record(memref);
+    assert(status == scheduler_t::STATUS_REGION_INVALID);
+}
+
+static void
 test_regions()
 {
     test_regions_timestamps();
     test_regions_bare();
     test_regions_start();
+    test_regions_too_far();
 }
 
 static void


### PR DESCRIPTION
Adds an explicit check for -skip_instructions hitting the footer to avoid an assert on trying to process it as a normal entry.

Adds a scheduler test.

Adds a separate analyzer error string for this.
I tested this manually:
    -------------
    $ clients/bin64/drcachesim -simulator_type view -indir drmemtrace.*.dir -skip_instrs 6300 -verbose 2
    ERROR: failed to run analyzer: Too-far -skip_instrs for: drmemtrace.allasm_x86_64.2490594.5358.trace.zip
    -------------

Fixes #5950