### PR TITLE
i#5955: Update expected rseq offset for glibc 2.36

### DIFF
--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -122,14 +122,27 @@ register_rseq()
          * fallback that does a wider search, it would be good to keep the
          * expected offset in sync with glibc changes.
          */
-#    ifdef X86
-#        ifdef X64
-        assert(__rseq_offset == 2464);
+#    if __GLIBC__ == 2 && __GLIBC_MINOR__ >= 36
+#        ifdef X86
+#            ifdef X64
+        assert(__rseq_offset == 2336);
+#            else
+        assert(__rseq_offset == 1184);
+#            endif
 #        else
-        assert(__rseq_offset == 1312);
+        /* Did not change on glibc 2.36. */
+        assert(__rseq_offset == -32);
 #        endif
 #    else
+#        ifdef X86
+#            ifdef X64
+        assert(__rseq_offset == 2464);
+#            else
+        assert(__rseq_offset == 1312);
+#            endif
+#        else
         assert(__rseq_offset == -32);
+#        endif
 #    endif
         /* Already registered by glibc. Verify that it's there. */
         struct rseq *reg_rseq = __builtin_thread_pointer() + __rseq_offset;


### PR DESCRIPTION
Adds struct rseq offset for glibc 2.36, but also preserves the existing ones for
older glibc since our CI workflows are still on the older versions.

Glibc 2.36 made some changes to the __rseq_offset. We have logic that uses a
heuristic to search for the struct rseq offset. But we also assert on the
expected known glibc rseq offset in the linux.rseq test; this is to
proactively detect glibc changes in rseq handling.

This fixes all rseq tests on glibc 2.36 except tool.drcacheoff.rseq which is
covered by #5734.

Fixes: #5955