### PR TITLE
i#4062: Remove trace_converter_t to simplify raw2trace_t

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -690,7 +690,7 @@ Further non-compatibility-affecting changes include:
      #raw2trace_t for writing trace metadata: process/thread ids, timestamps, etc.
    - Added #trace_metadata_reader_t, a set of utilities for checking and validating
      thread start successions of offline entries in a raw data file.
-   - Added #trace_converter_t, an extensibility mechanism for raw trace conversion.
+   - Added trace_converter_t, an extensibility mechanism for raw trace conversion.
  - Added drmemtrace_get_timestamp_from_offline_trace(), an API for fetching the timestamp
    from the beginning of a raw trace bundle (regardless of whether it is a thread start
    or just a subsequent bundle).

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -281,7 +281,7 @@ raw2trace_t::do_module_parsing()
 {
     if (!module_mapper_) {
         module_mapper_ = module_mapper_t::create(
-            modmap_, user_parse_, user_process_, user_process_data_, user_free_,
+            modmap_bytes_, user_parse_, user_process_, user_process_data_, user_free_,
             verbosity_, alt_module_dir_, encoding_file_);
     }
     return module_mapper_->get_last_error();
@@ -540,6 +540,149 @@ module_mapper_t::write_module_data(char *buf, size_t buf_size,
 /***************************************************************************
  * Top-level
  */
+
+std::string
+raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
+                                   const offline_entry_t *in_entry, thread_id_t tid,
+                                   OUT bool *end_of_record, OUT bool *last_bb_handled)
+{
+    trace_entry_t *buf_base = get_write_buffer(tdata);
+    byte *buf = reinterpret_cast<byte *>(buf_base);
+    if (in_entry->extended.type == OFFLINE_TYPE_EXTENDED) {
+        if (in_entry->extended.ext == OFFLINE_EXT_TYPE_FOOTER) {
+            DR_CHECK(tid != INVALID_THREAD_ID, "Missing thread id");
+            log(2, "Thread %d exit\n", (uint)tid);
+            buf += trace_metadata_writer_t::write_thread_exit(buf, tid);
+            *end_of_record = true;
+            std::string error =
+                write(tdata, buf_base, reinterpret_cast<trace_entry_t *>(buf));
+            if (!error.empty())
+                return error;
+            // Let the user determine what other actions to take, e.g. account for
+            // the ending of the current thread, etc.
+            return on_thread_end(tdata);
+        } else if (in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER) {
+            uintptr_t marker_val = 0;
+            std::string err = get_marker_value(tdata, &in_entry, &marker_val);
+            if (!err.empty())
+                return err;
+            buf += trace_metadata_writer_t::write_marker(
+                buf, (trace_marker_type_t)in_entry->extended.valueB, marker_val);
+            if (in_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+                log(4, "Signal/exception between bbs\n");
+            }
+            // If there is currently a delayed branch that has not been emitted yet,
+            // delay most markers since intra-block markers can cause issues with
+            // tools that do not expect markers amid records for a single instruction
+            // or inside a basic block. We don't delay TRACE_MARKER_TYPE_CPU_ID which
+            // identifies the CPU on which subsequent records were collected and
+            // OFFLINE_TYPE_TIMESTAMP which is handled at a higher level in
+            // process_next_thread_buffer() so there is no need to have a separate
+            // check for it here.
+            if (in_entry->extended.valueB != TRACE_MARKER_TYPE_CPU_ID) {
+                if (delayed_branches_exist(tdata)) {
+                    std::string error = write_delayed_branches(
+                        tdata, buf_base, reinterpret_cast<trace_entry_t *>(buf));
+                    if (!error.empty())
+                        return error;
+                    return "";
+                }
+            }
+            log(3, "Appended marker type %u value " PIFX "\n",
+                (trace_marker_type_t)in_entry->extended.valueB,
+                (uintptr_t)in_entry->extended.valueA);
+        } else {
+            std::stringstream ss;
+            ss << "Invalid extension type " << (int)in_entry->extended.ext;
+            return ss.str();
+        }
+    } else if (in_entry->addr.type == OFFLINE_TYPE_MEMREF ||
+               in_entry->addr.type == OFFLINE_TYPE_MEMREF_HIGH) {
+        if (!*last_bb_handled &&
+            // Shouldn't get here if encodings are present.
+            get_version(tdata) < OFFLINE_FILE_VERSION_ENCODINGS) {
+            // For legacy traces with unhandled non-module code, memrefs are handled
+            // here where we can easily handle the transition out of the bb.
+            trace_entry_t *entry = reinterpret_cast<trace_entry_t *>(buf);
+            entry->type = TRACE_TYPE_READ; // Guess.
+            entry->size = 1;               // Guess.
+            entry->addr = (addr_t)in_entry->combined_value;
+            log(4, "Appended non-module memref to " PFX "\n", (ptr_uint_t)entry->addr);
+            buf += sizeof(*entry);
+        } else {
+            // We should see an instr entry first
+            log(3, "extra memref entry: %p\n", in_entry->addr.addr);
+            return "memref entry found outside of bb";
+        }
+    } else if (in_entry->pc.type == OFFLINE_TYPE_PC) {
+        DR_CHECK(reinterpret_cast<trace_entry_t *>(buf) == buf_base,
+                 "We shouldn't have buffered anything before calling "
+                 "append_bb_entries");
+        std::string result = append_bb_entries(tdata, in_entry, last_bb_handled);
+        if (!result.empty())
+            return result;
+    } else if (in_entry->addr.type == OFFLINE_TYPE_IFLUSH) {
+        const offline_entry_t *entry = get_next_entry(tdata);
+        if (entry == nullptr || entry->addr.type != OFFLINE_TYPE_IFLUSH)
+            return "Flush missing 2nd entry";
+        log(2, "Flush " PFX "-" PFX "\n", (ptr_uint_t)in_entry->addr.addr,
+            (ptr_uint_t)entry->addr.addr);
+        buf += trace_metadata_writer_t::write_iflush(
+            buf, in_entry->addr.addr, (size_t)(entry->addr.addr - in_entry->addr.addr));
+    } else {
+        std::stringstream ss;
+        ss << "Unknown trace type " << (int)in_entry->timestamp.type;
+        return ss.str();
+    }
+    size_t size = reinterpret_cast<trace_entry_t *>(buf) - buf_base;
+    DR_CHECK((uint)size < WRITE_BUFFER_SIZE, "Too many entries");
+    if (size > 0) {
+        std::string error =
+            write(tdata, buf_base, reinterpret_cast<trace_entry_t *>(buf));
+        if (!error.empty())
+            return error;
+    }
+    return "";
+}
+
+std::string
+raw2trace_t::read_header(raw2trace_thread_data_t *tdata, OUT trace_header_t *header)
+{
+    const offline_entry_t *in_entry = get_next_entry(tdata);
+    if (in_entry == nullptr)
+        return "Failed to read header from input file";
+    // Handle legacy traces which have the timestamp first.
+    if (in_entry->tid.type == OFFLINE_TYPE_TIMESTAMP) {
+        header->timestamp = in_entry->timestamp.usec;
+        in_entry = get_next_entry(tdata);
+        if (in_entry == nullptr)
+            return "Failed to read header from input file";
+    }
+    DR_ASSERT(in_entry->tid.type == OFFLINE_TYPE_THREAD);
+    header->tid = in_entry->tid.tid;
+
+    in_entry = get_next_entry(tdata);
+    if (in_entry == nullptr)
+        return "Failed to read header from input file";
+    DR_ASSERT(in_entry->pid.type == OFFLINE_TYPE_PID);
+    header->pid = in_entry->pid.pid;
+
+    in_entry = get_next_entry(tdata);
+    if (in_entry == nullptr)
+        return "Failed to read header from input file";
+    if (in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
+        in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER &&
+        in_entry->extended.valueB == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {
+        header->cache_line_size = in_entry->extended.valueA;
+    } else {
+        log(2,
+            "Cache line size not found in raw trace header. Adding "
+            "current processor's cache line size to final trace instead.\n");
+        header->cache_line_size = proc_get_cache_line_size();
+        unread_last_entry(tdata);
+    }
+    return "";
+}
 
 std::string
 raw2trace_t::process_header(raw2trace_thread_data_t *tdata)
@@ -838,10 +981,699 @@ raw2trace_t::aggregate_and_write_schedule_files()
     return "";
 }
 
-bool
-raw2trace_t::record_encoding_emitted(void *tls, app_pc pc)
+/***************************************************************************
+ * Block and memref handling
+ */
+
+std::string
+raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                        uint64 modoffs, app_pc start_pc, uint instr_count)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
+    int version = get_version(tdata);
+    // Old versions have no elision.
+    if (version <= OFFLINE_FILE_VERSION_NO_ELISION)
+        return "";
+    // Filtered and instruction-only traces have no elision.
+    if (TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS |
+                    OFFLINE_FILE_TYPE_INSTRUCTION_ONLY,
+                get_file_type(tdata)))
+        return "";
+    // We build an ilist to use identify_elidable_addresses() and fill in
+    // state needed to reconstruct elided addresses.
+    instrlist_t *ilist = instrlist_create(dcontext_);
+    app_pc pc = start_pc;
+    for (uint count = 0; count < instr_count; ++count) {
+        instr_t *inst = instr_create(dcontext_);
+        app_pc next_pc = decode(dcontext_, pc, inst);
+        DR_ASSERT(next_pc != NULL);
+        instr_set_translation(inst, pc);
+        instr_set_note(inst, reinterpret_cast<void *>(static_cast<ptr_int_t>(count)));
+        pc = next_pc;
+        instrlist_append(ilist, inst);
+    }
+
+    instru_offline_.identify_elidable_addresses(dcontext_, ilist, version);
+
+    for (instr_t *inst = instrlist_first(ilist); inst != nullptr;
+         inst = instr_get_next(inst)) {
+        int index, memop_index;
+        bool write, needs_base;
+        if (!instru_offline_.label_marks_elidable(inst, &index, &memop_index, &write,
+                                                  &needs_base))
+            continue;
+        // There could be multiple labels for one instr (e.g., "push (%rsp)".
+        instr_t *meminst = instr_get_next(inst);
+        while (meminst != nullptr && instr_is_label(meminst))
+            meminst = instr_get_next(meminst);
+        DR_ASSERT(meminst != nullptr);
+        pc = instr_get_app_pc(meminst);
+        int index_in_bb =
+            static_cast<int>(reinterpret_cast<ptr_int_t>(instr_get_note(meminst)));
+        app_pc orig_pc = modmap_().get_orig_pc_from_map_pc(pc, modidx, modoffs);
+        log(5, "Marking < " PFX ", " PFX "> %s #%d to use remembered base\n", start_pc,
+            pc, write ? "write" : "read", memop_index);
+        if (!set_instr_summary_flags(tdata, modidx, modoffs, start_pc, instr_count,
+                                     index_in_bb, pc, orig_pc, write, memop_index,
+                                     true /*use_remembered*/,
+                                     false /*don't change "remember"*/))
+            return "Failed to set flags for elided base address";
+        // We still need to set the use_remember flag for rip-rel, even though it
+        // does not need a prior base, because we do not elide *all* rip-rels
+        // (e.g., predicated rip-rels).
+        if (!needs_base)
+            continue;
+        // Find the source of the base.  It has to be the first instance when
+        // walking backward.
+        opnd_t elided_op =
+            write ? instr_get_dst(meminst, index) : instr_get_src(meminst, index);
+        reg_id_t base;
+        bool got_base = instru_offline_.opnd_is_elidable(elided_op, base, version);
+        DR_ASSERT(got_base && base != DR_REG_NULL);
+        int remember_index = -1;
+        for (instr_t *prev = meminst; prev != nullptr; prev = instr_get_prev(prev)) {
+            if (!instr_is_app(prev))
+                continue;
+            // Use instr_{reads,writes}_memory() to rule out LEA and NOP.
+            if (!instr_reads_memory(prev) && !instr_writes_memory(prev))
+                continue;
+            bool remember_write = false;
+            int mem_count = 0;
+            if (prev != meminst || write) {
+                for (int i = 0; i < instr_num_srcs(prev); i++) {
+                    reg_id_t prev_base;
+                    if (opnd_is_memory_reference(instr_get_src(prev, i))) {
+                        if (instru_offline_.opnd_is_elidable(instr_get_src(prev, i),
+                                                             prev_base, version) &&
+                            prev_base == base) {
+                            remember_index = mem_count;
+                            break;
+                        }
+                        ++mem_count;
+                    }
+                }
+            }
+            if (remember_index == -1 && prev != meminst) {
+                mem_count = 0;
+                for (int i = 0; i < instr_num_dsts(prev); i++) {
+                    reg_id_t prev_base;
+                    if (opnd_is_memory_reference(instr_get_dst(prev, i))) {
+                        if (instru_offline_.opnd_is_elidable(instr_get_dst(prev, i),
+                                                             prev_base, version) &&
+                            prev_base == base) {
+                            remember_index = mem_count;
+                            remember_write = true;
+                            break;
+                        }
+                        ++mem_count;
+                    }
+                }
+            }
+            if (remember_index == -1)
+                continue;
+            app_pc pc_prev = instr_get_app_pc(prev);
+            app_pc orig_pc_prev =
+                modmap_().get_orig_pc_from_map_pc(pc_prev, modidx, modoffs);
+            int index_prev =
+                static_cast<int>(reinterpret_cast<ptr_int_t>(instr_get_note(prev)));
+            if (!set_instr_summary_flags(
+                    tdata, modidx, modoffs, start_pc, instr_count, index_prev, pc_prev,
+                    orig_pc_prev, remember_write, remember_index,
+                    false /*don't change "use_remembered"*/, true /*remember*/))
+                return "Failed to set flags for elided base address";
+            log(5, "Asking <" PFX ", " PFX "> %s #%d to remember base\n", start_pc,
+                pc_prev, remember_write ? "write" : "read", remember_index);
+            break;
+        }
+        if (remember_index == -1)
+            return "Failed to find the source of the elided base";
+    }
+    instrlist_clear_and_destroy(dcontext_, ilist);
+    return "";
+}
+
+std::string
+raw2trace_t::process_memref(raw2trace_thread_data_t *tdata, trace_entry_t **buf_in,
+                            const instr_summary_t *instr,
+                            instr_summary_t::memref_summary_t memref, bool write,
+                            std::unordered_map<reg_id_t, addr_t> &reg_vals,
+                            uint64_t cur_pc, uint64_t cur_offs, bool instrs_are_separate,
+                            OUT bool *reached_end_of_memrefs, OUT bool *interrupted)
+{
+    std::string error = append_memref(tdata, buf_in, instr, memref, write, reg_vals,
+                                      reached_end_of_memrefs);
+    if (!error.empty())
+        return error;
+    error = handle_kernel_interrupt_and_markers(tdata, buf_in, cur_pc, cur_offs,
+                                                instr->length(), instrs_are_separate,
+                                                interrupted);
+    return error;
+}
+
+std::string
+raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
+                               const offline_entry_t *in_entry, OUT bool *handled)
+{
+    std::string error = "";
+    uint instr_count = in_entry->pc.instr_count;
+    const instr_summary_t *instr = nullptr;
+    app_pc start_pc = modmap_().get_map_pc(in_entry->pc.modidx, in_entry->pc.modoffs);
+    app_pc pc, decode_pc = start_pc;
+    if (in_entry->pc.modidx == PC_MODIDX_INVALID) {
+        log(3, "Appending %u instrs in bb " PFX " in generated code\n", instr_count,
+            reinterpret_cast<ptr_uint_t>(
+                modmap_().get_orig_pc(in_entry->pc.modidx, in_entry->pc.modoffs)));
+    } else if ((in_entry->pc.modidx == 0 && in_entry->pc.modoffs == 0) ||
+               modvec_()[in_entry->pc.modidx].map_seg_base == NULL) {
+        if (get_version(tdata) >= OFFLINE_FILE_VERSION_ENCODINGS) {
+            // This is a fatal error if this trace should have encodings.
+            return "Non-module instructions found with no encoding information.";
+        }
+        //  This is a legacy trace without generated code support.
+        //  A race is fine for our visible ~one-time warning at level 0.
+        static volatile bool warned_once;
+        if (!warned_once) {
+            log(0, "WARNING: Skipping ifetch for unknown-encoding instructions\n");
+            warned_once = true;
+        }
+        log(1, "Skipping ifetch for %u unknown-encoding instrs (idx %d, +" PIFX ")\n",
+            instr_count, in_entry->pc.modidx, in_entry->pc.modoffs);
+        // XXX i#2062: If we abandon this graceful skip (maybe once all legacy
+        // traces have expired), we can remove the bool return value and handle the
+        // memrefs in this function.
+        *handled = false;
+        return "";
+    } else {
+        log(3, "Appending %u instrs in bb " PFX " in mod %u +" PIFX " = %s\n",
+            instr_count, (ptr_uint_t)start_pc, (uint)in_entry->pc.modidx,
+            (ptr_uint_t)in_entry->pc.modoffs, modvec_()[in_entry->pc.modidx].path);
+    }
+    bool skip_icache = false;
+    // This indicates that each memref has its own PC entry and that each
+    // icache entry does not need to be considered a memref PC entry as well.
+    bool instrs_are_separate = TESTANY(
+        OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED, get_file_type(tdata));
+    bool is_instr_only_trace =
+        TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, get_file_type(tdata));
+    // Cast to unsigned pointer-sized int first to avoid sign-extending.
+    uint64_t cur_pc = static_cast<uint64_t>(reinterpret_cast<ptr_uint_t>(
+        modmap_().get_orig_pc(in_entry->pc.modidx, in_entry->pc.modoffs)));
+    // Legacy traces need the offset, not the pc.
+    uint64_t cur_offs = in_entry->pc.modoffs;
+    std::unordered_map<reg_id_t, addr_t> reg_vals;
+    if (instr_count == 0) {
+        // L0 filtering adds a PC entry with a count of 0 prior to each memref.
+        skip_icache = true;
+        instr_count = 1;
+        // We should have set a flag to avoid peeking forward on instr entries
+        // based on OFFLINE_FILE_TYPE_FILTERED and
+        // OFFLINE_FILE_TYPE_IFILTERED.
+        DR_ASSERT(instrs_are_separate);
+    } else {
+        if (!instr_summary_exists(tdata, in_entry->pc.modidx, in_entry->pc.modoffs,
+                                  start_pc, 0, decode_pc)) {
+            std::string res = analyze_elidable_addresses(
+                tdata, in_entry->pc.modidx, in_entry->pc.modoffs, start_pc, instr_count);
+            if (!res.empty())
+                return res;
+        }
+    }
+    DR_CHECK(!instrs_are_separate || instr_count == 1, "cannot mix 0-count and >1-count");
+    for (uint i = 0; i < instr_count; ++i) {
+        trace_entry_t *buf_start = get_write_buffer(tdata);
+        trace_entry_t *buf = buf_start;
+        app_pc saved_decode_pc = decode_pc;
+        app_pc orig_pc = modmap_().get_orig_pc_from_map_pc(decode_pc, in_entry->pc.modidx,
+                                                           in_entry->pc.modoffs);
+        // To avoid repeatedly decoding the same instruction on every one of its
+        // dynamic executions, we cache the decoding in a hashtable.
+        pc = decode_pc;
+        log_instruction(4, decode_pc, orig_pc);
+        instr = get_instr_summary(tdata, in_entry->pc.modidx, in_entry->pc.modoffs,
+                                  start_pc, instr_count, i, &pc, orig_pc);
+        if (instr == nullptr) {
+            // We hit some error somewhere, and already reported it. Just exit the
+            // loop.
+            break;
+        }
+        DR_CHECK(pc > decode_pc, "error advancing inside block");
+        DR_CHECK(!instr->is_cti() || i == instr_count - 1, "invalid cti");
+        if (!instr->is_cti()) {
+            // Write out delayed branches now that we have a target.
+            error = append_delayed_branch(tdata);
+            if (!error.empty())
+                return error;
+        }
+        if (!skip_icache && record_encoding_emitted(tdata, decode_pc)) {
+            error = append_encoding(tdata, decode_pc, instr->length(), buf, buf_start);
+            if (!error.empty())
+                return error;
+        }
+        // TODO i#5934: This is a workaround for the trace invariant error triggered
+        // by consecutive duplicate system call instructions. Remove this when the
+        // error is fixed in the drmemtrace tracer.
+        if (instr->is_syscall() && get_last_pc_if_syscall(tdata) == orig_pc &&
+            instr_count == 1) {
+            add_to_statistic(tdata, RAW2TRACE_STAT_DUPLICATE_SYSCALL, 1);
+            log(3, "Found block with duplicate system call instruction. Skipping.");
+            // Since this instr is in its own block, we're done.
+            // Note that this will result in a pair of timestamp+cpu markers without
+            // anything before the next timestamp+cpu pair.
+            break;
+        }
+
+        // XXX i#1729: make bundles via lazy accum until hit memref/end, if
+        // we don't need encodings.
+        buf->type = instr->type();
+        if (buf->type == TRACE_TYPE_INSTR_MAYBE_FETCH) {
+            // We want it to look like the original rep string, with just one instr
+            // fetch for the whole loop, instead of the drutil-expanded loop.
+            // We fix up the maybe-fetch here so our offline file doesn't have to
+            // rely on our own reader.
+            if (!was_prev_instr_rep_string(tdata)) {
+                set_prev_instr_rep_string(tdata, true);
+                buf->type = TRACE_TYPE_INSTR;
+            } else {
+                log(3, "Skipping instr fetch for " PFX "\n", (ptr_uint_t)decode_pc);
+                // We still include the instr to make it easier for core simulators
+                // (i#2051).
+                buf->type = TRACE_TYPE_INSTR_NO_FETCH;
+            }
+        } else
+            set_prev_instr_rep_string(tdata, false);
+        if (instr->is_syscall())
+            set_last_pc_if_syscall(tdata, orig_pc);
+        else
+            set_last_pc_if_syscall(tdata, 0);
+        buf->size = (ushort)(skip_icache ? 0 : instr->length());
+        buf->addr = (addr_t)orig_pc;
+        ++buf;
+        log(4, "Appended instr fetch for original %p\n", orig_pc);
+        decode_pc = pc;
+        // Check for a signal *after* the instruction.  The trace is recording
+        // instruction *fetches*, not instruction retirement, and we want to
+        // include a faulting instruction before its raised signal.
+        bool interrupted = false;
+        error = handle_kernel_interrupt_and_markers(tdata, &buf, cur_pc, cur_offs,
+                                                    instr->length(), instrs_are_separate,
+                                                    &interrupted);
+        if (!error.empty())
+            return error;
+        if (interrupted) {
+            log(3, "Stopping bb at kernel interruption point %p\n", cur_pc);
+        }
+        // We need to interleave instrs with memrefs.
+        // There is no following memref for (instrs_are_separate && !skip_icache).
+        if (!interrupted && (!instrs_are_separate || skip_icache) &&
+            // Rule out OP_lea.
+            (instr->reads_memory() || instr->writes_memory()) &&
+            // No following memref for instruction-only trace type.
+            !is_instr_only_trace) {
+            if (instr->is_scatter_or_gather()) {
+                // The instr should either load or store, but not both. Also,
+                // it should have a single src or dest operand.
+                DR_ASSERT(instr->num_mem_srcs() + instr->num_mem_dests() == 1);
+                bool is_scatter = instr->num_mem_dests() == 1;
+                bool reached_end_of_memrefs = false;
+                // For expanded scatter/gather instrs, we do not have prior knowledge
+                // of the number of store/load memrefs that will be present. So we
+                // continue reading entries until we find a non-memref entry.
+                // This works only because drx_expand_scatter_gather ensures that the
+                // expansion has its own basic block, with no other app instr in it.
+                while (!reached_end_of_memrefs) {
+                    // XXX: Add sanity check for max count of store/load memrefs
+                    // possible for a given scatter/gather instr.
+                    error = process_memref(
+                        tdata, &buf, instr,
+                        // These memrefs were output by multiple store/load instrs in
+                        // the expanded scatter/gather sequence. In raw2trace we see
+                        // only the original app instr though. So we use the 0th
+                        // dest/src of the original scatter/gather instr for all.
+                        is_scatter ? instr->mem_dest_at(0) : instr->mem_src_at(0),
+                        is_scatter, reg_vals, cur_pc, cur_offs, instrs_are_separate,
+                        &reached_end_of_memrefs, &interrupted);
+                    if (!error.empty())
+                        return error;
+                    if (interrupted)
+                        break;
+                }
+            } else {
+                for (uint j = 0; j < instr->num_mem_srcs(); j++) {
+                    error = process_memref(tdata, &buf, instr, instr->mem_src_at(j),
+                                           false, reg_vals, cur_pc, cur_offs,
+                                           instrs_are_separate, nullptr, &interrupted);
+                    if (!error.empty())
+                        return error;
+                    if (interrupted)
+                        break;
+                }
+                // We break before subsequent memrefs on an interrupt, though with
+                // today's tracer that will never happen (i#3958).
+                for (uint j = 0; !interrupted && j < instr->num_mem_dests(); j++) {
+                    error = process_memref(tdata, &buf, instr, instr->mem_dest_at(j),
+                                           true, reg_vals, cur_pc, cur_offs,
+                                           instrs_are_separate, nullptr, &interrupted);
+                    if (!error.empty())
+                        return error;
+                    if (interrupted)
+                        break;
+                }
+            }
+        }
+        cur_pc += instr->length();
+        cur_offs += instr->length();
+        DR_CHECK((size_t)(buf - buf_start) < WRITE_BUFFER_SIZE, "Too many entries");
+        if (instr->is_cti()) {
+            // In case this is the last branch prior to a thread switch, buffer it. We
+            // avoid swapping threads immediately after a branch so that analyzers can
+            // more easily find the branch target.  Doing this in the tracer would
+            // incur extra overhead, and in the reader would be more complex and messy
+            // than here (and we are ok bailing on doing this for online traces), so
+            // we handle it in post-processing by delaying a thread-block-final branch
+            // (and its memrefs) to that thread's next block.  This changes the
+            // timestamp of the branch, which we live with. To avoid marker
+            // misplacement (e.g. in the middle of a basic block), we also
+            // delay markers.
+            log(4, "Delaying %d entries for decode=" PIFX "\n", buf - buf_start,
+                saved_decode_pc);
+            error = write_delayed_branches(tdata, buf_start, buf, saved_decode_pc);
+            if (!error.empty())
+                return error;
+        } else {
+            error = write(tdata, buf_start, buf, { saved_decode_pc });
+            if (!error.empty())
+                return error;
+        }
+        if (interrupted)
+            break;
+    }
+    *handled = true;
+    return "";
+}
+
+// Returns true if a kernel interrupt happened at cur_pc.
+// Outputs a kernel interrupt if this is the right location.
+// Outputs any other markers observed if !instrs_are_separate, since they
+// are part of this block and need to be inserted now. Inserts all
+// intra-block markers (i.e., the higher level process_offline_entry() will
+// never insert a marker intra-block) and all inter-block markers are
+// handled at a higher level (process_offline_entry()) and are never
+// inserted here.
+std::string
+raw2trace_t::handle_kernel_interrupt_and_markers(
+    raw2trace_thread_data_t *tdata, INOUT trace_entry_t **buf_in, uint64_t cur_pc,
+    uint64_t cur_offs, int instr_length, bool instrs_are_separate, OUT bool *interrupted)
+{
+    // To avoid having to backtrack later, we read ahead to ensure we insert
+    // an interrupt at the right place between memrefs or between instructions.
+    *interrupted = false;
+    bool append = false;
+    trace_entry_t *buf_start = get_write_buffer(tdata);
+    do {
+        const offline_entry_t *in_entry = get_next_entry(tdata);
+        if (in_entry == nullptr)
+            return "";
+        append = false;
+        if (in_entry->extended.type != OFFLINE_TYPE_EXTENDED ||
+            in_entry->extended.ext != OFFLINE_EXT_TYPE_MARKER) {
+            // Not a marker: just put it back.
+            unread_last_entry(tdata);
+            continue;
+        }
+        // The kernel markers can take two entries, so we have to read both
+        // if present to get to the type.  There is support for unreading
+        // both.
+        uintptr_t marker_val = 0;
+        std::string err = get_marker_value(tdata, &in_entry, &marker_val);
+        if (!err.empty())
+            return err;
+        if (in_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+            in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT) {
+            // A signal/exception marker in the next entry could be at any point
+            // among non-memref instrs, or it could be after this bb.
+            // We check the stored PC.
+            int version = get_version(tdata);
+            bool at_interrupted_pc = false;
+            bool rseq_rollback = false;
+            if (version < OFFLINE_FILE_VERSION_KERNEL_INT_PC) {
+                // We have only the offs, so we can't handle differing modules for
+                // the source and target for legacy traces.
+                if (marker_val == cur_offs)
+                    at_interrupted_pc = true;
+            } else {
+                if (marker_val == cur_pc)
+                    at_interrupted_pc = true;
+            }
+            if (in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT ||
+                (version < OFFLINE_FILE_VERSION_KERNEL_INT_PC && marker_val == 0)) {
+                // For the older version, we will not get here for Windows
+                // callbacks, the other event with a 0 modoffs, because they are
+                // always between bbs.  (Unfortunately there's no simple way to
+                // assert or check that here or in the tracer.)
+                rseq_rollback = true;
+            }
+            log(4,
+                "Checking whether reached signal/exception %p vs "
+                "cur 0x" HEX64_FORMAT_STRING "\n",
+                marker_val, cur_pc);
+            if (marker_val == 0 || at_interrupted_pc || rseq_rollback) {
+                log(4, "Signal/exception interrupted the bb @ %p\n", cur_pc);
+                append = true;
+                *interrupted = true;
+                if (rseq_rollback) {
+                    // This happens on rseq native aborts, where the trace instru
+                    // includes the rseq committing store before the native rseq
+                    // execution hits the native abort.  Pretend the native abort
+                    // happened *before* the committing store by walking the store
+                    // backward.  Everything in the buffer is for the store;
+                    // there should be no (other) intra-bb markers not for the store.
+                    log(4, "Rolling back %d entries for rseq abort\n",
+                        *buf_in - buf_start);
+                    // If we recorded and emitted an encoding we would not emit
+                    // it next time and be missing the encoding so we must clear
+                    // the cache for that entry.  This will only happen once
+                    // for any new encoding (one synchronous signal/rseq abort
+                    // per instr) so we will satisfy the one-time limit of
+                    // rollback_last_encoding() (it has an assert to verify).
+                    for (trace_entry_t *entry = buf_start; entry < *buf_in; ++entry) {
+                        if (entry->type == TRACE_TYPE_ENCODING) {
+                            rollback_last_encoding(tdata);
+                            break;
+                        }
+                    }
+                    *buf_in = buf_start;
+                }
+            } else {
+                // Put it back (below). We do not have a problem with other markers
+                // following this, because we will have to hit the correct point
+                // for this interrupt marker before we hit a memref entry, avoiding
+                // the danger of wanting a memref entry, seeing a marker, continuing,
+                // and hitting a fatal error when we find the memref back in the
+                // not-inside-a-block main loop.
+            }
+        } else {
+            // Other than kernel event markers checked above, markers should be
+            // only at block boundaries, as we cannot figure out where they should go
+            // (and could easily insert them in the middle of this block instead
+            // of between this and the next block, with implicit instructions added).
+            // Thus, we do not append any other markers.
+        }
+        if (append) {
+            byte *buf = reinterpret_cast<byte *>(*buf_in);
+            buf += trace_metadata_writer_t::write_marker(
+                buf, (trace_marker_type_t)in_entry->extended.valueB, marker_val);
+            *buf_in = reinterpret_cast<trace_entry_t *>(buf);
+            log(3, "Appended marker type %u value " PIFX "\n",
+                (trace_marker_type_t)in_entry->extended.valueB, marker_val);
+            // There can be many markers in a row, esp for function tracing on
+            // longjmp or some other xfer that skips many post-call points.
+            // But, we can't easily write the buffer out, b/c we want to defer
+            // it for branches, and roll it back for rseq.
+            // XXX i#4159: We could switch to dynamic storage (and update all uses
+            // that assume no re-allocation), but this should be pathological so for
+            // now we have a release-build failure.
+            DR_CHECK((size_t)(*buf_in - buf_start) < WRITE_BUFFER_SIZE,
+                     "Too many entries");
+        } else {
+            // Put it back.
+            unread_last_entry(tdata);
+        }
+    } while (append);
+    return "";
+}
+
+std::string
+raw2trace_t::get_marker_value(raw2trace_thread_data_t *tdata,
+                              INOUT const offline_entry_t **entry, OUT uintptr_t *value)
+{
+    uintptr_t marker_val = static_cast<uintptr_t>((*entry)->extended.valueA);
+    if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_SPLIT_VALUE) {
+#ifdef X64
+        // Keep the prior so we can unread both at once if we roll back.
+        const offline_entry_t *next = get_next_entry_keep_prior(tdata);
+        if (next == nullptr || next->extended.ext != OFFLINE_EXT_TYPE_MARKER)
+            return "SPLIT_VALUE marker is not adjacent to 2nd entry";
+        marker_val = (marker_val << 32) | static_cast<uintptr_t>(next->extended.valueA);
+        *entry = next;
+#else
+        return "TRACE_MARKER_TYPE_SPLIT_VALUE unexpected for 32-bit";
+#endif
+    }
+#ifdef X64 // 32-bit has the absolute pc as the raw marker value.
+    if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+        (*entry)->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT ||
+        (*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER) {
+        if (get_version(tdata) >= OFFLINE_FILE_VERSION_KERNEL_INT_PC) {
+            // We convert the idx:offs to an absolute PC.
+            // TODO i#2062: For non-module code we don't have the block id and so
+            // cannot use this format.  We should probably just abandon this and
+            // always store the absolute PC.
+            kernel_interrupted_raw_pc_t raw_pc;
+            raw_pc.combined_value = marker_val;
+            DR_ASSERT(raw_pc.pc.modidx != PC_MODIDX_INVALID);
+            app_pc pc = modvec_()[raw_pc.pc.modidx].orig_seg_base +
+                (raw_pc.pc.modoffs - modvec_()[raw_pc.pc.modidx].seg_offs);
+            log(3,
+                "Kernel marker: converting 0x" ZHEX64_FORMAT_STRING
+                " idx=" INT64_FORMAT_STRING " with base=%p to %p\n",
+                marker_val, raw_pc.pc.modidx, modvec_()[raw_pc.pc.modidx].orig_seg_base,
+                pc);
+            marker_val = reinterpret_cast<uintptr_t>(pc);
+        } // Else we've already marked as TRACE_ENTRY_VERSION_NO_KERNEL_PC.
+    }
+#endif
+    *value = marker_val;
+    return "";
+}
+
+std::string
+raw2trace_t::append_memref(raw2trace_thread_data_t *tdata, INOUT trace_entry_t **buf_in,
+                           const instr_summary_t *instr,
+                           instr_summary_t::memref_summary_t memref, bool write,
+                           std::unordered_map<reg_id_t, addr_t> &reg_vals,
+                           OUT bool *reached_end_of_memrefs)
+{
+    DR_ASSERT(!TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, get_file_type(tdata)));
+    trace_entry_t *buf = *buf_in;
+    const offline_entry_t *in_entry = nullptr;
+    bool have_addr = false;
+    bool have_type = false;
+    reg_id_t base;
+    int version = get_version(tdata);
+    if (memref.use_remembered_base) {
+        DR_ASSERT(!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED |
+                               OFFLINE_FILE_TYPE_DFILTERED,
+                           get_file_type(tdata)));
+        bool is_elidable = instru_offline_.opnd_is_elidable(memref.opnd, base, version);
+        DR_ASSERT(is_elidable);
+        if (base == DR_REG_NULL) {
+            DR_ASSERT(IF_REL_ADDRS(opnd_is_near_rel_addr(memref.opnd) ||)
+                          opnd_is_near_abs_addr(memref.opnd));
+            buf->addr = reinterpret_cast<addr_t>(opnd_get_addr(memref.opnd));
+            log(4, "Filling in elided rip-rel addr with %p\n", buf->addr);
+        } else {
+            buf->addr = reg_vals[base];
+            log(4, "Filling in elided addr with remembered %s: %p\n",
+                get_register_name(base), buf->addr);
+        }
+        have_addr = true;
+        add_to_statistic(tdata, RAW2TRACE_STAT_COUNT_ELIDED, 1);
+    }
+    if (!have_addr) {
+        if (memref.use_remembered_base)
+            return "Non-elided base mislabeled to use remembered base";
+        in_entry = get_next_entry(tdata);
+    }
+    if (in_entry != nullptr && in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
+        in_entry->extended.ext == OFFLINE_EXT_TYPE_MEMINFO) {
+        // For -L0_filter we have to store the type for multi-memref instrs where
+        // we can't tell which memref it is (we'll still come here for the subsequent
+        // memref operands but we'll exit early in the check below).
+        have_type = true;
+        buf->type = in_entry->extended.valueB;
+        buf->size = in_entry->extended.valueA;
+        log(4, "Found type entry type %s (%d) size %d\n", trace_type_names[buf->type],
+            buf->type, buf->size);
+        in_entry = get_next_entry(tdata);
+        if (in_entry == nullptr)
+            return "Trace ends mid-block";
+    }
+    if (!have_addr &&
+        (in_entry == nullptr ||
+         (in_entry->addr.type != OFFLINE_TYPE_MEMREF &&
+          in_entry->addr.type != OFFLINE_TYPE_MEMREF_HIGH))) {
+        // This happens when there are predicated memrefs in the bb, or for a
+        // zero-iter rep string loop, or for a multi-memref instr with -L0_filter.
+        // For predicated memrefs, they could be earlier, so "instr"
+        // may not itself be predicated.
+        // XXX i#2015: if there are multiple predicated memrefs, our instr vs
+        // data stream may not be in the correct order here.
+        log(4,
+            "Missing memref from predication, 0-iter repstr, filter, "
+            "or reached end of memrefs output by scatter/gather seq "
+            "(next type is 0x" ZHEX64_FORMAT_STRING ")\n",
+            in_entry == nullptr ? 0 : in_entry->combined_value);
+        if (in_entry != nullptr) {
+            unread_last_entry(tdata);
+        }
+        if (reached_end_of_memrefs != nullptr) {
+            *reached_end_of_memrefs = true;
+        }
+        return "";
+    }
+    if (!have_type) {
+        if (instr->is_prefetch()) {
+            buf->type = instr->prefetch_type();
+            buf->size = 1;
+        } else if (instr->is_flush()) {
+            buf->type = instr->flush_type();
+            // TODO i#4398: Handle flush sizes larger than ushort.
+            // TODO i#4406: Handle flush instrs with sizes other than cache line.
+            buf->size = (ushort)get_cache_line_size(tdata);
+        } else {
+            if (write)
+                buf->type = TRACE_TYPE_WRITE;
+            else
+                buf->type = TRACE_TYPE_READ;
+            buf->size = (ushort)opnd_size_in_bytes(opnd_get_size(memref.opnd));
+        }
+    }
+    if (!have_addr) {
+        DR_ASSERT(in_entry != nullptr);
+        // We take the full value, to handle low or high.
+        buf->addr = (addr_t)in_entry->combined_value;
+    }
+    if (memref.remember_base &&
+        instru_offline_.opnd_is_elidable(memref.opnd, base, version)) {
+        log(5, "Remembering base " PFX " for %s\n", buf->addr, get_register_name(base));
+        reg_vals[base] = buf->addr;
+    }
+    if (!TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, get_file_type(tdata)) &&
+        instru_offline_.opnd_disp_is_elidable(memref.opnd)) {
+        // We stored only the base reg, as an optimization.
+        buf->addr += opnd_get_disp(memref.opnd);
+    }
+    log(4, "Appended memref type %s (%d) size %d to " PFX "\n",
+        trace_type_names[buf->type], buf->type, buf->size, (ptr_uint_t)buf->addr);
+
+#ifdef AARCH64
+    // TODO i#4400: Following is a workaround to correctly represent DC ZVA in
+    // offline traces. Note that this doesn't help with online traces.
+    // TODO i#3339: This workaround causes us to lose the address that was present
+    // in the original instruction. For re-encoding fidelity, we may want the
+    // original address in the IR.
+    if (instr->is_aarch64_dc_zva()) {
+        buf->addr = ALIGN_BACKWARD(buf->addr, get_cache_line_size(tdata));
+        buf->size = get_cache_line_size(tdata);
+        buf->type = TRACE_TYPE_WRITE;
+    }
+#endif
+    *buf_in = ++buf;
+    return "";
+}
+
+bool
+raw2trace_t::record_encoding_emitted(raw2trace_thread_data_t *tdata, app_pc pc)
+{
     if (tdata->encoding_emitted.find(pc) != tdata->encoding_emitted.end())
         return false;
     tdata->encoding_emitted.insert(pc);
@@ -852,19 +1684,17 @@ raw2trace_t::record_encoding_emitted(void *tls, app_pc pc)
 // This can only be called once between calls to record_encoding_emitted()
 // and only after record_encoding_emitted() returns true.
 void
-raw2trace_t::rollback_last_encoding(void *tls)
+raw2trace_t::rollback_last_encoding(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     DEBUG_ASSERT(tdata->last_encoding_emitted != nullptr);
     tdata->encoding_emitted.erase(tdata->last_encoding_emitted);
     tdata->last_encoding_emitted = nullptr;
 }
 
 raw2trace_t::block_summary_t *
-raw2trace_t::lookup_block_summary(void *tls, uint64 modidx, uint64 modoffs,
-                                  app_pc block_start)
+raw2trace_t::lookup_block_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                  uint64 modoffs, app_pc block_start)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     // There is no sentinel available for modidx+modoffs so we use block_start for that.
     if (block_start == tdata->last_decode_block_start &&
         modidx == tdata->last_decode_modidx && modoffs == tdata->last_decode_modoffs) {
@@ -886,11 +1716,11 @@ raw2trace_t::lookup_block_summary(void *tls, uint64 modidx, uint64 modoffs,
 }
 
 instr_summary_t *
-raw2trace_t::lookup_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
-                                  app_pc block_start, int index, app_pc pc,
-                                  OUT block_summary_t **block_summary)
+raw2trace_t::lookup_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                  uint64 modoffs, app_pc block_start, int index,
+                                  app_pc pc, OUT block_summary_t **block_summary)
 {
-    block_summary_t *block = lookup_block_summary(tls, modidx, modoffs, block_start);
+    block_summary_t *block = lookup_block_summary(tdata, modidx, modoffs, block_start);
     if (block_summary != nullptr)
         *block_summary = block;
     if (block == nullptr)
@@ -903,20 +1733,20 @@ raw2trace_t::lookup_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
 }
 
 bool
-raw2trace_t::instr_summary_exists(void *tls, uint64 modidx, uint64 modoffs,
-                                  app_pc block_start, int index, app_pc pc)
+raw2trace_t::instr_summary_exists(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                  uint64 modoffs, app_pc block_start, int index,
+                                  app_pc pc)
 {
-    return lookup_instr_summary(tls, modidx, modoffs, block_start, index, pc, nullptr) !=
-        nullptr;
+    return lookup_instr_summary(tdata, modidx, modoffs, block_start, index, pc,
+                                nullptr) != nullptr;
 }
 
 instr_summary_t *
-raw2trace_t::create_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
-                                  block_summary_t *block, app_pc block_start,
-                                  int instr_count, int index, INOUT app_pc *pc,
-                                  app_pc orig)
+raw2trace_t::create_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                  uint64 modoffs, block_summary_t *block,
+                                  app_pc block_start, int instr_count, int index,
+                                  INOUT app_pc *pc, app_pc orig)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     if (block == nullptr) {
         block = new block_summary_t(block_start, instr_count);
         DEBUG_ASSERT(index >= 0 && index < static_cast<int>(block->instrs.size()));
@@ -943,16 +1773,16 @@ raw2trace_t::create_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
 }
 
 const instr_summary_t *
-raw2trace_t::get_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
-                               app_pc block_start, int instr_count, int index,
-                               INOUT app_pc *pc, app_pc orig)
+raw2trace_t::get_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
+                               uint64 modoffs, app_pc block_start, int instr_count,
+                               int index, INOUT app_pc *pc, app_pc orig)
 {
     block_summary_t *block;
     const instr_summary_t *ret =
-        lookup_instr_summary(tls, modidx, modoffs, block_start, index, *pc, &block);
+        lookup_instr_summary(tdata, modidx, modoffs, block_start, index, *pc, &block);
     if (ret == nullptr) {
-        return create_instr_summary(tls, modidx, modoffs, block, block_start, instr_count,
-                                    index, pc, orig);
+        return create_instr_summary(tdata, modidx, modoffs, block, block_start,
+                                    instr_count, index, pc, orig);
     }
     *pc = ret->next_pc();
     return ret;
@@ -962,18 +1792,19 @@ raw2trace_t::get_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
 // multiple flags, we'd need get_instr_summary() to take in a vector or sthg.
 // Instead we set after the fact.
 bool
-raw2trace_t::set_instr_summary_flags(void *tls, uint64 modidx, uint64 modoffs,
-                                     app_pc block_start, int instr_count, int index,
-                                     app_pc pc, app_pc orig, bool write, int memop_index,
-                                     bool use_remembered_base, bool remember_base)
+raw2trace_t::set_instr_summary_flags(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                     uint64 modoffs, app_pc block_start, int instr_count,
+                                     int index, app_pc pc, app_pc orig, bool write,
+                                     int memop_index, bool use_remembered_base,
+                                     bool remember_base)
 {
     block_summary_t *block;
     instr_summary_t *desc =
-        lookup_instr_summary(tls, modidx, modoffs, block_start, index, pc, &block);
+        lookup_instr_summary(tdata, modidx, modoffs, block_start, index, pc, &block);
     if (desc == nullptr) {
         app_pc pc_copy = pc;
-        desc = create_instr_summary(tls, modidx, modoffs, block, block_start, instr_count,
-                                    index, &pc_copy, orig);
+        desc = create_instr_summary(tdata, modidx, modoffs, block, block_start,
+                                    instr_count, index, &pc_copy, orig);
     }
     if (desc == nullptr)
         return false;
@@ -1074,14 +1905,13 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
 }
 
 const offline_entry_t *
-raw2trace_t::get_next_entry(void *tls)
+raw2trace_t::get_next_entry(raw2trace_thread_data_t *tdata)
 {
     // We do our own buffering to avoid performance problems for some istreams where
     // seekg is slow.  We expect just 1 entry peeked and put back the vast majority of the
     // time, but we use a vector for generality.  We expect our overall performance to
     // be i/o bound (or ISA decode bound) and aren't worried about some extra copies
     // from the vector.
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     tdata->last_entry_is_split = false;
     if (!tdata->pre_read.empty()) {
         tdata->last_entry = tdata->pre_read[0];
@@ -1101,25 +1931,23 @@ raw2trace_t::get_next_entry(void *tls)
 }
 
 const offline_entry_t *
-raw2trace_t::get_next_entry_keep_prior(void *tls)
+raw2trace_t::get_next_entry_keep_prior(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     if (tdata->last_entry_is_split) {
         // Cannot record two live split entries.
         return nullptr;
     }
     VPRINT(4, "Remembering split entry for unreading both at once\n");
     tdata->last_split_first_entry = tdata->last_entry;
-    const offline_entry_t *next = get_next_entry(tls);
+    const offline_entry_t *next = get_next_entry(tdata);
     // Set this *after* calling get_next_entry as it clears the field.
     tdata->last_entry_is_split = true;
     return next;
 }
 
 void
-raw2trace_t::unread_last_entry(void *tls)
+raw2trace_t::unread_last_entry(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     VPRINT(5, "Unreading last entry\n");
     if (tdata->last_entry_is_split) {
         VPRINT(4, "Unreading both parts of split entry at once\n");
@@ -1130,16 +1958,14 @@ raw2trace_t::unread_last_entry(void *tls)
 }
 
 bool
-raw2trace_t::thread_file_at_eof(void *tls)
+raw2trace_t::thread_file_at_eof(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return tdata->pre_read.empty() && tdata->thread_file->eof();
 }
 
 std::string
-raw2trace_t::append_delayed_branch(void *tls)
+raw2trace_t::append_delayed_branch(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     if (tdata->delayed_branch.empty())
         return "";
     if (verbosity_ >= 4) {
@@ -1171,9 +1997,8 @@ raw2trace_t::append_delayed_branch(void *tls)
 }
 
 trace_entry_t *
-raw2trace_t::get_write_buffer(void *tls)
+raw2trace_t::get_write_buffer(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return tdata->out_buf.data();
 }
 
@@ -1264,8 +2089,9 @@ raw2trace_t::open_new_chunk(raw2trace_thread_data_t *tdata)
 }
 
 std::string
-raw2trace_t::append_encoding(void *tls, app_pc pc, size_t instr_length,
-                             trace_entry_t *&buf, trace_entry_t *buf_start)
+raw2trace_t::append_encoding(raw2trace_thread_data_t *tdata, app_pc pc,
+                             size_t instr_length, trace_entry_t *&buf,
+                             trace_entry_t *buf_start)
 {
     size_t size_left = instr_length;
     size_t offs = 0;
@@ -1294,15 +2120,14 @@ raw2trace_t::append_encoding(void *tls, app_pc pc, size_t instr_length,
 }
 
 std::string
-raw2trace_t::insert_post_chunk_encodings(void *tls, const trace_entry_t *instr,
-                                         app_pc decode_pc)
+raw2trace_t::insert_post_chunk_encodings(raw2trace_thread_data_t *tdata,
+                                         const trace_entry_t *instr, app_pc decode_pc)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     trace_entry_t encodings[WRITE_BUFFER_SIZE];
     trace_entry_t *buf = encodings;
     log(4, "Adding post-chunk-boundary encoding entry for decode=%p app=%p\n", decode_pc,
         instr->addr);
-    std::string err = append_encoding(tls, decode_pc, instr->size, buf, encodings);
+    std::string err = append_encoding(tdata, decode_pc, instr->size, buf, encodings);
     if (!err.empty())
         return err;
     if (!tdata->out_file->write(reinterpret_cast<const char *>(encodings),
@@ -1316,12 +2141,11 @@ raw2trace_t::insert_post_chunk_encodings(void *tls, const trace_entry_t *instr,
 // and footers (to do so would cause recursion; we assume those do not need
 // extra processing here).
 std::string
-raw2trace_t::write(void *tls, const trace_entry_t *start, const trace_entry_t *end,
-                   std::vector<app_pc> decode_pcs)
+raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
+                   const trace_entry_t *end, std::vector<app_pc> decode_pcs)
 {
     if (end == start)
         return "Empty buffer passed to write()";
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     if (tdata->out_archive != nullptr) {
         bool prev_was_encoding = false;
         int instr_ordinal = -1;
@@ -1367,7 +2191,7 @@ raw2trace_t::write(void *tls, const trace_entry_t *start, const trace_entry_t *e
                 type_is_instr(static_cast<trace_type_t>(it->type)) &&
                 // We don't want encodings for the PC-only i-filtered entries.
                 it->size > 0 && !prev_was_encoding &&
-                record_encoding_emitted(tls, decode_pcs[instr_ordinal])) {
+                record_encoding_emitted(tdata, decode_pcs[instr_ordinal])) {
                 // Write any data we were waiting until post-loop to write.
                 if (it > start &&
                     !tdata->out_file->write(reinterpret_cast<const char *>(start),
@@ -1375,7 +2199,7 @@ raw2trace_t::write(void *tls, const trace_entry_t *start, const trace_entry_t *e
                                                 reinterpret_cast<const char *>(start)))
                     return "Failed to write to output file";
                 std::string err =
-                    insert_post_chunk_encodings(tls, it, decode_pcs[instr_ordinal]);
+                    insert_post_chunk_encodings(tdata, it, decode_pcs[instr_ordinal]);
                 if (!err.empty())
                     return err;
                 if (!tdata->out_file->write(reinterpret_cast<const char *>(it),
@@ -1419,10 +2243,10 @@ raw2trace_t::write(void *tls, const trace_entry_t *start, const trace_entry_t *e
 }
 
 std::string
-raw2trace_t::write_delayed_branches(void *tls, const trace_entry_t *start,
-                                    const trace_entry_t *end, app_pc decode_pc)
+raw2trace_t::write_delayed_branches(raw2trace_thread_data_t *tdata,
+                                    const trace_entry_t *start, const trace_entry_t *end,
+                                    app_pc decode_pc)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     int instr_count = 0;
     for (const trace_entry_t *it = start; it < end; ++it) {
         tdata->delayed_branch.push_back(*it);
@@ -1441,16 +2265,14 @@ raw2trace_t::write_delayed_branches(void *tls, const trace_entry_t *start,
 }
 
 bool
-raw2trace_t::delayed_branches_exist(void *tls)
+raw2trace_t::delayed_branches_exist(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return !tdata->delayed_branch.empty();
 }
 
 std::string
-raw2trace_t::write_footer(void *tls)
+raw2trace_t::write_footer(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     trace_entry_t entry;
     entry.type = TRACE_TYPE_FOOTER;
     entry.size = 0;
@@ -1462,9 +2284,8 @@ raw2trace_t::write_footer(void *tls)
 }
 
 std::string
-raw2trace_t::on_thread_end(void *tls)
+raw2trace_t::on_thread_end(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     if (get_next_entry(tdata) != nullptr || !thread_file_at_eof(tdata))
         return "Footer is not the final entry";
     return write_footer(tdata);
@@ -1496,51 +2317,44 @@ raw2trace_t::log_instruction(uint level, app_pc decode_pc, app_pc orig_pc)
 }
 
 void
-raw2trace_t::set_last_pc_if_syscall(void *tls, app_pc value)
+raw2trace_t::set_last_pc_if_syscall(raw2trace_thread_data_t *tdata, app_pc value)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     tdata->last_pc_if_syscall_ = value;
 }
 
 app_pc
-raw2trace_t::get_last_pc_if_syscall(void *tls)
+raw2trace_t::get_last_pc_if_syscall(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return tdata->last_pc_if_syscall_;
 }
 
 void
-raw2trace_t::set_prev_instr_rep_string(void *tls, bool value)
+raw2trace_t::set_prev_instr_rep_string(raw2trace_thread_data_t *tdata, bool value)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     tdata->prev_instr_was_rep_string = value;
 }
 
 bool
-raw2trace_t::was_prev_instr_rep_string(void *tls)
+raw2trace_t::was_prev_instr_rep_string(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return tdata->prev_instr_was_rep_string;
 }
 
 int
-raw2trace_t::get_version(void *tls)
+raw2trace_t::get_version(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return tdata->version;
 }
 
 size_t
-raw2trace_t::get_cache_line_size(void *tls)
+raw2trace_t::get_cache_line_size(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return tdata->cache_line_size;
 }
 
 offline_file_type_t
-raw2trace_t::get_file_type(void *tls)
+raw2trace_t::get_file_type(raw2trace_thread_data_t *tdata)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     return tdata->file_type;
 }
 
@@ -1552,11 +2366,12 @@ raw2trace_t::raw2trace_t(const char *module_map,
                          archive_ostream_t *cpu_schedule_file, void *dcontext,
                          unsigned int verbosity, int worker_count,
                          const std::string &alt_module_dir, uint64_t chunk_instr_count)
-    : trace_converter_t(dcontext)
+    : dcontext_(dcontext == nullptr ? dr_standalone_init() : dcontext)
+    , passed_dcontext_(dcontext != nullptr)
     , worker_count_(worker_count)
     , user_process_(nullptr)
     , user_process_data_(nullptr)
-    , modmap_(module_map)
+    , modmap_bytes_(module_map)
     , encoding_file_(encoding_file)
     , serial_schedule_file_(serial_schedule_file)
     , cpu_schedule_file_(cpu_schedule_file)
@@ -1622,6 +2437,8 @@ raw2trace_t::raw2trace_t(const char *module_map,
 raw2trace_t::~raw2trace_t()
 {
     module_mapper_.reset();
+    if (!passed_dcontext_)
+        dr_standalone_exit();
 }
 
 bool
@@ -1721,9 +2538,9 @@ drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t trace_size
 }
 
 void
-raw2trace_t::add_to_statistic(void *tls, raw2trace_statistic_t stat, int value)
+raw2trace_t::add_to_statistic(raw2trace_thread_data_t *tdata, raw2trace_statistic_t stat,
+                              int value)
 {
-    auto tdata = reinterpret_cast<raw2trace_thread_data_t *>(tls);
     switch (stat) {
     case RAW2TRACE_STAT_COUNT_ELIDED: tdata->count_elided += value; break;
     case RAW2TRACE_STAT_DUPLICATE_SYSCALL: tdata->count_duplicate_syscall += value; break;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -219,7 +219,7 @@ struct instr_summary_t final {
     }
 
 private:
-    template <typename T> friend class trace_converter_t;
+    friend class raw2trace_t;
 
     byte
     length() const
@@ -617,1125 +617,11 @@ struct trace_header_t {
     size_t cache_line_size;
 };
 
-/* XXX i#4062: We are no longer using this split interface.
- * Should we refactor and merge trace_converter_t into raw2trace_t for simpler code?
- */
-
-/**
- * #trace_converter_t is a reusable component that encapsulates raw trace conversion.
- *
- * Conversion happens from a data source abstracted by the type parameter T. We make no
- * assumption about how thread buffers are organized. We do assume the internal
- * composition of thread buffers is "as written" by the thread. For example, all thread
- * buffers belonging to different threads may be in a separate files; or buffers may be
- * co-located in one large file, or spread accross multiple, mixed-thread files.
- *
- * #trace_converter_t expects to be instantiated with its type template T which should
- * provide the following APIs.  These pass through an opaque pointer which provides
- * per-traced-thread-local data to the converter:
- *
- * <UL> <LI>const offline_entry_t *get_next_entry(void *tls)
- *
- * Point to the next offline entry_t. There is no assumption about the underlying source
- * of the data, and #trace_converter_t will not attempt to dereference past the provided
- * pointer.</LI>
- *
- * <LI>const offline_entry_t *get_next_entry_keep_prior(void *tls)
- *
- * Records the currently stored last entry in order to remember two entries at once
- * (for handling split two-entry markers) and then reads and returns a pointer to the
- * next entry.  A subsequent call to unread_last_entry() will put back both entries.
- * Returns an emptry string on success or an error description on an error.
- *
- * <LI>void unread_last_entry(void *tls)
- *
- * Ensure that the next call to get_next_entry() re-reads the last value.</LI>
- *
- * <LI>trace_entry_t *get_write_buffer(void *tls)
- *
- * Return a writable buffer guaranteed to be at least #WRITE_BUFFER_SIZE large.
- *  get_write_buffer() may reuse the same buffer after write() or write_delayed_branches()
- * is called.</LI>
- *
- * <LI>std::string write(void *tls, const trace_entry_t *start, const trace_entry_t *end,
- *                       std::vector<app_pc> decode_pcs = {})
- *
- * Writes the converted traces between start and end, where end is past the last
- * item to write. Both start and end are assumed to be pointers inside a buffer
- * returned by get_write_buffer().  decode_pcs is only needed if there is more
- * than one instruction in the buffer; in that case it must contain one entry per
- * instruction.</LI>
- *
- * <LI>std::string write_delayed_branches(void *tls, const trace_entry_t *start,
- * const trace_entry_t *end, app_pc decode_pc)
- *
- * Similar to write(), but treat the provided traces as delayed branches: if they
- * are the last values in a record, they belong to the next record of the same
- * thread.  The start..end sequence must contain one instruction.</LI>
- *
- * <LI>bool delayed_branches_exist(void *tls)
- *
- * Returns true if there are currently delayed branches that have not been emitted
- * yet.</LI>
- *
- * <LI>std::string append_delayed_branch(void *tls)
- *
- * Flush the branches sent to write_delayed_branches().</LI>
- *
- * <LI>std::string on_thread_end(void *tls)
- *
- * Callback notifying the currently-processed thread has exited. #trace_converter_t
- * extenders are expected to track record metadata themselves. #trace_converter_t offers
- * APIs for extracting that metadata.</LI>
- *
- * <LI>void log(uint level, const char *fmt, ...)
- *
- * Implementers are given the opportunity to implement their own logging. The level
- * parameter represents severity: the lower the level, the higher the severity.</LI>
- *
- * <LI>void log_instruction(uint level, app_pc decode_pc, app_pc orig_pc);
- *
- * Similar to log() but this disassembles the given PC.</LI>
- *
- * <LI>void add_to_statistic(void *tls, raw2trace_statistic_t stat, int value)
- *
- * Increases the per-thread counter for the statistic identified by stat by value.
- * </LI>
- *
- * <LI>bool raw2trace_t::record_encoding_emitted(void *tls, app_pc pc)
- *
- * Returns false if an encoding was already emitted.
- * Otherwise, remembers that an encoding is being emitted now, and returns true.
- * </LI>
- *
- * <LI>void raw2trace_t::rollback_last_encoding(void *tls)
- *
- * Removes the record of the last encoding remembered in record_encoding_emitted().
- * This can only be called once between calls to record_encoding_emitted()
- * and only after record_encoding_emitted() returns true.
- * </LI>
- *
- * <LI>bool raw2trace_t::instr_summary_exists(void *tls, uint64 modidx, uint64 modoffs,
- * int index) const
- *
- * Returns whether an #instr_summary_t representation of the instruction at pc inside
- * the block that begins at block_start_pc in the specified module exists.
- * </LI>
- *
- * <LI>const instr_summary_t *get_instr_summary(void *tls, uint64 modidx, uint64 modoffs,
- * app_pc block_start_pc, int instr_count, int index, INOUT app_pc *pc, app_pc orig)
- *
- * Return the #instr_summary_t representation of the index-th instruction (at *pc)
- * inside the block that begins at block_start_pc and contains instr_count
- * instructions in the specified module.  Updates the value at pc to the PC of the
- * next instruction. It is assumed the app binaries have already been loaded using
- * #module_mapper_t, and the values at *pc point within memory mapped by the module
- * mapper. This API provides an opportunity to cache decoded instructions.  </LI>
- *
- * <LI>bool set_instr_summary_flags(void *tls, uint64 modidx, uint64 modoffs,
- * app_pc block_start_pc, int instr_count, int index, app_pc pc, app_pc orig,
- * bool write, int memop_index, bool use_remembered_base, bool remember_base)
- *
- * Sets two flags stored in the memref_summary_t inside the instr_summary_t for the
- * index-th instruction (at pc) inside the block that begins at block_start_pc and
- * contains instr_count instructions in the specified module.  The flags
- * use_remembered_base and remember_base are set for the source (write==false) or
- * destination (write==true) operand of index memop_index. The flags are OR-ed in: i.e.,
- * they are never cleared.
- * </LI>
- *
- * <LI>void set_prev_instr_rep_string(void *tls, bool value)
- *
- * Sets a per-traced-thread cached flag that is read by was_prev_instr_rep_string().
- * </LI>
- *
- * <LI>bool was_prev_instr_rep_string(void *tls)
- *
- * Queries a per-traced-thread cached flag that is set by set_prev_instr_rep_string().
- * </LI>
- *
- * <LI>int get_version(void *tls)
- *
- * Returns the trace file version (an OFFLINE_FILE_VERSION* constant).
- * </LI>
- *
- * <LI>offline_file_type_t get_file_type(void *tls)
- *
- * Returns the trace file type (a combination of OFFLINE_FILE_TYPE* constants).
- * </LI>
- *
- * <LI>std::string append_encoding(void *tls, app_pc pc, size_t instr_length,
- *                                 trace_entry_t *&buf, trace_entry_t *buf_start)
- *
- * Writes encoding entries for pc..pc+instr_length to buf.
- * </UL>
- */
-template <typename T> class trace_converter_t {
 #define DR_CHECK(val, msg) \
     do {                   \
         if (!(val))        \
             return msg;    \
     } while (0)
-public:
-    trace_converter_t(const trace_converter_t &) = delete;
-    trace_converter_t &
-    operator=(const trace_converter_t &) = delete;
-#ifndef WINDOWS
-    trace_converter_t(trace_converter_t &&) = default;
-    trace_converter_t &
-    operator=(trace_converter_t &&) = default;
-#endif
-
-protected:
-    /**
-     * Construct a new #trace_converter_t object. If a nullptr dcontext is passed,
-     * creates a new DR context va dr_standalone_init().
-     */
-    trace_converter_t(void *dcontext)
-        : dcontext_(dcontext == nullptr ? dr_standalone_init() : dcontext)
-        , passed_dcontext_(dcontext != nullptr)
-    {
-    }
-
-    /**
-     * Destroys this #trace_converter_t object.  If a nullptr dcontext_in was passed
-     * to the constructor, calls dr_standalone_exit().
-     */
-    ~trace_converter_t()
-    {
-        if (!passed_dcontext_)
-            dr_standalone_exit();
-    }
-
-    /**
-     * Convert starting from in_entry, and reading more entries as required.
-     * Sets end_of_record to true if processing hit the end of a record.
-     * read_and_map_modules() must have been called by the implementation before
-     * calling this API.
-     */
-    std::string
-    process_offline_entry(void *tls, const offline_entry_t *in_entry, thread_id_t tid,
-                          OUT bool *end_of_record, OUT bool *last_bb_handled)
-    {
-        trace_entry_t *buf_base = impl()->get_write_buffer(tls);
-        byte *buf = reinterpret_cast<byte *>(buf_base);
-        if (in_entry->extended.type == OFFLINE_TYPE_EXTENDED) {
-            if (in_entry->extended.ext == OFFLINE_EXT_TYPE_FOOTER) {
-                DR_CHECK(tid != INVALID_THREAD_ID, "Missing thread id");
-                impl()->log(2, "Thread %d exit\n", (uint)tid);
-                buf += trace_metadata_writer_t::write_thread_exit(buf, tid);
-                *end_of_record = true;
-                std::string error =
-                    impl()->write(tls, buf_base, reinterpret_cast<trace_entry_t *>(buf));
-                if (!error.empty())
-                    return error;
-                // Let the user determine what other actions to take, e.g. account for
-                // the ending of the current thread, etc.
-                return impl()->on_thread_end(tls);
-            } else if (in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER) {
-                uintptr_t marker_val = 0;
-                std::string err = get_marker_value(tls, &in_entry, &marker_val);
-                if (!err.empty())
-                    return err;
-                buf += trace_metadata_writer_t::write_marker(
-                    buf, (trace_marker_type_t)in_entry->extended.valueB, marker_val);
-                if (in_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT) {
-                    impl()->log(4, "Signal/exception between bbs\n");
-                }
-                // If there is currently a delayed branch that has not been emitted yet,
-                // delay most markers since intra-block markers can cause issues with
-                // tools that do not expect markers amid records for a single instruction
-                // or inside a basic block. We don't delay TRACE_MARKER_TYPE_CPU_ID which
-                // identifies the CPU on which subsequent records were collected and
-                // OFFLINE_TYPE_TIMESTAMP which is handled at a higher level in
-                // process_next_thread_buffer() so there is no need to have a separate
-                // check for it here.
-                if (in_entry->extended.valueB != TRACE_MARKER_TYPE_CPU_ID) {
-                    if (impl()->delayed_branches_exist(tls)) {
-                        std::string error = impl()->write_delayed_branches(
-                            tls, buf_base, reinterpret_cast<trace_entry_t *>(buf));
-                        if (!error.empty())
-                            return error;
-                        return "";
-                    }
-                }
-                impl()->log(3, "Appended marker type %u value " PIFX "\n",
-                            (trace_marker_type_t)in_entry->extended.valueB,
-                            (uintptr_t)in_entry->extended.valueA);
-            } else {
-                std::stringstream ss;
-                ss << "Invalid extension type " << (int)in_entry->extended.ext;
-                return ss.str();
-            }
-        } else if (in_entry->addr.type == OFFLINE_TYPE_MEMREF ||
-                   in_entry->addr.type == OFFLINE_TYPE_MEMREF_HIGH) {
-            if (!*last_bb_handled &&
-                // Shouldn't get here if encodings are present.
-                impl()->get_version(tls) < OFFLINE_FILE_VERSION_ENCODINGS) {
-                // For legacy traces with unhandled non-module code, memrefs are handled
-                // here where we can easily handle the transition out of the bb.
-                trace_entry_t *entry = reinterpret_cast<trace_entry_t *>(buf);
-                entry->type = TRACE_TYPE_READ; // Guess.
-                entry->size = 1;               // Guess.
-                entry->addr = (addr_t)in_entry->combined_value;
-                impl()->log(4, "Appended non-module memref to " PFX "\n",
-                            (ptr_uint_t)entry->addr);
-                buf += sizeof(*entry);
-            } else {
-                // We should see an instr entry first
-                impl()->log(3, "extra memref entry: %p\n", in_entry->addr.addr);
-                return "memref entry found outside of bb";
-            }
-        } else if (in_entry->pc.type == OFFLINE_TYPE_PC) {
-            DR_CHECK(reinterpret_cast<trace_entry_t *>(buf) == buf_base,
-                     "We shouldn't have buffered anything before calling "
-                     "append_bb_entries");
-            std::string result = append_bb_entries(tls, in_entry, last_bb_handled);
-            if (!result.empty())
-                return result;
-        } else if (in_entry->addr.type == OFFLINE_TYPE_IFLUSH) {
-            const offline_entry_t *entry = impl()->get_next_entry(tls);
-            if (entry == nullptr || entry->addr.type != OFFLINE_TYPE_IFLUSH)
-                return "Flush missing 2nd entry";
-            impl()->log(2, "Flush " PFX "-" PFX "\n", (ptr_uint_t)in_entry->addr.addr,
-                        (ptr_uint_t)entry->addr.addr);
-            buf += trace_metadata_writer_t::write_iflush(
-                buf, in_entry->addr.addr,
-                (size_t)(entry->addr.addr - in_entry->addr.addr));
-        } else {
-            std::stringstream ss;
-            ss << "Unknown trace type " << (int)in_entry->timestamp.type;
-            return ss.str();
-        }
-        size_t size = reinterpret_cast<trace_entry_t *>(buf) - buf_base;
-        DR_CHECK((uint)size < WRITE_BUFFER_SIZE, "Too many entries");
-        if (size > 0) {
-            std::string error =
-                impl()->write(tls, buf_base, reinterpret_cast<trace_entry_t *>(buf));
-            if (!error.empty())
-                return error;
-        }
-        return "";
-    }
-
-    /**
-     * Read the header of a thread, by calling T's get_next_entry() successively to
-     * populate the header values. The timestamp field is populated only
-     * for legacy traces.
-     */
-    std::string
-    read_header(void *tls, OUT trace_header_t *header)
-    {
-        const offline_entry_t *in_entry = impl()->get_next_entry(tls);
-        if (in_entry == nullptr)
-            return "Failed to read header from input file";
-        // Handle legacy traces which have the timestamp first.
-        if (in_entry->tid.type == OFFLINE_TYPE_TIMESTAMP) {
-            header->timestamp = in_entry->timestamp.usec;
-            in_entry = impl()->get_next_entry(tls);
-            if (in_entry == nullptr)
-                return "Failed to read header from input file";
-        }
-        DR_ASSERT(in_entry->tid.type == OFFLINE_TYPE_THREAD);
-        header->tid = in_entry->tid.tid;
-
-        in_entry = impl()->get_next_entry(tls);
-        if (in_entry == nullptr)
-            return "Failed to read header from input file";
-        DR_ASSERT(in_entry->pid.type == OFFLINE_TYPE_PID);
-        header->pid = in_entry->pid.pid;
-
-        in_entry = impl()->get_next_entry(tls);
-        if (in_entry == nullptr)
-            return "Failed to read header from input file";
-        if (in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
-            in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER &&
-            in_entry->extended.valueB == TRACE_MARKER_TYPE_CACHE_LINE_SIZE) {
-            header->cache_line_size = in_entry->extended.valueA;
-        } else {
-            impl()->log(2,
-                        "Cache line size not found in raw trace header. Adding "
-                        "current processor's cache line size to final trace instead.\n");
-            header->cache_line_size = proc_get_cache_line_size();
-            impl()->unread_last_entry(tls);
-        }
-        return "";
-    }
-
-    /**
-     * The trace_entry_t buffer returned by get_write_buffer() is assumed to be at least
-     * #WRITE_BUFFER_SIZE large.
-     */
-    static const uint WRITE_BUFFER_SIZE = 64;
-
-    /**
-     * The pointer to the DR context.
-     */
-    void *const dcontext_;
-
-    /**
-     * Whether a non-nullptr dcontext was passed to the constructor.
-     */
-    bool passed_dcontext_ = false;
-
-    /* TODO i#2062: Remove this after replacing all uses in favor of queries to
-     * module_mapper_t to handle both generated and module code.
-     */
-    /**
-     * Get the module map.
-     */
-    const std::vector<module_t> &
-    modvec_() const
-    {
-        return *modvec_ptr_;
-    }
-
-    /* TODO i#2062: Remove this after replacing all uses in favor of queries to
-     * module_mapper_t to handle both generated and module code.
-     */
-    /**
-     * Set the module map. Must be called before process_offline_entry() is called.
-     */
-    void
-    set_modvec_(const std::vector<module_t> *modvec)
-    {
-        modvec_ptr_ = modvec;
-    }
-
-    /**
-     * Get the module mapper.
-     */
-    const module_mapper_t &
-    modmap_() const
-    {
-        return *modmap_ptr_;
-    }
-
-    /**
-     * Set the module mapper. Must be called before process_offline_entry() is called.
-     */
-    void
-    set_modmap_(const module_mapper_t *modmap)
-    {
-        modmap_ptr_ = modmap;
-    }
-
-    const module_mapper_t *modmap_ptr_ = nullptr;
-
-private:
-    T *
-    impl()
-    {
-        return static_cast<T *>(this);
-    }
-
-    std::string
-    analyze_elidable_addresses(void *tls, uint64 modidx, uint64 modoffs, app_pc start_pc,
-                               uint instr_count)
-    {
-        int version = impl()->get_version(tls);
-        // Old versions have no elision.
-        if (version <= OFFLINE_FILE_VERSION_NO_ELISION)
-            return "";
-        // Filtered and instruction-only traces have no elision.
-        if (TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS |
-                        OFFLINE_FILE_TYPE_INSTRUCTION_ONLY,
-                    impl()->get_file_type(tls)))
-            return "";
-        // We build an ilist to use identify_elidable_addresses() and fill in
-        // state needed to reconstruct elided addresses.
-        instrlist_t *ilist = instrlist_create(dcontext_);
-        app_pc pc = start_pc;
-        for (uint count = 0; count < instr_count; ++count) {
-            instr_t *inst = instr_create(dcontext_);
-            app_pc next_pc = decode(dcontext_, pc, inst);
-            DR_ASSERT(next_pc != NULL);
-            instr_set_translation(inst, pc);
-            instr_set_note(inst, reinterpret_cast<void *>(static_cast<ptr_int_t>(count)));
-            pc = next_pc;
-            instrlist_append(ilist, inst);
-        }
-
-        instru_offline_.identify_elidable_addresses(dcontext_, ilist, version);
-
-        for (instr_t *inst = instrlist_first(ilist); inst != nullptr;
-             inst = instr_get_next(inst)) {
-            int index, memop_index;
-            bool write, needs_base;
-            if (!instru_offline_.label_marks_elidable(inst, &index, &memop_index, &write,
-                                                      &needs_base))
-                continue;
-            // There could be multiple labels for one instr (e.g., "push (%rsp)".
-            instr_t *meminst = instr_get_next(inst);
-            while (meminst != nullptr && instr_is_label(meminst))
-                meminst = instr_get_next(meminst);
-            DR_ASSERT(meminst != nullptr);
-            pc = instr_get_app_pc(meminst);
-            int index_in_bb =
-                static_cast<int>(reinterpret_cast<ptr_int_t>(instr_get_note(meminst)));
-            app_pc orig_pc = modmap_().get_orig_pc_from_map_pc(pc, modidx, modoffs);
-            impl()->log(5, "Marking < " PFX ", " PFX "> %s #%d to use remembered base\n",
-                        start_pc, pc, write ? "write" : "read", memop_index);
-            if (!impl()->set_instr_summary_flags(
-                    tls, modidx, modoffs, start_pc, instr_count, index_in_bb, pc, orig_pc,
-                    write, memop_index, true /*use_remembered*/,
-                    false /*don't change "remember"*/))
-                return "Failed to set flags for elided base address";
-            // We still need to set the use_remember flag for rip-rel, even though it
-            // does not need a prior base, because we do not elide *all* rip-rels
-            // (e.g., predicated rip-rels).
-            if (!needs_base)
-                continue;
-            // Find the source of the base.  It has to be the first instance when
-            // walking backward.
-            opnd_t elided_op =
-                write ? instr_get_dst(meminst, index) : instr_get_src(meminst, index);
-            reg_id_t base;
-            bool got_base = instru_offline_.opnd_is_elidable(elided_op, base, version);
-            DR_ASSERT(got_base && base != DR_REG_NULL);
-            int remember_index = -1;
-            for (instr_t *prev = meminst; prev != nullptr; prev = instr_get_prev(prev)) {
-                if (!instr_is_app(prev))
-                    continue;
-                // Use instr_{reads,writes}_memory() to rule out LEA and NOP.
-                if (!instr_reads_memory(prev) && !instr_writes_memory(prev))
-                    continue;
-                bool remember_write = false;
-                int mem_count = 0;
-                if (prev != meminst || write) {
-                    for (int i = 0; i < instr_num_srcs(prev); i++) {
-                        reg_id_t prev_base;
-                        if (opnd_is_memory_reference(instr_get_src(prev, i))) {
-                            if (instru_offline_.opnd_is_elidable(instr_get_src(prev, i),
-                                                                 prev_base, version) &&
-                                prev_base == base) {
-                                remember_index = mem_count;
-                                break;
-                            }
-                            ++mem_count;
-                        }
-                    }
-                }
-                if (remember_index == -1 && prev != meminst) {
-                    mem_count = 0;
-                    for (int i = 0; i < instr_num_dsts(prev); i++) {
-                        reg_id_t prev_base;
-                        if (opnd_is_memory_reference(instr_get_dst(prev, i))) {
-                            if (instru_offline_.opnd_is_elidable(instr_get_dst(prev, i),
-                                                                 prev_base, version) &&
-                                prev_base == base) {
-                                remember_index = mem_count;
-                                remember_write = true;
-                                break;
-                            }
-                            ++mem_count;
-                        }
-                    }
-                }
-                if (remember_index == -1)
-                    continue;
-                app_pc pc_prev = instr_get_app_pc(prev);
-                app_pc orig_pc_prev =
-                    modmap_().get_orig_pc_from_map_pc(pc_prev, modidx, modoffs);
-                int index_prev =
-                    static_cast<int>(reinterpret_cast<ptr_int_t>(instr_get_note(prev)));
-                if (!impl()->set_instr_summary_flags(
-                        tls, modidx, modoffs, start_pc, instr_count, index_prev, pc_prev,
-                        orig_pc_prev, remember_write, remember_index,
-                        false /*don't change "use_remembered"*/, true /*remember*/))
-                    return "Failed to set flags for elided base address";
-                impl()->log(5, "Asking <" PFX ", " PFX "> %s #%d to remember base\n",
-                            start_pc, pc_prev, remember_write ? "write" : "read",
-                            remember_index);
-                break;
-            }
-            if (remember_index == -1)
-                return "Failed to find the source of the elided base";
-        }
-        instrlist_clear_and_destroy(dcontext_, ilist);
-        return "";
-    }
-
-    std::string
-    process_memref(void *tls, trace_entry_t **buf_in, const instr_summary_t *instr,
-                   instr_summary_t::memref_summary_t memref, bool write,
-                   std::unordered_map<reg_id_t, addr_t> &reg_vals, uint64_t cur_pc,
-                   uint64_t cur_offs, bool instrs_are_separate,
-                   OUT bool *reached_end_of_memrefs, OUT bool *interrupted)
-    {
-        std::string error = append_memref(tls, buf_in, instr, memref, write, reg_vals,
-                                          reached_end_of_memrefs);
-        if (!error.empty())
-            return error;
-        error = handle_kernel_interrupt_and_markers(tls, buf_in, cur_pc, cur_offs,
-                                                    instr->length(), instrs_are_separate,
-                                                    interrupted);
-        return error;
-    }
-
-    std::string
-    append_bb_entries(void *tls, const offline_entry_t *in_entry, OUT bool *handled)
-    {
-        std::string error = "";
-        uint instr_count = in_entry->pc.instr_count;
-        const instr_summary_t *instr = nullptr;
-        app_pc start_pc = modmap_().get_map_pc(in_entry->pc.modidx, in_entry->pc.modoffs);
-        app_pc pc, decode_pc = start_pc;
-        if (in_entry->pc.modidx == PC_MODIDX_INVALID) {
-            impl()->log(3, "Appending %u instrs in bb " PFX " in generated code\n",
-                        instr_count,
-                        reinterpret_cast<ptr_uint_t>(modmap_().get_orig_pc(
-                            in_entry->pc.modidx, in_entry->pc.modoffs)));
-        } else if ((in_entry->pc.modidx == 0 && in_entry->pc.modoffs == 0) ||
-                   modvec_()[in_entry->pc.modidx].map_seg_base == NULL) {
-            if (impl()->get_version(tls) >= OFFLINE_FILE_VERSION_ENCODINGS) {
-                // This is a fatal error if this trace should have encodings.
-                return "Non-module instructions found with no encoding information.";
-            }
-            //  This is a legacy trace without generated code support.
-            //  A race is fine for our visible ~one-time warning at level 0.
-            static volatile bool warned_once;
-            if (!warned_once) {
-                impl()->log(
-                    0, "WARNING: Skipping ifetch for unknown-encoding instructions\n");
-                warned_once = true;
-            }
-            impl()->log(
-                1, "Skipping ifetch for %u unknown-encoding instrs (idx %d, +" PIFX ")\n",
-                instr_count, in_entry->pc.modidx, in_entry->pc.modoffs);
-            // XXX i#2062: If we abandon this graceful skip (maybe once all legacy
-            // traces have expired), we can remove the bool return value and handle the
-            // memrefs in this function.
-            *handled = false;
-            return "";
-        } else {
-            impl()->log(3, "Appending %u instrs in bb " PFX " in mod %u +" PIFX " = %s\n",
-                        instr_count, (ptr_uint_t)start_pc, (uint)in_entry->pc.modidx,
-                        (ptr_uint_t)in_entry->pc.modoffs,
-                        modvec_()[in_entry->pc.modidx].path);
-        }
-        bool skip_icache = false;
-        // This indicates that each memref has its own PC entry and that each
-        // icache entry does not need to be considered a memref PC entry as well.
-        bool instrs_are_separate =
-            TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED,
-                    impl()->get_file_type(tls));
-        bool is_instr_only_trace =
-            TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, impl()->get_file_type(tls));
-        // Cast to unsigned pointer-sized int first to avoid sign-extending.
-        uint64_t cur_pc = static_cast<uint64_t>(reinterpret_cast<ptr_uint_t>(
-            modmap_().get_orig_pc(in_entry->pc.modidx, in_entry->pc.modoffs)));
-        // Legacy traces need the offset, not the pc.
-        uint64_t cur_offs = in_entry->pc.modoffs;
-        std::unordered_map<reg_id_t, addr_t> reg_vals;
-        if (instr_count == 0) {
-            // L0 filtering adds a PC entry with a count of 0 prior to each memref.
-            skip_icache = true;
-            instr_count = 1;
-            // We should have set a flag to avoid peeking forward on instr entries
-            // based on OFFLINE_FILE_TYPE_FILTERED and
-            // OFFLINE_FILE_TYPE_IFILTERED.
-            DR_ASSERT(instrs_are_separate);
-        } else {
-            if (!impl()->instr_summary_exists(tls, in_entry->pc.modidx,
-                                              in_entry->pc.modoffs, start_pc, 0,
-                                              decode_pc)) {
-                std::string res = analyze_elidable_addresses(tls, in_entry->pc.modidx,
-                                                             in_entry->pc.modoffs,
-                                                             start_pc, instr_count);
-                if (!res.empty())
-                    return res;
-            }
-        }
-        DR_CHECK(!instrs_are_separate || instr_count == 1,
-                 "cannot mix 0-count and >1-count");
-        for (uint i = 0; i < instr_count; ++i) {
-            trace_entry_t *buf_start = impl()->get_write_buffer(tls);
-            trace_entry_t *buf = buf_start;
-            app_pc saved_decode_pc = decode_pc;
-            app_pc orig_pc = modmap_().get_orig_pc_from_map_pc(
-                decode_pc, in_entry->pc.modidx, in_entry->pc.modoffs);
-            // To avoid repeatedly decoding the same instruction on every one of its
-            // dynamic executions, we cache the decoding in a hashtable.
-            pc = decode_pc;
-            impl()->log_instruction(4, decode_pc, orig_pc);
-            instr =
-                impl()->get_instr_summary(tls, in_entry->pc.modidx, in_entry->pc.modoffs,
-                                          start_pc, instr_count, i, &pc, orig_pc);
-            if (instr == nullptr) {
-                // We hit some error somewhere, and already reported it. Just exit the
-                // loop.
-                break;
-            }
-            DR_CHECK(pc > decode_pc, "error advancing inside block");
-            DR_CHECK(!instr->is_cti() || i == instr_count - 1, "invalid cti");
-            if (!instr->is_cti()) {
-                // Write out delayed branches now that we have a target.
-                error = impl()->append_delayed_branch(tls);
-                if (!error.empty())
-                    return error;
-            }
-            if (!skip_icache && impl()->record_encoding_emitted(tls, decode_pc)) {
-                error = impl()->append_encoding(tls, decode_pc, instr->length(), buf,
-                                                buf_start);
-                if (!error.empty())
-                    return error;
-            }
-            // TODO i#5934: This is a workaround for the trace invariant error triggered
-            // by consecutive duplicate system call instructions. Remove this when the
-            // error is fixed in the drmemtrace tracer.
-            if (instr->is_syscall() && impl()->get_last_pc_if_syscall(tls) == orig_pc &&
-                instr_count == 1) {
-                impl()->add_to_statistic(tls, RAW2TRACE_STAT_DUPLICATE_SYSCALL, 1);
-                impl()->log(
-                    3, "Found block with duplicate system call instruction. Skipping.");
-                // Since this instr is in its own block, we're done.
-                // Note that this will result in a pair of timestamp+cpu markers without
-                // anything before the next timestamp+cpu pair.
-                break;
-            }
-
-            // XXX i#1729: make bundles via lazy accum until hit memref/end, if
-            // we don't need encodings.
-            buf->type = instr->type();
-            if (buf->type == TRACE_TYPE_INSTR_MAYBE_FETCH) {
-                // We want it to look like the original rep string, with just one instr
-                // fetch for the whole loop, instead of the drutil-expanded loop.
-                // We fix up the maybe-fetch here so our offline file doesn't have to
-                // rely on our own reader.
-                if (!impl()->was_prev_instr_rep_string(tls)) {
-                    impl()->set_prev_instr_rep_string(tls, true);
-                    buf->type = TRACE_TYPE_INSTR;
-                } else {
-                    impl()->log(3, "Skipping instr fetch for " PFX "\n",
-                                (ptr_uint_t)decode_pc);
-                    // We still include the instr to make it easier for core simulators
-                    // (i#2051).
-                    buf->type = TRACE_TYPE_INSTR_NO_FETCH;
-                }
-            } else
-                impl()->set_prev_instr_rep_string(tls, false);
-            if (instr->is_syscall())
-                impl()->set_last_pc_if_syscall(tls, orig_pc);
-            else
-                impl()->set_last_pc_if_syscall(tls, 0);
-            buf->size = (ushort)(skip_icache ? 0 : instr->length());
-            buf->addr = (addr_t)orig_pc;
-            ++buf;
-            impl()->log(4, "Appended instr fetch for original %p\n", orig_pc);
-            decode_pc = pc;
-            // Check for a signal *after* the instruction.  The trace is recording
-            // instruction *fetches*, not instruction retirement, and we want to
-            // include a faulting instruction before its raised signal.
-            bool interrupted = false;
-            error = handle_kernel_interrupt_and_markers(
-                tls, &buf, cur_pc, cur_offs, instr->length(), instrs_are_separate,
-                &interrupted);
-            if (!error.empty())
-                return error;
-            if (interrupted) {
-                impl()->log(3, "Stopping bb at kernel interruption point %p\n", cur_pc);
-            }
-            // We need to interleave instrs with memrefs.
-            // There is no following memref for (instrs_are_separate && !skip_icache).
-            if (!interrupted && (!instrs_are_separate || skip_icache) &&
-                // Rule out OP_lea.
-                (instr->reads_memory() || instr->writes_memory()) &&
-                // No following memref for instruction-only trace type.
-                !is_instr_only_trace) {
-                if (instr->is_scatter_or_gather()) {
-                    // The instr should either load or store, but not both. Also,
-                    // it should have a single src or dest operand.
-                    DR_ASSERT(instr->num_mem_srcs() + instr->num_mem_dests() == 1);
-                    bool is_scatter = instr->num_mem_dests() == 1;
-                    bool reached_end_of_memrefs = false;
-                    // For expanded scatter/gather instrs, we do not have prior knowledge
-                    // of the number of store/load memrefs that will be present. So we
-                    // continue reading entries until we find a non-memref entry.
-                    // This works only because drx_expand_scatter_gather ensures that the
-                    // expansion has its own basic block, with no other app instr in it.
-                    while (!reached_end_of_memrefs) {
-                        // XXX: Add sanity check for max count of store/load memrefs
-                        // possible for a given scatter/gather instr.
-                        error = process_memref(
-                            tls, &buf, instr,
-                            // These memrefs were output by multiple store/load instrs in
-                            // the expanded scatter/gather sequence. In raw2trace we see
-                            // only the original app instr though. So we use the 0th
-                            // dest/src of the original scatter/gather instr for all.
-                            is_scatter ? instr->mem_dest_at(0) : instr->mem_src_at(0),
-                            is_scatter, reg_vals, cur_pc, cur_offs, instrs_are_separate,
-                            &reached_end_of_memrefs, &interrupted);
-                        if (!error.empty())
-                            return error;
-                        if (interrupted)
-                            break;
-                    }
-                } else {
-                    for (uint j = 0; j < instr->num_mem_srcs(); j++) {
-                        error = process_memref(
-                            tls, &buf, instr, instr->mem_src_at(j), false, reg_vals,
-                            cur_pc, cur_offs, instrs_are_separate, nullptr, &interrupted);
-                        if (!error.empty())
-                            return error;
-                        if (interrupted)
-                            break;
-                    }
-                    // We break before subsequent memrefs on an interrupt, though with
-                    // today's tracer that will never happen (i#3958).
-                    for (uint j = 0; !interrupted && j < instr->num_mem_dests(); j++) {
-                        error = process_memref(
-                            tls, &buf, instr, instr->mem_dest_at(j), true, reg_vals,
-                            cur_pc, cur_offs, instrs_are_separate, nullptr, &interrupted);
-                        if (!error.empty())
-                            return error;
-                        if (interrupted)
-                            break;
-                    }
-                }
-            }
-            cur_pc += instr->length();
-            cur_offs += instr->length();
-            DR_CHECK((size_t)(buf - buf_start) < WRITE_BUFFER_SIZE, "Too many entries");
-            if (instr->is_cti()) {
-                // In case this is the last branch prior to a thread switch, buffer it. We
-                // avoid swapping threads immediately after a branch so that analyzers can
-                // more easily find the branch target.  Doing this in the tracer would
-                // incur extra overhead, and in the reader would be more complex and messy
-                // than here (and we are ok bailing on doing this for online traces), so
-                // we handle it in post-processing by delaying a thread-block-final branch
-                // (and its memrefs) to that thread's next block.  This changes the
-                // timestamp of the branch, which we live with. To avoid marker
-                // misplacement (e.g. in the middle of a basic block), we also
-                // delay markers.
-                impl()->log(4, "Delaying %d entries for decode=" PIFX "\n",
-                            buf - buf_start, saved_decode_pc);
-                error =
-                    impl()->write_delayed_branches(tls, buf_start, buf, saved_decode_pc);
-                if (!error.empty())
-                    return error;
-            } else {
-                error = impl()->write(tls, buf_start, buf, { saved_decode_pc });
-                if (!error.empty())
-                    return error;
-            }
-            if (interrupted)
-                break;
-        }
-        *handled = true;
-        return "";
-    }
-
-    // Returns true if a kernel interrupt happened at cur_pc.
-    // Outputs a kernel interrupt if this is the right location.
-    // Outputs any other markers observed if !instrs_are_separate, since they
-    // are part of this block and need to be inserted now. Inserts all
-    // intra-block markers (i.e., the higher level process_offline_entry() will
-    // never insert a marker intra-block) and all inter-block markers are
-    // handled at a higher level (process_offline_entry()) and are never
-    // inserted here.
-    std::string
-    handle_kernel_interrupt_and_markers(void *tls, INOUT trace_entry_t **buf_in,
-                                        uint64_t cur_pc, uint64_t cur_offs,
-                                        int instr_length, bool instrs_are_separate,
-                                        OUT bool *interrupted)
-    {
-        // To avoid having to backtrack later, we read ahead to ensure we insert
-        // an interrupt at the right place between memrefs or between instructions.
-        *interrupted = false;
-        bool append = false;
-        trace_entry_t *buf_start = impl()->get_write_buffer(tls);
-        do {
-            const offline_entry_t *in_entry = impl()->get_next_entry(tls);
-            if (in_entry == nullptr)
-                return "";
-            append = false;
-            if (in_entry->extended.type != OFFLINE_TYPE_EXTENDED ||
-                in_entry->extended.ext != OFFLINE_EXT_TYPE_MARKER) {
-                // Not a marker: just put it back.
-                impl()->unread_last_entry(tls);
-                continue;
-            }
-            // The kernel markers can take two entries, so we have to read both
-            // if present to get to the type.  There is support for unreading
-            // both.
-            uintptr_t marker_val = 0;
-            std::string err = get_marker_value(tls, &in_entry, &marker_val);
-            if (!err.empty())
-                return err;
-            if (in_entry->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT) {
-                // A signal/exception marker in the next entry could be at any point
-                // among non-memref instrs, or it could be after this bb.
-                // We check the stored PC.
-                int version = impl()->get_version(tls);
-                bool at_interrupted_pc = false;
-                bool rseq_rollback = false;
-                if (version < OFFLINE_FILE_VERSION_KERNEL_INT_PC) {
-                    // We have only the offs, so we can't handle differing modules for
-                    // the source and target for legacy traces.
-                    if (marker_val == cur_offs)
-                        at_interrupted_pc = true;
-                } else {
-                    if (marker_val == cur_pc)
-                        at_interrupted_pc = true;
-                }
-                if (in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT ||
-                    (version < OFFLINE_FILE_VERSION_KERNEL_INT_PC && marker_val == 0)) {
-                    // For the older version, we will not get here for Windows
-                    // callbacks, the other event with a 0 modoffs, because they are
-                    // always between bbs.  (Unfortunately there's no simple way to
-                    // assert or check that here or in the tracer.)
-                    rseq_rollback = true;
-                }
-                impl()->log(4,
-                            "Checking whether reached signal/exception %p vs "
-                            "cur 0x" HEX64_FORMAT_STRING "\n",
-                            marker_val, cur_pc);
-                if (marker_val == 0 || at_interrupted_pc || rseq_rollback) {
-                    impl()->log(4, "Signal/exception interrupted the bb @ %p\n", cur_pc);
-                    append = true;
-                    *interrupted = true;
-                    if (rseq_rollback) {
-                        // This happens on rseq native aborts, where the trace instru
-                        // includes the rseq committing store before the native rseq
-                        // execution hits the native abort.  Pretend the native abort
-                        // happened *before* the committing store by walking the store
-                        // backward.  Everything in the buffer is for the store;
-                        // there should be no (other) intra-bb markers not for the store.
-                        impl()->log(4, "Rolling back %d entries for rseq abort\n",
-                                    *buf_in - buf_start);
-                        // If we recorded and emitted an encoding we would not emit
-                        // it next time and be missing the encoding so we must clear
-                        // the cache for that entry.  This will only happen once
-                        // for any new encoding (one synchronous signal/rseq abort
-                        // per instr) so we will satisfy the one-time limit of
-                        // rollback_last_encoding() (it has an assert to verify).
-                        for (trace_entry_t *entry = buf_start; entry < *buf_in; ++entry) {
-                            if (entry->type == TRACE_TYPE_ENCODING) {
-                                impl()->rollback_last_encoding(tls);
-                                break;
-                            }
-                        }
-                        *buf_in = buf_start;
-                    }
-                } else {
-                    // Put it back (below). We do not have a problem with other markers
-                    // following this, because we will have to hit the correct point
-                    // for this interrupt marker before we hit a memref entry, avoiding
-                    // the danger of wanting a memref entry, seeing a marker, continuing,
-                    // and hitting a fatal error when we find the memref back in the
-                    // not-inside-a-block main loop.
-                }
-            } else {
-                // Other than kernel event markers checked above, markers should be
-                // only at block boundaries, as we cannot figure out where they should go
-                // (and could easily insert them in the middle of this block instead
-                // of between this and the next block, with implicit instructions added).
-                // Thus, we do not append any other markers.
-            }
-            if (append) {
-                byte *buf = reinterpret_cast<byte *>(*buf_in);
-                buf += trace_metadata_writer_t::write_marker(
-                    buf, (trace_marker_type_t)in_entry->extended.valueB, marker_val);
-                *buf_in = reinterpret_cast<trace_entry_t *>(buf);
-                impl()->log(3, "Appended marker type %u value " PIFX "\n",
-                            (trace_marker_type_t)in_entry->extended.valueB, marker_val);
-                // There can be many markers in a row, esp for function tracing on
-                // longjmp or some other xfer that skips many post-call points.
-                // But, we can't easily write the buffer out, b/c we want to defer
-                // it for branches, and roll it back for rseq.
-                // XXX i#4159: We could switch to dynamic storage (and update all uses
-                // that assume no re-allocation), but this should be pathological so for
-                // now we have a release-build failure.
-                DR_CHECK((size_t)(*buf_in - buf_start) < WRITE_BUFFER_SIZE,
-                         "Too many entries");
-            } else {
-                // Put it back.
-                impl()->unread_last_entry(tls);
-            }
-        } while (append);
-        return "";
-    }
-
-    std::string
-    get_marker_value(void *tls, INOUT const offline_entry_t **entry, OUT uintptr_t *value)
-    {
-        uintptr_t marker_val = static_cast<uintptr_t>((*entry)->extended.valueA);
-        if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_SPLIT_VALUE) {
-#ifdef X64
-            // Keep the prior so we can unread both at once if we roll back.
-            const offline_entry_t *next = impl()->get_next_entry_keep_prior(tls);
-            if (next == nullptr || next->extended.ext != OFFLINE_EXT_TYPE_MARKER)
-                return "SPLIT_VALUE marker is not adjacent to 2nd entry";
-            marker_val =
-                (marker_val << 32) | static_cast<uintptr_t>(next->extended.valueA);
-            *entry = next;
-#else
-            return "TRACE_MARKER_TYPE_SPLIT_VALUE unexpected for 32-bit";
-#endif
-        }
-#ifdef X64 // 32-bit has the absolute pc as the raw marker value.
-        if ((*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-            (*entry)->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT ||
-            (*entry)->extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER) {
-            if (impl()->get_version(tls) >= OFFLINE_FILE_VERSION_KERNEL_INT_PC) {
-                // We convert the idx:offs to an absolute PC.
-                // TODO i#2062: For non-module code we don't have the block id and so
-                // cannot use this format.  We should probably just abandon this and
-                // always store the absolute PC.
-                kernel_interrupted_raw_pc_t raw_pc;
-                raw_pc.combined_value = marker_val;
-                DR_ASSERT(raw_pc.pc.modidx != PC_MODIDX_INVALID);
-                app_pc pc = modvec_()[raw_pc.pc.modidx].orig_seg_base +
-                    (raw_pc.pc.modoffs - modvec_()[raw_pc.pc.modidx].seg_offs);
-                impl()->log(3,
-                            "Kernel marker: converting 0x" ZHEX64_FORMAT_STRING
-                            " idx=" INT64_FORMAT_STRING " with base=%p to %p\n",
-                            marker_val, raw_pc.pc.modidx,
-                            modvec_()[raw_pc.pc.modidx].orig_seg_base, pc);
-                marker_val = reinterpret_cast<uintptr_t>(pc);
-            } // Else we've already marked as TRACE_ENTRY_VERSION_NO_KERNEL_PC.
-        }
-#endif
-        *value = marker_val;
-        return "";
-    }
-
-    std::string
-    append_memref(void *tls, INOUT trace_entry_t **buf_in, const instr_summary_t *instr,
-                  instr_summary_t::memref_summary_t memref, bool write,
-                  std::unordered_map<reg_id_t, addr_t> &reg_vals,
-                  OUT bool *reached_end_of_memrefs)
-    {
-        DR_ASSERT(
-            !TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, impl()->get_file_type(tls)));
-        trace_entry_t *buf = *buf_in;
-        const offline_entry_t *in_entry = nullptr;
-        bool have_addr = false;
-        bool have_type = false;
-        reg_id_t base;
-        int version = impl()->get_version(tls);
-        if (memref.use_remembered_base) {
-            DR_ASSERT(!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED |
-                                   OFFLINE_FILE_TYPE_DFILTERED,
-                               impl()->get_file_type(tls)));
-            bool is_elidable =
-                instru_offline_.opnd_is_elidable(memref.opnd, base, version);
-            DR_ASSERT(is_elidable);
-            if (base == DR_REG_NULL) {
-                DR_ASSERT(IF_REL_ADDRS(opnd_is_near_rel_addr(memref.opnd) ||)
-                              opnd_is_near_abs_addr(memref.opnd));
-                buf->addr = reinterpret_cast<addr_t>(opnd_get_addr(memref.opnd));
-                impl()->log(4, "Filling in elided rip-rel addr with %p\n", buf->addr);
-            } else {
-                buf->addr = reg_vals[base];
-                impl()->log(4, "Filling in elided addr with remembered %s: %p\n",
-                            get_register_name(base), buf->addr);
-            }
-            have_addr = true;
-            impl()->add_to_statistic(tls, RAW2TRACE_STAT_COUNT_ELIDED, 1);
-        }
-        if (!have_addr) {
-            if (memref.use_remembered_base)
-                return "Non-elided base mislabeled to use remembered base";
-            in_entry = impl()->get_next_entry(tls);
-        }
-        if (in_entry != nullptr && in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
-            in_entry->extended.ext == OFFLINE_EXT_TYPE_MEMINFO) {
-            // For -L0_filter we have to store the type for multi-memref instrs where
-            // we can't tell which memref it is (we'll still come here for the subsequent
-            // memref operands but we'll exit early in the check below).
-            have_type = true;
-            buf->type = in_entry->extended.valueB;
-            buf->size = in_entry->extended.valueA;
-            impl()->log(4, "Found type entry type %s (%d) size %d\n",
-                        trace_type_names[buf->type], buf->type, buf->size);
-            in_entry = impl()->get_next_entry(tls);
-            if (in_entry == nullptr)
-                return "Trace ends mid-block";
-        }
-        if (!have_addr &&
-            (in_entry == nullptr ||
-             (in_entry->addr.type != OFFLINE_TYPE_MEMREF &&
-              in_entry->addr.type != OFFLINE_TYPE_MEMREF_HIGH))) {
-            // This happens when there are predicated memrefs in the bb, or for a
-            // zero-iter rep string loop, or for a multi-memref instr with -L0_filter.
-            // For predicated memrefs, they could be earlier, so "instr"
-            // may not itself be predicated.
-            // XXX i#2015: if there are multiple predicated memrefs, our instr vs
-            // data stream may not be in the correct order here.
-            impl()->log(4,
-                        "Missing memref from predication, 0-iter repstr, filter, "
-                        "or reached end of memrefs output by scatter/gather seq "
-                        "(next type is 0x" ZHEX64_FORMAT_STRING ")\n",
-                        in_entry == nullptr ? 0 : in_entry->combined_value);
-            if (in_entry != nullptr) {
-                impl()->unread_last_entry(tls);
-            }
-            if (reached_end_of_memrefs != nullptr) {
-                *reached_end_of_memrefs = true;
-            }
-            return "";
-        }
-        if (!have_type) {
-            if (instr->is_prefetch()) {
-                buf->type = instr->prefetch_type();
-                buf->size = 1;
-            } else if (instr->is_flush()) {
-                buf->type = instr->flush_type();
-                // TODO i#4398: Handle flush sizes larger than ushort.
-                // TODO i#4406: Handle flush instrs with sizes other than cache line.
-                buf->size = (ushort)impl()->get_cache_line_size(tls);
-            } else {
-                if (write)
-                    buf->type = TRACE_TYPE_WRITE;
-                else
-                    buf->type = TRACE_TYPE_READ;
-                buf->size = (ushort)opnd_size_in_bytes(opnd_get_size(memref.opnd));
-            }
-        }
-        if (!have_addr) {
-            DR_ASSERT(in_entry != nullptr);
-            // We take the full value, to handle low or high.
-            buf->addr = (addr_t)in_entry->combined_value;
-        }
-        if (memref.remember_base &&
-            instru_offline_.opnd_is_elidable(memref.opnd, base, version)) {
-            impl()->log(5, "Remembering base " PFX " for %s\n", buf->addr,
-                        get_register_name(base));
-            reg_vals[base] = buf->addr;
-        }
-        if (!TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, impl()->get_file_type(tls)) &&
-            instru_offline_.opnd_disp_is_elidable(memref.opnd)) {
-            // We stored only the base reg, as an optimization.
-            buf->addr += opnd_get_disp(memref.opnd);
-        }
-        impl()->log(4, "Appended memref type %s (%d) size %d to " PFX "\n",
-                    trace_type_names[buf->type], buf->type, buf->size,
-                    (ptr_uint_t)buf->addr);
-
-#ifdef AARCH64
-        // TODO i#4400: Following is a workaround to correctly represent DC ZVA in
-        // offline traces. Note that this doesn't help with online traces.
-        // TODO i#3339: This workaround causes us to lose the address that was present
-        // in the original instruction. For re-encoding fidelity, we may want the
-        // original address in the IR.
-        if (instr->is_aarch64_dc_zva()) {
-            buf->addr = ALIGN_BACKWARD(buf->addr, impl()->get_cache_line_size(tls));
-            buf->size = impl()->get_cache_line_size(tls);
-            buf->type = TRACE_TYPE_WRITE;
-        }
-#endif
-        *buf_in = ++buf;
-        return "";
-    }
-
-    offline_instru_t instru_offline_;
-    const std::vector<module_t> *modvec_ptr_ = nullptr;
-
-#undef DR_CHECK
-};
 
 // We need to determine the memref_t record count for inserting a marker with
 // that count at the start of each chunk.
@@ -1800,13 +686,14 @@ private:
  * expected by analysis tools.  It requires access to the binary files for the
  * libraries and executable that were present during tracing.
  */
-class raw2trace_t : public trace_converter_t<raw2trace_t> {
+class raw2trace_t {
 public:
     // Only one of out_files and out_archives should be non-empty: archives support fast
     // seeking and are preferred but require zlib.
     // module_map, encoding_file, serial_schedule_file, cpu_schedule_file, thread_files,
     // and out_files are all owned and opened/closed by the caller.  module_map is not a
     // string and can contain binary data.
+    // If a nullptr dcontext is passed, creates a new DR context va dr_standalone_init().
     raw2trace_t(const char *module_map, const std::vector<std::istream *> &thread_files,
                 const std::vector<std::ostream *> &out_files,
                 const std::vector<archive_ostream_t *> &out_archives,
@@ -1816,6 +703,7 @@ public:
                 unsigned int verbosity = 0, int worker_count = -1,
                 const std::string &alt_module_dir = "",
                 uint64_t chunk_instr_count = 10 * 1000 * 1000);
+    // If a nullptr dcontext_in was passed to the constructor, calls dr_standalone_exit().
     virtual ~raw2trace_t();
 
     /**
@@ -1900,19 +788,11 @@ public:
     get_statistic(raw2trace_statistic_t stat);
 
 protected:
-    // Overridable parts of the interface expected by trace_converter_t.
-    virtual const offline_entry_t *
-    get_next_entry(void *tls);
-    virtual const offline_entry_t *
-    get_next_entry_keep_prior(void *tls);
-    virtual void
-    unread_last_entry(void *tls);
-    virtual std::string
-    on_thread_end(void *tls);
-    virtual void
-    log(uint level, const char *fmt, ...);
-    virtual void
-    log_instruction(uint level, app_pc decode_pc, app_pc orig_pc);
+    /**
+     * The trace_entry_t buffer returned by get_write_buffer() is assumed to be at least
+     * #WRITE_BUFFER_SIZE large.
+     */
+    static const uint WRITE_BUFFER_SIZE = 64;
 
     struct block_summary_t {
         block_summary_t(app_pc start, int instr_count)
@@ -1926,7 +806,6 @@ protected:
 
     // Per-traced-thread data is stored here and accessed without locks by having each
     // traced thread processed by only one processing thread.
-    // This is what trace_converter_t passes as void* to our routines.
     struct raw2trace_thread_data_t {
         raw2trace_thread_data_t()
             : index(0)
@@ -2003,13 +882,74 @@ protected:
         std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
     };
 
+    /**
+     * Convert starting from in_entry, and reading more entries as required.
+     * Sets end_of_record to true if processing hit the end of a record.
+     * read_and_map_modules() must have been called by the implementation before
+     * calling this API.
+     */
+    std::string
+    process_offline_entry(raw2trace_thread_data_t *tdata, const offline_entry_t *in_entry,
+                          thread_id_t tid, OUT bool *end_of_record,
+                          OUT bool *last_bb_handled);
+
+    /**
+     * Read the header of a thread, by calling get_next_entry() successively to
+     * populate the header values. The timestamp field is populated only
+     * for legacy traces.
+     */
+    std::string
+    read_header(raw2trace_thread_data_t *tdata, OUT trace_header_t *header);
+
+    /**
+     * Point to the next offline entry_t.  Will not attempt to dereference past the
+     * returned pointer.
+     */
+    virtual const offline_entry_t *
+    get_next_entry(raw2trace_thread_data_t *tdata);
+
+    /**
+     * Records the currently stored last entry in order to remember two entries at once
+     * (for handling split two-entry markers) and then reads and returns a pointer to the
+     * next entry.  A subsequent call to unread_last_entry() will put back both entries.
+     * Returns an emptry string on success or an error description on an error.
+     */
+    virtual const offline_entry_t *
+    get_next_entry_keep_prior(raw2trace_thread_data_t *tdata);
+
+    virtual void
+    unread_last_entry(raw2trace_thread_data_t *tdata);
+
+    /**
+     * Callback notifying the currently-processed thread has exited. Subclasses are
+     * expected to track record metadata themselves.  APIs for extracting that metadata
+     * are exposed.
+     */
+    virtual std::string
+    on_thread_end(raw2trace_thread_data_t *tdata);
+
+    /**
+     * The level parameter represents severity: the lower the level, the higher the
+     * severity.
+     */
+    virtual void
+    log(uint level, const char *fmt, ...);
+
+    /**
+     * Similar to log() but this disassembles the given PC.
+     */
+    virtual void
+    log_instruction(uint level, app_pc decode_pc, app_pc orig_pc);
+
     virtual std::string
     read_and_map_modules();
 
-    // Processes a raw buffer which must be the next buffer in the desired (typically
-    // timestamp-sorted) order for its traced thread.  For concurrent buffer processing,
-    // all buffers from any one traced thread must be processed by the same worker
-    // thread, both for correct ordering and correct synchronization.
+    /**
+     * Processes a raw buffer which must be the next buffer in the desired (typically
+     * timestamp-sorted) order for its traced thread.  For concurrent buffer processing,
+     * all buffers from any one traced thread must be processed by the same worker
+     * thread, both for correct ordering and correct synchronization.
+     */
     std::string
     process_next_thread_buffer(raw2trace_thread_data_t *tdata, OUT bool *end_of_record);
 
@@ -2017,10 +957,64 @@ protected:
     aggregate_and_write_schedule_files();
 
     std::string
-    write_footer(void *tls);
+    write_footer(raw2trace_thread_data_t *tdata);
 
     std::string
     open_new_chunk(raw2trace_thread_data_t *tdata);
+
+    /**
+     * The pointer to the DR context.
+     */
+    void *const dcontext_;
+
+    /**
+     * Whether a non-nullptr dcontext was passed to the constructor.
+     */
+    bool passed_dcontext_ = false;
+
+    /* TODO i#2062: Remove this after replacing all uses in favor of queries to
+     * module_mapper_t to handle both generated and module code.
+     */
+    /**
+     * Get the module map.
+     */
+    const std::vector<module_t> &
+    modvec_() const
+    {
+        return *modvec_ptr_;
+    }
+
+    /* TODO i#2062: Remove this after replacing all uses in favor of queries to
+     * module_mapper_t to handle both generated and module code.
+     */
+    /**
+     * Set the module map. Must be called before process_offline_entry() is called.
+     */
+    void
+    set_modvec_(const std::vector<module_t> *modvec)
+    {
+        modvec_ptr_ = modvec;
+    }
+
+    /**
+     * Get the module mapper.
+     */
+    const module_mapper_t &
+    modmap_() const
+    {
+        return *modmap_ptr_;
+    }
+
+    /**
+     * Set the module mapper. Must be called before process_offline_entry() is called.
+     */
+    void
+    set_modmap_(const module_mapper_t *modmap)
+    {
+        modmap_ptr_ = modmap;
+    }
+
+    const module_mapper_t *modmap_ptr_ = nullptr;
 
     uint64 count_elided_ = 0;
     uint64 count_duplicate_syscall_ = 0;
@@ -2030,8 +1024,6 @@ protected:
     std::vector<std::unique_ptr<raw2trace_thread_data_t>> thread_data_;
 
 private:
-    friend class trace_converter_t<raw2trace_t>;
-
     // We store this in drmodtrack_info_t.custom to combine our binary contents
     // data with any user-added module data from drmemtrace_custom_module_data.
     struct custom_module_data_t {
@@ -2040,73 +1032,130 @@ private:
         void *user_data;
     };
 
-    // Non-overridable parts of the interface expected by trace_converter_t.
+    // Return a writable buffer guaranteed to be at least #WRITE_BUFFER_SIZE large.
+    //  get_write_buffer() may reuse the same buffer after write() or
+    //  write_delayed_branches()
+    // is called.
     trace_entry_t *
-    get_write_buffer(void *tls);
-    std::string
-    write(void *tls, const trace_entry_t *start, const trace_entry_t *end,
-          std::vector<app_pc> decode_pcs = {});
-    std::string
-    write_delayed_branches(void *tls, const trace_entry_t *start,
-                           const trace_entry_t *end, app_pc decode_pc = nullptr);
-    std::string
-    append_encoding(void *tls, app_pc pc, size_t instr_length, trace_entry_t *&buf,
-                    trace_entry_t *buf_start);
-    std::string
-    insert_post_chunk_encodings(void *tls, const trace_entry_t *instr, app_pc decode_pc);
+    get_write_buffer(raw2trace_thread_data_t *tdata);
 
+    // Writes the converted traces between start and end, where end is past the last
+    // item to write. Both start and end are assumed to be pointers inside a buffer
+    // returned by get_write_buffer().  decode_pcs is only needed if there is more
+    // than one instruction in the buffer; in that case it must contain one entry per
+    // instruction.
+    std::string
+    write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
+          const trace_entry_t *end, std::vector<app_pc> decode_pcs = {});
+
+    // Similar to write(), but treat the provided traces as delayed branches: if they
+    // are the last values in a record, they belong to the next record of the same
+    // thread.  The start..end sequence must contain one instruction.
+    std::string
+    write_delayed_branches(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
+                           const trace_entry_t *end, app_pc decode_pc = nullptr);
+
+    // Writes encoding entries for pc..pc+instr_length to buf.
+    std::string
+    append_encoding(raw2trace_thread_data_t *tdata, app_pc pc, size_t instr_length,
+                    trace_entry_t *&buf, trace_entry_t *buf_start);
+
+    std::string
+    insert_post_chunk_encodings(raw2trace_thread_data_t *tdata,
+                                const trace_entry_t *instr, app_pc decode_pc);
+
+    // Returns true if there are currently delayed branches that have not been emitted
+    // yet.
     bool
-    delayed_branches_exist(void *tls);
+    delayed_branches_exist(raw2trace_thread_data_t *tdata);
+
+    // Returns false if an encoding was already emitted.
+    // Otherwise, remembers that an encoding is being emitted now, and returns true.
     bool
-    record_encoding_emitted(void *tls, app_pc pc);
+    record_encoding_emitted(raw2trace_thread_data_t *tdata, app_pc pc);
+
+    // Removes the record of the last encoding remembered in record_encoding_emitted().
     // This can only be called once between calls to record_encoding_emitted()
     // and only after record_encoding_emitted() returns true.
     void
-    rollback_last_encoding(void *tls);
+    rollback_last_encoding(raw2trace_thread_data_t *tdata);
+
+    // Returns whether an #instr_summary_t representation of the instruction at pc inside
+    // the block that begins at block_start_pc in the specified module exists.
     bool
-    instr_summary_exists(void *tls, uint64 modidx, uint64 modoffs, app_pc block_start,
-                         int index, app_pc pc);
+    instr_summary_exists(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                         app_pc block_start, int index, app_pc pc);
     block_summary_t *
-    lookup_block_summary(void *tls, uint64 modidx, uint64 modoffs, app_pc block_start);
+    lookup_block_summary(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                         app_pc block_start);
     instr_summary_t *
-    lookup_instr_summary(void *tls, uint64 modidx, uint64 modoffs, app_pc block_start,
-                         int index, app_pc pc, OUT block_summary_t **block_summary);
+    lookup_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                         app_pc block_start, int index, app_pc pc,
+                         OUT block_summary_t **block_summary);
     instr_summary_t *
-    create_instr_summary(void *tls, uint64 modidx, uint64 modoffs, block_summary_t *block,
-                         app_pc block_start, int instr_count, int index, INOUT app_pc *pc,
-                         app_pc orig);
+    create_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                         block_summary_t *block, app_pc block_start, int instr_count,
+                         int index, INOUT app_pc *pc, app_pc orig);
+
+    // Return the #instr_summary_t representation of the index-th instruction (at *pc)
+    // inside the block that begins at block_start_pc and contains instr_count
+    // instructions in the specified module.  Updates the value at pc to the PC of the
+    // next instruction. It is assumed the app binaries have already been loaded using
+    // #module_mapper_t, and the values at *pc point within memory mapped by the module
+    // mapper. This API provides an opportunity to cache decoded instructions.
     const instr_summary_t *
-    get_instr_summary(void *tls, uint64 modidx, uint64 modoffs, app_pc block_start,
-                      int instr_count, int index, INOUT app_pc *pc, app_pc orig);
+    get_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                      app_pc block_start, int instr_count, int index, INOUT app_pc *pc,
+                      app_pc orig);
+
+    // Sets two flags stored in the memref_summary_t inside the instr_summary_t for the
+    // index-th instruction (at pc) inside the block that begins at block_start_pc and
+    // contains instr_count instructions in the specified module.  The flags
+    // use_remembered_base and remember_base are set for the source (write==false) or
+    // destination (write==true) operand of index memop_index. The flags are OR-ed in:
+    // i.e., they are never cleared.
     bool
-    set_instr_summary_flags(void *tls, uint64 modidx, uint64 modoffs, app_pc block_start,
-                            int instr_count, int index, app_pc pc, app_pc orig,
-                            bool write, int memop_index, bool use_remembered_base,
-                            bool remember_base);
+    set_instr_summary_flags(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                            app_pc block_start, int instr_count, int index, app_pc pc,
+                            app_pc orig, bool write, int memop_index,
+                            bool use_remembered_base, bool remember_base);
     void
-    set_last_pc_if_syscall(void *tls, app_pc value);
+    set_last_pc_if_syscall(raw2trace_thread_data_t *tdata, app_pc value);
     app_pc
-    get_last_pc_if_syscall(void *tls);
+    get_last_pc_if_syscall(raw2trace_thread_data_t *tdata);
+
+    // Sets a per-traced-thread cached flag that is read by was_prev_instr_rep_string().
     void
-    set_prev_instr_rep_string(void *tls, bool value);
+    set_prev_instr_rep_string(raw2trace_thread_data_t *tdata, bool value);
+
+    // Queries a per-traced-thread cached flag that is set by set_prev_instr_rep_string().
     bool
-    was_prev_instr_rep_string(void *tls);
+    was_prev_instr_rep_string(raw2trace_thread_data_t *tdata);
+
+    // Returns the trace file version (an OFFLINE_FILE_VERSION* constant).
     int
-    get_version(void *tls);
+    get_version(raw2trace_thread_data_t *tdata);
+
+    // Returns the trace file type (a combination of OFFLINE_FILE_TYPE* constants).
     offline_file_type_t
-    get_file_type(void *tls);
+    get_file_type(raw2trace_thread_data_t *tdata);
+
     size_t
-    get_cache_line_size(void *tls);
+    get_cache_line_size(raw2trace_thread_data_t *tdata);
+
+    // Increases the per-thread counter for the statistic identified by stat by value.
     void
-    add_to_statistic(void *tls, raw2trace_statistic_t stat, int value);
+    add_to_statistic(raw2trace_thread_data_t *tdata, raw2trace_statistic_t stat,
+                     int value);
     void
     log_instruction(app_pc decode_pc, app_pc orig_pc);
 
+    // Flush the branches sent to write_delayed_branches().
     std::string
-    append_delayed_branch(void *tls);
+    append_delayed_branch(raw2trace_thread_data_t *tdata);
 
     bool
-    thread_file_at_eof(void *tls);
+    thread_file_at_eof(raw2trace_thread_data_t *tdata);
     std::string
     process_header(raw2trace_thread_data_t *tdata);
 
@@ -2118,6 +1167,45 @@ private:
 
     std::string
     emit_new_chunk_header(raw2trace_thread_data_t *tdata);
+
+    std::string
+    analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 modidx,
+                               uint64 modoffs, app_pc start_pc, uint instr_count);
+
+    std::string
+    process_memref(raw2trace_thread_data_t *tdata, trace_entry_t **buf_in,
+                   const instr_summary_t *instr, instr_summary_t::memref_summary_t memref,
+                   bool write, std::unordered_map<reg_id_t, addr_t> &reg_vals,
+                   uint64_t cur_pc, uint64_t cur_offs, bool instrs_are_separate,
+                   OUT bool *reached_end_of_memrefs, OUT bool *interrupted);
+
+    std::string
+    append_bb_entries(raw2trace_thread_data_t *tdata, const offline_entry_t *in_entry,
+                      OUT bool *handled);
+
+    // Returns true if a kernel interrupt happened at cur_pc.
+    // Outputs a kernel interrupt if this is the right location.
+    // Outputs any other markers observed if !instrs_are_separate, since they
+    // are part of this block and need to be inserted now. Inserts all
+    // intra-block markers (i.e., the higher level process_offline_entry() will
+    // never insert a marker intra-block) and all inter-block markers are
+    // handled at a higher level (process_offline_entry()) and are never
+    // inserted here.
+    std::string
+    handle_kernel_interrupt_and_markers(raw2trace_thread_data_t *tdata,
+                                        INOUT trace_entry_t **buf_in, uint64_t cur_pc,
+                                        uint64_t cur_offs, int instr_length,
+                                        bool instrs_are_separate, OUT bool *interrupted);
+
+    std::string
+    get_marker_value(raw2trace_thread_data_t *tdata, INOUT const offline_entry_t **entry,
+                     OUT uintptr_t *value);
+
+    std::string
+    append_memref(raw2trace_thread_data_t *tdata, INOUT trace_entry_t **buf_in,
+                  const instr_summary_t *instr, instr_summary_t::memref_summary_t memref,
+                  bool write, std::unordered_map<reg_id_t, addr_t> &reg_vals,
+                  OUT bool *reached_end_of_memrefs);
 
     int worker_count_;
     std::vector<std::vector<raw2trace_thread_data_t *>> worker_tasks_;
@@ -2216,7 +1304,7 @@ private:
                                  void *user_data) = nullptr;
     void *user_process_data_ = nullptr;
 
-    const char *modmap_;
+    const char *modmap_bytes_;
     file_t encoding_file_ = INVALID_FILE;
     std::ostream *serial_schedule_file_ = nullptr;
     archive_ostream_t *cpu_schedule_file_ = nullptr;
@@ -2231,6 +1319,9 @@ private:
 
     // Chunking for seeking support in compressed files.
     uint64_t chunk_instr_count_ = 0;
+
+    offline_instru_t instru_offline_;
+    const std::vector<module_t> *modvec_ptr_ = nullptr;
 };
 
 #endif /* _RAW2TRACE_H_ */


### PR DESCRIPTION
Removes the separate template class trace_converter_t and moves its contents into the raw2trace_t class.  We no longer need this separation, and in fact it is hindering our efforts to add new capabilities to raw2trace_t.

Fixes #4062