### PR TITLE
i#5954: Adjust rseq trace path to match real path

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -227,6 +227,8 @@ Further non-compatibility-affecting changes include:
    query key attributes of each input trace.
  - Added instr_create_1dst_6src() convenience function that returns an instr_t
    with one destination and six sources.
+ - Added a new label to help in handling "rseq" (Linux restartable sequence) regions:
+   #DR_NOTE_RSEQ_ENTRY.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -424,6 +424,13 @@ typedef enum {
      * warmup part of the trace ends.
      */
     TRACE_MARKER_TYPE_FILTER_ENDPOINT,
+
+    /**
+     * Indicates the start of an "rseq" (Linux restartable sequence) region.  The marker
+     * value holds the end PC of the region (this is the PC after the committing store).
+     */
+    TRACE_MARKER_TYPE_RSEQ_ENTRY,
+
     // ...
     // These values are reserved for future built-in marker types.
     // ...
@@ -482,6 +489,16 @@ type_has_address(const trace_type_t type)
 {
     return type_is_instr(type) || type == TRACE_TYPE_INSTR_NO_FETCH ||
         type == TRACE_TYPE_INSTR_MAYBE_FETCH || type_is_prefetch(type) ||
+        type == TRACE_TYPE_READ || type == TRACE_TYPE_WRITE ||
+        type == TRACE_TYPE_INSTR_FLUSH || type == TRACE_TYPE_INSTR_FLUSH_END ||
+        type == TRACE_TYPE_DATA_FLUSH || type == TRACE_TYPE_DATA_FLUSH_END;
+}
+
+/** Returns whether the type represents an operand of an instruction. */
+static inline bool
+type_is_data(const trace_type_t type)
+{
+    return type == TRACE_TYPE_INSTR_MAYBE_FETCH || type_is_prefetch(type) ||
         type == TRACE_TYPE_READ || type == TRACE_TYPE_WRITE ||
         type == TRACE_TYPE_INSTR_FLUSH || type == TRACE_TYPE_INSTR_FLUSH_END ||
         type == TRACE_TYPE_DATA_FLUSH || type == TRACE_TYPE_DATA_FLUSH_END;

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -425,6 +425,11 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_FILTER_ENDPOINT,
 
+    // We use one marker at the start whose data is the end, instead of a separate
+    // marker at the end PC, as this seems easier for users to process as they can plan
+    // ahead. Also, when the rseq aborted, if we had the marker at the committing store
+    // the user would then not know where it was supposed to be as it would not be
+    // present.
     /**
      * Indicates the start of an "rseq" (Linux restartable sequence) region.  The marker
      * value holds the end PC of the region (this is the PC after the committing store).
@@ -483,7 +488,10 @@ type_is_prefetch(const trace_type_t type)
         type == TRACE_TYPE_HARDWARE_PREFETCH;
 }
 
-/** Returns whether the type contains an address. */
+/**
+ * Returns whether the type contains an address.  This includes both instruction
+ * fetches and instruction operands.
+ */
 static inline bool
 type_has_address(const trace_type_t type)
 {
@@ -494,7 +502,11 @@ type_has_address(const trace_type_t type)
         type == TRACE_TYPE_DATA_FLUSH || type == TRACE_TYPE_DATA_FLUSH_END;
 }
 
-/** Returns whether the type represents an operand of an instruction. */
+/**
+ * Returns whether the type represents an address operand of an instruction.
+ * This is a subset of type_has_address() as type_has_address() includes
+ * instruction fetches.
+ */
 static inline bool
 type_is_data(const trace_type_t type)
 {

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -182,7 +182,7 @@ make_block(uint64_t offs, uint64_t instr_count)
 }
 
 offline_entry_t
-make_load(uint64_t addr)
+make_memref(uint64_t addr)
 {
     offline_entry_t entry;
     entry.addr.type = OFFLINE_TYPE_MEMREF;
@@ -235,14 +235,16 @@ make_marker(uint64_t type, int64_t value)
 
 bool
 check_entry(std::vector<trace_entry_t> &entries, int &idx, unsigned short expected_type,
-            int expected_size)
+            int expected_size, addr_t expected_addr = 0)
 {
     if (expected_type != entries[idx].type ||
         (expected_size > 0 &&
-         static_cast<unsigned short>(expected_size) != entries[idx].size)) {
+         static_cast<unsigned short>(expected_size) != entries[idx].size) ||
+        (expected_addr > 0 && expected_addr != entries[idx].addr)) {
         std::cerr << "Entry " << idx << " has type " << entries[idx].type << " and size "
-                  << entries[idx].size << " != expected type " << expected_type
-                  << " and expected size " << expected_size << "\n";
+                  << entries[idx].size << " and addr " << entries[idx].addr
+                  << " != expected type " << expected_type << " and expected size "
+                  << expected_size << " and expected addr " << expected_addr << "\n";
         return false;
     }
     ++idx;
@@ -400,8 +402,11 @@ test_marker_placement(void *drcontext)
         XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
 #ifdef AARCH64
     // XXX i#5628: opnd_create_mem_instr is not supported yet on AArch64.
-    instr_t *load1 = INSTR_CREATE_ldr(drcontext, opnd_create_reg(REG1),
-                                      OPND_CREATE_ABSMEM(move2, OPSZ_PTR));
+    instr_t *load1 =
+        INSTR_CREATE_ldr(drcontext, opnd_create_reg(REG1),
+                         // Our addresses are 0-based so we pick a low value that a
+                         // PC-relative offset can reach.
+                         OPND_CREATE_ABSMEM(reinterpret_cast<void *>(1024ULL), OPSZ_PTR));
 #else
     instr_t *load1 = XINST_CREATE_load(drcontext, opnd_create_reg(REG1),
                                        opnd_create_mem_instr(move1, 0, OPSZ_PTR));
@@ -895,6 +900,634 @@ test_duplicate_syscalls(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
 }
 
+bool
+test_rseq_fallthrough(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting rseq fallthrough\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    size_t offs_nop = 0;
+    size_t offs_move1 = offs_nop + instr_length(drcontext, nop);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    // The end of our rseq sequence, ending in a committing store.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    // No abort or side exit: we just fall through.
+    raw.push_back(make_block(offs_move2, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        // The move1 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        // The committing store.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+        check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
+        // The move2 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move2) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
+/* Tests rseq rollback without the new entry marker. */
+bool
+test_rseq_rollback_legacy(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting legacy rseq rollback\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    size_t offs_nop = 0;
+    size_t offs_move1 = offs_nop + instr_length(drcontext, nop);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    // The end of our rseq sequence, ending in a committing store.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ABORT, offs_store));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, offs_store));
+    raw.push_back(make_block(offs_move2, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        // The move1 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        // The committing store should not be here.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ABORT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_EVENT) &&
+        // The move2 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move2) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
+bool
+test_rseq_rollback(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting rseq rollback\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    size_t offs_nop = 0;
+    size_t offs_move1 = offs_nop + instr_length(drcontext, nop);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    // The end of our rseq sequence, ending in a committing store.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ABORT, offs_store));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, offs_store));
+    raw.push_back(make_block(offs_move2, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        // The move1 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        // The committing store should not be here.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ABORT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_EVENT) &&
+        // The move2 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move2) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
+/* Tests i#5954 where a timestamp preceds the abort marker. */
+bool
+test_rseq_rollback_with_timestamps(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting rseq rollback with timestamps\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    size_t offs_nop = 0;
+    size_t offs_move1 = offs_nop + instr_length(drcontext, nop);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    // The end of our rseq sequence, ending in a committing store.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ABORT, offs_store));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, offs_store));
+    raw.push_back(make_block(offs_move2, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        // The move1 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        // The committing store should not be here.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ABORT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_EVENT) &&
+        // The move2 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move2) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
+/* Tests rollback i#5954 where a chunk boundary splits an rseq region. */
+bool
+test_rseq_rollback_with_chunks(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting rseq rollback with chunks\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    size_t offs_nop = 0;
+    size_t offs_move1 = offs_nop + instr_length(drcontext, nop);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    // One completed rseq region to cache encodings.
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    raw.push_back(make_block(offs_move2, 1));
+    // A second one which should not need encodings.
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    raw.push_back(make_block(offs_move2, 1));
+    // Now a third split by a chunk boundary.
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ABORT, offs_store));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, offs_store));
+    raw.push_back(make_block(offs_move2, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    // 6 instrs puts a new chunk at the start of the 3rd region.
+    if (!run_raw2trace(drcontext, raw, ilist, entries, 6))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        // First sequence, with encodings.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+        check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move2) &&
+        // Second sequence, without encodings.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+        check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move2) &&
+        // Third aborted sequence in new chunk with encodings.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_FOOTER) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RECORD_ORDINAL) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ABORT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_EVENT) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move2) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
+/* Tests a typical rseq side exit (i#5953).
+ *
+ * XXX: We could test even more variants, like having multiple potential
+ * exits.
+ */
+bool
+test_rseq_side_exit(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting rseq side exit\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move3 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *jcc =
+        XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ, opnd_create_instr(move3));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, jcc);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    instrlist_append(ilist, move3);
+    size_t offs_nop = 0;
+    size_t offs_jcc = offs_nop + instr_length(drcontext, nop);
+    size_t offs_move1 = offs_jcc + instr_length(drcontext, jcc);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+    size_t offs_move3 = offs_move2 + instr_length(drcontext, move2);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    // Side exit is here; not taken in instrumented execution.
+    raw.push_back(make_block(offs_jcc, 1));
+    // The end of our rseq sequence, ending in a committing store.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    // A discontinuity as we continue with the side exit target.
+    raw.push_back(make_block(offs_move3, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        // The jcc instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+        // An extra encoding entry is needed.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+        check_entry(entries, idx, TRACE_TYPE_INSTR_CONDITIONAL_JUMP, -1, offs_jcc) &&
+        // The move2 + committing store should be gone.
+        // We should go straight to the move3 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move3) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
+/* Tests an rseq side exit with an arriving signal (i#5953). */
+bool
+test_rseq_side_exit_signal(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting rseq side exit with signal\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move3 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *jcc =
+        XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ, opnd_create_instr(move3));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, jcc);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    instrlist_append(ilist, move3);
+    size_t offs_nop = 0;
+    size_t offs_jcc = offs_nop + instr_length(drcontext, nop);
+    size_t offs_move1 = offs_jcc + instr_length(drcontext, jcc);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+    size_t offs_move3 = offs_move2 + instr_length(drcontext, move2);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    // Side exit is here; not taken in instrumented execution.
+    raw.push_back(make_block(offs_jcc, 1));
+    // The end of our rseq sequence, ending in a committing store.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    // A discontinuity as we continue with the side exit target.
+    // But, a signal arrived (whose interruption must be that target).
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, offs_move3));
+    raw.push_back(make_block(offs_move1, 1));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_XFER, offs_store));
+    raw.push_back(make_block(offs_move3, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        // The jcc instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+        // An extra encoding entry is needed.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+        check_entry(entries, idx, TRACE_TYPE_INSTR_CONDITIONAL_JUMP, -1, offs_jcc) &&
+        // The move2 + committing store should be gone.
+        // We should go straight to the signal and then the move3 instr.
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_EVENT) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_XFER) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move3) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
+/* Tests an inverted rseq side exit (i#5953). */
+bool
+test_rseq_side_exit_inverted(void *drcontext)
+{
+    std::cerr << "\n===============\nTesting inverted rseq side exit\n";
+    instrlist_t *ilist = instrlist_create(drcontext);
+    // raw2trace doesn't like offsets of 0 so we shift with a nop.
+    instr_t *nop = XINST_CREATE_nop(drcontext);
+    instr_t *move1 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instr_t *move3 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    // Our conditional jumps over the jump which is the exit.
+    instr_t *jcc =
+        XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ, opnd_create_instr(move1));
+    instr_t *jmp = XINST_CREATE_jump(drcontext, opnd_create_instr(move3));
+    instr_t *store =
+        XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0), opnd_create_reg(REG1));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG2), opnd_create_reg(REG1));
+    instrlist_append(ilist, nop);
+    instrlist_append(ilist, jcc);
+    instrlist_append(ilist, jmp);
+    instrlist_append(ilist, move1);
+    instrlist_append(ilist, store);
+    instrlist_append(ilist, move2);
+    instrlist_append(ilist, move3);
+    size_t offs_nop = 0;
+    size_t offs_jcc = offs_nop + instr_length(drcontext, nop);
+    size_t offs_jmp = offs_jcc + instr_length(drcontext, jcc);
+    size_t offs_move1 = offs_jmp + instr_length(drcontext, jmp);
+    size_t offs_store = offs_move1 + instr_length(drcontext, move1);
+    size_t offs_move2 = offs_store + instr_length(drcontext, store);
+    size_t offs_move3 = offs_move2 + instr_length(drcontext, move2);
+
+    std::vector<offline_entry_t> raw;
+    raw.push_back(make_header());
+    raw.push_back(make_tid());
+    raw.push_back(make_pid());
+    raw.push_back(make_line_size());
+    raw.push_back(make_timestamp());
+    raw.push_back(make_core());
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_RSEQ_ENTRY, offs_move2));
+    // The jcc is taken and we don't see the side exit in instrumented execution.
+    raw.push_back(make_block(offs_jcc, 1));
+    // The end of our rseq sequence, ending in a committing store.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
+    // A discontinuity as we continue with the side exit target.
+    raw.push_back(make_block(offs_move3, 1));
+    raw.push_back(make_exit());
+
+    std::vector<trace_entry_t> entries;
+    if (!run_raw2trace(drcontext, raw, ilist, entries))
+        return false;
+    int idx = 0;
+    return (
+        check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER,
+                    TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_RSEQ_ENTRY) &&
+        // The jcc instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+        // An extra encoding entry is needed.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+        check_entry(entries, idx, TRACE_TYPE_INSTR_CONDITIONAL_JUMP, -1, offs_jcc) &&
+        // The jmp which raw2trace has to synthesize.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+        // An extra encoding entry is needed.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+        check_entry(entries, idx, TRACE_TYPE_INSTR_DIRECT_JUMP, -1, offs_jmp) &&
+        // The move2 + committing store should be gone.
+        // We should go straight to the move3 instr.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move3) &&
+        check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_FOOTER, -1));
+}
+
 int
 main(int argc, const char *argv[])
 {
@@ -902,7 +1535,13 @@ main(int argc, const char *argv[])
     void *drcontext = dr_standalone_init();
     if (!test_branch_delays(drcontext) || !test_marker_placement(drcontext) ||
         !test_marker_delays(drcontext) || !test_chunk_boundaries(drcontext) ||
-        !test_chunk_encodings(drcontext) || !test_duplicate_syscalls(drcontext))
+        !test_chunk_encodings(drcontext) || !test_duplicate_syscalls(drcontext) ||
+        !test_rseq_fallthrough(drcontext) || !test_rseq_rollback_legacy(drcontext) ||
+        !test_rseq_rollback(drcontext) ||
+        !test_rseq_rollback_with_timestamps(drcontext) ||
+        !test_rseq_rollback_with_chunks(drcontext) || !test_rseq_side_exit(drcontext) ||
+        !test_rseq_side_exit_signal(drcontext) ||
+        !test_rseq_side_exit_inverted(drcontext))
         return 1;
     return 0;
 }

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -309,6 +309,10 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         case TRACE_MARKER_TYPE_RSEQ_ABORT:
             std::cerr << "<marker: rseq abort from 0x" << std::hex
                       << memref.marker.marker_value << std::dec << " to handler>\n";
+            break;
+        case TRACE_MARKER_TYPE_RSEQ_ENTRY:
+            std::cerr << "<marker: rseq entry with end at 0x" << std::hex
+                      << memref.marker.marker_value << std::dec << ">\n";
             break;
         case TRACE_MARKER_TYPE_KERNEL_XFER:
             if (trace_version_ <= TRACE_ENTRY_VERSION_NO_KERNEL_PC) {

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -250,6 +250,9 @@ public:
     instrument_instr_encoding(void *drcontext, void *tag, void *bb_field,
                               instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
                               int adjust, instr_t *app) = 0;
+    virtual int
+    instrument_rseq_entry(void *drcontext, instrlist_t *ilist, instr_t *where,
+                          instr_t *rseq_label, reg_id_t reg_ptr, int adjust) = 0;
 
     virtual void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
@@ -364,6 +367,9 @@ public:
     instrument_instr_encoding(void *drcontext, void *tag, void *bb_field,
                               instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
                               int adjust, instr_t *app) override;
+    int
+    instrument_rseq_entry(void *drcontext, instrlist_t *ilist, instr_t *where,
+                          instr_t *rseq_label, reg_id_t reg_ptr, int adjust) override;
 
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,
@@ -447,6 +453,9 @@ public:
     instrument_instr_encoding(void *drcontext, void *tag, void *bb_field,
                               instrlist_t *ilist, instr_t *where, reg_id_t reg_ptr,
                               int adjust, instr_t *app) override;
+    int
+    instrument_rseq_entry(void *drcontext, instrlist_t *ilist, instr_t *where,
+                          instr_t *rseq_label, reg_id_t reg_ptr, int adjust) override;
 
     void
     bb_analysis(void *drcontext, void *tag, void **bb_field, instrlist_t *ilist,

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -790,11 +790,14 @@ offline_instru_t::instrument_rseq_entry(void *drcontext, instrlist_t *ilist,
         drreg_reserve_register(drcontext, ilist, where, reg_vector_, &reg_tmp);
     DR_ASSERT(res == DRREG_SUCCESS); // Can't recover.
     // We may need 2 entries for our marker.  We write the entry
-    // marker with payload data[0]==rseq end.  We don't need data[1]==rseq handler
-    // in raw2trace so we do not bother to emit a marker for it.
+    // marker with payload data[0]==rseq end.
+    // TODO i#4041: We don't need data[1]==rseq handler in raw2trace now, but
+    // we will need it once we udpate i#4041, so at that point we'll need to
+    // emit a new marker here for that.
+    static constexpr int RSEQ_LABEL_END_PC_INDEX = 0;
     offline_entry_t entries[2];
-    int size =
-        append_marker((byte *)entries, TRACE_MARKER_TYPE_RSEQ_ENTRY, data->data[0]);
+    int size = append_marker((byte *)entries, TRACE_MARKER_TYPE_RSEQ_ENTRY,
+                             data->data[RSEQ_LABEL_END_PC_INDEX]);
     DR_ASSERT(size % sizeof(offline_entry_t) == 0);
     size /= sizeof(offline_entry_t);
     DR_ASSERT(size <= static_cast<int>(sizeof(entries)));

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -441,6 +441,16 @@ online_instru_t::instrument_instr_encoding(void *drcontext, void *tag, void *bb_
 }
 
 int
+online_instru_t::instrument_rseq_entry(void *drcontext, instrlist_t *ilist,
+                                       instr_t *where, instr_t *rseq_label,
+                                       reg_id_t reg_ptr, int adjust)
+{
+    // TODO i#5953: Design a way to roll back records already sent to the analyzer.
+    // For now we live with discontinuities with online mode.
+    return adjust;
+}
+
+int
 online_instru_t::instrument_ibundle(void *drcontext, instrlist_t *ilist, instr_t *where,
                                     reg_id_t reg_ptr, int adjust, instr_t **delay_instrs,
                                     int num_delay_instrs)

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2106,7 +2106,7 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
         dr_print_instr(dcontext, STDERR, instr, "");
     }
     DEBUG_ASSERT(*pc > desc->pc_);
-    desc->length_ = static_cast<unsigned short>(*pc - desc->pc_);
+    desc->length_ = static_cast<byte>(*pc - desc->pc_);
     DEBUG_ASSERT(*pc - desc->pc_ == instr_length(dcontext, instr));
 
     desc->packed_ = 0;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1272,7 +1272,8 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                         orig_pc);
                     tdata->rseq_commit_pc_ = reinterpret_cast<addr_t>(orig_pc);
                     tdata->rseq_past_end_ = true;
-                    tdata->rseq_commit_idx_ = tdata->rseq_buffer_.size();
+                    tdata->rseq_commit_idx_ =
+                        static_cast<int>(tdata->rseq_buffer_.size());
                 }
             }
         }
@@ -1497,7 +1498,7 @@ raw2trace_t::handle_kernel_interrupt_and_markers(
             if (marker_val == 0 || at_interrupted_pc || legacy_rseq_rollback) {
                 log(4, "Signal/exception interrupted the bb @ %p\n", cur_pc);
                 if (tdata->rseq_past_end_) {
-                    err = adjust_and_emit_rseq_buffer(tdata, cur_pc);
+                    err = adjust_and_emit_rseq_buffer(tdata, static_cast<addr_t>(cur_pc));
                     if (!err.empty())
                         return err;
                 }
@@ -1905,7 +1906,7 @@ raw2trace_t::adjust_and_emit_rseq_buffer(raw2trace_thread_data_t *tdata, addr_t 
             trace_entry_t jump;
             jump.type = TRACE_TYPE_INSTR_DIRECT_JUMP;
             jump.addr = reinterpret_cast<addr_t>(info.pc) + branch_size;
-            jump.size = enc_next - encoding;
+            jump.size = static_cast<unsigned short>(enc_next - encoding);
             trace_entry_t toadd[WRITE_BUFFER_SIZE];
             bool exists =
                 !record_encoding_emitted(tdata, reinterpret_cast<app_pc>(jump.addr));
@@ -2105,7 +2106,7 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
         dr_print_instr(dcontext, STDERR, instr, "");
     }
     DEBUG_ASSERT(*pc > desc->pc_);
-    desc->length_ = *pc - desc->pc_;
+    desc->length_ = static_cast<unsigned short>(*pc - desc->pc_);
     DEBUG_ASSERT(*pc - desc->pc_ == instr_length(dcontext, instr));
 
     desc->packed_ = 0;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1264,7 +1264,8 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                     log(4, "Remembering rseq branch %p -> %p\n", orig_pc,
                         instr->branch_target_pc());
                     tdata->rseq_branch_targets_.emplace_back(
-                        orig_pc, instr->branch_target_pc(), tdata->rseq_buffer_.size());
+                        orig_pc, instr->branch_target_pc(),
+                        static_cast<int>(tdata->rseq_buffer_.size()));
                 }
                 if (reinterpret_cast<addr_t>(orig_pc) + instr->length() ==
                     tdata->rseq_end_pc_) {
@@ -1898,6 +1899,8 @@ raw2trace_t::adjust_and_emit_rseq_buffer(raw2trace_thread_data_t *tdata, addr_t 
             // exit could be indirect; etc.  But this is the best we can readily do.
             instr_t *instr = XINST_CREATE_jump(
                 dcontext_, opnd_create_pc(reinterpret_cast<app_pc>(next_pc)));
+            log(1, "synthetic jump copy_pc=%p final_pc=%p\n", encoding,
+                info.pc + branch_size); // NOCHECK
             byte *enc_next =
                 instr_encode_to_copy(dcontext_, instr, encoding, info.pc + branch_size);
             instr_destroy(dcontext_, instr);
@@ -1926,7 +1929,8 @@ raw2trace_t::adjust_and_emit_rseq_buffer(raw2trace_thread_data_t *tdata, addr_t 
                 tdata->rseq_buffer_.push_back(*e);
             tdata->rseq_buffer_.push_back(jump);
             tdata->rseq_decode_pcs_.push_back(encoding);
-            log(4, "Appended synthetic jump 0x%zx -> 0x%zx\n", jump.addr, next_pc);
+            log(1 /*NOCHECK 4*/, "Appended synthetic jump 0x%zx -> 0x%zx\n", jump.addr,
+                next_pc);
         }
     }
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -98,7 +98,9 @@
 
 typedef enum {
     RAW2TRACE_STAT_COUNT_ELIDED,
-    RAW2TRACE_STAT_DUPLICATE_SYSCALL
+    RAW2TRACE_STAT_DUPLICATE_SYSCALL,
+    RAW2TRACE_STAT_RSEQ_ABORT,
+    RAW2TRACE_STAT_RSEQ_SIDE_EXIT,
 } raw2trace_statistic_t;
 
 struct module_t {
@@ -183,7 +185,7 @@ struct instr_summary_t final {
     app_pc
     next_pc() const
     {
-        return next_pc_;
+        return pc_ + length_;
     }
     /** Get the pc of the start of this instrucion. */
     app_pc
@@ -305,6 +307,12 @@ private:
     {
         return mem_srcs_and_dests_.size() - num_mem_srcs_;
     }
+    // Returns 0 for indirect branches or non-branches.
+    app_pc
+    branch_target_pc() const
+    {
+        return branch_target_pc_;
+    }
 
     static const int kReadsMemMask = 0x0001;
     static const int kWritesMemMask = 0x0002;
@@ -333,7 +341,7 @@ private:
     uint16_t prefetch_type_ = 0;
     uint16_t flush_type_ = 0;
     byte length_ = 0;
-    app_pc next_pc_ = 0;
+    app_pc branch_target_pc_ = 0;
 
     // Squash srcs and dests to save memory usage. We may want to
     // bulk-allocate pages of instr_summary_t objects, instead
@@ -617,7 +625,9 @@ public:
     test_module_mapper_t(instrlist_t *instrs, void *drcontext)
         : module_mapper_t(nullptr)
     {
-        byte *pc = instrlist_encode(drcontext, instrs, decode_buf_, true);
+        // We encode for 0-based addresses for simpler tests with low values.
+        byte *pc = instrlist_encode_to_copy(drcontext, instrs, decode_buf_, nullptr,
+                                            nullptr, true);
         DR_ASSERT(pc != nullptr);
         DR_ASSERT(pc - decode_buf_ < MAX_DECODE_SIZE);
         // Clear do_module_parsing error; we can't cleanly make virtual b/c it's
@@ -835,6 +845,24 @@ protected:
         std::vector<instr_summary_t> instrs;
     };
 
+    struct branch_info_t {
+        branch_info_t(app_pc pc, app_pc target, int idx)
+            : pc(pc)
+            , target_pc(target)
+            , buf_idx(idx)
+        {
+        }
+        branch_info_t()
+            : pc(0)
+            , target_pc(0)
+            , buf_idx(-1)
+        {
+        }
+        app_pc pc;
+        app_pc target_pc;
+        int buf_idx; // Index into rseq_buffer_.
+    };
+
     // Per-traced-thread data is stored here and accessed without locks by having each
     // traced thread processed by only one processing thread.
     struct raw2trace_thread_data_t {
@@ -897,6 +925,8 @@ protected:
         // Statistics on the processing.
         uint64 count_elided = 0;
         uint64 count_duplicate_syscall = 0;
+        uint64 count_rseq_abort = 0;
+        uint64 count_rseq_side_exit = 0;
 
         uint64 cur_chunk_instr_count = 0;
         uint64 cur_chunk_ref_count = 0;
@@ -911,6 +941,17 @@ protected:
 
         std::vector<schedule_entry_t> sched;
         std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
+
+        // State for rolling back rseq aborts and side exits.
+        bool rseq_ever_saw_entry_ = false;
+        bool rseq_buffering_enabled_ = false;
+        bool rseq_past_end_ = false;
+        addr_t rseq_commit_pc_ = 0;
+        addr_t rseq_end_pc_ = 0;
+        std::vector<trace_entry_t> rseq_buffer_;
+        int rseq_commit_idx_ = -1; // Index into rseq_buffer_.
+        std::vector<branch_info_t> rseq_branch_targets_;
+        std::vector<app_pc> rseq_decode_pcs_;
     };
 
     /**
@@ -1049,6 +1090,8 @@ protected:
 
     uint64 count_elided_ = 0;
     uint64 count_duplicate_syscall_ = 0;
+    uint64 count_rseq_abort_ = 0;
+    uint64 count_rseq_side_exit_ = 0;
 
     std::unique_ptr<module_mapper_t> module_mapper_;
 
@@ -1110,6 +1153,20 @@ private:
     // and only after record_encoding_emitted() returns true.
     void
     rollback_last_encoding(raw2trace_thread_data_t *tdata);
+
+    // Writes out the buffered entries for an rseq region, after rolling back to
+    // a side exit or abort if necessary.
+    std::string
+    adjust_and_emit_rseq_buffer(raw2trace_thread_data_t *tdata, addr_t next_pc);
+
+    // Removes entries from tdata->rseq_buffer_ between and including the instructions
+    // starting at or after remove_start_rough_idx and before or equal to
+    // remove_end_rough_idx.  These "rough" indices can be on the encoding or instr
+    // fetch to include that instruction.
+    std::string
+    rollback_rseq_buffer(raw2trace_thread_data_t *tdata, int remove_start_rough_idx,
+                         // This is inclusive.
+                         int remove_end_rough_idx);
 
     // Returns whether an #instr_summary_t representation of the instruction at pc inside
     // the block that begins at block_start_pc in the specified module exists.

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1056,7 +1056,9 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     }
 
     bool needs_instru = false;
-    if (instr_is_label(instr) && instr_get_note(instr) == (void *)DR_NOTE_RSEQ_ENTRY) {
+    bool instr_is_rseq_entry_label =
+        instr_is_label(instr) && instr_get_note(instr) == (void *)DR_NOTE_RSEQ_ENTRY;
+    if (instr_is_rseq_entry_label) {
         needs_instru = true;
     }
 
@@ -1187,7 +1189,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         ud->strex = NULL;
     }
 
-    if (instr_is_label(instr) && instr_get_note(instr) == (void *)DR_NOTE_RSEQ_ENTRY) {
+    if (instr_is_rseq_entry_label) {
         adjust =
             instru->instrument_rseq_entry(drcontext, bb, where, instr, reg_ptr, adjust);
     }

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -138,6 +138,12 @@
 #define FRAG_TEMP_PRIVATE 0x2000000
 
 #define FRAG_TRACE_OUTPUT 0x4000000
+/* Used only during block building, which means there is no conflict with
+ * FRAG_TRACE_OUTPUT.
+ */
+#ifdef LINUX
+#    define FRAG_STARTS_RSEQ_REGION 0x4000000
+#endif
 
 #define FRAG_CBR_FALLTHROUGH_SHORT 0x8000000
 

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -862,6 +862,13 @@ enum {
      */
     DR_NOTE_CALL_SEQUENCE_START,
     DR_NOTE_CALL_SEQUENCE_END,
+    /**
+     * Placed at the top of a basic block, this identifies the entry to an "rseq" (Linux
+     * restartable sequence) region.  The first two label data fields (see
+     * instr_get_label_data_area()) are filled in with this rseq region's end PC
+     * and its abort handler PC, in that order.
+     */
+    DR_NOTE_RSEQ_ENTRY,
 };
 
 /**

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -593,7 +593,7 @@ send_nudge_signal(process_id_t pid, uint action_mask, client_id_t client_id,
 bool
 at_dl_runtime_resolve_ret(dcontext_t *dcontext, app_pc source_fragment, int *ret_imm);
 
-/* rseq.c */
+/* rseq_linux.c */
 #ifdef LINUX
 extern vm_area_vector_t *d_r_rseq_areas;
 
@@ -628,6 +628,9 @@ rseq_shared_fragment_flushtime_update(dcontext_t *dcontext);
 
 void
 rseq_process_native_abort(dcontext_t *dcontext);
+
+void
+rseq_insert_start_label(dcontext_t *dcontext, app_pc tag, instrlist_t *ilist);
 
 #endif
 

--- a/core/unix/rseq_linux.h
+++ b/core/unix/rseq_linux.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2019-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2023 Google, Inc.  All rights reserved.
  * *******************************************************************************/
 
 /*
@@ -44,6 +44,8 @@
 #ifndef LINUX
 #    error Rseq is a Linux-only feature
 #endif
+
+/* Routines exported outside of unix/ are in os_exports.h. */
 
 void
 d_r_rseq_init(void);

--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -8273,6 +8273,8 @@ check_thread_vm_area(dcontext_t *dcontext, app_pc pc, app_pc tag, void **vmlist,
                                      NULL)) {
                 if (rseq_start > tag)
                     entered_rseq = true;
+                else if (tag == rseq_start)
+                    *flags |= FRAG_STARTS_RSEQ_REGION;
             } else {
                 app_pc prev_end;
                 if (vmvector_lookup_prev_next(d_r_rseq_areas, pc, NULL, &prev_end,


### PR DESCRIPTION
With our run-twice rseq solution, we first run an instrumented path through the rseq region which goes into the recorded drmemtrace trace. But the native rseq execution might take a side exit or abort.  We already had code to try to roll back the committing store on an abort, but it was fragile as a timestamp in between thwarted it.  We had no code to make a side exit match and as a result we'd see PC discontinuities.

Here, we solve both problems with the following approach:

First, we have DR add a new DR_NOTE_RSEQ_ENTRY label to the top of the first block in an rseq region.  This label's data stores the end PC and the abort handler PC (we do not currently use the latter in drmemtrace: once we revert #4041 we may need to do so).

Next, the tracer turns that label into a new
TRACE_MARKER_TYPE_RSEQ_ENTRY marker with the end PC as the marker value.

Finally, rawtrace uses the new label to fix up the trace.  When it sees the entry marker, it starts buffering instead of writing out records.  While buffering, it remembers the decode PC of each insruction (for encoding entries), plus the PC + target of each branch.  When it sees the rseq end PC, it sets a flag, and on the next instruction it has the rseq exit PC.  If it sees an rseq abort marker or a signal marker with the flag set, it uses the interrupted PC as the rseq exit PC (this avoids having to wait for the other side of the signal handler).

With this rseq exit PC, raw2trace takes the following actions depending on the PC value:
+ End PC fall-through: completed; emit entire buffer.
+ Committing store PC: roll back final instr in buffer. (Once #4041 reverts this to the handler PC we'll use the handler PC here and will add a new marker to hold that data.)
+ Target of a branch in the buffer: roll back to that branch. If multiple: take most recent.
+ None of the above: there cannot be an indirect branch we observed so we assume this is an inverted cbr.  If there is a forward direct cbr which was taken and stayed in the region, we synthesize a direct jump in the gap it jumped over.  This is not perfect but is the best we can readily do.

We leave the old rollback method (which didn't handle a timestamp in between) in place but it is only enabled if we see an rseq abort marker without the new rseq entry marker first.  We decided to not bump the trace version nor add a new filetype to indicate the presence of rseq entry markers as we can support legacy traces this way (at least as well as they were supported before).

We give up on identifying which of multiple indirect rseq side exits were taken. We give up on distinguishing a side exit whose target is the end PC fall-through from a completion.

For emitting the accumulated rseq buffer, the delayed branch code added for #5941 will handle chunk boundaries.

A side improvements along the way: we add a branch target pc to instr_summary_t and avoided increasing its space by removing the previously-stored next_pc and computing it from the length.

Adds a number of unit tests for rseq rollback and side exits, along with a more-real instance in the linux.rseq test.  This was also tested on a large proprietary application with multiple real instances of rseq aborts and side exits.

Issue: #5953, #5953, #4041
Fixes #5953
Fixes #5954