### PR TITLE
i#5953 rseq: Fix rseq adjust issues with filtering

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -156,10 +156,12 @@ changes:
    AArch64 instruction and "reta" entries in the AArch64 codec were being used to
    decode "retaa" and "retab". These instructions will now encode and decode correctly
    as "retaa" and "retab".
- - Changed the interrupted PC for #DR_XFER_RSEQ_ABORT and a signal generated during
-   an rseq region to be the abort handler rather than the committing store,
-   matching the kernel behavior.
  - Added a #DR_XFER_RSEQ_ABORT event for a signal generated during an rseq region.
+ - Changed the interrupted PC for #DR_XFER_RSEQ_ABORT for native execution aborts to be
+   the abort handler (a signal during the instrumented execution will continue to have
+   the actual interrupted PC); changed the interrupted PC for #DR_XFER_SIGNAL_DELIVERY
+   for a signal generated during an rseq region to be the abort handler, matching the
+   kernel behavior.
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -348,7 +348,9 @@ typedef enum {
     /**
      * Serves to further identify #TRACE_MARKER_TYPE_KERNEL_EVENT as a
      * restartable sequence abort handler.  This will always be immediately followed
-     * by #TRACE_MARKER_TYPE_KERNEL_EVENT.  The marker value holds the continuation
+     * by #TRACE_MARKER_TYPE_KERNEL_EVENT.  The marker value for a signal that
+     * interrupted the instrumented execution is the precise interrupted PC, but
+     * for all other cases the value holds the continuation
      * program counter, which is the restartable sequence abort handler.  (The precise
      * interrupted point inside the sequence is not provided by the kernel.)
      */

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -349,11 +349,27 @@ check_rseq()
     // Roll back rseq final instr.
     {
         std::vector<memref_t> memrefs = {
+            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
+            gen_instr(1, 1),
+            // Rolled back instr at pc=2 size=1.
+            // Point to the abort handler.
+            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ABORT, 4),
+            gen_marker(1, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_instr(1, 4),
+        };
+        if (!run_checker(memrefs, false))
+            return false;
+    }
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
             gen_instr(1, 1),
             gen_instr(1, 2),
-            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ABORT, 1),
-            gen_marker(1, TRACE_MARKER_TYPE_KERNEL_EVENT, 1),
-            gen_instr(1, 1),
+            // A fault in the instrumented execution.
+            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ABORT, 2),
+            gen_marker(1, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_marker(1, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_instr(1, 4),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -361,13 +377,14 @@ check_rseq()
     // Fail to roll back rseq final instr.
     {
         std::vector<memref_t> memrefs = {
+            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
             gen_instr(1, 1),
             gen_instr(1, 2),
-            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ABORT, 2),
-            gen_marker(1, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(1, 1),
+            gen_marker(1, TRACE_MARKER_TYPE_RSEQ_ABORT, 4),
+            gen_marker(1, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_instr(1, 4),
         };
-        if (!run_checker(memrefs, true, 1, 3,
+        if (!run_checker(memrefs, true, 1, 4,
                          "Rseq post-abort instruction not rolled back",
                          "Failed to catch bad rseq abort"))
             return false;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -409,7 +409,10 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                     memref.instr.addr == shard->app_handler_pc_ ||
                     // Marker for rseq abort handler.  Not as unique as a prefetch, but
                     // we need an instruction and not a data type.
-                    memref.instr.type == TRACE_TYPE_INSTR_DIRECT_JUMP,
+                    memref.instr.type == TRACE_TYPE_INSTR_DIRECT_JUMP ||
+                    // Instruction-filtered can easily skip the return point.
+                    TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED,
+                            shard->file_type_),
                 "Signal handler return point incorrect");
             // We assume paired signal entry-exit (so no longjmp and no rseq
             // inside signal handlers).

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -123,6 +123,7 @@ protected:
         // We could move this to per-worker data and still not need a lock
         // (we don't currently have per-worker data though so leaving it as per-shard).
         std::unordered_map<addr_t, addr_t> branch_target_cache;
+        addr_t rseq_end_pc_ = 0;
     };
 
     // We provide this for subclasses to run these invariants with custom

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -307,8 +307,8 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             }
             break;
         case TRACE_MARKER_TYPE_RSEQ_ABORT:
-            std::cerr << "<marker: rseq abort xfer to handler 0x" << std::hex
-                      << memref.marker.marker_value << std::dec << "\n";
+            std::cerr << "<marker: rseq abort from 0x" << std::hex
+                      << memref.marker.marker_value << std::dec << " to handler>\n";
             break;
         case TRACE_MARKER_TYPE_RSEQ_ENTRY:
             std::cerr << "<marker: rseq entry with end at 0x" << std::hex

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -943,6 +943,7 @@ protected:
         std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
 
         // State for rolling back rseq aborts and side exits.
+        bool rseq_want_rollback_ = false;
         bool rseq_ever_saw_entry_ = false;
         bool rseq_buffering_enabled_ = false;
         bool rseq_past_end_ = false;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1158,7 +1158,7 @@ private:
     // a side exit or abort if necessary.
     std::string
     adjust_and_emit_rseq_buffer(raw2trace_thread_data_t *tdata, addr_t next_pc,
-                                addr_t abort_handler_pc = 0);
+                                addr_t abort_pc = 0);
 
     // Removes entries from tdata->rseq_buffer_ between and including the instructions
     // starting at or after remove_start_rough_idx and before or equal to

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1058,7 +1058,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     bool need_rseq_instru = instr_is_label(instr) &&
         instr_get_note(instr) == (void *)DR_NOTE_RSEQ_ENTRY &&
         // For filtered instructions we can't adjust rseq regions as we do not have
-        // the fill instrution sequence so we reduce overhead by not outputting the
+        // the fill instruction sequence so we reduce overhead by not outputting the
         // entry markers.
         !op_L0I_filter.get_value();
 

--- a/core/globals.h
+++ b/core/globals.h
@@ -391,8 +391,8 @@ typedef struct _client_data_t {
     bool is_translating;
 #endif
 #ifdef LINUX
-    /* i#4041: Pass rseq events in addition to signal events. */
-    bool last_xl8_in_rseq;
+    /* i#4041: Pass the real translation for signals in rseq sequences. */
+    app_pc last_special_xl8;
 #endif
 
     /* flags for asserts on linux and for getting param base right on windows */

--- a/core/lib/dr_events.h
+++ b/core/lib/dr_events.h
@@ -998,7 +998,9 @@ typedef enum {
     DR_XFER_SET_CONTEXT_THREAD, /**< NtSetContextThread system call. */
     DR_XFER_CLIENT_REDIRECT,    /**< dr_redirect_execution() or #DR_SIGNAL_REDIRECT. */
     /**
-     * A Linux restartable sequence was aborted.  The interrupted PC always points
+     * A Linux restartable sequence was aborted.  The interrupted PC for a signal in
+     * the execution instrumentation points to the precise interrupted
+     * instruction; but for an abort in the native exeuction, the PC always points
      * to the abort handler, rather than the precise instruction that was aborted.
      * This aligns with kernel behavior: the interrupted PC is not saved anywhere.
      */

--- a/core/translate.h
+++ b/core/translate.h
@@ -113,7 +113,10 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
 bool
 at_syscall_translation(dcontext_t *dcontext, app_pc pc);
 
-bool
-translate_last_in_rseq(dcontext_t *dcontext);
+/* Returns the direct translation when given the "official" translation.
+ * Some special cases like rseq sequences obfuscate the interrupted PC: i#4041.
+ */
+app_pc
+translate_last_direct_translation(dcontext_t *dcontext, app_pc pc);
 
 #endif /* _TRANSLATE_H_ */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4010,11 +4010,18 @@ transfer_from_sig_handler_to_fcache_return(dcontext_t *dcontext, kernel_ucontext
         sig_full_cxt_t sc_full;
         sig_full_initialize(&sc_full, uc);
         sc->SC_XIP = (ptr_uint_t)next_pc;
-        if (translate_last_in_rseq(dcontext)) {
+        /* i#4041: Provide the actually-interrupted mid-rseq PC to the rseq event. */
+        ptr_uint_t official_xl8 = sc_interrupted->SC_XIP;
+        ptr_uint_t rseq_xl8 =
+            (ptr_uint_t)translate_last_direct_translation(dcontext, (app_pc)official_xl8);
+        if (rseq_xl8 != official_xl8) {
+            sc_interrupted->SC_XIP = rseq_xl8;
             if (instrument_kernel_xfer(dcontext, DR_XFER_RSEQ_ABORT, sc_interrupted_full,
                                        NULL, NULL, next_pc, sc->SC_XSP, sc_full, NULL,
                                        sig))
                 next_pc = (app_pc)sc->SC_XIP;
+            /* The signal event has the abort handler, like the kernel passes. */
+            sc_interrupted->SC_XIP = official_xl8;
         }
         if (instrument_kernel_xfer(dcontext, DR_XFER_SIGNAL_DELIVERY, sc_interrupted_full,
                                    NULL, NULL, next_pc, sc->SC_XSP, sc_full, NULL, sig))
@@ -6411,9 +6418,16 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
         info->sighand->action[sig]->handler = (handler_t)SIG_DFL;
     }
     sig_full_cxt_t sc_full = { sc, NULL /*not provided*/ };
-    if (translate_last_in_rseq(dcontext)) {
+    /* i#4041: Provide the actually-interrupted mid-rseq PC to the rseq event. */
+    ptr_uint_t official_xl8 = sc->SC_XIP;
+    ptr_uint_t rseq_xl8 =
+        (ptr_uint_t)translate_last_direct_translation(dcontext, (app_pc)official_xl8);
+    if (rseq_xl8 != official_xl8) {
+        sc->SC_XIP = rseq_xl8;
         instrument_kernel_xfer(dcontext, DR_XFER_RSEQ_ABORT, sc_full, NULL, NULL,
                                mcontext->pc, mcontext->xsp, osc_empty, mcontext, sig);
+        /* The signal event has the abort handler, like the kernel passes. */
+        sc->SC_XIP = official_xl8;
     }
     instrument_kernel_xfer(dcontext, DR_XFER_SIGNAL_DELIVERY, sc_full, NULL, NULL,
                            mcontext->pc, mcontext->xsp, osc_empty, mcontext, sig);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3940,6 +3940,15 @@ if (BUILD_CLIENTS)
         # drbbdup + rseq combo (i#5658, i#5659).
         "-trace_after_instrs 5K"
         "@${test_mode_flag}@-test_mode_name@rseq_app" "")
+      # Test filtering.
+      torunonly_drcacheoff(rseq-filter linux.rseq
+        "-trace_after_instrs 5K -L0_filter"
+        "@${test_mode_flag}@-test_mode_name@rseq_app" "")
+      set(tool.drcacheoff.rseq-filter_expectbase "offline-rseq")
+      torunonly_drcacheoff(rseq-dfilter linux.rseq
+        "-trace_after_instrs 5K -L0D_filter"
+        "@${test_mode_flag}@-test_mode_name@rseq_app" "")
+      set(tool.drcacheoff.rseq-dfilter_expectbase "offline-rseq")
     endif ()
 
     if (AARCH64)


### PR DESCRIPTION
Fixes problems with the new rseq adjustment code with filtered traces:
+ Load and update the buffer pointer when emitting the rseq entry label
+ Do not try to adjust for i-filtered

Adds 2 new tests for filtering the linux.rseq app.

The new tests revealed a problem with the instr counts in the schedule file:
raw2trace was counting the PC-only entries as instructions; we fix that here.

Reverts the rseq abort event and marker value back to the interrupted
PC for a signal in the instrumented execution.  Leaves all other cases
(all aborts in the native execution) as the handler.  This lets us
properly place the abort+signal for the instrumented interruption
case.
    
Adjusts the invariant checker abort check to use the new end PC for a
more accurate test to avoid false positives and negatives.

Fixes #5953, #4041
