### PR TITLE
i#3044 AArch64 SVE codec: Add TRN1/2 Q-sized opcodes

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -181,6 +181,7 @@ proc_init_arch(void)
             cpu_info.features.flags_aa64zfr0);
         LOG_FEATURE(FEATURE_BF16);
         LOG_FEATURE(FEATURE_I8MM);
+        LOG_FEATURE(FEATURE_F64MM);
     });
 #    endif
 #endif
@@ -218,6 +219,7 @@ proc_has_feature(feature_bit_t f)
     case FEATURE_LRCPC2:
     case FEATURE_BF16:
     case FEATURE_I8MM:
+    case FEATURE_F64MM:
     case FEATURE_FlagM:
     case FEATURE_JSCVT:
     case FEATURE_DPB:

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -355,6 +355,7 @@ typedef enum {
     FEATURE_LRCPC2 = DEF_FEAT(AA64ISAR1, 5, 2, 0), /**< LDAPUR*, STLUR* (AArch64) */
     FEATURE_BF16 = DEF_FEAT(AA64ZFR0, 5, 1, 0),    /**< SVE BFloat16 */
     FEATURE_I8MM = DEF_FEAT(AA64ZFR0, 11, 1, 0),   /**< SVE Int8 matrix multiplication */
+    FEATURE_F64MM = DEF_FEAT(AA64ZFR0, 14, 1, 0),  /**< SVE FP64 matrix multiplication */
 } feature_bit_t;
 #endif
 #ifdef RISCV64

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -737,8 +737,10 @@
 00000101xx1xxxxx001100xxxxxxxxxx  n   490  SVE      tbl  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000101xx10xxxx0101000xxxx0xxxx  n   494  SVE     trn1  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011100xxxxxxxxxx  n   494  SVE     trn1  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+00000101101xxxxx000110xxxxxxxxxx  n   494  F64MM   trn1          z_q_0 : z_q_5 z_q_16
 00000101xx10xxxx0101010xxxx0xxxx  n   495  SVE     trn2  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011101xxxxxxxxxx  n   495  SVE     trn2  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+00000101101xxxxx000111xxxxxxxxxx  n   495  F64MM   trn2          z_q_0 : z_q_5 z_q_16
 00000100xx001101000xxxxxxxxxxxxx  n   499  SVE     uabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx000001001xxxxxxxxxxxxx  n   921  SVE    uaddv             d0 : p10_lo z_size_bhsd_5
 0110010101010011101xxxxxxxxxxxxx  n   510  SVE    ucvtf          z_h_0 : p10_mrg_lo z_h_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -14069,4 +14069,33 @@
                            opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
                                                          0, false, 0, 0, OPSZ_sys))
 
+/**
+ * Creates a TRN1 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_trn1_sve(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_trn1, Zd, Zn, Zm)
+
+/**
+ * Creates a TRN2 instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_trn2_sve(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_trn2, Zd, Zn, Zm)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -22711,6 +22711,24 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 05fd739b : trn1 z27.d, z28.d, z29.d                  : trn1   %z28.d %z29.d -> %z27.d
 05ff73ff : trn1 z31.d, z31.d, z31.d                  : trn1   %z31.d %z31.d -> %z31.d
 
+# TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q (TRN1-Z.ZZ-Q)
+05a01800 : trn1 z0.q, z0.q, z0.q                     : trn1   %z0.q %z0.q -> %z0.q
+05a41862 : trn1 z2.q, z3.q, z4.q                     : trn1   %z3.q %z4.q -> %z2.q
+05a618a4 : trn1 z4.q, z5.q, z6.q                     : trn1   %z5.q %z6.q -> %z4.q
+05a818e6 : trn1 z6.q, z7.q, z8.q                     : trn1   %z7.q %z8.q -> %z6.q
+05aa1928 : trn1 z8.q, z9.q, z10.q                    : trn1   %z9.q %z10.q -> %z8.q
+05ac196a : trn1 z10.q, z11.q, z12.q                  : trn1   %z11.q %z12.q -> %z10.q
+05ae19ac : trn1 z12.q, z13.q, z14.q                  : trn1   %z13.q %z14.q -> %z12.q
+05b019ee : trn1 z14.q, z15.q, z16.q                  : trn1   %z15.q %z16.q -> %z14.q
+05b21a30 : trn1 z16.q, z17.q, z18.q                  : trn1   %z17.q %z18.q -> %z16.q
+05b31a51 : trn1 z17.q, z18.q, z19.q                  : trn1   %z18.q %z19.q -> %z17.q
+05b51a93 : trn1 z19.q, z20.q, z21.q                  : trn1   %z20.q %z21.q -> %z19.q
+05b71ad5 : trn1 z21.q, z22.q, z23.q                  : trn1   %z22.q %z23.q -> %z21.q
+05b91b17 : trn1 z23.q, z24.q, z25.q                  : trn1   %z24.q %z25.q -> %z23.q
+05bb1b59 : trn1 z25.q, z26.q, z27.q                  : trn1   %z26.q %z27.q -> %z25.q
+05bd1b9b : trn1 z27.q, z28.q, z29.q                  : trn1   %z28.q %z29.q -> %z27.q
+05bf1bff : trn1 z31.q, z31.q, z31.q                  : trn1   %z31.q %z31.q -> %z31.q
+
 # TRN2    <Pd>.<T>, <Pn>.<T>, <Pm>.<T> (TRN2-P.PP-_)
 05205400 : trn2 p0.b, p0.b, p0.b                     : trn2   %p0.b %p0.b -> %p0.b
 05235441 : trn2 p1.b, p2.b, p3.b                     : trn2   %p2.b %p3.b -> %p1.b
@@ -22842,6 +22860,24 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 05fb7759 : trn2 z25.d, z26.d, z27.d                  : trn2   %z26.d %z27.d -> %z25.d
 05fd779b : trn2 z27.d, z28.d, z29.d                  : trn2   %z28.d %z29.d -> %z27.d
 05ff77ff : trn2 z31.d, z31.d, z31.d                  : trn2   %z31.d %z31.d -> %z31.d
+
+# TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q (TRN2-Z.ZZ-Q)
+05a01c00 : trn2 z0.q, z0.q, z0.q                     : trn2   %z0.q %z0.q -> %z0.q
+05a41c62 : trn2 z2.q, z3.q, z4.q                     : trn2   %z3.q %z4.q -> %z2.q
+05a61ca4 : trn2 z4.q, z5.q, z6.q                     : trn2   %z5.q %z6.q -> %z4.q
+05a81ce6 : trn2 z6.q, z7.q, z8.q                     : trn2   %z7.q %z8.q -> %z6.q
+05aa1d28 : trn2 z8.q, z9.q, z10.q                    : trn2   %z9.q %z10.q -> %z8.q
+05ac1d6a : trn2 z10.q, z11.q, z12.q                  : trn2   %z11.q %z12.q -> %z10.q
+05ae1dac : trn2 z12.q, z13.q, z14.q                  : trn2   %z13.q %z14.q -> %z12.q
+05b01dee : trn2 z14.q, z15.q, z16.q                  : trn2   %z15.q %z16.q -> %z14.q
+05b21e30 : trn2 z16.q, z17.q, z18.q                  : trn2   %z17.q %z18.q -> %z16.q
+05b31e51 : trn2 z17.q, z18.q, z19.q                  : trn2   %z18.q %z19.q -> %z17.q
+05b51e93 : trn2 z19.q, z20.q, z21.q                  : trn2   %z20.q %z21.q -> %z19.q
+05b71ed5 : trn2 z21.q, z22.q, z23.q                  : trn2   %z22.q %z23.q -> %z21.q
+05b91f17 : trn2 z23.q, z24.q, z25.q                  : trn2   %z24.q %z25.q -> %z23.q
+05bb1f59 : trn2 z25.q, z26.q, z27.q                  : trn2   %z26.q %z27.q -> %z25.q
+05bd1f9b : trn2 z27.q, z28.q, z29.q                  : trn2   %z28.q %z29.q -> %z27.q
+05bf1fff : trn2 z31.q, z31.q, z31.q                  : trn2   %z31.q %z31.q -> %z31.q
 
 # UABD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (UABD-Z.P.ZZ-_)
 040d0000 : uabd z0.b, p0/M, z0.b, z0.b               : uabd   %p0/m %z0.b %z0.b -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -19925,6 +19925,35 @@ TEST_INSTR(stnt1w_sve_pred)
         opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
 }
 
+TEST_INSTR(trn1_sve)
+{
+
+    /* Testing TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *const expected_0_0[6] = {
+        "trn1   %z0.q %z0.q -> %z0.q",    "trn1   %z6.q %z7.q -> %z5.q",
+        "trn1   %z11.q %z12.q -> %z10.q", "trn1   %z17.q %z18.q -> %z16.q",
+        "trn1   %z22.q %z23.q -> %z21.q", "trn1   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(trn1, trn1_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
+}
+
+TEST_INSTR(trn2_sve)
+{
+
+    /* Testing TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *const expected_0_0[6] = {
+        "trn2   %z0.q %z0.q -> %z0.q",    "trn2   %z6.q %z7.q -> %z5.q",
+        "trn2   %z11.q %z12.q -> %z10.q", "trn2   %z17.q %z18.q -> %z16.q",
+        "trn2   %z22.q %z23.q -> %z21.q", "trn2   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(trn2, trn2_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
+}
 int
 main(int argc, char *argv[])
 {
@@ -20422,6 +20451,9 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ldnf1sh_sve_pred);
     RUN_INSTR_TEST(ldnf1sw_sve_pred);
     RUN_INSTR_TEST(ldnf1w_sve_pred);
+
+    RUN_INSTR_TEST(trn1_sve);
+    RUN_INSTR_TEST(trn2_sve);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q
TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q
```
issue: #3044
