### PR TITLE
i#5951: Make -only_thread a top-level analyzer option

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -136,6 +136,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t()
 template <typename RecordType, typename ReaderType>
 bool
 analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(const std::string &trace_path,
+                                                        memref_tid_t only_thread,
                                                         int verbosity)
 {
     verbosity_ = verbosity;
@@ -152,6 +153,9 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(const std::string &trace
         regions.emplace_back(skip_instrs_ + 1, 0);
     }
     typename sched_type_t::input_workload_t workload(trace_path, regions);
+    if (only_thread != INVALID_THREAD_ID) {
+        workload.only_threads.insert(only_thread);
+    }
     return init_scheduler_common(workload);
 }
 

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -140,7 +140,8 @@ protected:
     };
 
     bool
-    init_scheduler(const std::string &trace_path, int verbosity = 0);
+    init_scheduler(const std::string &trace_path,
+                   memref_tid_t only_thread = INVALID_THREAD_ID, int verbosity = 0);
 
     bool
     init_scheduler(

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -129,7 +129,7 @@ analyzer_multi_t::analyzer_multi_t()
     if (!op_indir.get_value().empty()) {
         std::string tracedir =
             raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
-        if (!init_scheduler(tracedir, op_verbose.get_value()))
+        if (!init_scheduler(tracedir, op_only_thread.get_value(), op_verbose.get_value()))
             success_ = false;
     } else if (op_infile.get_value().empty()) {
         // XXX i#3323: Add parallel analysis support for online tools.

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -490,7 +490,7 @@ droption_t<std::string> op_tracer_ops(
 droption_t<int>
     op_only_thread(DROPTION_SCOPE_FRONTEND, "only_thread", 0,
                    "Only analyze this thread (0 means all)",
-                   "For simulator types that support it, limits analyis to the single "
+                   "Limits analyis to the single "
                    "thread with the given identifier.  0 enables all threads.");
 
 droption_t<bytesize_t> op_skip_instrs(

--- a/clients/drcachesim/simulator/analyzer_interface.cpp
+++ b/clients/drcachesim/simulator/analyzer_interface.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -203,10 +203,9 @@ drmemtrace_analysis_tool_create()
     } else if (op_simulator_type.get_value() == VIEW) {
         std::string module_file_path = get_module_file_path();
         // The module file is optional so we don't check for emptiness.
-        return view_tool_create(module_file_path, op_only_thread.get_value(),
-                                op_skip_refs.get_value(), op_sim_refs.get_value(),
-                                op_view_syntax.get_value(), op_verbose.get_value(),
-                                op_alt_module_dir.get_value());
+        return view_tool_create(module_file_path, op_skip_refs.get_value(),
+                                op_sim_refs.get_value(), op_view_syntax.get_value(),
+                                op_verbose.get_value(), op_alt_module_dir.get_value());
     } else if (op_simulator_type.get_value() == FUNC_VIEW) {
         std::string funclist_file_path = get_aux_file_path(
             op_funclist_file.get_value(), DRMEMTRACE_FUNCTION_LIST_FILENAME);

--- a/clients/drcachesim/tests/counts_only_thread.templatex
+++ b/clients/drcachesim/tests/counts_only_thread.templatex
@@ -1,0 +1,5 @@
+Basic counts tool results:
+Total counts:
+.*
+           1 total threads
+.*

--- a/clients/drcachesim/tests/skip_unit_tests.cpp
+++ b/clients/drcachesim/tests/skip_unit_tests.cpp
@@ -89,9 +89,8 @@ test_skip_initial()
         std::unique_ptr<reader_t> iter_end =
             std::unique_ptr<reader_t>(new zipfile_file_reader_t());
         // Run the tool.
-        std::unique_ptr<analysis_tool_t> tool =
-            std::unique_ptr<analysis_tool_t>(view_tool_create(
-                "", /*thread=*/0, /*skip_refs=*/0, /*sim_refs=*/view_count, "att"));
+        std::unique_ptr<analysis_tool_t> tool = std::unique_ptr<analysis_tool_t>(
+            view_tool_create("", /*skip_refs=*/0, /*sim_refs=*/view_count, "att"));
         std::string error = tool->initialize_stream(iter.get());
         CHECK(error.empty(), error.c_str());
         iter->skip_instructions(skip_instrs);

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -92,9 +92,9 @@ namespace {
 
 class view_test_t : public view_t {
 public:
-    view_test_t(void *drcontext, instrlist_t &instrs, memref_tid_t thread,
-                uint64_t skip_refs, uint64_t sim_refs)
-        : view_t("", thread, skip_refs, sim_refs, "", 0)
+    view_test_t(void *drcontext, instrlist_t &instrs, uint64_t skip_refs,
+                uint64_t sim_refs)
+        : view_t("", skip_refs, sim_refs, "", 0)
     {
         module_mapper_ = std::unique_ptr<module_mapper_t>(
             new test_module_mapper_t(&instrs, drcontext));
@@ -113,9 +113,9 @@ public:
 
 class view_nomod_test_t : public view_t {
 public:
-    view_nomod_test_t(void *drcontext, instrlist_t &instrs, memref_tid_t thread,
-                      uint64_t skip_refs, uint64_t sim_refs)
-        : view_t("", thread, skip_refs, sim_refs, "", 0)
+    view_nomod_test_t(void *drcontext, instrlist_t &instrs, uint64_t skip_refs,
+                      uint64_t sim_refs)
+        : view_t("", skip_refs, sim_refs, "", 0)
     {
     }
 };
@@ -177,7 +177,7 @@ run_test_helper(view_t &view, const std::vector<memref_t> &memrefs)
 bool
 test_no_limit(void *drcontext, instrlist_t &ilist, const std::vector<memref_t> &memrefs)
 {
-    view_test_t view(drcontext, ilist, 0, 0, 0);
+    view_test_t view(drcontext, ilist, 0, 0);
     std::string res = run_test_helper(view, memrefs);
     if (std::count(res.begin(), res.end(), '\n') != static_cast<int>(memrefs.size())) {
         std::cerr << "Incorrect line count\n";
@@ -199,7 +199,7 @@ test_num_memrefs(void *drcontext, instrlist_t &ilist,
 {
     ASSERT(static_cast<size_t>(num_memrefs) < memrefs.size(),
            "need more memrefs to limit");
-    view_test_t view(drcontext, ilist, 0, 0, num_memrefs);
+    view_test_t view(drcontext, ilist, 0, num_memrefs);
     std::string res = run_test_helper(view, memrefs);
     if (std::count(res.begin(), res.end(), '\n') != num_memrefs) {
         std::cerr << "Incorrect num_memrefs count: expect " << num_memrefs
@@ -228,7 +228,7 @@ test_skip_memrefs(void *drcontext, instrlist_t &ilist,
     }
     ASSERT(static_cast<size_t>(num_memrefs + skip_memrefs) <= memrefs.size(),
            "need more memrefs to skip");
-    view_test_t view(drcontext, ilist, 0, skip_memrefs, num_memrefs);
+    view_test_t view(drcontext, ilist, skip_memrefs, num_memrefs);
     std::string res = run_test_helper(view, memrefs);
     if (std::count(res.begin(), res.end(), '\n') != num_memrefs) {
         std::cerr << "Incorrect skipped_memrefs count: expect " << num_memrefs
@@ -264,41 +264,9 @@ test_skip_memrefs(void *drcontext, instrlist_t &ilist,
 }
 
 bool
-test_thread_limit(instrlist_t &ilist, const std::vector<memref_t> &memrefs,
-                  void *drcontext, int thread2_id)
-{
-    int thread2_count = 0;
-    for (const auto &memref : memrefs) {
-        if (memref.data.tid == thread2_id)
-            ++thread2_count;
-    }
-    view_test_t view(drcontext, ilist, thread2_id, 0, 0);
-    std::string res = run_test_helper(view, memrefs);
-    // Count the "       nnnn" prefixes (tid column value).
-    std::stringstream ss;
-    ss << std::setw(view.tid_column_width()) << thread2_id;
-    std::string prefix = ss.str();
-    int found_prefixes = 0;
-    size_t pos = 0;
-    while (pos != std::string::npos) {
-        pos = res.find(prefix, pos);
-        if (pos != std::string::npos) {
-            ++found_prefixes;
-            ++pos;
-        }
-    }
-    if (std::count(res.begin(), res.end(), '\n') != thread2_count ||
-        found_prefixes != thread2_count) {
-        std::cerr << "Incorrect thread2 count\n";
-        return false;
-    }
-    return true;
-}
-
-bool
 test_no_modules(void *drcontext, instrlist_t &ilist, const std::vector<memref_t> &memrefs)
 {
-    view_nomod_test_t view(drcontext, ilist, 0, 0, 0);
+    view_nomod_test_t view(drcontext, ilist, 0, 0);
     std::string res = run_test_helper(view, memrefs);
     if (std::count(res.begin(), res.end(), '\n') != static_cast<int>(memrefs.size())) {
         std::cerr << "Incorrect line count\n";
@@ -358,29 +326,6 @@ run_limit_tests(void *drcontext)
 
     // Ensure missing modules are fine.
     res = test_no_modules(drcontext, *ilist, memrefs) && res;
-
-    const memref_tid_t t2 = 21;
-    std::vector<memref_t> thread_memrefs = {
-        gen_marker(t1, TRACE_MARKER_TYPE_VERSION, 3),
-        gen_marker(t1, TRACE_MARKER_TYPE_FILETYPE, 0),
-        gen_marker(t1, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
-        gen_instr(t1, offs_nop1),
-        gen_data(t1, true, 0x42, 4),
-        gen_branch(t1, offs_jz),
-        gen_branch(t1, offs_nop2),
-        gen_data(t1, true, 0x42, 4),
-        gen_marker(t2, TRACE_MARKER_TYPE_VERSION, 3),
-        gen_marker(t2, TRACE_MARKER_TYPE_FILETYPE, 0),
-        gen_marker(t2, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
-        gen_marker(t2, TRACE_MARKER_TYPE_TIMESTAMP, 101),
-        gen_marker(t2, TRACE_MARKER_TYPE_CPU_ID, 3),
-        gen_instr(t2, offs_nop1),
-        gen_data(t2, true, 0x42, 4),
-        gen_branch(t2, offs_jz),
-        gen_branch(t2, offs_nop2),
-        gen_data(t2, true, 0x42, 4),
-    };
-    res = test_thread_limit(*ilist, thread_memrefs, drcontext, t2) && res;
 
     instrlist_clear_and_destroy(drcontext, ilist);
     return res;
@@ -541,7 +486,7 @@ run_single_thread_chunk_test(void *drcontext)
           10           3:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
 )DELIM";
     instrlist_t *ilist_unused = nullptr;
-    view_nomod_test_t view(drcontext, *ilist_unused, 0, 0, 0);
+    view_nomod_test_t view(drcontext, *ilist_unused, 0, 0);
     std::string res = run_serial_test_helper(view, entries, tids);
     // Make 64-bit match our 32-bit expect string.
     res = std::regex_replace(res, std::regex("0x000000000000002a"), "0x0000002a");
@@ -623,7 +568,7 @@ run_serial_chunk_test(void *drcontext)
           22           6:           7 ifetch       4 byte(s) @ 0x0000002a non-branch
 )DELIM";
     instrlist_t *ilist_unused = nullptr;
-    view_nomod_test_t view(drcontext, *ilist_unused, 0, 0, 0);
+    view_nomod_test_t view(drcontext, *ilist_unused, 0, 0);
     std::string res = run_serial_test_helper(view, entries, tids);
     // Make 64-bit match our 32-bit expect string.
     res = std::regex_replace(res, std::regex("0x000000000000002a"), "0x0000002a");

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -46,21 +46,20 @@
 const std::string view_t::TOOL_NAME = "View tool";
 
 analysis_tool_t *
-view_tool_create(const std::string &module_file_path, memref_tid_t thread,
-                 uint64_t skip_refs, uint64_t sim_refs, const std::string &syntax,
-                 unsigned int verbose, const std::string &alt_module_dir)
+view_tool_create(const std::string &module_file_path, uint64_t skip_refs,
+                 uint64_t sim_refs, const std::string &syntax, unsigned int verbose,
+                 const std::string &alt_module_dir)
 {
-    return new view_t(module_file_path, thread, skip_refs, sim_refs, syntax, verbose,
+    return new view_t(module_file_path, skip_refs, sim_refs, syntax, verbose,
                       alt_module_dir);
 }
 
-view_t::view_t(const std::string &module_file_path, memref_tid_t thread,
-               uint64_t skip_refs, uint64_t sim_refs, const std::string &syntax,
-               unsigned int verbose, const std::string &alt_module_dir)
+view_t::view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t sim_refs,
+               const std::string &syntax, unsigned int verbose,
+               const std::string &alt_module_dir)
     : module_file_path_(module_file_path)
     , knob_verbose_(verbose)
     , trace_version_(-1)
-    , knob_thread_(thread)
     , knob_skip_refs_(skip_refs)
     , skip_refs_left_(knob_skip_refs_)
     , knob_sim_refs_(sim_refs)
@@ -118,9 +117,7 @@ view_t::initialize_stream(memtrace_stream_t *serial_stream)
 bool
 view_t::parallel_shard_supported()
 {
-    // When just one thread is selected, we support parallel operation to reduce
-    // overhead from reading all the other thread files in series.
-    return knob_thread_ > 0;
+    return false;
 }
 
 void *
@@ -178,8 +175,6 @@ bool
 view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     memtrace_stream_t *memstream = reinterpret_cast<memtrace_stream_t *>(shard_data);
-    if (knob_thread_ > 0 && memref.data.tid > 0 && memref.data.tid != knob_thread_)
-        return true;
     // Even for -skip_refs we need to process the up-front version and type.
     if (memref.marker.type == TRACE_TYPE_MARKER) {
         switch (memref.marker.marker_type) {

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,8 +49,8 @@ public:
     // OFFLINE_FILE_TYPE_ENCODINGS.
     // XXX: Once we update our toolchains to guarantee C++17 support we could use
     // std::optional here.
-    view_t(const std::string &module_file_path, memref_tid_t thread, uint64_t skip_refs,
-           uint64_t sim_refs, const std::string &syntax, unsigned int verbose,
+    view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t sim_refs,
+           const std::string &syntax, unsigned int verbose,
            const std::string &alt_module_dir = "");
     std::string
     initialize_stream(memtrace_stream_t *serial_stream) override;
@@ -132,7 +132,6 @@ protected:
     unsigned int knob_verbose_;
     int trace_version_;
     static const std::string TOOL_NAME;
-    memref_tid_t knob_thread_;
     uint64_t knob_skip_refs_;
     uint64_t skip_refs_left_;
     uint64_t knob_sim_refs_;

--- a/clients/drcachesim/tools/view_create.h
+++ b/clients/drcachesim/tools/view_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,8 +49,8 @@
  * It does not support online analysis.
  */
 analysis_tool_t *
-view_tool_create(const std::string &module_file_path, memref_tid_t thread,
-                 uint64_t skip_refs, uint64_t sim_refs, const std::string &syntax,
-                 unsigned int verbose = 0, const std::string &alt_module_dir = "");
+view_tool_create(const std::string &module_file_path, uint64_t skip_refs,
+                 uint64_t sim_refs, const std::string &syntax, unsigned int verbose = 0,
+                 const std::string &alt_module_dir = "");
 
 #endif /* _OPCODE_MIX_CREATE_H_ */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3578,6 +3578,10 @@ if (BUILD_CLIENTS)
         torunonly_simtool(reuse_time_offline ${ci_shared_app}
           "-indir ${thread_trace_dir} -simulator_type reuse_time" "")
         set(tool.reuse_time_offline_rawtemp ON) # no preprocessor
+
+        torunonly_simtool(counts_only_thread ${ci_shared_app}
+          "-indir ${thread_trace_dir} -simulator_type basic_counts -only_thread 10506" "")
+        set(tool.counts_only_thread_rawtemp ON) # no preprocessor
       endif ()
     endif ()
 


### PR DESCRIPTION
Applies -only_thread at the analyzer framework level, setting a thread filter for the scheduler.  This results in just one thread file being opened.

Removes the only_thread knob from the view tool.

Tested:
Before:
  $ bin64/drrun -t drcachesim -verbose 1 -simulator_type view -indir drmemtrace.*.dir -only_thread 2557808 -sim_refs 20 2>&1 | grep -c 'Opened reader'
  9
After:
  $ bin64/drrun -t drcachesim -verbose 1 -simulator_type view -indir drmemtrace.*.dir -only_thread 2557808 -sim_refs 20 2>&1 | grep -c 'Opened reader'
  0

Fixes #5951