### PR TITLE
i#5980: Fix 3 rseq exit/signal issues

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -207,7 +207,33 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ENTRY) {
+        shard->in_rseq_region_ = true;
+        shard->rseq_start_pc_ = 0;
         shard->rseq_end_pc_ = memref.marker.marker_value;
+    } else if (shard->in_rseq_region_) {
+        if (type_is_instr(memref.instr.type)) {
+            if (shard->rseq_start_pc_ == 0)
+                shard->rseq_start_pc_ = memref.instr.addr;
+            if (memref.instr.addr + memref.instr.size == shard->rseq_end_pc_) {
+                // Completed normally.
+                shard->in_rseq_region_ = false;
+            } else if (memref.instr.addr >= shard->rseq_start_pc_ &&
+                       memref.instr.addr < shard->rseq_end_pc_) {
+                // Still in the region.
+            } else {
+                // We should see an abort marker or a side exit if we leave the region.
+                report_if_false(shard,
+                                type_is_instr_branch(shard->prev_instr_.instr.type),
+                                "Rseq region exit requires marker, branch, or commit");
+                shard->in_rseq_region_ = false;
+            }
+        } else {
+            report_if_false(shard,
+                            memref.marker.type != TRACE_TYPE_MARKER ||
+                                memref.marker.marker_type !=
+                                    TRACE_MARKER_TYPE_KERNEL_EVENT,
+                            "Signal in rseq region should have abort marker");
+        }
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT) {
@@ -221,6 +247,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                                 shard->rseq_end_pc_ ||
                             shard->prev_instr_.instr.addr == memref.marker.marker_value,
                         "Rseq post-abort instruction not rolled back");
+        shard->in_rseq_region_ = false;
     }
 #endif
 

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -231,7 +231,9 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             report_if_false(shard,
                             memref.marker.type != TRACE_TYPE_MARKER ||
                                 memref.marker.marker_type !=
-                                    TRACE_MARKER_TYPE_KERNEL_EVENT,
+                                    TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                                // Side exit.
+                                type_is_instr_branch(shard->prev_instr_.instr.type),
                             "Signal in rseq region should have abort marker");
         }
     }

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -125,6 +125,9 @@ protected:
         // We could move this to per-worker data and still not need a lock
         // (we don't currently have per-worker data though so leaving it as per-shard).
         std::unordered_map<addr_t, addr_t> branch_target_cache;
+        // Rseq region state.
+        bool in_rseq_region_ = false;
+        addr_t rseq_start_pc_ = 0;
         addr_t rseq_end_pc_ = 0;
     };
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -585,6 +585,9 @@ raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
             } else if (in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ENTRY) {
                 if (tdata->rseq_want_rollback_) {
                     if (tdata->rseq_buffering_enabled_) {
+                        // Our rollback schemes do the minimal rollback: for a side
+                        // exit, taking the last branch.  This means we don't need the
+                        // prior iterations in the buffer.
                         log(4, "Rseq was already buffered: assuming loop; emitting\n");
                         err = adjust_and_emit_rseq_buffer(tdata, marker_val);
                         if (!err.empty())
@@ -1282,7 +1285,7 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                     return error;
             } else if (instr_pc < tdata->rseq_start_pc_ ||
                        instr_pc >= tdata->rseq_end_pc_) {
-                log(4, "Hit rseq instrumented exit to 0x%zx\n", orig_pc);
+                log(4, "Hit exit to 0x%zx during instrumented rseq run\n", orig_pc);
                 error = adjust_and_emit_rseq_buffer(tdata, instr_pc);
                 if (!error.empty())
                     return error;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -578,16 +578,23 @@ raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
                         return err;
                 }
             } else if (in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT) {
-                log(4, "Rseq abort\n");
+                log(4, "Rseq abort %d\n", tdata->rseq_past_end_);
                 err = adjust_and_emit_rseq_buffer(tdata, marker_val, marker_val);
                 if (!err.empty())
                     return err;
             } else if (in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ENTRY) {
                 if (tdata->rseq_want_rollback_) {
+                    if (tdata->rseq_buffering_enabled_) {
+                        log(4, "Rseq was already buffered: assuming loop; emitting\n");
+                        err = adjust_and_emit_rseq_buffer(tdata, marker_val);
+                        if (!err.empty())
+                            return err;
+                    }
                     log(4,
                         "--- Reached rseq entry (end=0x%zx): buffering all output ---\n",
                         marker_val);
-                    tdata->rseq_ever_saw_entry_ = true;
+                    if (!tdata->rseq_ever_saw_entry_)
+                        tdata->rseq_ever_saw_entry_ = true;
                     tdata->rseq_buffering_enabled_ = true;
                     tdata->rseq_end_pc_ = marker_val;
                 }
@@ -1268,9 +1275,15 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                 return error;
         }
         if (tdata->rseq_buffering_enabled_) {
+            addr_t instr_pc = reinterpret_cast<addr_t>(orig_pc);
             if (tdata->rseq_past_end_) {
-                error =
-                    adjust_and_emit_rseq_buffer(tdata, reinterpret_cast<addr_t>(orig_pc));
+                error = adjust_and_emit_rseq_buffer(tdata, instr_pc);
+                if (!error.empty())
+                    return error;
+            } else if (instr_pc < tdata->rseq_start_pc_ ||
+                       instr_pc >= tdata->rseq_end_pc_) {
+                log(4, "Hit rseq instrumented exit to 0x%zx\n", orig_pc);
+                error = adjust_and_emit_rseq_buffer(tdata, instr_pc);
                 if (!error.empty())
                     return error;
             } else {
@@ -1284,11 +1297,13 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                         // will walk it forward to the branch.
                         static_cast<int>(tdata->rseq_buffer_.size()));
                 }
-                if (reinterpret_cast<addr_t>(orig_pc) + instr->length() ==
-                    tdata->rseq_end_pc_) {
+                if (tdata->rseq_start_pc_ == 0) {
+                    tdata->rseq_start_pc_ = instr_pc;
+                }
+                if (instr_pc + instr->length() == tdata->rseq_end_pc_) {
                     log(4, "Hit rseq endpoint 0x%zx @ %p\n", tdata->rseq_end_pc_,
                         orig_pc);
-                    tdata->rseq_commit_pc_ = reinterpret_cast<addr_t>(orig_pc);
+                    tdata->rseq_commit_pc_ = instr_pc;
                     tdata->rseq_past_end_ = true;
                     tdata->rseq_commit_idx_ =
                         static_cast<int>(tdata->rseq_buffer_.size());
@@ -1855,17 +1870,34 @@ raw2trace_t::adjust_and_emit_rseq_buffer(raw2trace_thread_data_t *tdata, addr_t 
         // so we do the simplest thing and only roll back the committing store.
         log(4, "Rseq aborted\n");
         add_to_statistic(tdata, RAW2TRACE_STAT_RSEQ_ABORT, 1);
-        if (tdata->rseq_commit_idx_ < 0)
-            return "Failed to identify rseq commit index";
-        std::string error =
-            rollback_rseq_buffer(tdata, tdata->rseq_commit_idx_, tdata->rseq_commit_idx_);
-        if (!error.empty())
-            return error;
+        if (tdata->rseq_commit_idx_ < 0) {
+            if (tdata->rseq_buffer_.empty()) {
+                // This is a graceful failure: we consider this a bug to
+                // have an extra abort marker but we do not want to make it
+                // fatal if the buffer is empty as we can continue.
+                // XXX: Add an invariant check for this.
+                log(1, "Extra abort marker found");
+                return "";
+            }
+            // Else this is an abort in the instrumented run, such as a
+            // fault or signal, so no rollback is needed.
+        } else {
+            std::string error = rollback_rseq_buffer(tdata, tdata->rseq_commit_idx_,
+                                                     tdata->rseq_commit_idx_);
+            if (!error.empty())
+                return error;
+        }
     } else if (next_pc == tdata->rseq_end_pc_) {
         // Normal fall-through of the committing store: nothing to roll back.  We give
         // up on distinguishing a side exit whose target is the end PC fall-through from
         // a completion.
         log(4, "Rseq completed normally\n");
+    } else if (!tdata->rseq_past_end_ &&
+               (next_pc < tdata->rseq_start_pc_ || next_pc >= tdata->rseq_end_pc_)) {
+        // The instrumented execution took a side exit.
+        DEBUG_ASSERT(tdata->rseq_commit_pc_ == 0);
+        DEBUG_ASSERT(abort_pc == 0);
+        log(4, "Rseq instrumented side exit\n");
     } else {
         log(4, "Rseq exited on the side: searching for where\n");
         add_to_statistic(tdata, RAW2TRACE_STAT_RSEQ_SIDE_EXIT, 1);
@@ -1965,6 +1997,7 @@ raw2trace_t::adjust_and_emit_rseq_buffer(raw2trace_thread_data_t *tdata, addr_t 
 
     tdata->rseq_past_end_ = false;
     tdata->rseq_commit_pc_ = 0;
+    tdata->rseq_start_pc_ = 0;
     tdata->rseq_end_pc_ = 0;
     tdata->rseq_buffer_.clear();
     tdata->rseq_commit_idx_ = -1;
@@ -2437,6 +2470,12 @@ raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
     if (tdata->rseq_buffering_enabled_) {
         for (const trace_entry_t *it = start; it < end; ++it)
             tdata->rseq_buffer_.push_back(*it);
+        // Look for a runaway buffer which indicates a bug.
+        // There are rseq regions with loops but they should be relatively short.
+        static constexpr int MAX_REASONABLE_RSEQ_LENGTH = 4096;
+        if (tdata->rseq_buffer_.size() > MAX_REASONABLE_RSEQ_LENGTH) {
+            return "Runaway rseq buffer indicates an rseq exit was missed";
+        }
         tdata->rseq_decode_pcs_.insert(tdata->rseq_decode_pcs_.end(), decode_pcs.begin(),
                                        decode_pcs.end());
         return "";

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -948,6 +948,7 @@ protected:
         bool rseq_buffering_enabled_ = false;
         bool rseq_past_end_ = false;
         addr_t rseq_commit_pc_ = 0;
+        addr_t rseq_start_pc_ = 0;
         addr_t rseq_end_pc_ = 0;
         std::vector<trace_entry_t> rseq_buffer_;
         int rseq_commit_idx_ = -1; // Index into rseq_buffer_.

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -2104,6 +2104,7 @@ instrument_kernel_xfer(dcontext_t *dcontext, dr_kernel_xfer_type_t type,
     if (kernel_xfer_callbacks.num == 0) {
         return false;
     }
+    LOG(THREAD, LOG_INTERP, 3, "%s: type=%d\n", __FUNCTION__, type);
     dr_kernel_xfer_info_t info;
     info.type = type;
     info.source_mcontext = NULL;

--- a/core/translate.c
+++ b/core/translate.c
@@ -725,7 +725,7 @@ translate_restore_clean_call(dcontext_t *tdcontext, translate_walk_t *walk)
      */
 }
 
-static app_pc
+app_pc
 translate_restore_special_cases(dcontext_t *dcontext, app_pc pc)
 {
 #ifdef LINUX
@@ -755,6 +755,14 @@ translate_last_direct_translation(dcontext_t *dcontext, app_pc pc)
         return dcontext->client_data->last_special_xl8;
 #endif
     return pc;
+}
+
+void
+translate_clear_last_direct_translation(dcontext_t *dcontext)
+{
+#ifdef LINUX
+    dcontext->client_data->last_special_xl8 = NULL;
+#endif
 }
 
 /* Returns a success code, but makes a best effort regardless.

--- a/core/translate.h
+++ b/core/translate.h
@@ -113,10 +113,19 @@ stress_test_recreate_state(dcontext_t *dcontext, fragment_t *f, instrlist_t *ili
 bool
 at_syscall_translation(dcontext_t *dcontext, app_pc pc);
 
+/* Returns a replacement pc if it is a special case such as in an rseq region;
+ * else returns pc.
+ */
+app_pc
+translate_restore_special_cases(dcontext_t *dcontext, app_pc pc);
+
 /* Returns the direct translation when given the "official" translation.
  * Some special cases like rseq sequences obfuscate the interrupted PC: i#4041.
  */
 app_pc
 translate_last_direct_translation(dcontext_t *dcontext, app_pc pc);
+
+void
+translate_clear_last_direct_translation(dcontext_t *dcontext);
 
 #endif /* _TRANSLATE_H_ */

--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -869,6 +869,15 @@ rseq_process_native_abort(dcontext_t *dcontext)
     }
     if (source_mc != NULL)
         HEAP_TYPE_FREE(dcontext, source_mc, priv_mcontext_t, ACCT_CLIENT, PROTECTED);
+    /* Make sure we do not raise a duplicate abort if we had a pending signal that
+     * caused the abort.  (It might be better to instead suppress this abort-exit
+     * event and present the signal as causing the abort but that is more complex
+     * to implement so we pretend the signal came in after the abort.)
+     * XXX: We saw a double abort and assume it is from some signal+abort
+     * combination but we failed to reproduce it in our linux.rseq tests cases
+     * so we do not have proof that this is solving anything here.
+     */
+    translate_clear_last_direct_translation(dcontext);
 }
 
 void

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -6241,6 +6241,7 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
          */
         mcontext_to_ucontext(uc, mcontext);
     }
+
     /* Sigreturn needs the target ISA mode to be set in the T bit in cpsr.
      * Since we came from d_r_dispatch, the post-signal target's mode is in dcontext.
      */
@@ -6283,6 +6284,15 @@ execute_handler_from_dispatch(dcontext_t *dcontext, int sig)
     if (!info->sigpending[sig]->use_sigcontext) {
         /* for the pc we want the app pc not the cache pc */
         sc->SC_XIP = (ptr_uint_t)dcontext->next_tag;
+        /* Point at the rseq abort handler if in an rseq region. */
+        ptr_uint_t special_xl8 =
+            (ptr_uint_t)translate_restore_special_cases(dcontext, (app_pc)sc->SC_XIP);
+        if (special_xl8 != sc->SC_XIP) {
+            dcontext->next_tag = (app_pc)special_xl8;
+            sc->SC_XIP = special_xl8;
+            LOG(THREAD, LOG_ASYNCH, 3, "set next PC to special xl8 %p\n",
+                dcontext->next_tag);
+        }
         LOG(THREAD, LOG_ASYNCH, 3, "\tset frame's eip to " PFX "\n", sc->SC_XIP);
     }
 

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -875,7 +875,7 @@ test_rseq_asynch_signal(void)
 #    elif defined(AARCH64)
     __asm__ __volatile__(
         /* clang-format off */ /* (avoid indenting next few lines) */
-        RSEQ_ADD_TABLE_ENTRY(abort, 2f, 3f, 4f)
+        RSEQ_ADD_TABLE_ENTRY(asynch_signal, 2f, 3f, 4f)
         /* clang-format on */
 
         "6:\n\t"
@@ -922,8 +922,7 @@ test_rseq_asynch_signal(void)
         /* clang-format on */
 
         : [rseq_cs] "=m"(reg_rseq->rseq_cs), [restarts] "=m"(restarts)
-        : [cpu_mask_size] "i"(sizeof(cpu_set_t)),
-          [sysnum_setaffinity] "i"(SYS_sched_setaffinity)
+        : [signum_alarm] "i"(SIGALRM), [sysnum_kill] "i"(SYS_kill)
         : "x0", "x1", "x2", "x8", "q0", "q1", "memory");
 #    else
 #        error Unsupported arch
@@ -1105,7 +1104,7 @@ test_rseq_instru_side_exit(void)
 #elif defined(AARCH64)
     __asm__ __volatile__(
         /* clang-format off */ /* (avoid indenting next few lines) */
-        RSEQ_ADD_TABLE_ENTRY(side, 2f, 3f, 4f)
+        RSEQ_ADD_TABLE_ENTRY(side_instru, 2f, 3f, 4f)
         /* clang-format on */
 
         "6:\n\t"

--- a/suite/tests/linux/rseq.c
+++ b/suite/tests/linux/rseq.c
@@ -812,6 +812,127 @@ test_rseq_native_abort(void)
 #endif /* DEBUG */
 }
 
+/* Tests that DR handles an asynch signal in the native code in the final rseq
+ * fragment.  We use a system call, which is officially disallowed.  We have special
+ * exceptions in the code which look for the test name "linux.rseq" and are limited to
+ * DEBUG.
+ */
+static void
+test_rseq_asynch_signal(void)
+{
+    volatile struct rseq *reg_rseq = get_my_rseq();
+#ifdef DEBUG /* See above: special code in core/ is DEBUG-only> */
+    int restarts = 0;
+#    ifdef X86
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(asynch_signal, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "leaq rseq_cs_abort(%%rip), %%rax\n\t"
+        "movq %%rax, %[rseq_cs]\n\t"
+        "pxor %%xmm0, %%xmm0\n\t"
+        "mov $1,%%rcx\n\t"
+        "movq %%rcx, %%xmm1\n\t"
+
+        /* Restartable sequence. */
+        "2:\n\t"
+        /* Increase xmm0 every time.  DR (currently) won't restore xmm inputs
+         * to rseq sequences, nor does it detect that it needs to.
+         */
+        "paddq %%xmm1,%%xmm0\n\t"
+        "movq %%xmm0, %%rax\n\t"
+        /* We raise the signal on the instrumented run and never come back. */
+        /* Send ourselves a SIGALRM. */
+        "mov $0, %%rdi\n\t"
+        "mov %[signum_alarm], %%rsi\n\t"
+        "mov %[sysnum_kill], %%eax\n\t"
+        "syscall\n\t"
+        "11:\n\t"
+        "nop\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "jmp 5f\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        "addl $1, %[restarts]\n\t"
+        "jmp 5f\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "movq $0, %[rseq_cs]\n\t"
+        /* clang-format on */
+
+        : [rseq_cs] "=m"(reg_rseq->rseq_cs), [restarts] "=m"(restarts)
+        : [signum_alarm] "i"(SIGALRM), [sysnum_kill] "i"(SYS_kill)
+        : "rax", "rcx", "rdx", "rsi", "rdi", "xmm0", "xmm1", "memory");
+#    elif defined(AARCH64)
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(abort, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "adrp x0, rseq_cs_abort\n\t"
+        "add x0, x0, :lo12:rseq_cs_abort\n\t"
+        "str x0, %[rseq_cs]\n\t"
+        "eor v0.16b, v0.16b, v0.16b\n\t"
+        "mov x1, #1\n\t"
+        "mov v1.D[0], x1\n\t"
+
+        /* Restartable sequence. */
+        "2:\n\t"
+        /* Increase xmm0 every time.  DR (currently) won't restore xmm inputs
+         * to rseq sequences, nor does it detect that it needs to.
+         */
+        "add d0, d0, d1\n\t"
+        "mov x0, v0.D[0]\n\t"
+        /* We raise the signal on the instrumented run and never come back. */
+        /* Send ourselves a SIGALRM. */
+        "mov x0, #0\n\t"
+        "mov w1, #%[signum_alarm]\n\t"
+        "mov w8, #%[sysnum_kill]\n\t"
+        "svc #0\n\t"
+        "11:\n\t"
+        "nop\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "b 5f\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        "ldr x1, %[restarts]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[restarts]\n\t"
+        "b 5f\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "str xzr, %[rseq_cs]\n\t"
+        /* clang-format on */
+
+        : [rseq_cs] "=m"(reg_rseq->rseq_cs), [restarts] "=m"(restarts)
+        : [cpu_mask_size] "i"(sizeof(cpu_set_t)),
+          [sysnum_setaffinity] "i"(SYS_sched_setaffinity)
+        : "x0", "x1", "x2", "x8", "q0", "q1", "memory");
+#    else
+#        error Unsupported arch
+#    endif
+    /* This is expected to fail on a native run where restarts will be 0. */
+    assert(restarts > 0);
+#endif /* DEBUG */
+}
+
 /* Tests that DR and drmemtrace handle a side exit in the native sequence. */
 static void
 test_rseq_side_exit(void)
@@ -893,6 +1014,119 @@ test_rseq_side_exit(void)
         "cmp x0, #2\n\t"
         "b.ne 7f\n\t"
         "b 5f\n\t"
+        "7:\n\t"
+        "ldr x0, %[commits]\n\t"
+        "add x0, x0, #1\n\t"
+        "str x0, %[commits]\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "b 5f\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        "ldr x1, %[restarts]\n\t"
+        "add x1, x1, #1\n\t"
+        "str x1, %[restarts]\n\t"
+        "b 2b\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "str xzr, %[rseq_cs]\n\t"
+        /* clang-format on */
+
+        : [rseq_cs] "=m"(reg_rseq->rseq_cs), [restarts] "=m"(restarts),
+          [commits] "=m"(commits)
+        :
+        : "x0", "q0", "q1", "memory");
+#else
+#    error Unsupported arch
+#endif
+    assert(restarts == 0);
+    assert(commits == 0);
+}
+
+/* Tests that DR and drmemtrace handle a side exit in the instrumented sequence. */
+static void
+test_rseq_instru_side_exit(void)
+{
+    volatile struct rseq *reg_rseq = get_my_rseq();
+    int restarts = 0;
+    int commits = 0;
+#ifdef X86
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(side_instru, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "leaq rseq_cs_side(%%rip), %%rax\n\t"
+        "movq %%rax, %[rseq_cs]\n\t"
+        "pxor %%xmm0, %%xmm0\n\t"
+        "mov $1,%%rax\n\t"
+        "movq %%rax, %%xmm1\n\t"
+
+        /* Restartable sequence. */
+        "2:\n\t"
+        /* Increase xmm0 every time.  DR (currently) won't restore xmm inputs
+         * to rseq sequences, nor does it detect that it needs to.
+         */
+        "paddq %%xmm1,%%xmm0\n\t"
+        "movq %%xmm0, %%rax\n\t"
+        /* Take a side exit in the 1st run == instrumented run. */
+        "cmp $2, %%rax\n\t"
+        "jne 5f\n\t"
+        "7:\n\t"
+        "addl $1, %[commits]\n\t"
+
+        /* Post-commit. */
+        "3:\n\t"
+        "jmp 5f\n\t"
+
+        /* Abort handler. */
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        ".long " STRINGIFY(RSEQ_SIG) "\n\t"
+        "4:\n\t"
+        "addl $1, %[restarts]\n\t"
+        "jmp 2b\n\t"
+
+        /* Clear the ptr. */
+        "5:\n\t"
+        "movq $0, %[rseq_cs]\n\t"
+        /* clang-format on */
+
+        : [rseq_cs] "=m"(reg_rseq->rseq_cs), [restarts] "=m"(restarts),
+          [commits] "=m"(commits)
+        :
+        : "rax", "xmm0", "xmm1", "memory");
+#elif defined(AARCH64)
+    __asm__ __volatile__(
+        /* clang-format off */ /* (avoid indenting next few lines) */
+        RSEQ_ADD_TABLE_ENTRY(side, 2f, 3f, 4f)
+        /* clang-format on */
+
+        "6:\n\t"
+        /* Store the entry into the ptr. */
+        "adrp x0, rseq_cs_side\n\t"
+        "add x0, x0, :lo12:rseq_cs_side\n\t"
+        "str x0, %[rseq_cs]\n\t"
+        "eor v0.16b, v0.16b, v0.16b\n\t"
+        "mov x0, #1\n\t"
+        "mov v1.D[0], x0\n\t"
+
+        /* Restartable sequence. */
+        "2:\n\t"
+        /* Increase xmm0 every time.  DR (currently) won't restore xmm inputs
+         * to rseq sequences, nor does it detect that it needs to.
+         */
+        "add d0, d0, d1\n\t"
+        "mov x0, v0.D[0]\n\t"
+        /* Take a side exit in the 1st run == instrumented run. */
+        "cmp x0, #2\n\t"
+        "b.ne 5f\n\t"
         "7:\n\t"
         "ldr x0, %[commits]\n\t"
         "add x0, x0, #1\n\t"
@@ -1168,6 +1402,7 @@ int
 main()
 {
     intercept_signal(SIGILL, signal_handler, false);
+    intercept_signal(SIGALRM, signal_handler, false);
     if (register_rseq()) {
 #ifdef RSEQ_TEST_ATTACH
         /* Set -offline to avoid trying to open a pipe to a missing reader. */
@@ -1190,8 +1425,12 @@ main()
         test_rseq_native_fault();
         /* Test a non-fault abort in the native run. */
         test_rseq_native_abort();
+        /* Test a (non-fault) signal. */
+        test_rseq_asynch_signal();
         /* Test a side exit in the native run. */
         test_rseq_side_exit();
+        /* Test a side exit in the instrumented run. */
+        test_rseq_instru_side_exit();
         /* Test a trace. */
         int i;
         for (i = 0; i < 200; i++)


### PR DESCRIPTION
Fixes 3 more problems with rseq in DR and in drmemtraces related to exits and signals:

1) Side exit in instrumented run: avoids unbounded buffer growth by detecting by looking at the region bounds.  Adds a buffer large size sanity check.  Adds a test to linux.rseq.

2) Try to handle double-abort: couldn't repro in test though so the fix of disabling a later signal from reporting an abort when we report an abort fragment exit is not fully vetted.

3) Asynch signal in instrumented run: this was not being adjusted so the interruption/continuation PC is the abort handler.  Adds a test to linux.rseq.

Adds more invariant checks around rseq region exits.

Issue: #5953, #4041, #5954, #5980
Fixes #5980