### PR TITLE
i#5982: Fix memory leak in invariant checker

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -732,7 +732,7 @@ invariant_checker_t::check_for_pc_discontinuity(
                 }
             } else if (cur_instr_decoded != nullptr &&
                        shard->prev_instr_decoded_ != nullptr &&
-                       instr_is_syscall(cur_instr_decoded.get()->data) &&
+                       instr_is_syscall(cur_instr_decoded->data) &&
                        memref.instr.addr == prev_instr_trace_pc &&
                        instr_is_syscall(shard->prev_instr_decoded_->data)) {
                 error_msg = "Duplicate syscall instrs with the same PC";

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -109,6 +109,9 @@ invariant_checker_t::parallel_shard_init(int shard_index, void *worker_data)
 bool
 invariant_checker_t::parallel_shard_exit(void *shard_data)
 {
+    per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
+    if (shard->prev_instr_decoded_.get() != nullptr)
+        instr_free(GLOBAL_DCONTEXT, shard->prev_instr_decoded_.get());
     return true;
 }
 

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -381,10 +381,9 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         std::unique_ptr<instr_autoclean_t> cur_instr_decoded = nullptr;
         if (expect_encoding) {
             cur_instr_decoded.reset(new instr_autoclean_t(GLOBAL_DCONTEXT));
-            app_pc next_pc = decode_from_copy(GLOBAL_DCONTEXT,
-                                              const_cast<app_pc>(memref.instr.encoding),
-                                              reinterpret_cast<app_pc>(memref.instr.addr),
-                                              cur_instr_decoded->data);
+            app_pc next_pc = decode_from_copy(
+                GLOBAL_DCONTEXT, const_cast<app_pc>(memref.instr.encoding),
+                reinterpret_cast<app_pc>(memref.instr.addr), cur_instr_decoded->data);
             if (next_pc == nullptr) {
                 cur_instr_decoded.reset(nullptr);
             }

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -38,6 +38,7 @@
 
 #include "analysis_tool.h"
 #include "dr_api.h"
+#include <iostream>
 #include "memref.h"
 #include <memory>
 #include <mutex>

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -54,16 +54,14 @@ public:
     instr_autoclean_t(void *drcontext)
         : drcontext(drcontext)
     {
-        data = instr_create(drcontext);
-    }
-    ~instr_autoclean_t()
-    {
-#ifdef DEBUG
         if (drcontext == nullptr) {
             std::cerr << "instr_autoclean_t: invalid drcontext" << std::endl;
             exit(1);
         }
-#endif
+        data = instr_create(drcontext);
+    }
+    ~instr_autoclean_t()
+    {
         if (data != nullptr) {
             instr_destroy(drcontext, data);
             data = nullptr;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -51,10 +51,10 @@
  */
 struct instr_autoclean_t {
 public:
-    instr_autoclean_t(void *drcontext, instr_t *data)
+    instr_autoclean_t(void *drcontext)
         : drcontext(drcontext)
-        , data(data)
     {
+        data = instr_create(drcontext);
     }
     ~instr_autoclean_t()
     {
@@ -114,7 +114,7 @@ protected:
         memtrace_stream_t *stream = nullptr;
         memref_t prev_entry_ = {};
         memref_t prev_instr_ = {};
-        std::unique_ptr<instr_t> prev_instr_decoded_ = nullptr;
+        std::unique_ptr<instr_autoclean_t> prev_instr_decoded_ = nullptr;
         memref_t prev_xfer_marker_ = {}; // Cleared on seeing an instr.
         memref_t last_xfer_marker_ = {}; // Not cleared: just the prior xfer marker.
         addr_t last_retaddr_ = 0;


### PR DESCRIPTION
Adds instr_autoclean_t to ensure the instance of instr_t is cleaned up when it is out of scope.

Fixes #5982