### PR TITLE
i#5984: Fix trace invariant false positive on back-to-back signals

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -86,6 +86,11 @@ protected:
         memtrace_stream_t *stream = nullptr;
         memref_t prev_entry_ = {};
         memref_t prev_instr_ = {};
+
+#define MAX_SIGNAL_DEPTH 100
+        memref_t prev_instr_at_depth_[MAX_SIGNAL_DEPTH] = {};
+        int cur_signal_depth_ = 0;
+
         std::unique_ptr<instr_t> prev_instr_decoded_ = nullptr;
         memref_t prev_xfer_marker_ = {}; // Cleared on seeing an instr.
         memref_t last_xfer_marker_ = {}; // Not cleared: just the prior xfer marker.
@@ -93,13 +98,18 @@ protected:
 #ifdef UNIX
         // We only support sigreturn-using handlers so we have pairing: no longjmp.
         std::stack<addr_t> prev_xfer_int_pc_;
+        // Last addr_t popped from prev_xfer_int_pc_. We need to save this as it
+        // is required after prev_xfer_int_pc_ is popped at the xfer marker.
+        addr_t last_xfer_int_pc_ = 0;
         memref_t prev_prev_entry_ = {};
         std::stack<memref_t> pre_signal_instr_;
+        // Last memref_t popped from pre_signal_instr_. We need to save this as it
+        // is required after pre_signal_instr_ is popped at the xfer marker.
+        memref_t last_pre_signal_instr_ = {};
         // These are only available via annotations in signal_invariants.cpp.
         int instrs_until_interrupt_ = -1;
         int memrefs_until_interrupt_ = -1;
 #endif
-        bool saw_kernel_xfer_after_prev_instr_ = false;
         bool saw_timestamp_but_no_instr_ = false;
         bool found_cache_line_size_marker_ = false;
         bool found_instr_count_marker_ = false;


### PR DESCRIPTION
Moves tracking for previous kernel_event marker values and previous pre-signal instrs at the kernel_event and kernel_xfer markers. Previously we did some part of this book-keeping at instrs after the kernel_xfer marker, which would be erroneously skipped when there are back-to-back signals without any intervening instrs.

Adds tracking for last seen instr at each signal depth. This is required to correctly find the pre-signal instr for the second signal in a back-to-back signal pair. Without this, the pre-signal instr for the second signal is erroneously assumed to be whatever the last instr is, which may be some instr in the first signal's body. This also obviates the need to track the boolean for saw_kernel_xfer_after_prev_instr_, which was to detect nested signals Without any intervening instr.

Adds a test case that verifies the scenario with back-to-back signals without any intervening instr.

Fixes: #5984