### PR TITLE
i#3044 AArch64 SVE codec: Add SDOT/UDOT

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -3808,6 +3808,23 @@ encode_opnd_imm4_16p1(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc
     return true;
 }
 
+/* z4_h_16: Z0-15 register with h size elements at position 16 */
+
+static inline bool
+decode_opnd_z4_h_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_single_sized(DR_REG_Z0, DR_REG_Z15, 16, 4, HALF_REG, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_z4_h_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    const reg_id_t reg = opnd_get_reg(opnd);
+    IF_RETURN_FALSE((reg < DR_REG_Z0) || (reg > DR_REG_Z15))
+
+    return encode_single_sized(OPSZ_SCALABLE, 16, HALF_REG, 0, opnd, enc_out);
+}
+
 /* z4_s_16: Z0-15 register with s size elements at position 16 */
 
 static inline bool

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -602,6 +602,10 @@
 0110010111010100101xxxxxxxxxxxxx  n   362  SVE    scvtf          z_s_0 : p10_mrg_lo z_d_5
 00000100xx010100000xxxxxxxxxxxxx  n   363  SVE     sdiv    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
 00000100xx010110000xxxxxxxxxxxxx  n   794  SVE    sdivr    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
+01000100110xxxxx000000xxxxxxxxxx  n   364  SVE     sdot          z_d_0 : z_d_0 z_h_5 z_h_16
+01000100100xxxxx000000xxxxxxxxxx  n   364  SVE     sdot          z_s_0 : z_s_0 z_b_5 z_b_16
+01000100111xxxxx000000xxxxxxxxxx  n   364  SVE     sdot          z_d_0 : z_d_0 z_h_5 z4_h_16 i1_index_20
+01000100101xxxxx000000xxxxxxxxxx  n   364  SVE     sdot          z_s_0 : z_s_0 z_b_5 z3_b_16 i2_index_19
 001001010000xxxx01xxxx1xxxx1xxxx  n   896  SVE      sel          p_b_0 : p10 p_b_5 p_b_16
 00000101xx1xxxxx11xxxxxxxxxxxxxx  n   896  SVE      sel  z_size_bhsd_0 : p10 z_size_bhsd_5 z_size_bhsd_16
 00100101001011001001000000000000  n   819  SVE   setffr                :
@@ -759,6 +763,10 @@
 0110010111010101101xxxxxxxxxxxxx  n   510  SVE    ucvtf          z_s_0 : p10_mrg_lo z_d_5
 00000100xx010101000xxxxxxxxxxxxx  n   511  SVE     udiv    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
 00000100xx010111000xxxxxxxxxxxxx  n   795  SVE    udivr    z_size_sd_0 : p10_mrg_lo z_size_sd_0 z_size_sd_5
+01000100110xxxxx000001xxxxxxxxxx  n   512  SVE     udot          z_d_0 : z_d_0 z_h_5 z_h_16
+01000100100xxxxx000001xxxxxxxxxx  n   512  SVE     udot          z_s_0 : z_s_0 z_b_5 z_b_16
+01000100111xxxxx000001xxxxxxxxxx  n   512  SVE     udot          z_d_0 : z_d_0 z_h_5 z4_h_16 i1_index_20
+01000100101xxxxx000001xxxxxxxxxx  n   512  SVE     udot          z_s_0 : z_s_0 z_b_5 z3_b_16 i2_index_19
 00000100xx001001000xxxxxxxxxxxxx  n   516  SVE     umax  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx101001110xxxxxxxxxxxxx  n   516  SVE     umax  z_size_bhsd_0 : z_size_bhsd_0 imm8_5
 0000010000001001001xxxxxxxxxxxxx  n   518  SVE    umaxv             b0 : p10_lo z_size_bhsd_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -14173,4 +14173,71 @@
 #define INSTR_CREATE_trn2_sve(dc, Zd, Zn, Zm) \
     instr_create_1dst_2src(dc, OP_trn2, Zd, Zn, Zm)
 
+/**
+ * Creates a SDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SDOT    <Zda>.<Ts>, <Zn>.<Tb>, <Zm>.<Tb>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_sdot_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_sdot, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates a SDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SDOT    <Zda>.D, <Zn>.H, <Zm>.H[<index>]
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ * \param index The immediate index for Zm.
+ *              In the range 0-1 for the 64-bit (D) variant or 0-3 for the
+ *              32-bit (S) variant.
+ */
+#define INSTR_CREATE_sdot_sve_idx(dc, Zda, Zn, Zm, index) \
+    instr_create_1dst_4src(dc, OP_sdot, Zda, Zda, Zn, Zm, index)
+
+/**
+ * Creates an UDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UDOT    <Zda>.<Ts>, <Zn>.<Tb>, <Zm>.<Tb>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda  The source and destination vector register, Z (Scalable).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_udot_sve(dc, Zda, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_udot, Zda, Zda, Zn, Zm)
+
+/**
+ * Creates an UDOT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    UDOT    <Zda>.D, <Zn>.H, <Zm>.H[<index>]
+ *    UDOT    <Zda>.S, <Zn>.B, <Zm>.B[<index>]
+ * \endverbatim
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Zn    The second source vector register, Z (Scalable).
+ * \param Zm    The third source vector register, Z (Scalable).
+ * \param index The immediate index for Zm.
+ *              In the range 0-1 for the 64-bit (D) variant or 0-3 for the
+ *              32-bit (S) variant.
+ */
+#define INSTR_CREATE_udot_sve_idx(dc, Zda, Zn, Zm, index) \
+    instr_create_1dst_4src(dc, OP_udot, Zda, Zda, Zn, Zm, index)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -179,6 +179,7 @@
 ------------xxxx----------------  p16_zer    # zeroing P register at position 16
 ------------xxxx----------------  p_b_16     # P register with a byte element size at position 16
 ------------xxxx----------------  imm4_16p1  # 4bit imm at 19-16, plus 1
+------------xxxx----------------  z4_h_16     # Z0-15 register with h size elements at position 16
 ------------xxxx----------------  z4_s_16     # Z0-15 register with s size elements at position 16
 ------------xxxx----------------  z4_d_16     # Z0-15 register with d size elements at position 16
 ------------xxxx----------------  q4_16       # Q0-15 register at position 16

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -18408,6 +18408,76 @@ c51fffef : prfw 15, p7, [z31.d, #124]                : prfw   $0x0f %p7 +0x7c(%z
 04d61fbb : sdivr z27.d, p7/M, z27.d, z29.d           : sdivr  %p7/m %z27.d %z29.d -> %z27.d
 04d61fff : sdivr z31.d, p7/M, z31.d, z31.d           : sdivr  %p7/m %z31.d %z31.d -> %z31.d
 
+# SDOT    <Zda>.<T>, <Zn>.<Tb>, <Zm>.<Tb> (SDOT-Z.ZZZ-_)
+44800000 : sdot z0.s, z0.b, z0.b                     : sdot   %z0.s %z0.b %z0.b -> %z0.s
+44840062 : sdot z2.s, z3.b, z4.b                     : sdot   %z2.s %z3.b %z4.b -> %z2.s
+448600a4 : sdot z4.s, z5.b, z6.b                     : sdot   %z4.s %z5.b %z6.b -> %z4.s
+448800e6 : sdot z6.s, z7.b, z8.b                     : sdot   %z6.s %z7.b %z8.b -> %z6.s
+448a0128 : sdot z8.s, z9.b, z10.b                    : sdot   %z8.s %z9.b %z10.b -> %z8.s
+448c016a : sdot z10.s, z11.b, z12.b                  : sdot   %z10.s %z11.b %z12.b -> %z10.s
+448e01ac : sdot z12.s, z13.b, z14.b                  : sdot   %z12.s %z13.b %z14.b -> %z12.s
+449001ee : sdot z14.s, z15.b, z16.b                  : sdot   %z14.s %z15.b %z16.b -> %z14.s
+44920230 : sdot z16.s, z17.b, z18.b                  : sdot   %z16.s %z17.b %z18.b -> %z16.s
+44930251 : sdot z17.s, z18.b, z19.b                  : sdot   %z17.s %z18.b %z19.b -> %z17.s
+44950293 : sdot z19.s, z20.b, z21.b                  : sdot   %z19.s %z20.b %z21.b -> %z19.s
+449702d5 : sdot z21.s, z22.b, z23.b                  : sdot   %z21.s %z22.b %z23.b -> %z21.s
+44990317 : sdot z23.s, z24.b, z25.b                  : sdot   %z23.s %z24.b %z25.b -> %z23.s
+449b0359 : sdot z25.s, z26.b, z27.b                  : sdot   %z25.s %z26.b %z27.b -> %z25.s
+449d039b : sdot z27.s, z28.b, z29.b                  : sdot   %z27.s %z28.b %z29.b -> %z27.s
+449f03ff : sdot z31.s, z31.b, z31.b                  : sdot   %z31.s %z31.b %z31.b -> %z31.s
+44c00000 : sdot z0.d, z0.h, z0.h                     : sdot   %z0.d %z0.h %z0.h -> %z0.d
+44c40062 : sdot z2.d, z3.h, z4.h                     : sdot   %z2.d %z3.h %z4.h -> %z2.d
+44c600a4 : sdot z4.d, z5.h, z6.h                     : sdot   %z4.d %z5.h %z6.h -> %z4.d
+44c800e6 : sdot z6.d, z7.h, z8.h                     : sdot   %z6.d %z7.h %z8.h -> %z6.d
+44ca0128 : sdot z8.d, z9.h, z10.h                    : sdot   %z8.d %z9.h %z10.h -> %z8.d
+44cc016a : sdot z10.d, z11.h, z12.h                  : sdot   %z10.d %z11.h %z12.h -> %z10.d
+44ce01ac : sdot z12.d, z13.h, z14.h                  : sdot   %z12.d %z13.h %z14.h -> %z12.d
+44d001ee : sdot z14.d, z15.h, z16.h                  : sdot   %z14.d %z15.h %z16.h -> %z14.d
+44d20230 : sdot z16.d, z17.h, z18.h                  : sdot   %z16.d %z17.h %z18.h -> %z16.d
+44d30251 : sdot z17.d, z18.h, z19.h                  : sdot   %z17.d %z18.h %z19.h -> %z17.d
+44d50293 : sdot z19.d, z20.h, z21.h                  : sdot   %z19.d %z20.h %z21.h -> %z19.d
+44d702d5 : sdot z21.d, z22.h, z23.h                  : sdot   %z21.d %z22.h %z23.h -> %z21.d
+44d90317 : sdot z23.d, z24.h, z25.h                  : sdot   %z23.d %z24.h %z25.h -> %z23.d
+44db0359 : sdot z25.d, z26.h, z27.h                  : sdot   %z25.d %z26.h %z27.h -> %z25.d
+44dd039b : sdot z27.d, z28.h, z29.h                  : sdot   %z27.d %z28.h %z29.h -> %z27.d
+44df03ff : sdot z31.d, z31.h, z31.h                  : sdot   %z31.d %z31.h %z31.h -> %z31.d
+
+# SDOT    <Zda>.S, <Zn>.B, <Zm>.B[<imm>] (SDOT-Z.ZZZi-S)
+44a00000 : sdot z0.s, z0.b, z0.b[0]                  : sdot   %z0.s %z0.b %z0.b $0x00 -> %z0.s
+44a20062 : sdot z2.s, z3.b, z2.b[0]                  : sdot   %z2.s %z3.b %z2.b $0x00 -> %z2.s
+44a300a4 : sdot z4.s, z5.b, z3.b[0]                  : sdot   %z4.s %z5.b %z3.b $0x00 -> %z4.s
+44ab00e6 : sdot z6.s, z7.b, z3.b[1]                  : sdot   %z6.s %z7.b %z3.b $0x01 -> %z6.s
+44ac0128 : sdot z8.s, z9.b, z4.b[1]                  : sdot   %z8.s %z9.b %z4.b $0x01 -> %z8.s
+44ac016a : sdot z10.s, z11.b, z4.b[1]                : sdot   %z10.s %z11.b %z4.b $0x01 -> %z10.s
+44ad01ac : sdot z12.s, z13.b, z5.b[1]                : sdot   %z12.s %z13.b %z5.b $0x01 -> %z12.s
+44ad01ee : sdot z14.s, z15.b, z5.b[1]                : sdot   %z14.s %z15.b %z5.b $0x01 -> %z14.s
+44b60230 : sdot z16.s, z17.b, z6.b[2]                : sdot   %z16.s %z17.b %z6.b $0x02 -> %z16.s
+44b60251 : sdot z17.s, z18.b, z6.b[2]                : sdot   %z17.s %z18.b %z6.b $0x02 -> %z17.s
+44b60293 : sdot z19.s, z20.b, z6.b[2]                : sdot   %z19.s %z20.b %z6.b $0x02 -> %z19.s
+44b702d5 : sdot z21.s, z22.b, z7.b[2]                : sdot   %z21.s %z22.b %z7.b $0x02 -> %z21.s
+44b70317 : sdot z23.s, z24.b, z7.b[2]                : sdot   %z23.s %z24.b %z7.b $0x02 -> %z23.s
+44b00359 : sdot z25.s, z26.b, z0.b[2]                : sdot   %z25.s %z26.b %z0.b $0x02 -> %z25.s
+44b8039b : sdot z27.s, z28.b, z0.b[3]                : sdot   %z27.s %z28.b %z0.b $0x03 -> %z27.s
+44bf03ff : sdot z31.s, z31.b, z7.b[3]                : sdot   %z31.s %z31.b %z7.b $0x03 -> %z31.s
+
+# SDOT    <Zda>.D, <Zn>.H, <Zm>.H[<imm>] (SDOT-Z.ZZZi-D)
+44e00000 : sdot z0.d, z0.h, z0.h[0]                  : sdot   %z0.d %z0.h %z0.h $0x00 -> %z0.d
+44e30062 : sdot z2.d, z3.h, z3.h[0]                  : sdot   %z2.d %z3.h %z3.h $0x00 -> %z2.d
+44e400a4 : sdot z4.d, z5.h, z4.h[0]                  : sdot   %z4.d %z5.h %z4.h $0x00 -> %z4.d
+44e500e6 : sdot z6.d, z7.h, z5.h[0]                  : sdot   %z6.d %z7.h %z5.h $0x00 -> %z6.d
+44e60128 : sdot z8.d, z9.h, z6.h[0]                  : sdot   %z8.d %z9.h %z6.h $0x00 -> %z8.d
+44e7016a : sdot z10.d, z11.h, z7.h[0]                : sdot   %z10.d %z11.h %z7.h $0x00 -> %z10.d
+44e801ac : sdot z12.d, z13.h, z8.h[0]                : sdot   %z12.d %z13.h %z8.h $0x00 -> %z12.d
+44e901ee : sdot z14.d, z15.h, z9.h[0]                : sdot   %z14.d %z15.h %z9.h $0x00 -> %z14.d
+44ea0230 : sdot z16.d, z17.h, z10.h[0]               : sdot   %z16.d %z17.h %z10.h $0x00 -> %z16.d
+44fa0251 : sdot z17.d, z18.h, z10.h[1]               : sdot   %z17.d %z18.h %z10.h $0x01 -> %z17.d
+44fb0293 : sdot z19.d, z20.h, z11.h[1]               : sdot   %z19.d %z20.h %z11.h $0x01 -> %z19.d
+44fc02d5 : sdot z21.d, z22.h, z12.h[1]               : sdot   %z21.d %z22.h %z12.h $0x01 -> %z21.d
+44fd0317 : sdot z23.d, z24.h, z13.h[1]               : sdot   %z23.d %z24.h %z13.h $0x01 -> %z23.d
+44fe0359 : sdot z25.d, z26.h, z14.h[1]               : sdot   %z25.d %z26.h %z14.h $0x01 -> %z25.d
+44ff039b : sdot z27.d, z28.h, z15.h[1]               : sdot   %z27.d %z28.h %z15.h $0x01 -> %z27.d
+44ff03ff : sdot z31.d, z31.h, z15.h[1]               : sdot   %z31.d %z31.h %z15.h $0x01 -> %z31.d
+
 # SEL     <Zd>.<T>, <Pv>, <Zn>.<T>, <Zm>.<T> (SEL-Z.P.ZZ-_)
 0520c000 : sel z0.b, p0, z0.b, z0.b                  : sel    %p0 %z0.b %z0.b -> %z0.b
 0525c882 : sel z2.b, p2, z4.b, z5.b                  : sel    %p2 %z4.b %z5.b -> %z2.b
@@ -23330,6 +23400,76 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 04d71f79 : udivr z25.d, p7/M, z25.d, z27.d           : udivr  %p7/m %z25.d %z27.d -> %z25.d
 04d71fbb : udivr z27.d, p7/M, z27.d, z29.d           : udivr  %p7/m %z27.d %z29.d -> %z27.d
 04d71fff : udivr z31.d, p7/M, z31.d, z31.d           : udivr  %p7/m %z31.d %z31.d -> %z31.d
+
+# UDOT    <Zda>.<T>, <Zn>.<Tb>, <Zm>.<Tb> (UDOT-Z.ZZZ-_)
+44800400 : udot z0.s, z0.b, z0.b                     : udot   %z0.s %z0.b %z0.b -> %z0.s
+44840462 : udot z2.s, z3.b, z4.b                     : udot   %z2.s %z3.b %z4.b -> %z2.s
+448604a4 : udot z4.s, z5.b, z6.b                     : udot   %z4.s %z5.b %z6.b -> %z4.s
+448804e6 : udot z6.s, z7.b, z8.b                     : udot   %z6.s %z7.b %z8.b -> %z6.s
+448a0528 : udot z8.s, z9.b, z10.b                    : udot   %z8.s %z9.b %z10.b -> %z8.s
+448c056a : udot z10.s, z11.b, z12.b                  : udot   %z10.s %z11.b %z12.b -> %z10.s
+448e05ac : udot z12.s, z13.b, z14.b                  : udot   %z12.s %z13.b %z14.b -> %z12.s
+449005ee : udot z14.s, z15.b, z16.b                  : udot   %z14.s %z15.b %z16.b -> %z14.s
+44920630 : udot z16.s, z17.b, z18.b                  : udot   %z16.s %z17.b %z18.b -> %z16.s
+44930651 : udot z17.s, z18.b, z19.b                  : udot   %z17.s %z18.b %z19.b -> %z17.s
+44950693 : udot z19.s, z20.b, z21.b                  : udot   %z19.s %z20.b %z21.b -> %z19.s
+449706d5 : udot z21.s, z22.b, z23.b                  : udot   %z21.s %z22.b %z23.b -> %z21.s
+44990717 : udot z23.s, z24.b, z25.b                  : udot   %z23.s %z24.b %z25.b -> %z23.s
+449b0759 : udot z25.s, z26.b, z27.b                  : udot   %z25.s %z26.b %z27.b -> %z25.s
+449d079b : udot z27.s, z28.b, z29.b                  : udot   %z27.s %z28.b %z29.b -> %z27.s
+449f07ff : udot z31.s, z31.b, z31.b                  : udot   %z31.s %z31.b %z31.b -> %z31.s
+44c00400 : udot z0.d, z0.h, z0.h                     : udot   %z0.d %z0.h %z0.h -> %z0.d
+44c40462 : udot z2.d, z3.h, z4.h                     : udot   %z2.d %z3.h %z4.h -> %z2.d
+44c604a4 : udot z4.d, z5.h, z6.h                     : udot   %z4.d %z5.h %z6.h -> %z4.d
+44c804e6 : udot z6.d, z7.h, z8.h                     : udot   %z6.d %z7.h %z8.h -> %z6.d
+44ca0528 : udot z8.d, z9.h, z10.h                    : udot   %z8.d %z9.h %z10.h -> %z8.d
+44cc056a : udot z10.d, z11.h, z12.h                  : udot   %z10.d %z11.h %z12.h -> %z10.d
+44ce05ac : udot z12.d, z13.h, z14.h                  : udot   %z12.d %z13.h %z14.h -> %z12.d
+44d005ee : udot z14.d, z15.h, z16.h                  : udot   %z14.d %z15.h %z16.h -> %z14.d
+44d20630 : udot z16.d, z17.h, z18.h                  : udot   %z16.d %z17.h %z18.h -> %z16.d
+44d30651 : udot z17.d, z18.h, z19.h                  : udot   %z17.d %z18.h %z19.h -> %z17.d
+44d50693 : udot z19.d, z20.h, z21.h                  : udot   %z19.d %z20.h %z21.h -> %z19.d
+44d706d5 : udot z21.d, z22.h, z23.h                  : udot   %z21.d %z22.h %z23.h -> %z21.d
+44d90717 : udot z23.d, z24.h, z25.h                  : udot   %z23.d %z24.h %z25.h -> %z23.d
+44db0759 : udot z25.d, z26.h, z27.h                  : udot   %z25.d %z26.h %z27.h -> %z25.d
+44dd079b : udot z27.d, z28.h, z29.h                  : udot   %z27.d %z28.h %z29.h -> %z27.d
+44df07ff : udot z31.d, z31.h, z31.h                  : udot   %z31.d %z31.h %z31.h -> %z31.d
+
+# UDOT    <Zda>.S, <Zn>.B, <Zm>.B[<imm>] (UDOT-Z.ZZZi-S)
+44a00400 : udot z0.s, z0.b, z0.b[0]                  : udot   %z0.s %z0.b %z0.b $0x00 -> %z0.s
+44a20462 : udot z2.s, z3.b, z2.b[0]                  : udot   %z2.s %z3.b %z2.b $0x00 -> %z2.s
+44a304a4 : udot z4.s, z5.b, z3.b[0]                  : udot   %z4.s %z5.b %z3.b $0x00 -> %z4.s
+44ab04e6 : udot z6.s, z7.b, z3.b[1]                  : udot   %z6.s %z7.b %z3.b $0x01 -> %z6.s
+44ac0528 : udot z8.s, z9.b, z4.b[1]                  : udot   %z8.s %z9.b %z4.b $0x01 -> %z8.s
+44ac056a : udot z10.s, z11.b, z4.b[1]                : udot   %z10.s %z11.b %z4.b $0x01 -> %z10.s
+44ad05ac : udot z12.s, z13.b, z5.b[1]                : udot   %z12.s %z13.b %z5.b $0x01 -> %z12.s
+44ad05ee : udot z14.s, z15.b, z5.b[1]                : udot   %z14.s %z15.b %z5.b $0x01 -> %z14.s
+44b60630 : udot z16.s, z17.b, z6.b[2]                : udot   %z16.s %z17.b %z6.b $0x02 -> %z16.s
+44b60651 : udot z17.s, z18.b, z6.b[2]                : udot   %z17.s %z18.b %z6.b $0x02 -> %z17.s
+44b60693 : udot z19.s, z20.b, z6.b[2]                : udot   %z19.s %z20.b %z6.b $0x02 -> %z19.s
+44b706d5 : udot z21.s, z22.b, z7.b[2]                : udot   %z21.s %z22.b %z7.b $0x02 -> %z21.s
+44b70717 : udot z23.s, z24.b, z7.b[2]                : udot   %z23.s %z24.b %z7.b $0x02 -> %z23.s
+44b00759 : udot z25.s, z26.b, z0.b[2]                : udot   %z25.s %z26.b %z0.b $0x02 -> %z25.s
+44b8079b : udot z27.s, z28.b, z0.b[3]                : udot   %z27.s %z28.b %z0.b $0x03 -> %z27.s
+44bf07ff : udot z31.s, z31.b, z7.b[3]                : udot   %z31.s %z31.b %z7.b $0x03 -> %z31.s
+
+# UDOT    <Zda>.D, <Zn>.H, <Zm>.H[<imm>] (UDOT-Z.ZZZi-D)
+44e00400 : udot z0.d, z0.h, z0.h[0]                  : udot   %z0.d %z0.h %z0.h $0x00 -> %z0.d
+44e30462 : udot z2.d, z3.h, z3.h[0]                  : udot   %z2.d %z3.h %z3.h $0x00 -> %z2.d
+44e404a4 : udot z4.d, z5.h, z4.h[0]                  : udot   %z4.d %z5.h %z4.h $0x00 -> %z4.d
+44e504e6 : udot z6.d, z7.h, z5.h[0]                  : udot   %z6.d %z7.h %z5.h $0x00 -> %z6.d
+44e60528 : udot z8.d, z9.h, z6.h[0]                  : udot   %z8.d %z9.h %z6.h $0x00 -> %z8.d
+44e7056a : udot z10.d, z11.h, z7.h[0]                : udot   %z10.d %z11.h %z7.h $0x00 -> %z10.d
+44e805ac : udot z12.d, z13.h, z8.h[0]                : udot   %z12.d %z13.h %z8.h $0x00 -> %z12.d
+44e905ee : udot z14.d, z15.h, z9.h[0]                : udot   %z14.d %z15.h %z9.h $0x00 -> %z14.d
+44ea0630 : udot z16.d, z17.h, z10.h[0]               : udot   %z16.d %z17.h %z10.h $0x00 -> %z16.d
+44fa0651 : udot z17.d, z18.h, z10.h[1]               : udot   %z17.d %z18.h %z10.h $0x01 -> %z17.d
+44fb0693 : udot z19.d, z20.h, z11.h[1]               : udot   %z19.d %z20.h %z11.h $0x01 -> %z19.d
+44fc06d5 : udot z21.d, z22.h, z12.h[1]               : udot   %z21.d %z22.h %z12.h $0x01 -> %z21.d
+44fd0717 : udot z23.d, z24.h, z13.h[1]               : udot   %z23.d %z24.h %z13.h $0x01 -> %z23.d
+44fe0759 : udot z25.d, z26.h, z14.h[1]               : udot   %z25.d %z26.h %z14.h $0x01 -> %z25.d
+44ff079b : udot z27.d, z28.h, z15.h[1]               : udot   %z27.d %z28.h %z15.h $0x01 -> %z27.d
+44ff07ff : udot z31.d, z31.h, z15.h[1]               : udot   %z31.d %z31.h %z15.h $0x01 -> %z31.d
 
 # UMAX    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (UMAX-Z.P.ZZ-_)
 04090000 : umax z0.b, p0/M, z0.b, z0.b               : umax   %p0/m %z0.b %z0.b -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -20075,6 +20075,132 @@ TEST_INSTR(trn2_sve)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
+TEST_INSTR(sdot_sve)
+{
+    /* Testing SDOT    <Zda>.<Ts>, <Zn>.<Tb>, <Zm>.<Tb> */
+    const char *const expected_0_0[6] = {
+        "sdot   %z0.s %z0.b %z0.b -> %z0.s",     "sdot   %z5.s %z6.b %z7.b -> %z5.s",
+        "sdot   %z10.s %z11.b %z12.b -> %z10.s", "sdot   %z16.s %z17.b %z18.b -> %z16.s",
+        "sdot   %z21.s %z22.b %z23.b -> %z21.s", "sdot   %z31.s %z31.b %z31.b -> %z31.s",
+    };
+    TEST_LOOP(sdot, sdot_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "sdot   %z0.d %z0.h %z0.h -> %z0.d",     "sdot   %z5.d %z6.h %z7.h -> %z5.d",
+        "sdot   %z10.d %z11.h %z12.h -> %z10.d", "sdot   %z16.d %z17.h %z18.h -> %z16.d",
+        "sdot   %z21.d %z22.h %z23.h -> %z21.d", "sdot   %z31.d %z31.h %z31.h -> %z31.d",
+    };
+    TEST_LOOP(sdot, sdot_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+}
+
+TEST_INSTR(sdot_sve_idx)
+{
+    /* Testing SDOT    <Zda>.D, <Zn>.H, <Zm>.H[<index>] */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z4,  DR_REG_Z7,
+                                        DR_REG_Z10, DR_REG_Z12, DR_REG_Z15 };
+    static const uint i1_0_0[6] = { 0, 1, 1, 1, 0, 1 };
+    const char *const expected_0_0[6] = {
+        "sdot   %z0.d %z0.h %z0.h $0x00 -> %z0.d",
+        "sdot   %z5.d %z6.h %z4.h $0x01 -> %z5.d",
+        "sdot   %z10.d %z11.h %z7.h $0x01 -> %z10.d",
+        "sdot   %z16.d %z17.h %z10.h $0x01 -> %z16.d",
+        "sdot   %z21.d %z22.h %z12.h $0x00 -> %z21.d",
+        "sdot   %z31.d %z31.h %z15.h $0x01 -> %z31.d",
+    };
+    TEST_LOOP(sdot, sdot_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_immed_uint(i1_0_0[i], OPSZ_1b));
+
+    /* Testing SDOT    <Zda>.S, <Zn>.B, <Zm>.B[<index>] */
+    static const reg_id_t Zm_1_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_1_0[6] = { 0, 3, 0, 1, 1, 3 };
+    const char *const expected_1_0[6] = {
+        "sdot   %z0.s %z0.b %z0.b $0x00 -> %z0.s",
+        "sdot   %z5.s %z6.b %z3.b $0x03 -> %z5.s",
+        "sdot   %z10.s %z11.b %z4.b $0x00 -> %z10.s",
+        "sdot   %z16.s %z17.b %z6.b $0x01 -> %z16.s",
+        "sdot   %z21.s %z22.b %z7.b $0x01 -> %z21.s",
+        "sdot   %z31.s %z31.b %z7.b $0x03 -> %z31.s",
+    };
+    TEST_LOOP(sdot, sdot_sve_idx, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zm_1_0[i], OPSZ_1),
+              opnd_create_immed_uint(i2_1_0[i], OPSZ_2b));
+}
+
+TEST_INSTR(udot_sve)
+{
+    /* Testing UDOT    <Zda>.<Ts>, <Zn>.<Tb>, <Zm>.<Tb> */
+    const char *const expected_0_0[6] = {
+        "udot   %z0.s %z0.b %z0.b -> %z0.s",     "udot   %z5.s %z6.b %z7.b -> %z5.s",
+        "udot   %z10.s %z11.b %z12.b -> %z10.s", "udot   %z16.s %z17.b %z18.b -> %z16.s",
+        "udot   %z21.s %z22.b %z23.b -> %z21.s", "udot   %z31.s %z31.b %z31.b -> %z31.s",
+    };
+    TEST_LOOP(udot, udot_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "udot   %z0.d %z0.h %z0.h -> %z0.d",     "udot   %z5.d %z6.h %z7.h -> %z5.d",
+        "udot   %z10.d %z11.h %z12.h -> %z10.d", "udot   %z16.d %z17.h %z18.h -> %z16.d",
+        "udot   %z21.d %z22.h %z23.h -> %z21.d", "udot   %z31.d %z31.h %z31.h -> %z31.d",
+    };
+    TEST_LOOP(udot, udot_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+}
+
+TEST_INSTR(udot_sve_idx)
+{
+    /* Testing UDOT    <Zda>.D, <Zn>.H, <Zm>.H[<index>] */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z4,  DR_REG_Z7,
+                                        DR_REG_Z10, DR_REG_Z12, DR_REG_Z15 };
+    static const uint i1_0_0[6] = { 0, 1, 1, 1, 0, 1 };
+    const char *const expected_0_0[6] = {
+        "udot   %z0.d %z0.h %z0.h $0x00 -> %z0.d",
+        "udot   %z5.d %z6.h %z4.h $0x01 -> %z5.d",
+        "udot   %z10.d %z11.h %z7.h $0x01 -> %z10.d",
+        "udot   %z16.d %z17.h %z10.h $0x01 -> %z16.d",
+        "udot   %z21.d %z22.h %z12.h $0x00 -> %z21.d",
+        "udot   %z31.d %z31.h %z15.h $0x01 -> %z31.d",
+    };
+    TEST_LOOP(udot, udot_sve_idx, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_immed_uint(i1_0_0[i], OPSZ_1b));
+
+    /* Testing UDOT    <Zda>.S, <Zn>.B, <Zm>.B[<index>] */
+    static const reg_id_t Zm_1_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_1_0[6] = { 0, 3, 0, 1, 1, 3 };
+    const char *const expected_1_0[6] = {
+        "udot   %z0.s %z0.b %z0.b $0x00 -> %z0.s",
+        "udot   %z5.s %z6.b %z3.b $0x03 -> %z5.s",
+        "udot   %z10.s %z11.b %z4.b $0x00 -> %z10.s",
+        "udot   %z16.s %z17.b %z6.b $0x01 -> %z16.s",
+        "udot   %z21.s %z22.b %z7.b $0x01 -> %z21.s",
+        "udot   %z31.s %z31.b %z7.b $0x03 -> %z31.s",
+    };
+    TEST_LOOP(udot, udot_sve_idx, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zm_1_0[i], OPSZ_1),
+              opnd_create_immed_uint(i2_1_0[i], OPSZ_2b));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -20579,6 +20705,11 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(trn1_sve);
     RUN_INSTR_TEST(trn2_sve);
+
+    RUN_INSTR_TEST(sdot_sve);
+    RUN_INSTR_TEST(sdot_sve_idx);
+    RUN_INSTR_TEST(udot_sve);
+    RUN_INSTR_TEST(udot_sve_idx);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
SDOT    <Zda>.<Ts>, <Zn>.<Tb>, <Zm>.<Tb>
SDOT    <Zda>.D, <Zn>.H, <Zm>.H[<index>]
SDOT    <Zda>.S, <Zn>.B, <Zm>.B[<index>]
UDOT    <Zda>.<Ts>, <Zn>.<Tb>, <Zm>.<Tb>
UDOT    <Zda>.D, <Zn>.H, <Zm>.H[<index>]
UDOT    <Zda>.S, <Zn>.B, <Zm>.B[<index>]
```

Issue: #3044