### PR TITLE
iX: Add native aarch64 test workflow

### DIFF
--- a/.github/workflows/ci-aarch64-native.yml
+++ b/.github/workflows/ci-aarch64-native.yml
@@ -1,0 +1,103 @@
+# **********************************************************
+# Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
+# Copyright (c) 2023 Arm Limited        All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of Google, Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# Github Actions workflow for aarch64 Continuous Integration testing.
+
+name: ci-aarch64-native
+
+on:
+  # Run on pushes to master and on pull request changes, including from a
+  # forked repo with no "push" trigger, while avoiding duplicate triggers.
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+  merge_group:
+
+  workflow_dispatch:
+
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: [self-hosted, linux, ARM64]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      # Cancel any prior runs for a PR (but do not cancel master branch runs).
+      - name: Cancel previous runs
+        uses: n1hility/cancel-previous-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'pull_request' }}
+
+      # We also need origin/master for pre-commit source file checks in runsuite.cmake.
+      # But fetching multiple branches isn't supported yet: actions/checkout#214
+      # Pending PR that adds this support actions/checkout#155
+      # TODO i#4549: When necessary support is available, remove/replace the
+      # workaround here and from every job in other Github Actions CI workflows.
+      - name: Fetch master
+        run: git fetch --no-tags --depth=1 origin master
+
+      - name: Create build directory
+        run: mkdir build
+
+      - name: Run Suite
+        working-directory: build
+        run: ../suite/runsuite_wrapper.pl travis
+        env:
+          CI_BRANCH: ${{ github.ref }}
+
+      - name: Send failure mail to dynamorio-devs
+        if: failure() && github.ref == 'refs/heads/master'
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+          password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+          subject: |
+            [${{github.repository}}] ${{github.workflow}} FAILED
+            on ${{github.event_name}} at ${{github.ref}}
+          body: |
+            Github Actions CI workflow run FAILED!
+            Workflow: ${{github.workflow}}/x86-32
+            Repository: ${{github.repository}}
+            Branch ref: ${{github.ref}}
+            SHA: ${{github.sha}}
+            Triggering actor: ${{github.actor}}
+            Triggering event: ${{github.event_name}}
+            Run Id: ${{github.run_id}}
+            See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+          to: dynamorio-devs@googlegroups.com
+          from: Github Action CI


### PR DESCRIPTION
Adds test workflow running on self-hosted aarch64 runner, as these are not currently available from Github.
This will replace tests triggered on external Jenkins instance.