### PR TITLE
i#6000 AArch64: Fix INSTR_CREATE macros which use 0 for enums

### DIFF
--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -756,10 +756,10 @@
  * \param Rn   The input register containing the virtual address to use.
  *             No alignment restrictions apply to this VA.
  */
-#define INSTR_CREATE_dc_civac(dc, Rn)                                                   \
-    instr_create_0dst_1src(dc, OP_dc_civac,                                             \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         0, false, 0, 0, OPSZ_sys))
+#define INSTR_CREATE_dc_civac(dc, Rn) \
+    instr_create_0dst_1src(           \
+        dc, OP_dc_civac,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates a DC CSW instruction to Clean data cache line by Set/Way.
@@ -776,10 +776,10 @@
  * \param Rn   The input register containing the virtual address to use.
  *             No alignment restrictions apply to this VA.
  */
-#define INSTR_CREATE_dc_cvac(dc, Rn)                                                    \
-    instr_create_0dst_1src(dc, OP_dc_cvac,                                              \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         0, false, 0, 0, OPSZ_sys))
+#define INSTR_CREATE_dc_cvac(dc, Rn) \
+    instr_create_0dst_1src(          \
+        dc, OP_dc_cvac,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates a DC CVAU instruction to Clean data cache by Virtual Address to
@@ -788,10 +788,10 @@
  * \param Rn   The input register containing the virtual address to use.
  *             No alignment restrictions apply to this VA.
  */
-#define INSTR_CREATE_dc_cvau(dc, Rn)                                                    \
-    instr_create_0dst_1src(dc, OP_dc_cvau,                                              \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         0, false, 0, 0, OPSZ_sys))
+#define INSTR_CREATE_dc_cvau(dc, Rn) \
+    instr_create_0dst_1src(          \
+        dc, OP_dc_cvau,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates a DC ISW instruction to Invalidate data cache line by Set/Way.
@@ -808,11 +808,10 @@
  * \param Rn   The input register containing the virtual address to use.
  *             No alignment restrictions apply to this VA.
  */
-#define INSTR_CREATE_dc_ivac(dc, Rn)                                                    \
-    instr_create_0dst_1src(dc, OP_dc_ivac,                                              \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         DR_EXTEND_DEFAULT, false, 0,   \
-                                                         DR_OPND_DEFAULT, OPSZ_sys))
+#define INSTR_CREATE_dc_ivac(dc, Rn) \
+    instr_create_0dst_1src(          \
+        dc, OP_dc_ivac,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates a DC ZVA instruction to Zero data cache by Virtual Address.
@@ -823,10 +822,10 @@
  *             There is no alignment restriction on the address within the
  *             block of N bytes that is used.
  */
-#define INSTR_CREATE_dc_zva(dc, Rn)                                                     \
-    instr_create_1dst_0src(dc, OP_dc_zva,                                               \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         0, false, 0, 0, OPSZ_sys))
+#define INSTR_CREATE_dc_zva(dc, Rn) \
+    instr_create_1dst_0src(         \
+        dc, OP_dc_zva,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates an IC IVAU instruction to Invalidate instruction cache line by
@@ -835,10 +834,10 @@
  * \param Rn   The input register containing the virtual address to use.
  *             No alignment restrictions apply to this VA.
  */
-#define INSTR_CREATE_ic_ivau(dc, Rn)                                                    \
-    instr_create_0dst_1src(dc, OP_ic_ivau,                                              \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         0, false, 0, 0, OPSZ_sys))
+#define INSTR_CREATE_ic_ivau(dc, Rn) \
+    instr_create_0dst_1src(          \
+        dc, OP_ic_ivau,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates an IC IALLU instruction to Invalidate All of instruction caches
@@ -14127,10 +14126,10 @@
  * \param Rn   The input register containing the virtual address to use.
  *             No alignment restrictions apply to this VA.
  */
-#define INSTR_CREATE_dc_cvap(dc, Rn)                                                    \
-    instr_create_0dst_1src(dc, OP_dc_cvap,                                              \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         0, false, 0, 0, OPSZ_sys))
+#define INSTR_CREATE_dc_cvap(dc, Rn) \
+    instr_create_0dst_1src(          \
+        dc, OP_dc_cvap,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates a DC CVADP instruction.
@@ -14139,10 +14138,10 @@
  * \param Rn   The input register containing the virtual address to use.
  *             No alignment restrictions apply to this VA.
  */
-#define INSTR_CREATE_dc_cvadp(dc, Rn)                                                   \
-    instr_create_0dst_1src(dc, OP_dc_cvadp,                                             \
-                           opnd_create_base_disp_aarch64(opnd_get_reg(Rn), DR_REG_NULL, \
-                                                         0, false, 0, 0, OPSZ_sys))
+#define INSTR_CREATE_dc_cvadp(dc, Rn) \
+    instr_create_0dst_1src(           \
+        dc, OP_dc_cvadp,              \
+        opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
  * Creates a TRN1 instruction.


### PR DESCRIPTION
Some INSTR_CREATE macros which use opnd_create_base_disp_aarch64() pass in 0 for the dr_extend_type_t and/or dr_opnd_flags_t parameters. The implicit conversion from int to enum fails when such macros are used in C++ source. This patch replaces addressing with the simpler generic opnd_create_base_disp() to avoid using dr_extend_type_t and dr_opnd_flags_t parameters.

Issue: #6000