### PR TITLE
i#3044 Add DR_REG member for SVE First-Fault Register

### DIFF
--- a/core/ir/aarch64/encode.c
+++ b/core/ir/aarch64/encode.c
@@ -116,6 +116,7 @@ const char *const reg_names[] = {
 
     "p0",  "p1",  "p2",  "p3",  "p4",  "p5",  "p6",  "p7",  "p8",  "p9",
     "p10", "p11", "p12", "p13", "p14", "p15",
+    "ffr",
 
     "cntvct_el0",
 };
@@ -191,6 +192,7 @@ const reg_id_t dr_reg_fixer[] = { REG_NULL,
     DR_REG_P0, DR_REG_P1, DR_REG_P2, DR_REG_P3, DR_REG_P4, DR_REG_P5,
     DR_REG_P6, DR_REG_P7, DR_REG_P8, DR_REG_P9, DR_REG_P10, DR_REG_P11,
     DR_REG_P12, DR_REG_P13, DR_REG_P14, DR_REG_P15,
+    DR_REG_FFR,
 
     DR_REG_CNTVCT_EL0,
 };

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1038,6 +1038,8 @@ enum {
     DR_REG_P13, /**< The "p13" register. */
     DR_REG_P14, /**< The "p14" register. */
     DR_REG_P15, /**< The "p15" register. */
+
+    DR_REG_FFR, /**< The SVE First-Fault Register. */
 #    endif
 
 #    ifdef AARCH64

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2761,7 +2761,7 @@ reg_get_size(reg_id_t reg)
         return OPSZ_8;
     if (reg >= DR_REG_Z0 && reg <= DR_REG_Z31)
         return OPSZ_SCALABLE;
-    if (reg >= DR_REG_P0 && reg <= DR_REG_P15)
+    if ((reg >= DR_REG_P0 && reg <= DR_REG_P15) || reg == DR_REG_FFR)
         return OPSZ_SCALABLE_PRED;
     if (reg == DR_REG_CNTVCT_EL0)
         return OPSZ_8;


### PR DESCRIPTION
Add a new DR_REG_FFR member to the DR_REG enum to represent the SVE First-Fault Register.

Issue: #3044