### PR TITLE
i#3044 AArch64 SVE codec: Update old AND, BIC, EOR and ORR encodings

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -90,7 +90,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.93.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -102,7 +102,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.93.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -194,7 +194,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.93.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -282,7 +282,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.93.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -370,7 +370,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.93.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -450,7 +450,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=9.93.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -535,7 +535,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER="9.92.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export VERSION_NUMBER="9.93.$((`git log -n 1 --format=%ct` / (60*60*24)))"
           export PREFIX="cronbuild-"
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -567,7 +567,7 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 
 # N.B.: When updating this, update all the default versions in ci-package.yml
 # and ci-docs.yml.  We should find a way to share (xref i#1565).
-set(VERSION_NUMBER_DEFAULT "9.92.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "9.93.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -162,6 +162,10 @@ changes:
    the actual interrupted PC); changed the interrupted PC for #DR_XFER_SIGNAL_DELIVERY
    for a signal generated during an rseq region to be the abort handler, matching the
    kernel behavior.
+ - Changed the arguments and decode behavior of the INSTR_CREATE_orr_sve_pred(),
+   INSTR_CREATE_eor_sve_pred(), INSTR_CREATE_and_sve_pred() and
+   INSTR_CREATE_bic_sve_pred() to use the new vector element registers and to
+   correctly encode the predicate mode.
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -53,6 +53,7 @@
 00000101100000xxxxxxxxxxxxxxxxxx  n   21   SVE      and  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010000xxxx01xxxx0xxxx0xxxx  n   21   SVE      and          p_b_0 : p10_zer p_b_5 p_b_16
 00000100001xxxxx001100xxxxxxxxxx  n   21   SVE      and          z_d_0 : z_d_5 z_d_16
+00000100xx011010000xxxxxxxxxxxxx  n   21   SVE      and  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 001001010100xxxx01xxxx0xxxx0xxxx  w   22   SVE     ands          p_b_0 : p10_zer p_b_5 p_b_16
 0000010000011010001xxxxxxxxxxxxx  n   915  SVE     andv             b0 : p10_lo z_size_bhsd_5
 0000010001011010001xxxxxxxxxxxxx  n   915  SVE     andv             h0 : p10_lo z_size_bhsd_5
@@ -76,6 +77,7 @@
 00000100xx011011000xxxxxxxxxxxxx  n   29   SVE      bic             z0 : p10_lo z0 z5 bhsd_sz
 001001010000xxxx01xxxx0xxxx1xxxx  n   29   SVE      bic          p_b_0 : p10_zer p_b_5 p_b_16
 00000100111xxxxx001100xxxxxxxxxx  n   29   SVE      bic          z_d_0 : z_d_5 z_d_16
+00000100xx011011000xxxxxxxxxxxxx  n   29   SVE      bic  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 001001010100xxxx01xxxx0xxxx1xxxx  w   30   SVE     bics          p_b_0 : p10_zer p_b_5 p_b_16
 001001010001000001xxxx0xxxx0xxxx  n   867  SVE     brka          p_b_0 : p10_zer p_b_5
 001001010001000001xxxx0xxxx1xxxx  n   867  SVE     brka          p_b_0 : p10_mrg p_b_5
@@ -154,6 +156,7 @@
 00000101010000xxxxxxxxxxxxxxxxxx  n   90   SVE      eor  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001010000xxxx01xxxx1xxxx0xxxx  n   90   SVE      eor          p_b_0 : p10_zer p_b_5 p_b_16
 00000100101xxxxx001100xxxxxxxxxx  n   90   SVE      eor          z_d_0 : z_d_5 z_d_16
+00000100xx011001000xxxxxxxxxxxxx  n   90   SVE      eor  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 001001010100xxxx01xxxx1xxxx0xxxx  w   828  SVE     eors          p_b_0 : p10_zer p_b_5 p_b_16
 0000010000011001001xxxxxxxxxxxxx  n   916  SVE     eorv             b0 : p10_lo z_size_bhsd_5
 0000010001011001001xxxxxxxxxxxxx  n   916  SVE     eorv             h0 : p10_lo z_size_bhsd_5
@@ -545,6 +548,7 @@
 00000101000000xxxxxxxxxxxxxxxxxx  n   327  SVE      orr  z_imm13_bhsd_0 : z_imm13_bhsd_0 imm13_const
 001001011000xxxx01xxxx0xxxx0xxxx  n   327  SVE      orr          p_b_0 : p10_zer p_b_5 p_b_16
 00000100011xxxxx001100xxxxxxxxxx  n   327  SVE      orr          z_d_0 : z_d_5 z_d_16
+00000100xx011000000xxxxxxxxxxxxx  n   327  SVE      orr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 001001011100xxxx01xxxx0xxxx0xxxx  w   834  SVE     orrs          p_b_0 : p10_zer p_b_5 p_b_16
 0000010000011000001xxxxxxxxxxxxx  n   919  SVE      orv             b0 : p10_lo z_size_bhsd_5
 0000010001011000001xxxxxxxxxxxxx  n   919  SVE      orv             h0 : p10_lo z_size_bhsd_5
@@ -753,10 +757,10 @@
 00000101xx1xxxxx001100xxxxxxxxxx  n   490  SVE      tbl  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
 00000101xx10xxxx0101000xxxx0xxxx  n   494  SVE     trn1  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011100xxxxxxxxxx  n   494  SVE     trn1  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
-00000101101xxxxx000110xxxxxxxxxx  n   494  F64MM   trn1          z_q_0 : z_q_5 z_q_16
+00000101101xxxxx000110xxxxxxxxxx  n   494  F64MM    trn1          z_q_0 : z_q_5 z_q_16
 00000101xx10xxxx0101010xxxx0xxxx  n   495  SVE     trn2  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011101xxxxxxxxxx  n   495  SVE     trn2  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
-00000101101xxxxx000111xxxxxxxxxx  n   495  F64MM   trn2          z_q_0 : z_q_5 z_q_16
+00000101101xxxxx000111xxxxxxxxxx  n   495  F64MM    trn2          z_q_0 : z_q_5 z_q_16
 00000100xx001101000xxxxxxxxxxxxx  n   499  SVE     uabd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx000001001xxxxxxxxxxxxx  n   921  SVE    uaddv             d0 : p10_lo z_size_bhsd_5
 0110010101010011101xxxxxxxxxxxxx  n   510  SVE    ucvtf          z_h_0 : p10_mrg_lo z_h_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -5255,56 +5255,64 @@
 /* -------- SVE bitwise logical operations (predicated) ---------------- */
 
 /**
- * Creates an ORR scalable vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Zd      The output SVE vector register.
- * \param Pg      Predicate register for predicated instruction, P0-P7.
- * \param Zd_     The first input SVE vector register. Must match Zd.
- * \param Zm      The second input SVE vector register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
- *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * Creates an ORR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ORR     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zm   The second source vector register, Z (Scalable).
  */
-#define INSTR_CREATE_orr_sve_pred(dc, Zd, Pg, Zd_, Zm, width) \
-    instr_create_1dst_4src(dc, OP_orr, Zd, Pg, Zd_, Zm, width)
+#define INSTR_CREATE_orr_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_orr, Zdn, Pg, Zdn, Zm)
 
 /**
- * Creates an EOR scalable vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Zd      The output SVE vector register.
- * \param Pg      Predicate register for predicated instruction, P0-P7.
- * \param Zd_     The first input SVE vector register. Must match Zd.
- * \param Zm      The second input SVE vector register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
- *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * Creates an EOR instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    EOR     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zm   The second source vector register, Z (Scalable).
  */
-#define INSTR_CREATE_eor_sve_pred(dc, Zd, Pg, Zd_, Zm, width) \
-    instr_create_1dst_4src(dc, OP_eor, Zd, Pg, Zd_, Zm, width)
+#define INSTR_CREATE_eor_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_eor, Zdn, Pg, Zdn, Zm)
 
 /**
- * Creates an AND scalable vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Zd      The output SVE vector register.
- * \param Pg      Predicate register for predicated instruction, P0-P7.
- * \param Zd_     The first input SVE vector register. Must match Zd.
- * \param Zm      The second input SVE vector register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
- *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * Creates an AND instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    AND     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zm   The second source vector register, Z (Scalable).
  */
-#define INSTR_CREATE_and_sve_pred(dc, Zd, Pg, Zd_, Zm, width) \
-    instr_create_1dst_4src(dc, OP_and, Zd, Pg, Zd_, Zm, width)
+#define INSTR_CREATE_and_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_and, Zdn, Pg, Zdn, Zm)
 
 /**
- * Creates a BIC scalable vector instruction.
- * \param dc      The void * dcontext used to allocate memory for the instr_t.
- * \param Zd      The output SVE vector register.
- * \param Pg      Predicate register for predicated instruction, P0-P7.
- * \param Zd_     The first input SVE vector register. Must match Zd.
- * \param Zm      The second input SVE vector register.
- * \param width   The vector element width. Use either OPND_CREATE_BYTE(),
- *                OPND_CREATE_HALF(), OPND_CREATE_SINGLE() or OPND_CREATE_DOUBLE().
+ * Creates a BIC instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BIC     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zdn   The first source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zm   The second source vector register, Z (Scalable).
  */
-#define INSTR_CREATE_bic_sve_pred(dc, Zd, Pg, Zd_, Zm, width) \
-    instr_create_1dst_4src(dc, OP_bic, Zd, Pg, Zd_, Zm, width)
+#define INSTR_CREATE_bic_sve_pred(dc, Zdn, Pg, Zm) \
+    instr_create_1dst_3src(dc, OP_bic, Zdn, Pg, Zdn, Zm)
 
 /**
  * Creates a ZIP2 instruction.

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -611,10 +611,71 @@
 04fdaf9b : adr z27.d, [z28.d, z29.d, LSL #3]         : adr    (%z28.d,%z29.d,lsl #3) -> %z27.d
 04ffafff : adr z31.d, [z31.d, z31.d, LSL #3]         : adr    (%z31.d,%z31.d,lsl #3) -> %z31.d
 
-041a06ff : and z31.b, p1/m, z31.b, z23.b            : and    %p1 %z31 %z23 $0x00 -> %z31
-045a06ff : and z31.h, p1/m, z31.h, z23.h            : and    %p1 %z31 %z23 $0x01 -> %z31
-049a06ff : and z31.s, p1/m, z31.s, z23.s            : and    %p1 %z31 %z23 $0x02 -> %z31
-04da06ff : and z31.d, p1/m, z31.d, z23.d            : and    %p1 %z31 %z23 $0x03 -> %z31
+# AND     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (AND-Z.P.ZZ-_)
+041a0000 : and z0.b, p0/M, z0.b, z0.b                : and    %p0/m %z0.b %z0.b -> %z0.b
+041a0482 : and z2.b, p1/M, z2.b, z4.b                : and    %p1/m %z2.b %z4.b -> %z2.b
+041a08c4 : and z4.b, p2/M, z4.b, z6.b                : and    %p2/m %z4.b %z6.b -> %z4.b
+041a0906 : and z6.b, p2/M, z6.b, z8.b                : and    %p2/m %z6.b %z8.b -> %z6.b
+041a0d48 : and z8.b, p3/M, z8.b, z10.b               : and    %p3/m %z8.b %z10.b -> %z8.b
+041a0d8a : and z10.b, p3/M, z10.b, z12.b             : and    %p3/m %z10.b %z12.b -> %z10.b
+041a11cc : and z12.b, p4/M, z12.b, z14.b             : and    %p4/m %z12.b %z14.b -> %z12.b
+041a120e : and z14.b, p4/M, z14.b, z16.b             : and    %p4/m %z14.b %z16.b -> %z14.b
+041a1650 : and z16.b, p5/M, z16.b, z18.b             : and    %p5/m %z16.b %z18.b -> %z16.b
+041a1671 : and z17.b, p5/M, z17.b, z19.b             : and    %p5/m %z17.b %z19.b -> %z17.b
+041a16b3 : and z19.b, p5/M, z19.b, z21.b             : and    %p5/m %z19.b %z21.b -> %z19.b
+041a1af5 : and z21.b, p6/M, z21.b, z23.b             : and    %p6/m %z21.b %z23.b -> %z21.b
+041a1b37 : and z23.b, p6/M, z23.b, z25.b             : and    %p6/m %z23.b %z25.b -> %z23.b
+041a1f79 : and z25.b, p7/M, z25.b, z27.b             : and    %p7/m %z25.b %z27.b -> %z25.b
+041a1fbb : and z27.b, p7/M, z27.b, z29.b             : and    %p7/m %z27.b %z29.b -> %z27.b
+041a1fff : and z31.b, p7/M, z31.b, z31.b             : and    %p7/m %z31.b %z31.b -> %z31.b
+045a0000 : and z0.h, p0/M, z0.h, z0.h                : and    %p0/m %z0.h %z0.h -> %z0.h
+045a0482 : and z2.h, p1/M, z2.h, z4.h                : and    %p1/m %z2.h %z4.h -> %z2.h
+045a08c4 : and z4.h, p2/M, z4.h, z6.h                : and    %p2/m %z4.h %z6.h -> %z4.h
+045a0906 : and z6.h, p2/M, z6.h, z8.h                : and    %p2/m %z6.h %z8.h -> %z6.h
+045a0d48 : and z8.h, p3/M, z8.h, z10.h               : and    %p3/m %z8.h %z10.h -> %z8.h
+045a0d8a : and z10.h, p3/M, z10.h, z12.h             : and    %p3/m %z10.h %z12.h -> %z10.h
+045a11cc : and z12.h, p4/M, z12.h, z14.h             : and    %p4/m %z12.h %z14.h -> %z12.h
+045a120e : and z14.h, p4/M, z14.h, z16.h             : and    %p4/m %z14.h %z16.h -> %z14.h
+045a1650 : and z16.h, p5/M, z16.h, z18.h             : and    %p5/m %z16.h %z18.h -> %z16.h
+045a1671 : and z17.h, p5/M, z17.h, z19.h             : and    %p5/m %z17.h %z19.h -> %z17.h
+045a16b3 : and z19.h, p5/M, z19.h, z21.h             : and    %p5/m %z19.h %z21.h -> %z19.h
+045a1af5 : and z21.h, p6/M, z21.h, z23.h             : and    %p6/m %z21.h %z23.h -> %z21.h
+045a1b37 : and z23.h, p6/M, z23.h, z25.h             : and    %p6/m %z23.h %z25.h -> %z23.h
+045a1f79 : and z25.h, p7/M, z25.h, z27.h             : and    %p7/m %z25.h %z27.h -> %z25.h
+045a1fbb : and z27.h, p7/M, z27.h, z29.h             : and    %p7/m %z27.h %z29.h -> %z27.h
+045a1fff : and z31.h, p7/M, z31.h, z31.h             : and    %p7/m %z31.h %z31.h -> %z31.h
+049a0000 : and z0.s, p0/M, z0.s, z0.s                : and    %p0/m %z0.s %z0.s -> %z0.s
+049a0482 : and z2.s, p1/M, z2.s, z4.s                : and    %p1/m %z2.s %z4.s -> %z2.s
+049a08c4 : and z4.s, p2/M, z4.s, z6.s                : and    %p2/m %z4.s %z6.s -> %z4.s
+049a0906 : and z6.s, p2/M, z6.s, z8.s                : and    %p2/m %z6.s %z8.s -> %z6.s
+049a0d48 : and z8.s, p3/M, z8.s, z10.s               : and    %p3/m %z8.s %z10.s -> %z8.s
+049a0d8a : and z10.s, p3/M, z10.s, z12.s             : and    %p3/m %z10.s %z12.s -> %z10.s
+049a11cc : and z12.s, p4/M, z12.s, z14.s             : and    %p4/m %z12.s %z14.s -> %z12.s
+049a120e : and z14.s, p4/M, z14.s, z16.s             : and    %p4/m %z14.s %z16.s -> %z14.s
+049a1650 : and z16.s, p5/M, z16.s, z18.s             : and    %p5/m %z16.s %z18.s -> %z16.s
+049a1671 : and z17.s, p5/M, z17.s, z19.s             : and    %p5/m %z17.s %z19.s -> %z17.s
+049a16b3 : and z19.s, p5/M, z19.s, z21.s             : and    %p5/m %z19.s %z21.s -> %z19.s
+049a1af5 : and z21.s, p6/M, z21.s, z23.s             : and    %p6/m %z21.s %z23.s -> %z21.s
+049a1b37 : and z23.s, p6/M, z23.s, z25.s             : and    %p6/m %z23.s %z25.s -> %z23.s
+049a1f79 : and z25.s, p7/M, z25.s, z27.s             : and    %p7/m %z25.s %z27.s -> %z25.s
+049a1fbb : and z27.s, p7/M, z27.s, z29.s             : and    %p7/m %z27.s %z29.s -> %z27.s
+049a1fff : and z31.s, p7/M, z31.s, z31.s             : and    %p7/m %z31.s %z31.s -> %z31.s
+04da0000 : and z0.d, p0/M, z0.d, z0.d                : and    %p0/m %z0.d %z0.d -> %z0.d
+04da0482 : and z2.d, p1/M, z2.d, z4.d                : and    %p1/m %z2.d %z4.d -> %z2.d
+04da08c4 : and z4.d, p2/M, z4.d, z6.d                : and    %p2/m %z4.d %z6.d -> %z4.d
+04da0906 : and z6.d, p2/M, z6.d, z8.d                : and    %p2/m %z6.d %z8.d -> %z6.d
+04da0d48 : and z8.d, p3/M, z8.d, z10.d               : and    %p3/m %z8.d %z10.d -> %z8.d
+04da0d8a : and z10.d, p3/M, z10.d, z12.d             : and    %p3/m %z10.d %z12.d -> %z10.d
+04da11cc : and z12.d, p4/M, z12.d, z14.d             : and    %p4/m %z12.d %z14.d -> %z12.d
+04da120e : and z14.d, p4/M, z14.d, z16.d             : and    %p4/m %z14.d %z16.d -> %z14.d
+04da1650 : and z16.d, p5/M, z16.d, z18.d             : and    %p5/m %z16.d %z18.d -> %z16.d
+04da1671 : and z17.d, p5/M, z17.d, z19.d             : and    %p5/m %z17.d %z19.d -> %z17.d
+04da16b3 : and z19.d, p5/M, z19.d, z21.d             : and    %p5/m %z19.d %z21.d -> %z19.d
+04da1af5 : and z21.d, p6/M, z21.d, z23.d             : and    %p6/m %z21.d %z23.d -> %z21.d
+04da1b37 : and z23.d, p6/M, z23.d, z25.d             : and    %p6/m %z23.d %z25.d -> %z23.d
+04da1f79 : and z25.d, p7/M, z25.d, z27.d             : and    %p7/m %z25.d %z27.d -> %z25.d
+04da1fbb : and z27.d, p7/M, z27.d, z29.d             : and    %p7/m %z27.d %z29.d -> %z27.d
+04da1fff : and z31.d, p7/M, z31.d, z31.d             : and    %p7/m %z31.d %z31.d -> %z31.d
 
 # AND     <Zd>.D, <Zn>.D, <Zm>.D (AND-Z.ZZ-_)
 04203000 : and z0.d, z0.d, z0.d                      : and    %z0.d %z0.d -> %z0.d
@@ -1372,10 +1433,71 @@
 647de79b : bfmmla z27.s, z28.h, z29.h                : bfmmla %z27.s %z28.h %z29.h -> %z27.s
 647fe7ff : bfmmla z31.s, z31.h, z31.h                : bfmmla %z31.s %z31.h %z31.h -> %z31.s
 
-041b0b02 : bic z2.b, p2/m, z2.b, z24.b              : bic    %p2 %z2 %z24 $0x00 -> %z2
-045b0b02 : bic z2.h, p2/m, z2.h, z24.h              : bic    %p2 %z2 %z24 $0x01 -> %z2
-049b0b02 : bic z2.s, p2/m, z2.s, z24.s              : bic    %p2 %z2 %z24 $0x02 -> %z2
-04db0b02 : bic z2.d, p2/m, z2.d, z24.d              : bic    %p2 %z2 %z24 $0x03 -> %z2
+# BIC     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (BIC-Z.P.ZZ-_)
+041b0000 : bic z0.b, p0/M, z0.b, z0.b                : bic    %p0/m %z0.b %z0.b -> %z0.b
+041b0482 : bic z2.b, p1/M, z2.b, z4.b                : bic    %p1/m %z2.b %z4.b -> %z2.b
+041b08c4 : bic z4.b, p2/M, z4.b, z6.b                : bic    %p2/m %z4.b %z6.b -> %z4.b
+041b0906 : bic z6.b, p2/M, z6.b, z8.b                : bic    %p2/m %z6.b %z8.b -> %z6.b
+041b0d48 : bic z8.b, p3/M, z8.b, z10.b               : bic    %p3/m %z8.b %z10.b -> %z8.b
+041b0d8a : bic z10.b, p3/M, z10.b, z12.b             : bic    %p3/m %z10.b %z12.b -> %z10.b
+041b11cc : bic z12.b, p4/M, z12.b, z14.b             : bic    %p4/m %z12.b %z14.b -> %z12.b
+041b120e : bic z14.b, p4/M, z14.b, z16.b             : bic    %p4/m %z14.b %z16.b -> %z14.b
+041b1650 : bic z16.b, p5/M, z16.b, z18.b             : bic    %p5/m %z16.b %z18.b -> %z16.b
+041b1671 : bic z17.b, p5/M, z17.b, z19.b             : bic    %p5/m %z17.b %z19.b -> %z17.b
+041b16b3 : bic z19.b, p5/M, z19.b, z21.b             : bic    %p5/m %z19.b %z21.b -> %z19.b
+041b1af5 : bic z21.b, p6/M, z21.b, z23.b             : bic    %p6/m %z21.b %z23.b -> %z21.b
+041b1b37 : bic z23.b, p6/M, z23.b, z25.b             : bic    %p6/m %z23.b %z25.b -> %z23.b
+041b1f79 : bic z25.b, p7/M, z25.b, z27.b             : bic    %p7/m %z25.b %z27.b -> %z25.b
+041b1fbb : bic z27.b, p7/M, z27.b, z29.b             : bic    %p7/m %z27.b %z29.b -> %z27.b
+041b1fff : bic z31.b, p7/M, z31.b, z31.b             : bic    %p7/m %z31.b %z31.b -> %z31.b
+045b0000 : bic z0.h, p0/M, z0.h, z0.h                : bic    %p0/m %z0.h %z0.h -> %z0.h
+045b0482 : bic z2.h, p1/M, z2.h, z4.h                : bic    %p1/m %z2.h %z4.h -> %z2.h
+045b08c4 : bic z4.h, p2/M, z4.h, z6.h                : bic    %p2/m %z4.h %z6.h -> %z4.h
+045b0906 : bic z6.h, p2/M, z6.h, z8.h                : bic    %p2/m %z6.h %z8.h -> %z6.h
+045b0d48 : bic z8.h, p3/M, z8.h, z10.h               : bic    %p3/m %z8.h %z10.h -> %z8.h
+045b0d8a : bic z10.h, p3/M, z10.h, z12.h             : bic    %p3/m %z10.h %z12.h -> %z10.h
+045b11cc : bic z12.h, p4/M, z12.h, z14.h             : bic    %p4/m %z12.h %z14.h -> %z12.h
+045b120e : bic z14.h, p4/M, z14.h, z16.h             : bic    %p4/m %z14.h %z16.h -> %z14.h
+045b1650 : bic z16.h, p5/M, z16.h, z18.h             : bic    %p5/m %z16.h %z18.h -> %z16.h
+045b1671 : bic z17.h, p5/M, z17.h, z19.h             : bic    %p5/m %z17.h %z19.h -> %z17.h
+045b16b3 : bic z19.h, p5/M, z19.h, z21.h             : bic    %p5/m %z19.h %z21.h -> %z19.h
+045b1af5 : bic z21.h, p6/M, z21.h, z23.h             : bic    %p6/m %z21.h %z23.h -> %z21.h
+045b1b37 : bic z23.h, p6/M, z23.h, z25.h             : bic    %p6/m %z23.h %z25.h -> %z23.h
+045b1f79 : bic z25.h, p7/M, z25.h, z27.h             : bic    %p7/m %z25.h %z27.h -> %z25.h
+045b1fbb : bic z27.h, p7/M, z27.h, z29.h             : bic    %p7/m %z27.h %z29.h -> %z27.h
+045b1fff : bic z31.h, p7/M, z31.h, z31.h             : bic    %p7/m %z31.h %z31.h -> %z31.h
+049b0000 : bic z0.s, p0/M, z0.s, z0.s                : bic    %p0/m %z0.s %z0.s -> %z0.s
+049b0482 : bic z2.s, p1/M, z2.s, z4.s                : bic    %p1/m %z2.s %z4.s -> %z2.s
+049b08c4 : bic z4.s, p2/M, z4.s, z6.s                : bic    %p2/m %z4.s %z6.s -> %z4.s
+049b0906 : bic z6.s, p2/M, z6.s, z8.s                : bic    %p2/m %z6.s %z8.s -> %z6.s
+049b0d48 : bic z8.s, p3/M, z8.s, z10.s               : bic    %p3/m %z8.s %z10.s -> %z8.s
+049b0d8a : bic z10.s, p3/M, z10.s, z12.s             : bic    %p3/m %z10.s %z12.s -> %z10.s
+049b11cc : bic z12.s, p4/M, z12.s, z14.s             : bic    %p4/m %z12.s %z14.s -> %z12.s
+049b120e : bic z14.s, p4/M, z14.s, z16.s             : bic    %p4/m %z14.s %z16.s -> %z14.s
+049b1650 : bic z16.s, p5/M, z16.s, z18.s             : bic    %p5/m %z16.s %z18.s -> %z16.s
+049b1671 : bic z17.s, p5/M, z17.s, z19.s             : bic    %p5/m %z17.s %z19.s -> %z17.s
+049b16b3 : bic z19.s, p5/M, z19.s, z21.s             : bic    %p5/m %z19.s %z21.s -> %z19.s
+049b1af5 : bic z21.s, p6/M, z21.s, z23.s             : bic    %p6/m %z21.s %z23.s -> %z21.s
+049b1b37 : bic z23.s, p6/M, z23.s, z25.s             : bic    %p6/m %z23.s %z25.s -> %z23.s
+049b1f79 : bic z25.s, p7/M, z25.s, z27.s             : bic    %p7/m %z25.s %z27.s -> %z25.s
+049b1fbb : bic z27.s, p7/M, z27.s, z29.s             : bic    %p7/m %z27.s %z29.s -> %z27.s
+049b1fff : bic z31.s, p7/M, z31.s, z31.s             : bic    %p7/m %z31.s %z31.s -> %z31.s
+04db0000 : bic z0.d, p0/M, z0.d, z0.d                : bic    %p0/m %z0.d %z0.d -> %z0.d
+04db0482 : bic z2.d, p1/M, z2.d, z4.d                : bic    %p1/m %z2.d %z4.d -> %z2.d
+04db08c4 : bic z4.d, p2/M, z4.d, z6.d                : bic    %p2/m %z4.d %z6.d -> %z4.d
+04db0906 : bic z6.d, p2/M, z6.d, z8.d                : bic    %p2/m %z6.d %z8.d -> %z6.d
+04db0d48 : bic z8.d, p3/M, z8.d, z10.d               : bic    %p3/m %z8.d %z10.d -> %z8.d
+04db0d8a : bic z10.d, p3/M, z10.d, z12.d             : bic    %p3/m %z10.d %z12.d -> %z10.d
+04db11cc : bic z12.d, p4/M, z12.d, z14.d             : bic    %p4/m %z12.d %z14.d -> %z12.d
+04db120e : bic z14.d, p4/M, z14.d, z16.d             : bic    %p4/m %z14.d %z16.d -> %z14.d
+04db1650 : bic z16.d, p5/M, z16.d, z18.d             : bic    %p5/m %z16.d %z18.d -> %z16.d
+04db1671 : bic z17.d, p5/M, z17.d, z19.d             : bic    %p5/m %z17.d %z19.d -> %z17.d
+04db16b3 : bic z19.d, p5/M, z19.d, z21.d             : bic    %p5/m %z19.d %z21.d -> %z19.d
+04db1af5 : bic z21.d, p6/M, z21.d, z23.d             : bic    %p6/m %z21.d %z23.d -> %z21.d
+04db1b37 : bic z23.d, p6/M, z23.d, z25.d             : bic    %p6/m %z23.d %z25.d -> %z23.d
+04db1f79 : bic z25.d, p7/M, z25.d, z27.d             : bic    %p7/m %z25.d %z27.d -> %z25.d
+04db1fbb : bic z27.d, p7/M, z27.d, z29.d             : bic    %p7/m %z27.d %z29.d -> %z27.d
+04db1fff : bic z31.d, p7/M, z31.d, z31.d             : bic    %p7/m %z31.d %z31.d -> %z31.d
 
 # BIC     <Zd>.D, <Zn>.D, <Zm>.D (BIC-Z.ZZ-_)
 04e03000 : bic z0.d, z0.d, z0.d                      : bic    %z0.d %z0.d -> %z0.d
@@ -5123,10 +5245,71 @@
 05c3e85c : dupm z28.d, #0x38                  : dupm   $0x0000000000000038 -> %z28.d
 05c3e03f : dupm z31.d, #0x30                  : dupm   $0x0000000000000030 -> %z31.d
 
-0419105d : eor z29.b, p4/m, z29.b, z2.b             : eor    %p4 %z29 %z2 $0x00 -> %z29
-0459105d : eor z29.h, p4/m, z29.h, z2.h             : eor    %p4 %z29 %z2 $0x01 -> %z29
-0499105d : eor z29.s, p4/m, z29.s, z2.s             : eor    %p4 %z29 %z2 $0x02 -> %z29
-04d9105d : eor z29.d, p4/m, z29.d, z2.d             : eor    %p4 %z29 %z2 $0x03 -> %z29
+# EOR     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (EOR-Z.P.ZZ-_)
+04190000 : eor z0.b, p0/M, z0.b, z0.b                : eor    %p0/m %z0.b %z0.b -> %z0.b
+04190482 : eor z2.b, p1/M, z2.b, z4.b                : eor    %p1/m %z2.b %z4.b -> %z2.b
+041908c4 : eor z4.b, p2/M, z4.b, z6.b                : eor    %p2/m %z4.b %z6.b -> %z4.b
+04190906 : eor z6.b, p2/M, z6.b, z8.b                : eor    %p2/m %z6.b %z8.b -> %z6.b
+04190d48 : eor z8.b, p3/M, z8.b, z10.b               : eor    %p3/m %z8.b %z10.b -> %z8.b
+04190d8a : eor z10.b, p3/M, z10.b, z12.b             : eor    %p3/m %z10.b %z12.b -> %z10.b
+041911cc : eor z12.b, p4/M, z12.b, z14.b             : eor    %p4/m %z12.b %z14.b -> %z12.b
+0419120e : eor z14.b, p4/M, z14.b, z16.b             : eor    %p4/m %z14.b %z16.b -> %z14.b
+04191650 : eor z16.b, p5/M, z16.b, z18.b             : eor    %p5/m %z16.b %z18.b -> %z16.b
+04191671 : eor z17.b, p5/M, z17.b, z19.b             : eor    %p5/m %z17.b %z19.b -> %z17.b
+041916b3 : eor z19.b, p5/M, z19.b, z21.b             : eor    %p5/m %z19.b %z21.b -> %z19.b
+04191af5 : eor z21.b, p6/M, z21.b, z23.b             : eor    %p6/m %z21.b %z23.b -> %z21.b
+04191b37 : eor z23.b, p6/M, z23.b, z25.b             : eor    %p6/m %z23.b %z25.b -> %z23.b
+04191f79 : eor z25.b, p7/M, z25.b, z27.b             : eor    %p7/m %z25.b %z27.b -> %z25.b
+04191fbb : eor z27.b, p7/M, z27.b, z29.b             : eor    %p7/m %z27.b %z29.b -> %z27.b
+04191fff : eor z31.b, p7/M, z31.b, z31.b             : eor    %p7/m %z31.b %z31.b -> %z31.b
+04590000 : eor z0.h, p0/M, z0.h, z0.h                : eor    %p0/m %z0.h %z0.h -> %z0.h
+04590482 : eor z2.h, p1/M, z2.h, z4.h                : eor    %p1/m %z2.h %z4.h -> %z2.h
+045908c4 : eor z4.h, p2/M, z4.h, z6.h                : eor    %p2/m %z4.h %z6.h -> %z4.h
+04590906 : eor z6.h, p2/M, z6.h, z8.h                : eor    %p2/m %z6.h %z8.h -> %z6.h
+04590d48 : eor z8.h, p3/M, z8.h, z10.h               : eor    %p3/m %z8.h %z10.h -> %z8.h
+04590d8a : eor z10.h, p3/M, z10.h, z12.h             : eor    %p3/m %z10.h %z12.h -> %z10.h
+045911cc : eor z12.h, p4/M, z12.h, z14.h             : eor    %p4/m %z12.h %z14.h -> %z12.h
+0459120e : eor z14.h, p4/M, z14.h, z16.h             : eor    %p4/m %z14.h %z16.h -> %z14.h
+04591650 : eor z16.h, p5/M, z16.h, z18.h             : eor    %p5/m %z16.h %z18.h -> %z16.h
+04591671 : eor z17.h, p5/M, z17.h, z19.h             : eor    %p5/m %z17.h %z19.h -> %z17.h
+045916b3 : eor z19.h, p5/M, z19.h, z21.h             : eor    %p5/m %z19.h %z21.h -> %z19.h
+04591af5 : eor z21.h, p6/M, z21.h, z23.h             : eor    %p6/m %z21.h %z23.h -> %z21.h
+04591b37 : eor z23.h, p6/M, z23.h, z25.h             : eor    %p6/m %z23.h %z25.h -> %z23.h
+04591f79 : eor z25.h, p7/M, z25.h, z27.h             : eor    %p7/m %z25.h %z27.h -> %z25.h
+04591fbb : eor z27.h, p7/M, z27.h, z29.h             : eor    %p7/m %z27.h %z29.h -> %z27.h
+04591fff : eor z31.h, p7/M, z31.h, z31.h             : eor    %p7/m %z31.h %z31.h -> %z31.h
+04990000 : eor z0.s, p0/M, z0.s, z0.s                : eor    %p0/m %z0.s %z0.s -> %z0.s
+04990482 : eor z2.s, p1/M, z2.s, z4.s                : eor    %p1/m %z2.s %z4.s -> %z2.s
+049908c4 : eor z4.s, p2/M, z4.s, z6.s                : eor    %p2/m %z4.s %z6.s -> %z4.s
+04990906 : eor z6.s, p2/M, z6.s, z8.s                : eor    %p2/m %z6.s %z8.s -> %z6.s
+04990d48 : eor z8.s, p3/M, z8.s, z10.s               : eor    %p3/m %z8.s %z10.s -> %z8.s
+04990d8a : eor z10.s, p3/M, z10.s, z12.s             : eor    %p3/m %z10.s %z12.s -> %z10.s
+049911cc : eor z12.s, p4/M, z12.s, z14.s             : eor    %p4/m %z12.s %z14.s -> %z12.s
+0499120e : eor z14.s, p4/M, z14.s, z16.s             : eor    %p4/m %z14.s %z16.s -> %z14.s
+04991650 : eor z16.s, p5/M, z16.s, z18.s             : eor    %p5/m %z16.s %z18.s -> %z16.s
+04991671 : eor z17.s, p5/M, z17.s, z19.s             : eor    %p5/m %z17.s %z19.s -> %z17.s
+049916b3 : eor z19.s, p5/M, z19.s, z21.s             : eor    %p5/m %z19.s %z21.s -> %z19.s
+04991af5 : eor z21.s, p6/M, z21.s, z23.s             : eor    %p6/m %z21.s %z23.s -> %z21.s
+04991b37 : eor z23.s, p6/M, z23.s, z25.s             : eor    %p6/m %z23.s %z25.s -> %z23.s
+04991f79 : eor z25.s, p7/M, z25.s, z27.s             : eor    %p7/m %z25.s %z27.s -> %z25.s
+04991fbb : eor z27.s, p7/M, z27.s, z29.s             : eor    %p7/m %z27.s %z29.s -> %z27.s
+04991fff : eor z31.s, p7/M, z31.s, z31.s             : eor    %p7/m %z31.s %z31.s -> %z31.s
+04d90000 : eor z0.d, p0/M, z0.d, z0.d                : eor    %p0/m %z0.d %z0.d -> %z0.d
+04d90482 : eor z2.d, p1/M, z2.d, z4.d                : eor    %p1/m %z2.d %z4.d -> %z2.d
+04d908c4 : eor z4.d, p2/M, z4.d, z6.d                : eor    %p2/m %z4.d %z6.d -> %z4.d
+04d90906 : eor z6.d, p2/M, z6.d, z8.d                : eor    %p2/m %z6.d %z8.d -> %z6.d
+04d90d48 : eor z8.d, p3/M, z8.d, z10.d               : eor    %p3/m %z8.d %z10.d -> %z8.d
+04d90d8a : eor z10.d, p3/M, z10.d, z12.d             : eor    %p3/m %z10.d %z12.d -> %z10.d
+04d911cc : eor z12.d, p4/M, z12.d, z14.d             : eor    %p4/m %z12.d %z14.d -> %z12.d
+04d9120e : eor z14.d, p4/M, z14.d, z16.d             : eor    %p4/m %z14.d %z16.d -> %z14.d
+04d91650 : eor z16.d, p5/M, z16.d, z18.d             : eor    %p5/m %z16.d %z18.d -> %z16.d
+04d91671 : eor z17.d, p5/M, z17.d, z19.d             : eor    %p5/m %z17.d %z19.d -> %z17.d
+04d916b3 : eor z19.d, p5/M, z19.d, z21.d             : eor    %p5/m %z19.d %z21.d -> %z19.d
+04d91af5 : eor z21.d, p6/M, z21.d, z23.d             : eor    %p6/m %z21.d %z23.d -> %z21.d
+04d91b37 : eor z23.d, p6/M, z23.d, z25.d             : eor    %p6/m %z23.d %z25.d -> %z23.d
+04d91f79 : eor z25.d, p7/M, z25.d, z27.d             : eor    %p7/m %z25.d %z27.d -> %z25.d
+04d91fbb : eor z27.d, p7/M, z27.d, z29.d             : eor    %p7/m %z27.d %z29.d -> %z27.d
+04d91fff : eor z31.d, p7/M, z31.d, z31.d             : eor    %p7/m %z31.d %z31.d -> %z31.d
 
 # EOR     <Zd>.D, <Zn>.D, <Zm>.D (EOR-Z.ZZ-_)
 04a03000 : eor z0.d, z0.d, z0.d                      : eor    %z0.d %z0.d -> %z0.d
@@ -16613,10 +16796,71 @@ a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0x07(%sp)[32byte]
 25c079fd : orns p13.b, p14/Z, p15.b, p0.b            : orns   %p14/z %p15.b %p0.b -> %p13.b
 25cf7dff : orns p15.b, p15/Z, p15.b, p15.b           : orns   %p15/z %p15.b %p15.b -> %p15.b
 
-04181da2 : orr z2.b, p7/m, z2.b, z13.b              : orr    %p7 %z2 %z13 $0x00 -> %z2
-04581da2 : orr z2.h, p7/m, z2.h, z13.h              : orr    %p7 %z2 %z13 $0x01 -> %z2
-04981da2 : orr z2.s, p7/m, z2.s, z13.s              : orr    %p7 %z2 %z13 $0x02 -> %z2
-04d81da2 : orr z2.d, p7/m, z2.d, z13.d              : orr    %p7 %z2 %z13 $0x03 -> %z2
+# ORR     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (ORR-Z.P.ZZ-_)
+04180000 : orr z0.b, p0/M, z0.b, z0.b                : orr    %p0/m %z0.b %z0.b -> %z0.b
+04180482 : orr z2.b, p1/M, z2.b, z4.b                : orr    %p1/m %z2.b %z4.b -> %z2.b
+041808c4 : orr z4.b, p2/M, z4.b, z6.b                : orr    %p2/m %z4.b %z6.b -> %z4.b
+04180906 : orr z6.b, p2/M, z6.b, z8.b                : orr    %p2/m %z6.b %z8.b -> %z6.b
+04180d48 : orr z8.b, p3/M, z8.b, z10.b               : orr    %p3/m %z8.b %z10.b -> %z8.b
+04180d8a : orr z10.b, p3/M, z10.b, z12.b             : orr    %p3/m %z10.b %z12.b -> %z10.b
+041811cc : orr z12.b, p4/M, z12.b, z14.b             : orr    %p4/m %z12.b %z14.b -> %z12.b
+0418120e : orr z14.b, p4/M, z14.b, z16.b             : orr    %p4/m %z14.b %z16.b -> %z14.b
+04181650 : orr z16.b, p5/M, z16.b, z18.b             : orr    %p5/m %z16.b %z18.b -> %z16.b
+04181671 : orr z17.b, p5/M, z17.b, z19.b             : orr    %p5/m %z17.b %z19.b -> %z17.b
+041816b3 : orr z19.b, p5/M, z19.b, z21.b             : orr    %p5/m %z19.b %z21.b -> %z19.b
+04181af5 : orr z21.b, p6/M, z21.b, z23.b             : orr    %p6/m %z21.b %z23.b -> %z21.b
+04181b37 : orr z23.b, p6/M, z23.b, z25.b             : orr    %p6/m %z23.b %z25.b -> %z23.b
+04181f79 : orr z25.b, p7/M, z25.b, z27.b             : orr    %p7/m %z25.b %z27.b -> %z25.b
+04181fbb : orr z27.b, p7/M, z27.b, z29.b             : orr    %p7/m %z27.b %z29.b -> %z27.b
+04181fff : orr z31.b, p7/M, z31.b, z31.b             : orr    %p7/m %z31.b %z31.b -> %z31.b
+04580000 : orr z0.h, p0/M, z0.h, z0.h                : orr    %p0/m %z0.h %z0.h -> %z0.h
+04580482 : orr z2.h, p1/M, z2.h, z4.h                : orr    %p1/m %z2.h %z4.h -> %z2.h
+045808c4 : orr z4.h, p2/M, z4.h, z6.h                : orr    %p2/m %z4.h %z6.h -> %z4.h
+04580906 : orr z6.h, p2/M, z6.h, z8.h                : orr    %p2/m %z6.h %z8.h -> %z6.h
+04580d48 : orr z8.h, p3/M, z8.h, z10.h               : orr    %p3/m %z8.h %z10.h -> %z8.h
+04580d8a : orr z10.h, p3/M, z10.h, z12.h             : orr    %p3/m %z10.h %z12.h -> %z10.h
+045811cc : orr z12.h, p4/M, z12.h, z14.h             : orr    %p4/m %z12.h %z14.h -> %z12.h
+0458120e : orr z14.h, p4/M, z14.h, z16.h             : orr    %p4/m %z14.h %z16.h -> %z14.h
+04581650 : orr z16.h, p5/M, z16.h, z18.h             : orr    %p5/m %z16.h %z18.h -> %z16.h
+04581671 : orr z17.h, p5/M, z17.h, z19.h             : orr    %p5/m %z17.h %z19.h -> %z17.h
+045816b3 : orr z19.h, p5/M, z19.h, z21.h             : orr    %p5/m %z19.h %z21.h -> %z19.h
+04581af5 : orr z21.h, p6/M, z21.h, z23.h             : orr    %p6/m %z21.h %z23.h -> %z21.h
+04581b37 : orr z23.h, p6/M, z23.h, z25.h             : orr    %p6/m %z23.h %z25.h -> %z23.h
+04581f79 : orr z25.h, p7/M, z25.h, z27.h             : orr    %p7/m %z25.h %z27.h -> %z25.h
+04581fbb : orr z27.h, p7/M, z27.h, z29.h             : orr    %p7/m %z27.h %z29.h -> %z27.h
+04581fff : orr z31.h, p7/M, z31.h, z31.h             : orr    %p7/m %z31.h %z31.h -> %z31.h
+04980000 : orr z0.s, p0/M, z0.s, z0.s                : orr    %p0/m %z0.s %z0.s -> %z0.s
+04980482 : orr z2.s, p1/M, z2.s, z4.s                : orr    %p1/m %z2.s %z4.s -> %z2.s
+049808c4 : orr z4.s, p2/M, z4.s, z6.s                : orr    %p2/m %z4.s %z6.s -> %z4.s
+04980906 : orr z6.s, p2/M, z6.s, z8.s                : orr    %p2/m %z6.s %z8.s -> %z6.s
+04980d48 : orr z8.s, p3/M, z8.s, z10.s               : orr    %p3/m %z8.s %z10.s -> %z8.s
+04980d8a : orr z10.s, p3/M, z10.s, z12.s             : orr    %p3/m %z10.s %z12.s -> %z10.s
+049811cc : orr z12.s, p4/M, z12.s, z14.s             : orr    %p4/m %z12.s %z14.s -> %z12.s
+0498120e : orr z14.s, p4/M, z14.s, z16.s             : orr    %p4/m %z14.s %z16.s -> %z14.s
+04981650 : orr z16.s, p5/M, z16.s, z18.s             : orr    %p5/m %z16.s %z18.s -> %z16.s
+04981671 : orr z17.s, p5/M, z17.s, z19.s             : orr    %p5/m %z17.s %z19.s -> %z17.s
+049816b3 : orr z19.s, p5/M, z19.s, z21.s             : orr    %p5/m %z19.s %z21.s -> %z19.s
+04981af5 : orr z21.s, p6/M, z21.s, z23.s             : orr    %p6/m %z21.s %z23.s -> %z21.s
+04981b37 : orr z23.s, p6/M, z23.s, z25.s             : orr    %p6/m %z23.s %z25.s -> %z23.s
+04981f79 : orr z25.s, p7/M, z25.s, z27.s             : orr    %p7/m %z25.s %z27.s -> %z25.s
+04981fbb : orr z27.s, p7/M, z27.s, z29.s             : orr    %p7/m %z27.s %z29.s -> %z27.s
+04981fff : orr z31.s, p7/M, z31.s, z31.s             : orr    %p7/m %z31.s %z31.s -> %z31.s
+04d80000 : orr z0.d, p0/M, z0.d, z0.d                : orr    %p0/m %z0.d %z0.d -> %z0.d
+04d80482 : orr z2.d, p1/M, z2.d, z4.d                : orr    %p1/m %z2.d %z4.d -> %z2.d
+04d808c4 : orr z4.d, p2/M, z4.d, z6.d                : orr    %p2/m %z4.d %z6.d -> %z4.d
+04d80906 : orr z6.d, p2/M, z6.d, z8.d                : orr    %p2/m %z6.d %z8.d -> %z6.d
+04d80d48 : orr z8.d, p3/M, z8.d, z10.d               : orr    %p3/m %z8.d %z10.d -> %z8.d
+04d80d8a : orr z10.d, p3/M, z10.d, z12.d             : orr    %p3/m %z10.d %z12.d -> %z10.d
+04d811cc : orr z12.d, p4/M, z12.d, z14.d             : orr    %p4/m %z12.d %z14.d -> %z12.d
+04d8120e : orr z14.d, p4/M, z14.d, z16.d             : orr    %p4/m %z14.d %z16.d -> %z14.d
+04d81650 : orr z16.d, p5/M, z16.d, z18.d             : orr    %p5/m %z16.d %z18.d -> %z16.d
+04d81671 : orr z17.d, p5/M, z17.d, z19.d             : orr    %p5/m %z17.d %z19.d -> %z17.d
+04d816b3 : orr z19.d, p5/M, z19.d, z21.d             : orr    %p5/m %z19.d %z21.d -> %z19.d
+04d81af5 : orr z21.d, p6/M, z21.d, z23.d             : orr    %p6/m %z21.d %z23.d -> %z21.d
+04d81b37 : orr z23.d, p6/M, z23.d, z25.d             : orr    %p6/m %z23.d %z25.d -> %z23.d
+04d81f79 : orr z25.d, p7/M, z25.d, z27.d             : orr    %p7/m %z25.d %z27.d -> %z25.d
+04d81fbb : orr z27.d, p7/M, z27.d, z29.d             : orr    %p7/m %z27.d %z29.d -> %z27.d
+04d81fff : orr z31.d, p7/M, z31.d, z31.d             : orr    %p7/m %z31.d %z31.d -> %z31.d
 
 # ORR     <Zd>.D, <Zn>.D, <Zm>.D (ORR-Z.ZZ-_)
 04603000 : orr z0.d, z0.d, z0.d                      : orr    %z0.d %z0.d -> %z0.d

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -4473,95 +4473,6 @@ test_floatdp3(void *dc)
 }
 
 static void
-test_sve_int_bin_pred_log(void *dc)
-{
-    byte *pc;
-    instr_t *instr;
-
-    /* SVE bitwise logical operations (predicated) */
-
-    instr = INSTR_CREATE_orr_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P7),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z13), OPND_CREATE_BYTE());
-    test_instr_encoding(dc, OP_orr, instr);
-
-    instr = INSTR_CREATE_orr_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P7),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z13), OPND_CREATE_HALF());
-    test_instr_encoding(dc, OP_orr, instr);
-
-    instr = INSTR_CREATE_orr_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P7),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z13), OPND_CREATE_SINGLE());
-    test_instr_encoding(dc, OP_orr, instr);
-
-    instr = INSTR_CREATE_orr_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P7),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z13), OPND_CREATE_DOUBLE());
-    test_instr_encoding(dc, OP_orr, instr);
-
-    instr = INSTR_CREATE_eor_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P4),
-        opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_Z2), OPND_CREATE_BYTE());
-    test_instr_encoding(dc, OP_eor, instr);
-
-    instr = INSTR_CREATE_eor_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P4),
-        opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_Z2), OPND_CREATE_HALF());
-    test_instr_encoding(dc, OP_eor, instr);
-
-    instr = INSTR_CREATE_eor_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P4),
-        opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_Z2), OPND_CREATE_SINGLE());
-    test_instr_encoding(dc, OP_eor, instr);
-
-    instr = INSTR_CREATE_eor_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P4),
-        opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_Z2), OPND_CREATE_DOUBLE());
-    test_instr_encoding(dc, OP_eor, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P1),
-        opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_BYTE());
-    test_instr_encoding(dc, OP_and, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P1),
-        opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_HALF());
-    test_instr_encoding(dc, OP_and, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P1),
-        opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
-    test_instr_encoding(dc, OP_and, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P1),
-        opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_DOUBLE());
-    test_instr_encoding(dc, OP_and, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P2),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_BYTE());
-    test_instr_encoding(dc, OP_bic, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P2),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
-    test_instr_encoding(dc, OP_bic, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P2),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_SINGLE());
-    test_instr_encoding(dc, OP_bic, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P2),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_DOUBLE());
-    test_instr_encoding(dc, OP_bic, instr);
-}
-
-static void
 test_asimddiff(void *dc)
 {
     byte *pc;
@@ -7098,9 +7009,6 @@ main(int argc, char *argv[])
 
     test_floatdp3(dcontext);
     print("test_floatdp3 complete\n");
-
-    test_sve_int_bin_pred_log(dcontext);
-    print("test_sve_int_bin_pred_log complete\n");
 
     test_asimddiff(dcontext);
     print("test_asimddiff complete\n");

--- a/suite/tests/api/ir_aarch64.expect
+++ b/suite/tests/api/ir_aarch64.expect
@@ -631,23 +631,6 @@ fnmsub %d15 %d23 %d2 -> %d4
 fnmsub %s15 %s23 %s2 -> %s4
 fnmsub %h15 %h23 %h2 -> %h4
 test_floatdp3 complete
-orr    %p7 %z2 %z13 $0x00 -> %z2
-orr    %p7 %z2 %z13 $0x01 -> %z2
-orr    %p7 %z2 %z13 $0x02 -> %z2
-orr    %p7 %z2 %z13 $0x03 -> %z2
-eor    %p4 %z29 %z2 $0x00 -> %z29
-eor    %p4 %z29 %z2 $0x01 -> %z29
-eor    %p4 %z29 %z2 $0x02 -> %z29
-eor    %p4 %z29 %z2 $0x03 -> %z29
-and    %p1 %z31 %z23 $0x00 -> %z31
-and    %p1 %z31 %z23 $0x01 -> %z31
-and    %p1 %z31 %z23 $0x02 -> %z31
-and    %p1 %z31 %z23 $0x03 -> %z31
-bic    %p2 %z2 %z24 $0x00 -> %z2
-bic    %p2 %z2 %z24 $0x01 -> %z2
-bic    %p2 %z2 %z24 $0x02 -> %z2
-bic    %p2 %z2 %z24 $0x03 -> %z2
-test_sve_int_bin_pred_log complete
 saddl  %d13 %d18 $0x00 -> %q18
 saddl  %d13 %d18 $0x01 -> %q18
 saddl  %d13 %d18 $0x02 -> %q18

--- a/suite/tests/api/ir_aarch64_negative.c
+++ b/suite/tests/api/ir_aarch64_negative.c
@@ -84,90 +84,6 @@ test_fmov_general(void *dc)
     instr_destroy(dc, instr);
 }
 
-static void
-test_sve_int_bin_pred_log(void *dc)
-{
-    byte *pc;
-    instr_t *instr;
-
-    /* SVE bitwise logical operations (predicated)
-     * Make sure we fail to encode if output and first input registers do not match.
-     */
-
-    instr = INSTR_CREATE_orr_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P7),
-        opnd_create_reg(DR_REG_Z5), opnd_create_reg(DR_REG_Z13), OPND_CREATE_BYTE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_eor_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P4),
-        opnd_create_reg(DR_REG_Z9), opnd_create_reg(DR_REG_Z2), OPND_CREATE_DOUBLE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P1),
-        opnd_create_reg(DR_REG_Z1), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P2),
-        opnd_create_reg(DR_REG_Z3), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    /* Make sure predicate registers P8-P15 are not accepted. */
-    instr = INSTR_CREATE_orr_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P8),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z13), OPND_CREATE_BYTE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_eor_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_P9),
-        opnd_create_reg(DR_REG_Z29), opnd_create_reg(DR_REG_Z2), OPND_CREATE_DOUBLE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P10),
-        opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P11),
-        opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P12),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_and_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_P13),
-        opnd_create_reg(DR_REG_Z31), opnd_create_reg(DR_REG_Z23), OPND_CREATE_SINGLE());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P14),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-
-    instr = INSTR_CREATE_bic_sve_pred(
-        dc, opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_P15),
-        opnd_create_reg(DR_REG_Z2), opnd_create_reg(DR_REG_Z24), OPND_CREATE_HALF());
-    ASSERT(!instr_is_encoding_possible(instr));
-    instr_destroy(dc, instr);
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -179,9 +95,6 @@ main(int argc, char *argv[])
 
     test_fmov_general(dcontext);
     print("test_fmov_general complete\n");
-
-    test_sve_int_bin_pred_log(dcontext);
-    print("test_sve_int_bin_pred_log complete\n");
 
     print("All tests complete\n");
 #ifndef STANDALONE_DECODER

--- a/suite/tests/api/ir_aarch64_negative.expect
+++ b/suite/tests/api/ir_aarch64_negative.expect
@@ -1,3 +1,2 @@
 test_fmov_general complete
-test_sve_int_bin_pred_log complete
 All tests complete

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -20299,6 +20299,186 @@ TEST_INSTR(udot_sve_idx)
               opnd_create_immed_uint(i2_1_0[i], OPSZ_2b));
 }
 
+TEST_INSTR(and_sve_pred)
+{
+
+    /* Testing AND     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "and    %p0/m %z0.b %z0.b -> %z0.b",    "and    %p2/m %z5.b %z7.b -> %z5.b",
+        "and    %p3/m %z10.b %z12.b -> %z10.b", "and    %p5/m %z16.b %z18.b -> %z16.b",
+        "and    %p6/m %z21.b %z23.b -> %z21.b", "and    %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(and, and_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "and    %p0/m %z0.h %z0.h -> %z0.h",    "and    %p2/m %z5.h %z7.h -> %z5.h",
+        "and    %p3/m %z10.h %z12.h -> %z10.h", "and    %p5/m %z16.h %z18.h -> %z16.h",
+        "and    %p6/m %z21.h %z23.h -> %z21.h", "and    %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(and, and_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "and    %p0/m %z0.s %z0.s -> %z0.s",    "and    %p2/m %z5.s %z7.s -> %z5.s",
+        "and    %p3/m %z10.s %z12.s -> %z10.s", "and    %p5/m %z16.s %z18.s -> %z16.s",
+        "and    %p6/m %z21.s %z23.s -> %z21.s", "and    %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(and, and_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "and    %p0/m %z0.d %z0.d -> %z0.d",    "and    %p2/m %z5.d %z7.d -> %z5.d",
+        "and    %p3/m %z10.d %z12.d -> %z10.d", "and    %p5/m %z16.d %z18.d -> %z16.d",
+        "and    %p6/m %z21.d %z23.d -> %z21.d", "and    %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(and, and_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(bic_sve_pred)
+{
+
+    /* Testing BIC     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "bic    %p0/m %z0.b %z0.b -> %z0.b",    "bic    %p2/m %z5.b %z7.b -> %z5.b",
+        "bic    %p3/m %z10.b %z12.b -> %z10.b", "bic    %p5/m %z16.b %z18.b -> %z16.b",
+        "bic    %p6/m %z21.b %z23.b -> %z21.b", "bic    %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(bic, bic_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "bic    %p0/m %z0.h %z0.h -> %z0.h",    "bic    %p2/m %z5.h %z7.h -> %z5.h",
+        "bic    %p3/m %z10.h %z12.h -> %z10.h", "bic    %p5/m %z16.h %z18.h -> %z16.h",
+        "bic    %p6/m %z21.h %z23.h -> %z21.h", "bic    %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(bic, bic_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "bic    %p0/m %z0.s %z0.s -> %z0.s",    "bic    %p2/m %z5.s %z7.s -> %z5.s",
+        "bic    %p3/m %z10.s %z12.s -> %z10.s", "bic    %p5/m %z16.s %z18.s -> %z16.s",
+        "bic    %p6/m %z21.s %z23.s -> %z21.s", "bic    %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(bic, bic_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "bic    %p0/m %z0.d %z0.d -> %z0.d",    "bic    %p2/m %z5.d %z7.d -> %z5.d",
+        "bic    %p3/m %z10.d %z12.d -> %z10.d", "bic    %p5/m %z16.d %z18.d -> %z16.d",
+        "bic    %p6/m %z21.d %z23.d -> %z21.d", "bic    %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(bic, bic_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(eor_sve_pred)
+{
+
+    /* Testing EOR     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "eor    %p0/m %z0.b %z0.b -> %z0.b",    "eor    %p2/m %z5.b %z7.b -> %z5.b",
+        "eor    %p3/m %z10.b %z12.b -> %z10.b", "eor    %p5/m %z16.b %z18.b -> %z16.b",
+        "eor    %p6/m %z21.b %z23.b -> %z21.b", "eor    %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(eor, eor_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "eor    %p0/m %z0.h %z0.h -> %z0.h",    "eor    %p2/m %z5.h %z7.h -> %z5.h",
+        "eor    %p3/m %z10.h %z12.h -> %z10.h", "eor    %p5/m %z16.h %z18.h -> %z16.h",
+        "eor    %p6/m %z21.h %z23.h -> %z21.h", "eor    %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(eor, eor_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "eor    %p0/m %z0.s %z0.s -> %z0.s",    "eor    %p2/m %z5.s %z7.s -> %z5.s",
+        "eor    %p3/m %z10.s %z12.s -> %z10.s", "eor    %p5/m %z16.s %z18.s -> %z16.s",
+        "eor    %p6/m %z21.s %z23.s -> %z21.s", "eor    %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(eor, eor_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "eor    %p0/m %z0.d %z0.d -> %z0.d",    "eor    %p2/m %z5.d %z7.d -> %z5.d",
+        "eor    %p3/m %z10.d %z12.d -> %z10.d", "eor    %p5/m %z16.d %z18.d -> %z16.d",
+        "eor    %p6/m %z21.d %z23.d -> %z21.d", "eor    %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(eor, eor_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
+TEST_INSTR(orr_sve_pred)
+{
+
+    /* Testing ORR     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "orr    %p0/m %z0.b %z0.b -> %z0.b",    "orr    %p2/m %z5.b %z7.b -> %z5.b",
+        "orr    %p3/m %z10.b %z12.b -> %z10.b", "orr    %p5/m %z16.b %z18.b -> %z16.b",
+        "orr    %p6/m %z21.b %z23.b -> %z21.b", "orr    %p7/m %z31.b %z31.b -> %z31.b",
+    };
+    TEST_LOOP(orr, orr_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "orr    %p0/m %z0.h %z0.h -> %z0.h",    "orr    %p2/m %z5.h %z7.h -> %z5.h",
+        "orr    %p3/m %z10.h %z12.h -> %z10.h", "orr    %p5/m %z16.h %z18.h -> %z16.h",
+        "orr    %p6/m %z21.h %z23.h -> %z21.h", "orr    %p7/m %z31.h %z31.h -> %z31.h",
+    };
+    TEST_LOOP(orr, orr_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "orr    %p0/m %z0.s %z0.s -> %z0.s",    "orr    %p2/m %z5.s %z7.s -> %z5.s",
+        "orr    %p3/m %z10.s %z12.s -> %z10.s", "orr    %p5/m %z16.s %z18.s -> %z16.s",
+        "orr    %p6/m %z21.s %z23.s -> %z21.s", "orr    %p7/m %z31.s %z31.s -> %z31.s",
+    };
+    TEST_LOOP(orr, orr_sve_pred, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "orr    %p0/m %z0.d %z0.d -> %z0.d",    "orr    %p2/m %z5.d %z7.d -> %z5.d",
+        "orr    %p3/m %z10.d %z12.d -> %z10.d", "orr    %p5/m %z16.d %z18.d -> %z16.d",
+        "orr    %p6/m %z21.d %z23.d -> %z21.d", "orr    %p7/m %z31.d %z31.d -> %z31.d",
+    };
+    TEST_LOOP(orr, orr_sve_pred, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -20809,6 +20989,11 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(sdot_sve_idx);
     RUN_INSTR_TEST(udot_sve);
     RUN_INSTR_TEST(udot_sve_idx);
+
+    RUN_INSTR_TEST(and_sve_pred);
+    RUN_INSTR_TEST(bic_sve_pred);
+    RUN_INSTR_TEST(eor_sve_pred);
+    RUN_INSTR_TEST(orr_sve_pred);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
These instructions were implemented before the IR was fully defined for SVE and were thus missing the predicate mode and the vector element sizes.

This patch updates the appropriate macros, tests and codec entries to encode the following variants:
```
AND     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
BIC     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
EOR     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
ORR     <Zdn>.<Ts>, <Pg>/M, <Zdn>.<Ts>, <Zm>.<Ts>
```
issue: #3044
