### PR TITLE
i#5843 scheduler: Implement speculation with nops

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -674,6 +674,7 @@ if (BUILD_TESTS)
     tests/scheduler_unit_tests.cpp)
   target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer)
   add_win32_flags(tool.scheduler.unit_tests)
+  configure_DynamoRIO_standalone(tool.scheduler.unit_tests)
   add_test(NAME tool.scheduler.unit_tests
     COMMAND tool.scheduler.unit_tests
     ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -672,10 +672,13 @@ if (BUILD_TESTS)
 
   add_executable(tool.scheduler.unit_tests tests/scheduler_unit_tests.cpp
     tests/scheduler_unit_tests.cpp)
-  # We hit dup symbol errors on Windows so we need libc earlier before DR:
-  _DR_get_static_libc_list(static_libc)
-  target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer ${static_libc})
+  target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer)
   add_win32_flags(tool.scheduler.unit_tests)
+  if (WIN32)
+    # We have a dup symbol from linking in DR.  Linking libc first doesn't help.
+    append_property_string(TARGET tool.scheduler.unit_tests LINK_FLAGS
+      "/force:multiple")
+  endif ()
   configure_DynamoRIO_standalone(tool.scheduler.unit_tests)
   add_test(NAME tool.scheduler.unit_tests
     COMMAND tool.scheduler.unit_tests

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -672,7 +672,9 @@ if (BUILD_TESTS)
 
   add_executable(tool.scheduler.unit_tests tests/scheduler_unit_tests.cpp
     tests/scheduler_unit_tests.cpp)
-  target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer)
+  # We hit dup symbol errors on Windows so we need libc earlier before DR:
+  _DR_get_static_libc_list(static_libc)
+  target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer ${static_libc})
   add_win32_flags(tool.scheduler.unit_tests)
   configure_DynamoRIO_standalone(tool.scheduler.unit_tests)
   add_test(NAME tool.scheduler.unit_tests

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -315,6 +315,7 @@ install_client_nonDR_header(drmemtrace tools/view_create.h)
 install_client_nonDR_header(drmemtrace tools/func_view_create.h)
 install_client_nonDR_header(drmemtrace tracer/raw2trace.h)
 install_client_nonDR_header(drmemtrace scheduler/scheduler.h)
+install_client_nonDR_header(drmemtrace scheduler/speculator.h)
 
 # We show one example of how to create a standalone analyzer of trace
 # files that does not need to link with DR.

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -232,6 +232,7 @@ endif ()
 set(drcachesim_srcs
   launcher.cpp
   scheduler/scheduler.cpp
+  scheduler/speculator.cpp
   analyzer.cpp
   analyzer_multi.cpp
   ${client_and_sim_srcs}
@@ -277,6 +278,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_exported_library(drmemtrace_analyzer STATIC
   analyzer.cpp
   scheduler/scheduler.cpp
+  scheduler/speculator.cpp
   common/trace_entry.cpp
   reader/reader.cpp
   reader/config_reader.cpp

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -912,6 +912,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         if (!error_string_.empty())
             return sched_type_t::STATUS_INVALID;
         // Leave the cur input where it is: the ordinals will remain unchanged.
+        // Also avoid the context switch checks below as we cannot switch in the
+        // middle of speculating (we also don't count speculated instructions toward
+        // QUANTUM_INSTRUCTIONS).
         return sched_type_t::STATUS_OK;
     }
     while (true) {

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -380,16 +380,16 @@ scheduler_tmpl_t<RecordType, ReaderType>::stream_t::report_time(uint64_t cur_tim
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::stream_t::start_speculation(
-    addr_t start_address)
+    addr_t start_address, bool queue_current_record)
 {
-    return sched_type_t::STATUS_NOT_IMPLEMENTED;
+    return scheduler_->start_speculation(ordinal_, start_address, queue_current_record);
 }
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::stream_t::stop_speculation()
 {
-    return sched_type_t::STATUS_NOT_IMPLEMENTED;
+    return scheduler_->stop_speculation(ordinal_);
 }
 
 /***************************************************************************
@@ -492,9 +492,20 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
             static_cast<int>(sched_type_t::SCHEDULER_USE_INPUT_ORDINALS));
     }
 
+    // TODO i#5843: Once the speculator supports more options, change the
+    // default.  For now we hardcode nops as the only supported option.
+    options_.flags = static_cast<scheduler_flags_t>(
+        static_cast<int>(options_.flags) |
+        static_cast<int>(sched_type_t::SCHEDULER_SPECULATE_NOPS));
+
     outputs_.reserve(output_count);
     for (int i = 0; i < output_count; i++) {
-        outputs_.emplace_back(this, i, verbosity_);
+        outputs_.emplace_back(this, i,
+                              TESTANY(SCHEDULER_SPECULATE_NOPS, options_.flags)
+                                  ? spec_type_t::USE_NOPS
+                                  // TODO i#5843: Add more flags for other options.
+                                  : spec_type_t::LAST_FROM_TRACE,
+                              verbosity_);
     }
     if (options_.mapping == MAP_TO_CONSISTENT_OUTPUT) {
         // Assign the inputs up front to avoid locks once we're in parallel mode.
@@ -895,6 +906,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         return sched_type_t::STATUS_EOF;
     }
     input = &inputs_[outputs_[output].cur_input];
+    if (outputs_[output].speculating) {
+        error_string_ = outputs_[output].speculator.next_record(
+            outputs_[output].speculate_pc, record);
+        if (!error_string_.empty())
+            return sched_type_t::STATUS_INVALID;
+        // Leave the cur input where it is: the ordinals will remain unchanged.
+        return sched_type_t::STATUS_OK;
+    }
     while (true) {
         if (input->needs_init) {
             // We pay the cost of this conditional to support ipc_reader_t::init() which
@@ -972,6 +991,31 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
     VPRINT(this, 4, "next_record[%d]: from %d: ", output, input->index);
     VDO(this, 4, print_record(record););
 
+    outputs_[output].last_record = record;
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::start_speculation(output_ordinal_t output,
+                                                            addr_t start_address,
+                                                            bool queue_current_record)
+{
+    if (!outputs_[output].speculating && queue_current_record) {
+        inputs_[outputs_[output].cur_input].queue.push_back(outputs_[output].last_record);
+    }
+    outputs_[output].speculating = true;
+    outputs_[output].speculate_pc = start_address;
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::stop_speculation(output_ordinal_t output)
+{
+    if (!outputs_[output].speculating)
+        return sched_type_t::STATUS_INVALID;
+    outputs_[output].speculating = false;
     return sched_type_t::STATUS_OK;
 }
 

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -502,7 +502,8 @@ public:
          * record at that time, if "true" was passed for "queue_current_record" to
          * start_speculation(), or continuing on the subsequent record if "false" was
          * passed).  Returns #dynamorio::drmemtrace::scheduler_tmpl_t::STATUS_INVALID if
-         * there was no prior start_speculation() call.
+         * there was no prior start_speculation() call or if stop_speculation() was
+         * already called since the last start.
          */
         virtual stream_status_t
         stop_speculation();

--- a/clients/drcachesim/scheduler/speculator.cpp
+++ b/clients/drcachesim/scheduler/speculator.cpp
@@ -82,15 +82,15 @@ speculator_tmpl_t<memref_t>::next_record(addr_t &pc, memref_t &memref)
 
     int encoding;
     int len;
-#ifdef AARCH64
-    static constexpr int NOP_ENCODING = 0xd503201f;
-    encoding = NOP_ENCODING;
-    len = 4;
-#elif defined(X86_64) || defined(X86_32)
+#if defined(X86_64) || defined(X86_32)
     static constexpr int NOP_ENCODING = 0x90;
     encoding = NOP_ENCODING;
     len = 1;
-#elif defined(ARM)
+#elif defined(ARM_64)
+    static constexpr int NOP_ENCODING = 0xd503201f;
+    encoding = NOP_ENCODING;
+    len = 4;
+#elif defined(ARM_32)
     static constexpr int NOP_ENCODING_ARM = 0xe320f000;
     static constexpr int NOP_ENCODING_THUMB = 0xbf00;
     static constexpr int LEN_ARM = 4;

--- a/clients/drcachesim/scheduler/speculator.cpp
+++ b/clients/drcachesim/scheduler/speculator.cpp
@@ -1,0 +1,123 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <string.h>
+#include "speculator.h"
+#include "utils.h"
+
+#undef VPRINT
+#ifdef DEBUG
+#    define VPRINT(obj, level, ...)                            \
+        do {                                                   \
+            if ((obj)->verbosity_ >= (level)) {                \
+                fprintf(stderr, "%s ", (obj)->output_prefix_); \
+                fprintf(stderr, __VA_ARGS__);                  \
+            }                                                  \
+        } while (0)
+#else
+#    define VPRINT(reader, level, ...) /* Nothing. */
+#endif
+
+namespace dynamorio {
+namespace drmemtrace {
+
+template <typename RecordType>
+std::string
+speculator_tmpl_t<RecordType>::next_record(addr_t &pc, RecordType &record)
+{
+    return "Not implemented";
+}
+
+template <>
+std::string
+speculator_tmpl_t<memref_t>::next_record(addr_t &pc, memref_t &memref)
+{
+    if (TESTANY(LAST_FROM_TRACE | AVERAGE_FROM_TRACE, flags_)) {
+        // TODO i#5843: Add prior-seen-in-trace support by having the scheduler
+        // pass us every record so we can track prior instructions.  Instead of
+        // using the same data address as the most recent instance of a pc,
+        // we should use some weighted average across the last N instances.
+        return "Not implemented";
+    } else if (TESTANY(FROM_BINARY, flags_)) {
+        // TODO i#5843: Add support for grabbing never-seen instructions from the
+        // binary, if available.  We'll need module map info passed to us.
+    } else if (!TESTANY(USE_NOPS, flags_)) {
+        return "Invalid flags";
+    }
+
+    // Supply nops.
+    // Since this is just one encoding, we hardcoded it.
+    // If we add more we'll want to pull in DR's encoder and use its IR.
+    memref.instr.type = TRACE_TYPE_INSTR;
+    memref.instr.addr = pc;
+
+    int encoding;
+    int len;
+#ifdef AARCH64
+    static constexpr int NOP_ENCODING = 0xd503201f;
+    encoding = NOP_ENCODING;
+    len = 4;
+#elif defined(X86_64) || defined(X86_32)
+    static constexpr int NOP_ENCODING = 0x90;
+    encoding = NOP_ENCODING;
+    len = 1;
+#elif defined(ARM)
+    static constexpr int NOP_ENCODING_ARM = 0xe320f000;
+    static constexpr int NOP_ENCODING_THUMB = 0xbf00;
+    static constexpr int LEN_ARM = 4;
+    static constexpr int LEN_THUMB = 2;
+    // Trace PC values have LSB=1 for Thumb mode.
+    if (TESTANY(1, pc)) {
+        encoding = NOP_ENCODING_THUMB;
+        len = LEN_THUMB;
+    } else {
+        encoding = NOP_ENCODING_ARM;
+        len = LEN_ARM;
+    }
+#else
+    return "Not implemented";
+#endif
+    memref.instr.size = len;
+    memcpy(memref.instr.encoding, &encoding, len);
+    // We do not try to figure out whether we've emitted this same PC before.
+    memref.instr.encoding_is_new = true;
+
+    pc += len;
+
+    return "";
+}
+
+template class speculator_tmpl_t<memref_t>;
+template class speculator_tmpl_t<trace_entry_t>;
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/scheduler/speculator.h
+++ b/clients/drcachesim/scheduler/speculator.h
@@ -1,0 +1,106 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Speculative execution path instruction and data access generation. */
+
+#ifndef _DRMEMTRACE_SPECULATOR_H_
+#define _DRMEMTRACE_SPECULATOR_H_ 1
+
+/**
+ * @file drmemtrace/speculator.h
+ * @brief DrMemtrace trace speculative path generation.
+ */
+
+#include "memref.h"
+#include "utils.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+/**
+ * Provides instruction fetch and data access trace record generation for
+ * speculative paths that were not actually traced.  Supports a variety of
+ * methods for obtaining speculative content.
+ */
+template <typename RecordType> class speculator_tmpl_t {
+public:
+    /** Options controlling which speculation strategy to use. */
+    enum speculator_flags_t {
+        /**
+         * Specifies that speculation should supply just NOP instructions.
+         */
+        USE_NOPS = 0x01,
+        /**
+         * Specifies that speculation should supply the last-seen instruction
+         * and its data address.
+         */
+        LAST_FROM_TRACE = 0x02,
+        /**
+         * Specifies that speculation should supply an average (weighted, perhaps)
+         * of the last N observed instructions at the given PC.
+         */
+        AVERAGE_FROM_TRACE = 0x04,
+        /**
+         * Specifies that speculation should obtain the instruction from the binary.
+         * The address source is unspecified.
+         */
+        FROM_BINARY = 0x08,
+    };
+
+    /** Default constructor. */
+    speculator_tmpl_t(speculator_flags_t flags, int verbosity = 0)
+        : flags_(flags)
+        , verbosity_(verbosity)
+    {
+    }
+    virtual ~speculator_tmpl_t() = default;
+
+    // Returns a record for the instruction at "pc" and updates "pc" to the
+    // next fetch address.
+    virtual std::string
+    next_record(addr_t &pc, RecordType &record);
+
+protected:
+    speculator_flags_t flags_ = speculator_flags_t::SPECULATE_NOPS;
+    int verbosity_ = 0;
+};
+
+/** See #dynamorio::drmemtrace::speculator_tmpl_t. */
+typedef speculator_tmpl_t<memref_t> speculator_t;
+
+/** See #dynamorio::drmemtrace::speculator_tmpl_t. */
+typedef speculator_tmpl_t<trace_entry_t> record_speculator_t;
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _DRMEMTRACE_SPECULATOR_H_ */

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -86,7 +86,7 @@ static trace_entry_t
 make_instr(addr_t pc, trace_type_t type = TRACE_TYPE_INSTR)
 {
     trace_entry_t entry;
-    entry.type = type;
+    entry.type = static_cast<unsigned short>(type);
     entry.size = 1;
     entry.addr = pc;
     return entry;
@@ -152,7 +152,7 @@ make_marker(trace_marker_type_t type, uintptr_t value)
 {
     trace_entry_t entry;
     entry.type = TRACE_TYPE_MARKER;
-    entry.size = type;
+    entry.size = static_cast<unsigned short>(type);
     entry.addr = value;
     return entry;
 }
@@ -796,7 +796,8 @@ test_synthetic()
             }
             assert(status == scheduler_t::STATUS_OK);
             if (type_is_instr(memref.instr.type))
-                sched_as_string[i] += 'A' + (memref.instr.tid - TID_BASE);
+                sched_as_string[i] +=
+                    'A' + static_cast<char>(memref.instr.tid - TID_BASE);
         }
     }
     for (int i = 0; i < NUM_OUTPUTS; i++) {

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -97,7 +97,7 @@ make_exit(memref_tid_t tid)
 {
     trace_entry_t entry;
     entry.type = TRACE_TYPE_THREAD_EXIT;
-    entry.addr = tid;
+    entry.addr = static_cast<addr_t>(tid);
     return entry;
 }
 
@@ -124,7 +124,7 @@ make_thread(memref_tid_t tid)
 {
     trace_entry_t entry;
     entry.type = TRACE_TYPE_THREAD;
-    entry.addr = tid;
+    entry.addr = static_cast<addr_t>(tid);
     return entry;
 }
 
@@ -133,7 +133,7 @@ make_pid(memref_pid_t pid)
 {
     trace_entry_t entry;
     entry.type = TRACE_TYPE_PID;
-    entry.addr = pid;
+    entry.addr = static_cast<addr_t>(pid);
     return entry;
 }
 
@@ -143,7 +143,7 @@ make_timestamp(uint64_t timestamp)
     trace_entry_t entry;
     entry.type = TRACE_TYPE_MARKER;
     entry.size = TRACE_MARKER_TYPE_TIMESTAMP;
-    entry.addr = timestamp;
+    entry.addr = static_cast<addr_t>(timestamp);
     return entry;
 }
 
@@ -255,7 +255,7 @@ test_parallel()
         inputs[i] = input_sequence;
         for (auto &record : inputs[i]) {
             if (record.type == TRACE_TYPE_THREAD || record.type == TRACE_TYPE_THREAD_EXIT)
-                record.addr = tid;
+                record.addr = static_cast<addr_t>(tid);
         }
         std::vector<scheduler_t::input_reader_t> readers;
         readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[i])),
@@ -795,9 +795,10 @@ test_synthetic()
                 continue;
             }
             assert(status == scheduler_t::STATUS_OK);
-            if (type_is_instr(memref.instr.type))
+            if (type_is_instr(memref.instr.type)) {
                 sched_as_string[i] +=
                     'A' + static_cast<char>(memref.instr.tid - TID_BASE);
+            }
         }
     }
     for (int i = 0; i < NUM_OUTPUTS; i++) {


### PR DESCRIPTION
Implements initial speculation support, supplying nops.  Speculation is separated into its own class where we can fill in different strategies in the future.

The start_speculation() function takes a flag controlling whether the scheduler queues up the current record and re-returns it as the first record after speculation stops.  This is often what a simulator wants as it has to read the instruction record following a branch to determine whether it is on the wrong path, and it would like to resume with that already-read instruction after speculation.

Adds a unit test.

Issue: #5843