### PR TITLE
Remove instruction fetch from type_is_data()

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -508,10 +508,10 @@ type_has_address(const trace_type_t type)
 static inline bool
 type_is_data(const trace_type_t type)
 {
-    return type == TRACE_TYPE_INSTR_MAYBE_FETCH || type_is_prefetch(type) ||
-        type == TRACE_TYPE_READ || type == TRACE_TYPE_WRITE ||
-        type == TRACE_TYPE_INSTR_FLUSH || type == TRACE_TYPE_INSTR_FLUSH_END ||
-        type == TRACE_TYPE_DATA_FLUSH || type == TRACE_TYPE_DATA_FLUSH_END;
+    return type_is_prefetch(type) || type == TRACE_TYPE_READ ||
+        type == TRACE_TYPE_WRITE || type == TRACE_TYPE_INSTR_FLUSH ||
+        type == TRACE_TYPE_INSTR_FLUSH_END || type == TRACE_TYPE_DATA_FLUSH ||
+        type == TRACE_TYPE_DATA_FLUSH_END;
 }
 
 static inline bool


### PR DESCRIPTION
Removes the maybe-fetch type which was erroneously included in the type_is_data() helper function for drmemtrace types.