### PR TITLE
i#3044: AArch64 SVE codec: Fix misplaced predicates

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -144,8 +144,8 @@
 000001001111xxxx110001xxxxxxxxxx  n   841  SVE     decd          z_d_0 : z_d_0 pred_constr mul imm4_16p1
 000001000111xxxx111001xxxxxxxxxx  n   842  SVE     dech             x0 : x0 pred_constr mul imm4_16p1
 000001000111xxxx110001xxxxxxxxxx  n   842  SVE     dech          z_h_0 : z_h_0 pred_constr mul imm4_16p1
-00100101xx1011011000100xxxxxxxxx  n   822  SVE     decp             x0 : p_size_bhsd_5 x0
-00100101xx1011011000000xxxxxxxxx  n   822  SVE     decp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1011011000100xxxxxxxxx  n   822  SVE     decp             x0 : x0 p_size_bhsd_5
+00100101xx1011011000000xxxxxxxxx  n   822  SVE     decp   z_size_hsd_0 : z_size_hsd_0 p_size_hsd_5
 000001001011xxxx111001xxxxxxxxxx  n   847  SVE     decw             x0 : x0 pred_constr mul imm4_16p1
 000001001011xxxx110001xxxxxxxxxx  n   847  SVE     decw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
 00100101xx11100011xxxxxxxxxxxxxx  n   88   SVE      dup  z_size_bhsd_0 : simm8_5 lsl shift1
@@ -285,8 +285,8 @@
 000001001111xxxx110000xxxxxxxxxx  n   849  SVE     incd          z_d_0 : z_d_0 pred_constr mul imm4_16p1
 000001000111xxxx111000xxxxxxxxxx  n   850  SVE     inch             x0 : x0 pred_constr mul imm4_16p1
 000001000111xxxx110000xxxxxxxxxx  n   850  SVE     inch          z_h_0 : z_h_0 pred_constr mul imm4_16p1
-00100101xx1011001000100xxxxxxxxx  n   823  SVE     incp             x0 : p_size_bhsd_5 x0
-00100101xx1011001000000xxxxxxxxx  n   823  SVE     incp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1011001000100xxxxxxxxx  n   823  SVE     incp             x0 : x0 p_size_bhsd_5
+00100101xx1011001000000xxxxxxxxx  n   823  SVE     incp   z_size_hsd_0 : z_size_hsd_0 p_size_hsd_5
 000001001011xxxx111000xxxxxxxxxx  n   851  SVE     incw             x0 : x0 pred_constr mul imm4_16p1
 000001001011xxxx110000xxxxxxxxxx  n   851  SVE     incw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
 00000100xx1xxxxx010000xxxxxxxxxx  n   922  SVE    index  z_size_bhsd_0 : simm5_5 simm5
@@ -527,13 +527,13 @@
 00000100xx1xxxxx100101xxxxxxxxxx  n   904  SVE      lsr  z_tszl19_bhsd_0 : z_tszl19_bhsd_5 tszl19_imm3_16p1
 00000100xx1xxxxx100001xxxxxxxxxx  n   904  SVE      lsr   z_size_bhs_0 : z_size_bhs_5 z_d_16
 00000100xx010101100xxxxxxxxxxxxx  n   905  SVE     lsrr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
-00000100xx0xxxxx110xxxxxxxxxxxxx  n   787  SVE      mad  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_16 z_size_bhsd_5
-00000100xx0xxxxx010xxxxxxxxxxxxx  n   312  SVE      mla  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16 z_size_bhsd_0
-00000100xx0xxxxx011xxxxxxxxxxxxx  n   313  SVE      mls  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16 z_size_bhsd_0
+00000100xx0xxxxx110xxxxxxxxxxxxx  n   787  SVE      mad  z_size_bhsd_0 : z_size_bhsd_0 p10_mrg_lo z_size_bhsd_16 z_size_bhsd_5
+00000100xx0xxxxx010xxxxxxxxxxxxx  n   312  SVE      mla  z_size_bhsd_0 : z_size_bhsd_0 p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16
+00000100xx0xxxxx011xxxxxxxxxxxxx  n   313  SVE      mls  z_size_bhsd_0 : z_size_bhsd_0 p10_mrg_lo z_size_bhsd_5 z_size_bhsd_16
 0000010000100000101111xxxxxxxxxx  n   783  SVE  movprfx             z0 : z5
 00000100xx010000001xxxxxxxxxxxxx  n   783  SVE  movprfx  z_size_bhsd_0 : p10_zer_lo z_size_bhsd_5
 00000100xx010001001xxxxxxxxxxxxx  n   783  SVE  movprfx  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
-00000100xx0xxxxx111xxxxxxxxxxxxx  n   788  SVE      msb  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_16 z_size_bhsd_5
+00000100xx0xxxxx111xxxxxxxxxxxxx  n   788  SVE      msb  z_size_bhsd_0 : z_size_bhsd_0 p10_mrg_lo z_size_bhsd_16 z_size_bhsd_5
 00000100xx010000000xxxxxxxxxxxxx  n   321  SVE      mul  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00100101xx110000110xxxxxxxxxxxxx  n   321  SVE      mul  z_size_bhsd_0 : z_size_bhsd_0 simm8_5
 001001011000xxxx01xxxx1xxxx1xxxx  n   829  SVE     nand          p_b_0 : p10_zer p_b_5 p_b_16
@@ -644,9 +644,8 @@
 000001000110xxxx111110xxxxxxxxxx  n   843  SVE   sqdech             x0 : w0 pred_constr mul imm4_16p1
 000001000111xxxx111110xxxxxxxxxx  n   843  SVE   sqdech             x0 : x0 pred_constr mul imm4_16p1
 000001000110xxxx110010xxxxxxxxxx  n   843  SVE   sqdech          z_h_0 : z_h_0 pred_constr mul imm4_16p1
-00100101xx1010101000100xxxxxxxxx  n   824  SVE   sqdecp             x0 : p_size_bhsd_5 w0
-00100101xx1010101000110xxxxxxxxx  n   824  SVE   sqdecp             x0 : p_size_bhsd_5 x0
-00100101xx1010101000000xxxxxxxxx  n   824  SVE   sqdecp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1010101000110xxxxxxxxx  n   824  SVE   sqdecp             x0 : x0 p_size_bhsd_5
+00100101xx1010101000000xxxxxxxxx  n   824  SVE   sqdecp   z_size_hsd_0 : z_size_hsd_0 p_size_hsd_5
 000001001010xxxx111110xxxxxxxxxx  n   854  SVE   sqdecw             x0 : w0 pred_constr mul imm4_16p1
 000001001011xxxx111110xxxxxxxxxx  n   854  SVE   sqdecw             x0 : x0 pred_constr mul imm4_16p1
 000001001010xxxx110010xxxxxxxxxx  n   854  SVE   sqdecw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
@@ -659,8 +658,8 @@
 000001000111xxxx111100xxxxxxxxxx  n   857  SVE   sqinch             x0 : x0 pred_constr mul imm4_16p1
 000001000110xxxx110000xxxxxxxxxx  n   857  SVE   sqinch          z_h_0 : z_h_0 pred_constr mul imm4_16p1
 00100101xx1010001000100xxxxxxxxx  n   825  SVE   sqincp             x0 : p_size_bhsd_5 w0
-00100101xx1010001000110xxxxxxxxx  n   825  SVE   sqincp             x0 : p_size_bhsd_5 x0
-00100101xx1010001000000xxxxxxxxx  n   825  SVE   sqincp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1010001000110xxxxxxxxx  n   825  SVE   sqincp             x0 : x0 p_size_bhsd_5
+00100101xx1010001000000xxxxxxxxx  n   825  SVE   sqincp   z_size_hsd_0 : z_size_hsd_0 p_size_hsd_5
 000001001010xxxx111100xxxxxxxxxx  n   858  SVE   sqincw             x0 : w0 pred_constr mul imm4_16p1
 000001001011xxxx111100xxxxxxxxxx  n   858  SVE   sqincw             x0 : x0 pred_constr mul imm4_16p1
 000001001010xxxx110000xxxxxxxxxx  n   858  SVE   sqincw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
@@ -801,9 +800,9 @@
 000001000110xxxx111111xxxxxxxxxx  n   861  SVE   uqdech             w0 : w0 pred_constr mul imm4_16p1
 000001000111xxxx111111xxxxxxxxxx  n   861  SVE   uqdech             x0 : x0 pred_constr mul imm4_16p1
 000001000110xxxx110011xxxxxxxxxx  n   861  SVE   uqdech          z_h_0 : z_h_0 pred_constr mul imm4_16p1
-00100101xx1010111000100xxxxxxxxx  n   826  SVE   uqdecp             w0 : p_size_bhsd_5 w0
-00100101xx1010111000110xxxxxxxxx  n   826  SVE   uqdecp             x0 : p_size_bhsd_5 x0
-00100101xx1010111000000xxxxxxxxx  n   826  SVE   uqdecp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1010111000100xxxxxxxxx  n   826  SVE   uqdecp             w0 : w0 p_size_bhsd_5
+00100101xx1010111000110xxxxxxxxx  n   826  SVE   uqdecp             x0 : x0 p_size_bhsd_5
+00100101xx1010111000000xxxxxxxxx  n   826  SVE   uqdecp   z_size_hsd_0 : z_size_hsd_0 p_size_hsd_5
 000001001010xxxx111111xxxxxxxxxx  n   862  SVE   uqdecw             w0 : w0 pred_constr mul imm4_16p1
 000001001011xxxx111111xxxxxxxxxx  n   862  SVE   uqdecw             x0 : x0 pred_constr mul imm4_16p1
 000001001010xxxx110011xxxxxxxxxx  n   862  SVE   uqdecw          z_s_0 : z_s_0 pred_constr mul imm4_16p1
@@ -815,9 +814,9 @@
 000001000110xxxx111101xxxxxxxxxx  n   865  SVE   uqinch             w0 : w0 pred_constr mul imm4_16p1
 000001000111xxxx111101xxxxxxxxxx  n   865  SVE   uqinch             x0 : x0 pred_constr mul imm4_16p1
 000001000110xxxx110001xxxxxxxxxx  n   865  SVE   uqinch          z_h_0 : z_h_0 pred_constr mul imm4_16p1
-00100101xx1010011000100xxxxxxxxx  n   827  SVE   uqincp             w0 : p_size_bhsd_5 w0
-00100101xx1010011000110xxxxxxxxx  n   827  SVE   uqincp             x0 : p_size_bhsd_5 x0
-00100101xx1010011000000xxxxxxxxx  n   827  SVE   uqincp   z_size_hsd_0 : p_size_hsd_5 z_size_hsd_0
+00100101xx1010011000100xxxxxxxxx  n   827  SVE   uqincp             w0 : w0 p_size_bhsd_5
+00100101xx1010011000110xxxxxxxxx  n   827  SVE   uqincp             x0 : x0 p_size_bhsd_5
+00100101xx1010011000000xxxxxxxxx  n   827  SVE   uqincp   z_size_hsd_0 : z_size_hsd_0 p_size_hsd_5
 000001001010xxxx111101xxxxxxxxxx  n   866  SVE   uqincw             w0 : w0 pred_constr mul imm4_16p1
 000001001011xxxx111101xxxxxxxxxx  n   866  SVE   uqincw             x0 : x0 pred_constr mul imm4_16p1
 000001001010xxxx110001xxxxxxxxxx  n   866  SVE   uqincw          z_s_0 : z_s_0 pred_constr mul imm4_16p1

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -5656,13 +5656,13 @@
  *    MAD     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The first source and destination vector register, Z (Scalable)
- * \param Pg   The governing predicate register, P (Predicate)
- * \param Zm   The second source vector register, Z (Scalable)
- * \param Za   The third source vector register, Z (Scalable)
+ * \param Zdn   The source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zm   The second source vector register, Z (Scalable).
+ * \param Za   The third source vector register, Z (Scalable).
  */
 #define INSTR_CREATE_mad_sve_pred(dc, Zdn, Pg, Zm, Za) \
-    instr_create_1dst_4src(dc, OP_mad, Zdn, Pg, Zdn, Zm, Za)
+    instr_create_1dst_4src(dc, OP_mad, Zdn, Zdn, Pg, Zm, Za)
 
 /**
  * Creates a MLA instruction.
@@ -5672,13 +5672,13 @@
  *    MLA     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zda   The third source and destination vector register, Z (Scalable)
- * \param Pg   The governing predicate register, P (Predicate)
- * \param Zn   The first source vector register, Z (Scalable)
- * \param Zm   The second source vector register, Z (Scalable)
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
  */
 #define INSTR_CREATE_mla_sve_pred(dc, Zda, Pg, Zn, Zm) \
-    instr_create_1dst_4src(dc, OP_mla, Zda, Pg, Zn, Zm, Zda)
+    instr_create_1dst_4src(dc, OP_mla, Zda, Zda, Pg, Zn, Zm)
 
 /**
  * Creates a MLS instruction.
@@ -5688,13 +5688,13 @@
  *    MLS     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zda   The third source and destination vector register, Z (Scalable)
- * \param Pg   The governing predicate register, P (Predicate)
- * \param Zn   The first source vector register, Z (Scalable)
- * \param Zm   The second source vector register, Z (Scalable)
+ * \param Zda   The source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The second source vector register, Z (Scalable).
+ * \param Zm   The third source vector register, Z (Scalable).
  */
 #define INSTR_CREATE_mls_sve_pred(dc, Zda, Pg, Zn, Zm) \
-    instr_create_1dst_4src(dc, OP_mls, Zda, Pg, Zn, Zm, Zda)
+    instr_create_1dst_4src(dc, OP_mls, Zda, Zda, Pg, Zn, Zm)
 
 /**
  * Creates a MSB instruction.
@@ -5704,13 +5704,13 @@
  *    MSB     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The first source and destination vector register, Z (Scalable)
- * \param Pg   The governing predicate register, P (Predicate)
- * \param Zm   The second source vector register, Z (Scalable)
- * \param Za   The third source vector register, Z (Scalable)
+ * \param Zdn   The source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zm   The second source vector register, Z (Scalable).
+ * \param Za   The third source vector register, Z (Scalable).
  */
 #define INSTR_CREATE_msb_sve_pred(dc, Zdn, Pg, Zm, Za) \
-    instr_create_1dst_4src(dc, OP_msb, Zdn, Pg, Zdn, Zm, Za)
+    instr_create_1dst_4src(dc, OP_msb, Zdn, Zdn, Pg, Zm, Za)
 
 /**
  * Creates a MUL instruction.
@@ -6816,11 +6816,11 @@
  *    DECP    <Xdn>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rdn   The second source and destination register, X (Extended, 64 bits).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Rdn   The GPR register to be decremented, X (Extended, 64 bits).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_decp_sve(dc, Rdn, Pm) \
-    instr_create_1dst_2src(dc, OP_decp, Rdn, Pm, Rdn)
+    instr_create_1dst_2src(dc, OP_decp, Rdn, Rdn, Pm)
 
 /**
  * Creates a DECP instruction.
@@ -6830,11 +6830,11 @@
  *    DECP    <Zdn>.<Ts>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The second source and destination vector register, Z (Scalable).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Zdn   The vector register to be decremented, Z (Scalable).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_decp_sve_vector(dc, Zdn, Pm) \
-    instr_create_1dst_2src(dc, OP_decp, Zdn, Pm, Zdn)
+    instr_create_1dst_2src(dc, OP_decp, Zdn, Zdn, Pm)
 
 /**
  * Creates an INCP instruction.
@@ -6844,11 +6844,12 @@
  *    INCP    <Xdn>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rdn   The second source and destination register, X (Extended, 64 bits).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Rdn   The first source and destination  register, X (Extended, 64
+ *              bits).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_incp_sve(dc, Rdn, Pm) \
-    instr_create_1dst_2src(dc, OP_incp, Rdn, Pm, Rdn)
+    instr_create_1dst_2src(dc, OP_incp, Rdn, Rdn, Pm)
 
 /**
  * Creates an INCP instruction.
@@ -6858,11 +6859,11 @@
  *    INCP    <Zdn>.<Ts>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The second source and destination vector register, Z (Scalable).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Zdn   The source and destination vector register, Z (Scalable).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_incp_sve_vector(dc, Zdn, Pm) \
-    instr_create_1dst_2src(dc, OP_incp, Zdn, Pm, Zdn)
+    instr_create_1dst_2src(dc, OP_incp, Zdn, Zdn, Pm)
 
 /**
  * Creates a SQDECP instruction.
@@ -6872,11 +6873,12 @@
  *    SQDECP  <Xdn>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rdn   The source and destination register, X (Extended, 64 bits).
- * \param Pm   The source predicate register, P (Predicate).
+ * \param Rdn   The first source and destination  register, X (Extended, 64
+ *              bits).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_sqdecp_sve(dc, Rdn, Pm) \
-    instr_create_1dst_2src(dc, OP_sqdecp, Rdn, Pm, Rdn)
+    instr_create_1dst_2src(dc, OP_sqdecp, Rdn, Rdn, Pm)
 
 /**
  * Creates a SQDECP instruction.
@@ -6901,11 +6903,11 @@
  *    SQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The second source and destination vector register, Z (Scalable).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Zdn   The source and destination vector register, Z (Scalable).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_sqdecp_sve_vector(dc, Zdn, Pm) \
-    instr_create_1dst_2src(dc, OP_sqdecp, Zdn, Pm, Zdn)
+    instr_create_1dst_2src(dc, OP_sqdecp, Zdn, Zdn, Pm)
 
 /**
  * Creates a SQINCP instruction.
@@ -6915,11 +6917,12 @@
  *    SQINCP  <Xdn>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rdn   The second source and destination register, X (Extended, 64 bits).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Rdn   The first source and destination  register, X (Extended, 64
+ *              bits).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_sqincp_sve(dc, Rdn, Pm) \
-    instr_create_1dst_2src(dc, OP_sqincp, Rdn, Pm, Rdn)
+    instr_create_1dst_2src(dc, OP_sqincp, Rdn, Rdn, Pm)
 
 /**
  * Creates a SQINCP instruction.
@@ -6929,7 +6932,9 @@
  *    SQINCP  <Xdn>, <Pm>.<Ts>, <Wdn>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rdn   The second source and destination register, X (Extended, 64 bits).
+ * \param Rdn   The second source and destination  register, X (Extended, 64
+ *              bits). The 32 bit result from the source
+ *              register is sign extended to 64 bits.
  * \param Pm   The first source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_sqincp_sve_wide(dc, Rdn, Pm)  \
@@ -6944,11 +6949,11 @@
  *    SQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The second source and destination vector register, Z (Scalable).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Zdn   The source and destination vector register, Z (Scalable).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_sqincp_sve_vector(dc, Zdn, Pm) \
-    instr_create_1dst_2src(dc, OP_sqincp, Zdn, Pm, Zdn)
+    instr_create_1dst_2src(dc, OP_sqincp, Zdn, Zdn, Pm)
 
 /**
  * Creates an UQDECP instruction.
@@ -6959,11 +6964,12 @@
  *    UQDECP  <Xdn>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rdn   The second source and destination register. Can be X (Extended, 64 bits)
- * or W (Word, 32 bits). \param Pm   The first source predicate register, P (Predicate).
+ * \param Rdn   The first source and destination  register. Can be W (Word, 32
+ *              bits) or X (Extended, 64 bits).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_uqdecp_sve(dc, Rdn, Pm) \
-    instr_create_1dst_2src(dc, OP_uqdecp, Rdn, Pm, Rdn)
+    instr_create_1dst_2src(dc, OP_uqdecp, Rdn, Rdn, Pm)
 
 /**
  * Creates an UQDECP instruction.
@@ -6973,11 +6979,11 @@
  *    UQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The second source and destination vector register, Z (Scalable).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Zdn   The source and destination vector register, Z (Scalable).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_uqdecp_sve_vector(dc, Zdn, Pm) \
-    instr_create_1dst_2src(dc, OP_uqdecp, Zdn, Pm, Zdn)
+    instr_create_1dst_2src(dc, OP_uqdecp, Zdn, Zdn, Pm)
 
 /**
  * Creates an UQINCP instruction.
@@ -6988,11 +6994,12 @@
  *    UQINCP  <Xdn>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Rdn   The second source and destination register. Can be X (Extended, 64 bits)
- * or W (Word, 32 bits). \param Pm   The first source predicate register, P (Predicate).
+ * \param Rdn   The first source and destination  register. Can be W (Word, 32
+ *              bits) or X (Extended, 64 bits).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_uqincp_sve(dc, Rdn, Pm) \
-    instr_create_1dst_2src(dc, OP_uqincp, Rdn, Pm, Rdn)
+    instr_create_1dst_2src(dc, OP_uqincp, Rdn, Rdn, Pm)
 
 /**
  * Creates an UQINCP instruction.
@@ -7002,11 +7009,11 @@
  *    UQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zdn   The second source and destination vector register, Z (Scalable).
- * \param Pm   The first source predicate register, P (Predicate).
+ * \param Zdn   The source and destination vector register, Z (Scalable).
+ * \param Pm   The second source predicate register, P (Predicate).
  */
 #define INSTR_CREATE_uqincp_sve_vector(dc, Zdn, Pm) \
-    instr_create_1dst_2src(dc, OP_uqincp, Zdn, Pm, Zdn)
+    instr_create_1dst_2src(dc, OP_uqincp, Zdn, Zdn, Pm)
 
 /**
  * Creates an AND instruction.

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -4786,120 +4786,120 @@
 047fe7fe : dech x30, ALL, MUL #16                    : dech   %x30 ALL mul $0x10 -> %x30
 
 # DECP    <Xdn>, <Pm>.<T> (DECP-R.P.R-_)
-252d8800 : decp x0, p0.b                             : decp   %p0.b %x0 -> %x0
-252d8842 : decp x2, p2.b                             : decp   %p2.b %x2 -> %x2
-252d8864 : decp x4, p3.b                             : decp   %p3.b %x4 -> %x4
-252d8886 : decp x6, p4.b                             : decp   %p4.b %x6 -> %x6
-252d88a8 : decp x8, p5.b                             : decp   %p5.b %x8 -> %x8
-252d88c9 : decp x9, p6.b                             : decp   %p6.b %x9 -> %x9
-252d88eb : decp x11, p7.b                            : decp   %p7.b %x11 -> %x11
-252d890d : decp x13, p8.b                            : decp   %p8.b %x13 -> %x13
-252d892f : decp x15, p9.b                            : decp   %p9.b %x15 -> %x15
-252d8931 : decp x17, p9.b                            : decp   %p9.b %x17 -> %x17
-252d8953 : decp x19, p10.b                           : decp   %p10.b %x19 -> %x19
-252d8975 : decp x21, p11.b                           : decp   %p11.b %x21 -> %x21
-252d8996 : decp x22, p12.b                           : decp   %p12.b %x22 -> %x22
-252d89b8 : decp x24, p13.b                           : decp   %p13.b %x24 -> %x24
-252d89da : decp x26, p14.b                           : decp   %p14.b %x26 -> %x26
-252d89fe : decp x30, p15.b                           : decp   %p15.b %x30 -> %x30
-256d8800 : decp x0, p0.h                             : decp   %p0.h %x0 -> %x0
-256d8842 : decp x2, p2.h                             : decp   %p2.h %x2 -> %x2
-256d8864 : decp x4, p3.h                             : decp   %p3.h %x4 -> %x4
-256d8886 : decp x6, p4.h                             : decp   %p4.h %x6 -> %x6
-256d88a8 : decp x8, p5.h                             : decp   %p5.h %x8 -> %x8
-256d88c9 : decp x9, p6.h                             : decp   %p6.h %x9 -> %x9
-256d88eb : decp x11, p7.h                            : decp   %p7.h %x11 -> %x11
-256d890d : decp x13, p8.h                            : decp   %p8.h %x13 -> %x13
-256d892f : decp x15, p9.h                            : decp   %p9.h %x15 -> %x15
-256d8931 : decp x17, p9.h                            : decp   %p9.h %x17 -> %x17
-256d8953 : decp x19, p10.h                           : decp   %p10.h %x19 -> %x19
-256d8975 : decp x21, p11.h                           : decp   %p11.h %x21 -> %x21
-256d8996 : decp x22, p12.h                           : decp   %p12.h %x22 -> %x22
-256d89b8 : decp x24, p13.h                           : decp   %p13.h %x24 -> %x24
-256d89da : decp x26, p14.h                           : decp   %p14.h %x26 -> %x26
-256d89fe : decp x30, p15.h                           : decp   %p15.h %x30 -> %x30
-25ad8800 : decp x0, p0.s                             : decp   %p0.s %x0 -> %x0
-25ad8842 : decp x2, p2.s                             : decp   %p2.s %x2 -> %x2
-25ad8864 : decp x4, p3.s                             : decp   %p3.s %x4 -> %x4
-25ad8886 : decp x6, p4.s                             : decp   %p4.s %x6 -> %x6
-25ad88a8 : decp x8, p5.s                             : decp   %p5.s %x8 -> %x8
-25ad88c9 : decp x9, p6.s                             : decp   %p6.s %x9 -> %x9
-25ad88eb : decp x11, p7.s                            : decp   %p7.s %x11 -> %x11
-25ad890d : decp x13, p8.s                            : decp   %p8.s %x13 -> %x13
-25ad892f : decp x15, p9.s                            : decp   %p9.s %x15 -> %x15
-25ad8931 : decp x17, p9.s                            : decp   %p9.s %x17 -> %x17
-25ad8953 : decp x19, p10.s                           : decp   %p10.s %x19 -> %x19
-25ad8975 : decp x21, p11.s                           : decp   %p11.s %x21 -> %x21
-25ad8996 : decp x22, p12.s                           : decp   %p12.s %x22 -> %x22
-25ad89b8 : decp x24, p13.s                           : decp   %p13.s %x24 -> %x24
-25ad89da : decp x26, p14.s                           : decp   %p14.s %x26 -> %x26
-25ad89fe : decp x30, p15.s                           : decp   %p15.s %x30 -> %x30
-25ed8800 : decp x0, p0.d                             : decp   %p0.d %x0 -> %x0
-25ed8842 : decp x2, p2.d                             : decp   %p2.d %x2 -> %x2
-25ed8864 : decp x4, p3.d                             : decp   %p3.d %x4 -> %x4
-25ed8886 : decp x6, p4.d                             : decp   %p4.d %x6 -> %x6
-25ed88a8 : decp x8, p5.d                             : decp   %p5.d %x8 -> %x8
-25ed88c9 : decp x9, p6.d                             : decp   %p6.d %x9 -> %x9
-25ed88eb : decp x11, p7.d                            : decp   %p7.d %x11 -> %x11
-25ed890d : decp x13, p8.d                            : decp   %p8.d %x13 -> %x13
-25ed892f : decp x15, p9.d                            : decp   %p9.d %x15 -> %x15
-25ed8931 : decp x17, p9.d                            : decp   %p9.d %x17 -> %x17
-25ed8953 : decp x19, p10.d                           : decp   %p10.d %x19 -> %x19
-25ed8975 : decp x21, p11.d                           : decp   %p11.d %x21 -> %x21
-25ed8996 : decp x22, p12.d                           : decp   %p12.d %x22 -> %x22
-25ed89b8 : decp x24, p13.d                           : decp   %p13.d %x24 -> %x24
-25ed89da : decp x26, p14.d                           : decp   %p14.d %x26 -> %x26
-25ed89fe : decp x30, p15.d                           : decp   %p15.d %x30 -> %x30
+252d8800 : decp x0, p0.b                             : decp   %x0 %p0.b -> %x0
+252d8842 : decp x2, p2.b                             : decp   %x2 %p2.b -> %x2
+252d8864 : decp x4, p3.b                             : decp   %x4 %p3.b -> %x4
+252d8886 : decp x6, p4.b                             : decp   %x6 %p4.b -> %x6
+252d88a8 : decp x8, p5.b                             : decp   %x8 %p5.b -> %x8
+252d88c9 : decp x9, p6.b                             : decp   %x9 %p6.b -> %x9
+252d88eb : decp x11, p7.b                            : decp   %x11 %p7.b -> %x11
+252d890d : decp x13, p8.b                            : decp   %x13 %p8.b -> %x13
+252d892f : decp x15, p9.b                            : decp   %x15 %p9.b -> %x15
+252d8931 : decp x17, p9.b                            : decp   %x17 %p9.b -> %x17
+252d8953 : decp x19, p10.b                           : decp   %x19 %p10.b -> %x19
+252d8975 : decp x21, p11.b                           : decp   %x21 %p11.b -> %x21
+252d8996 : decp x22, p12.b                           : decp   %x22 %p12.b -> %x22
+252d89b8 : decp x24, p13.b                           : decp   %x24 %p13.b -> %x24
+252d89da : decp x26, p14.b                           : decp   %x26 %p14.b -> %x26
+252d89fe : decp x30, p15.b                           : decp   %x30 %p15.b -> %x30
+256d8800 : decp x0, p0.h                             : decp   %x0 %p0.h -> %x0
+256d8842 : decp x2, p2.h                             : decp   %x2 %p2.h -> %x2
+256d8864 : decp x4, p3.h                             : decp   %x4 %p3.h -> %x4
+256d8886 : decp x6, p4.h                             : decp   %x6 %p4.h -> %x6
+256d88a8 : decp x8, p5.h                             : decp   %x8 %p5.h -> %x8
+256d88c9 : decp x9, p6.h                             : decp   %x9 %p6.h -> %x9
+256d88eb : decp x11, p7.h                            : decp   %x11 %p7.h -> %x11
+256d890d : decp x13, p8.h                            : decp   %x13 %p8.h -> %x13
+256d892f : decp x15, p9.h                            : decp   %x15 %p9.h -> %x15
+256d8931 : decp x17, p9.h                            : decp   %x17 %p9.h -> %x17
+256d8953 : decp x19, p10.h                           : decp   %x19 %p10.h -> %x19
+256d8975 : decp x21, p11.h                           : decp   %x21 %p11.h -> %x21
+256d8996 : decp x22, p12.h                           : decp   %x22 %p12.h -> %x22
+256d89b8 : decp x24, p13.h                           : decp   %x24 %p13.h -> %x24
+256d89da : decp x26, p14.h                           : decp   %x26 %p14.h -> %x26
+256d89fe : decp x30, p15.h                           : decp   %x30 %p15.h -> %x30
+25ad8800 : decp x0, p0.s                             : decp   %x0 %p0.s -> %x0
+25ad8842 : decp x2, p2.s                             : decp   %x2 %p2.s -> %x2
+25ad8864 : decp x4, p3.s                             : decp   %x4 %p3.s -> %x4
+25ad8886 : decp x6, p4.s                             : decp   %x6 %p4.s -> %x6
+25ad88a8 : decp x8, p5.s                             : decp   %x8 %p5.s -> %x8
+25ad88c9 : decp x9, p6.s                             : decp   %x9 %p6.s -> %x9
+25ad88eb : decp x11, p7.s                            : decp   %x11 %p7.s -> %x11
+25ad890d : decp x13, p8.s                            : decp   %x13 %p8.s -> %x13
+25ad892f : decp x15, p9.s                            : decp   %x15 %p9.s -> %x15
+25ad8931 : decp x17, p9.s                            : decp   %x17 %p9.s -> %x17
+25ad8953 : decp x19, p10.s                           : decp   %x19 %p10.s -> %x19
+25ad8975 : decp x21, p11.s                           : decp   %x21 %p11.s -> %x21
+25ad8996 : decp x22, p12.s                           : decp   %x22 %p12.s -> %x22
+25ad89b8 : decp x24, p13.s                           : decp   %x24 %p13.s -> %x24
+25ad89da : decp x26, p14.s                           : decp   %x26 %p14.s -> %x26
+25ad89fe : decp x30, p15.s                           : decp   %x30 %p15.s -> %x30
+25ed8800 : decp x0, p0.d                             : decp   %x0 %p0.d -> %x0
+25ed8842 : decp x2, p2.d                             : decp   %x2 %p2.d -> %x2
+25ed8864 : decp x4, p3.d                             : decp   %x4 %p3.d -> %x4
+25ed8886 : decp x6, p4.d                             : decp   %x6 %p4.d -> %x6
+25ed88a8 : decp x8, p5.d                             : decp   %x8 %p5.d -> %x8
+25ed88c9 : decp x9, p6.d                             : decp   %x9 %p6.d -> %x9
+25ed88eb : decp x11, p7.d                            : decp   %x11 %p7.d -> %x11
+25ed890d : decp x13, p8.d                            : decp   %x13 %p8.d -> %x13
+25ed892f : decp x15, p9.d                            : decp   %x15 %p9.d -> %x15
+25ed8931 : decp x17, p9.d                            : decp   %x17 %p9.d -> %x17
+25ed8953 : decp x19, p10.d                           : decp   %x19 %p10.d -> %x19
+25ed8975 : decp x21, p11.d                           : decp   %x21 %p11.d -> %x21
+25ed8996 : decp x22, p12.d                           : decp   %x22 %p12.d -> %x22
+25ed89b8 : decp x24, p13.d                           : decp   %x24 %p13.d -> %x24
+25ed89da : decp x26, p14.d                           : decp   %x26 %p14.d -> %x26
+25ed89fe : decp x30, p15.d                           : decp   %x30 %p15.d -> %x30
 
 # DECP    <Zdn>.<T>, <Pm>.<T> (DECP-Z.P.Z-_)
-256d8000 : decp z0.h, p0                             : decp   %p0.h %z0.h -> %z0.h
-256d8042 : decp z2.h, p2                             : decp   %p2.h %z2.h -> %z2.h
-256d8064 : decp z4.h, p3                             : decp   %p3.h %z4.h -> %z4.h
-256d8086 : decp z6.h, p4                             : decp   %p4.h %z6.h -> %z6.h
-256d80a8 : decp z8.h, p5                             : decp   %p5.h %z8.h -> %z8.h
-256d80ca : decp z10.h, p6                            : decp   %p6.h %z10.h -> %z10.h
-256d80ec : decp z12.h, p7                            : decp   %p7.h %z12.h -> %z12.h
-256d810e : decp z14.h, p8                            : decp   %p8.h %z14.h -> %z14.h
-256d8130 : decp z16.h, p9                            : decp   %p9.h %z16.h -> %z16.h
-256d8131 : decp z17.h, p9                            : decp   %p9.h %z17.h -> %z17.h
-256d8153 : decp z19.h, p10                           : decp   %p10.h %z19.h -> %z19.h
-256d8175 : decp z21.h, p11                           : decp   %p11.h %z21.h -> %z21.h
-256d8197 : decp z23.h, p12                           : decp   %p12.h %z23.h -> %z23.h
-256d81b9 : decp z25.h, p13                           : decp   %p13.h %z25.h -> %z25.h
-256d81db : decp z27.h, p14                           : decp   %p14.h %z27.h -> %z27.h
-256d81ff : decp z31.h, p15                           : decp   %p15.h %z31.h -> %z31.h
-25ad8000 : decp z0.s, p0                             : decp   %p0.s %z0.s -> %z0.s
-25ad8042 : decp z2.s, p2                             : decp   %p2.s %z2.s -> %z2.s
-25ad8064 : decp z4.s, p3                             : decp   %p3.s %z4.s -> %z4.s
-25ad8086 : decp z6.s, p4                             : decp   %p4.s %z6.s -> %z6.s
-25ad80a8 : decp z8.s, p5                             : decp   %p5.s %z8.s -> %z8.s
-25ad80ca : decp z10.s, p6                            : decp   %p6.s %z10.s -> %z10.s
-25ad80ec : decp z12.s, p7                            : decp   %p7.s %z12.s -> %z12.s
-25ad810e : decp z14.s, p8                            : decp   %p8.s %z14.s -> %z14.s
-25ad8130 : decp z16.s, p9                            : decp   %p9.s %z16.s -> %z16.s
-25ad8131 : decp z17.s, p9                            : decp   %p9.s %z17.s -> %z17.s
-25ad8153 : decp z19.s, p10                           : decp   %p10.s %z19.s -> %z19.s
-25ad8175 : decp z21.s, p11                           : decp   %p11.s %z21.s -> %z21.s
-25ad8197 : decp z23.s, p12                           : decp   %p12.s %z23.s -> %z23.s
-25ad81b9 : decp z25.s, p13                           : decp   %p13.s %z25.s -> %z25.s
-25ad81db : decp z27.s, p14                           : decp   %p14.s %z27.s -> %z27.s
-25ad81ff : decp z31.s, p15                           : decp   %p15.s %z31.s -> %z31.s
-25ed8000 : decp z0.d, p0                             : decp   %p0.d %z0.d -> %z0.d
-25ed8042 : decp z2.d, p2                             : decp   %p2.d %z2.d -> %z2.d
-25ed8064 : decp z4.d, p3                             : decp   %p3.d %z4.d -> %z4.d
-25ed8086 : decp z6.d, p4                             : decp   %p4.d %z6.d -> %z6.d
-25ed80a8 : decp z8.d, p5                             : decp   %p5.d %z8.d -> %z8.d
-25ed80ca : decp z10.d, p6                            : decp   %p6.d %z10.d -> %z10.d
-25ed80ec : decp z12.d, p7                            : decp   %p7.d %z12.d -> %z12.d
-25ed810e : decp z14.d, p8                            : decp   %p8.d %z14.d -> %z14.d
-25ed8130 : decp z16.d, p9                            : decp   %p9.d %z16.d -> %z16.d
-25ed8131 : decp z17.d, p9                            : decp   %p9.d %z17.d -> %z17.d
-25ed8153 : decp z19.d, p10                           : decp   %p10.d %z19.d -> %z19.d
-25ed8175 : decp z21.d, p11                           : decp   %p11.d %z21.d -> %z21.d
-25ed8197 : decp z23.d, p12                           : decp   %p12.d %z23.d -> %z23.d
-25ed81b9 : decp z25.d, p13                           : decp   %p13.d %z25.d -> %z25.d
-25ed81db : decp z27.d, p14                           : decp   %p14.d %z27.d -> %z27.d
-25ed81ff : decp z31.d, p15                           : decp   %p15.d %z31.d -> %z31.d
+256d8000 : decp z0.h, p0                             : decp   %z0.h %p0.h -> %z0.h
+256d8042 : decp z2.h, p2                             : decp   %z2.h %p2.h -> %z2.h
+256d8064 : decp z4.h, p3                             : decp   %z4.h %p3.h -> %z4.h
+256d8086 : decp z6.h, p4                             : decp   %z6.h %p4.h -> %z6.h
+256d80a8 : decp z8.h, p5                             : decp   %z8.h %p5.h -> %z8.h
+256d80ca : decp z10.h, p6                            : decp   %z10.h %p6.h -> %z10.h
+256d80ec : decp z12.h, p7                            : decp   %z12.h %p7.h -> %z12.h
+256d810e : decp z14.h, p8                            : decp   %z14.h %p8.h -> %z14.h
+256d8130 : decp z16.h, p9                            : decp   %z16.h %p9.h -> %z16.h
+256d8131 : decp z17.h, p9                            : decp   %z17.h %p9.h -> %z17.h
+256d8153 : decp z19.h, p10                           : decp   %z19.h %p10.h -> %z19.h
+256d8175 : decp z21.h, p11                           : decp   %z21.h %p11.h -> %z21.h
+256d8197 : decp z23.h, p12                           : decp   %z23.h %p12.h -> %z23.h
+256d81b9 : decp z25.h, p13                           : decp   %z25.h %p13.h -> %z25.h
+256d81db : decp z27.h, p14                           : decp   %z27.h %p14.h -> %z27.h
+256d81ff : decp z31.h, p15                           : decp   %z31.h %p15.h -> %z31.h
+25ad8000 : decp z0.s, p0                             : decp   %z0.s %p0.s -> %z0.s
+25ad8042 : decp z2.s, p2                             : decp   %z2.s %p2.s -> %z2.s
+25ad8064 : decp z4.s, p3                             : decp   %z4.s %p3.s -> %z4.s
+25ad8086 : decp z6.s, p4                             : decp   %z6.s %p4.s -> %z6.s
+25ad80a8 : decp z8.s, p5                             : decp   %z8.s %p5.s -> %z8.s
+25ad80ca : decp z10.s, p6                            : decp   %z10.s %p6.s -> %z10.s
+25ad80ec : decp z12.s, p7                            : decp   %z12.s %p7.s -> %z12.s
+25ad810e : decp z14.s, p8                            : decp   %z14.s %p8.s -> %z14.s
+25ad8130 : decp z16.s, p9                            : decp   %z16.s %p9.s -> %z16.s
+25ad8131 : decp z17.s, p9                            : decp   %z17.s %p9.s -> %z17.s
+25ad8153 : decp z19.s, p10                           : decp   %z19.s %p10.s -> %z19.s
+25ad8175 : decp z21.s, p11                           : decp   %z21.s %p11.s -> %z21.s
+25ad8197 : decp z23.s, p12                           : decp   %z23.s %p12.s -> %z23.s
+25ad81b9 : decp z25.s, p13                           : decp   %z25.s %p13.s -> %z25.s
+25ad81db : decp z27.s, p14                           : decp   %z27.s %p14.s -> %z27.s
+25ad81ff : decp z31.s, p15                           : decp   %z31.s %p15.s -> %z31.s
+25ed8000 : decp z0.d, p0                             : decp   %z0.d %p0.d -> %z0.d
+25ed8042 : decp z2.d, p2                             : decp   %z2.d %p2.d -> %z2.d
+25ed8064 : decp z4.d, p3                             : decp   %z4.d %p3.d -> %z4.d
+25ed8086 : decp z6.d, p4                             : decp   %z6.d %p4.d -> %z6.d
+25ed80a8 : decp z8.d, p5                             : decp   %z8.d %p5.d -> %z8.d
+25ed80ca : decp z10.d, p6                            : decp   %z10.d %p6.d -> %z10.d
+25ed80ec : decp z12.d, p7                            : decp   %z12.d %p7.d -> %z12.d
+25ed810e : decp z14.d, p8                            : decp   %z14.d %p8.d -> %z14.d
+25ed8130 : decp z16.d, p9                            : decp   %z16.d %p9.d -> %z16.d
+25ed8131 : decp z17.d, p9                            : decp   %z17.d %p9.d -> %z17.d
+25ed8153 : decp z19.d, p10                           : decp   %z19.d %p10.d -> %z19.d
+25ed8175 : decp z21.d, p11                           : decp   %z21.d %p11.d -> %z21.d
+25ed8197 : decp z23.d, p12                           : decp   %z23.d %p12.d -> %z23.d
+25ed81b9 : decp z25.d, p13                           : decp   %z25.d %p13.d -> %z25.d
+25ed81db : decp z27.d, p14                           : decp   %z27.d %p14.d -> %z27.d
+25ed81ff : decp z31.d, p15                           : decp   %z31.d %p15.d -> %z31.d
 
 # DECW    <Zdn>.S{, <pattern>{, MUL #<imm>}} (DECW-Z.ZS-_)
 04b0c400 : decw z0.s, POW2, MUL #1                   : decw   %z0.s POW2 mul $0x01 -> %z0.s
@@ -9940,120 +9940,120 @@
 047fe3fe : inch x30, ALL, MUL #16                    : inch   %x30 ALL mul $0x10 -> %x30
 
 # INCP    <Xdn>, <Pm>.<T> (INCP-R.P.R-_)
-252c8800 : incp x0, p0.b                             : incp   %p0.b %x0 -> %x0
-252c8842 : incp x2, p2.b                             : incp   %p2.b %x2 -> %x2
-252c8864 : incp x4, p3.b                             : incp   %p3.b %x4 -> %x4
-252c8886 : incp x6, p4.b                             : incp   %p4.b %x6 -> %x6
-252c88a8 : incp x8, p5.b                             : incp   %p5.b %x8 -> %x8
-252c88c9 : incp x9, p6.b                             : incp   %p6.b %x9 -> %x9
-252c88eb : incp x11, p7.b                            : incp   %p7.b %x11 -> %x11
-252c890d : incp x13, p8.b                            : incp   %p8.b %x13 -> %x13
-252c892f : incp x15, p9.b                            : incp   %p9.b %x15 -> %x15
-252c8931 : incp x17, p9.b                            : incp   %p9.b %x17 -> %x17
-252c8953 : incp x19, p10.b                           : incp   %p10.b %x19 -> %x19
-252c8975 : incp x21, p11.b                           : incp   %p11.b %x21 -> %x21
-252c8996 : incp x22, p12.b                           : incp   %p12.b %x22 -> %x22
-252c89b8 : incp x24, p13.b                           : incp   %p13.b %x24 -> %x24
-252c89da : incp x26, p14.b                           : incp   %p14.b %x26 -> %x26
-252c89fe : incp x30, p15.b                           : incp   %p15.b %x30 -> %x30
-256c8800 : incp x0, p0.h                             : incp   %p0.h %x0 -> %x0
-256c8842 : incp x2, p2.h                             : incp   %p2.h %x2 -> %x2
-256c8864 : incp x4, p3.h                             : incp   %p3.h %x4 -> %x4
-256c8886 : incp x6, p4.h                             : incp   %p4.h %x6 -> %x6
-256c88a8 : incp x8, p5.h                             : incp   %p5.h %x8 -> %x8
-256c88c9 : incp x9, p6.h                             : incp   %p6.h %x9 -> %x9
-256c88eb : incp x11, p7.h                            : incp   %p7.h %x11 -> %x11
-256c890d : incp x13, p8.h                            : incp   %p8.h %x13 -> %x13
-256c892f : incp x15, p9.h                            : incp   %p9.h %x15 -> %x15
-256c8931 : incp x17, p9.h                            : incp   %p9.h %x17 -> %x17
-256c8953 : incp x19, p10.h                           : incp   %p10.h %x19 -> %x19
-256c8975 : incp x21, p11.h                           : incp   %p11.h %x21 -> %x21
-256c8996 : incp x22, p12.h                           : incp   %p12.h %x22 -> %x22
-256c89b8 : incp x24, p13.h                           : incp   %p13.h %x24 -> %x24
-256c89da : incp x26, p14.h                           : incp   %p14.h %x26 -> %x26
-256c89fe : incp x30, p15.h                           : incp   %p15.h %x30 -> %x30
-25ac8800 : incp x0, p0.s                             : incp   %p0.s %x0 -> %x0
-25ac8842 : incp x2, p2.s                             : incp   %p2.s %x2 -> %x2
-25ac8864 : incp x4, p3.s                             : incp   %p3.s %x4 -> %x4
-25ac8886 : incp x6, p4.s                             : incp   %p4.s %x6 -> %x6
-25ac88a8 : incp x8, p5.s                             : incp   %p5.s %x8 -> %x8
-25ac88c9 : incp x9, p6.s                             : incp   %p6.s %x9 -> %x9
-25ac88eb : incp x11, p7.s                            : incp   %p7.s %x11 -> %x11
-25ac890d : incp x13, p8.s                            : incp   %p8.s %x13 -> %x13
-25ac892f : incp x15, p9.s                            : incp   %p9.s %x15 -> %x15
-25ac8931 : incp x17, p9.s                            : incp   %p9.s %x17 -> %x17
-25ac8953 : incp x19, p10.s                           : incp   %p10.s %x19 -> %x19
-25ac8975 : incp x21, p11.s                           : incp   %p11.s %x21 -> %x21
-25ac8996 : incp x22, p12.s                           : incp   %p12.s %x22 -> %x22
-25ac89b8 : incp x24, p13.s                           : incp   %p13.s %x24 -> %x24
-25ac89da : incp x26, p14.s                           : incp   %p14.s %x26 -> %x26
-25ac89fe : incp x30, p15.s                           : incp   %p15.s %x30 -> %x30
-25ec8800 : incp x0, p0.d                             : incp   %p0.d %x0 -> %x0
-25ec8842 : incp x2, p2.d                             : incp   %p2.d %x2 -> %x2
-25ec8864 : incp x4, p3.d                             : incp   %p3.d %x4 -> %x4
-25ec8886 : incp x6, p4.d                             : incp   %p4.d %x6 -> %x6
-25ec88a8 : incp x8, p5.d                             : incp   %p5.d %x8 -> %x8
-25ec88c9 : incp x9, p6.d                             : incp   %p6.d %x9 -> %x9
-25ec88eb : incp x11, p7.d                            : incp   %p7.d %x11 -> %x11
-25ec890d : incp x13, p8.d                            : incp   %p8.d %x13 -> %x13
-25ec892f : incp x15, p9.d                            : incp   %p9.d %x15 -> %x15
-25ec8931 : incp x17, p9.d                            : incp   %p9.d %x17 -> %x17
-25ec8953 : incp x19, p10.d                           : incp   %p10.d %x19 -> %x19
-25ec8975 : incp x21, p11.d                           : incp   %p11.d %x21 -> %x21
-25ec8996 : incp x22, p12.d                           : incp   %p12.d %x22 -> %x22
-25ec89b8 : incp x24, p13.d                           : incp   %p13.d %x24 -> %x24
-25ec89da : incp x26, p14.d                           : incp   %p14.d %x26 -> %x26
-25ec89fe : incp x30, p15.d                           : incp   %p15.d %x30 -> %x30
+252c8800 : incp x0, p0.b                             : incp   %x0 %p0.b -> %x0
+252c8842 : incp x2, p2.b                             : incp   %x2 %p2.b -> %x2
+252c8864 : incp x4, p3.b                             : incp   %x4 %p3.b -> %x4
+252c8886 : incp x6, p4.b                             : incp   %x6 %p4.b -> %x6
+252c88a8 : incp x8, p5.b                             : incp   %x8 %p5.b -> %x8
+252c88c9 : incp x9, p6.b                             : incp   %x9 %p6.b -> %x9
+252c88eb : incp x11, p7.b                            : incp   %x11 %p7.b -> %x11
+252c890d : incp x13, p8.b                            : incp   %x13 %p8.b -> %x13
+252c892f : incp x15, p9.b                            : incp   %x15 %p9.b -> %x15
+252c8931 : incp x17, p9.b                            : incp   %x17 %p9.b -> %x17
+252c8953 : incp x19, p10.b                           : incp   %x19 %p10.b -> %x19
+252c8975 : incp x21, p11.b                           : incp   %x21 %p11.b -> %x21
+252c8996 : incp x22, p12.b                           : incp   %x22 %p12.b -> %x22
+252c89b8 : incp x24, p13.b                           : incp   %x24 %p13.b -> %x24
+252c89da : incp x26, p14.b                           : incp   %x26 %p14.b -> %x26
+252c89fe : incp x30, p15.b                           : incp   %x30 %p15.b -> %x30
+256c8800 : incp x0, p0.h                             : incp   %x0 %p0.h -> %x0
+256c8842 : incp x2, p2.h                             : incp   %x2 %p2.h -> %x2
+256c8864 : incp x4, p3.h                             : incp   %x4 %p3.h -> %x4
+256c8886 : incp x6, p4.h                             : incp   %x6 %p4.h -> %x6
+256c88a8 : incp x8, p5.h                             : incp   %x8 %p5.h -> %x8
+256c88c9 : incp x9, p6.h                             : incp   %x9 %p6.h -> %x9
+256c88eb : incp x11, p7.h                            : incp   %x11 %p7.h -> %x11
+256c890d : incp x13, p8.h                            : incp   %x13 %p8.h -> %x13
+256c892f : incp x15, p9.h                            : incp   %x15 %p9.h -> %x15
+256c8931 : incp x17, p9.h                            : incp   %x17 %p9.h -> %x17
+256c8953 : incp x19, p10.h                           : incp   %x19 %p10.h -> %x19
+256c8975 : incp x21, p11.h                           : incp   %x21 %p11.h -> %x21
+256c8996 : incp x22, p12.h                           : incp   %x22 %p12.h -> %x22
+256c89b8 : incp x24, p13.h                           : incp   %x24 %p13.h -> %x24
+256c89da : incp x26, p14.h                           : incp   %x26 %p14.h -> %x26
+256c89fe : incp x30, p15.h                           : incp   %x30 %p15.h -> %x30
+25ac8800 : incp x0, p0.s                             : incp   %x0 %p0.s -> %x0
+25ac8842 : incp x2, p2.s                             : incp   %x2 %p2.s -> %x2
+25ac8864 : incp x4, p3.s                             : incp   %x4 %p3.s -> %x4
+25ac8886 : incp x6, p4.s                             : incp   %x6 %p4.s -> %x6
+25ac88a8 : incp x8, p5.s                             : incp   %x8 %p5.s -> %x8
+25ac88c9 : incp x9, p6.s                             : incp   %x9 %p6.s -> %x9
+25ac88eb : incp x11, p7.s                            : incp   %x11 %p7.s -> %x11
+25ac890d : incp x13, p8.s                            : incp   %x13 %p8.s -> %x13
+25ac892f : incp x15, p9.s                            : incp   %x15 %p9.s -> %x15
+25ac8931 : incp x17, p9.s                            : incp   %x17 %p9.s -> %x17
+25ac8953 : incp x19, p10.s                           : incp   %x19 %p10.s -> %x19
+25ac8975 : incp x21, p11.s                           : incp   %x21 %p11.s -> %x21
+25ac8996 : incp x22, p12.s                           : incp   %x22 %p12.s -> %x22
+25ac89b8 : incp x24, p13.s                           : incp   %x24 %p13.s -> %x24
+25ac89da : incp x26, p14.s                           : incp   %x26 %p14.s -> %x26
+25ac89fe : incp x30, p15.s                           : incp   %x30 %p15.s -> %x30
+25ec8800 : incp x0, p0.d                             : incp   %x0 %p0.d -> %x0
+25ec8842 : incp x2, p2.d                             : incp   %x2 %p2.d -> %x2
+25ec8864 : incp x4, p3.d                             : incp   %x4 %p3.d -> %x4
+25ec8886 : incp x6, p4.d                             : incp   %x6 %p4.d -> %x6
+25ec88a8 : incp x8, p5.d                             : incp   %x8 %p5.d -> %x8
+25ec88c9 : incp x9, p6.d                             : incp   %x9 %p6.d -> %x9
+25ec88eb : incp x11, p7.d                            : incp   %x11 %p7.d -> %x11
+25ec890d : incp x13, p8.d                            : incp   %x13 %p8.d -> %x13
+25ec892f : incp x15, p9.d                            : incp   %x15 %p9.d -> %x15
+25ec8931 : incp x17, p9.d                            : incp   %x17 %p9.d -> %x17
+25ec8953 : incp x19, p10.d                           : incp   %x19 %p10.d -> %x19
+25ec8975 : incp x21, p11.d                           : incp   %x21 %p11.d -> %x21
+25ec8996 : incp x22, p12.d                           : incp   %x22 %p12.d -> %x22
+25ec89b8 : incp x24, p13.d                           : incp   %x24 %p13.d -> %x24
+25ec89da : incp x26, p14.d                           : incp   %x26 %p14.d -> %x26
+25ec89fe : incp x30, p15.d                           : incp   %x30 %p15.d -> %x30
 
 # INCP    <Zdn>.<T>, <Pm>.<T> (INCP-Z.P.Z-_)
-256c8000 : incp z0.h, p0                             : incp   %p0.h %z0.h -> %z0.h
-256c8042 : incp z2.h, p2                             : incp   %p2.h %z2.h -> %z2.h
-256c8064 : incp z4.h, p3                             : incp   %p3.h %z4.h -> %z4.h
-256c8086 : incp z6.h, p4                             : incp   %p4.h %z6.h -> %z6.h
-256c80a8 : incp z8.h, p5                             : incp   %p5.h %z8.h -> %z8.h
-256c80ca : incp z10.h, p6                            : incp   %p6.h %z10.h -> %z10.h
-256c80ec : incp z12.h, p7                            : incp   %p7.h %z12.h -> %z12.h
-256c810e : incp z14.h, p8                            : incp   %p8.h %z14.h -> %z14.h
-256c8130 : incp z16.h, p9                            : incp   %p9.h %z16.h -> %z16.h
-256c8131 : incp z17.h, p9                            : incp   %p9.h %z17.h -> %z17.h
-256c8153 : incp z19.h, p10                           : incp   %p10.h %z19.h -> %z19.h
-256c8175 : incp z21.h, p11                           : incp   %p11.h %z21.h -> %z21.h
-256c8197 : incp z23.h, p12                           : incp   %p12.h %z23.h -> %z23.h
-256c81b9 : incp z25.h, p13                           : incp   %p13.h %z25.h -> %z25.h
-256c81db : incp z27.h, p14                           : incp   %p14.h %z27.h -> %z27.h
-256c81ff : incp z31.h, p15                           : incp   %p15.h %z31.h -> %z31.h
-25ac8000 : incp z0.s, p0                             : incp   %p0.s %z0.s -> %z0.s
-25ac8042 : incp z2.s, p2                             : incp   %p2.s %z2.s -> %z2.s
-25ac8064 : incp z4.s, p3                             : incp   %p3.s %z4.s -> %z4.s
-25ac8086 : incp z6.s, p4                             : incp   %p4.s %z6.s -> %z6.s
-25ac80a8 : incp z8.s, p5                             : incp   %p5.s %z8.s -> %z8.s
-25ac80ca : incp z10.s, p6                            : incp   %p6.s %z10.s -> %z10.s
-25ac80ec : incp z12.s, p7                            : incp   %p7.s %z12.s -> %z12.s
-25ac810e : incp z14.s, p8                            : incp   %p8.s %z14.s -> %z14.s
-25ac8130 : incp z16.s, p9                            : incp   %p9.s %z16.s -> %z16.s
-25ac8131 : incp z17.s, p9                            : incp   %p9.s %z17.s -> %z17.s
-25ac8153 : incp z19.s, p10                           : incp   %p10.s %z19.s -> %z19.s
-25ac8175 : incp z21.s, p11                           : incp   %p11.s %z21.s -> %z21.s
-25ac8197 : incp z23.s, p12                           : incp   %p12.s %z23.s -> %z23.s
-25ac81b9 : incp z25.s, p13                           : incp   %p13.s %z25.s -> %z25.s
-25ac81db : incp z27.s, p14                           : incp   %p14.s %z27.s -> %z27.s
-25ac81ff : incp z31.s, p15                           : incp   %p15.s %z31.s -> %z31.s
-25ec8000 : incp z0.d, p0                             : incp   %p0.d %z0.d -> %z0.d
-25ec8042 : incp z2.d, p2                             : incp   %p2.d %z2.d -> %z2.d
-25ec8064 : incp z4.d, p3                             : incp   %p3.d %z4.d -> %z4.d
-25ec8086 : incp z6.d, p4                             : incp   %p4.d %z6.d -> %z6.d
-25ec80a8 : incp z8.d, p5                             : incp   %p5.d %z8.d -> %z8.d
-25ec80ca : incp z10.d, p6                            : incp   %p6.d %z10.d -> %z10.d
-25ec80ec : incp z12.d, p7                            : incp   %p7.d %z12.d -> %z12.d
-25ec810e : incp z14.d, p8                            : incp   %p8.d %z14.d -> %z14.d
-25ec8130 : incp z16.d, p9                            : incp   %p9.d %z16.d -> %z16.d
-25ec8131 : incp z17.d, p9                            : incp   %p9.d %z17.d -> %z17.d
-25ec8153 : incp z19.d, p10                           : incp   %p10.d %z19.d -> %z19.d
-25ec8175 : incp z21.d, p11                           : incp   %p11.d %z21.d -> %z21.d
-25ec8197 : incp z23.d, p12                           : incp   %p12.d %z23.d -> %z23.d
-25ec81b9 : incp z25.d, p13                           : incp   %p13.d %z25.d -> %z25.d
-25ec81db : incp z27.d, p14                           : incp   %p14.d %z27.d -> %z27.d
-25ec81ff : incp z31.d, p15                           : incp   %p15.d %z31.d -> %z31.d
+256c8000 : incp z0.h, p0                             : incp   %z0.h %p0.h -> %z0.h
+256c8042 : incp z2.h, p2                             : incp   %z2.h %p2.h -> %z2.h
+256c8064 : incp z4.h, p3                             : incp   %z4.h %p3.h -> %z4.h
+256c8086 : incp z6.h, p4                             : incp   %z6.h %p4.h -> %z6.h
+256c80a8 : incp z8.h, p5                             : incp   %z8.h %p5.h -> %z8.h
+256c80ca : incp z10.h, p6                            : incp   %z10.h %p6.h -> %z10.h
+256c80ec : incp z12.h, p7                            : incp   %z12.h %p7.h -> %z12.h
+256c810e : incp z14.h, p8                            : incp   %z14.h %p8.h -> %z14.h
+256c8130 : incp z16.h, p9                            : incp   %z16.h %p9.h -> %z16.h
+256c8131 : incp z17.h, p9                            : incp   %z17.h %p9.h -> %z17.h
+256c8153 : incp z19.h, p10                           : incp   %z19.h %p10.h -> %z19.h
+256c8175 : incp z21.h, p11                           : incp   %z21.h %p11.h -> %z21.h
+256c8197 : incp z23.h, p12                           : incp   %z23.h %p12.h -> %z23.h
+256c81b9 : incp z25.h, p13                           : incp   %z25.h %p13.h -> %z25.h
+256c81db : incp z27.h, p14                           : incp   %z27.h %p14.h -> %z27.h
+256c81ff : incp z31.h, p15                           : incp   %z31.h %p15.h -> %z31.h
+25ac8000 : incp z0.s, p0                             : incp   %z0.s %p0.s -> %z0.s
+25ac8042 : incp z2.s, p2                             : incp   %z2.s %p2.s -> %z2.s
+25ac8064 : incp z4.s, p3                             : incp   %z4.s %p3.s -> %z4.s
+25ac8086 : incp z6.s, p4                             : incp   %z6.s %p4.s -> %z6.s
+25ac80a8 : incp z8.s, p5                             : incp   %z8.s %p5.s -> %z8.s
+25ac80ca : incp z10.s, p6                            : incp   %z10.s %p6.s -> %z10.s
+25ac80ec : incp z12.s, p7                            : incp   %z12.s %p7.s -> %z12.s
+25ac810e : incp z14.s, p8                            : incp   %z14.s %p8.s -> %z14.s
+25ac8130 : incp z16.s, p9                            : incp   %z16.s %p9.s -> %z16.s
+25ac8131 : incp z17.s, p9                            : incp   %z17.s %p9.s -> %z17.s
+25ac8153 : incp z19.s, p10                           : incp   %z19.s %p10.s -> %z19.s
+25ac8175 : incp z21.s, p11                           : incp   %z21.s %p11.s -> %z21.s
+25ac8197 : incp z23.s, p12                           : incp   %z23.s %p12.s -> %z23.s
+25ac81b9 : incp z25.s, p13                           : incp   %z25.s %p13.s -> %z25.s
+25ac81db : incp z27.s, p14                           : incp   %z27.s %p14.s -> %z27.s
+25ac81ff : incp z31.s, p15                           : incp   %z31.s %p15.s -> %z31.s
+25ec8000 : incp z0.d, p0                             : incp   %z0.d %p0.d -> %z0.d
+25ec8042 : incp z2.d, p2                             : incp   %z2.d %p2.d -> %z2.d
+25ec8064 : incp z4.d, p3                             : incp   %z4.d %p3.d -> %z4.d
+25ec8086 : incp z6.d, p4                             : incp   %z6.d %p4.d -> %z6.d
+25ec80a8 : incp z8.d, p5                             : incp   %z8.d %p5.d -> %z8.d
+25ec80ca : incp z10.d, p6                            : incp   %z10.d %p6.d -> %z10.d
+25ec80ec : incp z12.d, p7                            : incp   %z12.d %p7.d -> %z12.d
+25ec810e : incp z14.d, p8                            : incp   %z14.d %p8.d -> %z14.d
+25ec8130 : incp z16.d, p9                            : incp   %z16.d %p9.d -> %z16.d
+25ec8131 : incp z17.d, p9                            : incp   %z17.d %p9.d -> %z17.d
+25ec8153 : incp z19.d, p10                           : incp   %z19.d %p10.d -> %z19.d
+25ec8175 : incp z21.d, p11                           : incp   %z21.d %p11.d -> %z21.d
+25ec8197 : incp z23.d, p12                           : incp   %z23.d %p12.d -> %z23.d
+25ec81b9 : incp z25.d, p13                           : incp   %z25.d %p13.d -> %z25.d
+25ec81db : incp z27.d, p14                           : incp   %z27.d %p14.d -> %z27.d
+25ec81ff : incp z31.d, p15                           : incp   %z31.d %p15.d -> %z31.d
 
 # INCW    <Zdn>.S{, <pattern>{, MUL #<imm>}} (INCW-Z.ZS-_)
 04b0c000 : incw z0.s, POW2, MUL #1                   : incw   %z0.s POW2 mul $0x01 -> %z0.s
@@ -16013,202 +16013,202 @@ a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0x07(%sp)[32byte]
 04d59fff : lsrr z31.d, p7/M, z31.d, z31.d            : lsrr   %p7/m %z31.d %z31.d -> %z31.d
 
 # MAD     <Zdn>.<T>, <Pg>/M, <Zm>.<T>, <Za>.<T> (MAD-Z.P.ZZZ-_)
-0400c000 : mad z0.b, p0/M, z0.b, z0.b                : mad    %p0/m %z0.b %z0.b %z0.b -> %z0.b
-0404c4a2 : mad z2.b, p1/M, z4.b, z5.b                : mad    %p1/m %z2.b %z4.b %z5.b -> %z2.b
-0406c8e4 : mad z4.b, p2/M, z6.b, z7.b                : mad    %p2/m %z4.b %z6.b %z7.b -> %z4.b
-0408c926 : mad z6.b, p2/M, z8.b, z9.b                : mad    %p2/m %z6.b %z8.b %z9.b -> %z6.b
-040acd68 : mad z8.b, p3/M, z10.b, z11.b              : mad    %p3/m %z8.b %z10.b %z11.b -> %z8.b
-040ccdaa : mad z10.b, p3/M, z12.b, z13.b             : mad    %p3/m %z10.b %z12.b %z13.b -> %z10.b
-040ed1ec : mad z12.b, p4/M, z14.b, z15.b             : mad    %p4/m %z12.b %z14.b %z15.b -> %z12.b
-0410d22e : mad z14.b, p4/M, z16.b, z17.b             : mad    %p4/m %z14.b %z16.b %z17.b -> %z14.b
-0412d670 : mad z16.b, p5/M, z18.b, z19.b             : mad    %p5/m %z16.b %z18.b %z19.b -> %z16.b
-0413d691 : mad z17.b, p5/M, z19.b, z20.b             : mad    %p5/m %z17.b %z19.b %z20.b -> %z17.b
-0415d6d3 : mad z19.b, p5/M, z21.b, z22.b             : mad    %p5/m %z19.b %z21.b %z22.b -> %z19.b
-0417db15 : mad z21.b, p6/M, z23.b, z24.b             : mad    %p6/m %z21.b %z23.b %z24.b -> %z21.b
-0419db57 : mad z23.b, p6/M, z25.b, z26.b             : mad    %p6/m %z23.b %z25.b %z26.b -> %z23.b
-041bdf99 : mad z25.b, p7/M, z27.b, z28.b             : mad    %p7/m %z25.b %z27.b %z28.b -> %z25.b
-041ddfdb : mad z27.b, p7/M, z29.b, z30.b             : mad    %p7/m %z27.b %z29.b %z30.b -> %z27.b
-041fdfff : mad z31.b, p7/M, z31.b, z31.b             : mad    %p7/m %z31.b %z31.b %z31.b -> %z31.b
-0440c000 : mad z0.h, p0/M, z0.h, z0.h                : mad    %p0/m %z0.h %z0.h %z0.h -> %z0.h
-0444c4a2 : mad z2.h, p1/M, z4.h, z5.h                : mad    %p1/m %z2.h %z4.h %z5.h -> %z2.h
-0446c8e4 : mad z4.h, p2/M, z6.h, z7.h                : mad    %p2/m %z4.h %z6.h %z7.h -> %z4.h
-0448c926 : mad z6.h, p2/M, z8.h, z9.h                : mad    %p2/m %z6.h %z8.h %z9.h -> %z6.h
-044acd68 : mad z8.h, p3/M, z10.h, z11.h              : mad    %p3/m %z8.h %z10.h %z11.h -> %z8.h
-044ccdaa : mad z10.h, p3/M, z12.h, z13.h             : mad    %p3/m %z10.h %z12.h %z13.h -> %z10.h
-044ed1ec : mad z12.h, p4/M, z14.h, z15.h             : mad    %p4/m %z12.h %z14.h %z15.h -> %z12.h
-0450d22e : mad z14.h, p4/M, z16.h, z17.h             : mad    %p4/m %z14.h %z16.h %z17.h -> %z14.h
-0452d670 : mad z16.h, p5/M, z18.h, z19.h             : mad    %p5/m %z16.h %z18.h %z19.h -> %z16.h
-0453d691 : mad z17.h, p5/M, z19.h, z20.h             : mad    %p5/m %z17.h %z19.h %z20.h -> %z17.h
-0455d6d3 : mad z19.h, p5/M, z21.h, z22.h             : mad    %p5/m %z19.h %z21.h %z22.h -> %z19.h
-0457db15 : mad z21.h, p6/M, z23.h, z24.h             : mad    %p6/m %z21.h %z23.h %z24.h -> %z21.h
-0459db57 : mad z23.h, p6/M, z25.h, z26.h             : mad    %p6/m %z23.h %z25.h %z26.h -> %z23.h
-045bdf99 : mad z25.h, p7/M, z27.h, z28.h             : mad    %p7/m %z25.h %z27.h %z28.h -> %z25.h
-045ddfdb : mad z27.h, p7/M, z29.h, z30.h             : mad    %p7/m %z27.h %z29.h %z30.h -> %z27.h
-045fdfff : mad z31.h, p7/M, z31.h, z31.h             : mad    %p7/m %z31.h %z31.h %z31.h -> %z31.h
-0480c000 : mad z0.s, p0/M, z0.s, z0.s                : mad    %p0/m %z0.s %z0.s %z0.s -> %z0.s
-0484c4a2 : mad z2.s, p1/M, z4.s, z5.s                : mad    %p1/m %z2.s %z4.s %z5.s -> %z2.s
-0486c8e4 : mad z4.s, p2/M, z6.s, z7.s                : mad    %p2/m %z4.s %z6.s %z7.s -> %z4.s
-0488c926 : mad z6.s, p2/M, z8.s, z9.s                : mad    %p2/m %z6.s %z8.s %z9.s -> %z6.s
-048acd68 : mad z8.s, p3/M, z10.s, z11.s              : mad    %p3/m %z8.s %z10.s %z11.s -> %z8.s
-048ccdaa : mad z10.s, p3/M, z12.s, z13.s             : mad    %p3/m %z10.s %z12.s %z13.s -> %z10.s
-048ed1ec : mad z12.s, p4/M, z14.s, z15.s             : mad    %p4/m %z12.s %z14.s %z15.s -> %z12.s
-0490d22e : mad z14.s, p4/M, z16.s, z17.s             : mad    %p4/m %z14.s %z16.s %z17.s -> %z14.s
-0492d670 : mad z16.s, p5/M, z18.s, z19.s             : mad    %p5/m %z16.s %z18.s %z19.s -> %z16.s
-0493d691 : mad z17.s, p5/M, z19.s, z20.s             : mad    %p5/m %z17.s %z19.s %z20.s -> %z17.s
-0495d6d3 : mad z19.s, p5/M, z21.s, z22.s             : mad    %p5/m %z19.s %z21.s %z22.s -> %z19.s
-0497db15 : mad z21.s, p6/M, z23.s, z24.s             : mad    %p6/m %z21.s %z23.s %z24.s -> %z21.s
-0499db57 : mad z23.s, p6/M, z25.s, z26.s             : mad    %p6/m %z23.s %z25.s %z26.s -> %z23.s
-049bdf99 : mad z25.s, p7/M, z27.s, z28.s             : mad    %p7/m %z25.s %z27.s %z28.s -> %z25.s
-049ddfdb : mad z27.s, p7/M, z29.s, z30.s             : mad    %p7/m %z27.s %z29.s %z30.s -> %z27.s
-049fdfff : mad z31.s, p7/M, z31.s, z31.s             : mad    %p7/m %z31.s %z31.s %z31.s -> %z31.s
-04c0c000 : mad z0.d, p0/M, z0.d, z0.d                : mad    %p0/m %z0.d %z0.d %z0.d -> %z0.d
-04c4c4a2 : mad z2.d, p1/M, z4.d, z5.d                : mad    %p1/m %z2.d %z4.d %z5.d -> %z2.d
-04c6c8e4 : mad z4.d, p2/M, z6.d, z7.d                : mad    %p2/m %z4.d %z6.d %z7.d -> %z4.d
-04c8c926 : mad z6.d, p2/M, z8.d, z9.d                : mad    %p2/m %z6.d %z8.d %z9.d -> %z6.d
-04cacd68 : mad z8.d, p3/M, z10.d, z11.d              : mad    %p3/m %z8.d %z10.d %z11.d -> %z8.d
-04cccdaa : mad z10.d, p3/M, z12.d, z13.d             : mad    %p3/m %z10.d %z12.d %z13.d -> %z10.d
-04ced1ec : mad z12.d, p4/M, z14.d, z15.d             : mad    %p4/m %z12.d %z14.d %z15.d -> %z12.d
-04d0d22e : mad z14.d, p4/M, z16.d, z17.d             : mad    %p4/m %z14.d %z16.d %z17.d -> %z14.d
-04d2d670 : mad z16.d, p5/M, z18.d, z19.d             : mad    %p5/m %z16.d %z18.d %z19.d -> %z16.d
-04d3d691 : mad z17.d, p5/M, z19.d, z20.d             : mad    %p5/m %z17.d %z19.d %z20.d -> %z17.d
-04d5d6d3 : mad z19.d, p5/M, z21.d, z22.d             : mad    %p5/m %z19.d %z21.d %z22.d -> %z19.d
-04d7db15 : mad z21.d, p6/M, z23.d, z24.d             : mad    %p6/m %z21.d %z23.d %z24.d -> %z21.d
-04d9db57 : mad z23.d, p6/M, z25.d, z26.d             : mad    %p6/m %z23.d %z25.d %z26.d -> %z23.d
-04dbdf99 : mad z25.d, p7/M, z27.d, z28.d             : mad    %p7/m %z25.d %z27.d %z28.d -> %z25.d
-04dddfdb : mad z27.d, p7/M, z29.d, z30.d             : mad    %p7/m %z27.d %z29.d %z30.d -> %z27.d
-04dfdfff : mad z31.d, p7/M, z31.d, z31.d             : mad    %p7/m %z31.d %z31.d %z31.d -> %z31.d
+0400c000 : mad z0.b, p0/M, z0.b, z0.b                : mad    %z0.b %p0/m %z0.b %z0.b -> %z0.b
+0404c4a2 : mad z2.b, p1/M, z4.b, z5.b                : mad    %z2.b %p1/m %z4.b %z5.b -> %z2.b
+0406c8e4 : mad z4.b, p2/M, z6.b, z7.b                : mad    %z4.b %p2/m %z6.b %z7.b -> %z4.b
+0408c926 : mad z6.b, p2/M, z8.b, z9.b                : mad    %z6.b %p2/m %z8.b %z9.b -> %z6.b
+040acd68 : mad z8.b, p3/M, z10.b, z11.b              : mad    %z8.b %p3/m %z10.b %z11.b -> %z8.b
+040ccdaa : mad z10.b, p3/M, z12.b, z13.b             : mad    %z10.b %p3/m %z12.b %z13.b -> %z10.b
+040ed1ec : mad z12.b, p4/M, z14.b, z15.b             : mad    %z12.b %p4/m %z14.b %z15.b -> %z12.b
+0410d22e : mad z14.b, p4/M, z16.b, z17.b             : mad    %z14.b %p4/m %z16.b %z17.b -> %z14.b
+0412d670 : mad z16.b, p5/M, z18.b, z19.b             : mad    %z16.b %p5/m %z18.b %z19.b -> %z16.b
+0413d691 : mad z17.b, p5/M, z19.b, z20.b             : mad    %z17.b %p5/m %z19.b %z20.b -> %z17.b
+0415d6d3 : mad z19.b, p5/M, z21.b, z22.b             : mad    %z19.b %p5/m %z21.b %z22.b -> %z19.b
+0417db15 : mad z21.b, p6/M, z23.b, z24.b             : mad    %z21.b %p6/m %z23.b %z24.b -> %z21.b
+0419db57 : mad z23.b, p6/M, z25.b, z26.b             : mad    %z23.b %p6/m %z25.b %z26.b -> %z23.b
+041bdf99 : mad z25.b, p7/M, z27.b, z28.b             : mad    %z25.b %p7/m %z27.b %z28.b -> %z25.b
+041ddfdb : mad z27.b, p7/M, z29.b, z30.b             : mad    %z27.b %p7/m %z29.b %z30.b -> %z27.b
+041fdfff : mad z31.b, p7/M, z31.b, z31.b             : mad    %z31.b %p7/m %z31.b %z31.b -> %z31.b
+0440c000 : mad z0.h, p0/M, z0.h, z0.h                : mad    %z0.h %p0/m %z0.h %z0.h -> %z0.h
+0444c4a2 : mad z2.h, p1/M, z4.h, z5.h                : mad    %z2.h %p1/m %z4.h %z5.h -> %z2.h
+0446c8e4 : mad z4.h, p2/M, z6.h, z7.h                : mad    %z4.h %p2/m %z6.h %z7.h -> %z4.h
+0448c926 : mad z6.h, p2/M, z8.h, z9.h                : mad    %z6.h %p2/m %z8.h %z9.h -> %z6.h
+044acd68 : mad z8.h, p3/M, z10.h, z11.h              : mad    %z8.h %p3/m %z10.h %z11.h -> %z8.h
+044ccdaa : mad z10.h, p3/M, z12.h, z13.h             : mad    %z10.h %p3/m %z12.h %z13.h -> %z10.h
+044ed1ec : mad z12.h, p4/M, z14.h, z15.h             : mad    %z12.h %p4/m %z14.h %z15.h -> %z12.h
+0450d22e : mad z14.h, p4/M, z16.h, z17.h             : mad    %z14.h %p4/m %z16.h %z17.h -> %z14.h
+0452d670 : mad z16.h, p5/M, z18.h, z19.h             : mad    %z16.h %p5/m %z18.h %z19.h -> %z16.h
+0453d691 : mad z17.h, p5/M, z19.h, z20.h             : mad    %z17.h %p5/m %z19.h %z20.h -> %z17.h
+0455d6d3 : mad z19.h, p5/M, z21.h, z22.h             : mad    %z19.h %p5/m %z21.h %z22.h -> %z19.h
+0457db15 : mad z21.h, p6/M, z23.h, z24.h             : mad    %z21.h %p6/m %z23.h %z24.h -> %z21.h
+0459db57 : mad z23.h, p6/M, z25.h, z26.h             : mad    %z23.h %p6/m %z25.h %z26.h -> %z23.h
+045bdf99 : mad z25.h, p7/M, z27.h, z28.h             : mad    %z25.h %p7/m %z27.h %z28.h -> %z25.h
+045ddfdb : mad z27.h, p7/M, z29.h, z30.h             : mad    %z27.h %p7/m %z29.h %z30.h -> %z27.h
+045fdfff : mad z31.h, p7/M, z31.h, z31.h             : mad    %z31.h %p7/m %z31.h %z31.h -> %z31.h
+0480c000 : mad z0.s, p0/M, z0.s, z0.s                : mad    %z0.s %p0/m %z0.s %z0.s -> %z0.s
+0484c4a2 : mad z2.s, p1/M, z4.s, z5.s                : mad    %z2.s %p1/m %z4.s %z5.s -> %z2.s
+0486c8e4 : mad z4.s, p2/M, z6.s, z7.s                : mad    %z4.s %p2/m %z6.s %z7.s -> %z4.s
+0488c926 : mad z6.s, p2/M, z8.s, z9.s                : mad    %z6.s %p2/m %z8.s %z9.s -> %z6.s
+048acd68 : mad z8.s, p3/M, z10.s, z11.s              : mad    %z8.s %p3/m %z10.s %z11.s -> %z8.s
+048ccdaa : mad z10.s, p3/M, z12.s, z13.s             : mad    %z10.s %p3/m %z12.s %z13.s -> %z10.s
+048ed1ec : mad z12.s, p4/M, z14.s, z15.s             : mad    %z12.s %p4/m %z14.s %z15.s -> %z12.s
+0490d22e : mad z14.s, p4/M, z16.s, z17.s             : mad    %z14.s %p4/m %z16.s %z17.s -> %z14.s
+0492d670 : mad z16.s, p5/M, z18.s, z19.s             : mad    %z16.s %p5/m %z18.s %z19.s -> %z16.s
+0493d691 : mad z17.s, p5/M, z19.s, z20.s             : mad    %z17.s %p5/m %z19.s %z20.s -> %z17.s
+0495d6d3 : mad z19.s, p5/M, z21.s, z22.s             : mad    %z19.s %p5/m %z21.s %z22.s -> %z19.s
+0497db15 : mad z21.s, p6/M, z23.s, z24.s             : mad    %z21.s %p6/m %z23.s %z24.s -> %z21.s
+0499db57 : mad z23.s, p6/M, z25.s, z26.s             : mad    %z23.s %p6/m %z25.s %z26.s -> %z23.s
+049bdf99 : mad z25.s, p7/M, z27.s, z28.s             : mad    %z25.s %p7/m %z27.s %z28.s -> %z25.s
+049ddfdb : mad z27.s, p7/M, z29.s, z30.s             : mad    %z27.s %p7/m %z29.s %z30.s -> %z27.s
+049fdfff : mad z31.s, p7/M, z31.s, z31.s             : mad    %z31.s %p7/m %z31.s %z31.s -> %z31.s
+04c0c000 : mad z0.d, p0/M, z0.d, z0.d                : mad    %z0.d %p0/m %z0.d %z0.d -> %z0.d
+04c4c4a2 : mad z2.d, p1/M, z4.d, z5.d                : mad    %z2.d %p1/m %z4.d %z5.d -> %z2.d
+04c6c8e4 : mad z4.d, p2/M, z6.d, z7.d                : mad    %z4.d %p2/m %z6.d %z7.d -> %z4.d
+04c8c926 : mad z6.d, p2/M, z8.d, z9.d                : mad    %z6.d %p2/m %z8.d %z9.d -> %z6.d
+04cacd68 : mad z8.d, p3/M, z10.d, z11.d              : mad    %z8.d %p3/m %z10.d %z11.d -> %z8.d
+04cccdaa : mad z10.d, p3/M, z12.d, z13.d             : mad    %z10.d %p3/m %z12.d %z13.d -> %z10.d
+04ced1ec : mad z12.d, p4/M, z14.d, z15.d             : mad    %z12.d %p4/m %z14.d %z15.d -> %z12.d
+04d0d22e : mad z14.d, p4/M, z16.d, z17.d             : mad    %z14.d %p4/m %z16.d %z17.d -> %z14.d
+04d2d670 : mad z16.d, p5/M, z18.d, z19.d             : mad    %z16.d %p5/m %z18.d %z19.d -> %z16.d
+04d3d691 : mad z17.d, p5/M, z19.d, z20.d             : mad    %z17.d %p5/m %z19.d %z20.d -> %z17.d
+04d5d6d3 : mad z19.d, p5/M, z21.d, z22.d             : mad    %z19.d %p5/m %z21.d %z22.d -> %z19.d
+04d7db15 : mad z21.d, p6/M, z23.d, z24.d             : mad    %z21.d %p6/m %z23.d %z24.d -> %z21.d
+04d9db57 : mad z23.d, p6/M, z25.d, z26.d             : mad    %z23.d %p6/m %z25.d %z26.d -> %z23.d
+04dbdf99 : mad z25.d, p7/M, z27.d, z28.d             : mad    %z25.d %p7/m %z27.d %z28.d -> %z25.d
+04dddfdb : mad z27.d, p7/M, z29.d, z30.d             : mad    %z27.d %p7/m %z29.d %z30.d -> %z27.d
+04dfdfff : mad z31.d, p7/M, z31.d, z31.d             : mad    %z31.d %p7/m %z31.d %z31.d -> %z31.d
 
 # MLA     <Zda>.<T>, <Pg>/M, <Zn>.<T>, <Zm>.<T> (MLA-Z.P.ZZZ-_)
-04004000 : mla z0.b, p0/M, z0.b, z0.b                : mla    %p0/m %z0.b %z0.b %z0.b -> %z0.b
-04054482 : mla z2.b, p1/M, z4.b, z5.b                : mla    %p1/m %z4.b %z5.b %z2.b -> %z2.b
-040748c4 : mla z4.b, p2/M, z6.b, z7.b                : mla    %p2/m %z6.b %z7.b %z4.b -> %z4.b
-04094906 : mla z6.b, p2/M, z8.b, z9.b                : mla    %p2/m %z8.b %z9.b %z6.b -> %z6.b
-040b4d48 : mla z8.b, p3/M, z10.b, z11.b              : mla    %p3/m %z10.b %z11.b %z8.b -> %z8.b
-040d4d8a : mla z10.b, p3/M, z12.b, z13.b             : mla    %p3/m %z12.b %z13.b %z10.b -> %z10.b
-040f51cc : mla z12.b, p4/M, z14.b, z15.b             : mla    %p4/m %z14.b %z15.b %z12.b -> %z12.b
-0411520e : mla z14.b, p4/M, z16.b, z17.b             : mla    %p4/m %z16.b %z17.b %z14.b -> %z14.b
-04135650 : mla z16.b, p5/M, z18.b, z19.b             : mla    %p5/m %z18.b %z19.b %z16.b -> %z16.b
-04145671 : mla z17.b, p5/M, z19.b, z20.b             : mla    %p5/m %z19.b %z20.b %z17.b -> %z17.b
-041656b3 : mla z19.b, p5/M, z21.b, z22.b             : mla    %p5/m %z21.b %z22.b %z19.b -> %z19.b
-04185af5 : mla z21.b, p6/M, z23.b, z24.b             : mla    %p6/m %z23.b %z24.b %z21.b -> %z21.b
-041a5b37 : mla z23.b, p6/M, z25.b, z26.b             : mla    %p6/m %z25.b %z26.b %z23.b -> %z23.b
-041c5f79 : mla z25.b, p7/M, z27.b, z28.b             : mla    %p7/m %z27.b %z28.b %z25.b -> %z25.b
-041e5fbb : mla z27.b, p7/M, z29.b, z30.b             : mla    %p7/m %z29.b %z30.b %z27.b -> %z27.b
-041f5fff : mla z31.b, p7/M, z31.b, z31.b             : mla    %p7/m %z31.b %z31.b %z31.b -> %z31.b
-04404000 : mla z0.h, p0/M, z0.h, z0.h                : mla    %p0/m %z0.h %z0.h %z0.h -> %z0.h
-04454482 : mla z2.h, p1/M, z4.h, z5.h                : mla    %p1/m %z4.h %z5.h %z2.h -> %z2.h
-044748c4 : mla z4.h, p2/M, z6.h, z7.h                : mla    %p2/m %z6.h %z7.h %z4.h -> %z4.h
-04494906 : mla z6.h, p2/M, z8.h, z9.h                : mla    %p2/m %z8.h %z9.h %z6.h -> %z6.h
-044b4d48 : mla z8.h, p3/M, z10.h, z11.h              : mla    %p3/m %z10.h %z11.h %z8.h -> %z8.h
-044d4d8a : mla z10.h, p3/M, z12.h, z13.h             : mla    %p3/m %z12.h %z13.h %z10.h -> %z10.h
-044f51cc : mla z12.h, p4/M, z14.h, z15.h             : mla    %p4/m %z14.h %z15.h %z12.h -> %z12.h
-0451520e : mla z14.h, p4/M, z16.h, z17.h             : mla    %p4/m %z16.h %z17.h %z14.h -> %z14.h
-04535650 : mla z16.h, p5/M, z18.h, z19.h             : mla    %p5/m %z18.h %z19.h %z16.h -> %z16.h
-04545671 : mla z17.h, p5/M, z19.h, z20.h             : mla    %p5/m %z19.h %z20.h %z17.h -> %z17.h
-045656b3 : mla z19.h, p5/M, z21.h, z22.h             : mla    %p5/m %z21.h %z22.h %z19.h -> %z19.h
-04585af5 : mla z21.h, p6/M, z23.h, z24.h             : mla    %p6/m %z23.h %z24.h %z21.h -> %z21.h
-045a5b37 : mla z23.h, p6/M, z25.h, z26.h             : mla    %p6/m %z25.h %z26.h %z23.h -> %z23.h
-045c5f79 : mla z25.h, p7/M, z27.h, z28.h             : mla    %p7/m %z27.h %z28.h %z25.h -> %z25.h
-045e5fbb : mla z27.h, p7/M, z29.h, z30.h             : mla    %p7/m %z29.h %z30.h %z27.h -> %z27.h
-045f5fff : mla z31.h, p7/M, z31.h, z31.h             : mla    %p7/m %z31.h %z31.h %z31.h -> %z31.h
-04804000 : mla z0.s, p0/M, z0.s, z0.s                : mla    %p0/m %z0.s %z0.s %z0.s -> %z0.s
-04854482 : mla z2.s, p1/M, z4.s, z5.s                : mla    %p1/m %z4.s %z5.s %z2.s -> %z2.s
-048748c4 : mla z4.s, p2/M, z6.s, z7.s                : mla    %p2/m %z6.s %z7.s %z4.s -> %z4.s
-04894906 : mla z6.s, p2/M, z8.s, z9.s                : mla    %p2/m %z8.s %z9.s %z6.s -> %z6.s
-048b4d48 : mla z8.s, p3/M, z10.s, z11.s              : mla    %p3/m %z10.s %z11.s %z8.s -> %z8.s
-048d4d8a : mla z10.s, p3/M, z12.s, z13.s             : mla    %p3/m %z12.s %z13.s %z10.s -> %z10.s
-048f51cc : mla z12.s, p4/M, z14.s, z15.s             : mla    %p4/m %z14.s %z15.s %z12.s -> %z12.s
-0491520e : mla z14.s, p4/M, z16.s, z17.s             : mla    %p4/m %z16.s %z17.s %z14.s -> %z14.s
-04935650 : mla z16.s, p5/M, z18.s, z19.s             : mla    %p5/m %z18.s %z19.s %z16.s -> %z16.s
-04945671 : mla z17.s, p5/M, z19.s, z20.s             : mla    %p5/m %z19.s %z20.s %z17.s -> %z17.s
-049656b3 : mla z19.s, p5/M, z21.s, z22.s             : mla    %p5/m %z21.s %z22.s %z19.s -> %z19.s
-04985af5 : mla z21.s, p6/M, z23.s, z24.s             : mla    %p6/m %z23.s %z24.s %z21.s -> %z21.s
-049a5b37 : mla z23.s, p6/M, z25.s, z26.s             : mla    %p6/m %z25.s %z26.s %z23.s -> %z23.s
-049c5f79 : mla z25.s, p7/M, z27.s, z28.s             : mla    %p7/m %z27.s %z28.s %z25.s -> %z25.s
-049e5fbb : mla z27.s, p7/M, z29.s, z30.s             : mla    %p7/m %z29.s %z30.s %z27.s -> %z27.s
-049f5fff : mla z31.s, p7/M, z31.s, z31.s             : mla    %p7/m %z31.s %z31.s %z31.s -> %z31.s
-04c04000 : mla z0.d, p0/M, z0.d, z0.d                : mla    %p0/m %z0.d %z0.d %z0.d -> %z0.d
-04c54482 : mla z2.d, p1/M, z4.d, z5.d                : mla    %p1/m %z4.d %z5.d %z2.d -> %z2.d
-04c748c4 : mla z4.d, p2/M, z6.d, z7.d                : mla    %p2/m %z6.d %z7.d %z4.d -> %z4.d
-04c94906 : mla z6.d, p2/M, z8.d, z9.d                : mla    %p2/m %z8.d %z9.d %z6.d -> %z6.d
-04cb4d48 : mla z8.d, p3/M, z10.d, z11.d              : mla    %p3/m %z10.d %z11.d %z8.d -> %z8.d
-04cd4d8a : mla z10.d, p3/M, z12.d, z13.d             : mla    %p3/m %z12.d %z13.d %z10.d -> %z10.d
-04cf51cc : mla z12.d, p4/M, z14.d, z15.d             : mla    %p4/m %z14.d %z15.d %z12.d -> %z12.d
-04d1520e : mla z14.d, p4/M, z16.d, z17.d             : mla    %p4/m %z16.d %z17.d %z14.d -> %z14.d
-04d35650 : mla z16.d, p5/M, z18.d, z19.d             : mla    %p5/m %z18.d %z19.d %z16.d -> %z16.d
-04d45671 : mla z17.d, p5/M, z19.d, z20.d             : mla    %p5/m %z19.d %z20.d %z17.d -> %z17.d
-04d656b3 : mla z19.d, p5/M, z21.d, z22.d             : mla    %p5/m %z21.d %z22.d %z19.d -> %z19.d
-04d85af5 : mla z21.d, p6/M, z23.d, z24.d             : mla    %p6/m %z23.d %z24.d %z21.d -> %z21.d
-04da5b37 : mla z23.d, p6/M, z25.d, z26.d             : mla    %p6/m %z25.d %z26.d %z23.d -> %z23.d
-04dc5f79 : mla z25.d, p7/M, z27.d, z28.d             : mla    %p7/m %z27.d %z28.d %z25.d -> %z25.d
-04de5fbb : mla z27.d, p7/M, z29.d, z30.d             : mla    %p7/m %z29.d %z30.d %z27.d -> %z27.d
-04df5fff : mla z31.d, p7/M, z31.d, z31.d             : mla    %p7/m %z31.d %z31.d %z31.d -> %z31.d
+04004000 : mla z0.b, p0/M, z0.b, z0.b                : mla    %z0.b %p0/m %z0.b %z0.b -> %z0.b
+04054482 : mla z2.b, p1/M, z4.b, z5.b                : mla    %z2.b %p1/m %z4.b %z5.b -> %z2.b
+040748c4 : mla z4.b, p2/M, z6.b, z7.b                : mla    %z4.b %p2/m %z6.b %z7.b -> %z4.b
+04094906 : mla z6.b, p2/M, z8.b, z9.b                : mla    %z6.b %p2/m %z8.b %z9.b -> %z6.b
+040b4d48 : mla z8.b, p3/M, z10.b, z11.b              : mla    %z8.b %p3/m %z10.b %z11.b -> %z8.b
+040d4d8a : mla z10.b, p3/M, z12.b, z13.b             : mla    %z10.b %p3/m %z12.b %z13.b -> %z10.b
+040f51cc : mla z12.b, p4/M, z14.b, z15.b             : mla    %z12.b %p4/m %z14.b %z15.b -> %z12.b
+0411520e : mla z14.b, p4/M, z16.b, z17.b             : mla    %z14.b %p4/m %z16.b %z17.b -> %z14.b
+04135650 : mla z16.b, p5/M, z18.b, z19.b             : mla    %z16.b %p5/m %z18.b %z19.b -> %z16.b
+04145671 : mla z17.b, p5/M, z19.b, z20.b             : mla    %z17.b %p5/m %z19.b %z20.b -> %z17.b
+041656b3 : mla z19.b, p5/M, z21.b, z22.b             : mla    %z19.b %p5/m %z21.b %z22.b -> %z19.b
+04185af5 : mla z21.b, p6/M, z23.b, z24.b             : mla    %z21.b %p6/m %z23.b %z24.b -> %z21.b
+041a5b37 : mla z23.b, p6/M, z25.b, z26.b             : mla    %z23.b %p6/m %z25.b %z26.b -> %z23.b
+041c5f79 : mla z25.b, p7/M, z27.b, z28.b             : mla    %z25.b %p7/m %z27.b %z28.b -> %z25.b
+041e5fbb : mla z27.b, p7/M, z29.b, z30.b             : mla    %z27.b %p7/m %z29.b %z30.b -> %z27.b
+041f5fff : mla z31.b, p7/M, z31.b, z31.b             : mla    %z31.b %p7/m %z31.b %z31.b -> %z31.b
+04404000 : mla z0.h, p0/M, z0.h, z0.h                : mla    %z0.h %p0/m %z0.h %z0.h -> %z0.h
+04454482 : mla z2.h, p1/M, z4.h, z5.h                : mla    %z2.h %p1/m %z4.h %z5.h -> %z2.h
+044748c4 : mla z4.h, p2/M, z6.h, z7.h                : mla    %z4.h %p2/m %z6.h %z7.h -> %z4.h
+04494906 : mla z6.h, p2/M, z8.h, z9.h                : mla    %z6.h %p2/m %z8.h %z9.h -> %z6.h
+044b4d48 : mla z8.h, p3/M, z10.h, z11.h              : mla    %z8.h %p3/m %z10.h %z11.h -> %z8.h
+044d4d8a : mla z10.h, p3/M, z12.h, z13.h             : mla    %z10.h %p3/m %z12.h %z13.h -> %z10.h
+044f51cc : mla z12.h, p4/M, z14.h, z15.h             : mla    %z12.h %p4/m %z14.h %z15.h -> %z12.h
+0451520e : mla z14.h, p4/M, z16.h, z17.h             : mla    %z14.h %p4/m %z16.h %z17.h -> %z14.h
+04535650 : mla z16.h, p5/M, z18.h, z19.h             : mla    %z16.h %p5/m %z18.h %z19.h -> %z16.h
+04545671 : mla z17.h, p5/M, z19.h, z20.h             : mla    %z17.h %p5/m %z19.h %z20.h -> %z17.h
+045656b3 : mla z19.h, p5/M, z21.h, z22.h             : mla    %z19.h %p5/m %z21.h %z22.h -> %z19.h
+04585af5 : mla z21.h, p6/M, z23.h, z24.h             : mla    %z21.h %p6/m %z23.h %z24.h -> %z21.h
+045a5b37 : mla z23.h, p6/M, z25.h, z26.h             : mla    %z23.h %p6/m %z25.h %z26.h -> %z23.h
+045c5f79 : mla z25.h, p7/M, z27.h, z28.h             : mla    %z25.h %p7/m %z27.h %z28.h -> %z25.h
+045e5fbb : mla z27.h, p7/M, z29.h, z30.h             : mla    %z27.h %p7/m %z29.h %z30.h -> %z27.h
+045f5fff : mla z31.h, p7/M, z31.h, z31.h             : mla    %z31.h %p7/m %z31.h %z31.h -> %z31.h
+04804000 : mla z0.s, p0/M, z0.s, z0.s                : mla    %z0.s %p0/m %z0.s %z0.s -> %z0.s
+04854482 : mla z2.s, p1/M, z4.s, z5.s                : mla    %z2.s %p1/m %z4.s %z5.s -> %z2.s
+048748c4 : mla z4.s, p2/M, z6.s, z7.s                : mla    %z4.s %p2/m %z6.s %z7.s -> %z4.s
+04894906 : mla z6.s, p2/M, z8.s, z9.s                : mla    %z6.s %p2/m %z8.s %z9.s -> %z6.s
+048b4d48 : mla z8.s, p3/M, z10.s, z11.s              : mla    %z8.s %p3/m %z10.s %z11.s -> %z8.s
+048d4d8a : mla z10.s, p3/M, z12.s, z13.s             : mla    %z10.s %p3/m %z12.s %z13.s -> %z10.s
+048f51cc : mla z12.s, p4/M, z14.s, z15.s             : mla    %z12.s %p4/m %z14.s %z15.s -> %z12.s
+0491520e : mla z14.s, p4/M, z16.s, z17.s             : mla    %z14.s %p4/m %z16.s %z17.s -> %z14.s
+04935650 : mla z16.s, p5/M, z18.s, z19.s             : mla    %z16.s %p5/m %z18.s %z19.s -> %z16.s
+04945671 : mla z17.s, p5/M, z19.s, z20.s             : mla    %z17.s %p5/m %z19.s %z20.s -> %z17.s
+049656b3 : mla z19.s, p5/M, z21.s, z22.s             : mla    %z19.s %p5/m %z21.s %z22.s -> %z19.s
+04985af5 : mla z21.s, p6/M, z23.s, z24.s             : mla    %z21.s %p6/m %z23.s %z24.s -> %z21.s
+049a5b37 : mla z23.s, p6/M, z25.s, z26.s             : mla    %z23.s %p6/m %z25.s %z26.s -> %z23.s
+049c5f79 : mla z25.s, p7/M, z27.s, z28.s             : mla    %z25.s %p7/m %z27.s %z28.s -> %z25.s
+049e5fbb : mla z27.s, p7/M, z29.s, z30.s             : mla    %z27.s %p7/m %z29.s %z30.s -> %z27.s
+049f5fff : mla z31.s, p7/M, z31.s, z31.s             : mla    %z31.s %p7/m %z31.s %z31.s -> %z31.s
+04c04000 : mla z0.d, p0/M, z0.d, z0.d                : mla    %z0.d %p0/m %z0.d %z0.d -> %z0.d
+04c54482 : mla z2.d, p1/M, z4.d, z5.d                : mla    %z2.d %p1/m %z4.d %z5.d -> %z2.d
+04c748c4 : mla z4.d, p2/M, z6.d, z7.d                : mla    %z4.d %p2/m %z6.d %z7.d -> %z4.d
+04c94906 : mla z6.d, p2/M, z8.d, z9.d                : mla    %z6.d %p2/m %z8.d %z9.d -> %z6.d
+04cb4d48 : mla z8.d, p3/M, z10.d, z11.d              : mla    %z8.d %p3/m %z10.d %z11.d -> %z8.d
+04cd4d8a : mla z10.d, p3/M, z12.d, z13.d             : mla    %z10.d %p3/m %z12.d %z13.d -> %z10.d
+04cf51cc : mla z12.d, p4/M, z14.d, z15.d             : mla    %z12.d %p4/m %z14.d %z15.d -> %z12.d
+04d1520e : mla z14.d, p4/M, z16.d, z17.d             : mla    %z14.d %p4/m %z16.d %z17.d -> %z14.d
+04d35650 : mla z16.d, p5/M, z18.d, z19.d             : mla    %z16.d %p5/m %z18.d %z19.d -> %z16.d
+04d45671 : mla z17.d, p5/M, z19.d, z20.d             : mla    %z17.d %p5/m %z19.d %z20.d -> %z17.d
+04d656b3 : mla z19.d, p5/M, z21.d, z22.d             : mla    %z19.d %p5/m %z21.d %z22.d -> %z19.d
+04d85af5 : mla z21.d, p6/M, z23.d, z24.d             : mla    %z21.d %p6/m %z23.d %z24.d -> %z21.d
+04da5b37 : mla z23.d, p6/M, z25.d, z26.d             : mla    %z23.d %p6/m %z25.d %z26.d -> %z23.d
+04dc5f79 : mla z25.d, p7/M, z27.d, z28.d             : mla    %z25.d %p7/m %z27.d %z28.d -> %z25.d
+04de5fbb : mla z27.d, p7/M, z29.d, z30.d             : mla    %z27.d %p7/m %z29.d %z30.d -> %z27.d
+04df5fff : mla z31.d, p7/M, z31.d, z31.d             : mla    %z31.d %p7/m %z31.d %z31.d -> %z31.d
 
 # MLS     <Zda>.<T>, <Pg>/M, <Zn>.<T>, <Zm>.<T> (MLS-Z.P.ZZZ-_)
-04006000 : mls z0.b, p0/M, z0.b, z0.b                : mls    %p0/m %z0.b %z0.b %z0.b -> %z0.b
-04056482 : mls z2.b, p1/M, z4.b, z5.b                : mls    %p1/m %z4.b %z5.b %z2.b -> %z2.b
-040768c4 : mls z4.b, p2/M, z6.b, z7.b                : mls    %p2/m %z6.b %z7.b %z4.b -> %z4.b
-04096906 : mls z6.b, p2/M, z8.b, z9.b                : mls    %p2/m %z8.b %z9.b %z6.b -> %z6.b
-040b6d48 : mls z8.b, p3/M, z10.b, z11.b              : mls    %p3/m %z10.b %z11.b %z8.b -> %z8.b
-040d6d8a : mls z10.b, p3/M, z12.b, z13.b             : mls    %p3/m %z12.b %z13.b %z10.b -> %z10.b
-040f71cc : mls z12.b, p4/M, z14.b, z15.b             : mls    %p4/m %z14.b %z15.b %z12.b -> %z12.b
-0411720e : mls z14.b, p4/M, z16.b, z17.b             : mls    %p4/m %z16.b %z17.b %z14.b -> %z14.b
-04137650 : mls z16.b, p5/M, z18.b, z19.b             : mls    %p5/m %z18.b %z19.b %z16.b -> %z16.b
-04147671 : mls z17.b, p5/M, z19.b, z20.b             : mls    %p5/m %z19.b %z20.b %z17.b -> %z17.b
-041676b3 : mls z19.b, p5/M, z21.b, z22.b             : mls    %p5/m %z21.b %z22.b %z19.b -> %z19.b
-04187af5 : mls z21.b, p6/M, z23.b, z24.b             : mls    %p6/m %z23.b %z24.b %z21.b -> %z21.b
-041a7b37 : mls z23.b, p6/M, z25.b, z26.b             : mls    %p6/m %z25.b %z26.b %z23.b -> %z23.b
-041c7f79 : mls z25.b, p7/M, z27.b, z28.b             : mls    %p7/m %z27.b %z28.b %z25.b -> %z25.b
-041e7fbb : mls z27.b, p7/M, z29.b, z30.b             : mls    %p7/m %z29.b %z30.b %z27.b -> %z27.b
-041f7fff : mls z31.b, p7/M, z31.b, z31.b             : mls    %p7/m %z31.b %z31.b %z31.b -> %z31.b
-04406000 : mls z0.h, p0/M, z0.h, z0.h                : mls    %p0/m %z0.h %z0.h %z0.h -> %z0.h
-04456482 : mls z2.h, p1/M, z4.h, z5.h                : mls    %p1/m %z4.h %z5.h %z2.h -> %z2.h
-044768c4 : mls z4.h, p2/M, z6.h, z7.h                : mls    %p2/m %z6.h %z7.h %z4.h -> %z4.h
-04496906 : mls z6.h, p2/M, z8.h, z9.h                : mls    %p2/m %z8.h %z9.h %z6.h -> %z6.h
-044b6d48 : mls z8.h, p3/M, z10.h, z11.h              : mls    %p3/m %z10.h %z11.h %z8.h -> %z8.h
-044d6d8a : mls z10.h, p3/M, z12.h, z13.h             : mls    %p3/m %z12.h %z13.h %z10.h -> %z10.h
-044f71cc : mls z12.h, p4/M, z14.h, z15.h             : mls    %p4/m %z14.h %z15.h %z12.h -> %z12.h
-0451720e : mls z14.h, p4/M, z16.h, z17.h             : mls    %p4/m %z16.h %z17.h %z14.h -> %z14.h
-04537650 : mls z16.h, p5/M, z18.h, z19.h             : mls    %p5/m %z18.h %z19.h %z16.h -> %z16.h
-04547671 : mls z17.h, p5/M, z19.h, z20.h             : mls    %p5/m %z19.h %z20.h %z17.h -> %z17.h
-045676b3 : mls z19.h, p5/M, z21.h, z22.h             : mls    %p5/m %z21.h %z22.h %z19.h -> %z19.h
-04587af5 : mls z21.h, p6/M, z23.h, z24.h             : mls    %p6/m %z23.h %z24.h %z21.h -> %z21.h
-045a7b37 : mls z23.h, p6/M, z25.h, z26.h             : mls    %p6/m %z25.h %z26.h %z23.h -> %z23.h
-045c7f79 : mls z25.h, p7/M, z27.h, z28.h             : mls    %p7/m %z27.h %z28.h %z25.h -> %z25.h
-045e7fbb : mls z27.h, p7/M, z29.h, z30.h             : mls    %p7/m %z29.h %z30.h %z27.h -> %z27.h
-045f7fff : mls z31.h, p7/M, z31.h, z31.h             : mls    %p7/m %z31.h %z31.h %z31.h -> %z31.h
-04806000 : mls z0.s, p0/M, z0.s, z0.s                : mls    %p0/m %z0.s %z0.s %z0.s -> %z0.s
-04856482 : mls z2.s, p1/M, z4.s, z5.s                : mls    %p1/m %z4.s %z5.s %z2.s -> %z2.s
-048768c4 : mls z4.s, p2/M, z6.s, z7.s                : mls    %p2/m %z6.s %z7.s %z4.s -> %z4.s
-04896906 : mls z6.s, p2/M, z8.s, z9.s                : mls    %p2/m %z8.s %z9.s %z6.s -> %z6.s
-048b6d48 : mls z8.s, p3/M, z10.s, z11.s              : mls    %p3/m %z10.s %z11.s %z8.s -> %z8.s
-048d6d8a : mls z10.s, p3/M, z12.s, z13.s             : mls    %p3/m %z12.s %z13.s %z10.s -> %z10.s
-048f71cc : mls z12.s, p4/M, z14.s, z15.s             : mls    %p4/m %z14.s %z15.s %z12.s -> %z12.s
-0491720e : mls z14.s, p4/M, z16.s, z17.s             : mls    %p4/m %z16.s %z17.s %z14.s -> %z14.s
-04937650 : mls z16.s, p5/M, z18.s, z19.s             : mls    %p5/m %z18.s %z19.s %z16.s -> %z16.s
-04947671 : mls z17.s, p5/M, z19.s, z20.s             : mls    %p5/m %z19.s %z20.s %z17.s -> %z17.s
-049676b3 : mls z19.s, p5/M, z21.s, z22.s             : mls    %p5/m %z21.s %z22.s %z19.s -> %z19.s
-04987af5 : mls z21.s, p6/M, z23.s, z24.s             : mls    %p6/m %z23.s %z24.s %z21.s -> %z21.s
-049a7b37 : mls z23.s, p6/M, z25.s, z26.s             : mls    %p6/m %z25.s %z26.s %z23.s -> %z23.s
-049c7f79 : mls z25.s, p7/M, z27.s, z28.s             : mls    %p7/m %z27.s %z28.s %z25.s -> %z25.s
-049e7fbb : mls z27.s, p7/M, z29.s, z30.s             : mls    %p7/m %z29.s %z30.s %z27.s -> %z27.s
-049f7fff : mls z31.s, p7/M, z31.s, z31.s             : mls    %p7/m %z31.s %z31.s %z31.s -> %z31.s
-04c06000 : mls z0.d, p0/M, z0.d, z0.d                : mls    %p0/m %z0.d %z0.d %z0.d -> %z0.d
-04c56482 : mls z2.d, p1/M, z4.d, z5.d                : mls    %p1/m %z4.d %z5.d %z2.d -> %z2.d
-04c768c4 : mls z4.d, p2/M, z6.d, z7.d                : mls    %p2/m %z6.d %z7.d %z4.d -> %z4.d
-04c96906 : mls z6.d, p2/M, z8.d, z9.d                : mls    %p2/m %z8.d %z9.d %z6.d -> %z6.d
-04cb6d48 : mls z8.d, p3/M, z10.d, z11.d              : mls    %p3/m %z10.d %z11.d %z8.d -> %z8.d
-04cd6d8a : mls z10.d, p3/M, z12.d, z13.d             : mls    %p3/m %z12.d %z13.d %z10.d -> %z10.d
-04cf71cc : mls z12.d, p4/M, z14.d, z15.d             : mls    %p4/m %z14.d %z15.d %z12.d -> %z12.d
-04d1720e : mls z14.d, p4/M, z16.d, z17.d             : mls    %p4/m %z16.d %z17.d %z14.d -> %z14.d
-04d37650 : mls z16.d, p5/M, z18.d, z19.d             : mls    %p5/m %z18.d %z19.d %z16.d -> %z16.d
-04d47671 : mls z17.d, p5/M, z19.d, z20.d             : mls    %p5/m %z19.d %z20.d %z17.d -> %z17.d
-04d676b3 : mls z19.d, p5/M, z21.d, z22.d             : mls    %p5/m %z21.d %z22.d %z19.d -> %z19.d
-04d87af5 : mls z21.d, p6/M, z23.d, z24.d             : mls    %p6/m %z23.d %z24.d %z21.d -> %z21.d
-04da7b37 : mls z23.d, p6/M, z25.d, z26.d             : mls    %p6/m %z25.d %z26.d %z23.d -> %z23.d
-04dc7f79 : mls z25.d, p7/M, z27.d, z28.d             : mls    %p7/m %z27.d %z28.d %z25.d -> %z25.d
-04de7fbb : mls z27.d, p7/M, z29.d, z30.d             : mls    %p7/m %z29.d %z30.d %z27.d -> %z27.d
-04df7fff : mls z31.d, p7/M, z31.d, z31.d             : mls    %p7/m %z31.d %z31.d %z31.d -> %z31.d
+04006000 : mls z0.b, p0/M, z0.b, z0.b                : mls    %z0.b %p0/m %z0.b %z0.b -> %z0.b
+04056482 : mls z2.b, p1/M, z4.b, z5.b                : mls    %z2.b %p1/m %z4.b %z5.b -> %z2.b
+040768c4 : mls z4.b, p2/M, z6.b, z7.b                : mls    %z4.b %p2/m %z6.b %z7.b -> %z4.b
+04096906 : mls z6.b, p2/M, z8.b, z9.b                : mls    %z6.b %p2/m %z8.b %z9.b -> %z6.b
+040b6d48 : mls z8.b, p3/M, z10.b, z11.b              : mls    %z8.b %p3/m %z10.b %z11.b -> %z8.b
+040d6d8a : mls z10.b, p3/M, z12.b, z13.b             : mls    %z10.b %p3/m %z12.b %z13.b -> %z10.b
+040f71cc : mls z12.b, p4/M, z14.b, z15.b             : mls    %z12.b %p4/m %z14.b %z15.b -> %z12.b
+0411720e : mls z14.b, p4/M, z16.b, z17.b             : mls    %z14.b %p4/m %z16.b %z17.b -> %z14.b
+04137650 : mls z16.b, p5/M, z18.b, z19.b             : mls    %z16.b %p5/m %z18.b %z19.b -> %z16.b
+04147671 : mls z17.b, p5/M, z19.b, z20.b             : mls    %z17.b %p5/m %z19.b %z20.b -> %z17.b
+041676b3 : mls z19.b, p5/M, z21.b, z22.b             : mls    %z19.b %p5/m %z21.b %z22.b -> %z19.b
+04187af5 : mls z21.b, p6/M, z23.b, z24.b             : mls    %z21.b %p6/m %z23.b %z24.b -> %z21.b
+041a7b37 : mls z23.b, p6/M, z25.b, z26.b             : mls    %z23.b %p6/m %z25.b %z26.b -> %z23.b
+041c7f79 : mls z25.b, p7/M, z27.b, z28.b             : mls    %z25.b %p7/m %z27.b %z28.b -> %z25.b
+041e7fbb : mls z27.b, p7/M, z29.b, z30.b             : mls    %z27.b %p7/m %z29.b %z30.b -> %z27.b
+041f7fff : mls z31.b, p7/M, z31.b, z31.b             : mls    %z31.b %p7/m %z31.b %z31.b -> %z31.b
+04406000 : mls z0.h, p0/M, z0.h, z0.h                : mls    %z0.h %p0/m %z0.h %z0.h -> %z0.h
+04456482 : mls z2.h, p1/M, z4.h, z5.h                : mls    %z2.h %p1/m %z4.h %z5.h -> %z2.h
+044768c4 : mls z4.h, p2/M, z6.h, z7.h                : mls    %z4.h %p2/m %z6.h %z7.h -> %z4.h
+04496906 : mls z6.h, p2/M, z8.h, z9.h                : mls    %z6.h %p2/m %z8.h %z9.h -> %z6.h
+044b6d48 : mls z8.h, p3/M, z10.h, z11.h              : mls    %z8.h %p3/m %z10.h %z11.h -> %z8.h
+044d6d8a : mls z10.h, p3/M, z12.h, z13.h             : mls    %z10.h %p3/m %z12.h %z13.h -> %z10.h
+044f71cc : mls z12.h, p4/M, z14.h, z15.h             : mls    %z12.h %p4/m %z14.h %z15.h -> %z12.h
+0451720e : mls z14.h, p4/M, z16.h, z17.h             : mls    %z14.h %p4/m %z16.h %z17.h -> %z14.h
+04537650 : mls z16.h, p5/M, z18.h, z19.h             : mls    %z16.h %p5/m %z18.h %z19.h -> %z16.h
+04547671 : mls z17.h, p5/M, z19.h, z20.h             : mls    %z17.h %p5/m %z19.h %z20.h -> %z17.h
+045676b3 : mls z19.h, p5/M, z21.h, z22.h             : mls    %z19.h %p5/m %z21.h %z22.h -> %z19.h
+04587af5 : mls z21.h, p6/M, z23.h, z24.h             : mls    %z21.h %p6/m %z23.h %z24.h -> %z21.h
+045a7b37 : mls z23.h, p6/M, z25.h, z26.h             : mls    %z23.h %p6/m %z25.h %z26.h -> %z23.h
+045c7f79 : mls z25.h, p7/M, z27.h, z28.h             : mls    %z25.h %p7/m %z27.h %z28.h -> %z25.h
+045e7fbb : mls z27.h, p7/M, z29.h, z30.h             : mls    %z27.h %p7/m %z29.h %z30.h -> %z27.h
+045f7fff : mls z31.h, p7/M, z31.h, z31.h             : mls    %z31.h %p7/m %z31.h %z31.h -> %z31.h
+04806000 : mls z0.s, p0/M, z0.s, z0.s                : mls    %z0.s %p0/m %z0.s %z0.s -> %z0.s
+04856482 : mls z2.s, p1/M, z4.s, z5.s                : mls    %z2.s %p1/m %z4.s %z5.s -> %z2.s
+048768c4 : mls z4.s, p2/M, z6.s, z7.s                : mls    %z4.s %p2/m %z6.s %z7.s -> %z4.s
+04896906 : mls z6.s, p2/M, z8.s, z9.s                : mls    %z6.s %p2/m %z8.s %z9.s -> %z6.s
+048b6d48 : mls z8.s, p3/M, z10.s, z11.s              : mls    %z8.s %p3/m %z10.s %z11.s -> %z8.s
+048d6d8a : mls z10.s, p3/M, z12.s, z13.s             : mls    %z10.s %p3/m %z12.s %z13.s -> %z10.s
+048f71cc : mls z12.s, p4/M, z14.s, z15.s             : mls    %z12.s %p4/m %z14.s %z15.s -> %z12.s
+0491720e : mls z14.s, p4/M, z16.s, z17.s             : mls    %z14.s %p4/m %z16.s %z17.s -> %z14.s
+04937650 : mls z16.s, p5/M, z18.s, z19.s             : mls    %z16.s %p5/m %z18.s %z19.s -> %z16.s
+04947671 : mls z17.s, p5/M, z19.s, z20.s             : mls    %z17.s %p5/m %z19.s %z20.s -> %z17.s
+049676b3 : mls z19.s, p5/M, z21.s, z22.s             : mls    %z19.s %p5/m %z21.s %z22.s -> %z19.s
+04987af5 : mls z21.s, p6/M, z23.s, z24.s             : mls    %z21.s %p6/m %z23.s %z24.s -> %z21.s
+049a7b37 : mls z23.s, p6/M, z25.s, z26.s             : mls    %z23.s %p6/m %z25.s %z26.s -> %z23.s
+049c7f79 : mls z25.s, p7/M, z27.s, z28.s             : mls    %z25.s %p7/m %z27.s %z28.s -> %z25.s
+049e7fbb : mls z27.s, p7/M, z29.s, z30.s             : mls    %z27.s %p7/m %z29.s %z30.s -> %z27.s
+049f7fff : mls z31.s, p7/M, z31.s, z31.s             : mls    %z31.s %p7/m %z31.s %z31.s -> %z31.s
+04c06000 : mls z0.d, p0/M, z0.d, z0.d                : mls    %z0.d %p0/m %z0.d %z0.d -> %z0.d
+04c56482 : mls z2.d, p1/M, z4.d, z5.d                : mls    %z2.d %p1/m %z4.d %z5.d -> %z2.d
+04c768c4 : mls z4.d, p2/M, z6.d, z7.d                : mls    %z4.d %p2/m %z6.d %z7.d -> %z4.d
+04c96906 : mls z6.d, p2/M, z8.d, z9.d                : mls    %z6.d %p2/m %z8.d %z9.d -> %z6.d
+04cb6d48 : mls z8.d, p3/M, z10.d, z11.d              : mls    %z8.d %p3/m %z10.d %z11.d -> %z8.d
+04cd6d8a : mls z10.d, p3/M, z12.d, z13.d             : mls    %z10.d %p3/m %z12.d %z13.d -> %z10.d
+04cf71cc : mls z12.d, p4/M, z14.d, z15.d             : mls    %z12.d %p4/m %z14.d %z15.d -> %z12.d
+04d1720e : mls z14.d, p4/M, z16.d, z17.d             : mls    %z14.d %p4/m %z16.d %z17.d -> %z14.d
+04d37650 : mls z16.d, p5/M, z18.d, z19.d             : mls    %z16.d %p5/m %z18.d %z19.d -> %z16.d
+04d47671 : mls z17.d, p5/M, z19.d, z20.d             : mls    %z17.d %p5/m %z19.d %z20.d -> %z17.d
+04d676b3 : mls z19.d, p5/M, z21.d, z22.d             : mls    %z19.d %p5/m %z21.d %z22.d -> %z19.d
+04d87af5 : mls z21.d, p6/M, z23.d, z24.d             : mls    %z21.d %p6/m %z23.d %z24.d -> %z21.d
+04da7b37 : mls z23.d, p6/M, z25.d, z26.d             : mls    %z23.d %p6/m %z25.d %z26.d -> %z23.d
+04dc7f79 : mls z25.d, p7/M, z27.d, z28.d             : mls    %z25.d %p7/m %z27.d %z28.d -> %z25.d
+04de7fbb : mls z27.d, p7/M, z29.d, z30.d             : mls    %z27.d %p7/m %z29.d %z30.d -> %z27.d
+04df7fff : mls z31.d, p7/M, z31.d, z31.d             : mls    %z31.d %p7/m %z31.d %z31.d -> %z31.d
 
 # MOVPRFX <Zd>.<T>, <Pg>/<ZM>, <Zn>.<T> (MOVPRFX-Z.P.Z-_)
 04102000 : movprfx z0.b, p0/Z, z0.b                  : movprfx %p0/z %z0.b -> %z0.b
@@ -16359,70 +16359,70 @@ a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0x07(%sp)[32byte]
 0420bfde : movprfx z30, z30                          : movprfx %z30 -> %z30
 
 # MSB     <Zdn>.<T>, <Pg>/M, <Zm>.<T>, <Za>.<T> (MSB-Z.P.ZZZ-_)
-0400e000 : msb z0.b, p0/M, z0.b, z0.b                : msb    %p0/m %z0.b %z0.b %z0.b -> %z0.b
-0404e4a2 : msb z2.b, p1/M, z4.b, z5.b                : msb    %p1/m %z2.b %z4.b %z5.b -> %z2.b
-0406e8e4 : msb z4.b, p2/M, z6.b, z7.b                : msb    %p2/m %z4.b %z6.b %z7.b -> %z4.b
-0408e926 : msb z6.b, p2/M, z8.b, z9.b                : msb    %p2/m %z6.b %z8.b %z9.b -> %z6.b
-040aed68 : msb z8.b, p3/M, z10.b, z11.b              : msb    %p3/m %z8.b %z10.b %z11.b -> %z8.b
-040cedaa : msb z10.b, p3/M, z12.b, z13.b             : msb    %p3/m %z10.b %z12.b %z13.b -> %z10.b
-040ef1ec : msb z12.b, p4/M, z14.b, z15.b             : msb    %p4/m %z12.b %z14.b %z15.b -> %z12.b
-0410f22e : msb z14.b, p4/M, z16.b, z17.b             : msb    %p4/m %z14.b %z16.b %z17.b -> %z14.b
-0412f670 : msb z16.b, p5/M, z18.b, z19.b             : msb    %p5/m %z16.b %z18.b %z19.b -> %z16.b
-0413f691 : msb z17.b, p5/M, z19.b, z20.b             : msb    %p5/m %z17.b %z19.b %z20.b -> %z17.b
-0415f6d3 : msb z19.b, p5/M, z21.b, z22.b             : msb    %p5/m %z19.b %z21.b %z22.b -> %z19.b
-0417fb15 : msb z21.b, p6/M, z23.b, z24.b             : msb    %p6/m %z21.b %z23.b %z24.b -> %z21.b
-0419fb57 : msb z23.b, p6/M, z25.b, z26.b             : msb    %p6/m %z23.b %z25.b %z26.b -> %z23.b
-041bff99 : msb z25.b, p7/M, z27.b, z28.b             : msb    %p7/m %z25.b %z27.b %z28.b -> %z25.b
-041dffdb : msb z27.b, p7/M, z29.b, z30.b             : msb    %p7/m %z27.b %z29.b %z30.b -> %z27.b
-041fffff : msb z31.b, p7/M, z31.b, z31.b             : msb    %p7/m %z31.b %z31.b %z31.b -> %z31.b
-0440e000 : msb z0.h, p0/M, z0.h, z0.h                : msb    %p0/m %z0.h %z0.h %z0.h -> %z0.h
-0444e4a2 : msb z2.h, p1/M, z4.h, z5.h                : msb    %p1/m %z2.h %z4.h %z5.h -> %z2.h
-0446e8e4 : msb z4.h, p2/M, z6.h, z7.h                : msb    %p2/m %z4.h %z6.h %z7.h -> %z4.h
-0448e926 : msb z6.h, p2/M, z8.h, z9.h                : msb    %p2/m %z6.h %z8.h %z9.h -> %z6.h
-044aed68 : msb z8.h, p3/M, z10.h, z11.h              : msb    %p3/m %z8.h %z10.h %z11.h -> %z8.h
-044cedaa : msb z10.h, p3/M, z12.h, z13.h             : msb    %p3/m %z10.h %z12.h %z13.h -> %z10.h
-044ef1ec : msb z12.h, p4/M, z14.h, z15.h             : msb    %p4/m %z12.h %z14.h %z15.h -> %z12.h
-0450f22e : msb z14.h, p4/M, z16.h, z17.h             : msb    %p4/m %z14.h %z16.h %z17.h -> %z14.h
-0452f670 : msb z16.h, p5/M, z18.h, z19.h             : msb    %p5/m %z16.h %z18.h %z19.h -> %z16.h
-0453f691 : msb z17.h, p5/M, z19.h, z20.h             : msb    %p5/m %z17.h %z19.h %z20.h -> %z17.h
-0455f6d3 : msb z19.h, p5/M, z21.h, z22.h             : msb    %p5/m %z19.h %z21.h %z22.h -> %z19.h
-0457fb15 : msb z21.h, p6/M, z23.h, z24.h             : msb    %p6/m %z21.h %z23.h %z24.h -> %z21.h
-0459fb57 : msb z23.h, p6/M, z25.h, z26.h             : msb    %p6/m %z23.h %z25.h %z26.h -> %z23.h
-045bff99 : msb z25.h, p7/M, z27.h, z28.h             : msb    %p7/m %z25.h %z27.h %z28.h -> %z25.h
-045dffdb : msb z27.h, p7/M, z29.h, z30.h             : msb    %p7/m %z27.h %z29.h %z30.h -> %z27.h
-045fffff : msb z31.h, p7/M, z31.h, z31.h             : msb    %p7/m %z31.h %z31.h %z31.h -> %z31.h
-0480e000 : msb z0.s, p0/M, z0.s, z0.s                : msb    %p0/m %z0.s %z0.s %z0.s -> %z0.s
-0484e4a2 : msb z2.s, p1/M, z4.s, z5.s                : msb    %p1/m %z2.s %z4.s %z5.s -> %z2.s
-0486e8e4 : msb z4.s, p2/M, z6.s, z7.s                : msb    %p2/m %z4.s %z6.s %z7.s -> %z4.s
-0488e926 : msb z6.s, p2/M, z8.s, z9.s                : msb    %p2/m %z6.s %z8.s %z9.s -> %z6.s
-048aed68 : msb z8.s, p3/M, z10.s, z11.s              : msb    %p3/m %z8.s %z10.s %z11.s -> %z8.s
-048cedaa : msb z10.s, p3/M, z12.s, z13.s             : msb    %p3/m %z10.s %z12.s %z13.s -> %z10.s
-048ef1ec : msb z12.s, p4/M, z14.s, z15.s             : msb    %p4/m %z12.s %z14.s %z15.s -> %z12.s
-0490f22e : msb z14.s, p4/M, z16.s, z17.s             : msb    %p4/m %z14.s %z16.s %z17.s -> %z14.s
-0492f670 : msb z16.s, p5/M, z18.s, z19.s             : msb    %p5/m %z16.s %z18.s %z19.s -> %z16.s
-0493f691 : msb z17.s, p5/M, z19.s, z20.s             : msb    %p5/m %z17.s %z19.s %z20.s -> %z17.s
-0495f6d3 : msb z19.s, p5/M, z21.s, z22.s             : msb    %p5/m %z19.s %z21.s %z22.s -> %z19.s
-0497fb15 : msb z21.s, p6/M, z23.s, z24.s             : msb    %p6/m %z21.s %z23.s %z24.s -> %z21.s
-0499fb57 : msb z23.s, p6/M, z25.s, z26.s             : msb    %p6/m %z23.s %z25.s %z26.s -> %z23.s
-049bff99 : msb z25.s, p7/M, z27.s, z28.s             : msb    %p7/m %z25.s %z27.s %z28.s -> %z25.s
-049dffdb : msb z27.s, p7/M, z29.s, z30.s             : msb    %p7/m %z27.s %z29.s %z30.s -> %z27.s
-049fffff : msb z31.s, p7/M, z31.s, z31.s             : msb    %p7/m %z31.s %z31.s %z31.s -> %z31.s
-04c0e000 : msb z0.d, p0/M, z0.d, z0.d                : msb    %p0/m %z0.d %z0.d %z0.d -> %z0.d
-04c4e4a2 : msb z2.d, p1/M, z4.d, z5.d                : msb    %p1/m %z2.d %z4.d %z5.d -> %z2.d
-04c6e8e4 : msb z4.d, p2/M, z6.d, z7.d                : msb    %p2/m %z4.d %z6.d %z7.d -> %z4.d
-04c8e926 : msb z6.d, p2/M, z8.d, z9.d                : msb    %p2/m %z6.d %z8.d %z9.d -> %z6.d
-04caed68 : msb z8.d, p3/M, z10.d, z11.d              : msb    %p3/m %z8.d %z10.d %z11.d -> %z8.d
-04ccedaa : msb z10.d, p3/M, z12.d, z13.d             : msb    %p3/m %z10.d %z12.d %z13.d -> %z10.d
-04cef1ec : msb z12.d, p4/M, z14.d, z15.d             : msb    %p4/m %z12.d %z14.d %z15.d -> %z12.d
-04d0f22e : msb z14.d, p4/M, z16.d, z17.d             : msb    %p4/m %z14.d %z16.d %z17.d -> %z14.d
-04d2f670 : msb z16.d, p5/M, z18.d, z19.d             : msb    %p5/m %z16.d %z18.d %z19.d -> %z16.d
-04d3f691 : msb z17.d, p5/M, z19.d, z20.d             : msb    %p5/m %z17.d %z19.d %z20.d -> %z17.d
-04d5f6d3 : msb z19.d, p5/M, z21.d, z22.d             : msb    %p5/m %z19.d %z21.d %z22.d -> %z19.d
-04d7fb15 : msb z21.d, p6/M, z23.d, z24.d             : msb    %p6/m %z21.d %z23.d %z24.d -> %z21.d
-04d9fb57 : msb z23.d, p6/M, z25.d, z26.d             : msb    %p6/m %z23.d %z25.d %z26.d -> %z23.d
-04dbff99 : msb z25.d, p7/M, z27.d, z28.d             : msb    %p7/m %z25.d %z27.d %z28.d -> %z25.d
-04ddffdb : msb z27.d, p7/M, z29.d, z30.d             : msb    %p7/m %z27.d %z29.d %z30.d -> %z27.d
-04dfffff : msb z31.d, p7/M, z31.d, z31.d             : msb    %p7/m %z31.d %z31.d %z31.d -> %z31.d
+0400e000 : msb z0.b, p0/M, z0.b, z0.b                : msb    %z0.b %p0/m %z0.b %z0.b -> %z0.b
+0404e4a2 : msb z2.b, p1/M, z4.b, z5.b                : msb    %z2.b %p1/m %z4.b %z5.b -> %z2.b
+0406e8e4 : msb z4.b, p2/M, z6.b, z7.b                : msb    %z4.b %p2/m %z6.b %z7.b -> %z4.b
+0408e926 : msb z6.b, p2/M, z8.b, z9.b                : msb    %z6.b %p2/m %z8.b %z9.b -> %z6.b
+040aed68 : msb z8.b, p3/M, z10.b, z11.b              : msb    %z8.b %p3/m %z10.b %z11.b -> %z8.b
+040cedaa : msb z10.b, p3/M, z12.b, z13.b             : msb    %z10.b %p3/m %z12.b %z13.b -> %z10.b
+040ef1ec : msb z12.b, p4/M, z14.b, z15.b             : msb    %z12.b %p4/m %z14.b %z15.b -> %z12.b
+0410f22e : msb z14.b, p4/M, z16.b, z17.b             : msb    %z14.b %p4/m %z16.b %z17.b -> %z14.b
+0412f670 : msb z16.b, p5/M, z18.b, z19.b             : msb    %z16.b %p5/m %z18.b %z19.b -> %z16.b
+0413f691 : msb z17.b, p5/M, z19.b, z20.b             : msb    %z17.b %p5/m %z19.b %z20.b -> %z17.b
+0415f6d3 : msb z19.b, p5/M, z21.b, z22.b             : msb    %z19.b %p5/m %z21.b %z22.b -> %z19.b
+0417fb15 : msb z21.b, p6/M, z23.b, z24.b             : msb    %z21.b %p6/m %z23.b %z24.b -> %z21.b
+0419fb57 : msb z23.b, p6/M, z25.b, z26.b             : msb    %z23.b %p6/m %z25.b %z26.b -> %z23.b
+041bff99 : msb z25.b, p7/M, z27.b, z28.b             : msb    %z25.b %p7/m %z27.b %z28.b -> %z25.b
+041dffdb : msb z27.b, p7/M, z29.b, z30.b             : msb    %z27.b %p7/m %z29.b %z30.b -> %z27.b
+041fffff : msb z31.b, p7/M, z31.b, z31.b             : msb    %z31.b %p7/m %z31.b %z31.b -> %z31.b
+0440e000 : msb z0.h, p0/M, z0.h, z0.h                : msb    %z0.h %p0/m %z0.h %z0.h -> %z0.h
+0444e4a2 : msb z2.h, p1/M, z4.h, z5.h                : msb    %z2.h %p1/m %z4.h %z5.h -> %z2.h
+0446e8e4 : msb z4.h, p2/M, z6.h, z7.h                : msb    %z4.h %p2/m %z6.h %z7.h -> %z4.h
+0448e926 : msb z6.h, p2/M, z8.h, z9.h                : msb    %z6.h %p2/m %z8.h %z9.h -> %z6.h
+044aed68 : msb z8.h, p3/M, z10.h, z11.h              : msb    %z8.h %p3/m %z10.h %z11.h -> %z8.h
+044cedaa : msb z10.h, p3/M, z12.h, z13.h             : msb    %z10.h %p3/m %z12.h %z13.h -> %z10.h
+044ef1ec : msb z12.h, p4/M, z14.h, z15.h             : msb    %z12.h %p4/m %z14.h %z15.h -> %z12.h
+0450f22e : msb z14.h, p4/M, z16.h, z17.h             : msb    %z14.h %p4/m %z16.h %z17.h -> %z14.h
+0452f670 : msb z16.h, p5/M, z18.h, z19.h             : msb    %z16.h %p5/m %z18.h %z19.h -> %z16.h
+0453f691 : msb z17.h, p5/M, z19.h, z20.h             : msb    %z17.h %p5/m %z19.h %z20.h -> %z17.h
+0455f6d3 : msb z19.h, p5/M, z21.h, z22.h             : msb    %z19.h %p5/m %z21.h %z22.h -> %z19.h
+0457fb15 : msb z21.h, p6/M, z23.h, z24.h             : msb    %z21.h %p6/m %z23.h %z24.h -> %z21.h
+0459fb57 : msb z23.h, p6/M, z25.h, z26.h             : msb    %z23.h %p6/m %z25.h %z26.h -> %z23.h
+045bff99 : msb z25.h, p7/M, z27.h, z28.h             : msb    %z25.h %p7/m %z27.h %z28.h -> %z25.h
+045dffdb : msb z27.h, p7/M, z29.h, z30.h             : msb    %z27.h %p7/m %z29.h %z30.h -> %z27.h
+045fffff : msb z31.h, p7/M, z31.h, z31.h             : msb    %z31.h %p7/m %z31.h %z31.h -> %z31.h
+0480e000 : msb z0.s, p0/M, z0.s, z0.s                : msb    %z0.s %p0/m %z0.s %z0.s -> %z0.s
+0484e4a2 : msb z2.s, p1/M, z4.s, z5.s                : msb    %z2.s %p1/m %z4.s %z5.s -> %z2.s
+0486e8e4 : msb z4.s, p2/M, z6.s, z7.s                : msb    %z4.s %p2/m %z6.s %z7.s -> %z4.s
+0488e926 : msb z6.s, p2/M, z8.s, z9.s                : msb    %z6.s %p2/m %z8.s %z9.s -> %z6.s
+048aed68 : msb z8.s, p3/M, z10.s, z11.s              : msb    %z8.s %p3/m %z10.s %z11.s -> %z8.s
+048cedaa : msb z10.s, p3/M, z12.s, z13.s             : msb    %z10.s %p3/m %z12.s %z13.s -> %z10.s
+048ef1ec : msb z12.s, p4/M, z14.s, z15.s             : msb    %z12.s %p4/m %z14.s %z15.s -> %z12.s
+0490f22e : msb z14.s, p4/M, z16.s, z17.s             : msb    %z14.s %p4/m %z16.s %z17.s -> %z14.s
+0492f670 : msb z16.s, p5/M, z18.s, z19.s             : msb    %z16.s %p5/m %z18.s %z19.s -> %z16.s
+0493f691 : msb z17.s, p5/M, z19.s, z20.s             : msb    %z17.s %p5/m %z19.s %z20.s -> %z17.s
+0495f6d3 : msb z19.s, p5/M, z21.s, z22.s             : msb    %z19.s %p5/m %z21.s %z22.s -> %z19.s
+0497fb15 : msb z21.s, p6/M, z23.s, z24.s             : msb    %z21.s %p6/m %z23.s %z24.s -> %z21.s
+0499fb57 : msb z23.s, p6/M, z25.s, z26.s             : msb    %z23.s %p6/m %z25.s %z26.s -> %z23.s
+049bff99 : msb z25.s, p7/M, z27.s, z28.s             : msb    %z25.s %p7/m %z27.s %z28.s -> %z25.s
+049dffdb : msb z27.s, p7/M, z29.s, z30.s             : msb    %z27.s %p7/m %z29.s %z30.s -> %z27.s
+049fffff : msb z31.s, p7/M, z31.s, z31.s             : msb    %z31.s %p7/m %z31.s %z31.s -> %z31.s
+04c0e000 : msb z0.d, p0/M, z0.d, z0.d                : msb    %z0.d %p0/m %z0.d %z0.d -> %z0.d
+04c4e4a2 : msb z2.d, p1/M, z4.d, z5.d                : msb    %z2.d %p1/m %z4.d %z5.d -> %z2.d
+04c6e8e4 : msb z4.d, p2/M, z6.d, z7.d                : msb    %z4.d %p2/m %z6.d %z7.d -> %z4.d
+04c8e926 : msb z6.d, p2/M, z8.d, z9.d                : msb    %z6.d %p2/m %z8.d %z9.d -> %z6.d
+04caed68 : msb z8.d, p3/M, z10.d, z11.d              : msb    %z8.d %p3/m %z10.d %z11.d -> %z8.d
+04ccedaa : msb z10.d, p3/M, z12.d, z13.d             : msb    %z10.d %p3/m %z12.d %z13.d -> %z10.d
+04cef1ec : msb z12.d, p4/M, z14.d, z15.d             : msb    %z12.d %p4/m %z14.d %z15.d -> %z12.d
+04d0f22e : msb z14.d, p4/M, z16.d, z17.d             : msb    %z14.d %p4/m %z16.d %z17.d -> %z14.d
+04d2f670 : msb z16.d, p5/M, z18.d, z19.d             : msb    %z16.d %p5/m %z18.d %z19.d -> %z16.d
+04d3f691 : msb z17.d, p5/M, z19.d, z20.d             : msb    %z17.d %p5/m %z19.d %z20.d -> %z17.d
+04d5f6d3 : msb z19.d, p5/M, z21.d, z22.d             : msb    %z19.d %p5/m %z21.d %z22.d -> %z19.d
+04d7fb15 : msb z21.d, p6/M, z23.d, z24.d             : msb    %z21.d %p6/m %z23.d %z24.d -> %z21.d
+04d9fb57 : msb z23.d, p6/M, z25.d, z26.d             : msb    %z23.d %p6/m %z25.d %z26.d -> %z23.d
+04dbff99 : msb z25.d, p7/M, z27.d, z28.d             : msb    %z25.d %p7/m %z27.d %z28.d -> %z25.d
+04ddffdb : msb z27.d, p7/M, z29.d, z30.d             : msb    %z27.d %p7/m %z29.d %z30.d -> %z27.d
+04dfffff : msb z31.d, p7/M, z31.d, z31.d             : msb    %z31.d %p7/m %z31.d %z31.d -> %z31.d
 
 # MUL     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (MUL-Z.P.ZZ-_)
 04100000 : mul z0.b, p0/M, z0.b, z0.b                : mul    %p0/m %z0.b %z0.b -> %z0.b
@@ -19881,187 +19881,121 @@ c51fffef : prfw 15, p7, [z31.d, #124]                : prfw   $0x0f %p7 +0x7c(%z
 047efbdc : sqdech x28, MUL3, MUL #15                 : sqdech %x28 MUL3 mul $0x0f -> %x28
 047ffbfe : sqdech x30, ALL, MUL #16                  : sqdech %x30 ALL mul $0x10 -> %x30
 
-# SQDECP  <Xdn>, <Pm>.<T>, <Wdn> (SQDECP-R.P.R-SX)
-252a8800 : sqdecp x0, p0.b, w0                       : sqdecp %p0.b %w0 -> %x0
-252a8842 : sqdecp x2, p2.b, w2                       : sqdecp %p2.b %w2 -> %x2
-252a8864 : sqdecp x4, p3.b, w4                       : sqdecp %p3.b %w4 -> %x4
-252a8886 : sqdecp x6, p4.b, w6                       : sqdecp %p4.b %w6 -> %x6
-252a88a8 : sqdecp x8, p5.b, w8                       : sqdecp %p5.b %w8 -> %x8
-252a88c9 : sqdecp x9, p6.b, w9                       : sqdecp %p6.b %w9 -> %x9
-252a88eb : sqdecp x11, p7.b, w11                     : sqdecp %p7.b %w11 -> %x11
-252a890d : sqdecp x13, p8.b, w13                     : sqdecp %p8.b %w13 -> %x13
-252a892f : sqdecp x15, p9.b, w15                     : sqdecp %p9.b %w15 -> %x15
-252a8931 : sqdecp x17, p9.b, w17                     : sqdecp %p9.b %w17 -> %x17
-252a8953 : sqdecp x19, p10.b, w19                    : sqdecp %p10.b %w19 -> %x19
-252a8975 : sqdecp x21, p11.b, w21                    : sqdecp %p11.b %w21 -> %x21
-252a8996 : sqdecp x22, p12.b, w22                    : sqdecp %p12.b %w22 -> %x22
-252a89b8 : sqdecp x24, p13.b, w24                    : sqdecp %p13.b %w24 -> %x24
-252a89da : sqdecp x26, p14.b, w26                    : sqdecp %p14.b %w26 -> %x26
-252a89fe : sqdecp x30, p15.b, w30                    : sqdecp %p15.b %w30 -> %x30
-256a8800 : sqdecp x0, p0.h, w0                       : sqdecp %p0.h %w0 -> %x0
-256a8842 : sqdecp x2, p2.h, w2                       : sqdecp %p2.h %w2 -> %x2
-256a8864 : sqdecp x4, p3.h, w4                       : sqdecp %p3.h %w4 -> %x4
-256a8886 : sqdecp x6, p4.h, w6                       : sqdecp %p4.h %w6 -> %x6
-256a88a8 : sqdecp x8, p5.h, w8                       : sqdecp %p5.h %w8 -> %x8
-256a88c9 : sqdecp x9, p6.h, w9                       : sqdecp %p6.h %w9 -> %x9
-256a88eb : sqdecp x11, p7.h, w11                     : sqdecp %p7.h %w11 -> %x11
-256a890d : sqdecp x13, p8.h, w13                     : sqdecp %p8.h %w13 -> %x13
-256a892f : sqdecp x15, p9.h, w15                     : sqdecp %p9.h %w15 -> %x15
-256a8931 : sqdecp x17, p9.h, w17                     : sqdecp %p9.h %w17 -> %x17
-256a8953 : sqdecp x19, p10.h, w19                    : sqdecp %p10.h %w19 -> %x19
-256a8975 : sqdecp x21, p11.h, w21                    : sqdecp %p11.h %w21 -> %x21
-256a8996 : sqdecp x22, p12.h, w22                    : sqdecp %p12.h %w22 -> %x22
-256a89b8 : sqdecp x24, p13.h, w24                    : sqdecp %p13.h %w24 -> %x24
-256a89da : sqdecp x26, p14.h, w26                    : sqdecp %p14.h %w26 -> %x26
-256a89fe : sqdecp x30, p15.h, w30                    : sqdecp %p15.h %w30 -> %x30
-25aa8800 : sqdecp x0, p0.s, w0                       : sqdecp %p0.s %w0 -> %x0
-25aa8842 : sqdecp x2, p2.s, w2                       : sqdecp %p2.s %w2 -> %x2
-25aa8864 : sqdecp x4, p3.s, w4                       : sqdecp %p3.s %w4 -> %x4
-25aa8886 : sqdecp x6, p4.s, w6                       : sqdecp %p4.s %w6 -> %x6
-25aa88a8 : sqdecp x8, p5.s, w8                       : sqdecp %p5.s %w8 -> %x8
-25aa88c9 : sqdecp x9, p6.s, w9                       : sqdecp %p6.s %w9 -> %x9
-25aa88eb : sqdecp x11, p7.s, w11                     : sqdecp %p7.s %w11 -> %x11
-25aa890d : sqdecp x13, p8.s, w13                     : sqdecp %p8.s %w13 -> %x13
-25aa892f : sqdecp x15, p9.s, w15                     : sqdecp %p9.s %w15 -> %x15
-25aa8931 : sqdecp x17, p9.s, w17                     : sqdecp %p9.s %w17 -> %x17
-25aa8953 : sqdecp x19, p10.s, w19                    : sqdecp %p10.s %w19 -> %x19
-25aa8975 : sqdecp x21, p11.s, w21                    : sqdecp %p11.s %w21 -> %x21
-25aa8996 : sqdecp x22, p12.s, w22                    : sqdecp %p12.s %w22 -> %x22
-25aa89b8 : sqdecp x24, p13.s, w24                    : sqdecp %p13.s %w24 -> %x24
-25aa89da : sqdecp x26, p14.s, w26                    : sqdecp %p14.s %w26 -> %x26
-25aa89fe : sqdecp x30, p15.s, w30                    : sqdecp %p15.s %w30 -> %x30
-25ea8800 : sqdecp x0, p0.d, w0                       : sqdecp %p0.d %w0 -> %x0
-25ea8842 : sqdecp x2, p2.d, w2                       : sqdecp %p2.d %w2 -> %x2
-25ea8864 : sqdecp x4, p3.d, w4                       : sqdecp %p3.d %w4 -> %x4
-25ea8886 : sqdecp x6, p4.d, w6                       : sqdecp %p4.d %w6 -> %x6
-25ea88a8 : sqdecp x8, p5.d, w8                       : sqdecp %p5.d %w8 -> %x8
-25ea88c9 : sqdecp x9, p6.d, w9                       : sqdecp %p6.d %w9 -> %x9
-25ea88eb : sqdecp x11, p7.d, w11                     : sqdecp %p7.d %w11 -> %x11
-25ea890d : sqdecp x13, p8.d, w13                     : sqdecp %p8.d %w13 -> %x13
-25ea892f : sqdecp x15, p9.d, w15                     : sqdecp %p9.d %w15 -> %x15
-25ea8931 : sqdecp x17, p9.d, w17                     : sqdecp %p9.d %w17 -> %x17
-25ea8953 : sqdecp x19, p10.d, w19                    : sqdecp %p10.d %w19 -> %x19
-25ea8975 : sqdecp x21, p11.d, w21                    : sqdecp %p11.d %w21 -> %x21
-25ea8996 : sqdecp x22, p12.d, w22                    : sqdecp %p12.d %w22 -> %x22
-25ea89b8 : sqdecp x24, p13.d, w24                    : sqdecp %p13.d %w24 -> %x24
-25ea89da : sqdecp x26, p14.d, w26                    : sqdecp %p14.d %w26 -> %x26
-25ea89fe : sqdecp x30, p15.d, w30                    : sqdecp %p15.d %w30 -> %x30
-
 # SQDECP  <Xdn>, <Pm>.<T> (SQDECP-R.P.R-X)
-252a8c00 : sqdecp x0, p0.b                           : sqdecp %p0.b %x0 -> %x0
-252a8c42 : sqdecp x2, p2.b                           : sqdecp %p2.b %x2 -> %x2
-252a8c64 : sqdecp x4, p3.b                           : sqdecp %p3.b %x4 -> %x4
-252a8c86 : sqdecp x6, p4.b                           : sqdecp %p4.b %x6 -> %x6
-252a8ca8 : sqdecp x8, p5.b                           : sqdecp %p5.b %x8 -> %x8
-252a8cc9 : sqdecp x9, p6.b                           : sqdecp %p6.b %x9 -> %x9
-252a8ceb : sqdecp x11, p7.b                          : sqdecp %p7.b %x11 -> %x11
-252a8d0d : sqdecp x13, p8.b                          : sqdecp %p8.b %x13 -> %x13
-252a8d2f : sqdecp x15, p9.b                          : sqdecp %p9.b %x15 -> %x15
-252a8d31 : sqdecp x17, p9.b                          : sqdecp %p9.b %x17 -> %x17
-252a8d53 : sqdecp x19, p10.b                         : sqdecp %p10.b %x19 -> %x19
-252a8d75 : sqdecp x21, p11.b                         : sqdecp %p11.b %x21 -> %x21
-252a8d96 : sqdecp x22, p12.b                         : sqdecp %p12.b %x22 -> %x22
-252a8db8 : sqdecp x24, p13.b                         : sqdecp %p13.b %x24 -> %x24
-252a8dda : sqdecp x26, p14.b                         : sqdecp %p14.b %x26 -> %x26
-252a8dfe : sqdecp x30, p15.b                         : sqdecp %p15.b %x30 -> %x30
-256a8c00 : sqdecp x0, p0.h                           : sqdecp %p0.h %x0 -> %x0
-256a8c42 : sqdecp x2, p2.h                           : sqdecp %p2.h %x2 -> %x2
-256a8c64 : sqdecp x4, p3.h                           : sqdecp %p3.h %x4 -> %x4
-256a8c86 : sqdecp x6, p4.h                           : sqdecp %p4.h %x6 -> %x6
-256a8ca8 : sqdecp x8, p5.h                           : sqdecp %p5.h %x8 -> %x8
-256a8cc9 : sqdecp x9, p6.h                           : sqdecp %p6.h %x9 -> %x9
-256a8ceb : sqdecp x11, p7.h                          : sqdecp %p7.h %x11 -> %x11
-256a8d0d : sqdecp x13, p8.h                          : sqdecp %p8.h %x13 -> %x13
-256a8d2f : sqdecp x15, p9.h                          : sqdecp %p9.h %x15 -> %x15
-256a8d31 : sqdecp x17, p9.h                          : sqdecp %p9.h %x17 -> %x17
-256a8d53 : sqdecp x19, p10.h                         : sqdecp %p10.h %x19 -> %x19
-256a8d75 : sqdecp x21, p11.h                         : sqdecp %p11.h %x21 -> %x21
-256a8d96 : sqdecp x22, p12.h                         : sqdecp %p12.h %x22 -> %x22
-256a8db8 : sqdecp x24, p13.h                         : sqdecp %p13.h %x24 -> %x24
-256a8dda : sqdecp x26, p14.h                         : sqdecp %p14.h %x26 -> %x26
-256a8dfe : sqdecp x30, p15.h                         : sqdecp %p15.h %x30 -> %x30
-25aa8c00 : sqdecp x0, p0.s                           : sqdecp %p0.s %x0 -> %x0
-25aa8c42 : sqdecp x2, p2.s                           : sqdecp %p2.s %x2 -> %x2
-25aa8c64 : sqdecp x4, p3.s                           : sqdecp %p3.s %x4 -> %x4
-25aa8c86 : sqdecp x6, p4.s                           : sqdecp %p4.s %x6 -> %x6
-25aa8ca8 : sqdecp x8, p5.s                           : sqdecp %p5.s %x8 -> %x8
-25aa8cc9 : sqdecp x9, p6.s                           : sqdecp %p6.s %x9 -> %x9
-25aa8ceb : sqdecp x11, p7.s                          : sqdecp %p7.s %x11 -> %x11
-25aa8d0d : sqdecp x13, p8.s                          : sqdecp %p8.s %x13 -> %x13
-25aa8d2f : sqdecp x15, p9.s                          : sqdecp %p9.s %x15 -> %x15
-25aa8d31 : sqdecp x17, p9.s                          : sqdecp %p9.s %x17 -> %x17
-25aa8d53 : sqdecp x19, p10.s                         : sqdecp %p10.s %x19 -> %x19
-25aa8d75 : sqdecp x21, p11.s                         : sqdecp %p11.s %x21 -> %x21
-25aa8d96 : sqdecp x22, p12.s                         : sqdecp %p12.s %x22 -> %x22
-25aa8db8 : sqdecp x24, p13.s                         : sqdecp %p13.s %x24 -> %x24
-25aa8dda : sqdecp x26, p14.s                         : sqdecp %p14.s %x26 -> %x26
-25aa8dfe : sqdecp x30, p15.s                         : sqdecp %p15.s %x30 -> %x30
-25ea8c00 : sqdecp x0, p0.d                           : sqdecp %p0.d %x0 -> %x0
-25ea8c42 : sqdecp x2, p2.d                           : sqdecp %p2.d %x2 -> %x2
-25ea8c64 : sqdecp x4, p3.d                           : sqdecp %p3.d %x4 -> %x4
-25ea8c86 : sqdecp x6, p4.d                           : sqdecp %p4.d %x6 -> %x6
-25ea8ca8 : sqdecp x8, p5.d                           : sqdecp %p5.d %x8 -> %x8
-25ea8cc9 : sqdecp x9, p6.d                           : sqdecp %p6.d %x9 -> %x9
-25ea8ceb : sqdecp x11, p7.d                          : sqdecp %p7.d %x11 -> %x11
-25ea8d0d : sqdecp x13, p8.d                          : sqdecp %p8.d %x13 -> %x13
-25ea8d2f : sqdecp x15, p9.d                          : sqdecp %p9.d %x15 -> %x15
-25ea8d31 : sqdecp x17, p9.d                          : sqdecp %p9.d %x17 -> %x17
-25ea8d53 : sqdecp x19, p10.d                         : sqdecp %p10.d %x19 -> %x19
-25ea8d75 : sqdecp x21, p11.d                         : sqdecp %p11.d %x21 -> %x21
-25ea8d96 : sqdecp x22, p12.d                         : sqdecp %p12.d %x22 -> %x22
-25ea8db8 : sqdecp x24, p13.d                         : sqdecp %p13.d %x24 -> %x24
-25ea8dda : sqdecp x26, p14.d                         : sqdecp %p14.d %x26 -> %x26
-25ea8dfe : sqdecp x30, p15.d                         : sqdecp %p15.d %x30 -> %x30
+252a8c00 : sqdecp x0, p0.b                           : sqdecp %x0 %p0.b -> %x0
+252a8c42 : sqdecp x2, p2.b                           : sqdecp %x2 %p2.b -> %x2
+252a8c64 : sqdecp x4, p3.b                           : sqdecp %x4 %p3.b -> %x4
+252a8c86 : sqdecp x6, p4.b                           : sqdecp %x6 %p4.b -> %x6
+252a8ca8 : sqdecp x8, p5.b                           : sqdecp %x8 %p5.b -> %x8
+252a8cc9 : sqdecp x9, p6.b                           : sqdecp %x9 %p6.b -> %x9
+252a8ceb : sqdecp x11, p7.b                          : sqdecp %x11 %p7.b -> %x11
+252a8d0d : sqdecp x13, p8.b                          : sqdecp %x13 %p8.b -> %x13
+252a8d2f : sqdecp x15, p9.b                          : sqdecp %x15 %p9.b -> %x15
+252a8d31 : sqdecp x17, p9.b                          : sqdecp %x17 %p9.b -> %x17
+252a8d53 : sqdecp x19, p10.b                         : sqdecp %x19 %p10.b -> %x19
+252a8d75 : sqdecp x21, p11.b                         : sqdecp %x21 %p11.b -> %x21
+252a8d96 : sqdecp x22, p12.b                         : sqdecp %x22 %p12.b -> %x22
+252a8db8 : sqdecp x24, p13.b                         : sqdecp %x24 %p13.b -> %x24
+252a8dda : sqdecp x26, p14.b                         : sqdecp %x26 %p14.b -> %x26
+252a8dfe : sqdecp x30, p15.b                         : sqdecp %x30 %p15.b -> %x30
+256a8c00 : sqdecp x0, p0.h                           : sqdecp %x0 %p0.h -> %x0
+256a8c42 : sqdecp x2, p2.h                           : sqdecp %x2 %p2.h -> %x2
+256a8c64 : sqdecp x4, p3.h                           : sqdecp %x4 %p3.h -> %x4
+256a8c86 : sqdecp x6, p4.h                           : sqdecp %x6 %p4.h -> %x6
+256a8ca8 : sqdecp x8, p5.h                           : sqdecp %x8 %p5.h -> %x8
+256a8cc9 : sqdecp x9, p6.h                           : sqdecp %x9 %p6.h -> %x9
+256a8ceb : sqdecp x11, p7.h                          : sqdecp %x11 %p7.h -> %x11
+256a8d0d : sqdecp x13, p8.h                          : sqdecp %x13 %p8.h -> %x13
+256a8d2f : sqdecp x15, p9.h                          : sqdecp %x15 %p9.h -> %x15
+256a8d31 : sqdecp x17, p9.h                          : sqdecp %x17 %p9.h -> %x17
+256a8d53 : sqdecp x19, p10.h                         : sqdecp %x19 %p10.h -> %x19
+256a8d75 : sqdecp x21, p11.h                         : sqdecp %x21 %p11.h -> %x21
+256a8d96 : sqdecp x22, p12.h                         : sqdecp %x22 %p12.h -> %x22
+256a8db8 : sqdecp x24, p13.h                         : sqdecp %x24 %p13.h -> %x24
+256a8dda : sqdecp x26, p14.h                         : sqdecp %x26 %p14.h -> %x26
+256a8dfe : sqdecp x30, p15.h                         : sqdecp %x30 %p15.h -> %x30
+25aa8c00 : sqdecp x0, p0.s                           : sqdecp %x0 %p0.s -> %x0
+25aa8c42 : sqdecp x2, p2.s                           : sqdecp %x2 %p2.s -> %x2
+25aa8c64 : sqdecp x4, p3.s                           : sqdecp %x4 %p3.s -> %x4
+25aa8c86 : sqdecp x6, p4.s                           : sqdecp %x6 %p4.s -> %x6
+25aa8ca8 : sqdecp x8, p5.s                           : sqdecp %x8 %p5.s -> %x8
+25aa8cc9 : sqdecp x9, p6.s                           : sqdecp %x9 %p6.s -> %x9
+25aa8ceb : sqdecp x11, p7.s                          : sqdecp %x11 %p7.s -> %x11
+25aa8d0d : sqdecp x13, p8.s                          : sqdecp %x13 %p8.s -> %x13
+25aa8d2f : sqdecp x15, p9.s                          : sqdecp %x15 %p9.s -> %x15
+25aa8d31 : sqdecp x17, p9.s                          : sqdecp %x17 %p9.s -> %x17
+25aa8d53 : sqdecp x19, p10.s                         : sqdecp %x19 %p10.s -> %x19
+25aa8d75 : sqdecp x21, p11.s                         : sqdecp %x21 %p11.s -> %x21
+25aa8d96 : sqdecp x22, p12.s                         : sqdecp %x22 %p12.s -> %x22
+25aa8db8 : sqdecp x24, p13.s                         : sqdecp %x24 %p13.s -> %x24
+25aa8dda : sqdecp x26, p14.s                         : sqdecp %x26 %p14.s -> %x26
+25aa8dfe : sqdecp x30, p15.s                         : sqdecp %x30 %p15.s -> %x30
+25ea8c00 : sqdecp x0, p0.d                           : sqdecp %x0 %p0.d -> %x0
+25ea8c42 : sqdecp x2, p2.d                           : sqdecp %x2 %p2.d -> %x2
+25ea8c64 : sqdecp x4, p3.d                           : sqdecp %x4 %p3.d -> %x4
+25ea8c86 : sqdecp x6, p4.d                           : sqdecp %x6 %p4.d -> %x6
+25ea8ca8 : sqdecp x8, p5.d                           : sqdecp %x8 %p5.d -> %x8
+25ea8cc9 : sqdecp x9, p6.d                           : sqdecp %x9 %p6.d -> %x9
+25ea8ceb : sqdecp x11, p7.d                          : sqdecp %x11 %p7.d -> %x11
+25ea8d0d : sqdecp x13, p8.d                          : sqdecp %x13 %p8.d -> %x13
+25ea8d2f : sqdecp x15, p9.d                          : sqdecp %x15 %p9.d -> %x15
+25ea8d31 : sqdecp x17, p9.d                          : sqdecp %x17 %p9.d -> %x17
+25ea8d53 : sqdecp x19, p10.d                         : sqdecp %x19 %p10.d -> %x19
+25ea8d75 : sqdecp x21, p11.d                         : sqdecp %x21 %p11.d -> %x21
+25ea8d96 : sqdecp x22, p12.d                         : sqdecp %x22 %p12.d -> %x22
+25ea8db8 : sqdecp x24, p13.d                         : sqdecp %x24 %p13.d -> %x24
+25ea8dda : sqdecp x26, p14.d                         : sqdecp %x26 %p14.d -> %x26
+25ea8dfe : sqdecp x30, p15.d                         : sqdecp %x30 %p15.d -> %x30
 
 # SQDECP  <Zdn>.<T>, <Pm>.<T> (SQDECP-Z.P.Z-_)
-256a8000 : sqdecp z0.h, p0                           : sqdecp %p0.h %z0.h -> %z0.h
-256a8042 : sqdecp z2.h, p2                           : sqdecp %p2.h %z2.h -> %z2.h
-256a8064 : sqdecp z4.h, p3                           : sqdecp %p3.h %z4.h -> %z4.h
-256a8086 : sqdecp z6.h, p4                           : sqdecp %p4.h %z6.h -> %z6.h
-256a80a8 : sqdecp z8.h, p5                           : sqdecp %p5.h %z8.h -> %z8.h
-256a80ca : sqdecp z10.h, p6                          : sqdecp %p6.h %z10.h -> %z10.h
-256a80ec : sqdecp z12.h, p7                          : sqdecp %p7.h %z12.h -> %z12.h
-256a810e : sqdecp z14.h, p8                          : sqdecp %p8.h %z14.h -> %z14.h
-256a8130 : sqdecp z16.h, p9                          : sqdecp %p9.h %z16.h -> %z16.h
-256a8131 : sqdecp z17.h, p9                          : sqdecp %p9.h %z17.h -> %z17.h
-256a8153 : sqdecp z19.h, p10                         : sqdecp %p10.h %z19.h -> %z19.h
-256a8175 : sqdecp z21.h, p11                         : sqdecp %p11.h %z21.h -> %z21.h
-256a8197 : sqdecp z23.h, p12                         : sqdecp %p12.h %z23.h -> %z23.h
-256a81b9 : sqdecp z25.h, p13                         : sqdecp %p13.h %z25.h -> %z25.h
-256a81db : sqdecp z27.h, p14                         : sqdecp %p14.h %z27.h -> %z27.h
-256a81ff : sqdecp z31.h, p15                         : sqdecp %p15.h %z31.h -> %z31.h
-25aa8000 : sqdecp z0.s, p0                           : sqdecp %p0.s %z0.s -> %z0.s
-25aa8042 : sqdecp z2.s, p2                           : sqdecp %p2.s %z2.s -> %z2.s
-25aa8064 : sqdecp z4.s, p3                           : sqdecp %p3.s %z4.s -> %z4.s
-25aa8086 : sqdecp z6.s, p4                           : sqdecp %p4.s %z6.s -> %z6.s
-25aa80a8 : sqdecp z8.s, p5                           : sqdecp %p5.s %z8.s -> %z8.s
-25aa80ca : sqdecp z10.s, p6                          : sqdecp %p6.s %z10.s -> %z10.s
-25aa80ec : sqdecp z12.s, p7                          : sqdecp %p7.s %z12.s -> %z12.s
-25aa810e : sqdecp z14.s, p8                          : sqdecp %p8.s %z14.s -> %z14.s
-25aa8130 : sqdecp z16.s, p9                          : sqdecp %p9.s %z16.s -> %z16.s
-25aa8131 : sqdecp z17.s, p9                          : sqdecp %p9.s %z17.s -> %z17.s
-25aa8153 : sqdecp z19.s, p10                         : sqdecp %p10.s %z19.s -> %z19.s
-25aa8175 : sqdecp z21.s, p11                         : sqdecp %p11.s %z21.s -> %z21.s
-25aa8197 : sqdecp z23.s, p12                         : sqdecp %p12.s %z23.s -> %z23.s
-25aa81b9 : sqdecp z25.s, p13                         : sqdecp %p13.s %z25.s -> %z25.s
-25aa81db : sqdecp z27.s, p14                         : sqdecp %p14.s %z27.s -> %z27.s
-25aa81ff : sqdecp z31.s, p15                         : sqdecp %p15.s %z31.s -> %z31.s
-25ea8000 : sqdecp z0.d, p0                           : sqdecp %p0.d %z0.d -> %z0.d
-25ea8042 : sqdecp z2.d, p2                           : sqdecp %p2.d %z2.d -> %z2.d
-25ea8064 : sqdecp z4.d, p3                           : sqdecp %p3.d %z4.d -> %z4.d
-25ea8086 : sqdecp z6.d, p4                           : sqdecp %p4.d %z6.d -> %z6.d
-25ea80a8 : sqdecp z8.d, p5                           : sqdecp %p5.d %z8.d -> %z8.d
-25ea80ca : sqdecp z10.d, p6                          : sqdecp %p6.d %z10.d -> %z10.d
-25ea80ec : sqdecp z12.d, p7                          : sqdecp %p7.d %z12.d -> %z12.d
-25ea810e : sqdecp z14.d, p8                          : sqdecp %p8.d %z14.d -> %z14.d
-25ea8130 : sqdecp z16.d, p9                          : sqdecp %p9.d %z16.d -> %z16.d
-25ea8131 : sqdecp z17.d, p9                          : sqdecp %p9.d %z17.d -> %z17.d
-25ea8153 : sqdecp z19.d, p10                         : sqdecp %p10.d %z19.d -> %z19.d
-25ea8175 : sqdecp z21.d, p11                         : sqdecp %p11.d %z21.d -> %z21.d
-25ea8197 : sqdecp z23.d, p12                         : sqdecp %p12.d %z23.d -> %z23.d
-25ea81b9 : sqdecp z25.d, p13                         : sqdecp %p13.d %z25.d -> %z25.d
-25ea81db : sqdecp z27.d, p14                         : sqdecp %p14.d %z27.d -> %z27.d
-25ea81ff : sqdecp z31.d, p15                         : sqdecp %p15.d %z31.d -> %z31.d
+256a8000 : sqdecp z0.h, p0                           : sqdecp %z0.h %p0.h -> %z0.h
+256a8042 : sqdecp z2.h, p2                           : sqdecp %z2.h %p2.h -> %z2.h
+256a8064 : sqdecp z4.h, p3                           : sqdecp %z4.h %p3.h -> %z4.h
+256a8086 : sqdecp z6.h, p4                           : sqdecp %z6.h %p4.h -> %z6.h
+256a80a8 : sqdecp z8.h, p5                           : sqdecp %z8.h %p5.h -> %z8.h
+256a80ca : sqdecp z10.h, p6                          : sqdecp %z10.h %p6.h -> %z10.h
+256a80ec : sqdecp z12.h, p7                          : sqdecp %z12.h %p7.h -> %z12.h
+256a810e : sqdecp z14.h, p8                          : sqdecp %z14.h %p8.h -> %z14.h
+256a8130 : sqdecp z16.h, p9                          : sqdecp %z16.h %p9.h -> %z16.h
+256a8131 : sqdecp z17.h, p9                          : sqdecp %z17.h %p9.h -> %z17.h
+256a8153 : sqdecp z19.h, p10                         : sqdecp %z19.h %p10.h -> %z19.h
+256a8175 : sqdecp z21.h, p11                         : sqdecp %z21.h %p11.h -> %z21.h
+256a8197 : sqdecp z23.h, p12                         : sqdecp %z23.h %p12.h -> %z23.h
+256a81b9 : sqdecp z25.h, p13                         : sqdecp %z25.h %p13.h -> %z25.h
+256a81db : sqdecp z27.h, p14                         : sqdecp %z27.h %p14.h -> %z27.h
+256a81ff : sqdecp z31.h, p15                         : sqdecp %z31.h %p15.h -> %z31.h
+25aa8000 : sqdecp z0.s, p0                           : sqdecp %z0.s %p0.s -> %z0.s
+25aa8042 : sqdecp z2.s, p2                           : sqdecp %z2.s %p2.s -> %z2.s
+25aa8064 : sqdecp z4.s, p3                           : sqdecp %z4.s %p3.s -> %z4.s
+25aa8086 : sqdecp z6.s, p4                           : sqdecp %z6.s %p4.s -> %z6.s
+25aa80a8 : sqdecp z8.s, p5                           : sqdecp %z8.s %p5.s -> %z8.s
+25aa80ca : sqdecp z10.s, p6                          : sqdecp %z10.s %p6.s -> %z10.s
+25aa80ec : sqdecp z12.s, p7                          : sqdecp %z12.s %p7.s -> %z12.s
+25aa810e : sqdecp z14.s, p8                          : sqdecp %z14.s %p8.s -> %z14.s
+25aa8130 : sqdecp z16.s, p9                          : sqdecp %z16.s %p9.s -> %z16.s
+25aa8131 : sqdecp z17.s, p9                          : sqdecp %z17.s %p9.s -> %z17.s
+25aa8153 : sqdecp z19.s, p10                         : sqdecp %z19.s %p10.s -> %z19.s
+25aa8175 : sqdecp z21.s, p11                         : sqdecp %z21.s %p11.s -> %z21.s
+25aa8197 : sqdecp z23.s, p12                         : sqdecp %z23.s %p12.s -> %z23.s
+25aa81b9 : sqdecp z25.s, p13                         : sqdecp %z25.s %p13.s -> %z25.s
+25aa81db : sqdecp z27.s, p14                         : sqdecp %z27.s %p14.s -> %z27.s
+25aa81ff : sqdecp z31.s, p15                         : sqdecp %z31.s %p15.s -> %z31.s
+25ea8000 : sqdecp z0.d, p0                           : sqdecp %z0.d %p0.d -> %z0.d
+25ea8042 : sqdecp z2.d, p2                           : sqdecp %z2.d %p2.d -> %z2.d
+25ea8064 : sqdecp z4.d, p3                           : sqdecp %z4.d %p3.d -> %z4.d
+25ea8086 : sqdecp z6.d, p4                           : sqdecp %z6.d %p4.d -> %z6.d
+25ea80a8 : sqdecp z8.d, p5                           : sqdecp %z8.d %p5.d -> %z8.d
+25ea80ca : sqdecp z10.d, p6                          : sqdecp %z10.d %p6.d -> %z10.d
+25ea80ec : sqdecp z12.d, p7                          : sqdecp %z12.d %p7.d -> %z12.d
+25ea810e : sqdecp z14.d, p8                          : sqdecp %z14.d %p8.d -> %z14.d
+25ea8130 : sqdecp z16.d, p9                          : sqdecp %z16.d %p9.d -> %z16.d
+25ea8131 : sqdecp z17.d, p9                          : sqdecp %z17.d %p9.d -> %z17.d
+25ea8153 : sqdecp z19.d, p10                         : sqdecp %z19.d %p10.d -> %z19.d
+25ea8175 : sqdecp z21.d, p11                         : sqdecp %z21.d %p11.d -> %z21.d
+25ea8197 : sqdecp z23.d, p12                         : sqdecp %z23.d %p12.d -> %z23.d
+25ea81b9 : sqdecp z25.d, p13                         : sqdecp %z25.d %p13.d -> %z25.d
+25ea81db : sqdecp z27.d, p14                         : sqdecp %z27.d %p14.d -> %z27.d
+25ea81ff : sqdecp z31.d, p15                         : sqdecp %z31.d %p15.d -> %z31.d
 
 # SQDECW  <Zdn>.S{, <pattern>{, MUL #<imm>}} (SQDECW-Z.ZS-_)
 04a0c800 : sqdecw z0.s, POW2, MUL #1                 : sqdecw %z0.s POW2 mul $0x01 -> %z0.s
@@ -20438,186 +20372,186 @@ c51fffef : prfw 15, p7, [z31.d, #124]                : prfw   $0x0f %p7 +0x7c(%z
 047ff3fe : sqinch x30, ALL, MUL #16                  : sqinch %x30 ALL mul $0x10 -> %x30
 
 # SQINCP  <Xdn>, <Pm>.<T>, <Wdn> (SQINCP-R.P.R-SX)
-25288800 : sqincp x0, p0.b, w0                           : sqincp %p0.b %w0 -> %x0
-25288842 : sqincp x2, p2.b, w2                           : sqincp %p2.b %w2 -> %x2
-25288864 : sqincp x4, p3.b, w4                           : sqincp %p3.b %w4 -> %x4
-25288886 : sqincp x6, p4.b, w6                           : sqincp %p4.b %w6 -> %x6
-252888a8 : sqincp x8, p5.b, w8                           : sqincp %p5.b %w8 -> %x8
-252888c9 : sqincp x9, p6.b, w9                           : sqincp %p6.b %w9 -> %x9
-252888eb : sqincp x11, p7.b, w11                          : sqincp %p7.b %w11 -> %x11
-2528890d : sqincp x13, p8.b, w13                          : sqincp %p8.b %w13 -> %x13
-2528892f : sqincp x15, p9.b, w15                          : sqincp %p9.b %w15 -> %x15
-25288931 : sqincp x17, p9.b, w17                          : sqincp %p9.b %w17 -> %x17
-25288953 : sqincp x19, p10.b, w19                         : sqincp %p10.b %w19 -> %x19
-25288975 : sqincp x21, p11.b, w21                         : sqincp %p11.b %w21 -> %x21
-25288996 : sqincp x22, p12.b, w22                         : sqincp %p12.b %w22 -> %x22
-252889b8 : sqincp x24, p13.b, w24                         : sqincp %p13.b %w24 -> %x24
-252889da : sqincp x26, p14.b, w26                         : sqincp %p14.b %w26 -> %x26
-252889fe : sqincp x30, p15.b, w30                         : sqincp %p15.b %w30 -> %x30
-25688800 : sqincp x0, p0.h, w0                           : sqincp %p0.h %w0 -> %x0
-25688842 : sqincp x2, p2.h, w2                           : sqincp %p2.h %w2 -> %x2
-25688864 : sqincp x4, p3.h, w4                           : sqincp %p3.h %w4 -> %x4
-25688886 : sqincp x6, p4.h, w6                           : sqincp %p4.h %w6 -> %x6
-256888a8 : sqincp x8, p5.h, w8                           : sqincp %p5.h %w8 -> %x8
-256888c9 : sqincp x9, p6.h, w9                           : sqincp %p6.h %w9 -> %x9
-256888eb : sqincp x11, p7.h, w11                          : sqincp %p7.h %w11 -> %x11
-2568890d : sqincp x13, p8.h, w13                          : sqincp %p8.h %w13 -> %x13
-2568892f : sqincp x15, p9.h, w15                          : sqincp %p9.h %w15 -> %x15
-25688931 : sqincp x17, p9.h, w17                          : sqincp %p9.h %w17 -> %x17
-25688953 : sqincp x19, p10.h, w19                         : sqincp %p10.h %w19 -> %x19
-25688975 : sqincp x21, p11.h, w21                         : sqincp %p11.h %w21 -> %x21
-25688996 : sqincp x22, p12.h, w22                         : sqincp %p12.h %w22 -> %x22
-256889b8 : sqincp x24, p13.h, w24                         : sqincp %p13.h %w24 -> %x24
-256889da : sqincp x26, p14.h, w26                         : sqincp %p14.h %w26 -> %x26
-256889fe : sqincp x30, p15.h, w30                         : sqincp %p15.h %w30 -> %x30
-25a88800 : sqincp x0, p0.s, w0                           : sqincp %p0.s %w0 -> %x0
-25a88842 : sqincp x2, p2.s, w2                           : sqincp %p2.s %w2 -> %x2
-25a88864 : sqincp x4, p3.s, w4                           : sqincp %p3.s %w4 -> %x4
-25a88886 : sqincp x6, p4.s, w6                           : sqincp %p4.s %w6 -> %x6
-25a888a8 : sqincp x8, p5.s, w8                           : sqincp %p5.s %w8 -> %x8
-25a888c9 : sqincp x9, p6.s, w9                           : sqincp %p6.s %w9 -> %x9
-25a888eb : sqincp x11, p7.s, w11                          : sqincp %p7.s %w11 -> %x11
-25a8890d : sqincp x13, p8.s, w13                          : sqincp %p8.s %w13 -> %x13
-25a8892f : sqincp x15, p9.s, w15                          : sqincp %p9.s %w15 -> %x15
-25a88931 : sqincp x17, p9.s, w17                          : sqincp %p9.s %w17 -> %x17
-25a88953 : sqincp x19, p10.s, w19                         : sqincp %p10.s %w19 -> %x19
-25a88975 : sqincp x21, p11.s, w21                         : sqincp %p11.s %w21 -> %x21
-25a88996 : sqincp x22, p12.s, w22                         : sqincp %p12.s %w22 -> %x22
-25a889b8 : sqincp x24, p13.s, w24                         : sqincp %p13.s %w24 -> %x24
-25a889da : sqincp x26, p14.s, w26                         : sqincp %p14.s %w26 -> %x26
-25a889fe : sqincp x30, p15.s, w30                         : sqincp %p15.s %w30 -> %x30
-25e88800 : sqincp x0, p0.d, w0                           : sqincp %p0.d %w0 -> %x0
-25e88842 : sqincp x2, p2.d, w2                           : sqincp %p2.d %w2 -> %x2
-25e88864 : sqincp x4, p3.d, w4                           : sqincp %p3.d %w4 -> %x4
-25e88886 : sqincp x6, p4.d, w6                           : sqincp %p4.d %w6 -> %x6
-25e888a8 : sqincp x8, p5.d, w8                           : sqincp %p5.d %w8 -> %x8
-25e888c9 : sqincp x9, p6.d, w9                           : sqincp %p6.d %w9 -> %x9
-25e888eb : sqincp x11, p7.d, w11                          : sqincp %p7.d %w11 -> %x11
-25e8890d : sqincp x13, p8.d, w13                          : sqincp %p8.d %w13 -> %x13
-25e8892f : sqincp x15, p9.d, w15                          : sqincp %p9.d %w15 -> %x15
-25e88931 : sqincp x17, p9.d, w17                          : sqincp %p9.d %w17 -> %x17
-25e88953 : sqincp x19, p10.d, w19                         : sqincp %p10.d %w19 -> %x19
-25e88975 : sqincp x21, p11.d, w21                         : sqincp %p11.d %w21 -> %x21
-25e88996 : sqincp x22, p12.d, w22                         : sqincp %p12.d %w22 -> %x22
-25e889b8 : sqincp x24, p13.d, w24                         : sqincp %p13.d %w24 -> %x24
-25e889da : sqincp x26, p14.d, w26                         : sqincp %p14.d %w26 -> %x26
-25e889fe : sqincp x30, p15.d, w30                         : sqincp %p15.d %w30 -> %x30
+25288800 : sqincp x0, p0.b, w0                       : sqincp %p0.b %w0 -> %x0
+25288842 : sqincp x2, p2.b, w2                       : sqincp %p2.b %w2 -> %x2
+25288864 : sqincp x4, p3.b, w4                       : sqincp %p3.b %w4 -> %x4
+25288886 : sqincp x6, p4.b, w6                       : sqincp %p4.b %w6 -> %x6
+252888a8 : sqincp x8, p5.b, w8                       : sqincp %p5.b %w8 -> %x8
+252888c9 : sqincp x9, p6.b, w9                       : sqincp %p6.b %w9 -> %x9
+252888eb : sqincp x11, p7.b, w11                     : sqincp %p7.b %w11 -> %x11
+2528890d : sqincp x13, p8.b, w13                     : sqincp %p8.b %w13 -> %x13
+2528892f : sqincp x15, p9.b, w15                     : sqincp %p9.b %w15 -> %x15
+25288931 : sqincp x17, p9.b, w17                     : sqincp %p9.b %w17 -> %x17
+25288953 : sqincp x19, p10.b, w19                    : sqincp %p10.b %w19 -> %x19
+25288975 : sqincp x21, p11.b, w21                    : sqincp %p11.b %w21 -> %x21
+25288996 : sqincp x22, p12.b, w22                    : sqincp %p12.b %w22 -> %x22
+252889b8 : sqincp x24, p13.b, w24                    : sqincp %p13.b %w24 -> %x24
+252889da : sqincp x26, p14.b, w26                    : sqincp %p14.b %w26 -> %x26
+252889fe : sqincp x30, p15.b, w30                    : sqincp %p15.b %w30 -> %x30
+25688800 : sqincp x0, p0.h, w0                       : sqincp %p0.h %w0 -> %x0
+25688842 : sqincp x2, p2.h, w2                       : sqincp %p2.h %w2 -> %x2
+25688864 : sqincp x4, p3.h, w4                       : sqincp %p3.h %w4 -> %x4
+25688886 : sqincp x6, p4.h, w6                       : sqincp %p4.h %w6 -> %x6
+256888a8 : sqincp x8, p5.h, w8                       : sqincp %p5.h %w8 -> %x8
+256888c9 : sqincp x9, p6.h, w9                       : sqincp %p6.h %w9 -> %x9
+256888eb : sqincp x11, p7.h, w11                     : sqincp %p7.h %w11 -> %x11
+2568890d : sqincp x13, p8.h, w13                     : sqincp %p8.h %w13 -> %x13
+2568892f : sqincp x15, p9.h, w15                     : sqincp %p9.h %w15 -> %x15
+25688931 : sqincp x17, p9.h, w17                     : sqincp %p9.h %w17 -> %x17
+25688953 : sqincp x19, p10.h, w19                    : sqincp %p10.h %w19 -> %x19
+25688975 : sqincp x21, p11.h, w21                    : sqincp %p11.h %w21 -> %x21
+25688996 : sqincp x22, p12.h, w22                    : sqincp %p12.h %w22 -> %x22
+256889b8 : sqincp x24, p13.h, w24                    : sqincp %p13.h %w24 -> %x24
+256889da : sqincp x26, p14.h, w26                    : sqincp %p14.h %w26 -> %x26
+256889fe : sqincp x30, p15.h, w30                    : sqincp %p15.h %w30 -> %x30
+25a88800 : sqincp x0, p0.s, w0                       : sqincp %p0.s %w0 -> %x0
+25a88842 : sqincp x2, p2.s, w2                       : sqincp %p2.s %w2 -> %x2
+25a88864 : sqincp x4, p3.s, w4                       : sqincp %p3.s %w4 -> %x4
+25a88886 : sqincp x6, p4.s, w6                       : sqincp %p4.s %w6 -> %x6
+25a888a8 : sqincp x8, p5.s, w8                       : sqincp %p5.s %w8 -> %x8
+25a888c9 : sqincp x9, p6.s, w9                       : sqincp %p6.s %w9 -> %x9
+25a888eb : sqincp x11, p7.s, w11                     : sqincp %p7.s %w11 -> %x11
+25a8890d : sqincp x13, p8.s, w13                     : sqincp %p8.s %w13 -> %x13
+25a8892f : sqincp x15, p9.s, w15                     : sqincp %p9.s %w15 -> %x15
+25a88931 : sqincp x17, p9.s, w17                     : sqincp %p9.s %w17 -> %x17
+25a88953 : sqincp x19, p10.s, w19                    : sqincp %p10.s %w19 -> %x19
+25a88975 : sqincp x21, p11.s, w21                    : sqincp %p11.s %w21 -> %x21
+25a88996 : sqincp x22, p12.s, w22                    : sqincp %p12.s %w22 -> %x22
+25a889b8 : sqincp x24, p13.s, w24                    : sqincp %p13.s %w24 -> %x24
+25a889da : sqincp x26, p14.s, w26                    : sqincp %p14.s %w26 -> %x26
+25a889fe : sqincp x30, p15.s, w30                    : sqincp %p15.s %w30 -> %x30
+25e88800 : sqincp x0, p0.d, w0                       : sqincp %p0.d %w0 -> %x0
+25e88842 : sqincp x2, p2.d, w2                       : sqincp %p2.d %w2 -> %x2
+25e88864 : sqincp x4, p3.d, w4                       : sqincp %p3.d %w4 -> %x4
+25e88886 : sqincp x6, p4.d, w6                       : sqincp %p4.d %w6 -> %x6
+25e888a8 : sqincp x8, p5.d, w8                       : sqincp %p5.d %w8 -> %x8
+25e888c9 : sqincp x9, p6.d, w9                       : sqincp %p6.d %w9 -> %x9
+25e888eb : sqincp x11, p7.d, w11                     : sqincp %p7.d %w11 -> %x11
+25e8890d : sqincp x13, p8.d, w13                     : sqincp %p8.d %w13 -> %x13
+25e8892f : sqincp x15, p9.d, w15                     : sqincp %p9.d %w15 -> %x15
+25e88931 : sqincp x17, p9.d, w17                     : sqincp %p9.d %w17 -> %x17
+25e88953 : sqincp x19, p10.d, w19                    : sqincp %p10.d %w19 -> %x19
+25e88975 : sqincp x21, p11.d, w21                    : sqincp %p11.d %w21 -> %x21
+25e88996 : sqincp x22, p12.d, w22                    : sqincp %p12.d %w22 -> %x22
+25e889b8 : sqincp x24, p13.d, w24                    : sqincp %p13.d %w24 -> %x24
+25e889da : sqincp x26, p14.d, w26                    : sqincp %p14.d %w26 -> %x26
+25e889fe : sqincp x30, p15.d, w30                    : sqincp %p15.d %w30 -> %x30
 
 # SQINCP  <Xdn>, <Pm>.<T> (SQINCP-R.P.R-X)
-25288c00 : sqincp x0, p0.b                           : sqincp %p0.b %x0 -> %x0
-25288c42 : sqincp x2, p2.b                           : sqincp %p2.b %x2 -> %x2
-25288c64 : sqincp x4, p3.b                           : sqincp %p3.b %x4 -> %x4
-25288c86 : sqincp x6, p4.b                           : sqincp %p4.b %x6 -> %x6
-25288ca8 : sqincp x8, p5.b                           : sqincp %p5.b %x8 -> %x8
-25288cc9 : sqincp x9, p6.b                           : sqincp %p6.b %x9 -> %x9
-25288ceb : sqincp x11, p7.b                          : sqincp %p7.b %x11 -> %x11
-25288d0d : sqincp x13, p8.b                          : sqincp %p8.b %x13 -> %x13
-25288d2f : sqincp x15, p9.b                          : sqincp %p9.b %x15 -> %x15
-25288d31 : sqincp x17, p9.b                          : sqincp %p9.b %x17 -> %x17
-25288d53 : sqincp x19, p10.b                         : sqincp %p10.b %x19 -> %x19
-25288d75 : sqincp x21, p11.b                         : sqincp %p11.b %x21 -> %x21
-25288d96 : sqincp x22, p12.b                         : sqincp %p12.b %x22 -> %x22
-25288db8 : sqincp x24, p13.b                         : sqincp %p13.b %x24 -> %x24
-25288dda : sqincp x26, p14.b                         : sqincp %p14.b %x26 -> %x26
-25288dfe : sqincp x30, p15.b                         : sqincp %p15.b %x30 -> %x30
-25688c00 : sqincp x0, p0.h                           : sqincp %p0.h %x0 -> %x0
-25688c42 : sqincp x2, p2.h                           : sqincp %p2.h %x2 -> %x2
-25688c64 : sqincp x4, p3.h                           : sqincp %p3.h %x4 -> %x4
-25688c86 : sqincp x6, p4.h                           : sqincp %p4.h %x6 -> %x6
-25688ca8 : sqincp x8, p5.h                           : sqincp %p5.h %x8 -> %x8
-25688cc9 : sqincp x9, p6.h                           : sqincp %p6.h %x9 -> %x9
-25688ceb : sqincp x11, p7.h                          : sqincp %p7.h %x11 -> %x11
-25688d0d : sqincp x13, p8.h                          : sqincp %p8.h %x13 -> %x13
-25688d2f : sqincp x15, p9.h                          : sqincp %p9.h %x15 -> %x15
-25688d31 : sqincp x17, p9.h                          : sqincp %p9.h %x17 -> %x17
-25688d53 : sqincp x19, p10.h                         : sqincp %p10.h %x19 -> %x19
-25688d75 : sqincp x21, p11.h                         : sqincp %p11.h %x21 -> %x21
-25688d96 : sqincp x22, p12.h                         : sqincp %p12.h %x22 -> %x22
-25688db8 : sqincp x24, p13.h                         : sqincp %p13.h %x24 -> %x24
-25688dda : sqincp x26, p14.h                         : sqincp %p14.h %x26 -> %x26
-25688dfe : sqincp x30, p15.h                         : sqincp %p15.h %x30 -> %x30
-25a88c00 : sqincp x0, p0.s                           : sqincp %p0.s %x0 -> %x0
-25a88c42 : sqincp x2, p2.s                           : sqincp %p2.s %x2 -> %x2
-25a88c64 : sqincp x4, p3.s                           : sqincp %p3.s %x4 -> %x4
-25a88c86 : sqincp x6, p4.s                           : sqincp %p4.s %x6 -> %x6
-25a88ca8 : sqincp x8, p5.s                           : sqincp %p5.s %x8 -> %x8
-25a88cc9 : sqincp x9, p6.s                           : sqincp %p6.s %x9 -> %x9
-25a88ceb : sqincp x11, p7.s                          : sqincp %p7.s %x11 -> %x11
-25a88d0d : sqincp x13, p8.s                          : sqincp %p8.s %x13 -> %x13
-25a88d2f : sqincp x15, p9.s                          : sqincp %p9.s %x15 -> %x15
-25a88d31 : sqincp x17, p9.s                          : sqincp %p9.s %x17 -> %x17
-25a88d53 : sqincp x19, p10.s                         : sqincp %p10.s %x19 -> %x19
-25a88d75 : sqincp x21, p11.s                         : sqincp %p11.s %x21 -> %x21
-25a88d96 : sqincp x22, p12.s                         : sqincp %p12.s %x22 -> %x22
-25a88db8 : sqincp x24, p13.s                         : sqincp %p13.s %x24 -> %x24
-25a88dda : sqincp x26, p14.s                         : sqincp %p14.s %x26 -> %x26
-25a88dfe : sqincp x30, p15.s                         : sqincp %p15.s %x30 -> %x30
-25e88c00 : sqincp x0, p0.d                           : sqincp %p0.d %x0 -> %x0
-25e88c42 : sqincp x2, p2.d                           : sqincp %p2.d %x2 -> %x2
-25e88c64 : sqincp x4, p3.d                           : sqincp %p3.d %x4 -> %x4
-25e88c86 : sqincp x6, p4.d                           : sqincp %p4.d %x6 -> %x6
-25e88ca8 : sqincp x8, p5.d                           : sqincp %p5.d %x8 -> %x8
-25e88cc9 : sqincp x9, p6.d                           : sqincp %p6.d %x9 -> %x9
-25e88ceb : sqincp x11, p7.d                          : sqincp %p7.d %x11 -> %x11
-25e88d0d : sqincp x13, p8.d                          : sqincp %p8.d %x13 -> %x13
-25e88d2f : sqincp x15, p9.d                          : sqincp %p9.d %x15 -> %x15
-25e88d31 : sqincp x17, p9.d                          : sqincp %p9.d %x17 -> %x17
-25e88d53 : sqincp x19, p10.d                         : sqincp %p10.d %x19 -> %x19
-25e88d75 : sqincp x21, p11.d                         : sqincp %p11.d %x21 -> %x21
-25e88d96 : sqincp x22, p12.d                         : sqincp %p12.d %x22 -> %x22
-25e88db8 : sqincp x24, p13.d                         : sqincp %p13.d %x24 -> %x24
-25e88dda : sqincp x26, p14.d                         : sqincp %p14.d %x26 -> %x26
-25e88dfe : sqincp x30, p15.d                         : sqincp %p15.d %x30 -> %x30
+25288c00 : sqincp x0, p0.b                           : sqincp %x0 %p0.b -> %x0
+25288c42 : sqincp x2, p2.b                           : sqincp %x2 %p2.b -> %x2
+25288c64 : sqincp x4, p3.b                           : sqincp %x4 %p3.b -> %x4
+25288c86 : sqincp x6, p4.b                           : sqincp %x6 %p4.b -> %x6
+25288ca8 : sqincp x8, p5.b                           : sqincp %x8 %p5.b -> %x8
+25288cc9 : sqincp x9, p6.b                           : sqincp %x9 %p6.b -> %x9
+25288ceb : sqincp x11, p7.b                          : sqincp %x11 %p7.b -> %x11
+25288d0d : sqincp x13, p8.b                          : sqincp %x13 %p8.b -> %x13
+25288d2f : sqincp x15, p9.b                          : sqincp %x15 %p9.b -> %x15
+25288d31 : sqincp x17, p9.b                          : sqincp %x17 %p9.b -> %x17
+25288d53 : sqincp x19, p10.b                         : sqincp %x19 %p10.b -> %x19
+25288d75 : sqincp x21, p11.b                         : sqincp %x21 %p11.b -> %x21
+25288d96 : sqincp x22, p12.b                         : sqincp %x22 %p12.b -> %x22
+25288db8 : sqincp x24, p13.b                         : sqincp %x24 %p13.b -> %x24
+25288dda : sqincp x26, p14.b                         : sqincp %x26 %p14.b -> %x26
+25288dfe : sqincp x30, p15.b                         : sqincp %x30 %p15.b -> %x30
+25688c00 : sqincp x0, p0.h                           : sqincp %x0 %p0.h -> %x0
+25688c42 : sqincp x2, p2.h                           : sqincp %x2 %p2.h -> %x2
+25688c64 : sqincp x4, p3.h                           : sqincp %x4 %p3.h -> %x4
+25688c86 : sqincp x6, p4.h                           : sqincp %x6 %p4.h -> %x6
+25688ca8 : sqincp x8, p5.h                           : sqincp %x8 %p5.h -> %x8
+25688cc9 : sqincp x9, p6.h                           : sqincp %x9 %p6.h -> %x9
+25688ceb : sqincp x11, p7.h                          : sqincp %x11 %p7.h -> %x11
+25688d0d : sqincp x13, p8.h                          : sqincp %x13 %p8.h -> %x13
+25688d2f : sqincp x15, p9.h                          : sqincp %x15 %p9.h -> %x15
+25688d31 : sqincp x17, p9.h                          : sqincp %x17 %p9.h -> %x17
+25688d53 : sqincp x19, p10.h                         : sqincp %x19 %p10.h -> %x19
+25688d75 : sqincp x21, p11.h                         : sqincp %x21 %p11.h -> %x21
+25688d96 : sqincp x22, p12.h                         : sqincp %x22 %p12.h -> %x22
+25688db8 : sqincp x24, p13.h                         : sqincp %x24 %p13.h -> %x24
+25688dda : sqincp x26, p14.h                         : sqincp %x26 %p14.h -> %x26
+25688dfe : sqincp x30, p15.h                         : sqincp %x30 %p15.h -> %x30
+25a88c00 : sqincp x0, p0.s                           : sqincp %x0 %p0.s -> %x0
+25a88c42 : sqincp x2, p2.s                           : sqincp %x2 %p2.s -> %x2
+25a88c64 : sqincp x4, p3.s                           : sqincp %x4 %p3.s -> %x4
+25a88c86 : sqincp x6, p4.s                           : sqincp %x6 %p4.s -> %x6
+25a88ca8 : sqincp x8, p5.s                           : sqincp %x8 %p5.s -> %x8
+25a88cc9 : sqincp x9, p6.s                           : sqincp %x9 %p6.s -> %x9
+25a88ceb : sqincp x11, p7.s                          : sqincp %x11 %p7.s -> %x11
+25a88d0d : sqincp x13, p8.s                          : sqincp %x13 %p8.s -> %x13
+25a88d2f : sqincp x15, p9.s                          : sqincp %x15 %p9.s -> %x15
+25a88d31 : sqincp x17, p9.s                          : sqincp %x17 %p9.s -> %x17
+25a88d53 : sqincp x19, p10.s                         : sqincp %x19 %p10.s -> %x19
+25a88d75 : sqincp x21, p11.s                         : sqincp %x21 %p11.s -> %x21
+25a88d96 : sqincp x22, p12.s                         : sqincp %x22 %p12.s -> %x22
+25a88db8 : sqincp x24, p13.s                         : sqincp %x24 %p13.s -> %x24
+25a88dda : sqincp x26, p14.s                         : sqincp %x26 %p14.s -> %x26
+25a88dfe : sqincp x30, p15.s                         : sqincp %x30 %p15.s -> %x30
+25e88c00 : sqincp x0, p0.d                           : sqincp %x0 %p0.d -> %x0
+25e88c42 : sqincp x2, p2.d                           : sqincp %x2 %p2.d -> %x2
+25e88c64 : sqincp x4, p3.d                           : sqincp %x4 %p3.d -> %x4
+25e88c86 : sqincp x6, p4.d                           : sqincp %x6 %p4.d -> %x6
+25e88ca8 : sqincp x8, p5.d                           : sqincp %x8 %p5.d -> %x8
+25e88cc9 : sqincp x9, p6.d                           : sqincp %x9 %p6.d -> %x9
+25e88ceb : sqincp x11, p7.d                          : sqincp %x11 %p7.d -> %x11
+25e88d0d : sqincp x13, p8.d                          : sqincp %x13 %p8.d -> %x13
+25e88d2f : sqincp x15, p9.d                          : sqincp %x15 %p9.d -> %x15
+25e88d31 : sqincp x17, p9.d                          : sqincp %x17 %p9.d -> %x17
+25e88d53 : sqincp x19, p10.d                         : sqincp %x19 %p10.d -> %x19
+25e88d75 : sqincp x21, p11.d                         : sqincp %x21 %p11.d -> %x21
+25e88d96 : sqincp x22, p12.d                         : sqincp %x22 %p12.d -> %x22
+25e88db8 : sqincp x24, p13.d                         : sqincp %x24 %p13.d -> %x24
+25e88dda : sqincp x26, p14.d                         : sqincp %x26 %p14.d -> %x26
+25e88dfe : sqincp x30, p15.d                         : sqincp %x30 %p15.d -> %x30
 
 # SQINCP  <Zdn>.<T>, <Pm>.<T> (SQINCP-Z.P.Z-_)
-25688000 : sqincp z0.h, p0                           : sqincp %p0.h %z0.h -> %z0.h
-25688042 : sqincp z2.h, p2                           : sqincp %p2.h %z2.h -> %z2.h
-25688064 : sqincp z4.h, p3                           : sqincp %p3.h %z4.h -> %z4.h
-25688086 : sqincp z6.h, p4                           : sqincp %p4.h %z6.h -> %z6.h
-256880a8 : sqincp z8.h, p5                           : sqincp %p5.h %z8.h -> %z8.h
-256880ca : sqincp z10.h, p6                          : sqincp %p6.h %z10.h -> %z10.h
-256880ec : sqincp z12.h, p7                          : sqincp %p7.h %z12.h -> %z12.h
-2568810e : sqincp z14.h, p8                          : sqincp %p8.h %z14.h -> %z14.h
-25688130 : sqincp z16.h, p9                          : sqincp %p9.h %z16.h -> %z16.h
-25688131 : sqincp z17.h, p9                          : sqincp %p9.h %z17.h -> %z17.h
-25688153 : sqincp z19.h, p10                         : sqincp %p10.h %z19.h -> %z19.h
-25688175 : sqincp z21.h, p11                         : sqincp %p11.h %z21.h -> %z21.h
-25688197 : sqincp z23.h, p12                         : sqincp %p12.h %z23.h -> %z23.h
-256881b9 : sqincp z25.h, p13                         : sqincp %p13.h %z25.h -> %z25.h
-256881db : sqincp z27.h, p14                         : sqincp %p14.h %z27.h -> %z27.h
-256881ff : sqincp z31.h, p15                         : sqincp %p15.h %z31.h -> %z31.h
-25a88000 : sqincp z0.s, p0                           : sqincp %p0.s %z0.s -> %z0.s
-25a88042 : sqincp z2.s, p2                           : sqincp %p2.s %z2.s -> %z2.s
-25a88064 : sqincp z4.s, p3                           : sqincp %p3.s %z4.s -> %z4.s
-25a88086 : sqincp z6.s, p4                           : sqincp %p4.s %z6.s -> %z6.s
-25a880a8 : sqincp z8.s, p5                           : sqincp %p5.s %z8.s -> %z8.s
-25a880ca : sqincp z10.s, p6                          : sqincp %p6.s %z10.s -> %z10.s
-25a880ec : sqincp z12.s, p7                          : sqincp %p7.s %z12.s -> %z12.s
-25a8810e : sqincp z14.s, p8                          : sqincp %p8.s %z14.s -> %z14.s
-25a88130 : sqincp z16.s, p9                          : sqincp %p9.s %z16.s -> %z16.s
-25a88131 : sqincp z17.s, p9                          : sqincp %p9.s %z17.s -> %z17.s
-25a88153 : sqincp z19.s, p10                         : sqincp %p10.s %z19.s -> %z19.s
-25a88175 : sqincp z21.s, p11                         : sqincp %p11.s %z21.s -> %z21.s
-25a88197 : sqincp z23.s, p12                         : sqincp %p12.s %z23.s -> %z23.s
-25a881b9 : sqincp z25.s, p13                         : sqincp %p13.s %z25.s -> %z25.s
-25a881db : sqincp z27.s, p14                         : sqincp %p14.s %z27.s -> %z27.s
-25a881ff : sqincp z31.s, p15                         : sqincp %p15.s %z31.s -> %z31.s
-25e88000 : sqincp z0.d, p0                           : sqincp %p0.d %z0.d -> %z0.d
-25e88042 : sqincp z2.d, p2                           : sqincp %p2.d %z2.d -> %z2.d
-25e88064 : sqincp z4.d, p3                           : sqincp %p3.d %z4.d -> %z4.d
-25e88086 : sqincp z6.d, p4                           : sqincp %p4.d %z6.d -> %z6.d
-25e880a8 : sqincp z8.d, p5                           : sqincp %p5.d %z8.d -> %z8.d
-25e880ca : sqincp z10.d, p6                          : sqincp %p6.d %z10.d -> %z10.d
-25e880ec : sqincp z12.d, p7                          : sqincp %p7.d %z12.d -> %z12.d
-25e8810e : sqincp z14.d, p8                          : sqincp %p8.d %z14.d -> %z14.d
-25e88130 : sqincp z16.d, p9                          : sqincp %p9.d %z16.d -> %z16.d
-25e88131 : sqincp z17.d, p9                          : sqincp %p9.d %z17.d -> %z17.d
-25e88153 : sqincp z19.d, p10                         : sqincp %p10.d %z19.d -> %z19.d
-25e88175 : sqincp z21.d, p11                         : sqincp %p11.d %z21.d -> %z21.d
-25e88197 : sqincp z23.d, p12                         : sqincp %p12.d %z23.d -> %z23.d
-25e881b9 : sqincp z25.d, p13                         : sqincp %p13.d %z25.d -> %z25.d
-25e881db : sqincp z27.d, p14                         : sqincp %p14.d %z27.d -> %z27.d
-25e881ff : sqincp z31.d, p15                         : sqincp %p15.d %z31.d -> %z31.d
+25688000 : sqincp z0.h, p0                           : sqincp %z0.h %p0.h -> %z0.h
+25688042 : sqincp z2.h, p2                           : sqincp %z2.h %p2.h -> %z2.h
+25688064 : sqincp z4.h, p3                           : sqincp %z4.h %p3.h -> %z4.h
+25688086 : sqincp z6.h, p4                           : sqincp %z6.h %p4.h -> %z6.h
+256880a8 : sqincp z8.h, p5                           : sqincp %z8.h %p5.h -> %z8.h
+256880ca : sqincp z10.h, p6                          : sqincp %z10.h %p6.h -> %z10.h
+256880ec : sqincp z12.h, p7                          : sqincp %z12.h %p7.h -> %z12.h
+2568810e : sqincp z14.h, p8                          : sqincp %z14.h %p8.h -> %z14.h
+25688130 : sqincp z16.h, p9                          : sqincp %z16.h %p9.h -> %z16.h
+25688131 : sqincp z17.h, p9                          : sqincp %z17.h %p9.h -> %z17.h
+25688153 : sqincp z19.h, p10                         : sqincp %z19.h %p10.h -> %z19.h
+25688175 : sqincp z21.h, p11                         : sqincp %z21.h %p11.h -> %z21.h
+25688197 : sqincp z23.h, p12                         : sqincp %z23.h %p12.h -> %z23.h
+256881b9 : sqincp z25.h, p13                         : sqincp %z25.h %p13.h -> %z25.h
+256881db : sqincp z27.h, p14                         : sqincp %z27.h %p14.h -> %z27.h
+256881ff : sqincp z31.h, p15                         : sqincp %z31.h %p15.h -> %z31.h
+25a88000 : sqincp z0.s, p0                           : sqincp %z0.s %p0.s -> %z0.s
+25a88042 : sqincp z2.s, p2                           : sqincp %z2.s %p2.s -> %z2.s
+25a88064 : sqincp z4.s, p3                           : sqincp %z4.s %p3.s -> %z4.s
+25a88086 : sqincp z6.s, p4                           : sqincp %z6.s %p4.s -> %z6.s
+25a880a8 : sqincp z8.s, p5                           : sqincp %z8.s %p5.s -> %z8.s
+25a880ca : sqincp z10.s, p6                          : sqincp %z10.s %p6.s -> %z10.s
+25a880ec : sqincp z12.s, p7                          : sqincp %z12.s %p7.s -> %z12.s
+25a8810e : sqincp z14.s, p8                          : sqincp %z14.s %p8.s -> %z14.s
+25a88130 : sqincp z16.s, p9                          : sqincp %z16.s %p9.s -> %z16.s
+25a88131 : sqincp z17.s, p9                          : sqincp %z17.s %p9.s -> %z17.s
+25a88153 : sqincp z19.s, p10                         : sqincp %z19.s %p10.s -> %z19.s
+25a88175 : sqincp z21.s, p11                         : sqincp %z21.s %p11.s -> %z21.s
+25a88197 : sqincp z23.s, p12                         : sqincp %z23.s %p12.s -> %z23.s
+25a881b9 : sqincp z25.s, p13                         : sqincp %z25.s %p13.s -> %z25.s
+25a881db : sqincp z27.s, p14                         : sqincp %z27.s %p14.s -> %z27.s
+25a881ff : sqincp z31.s, p15                         : sqincp %z31.s %p15.s -> %z31.s
+25e88000 : sqincp z0.d, p0                           : sqincp %z0.d %p0.d -> %z0.d
+25e88042 : sqincp z2.d, p2                           : sqincp %z2.d %p2.d -> %z2.d
+25e88064 : sqincp z4.d, p3                           : sqincp %z4.d %p3.d -> %z4.d
+25e88086 : sqincp z6.d, p4                           : sqincp %z6.d %p4.d -> %z6.d
+25e880a8 : sqincp z8.d, p5                           : sqincp %z8.d %p5.d -> %z8.d
+25e880ca : sqincp z10.d, p6                          : sqincp %z10.d %p6.d -> %z10.d
+25e880ec : sqincp z12.d, p7                          : sqincp %z12.d %p7.d -> %z12.d
+25e8810e : sqincp z14.d, p8                          : sqincp %z14.d %p8.d -> %z14.d
+25e88130 : sqincp z16.d, p9                          : sqincp %z16.d %p9.d -> %z16.d
+25e88131 : sqincp z17.d, p9                          : sqincp %z17.d %p9.d -> %z17.d
+25e88153 : sqincp z19.d, p10                         : sqincp %z19.d %p10.d -> %z19.d
+25e88175 : sqincp z21.d, p11                         : sqincp %z21.d %p11.d -> %z21.d
+25e88197 : sqincp z23.d, p12                         : sqincp %z23.d %p12.d -> %z23.d
+25e881b9 : sqincp z25.d, p13                         : sqincp %z25.d %p13.d -> %z25.d
+25e881db : sqincp z27.d, p14                         : sqincp %z27.d %p14.d -> %z27.d
+25e881ff : sqincp z31.d, p15                         : sqincp %z31.d %p15.d -> %z31.d
 
 # SQINCW  <Zdn>.S{, <pattern>{, MUL #<imm>}} (SQINCW-Z.ZS-_)
 04a0c000 : sqincw z0.s, POW2, MUL #1                 : sqincw %z0.s POW2 mul $0x01 -> %z0.s
@@ -24722,186 +24656,186 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 047ffffe : uqdech x30, ALL, MUL #16                  : uqdech %x30 ALL mul $0x10 -> %x30
 
 # UQDECP  <Wdn>, <Pm>.<T> (UQDECP-R.P.R-UW)
-252b8800 : uqdecp w0, p0.b                           : uqdecp %p0.b %w0 -> %w0
-252b8842 : uqdecp w2, p2.b                           : uqdecp %p2.b %w2 -> %w2
-252b8864 : uqdecp w4, p3.b                           : uqdecp %p3.b %w4 -> %w4
-252b8886 : uqdecp w6, p4.b                           : uqdecp %p4.b %w6 -> %w6
-252b88a8 : uqdecp w8, p5.b                           : uqdecp %p5.b %w8 -> %w8
-252b88c9 : uqdecp w9, p6.b                           : uqdecp %p6.b %w9 -> %w9
-252b88eb : uqdecp w11, p7.b                          : uqdecp %p7.b %w11 -> %w11
-252b890d : uqdecp w13, p8.b                          : uqdecp %p8.b %w13 -> %w13
-252b892f : uqdecp w15, p9.b                          : uqdecp %p9.b %w15 -> %w15
-252b8931 : uqdecp w17, p9.b                          : uqdecp %p9.b %w17 -> %w17
-252b8953 : uqdecp w19, p10.b                         : uqdecp %p10.b %w19 -> %w19
-252b8975 : uqdecp w21, p11.b                         : uqdecp %p11.b %w21 -> %w21
-252b8996 : uqdecp w22, p12.b                         : uqdecp %p12.b %w22 -> %w22
-252b89b8 : uqdecp w24, p13.b                         : uqdecp %p13.b %w24 -> %w24
-252b89da : uqdecp w26, p14.b                         : uqdecp %p14.b %w26 -> %w26
-252b89fe : uqdecp w30, p15.b                         : uqdecp %p15.b %w30 -> %w30
-256b8800 : uqdecp w0, p0.h                           : uqdecp %p0.h %w0 -> %w0
-256b8842 : uqdecp w2, p2.h                           : uqdecp %p2.h %w2 -> %w2
-256b8864 : uqdecp w4, p3.h                           : uqdecp %p3.h %w4 -> %w4
-256b8886 : uqdecp w6, p4.h                           : uqdecp %p4.h %w6 -> %w6
-256b88a8 : uqdecp w8, p5.h                           : uqdecp %p5.h %w8 -> %w8
-256b88c9 : uqdecp w9, p6.h                           : uqdecp %p6.h %w9 -> %w9
-256b88eb : uqdecp w11, p7.h                          : uqdecp %p7.h %w11 -> %w11
-256b890d : uqdecp w13, p8.h                          : uqdecp %p8.h %w13 -> %w13
-256b892f : uqdecp w15, p9.h                          : uqdecp %p9.h %w15 -> %w15
-256b8931 : uqdecp w17, p9.h                          : uqdecp %p9.h %w17 -> %w17
-256b8953 : uqdecp w19, p10.h                         : uqdecp %p10.h %w19 -> %w19
-256b8975 : uqdecp w21, p11.h                         : uqdecp %p11.h %w21 -> %w21
-256b8996 : uqdecp w22, p12.h                         : uqdecp %p12.h %w22 -> %w22
-256b89b8 : uqdecp w24, p13.h                         : uqdecp %p13.h %w24 -> %w24
-256b89da : uqdecp w26, p14.h                         : uqdecp %p14.h %w26 -> %w26
-256b89fe : uqdecp w30, p15.h                         : uqdecp %p15.h %w30 -> %w30
-25ab8800 : uqdecp w0, p0.s                           : uqdecp %p0.s %w0 -> %w0
-25ab8842 : uqdecp w2, p2.s                           : uqdecp %p2.s %w2 -> %w2
-25ab8864 : uqdecp w4, p3.s                           : uqdecp %p3.s %w4 -> %w4
-25ab8886 : uqdecp w6, p4.s                           : uqdecp %p4.s %w6 -> %w6
-25ab88a8 : uqdecp w8, p5.s                           : uqdecp %p5.s %w8 -> %w8
-25ab88c9 : uqdecp w9, p6.s                           : uqdecp %p6.s %w9 -> %w9
-25ab88eb : uqdecp w11, p7.s                          : uqdecp %p7.s %w11 -> %w11
-25ab890d : uqdecp w13, p8.s                          : uqdecp %p8.s %w13 -> %w13
-25ab892f : uqdecp w15, p9.s                          : uqdecp %p9.s %w15 -> %w15
-25ab8931 : uqdecp w17, p9.s                          : uqdecp %p9.s %w17 -> %w17
-25ab8953 : uqdecp w19, p10.s                         : uqdecp %p10.s %w19 -> %w19
-25ab8975 : uqdecp w21, p11.s                         : uqdecp %p11.s %w21 -> %w21
-25ab8996 : uqdecp w22, p12.s                         : uqdecp %p12.s %w22 -> %w22
-25ab89b8 : uqdecp w24, p13.s                         : uqdecp %p13.s %w24 -> %w24
-25ab89da : uqdecp w26, p14.s                         : uqdecp %p14.s %w26 -> %w26
-25ab89fe : uqdecp w30, p15.s                         : uqdecp %p15.s %w30 -> %w30
-25eb8800 : uqdecp w0, p0.d                           : uqdecp %p0.d %w0 -> %w0
-25eb8842 : uqdecp w2, p2.d                           : uqdecp %p2.d %w2 -> %w2
-25eb8864 : uqdecp w4, p3.d                           : uqdecp %p3.d %w4 -> %w4
-25eb8886 : uqdecp w6, p4.d                           : uqdecp %p4.d %w6 -> %w6
-25eb88a8 : uqdecp w8, p5.d                           : uqdecp %p5.d %w8 -> %w8
-25eb88c9 : uqdecp w9, p6.d                           : uqdecp %p6.d %w9 -> %w9
-25eb88eb : uqdecp w11, p7.d                          : uqdecp %p7.d %w11 -> %w11
-25eb890d : uqdecp w13, p8.d                          : uqdecp %p8.d %w13 -> %w13
-25eb892f : uqdecp w15, p9.d                          : uqdecp %p9.d %w15 -> %w15
-25eb8931 : uqdecp w17, p9.d                          : uqdecp %p9.d %w17 -> %w17
-25eb8953 : uqdecp w19, p10.d                         : uqdecp %p10.d %w19 -> %w19
-25eb8975 : uqdecp w21, p11.d                         : uqdecp %p11.d %w21 -> %w21
-25eb8996 : uqdecp w22, p12.d                         : uqdecp %p12.d %w22 -> %w22
-25eb89b8 : uqdecp w24, p13.d                         : uqdecp %p13.d %w24 -> %w24
-25eb89da : uqdecp w26, p14.d                         : uqdecp %p14.d %w26 -> %w26
-25eb89fe : uqdecp w30, p15.d                         : uqdecp %p15.d %w30 -> %w30
+252b8800 : uqdecp w0, p0.b                           : uqdecp %w0 %p0.b -> %w0
+252b8842 : uqdecp w2, p2.b                           : uqdecp %w2 %p2.b -> %w2
+252b8864 : uqdecp w4, p3.b                           : uqdecp %w4 %p3.b -> %w4
+252b8886 : uqdecp w6, p4.b                           : uqdecp %w6 %p4.b -> %w6
+252b88a8 : uqdecp w8, p5.b                           : uqdecp %w8 %p5.b -> %w8
+252b88c9 : uqdecp w9, p6.b                           : uqdecp %w9 %p6.b -> %w9
+252b88eb : uqdecp w11, p7.b                          : uqdecp %w11 %p7.b -> %w11
+252b890d : uqdecp w13, p8.b                          : uqdecp %w13 %p8.b -> %w13
+252b892f : uqdecp w15, p9.b                          : uqdecp %w15 %p9.b -> %w15
+252b8931 : uqdecp w17, p9.b                          : uqdecp %w17 %p9.b -> %w17
+252b8953 : uqdecp w19, p10.b                         : uqdecp %w19 %p10.b -> %w19
+252b8975 : uqdecp w21, p11.b                         : uqdecp %w21 %p11.b -> %w21
+252b8996 : uqdecp w22, p12.b                         : uqdecp %w22 %p12.b -> %w22
+252b89b8 : uqdecp w24, p13.b                         : uqdecp %w24 %p13.b -> %w24
+252b89da : uqdecp w26, p14.b                         : uqdecp %w26 %p14.b -> %w26
+252b89fe : uqdecp w30, p15.b                         : uqdecp %w30 %p15.b -> %w30
+256b8800 : uqdecp w0, p0.h                           : uqdecp %w0 %p0.h -> %w0
+256b8842 : uqdecp w2, p2.h                           : uqdecp %w2 %p2.h -> %w2
+256b8864 : uqdecp w4, p3.h                           : uqdecp %w4 %p3.h -> %w4
+256b8886 : uqdecp w6, p4.h                           : uqdecp %w6 %p4.h -> %w6
+256b88a8 : uqdecp w8, p5.h                           : uqdecp %w8 %p5.h -> %w8
+256b88c9 : uqdecp w9, p6.h                           : uqdecp %w9 %p6.h -> %w9
+256b88eb : uqdecp w11, p7.h                          : uqdecp %w11 %p7.h -> %w11
+256b890d : uqdecp w13, p8.h                          : uqdecp %w13 %p8.h -> %w13
+256b892f : uqdecp w15, p9.h                          : uqdecp %w15 %p9.h -> %w15
+256b8931 : uqdecp w17, p9.h                          : uqdecp %w17 %p9.h -> %w17
+256b8953 : uqdecp w19, p10.h                         : uqdecp %w19 %p10.h -> %w19
+256b8975 : uqdecp w21, p11.h                         : uqdecp %w21 %p11.h -> %w21
+256b8996 : uqdecp w22, p12.h                         : uqdecp %w22 %p12.h -> %w22
+256b89b8 : uqdecp w24, p13.h                         : uqdecp %w24 %p13.h -> %w24
+256b89da : uqdecp w26, p14.h                         : uqdecp %w26 %p14.h -> %w26
+256b89fe : uqdecp w30, p15.h                         : uqdecp %w30 %p15.h -> %w30
+25ab8800 : uqdecp w0, p0.s                           : uqdecp %w0 %p0.s -> %w0
+25ab8842 : uqdecp w2, p2.s                           : uqdecp %w2 %p2.s -> %w2
+25ab8864 : uqdecp w4, p3.s                           : uqdecp %w4 %p3.s -> %w4
+25ab8886 : uqdecp w6, p4.s                           : uqdecp %w6 %p4.s -> %w6
+25ab88a8 : uqdecp w8, p5.s                           : uqdecp %w8 %p5.s -> %w8
+25ab88c9 : uqdecp w9, p6.s                           : uqdecp %w9 %p6.s -> %w9
+25ab88eb : uqdecp w11, p7.s                          : uqdecp %w11 %p7.s -> %w11
+25ab890d : uqdecp w13, p8.s                          : uqdecp %w13 %p8.s -> %w13
+25ab892f : uqdecp w15, p9.s                          : uqdecp %w15 %p9.s -> %w15
+25ab8931 : uqdecp w17, p9.s                          : uqdecp %w17 %p9.s -> %w17
+25ab8953 : uqdecp w19, p10.s                         : uqdecp %w19 %p10.s -> %w19
+25ab8975 : uqdecp w21, p11.s                         : uqdecp %w21 %p11.s -> %w21
+25ab8996 : uqdecp w22, p12.s                         : uqdecp %w22 %p12.s -> %w22
+25ab89b8 : uqdecp w24, p13.s                         : uqdecp %w24 %p13.s -> %w24
+25ab89da : uqdecp w26, p14.s                         : uqdecp %w26 %p14.s -> %w26
+25ab89fe : uqdecp w30, p15.s                         : uqdecp %w30 %p15.s -> %w30
+25eb8800 : uqdecp w0, p0.d                           : uqdecp %w0 %p0.d -> %w0
+25eb8842 : uqdecp w2, p2.d                           : uqdecp %w2 %p2.d -> %w2
+25eb8864 : uqdecp w4, p3.d                           : uqdecp %w4 %p3.d -> %w4
+25eb8886 : uqdecp w6, p4.d                           : uqdecp %w6 %p4.d -> %w6
+25eb88a8 : uqdecp w8, p5.d                           : uqdecp %w8 %p5.d -> %w8
+25eb88c9 : uqdecp w9, p6.d                           : uqdecp %w9 %p6.d -> %w9
+25eb88eb : uqdecp w11, p7.d                          : uqdecp %w11 %p7.d -> %w11
+25eb890d : uqdecp w13, p8.d                          : uqdecp %w13 %p8.d -> %w13
+25eb892f : uqdecp w15, p9.d                          : uqdecp %w15 %p9.d -> %w15
+25eb8931 : uqdecp w17, p9.d                          : uqdecp %w17 %p9.d -> %w17
+25eb8953 : uqdecp w19, p10.d                         : uqdecp %w19 %p10.d -> %w19
+25eb8975 : uqdecp w21, p11.d                         : uqdecp %w21 %p11.d -> %w21
+25eb8996 : uqdecp w22, p12.d                         : uqdecp %w22 %p12.d -> %w22
+25eb89b8 : uqdecp w24, p13.d                         : uqdecp %w24 %p13.d -> %w24
+25eb89da : uqdecp w26, p14.d                         : uqdecp %w26 %p14.d -> %w26
+25eb89fe : uqdecp w30, p15.d                         : uqdecp %w30 %p15.d -> %w30
 
 # UQDECP  <Xdn>, <Pm>.<T> (UQDECP-R.P.R-X)
-252b8c00 : uqdecp x0, p0.b                           : uqdecp %p0.b %x0 -> %x0
-252b8c42 : uqdecp x2, p2.b                           : uqdecp %p2.b %x2 -> %x2
-252b8c64 : uqdecp x4, p3.b                           : uqdecp %p3.b %x4 -> %x4
-252b8c86 : uqdecp x6, p4.b                           : uqdecp %p4.b %x6 -> %x6
-252b8ca8 : uqdecp x8, p5.b                           : uqdecp %p5.b %x8 -> %x8
-252b8cc9 : uqdecp x9, p6.b                           : uqdecp %p6.b %x9 -> %x9
-252b8ceb : uqdecp x11, p7.b                          : uqdecp %p7.b %x11 -> %x11
-252b8d0d : uqdecp x13, p8.b                          : uqdecp %p8.b %x13 -> %x13
-252b8d2f : uqdecp x15, p9.b                          : uqdecp %p9.b %x15 -> %x15
-252b8d31 : uqdecp x17, p9.b                          : uqdecp %p9.b %x17 -> %x17
-252b8d53 : uqdecp x19, p10.b                         : uqdecp %p10.b %x19 -> %x19
-252b8d75 : uqdecp x21, p11.b                         : uqdecp %p11.b %x21 -> %x21
-252b8d96 : uqdecp x22, p12.b                         : uqdecp %p12.b %x22 -> %x22
-252b8db8 : uqdecp x24, p13.b                         : uqdecp %p13.b %x24 -> %x24
-252b8dda : uqdecp x26, p14.b                         : uqdecp %p14.b %x26 -> %x26
-252b8dfe : uqdecp x30, p15.b                         : uqdecp %p15.b %x30 -> %x30
-256b8c00 : uqdecp x0, p0.h                           : uqdecp %p0.h %x0 -> %x0
-256b8c42 : uqdecp x2, p2.h                           : uqdecp %p2.h %x2 -> %x2
-256b8c64 : uqdecp x4, p3.h                           : uqdecp %p3.h %x4 -> %x4
-256b8c86 : uqdecp x6, p4.h                           : uqdecp %p4.h %x6 -> %x6
-256b8ca8 : uqdecp x8, p5.h                           : uqdecp %p5.h %x8 -> %x8
-256b8cc9 : uqdecp x9, p6.h                           : uqdecp %p6.h %x9 -> %x9
-256b8ceb : uqdecp x11, p7.h                          : uqdecp %p7.h %x11 -> %x11
-256b8d0d : uqdecp x13, p8.h                          : uqdecp %p8.h %x13 -> %x13
-256b8d2f : uqdecp x15, p9.h                          : uqdecp %p9.h %x15 -> %x15
-256b8d31 : uqdecp x17, p9.h                          : uqdecp %p9.h %x17 -> %x17
-256b8d53 : uqdecp x19, p10.h                         : uqdecp %p10.h %x19 -> %x19
-256b8d75 : uqdecp x21, p11.h                         : uqdecp %p11.h %x21 -> %x21
-256b8d96 : uqdecp x22, p12.h                         : uqdecp %p12.h %x22 -> %x22
-256b8db8 : uqdecp x24, p13.h                         : uqdecp %p13.h %x24 -> %x24
-256b8dda : uqdecp x26, p14.h                         : uqdecp %p14.h %x26 -> %x26
-256b8dfe : uqdecp x30, p15.h                         : uqdecp %p15.h %x30 -> %x30
-25ab8c00 : uqdecp x0, p0.s                           : uqdecp %p0.s %x0 -> %x0
-25ab8c42 : uqdecp x2, p2.s                           : uqdecp %p2.s %x2 -> %x2
-25ab8c64 : uqdecp x4, p3.s                           : uqdecp %p3.s %x4 -> %x4
-25ab8c86 : uqdecp x6, p4.s                           : uqdecp %p4.s %x6 -> %x6
-25ab8ca8 : uqdecp x8, p5.s                           : uqdecp %p5.s %x8 -> %x8
-25ab8cc9 : uqdecp x9, p6.s                           : uqdecp %p6.s %x9 -> %x9
-25ab8ceb : uqdecp x11, p7.s                          : uqdecp %p7.s %x11 -> %x11
-25ab8d0d : uqdecp x13, p8.s                          : uqdecp %p8.s %x13 -> %x13
-25ab8d2f : uqdecp x15, p9.s                          : uqdecp %p9.s %x15 -> %x15
-25ab8d31 : uqdecp x17, p9.s                          : uqdecp %p9.s %x17 -> %x17
-25ab8d53 : uqdecp x19, p10.s                         : uqdecp %p10.s %x19 -> %x19
-25ab8d75 : uqdecp x21, p11.s                         : uqdecp %p11.s %x21 -> %x21
-25ab8d96 : uqdecp x22, p12.s                         : uqdecp %p12.s %x22 -> %x22
-25ab8db8 : uqdecp x24, p13.s                         : uqdecp %p13.s %x24 -> %x24
-25ab8dda : uqdecp x26, p14.s                         : uqdecp %p14.s %x26 -> %x26
-25ab8dfe : uqdecp x30, p15.s                         : uqdecp %p15.s %x30 -> %x30
-25eb8c00 : uqdecp x0, p0.d                           : uqdecp %p0.d %x0 -> %x0
-25eb8c42 : uqdecp x2, p2.d                           : uqdecp %p2.d %x2 -> %x2
-25eb8c64 : uqdecp x4, p3.d                           : uqdecp %p3.d %x4 -> %x4
-25eb8c86 : uqdecp x6, p4.d                           : uqdecp %p4.d %x6 -> %x6
-25eb8ca8 : uqdecp x8, p5.d                           : uqdecp %p5.d %x8 -> %x8
-25eb8cc9 : uqdecp x9, p6.d                           : uqdecp %p6.d %x9 -> %x9
-25eb8ceb : uqdecp x11, p7.d                          : uqdecp %p7.d %x11 -> %x11
-25eb8d0d : uqdecp x13, p8.d                          : uqdecp %p8.d %x13 -> %x13
-25eb8d2f : uqdecp x15, p9.d                          : uqdecp %p9.d %x15 -> %x15
-25eb8d31 : uqdecp x17, p9.d                          : uqdecp %p9.d %x17 -> %x17
-25eb8d53 : uqdecp x19, p10.d                         : uqdecp %p10.d %x19 -> %x19
-25eb8d75 : uqdecp x21, p11.d                         : uqdecp %p11.d %x21 -> %x21
-25eb8d96 : uqdecp x22, p12.d                         : uqdecp %p12.d %x22 -> %x22
-25eb8db8 : uqdecp x24, p13.d                         : uqdecp %p13.d %x24 -> %x24
-25eb8dda : uqdecp x26, p14.d                         : uqdecp %p14.d %x26 -> %x26
-25eb8dfe : uqdecp x30, p15.d                         : uqdecp %p15.d %x30 -> %x30
+252b8c00 : uqdecp x0, p0.b                           : uqdecp %x0 %p0.b -> %x0
+252b8c42 : uqdecp x2, p2.b                           : uqdecp %x2 %p2.b -> %x2
+252b8c64 : uqdecp x4, p3.b                           : uqdecp %x4 %p3.b -> %x4
+252b8c86 : uqdecp x6, p4.b                           : uqdecp %x6 %p4.b -> %x6
+252b8ca8 : uqdecp x8, p5.b                           : uqdecp %x8 %p5.b -> %x8
+252b8cc9 : uqdecp x9, p6.b                           : uqdecp %x9 %p6.b -> %x9
+252b8ceb : uqdecp x11, p7.b                          : uqdecp %x11 %p7.b -> %x11
+252b8d0d : uqdecp x13, p8.b                          : uqdecp %x13 %p8.b -> %x13
+252b8d2f : uqdecp x15, p9.b                          : uqdecp %x15 %p9.b -> %x15
+252b8d31 : uqdecp x17, p9.b                          : uqdecp %x17 %p9.b -> %x17
+252b8d53 : uqdecp x19, p10.b                         : uqdecp %x19 %p10.b -> %x19
+252b8d75 : uqdecp x21, p11.b                         : uqdecp %x21 %p11.b -> %x21
+252b8d96 : uqdecp x22, p12.b                         : uqdecp %x22 %p12.b -> %x22
+252b8db8 : uqdecp x24, p13.b                         : uqdecp %x24 %p13.b -> %x24
+252b8dda : uqdecp x26, p14.b                         : uqdecp %x26 %p14.b -> %x26
+252b8dfe : uqdecp x30, p15.b                         : uqdecp %x30 %p15.b -> %x30
+256b8c00 : uqdecp x0, p0.h                           : uqdecp %x0 %p0.h -> %x0
+256b8c42 : uqdecp x2, p2.h                           : uqdecp %x2 %p2.h -> %x2
+256b8c64 : uqdecp x4, p3.h                           : uqdecp %x4 %p3.h -> %x4
+256b8c86 : uqdecp x6, p4.h                           : uqdecp %x6 %p4.h -> %x6
+256b8ca8 : uqdecp x8, p5.h                           : uqdecp %x8 %p5.h -> %x8
+256b8cc9 : uqdecp x9, p6.h                           : uqdecp %x9 %p6.h -> %x9
+256b8ceb : uqdecp x11, p7.h                          : uqdecp %x11 %p7.h -> %x11
+256b8d0d : uqdecp x13, p8.h                          : uqdecp %x13 %p8.h -> %x13
+256b8d2f : uqdecp x15, p9.h                          : uqdecp %x15 %p9.h -> %x15
+256b8d31 : uqdecp x17, p9.h                          : uqdecp %x17 %p9.h -> %x17
+256b8d53 : uqdecp x19, p10.h                         : uqdecp %x19 %p10.h -> %x19
+256b8d75 : uqdecp x21, p11.h                         : uqdecp %x21 %p11.h -> %x21
+256b8d96 : uqdecp x22, p12.h                         : uqdecp %x22 %p12.h -> %x22
+256b8db8 : uqdecp x24, p13.h                         : uqdecp %x24 %p13.h -> %x24
+256b8dda : uqdecp x26, p14.h                         : uqdecp %x26 %p14.h -> %x26
+256b8dfe : uqdecp x30, p15.h                         : uqdecp %x30 %p15.h -> %x30
+25ab8c00 : uqdecp x0, p0.s                           : uqdecp %x0 %p0.s -> %x0
+25ab8c42 : uqdecp x2, p2.s                           : uqdecp %x2 %p2.s -> %x2
+25ab8c64 : uqdecp x4, p3.s                           : uqdecp %x4 %p3.s -> %x4
+25ab8c86 : uqdecp x6, p4.s                           : uqdecp %x6 %p4.s -> %x6
+25ab8ca8 : uqdecp x8, p5.s                           : uqdecp %x8 %p5.s -> %x8
+25ab8cc9 : uqdecp x9, p6.s                           : uqdecp %x9 %p6.s -> %x9
+25ab8ceb : uqdecp x11, p7.s                          : uqdecp %x11 %p7.s -> %x11
+25ab8d0d : uqdecp x13, p8.s                          : uqdecp %x13 %p8.s -> %x13
+25ab8d2f : uqdecp x15, p9.s                          : uqdecp %x15 %p9.s -> %x15
+25ab8d31 : uqdecp x17, p9.s                          : uqdecp %x17 %p9.s -> %x17
+25ab8d53 : uqdecp x19, p10.s                         : uqdecp %x19 %p10.s -> %x19
+25ab8d75 : uqdecp x21, p11.s                         : uqdecp %x21 %p11.s -> %x21
+25ab8d96 : uqdecp x22, p12.s                         : uqdecp %x22 %p12.s -> %x22
+25ab8db8 : uqdecp x24, p13.s                         : uqdecp %x24 %p13.s -> %x24
+25ab8dda : uqdecp x26, p14.s                         : uqdecp %x26 %p14.s -> %x26
+25ab8dfe : uqdecp x30, p15.s                         : uqdecp %x30 %p15.s -> %x30
+25eb8c00 : uqdecp x0, p0.d                           : uqdecp %x0 %p0.d -> %x0
+25eb8c42 : uqdecp x2, p2.d                           : uqdecp %x2 %p2.d -> %x2
+25eb8c64 : uqdecp x4, p3.d                           : uqdecp %x4 %p3.d -> %x4
+25eb8c86 : uqdecp x6, p4.d                           : uqdecp %x6 %p4.d -> %x6
+25eb8ca8 : uqdecp x8, p5.d                           : uqdecp %x8 %p5.d -> %x8
+25eb8cc9 : uqdecp x9, p6.d                           : uqdecp %x9 %p6.d -> %x9
+25eb8ceb : uqdecp x11, p7.d                          : uqdecp %x11 %p7.d -> %x11
+25eb8d0d : uqdecp x13, p8.d                          : uqdecp %x13 %p8.d -> %x13
+25eb8d2f : uqdecp x15, p9.d                          : uqdecp %x15 %p9.d -> %x15
+25eb8d31 : uqdecp x17, p9.d                          : uqdecp %x17 %p9.d -> %x17
+25eb8d53 : uqdecp x19, p10.d                         : uqdecp %x19 %p10.d -> %x19
+25eb8d75 : uqdecp x21, p11.d                         : uqdecp %x21 %p11.d -> %x21
+25eb8d96 : uqdecp x22, p12.d                         : uqdecp %x22 %p12.d -> %x22
+25eb8db8 : uqdecp x24, p13.d                         : uqdecp %x24 %p13.d -> %x24
+25eb8dda : uqdecp x26, p14.d                         : uqdecp %x26 %p14.d -> %x26
+25eb8dfe : uqdecp x30, p15.d                         : uqdecp %x30 %p15.d -> %x30
 
 # UQDECP  <Zdn>.<T>, <Pm>.<T> (UQDECP-Z.P.Z-_)
-256b8000 : uqdecp z0.h, p0                           : uqdecp %p0.h %z0.h -> %z0.h
-256b8042 : uqdecp z2.h, p2                           : uqdecp %p2.h %z2.h -> %z2.h
-256b8064 : uqdecp z4.h, p3                           : uqdecp %p3.h %z4.h -> %z4.h
-256b8086 : uqdecp z6.h, p4                           : uqdecp %p4.h %z6.h -> %z6.h
-256b80a8 : uqdecp z8.h, p5                           : uqdecp %p5.h %z8.h -> %z8.h
-256b80ca : uqdecp z10.h, p6                          : uqdecp %p6.h %z10.h -> %z10.h
-256b80ec : uqdecp z12.h, p7                          : uqdecp %p7.h %z12.h -> %z12.h
-256b810e : uqdecp z14.h, p8                          : uqdecp %p8.h %z14.h -> %z14.h
-256b8130 : uqdecp z16.h, p9                          : uqdecp %p9.h %z16.h -> %z16.h
-256b8131 : uqdecp z17.h, p9                          : uqdecp %p9.h %z17.h -> %z17.h
-256b8153 : uqdecp z19.h, p10                         : uqdecp %p10.h %z19.h -> %z19.h
-256b8175 : uqdecp z21.h, p11                         : uqdecp %p11.h %z21.h -> %z21.h
-256b8197 : uqdecp z23.h, p12                         : uqdecp %p12.h %z23.h -> %z23.h
-256b81b9 : uqdecp z25.h, p13                         : uqdecp %p13.h %z25.h -> %z25.h
-256b81db : uqdecp z27.h, p14                         : uqdecp %p14.h %z27.h -> %z27.h
-256b81ff : uqdecp z31.h, p15                         : uqdecp %p15.h %z31.h -> %z31.h
-25ab8000 : uqdecp z0.s, p0                           : uqdecp %p0.s %z0.s -> %z0.s
-25ab8042 : uqdecp z2.s, p2                           : uqdecp %p2.s %z2.s -> %z2.s
-25ab8064 : uqdecp z4.s, p3                           : uqdecp %p3.s %z4.s -> %z4.s
-25ab8086 : uqdecp z6.s, p4                           : uqdecp %p4.s %z6.s -> %z6.s
-25ab80a8 : uqdecp z8.s, p5                           : uqdecp %p5.s %z8.s -> %z8.s
-25ab80ca : uqdecp z10.s, p6                          : uqdecp %p6.s %z10.s -> %z10.s
-25ab80ec : uqdecp z12.s, p7                          : uqdecp %p7.s %z12.s -> %z12.s
-25ab810e : uqdecp z14.s, p8                          : uqdecp %p8.s %z14.s -> %z14.s
-25ab8130 : uqdecp z16.s, p9                          : uqdecp %p9.s %z16.s -> %z16.s
-25ab8131 : uqdecp z17.s, p9                          : uqdecp %p9.s %z17.s -> %z17.s
-25ab8153 : uqdecp z19.s, p10                         : uqdecp %p10.s %z19.s -> %z19.s
-25ab8175 : uqdecp z21.s, p11                         : uqdecp %p11.s %z21.s -> %z21.s
-25ab8197 : uqdecp z23.s, p12                         : uqdecp %p12.s %z23.s -> %z23.s
-25ab81b9 : uqdecp z25.s, p13                         : uqdecp %p13.s %z25.s -> %z25.s
-25ab81db : uqdecp z27.s, p14                         : uqdecp %p14.s %z27.s -> %z27.s
-25ab81ff : uqdecp z31.s, p15                         : uqdecp %p15.s %z31.s -> %z31.s
-25eb8000 : uqdecp z0.d, p0                           : uqdecp %p0.d %z0.d -> %z0.d
-25eb8042 : uqdecp z2.d, p2                           : uqdecp %p2.d %z2.d -> %z2.d
-25eb8064 : uqdecp z4.d, p3                           : uqdecp %p3.d %z4.d -> %z4.d
-25eb8086 : uqdecp z6.d, p4                           : uqdecp %p4.d %z6.d -> %z6.d
-25eb80a8 : uqdecp z8.d, p5                           : uqdecp %p5.d %z8.d -> %z8.d
-25eb80ca : uqdecp z10.d, p6                          : uqdecp %p6.d %z10.d -> %z10.d
-25eb80ec : uqdecp z12.d, p7                          : uqdecp %p7.d %z12.d -> %z12.d
-25eb810e : uqdecp z14.d, p8                          : uqdecp %p8.d %z14.d -> %z14.d
-25eb8130 : uqdecp z16.d, p9                          : uqdecp %p9.d %z16.d -> %z16.d
-25eb8131 : uqdecp z17.d, p9                          : uqdecp %p9.d %z17.d -> %z17.d
-25eb8153 : uqdecp z19.d, p10                         : uqdecp %p10.d %z19.d -> %z19.d
-25eb8175 : uqdecp z21.d, p11                         : uqdecp %p11.d %z21.d -> %z21.d
-25eb8197 : uqdecp z23.d, p12                         : uqdecp %p12.d %z23.d -> %z23.d
-25eb81b9 : uqdecp z25.d, p13                         : uqdecp %p13.d %z25.d -> %z25.d
-25eb81db : uqdecp z27.d, p14                         : uqdecp %p14.d %z27.d -> %z27.d
-25eb81ff : uqdecp z31.d, p15                         : uqdecp %p15.d %z31.d -> %z31.d
+256b8000 : uqdecp z0.h, p0                           : uqdecp %z0.h %p0.h -> %z0.h
+256b8042 : uqdecp z2.h, p2                           : uqdecp %z2.h %p2.h -> %z2.h
+256b8064 : uqdecp z4.h, p3                           : uqdecp %z4.h %p3.h -> %z4.h
+256b8086 : uqdecp z6.h, p4                           : uqdecp %z6.h %p4.h -> %z6.h
+256b80a8 : uqdecp z8.h, p5                           : uqdecp %z8.h %p5.h -> %z8.h
+256b80ca : uqdecp z10.h, p6                          : uqdecp %z10.h %p6.h -> %z10.h
+256b80ec : uqdecp z12.h, p7                          : uqdecp %z12.h %p7.h -> %z12.h
+256b810e : uqdecp z14.h, p8                          : uqdecp %z14.h %p8.h -> %z14.h
+256b8130 : uqdecp z16.h, p9                          : uqdecp %z16.h %p9.h -> %z16.h
+256b8131 : uqdecp z17.h, p9                          : uqdecp %z17.h %p9.h -> %z17.h
+256b8153 : uqdecp z19.h, p10                         : uqdecp %z19.h %p10.h -> %z19.h
+256b8175 : uqdecp z21.h, p11                         : uqdecp %z21.h %p11.h -> %z21.h
+256b8197 : uqdecp z23.h, p12                         : uqdecp %z23.h %p12.h -> %z23.h
+256b81b9 : uqdecp z25.h, p13                         : uqdecp %z25.h %p13.h -> %z25.h
+256b81db : uqdecp z27.h, p14                         : uqdecp %z27.h %p14.h -> %z27.h
+256b81ff : uqdecp z31.h, p15                         : uqdecp %z31.h %p15.h -> %z31.h
+25ab8000 : uqdecp z0.s, p0                           : uqdecp %z0.s %p0.s -> %z0.s
+25ab8042 : uqdecp z2.s, p2                           : uqdecp %z2.s %p2.s -> %z2.s
+25ab8064 : uqdecp z4.s, p3                           : uqdecp %z4.s %p3.s -> %z4.s
+25ab8086 : uqdecp z6.s, p4                           : uqdecp %z6.s %p4.s -> %z6.s
+25ab80a8 : uqdecp z8.s, p5                           : uqdecp %z8.s %p5.s -> %z8.s
+25ab80ca : uqdecp z10.s, p6                          : uqdecp %z10.s %p6.s -> %z10.s
+25ab80ec : uqdecp z12.s, p7                          : uqdecp %z12.s %p7.s -> %z12.s
+25ab810e : uqdecp z14.s, p8                          : uqdecp %z14.s %p8.s -> %z14.s
+25ab8130 : uqdecp z16.s, p9                          : uqdecp %z16.s %p9.s -> %z16.s
+25ab8131 : uqdecp z17.s, p9                          : uqdecp %z17.s %p9.s -> %z17.s
+25ab8153 : uqdecp z19.s, p10                         : uqdecp %z19.s %p10.s -> %z19.s
+25ab8175 : uqdecp z21.s, p11                         : uqdecp %z21.s %p11.s -> %z21.s
+25ab8197 : uqdecp z23.s, p12                         : uqdecp %z23.s %p12.s -> %z23.s
+25ab81b9 : uqdecp z25.s, p13                         : uqdecp %z25.s %p13.s -> %z25.s
+25ab81db : uqdecp z27.s, p14                         : uqdecp %z27.s %p14.s -> %z27.s
+25ab81ff : uqdecp z31.s, p15                         : uqdecp %z31.s %p15.s -> %z31.s
+25eb8000 : uqdecp z0.d, p0                           : uqdecp %z0.d %p0.d -> %z0.d
+25eb8042 : uqdecp z2.d, p2                           : uqdecp %z2.d %p2.d -> %z2.d
+25eb8064 : uqdecp z4.d, p3                           : uqdecp %z4.d %p3.d -> %z4.d
+25eb8086 : uqdecp z6.d, p4                           : uqdecp %z6.d %p4.d -> %z6.d
+25eb80a8 : uqdecp z8.d, p5                           : uqdecp %z8.d %p5.d -> %z8.d
+25eb80ca : uqdecp z10.d, p6                          : uqdecp %z10.d %p6.d -> %z10.d
+25eb80ec : uqdecp z12.d, p7                          : uqdecp %z12.d %p7.d -> %z12.d
+25eb810e : uqdecp z14.d, p8                          : uqdecp %z14.d %p8.d -> %z14.d
+25eb8130 : uqdecp z16.d, p9                          : uqdecp %z16.d %p9.d -> %z16.d
+25eb8131 : uqdecp z17.d, p9                          : uqdecp %z17.d %p9.d -> %z17.d
+25eb8153 : uqdecp z19.d, p10                         : uqdecp %z19.d %p10.d -> %z19.d
+25eb8175 : uqdecp z21.d, p11                         : uqdecp %z21.d %p11.d -> %z21.d
+25eb8197 : uqdecp z23.d, p12                         : uqdecp %z23.d %p12.d -> %z23.d
+25eb81b9 : uqdecp z25.d, p13                         : uqdecp %z25.d %p13.d -> %z25.d
+25eb81db : uqdecp z27.d, p14                         : uqdecp %z27.d %p14.d -> %z27.d
+25eb81ff : uqdecp z31.d, p15                         : uqdecp %z31.d %p15.d -> %z31.d
 
 # UQDECW  <Zdn>.S{, <pattern>{, MUL #<imm>}} (UQDECW-Z.ZS-_)
 04a0cc00 : uqdecw z0.s, POW2, MUL #1                 : uqdecw %z0.s POW2 mul $0x01 -> %z0.s
@@ -25278,186 +25212,186 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 047ff7fe : uqinch x30, ALL, MUL #16                  : uqinch %x30 ALL mul $0x10 -> %x30
 
 # UQINCP  <Wdn>, <Pm>.<T> (UQINCP-R.P.R-UW)
-25298800 : uqincp w0, p0.b                           : uqincp %p0.b %w0 -> %w0
-25298842 : uqincp w2, p2.b                           : uqincp %p2.b %w2 -> %w2
-25298864 : uqincp w4, p3.b                           : uqincp %p3.b %w4 -> %w4
-25298886 : uqincp w6, p4.b                           : uqincp %p4.b %w6 -> %w6
-252988a8 : uqincp w8, p5.b                           : uqincp %p5.b %w8 -> %w8
-252988c9 : uqincp w9, p6.b                           : uqincp %p6.b %w9 -> %w9
-252988eb : uqincp w11, p7.b                          : uqincp %p7.b %w11 -> %w11
-2529890d : uqincp w13, p8.b                          : uqincp %p8.b %w13 -> %w13
-2529892f : uqincp w15, p9.b                          : uqincp %p9.b %w15 -> %w15
-25298931 : uqincp w17, p9.b                          : uqincp %p9.b %w17 -> %w17
-25298953 : uqincp w19, p10.b                         : uqincp %p10.b %w19 -> %w19
-25298975 : uqincp w21, p11.b                         : uqincp %p11.b %w21 -> %w21
-25298996 : uqincp w22, p12.b                         : uqincp %p12.b %w22 -> %w22
-252989b8 : uqincp w24, p13.b                         : uqincp %p13.b %w24 -> %w24
-252989da : uqincp w26, p14.b                         : uqincp %p14.b %w26 -> %w26
-252989fe : uqincp w30, p15.b                         : uqincp %p15.b %w30 -> %w30
-25698800 : uqincp w0, p0.h                           : uqincp %p0.h %w0 -> %w0
-25698842 : uqincp w2, p2.h                           : uqincp %p2.h %w2 -> %w2
-25698864 : uqincp w4, p3.h                           : uqincp %p3.h %w4 -> %w4
-25698886 : uqincp w6, p4.h                           : uqincp %p4.h %w6 -> %w6
-256988a8 : uqincp w8, p5.h                           : uqincp %p5.h %w8 -> %w8
-256988c9 : uqincp w9, p6.h                           : uqincp %p6.h %w9 -> %w9
-256988eb : uqincp w11, p7.h                          : uqincp %p7.h %w11 -> %w11
-2569890d : uqincp w13, p8.h                          : uqincp %p8.h %w13 -> %w13
-2569892f : uqincp w15, p9.h                          : uqincp %p9.h %w15 -> %w15
-25698931 : uqincp w17, p9.h                          : uqincp %p9.h %w17 -> %w17
-25698953 : uqincp w19, p10.h                         : uqincp %p10.h %w19 -> %w19
-25698975 : uqincp w21, p11.h                         : uqincp %p11.h %w21 -> %w21
-25698996 : uqincp w22, p12.h                         : uqincp %p12.h %w22 -> %w22
-256989b8 : uqincp w24, p13.h                         : uqincp %p13.h %w24 -> %w24
-256989da : uqincp w26, p14.h                         : uqincp %p14.h %w26 -> %w26
-256989fe : uqincp w30, p15.h                         : uqincp %p15.h %w30 -> %w30
-25a98800 : uqincp w0, p0.s                           : uqincp %p0.s %w0 -> %w0
-25a98842 : uqincp w2, p2.s                           : uqincp %p2.s %w2 -> %w2
-25a98864 : uqincp w4, p3.s                           : uqincp %p3.s %w4 -> %w4
-25a98886 : uqincp w6, p4.s                           : uqincp %p4.s %w6 -> %w6
-25a988a8 : uqincp w8, p5.s                           : uqincp %p5.s %w8 -> %w8
-25a988c9 : uqincp w9, p6.s                           : uqincp %p6.s %w9 -> %w9
-25a988eb : uqincp w11, p7.s                          : uqincp %p7.s %w11 -> %w11
-25a9890d : uqincp w13, p8.s                          : uqincp %p8.s %w13 -> %w13
-25a9892f : uqincp w15, p9.s                          : uqincp %p9.s %w15 -> %w15
-25a98931 : uqincp w17, p9.s                          : uqincp %p9.s %w17 -> %w17
-25a98953 : uqincp w19, p10.s                         : uqincp %p10.s %w19 -> %w19
-25a98975 : uqincp w21, p11.s                         : uqincp %p11.s %w21 -> %w21
-25a98996 : uqincp w22, p12.s                         : uqincp %p12.s %w22 -> %w22
-25a989b8 : uqincp w24, p13.s                         : uqincp %p13.s %w24 -> %w24
-25a989da : uqincp w26, p14.s                         : uqincp %p14.s %w26 -> %w26
-25a989fe : uqincp w30, p15.s                         : uqincp %p15.s %w30 -> %w30
-25e98800 : uqincp w0, p0.d                           : uqincp %p0.d %w0 -> %w0
-25e98842 : uqincp w2, p2.d                           : uqincp %p2.d %w2 -> %w2
-25e98864 : uqincp w4, p3.d                           : uqincp %p3.d %w4 -> %w4
-25e98886 : uqincp w6, p4.d                           : uqincp %p4.d %w6 -> %w6
-25e988a8 : uqincp w8, p5.d                           : uqincp %p5.d %w8 -> %w8
-25e988c9 : uqincp w9, p6.d                           : uqincp %p6.d %w9 -> %w9
-25e988eb : uqincp w11, p7.d                          : uqincp %p7.d %w11 -> %w11
-25e9890d : uqincp w13, p8.d                          : uqincp %p8.d %w13 -> %w13
-25e9892f : uqincp w15, p9.d                          : uqincp %p9.d %w15 -> %w15
-25e98931 : uqincp w17, p9.d                          : uqincp %p9.d %w17 -> %w17
-25e98953 : uqincp w19, p10.d                         : uqincp %p10.d %w19 -> %w19
-25e98975 : uqincp w21, p11.d                         : uqincp %p11.d %w21 -> %w21
-25e98996 : uqincp w22, p12.d                         : uqincp %p12.d %w22 -> %w22
-25e989b8 : uqincp w24, p13.d                         : uqincp %p13.d %w24 -> %w24
-25e989da : uqincp w26, p14.d                         : uqincp %p14.d %w26 -> %w26
-25e989fe : uqincp w30, p15.d                         : uqincp %p15.d %w30 -> %w30
+25298800 : uqincp w0, p0.b                           : uqincp %w0 %p0.b -> %w0
+25298842 : uqincp w2, p2.b                           : uqincp %w2 %p2.b -> %w2
+25298864 : uqincp w4, p3.b                           : uqincp %w4 %p3.b -> %w4
+25298886 : uqincp w6, p4.b                           : uqincp %w6 %p4.b -> %w6
+252988a8 : uqincp w8, p5.b                           : uqincp %w8 %p5.b -> %w8
+252988c9 : uqincp w9, p6.b                           : uqincp %w9 %p6.b -> %w9
+252988eb : uqincp w11, p7.b                          : uqincp %w11 %p7.b -> %w11
+2529890d : uqincp w13, p8.b                          : uqincp %w13 %p8.b -> %w13
+2529892f : uqincp w15, p9.b                          : uqincp %w15 %p9.b -> %w15
+25298931 : uqincp w17, p9.b                          : uqincp %w17 %p9.b -> %w17
+25298953 : uqincp w19, p10.b                         : uqincp %w19 %p10.b -> %w19
+25298975 : uqincp w21, p11.b                         : uqincp %w21 %p11.b -> %w21
+25298996 : uqincp w22, p12.b                         : uqincp %w22 %p12.b -> %w22
+252989b8 : uqincp w24, p13.b                         : uqincp %w24 %p13.b -> %w24
+252989da : uqincp w26, p14.b                         : uqincp %w26 %p14.b -> %w26
+252989fe : uqincp w30, p15.b                         : uqincp %w30 %p15.b -> %w30
+25698800 : uqincp w0, p0.h                           : uqincp %w0 %p0.h -> %w0
+25698842 : uqincp w2, p2.h                           : uqincp %w2 %p2.h -> %w2
+25698864 : uqincp w4, p3.h                           : uqincp %w4 %p3.h -> %w4
+25698886 : uqincp w6, p4.h                           : uqincp %w6 %p4.h -> %w6
+256988a8 : uqincp w8, p5.h                           : uqincp %w8 %p5.h -> %w8
+256988c9 : uqincp w9, p6.h                           : uqincp %w9 %p6.h -> %w9
+256988eb : uqincp w11, p7.h                          : uqincp %w11 %p7.h -> %w11
+2569890d : uqincp w13, p8.h                          : uqincp %w13 %p8.h -> %w13
+2569892f : uqincp w15, p9.h                          : uqincp %w15 %p9.h -> %w15
+25698931 : uqincp w17, p9.h                          : uqincp %w17 %p9.h -> %w17
+25698953 : uqincp w19, p10.h                         : uqincp %w19 %p10.h -> %w19
+25698975 : uqincp w21, p11.h                         : uqincp %w21 %p11.h -> %w21
+25698996 : uqincp w22, p12.h                         : uqincp %w22 %p12.h -> %w22
+256989b8 : uqincp w24, p13.h                         : uqincp %w24 %p13.h -> %w24
+256989da : uqincp w26, p14.h                         : uqincp %w26 %p14.h -> %w26
+256989fe : uqincp w30, p15.h                         : uqincp %w30 %p15.h -> %w30
+25a98800 : uqincp w0, p0.s                           : uqincp %w0 %p0.s -> %w0
+25a98842 : uqincp w2, p2.s                           : uqincp %w2 %p2.s -> %w2
+25a98864 : uqincp w4, p3.s                           : uqincp %w4 %p3.s -> %w4
+25a98886 : uqincp w6, p4.s                           : uqincp %w6 %p4.s -> %w6
+25a988a8 : uqincp w8, p5.s                           : uqincp %w8 %p5.s -> %w8
+25a988c9 : uqincp w9, p6.s                           : uqincp %w9 %p6.s -> %w9
+25a988eb : uqincp w11, p7.s                          : uqincp %w11 %p7.s -> %w11
+25a9890d : uqincp w13, p8.s                          : uqincp %w13 %p8.s -> %w13
+25a9892f : uqincp w15, p9.s                          : uqincp %w15 %p9.s -> %w15
+25a98931 : uqincp w17, p9.s                          : uqincp %w17 %p9.s -> %w17
+25a98953 : uqincp w19, p10.s                         : uqincp %w19 %p10.s -> %w19
+25a98975 : uqincp w21, p11.s                         : uqincp %w21 %p11.s -> %w21
+25a98996 : uqincp w22, p12.s                         : uqincp %w22 %p12.s -> %w22
+25a989b8 : uqincp w24, p13.s                         : uqincp %w24 %p13.s -> %w24
+25a989da : uqincp w26, p14.s                         : uqincp %w26 %p14.s -> %w26
+25a989fe : uqincp w30, p15.s                         : uqincp %w30 %p15.s -> %w30
+25e98800 : uqincp w0, p0.d                           : uqincp %w0 %p0.d -> %w0
+25e98842 : uqincp w2, p2.d                           : uqincp %w2 %p2.d -> %w2
+25e98864 : uqincp w4, p3.d                           : uqincp %w4 %p3.d -> %w4
+25e98886 : uqincp w6, p4.d                           : uqincp %w6 %p4.d -> %w6
+25e988a8 : uqincp w8, p5.d                           : uqincp %w8 %p5.d -> %w8
+25e988c9 : uqincp w9, p6.d                           : uqincp %w9 %p6.d -> %w9
+25e988eb : uqincp w11, p7.d                          : uqincp %w11 %p7.d -> %w11
+25e9890d : uqincp w13, p8.d                          : uqincp %w13 %p8.d -> %w13
+25e9892f : uqincp w15, p9.d                          : uqincp %w15 %p9.d -> %w15
+25e98931 : uqincp w17, p9.d                          : uqincp %w17 %p9.d -> %w17
+25e98953 : uqincp w19, p10.d                         : uqincp %w19 %p10.d -> %w19
+25e98975 : uqincp w21, p11.d                         : uqincp %w21 %p11.d -> %w21
+25e98996 : uqincp w22, p12.d                         : uqincp %w22 %p12.d -> %w22
+25e989b8 : uqincp w24, p13.d                         : uqincp %w24 %p13.d -> %w24
+25e989da : uqincp w26, p14.d                         : uqincp %w26 %p14.d -> %w26
+25e989fe : uqincp w30, p15.d                         : uqincp %w30 %p15.d -> %w30
 
 # UQINCP  <Xdn>, <Pm>.<T> (UQINCP-R.P.R-X)
-25298c00 : uqincp x0, p0.b                           : uqincp %p0.b %x0 -> %x0
-25298c42 : uqincp x2, p2.b                           : uqincp %p2.b %x2 -> %x2
-25298c64 : uqincp x4, p3.b                           : uqincp %p3.b %x4 -> %x4
-25298c86 : uqincp x6, p4.b                           : uqincp %p4.b %x6 -> %x6
-25298ca8 : uqincp x8, p5.b                           : uqincp %p5.b %x8 -> %x8
-25298cc9 : uqincp x9, p6.b                           : uqincp %p6.b %x9 -> %x9
-25298ceb : uqincp x11, p7.b                          : uqincp %p7.b %x11 -> %x11
-25298d0d : uqincp x13, p8.b                          : uqincp %p8.b %x13 -> %x13
-25298d2f : uqincp x15, p9.b                          : uqincp %p9.b %x15 -> %x15
-25298d31 : uqincp x17, p9.b                          : uqincp %p9.b %x17 -> %x17
-25298d53 : uqincp x19, p10.b                         : uqincp %p10.b %x19 -> %x19
-25298d75 : uqincp x21, p11.b                         : uqincp %p11.b %x21 -> %x21
-25298d96 : uqincp x22, p12.b                         : uqincp %p12.b %x22 -> %x22
-25298db8 : uqincp x24, p13.b                         : uqincp %p13.b %x24 -> %x24
-25298dda : uqincp x26, p14.b                         : uqincp %p14.b %x26 -> %x26
-25298dfe : uqincp x30, p15.b                         : uqincp %p15.b %x30 -> %x30
-25698c00 : uqincp x0, p0.h                           : uqincp %p0.h %x0 -> %x0
-25698c42 : uqincp x2, p2.h                           : uqincp %p2.h %x2 -> %x2
-25698c64 : uqincp x4, p3.h                           : uqincp %p3.h %x4 -> %x4
-25698c86 : uqincp x6, p4.h                           : uqincp %p4.h %x6 -> %x6
-25698ca8 : uqincp x8, p5.h                           : uqincp %p5.h %x8 -> %x8
-25698cc9 : uqincp x9, p6.h                           : uqincp %p6.h %x9 -> %x9
-25698ceb : uqincp x11, p7.h                          : uqincp %p7.h %x11 -> %x11
-25698d0d : uqincp x13, p8.h                          : uqincp %p8.h %x13 -> %x13
-25698d2f : uqincp x15, p9.h                          : uqincp %p9.h %x15 -> %x15
-25698d31 : uqincp x17, p9.h                          : uqincp %p9.h %x17 -> %x17
-25698d53 : uqincp x19, p10.h                         : uqincp %p10.h %x19 -> %x19
-25698d75 : uqincp x21, p11.h                         : uqincp %p11.h %x21 -> %x21
-25698d96 : uqincp x22, p12.h                         : uqincp %p12.h %x22 -> %x22
-25698db8 : uqincp x24, p13.h                         : uqincp %p13.h %x24 -> %x24
-25698dda : uqincp x26, p14.h                         : uqincp %p14.h %x26 -> %x26
-25698dfe : uqincp x30, p15.h                         : uqincp %p15.h %x30 -> %x30
-25a98c00 : uqincp x0, p0.s                           : uqincp %p0.s %x0 -> %x0
-25a98c42 : uqincp x2, p2.s                           : uqincp %p2.s %x2 -> %x2
-25a98c64 : uqincp x4, p3.s                           : uqincp %p3.s %x4 -> %x4
-25a98c86 : uqincp x6, p4.s                           : uqincp %p4.s %x6 -> %x6
-25a98ca8 : uqincp x8, p5.s                           : uqincp %p5.s %x8 -> %x8
-25a98cc9 : uqincp x9, p6.s                           : uqincp %p6.s %x9 -> %x9
-25a98ceb : uqincp x11, p7.s                          : uqincp %p7.s %x11 -> %x11
-25a98d0d : uqincp x13, p8.s                          : uqincp %p8.s %x13 -> %x13
-25a98d2f : uqincp x15, p9.s                          : uqincp %p9.s %x15 -> %x15
-25a98d31 : uqincp x17, p9.s                          : uqincp %p9.s %x17 -> %x17
-25a98d53 : uqincp x19, p10.s                         : uqincp %p10.s %x19 -> %x19
-25a98d75 : uqincp x21, p11.s                         : uqincp %p11.s %x21 -> %x21
-25a98d96 : uqincp x22, p12.s                         : uqincp %p12.s %x22 -> %x22
-25a98db8 : uqincp x24, p13.s                         : uqincp %p13.s %x24 -> %x24
-25a98dda : uqincp x26, p14.s                         : uqincp %p14.s %x26 -> %x26
-25a98dfe : uqincp x30, p15.s                         : uqincp %p15.s %x30 -> %x30
-25e98c00 : uqincp x0, p0.d                           : uqincp %p0.d %x0 -> %x0
-25e98c42 : uqincp x2, p2.d                           : uqincp %p2.d %x2 -> %x2
-25e98c64 : uqincp x4, p3.d                           : uqincp %p3.d %x4 -> %x4
-25e98c86 : uqincp x6, p4.d                           : uqincp %p4.d %x6 -> %x6
-25e98ca8 : uqincp x8, p5.d                           : uqincp %p5.d %x8 -> %x8
-25e98cc9 : uqincp x9, p6.d                           : uqincp %p6.d %x9 -> %x9
-25e98ceb : uqincp x11, p7.d                          : uqincp %p7.d %x11 -> %x11
-25e98d0d : uqincp x13, p8.d                          : uqincp %p8.d %x13 -> %x13
-25e98d2f : uqincp x15, p9.d                          : uqincp %p9.d %x15 -> %x15
-25e98d31 : uqincp x17, p9.d                          : uqincp %p9.d %x17 -> %x17
-25e98d53 : uqincp x19, p10.d                         : uqincp %p10.d %x19 -> %x19
-25e98d75 : uqincp x21, p11.d                         : uqincp %p11.d %x21 -> %x21
-25e98d96 : uqincp x22, p12.d                         : uqincp %p12.d %x22 -> %x22
-25e98db8 : uqincp x24, p13.d                         : uqincp %p13.d %x24 -> %x24
-25e98dda : uqincp x26, p14.d                         : uqincp %p14.d %x26 -> %x26
-25e98dfe : uqincp x30, p15.d                         : uqincp %p15.d %x30 -> %x30
+25298c00 : uqincp x0, p0.b                           : uqincp %x0 %p0.b -> %x0
+25298c42 : uqincp x2, p2.b                           : uqincp %x2 %p2.b -> %x2
+25298c64 : uqincp x4, p3.b                           : uqincp %x4 %p3.b -> %x4
+25298c86 : uqincp x6, p4.b                           : uqincp %x6 %p4.b -> %x6
+25298ca8 : uqincp x8, p5.b                           : uqincp %x8 %p5.b -> %x8
+25298cc9 : uqincp x9, p6.b                           : uqincp %x9 %p6.b -> %x9
+25298ceb : uqincp x11, p7.b                          : uqincp %x11 %p7.b -> %x11
+25298d0d : uqincp x13, p8.b                          : uqincp %x13 %p8.b -> %x13
+25298d2f : uqincp x15, p9.b                          : uqincp %x15 %p9.b -> %x15
+25298d31 : uqincp x17, p9.b                          : uqincp %x17 %p9.b -> %x17
+25298d53 : uqincp x19, p10.b                         : uqincp %x19 %p10.b -> %x19
+25298d75 : uqincp x21, p11.b                         : uqincp %x21 %p11.b -> %x21
+25298d96 : uqincp x22, p12.b                         : uqincp %x22 %p12.b -> %x22
+25298db8 : uqincp x24, p13.b                         : uqincp %x24 %p13.b -> %x24
+25298dda : uqincp x26, p14.b                         : uqincp %x26 %p14.b -> %x26
+25298dfe : uqincp x30, p15.b                         : uqincp %x30 %p15.b -> %x30
+25698c00 : uqincp x0, p0.h                           : uqincp %x0 %p0.h -> %x0
+25698c42 : uqincp x2, p2.h                           : uqincp %x2 %p2.h -> %x2
+25698c64 : uqincp x4, p3.h                           : uqincp %x4 %p3.h -> %x4
+25698c86 : uqincp x6, p4.h                           : uqincp %x6 %p4.h -> %x6
+25698ca8 : uqincp x8, p5.h                           : uqincp %x8 %p5.h -> %x8
+25698cc9 : uqincp x9, p6.h                           : uqincp %x9 %p6.h -> %x9
+25698ceb : uqincp x11, p7.h                          : uqincp %x11 %p7.h -> %x11
+25698d0d : uqincp x13, p8.h                          : uqincp %x13 %p8.h -> %x13
+25698d2f : uqincp x15, p9.h                          : uqincp %x15 %p9.h -> %x15
+25698d31 : uqincp x17, p9.h                          : uqincp %x17 %p9.h -> %x17
+25698d53 : uqincp x19, p10.h                         : uqincp %x19 %p10.h -> %x19
+25698d75 : uqincp x21, p11.h                         : uqincp %x21 %p11.h -> %x21
+25698d96 : uqincp x22, p12.h                         : uqincp %x22 %p12.h -> %x22
+25698db8 : uqincp x24, p13.h                         : uqincp %x24 %p13.h -> %x24
+25698dda : uqincp x26, p14.h                         : uqincp %x26 %p14.h -> %x26
+25698dfe : uqincp x30, p15.h                         : uqincp %x30 %p15.h -> %x30
+25a98c00 : uqincp x0, p0.s                           : uqincp %x0 %p0.s -> %x0
+25a98c42 : uqincp x2, p2.s                           : uqincp %x2 %p2.s -> %x2
+25a98c64 : uqincp x4, p3.s                           : uqincp %x4 %p3.s -> %x4
+25a98c86 : uqincp x6, p4.s                           : uqincp %x6 %p4.s -> %x6
+25a98ca8 : uqincp x8, p5.s                           : uqincp %x8 %p5.s -> %x8
+25a98cc9 : uqincp x9, p6.s                           : uqincp %x9 %p6.s -> %x9
+25a98ceb : uqincp x11, p7.s                          : uqincp %x11 %p7.s -> %x11
+25a98d0d : uqincp x13, p8.s                          : uqincp %x13 %p8.s -> %x13
+25a98d2f : uqincp x15, p9.s                          : uqincp %x15 %p9.s -> %x15
+25a98d31 : uqincp x17, p9.s                          : uqincp %x17 %p9.s -> %x17
+25a98d53 : uqincp x19, p10.s                         : uqincp %x19 %p10.s -> %x19
+25a98d75 : uqincp x21, p11.s                         : uqincp %x21 %p11.s -> %x21
+25a98d96 : uqincp x22, p12.s                         : uqincp %x22 %p12.s -> %x22
+25a98db8 : uqincp x24, p13.s                         : uqincp %x24 %p13.s -> %x24
+25a98dda : uqincp x26, p14.s                         : uqincp %x26 %p14.s -> %x26
+25a98dfe : uqincp x30, p15.s                         : uqincp %x30 %p15.s -> %x30
+25e98c00 : uqincp x0, p0.d                           : uqincp %x0 %p0.d -> %x0
+25e98c42 : uqincp x2, p2.d                           : uqincp %x2 %p2.d -> %x2
+25e98c64 : uqincp x4, p3.d                           : uqincp %x4 %p3.d -> %x4
+25e98c86 : uqincp x6, p4.d                           : uqincp %x6 %p4.d -> %x6
+25e98ca8 : uqincp x8, p5.d                           : uqincp %x8 %p5.d -> %x8
+25e98cc9 : uqincp x9, p6.d                           : uqincp %x9 %p6.d -> %x9
+25e98ceb : uqincp x11, p7.d                          : uqincp %x11 %p7.d -> %x11
+25e98d0d : uqincp x13, p8.d                          : uqincp %x13 %p8.d -> %x13
+25e98d2f : uqincp x15, p9.d                          : uqincp %x15 %p9.d -> %x15
+25e98d31 : uqincp x17, p9.d                          : uqincp %x17 %p9.d -> %x17
+25e98d53 : uqincp x19, p10.d                         : uqincp %x19 %p10.d -> %x19
+25e98d75 : uqincp x21, p11.d                         : uqincp %x21 %p11.d -> %x21
+25e98d96 : uqincp x22, p12.d                         : uqincp %x22 %p12.d -> %x22
+25e98db8 : uqincp x24, p13.d                         : uqincp %x24 %p13.d -> %x24
+25e98dda : uqincp x26, p14.d                         : uqincp %x26 %p14.d -> %x26
+25e98dfe : uqincp x30, p15.d                         : uqincp %x30 %p15.d -> %x30
 
 # UQINCP  <Zdn>.<T>, <Pm>.<T> (UQINCP-Z.P.Z-_)
-25698000 : uqincp z0.h, p0                           : uqincp %p0.h %z0.h -> %z0.h
-25698042 : uqincp z2.h, p2                           : uqincp %p2.h %z2.h -> %z2.h
-25698064 : uqincp z4.h, p3                           : uqincp %p3.h %z4.h -> %z4.h
-25698086 : uqincp z6.h, p4                           : uqincp %p4.h %z6.h -> %z6.h
-256980a8 : uqincp z8.h, p5                           : uqincp %p5.h %z8.h -> %z8.h
-256980ca : uqincp z10.h, p6                          : uqincp %p6.h %z10.h -> %z10.h
-256980ec : uqincp z12.h, p7                          : uqincp %p7.h %z12.h -> %z12.h
-2569810e : uqincp z14.h, p8                          : uqincp %p8.h %z14.h -> %z14.h
-25698130 : uqincp z16.h, p9                          : uqincp %p9.h %z16.h -> %z16.h
-25698131 : uqincp z17.h, p9                          : uqincp %p9.h %z17.h -> %z17.h
-25698153 : uqincp z19.h, p10                         : uqincp %p10.h %z19.h -> %z19.h
-25698175 : uqincp z21.h, p11                         : uqincp %p11.h %z21.h -> %z21.h
-25698197 : uqincp z23.h, p12                         : uqincp %p12.h %z23.h -> %z23.h
-256981b9 : uqincp z25.h, p13                         : uqincp %p13.h %z25.h -> %z25.h
-256981db : uqincp z27.h, p14                         : uqincp %p14.h %z27.h -> %z27.h
-256981ff : uqincp z31.h, p15                         : uqincp %p15.h %z31.h -> %z31.h
-25a98000 : uqincp z0.s, p0                           : uqincp %p0.s %z0.s -> %z0.s
-25a98042 : uqincp z2.s, p2                           : uqincp %p2.s %z2.s -> %z2.s
-25a98064 : uqincp z4.s, p3                           : uqincp %p3.s %z4.s -> %z4.s
-25a98086 : uqincp z6.s, p4                           : uqincp %p4.s %z6.s -> %z6.s
-25a980a8 : uqincp z8.s, p5                           : uqincp %p5.s %z8.s -> %z8.s
-25a980ca : uqincp z10.s, p6                          : uqincp %p6.s %z10.s -> %z10.s
-25a980ec : uqincp z12.s, p7                          : uqincp %p7.s %z12.s -> %z12.s
-25a9810e : uqincp z14.s, p8                          : uqincp %p8.s %z14.s -> %z14.s
-25a98130 : uqincp z16.s, p9                          : uqincp %p9.s %z16.s -> %z16.s
-25a98131 : uqincp z17.s, p9                          : uqincp %p9.s %z17.s -> %z17.s
-25a98153 : uqincp z19.s, p10                         : uqincp %p10.s %z19.s -> %z19.s
-25a98175 : uqincp z21.s, p11                         : uqincp %p11.s %z21.s -> %z21.s
-25a98197 : uqincp z23.s, p12                         : uqincp %p12.s %z23.s -> %z23.s
-25a981b9 : uqincp z25.s, p13                         : uqincp %p13.s %z25.s -> %z25.s
-25a981db : uqincp z27.s, p14                         : uqincp %p14.s %z27.s -> %z27.s
-25a981ff : uqincp z31.s, p15                         : uqincp %p15.s %z31.s -> %z31.s
-25e98000 : uqincp z0.d, p0                           : uqincp %p0.d %z0.d -> %z0.d
-25e98042 : uqincp z2.d, p2                           : uqincp %p2.d %z2.d -> %z2.d
-25e98064 : uqincp z4.d, p3                           : uqincp %p3.d %z4.d -> %z4.d
-25e98086 : uqincp z6.d, p4                           : uqincp %p4.d %z6.d -> %z6.d
-25e980a8 : uqincp z8.d, p5                           : uqincp %p5.d %z8.d -> %z8.d
-25e980ca : uqincp z10.d, p6                          : uqincp %p6.d %z10.d -> %z10.d
-25e980ec : uqincp z12.d, p7                          : uqincp %p7.d %z12.d -> %z12.d
-25e9810e : uqincp z14.d, p8                          : uqincp %p8.d %z14.d -> %z14.d
-25e98130 : uqincp z16.d, p9                          : uqincp %p9.d %z16.d -> %z16.d
-25e98131 : uqincp z17.d, p9                          : uqincp %p9.d %z17.d -> %z17.d
-25e98153 : uqincp z19.d, p10                         : uqincp %p10.d %z19.d -> %z19.d
-25e98175 : uqincp z21.d, p11                         : uqincp %p11.d %z21.d -> %z21.d
-25e98197 : uqincp z23.d, p12                         : uqincp %p12.d %z23.d -> %z23.d
-25e981b9 : uqincp z25.d, p13                         : uqincp %p13.d %z25.d -> %z25.d
-25e981db : uqincp z27.d, p14                         : uqincp %p14.d %z27.d -> %z27.d
-25e981ff : uqincp z31.d, p15                         : uqincp %p15.d %z31.d -> %z31.d
+25698000 : uqincp z0.h, p0                           : uqincp %z0.h %p0.h -> %z0.h
+25698042 : uqincp z2.h, p2                           : uqincp %z2.h %p2.h -> %z2.h
+25698064 : uqincp z4.h, p3                           : uqincp %z4.h %p3.h -> %z4.h
+25698086 : uqincp z6.h, p4                           : uqincp %z6.h %p4.h -> %z6.h
+256980a8 : uqincp z8.h, p5                           : uqincp %z8.h %p5.h -> %z8.h
+256980ca : uqincp z10.h, p6                          : uqincp %z10.h %p6.h -> %z10.h
+256980ec : uqincp z12.h, p7                          : uqincp %z12.h %p7.h -> %z12.h
+2569810e : uqincp z14.h, p8                          : uqincp %z14.h %p8.h -> %z14.h
+25698130 : uqincp z16.h, p9                          : uqincp %z16.h %p9.h -> %z16.h
+25698131 : uqincp z17.h, p9                          : uqincp %z17.h %p9.h -> %z17.h
+25698153 : uqincp z19.h, p10                         : uqincp %z19.h %p10.h -> %z19.h
+25698175 : uqincp z21.h, p11                         : uqincp %z21.h %p11.h -> %z21.h
+25698197 : uqincp z23.h, p12                         : uqincp %z23.h %p12.h -> %z23.h
+256981b9 : uqincp z25.h, p13                         : uqincp %z25.h %p13.h -> %z25.h
+256981db : uqincp z27.h, p14                         : uqincp %z27.h %p14.h -> %z27.h
+256981ff : uqincp z31.h, p15                         : uqincp %z31.h %p15.h -> %z31.h
+25a98000 : uqincp z0.s, p0                           : uqincp %z0.s %p0.s -> %z0.s
+25a98042 : uqincp z2.s, p2                           : uqincp %z2.s %p2.s -> %z2.s
+25a98064 : uqincp z4.s, p3                           : uqincp %z4.s %p3.s -> %z4.s
+25a98086 : uqincp z6.s, p4                           : uqincp %z6.s %p4.s -> %z6.s
+25a980a8 : uqincp z8.s, p5                           : uqincp %z8.s %p5.s -> %z8.s
+25a980ca : uqincp z10.s, p6                          : uqincp %z10.s %p6.s -> %z10.s
+25a980ec : uqincp z12.s, p7                          : uqincp %z12.s %p7.s -> %z12.s
+25a9810e : uqincp z14.s, p8                          : uqincp %z14.s %p8.s -> %z14.s
+25a98130 : uqincp z16.s, p9                          : uqincp %z16.s %p9.s -> %z16.s
+25a98131 : uqincp z17.s, p9                          : uqincp %z17.s %p9.s -> %z17.s
+25a98153 : uqincp z19.s, p10                         : uqincp %z19.s %p10.s -> %z19.s
+25a98175 : uqincp z21.s, p11                         : uqincp %z21.s %p11.s -> %z21.s
+25a98197 : uqincp z23.s, p12                         : uqincp %z23.s %p12.s -> %z23.s
+25a981b9 : uqincp z25.s, p13                         : uqincp %z25.s %p13.s -> %z25.s
+25a981db : uqincp z27.s, p14                         : uqincp %z27.s %p14.s -> %z27.s
+25a981ff : uqincp z31.s, p15                         : uqincp %z31.s %p15.s -> %z31.s
+25e98000 : uqincp z0.d, p0                           : uqincp %z0.d %p0.d -> %z0.d
+25e98042 : uqincp z2.d, p2                           : uqincp %z2.d %p2.d -> %z2.d
+25e98064 : uqincp z4.d, p3                           : uqincp %z4.d %p3.d -> %z4.d
+25e98086 : uqincp z6.d, p4                           : uqincp %z6.d %p4.d -> %z6.d
+25e980a8 : uqincp z8.d, p5                           : uqincp %z8.d %p5.d -> %z8.d
+25e980ca : uqincp z10.d, p6                          : uqincp %z10.d %p6.d -> %z10.d
+25e980ec : uqincp z12.d, p7                          : uqincp %z12.d %p7.d -> %z12.d
+25e9810e : uqincp z14.d, p8                          : uqincp %z14.d %p8.d -> %z14.d
+25e98130 : uqincp z16.d, p9                          : uqincp %z16.d %p9.d -> %z16.d
+25e98131 : uqincp z17.d, p9                          : uqincp %z17.d %p9.d -> %z17.d
+25e98153 : uqincp z19.d, p10                         : uqincp %z19.d %p10.d -> %z19.d
+25e98175 : uqincp z21.d, p11                         : uqincp %z21.d %p11.d -> %z21.d
+25e98197 : uqincp z23.d, p12                         : uqincp %z23.d %p12.d -> %z23.d
+25e981b9 : uqincp z25.d, p13                         : uqincp %z25.d %p13.d -> %z25.d
+25e981db : uqincp z27.d, p14                         : uqincp %z27.d %p14.d -> %z27.d
+25e981ff : uqincp z31.d, p15                         : uqincp %z31.d %p15.d -> %z31.d
 
 # UQINCW  <Zdn>.S{, <pattern>{, MUL #<imm>}} (UQINCW-Z.ZS-_)
 04a0c400 : uqincw z0.s, POW2, MUL #1                 : uqincw %z0.s POW2 mul $0x01 -> %z0.s

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -1233,14 +1233,15 @@ TEST_INSTR(ptest_sve_pred)
 
 TEST_INSTR(mad_sve_pred)
 {
+
     /* Testing MAD     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts> */
-    const char *expected_0_0[6] = {
-        "mad    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
-        "mad    %p2/m %z5.b %z7.b %z8.b -> %z5.b",
-        "mad    %p3/m %z10.b %z12.b %z13.b -> %z10.b",
-        "mad    %p5/m %z16.b %z18.b %z19.b -> %z16.b",
-        "mad    %p6/m %z21.b %z23.b %z24.b -> %z21.b",
-        "mad    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
+    const char *const expected_0_0[6] = {
+        "mad    %z0.b %p0/m %z0.b %z0.b -> %z0.b",
+        "mad    %z5.b %p2/m %z7.b %z8.b -> %z5.b",
+        "mad    %z10.b %p3/m %z12.b %z13.b -> %z10.b",
+        "mad    %z16.b %p5/m %z18.b %z19.b -> %z16.b",
+        "mad    %z21.b %p6/m %z23.b %z24.b -> %z21.b",
+        "mad    %z31.b %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -1248,13 +1249,13 @@ TEST_INSTR(mad_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "mad    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
-        "mad    %p2/m %z5.h %z7.h %z8.h -> %z5.h",
-        "mad    %p3/m %z10.h %z12.h %z13.h -> %z10.h",
-        "mad    %p5/m %z16.h %z18.h %z19.h -> %z16.h",
-        "mad    %p6/m %z21.h %z23.h %z24.h -> %z21.h",
-        "mad    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
+    const char *const expected_0_1[6] = {
+        "mad    %z0.h %p0/m %z0.h %z0.h -> %z0.h",
+        "mad    %z5.h %p2/m %z7.h %z8.h -> %z5.h",
+        "mad    %z10.h %p3/m %z12.h %z13.h -> %z10.h",
+        "mad    %z16.h %p5/m %z18.h %z19.h -> %z16.h",
+        "mad    %z21.h %p6/m %z23.h %z24.h -> %z21.h",
+        "mad    %z31.h %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
@@ -1262,13 +1263,13 @@ TEST_INSTR(mad_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "mad    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
-        "mad    %p2/m %z5.s %z7.s %z8.s -> %z5.s",
-        "mad    %p3/m %z10.s %z12.s %z13.s -> %z10.s",
-        "mad    %p5/m %z16.s %z18.s %z19.s -> %z16.s",
-        "mad    %p6/m %z21.s %z23.s %z24.s -> %z21.s",
-        "mad    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
+    const char *const expected_0_2[6] = {
+        "mad    %z0.s %p0/m %z0.s %z0.s -> %z0.s",
+        "mad    %z5.s %p2/m %z7.s %z8.s -> %z5.s",
+        "mad    %z10.s %p3/m %z12.s %z13.s -> %z10.s",
+        "mad    %z16.s %p5/m %z18.s %z19.s -> %z16.s",
+        "mad    %z21.s %p6/m %z23.s %z24.s -> %z21.s",
+        "mad    %z31.s %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
@@ -1276,13 +1277,13 @@ TEST_INSTR(mad_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "mad    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
-        "mad    %p2/m %z5.d %z7.d %z8.d -> %z5.d",
-        "mad    %p3/m %z10.d %z12.d %z13.d -> %z10.d",
-        "mad    %p5/m %z16.d %z18.d %z19.d -> %z16.d",
-        "mad    %p6/m %z21.d %z23.d %z24.d -> %z21.d",
-        "mad    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
+    const char *const expected_0_3[6] = {
+        "mad    %z0.d %p0/m %z0.d %z0.d -> %z0.d",
+        "mad    %z5.d %p2/m %z7.d %z8.d -> %z5.d",
+        "mad    %z10.d %p3/m %z12.d %z13.d -> %z10.d",
+        "mad    %z16.d %p5/m %z18.d %z19.d -> %z16.d",
+        "mad    %z21.d %p6/m %z23.d %z24.d -> %z21.d",
+        "mad    %z31.d %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(mad, mad_sve_pred, 6, expected_0_3[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -1293,14 +1294,15 @@ TEST_INSTR(mad_sve_pred)
 
 TEST_INSTR(mla_sve_pred)
 {
+
     /* Testing MLA     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "mla    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
-        "mla    %p2/m %z7.b %z8.b %z5.b -> %z5.b",
-        "mla    %p3/m %z12.b %z13.b %z10.b -> %z10.b",
-        "mla    %p5/m %z18.b %z19.b %z16.b -> %z16.b",
-        "mla    %p6/m %z23.b %z24.b %z21.b -> %z21.b",
-        "mla    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
+    const char *const expected_0_0[6] = {
+        "mla    %z0.b %p0/m %z0.b %z0.b -> %z0.b",
+        "mla    %z5.b %p2/m %z7.b %z8.b -> %z5.b",
+        "mla    %z10.b %p3/m %z12.b %z13.b -> %z10.b",
+        "mla    %z16.b %p5/m %z18.b %z19.b -> %z16.b",
+        "mla    %z21.b %p6/m %z23.b %z24.b -> %z21.b",
+        "mla    %z31.b %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -1308,13 +1310,13 @@ TEST_INSTR(mla_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "mla    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
-        "mla    %p2/m %z7.h %z8.h %z5.h -> %z5.h",
-        "mla    %p3/m %z12.h %z13.h %z10.h -> %z10.h",
-        "mla    %p5/m %z18.h %z19.h %z16.h -> %z16.h",
-        "mla    %p6/m %z23.h %z24.h %z21.h -> %z21.h",
-        "mla    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
+    const char *const expected_0_1[6] = {
+        "mla    %z0.h %p0/m %z0.h %z0.h -> %z0.h",
+        "mla    %z5.h %p2/m %z7.h %z8.h -> %z5.h",
+        "mla    %z10.h %p3/m %z12.h %z13.h -> %z10.h",
+        "mla    %z16.h %p5/m %z18.h %z19.h -> %z16.h",
+        "mla    %z21.h %p6/m %z23.h %z24.h -> %z21.h",
+        "mla    %z31.h %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
@@ -1322,13 +1324,13 @@ TEST_INSTR(mla_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "mla    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
-        "mla    %p2/m %z7.s %z8.s %z5.s -> %z5.s",
-        "mla    %p3/m %z12.s %z13.s %z10.s -> %z10.s",
-        "mla    %p5/m %z18.s %z19.s %z16.s -> %z16.s",
-        "mla    %p6/m %z23.s %z24.s %z21.s -> %z21.s",
-        "mla    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
+    const char *const expected_0_2[6] = {
+        "mla    %z0.s %p0/m %z0.s %z0.s -> %z0.s",
+        "mla    %z5.s %p2/m %z7.s %z8.s -> %z5.s",
+        "mla    %z10.s %p3/m %z12.s %z13.s -> %z10.s",
+        "mla    %z16.s %p5/m %z18.s %z19.s -> %z16.s",
+        "mla    %z21.s %p6/m %z23.s %z24.s -> %z21.s",
+        "mla    %z31.s %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
@@ -1336,13 +1338,13 @@ TEST_INSTR(mla_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "mla    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
-        "mla    %p2/m %z7.d %z8.d %z5.d -> %z5.d",
-        "mla    %p3/m %z12.d %z13.d %z10.d -> %z10.d",
-        "mla    %p5/m %z18.d %z19.d %z16.d -> %z16.d",
-        "mla    %p6/m %z23.d %z24.d %z21.d -> %z21.d",
-        "mla    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
+    const char *const expected_0_3[6] = {
+        "mla    %z0.d %p0/m %z0.d %z0.d -> %z0.d",
+        "mla    %z5.d %p2/m %z7.d %z8.d -> %z5.d",
+        "mla    %z10.d %p3/m %z12.d %z13.d -> %z10.d",
+        "mla    %z16.d %p5/m %z18.d %z19.d -> %z16.d",
+        "mla    %z21.d %p6/m %z23.d %z24.d -> %z21.d",
+        "mla    %z31.d %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(mla, mla_sve_pred, 6, expected_0_3[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -1353,14 +1355,15 @@ TEST_INSTR(mla_sve_pred)
 
 TEST_INSTR(mls_sve_pred)
 {
+
     /* Testing MLS     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "mls    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
-        "mls    %p2/m %z7.b %z8.b %z5.b -> %z5.b",
-        "mls    %p3/m %z12.b %z13.b %z10.b -> %z10.b",
-        "mls    %p5/m %z18.b %z19.b %z16.b -> %z16.b",
-        "mls    %p6/m %z23.b %z24.b %z21.b -> %z21.b",
-        "mls    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
+    const char *const expected_0_0[6] = {
+        "mls    %z0.b %p0/m %z0.b %z0.b -> %z0.b",
+        "mls    %z5.b %p2/m %z7.b %z8.b -> %z5.b",
+        "mls    %z10.b %p3/m %z12.b %z13.b -> %z10.b",
+        "mls    %z16.b %p5/m %z18.b %z19.b -> %z16.b",
+        "mls    %z21.b %p6/m %z23.b %z24.b -> %z21.b",
+        "mls    %z31.b %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -1368,13 +1371,13 @@ TEST_INSTR(mls_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "mls    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
-        "mls    %p2/m %z7.h %z8.h %z5.h -> %z5.h",
-        "mls    %p3/m %z12.h %z13.h %z10.h -> %z10.h",
-        "mls    %p5/m %z18.h %z19.h %z16.h -> %z16.h",
-        "mls    %p6/m %z23.h %z24.h %z21.h -> %z21.h",
-        "mls    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
+    const char *const expected_0_1[6] = {
+        "mls    %z0.h %p0/m %z0.h %z0.h -> %z0.h",
+        "mls    %z5.h %p2/m %z7.h %z8.h -> %z5.h",
+        "mls    %z10.h %p3/m %z12.h %z13.h -> %z10.h",
+        "mls    %z16.h %p5/m %z18.h %z19.h -> %z16.h",
+        "mls    %z21.h %p6/m %z23.h %z24.h -> %z21.h",
+        "mls    %z31.h %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
@@ -1382,13 +1385,13 @@ TEST_INSTR(mls_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "mls    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
-        "mls    %p2/m %z7.s %z8.s %z5.s -> %z5.s",
-        "mls    %p3/m %z12.s %z13.s %z10.s -> %z10.s",
-        "mls    %p5/m %z18.s %z19.s %z16.s -> %z16.s",
-        "mls    %p6/m %z23.s %z24.s %z21.s -> %z21.s",
-        "mls    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
+    const char *const expected_0_2[6] = {
+        "mls    %z0.s %p0/m %z0.s %z0.s -> %z0.s",
+        "mls    %z5.s %p2/m %z7.s %z8.s -> %z5.s",
+        "mls    %z10.s %p3/m %z12.s %z13.s -> %z10.s",
+        "mls    %z16.s %p5/m %z18.s %z19.s -> %z16.s",
+        "mls    %z21.s %p6/m %z23.s %z24.s -> %z21.s",
+        "mls    %z31.s %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
@@ -1396,13 +1399,13 @@ TEST_INSTR(mls_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "mls    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
-        "mls    %p2/m %z7.d %z8.d %z5.d -> %z5.d",
-        "mls    %p3/m %z12.d %z13.d %z10.d -> %z10.d",
-        "mls    %p5/m %z18.d %z19.d %z16.d -> %z16.d",
-        "mls    %p6/m %z23.d %z24.d %z21.d -> %z21.d",
-        "mls    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
+    const char *const expected_0_3[6] = {
+        "mls    %z0.d %p0/m %z0.d %z0.d -> %z0.d",
+        "mls    %z5.d %p2/m %z7.d %z8.d -> %z5.d",
+        "mls    %z10.d %p3/m %z12.d %z13.d -> %z10.d",
+        "mls    %z16.d %p5/m %z18.d %z19.d -> %z16.d",
+        "mls    %z21.d %p6/m %z23.d %z24.d -> %z21.d",
+        "mls    %z31.d %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(mls, mls_sve_pred, 6, expected_0_3[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -1413,14 +1416,15 @@ TEST_INSTR(mls_sve_pred)
 
 TEST_INSTR(msb_sve_pred)
 {
+
     /* Testing MSB     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts> */
-    const char *expected_0_0[6] = {
-        "msb    %p0/m %z0.b %z0.b %z0.b -> %z0.b",
-        "msb    %p2/m %z5.b %z7.b %z8.b -> %z5.b",
-        "msb    %p3/m %z10.b %z12.b %z13.b -> %z10.b",
-        "msb    %p5/m %z16.b %z18.b %z19.b -> %z16.b",
-        "msb    %p6/m %z21.b %z23.b %z24.b -> %z21.b",
-        "msb    %p7/m %z31.b %z31.b %z31.b -> %z31.b",
+    const char *const expected_0_0[6] = {
+        "msb    %z0.b %p0/m %z0.b %z0.b -> %z0.b",
+        "msb    %z5.b %p2/m %z7.b %z8.b -> %z5.b",
+        "msb    %z10.b %p3/m %z12.b %z13.b -> %z10.b",
+        "msb    %z16.b %p5/m %z18.b %z19.b -> %z16.b",
+        "msb    %z21.b %p6/m %z23.b %z24.b -> %z21.b",
+        "msb    %z31.b %p7/m %z31.b %z31.b -> %z31.b",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -1428,13 +1432,13 @@ TEST_INSTR(msb_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "msb    %p0/m %z0.h %z0.h %z0.h -> %z0.h",
-        "msb    %p2/m %z5.h %z7.h %z8.h -> %z5.h",
-        "msb    %p3/m %z10.h %z12.h %z13.h -> %z10.h",
-        "msb    %p5/m %z16.h %z18.h %z19.h -> %z16.h",
-        "msb    %p6/m %z21.h %z23.h %z24.h -> %z21.h",
-        "msb    %p7/m %z31.h %z31.h %z31.h -> %z31.h",
+    const char *const expected_0_1[6] = {
+        "msb    %z0.h %p0/m %z0.h %z0.h -> %z0.h",
+        "msb    %z5.h %p2/m %z7.h %z8.h -> %z5.h",
+        "msb    %z10.h %p3/m %z12.h %z13.h -> %z10.h",
+        "msb    %z16.h %p5/m %z18.h %z19.h -> %z16.h",
+        "msb    %z21.h %p6/m %z23.h %z24.h -> %z21.h",
+        "msb    %z31.h %p7/m %z31.h %z31.h -> %z31.h",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
@@ -1442,13 +1446,13 @@ TEST_INSTR(msb_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "msb    %p0/m %z0.s %z0.s %z0.s -> %z0.s",
-        "msb    %p2/m %z5.s %z7.s %z8.s -> %z5.s",
-        "msb    %p3/m %z10.s %z12.s %z13.s -> %z10.s",
-        "msb    %p5/m %z16.s %z18.s %z19.s -> %z16.s",
-        "msb    %p6/m %z21.s %z23.s %z24.s -> %z21.s",
-        "msb    %p7/m %z31.s %z31.s %z31.s -> %z31.s",
+    const char *const expected_0_2[6] = {
+        "msb    %z0.s %p0/m %z0.s %z0.s -> %z0.s",
+        "msb    %z5.s %p2/m %z7.s %z8.s -> %z5.s",
+        "msb    %z10.s %p3/m %z12.s %z13.s -> %z10.s",
+        "msb    %z16.s %p5/m %z18.s %z19.s -> %z16.s",
+        "msb    %z21.s %p6/m %z23.s %z24.s -> %z21.s",
+        "msb    %z31.s %p7/m %z31.s %z31.s -> %z31.s",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
@@ -1456,13 +1460,13 @@ TEST_INSTR(msb_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4),
               opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "msb    %p0/m %z0.d %z0.d %z0.d -> %z0.d",
-        "msb    %p2/m %z5.d %z7.d %z8.d -> %z5.d",
-        "msb    %p3/m %z10.d %z12.d %z13.d -> %z10.d",
-        "msb    %p5/m %z16.d %z18.d %z19.d -> %z16.d",
-        "msb    %p6/m %z21.d %z23.d %z24.d -> %z21.d",
-        "msb    %p7/m %z31.d %z31.d %z31.d -> %z31.d",
+    const char *const expected_0_3[6] = {
+        "msb    %z0.d %p0/m %z0.d %z0.d -> %z0.d",
+        "msb    %z5.d %p2/m %z7.d %z8.d -> %z5.d",
+        "msb    %z10.d %p3/m %z12.d %z13.d -> %z10.d",
+        "msb    %z16.d %p5/m %z18.d %z19.d -> %z16.d",
+        "msb    %z21.d %p6/m %z23.d %z24.d -> %z21.d",
+        "msb    %z31.d %p7/m %z31.d %z31.d -> %z31.d",
     };
     TEST_LOOP(msb, msb_sve_pred, 6, expected_0_3[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
@@ -4387,34 +4391,34 @@ TEST_INSTR(decp_sve)
 {
 
     /* Testing DECP    <Xdn>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "decp   %p0.b %x0 -> %x0",    "decp   %p3.b %x5 -> %x5",
-        "decp   %p6.b %x10 -> %x10",  "decp   %p9.b %x15 -> %x15",
-        "decp   %p11.b %x20 -> %x20", "decp   %p15.b %x30 -> %x30",
+    const char *const expected_0_0[6] = {
+        "decp   %x0 %p0.b -> %x0",    "decp   %x5 %p3.b -> %x5",
+        "decp   %x10 %p6.b -> %x10",  "decp   %x15 %p9.b -> %x15",
+        "decp   %x20 %p11.b -> %x20", "decp   %x30 %p15.b -> %x30",
     };
     TEST_LOOP(decp, decp_sve, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "decp   %p0.h %x0 -> %x0",    "decp   %p3.h %x5 -> %x5",
-        "decp   %p6.h %x10 -> %x10",  "decp   %p9.h %x15 -> %x15",
-        "decp   %p11.h %x20 -> %x20", "decp   %p15.h %x30 -> %x30",
+    const char *const expected_0_1[6] = {
+        "decp   %x0 %p0.h -> %x0",    "decp   %x5 %p3.h -> %x5",
+        "decp   %x10 %p6.h -> %x10",  "decp   %x15 %p9.h -> %x15",
+        "decp   %x20 %p11.h -> %x20", "decp   %x30 %p15.h -> %x30",
     };
     TEST_LOOP(decp, decp_sve, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "decp   %p0.s %x0 -> %x0",    "decp   %p3.s %x5 -> %x5",
-        "decp   %p6.s %x10 -> %x10",  "decp   %p9.s %x15 -> %x15",
-        "decp   %p11.s %x20 -> %x20", "decp   %p15.s %x30 -> %x30",
+    const char *const expected_0_2[6] = {
+        "decp   %x0 %p0.s -> %x0",    "decp   %x5 %p3.s -> %x5",
+        "decp   %x10 %p6.s -> %x10",  "decp   %x15 %p9.s -> %x15",
+        "decp   %x20 %p11.s -> %x20", "decp   %x30 %p15.s -> %x30",
     };
     TEST_LOOP(decp, decp_sve, 6, expected_0_2[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "decp   %p0.d %x0 -> %x0",    "decp   %p3.d %x5 -> %x5",
-        "decp   %p6.d %x10 -> %x10",  "decp   %p9.d %x15 -> %x15",
-        "decp   %p11.d %x20 -> %x20", "decp   %p15.d %x30 -> %x30",
+    const char *const expected_0_3[6] = {
+        "decp   %x0 %p0.d -> %x0",    "decp   %x5 %p3.d -> %x5",
+        "decp   %x10 %p6.d -> %x10",  "decp   %x15 %p9.d -> %x15",
+        "decp   %x20 %p11.d -> %x20", "decp   %x30 %p15.d -> %x30",
     };
     TEST_LOOP(decp, decp_sve, 6, expected_0_3[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
@@ -4424,30 +4428,30 @@ TEST_INSTR(decp_sve_vector)
 {
 
     /* Testing DECP    <Zdn>.<Ts>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "decp   %p0.h %z0.h -> %z0.h",    "decp   %p3.h %z5.h -> %z5.h",
-        "decp   %p6.h %z10.h -> %z10.h",  "decp   %p9.h %z16.h -> %z16.h",
-        "decp   %p11.h %z21.h -> %z21.h", "decp   %p15.h %z31.h -> %z31.h",
+    const char *const expected_0_0[6] = {
+        "decp   %z0.h %p0.h -> %z0.h",    "decp   %z5.h %p3.h -> %z5.h",
+        "decp   %z10.h %p6.h -> %z10.h",  "decp   %z16.h %p9.h -> %z16.h",
+        "decp   %z21.h %p11.h -> %z21.h", "decp   %z31.h %p15.h -> %z31.h",
     };
-    TEST_LOOP(decp, decp_sve, 6, expected_0_0[i],
+    TEST_LOOP(decp, decp_sve_vector, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_1[6] = {
-        "decp   %p0.s %z0.s -> %z0.s",    "decp   %p3.s %z5.s -> %z5.s",
-        "decp   %p6.s %z10.s -> %z10.s",  "decp   %p9.s %z16.s -> %z16.s",
-        "decp   %p11.s %z21.s -> %z21.s", "decp   %p15.s %z31.s -> %z31.s",
+    const char *const expected_0_1[6] = {
+        "decp   %z0.s %p0.s -> %z0.s",    "decp   %z5.s %p3.s -> %z5.s",
+        "decp   %z10.s %p6.s -> %z10.s",  "decp   %z16.s %p9.s -> %z16.s",
+        "decp   %z21.s %p11.s -> %z21.s", "decp   %z31.s %p15.s -> %z31.s",
     };
-    TEST_LOOP(decp, decp_sve, 6, expected_0_1[i],
+    TEST_LOOP(decp, decp_sve_vector, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_2[6] = {
-        "decp   %p0.d %z0.d -> %z0.d",    "decp   %p3.d %z5.d -> %z5.d",
-        "decp   %p6.d %z10.d -> %z10.d",  "decp   %p9.d %z16.d -> %z16.d",
-        "decp   %p11.d %z21.d -> %z21.d", "decp   %p15.d %z31.d -> %z31.d",
+    const char *const expected_0_2[6] = {
+        "decp   %z0.d %p0.d -> %z0.d",    "decp   %z5.d %p3.d -> %z5.d",
+        "decp   %z10.d %p6.d -> %z10.d",  "decp   %z16.d %p9.d -> %z16.d",
+        "decp   %z21.d %p11.d -> %z21.d", "decp   %z31.d %p15.d -> %z31.d",
     };
-    TEST_LOOP(decp, decp_sve, 6, expected_0_2[i],
+    TEST_LOOP(decp, decp_sve_vector, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
@@ -4456,34 +4460,34 @@ TEST_INSTR(incp_sve)
 {
 
     /* Testing INCP    <Xdn>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "incp   %p0.b %x0 -> %x0",    "incp   %p3.b %x5 -> %x5",
-        "incp   %p6.b %x10 -> %x10",  "incp   %p9.b %x15 -> %x15",
-        "incp   %p11.b %x20 -> %x20", "incp   %p15.b %x30 -> %x30",
+    const char *const expected_0_0[6] = {
+        "incp   %x0 %p0.b -> %x0",    "incp   %x5 %p3.b -> %x5",
+        "incp   %x10 %p6.b -> %x10",  "incp   %x15 %p9.b -> %x15",
+        "incp   %x20 %p11.b -> %x20", "incp   %x30 %p15.b -> %x30",
     };
     TEST_LOOP(incp, incp_sve, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "incp   %p0.h %x0 -> %x0",    "incp   %p3.h %x5 -> %x5",
-        "incp   %p6.h %x10 -> %x10",  "incp   %p9.h %x15 -> %x15",
-        "incp   %p11.h %x20 -> %x20", "incp   %p15.h %x30 -> %x30",
+    const char *const expected_0_1[6] = {
+        "incp   %x0 %p0.h -> %x0",    "incp   %x5 %p3.h -> %x5",
+        "incp   %x10 %p6.h -> %x10",  "incp   %x15 %p9.h -> %x15",
+        "incp   %x20 %p11.h -> %x20", "incp   %x30 %p15.h -> %x30",
     };
     TEST_LOOP(incp, incp_sve, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "incp   %p0.s %x0 -> %x0",    "incp   %p3.s %x5 -> %x5",
-        "incp   %p6.s %x10 -> %x10",  "incp   %p9.s %x15 -> %x15",
-        "incp   %p11.s %x20 -> %x20", "incp   %p15.s %x30 -> %x30",
+    const char *const expected_0_2[6] = {
+        "incp   %x0 %p0.s -> %x0",    "incp   %x5 %p3.s -> %x5",
+        "incp   %x10 %p6.s -> %x10",  "incp   %x15 %p9.s -> %x15",
+        "incp   %x20 %p11.s -> %x20", "incp   %x30 %p15.s -> %x30",
     };
     TEST_LOOP(incp, incp_sve, 6, expected_0_2[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "incp   %p0.d %x0 -> %x0",    "incp   %p3.d %x5 -> %x5",
-        "incp   %p6.d %x10 -> %x10",  "incp   %p9.d %x15 -> %x15",
-        "incp   %p11.d %x20 -> %x20", "incp   %p15.d %x30 -> %x30",
+    const char *const expected_0_3[6] = {
+        "incp   %x0 %p0.d -> %x0",    "incp   %x5 %p3.d -> %x5",
+        "incp   %x10 %p6.d -> %x10",  "incp   %x15 %p9.d -> %x15",
+        "incp   %x20 %p11.d -> %x20", "incp   %x30 %p15.d -> %x30",
     };
     TEST_LOOP(incp, incp_sve, 6, expected_0_3[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
@@ -4493,30 +4497,30 @@ TEST_INSTR(incp_sve_vector)
 {
 
     /* Testing INCP    <Zdn>.<Ts>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "incp   %p0.h %z0.h -> %z0.h",    "incp   %p3.h %z5.h -> %z5.h",
-        "incp   %p6.h %z10.h -> %z10.h",  "incp   %p9.h %z16.h -> %z16.h",
-        "incp   %p11.h %z21.h -> %z21.h", "incp   %p15.h %z31.h -> %z31.h",
+    const char *const expected_0_0[6] = {
+        "incp   %z0.h %p0.h -> %z0.h",    "incp   %z5.h %p3.h -> %z5.h",
+        "incp   %z10.h %p6.h -> %z10.h",  "incp   %z16.h %p9.h -> %z16.h",
+        "incp   %z21.h %p11.h -> %z21.h", "incp   %z31.h %p15.h -> %z31.h",
     };
-    TEST_LOOP(incp, incp_sve, 6, expected_0_0[i],
+    TEST_LOOP(incp, incp_sve_vector, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_1[6] = {
-        "incp   %p0.s %z0.s -> %z0.s",    "incp   %p3.s %z5.s -> %z5.s",
-        "incp   %p6.s %z10.s -> %z10.s",  "incp   %p9.s %z16.s -> %z16.s",
-        "incp   %p11.s %z21.s -> %z21.s", "incp   %p15.s %z31.s -> %z31.s",
+    const char *const expected_0_1[6] = {
+        "incp   %z0.s %p0.s -> %z0.s",    "incp   %z5.s %p3.s -> %z5.s",
+        "incp   %z10.s %p6.s -> %z10.s",  "incp   %z16.s %p9.s -> %z16.s",
+        "incp   %z21.s %p11.s -> %z21.s", "incp   %z31.s %p15.s -> %z31.s",
     };
-    TEST_LOOP(incp, incp_sve, 6, expected_0_1[i],
+    TEST_LOOP(incp, incp_sve_vector, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_2[6] = {
-        "incp   %p0.d %z0.d -> %z0.d",    "incp   %p3.d %z5.d -> %z5.d",
-        "incp   %p6.d %z10.d -> %z10.d",  "incp   %p9.d %z16.d -> %z16.d",
-        "incp   %p11.d %z21.d -> %z21.d", "incp   %p15.d %z31.d -> %z31.d",
+    const char *const expected_0_2[6] = {
+        "incp   %z0.d %p0.d -> %z0.d",    "incp   %z5.d %p3.d -> %z5.d",
+        "incp   %z10.d %p6.d -> %z10.d",  "incp   %z16.d %p9.d -> %z16.d",
+        "incp   %z21.d %p11.d -> %z21.d", "incp   %z31.d %p15.d -> %z31.d",
     };
-    TEST_LOOP(incp, incp_sve, 6, expected_0_2[i],
+    TEST_LOOP(incp, incp_sve_vector, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
@@ -4524,74 +4528,37 @@ TEST_INSTR(incp_sve_vector)
 TEST_INSTR(sqdecp_sve)
 {
 
-    /* Testing SQDECP  <Xdn>, <Pm>.<Ts>, <Wdn> */
-    const char *expected_0_0[6] = {
-        "sqdecp %p0.b %w0 -> %x0",    "sqdecp %p3.b %w5 -> %x5",
-        "sqdecp %p6.b %w10 -> %x10",  "sqdecp %p9.b %w15 -> %x15",
-        "sqdecp %p11.b %w20 -> %x20", "sqdecp %p15.b %w30 -> %x30",
-    };
-    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_0[i],
-              opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
-
-    const char *expected_0_1[6] = {
-        "sqdecp %p0.h %w0 -> %x0",    "sqdecp %p3.h %w5 -> %x5",
-        "sqdecp %p6.h %w10 -> %x10",  "sqdecp %p9.h %w15 -> %x15",
-        "sqdecp %p11.h %w20 -> %x20", "sqdecp %p15.h %w30 -> %x30",
-    };
-    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_1[i],
-              opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
-
-    const char *expected_0_2[6] = {
-        "sqdecp %p0.s %w0 -> %x0",    "sqdecp %p3.s %w5 -> %x5",
-        "sqdecp %p6.s %w10 -> %x10",  "sqdecp %p9.s %w15 -> %x15",
-        "sqdecp %p11.s %w20 -> %x20", "sqdecp %p15.s %w30 -> %x30",
-    };
-    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_2[i],
-              opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
-
-    const char *expected_0_3[6] = {
-        "sqdecp %p0.d %w0 -> %x0",    "sqdecp %p3.d %w5 -> %x5",
-        "sqdecp %p6.d %w10 -> %x10",  "sqdecp %p9.d %w15 -> %x15",
-        "sqdecp %p11.d %w20 -> %x20", "sqdecp %p15.d %w30 -> %x30",
-    };
-    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_3[i],
-              opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
-
     /* Testing SQDECP  <Xdn>, <Pm>.<Ts> */
-    const char *expected_1_0[6] = {
-        "sqdecp %p0.b %x0 -> %x0",    "sqdecp %p3.b %x5 -> %x5",
-        "sqdecp %p6.b %x10 -> %x10",  "sqdecp %p9.b %x15 -> %x15",
-        "sqdecp %p11.b %x20 -> %x20", "sqdecp %p15.b %x30 -> %x30",
+    const char *const expected_0_0[6] = {
+        "sqdecp %x0 %p0.b -> %x0",    "sqdecp %x5 %p3.b -> %x5",
+        "sqdecp %x10 %p6.b -> %x10",  "sqdecp %x15 %p9.b -> %x15",
+        "sqdecp %x20 %p11.b -> %x20", "sqdecp %x30 %p15.b -> %x30",
     };
-    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_1_1[6] = {
-        "sqdecp %p0.h %x0 -> %x0",    "sqdecp %p3.h %x5 -> %x5",
-        "sqdecp %p6.h %x10 -> %x10",  "sqdecp %p9.h %x15 -> %x15",
-        "sqdecp %p11.h %x20 -> %x20", "sqdecp %p15.h %x30 -> %x30",
+    const char *const expected_0_1[6] = {
+        "sqdecp %x0 %p0.h -> %x0",    "sqdecp %x5 %p3.h -> %x5",
+        "sqdecp %x10 %p6.h -> %x10",  "sqdecp %x15 %p9.h -> %x15",
+        "sqdecp %x20 %p11.h -> %x20", "sqdecp %x30 %p15.h -> %x30",
     };
-    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_1_2[6] = {
-        "sqdecp %p0.s %x0 -> %x0",    "sqdecp %p3.s %x5 -> %x5",
-        "sqdecp %p6.s %x10 -> %x10",  "sqdecp %p9.s %x15 -> %x15",
-        "sqdecp %p11.s %x20 -> %x20", "sqdecp %p15.s %x30 -> %x30",
+    const char *const expected_0_2[6] = {
+        "sqdecp %x0 %p0.s -> %x0",    "sqdecp %x5 %p3.s -> %x5",
+        "sqdecp %x10 %p6.s -> %x10",  "sqdecp %x15 %p9.s -> %x15",
+        "sqdecp %x20 %p11.s -> %x20", "sqdecp %x30 %p15.s -> %x30",
     };
-    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_2[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_1_3[6] = {
-        "sqdecp %p0.d %x0 -> %x0",    "sqdecp %p3.d %x5 -> %x5",
-        "sqdecp %p6.d %x10 -> %x10",  "sqdecp %p9.d %x15 -> %x15",
-        "sqdecp %p11.d %x20 -> %x20", "sqdecp %p15.d %x30 -> %x30",
+    const char *const expected_0_3[6] = {
+        "sqdecp %x0 %p0.d -> %x0",    "sqdecp %x5 %p3.d -> %x5",
+        "sqdecp %x10 %p6.d -> %x10",  "sqdecp %x15 %p9.d -> %x15",
+        "sqdecp %x20 %p11.d -> %x20", "sqdecp %x30 %p15.d -> %x30",
     };
-    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_3[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
 
@@ -4599,30 +4566,30 @@ TEST_INSTR(sqdecp_sve_vector)
 {
 
     /* Testing SQDECP  <Zdn>.<Ts>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "sqdecp %p0.h %z0.h -> %z0.h",    "sqdecp %p3.h %z5.h -> %z5.h",
-        "sqdecp %p6.h %z10.h -> %z10.h",  "sqdecp %p9.h %z16.h -> %z16.h",
-        "sqdecp %p11.h %z21.h -> %z21.h", "sqdecp %p15.h %z31.h -> %z31.h",
+    const char *const expected_0_0[6] = {
+        "sqdecp %z0.h %p0.h -> %z0.h",    "sqdecp %z5.h %p3.h -> %z5.h",
+        "sqdecp %z10.h %p6.h -> %z10.h",  "sqdecp %z16.h %p9.h -> %z16.h",
+        "sqdecp %z21.h %p11.h -> %z21.h", "sqdecp %z31.h %p15.h -> %z31.h",
     };
-    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_0[i],
+    TEST_LOOP(sqdecp, sqdecp_sve_vector, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_1[6] = {
-        "sqdecp %p0.s %z0.s -> %z0.s",    "sqdecp %p3.s %z5.s -> %z5.s",
-        "sqdecp %p6.s %z10.s -> %z10.s",  "sqdecp %p9.s %z16.s -> %z16.s",
-        "sqdecp %p11.s %z21.s -> %z21.s", "sqdecp %p15.s %z31.s -> %z31.s",
+    const char *const expected_0_1[6] = {
+        "sqdecp %z0.s %p0.s -> %z0.s",    "sqdecp %z5.s %p3.s -> %z5.s",
+        "sqdecp %z10.s %p6.s -> %z10.s",  "sqdecp %z16.s %p9.s -> %z16.s",
+        "sqdecp %z21.s %p11.s -> %z21.s", "sqdecp %z31.s %p15.s -> %z31.s",
     };
-    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_1[i],
+    TEST_LOOP(sqdecp, sqdecp_sve_vector, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_2[6] = {
-        "sqdecp %p0.d %z0.d -> %z0.d",    "sqdecp %p3.d %z5.d -> %z5.d",
-        "sqdecp %p6.d %z10.d -> %z10.d",  "sqdecp %p9.d %z16.d -> %z16.d",
-        "sqdecp %p11.d %z21.d -> %z21.d", "sqdecp %p15.d %z31.d -> %z31.d",
+    const char *const expected_0_2[6] = {
+        "sqdecp %z0.d %p0.d -> %z0.d",    "sqdecp %z5.d %p3.d -> %z5.d",
+        "sqdecp %z10.d %p6.d -> %z10.d",  "sqdecp %z16.d %p9.d -> %z16.d",
+        "sqdecp %z21.d %p11.d -> %z21.d", "sqdecp %z31.d %p15.d -> %z31.d",
     };
-    TEST_LOOP(sqdecp, sqdecp_sve, 6, expected_0_2[i],
+    TEST_LOOP(sqdecp, sqdecp_sve_vector, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
@@ -4630,8 +4597,77 @@ TEST_INSTR(sqdecp_sve_vector)
 TEST_INSTR(sqincp_sve)
 {
 
+    /* Testing SQINCP  <Xdn>, <Pm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "sqincp %x0 %p0.b -> %x0",    "sqincp %x5 %p3.b -> %x5",
+        "sqincp %x10 %p6.b -> %x10",  "sqincp %x15 %p9.b -> %x15",
+        "sqincp %x20 %p11.b -> %x20", "sqincp %x30 %p15.b -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_0[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "sqincp %x0 %p0.h -> %x0",    "sqincp %x5 %p3.h -> %x5",
+        "sqincp %x10 %p6.h -> %x10",  "sqincp %x15 %p9.h -> %x15",
+        "sqincp %x20 %p11.h -> %x20", "sqincp %x30 %p15.h -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_1[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "sqincp %x0 %p0.s -> %x0",    "sqincp %x5 %p3.s -> %x5",
+        "sqincp %x10 %p6.s -> %x10",  "sqincp %x15 %p9.s -> %x15",
+        "sqincp %x20 %p11.s -> %x20", "sqincp %x30 %p15.s -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_2[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "sqincp %x0 %p0.d -> %x0",    "sqincp %x5 %p3.d -> %x5",
+        "sqincp %x10 %p6.d -> %x10",  "sqincp %x15 %p9.d -> %x15",
+        "sqincp %x20 %p11.d -> %x20", "sqincp %x30 %p15.d -> %x30",
+    };
+    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_3[i], opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(sqincp_sve_vector)
+{
+
+    /* Testing SQINCP  <Zdn>.<Ts>, <Pm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "sqincp %z0.h %p0.h -> %z0.h",    "sqincp %z5.h %p3.h -> %z5.h",
+        "sqincp %z10.h %p6.h -> %z10.h",  "sqincp %z16.h %p9.h -> %z16.h",
+        "sqincp %z21.h %p11.h -> %z21.h", "sqincp %z31.h %p15.h -> %z31.h",
+    };
+    TEST_LOOP(sqincp, sqincp_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *const expected_0_1[6] = {
+        "sqincp %z0.s %p0.s -> %z0.s",    "sqincp %z5.s %p3.s -> %z5.s",
+        "sqincp %z10.s %p6.s -> %z10.s",  "sqincp %z16.s %p9.s -> %z16.s",
+        "sqincp %z21.s %p11.s -> %z21.s", "sqincp %z31.s %p15.s -> %z31.s",
+    };
+    TEST_LOOP(sqincp, sqincp_sve_vector, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *const expected_0_2[6] = {
+        "sqincp %z0.d %p0.d -> %z0.d",    "sqincp %z5.d %p3.d -> %z5.d",
+        "sqincp %z10.d %p6.d -> %z10.d",  "sqincp %z16.d %p9.d -> %z16.d",
+        "sqincp %z21.d %p11.d -> %z21.d", "sqincp %z31.d %p15.d -> %z31.d",
+    };
+    TEST_LOOP(sqincp, sqincp_sve_vector, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(sqincp_sve_wide)
+{
+
     /* Testing SQINCP  <Xdn>, <Pm>.<Ts>, <Wdn> */
-    const char *expected_0_0[6] = {
+    const char *const expected_0_0[6] = {
         "sqincp %p0.b %w0 -> %x0",    "sqincp %p3.b %w5 -> %x5",
         "sqincp %p6.b %w10 -> %x10",  "sqincp %p9.b %w15 -> %x15",
         "sqincp %p11.b %w20 -> %x20", "sqincp %p15.b %w30 -> %x30",
@@ -4640,7 +4676,7 @@ TEST_INSTR(sqincp_sve)
               opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
+    const char *const expected_0_1[6] = {
         "sqincp %p0.h %w0 -> %x0",    "sqincp %p3.h %w5 -> %x5",
         "sqincp %p6.h %w10 -> %x10",  "sqincp %p9.h %w15 -> %x15",
         "sqincp %p11.h %w20 -> %x20", "sqincp %p15.h %w30 -> %x30",
@@ -4649,7 +4685,7 @@ TEST_INSTR(sqincp_sve)
               opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
+    const char *const expected_0_2[6] = {
         "sqincp %p0.s %w0 -> %x0",    "sqincp %p3.s %w5 -> %x5",
         "sqincp %p6.s %w10 -> %x10",  "sqincp %p9.s %w15 -> %x15",
         "sqincp %p11.s %w20 -> %x20", "sqincp %p15.s %w30 -> %x30",
@@ -4658,7 +4694,7 @@ TEST_INSTR(sqincp_sve)
               opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
+    const char *const expected_0_3[6] = {
         "sqincp %p0.d %w0 -> %x0",    "sqincp %p3.d %w5 -> %x5",
         "sqincp %p6.d %w10 -> %x10",  "sqincp %p9.d %w15 -> %x15",
         "sqincp %p11.d %w20 -> %x20", "sqincp %p15.d %w30 -> %x30",
@@ -4666,138 +4702,73 @@ TEST_INSTR(sqincp_sve)
     TEST_LOOP(sqincp, sqincp_sve_wide, 6, expected_0_3[i],
               opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
-
-    /* Testing SQINCP  <Xdn>, <Pm>.<Ts> */
-    const char *expected_1_0[6] = {
-        "sqincp %p0.b %x0 -> %x0",    "sqincp %p3.b %x5 -> %x5",
-        "sqincp %p6.b %x10 -> %x10",  "sqincp %p9.b %x15 -> %x15",
-        "sqincp %p11.b %x20 -> %x20", "sqincp %p15.b %x30 -> %x30",
-    };
-    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
-
-    const char *expected_1_1[6] = {
-        "sqincp %p0.h %x0 -> %x0",    "sqincp %p3.h %x5 -> %x5",
-        "sqincp %p6.h %x10 -> %x10",  "sqincp %p9.h %x15 -> %x15",
-        "sqincp %p11.h %x20 -> %x20", "sqincp %p15.h %x30 -> %x30",
-    };
-    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
-
-    const char *expected_1_2[6] = {
-        "sqincp %p0.s %x0 -> %x0",    "sqincp %p3.s %x5 -> %x5",
-        "sqincp %p6.s %x10 -> %x10",  "sqincp %p9.s %x15 -> %x15",
-        "sqincp %p11.s %x20 -> %x20", "sqincp %p15.s %x30 -> %x30",
-    };
-    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
-
-    const char *expected_1_3[6] = {
-        "sqincp %p0.d %x0 -> %x0",    "sqincp %p3.d %x5 -> %x5",
-        "sqincp %p6.d %x10 -> %x10",  "sqincp %p9.d %x15 -> %x15",
-        "sqincp %p11.d %x20 -> %x20", "sqincp %p15.d %x30 -> %x30",
-    };
-    TEST_LOOP(sqincp, sqincp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
-}
-
-TEST_INSTR(sqincp_sve_vector)
-{
-
-    /* Testing SQINCP  <Zdn>.<Ts>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "sqincp %p0.h %z0.h -> %z0.h",    "sqincp %p3.h %z5.h -> %z5.h",
-        "sqincp %p6.h %z10.h -> %z10.h",  "sqincp %p9.h %z16.h -> %z16.h",
-        "sqincp %p11.h %z21.h -> %z21.h", "sqincp %p15.h %z31.h -> %z31.h",
-    };
-    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
-
-    const char *expected_0_1[6] = {
-        "sqincp %p0.s %z0.s -> %z0.s",    "sqincp %p3.s %z5.s -> %z5.s",
-        "sqincp %p6.s %z10.s -> %z10.s",  "sqincp %p9.s %z16.s -> %z16.s",
-        "sqincp %p11.s %z21.s -> %z21.s", "sqincp %p15.s %z31.s -> %z31.s",
-    };
-    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_1[i],
-              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
-
-    const char *expected_0_2[6] = {
-        "sqincp %p0.d %z0.d -> %z0.d",    "sqincp %p3.d %z5.d -> %z5.d",
-        "sqincp %p6.d %z10.d -> %z10.d",  "sqincp %p9.d %z16.d -> %z16.d",
-        "sqincp %p11.d %z21.d -> %z21.d", "sqincp %p15.d %z31.d -> %z31.d",
-    };
-    TEST_LOOP(sqincp, sqincp_sve, 6, expected_0_2[i],
-              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
 
 TEST_INSTR(uqdecp_sve)
 {
 
     /* Testing UQDECP  <Wdn>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "uqdecp %p0.b %w0 -> %w0",    "uqdecp %p3.b %w5 -> %w5",
-        "uqdecp %p6.b %w10 -> %w10",  "uqdecp %p9.b %w15 -> %w15",
-        "uqdecp %p11.b %w20 -> %w20", "uqdecp %p15.b %w30 -> %w30",
+    const char *const expected_0_0[6] = {
+        "uqdecp %w0 %p0.b -> %w0",    "uqdecp %w5 %p3.b -> %w5",
+        "uqdecp %w10 %p6.b -> %w10",  "uqdecp %w15 %p9.b -> %w15",
+        "uqdecp %w20 %p11.b -> %w20", "uqdecp %w30 %p15.b -> %w30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_0[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "uqdecp %p0.h %w0 -> %w0",    "uqdecp %p3.h %w5 -> %w5",
-        "uqdecp %p6.h %w10 -> %w10",  "uqdecp %p9.h %w15 -> %w15",
-        "uqdecp %p11.h %w20 -> %w20", "uqdecp %p15.h %w30 -> %w30",
+    const char *const expected_0_1[6] = {
+        "uqdecp %w0 %p0.h -> %w0",    "uqdecp %w5 %p3.h -> %w5",
+        "uqdecp %w10 %p6.h -> %w10",  "uqdecp %w15 %p9.h -> %w15",
+        "uqdecp %w20 %p11.h -> %w20", "uqdecp %w30 %p15.h -> %w30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_1[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "uqdecp %p0.s %w0 -> %w0",    "uqdecp %p3.s %w5 -> %w5",
-        "uqdecp %p6.s %w10 -> %w10",  "uqdecp %p9.s %w15 -> %w15",
-        "uqdecp %p11.s %w20 -> %w20", "uqdecp %p15.s %w30 -> %w30",
+    const char *const expected_0_2[6] = {
+        "uqdecp %w0 %p0.s -> %w0",    "uqdecp %w5 %p3.s -> %w5",
+        "uqdecp %w10 %p6.s -> %w10",  "uqdecp %w15 %p9.s -> %w15",
+        "uqdecp %w20 %p11.s -> %w20", "uqdecp %w30 %p15.s -> %w30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_2[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "uqdecp %p0.d %w0 -> %w0",    "uqdecp %p3.d %w5 -> %w5",
-        "uqdecp %p6.d %w10 -> %w10",  "uqdecp %p9.d %w15 -> %w15",
-        "uqdecp %p11.d %w20 -> %w20", "uqdecp %p15.d %w30 -> %w30",
+    const char *const expected_0_3[6] = {
+        "uqdecp %w0 %p0.d -> %w0",    "uqdecp %w5 %p3.d -> %w5",
+        "uqdecp %w10 %p6.d -> %w10",  "uqdecp %w15 %p9.d -> %w15",
+        "uqdecp %w20 %p11.d -> %w20", "uqdecp %w30 %p15.d -> %w30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_3[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 
     /* Testing UQDECP  <Xdn>, <Pm>.<Ts> */
-    const char *expected_1_0[6] = {
-        "uqdecp %p0.b %x0 -> %x0",    "uqdecp %p3.b %x5 -> %x5",
-        "uqdecp %p6.b %x10 -> %x10",  "uqdecp %p9.b %x15 -> %x15",
-        "uqdecp %p11.b %x20 -> %x20", "uqdecp %p15.b %x30 -> %x30",
+    const char *const expected_1_0[6] = {
+        "uqdecp %x0 %p0.b -> %x0",    "uqdecp %x5 %p3.b -> %x5",
+        "uqdecp %x10 %p6.b -> %x10",  "uqdecp %x15 %p9.b -> %x15",
+        "uqdecp %x20 %p11.b -> %x20", "uqdecp %x30 %p15.b -> %x30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_1_1[6] = {
-        "uqdecp %p0.h %x0 -> %x0",    "uqdecp %p3.h %x5 -> %x5",
-        "uqdecp %p6.h %x10 -> %x10",  "uqdecp %p9.h %x15 -> %x15",
-        "uqdecp %p11.h %x20 -> %x20", "uqdecp %p15.h %x30 -> %x30",
+    const char *const expected_1_1[6] = {
+        "uqdecp %x0 %p0.h -> %x0",    "uqdecp %x5 %p3.h -> %x5",
+        "uqdecp %x10 %p6.h -> %x10",  "uqdecp %x15 %p9.h -> %x15",
+        "uqdecp %x20 %p11.h -> %x20", "uqdecp %x30 %p15.h -> %x30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_1_2[6] = {
-        "uqdecp %p0.s %x0 -> %x0",    "uqdecp %p3.s %x5 -> %x5",
-        "uqdecp %p6.s %x10 -> %x10",  "uqdecp %p9.s %x15 -> %x15",
-        "uqdecp %p11.s %x20 -> %x20", "uqdecp %p15.s %x30 -> %x30",
+    const char *const expected_1_2[6] = {
+        "uqdecp %x0 %p0.s -> %x0",    "uqdecp %x5 %p3.s -> %x5",
+        "uqdecp %x10 %p6.s -> %x10",  "uqdecp %x15 %p9.s -> %x15",
+        "uqdecp %x20 %p11.s -> %x20", "uqdecp %x30 %p15.s -> %x30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_1_3[6] = {
-        "uqdecp %p0.d %x0 -> %x0",    "uqdecp %p3.d %x5 -> %x5",
-        "uqdecp %p6.d %x10 -> %x10",  "uqdecp %p9.d %x15 -> %x15",
-        "uqdecp %p11.d %x20 -> %x20", "uqdecp %p15.d %x30 -> %x30",
+    const char *const expected_1_3[6] = {
+        "uqdecp %x0 %p0.d -> %x0",    "uqdecp %x5 %p3.d -> %x5",
+        "uqdecp %x10 %p6.d -> %x10",  "uqdecp %x15 %p9.d -> %x15",
+        "uqdecp %x20 %p11.d -> %x20", "uqdecp %x30 %p15.d -> %x30",
     };
     TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
@@ -4807,30 +4778,30 @@ TEST_INSTR(uqdecp_sve_vector)
 {
 
     /* Testing UQDECP  <Zdn>.<Ts>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "uqdecp %p0.h %z0.h -> %z0.h",    "uqdecp %p3.h %z5.h -> %z5.h",
-        "uqdecp %p6.h %z10.h -> %z10.h",  "uqdecp %p9.h %z16.h -> %z16.h",
-        "uqdecp %p11.h %z21.h -> %z21.h", "uqdecp %p15.h %z31.h -> %z31.h",
+    const char *const expected_0_0[6] = {
+        "uqdecp %z0.h %p0.h -> %z0.h",    "uqdecp %z5.h %p3.h -> %z5.h",
+        "uqdecp %z10.h %p6.h -> %z10.h",  "uqdecp %z16.h %p9.h -> %z16.h",
+        "uqdecp %z21.h %p11.h -> %z21.h", "uqdecp %z31.h %p15.h -> %z31.h",
     };
-    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_0[i],
+    TEST_LOOP(uqdecp, uqdecp_sve_vector, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_1[6] = {
-        "uqdecp %p0.s %z0.s -> %z0.s",    "uqdecp %p3.s %z5.s -> %z5.s",
-        "uqdecp %p6.s %z10.s -> %z10.s",  "uqdecp %p9.s %z16.s -> %z16.s",
-        "uqdecp %p11.s %z21.s -> %z21.s", "uqdecp %p15.s %z31.s -> %z31.s",
+    const char *const expected_0_1[6] = {
+        "uqdecp %z0.s %p0.s -> %z0.s",    "uqdecp %z5.s %p3.s -> %z5.s",
+        "uqdecp %z10.s %p6.s -> %z10.s",  "uqdecp %z16.s %p9.s -> %z16.s",
+        "uqdecp %z21.s %p11.s -> %z21.s", "uqdecp %z31.s %p15.s -> %z31.s",
     };
-    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_1[i],
+    TEST_LOOP(uqdecp, uqdecp_sve_vector, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_2[6] = {
-        "uqdecp %p0.d %z0.d -> %z0.d",    "uqdecp %p3.d %z5.d -> %z5.d",
-        "uqdecp %p6.d %z10.d -> %z10.d",  "uqdecp %p9.d %z16.d -> %z16.d",
-        "uqdecp %p11.d %z21.d -> %z21.d", "uqdecp %p15.d %z31.d -> %z31.d",
+    const char *const expected_0_2[6] = {
+        "uqdecp %z0.d %p0.d -> %z0.d",    "uqdecp %z5.d %p3.d -> %z5.d",
+        "uqdecp %z10.d %p6.d -> %z10.d",  "uqdecp %z16.d %p9.d -> %z16.d",
+        "uqdecp %z21.d %p11.d -> %z21.d", "uqdecp %z31.d %p15.d -> %z31.d",
     };
-    TEST_LOOP(uqdecp, uqdecp_sve, 6, expected_0_2[i],
+    TEST_LOOP(uqdecp, uqdecp_sve_vector, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
@@ -4839,67 +4810,67 @@ TEST_INSTR(uqincp_sve)
 {
 
     /* Testing UQINCP  <Wdn>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "uqincp %p0.b %w0 -> %w0",    "uqincp %p3.b %w5 -> %w5",
-        "uqincp %p6.b %w10 -> %w10",  "uqincp %p9.b %w15 -> %w15",
-        "uqincp %p11.b %w20 -> %w20", "uqincp %p15.b %w30 -> %w30",
+    const char *const expected_0_0[6] = {
+        "uqincp %w0 %p0.b -> %w0",    "uqincp %w5 %p3.b -> %w5",
+        "uqincp %w10 %p6.b -> %w10",  "uqincp %w15 %p9.b -> %w15",
+        "uqincp %w20 %p11.b -> %w20", "uqincp %w30 %p15.b -> %w30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_0[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_0_1[6] = {
-        "uqincp %p0.h %w0 -> %w0",    "uqincp %p3.h %w5 -> %w5",
-        "uqincp %p6.h %w10 -> %w10",  "uqincp %p9.h %w15 -> %w15",
-        "uqincp %p11.h %w20 -> %w20", "uqincp %p15.h %w30 -> %w30",
+    const char *const expected_0_1[6] = {
+        "uqincp %w0 %p0.h -> %w0",    "uqincp %w5 %p3.h -> %w5",
+        "uqincp %w10 %p6.h -> %w10",  "uqincp %w15 %p9.h -> %w15",
+        "uqincp %w20 %p11.h -> %w20", "uqincp %w30 %p15.h -> %w30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_1[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_2[6] = {
-        "uqincp %p0.s %w0 -> %w0",    "uqincp %p3.s %w5 -> %w5",
-        "uqincp %p6.s %w10 -> %w10",  "uqincp %p9.s %w15 -> %w15",
-        "uqincp %p11.s %w20 -> %w20", "uqincp %p15.s %w30 -> %w30",
+    const char *const expected_0_2[6] = {
+        "uqincp %w0 %p0.s -> %w0",    "uqincp %w5 %p3.s -> %w5",
+        "uqincp %w10 %p6.s -> %w10",  "uqincp %w15 %p9.s -> %w15",
+        "uqincp %w20 %p11.s -> %w20", "uqincp %w30 %p15.s -> %w30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_2[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_3[6] = {
-        "uqincp %p0.d %w0 -> %w0",    "uqincp %p3.d %w5 -> %w5",
-        "uqincp %p6.d %w10 -> %w10",  "uqincp %p9.d %w15 -> %w15",
-        "uqincp %p11.d %w20 -> %w20", "uqincp %p15.d %w30 -> %w30",
+    const char *const expected_0_3[6] = {
+        "uqincp %w0 %p0.d -> %w0",    "uqincp %w5 %p3.d -> %w5",
+        "uqincp %w10 %p6.d -> %w10",  "uqincp %w15 %p9.d -> %w15",
+        "uqincp %w20 %p11.d -> %w20", "uqincp %w30 %p15.d -> %w30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_3[i], opnd_create_reg(Wn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 
     /* Testing UQINCP  <Xdn>, <Pm>.<Ts> */
-    const char *expected_1_0[6] = {
-        "uqincp %p0.b %x0 -> %x0",    "uqincp %p3.b %x5 -> %x5",
-        "uqincp %p6.b %x10 -> %x10",  "uqincp %p9.b %x15 -> %x15",
-        "uqincp %p11.b %x20 -> %x20", "uqincp %p15.b %x30 -> %x30",
+    const char *const expected_1_0[6] = {
+        "uqincp %x0 %p0.b -> %x0",    "uqincp %x5 %p3.b -> %x5",
+        "uqincp %x10 %p6.b -> %x10",  "uqincp %x15 %p9.b -> %x15",
+        "uqincp %x20 %p11.b -> %x20", "uqincp %x30 %p15.b -> %x30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_0[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
 
-    const char *expected_1_1[6] = {
-        "uqincp %p0.h %x0 -> %x0",    "uqincp %p3.h %x5 -> %x5",
-        "uqincp %p6.h %x10 -> %x10",  "uqincp %p9.h %x15 -> %x15",
-        "uqincp %p11.h %x20 -> %x20", "uqincp %p15.h %x30 -> %x30",
+    const char *const expected_1_1[6] = {
+        "uqincp %x0 %p0.h -> %x0",    "uqincp %x5 %p3.h -> %x5",
+        "uqincp %x10 %p6.h -> %x10",  "uqincp %x15 %p9.h -> %x15",
+        "uqincp %x20 %p11.h -> %x20", "uqincp %x30 %p15.h -> %x30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_1[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_1_2[6] = {
-        "uqincp %p0.s %x0 -> %x0",    "uqincp %p3.s %x5 -> %x5",
-        "uqincp %p6.s %x10 -> %x10",  "uqincp %p9.s %x15 -> %x15",
-        "uqincp %p11.s %x20 -> %x20", "uqincp %p15.s %x30 -> %x30",
+    const char *const expected_1_2[6] = {
+        "uqincp %x0 %p0.s -> %x0",    "uqincp %x5 %p3.s -> %x5",
+        "uqincp %x10 %p6.s -> %x10",  "uqincp %x15 %p9.s -> %x15",
+        "uqincp %x20 %p11.s -> %x20", "uqincp %x30 %p15.s -> %x30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_2[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_1_3[6] = {
-        "uqincp %p0.d %x0 -> %x0",    "uqincp %p3.d %x5 -> %x5",
-        "uqincp %p6.d %x10 -> %x10",  "uqincp %p9.d %x15 -> %x15",
-        "uqincp %p11.d %x20 -> %x20", "uqincp %p15.d %x30 -> %x30",
+    const char *const expected_1_3[6] = {
+        "uqincp %x0 %p0.d -> %x0",    "uqincp %x5 %p3.d -> %x5",
+        "uqincp %x10 %p6.d -> %x10",  "uqincp %x15 %p9.d -> %x15",
+        "uqincp %x20 %p11.d -> %x20", "uqincp %x30 %p15.d -> %x30",
     };
     TEST_LOOP(uqincp, uqincp_sve, 6, expected_1_3[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
@@ -4909,30 +4880,30 @@ TEST_INSTR(uqincp_sve_vector)
 {
 
     /* Testing UQINCP  <Zdn>.<Ts>, <Pm>.<Ts> */
-    const char *expected_0_0[6] = {
-        "uqincp %p0.h %z0.h -> %z0.h",    "uqincp %p3.h %z5.h -> %z5.h",
-        "uqincp %p6.h %z10.h -> %z10.h",  "uqincp %p9.h %z16.h -> %z16.h",
-        "uqincp %p11.h %z21.h -> %z21.h", "uqincp %p15.h %z31.h -> %z31.h",
+    const char *const expected_0_0[6] = {
+        "uqincp %z0.h %p0.h -> %z0.h",    "uqincp %z5.h %p3.h -> %z5.h",
+        "uqincp %z10.h %p6.h -> %z10.h",  "uqincp %z16.h %p9.h -> %z16.h",
+        "uqincp %z21.h %p11.h -> %z21.h", "uqincp %z31.h %p15.h -> %z31.h",
     };
-    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_0[i],
+    TEST_LOOP(uqincp, uqincp_sve_vector, 6, expected_0_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
 
-    const char *expected_0_1[6] = {
-        "uqincp %p0.s %z0.s -> %z0.s",    "uqincp %p3.s %z5.s -> %z5.s",
-        "uqincp %p6.s %z10.s -> %z10.s",  "uqincp %p9.s %z16.s -> %z16.s",
-        "uqincp %p11.s %z21.s -> %z21.s", "uqincp %p15.s %z31.s -> %z31.s",
+    const char *const expected_0_1[6] = {
+        "uqincp %z0.s %p0.s -> %z0.s",    "uqincp %z5.s %p3.s -> %z5.s",
+        "uqincp %z10.s %p6.s -> %z10.s",  "uqincp %z16.s %p9.s -> %z16.s",
+        "uqincp %z21.s %p11.s -> %z21.s", "uqincp %z31.s %p15.s -> %z31.s",
     };
-    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_1[i],
+    TEST_LOOP(uqincp, uqincp_sve_vector, 6, expected_0_1[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
 
-    const char *expected_0_2[6] = {
-        "uqincp %p0.d %z0.d -> %z0.d",    "uqincp %p3.d %z5.d -> %z5.d",
-        "uqincp %p6.d %z10.d -> %z10.d",  "uqincp %p9.d %z16.d -> %z16.d",
-        "uqincp %p11.d %z21.d -> %z21.d", "uqincp %p15.d %z31.d -> %z31.d",
+    const char *const expected_0_2[6] = {
+        "uqincp %z0.d %p0.d -> %z0.d",    "uqincp %z5.d %p3.d -> %z5.d",
+        "uqincp %z10.d %p6.d -> %z10.d",  "uqincp %z16.d %p9.d -> %z16.d",
+        "uqincp %z21.d %p11.d -> %z21.d", "uqincp %z31.d %p15.d -> %z31.d",
     };
-    TEST_LOOP(uqincp, uqincp_sve, 6, expected_0_2[i],
+    TEST_LOOP(uqincp, uqincp_sve_vector, 6, expected_0_2[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
 }
@@ -20601,17 +20572,18 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(cntp_sve_pred);
     RUN_INSTR_TEST(decp_sve);
-    RUN_INSTR_TEST(decp_sve);
+    RUN_INSTR_TEST(decp_sve_vector);
     RUN_INSTR_TEST(incp_sve);
-    RUN_INSTR_TEST(incp_sve);
+    RUN_INSTR_TEST(incp_sve_vector);
     RUN_INSTR_TEST(sqdecp_sve);
-    RUN_INSTR_TEST(sqdecp_sve);
+    RUN_INSTR_TEST(sqdecp_sve_vector);
     RUN_INSTR_TEST(sqincp_sve);
-    RUN_INSTR_TEST(sqincp_sve);
+    RUN_INSTR_TEST(sqincp_sve_vector);
+    RUN_INSTR_TEST(sqincp_sve_wide);
     RUN_INSTR_TEST(uqdecp_sve);
-    RUN_INSTR_TEST(uqdecp_sve);
+    RUN_INSTR_TEST(uqdecp_sve_vector);
     RUN_INSTR_TEST(uqincp_sve);
-    RUN_INSTR_TEST(uqincp_sve);
+    RUN_INSTR_TEST(uqincp_sve_vector);
 
     RUN_INSTR_TEST(and_sve_imm);
     RUN_INSTR_TEST(bic_sve_imm);


### PR DESCRIPTION
Several instructions had the predicate decoded into the wrong location in the ir relative to the disassembly. This patch corrects that

This patch fixes the appropriate macros, tests and codec entries to encode the following variants:
```
DECP    <Xdn>, <Pm>.<Ts>
DECP    <Zdn>.<Ts>, <Pm>.<Ts>
INCP    <Xdn>, <Pm>.<Ts>
INCP    <Zdn>.<Ts>, <Pm>.<Ts>
MAD     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts>
MLA     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts>
MLS     <Zda>.<Ts>, <Pg>/M, <Zn>.<Ts>, <Zm>.<Ts>
MSB     <Zdn>.<Ts>, <Pg>/M, <Zm>.<Ts>, <Za>.<Ts>
SQDECP  <Xdn>, <Pm>.<Ts>
SQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
SQINCP  <Xdn>, <Pm>.<Ts>, <Wdn>
SQINCP  <Xdn>, <Pm>.<Ts>
SQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
UQDECP  <Wdn>, <Pm>.<Ts>
UQDECP  <Xdn>, <Pm>.<Ts>
UQDECP  <Zdn>.<Ts>, <Pm>.<Ts>
UQINCP  <Wdn>, <Pm>.<Ts>
UQINCP  <Xdn>, <Pm>.<Ts>
UQINCP  <Zdn>.<Ts>, <Pm>.<Ts>
```

issue: #3044