### PR TITLE
i#5858: Fix drmemtrace docs location in menu

### DIFF
--- a/api/docs/CMakeLists.txt
+++ b/api/docs/CMakeLists.txt
@@ -53,9 +53,7 @@ set(genimg_dirname ${CMAKE_CURRENT_BINARY_DIR}/genimages)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/genimages DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 function (gendox_to_dox gendox_in gendox_out path master_list)
-  file(GLOB dox_glob "${path}/*.dox" "${path}/*.dox.in"
-    # Support docs files another dir deeper.
-    "${path}/*/*.dox" "${path}/*/*.dox.in")
+  file(GLOB_RECURSE dox_glob "${path}/*.dox" "${path}/*.dox.in")
   set(${master_list} ${${master_list}};${dox_files} PARENT_SCOPE)
   foreach (dox_file ${dox_glob})
     file(READ "${dox_file}" dox_string)
@@ -74,8 +72,8 @@ endfunction (gendox_to_dox)
 # we want docs for Extensions (i#277/PR 540817) to be subpages but we
 # don't want to edit a top-level page to add new ones so we generate it
 file(GLOB dox_files *.dox)
-gendox_to_dox("ext" "ext_gendox" "${PROJECT_SOURCE_DIR}/ext/*/" dox_files)
-gendox_to_dox("tool" "tool_gendox" "${PROJECT_SOURCE_DIR}/clients/*/" dox_files)
+gendox_to_dox("ext" "ext_gendox" "${PROJECT_SOURCE_DIR}/ext" dox_files)
+gendox_to_dox("tool" "tool_gendox" "${PROJECT_SOURCE_DIR}/clients" dox_files)
 
 # determine doxygen version
 include(CMake_doxyutils.cmake)

--- a/api/docs/CMakeLists.txt
+++ b/api/docs/CMakeLists.txt
@@ -53,7 +53,9 @@ set(genimg_dirname ${CMAKE_CURRENT_BINARY_DIR}/genimages)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/genimages DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 function (gendox_to_dox gendox_in gendox_out path master_list)
-  file(GLOB dox_glob "${path}/*.dox" "${path}/*.dox.in")
+  file(GLOB dox_glob "${path}/*.dox" "${path}/*.dox.in"
+    # Support docs files another dir deeper.
+    "${path}/*/*.dox" "${path}/*/*.dox.in")
   set(${master_list} ${${master_list}};${dox_files} PARENT_SCOPE)
   foreach (dox_file ${dox_glob})
     file(READ "${dox_file}" dox_string)


### PR DESCRIPTION
The online html docs ended up with the Tracing and Analysis Framework at the top level listed under License, rather than a sub-menu entry of Available Tools, due to PR #5685 which moved drcachesim.dox.in into a docs/ subdir and now the cmake glob doesn't find it.

We fix that by extending the glob.

Tested with a local docs build.

Fixes #5858