### PR TITLE
Rename new aarch64 native Actions worfklow

### DIFF
--- a/.github/workflows/ci-aarch64-native.yml
+++ b/.github/workflows/ci-aarch64-native.yml
@@ -46,7 +46,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Explore-GitHub-Actions:
+  aarch64-native:
     runs-on: [self-hosted, linux, ARM64]
     steps:
       - name: Check out repository code


### PR DESCRIPTION
The new aarch64 Github Actions workflow's official name was "Explore-GitHub-Actions".  We rename it to "aarch64-native" here.