### PR TITLE
removed "docs/" prefix from drmemory.org/docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Tools built on DynamoRIO and available in the [release package](https://dynamori
 - The instruction tracing tool [instrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/instrace_x86.c) ([drmemtrace](https://dynamorio.org/page_drcachesim.html)'s offline traces are faster with more surrounding infrastructure, but this is a simpler starting point for customized instruction tracing)
 - The basic block tracing tool [bbbuf](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/bbbuf.c)
 - The instruction counting tool [inscount](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/inscount.c)
-- The dynamic fuzz testing tool [Dr. Fuzz](http://drmemory.org/docs/page_drfuzz.html)
+- The dynamic fuzz testing tool [Dr. Fuzz](http://drmemory.org/page_drfuzz.html)
 - The disassembly tool [drdisas](https://dynamorio.org/page_drdisas.html)
 - And more, including opcode counts, branch instrumentation, etc.: see \ref API_samples.
 

--- a/api/docs/ext.gendox
+++ b/api/docs/ext.gendox
@@ -55,7 +55,7 @@ REPLACE_WITH_GENDOX_SUBPAGES
 Umbra is a DynamoRIO Extension that provides shadow memory features.  It is
 distributed as part of the Dr. Memory Framework, which is included with
 DynamoRIO versions 5.0.0 and higher.  <a
-href="http://drmemory.org/docs/page_umbra.html">Online documentation is
+href="http://drmemory.org/page_umbra.html">Online documentation is
 available</a>.  If this documentation is part of a DynamoRIO public
 release, <a href="../../drmemory/drmemory/docs/html/page_umbra.html">this
 link</a> should point at the local documentation provided with the release
@@ -68,7 +68,7 @@ Dr. Syscall is a DynamoRIO Extension that provides system call monitoring
 features beyond the basics in the DynamoRIO API itself.  It is distributed
 as part of the Dr. Memory Framework, which is included with DynamoRIO
 versions 5.0.0 and higher.  <a
-href="http://drmemory.org/docs/page_drsyscall.html">Online documentation is
+href="http://drmemory.org/page_drsyscall.html">Online documentation is
 available</a>.  If this documentation is part of a DynamoRIO public
 release, <a href="../../drmemory/drmemory/docs/html/page_drsyscall.html">this
 link</a> should point at the local documentation provided with the release
@@ -81,7 +81,7 @@ package.
 Dr. SymCache is a DynamoRIO Extension that provides caching of symbol
 lookup results.  It is distributed as part of the Dr. Memory Framework,
 which is included with DynamoRIO versions 5.0.0 and higher.  <a
-href="http://drmemory.org/docs/page_drsymcache.html">Online documentation is
+href="http://drmemory.org/page_drsymcache.html">Online documentation is
 available</a>.  If this documentation is part of a DynamoRIO public
 release, <a href="../../drmemory/drmemory/docs/html/page_drsymcache.html">this
 link</a> should point at the local documentation provided with the release

--- a/api/docs/home.dox
+++ b/api/docs/home.dox
@@ -85,7 +85,7 @@ Tools built on DynamoRIO and available in the [release package](@ref page_downlo
 - The instruction tracing tool [instrace](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/instrace_x86.c) ([drmemtrace](@ref page_drcachesim)'s offline traces are faster with more surrounding infrastructure, but this is a simpler starting point for customized instruction tracing)
 - The basic block tracing tool [bbbuf](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/bbbuf.c)
 - The instruction counting tool [inscount](https://github.com/DynamoRIO/dynamorio/blob/master/api/samples/inscount.c)
-- The dynamic fuzz testing tool [Dr. Fuzz](http://drmemory.org/docs/page_drfuzz.html)
+- The dynamic fuzz testing tool [Dr. Fuzz](http://drmemory.org/page_drfuzz.html)
 - The disassembly tool [drdisas](@ref page_drdisas)
 - And more, including opcode counts, branch instrumentation, etc.: see \ref API_samples.
 


### PR DESCRIPTION
Removed "docs/" prefix as was suggested by [derekbruening](https://github.com/derekbruening)
Related  [PR](https://github.com/DynamoRIO/dynamorio.github.io/pull/37)