### PR TITLE
i#3044: AArch64 SVE codec: Add bfcvtnt and sqdecp

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -67,6 +67,7 @@
 00000100xx000100100xxxxxxxxxxxxx  n   900  SVE     asrd  z_tszl8_bhsd_0 : p10_mrg_lo z_tszl8_bhsd_0 tszl8_imm3_5p1
 00000100xx010100100xxxxxxxxxxxxx  n   901  SVE     asrr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 0110010110001010101xxxxxxxxxxxxx  n   953  BF16   bfcvt          z_h_0 : p10_mrg_lo z_s_5
+0110010010001010101xxxxxxxxxxxxx  n   1064 BF16 bfcvtnt   z_msz_bhsd_0 : z_msz_bhsd_0 p10_mrg_lo z_s_5
 01100100011xxxxx100000xxxxxxxxxx  n   954  BF16   bfdot          z_s_0 : z_s_0 z_h_5 z_h_16
 01100100011xxxxx010000xxxxxxxxxx  n   954  BF16   bfdot          z_s_0 : z_s_0 z_h_5 z3_h_16 i2_index_19
 01100100111xxxxx100000xxxxxxxxxx  n   955  BF16 bfmlalb          z_s_0 : z_s_0 z_h_5 z_h_16
@@ -646,6 +647,7 @@
 000001000110xxxx110010xxxxxxxxxx  n   843  SVE   sqdech          z_h_0 : z_h_0 pred_constr mul imm4_16p1
 00100101xx1010101000110xxxxxxxxx  n   824  SVE   sqdecp             x0 : x0 p_size_bhsd_5
 00100101xx1010101000000xxxxxxxxx  n   824  SVE   sqdecp   z_size_hsd_0 : z_size_hsd_0 p_size_hsd_5
+00100101xx1010101000100xxxxxxxxx  n   824  SVE   sqdecp             x0 : p_size_bhsd_5 w0
 000001001010xxxx111110xxxxxxxxxx  n   854  SVE   sqdecw             x0 : w0 pred_constr mul imm4_16p1
 000001001011xxxx111110xxxxxxxxxx  n   854  SVE   sqdecw             x0 : x0 pred_constr mul imm4_16p1
 000001001010xxxx110010xxxxxxxxxx  n   854  SVE   sqdecw          z_s_0 : z_s_0 pred_constr mul imm4_16p1

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -14287,4 +14287,18 @@
 #define INSTR_CREATE_udot_sve_idx(dc, Zda, Zn, Zm, index) \
     instr_create_1dst_4src(dc, OP_udot, Zda, Zda, Zn, Zm, index)
 
+/**
+ * Creates a BFCVTNT instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BFCVTNT <Zd>.H, <Pg>/M, <Zn>.S
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The source and destination vector register, Z (Scalable).
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_bfcvtnt_sve_pred(dc, Zd, Pg, Zn) \
+    instr_create_1dst_3src(dc, OP_bfcvtnt, Zd, Zd, Pg, Zn)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -1307,6 +1307,24 @@
 658abfbb : bfcvt z27.h, p7/M, z29.s                  : bfcvt  %p7/m %z29.s -> %z27.h
 658abfff : bfcvt z31.h, p7/M, z31.s                  : bfcvt  %p7/m %z31.s -> %z31.h
 
+# BFCVTNT <Zd>.H, <Pg>/M, <Zn>.S (BFCVTNT-Z.P.Z-S2BF)
+648aa000 : bfcvtnt z0.h, p0/M, z0.s                  : bfcvtnt %z0.h %p0/m %z0.s -> %z0.h
+648aa482 : bfcvtnt z2.h, p1/M, z4.s                  : bfcvtnt %z2.h %p1/m %z4.s -> %z2.h
+648aa8c4 : bfcvtnt z4.h, p2/M, z6.s                  : bfcvtnt %z4.h %p2/m %z6.s -> %z4.h
+648aa906 : bfcvtnt z6.h, p2/M, z8.s                  : bfcvtnt %z6.h %p2/m %z8.s -> %z6.h
+648aad48 : bfcvtnt z8.h, p3/M, z10.s                 : bfcvtnt %z8.h %p3/m %z10.s -> %z8.h
+648aad8a : bfcvtnt z10.h, p3/M, z12.s                : bfcvtnt %z10.h %p3/m %z12.s -> %z10.h
+648ab1cc : bfcvtnt z12.h, p4/M, z14.s                : bfcvtnt %z12.h %p4/m %z14.s -> %z12.h
+648ab20e : bfcvtnt z14.h, p4/M, z16.s                : bfcvtnt %z14.h %p4/m %z16.s -> %z14.h
+648ab650 : bfcvtnt z16.h, p5/M, z18.s                : bfcvtnt %z16.h %p5/m %z18.s -> %z16.h
+648ab671 : bfcvtnt z17.h, p5/M, z19.s                : bfcvtnt %z17.h %p5/m %z19.s -> %z17.h
+648ab6b3 : bfcvtnt z19.h, p5/M, z21.s                : bfcvtnt %z19.h %p5/m %z21.s -> %z19.h
+648abaf5 : bfcvtnt z21.h, p6/M, z23.s                : bfcvtnt %z21.h %p6/m %z23.s -> %z21.h
+648abb37 : bfcvtnt z23.h, p6/M, z25.s                : bfcvtnt %z23.h %p6/m %z25.s -> %z23.h
+648abf79 : bfcvtnt z25.h, p7/M, z27.s                : bfcvtnt %z25.h %p7/m %z27.s -> %z25.h
+648abfbb : bfcvtnt z27.h, p7/M, z29.s                : bfcvtnt %z27.h %p7/m %z29.s -> %z27.h
+648abfff : bfcvtnt z31.h, p7/M, z31.s                : bfcvtnt %z31.h %p7/m %z31.s -> %z31.h
+
 # BFDOT   <Zda>.S, <Zn>.H, <Zm>.H[<imm>] (BFDOT-Z.ZZZi-_)
 64604000 : bfdot z0.s, z0.h, z0.h[0]                 : bfdot  %z0.s %z0.h %z0.h $0x00 -> %z0.s
 64624062 : bfdot z2.s, z3.h, z2.h[0]                 : bfdot  %z2.s %z3.h %z2.h $0x00 -> %z2.s
@@ -19880,6 +19898,72 @@ c51fffef : prfw 15, p7, [z31.d, #124]                : prfw   $0x0f %p7 +0x7c(%z
 047efbbb : sqdech x27, MUL4, MUL #15                 : sqdech %x27 MUL4 mul $0x0f -> %x27
 047efbdc : sqdech x28, MUL3, MUL #15                 : sqdech %x28 MUL3 mul $0x0f -> %x28
 047ffbfe : sqdech x30, ALL, MUL #16                  : sqdech %x30 ALL mul $0x10 -> %x30
+
+# SQDECP  <Xdn>, <Pm>.<T>, <Wdn> (SQDECP-R.P.R-SX)
+252a8800 : sqdecp x0, p0.b, w0                       : sqdecp %p0.b %w0 -> %x0
+252a8842 : sqdecp x2, p2.b, w2                       : sqdecp %p2.b %w2 -> %x2
+252a8864 : sqdecp x4, p3.b, w4                       : sqdecp %p3.b %w4 -> %x4
+252a8886 : sqdecp x6, p4.b, w6                       : sqdecp %p4.b %w6 -> %x6
+252a88a8 : sqdecp x8, p5.b, w8                       : sqdecp %p5.b %w8 -> %x8
+252a88c9 : sqdecp x9, p6.b, w9                       : sqdecp %p6.b %w9 -> %x9
+252a88eb : sqdecp x11, p7.b, w11                     : sqdecp %p7.b %w11 -> %x11
+252a890d : sqdecp x13, p8.b, w13                     : sqdecp %p8.b %w13 -> %x13
+252a892f : sqdecp x15, p9.b, w15                     : sqdecp %p9.b %w15 -> %x15
+252a8931 : sqdecp x17, p9.b, w17                     : sqdecp %p9.b %w17 -> %x17
+252a8953 : sqdecp x19, p10.b, w19                    : sqdecp %p10.b %w19 -> %x19
+252a8975 : sqdecp x21, p11.b, w21                    : sqdecp %p11.b %w21 -> %x21
+252a8996 : sqdecp x22, p12.b, w22                    : sqdecp %p12.b %w22 -> %x22
+252a89b8 : sqdecp x24, p13.b, w24                    : sqdecp %p13.b %w24 -> %x24
+252a89da : sqdecp x26, p14.b, w26                    : sqdecp %p14.b %w26 -> %x26
+252a89fe : sqdecp x30, p15.b, w30                    : sqdecp %p15.b %w30 -> %x30
+256a8800 : sqdecp x0, p0.h, w0                       : sqdecp %p0.h %w0 -> %x0
+256a8842 : sqdecp x2, p2.h, w2                       : sqdecp %p2.h %w2 -> %x2
+256a8864 : sqdecp x4, p3.h, w4                       : sqdecp %p3.h %w4 -> %x4
+256a8886 : sqdecp x6, p4.h, w6                       : sqdecp %p4.h %w6 -> %x6
+256a88a8 : sqdecp x8, p5.h, w8                       : sqdecp %p5.h %w8 -> %x8
+256a88c9 : sqdecp x9, p6.h, w9                       : sqdecp %p6.h %w9 -> %x9
+256a88eb : sqdecp x11, p7.h, w11                     : sqdecp %p7.h %w11 -> %x11
+256a890d : sqdecp x13, p8.h, w13                     : sqdecp %p8.h %w13 -> %x13
+256a892f : sqdecp x15, p9.h, w15                     : sqdecp %p9.h %w15 -> %x15
+256a8931 : sqdecp x17, p9.h, w17                     : sqdecp %p9.h %w17 -> %x17
+256a8953 : sqdecp x19, p10.h, w19                    : sqdecp %p10.h %w19 -> %x19
+256a8975 : sqdecp x21, p11.h, w21                    : sqdecp %p11.h %w21 -> %x21
+256a8996 : sqdecp x22, p12.h, w22                    : sqdecp %p12.h %w22 -> %x22
+256a89b8 : sqdecp x24, p13.h, w24                    : sqdecp %p13.h %w24 -> %x24
+256a89da : sqdecp x26, p14.h, w26                    : sqdecp %p14.h %w26 -> %x26
+256a89fe : sqdecp x30, p15.h, w30                    : sqdecp %p15.h %w30 -> %x30
+25aa8800 : sqdecp x0, p0.s, w0                       : sqdecp %p0.s %w0 -> %x0
+25aa8842 : sqdecp x2, p2.s, w2                       : sqdecp %p2.s %w2 -> %x2
+25aa8864 : sqdecp x4, p3.s, w4                       : sqdecp %p3.s %w4 -> %x4
+25aa8886 : sqdecp x6, p4.s, w6                       : sqdecp %p4.s %w6 -> %x6
+25aa88a8 : sqdecp x8, p5.s, w8                       : sqdecp %p5.s %w8 -> %x8
+25aa88c9 : sqdecp x9, p6.s, w9                       : sqdecp %p6.s %w9 -> %x9
+25aa88eb : sqdecp x11, p7.s, w11                     : sqdecp %p7.s %w11 -> %x11
+25aa890d : sqdecp x13, p8.s, w13                     : sqdecp %p8.s %w13 -> %x13
+25aa892f : sqdecp x15, p9.s, w15                     : sqdecp %p9.s %w15 -> %x15
+25aa8931 : sqdecp x17, p9.s, w17                     : sqdecp %p9.s %w17 -> %x17
+25aa8953 : sqdecp x19, p10.s, w19                    : sqdecp %p10.s %w19 -> %x19
+25aa8975 : sqdecp x21, p11.s, w21                    : sqdecp %p11.s %w21 -> %x21
+25aa8996 : sqdecp x22, p12.s, w22                    : sqdecp %p12.s %w22 -> %x22
+25aa89b8 : sqdecp x24, p13.s, w24                    : sqdecp %p13.s %w24 -> %x24
+25aa89da : sqdecp x26, p14.s, w26                    : sqdecp %p14.s %w26 -> %x26
+25aa89fe : sqdecp x30, p15.s, w30                    : sqdecp %p15.s %w30 -> %x30
+25ea8800 : sqdecp x0, p0.d, w0                       : sqdecp %p0.d %w0 -> %x0
+25ea8842 : sqdecp x2, p2.d, w2                       : sqdecp %p2.d %w2 -> %x2
+25ea8864 : sqdecp x4, p3.d, w4                       : sqdecp %p3.d %w4 -> %x4
+25ea8886 : sqdecp x6, p4.d, w6                       : sqdecp %p4.d %w6 -> %x6
+25ea88a8 : sqdecp x8, p5.d, w8                       : sqdecp %p5.d %w8 -> %x8
+25ea88c9 : sqdecp x9, p6.d, w9                       : sqdecp %p6.d %w9 -> %x9
+25ea88eb : sqdecp x11, p7.d, w11                     : sqdecp %p7.d %w11 -> %x11
+25ea890d : sqdecp x13, p8.d, w13                     : sqdecp %p8.d %w13 -> %x13
+25ea892f : sqdecp x15, p9.d, w15                     : sqdecp %p9.d %w15 -> %x15
+25ea8931 : sqdecp x17, p9.d, w17                     : sqdecp %p9.d %w17 -> %x17
+25ea8953 : sqdecp x19, p10.d, w19                    : sqdecp %p10.d %w19 -> %x19
+25ea8975 : sqdecp x21, p11.d, w21                    : sqdecp %p11.d %w21 -> %x21
+25ea8996 : sqdecp x22, p12.d, w22                    : sqdecp %p12.d %w22 -> %x22
+25ea89b8 : sqdecp x24, p13.d, w24                    : sqdecp %p13.d %w24 -> %x24
+25ea89da : sqdecp x26, p14.d, w26                    : sqdecp %p14.d %w26 -> %x26
+25ea89fe : sqdecp x30, p15.d, w30                    : sqdecp %p15.d %w30 -> %x30
 
 # SQDECP  <Xdn>, <Pm>.<T> (SQDECP-R.P.R-X)
 252a8c00 : sqdecp x0, p0.b                           : sqdecp %x0 %p0.b -> %x0

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -20450,6 +20450,61 @@ TEST_INSTR(orr_sve_pred)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
+TEST_INSTR(sqdecp_sve_wide)
+{
+
+    /* Testing SQDECP  <Xdn>, <Pm>.<Ts>, <Wdn> */
+    const char *const expected_0_0[6] = {
+        "sqdecp %p0.b %w0 -> %x0",    "sqdecp %p3.b %w5 -> %x5",
+        "sqdecp %p6.b %w10 -> %x10",  "sqdecp %p9.b %w15 -> %x15",
+        "sqdecp %p11.b %w20 -> %x20", "sqdecp %p15.b %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_0[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "sqdecp %p0.h %w0 -> %x0",    "sqdecp %p3.h %w5 -> %x5",
+        "sqdecp %p6.h %w10 -> %x10",  "sqdecp %p9.h %w15 -> %x15",
+        "sqdecp %p11.h %w20 -> %x20", "sqdecp %p15.h %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_1[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_2));
+
+    const char *const expected_0_2[6] = {
+        "sqdecp %p0.s %w0 -> %x0",    "sqdecp %p3.s %w5 -> %x5",
+        "sqdecp %p6.s %w10 -> %x10",  "sqdecp %p9.s %w15 -> %x15",
+        "sqdecp %p11.s %w20 -> %x20", "sqdecp %p15.s %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_2[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_4));
+
+    const char *const expected_0_3[6] = {
+        "sqdecp %p0.d %w0 -> %x0",    "sqdecp %p3.d %w5 -> %x5",
+        "sqdecp %p6.d %w10 -> %x10",  "sqdecp %p9.d %w15 -> %x15",
+        "sqdecp %p11.d %w20 -> %x20", "sqdecp %p15.d %w30 -> %x30",
+    };
+    TEST_LOOP(sqdecp, sqdecp_sve_wide, 6, expected_0_3[i],
+              opnd_create_reg(Xn_six_offset_0[i]),
+              opnd_create_reg_element_vector(Pn_six_offset_1[i], OPSZ_8));
+}
+
+TEST_INSTR(bfcvtnt_sve_pred)
+{
+
+    /* Testing BFCVTNT <Zd>.H, <Pg>/M, <Zn>.S */
+    const char *const expected_0_0[6] = {
+        "bfcvtnt %z0.h %p0/m %z0.s -> %z0.h",    "bfcvtnt %z5.h %p2/m %z7.s -> %z5.h",
+        "bfcvtnt %z10.h %p3/m %z12.s -> %z10.h", "bfcvtnt %z16.h %p5/m %z18.s -> %z16.h",
+        "bfcvtnt %z21.h %p6/m %z23.s -> %z21.h", "bfcvtnt %z31.h %p7/m %z31.s -> %z31.h",
+    };
+    TEST_LOOP(bfcvtnt, bfcvtnt_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+}
 int
 main(int argc, char *argv[])
 {
@@ -20966,6 +21021,10 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(bic_sve_pred);
     RUN_INSTR_TEST(eor_sve_pred);
     RUN_INSTR_TEST(orr_sve_pred);
+
+    RUN_INSTR_TEST(sqdecp_sve_wide);
+
+    RUN_INSTR_TEST(bfcvtnt_sve_pred);
 
     print("All sve tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
BFCVTNT <Zd>.H, <Pg>/M, <Zn>.S
SQDECP  <Xdn>, <Pm>.<Ts>, <Wdn>
```

issue: #3044