### PR TITLE
i#5505 kernel trace: Add drir2trace to convert DR's IR to trace entries

### DIFF
--- a/clients/drcachesim/drpt2trace/CMakeLists.txt
+++ b/clients/drcachesim/drpt2trace/CMakeLists.txt
@@ -42,10 +42,10 @@ include_directories(
   ${PROJECT_BINARY_DIR}/third_party/include/libipt
 )
 
-# drpt2ir don't include configure.h so they don't get DR defines
+# drpt2ir don't include configure.h so they don't get DR defines.
 add_dr_defines()
 
-# We build drpt2ir to a static library. So we can link it in the independent
+# We build drpt2ir and drir2trace as static libraries so we can link it in the independent
 # clients drpt2trace and drraw2trace.
 set(drpt2ir_srcs
   pt2ir.cpp
@@ -58,7 +58,17 @@ target_link_libraries(drpt2ir ipt ipt-sb)
 install_client_nonDR_header(drmemtrace elf_loader.h)
 install_client_nonDR_header(drmemtrace pt2ir.h)
 
+set(drir2trace_srcs
+  ir2trace.cpp
+)
+add_library(drir2trace STATIC ${drir2trace_srcs})
+configure_DynamoRIO_decoder(drir2trace)
+add_dependencies(drir2trace api_headers)
+install_client_nonDR_header(drmemtrace ir2trace.h)
+
 include_directories(${PROJECT_BINARY_DIR}/clients/include/drmemtrace)
+# drpt2trace is a client that uses drpt2ir and drir2trace to convert PT data to trace
+# entries.
 set(drpt2trace_srcs
   drpt2trace.cpp
 )
@@ -66,10 +76,10 @@ add_definitions(-DBUILD_PT_TRACER)
 add_executable(drpt2trace ${drpt2trace_srcs})
 configure_DynamoRIO_standalone(drpt2trace)
 use_DynamoRIO_extension(drpt2trace droption)
-add_dependencies(drpt2trace drpt2ir ipt)
+add_dependencies(drpt2trace ipt drpt2ir drir2trace)
 # Add the directory containing libipt.so and libipt-sb.so to the linker search path.
 set(libipt_install_dir "${PROJECT_BINARY_DIR}/third_party/${INSTALL_LIB}")
 SET(CMAKE_EXE_LINKER_FLAGS
   "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath='${libipt_install_dir}'"
 )
-target_link_libraries(drpt2trace drpt2ir ipt)
+target_link_libraries(drpt2trace ipt drpt2ir drir2trace)

--- a/clients/drcachesim/drpt2trace/ir2trace.cpp
+++ b/clients/drcachesim/drpt2trace/ir2trace.cpp
@@ -1,0 +1,76 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "ir2trace.h"
+#include "dr_api.h"
+
+ir2trace_convert_status_t
+ir2trace_t::convert(IN drir_t &drir, OUT std::vector<trace_entry_t> &trace)
+{
+    if (drir.get_ilist() == NULL) {
+        return IR2TRACE_CONV_ERROR_INVALID_PARAMETER;
+    }
+    instr_t *instr = instrlist_first(drir.get_ilist());
+    while (instr != NULL) {
+        trace_entry_t entry = {};
+
+        /* Obtain the specific type of instruction. */
+        entry.type = TRACE_TYPE_INSTR;
+        if (instr_opcode_valid(instr)) {
+            if (instr_is_call_direct(instr)) {
+                entry.type = TRACE_TYPE_INSTR_DIRECT_CALL;
+            } else if (instr_is_call_indirect(instr)) {
+                entry.type = TRACE_TYPE_INSTR_INDIRECT_CALL;
+            } else if (instr_is_return(instr)) {
+                entry.type = TRACE_TYPE_INSTR_RETURN;
+            } else if (instr_is_ubr(instr)) {
+                entry.type = TRACE_TYPE_INSTR_DIRECT_JUMP;
+            } else if (instr_is_mbr(instr)) {
+                entry.type = TRACE_TYPE_INSTR_INDIRECT_JUMP;
+            } else if (instr_is_cbr(instr)) {
+                entry.type = TRACE_TYPE_INSTR_CONDITIONAL_JUMP;
+            } else if (instr_get_opcode(instr) == OP_sysenter) {
+                entry.type = TRACE_TYPE_INSTR_SYSENTER;
+            } else if (instr_is_rep_string_op(instr)) {
+                entry.type = TRACE_TYPE_INSTR_MAYBE_FETCH;
+            }
+        }
+
+        entry.size = instr_length(GLOBAL_DCONTEXT, instr);
+        entry.addr = (uintptr_t)instr_get_app_pc(instr);
+
+        trace.push_back(entry);
+
+        instr = instr_get_next(instr);
+    }
+    return IR2TRACE_CONV_SUCCESS;
+}

--- a/clients/drcachesim/drpt2trace/ir2trace.cpp
+++ b/clients/drcachesim/drpt2trace/ir2trace.cpp
@@ -30,8 +30,11 @@
  * DAMAGE.
  */
 
+#include "../common/utils.h"
 #include "ir2trace.h"
 #include "dr_api.h"
+
+#define ERRMSG_HEADER "[drpt2ir] "
 
 ir2trace_convert_status_t
 ir2trace_t::convert(IN drir_t &drir, OUT std::vector<trace_entry_t> &trace)
@@ -43,7 +46,12 @@ ir2trace_t::convert(IN drir_t &drir, OUT std::vector<trace_entry_t> &trace)
     while (instr != NULL) {
         trace_entry_t entry = {};
 
-        /* Obtain the specific type of instruction. */
+        /* Obtain the specific type of instruction.
+         * TODO i#5505: The following code shares similarities with
+         * instru_t::instr_to_instr_type(). After successfully linking the drir2trace
+         * library to raw2trace, the redundancy should be eliminated by removing the
+         * subsequent code.
+         */
         entry.type = TRACE_TYPE_INSTR;
         if (instr_opcode_valid(instr)) {
             if (instr_is_call_direct(instr)) {
@@ -63,6 +71,10 @@ ir2trace_t::convert(IN drir_t &drir, OUT std::vector<trace_entry_t> &trace)
             } else if (instr_is_rep_string_op(instr)) {
                 entry.type = TRACE_TYPE_INSTR_MAYBE_FETCH;
             }
+        } else {
+#ifdef DEBUG
+            ERRMSG(ERRMSG_HEADER "Try to convert an invalid instruction.\n");
+#endif
         }
 
         entry.size = instr_length(GLOBAL_DCONTEXT, instr);

--- a/clients/drcachesim/drpt2trace/ir2trace.h
+++ b/clients/drcachesim/drpt2trace/ir2trace.h
@@ -65,6 +65,9 @@ enum ir2trace_convert_status_t {
     IR2TRACE_CONV_ERROR_INVALID_PARAMETER
 };
 
+/**
+ * ir2trace_t is a class that can convert DynamoRIO's IR format to trace entries.
+ */
 class ir2trace_t {
 public:
     ir2trace_t()

--- a/clients/drcachesim/drpt2trace/ir2trace.h
+++ b/clients/drcachesim/drpt2trace/ir2trace.h
@@ -1,0 +1,89 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* ir2trace: convert DynamoRIO's IR format to trace entries. */
+
+#ifndef _IR2TRACE_H_
+#define _IR2TRACE_H_ 1
+
+/**
+ * @file ir2trace.h
+ * @brief Offline DynamoRIO's IR converter. Converts DynamoRIO's IR format to trace
+ * entries.
+ */
+
+#include <vector>
+#include "drir.h"
+#include "../common/trace_entry.h"
+
+#ifndef IN
+#    define IN // nothing
+#endif
+#ifndef OUT
+#    define OUT // nothing
+#endif
+#ifndef INOUT
+#    define INOUT // nothing
+#endif
+
+/**
+ * The type of ir2trace_t::convert() return value.
+ */
+enum ir2trace_convert_status_t {
+    /** The conversion process succeeded. */
+    IR2TRACE_CONV_SUCCESS = 0,
+    /** The conversion process failed: invalid parameter. */
+    IR2TRACE_CONV_ERROR_INVALID_PARAMETER
+};
+
+class ir2trace_t {
+public:
+    ir2trace_t()
+    {
+    }
+    ~ir2trace_t()
+    {
+    }
+
+    /**
+     * Converts DynamoRIO's IR format to trace entries.
+     * \param[in] drir DynamoRIO's IR format.
+     * \param[out] trace The converted trace entries.
+     * \return ir2trace_convert_status_t If the conversion is successful, the function
+     * returns #IR2TRACE_CONV_SUCCESS. Otherwise, the function returns the corresponding
+     * error code.
+     */
+    static ir2trace_convert_status_t
+    convert(IN drir_t &drir, OUT std::vector<trace_entry_t> &trace);
+};
+
+#endif /* _IR2TRACE_H_ */

--- a/clients/drcachesim/drpt2trace/test_simple.expect
+++ b/clients/drcachesim/drpt2trace/test_simple.expect
@@ -11,3 +11,4 @@ TAG  0x0000000000000000
 END 0x0000000000000000
 
 Number of Instructions: 8
+Number of Trace Entries: 8

--- a/clients/drcachesim/tests/offline-kernel-simple.templatex
+++ b/clients/drcachesim/tests/offline-kernel-simple.templatex
@@ -1,2 +1,3 @@
 Hello, world!
 (.*\n)*Number of Instructions: *[1-9][0-9]*
+(.*\n)*Number of Trace Entries: *[1-9][0-9]*


### PR DESCRIPTION
Adds a new library drir2trace and updates drpt2trace

(1) Adds a new library drir2trace to convert DR's IR to trace entries.
This library converts DynamoRIO's Intermediate Representation (DR's IR) into trace entries. Currently, the library focuses on converting DR's IR format into trace_entry_t instances specific to instruction types.

(2)Updates drpt2trace to support converting Intel PT raw data to trace entries.
drpt2trace is updated to facilitate the conversion of Intel PT raw data into trace entries. It accomplishes this by initially transforming the Intel PT raw data into DR's IR, which is subsequently converted into trace entries using the newly introduced drir2trace library.

Issue: #5505

