### PR TITLE
i#3544 RV64: Implemented dr_call_on_clean_stack

### DIFF
--- a/core/arch/riscv64/riscv64.asm
+++ b/core/arch/riscv64/riscv64.asm
@@ -129,8 +129,8 @@ GLOBAL_LABEL(dr_call_on_clean_stack:)
         mv       ARG4, ARG6          /* void *arg4 */
         mv       ARG5, ARG7          /* void *arg5 */
         mv       ARG6, ARG8          /* void *arg6 */
-        ld       ARG7, 0(s0)         /* void *arg7, retrived from the stack */
-        ld       ARG8, ARG_SZ(s0)    /* void *arg8, retrived from the stack */
+        ld       ARG7, 2*ARG_SZ(s0)  /* void *arg7, retrived from the stack */
+        ld       ARG8, 3*ARG_SZ(s0)  /* void *arg8, retrived from the stack */
         jalr     ra
         /* Swap stacks. */
         mv       sp, s0

--- a/core/arch/riscv64/riscv64.asm
+++ b/core/arch/riscv64/riscv64.asm
@@ -40,6 +40,11 @@ START_FILE
 # error Non-Linux is not supported
 #endif
 
+/* offsetof(dcontext_t, dstack) */
+#define dstack_OFFSET     0x458
+/* offsetof(dcontext_t, is_exiting) */
+#define is_exiting_OFFSET (dstack_OFFSET+1*ARG_SZ)
+
 #ifndef RISCV64
 # error RISCV64 must be defined
 #endif
@@ -110,7 +115,28 @@ call_dispatch_alt_stack_no_free:
  */
         DECLARE_EXPORTED_FUNC(dr_call_on_clean_stack)
 GLOBAL_LABEL(dr_call_on_clean_stack:)
-/* FIXME i#3544: Not implemented */
+        addi    sp, sp, -16
+        sd      ra, 8(sp)   /* Save link register. */
+        sd      s0, 0(sp)
+        mv      s0, sp      /* Save sp across the call. */
+        /* Swap stacks. */
+        ld      sp, dstack_OFFSET(ARG1)
+        /* Set up args. */
+        mv      ra,   ARG2 /* void *(*func)(arg1...arg8) */
+        mv      ARG1, ARG3          /* void *arg1 */
+        mv      ARG2, ARG4          /* void *arg2 */
+        mv      ARG3, ARG5          /* void *arg3 */
+        mv      ARG4, ARG6          /* void *arg4 */
+        mv      ARG5, ARG7          /* void *arg5 */
+        mv      ARG6, ARG8          /* void *arg6 */
+        ld      ARG7, 0(s0)         /* void *arg7, retrived from the stack */
+        ld      ARG8, ARG_SZ(s0)    /* void *arg8, retrived from the stack */
+        jalr    ra
+        /* Swap stacks. */
+        mv      sp, s0
+        ld      s0, 0 (sp)
+        ld      ra, 8 (sp)
+        addi    sp, sp, 16
         ret
         END_FUNC(dr_call_on_clean_stack)
 

--- a/core/arch/riscv64/riscv64.asm
+++ b/core/arch/riscv64/riscv64.asm
@@ -115,28 +115,28 @@ call_dispatch_alt_stack_no_free:
  */
         DECLARE_EXPORTED_FUNC(dr_call_on_clean_stack)
 GLOBAL_LABEL(dr_call_on_clean_stack:)
-        addi    sp, sp, -16
-        sd      ra, 8(sp)   /* Save link register. */
-        sd      s0, 0(sp)
-        mv      s0, sp      /* Save sp across the call. */
+        addi     sp, sp, -16
+        sd       ra, 8(sp)   /* Save link register. */
+        sd       s0, 0(sp)
+        mv       s0, sp      /* Save sp across the call. */
         /* Swap stacks. */
-        ld      sp, dstack_OFFSET(ARG1)
+        ld       sp, dstack_OFFSET(ARG1)
         /* Set up args. */
-        mv      ra,   ARG2 /* void *(*func)(arg1...arg8) */
-        mv      ARG1, ARG3          /* void *arg1 */
-        mv      ARG2, ARG4          /* void *arg2 */
-        mv      ARG3, ARG5          /* void *arg3 */
-        mv      ARG4, ARG6          /* void *arg4 */
-        mv      ARG5, ARG7          /* void *arg5 */
-        mv      ARG6, ARG8          /* void *arg6 */
-        ld      ARG7, 0(s0)         /* void *arg7, retrived from the stack */
-        ld      ARG8, ARG_SZ(s0)    /* void *arg8, retrived from the stack */
-        jalr    ra
+        mv       ra,   ARG2 /* void *(*func)(arg1...arg8) */
+        mv       ARG1, ARG3          /* void *arg1 */
+        mv       ARG2, ARG4          /* void *arg2 */
+        mv       ARG3, ARG5          /* void *arg3 */
+        mv       ARG4, ARG6          /* void *arg4 */
+        mv       ARG5, ARG7          /* void *arg5 */
+        mv       ARG6, ARG8          /* void *arg6 */
+        ld       ARG7, 0(s0)         /* void *arg7, retrived from the stack */
+        ld       ARG8, ARG_SZ(s0)    /* void *arg8, retrived from the stack */
+        jalr     ra
         /* Swap stacks. */
-        mv      sp, s0
-        ld      s0, 0 (sp)
-        ld      ra, 8 (sp)
-        addi    sp, sp, 16
+        mv       sp, s0
+        ld       s0, 0 (sp)
+        ld       ra, 8 (sp)
+        addi     sp, sp, 16
         ret
         END_FUNC(dr_call_on_clean_stack)
 


### PR DESCRIPTION
This patch implemented `dr_call_on_clean_stack` for RV64.

Issue: #3544