### PR TITLE
i#6020: Add TID to basic counts interval snapshot

### DIFF
--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -305,6 +305,7 @@ basic_counts_t::generate_shard_interval_snapshot(void *shard_data, uint64_t inte
     for (const auto &ctr : per_shard->counters) {
         snapshot->counters += ctr;
     }
+    snapshot->tid = per_shard->tid;
     return snapshot;
 }
 
@@ -317,6 +318,7 @@ basic_counts_t::generate_interval_snapshot(uint64_t interval_id)
             snapshot->counters += ctr;
         }
     }
+    snapshot->tid = 0;
     return snapshot;
 }
 

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -318,7 +318,7 @@ basic_counts_t::generate_interval_snapshot(uint64_t interval_id)
             snapshot->counters += ctr;
         }
     }
-    snapshot->tid = 0;
+    snapshot->tid = 0; // Use zero to represent the whole-trace interval.
     return snapshot;
 }
 

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -194,6 +194,7 @@ protected:
         // the cumulative values here and compute the delta at the end in
         // print_interval_results().
         counters_t counters;
+        memref_tid_t tid;
         // TODO i#6020: Add per-window counters to the snapshot, and also
         // return interval counts separately per-window in a structured
         // way and print under a flag.


### PR DESCRIPTION
Adds the TID to the basic_counts_t::count_snapshot_t struct. This is to
allow the tool to figure out the TID the snapshot belongs to if needed.

Issue: #6020