### PR TITLE
i#6020 interval analysis: Provide convenient instr counts

### DIFF
--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -167,14 +167,20 @@ public:
      * framework automatically.
      */
     struct interval_state_snapshot_t {
-        interval_state_snapshot_t(uint64_t interval_id, uint64_t interval_end_timestamp)
+        interval_state_snapshot_t(uint64_t interval_id, uint64_t interval_end_timestamp,
+                                  uint64_t instr_count_cumulative,
+                                  uint64_t instr_count_delta)
             : interval_id(interval_id)
             , interval_end_timestamp(interval_end_timestamp)
+            , instr_count_cumulative(instr_count_cumulative)
+            , instr_count_delta(instr_count_delta)
         {
         }
         interval_state_snapshot_t()
             : interval_id(0)
             , interval_end_timestamp(0)
+            , instr_count_cumulative(0)
+            , instr_count_delta(0)
         {
         }
 
@@ -184,6 +190,13 @@ public:
         // but simply the abstract boundary of the interval. This will be aligned
         // to the specified -interval_microseconds.
         uint64_t interval_end_timestamp;
+
+        // Count of instructions: cumulative till this interval, and the incremental
+        // delta in this interval vs the previous one. May be useful for tools to
+        // compute PKI (per kilo instruction) metrics; obviates the need for each
+        // tool to duplicate this.
+        uint64_t instr_count_cumulative;
+        uint64_t instr_count_delta;
 
         virtual ~interval_state_snapshot_t() = default;
     };

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -147,10 +147,12 @@ protected:
     struct analyzer_shard_data_t {
         analyzer_shard_data_t()
             : cur_interval_index(0)
+            , cur_interval_init_instr_count(0)
         {
         }
 
         uint64_t cur_interval_index;
+        uint64_t cur_interval_init_instr_count;
         std::vector<analyzer_tool_shard_data_t> tool_data;
 
     private:
@@ -225,8 +227,8 @@ protected:
     // parameter should be set to the shard_id for which the interval
     // finished. For serial analysis, it should remain the default value.
     bool
-    process_interval(uint64_t interval_id, analyzer_worker_data_t *worker, bool parallel,
-                     int shard_id = 0);
+    process_interval(uint64_t interval_id, uint64_t interval_init_instr_count,
+                     analyzer_worker_data_t *worker, bool parallel, int shard_id = 0);
 
     // Possibly advances the current interval id stored in the worker data, based
     // on the most recent seen timestamp in the trace stream. Returns whether the
@@ -235,7 +237,8 @@ protected:
     bool
     advance_interval_id(
         typename scheduler_tmpl_t<RecordType, ReaderType>::stream_t *stream,
-        analyzer_shard_data_t *shard, uint64_t &prev_interval_index);
+        analyzer_shard_data_t *shard, uint64_t &prev_interval_index,
+        uint64_t &prev_interval_init_instr_count);
 
     // Collects interval results for all shards from the workers, and then merges
     // the shard-local intervals to form the whole-trace interval results using
@@ -256,6 +259,19 @@ protected:
         std::vector<typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t
                         *> &merged_intervals,
         int tool_idx);
+
+    // Combines all interval snapshots in the given vector to create the interval
+    // snapshot for the whole-trace interval ending at interval_end_timestamp and
+    // stores it in 'result'. These snapshots are for the tool at tool_idx. Returns
+    // whether it was successful. This routine also combines the instr count fields
+    // in analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t.
+    bool
+    combine_interval_snapshots(
+        const std::vector<
+            const typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t *>
+            &snapshots,
+        uint64_t interval_end_timestamp, int tool_idx,
+        typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t *&result);
 
     bool success_;
     scheduler_tmpl_t<RecordType, ReaderType> scheduler_;

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -269,7 +269,7 @@ protected:
     combine_interval_snapshots(
         const std::vector<
             const typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t *>
-            &snapshots,
+            &latest_shard_snapshots,
         uint64_t interval_end_timestamp, int tool_idx,
         typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t *&result);
 

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -350,6 +350,20 @@ basic_counts_t::print_interval_results(
         diff -= last;
         print_counters(diff, 0, " interval delta");
         last = snapshot->counters;
+        if (knob_verbose_ > 0) {
+            if (snapshot->instr_count_cumulative !=
+                static_cast<uint64_t>(snapshot->counters.instrs)) {
+                std::cerr << "Cumulative instr count value provided by framework ("
+                          << snapshot->instr_count_cumulative
+                          << ") not equal to tool value (" << snapshot->counters.instrs
+                          << ")\n";
+            }
+            if (snapshot->instr_count_delta != static_cast<uint64_t>(diff.instrs)) {
+                std::cerr << "Delta instr count value provided by framework ("
+                          << snapshot->instr_count_delta << ") not equal to tool value ("
+                          << diff.instrs << ")\n";
+            }
+        }
     }
     return true;
 }

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -353,15 +353,21 @@ basic_counts_t::print_interval_results(
         if (knob_verbose_ > 0) {
             if (snapshot->instr_count_cumulative !=
                 static_cast<uint64_t>(snapshot->counters.instrs)) {
-                std::cerr << "Cumulative instr count value provided by framework ("
-                          << snapshot->instr_count_cumulative
-                          << ") not equal to tool value (" << snapshot->counters.instrs
-                          << ")\n";
+                std::stringstream err_stream;
+                err_stream << "Cumulative instr count value provided by framework ("
+                           << snapshot->instr_count_cumulative
+                           << ") not equal to tool value (" << snapshot->counters.instrs
+                           << ")\n";
+                error_string_ = err_stream.str();
+                return false;
             }
             if (snapshot->instr_count_delta != static_cast<uint64_t>(diff.instrs)) {
-                std::cerr << "Delta instr count value provided by framework ("
-                          << snapshot->instr_count_delta << ") not equal to tool value ("
-                          << diff.instrs << ")\n";
+                std::stringstream err_stream;
+                err_stream << "Delta instr count value provided by framework ("
+                           << snapshot->instr_count_delta << ") not equal to tool value ("
+                           << diff.instrs << ")\n";
+                error_string_ = err_stream.str();
+                return false;
             }
         }
     }


### PR DESCRIPTION
Provides instr counts cumulative till an interval and the incremental delta vs
the previous interval, in the analysis_tool_t::interval_state_snapshot_t
struct. This makes it easier for tools to compute per-kilo instr metrics,
without having to duplicate instr counting for intervals.

Also, adds comparison of the interval framework provided value with the
basic counts value, under the verbose flag.

Issue: #6020