### PR TITLE
 i#3544 RV64: Implemented a naive version of memfuncs

### DIFF
--- a/core/arch/riscv64/memfuncs.asm
+++ b/core/arch/riscv64/memfuncs.asm
@@ -44,16 +44,30 @@ START_FILE
  */
         DECLARE_FUNC(memcpy)
 GLOBAL_LABEL(memcpy:)
-/* FIXME i#3544: Not implemented */
-        ret
+/* TODO i#3544: Naive version, optimize it. */
+        mv       t1, ARG1
+        beqz     ARG3, 2f
+1:      lbu      t2, 0(ARG2)
+        addi     ARG2, ARG2, 1
+        sb       t2, 0(t1)
+        addi     t1, t1, 1
+        addi     ARG3, ARG3, -1
+        bnez     ARG3, 1b
+2:      ret
         END_FUNC(memcpy)
 
 /* Private memset.
  */
         DECLARE_FUNC(memset)
 GLOBAL_LABEL(memset:)
-/* FIXME i#3544: Not implemented */
-        ret
+/* TODO i#3544: Naive version, optimize it. */
+        mv       t1, ARG1
+        beqz     ARG3, 2f
+1:      sb       ARG2, 0(t1)
+        addi     t1, t1, 1
+        addi     ARG3, ARG3, -1
+        bnez     ARG3, 1b
+2:      ret
         END_FUNC(memset)
 
 /* See x86.asm notes about needing these to avoid gcc invoking *_chk */


### PR DESCRIPTION
This patch implements `memcpy` and `memset` for RV64.

`memset` is used in `drrun` when parsing config files at startup. After this patch, it can successfully parse the config file, and then segfaults in `execv`(expected, as the RV64 port is far from complete).

Issue: #3544