### PR TITLE
i#3544 RV64: One step closer to running Hello World

### DIFF
--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -307,8 +307,12 @@ patch_stub(fragment_t *f, cache_pc stub_pc, cache_pc target_pc, cache_pc target_
 static bool
 stub_is_patched_for_intermediate_fragment_link(dcontext_t *dcontext, cache_pc stub_pc)
 {
-    uint enc;
+    uint enc = 0;
+#ifdef RISCV64
+    ATOMIC_4BYTE_ALIGNED_READ(stub_pc, enc);
+#else
     ATOMIC_4BYTE_ALIGNED_READ(stub_pc, &enc);
+#endif
     return (enc & 0xfc000000) == 0x14000000; /* B (OP_b)*/
 }
 
@@ -316,8 +320,12 @@ static bool
 stub_is_patched_for_far_fragment_link(dcontext_t *dcontext, fragment_t *f,
                                       cache_pc stub_pc)
 {
-    ptr_uint_t target_pc;
+    ptr_uint_t target_pc = 0;
+#ifdef RISCV64
+    ATOMIC_8BYTE_ALIGNED_READ(get_target_pc_slot(f, stub_pc), target_pc);
+#else
     ATOMIC_8BYTE_ALIGNED_READ(get_target_pc_slot(f, stub_pc), &target_pc);
+#endif
     return target_pc != (ptr_uint_t)fcache_return_routine(dcontext);
 }
 

--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -308,11 +308,7 @@ static bool
 stub_is_patched_for_intermediate_fragment_link(dcontext_t *dcontext, cache_pc stub_pc)
 {
     uint enc = 0;
-#ifdef RISCV64
-    ATOMIC_4BYTE_ALIGNED_READ(stub_pc, enc);
-#else
     ATOMIC_4BYTE_ALIGNED_READ(stub_pc, &enc);
-#endif
     return (enc & 0xfc000000) == 0x14000000; /* B (OP_b)*/
 }
 
@@ -321,11 +317,7 @@ stub_is_patched_for_far_fragment_link(dcontext_t *dcontext, fragment_t *f,
                                       cache_pc stub_pc)
 {
     ptr_uint_t target_pc = 0;
-#ifdef RISCV64
-    ATOMIC_8BYTE_ALIGNED_READ(get_target_pc_slot(f, stub_pc), target_pc);
-#else
     ATOMIC_8BYTE_ALIGNED_READ(get_target_pc_slot(f, stub_pc), &target_pc);
-#endif
     return target_pc != (ptr_uint_t)fcache_return_routine(dcontext);
 }
 

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1051,8 +1051,8 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 #    define PC_LOAD_ADDR_ALIGN 4
 
 #elif defined(RISCV64)
-/* FIXME i#3544: This can be 2B in C. */
 #    define RISCV64_INSTR_SIZE 4
+#    define RISCV64_INSTR_C_SIZE 2
 /* FIXME i#3544: Not implemented */
 #    define FRAGMENT_BASE_PREFIX_SIZE(flags) RISCV64_INSTR_SIZE
 /* FIXME i#3544: Not implemented */

--- a/core/arch/atomic_exports.h
+++ b/core/arch/atomic_exports.h
@@ -730,25 +730,25 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define SET_IF_NOT_ZERO(flag) SET_FLAG(ne, flag)
 #        define SET_IF_NOT_LESS(flag) SET_FLAG(ge, flag)
 #    elif defined(DR_HOST_RISCV64)
-#        define ATOMIC_1BYTE_READ(addr_src, res)            \
-            do {                                            \
-                /* Fence for acquire semantics. */          \
-                __asm__ __volatile__("lbu %0, 0(%1)\n\t"    \
-                                     "fence iorw,iorw"      \
-                                     : "=r"(res)            \
-                                     : "r"(addr_src)        \
-                                     : "memory");           \
+#        define ATOMIC_1BYTE_READ(addr_src, res)         \
+            do {                                         \
+                /* Fence for acquire semantics. */       \
+                __asm__ __volatile__("lbu %0, 0(%1)\n\t" \
+                                     "fence iorw,iorw"   \
+                                     : "=r"(res)         \
+                                     : "r"(addr_src)     \
+                                     : "memory");        \
             } while (0)
-#        define ATOMIC_1BYTE_WRITE(target, value, hot_patch)    \
-            do {                                                \
-                /* Not currently used to write code */          \
-                ASSERT_CURIOSITY(!hot_patch);                   \
-                /* Fence for release semantics. */              \
-                __asm__ __volatile__("fence iorw,iorw\n\t"      \
-                                     "sb %1, 0(%0)\n\t"         \
-                                     :                          \
-                                     : "r"(target), "r"(value)  \
-                                     : "memory");               \
+#        define ATOMIC_1BYTE_WRITE(target, value, hot_patch)   \
+            do {                                               \
+                /* Not currently used to write code */         \
+                ASSERT_CURIOSITY(!hot_patch);                  \
+                /* Fence for release semantics. */             \
+                __asm__ __volatile__("fence iorw,iorw\n\t"     \
+                                     "sb %1, 0(%0)\n\t"        \
+                                     :                         \
+                                     : "r"(target), "r"(value) \
+                                     : "memory");              \
             } while (0)
 #        define ATOMIC_4BYTE_ALIGNED_WRITE(target, value, hot_patch) \
             do {                                                     \
@@ -770,20 +770,20 @@ atomic_dec_becomes_zero(volatile int *var)
                                      : "memory");                    \
             } while (0)
 #        define ATOMIC_4BYTE_WRITE ATOMIC_4BYTE_ALIGNED_WRITE
-#        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, res)            \
-            do {                                                    \
-                /* Page 25 of Volume I: RISC-V Unprivileged ISA     \
-                 * V20191213 states that aligned loads/stores are   \
-                 * atomic.                                          \
-                 */                                                 \
-                ASSERT(ALIGNED(addr_src, 4));                       \
-                ASSERT(ALIGNED(addr_res, 4));                       \
-                /* Fence for acquire semantics. */                  \
-                __asm__ __volatile__("lw %0, 0(%1)\n\t"             \
-                                     "fence iorw,iorw"              \
-                                     : "=r"(res)                    \
-                                     : "r"(addr_src)                \
-                                     : "memory");                   \
+#        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, res)          \
+            do {                                                  \
+                /* Page 25 of Volume I: RISC-V Unprivileged ISA   \
+                 * V20191213 states that aligned loads/stores are \
+                 * atomic.                                        \
+                 */                                               \
+                ASSERT(ALIGNED(addr_src, 4));                     \
+                ASSERT(ALIGNED(addr_res, 4));                     \
+                /* Fence for acquire semantics. */                \
+                __asm__ __volatile__("lw %0, 0(%1)\n\t"           \
+                                     "fence iorw,iorw"            \
+                                     : "=r"(res)                  \
+                                     : "r"(addr_src)              \
+                                     : "memory");                 \
             } while (0)
 #        define ATOMIC_8BYTE_ALIGNED_WRITE(target, value, hot_patch) \
             do {                                                     \
@@ -799,38 +799,38 @@ atomic_dec_becomes_zero(volatile int *var)
                 ASSERT_CURIOSITY(!hot_patch);                        \
                 /* Fence for release semantics. */                   \
                 __asm__ __volatile__("fence iorw,iorw\n\t"           \
-                                     "sd %1, 0(%0)\n\t"                 \
+                                     "sd %1, 0(%0)\n\t"              \
                                      :                               \
                                      : "r"(target), "r"(value)       \
                                      : "memory");                    \
             } while (0)
 #        define ATOMIC_8BYTE_WRITE ATOMIC_8BYTE_ALIGNED_WRITE
-#        define ATOMIC_8BYTE_ALIGNED_READ(addr_src, res)            \
-            do {                                                    \
-                /* Page 25 of Volume I: RISC-V Unprivileged ISA     \
-                 * V20191213 states that aligned loads/stores are   \
-                 * atomic.                                          \
-                 */                                                 \
-                ASSERT(ALIGNED(addr_src, 8));                       \
-                ASSERT(ALIGNED(addr_res, 8));                       \
-                __asm__ __volatile__("ld %0, 0(%1)\n\t"             \
-                                     "fence iorw,iorw"              \
-                                     : "=r"(res)                    \
-                                     : "r"(addr_src)                \
-                                     : "memory");                   \
+#        define ATOMIC_8BYTE_ALIGNED_READ(addr_src, res)          \
+            do {                                                  \
+                /* Page 25 of Volume I: RISC-V Unprivileged ISA   \
+                 * V20191213 states that aligned loads/stores are \
+                 * atomic.                                        \
+                 */                                               \
+                ASSERT(ALIGNED(addr_src, 8));                     \
+                ASSERT(ALIGNED(addr_res, 8));                     \
+                __asm__ __volatile__("ld %0, 0(%1)\n\t"           \
+                                     "fence iorw,iorw"            \
+                                     : "=r"(res)                  \
+                                     : "r"(addr_src)              \
+                                     : "memory");                 \
             } while (0)
 
-#        define ADDI_suffix(sfx, var, val, align)                               \
-            do {                                                                \
-                /* Page 53 of Volume I: RISC-V Unprivileged ISA V20191213       \
-                 * requires that var address is naturally aligned.              \
-                 */                                                             \
-                ASSERT(ALIGNED(var, align));                                    \
-                __asm__ __volatile__("li t0, " #val "\n\t"                      \
-                                     "amoadd." sfx ".aqrl zero,  t0, (%0)\n\t"  \
-                                     :                                          \
-                                     : "r"(var)                                 \
-                                     : "t0", "memory");                         \
+#        define ADDI_suffix(sfx, var, val, align)                              \
+            do {                                                               \
+                /* Page 53 of Volume I: RISC-V Unprivileged ISA V20191213      \
+                 * requires that var address is naturally aligned.             \
+                 */                                                            \
+                ASSERT(ALIGNED(var, align));                                   \
+                __asm__ __volatile__("li t0, " #val "\n\t"                     \
+                                     "amoadd." sfx ".aqrl zero,  t0, (%0)\n\t" \
+                                     :                                         \
+                                     : "r"(var)                                \
+                                     : "t0", "memory");                        \
             } while (0)
 
 static inline void
@@ -1183,11 +1183,11 @@ static inline int64
 atomic_aligned_read_int64(volatile int64 *var)
 {
     int64 temp = 0;
-#ifdef RISCV64
+#    ifdef RISCV64
     ATOMIC_8BYTE_ALIGNED_READ(var, temp);
-#else
+#    else
     ATOMIC_8BYTE_ALIGNED_READ(var, &temp);
-#endif
+#    endif
     return temp;
 }
 #endif

--- a/core/arch/atomic_exports.h
+++ b/core/arch/atomic_exports.h
@@ -777,7 +777,7 @@ atomic_dec_becomes_zero(volatile int *var)
                  * atomic.                                        \
                  */                                               \
                 ASSERT(ALIGNED(addr_src, 4));                     \
-                ASSERT(ALIGNED(res, 4));                     \
+                ASSERT(ALIGNED(res, 4));                          \
                 /* Fence for acquire semantics. */                \
                 __asm__ __volatile__("lw %0, 0(%1)\n\t"           \
                                      "fence iorw,iorw"            \
@@ -812,7 +812,7 @@ atomic_dec_becomes_zero(volatile int *var)
                  * atomic.                                        \
                  */                                               \
                 ASSERT(ALIGNED(addr_src, 8));                     \
-                ASSERT(ALIGNED(res, 8));                     \
+                ASSERT(ALIGNED(res, 8));                          \
                 __asm__ __volatile__("ld %0, 0(%1)\n\t"           \
                                      "fence iorw,iorw"            \
                                      : "=r"(res)                  \

--- a/core/arch/atomic_exports.h
+++ b/core/arch/atomic_exports.h
@@ -730,25 +730,25 @@ atomic_dec_becomes_zero(volatile int *var)
 #        define SET_IF_NOT_ZERO(flag) SET_FLAG(ne, flag)
 #        define SET_IF_NOT_LESS(flag) SET_FLAG(ge, flag)
 #    elif defined(DR_HOST_RISCV64)
-#        define ATOMIC_1BYTE_READ(addr_src, addr_res)               \
-            do {                                                    \
-                /* Fence for acquire semantics. */                  \
-                __asm__ __volatile__("lbu %0, 0(%1)\n\t"            \
-                                     "fence iorw,iorw"              \
-                                     :                              \
-                                     : "r"(addr_src), "r"(addr_res) \
-                                     : "memory");                   \
+#        define ATOMIC_1BYTE_READ(addr_src, res)            \
+            do {                                            \
+                /* Fence for acquire semantics. */          \
+                __asm__ __volatile__("lbu %0, 0(%1)\n\t"    \
+                                     "fence iorw,iorw"      \
+                                     : "=r"(res)            \
+                                     : "r"(addr_src)        \
+                                     : "memory");           \
             } while (0)
-#        define ATOMIC_1BYTE_WRITE(target, value, hot_patch)   \
-            do {                                               \
-                /* Not currently used to write code */         \
-                ASSERT_CURIOSITY(!hot_patch);                  \
-                /* Fence for release semantics. */             \
-                __asm__ __volatile__("fence iorw,iorw\n\t"     \
-                                     "sb %0, 0(%1)\n\t"        \
-                                     :                         \
-                                     : "r"(value), "r"(target) \
-                                     : "memory");              \
+#        define ATOMIC_1BYTE_WRITE(target, value, hot_patch)    \
+            do {                                                \
+                /* Not currently used to write code */          \
+                ASSERT_CURIOSITY(!hot_patch);                   \
+                /* Fence for release semantics. */              \
+                __asm__ __volatile__("fence iorw,iorw\n\t"      \
+                                     "sb %1, 0(%0)\n\t"         \
+                                     :                          \
+                                     : "r"(target), "r"(value)  \
+                                     : "memory");               \
             } while (0)
 #        define ATOMIC_4BYTE_ALIGNED_WRITE(target, value, hot_patch) \
             do {                                                     \
@@ -764,13 +764,13 @@ atomic_dec_becomes_zero(volatile int *var)
                 ASSERT_CURIOSITY(!hot_patch);                        \
                 /* Fence for release semantics. */                   \
                 __asm__ __volatile__("fence iorw,iorw\n\t"           \
-                                     "sw %0, 0(%1)\n\t"              \
+                                     "sw %1, 0(%0)\n\t"              \
                                      :                               \
-                                     : "r"(value), "r"(target)       \
+                                     : "r"(target), "r"(value)       \
                                      : "memory");                    \
             } while (0)
 #        define ATOMIC_4BYTE_WRITE ATOMIC_4BYTE_ALIGNED_WRITE
-#        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, addr_res)       \
+#        define ATOMIC_4BYTE_ALIGNED_READ(addr_src, res)            \
             do {                                                    \
                 /* Page 25 of Volume I: RISC-V Unprivileged ISA     \
                  * V20191213 states that aligned loads/stores are   \
@@ -781,8 +781,8 @@ atomic_dec_becomes_zero(volatile int *var)
                 /* Fence for acquire semantics. */                  \
                 __asm__ __volatile__("lw %0, 0(%1)\n\t"             \
                                      "fence iorw,iorw"              \
-                                     :                              \
-                                     : "r"(addr_src), "r"(addr_res) \
+                                     : "=r"(res)                    \
+                                     : "r"(addr_src)                \
                                      : "memory");                   \
             } while (0)
 #        define ATOMIC_8BYTE_ALIGNED_WRITE(target, value, hot_patch) \
@@ -799,13 +799,13 @@ atomic_dec_becomes_zero(volatile int *var)
                 ASSERT_CURIOSITY(!hot_patch);                        \
                 /* Fence for release semantics. */                   \
                 __asm__ __volatile__("fence iorw,iorw\n\t"           \
-                                     "sd %0, 0(%1)\n\t"              \
+                                     "sd %1, 0(%0)\n\t"                 \
                                      :                               \
-                                     : "r"(value), "r"(target)       \
+                                     : "r"(target), "r"(value)       \
                                      : "memory");                    \
             } while (0)
 #        define ATOMIC_8BYTE_WRITE ATOMIC_8BYTE_ALIGNED_WRITE
-#        define ATOMIC_8BYTE_ALIGNED_READ(addr_src, addr_res)       \
+#        define ATOMIC_8BYTE_ALIGNED_READ(addr_src, res)            \
             do {                                                    \
                 /* Page 25 of Volume I: RISC-V Unprivileged ISA     \
                  * V20191213 states that aligned loads/stores are   \
@@ -815,8 +815,8 @@ atomic_dec_becomes_zero(volatile int *var)
                 ASSERT(ALIGNED(addr_res, 8));                       \
                 __asm__ __volatile__("ld %0, 0(%1)\n\t"             \
                                      "fence iorw,iorw"              \
-                                     :                              \
-                                     : "r"(addr_src), "r"(addr_res) \
+                                     : "=r"(res)                    \
+                                     : "r"(addr_src)                \
                                      : "memory");                   \
             } while (0)
 
@@ -827,7 +827,7 @@ atomic_dec_becomes_zero(volatile int *var)
                  */                                                             \
                 ASSERT(ALIGNED(var, align));                                    \
                 __asm__ __volatile__("li t0, " #val "\n\t"                      \
-                                     "amoadd." sfx ".aqrl zero,  t0, 0(%0)\n\t" \
+                                     "amoadd." sfx ".aqrl zero,  t0, (%0)\n\t"  \
                                      :                                          \
                                      : "r"(var)                                 \
                                      : "t0", "memory");                         \
@@ -869,7 +869,7 @@ ATOMIC_ADD_int(volatile int *var, int val)
      * naturally aligned.
      */
     ASSERT(ALIGNED(var, 4));
-    __asm__ __volatile__("amoadd.w.aqrl zero, %1, 0(%0)\n\t"
+    __asm__ __volatile__("amoadd.w.aqrl zero, %1, (%0)\n\t"
                          :
                          : "r"(var), "r"(val)
                          : "memory");
@@ -882,7 +882,7 @@ ATOMIC_ADD_int64(volatile int64 *var, int64 val)
      * naturally aligned.
      */
     ASSERT(ALIGNED(var, 8));
-    __asm__ __volatile__("amoadd.d.aqrl zero, %1, 0(%0)\n\t"
+    __asm__ __volatile__("amoadd.d.aqrl zero, %1, (%0)\n\t"
                          :
                          : "r"(var), "r"(val)
                          : "memory");
@@ -893,12 +893,12 @@ ATOMIC_ADD_int64(volatile int64 *var, int64 val)
 static inline int
 atomic_add_exchange_int(volatile int *var, int val)
 {
-    int res;
+    volatile int res = 0;
     /* Page 53 of Volume I: RISC-V Unprivileged ISA V20191213 requires that var address is
      * naturally aligned.
      */
     ASSERT(ALIGNED(var, 4));
-    __asm__ __volatile__("amoadd.w.aqrl %0, %2, 0(%1)\n\t"
+    __asm__ __volatile__("amoadd.w.aqrl %0, %2, (%1)\n\t"
                          : "=r"(res)
                          : "r"(var), "r"(val)
                          : "memory");
@@ -908,12 +908,12 @@ atomic_add_exchange_int(volatile int *var, int val)
 static inline int64
 atomic_add_exchange_int64(volatile int64 *var, int64 val)
 {
-    int64 res;
+    volatile int64 res = 0;
     /* Page 53 of Volume I: RISC-V Unprivileged ISA V20191213 requires that var address is
      * naturally aligned.
      */
     ASSERT(ALIGNED(var, 8));
-    __asm__ __volatile__("amoadd.d.aqrl %0, %2, 0(%1)\n\t"
+    __asm__ __volatile__("amoadd.d.aqrl %0, %2, (%1)\n\t"
                          : "=r"(res)
                          : "r"(var), "r"(val)
                          : "memory");
@@ -925,7 +925,7 @@ atomic_add_exchange_int64(volatile int64 *var, int64 val)
 static inline bool
 atomic_compare_exchange_int(volatile int *var, int compare, int exchange)
 {
-    bool res = 1;
+    volatile bool res = 1;
     /* Page 49 of Volume I: RISC-V Unprivileged ISA V20191213 requires that var address is
      * naturally aligned.
      */
@@ -936,11 +936,12 @@ atomic_compare_exchange_int(volatile int *var, int compare, int exchange)
      * sequentially consistent memory order semantics.
      */
     __asm__ __volatile__("fence   iorw,ow\n\t"
-                         "1: lr.w.aq t0, (%1)\n\t"
-                         "   bne     t0, %2, 2f\n\t"
-                         "   sc.w.aq %0, %3, (%1)\n\t"
-                         "   bnez    %0, 1b\n\t"
-                         "2:"
+                         "1: lr.w.aqrl  t0, (%1)\n\t"
+                         "   bne        t0, %2, 2f\n\t"
+                         "   sc.w.rl    %0, %3, (%1)\n\t"
+                         "   bnez       %0, 1b\n\t"
+                         "2:\n\t"
+                         "   subw       %0, t0, %2\n\t"
                          : "+r"(res)
                          : "r"(var), "r"(compare), "r"(exchange)
                          : "t0", "memory");
@@ -950,7 +951,7 @@ atomic_compare_exchange_int(volatile int *var, int compare, int exchange)
 static inline bool
 atomic_compare_exchange_int64(volatile int64 *var, int64 compare, int64 exchange)
 {
-    bool res = 1;
+    volatile bool res = 1;
     /* Page 49 of Volume I: RISC-V Unprivileged ISA V20191213 requires that var address is
      * naturally aligned.
      */
@@ -961,11 +962,12 @@ atomic_compare_exchange_int64(volatile int64 *var, int64 compare, int64 exchange
      * sequentially consistent memory order semantics.
      */
     __asm__ __volatile__("fence   iorw,ow\n\t"
-                         "1: lr.d.aq t0, (%1)\n\t"
-                         "   bne     t0, %2, 2f\n\t"
-                         "   sc.d.aq %0, %3, (%1)\n\t"
-                         "   bnez    %0, 1b\n\t"
-                         "2:"
+                         "1: lr.d.aqrl  t0, (%1)\n\t"
+                         "   bne        t0, %2, 2f\n\t"
+                         "   sc.d.rl    %0, %3, (%1)\n\t"
+                         "   bnez       %0, 1b\n\t"
+                         "2:\n\t"
+                         "   sub        %0, t0, %2\n\t"
                          : "+r"(res)
                          : "r"(var), "r"(compare), "r"(exchange)
                          : "t0", "memory");
@@ -977,15 +979,16 @@ atomic_compare_exchange_int64(volatile int64 *var, int64 compare, int64 exchange
 #        define ATOMIC_COMPARE_EXCHANGE_int64(var, compare, exchange) \
             atomic_compare_exchange_int64(var, compare, exchange)
 
+/* exchanges *var with newval and returns original *var */
 static inline int
 atomic_exchange_int(volatile int *var, int newval)
 {
-    int res;
+    volatile int res;
     /* Page 53 of Volume I: RISC-V Unprivileged ISA V20191213 requires that var address
      * is naturally aligned.
      */
     ASSERT(ALIGNED(var, 4));
-    __asm__ __volatile__("amoswap.w.aqrl %0, %2, 0(%1)\n\t"
+    __asm__ __volatile__("amoswap.w.aqrl %0, %2, (%1)\n\t"
                          : "=r"(res)
                          : "r"(var), "r"(newval)
                          : "memory");
@@ -1154,16 +1157,24 @@ atomic_add_exchange_int64(volatile int64 *var, int64 value)
 static inline int
 atomic_aligned_read_int(volatile int *var)
 {
-    int temp;
+    int temp = 0;
+#ifdef RISCV64
+    ATOMIC_4BYTE_ALIGNED_READ(var, temp);
+#else
     ATOMIC_4BYTE_ALIGNED_READ(var, &temp);
+#endif
     return temp;
 }
 
 static inline bool
 atomic_read_bool(volatile bool *var)
 {
-    bool temp;
+    bool temp = 0;
+#ifdef RISCV64
+    ATOMIC_1BYTE_READ(var, temp);
+#else
     ATOMIC_1BYTE_READ(var, &temp);
+#endif
     return temp;
 }
 
@@ -1171,8 +1182,12 @@ atomic_read_bool(volatile bool *var)
 static inline int64
 atomic_aligned_read_int64(volatile int64 *var)
 {
-    int64 temp;
+    int64 temp = 0;
+#ifdef RISCV64
+    ATOMIC_8BYTE_ALIGNED_READ(var, temp);
+#else
     ATOMIC_8BYTE_ALIGNED_READ(var, &temp);
+#endif
     return temp;
 }
 #endif

--- a/core/arch/atomic_exports.h
+++ b/core/arch/atomic_exports.h
@@ -777,7 +777,7 @@ atomic_dec_becomes_zero(volatile int *var)
                  * atomic.                                        \
                  */                                               \
                 ASSERT(ALIGNED(addr_src, 4));                     \
-                ASSERT(ALIGNED(addr_res, 4));                     \
+                ASSERT(ALIGNED(res, 4));                     \
                 /* Fence for acquire semantics. */                \
                 __asm__ __volatile__("lw %0, 0(%1)\n\t"           \
                                      "fence iorw,iorw"            \
@@ -812,7 +812,7 @@ atomic_dec_becomes_zero(volatile int *var)
                  * atomic.                                        \
                  */                                               \
                 ASSERT(ALIGNED(addr_src, 8));                     \
-                ASSERT(ALIGNED(addr_res, 8));                     \
+                ASSERT(ALIGNED(res, 8));                     \
                 __asm__ __volatile__("ld %0, 0(%1)\n\t"           \
                                      "fence iorw,iorw"            \
                                      : "=r"(res)                  \

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -1897,11 +1897,9 @@ append_jmp_to_fcache_target(dcontext_t *dcontext, instrlist_t *ilist,
      */
     if (absolute) {
 #ifdef RISCV64
-            APP(ilist,
-                instr_create_restore_from_tls(dcontext, DR_REG_X5,
-                                              NEXT_TAG_OFFSET));
-            /* jalr x5 */
-            APP(ilist, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(DR_REG_X5)));
+        APP(ilist, instr_create_restore_from_tls(dcontext, DR_REG_X5, NEXT_TAG_OFFSET));
+        /* jalr x5 */
+        APP(ilist, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(DR_REG_X5)));
 #else
         APP(ilist, instr_create_jump_via_dcontext(dcontext, NEXT_TAG_OFFSET));
 #endif

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -4776,7 +4776,7 @@ build_native_exec_bb(dcontext_t *dcontext, build_bb_t *bb)
                                                           SCRATCH_REG0_OFFS));
     insert_shared_restore_dcontext_reg(dcontext, bb->ilist, NULL);
 
-#ifdef AARCH64
+#if defined(AARCH64) || defined(RISCV64)
     ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
 #else
     /* this is the jump to native code */

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1900,7 +1900,7 @@ find_syscall_num(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
     instr_t *walk, *tgt;
 
 #ifdef RISCV64
-/* FIXME i#3544: Not looking for syscall number for now. */
+    /* FIXME i#3544: Not looking for syscall number for now. */
     return 93; // exit
 #endif
 

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -1899,6 +1899,11 @@ find_syscall_num(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr)
     reg_id_t sysreg = reg_to_pointer_sized(DR_REG_SYSNUM);
     instr_t *walk, *tgt;
 
+#ifdef RISCV64
+/* FIXME i#3544: Not looking for syscall number for now. */
+    return 93; // exit
+#endif
+
     if (prev == NULL) {
 #if defined(WINDOWS) && defined(X64)
         if (get_os_version() >= WINDOWS_VERSION_10_1511) {

--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -114,8 +114,7 @@ is_elf_so_header_common(app_pc base, size_t size, bool memory)
             (memory && elf_header.e_ehsize != sizeof(ELF_HEADER_TYPE)) ||
             (memory &&
 #ifdef X64
-             elf_header.e_machine != EM_X86_64 &&
-             elf_header.e_machine != EM_AARCH64 &&
+             elf_header.e_machine != EM_X86_64 && elf_header.e_machine != EM_AARCH64 &&
              elf_header.e_machine != EM_RISCV
 #else
              elf_header.e_machine != EM_386 && elf_header.e_machine != EM_ARM

--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -114,7 +114,9 @@ is_elf_so_header_common(app_pc base, size_t size, bool memory)
             (memory && elf_header.e_ehsize != sizeof(ELF_HEADER_TYPE)) ||
             (memory &&
 #ifdef X64
-             elf_header.e_machine != EM_X86_64 && elf_header.e_machine != EM_AARCH64
+             elf_header.e_machine != EM_X86_64 &&
+             elf_header.e_machine != EM_AARCH64 &&
+             elf_header.e_machine != EM_RISCV
 #else
              elf_header.e_machine != EM_386 && elf_header.e_machine != EM_ARM
 #endif

--- a/core/drlibc/drlibc_riscv64.asm
+++ b/core/drlibc/drlibc_riscv64.asm
@@ -46,14 +46,17 @@ START_FILE
  */
         DECLARE_FUNC(dynamorio_syscall)
 GLOBAL_LABEL(dynamorio_syscall:)
-        mv      t0,a0
-        mv      a0,a2
-        mv      a1,a3
-        mv      a2,a4
-        mv      a3,a5
-        mv      a4,a6
-        mv      a5,a7
-        mv      a7,t0
+        slti     t0, ARG2, 7
+        mv       t1, ARG1
+        mv       ARG1, ARG3
+        mv       ARG2, ARG4
+        mv       ARG3, ARG5
+        mv       ARG4, ARG6
+        mv       ARG5, ARG7
+        mv       ARG6, ARG8
+        bnez     t0, 1f
+        ld       ARG7, 0(sp)
+1:      mv       SYSNUM_REG, t1
         ecall
         ret
 

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -6716,11 +6716,11 @@ flush_fragments_end_synch(dcontext_t *dcontext, bool keep_initexit_lock)
              */
 #ifdef DEBUG
             uint pre_flushtime;
-#ifdef RISCV64
+#    ifdef RISCV64
             ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, pre_flushtime);
-#else
+#    else
             ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, &pre_flushtime);
-#endif
+#    endif
 #endif
             vm_area_check_shared_pending(tgt_dcontext, NULL);
             /* lazy deletion may inc flushtime_global, so may have a higher

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -5425,7 +5425,7 @@ check_flush_queue(dcontext_t *dcontext, fragment_t *was_I_flushed)
             SELF_PROTECT_LOCAL(dcontext, READONLY);
     }
     /* now check shared queue to dec ref counts */
-    uint local_flushtime_global;
+    uint local_flushtime_global = 0;
     /* No lock needed: any racy incs to global are in safe direction, and our inc
      * is atomic so we shouldn't see any partial-word-updated values here.  This
      * check is our shared deletion algorithm's only perf hit when there's no
@@ -5826,7 +5826,7 @@ increment_global_flushtime()
     /* reset will turn flushtime_global back to 0, so we schedule one
      * when we're approaching overflow
      */
-    uint local_flushtime_global;
+    uint local_flushtime_global = 0;
 #ifdef RISCV64
     ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, local_flushtime_global);
 #else

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1925,7 +1925,7 @@ fragment_thread_reset_init(dcontext_t *dcontext)
 #endif
             }
         }
-
+#ifndef RISCV64
         /* When targetting BBs, currently the source is assumed to be only a
          * bb since traces going to a bb for the first time should mark it
          * as a trace head.  Therefore the tables are currently only
@@ -1960,7 +1960,7 @@ fragment_thread_reset_init(dcontext_t *dcontext)
                         ibl_bb_table_type_names[branch_type]));
                 /* mark as inclusive table for bb's - we in fact currently
                  * keep only frags that are not FRAG_IS_TRACE_HEAD */
-#ifdef HASHTABLE_STATISTICS
+#    ifdef HASHTABLE_STATISTICS
                 if (INTERNAL_OPTION(hashtable_ibl_stats)) {
                     /* for compatibility using an entry in the per-branch type stats */
                     CHECK_UNPROT_STATS(pt->bb_ibt[branch_type]);
@@ -1970,7 +1970,7 @@ fragment_thread_reset_init(dcontext_t *dcontext)
                 } else {
                     pt->bb_ibt[branch_type].unprot_stats = NULL;
                 }
-#endif /* HASHTABLE_STATISTICS */
+#    endif /* HASHTABLE_STATISTICS */
             } else {
                 /* ensure table from last time (if we had a reset) not still there */
                 memset(&pt->bb_ibt[branch_type], 0, sizeof(pt->bb_ibt[branch_type]));
@@ -1979,7 +1979,7 @@ fragment_thread_reset_init(dcontext_t *dcontext)
                                                        false, /* no adjust old
                                                                * ref-count */
                                                        true /* lock */);
-#ifdef HASHTABLE_STATISTICS
+#    ifdef HASHTABLE_STATISTICS
                 if (INTERNAL_OPTION(hashtable_ibl_stats)) {
                     ALLOC_UNPROT_STATS(dcontext, &pt->bb_ibt[branch_type]);
                     CHECK_UNPROT_STATS(pt->bb_ibt[branch_type]);
@@ -1988,9 +1988,10 @@ fragment_thread_reset_init(dcontext_t *dcontext)
                 } else {
                     pt->bb_ibt[branch_type].unprot_stats = NULL;
                 }
-#endif
+#    endif
             }
         }
+#endif
     }
     ASSERT(IBL_BRANCH_TYPE_END == 3);
 

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -3586,7 +3586,7 @@ instr_create_save_immed_to_dc_via_reg(dcontext_t *dcontext, reg_id_t basereg, in
 instr_t *
 instr_create_jump_via_dcontext(dcontext_t *dcontext, int offs)
 {
-#    ifdef AARCH64
+#    if defined(AARCH64) || defined(RISCV64)
     ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
     return 0;
 #    else

--- a/core/ir/riscv64/decode.c
+++ b/core/ir/riscv64/decode.c
@@ -94,9 +94,8 @@ decode_from_copy(void *drcontext, byte *copy_pc, byte *orig_pc, instr_t *instr)
 byte *
 decode_cti(void *drcontext, byte *pc, instr_t *instr)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
-    return NULL;
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    return decode(dcontext, pc, instr);
 }
 
 byte *

--- a/core/ir/riscv64/encode.c
+++ b/core/ir/riscv64/encode.c
@@ -90,15 +90,84 @@ decode_info_init_for_instr(decode_info_t *di, instr_t *instr)
     ASSERT_NOT_IMPLEMENTED(false);
 }
 
+/* FIXME: Code generation. */
+#define R_type(funct7, rs2, rs1, funct3, rd, opcode)    ((funct7)<<25 | (rs2)<<20 | (rs1)<<15 | (funct3)<<12 | (rd)<<7 | (opcode))
+#define I_type(imm12, rs1, funct3, rd, opcode)    ((imm12)<<20 | (rs1)<<15 | (funct3)<<12 | (rd)<<7 | (opcode))
+#define S_type(imm12, rs2, rs1, funct3, opcode)    (((imm12)>>5)<<25 | (rs2)<<20 | (rs1)<<15 | (funct3)<<12 | ((imm12)&31)<<7 | (opcode))
+#define B_type(imm13, rs2, rs1, funct3, opcode)      ((((imm13)>>12)&1)<<31 | (((imm13)>>5)&63)<<25 | (rs2)<<20 | (rs1)<<15 | (funct3)<<12 | (((imm13)>>1)&15)<<8 | (((imm13)>>11)&1)<<7 | (opcode))
+#define U_type(imm32, rd, opcode)    (((imm32)>>12)<<12 | (rd)<<7 | (opcode))
+#define J_type(imm21, rd, opcode)    ((((imm21)>>20)&1)<<31 | (((imm21)>>1)&0b1111111111)<<21 | (((imm21)>>11)&1)<<20 | (((imm21)>>12)&0b11111111)<<12 | (rd)<<7 | (opcode))
+
+#define LD(rd, rs1, imm12)      I_type(imm12, rs1, 0b011, rd, 0b0000011)
+#define SD(rs2, rs1, imm12)     S_type(imm12, rs2, rs1, 0b011, 0b0100011)
+#define JAL(rd, imm21)          J_type(imm21, rd, 0b1101111)
+#define JALR(rd, rs1, imm12)    I_type(imm12, rs1, 0b000, rd, 0b1100111)
+#define ADD(rd, rs1, rs2)       R_type(0b0000000, rs2, rs1, 0b000, rd, 0b0110011)
+#define ADDI(rd, rs1, imm12)    I_type((imm12)&0b111111111111, rs1, 0b000, rd, 0b0010011)
+#define AUIPC(rd, imm20)        U_type((imm20)<<12, rd, 0b0010111)
+
 byte *
 instr_encode_arch(dcontext_t *dcontext, instr_t *instr, byte *copy_pc, byte *final_pc,
                   bool check_reachable,
                   bool *has_instr_opnds /*OUT OPTIONAL*/
                       _IF_DEBUG(bool assert_reachable))
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
-    return NULL;
+    /* FIXME i#3544: Incomplete */
+    uint enc;
+
+    if (has_instr_opnds != NULL)
+        *has_instr_opnds = false;
+
+    if (instr_is_label(instr))
+        return copy_pc;
+
+    switch (instr->opcode) {
+        case OP_c_nop:
+            enc = 0x1;
+            break;
+        case OP_ecall:
+            enc = 0x73;
+            break;
+        case OP_addi:
+            enc = ADDI(instr->dsts[0].value.reg_and_element_size.reg,
+                       instr->src0.value.reg_and_element_size.reg,
+                       instr->srcs[0].value.immed_int);
+            break;
+        case OP_add:
+            enc = ADD(instr->dsts[0].value.reg_and_element_size.reg,
+                      instr->src0.value.reg_and_element_size.reg,
+                      instr->srcs[0].value.reg_and_element_size.reg);
+            break;
+        case OP_ld:
+            enc = LD(instr->dsts[0].value.reg_and_element_size.reg,
+                     instr->src0.value.base_disp.base_reg,
+                     instr->src0.value.base_disp.disp);
+            break;
+        case OP_sd:
+            enc = SD(instr->dsts[0].value.reg_and_element_size.reg,
+                     instr->src0.value.base_disp.base_reg,
+                     instr->src0.value.base_disp.disp);
+            break;
+        case OP_jal:
+            uint raw = (int)(instr->src0.value.pc - final_pc);
+            enc = JAL(instr->dsts[0].value.reg_and_element_size.reg, raw);
+            break;
+        case OP_jalr:
+            enc = JALR(instr->dsts[0].value.reg_and_element_size.reg,
+                       instr->src0.value.reg_and_element_size.reg,
+                       instr->srcs[0].value.immed_int);
+            break;
+        case OP_auipc:
+            enc = AUIPC(instr->dsts[0].value.reg_and_element_size.reg,
+                       instr->src0.value.immed_int);
+            break;
+        default:
+            enc = 0x0;
+            break;
+    }
+
+    *(uint *)copy_pc = enc;
+    return copy_pc + 4;
 }
 
 byte *

--- a/core/ir/riscv64/instr.c
+++ b/core/ir/riscv64/instr.c
@@ -48,6 +48,9 @@ instr_get_isa_mode(instr_t *instr)
 int
 instr_length_arch(dcontext_t *dcontext, instr_t *instr)
 {
+    if (instr->opcode >= OP_c_lwsp && instr->opcode <= OP_c_ebreak) {
+        return RISCV64_INSTR_C_SIZE;
+    }
     /* FIXME i#3544: Compressed Instructions ISA extension has a shorter instruction
      * length. */
     return RISCV64_INSTR_SIZE;

--- a/core/ir/riscv64/instr_create_api.h.in
+++ b/core/ir/riscv64/instr_create_api.h.in
@@ -252,7 +252,7 @@
  * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
  */
 #define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
-    (INSTR_CREATE_slli(dc, opnd_create_reg(DR_REG_X5), s2_toshift, shift_amount), \
+    (INSTR_CREATE_slli(dc, opnd_create_reg(DR_REG_X5), s2_toshift, opnd_create_immed_int(shift_amount, OPSZ_1)), \
      INSTR_CREATE_add(dc, d, s1, opnd_create_reg(DR_REG_X5)))
 
 /**

--- a/core/ir/riscv64/instr_create_api.h.in
+++ b/core/ir/riscv64/instr_create_api.h.in
@@ -56,7 +56,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load(dc, r, m) INSTR_CREATE_ld(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t which loads 1 byte
@@ -66,7 +66,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_1byte_zext4(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load_1byte_zext4(dc, r, m) INSTR_CREATE_lbu(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 1-byte
@@ -75,7 +75,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_1byte(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load_1byte(dc, r, m) INSTR_CREATE_lbu(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 2-byte
@@ -84,7 +84,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_2bytes(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load_2bytes(dc, r, m) INSTR_CREATE_lhu(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 4-byte
@@ -93,7 +93,7 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store(dc, m, r) instr_create_1dst_1src(dc, OP_c_nop, m, r)
+#define XINST_CREATE_store(dc, m, r) INSTR_CREATE_sd(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 1-byte
@@ -102,7 +102,7 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store_1byte(dc, m, r) instr_create_1dst_1src(dc, OP_c_nop, m, r)
+#define XINST_CREATE_store_1byte(dc, m, r) INSTR_CREATE_sb(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 2-byte
@@ -111,7 +111,7 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store_2bytes(dc, m, r) instr_create_1dst_1src(dc, OP_c_nop, m, r)
+#define XINST_CREATE_store_2bytes(dc, m, r) INSTR_CREATE_sh(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a register
@@ -120,7 +120,7 @@
  * \param d   The destination register opnd.
  * \param s   The source register opnd.
  */
-#define XINST_CREATE_move(dc, d, s) instr_create_1dst_1src(dc, OP_c_nop, d, s)
+#define XINST_CREATE_move(dc, d, s) INSTR_CREATE_addi(dc, d, s, opnd_create_immed_int(0, OPSZ_1))
 
 /**
  * This platform-independent macro creates an instr_t for a multimedia
@@ -142,21 +142,12 @@
 
 /**
  * This platform-independent macro creates an instr_t for an indirect
- * jump through memory instruction.  For AArch32, the memory address
- * must be aligned to 4.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param m   The memory opnd holding the target.
- */
-#define XINST_CREATE_jump_mem(dc, m) \
-    instr_create_0dst_2src(dc, OP_c_nop, opnd_create_reg(DR_REG_PC), (m))
-
-/**
- * This platform-independent macro creates an instr_t for an indirect
  * jump instruction through a register.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param r   The register opnd holding the target.
  */
-#define XINST_CREATE_jump_reg(dc, r) instr_create_0dst_1src(dc, OP_c_nop, r)
+#define XINST_CREATE_jump_reg(dc, r) \
+    INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_X0), r, opnd_create_immed_int(0, OPSZ_1))
 
 /**
  * This platform-independent macro creates an instr_t for an immediate
@@ -165,25 +156,26 @@
  * \param r   The destination register opnd.
  * \param i   The source immediate integer opnd.
  */
-#define XINST_CREATE_load_int(dc, r, i) instr_create_1dst_1src(dc, OP_c_nop, r, i)
+#define XINST_CREATE_load_int(dc, r, i) INSTR_CREATE_addi(dc, r, opnd_create_reg(DR_REG_X0), i)
 
 /**
  * This platform-independent macro creates an instr_t for a return instruction.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  */
-#define XINST_CREATE_return(dc) instr_create_0dst_0src(dc, OP_c_nop)
+#define XINST_CREATE_return(dc) \
+    INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X1), opnd_create_immed_int(0, OPSZ_1))
 
 /**
  * This platform-independent macro creates an instr_t for an unconditional
  * branch instruction.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param t   The opnd_t target operand for the instruction, which can be
- * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
+ * either a pc (opnd_create_pc()) or an instr_t (opnd_create_instr()).
  * Be sure to ensure that the limited reach of this short branch will reach
  * the target (a pc operand is not suitable for most uses unless you know
  * precisely where this instruction will be encoded).
  */
-#define XINST_CREATE_jump(dc, t) instr_create_0dst_1src(dc, OP_c_nop, t)
+#define XINST_CREATE_jump(dc, t) INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_X0), t)
 
 /**
  * This platform-independent macro creates an instr_t for an unconditional
@@ -195,7 +187,7 @@
  * the target (a pc operand is not suitable for most uses unless you know
  * precisely where this instruction will be encoded).
  */
-#define XINST_CREATE_jump_short(dc, t) instr_create_0dst_1src(dc, OP_c_nop, t)
+#define XINST_CREATE_jump_short(dc, t) INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_X0), t)
 
 /**
  * This platform-independent macro creates an instr_t for an unconditional
@@ -207,7 +199,7 @@
  * the target (a pc operand is not suitable for most uses unless you know
  * precisely where this instruction will be encoded).
  */
-#define XINST_CREATE_call(dc, t) instr_create_0dst_1src(dc, OP_c_nop, t)
+#define XINST_CREATE_call(dc, t) INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_X1), t)
 
 /**
  * This platform-independent macro creates an instr_t for a conditional
@@ -231,7 +223,7 @@
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s  The opnd_t explicit source operand for the instruction.
  */
-#define XINST_CREATE_add(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
+#define XINST_CREATE_add(dc, d, s) INSTR_CREATE_add(dc, d, d, s)
 
 /**
  * This platform-independent macro creates an instr_t for an addition
@@ -244,8 +236,7 @@
  * \param s2  The opnd_t explicit source operand for the instruction. This
  * can be either a register or an immediate integer.
  */
-#define XINST_CREATE_add_2src(dc, d, s1, s2) \
-    instr_create_1dst_2src(dc, OP_c_nop, d, s1, s2)
+#define XINST_CREATE_add_2src(dc, d, s1, s2) INSTR_CREATE_add(dc, d, s1, s2)
 
 /**
  * This platform-independent macro creates an instr_t for an addition
@@ -261,8 +252,8 @@
  * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
  */
 #define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
-    instr_create_1dst_3src(dc, OP_c_nop, d, s1, s2_toshift,        \
-                           opnd_create_immed_int(shift_amount, OPSZ_1))
+    (INSTR_CREATE_slli(dc, opnd_create_reg(DR_REG_X5), s2_toshift, shift_amount), \
+     INSTR_CREATE_add(dc, d, s1, opnd_create_reg(DR_REG_X5)))
 
 /**
  * This platform-independent macro creates an instr_t for an addition
@@ -271,7 +262,7 @@
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s  The opnd_t explicit source operand for the instruction.
  */
-#define XINST_CREATE_add_s(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
+#define XINST_CREATE_add_s(dc, d, s) INSTR_CREATE_add(dc, d, d, s)
 
 /**
  * This platform-independent macro creates an instr_t for a subtraction
@@ -281,7 +272,7 @@
  * \param s  The opnd_t explicit source operand for the instruction.
  */
 /* FIXME: How to handle a lack of flags register? */
-#define XINST_CREATE_sub(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
+#define XINST_CREATE_sub(dc, d, s) INSTR_CREATE_sub(dc, d, d, s)
 
 /**
  * This platform-independent macro creates an instr_t for a subtraction
@@ -291,7 +282,7 @@
  * \param s  The opnd_t explicit source operand for the instruction.
  */
 /* FIXME: How to handle a lack of flags register? */
-#define XINST_CREATE_sub_s(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
+#define XINST_CREATE_sub_s(dc, d, s) INSTR_CREATE_sub(dc, d, d, s)
 
 /**
  * This platform-independent macro creates an instr_t for a bitwise and
@@ -301,7 +292,7 @@
  * \param s  The opnd_t explicit source operand for the instruction.
  */
 /* FIXME: How to handle a lack of flags register? */
-#define XINST_CREATE_and_s(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
+#define XINST_CREATE_and_s(dc, d, s) INSTR_CREATE_and(dc, d, d, s)
 
 /**
  * This platform-independent macro creates an instr_t for a comparison

--- a/core/ir/riscv64/instr_create_api.h.in
+++ b/core/ir/riscv64/instr_create_api.h.in
@@ -120,7 +120,8 @@
  * \param d   The destination register opnd.
  * \param s   The source register opnd.
  */
-#define XINST_CREATE_move(dc, d, s) INSTR_CREATE_addi(dc, d, s, opnd_create_immed_int(0, OPSZ_1))
+#define XINST_CREATE_move(dc, d, s) \
+    INSTR_CREATE_addi(dc, d, s, opnd_create_immed_int(0, OPSZ_1))
 
 /**
  * This platform-independent macro creates an instr_t for a multimedia
@@ -156,14 +157,16 @@
  * \param r   The destination register opnd.
  * \param i   The source immediate integer opnd.
  */
-#define XINST_CREATE_load_int(dc, r, i) INSTR_CREATE_addi(dc, r, opnd_create_reg(DR_REG_X0), i)
+#define XINST_CREATE_load_int(dc, r, i) \
+    INSTR_CREATE_addi(dc, r, opnd_create_reg(DR_REG_X0), i)
 
 /**
  * This platform-independent macro creates an instr_t for a return instruction.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  */
-#define XINST_CREATE_return(dc) \
-    INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X1), opnd_create_immed_int(0, OPSZ_1))
+#define XINST_CREATE_return(dc)                                                   \
+    INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X1), \
+                      opnd_create_immed_int(0, OPSZ_1))
 
 /**
  * This platform-independent macro creates an instr_t for an unconditional
@@ -251,8 +254,9 @@
  * must be a register.
  * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
  */
-#define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
-    (INSTR_CREATE_slli(dc, opnd_create_reg(DR_REG_X5), s2_toshift, opnd_create_immed_int(shift_amount, OPSZ_1)), \
+#define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount)    \
+    (INSTR_CREATE_slli(dc, opnd_create_reg(DR_REG_X5), s2_toshift,   \
+                       opnd_create_immed_int(shift_amount, OPSZ_1)), \
      INSTR_CREATE_add(dc, d, s1, opnd_create_reg(DR_REG_X5)))
 
 /**

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1840,7 +1840,8 @@ privload_mem_is_elf_so_header(byte *mem)
      */
     if (
 #        ifdef X64
-        elf_hdr->e_machine != EM_X86_64 && elf_hdr->e_machine != EM_AARCH64 && elf_hdr->e_machine != EM_RISCV
+        elf_hdr->e_machine != EM_X86_64 && elf_hdr->e_machine != EM_AARCH64 &&
+        elf_hdr->e_machine != EM_RISCV
 #        else
         elf_hdr->e_machine != EM_386 && elf_hdr->e_machine != EM_ARM
 #        endif

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1840,7 +1840,7 @@ privload_mem_is_elf_so_header(byte *mem)
      */
     if (
 #        ifdef X64
-        elf_hdr->e_machine != EM_X86_64 && elf_hdr->e_machine != EM_AARCH64
+        elf_hdr->e_machine != EM_X86_64 && elf_hdr->e_machine != EM_AARCH64 && elf_hdr->e_machine != EM_RISCV
 #        else
         elf_hdr->e_machine != EM_386 && elf_hdr->e_machine != EM_ARM
 #        endif

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -2155,7 +2155,7 @@ get_local_state()
 void
 os_enter_dynamorio(void)
 {
-#    ifdef ARM
+#    if defined(ARM) || defined(RISCV64)
     /* i#1578: check that app's tls value doesn't match our sentinel */
     ASSERT(*(byte **)get_dr_tls_base_addr() != TLS_SLOT_VAL_EXITED);
 #    endif

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1730,7 +1730,7 @@ os_timeout(int time_in_milliseconds)
             ASSERT(sizeof(var) == sizeof(void *));                     \
             __asm__ __volatile__("ld %0, %1(tp) \n\t"                  \
                                  "ld %0, %2(%0) \n\t"                  \
-                                 : "=r"(var)                           \
+                                 : "+r"(var)                           \
                                  : "i"(DR_TLS_BASE_OFFSET), "i"(imm)); \
         } while (0)
 #    define WRITE_TLS_INT_SLOT_IMM(imm, var)                                   \
@@ -1868,7 +1868,7 @@ is_thread_tls_initialized(void)
         } else
             return false;
     }
-#elif defined(AARCHXX)
+#elif defined(AARCHXX) || defined(RISCV64)
     byte **dr_tls_base_addr;
     if (tls_global_type == TLS_TYPE_NONE)
         return false;
@@ -1884,10 +1884,6 @@ is_thread_tls_initialized(void)
      * which comes here.
      */
     return true;
-#else
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
-    return false;
 #endif
     return true;
 }
@@ -1982,7 +1978,7 @@ os_get_priv_tls_base(dcontext_t *dcontext, reg_id_t reg)
 os_local_state_t *
 get_os_tls(void)
 {
-    os_local_state_t *os_tls;
+    os_local_state_t *os_tls = NULL;
     ASSERT(is_thread_tls_initialized());
     READ_TLS_SLOT_IMM(TLS_SELF_OFFSET, os_tls);
     return os_tls;
@@ -2139,7 +2135,7 @@ get_app_segment_base(uint seg)
 local_state_extended_t *
 get_local_state_extended()
 {
-    os_local_state_t *os_tls;
+    os_local_state_t *os_tls = NULL;
     ASSERT(is_thread_tls_initialized());
     READ_TLS_SLOT_IMM(TLS_SELF_OFFSET, os_tls);
     return &(os_tls->state);
@@ -3051,7 +3047,7 @@ d_r_get_thread_id(void)
 thread_id_t
 get_tls_thread_id(void)
 {
-    ptr_int_t tid; /* can't use thread_id_t since it's 32-bits */
+    ptr_int_t tid = 0; /* can't use thread_id_t since it's 32-bits */
     if (!is_thread_tls_initialized())
         return INVALID_THREAD_ID;
     READ_TLS_SLOT_IMM(TLS_THREAD_ID_OFFSET, tid);
@@ -3068,7 +3064,7 @@ dcontext_t *
 get_thread_private_dcontext(void)
 {
 #ifdef HAVE_TLS
-    dcontext_t *dcontext;
+    dcontext_t *dcontext = NULL;
     /* We have to check this b/c this is called from __errno_location prior
      * to os_tls_init, as well as after os_tls_exit, and early in a new
      * thread's initialization (see comments below on that).
@@ -3182,7 +3178,7 @@ replace_thread_id(thread_id_t old, thread_id_t new)
     thread_id_t new_tid = new;
     ASSERT(is_thread_tls_initialized());
     DOCHECK(1, {
-        thread_id_t old_tid;
+        thread_id_t old_tid = 0;
         IF_LINUX_ELSE(READ_TLS_INT_SLOT_IMM(TLS_THREAD_ID_OFFSET, old_tid),
                       READ_TLS_SLOT_IMM(TLS_THREAD_ID_OFFSET, old_tid));
         ASSERT(old_tid == old);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1887,7 +1887,7 @@ is_thread_tls_initialized(void)
 #else
     /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
-    return true;
+    return false;
 #endif
     return true;
 }

--- a/core/unix/tls.h
+++ b/core/unix/tls.h
@@ -120,7 +120,7 @@ typedef struct _our_modify_ldt_t {
                          : "m"((val))                                                 \
                          : ASM_XAX);                                                  \
         } while (0)
-#elif defined(AARCHXX)
+#elif defined(AARCHXX) || defined(RISCV64)
 #    define WRITE_DR_SEG(val) ASSERT_NOT_REACHED()
 #    define WRITE_LIB_SEG(val) ASSERT_NOT_REACHED()
 #    define TLS_SLOT_VAL_EXITED ((byte *)PTR_UINT_MINUS_1)
@@ -314,7 +314,7 @@ tls_thread_preinit();
 void
 tls_thread_free(tls_type_t tls_type, int index);
 
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
 byte **
 get_dr_tls_base_addr(void);
 #endif

--- a/core/unix/tls_linux_riscv64.c
+++ b/core/unix/tls_linux_riscv64.c
@@ -57,21 +57,37 @@ get_dr_tls_base_addr(void)
 void
 tls_thread_init(os_local_state_t *os_tls, byte *segment)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
+    ASSERT(read_thread_register(TLS_REG_LIB) != 0);
+    ASSERT(os_tls->os_seg_info.priv_lib_tls_base == NULL);
+    ASSERT(*get_dr_tls_base_addr() == NULL ||
+           *get_dr_tls_base_addr() == TLS_SLOT_VAL_EXITED);
+    *get_dr_tls_base_addr() = segment;
+    os_tls->tls_type = TLS_TYPE_SLOT;
 }
 
 bool
 tls_thread_preinit()
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
-    return false;
+    return true;
 }
 
 void
 tls_thread_free(tls_type_t tls_type, int index)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
+    byte **dr_tls_base_addr;
+    os_local_state_t *os_tls;
+
+    ASSERT(tls_type == TLS_TYPE_SLOT);
+    dr_tls_base_addr = get_dr_tls_base_addr();
+    ASSERT(dr_tls_base_addr != NULL);
+    os_tls = (os_local_state_t *)*dr_tls_base_addr;
+    ASSERT(os_tls->self == os_tls);
+    /* FIXME i#1578: support detach on RISCV. We need some way to
+     * determine whether a thread has exited (for deadlock_avoidance_unlock,
+     * e.g.) after dcontext and os_tls are freed.  For now we store -1 in this
+     * slot and assume the app will never use that value (we check in
+     * os_enter_dynamorio()).
+     */
+    *dr_tls_base_addr = TLS_SLOT_VAL_EXITED;
+    return;
 }

--- a/core/unix/tls_linux_riscv64.c
+++ b/core/unix/tls_linux_riscv64.c
@@ -48,9 +48,10 @@
 byte **
 get_dr_tls_base_addr(void)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
-    return NULL;
+    byte *lib_tls_base = (byte *)read_thread_register(TLS_REG_LIB);
+    if (lib_tls_base == NULL)
+        return NULL;
+    return (byte **)(lib_tls_base + DR_TLS_BASE_OFFSET);
 }
 
 void


### PR DESCRIPTION
In this patch, along with other Pending PRs of mine (namely #6070 #6064 #6062 #6061), we're getting closer to `drrun` a simple hello world program. This patch contains the following changes:

1. Added machine type support for ELF hdr verification
2. Fixed various atomics and TLS issues

With this patch, running a simple program like this one:
```
.global _start
_start: li      a0, 1
        la      a1, helloworld
        li      a2, 14
        li      a7, 64
        ecall

        li      a0, 0
        li      a7, 93
        ecall

.data
helloworld:     .ascii "Hello, World!\n"
```
Gives meaningful error message(will segfault before):

```
debian@lpi4a:/media/debian/Data/dynamorio/build$ ./bin64/drrun -verbose hello
INFO: default root: /media/debian/Data/dynamorio/build/bin64/..
INFO: default toolconfig dir: /media/debian/Data/dynamorio/build/bin64/../tools
INFO: targeting application: "/media/debian/Data/dynamorio/build/hello"
INFO: app cmdline:  "hello"
INFO: configuration directory is "/home/debian/.dynamorio"
INFO: will exec /media/debian/Data/dynamorio/build/hello
<Application /media/debian/Data/dynamorio/build/hello (214671). Cannot correctly handle received signal 11 in thread 214671: default action in native thread.>
```

I'll keep trying to fix bugs in a follow-up PR.

Issue #3544 