### PR TITLE
i#6020: Document possible multiple print_interval_results calls

### DIFF
--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -167,6 +167,9 @@ public:
      * framework automatically.
      */
     struct interval_state_snapshot_t {
+        // This constructor is only for convenience in unit tests. The tool does not
+        // need to provide these values, and can simply use the default constructor
+        // below.
         interval_state_snapshot_t(uint64_t interval_id, uint64_t interval_end_timestamp,
                                   uint64_t instr_count_cumulative,
                                   uint64_t instr_count_delta)
@@ -184,6 +187,8 @@ public:
         {
         }
 
+        // The following fields are set automatically by the analyzer framework. The
+        // tool does not need to set them.
         uint64_t interval_id;
         // Stores the timestamp (exclusive) when the above interval ends. Note
         // that this is not the last timestamp actually seen in the trace interval,
@@ -269,8 +274,17 @@ public:
         return nullptr;
     }
     /**
-     * Prints the interval results for the whole trace. The state snapshots
-     * for intervals can be found in the given \p interval_snapshots.
+     * Prints the interval results for the given series of interval state snapshots in
+     * \p interval_snapshots.
+     *
+     * This is currently invoked with the list of whole-trace interval snapshots (for
+     * the parallel mode, these are the snapshots created by merging the shard-local
+     * snapshots).
+     *
+     * The framework should be able to invoke this multiple times, possibly with a
+     * different list of interval snapshots. So it should avoid free-ing memory or
+     * changing global state. This is to keep open the possibility of the framework
+     * printing interval results for each shard separately in future.
      */
     virtual bool
     print_interval_results(

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -309,13 +309,19 @@ public:
         {
             return interval_id == rhs.interval_id &&
                 interval_end_timestamp == rhs.interval_end_timestamp &&
+                instr_count_cumulative == rhs.instr_count_cumulative &&
+                instr_count_delta == rhs.instr_count_delta &&
+                active_shard_count == rhs.active_shard_count &&
                 component_intervals == rhs.component_intervals;
         }
         void
         print() const
         {
-            std::cerr << "(interval_id: " << interval_id
-                      << ", interval_end_timestamp: " << interval_end_timestamp
+            std::cerr << "(id: " << interval_id
+                      << ", end_timestamp: " << interval_end_timestamp
+                      << ", instr_count_cumulative: " << instr_count_cumulative
+                      << ", instr_count_delta: " << instr_count_delta
+                      << ", active_shard_count: " << active_shard_count
                       << ", component_intervals: ";
             for (const auto &s : component_intervals) {
                 std::cerr << "(tid:" << s.tid << ", seen_memrefs:" << s.seen_memrefs

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -311,7 +311,6 @@ public:
                 interval_end_timestamp == rhs.interval_end_timestamp &&
                 instr_count_cumulative == rhs.instr_count_cumulative &&
                 instr_count_delta == rhs.instr_count_delta &&
-                active_shard_count == rhs.active_shard_count &&
                 component_intervals == rhs.component_intervals;
         }
         void
@@ -321,7 +320,6 @@ public:
                       << ", end_timestamp: " << interval_end_timestamp
                       << ", instr_count_cumulative: " << instr_count_cumulative
                       << ", instr_count_delta: " << instr_count_delta
-                      << ", active_shard_count: " << active_shard_count
                       << ", component_intervals: ";
             for (const auto &s : component_intervals) {
                 std::cerr << "(tid:" << s.tid << ", seen_memrefs:" << s.seen_memrefs


### PR DESCRIPTION
Adds to the print_interval_results() doc that tools should avoid free-ing memory
or modifying global state, so that the analyzer framework can invoke it multiple
times. This is to keep open the possibility of the framework printing interval results
for each shard separately in the future by invoking this API multiple times.

Separately: Adds missing comparison for instr_count_delta and instr_count_cumulative
to recorded_snapshot_t::operator==().

Issue: #6020