### PR TITLE
i#2204: Retry flaky tests in suite

### DIFF
--- a/suite/runsuite_common_pre.cmake
+++ b/suite/runsuite_common_pre.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2022 Google, Inc.    All rights reserved.
+# Copyright (c) 2011-2023 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -686,6 +686,11 @@ function(testbuild_ex name is64 initial_cache test_only_in_long
         set(ctest_test_args ${ctest_test_args} EXCLUDE ${arg_exclude})
       endif (NOT "${arg_exclude}" STREQUAL "")
       set(ctest_test_args ${ctest_test_args} ${extra_ctest_args})
+      if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.17")
+        # CMake 3.17 supports retrying failed tests.  We avoid flaky tests on
+        # particular platforms failing the whole suite by trying multiple times.
+        set(ctest_test_args ${ctest_test_args} "REPEAT" "UNTIL_PASS:3")
+      endif ()
       if (WIN32 AND TEST_LONG)
         # FIXME i#265: on Windows we can't run multiple instances of
         # the same app b/c of global reg key conflicts: should support
@@ -718,7 +723,7 @@ function(testbuild_ex name is64 initial_cache test_only_in_long
       set(prefix "___${CTEST_BUILD_NAME}___${SUITE_TYPE}___XML___")
       foreach (xml ${xml_files})
         get_filename_component(base "${xml}" NAME)
-        # Avoid confusion with a later package buid in the same dir by
+        # Avoid confusion with a later package build in the same dir by
         # renaming instead of copying.
         file(RENAME "${xml}"
           "${CTEST_DROP_SITE}:${CTEST_DROP_LOCATION}/${prefix}${base}")


### PR DESCRIPTION
If cmake 3.17+ is in use, enables retrying of failed tests up to 3x with any one of them passing resulting in an overall pass.  This avoids flaky tests marking the whole suite red, which is even more problematic with merge queues.

All of our Github Actions platforms (macos-11, windows-2019, ubuntu-20.04, ubuntu-22.04) have cmake 3.26+ so this is enabled for all of our GA CI tests.

Tested:
I made a test which fails 3/4 of the time:
```
  add_test(bogus bash -c "exit \$((RANDOM % 4))")
```
I made it easy to run just this test (gave it a label; disabled other builds, etc.) for convenience and then ran:
```
  $ ctest -VV -S ../src/suite/runsuite.cmake,64_only
```
Which resulted in:
```
  test 1
      Start 1: bogus

  1: Test command: /usr/bin/bash "-c" "exit $((RANDOM % 4))"
  1: Working Directory: /usr/local/google/home/bruening/dr/git/build_suite/build_debug-internal-64
  1: Test timeout computed to be: 600
  1/1 Test #1: bogus ............................***Failed    0.00 sec
      Start 1: bogus

  1: Test command: /usr/bin/bash "-c" "exit $((RANDOM % 4))"
  1: Working Directory: /usr/local/google/home/bruening/dr/git/build_suite/build_debug-internal-64
  1: Test timeout computed to be: 600
      Test #1: bogus ............................   Passed    0.00 sec

  100% tests passed, 0 tests failed out of 1
```

Issue: #2204, #5873
Fixes #2204