### PR TITLE
i#6020 interval analysis: Adjust virtual interface

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -593,7 +593,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::merge_shard_interval_results(
 
 template <typename RecordType, typename ReaderType>
 bool
-analyzer_tmpl_t<RecordType, ReaderType>::collect_and_merge_shard_interval_results()
+analyzer_tmpl_t<RecordType, ReaderType>::collect_and_maybe_merge_shard_interval_results()
 {
     // all_intervals[tool_idx][shard_idx] contains a queue of the
     // interval_state_snapshot_t* that were output by that tool for that shard.
@@ -661,7 +661,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::run()
         }
     }
     if (interval_microseconds_ != 0) {
-        return collect_and_merge_shard_interval_results();
+        return collect_and_maybe_merge_shard_interval_results();
     }
     return true;
 }
@@ -677,7 +677,9 @@ analyzer_tmpl_t<RecordType, ReaderType>::print_stats()
             error_string_ = tools_[i]->get_error_string();
             return false;
         }
-        if (interval_microseconds_ != 0) {
+        if (interval_microseconds_ != 0 && !merged_interval_snapshots_.empty()) {
+            // merged_interval_snapshots_ may be empty depending on the derived class'
+            // implementation of collect_and_maybe_merge_shard_interval_results.
             if (!merged_interval_snapshots_[i].empty() &&
                 !tools_[i]->print_interval_results(merged_interval_snapshots_[i])) {
                 error_string_ = tools_[i]->get_error_string();

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -678,7 +678,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::print_stats()
             return false;
         }
         if (interval_microseconds_ != 0 && !merged_interval_snapshots_.empty()) {
-            // merged_interval_snapshots_ may be empty depending on the derived class'
+            // merged_interval_snapshots_ may be empty depending on the derived class's
             // implementation of collect_and_maybe_merge_shard_interval_results.
             if (!merged_interval_snapshots_[i].empty() &&
                 !tools_[i]->print_interval_results(merged_interval_snapshots_[i])) {

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -240,8 +240,8 @@ protected:
         analyzer_shard_data_t *shard, uint64_t &prev_interval_index,
         uint64_t &prev_interval_init_instr_count);
 
-    // Collects interval results for all shards from the workers, and then merges
-    // the shard-local intervals to form the whole-trace interval results using
+    // Collects interval results for all shards from the workers, and then optional
+    // merges the shard-local intervals to form the whole-trace interval results using
     // merge_shard_interval_results(). Derived classes may override this to change
     // whether and how shard-local intervals are merged.
     virtual bool
@@ -287,7 +287,7 @@ protected:
     // in merge_shard_interval_results.
     // merged_interval_snapshots_[tool_idx] is a vector of the interval snapshots
     // (in order of the intervals) for that tool.
-    // This may not be set, depending on the derived class' implementation of
+    // This may not be set, depending on the derived class's implementation of
     // collect_and_maybe_merge_shard_interval_results.
     std::vector<std::vector<
         typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t *>>

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -242,16 +242,17 @@ protected:
 
     // Collects interval results for all shards from the workers, and then merges
     // the shard-local intervals to form the whole-trace interval results using
-    // merge_shard_interval_results().
-    bool
-    collect_and_merge_shard_interval_results();
+    // merge_shard_interval_results(). Derived classes may override this to change
+    // whether and how shard-local intervals are merged.
+    virtual bool
+    collect_and_maybe_merge_shard_interval_results();
 
     // Computes and stores the interval results in merged_interval_snapshots_. For
     // serial analysis where we already have only a single shard, this involves
     // simply copying interval_state_snapshot_t* from the input. For parallel
     // analysis, this involves merging results from multiple shards for intervals
     // that map to the same final whole-trace interval.
-    virtual bool
+    bool
     merge_shard_interval_results(
         std::vector<std::queue<
             typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t *>>
@@ -286,6 +287,8 @@ protected:
     // in merge_shard_interval_results.
     // merged_interval_snapshots_[tool_idx] is a vector of the interval snapshots
     // (in order of the intervals) for that tool.
+    // This may not be set, depending on the derived class' implementation of
+    // collect_and_maybe_merge_shard_interval_results.
     std::vector<std::vector<
         typename analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t *>>
         merged_interval_snapshots_;


### PR DESCRIPTION
Adjusts virtual interfaces to allow derived classes to cleanly modify the
logic for handling merging of interval snapshots.

Issue: #6020