### PR TITLE
i#5843 scheduler: Add nested speculation layers

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1561,7 +1561,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::start_speculation(output_ordinal_t out
             outinfo.speculation_split.push(outinfo.speculate_pc);
     }
     outinfo.speculate_pc = start_address;
-    VPRINT(this, 2, "start_speculation layer=%zu pc=0x%" PRIx64 "\n",
+    VPRINT(this, 2, "start_speculation layer=%zu pc=0x%zx\n",
            outinfo.speculation_split.size(), start_address);
     return sched_type_t::STATUS_OK;
 }
@@ -1577,7 +1577,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::stop_speculation(output_ordinal_t outp
         // speculate_pc is only used when exiting inner layers.
         outinfo.speculate_pc = outinfo.speculation_split.top();
     }
-    VPRINT(this, 2, "stop_speculation layer=%zu (resume=0x%" PRIx64 ")\n",
+    VPRINT(this, 2, "stop_speculation layer=%zu (resume=0x%zx)\n",
            outinfo.speculation_split.size(), outinfo.speculate_pc);
     outinfo.speculation_split.pop();
     return sched_type_t::STATUS_OK;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -47,6 +47,7 @@
 #include <mutex>
 #include <queue>
 #include <set>
+#include <stack>
 #include <unordered_map>
 #include <vector>
 #include "archive_istream.h"
@@ -522,25 +523,23 @@ public:
          * Because the instruction record after a branch typically needs to be read
          * before knowing whether a simulator is on the wrong path or not, this routine
          * supports putting back the current record so that it will be re-provided as
-         * the first record after stop_speculation(), if "queue_current_record" is true.
-         * The "queue_current_record" parameter is ignored if speculation is already in
-         * effect.
+         * the first record after (the outermost) stop_speculation(), if
+         * "queue_current_record" is true.
          *
-         * This call can be "nested" but only one stop_speculation call is needed to
-         * resume the paused stream.
+         * This call can be nested; each call needs to be paired with a corresponding
+         * stop_speculation() call.
          */
         virtual stream_status_t
         start_speculation(addr_t start_address, bool queue_current_record);
 
         /**
-         * Stops speculative execution and resumes the regular stream of records from
-         * the point at which the most distant prior start_speculation() call without an
-         * intervening stop_speculation() call was made (either repeating the current
-         * record at that time, if "true" was passed for "queue_current_record" to
-         * start_speculation(), or continuing on the subsequent record if "false" was
-         * passed).  Returns #dynamorio::drmemtrace::scheduler_tmpl_t::STATUS_INVALID if
-         * there was no prior start_speculation() call or if stop_speculation() was
-         * already called since the last start.
+         * Stops speculative execution, resuming execution at the
+         * stream of records from the point at which the prior start_speculation()
+         * call was made, either repeating the current record at that time (if "true"
+         * was passed for "queue_current_record" to start_speculation()) or continuing
+         * on the subsequent record (if "false" was passed).  Returns
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::STATUS_INVALID if there was no
+         * prior start_speculation() call.
          */
         virtual stream_status_t
         stop_speculation();
@@ -891,9 +890,10 @@ protected:
         std::vector<input_ordinal_t> input_indices;
         int input_indices_index = 0;
         // Speculation support.
-        bool speculating = false;
+        std::stack<addr_t> speculation_split; // PC of resumption point.
         speculator_tmpl_t<RecordType> speculator;
         addr_t speculate_pc = 0;
+        addr_t prev_speculate_pc = 0;
         RecordType last_record;
         // A list of schedule segments.  These are accessed only while holding
         // sched_lock_.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -534,10 +534,10 @@ public:
 
         /**
          * Stops speculative execution, resuming execution at the
-         * stream of records from the point at which the prior start_speculation()
-         * call was made, either repeating the current record at that time (if "true"
-         * was passed for "queue_current_record" to start_speculation()) or continuing
-         * on the subsequent record (if "false" was passed).  Returns
+         * stream of records from the point at which the prior matching
+         * start_speculation() call was made, either repeating the current record at that
+         * time (if "true" was passed for "queue_current_record" to start_speculation())
+         * or continuing on the subsequent record (if "false" was passed).  Returns
          * #dynamorio::drmemtrace::scheduler_tmpl_t::STATUS_INVALID if there was no
          * prior start_speculation() call.
          */
@@ -890,9 +890,13 @@ protected:
         std::vector<input_ordinal_t> input_indices;
         int input_indices_index = 0;
         // Speculation support.
-        std::stack<addr_t> speculation_split; // PC of resumption point.
+        std::stack<addr_t> speculation_stack; // Stores PC of resumption point.
         speculator_tmpl_t<RecordType> speculator;
         addr_t speculate_pc = 0;
+        // Stores the value of speculate_pc before asking the speculator for the current
+        // record.  So if that record was an instruction, speculate_pc holds the next PC
+        // while this field holds the instruction's start PC.  The use case is for
+        // queueing a read-ahead instruction record for start_speculation().
         addr_t prev_speculate_pc = 0;
         RecordType last_record;
         // A list of schedule segments.  These are accessed only while holding

--- a/clients/drcachesim/scheduler/speculator.cpp
+++ b/clients/drcachesim/scheduler/speculator.cpp
@@ -77,6 +77,10 @@ speculator_tmpl_t<memref_t>::next_record(addr_t &pc, memref_t &memref)
     // Supply nops.
     // Since this is just one encoding, we hardcoded it.
     // If we add more we'll want to pull in DR's encoder and use its IR.
+    // XXX i#5843: Once we add more complex schemes, we'll need to either save
+    // the last record for a given PC or have the scheduler do it, to ensure
+    // resuming a nested speculation layer where the user asked to see the same
+    // instruction again provides the right data.
     memref.instr.type = TRACE_TYPE_INSTR;
     memref.instr.addr = pc;
 

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -993,17 +993,50 @@ test_speculation()
             stream->stop_speculation();
             break;
         case 12:
+            // Back to the outer speculation layer's next PC.
+            assert(type_is_instr(memref.instr.type));
+            assert(memref_is_nop_instr(memref));
+#ifdef AARCH64
+            assert(memref.instr.addr == 204);
+#elif defined(X86_64) || defined(X86_32)
+            assert(memref.instr.addr == 201);
+#elif defined(ARM)
+            assert(memref.instr.addr == 202 || memref.instr.addr == 204);
+#endif
+            // Test a nested start_speculation(), saving the current record.
+            stream->start_speculation(400, true);
+            break;
+        case 13:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref_is_nop_instr(memref));
+            assert(memref.instr.addr == 400);
+            stream->stop_speculation();
+            break;
+        case 14:
+            // Back to the outer speculation layer's prior PC.
+            assert(type_is_instr(memref.instr.type));
+            assert(memref_is_nop_instr(memref));
+#ifdef AARCH64
+            assert(memref.instr.addr == 204);
+#elif defined(X86_64) || defined(X86_32)
+            assert(memref.instr.addr == 201);
+#elif defined(ARM)
+            assert(memref.instr.addr == 202 || memref.instr.addr == 204);
+#endif
+            stream->stop_speculation();
+            break;
+        case 15:
             // Back to the trace, but skipping what we already read.
             assert(type_is_instr(memref.instr.type));
             assert(memref.instr.addr == 5);
             break;
         default:
-            assert(ordinal == 13);
+            assert(ordinal == 16);
             assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
         }
         ++ordinal;
     }
-    assert(ordinal == 14);
+    assert(ordinal == 17);
 }
 
 static void


### PR DESCRIPTION
Changes speculation support to use distinct layers, allowing an inner speculation to roll back to the next-outermost interruption point.

Adds unit tests.

Issue: #5843