### PR TITLE
i#5843 scheduler: Add time dependencies to dynamic schedules

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -422,7 +422,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
     options_ = options;
     verbosity_ = options_.verbosity;
     // workload_inputs is not const so we can std::move readers out of it.
-    for (auto &workload : workload_inputs) {
+    std::unordered_map<int, std::vector<int>> workload2inputs(workload_inputs.size());
+    for (int workload_idx = 0; workload_idx < static_cast<int>(workload_inputs.size());
+         ++workload_idx) {
+        auto &workload = workload_inputs[workload_idx];
         if (workload.struct_size != sizeof(input_workload_t))
             return STATUS_ERROR_INVALID_PARAMETER;
         std::unordered_map<memref_tid_t, int> workload_tids;
@@ -439,6 +442,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
                 inputs_.emplace_back();
                 input_info_t &input = inputs_.back();
                 input.index = index;
+                input.workload = workload_idx;
+                workload2inputs[workload_idx].push_back(index);
                 input.tid = reader.tid;
                 input.reader = std::move(reader.reader);
                 input.reader_end = std::move(reader.end);
@@ -452,6 +457,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
                 open_readers(workload.path, workload.only_threads, workload_tids);
             if (res != STATUS_SUCCESS)
                 return res;
+            for (const auto &it : workload_tids) {
+                inputs_[it.second].workload = workload_idx;
+                workload2inputs[workload_idx].push_back(it.second);
+            }
         }
         for (const auto &modifiers : workload.thread_modifiers) {
             if (modifiers.struct_size != sizeof(input_thread_info_t))
@@ -539,9 +548,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
         sched_type_t::scheduler_status_t status = read_recorded_schedule();
         if (status != sched_type_t::STATUS_SUCCESS)
             return STATUS_ERROR_INVALID_PARAMETER;
-    } else if (options_.schedule_replay_istream != nullptr)
+    } else if (options_.schedule_replay_istream != nullptr) {
         return STATUS_ERROR_INVALID_PARAMETER;
-    if (options_.mapping == MAP_TO_CONSISTENT_OUTPUT) {
+    } else if (options_.mapping == MAP_TO_CONSISTENT_OUTPUT) {
         // Assign the inputs up front to avoid locks once we're in parallel mode.
         // We use a simple round-robin static assignment for now.
         for (int i = 0; i < static_cast<input_ordinal_t>(inputs_.size()); ++i) {
@@ -570,6 +579,17 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
             sched_type_t::scheduler_status_t res = get_initial_timestamps();
             if (res != STATUS_SUCCESS)
                 return res;
+            uint64_t min_time = std::numeric_limits<uint64_t>::max();
+            input_ordinal_t min_input = -1;
+            for (int i = 0; i < static_cast<input_ordinal_t>(inputs_.size()); ++i) {
+                if (inputs_[i].next_timestamp < min_time) {
+                    min_time = inputs_[i].next_timestamp;
+                    min_input = i;
+                }
+            }
+            if (min_input < 0)
+                return STATUS_ERROR_INVALID_PARAMETER;
+            set_cur_input(0, static_cast<input_ordinal_t>(min_input));
         }
     } else {
         // TODO i#5843: Implement time-based quanta.
@@ -578,15 +598,60 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
         // Assign initial inputs.
         // TODO i#5843: Once we support core bindings and priorities we'll want
         // to consider that here.
-        for (int i = 0; i < static_cast<output_ordinal_t>(outputs_.size()); ++i) {
-            if (i < static_cast<input_ordinal_t>(inputs_.size()))
-                set_cur_input(i, i);
-            else
-                set_cur_input(i, INVALID_INPUT_ORDINAL);
-        }
-        for (int i = static_cast<output_ordinal_t>(outputs_.size());
-             i < static_cast<input_ordinal_t>(inputs_.size()); ++i) {
-            ready_.push(i);
+        if (options_.deps == DEPENDENCY_TIMESTAMPS) {
+            sched_type_t::scheduler_status_t res = get_initial_timestamps();
+            if (res != STATUS_SUCCESS)
+                return res;
+            // Compute the min timestamp (==base_timestamp) per workload and sort
+            // all inputs by relative time from the base.
+            for (int workload_idx = 0;
+                 workload_idx < static_cast<int>(workload_inputs.size());
+                 ++workload_idx) {
+                uint64_t min_time = std::numeric_limits<uint64_t>::max();
+                input_ordinal_t min_input = -1;
+                for (int input_idx : workload2inputs[workload_idx]) {
+                    if (inputs_[input_idx].next_timestamp < min_time) {
+                        min_time = inputs_[input_idx].next_timestamp;
+                        min_input = input_idx;
+                    }
+                }
+                if (min_input < 0)
+                    return STATUS_ERROR_INVALID_PARAMETER;
+                for (int input_idx : workload2inputs[workload_idx]) {
+                    VPRINT(this, 4,
+                           "workload %d: setting input %d base_timestamp to %" PRIu64
+                           " vs next_timestamp %" PRIu64 "\n",
+                           workload_idx, input_idx, min_time,
+                           inputs_[input_idx].next_timestamp);
+                    inputs_[input_idx].base_timestamp = min_time;
+                }
+            }
+            // Pick the starting inputs by sorting by relative time from each workload's
+            // base_timestamp, which our queue does for us.  We want the rest of the
+            // inputs in the queue in any case so it is simplest to insert all and
+            // remove the first N rather than sorting the first N separately.
+            for (int i = 0; i < static_cast<input_ordinal_t>(inputs_.size()); ++i) {
+                add_to_ready_queue(&inputs_[i]);
+            }
+            for (int i = 0; i < static_cast<output_ordinal_t>(outputs_.size()); ++i) {
+                if (i < static_cast<input_ordinal_t>(inputs_.size())) {
+                    input_info_t *queue_next = pop_from_ready_queue();
+                    set_cur_input(i, queue_next->index);
+                } else
+                    set_cur_input(i, INVALID_INPUT_ORDINAL);
+            }
+        } else {
+            // Just take the 1st N inputs (even if all from the same workload).
+            for (int i = 0; i < static_cast<output_ordinal_t>(outputs_.size()); ++i) {
+                if (i < static_cast<input_ordinal_t>(inputs_.size()))
+                    set_cur_input(i, i);
+                else
+                    set_cur_input(i, INVALID_INPUT_ORDINAL);
+            }
+            for (int i = static_cast<output_ordinal_t>(outputs_.size());
+                 i < static_cast<input_ordinal_t>(inputs_.size()); ++i) {
+                add_to_ready_queue(&inputs_[i]);
+            }
         }
     }
     return STATUS_SUCCESS;
@@ -831,7 +896,6 @@ scheduler_tmpl_t<RecordType, ReaderType>::get_initial_timestamps()
     // Read ahead in each input until we find a timestamp record.
     // Queue up any skipped records to ensure we present them to the
     // output stream(s).
-    uint64_t min_time = 0xffffffffffffffff;
     for (size_t i = 0; i < inputs_.size(); ++i) {
         input_info_t &input = inputs_[i];
         if (input.next_timestamp <= 0) {
@@ -855,15 +919,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::get_initial_timestamps()
         }
         if (input.next_timestamp <= 0)
             return STATUS_ERROR_INVALID_PARAMETER;
-        if (input.next_timestamp < min_time) {
-            min_time = input.next_timestamp;
-            // TODO i#5843: Support more than one output (already checked earlier).
-            set_cur_input(0, static_cast<input_ordinal_t>(i));
-        }
     }
-    if (outputs_[0].cur_input >= 0)
-        return STATUS_SUCCESS;
-    return STATUS_ERROR_INVALID_PARAMETER;
+    return STATUS_SUCCESS;
 }
 
 template <typename RecordType, typename ReaderType>
@@ -1158,6 +1215,44 @@ scheduler_tmpl_t<RecordType, ReaderType>::close_schedule_segment(output_ordinal_
 }
 
 template <typename RecordType, typename ReaderType>
+bool
+scheduler_tmpl_t<RecordType, ReaderType>::ready_queue_empty()
+{
+    if (options_.deps == DEPENDENCY_TIMESTAMPS)
+        return ready_.empty();
+    return ready_fifo_.empty();
+}
+
+template <typename RecordType, typename ReaderType>
+void
+scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(input_info_t *input)
+{
+    if (options_.deps == DEPENDENCY_TIMESTAMPS) {
+        VPRINT(this, 4, "add_to_ready_queue: input %d timestamp delta %" PRIu64 "\n",
+               input->index, input->reader->get_last_timestamp() - input->base_timestamp);
+        ready_.push(input);
+        return;
+    }
+    ready_fifo_.push(input);
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::input_info_t *
+scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue()
+{
+    if (options_.deps == DEPENDENCY_TIMESTAMPS) {
+        input_info_t *res = ready_.top();
+        ready_.pop();
+        VPRINT(this, 4, "pop_from_ready_queue: input %d timestamp delta %" PRIu64 "\n",
+               res->index, res->reader->get_last_timestamp() - res->base_timestamp);
+        return res;
+    }
+    input_info_t *res = ready_fifo_.front();
+    ready_fifo_.pop();
+    return res;
+}
+
+template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
                                                         input_ordinal_t input)
@@ -1168,7 +1263,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
     int prev_input = outputs_[output].cur_input;
     if (prev_input >= 0) {
         if (options_.mapping == MAP_TO_ANY_OUTPUT && prev_input != input)
-            ready_.push(prev_input);
+            add_to_ready_queue(&inputs_[prev_input]);
         if (prev_input != input && options_.schedule_record_ostream != nullptr) {
             input_info_t &prev_info = inputs_[prev_input];
             std::lock_guard<std::mutex> lock(*prev_info.lock);
@@ -1316,7 +1411,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                 }
                 ++outputs_[output].record_index;
             } else if (options_.mapping == MAP_TO_ANY_OUTPUT) {
-                if (ready_.empty()) {
+                if (ready_queue_empty()) {
                     std::lock_guard<std::mutex> lock(*inputs_[prev_index].lock);
                     if (inputs_[prev_index].at_eof)
                         return sched_type_t::STATUS_EOF;
@@ -1324,11 +1419,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         index = prev_index; // Go back to prior.
                 } else {
                     // TODO i#5843: Add core binding and priority support.
-                    index = ready_.front();
-                    ready_.pop();
+                    input_info_t *queue_next = pop_from_ready_queue();
+                    index = queue_next->index;
                 }
             } else if (options_.deps == DEPENDENCY_TIMESTAMPS) {
-                // TODO i#5843: This should require a lock for >1 outputs too.
                 uint64_t min_time = std::numeric_limits<uint64_t>::max();
                 for (size_t i = 0; i < inputs_.size(); ++i) {
                     std::lock_guard<std::mutex> lock(*inputs_[i].lock);
@@ -1479,11 +1573,20 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                    record_type_is_instr(record)) {
             // TODO i#5843: We also want to swap on blocking syscalls.
             ++input->instrs_in_quantum;
-            if (input->instrs_in_quantum > options_.quantum_duration)
+            if (input->instrs_in_quantum > options_.quantum_duration) {
+                // We again prefer to switch to another input even if the current
+                // input has the oldest timestamp, prioritizing context switches
+                // over timestamp ordering.
                 need_new_input = true;
+            }
         }
-        if (options_.mapping != MAP_AS_PREVIOUSLY &&
-            options_.deps == DEPENDENCY_TIMESTAMPS &&
+        if (options_.deps == DEPENDENCY_TIMESTAMPS &&
+            options_.mapping != MAP_AS_PREVIOUSLY &&
+            // For MAP_TO_ANY_OUTPUT with timestamps: enforcing asked-for context switch
+            // rates is more important that honoring precise trace-buffer-based
+            // timestamp inter-input dependencies so we do not end a quantum early due
+            // purely to timestamps.
+            options_.mapping != MAP_TO_ANY_OUTPUT &&
             record_type_is_timestamp(record, input->next_timestamp))
             need_new_input = true;
         if (need_new_input) {

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1577,6 +1577,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                 // We again prefer to switch to another input even if the current
                 // input has the oldest timestamp, prioritizing context switches
                 // over timestamp ordering.
+                // NOCHECK not true for priority; want FIFO for same-priority: have
+                // to impl in comparator w/ counters or sthg and re-add ourselves
+                // to the ready queue here.  Xref me removing the add-to-ready
+                // by set_cur_input to invalid up front: have to reconcile.
                 need_new_input = true;
             }
         }

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -257,9 +257,6 @@ public:
          */
         std::vector<input_reader_t> readers;
 
-        // TODO i#5843: This is currently ignored for MAP_TO_RECORDED_OUTPUT +
-        // DEPENDENCY_TIMESTAMPS b/c file_reader_t opens the individual files!
-        // TODO i#5843: Add a test of this field.
         /**
          * If empty, every trace file in 'path' or every reader in 'readers' becomes
          * an enabled input.  If non-empty, only those inputs whose thread ids are
@@ -309,9 +306,14 @@ public:
          */
         MAP_TO_RECORDED_OUTPUT,
         /**
-         * The input streams are scheduling using a new synthetic schedule onto the
+         * The input streams are scheduled using a new dynamic sequence onto the
          * output streams.  Any input markers indicating how the software threads were
-         * originally mapped to cores during tracing are ignored.
+         * originally mapped to cores during tracing are ignored.  Instead, inputs
+         * run until either a quantum expires (see
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::scheduler_options_t::quantum_unit)
+         * or a (potentially) blocking system call is identified.  At this point,
+         * a new input is selected, taking into consideration other options such
+         * as priorities, core bindings, and inter-input dependencies.
          */
         MAP_TO_ANY_OUTPUT,
         /**
@@ -330,7 +332,15 @@ public:
     enum inter_input_dependency_t {
         /** Ignores all inter-input dependencies. */
         DEPENDENCY_IGNORE,
-        /** Ensures timestamps in the inputs arrive at the outputs in timestamp order. */
+        /**
+         * Ensures timestamps in the inputs arrive at the outputs in timestamp order.
+         * For
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::MAP_TO_ANY_OUTPUT, enforcing
+         * asked-for context switch rates is more important that honoring precise
+         * trace-buffer-based timestamp inter-input dependencies: thus, timestamp
+         * ordering will be followed at context switch points for picking the next
+         * input, but timestamps will not preempt an input.
+         */
         DEPENDENCY_TIMESTAMPS,
         // TODO i#5843: Add inferred data dependencies.
     };
@@ -820,6 +830,8 @@ protected:
         uintptr_t next_timestamp = 0;
         uint64_t instrs_in_quantum = 0;
         bool recorded_in_schedule = false;
+        // This is a per-workload value, stored in each input for convenience.
+        uint64_t base_timestamp = 0;
     };
 
     // Format for recording a schedule to disk.  A separate sequence of these records
@@ -901,6 +913,8 @@ protected:
         int record_index = 0;
         bool waiting = false;
     };
+
+    // Assumed to only be called at initialization time.
     scheduler_status_t
     get_initial_timestamps();
 
@@ -1027,6 +1041,29 @@ protected:
     stream_status_t
     stop_speculation(output_ordinal_t output);
 
+    // Support for ready queues for who to schedule next:
+
+    // I tried using a lambda where we could capture "this" and so use int indices
+    // in the queues instead of pointers but hit problems (weird crash while running)
+    // so I'm sticking with this simpler solution of a separate class.
+    struct InputTimestampComparator {
+        bool
+        operator()(input_info_t *a, input_info_t *b) const
+        {
+            return (a->reader->get_last_timestamp() - a->base_timestamp) >
+                (b->reader->get_last_timestamp() - b->base_timestamp);
+        }
+    };
+
+    bool
+    ready_queue_empty();
+
+    void
+    add_to_ready_queue(input_info_t *input);
+
+    input_info_t *
+    pop_from_ready_queue();
+
     // This has the same value as scheduler_options_t.verbosity (for use in VPRINT).
     int verbosity_ = 0;
     const char *output_prefix_ = "[scheduler]";
@@ -1041,8 +1078,15 @@ protected:
     // cost is outweighed by the simulator's overhead.  This protects concurrent
     // access to inputs_.size(), outputs_.size(), and the ready_ field.
     std::mutex sched_lock_;
-    // Input indices ready to be scheduled.
-    std::queue<input_ordinal_t> ready_;
+    // Inputs ready to be scheduled when we have DEPENDENCY_IGNORE.
+    std::queue<input_info_t *> ready_fifo_;
+    // Inputs ready to be scheduled, sorted by timestamp if timestamp
+    // dependencies are requested.  We use the timestamp delta from the first observed
+    // timestamp in each workload in order to mix inputs from different workloads in the
+    // same queue.
+    std::priority_queue<input_info_t *, std::vector<input_info_t *>,
+                        InputTimestampComparator>
+        ready_;
 };
 
 /** See #dynamorio::drmemtrace::scheduler_tmpl_t. */

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -827,7 +827,7 @@ protected:
         bool needs_advance = false;
         bool needs_roi = true;
         bool at_eof = false;
-        uintptr_t next_timestamp = 0;
+        uint64_t next_timestamp = 0;
         uint64_t instrs_in_quantum = 0;
         bool recorded_in_schedule = false;
         // This is a per-workload value, stored in each input for convenience.

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -111,17 +111,23 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
             if (op_verbose.get_value() > 0) {
                 std::ostringstream line;
                 line
-                    << "Core #" << ordinal << " @" << stream->get_record_ordinal()
-                    << " refs, " << stream->get_instruction_ordinal() << " instrs: input "
-                    << stream->get_input_stream_ordinal() << " @"
+                    << "Core #" << std::setw(2) << ordinal << " @" << std::setw(9)
+                    << stream->get_record_ordinal() << " refs, " << std::setw(9)
+                    << stream->get_instruction_ordinal() << " instrs: input "
+                    << std::setw(4) << stream->get_input_stream_ordinal() << " @"
+                    << std::setw(9)
                     << scheduler
                            .get_input_stream_interface(stream->get_input_stream_ordinal())
                            ->get_record_ordinal()
-                    << " refs, "
+                    << " refs, " << std::setw(9)
                     << scheduler
                            .get_input_stream_interface(stream->get_input_stream_ordinal())
                            ->get_instruction_ordinal()
-                    << " instrs == thread " << record.instr.tid << "\n";
+                    << " instrs, time " << std::setw(16)
+                    << scheduler
+                           .get_input_stream_interface(stream->get_input_stream_ordinal())
+                           ->get_last_timestamp()
+                    << " == thread " << record.instr.tid << "\n";
                 std::cerr << line.str();
             }
         }

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -152,7 +152,7 @@ _tmain(int argc, const TCHAR *targv[])
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(op_trace_dir.get_value());
     scheduler_t::scheduler_options_t sched_ops(
-        scheduler_t::MAP_TO_ANY_OUTPUT, scheduler_t::DEPENDENCY_IGNORE,
+        scheduler_t::MAP_TO_ANY_OUTPUT, scheduler_t::DEPENDENCY_TIMESTAMPS,
         scheduler_t::SCHEDULER_DEFAULTS, op_verbose.get_value());
     sched_ops.quantum_duration = op_sched_quantum.get_value();
 #ifdef HAS_ZIP

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -842,18 +842,18 @@ test_synthetic_with_timestamps()
     for (int workload_idx = 0; workload_idx < NUM_WORKLOADS; workload_idx++) {
         std::vector<scheduler_t::input_reader_t> readers;
         for (int input_idx = 0; input_idx < NUM_INPUTS_PER_WORKLOAD; input_idx++) {
-            // We also test duplicate tids across workloads.
             memref_tid_t tid =
                 TID_BASE + workload_idx * NUM_INPUTS_PER_WORKLOAD + input_idx;
             std::vector<trace_entry_t> inputs;
             inputs.push_back(make_thread(tid));
             inputs.push_back(make_pid(1));
             for (int instr_idx = 0; instr_idx < NUM_INSTRS; instr_idx++) {
+                // Sprinkle timestamps every other instruction.
                 if (instr_idx % 2 == 0) {
+                    // We have different base timestamps per workload, and we have the
+                    // later-ordered inputs in each with the earlier timestamps to
+                    // better test scheduler ordering.
                     inputs.push_back(make_timestamp(
-                        // We have different base timestamps per workload, and we have the
-                        // later-ordered inputs in each with the earlier timestamps to
-                        // better test scheduler ordering.
                         1000 * workload_idx +
                         100 * (NUM_INPUTS_PER_WORKLOAD - input_idx) + 10 * instr_idx));
                 }
@@ -866,6 +866,23 @@ test_synthetic_with_timestamps()
         }
         sched_inputs.emplace_back(std::move(readers));
     }
+    // We have one input with lower timestamps than everyone, to
+    // test that it never gets switched out.
+    memref_tid_t tid = TID_BASE + NUM_WORKLOADS * NUM_INPUTS_PER_WORKLOAD;
+    std::vector<trace_entry_t> inputs;
+    inputs.push_back(make_thread(tid));
+    inputs.push_back(make_pid(1));
+    for (int instr_idx = 0; instr_idx < NUM_INSTRS; instr_idx++) {
+        if (instr_idx % 2 == 0)
+            inputs.push_back(make_timestamp(1 + instr_idx));
+        inputs.push_back(make_instr(42 + instr_idx * 4));
+    }
+    inputs.push_back(make_exit(tid));
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), tid);
+    sched_inputs.emplace_back(std::move(readers));
+
     scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
@@ -880,11 +897,13 @@ test_synthetic_with_timestamps()
     for (int i = 0; i < NUM_OUTPUTS; i++) {
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
-    // Hardcoding here for the 3x3 inputs where the inverted timestamps mean
-    // the priorities are {C,B,A},{F,E,D},{I,H,G}.  Thus we expect to first alternate
-    // among {C,F,I} and finish them off before moving to {B,E,H} and {A,D,G}:
-    assert(sched_as_string[0] == "CCCIIIFFFCCCIIIHHHBBBEEEHHHDDDGGGAAADDDGGG");
-    assert(sched_as_string[1] == "FFFCCCIIIFFFBBBEEEHHHBBBEEEAAADDDGGGAAA");
+    // Hardcoding here for the 3x3+1 inputs where the inverted timestamps mean the
+    // priorities are {C,B,A},{F,E,D},{I,H,G},{J} within the workloads.  Across
+    // workloads we should start with {C,F,I,J} and then move on to {B,E,H} and finish
+    // with {A,D,G}.  We should interleave within each group -- except once we reach J
+    // we should completely finish it.
+    assert(sched_as_string[0] == "CCCIIICCCFFFIIIFFFBBBHHHEEEBBBHHHDDDAAAGGGDDD");
+    assert(sched_as_string[1] == "FFFJJJJJJJJJCCCIIIEEEBBBHHHEEEAAAGGGDDDAAAGGG");
 }
 
 #if (defined(X86_64) || defined(ARM_64)) && defined(HAS_ZIP)


### PR DESCRIPTION
Adds timestamp ordering to dynamic scheduling.  Accomplishes this by using a priority queue keyed by the last timestamp seen in an input relative to the minimum timestamp across all inputs for that workload, to allow mixing workloads in the same queue.

Adds a test and updates other tests and tools to enable timestamps.

Also tested manually on some larger traces as sanity tests that no errors are reported at least.

Issue: #5843