### PR TITLE
i#5843 scheduler: Add priority support

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -490,10 +490,6 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
                     return STATUS_ERROR_NOT_IMPLEMENTED;
                 }
                 input.priority = modifiers.priority;
-                if (input.priority != 0) {
-                    // TODO i#5843: Implement priorities.
-                    return STATUS_ERROR_NOT_IMPLEMENTED;
-                }
                 for (size_t i = 0; i < modifiers.regions_of_interest.size(); ++i) {
                     const auto &range = modifiers.regions_of_interest[i];
                     if (range.start_instruction == 0 ||
@@ -1432,7 +1428,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                     // shouldn't switch.  The queue preserves FIFO for same-priority
                     // cases so we will switch if someone of equal priority is waiting.
                     set_cur_input(output, INVALID_INPUT_ORDINAL);
-                    // TODO i#5843: Add core binding and priority support.
+                    // TODO i#5843: Add core binding support.
                     input_info_t *queue_next = pop_from_ready_queue();
                     index = queue_next->index;
                 }

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1230,10 +1230,10 @@ template <typename RecordType, typename ReaderType>
 void
 scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(input_info_t *input)
 {
-    if (options_.deps == DEPENDENCY_TIMESTAMPS) {
-        VPRINT(this, 4, "add_to_ready_queue: input %d timestamp delta %" PRIu64 "\n",
-               input->index, input->reader->get_last_timestamp() - input->base_timestamp);
-    }
+    VPRINT(this, 4,
+           "add_to_ready_queue: input %d priority %d timestamp delta %" PRIu64 "\n",
+           input->index, input->priority,
+           input->reader->get_last_timestamp() - input->base_timestamp);
     input->queue_counter = ++ready_counter_;
     ready_priority_.push(input);
 }
@@ -1244,10 +1244,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue()
 {
     input_info_t *res = ready_priority_.top();
     ready_priority_.pop();
-    if (options_.deps == DEPENDENCY_TIMESTAMPS) {
-        VPRINT(this, 4, "pop_from_ready_queue: input %d timestamp delta %" PRIu64 "\n",
-               res->index, res->reader->get_last_timestamp() - res->base_timestamp);
-    }
+    VPRINT(this, 4,
+           "pop_from_ready_queue: input %d priority %d timestamp delta %" PRIu64 "\n",
+           res->index, res->priority,
+           res->reader->get_last_timestamp() - res->base_timestamp);
     return res;
 }
 

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -945,7 +945,9 @@ test_synthetic_with_priorities()
         }
         sched_inputs.emplace_back(std::move(readers));
         // Set some different priorities for the middle threads.
-        sched_inputs.back().thread_modifiers.emplace_back(get_tid(workload_idx, 1), 1);
+        // The others retain the default 0 priority.
+        sched_inputs.back().thread_modifiers.emplace_back(
+            get_tid(workload_idx, /*input_idx=*/1), /*priority=*/1);
     }
     // We have one input with lower timestamps than everyone, to test that it never gets
     // switched out once we get to it among the default-priority inputs.
@@ -978,9 +980,8 @@ test_synthetic_with_priorities()
     for (int i = 0; i < NUM_OUTPUTS; i++) {
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
-    // See the test_synthetic_with_timestamps() test which has our base sequence
-    // here where we would start with {C,F,I,J} and then move on to {B,E,H} and finish
-    // with {A,D,G} -- but we've elevated B, E, and H to higher priorities so they go
+    // See the test_synthetic_with_timestamps() test which has our base sequence.
+    // We've elevated B, E, and H to higher priorities so they go
     // first.  J remains uninterrupted due to lower timestamps.
     assert(sched_as_string[0] == "BBBHHHEEEBBBHHHFFFJJJJJJJJJCCCIIIDDDAAAGGGDDD");
     assert(sched_as_string[1] == "EEEBBBHHHEEECCCIIICCCFFFIIIFFFAAAGGGDDDAAAGGG");


### PR DESCRIPTION
Adds support for different input priorities.  This is easily done using the priority queue added for timestamp ordering simply by adding the input priority value to the priority queue comparator.

Removes the FIFO-only queue as priorities should be used with and without timestamps, using the priority queue for all cases.

Adds a unit test.

Issue: #5843