### PR TITLE
i#6020 interval analysis: add TID and positive interval_id

### DIFF
--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -170,17 +170,20 @@ public:
         // This constructor is only for convenience in unit tests. The tool does not
         // need to provide these values, and can simply use the default constructor
         // below.
-        interval_state_snapshot_t(uint64_t interval_id, uint64_t interval_end_timestamp,
+        interval_state_snapshot_t(int64_t shard_id, uint64_t interval_id,
+                                  uint64_t interval_end_timestamp,
                                   uint64_t instr_count_cumulative,
                                   uint64_t instr_count_delta)
-            : interval_id(interval_id)
+            : shard_id(shard_id)
+            , interval_id(interval_id)
             , interval_end_timestamp(interval_end_timestamp)
             , instr_count_cumulative(instr_count_cumulative)
             , instr_count_delta(instr_count_delta)
         {
         }
         interval_state_snapshot_t()
-            : interval_id(0)
+            : shard_id(0)
+            , interval_id(0)
             , interval_end_timestamp(0)
             , instr_count_cumulative(0)
             , instr_count_delta(0)
@@ -189,6 +192,10 @@ public:
 
         // The following fields are set automatically by the analyzer framework. The
         // tool does not need to set them.
+        // Identifier for the shard to which this interval belongs. Currently, shards
+        // map only to threads, so this is the thread id. Set to kWholeTraceShardId
+        // for the whole trace interval snapshots.
+        int64_t shard_id;
         uint64_t interval_id;
         // Stores the timestamp (exclusive) when the above interval ends. Note
         // that this is not the last timestamp actually seen in the trace interval,
@@ -203,6 +210,8 @@ public:
         uint64_t instr_count_cumulative;
         uint64_t instr_count_delta;
 
+        static constexpr int64_t kWholeTraceShardId = -1;
+
         virtual ~interval_state_snapshot_t() = default;
     };
     /**
@@ -212,8 +221,8 @@ public:
      * pointer will be provided to the tool in later combine_interval_snapshots()
      * and print_interval_result() calls.
      *
-     * \p interval_id is the ordinal of the trace interval that just ended. Trace
-     * intervals have a length equal to the \p -interval_microseconds specified
+     * \p interval_id is a positive ordinal of the trace interval that just ended.
+     * Trace intervals have a length equal to the \p -interval_microseconds specified
      * to the framework. Trace intervals are measured using the value of the
      * #TRACE_MARKER_TYPE_TIMESTAMP markers. The provided \p interval_id
      * values will be monotonically increasing but may not be continuous,
@@ -414,8 +423,8 @@ public:
      * shard-local \p interval_state_snapshot_t corresponding to that whole-trace
      * interval.
      *
-     * \p interval_id is the ordinal of the trace interval that just ended. Trace
-     * intervals have a length equal to the \p -interval_microseconds specified
+     * \p interval_id is a positive ordinal of the trace interval that just ended.
+     * Trace intervals have a length equal to the \p -interval_microseconds specified
      * to the framework. Trace intervals are measured using the value of the
      * #TRACE_MARKER_TYPE_TIMESTAMP markers. The provided \p interval_id
      * values will be monotonically increasing but may not be continuous,

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -190,8 +190,11 @@ public:
         {
         }
 
-        // The following fields are set automatically by the analyzer framework. The
-        // tool does not need to set them.
+        // The following fields are set automatically by the analyzer framework after
+        // the tool returns the interval_state_snapshot_t* in the
+        // generate_*interval_snapshot APIs. So they'll be available to the tool in
+        // the combine_interval_snapshots and print_interval_results APIs.
+
         // Identifier for the shard to which this interval belongs. Currently, shards
         // map only to threads, so this is the thread id. Set to kWholeTraceShardId
         // for the whole trace interval snapshots.

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -182,11 +182,6 @@ public:
         {
         }
         interval_state_snapshot_t()
-            : shard_id(0)
-            , interval_id(0)
-            , interval_end_timestamp(0)
-            , instr_count_cumulative(0)
-            , instr_count_delta(0)
         {
         }
 
@@ -196,24 +191,24 @@ public:
         // the combine_interval_snapshots and print_interval_results APIs.
 
         // Identifier for the shard to which this interval belongs. Currently, shards
-        // map only to threads, so this is the thread id. Set to kWholeTraceShardId
+        // map only to threads, so this is the thread id. Set to WHOLE_TRACE_SHARD_ID
         // for the whole trace interval snapshots.
-        int64_t shard_id;
-        uint64_t interval_id;
+        int64_t shard_id = 0;
+        uint64_t interval_id = 0;
         // Stores the timestamp (exclusive) when the above interval ends. Note
         // that this is not the last timestamp actually seen in the trace interval,
         // but simply the abstract boundary of the interval. This will be aligned
         // to the specified -interval_microseconds.
-        uint64_t interval_end_timestamp;
+        uint64_t interval_end_timestamp = 0;
 
         // Count of instructions: cumulative till this interval, and the incremental
         // delta in this interval vs the previous one. May be useful for tools to
         // compute PKI (per kilo instruction) metrics; obviates the need for each
         // tool to duplicate this.
-        uint64_t instr_count_cumulative;
-        uint64_t instr_count_delta;
+        uint64_t instr_count_cumulative = 0;
+        uint64_t instr_count_delta = 0;
 
-        static constexpr int64_t kWholeTraceShardId = -1;
+        static constexpr int64_t WHOLE_TRACE_SHARD_ID = -1;
 
         virtual ~interval_state_snapshot_t() = default;
     };

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -609,7 +609,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::merge_shard_interval_results(
             return false;
         // Add the merged interval to the result list of whole trace intervals.
         cur_merged_interval->shard_id = analysis_tool_tmpl_t<
-            RecordType>::interval_state_snapshot_t::kWholeTraceShardId;
+            RecordType>::interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID;
         cur_merged_interval->interval_end_timestamp = earliest_interval_end_timestamp;
         cur_merged_interval->interval_id = compute_interval_id(
             earliest_ever_interval_end_timestamp, earliest_interval_end_timestamp);
@@ -765,7 +765,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_interval(
             snapshot->shard_id = parallel
                 ? worker->shard_data[shard_idx].shard_id
                 : analysis_tool_tmpl_t<
-                      RecordType>::interval_state_snapshot_t::kWholeTraceShardId;
+                      RecordType>::interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID;
             snapshot->interval_id = interval_id;
             snapshot->interval_end_timestamp = compute_interval_end_timestamp(
                 worker->stream->get_first_timestamp(), interval_id);

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -437,8 +437,8 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *w
             }
         }
         memref_tid_t tid;
-        if (record_has_tid(record, tid) &&
-            worker->shard_data[shard_index].shard_id == 0) {
+        if (worker->shard_data[shard_index].shard_id == 0 &&
+            record_has_tid(record, tid)) {
             worker->shard_data[shard_index].shard_id = tid;
         }
         uint64_t prev_interval_index;

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -510,8 +510,6 @@ analyzer_tmpl_t<RecordType, ReaderType>::combine_interval_snapshots(
         error_string_ = "combine_interval_snapshots unexpectedly returned nullptr";
         return false;
     }
-    result->shard_id =
-        analysis_tool_tmpl_t<RecordType>::interval_state_snapshot_t::kWholeTraceShardId;
     result->instr_count_delta = 0;
     result->instr_count_cumulative = 0;
     for (auto snapshot : latest_shard_snapshots) {
@@ -610,6 +608,8 @@ analyzer_tmpl_t<RecordType, ReaderType>::merge_shard_interval_results(
                                         cur_merged_interval))
             return false;
         // Add the merged interval to the result list of whole trace intervals.
+        cur_merged_interval->shard_id = analysis_tool_tmpl_t<
+            RecordType>::interval_state_snapshot_t::kWholeTraceShardId;
         cur_merged_interval->interval_end_timestamp = earliest_interval_end_timestamp;
         cur_merged_interval->interval_id = compute_interval_id(
             earliest_ever_interval_end_timestamp, earliest_interval_end_timestamp);

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -437,6 +437,8 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *w
             }
         }
         memref_tid_t tid;
+        // Currently shards map only to threads, so the shard_id is the same as
+        // the thread id.
         if (worker->shard_data[shard_index].shard_id == 0 &&
             record_has_tid(record, tid)) {
             worker->shard_data[shard_index].shard_id = tid;

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -153,6 +153,9 @@ protected:
 
         uint64_t cur_interval_index;
         uint64_t cur_interval_init_instr_count;
+        // Identifier for the shard. Currently, shards map only to threads, so this is
+        // the thread id.
+        int64_t shard_id;
         std::vector<analyzer_tool_shard_data_t> tool_data;
 
     private:
@@ -228,7 +231,17 @@ protected:
     // finished. For serial analysis, it should remain the default value.
     bool
     process_interval(uint64_t interval_id, uint64_t interval_init_instr_count,
-                     analyzer_worker_data_t *worker, bool parallel, int shard_id = 0);
+                     analyzer_worker_data_t *worker, bool parallel, int shard_idx = 0);
+
+    // Compute interval id for the given latest_timestamp, assuming the trace (or
+    // trace shard) starts at the given first_timestamp.
+    uint64_t
+    compute_interval_id(uint64_t first_timestamp, uint64_t latest_timestamp);
+
+    // Compute the interval end timestamp for the given interval_id, assuming the trace
+    // (or trace shard) starts at the given first_timestamp.
+    uint64_t
+    compute_interval_end_timestamp(uint64_t first_timestamp, uint64_t interval_id);
 
     // Possibly advances the current interval id stored in the worker data, based
     // on the most recent seen timestamp in the trace stream. Returns whether the

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -148,6 +148,7 @@ protected:
         analyzer_shard_data_t()
             : cur_interval_index(0)
             , cur_interval_init_instr_count(0)
+            , shard_id(0)
         {
         }
 

--- a/clients/drcachesim/tests/offline-interval-count-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-count-output.templatex
@@ -38,7 +38,7 @@ Thread .* counts:
            0 physical address unavailable markers
      .* other markers
      .* encodings
-Interval total counts across threads:
+Counts per trace interval for whole trace:
 Interval #1 ending at timestamp.*
      .* interval delta \(fetched\) instructions
      .* interval delta unique \(fetched\) instructions

--- a/clients/drcachesim/tests/offline-interval-count-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-count-output.templatex
@@ -39,7 +39,7 @@ Thread .* counts:
      .* other markers
      .* encodings
 Interval total counts across threads:
-Interval #0 ending at timestamp.*
+Interval #1 ending at timestamp.*
      .* interval delta \(fetched\) instructions
      .* interval delta unique \(fetched\) instructions
      .* interval delta non-fetched instructions

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -442,7 +442,9 @@ public:
                 auto recorded_snapshot =
                     dynamic_cast<const recorded_snapshot_t *const>(snapshot);
                 if (recorded_snapshot->tool_shard_id != recorded_snapshot->shard_id) {
-                    std::cerr << "shard_id stored by tool and framework mismatch";
+                    std::cerr << "shard_id stored by tool ("
+                              << recorded_snapshot->tool_shard_id << ") and framework ("
+                              << recorded_snapshot->shard_id << ") mismatch\n";
                     return nullptr;
                 }
                 result->component_intervals.insert(

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -295,9 +295,13 @@ public:
             // Actual tools do not need to supply values to construct the base
             // interval_state_snapshot_t. This is only to make it easier to construct
             // the expected snapshot objects in this test.
-            : interval_state_snapshot_t(interval_id, interval_end_timestamp,
-                                        instr_count_cumulative, instr_count_delta)
+            // Since the final verification happens only for the whole trace intervals,
+            // we simply use kWholeTraceShardId here and for tool_shard_id below.
+            : interval_state_snapshot_t(kWholeTraceShardId, interval_id,
+                                        interval_end_timestamp, instr_count_cumulative,
+                                        instr_count_delta)
             , component_intervals(component_intervals)
+            , tool_shard_id(kWholeTraceShardId)
         {
         }
         recorded_snapshot_t()
@@ -307,7 +311,8 @@ public:
         bool
         operator==(const recorded_snapshot_t &rhs) const
         {
-            return interval_id == rhs.interval_id &&
+            return shard_id == rhs.shard_id && tool_shard_id == rhs.tool_shard_id &&
+                interval_id == rhs.interval_id &&
                 interval_end_timestamp == rhs.interval_end_timestamp &&
                 instr_count_cumulative == rhs.instr_count_cumulative &&
                 instr_count_delta == rhs.instr_count_delta &&
@@ -316,7 +321,8 @@ public:
         void
         print() const
         {
-            std::cerr << "(id: " << interval_id
+            std::cerr << "(shard_id: " << shard_id << ", interval_id: " << interval_id
+                      << ", tool_shard_id: " << tool_shard_id
                       << ", end_timestamp: " << interval_end_timestamp
                       << ", instr_count_cumulative: " << instr_count_cumulative
                       << ", instr_count_delta: " << instr_count_delta
@@ -333,6 +339,9 @@ public:
         // this contains a list of size equal to the count of shard interval snapshots
         // that were combined to create this snapshot.
         std::vector<interval_end_point_t> component_intervals;
+        // Stores the shard_id recorded by the test tool. Compared with the shard_id
+        // stored by the tool in the base struct.
+        int64_t tool_shard_id;
     };
 
     // Constructs an analysis_tool_t that expects the given interval state snapshots to be
@@ -355,6 +364,8 @@ public:
     generate_interval_snapshot(uint64_t interval_id) override
     {
         auto *snapshot = new recorded_snapshot_t();
+        snapshot->tool_shard_id =
+            analysis_tool_t::interval_state_snapshot_t::kWholeTraceShardId;
         snapshot->component_intervals.push_back(
             { /*tid=*/0, seen_memrefs_, interval_id });
         ++outstanding_snapshots_;
@@ -408,6 +419,7 @@ public:
         if (shard->tid == kInvalidTid)
             FATAL_ERROR("Expected TID to be found by now");
         auto *snapshot = new recorded_snapshot_t();
+        snapshot->tool_shard_id = shard->tid;
         snapshot->component_intervals.push_back(
             { shard->tid, shard->seen_memrefs, interval_id });
         ++outstanding_snapshots_;
@@ -420,6 +432,8 @@ public:
         uint64_t interval_end_timestamp) override
     {
         recorded_snapshot_t *result = new recorded_snapshot_t();
+        result->tool_shard_id =
+            analysis_tool_t::interval_state_snapshot_t::kWholeTraceShardId;
         ++outstanding_snapshots_;
         for (auto snapshot : latest_shard_snapshots) {
             if (snapshot != nullptr &&
@@ -427,6 +441,10 @@ public:
                  snapshot->interval_end_timestamp == interval_end_timestamp)) {
                 auto recorded_snapshot =
                     dynamic_cast<const recorded_snapshot_t *const>(snapshot);
+                if (recorded_snapshot->tool_shard_id != recorded_snapshot->shard_id) {
+                    std::cerr << "shard_id stored by tool and framework mismatch";
+                    return nullptr;
+                }
                 result->component_intervals.insert(
                     result->component_intervals.end(),
                     recorded_snapshot->component_intervals.begin(),
@@ -511,26 +529,26 @@ test_non_zero_interval(bool parallel, bool combine_only_active_shards = true)
         // Trace for a single worker which has two constituent shards. (scheduler_t
         // does not guarantee that workers will process shards one after the other.)
         // Expected active interval_id: tid_51_local | tid_52_local | whole_trace
-        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 40),  // 0 | _ | 0
-        gen_instr(51, 10000),                             // 0 | _ | 0
-        gen_data(51, true, 1234, 4),                      // 0 | _ | 0
-        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 151), // _ | 0 | 1
-        gen_instr(52, 20000),                             // _ | 0 | 1
-        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 170), // 1 | _ | 1
-        gen_instr(51, 10008),                             // 1 | _ | 1
-        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 201), // 2 | _ | 2
-        gen_instr(51, 20004),                             // 2 | _ | 2
-        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 210), // _ | 1 | 2
-        gen_instr(52, 20008),                             // _ | 1 | 2
-        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 270), // _ | 1 | 2
-        gen_instr(52, 20008),                             // _ | 1 | 2
-        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 490), // _ | 3 | 4
-        gen_instr(52, 20012),                             // _ | 3 | 4
-        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 590), // 5 | _ | 5
-        gen_exit(51),                                     // 5 | _ | 5
-        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 610), // _ | 5 | 6
-        gen_instr(52, 20016),                             // _ | 5 | 6
-        gen_exit(52)                                      // _ | 5 | 6
+        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 40),  // 1 | _ | 1
+        gen_instr(51, 10000),                             // 1 | _ | 1
+        gen_data(51, true, 1234, 4),                      // 1 | _ | 1
+        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 151), // _ | 1 | 2
+        gen_instr(52, 20000),                             // _ | 1 | 2
+        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 170), // 2 | _ | 2
+        gen_instr(51, 10008),                             // 2 | _ | 2
+        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 201), // 3 | _ | 3
+        gen_instr(51, 20004),                             // 3 | _ | 3
+        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 210), // _ | 2 | 3
+        gen_instr(52, 20008),                             // _ | 2 | 3
+        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 270), // _ | 2 | 3
+        gen_instr(52, 20008),                             // _ | 2 | 3
+        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 490), // _ | 4 | 5
+        gen_instr(52, 20012),                             // _ | 4 | 5
+        gen_marker(51, TRACE_MARKER_TYPE_TIMESTAMP, 590), // 6 | _ | 6
+        gen_exit(51),                                     // 6 | _ | 6
+        gen_marker(52, TRACE_MARKER_TYPE_TIMESTAMP, 610), // _ | 6 | 7
+        gen_instr(52, 20016),                             // _ | 6 | 7
+        gen_exit(52)                                      // _ | 6 | 7
     };
 
     std::vector<test_analysis_tool_t::recorded_snapshot_t> expected_state_snapshots;
@@ -539,46 +557,46 @@ test_non_zero_interval(bool parallel, bool combine_only_active_shards = true)
         // serial snapshot.
         expected_state_snapshots = {
             // Format for interval_end_point_t: <tid, seen_memrefs, interval_id>
-            test_analysis_tool_t::recorded_snapshot_t(0, 100, 1, 1, { { 0, 3, 0 } }),
-            test_analysis_tool_t::recorded_snapshot_t(1, 200, 3, 2, { { 0, 7, 1 } }),
-            test_analysis_tool_t::recorded_snapshot_t(2, 300, 6, 3, { { 0, 13, 2 } }),
-            test_analysis_tool_t::recorded_snapshot_t(4, 500, 7, 1, { { 0, 15, 4 } }),
-            test_analysis_tool_t::recorded_snapshot_t(5, 600, 7, 0, { { 0, 17, 5 } }),
-            test_analysis_tool_t::recorded_snapshot_t(6, 700, 8, 1, { { 0, 20, 6 } }),
+            test_analysis_tool_t::recorded_snapshot_t(1, 100, 1, 1, { { 0, 3, 1 } }),
+            test_analysis_tool_t::recorded_snapshot_t(2, 200, 3, 2, { { 0, 7, 2 } }),
+            test_analysis_tool_t::recorded_snapshot_t(3, 300, 6, 3, { { 0, 13, 3 } }),
+            test_analysis_tool_t::recorded_snapshot_t(5, 500, 7, 1, { { 0, 15, 5 } }),
+            test_analysis_tool_t::recorded_snapshot_t(6, 600, 7, 0, { { 0, 17, 6 } }),
+            test_analysis_tool_t::recorded_snapshot_t(7, 700, 8, 1, { { 0, 20, 7 } }),
         };
     } else if (combine_only_active_shards) {
         // Each whole trace interval is made up of snapshots from each
         // shard that was active in that interval.
         expected_state_snapshots = {
             // Format for interval_end_point_t: <tid, seen_memrefs, interval_id>
-            test_analysis_tool_t::recorded_snapshot_t(0, 100, 1, 1, { { 51, 3, 0 } }),
+            test_analysis_tool_t::recorded_snapshot_t(1, 100, 1, 1, { { 51, 3, 1 } }),
             // Narration: The whole-trace interval_id=1 with interval_end_timestamp=200
             // is made up of the following two shard-local interval snapshots:
             // - from shard_id=51, the interval_id=1 that ends at the local_memref=5
             // - from shard_id=52, the interval_id=0 that ends at the local_memref=2
-            test_analysis_tool_t::recorded_snapshot_t(1, 200, 3, 2,
-                                                      { { 51, 5, 1 }, { 52, 2, 0 } }),
-            test_analysis_tool_t::recorded_snapshot_t(2, 300, 6, 3,
-                                                      { { 51, 7, 2 }, { 52, 6, 1 } }),
-            test_analysis_tool_t::recorded_snapshot_t(4, 500, 7, 1, { { 52, 8, 3 } }),
-            test_analysis_tool_t::recorded_snapshot_t(5, 600, 7, 0, { { 51, 9, 5 } }),
-            test_analysis_tool_t::recorded_snapshot_t(6, 700, 8, 1, { { 52, 11, 5 } })
+            test_analysis_tool_t::recorded_snapshot_t(2, 200, 3, 2,
+                                                      { { 51, 5, 2 }, { 52, 2, 1 } }),
+            test_analysis_tool_t::recorded_snapshot_t(3, 300, 6, 3,
+                                                      { { 51, 7, 3 }, { 52, 6, 2 } }),
+            test_analysis_tool_t::recorded_snapshot_t(5, 500, 7, 1, { { 52, 8, 4 } }),
+            test_analysis_tool_t::recorded_snapshot_t(6, 600, 7, 0, { { 51, 9, 6 } }),
+            test_analysis_tool_t::recorded_snapshot_t(7, 700, 8, 1, { { 52, 11, 6 } })
         };
     } else {
         // Each whole trace interval is made up of last snapshots from all trace shards.
         expected_state_snapshots = {
             // Format for interval_end_point_t: <tid, seen_memrefs, interval_id>
-            test_analysis_tool_t::recorded_snapshot_t(0, 100, 1, 1, { { 51, 3, 0 } }),
-            test_analysis_tool_t::recorded_snapshot_t(1, 200, 3, 2,
-                                                      { { 51, 5, 1 }, { 52, 2, 0 } }),
-            test_analysis_tool_t::recorded_snapshot_t(2, 300, 6, 3,
-                                                      { { 51, 7, 2 }, { 52, 6, 1 } }),
-            test_analysis_tool_t::recorded_snapshot_t(4, 500, 7, 1,
-                                                      { { 51, 7, 2 }, { 52, 8, 3 } }),
-            test_analysis_tool_t::recorded_snapshot_t(5, 600, 7, 0,
-                                                      { { 51, 9, 5 }, { 52, 8, 3 } }),
-            test_analysis_tool_t::recorded_snapshot_t(6, 700, 8, 1,
-                                                      { { 51, 9, 5 }, { 52, 11, 5 } })
+            test_analysis_tool_t::recorded_snapshot_t(1, 100, 1, 1, { { 51, 3, 1 } }),
+            test_analysis_tool_t::recorded_snapshot_t(2, 200, 3, 2,
+                                                      { { 51, 5, 2 }, { 52, 2, 1 } }),
+            test_analysis_tool_t::recorded_snapshot_t(3, 300, 6, 3,
+                                                      { { 51, 7, 3 }, { 52, 6, 2 } }),
+            test_analysis_tool_t::recorded_snapshot_t(5, 500, 7, 1,
+                                                      { { 51, 7, 3 }, { 52, 8, 4 } }),
+            test_analysis_tool_t::recorded_snapshot_t(6, 600, 7, 0,
+                                                      { { 51, 9, 6 }, { 52, 8, 4 } }),
+            test_analysis_tool_t::recorded_snapshot_t(7, 700, 8, 1,
+                                                      { { 51, 9, 6 }, { 52, 11, 6 } })
         };
     }
     std::vector<analysis_tool_t *> tools;

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -297,16 +297,15 @@ public:
             // interval_state_snapshot_t. This is only to make it easier to construct
             // the expected snapshot objects in this test.
             // Since the final verification happens only for the whole trace intervals,
-            // we simply use kWholeTraceShardId here and for tool_shard_id below.
-            : interval_state_snapshot_t(kWholeTraceShardId, interval_id,
+            // we simply use WHOLE_TRACE_SHARD_ID here and for tool_shard_id below.
+            : interval_state_snapshot_t(WHOLE_TRACE_SHARD_ID, interval_id,
                                         interval_end_timestamp, instr_count_cumulative,
                                         instr_count_delta)
             , component_intervals(component_intervals)
-            , tool_shard_id(kWholeTraceShardId)
+            , tool_shard_id(WHOLE_TRACE_SHARD_ID)
         {
         }
         recorded_snapshot_t()
-            : interval_state_snapshot_t()
         {
         }
 
@@ -342,7 +341,7 @@ public:
         // that were combined to create this snapshot.
         std::vector<interval_end_point_t> component_intervals;
         // Stores the shard_id recorded by the test tool. Compared with the shard_id
-        // stored by the tool in the base struct.
+        // stored by the framework in the base struct.
         int64_t tool_shard_id;
     };
 
@@ -367,7 +366,7 @@ public:
     {
         auto *snapshot = new recorded_snapshot_t();
         snapshot->tool_shard_id =
-            analysis_tool_t::interval_state_snapshot_t::kWholeTraceShardId;
+            analysis_tool_t::interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID;
         snapshot->component_intervals.push_back(
             { /*tid=*/0, seen_memrefs_, interval_id });
         ++outstanding_snapshots_;
@@ -435,7 +434,7 @@ public:
     {
         recorded_snapshot_t *result = new recorded_snapshot_t();
         result->tool_shard_id =
-            analysis_tool_t::interval_state_snapshot_t::kWholeTraceShardId;
+            analysis_tool_t::interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID;
         ++outstanding_snapshots_;
         for (auto snapshot : latest_shard_snapshots) {
             if (snapshot != nullptr &&

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -36,6 +36,7 @@
 #include "memref_gen.h"
 
 #include <algorithm>
+#include <inttypes.h>
 #include <iostream>
 #include <vector>
 
@@ -443,8 +444,8 @@ public:
                 auto recorded_snapshot =
                     dynamic_cast<const recorded_snapshot_t *const>(snapshot);
                 if (recorded_snapshot->tool_shard_id != recorded_snapshot->shard_id) {
-                    FATAL_ERROR("shard_id stored by tool (" PRIi64
-                                ") and framework (" PRIi64 ") mismatch",
+                    FATAL_ERROR("shard_id stored by tool (%" PRIi64
+                                ") and framework (%" PRIi64 ") mismatch",
                                 recorded_snapshot->tool_shard_id,
                                 recorded_snapshot->shard_id);
                     return nullptr;

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -443,9 +443,10 @@ public:
                 auto recorded_snapshot =
                     dynamic_cast<const recorded_snapshot_t *const>(snapshot);
                 if (recorded_snapshot->tool_shard_id != recorded_snapshot->shard_id) {
-                    std::cerr << "shard_id stored by tool ("
-                              << recorded_snapshot->tool_shard_id << ") and framework ("
-                              << recorded_snapshot->shard_id << ") mismatch\n";
+                    FATAL_ERROR("shard_id stored by tool (" PRIi64
+                                ") and framework (" PRIi64 ") mismatch",
+                                recorded_snapshot->tool_shard_id,
+                                recorded_snapshot->shard_id);
                     return nullptr;
                 }
                 result->component_intervals.insert(
@@ -648,8 +649,8 @@ test_non_zero_interval(bool parallel, bool combine_only_active_shards = true)
 int
 main(int argc, const char *argv[])
 {
-    if (!test_non_zero_interval(false) || !test_non_zero_interval(true, false) ||
-        !test_non_zero_interval(true, true))
+    if (!test_non_zero_interval(false) || !test_non_zero_interval(true, true) ||
+        !test_non_zero_interval(true, false))
         return 1;
     fprintf(stderr, "All done!\n");
     return 0;

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -305,6 +305,7 @@ public:
         {
         }
         recorded_snapshot_t()
+            : interval_state_snapshot_t()
         {
         }
 
@@ -647,8 +648,8 @@ test_non_zero_interval(bool parallel, bool combine_only_active_shards = true)
 int
 main(int argc, const char *argv[])
 {
-    if (!test_non_zero_interval(false) || !test_non_zero_interval(true, true) ||
-        !test_non_zero_interval(true, false))
+    if (!test_non_zero_interval(false) || !test_non_zero_interval(true, false) ||
+        !test_non_zero_interval(true, true))
         return 1;
     fprintf(stderr, "All done!\n");
     return 0;

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -305,7 +305,6 @@ basic_counts_t::generate_shard_interval_snapshot(void *shard_data, uint64_t inte
     for (const auto &ctr : per_shard->counters) {
         snapshot->counters += ctr;
     }
-    snapshot->tid = per_shard->tid;
     return snapshot;
 }
 
@@ -318,7 +317,6 @@ basic_counts_t::generate_interval_snapshot(uint64_t interval_id)
             snapshot->counters += ctr;
         }
     }
-    snapshot->tid = 0; // Use zero to represent the whole-trace interval.
     return snapshot;
 }
 

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -340,7 +340,14 @@ bool
 basic_counts_t::print_interval_results(
     const std::vector<interval_state_snapshot_t *> &interval_snapshots)
 {
-    std::cerr << "Interval total counts across threads:\n";
+    std::cerr << "Counts per trace interval for ";
+    if (!interval_snapshots.empty() &&
+        interval_snapshots[0]->shard_id !=
+            interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID) {
+        std::cerr << "TID " << interval_snapshots[0]->shard_id << ":\n";
+    } else {
+        std::cerr << "whole trace:\n";
+    }
     counters_t last;
     for (const auto &snapshot_base : interval_snapshots) {
         auto *snapshot = dynamic_cast<count_snapshot_t *>(snapshot_base);

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -194,7 +194,6 @@ protected:
         // the cumulative values here and compute the delta at the end in
         // print_interval_results().
         counters_t counters;
-        memref_tid_t tid;
         // TODO i#6020: Add per-window counters to the snapshot, and also
         // return interval counts separately per-window in a structured
         // way and print under a flag.


### PR DESCRIPTION
Adds TID to the interval_state_snapshot_t base struct, so that tools do not need to track it themselves if they need it. The TID is stored as "shard_id" which in future may contain a different id if we define shards differently.

Also changes interval_id to always be a positive integer, which makes some things simpler downstream.

Issue: #6020