### PR TITLE
i#6083: Add missing cmake include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ endif ()
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+include(CheckIncludeFile)
 
 ###########################################################################
 # utility functions

--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2021 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2023 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -58,6 +58,8 @@ else ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
 endif ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
 
 project(DynamoRIO_samples)
+
+include(CheckIncludeFile)
 
 if ("${CMAKE_VERSION}" VERSION_EQUAL "3.9" OR
    "${CMAKE_VERSION}" VERSION_GREATER "3.9")


### PR DESCRIPTION
Adds a missing include for the cmake module CheckIncludeFile. This was breaking a separate build-and-test of our samples but somehow only on the aarchxx-native machine.

Fixes #6083