### PR TITLE
Document list of supported environments

### DIFF
--- a/api/docs/building.dox
+++ b/api/docs/building.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -37,6 +37,15 @@
 # Quick Start
 
 If you don't need to modify DR and just need a recent build, you can download [weekly package builds](@ref page_weekly_builds).
+
+The official list of environments for which we have complete or in-progress support are the ones on our [Github
+CI workflows page](https://github.com/DynamoRIO/dynamorio/tree/master/.github/workflows), These
+workflows run our test suite before the submission of each master merge, and also a longer test suite after each
+master merge. This helps in ensuring that DynamoRIO continues to build and run properly on these environments.
+For other environments, contributions from users are greatly appreciated. For help with any issue building or
+running on any environment, feel free to start a thread on our
+[discussion list](http://groups.google.com/group/DynamoRIO-Users) or report a bug on our
+[issue tracker](https://github.com/DynamoRIO/dynamorio/issues).
 
 ## Linux
 


### PR DESCRIPTION
Adds a link to the list of officially supported environments to the page on building from source. As requested on #6043.