### PR TITLE
i#3544 RV64: Added machine type support for ELF hdr verification

### DIFF
--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -114,7 +114,8 @@ is_elf_so_header_common(app_pc base, size_t size, bool memory)
             (memory && elf_header.e_ehsize != sizeof(ELF_HEADER_TYPE)) ||
             (memory &&
 #ifdef X64
-             elf_header.e_machine != EM_X86_64 && elf_header.e_machine != EM_AARCH64
+             elf_header.e_machine != EM_X86_64 && elf_header.e_machine != EM_AARCH64 &&
+             elf_header.e_machine != EM_RISCV
 #else
              elf_header.e_machine != EM_386 && elf_header.e_machine != EM_ARM
 #endif

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1840,7 +1840,8 @@ privload_mem_is_elf_so_header(byte *mem)
      */
     if (
 #        ifdef X64
-        elf_hdr->e_machine != EM_X86_64 && elf_hdr->e_machine != EM_AARCH64
+        elf_hdr->e_machine != EM_X86_64 && elf_hdr->e_machine != EM_AARCH64 &&
+        elf_hdr->e_machine != EM_RISCV
 #        else
         elf_hdr->e_machine != EM_386 && elf_hdr->e_machine != EM_ARM
 #        endif


### PR DESCRIPTION
This patch added ELF header checks for RISC-V.

Issue: https://github.com/DynamoRIO/dynamorio/issues/3544