### PR TITLE
i#3544 RV64: Fixed atomic functions and macros

### DIFF
--- a/core/arch/atomic_exports.h
+++ b/core/arch/atomic_exports.h
@@ -935,11 +935,11 @@ atomic_compare_exchange_int(volatile int *var, int compare, int exchange)
     ASSERT(ALIGNED(var, 4));
     /* This code is based on GCC's atomic_compare_exchange_strong().
      * The fence ensures no re-ordering beyond the start of the lr/sc loop.
-     * The lr/sc use acquire and release ordering to ensure that the full loop
-     * has sequentially consistent memory order semantics.
+     * Provides acquire/release semantics for LR/SC sequences by setting the
+     * aq and rl bits on lr and sc respectively.
      */
     __asm__ __volatile__("fence   iorw,ow\n\t"
-                         "1: lr.w.aqrl  t0, (%1)\n\t"
+                         "1: lr.w.aq    t0, (%1)\n\t"
                          "   bne        t0, %2, 2f\n\t"
                          "   sc.w.rl    %0, %3, (%1)\n\t"
                          "   bnez       %0, 1b\n\t"
@@ -960,11 +960,11 @@ atomic_compare_exchange_int64(volatile int64 *var, int64 compare, int64 exchange
     ASSERT(ALIGNED(var, 8));
     /* This code is based on GCC's atomic_compare_exchange_strong().
      * The fence ensures no re-ordering beyond the start of the lr/sc loop.
-     * The lr/sc use acquire ordering to ensure that the full loop has
-     * sequentially consistent memory order semantics.
+     * Provides acquire/release semantics for LR/SC sequences by setting the
+     * aq and rl bits on lr and sc respectively.
      */
     __asm__ __volatile__("fence   iorw,ow\n\t"
-                         "1: lr.d.aqrl  t0, (%1)\n\t"
+                         "1: lr.d.aq    t0, (%1)\n\t"
                          "   bne        t0, %2, 2f\n\t"
                          "   sc.d.rl    %0, %3, (%1)\n\t"
                          "   bnez       %0, 1b\n\t"

--- a/core/arch/atomic_exports.h
+++ b/core/arch/atomic_exports.h
@@ -932,7 +932,7 @@ atomic_compare_exchange_int(volatile int *var, int compare, int exchange)
     ASSERT(ALIGNED(var, 4));
     /* This code is based on GCC's atomic_compare_exchange_strong().
      * The fence ensures no re-ordering beyond the start of the lr/sc loop.
-     * The lr/sc use acquire and release ordering to ensure that the full loop 
+     * The lr/sc use acquire and release ordering to ensure that the full loop
      * has sequentially consistent memory order semantics.
      */
     __asm__ __volatile__("fence   iorw,ow\n\t"

--- a/core/arch/atomic_exports.h
+++ b/core/arch/atomic_exports.h
@@ -932,8 +932,8 @@ atomic_compare_exchange_int(volatile int *var, int compare, int exchange)
     ASSERT(ALIGNED(var, 4));
     /* This code is based on GCC's atomic_compare_exchange_strong().
      * The fence ensures no re-ordering beyond the start of the lr/sc loop.
-     * The lr/sc use acquire ordering to ensure that the full loop has
-     * sequentially consistent memory order semantics.
+     * The lr/sc use acquire and release ordering to ensure that the full loop 
+     * has sequentially consistent memory order semantics.
      */
     __asm__ __volatile__("fence   iorw,ow\n\t"
                          "1: lr.w.aqrl  t0, (%1)\n\t"
@@ -941,7 +941,6 @@ atomic_compare_exchange_int(volatile int *var, int compare, int exchange)
                          "   sc.w.rl    %0, %3, (%1)\n\t"
                          "   bnez       %0, 1b\n\t"
                          "2:\n\t"
-                         "   subw       %0, t0, %2\n\t"
                          : "+r"(res)
                          : "r"(var), "r"(compare), "r"(exchange)
                          : "t0", "memory");

--- a/core/fragment.c
+++ b/core/fragment.c
@@ -1842,7 +1842,11 @@ fragment_thread_reset_init(dcontext_t *dcontext)
     if (dynamo_resetting)
         pt->flushtime_last_update = 0;
     else
+#ifdef DR_HOST_RISCV64
+        ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, pt->flushtime_last_update);
+#else
         ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, &pt->flushtime_last_update);
+#endif
 
     /* set initial hashtable sizes */
     hashtable_fragment_init(
@@ -5421,13 +5425,17 @@ check_flush_queue(dcontext_t *dcontext, fragment_t *was_I_flushed)
             SELF_PROTECT_LOCAL(dcontext, READONLY);
     }
     /* now check shared queue to dec ref counts */
-    uint local_flushtime_global;
+    uint local_flushtime_global = 0;
     /* No lock needed: any racy incs to global are in safe direction, and our inc
      * is atomic so we shouldn't see any partial-word-updated values here.  This
      * check is our shared deletion algorithm's only perf hit when there's no
      * actual shared flushing.
      */
+#ifdef DR_HOST_RISCV64
+    ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, local_flushtime_global);
+#else
     ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, &local_flushtime_global);
+#endif
     if (DYNAMO_OPTION(shared_deletion) &&
         pt->flushtime_last_update < local_flushtime_global) {
 #ifdef LINUX
@@ -5818,8 +5826,12 @@ increment_global_flushtime()
     /* reset will turn flushtime_global back to 0, so we schedule one
      * when we're approaching overflow
      */
-    uint local_flushtime_global;
+    uint local_flushtime_global = 0;
+#ifdef DR_HOST_RISCV64
+    ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, local_flushtime_global);
+#else
     ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, &local_flushtime_global);
+#endif
     if (local_flushtime_global == UINT_MAX / 2) {
         ASSERT_NOT_TESTED(); /* FIXME: add -stress_flushtime_global_max */
         SYSLOG_INTERNAL_WARNING("flushtime_global approaching UINT_MAX, resetting");
@@ -6704,7 +6716,11 @@ flush_fragments_end_synch(dcontext_t *dcontext, bool keep_initexit_lock)
              */
 #ifdef DEBUG
             uint pre_flushtime;
+#    ifdef DR_HOST_RISCV64
+            ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, pre_flushtime);
+#    else
             ATOMIC_4BYTE_ALIGNED_READ(&flushtime_global, &pre_flushtime);
+#    endif
 #endif
             vm_area_check_shared_pending(tgt_dcontext, NULL);
             /* lazy deletion may inc flushtime_global, so may have a higher


### PR DESCRIPTION
This patch fixed some atomic functions and macros of the RV64 port.

Issue: https://github.com/DynamoRIO/dynamorio/issues/3544