### PR TITLE
AArch64: Fixed dr_longjmp

### DIFF
--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -498,8 +498,8 @@ GLOBAL_LABEL(dr_longjmp:)
         ldp      d10, d11, [ARG1, #128]
         ldp      d12, d13, [ARG1, #144]
         ldp      d14, d15, [ARG1, #160]
-        cmp      w0, #0
-        csinc    w0, w0, wzr, ne
+        cmp      w1, #0
+        csinc    w0, w1, wzr, ne
         br       x30
         END_FUNC(dr_longjmp)
 


### PR DESCRIPTION
This patch fixed a typo in AArch64 `dr_longjmp` assembly function.

`int dr_longjmp(dr_jmp_buf_t *buf, int val);`

The expected behavior of `dr_longjmp` is to return 1 if `val` is 0, and `val` otherwise. So we should check arg2 (`w1`) instead of arg1 (`w0`). In most cases, this typo won't cause an issue, I guess that's why we didn't notice it before.
