### PR TITLE
i#6020 interval analysis: optimize basic_counts memory

### DIFF
--- a/clients/drcachesim/tests/offline-interval-count-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-count-output.templatex
@@ -41,7 +41,6 @@ Thread .* counts:
 Counts per trace interval for whole trace:
 Interval #1 ending at timestamp.*
      .* interval delta \(fetched\) instructions
-     .* interval delta unique \(fetched\) instructions
      .* interval delta non-fetched instructions
      .* interval delta prefetches
      .* interval delta data loads

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -33,6 +33,7 @@
 #define NOMINMAX // Avoid windows.h messing up std::max.
 
 #include <algorithm>
+#include <cassert>
 #include <iomanip>
 #include <iostream>
 #include <vector>
@@ -208,8 +209,10 @@ basic_counts_t::print_counters(const counters_t &counters, int_least64_t num_thr
 {
     std::cerr << std::setw(12) << counters.instrs << prefix
               << " (fetched) instructions\n";
-    std::cerr << std::setw(12) << counters.unique_pc_addrs.size() << prefix
-              << " unique (fetched) instructions\n";
+    if (counters.is_tracking_unique_pc_addrs()) {
+        std::cerr << std::setw(12) << counters.unique_pc_addrs.size() << prefix
+                  << " unique (fetched) instructions\n";
+    }
     std::cerr << std::setw(12) << counters.instrs_nofetch << prefix
               << " non-fetched instructions\n";
     std::cerr << std::setw(12) << counters.prefetches << prefix << " prefetches\n";
@@ -302,6 +305,8 @@ basic_counts_t::generate_shard_interval_snapshot(void *shard_data, uint64_t inte
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     count_snapshot_t *snapshot = new count_snapshot_t;
+    // Tracking unique pc addresses for each snapshot takes up excessive space.
+    snapshot->counters.skip_tracking_unique_pc_addrs();
     for (const auto &ctr : per_shard->counters) {
         snapshot->counters += ctr;
     }
@@ -312,6 +317,8 @@ analysis_tool_t::interval_state_snapshot_t *
 basic_counts_t::generate_interval_snapshot(uint64_t interval_id)
 {
     count_snapshot_t *snapshot = new count_snapshot_t;
+    // Tracking unique pc addresses for each snapshot takes up excessive space.
+    snapshot->counters.skip_tracking_unique_pc_addrs();
     for (const auto &shard : shard_map_) {
         for (const auto &ctr : shard.second->counters) {
             snapshot->counters += ctr;
@@ -332,6 +339,7 @@ basic_counts_t::combine_interval_snapshots(
             continue;
         result->counters +=
             dynamic_cast<const count_snapshot_t *const>(snapshot)->counters;
+        assert(result->counters.unique_pc_addrs.empty());
     }
     return result;
 }

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -306,7 +306,7 @@ basic_counts_t::generate_shard_interval_snapshot(void *shard_data, uint64_t inte
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     count_snapshot_t *snapshot = new count_snapshot_t;
     // Tracking unique pc addresses for each snapshot takes up excessive space.
-    snapshot->counters.skip_tracking_unique_pc_addrs();
+    snapshot->counters.stop_tracking_unique_pc_addrs();
     for (const auto &ctr : per_shard->counters) {
         snapshot->counters += ctr;
     }
@@ -318,7 +318,7 @@ basic_counts_t::generate_interval_snapshot(uint64_t interval_id)
 {
     count_snapshot_t *snapshot = new count_snapshot_t;
     // Tracking unique pc addresses for each snapshot takes up excessive space.
-    snapshot->counters.skip_tracking_unique_pc_addrs();
+    snapshot->counters.stop_tracking_unique_pc_addrs();
     for (const auto &shard : shard_map_) {
         for (const auto &ctr : shard.second->counters) {
             snapshot->counters += ctr;

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -174,7 +174,7 @@ public:
         // Stops tracking unique_pc_addrs. Tracking unique_pc_addrs can be very
         // memory intensive. We skip it for interval state snapshots.
         void
-        skip_tracking_unique_pc_addrs()
+        stop_tracking_unique_pc_addrs()
         {
             track_unique_pc_addrs = false;
             unique_pc_addrs.clear();


### PR DESCRIPTION
Avoids tracking unique pc addresses in counters_t for interval state snapshots.

This takes up excessive memory on apps with a lot of threads, even if the
interval count is not that high. For apps with O(1K) threads and O(100) intervals,
the number of tracked "unique" pcs goes up by O(10^5), causing memory
usage to grow even beyond 300GB in some cases.

Issue: #6020