### PR TITLE
initialize kernel_sigaction_t variables in signal.c

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -2241,8 +2241,8 @@ uint
 handle_post_old_sigaction(dcontext_t *dcontext, bool success, int sig,
                           const old_sigaction_t *act, old_sigaction_t *oact)
 {
-    kernel_sigaction_t kact;
-    kernel_sigaction_t okact;
+    kernel_sigaction_t kact = {};
+    kernel_sigaction_t okact = {};
     ptr_uint_t res;
     if (act != NULL && success) {
         if (!convert_old_sigaction_to_kernel(dcontext, &kact, act)) {


### PR DESCRIPTION
When building dynamorio with -Wmaybe-uninitialized, the compiler reported the error. At a first glance, it looks like this is a false positive, as the variables are initialized by either of the above branches. However, it does not hurt to initialize them to make the compiler happy.

This is also helps when packaging for distros, as there usually this warning is enabled.