### PR TITLE
drsyms: link against import targets

### DIFF
--- a/ext/drsyms/CMakeLists.txt
+++ b/ext/drsyms/CMakeLists.txt
@@ -186,9 +186,9 @@ configure_extension(drsyms_static ON)
 configure_drsyms_target(drsyms_static)
 use_DynamoRIO_extension(drsyms_static drcontainers)
 
-target_link_libraries(drsyms "${dwarf_libpath}" "${elftc_libpath}")
+target_link_libraries(drsyms dwarf elftc)
 if (LINUX)
-  target_link_libraries(drsyms "${elf_libpath}")
+  target_link_libraries(drsyms elf)
 endif ()
 # i#693: CMake will try to export the path to the static libs we use via
 # IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG, but they won't exist on the


### PR DESCRIPTION
We already create cmake import targets for the vendored libraries. By that, also use them in target_link_libraries instead of using the full path. In most cases this does not have any effect, but it helps when debugging linking issues. It also makes the logic easier to read.