### PR TITLE
i#6112: Require a full output match in runmulti

### DIFF
--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -128,6 +128,6 @@ endif()
 # get expected output (must already be processed w/ regex => literal, etc.)
 file(READ "${cmp}" str)
 
-if (NOT "${tomatch}" MATCHES "${str}")
+if (NOT "${tomatch}" MATCHES "^${str}$")
   message(FATAL_ERROR "output |${tomatch}| failed to match expected output |${str}|")
 endif ()


### PR DESCRIPTION
Brackets the expected outpout with ^$ to require a complete match for tests using runmulti.cmake.  This matches what we do for single-command tests for their PASS_REGULAR_EXPRESSION property.

Fixes #6112