### PR TITLE
i#6020 interval analysis: Fix interval counts regex

### DIFF
--- a/clients/drcachesim/tests/offline-interval-count-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-count-output.templatex
@@ -1,61 +1,61 @@
 Hello, world!
 Basic counts tool results:
 Total counts:
-      [ 0-9]* total \(fetched\) instructions
-      [ 0-9]* total unique \(fetched\) instructions
-      [ 0-9]* total non-fetched instructions
-      [ 0-9]* total prefetches
-      [ 0-9]* total data loads
-      [ 0-9]* total data stores
-      [ 0-9]* total icache flushes
-      [ 0-9]* total dcache flushes
+     [ 0-9]* total \(fetched\) instructions
+     [ 0-9]* total unique \(fetched\) instructions
+     [ 0-9]* total non-fetched instructions
+     [ 0-9]* total prefetches
+     [ 0-9]* total data loads
+     [ 0-9]* total data stores
+     [ 0-9]* total icache flushes
+     [ 0-9]* total dcache flushes
            1 total threads
-      [ 0-9]* total scheduling markers
-      [ 0-9]* total transfer markers
-      [ 0-9]* total function id markers
-      [ 0-9]* total function return address markers
-      [ 0-9]* total function argument markers
-      [ 0-9]* total function return value markers
+     [ 0-9]* total scheduling markers
+     [ 0-9]* total transfer markers
+     [ 0-9]* total function id markers
+     [ 0-9]* total function return address markers
+     [ 0-9]* total function argument markers
+     [ 0-9]* total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-      [ 0-9]* total other markers
-      [ 0-9]* total encodings
+     [ 0-9]* total other markers
+     [ 0-9]* total encodings
 Thread [0-9]* counts:
-      [ 0-9]* \(fetched\) instructions
-      [ 0-9]* unique \(fetched\) instructions
-      [ 0-9]* non-fetched instructions
-      [ 0-9]* prefetches
-      [ 0-9]* data loads
-      [ 0-9]* data stores
-      [ 0-9]* icache flushes
-      [ 0-9]* dcache flushes
-      [ 0-9]* scheduling markers
-      [ 0-9]* transfer markers
-      [ 0-9]* function id markers
-      [ 0-9]* function return address markers
-      [ 0-9]* function argument markers
-      [ 0-9]* function return value markers
+     [ 0-9]* \(fetched\) instructions
+     [ 0-9]* unique \(fetched\) instructions
+     [ 0-9]* non-fetched instructions
+     [ 0-9]* prefetches
+     [ 0-9]* data loads
+     [ 0-9]* data stores
+     [ 0-9]* icache flushes
+     [ 0-9]* dcache flushes
+     [ 0-9]* scheduling markers
+     [ 0-9]* transfer markers
+     [ 0-9]* function id markers
+     [ 0-9]* function return address markers
+     [ 0-9]* function argument markers
+     [ 0-9]* function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-      [ 0-9]* other markers
-      [ 0-9]* encodings
+     [ 0-9]* other markers
+     [ 0-9]* encodings
 Counts per trace interval for whole trace:
 Interval #1 ending at timestamp [0-9]*:
-      [ 0-9]* interval delta \(fetched\) instructions
-      [ 0-9]* interval delta non-fetched instructions
-      [ 0-9]* interval delta prefetches
-      [ 0-9]* interval delta data loads
-      [ 0-9]* interval delta data stores
-      [ 0-9]* interval delta icache flushes
-      [ 0-9]* interval delta dcache flushes
-      [ 0-9]* interval delta scheduling markers
-      [ 0-9]* interval delta transfer markers
-      [ 0-9]* interval delta function id markers
-      [ 0-9]* interval delta function return address markers
-      [ 0-9]* interval delta function argument markers
-      [ 0-9]* interval delta function return value markers
+     [ 0-9]* interval delta \(fetched\) instructions
+     [ 0-9]* interval delta non-fetched instructions
+     [ 0-9]* interval delta prefetches
+     [ 0-9]* interval delta data loads
+     [ 0-9]* interval delta data stores
+     [ 0-9]* interval delta icache flushes
+     [ 0-9]* interval delta dcache flushes
+     [ 0-9]* interval delta scheduling markers
+     [ 0-9]* interval delta transfer markers
+     [ 0-9]* interval delta function id markers
+     [ 0-9]* interval delta function return address markers
+     [ 0-9]* interval delta function argument markers
+     [ 0-9]* interval delta function return value markers
            0 interval delta physical address \+ virtual address marker pairs
            0 interval delta physical address unavailable markers
-      [ 0-9]* interval delta other markers
-      [ 0-9]* interval delta encodings
+     [ 0-9]* interval delta other markers
+     [ 0-9]* interval delta encodings
 .*

--- a/clients/drcachesim/tests/offline-interval-count-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-count-output.templatex
@@ -1,61 +1,61 @@
 Hello, world!
 Basic counts tool results:
 Total counts:
-     .* total \(fetched\) instructions
-     .* total unique \(fetched\) instructions
-     .* total non-fetched instructions
-     .* total prefetches
-     .* total data loads
-     .* total data stores
-     .* total icache flushes
-     .* total dcache flushes
+      [ 0-9]* total \(fetched\) instructions
+      [ 0-9]* total unique \(fetched\) instructions
+      [ 0-9]* total non-fetched instructions
+      [ 0-9]* total prefetches
+      [ 0-9]* total data loads
+      [ 0-9]* total data stores
+      [ 0-9]* total icache flushes
+      [ 0-9]* total dcache flushes
            1 total threads
-     .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
+      [ 0-9]* total scheduling markers
+      [ 0-9]* total transfer markers
+      [ 0-9]* total function id markers
+      [ 0-9]* total function return address markers
+      [ 0-9]* total function argument markers
+      [ 0-9]* total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
-Thread .* counts:
-     .* \(fetched\) instructions
-     .* unique \(fetched\) instructions
-     .* non-fetched instructions
-     .* prefetches
-     .* data loads
-     .* data stores
-     .* icache flushes
-     .* dcache flushes
-     .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
+      [ 0-9]* total other markers
+      [ 0-9]* total encodings
+Thread [0-9]* counts:
+      [ 0-9]* \(fetched\) instructions
+      [ 0-9]* unique \(fetched\) instructions
+      [ 0-9]* non-fetched instructions
+      [ 0-9]* prefetches
+      [ 0-9]* data loads
+      [ 0-9]* data stores
+      [ 0-9]* icache flushes
+      [ 0-9]* dcache flushes
+      [ 0-9]* scheduling markers
+      [ 0-9]* transfer markers
+      [ 0-9]* function id markers
+      [ 0-9]* function return address markers
+      [ 0-9]* function argument markers
+      [ 0-9]* function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-     .* other markers
-     .* encodings
+      [ 0-9]* other markers
+      [ 0-9]* encodings
 Counts per trace interval for whole trace:
-Interval #1 ending at timestamp.*
-     .* interval delta \(fetched\) instructions
-     .* interval delta non-fetched instructions
-     .* interval delta prefetches
-     .* interval delta data loads
-     .* interval delta data stores
-     .* interval delta icache flushes
-     .* interval delta dcache flushes
-     .* interval delta scheduling markers
-     .* interval delta transfer markers
-     .* interval delta function id markers
-     .* interval delta function return address markers
-     .* interval delta function argument markers
-     .* interval delta function return value markers
+Interval #1 ending at timestamp [0-9]*:
+      [ 0-9]* interval delta \(fetched\) instructions
+      [ 0-9]* interval delta non-fetched instructions
+      [ 0-9]* interval delta prefetches
+      [ 0-9]* interval delta data loads
+      [ 0-9]* interval delta data stores
+      [ 0-9]* interval delta icache flushes
+      [ 0-9]* interval delta dcache flushes
+      [ 0-9]* interval delta scheduling markers
+      [ 0-9]* interval delta transfer markers
+      [ 0-9]* interval delta function id markers
+      [ 0-9]* interval delta function return address markers
+      [ 0-9]* interval delta function argument markers
+      [ 0-9]* interval delta function return value markers
            0 interval delta physical address \+ virtual address marker pairs
            0 interval delta physical address unavailable markers
-     .* interval delta other markers
-     .* interval delta encodings.*
+      [ 0-9]* interval delta other markers
+      [ 0-9]* interval delta encodings
 .*

--- a/clients/drcachesim/tests/offline-interval-count-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-count-output.templatex
@@ -57,5 +57,4 @@ Interval #1 ending at timestamp [0-9]*:
            0 interval delta physical address \+ virtual address marker pairs
            0 interval delta physical address unavailable markers
      [ 0-9]* interval delta other markers
-     [ 0-9]* interval delta encodings
-.*
+     [ 0-9]* interval delta encodings.*

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -334,6 +334,7 @@ basic_counts_t::combine_interval_snapshots(
     uint64_t interval_end_timestamp)
 {
     count_snapshot_t *result = new count_snapshot_t;
+    result->counters.stop_tracking_unique_pc_addrs();
     for (const auto snapshot : latest_shard_snapshots) {
         if (snapshot == nullptr)
             continue;

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -334,6 +334,12 @@ basic_counts_t::combine_interval_snapshots(
     uint64_t interval_end_timestamp)
 {
     count_snapshot_t *result = new count_snapshot_t;
+    // The snapshots in latest_shard_snapshots do not track unique_pc_addrs, so
+    // the combined result->counters also would not contain any element in the
+    // unique_pc_addrs set. But we still need to explicitly disable
+    // unique_pc_addrs tracking in result->counters using the following function
+    // call. This is so that printing of unique_pc_addrs count is skipped as
+    // intended during print_interval_results.
     result->counters.stop_tracking_unique_pc_addrs();
     for (const auto snapshot : latest_shard_snapshots) {
         if (snapshot == nullptr)


### PR DESCRIPTION
Ensures that we do not track unique PCs in the combined interval
snapshots. Since the shard-local snapshots themselves do not track
unique pcs, the combined snapshot also wouldn't have anything in
the unique pc set. But we need to explicitly disable unique pcs
tracking so that we skip printing that field. This was missing in the
original PR #6097.

Also fixes expected regex of basic counts interval output so that only
digits and leading white-spaces are accepted at the beginning of each
line. Otherwise we aren't able to detect that the unique pc addrs line
in the counters output is still present.

Also fixes a regression due to #6113 which causes a regex match
failure in case only a single interval is output for the whole trace.

Issue: #6020, #6112 