### PR TITLE
i#6112 runmulti: Remove diagnostic print

### DIFF
--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -118,7 +118,6 @@ endmacro()
 process_cmdline(precmd ON ignore)
 
 process_cmdline(cmd OFF tomatch)
-message("output: |${tomatch}|")
 
 if (NOT "${postcmd}" STREQUAL "")
   process_cmdline(postcmd OFF tomatch)


### PR DESCRIPTION
Removes a message line accidentally left in PR #6113.

Issue: #6112