### PR TITLE
i#6131 hang win32: Disable popups in drcachesim tests

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -319,6 +319,8 @@ install_client_nonDR_header(drmemtrace tracer/raw2trace.h)
 install_client_nonDR_header(drmemtrace scheduler/scheduler.h)
 install_client_nonDR_header(drmemtrace scheduler/speculator.h)
 
+add_library(test_helpers STATIC tests/test_helpers.cpp)
+
 # We show one example of how to create a standalone analyzer of trace
 # files that does not need to link with DR.
 add_executable(histogram_launcher
@@ -343,7 +345,7 @@ target_link_libraries(record_filter_launcher drmemtrace_analyzer drmemtrace_reco
 use_DynamoRIO_extension(record_filter_launcher droption)
 
 add_executable(scheduler_launcher tests/scheduler_launcher.cpp)
-target_link_libraries(scheduler_launcher drmemtrace_analyzer drfrontendlib)
+target_link_libraries(scheduler_launcher drmemtrace_analyzer drfrontendlib test_helpers)
 use_DynamoRIO_extension(scheduler_launcher droption)
 add_dependencies(scheduler_launcher api_headers)
 # Simple test to ensure this launcher keeps working.
@@ -515,6 +517,9 @@ restore_nonclient_flags(drmemtrace_invariant_checker)
 # get rid of add_win32_flags(target) since that just adds a couple of flags
 # back, and using the ORIG_ values is preferable.
 macro(add_win32_flags target)
+  if (DEBUG)
+    append_property_list(TARGET ${target} COMPILE_DEFINITIONS "DEBUG")
+  endif ()
   if (WIN32)
     if (DEBUG)
       get_property(cur TARGET ${target} PROPERTY COMPILE_FLAGS)
@@ -671,7 +676,7 @@ endif ()
 if (BUILD_TESTS)
   add_executable(tool.reuse_distance.unit_tests tests/reuse_distance_test.cpp)
   target_link_libraries(tool.reuse_distance.unit_tests drmemtrace_reuse_distance
-    drmemtrace_static)
+    drmemtrace_static test_helpers)
   add_win32_flags(tool.reuse_distance.unit_tests)
   add_test(NAME tool.reuse_distance.unit_tests
        COMMAND tool.reuse_distance.unit_tests)
@@ -679,7 +684,7 @@ if (BUILD_TESTS)
   add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp
     tests/cache_replacement_policy_unit_test.cpp tests/config_reader_unit_test.cpp)
   target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator
-    drmemtrace_static drmemtrace_analyzer ${zlib_libs})
+    drmemtrace_static drmemtrace_analyzer ${zlib_libs} test_helpers)
   add_win32_flags(tool.drcachesim.unit_tests)
   add_test(NAME tool.drcachesim.unit_tests
            COMMAND tool.drcachesim.unit_tests
@@ -688,7 +693,8 @@ if (BUILD_TESTS)
   add_executable(tool.drcacheoff.raw2trace_unit_tests tests/raw2trace_unit_tests.cpp)
   configure_DynamoRIO_standalone(tool.drcacheoff.raw2trace_unit_tests)
   add_win32_flags(tool.drcacheoff.raw2trace_unit_tests)
-  target_link_libraries(tool.drcacheoff.raw2trace_unit_tests drmemtrace_raw2trace)
+  target_link_libraries(tool.drcacheoff.raw2trace_unit_tests drmemtrace_raw2trace
+    test_helpers)
   use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drdecode)
   use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drcovlib_static)
   add_test(NAME tool.drcacheoff.raw2trace_unit_tests
@@ -696,7 +702,7 @@ if (BUILD_TESTS)
 
   add_executable(tool.scheduler.unit_tests tests/scheduler_unit_tests.cpp
     tests/scheduler_unit_tests.cpp)
-  target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer)
+  target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer test_helpers)
   add_win32_flags(tool.scheduler.unit_tests)
   if (WIN32)
     # We have a dup symbol from linking in DR.  Linking libc first doesn't help.
@@ -720,7 +726,7 @@ if (BUILD_TESTS)
                    tests/record_filter_unit_tests.cpp)
     configure_DynamoRIO_standalone(tool.drcacheoff.record_filter_unit_tests)
     target_link_libraries(tool.drcacheoff.record_filter_unit_tests drmemtrace_analyzer
-      drmemtrace_basic_counts drmemtrace_record_filter)
+      drmemtrace_basic_counts drmemtrace_record_filter test_helpers)
     add_test(NAME tool.drcacheoff.record_filter_unit_tests
              COMMAND tool.drcacheoff.record_filter_unit_tests --trace_dir
                      ${trace_dir} --tmp_output_dir ${tmp_output_dir})
@@ -730,7 +736,7 @@ if (BUILD_TESTS)
                  tests/trace_interval_analysis_unit_tests.cpp)
   add_win32_flags(tool.drcacheoff.trace_interval_analysis_unit_tests)
   target_link_libraries(tool.drcacheoff.trace_interval_analysis_unit_tests
-    drmemtrace_analyzer drdecode)
+    drmemtrace_analyzer drdecode test_helpers)
   add_test(NAME tool.drcacheoff.trace_interval_analysis_unit_tests
            COMMAND tool.drcacheoff.trace_interval_analysis_unit_tests)
 
@@ -739,7 +745,7 @@ if (BUILD_TESTS)
     configure_DynamoRIO_static(tool.drcacheoff.burst_aarch64_sys)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_aarch64_sys drmemtrace_static)
     target_link_libraries(tool.drcacheoff.burst_aarch64_sys drmemtrace_raw2trace
-      drmemtrace_analyzer)
+      drmemtrace_analyzer test_helpers)
     use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.burst_aarch64_sys)
     add_win32_flags(tool.drcacheoff.burst_aarch64_sys)
   endif ()
@@ -751,7 +757,7 @@ if (BUILD_TESTS)
     # Tests for the cache miss analyzer.
     add_executable(tool.drcachesim.miss_analyzer_unit_test tests/cache_miss_analyzer_test.cpp)
     target_link_libraries(tool.drcachesim.miss_analyzer_unit_test drmemtrace_simulator
-      drmemtrace_static drmemtrace_analyzer ${zlib_libs})
+      drmemtrace_static drmemtrace_analyzer ${zlib_libs} test_helpers)
     add_win32_flags(tool.drcachesim.miss_analyzer_unit_test)
     add_test(NAME tool.drcachesim.miss_analyzer_unit_test
              COMMAND tool.drcachesim.miss_analyzer_unit_test)
@@ -760,7 +766,7 @@ if (BUILD_TESTS)
     configure_DynamoRIO_standalone(tool.drcachesim.invariant_checker_test)
     add_win32_flags(tool.drcachesim.invariant_checker_test)
     target_link_libraries(tool.drcachesim.invariant_checker_test
-        drmemtrace_static drmemtrace_analyzer drmemtrace_invariant_checker)
+        drmemtrace_static drmemtrace_analyzer drmemtrace_invariant_checker test_helpers)
     add_test(NAME tool.drcachesim.invariant_checker_test
              COMMAND tool.drcachesim.invariant_checker_test)
 
@@ -768,7 +774,7 @@ if (BUILD_TESTS)
     configure_DynamoRIO_standalone(tool.drcacheoff.view_test)
     add_win32_flags(tool.drcacheoff.view_test)
     target_link_libraries(tool.drcacheoff.view_test drmemtrace_view drmemtrace_raw2trace
-      drmemtrace_analyzer)
+      drmemtrace_analyzer test_helpers)
     use_DynamoRIO_extension(tool.drcacheoff.view_test drreg_static)
     use_DynamoRIO_extension(tool.drcacheoff.view_test drcovlib_static)
     use_DynamoRIO_extension(tool.drcacheoff.view_test drdecode)
@@ -778,7 +784,7 @@ if (BUILD_TESTS)
     add_executable(tool.drcachesim.histogram_test
       tools/histogram.cpp tests/histogram_test.cpp)
     target_link_libraries(tool.drcachesim.histogram_test
-      drmemtrace_static drmemtrace_analyzer)
+      drmemtrace_static drmemtrace_analyzer test_helpers)
     add_win32_flags(tool.drcachesim.histogram_test)
     add_test(NAME tool.drcachesim.histogram_test
              COMMAND tool.drcachesim.histogram_test)
@@ -786,12 +792,14 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.burst_static tests/burst_static.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_static)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_static drmemtrace_static)
+    target_link_libraries(tool.drcacheoff.burst_static test_helpers)
     add_win32_flags(tool.drcacheoff.burst_static)
 
     add_executable(tool.drcacheoff.burst_replace tests/burst_replace.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_replace)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_replace drmemtrace_static)
-    target_link_libraries(tool.drcacheoff.burst_replace drmemtrace_raw2trace)
+    target_link_libraries(tool.drcacheoff.burst_replace drmemtrace_raw2trace
+      test_helpers)
     if (WIN32)
       # burst_replace is unusual in cramming the tracer and post-processor into the
       # same binary and we need some massaging to avoid duplicate symbol link errors.
@@ -804,6 +812,7 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.burst_replaceall tests/burst_replaceall.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_replaceall)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_replaceall drmemtrace_static)
+    target_link_libraries(tool.drcacheoff.burst_replaceall test_helpers)
     add_win32_flags(tool.drcacheoff.burst_replaceall)
     use_DynamoRIO_extension(tool.drcacheoff.burst_replaceall drcontainers)
     use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.burst_replaceall)
@@ -812,6 +821,7 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.burst_malloc tests/burst_malloc.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_malloc)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_malloc drmemtrace_static)
+    target_link_libraries(tool.drcacheoff.burst_malloc test_helpers)
     add_win32_flags(tool.drcacheoff.burst_malloc)
     if (UNIX)
       append_property_string(SOURCE tests/burst_malloc.cpp
@@ -822,17 +832,20 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.burst_reattach tests/burst_reattach.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_reattach)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_reattach drmemtrace_static)
+    target_link_libraries(tool.drcacheoff.burst_reattach test_helpers)
     add_win32_flags(tool.drcacheoff.burst_reattach)
 
     add_executable(tool.drcacheoff.burst_threads tests/burst_threads.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_threads)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_threads drmemtrace_static)
+    target_link_libraries(tool.drcacheoff.burst_threads test_helpers)
     add_win32_flags(tool.drcacheoff.burst_threads)
     link_with_pthread(tool.drcacheoff.burst_threads)
 
     add_executable(tool.drcacheoff.burst_threadfilter tests/burst_threadfilter.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_threadfilter)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_threadfilter drmemtrace_static)
+    target_link_libraries(tool.drcacheoff.burst_threadfilter test_helpers)
     add_win32_flags(tool.drcacheoff.burst_threadfilter)
     link_with_pthread(tool.drcacheoff.burst_threadfilter)
 
@@ -840,12 +853,15 @@ if (BUILD_TESTS)
       add_executable(tool.drcacheoff.burst_noreach tests/burst_noreach.cpp)
       configure_DynamoRIO_static(tool.drcacheoff.burst_noreach)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_noreach drmemtrace_static)
+      target_link_libraries(tool.drcacheoff.burst_noreach test_helpers)
       add_win32_flags(tool.drcacheoff.burst_noreach)
     endif ()
     if (LINUX) # Uses mremap.
-      add_executable(tool.drcacheoff.burst_maps tests/burst_maps.cpp)
+      add_executable(tool.drcacheoff.burst_maps tests/burst_maps.cpp
+        tests/test_helpers.cpp)
       configure_DynamoRIO_static(tool.drcacheoff.burst_maps)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_maps drmemtrace_static)
+      target_link_libraries(tool.drcacheoff.burst_maps test_helpers)
       add_win32_flags(tool.drcacheoff.burst_maps)
     endif ()
 
@@ -857,7 +873,8 @@ if (BUILD_TESTS)
           tracer/instru_online.cpp)
         configure_DynamoRIO_standalone(tool.drcacheoff.raw2trace_io)
         add_win32_flags(tool.drcacheoff.raw2trace_io)
-        target_link_libraries(tool.drcacheoff.raw2trace_io drmemtrace_raw2trace)
+        target_link_libraries(tool.drcacheoff.raw2trace_io drmemtrace_raw2trace
+          test_helpers)
         use_DynamoRIO_extension(tool.drcacheoff.raw2trace_io droption)
         target_link_libraries(tool.drcacheoff.raw2trace_io drdecode)
         use_DynamoRIO_extension(tool.drcacheoff.raw2trace_io drcovlib_static)
@@ -871,6 +888,7 @@ if (BUILD_TESTS)
         COMPILE_DEFINITIONS "TEST_APP_DR_CLIENT_MAIN")
       configure_DynamoRIO_static(tool.drcacheoff.burst_client)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_client drmemtrace_static)
+      target_link_libraries(tool.drcacheoff.burst_client test_helpers)
       # A nop, keep it for the future Windows support.
       add_win32_flags(tool.drcacheoff.burst_client)
     endif ()
@@ -893,7 +911,7 @@ if (BUILD_TESTS)
       endif ()
       use_DynamoRIO_static_client(tool.drcacheoff.burst_traceopts drmemtrace_static)
       target_link_libraries(tool.drcacheoff.burst_traceopts drmemtrace_raw2trace
-        drmemtrace_analyzer)
+        drmemtrace_analyzer test_helpers)
       if (WIN32)
         # Just like for burst_replace, linking everything together takes effort.
         target_link_libraries(tool.drcacheoff.burst_traceopts ${static_libc})
@@ -911,7 +929,8 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.skip_unit_tests tests/skip_unit_tests.cpp)
     configure_DynamoRIO_standalone(tool.drcacheoff.skip_unit_tests)
     target_link_libraries(tool.drcacheoff.skip_unit_tests drmemtrace_analyzer
-      drmemtrace_view drmemtrace_raw2trace)
+      drmemtrace_view drmemtrace_raw2trace test_helpers)
+    add_win32_flags(tool.drcacheoff.skip_unit_tests)
     use_DynamoRIO_extension(tool.drcacheoff.skip_unit_tests drreg_static)
     use_DynamoRIO_extension(tool.drcacheoff.skip_unit_tests drcovlib_static)
     use_DynamoRIO_extension(tool.drcacheoff.skip_unit_tests drdecode)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -687,7 +687,8 @@ if (BUILD_TESTS)
   add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp
     tests/cache_replacement_policy_unit_test.cpp tests/config_reader_unit_test.cpp)
   target_link_libraries(tool.drcachesim.unit_tests drmemtrace_simulator
-    drmemtrace_static drmemtrace_analyzer ${zlib_libs} test_helpers)
+    # Link test_helpers first, or else the zlib main takes over.
+    drmemtrace_static drmemtrace_analyzer test_helpers ${zlib_libs})
   add_win32_flags(tool.drcachesim.unit_tests)
   add_test(NAME tool.drcachesim.unit_tests
            COMMAND tool.drcachesim.unit_tests
@@ -760,7 +761,7 @@ if (BUILD_TESTS)
     # Tests for the cache miss analyzer.
     add_executable(tool.drcachesim.miss_analyzer_unit_test tests/cache_miss_analyzer_test.cpp)
     target_link_libraries(tool.drcachesim.miss_analyzer_unit_test drmemtrace_simulator
-      drmemtrace_static drmemtrace_analyzer ${zlib_libs} test_helpers)
+      drmemtrace_static drmemtrace_analyzer test_helpers ${zlib_libs})
     add_win32_flags(tool.drcachesim.miss_analyzer_unit_test)
     add_test(NAME tool.drcachesim.miss_analyzer_unit_test
              COMMAND tool.drcachesim.miss_analyzer_unit_test)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -344,8 +344,11 @@ add_executable(record_filter_launcher
 target_link_libraries(record_filter_launcher drmemtrace_analyzer drmemtrace_record_filter)
 use_DynamoRIO_extension(record_filter_launcher droption)
 
-add_executable(scheduler_launcher tests/scheduler_launcher.cpp)
-target_link_libraries(scheduler_launcher drmemtrace_analyzer drfrontendlib test_helpers)
+# We want to use test_helper's disable_popups() but we have _tmain and so do not want
+# the test_helper library's main symbol: so we compile ourselves and disable.
+add_executable(scheduler_launcher tests/scheduler_launcher.cpp tests/test_helpers.cpp)
+append_property_list(TARGET scheduler_launcher COMPILE_DEFINITIONS "NO_HELPER_MAIN")
+target_link_libraries(scheduler_launcher drmemtrace_analyzer drfrontendlib)
 use_DynamoRIO_extension(scheduler_launcher droption)
 add_dependencies(scheduler_launcher api_headers)
 # Simple test to ensure this launcher keeps working.
@@ -517,7 +520,7 @@ restore_nonclient_flags(drmemtrace_invariant_checker)
 # get rid of add_win32_flags(target) since that just adds a couple of flags
 # back, and using the ORIG_ values is preferable.
 macro(add_win32_flags target)
-  if (DEBUG)
+  if (DEBUG AND NOT DEFINED ${target}_uses_configure)
     append_property_list(TARGET ${target} COMPILE_DEFINITIONS "DEBUG")
   endif ()
   if (WIN32)
@@ -857,8 +860,7 @@ if (BUILD_TESTS)
       add_win32_flags(tool.drcacheoff.burst_noreach)
     endif ()
     if (LINUX) # Uses mremap.
-      add_executable(tool.drcacheoff.burst_maps tests/burst_maps.cpp
-        tests/test_helpers.cpp)
+      add_executable(tool.drcacheoff.burst_maps tests/burst_maps.cpp)
       configure_DynamoRIO_static(tool.drcacheoff.burst_maps)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_maps drmemtrace_static)
       target_link_libraries(tool.drcacheoff.burst_maps test_helpers)
@@ -916,6 +918,7 @@ if (BUILD_TESTS)
         # Just like for burst_replace, linking everything together takes effort.
         target_link_libraries(tool.drcacheoff.burst_traceopts ${static_libc})
       endif ()
+      set(tool.drcacheoff.burst_traceopts_uses_configure ON) # Avoid dup DEBUG.
       add_win32_flags(tool.drcacheoff.burst_traceopts)
       use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.burst_traceopts)
       use_DynamoRIO_extension(tool.drcacheoff.burst_traceopts drcovlib_static)

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -41,6 +41,7 @@
 
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <signal.h>
@@ -214,6 +215,8 @@ is_dc_zva_instr(void *dr_context, memref_t memref)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     // App setup.
     signal(SIGILL, sigill_handler);
 

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -41,7 +41,6 @@
 
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <signal.h>
@@ -213,10 +212,8 @@ is_dc_zva_instr(void *dr_context, memref_t memref)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     // App setup.
     signal(SIGILL, sigill_handler);
 

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -42,6 +42,7 @@
 #include "drmemtrace/raw2trace.h"
 #include "raw2trace_directory.h"
 #include "scheduler.h"
+#include "test_helpers.h"
 #include <assert.h>
 #ifdef LINUX
 #    include <signal.h>
@@ -380,6 +381,7 @@ look_for_gencode(std::string trace_dir)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
     std::string trace_dir = gather_trace();
     return look_for_gencode(trace_dir);
 }

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -42,7 +42,6 @@
 #include "drmemtrace/raw2trace.h"
 #include "raw2trace_directory.h"
 #include "scheduler.h"
-#include "test_helpers.h"
 #include <assert.h>
 #ifdef LINUX
 #    include <signal.h>
@@ -379,9 +378,8 @@ look_for_gencode(std::string trace_dir)
 } // namespace
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
     std::string trace_dir = gather_trace();
     return look_for_gencode(trace_dir);
 }

--- a/clients/drcachesim/tests/burst_malloc.cpp
+++ b/clients/drcachesim/tests/burst_malloc.cpp
@@ -40,7 +40,6 @@
 
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <fstream>
@@ -146,9 +145,8 @@ exit_cb(void *)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
     /* We also test -rstats_to_stderr */
     if (!my_setenv("DYNAMORIO_OPTIONS",
                    "-stderr_mask 0xc -rstats_to_stderr"

--- a/clients/drcachesim/tests/burst_malloc.cpp
+++ b/clients/drcachesim/tests/burst_malloc.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,7 @@
 
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <fstream>
@@ -147,6 +148,7 @@ exit_cb(void *)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
     /* We also test -rstats_to_stderr */
     if (!my_setenv("DYNAMORIO_OPTIONS",
                    "-stderr_mask 0xc -rstats_to_stderr"

--- a/clients/drcachesim/tests/burst_maps.cpp
+++ b/clients/drcachesim/tests/burst_maps.cpp
@@ -39,7 +39,6 @@
 /* Like burst_static we deliberately do not include configure.h here. */
 #include "dr_api.h"
 #include "../../common/utils.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -160,10 +159,8 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_maps.cpp
+++ b/clients/drcachesim/tests/burst_maps.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,7 @@
 /* Like burst_static we deliberately do not include configure.h here. */
 #include "dr_api.h"
 #include "../../common/utils.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -161,6 +162,8 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_noreach.cpp
+++ b/clients/drcachesim/tests/burst_noreach.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,7 @@
 
 /* Like burst_static we deliberately do not include configure.h here. */
 #include "dr_api.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -76,6 +77,8 @@ fill_up_heap()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_noreach.cpp
+++ b/clients/drcachesim/tests/burst_noreach.cpp
@@ -38,7 +38,6 @@
 
 /* Like burst_static we deliberately do not include configure.h here. */
 #include "dr_api.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -75,10 +74,8 @@ fill_up_heap()
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_reattach.cpp
+++ b/clients/drcachesim/tests/burst_reattach.cpp
@@ -39,7 +39,6 @@
 /* Like burst_static we deliberately do not include configure.h here */
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <fstream>
@@ -91,10 +90,8 @@ exit_cb(void *)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     if (!my_setenv("DYNAMORIO_OPTIONS",
                    "-stderr_mask 0xc"
                    " -client_lib '#;;-offline"

--- a/clients/drcachesim/tests/burst_reattach.cpp
+++ b/clients/drcachesim/tests/burst_reattach.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,7 @@
 /* Like burst_static we deliberately do not include configure.h here */
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <fstream>
@@ -92,6 +93,8 @@ exit_cb(void *)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     if (!my_setenv("DYNAMORIO_OPTIONS",
                    "-stderr_mask 0xc"
                    " -client_lib '#;;-offline"

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -43,7 +43,6 @@
 #include "drcovlib.h"
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -233,10 +232,8 @@ post_process()
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,7 @@
 #include "drcovlib.h"
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -234,6 +235,8 @@ post_process()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -43,7 +43,6 @@
 #include "drvector.h"
 #include "../../../suite/tests/client_tools.h"
 #include "../../../suite/tests/condvar.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -263,10 +262,8 @@ void *
 #endif
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,7 @@
 #include "drvector.h"
 #include "../../../suite/tests/client_tools.h"
 #include "../../../suite/tests/condvar.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -264,6 +265,8 @@ void *
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_static.cpp
+++ b/clients/drcachesim/tests/burst_static.cpp
@@ -39,7 +39,6 @@
  * for us.
  */
 #include "dr_api.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -67,10 +66,8 @@ do_some_work(int arg)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_static.cpp
+++ b/clients/drcachesim/tests/burst_static.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,7 @@
  * for us.
  */
 #include "dr_api.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -68,6 +69,8 @@ do_some_work(int arg)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     static int outer_iters = 2048;
     /* We trace a 4-iter burst of execution. */
     static int iter_start = outer_iters / 3;

--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -41,7 +41,6 @@
  */
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -203,10 +202,8 @@ void *
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
 #ifdef UNIX
     pthread_t thread[num_threads];
 #else

--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,6 +41,7 @@
  */
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -204,6 +205,8 @@ void *
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
 #ifdef UNIX
     pthread_t thread[num_threads];
 #else

--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -39,7 +39,6 @@
  * for us.
  */
 #include "dr_api.h"
-#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -177,10 +176,8 @@ void *
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
 #ifdef UNIX
     pthread_t thread[num_threads];
     pthread_t idle_thread[num_idle_threads];

--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,7 @@
  * for us.
  */
 #include "dr_api.h"
+#include "test_helpers.h"
 #include <assert.h>
 #include <iostream>
 #include <math.h>
@@ -178,6 +179,8 @@ void *
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
 #ifdef UNIX
     pthread_t thread[num_threads];
     pthread_t idle_thread[num_idle_threads];

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -44,7 +44,6 @@
 #    include "scheduler.h"
 #    include "tracer/raw2trace.h"
 #    include "tracer/raw2trace_directory.h"
-#    include "test_helpers.h"
 #    include <assert.h>
 #    include <iostream>
 #    include <math.h>
@@ -218,10 +217,8 @@ gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     reg_id_set_unit_tests();
 
     std::string dir_opt = gather_trace("", "opt");

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -44,6 +44,7 @@
 #    include "scheduler.h"
 #    include "tracer/raw2trace.h"
 #    include "tracer/raw2trace_directory.h"
+#    include "test_helpers.h"
 #    include <assert.h>
 #    include <iostream>
 #    include <math.h>
@@ -219,6 +220,8 @@ gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     reg_id_set_unit_tests();
 
     std::string dir_opt = gather_trace("", "opt");

--- a/clients/drcachesim/tests/cache_miss_analyzer_test.cpp
+++ b/clients/drcachesim/tests/cache_miss_analyzer_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2018 Google, LLC  All rights reserved.
+ * Copyright (c) 2015-2023 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -35,6 +35,7 @@
 #include "../simulator/cache_miss_analyzer.h"
 #include "../simulator/cache_simulator.h"
 #include "../common/memref.h"
+#include "test_helpers.h"
 
 static memref_t
 generate_mem_ref(const addr_t addr, const addr_t pc)
@@ -209,6 +210,8 @@ two_dominant_strides()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     if (no_dominant_stride() && one_dominant_stride() && two_dominant_strides()) {
         return 0;
     } else {

--- a/clients/drcachesim/tests/cache_miss_analyzer_test.cpp
+++ b/clients/drcachesim/tests/cache_miss_analyzer_test.cpp
@@ -35,7 +35,6 @@
 #include "../simulator/cache_miss_analyzer.h"
 #include "../simulator/cache_simulator.h"
 #include "../common/memref.h"
-#include "test_helpers.h"
 
 static memref_t
 generate_mem_ref(const addr_t addr, const addr_t pc)
@@ -208,10 +207,8 @@ two_dominant_strides()
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     if (no_dominant_stride() && one_dominant_stride() && two_dominant_strides()) {
         return 0;
     } else {

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,6 +41,7 @@
 #include "simulator/cache_lru.h"
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
+#include "test_helpers.h"
 
 static cache_simulator_knobs_t
 make_test_knobs()
@@ -550,6 +551,8 @@ unit_test_cache_bad_configs()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     // Takes in a path to the tests/ src dir.
     assert(argc == 2);
 

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -41,7 +41,6 @@
 #include "simulator/cache_lru.h"
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
-#include "test_helpers.h"
 
 static cache_simulator_knobs_t
 make_test_knobs()
@@ -549,10 +548,8 @@ unit_test_cache_bad_configs()
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     // Takes in a path to the tests/ src dir.
     assert(argc == 2);
 

--- a/clients/drcachesim/tests/histogram_test.cpp
+++ b/clients/drcachesim/tests/histogram_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2022 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2023 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,6 +42,7 @@
 #include "../tools/histogram.h"
 #include "../common/memref.h"
 #include "memref_gen.h"
+#include "test_helpers.h"
 
 namespace {
 
@@ -85,6 +86,8 @@ check_cross_line()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     if (check_cross_line()) {
         std::cerr << "histogram_test passed\n";
         return 0;

--- a/clients/drcachesim/tests/histogram_test.cpp
+++ b/clients/drcachesim/tests/histogram_test.cpp
@@ -42,7 +42,6 @@
 #include "../tools/histogram.h"
 #include "../common/memref.h"
 #include "memref_gen.h"
-#include "test_helpers.h"
 
 namespace {
 
@@ -84,10 +83,8 @@ check_cross_line()
 } // namespace
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     if (check_cross_line()) {
         std::cerr << "histogram_test passed\n";
         return 0;

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -42,6 +42,7 @@
 #include "../tools/invariant_checker.h"
 #include "../common/memref.h"
 #include "memref_gen.h"
+#include "test_helpers.h"
 
 namespace {
 
@@ -696,6 +697,8 @@ check_rseq_side_exit_discontinuity()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
         check_kernel_xfer() && check_rseq() && check_function_markers() &&
         check_duplicate_syscall_with_same_pc() && check_rseq_side_exit_discontinuity()) {

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -42,7 +42,6 @@
 #include "../tools/invariant_checker.h"
 #include "../common/memref.h"
 #include "memref_gen.h"
-#include "test_helpers.h"
 
 namespace {
 
@@ -695,10 +694,8 @@ check_rseq_side_exit_discontinuity()
 } // namespace
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
         check_kernel_xfer() && check_rseq() && check_function_markers() &&
         check_duplicate_syscall_with_same_pc() && check_rseq_side_exit_discontinuity()) {

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,6 +41,7 @@
 #include "droption.h"
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
+#include "test_helpers.h"
 #include <cassert>
 #include <errno.h>
 #include <fcntl.h>
@@ -258,6 +259,8 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
                                        &parse_err, NULL) ||

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -41,7 +41,6 @@
 #include "droption.h"
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
-#include "test_helpers.h"
 #include <cassert>
 #include <errno.h>
 #include <fcntl.h>
@@ -257,10 +256,8 @@ test_trace_timestamp_reader(const raw2trace_directory_t *dir)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
                                        &parse_err, NULL) ||

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -36,6 +36,7 @@
 #include "memref_gen.h"
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
+#include "test_helpers.h"
 #include <iostream>
 #include <sstream>
 
@@ -1974,6 +1975,7 @@ test_xfer_absolute(void *drcontext)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
 
     void *drcontext = dr_standalone_init();
     if (!test_branch_delays(drcontext) || !test_marker_placement(drcontext) ||

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -36,7 +36,6 @@
 #include "memref_gen.h"
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
-#include "test_helpers.h"
 #include <iostream>
 #include <sstream>
 
@@ -1973,10 +1972,8 @@ test_xfer_absolute(void *drcontext)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     void *drcontext = dr_standalone_init();
     if (!test_branch_delays(drcontext) || !test_marker_placement(drcontext) ||
         !test_marker_delays(drcontext) || !test_chunk_boundaries(drcontext) ||

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,7 @@
 #include "tools/filter/cache_filter.h"
 #include "tools/filter/record_filter.h"
 #include "tools/filter/type_filter.h"
+#include "test_helpers.h"
 
 #include <inttypes.h>
 #include <fstream>
@@ -431,6 +432,8 @@ test_null_filter()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
                                        &parse_err, NULL) ||

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -40,7 +40,6 @@
 #include "tools/filter/cache_filter.h"
 #include "tools/filter/record_filter.h"
 #include "tools/filter/type_filter.h"
-#include "test_helpers.h"
 
 #include <inttypes.h>
 #include <fstream>
@@ -430,10 +429,8 @@ test_null_filter()
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
                                        &parse_err, NULL) ||

--- a/clients/drcachesim/tests/reuse_distance_test.cpp
+++ b/clients/drcachesim/tests/reuse_distance_test.cpp
@@ -37,7 +37,6 @@
 #include "../tools/reuse_distance.h"
 #include "../tools/reuse_distance_create.h"
 #include "../common/memref.h"
-#include "test_helpers.h"
 
 namespace {
 
@@ -505,14 +504,13 @@ data_histogram_test()
 } // namespace
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     print_histogram_empty_test();
     print_histogram_mult_1p0_test();
     print_histogram_mult_1p2_test();
     simple_reuse_distance_test();
     reuse_distance_limit_test();
     data_histogram_test();
+    return 0;
 }

--- a/clients/drcachesim/tests/reuse_distance_test.cpp
+++ b/clients/drcachesim/tests/reuse_distance_test.cpp
@@ -37,6 +37,7 @@
 #include "../tools/reuse_distance.h"
 #include "../tools/reuse_distance_create.h"
 #include "../common/memref.h"
+#include "test_helpers.h"
 
 namespace {
 
@@ -506,6 +507,8 @@ data_histogram_test()
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     print_histogram_empty_test();
     print_histogram_mult_1p0_test();
     print_histogram_mult_1p2_test();

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -45,6 +45,7 @@
 #include "droption.h"
 #include "dr_frontend.h"
 #include "scheduler.h"
+#include "test_helpers.h"
 #ifdef HAS_ZIP
 #    include "zipfile_istream.h"
 #    include "zipfile_ostream.h"
@@ -140,6 +141,8 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
 int
 _tmain(int argc, const TCHAR *targv[])
 {
+    disable_popups();
+
     // Convert to UTF-8 if necessary
     char **argv;
     drfront_status_t sc = drfront_convert_args(targv, &argv, argc);

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -43,6 +43,7 @@
 #    include "zipfile_istream.h"
 #    include "zipfile_ostream.h"
 #endif
+#include "test_helpers.h"
 
 using namespace dynamorio::drmemtrace;
 
@@ -2026,6 +2027,8 @@ test_replay_as_traced_from_file(const char *testdir)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     // Takes in a path to the tests/ src dir.
     assert(argc == 2);
     // Avoid races with lazy drdecode init (b/279350357).

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -43,7 +43,6 @@
 #    include "zipfile_istream.h"
 #    include "zipfile_ostream.h"
 #endif
-#include "test_helpers.h"
 
 using namespace dynamorio::drmemtrace;
 
@@ -2025,10 +2024,8 @@ test_replay_as_traced_from_file(const char *testdir)
 } // namespace
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     // Takes in a path to the tests/ src dir.
     assert(argc == 2);
     // Avoid races with lazy drdecode init (b/279350357).

--- a/clients/drcachesim/tests/test_helpers.cpp
+++ b/clients/drcachesim/tests/test_helpers.cpp
@@ -1,0 +1,43 @@
+/* **********************************************************
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "test_helpers.h"
+
+#ifdef WINDOWS
+LONG WINAPI
+console_exception_filter(struct _EXCEPTION_POINTERS *pExceptionInfo)
+{
+    fprintf(stderr, "ERROR: Unhandled exception 0x%x caught\n",
+            pExceptionInfo->ExceptionRecord->ExceptionCode);
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+#endif

--- a/clients/drcachesim/tests/test_helpers.h
+++ b/clients/drcachesim/tests/test_helpers.h
@@ -1,0 +1,83 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* helpers.h: utilities for tests. */
+
+#ifndef _TEST_HELPERS_H_
+#define _TEST_HELPERS_H_ 1
+
+#include <stdio.h>
+
+#ifdef WINDOWS
+#    ifndef WIN32_LEAN_AND_MEAN
+#        define WIN32_LEAN_AND_MEAN
+#        include <windows.h>
+#    endif
+#    ifdef DEBUG
+#        include <crtdbg.h>
+#    endif
+#    include <stdlib.h>
+
+// We use the same controls as in suite/tests/tools.h to disable popups.
+
+LONG WINAPI
+console_exception_filter(struct _EXCEPTION_POINTERS *pExceptionInfo);
+
+static inline void
+disable_popups()
+{
+    // Set the global unhandled exception filter to the exception filter
+    SetUnhandledExceptionFilter(console_exception_filter);
+
+    // Avoid pop-up messageboxes in tests.
+    if (!IsDebuggerPresent()) {
+#    ifdef DEBUG
+        // Set for _CRT_{WARN,ERROR,ASSERT}.
+        for (int i = 0; i < _CRT_ERRCNT; i++) {
+            _CrtSetReportMode(i, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+            _CrtSetReportFile(i, _CRTDBG_FILE_STDERR);
+        }
+#    endif
+        // Configure assert() and _wassert() in release build. */
+        _set_error_mode(_OUT_TO_STDERR);
+    }
+}
+
+#else
+static inline void
+disable_popups()
+{
+    // Nothing to do.
+}
+#endif
+
+#endif /* _TEST_HELPERS_H_ */

--- a/clients/drcachesim/tests/test_helpers.h
+++ b/clients/drcachesim/tests/test_helpers.h
@@ -35,49 +35,9 @@
 #ifndef _TEST_HELPERS_H_
 #define _TEST_HELPERS_H_ 1
 
-#include <stdio.h>
-
-#ifdef WINDOWS
-#    ifndef WIN32_LEAN_AND_MEAN
-#        define WIN32_LEAN_AND_MEAN
-#        include <windows.h>
-#    endif
-#    ifdef DEBUG
-#        include <crtdbg.h>
-#    endif
-#    include <stdlib.h>
-
-// We use the same controls as in suite/tests/tools.h to disable popups.
-
-LONG WINAPI
-console_exception_filter(struct _EXCEPTION_POINTERS *pExceptionInfo);
-
-static inline void
-disable_popups()
-{
-    // Set the global unhandled exception filter to the exception filter
-    SetUnhandledExceptionFilter(console_exception_filter);
-
-    // Avoid pop-up messageboxes in tests.
-    if (!IsDebuggerPresent()) {
-#    ifdef DEBUG
-        // Set for _CRT_{WARN,ERROR,ASSERT}.
-        for (int i = 0; i < _CRT_ERRCNT; i++) {
-            _CrtSetReportMode(i, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
-            _CrtSetReportFile(i, _CRTDBG_FILE_STDERR);
-        }
-#    endif
-        // Configure assert() and _wassert() in release build. */
-        _set_error_mode(_OUT_TO_STDERR);
-    }
-}
-
-#else
-static inline void
-disable_popups()
-{
-    // Nothing to do.
-}
-#endif
+// Tests with a main() should use test_main() which calls this.  This is declared
+// separately for use with _tmain().
+void
+disable_popups();
 
 #endif /* _TEST_HELPERS_H_ */

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -34,6 +34,7 @@
 
 #include "analyzer.h"
 #include "memref_gen.h"
+#include "test_helpers.h"
 
 #include <algorithm>
 #include <inttypes.h>
@@ -649,6 +650,8 @@ test_non_zero_interval(bool parallel, bool combine_only_active_shards = true)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     if (!test_non_zero_interval(false) || !test_non_zero_interval(true, true) ||
         !test_non_zero_interval(true, false))
         return 1;

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -34,7 +34,6 @@
 
 #include "analyzer.h"
 #include "memref_gen.h"
-#include "test_helpers.h"
 
 #include <algorithm>
 #include <inttypes.h>
@@ -648,10 +647,8 @@ test_non_zero_interval(bool parallel, bool combine_only_active_shards = true)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     if (!test_non_zero_interval(false) || !test_non_zero_interval(true, true) ||
         !test_non_zero_interval(true, false))
         return 1;

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -44,7 +44,6 @@
 #include "../reader/file_reader.h"
 #include "../scheduler/scheduler.h"
 #include "memref_gen.h"
-#include "test_helpers.h"
 
 #undef ASSERT
 #define ASSERT(cond, msg, ...)        \
@@ -589,10 +588,8 @@ run_chunk_tests(void *drcontext)
 } // namespace
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
-    disable_popups();
-
     void *drcontext = dr_standalone_init();
     if (run_limit_tests(drcontext) && run_chunk_tests(drcontext)) {
         std::cerr << "view_test passed\n";

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -44,6 +44,7 @@
 #include "../reader/file_reader.h"
 #include "../scheduler/scheduler.h"
 #include "memref_gen.h"
+#include "test_helpers.h"
 
 #undef ASSERT
 #define ASSERT(cond, msg, ...)        \
@@ -590,6 +591,8 @@ run_chunk_tests(void *drcontext)
 int
 main(int argc, const char *argv[])
 {
+    disable_popups();
+
     void *drcontext = dr_standalone_init();
     if (run_limit_tests(drcontext) && run_chunk_tests(drcontext)) {
         std::cerr << "view_test passed\n";

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3991,7 +3991,7 @@ if (BUILD_CLIENTS)
       use_DynamoRIO_static_client(tool.drcacheoff.gencode drmemtrace_static)
       use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.gencode)
       target_link_libraries(tool.drcacheoff.gencode drmemtrace_raw2trace
-        drmemtrace_analyzer)
+        drmemtrace_analyzer test_helpers)
       target_include_directories(tool.drcacheoff.gencode PUBLIC
         "${PROJECT_SOURCE_DIR}/clients/drcachesim"
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/common"


### PR DESCRIPTION
Adds a library test_helpers for drcachesim tests which provides main() and calls disable_popups() to avoid Windows assert and exception pop-up windows hanging the test suite.  Tests now define a test_main() which is called by the test_helpers main().  (The DR core test suite has its own popup disabling code but it is complex to link that into
the standalone drcachesim tests.)

For _tmain, we compile test_helpers.cpp separately to access its disable_popups() but with a define to disable main().

Issue: #6131