### PR TITLE
i#6020: Add raw2trace stat for trace duration

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1253,7 +1253,7 @@ private:
     // Increases the per-thread counter for the statistic identified by stat by value.
     void
     add_to_statistic(raw2trace_thread_data_t *tdata, raw2trace_statistic_t stat,
-                     uint64_t value);
+                     uint64 value);
     void
     log_instruction(app_pc decode_pc, app_pc orig_pc);
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1250,10 +1250,12 @@ private:
     size_t
     get_cache_line_size(raw2trace_thread_data_t *tdata);
 
-    // Increases the per-thread counter for the statistic identified by stat by value.
+    // Accumulates the given value into the per-thread counter for the statistic
+    // identified by stat. This may involve a simple addition, or any other operation
+    // like std::min or std::max, depending on the statistic.
     void
-    add_to_statistic(raw2trace_thread_data_t *tdata, raw2trace_statistic_t stat,
-                     uint64 value);
+    accumulate_to_statistic(raw2trace_thread_data_t *tdata, raw2trace_statistic_t stat,
+                            uint64 value);
     void
     log_instruction(app_pc decode_pc, app_pc orig_pc);
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -933,7 +933,7 @@ protected:
         uint64 count_false_syscall = 0;
         uint64 count_rseq_abort = 0;
         uint64 count_rseq_side_exit = 0;
-        uint64 earliest_trace_timestamp = std::numeric_limits<uint64>::max();
+        uint64 earliest_trace_timestamp = (std::numeric_limits<uint64>::max)();
         uint64 latest_trace_timestamp = 0;
 
         uint64 cur_chunk_instr_count = 0;
@@ -1108,7 +1108,7 @@ protected:
     uint64 count_false_syscall_ = 0;
     uint64 count_rseq_abort_ = 0;
     uint64 count_rseq_side_exit_ = 0;
-    uint64 earliest_trace_timestamp_ = std::numeric_limits<uint64>::max();
+    uint64 earliest_trace_timestamp_ = (std::numeric_limits<uint64>::max)();
     uint64 latest_trace_timestamp_ = 0;
 
     std::unique_ptr<module_mapper_t> module_mapper_;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1250,7 +1250,7 @@ private:
     size_t
     get_cache_line_size(raw2trace_thread_data_t *tdata);
 
-    // Accumulates the given value into the per-thread counter for the statistic
+    // Accumulates the given value into the per-thread value for the statistic
     // identified by stat. This may involve a simple addition, or any other operation
     // like std::min or std::max, depending on the statistic.
     void

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -47,6 +47,7 @@
 #include "drcovlib.h"
 #include <array>
 #include <atomic>
+#include <limits>
 #include <list>
 #include <memory>
 #include <queue>
@@ -103,6 +104,8 @@ typedef enum {
     RAW2TRACE_STAT_RSEQ_ABORT,
     RAW2TRACE_STAT_RSEQ_SIDE_EXIT,
     RAW2TRACE_STAT_FALSE_SYSCALL,
+    RAW2TRACE_STAT_EARLIEST_TRACE_TIMESTAMP,
+    RAW2TRACE_STAT_LATEST_TRACE_TIMESTAMP
 } raw2trace_statistic_t;
 
 struct module_t {
@@ -930,6 +933,8 @@ protected:
         uint64 count_false_syscall = 0;
         uint64 count_rseq_abort = 0;
         uint64 count_rseq_side_exit = 0;
+        uint64 earliest_trace_timestamp = std::numeric_limits<uint64>::max();
+        uint64 latest_trace_timestamp = 0;
 
         uint64 cur_chunk_instr_count = 0;
         uint64 cur_chunk_ref_count = 0;
@@ -1103,6 +1108,8 @@ protected:
     uint64 count_false_syscall_ = 0;
     uint64 count_rseq_abort_ = 0;
     uint64 count_rseq_side_exit_ = 0;
+    uint64 earliest_trace_timestamp_ = std::numeric_limits<uint64>::max();
+    uint64 latest_trace_timestamp_ = 0;
 
     std::unique_ptr<module_mapper_t> module_mapper_;
 
@@ -1246,7 +1253,7 @@ private:
     // Increases the per-thread counter for the statistic identified by stat by value.
     void
     add_to_statistic(raw2trace_thread_data_t *tdata, raw2trace_statistic_t stat,
-                     int value);
+                     uint64_t value);
     void
     log_instruction(app_pc decode_pc, app_pc orig_pc);
 


### PR DESCRIPTION
Adds raw2trace stats for earliest and latest trace timestamp. These are used to compute the trace's wall-clock duration which is printed at the end of raw2trace decomposition, along with other raw2trace stats.

It may be useful for the user to know the trace's wall-clock duration to compute the value for `-trace_interval` (which is the length of each trace interval for interval analysis) to get the required number of total intervals.

Issue: #6020