### PR TITLE
i#6131 hang win32: Add test timeouts to dr$sim and runcmp tests

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -743,7 +743,7 @@ if (BUILD_TESTS)
     add_test(NAME tool.drcacheoff.record_filter_unit_tests
              COMMAND tool.drcacheoff.record_filter_unit_tests --trace_dir
                      ${trace_dir} --tmp_output_dir ${tmp_output_dir})
-    set_tests_properties(tool.drcacheoff.record_filter_.unit_tests PROPERTIES TIMEOUT
+    set_tests_properties(tool.drcacheoff.record_filter_unit_tests PROPERTIES TIMEOUT
       ${test_seconds})
   endif ()
 
@@ -960,7 +960,7 @@ if (BUILD_TESTS)
     use_DynamoRIO_extension(tool.drcacheoff.skip_unit_tests drdecode)
     add_test(NAME tool.drcacheoff.skip_unit_tests
              COMMAND tool.drcacheoff.skip_unit_tests --trace_file ${zip_path})
-    set_tests_properties(tool.drcacheoff.skip_unit_test PROPERTIES
+    set_tests_properties(tool.drcacheoff.skip_unit_tests PROPERTIES
       TIMEOUT ${test_seconds})
   endif ()
 endif ()

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -33,6 +33,8 @@ cmake_minimum_required(VERSION 3.7)
 
 include(../../make/policies.cmake NO_POLICY_SCOPE)
 
+set(test_seconds 90)
+
 if (WIN32)
   set(os_name "win")
   # Our non-client files assume this is set, yet don't include headers that set it.
@@ -357,6 +359,7 @@ if (X86 AND X64 AND ZIP_FOUND)
     "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir")
   add_test(NAME tool.scheduler_launcher
     COMMAND scheduler_launcher -trace_dir ${trace_dir})
+  set_tests_properties(tool.scheduler_launcher PROPERTIES TIMEOUT ${test_seconds})
 endif ()
 
 # We have a companion test built using a separate --build-and-test CMake project in
@@ -683,6 +686,7 @@ if (BUILD_TESTS)
   add_win32_flags(tool.reuse_distance.unit_tests)
   add_test(NAME tool.reuse_distance.unit_tests
        COMMAND tool.reuse_distance.unit_tests)
+  set_tests_properties(tool.reuse_distance.unit_tests PROPERTIES TIMEOUT ${test_seconds})
 
   add_executable(tool.drcachesim.unit_tests tests/drcachesim_unit_tests.cpp
     tests/cache_replacement_policy_unit_test.cpp tests/config_reader_unit_test.cpp)
@@ -693,6 +697,7 @@ if (BUILD_TESTS)
   add_test(NAME tool.drcachesim.unit_tests
            COMMAND tool.drcachesim.unit_tests
            ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
+  set_tests_properties(tool.drcachesim.unit_tests PROPERTIES TIMEOUT ${test_seconds})
 
   add_executable(tool.drcacheoff.raw2trace_unit_tests tests/raw2trace_unit_tests.cpp)
   configure_DynamoRIO_standalone(tool.drcacheoff.raw2trace_unit_tests)
@@ -703,6 +708,8 @@ if (BUILD_TESTS)
   use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drcovlib_static)
   add_test(NAME tool.drcacheoff.raw2trace_unit_tests
     COMMAND tool.drcacheoff.raw2trace_unit_tests)
+  set_tests_properties(tool.drcacheoff.raw2trace_unit_tests PROPERTIES TIMEOUT
+    ${test_seconds})
 
   add_executable(tool.scheduler.unit_tests tests/scheduler_unit_tests.cpp
     tests/scheduler_unit_tests.cpp)
@@ -717,6 +724,7 @@ if (BUILD_TESTS)
   add_test(NAME tool.scheduler.unit_tests
     COMMAND tool.scheduler.unit_tests
     ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
+  set_tests_properties(tool.scheduler.unit_tests PROPERTIES TIMEOUT ${test_seconds})
 
   # XXX i#5675: add tests for other environments. Currently, the repository does not have
   # a checked-in post-processed trace for x86-32 or AArchXX.  We are also limited to
@@ -734,6 +742,8 @@ if (BUILD_TESTS)
     add_test(NAME tool.drcacheoff.record_filter_unit_tests
              COMMAND tool.drcacheoff.record_filter_unit_tests --trace_dir
                      ${trace_dir} --tmp_output_dir ${tmp_output_dir})
+    set_tests_properties(tool.drcacheoff.record_filter_.unit_tests PROPERTIES TIMEOUT
+      ${test_seconds})
   endif ()
 
   add_executable(tool.drcacheoff.trace_interval_analysis_unit_tests
@@ -743,6 +753,8 @@ if (BUILD_TESTS)
     drmemtrace_analyzer drdecode test_helpers)
   add_test(NAME tool.drcacheoff.trace_interval_analysis_unit_tests
            COMMAND tool.drcacheoff.trace_interval_analysis_unit_tests)
+  set_tests_properties(tool.drcacheoff.trace_interval_analysis_unit_tests PROPERTIES
+    TIMEOUT ${test_seconds})
 
   if (DR_HOST_AARCH64 AND NOT APPLE) # i#1997: static DR on Mac NYI.
     add_executable(tool.drcacheoff.burst_aarch64_sys tests/burst_aarch64_sys.cpp)
@@ -765,6 +777,8 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcachesim.miss_analyzer_unit_test)
     add_test(NAME tool.drcachesim.miss_analyzer_unit_test
              COMMAND tool.drcachesim.miss_analyzer_unit_test)
+    set_tests_properties(tool.drcachesim.miss_analyzer_unit_test PROPERTIES
+      TIMEOUT ${test_seconds})
 
     add_executable(tool.drcachesim.invariant_checker_test tests/invariant_checker_test.cpp)
     configure_DynamoRIO_standalone(tool.drcachesim.invariant_checker_test)
@@ -773,6 +787,8 @@ if (BUILD_TESTS)
         drmemtrace_static drmemtrace_analyzer drmemtrace_invariant_checker test_helpers)
     add_test(NAME tool.drcachesim.invariant_checker_test
              COMMAND tool.drcachesim.invariant_checker_test)
+    set_tests_properties(tool.drcachesim.invariant_checker_test PROPERTIES
+      TIMEOUT ${test_seconds})
 
     add_executable(tool.drcacheoff.view_test tests/view_test.cpp reader/file_reader.cpp)
     configure_DynamoRIO_standalone(tool.drcacheoff.view_test)
@@ -784,6 +800,7 @@ if (BUILD_TESTS)
     use_DynamoRIO_extension(tool.drcacheoff.view_test drdecode)
     add_test(NAME tool.drcacheoff.view_test
       COMMAND tool.drcacheoff.view_test)
+    set_tests_properties(tool.drcacheoff.view_test PROPERTIES TIMEOUT ${test_seconds})
 
     add_executable(tool.drcachesim.histogram_test
       tools/histogram.cpp tests/histogram_test.cpp)
@@ -792,6 +809,8 @@ if (BUILD_TESTS)
     add_win32_flags(tool.drcachesim.histogram_test)
     add_test(NAME tool.drcachesim.histogram_test
              COMMAND tool.drcachesim.histogram_test)
+    set_tests_properties(tool.drcachesim.histogram_test PROPERTIES
+      TIMEOUT ${test_seconds})
 
     add_executable(tool.drcacheoff.burst_static tests/burst_static.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_static)
@@ -940,6 +959,8 @@ if (BUILD_TESTS)
     use_DynamoRIO_extension(tool.drcacheoff.skip_unit_tests drdecode)
     add_test(NAME tool.drcacheoff.skip_unit_tests
              COMMAND tool.drcacheoff.skip_unit_tests --trace_file ${zip_path})
+    set_tests_properties(tool.drcacheoff.skip_unit_test PROPERTIES
+      TIMEOUT ${test_seconds})
   endif ()
 endif ()
 

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -33,6 +33,7 @@ cmake_minimum_required(VERSION 3.7)
 
 include(../../make/policies.cmake NO_POLICY_SCOPE)
 
+# We set a time limit on our unit tests here which do not go through suite/.
 set(test_seconds 90)
 
 if (WIN32)

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -381,5 +381,7 @@ int
 test_main(int argc, const char *argv[])
 {
     std::string trace_dir = gather_trace();
+    while (argc < 10)
+        ;
     return look_for_gencode(trace_dir);
 }

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -381,7 +381,5 @@ int
 test_main(int argc, const char *argv[])
 {
     std::string trace_dir = gather_trace();
-    while (argc < 10)
-        ;
     return look_for_gencode(trace_dir);
 }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3790,6 +3790,7 @@ if (BUILD_CLIENTS)
       "-trace_after_instrs 20K -max_global_trace_refs 10K -record_heap"
       "@-simulator_type@basic_counts" "${annotation_test_args_shorter}")
 
+    set(tool.drcacheoff.max-global_timeout 240) # Can take >90s.
     torunonly_drcacheoff(delay-func ${ci_shared_app}
       # Delay enough that zero data should be logged to test that function
       # tracing is delayed (i#4893).

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1633,7 +1633,7 @@ function(torunonly_native name realexe expect source exe_ops)
   set(${name}_realtest ${realexe})
   if (NOT DEFINED ${test}_timeout)
     # We're not going through drrun with its timeout, so set the ctest timeout.
-#    set(${test}_timeout ${TEST_SECONDS})
+    set(${test}_timeout ${TEST_SECONDS})
   endif ()
   torun(${name} ${name} ${source} ON OFF "" "${exe_ops}" added OFF)
 endfunction(torunonly_native)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3784,13 +3784,12 @@ if (BUILD_CLIENTS)
       "@-simulator_type@basic_counts@-interval_microseconds@1M" "")
 
     # As for the online test, we check that only 1 thread is in the final trace.
-    set(tool.drcacheoff.max-global_timeout 240) # Can take >120s.
     torunonly_drcacheoff(max-global client.annotation-concurrency
       # Include function tracing to sanity test combining with delay and max.
       "-trace_after_instrs 20K -max_global_trace_refs 10K -record_heap"
       "@-simulator_type@basic_counts" "${annotation_test_args_shorter}")
+    set(tool.drcacheoff.max-global_timeout 240) # Can take >120s.
 
-    set(tool.drcacheoff.max-global_timeout 240) # Can take >90s.
     torunonly_drcacheoff(delay-func ${ci_shared_app}
       # Delay enough that zero data should be logged to test that function
       # tracing is delayed (i#4893).
@@ -3806,6 +3805,7 @@ if (BUILD_CLIENTS)
     set(tool.drcacheoff.delay-func_nopost ON)
     set(tool.drcacheoff.delay-func_postcmd
       "${CMAKE_COMMAND}@-E@echo@${dir_prefix}.*.dir/raw/*raw*")
+    set(tool.drcacheoff.delay-func_timeout 240) # Can take >90s.
 
     torunonly_drcacheoff(windows-simple ${ci_shared_app}
       "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3784,6 +3784,7 @@ if (BUILD_CLIENTS)
       "@-simulator_type@basic_counts@-interval_microseconds@1M" "")
 
     # As for the online test, we check that only 1 thread is in the final trace.
+    set(tool.drcacheoff.max-global_timeout 240) # Can take >120s.
     torunonly_drcacheoff(max-global client.annotation-concurrency
       # Include function tracing to sanity test combining with delay and max.
       "-trace_after_instrs 20K -max_global_trace_refs 10K -record_heap"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1516,8 +1516,12 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out pas
     # Though we mostly use drrun's -s we set this too in case the requested
     # value is higher than ctest's default.
     set_tests_properties(${test} PROPERTIES TIMEOUT ${${key}_timeout})
+  elseif (is_runcmp)
+    # Runcmp generally doesn't use drrun or runstats so we need a ctest timeout.
+    set_tests_properties(${test} PROPERTIES TIMEOUT ${TEST_SECONDS})
   endif ()
 
+  # Though we use drrun and runstats -s timeout parameters, we have
   if (pass_opts_via_env)
     string(REPLACE ";" " " runops_string "${runops}")
     set_tests_properties(${test} PROPERTIES ENVIRONMENT "DYNAMORIO_OPTIONS=${runops_string}")
@@ -1627,6 +1631,10 @@ function(torunonly_native name realexe expect source exe_ops)
   strings2lists(${name} ops)
   set(${name}_expectbase ${expect})
   set(${name}_realtest ${realexe})
+  if (NOT DEFINED ${test}_timeout)
+    # We're not going through drrun with its timeout, so set the ctest timeout.
+#    set(${test}_timeout ${TEST_SECONDS})
+  endif ()
   torun(${name} ${name} ${source} ON OFF "" "${exe_ops}" added OFF)
 endfunction(torunonly_native)
 


### PR DESCRIPTION
The dr$sim unit tests, tests using runcmp (such as nearly all
drcacheoff.* tests), and native tests had no drrun or runstats or
ctest timeout set, leaving them the too-long default 10 minutes,
which combined with the try-3-times results in 30 minutes for a
hung test.  We set the 90s timeout here for these tests.

Issue: #6131