### PR TITLE
i#3544 fix: risc-v TCB offset from tp register is negative according to psABI

### DIFF
--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -193,14 +193,15 @@ extern uint android_tls_base_offs;
 #endif
 
 #ifdef RISCV64
-/* FIXME i#3544: We might need to re-use ARM's approach and store DR TLS in
- * tcb_head_t::private field: typedef struct
+/* Re-using ARM's approach and store DR TLS in tcb_head_t::private,
+ * with the only difference being tp register points at the end of TCB
+ * typedef struct
  *   {
  *     dtv_t *dtv;
  *     void *private;
  *   } tcb_head_t;
  */
-#    define DR_TLS_BASE_OFFSET IF_X64_ELSE(-8, -4) /* skip dtv */
+#    define DR_TLS_BASE_OFFSET IF_X64_ELSE(-8, -4) /* tcb->private, skip dtv */
 #endif
 
 #ifdef LINUX

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -200,7 +200,7 @@ extern uint android_tls_base_offs;
  *     void *private;
  *   } tcb_head_t;
  */
-#    define DR_TLS_BASE_OFFSET IF_X64_ELSE(8, 4) /* skip dtv */
+#    define DR_TLS_BASE_OFFSET IF_X64_ELSE(-8, -4) /* skip dtv */
 #endif
 
 #ifdef LINUX

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -194,7 +194,8 @@ extern uint android_tls_base_offs;
 
 #ifdef RISCV64
 /* Re-using ARM's approach and store DR TLS in tcb_head_t::private,
- * with the only difference being tp register points at the end of TCB
+ * with the only difference being tp register points at the end of TCB.
+ *
  * typedef struct
  *   {
  *     dtv_t *dtv;


### PR DESCRIPTION
According to RISCV processor specific application binary interface, psABI : https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc "tp containing the address one past the end of the TCB." further documentation for that can be found in glibc sources sysdeps/riscv/nptl/tls.h:
/* Return the address of the dtv for the current thread.  */
  (((tcbhead_t *) (READ_THREAD_POINTER () - TLS_TCB_OFFSET))[-1].dtv)