### PR TITLE
i#3044 AArch64 SVE codec: Fix LDR/STR <P> mem size

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5156,8 +5156,12 @@ decode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, OUT opnd_t *opnd
     int offset9 = extract_int(simm9, 0, 9);
     if (offset9 < -256 || offset9 > 255)
         return false;
+
+    // Transfer size depends on whether we are transferring a Z register or a P register.
+    opnd_size_t memory_transfer_size = TEST(1u << 14, enc) ? OPSZ_SVE_VL : OPSZ_SVE_PL;
+
     *opnd = opnd_create_base_disp(decode_reg(extract_uint(enc, 5, 5), true, true),
-                                  DR_REG_NULL, 0, offset9, OPSZ_SVE_VL);
+                                  DR_REG_NULL, 0, offset9, memory_transfer_size);
     return true;
 }
 
@@ -5168,7 +5172,11 @@ encode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, opnd_t opnd,
     int disp;
     bool is_x;
     uint rn;
-    if (!opnd_is_base_disp(opnd) || opnd_get_size(opnd) != OPSZ_SVE_VL)
+
+    // Transfer size depends on whether we are transferring a Z register or a P register.
+    opnd_size_t memory_transfer_size = TEST(1u << 14, enc) ? OPSZ_SVE_VL : OPSZ_SVE_PL;
+
+    if (!opnd_is_base_disp(opnd) || opnd_get_size(opnd) != memory_transfer_size)
         return false;
     disp = opnd_get_disp(opnd);
     if (disp < -256 || disp > 255)

--- a/core/ir/aarch64/codec.h
+++ b/core/ir/aarch64/codec.h
@@ -63,6 +63,7 @@ encode_common(byte *pc, instr_t *i, decode_info_t *di);
  * Setting to fixed size for now in order to pass unit tests.
  */
 #    define OPSZ_SVE_VL opnd_size_from_bytes(dr_get_sve_vl() / 8)
+#    define OPSZ_SVE_PL opnd_size_from_bytes((dr_get_sve_vl() / 8) / 8)
 #else
 /* SVE vector length for off-line decoder set using -vl option with drdisas,
  * e.g.
@@ -72,6 +73,7 @@ encode_common(byte *pc, instr_t *i, decode_info_t *di);
  * $
  */
 #    define OPSZ_SVE_VL opnd_size_from_bytes(dr_get_sve_vl() / 8)
+#    define OPSZ_SVE_PL opnd_size_from_bytes((dr_get_sve_vl() / 8) / 8)
 #endif
 
 #define RETURN_FALSE                                           \

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -239,7 +239,7 @@
 ----------xxxxxx------xxxxx-----  svememx6_h_5    # vector memory reg with 6 bit imm for half value
 ----------xxxxxx------xxxxx-----  svememx6_s_5    # vector memory reg with 6 bit imm for single value
 ----------xxxxxx------xxxxx-----  svememx6_d_5    # vector memory reg with 6 bit imm for double value
-----------xxxxxx---xxxxxxxx-----  svemem_gpr_simm9_vl # imm offset and base reg for SVE ld/st
+----------xxxxxx-?-xxxxxxxx-----  svemem_gpr_simm9_vl # imm offset and base reg for SVE ld/st
 ----------xxxxxxxxxxxx----------  imm12      # immediate for ADD/SUB
 ----------xxxxxxxxxxxxxxxxx-----  mem12q     # size is 16 bytes
 ----------xxxxxxxxxxxxxxxxx-----  prf12      # size is 0 bytes (prefetch variant of mem12)

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -15204,38 +15204,38 @@ a505ff9b : ldnt1w z27.s, p7/Z, [x28, #5, MUL VL]     : ldnt1w +0x05(%x28)[32byte
 a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0x07(%sp)[32byte] %p7/z -> %z31.s
 
 # LDR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
-858003c0 : ldr p0, [x30]                            : ldr    (%x30)[32byte] -> %p0
-858003c0 : ldr p0, [x30]                            : ldr    (%x30)[32byte] -> %p0
-858017a1 : ldr p1, [x29, #5, mul vl]                : ldr    +0x05(%x29)[32byte] -> %p1
-85bf0fa1 : ldr p1, [x29, #-5, mul vl]               : ldr    -0x05(%x29)[32byte] -> %p1
-85810b82 : ldr p2, [x28, #10, mul vl]               : ldr    +0x0a(%x28)[32byte] -> %p2
-85be1b82 : ldr p2, [x28, #-10, mul vl]              : ldr    -0x0a(%x28)[32byte] -> %p2
-85811f63 : ldr p3, [x27, #15, mul vl]               : ldr    +0x0f(%x27)[32byte] -> %p3
-85be0763 : ldr p3, [x27, #-15, mul vl]              : ldr    -0x0f(%x27)[32byte] -> %p3
-85821344 : ldr p4, [x26, #20, mul vl]               : ldr    +0x14(%x26)[32byte] -> %p4
-85bd1344 : ldr p4, [x26, #-20, mul vl]              : ldr    -0x14(%x26)[32byte] -> %p4
-85830725 : ldr p5, [x25, #25, mul vl]               : ldr    +0x19(%x25)[32byte] -> %p5
-85bc1f25 : ldr p5, [x25, #-25, mul vl]              : ldr    -0x19(%x25)[32byte] -> %p5
-85831b06 : ldr p6, [x24, #30, mul vl]               : ldr    +0x1e(%x24)[32byte] -> %p6
-85bc0b06 : ldr p6, [x24, #-30, mul vl]              : ldr    -0x1e(%x24)[32byte] -> %p6
-85840ee7 : ldr p7, [x23, #35, mul vl]               : ldr    +0x23(%x23)[32byte] -> %p7
-85bb16e7 : ldr p7, [x23, #-35, mul vl]              : ldr    -0x23(%x23)[32byte] -> %p7
-858502c8 : ldr p8, [x22, #40, mul vl]               : ldr    +0x28(%x22)[32byte] -> %p8
-85bb02c8 : ldr p8, [x22, #-40, mul vl]              : ldr    -0x28(%x22)[32byte] -> %p8
-858516a9 : ldr p9, [x21, #45, mul vl]               : ldr    +0x2d(%x21)[32byte] -> %p9
-85ba0ea9 : ldr p9, [x21, #-45, mul vl]              : ldr    -0x2d(%x21)[32byte] -> %p9
-85860a8a : ldr p10, [x20, #50, mul vl]              : ldr    +0x32(%x20)[32byte] -> %p10
-85b91a8a : ldr p10, [x20, #-50, mul vl]             : ldr    -0x32(%x20)[32byte] -> %p10
-85861e6b : ldr p11, [x19, #55, mul vl]              : ldr    +0x37(%x19)[32byte] -> %p11
-85b9066b : ldr p11, [x19, #-55, mul vl]             : ldr    -0x37(%x19)[32byte] -> %p11
-8587124c : ldr p12, [x18, #60, mul vl]              : ldr    +0x3c(%x18)[32byte] -> %p12
-85b8124c : ldr p12, [x18, #-60, mul vl]             : ldr    -0x3c(%x18)[32byte] -> %p12
-8588062d : ldr p13, [x17, #65, mul vl]              : ldr    +0x41(%x17)[32byte] -> %p13
-85b71e2d : ldr p13, [x17, #-65, mul vl]             : ldr    -0x41(%x17)[32byte] -> %p13
-85881a0e : ldr p14, [x16, #70, mul vl]              : ldr    +0x46(%x16)[32byte] -> %p14
-85b70a0e : ldr p14, [x16, #-70, mul vl]             : ldr    -0x46(%x16)[32byte] -> %p14
-85890def : ldr p15, [x15, #75, mul vl]              : ldr    +0x4b(%x15)[32byte] -> %p15
-85b615ef : ldr p15, [x15, #-75, mul vl]             : ldr    -0x4b(%x15)[32byte] -> %p15
+858003c0 : ldr p0, [x30]                            : ldr    (%x30)[4byte] -> %p0
+858003c0 : ldr p0, [x30]                            : ldr    (%x30)[4byte] -> %p0
+858017a1 : ldr p1, [x29, #5, mul vl]                : ldr    +0x05(%x29)[4byte] -> %p1
+85bf0fa1 : ldr p1, [x29, #-5, mul vl]               : ldr    -0x05(%x29)[4byte] -> %p1
+85810b82 : ldr p2, [x28, #10, mul vl]               : ldr    +0x0a(%x28)[4byte] -> %p2
+85be1b82 : ldr p2, [x28, #-10, mul vl]              : ldr    -0x0a(%x28)[4byte] -> %p2
+85811f63 : ldr p3, [x27, #15, mul vl]               : ldr    +0x0f(%x27)[4byte] -> %p3
+85be0763 : ldr p3, [x27, #-15, mul vl]              : ldr    -0x0f(%x27)[4byte] -> %p3
+85821344 : ldr p4, [x26, #20, mul vl]               : ldr    +0x14(%x26)[4byte] -> %p4
+85bd1344 : ldr p4, [x26, #-20, mul vl]              : ldr    -0x14(%x26)[4byte] -> %p4
+85830725 : ldr p5, [x25, #25, mul vl]               : ldr    +0x19(%x25)[4byte] -> %p5
+85bc1f25 : ldr p5, [x25, #-25, mul vl]              : ldr    -0x19(%x25)[4byte] -> %p5
+85831b06 : ldr p6, [x24, #30, mul vl]               : ldr    +0x1e(%x24)[4byte] -> %p6
+85bc0b06 : ldr p6, [x24, #-30, mul vl]              : ldr    -0x1e(%x24)[4byte] -> %p6
+85840ee7 : ldr p7, [x23, #35, mul vl]               : ldr    +0x23(%x23)[4byte] -> %p7
+85bb16e7 : ldr p7, [x23, #-35, mul vl]              : ldr    -0x23(%x23)[4byte] -> %p7
+858502c8 : ldr p8, [x22, #40, mul vl]               : ldr    +0x28(%x22)[4byte] -> %p8
+85bb02c8 : ldr p8, [x22, #-40, mul vl]              : ldr    -0x28(%x22)[4byte] -> %p8
+858516a9 : ldr p9, [x21, #45, mul vl]               : ldr    +0x2d(%x21)[4byte] -> %p9
+85ba0ea9 : ldr p9, [x21, #-45, mul vl]              : ldr    -0x2d(%x21)[4byte] -> %p9
+85860a8a : ldr p10, [x20, #50, mul vl]              : ldr    +0x32(%x20)[4byte] -> %p10
+85b91a8a : ldr p10, [x20, #-50, mul vl]             : ldr    -0x32(%x20)[4byte] -> %p10
+85861e6b : ldr p11, [x19, #55, mul vl]              : ldr    +0x37(%x19)[4byte] -> %p11
+85b9066b : ldr p11, [x19, #-55, mul vl]             : ldr    -0x37(%x19)[4byte] -> %p11
+8587124c : ldr p12, [x18, #60, mul vl]              : ldr    +0x3c(%x18)[4byte] -> %p12
+85b8124c : ldr p12, [x18, #-60, mul vl]             : ldr    -0x3c(%x18)[4byte] -> %p12
+8588062d : ldr p13, [x17, #65, mul vl]              : ldr    +0x41(%x17)[4byte] -> %p13
+85b71e2d : ldr p13, [x17, #-65, mul vl]             : ldr    -0x41(%x17)[4byte] -> %p13
+85881a0e : ldr p14, [x16, #70, mul vl]              : ldr    +0x46(%x16)[4byte] -> %p14
+85b70a0e : ldr p14, [x16, #-70, mul vl]             : ldr    -0x46(%x16)[4byte] -> %p14
+85890def : ldr p15, [x15, #75, mul vl]              : ldr    +0x4b(%x15)[4byte] -> %p15
+85b615ef : ldr p15, [x15, #-75, mul vl]             : ldr    -0x4b(%x15)[4byte] -> %p15
 
 # LDR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
 858043c0 : ldr z0, [x30]                            : ldr    (%x30)[32byte] -> %z0
@@ -22444,38 +22444,38 @@ e515ff9b : stnt1w z27.s, p7, [x28, #5, MUL VL]       : stnt1w %z27.s %p7 -> +0x0
 e517ffff : stnt1w z31.s, p7, [sp, #7, MUL VL]        : stnt1w %z31.s %p7 -> +0x07(%sp)[32byte]
 
 # STR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
-e58003c0 : str p0, [x30]                            : str    %p0 -> (%x30)[32byte]
-e58003c0 : str p0, [x30]                            : str    %p0 -> (%x30)[32byte]
-e58017a1 : str p1, [x29, #5, mul vl]                : str    %p1 -> +0x05(%x29)[32byte]
-e5bf0fa1 : str p1, [x29, #-5, mul vl]               : str    %p1 -> -0x05(%x29)[32byte]
-e5810b82 : str p2, [x28, #10, mul vl]               : str    %p2 -> +0x0a(%x28)[32byte]
-e5be1b82 : str p2, [x28, #-10, mul vl]              : str    %p2 -> -0x0a(%x28)[32byte]
-e5811f63 : str p3, [x27, #15, mul vl]               : str    %p3 -> +0x0f(%x27)[32byte]
-e5be0763 : str p3, [x27, #-15, mul vl]              : str    %p3 -> -0x0f(%x27)[32byte]
-e5821344 : str p4, [x26, #20, mul vl]               : str    %p4 -> +0x14(%x26)[32byte]
-e5bd1344 : str p4, [x26, #-20, mul vl]              : str    %p4 -> -0x14(%x26)[32byte]
-e5830725 : str p5, [x25, #25, mul vl]               : str    %p5 -> +0x19(%x25)[32byte]
-e5bc1f25 : str p5, [x25, #-25, mul vl]              : str    %p5 -> -0x19(%x25)[32byte]
-e5831b06 : str p6, [x24, #30, mul vl]               : str    %p6 -> +0x1e(%x24)[32byte]
-e5bc0b06 : str p6, [x24, #-30, mul vl]              : str    %p6 -> -0x1e(%x24)[32byte]
-e5840ee7 : str p7, [x23, #35, mul vl]               : str    %p7 -> +0x23(%x23)[32byte]
-e5bb16e7 : str p7, [x23, #-35, mul vl]              : str    %p7 -> -0x23(%x23)[32byte]
-e58502c8 : str p8, [x22, #40, mul vl]               : str    %p8 -> +0x28(%x22)[32byte]
-e5bb02c8 : str p8, [x22, #-40, mul vl]              : str    %p8 -> -0x28(%x22)[32byte]
-e58516a9 : str p9, [x21, #45, mul vl]               : str    %p9 -> +0x2d(%x21)[32byte]
-e5ba0ea9 : str p9, [x21, #-45, mul vl]              : str    %p9 -> -0x2d(%x21)[32byte]
-e5860a8a : str p10, [x20, #50, mul vl]              : str    %p10 -> +0x32(%x20)[32byte]
-e5b91a8a : str p10, [x20, #-50, mul vl]             : str    %p10 -> -0x32(%x20)[32byte]
-e5861e6b : str p11, [x19, #55, mul vl]              : str    %p11 -> +0x37(%x19)[32byte]
-e5b9066b : str p11, [x19, #-55, mul vl]             : str    %p11 -> -0x37(%x19)[32byte]
-e587124c : str p12, [x18, #60, mul vl]              : str    %p12 -> +0x3c(%x18)[32byte]
-e5b8124c : str p12, [x18, #-60, mul vl]             : str    %p12 -> -0x3c(%x18)[32byte]
-e588062d : str p13, [x17, #65, mul vl]              : str    %p13 -> +0x41(%x17)[32byte]
-e5b71e2d : str p13, [x17, #-65, mul vl]             : str    %p13 -> -0x41(%x17)[32byte]
-e5881a0e : str p14, [x16, #70, mul vl]              : str    %p14 -> +0x46(%x16)[32byte]
-e5b70a0e : str p14, [x16, #-70, mul vl]             : str    %p14 -> -0x46(%x16)[32byte]
-e5890def : str p15, [x15, #75, mul vl]              : str    %p15 -> +0x4b(%x15)[32byte]
-e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x4b(%x15)[32byte]
+e58003c0 : str p0, [x30]                            : str    %p0 -> (%x30)[4byte]
+e58003c0 : str p0, [x30]                            : str    %p0 -> (%x30)[4byte]
+e58017a1 : str p1, [x29, #5, mul vl]                : str    %p1 -> +0x05(%x29)[4byte]
+e5bf0fa1 : str p1, [x29, #-5, mul vl]               : str    %p1 -> -0x05(%x29)[4byte]
+e5810b82 : str p2, [x28, #10, mul vl]               : str    %p2 -> +0x0a(%x28)[4byte]
+e5be1b82 : str p2, [x28, #-10, mul vl]              : str    %p2 -> -0x0a(%x28)[4byte]
+e5811f63 : str p3, [x27, #15, mul vl]               : str    %p3 -> +0x0f(%x27)[4byte]
+e5be0763 : str p3, [x27, #-15, mul vl]              : str    %p3 -> -0x0f(%x27)[4byte]
+e5821344 : str p4, [x26, #20, mul vl]               : str    %p4 -> +0x14(%x26)[4byte]
+e5bd1344 : str p4, [x26, #-20, mul vl]              : str    %p4 -> -0x14(%x26)[4byte]
+e5830725 : str p5, [x25, #25, mul vl]               : str    %p5 -> +0x19(%x25)[4byte]
+e5bc1f25 : str p5, [x25, #-25, mul vl]              : str    %p5 -> -0x19(%x25)[4byte]
+e5831b06 : str p6, [x24, #30, mul vl]               : str    %p6 -> +0x1e(%x24)[4byte]
+e5bc0b06 : str p6, [x24, #-30, mul vl]              : str    %p6 -> -0x1e(%x24)[4byte]
+e5840ee7 : str p7, [x23, #35, mul vl]               : str    %p7 -> +0x23(%x23)[4byte]
+e5bb16e7 : str p7, [x23, #-35, mul vl]              : str    %p7 -> -0x23(%x23)[4byte]
+e58502c8 : str p8, [x22, #40, mul vl]               : str    %p8 -> +0x28(%x22)[4byte]
+e5bb02c8 : str p8, [x22, #-40, mul vl]              : str    %p8 -> -0x28(%x22)[4byte]
+e58516a9 : str p9, [x21, #45, mul vl]               : str    %p9 -> +0x2d(%x21)[4byte]
+e5ba0ea9 : str p9, [x21, #-45, mul vl]              : str    %p9 -> -0x2d(%x21)[4byte]
+e5860a8a : str p10, [x20, #50, mul vl]              : str    %p10 -> +0x32(%x20)[4byte]
+e5b91a8a : str p10, [x20, #-50, mul vl]             : str    %p10 -> -0x32(%x20)[4byte]
+e5861e6b : str p11, [x19, #55, mul vl]              : str    %p11 -> +0x37(%x19)[4byte]
+e5b9066b : str p11, [x19, #-55, mul vl]             : str    %p11 -> -0x37(%x19)[4byte]
+e587124c : str p12, [x18, #60, mul vl]              : str    %p12 -> +0x3c(%x18)[4byte]
+e5b8124c : str p12, [x18, #-60, mul vl]             : str    %p12 -> -0x3c(%x18)[4byte]
+e588062d : str p13, [x17, #65, mul vl]              : str    %p13 -> +0x41(%x17)[4byte]
+e5b71e2d : str p13, [x17, #-65, mul vl]             : str    %p13 -> -0x41(%x17)[4byte]
+e5881a0e : str p14, [x16, #70, mul vl]              : str    %p14 -> +0x46(%x16)[4byte]
+e5b70a0e : str p14, [x16, #-70, mul vl]             : str    %p14 -> -0x46(%x16)[4byte]
+e5890def : str p15, [x15, #75, mul vl]              : str    %p15 -> +0x4b(%x15)[4byte]
+e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x4b(%x15)[4byte]
 
 # STR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
 e58043c0 : str z0, [x30]                            : str    %z0 -> (%x30)[32byte]

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -8331,13 +8331,13 @@ TEST_INSTR(str)
     /* STR <Pt>, [<Xn|SP>{, #<simm>, MUL VL}] */
     int simm_1[6] = { 0, 255, -256, 127, -128, -1 };
     const char *expected_1[6] = {
-        "str    %p0 -> (%x0)[32byte]",         "str    %p2 -> +0xff(%x5)[32byte]",
-        "str    %p5 -> -0x0100(%x10)[32byte]", "str    %p8 -> +0x7f(%x15)[32byte]",
-        "str    %p10 -> -0x80(%x20)[32byte]",  "str    %p15 -> -0x01(%x30)[32byte]"
+        "str    %p0 -> (%x0)[4byte]",         "str    %p2 -> +0xff(%x5)[4byte]",
+        "str    %p5 -> -0x0100(%x10)[4byte]", "str    %p8 -> +0x7f(%x15)[4byte]",
+        "str    %p10 -> -0x80(%x20)[4byte]",  "str    %p15 -> -0x01(%x30)[4byte]"
     };
     TEST_LOOP(str, str, 6, expected_1[i],
               opnd_create_base_disp_aarch64(Xn_six_offset_0[i], DR_REG_NULL, 0, false,
-                                            simm_1[i], 0, OPSZ_32),
+                                            simm_1[i], 0, OPSZ_4),
               opnd_create_reg(Pn_six_offset_0[i]));
 }
 
@@ -8357,13 +8357,13 @@ TEST_INSTR(ldr)
     /* LDR <Pt>, [<Xn|SP>{, #<simm>, MUL VL}] */
     int simm_1[6] = { 0, 255, -256, 127, -128, -1 };
     const char *expected_1[6] = {
-        "ldr    (%x0)[32byte] -> %p0",         "ldr    +0xff(%x6)[32byte] -> %p3",
-        "ldr    -0x0100(%x11)[32byte] -> %p6", "ldr    +0x7f(%x16)[32byte] -> %p9",
-        "ldr    -0x80(%x21)[32byte] -> %p11",  "ldr    -0x01(%x30)[32byte] -> %p15",
+        "ldr    (%x0)[4byte] -> %p0",         "ldr    +0xff(%x6)[4byte] -> %p3",
+        "ldr    -0x0100(%x11)[4byte] -> %p6", "ldr    +0x7f(%x16)[4byte] -> %p9",
+        "ldr    -0x80(%x21)[4byte] -> %p11",  "ldr    -0x01(%x30)[4byte] -> %p15",
     };
     TEST_LOOP(ldr, ldr, 6, expected_1[i], opnd_create_reg(Pn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,
-                                            simm_1[i], 0, OPSZ_32));
+                                            simm_1[i], 0, OPSZ_4));
 }
 
 TEST_INSTR(punpkhi_sve)


### PR DESCRIPTION
The svemem_gpr_simm9_vl operand was setting the memory transfer size to the current vector length, which is correct for Z register loads and stores but not P register loads and stores.

The encoder/decoder will now detect which kind of register is being accessed and set the correct size.

Issues: #3044