### PR TITLE
i#5843 scheduler: Fix syscall function id base

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -490,7 +490,7 @@ enum {
  * of the system call number for 32-bit marker values.
  */
 #ifdef X64
-    TRACE_FUNC_ID_SYSCALL_BASE = 0x100000000UL,
+    TRACE_FUNC_ID_SYSCALL_BASE = 0x100000000ULL,
 #else
     TRACE_FUNC_ID_SYSCALL_BASE = 0x10000U,
 #endif

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -490,7 +490,7 @@ enum {
  * of the system call number for 32-bit marker values.
  */
 #ifdef X64
-    TRACE_FUNC_ID_SYSCALL_BASE = 100000000UL,
+    TRACE_FUNC_ID_SYSCALL_BASE = 0x100000000UL,
 #else
     TRACE_FUNC_ID_SYSCALL_BASE = 0x10000U,
 #endif

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -280,12 +280,12 @@ typedef enum {
      *
      * This marker is also used to record parameter values for certain system calls such
      * as for #OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS.  These use large identifiers equal to
-     * #TRACE_FUNC_ID_SYSCALL_BASE plus the system call number (for 32-bit marker values
-     * just the bottom 16 bits of the system call number are added to the base).  These
-     * identifiers are not stored in the function list file
+     * #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system call number (for 32-bit
+     * marker values just the bottom 16 bits of the system call number are added to the
+     * base).  These identifiers are not stored in the function list file
      * (drmemtrace_get_funclist_path()).  The system call number used is the value
-     * passed to DynamoRIO's dr_register_pre_syscall_event() which is normalized
-     * to match SYS_ constants (see the dr_register_pre_syscall_event() documentation
+     * passed to DynamoRIO's dr_register_pre_syscall_event() which is normalized to
+     * match SYS_ constants (see the dr_register_pre_syscall_event() documentation
      * regarding MacOS).
      */
     TRACE_MARKER_TYPE_FUNC_ID,
@@ -313,9 +313,9 @@ typedef enum {
      * whose id is specified by the closest previous #TRACE_MARKER_TYPE_FUNC_ID
      * marker entry
      *
-     * The marker value for system calls (see #TRACE_FUNC_ID_SYSCALL_BASE) is either 0
-     * (failure) or 1 (success), as obtained from dr_syscall_get_result_ex() via the
-     * "succeeded" field of #dr_syscall_result_info_t.  See the corresponding
+     * The marker value for system calls (see #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE)
+     * is either 0 (failure) or 1 (success), as obtained from dr_syscall_get_result_ex()
+     * via the "succeeded" field of #dr_syscall_result_info_t.  See the corresponding
      * documentation for caveats about the accuracy of this value.
      */
     TRACE_MARKER_TYPE_FUNC_RETVAL,
@@ -480,7 +480,7 @@ typedef enum {
 } trace_marker_type_t;
 
 /** Constants related to function or system call parameter tracing. */
-enum {
+enum class func_trace_t : uint64_t { // VS2019 won't infer 64-bit with "enum {".
 /**
  * When system call parameter and return values are provided, they use the function
  * tracing markers #TRACE_MARKER_TYPE_FUNC_ID, #TRACE_MARKER_TYPE_FUNC_ARG, and
@@ -718,9 +718,9 @@ typedef enum {
      * and return values for kernel locks (SYS_futex on Linux) using the function tracing
      * markers #TRACE_MARKER_TYPE_FUNC_ID, #TRACE_MARKER_TYPE_FUNC_ARG, and
      * #TRACE_MARKER_TYPE_FUNC_RETVAL with an identifier equal to
-     * #TRACE_FUNC_ID_SYSCALL_BASE plus the system call number (or its bottom 16 bits
-     * for 32-bit marker values).  These identifiers are not stored in the function
-     * list file (drmemtrace_get_funclist_path()).
+     * #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system call number (or its
+     * bottom 16 bits for 32-bit marker values).  These identifiers are not stored in
+     * the function list file (drmemtrace_get_funclist_path()).
      *
      * The #TRACE_MARKER_TYPE_FUNC_RETVAL for system calls is either 0 (failure) or
      * 1 (success).

--- a/clients/drcachesim/tests/burst_futex.cpp
+++ b/clients/drcachesim/tests/burst_futex.cpp
@@ -168,7 +168,7 @@ main(int argc, const char *argv[])
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_ID) {
             saw_futex_marker = true;
             assert(memref.marker.marker_value ==
-                   TRACE_FUNC_ID_SYSCALL_BASE +
+                   static_cast<uintptr_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) +
                        IF_X64_ELSE(SYS_futex, SYS_futex & 0xffff));
         }
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_ARG) {

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -370,10 +370,12 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         marker_type_is_function_marker(memref.marker.marker_type)) {
-        report_if_false(shard,
-                        shard->prev_func_id_ >= TRACE_FUNC_ID_SYSCALL_BASE ||
-                            type_is_instr_branch(shard->prev_instr_.instr.type),
-                        "Function marker should be after a branch");
+        report_if_false(
+            shard,
+            shard->prev_func_id_ >=
+                    static_cast<uintptr_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) ||
+                type_is_instr_branch(shard->prev_instr_.instr.type),
+            "Function marker should be after a branch");
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_RETADDR) {

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -350,9 +350,12 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
                       << memref.marker.marker_value << std::dec << ">\n";
             break;
         case TRACE_MARKER_TYPE_FUNC_ID:
-            if (memref.marker.marker_value >= TRACE_FUNC_ID_SYSCALL_BASE) {
+            if (memref.marker.marker_value >=
+                static_cast<intptr_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE)) {
                 std::cerr << "<marker: function==syscall #"
-                          << (memref.marker.marker_value - TRACE_FUNC_ID_SYSCALL_BASE)
+                          << (memref.marker.marker_value -
+                              static_cast<uintptr_t>(
+                                  func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE))
                           << ">\n";
             } else {
                 std::cerr << "<marker: function #" << memref.marker.marker_value << ">\n";

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1354,7 +1354,8 @@ event_pre_syscall(void *drcontext, int sysnum)
             static constexpr int FUTEX_ARG_COUNT = 6;
             BUF_PTR(data->seg_base) += instru->append_marker(
                 BUF_PTR(data->seg_base), TRACE_MARKER_TYPE_FUNC_ID,
-                TRACE_FUNC_ID_SYSCALL_BASE + IF_X64_ELSE(sysnum, (sysnum & 0xffff)));
+                static_cast<uintptr_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) +
+                    IF_X64_ELSE(sysnum, (sysnum & 0xffff)));
             for (int i = 0; i < FUTEX_ARG_COUNT; ++i) {
                 BUF_PTR(data->seg_base) += instru->append_marker(
                     BUF_PTR(data->seg_base), TRACE_MARKER_TYPE_FUNC_ARG,
@@ -1417,7 +1418,8 @@ event_post_syscall(void *drcontext, int sysnum)
             dr_syscall_get_result_ex(drcontext, &info);
             BUF_PTR(data->seg_base) += instru->append_marker(
                 BUF_PTR(data->seg_base), TRACE_MARKER_TYPE_FUNC_ID,
-                TRACE_FUNC_ID_SYSCALL_BASE + IF_X64_ELSE(sysnum, (sysnum & 0xffff)));
+                static_cast<uintptr_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) +
+                    IF_X64_ELSE(sysnum, (sysnum & 0xffff)));
             /* XXX i#5843: Return values are complex and can include more than just
              * the primary register value.  Since we care mostly just about failure,
              * we use the "succeeded" field.  However, this is not accurate for all


### PR DESCRIPTION
The 64-bit system call function id base was accidentally put in as decimal rather than hex.  We fix that here.  Any traces created in between this and PR #6132 that contain futex should be considered ill-formed with respect to function markers.

Issue: #5843