### PR TITLE
i#5843 scheduler: Allow timestamp+cpu before syscall marker

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -649,6 +649,87 @@ check_duplicate_syscall_with_same_pc()
 }
 
 bool
+check_false_syscalls()
+{
+    // Ensure missing syscall markers (from "false syscalls") are detected.
+    // XXX: Just like raw2trace_unit_tests, we need to create a syscall instruction and
+    // it turns out there is no simple cross-platform way.
+#ifdef X86
+    instr_t *sys = INSTR_CREATE_syscall(GLOBAL_DCONTEXT);
+#elif defined(AARCHXX)
+    instr_t *sys =
+        INSTR_CREATE_svc(GLOBAL_DCONTEXT, opnd_create_immed_int((sbyte)0x0, OPSZ_1));
+#elif defined(RISCV64)
+    instr_t *sys = INSTR_CREATE_ecall(GLOBAL_DCONTEXT);
+#else
+#    error Unsupported architecture.
+#endif
+    instr_t *move1 =
+        XINST_CREATE_move(GLOBAL_DCONTEXT, opnd_create_reg(REG1), opnd_create_reg(REG2));
+    instrlist_t *ilist = instrlist_create(GLOBAL_DCONTEXT);
+    instrlist_append(ilist, sys);
+    instrlist_append(ilist, move1);
+    static constexpr addr_t BASE_ADDR = 0x123450;
+    static constexpr uintptr_t FILE_TYPE =
+        OFFLINE_FILE_TYPE_ENCODINGS | OFFLINE_FILE_TYPE_SYSCALL_NUMBERS;
+    bool res = true;
+    {
+        // Correct: syscall followed by marker.
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(1), sys },
+            { gen_marker(1, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, false))
+            res = false;
+    }
+    {
+        // Correct: syscall followed by marker with timestamp+cpu in between.
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(1), sys },
+            { gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
+            { gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(1, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, false))
+            res = false;
+    }
+    {
+        // Incorrect: syscall with no marker.
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(1), sys },
+            { gen_instr(1), move1 }
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, true, 1, 3,
+                         "Syscall instruction not followed by syscall marker",
+                         "Failed to catch syscall without number marker")) {
+            res = false;
+        }
+    }
+    {
+        // Incorrect: marker with no syscall.
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(1), move1 },
+            { gen_marker(1, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, true, 1, 3,
+                         "Syscall marker not placed after syscall instruction",
+                         "Failed to catch misplaced syscall marker")) {
+            res = false;
+        }
+    }
+    instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
+    return res;
+}
+
+bool
 check_rseq_side_exit_discontinuity()
 {
     // Negative test: Seemingly missing instructions in a basic block due to rseq side
@@ -684,6 +765,7 @@ check_rseq_side_exit_discontinuity()
     // TODO i#6023: Use this IR based encoder in other tests as well.
     static constexpr addr_t BASE_ADDR = 0xeba4ad4;
     auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
+    instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
     if (!run_checker(memrefs, true, 1, 5, "PC discontinuity due to rseq side exit",
                      "Failed to catch PC discontinuity from rseq side exit")) {
         return false;
@@ -698,7 +780,8 @@ test_main(int argc, const char *argv[])
 {
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
         check_kernel_xfer() && check_rseq() && check_function_markers() &&
-        check_duplicate_syscall_with_same_pc() && check_rseq_side_exit_discontinuity()) {
+        check_duplicate_syscall_with_same_pc() && check_false_syscalls() &&
+        check_rseq_side_exit_discontinuity()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -314,7 +314,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                type_is_instr(shard->prev_entry_.instr.type) &&
                shard->prev_instr_decoded_ != nullptr &&
                // TODO i#5949: For WOW64 instr_is_syscall() always returns false.
-               instr_is_syscall(shard->prev_instr_decoded_->data)) {
+               instr_is_syscall(shard->prev_instr_decoded_->data) &&
+               // Allow timestamp+cpuid in between.
+               (memref.marker.type != TRACE_TYPE_MARKER ||
+                (memref.marker.marker_type != TRACE_MARKER_TYPE_TIMESTAMP &&
+                 memref.marker.marker_type != TRACE_MARKER_TYPE_CPU_ID))) {
         report_if_false(shard,
                         shard->found_syscall_marker_ &&
                             shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&


### PR DESCRIPTION
Relaxes the invariant check that a syscall instruction is followed by a syscall marker to allow timestamp+cpu markers in between.

Adds unit tests.

Issue: #5843