### PR TITLE
i#5843 scheduler: Include core syscall.h

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -41,8 +41,10 @@
 #include "instru.h"
 #include "../common/memref.h"
 #include "../common/trace_entry.h"
+#ifdef LINUX
 // XXX: We should have the core export this to an include dir.
-#include "../../../core/unix/include/syscall.h"
+#    include "../../core/unix/include/syscall.h"
+#endif
 #ifdef BUILD_PT_POST_PROCESSOR
 #    include "../common/options.h"
 #    include "../drpt2trace/ir2trace.h"

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -41,6 +41,8 @@
 #include "instru.h"
 #include "../common/memref.h"
 #include "../common/trace_entry.h"
+// XXX: We should have the core export this to an include dir.
+#include "../../../core/unix/include/syscall.h"
 #ifdef BUILD_PT_POST_PROCESSOR
 #    include "../common/options.h"
 #    include "../drpt2trace/ir2trace.h"


### PR DESCRIPTION
To avoid issues building on other platforms (as evidenced by a user list email), we add an include of the core's syscall.h for the maybe-blocking syscall feature added by PR #6132.

Issue: #5843