### PR TITLE
Handle syscall-func markers in func_view.

### DIFF
--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -135,6 +135,12 @@ func_view_t::process_memref_for_markers(void *shard_data, const memref_t &memref
         shard->prev_pc = memref.instr.addr;
     if (memref.marker.type != TRACE_TYPE_MARKER)
         return;
+    if (memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_ID) {
+        shard->last_was_syscall = memref.marker.marker_value >=
+            static_cast<int64_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE);
+    }
+    if (shard->last_was_syscall)
+        return;
     switch (memref.marker.marker_type) {
     case TRACE_MARKER_TYPE_FUNC_ID:
         if (shard->last_func_id != -1)
@@ -184,7 +190,7 @@ func_view_t::process_memref(const memref_t &memref)
         else
             std::cerr << ") <no return>\n";
     }
-    if (memref.marker.type != TRACE_TYPE_MARKER)
+    if (memref.marker.type != TRACE_TYPE_MARKER || shard->last_was_syscall)
         return true;
     switch (memref.marker.marker_type) {
     case TRACE_MARKER_TYPE_FUNC_RETADDR: {

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -82,6 +82,11 @@ protected:
         memref_tid_t tid = 0;
         std::unordered_map<int, func_stats_t> func_map;
         std::string error;
+        // We use the function markers to record arguments and return
+        // values in the trace also for some system calls like futex.
+        // func_view skips printing details for such system calls,
+        // because these are not specified by the user.
+        bool last_was_syscall = false;
         int last_func_id = -1;
         int nesting_level = 0;
         int arg_idx = -1;


### PR DESCRIPTION
Augments the func_view tool to handle the syscall-related function markers.

The func_view tool is expected to print details of only the functions that the user specified explicitly in -record_function, and not the system calls like futex that also use function markers.

Tested locally with a trace that has futex calls.