### PR TITLE
i#4343: Add dynamorio::drmemtrace namespace to all drcachesim/ code

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -166,24 +166,14 @@ changes:
    INSTR_CREATE_eor_sve_pred(), INSTR_CREATE_and_sve_pred() and
    INSTR_CREATE_bic_sve_pred() to use the new vector element registers and to
    correctly encode the predicate mode.
- - Added a new drmemtrace analyzer option \p -interval_microseconds and various new
-   #analysis_tool_t APIs for producing per-interval results. The analyzer framework
-   invokes the generate_interval_snapshot() and generate_shard_interval_snapshot()
-   analysis tool APIs periodically every \p -interval_microseconds of the trace as
-   measured by the #TRACE_MARKER_TYPE_TIMESTAMP marker values. In these callbacks, the
-   tool creates and returns a snapshot of their internal state that is required to
-   produce and print per-interval results in a later print_interval_results() call.
-   The tool's internal state is a struct derived from the
-   #analysis_tool_tmpl_t::interval_state_snapshot_t base struct. Additionally, the tool
-   implements combine_interval_snapshot() to combine two interval snapshot structs,
-   which is required for producing whole-trace results in the parallel mode of analyzer
-   operation, and also release_interval_snapshot() which is used to release the
-   analyzer framework's claim to the interval snapshot objects.
  - ud2a and ud2b have been renamed to ud2 and ud1, respectively. The old constants
    #OP_ud2a and #OP_ud2b, as well as the #INSTR_CREATE_ud2a()/#INSTR_CREATE_ud2b()
    macros, are \#defined to the new names, #OP_ud2, #OP_ud1, #INSTR_CREATE_ud2(),
    and #INSTR_CREATE_ud1() respectively. ud1 now correctly accounts for its operands
    so manipulation of ud1 is not backwards compatible.
+ - All drcachesim/ code was changed to use the dynamorio::drmemtrace namespace.
+   External code using any drcachesim or drmemtrace library will need to be
+   recompiled.
 
 Further non-compatibility-affecting changes include:
  - Added AArchXX support for attaching to a running process.
@@ -197,14 +187,14 @@ Further non-compatibility-affecting changes include:
    default (if built with lz4 support).
  - Added drmodtrack_lookup_pc_from_index().
  - Added -use_physical support to drcachesim offline traces using three new
-   marker types: #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS,
-   #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, and
-   #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE.
+   marker types: #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS,
+   #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS, and
+   #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE.
  - Added an open-address hashtable implementation for cases where third-party
    libraries must be avoided and open addressing is best: dr_hashtable_create(),
    dr_hashtable_destroy(), dr_hashtable_clear(), dr_hashtable_lookup(),
    dr_hashtable_add(), dr_hashtable_remove().
- - Added a new #TRACE_MARKER_TYPE_PAGE_SIZE record to drcachesim offline traces.
+ - Added a new #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PAGE_SIZE record to drcachesim offline traces.
  - Added new drmemtrace options -L0I_filter and -L0D_filter that allow enabling
    online filtering for only instruction or only data entries respectively. The
    old option -L0_filter is deprecated but still supported for backward
@@ -237,8 +227,8 @@ Further non-compatibility-affecting changes include:
    The stream interface passed to analysis tools provides tools with the
    record and instruction ordinals along with the values of top-level
    headers.
- - Added #record_analyzer_t and #record_analysis_tool_t for analyzing the
-   sequence of #trace_entry_t exactly as present in a stored offline trace.
+ - Added #dynamorio::drmemtrace::record_analyzer_t and #dynamorio::drmemtrace::record_analysis_tool_t for analyzing the
+   sequence of #dynamorio::drmemtrace::trace_entry_t exactly as present in a stored offline trace.
  - Added opnd_size_to_shift_amount() and opnd_create_base_disp_shift_aarch64()
    for explicitly specifying shift amounts in the creation of operands for
    AArch64 memory addresses.
@@ -251,7 +241,7 @@ Further non-compatibility-affecting changes include:
  - Added a new #dynamorio::drmemtrace::scheduler_tmpl_t interface providing scheduling
    of drmemtrace offline files onto configurable output streams, meant for use by
    microarchitectural simulators.
- - Added a #memtrace_stream_t interface for drmemtrace analysis tools to
+ - Added a #dynamorio::drmemtrace::memtrace_stream_t interface for drmemtrace analysis tools to
    query key attributes of each input trace.
  - Added instr_create_1dst_6src() convenience function that returns an instr_t
    with one destination and six sources.
@@ -259,6 +249,19 @@ Further non-compatibility-affecting changes include:
    #DR_NOTE_RSEQ_ENTRY.
  - Added instr_get_offset() API for getting the offset of an instr in an instrlist that
    has been encoded with instrlist_encode* set of APIs.
+ - Added a new drmemtrace analyzer option \p -interval_microseconds and various new
+   #dynamorio::drmemtrace::analysis_tool_t APIs for producing per-interval results. The analyzer framework
+   invokes the generate_interval_snapshot() and generate_shard_interval_snapshot()
+   analysis tool APIs periodically every \p -interval_microseconds of the trace as
+   measured by the #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker values. In these callbacks, the
+   tool creates and returns a snapshot of their internal state that is required to
+   produce and print per-interval results in a later print_interval_results() call.
+   The tool's internal state is a struct derived from the
+   #dynamorio::drmemtrace::analysis_tool_tmpl_t::interval_state_snapshot_t base struct. Additionally, the tool
+   implements combine_interval_snapshot() to combine two interval snapshot structs,
+   which is required for producing whole-trace results in the parallel mode of analyzer
+   operation, and also release_interval_snapshot() which is used to release the
+   analyzer framework's claim to the interval snapshot objects.
  - Added a new drmemtrace analysis tool: syscall_mix, to count frequency of system
    calls in a trace. This tool works in both the online and offline modes of
    drmemtrace.
@@ -407,10 +410,10 @@ Further non-compatibility-affecting changes include:
    event callback(s) via the #dr_restore_state_info_t arg.
  - Added the source context for restartable sequence aborts (#DR_XFER_RSEQ_ABORT)
    which was previously missing.
- - Added a #TRACE_MARKER_TYPE_VERSION entry to drmemtrace traces.
- - Augmented drmemtrace #TRACE_MARKER_TYPE_KERNEL_EVENT entries with the absolute
+ - Added a #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION entry to drmemtrace traces.
+ - Augmented drmemtrace #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT entries with the absolute
    PC of the interruption point, including for restartable sequence aborts, which
-   now also have an additional #TRACE_MARKER_TYPE_RSEQ_ABORT identifier.
+   now also have an additional #dynamorio::drmemtrace::TRACE_MARKER_TYPE_RSEQ_ABORT identifier.
  - Added a fifth instrumentation phase (meta_instru) that executes after the
    insertion of instrumentation and instrumentation optimizations. Its primary purpose
    is to enable debugging of instrumentation sequences and detection of
@@ -715,15 +718,15 @@ Further non-compatibility-affecting changes include:
    setting up the code cache prior to execution.
  - Added support for Windows 10 1803. We provide an artificial version
    identifier #DR_WINDOWS_VERSION_10_1803 to distinguish this major update.
- - Generalization of the drcachesim #raw2trace_t API (Issue #3129):
-   - Added #module_mapper_t, which factors out the module mapping functionality
-     out of #raw2trace_t, replacing the following #raw2trace_t APIs:
-     #raw2trace_t::handle_custom_data(), #raw2trace_t::do_module_parsing(),
-     #raw2trace_t::do_module_parsing_and_mapping(), and
-     #raw2trace_t::find_mapped_trace_address().
-   - Added #trace_metadata_writer_t, a set of utility functions used by drcachesim's
-     #raw2trace_t for writing trace metadata: process/thread ids, timestamps, etc.
-   - Added #trace_metadata_reader_t, a set of utilities for checking and validating
+ - Generalization of the drcachesim #dynamorio::drmemtrace::raw2trace_t API (Issue #3129):
+   - Added #dynamorio::drmemtrace::module_mapper_t, which factors out the module mapping functionality
+     out of #dynamorio::drmemtrace::raw2trace_t, replacing the following #dynamorio::drmemtrace::raw2trace_t APIs:
+     #dynamorio::drmemtrace::raw2trace_t::handle_custom_data(), #dynamorio::drmemtrace::raw2trace_t::do_module_parsing(),
+     #dynamorio::drmemtrace::raw2trace_t::do_module_parsing_and_mapping(), and
+     #dynamorio::drmemtrace::raw2trace_t::find_mapped_trace_address().
+   - Added #dynamorio::drmemtrace::trace_metadata_writer_t, a set of utility functions used by drcachesim's
+     #dynamorio::drmemtrace::raw2trace_t for writing trace metadata: process/thread ids, timestamps, etc.
+   - Added #dynamorio::drmemtrace::trace_metadata_reader_t, a set of utilities for checking and validating
      thread start successions of offline entries in a raw data file.
    - Added trace_converter_t, an extensibility mechanism for raw trace conversion.
  - Added drmemtrace_get_timestamp_from_offline_trace(), an API for fetching the timestamp

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -343,14 +343,19 @@ add_dependencies(histogram_launcher api_headers)
 add_executable(prefetch_analyzer_launcher
   tests/prefetch_analyzer_launcher.cpp
   tests/prefetch_analyzer.cpp
+  tests/test_helpers.cpp
   )
 target_link_libraries(prefetch_analyzer_launcher drmemtrace_analyzer drfrontendlib)
+append_property_list(TARGET prefetch_analyzer_launcher
+  COMPILE_DEFINITIONS "NO_HELPER_MAIN")
 use_DynamoRIO_extension(prefetch_analyzer_launcher droption)
 add_dependencies(prefetch_analyzer_launcher api_headers)
 
 add_executable(record_filter_launcher
-  tools/record_filter_launcher.cpp)
+  tools/record_filter_launcher.cpp
+  tests/test_helpers.cpp)
 target_link_libraries(record_filter_launcher drmemtrace_analyzer drmemtrace_record_filter)
+append_property_list(TARGET record_filter_launcher COMPILE_DEFINITIONS "NO_HELPER_MAIN")
 use_DynamoRIO_extension(record_filter_launcher droption)
 
 # We want to use test_helper's disable_popups() but we have _tmain and so do not want
@@ -382,11 +387,13 @@ set_property(GLOBAL PROPERTY DynamoRIO_drmemtrace_build_dir
 if (NOT APPLE)
   add_executable(opcode_mix_launcher
     tools/opcode_mix_launcher.cpp
+    tests/test_helpers.cpp
     )
   # We hit dup symbol errors on Windows so we need libc earlier before DR:
   _DR_get_static_libc_list(static_libc)
   target_link_libraries(opcode_mix_launcher drmemtrace_analyzer drmemtrace_opcode_mix
     drmemtrace_raw2trace drcovlib_static drfrontendlib ${static_libc})
+  append_property_list(TARGET opcode_mix_launcher COMPILE_DEFINITIONS "NO_HELPER_MAIN")
   use_DynamoRIO_extension(opcode_mix_launcher droption)
   add_dependencies(opcode_mix_launcher api_headers)
   configure_DynamoRIO_static(opcode_mix_launcher)
@@ -959,7 +966,7 @@ if (BUILD_TESTS)
       configure_DynamoRIO_static(tool.drcacheoff.burst_futex)
       use_DynamoRIO_static_client(tool.drcacheoff.burst_futex drmemtrace_static)
       target_link_libraries(tool.drcacheoff.burst_futex drmemtrace_raw2trace
-        drmemtrace_analyzer)
+        drmemtrace_analyzer test_helpers)
       if (WIN32)
         # Just like for burst_replace, linking everything together takes effort.
         target_link_libraries(tool.drcacheoff.burst_futex ${static_libc})

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -49,6 +49,9 @@
 #include <string>
 #include <vector>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * The base class for a tool that analyzes a trace.  A new tool should subclass this
  * class.
@@ -457,9 +460,13 @@ protected:
     std::string error_string_;
 };
 
-/** See #analysis_tool_tmpl_t. */
+/** See #dynamorio::drmemtrace::analysis_tool_tmpl_t. */
 typedef analysis_tool_tmpl_t<memref_t> analysis_tool_t;
 
-/** See #analysis_tool_tmpl_t. */
+/** See #dynamorio::drmemtrace::analysis_tool_tmpl_t. */
 typedef analysis_tool_tmpl_t<trace_entry_t> record_analysis_tool_t;
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
 #endif /* _ANALYSIS_TOOL_H_ */

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -48,6 +48,9 @@
 #include "common/utils.h"
 #include "memtrace_stream.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifdef HAS_ZLIB
 // Even if the file is uncompressed, zlib's gzip interface is faster than
 // file_reader_t's fstream in our measurements, so we always use it when
@@ -783,3 +786,6 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_interval(
 
 template class analyzer_tmpl_t<memref_t, reader_t>;
 template class analyzer_tmpl_t<trace_entry_t, dynamorio::drmemtrace::record_reader_t>;
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -53,7 +53,8 @@
 #include "record_file_reader.h"
 #include "scheduler.h"
 
-using namespace dynamorio::drmemtrace;
+namespace dynamorio {
+namespace drmemtrace {
 
 /**
  * An analyzer is the top-level driver of a set of trace analysis tools.
@@ -61,22 +62,28 @@ using namespace dynamorio::drmemtrace;
  * trace and calls the process_memref() routine of each tool, or it exposes
  * an iteration interface to external control code.
  *
- * RecordType is the type of entry to be analyzed: #memref_t or #trace_entry_t.
- * ReaderType is the reader that allows reading entries of type T: #reader_t or
+ * RecordType is the type of entry to be analyzed: #dynamorio::drmemtrace::memref_t or
+ * #dynamorio::drmemtrace::trace_entry_t. ReaderType is the reader that allows reading
+ * entries of type T: #dynamorio::drmemtrace::reader_t or
  * #dynamorio::drmemtrace::record_reader_t respectively.
  *
- * #analyzer_tmpl_t<#memref_t, #reader_t> is the primary type of analyzer, which is used
- * for most purposes. It uses tools of type #analysis_tool_tmpl_t<#memref_t>. This
+ * #dynamorio::drmemtrace::analyzer_tmpl_t<#dynamorio::drmemtrace::memref_t,
+ * #dynamorio::drmemtrace::reader_t> is the primary type of analyzer, which is used for
+ * most purposes. It uses tools of type
+ * #dynamorio::drmemtrace::analysis_tool_tmpl_t<#dynamorio::drmemtrace::memref_t>. This
  * analyzer provides various features to support trace analysis, e.g. processing the
- * instruction encoding entries and making it available to the tool inside #memref_t.
+ * instruction encoding entries and making it available to the tool inside
+ * #dynamorio::drmemtrace::memref_t.
  *
- * #analyzer_tmpl_t<#trace_entry_t, #dynamorio::drmemtrace::record_reader_t> is used
- * in special cases where an offline trace needs to be observed exactly as stored on
- * disk, without hiding any internal entries. It uses tools of type
- * #analysis_tool_tmpl_t<#trace_entry_t>.
+ * #dynamorio::drmemtrace::analyzer_tmpl_t<#dynamorio::drmemtrace::trace_entry_t,
+ * #dynamorio::drmemtrace::record_reader_t> is used in special cases where an offline
+ * trace needs to be observed exactly as stored on disk, without hiding any internal
+ * entries. It uses tools of type
+ * #dynamorio::drmemtrace::analysis_tool_tmpl_t<#dynamorio::drmemtrace::trace_entry_t>.
  *
- * TODO i#5727: When we convert #reader_t into a template on RecordType, we can remove the
- * second template parameter to #analyzer_tmpl_t, and simply use reader_tmpl_t<RecordType>
+ * TODO i#5727: When we convert #dynamorio::drmemtrace::reader_t into a template on
+ * RecordType, we can remove the second template parameter to
+ * #dynamorio::drmemtrace::analyzer_tmpl_t, and simply use reader_tmpl_t<RecordType>
  * instead.
  */
 template <typename RecordType, typename ReaderType> class analyzer_tmpl_t {
@@ -318,10 +325,14 @@ private:
     serial_mode_supported();
 };
 
-/** See #analyzer_tmpl_t. */
+/** See #dynamorio::drmemtrace::analyzer_tmpl_t. */
 typedef analyzer_tmpl_t<memref_t, reader_t> analyzer_t;
 
-/** See #analyzer_tmpl_t. */
+/** See #dynamorio::drmemtrace::analyzer_tmpl_t. */
 typedef analyzer_tmpl_t<trace_entry_t, dynamorio::drmemtrace::record_reader_t>
     record_analyzer_t;
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
 #endif /* _ANALYZER_H_ */

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -59,6 +59,9 @@
 #include "tools/reuse_time_create.h"
 #include "tools/view_create.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 analyzer_multi_t::analyzer_multi_t()
 {
     worker_count_ = op_jobs.get_value();
@@ -446,3 +449,6 @@ analyzer_multi_t::get_cache_simulator_knobs()
     knobs->use_physical = op_use_physical.get_value();
     return knobs;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/analyzer_multi.h
+++ b/clients/drcachesim/analyzer_multi.h
@@ -40,6 +40,9 @@
 #include "analyzer.h"
 #include "simulator/cache_simulator_create.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class analyzer_multi_t : public analyzer_t {
 public:
     // Usage: errors encountered during the constructor will set a flag that should
@@ -78,5 +81,8 @@ protected:
 
     static const int max_num_tools_ = 8;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ANALYZER_MULTI_H_ */

--- a/clients/drcachesim/common/archive_istream.h
+++ b/clients/drcachesim/common/archive_istream.h
@@ -40,6 +40,9 @@
 
 #include <fstream>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class archive_istream_t : public std::istream {
 public:
     explicit archive_istream_t(std::basic_streambuf<char, std::char_traits<char>> *buf)
@@ -52,5 +55,8 @@ public:
     virtual std::string
     open_component(const std::string &name) = 0;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ARCHIVE_ISTREAM_H_ */

--- a/clients/drcachesim/common/archive_ostream.h
+++ b/clients/drcachesim/common/archive_ostream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,9 @@
 
 #include <fstream>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class archive_ostream_t : public std::ostream {
 public:
     explicit archive_ostream_t(std::basic_streambuf<char, std::char_traits<char>> *buf)
@@ -52,5 +55,8 @@ public:
     virtual std::string
     open_new_component(const std::string &name) = 0;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ARCHIVE_OSTREAM_H_ */

--- a/clients/drcachesim/common/crc32c.cpp
+++ b/clients/drcachesim/common/crc32c.cpp
@@ -1,5 +1,8 @@
 #include "crc32c.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /*
  * Copyright 2001, D. Otis.  Use this program, code or tables
  * extracted from it, as desired without restriction.
@@ -70,3 +73,6 @@ crc32c(const char *buf, const uint32_t len)
 
     return crc ^ 0xffffffff;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/crc32c.h
+++ b/clients/drcachesim/common/crc32c.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -30,10 +30,21 @@
  * DAMAGE.
  */
 
+#ifndef _CRC32_H_
+#define _CRC32_H_ 1
+
 #include <cstdint>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // Calculate the CRC32-C checksum for a buffer.
 // Note that this implements CRC32-C, which is a different variant from crc32() in
 // core/utils.h.
 uint32_t
 crc32c(const char *buf, const uint32_t len);
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _CRC32_H_ */

--- a/clients/drcachesim/common/directory_iterator.cpp
+++ b/clients/drcachesim/common/directory_iterator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -34,6 +34,9 @@
 #include "directory_iterator.h"
 #include "utils.h"
 #include "dr_frontend.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // Following typical stream iterator convention, the default constructor
 // produces an EOF object.
@@ -150,3 +153,6 @@ directory_iterator_t::create_directory(const std::string &path_in)
     }
     return drfront_create_dir(path.c_str()) == DRFRONT_SUCCESS;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/directory_iterator.h
+++ b/clients/drcachesim/common/directory_iterator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,6 +49,9 @@
 
 #include "utils.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // Iterates over files: skips sub-directories.
 // Returns the basenames of the files (i.e., not absolute paths).
 // This class is not thread-safe.
@@ -67,7 +70,8 @@ public:
         return error_descr_;
     }
 
-    virtual const std::string &operator*();
+    virtual const std::string &
+    operator*();
 
     // To avoid double-dispatch (requires listing all derived types in the base here)
     // and RTTI in trying to get the right operators called for subclasses, we
@@ -88,7 +92,8 @@ public:
     virtual directory_iterator_t &
     operator++();
 
-    virtual bool operator!()
+    virtual bool
+    operator!()
     {
         return at_eof_;
     }
@@ -116,5 +121,8 @@ private:
     struct dirent *ent_ = nullptr;
 #endif
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _DIRECTORY_ITERATOR_H_ */

--- a/clients/drcachesim/common/gzip_istream.h
+++ b/clients/drcachesim/common/gzip_istream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,9 @@
 #endif
 #include <fstream>
 #include <zlib.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 /* We need to override the stream buffer class which is where the file
  * reads happen.  The stream buffer base class reads from eback()..egptr()
@@ -110,5 +113,8 @@ public:
         delete rdbuf();
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _GZIP_ISTREAM_H_ */

--- a/clients/drcachesim/common/gzip_ostream.h
+++ b/clients/drcachesim/common/gzip_ostream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,9 @@
 #endif
 #include <fstream>
 #include <zlib.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 /* We need to override the stream buffer class which is where the file
  * writes happen.  We go ahead and use a simple buffer.  The stream
@@ -112,5 +115,8 @@ public:
         delete rdbuf();
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _GZIP_OSTREAM_H_ */

--- a/clients/drcachesim/common/lz4_istream.h
+++ b/clients/drcachesim/common/lz4_istream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,6 +44,9 @@
 #include <fstream>
 #include <lz4frame.h>
 #include <iostream>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 /* We need to override the stream buffer class which is where the file
  * reads happen.  The stream buffer base class reads from eback()..egptr()
@@ -142,5 +145,8 @@ public:
         delete rdbuf();
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _LZ4_ISTREAM_H_ */

--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,9 @@
  * @file drmemtrace/memref.h
  * @brief DrMemtrace trace entry structures.
  */
+
+namespace dynamorio {  /**< General DynamoRIO namespace. */
+namespace drmemtrace { /**< DrMemtrace tracing + simulation infrastructure namespace. */
 
 // On some platforms, like MacOS, a thread id is 64 bits.
 // We just make both 64 bits to cover all our bases.
@@ -139,5 +142,8 @@ typedef union _memref_t {
     struct _memref_thread_exit_t exit; /**< A thread exit. */
     struct _memref_marker_t marker;    /**< A marker holding metadata. */
 } memref_t;
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _MEMREF_H_ */

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -51,6 +51,9 @@
  * tools on the full stream of memory reference records.
  */
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * This is an interface for obtaining information from analysis tools
  * on the full stream of memory reference records.
@@ -62,9 +65,9 @@ public:
     {
     }
     /**
-     * Returns the count of #memref_t records from the start of the trace to this point.
-     * This includes records skipped over and not presented to any tool.
-     * It does not include synthetic records (see is_record_synthetic()).
+     * Returns the count of #dynamorio::drmemtrace::memref_t records from the start of the
+     * trace to this point. This includes records skipped over and not presented to any
+     * tool. It does not include synthetic records (see is_record_synthetic()).
      */
     virtual uint64_t
     get_record_ordinal() const = 0;
@@ -84,49 +87,54 @@ public:
     get_stream_name() const = 0;
 
     /**
-     * Returns the value of the most recently seen #TRACE_MARKER_TYPE_TIMESTAMP marker.
+     * Returns the value of the most recently seen
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
      */
     virtual uint64_t
     get_last_timestamp() const = 0;
 
     /**
-     * Returns the value of the first seen #TRACE_MARKER_TYPE_TIMESTAMP marker.
+     * Returns the value of the first seen
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
      */
     virtual uint64_t
     get_first_timestamp() const = 0;
 
     /**
-     * Returns the #trace_version_t value from the #TRACE_MARKER_TYPE_VERSION record
-     * in the trace header.
+     * Returns the #dynamorio::drmemtrace::trace_version_t value from the
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION record in the trace header.
      */
     virtual uint64_t
     get_version() const = 0;
 
     /**
-     * Returns the OFFLINE_FILE_TYPE_* bitfields of type #offline_file_type_t
-     * identifying the architecture and other key high-level attributes of the trace
-     * from the #TRACE_MARKER_TYPE_FILETYPE record in the trace header.
+     * Returns the OFFLINE_FILE_TYPE_* bitfields of type
+     * #dynamorio::drmemtrace::offline_file_type_t identifying the architecture and other
+     * key high-level attributes of the trace from the
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE record in the trace header.
      */
     virtual uint64_t
     get_filetype() const = 0;
 
     /**
-     * Returns the cache line size from the #TRACE_MARKER_TYPE_CACHE_LINE_SIZE record in
-     * the trace header.
+     * Returns the cache line size from the
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CACHE_LINE_SIZE record in the trace
+     * header.
      */
     virtual uint64_t
     get_cache_line_size() const = 0;
 
     /**
-     * Returns the chunk instruction count from the #TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT
-     * record in the trace header.
+     * Returns the chunk instruction count from the
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT record in the trace
+     * header.
      */
     virtual uint64_t
     get_chunk_instr_count() const = 0;
 
     /**
-     * Returns the page size from the #TRACE_MARKER_TYPE_PAGE_SIZE record in
-     * the trace header.
+     * Returns the page size from the #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PAGE_SIZE
+     * record in the trace header.
      */
     virtual uint64_t
     get_page_size() const = 0;
@@ -217,4 +225,8 @@ public:
 private:
     uint64_t *record_ordinal_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
 #endif /* _MEMTRACE_STREAM_H_ */

--- a/clients/drcachesim/common/named_pipe.h
+++ b/clients/drcachesim/common/named_pipe.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,15 +39,21 @@
 
 #include <string>
 #ifdef WINDOWS
+#    define WIN32_LEAN_AND_MEAN
+#    include <windows.h>
+#else
+#    include <unistd.h> // for ssize_t
+#endif
+
+namespace dynamorio {
+namespace drmemtrace {
+
+#ifdef WINDOWS
 #    ifdef X64
 typedef __int64 ssize_t;
 #    else
 typedef int ssize_t;
 #    endif
-#    define WIN32_LEAN_AND_MEAN
-#    include <windows.h>
-#else
-#    include <unistd.h> // for ssize_t
 #endif
 
 #ifndef OUT
@@ -122,5 +128,8 @@ private:
 #endif
     std::string pipe_name_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _NAMED_PIPE_H_ */

--- a/clients/drcachesim/common/named_pipe_unix.cpp
+++ b/clients/drcachesim/common/named_pipe_unix.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 #include <errno.h>
 #include <limits.h> /* for PIPE_BUF */
 #include "named_pipe.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // XXX: should read from /proc/sys/fs/pipe-max-size instead of hardcoding here.
 // This is the max size an unprivileged process can request.
@@ -223,3 +226,6 @@ named_pipe_t::get_atomic_write_size() const
 {
     return PIPE_BUF;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/named_pipe_win.cpp
+++ b/clients/drcachesim/common/named_pipe_win.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,6 +33,9 @@
 #include <string>
 #include <windows.h>
 #include "named_pipe.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 #define MAX_NAME_LEN 256 // From CreateNamedPipe docs.
 #define ALLOC_UNIT (64 * 1025)
@@ -169,3 +172,6 @@ named_pipe_t::get_atomic_write_size() const
     // FIXME i#1727: what's the atomic pipe write limit?
     return 512; // POSIX.1-2001 limit
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -37,6 +37,9 @@
 #include "droption.h"
 #include "options.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 droption_t<bool> op_offline(
     DROPTION_SCOPE_ALL, "offline", false, "Store trace files for offline analysis",
     "By default, traces are processed online, sent over a pipe to a simulator.  "
@@ -206,8 +209,8 @@ droption_t<bool> op_L0I_filter(
     "cache.  This cache is direct-mapped with size equal to L0I_size.  It uses virtual "
     "addresses regardless of -use_physical. The dynamic (pre-filtered) per-thread "
     "instruction count is tracked and supplied via a "
-    "#TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at thread buffer boundaries and at "
-    "thread exit.");
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at thread "
+    "buffer boundaries and at thread exit.");
 
 droption_t<bool> op_L0D_filter(
     DROPTION_SCOPE_CLIENT, "L0D_filter", false,
@@ -246,11 +249,12 @@ droption_t<bool> op_use_physical(
     "If available, metadata with virtual-to-physical-address translation information "
     "is added to the trace.  This is not possible from user mode on all platforms.  "
     "The regular trace entries remain virtual, with a pair of markers of "
-    "types #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS "
+    "types #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS "
     "inserted at some prior point for each new or changed page mapping to show the "
     "corresponding physical addresses.  If translation fails, a "
-    "#TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE is inserted. "
-    "This option may incur significant overhead "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE is "
+    "inserted. This option may incur significant overhead "
     "both for the physical translation and as it requires disabling optimizations."
     "For -offline, this option must be passed to both the tracer (to insert the "
     "markers) and the simulator (to use the markers).");
@@ -732,3 +736,6 @@ droption_t<bool> op_enable_kernel_tracing(
     "analysis. And this feature is available only on Intel CPUs that support Intel@ "
     "Processor Trace.");
 #endif
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -61,6 +61,9 @@
 #include <string>
 #include "droption.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 extern droption_t<bool> op_offline;
 extern droption_t<std::string> op_ipc_name;
 extern droption_t<std::string> op_outdir;
@@ -152,4 +155,7 @@ extern droption_t<bool> op_enable_drstatecmp;
 #ifdef BUILD_PT_TRACER
 extern droption_t<bool> op_enable_kernel_tracing;
 #endif
+} // namespace drmemtrace
+} // namespace dynamorio
+
 #endif /* _OPTIONS_H_ */

--- a/clients/drcachesim/common/snappy_consts.cpp
+++ b/clients/drcachesim/common/snappy_consts.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,7 +33,13 @@
 #include "snappy_consts.h"
 #include "crc32c.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 constexpr size_t snappy_consts_t::max_block_size_;
 constexpr size_t snappy_consts_t::max_compressed_size_;
 constexpr size_t snappy_consts_t::checksum_size_;
 constexpr char snappy_consts_t::magic_[];
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/snappy_consts.h
+++ b/clients/drcachesim/common/snappy_consts.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,6 +42,9 @@
 #include <cstddef>
 #include "crc32c.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class snappy_consts_t {
 protected:
     enum chunk_type_t : unsigned char {
@@ -79,5 +82,8 @@ protected:
     // Magic string identifying the snappy chunked format.
     static constexpr char magic_[] = "sNaPpY";
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SNAPPY_CONSTS_H_ */

--- a/clients/drcachesim/common/snappy_istream.h
+++ b/clients/drcachesim/common/snappy_istream.h
@@ -44,6 +44,9 @@
 #include <fstream>
 #include "../reader/snappy_file_reader.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /* We need to override the stream buffer class which is where the file
  * reads happen.  The stream buffer base class reads from eback()..egptr()
  * with the next to read at gptr().
@@ -107,5 +110,8 @@ public:
         delete rdbuf();
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SNAPPY_ISTREAM_H_ */

--- a/clients/drcachesim/common/trace_entry.cpp
+++ b/clients/drcachesim/common/trace_entry.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -31,6 +31,9 @@
  */
 
 #include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 const char *const trace_type_names[] = {
     "read",
@@ -82,3 +85,6 @@ const char *const trace_type_names[] = {
     "prefetch_write_l3_nt",
     "encoding",
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -51,37 +51,40 @@
  * @brief DrMemtrace trace entry enum types and definitions.
  */
 
+namespace dynamorio {
+namespace drmemtrace {
+
 typedef uintptr_t addr_t; /**< The type of a memory address. */
 
 /**
  * The version number of the trace format.
  * This is presented to analysis tools as a marker of type
- * #TRACE_MARKER_TYPE_VERSION.
+ * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION.
  */
 typedef enum {
     /**
-     * A prior version where #TRACE_MARKER_TYPE_KERNEL_EVENT provided the module
-     * offset (and nothing for restartable sequence aborts) rather than the absolute
-     * PC of the interruption point provided today.
+     * A prior version where #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT
+     * provided the module offset (and nothing for restartable sequence aborts) rather
+     * than the absolute PC of the interruption point provided today.
      */
     TRACE_ENTRY_VERSION_NO_KERNEL_PC = 2,
     /**
-     * #TRACE_MARKER_TYPE_KERNEL_EVENT records provide the absolute
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT records provide the absolute
      * PC of the interruption point.
      */
     TRACE_ENTRY_VERSION_KERNEL_PC = 3,
     /**
      * The trace supports embedded instruction encodings, but they are only present
-     * if #OFFLINE_FILE_TYPE_ENCODINGS is set.
+     * if #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_ENCODINGS is set.
      */
     TRACE_ENTRY_VERSION_ENCODINGS = 4,
     /** The latest version of the trace format. */
     TRACE_ENTRY_VERSION = TRACE_ENTRY_VERSION_ENCODINGS,
 } trace_version_t;
 
-/** The type of a trace entry in a #memref_t structure. */
+/** The type of a trace entry in a #dynamorio::drmemtrace::memref_t structure. */
 // The type identifier for trace entries in the raw trace_entry_t passed to
-// reader_t and the exposed #memref_t passed to analysis tools.
+// reader_t and the exposed #dynamorio::drmemtrace::memref_t passed to analysis tools.
 // XXX: if we want to rely on a recent C++ standard we could try to get
 // this enum to be just 2 bytes instead of an int and give it qualified names.
 // N.B.: when adding new values, be sure to update trace_type_names[].
@@ -178,7 +181,8 @@ typedef enum {
 
     /**
      * A marker containing metadata about this point in the trace.
-     * It includes a marker sub-type #trace_marker_type_t and a value.
+     * It includes a marker sub-type #dynamorio::drmemtrace::trace_marker_type_t and a
+     * value.
      */
     TRACE_TYPE_MARKER,
 
@@ -241,12 +245,12 @@ typedef enum {
      * The value of this marker contains the program counter at the kernel
      * interruption point.  If the interruption point is just after a branch, this
      * value is the target of that branch.
-     * (For trace version #TRACE_ENTRY_VERSION_NO_KERNEL_PC or below, the value is
-     * the module offset rather than the absolute program counter.)
+     * (For trace version #dynamorio::drmemtrace::TRACE_ENTRY_VERSION_NO_KERNEL_PC or
+     * below, the value is the module offset rather than the absolute program counter.)
      * The value is 0 for some types where this information is not available, namely
      * Windows callbacks.
      * A restartable sequence abort handler is further identified by a prior
-     * marker of type #TRACE_MARKER_TYPE_RSEQ_ABORT.
+     * marker of type #dynamorio::drmemtrace::TRACE_MARKER_TYPE_RSEQ_ABORT.
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT,
     /**
@@ -279,12 +283,13 @@ typedef enum {
      * the drmemtrace_get_funclist_path() function's documentation.
      *
      * This marker is also used to record parameter values for certain system calls such
-     * as for #OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS.  These use large identifiers equal to
-     * #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system call number (for 32-bit
-     * marker values just the bottom 16 bits of the system call number are added to the
-     * base).  These identifiers are not stored in the function list file
-     * (drmemtrace_get_funclist_path()).  The system call number used is the value
-     * passed to DynamoRIO's dr_register_pre_syscall_event() which is normalized to
+     * as for #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS.  These use
+     * large identifiers equal to
+     * #dynamorio::drmemtrace::func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system
+     * call number (for 32-bit marker values just the bottom 16 bits of the system call
+     * number are added to the base).  These identifiers are not stored in the function
+     * list file (drmemtrace_get_funclist_path()).  The system call number used is the
+     * value passed to DynamoRIO's dr_register_pre_syscall_event() which is normalized to
      * match SYS_ constants (see the dr_register_pre_syscall_event() documentation
      * regarding MacOS).
      */
@@ -294,15 +299,15 @@ typedef enum {
     /**
      * The marker value contains the return address of the just-entered
      * function, whose id is specified by the closest previous
-     * #TRACE_MARKER_TYPE_FUNC_ID marker entry.
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID marker entry.
      */
     TRACE_MARKER_TYPE_FUNC_RETADDR,
 
     /**
      * The marker value contains one argument value of the just-entered
      * function, whose id is specified by the closest previous
-     * #TRACE_MARKER_TYPE_FUNC_ID marker entry. The number of such entries
-     * for one function invocation is equal to the specified argument in
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID marker entry. The number of such
+     * entries for one function invocation is equal to the specified argument in
      * -record_function (or pre-defined functions in -record_heap_value if
      * -record_heap is specified).
      */
@@ -310,12 +315,13 @@ typedef enum {
 
     /**
      * The marker value contains the return value of the just-entered function,
-     * whose id is specified by the closest previous #TRACE_MARKER_TYPE_FUNC_ID
-     * marker entry
+     * whose id is specified by the closest previous
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID marker entry
      *
-     * The marker value for system calls (see #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE)
-     * is either 0 (failure) or 1 (success), as obtained from dr_syscall_get_result_ex()
-     * via the "succeeded" field of #dr_syscall_result_info_t.  See the corresponding
+     * The marker value for system calls (see
+     * #dynamorio::drmemtrace::func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) is either 0
+     * (failure) or 1 (success), as obtained from dr_syscall_get_result_ex() via the
+     * "succeeded" field of #dr_syscall_result_info_t.  See the corresponding
      * documentation for caveats about the accuracy of this value.
      */
     TRACE_MARKER_TYPE_FUNC_RETVAL,
@@ -331,8 +337,8 @@ typedef enum {
 
     /**
      * The marker value contains the OFFLINE_FILE_TYPE_* bitfields of type
-     * #offline_file_type_t identifying the architecture and other key high-level
-     * attributes of the trace.
+     * #dynamorio::drmemtrace::offline_file_type_t identifying the architecture and other
+     * key high-level attributes of the trace.
      */
     TRACE_MARKER_TYPE_FILETYPE,
 
@@ -351,19 +357,19 @@ typedef enum {
 
     /**
      * The marker value contains the version of the trace format: a value
-     * of type #trace_version_t.  The marker is present in the first few entries
-     * of a trace file.
+     * of type #dynamorio::drmemtrace::trace_version_t.  The marker is present in the
+     * first few entries of a trace file.
      */
     TRACE_MARKER_TYPE_VERSION,
 
     /**
-     * Serves to further identify #TRACE_MARKER_TYPE_KERNEL_EVENT as a
-     * restartable sequence abort handler.  This will always be immediately followed
-     * by #TRACE_MARKER_TYPE_KERNEL_EVENT.  The marker value for a signal that
-     * interrupted the instrumented execution is the precise interrupted PC, but
-     * for all other cases the value holds the continuation
-     * program counter, which is the restartable sequence abort handler.  (The precise
-     * interrupted point inside the sequence is not provided by the kernel.)
+     * Serves to further identify #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT
+     * as a restartable sequence abort handler.  This will always be immediately followed
+     * by #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT.  The marker value for a
+     * signal that interrupted the instrumented execution is the precise interrupted PC,
+     * but for all other cases the value holds the continuation program counter, which is
+     * the restartable sequence abort handler.  (The precise interrupted point inside the
+     * sequence is not provided by the kernel.)
      */
     TRACE_MARKER_TYPE_RSEQ_ABORT,
 
@@ -377,12 +383,13 @@ typedef enum {
 
     /**
      * The marker value contains the physical address corresponding to the subsequent
-     * #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS's virtual address.  A pair of such markers
-     * will appear somewhere prior to a regular instruction fetch or data load or store
-     * whose page's physical address has not yet been reported, or when a physical
-     * mapping change is detected.  If translation failed, a
-     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be present instead,
-     * without a corresponding #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS's virtual address.  A
+     * pair of such markers will appear somewhere prior to a regular instruction fetch or
+     * data load or store whose page's physical address has not yet been reported, or when
+     * a physical mapping change is detected.  If translation failed, a
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be
+     * present instead, without a corresponding
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
      */
     TRACE_MARKER_TYPE_PHYSICAL_ADDRESS,
 
@@ -394,12 +401,13 @@ typedef enum {
 
     /**
      * The marker value contains the virtual address corresponding to the prior
-     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS's physical address.  A pair of such markers
-     * will appear somewhere prior to a regular instruction fetch or data load or store
-     * whose page's physical address has not yet been reported, or when a physical
-     * mapping change is detected.  If translation failed, a
-     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be present instead,
-     * without a corresponding #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS's physical address.  A
+     * pair of such markers will appear somewhere prior to a regular instruction fetch or
+     * data load or store whose page's physical address has not yet been reported, or when
+     * a physical mapping change is detected.  If translation failed, a
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be
+     * present instead, without a corresponding
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
      */
     TRACE_MARKER_TYPE_VIRTUAL_ADDRESS,
 
@@ -427,7 +435,7 @@ typedef enum {
 
     /**
      * Marks the end of a chunk.  The final chunk does not have such a marker
-     * but instead relies on the #TRACE_TYPE_FOOTER entry.
+     * but instead relies on the #dynamorio::drmemtrace::TRACE_TYPE_FOOTER entry.
      */
     TRACE_MARKER_TYPE_CHUNK_FOOTER,
 
@@ -460,7 +468,7 @@ typedef enum {
      * This marker is emitted prior to each system call invocation, after the
      * instruction fetch entry for the system call gateway instruction from user mode. The
      * marker value contains the system call number.  If these markers are present, the
-     * file type #OFFLINE_FILE_TYPE_SYSCALL_NUMBERS is set.
+     * file type #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_SYSCALL_NUMBERS is set.
      */
     TRACE_MARKER_TYPE_SYSCALL,
 
@@ -473,7 +481,8 @@ typedef enum {
      * only for now).
      *
      * If these markers are present, the
-     * file type #OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS is set.  The marker value is 0.
+     * file type #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS is set.  The
+     * marker value is 0.
      */
     TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL,
 
@@ -498,11 +507,12 @@ typedef enum {
 enum class func_trace_t : uint64_t { // VS2019 won't infer 64-bit with "enum {".
 /**
  * When system call parameter and return values are provided, they use the function
- * tracing markers #TRACE_MARKER_TYPE_FUNC_ID, #TRACE_MARKER_TYPE_FUNC_ARG, and
- * #TRACE_MARKER_TYPE_FUNC_RETVAL.  The identifier used for
- * #TRACE_MARKER_TYPE_FUNC_ID is equal to this base value plus the 32-bit system
- * call number for 64-bit marker values or this base value plus the lower 16 bits
- * of the system call number for 32-bit marker values.
+ * tracing markers #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID,
+ * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, and
+ * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL.  The identifier used for
+ * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID is equal to this base value plus the
+ * 32-bit system call number for 64-bit marker values or this base value plus the lower 16
+ * bits of the system call number for 32-bit marker values.
  */
 #ifdef X64
     TRACE_FUNC_ID_SYSCALL_BASE = 0x100000000ULL,
@@ -598,8 +608,9 @@ marker_type_is_function_marker(const trace_marker_type_t mark)
 /**
  * This is the data format generated by the online tracer and produced after
  * post-processing of raw offline traces.
- * The #reader_t class transforms this into #memref_t before handing to analysis tools.
- * Each trace entry is a <type, size, addr> tuple representing:
+ * The #dynamorio::drmemtrace::reader_t class transforms this into
+ * #dynamorio::drmemtrace::memref_t before handing to analysis tools. Each trace entry is
+ * a <type, size, addr> tuple representing:
  * - a memory reference
  * - an instr fetch
  * - a bundle of instrs
@@ -625,7 +636,7 @@ struct _trace_entry_t {
     };
 } END_PACKED_STRUCTURE;
 
-/** See #_trace_entry_t. */
+/** See #dynamorio::drmemtrace::_trace_entry_t. */
 typedef struct _trace_entry_t trace_entry_t;
 
 ///////////////////////////////////////////////////////////////////////////
@@ -704,13 +715,15 @@ typedef enum {
  * Bitfields used to describe the high-level characteristics of both an
  * offline final trace and a raw not-yet-postprocessed trace, as well as
  * (despite the OFFLINE_ prefix) an online trace.
- * In a final trace these are stored in a marker of type #TRACE_MARKER_TYPE_FILETYPE.
+ * In a final trace these are stored in a marker of type
+ * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE.
  */
 typedef enum {
     OFFLINE_FILE_TYPE_DEFAULT = 0x00,
     /**
      * DEPRECATED: Addresses filtered online. Newer trace files use
-     * #OFFLINE_FILE_TYPE_IFILTERED and #OFFLINE_FILE_TYPE_DFILTERED.
+     * #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_IFILTERED and
+     * #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_DFILTERED.
      */
     OFFLINE_FILE_TYPE_FILTERED = 0x01,
     OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS = 0x02,
@@ -725,20 +738,22 @@ typedef enum {
     OFFLINE_FILE_TYPE_IFILTERED = 0x80,  /**< Instruction addresses filtered online. */
     OFFLINE_FILE_TYPE_DFILTERED = 0x100, /**< Data addresses filtered online. */
     OFFLINE_FILE_TYPE_ENCODINGS = 0x200, /**< Instruction encodings are included. */
-    /** System call number markers (#TRACE_MARKER_TYPE_SYSCALL) are included. */
+    /** System call number markers (#dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL) are
+       included. */
     OFFLINE_FILE_TYPE_SYSCALL_NUMBERS = 0x400,
     /**
      * Kernel scheduling information is included:
-     * #TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL markers and system call parameters
-     * and return values for kernel locks (SYS_futex on Linux) using the function tracing
-     * markers #TRACE_MARKER_TYPE_FUNC_ID, #TRACE_MARKER_TYPE_FUNC_ARG, and
-     * #TRACE_MARKER_TYPE_FUNC_RETVAL with an identifier equal to
-     * #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system call number (or its
-     * bottom 16 bits for 32-bit marker values).  These identifiers are not stored in
-     * the function list file (drmemtrace_get_funclist_path()).
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL markers and system
+     * call parameters and return values for kernel locks (SYS_futex on Linux) using the
+     * function tracing markers #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID,
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, and
+     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL with an identifier equal to
+     * #dynamorio::drmemtrace::func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system
+     * call number (or its bottom 16 bits for 32-bit marker values).  These identifiers
+     * are not stored in the function list file (drmemtrace_get_funclist_path()).
      *
-     * The #TRACE_MARKER_TYPE_FUNC_RETVAL for system calls is either 0 (failure) or
-     * 1 (success).
+     * The #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL for system calls is
+     * either 0 (failure) or 1 (success).
      */
     OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS = 0x800,
     /**
@@ -1077,5 +1092,8 @@ typedef enum {
  * from '/proc/kallsyms' during tracing.
  */
 #define DRMEMTRACE_KALLSYMS_FILENAME "kallsyms"
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _TRACE_ENTRY_H_ */

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -40,6 +40,9 @@
 #include <sstream>
 #include <string>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // XXX: DR should export this
 #define INVALID_THREAD_ID 0
 
@@ -162,5 +165,8 @@ starts_with(const std::string &str, const std::string &with)
         return false;
     return pos == 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _UTILS_H_ */

--- a/clients/drcachesim/common/zipfile_istream.h
+++ b/clients/drcachesim/common/zipfile_istream.h
@@ -46,6 +46,9 @@
 #include "minizip/unzip.h"
 #include "archive_istream.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /* We need to override the stream buffer class which is where the file
  * reads happen.  The stream buffer base class reads from eback()..egptr()
  * with the next to read at gptr().
@@ -159,5 +162,8 @@ public:
         return zbuf->open_component(name);
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ZIPFILE_ISTREAM_H_ */

--- a/clients/drcachesim/common/zipfile_ostream.h
+++ b/clients/drcachesim/common/zipfile_ostream.h
@@ -43,6 +43,9 @@
 #include <sstream>
 #include "minizip/zip.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // We need to override the stream buffer class which is where the file
 // writes happen.  We go ahead and use a simple buffer.  The stream
 // buffer base class writes to pbase()..epptr() with the next slot at
@@ -146,5 +149,8 @@ public:
         return zbuf->open_new_component(name);
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ZIPFILE_OSTREAM_H_ */

--- a/clients/drcachesim/common/zlib_istream.h
+++ b/clients/drcachesim/common/zlib_istream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,6 +44,9 @@
 #include <fstream>
 #include <zlib.h>
 #include <iostream>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 /* We need to override the stream buffer class which is where the file
  * reads happen.  The stream buffer base class reads from eback()..egptr()
@@ -140,5 +143,8 @@ public:
         delete rdbuf();
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ZLIB_ISTREAM_H_ */

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -94,26 +94,28 @@ devices for a target application (or multiple applications).
 and memory accesses during the traced window.
 
 A trace is presented to analysis tools as a stream of records.  Each
-record entry is of type #memref_t and represents one instruction or
-data reference or a metadata operation such as a thread exit or
-marker.  There are built-in scheduling markers providing the timestamp
-and cpu identifier on each thread transition.  Other built-in markers
-indicate disruptions in user mode control flow such as signal handler
-entry and exit.
+record entry is of type #dynamorio::drmemtrace::memref_t and
+represents one instruction or data reference or a metadata operation
+such as a thread exit or marker.  There are built-in scheduling
+markers providing the timestamp and cpu identifier on each thread
+transition.  Other built-in markers indicate disruptions in user mode
+control flow such as signal handler entry and exit.
 
 Each entry contains the common fields \p type, \p pid, and \p tid. The
 \p type field is used to identify the kind of each entry via a value
-of type #trace_marker_type_t.  The \p pid and \p tid identify the
-process and software thread owning the entry.  By default, all traced
-software threads are interleaved together, but with offline traces
-(see \ref sec_drcachesim_offline) each thread's trace can easily be
-analyzed separately as they are stored in separate files.
+of type #dynamorio::drmemtrace::trace_marker_type_t.  The \p pid and
+\p tid identify the process and software thread owning the entry.  By
+default, all traced software threads are interleaved together, but
+with offline traces (see \ref sec_drcachesim_offline) each thread's
+trace can easily be analyzed separately as they are stored in separate
+files.
 
 \section sec_drcachesim_format_instrs Instruction Records
 
-Executed instructions are stored in #_memref_instr_t.  The program
-counter and length of the encoded instruction are provided.  The
-length can be used to compute the address of the subsequent instruction.
+Executed instructions are stored in
+#dynamorio::drmemtrace::_memref_instr_t.  The program counter and
+length of the encoded instruction are provided.  The length can be
+used to compute the address of the subsequent instruction.
 
 The raw encoding of the instruction is provided.  This can be decoded
 using the drdecode decoder or any other decoder.  An additional field
@@ -133,51 +135,49 @@ copies of the binaries and reading the raw bytes for each instruction
 in order to obtain the opcode and full operand information.
 See also \ref sec_drcachesim_core.
 
-Branch targets are also not explicitly recorded (a design
-decision). The executed target as well as branch direction can be
-obtained by examining the address of the instruction immediately
-following a branch. If the program flow is changed by the kernel such
-as by signal delivery, the branch target is explicitly recorded in the
-trace in a metadata marker entry of type
-#TRACE_MARKER_TYPE_KERNEL_EVENT.
+Branch targets are also not explicitly recorded (a design decision). The executed target
+as well as branch direction can be obtained by examining the address of the instruction
+immediately following a branch. If the program flow is changed by the kernel such as by
+signal delivery, the branch target is explicitly recorded in the trace in a metadata
+marker entry of type #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT.
 
 \section sec_drcachesim_format_data Memory Access Records
 
-Memory accesses (data loads and stores) are stored in #_memref_data_t.
-The program counter of the instruction performing the memory access,
-the virtual address (convertable to physical: see \ref sec_drcachesim_phys), and
-the size are provided.
+Memory accesses (data loads and stores) are stored in
+#dynamorio::drmemtrace::_memref_data_t.  The program counter of the instruction
+performing the memory access, the virtual address (convertable to physical: see \ref
+sec_drcachesim_phys), and the size are provided.
 
 \section sec_drcachesim_format_other Other Records
 
-Besides instruction and memory records, other trace entry types
-include #_memref_marker_t, #_memref_flush_t, #_memref_thread_exit_t,
-etc. These records provide specific inforamtion about events that can
-alter the program flow or the system's states.
+Besides instruction and memory records, other trace entry types include
+#dynamorio::drmemtrace::_memref_marker_t, #dynamorio::drmemtrace::_memref_flush_t,
+#dynamorio::drmemtrace::_memref_thread_exit_t, etc. These records provide specific
+inforamtion about events that can alter the program flow or the system's states.
 
-Trace markers are particularly important to allow reconstruction of
-the program execution.  Marker records in #_memref_marker_t provide
-metadata identifying some event that occurred at this point in the
-trace.  Each marker record contains two additional fields:
+Trace markers are particularly important to allow reconstruction of the program
+execution.  Marker records in #dynamorio::drmemtrace::_memref_marker_t provide metadata
+identifying some event that occurred at this point in the trace.  Each marker record
+contains two additional fields:
 
 - \p marker_type - identifies the type of marker
 - \p marker_value - carries the value of the marker
 
 Some of the more important markers are:
 
-- #TRACE_MARKER_TYPE_KERNEL_EVENT - This identifies kernel-initiated control transfers such as signal delivery.  The next instruction record is the start of the handler for a kernel-initiated event.  The value of this type of marker contains the program counter at the kernel interruption point.  If the interruption point is just after a branch, this value is the target of that branch.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT - This identifies kernel-initiated control transfers such as signal delivery.  The next instruction record is the start of the handler for a kernel-initiated event.  The value of this type of marker contains the program counter at the kernel interruption point.  If the interruption point is just after a branch, this value is the target of that branch.
 
-- #TRACE_MARKER_TYPE_KERNEL_XFER - This identifies a system call that changes control flow, such as a signal return.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_XFER - This identifies a system call that changes control flow, such as a signal return.
 
-- #TRACE_MARKER_TYPE_TIMESTAMP - The marker value provides a timestamp for this point of the trace (in units of microseconds since Jan 1, 1601 UTC). This value can be used to synchronize records from different threads. It is used in the sequential analysis of a multi-threaded trace.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP - The marker value provides a timestamp for this point of the trace (in units of microseconds since Jan 1, 1601 UTC). This value can be used to synchronize records from different threads. It is used in the sequential analysis of a multi-threaded trace.
 
-- #TRACE_MARKER_TYPE_CPU_ID - The marker value contains the CPU identifier on which the subsequent records were collected. It is useful to help track thread migrations occurring during execution. This marker is written to the header of each trace buffer when the buffer is flushed. Note that if the thread migrates to a different CPU due to preemption by the kernel before a buffer is full, we do not output a separate #TRACE_MARKER_TYPE_CPU_ID marker to capture the previous CPU identifier. However, we expect such cases to be rare.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID - The marker value contains the CPU identifier on which the subsequent records were collected. It is useful to help track thread migrations occurring during execution. This marker is written to the header of each trace buffer when the buffer is flushed. Note that if the thread migrates to a different CPU due to preemption by the kernel before a buffer is full, we do not output a separate #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID marker to capture the previous CPU identifier. However, we expect such cases to be rare.
 
-- #TRACE_MARKER_TYPE_FUNC_ID, #TRACE_MARKER_TYPE_FUNC_RETADDR, #TRACE_MARKER_TYPE_FUNC_ARG, #TRACE_MARKER_TYPE_FUNC_RETVAL - These markers are used to capture information about function calls.  Which functions to capture must be explicitly selected at tracing time.  Typical candiates are heap allocation and freeing functions.  See \ref sec_drcachesim_funcs.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETADDR, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL - These markers are used to capture information about function calls.  Which functions to capture must be explicitly selected at tracing time.  Typical candiates are heap allocation and freeing functions.  See \ref sec_drcachesim_funcs.
 
-- #TRACE_MARKER_TYPE_WINDOW_ID - The marker value contains the ordinal of the trace burst window when the subsequent entries until the next #TRACE_MARKER_TYPE_WINDOW_ID or end-of-trace were collected (see \ref sec_drcachesim_partial).
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID - The marker value contains the ordinal of the trace burst window when the subsequent entries until the next #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID or end-of-trace were collected (see \ref sec_drcachesim_partial).
 
-The full set of markers is listed under the enum #trace_marker_type_t.
+The full set of markers is listed under the enum #dynamorio::drmemtrace::trace_marker_type_t.
 
 ****************************************************************************
 \page sec_drcachesim_run Running the Simulator
@@ -825,11 +825,11 @@ a trace for core simulation.
 
 \section sec_tool_syscall_mix System Call Mix
 
-The system call mix tool counts the frequency of system calls in a trace. It works
-for both online and offline traces. It uses the #TRACE_MARKER_TYPE_SYSCALL markers
-that store the system call number. This works only with traces that have these
-markers; that is, offline traces must have #OFFLINE_FILE_TYPE_SYSCALL_NUMBERS in
-their file type.
+The system call mix tool counts the frequency of system calls in a trace. It works for
+both online and offline traces. It uses the
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL markers that store the system call
+number. This works only with traces that have these markers; that is, offline traces
+must have #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_SYSCALL_NUMBERS in their file type.
 
 \code
 $ bin64/drrun -t drcachesim -indir drmemtrace.ls.*.dir -simulator_type syscall_mix
@@ -1117,7 +1117,7 @@ limited in several ways:
   produces a separate set of output files inside a window.NNNN subdirectory.
   Post-processing by default targets the first window; the others must be explicitly
   passed to separate post-processing invocations.  If \p -no_split_windows is set,
-  a single trace is created with #TRACE_MARKER_TYPE_WINDOW_ID
+  a single trace is created with #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID
   markers (see \ref sec_drcachesim_format_other) identifying the trace window
   transitions.
 - The \p -max_global_trace_refs option causes the recording of trace
@@ -1299,11 +1299,11 @@ http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ab676b
 
 When \p -use_physical is enabled, the regular trace entries remain
 virtual, with a pair of markers of types
-#TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and
-#TRACE_MARKER_TYPE_VIRTUAL_ADDRESS inserted at some prior point for
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS and
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS inserted at some prior point for
 each new page mapping to show the corresponding physical
 addresses.  If translation fails, a
-#TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE is inserted.
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE is inserted.
 Limited support for detecting changes in page mappings is provided via
 the \p -virt2phys_freq option to periodically clear cached
 translations.
@@ -1344,8 +1344,9 @@ does not hold when a kernel event such as a signal is delivered
 immediately after a branch; however, each marker indicating such a kernel transfer
 includes the interrupted PC, explicitly providing the branch target.
 
-Filtered traces (filtered via -L0_filter) include the dynamic (pre-filtered)
-per-thread instruction count in a #TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at
+Filtered traces (filtered via -L0_filter) include the dynamic
+(pre-filtered) per-thread instruction count in a
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at
 each thread buffer boundary and at thread exit.
 
 ****************************************************************************
@@ -1386,8 +1387,8 @@ drmemtrace_client_main().
 The tracer also supports storing custom data with each module (i.e.,
 library or executable) such as a build identifier via
 drmemtrace_custom_module_data().  The custom data may be retrieved by
-creating a custom offline trace post-processor and using the #module_mapper_t
-class.
+creating a custom offline trace post-processor and using the
+#dynamorio::drmemtrace::module_mapper_t class.
 
 ****************************************************************************
 \page sec_drcachesim_funcs Tracing Function Calls
@@ -1419,7 +1420,7 @@ paramter controls the contents of this set.
 
 \p drcachesim provides a \p drmemtrace analysis tool framework to make it
 easy to create new trace analysis tools.  A new tool should subclass
-#analysis_tool_t.
+#dynamorio::drmemtrace::analysis_tool_t.
 
 Concurrent processing of traces is supported by logically splitting a trace into
 "shards" which are each processed sequentially.  The default shard is a traced
@@ -1435,12 +1436,12 @@ entries from any one shard are processed by the same single worker thread, so no
 synchronization is needed inside the parallel_ functions.  A single worker thread
 invokes print_results() as well.
 
-For serial operation, process_memref(), operates on a trace entry in a single,
-sorted, interleaved stream of trace entries.  In the default mode of operation,
-the #analyzer_t class iterates over the trace and calls the process_memref()
-function of each tool.  An alternative mode is supported which exposes the
-iterator and allows a separate control infrastructure to be built.  This
-alternative mode does not support parallel operation at this time.
+For serial operation, process_memref(), operates on a trace entry in a single, sorted,
+interleaved stream of trace entries.  In the default mode of operation, the
+#dynamorio::drmemtrace::analyzer_t class iterates over the trace and calls the
+process_memref() function of each tool.  An alternative mode is supported which exposes
+the iterator and allows a separate control infrastructure to be built.  This alternative
+mode does not support parallel operation at this time.
 
 Both parallel and serial operation can be supported by a tool, typically by having
 process_memref() create data on a newly seen traced thread and invoking
@@ -1452,29 +1453,29 @@ present the results of the analysis.  For parallel operation, any desired
 aggregation across the whole trace should occur here as well, while shard-specific
 results can be presented in parallel_shard_exit().
 
-Tools can also perform trace analysis by intervals, e.g. to generate a time series
-of their results, using the \p -interval_microseconds option. The
-generate_interval_snapshot() API allows the tool to create a snapshot of its
-internal state when a trace interval ends. These snapshots are then passed to the
-tool in a later print_interval_results() API call where the tool can generate and
-print results for each trace interval. The length of a trace interval is defined by
-the \p -interval_microseconds option, measured using the #TRACE_MARKER_TYPE_TIMESTAMP
-marker values. Trace interval analysis is supported also for the parallel mode where
-the tool implements generate_shard_interval_snapshot() to generate a snapshot for
-shard-local intervals and the framework automatically combines the shard-local
-interval snapshots to create the whole-trace interval snapshots, using the
-tool's combine_interval_snapshots() API.
+Tools can also perform trace analysis by intervals, e.g. to generate a time series of
+their results, using the \p -interval_microseconds option. The
+generate_interval_snapshot() API allows the tool to create a snapshot of its internal
+state when a trace interval ends. These snapshots are then passed to the tool in a later
+print_interval_results() API call where the tool can generate and print results for each
+trace interval. The length of a trace interval is defined by the \p
+-interval_microseconds option, measured using the
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker values. Trace interval
+analysis is supported also for the parallel mode where the tool implements
+generate_shard_interval_snapshot() to generate a snapshot for shard-local intervals and
+the framework automatically combines the shard-local interval snapshots to create the
+whole-trace interval snapshots, using the tool's combine_interval_snapshots() API.
 
 Today, parallel analysis is only supported for offline traces.
 Support for online traces may be added in the future.
 
-In the default mode of operation, the #analyzer_t class iterates over
-the trace and calls the appropriate #analysis_tool_t functions for
-each tool.  An alternative mode is supported which exposes the
-iterator and allows a separate control infrastructure to be built.
+In the default mode of operation, the #dynamorio::drmemtrace::analyzer_t class iterates
+over the trace and calls the appropriate #dynamorio::drmemtrace::analysis_tool_t
+functions for each tool.  An alternative mode is supported which exposes the iterator
+and allows a separate control infrastructure to be built.
 
 As explained in \ref sec_drcachesim_format, each trace entry is of
-type #memref_t and represents one instruction or data reference or a
+type #dynamorio::drmemtrace::memref_t and represents one instruction or data reference or a
 metadata operation such as a thread exit or marker.  There are
 built-in scheduling markers providing the timestamp and cpu identifier
 on each thread transition.  Other built-in markers indicate
@@ -1482,7 +1483,7 @@ disruptions in user mode control flow such as signal handler entry and
 exit.
 
 The absolute ordinals for trace records and instruction fetches are
-available via the #memtrace_stream_t interface passed to the
+available via the #dynamorio::drmemtrace::memtrace_stream_t interface passed to the
 initialize_stream() function for serial operation and
 parallel_shard_init_stream() for parallel operation.  If the iterator
 skips over some records that are not passed to the tools, these
@@ -1491,10 +1492,12 @@ count only those records or instructions that it sees, it can add its
 own counters.
 
 In some cases, a tool may want to observe the exact sequence of
-#trace_entry_t in an offline trace stored on disk. To support such use cases,
-the #trace_entry_t specialization of #analysis_tool_tmpl_t and
-#analyzer_tmpl_t can be used. Specifically, such tools should subclass
-#record_analysis_tool_t, and use the #record_analyzer_t class.
+#dynamorio::drmemtrace::trace_entry_t in an offline trace stored on disk. To support
+such use cases, the #dynamorio::drmemtrace::trace_entry_t specialization of
+#dynamorio::drmemtrace::analysis_tool_tmpl_t and #dynamorio::drmemtrace::analyzer_tmpl_t
+can be used. Specifically, such tools should subclass
+#dynamorio::drmemtrace::record_analysis_tool_t, and use the
+#dynamorio::drmemtrace::record_analyzer_t class.
 
 CMake support is provided for including the headers and linking the
 libraries of the \p drmemtrace framework.  A new CMake function is defined

--- a/clients/drcachesim/drpt2trace/drir.h
+++ b/clients/drcachesim/drpt2trace/drir.h
@@ -39,6 +39,9 @@
 #include "dr_api.h"
 #include "../common/utils.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class drir_t {
 public:
     drir_t(void *drcontext)
@@ -85,5 +88,8 @@ private:
     void *drcontext_;
     instrlist_t *ilist_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _DRIR_H_ */

--- a/clients/drcachesim/drpt2trace/drpt2trace.cpp
+++ b/clients/drcachesim/drpt2trace/drpt2trace.cpp
@@ -52,6 +52,9 @@
 #include "ir2trace.h"
 #include "trace_entry.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define CLIENT_NAME "drpt2trace"
 #define SUCCESS 0
 #define FAILURE 1
@@ -385,6 +388,9 @@ load_file(IN const std::string &path, OUT std::vector<uint8_t> &buffer)
         }                                                           \
     } while (0)
 
+} // namespace drmemtrace
+} // namespace dynamorio
+
 /****************************************************************************
  * Main Function
  */
@@ -392,6 +398,8 @@ load_file(IN const std::string &path, OUT std::vector<uint8_t> &buffer)
 int
 main(int argc, const char *argv[])
 {
+    using namespace dynamorio::drmemtrace;
+
     /* Parse the command line. */
     if (!option_init(argc, argv)) {
         return FAILURE;

--- a/clients/drcachesim/drpt2trace/elf_loader.cpp
+++ b/clients/drcachesim/drpt2trace/elf_loader.cpp
@@ -36,6 +36,9 @@
 #include "elf_loader.h"
 #include "intel-pt.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define ERRMSG_HEADER "[elf_loader] "
 
 bool
@@ -169,3 +172,6 @@ elf_loader_t::load_section(IN const char *name, IN uint64_t offset, IN uint64_t 
     }
     return errcode == 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/drpt2trace/elf_loader.h
+++ b/clients/drcachesim/drpt2trace/elf_loader.h
@@ -44,6 +44,13 @@
 #include <fstream>
 #include <vector>
 
+// libipt global types.
+struct pt_image;
+struct pt_image_section_cache;
+
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifndef IN
 #    define IN // nothing
 #endif
@@ -95,5 +102,8 @@ private:
                  IN uint64_t vaddr, INOUT struct pt_image_section_cache *iscache,
                  INOUT struct pt_image *image);
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ELF_LOADER_H_ */

--- a/clients/drcachesim/drpt2trace/ir2trace.cpp
+++ b/clients/drcachesim/drpt2trace/ir2trace.cpp
@@ -33,6 +33,9 @@
 #include "ir2trace.h"
 #include "dr_api.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #undef VPRINT_HEADER
 #define VPRINT_HEADER()                  \
     do {                                 \
@@ -48,6 +51,8 @@
             fflush(stderr);               \
         }                                 \
     } while (0)
+
+#define ERRMSG_HEADER "[drpt2ir] "
 
 ir2trace_convert_status_t
 ir2trace_t::convert(IN drir_t &drir, INOUT std::vector<trace_entry_t> &trace,
@@ -98,3 +103,6 @@ ir2trace_t::convert(IN drir_t &drir, INOUT std::vector<trace_entry_t> &trace,
     }
     return IR2TRACE_CONV_SUCCESS;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/drpt2trace/ir2trace.h
+++ b/clients/drcachesim/drpt2trace/ir2trace.h
@@ -46,6 +46,9 @@
 #include "drir.h"
 #include "../common/trace_entry.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifndef IN
 #    define IN // nothing
 #endif
@@ -92,5 +95,8 @@ public:
     convert(IN drir_t &drir, INOUT std::vector<trace_entry_t> &trace,
             IN int verbosity = 0);
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _IR2TRACE_H_ */

--- a/clients/drcachesim/drpt2trace/pt2ir.cpp
+++ b/clients/drcachesim/drpt2trace/pt2ir.cpp
@@ -43,6 +43,9 @@
 #include "elf_loader.h"
 #include "pt2ir.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #undef VPRINT_HEADER
 #define VPRINT_HEADER()               \
     do {                              \
@@ -73,6 +76,8 @@ pt_iscache_autoclean_t::~pt_iscache_autoclean_t()
 }
 
 pt_iscache_autoclean_t pt2ir_t::share_iscache_;
+
+#define ERRMSG_HEADER "[drpt2ir] "
 
 pt2ir_t::pt2ir_t()
     : pt2ir_initialized_(false)
@@ -431,3 +436,6 @@ pt2ir_t::dx_decoding_error(IN int errcode, IN const char *errtype, IN uint64_t i
                ip, errtype, pt_errstr(pt_errcode(errcode)));
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/drpt2trace/pt2ir.h
+++ b/clients/drcachesim/drpt2trace/pt2ir.h
@@ -63,6 +63,7 @@
 #    define INOUT // nothing
 #endif
 
+// libipt global types.
 struct pt_config;
 struct pt_image;
 struct pt_image_section_cache;
@@ -70,6 +71,9 @@ struct pt_sb_pevent_config;
 struct pt_sb_session;
 struct pt_insn_decoder;
 struct pt_packet_decoder;
+
+namespace dynamorio {
+namespace drmemtrace {
 
 /**
  * The auto cleanup wrapper of struct pt_image_section_cache.
@@ -400,5 +404,8 @@ private:
     /* Integer value representing the verbosity level for notifications. */
     int verbosity_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _PT2IR_H_ */

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -59,6 +59,10 @@
 #include "droption.h"
 #include "common/options.h"
 #include "common/utils.h"
+
+using namespace dynamorio::drmemtrace;
+
+namespace {
 
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
@@ -190,6 +194,8 @@ configure_application(char *app_name, char **app_argv, std::string tracer_ops,
     }
     return true;
 }
+
+} // namespace
 
 int
 _tmain(int argc, const TCHAR *targv[])

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -32,7 +32,8 @@
 
 #include "compressed_file_reader.h"
 
-namespace {
+namespace dynamorio {
+namespace drmemtrace {
 
 /**************************************************************************
  * Common logic used in the gzip_reader_t specializations for file_reader_t
@@ -65,8 +66,6 @@ read_next_entry_common(gzip_reader_t *gzip, bool *eof)
     ++gzip->cur_buf;
     return res;
 }
-
-} // namespace
 
 /**************************************************
  * gzip_reader_t specializations for file_reader_t.
@@ -118,9 +117,6 @@ file_reader_t<gzip_reader_t>::read_next_entry()
     entry_copy_ = *entry;
     return &entry_copy_;
 }
-
-namespace dynamorio {
-namespace drmemtrace {
 
 /*********************************************************
  * gzip_reader_t specializations for record_file_reader_t.

--- a/clients/drcachesim/reader/compressed_file_reader.h
+++ b/clients/drcachesim/reader/compressed_file_reader.h
@@ -39,6 +39,9 @@
 #include "file_reader.h"
 #include "record_file_reader.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 struct gzip_reader_t {
     gzip_reader_t()
         : file(nullptr) {};
@@ -60,5 +63,8 @@ struct gzip_reader_t {
 typedef file_reader_t<gzip_reader_t> compressed_file_reader_t;
 typedef dynamorio::drmemtrace::record_file_reader_t<gzip_reader_t>
     compressed_record_file_reader_t;
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _COMPRESSED_FILE_READER_H_ */

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, LLC  All rights reserved.
+ * Copyright (c) 2018-2023 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,7 +33,9 @@
 #include "config_reader.h"
 
 #include <iostream>
-using namespace std;
+
+namespace dynamorio {
+namespace drmemtrace {
 
 config_reader_t::config_reader_t()
 {
@@ -50,7 +52,7 @@ config_reader_t::configure(std::istream *config_file, cache_simulator_knobs_t &k
     while (!fin_->eof()) {
         std::string param;
 
-        if (!(*fin_ >> ws >> param)) {
+        if (!(*fin_ >> std::ws >> param)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
@@ -167,7 +169,7 @@ config_reader_t::configure(std::istream *config_file, cache_simulator_knobs_t &k
             caches[cache.name] = cache;
         }
 
-        if (!(*fin_ >> ws)) {
+        if (!(*fin_ >> std::ws)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
@@ -184,7 +186,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
     std::string error_msg;
 
     char c;
-    if (!(*fin_ >> ws >> c)) {
+    if (!(*fin_ >> std::ws >> c)) {
         ERRMSG("Unable to read from the configuration file\n");
         return false;
     }
@@ -195,7 +197,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
 
     while (!fin_->eof()) {
         std::string param;
-        if (!(*fin_ >> ws >> param)) {
+        if (!(*fin_ >> std::ws >> param)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
@@ -316,7 +318,7 @@ config_reader_t::configure_cache(cache_params_t &cache)
             return false;
         }
 
-        if (!(*fin_ >> ws)) {
+        if (!(*fin_ >> std::ws)) {
             ERRMSG("Unable to read from the configuration file\n");
             return false;
         }
@@ -437,3 +439,6 @@ config_reader_t::convert_string_to_size(const std::string &s, uint64_t &size)
     }
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, LLC  All rights reserved.
+ * Copyright (c) 2018-2023 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -45,7 +45,8 @@
 #include "../simulator/cache.h"
 #include "../simulator/cache_simulator_create.h"
 
-using namespace std;
+namespace dynamorio {
+namespace drmemtrace {
 
 // Cache configuration settings.
 struct cache_params_t {
@@ -115,5 +116,8 @@ private:
         return false;
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CONFIG_READER_H_ */

--- a/clients/drcachesim/reader/file_reader.cpp
+++ b/clients/drcachesim/reader/file_reader.cpp
@@ -33,6 +33,9 @@
 #include <fstream>
 #include "file_reader.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /* clang-format off */ /* (make vera++ newline-after-type check happy) */
 template <>
 /* clang-format on */
@@ -79,3 +82,6 @@ file_reader_t<std::ifstream *>::read_next_entry()
            entry_copy_.addr);
     return &entry_copy_;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -49,6 +49,9 @@
 #include "trace_entry.h"
 #include "utils.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifndef ZHEX64_FORMAT_STRING
 /* We avoid dr_defines.h to keep this code separated and simpler for using with
  * external code.
@@ -174,5 +177,8 @@ protected:
 private:
     std::string input_path_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _FILE_READER_H_ */

--- a/clients/drcachesim/reader/ipc_reader.cpp
+++ b/clients/drcachesim/reader/ipc_reader.cpp
@@ -36,6 +36,9 @@
 #include "../common/memref.h"
 #include "../common/utils.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifdef VERBOSE
 #    include <iostream>
 #endif
@@ -119,3 +122,6 @@ ipc_reader_t::read_next_entry()
         at_eof_ = true;
     return cur_buf_;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/reader/ipc_reader.h
+++ b/clients/drcachesim/reader/ipc_reader.h
@@ -43,6 +43,9 @@
 #include "../common/named_pipe.h"
 #include "../common/trace_entry.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class ipc_reader_t : public reader_t {
 public:
     ipc_reader_t();
@@ -73,5 +76,8 @@ private:
     trace_entry_t *cur_buf_;
     trace_entry_t *end_buf_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _IPC_READER_H_ */

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -37,6 +37,9 @@
 #include "../common/memref.h"
 #include "../common/utils.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // Work around clang-format bug: no newline after return type for single-char operator.
 // clang-format off
 const memref_t &
@@ -477,3 +480,6 @@ reader_t::skip_instructions_with_timestamp(uint64_t stop_instruction_count)
     }
     return *this;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -47,6 +47,9 @@
 #include "memtrace_stream.h"
 #include "utils.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define OUT /* just a marker */
 
 #ifdef DEBUG
@@ -62,10 +65,10 @@
 #endif
 
 /**
- * Iterator over #memref_t trace entries. This class converts a trace
- * (offline or online) into a stream of #memref_t entries. It also
- * provides more information about the trace using the
- * #memtrace_stream_t API.
+ * Iterator over #dynamorio::drmemtrace::memref_t trace entries. This class converts a
+ * trace (offline or online) into a stream of #dynamorio::drmemtrace::memref_t entries. It
+ * also provides more information about the trace using the
+ * #dynamorio::drmemtrace::memtrace_stream_t API.
  */
 class reader_t : public std::iterator<std::input_iterator_tag, memref_t>,
                  public memtrace_stream_t {
@@ -260,5 +263,8 @@ private:
     encoding_info_t last_encoding_;
     std::unordered_map<addr_t, encoding_info_t> encodings_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _READER_H_ */

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -67,17 +67,20 @@ namespace dynamorio {
 namespace drmemtrace {
 
 /**
- * Trace reader that provides the stream of #trace_entry_t exactly as present
- * in an offline trace stored on disk. The public API is similar to #reader_t,
- * except that it is an iterator over #trace_entry_t entries instead of #memref_t.
- * This does not yet support iteration over a serialized stream of multiple traces.
+ * Trace reader that provides the stream of #dynamorio::drmemtrace::trace_entry_t exactly
+ * as present in an offline trace stored on disk. The public API is similar to
+ * #dynamorio::drmemtrace::reader_t, except that it is an iterator over
+ * #dynamorio::drmemtrace::trace_entry_t entries instead of
+ * #dynamorio::drmemtrace::memref_t. This does not yet support iteration over a serialized
+ * stream of multiple traces.
  *
- * TODO i#5727: Convert #reader_t and file_reader_t into templates:
+ * TODO i#5727: Convert #dynamorio::drmemtrace::reader_t and file_reader_t into templates:
  * `reader_tmpl_t<RecordType>` and file_reader_tmpl_t<T, RecordType> where T is one of
  * gzip_reader_t, zipfile_reader_t, snappy_reader_t, std::ifstream*, and RecordType is one
- * of #memref_t, #trace_entry_t. Then, typedef the #trace_entry_t specializations as
- * record_reader_t and record_file_reader_t<T> respectively. This will allow significant
- * code reuse, particularly for serializing multiple thread traces into a single stream.
+ * of #dynamorio::drmemtrace::memref_t, #dynamorio::drmemtrace::trace_entry_t. Then,
+ * typedef the #dynamorio::drmemtrace::trace_entry_t specializations as record_reader_t
+ * and record_file_reader_t<T> respectively. This will allow significant code reuse,
+ * particularly for serializing multiple thread traces into a single stream.
  *
  * Since the current file_reader_t is already a template on T, adding the second template
  * parameter RecordType is complex. Note that we cannot have partial specialization of
@@ -87,9 +90,9 @@ namespace drmemtrace {
  *
  * We have two options:
  * 1. For each member function specialized for some T, duplicate the definition for
- *    file_reader_tmpl_t<T, #memref_t> and file_reader_tmpl_t<T, trace_entry_t>. This has
- *    the obvious disadvantage of code duplication, which can be mitigated to some
- *    extent by extracting common logic in static routines.
+ *    file_reader_tmpl_t<T, #dynamorio::drmemtrace::memref_t> and file_reader_tmpl_t<T,
+ * trace_entry_t>. This has the obvious disadvantage of code duplication, which can be
+ * mitigated to some extent by extracting common logic in static routines.
  * 2. For each specialization of T, create a subclass templatized on RecordType that
  *    inherits from file_reader_tmpl_t<_, RecordType>. E.g. for T = gzip_reader_t, create
  *    `class gzip_file_reader_t<RecordType>: public file_reader_tmpl_t<gzip_reader_t,
@@ -101,11 +104,12 @@ namespace drmemtrace {
  * We prefer Option 2, since it has higher merit.
  *
  * Currently we do not have any use-case that needs this design, but when we need to
- * support serial iteration over #trace_entry_t, we would want to do this to reuse the
- * existing multiple trace serialization code in file_reader_t. file_reader_t hides
- * some #trace_entry_t entries today (like TRACE_TYPE_THREAD, TRACE_TYPE_PID, etc); we
- * would also need to avoid doing that since record_reader_t is expected to provide
- * the exact stream of #trace_entry_t as stored on disk.
+ * support serial iteration over #dynamorio::drmemtrace::trace_entry_t, we would want to
+ * do this to reuse the existing multiple trace serialization code in file_reader_t.
+ * file_reader_t hides some #dynamorio::drmemtrace::trace_entry_t entries today (like
+ * TRACE_TYPE_THREAD, TRACE_TYPE_PID, etc); we would also need to avoid doing that since
+ * record_reader_t is expected to provide the exact stream of
+ * #dynamorio::drmemtrace::trace_entry_t as stored on disk.
  */
 class record_reader_t : public std::iterator<std::input_iterator_tag, trace_entry_t>,
                         public memtrace_stream_t {

--- a/clients/drcachesim/reader/snappy_file_reader.cpp
+++ b/clients/drcachesim/reader/snappy_file_reader.cpp
@@ -32,6 +32,9 @@
 
 #include "snappy_file_reader.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 snappy_reader_t::snappy_reader_t(std::ifstream *stream)
     : fstream_(stream)
     , uncompressed_buf_(max_block_size_ + checksum_size_)
@@ -240,3 +243,6 @@ file_reader_t<snappy_reader_t>::read_next_entry()
            entry_copy_.addr);
     return &entry_copy_;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/reader/snappy_file_reader.h
+++ b/clients/drcachesim/reader/snappy_file_reader.h
@@ -43,11 +43,13 @@
 #include <memory>
 #include <string>
 #include <vector>
-
 #include <snappy.h>
 #include <snappy-sinksource.h>
 #include "snappy_consts.h"
 #include "file_reader.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 class snappy_reader_t : snappy_consts_t {
 public:
@@ -95,5 +97,8 @@ private:
 };
 
 typedef file_reader_t<snappy_reader_t> snappy_file_reader_t;
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SNAPPY_FILE_READER_H_ */

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -33,6 +33,9 @@
 #include "zipfile_file_reader.h"
 #include <inttypes.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // We use minizip, which is in the contrib/minizip directory in the zlib
 // sources.  The docs are the header files:
 // https://github.com/madler/zlib/blob/master/contrib/minizip/unzip.h
@@ -194,3 +197,6 @@ file_reader_t<zipfile_reader_t>::skip_instructions(uint64_t instruction_count)
     // Subtract 1 to pass the target instr itself.
     return skip_instructions_with_timestamp(stop_count - 1);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/reader/zipfile_file_reader.h
+++ b/clients/drcachesim/reader/zipfile_file_reader.h
@@ -39,6 +39,9 @@
 #include "minizip/unzip.h"
 #include "file_reader.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 struct zipfile_reader_t {
     zipfile_reader_t()
         : file(nullptr)
@@ -65,5 +68,8 @@ typedef file_reader_t<zipfile_reader_t> zipfile_file_reader_t;
 template <>
 reader_t &
 file_reader_t<zipfile_reader_t>::skip_instructions(uint64_t instruction_count);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _ZIPFILE_FILE_READER_H_ */

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -67,8 +67,9 @@ namespace drmemtrace {
  * Takes in a set of recorded traces and maps them onto a new set of output
  * streams, typically representing simulated cpus.
  *
- * This is a templated class to support not just operating over #memref_t inputs
- * read by #reader_t, but also over #trace_entry_t records read by
+ * This is a templated class to support not just operating over
+ * #dynamorio::drmemtrace::memref_t inputs read by #dynamorio::drmemtrace::reader_t, but
+ * also over #dynamorio::drmemtrace::trace_entry_t records read by
  * #dynamorio::drmemtrace::record_reader_t.
  */
 template <typename RecordType, typename ReaderType> class scheduler_tmpl_t {
@@ -192,10 +193,10 @@ public:
         /**
          * If non-empty, all input records outside of these ranges are skipped: it is as
          * though the input were constructed by concatenating these ranges together.  A
-         * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between ranges (with a value
-         * equal to the range ordinal) to notify the client of the discontinuity (but
-         * not before the first range).  These ranges must be non-overlapping and in
-         * increasing order.
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
+         * ranges (with a value equal to the range ordinal) to notify the client of the
+         * discontinuity (but not before the first range).  These ranges must be
+         * non-overlapping and in increasing order.
          */
         std::vector<range_t> regions_of_interest;
     };
@@ -504,8 +505,8 @@ public:
     /**
      * Represents a stream of RecordType trace records derived from a
      * subset of a set of input recorded traces.  Provides more
-     * information about the record stream using the #memtrace_stream_t
-     * API.
+     * information about the record stream using the
+     * #dynamorio::drmemtrace::memtrace_stream_t API.
      */
     class stream_t : public memtrace_stream_t {
     public:
@@ -574,8 +575,9 @@ public:
         // memtrace_stream_t interface:
 
         /**
-         * Returns the count of #memref_t records from the start of the trace to this
-         * point. It does not include synthetic records (see is_record_synthetic()).
+         * Returns the count of #dynamorio::drmemtrace::memref_t records from the start of
+         * the trace to this point. It does not include synthetic records (see
+         * is_record_synthetic()).
          *
          * If
          * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULER_USE_INPUT_ORDINALS
@@ -638,8 +640,8 @@ public:
             return scheduler_->get_input_ordinal(ordinal_);
         }
         /**
-         * Returns the value of the most recently seen #TRACE_MARKER_TYPE_TIMESTAMP
-         * marker.
+         * Returns the value of the most recently seen
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
          */
         uint64_t
         get_last_timestamp() const override
@@ -650,7 +652,8 @@ public:
             return last_timestamp_;
         }
         /**
-         * Returns the value of the first seen #TRACE_MARKER_TYPE_TIMESTAMP marker.
+         * Returns the value of the first seen
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
          */
         uint64_t
         get_first_timestamp() const override
@@ -661,8 +664,8 @@ public:
             return first_timestamp_;
         }
         /**
-         * Returns the #trace_version_t value from the #TRACE_MARKER_TYPE_VERSION record
-         * in the trace header.
+         * Returns the #dynamorio::drmemtrace::trace_version_t value from the
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION record in the trace header.
          */
         uint64_t
         get_version() const override
@@ -670,9 +673,10 @@ public:
             return version_;
         }
         /**
-         * Returns the OFFLINE_FILE_TYPE_* bitfields of type #offline_file_type_t
-         * identifying the architecture and other key high-level attributes of the trace
-         * from the #TRACE_MARKER_TYPE_FILETYPE record in the trace header.
+         * Returns the OFFLINE_FILE_TYPE_* bitfields of type
+         * #dynamorio::drmemtrace::offline_file_type_t identifying the architecture and
+         * other key high-level attributes of the trace from the
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE record in the trace header.
          */
         uint64_t
         get_filetype() const override
@@ -680,8 +684,9 @@ public:
             return filetype_;
         }
         /**
-         * Returns the cache line size from the #TRACE_MARKER_TYPE_CACHE_LINE_SIZE record
-         * in the trace header.
+         * Returns the cache line size from the
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CACHE_LINE_SIZE record in the trace
+         * header.
          */
         uint64_t
         get_cache_line_size() const override
@@ -690,7 +695,8 @@ public:
         }
         /**
          * Returns the chunk instruction count from the
-         * #TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT record in the trace header.
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT record in the trace
+         * header.
          */
         uint64_t
         get_chunk_instr_count() const override
@@ -698,8 +704,8 @@ public:
             return chunk_instr_count_;
         }
         /**
-         * Returns the page size from the #TRACE_MARKER_TYPE_PAGE_SIZE record in
-         * the trace header.
+         * Returns the page size from the
+         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PAGE_SIZE record in the trace header.
          */
         uint64_t
         get_page_size() const override
@@ -770,7 +776,10 @@ public:
         return static_cast<input_ordinal_t>(inputs_.size());
     }
 
-    /** Returns the #memtrace_stream_t interface for the 'ordinal'-th input stream. */
+    /**
+     * Returns the #dynamorio::drmemtrace::memtrace_stream_t interface for the
+     * 'ordinal'-th input stream.
+     */
     virtual memtrace_stream_t *
     get_input_stream_interface(input_ordinal_t input) const
     {

--- a/clients/drcachesim/simulator/cache.cpp
+++ b/clients/drcachesim/simulator/cache.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,6 +33,9 @@
 #include "cache.h"
 #include "../common/utils.h"
 #include <assert.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 bool
 cache_t::init(int associativity, int line_size, int total_size, caching_device_t *parent,
@@ -85,3 +88,6 @@ cache_t::flush(const memref_t &memref)
     if (stats_ != NULL)
         ((cache_stats_t *)stats_)->flush(memref);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/cache.h
+++ b/clients/drcachesim/simulator/cache.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,9 @@
 #include "cache_line.h"
 #include "cache_stats.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class cache_t : public caching_device_t {
 public:
     // Size, line size and associativity are generally used
@@ -61,5 +64,8 @@ protected:
     void
     init_blocks() override;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_H_ */

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -32,6 +32,9 @@
 
 #include "cache_fifo.h"
 #include <assert.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // For the FIFO/Round-Robin implementation, all the cache blocks in a set are organized
 // as a FIFO. The counters of a set of blocks simulate the replacement pointer.
@@ -102,3 +105,6 @@ cache_fifo_t::get_next_way_to_replace(const int block_idx) const
     assert(false);
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/cache_fifo.h
+++ b/clients/drcachesim/simulator/cache_fifo.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 
 #include "cache.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class cache_fifo_t : public cache_t {
 public:
     bool
@@ -55,5 +58,8 @@ protected:
     int
     get_next_way_to_replace(const int block_idx) const override;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_FIFO_H_ */

--- a/clients/drcachesim/simulator/cache_line.h
+++ b/clients/drcachesim/simulator/cache_line.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 
 #include "caching_device_block.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class cache_line_t : public caching_device_block_t {
 
     // Currently, "cache_line_t" is identical to caching_device_block_t; however,
@@ -45,5 +48,8 @@ class cache_line_t : public caching_device_block_t {
     // and functions, e.g., coherency-related ones. Therefore, it is
     // reasonable to keep two identical classes now rather than use one instead.
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_LINE_H_ */

--- a/clients/drcachesim/simulator/cache_lru.cpp
+++ b/clients/drcachesim/simulator/cache_lru.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -31,6 +31,9 @@
  */
 
 #include "cache_lru.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // For LRU implementation, we use the cache line counter to represent
 // how recently a cache line is accessed.
@@ -102,3 +105,6 @@ cache_lru_t::get_next_way_to_replace(int block_idx) const
     }
     return max_way;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/cache_lru.h
+++ b/clients/drcachesim/simulator/cache_lru.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 
 #include "cache.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class cache_lru_t : public cache_t {
 public:
     bool
@@ -55,5 +58,8 @@ protected:
     int
     get_next_way_to_replace(const int block_idx) const override;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_LRU_H_ */

--- a/clients/drcachesim/simulator/cache_miss_analyzer.cpp
+++ b/clients/drcachesim/simulator/cache_miss_analyzer.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, LLC  All rights reserved.
+ * Copyright (c) 2015-2023 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -34,6 +34,9 @@
 
 #include <iostream>
 #include <stdint.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 const char *cache_miss_stats_t::kNTA = "nta";
 const char *cache_miss_stats_t::kT0 = "t0";
@@ -209,3 +212,6 @@ cache_miss_analyzer_t::print_results()
     std::cerr << std::dec;
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/cache_miss_analyzer.h
+++ b/clients/drcachesim/simulator/cache_miss_analyzer.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, LLC  All rights reserved.
+ * Copyright (c) 2015-2023 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -47,6 +47,9 @@
 #include "cache_simulator.h"
 #include "cache_stats.h"
 #include "../common/memref.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // Represents the SW prefetching recommendation passed to the compiler.
 struct prefetching_recommendation_t {
@@ -156,5 +159,8 @@ private:
     // Recommendations are written to this file for use by the LLVM compiler.
     std::string recommendation_file_ = "";
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_MISS_ANALYZER_H_ */

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -48,8 +48,10 @@
 #include "cache_fifo.h"
 #include "cache_simulator.h"
 #include "droption.h"
-
 #include "snoop_filter.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 analysis_tool_t *
 cache_simulator_create(const cache_simulator_knobs_t &knobs)
@@ -664,3 +666,6 @@ cache_simulator_t::create_cache(const std::string &policy)
            "Please choose " REPLACE_POLICY_LRU " or " REPLACE_POLICY_LFU ".\n");
     return NULL;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,9 @@
 #include "cache.h"
 #include "snoop_filter.h"
 #include <limits.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 enum class cache_split_t { DATA, INSTRUCTION };
 
@@ -115,5 +118,8 @@ protected:
 private:
     bool is_warmed_up_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_SIMULATOR_H_ */

--- a/clients/drcachesim/simulator/cache_simulator_create.h
+++ b/clients/drcachesim/simulator/cache_simulator_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 #include <string>
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+// NOCHECK does this order matter vs @file?
 /**
  * @file drmemtrace/cache_simulator_create.h
  * @brief DrMemtrace cache simulator creation.
@@ -108,5 +111,8 @@ analysis_tool_t *
 cache_miss_analyzer_create(const cache_simulator_knobs_t &knobs,
                            unsigned int miss_count_threshold, double miss_frac_threshold,
                            double confidence_threshold);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_SIMULATOR_CREATE_H_ */

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,6 +33,9 @@
 #include <iostream>
 #include <iomanip>
 #include "cache_stats.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 cache_stats_t::cache_stats_t(int block_size, const std::string &miss_file,
                              bool warmup_enabled, bool is_coherent)
@@ -98,3 +101,6 @@ cache_stats_t::reset()
     num_prefetch_hits_ = 0;
     num_prefetch_misses_ = 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 #include <string>
 #include "caching_device_stats.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class cache_stats_t : public caching_device_stats_t {
 public:
     explicit cache_stats_t(int block_size, const std::string &miss_file = "",
@@ -70,5 +73,8 @@ protected:
     int_least64_t num_prefetch_hits_;
     int_least64_t num_prefetch_misses_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_STATS_H_ */

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,9 @@
 #include "snoop_filter.h"
 #include "../common/utils.h"
 #include <assert.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 caching_device_t::caching_device_t()
     : blocks_(NULL)
@@ -398,3 +401,6 @@ caching_device_t::record_access_stats(const memref_t &memref, bool hit,
     } else if (parent_ != nullptr)
         parent_->stats_->child_access(memref, hit, cache_block);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,6 +44,9 @@
 #include "caching_device_stats.h"
 #include "memref.h"
 #include "prefetcher.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // Statistics collection is abstracted out into the caching_device_stats_t class.
 
@@ -224,5 +227,8 @@ protected:
         tag2block;
     bool use_tag2block_table_ = false;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHING_DEVICE_H_ */

--- a/clients/drcachesim/simulator/caching_device_block.h
+++ b/clients/drcachesim/simulator/caching_device_block.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 #include <stdint.h>
 #include "memref.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // Assuming a block of a caching device represents a memory space of at least 4-byte,
 // e.g., a CPU cache line or a virtual/physical page, we can use special value
 // that cannot be computed from valid address as special tag for
@@ -66,5 +69,8 @@ public:
     // We already have stdint.h so we can reinstate int_least64_t easily.
     int counter_; // for use by replacement policies
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHING_DEVICE_BLOCK_H_ */

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -36,6 +36,9 @@
 #include "../common/options.h"
 #include "caching_device_stats.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 caching_device_stats_t::caching_device_stats_t(const std::string &miss_file,
                                                int block_size, bool warmup_enabled,
                                                bool is_coherent)
@@ -249,3 +252,6 @@ caching_device_stats_t::invalidate(invalidation_type_t invalidation_type)
         num_coherence_invalidates_++;
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -45,6 +45,9 @@
 #    include <zlib.h>
 #endif
 #include "memref.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 enum invalidation_type_t {
     INVALIDATION_INCLUSIVE,
@@ -244,5 +247,8 @@ protected:
     FILE *file_;
 #endif
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHING_DEVICE_STATS_H_ */

--- a/clients/drcachesim/simulator/prefetcher.cpp
+++ b/clients/drcachesim/simulator/prefetcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,6 +36,9 @@
 #include "caching_device.h"
 #include "../common/memref.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 prefetcher_t::prefetcher_t(int block_size)
     : block_size_(block_size)
 {
@@ -51,3 +54,6 @@ prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in)
     memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
     cache->request(memref);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/prefetcher.h
+++ b/clients/drcachesim/simulator/prefetcher.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 #include "caching_device.h"
 #include "memref.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class caching_device_t;
 
 class prefetcher_t {
@@ -53,5 +56,8 @@ public:
 private:
     int block_size_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _PREFETCHER_H_ */

--- a/clients/drcachesim/simulator/simulator.cpp
+++ b/clients/drcachesim/simulator/simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 #include "../common/utils.h"
 #include "droption.h"
 #include "simulator.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 simulator_t::simulator_t(unsigned int num_cores, uint64_t skip_refs, uint64_t warmup_refs,
                          double warmup_fraction, uint64_t sim_refs, bool cpu_scheduling,
@@ -270,3 +273,6 @@ simulator_t::print_core(int core) const
         std::cerr << ")" << std::endl;
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,9 @@
 #include "caching_device.h"
 #include "analysis_tool.h"
 #include "memref.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 class simulator_t : public analysis_tool_t {
 public:
@@ -111,5 +114,8 @@ protected:
     std::unordered_map<addr_t, addr_t> virt2phys_;
     addr_t prior_phys_addr_ = 0;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SIMULATOR_H_ */

--- a/clients/drcachesim/simulator/snoop_filter.cpp
+++ b/clients/drcachesim/simulator/snoop_filter.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -35,6 +35,9 @@
 #include <iomanip>
 #include <assert.h>
 #include <algorithm>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 snoop_filter_t::snoop_filter_t(void)
 {
@@ -135,3 +138,6 @@ snoop_filter_t::print_stats(void)
               << std::right << num_writebacks_ << std::endl;
     std::cerr.imbue(std::locale("C")); // Reset to avoid affecting later prints.
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/snoop_filter.h
+++ b/clients/drcachesim/simulator/snoop_filter.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,9 @@
 #include <unordered_map>
 #include <vector>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 struct coherence_table_entry_t {
     std::vector<bool> sharers;
     bool dirty;
@@ -66,5 +69,8 @@ protected:
     int_least64_t num_writebacks_;
     int_least64_t num_invalidates_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SNOOP_FILTER_H_ */

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,6 +33,9 @@
 #include "tlb.h"
 #include "../common/utils.h"
 #include <assert.h>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 void
 tlb_t::init_blocks()
@@ -121,3 +124,6 @@ tlb_t::request(const memref_t &memref_in)
         last_pid_ = pid;
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,9 @@
 #include "tlb_entry.h"
 #include "tlb_stats.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class tlb_t : public caching_device_t {
 public:
     void
@@ -56,5 +59,8 @@ protected:
     // Optimization: remember last pid in addition to last tag
     memref_pid_t last_pid_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _TLB_H_ */

--- a/clients/drcachesim/simulator/tlb_entry.h
+++ b/clients/drcachesim/simulator/tlb_entry.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 
 #include "caching_device_block.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class tlb_entry_t : public caching_device_block_t {
 public:
     // process ID to differentiate virtual pages
@@ -46,5 +49,8 @@ public:
 
     // XXX: support page privilege and MMU-related exceptions
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _TLB_ENTRY_H_ */

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,9 @@
 #include "tlb_stats.h"
 #include "tlb.h"
 #include "tlb_simulator.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 analysis_tool_t *
 tlb_simulator_create(const tlb_simulator_knobs_t &knobs)
@@ -246,3 +249,6 @@ tlb_simulator_t::create_tlb(std::string policy)
            "Please choose " REPLACE_POLICY_LFU ".\n");
     return NULL;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/simulator/tlb_simulator.h
+++ b/clients/drcachesim/simulator/tlb_simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,6 +42,9 @@
 #include "tlb_stats.h"
 #include "tlb.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class tlb_simulator_t : public simulator_t {
 public:
     tlb_simulator_t(const tlb_simulator_knobs_t &knobs);
@@ -64,5 +67,8 @@ protected:
     tlb_t **dtlbs_;
     tlb_t **lltlbs_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _TLB_SIMULATOR_H_ */

--- a/clients/drcachesim/simulator/tlb_simulator_create.h
+++ b/clients/drcachesim/simulator/tlb_simulator_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,9 @@
 
 #include <string>
 #include "analysis_tool.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 /**
  * @file drmemtrace/tlb_simulator_create.h
@@ -89,5 +92,8 @@ struct tlb_simulator_knobs_t {
 /** Creates an instance of a TLB simulator. */
 analysis_tool_t *
 tlb_simulator_create(const tlb_simulator_knobs_t &knobs);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _TLB_SIMULATOR_CREATE_H_ */

--- a/clients/drcachesim/simulator/tlb_stats.h
+++ b/clients/drcachesim/simulator/tlb_stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 
 #include "caching_device_stats.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class tlb_stats_t : public caching_device_stats_t {
 public:
     tlb_stats_t(int block_size)
@@ -49,5 +52,8 @@ public:
     // It might be necessary to report stats of exceptions
     // triggered by address translation, e.g., address unaligned exception.
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _TLB_STATS_H_ */

--- a/clients/drcachesim/tests/analyzer_separate.cpp
+++ b/clients/drcachesim/tests/analyzer_separate.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,6 +44,11 @@
 #include "drmemtrace/analyzer.h"
 #include "drmemtrace/histogram_create.h"
 
+using dynamorio::drmemtrace::analysis_tool_t;
+using dynamorio::drmemtrace::analyzer_t;
+
+namespace {
+
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
         fprintf(stderr, "ERROR: " msg "\n", ##__VA_ARGS__); \
@@ -72,6 +77,8 @@ droption_t<unsigned int>
 droption_t<unsigned int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 0, 0, 64,
                                     "Verbosity level",
                                     "Verbosity level for notifications.");
+
+} // namespace
 
 int
 _tmain(int argc, const TCHAR *targv[])

--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -46,6 +46,9 @@
 #include <signal.h>
 #include <setjmp.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define ASSERT_MSG(x, msg)                                                           \
     ((void)((!(x)) ? (dr_fprintf(STDERR, "ASSERT FAILURE: %s:%d: %s (%s)", __FILE__, \
                                  __LINE__, #x, msg),                                 \
@@ -53,8 +56,6 @@
                    : 0))
 #define ASSERT_NOT_REACHED() ASSERT_MSG(false, "Shouldn't be reached")
 #define ALIGNED(x, alignment) ((((ptr_uint_t)x) & ((alignment)-1)) == 0)
-
-using namespace dynamorio::drmemtrace;
 
 /*******************************************************************************
  * Begin application code.
@@ -276,3 +277,6 @@ test_main(int argc, const char *argv[])
 
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_futex.cpp
+++ b/clients/drcachesim/tests/burst_futex.cpp
@@ -49,7 +49,8 @@
 
 #include <iostream>
 
-using namespace dynamorio::drmemtrace;
+namespace dynamorio {
+namespace drmemtrace {
 
 static uint32_t futex_var;
 
@@ -136,7 +137,7 @@ gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
     std::string tracedir = gather_trace("", "futex");
 
@@ -198,3 +199,6 @@ main(int argc, const char *argv[])
     std::cerr << "all done\n";
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_gencode.cpp
+++ b/clients/drcachesim/tests/burst_gencode.cpp
@@ -52,9 +52,8 @@
 #undef ALIGN_FORWARD // Conflicts with drcachesim utils.h.
 #include "tools.h"   // Included after system headers to avoid printf warning.
 
-using namespace dynamorio::drmemtrace;
-
-namespace {
+namespace dynamorio {
+namespace drmemtrace {
 
 /***************************************************************************
  * Code generation.
@@ -375,11 +374,12 @@ look_for_gencode(std::string trace_dir)
     return 0;
 }
 
-} // namespace
-
 int
 test_main(int argc, const char *argv[])
 {
     std::string trace_dir = gather_trace();
     return look_for_gencode(trace_dir);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_malloc.cpp
+++ b/clients/drcachesim/tests/burst_malloc.cpp
@@ -47,6 +47,9 @@
 #include <math.h>
 #include <stdlib.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 bool
 my_setenv(const char *var, const char *value)
 {
@@ -58,7 +61,7 @@ my_setenv(const char *var, const char *value)
 }
 
 // Test recording large values that require two entries.
-ptr_uint_t
+extern "C" ptr_uint_t
 return_big_value(int arg)
 {
     return (((ptr_uint_t)1 << (8 * sizeof(ptr_uint_t) - 1)) - 1) | arg;
@@ -205,3 +208,6 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 }
 #    endif
 #endif /* UNIX && TEST_APP_DR_CLIENT_MAIN */
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_maps.cpp
+++ b/clients/drcachesim/tests/burst_maps.cpp
@@ -49,6 +49,9 @@
 #include <stdio.h>
 #include <string.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /* XXX: share these with suite/tests/tools.c and the core? */
 #define MAPS_LINE_LENGTH 4096
 #define MAPS_LINE_FORMAT4 "%08lx-%08lx %s %*x %*s %*u %4096s"
@@ -199,3 +202,6 @@ test_main(int argc, const char *argv[])
     }
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_noreach.cpp
+++ b/clients/drcachesim/tests/burst_noreach.cpp
@@ -44,6 +44,9 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 bool
 my_setenv(const char *var, const char *value)
 {
@@ -114,3 +117,6 @@ test_main(int argc, const char *argv[])
     }
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_reattach.cpp
+++ b/clients/drcachesim/tests/burst_reattach.cpp
@@ -46,6 +46,9 @@
 #include <math.h>
 #include <stdlib.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 bool
 my_setenv(const char *var, const char *value)
 {
@@ -146,3 +149,6 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 }
 #    endif
 #endif /* UNIX && TEST_APP_DR_CLIENT_MAIN */
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_replace.cpp
+++ b/clients/drcachesim/tests/burst_replace.cpp
@@ -49,6 +49,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define MAGIC_VALUE ((void *)(ptr_uint_t)0xdeadbeefUL)
 
 bool
@@ -277,3 +280,6 @@ test_main(int argc, const char *argv[])
     std::cerr << "all done\n";
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -49,6 +49,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <set>
+
+namespace dynamorio {
+namespace drmemtrace {
+
 // XXX i#2040: Static client limitations on Windows prevent the thread
 // aspect of this test from working today.  Once that is fixed we can
 // re-enable by removing all of the "ifndef WINDOWS" with this comment:
@@ -347,3 +351,6 @@ test_main(int argc, const char *argv[])
     std::cerr << "all done\n";
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_static.cpp
+++ b/clients/drcachesim/tests/burst_static.cpp
@@ -44,6 +44,9 @@
 #include <math.h>
 #include <stdlib.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 bool
 my_setenv(const char *var, const char *value)
 {
@@ -131,3 +134,6 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 }
 #    endif
 #endif /* UNIX && TEST_APP_DR_CLIENT_MAIN */
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_threadfilter.cpp
+++ b/clients/drcachesim/tests/burst_threadfilter.cpp
@@ -51,6 +51,9 @@
 #endif
 #include "../../../suite/tests/condvar.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 static const int num_threads = 8;
 static const int burst_owner = 4;
 static bool finished[num_threads];
@@ -248,3 +251,6 @@ test_main(int argc, const char *argv[])
     destroy_cond_var(burst_owner_finished);
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_threads.cpp
+++ b/clients/drcachesim/tests/burst_threads.cpp
@@ -52,6 +52,9 @@
 #endif
 #include "../../../suite/tests/condvar.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 static const int num_threads = 8;
 static const int num_idle_threads = 40;
 static const int burst_owner = 4;
@@ -255,3 +258,6 @@ test_main(int argc, const char *argv[])
     destroy_cond_var(idle_should_exit);
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/burst_traceopts.cpp
+++ b/clients/drcachesim/tests/burst_traceopts.cpp
@@ -50,12 +50,6 @@
 #    include <stdlib.h>
 #    include <string.h>
 
-using namespace dynamorio::drmemtrace;
-
-/* Unit tests for classes used for trace optimizations. */
-void
-reg_id_set_unit_tests();
-
 /* Asm routines. */
 extern "C" {
 void
@@ -63,6 +57,13 @@ test_disp_elision();
 void
 test_base_elision();
 };
+
+namespace dynamorio {
+namespace drmemtrace {
+
+/* Unit tests for classes used for trace optimizations. */
+void
+reg_id_set_unit_tests();
 
 std::string
 compare_memref(void *dcontext, int64 entry_count, const memref_t &memref1,
@@ -287,6 +288,10 @@ test_main(int argc, const char *argv[])
     std::cerr << "all done\n";
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
 #else /* asm code *************************************************************/
 /* Avoid warnings from defines passed to the C++ side from configuring it as a client.
  * Is there a better way?  Reset the flags for the client?

--- a/clients/drcachesim/tests/cache_miss_analyzer_test.cpp
+++ b/clients/drcachesim/tests/cache_miss_analyzer_test.cpp
@@ -36,6 +36,9 @@
 #include "../simulator/cache_simulator.h"
 #include "../common/memref.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 static memref_t
 generate_mem_ref(const addr_t addr, const addr_t pc)
 {
@@ -216,3 +219,6 @@ test_main(int argc, const char *argv[])
         exit(1);
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -38,6 +38,9 @@
 #include "simulator/cache_fifo.h"
 #include "simulator/cache_lru.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // Indices for test address vector.
 enum {
     ADDR_A,
@@ -393,3 +396,6 @@ unit_test_cache_replacement_policy()
     unit_test_cache_lfu_eight_way();
     // XXX i#4842: Add more test sequences.
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,7 +33,13 @@
 #ifndef _CACHE_REPLACEMENT_POLICY_UNIT_TEST_H_
 #define _CACHE_REPLACEMENT_POLICY_UNIT_TEST_H_ 1
 
+namespace dynamorio {
+namespace drmemtrace {
+
 void
 unit_test_cache_replacement_policy();
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CACHE_REPLACEMENT_POLICY_UNIT_TEST_H_ */

--- a/clients/drcachesim/tests/config_reader_unit_test.cpp
+++ b/clients/drcachesim/tests/config_reader_unit_test.cpp
@@ -36,6 +36,9 @@
 #include "simulator/cache.h"
 #include "simulator/cache_simulator_create.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 static void
 check_cache(const std::map<std::string, cache_params_t> &caches, std::string name,
             std::string type, int core, uint64_t size, unsigned int assoc, bool inclusive,
@@ -108,3 +111,6 @@ unit_test_config_reader(const char *testdir)
         }
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/config_reader_unit_test.h
+++ b/clients/drcachesim/tests/config_reader_unit_test.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,7 +33,13 @@
 #ifndef _CONFIG_READER_UNIT_TEST_H_
 #define _CONFIG_READER_UNIT_TEST_H_ 1
 
+namespace dynamorio {
+namespace drmemtrace {
+
 void
 unit_test_config_reader(const char *testdir);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _CONFIG_READER_UNIT_TEST_H_ */

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -42,6 +42,9 @@
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 static cache_simulator_knobs_t
 make_test_knobs()
 {
@@ -567,3 +570,6 @@ test_main(int argc, const char *argv[])
     unit_test_cache_replacement_policy();
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/heap_test.cpp
+++ b/clients/drcachesim/tests/heap_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,6 +33,8 @@
 #include "tools.h"
 #include <new>
 #include <stdio.h>
+
+namespace {
 
 static void
 test_operators()
@@ -142,6 +144,8 @@ test_operators()
         free(buf);
     }
 }
+
+} // namespace
 
 int
 main()

--- a/clients/drcachesim/tests/histogram_test.cpp
+++ b/clients/drcachesim/tests/histogram_test.cpp
@@ -43,9 +43,8 @@
 #include "../common/memref.h"
 #include "memref_gen.h"
 
-namespace {
-
-using namespace dynamorio::drmemtrace;
+namespace dynamorio {
+namespace drmemtrace {
 
 bool
 check_cross_line()
@@ -80,8 +79,6 @@ check_cross_line()
     return true;
 }
 
-} // namespace
-
 int
 test_main(int argc, const char *argv[])
 {
@@ -92,3 +89,6 @@ test_main(int argc, const char *argv[])
     std::cerr << "histogram_test FAILED\n";
     exit(1);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -44,9 +44,8 @@
 #include "../common/memref.h"
 #include "memref_gen.h"
 
-namespace {
-
-using namespace dynamorio::drmemtrace;
+namespace dynamorio {
+namespace drmemtrace {
 
 class checker_no_abort_t : public invariant_checker_t {
 public:
@@ -938,8 +937,6 @@ check_schedule_file()
     return true;
 }
 
-} // namespace
-
 int
 test_main(int argc, const char *argv[])
 {
@@ -953,3 +950,6 @@ test_main(int argc, const char *argv[])
     std::cerr << "invariant_checker_test FAILED\n";
     exit(1);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/prefetch_analyzer.cpp
+++ b/clients/drcachesim/tests/prefetch_analyzer.cpp
@@ -34,6 +34,9 @@
 #include "prefetch_analyzer.h"
 #include <iostream>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 bool
 prefetch_analyzer_t::process_memref(const memref_t &memref)
 {
@@ -53,3 +56,6 @@ prefetch_analyzer_t::print_results()
     }
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/prefetch_analyzer.h
+++ b/clients/drcachesim/tests/prefetch_analyzer.h
@@ -41,6 +41,9 @@
 #include "../common/trace_entry.h"
 #include <map>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class prefetch_analyzer_t : public analysis_tool_t {
 public:
     bool
@@ -51,5 +54,8 @@ public:
 protected:
     std::map<trace_type_t, int> trace_type_freq_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _PREFETCH_ANALYZER_H_ */

--- a/clients/drcachesim/tests/prefetch_analyzer_launcher.cpp
+++ b/clients/drcachesim/tests/prefetch_analyzer_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,6 +36,14 @@
 #include "dr_frontend.h"
 #include "../analyzer.h"
 #include "prefetch_analyzer.h"
+#include "test_helpers.h"
+
+using dynamorio::drmemtrace::analysis_tool_t;
+using dynamorio::drmemtrace::analyzer_t;
+using dynamorio::drmemtrace::disable_popups;
+using dynamorio::drmemtrace::prefetch_analyzer_t;
+
+namespace {
 
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
@@ -49,9 +57,13 @@ static droption_t<std::string>
                  "[Required] Trace input directory",
                  "Specifies the directory containing the trace files to be analyzed.");
 
+} // namespace
+
 int
-main(int argc, const TCHAR *targv[])
+_tmain(int argc, const TCHAR *targv[])
 {
+    disable_popups();
+
     // Convert to UTF-8 if necessary
     char **argv;
     drfront_status_t sc = drfront_convert_args(targv, &argv, argc);

--- a/clients/drcachesim/tests/raw2trace_io.cpp
+++ b/clients/drcachesim/tests/raw2trace_io.cpp
@@ -52,6 +52,9 @@
 #include <syscall.h>
 #include <unistd.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 static droption_t<std::string> op_indir(DROPTION_SCOPE_FRONTEND, "indir", "",
                                         "[Required] Directory with trace input files",
                                         "Specifies a directory with raw files.");
@@ -282,3 +285,6 @@ test_main(int argc, const char *argv[])
         return 1;
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -39,6 +39,9 @@
 #include <iostream>
 #include <sstream>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #undef ASSERT
 #define ASSERT(cond, msg, ...)        \
     do {                              \
@@ -1990,3 +1993,6 @@ test_main(int argc, const char *argv[])
         return 1;
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -45,6 +45,9 @@
 #include <fstream>
 #include <vector>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
         fprintf(stderr, "ERROR: " msg "\n", ##__VA_ARGS__); \
@@ -445,3 +448,6 @@ test_main(int argc, const char *argv[])
     fprintf(stderr, "All done!\n");
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/reg_id_set_unit_tests.cpp
+++ b/clients/drcachesim/tests/reg_id_set_unit_tests.cpp
@@ -38,6 +38,9 @@
 #include <assert.h>
 #include "tracer/instru.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 void
 reg_id_set_unit_tests()
 {
@@ -87,3 +90,6 @@ reg_id_set_unit_tests()
     find_res = set.find(DR_REG_START_GPR + 3);
     assert(find_res == set.end());
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/reuse_distance_test.cpp
+++ b/clients/drcachesim/tests/reuse_distance_test.cpp
@@ -38,7 +38,8 @@
 #include "../tools/reuse_distance_create.h"
 #include "../common/memref.h"
 
-namespace {
+namespace dynamorio {
+namespace drmemtrace {
 
 #define TEST_VERBOSE(N) (test_verbosity >= N)
 unsigned int test_verbosity = 0;
@@ -501,8 +502,6 @@ data_histogram_test()
     }
 }
 
-} // namespace
-
 int
 test_main(int argc, const char *argv[])
 {
@@ -514,3 +513,6 @@ test_main(int argc, const char *argv[])
     data_histogram_test();
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -51,7 +51,16 @@
 #    include "zipfile_ostream.h"
 #endif
 
-using namespace dynamorio::drmemtrace;
+using dynamorio::drmemtrace::disable_popups;
+using dynamorio::drmemtrace::memref_t;
+using dynamorio::drmemtrace::memref_tid_t;
+using dynamorio::drmemtrace::scheduler_t;
+#ifdef HAS_ZIP
+using dynamorio::drmemtrace::zipfile_istream_t;
+using dynamorio::drmemtrace::zipfile_ostream_t;
+#endif
+
+namespace {
 
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
@@ -59,8 +68,6 @@ using namespace dynamorio::drmemtrace;
         fflush(stderr);                                     \
         exit(1);                                            \
     } while (0)
-
-namespace {
 
 droption_t<std::string>
     op_trace_dir(DROPTION_SCOPE_FRONTEND, "trace_dir", "",

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -44,9 +44,8 @@
 #    include "zipfile_ostream.h"
 #endif
 
-using namespace dynamorio::drmemtrace;
-
-namespace {
+namespace dynamorio {
+namespace drmemtrace {
 
 // A mock reader that iterates over a vector of records.
 class mock_reader_t : public reader_t {
@@ -2021,8 +2020,6 @@ test_replay_as_traced_from_file(const char *testdir)
 #endif
 }
 
-} // namespace
-
 int
 test_main(int argc, const char *argv[])
 {
@@ -2055,3 +2052,6 @@ test_main(int argc, const char *argv[])
     dr_standalone_exit();
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/skip_unit_tests.cpp
+++ b/clients/drcachesim/tests/skip_unit_tests.cpp
@@ -39,6 +39,9 @@
 #include <iostream>
 #include <memory>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifndef HAS_ZIP
 #    error zipfile reading is required for this test
 #endif
@@ -153,7 +156,7 @@ test_skip_initial()
 }
 
 int
-main(int argc, const char *argv[])
+test_main(int argc, const char *argv[])
 {
     std::string parse_err;
     if (!droption_parser_t::parse_argv(DROPTION_SCOPE_FRONTEND, argc, (const char **)argv,
@@ -169,3 +172,6 @@ main(int argc, const char *argv[])
     fprintf(stderr, "Success\n");
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google LLC  All rights reserved.
+ * Copyright (c) 2018-2023 Google LLC  All rights reserved.
  * **********************************************************/
 
 /*

--- a/clients/drcachesim/tests/test_helpers.cpp
+++ b/clients/drcachesim/tests/test_helpers.cpp
@@ -40,7 +40,12 @@
 #    endif
 #    include <stdio.h>
 #    include <stdlib.h>
+#endif
 
+namespace dynamorio {
+namespace drmemtrace {
+
+#ifdef WINDOWS
 // We use the same controls as in suite/tests/tools.h to disable popups.
 
 static LONG WINAPI
@@ -83,11 +88,16 @@ disable_popups()
 // The test implements this.
 int
 test_main(int argc, const char *argv[]);
+#endif
 
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#ifndef NO_HELPER_MAIN
 int
 main(int argc, const char *argv[])
 {
-    disable_popups();
-    return test_main(argc, argv);
+    dynamorio::drmemtrace::disable_popups();
+    return dynamorio::drmemtrace::test_main(argc, argv);
 }
 #endif

--- a/clients/drcachesim/tests/test_helpers.h
+++ b/clients/drcachesim/tests/test_helpers.h
@@ -35,9 +35,15 @@
 #ifndef _TEST_HELPERS_H_
 #define _TEST_HELPERS_H_ 1
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // Tests with a main() should use test_main() which calls this.  This is declared
 // separately for use with _tmain().
 void
 disable_popups();
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _TEST_HELPERS_H_ */

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -40,6 +40,9 @@
 #include <iostream>
 #include <vector>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
         fprintf(stderr, "ERROR: " msg "\n", ##__VA_ARGS__); \
@@ -655,3 +658,6 @@ test_main(int argc, const char *argv[])
     fprintf(stderr, "All done!\n");
     return 0;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -45,6 +45,9 @@
 #include "../scheduler/scheduler.h"
 #include "memref_gen.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #undef ASSERT
 #define ASSERT(cond, msg, ...)        \
     do {                              \
@@ -85,10 +88,6 @@ file_reader_t<std::vector<trace_entry_t>>::read_next_entry()
 {
     return nullptr;
 }
-
-namespace {
-
-using namespace dynamorio::drmemtrace;
 
 class view_test_t : public view_t {
 public:
@@ -587,8 +586,6 @@ run_chunk_tests(void *drcontext)
     return run_single_thread_chunk_test(drcontext) && run_serial_chunk_test(drcontext);
 }
 
-} // namespace
-
 int
 test_main(int argc, const char *argv[])
 {
@@ -600,3 +597,6 @@ test_main(int argc, const char *argv[])
     std::cerr << "view_test FAILED\n";
     exit(1);
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -41,6 +41,9 @@
 #include "basic_counts.h"
 #include "../common/utils.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 const std::string basic_counts_t::TOOL_NAME = "Basic counts tool";
 
 analysis_tool_t *
@@ -427,3 +430,6 @@ basic_counts_t::release_interval_snapshot(
     delete snapshot;
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -40,6 +40,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class basic_counts_t : public analysis_tool_t {
 public:
     basic_counts_t(unsigned int verbose);
@@ -247,5 +250,8 @@ protected:
     unsigned int knob_verbose_;
     static const std::string TOOL_NAME;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _BASIC_COUNTS_H_ */

--- a/clients/drcachesim/tools/basic_counts_create.h
+++ b/clients/drcachesim/tools/basic_counts_create.h
@@ -37,6 +37,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/basic_counts_create.h
  * @brief DrMemtrace basic counting trace analysis tool creation.
@@ -48,5 +51,8 @@
  */
 analysis_tool_t *
 basic_counts_tool_create(unsigned int verbose = 0);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _BASIC_COUNTS_CREATE_H_ */

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -58,8 +58,8 @@
 
 namespace dynamorio {
 namespace drmemtrace {
-namespace {
 
+namespace {
 bool
 is_any_instr_type(trace_type_t type)
 {

--- a/clients/drcachesim/tools/filter/type_filter.h
+++ b/clients/drcachesim/tools/filter/type_filter.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -45,16 +45,16 @@
 // OSX particularly. In C++14, std::hash works as expected for enums
 // too: https://cplusplus.com/forum/general/238538/.
 namespace std {
-template <> struct hash<trace_type_t> {
+template <> struct hash<dynamorio::drmemtrace::trace_type_t> {
     size_t
-    operator()(trace_type_t t) const
+    operator()(dynamorio::drmemtrace::trace_type_t t) const
     {
         return static_cast<size_t>(t);
     }
 };
-template <> struct hash<trace_marker_type_t> {
+template <> struct hash<dynamorio::drmemtrace::trace_marker_type_t> {
     size_t
-    operator()(trace_marker_type_t t) const
+    operator()(dynamorio::drmemtrace::trace_marker_type_t t) const
     {
         return static_cast<size_t>(t);
     }

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -43,6 +43,9 @@
 #include <vector>
 #include <assert.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 const std::string func_view_t::TOOL_NAME = "Function view tool";
 
 analysis_tool_t *
@@ -298,3 +301,6 @@ func_view_t::print_results()
     // XXX: Should we print out a per-thread breakdown?
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,6 +42,9 @@
 #include "analysis_tool.h"
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 class func_view_t : public analysis_tool_t {
 public:
@@ -121,5 +124,8 @@ protected:
     // shard_map (process_memref, print_results) we are single-threaded.
     std::mutex shard_map_mutex_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _FUNC_VIEW_H_ */

--- a/clients/drcachesim/tools/func_view_create.h
+++ b/clients/drcachesim/tools/func_view_create.h
@@ -37,6 +37,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/func_view_create.h
  * @brief DrMemtrace func_view trace analysis tool creation.
@@ -51,5 +54,8 @@
 analysis_tool_t *
 func_view_tool_create(const std::string &funclist_file_path, bool full_trace,
                       unsigned int verbose = 0);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _OPCODE_MIX_CREATE_H_ */

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -36,6 +36,9 @@
 #include <vector>
 #include "histogram.h"
 #include "../common/utils.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 const std::string histogram_t::TOOL_NAME = "Cache line histogram tool";
 
@@ -208,3 +211,6 @@ histogram_t::print_results()
     std::cerr << std::dec;
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -42,6 +42,9 @@
 
 #include "analysis_tool.h"
 #include "memref.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 class histogram_t : public analysis_tool_t {
 public:
@@ -90,5 +93,8 @@ protected:
     // The combined data from all the shards.
     shard_data_t reduced_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _HISTOGRAM_H_ */

--- a/clients/drcachesim/tools/histogram_create.h
+++ b/clients/drcachesim/tools/histogram_create.h
@@ -37,6 +37,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/histogram_create.h
  * @brief DrMemtrace tool that computes the most-referenced cache lines.
@@ -50,5 +53,8 @@
 analysis_tool_t *
 histogram_tool_create(unsigned int line_size = 64, unsigned int report_top = 10,
                       unsigned int verbose = 0);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _HISTOGRAM_CREATE_H_ */

--- a/clients/drcachesim/tools/histogram_launcher.cpp
+++ b/clients/drcachesim/tools/histogram_launcher.cpp
@@ -45,7 +45,14 @@
 #include "histogram_create.h"
 #include "../tools/invariant_checker.h"
 
-using namespace dynamorio::drmemtrace;
+using dynamorio::drmemtrace::analysis_tool_t;
+using dynamorio::drmemtrace::analyzer_t;
+using dynamorio::drmemtrace::histogram_tool_create;
+using dynamorio::drmemtrace::invariant_checker_t;
+using dynamorio::drmemtrace::memref_t;
+using dynamorio::drmemtrace::scheduler_t;
+
+namespace {
 
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
@@ -83,6 +90,8 @@ droption_t<bool> op_test_mode(DROPTION_SCOPE_ALL, "test_mode", false, "Run tests
 droption_t<std::string> op_test_mode_name(DROPTION_SCOPE_ALL, "test_mode_name", "",
                                           "Test name",
                                           "Name of extra analyses for testing.");
+
+} // namespace
 
 int
 _tmain(int argc, const TCHAR *targv[])

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -38,6 +38,9 @@
 #include <cassert>
 #include <string.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 analysis_tool_t *
 invariant_checker_create(bool offline, unsigned int verbose)
 {
@@ -921,3 +924,6 @@ invariant_checker_t::check_for_pc_discontinuity(
 
     return error_msg;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -46,6 +46,9 @@
 #include <unordered_map>
 #include <vector>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /* The auto cleanup wrapper of instr_t.
  * This can ensure the instance of instr_t is cleaned up when it is out of scope.
  */
@@ -217,5 +220,8 @@ protected:
 
     memtrace_stream_t *serial_stream_ = nullptr;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _INVARIANT_CHECKER_H_ */

--- a/clients/drcachesim/tools/invariant_checker_create.h
+++ b/clients/drcachesim/tools/invariant_checker_create.h
@@ -35,6 +35,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/invariant_checker_create.h
  * @brief DrMemtrace trace invariant checker tool creation.
@@ -47,5 +50,8 @@
  */
 analysis_tool_t *
 invariant_checker_create(bool offline, unsigned int verbose = 0);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _INVARIANT_CHECKER_CREATE_H_ */

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -44,6 +44,9 @@
 #include <vector>
 #include <string.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 const std::string opcode_mix_t::TOOL_NAME = "Opcode mix tool";
 
 analysis_tool_t *
@@ -261,3 +264,6 @@ opcode_mix_t::print_results()
     }
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,9 @@
 #include "analysis_tool.h"
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 class opcode_mix_t : public analysis_tool_t {
 public:
@@ -136,5 +139,8 @@ protected:
     worker_data_t serial_worker_;
     shard_data_t serial_shard_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _OPCODE_MIX_H_ */

--- a/clients/drcachesim/tools/opcode_mix_create.h
+++ b/clients/drcachesim/tools/opcode_mix_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/opcode_mix_create.h
  * @brief DrMemtrace opcode mixture trace analysis tool creation.
@@ -52,5 +55,8 @@
 analysis_tool_t *
 opcode_mix_tool_create(const std::string &module_file_path, unsigned int verbose = 0,
                        const std::string &alt_module_dir = "");
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _OPCODE_MIX_CREATE_H_ */

--- a/clients/drcachesim/tools/opcode_mix_launcher.cpp
+++ b/clients/drcachesim/tools/opcode_mix_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,14 @@
 #include "dr_frontend.h"
 #include "analyzer.h"
 #include "opcode_mix_create.h"
+#include "../tests/test_helpers.h"
+
+using dynamorio::drmemtrace::analysis_tool_t;
+using dynamorio::drmemtrace::analyzer_t;
+using dynamorio::drmemtrace::disable_popups;
+using dynamorio::drmemtrace::opcode_mix_tool_create;
+
+namespace {
 
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
@@ -73,9 +81,13 @@ droption_t<unsigned int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 0, 0, 64,
                                     "Verbosity level",
                                     "Verbosity level for notifications.");
 
+} // namespace
+
 int
 _tmain(int argc, const TCHAR *targv[])
 {
+    disable_popups();
+
     // Convert to UTF-8 if necessary
     char **argv;
     drfront_status_t sc = drfront_convert_args(targv, &argv, argc);

--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,8 +39,17 @@
 #include "tools/filter/cache_filter.h"
 #include "tools/filter/type_filter.h"
 #include "tools/filter/record_filter.h"
+#include "tests/test_helpers.h"
 
 #include <limits>
+
+using dynamorio::drmemtrace::disable_popups;
+using dynamorio::drmemtrace::record_analysis_tool_t;
+using dynamorio::drmemtrace::record_analyzer_t;
+using dynamorio::drmemtrace::trace_marker_type_t;
+using dynamorio::drmemtrace::trace_type_t;
+
+namespace {
 
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
@@ -105,9 +114,13 @@ parse_string(const std::string &s, char sep = ',')
     return vec;
 }
 
+} // namespace
+
 int
 _tmain(int argc, const TCHAR *targv[])
 {
+    disable_popups();
+
     char **argv;
     drfront_status_t sc = drfront_convert_args(targv, &argv, argc);
     if (sc != DRFRONT_SUCCESS)

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,9 @@
 #include <vector>
 #include "reuse_distance.h"
 #include "../common/utils.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 const std::string reuse_distance_t::TOOL_NAME = "Reuse distance tool";
 
@@ -496,3 +499,6 @@ reuse_distance_t::print_results()
     std::cerr << std::dec;
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -47,6 +47,9 @@
 #include "analysis_tool.h"
 #include "reuse_distance_create.h"
 #include "memref.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // We see noticeable overhead in release build with an if() that directly
 // checks knob_verbose, so for non-debug uses we eliminate it entirely.
@@ -437,5 +440,8 @@ struct line_ref_list_t {
         return dist;
     }
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _REUSE_DISTANCE_H_ */

--- a/clients/drcachesim/tools/reuse_distance_create.h
+++ b/clients/drcachesim/tools/reuse_distance_create.h
@@ -37,6 +37,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/reuse_distance_create.h
  * @brief DrMemtrace reuse distance tool creation.
@@ -74,5 +77,8 @@ struct reuse_distance_knobs_t {
 /** Creates an analysis tool which computes reuse distance. */
 analysis_tool_t *
 reuse_distance_tool_create(const reuse_distance_knobs_t &knobs);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _REUSE_DISTANCE_CREATE_H_ */

--- a/clients/drcachesim/tools/reuse_time.cpp
+++ b/clients/drcachesim/tools/reuse_time.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 
 #include "reuse_time.h"
 #include "../common/utils.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 #ifdef DEBUG
 #    define DEBUG_VERBOSE(level) (knob_verbose_ >= (level))
@@ -238,3 +241,6 @@ reuse_time_t::print_results()
 
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/reuse_time.h
+++ b/clients/drcachesim/tools/reuse_time.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 #include <string>
 
 #include "analysis_tool.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 class reuse_time_t : public analysis_tool_t {
 public:
@@ -85,5 +88,8 @@ protected:
     // shard_map (process_memref, print_results) we are single-threaded.
     std::mutex shard_map_mutex_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _REUSE_TIME_H_ */

--- a/clients/drcachesim/tools/reuse_time_create.h
+++ b/clients/drcachesim/tools/reuse_time_create.h
@@ -37,6 +37,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/reuse_time_create.h
  * @brief DrMemtrace reuse time (i.e., reuse distance without regard to
@@ -51,5 +54,8 @@
 // These options are currently documented in ../common/options.cpp.
 analysis_tool_t *
 reuse_time_tool_create(unsigned int line_size = 64, unsigned int verbose = 0);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _REUSE_TIME_CREATE_H_ */

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -38,6 +38,9 @@
 #include <iostream>
 #include <vector>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 const std::string syscall_mix_t::TOOL_NAME = "Syscall mix tool";
 
 analysis_tool_t *
@@ -169,3 +172,6 @@ syscall_mix_t::print_results()
     }
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/syscall_mix.h
+++ b/clients/drcachesim/tools/syscall_mix.h
@@ -39,6 +39,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class syscall_mix_t : public analysis_tool_t {
 public:
     syscall_mix_t(unsigned int verbose);
@@ -77,5 +80,8 @@ protected:
 
     static const std::string TOOL_NAME;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SYSCALL_MIX_H_ */

--- a/clients/drcachesim/tools/syscall_mix_create.h
+++ b/clients/drcachesim/tools/syscall_mix_create.h
@@ -42,11 +42,17 @@
  * @brief DrMemtrace syscall mixture trace analysis tool creation.
  */
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * Creates an analysis tool which counts the number of instances of each system call
  * in the trace.
  */
 analysis_tool_t *
 syscall_mix_tool_create(unsigned int verbose = 0);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SYSCALL_MIX_CREATE_H_ */

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -43,6 +43,9 @@
 #include <iostream>
 #include <vector>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 const std::string view_t::TOOL_NAME = "View tool";
 
 analysis_tool_t *
@@ -538,3 +541,6 @@ view_t::print_results()
     std::cerr << std::setw(15) << num_disasm_instrs_ << " : total instructions\n";
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -43,6 +43,9 @@
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class view_t : public analysis_tool_t {
 public:
     // The module_file_path is optional and unused for traces with
@@ -158,5 +161,8 @@ private:
     static constexpr int INSTR_COLUMN_WIDTH = 12;
     static constexpr int TID_COLUMN_WIDTH = 11;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _VIEW_H_ */

--- a/clients/drcachesim/tools/view_create.h
+++ b/clients/drcachesim/tools/view_create.h
@@ -37,6 +37,9 @@
 
 #include "analysis_tool.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /**
  * @file drmemtrace/view_create.h
  * @brief DrMemtrace view trace analysis tool creation.
@@ -52,5 +55,8 @@ analysis_tool_t *
 view_tool_create(const std::string &module_file_path, uint64_t skip_refs,
                  uint64_t sim_refs, const std::string &syntax, unsigned int verbose = 0,
                  const std::string &alt_module_dir = "");
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _OPCODE_MIX_CREATE_H_ */

--- a/clients/drcachesim/tracer/dr_allocator.h
+++ b/clients/drcachesim/tracer/dr_allocator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2019 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 #include "dr_api.h"
 #include <cstdlib>
 #include <new>
+
+namespace dynamorio {
+namespace drmemtrace {
 
 #if defined(WINDOWS) && _MSC_VER < 1910
 #    define NOEXCEPT /* nothing: not supported */
@@ -82,5 +85,8 @@ operator!=(const dr_allocator_t<T> &, const dr_allocator_t<U> &)
 {
     return false;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _DR_ALLOCATOR_H_ */

--- a/clients/drcachesim/tracer/drmemtrace.h
+++ b/clients/drcachesim/tracer/drmemtrace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -47,6 +47,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+namespace dynamorio {
+namespace drmemtrace {
 
 /** Status return values from drmemtrace functions. */
 typedef enum {
@@ -371,7 +374,11 @@ drmemtrace_status_t
 drmemtrace_get_timestamp_from_offline_trace(const void *trace, size_t trace_size,
                                             OUT uint64 *timestamp);
 
+} // namespace drmemtrace
+} // namespace dynamorio
+
 #ifdef __cplusplus
 }
 #endif
+
 #endif /* _DRMEMTRACE_H */

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -46,6 +46,9 @@
 #include "trace_entry.h"
 #include "../common/options.h"
 #include "func_trace.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // The expected pattern for a single_op_value is:
 //     function_name|function_id|arguments_num
@@ -566,3 +569,6 @@ func_trace_exit()
     }
     drwrap_exit();
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/func_trace.h
+++ b/clients/drcachesim/tracer/func_trace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -37,6 +37,9 @@
 
 #include "dr_api.h"
 #include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 #define MAX_FUNC_TRACE_ENTRY_VEC_CAP 16
 
@@ -83,5 +86,8 @@ dr_emit_flags_t
 func_trace_disabled_instrument_event(void *drcontext, void *tag, instrlist_t *bb,
                                      instr_t *instr, instr_t *where, bool for_trace,
                                      bool translating, void *user_data);
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _FUNC_TRACE_ */

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,6 +49,9 @@
 #ifdef WINDOWS
 #    include <intrin.h>
 #endif
+
+namespace dynamorio {
+namespace drmemtrace {
 
 unsigned short
 instru_t::instr_to_instr_type(instr_t *instr, bool repstr_expanded)
@@ -349,3 +352,6 @@ instru_t::count_app_instrs(instrlist_t *ilist)
     }
     return count;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -44,6 +44,9 @@
 #include "trace_entry.h"
 #include "dr_allocator.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define MINSERT instrlist_meta_preinsert
 
 // Versioning for our drmodtrack custom module fields.
@@ -564,5 +567,8 @@ private:
     uint64_t encoding_id_ = 0;
     uint64_t encoding_bytes_written_ = 0;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _INSTRU_H_ */

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -46,6 +46,9 @@
 #include <stddef.h> /* for offsetof */
 #include <string.h> /* for strlen */
 
+namespace dynamorio {
+namespace drmemtrace {
+
 static const uint MAX_INSTR_COUNT = 64 * 1024;
 
 void *(*offline_instru_t::user_load_)(module_data_t *module, int seg_idx);
@@ -993,3 +996,6 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
         }
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -43,6 +43,9 @@
 #include <stddef.h>  /* for offsetof */
 #include <algorithm> /* for std::min */
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define MAX_IMM_DISP_STUR 255
 
 online_instru_t::online_instru_t(void (*insert_load_buf)(void *, instrlist_t *, instr_t *,
@@ -495,3 +498,6 @@ online_instru_t::bb_analysis_cleanup(void *drcontext, void *bb_field)
 {
     // Nothing to do.
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/kcore_copy.cpp
+++ b/clients/drcachesim/tracer/kcore_copy.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 #include "../common/trace_entry.h"
 #include "dr_api.h"
 #include "kcore_copy.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 #define MODULES_FILE_NAME "modules"
 #define MODULES_FILE_PATH "/proc/" MODULES_FILE_NAME
@@ -510,3 +513,6 @@ kcore_copy_t::read_kcore()
 
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/kcore_copy.h
+++ b/clients/drcachesim/tracer/kcore_copy.h
@@ -40,6 +40,9 @@
 #include <elf.h>
 #include "drmemtrace.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 struct proc_module_t;
 struct proc_kcore_code_segment_t;
 
@@ -114,5 +117,8 @@ private:
     /* The ELF header of '/proc/kcore'. */
     Elf64_Ehdr proc_kcore_ehdr_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _KCORE_COPY_H_ */

--- a/clients/drcachesim/tracer/physaddr.cpp
+++ b/clients/drcachesim/tracer/physaddr.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,6 +41,9 @@
 #include "physaddr.h"
 #include "../common/options.h"
 #include "../common/utils.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 #if defined(X86_32) || defined(ARM_32)
 #    define IF_X64_ELSE(x, y) y
@@ -273,3 +276,6 @@ physaddr_t::virtual2physical(void *drcontext, addr_t virt, OUT addr_t *phys,
     return false;
 #endif
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -40,6 +40,9 @@
 #include "dr_api.h"
 #include "hashtable.h"
 #include "../common/trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 // This class is not thread-safe: the caller should create a separate instance
 // per thread.
@@ -111,5 +114,8 @@ private:
     static std::atomic<bool> has_privileges_;
 #endif
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _PHYSADDR_H_ */

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -58,6 +58,9 @@
 
 #include <iostream>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 // Assumes we return an error string by convention.
 #define CHECK(val, msg) \
     do {                \
@@ -3321,3 +3324,6 @@ raw2trace_t::is_maybe_blocking_syscall(uintptr_t number)
     return false;
 #endif
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -65,6 +65,9 @@
 #    include "../drpt2trace/pt2ir.h"
 #endif
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifdef DEBUG
 #    define DEBUG_ASSERT(x) DR_ASSERT(x)
 #else
@@ -793,7 +796,7 @@ public:
      * for every module in the list, and returns an empty string at the end.
      * Returns a non-empty error message on failure.
      *
-     * \deprecated #module_mapper_t should be used instead.
+     * \deprecated #dynamorio::drmemtrace::module_mapper_t should be used instead.
      */
     std::string
     do_module_parsing();
@@ -809,7 +812,8 @@ public:
      * the current process.
      * Returns a non-empty error message on failure.
      *
-     * \deprecated #module_mapper_t::get_loaded_modules() should be used instead.
+     * \deprecated #dynamorio::drmemtrace::module_mapper_t::get_loaded_modules() should be
+     * used instead.
      */
     std::string
     do_module_parsing_and_mapping();
@@ -823,7 +827,8 @@ public:
      * allowing decoding for obtaining further information than is stored in the trace.
      * Returns a non-empty error message on failure.
      *
-     * \deprecated #module_mapper_t::find_mapped_trace_address() should be used instead.
+     * \deprecated #dynamorio::drmemtrace::module_mapper_t::find_mapped_trace_address()
+     * should be used instead.
      */
     std::string
     find_mapped_trace_address(app_pc trace_address, OUT app_pc *mapped_address);
@@ -1483,5 +1488,8 @@ private:
     const std::string kcore_path_;
     const std::string kallsyms_path_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _RAW2TRACE_H_ */

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -70,6 +70,9 @@
 #    include "common/lz4_istream.h"
 #endif
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #define FATAL_ERROR(msg, ...)                               \
     do {                                                    \
         fprintf(stderr, "ERROR: " msg "\n", ##__VA_ARGS__); \
@@ -582,3 +585,6 @@ raw2trace_directory_t::~raw2trace_directory_t()
     }
     dr_standalone_exit();
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -39,6 +39,9 @@
 
 #include "dr_api.h"
 #include "archive_ostream.h"
+
+namespace dynamorio {
+namespace drmemtrace {
 
 class raw2trace_directory_t {
 public:
@@ -112,5 +115,8 @@ private:
     std::string outdir_;
     unsigned int verbosity_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _RAW2TRACE_DIRECTORY_H_ */

--- a/clients/drcachesim/tracer/raw2trace_launcher.cpp
+++ b/clients/drcachesim/tracer/raw2trace_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -44,6 +44,11 @@
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
 
+using dynamorio::drmemtrace::raw2trace_directory_t;
+using dynamorio::drmemtrace::raw2trace_t;
+
+namespace {
+
 // XXX: We're duplicating some options from common/options.cpp: we should be
 // able to share?!
 
@@ -86,6 +91,8 @@ static droption_t<int>
         fflush(stderr);                                     \
         exit(1);                                            \
     } while (0)
+
+} // namespace
 
 int
 _tmain(int argc, const TCHAR *targv[])

--- a/clients/drcachesim/tracer/snappy_file_writer.cpp
+++ b/clients/drcachesim/tracer/snappy_file_writer.cpp
@@ -33,6 +33,9 @@
 #include "snappy_file_writer.h"
 #include <string.h>
 
+namespace dynamorio {
+namespace drmemtrace {
+
 bool
 snappy_file_writer_t::write_file_header()
 {
@@ -93,3 +96,6 @@ snappy_file_writer_t::compress_and_write(const void *buf, size_t count)
         return count;
     }
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/snappy_file_writer.h
+++ b/clients/drcachesim/tracer/snappy_file_writer.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2019-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2019-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -59,6 +59,9 @@
 #include "snappy_consts.h"
 #include "dr_api.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 class snappy_file_writer_t : snappy_consts_t {
 public:
     snappy_file_writer_t(file_t f,
@@ -85,5 +88,8 @@ private:
     ssize_t (*write_func_)(file_t file, const void *data, size_t count);
     bool include_checksums_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SNAPPY_FILE_WRITER_H_ */

--- a/clients/drcachesim/tracer/syscall_pt_trace.cpp
+++ b/clients/drcachesim/tracer/syscall_pt_trace.cpp
@@ -38,6 +38,9 @@
 #include "../../../core/unix/include/syscall_linux_x86.h"
 #include "syscall_pt_trace.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 #ifndef BUILD_PT_TRACER
 #    error "This module requires the drpttracer extension."
 #endif
@@ -280,3 +283,6 @@ syscall_pt_trace_t::is_syscall_pt_trace_enabled(IN int sysnum)
     }
     return true;
 }
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tracer/syscall_pt_trace.h
+++ b/clients/drcachesim/tracer/syscall_pt_trace.h
@@ -45,6 +45,9 @@
 #include "drmemtrace.h"
 #include "drpttracer.h"
 
+namespace dynamorio {
+namespace drmemtrace {
+
 /* The auto cleanup wrapper of pttracer handle.
  * This can ensure the pttracer handle is cleaned up when it is out of scope.
  */
@@ -196,5 +199,8 @@ private:
      */
     file_t output_file_;
 };
+
+} // namespace drmemtrace
+} // namespace dynamorio
 
 #endif /* _SYSCALL_PT_TRACE_ */

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -87,8 +87,6 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[]);
  */
 DR_DISALLOW_UNSAFE_STATIC
 
-using namespace dynamorio::drmemtrace;
-
 namespace dynamorio {
 namespace drmemtrace {
 
@@ -1873,13 +1871,6 @@ fork_init(void *drcontext)
 }
 #endif
 
-} // namespace drmemtrace
-} // namespace dynamorio
-
-/***************************************************************************
- * Outside of namespace.
- */
-
 drmemtrace_status_t
 drmemtrace_replace_file_ops(drmemtrace_open_file_func_t open_file_func,
                             drmemtrace_read_file_func_t read_file_func,
@@ -2215,6 +2206,13 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
 #endif
 }
 
+} // namespace drmemtrace
+} // namespace dynamorio
+
+/***************************************************************************
+ * Outside of namespace.
+ */
+
 /* To support statically linked multiple clients, we add drmemtrace_client_main
  * as the real client init function and make dr_client_main a weak symbol.
  * We could also use alias to link dr_client_main to drmemtrace_client_main.
@@ -2225,5 +2223,5 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
 DR_EXPORT WEAK void
 dr_client_main(client_id_t id, int argc, const char *argv[])
 {
-    drmemtrace_client_main(id, argc, argv);
+    dynamorio::drmemtrace::drmemtrace_client_main(id, argc, argv);
 }

--- a/ext/drpttracer/drpttracer.dox
+++ b/ext/drpttracer/drpttracer.dox
@@ -93,7 +93,7 @@ to ensure one thread only owns one pttracer handle.
 
 The client must ensure that the PT trace's ring buffer and the sideband data's ring buffer
 is large enough to hold the PT data. Insufficient buffer size will lead to lost data,
-which may cause issues in #pt2ir_t decoding.
+which may cause issues in #dynamorio::drmemtrace::pt2ir_t decoding.
 
 After creating a pttracer handle successfully, the client can start or stop a tracing
 session by calling drpttracer_start_tracing() and drpttracer_stop_tracing().
@@ -123,8 +123,8 @@ the output instances after using them:
  - drpttracer_destroy_output()
 
 Also, the client can dump the data in the output to different files for offline
-post-processing. The user can use the library #pt2ir_t in drcachesim to convert the PT
-trace to DynamoRIO's IR.
+post-processing. The user can use the library #dynamorio::drmemtrace::pt2ir_t in
+drcachesim to convert the PT trace to DynamoRIO's IR.
 
 \section sec_drpttracer_tracing_mode Tracing Mode
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -662,10 +662,11 @@ function(tobuild_ci test source client_ops dr_ops exe_ops)
   endif ()
 
   add_library(${test}.dll SHARED ${client_source})
-  if (NOT "${source}" MATCHES "cpp\\.cpp")
+  if (NOT DEFINED ${test}_no_reg_compat AND
+      NOT "${source}" MATCHES "cpp\\.cpp")
     # to avoid changing all the REG_ constants we ask for compatibility
     set(DynamoRIO_REG_COMPATIBILITY ON)
-  endif (NOT "${source}" MATCHES "cpp\\.cpp")
+  endif ()
   setup_test_client_dll_basics(${test}.dll)
   get_client_path(client_path ${test}.dll ${test})
 
@@ -4880,17 +4881,18 @@ if (UNIX)
     # The rseq kernel feature is Linux-only.
     # TODO i#2350: Port the assembly in the test to 32-bit x86 and to ARM.
     # TODO i#3544: Port tests to RISC-V 64
-    tobuild(linux.rseq linux/rseq.c)
+    set(linux.rseq_no_reg_compat)
+    tobuild(linux.rseq linux/rseq.cpp)
     # Test the other sections.  Unfortunately we need a separate binary for each.
-    tobuild(linux.rseq_table linux/rseq.c)
+    tobuild(linux.rseq_table linux/rseq.cpp)
     append_property_list(TARGET linux.rseq_table
       COMPILE_DEFINITIONS "RSEQ_TEST_USE_OLD_SECTION_NAME")
-    tobuild(linux.rseq_noarray linux/rseq.c)
+    tobuild(linux.rseq_noarray linux/rseq.cpp)
     append_property_list(TARGET linux.rseq_noarray
       COMPILE_DEFINITIONS "RSEQ_TEST_USE_NO_ARRAY")
     # Test attaching, which has a separate lazy rseq check.
     # We build with static DR to also test client interactions.
-    tobuild_api(api.rseq linux/rseq.c "" "" OFF ON OFF)
+    tobuild_api(api.rseq linux/rseq.cpp "" "" OFF ON OFF)
     link_with_pthread(api.rseq)
     append_property_list(TARGET api.rseq COMPILE_DEFINITIONS "RSEQ_TEST_ATTACH")
     use_DynamoRIO_static_client(api.rseq drmemtrace_static)

--- a/suite/tests/linux/rseq.cpp
+++ b/suite/tests/linux/rseq.cpp
@@ -30,6 +30,11 @@
  * DAMAGE.
  */
 
+/* XXX: We undef this b/c it's easier than getting rid of from CMake with the
+ * global cflags config where all the other tests want this set.
+ */
+#undef DR_REG_ENUM_COMPATIBILITY
+
 #ifdef RSEQ_TEST_ATTACH
 #    include "configure.h"
 #    include "dr_api.h"
@@ -38,7 +43,7 @@
 #ifdef RSEQ_TEST_ATTACH
 #    include "thread.h"
 #    include "condvar.h"
-#    include <stdatomic.h>
+#    include <atomic>
 #    include "drmemtrace/drmemtrace.h"
 #endif
 #ifndef LINUX
@@ -102,11 +107,11 @@ static __thread volatile struct rseq rseq_tls;
 /* Make it harder to find rseq_tls for DR's heuristic by adding more static TLS. */
 static __thread volatile struct rseq fill_up_tls[128];
 
-extern void
+extern "C" void
 test_rseq_native_abort_handler();
 
 #ifdef RSEQ_TEST_ATTACH
-static atomic_int exit_requested;
+static std::atomic<int> exit_requested;
 static void *thread_ready;
 #endif
 
@@ -146,7 +151,8 @@ register_rseq()
 #        endif
 #    endif
         /* Already registered by glibc. Verify that it's there. */
-        struct rseq *reg_rseq = __builtin_thread_pointer() + __rseq_offset;
+        struct rseq *reg_rseq = reinterpret_cast<struct rseq *>(
+            reinterpret_cast<byte *>(__builtin_thread_pointer()) + __rseq_offset);
         /* Glibc uses RSEQ_SIG as the signature. The following will return
          * EBUSY if reg_rseq is the registered struct rseq and EINVAL otherwise.
          * FTR: if we use some other value as signature (like zero),  this
@@ -171,7 +177,8 @@ get_my_rseq()
 {
 #ifdef GLIBC_RSEQ
     if (__rseq_size > 0)
-        return (struct rseq *)(__builtin_thread_pointer() + __rseq_offset);
+        return reinterpret_cast<struct rseq *>(
+            reinterpret_cast<byte *>(__builtin_thread_pointer()) + __rseq_offset);
 #endif
     return &rseq_tls;
 }
@@ -1399,7 +1406,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 {
     /* Ensure DR_XFER_RSEQ_ABORT is raised. */
     dr_register_kernel_xfer_event(kernel_xfer_event);
-    drmemtrace_client_main(id, argc, argv);
+    dynamorio::drmemtrace::drmemtrace_client_main(id, argc, argv);
 }
 #endif /* RSEQ_TEST_ATTACH */
 
@@ -1446,7 +1453,7 @@ main()
 #endif
 #ifdef RSEQ_TEST_ATTACH
         /* Detach while the thread is in its rseq region loop. */
-        atomic_store(&exit_requested, 1);
+        exit_requested.store(1, std::memory_order_release);
         dr_app_stop_and_cleanup();
         join_thread(mythread);
         destroy_cond_var(thread_ready);


### PR DESCRIPTION
Adds the dynamorio::drmemtrace namespace to all drcachesim/ code.  It was already present on newer code.

This breaks compatibility and external code using these files will need to be updated and recompiled.

Shifts suite/tests/rseq.c to be C++ code so it can continue to test drmemtrace_client_main() which is now inside the namespace.

Fixes #4343