### PR TITLE
Fix i-filtered trace issues

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -160,9 +160,12 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
              shard->memrefs_until_interrupt_ == 0)) {
             report_if_false(
                 shard,
-                (memref.marker.type == TRACE_TYPE_MARKER &&
-                 (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-                  memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT)) ||
+                // I-filtered traces don't have all instrs so this doesn't apply.
+                TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED,
+                        shard->file_type_) ||
+                    (memref.marker.type == TRACE_TYPE_MARKER &&
+                     (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+                      memref.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT)) ||
                     // TODO i#3937: Online instr bundles currently violate this.
                     !knob_offline_,
                 "Interruption marker mis-placed");

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1763,7 +1763,10 @@ raw2trace_t::handle_kernel_interrupt_and_markers(
             // rseq aborts with timestamps (i#5954) nor rseq side exits (i#5953) for
             // such traces but we can at least fix up typical aborts.
             if (!tdata->rseq_ever_saw_entry_ &&
-                in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT) {
+                in_entry->extended.valueB == TRACE_MARKER_TYPE_RSEQ_ABORT &&
+                // I-filtered don't have every instr so we can't roll back.
+                !TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED,
+                         get_file_type(tdata))) {
                 // For the older version, we will not get here for Windows
                 // callbacks, the other event with a 0 modoffs, because they are
                 // always between bbs.  (Unfortunately there's no simple way to


### PR DESCRIPTION
The #4343 namespace change PR #6169 changed suite/tests/rseq.c to be C++ which somehow triggered two problems with i-filtered traces.  To separate the fixes for those from the large namespace change we commit them separately:

+ Do not try to roll back rseq for i-filtered traces.

+ Do not complain about signal placement vs test-app annotations for i-filtered traces.

We rely on the rseq-filter test in PR #6169 as a test and do not attempt to add a different test here.

Issue: #4343