### PR TITLE
Fix out-of-bounds vector access in Scheduler

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1461,10 +1461,12 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input_as_previously(
         }
         if (inputs_[index].reader->get_instruction_ordinal() <
                 segment.start_instruction &&
-            // When we skip our separator+timestamp markers are at the
-            // prior instr ord so do not wait for that.
-            outputs_[output].record[outputs_[output].record_index].type !=
-                schedule_record_t::SKIP) {
+            // The output may have begun in the wait state.
+            (outputs_[output].record_index == -1 ||
+             // When we skip our separator+timestamp markers are at the
+             // prior instr ord so do not wait for that.
+             outputs_[output].record[outputs_[output].record_index].type !=
+                 schedule_record_t::SKIP)) {
             // Some other output stream has not advanced far enough, and we do
             // not support multiple positions in one input stream: we wait.
             // XXX i#5843: We may want to provide a kernel-mediated wait

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1967,7 +1967,7 @@ test_replay_as_traced()
 #ifdef HAS_ZIP
     std::cerr << "\n----------------\nTesting replay as-traced\n";
 
-    static constexpr int NUM_INPUTS = 4;
+    static constexpr int NUM_INPUTS = 5;
     static constexpr int NUM_OUTPUTS = 2;
     static constexpr int NUM_INSTRS = 9;
     static constexpr memref_tid_t TID_BASE = 100;
@@ -1978,17 +1978,21 @@ test_replay_as_traced()
         memref_tid_t tid = TID_BASE + i;
         inputs[i].push_back(make_thread(tid));
         inputs[i].push_back(make_pid(1));
-        for (int j = 0; j < NUM_INSTRS; j++)
+        // The last input will be earlier than all others. It will execute
+        // 3 instrs on each core. This is to test the case when an output
+        // begins in the wait state.
+        for (int j = 0; j < (i == NUM_INPUTS - 1 ? 6 : NUM_INSTRS); j++)
             inputs[i].push_back(make_instr(42 + j * 4));
         inputs[i].push_back(make_exit(tid));
     }
 
     // Synthesize a cpu-schedule file.
     std::string cpu_fname = "tmp_test_cpu_as_traced.zip";
-    static const char *const CORE0_SCHED_STRING = "AAACCCAAACCCBBBDDD";
-    static const char *const CORE1_SCHED_STRING = "BBBDDDBBBDDDAAACCC";
+    static const char *const CORE0_SCHED_STRING = "EEEAAACCCAAACCCBBBDDD";
+    static const char *const CORE1_SCHED_STRING = "EEEBBBDDDBBBDDDAAACCC";
     {
         std::vector<schedule_entry_t> sched0;
+        sched0.emplace_back(TID_BASE + 4, 10, CPU0, 0);
         sched0.emplace_back(TID_BASE, 101, CPU0, 0);
         sched0.emplace_back(TID_BASE + 2, 103, CPU0, 0);
         sched0.emplace_back(TID_BASE, 105, CPU0, 4);
@@ -1996,6 +2000,7 @@ test_replay_as_traced()
         sched0.emplace_back(TID_BASE + 1, 109, CPU0, 7);
         sched0.emplace_back(TID_BASE + 3, 111, CPU0, 7);
         std::vector<schedule_entry_t> sched1;
+        sched1.emplace_back(TID_BASE + 4, 20, CPU1, 4);
         sched1.emplace_back(TID_BASE + 1, 102, CPU1, 0);
         sched1.emplace_back(TID_BASE + 3, 104, CPU1, 0);
         sched1.emplace_back(TID_BASE + 1, 106, CPU1, 4);


### PR DESCRIPTION
Avoids an out-of-bounds vector access by checking for init value. This occurs in the case when an output starts in the wait state.

Modifies an existing scheduler unit test to test this case.