### PR TITLE
Sort also by CPU for schedule file invariant check

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -735,12 +735,15 @@ invariant_checker_t::check_schedule_data(per_shard_t *global)
             vec.insert(vec.end(), keyval.second.begin(), keyval.second.end());
         }
     }
-    std::sort(serial.begin(), serial.end(),
-              [](const schedule_entry_t &l, const schedule_entry_t &r) {
-                  if (l.timestamp == r.timestamp)
-                      return l.thread < r.thread;
-                  return l.timestamp < r.timestamp;
-              });
+    auto schedule_entry_comparator = [](const schedule_entry_t &l,
+                                        const schedule_entry_t &r) {
+        if (l.timestamp != r.timestamp)
+            return l.timestamp < r.timestamp;
+        if (l.cpu != r.cpu)
+            return l.cpu < r.cpu;
+        return l.thread < r.thread;
+    };
+    std::sort(serial.begin(), serial.end(), schedule_entry_comparator);
     // For entries with the same timestamp, the order can differ.  We could
     // identify each such sequence and collect it into a set but it is simpler to
     // read the whole file and sort it the same way.
@@ -751,12 +754,7 @@ invariant_checker_t::check_schedule_data(per_shard_t *global)
             serial_schedule_file_->read(reinterpret_cast<char *>(&next), sizeof(next))) {
             serial_file.push_back(next);
         }
-        std::sort(serial_file.begin(), serial_file.end(),
-                  [](const schedule_entry_t &l, const schedule_entry_t &r) {
-                      if (l.timestamp == r.timestamp)
-                          return l.thread < r.thread;
-                      return l.timestamp < r.timestamp;
-                  });
+        std::sort(serial_file.begin(), serial_file.end(), schedule_entry_comparator);
         if (knob_verbose_ >= 1) {
             std::cerr << "Serial schedule: read " << serial_file.size()
                       << " records from the file and observed " << serial.size()
@@ -785,12 +783,7 @@ invariant_checker_t::check_schedule_data(per_shard_t *global)
     if (cpu_schedule_file_ == nullptr)
         return;
     for (auto &keyval : cpu2sched) {
-        std::sort(keyval.second.begin(), keyval.second.end(),
-                  [](const schedule_entry_t &l, const schedule_entry_t &r) {
-                      if (l.timestamp == r.timestamp)
-                          return l.thread < r.thread;
-                      return l.timestamp < r.timestamp;
-                  });
+        std::sort(keyval.second.begin(), keyval.second.end(), schedule_entry_comparator);
     }
     // The zipfile reader will form a continuous stream from all elements in the
     // archive.  We figure out which cpu each one is from on the fly.

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -741,6 +741,11 @@ invariant_checker_t::check_schedule_data(per_shard_t *global)
             return l.timestamp < r.timestamp;
         if (l.cpu != r.cpu)
             return l.cpu < r.cpu;
+        // We really need to sort by either (timestamp, cpu_id) or
+        // (timestamp, thread_id): a single thread cannot be on two CPUs at
+        // the same timestamp; also a single CPU cannot have two threads at the
+        // same timestamp. We still sort by (timestamp, cpu_id, thread_id)
+        // to prevent inadvertent issues with test data.
         return l.thread < r.thread;
     };
     std::sort(serial.begin(), serial.end(), schedule_entry_comparator);


### PR DESCRIPTION
In some internal tests we modify the TID of some entries to test the schedule file invariant check. This inadvertently inverts the order of some entries for this check if the new synthetic TID matches with an existing real TID. By sorting also by CPU id, we ensure consistent ordering.