### PR TITLE
i#4343 namespaces: Add namespaces to drcpusim, drgui, drcov, samples

### DIFF
--- a/api/samples/callstack.cpp
+++ b/api/samples/callstack.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -45,6 +45,8 @@
 #include "droption.h"
 #include <string>
 
+namespace dynamorio {
+namespace samples {
 namespace {
 
 static droption_t<std::string> trace_function(
@@ -149,6 +151,8 @@ event_exit()
 }
 
 } // namespace
+} // namespace samples
+} // namespace dynamorio
 
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
@@ -164,9 +168,9 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     // Initialize the libraries we're using.
     if (!drwrap_init() || drcallstack_init(&ops) != DRCALLSTACK_SUCCESS ||
         drsym_init(0) != DRSYM_SUCCESS ||
-        !drmgr_register_module_load_event(module_load_event))
+        !drmgr_register_module_load_event(dynamorio::samples::module_load_event))
         DR_ASSERT(false);
-    dr_register_exit_event(event_exit);
+    dr_register_exit_event(dynamorio::samples::event_exit);
     // Improve performance as we only need basic wrapping support.
     drwrap_set_global_flags(
         static_cast<drwrap_global_flags_t>(DRWRAP_NO_FRILLS | DRWRAP_FAST_CLEANCALLS));

--- a/api/samples/inscount.cpp
+++ b/api/samples/inscount.cpp
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2014-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -50,6 +50,10 @@
 #include "droption.h"
 #include <string.h>
 
+namespace dynamorio {
+namespace samples {
+namespace {
+
 #ifdef WINDOWS
 #    define DISPLAY_STRING(msg) dr_messagebox(msg)
 #else
@@ -84,44 +88,6 @@ event_bb_analysis(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
 static dr_emit_flags_t
 event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst,
                       bool for_trace, bool translating, void *user_data);
-
-DR_EXPORT void
-dr_client_main(client_id_t id, int argc, const char *argv[])
-{
-    dr_set_client_name("DynamoRIO Sample Client 'inscount'",
-                       "http://dynamorio.org/issues");
-
-    /* Options */
-    if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv, NULL, NULL))
-        DR_ASSERT(false);
-    drmgr_init();
-
-    /* Get main module address */
-    if (only_from_app.get_value()) {
-        module_data_t *exe = dr_get_main_module();
-        if (exe != NULL)
-            exe_start = exe->start;
-        dr_free_module_data(exe);
-    }
-
-    /* register events */
-    dr_register_exit_event(event_exit);
-    drmgr_register_bb_instrumentation_event(event_bb_analysis, event_app_instruction,
-                                            NULL);
-
-    /* make it easy to tell, by looking at log file, which client executed */
-    dr_log(NULL, DR_LOG_ALL, 1, "Client 'inscount' initializing\n");
-#ifdef SHOW_RESULTS
-    /* also give notification to stderr */
-    if (dr_is_notify_on()) {
-#    ifdef WINDOWS
-        /* ask for best-effort printing to cmd window.  must be called at init. */
-        dr_enable_console_printing();
-#    endif
-        dr_fprintf(STDERR, "Client inscount is running\n");
-    }
-#endif
-}
 
 static void
 event_exit(void)
@@ -226,4 +192,47 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     dr_insert_clean_call(drcontext, bb, instrlist_first_app(bb), (void *)inscount,
                          false /* save fpstate */, 1, OPND_CREATE_INT32(num_instrs));
     return DR_EMIT_DEFAULT;
+}
+
+} // namespace
+} // namespace samples
+} // namespace dynamorio
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    dr_set_client_name("DynamoRIO Sample Client 'inscount'",
+                       "http://dynamorio.org/issues");
+
+    /* Options */
+    if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv, NULL, NULL))
+        DR_ASSERT(false);
+    drmgr_init();
+
+    /* Get main module address */
+    if (dynamorio::samples::only_from_app.get_value()) {
+        module_data_t *exe = dr_get_main_module();
+        if (exe != NULL)
+            dynamorio::samples::exe_start = exe->start;
+        dr_free_module_data(exe);
+    }
+
+    /* register events */
+    dr_register_exit_event(dynamorio::samples::event_exit);
+    drmgr_register_bb_instrumentation_event(dynamorio::samples::event_bb_analysis,
+                                            dynamorio::samples::event_app_instruction,
+                                            NULL);
+
+    /* make it easy to tell, by looking at log file, which client executed */
+    dr_log(NULL, DR_LOG_ALL, 1, "Client 'inscount' initializing\n");
+#ifdef SHOW_RESULTS
+    /* also give notification to stderr */
+    if (dr_is_notify_on()) {
+#    ifdef WINDOWS
+        /* ask for best-effort printing to cmd window.  must be called at init. */
+        dr_enable_console_printing();
+#    endif
+        dr_fprintf(STDERR, "Client inscount is running\n");
+    }
+#endif
 }

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -45,6 +45,10 @@
 #include "drreg.h"
 #include "drx.h"
 #include "droption.h"
+
+namespace dynamorio {
+namespace samples {
+namespace {
 
 #ifdef WINDOWS
 #    define DISPLAY_STRING(msg) dr_messagebox(msg)
@@ -140,6 +144,10 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     return DR_EMIT_DEFAULT;
 }
 
+} // namespace
+} // namespace samples
+} // namespace dynamorio
+
 DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
 {
@@ -148,7 +156,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* Get opcode and check if valid. */
-    int valid_opcode = opcode.get_value();
+    int valid_opcode = dynamorio::samples::opcode.get_value();
     if (valid_opcode < OP_FIRST || valid_opcode > OP_LAST) {
 #ifdef SHOW_RESULTS
         dr_fprintf(STDERR, "Error: give a valid opcode as a parameter.\n");
@@ -163,11 +171,12 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* Register opcode event. */
-    dr_register_exit_event(event_exit);
-    if (!drmgr_register_opcode_instrumentation_event(event_opcode_instruction,
-                                                     valid_opcode, NULL, NULL) ||
-        !drmgr_register_bb_instrumentation_event(event_bb_analysis, event_app_instruction,
-                                                 NULL))
+    dr_register_exit_event(dynamorio::samples::event_exit);
+    if (!drmgr_register_opcode_instrumentation_event(
+            dynamorio::samples::event_opcode_instruction, valid_opcode, NULL, NULL) ||
+        !drmgr_register_bb_instrumentation_event(
+            dynamorio::samples::event_bb_analysis,
+            dynamorio::samples::event_app_instruction, NULL))
         DR_ASSERT(false);
 
     /* Make it easy to tell, by looking at log file, which client executed. */

--- a/api/samples/stl_test.cpp
+++ b/api/samples/stl_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -49,9 +49,11 @@
 #    include <signal.h>
 #endif
 
-using namespace std;
+namespace dynamorio {
+namespace samples {
+namespace {
 
-#ifdef UNIX
+#if defined(UNIX) && defined(SHOW_RESULTS)
 __thread int tls_var;
 #endif
 
@@ -60,11 +62,16 @@ event_exit(void)
 {
 #ifdef SHOW_RESULTS
 #    ifdef UNIX
-    cout << "value of tls_var on exit: " << tls_var << endl;
+    std::cout << "value of tls_var on exit: " << tls_var << "\n";
 #    endif
-    cout << "Exit..." << endl;
+    std::cout << "Exit..."
+              << "\n";
 #endif
 }
+
+} // namespace
+} // namespace samples
+} // namespace dynamorio
 
 DR_EXPORT void
 dr_init(client_id_t client_id)
@@ -76,30 +83,32 @@ dr_init(client_id_t client_id)
                        "http://dynamorio.org/issues");
 
 #ifdef SHOW_RESULTS
-    cout << "Start..." << endl;
+    std::cout << "Start..."
+              << "\n";
 #endif
-    dr_register_exit_event(event_exit);
+    dr_register_exit_event(dynamorio::samples::event_exit);
 #if defined(UNIX) && defined(SHOW_RESULTS)
-    cout << "input a tls value" << endl;
-    cin >> tls_var;
-    cout << "Set tls var to " << tls_var << endl;
+    std::cout << "input a tls value"
+              << "\n";
+    std::cin >> dynamorio::samples::tls_var;
+    std::cout << "Set tls var to " << dynamorio::samples::tls_var << "\n";
 #endif
 
     //
     // Put values in a vector and read them out
     //
 #ifdef SHOW_RESULTS
-    cout << "testing vector...";
+    std::cout << "testing vector...";
 #endif
 
-    vector<int> *v = new vector<int>();
+    std::vector<int> *v = new std::vector<int>();
     for (i = 0; i < 5; i++) {
         v->push_back(i);
     }
 
     for (i = 0; i < 5; i++) {
 #ifdef SHOW_RESULTS
-        cout << (*v)[i];
+        std::cout << (*v)[i];
 #endif
         if ((*v)[i] != i) {
             success = false;
@@ -111,18 +120,18 @@ dr_init(client_id_t client_id)
     // Put values in a list and read them out
     //
 #ifdef SHOW_RESULTS
-    cout << "\ntesting list...";
+    std::cout << "\ntesting list...";
 #endif
 
-    list<int> l;
+    std::list<int> l;
     for (i = 0; i < 5; i++) {
         l.push_back(i);
     }
 
     i = 0;
-    for (list<int>::iterator l_iter = l.begin(); l_iter != l.end(); l_iter++) {
+    for (std::list<int>::iterator l_iter = l.begin(); l_iter != l.end(); l_iter++) {
 #ifdef SHOW_RESULTS
-        cout << *l_iter;
+        std::cout << *l_iter;
 #endif
         if (*l_iter != i) {
             success = false;
@@ -134,17 +143,17 @@ dr_init(client_id_t client_id)
     // Put values in a map and read them out
     //
 #ifdef SHOW_RESULTS
-    cout << "\ntesting map...";
+    std::cout << "\ntesting map...";
 #endif
 
-    map<int, int> m;
+    std::map<int, int> m;
     for (i = 0; i < 5; i++) {
         m[i] = i;
     }
 
     for (i = 0; i < 5; i++) {
 #ifdef SHOW_RESULTS
-        cout << m[i];
+        std::cout << m[i];
 #endif
         if (m[i] != i) {
             success = false;
@@ -159,13 +168,13 @@ dr_init(client_id_t client_id)
 #    ifdef WINDOWS
         dr_messagebox("SUCCESS");
 #    else
-        cout << "\nSUCCESS\n";
+        std::cout << "\nSUCCESS\n";
 #    endif
     } else {
 #    ifdef WINDOWS
         dr_messagebox("FAILURE");
 #    else
-        cout << "\nFAILURE\n";
+        std::cout << "\nFAILURE\n";
 #    endif
     }
 #endif

--- a/clients/drcov/postprocess/drcov2lcov.cpp
+++ b/clients/drcov/postprocess/drcov2lcov.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -65,9 +65,13 @@
 #    pragma comment(lib, "User32.lib")
 #endif
 
+namespace dynamorio {
+namespace drcov {
+namespace {
+
 #define PRINT(lvl, ...)                                         \
     do {                                                        \
-        if (op_verbose.get_value() >= lvl) {                    \
+        if (dynamorio::drcov::op_verbose.get_value() >= lvl) {  \
             fprintf(stdout, "[DRCOV2LCOV] INFO(%d):    ", lvl); \
             fprintf(stdout, __VA_ARGS__);                       \
         }                                                       \
@@ -75,7 +79,7 @@
 
 #define WARN(lvl, ...)                                          \
     do {                                                        \
-        if (op_warning.get_value() >= lvl) {                    \
+        if (dynamorio::drcov::op_warning.get_value() >= lvl) {  \
             fprintf(stderr, "[DRCOV2LCOV] WARNING(%d): ", lvl); \
             fprintf(stderr, __VA_ARGS__);                       \
         }                                                       \
@@ -1367,6 +1371,10 @@ option_init(int argc, const char *argv[])
     return true;
 }
 
+} // namespace
+} // namespace drcov
+} // namespace dynamorio
+
 /****************************************************************************
  * Main Function
  */
@@ -1374,7 +1382,7 @@ option_init(int argc, const char *argv[])
 int
 main(int argc, const char *argv[])
 {
-    if (!option_init(argc, argv))
+    if (!dynamorio::drcov::option_init(argc, argv))
         return 1;
 
     dr_standalone_init();
@@ -1382,36 +1390,37 @@ main(int argc, const char *argv[])
         ASSERT(false, "Unable to initialize symbol translation");
         return 1;
     }
-    hashtable_init_ex(&line_htable, LINE_HASH_TABLE_BITS, HASH_STRING, true /* strdup */,
-                      false /* !synch */, line_table_delete /* free */, NULL /* hash */,
+    hashtable_init_ex(&dynamorio::drcov::line_htable, LINE_HASH_TABLE_BITS, HASH_STRING,
+                      true /* strdup */, false /* !synch */,
+                      dynamorio::drcov::line_table_delete /* free */, NULL /* hash */,
                       NULL /* cmp */);
 
     PRINT(1, "Reading input files...\n");
-    if (!read_drcov_input()) {
+    if (!dynamorio::drcov::read_drcov_input()) {
         ASSERT(false, "Failed to read input files\n");
         return 1;
     }
 
     PRINT(1, "Enumerating line info...\n");
-    if (!enumerate_line_info()) {
+    if (!dynamorio::drcov::enumerate_line_info()) {
         ASSERT(false, "Failed to enumerate line info\n");
         return 1;
     }
 
     PRINT(1, "Writing output file...\n");
-    if (!write_lcov_output()) {
+    if (!dynamorio::drcov::write_lcov_output()) {
         ASSERT(false, "Failed to write output file\n");
         return 1;
     }
 
-    module_vec_delete();
-    hashtable_delete(&line_htable);
+    dynamorio::drcov::module_vec_delete();
+    hashtable_delete(&dynamorio::drcov::line_htable);
     if (drsym_exit() != DRSYM_SUCCESS) {
         ASSERT(false, "Failed to clean up symbol library\n");
         return 1;
     }
-    if (set_log != INVALID_FILE)
-        dr_close_file(set_log);
+    if (dynamorio::drcov::set_log != INVALID_FILE)
+        dr_close_file(dynamorio::drcov::set_log);
     dr_standalone_exit();
     return 0;
 }

--- a/clients/drcpusim/drcpusim.cpp
+++ b/clients/drcpusim/drcpusim.cpp
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -47,11 +47,14 @@
 #include <string>
 #include <sstream>
 
+namespace dynamorio {
+namespace drcpusim {
+
 // XXX i#1732: make a msgbox on Windows (controlled by option for batch runs)
-#define NOTIFY(level, ...)                     \
-    do {                                       \
-        if (op_verbose.get_value() >= (level)) \
-            dr_fprintf(STDERR, __VA_ARGS__);   \
+#define NOTIFY(level, ...)                                          \
+    do {                                                            \
+        if (dynamorio::drcpusim::op_verbose.get_value() >= (level)) \
+            dr_fprintf(STDERR, __VA_ARGS__);                        \
     } while (0)
 
 static bool (*opcode_supported)(instr_t *);
@@ -772,28 +775,9 @@ event_exit(void)
     drmgr_exit();
 }
 
-DR_EXPORT void
-dr_client_main(client_id_t id, int argc, const char *argv[])
+static void
+set_opcode_and_model()
 {
-    dr_set_client_name("DynamoRIO CPU Simulator", "http://dynamorio.org/issues");
-
-#ifdef WINDOWS
-    dr_enable_console_printing();
-#endif
-
-    std::string parse_err;
-    if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv, &parse_err,
-                                       NULL)) {
-        NOTIFY(0, "Usage error: %s\nUsage:\n%s", parse_err.c_str(),
-               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
-        dr_abort();
-    }
-    if (op_cpu.get_value().empty()) {
-        NOTIFY(0, "Usage error: cpu is required\nUsage:\n%s",
-               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
-        dr_abort();
-    }
-
 #ifdef X86
     if (op_cpu.get_value() == "Pentium") {
         opcode_supported = opcode_supported_Pentium;
@@ -854,18 +838,46 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     NOTIFY(0, "ARM not supported yet\n");
     dr_abort();
 #endif
+}
 
-    if (!op_blocklist.get_value().empty()) {
-        std::stringstream stream(op_blocklist.get_value());
-        std::string entry;
-        while (std::getline(stream, entry, ':'))
-            blocklist.push_back(entry);
+} // namespace drcpusim
+} // namespace dynamorio
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    dr_set_client_name("DynamoRIO CPU Simulator", "http://dynamorio.org/issues");
+
+#ifdef WINDOWS
+    dr_enable_console_printing();
+#endif
+
+    std::string parse_err;
+    if (!droption_parser_t::parse_argv(DROPTION_SCOPE_CLIENT, argc, argv, &parse_err,
+                                       NULL)) {
+        NOTIFY(0, "Usage error: %s\nUsage:\n%s", parse_err.c_str(),
+               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
+        dr_abort();
+    }
+    if (dynamorio::drcpusim::op_cpu.get_value().empty()) {
+        NOTIFY(0, "Usage error: cpu is required\nUsage:\n%s",
+               droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
+        dr_abort();
     }
 
-    if (op_ignore_all_libs.get_value()) {
+    dynamorio::drcpusim::set_opcode_and_model();
+
+    if (!dynamorio::drcpusim::op_blocklist.get_value().empty()) {
+        std::stringstream stream(dynamorio::drcpusim::op_blocklist.get_value());
+        std::string entry;
+        while (std::getline(stream, entry, ':'))
+            dynamorio::drcpusim::blocklist.push_back(entry);
+    }
+
+    if (dynamorio::drcpusim::op_ignore_all_libs.get_value()) {
         module_data_t *exe = dr_get_main_module();
         DR_ASSERT(exe != NULL);
-        exe_start = exe->start;
+        dynamorio::drcpusim::exe_start = exe->start;
         dr_free_module_data(exe);
     }
 
@@ -873,7 +885,8 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         DR_ASSERT(false);
 
     /* register events */
-    dr_register_exit_event(event_exit);
-    if (!drmgr_register_bb_instrumentation_event(NULL, event_app_instruction, NULL))
+    dr_register_exit_event(dynamorio::drcpusim::event_exit);
+    if (!drmgr_register_bb_instrumentation_event(
+            NULL, dynamorio::drcpusim::event_app_instruction, NULL))
         DR_ASSERT(false);
 }

--- a/clients/drcpusim/options.cpp
+++ b/clients/drcpusim/options.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -35,6 +35,9 @@
 #include <string>
 #include "droption.h"
 #include "options.h"
+
+namespace dynamorio {
+namespace drcpusim {
 
 #ifdef WINDOWS
 #    define IF_WINDOWS_ELSE(x, y) x
@@ -145,3 +148,6 @@ droption_t<bool> op_ignore_all_libs(
 droption_t<unsigned int> op_verbose(DROPTION_SCOPE_CLIENT, "verbose", 0, 0, 64,
                                     "Verbosity level",
                                     "Verbosity level for notifications.");
+
+} // namespace drcpusim
+} // namespace dynamorio

--- a/clients/drcpusim/options.h
+++ b/clients/drcpusim/options.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,6 +38,9 @@
 #include <string>
 #include "droption.h"
 
+namespace dynamorio {
+namespace drcpusim {
+
 extern droption_t<std::string> op_cpu;
 extern droption_t<bool> op_continue;
 extern droption_t<bool> op_fool_cpuid;
@@ -45,5 +48,8 @@ extern droption_t<bool> op_allow_prefetchw;
 extern droption_t<std::string> op_blocklist;
 extern droption_t<bool> op_ignore_all_libs;
 extern droption_t<unsigned int> op_verbose;
+
+} // namespace drcpusim
+} // namespace dynamorio
 
 #endif /* _OPTIONS_H_ */

--- a/ext/drgui/drgui_main_window.cpp
+++ b/ext/drgui/drgui_main_window.cpp
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -62,6 +62,9 @@
 #include "drgui_tool_interface.h"
 #include "drgui_options_window.h"
 #include "drgui_main_window.h"
+
+namespace dynamorio {
+namespace drgui {
 
 /* Public
  * Constructor, everything begins here
@@ -561,3 +564,6 @@ drgui_main_window_t::new_tool_instance(QWidget *tool, QString tool_name)
 {
     tab_area->setCurrentIndex(tab_area->addTab(tool, tool_name));
 }
+
+} // namespace drgui
+} // namespace dynamorio

--- a/ext/drgui/drgui_main_window.h
+++ b/ext/drgui/drgui_main_window.h
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -51,6 +51,9 @@ class QMdiArea;
 class QMdiSubWindow;
 class QActionGroup;
 class QPluginLoader;
+
+namespace dynamorio {
+namespace drgui {
 
 class drgui_options_window_t;
 class drgui_tool_interface_t;
@@ -175,5 +178,8 @@ private:
     QString custom_command_format;
     QList<QString> tool_files;
 };
+
+} // namespace drgui
+} // namespace dynamorio
 
 #endif

--- a/ext/drgui/drgui_options_interface.h
+++ b/ext/drgui/drgui_options_interface.h
@@ -1,4 +1,5 @@
 /* ***************************************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -40,6 +41,9 @@
 
 #include <QWidget>
 
+namespace dynamorio {
+namespace drgui {
+
 /**
  * Interface for tools' options pages that are to be accessed by drgui's
  * preferences dialog. The page will be accessed by drgui's preferences dialog
@@ -77,6 +81,10 @@ public:
 
 #define DrGUI_OptionsInterface_iid "DynamoRIO.DrGUI.OptionsInterface"
 
-Q_DECLARE_INTERFACE(drgui_options_interface_t, DrGUI_OptionsInterface_iid)
+} // namespace drgui
+} // namespace dynamorio
+
+Q_DECLARE_INTERFACE(dynamorio::drgui::drgui_options_interface_t,
+                    DrGUI_OptionsInterface_iid)
 
 #endif

--- a/ext/drgui/drgui_options_window.cpp
+++ b/ext/drgui/drgui_options_window.cpp
@@ -1,4 +1,5 @@
 /* ***************************************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -54,6 +55,9 @@
 #include "drgui_tool_interface.h"
 #include "drgui_options_interface.h"
 #include "drgui_options_window.h"
+
+namespace dynamorio {
+namespace drgui {
 
 /* Public
  * Constructor
@@ -182,3 +186,6 @@ drgui_options_window_t::cancel(void)
     if (sender() == cancel_button)
         close();
 }
+
+} // namespace drgui
+} // namespace dynamorio

--- a/ext/drgui/drgui_options_window.h
+++ b/ext/drgui/drgui_options_window.h
@@ -47,6 +47,9 @@ class QHBoxLayout;
 class QVBoxLayout;
 class QActionGroup;
 
+namespace dynamorio {
+namespace drgui {
+
 class drgui_options_window_t : public QDialog {
     Q_OBJECT
 
@@ -87,5 +90,8 @@ private:
 
     QActionGroup *tool_action_group;
 };
+
+} // namespace drgui
+} // namespace dynamorio
 
 #endif

--- a/ext/drgui/drgui_tool_interface.h
+++ b/ext/drgui/drgui_tool_interface.h
@@ -1,4 +1,5 @@
 /* ***************************************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -45,6 +46,9 @@
 #    define DRGUI_TOOL_INTERFACE_H
 
 #    include "drgui_options_interface.h"
+
+namespace dynamorio {
+namespace drgui {
 
 /**
  * Interface for drgui to interact with its loaded tools.
@@ -101,6 +105,9 @@ signals:
 
 #    define DrGUI_ToolInterface_iid "DynamoRIO.DrGUI.ToolInterface"
 
-Q_DECLARE_INTERFACE(drgui_tool_interface_t, DrGUI_ToolInterface_iid)
+} // namespace drgui
+} // namespace dynamorio
+
+Q_DECLARE_INTERFACE(dynamorio::drgui::drgui_tool_interface_t, DrGUI_ToolInterface_iid)
 
 #endif

--- a/ext/drgui/main.cpp
+++ b/ext/drgui/main.cpp
@@ -1,4 +1,5 @@
 /* ***************************************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2013 Branden Clark  All rights reserved.
  * ***************************************************************************/
 
@@ -40,6 +41,9 @@
 
 #include "drgui_main_window.h"
 
+namespace dynamorio {
+namespace drgui {
+
 struct tool_data_t {
     QString name;
     QStringList arguments;
@@ -49,23 +53,6 @@ static tool_data_t *
 process_arguments(int argc, char *argv[]);
 static void
 print_usage(char *arg_0);
-
-int
-main(int argc, char *argv[])
-{
-    QApplication app(argc, argv);
-    tool_data_t *tool = process_arguments(argc, argv);
-    QString tool_name = "";
-    QStringList tool_args;
-    if (tool != NULL) {
-        tool_name = tool->name;
-        tool_args = tool->arguments;
-        delete tool;
-    }
-    drgui_main_window_t main_win(tool_name, tool_args);
-    main_win.show();
-    return app.exec();
-}
 
 tool_data_t *
 process_arguments(int argc, char *argv[])
@@ -104,4 +91,24 @@ print_usage(char *arg_0)
     printf("  %-40s%s", "-t <tool_name> [options]",
            "Automatically load a tool with optional arguments");
     std::cout << std::endl;
+}
+
+} // namespace drgui
+} // namespace dynamorio
+
+int
+main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    dynamorio::drgui::tool_data_t *tool = dynamorio::drgui::process_arguments(argc, argv);
+    QString tool_name = "";
+    QStringList tool_args;
+    if (tool != NULL) {
+        tool_name = tool->name;
+        tool_args = tool->arguments;
+        delete tool;
+    }
+    dynamorio::drgui::drgui_main_window_t main_win(tool_name, tool_args);
+    main_win.show();
+    return app.exec();
 }

--- a/make/style_checks/exclude
+++ b/make/style_checks/exclude
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 # **********************************************************
-# Copyright (c) 2017-2021 Google, Inc.    All rights reserved.
+# Copyright (c) 2017-2023 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -44,6 +44,7 @@ set rules {
     break_after_return_type
     no_space_after_control
     space_after_call
+    required_namespaces
 }
 
 foreach rule $rules {


### PR DESCRIPTION
Adds dynamorio::<name> namespaces to drcpusim, drgui, drcov2lcov, and our C++ samples.

Adds a new vera++ check that all C++ files have namespaces; it excludes droption which is still not converted.
It only checks that namespace declarations are present, catching the most common error of a new file being
added but omitting namespaces.  it does not try to check that all code is inside the namespace (there are multiple
exceptions there to handle and it gets complex).

Issue: #4343