### PR TITLE
i#5844 scatter-gather: Fix broken include path

### DIFF
--- a/ext/drx/scatter_gather_x86.c
+++ b/ext/drx/scatter_gather_x86.c
@@ -50,7 +50,7 @@
 
 #ifdef UNIX
 #    ifdef LINUX
-#        include "../../../core/unix/include/syscall.h"
+#        include "../../core/unix/include/syscall.h"
 #    else
 #        include <sys/syscall.h>
 #    endif


### PR DESCRIPTION
Fixes a build breakage introduced in PR #6173 with an invalid include path.

Issue: #5844