### PR TITLE
i#3044 Add AArch64 SVE codec: Gather load non-temporal signed

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -7889,6 +7889,71 @@ encode_opnd_x16imm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
     return false;
 }
 
+/* svemem_vec_sd_gpr16: SVE memory address with GPR offset [<Zn>.S/D{, <Xm>}] */
+
+static inline bool
+decode_opnd_svemem_vec_sd_gpr16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    const aarch64_reg_offset msz = BITS(enc, 24, 23);
+    const uint scale = 1 << msz;
+
+    const aarch64_reg_offset element_size =
+        BITS(enc, 30, 30) > 0 ? DOUBLE_REG : SINGLE_REG;
+
+    const opnd_size_t mem_transfer =
+        opnd_size_from_bytes(scale * get_elements_in_sve_vector(element_size));
+
+    const reg_id_t zn = decode_vreg(Z_REG, extract_uint(enc, 5, 5));
+    ASSERT(reg_is_z(zn));
+
+    const reg_id_t xm = decode_reg(extract_uint(enc, 16, 5), true, false /* XZR */);
+    ASSERT(reg_is_gpr(xm));
+
+    *opnd = opnd_create_vector_base_disp_aarch64(
+        zn, xm, get_opnd_size_from_offset(element_size), DR_EXTEND_UXTX, false, 0, 0,
+        mem_transfer, 0);
+    return true;
+}
+
+static inline bool
+encode_opnd_svemem_vec_sd_gpr16(uint enc, int opcode, byte *pc, opnd_t opnd,
+                                OUT uint *enc_out)
+{
+    // Element size is a part of the constant bits
+    const aarch64_reg_offset element_size =
+        BITS(enc, 30, 30) > 0 ? DOUBLE_REG : SINGLE_REG;
+
+    if (!opnd_is_base_disp(opnd) || opnd_get_index(opnd) == DR_REG_NULL ||
+        get_vector_element_reg_offset(opnd) != element_size)
+        return false;
+
+    bool index_scaled;
+    uint index_scale_amount;
+    if (opnd_get_index_extend(opnd, &index_scaled, &index_scale_amount) !=
+            DR_EXTEND_UXTX ||
+        index_scaled || index_scale_amount != 0)
+        return false;
+
+    uint zreg_number;
+    opnd_size_t reg_size = OPSZ_SCALABLE;
+    IF_RETURN_FALSE(!encode_vreg(&reg_size, &zreg_number, opnd_get_base(opnd)))
+
+    const aarch64_reg_offset msz = BITS(enc, 24, 23);
+    const uint scale = 1 << msz;
+
+    const opnd_size_t mem_transfer =
+        opnd_size_from_bytes(scale * get_elements_in_sve_vector(element_size));
+    IF_RETURN_FALSE(opnd_get_size(opnd) != mem_transfer)
+
+    uint xreg_number;
+    bool is_x = false;
+    IF_RETURN_FALSE(!encode_reg(&xreg_number, &is_x, opnd_get_index(opnd), false) ||
+                    !is_x)
+
+    *enc_out |= (xreg_number << 16) | (zreg_number << 5);
+    return true;
+}
+
 /* index3: index of D subreg in Q register: 0-1 */
 
 static inline bool

--- a/core/ir/aarch64/codec_sve2.txt
+++ b/core/ir/aarch64/codec_sve2.txt
@@ -82,6 +82,11 @@
 01100100101xxxxx0110x1xxxxxxxxxx  n   1070 SVE2    fmlslt          z_s_0 : z_s_0 z_msz_bhsd_5 z3_msz_bhsd_16 i3_index_11
 01000101xx1xxxxx110xxxxxxxxxxxxx  n   1145 SVE2   histcnt    z_size_sd_0 : p10_zer_lo z_size_sd_5 z_size_sd_16
 01000101001xxxxx101000xxxxxxxxxx  n   1071 SVE2   histseg          z_b_0 : z_b_5 z_b_16
+11000100000xxxxx100xxxxxxxxxxxxx  n   1186 SVE2   ldnt1sb          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
+10000100000xxxxx100xxxxxxxxxxxxx  n   1186 SVE2   ldnt1sb          z_s_0 : svemem_vec_sd_gpr16 p10_zer_lo
+11000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
+10000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_s_0 : svemem_vec_sd_gpr16 p10_zer_lo
+11000101000xxxxx100xxxxxxxxxxxxx  n   1188 SVE2   ldnt1sw          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
 00000100111xxxxx001111xxxxxxxxxx  n   1072 SVE2      nbsl          z_d_0 : z_d_0 z_d_16 z_d_5
 00000100001xxxxx011001xxxxxxxxxx  n   328  SVE2      pmul   z_msz_bhsd_0 : z_msz_bhsd_5 z_msz_bhsd_16
 01000101xx0xxxxx011010xxxxxxxxxx  n   1084 SVE2    pmullb    z_size_hd_0 : z_sizep1_bs_5 z_sizep1_bs_16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -17411,4 +17411,60 @@
  */
 #define INSTR_CREATE_xar_sve(dc, Zdn, Zm, imm) \
     instr_create_1dst_3src(dc, OP_xar, Zdn, Zdn, Zm, imm)
+
+/**
+ * Creates a LDNT1SB instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      LDNT1SB { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
+      LDNT1SB { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register. Can be Z.d or Z.s.
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The first source vector base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Rm,
+ *             OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0, OPSZ_4, 0)
+ */
+#define INSTR_CREATE_ldnt1sb_sve_pred(dc, Zt, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_ldnt1sb, Zt, Zn, Pg)
+
+/**
+ * Creates a LDNT1SH instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      LDNT1SH { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
+      LDNT1SH { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register. Can be Z.d or Z.s.
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The first source vector base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Rm,
+ *             OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0, OPSZ_8, 0)
+ */
+#define INSTR_CREATE_ldnt1sh_sve_pred(dc, Zt, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_ldnt1sh, Zt, Zn, Pg)
+
+/**
+ * Creates a LDNT1SW instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      LDNT1SW { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zt   The destination vector register, Z.d.
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The first source vector base register with a register offset,
+ *             constructed with the function:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Rm,
+ *             OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0, OPSZ_16, 0)
+ */
+#define INSTR_CREATE_ldnt1sw_sve_pred(dc, Zt, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_ldnt1sw, Zt, Zn, Pg)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -342,7 +342,7 @@
 --------xx-xxxxx----------------  imm2_tsz_index   # Index encoded in imm2:tsz
 -------??--xxxxx------xxxxx-----  svemem_vec_s_imm5 # SVE memory address [<Zn>.S{, #<imm>}]
 -------??--xxxxx------xxxxx-----  svemem_vec_d_imm5 # SVE memory address [<Zn>.D{, #<imm>}]
--------??--xxxxx------xxxxx-----  sveprf_gpr_shf   # SVE memory address [<Xn|SP>, <Xm>, LSL #x] for prefetch operations
+-------??--xxxxx------xxxxx-----  sveprf_gpr_shf   # SVE memory address [<Xn|SP>, <Xm>, LSL #x] for prefetch operation
 -------??-?xxxxx------xxxxx-----  svemem_gpr_vec64 # SVE memory address (64-bit offset) [<Xn|SP>, <Zm>.D{, <mod>}]
 -------????-xxxx------xxxxx-----  svemem_gpr_simm4_vl_1reg # SVE memory operand [<Xn|SP>{, #<imm>, MUL VL}]
                                                            # 1 src/dest register
@@ -361,6 +361,7 @@
 -------xx--xxxxx----------------  z_msz_bhsd_16   # z register with element size determined by msz
 -?--------------------xxxxx-----  mem0p      # gets size from 30; no offset, pair
 -?---------xxxxx????------------  x16imm     # computes immed from 30 and 15:12
+-?-----??--xxxxx------xxxxx-----  svemem_vec_sd_gpr16  # SVE memory address with GPR offset [<Zn>.S/D{, <Xm>}]
 -x------------------------------  index3     # index of D subreg in Q: 0-1
 -x-------------------------xxxxx  wx0_30     # X register if bit 30 is set, else W
 -x-------------------------xxxxx  dq0        # Q register if bit 30 is set, else D

--- a/suite/tests/api/dis-a64-sve2.txt
+++ b/suite/tests/api/dis-a64-sve2.txt
@@ -1528,6 +1528,96 @@
 453da39b : histseg z27.b, z28.b, z29.b               : histseg %z28.b %z29.b -> %z27.b
 453fa3ff : histseg z31.b, z31.b, z31.b               : histseg %z31.b %z31.b -> %z31.b
 
+# LDNT1SB { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] (LDNT1SB-Z.P.AR-S.x32.unscaled)
+84008000 : ldnt1sb z0.s, p0/Z, [z0.s, x0]            : ldnt1sb (%z0.s,%x0)[8byte] %p0/z -> %z0.s
+84058482 : ldnt1sb z2.s, p1/Z, [z4.s, x5]            : ldnt1sb (%z4.s,%x5)[8byte] %p1/z -> %z2.s
+840788c4 : ldnt1sb z4.s, p2/Z, [z6.s, x7]            : ldnt1sb (%z6.s,%x7)[8byte] %p2/z -> %z4.s
+84098906 : ldnt1sb z6.s, p2/Z, [z8.s, x9]            : ldnt1sb (%z8.s,%x9)[8byte] %p2/z -> %z6.s
+840b8d48 : ldnt1sb z8.s, p3/Z, [z10.s, x11]          : ldnt1sb (%z10.s,%x11)[8byte] %p3/z -> %z8.s
+840c8d8a : ldnt1sb z10.s, p3/Z, [z12.s, x12]         : ldnt1sb (%z12.s,%x12)[8byte] %p3/z -> %z10.s
+840e91cc : ldnt1sb z12.s, p4/Z, [z14.s, x14]         : ldnt1sb (%z14.s,%x14)[8byte] %p4/z -> %z12.s
+8410920e : ldnt1sb z14.s, p4/Z, [z16.s, x16]         : ldnt1sb (%z16.s,%x16)[8byte] %p4/z -> %z14.s
+84129650 : ldnt1sb z16.s, p5/Z, [z18.s, x18]         : ldnt1sb (%z18.s,%x18)[8byte] %p5/z -> %z16.s
+84149671 : ldnt1sb z17.s, p5/Z, [z19.s, x20]         : ldnt1sb (%z19.s,%x20)[8byte] %p5/z -> %z17.s
+841696b3 : ldnt1sb z19.s, p5/Z, [z21.s, x22]         : ldnt1sb (%z21.s,%x22)[8byte] %p5/z -> %z19.s
+84189af5 : ldnt1sb z21.s, p6/Z, [z23.s, x24]         : ldnt1sb (%z23.s,%x24)[8byte] %p6/z -> %z21.s
+84199b37 : ldnt1sb z23.s, p6/Z, [z25.s, x25]         : ldnt1sb (%z25.s,%x25)[8byte] %p6/z -> %z23.s
+841b9f79 : ldnt1sb z25.s, p7/Z, [z27.s, x27]         : ldnt1sb (%z27.s,%x27)[8byte] %p7/z -> %z25.s
+841d9fbb : ldnt1sb z27.s, p7/Z, [z29.s, x29]         : ldnt1sb (%z29.s,%x29)[8byte] %p7/z -> %z27.s
+841e9fff : ldnt1sb z31.s, p7/Z, [z31.s, x30]         : ldnt1sb (%z31.s,%x30)[8byte] %p7/z -> %z31.s
+
+# LDNT1SB { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] (LDNT1SB-Z.P.AR-D.64.unscaled)
+c4008000 : ldnt1sb z0.d, p0/Z, [z0.d, x0]            : ldnt1sb (%z0.d,%x0)[4byte] %p0/z -> %z0.d
+c4058482 : ldnt1sb z2.d, p1/Z, [z4.d, x5]            : ldnt1sb (%z4.d,%x5)[4byte] %p1/z -> %z2.d
+c40788c4 : ldnt1sb z4.d, p2/Z, [z6.d, x7]            : ldnt1sb (%z6.d,%x7)[4byte] %p2/z -> %z4.d
+c4098906 : ldnt1sb z6.d, p2/Z, [z8.d, x9]            : ldnt1sb (%z8.d,%x9)[4byte] %p2/z -> %z6.d
+c40b8d48 : ldnt1sb z8.d, p3/Z, [z10.d, x11]          : ldnt1sb (%z10.d,%x11)[4byte] %p3/z -> %z8.d
+c40c8d8a : ldnt1sb z10.d, p3/Z, [z12.d, x12]         : ldnt1sb (%z12.d,%x12)[4byte] %p3/z -> %z10.d
+c40e91cc : ldnt1sb z12.d, p4/Z, [z14.d, x14]         : ldnt1sb (%z14.d,%x14)[4byte] %p4/z -> %z12.d
+c410920e : ldnt1sb z14.d, p4/Z, [z16.d, x16]         : ldnt1sb (%z16.d,%x16)[4byte] %p4/z -> %z14.d
+c4129650 : ldnt1sb z16.d, p5/Z, [z18.d, x18]         : ldnt1sb (%z18.d,%x18)[4byte] %p5/z -> %z16.d
+c4149671 : ldnt1sb z17.d, p5/Z, [z19.d, x20]         : ldnt1sb (%z19.d,%x20)[4byte] %p5/z -> %z17.d
+c41696b3 : ldnt1sb z19.d, p5/Z, [z21.d, x22]         : ldnt1sb (%z21.d,%x22)[4byte] %p5/z -> %z19.d
+c4189af5 : ldnt1sb z21.d, p6/Z, [z23.d, x24]         : ldnt1sb (%z23.d,%x24)[4byte] %p6/z -> %z21.d
+c4199b37 : ldnt1sb z23.d, p6/Z, [z25.d, x25]         : ldnt1sb (%z25.d,%x25)[4byte] %p6/z -> %z23.d
+c41b9f79 : ldnt1sb z25.d, p7/Z, [z27.d, x27]         : ldnt1sb (%z27.d,%x27)[4byte] %p7/z -> %z25.d
+c41d9fbb : ldnt1sb z27.d, p7/Z, [z29.d, x29]         : ldnt1sb (%z29.d,%x29)[4byte] %p7/z -> %z27.d
+c41e9fff : ldnt1sb z31.d, p7/Z, [z31.d, x30]         : ldnt1sb (%z31.d,%x30)[4byte] %p7/z -> %z31.d
+
+# LDNT1SH { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] (LDNT1SH-Z.P.AR-S.x32.unscaled)
+84808000 : ldnt1sh z0.s, p0/Z, [z0.s, x0]            : ldnt1sh (%z0.s,%x0)[16byte] %p0/z -> %z0.s
+84858482 : ldnt1sh z2.s, p1/Z, [z4.s, x5]            : ldnt1sh (%z4.s,%x5)[16byte] %p1/z -> %z2.s
+848788c4 : ldnt1sh z4.s, p2/Z, [z6.s, x7]            : ldnt1sh (%z6.s,%x7)[16byte] %p2/z -> %z4.s
+84898906 : ldnt1sh z6.s, p2/Z, [z8.s, x9]            : ldnt1sh (%z8.s,%x9)[16byte] %p2/z -> %z6.s
+848b8d48 : ldnt1sh z8.s, p3/Z, [z10.s, x11]          : ldnt1sh (%z10.s,%x11)[16byte] %p3/z -> %z8.s
+848c8d8a : ldnt1sh z10.s, p3/Z, [z12.s, x12]         : ldnt1sh (%z12.s,%x12)[16byte] %p3/z -> %z10.s
+848e91cc : ldnt1sh z12.s, p4/Z, [z14.s, x14]         : ldnt1sh (%z14.s,%x14)[16byte] %p4/z -> %z12.s
+8490920e : ldnt1sh z14.s, p4/Z, [z16.s, x16]         : ldnt1sh (%z16.s,%x16)[16byte] %p4/z -> %z14.s
+84929650 : ldnt1sh z16.s, p5/Z, [z18.s, x18]         : ldnt1sh (%z18.s,%x18)[16byte] %p5/z -> %z16.s
+84949671 : ldnt1sh z17.s, p5/Z, [z19.s, x20]         : ldnt1sh (%z19.s,%x20)[16byte] %p5/z -> %z17.s
+849696b3 : ldnt1sh z19.s, p5/Z, [z21.s, x22]         : ldnt1sh (%z21.s,%x22)[16byte] %p5/z -> %z19.s
+84989af5 : ldnt1sh z21.s, p6/Z, [z23.s, x24]         : ldnt1sh (%z23.s,%x24)[16byte] %p6/z -> %z21.s
+84999b37 : ldnt1sh z23.s, p6/Z, [z25.s, x25]         : ldnt1sh (%z25.s,%x25)[16byte] %p6/z -> %z23.s
+849b9f79 : ldnt1sh z25.s, p7/Z, [z27.s, x27]         : ldnt1sh (%z27.s,%x27)[16byte] %p7/z -> %z25.s
+849d9fbb : ldnt1sh z27.s, p7/Z, [z29.s, x29]         : ldnt1sh (%z29.s,%x29)[16byte] %p7/z -> %z27.s
+849e9fff : ldnt1sh z31.s, p7/Z, [z31.s, x30]         : ldnt1sh (%z31.s,%x30)[16byte] %p7/z -> %z31.s
+
+# LDNT1SH { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] (LDNT1SH-Z.P.AR-D.64.unscaled)
+c4808000 : ldnt1sh z0.d, p0/Z, [z0.d, x0]            : ldnt1sh (%z0.d,%x0)[8byte] %p0/z -> %z0.d
+c4858482 : ldnt1sh z2.d, p1/Z, [z4.d, x5]            : ldnt1sh (%z4.d,%x5)[8byte] %p1/z -> %z2.d
+c48788c4 : ldnt1sh z4.d, p2/Z, [z6.d, x7]            : ldnt1sh (%z6.d,%x7)[8byte] %p2/z -> %z4.d
+c4898906 : ldnt1sh z6.d, p2/Z, [z8.d, x9]            : ldnt1sh (%z8.d,%x9)[8byte] %p2/z -> %z6.d
+c48b8d48 : ldnt1sh z8.d, p3/Z, [z10.d, x11]          : ldnt1sh (%z10.d,%x11)[8byte] %p3/z -> %z8.d
+c48c8d8a : ldnt1sh z10.d, p3/Z, [z12.d, x12]         : ldnt1sh (%z12.d,%x12)[8byte] %p3/z -> %z10.d
+c48e91cc : ldnt1sh z12.d, p4/Z, [z14.d, x14]         : ldnt1sh (%z14.d,%x14)[8byte] %p4/z -> %z12.d
+c490920e : ldnt1sh z14.d, p4/Z, [z16.d, x16]         : ldnt1sh (%z16.d,%x16)[8byte] %p4/z -> %z14.d
+c4929650 : ldnt1sh z16.d, p5/Z, [z18.d, x18]         : ldnt1sh (%z18.d,%x18)[8byte] %p5/z -> %z16.d
+c4949671 : ldnt1sh z17.d, p5/Z, [z19.d, x20]         : ldnt1sh (%z19.d,%x20)[8byte] %p5/z -> %z17.d
+c49696b3 : ldnt1sh z19.d, p5/Z, [z21.d, x22]         : ldnt1sh (%z21.d,%x22)[8byte] %p5/z -> %z19.d
+c4989af5 : ldnt1sh z21.d, p6/Z, [z23.d, x24]         : ldnt1sh (%z23.d,%x24)[8byte] %p6/z -> %z21.d
+c4999b37 : ldnt1sh z23.d, p6/Z, [z25.d, x25]         : ldnt1sh (%z25.d,%x25)[8byte] %p6/z -> %z23.d
+c49b9f79 : ldnt1sh z25.d, p7/Z, [z27.d, x27]         : ldnt1sh (%z27.d,%x27)[8byte] %p7/z -> %z25.d
+c49d9fbb : ldnt1sh z27.d, p7/Z, [z29.d, x29]         : ldnt1sh (%z29.d,%x29)[8byte] %p7/z -> %z27.d
+c49e9fff : ldnt1sh z31.d, p7/Z, [z31.d, x30]         : ldnt1sh (%z31.d,%x30)[8byte] %p7/z -> %z31.d
+
+# LDNT1SW { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] (LDNT1SW-Z.P.AR-D.64.unscaled)
+c5008000 : ldnt1sw z0.d, p0/Z, [z0.d, x0]            : ldnt1sw (%z0.d,%x0)[16byte] %p0/z -> %z0.d
+c5058482 : ldnt1sw z2.d, p1/Z, [z4.d, x5]            : ldnt1sw (%z4.d,%x5)[16byte] %p1/z -> %z2.d
+c50788c4 : ldnt1sw z4.d, p2/Z, [z6.d, x7]            : ldnt1sw (%z6.d,%x7)[16byte] %p2/z -> %z4.d
+c5098906 : ldnt1sw z6.d, p2/Z, [z8.d, x9]            : ldnt1sw (%z8.d,%x9)[16byte] %p2/z -> %z6.d
+c50b8d48 : ldnt1sw z8.d, p3/Z, [z10.d, x11]          : ldnt1sw (%z10.d,%x11)[16byte] %p3/z -> %z8.d
+c50c8d8a : ldnt1sw z10.d, p3/Z, [z12.d, x12]         : ldnt1sw (%z12.d,%x12)[16byte] %p3/z -> %z10.d
+c50e91cc : ldnt1sw z12.d, p4/Z, [z14.d, x14]         : ldnt1sw (%z14.d,%x14)[16byte] %p4/z -> %z12.d
+c510920e : ldnt1sw z14.d, p4/Z, [z16.d, x16]         : ldnt1sw (%z16.d,%x16)[16byte] %p4/z -> %z14.d
+c5129650 : ldnt1sw z16.d, p5/Z, [z18.d, x18]         : ldnt1sw (%z18.d,%x18)[16byte] %p5/z -> %z16.d
+c5149671 : ldnt1sw z17.d, p5/Z, [z19.d, x20]         : ldnt1sw (%z19.d,%x20)[16byte] %p5/z -> %z17.d
+c51696b3 : ldnt1sw z19.d, p5/Z, [z21.d, x22]         : ldnt1sw (%z21.d,%x22)[16byte] %p5/z -> %z19.d
+c5189af5 : ldnt1sw z21.d, p6/Z, [z23.d, x24]         : ldnt1sw (%z23.d,%x24)[16byte] %p6/z -> %z21.d
+c5199b37 : ldnt1sw z23.d, p6/Z, [z25.d, x25]         : ldnt1sw (%z25.d,%x25)[16byte] %p6/z -> %z23.d
+c51b9f79 : ldnt1sw z25.d, p7/Z, [z27.d, x27]         : ldnt1sw (%z27.d,%x27)[16byte] %p7/z -> %z25.d
+c51d9fbb : ldnt1sw z27.d, p7/Z, [z29.d, x29]         : ldnt1sw (%z29.d,%x29)[16byte] %p7/z -> %z27.d
+c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16byte] %p7/z -> %z31.d
+
 # NBSL    <Zdn>.D, <Zdn>.D, <Zm>.D, <Zk>.D (NBSL-Z.ZZZ-_)
 04e03c00 : nbsl z0.d, z0.d, z0.d, z0.d               : nbsl   %z0.d %z0.d %z0.d -> %z0.d
 04e33c82 : nbsl z2.d, z2.d, z3.d, z4.d               : nbsl   %z2.d %z3.d %z4.d -> %z2.d

--- a/suite/tests/api/ir_aarch64_sve2.c
+++ b/suite/tests/api/ir_aarch64_sve2.c
@@ -7662,6 +7662,97 @@ TEST_INSTR(xar_sve)
               opnd_create_immed_uint(imm3_0_3[i], OPSZ_6b));
 }
 
+TEST_INSTR(ldnt1sb_sve_pred)
+{
+
+    /* Testing LDNT1SB { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "ldnt1sb (%z0.d,%x0)[4byte] %p0/z -> %z0.d",
+        "ldnt1sb (%z7.d,%x8)[4byte] %p2/z -> %z5.d",
+        "ldnt1sb (%z12.d,%x13)[4byte] %p3/z -> %z10.d",
+        "ldnt1sb (%z18.d,%x18)[4byte] %p5/z -> %z16.d",
+        "ldnt1sb (%z23.d,%x23)[4byte] %p6/z -> %z21.d",
+        "ldnt1sb (%z31.d,%x30)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldnt1sb, ldnt1sb_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_4, 0));
+
+    /* Testing LDNT1SB { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "ldnt1sb (%z0.s,%x0)[8byte] %p0/z -> %z0.s",
+        "ldnt1sb (%z7.s,%x8)[8byte] %p2/z -> %z5.s",
+        "ldnt1sb (%z12.s,%x13)[8byte] %p3/z -> %z10.s",
+        "ldnt1sb (%z18.s,%x18)[8byte] %p5/z -> %z16.s",
+        "ldnt1sb (%z23.s,%x23)[8byte] %p6/z -> %z21.s",
+        "ldnt1sb (%z31.s,%x30)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldnt1sb, ldnt1sb_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_8, 0));
+}
+
+TEST_INSTR(ldnt1sh_sve_pred)
+{
+
+    /* Testing LDNT1SH { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "ldnt1sh (%z0.d,%x0)[8byte] %p0/z -> %z0.d",
+        "ldnt1sh (%z7.d,%x8)[8byte] %p2/z -> %z5.d",
+        "ldnt1sh (%z12.d,%x13)[8byte] %p3/z -> %z10.d",
+        "ldnt1sh (%z18.d,%x18)[8byte] %p5/z -> %z16.d",
+        "ldnt1sh (%z23.d,%x23)[8byte] %p6/z -> %z21.d",
+        "ldnt1sh (%z31.d,%x30)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldnt1sh, ldnt1sh_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_8, 0));
+
+    /* Testing LDNT1SH { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "ldnt1sh (%z0.s,%x0)[16byte] %p0/z -> %z0.s",
+        "ldnt1sh (%z7.s,%x8)[16byte] %p2/z -> %z5.s",
+        "ldnt1sh (%z12.s,%x13)[16byte] %p3/z -> %z10.s",
+        "ldnt1sh (%z18.s,%x18)[16byte] %p5/z -> %z16.s",
+        "ldnt1sh (%z23.s,%x23)[16byte] %p6/z -> %z21.s",
+        "ldnt1sh (%z31.s,%x30)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldnt1sh, ldnt1sh_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_16, 0));
+}
+
+TEST_INSTR(ldnt1sw_sve_pred)
+{
+
+    /* Testing LDNT1SW { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "ldnt1sw (%z0.d,%x0)[16byte] %p0/z -> %z0.d",
+        "ldnt1sw (%z7.d,%x8)[16byte] %p2/z -> %z5.d",
+        "ldnt1sw (%z12.d,%x13)[16byte] %p3/z -> %z10.d",
+        "ldnt1sw (%z18.d,%x18)[16byte] %p5/z -> %z16.d",
+        "ldnt1sw (%z23.d,%x23)[16byte] %p6/z -> %z21.d",
+        "ldnt1sw (%z31.d,%x30)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldnt1sw, ldnt1sw_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_16, 0));
+}
 int
 main(int argc, char *argv[])
 {
@@ -7884,6 +7975,10 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ushllt_sve);
     RUN_INSTR_TEST(usra_sve);
     RUN_INSTR_TEST(xar_sve);
+
+    RUN_INSTR_TEST(ldnt1sb_sve_pred);
+    RUN_INSTR_TEST(ldnt1sh_sve_pred);
+    RUN_INSTR_TEST(ldnt1sw_sve_pred);
 
     print("All SVE2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
LDNT1SB { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
LDNT1SB { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
LDNT1SH { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
LDNT1SH { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
LDNT1SW { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]

Issue: #3044