### PR TITLE
i#5383 mac a64, part 4: Enable tests to build

### DIFF
--- a/api/samples/stl_test.cpp
+++ b/api/samples/stl_test.cpp
@@ -77,7 +77,9 @@ DR_EXPORT void
 dr_init(client_id_t client_id)
 {
     int i;
+#ifdef SHOW_RESULTS
     bool success = true;
+#endif
 
     dr_set_client_name("DynamoRIO Sample Client 'stl_test'",
                        "http://dynamorio.org/issues");
@@ -109,10 +111,10 @@ dr_init(client_id_t client_id)
     for (i = 0; i < 5; i++) {
 #ifdef SHOW_RESULTS
         std::cout << (*v)[i];
-#endif
         if ((*v)[i] != i) {
             success = false;
         }
+#endif
     }
     delete v;
 
@@ -132,10 +134,10 @@ dr_init(client_id_t client_id)
     for (std::list<int>::iterator l_iter = l.begin(); l_iter != l.end(); l_iter++) {
 #ifdef SHOW_RESULTS
         std::cout << *l_iter;
-#endif
         if (*l_iter != i) {
             success = false;
         }
+#endif
         i++;
     }
 
@@ -154,10 +156,10 @@ dr_init(client_id_t client_id)
     for (i = 0; i < 5; i++) {
 #ifdef SHOW_RESULTS
         std::cout << m[i];
-#endif
         if (m[i] != i) {
             success = false;
         }
+#endif
     }
 
     //

--- a/clients/drcachesim/tests/allasm_aarch64_flush.asm
+++ b/clients/drcachesim/tests/allasm_aarch64_flush.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc. All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc. All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -42,7 +42,13 @@ _start:
         sub      x0, x0, #1024 // x0 is bottom of region
         mov      sp, x0
 
+#ifdef __APPLE__
+        // XXX: Try to include asm_defines.asm for AARCH64_ADR_GOT().
+        adrp     x0, helloworld@PAGE
+        add      x0, x0, helloworld@PAGEOFF
+#else
         adr      x0, helloworld
+#endif
         adr      x1, .
 
         // Data cache flush operations.
@@ -55,7 +61,12 @@ _start:
 
         // Exit.
         mov      w0, #1            // stdout
+#ifdef __APPLE__
+        adrp     x1, helloworld@PAGE
+        add      x1, x1, helloworld@PAGEOFF
+#else
         adr      x1, helloworld
+#endif
         mov      w2, #14           // sizeof(helloworld)
         mov      w8, #64           // SYS_write
         svc      #0

--- a/clients/drcachesim/tests/allasm_aarch64_prefetch.asm
+++ b/clients/drcachesim/tests/allasm_aarch64_prefetch.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc. All rights reserved.
+ * Copyright (c) 2020-2023 Google, Inc. All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -42,8 +42,12 @@ _start:
         sub      x0, x0, #1024 // x0 is bottom of region
         mov      sp, x0
 
-
+#ifdef __APPLE__
+        adrp     x0, helloworld@PAGE
+        add      x0, x0, helloworld@PAGEOFF
+#else
         adr      x0, helloworld
+#endif
         adr      x1, .
 
         // prefetch_read_l1
@@ -165,7 +169,12 @@ _start:
 
         // Exit.
         mov      w0, #1            // stdout
+#ifdef __APPLE__
+        adrp     x1, helloworld@PAGE
+        add      x1, x1, helloworld@PAGEOFF
+#else
         adr      x1, helloworld
+#endif
         mov      w2, #14           // sizeof(helloworld)
         mov      w8, #64           // SYS_write
         svc      #0

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2009 VMware, Inc.  All rights reserved.
  * ********************************************************** */
 
@@ -106,20 +106,25 @@
 
 # if defined(MACOS) && defined(AARCH64)
 
-#  define DECLARE_FUNC(symbol) \
+/* The Mac assembler isn't resolving macro args so we have to force it to
+ * support FUNCNAME used in many files.
+ */
+#  define DECLARE_FUNC(symbol) DECLARE_FUNC_EVAL(symbol)
+#  define DECLARE_FUNC_EVAL(symbol) \
 .p2align 2 @N@ \
 .globl _##symbol @N@ \
-.private_extern _##symbol @N@ \
+.private_extern _##symbol @N@
 
 #  define DECLARE_EXPORTED_FUNC(symbol) \
 .p2align 2 @N@ \
-.globl _##symbol @N@ \
+.globl _##symbol @N@
 
 #  define DECLARE_GLOBAL(symbol) \
 .globl _##symbol @N@\
 .private_extern _##symbol
 
-#  define GLOBAL_LABEL(label) _##label
+#  define GLOBAL_LABEL(label) GLOBAL_LABEL_EVAL(label)
+#  define GLOBAL_LABEL_EVAL(label) _##label
 #  define GLOBAL_REF(label) _##label
 
 #  define AARCH64_ADRP_GOT(sym, reg) \
@@ -128,7 +133,7 @@ add reg, reg, sym@PAGEOFF
 
 #  define AARCH64_ADRP_GOT_LDR(sym, reg) \
 adrp reg, sym@PAGE @N@ \
-add  reg, reg, sym@PAGEOFF
+ldr  reg, [reg, sym@PAGEOFF]
 
 # else
 

--- a/core/arch/asm_defines.asm
+++ b/core/arch/asm_defines.asm
@@ -115,7 +115,8 @@
 .globl _##symbol @N@ \
 .private_extern _##symbol @N@
 
-#  define DECLARE_EXPORTED_FUNC(symbol) \
+#  define DECLARE_EXPORTED_FUNC(symbol) DECLARE_EXPORTED_FUNC_EVAL(symbol)
+#  define DECLARE_EXPORTED_FUNC_EVAL(symbol) \
 .p2align 2 @N@ \
 .globl _##symbol @N@
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5878,21 +5878,6 @@ extract_tsz_offset(uint enc, uint tszh_pos, uint tszl_pos)
     return offset;
 }
 
-static inline aarch64_reg_offset
-extract_tsz3_offset(uint enc, uint tszh_pos, uint tszl_pos)
-{
-    int offset;
-
-    ASSERT(tszh_pos < 30);
-    uint tsz = (extract_uint(enc, tszh_pos, 1) << 2) | extract_uint(enc, tszl_pos, 2);
-
-    if (!highest_bit_set(tsz, 0, 3, &offset))
-        return NOT_A_REG;
-
-    ASSERT(offset < 4);
-    return offset;
-}
-
 static inline bool
 decode_opnd_z_wtszl19p1_bhsd_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -2158,7 +2158,7 @@ get_local_state()
 void
 os_enter_dynamorio(void)
 {
-#    if defined(AARCHXX) || defined(RISCV64)
+#    if (defined(AARCHXX) || defined(RISCV64)) && !defined(MACOS)
     /* i#1578: check that app's tls value doesn't match our sentinel */
     ASSERT(*(byte **)get_dr_tls_base_addr() != TLS_SLOT_VAL_EXITED);
 #    endif

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -910,11 +910,15 @@ endmacro(tobuild_csharp)
 macro(append_pure_asm_app_link_flags target)
   set_target_properties(${target} PROPERTIES LINKER_LANGUAGE C)
   append_link_flags(${target} "-nostartfiles -nodefaultlibs -static")
-  append_property_string(TARGET ${target} LINK_FLAGS
-    # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
-    # with some tool chains (such as SUSE GCC 6.2) results in an executable that
-    # is not properly static. Adding --no-export-dynamic avoids the problem.
-    "-Wl,--no-export-dynamic")
+  if (APPLE)
+    append_property_string(TARGET ${target} LINK_FLAGS "-e _start")
+  else ()
+    append_property_string(TARGET ${target} LINK_FLAGS
+      # The default value of CMAKE_SHARED_LIBRARY_LINK_C_FLAGS has -rdynamic, which
+      # with some tool chains (such as SUSE GCC 6.2) results in an executable that
+      # is not properly static. Adding --no-export-dynamic avoids the problem.
+      "-Wl,--no-export-dynamic")
+  endif ()
 endmacro(append_pure_asm_app_link_flags)
 
 function(tobind target)
@@ -2109,11 +2113,13 @@ if (DR_HOST_ARM AND NOT ANDROID)
 endif ()
 
 if (DR_HOST_AARCH64)
-  tobuild_ops(common.allasm_aarch64_isa common/allasm_aarch64_isa.asm
-    "-early_inject" "") # FIXME i#1569: -enable_traces here
-  set_target_properties(common.allasm_aarch64_isa PROPERTIES LINKER_LANGUAGE C)
-  append_link_flags(common.allasm_aarch64_isa
-    "-nostartfiles -nodefaultlibs -static")
+  if (NOT APPLE) # TODO i#5383: Port to Mac M1.
+    tobuild_ops(common.allasm_aarch64_isa common/allasm_aarch64_isa.asm
+      "-early_inject" "") # FIXME i#1569: -enable_traces here
+    set_target_properties(common.allasm_aarch64_isa PROPERTIES LINKER_LANGUAGE C)
+    append_link_flags(common.allasm_aarch64_isa
+      "-nostartfiles -nodefaultlibs -static")
+  endif ()
 
   tobuild_ops(common.allasm_aarch64_cache common/allasm_aarch64_cache.asm
     "-early_inject" "")
@@ -2526,8 +2532,10 @@ else (UNIX)
 
   tobuild_ci(client.winxfer client-interface/winxfer.c "" "" "")
 endif (UNIX)
-tobuild_ci(client.file_io client-interface/file_io.c
-  "${CMAKE_CURRENT_SOURCE_DIR}/client-interface/file_io_data.txt" "" "")
+if (NOT APPLE OR NOT AARCH64) # TODO i#5383: Port to Mac M1.
+  tobuild_ci(client.file_io client-interface/file_io.c
+    "${CMAKE_CURRENT_SOURCE_DIR}/client-interface/file_io_data.txt" "" "")
+endif ()
 if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
   if (DEBUG) # FIXME i#1806: fails in release; also in OSX list below.
     # we add custom option to flush test based on dr ops in torun_ci()
@@ -2748,12 +2756,14 @@ if (UNIX)
 endif (UNIX)
 
 if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
+  if (NOT APPLE OR NOT AARCH64) # TODO i#5383: Port to Mac M1.
   tobuild_ci(client.drreg-test client-interface/drreg-test.c "" "" "")
   use_DynamoRIO_extension(client.drreg-test.dll drmgr)
   use_DynamoRIO_extension(client.drreg-test.dll drreg)
   use_DynamoRIO_extension(client.drreg-test.dll drx)
   target_include_directories(client.drreg-test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/client-interface)
+  endif ()
 
   tobuild_ci(client.drreg-end-restore client-interface/drreg-end-restore.c "" "" "")
   use_DynamoRIO_extension(client.drreg-end-restore.dll drmgr)
@@ -2868,7 +2878,7 @@ if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
   use_DynamoRIO_extension(client.drwrap-drreg-test.dll drmgr)
 endif (NOT RISCV64)
 
-if (AARCH64)
+if (AARCH64 AND NOT APPLE) # TODO i#5383: Port to Mac M1.
   # Create a fuzzing application for stress-testing via drstatecmp.
   add_api_exe(drstatecmp-fuzz-app client-interface/drstatecmp-fuzz-app.c ON OFF)
 endif ()
@@ -5481,7 +5491,6 @@ if (NOT ANDROID AND AARCHXX)
   if (AARCH64)
     set_tests_properties(
       code_api|common.allasm_aarch64_cache
-      code_api|common.allasm_aarch64_isa
       code_api|linux.mangle_asynch
       code_api|linux.mmap
       code_api|pthreads.pthreads_exit
@@ -5495,7 +5504,6 @@ if (NOT ANDROID AND AARCHXX)
       code_api|client.drreg-cross
       code_api|client.drreg-end-restore
       code_api|client.drreg-flow
-      code_api|client.drreg-test
       code_api|client.drutil-test
       code_api|client.drx_buf-test
       code_api|client.emulation_api_simple
@@ -5515,6 +5523,12 @@ if (NOT ANDROID AND AARCHXX)
       code_api|sample.memtrace_simple
       code_api|sample.memval_simple
       PROPERTIES LABELS RUNS_ON_QEMU)
+    if (NOT APPLE) # TODO i#5383: Port to Mac M1.
+      set_tests_properties(
+        code_api|common.allasm_aarch64_isa
+        code_api|client.drreg-test
+        PROPERTIES LABELS RUNS_ON_QEMU)
+    endif ()
     if (NOT CMAKE_COMPILER_IS_CLANG)
       set_tests_properties(
         code_api|security-linux.trampoline

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited.  All rights reserved.
  * **********************************************************/
 
@@ -86,13 +86,14 @@ test_mov_instr_addr(void)
      * can lead to SEGFAULTs or SIGILLS on the subsequent attempted
      * execution (i#5033)
      */
-    __builtin___clear_cache(generated_code, generated_code + gencode_max_size);
+    __builtin___clear_cache((char *)generated_code,
+                            (char *)generated_code + gencode_max_size);
 
     uint written = ((uint(*)(void))generated_code)();
     ASSERT(written == 0xdeadbeef);
 
     instrlist_clear_and_destroy(GD, ilist);
-    free_mem(generated_code, gencode_max_size);
+    free_mem((char *)generated_code, gencode_max_size);
 #endif
 }
 

--- a/suite/tests/api/ibl-stress.c
+++ b/suite/tests/api/ibl-stress.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -107,6 +107,7 @@ generate_stack_push(instrlist_t *ilist, byte *encode_pc, reg_id_t reg_1, reg_id_
         append_ilist(ilist, encode_pc,
                      XINST_CREATE_sub(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XSP),
                                       OPND_CREATE_INT(16)));
+    return encode_pc;
 }
 
 static byte *
@@ -121,6 +122,7 @@ generate_stack_pop(instrlist_t *ilist, byte *encode_pc, reg_id_t reg_1, reg_id_t
         append_ilist(ilist, encode_pc,
                      XINST_CREATE_add(GLOBAL_DCONTEXT, opnd_create_reg(DR_REG_XSP),
                                       OPND_CREATE_INT(16)));
+    return encode_pc;
 }
 #endif
 

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -5508,7 +5508,7 @@ test_opnd(void *dc)
      */
 }
 
-static uint
+static void
 test_mov_instr_addr_encoding(void *dc, instr_t *instr, uint opcode, uint target_off,
                              uint right_shift_amt, uint mask)
 {
@@ -5526,7 +5526,7 @@ test_mov_instr_addr_encoding(void *dc, instr_t *instr, uint opcode, uint target_
     ASSERT(instr_get_opcode(decin) == opcode);
 
     uint src_op = opcode == OP_movz ? 0 : 1;
-    uint expected_imm = ((ptr_int_t)buf + target_off >> right_shift_amt) & mask;
+    uint expected_imm = (((ptr_int_t)buf + target_off) >> right_shift_amt) & mask;
     ASSERT(opnd_get_immed_int(instr_get_src(decin, src_op)) == expected_imm);
 
     instr_destroy(dc, instr);

--- a/suite/tests/api/ir_aarch64.h
+++ b/suite/tests/api/ir_aarch64.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2022 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -107,9 +107,9 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr, const char *expected)
         return false;
     }
 
-    pc = instr_encode(dc, instr, buf);
+    pc = instr_encode(dc, instr, (byte *)buf);
     decin = instr_create(dc);
-    decode(dc, buf, decin);
+    decode(dc, (byte *)buf, decin);
     if (!instr_same(instr, decin)) {
         print("Reencoding failed, dissassembled as:\n   ");
         instr_disassemble(dc, decin, STDERR);

--- a/suite/tests/client-interface/drsyms-test.dll.cpp
+++ b/suite/tests/client-interface/drsyms-test.dll.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -888,7 +888,6 @@ static void
 lookup_glibc_syms(void *dc, const module_data_t *dll_data)
 {
     const char *libc_path;
-    app_pc libc_base;
     size_t malloc_offs;
     size_t gi_malloc_offs;
     drsym_error_t r;
@@ -903,7 +902,6 @@ lookup_glibc_syms(void *dc, const module_data_t *dll_data)
     already_called = true;
 
     libc_path = dll_data->full_path;
-    libc_base = dll_data->start;
 
     /* FIXME: When drsyms can read .dynsym we should always find malloc. */
     malloc_offs = 0;

--- a/suite/tests/client-interface/drwrap-drreg-test.appdll.c
+++ b/suite/tests/client-interface/drwrap-drreg-test.appdll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -82,7 +82,7 @@ int __attribute__((constructor)) so_init(void)
 /* clang-format off */
 START_FILE
 #define FUNCNAME reg_val_test
-        DECLARE_FUNC(FUNCNAME)
+        DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
         push     REG_XBP  /* Needed only to maintain 16-byte alignment for x64. */
@@ -122,7 +122,7 @@ GLOBAL_LABEL(FUNCNAME:)
 #  undef FUNCNAME
 
 #define FUNCNAME multipath_test
-        DECLARE_FUNC(FUNCNAME)
+        DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
         push     REG_XBP  /* Needed only to maintain 16-byte alignment for x64. */

--- a/suite/tests/client-interface/drwrap-drreg-test.appdll.c
+++ b/suite/tests/client-interface/drwrap-drreg-test.appdll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -82,7 +82,7 @@ int __attribute__((constructor)) so_init(void)
 /* clang-format off */
 START_FILE
 #define FUNCNAME reg_val_test
-        DECLARE_EXPORTED_FUNC(FUNCNAME)
+        DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
         push     REG_XBP  /* Needed only to maintain 16-byte alignment for x64. */
@@ -122,7 +122,7 @@ GLOBAL_LABEL(FUNCNAME:)
 #  undef FUNCNAME
 
 #define FUNCNAME multipath_test
-        DECLARE_EXPORTED_FUNC(FUNCNAME)
+        DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
         push     REG_XBP  /* Needed only to maintain 16-byte alignment for x64. */

--- a/suite/tests/client-interface/drwrap-test.appdll.c
+++ b/suite/tests/client-interface/drwrap-test.appdll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -356,7 +356,7 @@ DECL_EXTERN(level2)
 # endif
 
 #define FUNCNAME makes_tailcall
-        DECLARE_EXPORTED_FUNC(FUNCNAME)
+        DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # if defined(UNIX) && defined(X86) && defined(X64)
         push     REG_XBP  /* Needed only to maintain 16-byte alignment. */
@@ -375,7 +375,7 @@ GLOBAL_LABEL(FUNCNAME:)
 
 DECL_EXTERN(print_from_asm)
 #  define FUNCNAME tailcall_test2
-        DECLARE_EXPORTED_FUNC(FUNCNAME)
+        DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
         ADD_STACK_ALIGNMENT_NOSEH

--- a/suite/tests/client-interface/drwrap-test.appdll.c
+++ b/suite/tests/client-interface/drwrap-test.appdll.c
@@ -426,5 +426,5 @@ GLOBAL_LABEL(FUNCNAME:)
         END_FUNC(FUNCNAME)
 
 END_FILE
-/* clang-format on */
+        /* clang-format on */
 #endif /* ASM_CODE_ONLY */

--- a/suite/tests/client-interface/drwrap-test.appdll.c
+++ b/suite/tests/client-interface/drwrap-test.appdll.c
@@ -356,7 +356,7 @@ DECL_EXTERN(level2)
 # endif
 
 #define FUNCNAME makes_tailcall
-        DECLARE_FUNC(FUNCNAME)
+        DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # if defined(UNIX) && defined(X86) && defined(X64)
         push     REG_XBP  /* Needed only to maintain 16-byte alignment. */
@@ -375,7 +375,7 @@ GLOBAL_LABEL(FUNCNAME:)
 
 DECL_EXTERN(print_from_asm)
 #  define FUNCNAME tailcall_test2
-        DECLARE_FUNC(FUNCNAME)
+        DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 # ifdef X86
         ADD_STACK_ALIGNMENT_NOSEH
@@ -426,5 +426,5 @@ GLOBAL_LABEL(FUNCNAME:)
         END_FUNC(FUNCNAME)
 
 END_FILE
-        /* clang-format on */
+/* clang-format on */
 #endif /* ASM_CODE_ONLY */

--- a/suite/tests/client-interface/stolen-reg-index.c
+++ b/suite/tests/client-interface/stolen-reg-index.c
@@ -64,7 +64,7 @@ main(int argc, char *argv[])
 /* clang-format off */
 START_FILE
 #define FUNCNAME indexed_mem_test
-        DECLARE_FUNC(FUNCNAME)
+        DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 
         stp      x0, x1, [sp, #-16]!

--- a/suite/tests/client-interface/stolen-reg-index.c
+++ b/suite/tests/client-interface/stolen-reg-index.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2022 Arm Limited   All rights reserved.
  * **********************************************************/
 
@@ -63,7 +64,7 @@ main(int argc, char *argv[])
 /* clang-format off */
 START_FILE
 #define FUNCNAME indexed_mem_test
-        DECLARE_EXPORTED_FUNC(FUNCNAME)
+        DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
 
         stp      x0, x1, [sp, #-16]!

--- a/suite/tests/common/allasm_aarch64_cache.asm
+++ b/suite/tests/common/allasm_aarch64_cache.asm
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -56,7 +57,13 @@ loop2:  // The inner loop steps through the region writing zeroes.
 
         // Exit.
         mov      w0, #1            // stdout
+        // XXX: Use asm_defines.asm AARCH64_ADR_GOT()?
+#ifdef __APPLE__
+        adrp     x1, alldone@PAGE
+        add      x1, x1, alldone@PAGEOFF
+#else
         adr      x1, alldone
+#endif
         mov      w2, #9            // sizeof(alldone)
         mov      w8, #64           // SYS_write
         svc      #0

--- a/suite/tests/common/allasm_aarch64_isa.asm
+++ b/suite/tests/common/allasm_aarch64_isa.asm
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -126,10 +127,10 @@
         .endm
 
         // Write n-byte string from X0, adding '\n'.
-        .macro  printn n
+        .macro  printn c
         mov     w1, #'\n'
-        strb    w1, [x0, #\n]
-        mov     x1, #(\n + 1)
+        strb    w1, [x0, #\c]
+        mov     x1, #(\c + 1)
         write
         .endm
 

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2005-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -704,7 +704,7 @@ GLOBAL_LABEL(FUNCNAME:)
         pop      {r7}
         bx       lr
 # else
-        b        clear_icache
+        b        GLOBAL_REF(clear_icache)
 # endif
         END_FUNC(FUNCNAME)
 #endif

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -329,17 +329,22 @@ intercept_signal(int sig, handler_3_t handler, bool sigstack);
 #    define NOP_NOP_NOP asm("nop\n nop\n nop\n")
 #    ifdef X86
 #        ifdef MACOS
-#            define NOP_NOP_CALL(tgt) asm("nop\n nop\n call _" #tgt)
+#            define NOP_NOP_CALL(tgt) asm("nop\n nop\n call _" #            tgt)
 #        else
-#            define NOP_NOP_CALL(tgt) asm("nop\n nop\n call " #tgt)
+#            define NOP_NOP_CALL(tgt) asm("nop\n nop\n call " #            tgt)
 #        endif
 #    elif defined(AARCHXX)
 /* Make sure to mark LR/X30 as clobbered to avoid functions like
  * client-interface/call-retarget.c:main() being interpreted as a leaf
  * function that does not need the link register preserved.
  */
-#        define NOP_NOP_CALL(tgt) \
-            asm("nop\n nop\n bl " #tgt : : : IF_ARM_ELSE("lr", "x30"))
+#        ifdef MACOS
+#            define NOP_NOP_CALL(tgt) \
+                asm("nop\n nop\n bl _" #tgt : : : IF_ARM_ELSE("lr", "x30"))
+#        else
+#            define NOP_NOP_CALL(tgt) \
+                asm("nop\n nop\n bl " #tgt : : : IF_ARM_ELSE("lr", "x30"))
+#        endif
 #    endif
 #endif
 


### PR DESCRIPTION
Enables BUILD_TESTS to compile for M1: a combination of fixing and disabling tests.  Many issues came from assembler and pre-processor differences.

Issue: #5383