### PR TITLE
i#3044 AArch64 SVE codec: Add UZP1, UZP2, ZIP1 Q variants

### DIFF
--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -835,8 +835,10 @@
 0000010011010101101xxxxxxxxxxxxx  n   804  SVE     uxtw          z_d_0 : p10_mrg_lo z_d_5
 00000101xx10xxxx0100100xxxx0xxxx  n   557  SVE     uzp1  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011010xxxxxxxxxx  n   557  SVE     uzp1  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+00000101101xxxxx000010xxxxxxxxxx  n   557  F64MM   uzp1          z_q_0 : z_q_5 z_q_16
 00000101xx10xxxx0100110xxxx0xxxx  n   558  SVE     uzp2  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011011xxxxxxxxxx  n   558  SVE     uzp2  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+00000101101xxxxx000011xxxxxxxxxx  n   558  F64MM   uzp2          z_q_0 : z_q_5 z_q_16
 00100101xx1xxxxx000001xxxxx1xxxx  w   877  SVE  whilele  p_size_bhsd_0 : w5 w16
 00100101xx1xxxxx000101xxxxx1xxxx  w   877  SVE  whilele  p_size_bhsd_0 : x5 x16
 00100101xx1xxxxx000011xxxxx0xxxx  w   878  SVE  whilelo  p_size_bhsd_0 : w5 w16
@@ -848,6 +850,7 @@
 00100101001010001001000xxxx00000  n   820  SVE    wrffr                : p_b_5
 00000101xx10xxxx0100000xxxx0xxxx  n   565  SVE     zip1  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011000xxxxxxxxxx  n   565  SVE     zip1  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
+00000101101xxxxx000000xxxxxxxxxx  n   565  F64MM   zip1          z_q_0 : z_q_5 z_q_16
 00000101101xxxxx000001xxxxxxxxxx  n   566  SVE     zip2          z_q_0 : z_q_5 z_q_16
 00000101xx10xxxx0100010xxxx0xxxx  n   566  SVE     zip2  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011001xxxxxxxxxx  n   566  SVE     zip2  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -5315,21 +5315,6 @@
     instr_create_1dst_3src(dc, OP_bic, Zdn, Pg, Zdn, Zm)
 
 /**
- * Creates a ZIP2 instruction.
- *
- * This macro is used to encode the forms:
- * \verbatim
- *    ZIP2    <Zd>.Q, <Zn>.Q, <Zm>.Q
- * \endverbatim
- * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zd   The first destination vector register, Z (Scalable)
- * \param Zn   The second source vector register, Z (Scalable)
- * \param Zm   The third source vector register, Z (Scalable)
- */
-#define INSTR_CREATE_zip2_vector(dc, Zd, Zn, Zm) \
-    instr_create_1dst_2src(dc, OP_zip2, Zd, Zn, Zm)
-
-/**
  * Creates a MOVPRFX instruction.
  *
  * This macro is used to encode the forms:
@@ -8974,21 +8959,6 @@
     instr_create_1dst_2src(dc, OP_uzp1, Pd, Pn, Pm)
 
 /**
- * Creates an UZP1 instruction.
- *
- * This macro is used to encode the forms:
- * \verbatim
- *    UZP1    <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts>
- * \endverbatim
- * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zd   The destination vector register, Z (Scalable).
- * \param Zn   The first source vector register, Z (Scalable).
- * \param Zm   The second source vector register, Z (Scalable).
- */
-#define INSTR_CREATE_uzp1_sve_vector(dc, Zd, Zn, Zm) \
-    instr_create_1dst_2src(dc, OP_uzp1, Zd, Zn, Zm)
-
-/**
  * Creates an UZP2 instruction.
  *
  * This macro is used to encode the forms:
@@ -9009,6 +8979,7 @@
  * This macro is used to encode the forms:
  * \verbatim
  *    UZP2    <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts>
+ *    UZP2    <Zd>.Q, <Zn>.Q, <Zm>.Q
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zd   The destination vector register, Z (Scalable).
@@ -9039,6 +9010,7 @@
  * This macro is used to encode the forms:
  * \verbatim
  *    ZIP1    <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts>
+ *    ZIP1    <Zd>.Q, <Zn>.Q, <Zm>.Q
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zd   The destination vector register, Z (Scalable).
@@ -9069,6 +9041,7 @@
  * This macro is used to encode the forms:
  * \verbatim
  *    ZIP2    <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts>
+ *    ZIP2    <Zd>.Q, <Zn>.Q, <Zm>.Q
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zd   The destination vector register, Z (Scalable).
@@ -9099,6 +9072,7 @@
  * This macro is used to encode the forms:
  * \verbatim
  *    TRN1    <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts>
+ *    TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zd   The destination vector register, Z (Scalable).
@@ -9129,6 +9103,7 @@
  * This macro is used to encode the forms:
  * \verbatim
  *    TRN2    <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts>
+ *    TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zd   The destination vector register, Z (Scalable).
@@ -14191,36 +14166,6 @@
         opnd_create_base_disp(opnd_get_reg(Rn), DR_REG_NULL, 0, 0, OPSZ_sys))
 
 /**
- * Creates a TRN1 instruction.
- *
- * This macro is used to encode the forms:
- * \verbatim
- *    TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q
- * \endverbatim
- * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zd   The destination vector register, Z (Scalable).
- * \param Zn   The first source vector register, Z (Scalable).
- * \param Zm   The second source vector register, Z (Scalable).
- */
-#define INSTR_CREATE_trn1_sve(dc, Zd, Zn, Zm) \
-    instr_create_1dst_2src(dc, OP_trn1, Zd, Zn, Zm)
-
-/**
- * Creates a TRN2 instruction.
- *
- * This macro is used to encode the forms:
- * \verbatim
- *    TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q
- * \endverbatim
- * \param dc   The void * dcontext used to allocate memory for the #instr_t.
- * \param Zd   The destination vector register, Z (Scalable).
- * \param Zn   The first source vector register, Z (Scalable).
- * \param Zm   The second source vector register, Z (Scalable).
- */
-#define INSTR_CREATE_trn2_sve(dc, Zd, Zn, Zm) \
-    instr_create_1dst_2src(dc, OP_trn2, Zd, Zn, Zm)
-
-/**
  * Creates a SDOT instruction.
  *
  * This macro is used to encode the forms:
@@ -17467,4 +17412,21 @@
  */
 #define INSTR_CREATE_ldnt1sw_sve_pred(dc, Zt, Pg, Zn) \
     instr_create_1dst_2src(dc, OP_ldnt1sw, Zt, Zn, Pg)
+
+/**
+ * Creates an UZP1 instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      UZP1    <Zd>.<Ts>, <Zn>.<Ts>, <Zm>.<Ts>
+      UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z (Scalable).
+ * \param Zn   The first source vector register, Z (Scalable).
+ * \param Zm   The second source vector register, Z (Scalable).
+ */
+#define INSTR_CREATE_uzp1_sve_vector(dc, Zd, Zn, Zm) \
+    instr_create_1dst_2src(dc, OP_uzp1, Zd, Zn, Zm)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -26099,6 +26099,24 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 05fd6b9b : uzp1 z27.d, z28.d, z29.d                  : uzp1   %z28.d %z29.d -> %z27.d
 05ff6bff : uzp1 z31.d, z31.d, z31.d                  : uzp1   %z31.d %z31.d -> %z31.d
 
+# UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q (UZP1-Z.ZZ-Q)
+05a00800 : uzp1 z0.q, z0.q, z0.q                     : uzp1   %z0.q %z0.q -> %z0.q
+05a40862 : uzp1 z2.q, z3.q, z4.q                     : uzp1   %z3.q %z4.q -> %z2.q
+05a608a4 : uzp1 z4.q, z5.q, z6.q                     : uzp1   %z5.q %z6.q -> %z4.q
+05a808e6 : uzp1 z6.q, z7.q, z8.q                     : uzp1   %z7.q %z8.q -> %z6.q
+05aa0928 : uzp1 z8.q, z9.q, z10.q                    : uzp1   %z9.q %z10.q -> %z8.q
+05ac096a : uzp1 z10.q, z11.q, z12.q                  : uzp1   %z11.q %z12.q -> %z10.q
+05ae09ac : uzp1 z12.q, z13.q, z14.q                  : uzp1   %z13.q %z14.q -> %z12.q
+05b009ee : uzp1 z14.q, z15.q, z16.q                  : uzp1   %z15.q %z16.q -> %z14.q
+05b20a30 : uzp1 z16.q, z17.q, z18.q                  : uzp1   %z17.q %z18.q -> %z16.q
+05b30a51 : uzp1 z17.q, z18.q, z19.q                  : uzp1   %z18.q %z19.q -> %z17.q
+05b50a93 : uzp1 z19.q, z20.q, z21.q                  : uzp1   %z20.q %z21.q -> %z19.q
+05b70ad5 : uzp1 z21.q, z22.q, z23.q                  : uzp1   %z22.q %z23.q -> %z21.q
+05b90b17 : uzp1 z23.q, z24.q, z25.q                  : uzp1   %z24.q %z25.q -> %z23.q
+05bb0b59 : uzp1 z25.q, z26.q, z27.q                  : uzp1   %z26.q %z27.q -> %z25.q
+05bd0b9b : uzp1 z27.q, z28.q, z29.q                  : uzp1   %z28.q %z29.q -> %z27.q
+05bf0bff : uzp1 z31.q, z31.q, z31.q                  : uzp1   %z31.q %z31.q -> %z31.q
+
 # UZP2    <Pd>.<T>, <Pn>.<T>, <Pm>.<T> (UZP2-P.PP-_)
 05204c00 : uzp2 p0.b, p0.b, p0.b                     : uzp2   %p0.b %p0.b -> %p0.b
 05234c41 : uzp2 p1.b, p2.b, p3.b                     : uzp2   %p2.b %p3.b -> %p1.b
@@ -26230,6 +26248,24 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 05fb6f59 : uzp2 z25.d, z26.d, z27.d                  : uzp2   %z26.d %z27.d -> %z25.d
 05fd6f9b : uzp2 z27.d, z28.d, z29.d                  : uzp2   %z28.d %z29.d -> %z27.d
 05ff6fff : uzp2 z31.d, z31.d, z31.d                  : uzp2   %z31.d %z31.d -> %z31.d
+
+# UZP2    <Zd>.Q, <Zn>.Q, <Zm>.Q (UZP2-Z.ZZ-Q)
+05a00c00 : uzp2 z0.q, z0.q, z0.q                     : uzp2   %z0.q %z0.q -> %z0.q
+05a40c62 : uzp2 z2.q, z3.q, z4.q                     : uzp2   %z3.q %z4.q -> %z2.q
+05a60ca4 : uzp2 z4.q, z5.q, z6.q                     : uzp2   %z5.q %z6.q -> %z4.q
+05a80ce6 : uzp2 z6.q, z7.q, z8.q                     : uzp2   %z7.q %z8.q -> %z6.q
+05aa0d28 : uzp2 z8.q, z9.q, z10.q                    : uzp2   %z9.q %z10.q -> %z8.q
+05ac0d6a : uzp2 z10.q, z11.q, z12.q                  : uzp2   %z11.q %z12.q -> %z10.q
+05ae0dac : uzp2 z12.q, z13.q, z14.q                  : uzp2   %z13.q %z14.q -> %z12.q
+05b00dee : uzp2 z14.q, z15.q, z16.q                  : uzp2   %z15.q %z16.q -> %z14.q
+05b20e30 : uzp2 z16.q, z17.q, z18.q                  : uzp2   %z17.q %z18.q -> %z16.q
+05b30e51 : uzp2 z17.q, z18.q, z19.q                  : uzp2   %z18.q %z19.q -> %z17.q
+05b50e93 : uzp2 z19.q, z20.q, z21.q                  : uzp2   %z20.q %z21.q -> %z19.q
+05b70ed5 : uzp2 z21.q, z22.q, z23.q                  : uzp2   %z22.q %z23.q -> %z21.q
+05b90f17 : uzp2 z23.q, z24.q, z25.q                  : uzp2   %z24.q %z25.q -> %z23.q
+05bb0f59 : uzp2 z25.q, z26.q, z27.q                  : uzp2   %z26.q %z27.q -> %z25.q
+05bd0f9b : uzp2 z27.q, z28.q, z29.q                  : uzp2   %z28.q %z29.q -> %z27.q
+05bf0fff : uzp2 z31.q, z31.q, z31.q                  : uzp2   %z31.q %z31.q -> %z31.q
 
 # WHILELE <Pd>.<T>, <R><n>, <R><m> (WHILELE-P.P.RR-_)
 25200410 : whilele p0.b, w0, w0                      : whilele %w0 %w0 -> %p0.b
@@ -26900,6 +26936,24 @@ e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)
 05fb6359 : zip1 z25.d, z26.d, z27.d                  : zip1   %z26.d %z27.d -> %z25.d
 05fd639b : zip1 z27.d, z28.d, z29.d                  : zip1   %z28.d %z29.d -> %z27.d
 05ff63ff : zip1 z31.d, z31.d, z31.d                  : zip1   %z31.d %z31.d -> %z31.d
+
+# ZIP1    <Zd>.Q, <Zn>.Q, <Zm>.Q (ZIP1-Z.ZZ-Q)
+05a00000 : zip1 z0.q, z0.q, z0.q                     : zip1   %z0.q %z0.q -> %z0.q
+05a40062 : zip1 z2.q, z3.q, z4.q                     : zip1   %z3.q %z4.q -> %z2.q
+05a600a4 : zip1 z4.q, z5.q, z6.q                     : zip1   %z5.q %z6.q -> %z4.q
+05a800e6 : zip1 z6.q, z7.q, z8.q                     : zip1   %z7.q %z8.q -> %z6.q
+05aa0128 : zip1 z8.q, z9.q, z10.q                    : zip1   %z9.q %z10.q -> %z8.q
+05ac016a : zip1 z10.q, z11.q, z12.q                  : zip1   %z11.q %z12.q -> %z10.q
+05ae01ac : zip1 z12.q, z13.q, z14.q                  : zip1   %z13.q %z14.q -> %z12.q
+05b001ee : zip1 z14.q, z15.q, z16.q                  : zip1   %z15.q %z16.q -> %z14.q
+05b20230 : zip1 z16.q, z17.q, z18.q                  : zip1   %z17.q %z18.q -> %z16.q
+05b30251 : zip1 z17.q, z18.q, z19.q                  : zip1   %z18.q %z19.q -> %z17.q
+05b50293 : zip1 z19.q, z20.q, z21.q                  : zip1   %z20.q %z21.q -> %z19.q
+05b702d5 : zip1 z21.q, z22.q, z23.q                  : zip1   %z22.q %z23.q -> %z21.q
+05b90317 : zip1 z23.q, z24.q, z25.q                  : zip1   %z24.q %z25.q -> %z23.q
+05bb0359 : zip1 z25.q, z26.q, z27.q                  : zip1   %z26.q %z27.q -> %z25.q
+05bd039b : zip1 z27.q, z28.q, z29.q                  : zip1   %z28.q %z29.q -> %z27.q
+05bf03ff : zip1 z31.q, z31.q, z31.q                  : zip1   %z31.q %z31.q -> %z31.q
 
 # ZIP2    <Pd>.<T>, <Pn>.<T>, <Pm>.<T> (ZIP2-P.PP-_)
 05204400 : zip2 p0.b, p0.b, p0.b                     : zip2   %p0.b %p0.b -> %p0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -200,20 +200,6 @@ TEST_INSTR(add_sve)
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
 }
 
-TEST_INSTR(zip2_vector)
-{
-    /* Testing ZIP2    <Zd>.Q, <Zn>.Q, <Zm>.Q */
-    const char *expected_0_0[6] = {
-        "zip2   %z0.q %z0.q -> %z0.q",    "zip2   %z6.q %z7.q -> %z5.q",
-        "zip2   %z11.q %z12.q -> %z10.q", "zip2   %z17.q %z18.q -> %z16.q",
-        "zip2   %z22.q %z23.q -> %z21.q", "zip2   %z31.q %z31.q -> %z31.q",
-    };
-    TEST_LOOP(zip2, zip2_vector, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
-}
-
 TEST_INSTR(movprfx_vector)
 {
     /* Testing MOVPRFX <Zd>, <Zn> */
@@ -8600,6 +8586,17 @@ TEST_INSTR(uzp1_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+
+    /* Testing UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *const expected_0_0[6] = {
+        "uzp1   %z0.q %z0.q -> %z0.q",    "uzp1   %z6.q %z7.q -> %z5.q",
+        "uzp1   %z11.q %z12.q -> %z10.q", "uzp1   %z17.q %z18.q -> %z16.q",
+        "uzp1   %z22.q %z23.q -> %z21.q", "uzp1   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(uzp1, uzp1_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
 TEST_INSTR(uzp2_sve_pred)
@@ -8688,6 +8685,17 @@ TEST_INSTR(uzp2_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+
+    /* Testing UZP2    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *const expected_0_0[6] = {
+        "uzp2   %z0.q %z0.q -> %z0.q",    "uzp2   %z6.q %z7.q -> %z5.q",
+        "uzp2   %z11.q %z12.q -> %z10.q", "uzp2   %z17.q %z18.q -> %z16.q",
+        "uzp2   %z22.q %z23.q -> %z21.q", "uzp2   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(uzp2, uzp2_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
 TEST_INSTR(zip1_sve_pred)
@@ -8776,6 +8784,17 @@ TEST_INSTR(zip1_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+
+    /* Testing ZIP1    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *const expected_0_0[6] = {
+        "zip1   %z0.q %z0.q -> %z0.q",    "zip1   %z6.q %z7.q -> %z5.q",
+        "zip1   %z11.q %z12.q -> %z10.q", "zip1   %z17.q %z18.q -> %z16.q",
+        "zip1   %z22.q %z23.q -> %z21.q", "zip1   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(zip1, zip1_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
 TEST_INSTR(zip2_sve_pred)
@@ -8864,6 +8883,17 @@ TEST_INSTR(zip2_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+
+    /* Testing ZIP2    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *expected_0_0[6] = {
+        "zip2   %z0.q %z0.q -> %z0.q",    "zip2   %z6.q %z7.q -> %z5.q",
+        "zip2   %z11.q %z12.q -> %z10.q", "zip2   %z17.q %z18.q -> %z16.q",
+        "zip2   %z22.q %z23.q -> %z21.q", "zip2   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(zip2, zip2_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
 TEST_INSTR(trn1_sve_pred)
@@ -8952,6 +8982,17 @@ TEST_INSTR(trn1_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+
+    /* Testing TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *const expected_0_0[6] = {
+        "trn1   %z0.q %z0.q -> %z0.q",    "trn1   %z6.q %z7.q -> %z5.q",
+        "trn1   %z11.q %z12.q -> %z10.q", "trn1   %z17.q %z18.q -> %z16.q",
+        "trn1   %z22.q %z23.q -> %z21.q", "trn1   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(trn1, trn1_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
 TEST_INSTR(trn2_sve_pred)
@@ -9040,6 +9081,17 @@ TEST_INSTR(trn2_sve_vector)
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_8),
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_8));
+
+    /* Testing TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q */
+    const char *const expected_0_0[6] = {
+        "trn2   %z0.q %z0.q -> %z0.q",    "trn2   %z6.q %z7.q -> %z5.q",
+        "trn2   %z11.q %z12.q -> %z10.q", "trn2   %z17.q %z18.q -> %z16.q",
+        "trn2   %z22.q %z23.q -> %z21.q", "trn2   %z31.q %z31.q -> %z31.q",
+    };
+    TEST_LOOP(trn2, trn2_sve_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
 }
 
 TEST_INSTR(dupm_sve)
@@ -20114,36 +20166,6 @@ TEST_INSTR(stnt1w_sve_pred)
         opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
 }
 
-TEST_INSTR(trn1_sve)
-{
-
-    /* Testing TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q */
-    const char *const expected_0_0[6] = {
-        "trn1   %z0.q %z0.q -> %z0.q",    "trn1   %z6.q %z7.q -> %z5.q",
-        "trn1   %z11.q %z12.q -> %z10.q", "trn1   %z17.q %z18.q -> %z16.q",
-        "trn1   %z22.q %z23.q -> %z21.q", "trn1   %z31.q %z31.q -> %z31.q",
-    };
-    TEST_LOOP(trn1, trn1_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
-}
-
-TEST_INSTR(trn2_sve)
-{
-
-    /* Testing TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q */
-    const char *const expected_0_0[6] = {
-        "trn2   %z0.q %z0.q -> %z0.q",    "trn2   %z6.q %z7.q -> %z5.q",
-        "trn2   %z11.q %z12.q -> %z10.q", "trn2   %z17.q %z18.q -> %z16.q",
-        "trn2   %z22.q %z23.q -> %z21.q", "trn2   %z31.q %z31.q -> %z31.q",
-    };
-    TEST_LOOP(trn2, trn2_sve, 6, expected_0_0[i],
-              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_16),
-              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_16));
-}
-
 TEST_INSTR(sdot_sve)
 {
     /* Testing SDOT    <Zda>.<Ts>, <Zn>.<Tb>, <Zm>.<Tb> */
@@ -20505,6 +20527,7 @@ TEST_INSTR(bfcvtnt_sve_pred)
               opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
               opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
 }
+
 int
 main(int argc, char *argv[])
 {
@@ -20520,8 +20543,6 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(add_sve_pred);
     RUN_INSTR_TEST(add_sve_shift);
     RUN_INSTR_TEST(add_sve);
-
-    RUN_INSTR_TEST(zip2_vector);
 
     RUN_INSTR_TEST(movprfx_vector);
 
@@ -21008,9 +21029,6 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ld1rqd_sve_pred);
     RUN_INSTR_TEST(ld1rqh_sve_pred);
     RUN_INSTR_TEST(ld1rqw_sve_pred);
-
-    RUN_INSTR_TEST(trn1_sve);
-    RUN_INSTR_TEST(trn2_sve);
 
     RUN_INSTR_TEST(sdot_sve);
     RUN_INSTR_TEST(sdot_sve_idx);


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to decode and encode the following instructions:
```UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q (UZP1-Z.ZZ-Q)```
```UZP2    <Zd>.Q, <Zn>.Q, <Zm>.Q (UZP2-Z.ZZ-Q)```
```ZIP1    <Zd>.Q, <Zn>.Q, <Zm>.Q (ZIP1-Z.ZZ-Q)```

Issue: #3044