### PR TITLE
i#3044: AArch64 SVE2 codec: add instructions with consts and indexes

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -7815,6 +7815,47 @@ encode_opnd_z3_msz_bhsd_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint
 }
 
 static inline bool
+decode_opnd_z4_msz_bhsd_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    aarch64_reg_offset bit_size = extract_uint(enc, 23, 2);
+    if (bit_size < BYTE_REG)
+        return false;
+    if (bit_size > DOUBLE_REG)
+        return false;
+
+    return decode_single_sized(DR_REG_Z0, DR_REG_Z15, 16, 4, bit_size, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_z4_msz_bhsd_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    IF_RETURN_FALSE(!opnd_is_element_vector_reg(opnd));
+
+    const aarch64_reg_offset size = get_vector_element_reg_offset(opnd);
+    if (size == NOT_A_REG)
+        return false;
+
+    if (size > DOUBLE_REG)
+        return false;
+    if (size < BYTE_REG)
+        return false;
+
+    opnd_size_t reg_size = OPSZ_SCALABLE;
+
+    uint reg_number;
+    if (!is_vreg(&reg_size, &reg_number, opnd))
+        return false;
+
+    if (reg_number > 15)
+        return false;
+
+    *enc_out |= (reg_number << 16);
+    *enc_out |= (size << 23);
+
+    return true;
+}
+
+static inline bool
 decode_opnd_z_msz_bhsd_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     return decode_sized_z(16, 23, BYTE_REG, DOUBLE_REG, 0, 0, enc, pc, opnd);

--- a/core/ir/aarch64/codec_sve2.txt
+++ b/core/ir/aarch64/codec_sve2.txt
@@ -56,7 +56,11 @@
 00000100101xxxxx001111xxxxxxxxxx  n   1066 SVE2     bsl2n          z_d_0 : z_d_0 z_d_16 z_d_5
 01000101xx00000011011xxxxxxxxxxx  n   1161 SVE2      cadd  z_size_bhsd_0 : z_size_bhsd_0 z_size_bhsd_5 imm1_ew_10
 01000100xx0xxxxx0001xxxxxxxxxxxx  n   1162 SVE2      cdot    z_size_sd_0 : z_size_sd_0 z_sizep2_bh_5 z_sizep2_bh_16 imm2_nesw_10
+01000100111xxxxx0100xxxxxxxxxxxx  n   1162 SVE2      cdot          z_d_0 : z_d_0 z_msz_bhsd_5 z4_msz_bhsd_16 i1_index_20 imm2_nesw_10
+01000100101xxxxx0100xxxxxxxxxxxx  n   1162 SVE2      cdot          z_s_0 : z_s_0 z_b_5 z3_b_16 i2_index_19 imm2_nesw_10
 01000100xx0xxxxx0010xxxxxxxxxxxx  n   1163 SVE2      cmla  z_size_bhsd_0 : z_size_bhsd_0 z_size_bhsd_5 z_size_bhsd_16 imm2_nesw_10
+01000100101xxxxx0110xxxxxxxxxxxx  n   1163 SVE2      cmla   z_msz_bhsd_0 : z_msz_bhsd_0 z_msz_bhsd_5 z3_msz_bhsd_16 i2_index_19 imm2_nesw_10
+01000100111xxxxx0110xxxxxxxxxxxx  n   1163 SVE2      cmla          z_s_0 : z_s_0 z_s_5 z4_s_16 i1_index_20 imm2_nesw_10
 00000100001xxxxx001110xxxxxxxxxx  n   600  SVE2      eor3          z_d_0 : z_d_0 z_d_16 z_d_5
 01000101xx0xxxxx100100xxxxxxxxxx  n   1078 SVE2     eorbt  z_size_bhsd_0 : z_size_bhsd_0 z_size_bhsd_5 z_size_bhsd_16
 01000101xx0xxxxx100101xxxxxxxxxx  n   1079 SVE2     eortb  z_size_bhsd_0 : z_size_bhsd_0 z_size_bhsd_5 z_size_bhsd_16
@@ -169,6 +173,8 @@
 01000100101xxxxx1110x1xxxxxxxxxx  n   1112 SVE2  sqdmullt          z_s_0 : z_msz_bhsd_5 z3_msz_bhsd_16 i3_index_11
 01000100xx001001101xxxxxxxxxxxxx  n   411  SVE2     sqneg  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_5
 01000100xx0xxxxx0011xxxxxxxxxxxx  n   1169 SVE2 sqrdcmlah  z_size_bhsd_0 : z_size_bhsd_0 z_size_bhsd_5 z_size_bhsd_16 imm2_nesw_10
+01000100101xxxxx0111xxxxxxxxxxxx  n   1169 SVE2 sqrdcmlah   z_msz_bhsd_0 : z_msz_bhsd_0 z_msz_bhsd_5 z3_msz_bhsd_16 i2_index_19 imm2_nesw_10
+01000100111xxxxx0111xxxxxxxxxxxx  n   1169 SVE2 sqrdcmlah          z_s_0 : z_s_0 z_s_5 z4_s_16 i1_index_20 imm2_nesw_10
 01000100xx0xxxxx011100xxxxxxxxxx  n   412  SVE2  sqrdmlah  z_size_bhsd_0 : z_size_bhsd_0 z_size_bhsd_5 z_size_bhsd_16
 01000100111xxxxx000100xxxxxxxxxx  n   412  SVE2  sqrdmlah          z_d_0 : z_d_0 z_d_5 z4_d_16 i1_index_20
 010001000x1xxxxx000100xxxxxxxxxx  n   412  SVE2  sqrdmlah          z_h_0 : z_h_0 z_h_5 z3_h_16 i3_index_19

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -17467,4 +17467,59 @@
  */
 #define INSTR_CREATE_ldnt1sw_sve_pred(dc, Zt, Pg, Zn) \
     instr_create_1dst_2src(dc, OP_ldnt1sw, Zt, Zn, Pg)
+
+/*
+ * Creates a CDOT instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      CDOT    <Zda>.D, <Zn>.H, <Zm>.H[<imm>], <const>
+      CDOT    <Zda>.S, <Zn>.B, <Zm>.B[<imm>], <const>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register. Can be Z.d or Z.s.
+ * \param Zn   The second source vector register. Can be Z.h or Z.b.
+ * \param Zm   The third source vector register. Can be Z.h or Z.b.
+ * \param i1   The immediate index for Zm.
+ * \param rot  The immediate rotation which must be 0, 90, 180 or 270.
+ */
+#define INSTR_CREATE_cdot_sve_idx_imm_vector(dc, Zda, Zn, Zm, i1, rot) \
+    instr_create_1dst_5src(dc, OP_cdot, Zda, Zda, Zn, Zm, i1, rot)
+
+/**
+ * Creates a CMLA instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      CMLA    <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const>
+      CMLA    <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register. Can be Z.s or Z.h.
+ * \param Zn   The second source vector register. Can be Z.s or Z.h.
+ * \param Zm   The third source vector register. Can be Z.s or Z.h.
+ * \param i1   The immediate index for Zm.
+ * \param rot  The immediate rotation which must be 0, 90, 180 or 270.
+ */
+#define INSTR_CREATE_cmla_sve_idx_imm_vector(dc, Zda, Zn, Zm, i1, rot) \
+    instr_create_1dst_5src(dc, OP_cmla, Zda, Zda, Zn, Zm, i1, rot)
+
+/**
+ * Creates a SQRDCMLAH instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      SQRDCMLAH <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const>
+      SQRDCMLAH <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zda   The source and destination vector register. Can be Z.s or Z.h.
+ * \param Zn   The second source vector register. Can be Z.s or Z.h.
+ * \param Zm   The third source vector register. Can be Z.s or Z.h.
+ * \param i1   The immediate index for Zm.
+ * \param rot  The immediate rotation which must be 0, 90, 180 or 270.
+ */
+#define INSTR_CREATE_sqrdcmlah_sve_idx_imm_vector(dc, Zda, Zn, Zm, i1, rot) \
+    instr_create_1dst_5src(dc, OP_sqrdcmlah, Zda, Zda, Zn, Zm, i1, rot)
+
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -357,7 +357,8 @@
 -------xx------------------xxxxx  z_msz_bhsd_0p2  # z register with element size determined by msz, plus 2
 -------xx------------------xxxxx  z_msz_bhsd_0p3  # z register with element size determined by msz, plus 3
 -------xx-------------xxxxx-----  z_msz_bhsd_5    # z register with element size determined by msz
--------xx----xxx----------------  z3_msz_bhsd_16  # z register with element size determined by msz, max z8
+-------xx----xxx----------------  z3_msz_bhsd_16  # z register with element size determined by msz, max z7
+-------xx---xxxx----------------  z4_msz_bhsd_16  # z register with element size determined by msz, max z15
 -------xx--xxxxx----------------  z_msz_bhsd_16   # z register with element size determined by msz
 -?--------------------xxxxx-----  mem0p      # gets size from 30; no offset, pair
 -?---------xxxxx????------------  x16imm     # computes immed from 30 and 15:12

--- a/suite/tests/api/dis-a64-sve2.txt
+++ b/suite/tests/api/dis-a64-sve2.txt
@@ -708,6 +708,42 @@
 44dd1f9b : cdot z27.d, z28.h, z29.h, #0x10e          : cdot   %z27.d %z28.h %z29.h $0x010e -> %z27.d
 44df1fff : cdot z31.d, z31.h, z31.h, #0x10e          : cdot   %z31.d %z31.h %z31.h $0x010e -> %z31.d
 
+# CDOT    <Zda>.S, <Zn>.B, <Zm>.B[<imm>], <const> (CDOT-Z.ZZZi-S)
+44a04000 : cdot z0.s, z0.b, z0.b[0], #0x0            : cdot   %z0.s %z0.b %z0.b $0x00 $0x0000 -> %z0.s
+44a24062 : cdot z2.s, z3.b, z2.b[0], #0x0            : cdot   %z2.s %z3.b %z2.b $0x00 $0x0000 -> %z2.s
+44a340a4 : cdot z4.s, z5.b, z3.b[0], #0x0            : cdot   %z4.s %z5.b %z3.b $0x00 $0x0000 -> %z4.s
+44ab44e6 : cdot z6.s, z7.b, z3.b[1], #0x5a           : cdot   %z6.s %z7.b %z3.b $0x01 $0x005a -> %z6.s
+44ac4528 : cdot z8.s, z9.b, z4.b[1], #0x5a           : cdot   %z8.s %z9.b %z4.b $0x01 $0x005a -> %z8.s
+44ac456a : cdot z10.s, z11.b, z4.b[1], #0x5a         : cdot   %z10.s %z11.b %z4.b $0x01 $0x005a -> %z10.s
+44ad45ac : cdot z12.s, z13.b, z5.b[1], #0x5a         : cdot   %z12.s %z13.b %z5.b $0x01 $0x005a -> %z12.s
+44ad45ee : cdot z14.s, z15.b, z5.b[1], #0x5a         : cdot   %z14.s %z15.b %z5.b $0x01 $0x005a -> %z14.s
+44b64a30 : cdot z16.s, z17.b, z6.b[2], #0xb4         : cdot   %z16.s %z17.b %z6.b $0x02 $0x00b4 -> %z16.s
+44b64a51 : cdot z17.s, z18.b, z6.b[2], #0xb4         : cdot   %z17.s %z18.b %z6.b $0x02 $0x00b4 -> %z17.s
+44b64a93 : cdot z19.s, z20.b, z6.b[2], #0xb4         : cdot   %z19.s %z20.b %z6.b $0x02 $0x00b4 -> %z19.s
+44b74ad5 : cdot z21.s, z22.b, z7.b[2], #0xb4         : cdot   %z21.s %z22.b %z7.b $0x02 $0x00b4 -> %z21.s
+44b74b17 : cdot z23.s, z24.b, z7.b[2], #0xb4         : cdot   %z23.s %z24.b %z7.b $0x02 $0x00b4 -> %z23.s
+44b04b59 : cdot z25.s, z26.b, z0.b[2], #0xb4         : cdot   %z25.s %z26.b %z0.b $0x02 $0x00b4 -> %z25.s
+44b84f9b : cdot z27.s, z28.b, z0.b[3], #0x10e        : cdot   %z27.s %z28.b %z0.b $0x03 $0x010e -> %z27.s
+44bf4fff : cdot z31.s, z31.b, z7.b[3], #0x10e        : cdot   %z31.s %z31.b %z7.b $0x03 $0x010e -> %z31.s
+
+# CDOT    <Zda>.D, <Zn>.H, <Zm>.H[<imm>], <const> (CDOT-Z.ZZZi-D)
+44e04000 : cdot z0.d, z0.h, z0.h[0], #0x0            : cdot   %z0.d %z0.h %z0.h $0x00 $0x0000 -> %z0.d
+44e34062 : cdot z2.d, z3.h, z3.h[0], #0x0            : cdot   %z2.d %z3.h %z3.h $0x00 $0x0000 -> %z2.d
+44e440a4 : cdot z4.d, z5.h, z4.h[0], #0x0            : cdot   %z4.d %z5.h %z4.h $0x00 $0x0000 -> %z4.d
+44e544e6 : cdot z6.d, z7.h, z5.h[0], #0x5a           : cdot   %z6.d %z7.h %z5.h $0x00 $0x005a -> %z6.d
+44e64528 : cdot z8.d, z9.h, z6.h[0], #0x5a           : cdot   %z8.d %z9.h %z6.h $0x00 $0x005a -> %z8.d
+44e7456a : cdot z10.d, z11.h, z7.h[0], #0x5a         : cdot   %z10.d %z11.h %z7.h $0x00 $0x005a -> %z10.d
+44e845ac : cdot z12.d, z13.h, z8.h[0], #0x5a         : cdot   %z12.d %z13.h %z8.h $0x00 $0x005a -> %z12.d
+44e945ee : cdot z14.d, z15.h, z9.h[0], #0x5a         : cdot   %z14.d %z15.h %z9.h $0x00 $0x005a -> %z14.d
+44ea4a30 : cdot z16.d, z17.h, z10.h[0], #0xb4        : cdot   %z16.d %z17.h %z10.h $0x00 $0x00b4 -> %z16.d
+44fa4a51 : cdot z17.d, z18.h, z10.h[1], #0xb4        : cdot   %z17.d %z18.h %z10.h $0x01 $0x00b4 -> %z17.d
+44fb4a93 : cdot z19.d, z20.h, z11.h[1], #0xb4        : cdot   %z19.d %z20.h %z11.h $0x01 $0x00b4 -> %z19.d
+44fc4ad5 : cdot z21.d, z22.h, z12.h[1], #0xb4        : cdot   %z21.d %z22.h %z12.h $0x01 $0x00b4 -> %z21.d
+44fd4b17 : cdot z23.d, z24.h, z13.h[1], #0xb4        : cdot   %z23.d %z24.h %z13.h $0x01 $0x00b4 -> %z23.d
+44fe4b59 : cdot z25.d, z26.h, z14.h[1], #0xb4        : cdot   %z25.d %z26.h %z14.h $0x01 $0x00b4 -> %z25.d
+44ff4f9b : cdot z27.d, z28.h, z15.h[1], #0x10e       : cdot   %z27.d %z28.h %z15.h $0x01 $0x010e -> %z27.d
+44ff4fff : cdot z31.d, z31.h, z15.h[1], #0x10e       : cdot   %z31.d %z31.h %z15.h $0x01 $0x010e -> %z31.d
+
 # CMLA    <Zda>.<T>, <Zn>.<T>, <Zm>.<T>, <const> (CMLA-Z.ZZZ-_)
 44002000 : cmla z0.b, z0.b, z0.b, #0x0               : cmla   %z0.b %z0.b %z0.b $0x0000 -> %z0.b
 44042062 : cmla z2.b, z3.b, z4.b, #0x0               : cmla   %z2.b %z3.b %z4.b $0x0000 -> %z2.b
@@ -773,6 +809,42 @@
 44db2b59 : cmla z25.d, z26.d, z27.d, #0xb4           : cmla   %z25.d %z26.d %z27.d $0x00b4 -> %z25.d
 44dd2f9b : cmla z27.d, z28.d, z29.d, #0x10e          : cmla   %z27.d %z28.d %z29.d $0x010e -> %z27.d
 44df2fff : cmla z31.d, z31.d, z31.d, #0x10e          : cmla   %z31.d %z31.d %z31.d $0x010e -> %z31.d
+
+# CMLA    <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const> (CMLA-Z.ZZZi-H)
+44a06000 : cmla z0.h, z0.h, z0.h[0], #0x0            : cmla   %z0.h %z0.h %z0.h $0x00 $0x0000 -> %z0.h
+44a26062 : cmla z2.h, z3.h, z2.h[0], #0x0            : cmla   %z2.h %z3.h %z2.h $0x00 $0x0000 -> %z2.h
+44a360a4 : cmla z4.h, z5.h, z3.h[0], #0x0            : cmla   %z4.h %z5.h %z3.h $0x00 $0x0000 -> %z4.h
+44ab64e6 : cmla z6.h, z7.h, z3.h[1], #0x5a           : cmla   %z6.h %z7.h %z3.h $0x01 $0x005a -> %z6.h
+44ac6528 : cmla z8.h, z9.h, z4.h[1], #0x5a           : cmla   %z8.h %z9.h %z4.h $0x01 $0x005a -> %z8.h
+44ac656a : cmla z10.h, z11.h, z4.h[1], #0x5a         : cmla   %z10.h %z11.h %z4.h $0x01 $0x005a -> %z10.h
+44ad65ac : cmla z12.h, z13.h, z5.h[1], #0x5a         : cmla   %z12.h %z13.h %z5.h $0x01 $0x005a -> %z12.h
+44ad65ee : cmla z14.h, z15.h, z5.h[1], #0x5a         : cmla   %z14.h %z15.h %z5.h $0x01 $0x005a -> %z14.h
+44b66a30 : cmla z16.h, z17.h, z6.h[2], #0xb4         : cmla   %z16.h %z17.h %z6.h $0x02 $0x00b4 -> %z16.h
+44b66a51 : cmla z17.h, z18.h, z6.h[2], #0xb4         : cmla   %z17.h %z18.h %z6.h $0x02 $0x00b4 -> %z17.h
+44b66a93 : cmla z19.h, z20.h, z6.h[2], #0xb4         : cmla   %z19.h %z20.h %z6.h $0x02 $0x00b4 -> %z19.h
+44b76ad5 : cmla z21.h, z22.h, z7.h[2], #0xb4         : cmla   %z21.h %z22.h %z7.h $0x02 $0x00b4 -> %z21.h
+44b76b17 : cmla z23.h, z24.h, z7.h[2], #0xb4         : cmla   %z23.h %z24.h %z7.h $0x02 $0x00b4 -> %z23.h
+44b06b59 : cmla z25.h, z26.h, z0.h[2], #0xb4         : cmla   %z25.h %z26.h %z0.h $0x02 $0x00b4 -> %z25.h
+44b86f9b : cmla z27.h, z28.h, z0.h[3], #0x10e        : cmla   %z27.h %z28.h %z0.h $0x03 $0x010e -> %z27.h
+44bf6fff : cmla z31.h, z31.h, z7.h[3], #0x10e        : cmla   %z31.h %z31.h %z7.h $0x03 $0x010e -> %z31.h
+
+# CMLA    <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const> (CMLA-Z.ZZZi-S)
+44e06000 : cmla z0.s, z0.s, z0.s[0], #0x0            : cmla   %z0.s %z0.s %z0.s $0x00 $0x0000 -> %z0.s
+44e36062 : cmla z2.s, z3.s, z3.s[0], #0x0            : cmla   %z2.s %z3.s %z3.s $0x00 $0x0000 -> %z2.s
+44e460a4 : cmla z4.s, z5.s, z4.s[0], #0x0            : cmla   %z4.s %z5.s %z4.s $0x00 $0x0000 -> %z4.s
+44e564e6 : cmla z6.s, z7.s, z5.s[0], #0x5a           : cmla   %z6.s %z7.s %z5.s $0x00 $0x005a -> %z6.s
+44e66528 : cmla z8.s, z9.s, z6.s[0], #0x5a           : cmla   %z8.s %z9.s %z6.s $0x00 $0x005a -> %z8.s
+44e7656a : cmla z10.s, z11.s, z7.s[0], #0x5a         : cmla   %z10.s %z11.s %z7.s $0x00 $0x005a -> %z10.s
+44e865ac : cmla z12.s, z13.s, z8.s[0], #0x5a         : cmla   %z12.s %z13.s %z8.s $0x00 $0x005a -> %z12.s
+44e965ee : cmla z14.s, z15.s, z9.s[0], #0x5a         : cmla   %z14.s %z15.s %z9.s $0x00 $0x005a -> %z14.s
+44ea6a30 : cmla z16.s, z17.s, z10.s[0], #0xb4        : cmla   %z16.s %z17.s %z10.s $0x00 $0x00b4 -> %z16.s
+44fa6a51 : cmla z17.s, z18.s, z10.s[1], #0xb4        : cmla   %z17.s %z18.s %z10.s $0x01 $0x00b4 -> %z17.s
+44fb6a93 : cmla z19.s, z20.s, z11.s[1], #0xb4        : cmla   %z19.s %z20.s %z11.s $0x01 $0x00b4 -> %z19.s
+44fc6ad5 : cmla z21.s, z22.s, z12.s[1], #0xb4        : cmla   %z21.s %z22.s %z12.s $0x01 $0x00b4 -> %z21.s
+44fd6b17 : cmla z23.s, z24.s, z13.s[1], #0xb4        : cmla   %z23.s %z24.s %z13.s $0x01 $0x00b4 -> %z23.s
+44fe6b59 : cmla z25.s, z26.s, z14.s[1], #0xb4        : cmla   %z25.s %z26.s %z14.s $0x01 $0x00b4 -> %z25.s
+44ff6f9b : cmla z27.s, z28.s, z15.s[1], #0x10e       : cmla   %z27.s %z28.s %z15.s $0x01 $0x010e -> %z27.s
+44ff6fff : cmla z31.s, z31.s, z15.s[1], #0x10e       : cmla   %z31.s %z31.s %z15.s $0x01 $0x010e -> %z31.s
 
 # EOR3    <Zdn>.D, <Zdn>.D, <Zm>.D, <Zk>.D (EOR3-Z.ZZZ-_)
 04203800 : eor3 z0.d, z0.d, z0.d, z0.d               : eor3   %z0.d %z0.d %z0.d -> %z0.d
@@ -4721,6 +4793,42 @@ c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16b
 44db3b59 : sqrdcmlah z25.d, z26.d, z27.d, #0xb4      : sqrdcmlah %z25.d %z26.d %z27.d $0x00b4 -> %z25.d
 44dd3f9b : sqrdcmlah z27.d, z28.d, z29.d, #0x10e     : sqrdcmlah %z27.d %z28.d %z29.d $0x010e -> %z27.d
 44df3fff : sqrdcmlah z31.d, z31.d, z31.d, #0x10e     : sqrdcmlah %z31.d %z31.d %z31.d $0x010e -> %z31.d
+
+# SQRDCMLAH <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const> (SQRDCMLAH-Z.ZZZi-H)
+44a07000 : sqrdcmlah z0.h, z0.h, z0.h[0], #0x0       : sqrdcmlah %z0.h %z0.h %z0.h $0x00 $0x0000 -> %z0.h
+44a27062 : sqrdcmlah z2.h, z3.h, z2.h[0], #0x0       : sqrdcmlah %z2.h %z3.h %z2.h $0x00 $0x0000 -> %z2.h
+44a370a4 : sqrdcmlah z4.h, z5.h, z3.h[0], #0x0       : sqrdcmlah %z4.h %z5.h %z3.h $0x00 $0x0000 -> %z4.h
+44ab74e6 : sqrdcmlah z6.h, z7.h, z3.h[1], #0x5a      : sqrdcmlah %z6.h %z7.h %z3.h $0x01 $0x005a -> %z6.h
+44ac7528 : sqrdcmlah z8.h, z9.h, z4.h[1], #0x5a      : sqrdcmlah %z8.h %z9.h %z4.h $0x01 $0x005a -> %z8.h
+44ac756a : sqrdcmlah z10.h, z11.h, z4.h[1], #0x5a    : sqrdcmlah %z10.h %z11.h %z4.h $0x01 $0x005a -> %z10.h
+44ad75ac : sqrdcmlah z12.h, z13.h, z5.h[1], #0x5a    : sqrdcmlah %z12.h %z13.h %z5.h $0x01 $0x005a -> %z12.h
+44ad75ee : sqrdcmlah z14.h, z15.h, z5.h[1], #0x5a    : sqrdcmlah %z14.h %z15.h %z5.h $0x01 $0x005a -> %z14.h
+44b67a30 : sqrdcmlah z16.h, z17.h, z6.h[2], #0xb4    : sqrdcmlah %z16.h %z17.h %z6.h $0x02 $0x00b4 -> %z16.h
+44b67a51 : sqrdcmlah z17.h, z18.h, z6.h[2], #0xb4    : sqrdcmlah %z17.h %z18.h %z6.h $0x02 $0x00b4 -> %z17.h
+44b67a93 : sqrdcmlah z19.h, z20.h, z6.h[2], #0xb4    : sqrdcmlah %z19.h %z20.h %z6.h $0x02 $0x00b4 -> %z19.h
+44b77ad5 : sqrdcmlah z21.h, z22.h, z7.h[2], #0xb4    : sqrdcmlah %z21.h %z22.h %z7.h $0x02 $0x00b4 -> %z21.h
+44b77b17 : sqrdcmlah z23.h, z24.h, z7.h[2], #0xb4    : sqrdcmlah %z23.h %z24.h %z7.h $0x02 $0x00b4 -> %z23.h
+44b07b59 : sqrdcmlah z25.h, z26.h, z0.h[2], #0xb4    : sqrdcmlah %z25.h %z26.h %z0.h $0x02 $0x00b4 -> %z25.h
+44b87f9b : sqrdcmlah z27.h, z28.h, z0.h[3], #0x10e   : sqrdcmlah %z27.h %z28.h %z0.h $0x03 $0x010e -> %z27.h
+44bf7fff : sqrdcmlah z31.h, z31.h, z7.h[3], #0x10e   : sqrdcmlah %z31.h %z31.h %z7.h $0x03 $0x010e -> %z31.h
+
+# SQRDCMLAH <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const> (SQRDCMLAH-Z.ZZZi-S)
+44e07000 : sqrdcmlah z0.s, z0.s, z0.s[0], #0x0       : sqrdcmlah %z0.s %z0.s %z0.s $0x00 $0x0000 -> %z0.s
+44e37062 : sqrdcmlah z2.s, z3.s, z3.s[0], #0x0       : sqrdcmlah %z2.s %z3.s %z3.s $0x00 $0x0000 -> %z2.s
+44e470a4 : sqrdcmlah z4.s, z5.s, z4.s[0], #0x0       : sqrdcmlah %z4.s %z5.s %z4.s $0x00 $0x0000 -> %z4.s
+44e574e6 : sqrdcmlah z6.s, z7.s, z5.s[0], #0x5a      : sqrdcmlah %z6.s %z7.s %z5.s $0x00 $0x005a -> %z6.s
+44e67528 : sqrdcmlah z8.s, z9.s, z6.s[0], #0x5a      : sqrdcmlah %z8.s %z9.s %z6.s $0x00 $0x005a -> %z8.s
+44e7756a : sqrdcmlah z10.s, z11.s, z7.s[0], #0x5a    : sqrdcmlah %z10.s %z11.s %z7.s $0x00 $0x005a -> %z10.s
+44e875ac : sqrdcmlah z12.s, z13.s, z8.s[0], #0x5a    : sqrdcmlah %z12.s %z13.s %z8.s $0x00 $0x005a -> %z12.s
+44e975ee : sqrdcmlah z14.s, z15.s, z9.s[0], #0x5a    : sqrdcmlah %z14.s %z15.s %z9.s $0x00 $0x005a -> %z14.s
+44ea7a30 : sqrdcmlah z16.s, z17.s, z10.s[0], #0xb4   : sqrdcmlah %z16.s %z17.s %z10.s $0x00 $0x00b4 -> %z16.s
+44fa7a51 : sqrdcmlah z17.s, z18.s, z10.s[1], #0xb4   : sqrdcmlah %z17.s %z18.s %z10.s $0x01 $0x00b4 -> %z17.s
+44fb7a93 : sqrdcmlah z19.s, z20.s, z11.s[1], #0xb4   : sqrdcmlah %z19.s %z20.s %z11.s $0x01 $0x00b4 -> %z19.s
+44fc7ad5 : sqrdcmlah z21.s, z22.s, z12.s[1], #0xb4   : sqrdcmlah %z21.s %z22.s %z12.s $0x01 $0x00b4 -> %z21.s
+44fd7b17 : sqrdcmlah z23.s, z24.s, z13.s[1], #0xb4   : sqrdcmlah %z23.s %z24.s %z13.s $0x01 $0x00b4 -> %z23.s
+44fe7b59 : sqrdcmlah z25.s, z26.s, z14.s[1], #0xb4   : sqrdcmlah %z25.s %z26.s %z14.s $0x01 $0x00b4 -> %z25.s
+44ff7f9b : sqrdcmlah z27.s, z28.s, z15.s[1], #0x10e  : sqrdcmlah %z27.s %z28.s %z15.s $0x01 $0x010e -> %z27.s
+44ff7fff : sqrdcmlah z31.s, z31.s, z15.s[1], #0x10e  : sqrdcmlah %z31.s %z31.s %z15.s $0x01 $0x010e -> %z31.s
 
 # SQRDMLAH <Zda>.<T>, <Zn>.<T>, <Zm>.<T> (SQRDMLAH-Z.ZZZ-_)
 44007000 : sqrdmlah z0.b, z0.b, z0.b                 : sqrdmlah %z0.b %z0.b %z0.b -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve2.c
+++ b/suite/tests/api/ir_aarch64_sve2.c
@@ -7753,6 +7753,139 @@ TEST_INSTR(ldnt1sw_sve_pred)
                                                    OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
                                                    OPSZ_16, 0));
 }
+
+TEST_INSTR(cdot_sve_idx_imm_vector)
+{
+
+    /* Testing CDOT    <Zda>.D, <Zn>.H, <Zm>.H[<imm>], <const> */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z4,  DR_REG_Z7,
+                                        DR_REG_Z10, DR_REG_Z12, DR_REG_Z15 };
+    static const uint i1_0_0[6] = { 0, 1, 1, 1, 0, 1 };
+    static const uint rot_0_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_0_0[6] = {
+        "cdot   %z0.d %z0.h %z0.h $0x00 $0x0000 -> %z0.d",
+        "cdot   %z5.d %z6.h %z4.h $0x01 $0x0000 -> %z5.d",
+        "cdot   %z10.d %z11.h %z7.h $0x01 $0x005a -> %z10.d",
+        "cdot   %z16.d %z17.h %z10.h $0x01 $0x00b4 -> %z16.d",
+        "cdot   %z21.d %z22.h %z12.h $0x00 $0x00b4 -> %z21.d",
+        "cdot   %z31.d %z31.h %z15.h $0x01 $0x010e -> %z31.d",
+    };
+    TEST_LOOP(cdot, cdot_sve_idx_imm_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_2),
+              opnd_create_immed_uint(i1_0_0[i], OPSZ_1b),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    /* Testing CDOT    <Zda>.S, <Zn>.B, <Zm>.B[<imm>], <const> */
+    static const reg_id_t Zm_1_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_1_0[6] = { 0, 3, 0, 1, 1, 3 };
+    static const uint rot_1_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_1_0[6] = {
+        "cdot   %z0.s %z0.b %z0.b $0x00 $0x0000 -> %z0.s",
+        "cdot   %z5.s %z6.b %z3.b $0x03 $0x0000 -> %z5.s",
+        "cdot   %z10.s %z11.b %z4.b $0x00 $0x005a -> %z10.s",
+        "cdot   %z16.s %z17.b %z6.b $0x01 $0x00b4 -> %z16.s",
+        "cdot   %z21.s %z22.b %z7.b $0x01 $0x00b4 -> %z21.s",
+        "cdot   %z31.s %z31.b %z7.b $0x03 $0x010e -> %z31.s",
+    };
+    TEST_LOOP(cdot, cdot_sve_idx_imm_vector, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zm_1_0[i], OPSZ_1),
+              opnd_create_immed_uint(i2_1_0[i], OPSZ_2b),
+              opnd_create_immed_uint(rot_1_0[i], OPSZ_2));
+}
+
+TEST_INSTR(cmla_sve_idx_imm_vector)
+{
+
+    /* Testing CMLA    <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const> */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z4,  DR_REG_Z7,
+                                        DR_REG_Z10, DR_REG_Z12, DR_REG_Z15 };
+    static const uint i1_0_0[6] = { 0, 1, 1, 1, 0, 1 };
+    static const uint rot_0_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_0_0[6] = {
+        "cmla   %z0.s %z0.s %z0.s $0x00 $0x0000 -> %z0.s",
+        "cmla   %z5.s %z6.s %z4.s $0x01 $0x0000 -> %z5.s",
+        "cmla   %z10.s %z11.s %z7.s $0x01 $0x005a -> %z10.s",
+        "cmla   %z16.s %z17.s %z10.s $0x01 $0x00b4 -> %z16.s",
+        "cmla   %z21.s %z22.s %z12.s $0x00 $0x00b4 -> %z21.s",
+        "cmla   %z31.s %z31.s %z15.s $0x01 $0x010e -> %z31.s",
+    };
+    TEST_LOOP(cmla, cmla_sve_idx_imm_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_4),
+              opnd_create_immed_uint(i1_0_0[i], OPSZ_1b),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    /* Testing CMLA    <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const> */
+    static const reg_id_t Zm_1_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_1_0[6] = { 0, 3, 0, 1, 1, 3 };
+    static const uint rot_1_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_1_0[6] = {
+        "cmla   %z0.h %z0.h %z0.h $0x00 $0x0000 -> %z0.h",
+        "cmla   %z5.h %z6.h %z3.h $0x03 $0x0000 -> %z5.h",
+        "cmla   %z10.h %z11.h %z4.h $0x00 $0x005a -> %z10.h",
+        "cmla   %z16.h %z17.h %z6.h $0x01 $0x00b4 -> %z16.h",
+        "cmla   %z21.h %z22.h %z7.h $0x01 $0x00b4 -> %z21.h",
+        "cmla   %z31.h %z31.h %z7.h $0x03 $0x010e -> %z31.h",
+    };
+    TEST_LOOP(cmla, cmla_sve_idx_imm_vector, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_1_0[i], OPSZ_2),
+              opnd_create_immed_uint(i2_1_0[i], OPSZ_2b),
+              opnd_create_immed_uint(rot_1_0[i], OPSZ_2));
+}
+
+TEST_INSTR(sqrdcmlah_sve_idx_imm_vector)
+{
+
+    /* Testing SQRDCMLAH <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const> */
+    static const reg_id_t Zm_0_0[6] = { DR_REG_Z0,  DR_REG_Z4,  DR_REG_Z7,
+                                        DR_REG_Z10, DR_REG_Z12, DR_REG_Z15 };
+    static const uint i1_0_0[6] = { 0, 1, 1, 1, 0, 1 };
+    static const uint rot_0_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_0_0[6] = {
+        "sqrdcmlah %z0.s %z0.s %z0.s $0x00 $0x0000 -> %z0.s",
+        "sqrdcmlah %z5.s %z6.s %z4.s $0x01 $0x0000 -> %z5.s",
+        "sqrdcmlah %z10.s %z11.s %z7.s $0x01 $0x005a -> %z10.s",
+        "sqrdcmlah %z16.s %z17.s %z10.s $0x01 $0x00b4 -> %z16.s",
+        "sqrdcmlah %z21.s %z22.s %z12.s $0x00 $0x00b4 -> %z21.s",
+        "sqrdcmlah %z31.s %z31.s %z15.s $0x01 $0x010e -> %z31.s",
+    };
+    TEST_LOOP(sqrdcmlah, sqrdcmlah_sve_idx_imm_vector, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_4),
+              opnd_create_reg_element_vector(Zm_0_0[i], OPSZ_4),
+              opnd_create_immed_uint(i1_0_0[i], OPSZ_1b),
+              opnd_create_immed_uint(rot_0_0[i], OPSZ_2));
+
+    /* Testing SQRDCMLAH <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const> */
+    static const reg_id_t Zm_1_0[6] = { DR_REG_Z0, DR_REG_Z3, DR_REG_Z4,
+                                        DR_REG_Z6, DR_REG_Z7, DR_REG_Z7 };
+    static const uint i2_1_0[6] = { 0, 3, 0, 1, 1, 3 };
+    static const uint rot_1_0[6] = { 0, 0, 90, 180, 180, 270 };
+    const char *const expected_1_0[6] = {
+        "sqrdcmlah %z0.h %z0.h %z0.h $0x00 $0x0000 -> %z0.h",
+        "sqrdcmlah %z5.h %z6.h %z3.h $0x03 $0x0000 -> %z5.h",
+        "sqrdcmlah %z10.h %z11.h %z4.h $0x00 $0x005a -> %z10.h",
+        "sqrdcmlah %z16.h %z17.h %z6.h $0x01 $0x00b4 -> %z16.h",
+        "sqrdcmlah %z21.h %z22.h %z7.h $0x01 $0x00b4 -> %z21.h",
+        "sqrdcmlah %z31.h %z31.h %z7.h $0x03 $0x010e -> %z31.h",
+    };
+    TEST_LOOP(sqrdcmlah, sqrdcmlah_sve_idx_imm_vector, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_1[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zm_1_0[i], OPSZ_2),
+              opnd_create_immed_uint(i2_1_0[i], OPSZ_2b),
+              opnd_create_immed_uint(rot_1_0[i], OPSZ_2));
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -7979,6 +8112,10 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(ldnt1sb_sve_pred);
     RUN_INSTR_TEST(ldnt1sh_sve_pred);
     RUN_INSTR_TEST(ldnt1sw_sve_pred);
+
+    RUN_INSTR_TEST(cdot_sve_idx_imm_vector);
+    RUN_INSTR_TEST(cmla_sve_idx_imm_vector);
+    RUN_INSTR_TEST(sqrdcmlah_sve_idx_imm_vector);
 
     print("All SVE2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
CDOT    <Zda>.D, <Zn>.H, <Zm>.H[<imm>], <const>
CDOT    <Zda>.S, <Zn>.B, <Zm>.B[<imm>], <const>
CMLA    <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const>
CMLA    <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const>
SQRDCMLAH <Zda>.H, <Zn>.H, <Zm>.H[<imm>], <const>
SQRDCMLAH <Zda>.S, <Zn>.S, <Zm>.S[<imm>], <const>
```
issue: #3044