### PR TITLE
i#3044 AArch64 SVE2 codec: Add misc predicate instructions

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -6763,6 +6763,18 @@ encode_opnd_p_size_bhs_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *
 }
 
 static inline bool
+decode_opnd_p_size_bh_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_p(0, 22, BYTE_REG, HALF_REG, enc, pc, opnd);
+}
+
+static inline bool
+encode_opnd_p_size_bh_0(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_sized_p(0, 22, BYTE_REG, HALF_REG, opnd, enc_out);
+}
+
+static inline bool
 decode_opnd_p_size_hsd_0(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     return decode_sized_p(0, 22, HALF_REG, DOUBLE_REG, enc, pc, opnd);
@@ -6970,6 +6982,18 @@ static inline bool
 encode_opnd_z_size_bhs_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_sized_z(5, 22, BYTE_REG, SINGLE_REG, 0, 0, opnd, enc_out);
+}
+
+static inline bool
+decode_opnd_z_size_bh_5(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_z(5, 22, BYTE_REG, HALF_REG, 0, 0, enc, pc, opnd);
+}
+
+static inline bool
+encode_opnd_z_size_bh_5(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_sized_z(5, 22, BYTE_REG, HALF_REG, 0, 0, opnd, enc_out);
 }
 
 static inline bool
@@ -7223,6 +7247,18 @@ static inline bool
 encode_opnd_z_size_bhsd_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
 {
     return encode_sized_z(16, 22, BYTE_REG, DOUBLE_REG, 0, 0, opnd, enc_out);
+}
+
+static inline bool
+decode_opnd_z_size_bh_16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_sized_z(16, 22, BYTE_REG, HALF_REG, 0, 0, enc, pc, opnd);
+}
+
+static inline bool
+encode_opnd_z_size_bh_16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_sized_z(16, 22, BYTE_REG, HALF_REG, 0, 0, opnd, enc_out);
 }
 
 static inline bool

--- a/core/ir/aarch64/codec_sve2.txt
+++ b/core/ir/aarch64/codec_sve2.txt
@@ -91,7 +91,9 @@
 11000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
 10000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_s_0 : svemem_vec_sd_gpr16 p10_zer_lo
 11000101000xxxxx100xxxxxxxxxxxxx  n   1188 SVE2   ldnt1sw          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
+01000101xx1xxxxx100xxxxxxxx0xxxx  w   1189 SVE2     match    p_size_bh_0 : p10_zer_lo z_size_bh_5 z_size_bh_16
 00000100111xxxxx001111xxxxxxxxxx  n   1072 SVE2      nbsl          z_d_0 : z_d_0 z_d_16 z_d_5
+01000101xx1xxxxx100xxxxxxxx1xxxx  w   1190 SVE2    nmatch    p_size_bh_0 : p10_zer_lo z_size_bh_5 z_size_bh_16
 00000100001xxxxx011001xxxxxxxxxx  n   328  SVE2      pmul   z_msz_bhsd_0 : z_msz_bhsd_5 z_msz_bhsd_16
 01000101xx0xxxxx011010xxxxxxxxxx  n   1084 SVE2    pmullb    z_size_hd_0 : z_sizep1_bs_5 z_sizep1_bs_16
 01000101xx0xxxxx011011xxxxxxxxxx  n   1085 SVE2    pmullt    z_size_hd_0 : z_sizep1_bs_5 z_sizep1_bs_16
@@ -270,10 +272,12 @@
 01000100xx011111100xxxxxxxxxxxxx  n   1154 SVE2    uqsubr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 010001010x1xx000010010xxxxxxxxxx  n   1143 SVE2    uqxtnb  z_wtszl19_bhsd_0 : z_wtszl19p1_bhsd_5
 010001010x1xx000010011xxxxxxxxxx  n   1144 SVE2    uqxtnt  z_wtszl19_bhsd_0 : z_wtszl19_bhsd_0 z_wtszl19p1_bhsd_5
+0100010010000000101xxxxxxxxxxxxx  n   541  SVE2    urecpe          z_s_0 : p10_mrg_lo z_s_5
 01000100xx010101100xxxxxxxxxxxxx  n   542  SVE2    urhadd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 01000100xx000011100xxxxxxxxxxxxx  n   543  SVE2     urshl  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 01000100xx000111100xxxxxxxxxxxxx  n   1155 SVE2    urshlr  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5
 00000100xx001101100xxxxxxxxxxxxx  n   544  SVE2     urshr  z_tszl8_bhsd_0 : p10_mrg_lo z_tszl8_bhsd_0 tszl8_imm3_5p1
+0100010010000001101xxxxxxxxxxxxx  n   545  SVE2   ursqrte          z_s_0 : p10_mrg_lo z_s_5
 01000101xx0xxxxx111011xxxxxxxxxx  n   546  SVE2     ursra  z_tszl19_bhsd_0 : z_tszl19_bhsd_0 z_tszl19_bhsd_5 tszl19_imm3_16p1
 010001010x0xxxxx101010xxxxxxxxxx  n   1184 SVE2    ushllb  z_tszl19p1_hsd_0 : z_tszl19_bhs_5 tszl19lo_imm3_16
 010001010x0xxxxx101011xxxxxxxxxx  n   1185 SVE2    ushllt  z_tszl19p1_hsd_0 : z_tszl19_bhs_5 tszl19lo_imm3_16
@@ -283,4 +287,14 @@
 01000101xx0xxxxx000111xxxxxxxxxx  n   1136 SVE2    usublt   z_size_hsd_0 : z_sizep1_bhs_5 z_sizep1_bhs_16
 01000101xx0xxxxx010110xxxxxxxxxx  n   1137 SVE2    usubwb   z_size_hsd_0 : z_size_hsd_5 z_sizep1_bhs_16
 01000101xx0xxxxx010111xxxxxxxxxx  n   1138 SVE2    usubwt   z_size_hsd_0 : z_size_hsd_5 z_sizep1_bhs_16
+00100101xx1xxxxx000000xxxxx0xxxx  w   1191 SVE2   whilege  p_size_bhsd_0 : w5 w16
+00100101xx1xxxxx000100xxxxx0xxxx  w   1191 SVE2   whilege  p_size_bhsd_0 : x5 x16
+00100101xx1xxxxx000000xxxxx1xxxx  w   1192 SVE2   whilegt  p_size_bhsd_0 : w5 w16
+00100101xx1xxxxx000100xxxxx1xxxx  w   1192 SVE2   whilegt  p_size_bhsd_0 : x5 x16
+00100101xx1xxxxx000010xxxxx1xxxx  w   1193 SVE2   whilehi  p_size_bhsd_0 : w5 w16
+00100101xx1xxxxx000110xxxxx1xxxx  w   1193 SVE2   whilehi  p_size_bhsd_0 : x5 x16
+00100101xx1xxxxx000010xxxxx0xxxx  w   1194 SVE2   whilehs  p_size_bhsd_0 : w5 w16
+00100101xx1xxxxx000110xxxxx0xxxx  w   1194 SVE2   whilehs  p_size_bhsd_0 : x5 x16
+00100101xx1xxxxx001100xxxxx1xxxx  w   1195 SVE2   whilerw  p_size_bhsd_0 : x5 x16
+00100101xx1xxxxx001100xxxxx0xxxx  w   1196 SVE2   whilewr  p_size_bhsd_0 : x5 x16
 00000100xx1xxxxx001101xxxxxxxxxx  n   604  SVE2       xar  z_tszl19_bhsd_0 : z_tszl19_bhsd_0 z_tszl19_bhsd_5 tszl19_imm3_16p1

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -17483,4 +17483,163 @@
 #define INSTR_CREATE_sqrdcmlah_sve_idx_imm_vector(dc, Zda, Zn, Zm, i1, rot) \
     instr_create_1dst_5src(dc, OP_sqrdcmlah, Zda, Zda, Zn, Zm, i1, rot)
 
+/**
+ * Creates a MATCH instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      MATCH   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b or P.h.
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The first source vector register. Can be Z.b or Z.h.
+ * \param Zm   The second source vector register. Can be Z.b or Z.h.
+ */
+#define INSTR_CREATE_match_sve_pred(dc, Pd, Pg, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_match, Pd, Pg, Zn, Zm)
+
+/**
+ * Creates a NMATCH instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      NMATCH  <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b or P.h.
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The first source vector register. Can be Z.b or Z.h.
+ * \param Zm   The second source vector register. Can be Z.b or Z.h.
+ */
+#define INSTR_CREATE_nmatch_sve_pred(dc, Pd, Pg, Zn, Zm) \
+    instr_create_1dst_3src(dc, OP_nmatch, Pd, Pg, Zn, Zm)
+
+/**
+ * Creates an URECPE instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      URECPE  <Zd>.S, <Pg>/M, <Zn>.S
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z.s.
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z.s.
+ */
+#define INSTR_CREATE_urecpe_sve_pred(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_urecpe, Zd, Pg, Zn)
+
+/**
+ * Creates an URSQRTE instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      URSQRTE <Zd>.S, <Pg>/M, <Zn>.S
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Zd   The destination vector register, Z.s.
+ * \param Pg   The governing predicate register, P (Predicate).
+ * \param Zn   The source vector register, Z.s.
+ */
+#define INSTR_CREATE_ursqrte_sve_pred(dc, Zd, Pg, Zn) \
+    instr_create_1dst_2src(dc, OP_ursqrte, Zd, Pg, Zn)
+
+/**
+ * Creates a WHILEGE instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      WHILEGE <Pd>.<Ts>, <R><n>, <R><m>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b, P.h, P.s or P.d.
+ * \param Rn   The first source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ * \param Rm   The second source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ */
+#define INSTR_CREATE_whilege_sve(dc, Pd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_whilege, Pd, Rn, Rm)
+
+/**
+ * Creates a WHILEGT instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      WHILEGT <Pd>.<Ts>, <R><n>, <R><m>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b, P.h, P.s or P.d.
+ * \param Rn   The first source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ * \param Rm   The second source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ */
+#define INSTR_CREATE_whilegt_sve(dc, Pd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_whilegt, Pd, Rn, Rm)
+
+/**
+ * Creates a WHILEHI instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      WHILEHI <Pd>.<Ts>, <R><n>, <R><m>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b, P.h, P.s or P.d.
+ * \param Rn   The first source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ * \param Rm   The second source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ */
+#define INSTR_CREATE_whilehi_sve(dc, Pd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_whilehi, Pd, Rn, Rm)
+
+/**
+ * Creates a WHILEHS instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      WHILEHS <Pd>.<Ts>, <R><n>, <R><m>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b, P.h, P.s or P.d.
+ * \param Rn   The first source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ * \param Rm   The second source  register. Can be W (Word, 32 bits) or X
+ *             (Extended, 64 bits).
+ */
+#define INSTR_CREATE_whilehs_sve(dc, Pd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_whilehs, Pd, Rn, Rm)
+
+/**
+ * Creates a WHILERW instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      WHILERW <Pd>.<Ts>, <Xn>, <Xm>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b, P.h, P.s or P.d.
+ * \param Rn   The first source  register, X (Extended, 64 bits).
+ * \param Rm   The second source  register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_whilerw_sve(dc, Pd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_whilerw, Pd, Rn, Rm)
+
+/**
+ * Creates a WHILEWR instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      WHILEWR <Pd>.<Ts>, <Xn>, <Xm>
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Pd   The destination predicate register. Can be P.b, P.h, P.s or P.d.
+ * \param Rn   The first source  register, X (Extended, 64 bits).
+ * \param Rm   The second source  register, X (Extended, 64 bits).
+ */
+#define INSTR_CREATE_whilewr_sve(dc, Pd, Rn, Rm) \
+    instr_create_1dst_2src(dc, OP_whilewr, Pd, Rn, Rm)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -302,13 +302,14 @@
 --------xx----------------------  shift4     # shift type for logical (shifted register)
 --------xx------------------xxxx  p_size_bhsd_0    # sve predicate vector reg, elsz depending on size
 --------xx------------------xxxx  p_size_bhs_0     # sve predicate vector reg, elsz depending on size
+--------xx------------------xxxx  p_size_bh_0      # sve predicate vector reg, elsz depending on size
 --------xx------------------xxxx  p_size_hsd_0     # sve predicate vector reg, elsz depending on size
 --------xx-----------------xxxxx  float_reg0       # H, S or D register
 --------xx-----------------xxxxx  hsd_size_reg0    # hsd register, depending on size opcode
 --------xx-----------------xxxxx  bhsd_size_reg0   # bhsd register, depending on size opcode
 --------xx-----------------xxxxx  z_size_bhsd_0    # sve vector reg, elsz depending on size
 --------xx-----------------xxxxx  z_size_bhs_0     # sve vector reg, elsz depending on size
---------xx-----------------xxxxx  z_sizep1_bhs_0     # sve vector reg, elsz depending on size, plus one
+--------xx-----------------xxxxx  z_sizep1_bhs_0   # sve vector reg, elsz depending on size, plus one
 --------xx-----------------xxxxx  z_size_hsd_0     # sve vector reg, elsz depending on size
 --------xx-----------------xxxxx  z_size_sd_0      # sve vector reg, elsz depending on size
 --------xx-----------------xxxxx  z_size_hd_0      # sve vector reg, elsz depending on size
@@ -319,6 +320,7 @@
 --------xx------------xxxxx-----  p_size_hsd_5     # sve predicate vector reg, elsz depending on size
 --------xx------------xxxxx-----  z_size_bhsd_5    # sve vector reg, elsz depending on size
 --------xx------------xxxxx-----  z_size_bhs_5     # sve vector reg, elsz depending on size
+--------xx------------xxxxx-----  z_size_bh_5      # sve vector reg, elsz depending on size
 --------xx------------xxxxx-----  z_sizep1_bhs_5   # sve vector reg, elsz depending on size, plus 1
 --------xx------------xxxxx-----  z_sizep2_bh_5    # sve vector reg, elsz depending on size, plus 2
 --------xx------------xxxxx-----  z_sizep1_bs_5    # sve vector reg, elsz depending on size, plus 1
@@ -334,6 +336,7 @@
 --------xx-xxxxx----------------  bhsd_size_reg16  # bhsd register, depending on size opcode
 --------xx-xxxxx----------------  p_size_bhsd_16   # sve vector reg, elsz depending on size
 --------xx-xxxxx----------------  z_size_bhsd_16   # sve vector reg, elsz depending on size
+--------xx-xxxxx----------------  z_size_bh_16     # sve vector reg, elsz depending on size
 --------xx-xxxxx----------------  z_size_sd_16     # sve vector reg, elsz depending on size
 --------xx-xxxxx----------------  z_sizep1_bhs_16  # sve vector reg, elsz depending on size plus 1
 --------xx-xxxxx----------------  z_sizep2_bh_16   # sve vector reg, elsz depending on size plus 2

--- a/suite/tests/api/dis-a64-sve2.txt
+++ b/suite/tests/api/dis-a64-sve2.txt
@@ -1690,6 +1690,40 @@ c51b9f79 : ldnt1sw z25.d, p7/Z, [z27.d, x27]         : ldnt1sw (%z27.d,%x27)[16b
 c51d9fbb : ldnt1sw z27.d, p7/Z, [z29.d, x29]         : ldnt1sw (%z29.d,%x29)[16byte] %p7/z -> %z27.d
 c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16byte] %p7/z -> %z31.d
 
+# MATCH   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (MATCH-P.P.ZZ-_)
+45208000 : match p0.b, p0/Z, z0.b, z0.b              : match  %p0/z %z0.b %z0.b -> %p0.b
+45258481 : match p1.b, p1/Z, z4.b, z5.b              : match  %p1/z %z4.b %z5.b -> %p1.b
+452788c2 : match p2.b, p2/Z, z6.b, z7.b              : match  %p2/z %z6.b %z7.b -> %p2.b
+45298903 : match p3.b, p2/Z, z8.b, z9.b              : match  %p2/z %z8.b %z9.b -> %p3.b
+452b8d44 : match p4.b, p3/Z, z10.b, z11.b            : match  %p3/z %z10.b %z11.b -> %p4.b
+452d8d85 : match p5.b, p3/Z, z12.b, z13.b            : match  %p3/z %z12.b %z13.b -> %p5.b
+452f91c6 : match p6.b, p4/Z, z14.b, z15.b            : match  %p4/z %z14.b %z15.b -> %p6.b
+45319207 : match p7.b, p4/Z, z16.b, z17.b            : match  %p4/z %z16.b %z17.b -> %p7.b
+45339648 : match p8.b, p5/Z, z18.b, z19.b            : match  %p5/z %z18.b %z19.b -> %p8.b
+45349668 : match p8.b, p5/Z, z19.b, z20.b            : match  %p5/z %z19.b %z20.b -> %p8.b
+453696a9 : match p9.b, p5/Z, z21.b, z22.b            : match  %p5/z %z21.b %z22.b -> %p9.b
+45389aea : match p10.b, p6/Z, z23.b, z24.b           : match  %p6/z %z23.b %z24.b -> %p10.b
+453a9b2b : match p11.b, p6/Z, z25.b, z26.b           : match  %p6/z %z25.b %z26.b -> %p11.b
+453c9f6c : match p12.b, p7/Z, z27.b, z28.b           : match  %p7/z %z27.b %z28.b -> %p12.b
+453e9fad : match p13.b, p7/Z, z29.b, z30.b           : match  %p7/z %z29.b %z30.b -> %p13.b
+453f9fef : match p15.b, p7/Z, z31.b, z31.b           : match  %p7/z %z31.b %z31.b -> %p15.b
+45608000 : match p0.h, p0/Z, z0.h, z0.h              : match  %p0/z %z0.h %z0.h -> %p0.h
+45658481 : match p1.h, p1/Z, z4.h, z5.h              : match  %p1/z %z4.h %z5.h -> %p1.h
+456788c2 : match p2.h, p2/Z, z6.h, z7.h              : match  %p2/z %z6.h %z7.h -> %p2.h
+45698903 : match p3.h, p2/Z, z8.h, z9.h              : match  %p2/z %z8.h %z9.h -> %p3.h
+456b8d44 : match p4.h, p3/Z, z10.h, z11.h            : match  %p3/z %z10.h %z11.h -> %p4.h
+456d8d85 : match p5.h, p3/Z, z12.h, z13.h            : match  %p3/z %z12.h %z13.h -> %p5.h
+456f91c6 : match p6.h, p4/Z, z14.h, z15.h            : match  %p4/z %z14.h %z15.h -> %p6.h
+45719207 : match p7.h, p4/Z, z16.h, z17.h            : match  %p4/z %z16.h %z17.h -> %p7.h
+45739648 : match p8.h, p5/Z, z18.h, z19.h            : match  %p5/z %z18.h %z19.h -> %p8.h
+45749668 : match p8.h, p5/Z, z19.h, z20.h            : match  %p5/z %z19.h %z20.h -> %p8.h
+457696a9 : match p9.h, p5/Z, z21.h, z22.h            : match  %p5/z %z21.h %z22.h -> %p9.h
+45789aea : match p10.h, p6/Z, z23.h, z24.h           : match  %p6/z %z23.h %z24.h -> %p10.h
+457a9b2b : match p11.h, p6/Z, z25.h, z26.h           : match  %p6/z %z25.h %z26.h -> %p11.h
+457c9f6c : match p12.h, p7/Z, z27.h, z28.h           : match  %p7/z %z27.h %z28.h -> %p12.h
+457e9fad : match p13.h, p7/Z, z29.h, z30.h           : match  %p7/z %z29.h %z30.h -> %p13.h
+457f9fef : match p15.h, p7/Z, z31.h, z31.h           : match  %p7/z %z31.h %z31.h -> %p15.h
+
 # NBSL    <Zdn>.D, <Zdn>.D, <Zm>.D, <Zk>.D (NBSL-Z.ZZZ-_)
 04e03c00 : nbsl z0.d, z0.d, z0.d, z0.d               : nbsl   %z0.d %z0.d %z0.d -> %z0.d
 04e33c82 : nbsl z2.d, z2.d, z3.d, z4.d               : nbsl   %z2.d %z3.d %z4.d -> %z2.d
@@ -1707,6 +1741,40 @@ c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16b
 04fa3f79 : nbsl z25.d, z25.d, z26.d, z27.d           : nbsl   %z25.d %z26.d %z27.d -> %z25.d
 04fc3fbb : nbsl z27.d, z27.d, z28.d, z29.d           : nbsl   %z27.d %z28.d %z29.d -> %z27.d
 04ff3fff : nbsl z31.d, z31.d, z31.d, z31.d           : nbsl   %z31.d %z31.d %z31.d -> %z31.d
+
+# NMATCH  <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (NMATCH-P.P.ZZ-_)
+45208010 : nmatch p0.b, p0/Z, z0.b, z0.b             : nmatch %p0/z %z0.b %z0.b -> %p0.b
+45258491 : nmatch p1.b, p1/Z, z4.b, z5.b             : nmatch %p1/z %z4.b %z5.b -> %p1.b
+452788d2 : nmatch p2.b, p2/Z, z6.b, z7.b             : nmatch %p2/z %z6.b %z7.b -> %p2.b
+45298913 : nmatch p3.b, p2/Z, z8.b, z9.b             : nmatch %p2/z %z8.b %z9.b -> %p3.b
+452b8d54 : nmatch p4.b, p3/Z, z10.b, z11.b           : nmatch %p3/z %z10.b %z11.b -> %p4.b
+452d8d95 : nmatch p5.b, p3/Z, z12.b, z13.b           : nmatch %p3/z %z12.b %z13.b -> %p5.b
+452f91d6 : nmatch p6.b, p4/Z, z14.b, z15.b           : nmatch %p4/z %z14.b %z15.b -> %p6.b
+45319217 : nmatch p7.b, p4/Z, z16.b, z17.b           : nmatch %p4/z %z16.b %z17.b -> %p7.b
+45339658 : nmatch p8.b, p5/Z, z18.b, z19.b           : nmatch %p5/z %z18.b %z19.b -> %p8.b
+45349678 : nmatch p8.b, p5/Z, z19.b, z20.b           : nmatch %p5/z %z19.b %z20.b -> %p8.b
+453696b9 : nmatch p9.b, p5/Z, z21.b, z22.b           : nmatch %p5/z %z21.b %z22.b -> %p9.b
+45389afa : nmatch p10.b, p6/Z, z23.b, z24.b          : nmatch %p6/z %z23.b %z24.b -> %p10.b
+453a9b3b : nmatch p11.b, p6/Z, z25.b, z26.b          : nmatch %p6/z %z25.b %z26.b -> %p11.b
+453c9f7c : nmatch p12.b, p7/Z, z27.b, z28.b          : nmatch %p7/z %z27.b %z28.b -> %p12.b
+453e9fbd : nmatch p13.b, p7/Z, z29.b, z30.b          : nmatch %p7/z %z29.b %z30.b -> %p13.b
+453f9fff : nmatch p15.b, p7/Z, z31.b, z31.b          : nmatch %p7/z %z31.b %z31.b -> %p15.b
+45608010 : nmatch p0.h, p0/Z, z0.h, z0.h             : nmatch %p0/z %z0.h %z0.h -> %p0.h
+45658491 : nmatch p1.h, p1/Z, z4.h, z5.h             : nmatch %p1/z %z4.h %z5.h -> %p1.h
+456788d2 : nmatch p2.h, p2/Z, z6.h, z7.h             : nmatch %p2/z %z6.h %z7.h -> %p2.h
+45698913 : nmatch p3.h, p2/Z, z8.h, z9.h             : nmatch %p2/z %z8.h %z9.h -> %p3.h
+456b8d54 : nmatch p4.h, p3/Z, z10.h, z11.h           : nmatch %p3/z %z10.h %z11.h -> %p4.h
+456d8d95 : nmatch p5.h, p3/Z, z12.h, z13.h           : nmatch %p3/z %z12.h %z13.h -> %p5.h
+456f91d6 : nmatch p6.h, p4/Z, z14.h, z15.h           : nmatch %p4/z %z14.h %z15.h -> %p6.h
+45719217 : nmatch p7.h, p4/Z, z16.h, z17.h           : nmatch %p4/z %z16.h %z17.h -> %p7.h
+45739658 : nmatch p8.h, p5/Z, z18.h, z19.h           : nmatch %p5/z %z18.h %z19.h -> %p8.h
+45749678 : nmatch p8.h, p5/Z, z19.h, z20.h           : nmatch %p5/z %z19.h %z20.h -> %p8.h
+457696b9 : nmatch p9.h, p5/Z, z21.h, z22.h           : nmatch %p5/z %z21.h %z22.h -> %p9.h
+45789afa : nmatch p10.h, p6/Z, z23.h, z24.h          : nmatch %p6/z %z23.h %z24.h -> %p10.h
+457a9b3b : nmatch p11.h, p6/Z, z25.h, z26.h          : nmatch %p6/z %z25.h %z26.h -> %p11.h
+457c9f7c : nmatch p12.h, p7/Z, z27.h, z28.h          : nmatch %p7/z %z27.h %z28.h -> %p12.h
+457e9fbd : nmatch p13.h, p7/Z, z29.h, z30.h          : nmatch %p7/z %z29.h %z30.h -> %p13.h
+457f9fff : nmatch p15.h, p7/Z, z31.h, z31.h          : nmatch %p7/z %z31.h %z31.h -> %p15.h
 
 # PMUL    <Zd>.B, <Zn>.B, <Zm>.B (PMUL-Z.ZZ-_)
 04206400 : pmul z0.b, z0.b, z0.b                     : pmul   %z0.b %z0.b -> %z0.b
@@ -9404,6 +9472,24 @@ c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16b
 45604f9b : uqxtnt z27.s, z28.d                       : uqxtnt %z27.s %z28.d -> %z27.s
 45604fff : uqxtnt z31.s, z31.d                       : uqxtnt %z31.s %z31.d -> %z31.s
 
+# URECPE  <Zd>.S, <Pg>/M, <Zn>.S (URECPE-Z.P.Z-_)
+4480a000 : urecpe z0.s, p0/M, z0.s                   : urecpe %p0/m %z0.s -> %z0.s
+4480a482 : urecpe z2.s, p1/M, z4.s                   : urecpe %p1/m %z4.s -> %z2.s
+4480a8c4 : urecpe z4.s, p2/M, z6.s                   : urecpe %p2/m %z6.s -> %z4.s
+4480a906 : urecpe z6.s, p2/M, z8.s                   : urecpe %p2/m %z8.s -> %z6.s
+4480ad48 : urecpe z8.s, p3/M, z10.s                  : urecpe %p3/m %z10.s -> %z8.s
+4480ad8a : urecpe z10.s, p3/M, z12.s                 : urecpe %p3/m %z12.s -> %z10.s
+4480b1cc : urecpe z12.s, p4/M, z14.s                 : urecpe %p4/m %z14.s -> %z12.s
+4480b20e : urecpe z14.s, p4/M, z16.s                 : urecpe %p4/m %z16.s -> %z14.s
+4480b650 : urecpe z16.s, p5/M, z18.s                 : urecpe %p5/m %z18.s -> %z16.s
+4480b671 : urecpe z17.s, p5/M, z19.s                 : urecpe %p5/m %z19.s -> %z17.s
+4480b6b3 : urecpe z19.s, p5/M, z21.s                 : urecpe %p5/m %z21.s -> %z19.s
+4480baf5 : urecpe z21.s, p6/M, z23.s                 : urecpe %p6/m %z23.s -> %z21.s
+4480bb37 : urecpe z23.s, p6/M, z25.s                 : urecpe %p6/m %z25.s -> %z23.s
+4480bf79 : urecpe z25.s, p7/M, z27.s                 : urecpe %p7/m %z27.s -> %z25.s
+4480bfbb : urecpe z27.s, p7/M, z29.s                 : urecpe %p7/m %z29.s -> %z27.s
+4480bfff : urecpe z31.s, p7/M, z31.s                 : urecpe %p7/m %z31.s -> %z31.s
+
 # URHADD  <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (URHADD-Z.P.ZZ-_)
 44158000 : urhadd z0.b, p0/M, z0.b, z0.b             : urhadd %p0/m %z0.b %z0.b -> %z0.b
 44158482 : urhadd z2.b, p1/M, z2.b, z4.b             : urhadd %p1/m %z2.b %z4.b -> %z2.b
@@ -9667,6 +9753,24 @@ c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16b
 048d9d99 : urshr z25.d, p7/M, z25.d, #0x34           : urshr  %p7/m %z25.d $0x34 -> %z25.d
 048d9d1b : urshr z27.d, p7/M, z27.d, #0x38           : urshr  %p7/m %z27.d $0x38 -> %z27.d
 048d9c1f : urshr z31.d, p7/M, z31.d, #0x40           : urshr  %p7/m %z31.d $0x40 -> %z31.d
+
+# URSQRTE <Zd>.S, <Pg>/M, <Zn>.S (URSQRTE-Z.P.Z-_)
+4481a000 : ursqrte z0.s, p0/M, z0.s                  : ursqrte %p0/m %z0.s -> %z0.s
+4481a482 : ursqrte z2.s, p1/M, z4.s                  : ursqrte %p1/m %z4.s -> %z2.s
+4481a8c4 : ursqrte z4.s, p2/M, z6.s                  : ursqrte %p2/m %z6.s -> %z4.s
+4481a906 : ursqrte z6.s, p2/M, z8.s                  : ursqrte %p2/m %z8.s -> %z6.s
+4481ad48 : ursqrte z8.s, p3/M, z10.s                 : ursqrte %p3/m %z10.s -> %z8.s
+4481ad8a : ursqrte z10.s, p3/M, z12.s                : ursqrte %p3/m %z12.s -> %z10.s
+4481b1cc : ursqrte z12.s, p4/M, z14.s                : ursqrte %p4/m %z14.s -> %z12.s
+4481b20e : ursqrte z14.s, p4/M, z16.s                : ursqrte %p4/m %z16.s -> %z14.s
+4481b650 : ursqrte z16.s, p5/M, z18.s                : ursqrte %p5/m %z18.s -> %z16.s
+4481b671 : ursqrte z17.s, p5/M, z19.s                : ursqrte %p5/m %z19.s -> %z17.s
+4481b6b3 : ursqrte z19.s, p5/M, z21.s                : ursqrte %p5/m %z21.s -> %z19.s
+4481baf5 : ursqrte z21.s, p6/M, z23.s                : ursqrte %p6/m %z23.s -> %z21.s
+4481bb37 : ursqrte z23.s, p6/M, z25.s                : ursqrte %p6/m %z25.s -> %z23.s
+4481bf79 : ursqrte z25.s, p7/M, z27.s                : ursqrte %p7/m %z27.s -> %z25.s
+4481bfbb : ursqrte z27.s, p7/M, z29.s                : ursqrte %p7/m %z29.s -> %z27.s
+4481bfff : ursqrte z31.s, p7/M, z31.s                : ursqrte %p7/m %z31.s -> %z31.s
 
 # URSRA   <Zda>.<T>, <Zn>.<T>, #<const> (URSRA-Z.ZI-_)
 450fec00 : ursra z0.b, z0.b, #0x1                    : ursra  %z0.b %z0.b $0x01 -> %z0.b
@@ -10165,6 +10269,658 @@ c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16b
 45db5f59 : usubwt z25.d, z26.d, z27.s                : usubwt %z26.d %z27.s -> %z25.d
 45dd5f9b : usubwt z27.d, z28.d, z29.s                : usubwt %z28.d %z29.s -> %z27.d
 45df5fff : usubwt z31.d, z31.d, z31.s                : usubwt %z31.d %z31.s -> %z31.d
+
+# WHILEGE <Pd>.<T>, <R><n>, <R><m> (WHILEGE-P.P.RR-_)
+25200000 : whilege p0.b, w0, w0                      : whilege %w0 %w0 -> %p0.b
+25240061 : whilege p1.b, w3, w4                      : whilege %w3 %w4 -> %p1.b
+252600a2 : whilege p2.b, w5, w6                      : whilege %w5 %w6 -> %p2.b
+252800e3 : whilege p3.b, w7, w8                      : whilege %w7 %w8 -> %p3.b
+252a0124 : whilege p4.b, w9, w10                     : whilege %w9 %w10 -> %p4.b
+252b0145 : whilege p5.b, w10, w11                    : whilege %w10 %w11 -> %p5.b
+252d0186 : whilege p6.b, w12, w13                    : whilege %w12 %w13 -> %p6.b
+252f01c7 : whilege p7.b, w14, w15                    : whilege %w14 %w15 -> %p7.b
+25310208 : whilege p8.b, w16, w17                    : whilege %w16 %w17 -> %p8.b
+25330248 : whilege p8.b, w18, w19                    : whilege %w18 %w19 -> %p8.b
+25350289 : whilege p9.b, w20, w21                    : whilege %w20 %w21 -> %p9.b
+253702ca : whilege p10.b, w22, w23                   : whilege %w22 %w23 -> %p10.b
+253802eb : whilege p11.b, w23, w24                   : whilege %w23 %w24 -> %p11.b
+253a032c : whilege p12.b, w25, w26                   : whilege %w25 %w26 -> %p12.b
+253c036d : whilege p13.b, w27, w28                   : whilege %w27 %w28 -> %p13.b
+253e03cf : whilege p15.b, w30, w30                   : whilege %w30 %w30 -> %p15.b
+25201000 : whilege p0.b, x0, x0                      : whilege %x0 %x0 -> %p0.b
+25241061 : whilege p1.b, x3, x4                      : whilege %x3 %x4 -> %p1.b
+252610a2 : whilege p2.b, x5, x6                      : whilege %x5 %x6 -> %p2.b
+252810e3 : whilege p3.b, x7, x8                      : whilege %x7 %x8 -> %p3.b
+252a1124 : whilege p4.b, x9, x10                     : whilege %x9 %x10 -> %p4.b
+252b1145 : whilege p5.b, x10, x11                    : whilege %x10 %x11 -> %p5.b
+252d1186 : whilege p6.b, x12, x13                    : whilege %x12 %x13 -> %p6.b
+252f11c7 : whilege p7.b, x14, x15                    : whilege %x14 %x15 -> %p7.b
+25311208 : whilege p8.b, x16, x17                    : whilege %x16 %x17 -> %p8.b
+25331248 : whilege p8.b, x18, x19                    : whilege %x18 %x19 -> %p8.b
+25351289 : whilege p9.b, x20, x21                    : whilege %x20 %x21 -> %p9.b
+253712ca : whilege p10.b, x22, x23                   : whilege %x22 %x23 -> %p10.b
+253812eb : whilege p11.b, x23, x24                   : whilege %x23 %x24 -> %p11.b
+253a132c : whilege p12.b, x25, x26                   : whilege %x25 %x26 -> %p12.b
+253c136d : whilege p13.b, x27, x28                   : whilege %x27 %x28 -> %p13.b
+253e13cf : whilege p15.b, x30, x30                   : whilege %x30 %x30 -> %p15.b
+25600000 : whilege p0.h, w0, w0                      : whilege %w0 %w0 -> %p0.h
+25640061 : whilege p1.h, w3, w4                      : whilege %w3 %w4 -> %p1.h
+256600a2 : whilege p2.h, w5, w6                      : whilege %w5 %w6 -> %p2.h
+256800e3 : whilege p3.h, w7, w8                      : whilege %w7 %w8 -> %p3.h
+256a0124 : whilege p4.h, w9, w10                     : whilege %w9 %w10 -> %p4.h
+256b0145 : whilege p5.h, w10, w11                    : whilege %w10 %w11 -> %p5.h
+256d0186 : whilege p6.h, w12, w13                    : whilege %w12 %w13 -> %p6.h
+256f01c7 : whilege p7.h, w14, w15                    : whilege %w14 %w15 -> %p7.h
+25710208 : whilege p8.h, w16, w17                    : whilege %w16 %w17 -> %p8.h
+25730248 : whilege p8.h, w18, w19                    : whilege %w18 %w19 -> %p8.h
+25750289 : whilege p9.h, w20, w21                    : whilege %w20 %w21 -> %p9.h
+257702ca : whilege p10.h, w22, w23                   : whilege %w22 %w23 -> %p10.h
+257802eb : whilege p11.h, w23, w24                   : whilege %w23 %w24 -> %p11.h
+257a032c : whilege p12.h, w25, w26                   : whilege %w25 %w26 -> %p12.h
+257c036d : whilege p13.h, w27, w28                   : whilege %w27 %w28 -> %p13.h
+257e03cf : whilege p15.h, w30, w30                   : whilege %w30 %w30 -> %p15.h
+25601000 : whilege p0.h, x0, x0                      : whilege %x0 %x0 -> %p0.h
+25641061 : whilege p1.h, x3, x4                      : whilege %x3 %x4 -> %p1.h
+256610a2 : whilege p2.h, x5, x6                      : whilege %x5 %x6 -> %p2.h
+256810e3 : whilege p3.h, x7, x8                      : whilege %x7 %x8 -> %p3.h
+256a1124 : whilege p4.h, x9, x10                     : whilege %x9 %x10 -> %p4.h
+256b1145 : whilege p5.h, x10, x11                    : whilege %x10 %x11 -> %p5.h
+256d1186 : whilege p6.h, x12, x13                    : whilege %x12 %x13 -> %p6.h
+256f11c7 : whilege p7.h, x14, x15                    : whilege %x14 %x15 -> %p7.h
+25711208 : whilege p8.h, x16, x17                    : whilege %x16 %x17 -> %p8.h
+25731248 : whilege p8.h, x18, x19                    : whilege %x18 %x19 -> %p8.h
+25751289 : whilege p9.h, x20, x21                    : whilege %x20 %x21 -> %p9.h
+257712ca : whilege p10.h, x22, x23                   : whilege %x22 %x23 -> %p10.h
+257812eb : whilege p11.h, x23, x24                   : whilege %x23 %x24 -> %p11.h
+257a132c : whilege p12.h, x25, x26                   : whilege %x25 %x26 -> %p12.h
+257c136d : whilege p13.h, x27, x28                   : whilege %x27 %x28 -> %p13.h
+257e13cf : whilege p15.h, x30, x30                   : whilege %x30 %x30 -> %p15.h
+25a00000 : whilege p0.s, w0, w0                      : whilege %w0 %w0 -> %p0.s
+25a40061 : whilege p1.s, w3, w4                      : whilege %w3 %w4 -> %p1.s
+25a600a2 : whilege p2.s, w5, w6                      : whilege %w5 %w6 -> %p2.s
+25a800e3 : whilege p3.s, w7, w8                      : whilege %w7 %w8 -> %p3.s
+25aa0124 : whilege p4.s, w9, w10                     : whilege %w9 %w10 -> %p4.s
+25ab0145 : whilege p5.s, w10, w11                    : whilege %w10 %w11 -> %p5.s
+25ad0186 : whilege p6.s, w12, w13                    : whilege %w12 %w13 -> %p6.s
+25af01c7 : whilege p7.s, w14, w15                    : whilege %w14 %w15 -> %p7.s
+25b10208 : whilege p8.s, w16, w17                    : whilege %w16 %w17 -> %p8.s
+25b30248 : whilege p8.s, w18, w19                    : whilege %w18 %w19 -> %p8.s
+25b50289 : whilege p9.s, w20, w21                    : whilege %w20 %w21 -> %p9.s
+25b702ca : whilege p10.s, w22, w23                   : whilege %w22 %w23 -> %p10.s
+25b802eb : whilege p11.s, w23, w24                   : whilege %w23 %w24 -> %p11.s
+25ba032c : whilege p12.s, w25, w26                   : whilege %w25 %w26 -> %p12.s
+25bc036d : whilege p13.s, w27, w28                   : whilege %w27 %w28 -> %p13.s
+25be03cf : whilege p15.s, w30, w30                   : whilege %w30 %w30 -> %p15.s
+25a01000 : whilege p0.s, x0, x0                      : whilege %x0 %x0 -> %p0.s
+25a41061 : whilege p1.s, x3, x4                      : whilege %x3 %x4 -> %p1.s
+25a610a2 : whilege p2.s, x5, x6                      : whilege %x5 %x6 -> %p2.s
+25a810e3 : whilege p3.s, x7, x8                      : whilege %x7 %x8 -> %p3.s
+25aa1124 : whilege p4.s, x9, x10                     : whilege %x9 %x10 -> %p4.s
+25ab1145 : whilege p5.s, x10, x11                    : whilege %x10 %x11 -> %p5.s
+25ad1186 : whilege p6.s, x12, x13                    : whilege %x12 %x13 -> %p6.s
+25af11c7 : whilege p7.s, x14, x15                    : whilege %x14 %x15 -> %p7.s
+25b11208 : whilege p8.s, x16, x17                    : whilege %x16 %x17 -> %p8.s
+25b31248 : whilege p8.s, x18, x19                    : whilege %x18 %x19 -> %p8.s
+25b51289 : whilege p9.s, x20, x21                    : whilege %x20 %x21 -> %p9.s
+25b712ca : whilege p10.s, x22, x23                   : whilege %x22 %x23 -> %p10.s
+25b812eb : whilege p11.s, x23, x24                   : whilege %x23 %x24 -> %p11.s
+25ba132c : whilege p12.s, x25, x26                   : whilege %x25 %x26 -> %p12.s
+25bc136d : whilege p13.s, x27, x28                   : whilege %x27 %x28 -> %p13.s
+25be13cf : whilege p15.s, x30, x30                   : whilege %x30 %x30 -> %p15.s
+25e00000 : whilege p0.d, w0, w0                      : whilege %w0 %w0 -> %p0.d
+25e40061 : whilege p1.d, w3, w4                      : whilege %w3 %w4 -> %p1.d
+25e600a2 : whilege p2.d, w5, w6                      : whilege %w5 %w6 -> %p2.d
+25e800e3 : whilege p3.d, w7, w8                      : whilege %w7 %w8 -> %p3.d
+25ea0124 : whilege p4.d, w9, w10                     : whilege %w9 %w10 -> %p4.d
+25eb0145 : whilege p5.d, w10, w11                    : whilege %w10 %w11 -> %p5.d
+25ed0186 : whilege p6.d, w12, w13                    : whilege %w12 %w13 -> %p6.d
+25ef01c7 : whilege p7.d, w14, w15                    : whilege %w14 %w15 -> %p7.d
+25f10208 : whilege p8.d, w16, w17                    : whilege %w16 %w17 -> %p8.d
+25f30248 : whilege p8.d, w18, w19                    : whilege %w18 %w19 -> %p8.d
+25f50289 : whilege p9.d, w20, w21                    : whilege %w20 %w21 -> %p9.d
+25f702ca : whilege p10.d, w22, w23                   : whilege %w22 %w23 -> %p10.d
+25f802eb : whilege p11.d, w23, w24                   : whilege %w23 %w24 -> %p11.d
+25fa032c : whilege p12.d, w25, w26                   : whilege %w25 %w26 -> %p12.d
+25fc036d : whilege p13.d, w27, w28                   : whilege %w27 %w28 -> %p13.d
+25fe03cf : whilege p15.d, w30, w30                   : whilege %w30 %w30 -> %p15.d
+25e01000 : whilege p0.d, x0, x0                      : whilege %x0 %x0 -> %p0.d
+25e41061 : whilege p1.d, x3, x4                      : whilege %x3 %x4 -> %p1.d
+25e610a2 : whilege p2.d, x5, x6                      : whilege %x5 %x6 -> %p2.d
+25e810e3 : whilege p3.d, x7, x8                      : whilege %x7 %x8 -> %p3.d
+25ea1124 : whilege p4.d, x9, x10                     : whilege %x9 %x10 -> %p4.d
+25eb1145 : whilege p5.d, x10, x11                    : whilege %x10 %x11 -> %p5.d
+25ed1186 : whilege p6.d, x12, x13                    : whilege %x12 %x13 -> %p6.d
+25ef11c7 : whilege p7.d, x14, x15                    : whilege %x14 %x15 -> %p7.d
+25f11208 : whilege p8.d, x16, x17                    : whilege %x16 %x17 -> %p8.d
+25f31248 : whilege p8.d, x18, x19                    : whilege %x18 %x19 -> %p8.d
+25f51289 : whilege p9.d, x20, x21                    : whilege %x20 %x21 -> %p9.d
+25f712ca : whilege p10.d, x22, x23                   : whilege %x22 %x23 -> %p10.d
+25f812eb : whilege p11.d, x23, x24                   : whilege %x23 %x24 -> %p11.d
+25fa132c : whilege p12.d, x25, x26                   : whilege %x25 %x26 -> %p12.d
+25fc136d : whilege p13.d, x27, x28                   : whilege %x27 %x28 -> %p13.d
+25fe13cf : whilege p15.d, x30, x30                   : whilege %x30 %x30 -> %p15.d
+
+# WHILEGT <Pd>.<T>, <R><n>, <R><m> (WHILEGT-P.P.RR-_)
+25200010 : whilegt p0.b, w0, w0                      : whilegt %w0 %w0 -> %p0.b
+25240071 : whilegt p1.b, w3, w4                      : whilegt %w3 %w4 -> %p1.b
+252600b2 : whilegt p2.b, w5, w6                      : whilegt %w5 %w6 -> %p2.b
+252800f3 : whilegt p3.b, w7, w8                      : whilegt %w7 %w8 -> %p3.b
+252a0134 : whilegt p4.b, w9, w10                     : whilegt %w9 %w10 -> %p4.b
+252b0155 : whilegt p5.b, w10, w11                    : whilegt %w10 %w11 -> %p5.b
+252d0196 : whilegt p6.b, w12, w13                    : whilegt %w12 %w13 -> %p6.b
+252f01d7 : whilegt p7.b, w14, w15                    : whilegt %w14 %w15 -> %p7.b
+25310218 : whilegt p8.b, w16, w17                    : whilegt %w16 %w17 -> %p8.b
+25330258 : whilegt p8.b, w18, w19                    : whilegt %w18 %w19 -> %p8.b
+25350299 : whilegt p9.b, w20, w21                    : whilegt %w20 %w21 -> %p9.b
+253702da : whilegt p10.b, w22, w23                   : whilegt %w22 %w23 -> %p10.b
+253802fb : whilegt p11.b, w23, w24                   : whilegt %w23 %w24 -> %p11.b
+253a033c : whilegt p12.b, w25, w26                   : whilegt %w25 %w26 -> %p12.b
+253c037d : whilegt p13.b, w27, w28                   : whilegt %w27 %w28 -> %p13.b
+253e03df : whilegt p15.b, w30, w30                   : whilegt %w30 %w30 -> %p15.b
+25201010 : whilegt p0.b, x0, x0                      : whilegt %x0 %x0 -> %p0.b
+25241071 : whilegt p1.b, x3, x4                      : whilegt %x3 %x4 -> %p1.b
+252610b2 : whilegt p2.b, x5, x6                      : whilegt %x5 %x6 -> %p2.b
+252810f3 : whilegt p3.b, x7, x8                      : whilegt %x7 %x8 -> %p3.b
+252a1134 : whilegt p4.b, x9, x10                     : whilegt %x9 %x10 -> %p4.b
+252b1155 : whilegt p5.b, x10, x11                    : whilegt %x10 %x11 -> %p5.b
+252d1196 : whilegt p6.b, x12, x13                    : whilegt %x12 %x13 -> %p6.b
+252f11d7 : whilegt p7.b, x14, x15                    : whilegt %x14 %x15 -> %p7.b
+25311218 : whilegt p8.b, x16, x17                    : whilegt %x16 %x17 -> %p8.b
+25331258 : whilegt p8.b, x18, x19                    : whilegt %x18 %x19 -> %p8.b
+25351299 : whilegt p9.b, x20, x21                    : whilegt %x20 %x21 -> %p9.b
+253712da : whilegt p10.b, x22, x23                   : whilegt %x22 %x23 -> %p10.b
+253812fb : whilegt p11.b, x23, x24                   : whilegt %x23 %x24 -> %p11.b
+253a133c : whilegt p12.b, x25, x26                   : whilegt %x25 %x26 -> %p12.b
+253c137d : whilegt p13.b, x27, x28                   : whilegt %x27 %x28 -> %p13.b
+253e13df : whilegt p15.b, x30, x30                   : whilegt %x30 %x30 -> %p15.b
+25600010 : whilegt p0.h, w0, w0                      : whilegt %w0 %w0 -> %p0.h
+25640071 : whilegt p1.h, w3, w4                      : whilegt %w3 %w4 -> %p1.h
+256600b2 : whilegt p2.h, w5, w6                      : whilegt %w5 %w6 -> %p2.h
+256800f3 : whilegt p3.h, w7, w8                      : whilegt %w7 %w8 -> %p3.h
+256a0134 : whilegt p4.h, w9, w10                     : whilegt %w9 %w10 -> %p4.h
+256b0155 : whilegt p5.h, w10, w11                    : whilegt %w10 %w11 -> %p5.h
+256d0196 : whilegt p6.h, w12, w13                    : whilegt %w12 %w13 -> %p6.h
+256f01d7 : whilegt p7.h, w14, w15                    : whilegt %w14 %w15 -> %p7.h
+25710218 : whilegt p8.h, w16, w17                    : whilegt %w16 %w17 -> %p8.h
+25730258 : whilegt p8.h, w18, w19                    : whilegt %w18 %w19 -> %p8.h
+25750299 : whilegt p9.h, w20, w21                    : whilegt %w20 %w21 -> %p9.h
+257702da : whilegt p10.h, w22, w23                   : whilegt %w22 %w23 -> %p10.h
+257802fb : whilegt p11.h, w23, w24                   : whilegt %w23 %w24 -> %p11.h
+257a033c : whilegt p12.h, w25, w26                   : whilegt %w25 %w26 -> %p12.h
+257c037d : whilegt p13.h, w27, w28                   : whilegt %w27 %w28 -> %p13.h
+257e03df : whilegt p15.h, w30, w30                   : whilegt %w30 %w30 -> %p15.h
+25601010 : whilegt p0.h, x0, x0                      : whilegt %x0 %x0 -> %p0.h
+25641071 : whilegt p1.h, x3, x4                      : whilegt %x3 %x4 -> %p1.h
+256610b2 : whilegt p2.h, x5, x6                      : whilegt %x5 %x6 -> %p2.h
+256810f3 : whilegt p3.h, x7, x8                      : whilegt %x7 %x8 -> %p3.h
+256a1134 : whilegt p4.h, x9, x10                     : whilegt %x9 %x10 -> %p4.h
+256b1155 : whilegt p5.h, x10, x11                    : whilegt %x10 %x11 -> %p5.h
+256d1196 : whilegt p6.h, x12, x13                    : whilegt %x12 %x13 -> %p6.h
+256f11d7 : whilegt p7.h, x14, x15                    : whilegt %x14 %x15 -> %p7.h
+25711218 : whilegt p8.h, x16, x17                    : whilegt %x16 %x17 -> %p8.h
+25731258 : whilegt p8.h, x18, x19                    : whilegt %x18 %x19 -> %p8.h
+25751299 : whilegt p9.h, x20, x21                    : whilegt %x20 %x21 -> %p9.h
+257712da : whilegt p10.h, x22, x23                   : whilegt %x22 %x23 -> %p10.h
+257812fb : whilegt p11.h, x23, x24                   : whilegt %x23 %x24 -> %p11.h
+257a133c : whilegt p12.h, x25, x26                   : whilegt %x25 %x26 -> %p12.h
+257c137d : whilegt p13.h, x27, x28                   : whilegt %x27 %x28 -> %p13.h
+257e13df : whilegt p15.h, x30, x30                   : whilegt %x30 %x30 -> %p15.h
+25a00010 : whilegt p0.s, w0, w0                      : whilegt %w0 %w0 -> %p0.s
+25a40071 : whilegt p1.s, w3, w4                      : whilegt %w3 %w4 -> %p1.s
+25a600b2 : whilegt p2.s, w5, w6                      : whilegt %w5 %w6 -> %p2.s
+25a800f3 : whilegt p3.s, w7, w8                      : whilegt %w7 %w8 -> %p3.s
+25aa0134 : whilegt p4.s, w9, w10                     : whilegt %w9 %w10 -> %p4.s
+25ab0155 : whilegt p5.s, w10, w11                    : whilegt %w10 %w11 -> %p5.s
+25ad0196 : whilegt p6.s, w12, w13                    : whilegt %w12 %w13 -> %p6.s
+25af01d7 : whilegt p7.s, w14, w15                    : whilegt %w14 %w15 -> %p7.s
+25b10218 : whilegt p8.s, w16, w17                    : whilegt %w16 %w17 -> %p8.s
+25b30258 : whilegt p8.s, w18, w19                    : whilegt %w18 %w19 -> %p8.s
+25b50299 : whilegt p9.s, w20, w21                    : whilegt %w20 %w21 -> %p9.s
+25b702da : whilegt p10.s, w22, w23                   : whilegt %w22 %w23 -> %p10.s
+25b802fb : whilegt p11.s, w23, w24                   : whilegt %w23 %w24 -> %p11.s
+25ba033c : whilegt p12.s, w25, w26                   : whilegt %w25 %w26 -> %p12.s
+25bc037d : whilegt p13.s, w27, w28                   : whilegt %w27 %w28 -> %p13.s
+25be03df : whilegt p15.s, w30, w30                   : whilegt %w30 %w30 -> %p15.s
+25a01010 : whilegt p0.s, x0, x0                      : whilegt %x0 %x0 -> %p0.s
+25a41071 : whilegt p1.s, x3, x4                      : whilegt %x3 %x4 -> %p1.s
+25a610b2 : whilegt p2.s, x5, x6                      : whilegt %x5 %x6 -> %p2.s
+25a810f3 : whilegt p3.s, x7, x8                      : whilegt %x7 %x8 -> %p3.s
+25aa1134 : whilegt p4.s, x9, x10                     : whilegt %x9 %x10 -> %p4.s
+25ab1155 : whilegt p5.s, x10, x11                    : whilegt %x10 %x11 -> %p5.s
+25ad1196 : whilegt p6.s, x12, x13                    : whilegt %x12 %x13 -> %p6.s
+25af11d7 : whilegt p7.s, x14, x15                    : whilegt %x14 %x15 -> %p7.s
+25b11218 : whilegt p8.s, x16, x17                    : whilegt %x16 %x17 -> %p8.s
+25b31258 : whilegt p8.s, x18, x19                    : whilegt %x18 %x19 -> %p8.s
+25b51299 : whilegt p9.s, x20, x21                    : whilegt %x20 %x21 -> %p9.s
+25b712da : whilegt p10.s, x22, x23                   : whilegt %x22 %x23 -> %p10.s
+25b812fb : whilegt p11.s, x23, x24                   : whilegt %x23 %x24 -> %p11.s
+25ba133c : whilegt p12.s, x25, x26                   : whilegt %x25 %x26 -> %p12.s
+25bc137d : whilegt p13.s, x27, x28                   : whilegt %x27 %x28 -> %p13.s
+25be13df : whilegt p15.s, x30, x30                   : whilegt %x30 %x30 -> %p15.s
+25e00010 : whilegt p0.d, w0, w0                      : whilegt %w0 %w0 -> %p0.d
+25e40071 : whilegt p1.d, w3, w4                      : whilegt %w3 %w4 -> %p1.d
+25e600b2 : whilegt p2.d, w5, w6                      : whilegt %w5 %w6 -> %p2.d
+25e800f3 : whilegt p3.d, w7, w8                      : whilegt %w7 %w8 -> %p3.d
+25ea0134 : whilegt p4.d, w9, w10                     : whilegt %w9 %w10 -> %p4.d
+25eb0155 : whilegt p5.d, w10, w11                    : whilegt %w10 %w11 -> %p5.d
+25ed0196 : whilegt p6.d, w12, w13                    : whilegt %w12 %w13 -> %p6.d
+25ef01d7 : whilegt p7.d, w14, w15                    : whilegt %w14 %w15 -> %p7.d
+25f10218 : whilegt p8.d, w16, w17                    : whilegt %w16 %w17 -> %p8.d
+25f30258 : whilegt p8.d, w18, w19                    : whilegt %w18 %w19 -> %p8.d
+25f50299 : whilegt p9.d, w20, w21                    : whilegt %w20 %w21 -> %p9.d
+25f702da : whilegt p10.d, w22, w23                   : whilegt %w22 %w23 -> %p10.d
+25f802fb : whilegt p11.d, w23, w24                   : whilegt %w23 %w24 -> %p11.d
+25fa033c : whilegt p12.d, w25, w26                   : whilegt %w25 %w26 -> %p12.d
+25fc037d : whilegt p13.d, w27, w28                   : whilegt %w27 %w28 -> %p13.d
+25fe03df : whilegt p15.d, w30, w30                   : whilegt %w30 %w30 -> %p15.d
+25e01010 : whilegt p0.d, x0, x0                      : whilegt %x0 %x0 -> %p0.d
+25e41071 : whilegt p1.d, x3, x4                      : whilegt %x3 %x4 -> %p1.d
+25e610b2 : whilegt p2.d, x5, x6                      : whilegt %x5 %x6 -> %p2.d
+25e810f3 : whilegt p3.d, x7, x8                      : whilegt %x7 %x8 -> %p3.d
+25ea1134 : whilegt p4.d, x9, x10                     : whilegt %x9 %x10 -> %p4.d
+25eb1155 : whilegt p5.d, x10, x11                    : whilegt %x10 %x11 -> %p5.d
+25ed1196 : whilegt p6.d, x12, x13                    : whilegt %x12 %x13 -> %p6.d
+25ef11d7 : whilegt p7.d, x14, x15                    : whilegt %x14 %x15 -> %p7.d
+25f11218 : whilegt p8.d, x16, x17                    : whilegt %x16 %x17 -> %p8.d
+25f31258 : whilegt p8.d, x18, x19                    : whilegt %x18 %x19 -> %p8.d
+25f51299 : whilegt p9.d, x20, x21                    : whilegt %x20 %x21 -> %p9.d
+25f712da : whilegt p10.d, x22, x23                   : whilegt %x22 %x23 -> %p10.d
+25f812fb : whilegt p11.d, x23, x24                   : whilegt %x23 %x24 -> %p11.d
+25fa133c : whilegt p12.d, x25, x26                   : whilegt %x25 %x26 -> %p12.d
+25fc137d : whilegt p13.d, x27, x28                   : whilegt %x27 %x28 -> %p13.d
+25fe13df : whilegt p15.d, x30, x30                   : whilegt %x30 %x30 -> %p15.d
+
+# WHILEHI <Pd>.<T>, <R><n>, <R><m> (WHILEHI-P.P.RR-_)
+25200810 : whilehi p0.b, w0, w0                      : whilehi %w0 %w0 -> %p0.b
+25240871 : whilehi p1.b, w3, w4                      : whilehi %w3 %w4 -> %p1.b
+252608b2 : whilehi p2.b, w5, w6                      : whilehi %w5 %w6 -> %p2.b
+252808f3 : whilehi p3.b, w7, w8                      : whilehi %w7 %w8 -> %p3.b
+252a0934 : whilehi p4.b, w9, w10                     : whilehi %w9 %w10 -> %p4.b
+252b0955 : whilehi p5.b, w10, w11                    : whilehi %w10 %w11 -> %p5.b
+252d0996 : whilehi p6.b, w12, w13                    : whilehi %w12 %w13 -> %p6.b
+252f09d7 : whilehi p7.b, w14, w15                    : whilehi %w14 %w15 -> %p7.b
+25310a18 : whilehi p8.b, w16, w17                    : whilehi %w16 %w17 -> %p8.b
+25330a58 : whilehi p8.b, w18, w19                    : whilehi %w18 %w19 -> %p8.b
+25350a99 : whilehi p9.b, w20, w21                    : whilehi %w20 %w21 -> %p9.b
+25370ada : whilehi p10.b, w22, w23                   : whilehi %w22 %w23 -> %p10.b
+25380afb : whilehi p11.b, w23, w24                   : whilehi %w23 %w24 -> %p11.b
+253a0b3c : whilehi p12.b, w25, w26                   : whilehi %w25 %w26 -> %p12.b
+253c0b7d : whilehi p13.b, w27, w28                   : whilehi %w27 %w28 -> %p13.b
+253e0bdf : whilehi p15.b, w30, w30                   : whilehi %w30 %w30 -> %p15.b
+25201810 : whilehi p0.b, x0, x0                      : whilehi %x0 %x0 -> %p0.b
+25241871 : whilehi p1.b, x3, x4                      : whilehi %x3 %x4 -> %p1.b
+252618b2 : whilehi p2.b, x5, x6                      : whilehi %x5 %x6 -> %p2.b
+252818f3 : whilehi p3.b, x7, x8                      : whilehi %x7 %x8 -> %p3.b
+252a1934 : whilehi p4.b, x9, x10                     : whilehi %x9 %x10 -> %p4.b
+252b1955 : whilehi p5.b, x10, x11                    : whilehi %x10 %x11 -> %p5.b
+252d1996 : whilehi p6.b, x12, x13                    : whilehi %x12 %x13 -> %p6.b
+252f19d7 : whilehi p7.b, x14, x15                    : whilehi %x14 %x15 -> %p7.b
+25311a18 : whilehi p8.b, x16, x17                    : whilehi %x16 %x17 -> %p8.b
+25331a58 : whilehi p8.b, x18, x19                    : whilehi %x18 %x19 -> %p8.b
+25351a99 : whilehi p9.b, x20, x21                    : whilehi %x20 %x21 -> %p9.b
+25371ada : whilehi p10.b, x22, x23                   : whilehi %x22 %x23 -> %p10.b
+25381afb : whilehi p11.b, x23, x24                   : whilehi %x23 %x24 -> %p11.b
+253a1b3c : whilehi p12.b, x25, x26                   : whilehi %x25 %x26 -> %p12.b
+253c1b7d : whilehi p13.b, x27, x28                   : whilehi %x27 %x28 -> %p13.b
+253e1bdf : whilehi p15.b, x30, x30                   : whilehi %x30 %x30 -> %p15.b
+25600810 : whilehi p0.h, w0, w0                      : whilehi %w0 %w0 -> %p0.h
+25640871 : whilehi p1.h, w3, w4                      : whilehi %w3 %w4 -> %p1.h
+256608b2 : whilehi p2.h, w5, w6                      : whilehi %w5 %w6 -> %p2.h
+256808f3 : whilehi p3.h, w7, w8                      : whilehi %w7 %w8 -> %p3.h
+256a0934 : whilehi p4.h, w9, w10                     : whilehi %w9 %w10 -> %p4.h
+256b0955 : whilehi p5.h, w10, w11                    : whilehi %w10 %w11 -> %p5.h
+256d0996 : whilehi p6.h, w12, w13                    : whilehi %w12 %w13 -> %p6.h
+256f09d7 : whilehi p7.h, w14, w15                    : whilehi %w14 %w15 -> %p7.h
+25710a18 : whilehi p8.h, w16, w17                    : whilehi %w16 %w17 -> %p8.h
+25730a58 : whilehi p8.h, w18, w19                    : whilehi %w18 %w19 -> %p8.h
+25750a99 : whilehi p9.h, w20, w21                    : whilehi %w20 %w21 -> %p9.h
+25770ada : whilehi p10.h, w22, w23                   : whilehi %w22 %w23 -> %p10.h
+25780afb : whilehi p11.h, w23, w24                   : whilehi %w23 %w24 -> %p11.h
+257a0b3c : whilehi p12.h, w25, w26                   : whilehi %w25 %w26 -> %p12.h
+257c0b7d : whilehi p13.h, w27, w28                   : whilehi %w27 %w28 -> %p13.h
+257e0bdf : whilehi p15.h, w30, w30                   : whilehi %w30 %w30 -> %p15.h
+25601810 : whilehi p0.h, x0, x0                      : whilehi %x0 %x0 -> %p0.h
+25641871 : whilehi p1.h, x3, x4                      : whilehi %x3 %x4 -> %p1.h
+256618b2 : whilehi p2.h, x5, x6                      : whilehi %x5 %x6 -> %p2.h
+256818f3 : whilehi p3.h, x7, x8                      : whilehi %x7 %x8 -> %p3.h
+256a1934 : whilehi p4.h, x9, x10                     : whilehi %x9 %x10 -> %p4.h
+256b1955 : whilehi p5.h, x10, x11                    : whilehi %x10 %x11 -> %p5.h
+256d1996 : whilehi p6.h, x12, x13                    : whilehi %x12 %x13 -> %p6.h
+256f19d7 : whilehi p7.h, x14, x15                    : whilehi %x14 %x15 -> %p7.h
+25711a18 : whilehi p8.h, x16, x17                    : whilehi %x16 %x17 -> %p8.h
+25731a58 : whilehi p8.h, x18, x19                    : whilehi %x18 %x19 -> %p8.h
+25751a99 : whilehi p9.h, x20, x21                    : whilehi %x20 %x21 -> %p9.h
+25771ada : whilehi p10.h, x22, x23                   : whilehi %x22 %x23 -> %p10.h
+25781afb : whilehi p11.h, x23, x24                   : whilehi %x23 %x24 -> %p11.h
+257a1b3c : whilehi p12.h, x25, x26                   : whilehi %x25 %x26 -> %p12.h
+257c1b7d : whilehi p13.h, x27, x28                   : whilehi %x27 %x28 -> %p13.h
+257e1bdf : whilehi p15.h, x30, x30                   : whilehi %x30 %x30 -> %p15.h
+25a00810 : whilehi p0.s, w0, w0                      : whilehi %w0 %w0 -> %p0.s
+25a40871 : whilehi p1.s, w3, w4                      : whilehi %w3 %w4 -> %p1.s
+25a608b2 : whilehi p2.s, w5, w6                      : whilehi %w5 %w6 -> %p2.s
+25a808f3 : whilehi p3.s, w7, w8                      : whilehi %w7 %w8 -> %p3.s
+25aa0934 : whilehi p4.s, w9, w10                     : whilehi %w9 %w10 -> %p4.s
+25ab0955 : whilehi p5.s, w10, w11                    : whilehi %w10 %w11 -> %p5.s
+25ad0996 : whilehi p6.s, w12, w13                    : whilehi %w12 %w13 -> %p6.s
+25af09d7 : whilehi p7.s, w14, w15                    : whilehi %w14 %w15 -> %p7.s
+25b10a18 : whilehi p8.s, w16, w17                    : whilehi %w16 %w17 -> %p8.s
+25b30a58 : whilehi p8.s, w18, w19                    : whilehi %w18 %w19 -> %p8.s
+25b50a99 : whilehi p9.s, w20, w21                    : whilehi %w20 %w21 -> %p9.s
+25b70ada : whilehi p10.s, w22, w23                   : whilehi %w22 %w23 -> %p10.s
+25b80afb : whilehi p11.s, w23, w24                   : whilehi %w23 %w24 -> %p11.s
+25ba0b3c : whilehi p12.s, w25, w26                   : whilehi %w25 %w26 -> %p12.s
+25bc0b7d : whilehi p13.s, w27, w28                   : whilehi %w27 %w28 -> %p13.s
+25be0bdf : whilehi p15.s, w30, w30                   : whilehi %w30 %w30 -> %p15.s
+25a01810 : whilehi p0.s, x0, x0                      : whilehi %x0 %x0 -> %p0.s
+25a41871 : whilehi p1.s, x3, x4                      : whilehi %x3 %x4 -> %p1.s
+25a618b2 : whilehi p2.s, x5, x6                      : whilehi %x5 %x6 -> %p2.s
+25a818f3 : whilehi p3.s, x7, x8                      : whilehi %x7 %x8 -> %p3.s
+25aa1934 : whilehi p4.s, x9, x10                     : whilehi %x9 %x10 -> %p4.s
+25ab1955 : whilehi p5.s, x10, x11                    : whilehi %x10 %x11 -> %p5.s
+25ad1996 : whilehi p6.s, x12, x13                    : whilehi %x12 %x13 -> %p6.s
+25af19d7 : whilehi p7.s, x14, x15                    : whilehi %x14 %x15 -> %p7.s
+25b11a18 : whilehi p8.s, x16, x17                    : whilehi %x16 %x17 -> %p8.s
+25b31a58 : whilehi p8.s, x18, x19                    : whilehi %x18 %x19 -> %p8.s
+25b51a99 : whilehi p9.s, x20, x21                    : whilehi %x20 %x21 -> %p9.s
+25b71ada : whilehi p10.s, x22, x23                   : whilehi %x22 %x23 -> %p10.s
+25b81afb : whilehi p11.s, x23, x24                   : whilehi %x23 %x24 -> %p11.s
+25ba1b3c : whilehi p12.s, x25, x26                   : whilehi %x25 %x26 -> %p12.s
+25bc1b7d : whilehi p13.s, x27, x28                   : whilehi %x27 %x28 -> %p13.s
+25be1bdf : whilehi p15.s, x30, x30                   : whilehi %x30 %x30 -> %p15.s
+25e00810 : whilehi p0.d, w0, w0                      : whilehi %w0 %w0 -> %p0.d
+25e40871 : whilehi p1.d, w3, w4                      : whilehi %w3 %w4 -> %p1.d
+25e608b2 : whilehi p2.d, w5, w6                      : whilehi %w5 %w6 -> %p2.d
+25e808f3 : whilehi p3.d, w7, w8                      : whilehi %w7 %w8 -> %p3.d
+25ea0934 : whilehi p4.d, w9, w10                     : whilehi %w9 %w10 -> %p4.d
+25eb0955 : whilehi p5.d, w10, w11                    : whilehi %w10 %w11 -> %p5.d
+25ed0996 : whilehi p6.d, w12, w13                    : whilehi %w12 %w13 -> %p6.d
+25ef09d7 : whilehi p7.d, w14, w15                    : whilehi %w14 %w15 -> %p7.d
+25f10a18 : whilehi p8.d, w16, w17                    : whilehi %w16 %w17 -> %p8.d
+25f30a58 : whilehi p8.d, w18, w19                    : whilehi %w18 %w19 -> %p8.d
+25f50a99 : whilehi p9.d, w20, w21                    : whilehi %w20 %w21 -> %p9.d
+25f70ada : whilehi p10.d, w22, w23                   : whilehi %w22 %w23 -> %p10.d
+25f80afb : whilehi p11.d, w23, w24                   : whilehi %w23 %w24 -> %p11.d
+25fa0b3c : whilehi p12.d, w25, w26                   : whilehi %w25 %w26 -> %p12.d
+25fc0b7d : whilehi p13.d, w27, w28                   : whilehi %w27 %w28 -> %p13.d
+25fe0bdf : whilehi p15.d, w30, w30                   : whilehi %w30 %w30 -> %p15.d
+25e01810 : whilehi p0.d, x0, x0                      : whilehi %x0 %x0 -> %p0.d
+25e41871 : whilehi p1.d, x3, x4                      : whilehi %x3 %x4 -> %p1.d
+25e618b2 : whilehi p2.d, x5, x6                      : whilehi %x5 %x6 -> %p2.d
+25e818f3 : whilehi p3.d, x7, x8                      : whilehi %x7 %x8 -> %p3.d
+25ea1934 : whilehi p4.d, x9, x10                     : whilehi %x9 %x10 -> %p4.d
+25eb1955 : whilehi p5.d, x10, x11                    : whilehi %x10 %x11 -> %p5.d
+25ed1996 : whilehi p6.d, x12, x13                    : whilehi %x12 %x13 -> %p6.d
+25ef19d7 : whilehi p7.d, x14, x15                    : whilehi %x14 %x15 -> %p7.d
+25f11a18 : whilehi p8.d, x16, x17                    : whilehi %x16 %x17 -> %p8.d
+25f31a58 : whilehi p8.d, x18, x19                    : whilehi %x18 %x19 -> %p8.d
+25f51a99 : whilehi p9.d, x20, x21                    : whilehi %x20 %x21 -> %p9.d
+25f71ada : whilehi p10.d, x22, x23                   : whilehi %x22 %x23 -> %p10.d
+25f81afb : whilehi p11.d, x23, x24                   : whilehi %x23 %x24 -> %p11.d
+25fa1b3c : whilehi p12.d, x25, x26                   : whilehi %x25 %x26 -> %p12.d
+25fc1b7d : whilehi p13.d, x27, x28                   : whilehi %x27 %x28 -> %p13.d
+25fe1bdf : whilehi p15.d, x30, x30                   : whilehi %x30 %x30 -> %p15.d
+
+# WHILEHS <Pd>.<T>, <R><n>, <R><m> (WHILEHS-P.P.RR-_)
+25200800 : whilehs p0.b, w0, w0                      : whilehs %w0 %w0 -> %p0.b
+25240861 : whilehs p1.b, w3, w4                      : whilehs %w3 %w4 -> %p1.b
+252608a2 : whilehs p2.b, w5, w6                      : whilehs %w5 %w6 -> %p2.b
+252808e3 : whilehs p3.b, w7, w8                      : whilehs %w7 %w8 -> %p3.b
+252a0924 : whilehs p4.b, w9, w10                     : whilehs %w9 %w10 -> %p4.b
+252b0945 : whilehs p5.b, w10, w11                    : whilehs %w10 %w11 -> %p5.b
+252d0986 : whilehs p6.b, w12, w13                    : whilehs %w12 %w13 -> %p6.b
+252f09c7 : whilehs p7.b, w14, w15                    : whilehs %w14 %w15 -> %p7.b
+25310a08 : whilehs p8.b, w16, w17                    : whilehs %w16 %w17 -> %p8.b
+25330a48 : whilehs p8.b, w18, w19                    : whilehs %w18 %w19 -> %p8.b
+25350a89 : whilehs p9.b, w20, w21                    : whilehs %w20 %w21 -> %p9.b
+25370aca : whilehs p10.b, w22, w23                   : whilehs %w22 %w23 -> %p10.b
+25380aeb : whilehs p11.b, w23, w24                   : whilehs %w23 %w24 -> %p11.b
+253a0b2c : whilehs p12.b, w25, w26                   : whilehs %w25 %w26 -> %p12.b
+253c0b6d : whilehs p13.b, w27, w28                   : whilehs %w27 %w28 -> %p13.b
+253e0bcf : whilehs p15.b, w30, w30                   : whilehs %w30 %w30 -> %p15.b
+25201800 : whilehs p0.b, x0, x0                      : whilehs %x0 %x0 -> %p0.b
+25241861 : whilehs p1.b, x3, x4                      : whilehs %x3 %x4 -> %p1.b
+252618a2 : whilehs p2.b, x5, x6                      : whilehs %x5 %x6 -> %p2.b
+252818e3 : whilehs p3.b, x7, x8                      : whilehs %x7 %x8 -> %p3.b
+252a1924 : whilehs p4.b, x9, x10                     : whilehs %x9 %x10 -> %p4.b
+252b1945 : whilehs p5.b, x10, x11                    : whilehs %x10 %x11 -> %p5.b
+252d1986 : whilehs p6.b, x12, x13                    : whilehs %x12 %x13 -> %p6.b
+252f19c7 : whilehs p7.b, x14, x15                    : whilehs %x14 %x15 -> %p7.b
+25311a08 : whilehs p8.b, x16, x17                    : whilehs %x16 %x17 -> %p8.b
+25331a48 : whilehs p8.b, x18, x19                    : whilehs %x18 %x19 -> %p8.b
+25351a89 : whilehs p9.b, x20, x21                    : whilehs %x20 %x21 -> %p9.b
+25371aca : whilehs p10.b, x22, x23                   : whilehs %x22 %x23 -> %p10.b
+25381aeb : whilehs p11.b, x23, x24                   : whilehs %x23 %x24 -> %p11.b
+253a1b2c : whilehs p12.b, x25, x26                   : whilehs %x25 %x26 -> %p12.b
+253c1b6d : whilehs p13.b, x27, x28                   : whilehs %x27 %x28 -> %p13.b
+253e1bcf : whilehs p15.b, x30, x30                   : whilehs %x30 %x30 -> %p15.b
+25600800 : whilehs p0.h, w0, w0                      : whilehs %w0 %w0 -> %p0.h
+25640861 : whilehs p1.h, w3, w4                      : whilehs %w3 %w4 -> %p1.h
+256608a2 : whilehs p2.h, w5, w6                      : whilehs %w5 %w6 -> %p2.h
+256808e3 : whilehs p3.h, w7, w8                      : whilehs %w7 %w8 -> %p3.h
+256a0924 : whilehs p4.h, w9, w10                     : whilehs %w9 %w10 -> %p4.h
+256b0945 : whilehs p5.h, w10, w11                    : whilehs %w10 %w11 -> %p5.h
+256d0986 : whilehs p6.h, w12, w13                    : whilehs %w12 %w13 -> %p6.h
+256f09c7 : whilehs p7.h, w14, w15                    : whilehs %w14 %w15 -> %p7.h
+25710a08 : whilehs p8.h, w16, w17                    : whilehs %w16 %w17 -> %p8.h
+25730a48 : whilehs p8.h, w18, w19                    : whilehs %w18 %w19 -> %p8.h
+25750a89 : whilehs p9.h, w20, w21                    : whilehs %w20 %w21 -> %p9.h
+25770aca : whilehs p10.h, w22, w23                   : whilehs %w22 %w23 -> %p10.h
+25780aeb : whilehs p11.h, w23, w24                   : whilehs %w23 %w24 -> %p11.h
+257a0b2c : whilehs p12.h, w25, w26                   : whilehs %w25 %w26 -> %p12.h
+257c0b6d : whilehs p13.h, w27, w28                   : whilehs %w27 %w28 -> %p13.h
+257e0bcf : whilehs p15.h, w30, w30                   : whilehs %w30 %w30 -> %p15.h
+25601800 : whilehs p0.h, x0, x0                      : whilehs %x0 %x0 -> %p0.h
+25641861 : whilehs p1.h, x3, x4                      : whilehs %x3 %x4 -> %p1.h
+256618a2 : whilehs p2.h, x5, x6                      : whilehs %x5 %x6 -> %p2.h
+256818e3 : whilehs p3.h, x7, x8                      : whilehs %x7 %x8 -> %p3.h
+256a1924 : whilehs p4.h, x9, x10                     : whilehs %x9 %x10 -> %p4.h
+256b1945 : whilehs p5.h, x10, x11                    : whilehs %x10 %x11 -> %p5.h
+256d1986 : whilehs p6.h, x12, x13                    : whilehs %x12 %x13 -> %p6.h
+256f19c7 : whilehs p7.h, x14, x15                    : whilehs %x14 %x15 -> %p7.h
+25711a08 : whilehs p8.h, x16, x17                    : whilehs %x16 %x17 -> %p8.h
+25731a48 : whilehs p8.h, x18, x19                    : whilehs %x18 %x19 -> %p8.h
+25751a89 : whilehs p9.h, x20, x21                    : whilehs %x20 %x21 -> %p9.h
+25771aca : whilehs p10.h, x22, x23                   : whilehs %x22 %x23 -> %p10.h
+25781aeb : whilehs p11.h, x23, x24                   : whilehs %x23 %x24 -> %p11.h
+257a1b2c : whilehs p12.h, x25, x26                   : whilehs %x25 %x26 -> %p12.h
+257c1b6d : whilehs p13.h, x27, x28                   : whilehs %x27 %x28 -> %p13.h
+257e1bcf : whilehs p15.h, x30, x30                   : whilehs %x30 %x30 -> %p15.h
+25a00800 : whilehs p0.s, w0, w0                      : whilehs %w0 %w0 -> %p0.s
+25a40861 : whilehs p1.s, w3, w4                      : whilehs %w3 %w4 -> %p1.s
+25a608a2 : whilehs p2.s, w5, w6                      : whilehs %w5 %w6 -> %p2.s
+25a808e3 : whilehs p3.s, w7, w8                      : whilehs %w7 %w8 -> %p3.s
+25aa0924 : whilehs p4.s, w9, w10                     : whilehs %w9 %w10 -> %p4.s
+25ab0945 : whilehs p5.s, w10, w11                    : whilehs %w10 %w11 -> %p5.s
+25ad0986 : whilehs p6.s, w12, w13                    : whilehs %w12 %w13 -> %p6.s
+25af09c7 : whilehs p7.s, w14, w15                    : whilehs %w14 %w15 -> %p7.s
+25b10a08 : whilehs p8.s, w16, w17                    : whilehs %w16 %w17 -> %p8.s
+25b30a48 : whilehs p8.s, w18, w19                    : whilehs %w18 %w19 -> %p8.s
+25b50a89 : whilehs p9.s, w20, w21                    : whilehs %w20 %w21 -> %p9.s
+25b70aca : whilehs p10.s, w22, w23                   : whilehs %w22 %w23 -> %p10.s
+25b80aeb : whilehs p11.s, w23, w24                   : whilehs %w23 %w24 -> %p11.s
+25ba0b2c : whilehs p12.s, w25, w26                   : whilehs %w25 %w26 -> %p12.s
+25bc0b6d : whilehs p13.s, w27, w28                   : whilehs %w27 %w28 -> %p13.s
+25be0bcf : whilehs p15.s, w30, w30                   : whilehs %w30 %w30 -> %p15.s
+25a01800 : whilehs p0.s, x0, x0                      : whilehs %x0 %x0 -> %p0.s
+25a41861 : whilehs p1.s, x3, x4                      : whilehs %x3 %x4 -> %p1.s
+25a618a2 : whilehs p2.s, x5, x6                      : whilehs %x5 %x6 -> %p2.s
+25a818e3 : whilehs p3.s, x7, x8                      : whilehs %x7 %x8 -> %p3.s
+25aa1924 : whilehs p4.s, x9, x10                     : whilehs %x9 %x10 -> %p4.s
+25ab1945 : whilehs p5.s, x10, x11                    : whilehs %x10 %x11 -> %p5.s
+25ad1986 : whilehs p6.s, x12, x13                    : whilehs %x12 %x13 -> %p6.s
+25af19c7 : whilehs p7.s, x14, x15                    : whilehs %x14 %x15 -> %p7.s
+25b11a08 : whilehs p8.s, x16, x17                    : whilehs %x16 %x17 -> %p8.s
+25b31a48 : whilehs p8.s, x18, x19                    : whilehs %x18 %x19 -> %p8.s
+25b51a89 : whilehs p9.s, x20, x21                    : whilehs %x20 %x21 -> %p9.s
+25b71aca : whilehs p10.s, x22, x23                   : whilehs %x22 %x23 -> %p10.s
+25b81aeb : whilehs p11.s, x23, x24                   : whilehs %x23 %x24 -> %p11.s
+25ba1b2c : whilehs p12.s, x25, x26                   : whilehs %x25 %x26 -> %p12.s
+25bc1b6d : whilehs p13.s, x27, x28                   : whilehs %x27 %x28 -> %p13.s
+25be1bcf : whilehs p15.s, x30, x30                   : whilehs %x30 %x30 -> %p15.s
+25e00800 : whilehs p0.d, w0, w0                      : whilehs %w0 %w0 -> %p0.d
+25e40861 : whilehs p1.d, w3, w4                      : whilehs %w3 %w4 -> %p1.d
+25e608a2 : whilehs p2.d, w5, w6                      : whilehs %w5 %w6 -> %p2.d
+25e808e3 : whilehs p3.d, w7, w8                      : whilehs %w7 %w8 -> %p3.d
+25ea0924 : whilehs p4.d, w9, w10                     : whilehs %w9 %w10 -> %p4.d
+25eb0945 : whilehs p5.d, w10, w11                    : whilehs %w10 %w11 -> %p5.d
+25ed0986 : whilehs p6.d, w12, w13                    : whilehs %w12 %w13 -> %p6.d
+25ef09c7 : whilehs p7.d, w14, w15                    : whilehs %w14 %w15 -> %p7.d
+25f10a08 : whilehs p8.d, w16, w17                    : whilehs %w16 %w17 -> %p8.d
+25f30a48 : whilehs p8.d, w18, w19                    : whilehs %w18 %w19 -> %p8.d
+25f50a89 : whilehs p9.d, w20, w21                    : whilehs %w20 %w21 -> %p9.d
+25f70aca : whilehs p10.d, w22, w23                   : whilehs %w22 %w23 -> %p10.d
+25f80aeb : whilehs p11.d, w23, w24                   : whilehs %w23 %w24 -> %p11.d
+25fa0b2c : whilehs p12.d, w25, w26                   : whilehs %w25 %w26 -> %p12.d
+25fc0b6d : whilehs p13.d, w27, w28                   : whilehs %w27 %w28 -> %p13.d
+25fe0bcf : whilehs p15.d, w30, w30                   : whilehs %w30 %w30 -> %p15.d
+25e01800 : whilehs p0.d, x0, x0                      : whilehs %x0 %x0 -> %p0.d
+25e41861 : whilehs p1.d, x3, x4                      : whilehs %x3 %x4 -> %p1.d
+25e618a2 : whilehs p2.d, x5, x6                      : whilehs %x5 %x6 -> %p2.d
+25e818e3 : whilehs p3.d, x7, x8                      : whilehs %x7 %x8 -> %p3.d
+25ea1924 : whilehs p4.d, x9, x10                     : whilehs %x9 %x10 -> %p4.d
+25eb1945 : whilehs p5.d, x10, x11                    : whilehs %x10 %x11 -> %p5.d
+25ed1986 : whilehs p6.d, x12, x13                    : whilehs %x12 %x13 -> %p6.d
+25ef19c7 : whilehs p7.d, x14, x15                    : whilehs %x14 %x15 -> %p7.d
+25f11a08 : whilehs p8.d, x16, x17                    : whilehs %x16 %x17 -> %p8.d
+25f31a48 : whilehs p8.d, x18, x19                    : whilehs %x18 %x19 -> %p8.d
+25f51a89 : whilehs p9.d, x20, x21                    : whilehs %x20 %x21 -> %p9.d
+25f71aca : whilehs p10.d, x22, x23                   : whilehs %x22 %x23 -> %p10.d
+25f81aeb : whilehs p11.d, x23, x24                   : whilehs %x23 %x24 -> %p11.d
+25fa1b2c : whilehs p12.d, x25, x26                   : whilehs %x25 %x26 -> %p12.d
+25fc1b6d : whilehs p13.d, x27, x28                   : whilehs %x27 %x28 -> %p13.d
+25fe1bcf : whilehs p15.d, x30, x30                   : whilehs %x30 %x30 -> %p15.d
+
+# WHILERW <Pd>.<T>, <Xn>, <Xm> (WHILERW-P.RR-_)
+25203010 : whilerw p0.b, x0, x0                      : whilerw %x0 %x0 -> %p0.b
+25243071 : whilerw p1.b, x3, x4                      : whilerw %x3 %x4 -> %p1.b
+252630b2 : whilerw p2.b, x5, x6                      : whilerw %x5 %x6 -> %p2.b
+252830f3 : whilerw p3.b, x7, x8                      : whilerw %x7 %x8 -> %p3.b
+252a3134 : whilerw p4.b, x9, x10                     : whilerw %x9 %x10 -> %p4.b
+252b3155 : whilerw p5.b, x10, x11                    : whilerw %x10 %x11 -> %p5.b
+252d3196 : whilerw p6.b, x12, x13                    : whilerw %x12 %x13 -> %p6.b
+252f31d7 : whilerw p7.b, x14, x15                    : whilerw %x14 %x15 -> %p7.b
+25313218 : whilerw p8.b, x16, x17                    : whilerw %x16 %x17 -> %p8.b
+25333258 : whilerw p8.b, x18, x19                    : whilerw %x18 %x19 -> %p8.b
+25353299 : whilerw p9.b, x20, x21                    : whilerw %x20 %x21 -> %p9.b
+253732da : whilerw p10.b, x22, x23                   : whilerw %x22 %x23 -> %p10.b
+253832fb : whilerw p11.b, x23, x24                   : whilerw %x23 %x24 -> %p11.b
+253a333c : whilerw p12.b, x25, x26                   : whilerw %x25 %x26 -> %p12.b
+253c337d : whilerw p13.b, x27, x28                   : whilerw %x27 %x28 -> %p13.b
+253e33df : whilerw p15.b, x30, x30                   : whilerw %x30 %x30 -> %p15.b
+25603010 : whilerw p0.h, x0, x0                      : whilerw %x0 %x0 -> %p0.h
+25643071 : whilerw p1.h, x3, x4                      : whilerw %x3 %x4 -> %p1.h
+256630b2 : whilerw p2.h, x5, x6                      : whilerw %x5 %x6 -> %p2.h
+256830f3 : whilerw p3.h, x7, x8                      : whilerw %x7 %x8 -> %p3.h
+256a3134 : whilerw p4.h, x9, x10                     : whilerw %x9 %x10 -> %p4.h
+256b3155 : whilerw p5.h, x10, x11                    : whilerw %x10 %x11 -> %p5.h
+256d3196 : whilerw p6.h, x12, x13                    : whilerw %x12 %x13 -> %p6.h
+256f31d7 : whilerw p7.h, x14, x15                    : whilerw %x14 %x15 -> %p7.h
+25713218 : whilerw p8.h, x16, x17                    : whilerw %x16 %x17 -> %p8.h
+25733258 : whilerw p8.h, x18, x19                    : whilerw %x18 %x19 -> %p8.h
+25753299 : whilerw p9.h, x20, x21                    : whilerw %x20 %x21 -> %p9.h
+257732da : whilerw p10.h, x22, x23                   : whilerw %x22 %x23 -> %p10.h
+257832fb : whilerw p11.h, x23, x24                   : whilerw %x23 %x24 -> %p11.h
+257a333c : whilerw p12.h, x25, x26                   : whilerw %x25 %x26 -> %p12.h
+257c337d : whilerw p13.h, x27, x28                   : whilerw %x27 %x28 -> %p13.h
+257e33df : whilerw p15.h, x30, x30                   : whilerw %x30 %x30 -> %p15.h
+25a03010 : whilerw p0.s, x0, x0                      : whilerw %x0 %x0 -> %p0.s
+25a43071 : whilerw p1.s, x3, x4                      : whilerw %x3 %x4 -> %p1.s
+25a630b2 : whilerw p2.s, x5, x6                      : whilerw %x5 %x6 -> %p2.s
+25a830f3 : whilerw p3.s, x7, x8                      : whilerw %x7 %x8 -> %p3.s
+25aa3134 : whilerw p4.s, x9, x10                     : whilerw %x9 %x10 -> %p4.s
+25ab3155 : whilerw p5.s, x10, x11                    : whilerw %x10 %x11 -> %p5.s
+25ad3196 : whilerw p6.s, x12, x13                    : whilerw %x12 %x13 -> %p6.s
+25af31d7 : whilerw p7.s, x14, x15                    : whilerw %x14 %x15 -> %p7.s
+25b13218 : whilerw p8.s, x16, x17                    : whilerw %x16 %x17 -> %p8.s
+25b33258 : whilerw p8.s, x18, x19                    : whilerw %x18 %x19 -> %p8.s
+25b53299 : whilerw p9.s, x20, x21                    : whilerw %x20 %x21 -> %p9.s
+25b732da : whilerw p10.s, x22, x23                   : whilerw %x22 %x23 -> %p10.s
+25b832fb : whilerw p11.s, x23, x24                   : whilerw %x23 %x24 -> %p11.s
+25ba333c : whilerw p12.s, x25, x26                   : whilerw %x25 %x26 -> %p12.s
+25bc337d : whilerw p13.s, x27, x28                   : whilerw %x27 %x28 -> %p13.s
+25be33df : whilerw p15.s, x30, x30                   : whilerw %x30 %x30 -> %p15.s
+25e03010 : whilerw p0.d, x0, x0                      : whilerw %x0 %x0 -> %p0.d
+25e43071 : whilerw p1.d, x3, x4                      : whilerw %x3 %x4 -> %p1.d
+25e630b2 : whilerw p2.d, x5, x6                      : whilerw %x5 %x6 -> %p2.d
+25e830f3 : whilerw p3.d, x7, x8                      : whilerw %x7 %x8 -> %p3.d
+25ea3134 : whilerw p4.d, x9, x10                     : whilerw %x9 %x10 -> %p4.d
+25eb3155 : whilerw p5.d, x10, x11                    : whilerw %x10 %x11 -> %p5.d
+25ed3196 : whilerw p6.d, x12, x13                    : whilerw %x12 %x13 -> %p6.d
+25ef31d7 : whilerw p7.d, x14, x15                    : whilerw %x14 %x15 -> %p7.d
+25f13218 : whilerw p8.d, x16, x17                    : whilerw %x16 %x17 -> %p8.d
+25f33258 : whilerw p8.d, x18, x19                    : whilerw %x18 %x19 -> %p8.d
+25f53299 : whilerw p9.d, x20, x21                    : whilerw %x20 %x21 -> %p9.d
+25f732da : whilerw p10.d, x22, x23                   : whilerw %x22 %x23 -> %p10.d
+25f832fb : whilerw p11.d, x23, x24                   : whilerw %x23 %x24 -> %p11.d
+25fa333c : whilerw p12.d, x25, x26                   : whilerw %x25 %x26 -> %p12.d
+25fc337d : whilerw p13.d, x27, x28                   : whilerw %x27 %x28 -> %p13.d
+25fe33df : whilerw p15.d, x30, x30                   : whilerw %x30 %x30 -> %p15.d
+
+# WHILEWR <Pd>.<T>, <Xn>, <Xm> (WHILEWR-P.RR-_)
+25203000 : whilewr p0.b, x0, x0                      : whilewr %x0 %x0 -> %p0.b
+25243061 : whilewr p1.b, x3, x4                      : whilewr %x3 %x4 -> %p1.b
+252630a2 : whilewr p2.b, x5, x6                      : whilewr %x5 %x6 -> %p2.b
+252830e3 : whilewr p3.b, x7, x8                      : whilewr %x7 %x8 -> %p3.b
+252a3124 : whilewr p4.b, x9, x10                     : whilewr %x9 %x10 -> %p4.b
+252b3145 : whilewr p5.b, x10, x11                    : whilewr %x10 %x11 -> %p5.b
+252d3186 : whilewr p6.b, x12, x13                    : whilewr %x12 %x13 -> %p6.b
+252f31c7 : whilewr p7.b, x14, x15                    : whilewr %x14 %x15 -> %p7.b
+25313208 : whilewr p8.b, x16, x17                    : whilewr %x16 %x17 -> %p8.b
+25333248 : whilewr p8.b, x18, x19                    : whilewr %x18 %x19 -> %p8.b
+25353289 : whilewr p9.b, x20, x21                    : whilewr %x20 %x21 -> %p9.b
+253732ca : whilewr p10.b, x22, x23                   : whilewr %x22 %x23 -> %p10.b
+253832eb : whilewr p11.b, x23, x24                   : whilewr %x23 %x24 -> %p11.b
+253a332c : whilewr p12.b, x25, x26                   : whilewr %x25 %x26 -> %p12.b
+253c336d : whilewr p13.b, x27, x28                   : whilewr %x27 %x28 -> %p13.b
+253e33cf : whilewr p15.b, x30, x30                   : whilewr %x30 %x30 -> %p15.b
+25603000 : whilewr p0.h, x0, x0                      : whilewr %x0 %x0 -> %p0.h
+25643061 : whilewr p1.h, x3, x4                      : whilewr %x3 %x4 -> %p1.h
+256630a2 : whilewr p2.h, x5, x6                      : whilewr %x5 %x6 -> %p2.h
+256830e3 : whilewr p3.h, x7, x8                      : whilewr %x7 %x8 -> %p3.h
+256a3124 : whilewr p4.h, x9, x10                     : whilewr %x9 %x10 -> %p4.h
+256b3145 : whilewr p5.h, x10, x11                    : whilewr %x10 %x11 -> %p5.h
+256d3186 : whilewr p6.h, x12, x13                    : whilewr %x12 %x13 -> %p6.h
+256f31c7 : whilewr p7.h, x14, x15                    : whilewr %x14 %x15 -> %p7.h
+25713208 : whilewr p8.h, x16, x17                    : whilewr %x16 %x17 -> %p8.h
+25733248 : whilewr p8.h, x18, x19                    : whilewr %x18 %x19 -> %p8.h
+25753289 : whilewr p9.h, x20, x21                    : whilewr %x20 %x21 -> %p9.h
+257732ca : whilewr p10.h, x22, x23                   : whilewr %x22 %x23 -> %p10.h
+257832eb : whilewr p11.h, x23, x24                   : whilewr %x23 %x24 -> %p11.h
+257a332c : whilewr p12.h, x25, x26                   : whilewr %x25 %x26 -> %p12.h
+257c336d : whilewr p13.h, x27, x28                   : whilewr %x27 %x28 -> %p13.h
+257e33cf : whilewr p15.h, x30, x30                   : whilewr %x30 %x30 -> %p15.h
+25a03000 : whilewr p0.s, x0, x0                      : whilewr %x0 %x0 -> %p0.s
+25a43061 : whilewr p1.s, x3, x4                      : whilewr %x3 %x4 -> %p1.s
+25a630a2 : whilewr p2.s, x5, x6                      : whilewr %x5 %x6 -> %p2.s
+25a830e3 : whilewr p3.s, x7, x8                      : whilewr %x7 %x8 -> %p3.s
+25aa3124 : whilewr p4.s, x9, x10                     : whilewr %x9 %x10 -> %p4.s
+25ab3145 : whilewr p5.s, x10, x11                    : whilewr %x10 %x11 -> %p5.s
+25ad3186 : whilewr p6.s, x12, x13                    : whilewr %x12 %x13 -> %p6.s
+25af31c7 : whilewr p7.s, x14, x15                    : whilewr %x14 %x15 -> %p7.s
+25b13208 : whilewr p8.s, x16, x17                    : whilewr %x16 %x17 -> %p8.s
+25b33248 : whilewr p8.s, x18, x19                    : whilewr %x18 %x19 -> %p8.s
+25b53289 : whilewr p9.s, x20, x21                    : whilewr %x20 %x21 -> %p9.s
+25b732ca : whilewr p10.s, x22, x23                   : whilewr %x22 %x23 -> %p10.s
+25b832eb : whilewr p11.s, x23, x24                   : whilewr %x23 %x24 -> %p11.s
+25ba332c : whilewr p12.s, x25, x26                   : whilewr %x25 %x26 -> %p12.s
+25bc336d : whilewr p13.s, x27, x28                   : whilewr %x27 %x28 -> %p13.s
+25be33cf : whilewr p15.s, x30, x30                   : whilewr %x30 %x30 -> %p15.s
+25e03000 : whilewr p0.d, x0, x0                      : whilewr %x0 %x0 -> %p0.d
+25e43061 : whilewr p1.d, x3, x4                      : whilewr %x3 %x4 -> %p1.d
+25e630a2 : whilewr p2.d, x5, x6                      : whilewr %x5 %x6 -> %p2.d
+25e830e3 : whilewr p3.d, x7, x8                      : whilewr %x7 %x8 -> %p3.d
+25ea3124 : whilewr p4.d, x9, x10                     : whilewr %x9 %x10 -> %p4.d
+25eb3145 : whilewr p5.d, x10, x11                    : whilewr %x10 %x11 -> %p5.d
+25ed3186 : whilewr p6.d, x12, x13                    : whilewr %x12 %x13 -> %p6.d
+25ef31c7 : whilewr p7.d, x14, x15                    : whilewr %x14 %x15 -> %p7.d
+25f13208 : whilewr p8.d, x16, x17                    : whilewr %x16 %x17 -> %p8.d
+25f33248 : whilewr p8.d, x18, x19                    : whilewr %x18 %x19 -> %p8.d
+25f53289 : whilewr p9.d, x20, x21                    : whilewr %x20 %x21 -> %p9.d
+25f732ca : whilewr p10.d, x22, x23                   : whilewr %x22 %x23 -> %p10.d
+25f832eb : whilewr p11.d, x23, x24                   : whilewr %x23 %x24 -> %p11.d
+25fa332c : whilewr p12.d, x25, x26                   : whilewr %x25 %x26 -> %p12.d
+25fc336d : whilewr p13.d, x27, x28                   : whilewr %x27 %x28 -> %p13.d
+25fe33cf : whilewr p15.d, x30, x30                   : whilewr %x30 %x30 -> %p15.d
 
 # XAR     <Zdn>.<T>, <Zdn>.<T>, <Zm>.<T>, #<const> (XAR-Z.ZZI-_)
 042f3400 : xar z0.b, z0.b, z0.b, #0x1                : xar    %z0.b %z0.b $0x01 -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve2.c
+++ b/suite/tests/api/ir_aarch64_sve2.c
@@ -7886,6 +7886,479 @@ TEST_INSTR(sqrdcmlah_sve_idx_imm_vector)
               opnd_create_immed_uint(rot_1_0[i], OPSZ_2));
 }
 
+TEST_INSTR(match_sve_pred)
+{
+
+    /* Testing MATCH   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "match  %p0/z %z0.b %z0.b -> %p0.b",    "match  %p2/z %z7.b %z8.b -> %p2.b",
+        "match  %p3/z %z12.b %z13.b -> %p5.b",  "match  %p5/z %z18.b %z19.b -> %p8.b",
+        "match  %p6/z %z23.b %z24.b -> %p10.b", "match  %p7/z %z31.b %z31.b -> %p15.b",
+    };
+    TEST_LOOP(match, match_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "match  %p0/z %z0.h %z0.h -> %p0.h",    "match  %p2/z %z7.h %z8.h -> %p2.h",
+        "match  %p3/z %z12.h %z13.h -> %p5.h",  "match  %p5/z %z18.h %z19.h -> %p8.h",
+        "match  %p6/z %z23.h %z24.h -> %p10.h", "match  %p7/z %z31.h %z31.h -> %p15.h",
+    };
+    TEST_LOOP(match, match_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
+}
+
+TEST_INSTR(nmatch_sve_pred)
+{
+
+    /* Testing NMATCH  <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts> */
+    const char *const expected_0_0[6] = {
+        "nmatch %p0/z %z0.b %z0.b -> %p0.b",    "nmatch %p2/z %z7.b %z8.b -> %p2.b",
+        "nmatch %p3/z %z12.b %z13.b -> %p5.b",  "nmatch %p5/z %z18.b %z19.b -> %p8.b",
+        "nmatch %p6/z %z23.b %z24.b -> %p10.b", "nmatch %p7/z %z31.b %z31.b -> %p15.b",
+    };
+    TEST_LOOP(nmatch, nmatch_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_1),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_1));
+
+    const char *const expected_0_1[6] = {
+        "nmatch %p0/z %z0.h %z0.h -> %p0.h",    "nmatch %p2/z %z7.h %z8.h -> %p2.h",
+        "nmatch %p3/z %z12.h %z13.h -> %p5.h",  "nmatch %p5/z %z18.h %z19.h -> %p8.h",
+        "nmatch %p6/z %z23.h %z24.h -> %p10.h", "nmatch %p7/z %z31.h %z31.h -> %p15.h",
+    };
+    TEST_LOOP(nmatch, nmatch_sve_pred, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_2),
+              opnd_create_reg_element_vector(Zn_six_offset_3[i], OPSZ_2));
+}
+
+TEST_INSTR(urecpe_sve_pred)
+{
+
+    /* Testing URECPE  <Zd>.S, <Pg>/M, <Zn>.S */
+    const char *const expected_0_0[6] = {
+        "urecpe %p0/m %z0.s -> %z0.s",   "urecpe %p2/m %z7.s -> %z5.s",
+        "urecpe %p3/m %z12.s -> %z10.s", "urecpe %p5/m %z18.s -> %z16.s",
+        "urecpe %p6/m %z23.s -> %z21.s", "urecpe %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(urecpe, urecpe_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+}
+
+TEST_INSTR(ursqrte_sve_pred)
+{
+
+    /* Testing URSQRTE <Zd>.S, <Pg>/M, <Zn>.S */
+    const char *const expected_0_0[6] = {
+        "ursqrte %p0/m %z0.s -> %z0.s",   "ursqrte %p2/m %z7.s -> %z5.s",
+        "ursqrte %p3/m %z12.s -> %z10.s", "ursqrte %p5/m %z18.s -> %z16.s",
+        "ursqrte %p6/m %z23.s -> %z21.s", "ursqrte %p7/m %z31.s -> %z31.s",
+    };
+    TEST_LOOP(ursqrte, ursqrte_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], true),
+              opnd_create_reg_element_vector(Zn_six_offset_2[i], OPSZ_4));
+}
+
+TEST_INSTR(whilege_sve)
+{
+
+    /* Testing WHILEGE <Pd>.<Ts>, <R><n>, <R><m> */
+    const char *const expected_0_0[6] = {
+        "whilege %w0 %w0 -> %p0.b",    "whilege %w6 %w7 -> %p2.b",
+        "whilege %w11 %w12 -> %p5.b",  "whilege %w16 %w17 -> %p8.b",
+        "whilege %w21 %w22 -> %p10.b", "whilege %w30 %w30 -> %p15.b",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_1[6] = {
+        "whilege %x0 %x0 -> %p0.b",    "whilege %x6 %x7 -> %p2.b",
+        "whilege %x11 %x12 -> %p5.b",  "whilege %x16 %x17 -> %p8.b",
+        "whilege %x21 %x22 -> %p10.b", "whilege %x30 %x30 -> %p15.b",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_2[6] = {
+        "whilege %w0 %w0 -> %p0.h",    "whilege %w6 %w7 -> %p2.h",
+        "whilege %w11 %w12 -> %p5.h",  "whilege %w16 %w17 -> %p8.h",
+        "whilege %w21 %w22 -> %p10.h", "whilege %w30 %w30 -> %p15.h",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_3[6] = {
+        "whilege %x0 %x0 -> %p0.h",    "whilege %x6 %x7 -> %p2.h",
+        "whilege %x11 %x12 -> %p5.h",  "whilege %x16 %x17 -> %p8.h",
+        "whilege %x21 %x22 -> %p10.h", "whilege %x30 %x30 -> %p15.h",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_4[6] = {
+        "whilege %w0 %w0 -> %p0.s",    "whilege %w6 %w7 -> %p2.s",
+        "whilege %w11 %w12 -> %p5.s",  "whilege %w16 %w17 -> %p8.s",
+        "whilege %w21 %w22 -> %p10.s", "whilege %w30 %w30 -> %p15.s",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_4[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_5[6] = {
+        "whilege %x0 %x0 -> %p0.s",    "whilege %x6 %x7 -> %p2.s",
+        "whilege %x11 %x12 -> %p5.s",  "whilege %x16 %x17 -> %p8.s",
+        "whilege %x21 %x22 -> %p10.s", "whilege %x30 %x30 -> %p15.s",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_5[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_6[6] = {
+        "whilege %w0 %w0 -> %p0.d",    "whilege %w6 %w7 -> %p2.d",
+        "whilege %w11 %w12 -> %p5.d",  "whilege %w16 %w17 -> %p8.d",
+        "whilege %w21 %w22 -> %p10.d", "whilege %w30 %w30 -> %p15.d",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_6[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_7[6] = {
+        "whilege %x0 %x0 -> %p0.d",    "whilege %x6 %x7 -> %p2.d",
+        "whilege %x11 %x12 -> %p5.d",  "whilege %x16 %x17 -> %p8.d",
+        "whilege %x21 %x22 -> %p10.d", "whilege %x30 %x30 -> %p15.d",
+    };
+    TEST_LOOP(whilege, whilege_sve, 6, expected_0_7[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+}
+
+TEST_INSTR(whilegt_sve)
+{
+
+    /* Testing WHILEGT <Pd>.<Ts>, <R><n>, <R><m> */
+    const char *const expected_0_0[6] = {
+        "whilegt %w0 %w0 -> %p0.b",    "whilegt %w6 %w7 -> %p2.b",
+        "whilegt %w11 %w12 -> %p5.b",  "whilegt %w16 %w17 -> %p8.b",
+        "whilegt %w21 %w22 -> %p10.b", "whilegt %w30 %w30 -> %p15.b",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_1[6] = {
+        "whilegt %x0 %x0 -> %p0.b",    "whilegt %x6 %x7 -> %p2.b",
+        "whilegt %x11 %x12 -> %p5.b",  "whilegt %x16 %x17 -> %p8.b",
+        "whilegt %x21 %x22 -> %p10.b", "whilegt %x30 %x30 -> %p15.b",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_2[6] = {
+        "whilegt %w0 %w0 -> %p0.h",    "whilegt %w6 %w7 -> %p2.h",
+        "whilegt %w11 %w12 -> %p5.h",  "whilegt %w16 %w17 -> %p8.h",
+        "whilegt %w21 %w22 -> %p10.h", "whilegt %w30 %w30 -> %p15.h",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_3[6] = {
+        "whilegt %x0 %x0 -> %p0.h",    "whilegt %x6 %x7 -> %p2.h",
+        "whilegt %x11 %x12 -> %p5.h",  "whilegt %x16 %x17 -> %p8.h",
+        "whilegt %x21 %x22 -> %p10.h", "whilegt %x30 %x30 -> %p15.h",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_4[6] = {
+        "whilegt %w0 %w0 -> %p0.s",    "whilegt %w6 %w7 -> %p2.s",
+        "whilegt %w11 %w12 -> %p5.s",  "whilegt %w16 %w17 -> %p8.s",
+        "whilegt %w21 %w22 -> %p10.s", "whilegt %w30 %w30 -> %p15.s",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_4[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_5[6] = {
+        "whilegt %x0 %x0 -> %p0.s",    "whilegt %x6 %x7 -> %p2.s",
+        "whilegt %x11 %x12 -> %p5.s",  "whilegt %x16 %x17 -> %p8.s",
+        "whilegt %x21 %x22 -> %p10.s", "whilegt %x30 %x30 -> %p15.s",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_5[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_6[6] = {
+        "whilegt %w0 %w0 -> %p0.d",    "whilegt %w6 %w7 -> %p2.d",
+        "whilegt %w11 %w12 -> %p5.d",  "whilegt %w16 %w17 -> %p8.d",
+        "whilegt %w21 %w22 -> %p10.d", "whilegt %w30 %w30 -> %p15.d",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_6[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_7[6] = {
+        "whilegt %x0 %x0 -> %p0.d",    "whilegt %x6 %x7 -> %p2.d",
+        "whilegt %x11 %x12 -> %p5.d",  "whilegt %x16 %x17 -> %p8.d",
+        "whilegt %x21 %x22 -> %p10.d", "whilegt %x30 %x30 -> %p15.d",
+    };
+    TEST_LOOP(whilegt, whilegt_sve, 6, expected_0_7[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+}
+
+TEST_INSTR(whilehi_sve)
+{
+
+    /* Testing WHILEHI <Pd>.<Ts>, <R><n>, <R><m> */
+    const char *const expected_0_0[6] = {
+        "whilehi %w0 %w0 -> %p0.b",    "whilehi %w6 %w7 -> %p2.b",
+        "whilehi %w11 %w12 -> %p5.b",  "whilehi %w16 %w17 -> %p8.b",
+        "whilehi %w21 %w22 -> %p10.b", "whilehi %w30 %w30 -> %p15.b",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_1[6] = {
+        "whilehi %x0 %x0 -> %p0.b",    "whilehi %x6 %x7 -> %p2.b",
+        "whilehi %x11 %x12 -> %p5.b",  "whilehi %x16 %x17 -> %p8.b",
+        "whilehi %x21 %x22 -> %p10.b", "whilehi %x30 %x30 -> %p15.b",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_2[6] = {
+        "whilehi %w0 %w0 -> %p0.h",    "whilehi %w6 %w7 -> %p2.h",
+        "whilehi %w11 %w12 -> %p5.h",  "whilehi %w16 %w17 -> %p8.h",
+        "whilehi %w21 %w22 -> %p10.h", "whilehi %w30 %w30 -> %p15.h",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_3[6] = {
+        "whilehi %x0 %x0 -> %p0.h",    "whilehi %x6 %x7 -> %p2.h",
+        "whilehi %x11 %x12 -> %p5.h",  "whilehi %x16 %x17 -> %p8.h",
+        "whilehi %x21 %x22 -> %p10.h", "whilehi %x30 %x30 -> %p15.h",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_4[6] = {
+        "whilehi %w0 %w0 -> %p0.s",    "whilehi %w6 %w7 -> %p2.s",
+        "whilehi %w11 %w12 -> %p5.s",  "whilehi %w16 %w17 -> %p8.s",
+        "whilehi %w21 %w22 -> %p10.s", "whilehi %w30 %w30 -> %p15.s",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_4[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_5[6] = {
+        "whilehi %x0 %x0 -> %p0.s",    "whilehi %x6 %x7 -> %p2.s",
+        "whilehi %x11 %x12 -> %p5.s",  "whilehi %x16 %x17 -> %p8.s",
+        "whilehi %x21 %x22 -> %p10.s", "whilehi %x30 %x30 -> %p15.s",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_5[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_6[6] = {
+        "whilehi %w0 %w0 -> %p0.d",    "whilehi %w6 %w7 -> %p2.d",
+        "whilehi %w11 %w12 -> %p5.d",  "whilehi %w16 %w17 -> %p8.d",
+        "whilehi %w21 %w22 -> %p10.d", "whilehi %w30 %w30 -> %p15.d",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_6[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_7[6] = {
+        "whilehi %x0 %x0 -> %p0.d",    "whilehi %x6 %x7 -> %p2.d",
+        "whilehi %x11 %x12 -> %p5.d",  "whilehi %x16 %x17 -> %p8.d",
+        "whilehi %x21 %x22 -> %p10.d", "whilehi %x30 %x30 -> %p15.d",
+    };
+    TEST_LOOP(whilehi, whilehi_sve, 6, expected_0_7[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+}
+
+TEST_INSTR(whilehs_sve)
+{
+
+    /* Testing WHILEHS <Pd>.<Ts>, <R><n>, <R><m> */
+    const char *const expected_0_0[6] = {
+        "whilehs %w0 %w0 -> %p0.b",    "whilehs %w6 %w7 -> %p2.b",
+        "whilehs %w11 %w12 -> %p5.b",  "whilehs %w16 %w17 -> %p8.b",
+        "whilehs %w21 %w22 -> %p10.b", "whilehs %w30 %w30 -> %p15.b",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_1[6] = {
+        "whilehs %x0 %x0 -> %p0.b",    "whilehs %x6 %x7 -> %p2.b",
+        "whilehs %x11 %x12 -> %p5.b",  "whilehs %x16 %x17 -> %p8.b",
+        "whilehs %x21 %x22 -> %p10.b", "whilehs %x30 %x30 -> %p15.b",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_2[6] = {
+        "whilehs %w0 %w0 -> %p0.h",    "whilehs %w6 %w7 -> %p2.h",
+        "whilehs %w11 %w12 -> %p5.h",  "whilehs %w16 %w17 -> %p8.h",
+        "whilehs %w21 %w22 -> %p10.h", "whilehs %w30 %w30 -> %p15.h",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_3[6] = {
+        "whilehs %x0 %x0 -> %p0.h",    "whilehs %x6 %x7 -> %p2.h",
+        "whilehs %x11 %x12 -> %p5.h",  "whilehs %x16 %x17 -> %p8.h",
+        "whilehs %x21 %x22 -> %p10.h", "whilehs %x30 %x30 -> %p15.h",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_4[6] = {
+        "whilehs %w0 %w0 -> %p0.s",    "whilehs %w6 %w7 -> %p2.s",
+        "whilehs %w11 %w12 -> %p5.s",  "whilehs %w16 %w17 -> %p8.s",
+        "whilehs %w21 %w22 -> %p10.s", "whilehs %w30 %w30 -> %p15.s",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_4[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_5[6] = {
+        "whilehs %x0 %x0 -> %p0.s",    "whilehs %x6 %x7 -> %p2.s",
+        "whilehs %x11 %x12 -> %p5.s",  "whilehs %x16 %x17 -> %p8.s",
+        "whilehs %x21 %x22 -> %p10.s", "whilehs %x30 %x30 -> %p15.s",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_5[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_6[6] = {
+        "whilehs %w0 %w0 -> %p0.d",    "whilehs %w6 %w7 -> %p2.d",
+        "whilehs %w11 %w12 -> %p5.d",  "whilehs %w16 %w17 -> %p8.d",
+        "whilehs %w21 %w22 -> %p10.d", "whilehs %w30 %w30 -> %p15.d",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_6[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Wn_six_offset_1[i]), opnd_create_reg(Wn_six_offset_2[i]));
+
+    const char *const expected_0_7[6] = {
+        "whilehs %x0 %x0 -> %p0.d",    "whilehs %x6 %x7 -> %p2.d",
+        "whilehs %x11 %x12 -> %p5.d",  "whilehs %x16 %x17 -> %p8.d",
+        "whilehs %x21 %x22 -> %p10.d", "whilehs %x30 %x30 -> %p15.d",
+    };
+    TEST_LOOP(whilehs, whilehs_sve, 6, expected_0_7[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+}
+
+TEST_INSTR(whilerw_sve)
+{
+
+    /* Testing WHILERW <Pd>.<Ts>, <Xn>, <Xm> */
+    const char *const expected_0_0[6] = {
+        "whilerw %x0 %x0 -> %p0.b",    "whilerw %x6 %x7 -> %p2.b",
+        "whilerw %x11 %x12 -> %p5.b",  "whilerw %x16 %x17 -> %p8.b",
+        "whilerw %x21 %x22 -> %p10.b", "whilerw %x30 %x30 -> %p15.b",
+    };
+    TEST_LOOP(whilerw, whilerw_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_1[6] = {
+        "whilerw %x0 %x0 -> %p0.h",    "whilerw %x6 %x7 -> %p2.h",
+        "whilerw %x11 %x12 -> %p5.h",  "whilerw %x16 %x17 -> %p8.h",
+        "whilerw %x21 %x22 -> %p10.h", "whilerw %x30 %x30 -> %p15.h",
+    };
+    TEST_LOOP(whilerw, whilerw_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_2[6] = {
+        "whilerw %x0 %x0 -> %p0.s",    "whilerw %x6 %x7 -> %p2.s",
+        "whilerw %x11 %x12 -> %p5.s",  "whilerw %x16 %x17 -> %p8.s",
+        "whilerw %x21 %x22 -> %p10.s", "whilerw %x30 %x30 -> %p15.s",
+    };
+    TEST_LOOP(whilerw, whilerw_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_3[6] = {
+        "whilerw %x0 %x0 -> %p0.d",    "whilerw %x6 %x7 -> %p2.d",
+        "whilerw %x11 %x12 -> %p5.d",  "whilerw %x16 %x17 -> %p8.d",
+        "whilerw %x21 %x22 -> %p10.d", "whilerw %x30 %x30 -> %p15.d",
+    };
+    TEST_LOOP(whilerw, whilerw_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+}
+
+TEST_INSTR(whilewr_sve)
+{
+
+    /* Testing WHILEWR <Pd>.<Ts>, <Xn>, <Xm> */
+    const char *const expected_0_0[6] = {
+        "whilewr %x0 %x0 -> %p0.b",    "whilewr %x6 %x7 -> %p2.b",
+        "whilewr %x11 %x12 -> %p5.b",  "whilewr %x16 %x17 -> %p8.b",
+        "whilewr %x21 %x22 -> %p10.b", "whilewr %x30 %x30 -> %p15.b",
+    };
+    TEST_LOOP(whilewr, whilewr_sve, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_1[6] = {
+        "whilewr %x0 %x0 -> %p0.h",    "whilewr %x6 %x7 -> %p2.h",
+        "whilewr %x11 %x12 -> %p5.h",  "whilewr %x16 %x17 -> %p8.h",
+        "whilewr %x21 %x22 -> %p10.h", "whilewr %x30 %x30 -> %p15.h",
+    };
+    TEST_LOOP(whilewr, whilewr_sve, 6, expected_0_1[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_2[6] = {
+        "whilewr %x0 %x0 -> %p0.s",    "whilewr %x6 %x7 -> %p2.s",
+        "whilewr %x11 %x12 -> %p5.s",  "whilewr %x16 %x17 -> %p8.s",
+        "whilewr %x21 %x22 -> %p10.s", "whilewr %x30 %x30 -> %p15.s",
+    };
+    TEST_LOOP(whilewr, whilewr_sve, 6, expected_0_2[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+
+    const char *const expected_0_3[6] = {
+        "whilewr %x0 %x0 -> %p0.d",    "whilewr %x6 %x7 -> %p2.d",
+        "whilewr %x11 %x12 -> %p5.d",  "whilewr %x16 %x17 -> %p8.d",
+        "whilewr %x21 %x22 -> %p10.d", "whilewr %x30 %x30 -> %p15.d",
+    };
+    TEST_LOOP(whilewr, whilewr_sve, 6, expected_0_3[i],
+              opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
+}
 int
 main(int argc, char *argv[])
 {
@@ -8116,6 +8589,17 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(cdot_sve_idx_imm_vector);
     RUN_INSTR_TEST(cmla_sve_idx_imm_vector);
     RUN_INSTR_TEST(sqrdcmlah_sve_idx_imm_vector);
+
+    RUN_INSTR_TEST(match_sve_pred);
+    RUN_INSTR_TEST(nmatch_sve_pred);
+    RUN_INSTR_TEST(urecpe_sve_pred);
+    RUN_INSTR_TEST(ursqrte_sve_pred);
+    RUN_INSTR_TEST(whilege_sve);
+    RUN_INSTR_TEST(whilegt_sve);
+    RUN_INSTR_TEST(whilehi_sve);
+    RUN_INSTR_TEST(whilehs_sve);
+    RUN_INSTR_TEST(whilerw_sve);
+    RUN_INSTR_TEST(whilewr_sve);
 
     print("All SVE2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode and decode the following variants:
```
MATCH   <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
NMATCH  <Pd>.<Ts>, <Pg>/Z, <Zn>.<Ts>, <Zm>.<Ts>
URECPE  <Zd>.S, <Pg>/M, <Zn>.S
URSQRTE <Zd>.S, <Pg>/M, <Zn>.S
WHILEGE <Pd>.<Ts>, <R><n>, <R><m>
WHILEGT <Pd>.<Ts>, <R><n>, <R><m>
WHILEHI <Pd>.<Ts>, <R><n>, <R><m>
WHILEHS <Pd>.<Ts>, <R><n>, <R><m>
WHILERW <Pd>.<Ts>, <Xn>, <Xm>
WHILEWR <Pd>.<Ts>, <Xn>, <Xm>
```
issue: #3044