### PR TITLE
Fix build with GCC 13.1 and Doxygen 1.9.7

### DIFF
--- a/api/docs/API.doxy
+++ b/api/docs/API.doxy
@@ -239,7 +239,6 @@ DOT_IMAGE_FORMAT       = png
 DOT_PATH               =
 DOTFILE_DIRS           =
 MAX_DOT_GRAPH_DEPTH    = 1000
-DOT_TRANSPARENT        = NO
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES

--- a/clients/drcachesim/tests/burst_replaceall.cpp
+++ b/clients/drcachesim/tests/burst_replaceall.cpp
@@ -46,6 +46,7 @@
 #include <assert.h>
 #include <iostream>
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <set>


### PR DESCRIPTION
Adds missing include for `stdint.h` in one file that relies on `math.h`, which breaks with GCC 13.1.

Also, removes a redundant default-value assignment for DOT_TRANSPARENT, which is deprecated
and would abort in the newest Doxygen.