### PR TITLE
i#4343 namespaces: Shrink Doxygen qualifications where possible

### DIFF
--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -51,8 +51,8 @@
  * tools on the full stream of memory reference records.
  */
 
-namespace dynamorio {
-namespace drmemtrace {
+namespace dynamorio {  /**< General DynamoRIO namespace. */
+namespace drmemtrace { /**< DrMemtrace tracing + simulation infrastructure namespace. */
 
 /**
  * This is an interface for obtaining information from analysis tools
@@ -65,7 +65,7 @@ public:
     {
     }
     /**
-     * Returns the count of #dynamorio::drmemtrace::memref_t records from the start of the
+     * Returns the count of #memref_t records from the start of the
      * trace to this point. This includes records skipped over and not presented to any
      * tool. It does not include synthetic records (see is_record_synthetic()).
      */
@@ -88,37 +88,37 @@ public:
 
     /**
      * Returns the value of the most recently seen
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
+     * #TRACE_MARKER_TYPE_TIMESTAMP marker.
      */
     virtual uint64_t
     get_last_timestamp() const = 0;
 
     /**
      * Returns the value of the first seen
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
+     * #TRACE_MARKER_TYPE_TIMESTAMP marker.
      */
     virtual uint64_t
     get_first_timestamp() const = 0;
 
     /**
-     * Returns the #dynamorio::drmemtrace::trace_version_t value from the
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION record in the trace header.
+     * Returns the #trace_version_t value from the
+     * #TRACE_MARKER_TYPE_VERSION record in the trace header.
      */
     virtual uint64_t
     get_version() const = 0;
 
     /**
      * Returns the OFFLINE_FILE_TYPE_* bitfields of type
-     * #dynamorio::drmemtrace::offline_file_type_t identifying the architecture and other
+     * #offline_file_type_t identifying the architecture and other
      * key high-level attributes of the trace from the
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE record in the trace header.
+     * #TRACE_MARKER_TYPE_FILETYPE record in the trace header.
      */
     virtual uint64_t
     get_filetype() const = 0;
 
     /**
      * Returns the cache line size from the
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CACHE_LINE_SIZE record in the trace
+     * #TRACE_MARKER_TYPE_CACHE_LINE_SIZE record in the trace
      * header.
      */
     virtual uint64_t
@@ -126,14 +126,14 @@ public:
 
     /**
      * Returns the chunk instruction count from the
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT record in the trace
+     * #TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT record in the trace
      * header.
      */
     virtual uint64_t
     get_chunk_instr_count() const = 0;
 
     /**
-     * Returns the page size from the #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PAGE_SIZE
+     * Returns the page size from the #TRACE_MARKER_TYPE_PAGE_SIZE
      * record in the trace header.
      */
     virtual uint64_t

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -44,7 +44,6 @@ using ::dynamorio::droption::bytesize_t;
 using ::dynamorio::droption::DROPTION_FLAG_ACCUMULATE;
 using ::dynamorio::droption::DROPTION_FLAG_INTERNAL;
 using ::dynamorio::droption::DROPTION_FLAG_SWEEP;
-using ::dynamorio::droption::droption_parser_t;
 using ::dynamorio::droption::DROPTION_SCOPE_ALL;
 using ::dynamorio::droption::DROPTION_SCOPE_CLIENT;
 using ::dynamorio::droption::DROPTION_SCOPE_FRONTEND;

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -51,40 +51,40 @@
  * @brief DrMemtrace trace entry enum types and definitions.
  */
 
-namespace dynamorio {
-namespace drmemtrace {
+namespace dynamorio {  /**< General DynamoRIO namespace. */
+namespace drmemtrace { /**< DrMemtrace tracing + simulation infrastructure namespace. */
 
 typedef uintptr_t addr_t; /**< The type of a memory address. */
 
 /**
  * The version number of the trace format.
  * This is presented to analysis tools as a marker of type
- * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION.
+ * #TRACE_MARKER_TYPE_VERSION.
  */
 typedef enum {
     /**
-     * A prior version where #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT
+     * A prior version where #TRACE_MARKER_TYPE_KERNEL_EVENT
      * provided the module offset (and nothing for restartable sequence aborts) rather
      * than the absolute PC of the interruption point provided today.
      */
     TRACE_ENTRY_VERSION_NO_KERNEL_PC = 2,
     /**
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT records provide the absolute
+     * #TRACE_MARKER_TYPE_KERNEL_EVENT records provide the absolute
      * PC of the interruption point.
      */
     TRACE_ENTRY_VERSION_KERNEL_PC = 3,
     /**
      * The trace supports embedded instruction encodings, but they are only present
-     * if #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_ENCODINGS is set.
+     * if #OFFLINE_FILE_TYPE_ENCODINGS is set.
      */
     TRACE_ENTRY_VERSION_ENCODINGS = 4,
     /** The latest version of the trace format. */
     TRACE_ENTRY_VERSION = TRACE_ENTRY_VERSION_ENCODINGS,
 } trace_version_t;
 
-/** The type of a trace entry in a #dynamorio::drmemtrace::memref_t structure. */
+/** The type of a trace entry in a #memref_t structure. */
 // The type identifier for trace entries in the raw trace_entry_t passed to
-// reader_t and the exposed #dynamorio::drmemtrace::memref_t passed to analysis tools.
+// reader_t and the exposed #memref_t passed to analysis tools.
 // XXX: if we want to rely on a recent C++ standard we could try to get
 // this enum to be just 2 bytes instead of an int and give it qualified names.
 // N.B.: when adding new values, be sure to update trace_type_names[].
@@ -181,7 +181,7 @@ typedef enum {
 
     /**
      * A marker containing metadata about this point in the trace.
-     * It includes a marker sub-type #dynamorio::drmemtrace::trace_marker_type_t and a
+     * It includes a marker sub-type #trace_marker_type_t and a
      * value.
      */
     TRACE_TYPE_MARKER,
@@ -245,12 +245,12 @@ typedef enum {
      * The value of this marker contains the program counter at the kernel
      * interruption point.  If the interruption point is just after a branch, this
      * value is the target of that branch.
-     * (For trace version #dynamorio::drmemtrace::TRACE_ENTRY_VERSION_NO_KERNEL_PC or
+     * (For trace version #TRACE_ENTRY_VERSION_NO_KERNEL_PC or
      * below, the value is the module offset rather than the absolute program counter.)
      * The value is 0 for some types where this information is not available, namely
      * Windows callbacks.
      * A restartable sequence abort handler is further identified by a prior
-     * marker of type #dynamorio::drmemtrace::TRACE_MARKER_TYPE_RSEQ_ABORT.
+     * marker of type #TRACE_MARKER_TYPE_RSEQ_ABORT.
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT,
     /**
@@ -283,9 +283,9 @@ typedef enum {
      * the drmemtrace_get_funclist_path() function's documentation.
      *
      * This marker is also used to record parameter values for certain system calls such
-     * as for #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS.  These use
+     * as for #OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS.  These use
      * large identifiers equal to
-     * #dynamorio::drmemtrace::func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system
+     * #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system
      * call number (for 32-bit marker values just the bottom 16 bits of the system call
      * number are added to the base).  These identifiers are not stored in the function
      * list file (drmemtrace_get_funclist_path()).  The system call number used is the
@@ -299,14 +299,14 @@ typedef enum {
     /**
      * The marker value contains the return address of the just-entered
      * function, whose id is specified by the closest previous
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID marker entry.
+     * #TRACE_MARKER_TYPE_FUNC_ID marker entry.
      */
     TRACE_MARKER_TYPE_FUNC_RETADDR,
 
     /**
      * The marker value contains one argument value of the just-entered
      * function, whose id is specified by the closest previous
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID marker entry. The number of such
+     * #TRACE_MARKER_TYPE_FUNC_ID marker entry. The number of such
      * entries for one function invocation is equal to the specified argument in
      * -record_function (or pre-defined functions in -record_heap_value if
      * -record_heap is specified).
@@ -316,10 +316,10 @@ typedef enum {
     /**
      * The marker value contains the return value of the just-entered function,
      * whose id is specified by the closest previous
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID marker entry
+     * #TRACE_MARKER_TYPE_FUNC_ID marker entry
      *
      * The marker value for system calls (see
-     * #dynamorio::drmemtrace::func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) is either 0
+     * #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) is either 0
      * (failure) or 1 (success), as obtained from dr_syscall_get_result_ex() via the
      * "succeeded" field of #dr_syscall_result_info_t.  See the corresponding
      * documentation for caveats about the accuracy of this value.
@@ -337,7 +337,7 @@ typedef enum {
 
     /**
      * The marker value contains the OFFLINE_FILE_TYPE_* bitfields of type
-     * #dynamorio::drmemtrace::offline_file_type_t identifying the architecture and other
+     * #offline_file_type_t identifying the architecture and other
      * key high-level attributes of the trace.
      */
     TRACE_MARKER_TYPE_FILETYPE,
@@ -357,15 +357,15 @@ typedef enum {
 
     /**
      * The marker value contains the version of the trace format: a value
-     * of type #dynamorio::drmemtrace::trace_version_t.  The marker is present in the
+     * of type #trace_version_t.  The marker is present in the
      * first few entries of a trace file.
      */
     TRACE_MARKER_TYPE_VERSION,
 
     /**
-     * Serves to further identify #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT
+     * Serves to further identify #TRACE_MARKER_TYPE_KERNEL_EVENT
      * as a restartable sequence abort handler.  This will always be immediately followed
-     * by #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT.  The marker value for a
+     * by #TRACE_MARKER_TYPE_KERNEL_EVENT.  The marker value for a
      * signal that interrupted the instrumented execution is the precise interrupted PC,
      * but for all other cases the value holds the continuation program counter, which is
      * the restartable sequence abort handler.  (The precise interrupted point inside the
@@ -383,13 +383,13 @@ typedef enum {
 
     /**
      * The marker value contains the physical address corresponding to the subsequent
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS's virtual address.  A
+     * #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS's virtual address.  A
      * pair of such markers will appear somewhere prior to a regular instruction fetch or
      * data load or store whose page's physical address has not yet been reported, or when
      * a physical mapping change is detected.  If translation failed, a
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be
+     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be
      * present instead, without a corresponding
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
+     * #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
      */
     TRACE_MARKER_TYPE_PHYSICAL_ADDRESS,
 
@@ -401,13 +401,13 @@ typedef enum {
 
     /**
      * The marker value contains the virtual address corresponding to the prior
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS's physical address.  A
+     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS's physical address.  A
      * pair of such markers will appear somewhere prior to a regular instruction fetch or
      * data load or store whose page's physical address has not yet been reported, or when
      * a physical mapping change is detected.  If translation failed, a
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be
+     * #TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE will be
      * present instead, without a corresponding
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
+     * #TRACE_MARKER_TYPE_VIRTUAL_ADDRESS.
      */
     TRACE_MARKER_TYPE_VIRTUAL_ADDRESS,
 
@@ -435,7 +435,7 @@ typedef enum {
 
     /**
      * Marks the end of a chunk.  The final chunk does not have such a marker
-     * but instead relies on the #dynamorio::drmemtrace::TRACE_TYPE_FOOTER entry.
+     * but instead relies on the #TRACE_TYPE_FOOTER entry.
      */
     TRACE_MARKER_TYPE_CHUNK_FOOTER,
 
@@ -468,7 +468,7 @@ typedef enum {
      * This marker is emitted prior to each system call invocation, after the
      * instruction fetch entry for the system call gateway instruction from user mode. The
      * marker value contains the system call number.  If these markers are present, the
-     * file type #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_SYSCALL_NUMBERS is set.
+     * file type #OFFLINE_FILE_TYPE_SYSCALL_NUMBERS is set.
      */
     TRACE_MARKER_TYPE_SYSCALL,
 
@@ -481,7 +481,7 @@ typedef enum {
      * only for now).
      *
      * If these markers are present, the
-     * file type #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS is set.  The
+     * file type #OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS is set.  The
      * marker value is 0.
      */
     TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL,
@@ -507,12 +507,11 @@ typedef enum {
 enum class func_trace_t : uint64_t { // VS2019 won't infer 64-bit with "enum {".
 /**
  * When system call parameter and return values are provided, they use the function
- * tracing markers #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID,
- * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, and
- * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL.  The identifier used for
- * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID is equal to this base value plus the
- * 32-bit system call number for 64-bit marker values or this base value plus the lower 16
- * bits of the system call number for 32-bit marker values.
+ * tracing markers #TRACE_MARKER_TYPE_FUNC_ID, #TRACE_MARKER_TYPE_FUNC_ARG, and
+ * #TRACE_MARKER_TYPE_FUNC_RETVAL.  The identifier used for #TRACE_MARKER_TYPE_FUNC_ID is
+ * equal to this base value plus the 32-bit system call number for 64-bit marker values
+ * or this base value plus the lower 16 bits of the system call number for 32-bit marker
+ * values.
  */
 #ifdef X64
     TRACE_FUNC_ID_SYSCALL_BASE = 0x100000000ULL,
@@ -609,7 +608,7 @@ marker_type_is_function_marker(const trace_marker_type_t mark)
  * This is the data format generated by the online tracer and produced after
  * post-processing of raw offline traces.
  * The #dynamorio::drmemtrace::reader_t class transforms this into
- * #dynamorio::drmemtrace::memref_t before handing to analysis tools. Each trace entry is
+ * #memref_t before handing to analysis tools. Each trace entry is
  * a <type, size, addr> tuple representing:
  * - a memory reference
  * - an instr fetch
@@ -716,14 +715,13 @@ typedef enum {
  * offline final trace and a raw not-yet-postprocessed trace, as well as
  * (despite the OFFLINE_ prefix) an online trace.
  * In a final trace these are stored in a marker of type
- * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE.
+ * #TRACE_MARKER_TYPE_FILETYPE.
  */
 typedef enum {
     OFFLINE_FILE_TYPE_DEFAULT = 0x00,
     /**
      * DEPRECATED: Addresses filtered online. Newer trace files use
-     * #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_IFILTERED and
-     * #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_DFILTERED.
+     * #OFFLINE_FILE_TYPE_IFILTERED and #OFFLINE_FILE_TYPE_DFILTERED.
      */
     OFFLINE_FILE_TYPE_FILTERED = 0x01,
     OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS = 0x02,
@@ -738,21 +736,20 @@ typedef enum {
     OFFLINE_FILE_TYPE_IFILTERED = 0x80,  /**< Instruction addresses filtered online. */
     OFFLINE_FILE_TYPE_DFILTERED = 0x100, /**< Data addresses filtered online. */
     OFFLINE_FILE_TYPE_ENCODINGS = 0x200, /**< Instruction encodings are included. */
-    /** System call number markers (#dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL) are
+    /** System call number markers (#TRACE_MARKER_TYPE_SYSCALL) are
        included. */
     OFFLINE_FILE_TYPE_SYSCALL_NUMBERS = 0x400,
     /**
      * Kernel scheduling information is included:
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL markers and system
-     * call parameters and return values for kernel locks (SYS_futex on Linux) using the
-     * function tracing markers #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID,
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, and
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL with an identifier equal to
-     * #dynamorio::drmemtrace::func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system
-     * call number (or its bottom 16 bits for 32-bit marker values).  These identifiers
-     * are not stored in the function list file (drmemtrace_get_funclist_path()).
+     * #TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL markers and system call parameters and
+     * return values for kernel locks (SYS_futex on Linux) using the function tracing
+     * markers #TRACE_MARKER_TYPE_FUNC_ID, #TRACE_MARKER_TYPE_FUNC_ARG, and
+     * #TRACE_MARKER_TYPE_FUNC_RETVAL with an identifier equal to
+     * #func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE plus the system call number (or its
+     * bottom 16 bits for 32-bit marker values).  These identifiers are not stored in the
+     * function list file (drmemtrace_get_funclist_path()).
      *
-     * The #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL for system calls is
+     * The #TRACE_MARKER_TYPE_FUNC_RETVAL for system calls is
      * either 0 (failure) or 1 (success).
      */
     OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS = 0x800,

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -59,8 +59,8 @@
 #include "speculator.h"
 #include "utils.h"
 
-namespace dynamorio {
-namespace drmemtrace {
+namespace dynamorio {  /**< General DynamoRIO namespace. */
+namespace drmemtrace { /**< DrMemtrace tracing + simulation infrastructure namespace. */
 
 /**
  * Schedules traced software threads onto simulated cpus.
@@ -100,12 +100,10 @@ public:
          * For dynamic scheduling with cross-stream dependencies, the scheduler may pause
          * a stream if it gets ahead of another stream it should have a dependence on.
          * This value is also used for schedules following the recorded timestamps
-         * (#dynamorio::drmemtrace::scheduler_tmpl_t::DEPENDENCY_TIMESTAMPS) to
-         * avoid one stream getting ahead of another.  For replaying a schedule
-         * as it was traced with
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::MAP_TO_RECORDED_OUTPUT
-         * this can indicate an idle period on a core where the traced workload was
-         * not currently scheduled.
+         * (#DEPENDENCY_TIMESTAMPS) to avoid one stream getting ahead of another.  For
+         * replaying a schedule as it was traced with #MAP_TO_RECORDED_OUTPUT this can
+         * indicate an idle period on a core where the traced workload was not currently
+         * scheduled.
          */
         STATUS_WAIT,
         STATUS_INVALID,         /**< Error condition. */
@@ -186,14 +184,13 @@ public:
         /**
          * Relative priority for scheduling.  The default is 0.  Higher values have
          * higher priorities and will starve lower-priority inputs.
-         * Higher priorities out-weigh dependencies such as
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::DEPENDENCY_TIMESTAMPS.
+         * Higher priorities out-weigh dependencies such as #DEPENDENCY_TIMESTAMPS.
          */
         int priority = 0;
         /**
          * If non-empty, all input records outside of these ranges are skipped: it is as
          * though the input were constructed by concatenating these ranges together.  A
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
+         * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
          * ranges (with a value equal to the range ordinal) to notify the client of the
          * discontinuity (but not before the first range).  These ranges must be
          * non-overlapping and in increasing order.
@@ -301,7 +298,7 @@ public:
         /**
          * Each input stream is mapped to a single output stream (i.e., no input will
          * appear on more than one output), supporting lock-free parallel analysis when
-         * combined with #dynamorio::drmemtrace::scheduler_tmpl_t::DEPENDENCY_IGNORE.
+         * combined with #DEPENDENCY_IGNORE.
          */
         MAP_TO_CONSISTENT_OUTPUT,
         // TODO i#5843: Currently it is up to the user to figure out the original core
@@ -315,7 +312,7 @@ public:
          * number (considered to correspond to output stream ordinal) an input is
          * scheduled into.  This requires an output stream count equal to the number of
          * cores occupied by the input stream set.  When combined with
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::DEPENDENCY_TIMESTAMPS, this will
+         * #DEPENDENCY_TIMESTAMPS, this will
          * precisely replay the recorded schedule; for this mode,
          * #dynamorio::drmemtrace::scheduler_tmpl_t::
          * scheduler_options_t.replay_as_traced_istream
@@ -351,14 +348,11 @@ public:
         DEPENDENCY_IGNORE,
         /**
          * Ensures timestamps in the inputs arrive at the outputs in timestamp order.
-         * For
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::MAP_TO_ANY_OUTPUT, enforcing
-         * asked-for context switch rates is more important that honoring precise
-         * trace-buffer-based timestamp inter-input dependencies: thus, timestamp
-         * ordering will be followed at context switch points for picking the next
-         * input, but timestamps will not preempt an input.  To precisely follow
-         * the recorded timestamps, use
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::MAP_TO_RECORDED_OUTPUT.
+         * For #MAP_TO_ANY_OUTPUT, enforcing asked-for context switch rates is more
+         * important that honoring precise trace-buffer-based timestamp inter-input
+         * dependencies: thus, timestamp ordering will be followed at context switch
+         * points for picking the next input, but timestamps will not preempt an input.
+         * To precisely follow the recorded timestamps, use #MAP_TO_RECORDED_OUTPUT.
          */
         DEPENDENCY_TIMESTAMPS,
         // TODO i#5843: Add inferred data dependencies.
@@ -405,8 +399,7 @@ public:
         // whether to request SCHEDULER_USE_INPUT_ORDINALS.
         /**
          * If there is just one input and just one output stream, this sets
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULER_USE_INPUT_ORDINALS;
-         * otherwise, it has no effect.
+         * #SCHEDULER_USE_INPUT_ORDINALS; otherwise, it has no effect.
          */
         SCHEDULER_USE_SINGLE_INPUT_ORDINALS = 0x8,
         // TODO i#5843: Add more speculation flags for other strategies.
@@ -461,17 +454,15 @@ public:
         archive_ostream_t *schedule_record_ostream = nullptr;
         /**
          * Input stream for replaying a previously recorded schedule when
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::MAP_AS_PREVIOUSLY is specified.  If
-         * this is non-nullptr and MAP_AS_PREVIOUSLY is specified, schedule_record_ostream
-         * must be nullptr, and most other fields in this struct controlling scheduling
-         * are ignored.
+         * #MAP_AS_PREVIOUSLY is specified.  If this is non-nullptr and
+         * #MAP_AS_PREVIOUSLY is specified, schedule_record_ostream must be nullptr, and
+         * most other fields in this struct controlling scheduling are ignored.
          */
         archive_istream_t *schedule_replay_istream = nullptr;
         /**
-         * Input stream for replaying the traced schedule when
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::MAP_TO_RECORDED_OUTPUT is specified
-         * for more than one output stream (whose count must match the number of
-         * traced cores).
+         * Input stream for replaying the traced schedule when #MAP_TO_RECORDED_OUTPUT is
+         * specified for more than one output stream (whose count must match the number
+         * of traced cores).
          */
         archive_istream_t *replay_as_traced_istream = nullptr;
     };
@@ -536,10 +527,8 @@ public:
         next_record(RecordType &record);
 
         /**
-         * Reports the current time to the scheduler.  This is unitless: it just
-         * needs to be called regularly and consistently.
-         * This is used for
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::QUANTUM_TIME.
+         * Reports the current time to the scheduler.  This is unitless: it just needs to
+         * be called regularly and consistently.  This is used for #QUANTUM_TIME.
          */
         virtual stream_status_t
         report_time(uint64_t cur_time);
@@ -566,8 +555,7 @@ public:
          * start_speculation() call was made, either repeating the current record at that
          * time (if "true" was passed for "queue_current_record" to start_speculation())
          * or continuing on the subsequent record (if "false" was passed).  Returns
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::STATUS_INVALID if there was no
-         * prior start_speculation() call.
+         * #STATUS_INVALID if there was no prior start_speculation() call.
          */
         virtual stream_status_t
         stop_speculation();
@@ -575,21 +563,20 @@ public:
         // memtrace_stream_t interface:
 
         /**
-         * Returns the count of #dynamorio::drmemtrace::memref_t records from the start of
+         * Returns the count of #memref_t records from the start of
          * the trace to this point. It does not include synthetic records (see
          * is_record_synthetic()).
          *
-         * If
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULER_USE_INPUT_ORDINALS
-         * is set, then this value matches the record ordinal for the current input stream
-         * (and thus might decrease or not change across records if the input changed).
-         * Otherwise, if multiple input streams fed into this output stream, this
-         * includes the records from all those streams that were presented here: thus,
-         * this may be larger than what the current input stream reports (see
-         * get_input_stream_interface() and get_input_stream_ordinal()).  This does not
-         * advance across skipped records in an input stream from a region of interest
-         * (see #dynamorio::drmemtrace::scheduler_tmpl_t::range_t), but it does advance if
-         * the output stream skipped ahead.
+         * If #SCHEDULER_USE_INPUT_ORDINALS is set, then this value matches the record
+         * ordinal for the current input stream (and thus might decrease or not change
+         * across records if the input changed).  Otherwise, if multiple input streams
+         * fed into this output stream, this includes the records from all those streams
+         * that were presented here: thus, this may be larger than what the current input
+         * stream reports (see get_input_stream_interface() and
+         * get_input_stream_ordinal()).  This does not advance across skipped records in
+         * an input stream from a region of interest (see
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::range_t), but it does advance if the
+         * output stream skipped ahead.
          */
         uint64_t
         get_record_ordinal() const override
@@ -601,17 +588,16 @@ public:
         }
         /**
          * Returns the count of instructions from the start of the trace to this point.
-         * If
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::SCHEDULER_USE_INPUT_ORDINALS
-         * is set, then this value matches the instruction ordinal for the current input
-         * stream (and thus might decrease or not change across records if the input
-         * changed). Otherwise, if multiple input streams fed into this output stream,
-         * this includes the records from all those streams that were presented here:
-         * thus, this may be larger than what the current input stream reports (see
-         * get_input_stream_interface() and get_input_stream_ordinal()).  This does not
-         * advance across skipped records in an input stream from a region of interest
-         * (see #dynamorio::drmemtrace::scheduler_tmpl_t::range_t), but it does advance if
-         * the output stream skipped ahead.
+         * If #SCHEDULER_USE_INPUT_ORDINALS is set, then this value matches the
+         * instruction ordinal for the current input stream (and thus might decrease or
+         * not change across records if the input changed). Otherwise, if multiple input
+         * streams fed into this output stream, this includes the records from all those
+         * streams that were presented here: thus, this may be larger than what the
+         * current input stream reports (see get_input_stream_interface() and
+         * get_input_stream_ordinal()).  This does not advance across skipped records in
+         * an input stream from a region of interest (see
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::range_t), but it does advance if the
+         * output stream skipped ahead.
          */
         uint64_t
         get_instruction_ordinal() const override
@@ -640,8 +626,8 @@ public:
             return scheduler_->get_input_ordinal(ordinal_);
         }
         /**
-         * Returns the value of the most recently seen
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
+         * Returns the value of the most recently seen #TRACE_MARKER_TYPE_TIMESTAMP
+         * marker.
          */
         uint64_t
         get_last_timestamp() const override
@@ -652,8 +638,7 @@ public:
             return last_timestamp_;
         }
         /**
-         * Returns the value of the first seen
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP marker.
+         * Returns the value of the first seen #TRACE_MARKER_TYPE_TIMESTAMP marker.
          */
         uint64_t
         get_first_timestamp() const override
@@ -664,8 +649,8 @@ public:
             return first_timestamp_;
         }
         /**
-         * Returns the #dynamorio::drmemtrace::trace_version_t value from the
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION record in the trace header.
+         * Returns the #trace_version_t value from the
+         * #TRACE_MARKER_TYPE_VERSION record in the trace header.
          */
         uint64_t
         get_version() const override
@@ -674,9 +659,9 @@ public:
         }
         /**
          * Returns the OFFLINE_FILE_TYPE_* bitfields of type
-         * #dynamorio::drmemtrace::offline_file_type_t identifying the architecture and
+         * #offline_file_type_t identifying the architecture and
          * other key high-level attributes of the trace from the
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE record in the trace header.
+         * #TRACE_MARKER_TYPE_FILETYPE record in the trace header.
          */
         uint64_t
         get_filetype() const override
@@ -685,7 +670,7 @@ public:
         }
         /**
          * Returns the cache line size from the
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CACHE_LINE_SIZE record in the trace
+         * #TRACE_MARKER_TYPE_CACHE_LINE_SIZE record in the trace
          * header.
          */
         uint64_t
@@ -695,7 +680,7 @@ public:
         }
         /**
          * Returns the chunk instruction count from the
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT record in the trace
+         * #TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT record in the trace
          * header.
          */
         uint64_t
@@ -705,7 +690,7 @@ public:
         }
         /**
          * Returns the page size from the
-         * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_PAGE_SIZE record in the trace header.
+         * #TRACE_MARKER_TYPE_PAGE_SIZE record in the trace header.
          */
         uint64_t
         get_page_size() const override


### PR DESCRIPTION
By adding Doxygen docs to namespace declarations we can shrink many of
the awkwardly long references in Doxygen comments.  Some still produce
errors if not qualified which I do not understand so those are left.
I only updated a couple of key headers which contained the worst
instances.

Fixes a clang-tidy-found unused using declaration.

This completes the namespace cleanup.

Fixes #4343
