### PR TITLE
i#6196: fix UBSAN-reported issue in opnd_type_ok

### DIFF
--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -1285,15 +1285,6 @@ opnd_type_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, opn
     }
     case TYPE_O:
         return ((opnd_is_abs_addr(opnd) ||
-#ifdef X64
-                 /* We'll take a relative address that rip-rel won't reach:
-                  * after all, OPND_CREATE_ABSMEM() makes a rip-rel.
-                  */
-                 (opnd_is_rel_addr(opnd) &&
-                  (!REL32_REACHABLE(di->final_pc + MAX_INSTR_LENGTH,
-                                    (byte *)opnd_get_addr(opnd)) ||
-                   !REL32_REACHABLE(di->final_pc + 4, (byte *)opnd_get_addr(opnd)))) ||
-#endif
                  (!X64_MODE(di) && opnd_is_mem_instr(opnd))) &&
                 size_ok(di, opnd_get_size(opnd), opsize, false /*!addr*/));
     case TYPE_X:

--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -1284,8 +1284,7 @@ opnd_type_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, opn
         return (opnd_is_far_pc(opnd) || opnd_is_far_instr(opnd));
     }
     case TYPE_O:
-        return ((opnd_is_abs_addr(opnd) ||
-                 (!X64_MODE(di) && opnd_is_mem_instr(opnd))) &&
+        return ((opnd_is_abs_addr(opnd) || (!X64_MODE(di) && opnd_is_mem_instr(opnd))) &&
                 size_ok(di, opnd_get_size(opnd), opsize, false /*!addr*/));
     case TYPE_X:
         /* this means the memory address DS:(RE)(E)SI */


### PR DESCRIPTION
di->final_pc is NULL (not initialized) when called from encoding_possible(). So the reachability check does not really work and it's not necessary to determine possible encodings.
Adding something to a NULL pointer is also an UB as detected by UBSAN. So remove the reachability check in opnd_type_ok() for TYPE_O.

Fixes: #6196