### PR TITLE
drcachesim: add cache name and parameter accessors.

### DIFF
--- a/clients/drcachesim/simulator/cache.h
+++ b/clients/drcachesim/simulator/cache.h
@@ -45,6 +45,10 @@ namespace drmemtrace {
 
 class cache_t : public caching_device_t {
 public:
+    explicit cache_t(const std::string &name = "cache")
+        : caching_device_t(name)
+    {
+    }
     // Size, line size and associativity are generally used
     // to describe a CPU cache.
     // The id is an index into the snoop filter's array of caches for coherent caches.

--- a/clients/drcachesim/simulator/cache_fifo.h
+++ b/clients/drcachesim/simulator/cache_fifo.h
@@ -43,12 +43,22 @@ namespace drmemtrace {
 
 class cache_fifo_t : public cache_t {
 public:
+    explicit cache_fifo_t(const std::string &name = "cache_fifo")
+        : cache_t(name)
+    {
+    }
     bool
     init(int associativity, int line_size, int total_size, caching_device_t *parent,
          caching_device_stats_t *stats, prefetcher_t *prefetcher = nullptr,
          bool inclusive = false, bool coherent_cache = false, int id_ = -1,
          snoop_filter_t *snoop_filter_ = nullptr,
          const std::vector<caching_device_t *> &children = {}) override;
+
+    std::string
+    get_replace_policy() const override
+    {
+        return "FIFO";
+    }
 
 protected:
     void

--- a/clients/drcachesim/simulator/cache_lru.h
+++ b/clients/drcachesim/simulator/cache_lru.h
@@ -43,12 +43,21 @@ namespace drmemtrace {
 
 class cache_lru_t : public cache_t {
 public:
+    explicit cache_lru_t(const std::string &name = "cache_lru")
+        : cache_t(name)
+    {
+    }
     bool
     init(int associativity, int line_size, int total_size, caching_device_t *parent,
          caching_device_stats_t *stats, prefetcher_t *prefetcher = nullptr,
          bool inclusive = false, bool coherent_cache = false, int id_ = -1,
          snoop_filter_t *snoop_filter_ = nullptr,
          const std::vector<caching_device_t *> &children = {}) override;
+    std::string
+    get_replace_policy() const override
+    {
+        return "LRU";
+    }
 
 protected:
     void

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -578,15 +578,15 @@ cache_simulator_t::print_results()
         print_core(i);
         if (thread_ever_counts_[i] > 0) {
             if (l1_icaches_[i] != l1_dcaches_[i]) {
-                std::cerr << "  " << l1_icaches_[i]->get_name()
-                          << " stats: " << l1_icaches_[i]->get_description() << std::endl;
+                std::cerr << "  " << l1_icaches_[i]->get_name() << " ("
+                          << l1_icaches_[i]->get_description() << ") stats:" << std::endl;
                 l1_icaches_[i]->get_stats()->print_stats("    ");
-                std::cerr << "  " << l1_dcaches_[i]->get_name()
-                          << " stats: " << l1_dcaches_[i]->get_description() << std::endl;
+                std::cerr << "  " << l1_dcaches_[i]->get_name() << " ("
+                          << l1_dcaches_[i]->get_description() << ") stats:" << std::endl;
                 l1_dcaches_[i]->get_stats()->print_stats("    ");
             } else {
-                std::cerr << "  unified " << l1_icaches_[i]->get_name()
-                          << " stats: " << l1_icaches_[i]->get_description() << std::endl;
+                std::cerr << "  unified " << l1_icaches_[i]->get_name() << " ("
+                          << l1_icaches_[i]->get_description() << ") stats:" << std::endl;
                 l1_icaches_[i]->get_stats()->print_stats("    ");
             }
         }
@@ -594,15 +594,15 @@ cache_simulator_t::print_results()
 
     // Print non-L1, non-LLC cache stats.
     for (auto &caches_it : other_caches_) {
-        std::cerr << caches_it.first << " stats: " << caches_it.second->get_description()
-                  << std::endl;
+        std::cerr << caches_it.first << " (" << caches_it.second->get_description()
+                  << ") stats:" << std::endl;
         caches_it.second->get_stats()->print_stats("    ");
     }
 
     // Print LLC stats.
     for (auto &caches_it : llcaches_) {
-        std::cerr << caches_it.first << " stats: " << caches_it.second->get_description()
-                  << std::endl;
+        std::cerr << caches_it.first << " (" << caches_it.second->get_description()
+                  << ") stats:" << std::endl;
         caches_it.second->get_stats()->print_stats("    ");
     }
 

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -93,7 +93,7 @@ public:
 protected:
     // Create a cache_t object with a specific replacement policy.
     virtual cache_t *
-    create_cache(const std::string &policy);
+    create_cache(const std::string &name, const std::string &policy);
 
     cache_simulator_knobs_t knobs_;
 

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -37,6 +37,7 @@
 #define _CACHING_DEVICE_H_ 1
 
 #include <functional>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -60,7 +61,7 @@ class snoop_filter_t;
 
 class caching_device_t {
 public:
-    caching_device_t();
+    explicit caching_device_t(const std::string &name = "caching_device");
     virtual bool
     init(int associativity, int block_size, int num_blocks, caching_device_t *parent,
          caching_device_stats_t *stats, prefetcher_t *prefetcher = nullptr,
@@ -88,6 +89,9 @@ public:
     set_stats(caching_device_stats_t *stats)
     {
         stats_ = stats;
+        if (stats != nullptr) {
+            stats->set_caching_device(this);
+        }
     }
     prefetcher_t *
     get_prefetcher() const
@@ -125,6 +129,51 @@ public:
         int block_idx = compute_block_idx(tag);
         return block_idx;
     }
+
+    // Accessors for cache parameters.
+    virtual int
+    get_associativity() const
+    {
+        return associativity_;
+    }
+    virtual int
+    get_block_size() const
+    {
+        return block_size_;
+    }
+    virtual int
+    get_num_blocks() const
+    {
+        return num_blocks_;
+    }
+    virtual bool
+    is_inclusive() const
+    {
+        return inclusive_;
+    }
+    virtual bool
+    is_coherent() const
+    {
+        return coherent_cache_;
+    }
+    virtual int
+    get_size_bytes() const
+    {
+        return num_blocks_ * block_size_;
+    }
+    virtual std::string
+    get_replace_policy() const
+    {
+        return "LFU";
+    }
+    virtual const std::string &
+    get_name() const
+    {
+        return name_;
+    }
+    // Return a one-line string describing the cache configuration.
+    virtual std::string
+    get_description() const;
 
 protected:
     virtual void
@@ -226,6 +275,9 @@ protected:
                        std::function<unsigned long(addr_t)>>
         tag2block;
     bool use_tag2block_table_ = false;
+
+    // Name for this cache.
+    const std::string name_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -56,6 +56,7 @@ caching_device_stats_t::caching_device_stats_t(const std::string &miss_file,
     , is_coherent_(is_coherent)
     , access_count_(block_size)
     , file_(nullptr)
+    , caching_device_(nullptr)
 {
     if (miss_file.empty()) {
         dump_misses_ = false;

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -152,6 +152,8 @@ private:
     int block_size_;
 };
 
+class caching_device_t;
+
 class caching_device_stats_t {
 public:
     explicit caching_device_stats_t(const std::string &miss_file, int block_size,
@@ -175,7 +177,8 @@ public:
     virtual void
     reset();
 
-    virtual bool operator!()
+    virtual bool
+    operator!()
     {
         return !success_;
     }
@@ -193,6 +196,21 @@ public:
             ERRMSG("Wrong metric name.\n");
             return 0;
         }
+    }
+
+    // Returns the address of the caching device last linked to this stats
+    // object.  It is up to the user to ensure the caching device still exists
+    // before dereferencing this pointer.
+    caching_device_t *
+    get_caching_device() const
+    {
+        return caching_device_;
+    }
+
+    void
+    set_caching_device(caching_device_t *caching_device)
+    {
+        caching_device_ = caching_device;
     }
 
 protected:
@@ -246,6 +264,9 @@ protected:
 #else
     FILE *file_;
 #endif
+
+    // Convenience pointer to the caching_device last linked to this stats object.
+    caching_device_t *caching_device_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tests/allasm-aarch64-cache.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-cache.templatex
@@ -2,13 +2,13 @@ All done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                 *          8[,.]?246
     Misses:                              2
     Compulsory misses:                   *[0-9,\.]*
     Invalidations:        *              0
     Miss rate:                        0[.,]02%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                 *          2[,.]?030
     Misses:                             16
     Compulsory misses:                  *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                                0
     Misses:                             18
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/allasm-aarch64-cache.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-cache.templatex
@@ -2,13 +2,13 @@ All done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                 *          8[,.]?246
     Misses:                              2
     Compulsory misses:                   *[0-9,\.]*
     Invalidations:        *              0
     Miss rate:                        0[.,]02%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                 *          2[,.]?030
     Misses:                             16
     Compulsory misses:                  *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                                0
     Misses:                             18
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/allasm-arm.templatex
+++ b/clients/drcachesim/tests/allasm-arm.templatex
@@ -8,7 +8,7 @@ All done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                              [45][90][0-9]
     Misses:                              [5-9]
     Compulsory misses:                   *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
     Prefetch hits:                       1
     Prefetch misses:                     1
     Miss rate:                        [01][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                               1[0-9]
     Misses:                              [1-9]
     Compulsory misses:                   *[0-9,\.]*
@@ -28,7 +28,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                                1
     Misses:                             [ 1][0-9]
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/allasm-arm.templatex
+++ b/clients/drcachesim/tests/allasm-arm.templatex
@@ -8,7 +8,7 @@ All done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                              [45][90][0-9]
     Misses:                              [5-9]
     Compulsory misses:                   *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
     Prefetch hits:                       1
     Prefetch misses:                     1
     Miss rate:                        [01][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                               1[0-9]
     Misses:                              [1-9]
     Compulsory misses:                   *[0-9,\.]*
@@ -28,7 +28,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                                1
     Misses:                             [ 1][0-9]
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/allasm-thumb.templatex
+++ b/clients/drcachesim/tests/allasm-thumb.templatex
@@ -8,13 +8,13 @@ All done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                              6[34].
     Misses:                             11
     Compulsory misses:                  *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                        1[,\.]69%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                               3[0-9]
     Misses:                             *[0-9]*
     Compulsory misses:                  *[0-9,\.]*
@@ -25,7 +25,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                                3
     Misses:                             1[0-9]
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/allasm-thumb.templatex
+++ b/clients/drcachesim/tests/allasm-thumb.templatex
@@ -8,13 +8,13 @@ All done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                              6[34].
     Misses:                             11
     Compulsory misses:                  *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                        1[,\.]69%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                               3[0-9]
     Misses:                             *[0-9]*
     Compulsory misses:                  *[0-9,\.]*
@@ -25,7 +25,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                                3
     Misses:                             1[0-9]
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -78,10 +78,11 @@ public:
     void
     initialize_cache()
     {
-        caching_device_stats_t *stats = new cache_stats_t(line_size_, "", true);
+        caching_device_stats_t *stats = new cache_stats_t(line_size_, /*miss_file=*/"",
+                                                          /*warmup_enabled=*/true);
         if (!this->init(associativity_, line_size_, total_size_, nullptr, stats,
                         nullptr)) {
-            std::cerr << "FIFO cache failed to initialize\n";
+            std::cerr << this->get_replace_policy() << " cache failed to initialize\n";
             exit(1);
         }
     }
@@ -145,6 +146,7 @@ unit_test_cache_lru_four_way()
                                                     /*total_size=*/256);
     cache_lru_test.initialize_cache();
 
+    assert(cache_lru_test.get_replace_policy() == "LRU");
     assert(cache_lru_test.block_indices_are_identical(addr_vec));
     assert(cache_lru_test.tags_are_different(addr_vec));
 
@@ -183,6 +185,7 @@ unit_test_cache_lru_eight_way()
                                                     /*total_size=*/1024);
     cache_lru_test.initialize_cache();
 
+    assert(cache_lru_test.get_replace_policy() == "LRU");
     assert(cache_lru_test.block_indices_are_identical(addr_vec));
     assert(cache_lru_test.tags_are_different(addr_vec));
 
@@ -228,6 +231,7 @@ unit_test_cache_fifo_four_way()
                                                       /*total_size=*/256);
     cache_fifo_test.initialize_cache();
 
+    assert(cache_fifo_test.get_replace_policy() == "FIFO");
     assert(cache_fifo_test.block_indices_are_identical(addr_vec));
     assert(cache_fifo_test.tags_are_different(addr_vec));
 
@@ -269,6 +273,7 @@ unit_test_cache_fifo_eight_way()
                                                       /*total_size=*/1024);
     cache_fifo_test.initialize_cache();
 
+    assert(cache_fifo_test.get_replace_policy() == "FIFO");
     assert(cache_fifo_test.block_indices_are_identical(addr_vec));
     assert(cache_fifo_test.tags_are_different(addr_vec));
 
@@ -308,6 +313,7 @@ unit_test_cache_lfu_four_way()
                                                 /*total_size=*/256);
     cache_lfu_test.initialize_cache();
 
+    assert(cache_lfu_test.get_replace_policy() == "LFU");
     assert(cache_lfu_test.block_indices_are_identical(addr_vec));
     assert(cache_lfu_test.tags_are_different(addr_vec));
 
@@ -347,6 +353,7 @@ unit_test_cache_lfu_eight_way()
                                                 /*total_size=*/1024);
     cache_lfu_test.initialize_cache();
 
+    assert(cache_lfu_test.get_replace_policy() == "LFU");
     assert(cache_lfu_test.block_indices_are_identical(addr_vec));
     assert(cache_lfu_test.tags_are_different(addr_vec));
 

--- a/clients/drcachesim/tests/coherence.templatex
+++ b/clients/drcachesim/tests/coherence.templatex
@@ -31,14 +31,14 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(.*\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Parent invalidations:       *[0-9,\.]*
     Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -48,7 +48,7 @@ Core #0 \(.*\)
 Core #1 \(.*\).*
 Core #2 \(.*\).*
 Core #3 \(.*\).*
-LL stats:.*
+LL .* stats:
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/coherence.templatex
+++ b/clients/drcachesim/tests/coherence.templatex
@@ -31,14 +31,14 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(.*\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Parent invalidations:       *[0-9,\.]*
     Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -48,7 +48,7 @@ Core #0 \(.*\)
 Core #1 \(.*\).*
 Core #2 \(.*\).*
 Core #3 \(.*\).*
-LL stats:
+LL stats:.*
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/delay-simple.templatex
+++ b/clients/drcachesim/tests/delay-simple.templatex
@@ -3,13 +3,13 @@ Exiting process after ~1.... references.
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -18,7 +18,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/delay-simple.templatex
+++ b/clients/drcachesim/tests/delay-simple.templatex
@@ -3,13 +3,13 @@ Exiting process after ~1.... references.
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -18,7 +18,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -41,6 +41,7 @@
 #include "simulator/cache_lru.h"
 #include "simulator/cache_simulator.h"
 #include "../common/memref.h"
+#include "../common/utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -388,6 +389,7 @@ unit_test_cache_associativity()
             bool initialized =
                 cache.init(assoc, LINE_SIZE, total_size, /*parent=*/nullptr, &stats);
             assert(initialized);
+            assert(cache.get_associativity() == assoc);
             // Test start address is arbitrary.
             addr_t start_address = test_assoc * total_size;
 
@@ -436,6 +438,7 @@ unit_test_cache_size()
             bool initialized = cache.init(associativity, LINE_SIZE, cache_size,
                                           /*parent=*/nullptr, &stats);
             assert(initialized);
+            assert(cache.get_size_bytes() == cache_size);
             static constexpr int NUM_LOOPS = 3; // Anything >=2 should work.
             auto read_count = generate_1D_accesses(cache, 0, LINE_SIZE,
                                                    buffer_size / LINE_SIZE, NUM_LOOPS);
@@ -550,12 +553,56 @@ unit_test_cache_bad_configs()
     }
 }
 
+// Tests cache attribute accessors.
+void
+unit_test_cache_accessors()
+{
+    static const int TEST_ASSOCIATIVITIES[] = { 1, 7, 16 };
+    static const int TEST_SET_COUNTS[] = { 16, 128, 512 }; // Must be PO2.
+    static const int TEST_LINE_SIZES[] = { 16, 64, 256 };  // Must be PO2.
+
+    int loop_count = 0;
+    for (int associativity : TEST_ASSOCIATIVITIES) {
+        for (int set_count : TEST_SET_COUNTS) {
+            for (int line_size : TEST_LINE_SIZES) {
+                // Just cycle through these combinations.  No need to be exhaustive.
+                bool inclusive = TESTANY(0x1, loop_count);
+                bool coherent = TESTANY(0x2, loop_count);
+                ++loop_count;
+
+                int total_size = associativity * set_count * line_size;
+                std::string cache_name = "Test" + std::to_string(total_size);
+                caching_device_stats_t stats(/*miss_file=*/"", line_size);
+                // Only test LRU here.  Other replacement policy accessors are
+                // tested in the cache_replacement_policy_unit_test.
+                cache_lru_t cache(cache_name);
+                bool initialized =
+                    cache.init(associativity, line_size, total_size,
+                               /*parent=*/nullptr, &stats,
+                               /*prefetcher=*/nullptr, inclusive, coherent);
+                assert(initialized);
+                assert(cache.get_stats() == &stats);
+                assert(stats.get_caching_device() == &cache);
+                assert(cache.get_name() == cache_name);
+                assert(cache.get_replace_policy() == "LRU");
+                assert(cache.get_associativity() == associativity);
+                assert(cache.get_size_bytes() == total_size);
+                assert(cache.get_block_size() == line_size);
+                assert(cache.get_num_blocks() == total_size / line_size);
+                assert(cache.is_inclusive() == inclusive);
+                assert(cache.is_coherent() == coherent);
+            }
+        }
+    }
+}
+
 int
 test_main(int argc, const char *argv[])
 {
     // Takes in a path to the tests/ src dir.
     assert(argc == 2);
 
+    unit_test_cache_accessors();
     unit_test_config_reader(argv[1]);
     unit_test_cache_associativity();
     unit_test_cache_size();

--- a/clients/drcachesim/tests/drstatecmp-delay-simple.templatex
+++ b/clients/drcachesim/tests/drstatecmp-delay-simple.templatex
@@ -3,13 +3,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -18,7 +18,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/drstatecmp-delay-simple.templatex
+++ b/clients/drcachesim/tests/drstatecmp-delay-simple.templatex
@@ -3,13 +3,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -18,7 +18,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/filter-asm.templatex
+++ b/clients/drcachesim/tests/filter-asm.templatex
@@ -17,13 +17,13 @@ Hello world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                                0
     Misses:                             .*
     Compulsory misses:                  *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                      100.00%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -31,7 +31,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                                0
     Misses:                             .*
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/filter-asm.templatex
+++ b/clients/drcachesim/tests/filter-asm.templatex
@@ -17,13 +17,13 @@ Hello world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                                0
     Misses:                             .*
     Compulsory misses:                  *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                      100.00%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -31,7 +31,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                                0
     Misses:                             .*
     Compulsory misses:                  *[0-9,\.]*

--- a/clients/drcachesim/tests/filter-simple.templatex
+++ b/clients/drcachesim/tests/filter-simple.templatex
@@ -2,13 +2,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/filter-simple.templatex
+++ b/clients/drcachesim/tests/filter-simple.templatex
@@ -2,13 +2,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/instr-only-trace.templatex
+++ b/clients/drcachesim/tests/instr-only-trace.templatex
@@ -2,13 +2,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D stats:
+  L1D0 stats: size=[0-9].*
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/instr-only-trace.templatex
+++ b/clients/drcachesim/tests/instr-only-trace.templatex
@@ -2,13 +2,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats: size=[0-9].*
+  L1I0 .*size=[1-9].* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D0 stats: size=[0-9].*
+  L1D0 .*size=[1-9].* stats:
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats: size=[0-9].*
+LL .*size=[1-9].* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/missfile-config-file.templatex
+++ b/clients/drcachesim/tests/missfile-config-file.templatex
@@ -2,28 +2,28 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): #.*\)
-  L1I stats:
+  L1I stats:.*
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *[0-9,\.]*
-.*L1D stats:
+.*L1D stats:.*
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *[0-9,\.]*
-.*L2 stats:
+.*L2 stats:.*
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *[0-9,\.]*
-.*LLC stats:
+.*LLC stats:.*
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*

--- a/clients/drcachesim/tests/missfile-config-file.templatex
+++ b/clients/drcachesim/tests/missfile-config-file.templatex
@@ -2,28 +2,28 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): #.*\)
-  L1I stats:.*
+  L1I .* stats:
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *[0-9,\.]*
-.*L1D stats:.*
+.*L1D .* stats:
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *[0-9,\.]*
-.*L2 stats:.*
+.*L2 .* stats:
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *[0-9,\.]*
-.*LLC stats:.*
+.*LLC .* stats:
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*

--- a/clients/drcachesim/tests/multiproc.templatex
+++ b/clients/drcachesim/tests/multiproc.templatex
@@ -2,26 +2,26 @@ all done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*
     Invalidations:           *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9\.,]*
     Compulsory misses:       *[0-9\.,]*
     Invalidations:           *0
 .*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(1 thread\(s\)\)
-  L1I stats:
+  L1I1 stats:.*
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*
     Invalidations:           *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D1 stats:.*
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9]*[,\.]?...
     Compulsory misses:       *[0-9,\.]*
@@ -29,7 +29,7 @@ Core #1 \(1 thread\(s\)\)
 .*   Miss rate:              *[0-9]*[,\.]..%
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                    *[0-9]*
     Misses:                  *[0-9]*[,\.]?...
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/multiproc.templatex
+++ b/clients/drcachesim/tests/multiproc.templatex
@@ -2,26 +2,26 @@ all done
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*
     Invalidations:           *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9\.,]*
     Compulsory misses:       *[0-9\.,]*
     Invalidations:           *0
 .*   Miss rate:                        [0-3][,\.]..%
 Core #1 \(1 thread\(s\)\)
-  L1I1 stats:.*
+  L1I1 .* stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*
     Invalidations:           *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D1 stats:.*
+  L1D1 .* stats:
     Hits:                    *[0-9]*[,\.]?...[,\.]?...
     Misses:                  *[0-9]*[,\.]?...
     Compulsory misses:       *[0-9,\.]*
@@ -29,7 +29,7 @@ Core #1 \(1 thread\(s\)\)
 .*   Miss rate:              *[0-9]*[,\.]..%
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                    *[0-9]*
     Misses:                  *[0-9]*[,\.]?...
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_client.templatex
+++ b/clients/drcachesim/tests/offline-burst_client.templatex
@@ -24,13 +24,13 @@ DynamoRIO statistics:
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -39,7 +39,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_client.templatex
+++ b/clients/drcachesim/tests/offline-burst_client.templatex
@@ -24,13 +24,13 @@ DynamoRIO statistics:
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -39,7 +39,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_maps.templatex
+++ b/clients/drcachesim/tests/offline-burst_maps.templatex
@@ -12,13 +12,13 @@ pre-DR detach
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -27,7 +27,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_maps.templatex
+++ b/clients/drcachesim/tests/offline-burst_maps.templatex
@@ -12,13 +12,13 @@ pre-DR detach
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -27,7 +27,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_noreach.templatex
+++ b/clients/drcachesim/tests/offline-burst_noreach.templatex
@@ -12,13 +12,13 @@ pre-DR detach
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -27,7 +27,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_noreach.templatex
+++ b/clients/drcachesim/tests/offline-burst_noreach.templatex
@@ -12,13 +12,13 @@ pre-DR detach
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -27,7 +27,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -20,13 +20,13 @@ close file .*
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -35,7 +35,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_replace.templatex
+++ b/clients/drcachesim/tests/offline-burst_replace.templatex
@@ -20,13 +20,13 @@ close file .*
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -35,7 +35,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -21,13 +21,13 @@ DynamoRIO statistics:
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -36,7 +36,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_static.templatex
+++ b/clients/drcachesim/tests/offline-burst_static.templatex
@@ -21,13 +21,13 @@ DynamoRIO statistics:
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -36,7 +36,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -13,12 +13,12 @@ pre-DR detach
 all done
 Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Invalidations:              *0.*
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -26,7 +26,7 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
-LL stats:.*
+LL .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-burst_threads.templatex
+++ b/clients/drcachesim/tests/offline-burst_threads.templatex
@@ -13,12 +13,12 @@ pre-DR detach
 all done
 Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Invalidations:              *0.*
-  L1D stats:
+  L1D0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -26,7 +26,7 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
-LL stats:
+LL stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-cpu.templatex
+++ b/clients/drcachesim/tests/offline-cpu.templatex
@@ -1,12 +1,12 @@
 Cache simulation results:
 Core #0 \(1 traced CPU\(s\): #8\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                           *35[,\.]?903
     Misses:                            666
     Compulsory misses:                 664
     Invalidations:                       0
     Miss rate:                        1[,\.]82%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                            *9[,\.]?718
     Misses:                            354
     Compulsory misses:                 627
@@ -15,13 +15,13 @@ Core #0 \(1 traced CPU\(s\): #8\)
     Prefetch misses:                   280
     Miss rate:                        3[,\.]51%
 Core #1 \(1 traced CPU\(s\): #2\)
-  L1I stats:
+  L1I1 stats:.*
     Hits:                          *105[,\.]?796
     Misses:                            543
     Compulsory misses:                 543
     Invalidations:                       0
     Miss rate:                        0[,\.]51%
-  L1D stats:
+  L1D1 stats:.*
     Hits:                           *32[,\.]?672
     Misses:                          *1[,\.]?112
     Compulsory misses:               *1[,\.]?822
@@ -31,7 +31,7 @@ Core #1 \(1 traced CPU\(s\): #2\)
     Miss rate:                        3[,\.]29%
 Core #2 \(0 traced CPU\(s\)\)
 Core #3 \(0 traced CPU\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                              455
     Misses:                          *2[,\.]?220
     Compulsory misses:               *3[,\.]?222

--- a/clients/drcachesim/tests/offline-cpu.templatex
+++ b/clients/drcachesim/tests/offline-cpu.templatex
@@ -1,12 +1,12 @@
 Cache simulation results:
 Core #0 \(1 traced CPU\(s\): #8\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                           *35[,\.]?903
     Misses:                            666
     Compulsory misses:                 664
     Invalidations:                       0
     Miss rate:                        1[,\.]82%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                            *9[,\.]?718
     Misses:                            354
     Compulsory misses:                 627
@@ -15,13 +15,13 @@ Core #0 \(1 traced CPU\(s\): #8\)
     Prefetch misses:                   280
     Miss rate:                        3[,\.]51%
 Core #1 \(1 traced CPU\(s\): #2\)
-  L1I1 stats:.*
+  L1I1 .* stats:
     Hits:                          *105[,\.]?796
     Misses:                            543
     Compulsory misses:                 543
     Invalidations:                       0
     Miss rate:                        0[,\.]51%
-  L1D1 stats:.*
+  L1D1 .* stats:
     Hits:                           *32[,\.]?672
     Misses:                          *1[,\.]?112
     Compulsory misses:               *1[,\.]?822
@@ -31,7 +31,7 @@ Core #1 \(1 traced CPU\(s\): #2\)
     Miss rate:                        3[,\.]29%
 Core #2 \(0 traced CPU\(s\)\)
 Core #3 \(0 traced CPU\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                              455
     Misses:                          *2[,\.]?220
     Compulsory misses:               *3[,\.]?222

--- a/clients/drcachesim/tests/offline-filter-and-instr-only-trace.templatex
+++ b/clients/drcachesim/tests/offline-filter-and-instr-only-trace.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -15,7 +15,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-filter-and-instr-only-trace.templatex
+++ b/clients/drcachesim/tests/offline-filter-and-instr-only-trace.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -15,7 +15,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-filter.templatex
+++ b/clients/drcachesim/tests/offline-filter.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9]?[0-9][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-filter.templatex
+++ b/clients/drcachesim/tests/offline-filter.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9]?[0-9][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-fork.templatex
+++ b/clients/drcachesim/tests/offline-fork.templatex
@@ -4,13 +4,13 @@ child is running under DynamoRIO
 child has exited
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -19,7 +19,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-fork.templatex
+++ b/clients/drcachesim/tests/offline-fork.templatex
@@ -4,13 +4,13 @@ child is running under DynamoRIO
 child has exited
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -19,7 +19,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-instr-only-trace.templatex
+++ b/clients/drcachesim/tests/offline-instr-only-trace.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -15,7 +15,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-instr-only-trace.templatex
+++ b/clients/drcachesim/tests/offline-instr-only-trace.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[1-9]?[0-9][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                                0
     Misses:                              0
     Compulsory misses:                   *[0-9,\.]*
@@ -15,7 +15,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-legacy.templatex
+++ b/clients/drcachesim/tests/offline-legacy.templatex
@@ -1,12 +1,12 @@
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *61[,\.]?538
     Misses:                            724
     Compulsory misses:           *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                        1[,\.]16%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *21[,\.]?189
     Misses:                            774
     Compulsory misses:           *[0-9,\.]*
@@ -15,13 +15,13 @@ Core #0 \(1 thread\(s\)\)
     Prefetch misses:                   623
     Miss rate:                        3[,\.]52%
 Core #1 \(4 thread\(s\)\)
-  L1I stats:
+  L1I1 stats:.*
     Hits:                         *19[,\.]?428
     Misses:                            130
     Compulsory misses:           *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                        0[,\.]66%
-  L1D stats:
+  L1D1 stats:.*
     Hits:                         *20[,\.]?477
     Misses:                            258
     Compulsory misses:           *[0-9,\.]*
@@ -31,7 +31,7 @@ Core #1 \(4 thread\(s\)\)
     Miss rate:                        1[,\.]24%
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                              342
     Misses:                        *1[,\.]?544
     Compulsory misses:           *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-legacy.templatex
+++ b/clients/drcachesim/tests/offline-legacy.templatex
@@ -1,12 +1,12 @@
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *61[,\.]?538
     Misses:                            724
     Compulsory misses:           *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                        1[,\.]16%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *21[,\.]?189
     Misses:                            774
     Compulsory misses:           *[0-9,\.]*
@@ -15,13 +15,13 @@ Core #0 \(1 thread\(s\)\)
     Prefetch misses:                   623
     Miss rate:                        3[,\.]52%
 Core #1 \(4 thread\(s\)\)
-  L1I1 stats:.*
+  L1I1 .* stats:
     Hits:                         *19[,\.]?428
     Misses:                            130
     Compulsory misses:           *[0-9,\.]*
     Invalidations:                       0
     Miss rate:                        0[,\.]66%
-  L1D1 stats:.*
+  L1D1 .* stats:
     Hits:                         *20[,\.]?477
     Misses:                            258
     Compulsory misses:           *[0-9,\.]*
@@ -31,7 +31,7 @@ Core #1 \(4 thread\(s\)\)
     Miss rate:                        1[,\.]24%
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                              342
     Misses:                        *1[,\.]?544
     Compulsory misses:           *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-multiproc.templatex
+++ b/clients/drcachesim/tests/offline-multiproc.templatex
@@ -1,13 +1,13 @@
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*
     Invalidations:           *0
 .*    Miss rate:             *[0-9]*[,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
     Compulsory misses:       *[0-9\.,]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
     Compulsory misses:       *[0-9\.,]*

--- a/clients/drcachesim/tests/offline-multiproc.templatex
+++ b/clients/drcachesim/tests/offline-multiproc.templatex
@@ -1,13 +1,13 @@
 all done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*
     Invalidations:           *0
 .*    Miss rate:             *[0-9]*[,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
     Compulsory misses:       *[0-9\.,]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                    *[0-9\.,]*
     Misses:                  *[0-9\.,]*
     Compulsory misses:       *[0-9\.,]*

--- a/clients/drcachesim/tests/offline-rseq.templatex
+++ b/clients/drcachesim/tests/offline-rseq.templatex
@@ -2,13 +2,13 @@ Hit delay threshold: enabling tracing.
 All done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-rseq.templatex
+++ b/clients/drcachesim/tests/offline-rseq.templatex
@@ -2,13 +2,13 @@ Hit delay threshold: enabling tracing.
 All done
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*   Miss rate:                   *[0-9,\.]*%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-simple.templatex
+++ b/clients/drcachesim/tests/offline-simple.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-simple.templatex
+++ b/clients/drcachesim/tests/offline-simple.templatex
@@ -1,13 +1,13 @@
 Hello, world!
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -16,7 +16,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/offline-snappy-serial.templatex
+++ b/clients/drcachesim/tests/offline-snappy-serial.templatex
@@ -1,5 +1,5 @@
 Cache simulation results:
 .*
-LL stats:
+LL stats:.*
     Hits:                     *78[,\.]?312
 .*

--- a/clients/drcachesim/tests/offline-snappy-serial.templatex
+++ b/clients/drcachesim/tests/offline-snappy-serial.templatex
@@ -1,5 +1,5 @@
 Cache simulation results:
 .*
-LL stats:.*
+LL .* stats:
     Hits:                     *78[,\.]?312
 .*

--- a/clients/drcachesim/tests/phys-threads.templatex
+++ b/clients/drcachesim/tests/phys-threads.templatex
@@ -31,13 +31,13 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \([0-9]+ thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Invalidations:              *0
 .*    Miss rate:                *[0-9,\.]*%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -46,7 +46,7 @@ Core #0 \([0-9]+ thread\(s\)\)
 Core #1 \([0-9]+ thread\(s\).*
 Core #2 \([0-9]+ thread\(s\).*
 Core #3 \([0-9]+ thread\(s\).*
-LL stats:.*
+LL .* stats:
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/phys-threads.templatex
+++ b/clients/drcachesim/tests/phys-threads.templatex
@@ -31,13 +31,13 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \([0-9]+ thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Invalidations:              *0
 .*    Miss rate:                *[0-9,\.]*%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -46,7 +46,7 @@ Core #0 \([0-9]+ thread\(s\)\)
 Core #1 \([0-9]+ thread\(s\).*
 Core #2 \([0-9]+ thread\(s\).*
 Core #3 \([0-9]+ thread\(s\).*
-LL stats:
+LL stats:.*
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/phys.templatex
+++ b/clients/drcachesim/tests/phys.templatex
@@ -2,13 +2,13 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                         *[0-9].[,\.]?...
     Misses:                       *[0-9]*[,\.]?..?.?
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/phys.templatex
+++ b/clients/drcachesim/tests/phys.templatex
@@ -2,13 +2,13 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-3][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                         *[0-9].[,\.]?...
     Misses:                       *[0-9]*[,\.]?..?.?
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/simple-config-file.templatex
+++ b/clients/drcachesim/tests/simple-config-file.templatex
@@ -2,21 +2,21 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats: size=[0-9].*
+  L1I .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Parent invalidations:         *[0-9,\.]*
     Write invalidations:          *[0-9,\.]*
 .*    Miss rate:                        [0-9][,\.]..%
-  L1D stats: size=[0-9].*
+  L1D .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Parent invalidations:         *[0-9,\.]*
     Write invalidations:          *[0-9,\.]*
 .*   Miss rate:                        [0-9][,\.]..%
-L2 stats: size=[0-9].*
+L2 .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -24,7 +24,7 @@ L2 stats: size=[0-9].*
 .*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-3][,\.]..%
-LLC stats: size=[0-9].*
+LLC .* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/simple-config-file.templatex
+++ b/clients/drcachesim/tests/simple-config-file.templatex
@@ -2,21 +2,21 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Parent invalidations:         *[0-9,\.]*
     Write invalidations:          *[0-9,\.]*
 .*    Miss rate:                        [0-9][,\.]..%
-  L1D stats:
+  L1D stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Parent invalidations:         *[0-9,\.]*
     Write invalidations:          *[0-9,\.]*
 .*   Miss rate:                        [0-9][,\.]..%
-L2 stats:
+L2 stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -24,7 +24,7 @@ L2 stats:
 .*   Local miss rate:        *[0-9,.]*%
     Child hits:                   *[0-9,\.]*
     Total miss rate:                  [0-3][,\.]..%
-LLC stats:
+LLC stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/simple.templatex
+++ b/clients/drcachesim/tests/simple.templatex
@@ -2,13 +2,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats: size=[0-9].*
+  L1I0 .*size=[0-9].* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
-  L1D0 stats: size=[0-9].*
+  L1D0 .*size=[0-9].* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats: size=[0-9].*
+LL .*size=[0-9].* stats:
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/simple.templatex
+++ b/clients/drcachesim/tests/simple.templatex
@@ -2,13 +2,13 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
-  L1D stats:
+  L1D0 stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*
@@ -17,7 +17,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats: size=[0-9].*
     Hits:                         *[0-9,\.]*
     Misses:                       *[0-9,\.]*
     Compulsory misses:            *[0-9,\.]*

--- a/clients/drcachesim/tests/threads-with-config-file.templatex
+++ b/clients/drcachesim/tests/threads-with-config-file.templatex
@@ -31,21 +31,21 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(.*\)
-  L1I stats:
+  L1I stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Parent invalidations:       *[0-9,\.]*
     Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
-  L1D stats:
+  L1D stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Parent invalidations:       *[0-9,\.]*
     Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
-L2 stats:
+L2 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -53,7 +53,7 @@ L2 stats:
 .*    Local miss rate:        *[0-9,.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%
-LLC stats:
+LLC stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*

--- a/clients/drcachesim/tests/threads-with-config-file.templatex
+++ b/clients/drcachesim/tests/threads-with-config-file.templatex
@@ -31,21 +31,21 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(.*\)
-  L1I stats:.*
+  L1I .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Parent invalidations:       *[0-9,\.]*
     Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
-  L1D stats:.*
+  L1D .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Parent invalidations:       *[0-9,\.]*
     Write invalidations:        *[0-9,\.]*
 .*    Miss rate:                *[0-9,\.]*%
-L2 stats:.*
+L2 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -53,7 +53,7 @@ L2 stats:.*
 .*    Local miss rate:        *[0-9,.]*%
     Child hits:                 *[0-9,\.]*
     Total miss rate:            *[0-9,\.]*%
-LLC stats:.*
+LLC .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*

--- a/clients/drcachesim/tests/threads.templatex
+++ b/clients/drcachesim/tests/threads.templatex
@@ -31,13 +31,13 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
-  L1I stats:
+  L1I0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Invalidations:              *0
 .*    Miss rate:                *[0-9,\.]*%
-  L1D stats:
+  L1D0 stats:.*
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -46,7 +46,7 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
-LL stats:
+LL stats:.*
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/threads.templatex
+++ b/clients/drcachesim/tests/threads.templatex
@@ -31,13 +31,13 @@
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
     Invalidations:              *0
 .*    Miss rate:                *[0-9,\.]*%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Hits:                       *[0-9,\.]*
     Misses:                     *[0-9,\.]*
     Compulsory misses:          *[0-9,\.]*
@@ -46,7 +46,7 @@ Core #0 \([0-9] traced CPU\(s\): [#0-9, ]+\)
 Core #1 \([0-9] traced CPU\(s\).*
 Core #2 \([0-9] traced CPU\(s\).*
 Core #3 \([0-9] traced CPU\(s\).*
-LL stats:.*
+LL .* stats:
     Hits:                    *[0-9,\.]*
     Misses:                  *[0-9,\.]*
     Compulsory misses:       *[0-9,\.]*

--- a/clients/drcachesim/tests/warmup-valid.templatex
+++ b/clients/drcachesim/tests/warmup-valid.templatex
@@ -2,7 +2,7 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[1-9][0-9,\.]*
     Hits:                         *[0-9,\.]*
@@ -10,7 +10,7 @@ Core #0 \(1 thread\(s\)\)
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
@@ -21,7 +21,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*

--- a/clients/drcachesim/tests/warmup-valid.templatex
+++ b/clients/drcachesim/tests/warmup-valid.templatex
@@ -2,7 +2,7 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[1-9][0-9,\.]*
     Hits:                         *[0-9,\.]*
@@ -10,7 +10,7 @@ Core #0 \(1 thread\(s\)\)
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*
@@ -21,7 +21,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Warmup hits:                  *[0-9,\.]*
     Warmup misses:                *[0-9,\.]*
     Hits:                         *[0-9,\.]*

--- a/clients/drcachesim/tests/warmup-zeros.templatex
+++ b/clients/drcachesim/tests/warmup-zeros.templatex
@@ -2,7 +2,7 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I stats:
+  L1I0 stats:.*
     Warmup hits:                  *[0]*
     Warmup misses:                *[0]*
     Hits:                         *[0-9,\.]*
@@ -10,7 +10,7 @@ Core #0 \(1 thread\(s\)\)
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
-  L1D stats:
+  L1D0 stats:.*
     Warmup hits:                  *[0]*
     Warmup misses:                *[0]*
     Hits:                         *[0-9,\.]*
@@ -21,7 +21,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:
+LL stats:.*
     Warmup hits:                  *[0]*
     Warmup misses:                *[0]*
     Hits:                         *[0-9,\.]*

--- a/clients/drcachesim/tests/warmup-zeros.templatex
+++ b/clients/drcachesim/tests/warmup-zeros.templatex
@@ -2,7 +2,7 @@ Hello, world!
 ---- <application exited with code 0> ----
 Cache simulation results:
 Core #0 \(1 thread\(s\)\)
-  L1I0 stats:.*
+  L1I0 .* stats:
     Warmup hits:                  *[0]*
     Warmup misses:                *[0]*
     Hits:                         *[0-9,\.]*
@@ -10,7 +10,7 @@ Core #0 \(1 thread\(s\)\)
     Compulsory misses:            *[0-9,\.]*
     Invalidations:                *0
 .*    Miss rate:                        [0-1][,\.]..%
-  L1D0 stats:.*
+  L1D0 .* stats:
     Warmup hits:                  *[0]*
     Warmup misses:                *[0]*
     Hits:                         *[0-9,\.]*
@@ -21,7 +21,7 @@ Core #0 \(1 thread\(s\)\)
 Core #1 \(0 thread\(s\)\)
 Core #2 \(0 thread\(s\)\)
 Core #3 \(0 thread\(s\)\)
-LL stats:.*
+LL .* stats:
     Warmup hits:                  *[0]*
     Warmup misses:                *[0]*
     Hits:                         *[0-9,\.]*


### PR DESCRIPTION
Adds a name to caching_device, with accessors for the name and other cache parameters.  Added a "caching_device" pointer to caching_device_stats, to make it easier for client code to access the cache associated with a stats object.  Updated drcachesim output reports to include cache names and a short description of each cache's configuration.  Updated tests for the output format changes and new methods.