### PR TITLE
i#6196: Avoid adding to a null pointer

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -643,9 +643,11 @@ public:
     test_module_mapper_t(instrlist_t *instrs, void *drcontext)
         : module_mapper_t(nullptr)
     {
-        // We encode for 0-based addresses for simpler tests with low values.
-        byte *pc = instrlist_encode_to_copy(drcontext, instrs, decode_buf_, nullptr,
-                                            nullptr, true);
+        // We encode for 1-based addresses for simpler tests with low values while
+        // avoiding null pointer manipulation complaints (xref i#6196).
+        byte *pc = instrlist_encode_to_copy(
+            drcontext, instrs, decode_buf_,
+            reinterpret_cast<byte *>(static_cast<ptr_uint_t>(1)), nullptr, true);
         DR_ASSERT(pc != nullptr);
         DR_ASSERT(pc - decode_buf_ < MAX_DECODE_SIZE);
         // Clear do_module_parsing error; we can't cleanly make virtual b/c it's

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -647,7 +647,7 @@ public:
         // avoiding null pointer manipulation complaints (xref i#6196).
         byte *pc = instrlist_encode_to_copy(
             drcontext, instrs, decode_buf_,
-            reinterpret_cast<byte *>(static_cast<ptr_uint_t>(1)), nullptr, true);
+            reinterpret_cast<byte *>(static_cast<ptr_uint_t>(4)), nullptr, true);
         DR_ASSERT(pc != nullptr);
         DR_ASSERT(pc - decode_buf_ < MAX_DECODE_SIZE);
         // Clear do_module_parsing error; we can't cleanly make virtual b/c it's

--- a/core/ir/decode.h
+++ b/core/ir/decode.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -200,6 +200,13 @@ enum {
 #endif
 
 /* in encode.c, not exported to non-ir/ files */
+/* This returns encoding information that may not be accurate as
+ * it is not given the final PC and that may affect which encoding
+ * template is used.  Callers should only use this when the
+ * differences between templates with respect to reachability
+ * do not matter.  One known difference is the absolute address
+ * immediate templates on x86.
+ */
 const instr_info_t *
 get_encoding_info(instr_t *instr);
 const instr_info_t *

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -1747,6 +1747,10 @@ instr_shrink_to_16_bits(instr_t *instr)
     const instr_info_t *info;
     byte optype;
     CLIENT_ASSERT(instr_operands_valid(instr), "instr_shrink_to_16_bits: invalid opnds");
+    /* Our use of get_encoding_info() with no final PC specified works
+     * as there are no encoding template choices involving reachability
+     * which affect whether an operand has an indirect register.
+     */
     info = get_encoding_info(instr);
     for (i = 0; i < instr_num_dsts(instr); i++) {
         opnd = instr_get_dst(instr, i);
@@ -2050,6 +2054,10 @@ bool
 instr_zeroes_ymmh(instr_t *instr)
 {
     int i;
+    /* Our use of get_encoding_info() with no final PC specified works
+     * as there are no encoding template choices involving reachability
+     * which affect whether ymmh is zeroed.
+     */
     const instr_info_t *info = get_encoding_info(instr);
     if (info == NULL)
         return false;

--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1290,6 +1290,13 @@ opnd_type_ok(decode_info_t *di /*prefixes field is IN/OUT; x86_mode is IN*/, opn
                   * after all, OPND_CREATE_ABSMEM() makes a rip-rel.
                   */
                  (opnd_is_rel_addr(opnd) &&
+                  /* If we don't know the final PC we bypass this template in
+                   * favor of the general template which should always match
+                   * and generally be what is expected.  get_encoding_info()
+                   * is the caller for this case and it documents that its
+                   * result is not perfect.
+                   */
+                  di->final_pc != NULL &&
                   (!REL32_REACHABLE(di->final_pc + MAX_INSTR_LENGTH,
                                     (byte *)opnd_get_addr(opnd)) ||
                    !REL32_REACHABLE(di->final_pc + 4, (byte *)opnd_get_addr(opnd)))) ||


### PR DESCRIPTION
Avoids non-regular-encode code paths which do not set a final PC and thus have a null PC value from manipulating that PC in opnd_type_ok().

Documents that get_encoding_info() may not find the same template as when called with the real final PC.  Documents in key callers that this is fine.

Adjusts the raw2trace unit test helper to use a non-null final PC.

Fixes #6196