### PR TITLE
i#725 Re-expose the Windows detach in drconfig

### DIFF
--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1508,8 +1508,7 @@ _tmain(int argc, TCHAR *targv[])
                 nudge_all = true;
             nudge_id = strtoul(argv[++i], NULL, 16);
             nudge_arg = _strtoui64(argv[++i], NULL, 16);
-        }else if (strcmp(argv[i], "-detach") == 0)
-        {
+        }else if (strcmp(argv[i], "-detach") == 0){
             if (i + 1 >= argc)
                 usage(false, "detach requires a process id");
             const char *pid_str = argv[++i];

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1508,7 +1508,7 @@ _tmain(int argc, TCHAR *targv[])
                 nudge_all = true;
             nudge_id = strtoul(argv[++i], NULL, 16);
             nudge_arg = _strtoui64(argv[++i], NULL, 16);
-        }else if (strcmp(argv[i], "-detach") == 0){
+        } else if (strcmp(argv[i], "-detach") == 0) {
             if (i + 1 >= argc)
                 usage(false, "detach requires a process id");
             const char *pid_str = argv[++i];


### PR DESCRIPTION
The old way to trigger detach on the Windows platform is the no-longer-supported "drcontrol" front-end. 
Re-exposing the detach feature in drconfig front-end on the Windows platform.

Fixes [#725](https://github.com/DynamoRIO/dynamorio/issues/725)