### PR TITLE
i#725: Re-expose the Windows detach in drconfig

### DIFF
--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -240,9 +240,6 @@ const char *options_list_str =
 #endif
 #ifdef DRCONFIG
     "\n"
-    "       -detach <pid> \n"
-    "                         Detach to the process with the given pid.\n"
-    "\n"
 #    ifdef WINDOWS
     "       Note that nudging 64-bit processes is not yet supported.\n"
     "       -nudge <process> <client ID> <argument>\n"

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1878,7 +1878,7 @@ done_with_options:
             dr_registered_process_iterator_stop(iter);
         }
     }
-    /* FIXME i#95: Process detach NYI for Linux. */
+    /* FIXME i#95: Process detach NYI for UNIX. */
     else if (detach_pid != 0) {
         dr_config_status_t res = detach(detach_pid, TRUE, detach_timeout);
         if (res != DR_SUCCESS)

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1878,7 +1878,7 @@ done_with_options:
             dr_registered_process_iterator_stop(iter);
         }
     }
-    /* FIXME i#2644: Process detach NYI for Linux. */
+    /* FIXME i#95: Process detach NYI for Linux. */
     else if (detach_pid != 0) {
         dr_config_status_t res = detach(detach_pid, TRUE, detach_timeout);
         if (res != DR_SUCCESS)

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1880,7 +1880,9 @@ done_with_options:
     }
     /* FIXME i#2644: Process detach NYI for Linux. */
     else if (detach_pid != 0) {
-        detach(detach_pid, TRUE, detach_timeout);
+        dr_config_status_t res=detach(detach_pid, TRUE, detach_timeout);
+        if (res != DR_SUCCESS)
+            error("unable to detach: check pid and system ptrace permissions");
     }
 #        endif
     else if (!syswide_on && !syswide_off) {

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -240,8 +240,10 @@ const char *options_list_str =
 #endif
 #ifdef DRCONFIG
     "\n"
+    "       -detach <pid> \n"
+    "                         Detach from the process with the given pid.\n"
+    "\n"
 #    ifdef WINDOWS
-    "       Note that nudging 64-bit processes is not yet supported.\n"
     "       -nudge <process> <client ID> <argument>\n"
     "                          Nudge the client with ID <client ID> in all running\n"
     "                          processes with name <process>, and pass <argument>\n"

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -240,6 +240,9 @@ const char *options_list_str =
 #endif
 #ifdef DRCONFIG
     "\n"
+    "       -detach <pid> \n"
+    "                         Detach to the process with the given pid.\n"
+    "\n"
 #    ifdef WINDOWS
     "       Note that nudging 64-bit processes is not yet supported.\n"
     "       -nudge <process> <client ID> <argument>\n"
@@ -1179,6 +1182,7 @@ _tmain(int argc, TCHAR *targv[])
     uint64 nudge_arg = 0;
     bool list_registered = false;
     uint nudge_timeout = INFINITE;
+    uint detach_timeout = DETACH_RECOMMENDED_TIMEOUT;
     bool syswide_on = false;
     bool syswide_off = false;
 #endif /* WINDOWS */
@@ -1205,6 +1209,11 @@ _tmain(int argc, TCHAR *targv[])
     void *inject_data;
     bool success;
     bool exit0 = false;
+#endif
+#if defined(DRCONFIG)
+#    ifdef WINDOWS
+    process_id_t detach_pid = 0;
+#    endif
 #endif
     char *drlib_path = NULL;
 #if defined(DRCONFIG) || defined(DRRUN)
@@ -1499,6 +1508,17 @@ _tmain(int argc, TCHAR *targv[])
                 nudge_all = true;
             nudge_id = strtoul(argv[++i], NULL, 16);
             nudge_arg = _strtoui64(argv[++i], NULL, 16);
+        } else if (strcmp(argv[i], "-detach") == 0) {
+            if (i + 1 >= argc)
+                usage(false, "detach requires a process id");
+            const char *pid_str = argv[++i];
+            process_id_t pid = strtoul(pid_str, NULL, 10);
+            if (pid == ULONG_MAX)
+                usage(false, "detach expects an integer pid: '%s'", pid_str);
+            if (pid == 0) {
+                usage(false, "detach passed an invalid pid: '%s'", pid_str);
+            }
+            detach_pid = pid;
         }
 #    endif
 #endif
@@ -1857,6 +1877,10 @@ done_with_options:
                 list_process(NULL, global, dr_platform, iter);
             dr_registered_process_iterator_stop(iter);
         }
+    }
+    /* FIXME i#2644: Process detach NYI for Linux. */
+    else if (detach_pid != 0) {
+        detach(detach_pid, TRUE, detach_timeout);
     }
 #        endif
     else if (!syswide_on && !syswide_off) {

--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -1880,7 +1880,7 @@ done_with_options:
     }
     /* FIXME i#2644: Process detach NYI for Linux. */
     else if (detach_pid != 0) {
-        dr_config_status_t res=detach(detach_pid, TRUE, detach_timeout);
+        dr_config_status_t res = detach(detach_pid, TRUE, detach_timeout);
         if (res != DR_SUCCESS)
             error("unable to detach: check pid and system ptrace permissions");
     }


### PR DESCRIPTION
The old way to trigger detach on the Windows platform is the no-longer-supported "drcontrol" front-end. 
Re-exposing the detach feature in drconfig front-end on the Windows platform.

The following briefly describes my manual testing process, and I'll continue to submit an automated testing tool in a new PR soon.


I wrote my own continuously running example as a manual test case for DynamoRIO, which counts the time of summing the first 1 billion numbers in real time. I'd like to use the real-time output of the test case to present the running state of the program.
```
#include <iostream>
#include <chrono>
#define LOOPCOUNT 100000;
// Function to perform a computationally intensive task
void performTask()
{
    //calculate the sum of the first 1 billion numbers
    long long unsigned sum = 0;
    for (int i = 1; i <= 1000000000; ++i)
    {
            sum += i;
    }
    std::cout << "The sum of the first 1 billion numbers: " << sum << std::endl;
}
void single_loop() {
    // Start the timer
    auto start = std::chrono::high_resolution_clock::now();
    // Perform the computationally intensive task
    performTask();
    // Stop the timer
    auto end = std::chrono::high_resolution_clock::now();
    // Calculate the elapsed time
    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
    // Print the elapsed time
    std::cout << "Elapsed time: " << duration.count() << " milliseconds" << std::endl;
}
int main()
{
    int counts = LOOPCOUNT;
    for (int i = 0; i < counts;i++)
    {
        single_loop();
    }
    return 0;
}
```
Here are the steps to perform a manual test：

1. Execute our test case: ./SumOneBillion.exe
2. Use the "ps" command to get the target process ID: ps | grep SumOneBillion
3. Use "-attach" option to instrument the  target process ID： .\drrun.exe -attach pid  -c64 D:\dynamorio\build_debug\api\bin\inscount.dll
4. Use "-detach" option to stop the instrumentation：.\drconfig.exe -detach pid

The output of the test case and the DynamoRIO in debug version is like following.


> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 192 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 191 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 191 milliseconds
**> <Starting application D:\vs_demos_repos\SumOneBillion\x64\Release\SumOneBillion.exe (16300)>
> <cannot remove dll from rbtree: at root/min + can't find real tree>
> <Running on newer-than-this-build "Microsoft Windows 10-2009 x64">
> <Early threads found>
> <Initial options = -no_dynamic_options -client_lib 'D:\dynamorio\build_debug\api\bin\inscount.dll;0;' -client_lib64 'D:\dynamorio\build_debug\api\bin\inscount.dll;0;' -code_api -probe_api -stack_size 56K -max_elide_jmp 0 -max_elide_call 0 -no_inline_ignored_syscalls -native_exec_default_list '' -no_native_exec_managed_code -skip_terminating_threads -no_indcall2direct >
> Client inscount is running**
> <CURIOSITY : instr_get_opcode(instr_new) != instr_get_opcode(instr_old) in file D:\DynamoRIODetach\dynamorio-master\core\win32\callback.c line 2079
> version 9.93.19549, custom build
> -no_dynamic_options -client_lib 'D:\dynamorio\build_debug\api\bin\inscount.dll;0;' -client_lib64 'D:\dynamorio\build_debug\api\bin\inscount.dll;0;' -code_api -probe_api -stack_size 56K -max_elide_jmp 0 -max_elide_call 0 -no_inline_ignored_syscalls -native_exec_default_list ''
> D:\dynamorio\build_debug\lib64\debug\dynamorio.dll=0x0000000015000000
> D:\dynamorio\build_debug\api\bin\inscount.dll=0x00007ff721f90000
> C:\WINDOWS/system32/KERNEL32.dll=0x0000026257e00000
> C:\WINDOWS/system32/KERNELBASE.dll=0x0000026257f40000
> D:\dynamorio\build_debug\ext\lib64\debug/drmgr.dll=0x00007ff721ff0000>
> <CURIOSITY : instr_new == instrlist_first(ilist) || instr_new == instr_get_next(instrlist_first(ilist)) in file D:\dynamorio\core\win32\callback.c line 2082
> version 9.93.19549, custom build
> -no_dynamic_options -client_lib 'D:\dynamorio\build_debug\api\bin\inscount.dll;0;' -client_lib64 'D:\dynamorio\build_debug\api\bin\inscount.dll;0;' -code_api -probe_api -stack_size 56K -max_elide_jmp 0 -max_elide_call 0 -no_inline_ignored_syscalls -native_exec_default_list ''
> D:\dynamorio\build_debug\lib64\debug\dynamorio.dll=0x0000000015000000
> D:\dynamorio\build_debug\api\bin\inscount.dll=0x00007ff721f90000
> C:\WINDOWS/system32/KERNEL32.dll=0x0000026257e00000
> C:\WINDOWS/system32/KERNELBASE.dll=0x0000026257f40000
> D:\dynamorio\build_debug\ext\lib64\debug/drmgr.dll=0x00007ff721ff0000>
> <Cleaning hooked Nt wrapper @0x00007ffeba790800 sysnum=0x1c2>
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 417 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 552 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 545 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 537 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 543 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 539 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 538 milliseconds
**> <curiosity: rex.w on OPSZ_6_irex10_short4!>
> <received nudge mask=0x4 id=0x00000000 arg=0x0000000000000000>
> <Detaching from application D:\vs_demos_repos\SumOneBillion\x64\Release\SumOneBillion.exe (16300)>
> <Detaching from process, entering final cleanup>
> Instrumentation results: 20766267822 instructions executed**
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 194 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 194 milliseconds
> The sum of the first 1 billion numbers: 500000000500000000
> Elapsed time: 194 milliseconds
> 

Issue: [#725](https://github.com/DynamoRIO/dynamorio/issues/725)

