### PR TITLE
i#3544 RV64: Implemented machine_cache_sync

### DIFF
--- a/core/arch/riscv64/proc.c
+++ b/core/arch/riscv64/proc.c
@@ -140,8 +140,11 @@ proc_has_feature(feature_bit_t f)
 void
 machine_cache_sync(void *pc_start, void *pc_end, bool flush_icache)
 {
-    /* FIXME i#3544: Not implemented. FENCE.I ? Maybe a syscall to clean icache? */
-    ASSERT_NOT_IMPLEMENTED(false);
+    /*
+     * RISC-V doesn't have an instruction to flush parts of the instruction cache,
+     * so instead we just flush the whole thing.
+     */
+    __asm__ __volatile__("fence.i" : : : "memory");
 }
 
 DR_API

--- a/core/arch/riscv64/proc.c
+++ b/core/arch/riscv64/proc.c
@@ -38,6 +38,9 @@
 #    error NYI
 #endif
 
+/* From Linux kernel, it's the only option available. */
+#define SYS_RISCV_FLUSH_ICACHE_LOCAL 1
+
 static int num_simd_saved;
 static int num_simd_registers;
 static int num_opmask_registers;
@@ -147,10 +150,9 @@ machine_cache_sync(void *pc_start, void *pc_end, bool flush_icache)
 {
     /* We need to flush the icache on all harts, which is not feasible for FENCE.I, so we
      * use SYS_riscv_flush_icache to let the kernel do this.
-     * The flag here is set to SYS_RISCV_FLUSH_ICACHE_LOCAL, which is defined as 1 in the
-     * Linux kernel.
      */
-    dynamorio_syscall(SYS_riscv_flush_icache, 3, pc_start, pc_end, /* flag */ 1);
+    dynamorio_syscall(SYS_riscv_flush_icache, 3, pc_start, pc_end,
+                      SYS_RISCV_FLUSH_ICACHE_LOCAL);
 }
 
 DR_API

--- a/core/unix/include/syscall_linux_riscv64.h
+++ b/core/unix/include/syscall_linux_riscv64.h
@@ -11,13 +11,13 @@
 #    error Only use this file on Linux
 #endif
 
+#ifndef __NR_riscv_flush_icache
+#    define __NR_riscv_flush_icache (__NR_arch_specific_syscall + 15)
+#endif
+
 /* Derived from /usr/riscv64-linux-gnu/include/asm/unistd.h
  * on Ubuntu GLIBC 2.36.1-6ubuntu on Linux 5.15.0-1008-generic
  */
 #include "syscall_linux_uapi.h"
-
-#ifndef __NR_riscv_flush_icache
-#    define __NR_riscv_flush_icache (__NR_arch_specific_syscall + 15)
-#endif
 
 #endif /* SYSCALL_LINUX_RISCV64_H */


### PR DESCRIPTION
We need to flush the icache on all harts, which is not feasible for FENCE.I, so we use `SYS_riscv_flush_icache` to let the kernel do this. Note this is also how gcc implements `__builtin___clear_cache`.

Issue: https://github.com/DynamoRIO/dynamorio/issues/3544