### PR TITLE
i#6187: Add invariant check that timestamps always stay the same or i…

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -937,13 +937,53 @@ check_schedule_file()
     return true;
 }
 
+bool
+check_timestamp_increase_monotonically(void)
+{
+    // Positive test: timestamps increase monotonically.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+        };
+        if (!run_checker(memrefs, false))
+            return false;
+    }
+    // Negative test: timestamp does not increase monotonically .
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 5),
+        };
+        if (!run_checker(memrefs, true, 1, 3,
+                         "Timestamp does not increase monotonically"))
+            return false;
+    }
+#ifdef X86_32
+    // Positive test: timestamp rollovers
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, UINT32_MAX - 10),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, UINT32_MAX),
+            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+        };
+        if (!run_checker(memrefs, false))
+            return false;
+    }
+#endif
+    return true;
+}
+
 int
 test_main(int argc, const char *argv[])
 {
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
         check_kernel_xfer() && check_rseq() && check_function_markers() &&
         check_duplicate_syscall_with_same_pc() && check_false_syscalls() &&
-        check_rseq_side_exit_discontinuity() && check_schedule_file()) {
+        check_rseq_side_exit_discontinuity() && check_schedule_file() &&
+        check_timestamp_increase_monotonically()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -582,6 +582,22 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
+#ifdef X86_32
+        // i#5634: Truncated for 32-bit, as documented.
+        // A 32 bit timestamp rolls over every 4294 seconds, so it needs to be
+        // considered when timetsamps are compared. The check assumes two
+        // consecutive timestamps will never be more than 2^31 microseconds (
+        // 2147 seconds) apart.
+        const uintptr_t last_timestamp = static_cast<uintptr_t>(shard->last_timestamp_);
+        if (memref.marker.marker_value < last_timestamp) {
+            report_if_false(
+                shard, last_timestamp > (memref.marker.marker_value + UINT32_MAX / 2),
+                "Timestamp does not increase monotonically");
+        }
+#else
+        report_if_false(shard, memref.marker.marker_value >= shard->last_timestamp_,
+                        "Timestamp does not increase monotonically");
+#endif
         shard->last_timestamp_ = memref.marker.marker_value;
         shard->saw_timestamp_but_no_instr_ = true;
         if (knob_verbose_ >= 3) {

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -206,8 +206,10 @@ online_instru_t::refresh_unit_header_timestamp(byte *buf_ptr, uint64 min_timesta
     stamp++; // Skip the tid added by append_unit_header() before the timestamp.
     DR_ASSERT(stamp->type == TRACE_TYPE_MARKER &&
               stamp->size == TRACE_MARKER_TYPE_TIMESTAMP);
-    if (stamp->addr < min_timestamp) {
-        stamp->addr = static_cast<uintptr_t>(min_timestamp);
+    // i#5634: Truncated for 32-bit, as documented.
+    const uintptr_t new_timestamp = static_cast<uintptr_t>(min_timestamp);
+    if (stamp->addr < new_timestamp) {
+        stamp->addr = new_timestamp;
         return true;
     }
     return false;


### PR DESCRIPTION
…ncrease.

Fix the check in online_instru_t::refresh_unit_header_timestamp which compares a truncated timestamp with a 64 bit timestamp on a 32 bit system.

Fixes: #6187