### PR TITLE
i#3044 AArch64 SVE codec: change LDR/STR and PRF to use byte offsets

### DIFF
--- a/clients/drdisas/test_simple.template
+++ b/clients/drdisas/test_simple.template
@@ -2,8 +2,8 @@
  00000000   udf    $0x0000
  f94017a0   ldr    +0x28(%x29)[8byte] -> %x0
  a9be7bfd   stp    %x29 %x30 %sp $0xffffffffffffffe0 -> -0x20(%sp)[16byte] %sp
- e58057a1   str    %z1 -> +0x05(%x29)[32byte]
- 85865e6b   ldr    +0x37(%x19)[32byte] -> %z11
+ e58057a1   str    %z1 -> +0xa0(%x29)[32byte]
+ 85865e6b   ldr    +0x06e0(%x19)[32byte] -> %z11
 disassembly failed: invalid instruction: not enough bytes: 0x88
 #elif defined(ARM) && !defined(thumb)
  f2436813   vtst.8 %d3 %d3 -> %d22

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5178,9 +5178,19 @@ static inline bool
 decode_opnd_svemem_gpr_simm6_vl(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     const int offset = extract_int(enc, 16, 6);
+    IF_RETURN_FALSE(offset < -32 || offset > 31)
     const reg_id_t rn = decode_reg(extract_uint(enc, 5, 5), true, true);
     const opnd_size_t mem_transfer = op_is_prefetch(opcode) ? OPSZ_0 : OPSZ_SVE_VL;
-    *opnd = opnd_create_base_disp(rn, DR_REG_NULL, 0, offset, mem_transfer);
+
+    /* As specified in the AArch64 SVE reference manual for contiguous prefetch
+     * instructions, the immediate index value is a vector index into memory, NOT
+     * an element or byte index. In DynamoRIO's IR, base-displacement operands
+     * should always refer to the address as a base register value + the linear
+     * memory displacement. So when creating the address operand here, it should be
+     * multiplied by the current vector register length in bytes.
+     */
+    int vl_bytes = dr_get_sve_vl() / 8;
+    *opnd = opnd_create_base_disp(rn, DR_REG_NULL, 0, offset * vl_bytes, mem_transfer);
 
     return true;
 }
@@ -5193,9 +5203,20 @@ encode_opnd_svemem_gpr_simm6_vl(uint enc, int opcode, byte *pc, opnd_t opnd,
     if (!opnd_is_base_disp(opnd) || opnd_get_index(opnd) != DR_REG_NULL ||
         opnd_get_size(opnd) != mem_transfer)
         return false;
+    if (!reg_is_gpr(opnd_get_base(opnd)))
+        return false;
+
+    /* As described in decode_opnd_svemem_gpr_simm6_vl(), disp is a multiple of
+     * vector length at the IR level, transformed to a vector index in the
+     * encoding.
+     */
+    int vl_bytes = dr_get_sve_vl() / 8;
+    ASSERT((opnd_get_disp(opnd) % vl_bytes) == 0);
+    int disp = opnd_get_disp(opnd) / vl_bytes;
+    IF_RETURN_FALSE(disp < -32 || disp > 31)
 
     uint imm6;
-    if (!try_encode_int(&imm6, 6, 0, opnd_get_disp(opnd)))
+    if (!try_encode_int(&imm6, 6, 0, disp))
         return false;
 
     uint rn;
@@ -5302,14 +5323,26 @@ decode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, OUT opnd_t *opnd
 {
     uint simm9 = (extract_uint(enc, 16, 6) << 3) | extract_uint(enc, 10, 3);
     int offset9 = extract_int(simm9, 0, 9);
-    if (offset9 < -256 || offset9 > 255)
-        return false;
+    IF_RETURN_FALSE(offset9 < -256 || offset9 > 255)
 
-    // Transfer size depends on whether we are transferring a Z register or a P register.
-    opnd_size_t memory_transfer_size = TEST(1u << 14, enc) ? OPSZ_SVE_VL : OPSZ_SVE_PL;
+    bool is_vector = TEST(1u << 14, enc);
 
+    /* Transfer size depends on whether we are transferring a Z or a P register. */
+    opnd_size_t memory_transfer_size = is_vector ? OPSZ_SVE_VL : OPSZ_SVE_PL;
+
+    /* As specified in the AArch64 SVE reference manual for unpredicated vector
+     * register load LDR and store STR instructions, the immediate index value is a
+     * vector index into memory, NOT an element or byte index. In DynamoRIO's IR,
+     * base-displacement operands should always refer to the address as a base
+     * register value + the linear memory displacement. So when creating the
+     * address operand here, it should be multiplied by the current vector or
+     * predicate register length in bytes.
+     */
+    int vl_bytes = dr_get_sve_vl() / 8;
+    int pl_bytes = vl_bytes / 8;
+    int mul_len = is_vector ? vl_bytes : pl_bytes;
     *opnd = opnd_create_base_disp(decode_reg(extract_uint(enc, 5, 5), true, true),
-                                  DR_REG_NULL, 0, offset9, memory_transfer_size);
+                                  DR_REG_NULL, 0, offset9 * mul_len, memory_transfer_size);
     return true;
 }
 
@@ -5321,16 +5354,28 @@ encode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, opnd_t opnd,
     bool is_x;
     uint rn;
 
-    // Transfer size depends on whether we are transferring a Z register or a P register.
-    opnd_size_t memory_transfer_size = TEST(1u << 14, enc) ? OPSZ_SVE_VL : OPSZ_SVE_PL;
+    bool is_vector = TEST(1u << 14, enc);
+
+    /* Transfer size depends on whether we are transferring a Z or a P register. */
+    opnd_size_t memory_transfer_size = is_vector ? OPSZ_SVE_VL : OPSZ_SVE_PL;
 
     if (!opnd_is_base_disp(opnd) || opnd_get_size(opnd) != memory_transfer_size)
         return false;
-    disp = opnd_get_disp(opnd);
-    if (disp < -256 || disp > 255)
-        return false;
-    if (!encode_reg(&rn, &is_x, opnd_get_base(opnd), true) || !is_x)
-        return false;
+    /* As described in decode_opnd_svemem_gpr_simm9_vl(), disp is a multiple of
+     * vector or predicate length at the IR level, transformed to a vector or
+     * predicate index in the encoding.
+     */
+    int vl_bytes = dr_get_sve_vl() / 8;
+    int pl_bytes = vl_bytes / 8;
+    if (is_vector)
+        ASSERT((opnd_get_disp(opnd) % vl_bytes) == 0);
+    else
+        ASSERT((opnd_get_disp(opnd) % pl_bytes) == 0);
+
+    disp = is_vector ? (opnd_get_disp(opnd) / vl_bytes) : (opnd_get_disp(opnd) / pl_bytes);
+    IF_RETURN_FALSE(disp < -256 || disp > 255)
+    IF_RETURN_FALSE(!encode_reg(&rn, &is_x, opnd_get_base(opnd), true) || !is_x)
+
     *enc_out = (rn << 5) | (BITS(disp, 8, 3) << 16) | (BITS(disp, 2, 0) << 10);
     return true;
 }

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5341,8 +5341,9 @@ decode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, OUT opnd_t *opnd
     int vl_bytes = dr_get_sve_vl() / 8;
     int pl_bytes = vl_bytes / 8;
     int mul_len = is_vector ? vl_bytes : pl_bytes;
-    *opnd = opnd_create_base_disp(decode_reg(extract_uint(enc, 5, 5), true, true),
-                                  DR_REG_NULL, 0, offset9 * mul_len, memory_transfer_size);
+    *opnd =
+        opnd_create_base_disp(decode_reg(extract_uint(enc, 5, 5), true, true),
+                              DR_REG_NULL, 0, offset9 * mul_len, memory_transfer_size);
     return true;
 }
 
@@ -5372,7 +5373,8 @@ encode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, opnd_t opnd,
     else
         ASSERT((opnd_get_disp(opnd) % pl_bytes) == 0);
 
-    disp = is_vector ? (opnd_get_disp(opnd) / vl_bytes) : (opnd_get_disp(opnd) / pl_bytes);
+    disp =
+        is_vector ? (opnd_get_disp(opnd) / vl_bytes) : (opnd_get_disp(opnd) / pl_bytes);
     IF_RETURN_FALSE(disp < -256 || disp > 255)
     IF_RETURN_FALSE(!encode_reg(&rn, &is_x, opnd_get_base(opnd), true) || !is_x)
 

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5211,7 +5211,8 @@ encode_opnd_svemem_gpr_simm6_vl(uint enc, int opcode, byte *pc, opnd_t opnd,
      * encoding.
      */
     int vl_bytes = dr_get_sve_vl() / 8;
-    ASSERT((opnd_get_disp(opnd) % vl_bytes) == 0);
+    if ((opnd_get_disp(opnd) % vl_bytes) != 0)
+        return false;
     int disp = opnd_get_disp(opnd) / vl_bytes;
     IF_RETURN_FALSE(disp < -32 || disp > 31)
 
@@ -5368,10 +5369,13 @@ encode_opnd_svemem_gpr_simm9_vl(uint enc, int opcode, byte *pc, opnd_t opnd,
      */
     int vl_bytes = dr_get_sve_vl() / 8;
     int pl_bytes = vl_bytes / 8;
-    if (is_vector)
-        ASSERT((opnd_get_disp(opnd) % vl_bytes) == 0);
-    else
-        ASSERT((opnd_get_disp(opnd) % pl_bytes) == 0);
+    if (is_vector) {
+        if ((opnd_get_disp(opnd) % vl_bytes) != 0)
+            return false;
+    } else {
+        if ((opnd_get_disp(opnd) % pl_bytes) != 0)
+            return false;
+    }
 
     disp =
         is_vector ? (opnd_get_disp(opnd) / vl_bytes) : (opnd_get_disp(opnd) / pl_bytes);

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -15206,101 +15206,101 @@ a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0x07(%sp)[32byte]
 # LDR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
 858003c0 : ldr p0, [x30]                            : ldr    (%x30)[4byte] -> %p0
 858003c0 : ldr p0, [x30]                            : ldr    (%x30)[4byte] -> %p0
-858017a1 : ldr p1, [x29, #5, mul vl]                : ldr    +0x05(%x29)[4byte] -> %p1
-85bf0fa1 : ldr p1, [x29, #-5, mul vl]               : ldr    -0x05(%x29)[4byte] -> %p1
-85810b82 : ldr p2, [x28, #10, mul vl]               : ldr    +0x0a(%x28)[4byte] -> %p2
-85be1b82 : ldr p2, [x28, #-10, mul vl]              : ldr    -0x0a(%x28)[4byte] -> %p2
-85811f63 : ldr p3, [x27, #15, mul vl]               : ldr    +0x0f(%x27)[4byte] -> %p3
-85be0763 : ldr p3, [x27, #-15, mul vl]              : ldr    -0x0f(%x27)[4byte] -> %p3
-85821344 : ldr p4, [x26, #20, mul vl]               : ldr    +0x14(%x26)[4byte] -> %p4
-85bd1344 : ldr p4, [x26, #-20, mul vl]              : ldr    -0x14(%x26)[4byte] -> %p4
-85830725 : ldr p5, [x25, #25, mul vl]               : ldr    +0x19(%x25)[4byte] -> %p5
-85bc1f25 : ldr p5, [x25, #-25, mul vl]              : ldr    -0x19(%x25)[4byte] -> %p5
-85831b06 : ldr p6, [x24, #30, mul vl]               : ldr    +0x1e(%x24)[4byte] -> %p6
-85bc0b06 : ldr p6, [x24, #-30, mul vl]              : ldr    -0x1e(%x24)[4byte] -> %p6
-85840ee7 : ldr p7, [x23, #35, mul vl]               : ldr    +0x23(%x23)[4byte] -> %p7
-85bb16e7 : ldr p7, [x23, #-35, mul vl]              : ldr    -0x23(%x23)[4byte] -> %p7
-858502c8 : ldr p8, [x22, #40, mul vl]               : ldr    +0x28(%x22)[4byte] -> %p8
-85bb02c8 : ldr p8, [x22, #-40, mul vl]              : ldr    -0x28(%x22)[4byte] -> %p8
-858516a9 : ldr p9, [x21, #45, mul vl]               : ldr    +0x2d(%x21)[4byte] -> %p9
-85ba0ea9 : ldr p9, [x21, #-45, mul vl]              : ldr    -0x2d(%x21)[4byte] -> %p9
-85860a8a : ldr p10, [x20, #50, mul vl]              : ldr    +0x32(%x20)[4byte] -> %p10
-85b91a8a : ldr p10, [x20, #-50, mul vl]             : ldr    -0x32(%x20)[4byte] -> %p10
-85861e6b : ldr p11, [x19, #55, mul vl]              : ldr    +0x37(%x19)[4byte] -> %p11
-85b9066b : ldr p11, [x19, #-55, mul vl]             : ldr    -0x37(%x19)[4byte] -> %p11
-8587124c : ldr p12, [x18, #60, mul vl]              : ldr    +0x3c(%x18)[4byte] -> %p12
-85b8124c : ldr p12, [x18, #-60, mul vl]             : ldr    -0x3c(%x18)[4byte] -> %p12
-8588062d : ldr p13, [x17, #65, mul vl]              : ldr    +0x41(%x17)[4byte] -> %p13
-85b71e2d : ldr p13, [x17, #-65, mul vl]             : ldr    -0x41(%x17)[4byte] -> %p13
-85881a0e : ldr p14, [x16, #70, mul vl]              : ldr    +0x46(%x16)[4byte] -> %p14
-85b70a0e : ldr p14, [x16, #-70, mul vl]             : ldr    -0x46(%x16)[4byte] -> %p14
-85890def : ldr p15, [x15, #75, mul vl]              : ldr    +0x4b(%x15)[4byte] -> %p15
-85b615ef : ldr p15, [x15, #-75, mul vl]             : ldr    -0x4b(%x15)[4byte] -> %p15
+858017a1 : ldr p1, [x29, #5, mul vl]                : ldr    +0x14(%x29)[4byte] -> %p1
+85bf0fa1 : ldr p1, [x29, #-5, mul vl]               : ldr    -0x14(%x29)[4byte] -> %p1
+85810b82 : ldr p2, [x28, #10, mul vl]               : ldr    +0x28(%x28)[4byte] -> %p2
+85be1b82 : ldr p2, [x28, #-10, mul vl]              : ldr    -0x28(%x28)[4byte] -> %p2
+85811f63 : ldr p3, [x27, #15, mul vl]               : ldr    +0x3c(%x27)[4byte] -> %p3
+85be0763 : ldr p3, [x27, #-15, mul vl]              : ldr    -0x3c(%x27)[4byte] -> %p3
+85821344 : ldr p4, [x26, #20, mul vl]               : ldr    +0x50(%x26)[4byte] -> %p4
+85bd1344 : ldr p4, [x26, #-20, mul vl]              : ldr    -0x50(%x26)[4byte] -> %p4
+85830725 : ldr p5, [x25, #25, mul vl]               : ldr    +0x64(%x25)[4byte] -> %p5
+85bc1f25 : ldr p5, [x25, #-25, mul vl]              : ldr    -0x64(%x25)[4byte] -> %p5
+85831b06 : ldr p6, [x24, #30, mul vl]               : ldr    +0x78(%x24)[4byte] -> %p6
+85bc0b06 : ldr p6, [x24, #-30, mul vl]              : ldr    -0x78(%x24)[4byte] -> %p6
+85840ee7 : ldr p7, [x23, #35, mul vl]               : ldr    +0x8c(%x23)[4byte] -> %p7
+85bb16e7 : ldr p7, [x23, #-35, mul vl]              : ldr    -0x8c(%x23)[4byte] -> %p7
+858502c8 : ldr p8, [x22, #40, mul vl]               : ldr    +0xa0(%x22)[4byte] -> %p8
+85bb02c8 : ldr p8, [x22, #-40, mul vl]              : ldr    -0xa0(%x22)[4byte] -> %p8
+858516a9 : ldr p9, [x21, #45, mul vl]               : ldr    +0xb4(%x21)[4byte] -> %p9
+85ba0ea9 : ldr p9, [x21, #-45, mul vl]              : ldr    -0xb4(%x21)[4byte] -> %p9
+85860a8a : ldr p10, [x20, #50, mul vl]              : ldr    +0xc8(%x20)[4byte] -> %p10
+85b91a8a : ldr p10, [x20, #-50, mul vl]             : ldr    -0xc8(%x20)[4byte] -> %p10
+85861e6b : ldr p11, [x19, #55, mul vl]              : ldr    +0xdc(%x19)[4byte] -> %p11
+85b9066b : ldr p11, [x19, #-55, mul vl]             : ldr    -0xdc(%x19)[4byte] -> %p11
+8587124c : ldr p12, [x18, #60, mul vl]              : ldr    +0xf0(%x18)[4byte] -> %p12
+85b8124c : ldr p12, [x18, #-60, mul vl]             : ldr    -0xf0(%x18)[4byte] -> %p12
+8588062d : ldr p13, [x17, #65, mul vl]              : ldr    +0x0104(%x17)[4byte] -> %p13
+85b71e2d : ldr p13, [x17, #-65, mul vl]             : ldr    -0x0104(%x17)[4byte] -> %p13
+85881a0e : ldr p14, [x16, #70, mul vl]              : ldr    +0x0118(%x16)[4byte] -> %p14
+85b70a0e : ldr p14, [x16, #-70, mul vl]             : ldr    -0x0118(%x16)[4byte] -> %p14
+85890def : ldr p15, [x15, #75, mul vl]              : ldr    +0x012c(%x15)[4byte] -> %p15
+85b615ef : ldr p15, [x15, #-75, mul vl]             : ldr    -0x012c(%x15)[4byte] -> %p15
 
 # LDR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
 858043c0 : ldr z0, [x30]                            : ldr    (%x30)[32byte] -> %z0
-858057a1 : ldr z1, [x29, #5, mul vl]                : ldr    +0x05(%x29)[32byte] -> %z1
-85bf4fa1 : ldr z1, [x29, #-5, mul vl]               : ldr    -0x05(%x29)[32byte] -> %z1
-85814b82 : ldr z2, [x28, #10, mul vl]               : ldr    +0x0a(%x28)[32byte] -> %z2
-85be5b82 : ldr z2, [x28, #-10, mul vl]              : ldr    -0x0a(%x28)[32byte] -> %z2
-85815f63 : ldr z3, [x27, #15, mul vl]               : ldr    +0x0f(%x27)[32byte] -> %z3
-85be4763 : ldr z3, [x27, #-15, mul vl]              : ldr    -0x0f(%x27)[32byte] -> %z3
-85825344 : ldr z4, [x26, #20, mul vl]               : ldr    +0x14(%x26)[32byte] -> %z4
-85bd5344 : ldr z4, [x26, #-20, mul vl]              : ldr    -0x14(%x26)[32byte] -> %z4
-85834725 : ldr z5, [x25, #25, mul vl]               : ldr    +0x19(%x25)[32byte] -> %z5
-85bc5f25 : ldr z5, [x25, #-25, mul vl]              : ldr    -0x19(%x25)[32byte] -> %z5
-85835b06 : ldr z6, [x24, #30, mul vl]               : ldr    +0x1e(%x24)[32byte] -> %z6
-85bc4b06 : ldr z6, [x24, #-30, mul vl]              : ldr    -0x1e(%x24)[32byte] -> %z6
-85844ee7 : ldr z7, [x23, #35, mul vl]               : ldr    +0x23(%x23)[32byte] -> %z7
-85bb56e7 : ldr z7, [x23, #-35, mul vl]              : ldr    -0x23(%x23)[32byte] -> %z7
-858542c8 : ldr z8, [x22, #40, mul vl]               : ldr    +0x28(%x22)[32byte] -> %z8
-85bb42c8 : ldr z8, [x22, #-40, mul vl]              : ldr    -0x28(%x22)[32byte] -> %z8
-858556a9 : ldr z9, [x21, #45, mul vl]               : ldr    +0x2d(%x21)[32byte] -> %z9
-85ba4ea9 : ldr z9, [x21, #-45, mul vl]              : ldr    -0x2d(%x21)[32byte] -> %z9
-85864a8a : ldr z10, [x20, #50, mul vl]              : ldr    +0x32(%x20)[32byte] -> %z10
-85b95a8a : ldr z10, [x20, #-50, mul vl]             : ldr    -0x32(%x20)[32byte] -> %z10
-85865e6b : ldr z11, [x19, #55, mul vl]              : ldr    +0x37(%x19)[32byte] -> %z11
-85b9466b : ldr z11, [x19, #-55, mul vl]             : ldr    -0x37(%x19)[32byte] -> %z11
-8587524c : ldr z12, [x18, #60, mul vl]              : ldr    +0x3c(%x18)[32byte] -> %z12
-85b8524c : ldr z12, [x18, #-60, mul vl]             : ldr    -0x3c(%x18)[32byte] -> %z12
-8588462d : ldr z13, [x17, #65, mul vl]              : ldr    +0x41(%x17)[32byte] -> %z13
-85b75e2d : ldr z13, [x17, #-65, mul vl]             : ldr    -0x41(%x17)[32byte] -> %z13
-85885a0e : ldr z14, [x16, #70, mul vl]              : ldr    +0x46(%x16)[32byte] -> %z14
-85b74a0e : ldr z14, [x16, #-70, mul vl]             : ldr    -0x46(%x16)[32byte] -> %z14
-85894def : ldr z15, [x15, #75, mul vl]              : ldr    +0x4b(%x15)[32byte] -> %z15
-85b655ef : ldr z15, [x15, #-75, mul vl]             : ldr    -0x4b(%x15)[32byte] -> %z15
-858a41d0 : ldr z16, [x14, #80, mul vl]              : ldr    +0x50(%x14)[32byte] -> %z16
-85b641d0 : ldr z16, [x14, #-80, mul vl]             : ldr    -0x50(%x14)[32byte] -> %z16
-858a55b1 : ldr z17, [x13, #85, mul vl]              : ldr    +0x55(%x13)[32byte] -> %z17
-85b54db1 : ldr z17, [x13, #-85, mul vl]             : ldr    -0x55(%x13)[32byte] -> %z17
-858b4992 : ldr z18, [x12, #90, mul vl]              : ldr    +0x5a(%x12)[32byte] -> %z18
-85b45992 : ldr z18, [x12, #-90, mul vl]             : ldr    -0x5a(%x12)[32byte] -> %z18
-858b5d73 : ldr z19, [x11, #95, mul vl]              : ldr    +0x5f(%x11)[32byte] -> %z19
-85b44573 : ldr z19, [x11, #-95, mul vl]             : ldr    -0x5f(%x11)[32byte] -> %z19
-858c5154 : ldr z20, [x10, #100, mul vl]             : ldr    +0x64(%x10)[32byte] -> %z20
-85b35154 : ldr z20, [x10, #-100, mul vl]            : ldr    -0x64(%x10)[32byte] -> %z20
-858d4535 : ldr z21, [x9, #105, mul vl]              : ldr    +0x69(%x9)[32byte] -> %z21
-85b25d35 : ldr z21, [x9, #-105, mul vl]             : ldr    -0x69(%x9)[32byte] -> %z21
-858d5916 : ldr z22, [x8, #110, mul vl]              : ldr    +0x6e(%x8)[32byte] -> %z22
-85b24916 : ldr z22, [x8, #-110, mul vl]             : ldr    -0x6e(%x8)[32byte] -> %z22
-858e4cf7 : ldr z23, [x7, #115, mul vl]              : ldr    +0x73(%x7)[32byte] -> %z23
-85b154f7 : ldr z23, [x7, #-115, mul vl]             : ldr    -0x73(%x7)[32byte] -> %z23
-858f40d8 : ldr z24, [x6, #120, mul vl]              : ldr    +0x78(%x6)[32byte] -> %z24
-85b140d8 : ldr z24, [x6, #-120, mul vl]             : ldr    -0x78(%x6)[32byte] -> %z24
-858f54b9 : ldr z25, [x5, #125, mul vl]              : ldr    +0x7d(%x5)[32byte] -> %z25
-85b04cb9 : ldr z25, [x5, #-125, mul vl]             : ldr    -0x7d(%x5)[32byte] -> %z25
-8590489a : ldr z26, [x4, #130, mul vl]              : ldr    +0x82(%x4)[32byte] -> %z26
-85af589a : ldr z26, [x4, #-130, mul vl]             : ldr    -0x82(%x4)[32byte] -> %z26
-85905c7b : ldr z27, [x3, #135, mul vl]              : ldr    +0x87(%x3)[32byte] -> %z27
-85af447b : ldr z27, [x3, #-135, mul vl]             : ldr    -0x87(%x3)[32byte] -> %z27
-8591505c : ldr z28, [x2, #140, mul vl]              : ldr    +0x8c(%x2)[32byte] -> %z28
-85ae505c : ldr z28, [x2, #-140, mul vl]             : ldr    -0x8c(%x2)[32byte] -> %z28
-8592443d : ldr z29, [x1, #145, mul vl]              : ldr    +0x91(%x1)[32byte] -> %z29
-85ad5c3d : ldr z29, [x1, #-145, mul vl]             : ldr    -0x91(%x1)[32byte] -> %z29
-8592581e : ldr z30, [x0, #150, mul vl]              : ldr    +0x96(%x0)[32byte] -> %z30
-85ad481e : ldr z30, [x0, #-150, mul vl]             : ldr    -0x96(%x0)[32byte] -> %z30
-85934fdf : ldr z31, [x30, #155, mul vl]             : ldr    +0x9b(%x30)[32byte] -> %z31
-85ac57df : ldr z31, [x30, #-155, mul vl]            : ldr    -0x9b(%x30)[32byte] -> %z31
+858057a1 : ldr z1, [x29, #5, mul vl]                : ldr    +0xa0(%x29)[32byte] -> %z1
+85bf4fa1 : ldr z1, [x29, #-5, mul vl]               : ldr    -0xa0(%x29)[32byte] -> %z1
+85814b82 : ldr z2, [x28, #10, mul vl]               : ldr    +0x0140(%x28)[32byte] -> %z2
+85be5b82 : ldr z2, [x28, #-10, mul vl]              : ldr    -0x0140(%x28)[32byte] -> %z2
+85815f63 : ldr z3, [x27, #15, mul vl]               : ldr    +0x01e0(%x27)[32byte] -> %z3
+85be4763 : ldr z3, [x27, #-15, mul vl]              : ldr    -0x01e0(%x27)[32byte] -> %z3
+85825344 : ldr z4, [x26, #20, mul vl]               : ldr    +0x0280(%x26)[32byte] -> %z4
+85bd5344 : ldr z4, [x26, #-20, mul vl]              : ldr    -0x0280(%x26)[32byte] -> %z4
+85834725 : ldr z5, [x25, #25, mul vl]               : ldr    +0x0320(%x25)[32byte] -> %z5
+85bc5f25 : ldr z5, [x25, #-25, mul vl]              : ldr    -0x0320(%x25)[32byte] -> %z5
+85835b06 : ldr z6, [x24, #30, mul vl]               : ldr    +0x03c0(%x24)[32byte] -> %z6
+85bc4b06 : ldr z6, [x24, #-30, mul vl]              : ldr    -0x03c0(%x24)[32byte] -> %z6
+85844ee7 : ldr z7, [x23, #35, mul vl]               : ldr    +0x0460(%x23)[32byte] -> %z7
+85bb56e7 : ldr z7, [x23, #-35, mul vl]              : ldr    -0x0460(%x23)[32byte] -> %z7
+858542c8 : ldr z8, [x22, #40, mul vl]               : ldr    +0x0500(%x22)[32byte] -> %z8
+85bb42c8 : ldr z8, [x22, #-40, mul vl]              : ldr    -0x0500(%x22)[32byte] -> %z8
+858556a9 : ldr z9, [x21, #45, mul vl]               : ldr    +0x05a0(%x21)[32byte] -> %z9
+85ba4ea9 : ldr z9, [x21, #-45, mul vl]              : ldr    -0x05a0(%x21)[32byte] -> %z9
+85864a8a : ldr z10, [x20, #50, mul vl]              : ldr    +0x0640(%x20)[32byte] -> %z10
+85b95a8a : ldr z10, [x20, #-50, mul vl]             : ldr    -0x0640(%x20)[32byte] -> %z10
+85865e6b : ldr z11, [x19, #55, mul vl]              : ldr    +0x06e0(%x19)[32byte] -> %z11
+85b9466b : ldr z11, [x19, #-55, mul vl]             : ldr    -0x06e0(%x19)[32byte] -> %z11
+8587524c : ldr z12, [x18, #60, mul vl]              : ldr    +0x0780(%x18)[32byte] -> %z12
+85b8524c : ldr z12, [x18, #-60, mul vl]             : ldr    -0x0780(%x18)[32byte] -> %z12
+8588462d : ldr z13, [x17, #65, mul vl]              : ldr    +0x0820(%x17)[32byte] -> %z13
+85b75e2d : ldr z13, [x17, #-65, mul vl]             : ldr    -0x0820(%x17)[32byte] -> %z13
+85885a0e : ldr z14, [x16, #70, mul vl]              : ldr    +0x08c0(%x16)[32byte] -> %z14
+85b74a0e : ldr z14, [x16, #-70, mul vl]             : ldr    -0x08c0(%x16)[32byte] -> %z14
+85894def : ldr z15, [x15, #75, mul vl]              : ldr    +0x0960(%x15)[32byte] -> %z15
+85b655ef : ldr z15, [x15, #-75, mul vl]             : ldr    -0x0960(%x15)[32byte] -> %z15
+858a41d0 : ldr z16, [x14, #80, mul vl]              : ldr    +0x0a00(%x14)[32byte] -> %z16
+85b641d0 : ldr z16, [x14, #-80, mul vl]             : ldr    -0x0a00(%x14)[32byte] -> %z16
+858a55b1 : ldr z17, [x13, #85, mul vl]              : ldr    +0x0aa0(%x13)[32byte] -> %z17
+85b54db1 : ldr z17, [x13, #-85, mul vl]             : ldr    -0x0aa0(%x13)[32byte] -> %z17
+858b4992 : ldr z18, [x12, #90, mul vl]              : ldr    +0x0b40(%x12)[32byte] -> %z18
+85b45992 : ldr z18, [x12, #-90, mul vl]             : ldr    -0x0b40(%x12)[32byte] -> %z18
+858b5d73 : ldr z19, [x11, #95, mul vl]              : ldr    +0x0be0(%x11)[32byte] -> %z19
+85b44573 : ldr z19, [x11, #-95, mul vl]             : ldr    -0x0be0(%x11)[32byte] -> %z19
+858c5154 : ldr z20, [x10, #100, mul vl]             : ldr    +0x0c80(%x10)[32byte] -> %z20
+85b35154 : ldr z20, [x10, #-100, mul vl]            : ldr    -0x0c80(%x10)[32byte] -> %z20
+858d4535 : ldr z21, [x9, #105, mul vl]              : ldr    +0x0d20(%x9)[32byte] -> %z21
+85b25d35 : ldr z21, [x9, #-105, mul vl]             : ldr    -0x0d20(%x9)[32byte] -> %z21
+858d5916 : ldr z22, [x8, #110, mul vl]              : ldr    +0x0dc0(%x8)[32byte] -> %z22
+85b24916 : ldr z22, [x8, #-110, mul vl]             : ldr    -0x0dc0(%x8)[32byte] -> %z22
+858e4cf7 : ldr z23, [x7, #115, mul vl]              : ldr    +0x0e60(%x7)[32byte] -> %z23
+85b154f7 : ldr z23, [x7, #-115, mul vl]             : ldr    -0x0e60(%x7)[32byte] -> %z23
+858f40d8 : ldr z24, [x6, #120, mul vl]              : ldr    +0x0f00(%x6)[32byte] -> %z24
+85b140d8 : ldr z24, [x6, #-120, mul vl]             : ldr    -0x0f00(%x6)[32byte] -> %z24
+858f54b9 : ldr z25, [x5, #125, mul vl]              : ldr    +0x0fa0(%x5)[32byte] -> %z25
+85b04cb9 : ldr z25, [x5, #-125, mul vl]             : ldr    -0x0fa0(%x5)[32byte] -> %z25
+8590489a : ldr z26, [x4, #130, mul vl]              : ldr    +0x1040(%x4)[32byte] -> %z26
+85af589a : ldr z26, [x4, #-130, mul vl]             : ldr    -0x1040(%x4)[32byte] -> %z26
+85905c7b : ldr z27, [x3, #135, mul vl]              : ldr    +0x10e0(%x3)[32byte] -> %z27
+85af447b : ldr z27, [x3, #-135, mul vl]             : ldr    -0x10e0(%x3)[32byte] -> %z27
+8591505c : ldr z28, [x2, #140, mul vl]              : ldr    +0x1180(%x2)[32byte] -> %z28
+85ae505c : ldr z28, [x2, #-140, mul vl]             : ldr    -0x1180(%x2)[32byte] -> %z28
+8592443d : ldr z29, [x1, #145, mul vl]              : ldr    +0x1220(%x1)[32byte] -> %z29
+85ad5c3d : ldr z29, [x1, #-145, mul vl]             : ldr    -0x1220(%x1)[32byte] -> %z29
+8592581e : ldr z30, [x0, #150, mul vl]              : ldr    +0x12c0(%x0)[32byte] -> %z30
+85ad481e : ldr z30, [x0, #-150, mul vl]             : ldr    -0x12c0(%x0)[32byte] -> %z30
+85934fdf : ldr z31, [x30, #155, mul vl]             : ldr    +0x1360(%x30)[32byte] -> %z31
+85ac57df : ldr z31, [x30, #-155, mul vl]            : ldr    -0x1360(%x30)[32byte] -> %z31
 
 # LSL     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, #<const> (LSL-Z.P.ZI-_)
 04038100 : lsl z0.b, p0/M, z0.b, #0x0                : lsl    %p0/m %z0.b $0x00 -> %z0.b
@@ -17235,22 +17235,22 @@ a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0x07(%sp)[32byte]
 847f1fef : prfb 15, p7, [sp, z31.s, SXTW]            : prfb   $0x0f %p7 (%sp,%z31.s,sxtw)
 
 # PRFB    <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}] (PRFB-I.P.BI-S)
-85e00000 : prfb PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfb   $0x00 %p0 -0x20(%x0)
-85e40481 : prfb PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfb   $0x01 %p1 -0x1c(%x4)
-85e808c2 : prfb PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfb   $0x02 %p2 -0x18(%x6)
-85ec0903 : prfb PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfb   $0x03 %p2 -0x14(%x8)
-85f00d44 : prfb PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfb   $0x04 %p3 -0x10(%x10)
-85f40d65 : prfb PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfb   $0x05 %p3 -0x0c(%x11)
-85f811a6 : prfb 6, p4, [x13, #-8, MUL VL]            : prfb   $0x06 %p4 -0x08(%x13)
-85fc11e7 : prfb 7, p4, [x15, #-4, MUL VL]            : prfb   $0x07 %p4 -0x04(%x15)
+85e00000 : prfb PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfb   $0x00 %p0 -0x0400(%x0)
+85e40481 : prfb PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfb   $0x01 %p1 -0x0380(%x4)
+85e808c2 : prfb PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfb   $0x02 %p2 -0x0300(%x6)
+85ec0903 : prfb PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfb   $0x03 %p2 -0x0280(%x8)
+85f00d44 : prfb PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfb   $0x04 %p3 -0x0200(%x10)
+85f40d65 : prfb PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfb   $0x05 %p3 -0x0180(%x11)
+85f811a6 : prfb 6, p4, [x13, #-8, MUL VL]            : prfb   $0x06 %p4 -0x0100(%x13)
+85fc11e7 : prfb 7, p4, [x15, #-4, MUL VL]            : prfb   $0x07 %p4 -0x80(%x15)
 85c01628 : prfb PSTL1KEEP, p5, [x17, #0, MUL VL]     : prfb   $0x08 %p5 (%x17)
-85c31669 : prfb PSTL1STRM, p5, [x19, #3, MUL VL]     : prfb   $0x09 %p5 +0x03(%x19)
-85c716aa : prfb PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfb   $0x0a %p5 +0x07(%x21)
-85cb1aeb : prfb PSTL2STRM, p6, [x23, #11, MUL VL]    : prfb   $0x0b %p6 +0x0b(%x23)
-85cf1b0c : prfb PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfb   $0x0c %p6 +0x0f(%x24)
-85d31f4d : prfb PSTL3STRM, p7, [x26, #19, MUL VL]    : prfb   $0x0d %p7 +0x13(%x26)
-85d71f8e : prfb 14, p7, [x28, #23, MUL VL]           : prfb   $0x0e %p7 +0x17(%x28)
-85df1fef : prfb 15, p7, [sp, #31, MUL VL]            : prfb   $0x0f %p7 +0x1f(%sp)
+85c31669 : prfb PSTL1STRM, p5, [x19, #3, MUL VL]     : prfb   $0x09 %p5 +0x60(%x19)
+85c716aa : prfb PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfb   $0x0a %p5 +0xe0(%x21)
+85cb1aeb : prfb PSTL2STRM, p6, [x23, #11, MUL VL]    : prfb   $0x0b %p6 +0x0160(%x23)
+85cf1b0c : prfb PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfb   $0x0c %p6 +0x01e0(%x24)
+85d31f4d : prfb PSTL3STRM, p7, [x26, #19, MUL VL]    : prfb   $0x0d %p7 +0x0260(%x26)
+85d71f8e : prfb 14, p7, [x28, #23, MUL VL]           : prfb   $0x0e %p7 +0x02e0(%x28)
+85df1fef : prfb 15, p7, [sp, #31, MUL VL]            : prfb   $0x0f %p7 +0x03e0(%sp)
 
 # PRFB    <prfop>, <Pg>, [<Zn>.D{, #<imm>}] (PRFB-I.P.AI-D)
 c400e000 : prfb PLDL1KEEP, p0, [z0.d, #0]            : prfb   $0x00 %p0 (%z0.d)
@@ -17393,22 +17393,22 @@ c47f9fef : prfb 15, p7, [sp, z31.d]                  : prfb   $0x0f %p7 (%sp,%z3
 859fffef : prfd 15, p7, [z31.s, #248]                : prfd   $0x0f %p7 +0xf8(%z31.s)
 
 # PRFD    <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}] (PRFD-I.P.BI-S)
-85e06000 : prfd PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfd   $0x00 %p0 -0x20(%x0)
-85e46481 : prfd PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfd   $0x01 %p1 -0x1c(%x4)
-85e868c2 : prfd PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfd   $0x02 %p2 -0x18(%x6)
-85ec6903 : prfd PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfd   $0x03 %p2 -0x14(%x8)
-85f06d44 : prfd PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfd   $0x04 %p3 -0x10(%x10)
-85f46d65 : prfd PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfd   $0x05 %p3 -0x0c(%x11)
-85f871a6 : prfd 6, p4, [x13, #-8, MUL VL]            : prfd   $0x06 %p4 -0x08(%x13)
-85fc71e7 : prfd 7, p4, [x15, #-4, MUL VL]            : prfd   $0x07 %p4 -0x04(%x15)
+85e06000 : prfd PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfd   $0x00 %p0 -0x0400(%x0)
+85e46481 : prfd PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfd   $0x01 %p1 -0x0380(%x4)
+85e868c2 : prfd PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfd   $0x02 %p2 -0x0300(%x6)
+85ec6903 : prfd PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfd   $0x03 %p2 -0x0280(%x8)
+85f06d44 : prfd PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfd   $0x04 %p3 -0x0200(%x10)
+85f46d65 : prfd PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfd   $0x05 %p3 -0x0180(%x11)
+85f871a6 : prfd 6, p4, [x13, #-8, MUL VL]            : prfd   $0x06 %p4 -0x0100(%x13)
+85fc71e7 : prfd 7, p4, [x15, #-4, MUL VL]            : prfd   $0x07 %p4 -0x80(%x15)
 85c07628 : prfd PSTL1KEEP, p5, [x17, #0, MUL VL]     : prfd   $0x08 %p5 (%x17)
-85c37669 : prfd PSTL1STRM, p5, [x19, #3, MUL VL]     : prfd   $0x09 %p5 +0x03(%x19)
-85c776aa : prfd PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfd   $0x0a %p5 +0x07(%x21)
-85cb7aeb : prfd PSTL2STRM, p6, [x23, #11, MUL VL]    : prfd   $0x0b %p6 +0x0b(%x23)
-85cf7b0c : prfd PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfd   $0x0c %p6 +0x0f(%x24)
-85d37f4d : prfd PSTL3STRM, p7, [x26, #19, MUL VL]    : prfd   $0x0d %p7 +0x13(%x26)
-85d77f8e : prfd 14, p7, [x28, #23, MUL VL]           : prfd   $0x0e %p7 +0x17(%x28)
-85df7fef : prfd 15, p7, [sp, #31, MUL VL]            : prfd   $0x0f %p7 +0x1f(%sp)
+85c37669 : prfd PSTL1STRM, p5, [x19, #3, MUL VL]     : prfd   $0x09 %p5 +0x60(%x19)
+85c776aa : prfd PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfd   $0x0a %p5 +0xe0(%x21)
+85cb7aeb : prfd PSTL2STRM, p6, [x23, #11, MUL VL]    : prfd   $0x0b %p6 +0x0160(%x23)
+85cf7b0c : prfd PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfd   $0x0c %p6 +0x01e0(%x24)
+85d37f4d : prfd PSTL3STRM, p7, [x26, #19, MUL VL]    : prfd   $0x0d %p7 +0x0260(%x26)
+85d77f8e : prfd 14, p7, [x28, #23, MUL VL]           : prfd   $0x0e %p7 +0x02e0(%x28)
+85df7fef : prfd 15, p7, [sp, #31, MUL VL]            : prfd   $0x0f %p7 +0x03e0(%sp)
 
 # PRFD    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #3] (PRFD-I.P.BZ-D.x32.scaled)
 c4206000 : prfd PLDL1KEEP, p0, [x0, z0.d, UXTW #3]   : prfd   $0x00 %p0 (%x0,%z0.d,uxtw #3)
@@ -17551,22 +17551,22 @@ c59fffef : prfd 15, p7, [z31.d, #248]                : prfd   $0x0f %p7 +0xf8(%z
 849fffef : prfh 15, p7, [z31.s, #62]                 : prfh   $0x0f %p7 +0x3e(%z31.s)
 
 # PRFH    <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}] (PRFH-I.P.BI-S)
-85e02000 : prfh PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfh   $0x00 %p0 -0x20(%x0)
-85e42481 : prfh PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfh   $0x01 %p1 -0x1c(%x4)
-85e828c2 : prfh PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfh   $0x02 %p2 -0x18(%x6)
-85ec2903 : prfh PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfh   $0x03 %p2 -0x14(%x8)
-85f02d44 : prfh PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfh   $0x04 %p3 -0x10(%x10)
-85f42d65 : prfh PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfh   $0x05 %p3 -0x0c(%x11)
-85f831a6 : prfh 6, p4, [x13, #-8, MUL VL]            : prfh   $0x06 %p4 -0x08(%x13)
-85fc31e7 : prfh 7, p4, [x15, #-4, MUL VL]            : prfh   $0x07 %p4 -0x04(%x15)
+85e02000 : prfh PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfh   $0x00 %p0 -0x0400(%x0)
+85e42481 : prfh PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfh   $0x01 %p1 -0x0380(%x4)
+85e828c2 : prfh PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfh   $0x02 %p2 -0x0300(%x6)
+85ec2903 : prfh PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfh   $0x03 %p2 -0x0280(%x8)
+85f02d44 : prfh PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfh   $0x04 %p3 -0x0200(%x10)
+85f42d65 : prfh PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfh   $0x05 %p3 -0x0180(%x11)
+85f831a6 : prfh 6, p4, [x13, #-8, MUL VL]            : prfh   $0x06 %p4 -0x0100(%x13)
+85fc31e7 : prfh 7, p4, [x15, #-4, MUL VL]            : prfh   $0x07 %p4 -0x80(%x15)
 85c03628 : prfh PSTL1KEEP, p5, [x17, #0, MUL VL]     : prfh   $0x08 %p5 (%x17)
-85c33669 : prfh PSTL1STRM, p5, [x19, #3, MUL VL]     : prfh   $0x09 %p5 +0x03(%x19)
-85c736aa : prfh PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfh   $0x0a %p5 +0x07(%x21)
-85cb3aeb : prfh PSTL2STRM, p6, [x23, #11, MUL VL]    : prfh   $0x0b %p6 +0x0b(%x23)
-85cf3b0c : prfh PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfh   $0x0c %p6 +0x0f(%x24)
-85d33f4d : prfh PSTL3STRM, p7, [x26, #19, MUL VL]    : prfh   $0x0d %p7 +0x13(%x26)
-85d73f8e : prfh 14, p7, [x28, #23, MUL VL]           : prfh   $0x0e %p7 +0x17(%x28)
-85df3fef : prfh 15, p7, [sp, #31, MUL VL]            : prfh   $0x0f %p7 +0x1f(%sp)
+85c33669 : prfh PSTL1STRM, p5, [x19, #3, MUL VL]     : prfh   $0x09 %p5 +0x60(%x19)
+85c736aa : prfh PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfh   $0x0a %p5 +0xe0(%x21)
+85cb3aeb : prfh PSTL2STRM, p6, [x23, #11, MUL VL]    : prfh   $0x0b %p6 +0x0160(%x23)
+85cf3b0c : prfh PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfh   $0x0c %p6 +0x01e0(%x24)
+85d33f4d : prfh PSTL3STRM, p7, [x26, #19, MUL VL]    : prfh   $0x0d %p7 +0x0260(%x26)
+85d73f8e : prfh 14, p7, [x28, #23, MUL VL]           : prfh   $0x0e %p7 +0x02e0(%x28)
+85df3fef : prfh 15, p7, [sp, #31, MUL VL]            : prfh   $0x0f %p7 +0x03e0(%sp)
 
 # PRFH    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #1] (PRFH-I.P.BZ-D.x32.scaled)
 c4202000 : prfh PLDL1KEEP, p0, [x0, z0.d, UXTW #1]   : prfh   $0x00 %p0 (%x0,%z0.d,uxtw #1)
@@ -17709,22 +17709,22 @@ c49fffef : prfh 15, p7, [z31.d, #62]                 : prfh   $0x0f %p7 +0x3e(%z
 851fffef : prfw 15, p7, [z31.s, #124]                : prfw   $0x0f %p7 +0x7c(%z31.s)
 
 # PRFW    <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}] (PRFW-I.P.BI-S)
-85e04000 : prfw PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfw   $0x00 %p0 -0x20(%x0)
-85e44481 : prfw PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfw   $0x01 %p1 -0x1c(%x4)
-85e848c2 : prfw PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfw   $0x02 %p2 -0x18(%x6)
-85ec4903 : prfw PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfw   $0x03 %p2 -0x14(%x8)
-85f04d44 : prfw PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfw   $0x04 %p3 -0x10(%x10)
-85f44d65 : prfw PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfw   $0x05 %p3 -0x0c(%x11)
-85f851a6 : prfw 6, p4, [x13, #-8, MUL VL]            : prfw   $0x06 %p4 -0x08(%x13)
-85fc51e7 : prfw 7, p4, [x15, #-4, MUL VL]            : prfw   $0x07 %p4 -0x04(%x15)
+85e04000 : prfw PLDL1KEEP, p0, [x0, #-32, MUL VL]    : prfw   $0x00 %p0 -0x0400(%x0)
+85e44481 : prfw PLDL1STRM, p1, [x4, #-28, MUL VL]    : prfw   $0x01 %p1 -0x0380(%x4)
+85e848c2 : prfw PLDL2KEEP, p2, [x6, #-24, MUL VL]    : prfw   $0x02 %p2 -0x0300(%x6)
+85ec4903 : prfw PLDL2STRM, p2, [x8, #-20, MUL VL]    : prfw   $0x03 %p2 -0x0280(%x8)
+85f04d44 : prfw PLDL3KEEP, p3, [x10, #-16, MUL VL]   : prfw   $0x04 %p3 -0x0200(%x10)
+85f44d65 : prfw PLDL3STRM, p3, [x11, #-12, MUL VL]   : prfw   $0x05 %p3 -0x0180(%x11)
+85f851a6 : prfw 6, p4, [x13, #-8, MUL VL]            : prfw   $0x06 %p4 -0x0100(%x13)
+85fc51e7 : prfw 7, p4, [x15, #-4, MUL VL]            : prfw   $0x07 %p4 -0x80(%x15)
 85c05628 : prfw PSTL1KEEP, p5, [x17, #0, MUL VL]     : prfw   $0x08 %p5 (%x17)
-85c35669 : prfw PSTL1STRM, p5, [x19, #3, MUL VL]     : prfw   $0x09 %p5 +0x03(%x19)
-85c756aa : prfw PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfw   $0x0a %p5 +0x07(%x21)
-85cb5aeb : prfw PSTL2STRM, p6, [x23, #11, MUL VL]    : prfw   $0x0b %p6 +0x0b(%x23)
-85cf5b0c : prfw PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfw   $0x0c %p6 +0x0f(%x24)
-85d35f4d : prfw PSTL3STRM, p7, [x26, #19, MUL VL]    : prfw   $0x0d %p7 +0x13(%x26)
-85d75f8e : prfw 14, p7, [x28, #23, MUL VL]           : prfw   $0x0e %p7 +0x17(%x28)
-85df5fef : prfw 15, p7, [sp, #31, MUL VL]            : prfw   $0x0f %p7 +0x1f(%sp)
+85c35669 : prfw PSTL1STRM, p5, [x19, #3, MUL VL]     : prfw   $0x09 %p5 +0x60(%x19)
+85c756aa : prfw PSTL2KEEP, p5, [x21, #7, MUL VL]     : prfw   $0x0a %p5 +0xe0(%x21)
+85cb5aeb : prfw PSTL2STRM, p6, [x23, #11, MUL VL]    : prfw   $0x0b %p6 +0x0160(%x23)
+85cf5b0c : prfw PSTL3KEEP, p6, [x24, #15, MUL VL]    : prfw   $0x0c %p6 +0x01e0(%x24)
+85d35f4d : prfw PSTL3STRM, p7, [x26, #19, MUL VL]    : prfw   $0x0d %p7 +0x0260(%x26)
+85d75f8e : prfw 14, p7, [x28, #23, MUL VL]           : prfw   $0x0e %p7 +0x02e0(%x28)
+85df5fef : prfw 15, p7, [sp, #31, MUL VL]            : prfw   $0x0f %p7 +0x03e0(%sp)
 
 # PRFW    <prfop>, <Pg>, [<Xn|SP>, <Zm>.D, <extend> #2] (PRFW-I.P.BZ-D.x32.scaled)
 c4204000 : prfw PLDL1KEEP, p0, [x0, z0.d, UXTW #2]   : prfw   $0x00 %p0 (%x0,%z0.d,uxtw #2)
@@ -22446,102 +22446,101 @@ e517ffff : stnt1w z31.s, p7, [sp, #7, MUL VL]        : stnt1w %z31.s %p7 -> +0x0
 # STR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
 e58003c0 : str p0, [x30]                            : str    %p0 -> (%x30)[4byte]
 e58003c0 : str p0, [x30]                            : str    %p0 -> (%x30)[4byte]
-e58017a1 : str p1, [x29, #5, mul vl]                : str    %p1 -> +0x05(%x29)[4byte]
-e5bf0fa1 : str p1, [x29, #-5, mul vl]               : str    %p1 -> -0x05(%x29)[4byte]
-e5810b82 : str p2, [x28, #10, mul vl]               : str    %p2 -> +0x0a(%x28)[4byte]
-e5be1b82 : str p2, [x28, #-10, mul vl]              : str    %p2 -> -0x0a(%x28)[4byte]
-e5811f63 : str p3, [x27, #15, mul vl]               : str    %p3 -> +0x0f(%x27)[4byte]
-e5be0763 : str p3, [x27, #-15, mul vl]              : str    %p3 -> -0x0f(%x27)[4byte]
-e5821344 : str p4, [x26, #20, mul vl]               : str    %p4 -> +0x14(%x26)[4byte]
-e5bd1344 : str p4, [x26, #-20, mul vl]              : str    %p4 -> -0x14(%x26)[4byte]
-e5830725 : str p5, [x25, #25, mul vl]               : str    %p5 -> +0x19(%x25)[4byte]
-e5bc1f25 : str p5, [x25, #-25, mul vl]              : str    %p5 -> -0x19(%x25)[4byte]
-e5831b06 : str p6, [x24, #30, mul vl]               : str    %p6 -> +0x1e(%x24)[4byte]
-e5bc0b06 : str p6, [x24, #-30, mul vl]              : str    %p6 -> -0x1e(%x24)[4byte]
-e5840ee7 : str p7, [x23, #35, mul vl]               : str    %p7 -> +0x23(%x23)[4byte]
-e5bb16e7 : str p7, [x23, #-35, mul vl]              : str    %p7 -> -0x23(%x23)[4byte]
-e58502c8 : str p8, [x22, #40, mul vl]               : str    %p8 -> +0x28(%x22)[4byte]
-e5bb02c8 : str p8, [x22, #-40, mul vl]              : str    %p8 -> -0x28(%x22)[4byte]
-e58516a9 : str p9, [x21, #45, mul vl]               : str    %p9 -> +0x2d(%x21)[4byte]
-e5ba0ea9 : str p9, [x21, #-45, mul vl]              : str    %p9 -> -0x2d(%x21)[4byte]
-e5860a8a : str p10, [x20, #50, mul vl]              : str    %p10 -> +0x32(%x20)[4byte]
-e5b91a8a : str p10, [x20, #-50, mul vl]             : str    %p10 -> -0x32(%x20)[4byte]
-e5861e6b : str p11, [x19, #55, mul vl]              : str    %p11 -> +0x37(%x19)[4byte]
-e5b9066b : str p11, [x19, #-55, mul vl]             : str    %p11 -> -0x37(%x19)[4byte]
-e587124c : str p12, [x18, #60, mul vl]              : str    %p12 -> +0x3c(%x18)[4byte]
-e5b8124c : str p12, [x18, #-60, mul vl]             : str    %p12 -> -0x3c(%x18)[4byte]
-e588062d : str p13, [x17, #65, mul vl]              : str    %p13 -> +0x41(%x17)[4byte]
-e5b71e2d : str p13, [x17, #-65, mul vl]             : str    %p13 -> -0x41(%x17)[4byte]
-e5881a0e : str p14, [x16, #70, mul vl]              : str    %p14 -> +0x46(%x16)[4byte]
-e5b70a0e : str p14, [x16, #-70, mul vl]             : str    %p14 -> -0x46(%x16)[4byte]
-e5890def : str p15, [x15, #75, mul vl]              : str    %p15 -> +0x4b(%x15)[4byte]
-e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x4b(%x15)[4byte]
+e58017a1 : str p1, [x29, #5, mul vl]                : str    %p1 -> +0x14(%x29)[4byte]
+e5bf0fa1 : str p1, [x29, #-5, mul vl]               : str    %p1 -> -0x14(%x29)[4byte]
+e5810b82 : str p2, [x28, #10, mul vl]               : str    %p2 -> +0x28(%x28)[4byte]
+e5be1b82 : str p2, [x28, #-10, mul vl]              : str    %p2 -> -0x28(%x28)[4byte]
+e5811f63 : str p3, [x27, #15, mul vl]               : str    %p3 -> +0x3c(%x27)[4byte]
+e5be0763 : str p3, [x27, #-15, mul vl]              : str    %p3 -> -0x3c(%x27)[4byte]
+e5821344 : str p4, [x26, #20, mul vl]               : str    %p4 -> +0x50(%x26)[4byte]
+e5bd1344 : str p4, [x26, #-20, mul vl]              : str    %p4 -> -0x50(%x26)[4byte]
+e5830725 : str p5, [x25, #25, mul vl]               : str    %p5 -> +0x64(%x25)[4byte]
+e5bc1f25 : str p5, [x25, #-25, mul vl]              : str    %p5 -> -0x64(%x25)[4byte]
+e5831b06 : str p6, [x24, #30, mul vl]               : str    %p6 -> +0x78(%x24)[4byte]
+e5bc0b06 : str p6, [x24, #-30, mul vl]              : str    %p6 -> -0x78(%x24)[4byte]
+e5840ee7 : str p7, [x23, #35, mul vl]               : str    %p7 -> +0x8c(%x23)[4byte]
+e5bb16e7 : str p7, [x23, #-35, mul vl]              : str    %p7 -> -0x8c(%x23)[4byte]
+e58502c8 : str p8, [x22, #40, mul vl]               : str    %p8 -> +0xa0(%x22)[4byte]
+e5bb02c8 : str p8, [x22, #-40, mul vl]              : str    %p8 -> -0xa0(%x22)[4byte]
+e58516a9 : str p9, [x21, #45, mul vl]               : str    %p9 -> +0xb4(%x21)[4byte]
+e5ba0ea9 : str p9, [x21, #-45, mul vl]              : str    %p9 -> -0xb4(%x21)[4byte]
+e5860a8a : str p10, [x20, #50, mul vl]              : str    %p10 -> +0xc8(%x20)[4byte]
+e5b91a8a : str p10, [x20, #-50, mul vl]             : str    %p10 -> -0xc8(%x20)[4byte]
+e5861e6b : str p11, [x19, #55, mul vl]              : str    %p11 -> +0xdc(%x19)[4byte]
+e5b9066b : str p11, [x19, #-55, mul vl]             : str    %p11 -> -0xdc(%x19)[4byte]
+e587124c : str p12, [x18, #60, mul vl]              : str    %p12 -> +0xf0(%x18)[4byte]
+e5b8124c : str p12, [x18, #-60, mul vl]             : str    %p12 -> -0xf0(%x18)[4byte]
+e588062d : str p13, [x17, #65, mul vl]              : str    %p13 -> +0x0104(%x17)[4byte]
+e5b71e2d : str p13, [x17, #-65, mul vl]             : str    %p13 -> -0x0104(%x17)[4byte]
+e5881a0e : str p14, [x16, #70, mul vl]              : str    %p14 -> +0x0118(%x16)[4byte]
+e5b70a0e : str p14, [x16, #-70, mul vl]             : str    %p14 -> -0x0118(%x16)[4byte]
+e5890def : str p15, [x15, #75, mul vl]              : str    %p15 -> +0x012c(%x15)[4byte]
+e5b615ef : str p15, [x15, #-75, mul vl]             : str    %p15 -> -0x012c(%x15)[4byte]
 
 # STR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
 e58043c0 : str z0, [x30]                            : str    %z0 -> (%x30)[32byte]
-e58043c0 : str z0, [x30]                            : str    %z0 -> (%x30)[32byte]
-e58057a1 : str z1, [x29, #5, mul vl]                : str    %z1 -> +0x05(%x29)[32byte]
-e5bf4fa1 : str z1, [x29, #-5, mul vl]               : str    %z1 -> -0x05(%x29)[32byte]
-e5814b82 : str z2, [x28, #10, mul vl]               : str    %z2 -> +0x0a(%x28)[32byte]
-e5be5b82 : str z2, [x28, #-10, mul vl]              : str    %z2 -> -0x0a(%x28)[32byte]
-e5815f63 : str z3, [x27, #15, mul vl]               : str    %z3 -> +0x0f(%x27)[32byte]
-e5be4763 : str z3, [x27, #-15, mul vl]              : str    %z3 -> -0x0f(%x27)[32byte]
-e5825344 : str z4, [x26, #20, mul vl]               : str    %z4 -> +0x14(%x26)[32byte]
-e5bd5344 : str z4, [x26, #-20, mul vl]              : str    %z4 -> -0x14(%x26)[32byte]
-e5834725 : str z5, [x25, #25, mul vl]               : str    %z5 -> +0x19(%x25)[32byte]
-e5bc5f25 : str z5, [x25, #-25, mul vl]              : str    %z5 -> -0x19(%x25)[32byte]
-e5835b06 : str z6, [x24, #30, mul vl]               : str    %z6 -> +0x1e(%x24)[32byte]
-e5bc4b06 : str z6, [x24, #-30, mul vl]              : str    %z6 -> -0x1e(%x24)[32byte]
-e5844ee7 : str z7, [x23, #35, mul vl]               : str    %z7 -> +0x23(%x23)[32byte]
-e5bb56e7 : str z7, [x23, #-35, mul vl]              : str    %z7 -> -0x23(%x23)[32byte]
-e58542c8 : str z8, [x22, #40, mul vl]               : str    %z8 -> +0x28(%x22)[32byte]
-e5bb42c8 : str z8, [x22, #-40, mul vl]              : str    %z8 -> -0x28(%x22)[32byte]
-e58556a9 : str z9, [x21, #45, mul vl]               : str    %z9 -> +0x2d(%x21)[32byte]
-e5ba4ea9 : str z9, [x21, #-45, mul vl]              : str    %z9 -> -0x2d(%x21)[32byte]
-e5864a8a : str z10, [x20, #50, mul vl]              : str    %z10 -> +0x32(%x20)[32byte]
-e5b95a8a : str z10, [x20, #-50, mul vl]             : str    %z10 -> -0x32(%x20)[32byte]
-e5865e6b : str z11, [x19, #55, mul vl]              : str    %z11 -> +0x37(%x19)[32byte]
-e5b9466b : str z11, [x19, #-55, mul vl]             : str    %z11 -> -0x37(%x19)[32byte]
-e587524c : str z12, [x18, #60, mul vl]              : str    %z12 -> +0x3c(%x18)[32byte]
-e5b8524c : str z12, [x18, #-60, mul vl]             : str    %z12 -> -0x3c(%x18)[32byte]
-e588462d : str z13, [x17, #65, mul vl]              : str    %z13 -> +0x41(%x17)[32byte]
-e5b75e2d : str z13, [x17, #-65, mul vl]             : str    %z13 -> -0x41(%x17)[32byte]
-e5885a0e : str z14, [x16, #70, mul vl]              : str    %z14 -> +0x46(%x16)[32byte]
-e5b74a0e : str z14, [x16, #-70, mul vl]             : str    %z14 -> -0x46(%x16)[32byte]
-e5894def : str z15, [x15, #75, mul vl]              : str    %z15 -> +0x4b(%x15)[32byte]
-e5b655ef : str z15, [x15, #-75, mul vl]             : str    %z15 -> -0x4b(%x15)[32byte]
-e58a41d0 : str z16, [x14, #80, mul vl]              : str    %z16 -> +0x50(%x14)[32byte]
-e5b641d0 : str z16, [x14, #-80, mul vl]             : str    %z16 -> -0x50(%x14)[32byte]
-e58a55b1 : str z17, [x13, #85, mul vl]              : str    %z17 -> +0x55(%x13)[32byte]
-e5b54db1 : str z17, [x13, #-85, mul vl]             : str    %z17 -> -0x55(%x13)[32byte]
-e58b4992 : str z18, [x12, #90, mul vl]              : str    %z18 -> +0x5a(%x12)[32byte]
-e5b45992 : str z18, [x12, #-90, mul vl]             : str    %z18 -> -0x5a(%x12)[32byte]
-e58b5d73 : str z19, [x11, #95, mul vl]              : str    %z19 -> +0x5f(%x11)[32byte]
-e5b44573 : str z19, [x11, #-95, mul vl]             : str    %z19 -> -0x5f(%x11)[32byte]
-e58c5154 : str z20, [x10, #100, mul vl]             : str    %z20 -> +0x64(%x10)[32byte]
-e5b35154 : str z20, [x10, #-100, mul vl]            : str    %z20 -> -0x64(%x10)[32byte]
-e58d4535 : str z21, [x9, #105, mul vl]              : str    %z21 -> +0x69(%x9)[32byte]
-e5b25d35 : str z21, [x9, #-105, mul vl]             : str    %z21 -> -0x69(%x9)[32byte]
-e58d5916 : str z22, [x8, #110, mul vl]              : str    %z22 -> +0x6e(%x8)[32byte]
-e5b24916 : str z22, [x8, #-110, mul vl]             : str    %z22 -> -0x6e(%x8)[32byte]
-e58e4cf7 : str z23, [x7, #115, mul vl]              : str    %z23 -> +0x73(%x7)[32byte]
-e5b154f7 : str z23, [x7, #-115, mul vl]             : str    %z23 -> -0x73(%x7)[32byte]
-e58f40d8 : str z24, [x6, #120, mul vl]              : str    %z24 -> +0x78(%x6)[32byte]
-e5b140d8 : str z24, [x6, #-120, mul vl]             : str    %z24 -> -0x78(%x6)[32byte]
-e58f54b9 : str z25, [x5, #125, mul vl]              : str    %z25 -> +0x7d(%x5)[32byte]
-e5b04cb9 : str z25, [x5, #-125, mul vl]             : str    %z25 -> -0x7d(%x5)[32byte]
-e590489a : str z26, [x4, #130, mul vl]              : str    %z26 -> +0x82(%x4)[32byte]
-e5af589a : str z26, [x4, #-130, mul vl]             : str    %z26 -> -0x82(%x4)[32byte]
-e5905c7b : str z27, [x3, #135, mul vl]              : str    %z27 -> +0x87(%x3)[32byte]
-e5af447b : str z27, [x3, #-135, mul vl]             : str    %z27 -> -0x87(%x3)[32byte]
-e591505c : str z28, [x2, #140, mul vl]              : str    %z28 -> +0x8c(%x2)[32byte]
-e5ae505c : str z28, [x2, #-140, mul vl]             : str    %z28 -> -0x8c(%x2)[32byte]
-e592443d : str z29, [x1, #145, mul vl]              : str    %z29 -> +0x91(%x1)[32byte]
-e5ad5c3d : str z29, [x1, #-145, mul vl]             : str    %z29 -> -0x91(%x1)[32byte]
-e592581e : str z30, [x0, #150, mul vl]              : str    %z30 -> +0x96(%x0)[32byte]
-e5ad481e : str z30, [x0, #-150, mul vl]             : str    %z30 -> -0x96(%x0)[32byte]
-e5934fdf : str z31, [x30, #155, mul vl]             : str    %z31 -> +0x9b(%x30)[32byte]
-e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x9b(%x30)[32byte]
+e58057a1 : str z1, [x29, #5, mul vl]                : str    %z1 -> +0xa0(%x29)[32byte]
+e5bf4fa1 : str z1, [x29, #-5, mul vl]               : str    %z1 -> -0xa0(%x29)[32byte]
+e5814b82 : str z2, [x28, #10, mul vl]               : str    %z2 -> +0x0140(%x28)[32byte]
+e5be5b82 : str z2, [x28, #-10, mul vl]              : str    %z2 -> -0x0140(%x28)[32byte]
+e5815f63 : str z3, [x27, #15, mul vl]               : str    %z3 -> +0x01e0(%x27)[32byte]
+e5be4763 : str z3, [x27, #-15, mul vl]              : str    %z3 -> -0x01e0(%x27)[32byte]
+e5825344 : str z4, [x26, #20, mul vl]               : str    %z4 -> +0x0280(%x26)[32byte]
+e5bd5344 : str z4, [x26, #-20, mul vl]              : str    %z4 -> -0x0280(%x26)[32byte]
+e5834725 : str z5, [x25, #25, mul vl]               : str    %z5 -> +0x0320(%x25)[32byte]
+e5bc5f25 : str z5, [x25, #-25, mul vl]              : str    %z5 -> -0x0320(%x25)[32byte]
+e5835b06 : str z6, [x24, #30, mul vl]               : str    %z6 -> +0x03c0(%x24)[32byte]
+e5bc4b06 : str z6, [x24, #-30, mul vl]              : str    %z6 -> -0x03c0(%x24)[32byte]
+e5844ee7 : str z7, [x23, #35, mul vl]               : str    %z7 -> +0x0460(%x23)[32byte]
+e5bb56e7 : str z7, [x23, #-35, mul vl]              : str    %z7 -> -0x0460(%x23)[32byte]
+e58542c8 : str z8, [x22, #40, mul vl]               : str    %z8 -> +0x0500(%x22)[32byte]
+e5bb42c8 : str z8, [x22, #-40, mul vl]              : str    %z8 -> -0x0500(%x22)[32byte]
+e58556a9 : str z9, [x21, #45, mul vl]               : str    %z9 -> +0x05a0(%x21)[32byte]
+e5ba4ea9 : str z9, [x21, #-45, mul vl]              : str    %z9 -> -0x05a0(%x21)[32byte]
+e5864a8a : str z10, [x20, #50, mul vl]              : str    %z10 -> +0x0640(%x20)[32byte]
+e5b95a8a : str z10, [x20, #-50, mul vl]             : str    %z10 -> -0x0640(%x20)[32byte]
+e5865e6b : str z11, [x19, #55, mul vl]              : str    %z11 -> +0x06e0(%x19)[32byte]
+e5b9466b : str z11, [x19, #-55, mul vl]             : str    %z11 -> -0x06e0(%x19)[32byte]
+e587524c : str z12, [x18, #60, mul vl]              : str    %z12 -> +0x0780(%x18)[32byte]
+e5b8524c : str z12, [x18, #-60, mul vl]             : str    %z12 -> -0x0780(%x18)[32byte]
+e588462d : str z13, [x17, #65, mul vl]              : str    %z13 -> +0x0820(%x17)[32byte]
+e5b75e2d : str z13, [x17, #-65, mul vl]             : str    %z13 -> -0x0820(%x17)[32byte]
+e5885a0e : str z14, [x16, #70, mul vl]              : str    %z14 -> +0x08c0(%x16)[32byte]
+e5b74a0e : str z14, [x16, #-70, mul vl]             : str    %z14 -> -0x08c0(%x16)[32byte]
+e5894def : str z15, [x15, #75, mul vl]              : str    %z15 -> +0x0960(%x15)[32byte]
+e5b655ef : str z15, [x15, #-75, mul vl]             : str    %z15 -> -0x0960(%x15)[32byte]
+e58a41d0 : str z16, [x14, #80, mul vl]              : str    %z16 -> +0x0a00(%x14)[32byte]
+e5b641d0 : str z16, [x14, #-80, mul vl]             : str    %z16 -> -0x0a00(%x14)[32byte]
+e58a55b1 : str z17, [x13, #85, mul vl]              : str    %z17 -> +0x0aa0(%x13)[32byte]
+e5b54db1 : str z17, [x13, #-85, mul vl]             : str    %z17 -> -0x0aa0(%x13)[32byte]
+e58b4992 : str z18, [x12, #90, mul vl]              : str    %z18 -> +0x0b40(%x12)[32byte]
+e5b45992 : str z18, [x12, #-90, mul vl]             : str    %z18 -> -0x0b40(%x12)[32byte]
+e58b5d73 : str z19, [x11, #95, mul vl]              : str    %z19 -> +0x0be0(%x11)[32byte]
+e5b44573 : str z19, [x11, #-95, mul vl]             : str    %z19 -> -0x0be0(%x11)[32byte]
+e58c5154 : str z20, [x10, #100, mul vl]             : str    %z20 -> +0x0c80(%x10)[32byte]
+e5b35154 : str z20, [x10, #-100, mul vl]            : str    %z20 -> -0x0c80(%x10)[32byte]
+e58d4535 : str z21, [x9, #105, mul vl]              : str    %z21 -> +0x0d20(%x9)[32byte]
+e5b25d35 : str z21, [x9, #-105, mul vl]             : str    %z21 -> -0x0d20(%x9)[32byte]
+e58d5916 : str z22, [x8, #110, mul vl]              : str    %z22 -> +0x0dc0(%x8)[32byte]
+e5b24916 : str z22, [x8, #-110, mul vl]             : str    %z22 -> -0x0dc0(%x8)[32byte]
+e58e4cf7 : str z23, [x7, #115, mul vl]              : str    %z23 -> +0x0e60(%x7)[32byte]
+e5b154f7 : str z23, [x7, #-115, mul vl]             : str    %z23 -> -0x0e60(%x7)[32byte]
+e58f40d8 : str z24, [x6, #120, mul vl]              : str    %z24 -> +0x0f00(%x6)[32byte]
+e5b140d8 : str z24, [x6, #-120, mul vl]             : str    %z24 -> -0x0f00(%x6)[32byte]
+e58f54b9 : str z25, [x5, #125, mul vl]              : str    %z25 -> +0x0fa0(%x5)[32byte]
+e5b04cb9 : str z25, [x5, #-125, mul vl]             : str    %z25 -> -0x0fa0(%x5)[32byte]
+e590489a : str z26, [x4, #130, mul vl]              : str    %z26 -> +0x1040(%x4)[32byte]
+e5af589a : str z26, [x4, #-130, mul vl]             : str    %z26 -> -0x1040(%x4)[32byte]
+e5905c7b : str z27, [x3, #135, mul vl]              : str    %z27 -> +0x10e0(%x3)[32byte]
+e5af447b : str z27, [x3, #-135, mul vl]             : str    %z27 -> -0x10e0(%x3)[32byte]
+e591505c : str z28, [x2, #140, mul vl]              : str    %z28 -> +0x1180(%x2)[32byte]
+e5ae505c : str z28, [x2, #-140, mul vl]             : str    %z28 -> -0x1180(%x2)[32byte]
+e592443d : str z29, [x1, #145, mul vl]              : str    %z29 -> +0x1220(%x1)[32byte]
+e5ad5c3d : str z29, [x1, #-145, mul vl]             : str    %z29 -> -0x1220(%x1)[32byte]
+e592581e : str z30, [x0, #150, mul vl]              : str    %z30 -> +0x12c0(%x0)[32byte]
+e5ad481e : str z30, [x0, #-150, mul vl]             : str    %z30 -> -0x12c0(%x0)[32byte]
+e5934fdf : str z31, [x30, #155, mul vl]             : str    %z31 -> +0x1360(%x30)[32byte]
+e5ac57df : str z31, [x30, #-155, mul vl]            : str    %z31 -> -0x1360(%x30)[32byte]
 
 # SUB     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T> (SUB-Z.P.ZZ-_)
 04010000 : sub z0.b, p0/M, z0.b, z0.b                : sub    %p0/m %z0.b %z0.b -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -8315,11 +8315,11 @@ TEST_INSTR(str)
               opnd_create_reg(Zn_six_offset_0[i]));
 
     /* STR <Pt>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    int simm_1[6] = { 0, 64, -64, 512, -512, -4 };
+    int simm_1[6] = { 0, 64, -64, 1020, -1024, -4 };
     const char *expected_1[6] = {
         "str    %p0 -> (%x0)[4byte]",          "str    %p2 -> +0x40(%x5)[4byte]",
-        "str    %p5 -> -0x40(%x10)[4byte]",    "str    %p8 -> +0x0200(%x15)[4byte]",
-        "str    %p10 -> -0x0200(%x20)[4byte]", "str    %p15 -> -0x04(%x30)[4byte]"
+        "str    %p5 -> -0x40(%x10)[4byte]",    "str    %p8 -> +0x03fc(%x15)[4byte]",
+        "str    %p10 -> -0x0400(%x20)[4byte]", "str    %p15 -> -0x04(%x30)[4byte]"
     };
     TEST_LOOP(str, str, 6, expected_1[i],
               opnd_create_base_disp_aarch64(Xn_six_offset_0[i], DR_REG_NULL, 0, false,
@@ -8330,11 +8330,11 @@ TEST_INSTR(str)
 TEST_INSTR(ldr)
 {
     /* Testing LDR <Zt>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    int simm_0[6] = { 0, 8160, -4096, 2048, -1024, -32 };
+    int simm_0[6] = { 0, 8160, -4096, 2048, -8192, -32 };
     const char *expected_0[6] = {
         "ldr    (%x0)[32byte] -> %z0",          "ldr    +0x1fe0(%x6)[32byte] -> %z6",
         "ldr    -0x1000(%x11)[32byte] -> %z11", "ldr    +0x0800(%x16)[32byte] -> %z17",
-        "ldr    -0x0400(%x21)[32byte] -> %z22", "ldr    -0x20(%x30)[32byte] -> %z31",
+        "ldr    -0x2000(%x21)[32byte] -> %z22", "ldr    -0x20(%x30)[32byte] -> %z31",
     };
     TEST_LOOP(ldr, ldr, 6, expected_0[i], opnd_create_reg(Zn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -8306,8 +8306,8 @@ TEST_INSTR(str)
     int simm_0[6] = { 0, 32, -32, 8160, -4096, -8192 };
     const char *expected_0[6] = {
         "str    %z0 -> (%x0)[32byte]",          "str    %z5 -> +0x20(%x5)[32byte]",
-        "str    %z10 -> -0x20(%x10)[32byte]", "str    %z16 -> +0x1fe0(%x15)[32byte]",
-        "str    %z21 -> -0x1000(%x20)[32byte]",   "str    %z31 -> -0x2000(%x30)[32byte]"
+        "str    %z10 -> -0x20(%x10)[32byte]",   "str    %z16 -> +0x1fe0(%x15)[32byte]",
+        "str    %z21 -> -0x1000(%x20)[32byte]", "str    %z31 -> -0x2000(%x30)[32byte]"
     };
     TEST_LOOP(str, str, 6, expected_0[i],
               opnd_create_base_disp_aarch64(Xn_six_offset_0[i], DR_REG_NULL, 0, false,
@@ -8317,9 +8317,9 @@ TEST_INSTR(str)
     /* STR <Pt>, [<Xn|SP>{, #<simm>, MUL VL}] */
     int simm_1[6] = { 0, 64, -64, 512, -512, -4 };
     const char *expected_1[6] = {
-        "str    %p0 -> (%x0)[4byte]",         "str    %p2 -> +0x40(%x5)[4byte]",
-        "str    %p5 -> -0x40(%x10)[4byte]", "str    %p8 -> +0x0200(%x15)[4byte]",
-        "str    %p10 -> -0x0200(%x20)[4byte]",  "str    %p15 -> -0x04(%x30)[4byte]"
+        "str    %p0 -> (%x0)[4byte]",          "str    %p2 -> +0x40(%x5)[4byte]",
+        "str    %p5 -> -0x40(%x10)[4byte]",    "str    %p8 -> +0x0200(%x15)[4byte]",
+        "str    %p10 -> -0x0200(%x20)[4byte]", "str    %p15 -> -0x04(%x30)[4byte]"
     };
     TEST_LOOP(str, str, 6, expected_1[i],
               opnd_create_base_disp_aarch64(Xn_six_offset_0[i], DR_REG_NULL, 0, false,
@@ -8334,7 +8334,7 @@ TEST_INSTR(ldr)
     const char *expected_0[6] = {
         "ldr    (%x0)[32byte] -> %z0",          "ldr    +0x1fe0(%x6)[32byte] -> %z6",
         "ldr    -0x1000(%x11)[32byte] -> %z11", "ldr    +0x0800(%x16)[32byte] -> %z17",
-        "ldr    -0x0400(%x21)[32byte] -> %z22",   "ldr    -0x20(%x30)[32byte] -> %z31",
+        "ldr    -0x0400(%x21)[32byte] -> %z22", "ldr    -0x20(%x30)[32byte] -> %z31",
     };
     TEST_LOOP(ldr, ldr, 6, expected_0[i], opnd_create_reg(Zn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,
@@ -8343,9 +8343,9 @@ TEST_INSTR(ldr)
     /* LDR <Pt>, [<Xn|SP>{, #<simm>, MUL VL}] */
     int simm_1[6] = { 0, 4, -8, 1020, -1024, -256 };
     const char *expected_1[6] = {
-        "ldr    (%x0)[4byte] -> %p0",         "ldr    +0x04(%x6)[4byte] -> %p3",
-        "ldr    -0x08(%x11)[4byte] -> %p6", "ldr    +0x03fc(%x16)[4byte] -> %p9",
-        "ldr    -0x0400(%x21)[4byte] -> %p11",  "ldr    -0x0100(%x30)[4byte] -> %p15",
+        "ldr    (%x0)[4byte] -> %p0",          "ldr    +0x04(%x6)[4byte] -> %p3",
+        "ldr    -0x08(%x11)[4byte] -> %p6",    "ldr    +0x03fc(%x16)[4byte] -> %p9",
+        "ldr    -0x0400(%x21)[4byte] -> %p11", "ldr    -0x0100(%x30)[4byte] -> %p15",
     };
     TEST_LOOP(ldr, ldr, 6, expected_1[i], opnd_create_reg(Pn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -8303,11 +8303,11 @@ TEST_INSTR(compact_sve)
 TEST_INSTR(str)
 {
     /* Testing STR <Zt>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    int simm_0[6] = { 0, 255, -256, 127, -128, -1 };
+    int simm_0[6] = { 0, 32, -32, 8160, -4096, -8192 };
     const char *expected_0[6] = {
-        "str    %z0 -> (%x0)[32byte]",          "str    %z5 -> +0xff(%x5)[32byte]",
-        "str    %z10 -> -0x0100(%x10)[32byte]", "str    %z16 -> +0x7f(%x15)[32byte]",
-        "str    %z21 -> -0x80(%x20)[32byte]",   "str    %z31 -> -0x01(%x30)[32byte]"
+        "str    %z0 -> (%x0)[32byte]",          "str    %z5 -> +0x20(%x5)[32byte]",
+        "str    %z10 -> -0x20(%x10)[32byte]", "str    %z16 -> +0x1fe0(%x15)[32byte]",
+        "str    %z21 -> -0x1000(%x20)[32byte]",   "str    %z31 -> -0x2000(%x30)[32byte]"
     };
     TEST_LOOP(str, str, 6, expected_0[i],
               opnd_create_base_disp_aarch64(Xn_six_offset_0[i], DR_REG_NULL, 0, false,
@@ -8315,11 +8315,11 @@ TEST_INSTR(str)
               opnd_create_reg(Zn_six_offset_0[i]));
 
     /* STR <Pt>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    int simm_1[6] = { 0, 255, -256, 127, -128, -1 };
+    int simm_1[6] = { 0, 64, -64, 512, -512, -4 };
     const char *expected_1[6] = {
-        "str    %p0 -> (%x0)[4byte]",         "str    %p2 -> +0xff(%x5)[4byte]",
-        "str    %p5 -> -0x0100(%x10)[4byte]", "str    %p8 -> +0x7f(%x15)[4byte]",
-        "str    %p10 -> -0x80(%x20)[4byte]",  "str    %p15 -> -0x01(%x30)[4byte]"
+        "str    %p0 -> (%x0)[4byte]",         "str    %p2 -> +0x40(%x5)[4byte]",
+        "str    %p5 -> -0x40(%x10)[4byte]", "str    %p8 -> +0x0200(%x15)[4byte]",
+        "str    %p10 -> -0x0200(%x20)[4byte]",  "str    %p15 -> -0x04(%x30)[4byte]"
     };
     TEST_LOOP(str, str, 6, expected_1[i],
               opnd_create_base_disp_aarch64(Xn_six_offset_0[i], DR_REG_NULL, 0, false,
@@ -8329,23 +8329,23 @@ TEST_INSTR(str)
 
 TEST_INSTR(ldr)
 {
-    /* Testing STR <Zt>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    int simm_0[6] = { 0, 255, -256, 127, -128, -1 };
+    /* Testing LDR <Zt>, [<Xn|SP>{, #<simm>, MUL VL}] */
+    int simm_0[6] = { 0, 8160, -4096, 2048, -1024, -32 };
     const char *expected_0[6] = {
-        "ldr    (%x0)[32byte] -> %z0",          "ldr    +0xff(%x6)[32byte] -> %z6",
-        "ldr    -0x0100(%x11)[32byte] -> %z11", "ldr    +0x7f(%x16)[32byte] -> %z17",
-        "ldr    -0x80(%x21)[32byte] -> %z22",   "ldr    -0x01(%x30)[32byte] -> %z31",
+        "ldr    (%x0)[32byte] -> %z0",          "ldr    +0x1fe0(%x6)[32byte] -> %z6",
+        "ldr    -0x1000(%x11)[32byte] -> %z11", "ldr    +0x0800(%x16)[32byte] -> %z17",
+        "ldr    -0x0400(%x21)[32byte] -> %z22",   "ldr    -0x20(%x30)[32byte] -> %z31",
     };
     TEST_LOOP(ldr, ldr, 6, expected_0[i], opnd_create_reg(Zn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,
                                             simm_0[i], 0, OPSZ_32));
 
     /* LDR <Pt>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    int simm_1[6] = { 0, 255, -256, 127, -128, -1 };
+    int simm_1[6] = { 0, 4, -8, 1020, -1024, -256 };
     const char *expected_1[6] = {
-        "ldr    (%x0)[4byte] -> %p0",         "ldr    +0xff(%x6)[4byte] -> %p3",
-        "ldr    -0x0100(%x11)[4byte] -> %p6", "ldr    +0x7f(%x16)[4byte] -> %p9",
-        "ldr    -0x80(%x21)[4byte] -> %p11",  "ldr    -0x01(%x30)[4byte] -> %p15",
+        "ldr    (%x0)[4byte] -> %p0",         "ldr    +0x04(%x6)[4byte] -> %p3",
+        "ldr    -0x08(%x11)[4byte] -> %p6", "ldr    +0x03fc(%x16)[4byte] -> %p9",
+        "ldr    -0x0400(%x21)[4byte] -> %p11",  "ldr    -0x0100(%x30)[4byte] -> %p15",
     };
     TEST_LOOP(ldr, ldr, 6, expected_1[i], opnd_create_reg(Pn_six_offset_1[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1[i], DR_REG_NULL, 0, false,
@@ -16321,11 +16321,11 @@ TEST_INSTR(prfb_sve_pred)
     static const uint prfop[6] = { /*PLDL1KEEP*/ 0,  /*PLDL2KEEP*/ 2,
                                    /*PLDL3STRM*/ 5,  /*PSTL1KEEP*/ 8,
                                    /*PSTL2KEEP*/ 10, 15 };
-    static const int imm6[6] = { -32, -19, -8, 0, 13, 31 };
+    static const int imm6[6] = { -1024, -608, -256, 0, 416, 992 };
     const char *const expected_0_0[6] = {
-        "prfb   $0x00 %p0 -0x20(%x0)",  "prfb   $0x02 %p2 -0x13(%x7)",
-        "prfb   $0x05 %p3 -0x08(%x12)", "prfb   $0x08 %p5 (%x17)",
-        "prfb   $0x0a %p6 +0x0d(%x22)", "prfb   $0x0f %p7 +0x1f(%sp)",
+        "prfb   $0x00 %p0 -0x0400(%x0)",  "prfb   $0x02 %p2 -0x0260(%x7)",
+        "prfb   $0x05 %p3 -0x0100(%x12)", "prfb   $0x08 %p5 (%x17)",
+        "prfb   $0x0a %p6 +0x01a0(%x22)", "prfb   $0x0f %p7 +0x03e0(%sp)",
     };
     TEST_LOOP(
         prfb, prfb_sve_pred, 6, expected_0_0[i],
@@ -16443,11 +16443,11 @@ TEST_INSTR(prfd_sve_pred)
     static const uint prfop[6] = { /*PLDL1KEEP*/ 0,  /*PLDL2KEEP*/ 2,
                                    /*PLDL3STRM*/ 5,  /*PSTL1KEEP*/ 8,
                                    /*PSTL2KEEP*/ 10, 15 };
-    static const int imm6[6] = { -32, -19, -8, 0, 13, 31 };
+    static const int imm6[6] = { -1024, -608, -256, 0, 416, 992 };
     const char *const expected_0_0[6] = {
-        "prfd   $0x00 %p0 -0x20(%x0)",  "prfd   $0x02 %p2 -0x13(%x7)",
-        "prfd   $0x05 %p3 -0x08(%x12)", "prfd   $0x08 %p5 (%x17)",
-        "prfd   $0x0a %p6 +0x0d(%x22)", "prfd   $0x0f %p7 +0x1f(%sp)",
+        "prfd   $0x00 %p0 -0x0400(%x0)",  "prfd   $0x02 %p2 -0x0260(%x7)",
+        "prfd   $0x05 %p3 -0x0100(%x12)", "prfd   $0x08 %p5 (%x17)",
+        "prfd   $0x0a %p6 +0x01a0(%x22)", "prfd   $0x0f %p7 +0x03e0(%sp)",
     };
     TEST_LOOP(
         prfd, prfd_sve_pred, 6, expected_0_0[i],
@@ -16576,11 +16576,11 @@ TEST_INSTR(prfh_sve_pred)
     static const uint prfop[6] = { /*PLDL1KEEP*/ 0,  /*PLDL2KEEP*/ 2,
                                    /*PLDL3STRM*/ 5,  /*PSTL1KEEP*/ 8,
                                    /*PSTL2KEEP*/ 10, 15 };
-    static const int imm6[6] = { -32, -19, -8, 0, 13, 31 };
+    static const int imm6[6] = { -1024, -608, -256, 0, 416, 992 };
     const char *const expected_0_0[6] = {
-        "prfh   $0x00 %p0 -0x20(%x0)",  "prfh   $0x02 %p2 -0x13(%x7)",
-        "prfh   $0x05 %p3 -0x08(%x12)", "prfh   $0x08 %p5 (%x17)",
-        "prfh   $0x0a %p6 +0x0d(%x22)", "prfh   $0x0f %p7 +0x1f(%sp)",
+        "prfh   $0x00 %p0 -0x0400(%x0)",  "prfh   $0x02 %p2 -0x0260(%x7)",
+        "prfh   $0x05 %p3 -0x0100(%x12)", "prfh   $0x08 %p5 (%x17)",
+        "prfh   $0x0a %p6 +0x01a0(%x22)", "prfh   $0x0f %p7 +0x03e0(%sp)",
     };
     TEST_LOOP(
         prfh, prfh_sve_pred, 6, expected_0_0[i],
@@ -16710,11 +16710,11 @@ TEST_INSTR(prfw_sve_pred)
     static const uint prfop[6] = { /*PLDL1KEEP*/ 0,  /*PLDL2KEEP*/ 2,
                                    /*PLDL3STRM*/ 5,  /*PSTL1KEEP*/ 8,
                                    /*PSTL2KEEP*/ 10, 15 };
-    static const int imm6[6] = { -32, -19, -8, 0, 13, 31 };
+    static const int imm6[6] = { -1024, -608, -256, 0, 416, 992 };
     const char *const expected_0_0[6] = {
-        "prfw   $0x00 %p0 -0x20(%x0)",  "prfw   $0x02 %p2 -0x13(%x7)",
-        "prfw   $0x05 %p3 -0x08(%x12)", "prfw   $0x08 %p5 (%x17)",
-        "prfw   $0x0a %p6 +0x0d(%x22)", "prfw   $0x0f %p7 +0x1f(%sp)",
+        "prfw   $0x00 %p0 -0x0400(%x0)",  "prfw   $0x02 %p2 -0x0260(%x7)",
+        "prfw   $0x05 %p3 -0x0100(%x12)", "prfw   $0x08 %p5 (%x17)",
+        "prfw   $0x0a %p6 +0x01a0(%x22)", "prfw   $0x0f %p7 +0x03e0(%sp)",
     };
     TEST_LOOP(
         prfw, prfw_sve_pred, 6, expected_0_0[i],


### PR DESCRIPTION
For the current decode/encode functions of:
```
LDR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
LDR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
STR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
STR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
PRFB <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
PRFH <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
PRFW <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
PRFD <prfop>, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
```
Vector indexing is used in the memory operand at the IR level. However
the IR must always refer to the address in terms of the base register
value plus a byte offset displacement. This patch changes the
decode/encode functions for these instructions to expect byte offsets
at the IR level, converting to vector length offsets within the codec.

Issues #3044, #5365