### PR TITLE
i#6164: Add new file type for bimodal filtered traces

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -183,6 +183,9 @@ changes:
 Further non-compatibility-affecting changes include:
  - Added new drmemtrace option -L0_filter_until_instrs which enables filtering
    for the specified instruction count before switching to full instruction tracing.
+   Such bimodal filtered traces have #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP
+   in their file type, and a #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILTER_ENDPOINT marker
+   at the point in the trace when filtering ended.
  - Added AArchXX support for attaching to a running process.
  - Added new fields analyze_case_ex and instrument_instr_ex to #drbbdup_options_t.
  - Added drbbdup support to drwrap via #DRWRAP_INVERT_CONTROL, drwrap_invoke_insert(),

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -808,6 +808,14 @@ typedef enum {
      * The included kernel traces are in the Intel® Processor Trace format.
      */
     OFFLINE_FILE_TYPE_KERNEL_SYSCALLS = 0x1000,
+    /**
+     * Partially filtered trace. The initial part upto the
+     * #TRACE_MARKER_TYPE_FILTER_ENDPOINT marker is filtered, and the later part is not.
+     * Look for other filtering-related file types (#OFFLINE_FILE_TYPE_IFILTERED and
+     * #OFFLINE_FILE_TYPE_DFILTERED) to determine how the initial part was filtered.
+     * The initial part can be used by a simulator for warmup.
+     */
+    OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP = 0x2000,
 } offline_file_type_t;
 
 static inline const char *

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -474,9 +474,11 @@ typedef enum {
     TRACE_MARKER_TYPE_RECORD_ORDINAL,
 
     /**
-     * Indicates a point in the trace where filtering ended.
-     * This is currently added by the record_filter tool to annotate when the
-     * warmup part of the trace ends.
+     * Indicates the point in the trace where filtering ended. It is accompanied by
+     * #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP in the file
+     * type. This is added by the record_filter tool and also by the drmemtrace tracer
+     * (with -L0_filter_until_instrs) to annotate when the warmup part of the trace
+     * ended.
      */
     TRACE_MARKER_TYPE_FILTER_ENDPOINT,
 
@@ -774,15 +776,14 @@ typedef enum {
         OFFLINE_FILE_TYPE_ARCH_X86_64, /**< All possible architecture types. */
     /**
      * Instruction addresses filtered online.
-     * Note: this file type may transition to non-filtered. This transition is indicated
-     * by the #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILTER_ENDPOINT marker. Each
-     * window (which is indicated by the
-     * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID marker) starts out filtered.
-     * This applies to #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_DFILTERED also. Note that
-     * threads that were created after the transition will also have this marker - right
-     * at the beginning.
+     * Note: this file type may transition to non-filtered. If so, the transition is
+     * indicated by the #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILTER_ENDPOINT marker
+     * and the #OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP file type. Each window (which is
+     * indicated by the #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID marker) starts
+     * out filtered. This applies to #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_DFILTERED
+     * also. Note that threads that were created after the transition will also have this
+     * marker - right at the beginning.
      */
-    /* TODO i#6164: add a new file type for mixed traces. */
     OFFLINE_FILE_TYPE_IFILTERED = 0x80,
     OFFLINE_FILE_TYPE_DFILTERED = 0x100, /**< Data addresses filtered online. */
     OFFLINE_FILE_TYPE_ENCODINGS = 0x200, /**< Instruction encodings are included. */
@@ -809,7 +810,7 @@ typedef enum {
      */
     OFFLINE_FILE_TYPE_KERNEL_SYSCALLS = 0x1000,
     /**
-     * Partially filtered trace. The initial part upto the
+     * Partially filtered trace. The initial part up to the
      * #TRACE_MARKER_TYPE_FILTER_ENDPOINT marker is filtered, and the later part is not.
      * Look for other filtering-related file types (#OFFLINE_FILE_TYPE_IFILTERED and
      * #OFFLINE_FILE_TYPE_DFILTERED) to determine how the initial part was filtered.

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -202,7 +202,8 @@ test_cache_and_type_filter()
         { { TRACE_TYPE_MARKER,
             TRACE_MARKER_TYPE_FILETYPE,
             { OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS | OFFLINE_FILE_TYPE_ENCODINGS |
-              OFFLINE_FILE_TYPE_DFILTERED | OFFLINE_FILE_TYPE_IFILTERED } },
+              OFFLINE_FILE_TYPE_DFILTERED | OFFLINE_FILE_TYPE_IFILTERED |
+              OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP } },
           false,
           { false, true } },
         { { TRACE_TYPE_THREAD, 0, { 0x4 } }, true, { true, true } },

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -412,9 +412,14 @@ test_null_filter()
         std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>>
         filter_funcs;
     filter_funcs.push_back(std::move(null_filter));
+    // We use a very small stop_timestamp for the record filter. This is to verify that
+    // we emit the TRACE_MARKER_TYPE_FILTER_ENDPOINT marker for each thread even if
+    // starts after the given stop_timestamp. Since the stop_timestamp is so small, all
+    // other entries are expected to stay.
+    static constexpr uint64_t stop_timestamp_us = 1;
     auto record_filter = std::unique_ptr<dynamorio::drmemtrace::record_filter_t>(
         new dynamorio::drmemtrace::record_filter_t(output_dir, std::move(filter_funcs),
-                                                   /*stop_timestamp_us=*/0,
+                                                   stop_timestamp_us,
                                                    /*verbosity=*/0));
     std::vector<record_analysis_tool_t *> tools;
     tools.push_back(record_filter.get());
@@ -430,6 +435,8 @@ test_null_filter()
     }
 
     basic_counts_t::counters_t c1 = get_basic_counts(op_trace_dir.get_value());
+    // We expect one extra marker (TRACE_MARKER_TYPE_FILTER_ENDPOINT) for each thread.
+    c1.other_markers += c1.shard_count;
     basic_counts_t::counters_t c2 = get_basic_counts(output_dir);
     CHECK(c1.instrs != 0, "Bad input trace\n");
     CHECK(c1 == c2, "Null filter returned different counts\n");

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -413,7 +413,7 @@ test_null_filter()
         filter_funcs;
     filter_funcs.push_back(std::move(null_filter));
     // We use a very small stop_timestamp for the record filter. This is to verify that
-    // we emit the TRACE_MARKER_TYPE_FILTER_ENDPOINT marker for each thread even if
+    // we emit the TRACE_MARKER_TYPE_FILTER_ENDPOINT marker for each thread even if it
     // starts after the given stop_timestamp. Since the stop_timestamp is so small, all
     // other entries are expected to stay.
     static constexpr uint64_t stop_timestamp_us = 1;

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -284,6 +284,7 @@ basic_counts_t::print_results()
             for_kernel_trace = true;
         }
     }
+    total.shard_count = shard_map_.size();
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << "Total counts:\n";
     print_counters(total, shard_map_.size(), " total", for_kernel_trace);
@@ -324,6 +325,7 @@ basic_counts_t::get_total_counts()
             total += ctr;
         }
     }
+    total.shard_count = shard_map_.size();
     return total;
 }
 
@@ -368,11 +370,13 @@ basic_counts_t::combine_interval_snapshots(
     // call. This is so that printing of unique_pc_addrs count is skipped as
     // intended during print_interval_results.
     result->counters.stop_tracking_unique_pc_addrs();
+    result->counters.shard_count = 0;
     for (const auto snapshot : latest_shard_snapshots) {
         if (snapshot == nullptr)
             continue;
         result->counters +=
             dynamic_cast<const count_snapshot_t *const>(snapshot)->counters;
+        ++result->counters.shard_count;
         assert(result->counters.unique_pc_addrs.empty());
     }
     return result;

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -182,6 +182,12 @@ public:
         int_least64_t encodings = 0;
         std::unordered_set<uint64_t> unique_pc_addrs;
 
+        // Metadata for the counts. These are not used for the equality, increment,
+        // or decrement operation, and must be set explicitly.
+
+        // Count of shards that were combined to produce the above counts.
+        int_least64_t shard_count = 1;
+
         // Stops tracking unique_pc_addrs. Tracking unique_pc_addrs can be very
         // memory intensive. We skip it for interval state snapshots.
         void

--- a/clients/drcachesim/tools/filter/cache_filter.cpp
+++ b/clients/drcachesim/tools/filter/cache_filter.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*

--- a/clients/drcachesim/tools/filter/cache_filter.cpp
+++ b/clients/drcachesim/tools/filter/cache_filter.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -208,10 +208,13 @@ record_filter_t::parallel_shard_memref(void *shard_data, const trace_entry_t &in
         }
     }
 
-    // Optimize space by outputting the unit header only if we are outputting something
-    // from that unit.
     if (entry.type == TRACE_TYPE_MARKER) {
         switch (entry.size) {
+        case TRACE_MARKER_TYPE_FILETYPE:
+            if (stop_timestamp_ != 0) {
+                entry.addr |= OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP;
+            }
+            break;
         case TRACE_MARKER_TYPE_TIMESTAMP:
             // No need to remember the previous unit's header anymore. We're in the
             // next unit now.
@@ -222,6 +225,8 @@ record_filter_t::parallel_shard_memref(void *shard_data, const trace_entry_t &in
             ANNOTATE_FALLTHROUGH;
         case TRACE_MARKER_TYPE_WINDOW_ID:
         case TRACE_MARKER_TYPE_CPU_ID:
+            // Optimize space by outputting the unit header only if we are outputting
+            // something from that unit.
             if (output)
                 per_shard->last_delayed_unit_header.push_back(entry);
             return true;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -425,6 +425,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             !shard->found_blocking_marker_ ||
                 TESTANY(OFFLINE_FILE_TYPE_BLOCKING_SYSCALLS, shard->file_type_),
             "Kernel scheduling marker presence does not match filetype");
+        report_if_false(
+            shard,
+            !TESTANY(OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP, shard->file_type_) ||
+                shard->saw_filter_endpoint_marker_,
+            "Expected to find TRACE_MARKER_TYPE_FILTER_ENDPOINT for the given file type");
         if (knob_test_name_ == "filter_asm_instr_count") {
             static constexpr int ASM_INSTR_COUNT = 133;
             report_if_false(shard, shard->last_instr_count_marker_ == ASM_INSTR_COUNT,
@@ -703,6 +708,15 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         memref.marker.marker_type == TRACE_MARKER_TYPE_BRANCH_TARGET) {
         shard->last_branch_marker_value_ = memref.marker.marker_value;
     }
+
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_FILTER_ENDPOINT) {
+        shard->saw_filter_endpoint_marker_ = true;
+        report_if_false(
+            shard, TESTANY(OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP, shard->file_type_),
+            "Found TRACE_MARKER_TYPE_FILTER_ENDPOINT without the correct file type");
+    }
+
     if (knob_offline_ && shard->trace_version_ >= TRACE_ENTRY_VERSION_BRANCH_INFO) {
         if (type_is_instr_branch(memref.instr.type) &&
             // I-filtered traces don't mark branch targets.

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -192,6 +192,7 @@ protected:
         bool in_rseq_region_ = false;
         addr_t rseq_start_pc_ = 0;
         addr_t rseq_end_pc_ = 0;
+        bool saw_filter_endpoint_marker_ = false;
     };
 
     // We provide this for subclasses to run these invariants with custom

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -173,6 +173,10 @@ get_file_type()
         file_type =
             static_cast<offline_file_type_t>(file_type | OFFLINE_FILE_TYPE_DFILTERED);
     }
+    if (op_L0_filter_until_instrs.get_value()) {
+        file_type = static_cast<offline_file_type_t>(
+            file_type | OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP);
+    }
     if (op_disable_optimizations.get_value()) {
         file_type = static_cast<offline_file_type_t>(file_type |
                                                      OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS);
@@ -1114,7 +1118,6 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
     }
 
     if (do_write) {
-
         if (op_L0_filter_until_instrs.get_value() && mode == BBDUP_MODE_L0_FILTER) {
             uintptr_t toadd =
                 *(uintptr_t *)TLS_SLOT(data->seg_base, MEMTRACE_TLS_OFFS_ICOUNT);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -626,6 +626,8 @@ raw2trace_t::process_offline_entry(raw2trace_thread_data_t *tdata,
                 // process the entries that follow after. This does not affect the
                 // written-out type.
                 int file_type = get_file_type(tdata);
+                // We do not remove OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP here
+                // because that still stands true for this trace.
                 file_type &= ~(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED |
                                OFFLINE_FILE_TYPE_DFILTERED);
                 set_file_type(tdata, (offline_file_type_t)file_type);


### PR DESCRIPTION
Adds OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP for traces that are filtered before the TRACE_MARKER_TYPE_FILTER_ENDPOINT marker and unfiltered after it.

Adds invariant_checker checks to make sure the new file type and the filter end-point marker are
always present together, or not at all.

Adds a test that the record filter adds the filter end-point marker also for threads that start after
the filtering stop_timestamp. Adds a shard_count member to basic_counts_t::counters_t to make
it easier to write the new test without hard-coding count of threads in the test.

Fixes: #6164