### PR TITLE
i#5843 scheduler: Delay switch to instr after blocking syscall

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1739,21 +1739,22 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         } else if (options_.mapping == MAP_TO_ANY_OUTPUT) {
             trace_marker_type_t marker_type;
             uintptr_t marker_value;
-            if (input->saw_blocking_syscall) {
+            if (input->processing_blocking_syscall) {
                 // Wait until we're past all the markers associated with the syscall.
-                // If a signal arrives we would like the kernel xfer markers to go
-                // the next instr: but our recorded format is on instr boundaries.
+                // XXX: We may prefer to stop before the return value marker for futex,
+                // or a kernel xfer marker, but our recorded format is on instr
+                // boundaries so we live with those being before the switch.
                 if (record_type_is_instr(record)) {
                     // Assume it will block and we should switch to a different input.
                     need_new_input = true;
                     in_wait_state = true;
-                    input->saw_blocking_syscall = false;
+                    input->processing_blocking_syscall = false;
                     VPRINT(this, 3, "next_record[%d]: hit blocking syscall in input %d\n",
                            output, input->index);
                 }
             } else if (record_type_is_marker(record, marker_type, marker_value) &&
                        marker_type == TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL) {
-                input->saw_blocking_syscall = true;
+                input->processing_blocking_syscall = true;
             } else if (options_.quantum_unit == QUANTUM_INSTRUCTIONS &&
                        record_type_is_instr(record)) {
                 ++input->instrs_in_quantum;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -852,7 +852,7 @@ protected:
         // Global ready queue counter used to provide FIFO for same-priority inputs.
         uint64_t queue_counter = 0;
         // Used to switch on the insruction *after* a blocking syscall.
-        bool saw_blocking_syscall = false;
+        bool processing_blocking_syscall = false;
     };
 
     // Format for recording a schedule to disk.  A separate sequence of these records

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -192,9 +192,9 @@ public:
          * though the input were constructed by concatenating these ranges together.  A
          * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
          * ranges (with a value equal to the range ordinal) to notify the client of the
-         * discontinuity (but not before the first range), with a #THREAD_EXIT record
-         * inserted after the final range.  These ranges must be
-         * non-overlapping and in increasing order.
+         * discontinuity (but not before the first range), with a
+         * #dynamorio::drmemtrace::TRACE_TYPE_THREAD_EXIT record inserted after the final
+         * range.  These ranges must be non-overlapping and in increasing order.
          */
         std::vector<range_t> regions_of_interest;
     };

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -192,7 +192,8 @@ public:
          * though the input were constructed by concatenating these ranges together.  A
          * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
          * ranges (with a value equal to the range ordinal) to notify the client of the
-         * discontinuity (but not before the first range).  These ranges must be
+         * discontinuity (but not before the first range), with a #THREAD_EXIT record
+         * inserted after the final range.  These ranges must be
          * non-overlapping and in increasing order.
          */
         std::vector<range_t> regions_of_interest;
@@ -850,8 +851,8 @@ protected:
         bool order_by_timestamp = false;
         // Global ready queue counter used to provide FIFO for same-priority inputs.
         uint64_t queue_counter = 0;
-        // Used to ensure we make progress past a blocking syscall.
-        bool processed_blocking_syscall = false;
+        // Used to switch on the insruction *after* a blocking syscall.
+        bool saw_blocking_syscall = false;
     };
 
     // Format for recording a schedule to disk.  A separate sequence of these records
@@ -896,7 +897,7 @@ protected:
         } END_PACKED_STRUCTURE key;
         // Input stream ordinal of starting point.
         uint64_t start_instruction = 0;
-        // Input stream ordinal, inclusive.  Max numeric value means continue until EOF.
+        // Input stream ordinal, exclusive.  Max numeric value means continue until EOF.
         uint64_t stop_instruction = 0;
         // Timestamp in microseconds to keep context switches ordered.
         // XXX: To add more fine-grained ordering we could emit multiple entries

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1281,12 +1281,20 @@ test_synthetic_with_syscalls_single()
 
 static bool
 check_ref(std::vector<memref_t> &refs, int &idx, memref_tid_t expected_tid,
-          trace_type_t expected_type)
+          trace_type_t expected_type,
+          trace_marker_type_t expected_marker = TRACE_MARKER_TYPE_RESERVED_END)
 {
     if (expected_tid != refs[idx].instr.tid || expected_type != refs[idx].instr.type) {
         std::cerr << "Record " << idx << " has tid " << refs[idx].instr.tid
                   << " and type " << refs[idx].instr.type << " != expected tid "
                   << expected_tid << " and expected type " << expected_type << "\n";
+        return false;
+    }
+    if (expected_type == TRACE_TYPE_MARKER &&
+        expected_marker != refs[idx].marker.marker_type) {
+        std::cerr << "Record " << idx << " has marker type "
+                  << refs[idx].marker.marker_type << " but expected " << expected_marker
+                  << "\n";
         return false;
     }
     ++idx;
@@ -1304,17 +1312,12 @@ test_synthetic_with_syscalls_precise()
         /* clang-format off */
         make_thread(TID_A),
         make_pid(1),
-        make_version(4),
+        make_version(TRACE_ENTRY_VERSION),
         make_timestamp(20),
         make_instr(10),
         make_marker(TRACE_MARKER_TYPE_SYSCALL, SYSNUM),
         make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
         make_marker(TRACE_MARKER_TYPE_FUNC_ID, 100),
-        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
-        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
-        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
-        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
-        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
         make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
         make_timestamp(50),
         make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
@@ -1328,7 +1331,7 @@ test_synthetic_with_syscalls_precise()
         /* clang-format off */
         make_thread(TID_B),
         make_pid(1),
-        make_version(4),
+        make_version(TRACE_ENTRY_VERSION),
         make_timestamp(120),
         make_instr(20),
         make_instr(21),
@@ -1360,25 +1363,22 @@ test_synthetic_with_syscalls_precise()
     std::vector<trace_entry_t> entries;
     int idx = 0;
     bool res = true;
-    res = res && check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+    res = res &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
         check_ref(refs, idx, TID_A, TRACE_TYPE_INSTR) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER,
+                  TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FUNC_ID) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FUNC_ARG) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FUNC_ID) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FUNC_RETVAL) &&
         // Shouldn't switch until after all the syscall's markers.
-        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER) &&
-        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
         check_ref(refs, idx, TID_B, TRACE_TYPE_INSTR) &&
         check_ref(refs, idx, TID_B, TRACE_TYPE_INSTR) &&
         check_ref(refs, idx, TID_B, TRACE_TYPE_THREAD_EXIT) &&

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1210,13 +1210,10 @@ test_synthetic_with_syscalls_multiple()
     // quantum.)  Furthermore, B isn't finished by the time E and H are done and we see
     // the lower-priority C and F getting scheduled while B is in a wait state for its
     // blocking syscall.
-    assert(sched_as_string[0] == "BHHHBEEBHHHBCCCBIIICCCFFFIIIFFFAAAGGGDDDAAAGGG");
-    assert(sched_as_string[1] == "EEBEEHHHEEBEBFFFBJJJJJJJJJCCCIIIDDDAAAGGGDDD");
-    // Sanity check that the same input isn't on both cores at once.
-    for (size_t i = 0; i < std::min(sched_as_string[0].size(), sched_as_string[1].size());
-         ++i) {
-        assert(sched_as_string[0][i] != sched_as_string[1][i]);
-    }
+    // Note that the 3rd B is not really on the two cores at the same time as there are
+    // markers and other records that cause them to not actually line up.
+    assert(sched_as_string[0] == "BHHHBHHHBHHHBEBIIIJJJJJJJJJCCCIIIDDDAAAGGGDDD");
+    assert(sched_as_string[1] == "EEBEEBEEBEECCCFFFBCCCFFFIIIFFFAAAGGGDDDAAAGGG");
 }
 
 static void
@@ -1282,11 +1279,120 @@ test_synthetic_with_syscalls_single()
     assert(sched_as_string[1] == "");
 }
 
+static bool
+check_ref(std::vector<memref_t> &refs, int &idx, memref_tid_t expected_tid,
+          trace_type_t expected_type)
+{
+    if (expected_tid != refs[idx].instr.tid || expected_type != refs[idx].instr.type) {
+        std::cerr << "Record " << idx << " has tid " << refs[idx].instr.tid
+                  << " and type " << refs[idx].instr.type << " != expected tid "
+                  << expected_tid << " and expected type " << expected_type << "\n";
+        return false;
+    }
+    ++idx;
+    return true;
+}
+
+static void
+test_synthetic_with_syscalls_precise()
+{
+    std::cerr << "\n----------------\nTesting blocking syscall precise switch points\n";
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr memref_tid_t TID_B = 99;
+    static constexpr int SYSNUM = 202;
+    std::vector<trace_entry_t> refs_A = {
+        /* clang-format off */
+        make_thread(TID_A),
+        make_pid(1),
+        make_version(4),
+        make_timestamp(20),
+        make_instr(10),
+        make_marker(TRACE_MARKER_TYPE_SYSCALL, SYSNUM),
+        make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ID, 100),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_timestamp(50),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ID, 100),
+        make_marker(TRACE_MARKER_TYPE_FUNC_RETVAL, 0),
+        make_instr(12),
+        make_exit(TID_A),
+        /* clang-format on */
+    };
+    std::vector<trace_entry_t> refs_B = {
+        /* clang-format off */
+        make_thread(TID_B),
+        make_pid(1),
+        make_version(4),
+        make_timestamp(120),
+        make_instr(20),
+        make_instr(21),
+        make_exit(TID_B),
+        /* clang-format on */
+    };
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_A)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_B)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_B);
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(readers));
+    scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                               scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                               scheduler_t::SCHEDULER_DEFAULTS,
+                                               /*verbosity=*/4);
+    scheduler_t scheduler;
+    if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    auto *stream = scheduler.get_stream(0);
+    memref_t memref;
+    std::vector<memref_t> refs;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+        assert(status == scheduler_t::STATUS_OK);
+        refs.push_back(memref);
+    }
+    std::vector<trace_entry_t> entries;
+    int idx = 0;
+    bool res = true;
+    res = res && check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        // Shouldn't switch until after all the syscall's markers.
+        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_THREAD_EXIT) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_THREAD_EXIT);
+    assert(res);
+}
+
 static void
 test_synthetic_with_syscalls()
 {
     test_synthetic_with_syscalls_multiple();
     test_synthetic_with_syscalls_single();
+    test_synthetic_with_syscalls_precise();
 }
 
 #if (defined(X86_64) || defined(ARM_64)) && defined(HAS_ZIP)


### PR DESCRIPTION
Fixes a problem with the implementation of context switching on a blocking syscall: it was being done immediately upon seeing the maybe-blocking marker, which is right after the syscall instruction. This resulted in recording the syscall instruction ordinal as the switch point, when that ordinal is supposed to be exclusive and so needs to be right before the subsequent instruction.

Adds a test that ensures we don't switch until after all the markers after a blocking syscall.

Issue: #5843