### PR TITLE
i#5843 scheduler: Fix record-replay ordinal mismatches

### DIFF
--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -392,7 +392,7 @@ reader_t::skip_instructions_with_timestamp(uint64_t stop_instruction_count)
     // instr, so we look for the 1st unskipped instr: but we do not want to
     // process it so we do not use the ++ operator function.
     uint64_t stop_count = stop_instruction_count + 1;
-    trace_entry_t timestamp;
+    trace_entry_t timestamp = {};
     // Use the most recent timestamp.
     if (last_timestamp_ != 0) {
         timestamp.type = TRACE_TYPE_MARKER;

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -79,7 +79,7 @@ reader_t::operator++()
             // We've already presented the thread exit entry to the analyzer.
             continue;
         }
-        VPRINT(this, 4, "RECV: type=%s (%d), size=%d, addr=0x%zx\n",
+        VPRINT(this, 5, "RECV: type=%s (%d), size=%d, addr=0x%zx\n",
                trace_type_names[input_entry_->type], input_entry_->type,
                input_entry_->size, input_entry_->addr);
         if (process_input_entry())
@@ -392,7 +392,13 @@ reader_t::skip_instructions_with_timestamp(uint64_t stop_instruction_count)
     // instr, so we look for the 1st unskipped instr: but we do not want to
     // process it so we do not use the ++ operator function.
     uint64_t stop_count = stop_instruction_count + 1;
-    trace_entry_t timestamp = {};
+    trace_entry_t timestamp;
+    // Use the most recent timestamp.
+    if (last_timestamp_ != 0) {
+        timestamp.type = TRACE_TYPE_MARKER;
+        timestamp.size = TRACE_MARKER_TYPE_TIMESTAMP;
+        timestamp.addr = static_cast<addr_t>(last_timestamp_);
+    }
     trace_entry_t cpu = {};
     trace_entry_t next_instr = {};
     bool prev_was_record_ord = false;

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -127,7 +127,7 @@ file_reader_t<zipfile_reader_t>::read_next_entry()
     }
     entry_copy_ = *zipfile->cur_buf;
     ++zipfile->cur_buf;
-    VPRINT(this, 4, "Read: type=%s (%d), size=%d, addr=%zu\n",
+    VPRINT(this, 5, "Read: type=%s (%d), size=%d, addr=%zu\n",
            trace_type_names[entry_copy_.type], entry_copy_.type, entry_copy_.size,
            entry_copy_.addr);
     return &entry_copy_;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -192,9 +192,9 @@ public:
          * though the input were constructed by concatenating these ranges together.  A
          * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
          * ranges (with a value equal to the range ordinal) to notify the client of the
-         * discontinuity (but not before the first range), with a #THREAD_EXIT record
-         * inserted after the final range.  These ranges must be
-         * non-overlapping and in increasing order.
+         * discontinuity (but not before the first range), with a
+         * #dynamorio::drmemtrace::TRACE_TYPE_THREAD_EXIT record inserted after the final
+         * range.  These ranges must be non-overlapping and in increasing order.
          */
         std::vector<range_t> regions_of_interest;
     };

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -192,7 +192,8 @@ public:
          * though the input were constructed by concatenating these ranges together.  A
          * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
          * ranges (with a value equal to the range ordinal) to notify the client of the
-         * discontinuity (but not before the first range).  These ranges must be
+         * discontinuity (but not before the first range), with a #THREAD_EXIT record
+         * inserted after the final range.  These ranges must be
          * non-overlapping and in increasing order.
          */
         std::vector<range_t> regions_of_interest;
@@ -850,8 +851,8 @@ protected:
         bool order_by_timestamp = false;
         // Global ready queue counter used to provide FIFO for same-priority inputs.
         uint64_t queue_counter = 0;
-        // Used to ensure we make progress past a blocking syscall.
-        bool processed_blocking_syscall = false;
+        // Used to switch on the insruction *after* a blocking syscall.
+        bool saw_blocking_syscall = false;
     };
 
     // Format for recording a schedule to disk.  A separate sequence of these records
@@ -896,7 +897,7 @@ protected:
         } END_PACKED_STRUCTURE key;
         // Input stream ordinal of starting point.
         uint64_t start_instruction = 0;
-        // Input stream ordinal, inclusive.  Max numeric value means continue until EOF.
+        // Input stream ordinal, exclusive.  Max numeric value means continue until EOF.
         uint64_t stop_instruction = 0;
         // Timestamp in microseconds to keep context switches ordered.
         // XXX: To add more fine-grained ordering we could emit multiple entries

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -90,6 +90,7 @@ private:
     int index_ = -1;
 };
 
+#if (defined(X86_64) || defined(ARM_64)) && defined(HAS_ZIP)
 struct trace_position_t {
     trace_position_t(uint64_t record, uint64_t instr, uint64_t timestamp)
         : record_ordinal(record)
@@ -152,6 +153,7 @@ operator<<(std::ostream &o, const context_switch_t &cs)
     return o << cs.prev_tid << " => " << cs.new_tid << " @ " << cs.output_position << " ("
              << cs.prev_input_position << " => " << cs.new_input_position << ")";
 }
+#endif /* (defined(X86_64) || defined(ARM_64)) && defined(HAS_ZIP) */
 
 static trace_entry_t
 make_instr(addr_t pc, trace_type_t type = TRACE_TYPE_INSTR)

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -48,6 +48,8 @@
 namespace dynamorio {
 namespace drmemtrace {
 
+using ::dynamorio::drmemtrace::memtrace_stream_t;
+
 // A mock reader that iterates over a vector of records.
 class mock_reader_t : public reader_t {
 public:
@@ -87,6 +89,69 @@ private:
     std::vector<trace_entry_t> trace_;
     int index_ = -1;
 };
+
+struct trace_position_t {
+    trace_position_t(uint64_t record, uint64_t instr, uint64_t timestamp)
+        : record_ordinal(record)
+        , instruction_ordinal(instr)
+        , last_timestamp(timestamp)
+    {
+    }
+    bool
+    operator==(const trace_position_t &rhs)
+    {
+        return record_ordinal == rhs.record_ordinal &&
+            instruction_ordinal == rhs.instruction_ordinal &&
+            last_timestamp == rhs.last_timestamp;
+    }
+    uint64_t record_ordinal;
+    uint64_t instruction_ordinal;
+    uint64_t last_timestamp;
+};
+
+struct context_switch_t {
+    context_switch_t(memref_tid_t prev_tid, memref_tid_t new_tid, trace_position_t output,
+                     trace_position_t prev, trace_position_t next)
+        : prev_tid(prev_tid)
+        , new_tid(new_tid)
+        , output_position(output)
+        , prev_input_position(prev)
+        , new_input_position(next)
+    {
+    }
+    bool
+    operator==(const context_switch_t &rhs)
+    {
+        return prev_tid == rhs.prev_tid && new_tid == rhs.new_tid &&
+            output_position == rhs.output_position &&
+            prev_input_position == rhs.prev_input_position &&
+            new_input_position == rhs.new_input_position;
+    }
+    memref_tid_t prev_tid;
+    memref_tid_t new_tid;
+    trace_position_t output_position;
+    trace_position_t prev_input_position;
+    trace_position_t new_input_position;
+};
+
+static std::ostream &
+operator<<(std::ostream &o, const trace_position_t &tp)
+{
+    // We are deliberately terse to keep the output on one line.
+    return o << "<" << tp.record_ordinal << "," << tp.instruction_ordinal << ","
+             << tp.last_timestamp << ">";
+}
+
+static std::ostream &
+operator<<(std::ostream &o, const context_switch_t &cs)
+{
+    if (cs.prev_tid == INVALID_THREAD_ID) {
+        // Initial thread: omit the transition and all the positions.
+        return o << cs.new_tid;
+    }
+    return o << cs.prev_tid << " => " << cs.new_tid << " @ " << cs.output_position << " ("
+             << cs.prev_input_position << " => " << cs.new_input_position << ")";
+}
 
 static trace_entry_t
 make_instr(addr_t pc, trace_type_t type = TRACE_TYPE_INSTR)
@@ -1678,7 +1743,7 @@ test_replay()
             sched_inputs.emplace_back(std::move(readers));
         }
         scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_AS_PREVIOUSLY,
-                                                   scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/2);
         zipfile_istream_t infile(record_fname);
@@ -1702,10 +1767,12 @@ test_replay()
 #if (defined(X86_64) || defined(ARM_64)) && defined(HAS_ZIP)
 static void
 simulate_core_and_record_schedule(scheduler_t::stream_t *stream,
-                                  std::vector<memref_tid_t> &thread_sequence)
+                                  const scheduler_t &scheduler,
+                                  std::vector<context_switch_t> &thread_sequence)
 {
     memref_t record;
     memref_tid_t prev_tid = INVALID_THREAD_ID;
+    memtrace_stream_t *prev_stream = nullptr;
     for (scheduler_t::stream_status_t status = stream->next_record(record);
          status != scheduler_t::STATUS_EOF; status = stream->next_record(record)) {
         if (status == scheduler_t::STATUS_WAIT) {
@@ -1713,11 +1780,32 @@ simulate_core_and_record_schedule(scheduler_t::stream_t *stream,
             continue;
         }
         assert(status == scheduler_t::STATUS_OK);
-        if (thread_sequence.empty())
-            thread_sequence.push_back(record.instr.tid);
-        else if (record.instr.tid != prev_tid)
-            thread_sequence.push_back(record.instr.tid);
+        if (record.instr.tid != prev_tid && prev_tid != INVALID_THREAD_ID) {
+            auto *new_stream =
+                scheduler.get_input_stream_interface(stream->get_input_stream_ordinal());
+            assert(new_stream != nullptr);
+            assert(prev_stream != nullptr);
+            thread_sequence.emplace_back(
+                prev_tid, record.instr.tid,
+                trace_position_t(stream->get_record_ordinal(),
+                                 stream->get_instruction_ordinal(),
+                                 stream->get_last_timestamp()),
+                trace_position_t(prev_stream->get_record_ordinal(),
+                                 prev_stream->get_instruction_ordinal(),
+                                 prev_stream->get_last_timestamp()),
+                trace_position_t(new_stream->get_record_ordinal(),
+                                 new_stream->get_instruction_ordinal(),
+                                 new_stream->get_last_timestamp()));
+        }
         prev_tid = record.instr.tid;
+        prev_stream =
+            scheduler.get_input_stream_interface(stream->get_input_stream_ordinal());
+    }
+    if (thread_sequence.empty()) {
+        // Create a single-thread entry.
+        thread_sequence.emplace_back(INVALID_THREAD_ID, prev_tid,
+                                     trace_position_t(0, 0, 0), trace_position_t(0, 0, 0),
+                                     trace_position_t(0, 0, 0));
     }
 }
 #endif
@@ -1731,7 +1819,7 @@ test_replay_multi_threaded(const char *testdir)
     std::string path = std::string(testdir) + "/drmemtrace.threadsig.x64.tracedir";
     std::string record_fname = "tmp_test_replay_multi_record.zip";
     static constexpr int NUM_OUTPUTS = 4;
-    std::vector<std::vector<memref_tid_t>> thread_sequence(NUM_OUTPUTS);
+    std::vector<std::vector<context_switch_t>> thread_sequence(NUM_OUTPUTS);
     {
         // Record.
         scheduler_t scheduler;
@@ -1752,7 +1840,7 @@ test_replay_multi_threaded(const char *testdir)
         threads.reserve(NUM_OUTPUTS);
         for (int i = 0; i < NUM_OUTPUTS; ++i) {
             threads.emplace_back(std::thread(&simulate_core_and_record_schedule,
-                                             scheduler.get_stream(i),
+                                             scheduler.get_stream(i), std::ref(scheduler),
                                              std::ref(thread_sequence[i])));
         }
         for (std::thread &thread : threads)
@@ -1774,12 +1862,12 @@ test_replay_multi_threaded(const char *testdir)
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, sched_ops) !=
             scheduler_t::STATUS_SUCCESS)
             assert(false);
-        std::vector<std::vector<memref_tid_t>> replay_sequence(NUM_OUTPUTS);
+        std::vector<std::vector<context_switch_t>> replay_sequence(NUM_OUTPUTS);
         std::vector<std::thread> threads;
         threads.reserve(NUM_OUTPUTS);
         for (int i = 0; i < NUM_OUTPUTS; ++i) {
             threads.emplace_back(std::thread(&simulate_core_and_record_schedule,
-                                             scheduler.get_stream(i),
+                                             scheduler.get_stream(i), std::ref(scheduler),
                                              std::ref(replay_sequence[i])));
         }
         for (std::thread &thread : threads)
@@ -1787,19 +1875,17 @@ test_replay_multi_threaded(const char *testdir)
         std::cerr << "Recorded:\n";
         for (int i = 0; i < NUM_OUTPUTS; ++i) {
             std::cerr << "Core #" << i << ": ";
-            for (memref_tid_t tid : thread_sequence[i])
-                std::cerr << tid << " ";
+            for (const auto &cs : thread_sequence[i])
+                std::cerr << "  " << cs << "\n";
             std::cerr << "\n";
         }
         std::cerr << "Replayed:\n";
         for (int i = 0; i < NUM_OUTPUTS; ++i) {
             std::cerr << "Core #" << i << ": ";
-            for (memref_tid_t tid : replay_sequence[i])
-                std::cerr << tid << " ";
+            for (const auto &cs : replay_sequence[i])
+                std::cerr << "  " << cs << "\n";
             std::cerr << "\n";
         }
-        // TODO i#5438: Save the record and instruction ordinals at each context switch
-        // and compare them, once fencepost errors with queueing are solved.
         for (int i = 0; i < NUM_OUTPUTS; ++i) {
             assert(thread_sequence[i].size() == replay_sequence[i].size());
             for (size_t j = 0; j < thread_sequence[i].size(); ++j) {
@@ -1875,6 +1961,10 @@ test_replay_timestamps()
         memref_tid_t tid = TID_BASE + i;
         inputs[i].push_back(make_thread(tid));
         inputs[i].push_back(make_pid(1));
+        // We need a timestamp so the scheduler will find one for initial
+        // input processing.  We do not try to duplicate the timestamp
+        // sequences in the stored file and just use a dummy timestamp here.
+        inputs[i].push_back(make_timestamp(10 + i));
         for (int j = 0; j < NUM_INSTRS; j++)
             inputs[i].push_back(make_instr(42 + j * 4));
         inputs[i].push_back(make_exit(tid));
@@ -1966,7 +2056,7 @@ test_replay_skip()
         sched_inputs[0].thread_modifiers.push_back(
             scheduler_t::input_thread_info_t(regions));
         scheduler_t scheduler;
-        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_RECORDED_OUTPUT,
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
                                                    scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/4);
@@ -2254,8 +2344,9 @@ test_replay_as_traced_from_file(const char *testdir)
     // much thread migration but our synthetic test above covers that.
     static const char *const SCHED_STRING =
         "Core #0: 1257598 \nCore #1: 1257603 \nCore #2: 1257601 \n"
-        "Core #3: 1257599 1257604 \nCore #4: 1257600 \nCore #5: 1257596 \n"
-        "Core #6: 1257602 \n";
+        "Core #3: 1257599 => 1257604 @ <366987,87875,13331862029895453> "
+        "(<366986,87875,13331862029895453> => <1,0,0>) \n"
+        "Core #4: 1257600 \nCore #5: 1257596 \nCore #6: 1257602 \n";
     static constexpr int NUM_OUTPUTS = 7; // Matches the actual trace's core footprint.
     scheduler_t scheduler;
     std::vector<scheduler_t::input_workload_t> sched_inputs;
@@ -2270,12 +2361,12 @@ test_replay_as_traced_from_file(const char *testdir)
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, sched_ops) !=
         scheduler_t::STATUS_SUCCESS)
         assert(false);
-    std::vector<std::vector<memref_tid_t>> replay_sequence(NUM_OUTPUTS);
+    std::vector<std::vector<context_switch_t>> replay_sequence(NUM_OUTPUTS);
     std::vector<std::thread> threads;
     threads.reserve(NUM_OUTPUTS);
     for (int i = 0; i < NUM_OUTPUTS; ++i) {
         threads.emplace_back(std::thread(&simulate_core_and_record_schedule,
-                                         scheduler.get_stream(i),
+                                         scheduler.get_stream(i), std::ref(scheduler),
                                          std::ref(replay_sequence[i])));
     }
     for (std::thread &thread : threads)
@@ -2283,8 +2374,8 @@ test_replay_as_traced_from_file(const char *testdir)
     std::ostringstream replay_string;
     for (int i = 0; i < NUM_OUTPUTS; ++i) {
         replay_string << "Core #" << i << ": ";
-        for (memref_tid_t tid : replay_sequence[i])
-            replay_string << tid << " ";
+        for (const auto &cs : replay_sequence[i])
+            replay_string << cs << " ";
         replay_string << "\n";
     }
     std::cerr << "As-traced from file:\n"

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1210,13 +1210,10 @@ test_synthetic_with_syscalls_multiple()
     // quantum.)  Furthermore, B isn't finished by the time E and H are done and we see
     // the lower-priority C and F getting scheduled while B is in a wait state for its
     // blocking syscall.
-    assert(sched_as_string[0] == "BHHHBEEBHHHBCCCBIIICCCFFFIIIFFFAAAGGGDDDAAAGGG");
-    assert(sched_as_string[1] == "EEBEEHHHEEBEBFFFBJJJJJJJJJCCCIIIDDDAAAGGGDDD");
-    // Sanity check that the same input isn't on both cores at once.
-    for (size_t i = 0; i < std::min(sched_as_string[0].size(), sched_as_string[1].size());
-         ++i) {
-        assert(sched_as_string[0][i] != sched_as_string[1][i]);
-    }
+    // Note that the 3rd B is not really on the two cores at the same time as there are
+    // markers and other records that cause them to not actually line up.
+    assert(sched_as_string[0] == "BHHHBHHHBHHHBEBIIIJJJJJJJJJCCCIIIDDDAAAGGGDDD");
+    assert(sched_as_string[1] == "EEBEEBEEBEECCCFFFBCCCFFFIIIFFFAAAGGGDDDAAAGGG");
 }
 
 static void
@@ -1282,11 +1279,120 @@ test_synthetic_with_syscalls_single()
     assert(sched_as_string[1] == "");
 }
 
+static bool
+check_ref(std::vector<memref_t> &refs, int &idx, memref_tid_t expected_tid,
+          trace_type_t expected_type)
+{
+    if (expected_tid != refs[idx].instr.tid || expected_type != refs[idx].instr.type) {
+        std::cerr << "Record " << idx << " has tid " << refs[idx].instr.tid
+                  << " and type " << refs[idx].instr.type << " != expected tid "
+                  << expected_tid << " and expected type " << expected_type << "\n";
+        return false;
+    }
+    ++idx;
+    return true;
+}
+
+static void
+test_synthetic_with_syscalls_precise()
+{
+    std::cerr << "\n----------------\nTesting blocking syscall precise switch points\n";
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr memref_tid_t TID_B = 99;
+    static constexpr int SYSNUM = 202;
+    std::vector<trace_entry_t> refs_A = {
+        /* clang-format off */
+        make_thread(TID_A),
+        make_pid(1),
+        make_version(4),
+        make_timestamp(20),
+        make_instr(10),
+        make_marker(TRACE_MARKER_TYPE_SYSCALL, SYSNUM),
+        make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ID, 100),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
+        make_timestamp(50),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        make_marker(TRACE_MARKER_TYPE_FUNC_ID, 100),
+        make_marker(TRACE_MARKER_TYPE_FUNC_RETVAL, 0),
+        make_instr(12),
+        make_exit(TID_A),
+        /* clang-format on */
+    };
+    std::vector<trace_entry_t> refs_B = {
+        /* clang-format off */
+        make_thread(TID_B),
+        make_pid(1),
+        make_version(4),
+        make_timestamp(120),
+        make_instr(20),
+        make_instr(21),
+        make_exit(TID_B),
+        /* clang-format on */
+    };
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_A)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_B)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_B);
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(readers));
+    scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                               scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                               scheduler_t::SCHEDULER_DEFAULTS,
+                                               /*verbosity=*/4);
+    scheduler_t scheduler;
+    if (scheduler.init(sched_inputs, 1, sched_ops) != scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    auto *stream = scheduler.get_stream(0);
+    memref_t memref;
+    std::vector<memref_t> refs;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+        assert(status == scheduler_t::STATUS_OK);
+        refs.push_back(memref);
+    }
+    std::vector<trace_entry_t> entries;
+    int idx = 0;
+    bool res = true;
+    res = res && check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER) &&
+        // Shouldn't switch until after all the syscall's markers.
+        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_MARKER) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_B, TRACE_TYPE_THREAD_EXIT) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_THREAD_EXIT);
+    assert(res);
+}
+
 static void
 test_synthetic_with_syscalls()
 {
     test_synthetic_with_syscalls_multiple();
     test_synthetic_with_syscalls_single();
+    test_synthetic_with_syscalls_precise();
 }
 
 #if (defined(X86_64) || defined(ARM_64)) && defined(HAS_ZIP)


### PR DESCRIPTION
Adds read-ahead to timestamps when replaying, to match record ordinals and not just instruction ordinals at start and switch points when recording.

Adds use of the just-read timestamp when skipping in the reader, to avoid losing the timestamp when the scheduler has read ahead.

Adds recording of the ordinals at switch points in the unit tests for comprehensive testing of switch points instead of just testing thread sequences.

Fixes several tests which were passing incorrect flags.

Issue: #5843