### PR TITLE
Replace {u,}int_least64_t with {u,}int64_t

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -179,6 +179,8 @@ changes:
    is deprecated in offline traces where it is replaced by
    #dynamorio::drmemtrace::TRACE_TYPE_INSTR_TAKEN_JUMP and
    #dynamorio::drmemtrace::TRACE_TYPE_INSTR_UNTAKEN_JUMP.
+ - All int_least64_t and uint_least64_t types in drcachesim were replaced with
+   their precise counterparts int64_t and uint64_t.
 
 Further non-compatibility-affecting changes include:
  - Added new drmemtrace option -L0_filter_until_instrs which enables filtering

--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -49,8 +49,8 @@ namespace drmemtrace { /**< DrMemtrace tracing + simulation infrastructure names
 
 // On some platforms, like MacOS, a thread id is 64 bits.
 // We just make both 64 bits to cover all our bases.
-typedef int_least64_t memref_pid_t; /**< Process id type. */
-typedef int_least64_t memref_tid_t; /**< Thread id type. */
+typedef int64_t memref_pid_t; /**< Process id type. */
+typedef int64_t memref_tid_t; /**< Thread id type. */
 
 /** A trace entry representing a data load, store, or prefetch. */
 struct _memref_data_t {

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -615,7 +615,7 @@ cache_simulator_t::print_results()
 
 // All valid metrics are returned as a positive number.
 // Negative return value is an error and is of type stats_error_t.
-int_least64_t
+int64_t
 cache_simulator_t::get_cache_metric(metric_name_t metric, unsigned level, unsigned core,
                                     cache_split_t split) const
 {

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -77,7 +77,7 @@ public:
     bool
     print_results() override;
 
-    int_least64_t
+    int64_t
     get_cache_metric(metric_name_t metric, unsigned level, unsigned core = 0,
                      cache_split_t split = cache_split_t::DATA) const;
 

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -69,9 +69,9 @@ protected:
 
     // A CPU cache handles flushes and prefetching requests
     // as well as regular memory accesses.
-    int_least64_t num_flushes_;
-    int_least64_t num_prefetch_hits_;
-    int_least64_t num_prefetch_misses_;
+    int64_t num_flushes_;
+    int64_t num_prefetch_hits_;
+    int64_t num_prefetch_misses_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/simulator/caching_device_block.h
+++ b/clients/drcachesim/simulator/caching_device_block.h
@@ -64,9 +64,9 @@ public:
 
     addr_t tag_;
 
-    // XXX: using int_least64_t here results in a ~4% slowdown for 32-bit apps.
+    // XXX: using int64_t here results in a ~4% slowdown for 32-bit apps.
     // A 32-bit counter should be sufficient but we may want to revisit.
-    // We already have stdint.h so we can reinstate int_least64_t easily.
+    // We already have stdint.h so we can reinstate int64_t easily.
     int counter_; // for use by replacement policies
 };
 

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -187,7 +187,7 @@ public:
     virtual void
     invalidate(invalidation_type_t invalidation_type);
 
-    int_least64_t
+    int64_t
     get_metric(metric_name_t metric) const
     {
         if (stats_map_.find(metric) != stats_map_.end()) {
@@ -232,19 +232,19 @@ protected:
     void
     check_compulsory_miss(addr_t addr);
 
-    int_least64_t num_hits_;
-    int_least64_t num_misses_;
-    int_least64_t num_compulsory_misses_;
-    int_least64_t num_child_hits_;
+    int64_t num_hits_;
+    int64_t num_misses_;
+    int64_t num_compulsory_misses_;
+    int64_t num_child_hits_;
 
-    int_least64_t num_inclusive_invalidates_;
-    int_least64_t num_coherence_invalidates_;
+    int64_t num_inclusive_invalidates_;
+    int64_t num_coherence_invalidates_;
 
     // Stats saved when the last reset was called. This helps us get insight
     // into what the stats were when the cache was warmed up.
-    int_least64_t num_hits_at_reset_;
-    int_least64_t num_misses_at_reset_;
-    int_least64_t num_child_hits_at_reset_;
+    int64_t num_hits_at_reset_;
+    int64_t num_misses_at_reset_;
+    int64_t num_child_hits_at_reset_;
     // Enabled if options warmup_refs > 0 || warmup_fraction > 0
     bool warmup_enabled_;
 
@@ -253,7 +253,7 @@ protected:
 
     // References to the properties with statistics are held in the map with the
     // statistic name as the key. Sample map element: {HITS, num_hits_}
-    std::map<metric_name_t, int_least64_t &> stats_map_;
+    std::map<metric_name_t, int64_t &> stats_map_;
 
     // We provide a feature of dumping misses to a file.
     bool dump_misses_;

--- a/clients/drcachesim/simulator/snoop_filter.h
+++ b/clients/drcachesim/simulator/snoop_filter.h
@@ -65,9 +65,9 @@ protected:
     std::unordered_map<addr_t, coherence_table_entry_t> coherence_table_;
     cache_t **caches_;
     int num_snooped_caches_;
-    int_least64_t num_writes_;
-    int_least64_t num_writebacks_;
-    int_least64_t num_invalidates_;
+    int64_t num_writes_;
+    int64_t num_writebacks_;
+    int64_t num_invalidates_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -352,9 +352,9 @@ generate_1D_accesses(cache_t &cache, addr_t start_address, int step_size, int st
 
 // Helper code to grab a snapshot of cache stats.
 struct cache_stats_snapshot_t {
-    int_least64_t hits;
-    int_least64_t misses;
-    int_least64_t child_hits;
+    int64_t hits;
+    int64_t misses;
+    int64_t child_hits;
 };
 
 static cache_stats_snapshot_t

--- a/clients/drcachesim/tests/reuse_distance_test.cpp
+++ b/clients/drcachesim/tests/reuse_distance_test.cpp
@@ -309,7 +309,7 @@ print_histogram_empty_test()
     reuse_distance_test_t reuse_distance(knobs);
 
     // Create an empty histogram vector and distance histogram.
-    std::vector<std::pair<int_least64_t, int_least64_t>> sorted;
+    std::vector<std::pair<int64_t, int64_t>> sorted;
     reuse_distance_t::distance_histogram_t distance_map_data;
 
     // Make sure print_histogram handles this case without crashing.
@@ -336,13 +336,13 @@ print_histogram_mult_1p0_test()
     reuse_distance_test_t reuse_distance(knobs);
 
     // Fill in a sorted histogram vector.
-    std::vector<std::pair<int_least64_t, int_least64_t>> sorted;
+    std::vector<std::pair<int64_t, int64_t>> sorted;
     // Also put some matching entries in a data histogram.
     reuse_distance_t::distance_histogram_t distance_map_data;
 
     constexpr int N = 100;
 
-    int_least64_t count = 0;
+    int64_t count = 0;
     for (int i = 0; i < N; ++i) {
         sorted.emplace_back(i, 1);
         count += sorted.back().second;
@@ -381,12 +381,12 @@ print_histogram_mult_1p2_test()
     reuse_distance_test_t reuse_distance(knobs);
 
     // Fill in a sorted histogram vector.
-    std::vector<std::pair<int_least64_t, int_least64_t>> sorted;
+    std::vector<std::pair<int64_t, int64_t>> sorted;
     reuse_distance_t::distance_histogram_t distance_map_data;
 
     constexpr int N = 100;
 
-    int_least64_t count = 0;
+    int64_t count = 0;
     for (int i = 0; i < N; ++i) {
         sorted.emplace_back(i, 2);
         count += sorted.back().second;

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -218,7 +218,7 @@ basic_counts_t::cmp_threads(const std::pair<memref_tid_t, per_shard_t *> &l,
 }
 
 void
-basic_counts_t::print_counters(const counters_t &counters, int_least64_t num_threads,
+basic_counts_t::print_counters(const counters_t &counters, int64_t num_threads,
                                const std::string &prefix, bool for_kernel_trace)
 {
     std::cerr << std::setw(12) << counters.instrs << prefix

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -158,35 +158,35 @@ public:
                 dcache_flushes == rhs.dcache_flushes && encodings == rhs.encodings &&
                 unique_pc_addrs == rhs.unique_pc_addrs;
         }
-        int_least64_t instrs = 0;
-        int_least64_t instrs_nofetch = 0;
-        int_least64_t user_instrs = 0;
-        int_least64_t kernel_instrs = 0;
-        int_least64_t prefetches = 0;
-        int_least64_t loads = 0;
-        int_least64_t stores = 0;
-        int_least64_t sched_markers = 0;
-        int_least64_t xfer_markers = 0;
-        int_least64_t func_id_markers = 0;
-        int_least64_t func_retaddr_markers = 0;
-        int_least64_t func_arg_markers = 0;
-        int_least64_t func_retval_markers = 0;
-        int_least64_t phys_addr_markers = 0;
-        int_least64_t phys_unavail_markers = 0;
+        int64_t instrs = 0;
+        int64_t instrs_nofetch = 0;
+        int64_t user_instrs = 0;
+        int64_t kernel_instrs = 0;
+        int64_t prefetches = 0;
+        int64_t loads = 0;
+        int64_t stores = 0;
+        int64_t sched_markers = 0;
+        int64_t xfer_markers = 0;
+        int64_t func_id_markers = 0;
+        int64_t func_retaddr_markers = 0;
+        int64_t func_arg_markers = 0;
+        int64_t func_retval_markers = 0;
+        int64_t phys_addr_markers = 0;
+        int64_t phys_unavail_markers = 0;
         // XXX i#5490: Add a counter for indirect branch target markers?
-        int_least64_t other_markers = 0;
-        int_least64_t icache_flushes = 0;
-        int_least64_t dcache_flushes = 0;
+        int64_t other_markers = 0;
+        int64_t icache_flushes = 0;
+        int64_t dcache_flushes = 0;
         // The encoding entries aren't exposed at the memref_t level, but
         // we use encoding_is_new as a proxy.
-        int_least64_t encodings = 0;
+        int64_t encodings = 0;
         std::unordered_set<uint64_t> unique_pc_addrs;
 
         // Metadata for the counts. These are not used for the equality, increment,
         // or decrement operation, and must be set explicitly.
 
         // Count of shards that were combined to produce the above counts.
-        int_least64_t shard_count = 1;
+        int64_t shard_count = 1;
 
         // Stops tracking unique_pc_addrs. Tracking unique_pc_addrs can be very
         // memory intensive. We skip it for interval state snapshots.
@@ -244,7 +244,7 @@ protected:
     cmp_threads(const std::pair<memref_tid_t, per_shard_t *> &l,
                 const std::pair<memref_tid_t, per_shard_t *> &r);
     static void
-    print_counters(const counters_t &counters, int_least64_t num_threads,
+    print_counters(const counters_t &counters, int64_t num_threads,
                    const std::string &prefix, bool for_kernel_trace = false);
     void
     compute_shard_interval_result(per_shard_t *shard, uint64_t interval_id);

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -77,8 +77,8 @@ protected:
             num_returns += rhs.num_returns;
             return *this;
         }
-        int_least64_t num_calls = 0;
-        int_least64_t num_returns = 0;
+        int64_t num_calls = 0;
+        int64_t num_returns = 0;
         // TODO i#4083: Record the arg and retval distributions.
     };
     struct shard_data_t {

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -234,7 +234,7 @@ opcode_mix_t::process_memref(const memref_t &memref)
 }
 
 static bool
-cmp_val(const std::pair<int, int_least64_t> &l, const std::pair<int, int_least64_t> &r)
+cmp_val(const std::pair<int, int64_t> &l, const std::pair<int, int64_t> &r)
 {
     return (l.second > r.second);
 }
@@ -255,8 +255,8 @@ opcode_mix_t::print_results()
     }
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << std::setw(15) << total.instr_count << " : total executed instructions\n";
-    std::vector<std::pair<int, int_least64_t>> sorted(total.opcode_counts.begin(),
-                                                      total.opcode_counts.end());
+    std::vector<std::pair<int, int64_t>> sorted(total.opcode_counts.begin(),
+                                                total.opcode_counts.end());
     std::sort(sorted.begin(), sorted.end(), cmp_val);
     for (const auto &keyvals : sorted) {
         std::cerr << std::setw(15) << keyvals.second << " : " << std::setw(9)

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -94,8 +94,8 @@ protected:
         {
         }
         worker_data_t *worker;
-        int_least64_t instr_count;
-        std::unordered_map<int, int_least64_t> opcode_counts;
+        int64_t instr_count;
+        std::unordered_map<int, int64_t> opcode_counts;
         std::string error;
         app_pc last_trace_module_start;
         size_t last_trace_module_size;

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -166,7 +166,7 @@ reuse_distance_t::parallel_shard_memref(void *shard_data, const memref_t &memref
                 delete ref;
             }
         } else {
-            int_least64_t dist = shard->ref_list->move_to_front(it->second);
+            int64_t dist = shard->ref_list->move_to_front(it->second);
             auto &dist_map = is_instr_type ? shard->dist_map : shard->dist_map_data;
             distance_histogram_t::iterator dist_it = dist_map.find(dist);
             if (dist_it == dist_map.end())
@@ -257,7 +257,7 @@ reuse_distance_t::print_shard_results(const shard_data_t *shard)
     std::cerr.setf(std::ios::fixed);
 
     double sum = 0.0;
-    int_least64_t count = 0;
+    int64_t count = 0;
     for (const auto &it : shard->dist_map) {
         sum += it.first * it.second;
         count += it.second;
@@ -265,7 +265,7 @@ reuse_distance_t::print_shard_results(const shard_data_t *shard)
     double mean = sum / count;
     std::cerr << "Reuse distance mean: " << mean << "\n";
     double sum_of_squares = 0;
-    int_least64_t recount = 0;
+    int64_t recount = 0;
     bool have_median = false;
     std::vector<distance_map_pair_t> sorted(shard->dist_map.size());
     std::partial_sort_copy(shard->dist_map.begin(), shard->dist_map.end(), sorted.begin(),
@@ -331,7 +331,7 @@ reuse_distance_t::print_shard_results(const shard_data_t *shard)
 }
 
 void
-reuse_distance_t::print_histogram(std::ostream &out, int_least64_t total_count,
+reuse_distance_t::print_histogram(std::ostream &out, int64_t total_count,
                                   const std::vector<distance_map_pair_t> &sorted,
                                   const distance_histogram_t &dist_map_data)
 {
@@ -353,20 +353,20 @@ reuse_distance_t::print_histogram(std::ostream &out, int_least64_t total_count,
     out << std::setw(12) << "Count"
         << "  Percent  Cumulative"
         << "  :       Count  Percent  Cumulative\n";
-    int_least64_t max_distance = sorted.empty() ? 0 : sorted.back().first;
+    int64_t max_distance = sorted.empty() ? 0 : sorted.back().first;
     double cum_percent = 0;
     double data_cum_percent = 0;
-    int_least64_t bin_count = 0;
-    int_least64_t data_bin_count = 0;
-    int_least64_t bin_size = 1;
+    int64_t bin_count = 0;
+    int64_t data_bin_count = 0;
+    int64_t bin_size = 1;
     double bin_size_float = 1.0;
-    int_least64_t bin_start = 0;
-    int_least64_t bin_next_start = bin_start + bin_size;
+    int64_t bin_start = 0;
+    int64_t bin_next_start = bin_start + bin_size;
     for (auto it = sorted.begin(); it != sorted.end(); ++it) {
         const auto this_bin_number = it->first;
         auto data_it = dist_map_data.find(this_bin_number);
-        int_least64_t this_bin_count = it->second;
-        int_least64_t this_data_bin_count =
+        int64_t this_bin_count = it->second;
+        int64_t this_data_bin_count =
             data_it == dist_map_data.end() ? 0 : data_it->second;
         // The last bin needs to force an output.
         bool last_bin = *it == sorted.back();
@@ -403,7 +403,7 @@ reuse_distance_t::print_histogram(std::ostream &out, int_least64_t total_count,
             bin_start = bin_next_start;
             bin_size_float *= bin_multiplier;
             // Use floor() to favor smaller bin sizes.
-            bin_size = static_cast<int_least64_t>(std::floor(bin_size_float));
+            bin_size = static_cast<int64_t>(std::floor(bin_size_float));
             bin_next_start = bin_start + bin_size;
         }
         bin_count += this_bin_count;

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -93,8 +93,8 @@ public:
     // different verbosities.
     static unsigned int knob_verbose;
 
-    using distance_histogram_t = std::unordered_map<int_least64_t, int_least64_t>;
-    using distance_map_pair_t = std::pair<int_least64_t, int_least64_t>;
+    using distance_histogram_t = std::unordered_map<int64_t, int64_t>;
+    using distance_map_pair_t = std::pair<int64_t, int64_t>;
 
 protected:
     // We assume that the shard unit is the unit over which we should measure
@@ -121,8 +121,8 @@ protected:
         distance_histogram_t dist_map_data;
         bool dist_map_is_instr_only = true;
         std::unique_ptr<line_ref_list_t> ref_list;
-        int_least64_t total_refs = 0;
-        int_least64_t data_refs = 0; // Non-instruction reference count.
+        int64_t total_refs = 0;
+        int64_t data_refs = 0; // Non-instruction reference count.
         // Ideally the shard index would be the tid when shard==thread but that's
         // not the case today so we store the tid.
         memref_tid_t tid;
@@ -131,12 +131,12 @@ protected:
         unsigned int distance_limit = 0;
         // Track the number of insertions (pruned_address_count) and deletions
         // (pruned_address_hits) from the pruned_addresses set.
-        uint_least64_t pruned_address_count = 0;
-        uint_least64_t pruned_address_hits = 0;
+        uint64_t pruned_address_count = 0;
+        uint64_t pruned_address_hits = 0;
     };
 
     void
-    print_histogram(std::ostream &out, int_least64_t total_count,
+    print_histogram(std::ostream &out, int64_t total_count,
                     const std::vector<distance_map_pair_t> &sorted,
                     const distance_histogram_t &dist_map_data);
 
@@ -171,7 +171,7 @@ struct line_ref_t {
     // We inline the fields in every node for simplicity and to reduce allocs.
     struct line_ref_t *prev_skip; // the prev line_ref in the skip list
     struct line_ref_t *next_skip; // the next line_ref in the skip list
-    int_least64_t depth;          // only valid for skip list nodes; -1 for others
+    int64_t depth;                // only valid for skip list nodes; -1 for others
 
     line_ref_t(addr_t val)
         : prev(NULL)
@@ -361,7 +361,7 @@ struct line_ref_list_t {
     // We need to move the gate_ pointer forward if the referenced cache
     // line is the gate_ cache line or any cache line after.
     // Returns the reuse distance of ref.
-    int_least64_t
+    int64_t
     move_to_front(line_ref_t *ref)
     {
         IF_DEBUG_VERBOSE(
@@ -384,7 +384,7 @@ struct line_ref_list_t {
         }
 
         // Compute reuse distance.
-        int_least64_t dist = 0;
+        int64_t dist = 0;
         line_ref_t *skip;
         for (skip = ref; skip != NULL && skip->depth == -1; skip = skip->prev)
             ++dist;
@@ -398,7 +398,7 @@ struct line_ref_list_t {
                 // Compute reuse distance with a full list walk as a sanity check.
                 // This is a debug-only option, so we guard with IF_DEBUG_VERBOSE(0).
                 // Yes, the option check branch shows noticeable overhead without it.
-                int_least64_t brute_dist = 0;
+                int64_t brute_dist = 0;
                 for (prev = head_; prev != ref; prev = prev->next)
                     ++brute_dist;
                 if (brute_dist != dist) {

--- a/clients/drcachesim/tools/reuse_time.cpp
+++ b/clients/drcachesim/tools/reuse_time.cpp
@@ -136,7 +136,7 @@ reuse_time_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     shard->time_stamp++;
     addr_t line = memref.data.addr >> line_size_bits_;
     if (shard->time_map.count(line) > 0) {
-        int_least64_t reuse_time = shard->time_stamp - shard->time_map[line];
+        int64_t reuse_time = shard->time_stamp - shard->time_map[line];
         if (DEBUG_VERBOSE(3)) {
             std::cerr << "Reuse " << reuse_time << std::endl;
         }
@@ -165,8 +165,7 @@ reuse_time_t::process_memref(const memref_t &memref)
 }
 
 static bool
-cmp_dist_key(const std::pair<int_least64_t, int_least64_t> &l,
-             const std::pair<int_least64_t, int_least64_t> &r)
+cmp_dist_key(const std::pair<int64_t, int64_t> &l, const std::pair<int64_t, int64_t> &r)
 {
     return (l.first < r.first);
 }
@@ -179,8 +178,8 @@ reuse_time_t::print_shard_results(const shard_data_t *shard)
     std::cerr.precision(2);
     std::cerr.setf(std::ios::fixed);
 
-    int_least64_t count = 0;
-    int_least64_t sum = 0;
+    int64_t count = 0;
+    int64_t sum = 0;
     for (const auto &it : shard->reuse_time_histogram) {
         count += it.second;
         sum += it.first * it.second;
@@ -192,8 +191,7 @@ reuse_time_t::print_shard_results(const shard_data_t *shard)
               << "Percent" << std::setw(12) << "Cumulative";
     std::cerr << std::endl;
     double cum_percent = 0.0;
-    std::vector<std::pair<int_least64_t, int_least64_t>> sorted(
-        shard->reuse_time_histogram.size());
+    std::vector<std::pair<int64_t, int64_t>> sorted(shard->reuse_time_histogram.size());
     std::partial_sort_copy(shard->reuse_time_histogram.begin(),
                            shard->reuse_time_histogram.end(), sorted.begin(),
                            sorted.end(), cmp_dist_key);

--- a/clients/drcachesim/tools/reuse_time.h
+++ b/clients/drcachesim/tools/reuse_time.h
@@ -65,10 +65,10 @@ protected:
     // Just like for reuse_distance_t, we assume that the shard unit is the unit over
     // which we should measure time.  By default this is a traced thread.
     struct shard_data_t {
-        std::unordered_map<addr_t, int_least64_t> time_map;
-        int_least64_t time_stamp = 0;
-        int_least64_t total_instructions = 0;
-        std::unordered_map<int_least64_t, int_least64_t> reuse_time_histogram;
+        std::unordered_map<addr_t, int64_t> time_map;
+        int64_t time_stamp = 0;
+        int64_t total_instructions = 0;
+        std::unordered_map<int64_t, int64_t> reuse_time_histogram;
         memref_tid_t tid;
         std::string error;
     };

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -139,8 +139,7 @@ syscall_mix_t::process_memref(const memref_t &memref)
 }
 
 static bool
-cmp_second_val(const std::pair<int, int_least64_t> &l,
-               const std::pair<int, int_least64_t> &r)
+cmp_second_val(const std::pair<int, int64_t> &l, const std::pair<int, int64_t> &r)
 {
     return l.second > r.second;
 }
@@ -161,8 +160,8 @@ syscall_mix_t::print_results()
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << std::setw(15) << "count"
               << " : " << std::setw(9) << "syscall_num\n";
-    std::vector<std::pair<int, int_least64_t>> sorted(total.syscall_counts.begin(),
-                                                      total.syscall_counts.end());
+    std::vector<std::pair<int, int64_t>> sorted(total.syscall_counts.begin(),
+                                                total.syscall_counts.end());
     std::sort(sorted.begin(), sorted.end(), cmp_second_val);
     for (const auto &keyvals : sorted) {
         // XXX: It would be nicer to print the system call name string instead of

--- a/clients/drcachesim/tools/syscall_mix.h
+++ b/clients/drcachesim/tools/syscall_mix.h
@@ -67,7 +67,7 @@ public:
 
 protected:
     struct shard_data_t {
-        std::unordered_map<int, int_least64_t> syscall_counts;
+        std::unordered_map<int, int64_t> syscall_counts;
         std::string error;
     };
 


### PR DESCRIPTION
Replaces the {u,}int_least64_t types used throughout the drcachesim code base with the more-precise {u,}int64_t types.  We were treating them as 64-bit anyway in our printf codes and other places, and all our supported toolchains have precise 64-bit types.

Adds a note to the release docs on the change.