### PR TITLE
i#725 attach: Remove flakiness from attach test

### DIFF
--- a/suite/tests/client-interface/attach_blocking.expect
+++ b/suite/tests/client-interface/attach_blocking.expect
@@ -1,5 +1,4 @@
 starting
 thank you for testing attach
 thread init
-event_post_attach
 done

--- a/suite/tests/client-interface/attach_test.dll.c
+++ b/suite/tests/client-interface/attach_test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -39,14 +39,17 @@
 
 static thread_id_t injection_tid;
 static bool first_thread = true;
+static bool saw_attach_event = false;
 
 static void
 dr_exit(void)
 {
+    if (!saw_attach_event)
+        dr_fprintf(STDERR, "Error: never saw attach event!\n");
 #ifdef WINDOWS
     dr_fprintf(STDERR, "done\n");
 #else
-    /* The app prints 'done' for us. */
+        /* The app prints 'done' for us. */
 #endif
 }
 
@@ -91,7 +94,8 @@ dr_exception_event(void *drcontext, dr_exception_t *excpt)
 static void
 event_post_attach(void)
 {
-    dr_fprintf(STDERR, "%s\n", __FUNCTION__);
+    // We do not print here as the ordering is non-deterministic vs thread init.
+    saw_attach_event = true;
 }
 
 DR_EXPORT

--- a/suite/tests/client-interface/attach_test.template
+++ b/suite/tests/client-interface/attach_test.template
@@ -4,13 +4,7 @@ starting attachee
 starting
 #endif
 thank you for testing attach
-#ifdef WINDOWS
-event_post_attach
 thread init
-#else
-thread init
-event_post_attach
-#endif
 #ifdef WINDOWS
 MessageBox closed
 #endif


### PR DESCRIPTION
Removes the printing of "event_post_attach" in the client.attach test, as it had non-deterministic ordering versus the "thread init" printing (and runall.cmake requires "thread init").  Replaces with a boolean check and error print at exit to ensure we saw the attach event.

This completes the base attach feature.  Future problems should open new issues.

Fixes #725