### PR TITLE
i#5843 scheduler: Add query of input workload

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1170,6 +1170,17 @@ scheduler_tmpl_t<RecordType, ReaderType>::get_input_ordinal(output_ordinal_t out
 }
 
 template <typename RecordType, typename ReaderType>
+int
+scheduler_tmpl_t<RecordType, ReaderType>::get_workload_ordinal(output_ordinal_t output)
+{
+    if (output < 0 || output >= static_cast<output_ordinal_t>(outputs_.size()))
+        return -1;
+    if (outputs_[output].cur_input < 0)
+        return -1;
+    return inputs_[outputs_[output].cur_input].workload;
+}
+
+template <typename RecordType, typename ReaderType>
 bool
 scheduler_tmpl_t<RecordType, ReaderType>::is_record_synthetic(output_ordinal_t output)
 {

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -627,6 +627,17 @@ public:
             return scheduler_->get_input_ordinal(ordinal_);
         }
         /**
+         * Returns the ordinal for the workload which is the source of the current input
+         * stream feeding this output stream.  This workload ordinal is the index into the
+         * vector of #input_workload_t passed to init().  Returns -1 if there is no
+         * current input for this output stream.
+         */
+        virtual int
+        get_input_workload_ordinal()
+        {
+            return scheduler_->get_workload_ordinal(ordinal_);
+        }
+        /**
          * Returns the value of the most recently seen #TRACE_MARKER_TYPE_TIMESTAMP
          * marker.
          */
@@ -1079,6 +1090,11 @@ protected:
     // the 'output_ordinal'-th output stream.
     input_ordinal_t
     get_input_ordinal(output_ordinal_t output);
+
+    // Returns the workload ordinal value for the current input stream scheduled on
+    // the 'output_ordinal'-th output stream.
+    int
+    get_workload_ordinal(output_ordinal_t output);
 
     // Returns whether the current record for the current input stream scheduled on
     // the 'output_ordinal'-th output stream is synthetic.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -629,8 +629,9 @@ public:
         /**
          * Returns the ordinal for the workload which is the source of the current input
          * stream feeding this output stream.  This workload ordinal is the index into the
-         * vector of #input_workload_t passed to init().  Returns -1 if there is no
-         * current input for this output stream.
+         * vector of type #dynamorio::drmemtrace::scheduler_tmpl_t::input_workload_t
+         * passed to init().  Returns -1 if there is no current input for this output
+         * stream.
          */
         virtual int
         get_input_workload_ordinal()


### PR DESCRIPTION
Adds a new stream API get_input_workload_ordinal() which allows the output stream to figure out which workload its current input stream came from.

Adds a couple of sanity tests.

Issue: #5843