### PR TITLE
i#5490 ib targets: Add memref ind branch target field

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -181,6 +181,8 @@ changes:
    #dynamorio::drmemtrace::TRACE_TYPE_INSTR_UNTAKEN_JUMP.
  - All int_least64_t and uint_least64_t types in drcachesim were replaced with
    their precise counterparts int64_t and uint64_t.
+ - The #dynamorio::drmemtrace::memref_t structure has a new field appended for
+   holding the actual target of each indirect branch.
 
 Further non-compatibility-affecting changes include:
  - Added new drmemtrace option -L0_filter_until_instrs which enables filtering
@@ -277,10 +279,6 @@ Further non-compatibility-affecting changes include:
  - Added a new drmemtrace analysis tool: syscall_mix, to count frequency of system
    calls in a trace. This tool works in both the online and offline modes of
    drmemtrace.
- - Indirect branches in drmemtrace traces now contain a marker holding the
-   actual target
-   (#dynamorio::drmemtrace::TRACE_MARKER_TYPE_BRANCH_TARGET), which immediately
-   precedes the branch record.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -83,6 +83,13 @@ struct _memref_instr_t {
      * not only when application code actually changed.
      */
     bool encoding_is_new;
+    /**
+     * Valid only for an indirect branch instruction (types
+     * #TRACE_TYPE_INSTR_INDIRECT_JUMP, #TRACE_TYPE_INSTR_INDIRECT_CALL, and
+     * #TRACE_TYPE_INSTR_RETURN).  Holds the actual target of that branch.  This is only
+     * present in trace version #TRACE_ENTRY_VERSION_BRANCH_INFO and higher.
+     */
+    addr_t indirect_branch_target;
 };
 
 /** A trace entry representing a software-requested explicit cache flush. */

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -82,8 +82,8 @@ typedef enum {
      * The trace includes branch taken and target information up front.  This means that
      * conditional branches use either #TRACE_TYPE_INSTR_TAKEN_JUMP or
      * #TRACE_TYPE_INSTR_UNTAKEN_JUMP and that the target of indirect branches is in a
-     * marker of type #TRACE_MARKER_TYPE_BRANCH_TARGET prior to the indirect branch
-     * instruction entry itself.  This only applies to offline traces whose instructions
+     * new field "indirect_branch_target" in #memref_t.
+     * This only applies to offline traces whose instructions
      * are not filtered; online traces, and i-filtered offline traces, even at this
      * version, do not contain this information.
      */
@@ -525,11 +525,9 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
 
-    /**
-     * This marker is present just before each indirect branch instruction in offline
-     * non-i-filtered traces.  The marker value holds the actual target of the
-     * branch.
-     */
+    // Internal marker present just before each indirect branch instruction in offline
+    // non-i-filtered traces.  The marker value holds the actual target of the
+    // branch.  The reader converts this to the memref_t "indirect_branch_target" field.
     TRACE_MARKER_TYPE_BRANCH_TARGET,
 
     // ...

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -140,9 +140,8 @@ See also \ref sec_drcachesim_core.
 Whether conditional branches are taken or untaken is indicated by the
 instruction types #dynamorio::drmemtrace::TRACE_TYPE_INSTR_TAKEN_JUMP
 and #dynamorio::drmemtrace::TRACE_TYPE_INSTR_UNTAKEN_JUMP.  The target
-of each indirect branch is explicitly provided by a metadata marker
-record of type #dynamorio::drmemtrace::TRACE_MARKER_TYPE_BRANCH_TARGET
-just prior to the branch record itself.
+of each indirect branch is explicitly provided by the "indirect_branch_target"
+field in #dynamorio::drmemtrace::memref_t.
 If the program flow is changed by the kernel such as by
 signal delivery, the branch target is explicitly recorded in the trace in a metadata
 marker entry of type #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT.
@@ -707,49 +706,45 @@ An example of thread switches:
 
 
 Here is an example of a signal handler interrupting the regular flow,
-with metadata showing that the signal was delivered just after a
-taken conditional branch:
+with metadata showing that the signal was delivered just after an
+untaken conditional branch:
 
 \code
-     2214424     1649600:     1249326 ifetch       4 byte(s) @ 0x00007f34066b86c5 48 83 fa 17          cmp    %rdx, $0x17
-     2214425     1649601:     1249326 ifetch       6 byte(s) @ 0x00007f34066b86c9 0f 86 4f 01 00 00    jbe    $0x00007f34066b881e (untaken)
-     2214426     1649602:     1249326 ifetch       4 byte(s) @ 0x00007f34066b86cf 48 83 fa 4f          cmp    %rdx, $0x4f
-     2214427     1649603:     1249326 ifetch       6 byte(s) @ 0x00007f34066b86d3 0f 87 b7 00 00 00    jnbe   $0x00007f34066b8790 (taken)
-     2214428     1649603:     1249326 <marker: kernel xfer from 0x7f34066b8790 to handler>
-     2214429     1649603:     1249326 <marker: timestamp 13334353561241197>
-     2214430     1649603:     1249326 <marker: tid 1249326 on core 1>
-     2214431     1649604:     1249326 ifetch       1 byte(s) @ 0x00007f3402ffa259 55                   push   %rbp
-     2214432     1649604:     1249326 write        8 byte(s) @ 0x00007ffd91e24230 by PC 0x00007f3402ffa259
-     2214433     1649605:     1249326 ifetch       3 byte(s) @ 0x00007f3402ffa25a 48 89 e5             mov    %rsp, %rbp
-     2214434     1649606:     1249326 ifetch       3 byte(s) @ 0x00007f3402ffa25d 89 7d fc             mov    %edi, -0x04(%rbp)
-     2214435     1649606:     1249326 write        4 byte(s) @ 0x00007ffd91e2422c by PC 0x00007f3402ffa25d
-     2214436     1649607:     1249326 ifetch       4 byte(s) @ 0x00007f3402ffa260 48 89 75 f0          mov    %rsi, -0x10(%rbp)
-     2214437     1649607:     1249326 write        8 byte(s) @ 0x00007ffd91e24220 by PC 0x00007f3402ffa260
-     2214438     1649608:     1249326 ifetch       4 byte(s) @ 0x00007f3402ffa264 48 89 55 e8          mov    %rdx, -0x18(%rbp)
-     2214439     1649608:     1249326 write        8 byte(s) @ 0x00007ffd91e24218 by PC 0x00007f3402ffa264
-     2214440     1649609:     1249326 ifetch       4 byte(s) @ 0x00007f3402ffa268 83 7d fc 1a          cmp    -0x04(%rbp), $0x1a
-     2214441     1649609:     1249326 read         4 byte(s) @ 0x00007ffd91e2422c by PC 0x00007f3402ffa268
-     2214442     1649610:     1249326 ifetch       2 byte(s) @ 0x00007f3402ffa26c 75 0f                jnz    $0x00007f3402ffa27d (untaken)
-     2214443     1649611:     1249326 ifetch       6 byte(s) @ 0x00007f3402ffa26e 8b 05 c0 3e 00 00    mov    <rel> 0x00007f3402ffe134, %eax
-     2214444     1649611:     1249326 read         4 byte(s) @ 0x00007f3402ffe134 by PC 0x00007f3402ffa26e
-     2214445     1649612:     1249326 ifetch       3 byte(s) @ 0x00007f3402ffa274 83 c0 01             add    $0x01, %eax
-     2214446     1649613:     1249326 ifetch       6 byte(s) @ 0x00007f3402ffa277 89 05 b7 3e 00 00    mov    %eax, <rel> 0x00007f3402ffe134
-     2214447     1649613:     1249326 write        4 byte(s) @ 0x00007f3402ffe134 by PC 0x00007f3402ffa277
-     2214448     1649614:     1249326 ifetch       1 byte(s) @ 0x00007f3402ffa27d 90                   nop
-     2214449     1649615:     1249326 ifetch       1 byte(s) @ 0x00007f3402ffa27e 5d                   pop    %rbp
-     2214450     1649615:     1249326 read         8 byte(s) @ 0x00007ffd91e24230 by PC 0x00007f3402ffa27e
-     2214451     1649615:     1249326 <marker: indirect branch target 0x7f340665af90>
-     2214452     1649616:     1249326 ifetch       1 byte(s) @ 0x00007f3402ffa27f c3                   ret
-     2214453     1649616:     1249326 read         8 byte(s) @ 0x00007ffd91e24238 by PC 0x00007f3402ffa27f
-     2214454     1649617:     1249326 ifetch       7 byte(s) @ 0x00007f340665af90 48 c7 c0 0f 00 00 00 mov    $0x0000000f, %rax
-     2214455     1649618:     1249326 ifetch       2 byte(s) @ 0x00007f340665af97 0f 05                syscall
-     2214456     1649618:     1249326 <marker: system call 15>
-     2214457     1649618:     1249326 <marker: timestamp 13334353561241207>
-     2214458     1649618:     1249326 <marker: tid 1249326 on core 1>
-     2214459     1649618:     1249326 <marker: syscall xfer from 0x7f340665af99>
-     2214460     1649618:     1249326 <marker: timestamp 13334353561241213>
-     2214461     1649618:     1249326 <marker: tid 1249326 on core 1>
-     2214462     1649619:     1249326 ifetch       4 byte(s) @ 0x00007f34066b8790 48 83 c4 18          add    $0x18, %rsp
+      801343      601827:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa5c70 75 57                jnz    $0x00007fc2c3aa5cc9 (untaken)
+      801344      601827:     1159769 <marker: kernel xfer from 0x7fc2c3aa5c72 to handler>
+      801345      601827:     1159769 <marker: timestamp 13335923552684013>
+      801346      601827:     1159769 <marker: tid 1159769 on core 7>
+      801347      601828:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa259 55                   push   %rbp
+      801348      601828:     1159769 write        8 byte(s) @ 0x00007fff8044e930 by PC 0x00007fc2c03fa259
+      801349      601829:     1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa25a 48 89 e5             mov    %rsp, %rbp
+      801350      601830:     1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa25d 89 7d fc             mov    %edi, -0x04(%rbp)
+      801351      601830:     1159769 write        4 byte(s) @ 0x00007fff8044e92c by PC 0x00007fc2c03fa25d
+      801352      601831:     1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa260 48 89 75 f0          mov    %rsi, -0x10(%rbp)
+      801353      601831:     1159769 write        8 byte(s) @ 0x00007fff8044e920 by PC 0x00007fc2c03fa260
+      801354      601832:     1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa264 48 89 55 e8          mov    %rdx, -0x18(%rbp)
+      801355      601832:     1159769 write        8 byte(s) @ 0x00007fff8044e918 by PC 0x00007fc2c03fa264
+      801356      601833:     1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa268 83 7d fc 1a          cmp    -0x04(%rbp), $0x1a
+      801357      601833:     1159769 read         4 byte(s) @ 0x00007fff8044e92c by PC 0x00007fc2c03fa268
+      801358      601834:     1159769 ifetch       2 byte(s) @ 0x00007fc2c03fa26c 75 0f                jnz    $0x00007fc2c03fa27d (untaken)
+      801359      601835:     1159769 ifetch       6 byte(s) @ 0x00007fc2c03fa26e 8b 05 c0 3e 00 00    mov    <rel> 0x00007fc2c03fe134, %eax
+      801360      601835:     1159769 read         4 byte(s) @ 0x00007fc2c03fe134 by PC 0x00007fc2c03fa26e
+      801361      601836:     1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa274 83 c0 01             add    $0x01, %eax
+      801362      601837:     1159769 ifetch       6 byte(s) @ 0x00007fc2c03fa277 89 05 b7 3e 00 00    mov    %eax, <rel> 0x00007fc2c03fe134
+      801363      601837:     1159769 write        4 byte(s) @ 0x00007fc2c03fe134 by PC 0x00007fc2c03fa277
+      801364      601838:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27d 90                   nop
+      801365      601839:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27e 5d                   pop    %rbp
+      801366      601839:     1159769 read         8 byte(s) @ 0x00007fff8044e930 by PC 0x00007fc2c03fa27e
+      801367      601840:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27f c3                   ret (target 0x7fc2c3a5af90)
+      801368      601840:     1159769 read         8 byte(s) @ 0x00007fff8044e938 by PC 0x00007fc2c03fa27f
+      801369      601841:     1159769 ifetch       7 byte(s) @ 0x00007fc2c3a5af90 48 c7 c0 0f 00 00 00 mov    $0x0000000f, %rax
+      801370      601842:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3a5af97 0f 05                syscall
+      801371      601842:     1159769 <marker: system call 15>
+      801372      601842:     1159769 <marker: timestamp 13335923552684023>
+      801373      601842:     1159769 <marker: tid 1159769 on core 7>
+      801374      601842:     1159769 <marker: syscall xfer from 0x7fc2c3a5af99>
+      801375      601842:     1159769 <marker: timestamp 13335923552684029>
+      801376      601842:     1159769 <marker: tid 1159769 on core 7>
+      801377      601843:     1159769 ifetch       4 byte(s) @ 0x00007fc2c3aa5c72 48 83 c4 48          add    $0x48, %rsp
 \endcode
 
 \section sec_tool_func_view View Function Calls
@@ -1375,18 +1370,19 @@ Traces also include markers indicating disruptions in user mode control
 flow such as signal handler entry and exit.
 
 Offline traces explicitly identify whether each conditional branch was
-taken or not, and include a marker showing the target of unconditional
+taken or not, and include the actual target of indirect
 branches, for convenience to avoid having to read either the
 subsequent entry or the kernel transfer event marker (or infer branch
 behavior for rseq aborts):
 
 ```
-     2212815     1648444:     1249326 ifetch       6 byte(s) @ 0x00007f3406720707 48 3d 01 f0 ff ff    cmp    %rax, $0xfffff001
-     2212816     1648445:     1249326 ifetch       2 byte(s) @ 0x00007f340672070d 73 01                jnb    $0x00007f3406720710 (untaken)
-     2212817     1648445:     1249326 <marker: indirect branch target 0x7f34066a8b37>
-     2212818     1648446:     1249326 ifetch       1 byte(s) @ 0x00007f340672070f c3                   ret
-     2212819     1648446:     1249326 read         8 byte(s) @ 0x00007ffd91e24fa8 by PC 0x00007f340672070f
-     2212820     1648447:     1249326 ifetch       5 byte(s) @ 0x00007f34066a8b37 4c 8b 54 24 48       mov    0x48(%rsp), %r10
+      801394      601853:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa91e3 7f 1b                jnle   $0x00007fc2c3aa9200 (untaken)
+      801395      601854:     1159769 ifetch       4 byte(s) @ 0x00007fc2c3aa91e5 48 83 c4 10          add    $0x10, %rsp
+      801396      601855:     1159769 ifetch       1 byte(s) @ 0x00007fc2c3aa91e9 5b                   pop    %rbx
+      801397      601855:     1159769 read         8 byte(s) @ 0x00007fff8044f6c0 by PC 0x00007fc2c3aa91e9
+      801398      601856:     1159769 ifetch       1 byte(s) @ 0x00007fc2c3aa91ea c3                   ret (target 0x7fc2c3aa81c1)
+      801399      601856:     1159769 read         8 byte(s) @ 0x00007fff8044f6c8 by PC 0x00007fc2c3aa91ea
+      801400      601857:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa81c1 89 c5                mov    %eax, %ebp
 ```
 
 Filtered traces (filtered via -L0_filter) include the dynamic

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -174,7 +174,12 @@ reader_t::process_input_entry()
             cur_ref_.instr.tid = cur_tid_;
             cur_ref_.instr.type = (trace_type_t)input_entry_->type;
             cur_ref_.instr.size = input_entry_->size;
-            cur_ref_.instr.indirect_branch_target = last_branch_target_;
+            if (type_is_instr_branch(cur_ref_.instr.type) &&
+                !type_is_instr_direct_branch(cur_ref_.instr.type)) {
+                cur_ref_.instr.indirect_branch_target = last_branch_target_;
+            } else {
+                cur_ref_.instr.indirect_branch_target = 0;
+            }
             cur_pc_ = input_entry_->addr;
             cur_ref_.instr.addr = cur_pc_;
             next_pc_ = cur_pc_ + cur_ref_.instr.size;

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -174,6 +174,7 @@ reader_t::process_input_entry()
             cur_ref_.instr.tid = cur_tid_;
             cur_ref_.instr.type = (trace_type_t)input_entry_->type;
             cur_ref_.instr.size = input_entry_->size;
+            cur_ref_.instr.indirect_branch_target = last_branch_target_;
             cur_pc_ = input_entry_->addr;
             cur_ref_.instr.addr = cur_pc_;
             next_pc_ = cur_pc_ + cur_ref_.instr.size;
@@ -286,6 +287,9 @@ reader_t::process_input_entry()
             skip_chunk_header_.erase(cur_tid_);
         } else if (cur_ref_.marker.marker_type == TRACE_MARKER_TYPE_RECORD_ORDINAL) {
             // Not exposed to tools.
+        } else if (cur_ref_.marker.marker_type == TRACE_MARKER_TYPE_BRANCH_TARGET) {
+            // Not exposed to tools.
+            last_branch_target_ = cur_ref_.marker.marker_value;
         } else {
             have_memref = true;
         }

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -262,6 +262,7 @@ private:
     bool expect_no_encodings_ = true;
     encoding_info_t last_encoding_;
     std::unordered_map<addr_t, encoding_info_t> encodings_;
+    addr_t last_branch_target_ = 0;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1020,8 +1020,8 @@ check_branch_decoration()
         std::vector<memref_t> memrefs = {
             gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
             gen_instr(TID, /*pc=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_BRANCH_TARGET, 32),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+                           /*target=*/32),
             gen_instr(TID, /*pc=*/32),
         };
         if (!run_checker(memrefs, false))
@@ -1034,8 +1034,8 @@ check_branch_decoration()
         std::vector<memref_t> memrefs = {
             gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
             gen_instr(TID, /*pc=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_BRANCH_TARGET, 32),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+                           /*target=*/32),
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 32),
             gen_instr(TID, /*pc=*/999),
         };
@@ -1043,35 +1043,35 @@ check_branch_decoration()
             return false;
     }
 #endif
-    // Indirect branch target: no marker.
+    // Indirect branch target: incorrect zero target PC.
     {
         std::vector<memref_t> memrefs = {
             gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
             gen_instr(TID, /*pc=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2),
-            gen_instr(TID, /*pc=*/32),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+                           /*target=*/0),
         };
         if (!run_checker(memrefs, true,
-                         { "Indirect branches must be preceded by their targets", TID,
+                         { "Indirect branches must contain targets", TID,
                            /*ref_ordinal=*/3, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
-                         "Failed to catch missing indirect branch target marker"))
+                         "Failed to catch missing indirect branch target field"))
             return false;
     }
-    // Indirect branch target: marker value incorrect.
+    // Indirect branch target: incorrect target value.
     {
         std::vector<memref_t> memrefs = {
             gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
             gen_instr(TID, /*pc=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_BRANCH_TARGET, 32),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+                           /*target=*/32),
             gen_instr(TID, /*pc=*/33),
         };
         if (!run_checker(memrefs, true,
                          { "Branch does not go to the correct target", TID,
-                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/3 },
-                         "Failed to catch bad indirect branch target marker"))
+                         "Failed to catch bad indirect branch target field"))
             return false;
     }
 #ifdef UNIX
@@ -1080,16 +1080,16 @@ check_branch_decoration()
         std::vector<memref_t> memrefs = {
             gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
             gen_instr(TID, /*pc=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_BRANCH_TARGET, 32),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+                           /*target=*/32),
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 999),
             gen_instr(TID, /*pc=*/32),
         };
         if (!run_checker(memrefs, true,
                          { "Branch does not go to the correct target", TID,
-                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
-                         "Failed to catch bad indirect branch target marker"))
+                         "Failed to catch bad indirect branch target field"))
             return false;
     }
 #endif

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -73,13 +73,15 @@ gen_data(memref_tid_t tid, bool load, addr_t addr, size_t size)
 }
 
 inline memref_t
-gen_instr_type(trace_type_t type, memref_tid_t tid, addr_t pc = 1, size_t size = 1)
+gen_instr_type(trace_type_t type, memref_tid_t tid, addr_t pc = 1, size_t size = 1,
+               addr_t indirect_branch_target = 0)
 {
     memref_t memref = {};
     memref.instr.type = type;
     memref.instr.tid = tid;
     memref.instr.addr = pc;
     memref.instr.size = size;
+    memref.instr.indirect_branch_target = indirect_branch_target;
     return memref;
 }
 

--- a/clients/drcachesim/tests/offline-legacy-int-offs.templatex
+++ b/clients/drcachesim/tests/offline-legacy-int-offs.templatex
@@ -20,7 +20,7 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-         752 total other markers
+          12 total other markers
         8429 total encodings
 Thread 552306 counts:
       101049 \(fetched\) instructions
@@ -39,7 +39,7 @@ Thread 552306 counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-         590 other markers
+           4 other markers
         6393 encodings
 Thread 552323 counts:
         4674 \(fetched\) instructions
@@ -58,7 +58,7 @@ Thread 552323 counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-          92 other markers
+           4 other markers
         1028 encodings
 Thread 552324 counts:
         3482 \(fetched\) instructions
@@ -77,7 +77,7 @@ Thread 552324 counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-          70 other markers
+           4 other markers
         1008 encodings
 #else
 ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.legacy-int-offs/raw/drmemtrace.drmemtrace.signal_invariants..*.raw.gz: Architecture mismatch: trace recorded on x86_64 but tools built for i386

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -173,7 +173,6 @@ public:
         int64_t func_retval_markers = 0;
         int64_t phys_addr_markers = 0;
         int64_t phys_unavail_markers = 0;
-        // XXX i#5490: Add a counter for indirect branch target markers?
         int64_t other_markers = 0;
         int64_t icache_flushes = 0;
         int64_t dcache_flushes = 0;

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -124,12 +124,6 @@ protected:
         memref_t last_xfer_marker_ = {}; // Not cleared: just the prior xfer marker.
         uintptr_t prev_func_id_ = 0;
         addr_t last_retaddr_ = 0;
-        // We treat 0 as a sentinel; thus we do not support a trace deliberately
-        // jumping to 0 and handling the fault.
-        addr_t last_indirect_target_ = 0;
-        // We need a dedicated variable to handle consecutive indirect branches
-        // where we can't just use the value from the last marker record.
-        addr_t last_branch_marker_value_ = 0;
         uintptr_t trace_version_ = 0;
 #ifdef UNIX
         // We keep track of some state per nested signal depth.

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -529,24 +529,23 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             return false;
         }
         disasm = buf;
-        auto newline = disasm.find('\n');
-        if (memref.instr.type == TRACE_TYPE_INSTR_TAKEN_JUMP)
-            disasm.insert(newline, " (taken)");
-        else if (memref.instr.type == TRACE_TYPE_INSTR_UNTAKEN_JUMP)
-            disasm.insert(newline, " (untaken)");
-        if (trace_version_ >= TRACE_ENTRY_VERSION_BRANCH_INFO &&
-            (memref.instr.type == TRACE_TYPE_INSTR_INDIRECT_JUMP ||
-             memref.instr.type == TRACE_TYPE_INSTR_INDIRECT_CALL ||
-             memref.instr.type == TRACE_TYPE_INSTR_RETURN)) {
-            std::stringstream str;
-            str << " (target 0x" << std::hex << memref.instr.indirect_branch_target
-                << ")";
-            disasm.insert(newline, str.str());
-        }
         disasm_cache_.insert({ orig_pc, disasm });
     }
-    // Put our prefix on raw byte spillover, and skip the other columns.
+    // Add branch decoration, which varies and so can't be cached purely by PC.
     auto newline = disasm.find('\n');
+    if (memref.instr.type == TRACE_TYPE_INSTR_TAKEN_JUMP)
+        disasm.insert(newline, " (taken)");
+    else if (memref.instr.type == TRACE_TYPE_INSTR_UNTAKEN_JUMP)
+        disasm.insert(newline, " (untaken)");
+    else if (trace_version_ >= TRACE_ENTRY_VERSION_BRANCH_INFO &&
+             type_is_instr_branch(memref.instr.type) &&
+             !type_is_instr_direct_branch(memref.instr.type)) {
+        std::stringstream str;
+        str << " (target 0x" << std::hex << memref.instr.indirect_branch_target << ")";
+        disasm.insert(newline, str.str());
+    }
+    // Put our prefix on raw byte spillover, and skip the other columns.
+    newline = disasm.find('\n');
     if (newline != std::string::npos && newline < disasm.size() - 1) {
         std::stringstream prefix;
         print_prefix(memstream, memref, -1, prefix);

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -534,6 +534,15 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             disasm.insert(newline, " (taken)");
         else if (memref.instr.type == TRACE_TYPE_INSTR_UNTAKEN_JUMP)
             disasm.insert(newline, " (untaken)");
+        if (trace_version_ >= TRACE_ENTRY_VERSION_BRANCH_INFO &&
+            (memref.instr.type == TRACE_TYPE_INSTR_INDIRECT_JUMP ||
+             memref.instr.type == TRACE_TYPE_INSTR_INDIRECT_CALL ||
+             memref.instr.type == TRACE_TYPE_INSTR_RETURN)) {
+            std::stringstream str;
+            str << " (target 0x" << std::hex << memref.instr.indirect_branch_target
+                << ")";
+            disasm.insert(newline, str.str());
+        }
         disasm_cache_.insert({ orig_pc, disasm });
     }
     // Put our prefix on raw byte spillover, and skip the other columns.


### PR DESCRIPTION
Adds a new "indirect_branch_target" field to memref_t.instr. Converts the new TRACE_MARKER_TYPE_BRANCH_TARGET marker to an internal record used by reader_t to fill in the new field.

Updates the invariant checker and test.
Updates the legacy test's marker counts.
Updates the documentation.

Issue: #5490