### PR TITLE
Fix gcc 12.2 warning in a64-on-x64 build

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1738,7 +1738,6 @@ drwrap_replace_native_fini(void *drcontext)
     volatile app_pc app_retaddr;
     byte *xsp = (byte *)dr_read_saved_reg(drcontext, DRWRAP_REPLACE_NATIVE_SP_SLOT);
 #ifdef DR_HOST_NOT_TARGET
-    byte *cur_xsp = NULL;
     ASSERT(false, "cross-arch execution is not supported");
 #elif defined(AARCHXX)
     byte *cur_xsp = get_cur_xsp();


### PR DESCRIPTION
Removes an unused variable which turns into an error in the aarch64-on-x86_64 build with gcc 12.2.