### PR TITLE
i#3544 RV64: Fix redundant compilation issue

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -169,7 +169,7 @@ add_gen_events_deps(drlibc)
 if (AARCH64)
   add_dependencies(drlibc gen_aarch64_codec)
 elseif (RISCV64)
-add_dependencies(drlibc gen_riscv64_codec)
+  add_dependencies(drlibc gen_riscv64_codec)
 endif (AARCH64)
 if (WIN32 AND "${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   # for parallel build correctness we need a target dependence

--- a/make/CMake_riscv64_gen_codec.cmake
+++ b/make/CMake_riscv64_gen_codec.cmake
@@ -38,7 +38,6 @@ endif ()
 
 set(RISCV64_CODEC_GEN_SRCS
   ${PROJECT_BINARY_DIR}/opcode_api.h
-  ${PROJECT_BINARY_DIR}/opcode_names.h
   ${PROJECT_BINARY_DIR}/instr_create_api.h
   ${PROJECT_BINARY_DIR}/instr_info_trie.h
 )


### PR DESCRIPTION
Currently, all C files that depend on header files generated by codec.py will be recompiled every time we run `make`, even if no changes have been made to those headers, causing headaches on weak devices. This issue is caused by two reasons:

1. opcode_names.h does not exist in RISC-V, but was added to `RISCV64_CODEC_GEN_SRCS` by mistake, so the primary custom command output (i.e. opcode_api.h) will be deleted to trigger a regeneration.
2. If codec.py gets modified, it will cause the header files to be regenerated even if the generated files have not changed.

This patch deletes opcode_names.h from `RISCV64_CODEC_GEN_SRCS`, and uses `write_if_changed` to write only files whose content has changed, thus fixing this issue.

Issue: #3544 