### PR TITLE
AARCHXX: Remove redundant macro definition

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -140,7 +140,6 @@ mixed_mode_enabled(void)
 #    define R12_OFFSET ((MC_OFFS) + (offsetof(priv_mcontext_t, r12)))
 #    define R13_OFFSET ((MC_OFFS) + (offsetof(priv_mcontext_t, r13)))
 #    define R14_OFFSET ((MC_OFFS) + (offsetof(priv_mcontext_t, r14)))
-#    define XFLAGS_OFFSET ((MC_OFFS) + (offsetof(priv_mcontext_t, xflags)))
 #    define PC_OFFSET ((MC_OFFS) + (offsetof(priv_mcontext_t, pc)))
 #    define SCRATCH_REG0 DR_REG_R0
 #    define SCRATCH_REG1 DR_REG_R1


### PR DESCRIPTION
`core/arch/arch.h:143` is duplicated with `core/arch/arch.h:188`, the definition is identical, which is allowed by C. But it will become different when line 188 adds support for RISC-V, this PR pre-removes the duplicate definition to avoid this issue.