### PR TITLE
i#4103 clang-tidy: Clean up headers to include what is used

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -30,15 +30,34 @@
  * DAMAGE.
  */
 
-#include <inttypes.h>
-#include <iostream>
-#include <thread>
-#include "analysis_tool.h"
 #include "analyzer.h"
-#include "reader/file_reader.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <queue>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "analyzer.h"
+#include "memref.h"
+#include "scheduler.h"
+#include "analysis_tool.h"
 #ifdef HAS_ZLIB
-#    include "reader/compressed_file_reader.h"
+#    include "compressed_file_reader.h"
+#else
+#    include "file_reader.h"
 #endif
+#include "reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 #ifdef HAS_ZIP
 #    include "reader/zipfile_file_reader.h"
 #endif
@@ -46,7 +65,6 @@
 #    include "reader/snappy_file_reader.h"
 #endif
 #include "common/utils.h"
-#include "memtrace_stream.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -43,15 +43,23 @@
  * @brief DrMemtrace top-level trace analysis driver.
  */
 
+#include <stdint.h>
+
 #include <iterator>
 #include <memory>
 #include <queue>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
+
 #include "analysis_tool.h"
+#include "memref.h"
 #include "reader.h"
 #include "record_file_reader.h"
 #include "scheduler.h"
+#include "analysis_tool.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/common/directory_iterator.cpp
+++ b/clients/drcachesim/common/directory_iterator.cpp
@@ -30,10 +30,15 @@
  * DAMAGE.
  */
 
-#include <algorithm>
 #include "directory_iterator.h"
-#include "utils.h"
+
+#include <dirent.h>
+
+#include <string>
+
+#include "directory_iterator.h"
 #include "dr_frontend.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/common/directory_iterator.h
+++ b/clients/drcachesim/common/directory_iterator.h
@@ -37,7 +37,9 @@
 #define _DIRECTORY_ITERATOR_H_ 1
 
 #include <assert.h>
+
 #include <iterator>
+#include <string>
 #ifdef WINDOWS
 #    define UNICODE
 #    define _UNICODE
@@ -47,6 +49,7 @@
 #    include <dirent.h> /* opendir, readdir */
 #endif
 
+#include "utils.h"
 #include "utils.h"
 
 namespace dynamorio {

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -45,6 +45,9 @@
 #ifndef _MEMTRACE_STREAM_H_
 #define _MEMTRACE_STREAM_H_ 1
 
+#include <cstdint>
+#include <string>
+
 /**
  * @file drmemtrace/memtrace_stream.h
  * @brief DrMemtrace interface for obtaining information from analysis

--- a/clients/drcachesim/common/named_pipe_unix.cpp
+++ b/clients/drcachesim/common/named_pipe_unix.cpp
@@ -30,13 +30,15 @@
  * DAMAGE.
  */
 
-#include <string>
-#include <sys/types.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h> /* for PIPE_BUF */
+#include <stddef.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <limits.h> /* for PIPE_BUF */
+
+#include <string>
+
 #include "named_pipe.h"
 
 namespace dynamorio {

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -32,10 +32,13 @@
 
 /* shared options for both the frontend and the client */
 
-#include <string>
-#include "dr_api.h" // For IF_X86_ELSE.
-#include "droption.h"
 #include "options.h"
+
+#include <string>
+
+#include "dr_api.h" // For IF_X86_ELSE.
+#include "options.h"
+#include "droption.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -69,6 +69,8 @@
 #endif
 
 #include <string>
+
+#include "droption.h"
 #include "droption.h"
 
 namespace dynamorio {

--- a/clients/drcachesim/common/trace_entry.cpp
+++ b/clients/drcachesim/common/trace_entry.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "trace_entry.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -43,7 +43,10 @@
 #ifndef _TRACE_ENTRY_H_
 #define _TRACE_ENTRY_H_ 1
 
+#include <stddef.h>
 #include <stdint.h>
+
+#include "utils.h"
 #include "utils.h"
 
 /**

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -31,6 +31,16 @@
  */
 
 #include "compressed_file_reader.h"
+#include "compressed_file_reader.h"
+
+#include <zlib.h>
+
+#include <memory>
+#include <string>
+
+#include "file_reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/compressed_file_reader.h
+++ b/clients/drcachesim/reader/compressed_file_reader.h
@@ -36,8 +36,12 @@
 #define _COMPRESSED_FILE_READER_H_ 1
 
 #include <zlib.h>
+
 #include "file_reader.h"
 #include "record_file_reader.h"
+#include "file_reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -31,8 +31,21 @@
  */
 
 #include "config_reader.h"
+#include "config_reader.h"
 
+#include <stdint.h>
+
+#include <cstdlib>
 #include <iostream>
+#include <iterator>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "options.h"
+#include "cache_simulator_create.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -37,13 +37,19 @@
 #ifndef _CONFIG_READER_H_
 #define _CONFIG_READER_H_ 1
 
+#include <stdint.h>
+
 #include <fstream>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "../common/options.h"
 #include "../simulator/cache.h"
 #include "../simulator/cache_simulator_create.h"
+#include "options.h"
+#include "cache.h"
+#include "cache_simulator_create.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/file_reader.cpp
+++ b/clients/drcachesim/reader/file_reader.cpp
@@ -30,8 +30,13 @@
  * DAMAGE.
  */
 
-#include <fstream>
 #include "file_reader.h"
+
+#include <fstream>
+#include <string>
+
+#include "reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -39,13 +39,18 @@
 #define _FILE_READER_H_ 1
 
 #include <inttypes.h>
+#include <stdint.h>
 #include <string.h>
+
 #include <fstream>
 #include <queue>
+#include <string>
 #include <vector>
-#include "reader.h"
-#include "memref.h"
+
 #include "directory_iterator.h"
+#include "memref.h"
+#include "reader.h"
+#include "reader.h"
 #include "trace_entry.h"
 #include "utils.h"
 

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -30,12 +30,22 @@
  * DAMAGE.
  */
 
+#include "reader.h"
+
 #include <assert.h>
 #include <inttypes.h>
+#include <stdint.h>
 #include <string.h>
+
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
 #include "reader.h"
-#include "../common/memref.h"
-#include "../common/utils.h"
+#include "memref.h"
+#include "utils.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -38,13 +38,18 @@
 #define _READER_H_ 1
 
 #include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <iterator>
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
+
 // For exporting we avoid "../common" and rely on -I.
 #include "memref.h"
 #include "memtrace_stream.h"
+#include "trace_entry.h"
 #include "utils.h"
 
 namespace dynamorio {

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -30,12 +30,30 @@
  * DAMAGE.
  */
 
-#include <algorithm>
-#include <set>
-#include <unordered_map>
-
 #include "scheduler.h"
-#include "file_reader.h"
+
+#include <stdint.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cinttypes>
+#include <cstdio>
+#include <iomanip>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 #ifdef HAS_LZ4
 #    include "lz4_file_reader.h"
 #endif

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -42,14 +42,21 @@
 
 #define NOMINMAX // Avoid windows.h messing up std::max.
 #include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <deque>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <queue>
 #include <set>
 #include <stack>
+#include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
+
 #include "archive_istream.h"
 #include "archive_ostream.h"
 #include "memref.h"
@@ -57,6 +64,10 @@
 #include "reader.h"
 #include "record_file_reader.h"
 #include "speculator.h"
+#include "reader.h"
+#include "record_file_reader.h"
+#include "speculator.h"
+#include "trace_entry.h"
 #include "utils.h"
 
 namespace dynamorio {  /**< General DynamoRIO namespace. */

--- a/clients/drcachesim/scheduler/speculator.cpp
+++ b/clients/drcachesim/scheduler/speculator.cpp
@@ -30,8 +30,14 @@
  * DAMAGE.
  */
 
-#include <string.h>
 #include "speculator.h"
+
+#include <string.h>
+
+#include <string>
+
+#include "memref.h"
+#include "trace_entry.h"
 #include "utils.h"
 
 #undef VPRINT

--- a/clients/drcachesim/scheduler/speculator.h
+++ b/clients/drcachesim/scheduler/speculator.h
@@ -40,7 +40,10 @@
  * @brief DrMemtrace trace speculative path generation.
  */
 
+#include <string>
+
 #include "memref.h"
+#include "trace_entry.h"
 #include "utils.h"
 
 namespace dynamorio {

--- a/clients/drcachesim/simulator/cache.cpp
+++ b/clients/drcachesim/simulator/cache.cpp
@@ -31,11 +31,26 @@
  */
 
 #include "cache.h"
-#include "../common/utils.h"
-#include <assert.h>
+#include "cache.h"
+
+#include <stddef.h>
+
+#include <utility>
+#include <vector>
+
+#include "memref.h"
+#include "cache_line.h"
+#include "cache_stats.h"
+#include "caching_device.h"
+#include "caching_device_block.h"
+#include "caching_device_stats.h"
+#include "prefetcher.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {
+
+class snoop_filter_t;
 
 bool
 cache_t::init(int associativity, int line_size, int total_size, caching_device_t *parent,

--- a/clients/drcachesim/simulator/cache.h
+++ b/clients/drcachesim/simulator/cache.h
@@ -36,12 +36,22 @@
 #ifndef _CACHE_H_
 #define _CACHE_H_ 1
 
-#include "caching_device.h"
+#include <string>
+#include <vector>
+
 #include "cache_line.h"
 #include "cache_stats.h"
+#include "caching_device.h"
+#include "memref.h"
+#include "cache_line.h"
+#include "cache_stats.h"
+#include "caching_device.h"
+#include "prefetcher.h"
 
 namespace dynamorio {
 namespace drmemtrace {
+
+class snoop_filter_t;
 
 class cache_t : public caching_device_t {
 public:

--- a/clients/drcachesim/simulator/cache_fifo.cpp
+++ b/clients/drcachesim/simulator/cache_fifo.cpp
@@ -31,7 +31,18 @@
  */
 
 #include "cache_fifo.h"
+#include "cache_fifo.h"
+
 #include <assert.h>
+
+#include <vector>
+
+#include "cache.h"
+#include "caching_device.h"
+#include "caching_device_block.h"
+#include "caching_device_stats.h"
+#include "prefetcher.h"
+#include "snoop_filter.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/cache_fifo.h
+++ b/clients/drcachesim/simulator/cache_fifo.h
@@ -36,10 +36,17 @@
 #ifndef _CACHE_FIFO_H_
 #define _CACHE_FIFO_H_ 1
 
+#include <string>
+#include <vector>
+
 #include "cache.h"
+#include "cache.h"
+#include "prefetcher.h"
 
 namespace dynamorio {
 namespace drmemtrace {
+
+class snoop_filter_t;
 
 class cache_fifo_t : public cache_t {
 public:

--- a/clients/drcachesim/simulator/cache_lru.cpp
+++ b/clients/drcachesim/simulator/cache_lru.cpp
@@ -31,6 +31,16 @@
  */
 
 #include "cache_lru.h"
+#include "cache_lru.h"
+
+#include <vector>
+
+#include "cache.h"
+#include "caching_device.h"
+#include "caching_device_block.h"
+#include "caching_device_stats.h"
+#include "prefetcher.h"
+#include "snoop_filter.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/cache_lru.h
+++ b/clients/drcachesim/simulator/cache_lru.h
@@ -36,7 +36,13 @@
 #ifndef _CACHE_LRU_H_
 #define _CACHE_LRU_H_ 1
 
+#include <string>
+#include <vector>
+
 #include "cache.h"
+#include "cache.h"
+#include "prefetcher.h"
+#include "snoop_filter.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -30,24 +30,38 @@
  * DAMAGE.
  */
 
-#include <iostream>
-#include <iterator>
-#include <string>
-#include <assert.h>
-#include <limits.h>
-#include <stdint.h> /* for supporting 64-bit integers*/
-#include "../common/memref.h"
-#include "../common/options.h"
-#include "../common/utils.h"
-#include "../reader/config_reader.h"
-#include "../reader/file_reader.h"
-#include "../reader/ipc_reader.h"
-#include "cache_stats.h"
-#include "cache.h"
-#include "cache_lru.h"
-#include "cache_fifo.h"
 #include "cache_simulator.h"
+
+#include <stddef.h>
+#include <stdint.h> /* for supporting 64-bit integers*/
+
+#include <functional>
+#include <iostream>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "analysis_tool.h"
+#include "cache_simulator.h"
+#include "memref.h"
+#include "options.h"
+#include "trace_entry.h"
+#include "config_reader.h"
+#include "file_reader.h"
+#include "ipc_reader.h"
+#include "cache.h"
+#include "cache_fifo.h"
+#include "cache_lru.h"
+#include "cache_simulator_create.h"
+#include "cache_stats.h"
+#include "caching_device.h"
+#include "caching_device_stats.h"
+#include "prefetcher.h"
+#include "simulator.h"
 #include "snoop_filter.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -36,13 +36,23 @@
 #ifndef _CACHE_SIMULATOR_H_
 #define _CACHE_SIMULATOR_H_ 1
 
+#include <limits.h>
+#include <stdint.h>
+
+#include <istream>
+#include <string>
 #include <unordered_map>
-#include "simulator.h"
+
+#include "cache.h"
 #include "cache_simulator_create.h"
 #include "cache_stats.h"
-#include "cache.h"
+#include "simulator.h"
 #include "snoop_filter.h"
-#include <limits.h>
+#include "cache.h"
+#include "cache_simulator_create.h"
+#include "cache_stats.h"
+#include "simulator.h"
+#include "snoop_filter.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/cache_stats.cpp
+++ b/clients/drcachesim/simulator/cache_stats.cpp
@@ -30,9 +30,18 @@
  * DAMAGE.
  */
 
-#include <iostream>
-#include <iomanip>
 #include "cache_stats.h"
+
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "cache_stats.h"
+#include "memref.h"
+#include "caching_device_block.h"
+#include "caching_device_stats.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/cache_stats.h
+++ b/clients/drcachesim/simulator/cache_stats.h
@@ -36,7 +36,12 @@
 #ifndef _CACHE_STATS_H_
 #define _CACHE_STATS_H_ 1
 
+#include <stdint.h>
+
 #include <string>
+
+#include "caching_device_stats.h"
+#include "memref.h"
 #include "caching_device_stats.h"
 
 namespace dynamorio {

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -30,15 +30,25 @@
  * DAMAGE.
  */
 
-#include <string>
-
 #include "caching_device.h"
+
+#include <assert.h>
+#include <stddef.h>
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "../common/utils.h"
+#include "caching_device.h"
+#include "memref.h"
 #include "caching_device_block.h"
 #include "caching_device_stats.h"
 #include "prefetcher.h"
 #include "snoop_filter.h"
-#include "../common/utils.h"
-#include <assert.h>
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -39,12 +39,13 @@
 #include <functional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "caching_device_block.h"
 #include "caching_device_stats.h"
 #include "memref.h"
-#include "prefetcher.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -58,6 +59,7 @@ namespace drmemtrace {
 // not need to synchronize data access.
 
 class snoop_filter_t;
+class prefetcher_t;
 
 class caching_device_t {
 public:

--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -30,11 +30,26 @@
  * DAMAGE.
  */
 
-#include <assert.h>
-#include <iostream>
-#include <iomanip>
-#include "../common/options.h"
 #include "caching_device_stats.h"
+
+#include <assert.h>
+#include <stdint.h>
+#ifdef HAS_ZLIB
+#    include <zlib.h>
+#endif
+
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <map>
+#include <string>
+#include <utility>
+
+#include "caching_device_stats.h"
+#include "memref.h"
+#include "options.h"
+#include "caching_device_block.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/caching_device_stats.h
+++ b/clients/drcachesim/simulator/caching_device_stats.h
@@ -36,14 +36,21 @@
 #ifndef _CACHING_DEVICE_STATS_H_
 #define _CACHING_DEVICE_STATS_H_ 1
 
-#include "caching_device_block.h"
-#include <string>
-#include <map>
 #include <stdint.h>
-#include <limits>
 #ifdef HAS_ZLIB
 #    include <zlib.h>
 #endif
+
+#include <iterator>
+#include <limits>
+#include <map>
+#include <string>
+#include <utility>
+
+#include "caching_device_block.h"
+#include "caching_device_block.h"
+#include "trace_entry.h"
+#include "utils.h"
 #include "memref.h"
 
 namespace dynamorio {

--- a/clients/drcachesim/simulator/prefetcher.cpp
+++ b/clients/drcachesim/simulator/prefetcher.cpp
@@ -33,8 +33,11 @@
 /* prefetcher: represents a hardware prefetching implementation.
  */
 
+#include "prefetcher.h"
+
+#include "memref.h"
 #include "caching_device.h"
-#include "../common/memref.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/simulator.cpp
+++ b/clients/drcachesim/simulator/simulator.cpp
@@ -30,14 +30,22 @@
  * DAMAGE.
  */
 
-#include <iostream>
-#include <iterator>
+#include "simulator.h"
+
 #include <assert.h>
 #include <limits.h>
-#include "../common/memref.h"
-#include "../common/options.h"
-#include "../common/utils.h"
+#include <stdint.h>
+
+#include <iostream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "memref.h"
 #include "simulator.h"
+#include "options.h"
+#include "utils.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -37,12 +37,19 @@
 #define _SIMULATOR_H_ 1
 
 #include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <unordered_map>
 #include <vector>
-#include "caching_device_stats.h"
-#include "caching_device.h"
+
 #include "analysis_tool.h"
+#include "caching_device.h"
+#include "caching_device_stats.h"
 #include "memref.h"
+#include "caching_device.h"
+#include "caching_device_stats.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/snoop_filter.cpp
+++ b/clients/drcachesim/simulator/snoop_filter.cpp
@@ -31,10 +31,23 @@
  */
 
 #include "snoop_filter.h"
-#include <iostream>
-#include <iomanip>
+#include "snoop_filter.h"
+
 #include <assert.h>
+#include <stdint.h>
+
 #include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "cache.h"
+#include "caching_device_block.h"
+#include "caching_device_stats.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/snoop_filter.h
+++ b/clients/drcachesim/simulator/snoop_filter.h
@@ -33,9 +33,14 @@
 #ifndef _SNOOP_FILTER_H_
 #define _SNOOP_FILTER_H_ 1
 
-#include "cache.h"
+#include <stdint.h>
+
 #include <unordered_map>
 #include <vector>
+
+#include "cache.h"
+#include "cache.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -31,8 +31,16 @@
  */
 
 #include "tlb.h"
-#include "../common/utils.h"
+#include "tlb.h"
+
 #include <assert.h>
+#include <stddef.h>
+
+#include "memref.h"
+#include "caching_device.h"
+#include "caching_device_block.h"
+#include "tlb_entry.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -37,6 +37,10 @@
 #define _TLB_H_ 1
 
 #include "caching_device.h"
+#include "memref.h"
+#include "caching_device.h"
+#include "tlb_entry.h"
+#include "tlb_stats.h"
 #include "tlb_entry.h"
 #include "tlb_stats.h"
 

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -30,18 +30,25 @@
  * DAMAGE.
  */
 
-#include <iostream>
-#include <iterator>
-#include <string>
-#include <assert.h>
-#include <limits.h>
-#include <stdint.h> /* for supporting 64-bit integers*/
-#include "../common/memref.h"
-#include "../common/options.h"
-#include "../common/utils.h"
-#include "tlb_stats.h"
-#include "tlb.h"
 #include "tlb_simulator.h"
+
+#include <stddef.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "analysis_tool.h"
+#include "memref.h"
+#include "options.h"
+#include "utils.h"
+#include "caching_device_stats.h"
+#include "simulator.h"
+#include "tlb.h"
+#include "tlb_simulator_create.h"
+#include "tlb_stats.h"
+#include "tlb_simulator.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/simulator/tlb_simulator.h
+++ b/clients/drcachesim/simulator/tlb_simulator.h
@@ -36,11 +36,18 @@
 #ifndef _TLB_SIMULATOR_H_
 #define _TLB_SIMULATOR_H_ 1
 
+#include <string>
 #include <unordered_map>
+
+#include "memref.h"
 #include "simulator.h"
+#include "simulator.h"
+#include "tlb.h"
 #include "tlb_simulator_create.h"
 #include "tlb_stats.h"
 #include "tlb.h"
+#include "tlb_simulator_create.h"
+#include "tlb_stats.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -32,14 +32,27 @@
 
 #define NOMINMAX // Avoid windows.h messing up std::max.
 
+#include "basic_counts.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
 #include <algorithm>
 #include <cassert>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
-#include "basic_counts.h"
 #include "../common/utils.h"
+#include "analysis_tool.h"
+#include "basic_counts.h"
+#include "memref.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -33,12 +33,17 @@
 #ifndef _BASIC_COUNTS_H_
 #define _BASIC_COUNTS_H_ 1
 
+#include <stdint.h>
+
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "analysis_tool.h"
+#include "memref.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/filter/cache_filter.cpp
+++ b/clients/drcachesim/tools/filter/cache_filter.cpp
@@ -31,7 +31,17 @@
  */
 
 #include "cache_filter.h"
+#include "cache_filter.h"
+
+#include <string>
+
 #include "cache_lru.h"
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "cache_stats.h"
+#include "caching_device_block.h"
+#include "caching_device_stats.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/filter/cache_filter.h
+++ b/clients/drcachesim/tools/filter/cache_filter.h
@@ -33,7 +33,10 @@
 #ifndef _CACHE_FILTER_H_
 #define _CACHE_FILTER_H_ 1
 
+#include "memtrace_stream.h"
 #include "record_filter.h"
+#include "record_filter.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -30,15 +30,27 @@
  * DAMAGE.
  */
 
-#include <iostream>
+#include "record_filter.h"
+
+#include <stdint.h>
+
 #include <fstream>
+#include <iostream>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #ifdef HAS_ZLIB
 #    include "common/gzip_ostream.h"
 #endif
+#include "memref.h"
+#include "memtrace_stream.h"
 #include "record_filter.h"
+#include "trace_entry.h"
+#include "utils.h"
 
 #ifdef DEBUG
 #    define VPRINT(reader, level, ...)                            \

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -33,11 +33,19 @@
 #ifndef _RECORD_FILTER_H_
 #define _RECORD_FILTER_H_ 1
 
-#include "analysis_tool.h"
+#include <stdint.h>
+
 #include <memory>
 #include <mutex>
+#include <ostream>
+#include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "analysis_tool.h"
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -35,13 +35,29 @@
  * to qualify function names for offline traces.
  */
 
-#include "dr_api.h"
 #include "func_view.h"
+
+#include <assert.h>
+#include <stdint.h>
+
 #include <algorithm>
+#include <cstdlib>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
+#include <mutex>
+#include <set>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
 #include <vector>
-#include <assert.h>
+
+#include "analysis_tool.h"
+#include "func_view.h"
+#include "memref.h"
+#include "raw2trace_directory.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -33,15 +33,22 @@
 #ifndef _FUNC_VIEW_H_
 #define _FUNC_VIEW_H_ 1
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <mutex>
 #include <set>
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "analysis_tool.h"
+#include "dr_api.h"
+#include "memref.h"
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/histogram.cpp
+++ b/clients/drcachesim/tools/histogram.cpp
@@ -30,12 +30,25 @@
  * DAMAGE.
  */
 
+#include "histogram.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
-#include "histogram.h"
+
 #include "../common/utils.h"
+#include "analysis_tool.h"
+#include "histogram.h"
+#include "memref.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/histogram.h
+++ b/clients/drcachesim/tools/histogram.h
@@ -36,12 +36,16 @@
 #ifndef _HISTOGRAM_H_
 #define _HISTOGRAM_H_ 1
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <mutex>
 #include <string>
 #include <unordered_map>
 
 #include "analysis_tool.h"
 #include "memref.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -30,13 +30,30 @@
  * DAMAGE.
  */
 
-#include "dr_api.h"
 #include "invariant_checker.h"
-#include "invariant_checker_create.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <algorithm>
 #include <iostream>
-#include <cassert>
-#include <string.h>
+#include <memory>
+#include <mutex>
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "analysis_tool.h"
+#include "dr_api.h"
+#include "invariant_checker.h"
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "invariant_checker_create.h"
+#include "trace_entry.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -36,15 +36,22 @@
 #ifndef _INVARIANT_CHECKER_H_
 #define _INVARIANT_CHECKER_H_ 1
 
-#include "analysis_tool.h"
-#include "dr_api.h"
+#include <stdint.h>
+
+#include <cstdlib>
 #include <iostream>
-#include "memref.h"
 #include <memory>
 #include <mutex>
 #include <stack>
+#include <string>
 #include <unordered_map>
 #include <vector>
+
+#include "analysis_tool.h"
+#include "dr_api.h"
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -36,13 +36,30 @@
  * It does not support online use, only offline.
  */
 
-#include "dr_api.h"
 #include "opcode_mix.h"
+
+#include <stdint.h>
+#include <string.h>
+
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
-#include <string.h>
+
+#include "analysis_tool.h"
+#include "dr_api.h"
+#include "memref.h"
+#include "opcode_mix.h"
+#include "raw2trace.h"
+#include "raw2trace_directory.h"
+#include "reader.h"
+#include "trace_entry.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -33,13 +33,20 @@
 #ifndef _OPCODE_MIX_H_
 #define _OPCODE_MIX_H_ 1
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 
+#include "dr_api.h" // Must be before trace_entry.h from analysis_tool.h.
 #include "analysis_tool.h"
+#include "memref.h"
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/reuse_distance.cpp
+++ b/clients/drcachesim/tools/reuse_distance.cpp
@@ -30,13 +30,30 @@
  * DAMAGE.
  */
 
+#include "reuse_distance.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
-#include "reuse_distance.h"
+
 #include "../common/utils.h"
+#include "analysis_tool.h"
+#include "memref.h"
+#include "reuse_distance.h"
+#include "reuse_distance_create.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/reuse_distance.h
+++ b/clients/drcachesim/tools/reuse_distance.h
@@ -36,17 +36,24 @@
 #ifndef _REUSE_DISTANCE_H_
 #define _REUSE_DISTANCE_H_ 1
 
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <iostream>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <string>
+#include <utility>
 #include <vector>
-#include <assert.h>
-#include <iostream>
+
 #include "analysis_tool.h"
-#include "reuse_distance_create.h"
 #include "memref.h"
+#include "reuse_distance_create.h"
+#include "reuse_distance_create.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -66,8 +73,8 @@ namespace drmemtrace {
 #    define IF_DEBUG_VERBOSE(level, action)
 #endif
 
-struct line_ref_t;
 struct line_ref_list_t;
+struct line_ref_t;
 
 class reuse_distance_t : public analysis_tool_t {
 public:

--- a/clients/drcachesim/tools/reuse_time.cpp
+++ b/clients/drcachesim/tools/reuse_time.cpp
@@ -30,14 +30,25 @@
  * DAMAGE.
  */
 
+#include "reuse_time.h"
+
+#include <stdint.h>
+
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
-#include "reuse_time.h"
 #include "../common/utils.h"
+#include "analysis_tool.h"
+#include "memref.h"
+#include "reuse_time.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/reuse_time.h
+++ b/clients/drcachesim/tools/reuse_time.h
@@ -33,11 +33,15 @@
 #ifndef _REUSE_TIME_H_
 #define _REUSE_TIME_H_ 1
 
+#include <stdint.h>
+
 #include <mutex>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 #include "analysis_tool.h"
+#include "memref.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/syscall_mix.cpp
+++ b/clients/drcachesim/tools/syscall_mix.cpp
@@ -30,13 +30,26 @@
  * DAMAGE.
  */
 
-#include "dr_api.h"
 #include "syscall_mix.h"
+
+#include <stdint.h>
+
 #include <algorithm>
 #include <cassert>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
+
+#include "analysis_tool.h"
+#include "dr_api.h"
+#include "memref.h"
+#include "syscall_mix.h"
+#include "trace_entry.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/syscall_mix.h
+++ b/clients/drcachesim/tools/syscall_mix.h
@@ -33,11 +33,14 @@
 #ifndef _SYSCALL_MIX_H_
 #define _SYSCALL_MIX_H_ 1
 
+#include <stdint.h>
+
 #include <mutex>
 #include <string>
 #include <unordered_map>
 
 #include "analysis_tool.h"
+#include "memref.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -36,12 +36,27 @@
  * It does not support online use, only offline.
  */
 
-#include "dr_api.h"
 #include "view.h"
-#include <algorithm>
+
+#include <stdint.h>
+
 #include <iomanip>
 #include <iostream>
-#include <vector>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "analysis_tool.h"
+#include "dr_api.h"
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "raw2trace.h"
+#include "raw2trace_directory.h"
+#include "trace_entry.h"
+#include "utils.h"
+#include "view.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -33,13 +33,19 @@
 #ifndef _VIEW_H_
 #define _VIEW_H_ 1
 
+#include <stdint.h>
+
 #include <iomanip>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 
+#include "dr_api.h" // Must be before trace_entry.h from analysis_tool.h.
 #include "analysis_tool.h"
+#include "memref.h"
+#include "memtrace_stream.h"
 #include "raw2trace.h"
 #include "raw2trace_directory.h"
 

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -33,19 +33,28 @@
 // func_trace.cpp: module for recording function traces
 
 #define NOMINMAX // Avoid windows.h messing up std::min.
+#include "func_trace.h"
+
+#include <sys/types.h>
+
 #include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
+
 #include "dr_api.h"
-#include "drsyms.h"
-#include "drwrap.h"
 #include "drmgr.h"
 #include "drvector.h"
+#include "options.h"
 #include "hashtable.h"
+#include "droption.h"
+#include "drsyms.h"
+#include "drwrap.h"
 #include "trace_entry.h"
-#include "../common/options.h"
-#include "func_trace.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/func_trace.h
+++ b/clients/drcachesim/tracer/func_trace.h
@@ -35,6 +35,11 @@
 #ifndef _FUNC_TRACE_
 #define _FUNC_TRACE_ 1
 
+#include <stddef.h>
+#include <sys/types.h>
+
+#include <cstdint>
+
 #include "dr_api.h"
 #include "trace_entry.h"
 

--- a/clients/drcachesim/tracer/instr_counter.cpp
+++ b/clients/drcachesim/tracer/instr_counter.cpp
@@ -35,20 +35,27 @@
  * Instruction counting mode where we do not record any trace data.
  */
 
+#include "instr_counter.h"
+
 #include <limits.h>
+#include <stddef.h>
+
 #include <atomic>
+#include <cstdint>
+
 #include "dr_api.h"
 #include "drmgr.h"
-#include "drmemtrace.h"
 #include "drreg.h"
-#include "drx.h"
 #include "instr_counter.h"
-#include "instru.h"
-#include "tracer.h"
+#include "options.h"
+#include "utils.h"
+#include "drmemtrace.h"
 #include "func_trace.h"
+#include "instru.h"
 #include "output.h"
-#include "../common/options.h"
-#include "../common/utils.h"
+#include "tracer.h"
+#include "droption.h"
+#include "drx.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/instr_counter.h
+++ b/clients/drcachesim/tracer/instr_counter.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * **********************************************************/
 

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -33,13 +33,17 @@
 /* instru: instrumentation utilities.
  */
 
+#include "instru.h"
+
+#include <stddef.h>
+
 #include "dr_api.h"
+#include "drmgr.h"
 #include "drreg.h"
 #include "drutil.h"
-#include "instru.h"
-#include "../common/trace_entry.h"
+#include "trace_entry.h"
+
 #ifdef LINUX
-#    include <sched.h>
 #    ifndef _GNU_SOURCE
 #        define _GNU_SOURCE // For syscall()
 #    endif

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -38,11 +38,17 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
+
 #include <atomic>
+#include <iterator>
+#include <utility>
+
+#include "dr_allocator.h"
 #include "dr_api.h"
 #include "drvector.h"
-#include "trace_entry.h"
 #include "dr_allocator.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -33,18 +33,23 @@
 /* instru_offline: inserts instrumentation for offline traces.
  */
 
+#include <stddef.h> /* for offsetof */
+#include <string.h> /* for strlen */
+#include <sys/types.h>
+
+#include <atomic>
+#include <cstdint>
+#include <new>
+
 #include "dr_api.h"
+#include "drcovlib.h"
 #include "drmgr.h"
 #include "drreg.h"
 #include "drutil.h"
-#include "drcovlib.h"
+#include "drvector.h"
+#include "trace_entry.h"
+#include "utils.h"
 #include "instru.h"
-#include "../common/trace_entry.h"
-#include "../common/utils.h"
-#include <new>
-#include <limits.h> /* for USHRT_MAX */
-#include <stddef.h> /* for offsetof */
-#include <string.h> /* for strlen */
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -33,15 +33,20 @@
 /* instru_online: inserts instrumentation for online traces.
  */
 
-#define NOMINMAX // Avoid windows.h messing up std::min.
+#define NOMINMAX    // Avoid windows.h messing up std::min.
+#include <limits.h> /* for USHRT_MAX */
+#include <stddef.h> /* for offsetof */
+
+#include <algorithm> /* for std::min */
+#include <atomic>
+#include <cstdint>
+
 #include "dr_api.h"
 #include "drreg.h"
 #include "drutil.h"
+#include "drvector.h"
+#include "trace_entry.h"
 #include "instru.h"
-#include "../common/trace_entry.h"
-#include <limits.h>  /* for USHRT_MAX */
-#include <stddef.h>  /* for offsetof */
-#include <algorithm> /* for std::min */
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/kcore_copy.cpp
+++ b/clients/drcachesim/tracer/kcore_copy.cpp
@@ -30,15 +30,21 @@
  * DAMAGE.
  */
 
-#include <inttypes.h>
-#include <string.h>
-#include <stdio.h>
-#include <fstream>
+#include "kcore_copy.h"
 
-#include "../common/utils.h"
-#include "../common/trace_entry.h"
+#include <elf.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include <fstream>
+#include <string>
+
 #include "dr_api.h"
 #include "kcore_copy.h"
+#include "trace_entry.h"
+#include "utils.h"
+#include "drmemtrace.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/kcore_copy.h
+++ b/clients/drcachesim/tracer/kcore_copy.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,13 +38,15 @@
 #define _KCORE_COPY_H_ 1
 
 #include <elf.h>
+
+#include "dr_api.h"
 #include "drmemtrace.h"
 
 namespace dynamorio {
 namespace drmemtrace {
 
-struct proc_module_t;
 struct proc_kcore_code_segment_t;
+struct proc_module_t;
 
 /* This class is used to copy kernel code segments and copy kallsyms.
  */

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -35,24 +35,32 @@
  * DrMemtrace trace data output logic.
  */
 
-#include <limits.h>
+#include "output.h"
+
+#include <sys/types.h>
+
 #include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
 #include "dr_api.h"
-#include "drmgr.h"
 #include "drmemtrace.h"
-#include "drreg.h"
+#include "drmgr.h"
+#include "droption.h"
 #include "drx.h"
 #include "instru.h"
-#include "tracer.h"
+#include "named_pipe.h"
+#include "options.h"
+#include "output.h"
 #include "physaddr.h"
 #include "raw2trace.h"
-#include "output.h"
-#include "../common/trace_entry.h"
-#include "../common/named_pipe.h"
-#include "../common/options.h"
-#include "../common/utils.h"
+#include "trace_entry.h"
+#include "tracer.h"
+#include "utils.h"
 #ifdef HAS_SNAPPY
 #    include <snappy.h>
+
 #    include "snappy_file_writer.h"
 #endif
 #ifdef HAS_ZLIB

--- a/clients/drcachesim/tracer/output.h
+++ b/clients/drcachesim/tracer/output.h
@@ -35,6 +35,7 @@
 #define _OUTPUT_ 1
 
 #include "dr_api.h"
+#include "tracer.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/physaddr.cpp
+++ b/clients/drcachesim/tracer/physaddr.cpp
@@ -31,16 +31,24 @@
  */
 
 #ifdef LINUX
+#    include <fcntl.h>
 #    include <sys/types.h>
 #    include <unistd.h>
-#    include <sys/stat.h>
-#    include <fcntl.h>
 #    include <linux/capability.h>
 #    include <fstream>
 #endif
 #include "physaddr.h"
-#include "../common/options.h"
-#include "../common/utils.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "dr_api.h"
+#include "options.h"
+#include "trace_entry.h"
+#include "utils.h"
+#include "droption.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/physaddr.h
+++ b/clients/drcachesim/tracer/physaddr.h
@@ -36,10 +36,16 @@
 #ifndef _PHYSADDR_H_
 #define _PHYSADDR_H_ 1
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <atomic>
+
+#include "../common/trace_entry.h"
 #include "dr_api.h"
 #include "hashtable.h"
-#include "../common/trace_entry.h"
+#include "trace_entry.h"
+#include "hashtable.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -35,32 +35,42 @@
  */
 
 #define NOMINMAX // Avoid windows.h messing up std::min.
+#include "archive_ostream.h"
 #include "dr_api.h"
 #include "drcovlib.h"
 #include "raw2trace.h"
+#include "reader.h"
+#include "memref.h"
+#include "trace_entry.h"
+#include "drmemtrace.h"
 #include "instru.h"
-#include "../common/memref.h"
-#include "../common/trace_entry.h"
+#include "utils.h"
 #ifdef LINUX
 // XXX: We should have the core export this to an include dir.
 #    include "../../core/unix/include/syscall.h"
 #endif
 #ifdef BUILD_PT_POST_PROCESSOR
+#    include <unistd.h>
 #    include "../common/options.h"
 #    include "../drpt2trace/ir2trace.h"
-#    include <unistd.h>
 #endif
-#include <algorithm>
-#include <cstring>
-#include <fstream>
-#include <sstream>
-#include <thread>
-#include <vector>
-#ifdef LINUX
-#    include <syscall.h>
-#endif
+#include "raw2trace.h"
 
-#include <iostream>
+#include <algorithm>
+#include <array>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -42,26 +42,37 @@
  */
 
 #define NOMINMAX // Avoid windows.h messing up std::min.
-#include "dr_api.h"
-#include "drmemtrace.h"
-#include "drcovlib.h"
+#include <stddef.h>
+#include <stdint.h>
+
 #include <array>
 #include <atomic>
+#include <bitset>
+#include <deque>
+#include <fstream>
 #include <limits>
 #include <list>
 #include <memory>
 #include <queue>
 #include <set>
+#include <string>
+#include <type_traits>
 #include <unordered_map>
-#include "trace_entry.h"
-#include "instru.h"
-#include "archive_ostream.h"
-#include "reader.h"
-#include "utils.h"
-#include <fstream>
-#include "hashtable.h"
+#include <utility>
 #include <vector>
-#include <bitset>
+
+#include "archive_ostream.h"
+#include "dr_api.h"
+#include "drcovlib.h"
+#include "drmemtrace.h"
+#include "hashtable.h"
+#include "instru.h"
+#include "reader.h"
+#include "drmemtrace.h"
+#include "instru.h"
+#include "hashtable.h"
+#include "trace_entry.h"
+#include "utils.h"
 #ifdef BUILD_PT_POST_PROCESSOR
 #    include "../drpt2trace/pt2ir.h"
 #endif

--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -34,13 +34,17 @@
  * Separate from raw2trace_t, so that raw2trace doesn't depend on dr_frontend.
  */
 
-#include <algorithm>
+#include "raw2trace_directory.h"
+
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <string>
+#include <utility>
 #include <vector>
 
 #ifdef UNIX
-#    include <sys/stat.h>
 #    include <sys/types.h>
 #else
 #    define UNICODE
@@ -49,11 +53,13 @@
 #    include <windows.h>
 #endif
 
-#include "dr_api.h"
-#include "dr_frontend.h"
-#include "raw2trace.h"
-#include "raw2trace_directory.h"
+#include "archive_ostream.h"
 #include "directory_iterator.h"
+#include "dr_api.h"
+#include "raw2trace_directory.h"
+#include "reader.h"
+#include "raw2trace.h"
+#include "trace_entry.h"
 #include "utils.h"
 #ifdef HAS_ZLIB
 #    include "common/gzip_istream.h"

--- a/clients/drcachesim/tracer/raw2trace_directory.h
+++ b/clients/drcachesim/tracer/raw2trace_directory.h
@@ -35,10 +35,11 @@
 
 #include <fstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
-#include "dr_api.h"
 #include "archive_ostream.h"
+#include "dr_api.h"
 
 #if !defined DEFAULT_TRACE_COMPRESSION_TYPE
 #    ifdef HAS_ZIP

--- a/clients/drcachesim/tracer/syscall_pt_trace.cpp
+++ b/clients/drcachesim/tracer/syscall_pt_trace.cpp
@@ -32,11 +32,19 @@
 
 /* syscall_pt_trace.cpp: module for recording kernel PT traces for every syscall. */
 
-#include <cstring>
+#include "syscall_pt_trace.h"
 
+#include <stdint.h>
+
+#include <string>
+
+#include "dr_api.h"
+#include "trace_entry.h"
+#include "utils.h"
+#include "drmemtrace.h"
+#include "drpttracer.h"
 /* For SYS_exit,SYS_exit_group. */
 #include "../../../core/unix/include/syscall_linux_x86.h"
-#include "syscall_pt_trace.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/syscall_pt_trace.h
+++ b/clients/drcachesim/tracer/syscall_pt_trace.h
@@ -39,9 +39,13 @@
 #include <cstddef>
 #include <string>
 
-#include "../common/utils.h"
 #include "../common/trace_entry.h"
+#include "../common/utils.h"
 #include "dr_api.h"
+#include "drmemtrace.h"
+#include "drpttracer.h"
+#include "trace_entry.h"
+#include "utils.h"
 #include "drmemtrace.h"
 #include "drpttracer.h"
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -37,30 +37,39 @@
  * XXX i#1703, i#2001: add in more optimizations to improve performance.
  */
 
-#include <string.h>
-#include <atomic>
-#include <string>
-#include "dr_api.h"
-#include "drmgr.h"
-#include "drwrap.h"
-#include "drmemtrace.h"
-#include "drreg.h"
-#include "drutil.h"
-#include "drx.h"
-#include "drstatecmp.h"
-#include "droption.h"
-#include "drbbdup.h"
-#include "instru.h"
 #include "tracer.h"
-#include "output.h"
-#include "raw2trace.h"
-#include "physaddr.h"
-#include "instr_counter.h"
+
+#include <string.h>
+#include <sys/types.h>
+
+#include <atomic>
+#include <cstdarg>
+#include <cstdint>
+#include <new>
+#include <string>
+
+#include "dr_api.h"
+#include "drbbdup.h"
+#include "drmemtrace.h"
+#include "drmgr.h"
+#include "droption.h"
+#include "drreg.h"
+#include "drstatecmp.h"
+#include "drutil.h"
+#include "drvector.h"
+#include "drwrap.h"
+#include "drx.h"
 #include "func_trace.h"
-#include "../common/trace_entry.h"
-#include "../common/named_pipe.h"
-#include "../common/options.h"
-#include "../common/utils.h"
+#include "instr_counter.h"
+#include "instru.h"
+#include "named_pipe.h"
+#include "options.h"
+#include "output.h"
+#include "physaddr.h"
+#include "raw2trace.h"
+#include "reader.h"
+#include "trace_entry.h"
+#include "utils.h"
 
 #ifdef ARM
 #    include "../../../core/unix/include/syscall_linux_arm.h" // for SYS_cacheflush
@@ -143,10 +152,10 @@ named_pipe_t ipc_pipe;
 instru_t *instru;
 
 static client_id_t client_id;
-void *mutex;            /* for multithread support */
-uint64 num_refs_racy;   /* racy global memory reference count */
+void *mutex;                 /* for multithread support */
+uint64 num_refs_racy;        /* racy global memory reference count */
 uint64 num_filter_refs_racy; /* racy global memory reference count in warmup mode */
-static uint64 num_refs; /* keep a global memory reference count */
+static uint64 num_refs;      /* keep a global memory reference count */
 static uint64 num_writeouts;
 static uint64 num_v2p_writeouts;
 static uint64 num_phys_markers;

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * **********************************************************/
 
@@ -34,14 +34,22 @@
 #ifndef _TRACER_
 #define _TRACER_ 1
 
+#include <stddef.h>
+
 #include <atomic>
+#include <cstdint>
+
 #include "dr_api.h"
-#include "physaddr.h"
+#include "drmemtrace.h"
 #include "instru.h"
-#include "../common/options.h"
-#include "../common/named_pipe.h"
+#include "physaddr.h"
+#include "named_pipe.h"
+#include "options.h"
+#include "instru.h"
+#include "physaddr.h"
 #ifdef HAS_SNAPPY
 #    include <snappy.h>
+
 #    include "snappy_file_writer.h"
 #endif
 #ifdef HAS_ZLIB


### PR DESCRIPTION
Updates many drcachesim files to include what is used.  This is to address clang-tidy warnings seen when we import the files into our environment.

Issue: #4103