### PR TITLE
i#6262: query cpu id for scheduler output streams

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -811,6 +811,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::read_traced_schedule()
     // We also need to translate the thread and cpu id values into 0-based ordinals.
     std::unordered_map<memref_tid_t, input_ordinal_t> tid2input;
     for (int i = 0; i < static_cast<input_ordinal_t>(inputs_.size()); ++i) {
+        VPRINT(this, 1, "tid2input: tid: %ld -> %d\n", inputs_[i].tid, i);
         tid2input[inputs_[i].tid] = i;
     }
     std::vector<std::set<uint64_t>> start2stop(inputs_.size());
@@ -838,6 +839,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::read_traced_schedule()
                 }
             }
             cur_cpu = entry.cpu;
+            VPRINT(this, 1, "Output #%d is CPU #%" PRId64 "\n", cur_output, cur_cpu);
+            outputs_[cur_output].cpu = cur_cpu;
         }
         input_ordinal_t input = tid2input[entry.thread];
         // We'll fill in the stop ordinal in our second pass below.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -778,6 +778,18 @@ public:
         return &outputs_[ordinal].stream;
     }
 
+    /**
+     * Returns the cpu number for the 'ordinal'-th output stream. This is only valid for
+     * MAP_TO_RECORDED_OUTPUT and returns -1 for other mappings.
+     */
+    virtual int
+    get_output_cpuid(output_ordinal_t ordinal)
+    {
+        if (ordinal < 0 || ordinal >= static_cast<output_ordinal_t>(outputs_.size()))
+            return -1;
+        return outputs_[ordinal].cpu;
+    }
+
     /** Returns the number of input streams. */
     virtual int
     get_input_stream_count() const
@@ -962,6 +974,7 @@ protected:
         // sched_lock_.
         std::vector<schedule_record_t> record;
         int record_index = 0;
+        int cpu = -1;
         bool waiting = false;
         bool active = true;
     };


### PR DESCRIPTION
Added an API to query cpu id

Issue: #6262