### PR TITLE
i#5843 scheduler: Add syscall marker counts to basic_counts

### DIFF
--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -526,66 +526,90 @@ Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-      267193 total (fetched) instructions
-         345 total non-fetched instructions
+      134566 total (fetched) instructions
+       13838 total unique (fetched) instructions
+         423 total non-fetched instructions
            0 total prefetches
-       67686 total data loads
-       22503 total data stores
+       30919 total data loads
+       13122 total data stores
+           0 total icache flushes
+           0 total dcache flushes
            3 total threads
-         280 total scheduling markers
-           0 total transfer markers
-           0 total function id markers
+        1134 total scheduling markers
+           5 total transfer markers
+          10 total function id markers
            0 total function return address markers
-           0 total function argument markers
-           0 total function return value markers
+          30 total function argument markers
+           5 total function return value markers
            0 total physical address + virtual address marker pairs
            0 total physical address unavailable markers
-           3 total other markers
-Thread 247451 counts:
-      255009 (fetched) instructions
-         345 non-fetched instructions
+          75 total system call number markers
+           0 total blocking system call markers
+          12 total other markers
+           0 total encodings
+Thread 64951 counts:
+      130900 (fetched) instructions
+       13469 unique (fetched) instructions
+         423 non-fetched instructions
            0 prefetches
-       64453 data loads
-       21243 data stores
-         258 scheduling markers
-           0 transfer markers
-           0 function id markers
+       29844 data loads
+       12594 data stores
+           0 icache flushes
+           0 dcache flushes
+        1072 scheduling markers
+           5 transfer markers
+           4 function id markers
            0 function return address markers
-           0 function argument markers
-           0 function return value markers
+          12 function argument markers
+           2 function return value markers
            0 physical address + virtual address marker pairs
            0 physical address unavailable markers
-           1 other markers
-Thread 247453 counts:
-        9195 (fetched) instructions
+          56 system call number markers
+           0 blocking system call markers
+           4 other markers
+           0 encodings
+Thread 64958 counts:
+        1861 (fetched) instructions
+        1009 unique (fetched) instructions
            0 non-fetched instructions
            0 prefetches
-        2444 data loads
-         937 data stores
-          12 scheduling markers
+         538 data loads
+         262 data stores
+           0 icache flushes
+           0 dcache flushes
+          30 scheduling markers
            0 transfer markers
-           0 function id markers
+           2 function id markers
            0 function return address markers
-           0 function argument markers
-           0 function return value markers
+           6 function argument markers
+           1 function return value markers
            0 physical address + virtual address marker pairs
            0 physical address unavailable markers
-           1 other markers
-Thread 247454 counts:
-        2989 (fetched) instructions
+           9 system call number markers
+           0 blocking system call markers
+           4 other markers
+           0 encodings
+Thread 64959 counts:
+        1805 (fetched) instructions
+         978 unique (fetched) instructions
            0 non-fetched instructions
            0 prefetches
-         789 data loads
-         323 data stores
-          10 scheduling markers
+         537 data loads
+         266 data stores
+           0 icache flushes
+           0 dcache flushes
+          32 scheduling markers
            0 transfer markers
-           0 function id markers
+           4 function id markers
            0 function return address markers
-           0 function argument markers
-           0 function return value markers
+          12 function argument markers
+           2 function return value markers
            0 physical address + virtual address marker pairs
            0 physical address unavailable markers
-           1 other markers
+          10 system call number markers
+           0 blocking system call markers
+           4 other markers
+           0 encodings
 \endcode
 
 The non-fetched instructions are x86 string loop instructions, where

--- a/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-aarch64-prefetch-basic-counts.templatex
@@ -12,15 +12,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
           96 \(fetched\) instructions
           96 unique \(fetched\) instructions
@@ -31,12 +23,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -28,7 +28,9 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-          15 total other markers
+          11 total system call number markers
+           0 total blocking system call markers
+           4 total other markers
          102 total encodings
 Thread [0-9]* counts:
           98 \(fetched\) instructions
@@ -47,5 +49,7 @@ Thread [0-9]* counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-          15 other markers
+          11 system call number markers
+           0 blocking system call markers
+           4 other markers
          102 encodings

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts.templatex
@@ -13,15 +13,7 @@ Total counts:
            0 total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
           96 \(fetched\) instructions
           96 unique \(fetched\) instructions
@@ -32,12 +24,4 @@ Thread .* counts:
            0 icache flushes
            0 dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/basic_counts.templatex
+++ b/clients/drcachesim/tests/basic_counts.templatex
@@ -41,6 +41,8 @@ Total counts:
      .* total function return value markers
      .* total physical address \+ virtual address marker pairs
      .* total physical address unavailable markers
+     .* total system call number markers
+     .* total blocking system call markers
      .* total other markers
      .* total encodings
 Thread .* counts:
@@ -64,5 +66,7 @@ Thread .* counts:
      .* function return value markers
      .* physical address \+ virtual address marker pairs
      .* physical address unavailable markers
+     .* system call number markers
+     .* blocking system call markers
      .* other markers
      .* encodings

--- a/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/builtin-prefetch-basic-counts.templatex
@@ -16,15 +16,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -39,12 +31,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/filter-no-d.templatex
+++ b/clients/drcachesim/tests/filter-no-d.templatex
@@ -12,15 +12,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -31,15 +23,7 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*
 
 ===========================================================================
 Trace invariant checks passed\)?

--- a/clients/drcachesim/tests/filter-no-i.templatex
+++ b/clients/drcachesim/tests/filter-no-i.templatex
@@ -12,15 +12,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread [1-9][0-9]* counts:
            0 \(fetched\) instructions
            0 unique \(fetched\) instructions
@@ -31,15 +23,7 @@ Thread [1-9][0-9]* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*
 
 ===========================================================================
 Trace invariant checks passed\)?

--- a/clients/drcachesim/tests/offline-L0-filter-until-instrs-2.templatex
+++ b/clients/drcachesim/tests/offline-L0-filter-until-instrs-2.templatex
@@ -17,15 +17,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -36,12 +28,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-L0-filter-until-instrs-exit-after.templatex
+++ b/clients/drcachesim/tests/offline-L0-filter-until-instrs-exit-after.templatex
@@ -15,15 +15,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -34,12 +26,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-L0-filter-until-instrs-max-refs.templatex
+++ b/clients/drcachesim/tests/offline-L0-filter-until-instrs-max-refs.templatex
@@ -16,15 +16,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -35,12 +27,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-L0-filter-until-instrs-max-trace-size.templatex
+++ b/clients/drcachesim/tests/offline-L0-filter-until-instrs-max-trace-size.templatex
@@ -15,15 +15,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -34,12 +26,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-aarch64-prefetch-counts.templatex
@@ -11,15 +11,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
           96 \(fetched\) instructions
           96 unique \(fetched\) instructions
@@ -30,15 +22,7 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*
 Prefetch operation frequencies:
            2 prefetch_read_l1
            4 prefetch_read_l2

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -27,7 +27,9 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-          26 total other markers
+          11 total system call number markers
+          10 total blocking system call markers
+           5 total other markers
           26 total encodings
 Thread [0-9]* counts:
           98 \(fetched\) instructions
@@ -46,5 +48,7 @@ Thread [0-9]* counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-          26 other markers
+          11 system call number markers
+          10 blocking system call markers
+           5 other markers
           26 encodings

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts.templatex
@@ -12,15 +12,7 @@ Total counts:
            0 total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
           96 \(fetched\) instructions
           96 unique \(fetched\) instructions
@@ -31,12 +23,4 @@ Thread .* counts:
            0 icache flushes
            0 dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-basic_counts.templatex
+++ b/clients/drcachesim/tests/offline-basic_counts.templatex
@@ -40,6 +40,8 @@ Total counts:
      .* total function return value markers
      .* total physical address \+ virtual address marker pairs
      .* total physical address unavailable markers
+     .* total system call number markers
+     .* total blocking system call markers
      .* total other markers
      .* total encodings
 Thread .* counts:
@@ -63,5 +65,7 @@ Thread .* counts:
      .* function return value markers
      .* physical address \+ virtual address marker pairs
      .* physical address unavailable markers
+     .* system call number markers
+     .* blocking system call markers
      .* other markers
      .* encodings

--- a/clients/drcachesim/tests/offline-builtin-prefetch-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-builtin-prefetch-basic-counts.templatex
@@ -15,15 +15,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -38,12 +30,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-burst_aarch64_sys.templatex
+++ b/clients/drcachesim/tests/offline-burst_aarch64_sys.templatex
@@ -16,15 +16,7 @@ Total counts:
            4 total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -35,12 +27,4 @@ Thread .* counts:
            1 icache flushes
            4 dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadL0filter.templatex
@@ -24,12 +24,4 @@ Total counts:
            4 total threads
     *[0-9]* total scheduling markers
     *[0-9]* total transfer markers
-           0 total function id markers
-           0 total function return address markers
-           0 total function argument markers
-           0 total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-    *[0-9]* total other markers
-    *[0-9]* total encodings
 .*

--- a/clients/drcachesim/tests/offline-burst_threadfilter.templatex
+++ b/clients/drcachesim/tests/offline-burst_threadfilter.templatex
@@ -24,12 +24,4 @@ Total counts:
            [1-4] total threads
     *[0-9]* total scheduling markers
     *[0-9]* total transfer markers
-           0 total function id markers
-           0 total function return address markers
-           0 total function argument markers
-           0 total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-    *[0-9]* total other markers
-    *[0-9]* total encodings
 .*

--- a/clients/drcachesim/tests/offline-filter-no-d.templatex
+++ b/clients/drcachesim/tests/offline-filter-no-d.templatex
@@ -11,15 +11,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -30,12 +22,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-filter-no-i.templatex
+++ b/clients/drcachesim/tests/offline-filter-no-i.templatex
@@ -11,15 +11,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread [1-9][0-9]* counts:
            0 \(fetched\) instructions
            0 unique \(fetched\) instructions
@@ -30,12 +22,4 @@ Thread [1-9][0-9]* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-interval-count-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-count-output.templatex
@@ -11,15 +11,7 @@ Total counts:
      [ 0-9]* total dcache flushes
            1 total threads
      [ 0-9]* total scheduling markers
-     [ 0-9]* total transfer markers
-     [ 0-9]* total function id markers
-     [ 0-9]* total function return address markers
-     [ 0-9]* total function argument markers
-     [ 0-9]* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     [ 0-9]* total other markers
-     [ 0-9]* total encodings
+.*
 Thread [0-9]* counts:
      [ 0-9]* \(fetched\) instructions
      [ 0-9]* unique \(fetched\) instructions
@@ -30,15 +22,7 @@ Thread [0-9]* counts:
      [ 0-9]* icache flushes
      [ 0-9]* dcache flushes
      [ 0-9]* scheduling markers
-     [ 0-9]* transfer markers
-     [ 0-9]* function id markers
-     [ 0-9]* function return address markers
-     [ 0-9]* function argument markers
-     [ 0-9]* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     [ 0-9]* other markers
-     [ 0-9]* encodings
+.*
 Counts per trace interval for whole trace:
 Interval #1 ending at timestamp [0-9]*:
      [ 0-9]* interval delta \(fetched\) instructions
@@ -49,12 +33,4 @@ Interval #1 ending at timestamp [0-9]*:
      [ 0-9]* interval delta icache flushes
      [ 0-9]* interval delta dcache flushes
      [ 0-9]* interval delta scheduling markers
-     [ 0-9]* interval delta transfer markers
-     [ 0-9]* interval delta function id markers
-     [ 0-9]* interval delta function return address markers
-     [ 0-9]* interval delta function argument markers
-     [ 0-9]* interval delta function return value markers
-           0 interval delta physical address \+ virtual address marker pairs
-           0 interval delta physical address unavailable markers
-     [ 0-9]* interval delta other markers
-     [ 0-9]* interval delta encodings.*
+.*

--- a/clients/drcachesim/tests/offline-kernel-simple.templatex
+++ b/clients/drcachesim/tests/offline-kernel-simple.templatex
@@ -13,15 +13,7 @@ Total counts:
  .* total dcache flushes
  .* total threads
  .* total scheduling markers
- .* total transfer markers
- .* total function id markers
- .* total function return address markers
- .* total function argument markers
- .* total function return value markers
- .* total physical address \+ virtual address marker pairs
- .* total physical address unavailable markers
- .* total other markers
- .* total encodings
+.*
 Thread .* counts:
  .* \(fetched\) instructions
  .* unique \(fetched\) instructions
@@ -34,12 +26,4 @@ Thread .* counts:
  .* icache flushes
  .* dcache flushes
  .* scheduling markers
- .* transfer markers
- .* function id markers
- .* function return address markers
- .* function argument markers
- .* function return value markers
- .* physical address \+ virtual address marker pairs
- .* physical address unavailable markers
- .* other markers
- .* encodings
+*

--- a/clients/drcachesim/tests/offline-legacy-int-offs.templatex
+++ b/clients/drcachesim/tests/offline-legacy-int-offs.templatex
@@ -20,6 +20,8 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
+           0 total system call number markers
+           0 total blocking system call markers
           12 total other markers
         8429 total encodings
 Thread 552306 counts:
@@ -39,6 +41,8 @@ Thread 552306 counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
+           0 system call number markers
+           0 blocking system call markers
            4 other markers
         6393 encodings
 Thread 552323 counts:
@@ -58,6 +62,8 @@ Thread 552323 counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
+           0 system call number markers
+           0 blocking system call markers
            4 other markers
         1028 encodings
 Thread 552324 counts:
@@ -77,6 +83,8 @@ Thread 552324 counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
+           0 system call number markers
+           0 blocking system call markers
            4 other markers
         1008 encodings
 #else

--- a/clients/drcachesim/tests/offline-sysnums.templatex
+++ b/clients/drcachesim/tests/offline-sysnums.templatex
@@ -11,14 +11,5 @@ Total counts:
     .* total dcache flushes
            1 total threads
     .* total scheduling markers
-    .* total transfer markers
-    .* total function id markers
-    .* total function return address markers
-    .* total function argument markers
-    .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-    .* total other markers
-    .* total encodings
 .*
 Trace invariant checks passed

--- a/clients/drcachesim/tests/offline-warmup-pthreads-2.templatex
+++ b/clients/drcachesim/tests/offline-warmup-pthreads-2.templatex
@@ -17,15 +17,7 @@ Total counts:
      .* total dcache flushes
            3 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -36,12 +28,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-warmup-pthreads-max-refs.templatex
+++ b/clients/drcachesim/tests/offline-warmup-pthreads-max-refs.templatex
@@ -15,15 +15,7 @@ Total counts:
      .* total dcache flushes
            3 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -34,12 +26,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-warmup-pthreads-max-trace-size.templatex
+++ b/clients/drcachesim/tests/offline-warmup-pthreads-max-trace-size.templatex
@@ -15,15 +15,7 @@ Total counts:
      .* total dcache flushes
            3 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-           0 total physical address \+ virtual address marker pairs
-           0 total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -34,12 +26,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -39,7 +39,9 @@ Total counts:
            0 total function return value markers
            0 total physical address \+ virtual address marker pairs
            0 total physical address unavailable markers
-          23 total other markers
+           6 total system call number markers
+           5 total blocking system call markers
+          12 total other markers
           21 total encodings
 Total windows: 7
 Window #0:
@@ -59,7 +61,9 @@ Window #0:
            0 window function return value markers
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
-           8 window other markers
+           1 window system call number markers
+           1 window blocking system call markers
+           6 window other markers
           15 window encodings
 Window #1:
            8 window \(fetched\) instructions
@@ -78,7 +82,9 @@ Window #1:
            0 window function return value markers
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
-           3 window other markers
+           1 window system call number markers
+           1 window blocking system call markers
+           1 window other markers
            3 window encodings
 Window #2:
            8 window \(fetched\) instructions
@@ -97,7 +103,9 @@ Window #2:
            0 window function return value markers
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
-           3 window other markers
+           1 window system call number markers
+           1 window blocking system call markers
+           1 window other markers
            0 window encodings
 Window #3:
            8 window \(fetched\) instructions
@@ -116,7 +124,9 @@ Window #3:
            0 window function return value markers
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
-           3 window other markers
+           1 window system call number markers
+           1 window blocking system call markers
+           1 window other markers
            0 window encodings
 Window #4:
            8 window \(fetched\) instructions
@@ -135,7 +145,9 @@ Window #4:
            0 window function return value markers
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
-           3 window other markers
+           1 window system call number markers
+           1 window blocking system call markers
+           1 window other markers
            0 window encodings
 Window #5:
            6 window \(fetched\) instructions
@@ -154,7 +166,9 @@ Window #5:
            0 window function return value markers
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
-           2 window other markers
+           1 window system call number markers
+           0 window blocking system call markers
+           1 window other markers
            3 window encodings
 Window #6:
            0 window \(fetched\) instructions
@@ -173,6 +187,8 @@ Window #6:
            0 window function return value markers
            0 window physical address \+ virtual address marker pairs
            0 window physical address unavailable markers
+           0 window system call number markers
+           0 window blocking system call markers
            1 window other markers
            0 window encodings
 Thread [0-9]* counts:
@@ -192,5 +208,7 @@ Thread [0-9]* counts:
            0 function return value markers
            0 physical address \+ virtual address marker pairs
            0 physical address unavailable markers
-           8 other markers
+           1 system call number markers
+           1 blocking system call markers
+           6 other markers
           15 encodings

--- a/clients/drcachesim/tests/scattergather.templatex
+++ b/clients/drcachesim/tests/scattergather.templatex
@@ -157,15 +157,7 @@ Total counts:
      .* total dcache flushes
            1 total threads
      .* total scheduling markers
-     .* total transfer markers
-     .* total function id markers
-     .* total function return address markers
-     .* total function argument markers
-     .* total function return value markers
-     .* total physical address \+ virtual address marker pairs
-     .* total physical address unavailable markers
-     .* total other markers
-     .* total encodings
+.*
 Thread .* counts:
      .* \(fetched\) instructions
      .* unique \(fetched\) instructions
@@ -176,12 +168,4 @@ Thread .* counts:
      .* icache flushes
      .* dcache flushes
      .* scheduling markers
-     .* transfer markers
-     .* function id markers
-     .* function return address markers
-     .* function argument markers
-     .* function return value markers
-     .* physical address \+ virtual address marker pairs
-     .* physical address unavailable markers
-     .* other markers
-     .* encodings
+.*

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -178,6 +178,10 @@ basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             case TRACE_MARKER_TYPE_PHYSICAL_ADDRESS_NOT_AVAILABLE:
                 ++counters->phys_unavail_markers;
                 break;
+            case TRACE_MARKER_TYPE_SYSCALL: ++counters->syscall_number_markers; break;
+            case TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL:
+                ++counters->syscall_blocking_markers;
+                break;
             case TRACE_MARKER_TYPE_SYSCALL_TRACE_START:
                 per_shard->is_kernel = true;
                 break;
@@ -273,6 +277,10 @@ basic_counts_t::print_counters(const counters_t &counters, int64_t num_threads,
               << " physical address + virtual address marker pairs\n";
     std::cerr << std::setw(12) << counters.phys_unavail_markers << prefix
               << " physical address unavailable markers\n";
+    std::cerr << std::setw(12) << counters.syscall_number_markers << prefix
+              << " system call number markers\n";
+    std::cerr << std::setw(12) << counters.syscall_blocking_markers << prefix
+              << " blocking system call markers\n";
     std::cerr << std::setw(12) << counters.other_markers << prefix << " other markers\n";
     std::cerr << std::setw(12) << counters.encodings << prefix << " encodings\n";
 }

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -103,6 +103,8 @@ public:
             func_retval_markers += rhs.func_retval_markers;
             phys_addr_markers += rhs.phys_addr_markers;
             phys_unavail_markers += rhs.phys_unavail_markers;
+            syscall_number_markers += rhs.syscall_number_markers;
+            syscall_blocking_markers += rhs.syscall_blocking_markers;
             other_markers += rhs.other_markers;
             icache_flushes += rhs.icache_flushes;
             dcache_flushes += rhs.dcache_flushes;
@@ -132,6 +134,8 @@ public:
             func_retval_markers -= rhs.func_retval_markers;
             phys_addr_markers -= rhs.phys_addr_markers;
             phys_unavail_markers -= rhs.phys_unavail_markers;
+            syscall_number_markers -= rhs.syscall_number_markers;
+            syscall_blocking_markers -= rhs.syscall_blocking_markers;
             other_markers -= rhs.other_markers;
             icache_flushes -= rhs.icache_flushes;
             dcache_flushes -= rhs.dcache_flushes;
@@ -158,6 +162,8 @@ public:
                 func_retval_markers == rhs.func_retval_markers &&
                 phys_addr_markers == rhs.phys_addr_markers &&
                 phys_unavail_markers == rhs.phys_unavail_markers &&
+                syscall_number_markers == rhs.syscall_number_markers &&
+                syscall_blocking_markers == rhs.syscall_blocking_markers &&
                 other_markers == rhs.other_markers &&
                 icache_flushes == rhs.icache_flushes &&
                 dcache_flushes == rhs.dcache_flushes && encodings == rhs.encodings &&
@@ -178,6 +184,8 @@ public:
         int64_t func_retval_markers = 0;
         int64_t phys_addr_markers = 0;
         int64_t phys_unavail_markers = 0;
+        int64_t syscall_number_markers = 0;
+        int64_t syscall_blocking_markers = 0;
         int64_t other_markers = 0;
         int64_t icache_flushes = 0;
         int64_t dcache_flushes = 0;


### PR DESCRIPTION
Adds the count of system call number markers and blocking system call markers to the basic_counts tool.  Updates the output in the docs and key tests.  Removes the long marker list from most tests which are not really checking any values anyway, to simplify future additions to the marker types counted.

Issue: #5843