### PR TITLE
Add 10.0.0 download links

### DIFF
--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -50,7 +50,19 @@ The source code is available:
 
 For the very latest changes since the last official release, you can download \ref page_weekly_builds.
 
-The [9.0.1 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_9.0.1):
+The [10.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_10.0.0):
+
+  - [DynamoRIO-Windows-10.0.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-Windows-10.0.0.zip)
+
+  - [DynamoRIO-Linux-10.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-Linux-10.0.0.tar.gz)
+
+  - [DynamoRIO-ARM-Linux-EABIHF-10.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-ARM-Linux-EABIHF-10.0.0.tar.gz)
+
+  - [DynamoRIO-ARM-Android-EABI-10.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-ARM-Android-EABI-10.0.0.tar.gz)
+
+  - [DynamoRIO-AArch64-Linux-10.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-AArch64-Linux-10.0.0.tar.gz)
+
+The prior [9.0.1 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_9.0.1):
 
   - [DynamoRIO-Windows-9.0.1.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-Windows-9.0.1.zip)
 
@@ -61,32 +73,6 @@ The [9.0.1 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_
   - [DynamoRIO-ARM-Android-EABI-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-ARM-Android-EABI-9.0.1.tar.gz)
 
   - [DynamoRIO-AArch64-Linux-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-AArch64-Linux-9.0.1.tar.gz)
-
-The prior [8.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_8.0.0-1):
-
-  - [DynamoRIO-Windows-8.0.0-1.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_8.0.0-1/DynamoRIO-Windows-8.0.0-1.zip)
-
-  - [DynamoRIO-Linux-8.0.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_8.0.0-1/DynamoRIO-Linux-8.0.0-1.tar.gz)
-
-  - [DynamoRIO-ARM-Linux-EABIHF-8.0.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_8.0.0-1/DynamoRIO-ARM-Linux-EABIHF-8.0.0-1.tar.gz)
-
-  - [DynamoRIO-ARM-Android-EABI-8.0.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_8.0.0-1/DynamoRIO-ARM-Android-EABI-8.0.0-1.tar.gz)
-
-  - [DynamoRIO-AArch64-Linux-8.0.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_8.0.0-1/DynamoRIO-AArch64-Linux-8.0.0-1.tar.gz)
-
-Please note that older releases than 8.0.0 do not support recent operating systems, in particular recent Windows versions from Windows 10 1809 onward.
-
-The prior [7.1.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_7.1.0):
-
-  - [DynamoRIO-Windows-7.1.0-1.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_7.1.0/DynamoRIO-Windows-7.1.0-1.zip)
-
-  - [DynamoRIO-Linux-7.1.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7.1.0/DynamoRIO-Linux-7.1.0-1.tar.gz)
-
-  - [DynamoRIO-ARM-Linux-EABIHF-7.1.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7.1.0/DynamoRIO-ARM-Linux-EABIHF-7.1.0-1.tar.gz)
-
-  - [DynamoRIO-ARM-Android-EABI-7.1.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7.1.0/DynamoRIO-ARM-Android-EABI-7.1.0-1.tar.gz)
-
-  - [DynamoRIO-AArch64-Linux-7.1.0-1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_7.1.0/DynamoRIO-AArch64-Linux-7.1.0-1.tar.gz)
 
 
 ***************************************************************************

--- a/api/docs/new_release.dox
+++ b/api/docs/new_release.dox
@@ -60,6 +60,14 @@ Update the following in the code and commit the change:
 
 Don't add a new changelist section for the next release after this one: that is best done after finishing this release.
 
+The Download page in the documentation can be updated in the same commit if there will be no manual testing and only one build will be created, rather than release candidate builds that will be further tested before finalization.
+
+## Update api/docs/download.dox
+
+Make a new list of direct links for the new version at \ref page_releases.
+As mentioned, this can be combined with the version bump into a single
+commit for a single-build release.
+
 ## Trigger a Package Build
 
 To create a new build:
@@ -67,7 +75,7 @@ To create a new build:
 1. Go to the Actions tab for the DynamoRIO/dynamorio repository.
 2. Click on "ci-package" on the list of workflows on the left.
 3. Click on "Run workflow" on the right.
-4. Select the branch.
+4. Select the branch.  For an official release, use `master`.
 5. Fill in the version number.  For an official release, use three digits (e.g., '9.0.0'). For a test build or periodic build (i.e., not an official new-version-number release), use the current version major.minor and the date-based patchlevel.  The patchlevel can be found from CMake's configuration output by running `cmake .`:
 ```
 -- Version number: 8.0.18611
@@ -82,20 +90,16 @@ Once the build is finished and posted to https://github.com/DynamoRIO/dynamorio/
 
 Also point at the changelog, as was done in this past release:
 
-https://github.com/DynamoRIO/dynamorio/releases/tag/release_7.1.0
+https://github.com/DynamoRIO/dynamorio/releases/tag/release_10.0.0
 
 We generally edit the title to simplify it: e.g., from `release_8.0.0-1` to just `8.0.0`.
-
-## Update api/docs/download.dox
-
-Make a new list of direct links for the new version at \ref page_releases.
 
 ## Trigger a Docs Update
 
 1. Go to the Actions tab for the DynamoRIO/dynamorio repository.
 2. Click on "ci-docs" on the list of workflows on the left.
 3. Click on "Run workflow" on the right.
-4. Select the branch.
+4. Select the branch (`master` for an official release).
 5. Fill in the version number and build number to match that used for the package build.
 
 Wait for the workflow to finish.  It should update the online docs.
@@ -112,7 +116,10 @@ Unless it's a minor patchlevel release or something, email the users list to ann
 
 Update the changelist in release.dox: create a new entry for the next release.
 
-# Per-Platform Testing
+# Manual Per-Platform Testing
+
+Additional manual testing for a release candidate build can provide
+confidence beyond the automated testing.
 
 Perform at least the "README test" on all platforms: paste the commands from the README into your shell and make sure they behave as expected.
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -124,7 +124,17 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
-The changes between version \DR_VERSION and 9.0.1 include the following compatibility
+The changes between version \DR_VERSION and 10.0.0 include the following compatibility
+changes:
+ - Nothing yet.
+
+Further non-compatibility-affecting changes include:
+ - Nothing yet.
+
+**************************************************
+<hr>
+
+The changes between version 10.0.0 and 9.0.1 include the following compatibility
 changes:
  - Eliminated the -skip_syscall option to drrun and drinject, which is now always
    on by default.


### PR DESCRIPTION
Adds a download section for the new 10.0.0 release.
    
Updates the New Release docs to suggest modifying the download docs at
the same time as the version bump, if doing a single-build release.
