### PR TITLE
i#5843 scheduler: Add better-diagnostic test and launcher output

### DIFF
--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -115,6 +115,10 @@ droption_t<std::string>
                          "Path with stored as-traced schedule for replay.");
 #endif
 
+droption_t<uint64_t> op_print_every(DROPTION_SCOPE_ALL, "print_every", 5000,
+                                    "A letter is printed every N instrs",
+                                    "A letter is printed every N instrs");
+
 uint64_t
 get_current_microseconds()
 {
@@ -136,10 +140,11 @@ get_current_microseconds()
 
 void
 simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &scheduler,
-              std::vector<scheduler_t::input_ordinal_t> &thread_sequence)
+              std::string &thread_sequence)
 {
     memref_t record;
     uint64_t micros = op_sched_time.get_value() ? get_current_microseconds() : 0;
+    uint64_t cur_segment_instrs = 0;
     // Thread ids can be duplicated, so use the input ordinals to distinguish.
     scheduler_t::input_ordinal_t prev_input = scheduler_t::INVALID_INPUT_ORDINAL;
     for (scheduler_t::stream_status_t status = stream->next_record(record, micros);
@@ -148,12 +153,13 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
         if (op_sched_time.get_value())
             micros = get_current_microseconds();
         if (status == scheduler_t::STATUS_WAIT) {
+            thread_sequence += '-';
             std::this_thread::yield();
             continue;
         }
         if (status != scheduler_t::STATUS_OK)
             FATAL_ERROR("scheduler failed to advance: %d", status);
-        if (op_verbose.get_value() >= 3) {
+        if (op_verbose.get_value() >= 4) {
             std::ostringstream line;
             line << "Core #" << std::setw(2) << ordinal << " @" << std::setw(9)
                  << stream->get_record_ordinal() << " refs, " << std::setw(9)
@@ -177,11 +183,13 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
             std::cerr << line.str();
         }
         scheduler_t::input_ordinal_t input = stream->get_input_stream_ordinal();
-        if (thread_sequence.empty())
-            thread_sequence.push_back(input);
-        else if (stream->get_input_stream_ordinal() != prev_input) {
-            thread_sequence.push_back(input);
-            if (op_verbose.get_value() > 0) {
+        if (input != prev_input) {
+            // We convert to letters which only works well for <=26 inputs.
+            if (!thread_sequence.empty())
+                thread_sequence += ',';
+            thread_sequence += 'A' + static_cast<char>(input % 26);
+            cur_segment_instrs = 0;
+            if (op_verbose.get_value() >= 2) {
                 std::ostringstream line;
                 line
                     << "Core #" << std::setw(2) << ordinal << " @" << std::setw(9)
@@ -205,6 +213,12 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
                     << " == thread " << record.instr.tid << "\n";
                 std::cerr << line.str();
             }
+        }
+        if (type_is_instr(record.instr.type))
+            ++cur_segment_instrs;
+        if (cur_segment_instrs == op_print_every.get_value()) {
+            thread_sequence += 'A' + static_cast<char>(input % 26);
+            cur_segment_instrs = 0;
         }
         prev_input = input;
     }
@@ -268,8 +282,7 @@ _tmain(int argc, const TCHAR *targv[])
     }
 
     std::vector<std::thread> threads;
-    std::vector<std::vector<scheduler_t::input_ordinal_t>> schedules(
-        op_num_cores.get_value());
+    std::vector<std::string> schedules(op_num_cores.get_value());
     std::cerr << "Creating " << op_num_cores.get_value() << " simulator threads\n";
     threads.reserve(op_num_cores.get_value());
     for (int i = 0; i < op_num_cores.get_value(); ++i) {
@@ -280,10 +293,7 @@ _tmain(int argc, const TCHAR *targv[])
         thread.join();
 
     for (int i = 0; i < op_num_cores.get_value(); ++i) {
-        std::cerr << "Core #" << i << ": ";
-        for (scheduler_t::input_ordinal_t input : schedules[i])
-            std::cerr << input << " ";
-        std::cerr << "\n";
+        std::cerr << "Core #" << i << ": " << schedules[i] << "\n";
     }
 
 #ifdef HAS_ZIP


### PR DESCRIPTION
Adds printing '.' for every record and '-' for waiting to the scheduler unit tests and udpates all the expected output.  This makes it much easier to understand some of the results as now the lockstep timing all lines up.

Adds -print_every to the launcher and switches to printing letters for a better output of what happened on each core (if #inputs<=26). Example:
```
$ clients/bin64/scheduler_launcher -trace_dir drmemtrace.*.dir/trace -num_cores 4 -sched_quantum 60000 -print_every 5000
Core #0: GGGGGGGGG,HH,F,B,G,I,A,CC,G,BB,A,FF,AA,GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG
Core #1: D,C,D,B,H,FF,EE,CC,II,AA,C,D,G,HH,D,G,II,G,I,G,I,G,HH,BB,II,BB,C,H,I,AA,C,F,I,H,II,AA,C,H,A,H,F,CC,DD,C,BB,HH,CC,F,BB,C,D,H,BB,D,B,EE,I,E,DD,B,F,H,A,D,C,D,E,B,D,I,D,AA,E,DD,EE,CC,II,C,D,I,AA,DD,B,E,I,D,C,E,FF,E,BB,EE,FF,E,AA,D,E,DD,H,BB,HH,D,H,BB,I,AA,II,H,A,FF,H,I,HH,DD,I,H,F,DD,I,A,HH,AA,CC,BB,CC,BB,D,B,FF,H,F,D,I,DD,FF,C,A,C,AA,F,AA,EE,A,D,E,FF,AA,F,A,E,A,E,DD,EE,F,E,F,A
Core #2: F,E,F,C,F,H,I,B,HH,II,FF,CC,G,H,DD,E,A,G,H,G,DD,G,F,D,A,H,I,FF,H,C,A,CC,II,A,FF,C,I,F,CC,B,FF,C,B,H,CC,B,D,B,DD,B,F,I,F,II,D,A,DD,I,D,H,E,H,I,D,HH,FF,BB,II,AA,EE,B,A,BB,E,II,A,BB,A,HH,E,AA,E,F,A,DD,HH,F,H,A,E,I,FF,I,B,F,II,A,FF,D,H,DD,I,AA,F,D,FF,AA,D,A,HH,A,H,F,A,FF,C,F,B,F,C,F,AA,B,FF,D,F,DD,B,C,H,CC,B,C,E,D,EE,C,E,D,EE,F,DD,E,F,D,A,DD,E,D,EE,D,E,D,AA,D,A,DD,F,D,C,D
Core #3: E,A,F,A,D,I,DD,BB,AA,BB,DD,G,EE,AA,H,G,D,B,G,B,G,II,F,HH,B,AA,I,B,A,HH,CC,HH,F,A,FF,C,HH,BB,F,D,F,C,FF,H,C,FF,DD,AA,I,B,II,AA,I,A,B,A,F,A,C,I,B,H,A,F,C,A,C,EE,F,D,EE,CC,E,BB,E,DD,E,CC,B,EE,C,EE,B,I,E,D,E,II,H,B,EE,I,EE,B,II,F,EE,A,D,AA,DD,HH,F,A,F,HH,D,A,II,H,F,II,FF,CC,B,AA,F,A,C,FF,D,C,D,CC,B,C,DD,H,I,F,CC,A,F,C,FF,E,A,DD,E,D,A,FF,AA,EE,F,DD,FF,E,F,EE,FF,AA,EEEEEEEEEEEEEEEE
```

Issue: #5843