### PR TITLE
i#5843 scheduler: Reduce default instr quantum to 500K

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -448,7 +448,7 @@ public:
          * specified by
          * #dynamorio::drmemtrace::scheduler_tmpl_t::scheduler_options_t::quantum_unit.
          */
-        uint64_t quantum_duration = 10 * 1000 * 1000;
+        uint64_t quantum_duration = 500 * 1000;
         /**
          * If > 0, diagnostic messages are printed to stderr.  Higher values produce
          * more frequent diagnostics.

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -88,7 +88,7 @@ droption_t<int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 1, 0, 64, "Verbosity l
 droption_t<int> op_num_cores(DROPTION_SCOPE_ALL, "num_cores", 4, 0, 8192,
                              "Number of cores", "Number of cores");
 
-droption_t<int64_t> op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 1 * 1000 * 1000,
+droption_t<int64_t> op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 500 * 1000,
                                      "Scheduling quantum",
                                      "Scheduling quantum: in instructions by default; in "
                                      "miroseconds if -sched_time is set.");


### PR DESCRIPTION
Updates the default instruction count scheduling quantum to be smaller and consistent: 500K instructions instead of the 1M it was in the launcher and 10M in the scheduler.

Issue: #5843