### PR TITLE
i#6280: Do not try to omit wow64 syscalls

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -968,6 +968,7 @@ test_false_syscalls(void *drcontext)
 {
 #if defined(WINDOWS) && !defined(X64)
     // We do not omit false syscalls for WOW64 today.
+    return true;
 #else
     std::cerr << "\n===============\nTesting false syscalls\n";
     // Our synthetic test first constructs a list of instructions to be encoded into

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1913,6 +1913,12 @@ raw2trace_t::should_omit_syscall(raw2trace_thread_data_t *tdata)
 {
     if (!TESTANY(OFFLINE_FILE_TYPE_SYSCALL_NUMBERS, tdata->file_type))
         return false;
+#if defined(WINDOWS) && !defined(X64)
+    // For WOW64 there is a store for the "syscall" call which complicates detecting and
+    // removing it.  Furthermore, instr_is_wow64_syscall() can vary whether using full DR
+    // or not: i#5949.  For simplicity for now we just bail on WOW64.
+    return false;
+#else
     // We have 2 scenarios where we record a syscall instr yet it doesn't
     // execute right away and so there's no syscall number marker:
     // 1) An asynchronous signal arrives during the block and is delivered
@@ -1949,6 +1955,7 @@ raw2trace_t::should_omit_syscall(raw2trace_thread_data_t *tdata)
         queue_entry(tdata, entry);
     }
     return omit;
+#endif
 }
 
 std::string


### PR DESCRIPTION
Due to complexities in identifying and removing them, omitting false wow64 syscalls is disabled.

Tested: Ran the windows-test from PR #6165 which was failing every time and confirmed it now passes.

Issue: #6280, #6131
Fixes #6280