### PR TITLE
i#6289: Add timestamps at buffer end and around syscalls

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -139,6 +139,8 @@ Further non-compatibility-affecting changes include:
    -core_serial) and control the schedule
    (-sched_quantum, -sched_time, sched_order_time, -record_file,
    -replay_file, -cpu_schedule_file).
+ - Added additional timestamps to drmemtrace traces: at the end of each buffer,
+   and before and after each system call.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -90,8 +90,15 @@ typedef enum {
      * version, do not contain this information.
      */
     TRACE_ENTRY_VERSION_BRANCH_INFO = 5,
+    /**
+     * The trace contains additional timestamps to identify and distinguish application
+     * instruction execution, application syscall invocation, and trace i/o.  The
+     * pre-syscall and post-syscall timestamps are as expected.  Prior versions have the
+     * post-syscall timestamp actually containing the pre-syscall time.
+     */
+    TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS = 6,
     /** The latest version of the trace format. */
-    TRACE_ENTRY_VERSION = TRACE_ENTRY_VERSION_BRANCH_INFO,
+    TRACE_ENTRY_VERSION = TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS,
 } trace_version_t;
 
 /** The type of a trace entry in a #memref_t structure. */

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -96,9 +96,9 @@ typedef enum {
      * pre-syscall and post-syscall timestamps are as expected.  Prior versions have the
      * post-syscall timestamp actually containing the pre-syscall time.
      */
-    TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS = 6,
+    TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS = 6,
     /** The latest version of the trace format. */
-    TRACE_ENTRY_VERSION = TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS,
+    TRACE_ENTRY_VERSION = TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS,
 } trace_version_t;
 
 /** The type of a trace entry in a #memref_t structure. */
@@ -940,6 +940,12 @@ struct schedule_entry_t {
         , cpu(cpu)
         , start_instruction(start_instruction)
     {
+    }
+    bool
+    operator!=(const schedule_entry_t &rhs)
+    {
+        return thread != rhs.thread || timestamp != rhs.timestamp || cpu != rhs.cpu ||
+            start_instruction != rhs.start_instruction;
     }
     uint64_t thread;
     uint64_t timestamp;

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -182,7 +182,7 @@ Some of the more important markers are:
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID - The marker value contains the ordinal of the trace burst window when the subsequent entries until the next #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID or end-of-trace were collected (see \ref sec_drcachesim_partial).
 
-- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL - This identifies a system call.  A timestamp is inserted in the trace before and after each system call.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL - This identifies a system call.  A timestamp is inserted in the trace before and after marker of this type.  This marker should be considered to be the actual system call invocation by the kernel, rather than the prior system call gateway instruction fetch record.  Thus, these timestamps provide the system call latency.
 
 The full set of markers is listed under the enum #dynamorio::drmemtrace::trace_marker_type_t.
 

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -99,8 +99,8 @@ A trace is presented to analysis tools as a stream of records.  Each
 record entry is of type #dynamorio::drmemtrace::memref_t and
 represents one instruction or data reference or a metadata operation
 such as a thread exit or marker.  There are built-in scheduling
-markers providing the timestamp and cpu identifier on each thread
-transition.  Other built-in markers indicate disruptions in user mode
+markers providing the timestamp and cpu identifier periodically and before and
+after each system call.  Other built-in markers indicate disruptions in user mode
 control flow such as signal handler entry and exit.
 
 Each entry contains the common fields \p type, \p pid, and \p tid. The
@@ -174,13 +174,15 @@ Some of the more important markers are:
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_XFER - This identifies a system call that changes control flow, such as a signal return.
 
-- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP - The marker value provides a timestamp for this point of the trace (in units of microseconds since Jan 1, 1601 UTC). This value can be used to synchronize records from different threads. It is used in the sequential analysis of a multi-threaded trace.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP - The marker value provides a timestamp for this point of the trace (in units of microseconds since Jan 1, 1601 UTC). This value can be used to synchronize records from different threads as well as analyze latencies (however, tracing overhead inflates time unevenly, so time deltas should not be considered perfectly representative). It is used in the sequential analysis of a multi-threaded trace.
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID - The marker value contains the CPU identifier on which the subsequent records were collected. It is useful to help track thread migrations occurring during execution. This marker is written to the header of each trace buffer when the buffer is flushed. Note that if the thread migrates to a different CPU due to preemption by the kernel before a buffer is full, we do not output a separate #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID marker to capture the previous CPU identifier. However, we expect such cases to be rare.
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETADDR, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL - These markers are used to capture information about function calls.  Which functions to capture must be explicitly selected at tracing time.  Typical candiates are heap allocation and freeing functions.  See \ref sec_drcachesim_funcs.
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID - The marker value contains the ordinal of the trace burst window when the subsequent entries until the next #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID or end-of-trace were collected (see \ref sec_drcachesim_partial).
+
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL - This identifies a system call.  A timestamp is inserted in the trace before and after each system call.
 
 The full set of markers is listed under the enum #dynamorio::drmemtrace::trace_marker_type_t.
 
@@ -684,7 +686,7 @@ $ $ bin64/drrun -t drcachesim -simulator_type view -indir drmemtrace.*.dir -sim_
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-           1           0:     3256418 <marker: version 5>
+           1           0:     3256418 <marker: version 6>
            2           0:     3256418 <marker: filetype 0x240>
            3           0:     3256418 <marker: cache line size 64>
            4           0:     3256418 <marker: chunk instruction count 1024>

--- a/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/allasm-repstr-basic-counts.templatex
@@ -20,7 +20,7 @@ Total counts:
            0 total icache flushes
            0 total dcache flushes
            1 total threads
-          24 total scheduling markers
+          44 total scheduling markers
            0 total transfer markers
            0 total function id markers
            0 total function return address markers
@@ -41,7 +41,7 @@ Thread [0-9]* counts:
            5 data stores
            0 icache flushes
            0 dcache flushes
-          24 scheduling markers
+          44 scheduling markers
            0 transfer markers
            0 function id markers
            0 function return address markers

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1188,7 +1188,8 @@ check_syscalls()
         OFFLINE_FILE_TYPE_ENCODINGS | OFFLINE_FILE_TYPE_SYSCALL_NUMBERS;
     bool res = true;
     {
-        // Correct: syscall followed by marker.
+        // Correct: syscall followed by marker (no timestamps; modeling versions
+        // prior to TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS).
         std::vector<memref_with_IR_t> memref_setup = {
             { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
             { gen_instr(TID), sys },
@@ -1272,7 +1273,7 @@ check_syscalls()
         // Correct: syscall preceded by timestamp+cpu.
         std::vector<memref_with_IR_t> memref_setup = {
             { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
-                         TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS),
+                         TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS),
               nullptr },
             { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
             { gen_instr(TID), sys },
@@ -1288,7 +1289,7 @@ check_syscalls()
         // Incorrect: syscall with no preceding timestamp+cpu.
         std::vector<memref_with_IR_t> memref_setup = {
             { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
-                         TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS),
+                         TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS),
               nullptr },
             { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
             { gen_instr(TID), sys },
@@ -1307,7 +1308,7 @@ check_syscalls()
         // Incorrect: syscall with preceding cpu but no timestamp.
         std::vector<memref_with_IR_t> memref_setup = {
             { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
-                         TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS),
+                         TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS),
               nullptr },
             { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
             { gen_instr(TID), sys },
@@ -1323,6 +1324,8 @@ check_syscalls()
             res = false;
         }
     }
+    // We deliberately do not test for missing post-syscall timestamps as some syscalls
+    // do not have a post-syscall event so we can't easily check that.
     instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
     return res;
 #endif

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -960,9 +960,10 @@ check_duplicate_syscall_with_same_pc()
 }
 
 bool
-check_false_syscalls()
+check_syscalls()
 {
     // Ensure missing syscall markers (from "false syscalls") are detected.
+    std::cerr << "Testing false syscalls\n";
 #if defined(WINDOWS) && !defined(X64)
     // TODO i#5949: For WOW64 instr_is_syscall() always returns false, so our
     // checks do not currently work properly there.
@@ -986,15 +987,39 @@ check_false_syscalls()
     instrlist_append(ilist, sys);
     instrlist_append(ilist, move1);
     static constexpr addr_t BASE_ADDR = 0x123450;
+    static constexpr memref_tid_t TID = 1;
     static constexpr uintptr_t FILE_TYPE =
         OFFLINE_FILE_TYPE_ENCODINGS | OFFLINE_FILE_TYPE_SYSCALL_NUMBERS;
     bool res = true;
     {
         // Correct: syscall followed by marker.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(1), sys },
-            { gen_marker(1, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), sys },
+            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, false))
+            res = false;
+    }
+    {
+        // Correct: syscall followed by marker with timestamp+cpu in between with
+        // subsequent function arg markers.
+        uintptr_t sys_func_id =
+            static_cast<uintptr_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) + 202;
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), sys },
+            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, sys_func_id), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ARG, 0), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, sys_func_id), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETVAL, 0), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 111), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_instr(TID), move1 }
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, false))
@@ -1003,11 +1028,11 @@ check_false_syscalls()
     {
         // Correct: syscall followed by marker with timestamp+cpu in between.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(1), sys },
-            { gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
-            { gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
-            { gen_marker(1, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), sys },
+            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, false))
@@ -1016,14 +1041,13 @@ check_false_syscalls()
     {
         // Incorrect: syscall with no marker.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(1), sys },
-            { gen_instr(1), move1 }
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), sys },
+            { gen_instr(TID), move1 }
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall instruction not followed by syscall marker",
-                           /*tid=*/1,
+                         { "Syscall marker missing after syscall instruction", TID,
                            /*ref_ordinal=*/3, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch syscall without number marker")) {
@@ -1033,17 +1057,73 @@ check_false_syscalls()
     {
         // Incorrect: marker with no syscall.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(1), move1 },
-            { gen_marker(1, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), move1 },
+            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall marker not placed after syscall instruction",
-                           /*tid=*/1,
+                         { "Syscall marker not placed after syscall instruction", TID,
                            /*ref_ordinal=*/3, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch misplaced syscall marker")) {
+            res = false;
+        }
+    }
+    // Ensure timestamps are where we expect them.
+    std::cerr << "Testing syscall timestamps\n";
+    {
+        // Correct: syscall preceded by timestamp+cpu.
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS),
+              nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), sys },
+            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, false))
+            res = false;
+    }
+    {
+        // Incorrect: syscall with no preceding timestamp+cpu.
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS),
+              nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), sys },
+            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, true,
+                         { "Syscall not preceded by timestamp + cpuid", TID,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/1 },
+                         "Failed to catch syscall without timestamp+cpuid")) {
+            res = false;
+        }
+    }
+    {
+        // Incorrect: syscall with preceding cpu but no timestamp.
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS),
+              nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_instr(TID), sys },
+            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, true,
+                         { "Syscall not preceded by timestamp + cpuid", TID,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/1 },
+                         "Failed to catch syscall without timestamp")) {
             res = false;
         }
     }
@@ -1681,7 +1761,7 @@ test_main(int argc, const char *argv[])
 {
     if (check_branch_target_after_branch() && check_sane_control_flow() &&
         check_kernel_xfer() && check_rseq() && check_function_markers() &&
-        check_duplicate_syscall_with_same_pc() && check_false_syscalls() &&
+        check_duplicate_syscall_with_same_pc() && check_syscalls() &&
         check_rseq_side_exit_discontinuity() && check_schedule_file() &&
         check_branch_decoration() && check_filter_endpoint() &&
         check_timestamps_increase_monotonically()) {

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1100,7 +1100,7 @@ check_syscalls()
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall not preceded by timestamp + cpuid", TID,
+                         { "Syscall marker not preceded by timestamp + cpuid", TID,
                            /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch syscall without timestamp+cpuid")) {
@@ -1120,7 +1120,7 @@ check_syscalls()
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall not preceded by timestamp + cpuid", TID,
+                         { "Syscall marker not preceded by timestamp + cpuid", TID,
                            /*ref_ordinal=*/5, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch syscall without timestamp")) {

--- a/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
+++ b/clients/drcachesim/tests/offline-allasm-repstr-basic-counts.templatex
@@ -19,7 +19,7 @@ Total counts:
            0 total icache flushes
            0 total dcache flushes
            1 total threads
-          24 total scheduling markers
+          44 total scheduling markers
            0 total transfer markers
            0 total function id markers
            0 total function return address markers
@@ -40,7 +40,7 @@ Thread [0-9]* counts:
            5 data stores
            0 icache flushes
            0 dcache flushes
-          24 scheduling markers
+          44 scheduling markers
            0 transfer markers
            0 function id markers
            0 function return address markers

--- a/clients/drcachesim/tests/offline-phys.templatex
+++ b/clients/drcachesim/tests/offline-phys.templatex
@@ -11,7 +11,7 @@ Adios world!
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-           1           0: +[0-9]+ <marker: version 5>
+           1           0: +[0-9]+ <marker: version 6>
            2           0: +[0-9]+ <marker: filetype 0xe42>
            3           0: +[0-9]+ <marker: cache line size [0-9]+>
            4           0: +[0-9]+ <marker: chunk instruction count [0-9]+>

--- a/clients/drcachesim/tests/offline-windows-asm.templatex
+++ b/clients/drcachesim/tests/offline-windows-asm.templatex
@@ -19,7 +19,7 @@ Hit tracing window #4 limit: disabling tracing.
 Adios world!
 Hit retrace threshold: enabling tracing for window #5.
 Adios world!
-Hit tracing window #5 limit: disabling tracing.*
+Hit tracing window #5 limit: disabling tracing.
 Basic counts tool results:
 Total counts:
           53 total \(fetched\) instructions
@@ -31,7 +31,7 @@ Total counts:
            0 total icache flushes
            0 total dcache flushes
            1 total threads
-          12 total scheduling markers
+          36 total scheduling markers
            0 total transfer markers
            0 total function id markers
            0 total function return address markers
@@ -41,9 +41,9 @@ Total counts:
            0 total physical address unavailable markers
            6 total system call number markers
            5 total blocking system call markers
-          11 total other markers
+          12 total other markers
           21 total encodings
-Total windows: 6
+Total windows: 7
 Window #0:
           15 window \(fetched\) instructions
           15 window unique \(fetched\) instructions
@@ -53,7 +53,7 @@ Window #0:
            5 window data stores
            0 window icache flushes
            0 window dcache flushes
-           3 window scheduling markers
+           5 window scheduling markers
            0 window transfer markers
            0 window function id markers
            0 window function return address markers
@@ -74,7 +74,7 @@ Window #1:
            0 window data stores
            0 window icache flushes
            0 window dcache flushes
-           2 window scheduling markers
+           6 window scheduling markers
            0 window transfer markers
            0 window function id markers
            0 window function return address markers
@@ -95,7 +95,7 @@ Window #2:
            0 window data stores
            0 window icache flushes
            0 window dcache flushes
-           2 window scheduling markers
+           6 window scheduling markers
            0 window transfer markers
            0 window function id markers
            0 window function return address markers
@@ -116,7 +116,7 @@ Window #3:
            0 window data stores
            0 window icache flushes
            0 window dcache flushes
-           2 window scheduling markers
+           6 window scheduling markers
            0 window transfer markers
            0 window function id markers
            0 window function return address markers
@@ -137,7 +137,7 @@ Window #4:
            0 window data stores
            0 window icache flushes
            0 window dcache flushes
-           2 window scheduling markers
+           6 window scheduling markers
            0 window transfer markers
            0 window function id markers
            0 window function return address markers
@@ -158,7 +158,7 @@ Window #5:
            0 window data stores
            0 window icache flushes
            0 window dcache flushes
-           1 window scheduling markers
+           6 window scheduling markers
            0 window transfer markers
            0 window function id markers
            0 window function return address markers
@@ -170,6 +170,27 @@ Window #5:
            0 window blocking system call markers
            1 window other markers
            3 window encodings
+Window #6:
+           0 window \(fetched\) instructions
+           0 window unique \(fetched\) instructions
+           0 window non-fetched instructions
+           0 window prefetches
+           0 window data loads
+           0 window data stores
+           0 window icache flushes
+           0 window dcache flushes
+           1 window scheduling markers
+           0 window transfer markers
+           0 window function id markers
+           0 window function return address markers
+           0 window function argument markers
+           0 window function return value markers
+           0 window physical address \+ virtual address marker pairs
+           0 window physical address unavailable markers
+           0 window system call number markers
+           0 window blocking system call markers
+           1 window other markers
+           0 window encodings
 Thread [0-9]* counts:
           15 \(fetched\) instructions
           15 unique \(fetched\) instructions
@@ -179,7 +200,7 @@ Thread [0-9]* counts:
            5 data stores
            0 icache flushes
            0 dcache flushes
-           3 scheduling markers
+           5 scheduling markers
            0 transfer markers
            0 function id markers
            0 function return address markers

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -341,7 +341,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
 #endif
         shard->expect_syscall_marker_ = false;
         // We expect an immediately preceding timestamp + cpuid.
-        if (shard->trace_version_ >= TRACE_ENTRY_VERSION_ACCURATE_TIMESTAMPS) {
+        if (shard->trace_version_ >= TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS) {
             report_if_false(
                 shard,
                 shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
@@ -499,6 +499,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     if (type_is_instr(memref.instr.type) ||
         memref.instr.type == TRACE_TYPE_PREFETCH_INSTR ||
         memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH) {
+        // We'd prefer to report this error at the syscall instr but it is easier
+        // to wait until here:
         report_if_false(shard,
                         !TESTANY(OFFLINE_FILE_TYPE_SYSCALL_NUMBERS, shard->file_type_) ||
                             !shard->expect_syscall_marker_,

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1018,10 +1018,13 @@ invariant_checker_t::check_for_pc_discontinuity(
         (prev_instr_trace_pc == cur_pc &&
          (memref.instr.type == TRACE_TYPE_INSTR_NO_FETCH ||
           // Online incorrectly marks the 1st string instr across a thread
-          // switch as fetched.
+          // switch as fetched.  We no longer emit timestamps in pipe splits so
+          // we can't use saw_timestamp_but_no_instr_.  We can't just check for
+          // prev_instr.instr_type being no-fetch as the prev might have been
+          // a single instance, which is fetched.  We check the sizes for now.
           // TODO i#4915, #4948: Eliminate non-fetched and remove the
           // underlying instrs altogether, which would fix this for us.
-          (!knob_offline_ && shard->saw_timestamp_but_no_instr_))) ||
+          (!knob_offline_ && memref.instr.size == prev_instr.instr.size))) ||
         // Same PC is allowed for a kernel interruption which may restart the
         // same instruction.
         (prev_instr_trace_pc == cur_pc && at_kernel_event) ||

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -817,8 +817,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                 memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID))) {
         shard->saw_rseq_abort_ = false;
     }
-    shard->prev_prev_entry_ = shard->prev_entry_;
 #endif
+    shard->prev_prev_entry_ = shard->prev_entry_;
     shard->prev_entry_ = memref;
     if (type_is_instr_branch(shard->prev_entry_.instr.type))
         shard->last_branch_ = shard->prev_entry_;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -349,7 +349,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                     shard->prev_prev_entry_.marker.type == TRACE_TYPE_MARKER &&
                     shard->prev_prev_entry_.marker.marker_type ==
                         TRACE_MARKER_TYPE_TIMESTAMP,
-                "Syscall not preceded by timestamp + cpuid");
+                "Syscall marker not preceded by timestamp + cpuid");
         }
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -196,6 +196,8 @@ protected:
         addr_t rseq_start_pc_ = 0;
         addr_t rseq_end_pc_ = 0;
         bool saw_filter_endpoint_marker_ = false;
+        // Used to check markers after each system call.
+        bool expect_syscall_marker_ = false;
     };
 
     // We provide this for subclasses to run these invariants with custom

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -125,6 +125,7 @@ protected:
         memref_t last_branch_ = {};
         memtrace_stream_t *stream = nullptr;
         memref_t prev_entry_ = {};
+        memref_t prev_prev_entry_ = {};
         memref_t prev_instr_ = {};
         std::unique_ptr<instr_autoclean_t> prev_instr_decoded_ = nullptr;
         memref_t prev_xfer_marker_ = {}; // Cleared on seeing an instr.
@@ -157,7 +158,6 @@ protected:
         memref_t last_instr_in_cur_context_ = {};
 
         bool saw_rseq_abort_ = false;
-        memref_t prev_prev_entry_ = {};
         // These are only available via annotations in signal_invariants.cpp.
         int instrs_until_interrupt_ = -1;
         int memrefs_until_interrupt_ = -1;

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -229,6 +229,8 @@ public:
     // This is a per-buffer-writeout header.
     virtual int
     append_unit_header(byte *buf_ptr, thread_id_t tid, ptr_int_t window) = 0;
+    virtual int
+    append_timestamp(byte *buf_ptr) = 0;
     // The entry at buf_ptr must be a timestamp.
     // If the timestamp value is < min_timestamp, replaces it with min_timestamp
     // and returns true; else returns false.
@@ -359,6 +361,8 @@ public:
     append_thread_header(byte *buf_ptr, thread_id_t tid, offline_file_type_t file_type);
     int
     append_unit_header(byte *buf_ptr, thread_id_t tid, ptr_int_t window) override;
+    int
+    append_timestamp(byte *buf_ptr) override;
     bool
     clamp_unit_header_timestamp(byte *buf_ptr, uint64 min_timestamp) override;
 
@@ -447,6 +451,8 @@ public:
     append_thread_header(byte *buf_ptr, thread_id_t tid, offline_file_type_t file_type);
     int
     append_unit_header(byte *buf_ptr, thread_id_t tid, ptr_int_t window) override;
+    int
+    append_timestamp(byte *buf_ptr) override;
     bool
     clamp_unit_header_timestamp(byte *buf_ptr, uint64 min_timestamp) override;
 

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -403,15 +403,21 @@ int
 offline_instru_t::append_unit_header(byte *buf_ptr, thread_id_t tid, ptr_int_t window)
 {
     byte *new_buf = buf_ptr;
-    offline_entry_t *entry = (offline_entry_t *)new_buf;
-    entry->timestamp.type = OFFLINE_TYPE_TIMESTAMP;
-    uint64 frozen = frozen_timestamp_.load(std::memory_order_acquire);
-    entry->timestamp.usec = frozen != 0 ? frozen : instru_t::get_timestamp();
-    new_buf += sizeof(*entry);
+    new_buf += append_timestamp(new_buf);
     if (window >= 0)
         new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_WINDOW_ID, (uintptr_t)window);
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CPU_ID, instru_t::get_cpu_id());
     return (int)(new_buf - buf_ptr);
+}
+
+int
+offline_instru_t::append_timestamp(byte *buf_ptr)
+{
+    offline_entry_t *entry = (offline_entry_t *)buf_ptr;
+    entry->timestamp.type = OFFLINE_TYPE_TIMESTAMP;
+    uint64 frozen = frozen_timestamp_.load(std::memory_order_acquire);
+    entry->timestamp.usec = frozen != 0 ? frozen : instru_t::get_timestamp();
+    return sizeof(*entry);
 }
 
 bool

--- a/clients/drcachesim/tracer/instru_online.cpp
+++ b/clients/drcachesim/tracer/instru_online.cpp
@@ -193,15 +193,21 @@ online_instru_t::append_unit_header(byte *buf_ptr, thread_id_t tid, intptr_t win
 {
     byte *new_buf = buf_ptr;
     new_buf += append_tid(new_buf, tid);
-    uint64 frozen = frozen_timestamp_.load(std::memory_order_acquire);
-    new_buf += append_marker(
-        new_buf, TRACE_MARKER_TYPE_TIMESTAMP,
-        // Truncated to 32 bits for 32-bit: we live with it.
-        static_cast<uintptr_t>(frozen != 0 ? frozen : instru_t::get_timestamp()));
+    new_buf += append_timestamp(new_buf);
     if (window >= 0)
         new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_WINDOW_ID, (uintptr_t)window);
     new_buf += append_marker(new_buf, TRACE_MARKER_TYPE_CPU_ID, instru_t::get_cpu_id());
     return (int)(new_buf - buf_ptr);
+}
+
+int
+online_instru_t::append_timestamp(byte *buf_ptr)
+{
+    uint64 frozen = frozen_timestamp_.load(std::memory_order_acquire);
+    return append_marker(
+        buf_ptr, TRACE_MARKER_TYPE_TIMESTAMP,
+        // Truncated to 32 bits for 32-bit: we live with it.
+        static_cast<uintptr_t>(frozen != 0 ? frozen : instru_t::get_timestamp()));
 }
 
 bool

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -506,9 +506,13 @@ atomic_pipe_write(void *drcontext, byte *pipe_start, byte *pipe_end, ptr_int_t w
         FATAL("Fatal error: failed to write to pipe\n");
     }
     // Re-emit buffer unit header to handle split pipe writes.
-    if (pipe_end - buf_hdr_slots_size > pipe_start) {
-        pipe_start = pipe_end - buf_hdr_slots_size;
-        append_unit_header(drcontext, pipe_start, dr_get_thread_id(drcontext), window);
+    // We need the tid to identify who the pipe buffer belongs to, but we do
+    // not include a timestamp as it will be out of order with respect to
+    // execution-time timestamps.
+    if (pipe_end - instru->sizeof_entry() > pipe_start) {
+        pipe_start = pipe_end - instru->sizeof_entry();
+        size_t added = instru->append_tid(pipe_start, dr_get_thread_id(drcontext));
+        DR_ASSERT(added == instru->sizeof_entry());
     }
     return pipe_start;
 }
@@ -707,15 +711,16 @@ create_v2p_buffer(per_thread_t *data)
 }
 
 static bool
-is_ok_to_split_before(trace_type_t type)
+is_ok_to_split_before(trace_type_t type, size_t size)
 {
     // We can split before the start of each sequence: we don't want to split
     // an <encoding, instruction, address> combination.
     return (op_instr_encodings.get_value()
                 ? type == TRACE_TYPE_ENCODING
                 : (type_is_instr(type) || type == TRACE_TYPE_INSTR_MAYBE_FETCH)) ||
-        type == TRACE_TYPE_MARKER || type == TRACE_TYPE_THREAD_EXIT ||
-        op_L0I_filter.get_value();
+        // Don't split a timestamp;cpuid pair.
+        (type == TRACE_TYPE_MARKER && size != TRACE_MARKER_TYPE_CPU_ID) ||
+        type == TRACE_TYPE_THREAD_EXIT || op_L0I_filter.get_value();
 }
 
 static uint
@@ -725,7 +730,10 @@ output_buffer(void *drcontext, per_thread_t *data, byte *buf_base, byte *buf_ptr
     byte *pipe_start = buf_base;
     byte *pipe_end = pipe_start;
     if (!op_offline.get_value()) {
-        for (byte *mem_ref = buf_base + header_size; mem_ref < buf_ptr;
+        byte *post_header = buf_base + header_size;
+        // Pipe split headers are just the tid.
+        header_size = instru->sizeof_entry();
+        for (byte *mem_ref = post_header; mem_ref < buf_ptr;
              mem_ref += instru->sizeof_entry()) {
             // Split up the buffer into multiple writes to ensure atomic pipe writes.
             // We can only split before TRACE_TYPE_INSTR, assuming only a few data
@@ -733,7 +741,8 @@ output_buffer(void *drcontext, per_thread_t *data, byte *buf_base, byte *buf_ptr
             // XXX i#2638: if we want to support branch target analysis in online
             // traces we'll need to not split after a branch: either split before
             // it or one instr after.
-            if (is_ok_to_split_before(instru->get_entry_type(mem_ref))) {
+            if (is_ok_to_split_before(instru->get_entry_type(mem_ref),
+                                      instru->get_entry_size(mem_ref))) {
                 pipe_end = mem_ref;
                 // We check the end of this entry + the max # of delay entries to
                 // avoid splitting an instr from its subsequent bundle entry.
@@ -741,7 +750,8 @@ output_buffer(void *drcontext, per_thread_t *data, byte *buf_base, byte *buf_ptr
                 if ((mem_ref + (1 + MAX_NUM_DELAY_ENTRIES) * instru->sizeof_entry() -
                      pipe_start) > ipc_pipe.get_atomic_write_size()) {
                     DR_ASSERT(is_ok_to_split_before(
-                        instru->get_entry_type(pipe_start + header_size)));
+                        instru->get_entry_type(pipe_start + header_size),
+                        instru->get_entry_size(pipe_start + header_size)));
                     pipe_start = atomic_pipe_write(drcontext, pipe_start, pipe_end,
                                                    get_local_window(data));
                 }
@@ -755,13 +765,15 @@ output_buffer(void *drcontext, per_thread_t *data, byte *buf_base, byte *buf_ptr
         // branch forward to the next buffer.
         if ((buf_ptr - pipe_start) > ipc_pipe.get_atomic_write_size()) {
             DR_ASSERT(
-                is_ok_to_split_before(instru->get_entry_type(pipe_start + header_size)));
+                is_ok_to_split_before(instru->get_entry_type(pipe_start + header_size),
+                                      instru->get_entry_size(pipe_start + header_size)));
             pipe_start = atomic_pipe_write(drcontext, pipe_start, pipe_end,
                                            get_local_window(data));
         }
         if ((buf_ptr - pipe_start) > (ssize_t)buf_hdr_slots_size) {
             DR_ASSERT(
-                is_ok_to_split_before(instru->get_entry_type(pipe_start + header_size)));
+                is_ok_to_split_before(instru->get_entry_type(pipe_start + header_size),
+                                      instru->get_entry_size(pipe_start + header_size)));
             atomic_pipe_write(drcontext, pipe_start, buf_ptr, get_local_window(data));
         }
     } else {

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1354,7 +1354,7 @@ exit_thread_io(void *drcontext)
         // For attach we switch to BBDUP_MODE_NOP but still need to finalize
         // each thread.  However, we omit threads that did nothing the entire time
         // we were attached.
-        (align_attach_detach_endpoints() &&
+        (!has_tracing_windows() && align_attach_detach_endpoints() &&
          (data->bytes_written > 0 ||
           BUF_PTR(data->seg_base) - data->buf_base >
               static_cast<ssize_t>(data->init_header_size + buf_hdr_slots_size)))) {

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1243,7 +1243,7 @@ init_thread_io(void *drcontext)
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
     byte *proc_info;
 
-    NOTIFY(1, "T" TIDFMT " in init_thread_io.\n", dr_get_thread_id(drcontext));
+    NOTIFY(2, "T" TIDFMT " in init_thread_io.\n", dr_get_thread_id(drcontext));
 #ifdef HAS_ZLIB
     if (op_offline.get_value() &&
         (op_raw_compress.get_value() == "zlib" ||

--- a/clients/drcachesim/tracer/output.h
+++ b/clients/drcachesim/tracer/output.h
@@ -70,7 +70,8 @@ inline bool
 is_new_window_buffer_empty(per_thread_t *data)
 {
     // Since it's non-initial we do not add init_header_size.
-    return BUF_PTR(data->seg_base) == data->buf_base + buf_hdr_slots_size &&
+    return has_tracing_windows() &&
+        BUF_PTR(data->seg_base) == data->buf_base + buf_hdr_slots_size &&
         data->cur_window_instr_count == 0;
 }
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1927,22 +1927,19 @@ raw2trace_t::should_omit_syscall(raw2trace_thread_data_t *tdata)
     //    syscall is handled.
     // In both cases, we want to just remove the syscall instr: so we remove
     // if we find no subsequent marker either immediately following or after
-    // a buffer header of timestamp+cpuid.
+    // potentially multiple timestamp+cpuid markers.
     // (For the window case there are alternatives where we try to emit
     // the marker by passing info to the pre-syscall event handler or by moving
     // the marker to the block instrumentation but these all incur more complexity
     // than this relatively simple solution.)
     const offline_entry_t *in_entry = get_next_entry(tdata);
     std::vector<offline_entry_t> saved;
-    if (in_entry->timestamp.type == OFFLINE_TYPE_TIMESTAMP) {
+    while (in_entry->timestamp.type == OFFLINE_TYPE_TIMESTAMP ||
+           (in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
+            in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER &&
+            in_entry->extended.valueB == TRACE_MARKER_TYPE_CPU_ID)) {
         saved.push_back(*in_entry);
         in_entry = get_next_entry(tdata);
-        if (in_entry->extended.type == OFFLINE_TYPE_EXTENDED &&
-            in_entry->extended.ext == OFFLINE_EXT_TYPE_MARKER &&
-            in_entry->extended.valueB == TRACE_MARKER_TYPE_CPU_ID) {
-            saved.push_back(*in_entry);
-            in_entry = get_next_entry(tdata);
-        }
     }
     bool omit = false;
     if (in_entry->extended.type != OFFLINE_TYPE_EXTENDED ||

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3117,23 +3117,14 @@ raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
                     tdata->last_cpu_ = static_cast<uint>(it->addr);
                     // Avoid identical entries, which are common with the end of the
                     // previous buffer's timestamp followed by the start of the next.
-                    if (tdata->sched.empty() ||
-                        (tdata->sched.back().thread !=
-                             static_cast<uint64_t>(tdata->tid) ||
-                         tdata->sched.back().timestamp != tdata->last_timestamp_ ||
-                         tdata->sched.back().cpu != tdata->last_cpu_ ||
-                         tdata->sched.back().start_instruction != instr_count)) {
+                    schedule_entry_t new_entry(tdata->tid, tdata->last_timestamp_,
+                                               tdata->last_cpu_, instr_count);
+                    if (tdata->sched.empty() || tdata->sched.back() != new_entry) {
                         tdata->sched.emplace_back(tdata->tid, tdata->last_timestamp_,
                                                   tdata->last_cpu_, instr_count);
                     }
                     if (tdata->cpu2sched[it->addr].empty() ||
-                        (tdata->cpu2sched[it->addr].back().thread !=
-                             static_cast<uint64_t>(tdata->tid) ||
-                         tdata->cpu2sched[it->addr].back().timestamp !=
-                             tdata->last_timestamp_ ||
-                         tdata->cpu2sched[it->addr].back().cpu != tdata->last_cpu_ ||
-                         tdata->cpu2sched[it->addr].back().start_instruction !=
-                             instr_count)) {
+                        tdata->cpu2sched[it->addr].back() != new_entry) {
                         tdata->cpu2sched[it->addr].emplace_back(
                             tdata->tid, tdata->last_timestamp_, tdata->last_cpu_,
                             instr_count);


### PR DESCRIPTION
Adds a timestamp+cpuid pair at the end of normal buffers, to help separate trace output i/o time.

Adds a timestamp+cpuid pair before and after each application syscall. It appears around the syscall marker.  The trace buffer is no longer output pre-syscall (this addresses #3113) except for i-filtered traces or small-window traces where we need a frequent trace size check.

Adds a timestamp+cpuid pair when a kernel transfer event occurs.  The trace buffer is no longer output here.

Fixes the existing behavior where the post-syscall-buffer's timestamp contains the pre-syscall time.

Bumps the trace version for this change as the contents of post-syscall timestamps are now different.

Augments the documentation around timestamps and adds a missing entry on syscall markers.

Adds some invariant checks, and improve existing syscall marker checks.  Further checks are more difficult as the post-syscall time is not present when there is no post-syscall event, such as with exit or sigreturn.  Did some manual testing with the view tool.

Applies several auxiliary changes required to get all modes to work with these additional timestamps:
+ Removes the timestamp+cpuid from the split-pipe header, as that timestamp is delayed by i/o and results in misleading out-of-order timestamps.
+ Prevents pipe-splitting before a cpuid, to avoid a confusing sequence.
+ Fixes a bug where a syscall marker is missing when the prior block wrote out its buffer (#6291).
+ Fixes #6245 by re-instating the footer for non-split window files and removing the template `.*` from PR #6165 which was hiding the warning (this one could possibly be split into its own PR).
+ Adjusts the PC discontinuity relaxation for online unfetched instrs (#4915) to check the size now that there's no timestamp.

Issue: #4915
Fixes #6289
Fixes #3113
Fixes #6291 
Fixes #6245