### PR TITLE
i#6294: Handle consecutive window-final branches

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -2332,6 +2332,86 @@ test_branch_decoration(void *drcontext)
             check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
             check_entry(entries, idx, TRACE_TYPE_FOOTER, -1);
     }
+    {
+        // Window-final two consecutive branches.
+        instrlist_t *ilist = instrlist_create(drcontext);
+        instr_t *nop1 = XINST_CREATE_nop(drcontext); // Avoid offset of 0.
+        instr_t *nop2 = XINST_CREATE_nop(drcontext);
+        instr_t *store = XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(REG2, 0),
+                                            opnd_create_reg(REG1));
+        instr_t *jcc =
+            XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ, opnd_create_instr(store));
+        instr_t *move =
+            XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
+        instr_t *jcc2 =
+            XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ, opnd_create_instr(move));
+        instrlist_append(ilist, nop1);
+        instrlist_append(ilist, move);
+        instrlist_append(ilist, jcc);
+        instrlist_append(ilist, jcc2);
+        instrlist_append(ilist, nop2);
+        instrlist_append(ilist, store);
+        size_t offs_nop1 = 0;
+        size_t offs_mov = offs_nop1 + instr_length(drcontext, nop1);
+        size_t offs_jcc = offs_mov + instr_length(drcontext, move);
+        size_t offs_jcc2 = offs_jcc + instr_length(drcontext, jcc);
+        size_t offs_nop2 = offs_jcc2 + instr_length(drcontext, jcc2);
+        size_t offs_store = offs_nop2 + instr_length(drcontext, nop2);
+
+        std::vector<offline_entry_t> raw;
+        raw.push_back(make_header());
+        raw.push_back(make_tid());
+        raw.push_back(make_pid());
+        raw.push_back(make_line_size());
+        raw.push_back(make_block(offs_mov, 2));
+        raw.push_back(make_block(offs_jcc2, 1));
+        // Test two consecutive branches at the end of a window.
+        raw.push_back(make_window_id(1));
+        // Now repeat both branches to test encodings.
+        raw.push_back(make_block(offs_mov, 2));
+        raw.push_back(make_block(offs_jcc2, 1));
+        raw.push_back(make_block(offs_store, 1));
+        raw.push_back(make_exit());
+
+        std::vector<trace_entry_t> entries;
+        if (!run_raw2trace(drcontext, raw, ilist, entries))
+            return false;
+        int idx = 0;
+        res = res && check_entry(entries, idx, TRACE_TYPE_HEADER, -1) &&
+            check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
+            check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_FILETYPE) &&
+            check_entry(entries, idx, TRACE_TYPE_THREAD, -1) &&
+            check_entry(entries, idx, TRACE_TYPE_PID, -1) &&
+            check_entry(entries, idx, TRACE_TYPE_MARKER,
+                        TRACE_MARKER_TYPE_CACHE_LINE_SIZE) &&
+            check_entry(entries, idx, TRACE_TYPE_MARKER,
+                        TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT) &&
+            check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+            check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_mov) &&
+            // The first branch should remain and be marked untaken.
+            check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+            // An extra encoding entry is needed.
+            check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+            check_entry(entries, idx, TRACE_TYPE_INSTR_UNTAKEN_JUMP, -1, offs_jcc) &&
+            // The second branch and its encoding should be removed.
+            check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_WINDOW_ID) &&
+            check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_mov) &&
+            // The first branch needs no encoding here.
+            check_entry(entries, idx, TRACE_TYPE_INSTR_UNTAKEN_JUMP, -1, offs_jcc) &&
+            // The second branch does need an encoding.
+            check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+            // An extra encoding entry is needed.
+            check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+            check_entry(entries, idx, TRACE_TYPE_INSTR_UNTAKEN_JUMP, -1, offs_jcc2) &&
+            check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+            check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+            check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
+            check_entry(entries, idx, TRACE_TYPE_FOOTER, -1);
+    }
     return res;
 }
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2715,8 +2715,59 @@ raw2trace_t::append_delayed_branch(raw2trace_thread_data_t *tdata, app_pc next_p
                 ++instr_count;
         }
         int instr_index = instr_count - 1;
-        // Walk backward so we have the next pc for stacked branches.
         app_pc next_instr_pc = next_pc;
+        if (next_instr_pc == nullptr) {
+            // We don't have the PC after the final branch so we may have to remove it.
+            for (int i = static_cast<int>(tdata->delayed_branch.size()) - 1; i >= 0;
+                 --i) {
+                auto &entry = tdata->delayed_branch[i];
+                if (type_is_instr(static_cast<trace_type_t>(entry.type))) {
+                    DEBUG_ASSERT(
+                        type_is_instr_branch(static_cast<trace_type_t>(entry.type)));
+                    if (tdata->delayed_branch_target_pcs.size() <=
+                        static_cast<size_t>(instr_index)) {
+                        tdata->error = "Delayed branch target vector mis-sized";
+                        return false;
+                    }
+                    app_pc target = tdata->delayed_branch_target_pcs[instr_index];
+                    next_instr_pc = reinterpret_cast<app_pc>(entry.addr);
+                    if (target == nullptr ||
+                        entry.type == TRACE_TYPE_INSTR_CONDITIONAL_JUMP) {
+                        // This is a trace-final or window-final indirect or conditional
+                        // branch but we do not have its taken/target without a subsequent
+                        // instr: just delete it.
+                        DEBUG_ASSERT(instr_index == instr_count - 1);
+                        if (i > 0 &&
+                            tdata->delayed_branch[i - 1].type == TRACE_TYPE_ENCODING) {
+                            log(4, "Erasing cached encoding for %p\n",
+                                tdata->delayed_branch_decode_pcs[instr_index]);
+                            tdata->encoding_emitted.erase(
+                                tdata->delayed_branch_decode_pcs[instr_index]);
+                        }
+                        int erase_from = i;
+                        while (erase_from > 0 &&
+                               tdata->delayed_branch[erase_from - 1].type ==
+                                   TRACE_TYPE_ENCODING) {
+                            --erase_from;
+                        }
+                        VPRINT(
+                            4,
+                            "Discarded %zd entries for final branch without subsequent "
+                            "instr\n",
+                            tdata->delayed_branch.size() - erase_from);
+                        tdata->delayed_branch.erase(tdata->delayed_branch.begin() +
+                                                        erase_from,
+                                                    tdata->delayed_branch.end());
+                        tdata->delayed_branch_decode_pcs.pop_back();
+                        tdata->delayed_branch_target_pcs.pop_back();
+                        --instr_count;
+                        --instr_index;
+                    }
+                    break;
+                }
+            }
+        }
+        // Walk backward so we have the next pc for stacked branches.
         for (int i = static_cast<int>(tdata->delayed_branch.size()) - 1; i >= 0; --i) {
             auto &entry = tdata->delayed_branch[i];
             if (type_is_instr(static_cast<trace_type_t>(entry.type))) {
@@ -2730,68 +2781,38 @@ raw2trace_t::append_delayed_branch(raw2trace_thread_data_t *tdata, app_pc next_p
                 // Cache entry fields before we insert any markers at entry's position.
                 app_pc branch_addr = reinterpret_cast<app_pc>(entry.addr);
                 trace_type_t branch_type = static_cast<trace_type_t>(entry.type);
-                if (next_instr_pc == nullptr &&
-                    (target == nullptr ||
-                     entry.type == TRACE_TYPE_INSTR_CONDITIONAL_JUMP)) {
-                    // This is a trace-final or window-final branch but we do not have
-                    // its taken/target without a subsequent instr: just delete it.
-                    DEBUG_ASSERT(instr_index == instr_count - 1);
-                    if (i > 0 &&
-                        tdata->delayed_branch[i - 1].type == TRACE_TYPE_ENCODING) {
-                        log(4, "Erasing cached encoding for %p\n",
-                            tdata->delayed_branch_decode_pcs[instr_index]);
-                        tdata->encoding_emitted.erase(
-                            tdata->delayed_branch_decode_pcs[instr_index]);
+                DEBUG_ASSERT(next_instr_pc != nullptr ||
+                             (target != nullptr &&
+                              entry.type != TRACE_TYPE_INSTR_CONDITIONAL_JUMP));
+                if (target == nullptr) {
+                    DEBUG_ASSERT(!type_is_instr_direct_branch(
+                        static_cast<trace_type_t>(entry.type)));
+                    trace_entry_t local[3];
+                    int size = trace_metadata_writer_t::write_marker(
+                        reinterpret_cast<byte *>(local), TRACE_MARKER_TYPE_BRANCH_TARGET,
+                        reinterpret_cast<uintptr_t>(next_instr_pc));
+                    DEBUG_ASSERT(static_cast<size_t>(size) <= sizeof(local));
+                    for (int local_idx = 0;
+                         local_idx < size / static_cast<int>(sizeof(local[0]));
+                         ++local_idx) {
+                        tdata->delayed_branch.insert(tdata->delayed_branch.begin() + i,
+                                                     local[local_idx]);
                     }
-                    int erase_from = i;
-                    while (erase_from > 0 &&
-                           tdata->delayed_branch[erase_from - 1].type ==
-                               TRACE_TYPE_ENCODING) {
-                        --erase_from;
+                    VPRINT(4, "Inserted indirect branch target %p\n", next_instr_pc);
+                } else if (entry.type == TRACE_TYPE_INSTR_CONDITIONAL_JUMP) {
+                    if (target == next_instr_pc) {
+                        branch_type = TRACE_TYPE_INSTR_TAKEN_JUMP;
+                    } else {
+                        branch_type = TRACE_TYPE_INSTR_UNTAKEN_JUMP;
                     }
-                    VPRINT(4,
-                           "Discarded %zd entries for final branch without subsequent "
-                           "instr\n",
-                           tdata->delayed_branch.size() - erase_from);
-                    tdata->delayed_branch.erase(tdata->delayed_branch.begin() +
-                                                    erase_from,
-                                                tdata->delayed_branch.end());
-                    tdata->delayed_branch_decode_pcs.pop_back();
-                    tdata->delayed_branch_target_pcs.pop_back();
-                    --instr_count;
-                } else {
-                    if (target == nullptr) {
-                        DEBUG_ASSERT(!type_is_instr_direct_branch(
-                            static_cast<trace_type_t>(entry.type)));
-                        trace_entry_t local[3];
-                        int size = trace_metadata_writer_t::write_marker(
-                            reinterpret_cast<byte *>(local),
-                            TRACE_MARKER_TYPE_BRANCH_TARGET,
-                            reinterpret_cast<uintptr_t>(next_instr_pc));
-                        DEBUG_ASSERT(static_cast<size_t>(size) <= sizeof(local));
-                        for (int local_idx = 0;
-                             local_idx < size / static_cast<int>(sizeof(local[0]));
-                             ++local_idx) {
-                            tdata->delayed_branch.insert(
-                                tdata->delayed_branch.begin() + i, local[local_idx]);
-                        }
-                        VPRINT(4, "Inserted indirect branch target %p\n", next_instr_pc);
-                    } else if (entry.type == TRACE_TYPE_INSTR_CONDITIONAL_JUMP) {
-                        if (target == next_instr_pc) {
-                            branch_type = TRACE_TYPE_INSTR_TAKEN_JUMP;
-                        } else {
-                            branch_type = TRACE_TYPE_INSTR_UNTAKEN_JUMP;
-                        }
-                        entry.type = static_cast<unsigned short>(branch_type);
-                    }
-                    VPRINT(
-                        4,
-                        "Appending delayed branch type=%d pc=%p decode=%p target=%p for "
-                        "thread %d\n",
-                        branch_type, branch_addr,
-                        tdata->delayed_branch_decode_pcs[instr_index], target,
-                        tdata->index);
+                    entry.type = static_cast<unsigned short>(branch_type);
                 }
+                VPRINT(4,
+                       "Appending delayed branch type=%d pc=%p decode=%p target=%p for "
+                       "thread %d\n",
+                       branch_type, branch_addr,
+                       tdata->delayed_branch_decode_pcs[instr_index], target,
+                       tdata->index);
                 next_instr_pc = branch_addr;
                 --instr_index;
             } else {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2737,13 +2737,17 @@ raw2trace_t::append_delayed_branch(raw2trace_thread_data_t *tdata, app_pc next_p
                     // its taken/target without a subsequent instr: just delete it.
                     DEBUG_ASSERT(instr_index == instr_count - 1);
                     int erase_from = i;
+                    bool cleared_encoding_emitted = false;
                     while (erase_from > 0 &&
                            tdata->delayed_branch[erase_from - 1].type ==
                                TRACE_TYPE_ENCODING) {
-                        log(4, "Erasing cached encoding for %p\n",
-                            tdata->delayed_branch_decode_pcs[instr_index]);
-                        tdata->encoding_emitted.erase(
-                            tdata->delayed_branch_decode_pcs[instr_index]);
+                        if (!cleared_encoding_emitted) {
+                            log(4, "Erasing cached encoding for %p\n",
+                                tdata->delayed_branch_decode_pcs[instr_index]);
+                            tdata->encoding_emitted.erase(
+                                tdata->delayed_branch_decode_pcs[instr_index]);
+                            cleared_encoding_emitted = true;
+                        }
                         --erase_from;
                     }
                     VPRINT(4,
@@ -2755,7 +2759,12 @@ raw2trace_t::append_delayed_branch(raw2trace_thread_data_t *tdata, app_pc next_p
                                                 tdata->delayed_branch.end());
                     tdata->delayed_branch_decode_pcs.pop_back();
                     tdata->delayed_branch_target_pcs.pop_back();
-                    break;
+                    // Start the iteration over.
+                    --instr_count;
+                    instr_index = instr_count - 1;
+                    next_instr_pc = branch_addr;
+                    i = static_cast<int>(tdata->delayed_branch.size());
+                    continue;
                 } else {
                     if (target == nullptr) {
                         DEBUG_ASSERT(!type_is_instr_direct_branch(


### PR DESCRIPTION
Adds a test case for consecutive window-final branches which reproduces a problem where the final is removed but the penultimate is then not marked taken/untaken.

Updates raw2trace to correctly mark the penultimate.  Also confirmed this fix on the drcacheoff.windows-invar test on aarch64 where it was first observed.

Fixes #6294