### PR TITLE
AArch64: Remove unused function get_fcache_return_tls_offs

### DIFF
--- a/core/arch/aarch64/emit_utils.c
+++ b/core/arch/aarch64/emit_utils.c
@@ -133,18 +133,6 @@ nop_pad_ilist(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist, bool emit
     return 0;
 }
 
-size_t
-get_fcache_return_tls_offs(dcontext_t *dcontext, uint flags)
-{
-    /* AArch64 always uses shared gencode so we ignore FRAG_DB_SHARED(flags) */
-    if (TEST(FRAG_COARSE_GRAIN, flags)) {
-        /* FIXME i#1575: coarse-grain NYI on AArch64 */
-        ASSERT_NOT_IMPLEMENTED(false);
-        return 0;
-    }
-    return TLS_FCACHE_RETURN_SLOT;
-}
-
 /* Generate move (immediate) of a 64-bit value using at most 4 instructions.
  * pc must be a writable (vmcode) pc.
  */

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1576,9 +1576,6 @@ get_direct_exit_target(dcontext_t *dcontext, uint flags);
 
 #ifdef AARCHXX
 size_t
-get_fcache_return_tls_offs(dcontext_t *dcontext, uint flags);
-
-size_t
 get_ibl_entry_tls_offs(dcontext_t *dcontext, cache_pc ibl_entry);
 #endif
 

--- a/core/arch/arm/emit_utils.c
+++ b/core/arch/arm/emit_utils.c
@@ -190,7 +190,7 @@ nop_pad_ilist(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist, bool emit
     return 0;
 }
 
-size_t
+static size_t
 get_fcache_return_tls_offs(dcontext_t *dcontext, uint flags)
 {
     /* ARM always uses shared gencode so we ignore FRAG_DB_SHARED(flags) */


### PR DESCRIPTION
The internal API `get_fcache_return_tls_offs()` was never used in Aarch64 and this patch removes it. Also changed the function signature in ARM to be static.