### PR TITLE
i#5036 A64 scatter/gather, part 2: Expand scalar+vector stores

### DIFF
--- a/clients/drcachesim/tests/scattergather-aarch64.templatex
+++ b/clients/drcachesim/tests/scattergather-aarch64.templatex
@@ -58,29 +58,68 @@ ld1d 32bit unpacked unscaled offset sxtw: PASS
 ld1d 64bit scaled offset: PASS
 ld1d 64bit unscaled offset: PASS
 ld1d 64bit unscaled offset Zt==Zm: PASS
+st1b 32bit unpacked unscaled offset uxtw: PASS
+st1b 32bit unpacked unscaled offset sxtw: PASS
+st1b 32bit unscaled offset uxtw: PASS
+st1b 32bit unscaled offset sxtw: PASS
+st1b 32bit unscaled offset sxtw \(repeated offset\): PASS
+st1b 64bit unscaled offset: PASS
+st1b 64bit unscaled offset \(repeated offset\): PASS
+st1h 32bit scaled offset uxtw: PASS
+st1h 32bit scaled offset sxtw: PASS
+st1h 32bit unpacked scaled offset uxtw: PASS
+st1h 32bit unpacked scaled offset sxtw: PASS
+st1h 32bit unpacked unscaled offset uxtw: PASS
+st1h 32bit unpacked unscaled offset sxtw: PASS
+st1h 32bit unscaled offset uxtw: PASS
+st1h 32bit unscaled offset sxtw: PASS
+st1h 32bit unscaled offset sxtw: PASS
+st1h 32bit unscaled offset sxtw \(repeated offset\): PASS
+st1h 64bit scaled offset: PASS
+st1h 64bit unscaled offset: PASS
+st1h 64bit unscaled offset \(repeated offset\): PASS
+st1w 32bit scaled offset uxtw: PASS
+st1w 32bit scaled offset sxtw: PASS
+st1w 32bit unpacked scaled offset uxtw: PASS
+st1w 32bit unpacked scaled offset sxtw: PASS
+st1w 32bit unpacked unscaled offset uxtw: PASS
+st1w 32bit unpacked unscaled offset sxtw: PASS
+st1w 32bit unscaled offset uxtw: PASS
+st1w 32bit unscaled offset sxtw: PASS
+st1w 32bit unscaled offset sxtw \(repeated offset\): PASS
+st1w 64bit scaled offset: PASS
+st1w 64bit unscaled offset: PASS
+st1w 64bit unscaled offset \(repeated offset\): PASS
+st1d 32bit unpacked scaled offset uxtw: PASS
+st1d 32bit unpacked scaled offset sxtw: PASS
+st1d 32bit unpacked unscaled offset uxtw: PASS
+st1d 32bit unpacked unscaled offset sxtw: PASS
+st1d 64bit scaled offset: PASS
+st1d 64bit unscaled offset: PASS
+st1d 64bit unscaled offset \(repeated offset\): PASS
 #endif /* __ARM_FEATURE_SVE */
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-     .* total \(fetched\) instructions
-     .* total unique \(fetched\) instructions
-     .* total non-fetched instructions
-     .* total prefetches
-     .* total data loads
-     .* total data stores
-     .* total icache flushes
-     .* total dcache flushes
+.* total \(fetched\) instructions
+.* total unique \(fetched\) instructions
+.* total non-fetched instructions
+.* total prefetches
+.* total data loads
+.* total data stores
+.* total icache flushes
+.* total dcache flushes
            1 total threads
-     .* total scheduling markers
+.* total scheduling markers
 .*
 Thread .* counts:
-     .* \(fetched\) instructions
-     .* unique \(fetched\) instructions
-     .* non-fetched instructions
-     .* prefetches
-     .* data loads
-     .* data stores
-     .* icache flushes
-     .* dcache flushes
-     .* scheduling markers
+.* \(fetched\) instructions
+.* unique \(fetched\) instructions
+.* non-fetched instructions
+.* prefetches
+.* data loads
+.* data stores
+.* icache flushes
+.* dcache flushes
+.* scheduling markers
 .*

--- a/suite/tests/client-interface/drx-scattergather-aarch64.cpp
+++ b/suite/tests/client-interface/drx-scattergather-aarch64.cpp
@@ -1902,8 +1902,5 @@ main(int argc, char **argv)
         status = FAIL;
 #endif
 
-    switch (status) {
-    case PASS: return 0;
-    case FAIL: return 1;
-    }
+    return status == PASS ? 0 : 1;
 }

--- a/suite/tests/client-interface/drx-scattergather-aarch64.cpp
+++ b/suite/tests/client-interface/drx-scattergather-aarch64.cpp
@@ -476,6 +476,8 @@ public:
         : data(mmap(nullptr, DATA_SIZE, PROT_READ | PROT_WRITE,
                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0))
     {
+        // TODO i#5036: Support page sizes > 4KiB
+        assert(sysconf(_SC_PAGE_SIZE) == 4096);
         reset();
     }
 

--- a/suite/tests/client-interface/drx-scattergather-aarch64.cpp
+++ b/suite/tests/client-interface/drx-scattergather-aarch64.cpp
@@ -646,7 +646,7 @@ public:
         : test_memory_t()
     {
         /*
-         * We set up nine pages of memory to use as input data for load instruction
+         * We set up nine pages of memory to write output data for store instruction
          * tests. The first page contains input data of different sizes and the rest
          * of the pages are set up to fault when they are accessed. The tests use
          * one of the first 4 regions as their base pointer, so when we want to

--- a/suite/tests/client-interface/drx-scattergather-aarch64.cpp
+++ b/suite/tests/client-interface/drx-scattergather-aarch64.cpp
@@ -469,7 +469,9 @@ run_tests(std::vector<TEST_CASE_T> tests)
 
 class test_memory_t {
 public:
-    const size_t DATA_SIZE = 9 * 4096; // 9 4KiB pages
+    static const size_t DATA_SIZE = 9 * 4096; // 9 4KiB pages
+    static const size_t REGION_SIZE = 1024;
+
     test_memory_t()
         : data(mmap(nullptr, DATA_SIZE, PROT_READ | PROT_WRITE,
                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0))
@@ -500,13 +502,13 @@ public:
     const void *
     region_start_addr(size_t offset) const
     {
-        return &static_cast<char *>(data)[1024 * offset];
+        return &static_cast<char *>(data)[REGION_SIZE * offset];
     }
 
     void *
     region_start_addr(size_t offset)
     {
-        return &static_cast<char *>(data)[1024 * offset];
+        return &static_cast<char *>(data)[REGION_SIZE * offset];
     }
 
 protected:
@@ -634,7 +636,7 @@ private:
         case element_size_t::DOUBLE: offset = 3; break;
         }
         // The base address is set to the 8th element in the region.
-        return (1024 * offset) + (static_cast<size_t>(element_size) * 8);
+        return (REGION_SIZE * offset) + (static_cast<size_t>(element_size) * 8);
     }
 };
 

--- a/suite/tests/client-interface/drx-scattergather-aarch64.templatex
+++ b/suite/tests/client-interface/drx-scattergather-aarch64.templatex
@@ -58,10 +58,49 @@ ld1d 32bit unpacked unscaled offset sxtw: PASS
 ld1d 64bit scaled offset: PASS
 ld1d 64bit unscaled offset: PASS
 ld1d 64bit unscaled offset Zt==Zm: PASS
+st1b 32bit unpacked unscaled offset uxtw: PASS
+st1b 32bit unpacked unscaled offset sxtw: PASS
+st1b 32bit unscaled offset uxtw: PASS
+st1b 32bit unscaled offset sxtw: PASS
+st1b 32bit unscaled offset sxtw \(repeated offset\): PASS
+st1b 64bit unscaled offset: PASS
+st1b 64bit unscaled offset \(repeated offset\): PASS
+st1h 32bit scaled offset uxtw: PASS
+st1h 32bit scaled offset sxtw: PASS
+st1h 32bit unpacked scaled offset uxtw: PASS
+st1h 32bit unpacked scaled offset sxtw: PASS
+st1h 32bit unpacked unscaled offset uxtw: PASS
+st1h 32bit unpacked unscaled offset sxtw: PASS
+st1h 32bit unscaled offset uxtw: PASS
+st1h 32bit unscaled offset sxtw: PASS
+st1h 32bit unscaled offset sxtw: PASS
+st1h 32bit unscaled offset sxtw \(repeated offset\): PASS
+st1h 64bit scaled offset: PASS
+st1h 64bit unscaled offset: PASS
+st1h 64bit unscaled offset \(repeated offset\): PASS
+st1w 32bit scaled offset uxtw: PASS
+st1w 32bit scaled offset sxtw: PASS
+st1w 32bit unpacked scaled offset uxtw: PASS
+st1w 32bit unpacked scaled offset sxtw: PASS
+st1w 32bit unpacked unscaled offset uxtw: PASS
+st1w 32bit unpacked unscaled offset sxtw: PASS
+st1w 32bit unscaled offset uxtw: PASS
+st1w 32bit unscaled offset sxtw: PASS
+st1w 32bit unscaled offset sxtw \(repeated offset\): PASS
+st1w 64bit scaled offset: PASS
+st1w 64bit unscaled offset: PASS
+st1w 64bit unscaled offset \(repeated offset\): PASS
+st1d 32bit unpacked scaled offset uxtw: PASS
+st1d 32bit unpacked scaled offset sxtw: PASS
+st1d 32bit unpacked unscaled offset uxtw: PASS
+st1d 32bit unpacked unscaled offset sxtw: PASS
+st1d 64bit scaled offset: PASS
+st1d 64bit unscaled offset: PASS
+st1d 64bit unscaled offset \(repeated offset\): PASS
 #endif /* __ARM_FEATURE_SVE */
 #ifndef TEST_SAMPLE_CLIENT
 #ifdef __ARM_FEATURE_SVE
-event_exit, 428 scatter/gather instructions
+event_exit, 752 scatter/gather instructions
 #else
 event_exit, 0 scatter/gather instructions
 #endif /* __ARM_FEATURE_SVE */


### PR DESCRIPTION
Adds support to drx_expand_scatter_gather() for SVE scalar+vector scatter store instructions, along with tests.

Issue: #5036