### PR TITLE
i#3544 RV64 XINST_CREATE: Implement platform-independent macros

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -721,17 +721,20 @@ if (BUILD_TESTS)
            ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
   set_tests_properties(tool.drcachesim.unit_tests PROPERTIES TIMEOUT ${test_seconds})
 
-  add_executable(tool.drcacheoff.raw2trace_unit_tests tests/raw2trace_unit_tests.cpp)
-  configure_DynamoRIO_standalone(tool.drcacheoff.raw2trace_unit_tests)
-  add_win32_flags(tool.drcacheoff.raw2trace_unit_tests)
-  target_link_libraries(tool.drcacheoff.raw2trace_unit_tests drmemtrace_raw2trace
-    test_helpers)
-  use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drdecode)
-  use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drcovlib_static)
-  add_test(NAME tool.drcacheoff.raw2trace_unit_tests
-    COMMAND tool.drcacheoff.raw2trace_unit_tests)
-  set_tests_properties(tool.drcacheoff.raw2trace_unit_tests PROPERTIES TIMEOUT
-    ${test_seconds})
+  # FIXME i#3544 Make raw2trace_unit_tests compilable in RISCV64.
+  if (NOT RISCV64)
+    add_executable(tool.drcacheoff.raw2trace_unit_tests tests/raw2trace_unit_tests.cpp)
+    configure_DynamoRIO_standalone(tool.drcacheoff.raw2trace_unit_tests)
+    add_win32_flags(tool.drcacheoff.raw2trace_unit_tests)
+    target_link_libraries(tool.drcacheoff.raw2trace_unit_tests drmemtrace_raw2trace
+      test_helpers)
+    use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drdecode)
+    use_DynamoRIO_extension(tool.drcacheoff.raw2trace_unit_tests drcovlib_static)
+    add_test(NAME tool.drcacheoff.raw2trace_unit_tests
+      COMMAND tool.drcacheoff.raw2trace_unit_tests)
+    set_tests_properties(tool.drcacheoff.raw2trace_unit_tests PROPERTIES TIMEOUT
+      ${test_seconds})
+  endif ()
 
   add_executable(tool.scheduler.unit_tests tests/scheduler_unit_tests.cpp)
   target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer test_helpers)

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -1900,15 +1900,21 @@ append_jmp_to_fcache_target(dcontext_t *dcontext, instrlist_t *ilist,
     } else {
         if (shared) {
             /* next_tag placed into tls slot earlier in this routine */
-#ifdef AARCH64
             /* Load next_tag from FCACHE_ENTER_TARGET_SLOT, stored by
              * append_setup_fcache_target.
              */
+#ifdef AARCH64
             APP(ilist,
                 instr_create_restore_from_tls(dcontext, DR_REG_X0,
                                               FCACHE_ENTER_TARGET_SLOT));
             /* br x0 */
             APP(ilist, INSTR_CREATE_br(dcontext, opnd_create_reg(DR_REG_X0)));
+#elif defined(RISCV64)
+            APP(ilist,
+                instr_create_restore_from_tls(dcontext, DR_REG_A0,
+                                              FCACHE_ENTER_TARGET_SLOT));
+            /* jr a0 */
+            APP(ilist, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(DR_REG_A0)));
 #else
             APP(ilist,
                 XINST_CREATE_jump_mem(dcontext,
@@ -3199,8 +3205,8 @@ append_ibl_found(dcontext_t *dcontext, instrlist_t *ilist, ibl_code_t *ibl_code,
         /* FIXME: do we want this?  seems to be a problem, I'm disabling:
          * ASSERT(!collision || start_pc_offset == FRAGMENT_START_PC_OFFS)
          */
-#ifdef AARCH64
-        ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+#if defined(AARCH64) || defined(RISCV64)
+        ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 i#3544 */
 #else
         APP(ilist,
             XINST_CREATE_jump_mem(dcontext,
@@ -3244,8 +3250,8 @@ append_ibl_found(dcontext_t *dcontext, instrlist_t *ilist, ibl_code_t *ibl_code,
 #endif
                 APP(ilist,
                     RESTORE_FROM_TLS(dcontext, SCRATCH_REG2, MANGLE_XCX_SPILL_SLOT));
-#ifdef AARCH64
-            ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+#if defined(AARCH64) || defined(RISCV64)
+            ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 i#3544 */
 #else
             APP(ilist,
                 XINST_CREATE_jump_mem(dcontext,

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -4776,8 +4776,8 @@ build_native_exec_bb(dcontext_t *dcontext, build_bb_t *bb)
                                                           SCRATCH_REG0_OFFS));
     insert_shared_restore_dcontext_reg(dcontext, bb->ilist, NULL);
 
-#ifdef AARCH64
-    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+#if defined(AARCH64) || defined(RISCV64)
+    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 i#3544 */
 #else
     /* this is the jump to native code */
     instrlist_append(bb->ilist,

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -3662,8 +3662,8 @@ instr_create_save_immed_to_dc_via_reg(dcontext_t *dcontext, reg_id_t basereg, in
 instr_t *
 instr_create_jump_via_dcontext(dcontext_t *dcontext, int offs)
 {
-#    ifdef AARCH64
-    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 */
+#    if defined(AARCH64) || defined(RISCV64)
+    ASSERT_NOT_IMPLEMENTED(false); /* FIXME i#1569 i#3544 */
     return 0;
 #    else
     opnd_t memopnd = opnd_create_dcontext_field(dcontext, offs);

--- a/core/ir/riscv64/instr_create_api.h.in
+++ b/core/ir/riscv64/instr_create_api.h.in
@@ -39,15 +39,12 @@
 /** @name Platform-independent macros */
 /** @{ */ /* doxygen start group */
 
-/* FIXME i#3544: Check and implement all INSTR_CREATE_ and XINST_CREATE_ macros. For now
- * all unimplemented instructions use OP_c_nop which is effectively a no-op. */
-
 /**
  * This platform-independent macro creates an instr_t for a debug trap
  * instruction, automatically supplying any implicit operands.
  * \param dc The void * dcontext used to allocate memory for the instr_t.
  */
-#define XINST_CREATE_debug_instr(dc) instr_create_0dst_0src(dc, OP_c_nop)
+#define XINST_CREATE_debug_instr(dc) INSTR_CREATE_ebreak(dc)
 
 /**
  * This platform-independent macro creates an instr_t for a 4-byte
@@ -56,7 +53,9 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load(dc, r, m)                            \
+    ((opnd_get_size(m) == OPSZ_4) ? INSTR_CREATE_lwu(dc, r, m) \
+                                  : INSTR_CREATE_ld(dc, r, m))
 
 /**
  * This platform-independent macro creates an instr_t which loads 1 byte
@@ -66,7 +65,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_1byte_zext4(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load_1byte_zext4(dc, r, m) INSTR_CREATE_lbu(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 1-byte
@@ -75,7 +74,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_1byte(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load_1byte(dc, r, m) INSTR_CREATE_lbu(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 2-byte
@@ -84,7 +83,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_2bytes(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load_2bytes(dc, r, m) INSTR_CREATE_lhu(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a 4-byte
@@ -93,7 +92,8 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store(dc, m, r) instr_create_1dst_1src(dc, OP_c_nop, m, r)
+#define XINST_CREATE_store(dc, m, r) \
+    ((opnd_get_size(m) == OPSZ_4) ? INSTR_CREATE_sw(dc, m, r) : INSTR_CREATE_sd(dc, m, r))
 
 /**
  * This platform-independent macro creates an instr_t for a 1-byte
@@ -102,7 +102,7 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store_1byte(dc, m, r) instr_create_1dst_1src(dc, OP_c_nop, m, r)
+#define XINST_CREATE_store_1byte(dc, m, r) INSTR_CREATE_sb(dc, m, r)
 
 /**
  * This platform-independent macro creates an instr_t for a 2-byte
@@ -111,7 +111,7 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store_2bytes(dc, m, r) instr_create_1dst_1src(dc, OP_c_nop, m, r)
+#define XINST_CREATE_store_2bytes(dc, m, r) INSTR_CREATE_sh(dc, m, r)
 
 /**
  * This platform-independent macro creates an instr_t for a register
@@ -120,8 +120,10 @@
  * \param d   The destination register opnd.
  * \param s   The source register opnd.
  */
-#define XINST_CREATE_move(dc, d, s) instr_create_1dst_1src(dc, OP_c_nop, d, s)
-
+#define XINST_CREATE_move(dc, d, s) \
+    INSTR_CREATE_addi(              \
+        dc, d, s,                   \
+        opnd_add_flags(opnd_create_immed_int(0, OPSZ_12b), DR_OPND_IMM_PRINT_DECIMAL))
 /**
  * This platform-independent macro creates an instr_t for a multimedia
  * register load instruction.
@@ -129,7 +131,7 @@
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
  */
-#define XINST_CREATE_load_simd(dc, r, m) instr_create_1dst_1src(dc, OP_c_nop, r, m)
+#define XINST_CREATE_load_simd(dc, r, m) XINST_CREATE_load(dc, r, m)
 
 /**
  * This platform-independent macro creates an instr_t for a multimedia
@@ -138,17 +140,7 @@
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
  */
-#define XINST_CREATE_store_simd(dc, m, r) instr_create_1dst_1src(dc, OP_c_nop, m, r)
-
-/**
- * This platform-independent macro creates an instr_t for an indirect
- * jump through memory instruction.  For AArch32, the memory address
- * must be aligned to 4.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param m   The memory opnd holding the target.
- */
-#define XINST_CREATE_jump_mem(dc, m) \
-    instr_create_0dst_2src(dc, OP_c_nop, opnd_create_reg(DR_REG_PC), (m))
+#define XINST_CREATE_store_simd(dc, m, r) XINST_CREATE_store(dc, m, r)
 
 /**
  * This platform-independent macro creates an instr_t for an indirect
@@ -156,7 +148,9 @@
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param r   The register opnd holding the target.
  */
-#define XINST_CREATE_jump_reg(dc, r) instr_create_0dst_1src(dc, OP_c_nop, r)
+#define XINST_CREATE_jump_reg(dc, r)                       \
+    INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_ZERO), r, \
+                      opnd_create_immed_int(0, OPSZ_12b))
 
 /**
  * This platform-independent macro creates an instr_t for an immediate
@@ -165,13 +159,16 @@
  * \param r   The destination register opnd.
  * \param i   The source immediate integer opnd.
  */
-#define XINST_CREATE_load_int(dc, r, i) instr_create_1dst_1src(dc, OP_c_nop, r, i)
+#define XINST_CREATE_load_int(dc, r, i) \
+    INSTR_CREATE_addi(dc, r, opnd_create_reg(DR_REG_ZERO), i)
 
 /**
  * This platform-independent macro creates an instr_t for a return instruction.
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  */
-#define XINST_CREATE_return(dc) instr_create_0dst_0src(dc, OP_c_nop)
+#define XINST_CREATE_return(dc)                                                     \
+    INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_ZERO), opnd_create_reg(DR_REG_RA), \
+                      opnd_create_immed_int(0, OPSZ_12b))
 
 /**
  * This platform-independent macro creates an instr_t for an unconditional
@@ -183,7 +180,7 @@
  * the target (a pc operand is not suitable for most uses unless you know
  * precisely where this instruction will be encoded).
  */
-#define XINST_CREATE_jump(dc, t) instr_create_0dst_1src(dc, OP_c_nop, t)
+#define XINST_CREATE_jump(dc, t) INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_ZERO), t)
 
 /**
  * This platform-independent macro creates an instr_t for an unconditional
@@ -195,7 +192,8 @@
  * the target (a pc operand is not suitable for most uses unless you know
  * precisely where this instruction will be encoded).
  */
-#define XINST_CREATE_jump_short(dc, t) instr_create_0dst_1src(dc, OP_c_nop, t)
+#define XINST_CREATE_jump_short(dc, t) \
+    INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_ZERO), t)
 
 /**
  * This platform-independent macro creates an instr_t for an unconditional
@@ -207,22 +205,7 @@
  * the target (a pc operand is not suitable for most uses unless you know
  * precisely where this instruction will be encoded).
  */
-#define XINST_CREATE_call(dc, t) instr_create_0dst_1src(dc, OP_c_nop, t)
-
-/**
- * This platform-independent macro creates an instr_t for a conditional
- * branch instruction that branches if the previously-set condition codes
- * indicate the condition indicated by \p pred.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param pred  The #dr_pred_type_t condition to match.
- * \param t   The opnd_t target operand for the instruction, which can be
- * either a pc (opnd_create_pc)()) or an instr_t (opnd_create_instr()).
- * Be sure to ensure that the limited reach of this short branch will reach
- * the target (a pc operand is not suitable for most uses unless you know
- * precisely where this instruction will be encoded).
- */
-#define XINST_CREATE_jump_cond(dc, pred, t) \
-    (INSTR_PRED(instr_create_0dst_1src(dc, OP_c_nop, t), (pred)))
+#define XINST_CREATE_call(dc, t) INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_RA), t)
 
 /**
  * This platform-independent macro creates an instr_t for an addition
@@ -231,7 +214,8 @@
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s  The opnd_t explicit source operand for the instruction.
  */
-#define XINST_CREATE_add(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
+#define XINST_CREATE_add(dc, d, s) \
+    opnd_is_reg(s) ? INSTR_CREATE_add(dc, d, d, s) : INSTR_CREATE_addi(dc, d, d, s)
 
 /**
  * This platform-independent macro creates an instr_t for an addition
@@ -245,33 +229,7 @@
  * can be either a register or an immediate integer.
  */
 #define XINST_CREATE_add_2src(dc, d, s1, s2) \
-    instr_create_1dst_2src(dc, OP_c_nop, d, s1, s2)
-
-/**
- * This platform-independent macro creates an instr_t for an addition
- * instruction that does not affect the status flags and takes two register sources
- * plus a destination, with one source being shifted logically left by
- * an immediate amount that is limited to either 0, 1, 2, or 3.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param d  The opnd_t explicit destination operand for the instruction.
- * \param s1  The opnd_t explicit first source operand for the instruction.  This
- * must be a register.
- * \param s2_toshift  The opnd_t explicit source operand for the instruction.  This
- * must be a register.
- * \param shift_amount  An integer value that must be either 0, 1, 2, or 3.
- */
-#define XINST_CREATE_add_sll(dc, d, s1, s2_toshift, shift_amount) \
-    instr_create_1dst_3src(dc, OP_c_nop, d, s1, s2_toshift,        \
-                           opnd_create_immed_int(shift_amount, OPSZ_1))
-
-/**
- * This platform-independent macro creates an instr_t for an addition
- * instruction that does affect the status flags.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param d  The opnd_t explicit destination operand for the instruction.
- * \param s  The opnd_t explicit source operand for the instruction.
- */
-#define XINST_CREATE_add_s(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
+    opnd_is_reg(s2) ? INSTR_CREATE_add(dc, d, s1, s2) : INSTR_CREATE_addi(dc, d, s1, s2)
 
 /**
  * This platform-independent macro creates an instr_t for a subtraction
@@ -280,38 +238,11 @@
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s  The opnd_t explicit source operand for the instruction.
  */
-/* FIXME: How to handle a lack of flags register? */
-#define XINST_CREATE_sub(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
-
-/**
- * This platform-independent macro creates an instr_t for a subtraction
- * instruction that does affect the status flags.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param d  The opnd_t explicit destination operand for the instruction.
- * \param s  The opnd_t explicit source operand for the instruction.
- */
-/* FIXME: How to handle a lack of flags register? */
-#define XINST_CREATE_sub_s(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
-
-/**
- * This platform-independent macro creates an instr_t for a bitwise and
- * instruction that does affect the status flags.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param d  The opnd_t explicit destination operand for the instruction.
- * \param s  The opnd_t explicit source operand for the instruction.
- */
-/* FIXME: How to handle a lack of flags register? */
-#define XINST_CREATE_and_s(dc, d, s) instr_create_1dst_2src(dc, OP_c_nop, d, d, s)
-
-/**
- * This platform-independent macro creates an instr_t for a comparison
- * instruction.
- * \param dc  The void * dcontext used to allocate memory for the instr_t.
- * \param s1  The opnd_t explicit source operand for the instruction.
- * \param s2  The opnd_t explicit source operand for the instruction.
- */
-/* FIXME: How to handle a lack of flags register? */
-#define XINST_CREATE_cmp(dc, s1, s2) instr_create_0dst_2src(dc, OP_c_nop, s1, s2)
+#define XINST_CREATE_sub(dc, d, s)      \
+    opnd_is_reg(s)                      \
+        ? INSTR_CREATE_sub(dc, d, d, s) \
+        : INSTR_CREATE_addi(dc, d, d,   \
+                            opnd_create_immed_int(-opnd_get_immed_int(s), OPSZ_12b))
 
 /**
  * This platform-independent macro creates an instr_t for a software
@@ -319,17 +250,7 @@
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param i   The source integer constant opnd_t operand.
  */
-#define XINST_CREATE_interrupt(dc, i) instr_create_0dst_1src(dc, OP_c_nop, i)
-
-/**
- * This platform-independent macro creates an instr_t for a logical right shift
- * instruction that does affect the status flags.
- * \param dc         The void * dcontext used to allocate memory for the instr_t.
- * \param d          The opnd_t explicit destination operand for the instruction.
- * \param rm_or_imm  The opnd_t explicit source operand for the instruction.
- */
-#define XINST_CREATE_slr_s(dc, d, rm_or_imm) \
-    instr_create_1dst_1src(dc, OP_c_nop, d, rm_or_imm)
+#define XINST_CREATE_interrupt(dc, i) INSTR_CREATE_ebreak(dc)
 
 /**
  * This platform-independent macro creates an instr_t for a nop instruction.
@@ -344,7 +265,9 @@
  * \param r   The opnd_t explicit source operand for the instruction. This should
  * be a reg_id_t operand with the address of the subroutine.
  */
-#define XINST_CREATE_call_reg(dc, r) instr_create_0dst_1src(dc, OP_c_nop, r)
+#define XINST_CREATE_call_reg(dc, r)                     \
+    INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_RA), r, \
+                      opnd_create_immed_int(0, OPSZ_12b))
 
 /**
  * Create an absolute address operand encoded as pc-relative.
@@ -368,7 +291,9 @@
  * \param dc The void * dcontext used to allocate memory for the instr_t.
  */
 /* Auto-generated by codec.py. */
+// clang-format off
 @INSTR_MACROS@
+// clang-format on
 /** @} */ /* end doxygen group */
 
 #endif /* _DR_IR_MACROS_RISCV64_H_ */

--- a/core/ir/riscv64/instr_create_api.h.in
+++ b/core/ir/riscv64/instr_create_api.h.in
@@ -130,6 +130,9 @@
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param r   The destination register opnd.
  * \param m   The source memory opnd.
+ *
+ * FIXME i#3544: Serve as a placeholder for now. Add a proper implementation once it makes
+ * sense.
  */
 #define XINST_CREATE_load_simd(dc, r, m) XINST_CREATE_load(dc, r, m)
 
@@ -139,6 +142,9 @@
  * \param dc  The void * dcontext used to allocate memory for the instr_t.
  * \param m   The destination memory opnd.
  * \param r   The source register opnd.
+ *
+ * FIXME i#3544: Serve as a placeholder for now. Add a proper implementation once it makes
+ * sense.
  */
 #define XINST_CREATE_store_simd(dc, m, r) XINST_CREATE_store(dc, m, r)
 
@@ -214,8 +220,7 @@
  * \param d  The opnd_t explicit destination operand for the instruction.
  * \param s  The opnd_t explicit source operand for the instruction.
  */
-#define XINST_CREATE_add(dc, d, s) \
-    opnd_is_reg(s) ? INSTR_CREATE_add(dc, d, d, s) : INSTR_CREATE_addi(dc, d, d, s)
+#define XINST_CREATE_add(dc, d, s) XINST_CREATE_add_2src(dc, d, d, s)
 
 /**
  * This platform-independent macro creates an instr_t for an addition

--- a/ext/drbbdup/drbbdup.c
+++ b/ext/drbbdup/drbbdup.c
@@ -1388,9 +1388,13 @@ drbbdup_insert_dynamic_handling(void *drcontext, void *tag, instrlist_t *bb,
             instrlist_insert_mov_immed_ptrsz(drcontext, (ptr_int_t)tag, drbbdup_opnd, bb,
                                              where, NULL, NULL);
 
+#ifdef RISCV64
+            ASSERT(false, "NYI on RISCV64"); /* FIXME i#3544 */
+#else
             /* Jump if hit reaches zero. */
             instr = XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ,
                                            opnd_create_pc(new_case_cache_pc));
+#endif
             instrlist_meta_preinsert(bb, where, instr);
 
         } else {

--- a/suite/tests/api/ir_riscv64.c
+++ b/suite/tests/api/ir_riscv64.c
@@ -1120,6 +1120,9 @@ test_jump_and_branch(void *dc)
     /* This is expected to fail since we are using an unaligned PC (i.e. target_pc -
      * instr_encode_pc has non-zero lower 12 bits). */
     test_instr_encoding_failure(dc, OP_auipc, pc + 4, instr);
+
+    /* Not printing disassembly for jal and branch instructions below, see comment of
+     * test_instr_encoding_jal_or_branch(). */
     instr = INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_A0), opnd_create_pc(pc));
     test_instr_encoding_jal_or_branch(dc, OP_jal, instr);
     instr = INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_A0), opnd_create_reg(DR_REG_A1),
@@ -1506,6 +1509,8 @@ test_xinst(void *dc)
            opnd_get_immed_int(instr_get_src(instr, 1)) == 0);
     test_instr_encoding(dc, OP_jalr, instr);
 
+    /* Not printing disassembly for jal and branch instructions below, see comment of
+     * test_instr_encoding_jal_or_branch(). */
     instr = XINST_CREATE_jump(dc, opnd_create_pc(pc));
     ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&
            opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_ZERO);

--- a/suite/tests/api/ir_riscv64.expect
+++ b/suite/tests/api/ir_riscv64.expect
@@ -221,7 +221,7 @@ c.xor  a5 -> fp
 c.sub  a5 -> fp
 test_integer_arith complete
 lui    0x2a -> a0
-<Internal Error: Failed to encode instruction: 'auipc  0x0000004000016234 -> a0'>
+<Internal Error: Failed to encode instruction: 'auipc  0x000000400001723c -> a0'>
 jalr   a1 0x2a -> a0
 c.li   31 -> a1
 c.lui  1 -> a1
@@ -301,4 +301,24 @@ cbo.clean (a1)
 cbo.flush (a1)
 cbo.inval (a1)
 test_misc complete
+lwu    (a1)[4byte] -> a0
+ld     (a1)[8byte] -> a0
+lbu    (a1)[1byte] -> a0
+lbu    (a1)[1byte] -> a0
+lhu    (a1)[2byte] -> a0
+sw     a0 -> (a1)[4byte]
+sd     a0 -> (a1)[8byte]
+sb     a0 -> (a1)[1byte]
+sh     a0 -> (a1)[2byte]
+addi   a1 0 -> a0
+jalr   a0 0x0 -> zero
+addi   zero 0x2a -> a0
+jalr   ra 0x0 -> zero
+add    a0 a1 -> a0
+addi   a0 0x2a -> a0
+add    a1 a2 -> a0
+sub    a0 a1 -> a0
+addi   a0 0xffffffd6 -> a0
+jalr   a0 0x0 -> ra
+test_xinst complete
 All tests complete


### PR DESCRIPTION
Implement platform-independent `XINST_CREATE_xxx` macros, also remove APIs that do not make sense for RISC-V.