### PR TITLE
i#5843 scheduler: Add unread_last_record()

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -258,6 +258,9 @@ typedef enum {
      */
     TRACE_TYPE_INSTR_UNTAKEN_JUMP,
 
+    /** An invalid record, meant for use as a sentinel value. */
+    TRACE_TYPE_INVALID,
+
     // Update trace_type_names[] when adding here.
 } trace_type_t;
 

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -549,6 +549,18 @@ public:
         next_record(RecordType &record, uint64_t cur_time);
 
         /**
+         * Queues the last-read record returned by next_record() such that it will be
+         * returned on the subsequent call to next_record() when this same input is
+         * active.  May not be called multiple times in a row without an intervening
+         * next_record() call.  This will cause ordinal queries on the current input to be
+         * off by one until the record is re-read.  Furthermore, the get_last_timestamp()
+         * query may still include this record, whether called on the input or output
+         * stream, immediately after this call.
+         */
+        virtual stream_status_t
+        unread_last_record();
+
+        /**
          * Begins a diversion from the regular inputs to a side stream of records
          * representing speculative execution starting at 'start_address'.
          *
@@ -556,7 +568,9 @@ public:
          * before knowing whether a simulator is on the wrong path or not, this routine
          * supports putting back the current record so that it will be re-provided as
          * the first record after (the outermost) stop_speculation(), if
-         * "queue_current_record" is true.
+         * "queue_current_record" is true.  An alternative way to accomplish this
+         * is to call unread_last_record().  The same caveats on the input stream
+         * ordinals and last timestamp apply to the queued record here.
          *
          * This call can be nested; each call needs to be paired with a corresponding
          * stop_speculation() call.
@@ -962,9 +976,10 @@ protected:
         output_info_t(scheduler_tmpl_t<RecordType, ReaderType> *scheduler,
                       output_ordinal_t ordinal,
                       typename spec_type_t::speculator_flags_t speculator_flags,
-                      int verbosity = 0)
+                      RecordType last_record_init, int verbosity = 0)
             : stream(scheduler, ordinal, verbosity)
             , speculator(speculator_flags, verbosity)
+            , last_record(last_record_init)
         {
         }
         stream_t stream;
@@ -984,7 +999,7 @@ protected:
         // while this field holds the instruction's start PC.  The use case is for
         // queueing a read-ahead instruction record for start_speculation().
         addr_t prev_speculate_pc = 0;
-        RecordType last_record;
+        RecordType last_record; // Set to TRACE_TYPE_INVALID in constructor.
         // A list of schedule segments.  These are accessed only while holding
         // sched_lock_.
         std::vector<schedule_record_t> record;
@@ -1032,6 +1047,10 @@ protected:
     stream_status_t
     next_record(output_ordinal_t output, RecordType &record, input_info_t *&input,
                 uint64_t cur_time = 0);
+
+    // Undoes the last read.  May only be called once between next_record() calls.
+    stream_status_t
+    unread_last_record(output_ordinal_t output, RecordType &record, input_info_t *&input);
 
     // Skips ahead to the next region of interest if necessary.
     // The caller must hold the input.lock.
@@ -1105,6 +1124,9 @@ protected:
     bool
     record_type_is_timestamp(RecordType record, uintptr_t &value);
 
+    bool
+    record_type_is_invalid(RecordType record);
+
     // Creates the marker we insert between regions of interest.
     RecordType
     create_region_separator_marker(memref_tid_t tid, uintptr_t value);
@@ -1112,6 +1134,9 @@ protected:
     // Creates a thread exit record.
     RecordType
     create_thread_exit(memref_tid_t tid);
+
+    RecordType
+    create_invalid_record();
 
     // Used for diagnostics: prints record fields to stderr.
     void

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1881,6 +1881,8 @@ test_speculation()
             // We realize now that we mispredicted that the branch would be taken.
             // We ask to queue this record for post-speculation.
             stream->start_speculation(100, true);
+            // Ensure unread_last_record() fails during speculation.
+            assert(stream->unread_last_record() == scheduler_t::STATUS_INVALID);
             break;
         case 5:
             // We should now see nops from the speculator.
@@ -1924,6 +1926,8 @@ test_speculation()
             assert(memref.instr.addr == 200);
             // Test a nested start_speculation().
             stream->start_speculation(300, false);
+            // Ensure unread_last_record() fails during nested speculation.
+            assert(stream->unread_last_record() == scheduler_t::STATUS_INVALID);
             break;
         case 11:
             assert(type_is_instr(memref.instr.type));
@@ -2794,6 +2798,8 @@ test_inactive()
         assert(status == scheduler_t::STATUS_OK);
         assert(stream0->get_record_ordinal() == ref_ord - 1);
         assert(stream0->get_instruction_ordinal() == instr_ord - 1);
+        // Speculation with queuing right after unread should fail.
+        assert(stream0->start_speculation(300, true) == scheduler_t::STATUS_INVALID);
         check_next(stream0, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_INSTR);
         assert(stream0->get_record_ordinal() == ref_ord);
         assert(stream0->get_instruction_ordinal() == instr_ord);


### PR DESCRIPTION
Adds a new scheduler output stream interface unread_last_record(). This queues the just-read record for reading later.  This is meant to aid simulators reading one record ahead to the next instruction, but not yet processing it.  The new interface is limited in that it can only be called once at a time and while the output ordinals are fixed up other metrics like the output last timestamp and the input ordinals are not.

Adds a new record type TRACE_TYPE_INVALID for use as a sentinel.

Adds some sanity tests.

Issue: #5843