### PR TITLE
i#6298 Use invariant_checker for drcachesim scattergather test

### DIFF
--- a/clients/drcachesim/tests/scattergather-aarch64.templatex
+++ b/clients/drcachesim/tests/scattergather-aarch64.templatex
@@ -99,27 +99,4 @@ st1d 64bit unscaled offset: PASS
 st1d 64bit unscaled offset \(repeated offset\): PASS
 #endif /* __ARM_FEATURE_SVE */
 ---- <application exited with code 0> ----
-Basic counts tool results:
-Total counts:
-.* total \(fetched\) instructions
-.* total unique \(fetched\) instructions
-.* total non-fetched instructions
-.* total prefetches
-.* total data loads
-.* total data stores
-.* total icache flushes
-.* total dcache flushes
-           1 total threads
-.* total scheduling markers
-.*
-Thread .* counts:
-.* \(fetched\) instructions
-.* unique \(fetched\) instructions
-.* non-fetched instructions
-.* prefetches
-.* data loads
-.* data stores
-.* icache flushes
-.* dcache flushes
-.* scheduling markers
-.*
+Trace invariant checks passed

--- a/clients/drcachesim/tests/scattergather-x86.templatex
+++ b/clients/drcachesim/tests/scattergather-x86.templatex
@@ -145,27 +145,4 @@ Test restoring the AVX2 gather scratch xmm register upon a fault
 #endif
 AVX2/AVX-512 scatter/gather checks ok
 ---- <application exited with code 0> ----
-Basic counts tool results:
-Total counts:
-     .* total \(fetched\) instructions
-     .* total unique \(fetched\) instructions
-     .* total non-fetched instructions
-     .* total prefetches
-     .* total data loads
-     .* total data stores
-     .* total icache flushes
-     .* total dcache flushes
-           1 total threads
-     .* total scheduling markers
-.*
-Thread .* counts:
-     .* \(fetched\) instructions
-     .* unique \(fetched\) instructions
-     .* non-fetched instructions
-     .* prefetches
-     .* data loads
-     .* data stores
-     .* icache flushes
-     .* dcache flushes
-     .* scheduling markers
-.*
+Trace invariant checks passed

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3709,7 +3709,7 @@ if (BUILD_CLIENTS)
 
     if ((NOT MACOS) AND (X86 OR AARCH64))
         torunonly_drcachesim(scattergather-${ARCH_NAME} client.drx-scattergather
-        "-simulator_type basic_counts" "")
+        "-simulator_type invariant_checker" "")
       unset(tool.drcachesim.scattergather-${ARCH_NAME}_rawtemp) # use preprocessor
       if (proc_supports_avx512)
         set(tool.drcachesim.scattergather-${ARCH_NAME}_runavx512 1)


### PR DESCRIPTION
This should reduce the churn in the test output template files compared to basic_counts which it used before.

Issues: #6298, #5036