### PR TITLE
i#3544 RV64: Fix AUIPC uimm sign-extension issue

### DIFF
--- a/core/ir/riscv64/codec.c
+++ b/core/ir/riscv64/codec.c
@@ -485,7 +485,7 @@ static bool
 decode_u_immpc_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *orig_pc,
                     int idx, instr_t *out)
 {
-    uint uimm = GET_FIELD(inst, 31, 12);
+    int32_t uimm = GET_FIELD(inst, 31, 12);
     opnd_t opnd = opnd_create_pc(orig_pc + (uimm << 12));
     instr_set_src(out, idx, opnd);
     return true;

--- a/suite/tests/api/ir_riscv64.c
+++ b/suite/tests/api/ir_riscv64.c
@@ -1111,8 +1111,15 @@ test_jump_and_branch(void *dc)
     instr = INSTR_CREATE_lui(dc, opnd_create_reg(DR_REG_A0),
                              opnd_create_immed_int(42, OPSZ_20b));
     pc = test_instr_encoding(dc, OP_lui, instr);
+
+    /* Not printing disassembly for jal and branch instructions below, see comment of
+     * test_instr_encoding_jal_or_branch(). */
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
                                opnd_create_pc(pc + (3 << 12)));
+    test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
+
+    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
+                               opnd_create_pc(pc - (3 << 12)));
     test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
 
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
@@ -1121,8 +1128,6 @@ test_jump_and_branch(void *dc)
      * instr_encode_pc has non-zero lower 12 bits). */
     test_instr_encoding_failure(dc, OP_auipc, pc + 4, instr);
 
-    /* Not printing disassembly for jal and branch instructions below, see comment of
-     * test_instr_encoding_jal_or_branch(). */
     instr = INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_A0), opnd_create_pc(pc));
     test_instr_encoding_jal_or_branch(dc, OP_jal, instr);
     instr = INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_A0), opnd_create_reg(DR_REG_A1),


### PR DESCRIPTION
The "u" in uimm means U-type, not unsigned, the immediate is a signed integer. This patch fixes this issue and adds a test case for it.