### PR TITLE
i#3544 RV64: Implement instr_* functions

### DIFF
--- a/core/fragment.h
+++ b/core/fragment.h
@@ -222,11 +222,14 @@ frag_flags_from_isa_mode(dr_isa_mode_t mode)
 }
 
 /* to save space size field is a ushort => maximum fragment size */
-#ifndef AARCH64
-enum { MAX_FRAGMENT_SIZE = USHRT_MAX };
-#else
+#ifdef AARCH64
 /* On AArch64, TBNZ/TBZ has a range of +/- 32 KiB. */
 enum { MAX_FRAGMENT_SIZE = 0x8000 };
+#elif defined(RISCV64)
+/* On RISCV64, direct branch has a range of +/- 4 KiB. */
+enum { MAX_FRAGMENT_SIZE = 0x1000 };
+#else
+enum { MAX_FRAGMENT_SIZE = USHRT_MAX };
 #endif
 
 /* fragment structure used for basic blocks and traces

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1930,7 +1930,7 @@ enum {
     FAR_PC_kind,    /* a segment is specified as a selector value */
     FAR_INSTR_kind, /* a segment is specified as a selector value */
 #    if defined(X64) || defined(ARM)
-    REL_ADDR_kind, /* pc-relative address: ARM or 64-bit X86 only */
+    REL_ADDR_kind, /* pc-relative address: ARM/RISCV64/64-bit X86 only */
 #    endif
 #    ifdef X64
     ABS_ADDR_kind, /* 64-bit absolute address: x64 only */

--- a/core/ir/riscv64/codec.c
+++ b/core/ir/riscv64/codec.c
@@ -486,7 +486,7 @@ decode_u_immpc_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *or
                     int idx, instr_t *out)
 {
     int32_t uimm = GET_FIELD(inst, 31, 12);
-    opnd_t opnd = opnd_create_pc(orig_pc + (uimm << 12));
+    opnd_t opnd = opnd_create_rel_addr(orig_pc + (uimm << 12), OPSZ_0);
     instr_set_src(out, idx, opnd);
     return true;
 }
@@ -1937,8 +1937,8 @@ encode_u_immpc_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out, decode_inf
 {
     opnd_t opnd = instr_get_src(instr, idx);
     uint32_t imm;
-    if (opnd.kind == PC_kind)
-        imm = opnd_get_pc(opnd) - pc;
+    if (opnd.kind == REL_ADDR_kind)
+        imm = (app_pc)opnd_get_addr(opnd) - pc;
     else if (opnd.kind == INSTR_kind)
         imm = (byte *)opnd_get_instr(opnd)->offset - (byte *)instr->offset;
     else

--- a/core/ir/riscv64/codec.c
+++ b/core/ir/riscv64/codec.c
@@ -486,6 +486,8 @@ decode_u_immpc_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *or
                     int idx, instr_t *out)
 {
     int32_t uimm = GET_FIELD(inst, 31, 12);
+    /* OPSZ_0 is used here to indicate that this is not a real memory access instruction.
+     */
     opnd_t opnd = opnd_create_rel_addr(orig_pc + (uimm << 12), OPSZ_0);
     instr_set_src(out, idx, opnd);
     return true;

--- a/suite/tests/api/ir_riscv64.c
+++ b/suite/tests/api/ir_riscv64.c
@@ -1115,15 +1115,15 @@ test_jump_and_branch(void *dc)
     /* Not printing disassembly for jal and branch instructions below, see comment of
      * test_instr_encoding_jal_or_branch(). */
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
-                               opnd_create_pc(pc + (3 << 12)));
+                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
     test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
 
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
-                               opnd_create_pc(pc - (3 << 12)));
+                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
     test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
 
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
-                               opnd_create_pc(pc + (3 << 12)));
+                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
     /* This is expected to fail since we are using an unaligned PC (i.e. target_pc -
      * instr_encode_pc has non-zero lower 12 bits). */
     test_instr_encoding_failure(dc, OP_auipc, pc + 4, instr);

--- a/suite/tests/api/ir_riscv64.expect
+++ b/suite/tests/api/ir_riscv64.expect
@@ -221,7 +221,7 @@ c.xor  fp a5 -> fp
 c.sub  fp a5 -> fp
 test_integer_arith complete
 lui    0x2a -> a0
-<Internal Error: Failed to encode instruction: 'auipc  0x000000400001823c -> a0'>
+<Internal Error: Failed to encode instruction: 'auipc  <rel> 0x0000004000018244 -> a0'>
 jalr   a1 0x2a -> a0
 c.li   zero 31 -> a1
 c.lui  1 -> a1


### PR DESCRIPTION
This patch implements the necessary instr_* functions that are called when running simple programs. Also, the opnd type of `auipc` has been changed again to `REL_ADDR_kind`. This is essential for `opc_is_not_a_real_memory_load()` and `instr_has_rel_addr_reference()` to work correctly.

Issue: #3544