### PR TITLE
i#1569: Fix compilation errors with GCC11 and "-O3" option

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3893,7 +3893,7 @@ get_time()
 bool
 is_ibl_routine_type(dcontext_t *dcontext, cache_pc target, ibl_branch_type_t branch_type)
 {
-    ibl_type_t ibl_type;
+    ibl_type_t ibl_type = {0};
     DEBUG_DECLARE(bool is_ibl =)
     get_ibl_routine_type_ex(dcontext, target, &ibl_type _IF_X86_64(NULL));
     ASSERT(is_ibl);

--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3893,7 +3893,7 @@ get_time()
 bool
 is_ibl_routine_type(dcontext_t *dcontext, cache_pc target, ibl_branch_type_t branch_type)
 {
-    ibl_type_t ibl_type = {0};
+    ibl_type_t ibl_type = { 0 };
     DEBUG_DECLARE(bool is_ibl =)
     get_ibl_routine_type_ex(dcontext, target, &ibl_type _IF_X86_64(NULL));
     ASSERT(is_ibl);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -10503,7 +10503,7 @@ wait_for_event(event_t e, int timeout_ms)
 #ifdef DEBUG
     dcontext_t *dcontext = get_thread_private_dcontext();
 #endif
-    uint64 start_time, cur_time;
+    uint64 start_time = 0, cur_time = 0;
     if (timeout_ms > 0)
         start_time = query_time_millis();
     /* Use a user-space event on Linux, a kernel event on Windows. */


### PR DESCRIPTION
GCC11 has stricter requirements for uninitialised
variables in -O3 mode

Issue: #1569