### PR TITLE
Add existing dynamorio-based external tools for value profilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ DynamoRIO is the basis for some well-known external tools:
 - The [Arm Instruction Emulator (ArmIE)](https://developer.arm.com/tools-and-software/server-and-hpc/arm-architecture-tools/arm-instruction-emulator)
 - [WinAFL](https://github.com/googleprojectzero/winafl), the Windows fuzzing tool, as an instrumentation and code coverage engine
 - The fine-grained profiler for ARM [DrCCTProf](https://xl10.github.io/blog/drcctprof.html)
+- The portable and efficient framework for fine-grained value profilers [VClinic](https://github.com/VClinic/VClinic)
 
 Tools built on DynamoRIO and available in the [release package](https://dynamorio.org/page_download) include:
 

--- a/api/docs/home.dox
+++ b/api/docs/home.dox
@@ -62,6 +62,7 @@ DynamoRIO is the basis for some well-known external tools:
 - The [Arm Instruction Emulator (ArmIE)](https://developer.arm.com/tools-and-software/server-and-hpc/arm-architecture-tools/arm-instruction-emulator)
 - [WinAFL](https://github.com/googleprojectzero/winafl), the Windows fuzzing tool, as an instrumentation and code coverage engine
 - The fine-grained profiler for ARM [DrCCTProf](https://xl10.github.io/blog/drcctprof.html)
+- The portable and efficient framework for fine-grained value profilers [VClinic](https://github.com/VClinic/VClinic)
 
 Tools built on DynamoRIO and available in the [release package](@ref page_download) include:
 


### PR DESCRIPTION
We develop a portable and efficient framework [VClinic](https://github.com/VClinic/VClinic) for fine-grained value profilers built atop DynamoRIO. We wish to add a short line of intrudocution with corresponding external link into the README. 

In short, the highlights of VClinic built upon DynamoRIO are shown as follows:

- Decoupling implementation of value tracing and value profiling
- Implement trace buffer with lightweight inline assembly for efficient value tracing
- Support operand-centric view for development of fine-grained value profilers instead of instruction-centric view of DynamoRIO.
- Currently support both ARM and X86 platforms. In the future, it can support all DynamoRIO-supported architectures.

The detailed document of VClinic can be referred to [here](https://vclinic.readthedocs.io/en/latest/index.html) and the related technical [paper](https://dl.acm.org/doi/abs/10.1145/3575693.3576934)