### PR TITLE
i#6303: Avoid duplicate encoding entry on chunk-split branch pair

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -887,7 +887,7 @@ test_chunk_encodings(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         // Block 4.
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
-        check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_nop_start) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -905,10 +905,6 @@ test_chunk_encodings(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID) &&
         // There should be just one encoding, before the branch target (i#6303).
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
-#ifdef X86_32
-        // An extra encoding entry is needed.
-        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
-#endif
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1, offs_ret) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3088,7 +3088,6 @@ raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
                     tdata->error = "Failed to write to output file";
                     return false;
                 }
-                // NOCHECK
                 if (!insert_post_chunk_encodings(tdata, it,
                                                  *(decode_pcs + instr_ordinal)))
                     return false;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3078,31 +3078,43 @@ raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
             if (TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, tdata->file_type) &&
                 type_is_instr(static_cast<trace_type_t>(it->type)) &&
                 // We don't want encodings for the PC-only i-filtered entries.
-                it->size > 0 && !prev_was_encoding &&
-                record_encoding_emitted(tdata, *(decode_pcs + instr_ordinal))) {
-                // Write any data we were waiting until post-loop to write.
-                if (it > start &&
-                    !tdata->out_file->write(reinterpret_cast<const char *>(start),
-                                            reinterpret_cast<const char *>(it) -
-                                                reinterpret_cast<const char *>(start))) {
-                    tdata->error = "Failed to write to output file";
-                    return false;
+                it->size > 0) {
+                if (prev_was_encoding) {
+                    // We've already emitted the encoding(s) for this instr.  But if we
+                    // opened a new chunk then we've cleared the hashtable record, so
+                    // re-add it here.
+                    record_encoding_emitted(tdata, *(decode_pcs + instr_ordinal));
+                } else if
+                    // Check whether this instr's encoding has already been emitted
+                    // due to multiple instances of the same delayed branch (the encoding
+                    // cache was cleared in open_new_chunk()).
+                    (record_encoding_emitted(tdata, *(decode_pcs + instr_ordinal))) {
+                    // Write any data we were waiting until post-loop to write.
+                    if (it > start &&
+                        !tdata->out_file->write(
+                            reinterpret_cast<const char *>(start),
+                            reinterpret_cast<const char *>(it) -
+                                reinterpret_cast<const char *>(start))) {
+                        tdata->error = "Failed to write to output file";
+                        return false;
+                    }
+                    if (!insert_post_chunk_encodings(tdata, it,
+                                                     *(decode_pcs + instr_ordinal)))
+                        return false;
+                    if (!tdata->out_file->write(reinterpret_cast<const char *>(it),
+                                                sizeof(*it))) {
+                        tdata->error = "Failed to write to output file";
+                        return false;
+                    }
+                    start = it + 1;
                 }
-                if (!insert_post_chunk_encodings(tdata, it,
-                                                 *(decode_pcs + instr_ordinal)))
-                    return false;
-                if (!tdata->out_file->write(reinterpret_cast<const char *>(it),
-                                            sizeof(*it))) {
-                    tdata->error = "Failed to write to output file";
-                    return false;
-                }
-                start = it + 1;
             }
             if (it->type == TRACE_TYPE_ENCODING)
                 prev_was_encoding = true;
             else {
-                // Do not clear across an indirect branch target, to avoid
-                // a duplicate encoding on the other side.
+                // Do not clear across an indirect branch target, to avoid a duplicate
+                // encoding being emitted when the indirect branch instruction itself is
+                // reached.
                 if (it->type != TRACE_TYPE_MARKER ||
                     it->size != TRACE_MARKER_TYPE_BRANCH_TARGET)
                     prev_was_encoding = false;


### PR DESCRIPTION
Fixes a case where a branch followed by an indirect branch with a chunk split in the middle results in an extra encoding entry after the indirect branch target marker.  This extra entry is accumulated in the reader and results in a fatal error.

Adds a unit test.  Confirmed the fix on the
drcacheoff.invariant_checker test as well where it was failing reliably on one machine.

Fixes #6303