### PR TITLE
Fix docs build with drmemory

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -73,7 +73,7 @@ jobs:
         # We do shallow clones and assume DrM will update its DR at least once
         # every 250 DR commits.
         git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-        cd drmemory && git submodule update --init --depth 250 && cd ..
+        cd drmemory && git submodule update --init --recursive --depth 250 && cd ..
 
     # Install needed packages.
     - name: Create Build Environment


### PR DESCRIPTION
With drmemory now updated to the latest DR, it needs to initialize the minizip submodule when we build its docs inside DR's docs.

Tested via a ci-docs action run on this branch: https://github.com/DynamoRIO/dynamorio/actions/runs/6270125682