### PR TITLE
i#3544 RV64: Add handling of SYSCALL_METHOD_ECALL in mangle_syscall

### DIFF
--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -663,7 +663,8 @@ mangle_syscall(dcontext_t *dcontext, instrlist_t *ilist, uint flags, instr_t *in
     if (get_syscall_method() != SYSCALL_METHOD_INT &&
         get_syscall_method() != SYSCALL_METHOD_SYSCALL &&
         get_syscall_method() != SYSCALL_METHOD_SYSENTER &&
-        get_syscall_method() != SYSCALL_METHOD_SVC) {
+        get_syscall_method() != SYSCALL_METHOD_SVC &&
+        get_syscall_method() != SYSCALL_METHOD_ECALL) {
         /* don't know convention on return address from kernel mode! */
         SYSLOG_INTERNAL_ERROR("unsupported system call method");
         LOG(THREAD, LOG_INTERP, 1, "don't know convention for this syscall method\n");


### PR DESCRIPTION
Add missing handling of RISC-V system call method `SYSCALL_METHOD_ECALL` in `mangle_syscall()`.

Issue: #3544 