### PR TITLE
i#6238: deprecate dr_fp_type_t structure and migrate to dr_instr_category_t

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -149,7 +149,7 @@ Further non-compatibility-affecting changes include:
  - Added type_is_read() API that returns true if a trace type reads from memory.
  - Added instr_num_memory_read_access() and instr_num_memory_write_access() that return
    the number of memory read and write accesses of an instruction respectively.
- - Deprecated dr_fp_type_t for Floating-Point operation types amd migrate to 
+ - Deprecated dr_fp_type_t for Floating-Point operation types amd migrate to
    dr_instr_category_t.
    Deprecated instr_is_floating_ex(), replacing them with instr_is_floating_exten().
    The old versions will continue to work.

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -149,6 +149,10 @@ Further non-compatibility-affecting changes include:
  - Added type_is_read() API that returns true if a trace type reads from memory.
  - Added instr_num_memory_read_access() and instr_num_memory_write_access() that return
    the number of memory read and write accesses of an instruction respectively.
+ - Deprecated dr_fp_type_t for Floating-Point operation types amd migrate to 
+   dr_instr_category_t.
+   Deprecated instr_is_floating_ex(), replacing them with instr_is_floating_exten().
+   The old versions will continue to work.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -149,9 +149,9 @@ Further non-compatibility-affecting changes include:
  - Added type_is_read() API that returns true if a trace type reads from memory.
  - Added instr_num_memory_read_access() and instr_num_memory_write_access() that return
    the number of memory read and write accesses of an instruction respectively.
- - Deprecated #dr_fp_type_t for Floating-Point operation types amd migrate to
+ - Deprecated #dr_fp_type_t for Floating-Point operation types in favor of the new
    #dr_instr_category_t.
-   Deprecated instr_is_floating_ex(), replacing them with instr_is_floating_exten().
+   Deprecated instr_is_floating_ex(), replacing it with instr_is_floating_type().
    The old versions will continue to work.
 
 **************************************************

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -149,8 +149,8 @@ Further non-compatibility-affecting changes include:
  - Added type_is_read() API that returns true if a trace type reads from memory.
  - Added instr_num_memory_read_access() and instr_num_memory_write_access() that return
    the number of memory read and write accesses of an instruction respectively.
- - Deprecated dr_fp_type_t for Floating-Point operation types amd migrate to
-   dr_instr_category_t.
+ - Deprecated #dr_fp_type_t for Floating-Point operation types amd migrate to
+   #dr_instr_category_t.
    Deprecated instr_is_floating_ex(), replacing them with instr_is_floating_exten().
    The old versions will continue to work.
 

--- a/api/samples/stats.c
+++ b/api/samples/stats.c
@@ -311,7 +311,7 @@ event_analyze_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     for (instr = instrlist_first_app(bb); instr != NULL;
          instr = instr_get_next_app(instr)) {
         num_instrs++;
-        if (instr_is_floating_ex(instr, &fp_type) &&
+        if (instr_is_floating_exten(instr, &fp_type) &&
             /* We exclude loads and stores (and reg-reg moves) and state preservation */
             (DR_INSTR_CATEGORY_CONVERT && fp_type != 0 ||
              DR_INSTR_CATEGORY_MATH && fp_type != 0)) {

--- a/api/samples/stats.c
+++ b/api/samples/stats.c
@@ -313,8 +313,8 @@ event_analyze_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
         num_instrs++;
         if (instr_is_floating_ex(instr, &fp_type) &&
             /* We exclude loads and stores (and reg-reg moves) and state preservation */
-            (TEST(DR_INSTR_CATEGORY_CONVERT, fp_type) ||
-             TEST(DR_INSTR_CATEGORY_MATH, fp_type))) {
+            (DR_INSTR_CATEGORY_CONVERT && fp_type != 0 ||
+             DR_INSTR_CATEGORY_MATH && fp_type != 0)) {
 #ifdef VERBOSE
             dr_print_instr(drcontext, STDOUT, instr, "Found flop: ");
 #endif

--- a/api/samples/stats.c
+++ b/api/samples/stats.c
@@ -311,7 +311,7 @@ event_analyze_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     for (instr = instrlist_first_app(bb); instr != NULL;
          instr = instr_get_next_app(instr)) {
         num_instrs++;
-        if (instr_is_floating_exten(instr, &fp_type) &&
+        if (instr_is_floating_type(instr, &fp_type) &&
             /* We exclude loads and stores (and reg-reg moves) and state preservation */
             (DR_INSTR_CATEGORY_CONVERT && fp_type != 0 ||
              DR_INSTR_CATEGORY_MATH && fp_type != 0)) {

--- a/api/samples/stats.c
+++ b/api/samples/stats.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -306,14 +306,15 @@ event_analyze_bb(void *drcontext, void *tag, instrlist_t *bb, bool for_trace,
     uint num_instrs = 0;
     uint num_flops = 0;
     uint num_syscalls = 0;
-    dr_fp_type_t fp_type;
+    dr_instr_category_t fp_type;
 
     for (instr = instrlist_first_app(bb); instr != NULL;
          instr = instr_get_next_app(instr)) {
         num_instrs++;
         if (instr_is_floating_ex(instr, &fp_type) &&
             /* We exclude loads and stores (and reg-reg moves) and state preservation */
-            (fp_type == DR_FP_CONVERT || fp_type == DR_FP_MATH)) {
+            (TEST(DR_INSTR_CATEGORY_CONVERT, fp_type) ||
+             TEST(DR_INSTR_CATEGORY_MATH, fp_type))) {
 #ifdef VERBOSE
             dr_print_instr(drcontext, STDOUT, instr, "Found flop: ");
 #endif

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -2341,10 +2341,10 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         instr_t *prev;
         for (prev = instr_get_prev_expanded(dcontext, ilist, instr); prev != NULL;
              prev = instr_get_prev_expanded(dcontext, ilist, prev)) {
-            dr_fp_type_t type;
+            dr_instr_category_t type;
             if (instr_is_app(prev) && instr_is_floating_ex(prev, &type)) {
                 bool control_instr = false;
-                if (type == DR_FP_STATE /* quick check */ &&
+                if (TEST(DR_INSTR_CATEGORY_STATE, type) /* quick check */ &&
                     /* Check the list from Intel Vol 1 8.1.8 */
                     (op == OP_fnclex || op == OP_fldcw || op == OP_fnstcw ||
                      op == OP_fnstsw || op == OP_fnstenv || op == OP_fldenv ||

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -2342,7 +2342,7 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         for (prev = instr_get_prev_expanded(dcontext, ilist, instr); prev != NULL;
              prev = instr_get_prev_expanded(dcontext, ilist, prev)) {
             dr_instr_category_t type;
-            if (instr_is_app(prev) && instr_is_floating_ex(prev, &type)) {
+            if (instr_is_app(prev) && instr_is_floating_exten(prev, &type)) {
                 bool control_instr = false;
                 if (TEST(DR_INSTR_CATEGORY_STATE, type) /* quick check */ &&
                     /* Check the list from Intel Vol 1 8.1.8 */

--- a/core/arch/x86/mangle.c
+++ b/core/arch/x86/mangle.c
@@ -2342,7 +2342,7 @@ mangle_float_pc(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         for (prev = instr_get_prev_expanded(dcontext, ilist, instr); prev != NULL;
              prev = instr_get_prev_expanded(dcontext, ilist, prev)) {
             dr_instr_category_t type;
-            if (instr_is_app(prev) && instr_is_floating_exten(prev, &type)) {
+            if (instr_is_app(prev) && instr_is_floating_type(prev, &type)) {
                 bool control_instr = false;
                 if (TEST(DR_INSTR_CATEGORY_STATE, type) /* quick check */ &&
                     /* Check the list from Intel Vol 1 8.1.8 */

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -324,6 +324,33 @@ instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
 }
 
 bool
+instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
+{
+    /* DR_FP_STATE instructions aren't available on AArch64.
+     * Processor state is saved/restored with loads and stores.
+     */
+    uint cat = instr_get_category(instr);
+    if (!TEST(DR_INSTR_CATEGORY_FP, cat))
+        return false;
+    else if (TEST(DR_INSTR_CATEGORY_MATH, cat)) {
+        if (type != NULL)
+            *type = DR_FP_MATH;
+        return true;
+    } else if (TEST(DR_INSTR_CATEGORY_CONVERT, cat)) {
+        if (type != NULL)
+            *type = DR_FP_CONVERT;
+        return true;
+    } else if (TEST(DR_INSTR_CATEGORY_MOVE, cat)) {
+        if (type != NULL)
+            *type = DR_FP_MOVE;
+        return true;
+    } else {
+        CLIENT_ASSERT(false, "instr_is_floating_ex: FP instruction without subcategory");
+        return false;
+    }
+}
+
+bool
 instr_is_floating(instr_t *instr)
 {
     return instr_is_floating_ex(instr, NULL);

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -310,7 +310,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
+instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type OUT)
 {
     /* DR_FP_STATE instructions aren't available on AArch64.
      * Processor state is saved/restored with loads and stores.

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -310,7 +310,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
+instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
 {
     /* DR_FP_STATE instructions aren't available on AArch64.
      * Processor state is saved/restored with loads and stores.
@@ -318,22 +318,9 @@ instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
     uint cat = instr_get_category(instr);
     if (!TEST(DR_INSTR_CATEGORY_FP, cat))
         return false;
-    else if (TEST(DR_INSTR_CATEGORY_MATH, cat)) {
-        if (type != NULL)
-            *type = DR_FP_MATH;
-        return true;
-    } else if (TEST(DR_INSTR_CATEGORY_CONVERT, cat)) {
-        if (type != NULL)
-            *type = DR_FP_CONVERT;
-        return true;
-    } else if (TEST(DR_INSTR_CATEGORY_MOVE, cat)) {
-        if (type != NULL)
-            *type = DR_FP_MOVE;
-        return true;
-    } else {
-        CLIENT_ASSERT(false, "instr_is_floating_ex: FP instruction without subcategory");
-        return false;
-    }
+    if (type != NULL)
+        *type = cat;
+    return true;
 }
 
 bool

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -310,7 +310,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type OUT)
+instr_is_floating_type(instr_t *instr, dr_instr_category_t *type OUT)
 {
     /* DR_FP_STATE instructions aren't available on AArch64.
      * Processor state is saved/restored with loads and stores.
@@ -353,7 +353,7 @@ instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
 bool
 instr_is_floating(instr_t *instr)
 {
-    return instr_is_floating_ex(instr, NULL);
+    return instr_is_floating_type(instr, NULL);
 }
 
 bool

--- a/core/ir/arm/instr.c
+++ b/core/ir/arm/instr.c
@@ -446,6 +446,14 @@ instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
 }
 
 bool
+instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
+{
+    /* FIXME i#1551: NYI */
+    CLIENT_ASSERT(false, "NYI");
+    return false;
+}
+
+bool
 instr_is_floating(instr_t *instr)
 {
     return instr_is_floating_ex(instr, NULL);

--- a/core/ir/arm/instr.c
+++ b/core/ir/arm/instr.c
@@ -438,7 +438,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
+instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type OUT)
 {
     /* FIXME i#1551: NYI */
     CLIENT_ASSERT(false, "NYI");

--- a/core/ir/arm/instr.c
+++ b/core/ir/arm/instr.c
@@ -438,7 +438,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type OUT)
+instr_is_floating_type(instr_t *instr, dr_instr_category_t *type OUT)
 {
     /* FIXME i#1551: NYI */
     CLIENT_ASSERT(false, "NYI");
@@ -456,7 +456,7 @@ instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
 bool
 instr_is_floating(instr_t *instr)
 {
-    return instr_is_floating_ex(instr, NULL);
+    return instr_is_floating_type(instr, NULL);
 }
 
 bool

--- a/core/ir/arm/instr.c
+++ b/core/ir/arm/instr.c
@@ -438,7 +438,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
+instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
 {
     /* FIXME i#1551: NYI */
     CLIENT_ASSERT(false, "NYI");

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -1911,7 +1911,8 @@ typedef enum {
 } dr_instr_category_t;
 
 /**
- * \deprecated Indicates which type of floating-point operation and instruction performs.
+ * Indicates which type of floating-point operation and instruction performs.
+ * \deprecated Replaced by the more general #dr_instr_category_t.
  */
 typedef enum {
     DR_FP_STATE,   /**< Saves, restores, or queries processor state. */
@@ -1928,14 +1929,16 @@ DR_API
  *   non-NULL, the type of the floating point operation is written to \p type.
  */
 bool
-instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type);
+instr_is_floating_type(instr_t *instr, dr_instr_category_t *type);
 
 DR_API
 /**
- * \deprecated Returns true iff \p instr is a floating point instruction.
+ * Returns true iff \p instr is a floating point instruction.
  * @param[in] instr  The instruction to query
  * @param[out] type  If the return value is true and \p type is
  *   non-NULL, the type of the floating point operation is written to \p type.
+ * \deprecated Prefer instr_is_floating_type() which uses the more general
+ * #dr_instr_category_t.
  */
 bool
 instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type);

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -1910,6 +1910,16 @@ typedef enum {
     DR_INSTR_CATEGORY_OTHER = 0x200 /**< Other types of instructions. */
 } dr_instr_category_t;
 
+/**
+ * \deprecated Indicates which type of floating-point operation and instruction performs.
+ */
+typedef enum {
+    DR_FP_STATE,   /**< Saves, restores, or queries processor state. */
+    DR_FP_MOVE,    /**< Moves floating point values from one location to another. */
+    DR_FP_CONVERT, /**< Converts to or from floating point values. */
+    DR_FP_MATH,    /**< Performs arithmetic or conditional operations. */
+} dr_fp_type_t;
+
 DR_API
 /**
  * Returns true iff \p instr is a floating point instruction.
@@ -1919,6 +1929,16 @@ DR_API
  */
 bool
 instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type);
+
+DR_API
+/**
+ * \deprecated Returns true iff \p instr is a floating point instruction.
+ * @param[in] instr  The instruction to query
+ * @param[out] type  If the return value is true and \p type is
+ *   non-NULL, the type of the floating point operation is written to \p type.
+ */
+bool
+instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type);
 
 DR_API
 /** Returns true iff \p instr is part of Intel's MMX instructions. */

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -1928,7 +1928,7 @@ DR_API
  *   non-NULL, the type of the floating point operation is written to \p type.
  */
 bool
-instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type);
+instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type);
 
 DR_API
 /**

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -1910,16 +1910,6 @@ typedef enum {
     DR_INSTR_CATEGORY_OTHER = 0x200 /**< Other types of instructions. */
 } dr_instr_category_t;
 
-/**
- * Indicates which type of floating-point operation and instruction performs.
- */
-typedef enum {
-    DR_FP_STATE,   /**< Saves, restores, or queries processor state. */
-    DR_FP_MOVE,    /**< Moves floating point values from one location to another. */
-    DR_FP_CONVERT, /**< Converts to or from floating point values. */
-    DR_FP_MATH,    /**< Performs arithmetic or conditional operations. */
-} dr_fp_type_t;
-
 DR_API
 /**
  * Returns true iff \p instr is a floating point instruction.
@@ -1928,7 +1918,7 @@ DR_API
  *   non-NULL, the type of the floating point operation is written to \p type.
  */
 bool
-instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type);
+instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type);
 
 DR_API
 /** Returns true iff \p instr is part of Intel's MMX instructions. */

--- a/core/ir/x86/decode.c
+++ b/core/ir/x86/decode.c
@@ -2449,17 +2449,11 @@ decode_category(instr_t *instr)
             if (instr_operands_valid(instr)) {
                 if (instr_reads_memory(instr)) {
                     category |= DR_INSTR_CATEGORY_LOAD;
-                    if (TEST(DR_INSTR_CATEGORY_MOVE, category)) {
-                        category &= ~DR_INSTR_CATEGORY_MOVE;
-                        category &= ~DR_INSTR_CATEGORY_FP;
-                    }
+                    category &= ~DR_INSTR_CATEGORY_MOVE;
                 }
                 if (instr_writes_memory(instr)) {
                     category |= DR_INSTR_CATEGORY_STORE;
-                    if (TEST(DR_INSTR_CATEGORY_MOVE, category)) {
-                        category &= ~DR_INSTR_CATEGORY_MOVE;
-                        category &= ~DR_INSTR_CATEGORY_FP;
-                    }
+                    category &= ~DR_INSTR_CATEGORY_MOVE;
                 }
             }
             instr_set_category(instr, category);

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -908,7 +908,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type OUT)
+instr_is_floating_type(instr_t *instr, dr_instr_category_t *type OUT)
 {
     uint cat = instr_get_category(instr);
     if (!TEST(DR_INSTR_CATEGORY_FP, cat))
@@ -973,7 +973,7 @@ instr_may_write_zmm_or_opmask_register(instr_t *instr)
 bool
 instr_is_floating(instr_t *instr)
 {
-    return instr_is_floating_ex(instr, NULL);
+    return instr_is_floating_type(instr, NULL);
 }
 
 bool

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -916,7 +916,7 @@ instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
     if (type != NULL)
         *type = cat;
     return true;
-2}
+}
 
 bool
 instr_can_set_single_step(instr_t *instr)

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -908,33 +908,15 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
+instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
 {
     uint cat = instr_get_category(instr);
-
     if (!TEST(DR_INSTR_CATEGORY_FP, cat))
         return false;
-    else if (TEST(DR_INSTR_CATEGORY_MATH, cat)) {
-        if (type != NULL)
-            *type = DR_FP_MATH;
-        return true;
-    } else if (TEST(DR_INSTR_CATEGORY_CONVERT, cat)) {
-        if (type != NULL)
-            *type = DR_FP_CONVERT;
-        return true;
-    } else if (TEST(DR_INSTR_CATEGORY_STATE, cat)) {
-        if (type != NULL)
-            *type = DR_FP_STATE;
-        return true;
-    } else if (TEST(DR_INSTR_CATEGORY_MOVE, cat)) {
-        if (type != NULL)
-            *type = DR_FP_MOVE;
-        return true;
-    } else {
-        CLIENT_ASSERT(false, "instr_is_floating_ex: FP instruction without subcategory");
-        return false;
-    }
-}
+    if (type != NULL)
+        *type = cat;
+    return true;
+2}
 
 bool
 instr_can_set_single_step(instr_t *instr)

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -919,6 +919,35 @@ instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
 }
 
 bool
+instr_is_floating_ex(instr_t *instr, dr_fp_type_t *type OUT)
+{
+    uint cat = instr_get_category(instr);
+
+    if (!TEST(DR_INSTR_CATEGORY_FP, cat))
+        return false;
+    else if (TEST(DR_INSTR_CATEGORY_MATH, cat)) {
+        if (type != NULL)
+            *type = DR_FP_MATH;
+        return true;
+    } else if (TEST(DR_INSTR_CATEGORY_CONVERT, cat)) {
+        if (type != NULL)
+            *type = DR_FP_CONVERT;
+        return true;
+    } else if (TEST(DR_INSTR_CATEGORY_STATE, cat)) {
+        if (type != NULL)
+            *type = DR_FP_STATE;
+        return true;
+    } else if (TEST(DR_INSTR_CATEGORY_MOVE, cat)) {
+        if (type != NULL)
+            *type = DR_FP_MOVE;
+        return true;
+    } else {
+        CLIENT_ASSERT(false, "instr_is_floating_ex: FP instruction without subcategory");
+        return false;
+    }
+}
+
+bool
 instr_can_set_single_step(instr_t *instr)
 {
     return (instr_get_opcode(instr) == OP_popf || instr_get_opcode(instr) == OP_iret);

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -908,7 +908,7 @@ instr_is_rep_string_op(instr_t *instr)
 }
 
 bool
-instr_is_floating_ex(instr_t *instr, dr_instr_category_t *type OUT)
+instr_is_floating_exten(instr_t *instr, dr_instr_category_t *type OUT)
 {
     uint cat = instr_get_category(instr);
     if (!TEST(DR_INSTR_CATEGORY_FP, cat))


### PR DESCRIPTION
Continue #6331 discussion
FP types are not needed now because all information is in category now



Issue: https://github.com/DynamoRIO/dynamorio/issues/6238