### PR TITLE
i#5694 core-sharded: Add stream input query interfaces

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -149,6 +149,9 @@ Further non-compatibility-affecting changes include:
  - Added type_is_read() API that returns true if a trace type reads from memory.
  - Added instr_num_memory_read_access() and instr_num_memory_write_access() that return
    the number of memory read and write accesses of an instruction respectively.
+ - Added several routines to the #dynamorio::drmemtrace::memtrace_stream_t interface
+   for drmemtrace analysis tools: get_output_cpuid(), get_workload_id(),
+   get_input_id(), get_input_interface().
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -807,6 +807,15 @@ if (BUILD_TESTS)
   set_tests_properties(tool.drcacheoff.trace_interval_analysis_unit_tests PROPERTIES
     TIMEOUT ${test_seconds})
 
+  add_executable(tool.drcacheoff.analysis_unit_tests tests/analysis_unit_tests.cpp)
+  add_win32_flags(tool.drcacheoff.analysis_unit_tests)
+  target_link_libraries(tool.drcacheoff.analysis_unit_tests
+    drmemtrace_analyzer test_helpers)
+  add_test(NAME tool.drcacheoff.analysis_unit_tests
+    COMMAND tool.drcacheoff.analysis_unit_tests)
+  set_tests_properties(tool.drcacheoff.analysis_unit_tests PROPERTIES
+    TIMEOUT ${test_seconds})
+
   if (DR_HOST_AARCH64 AND NOT APPLE) # i#1997: static DR on Mac NYI.
     add_executable(tool.drcacheoff.burst_aarch64_sys tests/burst_aarch64_sys.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_aarch64_sys)

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -464,6 +464,33 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_serial(analyzer_worker_data_t &
 }
 
 template <typename RecordType, typename ReaderType>
+bool
+analyzer_tmpl_t<RecordType, ReaderType>::process_shard_exit(
+    analyzer_worker_data_t *worker, int shard_index)
+{
+    VPRINT(this, 1, "Worker %d finished trace shard %s\n", worker->index,
+           worker->stream->get_stream_name().c_str());
+    if (interval_microseconds_ != 0 &&
+        !process_interval(worker->shard_data[shard_index].cur_interval_index,
+                          worker->shard_data[shard_index].cur_interval_init_instr_count,
+                          worker,
+                          /*parallel=*/true, shard_index))
+        return false;
+    for (int i = 0; i < num_tools_; ++i) {
+        if (!tools_[i]->parallel_shard_exit(
+                worker->shard_data[shard_index].tool_data[i].shard_data)) {
+            worker->error = tools_[i]->parallel_shard_error(
+                worker->shard_data[shard_index].tool_data[i].shard_data);
+            VPRINT(this, 1, "Worker %d hit shard exit error %s on trace shard %s\n",
+                   worker->index, worker->error.c_str(),
+                   worker->stream->get_stream_name().c_str());
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename RecordType, typename ReaderType>
 void
 analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *worker)
 {
@@ -471,28 +498,6 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *w
 
     for (int i = 0; i < num_tools_; ++i)
         user_worker_data[i] = tools_[i]->parallel_worker_init(worker->index);
-
-    auto process_shard_exit = [=](int shard_index) {
-        VPRINT(this, 1, "Worker %d finished trace shard %s\n", worker->index,
-               worker->stream->get_stream_name().c_str());
-        if (interval_microseconds_ != 0 &&
-            !process_interval(
-                worker->shard_data[shard_index].cur_interval_index,
-                worker->shard_data[shard_index].cur_interval_init_instr_count, worker,
-                /*parallel=*/true, shard_index))
-            return;
-        for (int i = 0; i < num_tools_; ++i) {
-            if (!tools_[i]->parallel_shard_exit(
-                    worker->shard_data[shard_index].tool_data[i].shard_data)) {
-                worker->error = tools_[i]->parallel_shard_error(
-                    worker->shard_data[shard_index].tool_data[i].shard_data);
-                VPRINT(this, 1, "Worker %d hit shard exit error %s on trace shard %s\n",
-                       worker->index, worker->error.c_str(),
-                       worker->stream->get_stream_name().c_str());
-                return;
-            }
-        }
-    };
 
     RecordType record;
     // The current time is used for time quanta; for instr quanta, it's ignored and
@@ -563,11 +568,13 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks(analyzer_worker_data_t *w
             }
         }
         if (record_is_thread_final(record) && shard_type_ != SHARD_BY_CORE) {
-            process_shard_exit(shard_index);
+            if (!process_shard_exit(worker, shard_index))
+                return;
         }
     }
     if (shard_type_ == SHARD_BY_CORE) {
-        process_shard_exit(worker->index);
+        if (!process_shard_exit(worker, worker->index))
+            return;
     }
     for (int i = 0; i < num_tools_; ++i) {
         const std::string error = tools_[i]->parallel_worker_exit(user_worker_data[i]);

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -233,6 +233,11 @@ protected:
     void
     process_serial(analyzer_worker_data_t &worker);
 
+    // Helper for process_tasks() which calls parallel_shard_exit() in each tool.
+    // Returns false if there was an error and the caller should return early.
+    bool
+    process_shard_exit(analyzer_worker_data_t *worker, int shard_index);
+
     bool
     record_has_tid(RecordType record, memref_tid_t &tid);
 

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -169,9 +169,10 @@ public:
     }
 
     /**
-     * Returns a unique identifier for the current workload.  This might be an
-     * ordinal from the list of active workloads, or some other identifier.
-     * If not implemented for the current mode, -1 is returned.
+     * Returns a unique identifier for the current workload.  This might be an ordinal
+     * from the list of active workloads, or some other identifier.  This is guaranteed
+     * to be unique among all inputs, unlike the process and thread identifiers in
+     * #memref_t. If not implemented for the current mode, -1 is returned.
      */
     virtual int64_t
     get_workload_id() const
@@ -180,9 +181,10 @@ public:
     }
 
     /**
-     * Returns a unique identifier for the current input trace.  This might be an
-     * ordinal from the list of active inputs, or some other identifier.
-     * If not implemented for the current mode, -1 is returned.
+     * Returns a unique identifier for the current input trace.  This might be an ordinal
+     * from the list of active inputs, or some other identifier.  This is guaranteed to
+     * be unique among all inputs, unlike the process and thread identifiers in
+     * #memref_t.  If not implemented for the current mode, -1 is returned.
      */
     virtual int64_t
     get_input_id() const

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -167,6 +167,40 @@ public:
     {
         return -1;
     }
+
+    /**
+     * Returns a unique identifier for the current workload.  This might be an
+     * ordinal from the list of active workloads, or some other identifier.
+     * If not implemented for the current mode, -1 is returned.
+     */
+    virtual int64_t
+    get_workload_id() const
+    {
+        return -1;
+    }
+
+    /**
+     * Returns a unique identifier for the current input trace.  This might be an
+     * ordinal from the list of active inputs, or some other identifier.
+     * If not implemented for the current mode, -1 is returned.
+     */
+    virtual int64_t
+    get_input_id() const
+    {
+        return -1;
+    }
+
+    /**
+     * Returns the stream interface for the current input trace.  This differs from
+     * "this" for #SHARD_BY_CORE where multiple inputs are interleaved on one
+     * output stream ("this").
+     * If not implemented for the current mode, nullptr is returned.
+     */
+    virtual memtrace_stream_t *
+    get_input_interface() const
+    {
+        return nullptr;
+    }
 };
 
 /**

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -663,7 +663,7 @@ public:
          * Returns the ordinal for the current input stream feeding this output stream.
          */
         virtual input_ordinal_t
-        get_input_stream_ordinal()
+        get_input_stream_ordinal() const
         {
             return scheduler_->get_input_ordinal(ordinal_);
         }
@@ -675,7 +675,7 @@ public:
          * stream.
          */
         virtual int
-        get_input_workload_ordinal()
+        get_input_workload_ordinal() const
         {
             return scheduler_->get_workload_ordinal(ordinal_);
         }
@@ -773,6 +773,35 @@ public:
         get_output_cpuid() const override
         {
             return scheduler_->get_output_cpuid(ordinal_);
+        }
+
+        /**
+         * Returns the ordinal for the current
+         * #dynamorio::drmemtrace::scheduler_tmpl_t::input_workload_t.
+         */
+        int64_t
+        get_workload_id() const override
+        {
+            return static_cast<int64_t>(get_input_workload_ordinal());
+        }
+
+        /**
+         * Returns the ordinal for the current input stream feeding this output stream.
+         */
+        int64_t
+        get_input_id() const override
+        {
+            return static_cast<int64_t>(get_input_stream_ordinal());
+        }
+
+        /**
+         * Returns the #dynamorio::drmemtrace::memtrace_stream_t interface for the
+         * current input stream feeding this output stream.
+         */
+        memtrace_stream_t *
+        get_input_interface() const override
+        {
+            return scheduler_->get_input_stream_interface(get_input_stream_ordinal());
         }
 
     protected:

--- a/clients/drcachesim/tests/analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/analysis_unit_tests.cpp
@@ -1,0 +1,189 @@
+/* **********************************************************
+ * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Unit tests for trace analysis APIs. */
+
+#include "analyzer.h"
+#include "mock_reader.h"
+#include "scheduler.h"
+
+#include <assert.h>
+
+#include <iostream>
+#include <vector>
+
+namespace dynamorio {
+namespace drmemtrace {
+
+// An analyzer that takes in any number of scheduler inputs, plus optional direct
+// scheduler options for SHARD_BY_CORE.
+class mock_analyzer_t : public analyzer_t {
+public:
+    mock_analyzer_t(std::vector<scheduler_t::input_workload_t> &sched_inputs,
+                    analysis_tool_t **tools, int num_tools, bool parallel,
+                    int worker_count, scheduler_t::scheduler_options_t *sched_ops_in)
+        : analyzer_t()
+    {
+        num_tools_ = num_tools;
+        tools_ = tools;
+        parallel_ = parallel;
+        verbosity_ = 1;
+        worker_count_ = worker_count;
+        scheduler_t::scheduler_options_t sched_ops;
+        if (sched_ops_in != nullptr) {
+            shard_type_ = SHARD_BY_CORE;
+            sched_ops = *sched_ops_in;
+            // XXX: We could refactor init_scheduler_common() to share a couple of
+            // these lines.
+            if (sched_ops.quantum_unit == sched_type_t::QUANTUM_TIME)
+                sched_by_time_ = true;
+        } else if (parallel)
+            sched_ops = scheduler_t::make_scheduler_parallel_options(verbosity_);
+        else
+            sched_ops = scheduler_t::make_scheduler_serial_options(verbosity_);
+        if (scheduler_.init(sched_inputs, worker_count_, sched_ops) !=
+            sched_type_t::STATUS_SUCCESS) {
+            assert(false);
+            success_ = false;
+        }
+        for (int i = 0; i < worker_count_; ++i) {
+            worker_data_.push_back(analyzer_worker_data_t(i, scheduler_.get_stream(i)));
+        }
+    }
+};
+
+bool
+test_queries()
+{
+    std::cerr << "\n----------------\nTesting queries\n";
+    std::vector<trace_entry_t> input_sequence = {
+        make_thread(/*tid=*/1),
+        make_pid(/*pid=*/1),
+        make_instr(/*pc=*/42),
+        make_exit(/*tid=*/1),
+    };
+    static constexpr int NUM_INPUTS = 3;
+    static constexpr int NUM_OUTPUTS = 2;
+    static constexpr int BASE_TID = 100;
+    std::vector<trace_entry_t> inputs[NUM_INPUTS];
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    for (int i = 0; i < NUM_INPUTS; i++) {
+        memref_tid_t tid = BASE_TID + i;
+        inputs[i] = input_sequence;
+        for (auto &record : inputs[i]) {
+            if (record.type == TRACE_TYPE_THREAD || record.type == TRACE_TYPE_THREAD_EXIT)
+                record.addr = static_cast<addr_t>(tid);
+        }
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[i])),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), tid);
+        sched_inputs.emplace_back(std::move(readers));
+    }
+    scheduler_t::scheduler_options_t sched_ops(
+        scheduler_t::MAP_TO_ANY_OUTPUT, scheduler_t::DEPENDENCY_IGNORE,
+        scheduler_t::SCHEDULER_DEFAULTS, /*verbosity=*/3);
+
+    class test_tool_t : public analysis_tool_t {
+    public:
+        bool
+        process_memref(const memref_t &memref) override
+        {
+            assert(false); // Only expect parallel mode.
+            return false;
+        }
+        bool
+        print_results() override
+        {
+            return true;
+        }
+        bool
+        parallel_shard_supported() override
+        {
+            return true;
+        }
+        void *
+        parallel_shard_init_stream(int shard_index, void *worker_data,
+                                   memtrace_stream_t *stream) override
+        {
+            auto per_shard = new per_shard_t;
+            per_shard->index = shard_index;
+            per_shard->stream = stream;
+            return reinterpret_cast<void *>(per_shard);
+        }
+        bool
+        parallel_shard_exit(void *shard_data) override
+        {
+            per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
+            delete shard;
+            return true;
+        }
+        bool
+        parallel_shard_memref(void *shard_data, const memref_t &memref) override
+        {
+            per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
+            // These are our testing goals: these queries.
+            // We have one thread for each of our NUM_INPUTS workloads.
+            assert(shard->stream->get_output_cpuid() == shard->index);
+            assert(shard->stream->get_workload_id() == memref.instr.tid - BASE_TID);
+            assert(shard->stream->get_input_id() == memref.instr.tid - BASE_TID);
+            return true;
+        }
+
+    private:
+        struct per_shard_t {
+            int index;
+            memtrace_stream_t *stream;
+        };
+    };
+
+    std::vector<analysis_tool_t *> tools;
+    auto test_tool = std::unique_ptr<test_tool_t>(new test_tool_t);
+    tools.push_back(test_tool.get());
+    mock_analyzer_t analyzer(sched_inputs, &tools[0], (int)tools.size(),
+                             /*parallel=*/true, NUM_OUTPUTS, &sched_ops);
+    assert(!!analyzer);
+    bool res = analyzer.run();
+    assert(res);
+    return true;
+}
+
+int
+test_main(int argc, const char *argv[])
+{
+    if (!test_queries())
+        return 1;
+    std::cerr << "All done!\n";
+    return 0;
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/analysis_unit_tests.cpp
@@ -153,6 +153,7 @@ test_queries()
             // These are our testing goals: these queries.
             // We have one thread for each of our NUM_INPUTS workloads.
             assert(shard->stream->get_output_cpuid() == shard->index);
+            // We have just one thread per workload, so they're the same.
             assert(shard->stream->get_workload_id() == memref.instr.tid - BASE_TID);
             assert(shard->stream->get_input_id() == memref.instr.tid - BASE_TID);
             return true;

--- a/clients/drcachesim/tests/mock_reader.h
+++ b/clients/drcachesim/tests/mock_reader.h
@@ -1,0 +1,164 @@
+/* **********************************************************
+ * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* A mock reader that iterates over a vector of trace_entry_t, for tests. */
+
+#ifndef _MOCK_READER_H_
+#define _MOCK_READER_H_ 1
+
+#include <vector>
+
+#include "reader.h"
+#include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+// A mock reader that iterates over a vector of records.
+class mock_reader_t : public reader_t {
+public:
+    mock_reader_t() = default;
+    explicit mock_reader_t(const std::vector<trace_entry_t> &trace)
+        : trace_(trace)
+    {
+        verbosity_ = 3;
+    }
+    bool
+    init() override
+    {
+        at_eof_ = false;
+        ++*this;
+        return true;
+    }
+    trace_entry_t *
+    read_next_entry() override
+    {
+        trace_entry_t *entry = read_queued_entry();
+        if (entry != nullptr)
+            return entry;
+        ++index_;
+        if (index_ >= static_cast<int>(trace_.size())) {
+            at_eof_ = true;
+            return nullptr;
+        }
+        return &trace_[index_];
+    }
+    std::string
+    get_stream_name() const override
+    {
+        return "";
+    }
+
+private:
+    std::vector<trace_entry_t> trace_;
+    int index_ = -1;
+};
+
+static inline trace_entry_t
+make_instr(addr_t pc, trace_type_t type = TRACE_TYPE_INSTR)
+{
+    trace_entry_t entry;
+    entry.type = static_cast<unsigned short>(type);
+    entry.size = 1;
+    entry.addr = pc;
+    return entry;
+}
+
+static inline trace_entry_t
+make_exit(memref_tid_t tid)
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_THREAD_EXIT;
+    entry.addr = static_cast<addr_t>(tid);
+    return entry;
+}
+
+static inline trace_entry_t
+make_footer()
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_FOOTER;
+    return entry;
+}
+
+static inline trace_entry_t
+make_version(int version)
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_MARKER;
+    entry.size = TRACE_MARKER_TYPE_VERSION;
+    entry.addr = version;
+    return entry;
+}
+
+static inline trace_entry_t
+make_thread(memref_tid_t tid)
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_THREAD;
+    entry.addr = static_cast<addr_t>(tid);
+    return entry;
+}
+
+static inline trace_entry_t
+make_pid(memref_pid_t pid)
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_PID;
+    entry.addr = static_cast<addr_t>(pid);
+    return entry;
+}
+
+static inline trace_entry_t
+make_timestamp(uint64_t timestamp)
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_MARKER;
+    entry.size = TRACE_MARKER_TYPE_TIMESTAMP;
+    entry.addr = static_cast<addr_t>(timestamp);
+    return entry;
+}
+
+static inline trace_entry_t
+make_marker(trace_marker_type_t type, uintptr_t value)
+{
+    trace_entry_t entry;
+    entry.type = TRACE_TYPE_MARKER;
+    entry.size = static_cast<unsigned short>(type);
+    entry.addr = value;
+    return entry;
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _MOCK_READER_H_ */

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -77,8 +77,8 @@ public:
         if (at_ + 1 < refs_.size()) {
             ++at_;
             record = refs_[at_];
-            if (tid2ordinal.find(record.instr.tid) == tid2ordinal.end()) {
-                tid2ordinal[record.instr.tid] = tid2ordinal.size();
+            if (tid2ordinal_.find(record.instr.tid) == tid2ordinal_.end()) {
+                tid2ordinal_[record.instr.tid] = tid2ordinal_.size();
             }
             if (record.marker.type == TRACE_TYPE_MARKER &&
                 record.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
@@ -107,11 +107,11 @@ public:
         return "test_stream";
     }
     scheduler_t::input_ordinal_t
-    get_input_stream_ordinal() override
+    get_input_stream_ordinal() const override
     {
         assert(at_ >= 0 && at_ < refs_.size());
         // Each TID forms a separate input stream.
-        return tid2ordinal[refs_[at_].instr.tid];
+        return tid2ordinal_.at(refs_[at_].instr.tid);
     }
     uint64_t
     get_first_timestamp() const override
@@ -145,7 +145,7 @@ public:
     }
 
 private:
-    std::unordered_map<memref_tid_t, scheduler_t::input_ordinal_t> tid2ordinal;
+    std::unordered_map<memref_tid_t, scheduler_t::input_ordinal_t> tid2ordinal_;
     std::vector<memref_t> refs_;
     int at_;
     bool parallel_;


### PR DESCRIPTION
Adds several routines to the memtrace_stream_t interface for drmemtrace analysis tools in core-sharded mode:
+ get_workload_id()
+ get_input_id()
+ get_input_interface()

Adds a new analysis_unit_tests executable with some sanity tests. Splits out the mock_reader_t and helpers used by scheduler_unit_tests to share them with the new test.

Documents the additions.

Fixes a bug with core-sharded analysis tools where parallel_shard_exit was called for every thread, resulting use-after-frees when more than one thread was on a core and the tool deletes its shard data structure in the parallel_shard_exit routine (most of our tools do not, which is why this was not noticed before).

Issue: #5694