### PR TITLE
i#4465: Trace realloc by default

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -149,6 +149,7 @@ Further non-compatibility-affecting changes include:
  - Added type_is_read() API that returns true if a trace type reads from memory.
  - Added instr_num_memory_read_access() and instr_num_memory_write_access() that return
    the number of memory read and write accesses of an instruction respectively.
+ - Added realloc to the set of functions traced by -record_heap by default.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -895,8 +895,14 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.burst_malloc tests/burst_malloc.cpp)
     configure_DynamoRIO_static(tool.drcacheoff.burst_malloc)
     use_DynamoRIO_static_client(tool.drcacheoff.burst_malloc drmemtrace_static)
-    target_link_libraries(tool.drcacheoff.burst_malloc test_helpers)
+    target_link_libraries(tool.drcacheoff.burst_malloc drmemtrace_raw2trace
+        drmemtrace_analyzer test_helpers)
+    if (WIN32)
+      # Just like for burst_replace + burst_futex, linking together takes effort.
+      target_link_libraries(tool.drcacheoff.burst_malloc ${static_libc})
+    endif ()
     add_win32_flags(tool.drcacheoff.burst_malloc)
+    use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.burst_malloc)
     if (UNIX)
       append_property_string(SOURCE tests/burst_malloc.cpp
         # Allow our different-arg-count aliases.

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -691,12 +691,18 @@ droption_t<bool> op_record_heap(
     " -record_function [heap_functions], where [heap_functions] is"
     " the value in -record_heap_value.");
 droption_t<std::string> op_record_heap_value(
+    // There are other, more obscure variants, like pvalloc, valloc, memalign,
+    // posix_memalign, independent_calloc, plus malloc_zone_* on Mac and
+    // *_impl versions on Windows.  We ignore these for now.
     DROPTION_SCOPE_CLIENT, "record_heap_value", DROPTION_FLAG_ACCUMULATE,
     OP_RECORD_FUNC_ITEM_SEP,
     "malloc|1" OP_RECORD_FUNC_ITEM_SEP "free|1|noret" OP_RECORD_FUNC_ITEM_SEP
+    "realloc|2" OP_RECORD_FUNC_ITEM_SEP "calloc|2" OP_RECORD_FUNC_ITEM_SEP
     "tc_malloc|1" OP_RECORD_FUNC_ITEM_SEP "tc_free|1|noret" OP_RECORD_FUNC_ITEM_SEP
+    "tc_realloc|2" OP_RECORD_FUNC_ITEM_SEP "tc_calloc|2" OP_RECORD_FUNC_ITEM_SEP
     "__libc_malloc|1" OP_RECORD_FUNC_ITEM_SEP
-    "__libc_free|1|noret" OP_RECORD_FUNC_ITEM_SEP "calloc|2"
+    "__libc_free|1|noret" OP_RECORD_FUNC_ITEM_SEP
+    "__libc_realloc|2" OP_RECORD_FUNC_ITEM_SEP "__libc_calloc|2"
 #ifdef UNIX
     // i#3048: We only have Itanium ABI manglings for now so we disable for MSVC.
     // XXX: This is getting quite long.  I would change the option to point at

--- a/clients/drcachesim/tests/burst_malloc.cpp
+++ b/clients/drcachesim/tests/burst_malloc.cpp
@@ -40,15 +40,22 @@
 
 #include "dr_api.h"
 #include "drmemtrace/drmemtrace.h"
+#include "scheduler.h"
+#include "tracer/raw2trace.h"
+#include "tracer/raw2trace_directory.h"
+
 #include <assert.h>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <math.h>
 #include <stdlib.h>
 
 namespace dynamorio {
 namespace drmemtrace {
+
+int realloc_id = -1;
 
 bool
 my_setenv(const char *var, const char *value)
@@ -100,6 +107,7 @@ do_some_work(int arg)
 #ifdef UNIX
         *val += has_aliases(i, i);
 #endif
+        vals[i] = (double *)realloc(vals[i], 2 * sizeof(double));
     }
     for (int i = 0; i < iters; i++) {
         *val += *vals[i];
@@ -123,6 +131,8 @@ exit_cb(void *)
     assert(stream.good());
     std::string line;
     bool found_malloc = false;
+    bool found_calloc = false;
+    bool found_realloc = false;
     bool found_return_big_value = false;
     int found_alias_count = 0;
     while (std::getline(stream, line)) {
@@ -131,6 +141,15 @@ exit_cb(void *)
             found_return_big_value = true;
         if (line.find("!malloc") != std::string::npos)
             found_malloc = true;
+        if (line.find("!calloc") != std::string::npos)
+            found_calloc = true;
+        if (line.find("!realloc") != std::string::npos &&
+            line.find("libc.so") != std::string::npos) {
+            found_realloc = true;
+            std::istringstream iss(line);
+            char comma;
+            iss >> realloc_id >> comma;
+        }
 #ifdef UNIX
         if (line.find("alias") != std::string::npos) {
             ++found_alias_count;
@@ -140,11 +159,107 @@ exit_cb(void *)
 #endif
     }
     assert(found_malloc);
+    assert(found_calloc);
+    assert(found_realloc);
+    assert(realloc_id >= 0);
     assert(found_return_big_value);
 #ifdef UNIX
     // All 3 should be in the file, even though 2 had duplicate PC's.
     assert(found_alias_count == 3);
 #endif
+}
+
+/* XXX: Some of this is very similar to code in other tests like burst_traceopts
+ * and burst_futex.  Maybe we can share some of it through common library.
+ */
+static std::string
+post_process()
+{
+    const char *raw_dir;
+    drmemtrace_status_t mem_res = drmemtrace_get_output_path(&raw_dir);
+    assert(mem_res == DRMEMTRACE_SUCCESS);
+    std::string outdir = std::string(raw_dir) + DIRSEP + "malloc";
+    void *dr_context = dr_standalone_init();
+    /* Use a new scope to free raw2trace_directory_t before dr_standalone_exit().
+     * We could alternatively make a scope exit template helper.
+     */
+    {
+        raw2trace_directory_t dir;
+        if (!dr_create_dir(outdir.c_str())) {
+            std::cerr << "Failed to create output dir";
+            assert(false);
+        }
+        std::string dir_err = dir.initialize(raw_dir, outdir);
+        assert(dir_err.empty());
+        raw2trace_t raw2trace(dir.modfile_bytes_, dir.in_files_, dir.out_files_,
+                              dir.out_archives_, dir.encoding_file_,
+                              dir.serial_schedule_file_, dir.cpu_schedule_file_,
+                              dr_context,
+                              0
+#ifdef WINDOWS
+                              /* FIXME i#3983: Creating threads in standalone mode
+                               * causes problems.  We disable the pool for now.
+                               */
+                              ,
+                              0
+#endif
+        );
+        std::string error = raw2trace.do_conversion();
+        if (!error.empty()) {
+            std::cerr << "raw2trace failed: " << error << "\n";
+            assert(false);
+        }
+    }
+    dr_standalone_exit();
+    return outdir;
+}
+
+void
+walk_trace(const std::string &tracedir)
+{
+    // Now walk the trace and ensure it has futex markers.
+    void *dr_context = dr_standalone_init();
+
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(tracedir);
+    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) !=
+        scheduler_t::STATUS_SUCCESS) {
+        std::cerr << "Failed to initialize scheduler " << scheduler.get_error_string()
+                  << "\n";
+    }
+
+    auto *stream = scheduler.get_stream(0);
+    memref_t memref;
+    int arg_ord = 0;
+    bool saw_realloc = false;
+    bool saw_realloc_args = false;
+    bool in_realloc_now = false;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+        assert(status == scheduler_t::STATUS_OK);
+        if (memref.marker.type != TRACE_TYPE_MARKER)
+            continue;
+        if (memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_ID) {
+            if (memref.marker.marker_value == realloc_id) {
+                saw_realloc = true;
+                in_realloc_now = true;
+            } else
+                in_realloc_now = false;
+        }
+        if (in_realloc_now && memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_ARG) {
+            saw_realloc_args = true;
+        }
+        if (in_realloc_now &&
+            memref.marker.marker_type == TRACE_MARKER_TYPE_FUNC_RETVAL) {
+            // Should have succeeded.
+            assert(memref.marker.marker_value > 0);
+        }
+    }
+    assert(saw_realloc);
+    assert(saw_realloc_args);
+
+    dr_standalone_exit();
 }
 
 int
@@ -165,7 +280,7 @@ test_main(int argc, const char *argv[])
                    " -record_function \"malloc|1&return_big_value|1\"'"))
         std::cerr << "failed to set env var!\n";
 
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 2; i++) {
         std::cerr << "pre-DR init\n";
         dr_app_setup();
         assert(!dr_app_running_under_dynamorio());
@@ -187,6 +302,9 @@ test_main(int argc, const char *argv[])
             std::cerr << "error in computation\n";
         std::cerr << "all done\n";
     }
+
+    std::string tracedir = post_process();
+    walk_trace(tracedir);
 
     return 0;
 }

--- a/clients/drcachesim/tests/offline-burst_malloc.templatex
+++ b/clients/drcachesim/tests/offline-burst_malloc.templatex
@@ -14,16 +14,8 @@ DynamoRIO statistics:
  *Peak threads under DynamoRIO control : *1
 .*
 all done
-pre-DR init
-Warning: duplicated function name malloc in [^W]*
-pre-DR start
-pre-DR detach
-DynamoRIO statistics:
- *Peak threads under DynamoRIO control : *1
 .*
-all done
-.*
-.* 70.. function id markers.*
-.* 40.. function return address markers.*
-.* 40.. function argument markers.*
-.* 30.. function return value markers.*
+.* 90.. function id markers.*
+.* 50.. function return address markers.*
+.* 60.. function argument markers.*
+.* 40.. function return value markers.*


### PR DESCRIPTION
Adds realloc to the list of heap functions traced by -record_heap by drmemtrace by default.  Also fills in missing variants for tc_ and __libc for calloc.

Adds a sanity check to the burst_malloc test that we find realloc, and extends burst_malloc to post-process and walk the trace and confirm we actually see markers for realloc.  Reduces the iteration count to try to keep the test from taking too long in the suite.

Fixes #4465