### PR TITLE
i#6342: Speed up function tracing on Windows

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3867,7 +3867,8 @@ if (BUILD_CLIENTS)
     # As for the online test, we check that only 1 thread is in the final trace.
     torunonly_drcacheoff(max-global client.annotation-concurrency
       # Include function tracing to sanity test combining with delay and max.
-      "-trace_after_instrs 20K -max_global_trace_refs 10K -record_heap"
+      # We don't use '-record_heap' as it is slow on Windows (i#6342).
+      "-trace_after_instrs 20K -max_global_trace_refs 10K -record_function malloc|1"
       "@-simulator_type@basic_counts" "${annotation_test_args_shorter}")
     set(tool.drcacheoff.max-global_timeout 240) # Can take >120s.
 


### PR DESCRIPTION
Looking up symbols is very slow on Windows.  Here we avoid looking at dynamorio.dll and the client and extension libraries.

For the drcacheoff.max-global test, we also reduce the number of functions from -record_heap to just -record_function 'malloc|1'.

Combined, these shrink the test from taking over 6 minutes on my local machine to taking 24 seconds.  The test was timing out periodically on GA CI and this should fix that.

Fixes #6342