### PR TITLE
Add raw2trace statistic for instr count

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3155,23 +3155,22 @@ raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
                 }
             }
         }
-    }
-    if (end > start) {
-        // We reach here also when we're not writing to a zip archive.
-
+    } else {
         for (const trace_entry_t *it = start; it < end; ++it) {
             if (type_is_instr(static_cast<trace_type_t>(it->type))) {
                 accumulate_to_statistic(tdata,
                                         RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT, 1);
             }
         }
-        if (!tdata->out_file->write(reinterpret_cast<const char *>(start),
-                                    reinterpret_cast<const char *>(end) -
-                                        reinterpret_cast<const char *>(start))) {
-            tdata->error = "Failed to write to output file";
-            return false;
-        }
     }
+    if (end > start &&
+        !tdata->out_file->write(reinterpret_cast<const char *>(start),
+                                reinterpret_cast<const char *>(end) -
+                                    reinterpret_cast<const char *>(start))) {
+        tdata->error = "Failed to write to output file";
+        return false;
+    }
+
     // If we're at the end of a block (minus its delayed branch) we need
     // to split now to avoid going too far by waiting for the next instr.
     if (tdata->cur_chunk_instr_count >= chunk_instr_count_) {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1214,6 +1214,7 @@ raw2trace_t::do_conversion()
                 earliest_trace_timestamp_, thread_data_[i]->earliest_trace_timestamp);
             latest_trace_timestamp_ = std::max(latest_trace_timestamp_,
                                                thread_data_[i]->latest_trace_timestamp);
+            final_trace_instr_count_ += thread_data_[i]->final_trace_instr_count;
         }
     } else {
         // The files can be converted concurrently.
@@ -1238,6 +1239,7 @@ raw2trace_t::do_conversion()
                 std::min(earliest_trace_timestamp_, tdata->earliest_trace_timestamp);
             latest_trace_timestamp_ =
                 std::max(latest_trace_timestamp_, tdata->latest_trace_timestamp);
+            final_trace_instr_count_ += tdata->final_trace_instr_count;
         }
     }
     error = aggregate_and_write_schedule_files();
@@ -1254,6 +1256,8 @@ raw2trace_t::do_conversion()
            count_rseq_side_exit_);
     VPRINT(1, "Trace duration %.3fs.\n",
            (latest_trace_timestamp_ - earliest_trace_timestamp_) / 1000000.0);
+    VPRINT(1, "Final trace instr count: " UINT64_FORMAT_STRING ".\n",
+           final_trace_instr_count_);
     VPRINT(1, "Successfully converted %zu thread files\n", thread_data_.size());
     return "";
 }
@@ -3055,6 +3059,8 @@ raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
             if (type_is_instr(static_cast<trace_type_t>(it->type)) &&
                 // Do not count PC-only i-filtered instrs.
                 it->size > 0) {
+                accumulate_to_statistic(tdata,
+                                        RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT, 1);
                 ++tdata->cur_chunk_instr_count;
                 ++instr_ordinal;
                 if (TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, tdata->file_type) &&
@@ -3502,6 +3508,9 @@ raw2trace_t::accumulate_to_statistic(raw2trace_thread_data_t *tdata,
     case RAW2TRACE_STAT_LATEST_TRACE_TIMESTAMP:
         tdata->latest_trace_timestamp = std::max(tdata->latest_trace_timestamp, value);
         break;
+    case RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT:
+        tdata->final_trace_instr_count += value;
+        break;
     default: DR_ASSERT(false);
     }
 }
@@ -3517,6 +3526,7 @@ raw2trace_t::get_statistic(raw2trace_statistic_t stat)
     case RAW2TRACE_STAT_RSEQ_SIDE_EXIT: return count_rseq_side_exit_;
     case RAW2TRACE_STAT_EARLIEST_TRACE_TIMESTAMP: return earliest_trace_timestamp_;
     case RAW2TRACE_STAT_LATEST_TRACE_TIMESTAMP: return latest_trace_timestamp_;
+    case RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT: return final_trace_instr_count_;
     default: DR_ASSERT(false); return 0;
     }
 }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3161,14 +3161,13 @@ raw2trace_t::write(raw2trace_thread_data_t *tdata, const trace_entry_t *start,
 
         for (const trace_entry_t *it = start; it < end; ++it) {
             if (type_is_instr(static_cast<trace_type_t>(it->type))) {
-                accumulate_to_statistic(
-                    tdata, RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT, 1);
+                accumulate_to_statistic(tdata,
+                                        RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT, 1);
             }
         }
-        if (!tdata->out_file->write(
-                reinterpret_cast<const char *>(start),
-                reinterpret_cast<const char *>(end) -
-                    reinterpret_cast<const char *>(start))) {
+        if (!tdata->out_file->write(reinterpret_cast<const char *>(start),
+                                    reinterpret_cast<const char *>(end) -
+                                        reinterpret_cast<const char *>(start))) {
             tdata->error = "Failed to write to output file";
             return false;
         }
@@ -3521,6 +3520,7 @@ raw2trace_t::accumulate_to_statistic(raw2trace_thread_data_t *tdata,
     case RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT:
         tdata->final_trace_instr_count += value;
         break;
+    case RAW2TRACE_STAT_MAX:
     default: DR_ASSERT(false);
     }
 }
@@ -3537,6 +3537,7 @@ raw2trace_t::get_statistic(raw2trace_statistic_t stat)
     case RAW2TRACE_STAT_EARLIEST_TRACE_TIMESTAMP: return earliest_trace_timestamp_;
     case RAW2TRACE_STAT_LATEST_TRACE_TIMESTAMP: return latest_trace_timestamp_;
     case RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT: return final_trace_instr_count_;
+    case RAW2TRACE_STAT_MAX:
     default: DR_ASSERT(false); return 0;
     }
 }

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -126,7 +126,8 @@ typedef enum {
     RAW2TRACE_STAT_RSEQ_SIDE_EXIT,
     RAW2TRACE_STAT_FALSE_SYSCALL,
     RAW2TRACE_STAT_EARLIEST_TRACE_TIMESTAMP,
-    RAW2TRACE_STAT_LATEST_TRACE_TIMESTAMP
+    RAW2TRACE_STAT_LATEST_TRACE_TIMESTAMP,
+    RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT
 } raw2trace_statistic_t;
 
 struct module_t {
@@ -1065,6 +1066,7 @@ protected:
         uint64 count_rseq_side_exit = 0;
         uint64 earliest_trace_timestamp = (std::numeric_limits<uint64>::max)();
         uint64 latest_trace_timestamp = 0;
+        uint64 final_trace_instr_count = 0;
 
         uint64 cur_chunk_instr_count = 0;
         uint64 cur_chunk_ref_count = 0;
@@ -1255,6 +1257,7 @@ protected:
     uint64 count_rseq_side_exit_ = 0;
     uint64 earliest_trace_timestamp_ = (std::numeric_limits<uint64>::max)();
     uint64 latest_trace_timestamp_ = 0;
+    uint64 final_trace_instr_count_ = 0;
 
     std::unique_ptr<module_mapper_t> module_mapper_;
 

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -127,7 +127,9 @@ typedef enum {
     RAW2TRACE_STAT_FALSE_SYSCALL,
     RAW2TRACE_STAT_EARLIEST_TRACE_TIMESTAMP,
     RAW2TRACE_STAT_LATEST_TRACE_TIMESTAMP,
-    RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT
+    RAW2TRACE_STAT_FINAL_TRACE_INSTRUCTION_COUNT,
+    // We add a MAX member so that we can iterate over all stats in unit tests.
+    RAW2TRACE_STAT_MAX,
 } raw2trace_statistic_t;
 
 struct module_t {


### PR DESCRIPTION
Adds a new raw2trace statistic that counts the number of instructions written to the final trace.

This instr count is printed out along with other raw2trace stats at the end of raw2trace conversion. It is also available for sub-classes to obtain using the get_statistic API.

Adds tests for the new and existing raw2trace stats in raw2trace_unit_tests.

Verified that the log printed by raw2trace has the same instr count as what's printed by basic_counts, for both the default .zip and `-compress none`.