### PR TITLE
i#6344: Add -record_syscall to drmemtrace

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -157,6 +157,7 @@ Further non-compatibility-affecting changes include:
  - Added several routines to the #dynamorio::drmemtrace::memtrace_stream_t interface
    for drmemtrace analysis tools: get_output_cpuid(), get_workload_id(),
    get_input_id(), get_input_interface().
+ - Added -record_syscall to drmemtrace for recording syscall parameters.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -749,6 +749,24 @@ droption_t<bool> op_record_replace_retaddr(
     "replacement, which has lower overhead, but runs the risk of breaking an "
     "application that examines or changes its own return addresses in the recorded "
     "functions.");
+droption_t<std::string> op_record_syscall(
+    DROPTION_SCOPE_CLIENT, "record_syscall", DROPTION_FLAG_ACCUMULATE,
+    OP_RECORD_FUNC_ITEM_SEP, "", "Record parameters for the specified syscall number(s).",
+    "Record the parameters and success of the specified system call number(s)."
+    " The option value should fit this format:"
+    " sycsall_number|parameter_number"
+    " E.g., -record_syscall \"2|2\" will record SYS_open's 2 parameters and whether"
+    " successful (1 for success or 0 for failure, in a function return value record)"
+    " for x86 Linux.  SYS_futex is recorded by default on Linux and this option's value"
+    " adds to futex rather than replacing it (setting futex to 0 parameters disables)."
+    " The trace identifies which syscall owns each set of parameter and return value"
+    " records via a numeric ID equal to the syscall number + TRACE_FUNC_ID_SYSCALL_BASE."
+    " Recording multiple syscalls can be achieved by using the separator"
+    " \"" OP_RECORD_FUNC_ITEM_SEP
+    "\" (e.g., -record_syscall \"202|6" OP_RECORD_FUNC_ITEM_SEP "3|1\"), or"
+    " specifying multiple -record_syscall options."
+    " It is up to the user to ensure the values are correct; a too-large parameter"
+    " count may cause tracing to fail with an error mid-run.");
 droption_t<unsigned int> op_miss_count_threshold(
     DROPTION_SCOPE_FRONTEND, "miss_count_threshold", 50000,
     "For cache miss analysis: minimum LLC miss count for a load to be eligible for "

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -57,6 +57,10 @@
 #define CACHE_TYPE_DATA "data"
 #define CACHE_TYPE_UNIFIED "unified"
 #define CACHE_PARENT_MEMORY "memory"
+// The expected pattern for a single_op_value is:
+//     function_name|function_id|arguments_num
+// where function_name can contain spaces (for instance, C++ namespace prefix)
+#define PATTERN_SEPARATOR "|"
 
 #ifdef HAS_ZIP
 #    define DEFAULT_TRACE_COMPRESSION_TYPE "zip"
@@ -169,6 +173,7 @@ extern dynamorio::droption::droption_t<bool> op_record_heap;
 extern dynamorio::droption::droption_t<std::string> op_record_heap_value;
 extern dynamorio::droption::droption_t<bool> op_record_dynsym_only;
 extern dynamorio::droption::droption_t<bool> op_record_replace_retaddr;
+extern dynamorio::droption::droption_t<std::string> op_record_syscall;
 extern dynamorio::droption::droption_t<unsigned int> op_miss_count_threshold;
 extern dynamorio::droption::droption_t<double> op_miss_frac_threshold;
 extern dynamorio::droption::droption_t<double> op_confidence_threshold;

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -39,6 +39,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -88,7 +89,7 @@ namespace drmemtrace {
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif
@@ -164,6 +165,19 @@ starts_with(const std::string &str, const std::string &with)
     if (pos == std::string::npos)
         return false;
     return pos == 0;
+}
+
+static inline std::vector<std::string>
+split_by(std::string s, std::string sep)
+{
+    size_t pos;
+    std::vector<std::string> vec;
+    do {
+        pos = s.find(sep);
+        vec.push_back(s.substr(0, pos));
+        s.erase(0, pos + sep.length());
+    } while (pos != std::string::npos);
+    return vec;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -89,7 +89,7 @@ namespace drmemtrace {
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -168,10 +168,12 @@ starts_with(const std::string &str, const std::string &with)
 }
 
 static inline std::vector<std::string>
-split_by(std::string s, std::string sep)
+split_by(std::string s, const std::string &sep)
 {
     size_t pos;
     std::vector<std::string> vec;
+    if (s.empty())
+        return vec;
     do {
         pos = s.find(sep);
         vec.push_back(s.substr(0, pos));

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1482,6 +1482,11 @@ The -record_heap parameter requests recording of a pre-determined set
 of functions related to heap allocation.  The -record_heap_value
 paramter controls the contents of this set.
 
+The tracer also supports recording system call argument and success
+values via the option -record_syscall, which functions similarly to
+-record_function with the system call number replacing the function
+name.
+
 ****************************************************************************
 \page sec_drcachesim_newtool Creating New Analysis Tools
 

--- a/clients/drcachesim/tests/offline-allasm-record-syscall.templatex
+++ b/clients/drcachesim/tests/offline-allasm-record-syscall.templatex
@@ -1,0 +1,24 @@
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+Adios world!
+.*
+          43          20:   .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
+          44          20:   .* <marker: timestamp .*>
+          45          20:   .* <marker: tid .* on core .*>
+          46          20:   .* <marker: system call 1>
+          47          20:   .* <marker: maybe-blocking system call>
+          48          20:   .* <marker: function==syscall #1>
+          49          20:   .* <marker: function argument 0x2>
+          50          20:   .* <marker: function argument 0x.*>
+          51          20:   .* <marker: function argument 0xd>
+          52          20:   .* <marker: function==syscall #1>
+          53          20:   .* <marker: function return value 0x1>
+          54          20:   .* <marker: timestamp .*>
+.*

--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -59,11 +59,6 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-// The expected pattern for a single_op_value is:
-//     function_name|function_id|arguments_num
-// where function_name can contain spaces (for instance, C++ namespace prefix)
-#define PATTERN_SEPARATOR "|"
-
 #define NOTIFY(level, ...)                     \
     do {                                       \
         if (op_verbose.get_value() >= (level)) \
@@ -382,19 +377,6 @@ func_trace_disabled_instrument_event(void *drcontext, void *tag, instrlist_t *bb
         return DR_EMIT_DEFAULT;
     return drwrap_invoke_insert_cleanup_only(drcontext, tag, bb, instr, where, for_trace,
                                              translating, user_data);
-}
-
-static std::vector<std::string>
-split_by(std::string s, std::string sep)
-{
-    size_t pos;
-    std::vector<std::string> vec;
-    do {
-        pos = s.find(sep);
-        vec.push_back(s.substr(0, pos));
-        s.erase(0, pos + sep.length());
-    } while (pos != std::string::npos);
-    return vec;
 }
 
 static void

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4294,6 +4294,10 @@ if (BUILD_CLIENTS)
         # We test counting encodings for online.
         "-instr_encodings -simulator_type basic_counts" "")
       unset(tool.drcachesim.allasm-repstr-basic-counts_rawtemp) # use preprocessor
+
+      # Test -record_syscall on SYS_write == #1 with 3 args.
+      torunonly_drcacheoff(allasm-record-syscall allasm_repstr
+        "-record_syscall 1|3" "@-simulator_type@view" "")
     endif (UNIX AND X86 AND X64)
 
     torunonly_drcacheoff(invariant_checker ${ci_shared_app}


### PR DESCRIPTION
Adds a new option -record_sysall to drmemtrace which records the parameter and success values for the given system call numbers.  Just like with -record_function, the user must specify the parameter count.

SYS_futex is left as traced by default, but it can be disabled.

Adds documentation and a test.

Further manual testing:
```
  ---------------------------------------------------------------------------
  $ rm -rf drmemtrace.*.dir; bin64/drrun -t drcachesim -offline -record_syscall '1|-3&12|4&9|2' -record_syscall '12|2&158|4' -- suite/tests/bin/simple_app && bin64/drrun -t drcachesim -indir drmemtrace.*.dir -simulator_type view 2>&1 | egrep 'system call |function'
  Error: -record_syscall invalid parameter count -3
  ---------------------------------------------------------------------------

  ---------------------------------------------------------------------------
  $ rm -rf drmemtrace.*.dir; bin64/drrun -t drcachesim -offline -record_syscall '1|-3&12|4&9|2' -record_syscall '12|2&158|4' -- suite/tests/bin/simple_app && bin64/drrun -t drcachesim -indir drmemtrace.*.dir -simulator_type view 2>&1 | egrep 'system call |function'
  <Application simple_app (484125) DynamoRIO usage error : invalid system call parameter number>
  ---------------------------------------------------------------------------

  ---------------------------------------------------------------------------
  $ rm -rf drmemtrace.*.dir; bin64/drrun -t drcachesim -offline -record_syscall '1|3&12|4&9|2' -record_syscall '12|2&158|4' -- suite/tests/bin/simple_app && bin64/drrun -t drcachesim -indir drmemtrace.*.dir -simulator_type view 2>&1 | egrep 'system call |function'
  ...
  Hello, world!
  <Stopping application simple_app (484049)>
         32411       26808:      484049 <marker: system call 12>
         32412       26808:      484049 <marker: function==syscall #12>
         32413       26808:      484049 <marker: function argument 0x0>
         32414       26808:      484049 <marker: function argument 0x7ffc87c52d4c>
         32415       26808:      484049 <marker: function==syscall #12>
         32416       26808:      484049 <marker: function return value 0x1>
         50436       41126:      484049 <marker: system call 9>
         50437       41126:      484049 <marker: function==syscall #9>
         50438       41126:      484049 <marker: function argument 0x0>
         50439       41126:      484049 <marker: function argument 0x2000>
         50440       41126:      484049 <marker: function==syscall #9>
         50441       41126:      484049 <marker: function return value 0x1>
         50980       41485:      484049 <marker: system call 21>
         52193       42391:      484049 <marker: system call 257>
         52223       42409:      484049 <marker: system call 262>
         52253       42430:      484049 <marker: system call 9>
         52254       42430:      484049 <marker: function==syscall #9>
         52255       42430:      484049 <marker: function argument 0x0>
         52256       42430:      484049 <marker: function argument 0x1b5c7>
         52257       42430:      484049 <marker: function==syscall #9>
         52258       42430:      484049 <marker: function return value 0x1>
         52274       42439:      484049 <marker: system call 3>
         54224       44056:      484049 <marker: system call 257>
         54252       44074:      484049 <marker: system call 0>
         54329       44130:      484049 <marker: system call 17>
         54455       44208:      484049 <marker: system call 262>
         54988       44591:      484049 <marker: system call 17>
         55653       45105:      484049 <marker: system call 9>
         55654       45105:      484049 <marker: function==syscall #9>
         55655       45105:      484049 <marker: function argument 0x0>
         55656       45105:      484049 <marker: function argument 0x1e1f50>
         55657       45105:      484049 <marker: function==syscall #9>
         55658       45105:      484049 <marker: function return value 0x1>
         ...
  ---------------------------------------------------------------------------
```
Fixes #6344