### PR TITLE
Fix include guard in memcache.h

### DIFF
--- a/core/unix/memcache.h
+++ b/core/unix/memcache.h
@@ -31,7 +31,7 @@
  */
 
 #ifndef _MEMCACHE_H_
-#    define _MEMCACHE_H_ 1
+#define _MEMCACHE_H_ 1
 
 void
 memcache_init(void);
@@ -62,10 +62,10 @@ memcache_remove(app_pc start, app_pc end);
 bool
 memcache_query_memory(const byte *pc, OUT dr_mem_info_t *out_info);
 
-#    if defined(DEBUG) && defined(INTERNAL)
+#if defined(DEBUG) && defined(INTERNAL)
 void
 memcache_print(file_t outf, const char *prefix);
-#    endif
+#endif
 
 void
 memcache_handle_mmap(dcontext_t *dcontext, app_pc base, size_t size, uint prot,

--- a/core/unix/memcache.h
+++ b/core/unix/memcache.h
@@ -31,7 +31,7 @@
  */
 
 #ifndef _MEMCACHE_H_
-#    define _MEMCACHE_ 1
+#    define _MEMCACHE_H_ 1
 
 void
 memcache_init(void);


### PR DESCRIPTION
The current one doesn't work because defined name is different from the one that's checked with `#ifndef`.
This can lead to including this header more than once.

Also changed `#define` formatting to be consistent with other files.