### PR TITLE
i#6354: Do not output zero-instruction (unfiltered) threads

### DIFF
--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -231,10 +231,11 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
                 thread_sequence += 'A' + static_cast<char>(input % 26);
                 cur_segment_instrs = 0;
             }
-        } else if (record.marker.type == dynamorio::drmemtrace::TRACE_TYPE_MARKER) {
+        }
+#ifdef HAS_ZIP
+        else if (record.marker.type == dynamorio::drmemtrace::TRACE_TYPE_MARKER) {
             if (record.marker.marker_type ==
                 dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID) {
-#ifdef HAS_ZIP
                 if (!op_cpu_schedule_file.get_value().empty()) {
                     int cpu = (int)record.marker.marker_value;
                     int output_cpuid = stream->get_output_cpuid();
@@ -244,9 +245,9 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
                                     cpu, ordinal, output_cpuid);
                     }
                 }
-#endif
             }
         }
+#endif
     }
 }
 

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -231,6 +231,21 @@ simulate_core(int ordinal, scheduler_t::stream_t *stream, const scheduler_t &sch
                 thread_sequence += 'A' + static_cast<char>(input % 26);
                 cur_segment_instrs = 0;
             }
+        } else if (record.marker.type == dynamorio::drmemtrace::TRACE_TYPE_MARKER) {
+            if (record.marker.marker_type ==
+                dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID) {
+#ifdef HAS_ZIP
+                if (!op_cpu_schedule_file.get_value().empty()) {
+                    int cpu = (int)record.marker.marker_value;
+                    int output_cpuid = stream->get_output_cpuid();
+                    if (cpu != output_cpuid) {
+                        FATAL_ERROR("CPU marker %d on core #%d differs from output "
+                                    "stream CPU ID %d\n",
+                                    cpu, ordinal, output_cpuid);
+                    }
+                }
+#endif
+            }
         }
     }
 }

--- a/clients/drcachesim/tools/external/example/CMakeLists.txt
+++ b/clients/drcachesim/tools/external/example/CMakeLists.txt
@@ -113,10 +113,7 @@ if (X86 AND X64 AND ZIP_FOUND)
   add_test(NAME drcachesim.non-existent_load
     COMMAND ${PROJECT_BINARY_DIR}/bin64/drrun -t drcachesim -offline
      -simulator_type non-existent -indir ${trace_dir})
-  set(nonexistent_regex "Usage error: unsupported analyzer type "non-existent".
-   Please choose cache, miss_analyzer, TLB, histogram, reuse_distance, basic_counts,
-    opcode_mix, syscall_mix, view, func_view, or some external analyzer.\nERROR: failed
-     to initialize analyzer: Failed to create analysis tool:")
+  set(nonexistent_regex "Usage error: unsupported analyzer type \"non-existent\". Please choose cache, miss_analyzer, TLB, histogram, reuse_distance, basic_counts, opcode_mix, syscall_mix, view, func_view, or some external analyzer.\nERROR: failed to initialize analyzer: Failed to create analysis tool:")
   set_tests_properties(drcachesim.non-existent_load
     PROPERTIES PASS_REGULAR_EXPRESSION "${nonexistent_regex}")
 endif ()

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -488,6 +488,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             report_if_false(shard, shard->last_instr_count_marker_ == ASM_INSTR_COUNT,
                             "Incorrect instr count marker value");
         }
+        if (!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED,
+                     shard->file_type_)) {
+            report_if_false(shard, type_is_instr(shard->prev_instr_.memref.instr.type),
+                            "An unfiltered thread should have at least 1 instruction");
+        }
     }
     if (shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
         shard->prev_entry_.marker.marker_type == TRACE_MARKER_TYPE_PHYSICAL_ADDRESS) {

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1378,22 +1378,28 @@ exit_thread_io(void *drcontext)
     }
 #endif
 
-    // Append a thread exit marker and output remaining records for this thread
-    // if we are still in a tracing mode or the thread has data from a prior window
-    // that it never wrote out.
-    if ((has_tracing_windows() &&
-         // If non-split we always want to append a thread exit marker as there
-         // wouldn't be on otherwise (split has one at the end of each window file).
-         (!op_split_windows.get_value() ||
-          // If split, we only need to write if we have data from a prior window.
-          (get_local_window(data) < tracing_window.load(std::memory_order_acquire) &&
-           !is_new_window_buffer_empty(data)))) ||
-        // Throw out empty threads even in a tracing mode.
-        ((data->bytes_written > 0 || buffer_contains_nontrivial_data(data)) &&
-         (is_in_tracing_mode(tracing_mode.load(std::memory_order_acquire)) ||
-          // For attach we switch to BBDUP_MODE_NOP but still need to finalize
-          // each (non-empty) thread.
-          (!has_tracing_windows() && align_attach_detach_endpoints())))) {
+    // Append a thread exit marker and output remaining records for this thread if it has
+    // data from a prior window that it never wrote out.
+    bool has_prior_window_data = has_tracing_windows() &&
+        // If non-split we always want to append a thread exit marker as there
+        // wouldn't be one otherwise (split has one at the end of each window file).
+        (!op_split_windows.get_value() ||
+         // If split, we only need to write if we have data from a prior window.
+         (get_local_window(data) < tracing_window.load(std::memory_order_acquire) &&
+          !is_new_window_buffer_empty(data)));
+
+    // Also append an exit for non-empty threads (those that wrote buffers out before,
+    // or have a current non-empty buffer).  We completely omit empty threads.
+    bool is_not_empty =
+        (data->bytes_written > 0 || buffer_contains_nontrivial_data(data)) &&
+        // XXX: We may not need any of the conditions below?  Should revisit
+        // whether a current-nop window-up-to-date needs to be excluded here.
+        (is_in_tracing_mode(tracing_mode.load(std::memory_order_acquire)) ||
+         // For attach we switch to BBDUP_MODE_NOP but still need to finalize
+         // each (non-empty) thread.
+         (!has_tracing_windows() && align_attach_detach_endpoints()));
+
+    if (has_prior_window_data || is_not_empty) {
         BUF_PTR(data->seg_base) += instru->append_thread_exit(
             BUF_PTR(data->seg_base), dr_get_thread_id(drcontext));
         process_and_output_buffer(drcontext,

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1381,19 +1381,19 @@ exit_thread_io(void *drcontext)
     // Append a thread exit marker and output remaining records for this thread
     // if we are still in a tracing mode or the thread has data from a prior window
     // that it never wrote out.
-    if (is_in_tracing_mode(tracing_mode.load(std::memory_order_acquire)) ||
-        (has_tracing_windows() &&
+    if ((has_tracing_windows() &&
          // If non-split we always want to append a thread exit marker as there
          // wouldn't be on otherwise (split has one at the end of each window file).
          (!op_split_windows.get_value() ||
           // If split, we only need to write if we have data from a prior window.
           (get_local_window(data) < tracing_window.load(std::memory_order_acquire) &&
            !is_new_window_buffer_empty(data)))) ||
-        // For attach we switch to BBDUP_MODE_NOP but still need to finalize
-        // each thread.  However, we omit threads that did nothing the entire time
-        // we were attached.
-        (!has_tracing_windows() && align_attach_detach_endpoints() &&
-         (data->bytes_written > 0 || buffer_contains_nontrivial_data(data)))) {
+        // Throw out empty threads even in a tracing mode.
+        ((data->bytes_written > 0 || buffer_contains_nontrivial_data(data)) &&
+         (is_in_tracing_mode(tracing_mode.load(std::memory_order_acquire)) ||
+          // For attach we switch to BBDUP_MODE_NOP but still need to finalize
+          // each (non-empty) thread.
+          (!has_tracing_windows() && align_attach_detach_endpoints())))) {
         BUF_PTR(data->seg_base) += instru->append_thread_exit(
             BUF_PTR(data->seg_base), dr_get_thread_id(drcontext));
         process_and_output_buffer(drcontext,


### PR DESCRIPTION
Tightens the normal-mode output rule to discard a thread with no instructions (keeping the no-data check for i-filtered modes) and expands the empty-thread behavior to include regular exit runs and not just detach.

Adds the scheduler_launcher CPU check from PR #6355.

It is not easy to create a test with a thread that reliably executes zero instructions yet still outputs some data.  I added an invariant check for a zero-instruction thread and confirmed it fires on the trace in PR #6355:

```
$ bin64/drrun -t drcachesim -simulator_type invariant_checker -indir ~/tmp/drmemtrace.schedtest.x64
Trace invariant failure in T85300 at ref # 12 (0 instrs since timestamp 13341391214912820): An unfiltered thread should have at least 1 instruction
```

Issue: #6354