### PR TITLE
i#3544 RV64: Fix invalid instr width handling when decoding

### DIFF
--- a/core/ir/riscv64/codec.c
+++ b/core/ir/riscv64/codec.c
@@ -1496,7 +1496,6 @@ decode_common(dcontext_t *dcontext, byte *pc, byte *orig_pc, instr_t *instr)
     default:
         LOG(THREAD, LOG_INTERP, 3, "decode: unhandled instruction width %d at " PFX "\n",
             width, pc);
-        CLIENT_ASSERT(false, "decode: invalid instr width");
         return NULL;
     }
     next_pc = pc + width;

--- a/core/ir/riscv64/codec.h
+++ b/core/ir/riscv64/codec.h
@@ -261,7 +261,7 @@ typedef enum {
 #define SET_FIELD(v, high, low) (((v) & ((1ULL << (high - low + 1)) - 1)) << low)
 #define SIGN_EXTEND(val, val_sz) (((int32_t)(val) << (32 - (val_sz))) >> (32 - (val_sz)))
 
-/* Calculate instruction width.
+/* Calculate instruction width, see page 8 of Volume I: RISC-V Unprivileged ISA V20191213.
  *
  * Returns a negative number on an invalid instruction width.
  */
@@ -280,12 +280,13 @@ instruction_width(uint16_t lower16b)
     /* ...xxxxxxxxx0111111 -> 64-bit */
     else if (TESTALL(0b0111111, GET_FIELD(lower16b, 6, 0)))
         return 8;
-    /* ...xnnnxxxxx1111111 -> nnn != 0b111 */
+    /* ...xnnnxxxxx1111111 -> (80+16*nnn)-bit (nnn != 111) */
     else if (TESTALL(0b1111111, GET_FIELD(lower16b, 6, 0)) &&
              !TESTALL(0b111, GET_FIELD(lower16b, 14, 12)))
-        return 80 + 16 * GET_FIELD(lower16b, 14, 12);
+        return (10 + 2 * GET_FIELD(lower16b, 14, 12));
+    /* Reserved for ≥192-bits. */
     else
-        return 0;
+        return -1;
 }
 
 /* Return instr_info_t for a given opcode. */

--- a/suite/tests/api/ir_riscv64.c
+++ b/suite/tests/api/ir_riscv64.c
@@ -101,6 +101,21 @@ test_instr_encoding_failure(void *dc, uint opcode, app_pc instr_pc, instr_t *ins
     instr_destroy(dc, instr);
 }
 
+static byte *
+test_instr_decoding_failure(void *dc, uint raw_instr)
+{
+    instr_t *decin;
+    byte *pc;
+
+    *(uint *)buf = raw_instr;
+    decin = instr_create(dc);
+    pc = decode(dc, buf, decin);
+    /* Returns NULL on failure. */
+    ASSERT(pc == NULL);
+    instr_destroy(dc, decin);
+    return pc;
+}
+
 static void
 test_instr_encoding_jal_or_branch(void *dc, uint opcode, instr_t *instr)
 {
@@ -1864,6 +1879,18 @@ test_insert_mov_immed_arch(void *dc)
     instrlist_destroy(dc, ilist);
 }
 
+static void
+test_decode_bad_data(void *dc)
+{
+    instr_t *instr;
+
+    /* Unhandled instruction width. */
+    test_instr_decoding_failure(dc, 0xabababab);
+    test_instr_decoding_failure(dc, 0xffffffff);
+    /* Unknown instruction. */
+    test_instr_decoding_failure(dc, 0xb);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1921,6 +1948,9 @@ main(int argc, char *argv[])
 
     test_xinst(dcontext);
     print("test_xinst complete\n");
+
+    test_decode_bad_data(dcontext);
+    print("test_decode_bad_data complete\n");
 
     print("All tests complete\n");
     return 0;

--- a/suite/tests/api/ir_riscv64.expect
+++ b/suite/tests/api/ir_riscv64.expect
@@ -321,4 +321,5 @@ sub    a0 a1 -> a0
 addi   a0 0xffffffd6 -> a0
 jalr   a0 0x0 -> ra
 test_xinst complete
+test_decode_bad_data complete
 All tests complete


### PR DESCRIPTION
Currently, valid RISC-V instruction length can be 16-bit (compressed instruction) or 32-bit, but according to the "Extended Instruction-Length Encoding" section of the RISC-V Unprivileged Specification 20191213 on page 8, instruction length can be greater than 32-bit in the future.

Our RISC-V instruction_width() function follows the spec except that it returns the wrong length for the last case. While this patch fixes that, it may still return an unsupported length for bad data.

While performing decoding, sometimes we decode bad data and expect the decoder to print an error message and carry on. Therefore, we should not assert unsupported instruction length, this patch also removes the corresponding assert in decode_common().

Issue: #3544