### PR TITLE
i#3544 RV64: Implement insert_exit_stub_other_flags

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1578,7 +1578,7 @@ add_patch_entry_internal(patch_list_t *patch, instr_t *instr, ushort patch_flags
 cache_pc
 get_direct_exit_target(dcontext_t *dcontext, uint flags);
 
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
 size_t
 get_ibl_entry_tls_offs(dcontext_t *dcontext, cache_pc ibl_entry);
 #endif

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -1068,11 +1068,17 @@ fill_with_nops(dr_isa_mode_t isa_mode, byte *addr, size_t size);
 #    define RISCV64_INSTR_COMPRESSED_SIZE 2
 #    define FRAGMENT_BASE_PREFIX_SIZE(flags) RISCV64_INSTR_SIZE * 2
 #    define DIRECT_EXIT_STUB_SIZE(flags) \
-        (16 * RISCV64_INSTR_SIZE) /* see insert_exit_stub_other_flags() */
+        (13 * RISCV64_INSTR_SIZE) +      \
+            DIRECT_EXIT_STUB_DATA_SZ /* See insert_exit_stub_other_flags(). */
 #    define FRAG_IS_32(flags) false
 #    define PC_AS_JMP_TGT(isa_mode, pc) pc
 #    define PC_AS_LOAD_TGT(isa_mode, pc) pc
-#    define DIRECT_EXIT_STUB_DATA_SLOT_ALIGNMENT_PADDING 4
+/* Size of data slot used to store address of linked fragment or fcache return routine.
+ * We reserve 16 bytes for the 8 byte address, so that we can store it in an 8-byte
+ * aligned address (unlike AArch64, 12 bytes is not enough as RISC-V instructions can
+ * be 2 bytes long). This is required for atomicity of write operations.
+ */
+#    define DIRECT_EXIT_STUB_DATA_SLOT_ALIGNMENT_PADDING 8
 #    define DIRECT_EXIT_STUB_DATA_SZ \
         (sizeof(app_pc) + DIRECT_EXIT_STUB_DATA_SLOT_ALIGNMENT_PADDING)
 #    define STUB_COARSE_DIRECT_SIZE(flags) (ASSERT_NOT_IMPLEMENTED(false), 0)

--- a/core/arch/emit_utils_shared.c
+++ b/core/arch/emit_utils_shared.c
@@ -133,6 +133,9 @@
         (FRAG_IS_32(flags) ? STUB_INDIRECT_SIZE32 : STUB_INDIRECT_SIZE64)
 #elif defined(AARCH64)
 #    define STUB_INDIRECT_SIZE(flags) (7 * AARCH64_INSTR_SIZE)
+#elif defined(RISCV64)
+#    define STUB_INDIRECT_SIZE(flags) \
+        (13 * RISCV64_INSTR_SIZE) /* See insert_exit_stub_other_flags(). */
 #else
 /* indirect stub is parallel to the direct one minus the data slot */
 #    define STUB_INDIRECT_SIZE(flags) \
@@ -5508,7 +5511,7 @@ special_ibl_xfer_is_thread_private(void)
 #endif
 }
 
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
 size_t
 get_ibl_entry_tls_offs(dcontext_t *dcontext, cache_pc ibl_entry)
 {
@@ -5519,7 +5522,7 @@ get_ibl_entry_tls_offs(dcontext_t *dcontext, cache_pc ibl_entry)
     DEBUG_DECLARE(bool is_ibl =)
     get_ibl_routine_type_ex(dcontext, ibl_entry, &ibl_type);
     ASSERT(is_ibl);
-    /* FIXME i#1575: coarse-grain NYI on ARM/AArch64 */
+    /* FIXME i#1575: coarse-grain NYI on ARM/AArch64/RISCV64 */
     ASSERT(ibl_type.source_fragment_type != IBL_COARSE_SHARED);
     if (IS_IBL_TRACE(ibl_type.source_fragment_type)) {
         if (IS_IBL_LINKED(ibl_type.link_state))

--- a/core/arch/riscv64/emit_utils.c
+++ b/core/arch/riscv64/emit_utils.c
@@ -75,8 +75,8 @@ nop_pad_ilist(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist, bool emit
     return 0;
 }
 
-/* Returns addr for the target_pc data slot of the given stub. The slot starts at the
- * 8-byte aligned region in the 12-byte slot reserved in the stub.
+/* Returns writable addr for the target_pc data slot of the given stub. The slot starts at
+ * the 8-byte aligned region in the 16-byte slot reserved in the stub.
  */
 static ptr_uint_t *
 get_target_pc_slot(fragment_t *f, cache_pc stub_pc)
@@ -104,12 +104,12 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
     ushort *pc = write_stub_pc, *new_pc;
     uint num_nops_needed = 0;
     uint max_instrs = 0;
-    uint reminder = (uint64)pc & 0x3;
+    uint remainder = (uint64)pc & 0x3;
 
     /* Insert a c.nop at top for non-aligned stub_pc, so instructions after are all
      * aligned. */
-    if (reminder != 0) {
-        ASSERT(reminder == 2);
+    if (remainder != 0) {
+        ASSERT(remainder == 2);
         *pc++ = RAW_C_NOP_INST;
     }
 
@@ -188,7 +188,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
                (byte *)pc + 2 == (byte *)target_pc_slot ||
                (byte *)pc + 4 == (byte *)target_pc_slot ||
                (byte *)pc + 6 == (byte *)target_pc_slot);
-        pc += (DIRECT_EXIT_STUB_DATA_SZ - reminder) / sizeof(ushort);
+        pc += (DIRECT_EXIT_STUB_DATA_SZ - remainder) / sizeof(ushort);
 
         /* We start off with the fcache-return routine address in the slot.
          * RISCV64 uses shared gencode. So, fcache_return routine address should be
@@ -240,7 +240,7 @@ insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
         }
 
         *pc++ = RAW_C_NOP_INST;
-        if (reminder == 0)
+        if (remainder == 0)
             *pc++ = RAW_C_NOP_INST;
     }
     instrlist_clear(dcontext, &ilist);

--- a/core/arch/riscv64/emit_utils.c
+++ b/core/arch/riscv64/emit_utils.c
@@ -33,7 +33,13 @@
 #include <stdint.h>
 
 #include "../globals.h"
+#include "instr_create_shared.h"
+#include "instrlist.h"
+#include "instrument.h"
 #include "arch.h"
+
+#define APP instrlist_meta_append
+#define PRE instrlist_meta_preinsert
 
 #define RAW_NOP_INST 0x00000013
 #define RAW_NOP_INST_SZ 4
@@ -69,13 +75,177 @@ nop_pad_ilist(dcontext_t *dcontext, fragment_t *f, instrlist_t *ilist, bool emit
     return 0;
 }
 
+/* Returns addr for the target_pc data slot of the given stub. The slot starts at the
+ * 8-byte aligned region in the 12-byte slot reserved in the stub.
+ */
+static ptr_uint_t *
+get_target_pc_slot(fragment_t *f, cache_pc stub_pc)
+{
+    return (ptr_uint_t *)ALIGN_FORWARD(
+        vmcode_get_writable_addr(stub_pc + DIRECT_EXIT_STUB_SIZE(f->flags) -
+                                 DIRECT_EXIT_STUB_DATA_SZ),
+        8);
+}
+
+/* Emit code for the exit stub at stub_pc. Return the size of the emitted code in bytes.
+ * This routine assumes that the caller will take care of any cache synchronization
+ * necessary. The stub is unlinked initially, except coarse grain indirect exits, which
+ * are always linked.
+ */
 int
 insert_exit_stub_other_flags(dcontext_t *dcontext, fragment_t *f, linkstub_t *l,
                              cache_pc stub_pc, ushort l_flags)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
-    return 0;
+    instrlist_t ilist;
+    instrlist_init(&ilist);
+
+    ushort *write_stub_pc = (ushort *)vmcode_get_writable_addr(stub_pc);
+    /* Declare pc as ushort to help handling of C extension instructions. */
+    ushort *pc = write_stub_pc, *new_pc;
+    uint num_nops_needed = 0;
+    uint max_instrs = 0;
+    uint reminder = (uint64)pc & 0x3;
+
+    /* Insert a c.nop at top for non-aligned stub_pc, so instructions after are all
+     * aligned. */
+    if (reminder != 0) {
+        ASSERT(reminder == 2);
+        *pc++ = RAW_C_NOP_INST;
+    }
+
+    /* FIXME i#3544: coarse-grain NYI on RISCV64 */
+    ASSERT_NOT_IMPLEMENTED(!TEST(FRAG_COARSE_GRAIN, f->flags));
+
+    if (LINKSTUB_DIRECT(l_flags)) {
+        APP(&ilist,
+            INSTR_CREATE_sd(dcontext, OPND_CREATE_MEMPTR(dr_reg_stolen, TLS_REG0_SLOT),
+                            opnd_create_reg(DR_REG_A0)));
+        max_instrs++;
+        APP(&ilist,
+            INSTR_CREATE_sd(dcontext, OPND_CREATE_MEMPTR(dr_reg_stolen, TLS_REG1_SLOT),
+                            opnd_create_reg(DR_REG_A1)));
+        max_instrs++;
+
+        /* Insert an anchor for the subsequent insert_mov_immed_ptrsz() call. */
+        instr_t *nop = INSTR_CREATE_addi(dcontext, opnd_create_reg(DR_REG_X0),
+                                         opnd_create_reg(DR_REG_X0),
+                                         opnd_create_immed_int(0, OPSZ_12b));
+        APP(&ilist, nop);
+
+        insert_mov_immed_ptrsz(dcontext, (ptr_int_t)l, opnd_create_reg(DR_REG_A0), &ilist,
+                               nop, NULL, NULL);
+        /* Up to 8 instructions will be generated, see mov64(). */
+        max_instrs += 8;
+
+        instrlist_remove(&ilist, nop);
+        instr_destroy(dcontext, nop);
+
+        new_pc = (ushort *)instrlist_encode(dcontext, &ilist, (byte *)pc, false);
+        instrlist_clear(dcontext, &ilist);
+
+        /* We can use INSTR_CREATE_auipc() here, but it's easier to use a raw value.
+         * Now, A1 holds the current pc - RISCV64_INSTR_SIZE.
+         */
+        *(uint *)new_pc = 0x00000597; /* auipc a1, 0x0 */
+        new_pc += 2;
+        max_instrs++;
+
+        ptr_uint_t *target_pc_slot = get_target_pc_slot(f, stub_pc);
+        ASSERT(new_pc < (ushort *)target_pc_slot);
+        uint target_pc_slot_offs =
+            (byte *)target_pc_slot - (byte *)new_pc + RISCV64_INSTR_SIZE;
+
+        instrlist_init(&ilist);
+
+        /* Now, A1 holds the address of fcache_return routine. */
+        APP(&ilist,
+            INSTR_CREATE_ld(dcontext, opnd_create_reg(DR_REG_A1),
+                            OPND_CREATE_MEMPTR(DR_REG_A1, target_pc_slot_offs)));
+        max_instrs++;
+
+        APP(&ilist, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(DR_REG_A1)));
+        max_instrs++;
+
+        new_pc = (ushort *)instrlist_encode(dcontext, &ilist, (byte *)new_pc, false);
+
+        num_nops_needed = max_instrs - ((uint *)new_pc - (uint *)pc);
+        pc = new_pc;
+
+        /* Fill up with NOPs, depending on how many instructions we needed to move
+         * the immediate into a register. Ideally we would skip adding NOPs, but
+         * lots of places expect the stub size to be fixed.
+         */
+        for (uint j = 0; j < num_nops_needed; j++) {
+            *(uint *)pc = RAW_NOP_INST;
+            pc += 2;
+        }
+
+        /* The final slot is a data slot, which will hold the address of either
+         * the fcache-return routine or the linked fragment. We reserve 16 bytes
+         * and use the 8-byte aligned region of 8 bytes within it.
+         */
+        ASSERT((byte *)pc == (byte *)target_pc_slot ||
+               (byte *)pc + 2 == (byte *)target_pc_slot ||
+               (byte *)pc + 4 == (byte *)target_pc_slot ||
+               (byte *)pc + 6 == (byte *)target_pc_slot);
+        pc += (DIRECT_EXIT_STUB_DATA_SZ - reminder) / sizeof(ushort);
+
+        /* We start off with the fcache-return routine address in the slot.
+         * RISCV64 uses shared gencode. So, fcache_return routine address should be
+         * same, no matter which thread creates/unpatches the stub.
+         */
+        ASSERT(fcache_return_routine(dcontext) == fcache_return_routine(GLOBAL_DCONTEXT));
+        *target_pc_slot = (ptr_uint_t)fcache_return_routine(dcontext);
+        ASSERT((ptr_int_t)((byte *)pc - (byte *)write_stub_pc) ==
+               DIRECT_EXIT_STUB_SIZE(l_flags));
+    } else {
+        /* Stub starts out unlinked. */
+        cache_pc exit_target =
+            get_unlinked_entry(dcontext, EXIT_TARGET_TAG(dcontext, f, l));
+        APP(&ilist,
+            INSTR_CREATE_sd(dcontext, OPND_CREATE_MEMPTR(dr_reg_stolen, TLS_REG0_SLOT),
+                            opnd_create_reg(DR_REG_A0)));
+        max_instrs++;
+        APP(&ilist,
+            INSTR_CREATE_sd(dcontext, OPND_CREATE_MEMPTR(dr_reg_stolen, TLS_REG1_SLOT),
+                            opnd_create_reg(DR_REG_A1)));
+        max_instrs++;
+
+        instr_t *next_instr = INSTR_CREATE_ld(
+            dcontext, opnd_create_reg(DR_REG_A1),
+            OPND_CREATE_MEMPTR(dr_reg_stolen,
+                               get_ibl_entry_tls_offs(dcontext, exit_target)));
+        APP(&ilist, next_instr);
+        max_instrs++;
+        insert_mov_immed_ptrsz(dcontext, (ptr_int_t)l, opnd_create_reg(DR_REG_A0), &ilist,
+                               next_instr, NULL, NULL);
+        /* Up to 8 instructions will be generated, see mov64(). */
+        max_instrs += 8;
+
+        APP(&ilist, XINST_CREATE_jump_reg(dcontext, opnd_create_reg(DR_REG_A1)));
+        max_instrs++;
+
+        new_pc = (ushort *)instrlist_encode(dcontext, &ilist, (byte *)pc, false);
+
+        num_nops_needed = max_instrs - ((uint *)new_pc - (uint *)pc);
+        pc = new_pc;
+
+        /* Fill up with NOPs, depending on how many instructions we needed to move
+         * the immediate into a register. Ideally we would skip adding NOPs, but
+         * lots of places expect the stub size to be fixed.
+         */
+        for (uint j = 0; j < num_nops_needed; j++) {
+            *(uint *)pc = RAW_NOP_INST;
+            pc += 2;
+        }
+
+        *pc++ = RAW_C_NOP_INST;
+        if (reminder == 0)
+            *pc++ = RAW_C_NOP_INST;
+    }
+    instrlist_clear(dcontext, &ilist);
+
+    return (int)((byte *)pc - (byte *)write_stub_pc);
 }
 
 bool


### PR DESCRIPTION
The implementation of this function is roughly the same as AArch64, except for some additional handling of C extension instructions.

Issue: #3544