### PR TITLE
i#6342 func trace opt: Make symbol skipping visible

### DIFF
--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -237,7 +237,7 @@ instru_funcs_module_load(void *drcontext, const module_data_t *mod, bool loaded)
     // on Windows and the fewer libs we check the better (i#6342), unless we're
     // statically linked (when the app itself might be excluded here).
     if (dr_memory_is_dr_internal(mod->start) || dr_memory_is_in_client(mod->start)) {
-        NOTIFY(3, "Not looking for symbols in DR/client library %s\n",
+        NOTIFY(1, "Not looking for symbols in DR/client library %s\n",
                get_module_basename(mod));
         return;
     }


### PR DESCRIPTION
Makes the function trace symbol skipping for a module considered a client or DR more visible to more easily diagnose missing function tracing.

Issue: #6342