### PR TITLE
i#6364: add start_instruction to schedule entry comparator.

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1615,6 +1615,8 @@ check_schedule_file()
     sched.emplace_back(TID_BASE + 1, TIMESTAMP_BASE, CPU_BASE + 2, 0);
     sched.emplace_back(TID_BASE, TIMESTAMP_BASE + 1, CPU_BASE + 1, 2);
     sched.emplace_back(TID_BASE + 1, TIMESTAMP_BASE + 2, CPU_BASE, 1);
+    // Include records with the same thread ID, timestamp, and CPU, but
+    // different start_instruction is being used for comparison.
     sched.emplace_back(TID_BASE + 2, TIMESTAMP_BASE + 3, CPU_BASE + 2, 3);
     sched.emplace_back(TID_BASE + 2, TIMESTAMP_BASE + 3, CPU_BASE + 2, 4);
     {
@@ -1650,6 +1652,8 @@ check_schedule_file()
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
             gen_instr(TID_BASE + 2, 4),
+            // Markers for the second schedule entry with the same thread ID,
+            // timestamp, and CPU as the previous one with a different start_instruction.
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
         };

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1616,6 +1616,7 @@ check_schedule_file()
     sched.emplace_back(TID_BASE, TIMESTAMP_BASE + 1, CPU_BASE + 1, 2);
     sched.emplace_back(TID_BASE + 1, TIMESTAMP_BASE + 2, CPU_BASE, 1);
     sched.emplace_back(TID_BASE + 2, TIMESTAMP_BASE + 3, CPU_BASE + 2, 3);
+    sched.emplace_back(TID_BASE + 2, TIMESTAMP_BASE + 3, CPU_BASE + 2, 4);
     {
         std::ofstream serial_file(serial_fname, std::ofstream::binary);
         if (!serial_file)
@@ -1649,6 +1650,8 @@ check_schedule_file()
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
             gen_instr(TID_BASE + 2, 4),
+            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
+            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
         };
         std::ifstream serial_read(serial_fname, std::ifstream::binary);
         if (!serial_read)
@@ -1715,6 +1718,9 @@ check_schedule_file()
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
             gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
             gen_instr(TID_BASE + 2, 3),
+            gen_instr(TID_BASE + 2, 4),
+            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
+            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
         };
         std::ifstream serial_read(serial_fname, std::ifstream::binary);
         if (!serial_read)

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -953,7 +953,9 @@ invariant_checker_t::check_schedule_data(per_shard_t *global)
         if (l.cpu != r.cpu)
             return l.cpu < r.cpu;
         // See comment in raw2trace_t::aggregate_and_write_schedule_files
-        return l.thread < r.thread;
+        if (l.thread != r.thread)
+            return l.thread < r.thread;
+        return l.start_instruction < r.start_instruction;
     };
     std::sort(serial.begin(), serial.end(), schedule_entry_comparator);
     // After i#6299, these files collapse same-thread entries.
@@ -1023,8 +1025,12 @@ invariant_checker_t::check_schedule_data(per_shard_t *global)
     for (auto &keyval : cpu2sched_file) {
         std::sort(keyval.second.begin(), keyval.second.end(),
                   [](const schedule_entry_t &l, const schedule_entry_t &r) {
-                      if (l.timestamp == r.timestamp)
-                          return l.thread < r.thread;
+                      if (l.timestamp == r.timestamp) {
+                          if (l.thread == r.thread)
+                              return l.start_instruction < r.start_instruction;
+                          else
+                              return l.thread < r.thread;
+                      }
                       return l.timestamp < r.timestamp;
                   });
         // After i#6299, these files collapse same-thread entries.

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1023,16 +1023,7 @@ invariant_checker_t::check_schedule_data(per_shard_t *global)
         cpu2sched_file[next.cpu].push_back(next);
     }
     for (auto &keyval : cpu2sched_file) {
-        std::sort(keyval.second.begin(), keyval.second.end(),
-                  [](const schedule_entry_t &l, const schedule_entry_t &r) {
-                      if (l.timestamp == r.timestamp) {
-                          if (l.thread == r.thread)
-                              return l.start_instruction < r.start_instruction;
-                          else
-                              return l.thread < r.thread;
-                      }
-                      return l.timestamp < r.timestamp;
-                  });
+        std::sort(keyval.second.begin(), keyval.second.end(), schedule_entry_comparator);
         // After i#6299, these files collapse same-thread entries.
         // We create both types of schedule and select which to compare against.
         std::vector<schedule_entry_t> redux;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1313,12 +1313,7 @@ raw2trace_t::aggregate_and_write_schedule_files()
     if (cpu_schedule_file_ == nullptr)
         return "";
     for (auto &keyval : cpu2sched) {
-        std::sort(keyval.second.begin(), keyval.second.end(),
-                  [](const schedule_entry_t &l, const schedule_entry_t &r) {
-                      if (l.timestamp != r.timestamp)
-                          return l.timestamp < r.timestamp;
-                      return l.start_instruction < r.start_instruction;
-                  });
+        std::sort(keyval.second.begin(), keyval.second.end(), schedule_entry_comparator);
         // Collapse same-thread entries.
         std::vector<schedule_entry_t> redux;
         for (const auto &entry : keyval.second) {


### PR DESCRIPTION
We have captured traces from the same thread with the same CPU and timestamp, their start_instructions are tens of instructions apart.

The current comparators in raw2trace and the invariant checker do not take start_instruction into account. And it leads to indeterministic sorting results. It causes the invariant checker to report cpu/serial entry does not match trace error when raw2trace and the invariant checker sort the entries differently.

The change is to compare the start_instruction when two schedule entries have the same CPU, thread ID, and timestamp.
And add a unit test to cover the case where two schedule entries have the same CPU, thread ID, and timestamp, but different start_instruction.

Fixes: #6364