### PR TITLE
i#6367: Insert FILTER_ENDPOINT when going to TRACE from COUNT also.

### DIFF
--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1101,7 +1101,8 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
     // thread triggered the switch.
     ptr_int_t mode = tracing_mode.load(std::memory_order_acquire);
     ptr_int_t local_mode = get_local_mode(data);
-    if (local_mode != mode && mode == BBDUP_MODE_TRACE) {
+    if (op_L0_filter_until_instrs.get_value() && local_mode != mode &&
+        mode == BBDUP_MODE_TRACE) {
         if (local_mode == BBDUP_MODE_L0_FILTER || local_mode == BBDUP_MODE_COUNT) {
             NOTIFY(0, "Thread %d: filter mode changed\n", dr_get_thread_id(drcontext));
 

--- a/clients/drcachesim/tracer/output.cpp
+++ b/clients/drcachesim/tracer/output.cpp
@@ -1100,8 +1100,9 @@ process_and_output_buffer(void *drcontext, bool skip_size_cap)
     // Switch to instruction-tracing mode by adding FILTER_ENDPOINT marker if another
     // thread triggered the switch.
     ptr_int_t mode = tracing_mode.load(std::memory_order_acquire);
-    if (get_local_mode(data) != mode) {
-        if (get_local_mode(data) == BBDUP_MODE_L0_FILTER) {
+    ptr_int_t local_mode = get_local_mode(data);
+    if (local_mode != mode && mode == BBDUP_MODE_TRACE) {
+        if (local_mode == BBDUP_MODE_L0_FILTER || local_mode == BBDUP_MODE_COUNT) {
             NOTIFY(0, "Thread %d: filter mode changed\n", dr_get_thread_id(drcontext));
 
             // If a switch occurred, then it is possible that the buffer


### PR DESCRIPTION
For BIMODAL traces (see https://github.com/DynamoRIO/dynamorio/issues/5199), the normal transition is from COUNT to L0_FILTER to TRACE. But some threads may transition from COUNT to TRACE directly e.g., if they were not scheduled during L0_FILTER mode. In this case, the FILTER_ENDPOINT marker is not inserted currently, which leads to raw2trace failures.

An example cmd line that reproduces the bug is shown below. Note that there is only one worker thread which transitions through L0_FILTER and TRACE mode while the main thread is still in COUNT mode.

```
bin64/drrun -t drcachesim -offline \
-trace_after_instrs 2200K -L0_filter_until_instrs 10K -max_trace_size 10K -- ./threadsig 1 1000
```

Issue: #6367