### PR TITLE
i#5036 A64 scatter/gather: Fix drcachesim offline tracing

### DIFF
--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -955,8 +955,7 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
         // view by expanding the instr in raw2trace (e.g. using
         // drx_expand_scatter_gather) when building the ilist.
         if (drutil_instr_is_stringop_loop(instr)
-            // TODO i#5036: Scatter/gather support incomplete on AArch64.
-            IF_X86(|| instr_is_scatter(instr) || instr_is_gather(instr))) {
+            IF_X86_OR_AARCH64(|| instr_is_scatter(instr) || instr_is_gather(instr))) {
             return;
         }
         if (drmgr_is_emulation_start(instr) || drmgr_is_emulation_end(instr)) {

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -955,7 +955,7 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
         // view by expanding the instr in raw2trace (e.g. using
         // drx_expand_scatter_gather) when building the ilist.
         if (drutil_instr_is_stringop_loop(instr)
-            IF_X86_OR_AARCH64(|| instr_is_scatter(instr) || instr_is_gather(instr))) {
+                IF_X86_OR_AARCH64(|| instr_is_scatter(instr) || instr_is_gather(instr))) {
             return;
         }
         if (drmgr_is_emulation_start(instr) || drmgr_is_emulation_end(instr)) {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2627,7 +2627,7 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, INOUT app_pc *pc,
         desc->packed_ |= kIsAarch64DcZvaMask;
 #endif
 
-#ifdef X86
+#if defined(X86) || defined(AARCH64)
     if (instr_is_scatter(instr) || instr_is_gather(instr))
         desc->packed_ |= kIsScatterOrGatherMask;
 #endif

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -537,6 +537,14 @@ typedef struct _instr_t instr_t;
 #    define IF_NOT_X64_OR_ARM(x) x
 #endif
 
+#if defined(X86) || defined(AARCH64)
+#    define IF_X86_OR_AARCH64(x) x
+#    define IF_NOT_X86_OR_AARCH64(x)
+#else
+#    define IF_X86_OR_AARCH64(x)
+#    define IF_NOT_X86_OR_AARCH64(x) x
+#endif
+
 /* Convenience defines for cross-platform printing.
  * For printing pointers: if using system printf, for %p gcc prepends 0x and uses
  * lowercase while cl does not prepend, puts leading 0's, and uses uppercase.


### PR DESCRIPTION
A couple of places in the drcachesim tracer there was code that handles scatter/gather instructions that was guarded by #ifdef X86 which meant offline traces that include scatter/gather instructions were producing errors on AArch64.

For example running the aarch64 scattergather test app:
```
$bin64/drrun -t drcachesim -offline -- suite/tests/bin/client.drx-scattergather
$bin64/drrun -t drcachesim -indir drmemtrace.client.drx-scattergather.662655.1769.dir
```

produced the error:
```
ERROR: failed to initialize analyzer: raw2trace failed: Failed to process file for thread 662655: memref entry found outside of bb
```

This commit enables the code on AArch64 as well and fixes the error.

Issue: #5036