### PR TITLE
i#6373: handle back-to-back signals after an rseq abort.

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -474,8 +474,8 @@ check_sane_control_flow()
     {
         std::vector<memref_t> memrefs = {
             gen_instr(TID, /*pc=*/101, /*size=*/1),
-            // The RSEQ_ABORT marker is always follwed by a KERNEL_EVENT marker.
             gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
+            // This is the signal which caused the RSEQ abort.
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
             // We get a signal after the RSEQ abort.
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
@@ -497,8 +497,8 @@ check_sane_control_flow()
     {
         std::vector<memref_t> memrefs = {
             gen_instr(TID, /*pc=*/101, /*size=*/1),
-            // The RSEQ_ABORT marker is always follwed by a KERNEL_EVENT marker.
             gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
+            // This is the signal which caused the RSEQ abort.
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
             // We get a signal after the RSEQ abort.
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
@@ -507,6 +507,8 @@ check_sane_control_flow()
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
             gen_instr(TID, /*pc=*/301, /*size=*/1),
             gen_instr(TID, /*pc=*/302, /*size=*/1),
+            // The kernel event marker should point to the previous instruction
+            // at PC 302, instead of 301.
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
         };
         if (!run_checker(
@@ -1879,8 +1881,8 @@ check_branch_decoration()
             gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
             gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID, /*pc=*/101, /*size=*/1,
                            /*target=*/0),
-            // The RSEQ_ABORT marker is always follwed by a KERNEL_EVENT marker.
             gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
+            // This is the signal which caused the RSEQ abort.
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
             // We get a signal after the RSEQ abort.
             gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1131,8 +1131,12 @@ invariant_checker_t::check_for_pc_discontinuity(
           shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
           shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT)) ||
 #ifdef UNIX
-        // Same PC is allowed for back-to-back signals without any intervening
-        // instructions.
+        // In case of an RSEQ abort followed by a signal, the pre-signal-instr PC is
+        // different from the interruption PC which is the RSEQ handler. If there is a
+        // back-to-back signal without any intervening instructions, the kernel transfer
+        // marker of the second signal should point to the same interruption PC, and not
+        // the pre-signal-instr PC. The shard->last_signal_context_ has not been updated,
+        // it still points to the previous signal context.
         (at_kernel_event && cur_pc == shard->last_signal_context_.xfer_int_pc &&
          prev_instr_trace_pc ==
              shard->last_signal_context_.pre_signal_instr.memref.instr.addr) ||

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1133,7 +1133,7 @@ invariant_checker_t::check_for_pc_discontinuity(
 #ifdef UNIX
         // Same PC is allowed for back-to-back signals without any intervening
         // instructions.
-        (cur_pc == shard->last_signal_context_.xfer_int_pc &&
+        (at_kernel_event && cur_pc == shard->last_signal_context_.xfer_int_pc &&
          prev_instr_trace_pc ==
              shard->last_signal_context_.pre_signal_instr.memref.instr.addr) ||
 #endif

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1130,6 +1130,11 @@ invariant_checker_t::check_for_pc_discontinuity(
          (shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
           shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
           shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT)) ||
+        // Same PC is allowed for back-to-back signals without any intervening
+        // instructions.
+        (cur_pc == shard->last_signal_context_.xfer_int_pc &&
+         prev_instr_trace_pc ==
+             shard->last_signal_context_.pre_signal_instr.memref.instr.addr) ||
         // We expect a gap on a window transition.
         shard->window_transition_ || prev_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER;
 

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1130,11 +1130,13 @@ invariant_checker_t::check_for_pc_discontinuity(
          (shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
           shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
           shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT)) ||
+#ifdef UNIX
         // Same PC is allowed for back-to-back signals without any intervening
         // instructions.
         (cur_pc == shard->last_signal_context_.xfer_int_pc &&
          prev_instr_trace_pc ==
              shard->last_signal_context_.pre_signal_instr.memref.instr.addr) ||
+#endif
         // We expect a gap on a window transition.
         shard->window_transition_ || prev_instr.instr.type == TRACE_TYPE_INSTR_SYSENTER;
 


### PR DESCRIPTION
When a signal causes an rseq abort, there will be a rseq  abort marker, followed by a kernel event marker.

When another signal follows immediately, another kernel event maker will be added with a different value.

If a back-to-back signal happens without any intervening instructions, the new kernel event marker (3rd one) should have the same value as the second kernel event marker.

The current implementation of the invariant check fails to consider this case, and flag an error.

If the instruction before the rseq marker is a branch, the invariant checker reports "Branch does not go to the correct target @ kernel_event marker", otherwise it reports "Non-explicit control flow has no marker @ kernel_event marker".

The fix is to check if the kernel event marker has the same value as the previous one, and if there are no intervening instructions between signals, do not flag an error.

Fixes: #6373