### PR TITLE
i#6376: Add issue# for supporting online func tracing

### DIFF
--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -421,7 +421,7 @@ func_trace_init(func_trace_append_entry_vec_t append_entry_vec_,
                 ssize_t (*write_file)(file_t file, const void *data, size_t count),
                 file_t funclist_file)
 {
-    // Online is not supported as we have no mechanism to pass the funclist_file
+    // i#6376: Online is not supported as we have no mechanism to pass the funclist_file
     // data to the simulator.
     if (!op_offline.get_value())
         return false;


### PR DESCRIPTION
Adds #6376 to the comment that documents that we do not currently
support function tracing in the drmemtrace online mode.

Issue: #6376