### PR TITLE
Document the endianness of drmemtrace wire formats

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -680,8 +680,10 @@ marker_type_is_function_marker(const trace_marker_type_t mark)
  * - a thread/process.
  * All fields are stored as little-endian.  The raw records from the tracer may
  * be big-endian (per the architecture trace type field), in which case raw2trace must
- * convert them to little-endian.  The #memref_t fields may also be big-endian to
- * simplify analyzers, with the #dynamorio::drmemtrace::reader_t class converting.
+ * convert them to little-endian.  The #memref_t fields may be presented as big-endian
+ * to simplify analyzers running on big-endian machines, in which case the conversion
+ * from the trace format #trace_entry_t to big-endian is performed by the
+ * #dynamorio::drmemtrace::reader_t class.
  */
 START_PACKED_STRUCTURE
 struct _trace_entry_t {

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -677,7 +677,11 @@ marker_type_is_function_marker(const trace_marker_type_t mark)
  * - a bundle of instrs
  * - a flush request
  * - a prefetch request
- * - a thread/process
+ * - a thread/process.
+ * All fields are stored as little-endian.  The raw records from the tracer may
+ * be big-endian (per the architecture trace type field), in which case raw2trace must
+ * convert them to little-endian.  The #memref_t fields may also be big-endian to
+ * simplify analyzers, with the #dynamorio::drmemtrace::reader_t class converting.
  */
 START_PACKED_STRUCTURE
 struct _trace_entry_t {
@@ -867,6 +871,8 @@ build_target_arch_type()
 }
 #endif
 
+// This structure may be big- or little-endian, but when converted to trace_entry_t
+// it must be converted to litte-endian.
 START_PACKED_STRUCTURE
 struct _offline_entry_t {
     union {
@@ -922,6 +928,7 @@ typedef union {
 #define ENCODING_FILE_INITIAL_VERSION 0
 #define ENCODING_FILE_VERSION ENCODING_FILE_INITIAL_VERSION
 
+// All fields are little-endian.
 START_PACKED_STRUCTURE
 struct _encoding_entry_t {
     size_t length; // Size of the entire structure.
@@ -942,6 +949,7 @@ typedef struct _encoding_entry_t encoding_entry_t;
 // A thread schedule file is a series of these records.
 // There is no version number here: we increase the version number in
 // the trace files when we change the format of this file.
+// All fields are little-endian.
 START_PACKED_STRUCTURE
 struct schedule_entry_t {
     schedule_entry_t(uint64_t thread, uint64_t timestamp, uint64_t cpu,
@@ -1008,6 +1016,7 @@ typedef enum {
     SYSCALL_PT_ENTRY_TYPE_MAX
 } syscall_pt_entry_type_t;
 
+// All fields are little-endian.
 START_PACKED_STRUCTURE
 struct _syscall_pt_entry_t {
     union {

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -955,6 +955,7 @@ protected:
     // Format for recording a schedule to disk.  A separate sequence of these records
     // is stored per output stream; each output stream's sequence is in one component
     // (subfile) of an archive file.
+    // All fields are little-endian.
     START_PACKED_STRUCTURE
     struct schedule_record_t {
         enum record_type_t {


### PR DESCRIPTION
Adds explicit documentation that the various drmemtrace packed on-disk formats are little-endian, except the raw offline trace format (for efficiency).  The memref_t format is left as flexible as the reader can convert from the little-endian trace_entry_t if desired.