### PR TITLE
i#3044 AArch64 SVE codec: fix scalar+immediate LD/ST offsets

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,6 +136,16 @@ changes:
    calls changed to contain the actual return value, rather than just whether
    successful.  A new marker #dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL_FAILED
    was added to indicate failure.
+ - Fixed a bug in the AArch64 codec with the way that SVE scalar+immediate predicated
+   contiguous load and store instructions represented the immediate offset in the IR.
+   In 10.0.0 the memory operand in these instruction used the immediate value from the
+   instruction (which is an index to be scaled by the vector length) as the displacement,
+   whereas the displacement value in a DynamoRIO memory operand should always be a byte
+   offset. This has now been corrected.
+   Traces and other tool results created with DynamoRIO prior to this fix may have
+   incorrect results if the application contained these instructions.
+   See <a href="https://github.com/DynamoRIO/dynamorio/pull/6390">PR #6390</a> for the
+   full list of affected instructions.
 
 Further non-compatibility-affecting changes include:
  - Added core-sharded analysis tool support where traces are sharded by

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,6 +136,8 @@ changes:
    calls changed to contain the actual return value, rather than just whether
    successful.  A new marker #dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL_FAILED
    was added to indicate failure.
+
+Further non-compatibility-affecting changes include:
  - Fixed a bug in the AArch64 codec with the way that SVE scalar+immediate predicated
    contiguous load and store instructions represented the immediate offset in the IR.
    In 10.0.0 the memory operand in these instruction used the immediate value from the
@@ -146,8 +148,6 @@ changes:
    incorrect results if the application contained these instructions.
    See <a href="https://github.com/DynamoRIO/dynamorio/pull/6390">PR #6390</a> for the
    full list of affected instructions.
-
-Further non-compatibility-affecting changes include:
  - Added core-sharded analysis tool support where traces are sharded by
    core instead of by thread, with the thread schedules onto the cores
    either following how they were traced or using a dynamic schedule.

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -5511,10 +5511,14 @@ static inline bool
 decode_opnd_svemem_gpr_simm4_vl_xreg(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
     const uint register_count = BITS(enc, 22, 21) + 1;
-    const opnd_size_t transfer_size =
-        opnd_size_from_bytes((register_count * dr_get_sve_vector_length()) / 8);
+    const uint transfer_bytes = (register_count * dr_get_sve_vector_length()) / 8;
+    /* The offset is scaled by the size of the vector in memory.
+     * This is the same as the transfer size.
+     */
+    const uint scale = transfer_bytes;
 
-    return decode_svemem_gpr_simm4(enc, transfer_size, register_count, opnd);
+    return decode_svemem_gpr_simm4(enc, opnd_size_from_bytes(transfer_bytes), scale,
+                                   opnd);
 }
 
 static inline bool
@@ -5522,10 +5526,14 @@ encode_opnd_svemem_gpr_simm4_vl_xreg(uint enc, int opcode, byte *pc, opnd_t opnd
                                      OUT uint *enc_out)
 {
     const uint register_count = BITS(enc, 22, 21) + 1;
-    const opnd_size_t transfer_size =
-        opnd_size_from_bytes((register_count * dr_get_sve_vector_length()) / 8);
+    const uint transfer_bytes = (register_count * dr_get_sve_vector_length()) / 8;
+    /* The offset is scaled by the size of the vector in memory.
+     * This is the same as the transfer size.
+     */
+    const uint scale = transfer_bytes;
 
-    return encode_svemem_gpr_simm4(enc, transfer_size, register_count, opnd, enc_out);
+    return encode_svemem_gpr_simm4(enc, opnd_size_from_bytes(transfer_bytes), scale, opnd,
+                                   enc_out);
 }
 
 /* hsd_immh_sz: The element size of a vector mediated by immh with possible values h, s
@@ -7931,15 +7939,18 @@ memory_transfer_size_from_dtype(uint enc)
 static inline bool
 decode_opnd_svemem_gpr_simm4_vl_1reg(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    return decode_svemem_gpr_simm4(enc, memory_transfer_size_from_dtype(enc), 1, opnd);
+    const opnd_size_t transfer_size = memory_transfer_size_from_dtype(enc);
+    return decode_svemem_gpr_simm4(enc, transfer_size, opnd_size_in_bytes(transfer_size),
+                                   opnd);
 }
 
 static inline bool
 encode_opnd_svemem_gpr_simm4_vl_1reg(uint enc, int opcode, byte *pc, opnd_t opnd,
                                      OUT uint *enc_out)
 {
-    return encode_svemem_gpr_simm4(enc, memory_transfer_size_from_dtype(enc), 1, opnd,
-                                   enc_out);
+    const opnd_size_t transfer_size = memory_transfer_size_from_dtype(enc);
+    return encode_svemem_gpr_simm4(enc, transfer_size, opnd_size_in_bytes(transfer_size),
+                                   opnd, enc_out);
 }
 
 /* SVE memory operand [<Xn|SP>, <Xm> LSL #x], mem transfer size based on ssz */

--- a/suite/tests/api/dis-a64-sve.txt
+++ b/suite/tests/api/dis-a64-sve.txt
@@ -10872,22 +10872,22 @@ a41d5f9b : ld1b z27.b, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[32byte
 a41e5fff : ld1b z31.b, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[32byte] %p7/z -> %z31.b
 
 # LD1B    { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1B-Z.P.BI-U8)
-a408a000 : ld1b z0.b, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x08(%x0)[32byte] %p0/z -> %z0.b
-a409a482 : ld1b z2.b, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0x07(%x4)[32byte] %p1/z -> %z2.b
-a40aa8c4 : ld1b z4.b, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0x06(%x6)[32byte] %p2/z -> %z4.b
-a40ba906 : ld1b z6.b, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0x05(%x8)[32byte] %p2/z -> %z6.b
-a40cad48 : ld1b z8.b, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x04(%x10)[32byte] %p3/z -> %z8.b
-a40dad6a : ld1b z10.b, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x03(%x11)[32byte] %p3/z -> %z10.b
-a40eb1ac : ld1b z12.b, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x02(%x13)[32byte] %p4/z -> %z12.b
-a40fb1ee : ld1b z14.b, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x01(%x15)[32byte] %p4/z -> %z14.b
+a408a000 : ld1b z0.b, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x0100(%x0)[32byte] %p0/z -> %z0.b
+a409a482 : ld1b z2.b, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0xe0(%x4)[32byte] %p1/z -> %z2.b
+a40aa8c4 : ld1b z4.b, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0xc0(%x6)[32byte] %p2/z -> %z4.b
+a40ba906 : ld1b z6.b, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0xa0(%x8)[32byte] %p2/z -> %z6.b
+a40cad48 : ld1b z8.b, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x80(%x10)[32byte] %p3/z -> %z8.b
+a40dad6a : ld1b z10.b, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x60(%x11)[32byte] %p3/z -> %z10.b
+a40eb1ac : ld1b z12.b, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x40(%x13)[32byte] %p4/z -> %z12.b
+a40fb1ee : ld1b z14.b, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x20(%x15)[32byte] %p4/z -> %z14.b
 a400b630 : ld1b z16.b, p5/Z, [x17, #0, MUL VL]       : ld1b   (%x17)[32byte] %p5/z -> %z16.b
 a400b671 : ld1b z17.b, p5/Z, [x19, #0, MUL VL]       : ld1b   (%x19)[32byte] %p5/z -> %z17.b
-a401b6b3 : ld1b z19.b, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x01(%x21)[32byte] %p5/z -> %z19.b
-a402baf5 : ld1b z21.b, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x02(%x23)[32byte] %p6/z -> %z21.b
-a403bb17 : ld1b z23.b, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x03(%x24)[32byte] %p6/z -> %z23.b
-a404bf59 : ld1b z25.b, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x04(%x26)[32byte] %p7/z -> %z25.b
-a405bf9b : ld1b z27.b, p7/Z, [x28, #5, MUL VL]       : ld1b   +0x05(%x28)[32byte] %p7/z -> %z27.b
-a407bfff : ld1b z31.b, p7/Z, [sp, #7, MUL VL]        : ld1b   +0x07(%sp)[32byte] %p7/z -> %z31.b
+a401b6b3 : ld1b z19.b, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x20(%x21)[32byte] %p5/z -> %z19.b
+a402baf5 : ld1b z21.b, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x40(%x23)[32byte] %p6/z -> %z21.b
+a403bb17 : ld1b z23.b, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x60(%x24)[32byte] %p6/z -> %z23.b
+a404bf59 : ld1b z25.b, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x80(%x26)[32byte] %p7/z -> %z25.b
+a405bf9b : ld1b z27.b, p7/Z, [x28, #5, MUL VL]       : ld1b   +0xa0(%x28)[32byte] %p7/z -> %z27.b
+a407bfff : ld1b z31.b, p7/Z, [sp, #7, MUL VL]        : ld1b   +0xe0(%sp)[32byte] %p7/z -> %z31.b
 
 # LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1B-Z.P.BR-U16)
 a4204000 : ld1b z0.h, p0/Z, [x0, x0]                 : ld1b   (%x0,%x0)[16byte] %p0/z -> %z0.h
@@ -10908,22 +10908,22 @@ a43d5f9b : ld1b z27.h, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[16byte
 a43e5fff : ld1b z31.h, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[16byte] %p7/z -> %z31.h
 
 # LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1B-Z.P.BI-U16)
-a428a000 : ld1b z0.h, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x08(%x0)[16byte] %p0/z -> %z0.h
-a429a482 : ld1b z2.h, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0x07(%x4)[16byte] %p1/z -> %z2.h
-a42aa8c4 : ld1b z4.h, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0x06(%x6)[16byte] %p2/z -> %z4.h
-a42ba906 : ld1b z6.h, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0x05(%x8)[16byte] %p2/z -> %z6.h
-a42cad48 : ld1b z8.h, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x04(%x10)[16byte] %p3/z -> %z8.h
-a42dad6a : ld1b z10.h, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x03(%x11)[16byte] %p3/z -> %z10.h
-a42eb1ac : ld1b z12.h, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x02(%x13)[16byte] %p4/z -> %z12.h
-a42fb1ee : ld1b z14.h, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x01(%x15)[16byte] %p4/z -> %z14.h
+a428a000 : ld1b z0.h, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x80(%x0)[16byte] %p0/z -> %z0.h
+a429a482 : ld1b z2.h, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0x70(%x4)[16byte] %p1/z -> %z2.h
+a42aa8c4 : ld1b z4.h, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0x60(%x6)[16byte] %p2/z -> %z4.h
+a42ba906 : ld1b z6.h, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0x50(%x8)[16byte] %p2/z -> %z6.h
+a42cad48 : ld1b z8.h, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x40(%x10)[16byte] %p3/z -> %z8.h
+a42dad6a : ld1b z10.h, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x30(%x11)[16byte] %p3/z -> %z10.h
+a42eb1ac : ld1b z12.h, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x20(%x13)[16byte] %p4/z -> %z12.h
+a42fb1ee : ld1b z14.h, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x10(%x15)[16byte] %p4/z -> %z14.h
 a420b630 : ld1b z16.h, p5/Z, [x17, #0, MUL VL]       : ld1b   (%x17)[16byte] %p5/z -> %z16.h
 a420b671 : ld1b z17.h, p5/Z, [x19, #0, MUL VL]       : ld1b   (%x19)[16byte] %p5/z -> %z17.h
-a421b6b3 : ld1b z19.h, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x01(%x21)[16byte] %p5/z -> %z19.h
-a422baf5 : ld1b z21.h, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x02(%x23)[16byte] %p6/z -> %z21.h
-a423bb17 : ld1b z23.h, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x03(%x24)[16byte] %p6/z -> %z23.h
-a424bf59 : ld1b z25.h, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x04(%x26)[16byte] %p7/z -> %z25.h
-a425bf9b : ld1b z27.h, p7/Z, [x28, #5, MUL VL]       : ld1b   +0x05(%x28)[16byte] %p7/z -> %z27.h
-a427bfff : ld1b z31.h, p7/Z, [sp, #7, MUL VL]        : ld1b   +0x07(%sp)[16byte] %p7/z -> %z31.h
+a421b6b3 : ld1b z19.h, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x10(%x21)[16byte] %p5/z -> %z19.h
+a422baf5 : ld1b z21.h, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x20(%x23)[16byte] %p6/z -> %z21.h
+a423bb17 : ld1b z23.h, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x30(%x24)[16byte] %p6/z -> %z23.h
+a424bf59 : ld1b z25.h, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x40(%x26)[16byte] %p7/z -> %z25.h
+a425bf9b : ld1b z27.h, p7/Z, [x28, #5, MUL VL]       : ld1b   +0x50(%x28)[16byte] %p7/z -> %z27.h
+a427bfff : ld1b z31.h, p7/Z, [sp, #7, MUL VL]        : ld1b   +0x70(%sp)[16byte] %p7/z -> %z31.h
 
 # LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1B-Z.P.BR-U32)
 a4404000 : ld1b z0.s, p0/Z, [x0, x0]                 : ld1b   (%x0,%x0)[8byte] %p0/z -> %z0.s
@@ -10944,22 +10944,22 @@ a45d5f9b : ld1b z27.s, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[8byte]
 a45e5fff : ld1b z31.s, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[8byte] %p7/z -> %z31.s
 
 # LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1B-Z.P.BI-U32)
-a448a000 : ld1b z0.s, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x08(%x0)[8byte] %p0/z -> %z0.s
-a449a482 : ld1b z2.s, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0x07(%x4)[8byte] %p1/z -> %z2.s
-a44aa8c4 : ld1b z4.s, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0x06(%x6)[8byte] %p2/z -> %z4.s
-a44ba906 : ld1b z6.s, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0x05(%x8)[8byte] %p2/z -> %z6.s
-a44cad48 : ld1b z8.s, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x04(%x10)[8byte] %p3/z -> %z8.s
-a44dad6a : ld1b z10.s, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x03(%x11)[8byte] %p3/z -> %z10.s
-a44eb1ac : ld1b z12.s, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x02(%x13)[8byte] %p4/z -> %z12.s
-a44fb1ee : ld1b z14.s, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x01(%x15)[8byte] %p4/z -> %z14.s
+a448a000 : ld1b z0.s, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x40(%x0)[8byte] %p0/z -> %z0.s
+a449a482 : ld1b z2.s, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0x38(%x4)[8byte] %p1/z -> %z2.s
+a44aa8c4 : ld1b z4.s, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0x30(%x6)[8byte] %p2/z -> %z4.s
+a44ba906 : ld1b z6.s, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0x28(%x8)[8byte] %p2/z -> %z6.s
+a44cad48 : ld1b z8.s, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x20(%x10)[8byte] %p3/z -> %z8.s
+a44dad6a : ld1b z10.s, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x18(%x11)[8byte] %p3/z -> %z10.s
+a44eb1ac : ld1b z12.s, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x10(%x13)[8byte] %p4/z -> %z12.s
+a44fb1ee : ld1b z14.s, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x08(%x15)[8byte] %p4/z -> %z14.s
 a440b630 : ld1b z16.s, p5/Z, [x17, #0, MUL VL]       : ld1b   (%x17)[8byte] %p5/z -> %z16.s
 a440b671 : ld1b z17.s, p5/Z, [x19, #0, MUL VL]       : ld1b   (%x19)[8byte] %p5/z -> %z17.s
-a441b6b3 : ld1b z19.s, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x01(%x21)[8byte] %p5/z -> %z19.s
-a442baf5 : ld1b z21.s, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x02(%x23)[8byte] %p6/z -> %z21.s
-a443bb17 : ld1b z23.s, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x03(%x24)[8byte] %p6/z -> %z23.s
-a444bf59 : ld1b z25.s, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x04(%x26)[8byte] %p7/z -> %z25.s
-a445bf9b : ld1b z27.s, p7/Z, [x28, #5, MUL VL]       : ld1b   +0x05(%x28)[8byte] %p7/z -> %z27.s
-a447bfff : ld1b z31.s, p7/Z, [sp, #7, MUL VL]        : ld1b   +0x07(%sp)[8byte] %p7/z -> %z31.s
+a441b6b3 : ld1b z19.s, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x08(%x21)[8byte] %p5/z -> %z19.s
+a442baf5 : ld1b z21.s, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x10(%x23)[8byte] %p6/z -> %z21.s
+a443bb17 : ld1b z23.s, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x18(%x24)[8byte] %p6/z -> %z23.s
+a444bf59 : ld1b z25.s, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x20(%x26)[8byte] %p7/z -> %z25.s
+a445bf9b : ld1b z27.s, p7/Z, [x28, #5, MUL VL]       : ld1b   +0x28(%x28)[8byte] %p7/z -> %z27.s
+a447bfff : ld1b z31.s, p7/Z, [sp, #7, MUL VL]        : ld1b   +0x38(%sp)[8byte] %p7/z -> %z31.s
 
 # LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1B-Z.P.BR-U64)
 a4604000 : ld1b z0.d, p0/Z, [x0, x0]                 : ld1b   (%x0,%x0)[4byte] %p0/z -> %z0.d
@@ -10980,22 +10980,22 @@ a47d5f9b : ld1b z27.d, p7/Z, [x28, x29]              : ld1b   (%x28,%x29)[4byte]
 a47e5fff : ld1b z31.d, p7/Z, [sp, x30]               : ld1b   (%sp,%x30)[4byte] %p7/z -> %z31.d
 
 # LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1B-Z.P.BI-U64)
-a468a000 : ld1b z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x08(%x0)[4byte] %p0/z -> %z0.d
-a469a482 : ld1b z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0x07(%x4)[4byte] %p1/z -> %z2.d
-a46aa8c4 : ld1b z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0x06(%x6)[4byte] %p2/z -> %z4.d
-a46ba906 : ld1b z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0x05(%x8)[4byte] %p2/z -> %z6.d
-a46cad48 : ld1b z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x04(%x10)[4byte] %p3/z -> %z8.d
-a46dad6a : ld1b z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x03(%x11)[4byte] %p3/z -> %z10.d
-a46eb1ac : ld1b z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x02(%x13)[4byte] %p4/z -> %z12.d
-a46fb1ee : ld1b z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x01(%x15)[4byte] %p4/z -> %z14.d
+a468a000 : ld1b z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1b   -0x20(%x0)[4byte] %p0/z -> %z0.d
+a469a482 : ld1b z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1b   -0x1c(%x4)[4byte] %p1/z -> %z2.d
+a46aa8c4 : ld1b z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1b   -0x18(%x6)[4byte] %p2/z -> %z4.d
+a46ba906 : ld1b z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1b   -0x14(%x8)[4byte] %p2/z -> %z6.d
+a46cad48 : ld1b z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1b   -0x10(%x10)[4byte] %p3/z -> %z8.d
+a46dad6a : ld1b z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1b   -0x0c(%x11)[4byte] %p3/z -> %z10.d
+a46eb1ac : ld1b z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1b   -0x08(%x13)[4byte] %p4/z -> %z12.d
+a46fb1ee : ld1b z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1b   -0x04(%x15)[4byte] %p4/z -> %z14.d
 a460b630 : ld1b z16.d, p5/Z, [x17, #0, MUL VL]       : ld1b   (%x17)[4byte] %p5/z -> %z16.d
 a460b671 : ld1b z17.d, p5/Z, [x19, #0, MUL VL]       : ld1b   (%x19)[4byte] %p5/z -> %z17.d
-a461b6b3 : ld1b z19.d, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x01(%x21)[4byte] %p5/z -> %z19.d
-a462baf5 : ld1b z21.d, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x02(%x23)[4byte] %p6/z -> %z21.d
-a463bb17 : ld1b z23.d, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x03(%x24)[4byte] %p6/z -> %z23.d
-a464bf59 : ld1b z25.d, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x04(%x26)[4byte] %p7/z -> %z25.d
-a465bf9b : ld1b z27.d, p7/Z, [x28, #5, MUL VL]       : ld1b   +0x05(%x28)[4byte] %p7/z -> %z27.d
-a467bfff : ld1b z31.d, p7/Z, [sp, #7, MUL VL]        : ld1b   +0x07(%sp)[4byte] %p7/z -> %z31.d
+a461b6b3 : ld1b z19.d, p5/Z, [x21, #1, MUL VL]       : ld1b   +0x04(%x21)[4byte] %p5/z -> %z19.d
+a462baf5 : ld1b z21.d, p6/Z, [x23, #2, MUL VL]       : ld1b   +0x08(%x23)[4byte] %p6/z -> %z21.d
+a463bb17 : ld1b z23.d, p6/Z, [x24, #3, MUL VL]       : ld1b   +0x0c(%x24)[4byte] %p6/z -> %z23.d
+a464bf59 : ld1b z25.d, p7/Z, [x26, #4, MUL VL]       : ld1b   +0x10(%x26)[4byte] %p7/z -> %z25.d
+a465bf9b : ld1b z27.d, p7/Z, [x28, #5, MUL VL]       : ld1b   +0x14(%x28)[4byte] %p7/z -> %z27.d
+a467bfff : ld1b z31.d, p7/Z, [sp, #7, MUL VL]        : ld1b   +0x1c(%sp)[4byte] %p7/z -> %z31.d
 
 # LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1B-Z.P.BZ-D.x32.unscaled)
 c4004000 : ld1b z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1b   (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d
@@ -11086,22 +11086,22 @@ a5fd5f9b : ld1d z27.d, p7/Z, [x28, x29, LSL #3]      : ld1d   (%x28,%x29,lsl #3)
 a5fe5fff : ld1d z31.d, p7/Z, [sp, x30, LSL #3]       : ld1d   (%sp,%x30,lsl #3)[32byte] %p7/z -> %z31.d
 
 # LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1D-Z.P.BI-U64)
-a5e8a000 : ld1d z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1d   -0x08(%x0)[32byte] %p0/z -> %z0.d
-a5e9a482 : ld1d z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1d   -0x07(%x4)[32byte] %p1/z -> %z2.d
-a5eaa8c4 : ld1d z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1d   -0x06(%x6)[32byte] %p2/z -> %z4.d
-a5eba906 : ld1d z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1d   -0x05(%x8)[32byte] %p2/z -> %z6.d
-a5ecad48 : ld1d z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1d   -0x04(%x10)[32byte] %p3/z -> %z8.d
-a5edad6a : ld1d z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1d   -0x03(%x11)[32byte] %p3/z -> %z10.d
-a5eeb1ac : ld1d z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1d   -0x02(%x13)[32byte] %p4/z -> %z12.d
-a5efb1ee : ld1d z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1d   -0x01(%x15)[32byte] %p4/z -> %z14.d
+a5e8a000 : ld1d z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1d   -0x0100(%x0)[32byte] %p0/z -> %z0.d
+a5e9a482 : ld1d z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1d   -0xe0(%x4)[32byte] %p1/z -> %z2.d
+a5eaa8c4 : ld1d z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1d   -0xc0(%x6)[32byte] %p2/z -> %z4.d
+a5eba906 : ld1d z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1d   -0xa0(%x8)[32byte] %p2/z -> %z6.d
+a5ecad48 : ld1d z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1d   -0x80(%x10)[32byte] %p3/z -> %z8.d
+a5edad6a : ld1d z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1d   -0x60(%x11)[32byte] %p3/z -> %z10.d
+a5eeb1ac : ld1d z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1d   -0x40(%x13)[32byte] %p4/z -> %z12.d
+a5efb1ee : ld1d z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1d   -0x20(%x15)[32byte] %p4/z -> %z14.d
 a5e0b630 : ld1d z16.d, p5/Z, [x17, #0, MUL VL]       : ld1d   (%x17)[32byte] %p5/z -> %z16.d
 a5e0b671 : ld1d z17.d, p5/Z, [x19, #0, MUL VL]       : ld1d   (%x19)[32byte] %p5/z -> %z17.d
-a5e1b6b3 : ld1d z19.d, p5/Z, [x21, #1, MUL VL]       : ld1d   +0x01(%x21)[32byte] %p5/z -> %z19.d
-a5e2baf5 : ld1d z21.d, p6/Z, [x23, #2, MUL VL]       : ld1d   +0x02(%x23)[32byte] %p6/z -> %z21.d
-a5e3bb17 : ld1d z23.d, p6/Z, [x24, #3, MUL VL]       : ld1d   +0x03(%x24)[32byte] %p6/z -> %z23.d
-a5e4bf59 : ld1d z25.d, p7/Z, [x26, #4, MUL VL]       : ld1d   +0x04(%x26)[32byte] %p7/z -> %z25.d
-a5e5bf9b : ld1d z27.d, p7/Z, [x28, #5, MUL VL]       : ld1d   +0x05(%x28)[32byte] %p7/z -> %z27.d
-a5e7bfff : ld1d z31.d, p7/Z, [sp, #7, MUL VL]        : ld1d   +0x07(%sp)[32byte] %p7/z -> %z31.d
+a5e1b6b3 : ld1d z19.d, p5/Z, [x21, #1, MUL VL]       : ld1d   +0x20(%x21)[32byte] %p5/z -> %z19.d
+a5e2baf5 : ld1d z21.d, p6/Z, [x23, #2, MUL VL]       : ld1d   +0x40(%x23)[32byte] %p6/z -> %z21.d
+a5e3bb17 : ld1d z23.d, p6/Z, [x24, #3, MUL VL]       : ld1d   +0x60(%x24)[32byte] %p6/z -> %z23.d
+a5e4bf59 : ld1d z25.d, p7/Z, [x26, #4, MUL VL]       : ld1d   +0x80(%x26)[32byte] %p7/z -> %z25.d
+a5e5bf9b : ld1d z27.d, p7/Z, [x28, #5, MUL VL]       : ld1d   +0xa0(%x28)[32byte] %p7/z -> %z27.d
+a5e7bfff : ld1d z31.d, p7/Z, [sp, #7, MUL VL]        : ld1d   +0xe0(%sp)[32byte] %p7/z -> %z31.d
 
 # LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1D-Z.P.BZ-D.x32.unscaled)
 c5804000 : ld1d z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1d   (%x0,%z0.d,uxtw)[32byte] %p0/z -> %z0.d
@@ -11330,22 +11330,22 @@ a4bd5f9b : ld1h z27.h, p7/Z, [x28, x29, LSL #1]      : ld1h   (%x28,%x29,lsl #1)
 a4be5fff : ld1h z31.h, p7/Z, [sp, x30, LSL #1]       : ld1h   (%sp,%x30,lsl #1)[32byte] %p7/z -> %z31.h
 
 # LD1H    { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1H-Z.P.BI-U16)
-a4a8a000 : ld1h z0.h, p0/Z, [x0, #-8, MUL VL]        : ld1h   -0x08(%x0)[32byte] %p0/z -> %z0.h
-a4a9a482 : ld1h z2.h, p1/Z, [x4, #-7, MUL VL]        : ld1h   -0x07(%x4)[32byte] %p1/z -> %z2.h
-a4aaa8c4 : ld1h z4.h, p2/Z, [x6, #-6, MUL VL]        : ld1h   -0x06(%x6)[32byte] %p2/z -> %z4.h
-a4aba906 : ld1h z6.h, p2/Z, [x8, #-5, MUL VL]        : ld1h   -0x05(%x8)[32byte] %p2/z -> %z6.h
-a4acad48 : ld1h z8.h, p3/Z, [x10, #-4, MUL VL]       : ld1h   -0x04(%x10)[32byte] %p3/z -> %z8.h
-a4adad6a : ld1h z10.h, p3/Z, [x11, #-3, MUL VL]      : ld1h   -0x03(%x11)[32byte] %p3/z -> %z10.h
-a4aeb1ac : ld1h z12.h, p4/Z, [x13, #-2, MUL VL]      : ld1h   -0x02(%x13)[32byte] %p4/z -> %z12.h
-a4afb1ee : ld1h z14.h, p4/Z, [x15, #-1, MUL VL]      : ld1h   -0x01(%x15)[32byte] %p4/z -> %z14.h
+a4a8a000 : ld1h z0.h, p0/Z, [x0, #-8, MUL VL]        : ld1h   -0x0100(%x0)[32byte] %p0/z -> %z0.h
+a4a9a482 : ld1h z2.h, p1/Z, [x4, #-7, MUL VL]        : ld1h   -0xe0(%x4)[32byte] %p1/z -> %z2.h
+a4aaa8c4 : ld1h z4.h, p2/Z, [x6, #-6, MUL VL]        : ld1h   -0xc0(%x6)[32byte] %p2/z -> %z4.h
+a4aba906 : ld1h z6.h, p2/Z, [x8, #-5, MUL VL]        : ld1h   -0xa0(%x8)[32byte] %p2/z -> %z6.h
+a4acad48 : ld1h z8.h, p3/Z, [x10, #-4, MUL VL]       : ld1h   -0x80(%x10)[32byte] %p3/z -> %z8.h
+a4adad6a : ld1h z10.h, p3/Z, [x11, #-3, MUL VL]      : ld1h   -0x60(%x11)[32byte] %p3/z -> %z10.h
+a4aeb1ac : ld1h z12.h, p4/Z, [x13, #-2, MUL VL]      : ld1h   -0x40(%x13)[32byte] %p4/z -> %z12.h
+a4afb1ee : ld1h z14.h, p4/Z, [x15, #-1, MUL VL]      : ld1h   -0x20(%x15)[32byte] %p4/z -> %z14.h
 a4a0b630 : ld1h z16.h, p5/Z, [x17, #0, MUL VL]       : ld1h   (%x17)[32byte] %p5/z -> %z16.h
 a4a0b671 : ld1h z17.h, p5/Z, [x19, #0, MUL VL]       : ld1h   (%x19)[32byte] %p5/z -> %z17.h
-a4a1b6b3 : ld1h z19.h, p5/Z, [x21, #1, MUL VL]       : ld1h   +0x01(%x21)[32byte] %p5/z -> %z19.h
-a4a2baf5 : ld1h z21.h, p6/Z, [x23, #2, MUL VL]       : ld1h   +0x02(%x23)[32byte] %p6/z -> %z21.h
-a4a3bb17 : ld1h z23.h, p6/Z, [x24, #3, MUL VL]       : ld1h   +0x03(%x24)[32byte] %p6/z -> %z23.h
-a4a4bf59 : ld1h z25.h, p7/Z, [x26, #4, MUL VL]       : ld1h   +0x04(%x26)[32byte] %p7/z -> %z25.h
-a4a5bf9b : ld1h z27.h, p7/Z, [x28, #5, MUL VL]       : ld1h   +0x05(%x28)[32byte] %p7/z -> %z27.h
-a4a7bfff : ld1h z31.h, p7/Z, [sp, #7, MUL VL]        : ld1h   +0x07(%sp)[32byte] %p7/z -> %z31.h
+a4a1b6b3 : ld1h z19.h, p5/Z, [x21, #1, MUL VL]       : ld1h   +0x20(%x21)[32byte] %p5/z -> %z19.h
+a4a2baf5 : ld1h z21.h, p6/Z, [x23, #2, MUL VL]       : ld1h   +0x40(%x23)[32byte] %p6/z -> %z21.h
+a4a3bb17 : ld1h z23.h, p6/Z, [x24, #3, MUL VL]       : ld1h   +0x60(%x24)[32byte] %p6/z -> %z23.h
+a4a4bf59 : ld1h z25.h, p7/Z, [x26, #4, MUL VL]       : ld1h   +0x80(%x26)[32byte] %p7/z -> %z25.h
+a4a5bf9b : ld1h z27.h, p7/Z, [x28, #5, MUL VL]       : ld1h   +0xa0(%x28)[32byte] %p7/z -> %z27.h
+a4a7bfff : ld1h z31.h, p7/Z, [sp, #7, MUL VL]        : ld1h   +0xe0(%sp)[32byte] %p7/z -> %z31.h
 
 # LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1] (LD1H-Z.P.BR-U32)
 a4c04000 : ld1h z0.s, p0/Z, [x0, x0, LSL #1]         : ld1h   (%x0,%x0,lsl #1)[16byte] %p0/z -> %z0.s
@@ -11366,22 +11366,22 @@ a4dd5f9b : ld1h z27.s, p7/Z, [x28, x29, LSL #1]      : ld1h   (%x28,%x29,lsl #1)
 a4de5fff : ld1h z31.s, p7/Z, [sp, x30, LSL #1]       : ld1h   (%sp,%x30,lsl #1)[16byte] %p7/z -> %z31.s
 
 # LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1H-Z.P.BI-U32)
-a4c8a000 : ld1h z0.s, p0/Z, [x0, #-8, MUL VL]        : ld1h   -0x08(%x0)[16byte] %p0/z -> %z0.s
-a4c9a482 : ld1h z2.s, p1/Z, [x4, #-7, MUL VL]        : ld1h   -0x07(%x4)[16byte] %p1/z -> %z2.s
-a4caa8c4 : ld1h z4.s, p2/Z, [x6, #-6, MUL VL]        : ld1h   -0x06(%x6)[16byte] %p2/z -> %z4.s
-a4cba906 : ld1h z6.s, p2/Z, [x8, #-5, MUL VL]        : ld1h   -0x05(%x8)[16byte] %p2/z -> %z6.s
-a4ccad48 : ld1h z8.s, p3/Z, [x10, #-4, MUL VL]       : ld1h   -0x04(%x10)[16byte] %p3/z -> %z8.s
-a4cdad6a : ld1h z10.s, p3/Z, [x11, #-3, MUL VL]      : ld1h   -0x03(%x11)[16byte] %p3/z -> %z10.s
-a4ceb1ac : ld1h z12.s, p4/Z, [x13, #-2, MUL VL]      : ld1h   -0x02(%x13)[16byte] %p4/z -> %z12.s
-a4cfb1ee : ld1h z14.s, p4/Z, [x15, #-1, MUL VL]      : ld1h   -0x01(%x15)[16byte] %p4/z -> %z14.s
+a4c8a000 : ld1h z0.s, p0/Z, [x0, #-8, MUL VL]        : ld1h   -0x80(%x0)[16byte] %p0/z -> %z0.s
+a4c9a482 : ld1h z2.s, p1/Z, [x4, #-7, MUL VL]        : ld1h   -0x70(%x4)[16byte] %p1/z -> %z2.s
+a4caa8c4 : ld1h z4.s, p2/Z, [x6, #-6, MUL VL]        : ld1h   -0x60(%x6)[16byte] %p2/z -> %z4.s
+a4cba906 : ld1h z6.s, p2/Z, [x8, #-5, MUL VL]        : ld1h   -0x50(%x8)[16byte] %p2/z -> %z6.s
+a4ccad48 : ld1h z8.s, p3/Z, [x10, #-4, MUL VL]       : ld1h   -0x40(%x10)[16byte] %p3/z -> %z8.s
+a4cdad6a : ld1h z10.s, p3/Z, [x11, #-3, MUL VL]      : ld1h   -0x30(%x11)[16byte] %p3/z -> %z10.s
+a4ceb1ac : ld1h z12.s, p4/Z, [x13, #-2, MUL VL]      : ld1h   -0x20(%x13)[16byte] %p4/z -> %z12.s
+a4cfb1ee : ld1h z14.s, p4/Z, [x15, #-1, MUL VL]      : ld1h   -0x10(%x15)[16byte] %p4/z -> %z14.s
 a4c0b630 : ld1h z16.s, p5/Z, [x17, #0, MUL VL]       : ld1h   (%x17)[16byte] %p5/z -> %z16.s
 a4c0b671 : ld1h z17.s, p5/Z, [x19, #0, MUL VL]       : ld1h   (%x19)[16byte] %p5/z -> %z17.s
-a4c1b6b3 : ld1h z19.s, p5/Z, [x21, #1, MUL VL]       : ld1h   +0x01(%x21)[16byte] %p5/z -> %z19.s
-a4c2baf5 : ld1h z21.s, p6/Z, [x23, #2, MUL VL]       : ld1h   +0x02(%x23)[16byte] %p6/z -> %z21.s
-a4c3bb17 : ld1h z23.s, p6/Z, [x24, #3, MUL VL]       : ld1h   +0x03(%x24)[16byte] %p6/z -> %z23.s
-a4c4bf59 : ld1h z25.s, p7/Z, [x26, #4, MUL VL]       : ld1h   +0x04(%x26)[16byte] %p7/z -> %z25.s
-a4c5bf9b : ld1h z27.s, p7/Z, [x28, #5, MUL VL]       : ld1h   +0x05(%x28)[16byte] %p7/z -> %z27.s
-a4c7bfff : ld1h z31.s, p7/Z, [sp, #7, MUL VL]        : ld1h   +0x07(%sp)[16byte] %p7/z -> %z31.s
+a4c1b6b3 : ld1h z19.s, p5/Z, [x21, #1, MUL VL]       : ld1h   +0x10(%x21)[16byte] %p5/z -> %z19.s
+a4c2baf5 : ld1h z21.s, p6/Z, [x23, #2, MUL VL]       : ld1h   +0x20(%x23)[16byte] %p6/z -> %z21.s
+a4c3bb17 : ld1h z23.s, p6/Z, [x24, #3, MUL VL]       : ld1h   +0x30(%x24)[16byte] %p6/z -> %z23.s
+a4c4bf59 : ld1h z25.s, p7/Z, [x26, #4, MUL VL]       : ld1h   +0x40(%x26)[16byte] %p7/z -> %z25.s
+a4c5bf9b : ld1h z27.s, p7/Z, [x28, #5, MUL VL]       : ld1h   +0x50(%x28)[16byte] %p7/z -> %z27.s
+a4c7bfff : ld1h z31.s, p7/Z, [sp, #7, MUL VL]        : ld1h   +0x70(%sp)[16byte] %p7/z -> %z31.s
 
 # LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1] (LD1H-Z.P.BR-U64)
 a4e04000 : ld1h z0.d, p0/Z, [x0, x0, LSL #1]         : ld1h   (%x0,%x0,lsl #1)[8byte] %p0/z -> %z0.d
@@ -11402,22 +11402,22 @@ a4fd5f9b : ld1h z27.d, p7/Z, [x28, x29, LSL #1]      : ld1h   (%x28,%x29,lsl #1)
 a4fe5fff : ld1h z31.d, p7/Z, [sp, x30, LSL #1]       : ld1h   (%sp,%x30,lsl #1)[8byte] %p7/z -> %z31.d
 
 # LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1H-Z.P.BI-U64)
-a4e8a000 : ld1h z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1h   -0x08(%x0)[8byte] %p0/z -> %z0.d
-a4e9a482 : ld1h z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1h   -0x07(%x4)[8byte] %p1/z -> %z2.d
-a4eaa8c4 : ld1h z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1h   -0x06(%x6)[8byte] %p2/z -> %z4.d
-a4eba906 : ld1h z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1h   -0x05(%x8)[8byte] %p2/z -> %z6.d
-a4ecad48 : ld1h z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1h   -0x04(%x10)[8byte] %p3/z -> %z8.d
-a4edad6a : ld1h z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1h   -0x03(%x11)[8byte] %p3/z -> %z10.d
-a4eeb1ac : ld1h z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1h   -0x02(%x13)[8byte] %p4/z -> %z12.d
-a4efb1ee : ld1h z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1h   -0x01(%x15)[8byte] %p4/z -> %z14.d
+a4e8a000 : ld1h z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1h   -0x40(%x0)[8byte] %p0/z -> %z0.d
+a4e9a482 : ld1h z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1h   -0x38(%x4)[8byte] %p1/z -> %z2.d
+a4eaa8c4 : ld1h z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1h   -0x30(%x6)[8byte] %p2/z -> %z4.d
+a4eba906 : ld1h z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1h   -0x28(%x8)[8byte] %p2/z -> %z6.d
+a4ecad48 : ld1h z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1h   -0x20(%x10)[8byte] %p3/z -> %z8.d
+a4edad6a : ld1h z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1h   -0x18(%x11)[8byte] %p3/z -> %z10.d
+a4eeb1ac : ld1h z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1h   -0x10(%x13)[8byte] %p4/z -> %z12.d
+a4efb1ee : ld1h z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1h   -0x08(%x15)[8byte] %p4/z -> %z14.d
 a4e0b630 : ld1h z16.d, p5/Z, [x17, #0, MUL VL]       : ld1h   (%x17)[8byte] %p5/z -> %z16.d
 a4e0b671 : ld1h z17.d, p5/Z, [x19, #0, MUL VL]       : ld1h   (%x19)[8byte] %p5/z -> %z17.d
-a4e1b6b3 : ld1h z19.d, p5/Z, [x21, #1, MUL VL]       : ld1h   +0x01(%x21)[8byte] %p5/z -> %z19.d
-a4e2baf5 : ld1h z21.d, p6/Z, [x23, #2, MUL VL]       : ld1h   +0x02(%x23)[8byte] %p6/z -> %z21.d
-a4e3bb17 : ld1h z23.d, p6/Z, [x24, #3, MUL VL]       : ld1h   +0x03(%x24)[8byte] %p6/z -> %z23.d
-a4e4bf59 : ld1h z25.d, p7/Z, [x26, #4, MUL VL]       : ld1h   +0x04(%x26)[8byte] %p7/z -> %z25.d
-a4e5bf9b : ld1h z27.d, p7/Z, [x28, #5, MUL VL]       : ld1h   +0x05(%x28)[8byte] %p7/z -> %z27.d
-a4e7bfff : ld1h z31.d, p7/Z, [sp, #7, MUL VL]        : ld1h   +0x07(%sp)[8byte] %p7/z -> %z31.d
+a4e1b6b3 : ld1h z19.d, p5/Z, [x21, #1, MUL VL]       : ld1h   +0x08(%x21)[8byte] %p5/z -> %z19.d
+a4e2baf5 : ld1h z21.d, p6/Z, [x23, #2, MUL VL]       : ld1h   +0x10(%x23)[8byte] %p6/z -> %z21.d
+a4e3bb17 : ld1h z23.d, p6/Z, [x24, #3, MUL VL]       : ld1h   +0x18(%x24)[8byte] %p6/z -> %z23.d
+a4e4bf59 : ld1h z25.d, p7/Z, [x26, #4, MUL VL]       : ld1h   +0x20(%x26)[8byte] %p7/z -> %z25.d
+a4e5bf9b : ld1h z27.d, p7/Z, [x28, #5, MUL VL]       : ld1h   +0x28(%x28)[8byte] %p7/z -> %z27.d
+a4e7bfff : ld1h z31.d, p7/Z, [sp, #7, MUL VL]        : ld1h   +0x38(%sp)[8byte] %p7/z -> %z31.d
 
 # LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1H-Z.P.BZ-D.x32.unscaled)
 c4804000 : ld1h z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1h   (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d
@@ -12062,22 +12062,22 @@ a59d5f9b : ld1sb z27.d, p7/Z, [x28, x29]             : ld1sb  (%x28,%x29)[4byte]
 a59e5fff : ld1sb z31.d, p7/Z, [sp, x30]              : ld1sb  (%sp,%x30)[4byte] %p7/z -> %z31.d
 
 # LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1SB-Z.P.BI-S64)
-a588a000 : ld1sb z0.d, p0/Z, [x0, #-8, MUL VL]       : ld1sb  -0x08(%x0)[4byte] %p0/z -> %z0.d
-a589a482 : ld1sb z2.d, p1/Z, [x4, #-7, MUL VL]       : ld1sb  -0x07(%x4)[4byte] %p1/z -> %z2.d
-a58aa8c4 : ld1sb z4.d, p2/Z, [x6, #-6, MUL VL]       : ld1sb  -0x06(%x6)[4byte] %p2/z -> %z4.d
-a58ba906 : ld1sb z6.d, p2/Z, [x8, #-5, MUL VL]       : ld1sb  -0x05(%x8)[4byte] %p2/z -> %z6.d
-a58cad48 : ld1sb z8.d, p3/Z, [x10, #-4, MUL VL]      : ld1sb  -0x04(%x10)[4byte] %p3/z -> %z8.d
-a58dad6a : ld1sb z10.d, p3/Z, [x11, #-3, MUL VL]     : ld1sb  -0x03(%x11)[4byte] %p3/z -> %z10.d
-a58eb1ac : ld1sb z12.d, p4/Z, [x13, #-2, MUL VL]     : ld1sb  -0x02(%x13)[4byte] %p4/z -> %z12.d
-a58fb1ee : ld1sb z14.d, p4/Z, [x15, #-1, MUL VL]     : ld1sb  -0x01(%x15)[4byte] %p4/z -> %z14.d
+a588a000 : ld1sb z0.d, p0/Z, [x0, #-8, MUL VL]       : ld1sb  -0x20(%x0)[4byte] %p0/z -> %z0.d
+a589a482 : ld1sb z2.d, p1/Z, [x4, #-7, MUL VL]       : ld1sb  -0x1c(%x4)[4byte] %p1/z -> %z2.d
+a58aa8c4 : ld1sb z4.d, p2/Z, [x6, #-6, MUL VL]       : ld1sb  -0x18(%x6)[4byte] %p2/z -> %z4.d
+a58ba906 : ld1sb z6.d, p2/Z, [x8, #-5, MUL VL]       : ld1sb  -0x14(%x8)[4byte] %p2/z -> %z6.d
+a58cad48 : ld1sb z8.d, p3/Z, [x10, #-4, MUL VL]      : ld1sb  -0x10(%x10)[4byte] %p3/z -> %z8.d
+a58dad6a : ld1sb z10.d, p3/Z, [x11, #-3, MUL VL]     : ld1sb  -0x0c(%x11)[4byte] %p3/z -> %z10.d
+a58eb1ac : ld1sb z12.d, p4/Z, [x13, #-2, MUL VL]     : ld1sb  -0x08(%x13)[4byte] %p4/z -> %z12.d
+a58fb1ee : ld1sb z14.d, p4/Z, [x15, #-1, MUL VL]     : ld1sb  -0x04(%x15)[4byte] %p4/z -> %z14.d
 a580b630 : ld1sb z16.d, p5/Z, [x17, #0, MUL VL]      : ld1sb  (%x17)[4byte] %p5/z -> %z16.d
 a580b671 : ld1sb z17.d, p5/Z, [x19, #0, MUL VL]      : ld1sb  (%x19)[4byte] %p5/z -> %z17.d
-a581b6b3 : ld1sb z19.d, p5/Z, [x21, #1, MUL VL]      : ld1sb  +0x01(%x21)[4byte] %p5/z -> %z19.d
-a582baf5 : ld1sb z21.d, p6/Z, [x23, #2, MUL VL]      : ld1sb  +0x02(%x23)[4byte] %p6/z -> %z21.d
-a583bb17 : ld1sb z23.d, p6/Z, [x24, #3, MUL VL]      : ld1sb  +0x03(%x24)[4byte] %p6/z -> %z23.d
-a584bf59 : ld1sb z25.d, p7/Z, [x26, #4, MUL VL]      : ld1sb  +0x04(%x26)[4byte] %p7/z -> %z25.d
-a585bf9b : ld1sb z27.d, p7/Z, [x28, #5, MUL VL]      : ld1sb  +0x05(%x28)[4byte] %p7/z -> %z27.d
-a587bfff : ld1sb z31.d, p7/Z, [sp, #7, MUL VL]       : ld1sb  +0x07(%sp)[4byte] %p7/z -> %z31.d
+a581b6b3 : ld1sb z19.d, p5/Z, [x21, #1, MUL VL]      : ld1sb  +0x04(%x21)[4byte] %p5/z -> %z19.d
+a582baf5 : ld1sb z21.d, p6/Z, [x23, #2, MUL VL]      : ld1sb  +0x08(%x23)[4byte] %p6/z -> %z21.d
+a583bb17 : ld1sb z23.d, p6/Z, [x24, #3, MUL VL]      : ld1sb  +0x0c(%x24)[4byte] %p6/z -> %z23.d
+a584bf59 : ld1sb z25.d, p7/Z, [x26, #4, MUL VL]      : ld1sb  +0x10(%x26)[4byte] %p7/z -> %z25.d
+a585bf9b : ld1sb z27.d, p7/Z, [x28, #5, MUL VL]      : ld1sb  +0x14(%x28)[4byte] %p7/z -> %z27.d
+a587bfff : ld1sb z31.d, p7/Z, [sp, #7, MUL VL]       : ld1sb  +0x1c(%sp)[4byte] %p7/z -> %z31.d
 
 # LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1SB-Z.P.BR-S32)
 a5a04000 : ld1sb z0.s, p0/Z, [x0, x0]                : ld1sb  (%x0,%x0)[8byte] %p0/z -> %z0.s
@@ -12098,22 +12098,22 @@ a5bd5f9b : ld1sb z27.s, p7/Z, [x28, x29]             : ld1sb  (%x28,%x29)[8byte]
 a5be5fff : ld1sb z31.s, p7/Z, [sp, x30]              : ld1sb  (%sp,%x30)[8byte] %p7/z -> %z31.s
 
 # LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1SB-Z.P.BI-S32)
-a5a8a000 : ld1sb z0.s, p0/Z, [x0, #-8, MUL VL]       : ld1sb  -0x08(%x0)[8byte] %p0/z -> %z0.s
-a5a9a482 : ld1sb z2.s, p1/Z, [x4, #-7, MUL VL]       : ld1sb  -0x07(%x4)[8byte] %p1/z -> %z2.s
-a5aaa8c4 : ld1sb z4.s, p2/Z, [x6, #-6, MUL VL]       : ld1sb  -0x06(%x6)[8byte] %p2/z -> %z4.s
-a5aba906 : ld1sb z6.s, p2/Z, [x8, #-5, MUL VL]       : ld1sb  -0x05(%x8)[8byte] %p2/z -> %z6.s
-a5acad48 : ld1sb z8.s, p3/Z, [x10, #-4, MUL VL]      : ld1sb  -0x04(%x10)[8byte] %p3/z -> %z8.s
-a5adad6a : ld1sb z10.s, p3/Z, [x11, #-3, MUL VL]     : ld1sb  -0x03(%x11)[8byte] %p3/z -> %z10.s
-a5aeb1ac : ld1sb z12.s, p4/Z, [x13, #-2, MUL VL]     : ld1sb  -0x02(%x13)[8byte] %p4/z -> %z12.s
-a5afb1ee : ld1sb z14.s, p4/Z, [x15, #-1, MUL VL]     : ld1sb  -0x01(%x15)[8byte] %p4/z -> %z14.s
+a5a8a000 : ld1sb z0.s, p0/Z, [x0, #-8, MUL VL]       : ld1sb  -0x40(%x0)[8byte] %p0/z -> %z0.s
+a5a9a482 : ld1sb z2.s, p1/Z, [x4, #-7, MUL VL]       : ld1sb  -0x38(%x4)[8byte] %p1/z -> %z2.s
+a5aaa8c4 : ld1sb z4.s, p2/Z, [x6, #-6, MUL VL]       : ld1sb  -0x30(%x6)[8byte] %p2/z -> %z4.s
+a5aba906 : ld1sb z6.s, p2/Z, [x8, #-5, MUL VL]       : ld1sb  -0x28(%x8)[8byte] %p2/z -> %z6.s
+a5acad48 : ld1sb z8.s, p3/Z, [x10, #-4, MUL VL]      : ld1sb  -0x20(%x10)[8byte] %p3/z -> %z8.s
+a5adad6a : ld1sb z10.s, p3/Z, [x11, #-3, MUL VL]     : ld1sb  -0x18(%x11)[8byte] %p3/z -> %z10.s
+a5aeb1ac : ld1sb z12.s, p4/Z, [x13, #-2, MUL VL]     : ld1sb  -0x10(%x13)[8byte] %p4/z -> %z12.s
+a5afb1ee : ld1sb z14.s, p4/Z, [x15, #-1, MUL VL]     : ld1sb  -0x08(%x15)[8byte] %p4/z -> %z14.s
 a5a0b630 : ld1sb z16.s, p5/Z, [x17, #0, MUL VL]      : ld1sb  (%x17)[8byte] %p5/z -> %z16.s
 a5a0b671 : ld1sb z17.s, p5/Z, [x19, #0, MUL VL]      : ld1sb  (%x19)[8byte] %p5/z -> %z17.s
-a5a1b6b3 : ld1sb z19.s, p5/Z, [x21, #1, MUL VL]      : ld1sb  +0x01(%x21)[8byte] %p5/z -> %z19.s
-a5a2baf5 : ld1sb z21.s, p6/Z, [x23, #2, MUL VL]      : ld1sb  +0x02(%x23)[8byte] %p6/z -> %z21.s
-a5a3bb17 : ld1sb z23.s, p6/Z, [x24, #3, MUL VL]      : ld1sb  +0x03(%x24)[8byte] %p6/z -> %z23.s
-a5a4bf59 : ld1sb z25.s, p7/Z, [x26, #4, MUL VL]      : ld1sb  +0x04(%x26)[8byte] %p7/z -> %z25.s
-a5a5bf9b : ld1sb z27.s, p7/Z, [x28, #5, MUL VL]      : ld1sb  +0x05(%x28)[8byte] %p7/z -> %z27.s
-a5a7bfff : ld1sb z31.s, p7/Z, [sp, #7, MUL VL]       : ld1sb  +0x07(%sp)[8byte] %p7/z -> %z31.s
+a5a1b6b3 : ld1sb z19.s, p5/Z, [x21, #1, MUL VL]      : ld1sb  +0x08(%x21)[8byte] %p5/z -> %z19.s
+a5a2baf5 : ld1sb z21.s, p6/Z, [x23, #2, MUL VL]      : ld1sb  +0x10(%x23)[8byte] %p6/z -> %z21.s
+a5a3bb17 : ld1sb z23.s, p6/Z, [x24, #3, MUL VL]      : ld1sb  +0x18(%x24)[8byte] %p6/z -> %z23.s
+a5a4bf59 : ld1sb z25.s, p7/Z, [x26, #4, MUL VL]      : ld1sb  +0x20(%x26)[8byte] %p7/z -> %z25.s
+a5a5bf9b : ld1sb z27.s, p7/Z, [x28, #5, MUL VL]      : ld1sb  +0x28(%x28)[8byte] %p7/z -> %z27.s
+a5a7bfff : ld1sb z31.s, p7/Z, [sp, #7, MUL VL]       : ld1sb  +0x38(%sp)[8byte] %p7/z -> %z31.s
 
 # LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD1SB-Z.P.BR-S16)
 a5c04000 : ld1sb z0.h, p0/Z, [x0, x0]                : ld1sb  (%x0,%x0)[16byte] %p0/z -> %z0.h
@@ -12134,22 +12134,22 @@ a5dd5f9b : ld1sb z27.h, p7/Z, [x28, x29]             : ld1sb  (%x28,%x29)[16byte
 a5de5fff : ld1sb z31.h, p7/Z, [sp, x30]              : ld1sb  (%sp,%x30)[16byte] %p7/z -> %z31.h
 
 # LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1SB-Z.P.BI-S16)
-a5c8a000 : ld1sb z0.h, p0/Z, [x0, #-8, MUL VL]       : ld1sb  -0x08(%x0)[16byte] %p0/z -> %z0.h
-a5c9a482 : ld1sb z2.h, p1/Z, [x4, #-7, MUL VL]       : ld1sb  -0x07(%x4)[16byte] %p1/z -> %z2.h
-a5caa8c4 : ld1sb z4.h, p2/Z, [x6, #-6, MUL VL]       : ld1sb  -0x06(%x6)[16byte] %p2/z -> %z4.h
-a5cba906 : ld1sb z6.h, p2/Z, [x8, #-5, MUL VL]       : ld1sb  -0x05(%x8)[16byte] %p2/z -> %z6.h
-a5ccad48 : ld1sb z8.h, p3/Z, [x10, #-4, MUL VL]      : ld1sb  -0x04(%x10)[16byte] %p3/z -> %z8.h
-a5cdad6a : ld1sb z10.h, p3/Z, [x11, #-3, MUL VL]     : ld1sb  -0x03(%x11)[16byte] %p3/z -> %z10.h
-a5ceb1ac : ld1sb z12.h, p4/Z, [x13, #-2, MUL VL]     : ld1sb  -0x02(%x13)[16byte] %p4/z -> %z12.h
-a5cfb1ee : ld1sb z14.h, p4/Z, [x15, #-1, MUL VL]     : ld1sb  -0x01(%x15)[16byte] %p4/z -> %z14.h
+a5c8a000 : ld1sb z0.h, p0/Z, [x0, #-8, MUL VL]       : ld1sb  -0x80(%x0)[16byte] %p0/z -> %z0.h
+a5c9a482 : ld1sb z2.h, p1/Z, [x4, #-7, MUL VL]       : ld1sb  -0x70(%x4)[16byte] %p1/z -> %z2.h
+a5caa8c4 : ld1sb z4.h, p2/Z, [x6, #-6, MUL VL]       : ld1sb  -0x60(%x6)[16byte] %p2/z -> %z4.h
+a5cba906 : ld1sb z6.h, p2/Z, [x8, #-5, MUL VL]       : ld1sb  -0x50(%x8)[16byte] %p2/z -> %z6.h
+a5ccad48 : ld1sb z8.h, p3/Z, [x10, #-4, MUL VL]      : ld1sb  -0x40(%x10)[16byte] %p3/z -> %z8.h
+a5cdad6a : ld1sb z10.h, p3/Z, [x11, #-3, MUL VL]     : ld1sb  -0x30(%x11)[16byte] %p3/z -> %z10.h
+a5ceb1ac : ld1sb z12.h, p4/Z, [x13, #-2, MUL VL]     : ld1sb  -0x20(%x13)[16byte] %p4/z -> %z12.h
+a5cfb1ee : ld1sb z14.h, p4/Z, [x15, #-1, MUL VL]     : ld1sb  -0x10(%x15)[16byte] %p4/z -> %z14.h
 a5c0b630 : ld1sb z16.h, p5/Z, [x17, #0, MUL VL]      : ld1sb  (%x17)[16byte] %p5/z -> %z16.h
 a5c0b671 : ld1sb z17.h, p5/Z, [x19, #0, MUL VL]      : ld1sb  (%x19)[16byte] %p5/z -> %z17.h
-a5c1b6b3 : ld1sb z19.h, p5/Z, [x21, #1, MUL VL]      : ld1sb  +0x01(%x21)[16byte] %p5/z -> %z19.h
-a5c2baf5 : ld1sb z21.h, p6/Z, [x23, #2, MUL VL]      : ld1sb  +0x02(%x23)[16byte] %p6/z -> %z21.h
-a5c3bb17 : ld1sb z23.h, p6/Z, [x24, #3, MUL VL]      : ld1sb  +0x03(%x24)[16byte] %p6/z -> %z23.h
-a5c4bf59 : ld1sb z25.h, p7/Z, [x26, #4, MUL VL]      : ld1sb  +0x04(%x26)[16byte] %p7/z -> %z25.h
-a5c5bf9b : ld1sb z27.h, p7/Z, [x28, #5, MUL VL]      : ld1sb  +0x05(%x28)[16byte] %p7/z -> %z27.h
-a5c7bfff : ld1sb z31.h, p7/Z, [sp, #7, MUL VL]       : ld1sb  +0x07(%sp)[16byte] %p7/z -> %z31.h
+a5c1b6b3 : ld1sb z19.h, p5/Z, [x21, #1, MUL VL]      : ld1sb  +0x10(%x21)[16byte] %p5/z -> %z19.h
+a5c2baf5 : ld1sb z21.h, p6/Z, [x23, #2, MUL VL]      : ld1sb  +0x20(%x23)[16byte] %p6/z -> %z21.h
+a5c3bb17 : ld1sb z23.h, p6/Z, [x24, #3, MUL VL]      : ld1sb  +0x30(%x24)[16byte] %p6/z -> %z23.h
+a5c4bf59 : ld1sb z25.h, p7/Z, [x26, #4, MUL VL]      : ld1sb  +0x40(%x26)[16byte] %p7/z -> %z25.h
+a5c5bf9b : ld1sb z27.h, p7/Z, [x28, #5, MUL VL]      : ld1sb  +0x50(%x28)[16byte] %p7/z -> %z27.h
+a5c7bfff : ld1sb z31.h, p7/Z, [sp, #7, MUL VL]       : ld1sb  +0x70(%sp)[16byte] %p7/z -> %z31.h
 
 # LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1SB-Z.P.BZ-D.x32.unscaled)
 c4000000 : ld1sb z0.d, p0/Z, [x0, z0.d, UXTW]        : ld1sb  (%x0,%z0.d,uxtw)[4byte] %p0/z -> %z0.d
@@ -12326,22 +12326,22 @@ a51d5f9b : ld1sh z27.d, p7/Z, [x28, x29, LSL #1]     : ld1sh  (%x28,%x29,lsl #1)
 a51e5fff : ld1sh z31.d, p7/Z, [sp, x30, LSL #1]      : ld1sh  (%sp,%x30,lsl #1)[8byte] %p7/z -> %z31.d
 
 # LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1SH-Z.P.BI-S64)
-a508a000 : ld1sh z0.d, p0/Z, [x0, #-8, MUL VL]       : ld1sh  -0x08(%x0)[8byte] %p0/z -> %z0.d
-a509a482 : ld1sh z2.d, p1/Z, [x4, #-7, MUL VL]       : ld1sh  -0x07(%x4)[8byte] %p1/z -> %z2.d
-a50aa8c4 : ld1sh z4.d, p2/Z, [x6, #-6, MUL VL]       : ld1sh  -0x06(%x6)[8byte] %p2/z -> %z4.d
-a50ba906 : ld1sh z6.d, p2/Z, [x8, #-5, MUL VL]       : ld1sh  -0x05(%x8)[8byte] %p2/z -> %z6.d
-a50cad48 : ld1sh z8.d, p3/Z, [x10, #-4, MUL VL]      : ld1sh  -0x04(%x10)[8byte] %p3/z -> %z8.d
-a50dad6a : ld1sh z10.d, p3/Z, [x11, #-3, MUL VL]     : ld1sh  -0x03(%x11)[8byte] %p3/z -> %z10.d
-a50eb1ac : ld1sh z12.d, p4/Z, [x13, #-2, MUL VL]     : ld1sh  -0x02(%x13)[8byte] %p4/z -> %z12.d
-a50fb1ee : ld1sh z14.d, p4/Z, [x15, #-1, MUL VL]     : ld1sh  -0x01(%x15)[8byte] %p4/z -> %z14.d
+a508a000 : ld1sh z0.d, p0/Z, [x0, #-8, MUL VL]       : ld1sh  -0x40(%x0)[8byte] %p0/z -> %z0.d
+a509a482 : ld1sh z2.d, p1/Z, [x4, #-7, MUL VL]       : ld1sh  -0x38(%x4)[8byte] %p1/z -> %z2.d
+a50aa8c4 : ld1sh z4.d, p2/Z, [x6, #-6, MUL VL]       : ld1sh  -0x30(%x6)[8byte] %p2/z -> %z4.d
+a50ba906 : ld1sh z6.d, p2/Z, [x8, #-5, MUL VL]       : ld1sh  -0x28(%x8)[8byte] %p2/z -> %z6.d
+a50cad48 : ld1sh z8.d, p3/Z, [x10, #-4, MUL VL]      : ld1sh  -0x20(%x10)[8byte] %p3/z -> %z8.d
+a50dad6a : ld1sh z10.d, p3/Z, [x11, #-3, MUL VL]     : ld1sh  -0x18(%x11)[8byte] %p3/z -> %z10.d
+a50eb1ac : ld1sh z12.d, p4/Z, [x13, #-2, MUL VL]     : ld1sh  -0x10(%x13)[8byte] %p4/z -> %z12.d
+a50fb1ee : ld1sh z14.d, p4/Z, [x15, #-1, MUL VL]     : ld1sh  -0x08(%x15)[8byte] %p4/z -> %z14.d
 a500b630 : ld1sh z16.d, p5/Z, [x17, #0, MUL VL]      : ld1sh  (%x17)[8byte] %p5/z -> %z16.d
 a500b671 : ld1sh z17.d, p5/Z, [x19, #0, MUL VL]      : ld1sh  (%x19)[8byte] %p5/z -> %z17.d
-a501b6b3 : ld1sh z19.d, p5/Z, [x21, #1, MUL VL]      : ld1sh  +0x01(%x21)[8byte] %p5/z -> %z19.d
-a502baf5 : ld1sh z21.d, p6/Z, [x23, #2, MUL VL]      : ld1sh  +0x02(%x23)[8byte] %p6/z -> %z21.d
-a503bb17 : ld1sh z23.d, p6/Z, [x24, #3, MUL VL]      : ld1sh  +0x03(%x24)[8byte] %p6/z -> %z23.d
-a504bf59 : ld1sh z25.d, p7/Z, [x26, #4, MUL VL]      : ld1sh  +0x04(%x26)[8byte] %p7/z -> %z25.d
-a505bf9b : ld1sh z27.d, p7/Z, [x28, #5, MUL VL]      : ld1sh  +0x05(%x28)[8byte] %p7/z -> %z27.d
-a507bfff : ld1sh z31.d, p7/Z, [sp, #7, MUL VL]       : ld1sh  +0x07(%sp)[8byte] %p7/z -> %z31.d
+a501b6b3 : ld1sh z19.d, p5/Z, [x21, #1, MUL VL]      : ld1sh  +0x08(%x21)[8byte] %p5/z -> %z19.d
+a502baf5 : ld1sh z21.d, p6/Z, [x23, #2, MUL VL]      : ld1sh  +0x10(%x23)[8byte] %p6/z -> %z21.d
+a503bb17 : ld1sh z23.d, p6/Z, [x24, #3, MUL VL]      : ld1sh  +0x18(%x24)[8byte] %p6/z -> %z23.d
+a504bf59 : ld1sh z25.d, p7/Z, [x26, #4, MUL VL]      : ld1sh  +0x20(%x26)[8byte] %p7/z -> %z25.d
+a505bf9b : ld1sh z27.d, p7/Z, [x28, #5, MUL VL]      : ld1sh  +0x28(%x28)[8byte] %p7/z -> %z27.d
+a507bfff : ld1sh z31.d, p7/Z, [sp, #7, MUL VL]       : ld1sh  +0x38(%sp)[8byte] %p7/z -> %z31.d
 
 # LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1] (LD1SH-Z.P.BR-S32)
 a5204000 : ld1sh z0.s, p0/Z, [x0, x0, LSL #1]        : ld1sh  (%x0,%x0,lsl #1)[16byte] %p0/z -> %z0.s
@@ -12362,22 +12362,22 @@ a53d5f9b : ld1sh z27.s, p7/Z, [x28, x29, LSL #1]     : ld1sh  (%x28,%x29,lsl #1)
 a53e5fff : ld1sh z31.s, p7/Z, [sp, x30, LSL #1]      : ld1sh  (%sp,%x30,lsl #1)[16byte] %p7/z -> %z31.s
 
 # LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1SH-Z.P.BI-S32)
-a528a000 : ld1sh z0.s, p0/Z, [x0, #-8, MUL VL]       : ld1sh  -0x08(%x0)[16byte] %p0/z -> %z0.s
-a529a482 : ld1sh z2.s, p1/Z, [x4, #-7, MUL VL]       : ld1sh  -0x07(%x4)[16byte] %p1/z -> %z2.s
-a52aa8c4 : ld1sh z4.s, p2/Z, [x6, #-6, MUL VL]       : ld1sh  -0x06(%x6)[16byte] %p2/z -> %z4.s
-a52ba906 : ld1sh z6.s, p2/Z, [x8, #-5, MUL VL]       : ld1sh  -0x05(%x8)[16byte] %p2/z -> %z6.s
-a52cad48 : ld1sh z8.s, p3/Z, [x10, #-4, MUL VL]      : ld1sh  -0x04(%x10)[16byte] %p3/z -> %z8.s
-a52dad6a : ld1sh z10.s, p3/Z, [x11, #-3, MUL VL]     : ld1sh  -0x03(%x11)[16byte] %p3/z -> %z10.s
-a52eb1ac : ld1sh z12.s, p4/Z, [x13, #-2, MUL VL]     : ld1sh  -0x02(%x13)[16byte] %p4/z -> %z12.s
-a52fb1ee : ld1sh z14.s, p4/Z, [x15, #-1, MUL VL]     : ld1sh  -0x01(%x15)[16byte] %p4/z -> %z14.s
+a528a000 : ld1sh z0.s, p0/Z, [x0, #-8, MUL VL]       : ld1sh  -0x80(%x0)[16byte] %p0/z -> %z0.s
+a529a482 : ld1sh z2.s, p1/Z, [x4, #-7, MUL VL]       : ld1sh  -0x70(%x4)[16byte] %p1/z -> %z2.s
+a52aa8c4 : ld1sh z4.s, p2/Z, [x6, #-6, MUL VL]       : ld1sh  -0x60(%x6)[16byte] %p2/z -> %z4.s
+a52ba906 : ld1sh z6.s, p2/Z, [x8, #-5, MUL VL]       : ld1sh  -0x50(%x8)[16byte] %p2/z -> %z6.s
+a52cad48 : ld1sh z8.s, p3/Z, [x10, #-4, MUL VL]      : ld1sh  -0x40(%x10)[16byte] %p3/z -> %z8.s
+a52dad6a : ld1sh z10.s, p3/Z, [x11, #-3, MUL VL]     : ld1sh  -0x30(%x11)[16byte] %p3/z -> %z10.s
+a52eb1ac : ld1sh z12.s, p4/Z, [x13, #-2, MUL VL]     : ld1sh  -0x20(%x13)[16byte] %p4/z -> %z12.s
+a52fb1ee : ld1sh z14.s, p4/Z, [x15, #-1, MUL VL]     : ld1sh  -0x10(%x15)[16byte] %p4/z -> %z14.s
 a520b630 : ld1sh z16.s, p5/Z, [x17, #0, MUL VL]      : ld1sh  (%x17)[16byte] %p5/z -> %z16.s
 a520b671 : ld1sh z17.s, p5/Z, [x19, #0, MUL VL]      : ld1sh  (%x19)[16byte] %p5/z -> %z17.s
-a521b6b3 : ld1sh z19.s, p5/Z, [x21, #1, MUL VL]      : ld1sh  +0x01(%x21)[16byte] %p5/z -> %z19.s
-a522baf5 : ld1sh z21.s, p6/Z, [x23, #2, MUL VL]      : ld1sh  +0x02(%x23)[16byte] %p6/z -> %z21.s
-a523bb17 : ld1sh z23.s, p6/Z, [x24, #3, MUL VL]      : ld1sh  +0x03(%x24)[16byte] %p6/z -> %z23.s
-a524bf59 : ld1sh z25.s, p7/Z, [x26, #4, MUL VL]      : ld1sh  +0x04(%x26)[16byte] %p7/z -> %z25.s
-a525bf9b : ld1sh z27.s, p7/Z, [x28, #5, MUL VL]      : ld1sh  +0x05(%x28)[16byte] %p7/z -> %z27.s
-a527bfff : ld1sh z31.s, p7/Z, [sp, #7, MUL VL]       : ld1sh  +0x07(%sp)[16byte] %p7/z -> %z31.s
+a521b6b3 : ld1sh z19.s, p5/Z, [x21, #1, MUL VL]      : ld1sh  +0x10(%x21)[16byte] %p5/z -> %z19.s
+a522baf5 : ld1sh z21.s, p6/Z, [x23, #2, MUL VL]      : ld1sh  +0x20(%x23)[16byte] %p6/z -> %z21.s
+a523bb17 : ld1sh z23.s, p6/Z, [x24, #3, MUL VL]      : ld1sh  +0x30(%x24)[16byte] %p6/z -> %z23.s
+a524bf59 : ld1sh z25.s, p7/Z, [x26, #4, MUL VL]      : ld1sh  +0x40(%x26)[16byte] %p7/z -> %z25.s
+a525bf9b : ld1sh z27.s, p7/Z, [x28, #5, MUL VL]      : ld1sh  +0x50(%x28)[16byte] %p7/z -> %z27.s
+a527bfff : ld1sh z31.s, p7/Z, [sp, #7, MUL VL]       : ld1sh  +0x70(%sp)[16byte] %p7/z -> %z31.s
 
 # LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1SH-Z.P.BZ-D.x32.unscaled)
 c4800000 : ld1sh z0.d, p0/Z, [x0, z0.d, UXTW]        : ld1sh  (%x0,%z0.d,uxtw)[8byte] %p0/z -> %z0.d
@@ -12520,22 +12520,22 @@ a49d5f9b : ld1sw z27.d, p7/Z, [x28, x29, LSL #2]     : ld1sw  (%x28,%x29,lsl #2)
 a49e5fff : ld1sw z31.d, p7/Z, [sp, x30, LSL #2]      : ld1sw  (%sp,%x30,lsl #2)[16byte] %p7/z -> %z31.d
 
 # LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1SW-Z.P.BI-S64)
-a488a000 : ld1sw z0.d, p0/Z, [x0, #-8, MUL VL]       : ld1sw  -0x08(%x0)[16byte] %p0/z -> %z0.d
-a489a482 : ld1sw z2.d, p1/Z, [x4, #-7, MUL VL]       : ld1sw  -0x07(%x4)[16byte] %p1/z -> %z2.d
-a48aa8c4 : ld1sw z4.d, p2/Z, [x6, #-6, MUL VL]       : ld1sw  -0x06(%x6)[16byte] %p2/z -> %z4.d
-a48ba906 : ld1sw z6.d, p2/Z, [x8, #-5, MUL VL]       : ld1sw  -0x05(%x8)[16byte] %p2/z -> %z6.d
-a48cad48 : ld1sw z8.d, p3/Z, [x10, #-4, MUL VL]      : ld1sw  -0x04(%x10)[16byte] %p3/z -> %z8.d
-a48dad6a : ld1sw z10.d, p3/Z, [x11, #-3, MUL VL]     : ld1sw  -0x03(%x11)[16byte] %p3/z -> %z10.d
-a48eb1ac : ld1sw z12.d, p4/Z, [x13, #-2, MUL VL]     : ld1sw  -0x02(%x13)[16byte] %p4/z -> %z12.d
-a48fb1ee : ld1sw z14.d, p4/Z, [x15, #-1, MUL VL]     : ld1sw  -0x01(%x15)[16byte] %p4/z -> %z14.d
+a488a000 : ld1sw z0.d, p0/Z, [x0, #-8, MUL VL]       : ld1sw  -0x80(%x0)[16byte] %p0/z -> %z0.d
+a489a482 : ld1sw z2.d, p1/Z, [x4, #-7, MUL VL]       : ld1sw  -0x70(%x4)[16byte] %p1/z -> %z2.d
+a48aa8c4 : ld1sw z4.d, p2/Z, [x6, #-6, MUL VL]       : ld1sw  -0x60(%x6)[16byte] %p2/z -> %z4.d
+a48ba906 : ld1sw z6.d, p2/Z, [x8, #-5, MUL VL]       : ld1sw  -0x50(%x8)[16byte] %p2/z -> %z6.d
+a48cad48 : ld1sw z8.d, p3/Z, [x10, #-4, MUL VL]      : ld1sw  -0x40(%x10)[16byte] %p3/z -> %z8.d
+a48dad6a : ld1sw z10.d, p3/Z, [x11, #-3, MUL VL]     : ld1sw  -0x30(%x11)[16byte] %p3/z -> %z10.d
+a48eb1ac : ld1sw z12.d, p4/Z, [x13, #-2, MUL VL]     : ld1sw  -0x20(%x13)[16byte] %p4/z -> %z12.d
+a48fb1ee : ld1sw z14.d, p4/Z, [x15, #-1, MUL VL]     : ld1sw  -0x10(%x15)[16byte] %p4/z -> %z14.d
 a480b630 : ld1sw z16.d, p5/Z, [x17, #0, MUL VL]      : ld1sw  (%x17)[16byte] %p5/z -> %z16.d
 a480b671 : ld1sw z17.d, p5/Z, [x19, #0, MUL VL]      : ld1sw  (%x19)[16byte] %p5/z -> %z17.d
-a481b6b3 : ld1sw z19.d, p5/Z, [x21, #1, MUL VL]      : ld1sw  +0x01(%x21)[16byte] %p5/z -> %z19.d
-a482baf5 : ld1sw z21.d, p6/Z, [x23, #2, MUL VL]      : ld1sw  +0x02(%x23)[16byte] %p6/z -> %z21.d
-a483bb17 : ld1sw z23.d, p6/Z, [x24, #3, MUL VL]      : ld1sw  +0x03(%x24)[16byte] %p6/z -> %z23.d
-a484bf59 : ld1sw z25.d, p7/Z, [x26, #4, MUL VL]      : ld1sw  +0x04(%x26)[16byte] %p7/z -> %z25.d
-a485bf9b : ld1sw z27.d, p7/Z, [x28, #5, MUL VL]      : ld1sw  +0x05(%x28)[16byte] %p7/z -> %z27.d
-a487bfff : ld1sw z31.d, p7/Z, [sp, #7, MUL VL]       : ld1sw  +0x07(%sp)[16byte] %p7/z -> %z31.d
+a481b6b3 : ld1sw z19.d, p5/Z, [x21, #1, MUL VL]      : ld1sw  +0x10(%x21)[16byte] %p5/z -> %z19.d
+a482baf5 : ld1sw z21.d, p6/Z, [x23, #2, MUL VL]      : ld1sw  +0x20(%x23)[16byte] %p6/z -> %z21.d
+a483bb17 : ld1sw z23.d, p6/Z, [x24, #3, MUL VL]      : ld1sw  +0x30(%x24)[16byte] %p6/z -> %z23.d
+a484bf59 : ld1sw z25.d, p7/Z, [x26, #4, MUL VL]      : ld1sw  +0x40(%x26)[16byte] %p7/z -> %z25.d
+a485bf9b : ld1sw z27.d, p7/Z, [x28, #5, MUL VL]      : ld1sw  +0x50(%x28)[16byte] %p7/z -> %z27.d
+a487bfff : ld1sw z31.d, p7/Z, [sp, #7, MUL VL]       : ld1sw  +0x70(%sp)[16byte] %p7/z -> %z31.d
 
 # LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1SW-Z.P.BZ-D.x32.unscaled)
 c5000000 : ld1sw z0.d, p0/Z, [x0, z0.d, UXTW]        : ld1sw  (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d
@@ -12764,22 +12764,22 @@ a55d5f9b : ld1w z27.s, p7/Z, [x28, x29, LSL #2]      : ld1w   (%x28,%x29,lsl #2)
 a55e5fff : ld1w z31.s, p7/Z, [sp, x30, LSL #2]       : ld1w   (%sp,%x30,lsl #2)[32byte] %p7/z -> %z31.s
 
 # LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1W-Z.P.BI-U32)
-a548a000 : ld1w z0.s, p0/Z, [x0, #-8, MUL VL]        : ld1w   -0x08(%x0)[32byte] %p0/z -> %z0.s
-a549a482 : ld1w z2.s, p1/Z, [x4, #-7, MUL VL]        : ld1w   -0x07(%x4)[32byte] %p1/z -> %z2.s
-a54aa8c4 : ld1w z4.s, p2/Z, [x6, #-6, MUL VL]        : ld1w   -0x06(%x6)[32byte] %p2/z -> %z4.s
-a54ba906 : ld1w z6.s, p2/Z, [x8, #-5, MUL VL]        : ld1w   -0x05(%x8)[32byte] %p2/z -> %z6.s
-a54cad48 : ld1w z8.s, p3/Z, [x10, #-4, MUL VL]       : ld1w   -0x04(%x10)[32byte] %p3/z -> %z8.s
-a54dad6a : ld1w z10.s, p3/Z, [x11, #-3, MUL VL]      : ld1w   -0x03(%x11)[32byte] %p3/z -> %z10.s
-a54eb1ac : ld1w z12.s, p4/Z, [x13, #-2, MUL VL]      : ld1w   -0x02(%x13)[32byte] %p4/z -> %z12.s
-a54fb1ee : ld1w z14.s, p4/Z, [x15, #-1, MUL VL]      : ld1w   -0x01(%x15)[32byte] %p4/z -> %z14.s
+a548a000 : ld1w z0.s, p0/Z, [x0, #-8, MUL VL]        : ld1w   -0x0100(%x0)[32byte] %p0/z -> %z0.s
+a549a482 : ld1w z2.s, p1/Z, [x4, #-7, MUL VL]        : ld1w   -0xe0(%x4)[32byte] %p1/z -> %z2.s
+a54aa8c4 : ld1w z4.s, p2/Z, [x6, #-6, MUL VL]        : ld1w   -0xc0(%x6)[32byte] %p2/z -> %z4.s
+a54ba906 : ld1w z6.s, p2/Z, [x8, #-5, MUL VL]        : ld1w   -0xa0(%x8)[32byte] %p2/z -> %z6.s
+a54cad48 : ld1w z8.s, p3/Z, [x10, #-4, MUL VL]       : ld1w   -0x80(%x10)[32byte] %p3/z -> %z8.s
+a54dad6a : ld1w z10.s, p3/Z, [x11, #-3, MUL VL]      : ld1w   -0x60(%x11)[32byte] %p3/z -> %z10.s
+a54eb1ac : ld1w z12.s, p4/Z, [x13, #-2, MUL VL]      : ld1w   -0x40(%x13)[32byte] %p4/z -> %z12.s
+a54fb1ee : ld1w z14.s, p4/Z, [x15, #-1, MUL VL]      : ld1w   -0x20(%x15)[32byte] %p4/z -> %z14.s
 a540b630 : ld1w z16.s, p5/Z, [x17, #0, MUL VL]       : ld1w   (%x17)[32byte] %p5/z -> %z16.s
 a540b671 : ld1w z17.s, p5/Z, [x19, #0, MUL VL]       : ld1w   (%x19)[32byte] %p5/z -> %z17.s
-a541b6b3 : ld1w z19.s, p5/Z, [x21, #1, MUL VL]       : ld1w   +0x01(%x21)[32byte] %p5/z -> %z19.s
-a542baf5 : ld1w z21.s, p6/Z, [x23, #2, MUL VL]       : ld1w   +0x02(%x23)[32byte] %p6/z -> %z21.s
-a543bb17 : ld1w z23.s, p6/Z, [x24, #3, MUL VL]       : ld1w   +0x03(%x24)[32byte] %p6/z -> %z23.s
-a544bf59 : ld1w z25.s, p7/Z, [x26, #4, MUL VL]       : ld1w   +0x04(%x26)[32byte] %p7/z -> %z25.s
-a545bf9b : ld1w z27.s, p7/Z, [x28, #5, MUL VL]       : ld1w   +0x05(%x28)[32byte] %p7/z -> %z27.s
-a547bfff : ld1w z31.s, p7/Z, [sp, #7, MUL VL]        : ld1w   +0x07(%sp)[32byte] %p7/z -> %z31.s
+a541b6b3 : ld1w z19.s, p5/Z, [x21, #1, MUL VL]       : ld1w   +0x20(%x21)[32byte] %p5/z -> %z19.s
+a542baf5 : ld1w z21.s, p6/Z, [x23, #2, MUL VL]       : ld1w   +0x40(%x23)[32byte] %p6/z -> %z21.s
+a543bb17 : ld1w z23.s, p6/Z, [x24, #3, MUL VL]       : ld1w   +0x60(%x24)[32byte] %p6/z -> %z23.s
+a544bf59 : ld1w z25.s, p7/Z, [x26, #4, MUL VL]       : ld1w   +0x80(%x26)[32byte] %p7/z -> %z25.s
+a545bf9b : ld1w z27.s, p7/Z, [x28, #5, MUL VL]       : ld1w   +0xa0(%x28)[32byte] %p7/z -> %z27.s
+a547bfff : ld1w z31.s, p7/Z, [sp, #7, MUL VL]        : ld1w   +0xe0(%sp)[32byte] %p7/z -> %z31.s
 
 # LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #2] (LD1W-Z.P.BR-U64)
 a5604000 : ld1w z0.d, p0/Z, [x0, x0, LSL #2]         : ld1w   (%x0,%x0,lsl #2)[16byte] %p0/z -> %z0.d
@@ -12800,22 +12800,22 @@ a57d5f9b : ld1w z27.d, p7/Z, [x28, x29, LSL #2]      : ld1w   (%x28,%x29,lsl #2)
 a57e5fff : ld1w z31.d, p7/Z, [sp, x30, LSL #2]       : ld1w   (%sp,%x30,lsl #2)[16byte] %p7/z -> %z31.d
 
 # LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD1W-Z.P.BI-U64)
-a568a000 : ld1w z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1w   -0x08(%x0)[16byte] %p0/z -> %z0.d
-a569a482 : ld1w z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1w   -0x07(%x4)[16byte] %p1/z -> %z2.d
-a56aa8c4 : ld1w z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1w   -0x06(%x6)[16byte] %p2/z -> %z4.d
-a56ba906 : ld1w z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1w   -0x05(%x8)[16byte] %p2/z -> %z6.d
-a56cad48 : ld1w z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1w   -0x04(%x10)[16byte] %p3/z -> %z8.d
-a56dad6a : ld1w z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1w   -0x03(%x11)[16byte] %p3/z -> %z10.d
-a56eb1ac : ld1w z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1w   -0x02(%x13)[16byte] %p4/z -> %z12.d
-a56fb1ee : ld1w z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1w   -0x01(%x15)[16byte] %p4/z -> %z14.d
+a568a000 : ld1w z0.d, p0/Z, [x0, #-8, MUL VL]        : ld1w   -0x80(%x0)[16byte] %p0/z -> %z0.d
+a569a482 : ld1w z2.d, p1/Z, [x4, #-7, MUL VL]        : ld1w   -0x70(%x4)[16byte] %p1/z -> %z2.d
+a56aa8c4 : ld1w z4.d, p2/Z, [x6, #-6, MUL VL]        : ld1w   -0x60(%x6)[16byte] %p2/z -> %z4.d
+a56ba906 : ld1w z6.d, p2/Z, [x8, #-5, MUL VL]        : ld1w   -0x50(%x8)[16byte] %p2/z -> %z6.d
+a56cad48 : ld1w z8.d, p3/Z, [x10, #-4, MUL VL]       : ld1w   -0x40(%x10)[16byte] %p3/z -> %z8.d
+a56dad6a : ld1w z10.d, p3/Z, [x11, #-3, MUL VL]      : ld1w   -0x30(%x11)[16byte] %p3/z -> %z10.d
+a56eb1ac : ld1w z12.d, p4/Z, [x13, #-2, MUL VL]      : ld1w   -0x20(%x13)[16byte] %p4/z -> %z12.d
+a56fb1ee : ld1w z14.d, p4/Z, [x15, #-1, MUL VL]      : ld1w   -0x10(%x15)[16byte] %p4/z -> %z14.d
 a560b630 : ld1w z16.d, p5/Z, [x17, #0, MUL VL]       : ld1w   (%x17)[16byte] %p5/z -> %z16.d
 a560b671 : ld1w z17.d, p5/Z, [x19, #0, MUL VL]       : ld1w   (%x19)[16byte] %p5/z -> %z17.d
-a561b6b3 : ld1w z19.d, p5/Z, [x21, #1, MUL VL]       : ld1w   +0x01(%x21)[16byte] %p5/z -> %z19.d
-a562baf5 : ld1w z21.d, p6/Z, [x23, #2, MUL VL]       : ld1w   +0x02(%x23)[16byte] %p6/z -> %z21.d
-a563bb17 : ld1w z23.d, p6/Z, [x24, #3, MUL VL]       : ld1w   +0x03(%x24)[16byte] %p6/z -> %z23.d
-a564bf59 : ld1w z25.d, p7/Z, [x26, #4, MUL VL]       : ld1w   +0x04(%x26)[16byte] %p7/z -> %z25.d
-a565bf9b : ld1w z27.d, p7/Z, [x28, #5, MUL VL]       : ld1w   +0x05(%x28)[16byte] %p7/z -> %z27.d
-a567bfff : ld1w z31.d, p7/Z, [sp, #7, MUL VL]        : ld1w   +0x07(%sp)[16byte] %p7/z -> %z31.d
+a561b6b3 : ld1w z19.d, p5/Z, [x21, #1, MUL VL]       : ld1w   +0x10(%x21)[16byte] %p5/z -> %z19.d
+a562baf5 : ld1w z21.d, p6/Z, [x23, #2, MUL VL]       : ld1w   +0x20(%x23)[16byte] %p6/z -> %z21.d
+a563bb17 : ld1w z23.d, p6/Z, [x24, #3, MUL VL]       : ld1w   +0x30(%x24)[16byte] %p6/z -> %z23.d
+a564bf59 : ld1w z25.d, p7/Z, [x26, #4, MUL VL]       : ld1w   +0x40(%x26)[16byte] %p7/z -> %z25.d
+a565bf9b : ld1w z27.d, p7/Z, [x28, #5, MUL VL]       : ld1w   +0x50(%x28)[16byte] %p7/z -> %z27.d
+a567bfff : ld1w z31.d, p7/Z, [sp, #7, MUL VL]        : ld1w   +0x70(%sp)[16byte] %p7/z -> %z31.d
 
 # LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D, <extend>] (LD1W-Z.P.BZ-D.x32.unscaled)
 c5004000 : ld1w z0.d, p0/Z, [x0, z0.d, UXTW]         : ld1w   (%x0,%z0.d,uxtw)[16byte] %p0/z -> %z0.d
@@ -12958,22 +12958,22 @@ a43ddf9b : ld2b {z27.b, z28.b}, p7/Z, [x28, x29]     : ld2b   (%x28,%x29)[64byte
 a43edfff : ld2b {z31.b, z0.b}, p7/Z, [sp, x30]       : ld2b   (%sp,%x30)[64byte] %p7/z -> %z31.b %z0.b
 
 # LD2B    { <Zt1>.B, <Zt2>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD2B-Z.P.BI-Contiguous)
-a428e000 : ld2b {z0.b, z1.b}, p0/Z, [x0, #-16, MUL VL] : ld2b   -0x10(%x0)[64byte] %p0/z -> %z0.b %z1.b
-a429e482 : ld2b {z2.b, z3.b}, p1/Z, [x4, #-14, MUL VL] : ld2b   -0x0e(%x4)[64byte] %p1/z -> %z2.b %z3.b
-a42ae8c4 : ld2b {z4.b, z5.b}, p2/Z, [x6, #-12, MUL VL] : ld2b   -0x0c(%x6)[64byte] %p2/z -> %z4.b %z5.b
-a42be906 : ld2b {z6.b, z7.b}, p2/Z, [x8, #-10, MUL VL] : ld2b   -0x0a(%x8)[64byte] %p2/z -> %z6.b %z7.b
-a42ced48 : ld2b {z8.b, z9.b}, p3/Z, [x10, #-8, MUL VL] : ld2b   -0x08(%x10)[64byte] %p3/z -> %z8.b %z9.b
-a42ded6a : ld2b {z10.b, z11.b}, p3/Z, [x11, #-6, MUL VL] : ld2b   -0x06(%x11)[64byte] %p3/z -> %z10.b %z11.b
-a42ef1ac : ld2b {z12.b, z13.b}, p4/Z, [x13, #-4, MUL VL] : ld2b   -0x04(%x13)[64byte] %p4/z -> %z12.b %z13.b
-a42ff1ee : ld2b {z14.b, z15.b}, p4/Z, [x15, #-2, MUL VL] : ld2b   -0x02(%x15)[64byte] %p4/z -> %z14.b %z15.b
+a428e000 : ld2b {z0.b, z1.b}, p0/Z, [x0, #-16, MUL VL] : ld2b   -0x0200(%x0)[64byte] %p0/z -> %z0.b %z1.b
+a429e482 : ld2b {z2.b, z3.b}, p1/Z, [x4, #-14, MUL VL] : ld2b   -0x01c0(%x4)[64byte] %p1/z -> %z2.b %z3.b
+a42ae8c4 : ld2b {z4.b, z5.b}, p2/Z, [x6, #-12, MUL VL] : ld2b   -0x0180(%x6)[64byte] %p2/z -> %z4.b %z5.b
+a42be906 : ld2b {z6.b, z7.b}, p2/Z, [x8, #-10, MUL VL] : ld2b   -0x0140(%x8)[64byte] %p2/z -> %z6.b %z7.b
+a42ced48 : ld2b {z8.b, z9.b}, p3/Z, [x10, #-8, MUL VL] : ld2b   -0x0100(%x10)[64byte] %p3/z -> %z8.b %z9.b
+a42ded6a : ld2b {z10.b, z11.b}, p3/Z, [x11, #-6, MUL VL] : ld2b   -0xc0(%x11)[64byte] %p3/z -> %z10.b %z11.b
+a42ef1ac : ld2b {z12.b, z13.b}, p4/Z, [x13, #-4, MUL VL] : ld2b   -0x80(%x13)[64byte] %p4/z -> %z12.b %z13.b
+a42ff1ee : ld2b {z14.b, z15.b}, p4/Z, [x15, #-2, MUL VL] : ld2b   -0x40(%x15)[64byte] %p4/z -> %z14.b %z15.b
 a420f630 : ld2b {z16.b, z17.b}, p5/Z, [x17, #0, MUL VL] : ld2b   (%x17)[64byte] %p5/z -> %z16.b %z17.b
 a420f671 : ld2b {z17.b, z18.b}, p5/Z, [x19, #0, MUL VL] : ld2b   (%x19)[64byte] %p5/z -> %z17.b %z18.b
-a421f6b3 : ld2b {z19.b, z20.b}, p5/Z, [x21, #2, MUL VL] : ld2b   +0x02(%x21)[64byte] %p5/z -> %z19.b %z20.b
-a422faf5 : ld2b {z21.b, z22.b}, p6/Z, [x23, #4, MUL VL] : ld2b   +0x04(%x23)[64byte] %p6/z -> %z21.b %z22.b
-a423fb17 : ld2b {z23.b, z24.b}, p6/Z, [x24, #6, MUL VL] : ld2b   +0x06(%x24)[64byte] %p6/z -> %z23.b %z24.b
-a424ff59 : ld2b {z25.b, z26.b}, p7/Z, [x26, #8, MUL VL] : ld2b   +0x08(%x26)[64byte] %p7/z -> %z25.b %z26.b
-a425ff9b : ld2b {z27.b, z28.b}, p7/Z, [x28, #10, MUL VL] : ld2b   +0x0a(%x28)[64byte] %p7/z -> %z27.b %z28.b
-a427ffff : ld2b {z31.b, z0.b}, p7/Z, [sp, #14, MUL VL] : ld2b   +0x0e(%sp)[64byte] %p7/z -> %z31.b %z0.b
+a421f6b3 : ld2b {z19.b, z20.b}, p5/Z, [x21, #2, MUL VL] : ld2b   +0x40(%x21)[64byte] %p5/z -> %z19.b %z20.b
+a422faf5 : ld2b {z21.b, z22.b}, p6/Z, [x23, #4, MUL VL] : ld2b   +0x80(%x23)[64byte] %p6/z -> %z21.b %z22.b
+a423fb17 : ld2b {z23.b, z24.b}, p6/Z, [x24, #6, MUL VL] : ld2b   +0xc0(%x24)[64byte] %p6/z -> %z23.b %z24.b
+a424ff59 : ld2b {z25.b, z26.b}, p7/Z, [x26, #8, MUL VL] : ld2b   +0x0100(%x26)[64byte] %p7/z -> %z25.b %z26.b
+a425ff9b : ld2b {z27.b, z28.b}, p7/Z, [x28, #10, MUL VL] : ld2b   +0x0140(%x28)[64byte] %p7/z -> %z27.b %z28.b
+a427ffff : ld2b {z31.b, z0.b}, p7/Z, [sp, #14, MUL VL] : ld2b   +0x01c0(%sp)[64byte] %p7/z -> %z31.b %z0.b
 
 # LD2D    { <Zt1>.D, <Zt2>.D }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #3] (LD2D-Z.P.BR-Contiguous)
 a5a0c000 : ld2d {z0.d, z1.d}, p0/Z, [x0, x0, LSL #3] : ld2d   (%x0,%x0,lsl #3)[64byte] %p0/z -> %z0.d %z1.d
@@ -12994,22 +12994,22 @@ a5bddf9b : ld2d {z27.d, z28.d}, p7/Z, [x28, x29, LSL #3] : ld2d   (%x28,%x29,lsl
 a5bedfff : ld2d {z31.d, z0.d}, p7/Z, [sp, x30, LSL #3] : ld2d   (%sp,%x30,lsl #3)[64byte] %p7/z -> %z31.d %z0.d
 
 # LD2D    { <Zt1>.D, <Zt2>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD2D-Z.P.BI-Contiguous)
-a5a8e000 : ld2d {z0.d, z1.d}, p0/Z, [x0, #-16, MUL VL] : ld2d   -0x10(%x0)[64byte] %p0/z -> %z0.d %z1.d
-a5a9e482 : ld2d {z2.d, z3.d}, p1/Z, [x4, #-14, MUL VL] : ld2d   -0x0e(%x4)[64byte] %p1/z -> %z2.d %z3.d
-a5aae8c4 : ld2d {z4.d, z5.d}, p2/Z, [x6, #-12, MUL VL] : ld2d   -0x0c(%x6)[64byte] %p2/z -> %z4.d %z5.d
-a5abe906 : ld2d {z6.d, z7.d}, p2/Z, [x8, #-10, MUL VL] : ld2d   -0x0a(%x8)[64byte] %p2/z -> %z6.d %z7.d
-a5aced48 : ld2d {z8.d, z9.d}, p3/Z, [x10, #-8, MUL VL] : ld2d   -0x08(%x10)[64byte] %p3/z -> %z8.d %z9.d
-a5aded6a : ld2d {z10.d, z11.d}, p3/Z, [x11, #-6, MUL VL] : ld2d   -0x06(%x11)[64byte] %p3/z -> %z10.d %z11.d
-a5aef1ac : ld2d {z12.d, z13.d}, p4/Z, [x13, #-4, MUL VL] : ld2d   -0x04(%x13)[64byte] %p4/z -> %z12.d %z13.d
-a5aff1ee : ld2d {z14.d, z15.d}, p4/Z, [x15, #-2, MUL VL] : ld2d   -0x02(%x15)[64byte] %p4/z -> %z14.d %z15.d
+a5a8e000 : ld2d {z0.d, z1.d}, p0/Z, [x0, #-16, MUL VL] : ld2d   -0x0200(%x0)[64byte] %p0/z -> %z0.d %z1.d
+a5a9e482 : ld2d {z2.d, z3.d}, p1/Z, [x4, #-14, MUL VL] : ld2d   -0x01c0(%x4)[64byte] %p1/z -> %z2.d %z3.d
+a5aae8c4 : ld2d {z4.d, z5.d}, p2/Z, [x6, #-12, MUL VL] : ld2d   -0x0180(%x6)[64byte] %p2/z -> %z4.d %z5.d
+a5abe906 : ld2d {z6.d, z7.d}, p2/Z, [x8, #-10, MUL VL] : ld2d   -0x0140(%x8)[64byte] %p2/z -> %z6.d %z7.d
+a5aced48 : ld2d {z8.d, z9.d}, p3/Z, [x10, #-8, MUL VL] : ld2d   -0x0100(%x10)[64byte] %p3/z -> %z8.d %z9.d
+a5aded6a : ld2d {z10.d, z11.d}, p3/Z, [x11, #-6, MUL VL] : ld2d   -0xc0(%x11)[64byte] %p3/z -> %z10.d %z11.d
+a5aef1ac : ld2d {z12.d, z13.d}, p4/Z, [x13, #-4, MUL VL] : ld2d   -0x80(%x13)[64byte] %p4/z -> %z12.d %z13.d
+a5aff1ee : ld2d {z14.d, z15.d}, p4/Z, [x15, #-2, MUL VL] : ld2d   -0x40(%x15)[64byte] %p4/z -> %z14.d %z15.d
 a5a0f630 : ld2d {z16.d, z17.d}, p5/Z, [x17, #0, MUL VL] : ld2d   (%x17)[64byte] %p5/z -> %z16.d %z17.d
 a5a0f671 : ld2d {z17.d, z18.d}, p5/Z, [x19, #0, MUL VL] : ld2d   (%x19)[64byte] %p5/z -> %z17.d %z18.d
-a5a1f6b3 : ld2d {z19.d, z20.d}, p5/Z, [x21, #2, MUL VL] : ld2d   +0x02(%x21)[64byte] %p5/z -> %z19.d %z20.d
-a5a2faf5 : ld2d {z21.d, z22.d}, p6/Z, [x23, #4, MUL VL] : ld2d   +0x04(%x23)[64byte] %p6/z -> %z21.d %z22.d
-a5a3fb17 : ld2d {z23.d, z24.d}, p6/Z, [x24, #6, MUL VL] : ld2d   +0x06(%x24)[64byte] %p6/z -> %z23.d %z24.d
-a5a4ff59 : ld2d {z25.d, z26.d}, p7/Z, [x26, #8, MUL VL] : ld2d   +0x08(%x26)[64byte] %p7/z -> %z25.d %z26.d
-a5a5ff9b : ld2d {z27.d, z28.d}, p7/Z, [x28, #10, MUL VL] : ld2d   +0x0a(%x28)[64byte] %p7/z -> %z27.d %z28.d
-a5a7ffff : ld2d {z31.d, z0.d}, p7/Z, [sp, #14, MUL VL] : ld2d   +0x0e(%sp)[64byte] %p7/z -> %z31.d %z0.d
+a5a1f6b3 : ld2d {z19.d, z20.d}, p5/Z, [x21, #2, MUL VL] : ld2d   +0x40(%x21)[64byte] %p5/z -> %z19.d %z20.d
+a5a2faf5 : ld2d {z21.d, z22.d}, p6/Z, [x23, #4, MUL VL] : ld2d   +0x80(%x23)[64byte] %p6/z -> %z21.d %z22.d
+a5a3fb17 : ld2d {z23.d, z24.d}, p6/Z, [x24, #6, MUL VL] : ld2d   +0xc0(%x24)[64byte] %p6/z -> %z23.d %z24.d
+a5a4ff59 : ld2d {z25.d, z26.d}, p7/Z, [x26, #8, MUL VL] : ld2d   +0x0100(%x26)[64byte] %p7/z -> %z25.d %z26.d
+a5a5ff9b : ld2d {z27.d, z28.d}, p7/Z, [x28, #10, MUL VL] : ld2d   +0x0140(%x28)[64byte] %p7/z -> %z27.d %z28.d
+a5a7ffff : ld2d {z31.d, z0.d}, p7/Z, [sp, #14, MUL VL] : ld2d   +0x01c0(%sp)[64byte] %p7/z -> %z31.d %z0.d
 
 # LD2H    { <Zt1>.H, <Zt2>.H }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1] (LD2H-Z.P.BR-Contiguous)
 a4a0c000 : ld2h {z0.h, z1.h}, p0/Z, [x0, x0, LSL #1] : ld2h   (%x0,%x0,lsl #1)[64byte] %p0/z -> %z0.h %z1.h
@@ -13030,22 +13030,22 @@ a4bddf9b : ld2h {z27.h, z28.h}, p7/Z, [x28, x29, LSL #1] : ld2h   (%x28,%x29,lsl
 a4bedfff : ld2h {z31.h, z0.h}, p7/Z, [sp, x30, LSL #1] : ld2h   (%sp,%x30,lsl #1)[64byte] %p7/z -> %z31.h %z0.h
 
 # LD2H    { <Zt1>.H, <Zt2>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD2H-Z.P.BI-Contiguous)
-a4a8e000 : ld2h {z0.h, z1.h}, p0/Z, [x0, #-16, MUL VL] : ld2h   -0x10(%x0)[64byte] %p0/z -> %z0.h %z1.h
-a4a9e482 : ld2h {z2.h, z3.h}, p1/Z, [x4, #-14, MUL VL] : ld2h   -0x0e(%x4)[64byte] %p1/z -> %z2.h %z3.h
-a4aae8c4 : ld2h {z4.h, z5.h}, p2/Z, [x6, #-12, MUL VL] : ld2h   -0x0c(%x6)[64byte] %p2/z -> %z4.h %z5.h
-a4abe906 : ld2h {z6.h, z7.h}, p2/Z, [x8, #-10, MUL VL] : ld2h   -0x0a(%x8)[64byte] %p2/z -> %z6.h %z7.h
-a4aced48 : ld2h {z8.h, z9.h}, p3/Z, [x10, #-8, MUL VL] : ld2h   -0x08(%x10)[64byte] %p3/z -> %z8.h %z9.h
-a4aded6a : ld2h {z10.h, z11.h}, p3/Z, [x11, #-6, MUL VL] : ld2h   -0x06(%x11)[64byte] %p3/z -> %z10.h %z11.h
-a4aef1ac : ld2h {z12.h, z13.h}, p4/Z, [x13, #-4, MUL VL] : ld2h   -0x04(%x13)[64byte] %p4/z -> %z12.h %z13.h
-a4aff1ee : ld2h {z14.h, z15.h}, p4/Z, [x15, #-2, MUL VL] : ld2h   -0x02(%x15)[64byte] %p4/z -> %z14.h %z15.h
+a4a8e000 : ld2h {z0.h, z1.h}, p0/Z, [x0, #-16, MUL VL] : ld2h   -0x0200(%x0)[64byte] %p0/z -> %z0.h %z1.h
+a4a9e482 : ld2h {z2.h, z3.h}, p1/Z, [x4, #-14, MUL VL] : ld2h   -0x01c0(%x4)[64byte] %p1/z -> %z2.h %z3.h
+a4aae8c4 : ld2h {z4.h, z5.h}, p2/Z, [x6, #-12, MUL VL] : ld2h   -0x0180(%x6)[64byte] %p2/z -> %z4.h %z5.h
+a4abe906 : ld2h {z6.h, z7.h}, p2/Z, [x8, #-10, MUL VL] : ld2h   -0x0140(%x8)[64byte] %p2/z -> %z6.h %z7.h
+a4aced48 : ld2h {z8.h, z9.h}, p3/Z, [x10, #-8, MUL VL] : ld2h   -0x0100(%x10)[64byte] %p3/z -> %z8.h %z9.h
+a4aded6a : ld2h {z10.h, z11.h}, p3/Z, [x11, #-6, MUL VL] : ld2h   -0xc0(%x11)[64byte] %p3/z -> %z10.h %z11.h
+a4aef1ac : ld2h {z12.h, z13.h}, p4/Z, [x13, #-4, MUL VL] : ld2h   -0x80(%x13)[64byte] %p4/z -> %z12.h %z13.h
+a4aff1ee : ld2h {z14.h, z15.h}, p4/Z, [x15, #-2, MUL VL] : ld2h   -0x40(%x15)[64byte] %p4/z -> %z14.h %z15.h
 a4a0f630 : ld2h {z16.h, z17.h}, p5/Z, [x17, #0, MUL VL] : ld2h   (%x17)[64byte] %p5/z -> %z16.h %z17.h
 a4a0f671 : ld2h {z17.h, z18.h}, p5/Z, [x19, #0, MUL VL] : ld2h   (%x19)[64byte] %p5/z -> %z17.h %z18.h
-a4a1f6b3 : ld2h {z19.h, z20.h}, p5/Z, [x21, #2, MUL VL] : ld2h   +0x02(%x21)[64byte] %p5/z -> %z19.h %z20.h
-a4a2faf5 : ld2h {z21.h, z22.h}, p6/Z, [x23, #4, MUL VL] : ld2h   +0x04(%x23)[64byte] %p6/z -> %z21.h %z22.h
-a4a3fb17 : ld2h {z23.h, z24.h}, p6/Z, [x24, #6, MUL VL] : ld2h   +0x06(%x24)[64byte] %p6/z -> %z23.h %z24.h
-a4a4ff59 : ld2h {z25.h, z26.h}, p7/Z, [x26, #8, MUL VL] : ld2h   +0x08(%x26)[64byte] %p7/z -> %z25.h %z26.h
-a4a5ff9b : ld2h {z27.h, z28.h}, p7/Z, [x28, #10, MUL VL] : ld2h   +0x0a(%x28)[64byte] %p7/z -> %z27.h %z28.h
-a4a7ffff : ld2h {z31.h, z0.h}, p7/Z, [sp, #14, MUL VL] : ld2h   +0x0e(%sp)[64byte] %p7/z -> %z31.h %z0.h
+a4a1f6b3 : ld2h {z19.h, z20.h}, p5/Z, [x21, #2, MUL VL] : ld2h   +0x40(%x21)[64byte] %p5/z -> %z19.h %z20.h
+a4a2faf5 : ld2h {z21.h, z22.h}, p6/Z, [x23, #4, MUL VL] : ld2h   +0x80(%x23)[64byte] %p6/z -> %z21.h %z22.h
+a4a3fb17 : ld2h {z23.h, z24.h}, p6/Z, [x24, #6, MUL VL] : ld2h   +0xc0(%x24)[64byte] %p6/z -> %z23.h %z24.h
+a4a4ff59 : ld2h {z25.h, z26.h}, p7/Z, [x26, #8, MUL VL] : ld2h   +0x0100(%x26)[64byte] %p7/z -> %z25.h %z26.h
+a4a5ff9b : ld2h {z27.h, z28.h}, p7/Z, [x28, #10, MUL VL] : ld2h   +0x0140(%x28)[64byte] %p7/z -> %z27.h %z28.h
+a4a7ffff : ld2h {z31.h, z0.h}, p7/Z, [sp, #14, MUL VL] : ld2h   +0x01c0(%sp)[64byte] %p7/z -> %z31.h %z0.h
 
 # LD2W    { <Zt1>.S, <Zt2>.S }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #2] (LD2W-Z.P.BR-Contiguous)
 a520c000 : ld2w {z0.s, z1.s}, p0/Z, [x0, x0, LSL #2] : ld2w   (%x0,%x0,lsl #2)[64byte] %p0/z -> %z0.s %z1.s
@@ -13066,22 +13066,22 @@ a53ddf9b : ld2w {z27.s, z28.s}, p7/Z, [x28, x29, LSL #2] : ld2w   (%x28,%x29,lsl
 a53edfff : ld2w {z31.s, z0.s}, p7/Z, [sp, x30, LSL #2] : ld2w   (%sp,%x30,lsl #2)[64byte] %p7/z -> %z31.s %z0.s
 
 # LD2W    { <Zt1>.S, <Zt2>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD2W-Z.P.BI-Contiguous)
-a528e000 : ld2w {z0.s, z1.s}, p0/Z, [x0, #-16, MUL VL] : ld2w   -0x10(%x0)[64byte] %p0/z -> %z0.s %z1.s
-a529e482 : ld2w {z2.s, z3.s}, p1/Z, [x4, #-14, MUL VL] : ld2w   -0x0e(%x4)[64byte] %p1/z -> %z2.s %z3.s
-a52ae8c4 : ld2w {z4.s, z5.s}, p2/Z, [x6, #-12, MUL VL] : ld2w   -0x0c(%x6)[64byte] %p2/z -> %z4.s %z5.s
-a52be906 : ld2w {z6.s, z7.s}, p2/Z, [x8, #-10, MUL VL] : ld2w   -0x0a(%x8)[64byte] %p2/z -> %z6.s %z7.s
-a52ced48 : ld2w {z8.s, z9.s}, p3/Z, [x10, #-8, MUL VL] : ld2w   -0x08(%x10)[64byte] %p3/z -> %z8.s %z9.s
-a52ded6a : ld2w {z10.s, z11.s}, p3/Z, [x11, #-6, MUL VL] : ld2w   -0x06(%x11)[64byte] %p3/z -> %z10.s %z11.s
-a52ef1ac : ld2w {z12.s, z13.s}, p4/Z, [x13, #-4, MUL VL] : ld2w   -0x04(%x13)[64byte] %p4/z -> %z12.s %z13.s
-a52ff1ee : ld2w {z14.s, z15.s}, p4/Z, [x15, #-2, MUL VL] : ld2w   -0x02(%x15)[64byte] %p4/z -> %z14.s %z15.s
+a528e000 : ld2w {z0.s, z1.s}, p0/Z, [x0, #-16, MUL VL] : ld2w   -0x0200(%x0)[64byte] %p0/z -> %z0.s %z1.s
+a529e482 : ld2w {z2.s, z3.s}, p1/Z, [x4, #-14, MUL VL] : ld2w   -0x01c0(%x4)[64byte] %p1/z -> %z2.s %z3.s
+a52ae8c4 : ld2w {z4.s, z5.s}, p2/Z, [x6, #-12, MUL VL] : ld2w   -0x0180(%x6)[64byte] %p2/z -> %z4.s %z5.s
+a52be906 : ld2w {z6.s, z7.s}, p2/Z, [x8, #-10, MUL VL] : ld2w   -0x0140(%x8)[64byte] %p2/z -> %z6.s %z7.s
+a52ced48 : ld2w {z8.s, z9.s}, p3/Z, [x10, #-8, MUL VL] : ld2w   -0x0100(%x10)[64byte] %p3/z -> %z8.s %z9.s
+a52ded6a : ld2w {z10.s, z11.s}, p3/Z, [x11, #-6, MUL VL] : ld2w   -0xc0(%x11)[64byte] %p3/z -> %z10.s %z11.s
+a52ef1ac : ld2w {z12.s, z13.s}, p4/Z, [x13, #-4, MUL VL] : ld2w   -0x80(%x13)[64byte] %p4/z -> %z12.s %z13.s
+a52ff1ee : ld2w {z14.s, z15.s}, p4/Z, [x15, #-2, MUL VL] : ld2w   -0x40(%x15)[64byte] %p4/z -> %z14.s %z15.s
 a520f630 : ld2w {z16.s, z17.s}, p5/Z, [x17, #0, MUL VL] : ld2w   (%x17)[64byte] %p5/z -> %z16.s %z17.s
 a520f671 : ld2w {z17.s, z18.s}, p5/Z, [x19, #0, MUL VL] : ld2w   (%x19)[64byte] %p5/z -> %z17.s %z18.s
-a521f6b3 : ld2w {z19.s, z20.s}, p5/Z, [x21, #2, MUL VL] : ld2w   +0x02(%x21)[64byte] %p5/z -> %z19.s %z20.s
-a522faf5 : ld2w {z21.s, z22.s}, p6/Z, [x23, #4, MUL VL] : ld2w   +0x04(%x23)[64byte] %p6/z -> %z21.s %z22.s
-a523fb17 : ld2w {z23.s, z24.s}, p6/Z, [x24, #6, MUL VL] : ld2w   +0x06(%x24)[64byte] %p6/z -> %z23.s %z24.s
-a524ff59 : ld2w {z25.s, z26.s}, p7/Z, [x26, #8, MUL VL] : ld2w   +0x08(%x26)[64byte] %p7/z -> %z25.s %z26.s
-a525ff9b : ld2w {z27.s, z28.s}, p7/Z, [x28, #10, MUL VL] : ld2w   +0x0a(%x28)[64byte] %p7/z -> %z27.s %z28.s
-a527ffff : ld2w {z31.s, z0.s}, p7/Z, [sp, #14, MUL VL] : ld2w   +0x0e(%sp)[64byte] %p7/z -> %z31.s %z0.s
+a521f6b3 : ld2w {z19.s, z20.s}, p5/Z, [x21, #2, MUL VL] : ld2w   +0x40(%x21)[64byte] %p5/z -> %z19.s %z20.s
+a522faf5 : ld2w {z21.s, z22.s}, p6/Z, [x23, #4, MUL VL] : ld2w   +0x80(%x23)[64byte] %p6/z -> %z21.s %z22.s
+a523fb17 : ld2w {z23.s, z24.s}, p6/Z, [x24, #6, MUL VL] : ld2w   +0xc0(%x24)[64byte] %p6/z -> %z23.s %z24.s
+a524ff59 : ld2w {z25.s, z26.s}, p7/Z, [x26, #8, MUL VL] : ld2w   +0x0100(%x26)[64byte] %p7/z -> %z25.s %z26.s
+a525ff9b : ld2w {z27.s, z28.s}, p7/Z, [x28, #10, MUL VL] : ld2w   +0x0140(%x28)[64byte] %p7/z -> %z27.s %z28.s
+a527ffff : ld2w {z31.s, z0.s}, p7/Z, [sp, #14, MUL VL] : ld2w   +0x01c0(%sp)[64byte] %p7/z -> %z31.s %z0.s
 
 # LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD3B-Z.P.BR-Contiguous)
 a440c000 : ld3b {z0.b, z1.b, z2.b}, p0/Z, [x0, x0]   : ld3b   (%x0,%x0)[96byte] %p0/z -> %z0.b %z1.b %z2.b
@@ -13102,22 +13102,22 @@ a45ddf9b : ld3b {z27.b, z28.b, z29.b}, p7/Z, [x28, x29] : ld3b   (%x28,%x29)[96b
 a45edfff : ld3b {z31.b, z0.b, z1.b}, p7/Z, [sp, x30] : ld3b   (%sp,%x30)[96byte] %p7/z -> %z31.b %z0.b %z1.b
 
 # LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD3B-Z.P.BI-Contiguous)
-a448e000 : ld3b {z0.b, z1.b, z2.b}, p0/Z, [x0, #-24, MUL VL] : ld3b   -0x18(%x0)[96byte] %p0/z -> %z0.b %z1.b %z2.b
-a449e482 : ld3b {z2.b, z3.b, z4.b}, p1/Z, [x4, #-21, MUL VL] : ld3b   -0x15(%x4)[96byte] %p1/z -> %z2.b %z3.b %z4.b
-a44ae8c4 : ld3b {z4.b, z5.b, z6.b}, p2/Z, [x6, #-18, MUL VL] : ld3b   -0x12(%x6)[96byte] %p2/z -> %z4.b %z5.b %z6.b
-a44be906 : ld3b {z6.b, z7.b, z8.b}, p2/Z, [x8, #-15, MUL VL] : ld3b   -0x0f(%x8)[96byte] %p2/z -> %z6.b %z7.b %z8.b
-a44ced48 : ld3b {z8.b, z9.b, z10.b}, p3/Z, [x10, #-12, MUL VL] : ld3b   -0x0c(%x10)[96byte] %p3/z -> %z8.b %z9.b %z10.b
-a44ded6a : ld3b {z10.b, z11.b, z12.b}, p3/Z, [x11, #-9, MUL VL] : ld3b   -0x09(%x11)[96byte] %p3/z -> %z10.b %z11.b %z12.b
-a44ef1ac : ld3b {z12.b, z13.b, z14.b}, p4/Z, [x13, #-6, MUL VL] : ld3b   -0x06(%x13)[96byte] %p4/z -> %z12.b %z13.b %z14.b
-a44ff1ee : ld3b {z14.b, z15.b, z16.b}, p4/Z, [x15, #-3, MUL VL] : ld3b   -0x03(%x15)[96byte] %p4/z -> %z14.b %z15.b %z16.b
+a448e000 : ld3b {z0.b, z1.b, z2.b}, p0/Z, [x0, #-24, MUL VL] : ld3b   -0x0300(%x0)[96byte] %p0/z -> %z0.b %z1.b %z2.b
+a449e482 : ld3b {z2.b, z3.b, z4.b}, p1/Z, [x4, #-21, MUL VL] : ld3b   -0x02a0(%x4)[96byte] %p1/z -> %z2.b %z3.b %z4.b
+a44ae8c4 : ld3b {z4.b, z5.b, z6.b}, p2/Z, [x6, #-18, MUL VL] : ld3b   -0x0240(%x6)[96byte] %p2/z -> %z4.b %z5.b %z6.b
+a44be906 : ld3b {z6.b, z7.b, z8.b}, p2/Z, [x8, #-15, MUL VL] : ld3b   -0x01e0(%x8)[96byte] %p2/z -> %z6.b %z7.b %z8.b
+a44ced48 : ld3b {z8.b, z9.b, z10.b}, p3/Z, [x10, #-12, MUL VL] : ld3b   -0x0180(%x10)[96byte] %p3/z -> %z8.b %z9.b %z10.b
+a44ded6a : ld3b {z10.b, z11.b, z12.b}, p3/Z, [x11, #-9, MUL VL] : ld3b   -0x0120(%x11)[96byte] %p3/z -> %z10.b %z11.b %z12.b
+a44ef1ac : ld3b {z12.b, z13.b, z14.b}, p4/Z, [x13, #-6, MUL VL] : ld3b   -0xc0(%x13)[96byte] %p4/z -> %z12.b %z13.b %z14.b
+a44ff1ee : ld3b {z14.b, z15.b, z16.b}, p4/Z, [x15, #-3, MUL VL] : ld3b   -0x60(%x15)[96byte] %p4/z -> %z14.b %z15.b %z16.b
 a440f630 : ld3b {z16.b, z17.b, z18.b}, p5/Z, [x17, #0, MUL VL] : ld3b   (%x17)[96byte] %p5/z -> %z16.b %z17.b %z18.b
 a440f671 : ld3b {z17.b, z18.b, z19.b}, p5/Z, [x19, #0, MUL VL] : ld3b   (%x19)[96byte] %p5/z -> %z17.b %z18.b %z19.b
-a441f6b3 : ld3b {z19.b, z20.b, z21.b}, p5/Z, [x21, #3, MUL VL] : ld3b   +0x03(%x21)[96byte] %p5/z -> %z19.b %z20.b %z21.b
-a442faf5 : ld3b {z21.b, z22.b, z23.b}, p6/Z, [x23, #6, MUL VL] : ld3b   +0x06(%x23)[96byte] %p6/z -> %z21.b %z22.b %z23.b
-a443fb17 : ld3b {z23.b, z24.b, z25.b}, p6/Z, [x24, #9, MUL VL] : ld3b   +0x09(%x24)[96byte] %p6/z -> %z23.b %z24.b %z25.b
-a444ff59 : ld3b {z25.b, z26.b, z27.b}, p7/Z, [x26, #12, MUL VL] : ld3b   +0x0c(%x26)[96byte] %p7/z -> %z25.b %z26.b %z27.b
-a445ff9b : ld3b {z27.b, z28.b, z29.b}, p7/Z, [x28, #15, MUL VL] : ld3b   +0x0f(%x28)[96byte] %p7/z -> %z27.b %z28.b %z29.b
-a447ffff : ld3b {z31.b, z0.b, z1.b}, p7/Z, [sp, #21, MUL VL] : ld3b   +0x15(%sp)[96byte] %p7/z -> %z31.b %z0.b %z1.b
+a441f6b3 : ld3b {z19.b, z20.b, z21.b}, p5/Z, [x21, #3, MUL VL] : ld3b   +0x60(%x21)[96byte] %p5/z -> %z19.b %z20.b %z21.b
+a442faf5 : ld3b {z21.b, z22.b, z23.b}, p6/Z, [x23, #6, MUL VL] : ld3b   +0xc0(%x23)[96byte] %p6/z -> %z21.b %z22.b %z23.b
+a443fb17 : ld3b {z23.b, z24.b, z25.b}, p6/Z, [x24, #9, MUL VL] : ld3b   +0x0120(%x24)[96byte] %p6/z -> %z23.b %z24.b %z25.b
+a444ff59 : ld3b {z25.b, z26.b, z27.b}, p7/Z, [x26, #12, MUL VL] : ld3b   +0x0180(%x26)[96byte] %p7/z -> %z25.b %z26.b %z27.b
+a445ff9b : ld3b {z27.b, z28.b, z29.b}, p7/Z, [x28, #15, MUL VL] : ld3b   +0x01e0(%x28)[96byte] %p7/z -> %z27.b %z28.b %z29.b
+a447ffff : ld3b {z31.b, z0.b, z1.b}, p7/Z, [sp, #21, MUL VL] : ld3b   +0x02a0(%sp)[96byte] %p7/z -> %z31.b %z0.b %z1.b
 
 # LD3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #3] (LD3D-Z.P.BR-Contiguous)
 a5c0c000 : ld3d {z0.d, z1.d, z2.d}, p0/Z, [x0, x0, LSL #3] : ld3d   (%x0,%x0,lsl #3)[96byte] %p0/z -> %z0.d %z1.d %z2.d
@@ -13138,22 +13138,22 @@ a5dddf9b : ld3d {z27.d, z28.d, z29.d}, p7/Z, [x28, x29, LSL #3] : ld3d   (%x28,%
 a5dedfff : ld3d {z31.d, z0.d, z1.d}, p7/Z, [sp, x30, LSL #3] : ld3d   (%sp,%x30,lsl #3)[96byte] %p7/z -> %z31.d %z0.d %z1.d
 
 # LD3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD3D-Z.P.BI-Contiguous)
-a5c8e000 : ld3d {z0.d, z1.d, z2.d}, p0/Z, [x0, #-24, MUL VL] : ld3d   -0x18(%x0)[96byte] %p0/z -> %z0.d %z1.d %z2.d
-a5c9e482 : ld3d {z2.d, z3.d, z4.d}, p1/Z, [x4, #-21, MUL VL] : ld3d   -0x15(%x4)[96byte] %p1/z -> %z2.d %z3.d %z4.d
-a5cae8c4 : ld3d {z4.d, z5.d, z6.d}, p2/Z, [x6, #-18, MUL VL] : ld3d   -0x12(%x6)[96byte] %p2/z -> %z4.d %z5.d %z6.d
-a5cbe906 : ld3d {z6.d, z7.d, z8.d}, p2/Z, [x8, #-15, MUL VL] : ld3d   -0x0f(%x8)[96byte] %p2/z -> %z6.d %z7.d %z8.d
-a5cced48 : ld3d {z8.d, z9.d, z10.d}, p3/Z, [x10, #-12, MUL VL] : ld3d   -0x0c(%x10)[96byte] %p3/z -> %z8.d %z9.d %z10.d
-a5cded6a : ld3d {z10.d, z11.d, z12.d}, p3/Z, [x11, #-9, MUL VL] : ld3d   -0x09(%x11)[96byte] %p3/z -> %z10.d %z11.d %z12.d
-a5cef1ac : ld3d {z12.d, z13.d, z14.d}, p4/Z, [x13, #-6, MUL VL] : ld3d   -0x06(%x13)[96byte] %p4/z -> %z12.d %z13.d %z14.d
-a5cff1ee : ld3d {z14.d, z15.d, z16.d}, p4/Z, [x15, #-3, MUL VL] : ld3d   -0x03(%x15)[96byte] %p4/z -> %z14.d %z15.d %z16.d
+a5c8e000 : ld3d {z0.d, z1.d, z2.d}, p0/Z, [x0, #-24, MUL VL] : ld3d   -0x0300(%x0)[96byte] %p0/z -> %z0.d %z1.d %z2.d
+a5c9e482 : ld3d {z2.d, z3.d, z4.d}, p1/Z, [x4, #-21, MUL VL] : ld3d   -0x02a0(%x4)[96byte] %p1/z -> %z2.d %z3.d %z4.d
+a5cae8c4 : ld3d {z4.d, z5.d, z6.d}, p2/Z, [x6, #-18, MUL VL] : ld3d   -0x0240(%x6)[96byte] %p2/z -> %z4.d %z5.d %z6.d
+a5cbe906 : ld3d {z6.d, z7.d, z8.d}, p2/Z, [x8, #-15, MUL VL] : ld3d   -0x01e0(%x8)[96byte] %p2/z -> %z6.d %z7.d %z8.d
+a5cced48 : ld3d {z8.d, z9.d, z10.d}, p3/Z, [x10, #-12, MUL VL] : ld3d   -0x0180(%x10)[96byte] %p3/z -> %z8.d %z9.d %z10.d
+a5cded6a : ld3d {z10.d, z11.d, z12.d}, p3/Z, [x11, #-9, MUL VL] : ld3d   -0x0120(%x11)[96byte] %p3/z -> %z10.d %z11.d %z12.d
+a5cef1ac : ld3d {z12.d, z13.d, z14.d}, p4/Z, [x13, #-6, MUL VL] : ld3d   -0xc0(%x13)[96byte] %p4/z -> %z12.d %z13.d %z14.d
+a5cff1ee : ld3d {z14.d, z15.d, z16.d}, p4/Z, [x15, #-3, MUL VL] : ld3d   -0x60(%x15)[96byte] %p4/z -> %z14.d %z15.d %z16.d
 a5c0f630 : ld3d {z16.d, z17.d, z18.d}, p5/Z, [x17, #0, MUL VL] : ld3d   (%x17)[96byte] %p5/z -> %z16.d %z17.d %z18.d
 a5c0f671 : ld3d {z17.d, z18.d, z19.d}, p5/Z, [x19, #0, MUL VL] : ld3d   (%x19)[96byte] %p5/z -> %z17.d %z18.d %z19.d
-a5c1f6b3 : ld3d {z19.d, z20.d, z21.d}, p5/Z, [x21, #3, MUL VL] : ld3d   +0x03(%x21)[96byte] %p5/z -> %z19.d %z20.d %z21.d
-a5c2faf5 : ld3d {z21.d, z22.d, z23.d}, p6/Z, [x23, #6, MUL VL] : ld3d   +0x06(%x23)[96byte] %p6/z -> %z21.d %z22.d %z23.d
-a5c3fb17 : ld3d {z23.d, z24.d, z25.d}, p6/Z, [x24, #9, MUL VL] : ld3d   +0x09(%x24)[96byte] %p6/z -> %z23.d %z24.d %z25.d
-a5c4ff59 : ld3d {z25.d, z26.d, z27.d}, p7/Z, [x26, #12, MUL VL] : ld3d   +0x0c(%x26)[96byte] %p7/z -> %z25.d %z26.d %z27.d
-a5c5ff9b : ld3d {z27.d, z28.d, z29.d}, p7/Z, [x28, #15, MUL VL] : ld3d   +0x0f(%x28)[96byte] %p7/z -> %z27.d %z28.d %z29.d
-a5c7ffff : ld3d {z31.d, z0.d, z1.d}, p7/Z, [sp, #21, MUL VL] : ld3d   +0x15(%sp)[96byte] %p7/z -> %z31.d %z0.d %z1.d
+a5c1f6b3 : ld3d {z19.d, z20.d, z21.d}, p5/Z, [x21, #3, MUL VL] : ld3d   +0x60(%x21)[96byte] %p5/z -> %z19.d %z20.d %z21.d
+a5c2faf5 : ld3d {z21.d, z22.d, z23.d}, p6/Z, [x23, #6, MUL VL] : ld3d   +0xc0(%x23)[96byte] %p6/z -> %z21.d %z22.d %z23.d
+a5c3fb17 : ld3d {z23.d, z24.d, z25.d}, p6/Z, [x24, #9, MUL VL] : ld3d   +0x0120(%x24)[96byte] %p6/z -> %z23.d %z24.d %z25.d
+a5c4ff59 : ld3d {z25.d, z26.d, z27.d}, p7/Z, [x26, #12, MUL VL] : ld3d   +0x0180(%x26)[96byte] %p7/z -> %z25.d %z26.d %z27.d
+a5c5ff9b : ld3d {z27.d, z28.d, z29.d}, p7/Z, [x28, #15, MUL VL] : ld3d   +0x01e0(%x28)[96byte] %p7/z -> %z27.d %z28.d %z29.d
+a5c7ffff : ld3d {z31.d, z0.d, z1.d}, p7/Z, [sp, #21, MUL VL] : ld3d   +0x02a0(%sp)[96byte] %p7/z -> %z31.d %z0.d %z1.d
 
 # LD3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1] (LD3H-Z.P.BR-Contiguous)
 a4c0c000 : ld3h {z0.h, z1.h, z2.h}, p0/Z, [x0, x0, LSL #1] : ld3h   (%x0,%x0,lsl #1)[96byte] %p0/z -> %z0.h %z1.h %z2.h
@@ -13174,22 +13174,22 @@ a4dddf9b : ld3h {z27.h, z28.h, z29.h}, p7/Z, [x28, x29, LSL #1] : ld3h   (%x28,%
 a4dedfff : ld3h {z31.h, z0.h, z1.h}, p7/Z, [sp, x30, LSL #1] : ld3h   (%sp,%x30,lsl #1)[96byte] %p7/z -> %z31.h %z0.h %z1.h
 
 # LD3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD3H-Z.P.BI-Contiguous)
-a4c8e000 : ld3h {z0.h, z1.h, z2.h}, p0/Z, [x0, #-24, MUL VL] : ld3h   -0x18(%x0)[96byte] %p0/z -> %z0.h %z1.h %z2.h
-a4c9e482 : ld3h {z2.h, z3.h, z4.h}, p1/Z, [x4, #-21, MUL VL] : ld3h   -0x15(%x4)[96byte] %p1/z -> %z2.h %z3.h %z4.h
-a4cae8c4 : ld3h {z4.h, z5.h, z6.h}, p2/Z, [x6, #-18, MUL VL] : ld3h   -0x12(%x6)[96byte] %p2/z -> %z4.h %z5.h %z6.h
-a4cbe906 : ld3h {z6.h, z7.h, z8.h}, p2/Z, [x8, #-15, MUL VL] : ld3h   -0x0f(%x8)[96byte] %p2/z -> %z6.h %z7.h %z8.h
-a4cced48 : ld3h {z8.h, z9.h, z10.h}, p3/Z, [x10, #-12, MUL VL] : ld3h   -0x0c(%x10)[96byte] %p3/z -> %z8.h %z9.h %z10.h
-a4cded6a : ld3h {z10.h, z11.h, z12.h}, p3/Z, [x11, #-9, MUL VL] : ld3h   -0x09(%x11)[96byte] %p3/z -> %z10.h %z11.h %z12.h
-a4cef1ac : ld3h {z12.h, z13.h, z14.h}, p4/Z, [x13, #-6, MUL VL] : ld3h   -0x06(%x13)[96byte] %p4/z -> %z12.h %z13.h %z14.h
-a4cff1ee : ld3h {z14.h, z15.h, z16.h}, p4/Z, [x15, #-3, MUL VL] : ld3h   -0x03(%x15)[96byte] %p4/z -> %z14.h %z15.h %z16.h
+a4c8e000 : ld3h {z0.h, z1.h, z2.h}, p0/Z, [x0, #-24, MUL VL] : ld3h   -0x0300(%x0)[96byte] %p0/z -> %z0.h %z1.h %z2.h
+a4c9e482 : ld3h {z2.h, z3.h, z4.h}, p1/Z, [x4, #-21, MUL VL] : ld3h   -0x02a0(%x4)[96byte] %p1/z -> %z2.h %z3.h %z4.h
+a4cae8c4 : ld3h {z4.h, z5.h, z6.h}, p2/Z, [x6, #-18, MUL VL] : ld3h   -0x0240(%x6)[96byte] %p2/z -> %z4.h %z5.h %z6.h
+a4cbe906 : ld3h {z6.h, z7.h, z8.h}, p2/Z, [x8, #-15, MUL VL] : ld3h   -0x01e0(%x8)[96byte] %p2/z -> %z6.h %z7.h %z8.h
+a4cced48 : ld3h {z8.h, z9.h, z10.h}, p3/Z, [x10, #-12, MUL VL] : ld3h   -0x0180(%x10)[96byte] %p3/z -> %z8.h %z9.h %z10.h
+a4cded6a : ld3h {z10.h, z11.h, z12.h}, p3/Z, [x11, #-9, MUL VL] : ld3h   -0x0120(%x11)[96byte] %p3/z -> %z10.h %z11.h %z12.h
+a4cef1ac : ld3h {z12.h, z13.h, z14.h}, p4/Z, [x13, #-6, MUL VL] : ld3h   -0xc0(%x13)[96byte] %p4/z -> %z12.h %z13.h %z14.h
+a4cff1ee : ld3h {z14.h, z15.h, z16.h}, p4/Z, [x15, #-3, MUL VL] : ld3h   -0x60(%x15)[96byte] %p4/z -> %z14.h %z15.h %z16.h
 a4c0f630 : ld3h {z16.h, z17.h, z18.h}, p5/Z, [x17, #0, MUL VL] : ld3h   (%x17)[96byte] %p5/z -> %z16.h %z17.h %z18.h
 a4c0f671 : ld3h {z17.h, z18.h, z19.h}, p5/Z, [x19, #0, MUL VL] : ld3h   (%x19)[96byte] %p5/z -> %z17.h %z18.h %z19.h
-a4c1f6b3 : ld3h {z19.h, z20.h, z21.h}, p5/Z, [x21, #3, MUL VL] : ld3h   +0x03(%x21)[96byte] %p5/z -> %z19.h %z20.h %z21.h
-a4c2faf5 : ld3h {z21.h, z22.h, z23.h}, p6/Z, [x23, #6, MUL VL] : ld3h   +0x06(%x23)[96byte] %p6/z -> %z21.h %z22.h %z23.h
-a4c3fb17 : ld3h {z23.h, z24.h, z25.h}, p6/Z, [x24, #9, MUL VL] : ld3h   +0x09(%x24)[96byte] %p6/z -> %z23.h %z24.h %z25.h
-a4c4ff59 : ld3h {z25.h, z26.h, z27.h}, p7/Z, [x26, #12, MUL VL] : ld3h   +0x0c(%x26)[96byte] %p7/z -> %z25.h %z26.h %z27.h
-a4c5ff9b : ld3h {z27.h, z28.h, z29.h}, p7/Z, [x28, #15, MUL VL] : ld3h   +0x0f(%x28)[96byte] %p7/z -> %z27.h %z28.h %z29.h
-a4c7ffff : ld3h {z31.h, z0.h, z1.h}, p7/Z, [sp, #21, MUL VL] : ld3h   +0x15(%sp)[96byte] %p7/z -> %z31.h %z0.h %z1.h
+a4c1f6b3 : ld3h {z19.h, z20.h, z21.h}, p5/Z, [x21, #3, MUL VL] : ld3h   +0x60(%x21)[96byte] %p5/z -> %z19.h %z20.h %z21.h
+a4c2faf5 : ld3h {z21.h, z22.h, z23.h}, p6/Z, [x23, #6, MUL VL] : ld3h   +0xc0(%x23)[96byte] %p6/z -> %z21.h %z22.h %z23.h
+a4c3fb17 : ld3h {z23.h, z24.h, z25.h}, p6/Z, [x24, #9, MUL VL] : ld3h   +0x0120(%x24)[96byte] %p6/z -> %z23.h %z24.h %z25.h
+a4c4ff59 : ld3h {z25.h, z26.h, z27.h}, p7/Z, [x26, #12, MUL VL] : ld3h   +0x0180(%x26)[96byte] %p7/z -> %z25.h %z26.h %z27.h
+a4c5ff9b : ld3h {z27.h, z28.h, z29.h}, p7/Z, [x28, #15, MUL VL] : ld3h   +0x01e0(%x28)[96byte] %p7/z -> %z27.h %z28.h %z29.h
+a4c7ffff : ld3h {z31.h, z0.h, z1.h}, p7/Z, [sp, #21, MUL VL] : ld3h   +0x02a0(%sp)[96byte] %p7/z -> %z31.h %z0.h %z1.h
 
 # LD3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #2] (LD3W-Z.P.BR-Contiguous)
 a540c000 : ld3w {z0.s, z1.s, z2.s}, p0/Z, [x0, x0, LSL #2] : ld3w   (%x0,%x0,lsl #2)[96byte] %p0/z -> %z0.s %z1.s %z2.s
@@ -13210,22 +13210,22 @@ a55ddf9b : ld3w {z27.s, z28.s, z29.s}, p7/Z, [x28, x29, LSL #2] : ld3w   (%x28,%
 a55edfff : ld3w {z31.s, z0.s, z1.s}, p7/Z, [sp, x30, LSL #2] : ld3w   (%sp,%x30,lsl #2)[96byte] %p7/z -> %z31.s %z0.s %z1.s
 
 # LD3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD3W-Z.P.BI-Contiguous)
-a548e000 : ld3w {z0.s, z1.s, z2.s}, p0/Z, [x0, #-24, MUL VL] : ld3w   -0x18(%x0)[96byte] %p0/z -> %z0.s %z1.s %z2.s
-a549e482 : ld3w {z2.s, z3.s, z4.s}, p1/Z, [x4, #-21, MUL VL] : ld3w   -0x15(%x4)[96byte] %p1/z -> %z2.s %z3.s %z4.s
-a54ae8c4 : ld3w {z4.s, z5.s, z6.s}, p2/Z, [x6, #-18, MUL VL] : ld3w   -0x12(%x6)[96byte] %p2/z -> %z4.s %z5.s %z6.s
-a54be906 : ld3w {z6.s, z7.s, z8.s}, p2/Z, [x8, #-15, MUL VL] : ld3w   -0x0f(%x8)[96byte] %p2/z -> %z6.s %z7.s %z8.s
-a54ced48 : ld3w {z8.s, z9.s, z10.s}, p3/Z, [x10, #-12, MUL VL] : ld3w   -0x0c(%x10)[96byte] %p3/z -> %z8.s %z9.s %z10.s
-a54ded6a : ld3w {z10.s, z11.s, z12.s}, p3/Z, [x11, #-9, MUL VL] : ld3w   -0x09(%x11)[96byte] %p3/z -> %z10.s %z11.s %z12.s
-a54ef1ac : ld3w {z12.s, z13.s, z14.s}, p4/Z, [x13, #-6, MUL VL] : ld3w   -0x06(%x13)[96byte] %p4/z -> %z12.s %z13.s %z14.s
-a54ff1ee : ld3w {z14.s, z15.s, z16.s}, p4/Z, [x15, #-3, MUL VL] : ld3w   -0x03(%x15)[96byte] %p4/z -> %z14.s %z15.s %z16.s
+a548e000 : ld3w {z0.s, z1.s, z2.s}, p0/Z, [x0, #-24, MUL VL] : ld3w   -0x0300(%x0)[96byte] %p0/z -> %z0.s %z1.s %z2.s
+a549e482 : ld3w {z2.s, z3.s, z4.s}, p1/Z, [x4, #-21, MUL VL] : ld3w   -0x02a0(%x4)[96byte] %p1/z -> %z2.s %z3.s %z4.s
+a54ae8c4 : ld3w {z4.s, z5.s, z6.s}, p2/Z, [x6, #-18, MUL VL] : ld3w   -0x0240(%x6)[96byte] %p2/z -> %z4.s %z5.s %z6.s
+a54be906 : ld3w {z6.s, z7.s, z8.s}, p2/Z, [x8, #-15, MUL VL] : ld3w   -0x01e0(%x8)[96byte] %p2/z -> %z6.s %z7.s %z8.s
+a54ced48 : ld3w {z8.s, z9.s, z10.s}, p3/Z, [x10, #-12, MUL VL] : ld3w   -0x0180(%x10)[96byte] %p3/z -> %z8.s %z9.s %z10.s
+a54ded6a : ld3w {z10.s, z11.s, z12.s}, p3/Z, [x11, #-9, MUL VL] : ld3w   -0x0120(%x11)[96byte] %p3/z -> %z10.s %z11.s %z12.s
+a54ef1ac : ld3w {z12.s, z13.s, z14.s}, p4/Z, [x13, #-6, MUL VL] : ld3w   -0xc0(%x13)[96byte] %p4/z -> %z12.s %z13.s %z14.s
+a54ff1ee : ld3w {z14.s, z15.s, z16.s}, p4/Z, [x15, #-3, MUL VL] : ld3w   -0x60(%x15)[96byte] %p4/z -> %z14.s %z15.s %z16.s
 a540f630 : ld3w {z16.s, z17.s, z18.s}, p5/Z, [x17, #0, MUL VL] : ld3w   (%x17)[96byte] %p5/z -> %z16.s %z17.s %z18.s
 a540f671 : ld3w {z17.s, z18.s, z19.s}, p5/Z, [x19, #0, MUL VL] : ld3w   (%x19)[96byte] %p5/z -> %z17.s %z18.s %z19.s
-a541f6b3 : ld3w {z19.s, z20.s, z21.s}, p5/Z, [x21, #3, MUL VL] : ld3w   +0x03(%x21)[96byte] %p5/z -> %z19.s %z20.s %z21.s
-a542faf5 : ld3w {z21.s, z22.s, z23.s}, p6/Z, [x23, #6, MUL VL] : ld3w   +0x06(%x23)[96byte] %p6/z -> %z21.s %z22.s %z23.s
-a543fb17 : ld3w {z23.s, z24.s, z25.s}, p6/Z, [x24, #9, MUL VL] : ld3w   +0x09(%x24)[96byte] %p6/z -> %z23.s %z24.s %z25.s
-a544ff59 : ld3w {z25.s, z26.s, z27.s}, p7/Z, [x26, #12, MUL VL] : ld3w   +0x0c(%x26)[96byte] %p7/z -> %z25.s %z26.s %z27.s
-a545ff9b : ld3w {z27.s, z28.s, z29.s}, p7/Z, [x28, #15, MUL VL] : ld3w   +0x0f(%x28)[96byte] %p7/z -> %z27.s %z28.s %z29.s
-a547ffff : ld3w {z31.s, z0.s, z1.s}, p7/Z, [sp, #21, MUL VL] : ld3w   +0x15(%sp)[96byte] %p7/z -> %z31.s %z0.s %z1.s
+a541f6b3 : ld3w {z19.s, z20.s, z21.s}, p5/Z, [x21, #3, MUL VL] : ld3w   +0x60(%x21)[96byte] %p5/z -> %z19.s %z20.s %z21.s
+a542faf5 : ld3w {z21.s, z22.s, z23.s}, p6/Z, [x23, #6, MUL VL] : ld3w   +0xc0(%x23)[96byte] %p6/z -> %z21.s %z22.s %z23.s
+a543fb17 : ld3w {z23.s, z24.s, z25.s}, p6/Z, [x24, #9, MUL VL] : ld3w   +0x0120(%x24)[96byte] %p6/z -> %z23.s %z24.s %z25.s
+a544ff59 : ld3w {z25.s, z26.s, z27.s}, p7/Z, [x26, #12, MUL VL] : ld3w   +0x0180(%x26)[96byte] %p7/z -> %z25.s %z26.s %z27.s
+a545ff9b : ld3w {z27.s, z28.s, z29.s}, p7/Z, [x28, #15, MUL VL] : ld3w   +0x01e0(%x28)[96byte] %p7/z -> %z27.s %z28.s %z29.s
+a547ffff : ld3w {z31.s, z0.s, z1.s}, p7/Z, [sp, #21, MUL VL] : ld3w   +0x02a0(%sp)[96byte] %p7/z -> %z31.s %z0.s %z1.s
 
 # LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LD4B-Z.P.BR-Contiguous)
 a460c000 : ld4b {z0.b, z1.b, z2.b, z3.b}, p0/Z, [x0, x0] : ld4b   (%x0,%x0)[128byte] %p0/z -> %z0.b %z1.b %z2.b %z3.b
@@ -13246,22 +13246,22 @@ a47ddf9b : ld4b {z27.b, z28.b, z29.b, z30.b}, p7/Z, [x28, x29] : ld4b   (%x28,%x
 a47edfff : ld4b {z31.b, z0.b, z1.b, z2.b}, p7/Z, [sp, x30] : ld4b   (%sp,%x30)[128byte] %p7/z -> %z31.b %z0.b %z1.b %z2.b
 
 # LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD4B-Z.P.BI-Contiguous)
-a468e000 : ld4b {z0.b, z1.b, z2.b, z3.b}, p0/Z, [x0, #-32, MUL VL] : ld4b   -0x20(%x0)[128byte] %p0/z -> %z0.b %z1.b %z2.b %z3.b
-a469e482 : ld4b {z2.b, z3.b, z4.b, z5.b}, p1/Z, [x4, #-28, MUL VL] : ld4b   -0x1c(%x4)[128byte] %p1/z -> %z2.b %z3.b %z4.b %z5.b
-a46ae8c4 : ld4b {z4.b, z5.b, z6.b, z7.b}, p2/Z, [x6, #-24, MUL VL] : ld4b   -0x18(%x6)[128byte] %p2/z -> %z4.b %z5.b %z6.b %z7.b
-a46be906 : ld4b {z6.b, z7.b, z8.b, z9.b}, p2/Z, [x8, #-20, MUL VL] : ld4b   -0x14(%x8)[128byte] %p2/z -> %z6.b %z7.b %z8.b %z9.b
-a46ced48 : ld4b {z8.b, z9.b, z10.b, z11.b}, p3/Z, [x10, #-16, MUL VL] : ld4b   -0x10(%x10)[128byte] %p3/z -> %z8.b %z9.b %z10.b %z11.b
-a46ded6a : ld4b {z10.b, z11.b, z12.b, z13.b}, p3/Z, [x11, #-12, MUL VL] : ld4b   -0x0c(%x11)[128byte] %p3/z -> %z10.b %z11.b %z12.b %z13.b
-a46ef1ac : ld4b {z12.b, z13.b, z14.b, z15.b}, p4/Z, [x13, #-8, MUL VL] : ld4b   -0x08(%x13)[128byte] %p4/z -> %z12.b %z13.b %z14.b %z15.b
-a46ff1ee : ld4b {z14.b, z15.b, z16.b, z17.b}, p4/Z, [x15, #-4, MUL VL] : ld4b   -0x04(%x15)[128byte] %p4/z -> %z14.b %z15.b %z16.b %z17.b
+a468e000 : ld4b {z0.b, z1.b, z2.b, z3.b}, p0/Z, [x0, #-32, MUL VL] : ld4b   -0x0400(%x0)[128byte] %p0/z -> %z0.b %z1.b %z2.b %z3.b
+a469e482 : ld4b {z2.b, z3.b, z4.b, z5.b}, p1/Z, [x4, #-28, MUL VL] : ld4b   -0x0380(%x4)[128byte] %p1/z -> %z2.b %z3.b %z4.b %z5.b
+a46ae8c4 : ld4b {z4.b, z5.b, z6.b, z7.b}, p2/Z, [x6, #-24, MUL VL] : ld4b   -0x0300(%x6)[128byte] %p2/z -> %z4.b %z5.b %z6.b %z7.b
+a46be906 : ld4b {z6.b, z7.b, z8.b, z9.b}, p2/Z, [x8, #-20, MUL VL] : ld4b   -0x0280(%x8)[128byte] %p2/z -> %z6.b %z7.b %z8.b %z9.b
+a46ced48 : ld4b {z8.b, z9.b, z10.b, z11.b}, p3/Z, [x10, #-16, MUL VL] : ld4b   -0x0200(%x10)[128byte] %p3/z -> %z8.b %z9.b %z10.b %z11.b
+a46ded6a : ld4b {z10.b, z11.b, z12.b, z13.b}, p3/Z, [x11, #-12, MUL VL] : ld4b   -0x0180(%x11)[128byte] %p3/z -> %z10.b %z11.b %z12.b %z13.b
+a46ef1ac : ld4b {z12.b, z13.b, z14.b, z15.b}, p4/Z, [x13, #-8, MUL VL] : ld4b   -0x0100(%x13)[128byte] %p4/z -> %z12.b %z13.b %z14.b %z15.b
+a46ff1ee : ld4b {z14.b, z15.b, z16.b, z17.b}, p4/Z, [x15, #-4, MUL VL] : ld4b   -0x80(%x15)[128byte] %p4/z -> %z14.b %z15.b %z16.b %z17.b
 a460f630 : ld4b {z16.b, z17.b, z18.b, z19.b}, p5/Z, [x17, #0, MUL VL] : ld4b   (%x17)[128byte] %p5/z -> %z16.b %z17.b %z18.b %z19.b
 a460f671 : ld4b {z17.b, z18.b, z19.b, z20.b}, p5/Z, [x19, #0, MUL VL] : ld4b   (%x19)[128byte] %p5/z -> %z17.b %z18.b %z19.b %z20.b
-a461f6b3 : ld4b {z19.b, z20.b, z21.b, z22.b}, p5/Z, [x21, #4, MUL VL] : ld4b   +0x04(%x21)[128byte] %p5/z -> %z19.b %z20.b %z21.b %z22.b
-a462faf5 : ld4b {z21.b, z22.b, z23.b, z24.b}, p6/Z, [x23, #8, MUL VL] : ld4b   +0x08(%x23)[128byte] %p6/z -> %z21.b %z22.b %z23.b %z24.b
-a463fb17 : ld4b {z23.b, z24.b, z25.b, z26.b}, p6/Z, [x24, #12, MUL VL] : ld4b   +0x0c(%x24)[128byte] %p6/z -> %z23.b %z24.b %z25.b %z26.b
-a464ff59 : ld4b {z25.b, z26.b, z27.b, z28.b}, p7/Z, [x26, #16, MUL VL] : ld4b   +0x10(%x26)[128byte] %p7/z -> %z25.b %z26.b %z27.b %z28.b
-a465ff9b : ld4b {z27.b, z28.b, z29.b, z30.b}, p7/Z, [x28, #20, MUL VL] : ld4b   +0x14(%x28)[128byte] %p7/z -> %z27.b %z28.b %z29.b %z30.b
-a467ffff : ld4b {z31.b, z0.b, z1.b, z2.b}, p7/Z, [sp, #28, MUL VL] : ld4b   +0x1c(%sp)[128byte] %p7/z -> %z31.b %z0.b %z1.b %z2.b
+a461f6b3 : ld4b {z19.b, z20.b, z21.b, z22.b}, p5/Z, [x21, #4, MUL VL] : ld4b   +0x80(%x21)[128byte] %p5/z -> %z19.b %z20.b %z21.b %z22.b
+a462faf5 : ld4b {z21.b, z22.b, z23.b, z24.b}, p6/Z, [x23, #8, MUL VL] : ld4b   +0x0100(%x23)[128byte] %p6/z -> %z21.b %z22.b %z23.b %z24.b
+a463fb17 : ld4b {z23.b, z24.b, z25.b, z26.b}, p6/Z, [x24, #12, MUL VL] : ld4b   +0x0180(%x24)[128byte] %p6/z -> %z23.b %z24.b %z25.b %z26.b
+a464ff59 : ld4b {z25.b, z26.b, z27.b, z28.b}, p7/Z, [x26, #16, MUL VL] : ld4b   +0x0200(%x26)[128byte] %p7/z -> %z25.b %z26.b %z27.b %z28.b
+a465ff9b : ld4b {z27.b, z28.b, z29.b, z30.b}, p7/Z, [x28, #20, MUL VL] : ld4b   +0x0280(%x28)[128byte] %p7/z -> %z27.b %z28.b %z29.b %z30.b
+a467ffff : ld4b {z31.b, z0.b, z1.b, z2.b}, p7/Z, [sp, #28, MUL VL] : ld4b   +0x0380(%sp)[128byte] %p7/z -> %z31.b %z0.b %z1.b %z2.b
 
 # LD4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #3] (LD4D-Z.P.BR-Contiguous)
 a5e0c000 : ld4d {z0.d, z1.d, z2.d, z3.d}, p0/Z, [x0, x0, LSL #3] : ld4d   (%x0,%x0,lsl #3)[128byte] %p0/z -> %z0.d %z1.d %z2.d %z3.d
@@ -13282,22 +13282,22 @@ a5fddf9b : ld4d {z27.d, z28.d, z29.d, z30.d}, p7/Z, [x28, x29, LSL #3] : ld4d   
 a5fedfff : ld4d {z31.d, z0.d, z1.d, z2.d}, p7/Z, [sp, x30, LSL #3] : ld4d   (%sp,%x30,lsl #3)[128byte] %p7/z -> %z31.d %z0.d %z1.d %z2.d
 
 # LD4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD4D-Z.P.BI-Contiguous)
-a5e8e000 : ld4d {z0.d, z1.d, z2.d, z3.d}, p0/Z, [x0, #-32, MUL VL] : ld4d   -0x20(%x0)[128byte] %p0/z -> %z0.d %z1.d %z2.d %z3.d
-a5e9e482 : ld4d {z2.d, z3.d, z4.d, z5.d}, p1/Z, [x4, #-28, MUL VL] : ld4d   -0x1c(%x4)[128byte] %p1/z -> %z2.d %z3.d %z4.d %z5.d
-a5eae8c4 : ld4d {z4.d, z5.d, z6.d, z7.d}, p2/Z, [x6, #-24, MUL VL] : ld4d   -0x18(%x6)[128byte] %p2/z -> %z4.d %z5.d %z6.d %z7.d
-a5ebe906 : ld4d {z6.d, z7.d, z8.d, z9.d}, p2/Z, [x8, #-20, MUL VL] : ld4d   -0x14(%x8)[128byte] %p2/z -> %z6.d %z7.d %z8.d %z9.d
-a5eced48 : ld4d {z8.d, z9.d, z10.d, z11.d}, p3/Z, [x10, #-16, MUL VL] : ld4d   -0x10(%x10)[128byte] %p3/z -> %z8.d %z9.d %z10.d %z11.d
-a5eded6a : ld4d {z10.d, z11.d, z12.d, z13.d}, p3/Z, [x11, #-12, MUL VL] : ld4d   -0x0c(%x11)[128byte] %p3/z -> %z10.d %z11.d %z12.d %z13.d
-a5eef1ac : ld4d {z12.d, z13.d, z14.d, z15.d}, p4/Z, [x13, #-8, MUL VL] : ld4d   -0x08(%x13)[128byte] %p4/z -> %z12.d %z13.d %z14.d %z15.d
-a5eff1ee : ld4d {z14.d, z15.d, z16.d, z17.d}, p4/Z, [x15, #-4, MUL VL] : ld4d   -0x04(%x15)[128byte] %p4/z -> %z14.d %z15.d %z16.d %z17.d
+a5e8e000 : ld4d {z0.d, z1.d, z2.d, z3.d}, p0/Z, [x0, #-32, MUL VL] : ld4d   -0x0400(%x0)[128byte] %p0/z -> %z0.d %z1.d %z2.d %z3.d
+a5e9e482 : ld4d {z2.d, z3.d, z4.d, z5.d}, p1/Z, [x4, #-28, MUL VL] : ld4d   -0x0380(%x4)[128byte] %p1/z -> %z2.d %z3.d %z4.d %z5.d
+a5eae8c4 : ld4d {z4.d, z5.d, z6.d, z7.d}, p2/Z, [x6, #-24, MUL VL] : ld4d   -0x0300(%x6)[128byte] %p2/z -> %z4.d %z5.d %z6.d %z7.d
+a5ebe906 : ld4d {z6.d, z7.d, z8.d, z9.d}, p2/Z, [x8, #-20, MUL VL] : ld4d   -0x0280(%x8)[128byte] %p2/z -> %z6.d %z7.d %z8.d %z9.d
+a5eced48 : ld4d {z8.d, z9.d, z10.d, z11.d}, p3/Z, [x10, #-16, MUL VL] : ld4d   -0x0200(%x10)[128byte] %p3/z -> %z8.d %z9.d %z10.d %z11.d
+a5eded6a : ld4d {z10.d, z11.d, z12.d, z13.d}, p3/Z, [x11, #-12, MUL VL] : ld4d   -0x0180(%x11)[128byte] %p3/z -> %z10.d %z11.d %z12.d %z13.d
+a5eef1ac : ld4d {z12.d, z13.d, z14.d, z15.d}, p4/Z, [x13, #-8, MUL VL] : ld4d   -0x0100(%x13)[128byte] %p4/z -> %z12.d %z13.d %z14.d %z15.d
+a5eff1ee : ld4d {z14.d, z15.d, z16.d, z17.d}, p4/Z, [x15, #-4, MUL VL] : ld4d   -0x80(%x15)[128byte] %p4/z -> %z14.d %z15.d %z16.d %z17.d
 a5e0f630 : ld4d {z16.d, z17.d, z18.d, z19.d}, p5/Z, [x17, #0, MUL VL] : ld4d   (%x17)[128byte] %p5/z -> %z16.d %z17.d %z18.d %z19.d
 a5e0f671 : ld4d {z17.d, z18.d, z19.d, z20.d}, p5/Z, [x19, #0, MUL VL] : ld4d   (%x19)[128byte] %p5/z -> %z17.d %z18.d %z19.d %z20.d
-a5e1f6b3 : ld4d {z19.d, z20.d, z21.d, z22.d}, p5/Z, [x21, #4, MUL VL] : ld4d   +0x04(%x21)[128byte] %p5/z -> %z19.d %z20.d %z21.d %z22.d
-a5e2faf5 : ld4d {z21.d, z22.d, z23.d, z24.d}, p6/Z, [x23, #8, MUL VL] : ld4d   +0x08(%x23)[128byte] %p6/z -> %z21.d %z22.d %z23.d %z24.d
-a5e3fb17 : ld4d {z23.d, z24.d, z25.d, z26.d}, p6/Z, [x24, #12, MUL VL] : ld4d   +0x0c(%x24)[128byte] %p6/z -> %z23.d %z24.d %z25.d %z26.d
-a5e4ff59 : ld4d {z25.d, z26.d, z27.d, z28.d}, p7/Z, [x26, #16, MUL VL] : ld4d   +0x10(%x26)[128byte] %p7/z -> %z25.d %z26.d %z27.d %z28.d
-a5e5ff9b : ld4d {z27.d, z28.d, z29.d, z30.d}, p7/Z, [x28, #20, MUL VL] : ld4d   +0x14(%x28)[128byte] %p7/z -> %z27.d %z28.d %z29.d %z30.d
-a5e7ffff : ld4d {z31.d, z0.d, z1.d, z2.d}, p7/Z, [sp, #28, MUL VL] : ld4d   +0x1c(%sp)[128byte] %p7/z -> %z31.d %z0.d %z1.d %z2.d
+a5e1f6b3 : ld4d {z19.d, z20.d, z21.d, z22.d}, p5/Z, [x21, #4, MUL VL] : ld4d   +0x80(%x21)[128byte] %p5/z -> %z19.d %z20.d %z21.d %z22.d
+a5e2faf5 : ld4d {z21.d, z22.d, z23.d, z24.d}, p6/Z, [x23, #8, MUL VL] : ld4d   +0x0100(%x23)[128byte] %p6/z -> %z21.d %z22.d %z23.d %z24.d
+a5e3fb17 : ld4d {z23.d, z24.d, z25.d, z26.d}, p6/Z, [x24, #12, MUL VL] : ld4d   +0x0180(%x24)[128byte] %p6/z -> %z23.d %z24.d %z25.d %z26.d
+a5e4ff59 : ld4d {z25.d, z26.d, z27.d, z28.d}, p7/Z, [x26, #16, MUL VL] : ld4d   +0x0200(%x26)[128byte] %p7/z -> %z25.d %z26.d %z27.d %z28.d
+a5e5ff9b : ld4d {z27.d, z28.d, z29.d, z30.d}, p7/Z, [x28, #20, MUL VL] : ld4d   +0x0280(%x28)[128byte] %p7/z -> %z27.d %z28.d %z29.d %z30.d
+a5e7ffff : ld4d {z31.d, z0.d, z1.d, z2.d}, p7/Z, [sp, #28, MUL VL] : ld4d   +0x0380(%sp)[128byte] %p7/z -> %z31.d %z0.d %z1.d %z2.d
 
 # LD4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1] (LD4H-Z.P.BR-Contiguous)
 a4e0c000 : ld4h {z0.h, z1.h, z2.h, z3.h}, p0/Z, [x0, x0, LSL #1] : ld4h   (%x0,%x0,lsl #1)[128byte] %p0/z -> %z0.h %z1.h %z2.h %z3.h
@@ -13318,22 +13318,22 @@ a4fddf9b : ld4h {z27.h, z28.h, z29.h, z30.h}, p7/Z, [x28, x29, LSL #1] : ld4h   
 a4fedfff : ld4h {z31.h, z0.h, z1.h, z2.h}, p7/Z, [sp, x30, LSL #1] : ld4h   (%sp,%x30,lsl #1)[128byte] %p7/z -> %z31.h %z0.h %z1.h %z2.h
 
 # LD4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD4H-Z.P.BI-Contiguous)
-a4e8e000 : ld4h {z0.h, z1.h, z2.h, z3.h}, p0/Z, [x0, #-32, MUL VL] : ld4h   -0x20(%x0)[128byte] %p0/z -> %z0.h %z1.h %z2.h %z3.h
-a4e9e482 : ld4h {z2.h, z3.h, z4.h, z5.h}, p1/Z, [x4, #-28, MUL VL] : ld4h   -0x1c(%x4)[128byte] %p1/z -> %z2.h %z3.h %z4.h %z5.h
-a4eae8c4 : ld4h {z4.h, z5.h, z6.h, z7.h}, p2/Z, [x6, #-24, MUL VL] : ld4h   -0x18(%x6)[128byte] %p2/z -> %z4.h %z5.h %z6.h %z7.h
-a4ebe906 : ld4h {z6.h, z7.h, z8.h, z9.h}, p2/Z, [x8, #-20, MUL VL] : ld4h   -0x14(%x8)[128byte] %p2/z -> %z6.h %z7.h %z8.h %z9.h
-a4eced48 : ld4h {z8.h, z9.h, z10.h, z11.h}, p3/Z, [x10, #-16, MUL VL] : ld4h   -0x10(%x10)[128byte] %p3/z -> %z8.h %z9.h %z10.h %z11.h
-a4eded6a : ld4h {z10.h, z11.h, z12.h, z13.h}, p3/Z, [x11, #-12, MUL VL] : ld4h   -0x0c(%x11)[128byte] %p3/z -> %z10.h %z11.h %z12.h %z13.h
-a4eef1ac : ld4h {z12.h, z13.h, z14.h, z15.h}, p4/Z, [x13, #-8, MUL VL] : ld4h   -0x08(%x13)[128byte] %p4/z -> %z12.h %z13.h %z14.h %z15.h
-a4eff1ee : ld4h {z14.h, z15.h, z16.h, z17.h}, p4/Z, [x15, #-4, MUL VL] : ld4h   -0x04(%x15)[128byte] %p4/z -> %z14.h %z15.h %z16.h %z17.h
+a4e8e000 : ld4h {z0.h, z1.h, z2.h, z3.h}, p0/Z, [x0, #-32, MUL VL] : ld4h   -0x0400(%x0)[128byte] %p0/z -> %z0.h %z1.h %z2.h %z3.h
+a4e9e482 : ld4h {z2.h, z3.h, z4.h, z5.h}, p1/Z, [x4, #-28, MUL VL] : ld4h   -0x0380(%x4)[128byte] %p1/z -> %z2.h %z3.h %z4.h %z5.h
+a4eae8c4 : ld4h {z4.h, z5.h, z6.h, z7.h}, p2/Z, [x6, #-24, MUL VL] : ld4h   -0x0300(%x6)[128byte] %p2/z -> %z4.h %z5.h %z6.h %z7.h
+a4ebe906 : ld4h {z6.h, z7.h, z8.h, z9.h}, p2/Z, [x8, #-20, MUL VL] : ld4h   -0x0280(%x8)[128byte] %p2/z -> %z6.h %z7.h %z8.h %z9.h
+a4eced48 : ld4h {z8.h, z9.h, z10.h, z11.h}, p3/Z, [x10, #-16, MUL VL] : ld4h   -0x0200(%x10)[128byte] %p3/z -> %z8.h %z9.h %z10.h %z11.h
+a4eded6a : ld4h {z10.h, z11.h, z12.h, z13.h}, p3/Z, [x11, #-12, MUL VL] : ld4h   -0x0180(%x11)[128byte] %p3/z -> %z10.h %z11.h %z12.h %z13.h
+a4eef1ac : ld4h {z12.h, z13.h, z14.h, z15.h}, p4/Z, [x13, #-8, MUL VL] : ld4h   -0x0100(%x13)[128byte] %p4/z -> %z12.h %z13.h %z14.h %z15.h
+a4eff1ee : ld4h {z14.h, z15.h, z16.h, z17.h}, p4/Z, [x15, #-4, MUL VL] : ld4h   -0x80(%x15)[128byte] %p4/z -> %z14.h %z15.h %z16.h %z17.h
 a4e0f630 : ld4h {z16.h, z17.h, z18.h, z19.h}, p5/Z, [x17, #0, MUL VL] : ld4h   (%x17)[128byte] %p5/z -> %z16.h %z17.h %z18.h %z19.h
 a4e0f671 : ld4h {z17.h, z18.h, z19.h, z20.h}, p5/Z, [x19, #0, MUL VL] : ld4h   (%x19)[128byte] %p5/z -> %z17.h %z18.h %z19.h %z20.h
-a4e1f6b3 : ld4h {z19.h, z20.h, z21.h, z22.h}, p5/Z, [x21, #4, MUL VL] : ld4h   +0x04(%x21)[128byte] %p5/z -> %z19.h %z20.h %z21.h %z22.h
-a4e2faf5 : ld4h {z21.h, z22.h, z23.h, z24.h}, p6/Z, [x23, #8, MUL VL] : ld4h   +0x08(%x23)[128byte] %p6/z -> %z21.h %z22.h %z23.h %z24.h
-a4e3fb17 : ld4h {z23.h, z24.h, z25.h, z26.h}, p6/Z, [x24, #12, MUL VL] : ld4h   +0x0c(%x24)[128byte] %p6/z -> %z23.h %z24.h %z25.h %z26.h
-a4e4ff59 : ld4h {z25.h, z26.h, z27.h, z28.h}, p7/Z, [x26, #16, MUL VL] : ld4h   +0x10(%x26)[128byte] %p7/z -> %z25.h %z26.h %z27.h %z28.h
-a4e5ff9b : ld4h {z27.h, z28.h, z29.h, z30.h}, p7/Z, [x28, #20, MUL VL] : ld4h   +0x14(%x28)[128byte] %p7/z -> %z27.h %z28.h %z29.h %z30.h
-a4e7ffff : ld4h {z31.h, z0.h, z1.h, z2.h}, p7/Z, [sp, #28, MUL VL] : ld4h   +0x1c(%sp)[128byte] %p7/z -> %z31.h %z0.h %z1.h %z2.h
+a4e1f6b3 : ld4h {z19.h, z20.h, z21.h, z22.h}, p5/Z, [x21, #4, MUL VL] : ld4h   +0x80(%x21)[128byte] %p5/z -> %z19.h %z20.h %z21.h %z22.h
+a4e2faf5 : ld4h {z21.h, z22.h, z23.h, z24.h}, p6/Z, [x23, #8, MUL VL] : ld4h   +0x0100(%x23)[128byte] %p6/z -> %z21.h %z22.h %z23.h %z24.h
+a4e3fb17 : ld4h {z23.h, z24.h, z25.h, z26.h}, p6/Z, [x24, #12, MUL VL] : ld4h   +0x0180(%x24)[128byte] %p6/z -> %z23.h %z24.h %z25.h %z26.h
+a4e4ff59 : ld4h {z25.h, z26.h, z27.h, z28.h}, p7/Z, [x26, #16, MUL VL] : ld4h   +0x0200(%x26)[128byte] %p7/z -> %z25.h %z26.h %z27.h %z28.h
+a4e5ff9b : ld4h {z27.h, z28.h, z29.h, z30.h}, p7/Z, [x28, #20, MUL VL] : ld4h   +0x0280(%x28)[128byte] %p7/z -> %z27.h %z28.h %z29.h %z30.h
+a4e7ffff : ld4h {z31.h, z0.h, z1.h, z2.h}, p7/Z, [sp, #28, MUL VL] : ld4h   +0x0380(%sp)[128byte] %p7/z -> %z31.h %z0.h %z1.h %z2.h
 
 # LD4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #2] (LD4W-Z.P.BR-Contiguous)
 a560c000 : ld4w {z0.s, z1.s, z2.s, z3.s}, p0/Z, [x0, x0, LSL #2] : ld4w   (%x0,%x0,lsl #2)[128byte] %p0/z -> %z0.s %z1.s %z2.s %z3.s
@@ -13354,22 +13354,22 @@ a57ddf9b : ld4w {z27.s, z28.s, z29.s, z30.s}, p7/Z, [x28, x29, LSL #2] : ld4w   
 a57edfff : ld4w {z31.s, z0.s, z1.s, z2.s}, p7/Z, [sp, x30, LSL #2] : ld4w   (%sp,%x30,lsl #2)[128byte] %p7/z -> %z31.s %z0.s %z1.s %z2.s
 
 # LD4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LD4W-Z.P.BI-Contiguous)
-a568e000 : ld4w {z0.s, z1.s, z2.s, z3.s}, p0/Z, [x0, #-32, MUL VL] : ld4w   -0x20(%x0)[128byte] %p0/z -> %z0.s %z1.s %z2.s %z3.s
-a569e482 : ld4w {z2.s, z3.s, z4.s, z5.s}, p1/Z, [x4, #-28, MUL VL] : ld4w   -0x1c(%x4)[128byte] %p1/z -> %z2.s %z3.s %z4.s %z5.s
-a56ae8c4 : ld4w {z4.s, z5.s, z6.s, z7.s}, p2/Z, [x6, #-24, MUL VL] : ld4w   -0x18(%x6)[128byte] %p2/z -> %z4.s %z5.s %z6.s %z7.s
-a56be906 : ld4w {z6.s, z7.s, z8.s, z9.s}, p2/Z, [x8, #-20, MUL VL] : ld4w   -0x14(%x8)[128byte] %p2/z -> %z6.s %z7.s %z8.s %z9.s
-a56ced48 : ld4w {z8.s, z9.s, z10.s, z11.s}, p3/Z, [x10, #-16, MUL VL] : ld4w   -0x10(%x10)[128byte] %p3/z -> %z8.s %z9.s %z10.s %z11.s
-a56ded6a : ld4w {z10.s, z11.s, z12.s, z13.s}, p3/Z, [x11, #-12, MUL VL] : ld4w   -0x0c(%x11)[128byte] %p3/z -> %z10.s %z11.s %z12.s %z13.s
-a56ef1ac : ld4w {z12.s, z13.s, z14.s, z15.s}, p4/Z, [x13, #-8, MUL VL] : ld4w   -0x08(%x13)[128byte] %p4/z -> %z12.s %z13.s %z14.s %z15.s
-a56ff1ee : ld4w {z14.s, z15.s, z16.s, z17.s}, p4/Z, [x15, #-4, MUL VL] : ld4w   -0x04(%x15)[128byte] %p4/z -> %z14.s %z15.s %z16.s %z17.s
+a568e000 : ld4w {z0.s, z1.s, z2.s, z3.s}, p0/Z, [x0, #-32, MUL VL] : ld4w   -0x0400(%x0)[128byte] %p0/z -> %z0.s %z1.s %z2.s %z3.s
+a569e482 : ld4w {z2.s, z3.s, z4.s, z5.s}, p1/Z, [x4, #-28, MUL VL] : ld4w   -0x0380(%x4)[128byte] %p1/z -> %z2.s %z3.s %z4.s %z5.s
+a56ae8c4 : ld4w {z4.s, z5.s, z6.s, z7.s}, p2/Z, [x6, #-24, MUL VL] : ld4w   -0x0300(%x6)[128byte] %p2/z -> %z4.s %z5.s %z6.s %z7.s
+a56be906 : ld4w {z6.s, z7.s, z8.s, z9.s}, p2/Z, [x8, #-20, MUL VL] : ld4w   -0x0280(%x8)[128byte] %p2/z -> %z6.s %z7.s %z8.s %z9.s
+a56ced48 : ld4w {z8.s, z9.s, z10.s, z11.s}, p3/Z, [x10, #-16, MUL VL] : ld4w   -0x0200(%x10)[128byte] %p3/z -> %z8.s %z9.s %z10.s %z11.s
+a56ded6a : ld4w {z10.s, z11.s, z12.s, z13.s}, p3/Z, [x11, #-12, MUL VL] : ld4w   -0x0180(%x11)[128byte] %p3/z -> %z10.s %z11.s %z12.s %z13.s
+a56ef1ac : ld4w {z12.s, z13.s, z14.s, z15.s}, p4/Z, [x13, #-8, MUL VL] : ld4w   -0x0100(%x13)[128byte] %p4/z -> %z12.s %z13.s %z14.s %z15.s
+a56ff1ee : ld4w {z14.s, z15.s, z16.s, z17.s}, p4/Z, [x15, #-4, MUL VL] : ld4w   -0x80(%x15)[128byte] %p4/z -> %z14.s %z15.s %z16.s %z17.s
 a560f630 : ld4w {z16.s, z17.s, z18.s, z19.s}, p5/Z, [x17, #0, MUL VL] : ld4w   (%x17)[128byte] %p5/z -> %z16.s %z17.s %z18.s %z19.s
 a560f671 : ld4w {z17.s, z18.s, z19.s, z20.s}, p5/Z, [x19, #0, MUL VL] : ld4w   (%x19)[128byte] %p5/z -> %z17.s %z18.s %z19.s %z20.s
-a561f6b3 : ld4w {z19.s, z20.s, z21.s, z22.s}, p5/Z, [x21, #4, MUL VL] : ld4w   +0x04(%x21)[128byte] %p5/z -> %z19.s %z20.s %z21.s %z22.s
-a562faf5 : ld4w {z21.s, z22.s, z23.s, z24.s}, p6/Z, [x23, #8, MUL VL] : ld4w   +0x08(%x23)[128byte] %p6/z -> %z21.s %z22.s %z23.s %z24.s
-a563fb17 : ld4w {z23.s, z24.s, z25.s, z26.s}, p6/Z, [x24, #12, MUL VL] : ld4w   +0x0c(%x24)[128byte] %p6/z -> %z23.s %z24.s %z25.s %z26.s
-a564ff59 : ld4w {z25.s, z26.s, z27.s, z28.s}, p7/Z, [x26, #16, MUL VL] : ld4w   +0x10(%x26)[128byte] %p7/z -> %z25.s %z26.s %z27.s %z28.s
-a565ff9b : ld4w {z27.s, z28.s, z29.s, z30.s}, p7/Z, [x28, #20, MUL VL] : ld4w   +0x14(%x28)[128byte] %p7/z -> %z27.s %z28.s %z29.s %z30.s
-a567ffff : ld4w {z31.s, z0.s, z1.s, z2.s}, p7/Z, [sp, #28, MUL VL] : ld4w   +0x1c(%sp)[128byte] %p7/z -> %z31.s %z0.s %z1.s %z2.s
+a561f6b3 : ld4w {z19.s, z20.s, z21.s, z22.s}, p5/Z, [x21, #4, MUL VL] : ld4w   +0x80(%x21)[128byte] %p5/z -> %z19.s %z20.s %z21.s %z22.s
+a562faf5 : ld4w {z21.s, z22.s, z23.s, z24.s}, p6/Z, [x23, #8, MUL VL] : ld4w   +0x0100(%x23)[128byte] %p6/z -> %z21.s %z22.s %z23.s %z24.s
+a563fb17 : ld4w {z23.s, z24.s, z25.s, z26.s}, p6/Z, [x24, #12, MUL VL] : ld4w   +0x0180(%x24)[128byte] %p6/z -> %z23.s %z24.s %z25.s %z26.s
+a564ff59 : ld4w {z25.s, z26.s, z27.s, z28.s}, p7/Z, [x26, #16, MUL VL] : ld4w   +0x0200(%x26)[128byte] %p7/z -> %z25.s %z26.s %z27.s %z28.s
+a565ff9b : ld4w {z27.s, z28.s, z29.s, z30.s}, p7/Z, [x28, #20, MUL VL] : ld4w   +0x0280(%x28)[128byte] %p7/z -> %z27.s %z28.s %z29.s %z30.s
+a567ffff : ld4w {z31.s, z0.s, z1.s, z2.s}, p7/Z, [sp, #28, MUL VL] : ld4w   +0x0380(%sp)[128byte] %p7/z -> %z31.s %z0.s %z1.s %z2.s
 
 # LDFF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Zm>.S, <extend>] (LDFF1B-Z.P.BZ-S.x32.unscaled)
 84006000 : ldff1b z0.s, p0/Z, [x0, z0.s, UXTW]       : ldff1b (%x0,%z0.s,uxtw)[8byte] %p0/z -> %z0.s
@@ -14772,292 +14772,292 @@ c57eff9b : ldff1w z27.d, p7/Z, [x28, z30.d, LSL #2]  : ldff1w (%x28,%z30.d,lsl #
 c57fffff : ldff1w z31.d, p7/Z, [sp, z31.d, LSL #2]   : ldff1w (%sp,%z31.d,lsl #2)[16byte] %p7/z -> %z31.d
 
 # LDNF1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1B-Z.P.BI-U8)
-a418a000 : ldnf1b z0.b, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x08(%x0)[32byte] %p0/z -> %z0.b
-a419a482 : ldnf1b z2.b, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0x07(%x4)[32byte] %p1/z -> %z2.b
-a41aa8c4 : ldnf1b z4.b, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0x06(%x6)[32byte] %p2/z -> %z4.b
-a41ba906 : ldnf1b z6.b, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0x05(%x8)[32byte] %p2/z -> %z6.b
-a41cad48 : ldnf1b z8.b, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x04(%x10)[32byte] %p3/z -> %z8.b
-a41dad6a : ldnf1b z10.b, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x03(%x11)[32byte] %p3/z -> %z10.b
-a41eb1ac : ldnf1b z12.b, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x02(%x13)[32byte] %p4/z -> %z12.b
-a41fb1ee : ldnf1b z14.b, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x01(%x15)[32byte] %p4/z -> %z14.b
+a418a000 : ldnf1b z0.b, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x0100(%x0)[32byte] %p0/z -> %z0.b
+a419a482 : ldnf1b z2.b, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0xe0(%x4)[32byte] %p1/z -> %z2.b
+a41aa8c4 : ldnf1b z4.b, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0xc0(%x6)[32byte] %p2/z -> %z4.b
+a41ba906 : ldnf1b z6.b, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0xa0(%x8)[32byte] %p2/z -> %z6.b
+a41cad48 : ldnf1b z8.b, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x80(%x10)[32byte] %p3/z -> %z8.b
+a41dad6a : ldnf1b z10.b, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x60(%x11)[32byte] %p3/z -> %z10.b
+a41eb1ac : ldnf1b z12.b, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x40(%x13)[32byte] %p4/z -> %z12.b
+a41fb1ee : ldnf1b z14.b, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x20(%x15)[32byte] %p4/z -> %z14.b
 a410b630 : ldnf1b z16.b, p5/Z, [x17, #0, MUL VL]     : ldnf1b (%x17)[32byte] %p5/z -> %z16.b
 a410b671 : ldnf1b z17.b, p5/Z, [x19, #0, MUL VL]     : ldnf1b (%x19)[32byte] %p5/z -> %z17.b
-a411b6b3 : ldnf1b z19.b, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x01(%x21)[32byte] %p5/z -> %z19.b
-a412baf5 : ldnf1b z21.b, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x02(%x23)[32byte] %p6/z -> %z21.b
-a413bb17 : ldnf1b z23.b, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x03(%x24)[32byte] %p6/z -> %z23.b
-a414bf59 : ldnf1b z25.b, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x04(%x26)[32byte] %p7/z -> %z25.b
-a415bf9b : ldnf1b z27.b, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0x05(%x28)[32byte] %p7/z -> %z27.b
-a417bfff : ldnf1b z31.b, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0x07(%sp)[32byte] %p7/z -> %z31.b
+a411b6b3 : ldnf1b z19.b, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x20(%x21)[32byte] %p5/z -> %z19.b
+a412baf5 : ldnf1b z21.b, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x40(%x23)[32byte] %p6/z -> %z21.b
+a413bb17 : ldnf1b z23.b, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x60(%x24)[32byte] %p6/z -> %z23.b
+a414bf59 : ldnf1b z25.b, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x80(%x26)[32byte] %p7/z -> %z25.b
+a415bf9b : ldnf1b z27.b, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0xa0(%x28)[32byte] %p7/z -> %z27.b
+a417bfff : ldnf1b z31.b, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0xe0(%sp)[32byte] %p7/z -> %z31.b
 
 # LDNF1B  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1B-Z.P.BI-U16)
-a438a000 : ldnf1b z0.h, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x08(%x0)[16byte] %p0/z -> %z0.h
-a439a482 : ldnf1b z2.h, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0x07(%x4)[16byte] %p1/z -> %z2.h
-a43aa8c4 : ldnf1b z4.h, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0x06(%x6)[16byte] %p2/z -> %z4.h
-a43ba906 : ldnf1b z6.h, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0x05(%x8)[16byte] %p2/z -> %z6.h
-a43cad48 : ldnf1b z8.h, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x04(%x10)[16byte] %p3/z -> %z8.h
-a43dad6a : ldnf1b z10.h, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x03(%x11)[16byte] %p3/z -> %z10.h
-a43eb1ac : ldnf1b z12.h, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x02(%x13)[16byte] %p4/z -> %z12.h
-a43fb1ee : ldnf1b z14.h, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x01(%x15)[16byte] %p4/z -> %z14.h
+a438a000 : ldnf1b z0.h, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x80(%x0)[16byte] %p0/z -> %z0.h
+a439a482 : ldnf1b z2.h, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0x70(%x4)[16byte] %p1/z -> %z2.h
+a43aa8c4 : ldnf1b z4.h, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0x60(%x6)[16byte] %p2/z -> %z4.h
+a43ba906 : ldnf1b z6.h, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0x50(%x8)[16byte] %p2/z -> %z6.h
+a43cad48 : ldnf1b z8.h, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x40(%x10)[16byte] %p3/z -> %z8.h
+a43dad6a : ldnf1b z10.h, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x30(%x11)[16byte] %p3/z -> %z10.h
+a43eb1ac : ldnf1b z12.h, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x20(%x13)[16byte] %p4/z -> %z12.h
+a43fb1ee : ldnf1b z14.h, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x10(%x15)[16byte] %p4/z -> %z14.h
 a430b630 : ldnf1b z16.h, p5/Z, [x17, #0, MUL VL]     : ldnf1b (%x17)[16byte] %p5/z -> %z16.h
 a430b671 : ldnf1b z17.h, p5/Z, [x19, #0, MUL VL]     : ldnf1b (%x19)[16byte] %p5/z -> %z17.h
-a431b6b3 : ldnf1b z19.h, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x01(%x21)[16byte] %p5/z -> %z19.h
-a432baf5 : ldnf1b z21.h, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x02(%x23)[16byte] %p6/z -> %z21.h
-a433bb17 : ldnf1b z23.h, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x03(%x24)[16byte] %p6/z -> %z23.h
-a434bf59 : ldnf1b z25.h, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x04(%x26)[16byte] %p7/z -> %z25.h
-a435bf9b : ldnf1b z27.h, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0x05(%x28)[16byte] %p7/z -> %z27.h
-a437bfff : ldnf1b z31.h, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0x07(%sp)[16byte] %p7/z -> %z31.h
+a431b6b3 : ldnf1b z19.h, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x10(%x21)[16byte] %p5/z -> %z19.h
+a432baf5 : ldnf1b z21.h, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x20(%x23)[16byte] %p6/z -> %z21.h
+a433bb17 : ldnf1b z23.h, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x30(%x24)[16byte] %p6/z -> %z23.h
+a434bf59 : ldnf1b z25.h, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x40(%x26)[16byte] %p7/z -> %z25.h
+a435bf9b : ldnf1b z27.h, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0x50(%x28)[16byte] %p7/z -> %z27.h
+a437bfff : ldnf1b z31.h, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0x70(%sp)[16byte] %p7/z -> %z31.h
 
 # LDNF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1B-Z.P.BI-U32)
-a458a000 : ldnf1b z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x08(%x0)[8byte] %p0/z -> %z0.s
-a459a482 : ldnf1b z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0x07(%x4)[8byte] %p1/z -> %z2.s
-a45aa8c4 : ldnf1b z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0x06(%x6)[8byte] %p2/z -> %z4.s
-a45ba906 : ldnf1b z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0x05(%x8)[8byte] %p2/z -> %z6.s
-a45cad48 : ldnf1b z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x04(%x10)[8byte] %p3/z -> %z8.s
-a45dad6a : ldnf1b z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x03(%x11)[8byte] %p3/z -> %z10.s
-a45eb1ac : ldnf1b z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x02(%x13)[8byte] %p4/z -> %z12.s
-a45fb1ee : ldnf1b z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x01(%x15)[8byte] %p4/z -> %z14.s
+a458a000 : ldnf1b z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x40(%x0)[8byte] %p0/z -> %z0.s
+a459a482 : ldnf1b z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0x38(%x4)[8byte] %p1/z -> %z2.s
+a45aa8c4 : ldnf1b z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0x30(%x6)[8byte] %p2/z -> %z4.s
+a45ba906 : ldnf1b z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0x28(%x8)[8byte] %p2/z -> %z6.s
+a45cad48 : ldnf1b z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x20(%x10)[8byte] %p3/z -> %z8.s
+a45dad6a : ldnf1b z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x18(%x11)[8byte] %p3/z -> %z10.s
+a45eb1ac : ldnf1b z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x10(%x13)[8byte] %p4/z -> %z12.s
+a45fb1ee : ldnf1b z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x08(%x15)[8byte] %p4/z -> %z14.s
 a450b630 : ldnf1b z16.s, p5/Z, [x17, #0, MUL VL]     : ldnf1b (%x17)[8byte] %p5/z -> %z16.s
 a450b671 : ldnf1b z17.s, p5/Z, [x19, #0, MUL VL]     : ldnf1b (%x19)[8byte] %p5/z -> %z17.s
-a451b6b3 : ldnf1b z19.s, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x01(%x21)[8byte] %p5/z -> %z19.s
-a452baf5 : ldnf1b z21.s, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x02(%x23)[8byte] %p6/z -> %z21.s
-a453bb17 : ldnf1b z23.s, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x03(%x24)[8byte] %p6/z -> %z23.s
-a454bf59 : ldnf1b z25.s, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x04(%x26)[8byte] %p7/z -> %z25.s
-a455bf9b : ldnf1b z27.s, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0x05(%x28)[8byte] %p7/z -> %z27.s
-a457bfff : ldnf1b z31.s, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0x07(%sp)[8byte] %p7/z -> %z31.s
+a451b6b3 : ldnf1b z19.s, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x08(%x21)[8byte] %p5/z -> %z19.s
+a452baf5 : ldnf1b z21.s, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x10(%x23)[8byte] %p6/z -> %z21.s
+a453bb17 : ldnf1b z23.s, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x18(%x24)[8byte] %p6/z -> %z23.s
+a454bf59 : ldnf1b z25.s, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x20(%x26)[8byte] %p7/z -> %z25.s
+a455bf9b : ldnf1b z27.s, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0x28(%x28)[8byte] %p7/z -> %z27.s
+a457bfff : ldnf1b z31.s, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0x38(%sp)[8byte] %p7/z -> %z31.s
 
 # LDNF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1B-Z.P.BI-U64)
-a478a000 : ldnf1b z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x08(%x0)[4byte] %p0/z -> %z0.d
-a479a482 : ldnf1b z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0x07(%x4)[4byte] %p1/z -> %z2.d
-a47aa8c4 : ldnf1b z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0x06(%x6)[4byte] %p2/z -> %z4.d
-a47ba906 : ldnf1b z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0x05(%x8)[4byte] %p2/z -> %z6.d
-a47cad48 : ldnf1b z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x04(%x10)[4byte] %p3/z -> %z8.d
-a47dad6a : ldnf1b z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x03(%x11)[4byte] %p3/z -> %z10.d
-a47eb1ac : ldnf1b z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x02(%x13)[4byte] %p4/z -> %z12.d
-a47fb1ee : ldnf1b z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x01(%x15)[4byte] %p4/z -> %z14.d
+a478a000 : ldnf1b z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1b -0x20(%x0)[4byte] %p0/z -> %z0.d
+a479a482 : ldnf1b z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1b -0x1c(%x4)[4byte] %p1/z -> %z2.d
+a47aa8c4 : ldnf1b z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1b -0x18(%x6)[4byte] %p2/z -> %z4.d
+a47ba906 : ldnf1b z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1b -0x14(%x8)[4byte] %p2/z -> %z6.d
+a47cad48 : ldnf1b z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1b -0x10(%x10)[4byte] %p3/z -> %z8.d
+a47dad6a : ldnf1b z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1b -0x0c(%x11)[4byte] %p3/z -> %z10.d
+a47eb1ac : ldnf1b z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1b -0x08(%x13)[4byte] %p4/z -> %z12.d
+a47fb1ee : ldnf1b z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1b -0x04(%x15)[4byte] %p4/z -> %z14.d
 a470b630 : ldnf1b z16.d, p5/Z, [x17, #0, MUL VL]     : ldnf1b (%x17)[4byte] %p5/z -> %z16.d
 a470b671 : ldnf1b z17.d, p5/Z, [x19, #0, MUL VL]     : ldnf1b (%x19)[4byte] %p5/z -> %z17.d
-a471b6b3 : ldnf1b z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x01(%x21)[4byte] %p5/z -> %z19.d
-a472baf5 : ldnf1b z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x02(%x23)[4byte] %p6/z -> %z21.d
-a473bb17 : ldnf1b z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x03(%x24)[4byte] %p6/z -> %z23.d
-a474bf59 : ldnf1b z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x04(%x26)[4byte] %p7/z -> %z25.d
-a475bf9b : ldnf1b z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0x05(%x28)[4byte] %p7/z -> %z27.d
-a477bfff : ldnf1b z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0x07(%sp)[4byte] %p7/z -> %z31.d
+a471b6b3 : ldnf1b z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1b +0x04(%x21)[4byte] %p5/z -> %z19.d
+a472baf5 : ldnf1b z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1b +0x08(%x23)[4byte] %p6/z -> %z21.d
+a473bb17 : ldnf1b z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1b +0x0c(%x24)[4byte] %p6/z -> %z23.d
+a474bf59 : ldnf1b z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1b +0x10(%x26)[4byte] %p7/z -> %z25.d
+a475bf9b : ldnf1b z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1b +0x14(%x28)[4byte] %p7/z -> %z27.d
+a477bfff : ldnf1b z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1b +0x1c(%sp)[4byte] %p7/z -> %z31.d
 
 # LDNF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1D-Z.P.BI-U64)
-a5f8a000 : ldnf1d z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1d -0x08(%x0)[32byte] %p0/z -> %z0.d
-a5f9a482 : ldnf1d z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1d -0x07(%x4)[32byte] %p1/z -> %z2.d
-a5faa8c4 : ldnf1d z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1d -0x06(%x6)[32byte] %p2/z -> %z4.d
-a5fba906 : ldnf1d z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1d -0x05(%x8)[32byte] %p2/z -> %z6.d
-a5fcad48 : ldnf1d z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1d -0x04(%x10)[32byte] %p3/z -> %z8.d
-a5fdad6a : ldnf1d z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1d -0x03(%x11)[32byte] %p3/z -> %z10.d
-a5feb1ac : ldnf1d z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1d -0x02(%x13)[32byte] %p4/z -> %z12.d
-a5ffb1ee : ldnf1d z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1d -0x01(%x15)[32byte] %p4/z -> %z14.d
+a5f8a000 : ldnf1d z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1d -0x0100(%x0)[32byte] %p0/z -> %z0.d
+a5f9a482 : ldnf1d z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1d -0xe0(%x4)[32byte] %p1/z -> %z2.d
+a5faa8c4 : ldnf1d z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1d -0xc0(%x6)[32byte] %p2/z -> %z4.d
+a5fba906 : ldnf1d z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1d -0xa0(%x8)[32byte] %p2/z -> %z6.d
+a5fcad48 : ldnf1d z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1d -0x80(%x10)[32byte] %p3/z -> %z8.d
+a5fdad6a : ldnf1d z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1d -0x60(%x11)[32byte] %p3/z -> %z10.d
+a5feb1ac : ldnf1d z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1d -0x40(%x13)[32byte] %p4/z -> %z12.d
+a5ffb1ee : ldnf1d z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1d -0x20(%x15)[32byte] %p4/z -> %z14.d
 a5f0b630 : ldnf1d z16.d, p5/Z, [x17, #0, MUL VL]     : ldnf1d (%x17)[32byte] %p5/z -> %z16.d
 a5f0b671 : ldnf1d z17.d, p5/Z, [x19, #0, MUL VL]     : ldnf1d (%x19)[32byte] %p5/z -> %z17.d
-a5f1b6b3 : ldnf1d z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1d +0x01(%x21)[32byte] %p5/z -> %z19.d
-a5f2baf5 : ldnf1d z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1d +0x02(%x23)[32byte] %p6/z -> %z21.d
-a5f3bb17 : ldnf1d z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1d +0x03(%x24)[32byte] %p6/z -> %z23.d
-a5f4bf59 : ldnf1d z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1d +0x04(%x26)[32byte] %p7/z -> %z25.d
-a5f5bf9b : ldnf1d z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1d +0x05(%x28)[32byte] %p7/z -> %z27.d
-a5f7bfff : ldnf1d z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1d +0x07(%sp)[32byte] %p7/z -> %z31.d
+a5f1b6b3 : ldnf1d z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1d +0x20(%x21)[32byte] %p5/z -> %z19.d
+a5f2baf5 : ldnf1d z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1d +0x40(%x23)[32byte] %p6/z -> %z21.d
+a5f3bb17 : ldnf1d z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1d +0x60(%x24)[32byte] %p6/z -> %z23.d
+a5f4bf59 : ldnf1d z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1d +0x80(%x26)[32byte] %p7/z -> %z25.d
+a5f5bf9b : ldnf1d z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1d +0xa0(%x28)[32byte] %p7/z -> %z27.d
+a5f7bfff : ldnf1d z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1d +0xe0(%sp)[32byte] %p7/z -> %z31.d
 
 # LDNF1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1H-Z.P.BI-U16)
-a4b8a000 : ldnf1h z0.h, p0/Z, [x0, #-8, MUL VL]      : ldnf1h -0x08(%x0)[32byte] %p0/z -> %z0.h
-a4b9a482 : ldnf1h z2.h, p1/Z, [x4, #-7, MUL VL]      : ldnf1h -0x07(%x4)[32byte] %p1/z -> %z2.h
-a4baa8c4 : ldnf1h z4.h, p2/Z, [x6, #-6, MUL VL]      : ldnf1h -0x06(%x6)[32byte] %p2/z -> %z4.h
-a4bba906 : ldnf1h z6.h, p2/Z, [x8, #-5, MUL VL]      : ldnf1h -0x05(%x8)[32byte] %p2/z -> %z6.h
-a4bcad48 : ldnf1h z8.h, p3/Z, [x10, #-4, MUL VL]     : ldnf1h -0x04(%x10)[32byte] %p3/z -> %z8.h
-a4bdad6a : ldnf1h z10.h, p3/Z, [x11, #-3, MUL VL]    : ldnf1h -0x03(%x11)[32byte] %p3/z -> %z10.h
-a4beb1ac : ldnf1h z12.h, p4/Z, [x13, #-2, MUL VL]    : ldnf1h -0x02(%x13)[32byte] %p4/z -> %z12.h
-a4bfb1ee : ldnf1h z14.h, p4/Z, [x15, #-1, MUL VL]    : ldnf1h -0x01(%x15)[32byte] %p4/z -> %z14.h
+a4b8a000 : ldnf1h z0.h, p0/Z, [x0, #-8, MUL VL]      : ldnf1h -0x0100(%x0)[32byte] %p0/z -> %z0.h
+a4b9a482 : ldnf1h z2.h, p1/Z, [x4, #-7, MUL VL]      : ldnf1h -0xe0(%x4)[32byte] %p1/z -> %z2.h
+a4baa8c4 : ldnf1h z4.h, p2/Z, [x6, #-6, MUL VL]      : ldnf1h -0xc0(%x6)[32byte] %p2/z -> %z4.h
+a4bba906 : ldnf1h z6.h, p2/Z, [x8, #-5, MUL VL]      : ldnf1h -0xa0(%x8)[32byte] %p2/z -> %z6.h
+a4bcad48 : ldnf1h z8.h, p3/Z, [x10, #-4, MUL VL]     : ldnf1h -0x80(%x10)[32byte] %p3/z -> %z8.h
+a4bdad6a : ldnf1h z10.h, p3/Z, [x11, #-3, MUL VL]    : ldnf1h -0x60(%x11)[32byte] %p3/z -> %z10.h
+a4beb1ac : ldnf1h z12.h, p4/Z, [x13, #-2, MUL VL]    : ldnf1h -0x40(%x13)[32byte] %p4/z -> %z12.h
+a4bfb1ee : ldnf1h z14.h, p4/Z, [x15, #-1, MUL VL]    : ldnf1h -0x20(%x15)[32byte] %p4/z -> %z14.h
 a4b0b630 : ldnf1h z16.h, p5/Z, [x17, #0, MUL VL]     : ldnf1h (%x17)[32byte] %p5/z -> %z16.h
 a4b0b671 : ldnf1h z17.h, p5/Z, [x19, #0, MUL VL]     : ldnf1h (%x19)[32byte] %p5/z -> %z17.h
-a4b1b6b3 : ldnf1h z19.h, p5/Z, [x21, #1, MUL VL]     : ldnf1h +0x01(%x21)[32byte] %p5/z -> %z19.h
-a4b2baf5 : ldnf1h z21.h, p6/Z, [x23, #2, MUL VL]     : ldnf1h +0x02(%x23)[32byte] %p6/z -> %z21.h
-a4b3bb17 : ldnf1h z23.h, p6/Z, [x24, #3, MUL VL]     : ldnf1h +0x03(%x24)[32byte] %p6/z -> %z23.h
-a4b4bf59 : ldnf1h z25.h, p7/Z, [x26, #4, MUL VL]     : ldnf1h +0x04(%x26)[32byte] %p7/z -> %z25.h
-a4b5bf9b : ldnf1h z27.h, p7/Z, [x28, #5, MUL VL]     : ldnf1h +0x05(%x28)[32byte] %p7/z -> %z27.h
-a4b7bfff : ldnf1h z31.h, p7/Z, [sp, #7, MUL VL]      : ldnf1h +0x07(%sp)[32byte] %p7/z -> %z31.h
+a4b1b6b3 : ldnf1h z19.h, p5/Z, [x21, #1, MUL VL]     : ldnf1h +0x20(%x21)[32byte] %p5/z -> %z19.h
+a4b2baf5 : ldnf1h z21.h, p6/Z, [x23, #2, MUL VL]     : ldnf1h +0x40(%x23)[32byte] %p6/z -> %z21.h
+a4b3bb17 : ldnf1h z23.h, p6/Z, [x24, #3, MUL VL]     : ldnf1h +0x60(%x24)[32byte] %p6/z -> %z23.h
+a4b4bf59 : ldnf1h z25.h, p7/Z, [x26, #4, MUL VL]     : ldnf1h +0x80(%x26)[32byte] %p7/z -> %z25.h
+a4b5bf9b : ldnf1h z27.h, p7/Z, [x28, #5, MUL VL]     : ldnf1h +0xa0(%x28)[32byte] %p7/z -> %z27.h
+a4b7bfff : ldnf1h z31.h, p7/Z, [sp, #7, MUL VL]      : ldnf1h +0xe0(%sp)[32byte] %p7/z -> %z31.h
 
 # LDNF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1H-Z.P.BI-U32)
-a4d8a000 : ldnf1h z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnf1h -0x08(%x0)[16byte] %p0/z -> %z0.s
-a4d9a482 : ldnf1h z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnf1h -0x07(%x4)[16byte] %p1/z -> %z2.s
-a4daa8c4 : ldnf1h z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnf1h -0x06(%x6)[16byte] %p2/z -> %z4.s
-a4dba906 : ldnf1h z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnf1h -0x05(%x8)[16byte] %p2/z -> %z6.s
-a4dcad48 : ldnf1h z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnf1h -0x04(%x10)[16byte] %p3/z -> %z8.s
-a4ddad6a : ldnf1h z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnf1h -0x03(%x11)[16byte] %p3/z -> %z10.s
-a4deb1ac : ldnf1h z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnf1h -0x02(%x13)[16byte] %p4/z -> %z12.s
-a4dfb1ee : ldnf1h z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnf1h -0x01(%x15)[16byte] %p4/z -> %z14.s
+a4d8a000 : ldnf1h z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnf1h -0x80(%x0)[16byte] %p0/z -> %z0.s
+a4d9a482 : ldnf1h z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnf1h -0x70(%x4)[16byte] %p1/z -> %z2.s
+a4daa8c4 : ldnf1h z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnf1h -0x60(%x6)[16byte] %p2/z -> %z4.s
+a4dba906 : ldnf1h z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnf1h -0x50(%x8)[16byte] %p2/z -> %z6.s
+a4dcad48 : ldnf1h z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnf1h -0x40(%x10)[16byte] %p3/z -> %z8.s
+a4ddad6a : ldnf1h z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnf1h -0x30(%x11)[16byte] %p3/z -> %z10.s
+a4deb1ac : ldnf1h z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnf1h -0x20(%x13)[16byte] %p4/z -> %z12.s
+a4dfb1ee : ldnf1h z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnf1h -0x10(%x15)[16byte] %p4/z -> %z14.s
 a4d0b630 : ldnf1h z16.s, p5/Z, [x17, #0, MUL VL]     : ldnf1h (%x17)[16byte] %p5/z -> %z16.s
 a4d0b671 : ldnf1h z17.s, p5/Z, [x19, #0, MUL VL]     : ldnf1h (%x19)[16byte] %p5/z -> %z17.s
-a4d1b6b3 : ldnf1h z19.s, p5/Z, [x21, #1, MUL VL]     : ldnf1h +0x01(%x21)[16byte] %p5/z -> %z19.s
-a4d2baf5 : ldnf1h z21.s, p6/Z, [x23, #2, MUL VL]     : ldnf1h +0x02(%x23)[16byte] %p6/z -> %z21.s
-a4d3bb17 : ldnf1h z23.s, p6/Z, [x24, #3, MUL VL]     : ldnf1h +0x03(%x24)[16byte] %p6/z -> %z23.s
-a4d4bf59 : ldnf1h z25.s, p7/Z, [x26, #4, MUL VL]     : ldnf1h +0x04(%x26)[16byte] %p7/z -> %z25.s
-a4d5bf9b : ldnf1h z27.s, p7/Z, [x28, #5, MUL VL]     : ldnf1h +0x05(%x28)[16byte] %p7/z -> %z27.s
-a4d7bfff : ldnf1h z31.s, p7/Z, [sp, #7, MUL VL]      : ldnf1h +0x07(%sp)[16byte] %p7/z -> %z31.s
+a4d1b6b3 : ldnf1h z19.s, p5/Z, [x21, #1, MUL VL]     : ldnf1h +0x10(%x21)[16byte] %p5/z -> %z19.s
+a4d2baf5 : ldnf1h z21.s, p6/Z, [x23, #2, MUL VL]     : ldnf1h +0x20(%x23)[16byte] %p6/z -> %z21.s
+a4d3bb17 : ldnf1h z23.s, p6/Z, [x24, #3, MUL VL]     : ldnf1h +0x30(%x24)[16byte] %p6/z -> %z23.s
+a4d4bf59 : ldnf1h z25.s, p7/Z, [x26, #4, MUL VL]     : ldnf1h +0x40(%x26)[16byte] %p7/z -> %z25.s
+a4d5bf9b : ldnf1h z27.s, p7/Z, [x28, #5, MUL VL]     : ldnf1h +0x50(%x28)[16byte] %p7/z -> %z27.s
+a4d7bfff : ldnf1h z31.s, p7/Z, [sp, #7, MUL VL]      : ldnf1h +0x70(%sp)[16byte] %p7/z -> %z31.s
 
 # LDNF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1H-Z.P.BI-U64)
-a4f8a000 : ldnf1h z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1h -0x08(%x0)[8byte] %p0/z -> %z0.d
-a4f9a482 : ldnf1h z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1h -0x07(%x4)[8byte] %p1/z -> %z2.d
-a4faa8c4 : ldnf1h z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1h -0x06(%x6)[8byte] %p2/z -> %z4.d
-a4fba906 : ldnf1h z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1h -0x05(%x8)[8byte] %p2/z -> %z6.d
-a4fcad48 : ldnf1h z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1h -0x04(%x10)[8byte] %p3/z -> %z8.d
-a4fdad6a : ldnf1h z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1h -0x03(%x11)[8byte] %p3/z -> %z10.d
-a4feb1ac : ldnf1h z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1h -0x02(%x13)[8byte] %p4/z -> %z12.d
-a4ffb1ee : ldnf1h z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1h -0x01(%x15)[8byte] %p4/z -> %z14.d
+a4f8a000 : ldnf1h z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1h -0x40(%x0)[8byte] %p0/z -> %z0.d
+a4f9a482 : ldnf1h z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1h -0x38(%x4)[8byte] %p1/z -> %z2.d
+a4faa8c4 : ldnf1h z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1h -0x30(%x6)[8byte] %p2/z -> %z4.d
+a4fba906 : ldnf1h z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1h -0x28(%x8)[8byte] %p2/z -> %z6.d
+a4fcad48 : ldnf1h z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1h -0x20(%x10)[8byte] %p3/z -> %z8.d
+a4fdad6a : ldnf1h z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1h -0x18(%x11)[8byte] %p3/z -> %z10.d
+a4feb1ac : ldnf1h z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1h -0x10(%x13)[8byte] %p4/z -> %z12.d
+a4ffb1ee : ldnf1h z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1h -0x08(%x15)[8byte] %p4/z -> %z14.d
 a4f0b630 : ldnf1h z16.d, p5/Z, [x17, #0, MUL VL]     : ldnf1h (%x17)[8byte] %p5/z -> %z16.d
 a4f0b671 : ldnf1h z17.d, p5/Z, [x19, #0, MUL VL]     : ldnf1h (%x19)[8byte] %p5/z -> %z17.d
-a4f1b6b3 : ldnf1h z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1h +0x01(%x21)[8byte] %p5/z -> %z19.d
-a4f2baf5 : ldnf1h z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1h +0x02(%x23)[8byte] %p6/z -> %z21.d
-a4f3bb17 : ldnf1h z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1h +0x03(%x24)[8byte] %p6/z -> %z23.d
-a4f4bf59 : ldnf1h z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1h +0x04(%x26)[8byte] %p7/z -> %z25.d
-a4f5bf9b : ldnf1h z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1h +0x05(%x28)[8byte] %p7/z -> %z27.d
-a4f7bfff : ldnf1h z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1h +0x07(%sp)[8byte] %p7/z -> %z31.d
+a4f1b6b3 : ldnf1h z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1h +0x08(%x21)[8byte] %p5/z -> %z19.d
+a4f2baf5 : ldnf1h z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1h +0x10(%x23)[8byte] %p6/z -> %z21.d
+a4f3bb17 : ldnf1h z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1h +0x18(%x24)[8byte] %p6/z -> %z23.d
+a4f4bf59 : ldnf1h z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1h +0x20(%x26)[8byte] %p7/z -> %z25.d
+a4f5bf9b : ldnf1h z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1h +0x28(%x28)[8byte] %p7/z -> %z27.d
+a4f7bfff : ldnf1h z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1h +0x38(%sp)[8byte] %p7/z -> %z31.d
 
 # LDNF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1SB-Z.P.BI-S64)
-a598a000 : ldnf1sb z0.d, p0/Z, [x0, #-8, MUL VL]     : ldnf1sb -0x08(%x0)[4byte] %p0/z -> %z0.d
-a599a482 : ldnf1sb z2.d, p1/Z, [x4, #-7, MUL VL]     : ldnf1sb -0x07(%x4)[4byte] %p1/z -> %z2.d
-a59aa8c4 : ldnf1sb z4.d, p2/Z, [x6, #-6, MUL VL]     : ldnf1sb -0x06(%x6)[4byte] %p2/z -> %z4.d
-a59ba906 : ldnf1sb z6.d, p2/Z, [x8, #-5, MUL VL]     : ldnf1sb -0x05(%x8)[4byte] %p2/z -> %z6.d
-a59cad48 : ldnf1sb z8.d, p3/Z, [x10, #-4, MUL VL]    : ldnf1sb -0x04(%x10)[4byte] %p3/z -> %z8.d
-a59dad6a : ldnf1sb z10.d, p3/Z, [x11, #-3, MUL VL]   : ldnf1sb -0x03(%x11)[4byte] %p3/z -> %z10.d
-a59eb1ac : ldnf1sb z12.d, p4/Z, [x13, #-2, MUL VL]   : ldnf1sb -0x02(%x13)[4byte] %p4/z -> %z12.d
-a59fb1ee : ldnf1sb z14.d, p4/Z, [x15, #-1, MUL VL]   : ldnf1sb -0x01(%x15)[4byte] %p4/z -> %z14.d
+a598a000 : ldnf1sb z0.d, p0/Z, [x0, #-8, MUL VL]     : ldnf1sb -0x20(%x0)[4byte] %p0/z -> %z0.d
+a599a482 : ldnf1sb z2.d, p1/Z, [x4, #-7, MUL VL]     : ldnf1sb -0x1c(%x4)[4byte] %p1/z -> %z2.d
+a59aa8c4 : ldnf1sb z4.d, p2/Z, [x6, #-6, MUL VL]     : ldnf1sb -0x18(%x6)[4byte] %p2/z -> %z4.d
+a59ba906 : ldnf1sb z6.d, p2/Z, [x8, #-5, MUL VL]     : ldnf1sb -0x14(%x8)[4byte] %p2/z -> %z6.d
+a59cad48 : ldnf1sb z8.d, p3/Z, [x10, #-4, MUL VL]    : ldnf1sb -0x10(%x10)[4byte] %p3/z -> %z8.d
+a59dad6a : ldnf1sb z10.d, p3/Z, [x11, #-3, MUL VL]   : ldnf1sb -0x0c(%x11)[4byte] %p3/z -> %z10.d
+a59eb1ac : ldnf1sb z12.d, p4/Z, [x13, #-2, MUL VL]   : ldnf1sb -0x08(%x13)[4byte] %p4/z -> %z12.d
+a59fb1ee : ldnf1sb z14.d, p4/Z, [x15, #-1, MUL VL]   : ldnf1sb -0x04(%x15)[4byte] %p4/z -> %z14.d
 a590b630 : ldnf1sb z16.d, p5/Z, [x17, #0, MUL VL]    : ldnf1sb (%x17)[4byte] %p5/z -> %z16.d
 a590b671 : ldnf1sb z17.d, p5/Z, [x19, #0, MUL VL]    : ldnf1sb (%x19)[4byte] %p5/z -> %z17.d
-a591b6b3 : ldnf1sb z19.d, p5/Z, [x21, #1, MUL VL]    : ldnf1sb +0x01(%x21)[4byte] %p5/z -> %z19.d
-a592baf5 : ldnf1sb z21.d, p6/Z, [x23, #2, MUL VL]    : ldnf1sb +0x02(%x23)[4byte] %p6/z -> %z21.d
-a593bb17 : ldnf1sb z23.d, p6/Z, [x24, #3, MUL VL]    : ldnf1sb +0x03(%x24)[4byte] %p6/z -> %z23.d
-a594bf59 : ldnf1sb z25.d, p7/Z, [x26, #4, MUL VL]    : ldnf1sb +0x04(%x26)[4byte] %p7/z -> %z25.d
-a595bf9b : ldnf1sb z27.d, p7/Z, [x28, #5, MUL VL]    : ldnf1sb +0x05(%x28)[4byte] %p7/z -> %z27.d
-a597bfff : ldnf1sb z31.d, p7/Z, [sp, #7, MUL VL]     : ldnf1sb +0x07(%sp)[4byte] %p7/z -> %z31.d
+a591b6b3 : ldnf1sb z19.d, p5/Z, [x21, #1, MUL VL]    : ldnf1sb +0x04(%x21)[4byte] %p5/z -> %z19.d
+a592baf5 : ldnf1sb z21.d, p6/Z, [x23, #2, MUL VL]    : ldnf1sb +0x08(%x23)[4byte] %p6/z -> %z21.d
+a593bb17 : ldnf1sb z23.d, p6/Z, [x24, #3, MUL VL]    : ldnf1sb +0x0c(%x24)[4byte] %p6/z -> %z23.d
+a594bf59 : ldnf1sb z25.d, p7/Z, [x26, #4, MUL VL]    : ldnf1sb +0x10(%x26)[4byte] %p7/z -> %z25.d
+a595bf9b : ldnf1sb z27.d, p7/Z, [x28, #5, MUL VL]    : ldnf1sb +0x14(%x28)[4byte] %p7/z -> %z27.d
+a597bfff : ldnf1sb z31.d, p7/Z, [sp, #7, MUL VL]     : ldnf1sb +0x1c(%sp)[4byte] %p7/z -> %z31.d
 
 # LDNF1SB { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1SB-Z.P.BI-S32)
-a5b8a000 : ldnf1sb z0.s, p0/Z, [x0, #-8, MUL VL]     : ldnf1sb -0x08(%x0)[8byte] %p0/z -> %z0.s
-a5b9a482 : ldnf1sb z2.s, p1/Z, [x4, #-7, MUL VL]     : ldnf1sb -0x07(%x4)[8byte] %p1/z -> %z2.s
-a5baa8c4 : ldnf1sb z4.s, p2/Z, [x6, #-6, MUL VL]     : ldnf1sb -0x06(%x6)[8byte] %p2/z -> %z4.s
-a5bba906 : ldnf1sb z6.s, p2/Z, [x8, #-5, MUL VL]     : ldnf1sb -0x05(%x8)[8byte] %p2/z -> %z6.s
-a5bcad48 : ldnf1sb z8.s, p3/Z, [x10, #-4, MUL VL]    : ldnf1sb -0x04(%x10)[8byte] %p3/z -> %z8.s
-a5bdad6a : ldnf1sb z10.s, p3/Z, [x11, #-3, MUL VL]   : ldnf1sb -0x03(%x11)[8byte] %p3/z -> %z10.s
-a5beb1ac : ldnf1sb z12.s, p4/Z, [x13, #-2, MUL VL]   : ldnf1sb -0x02(%x13)[8byte] %p4/z -> %z12.s
-a5bfb1ee : ldnf1sb z14.s, p4/Z, [x15, #-1, MUL VL]   : ldnf1sb -0x01(%x15)[8byte] %p4/z -> %z14.s
+a5b8a000 : ldnf1sb z0.s, p0/Z, [x0, #-8, MUL VL]     : ldnf1sb -0x40(%x0)[8byte] %p0/z -> %z0.s
+a5b9a482 : ldnf1sb z2.s, p1/Z, [x4, #-7, MUL VL]     : ldnf1sb -0x38(%x4)[8byte] %p1/z -> %z2.s
+a5baa8c4 : ldnf1sb z4.s, p2/Z, [x6, #-6, MUL VL]     : ldnf1sb -0x30(%x6)[8byte] %p2/z -> %z4.s
+a5bba906 : ldnf1sb z6.s, p2/Z, [x8, #-5, MUL VL]     : ldnf1sb -0x28(%x8)[8byte] %p2/z -> %z6.s
+a5bcad48 : ldnf1sb z8.s, p3/Z, [x10, #-4, MUL VL]    : ldnf1sb -0x20(%x10)[8byte] %p3/z -> %z8.s
+a5bdad6a : ldnf1sb z10.s, p3/Z, [x11, #-3, MUL VL]   : ldnf1sb -0x18(%x11)[8byte] %p3/z -> %z10.s
+a5beb1ac : ldnf1sb z12.s, p4/Z, [x13, #-2, MUL VL]   : ldnf1sb -0x10(%x13)[8byte] %p4/z -> %z12.s
+a5bfb1ee : ldnf1sb z14.s, p4/Z, [x15, #-1, MUL VL]   : ldnf1sb -0x08(%x15)[8byte] %p4/z -> %z14.s
 a5b0b630 : ldnf1sb z16.s, p5/Z, [x17, #0, MUL VL]    : ldnf1sb (%x17)[8byte] %p5/z -> %z16.s
 a5b0b671 : ldnf1sb z17.s, p5/Z, [x19, #0, MUL VL]    : ldnf1sb (%x19)[8byte] %p5/z -> %z17.s
-a5b1b6b3 : ldnf1sb z19.s, p5/Z, [x21, #1, MUL VL]    : ldnf1sb +0x01(%x21)[8byte] %p5/z -> %z19.s
-a5b2baf5 : ldnf1sb z21.s, p6/Z, [x23, #2, MUL VL]    : ldnf1sb +0x02(%x23)[8byte] %p6/z -> %z21.s
-a5b3bb17 : ldnf1sb z23.s, p6/Z, [x24, #3, MUL VL]    : ldnf1sb +0x03(%x24)[8byte] %p6/z -> %z23.s
-a5b4bf59 : ldnf1sb z25.s, p7/Z, [x26, #4, MUL VL]    : ldnf1sb +0x04(%x26)[8byte] %p7/z -> %z25.s
-a5b5bf9b : ldnf1sb z27.s, p7/Z, [x28, #5, MUL VL]    : ldnf1sb +0x05(%x28)[8byte] %p7/z -> %z27.s
-a5b7bfff : ldnf1sb z31.s, p7/Z, [sp, #7, MUL VL]     : ldnf1sb +0x07(%sp)[8byte] %p7/z -> %z31.s
+a5b1b6b3 : ldnf1sb z19.s, p5/Z, [x21, #1, MUL VL]    : ldnf1sb +0x08(%x21)[8byte] %p5/z -> %z19.s
+a5b2baf5 : ldnf1sb z21.s, p6/Z, [x23, #2, MUL VL]    : ldnf1sb +0x10(%x23)[8byte] %p6/z -> %z21.s
+a5b3bb17 : ldnf1sb z23.s, p6/Z, [x24, #3, MUL VL]    : ldnf1sb +0x18(%x24)[8byte] %p6/z -> %z23.s
+a5b4bf59 : ldnf1sb z25.s, p7/Z, [x26, #4, MUL VL]    : ldnf1sb +0x20(%x26)[8byte] %p7/z -> %z25.s
+a5b5bf9b : ldnf1sb z27.s, p7/Z, [x28, #5, MUL VL]    : ldnf1sb +0x28(%x28)[8byte] %p7/z -> %z27.s
+a5b7bfff : ldnf1sb z31.s, p7/Z, [sp, #7, MUL VL]     : ldnf1sb +0x38(%sp)[8byte] %p7/z -> %z31.s
 
 # LDNF1SB { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1SB-Z.P.BI-S16)
-a5d8a000 : ldnf1sb z0.h, p0/Z, [x0, #-8, MUL VL]     : ldnf1sb -0x08(%x0)[16byte] %p0/z -> %z0.h
-a5d9a482 : ldnf1sb z2.h, p1/Z, [x4, #-7, MUL VL]     : ldnf1sb -0x07(%x4)[16byte] %p1/z -> %z2.h
-a5daa8c4 : ldnf1sb z4.h, p2/Z, [x6, #-6, MUL VL]     : ldnf1sb -0x06(%x6)[16byte] %p2/z -> %z4.h
-a5dba906 : ldnf1sb z6.h, p2/Z, [x8, #-5, MUL VL]     : ldnf1sb -0x05(%x8)[16byte] %p2/z -> %z6.h
-a5dcad48 : ldnf1sb z8.h, p3/Z, [x10, #-4, MUL VL]    : ldnf1sb -0x04(%x10)[16byte] %p3/z -> %z8.h
-a5ddad6a : ldnf1sb z10.h, p3/Z, [x11, #-3, MUL VL]   : ldnf1sb -0x03(%x11)[16byte] %p3/z -> %z10.h
-a5deb1ac : ldnf1sb z12.h, p4/Z, [x13, #-2, MUL VL]   : ldnf1sb -0x02(%x13)[16byte] %p4/z -> %z12.h
-a5dfb1ee : ldnf1sb z14.h, p4/Z, [x15, #-1, MUL VL]   : ldnf1sb -0x01(%x15)[16byte] %p4/z -> %z14.h
+a5d8a000 : ldnf1sb z0.h, p0/Z, [x0, #-8, MUL VL]     : ldnf1sb -0x80(%x0)[16byte] %p0/z -> %z0.h
+a5d9a482 : ldnf1sb z2.h, p1/Z, [x4, #-7, MUL VL]     : ldnf1sb -0x70(%x4)[16byte] %p1/z -> %z2.h
+a5daa8c4 : ldnf1sb z4.h, p2/Z, [x6, #-6, MUL VL]     : ldnf1sb -0x60(%x6)[16byte] %p2/z -> %z4.h
+a5dba906 : ldnf1sb z6.h, p2/Z, [x8, #-5, MUL VL]     : ldnf1sb -0x50(%x8)[16byte] %p2/z -> %z6.h
+a5dcad48 : ldnf1sb z8.h, p3/Z, [x10, #-4, MUL VL]    : ldnf1sb -0x40(%x10)[16byte] %p3/z -> %z8.h
+a5ddad6a : ldnf1sb z10.h, p3/Z, [x11, #-3, MUL VL]   : ldnf1sb -0x30(%x11)[16byte] %p3/z -> %z10.h
+a5deb1ac : ldnf1sb z12.h, p4/Z, [x13, #-2, MUL VL]   : ldnf1sb -0x20(%x13)[16byte] %p4/z -> %z12.h
+a5dfb1ee : ldnf1sb z14.h, p4/Z, [x15, #-1, MUL VL]   : ldnf1sb -0x10(%x15)[16byte] %p4/z -> %z14.h
 a5d0b630 : ldnf1sb z16.h, p5/Z, [x17, #0, MUL VL]    : ldnf1sb (%x17)[16byte] %p5/z -> %z16.h
 a5d0b671 : ldnf1sb z17.h, p5/Z, [x19, #0, MUL VL]    : ldnf1sb (%x19)[16byte] %p5/z -> %z17.h
-a5d1b6b3 : ldnf1sb z19.h, p5/Z, [x21, #1, MUL VL]    : ldnf1sb +0x01(%x21)[16byte] %p5/z -> %z19.h
-a5d2baf5 : ldnf1sb z21.h, p6/Z, [x23, #2, MUL VL]    : ldnf1sb +0x02(%x23)[16byte] %p6/z -> %z21.h
-a5d3bb17 : ldnf1sb z23.h, p6/Z, [x24, #3, MUL VL]    : ldnf1sb +0x03(%x24)[16byte] %p6/z -> %z23.h
-a5d4bf59 : ldnf1sb z25.h, p7/Z, [x26, #4, MUL VL]    : ldnf1sb +0x04(%x26)[16byte] %p7/z -> %z25.h
-a5d5bf9b : ldnf1sb z27.h, p7/Z, [x28, #5, MUL VL]    : ldnf1sb +0x05(%x28)[16byte] %p7/z -> %z27.h
-a5d7bfff : ldnf1sb z31.h, p7/Z, [sp, #7, MUL VL]     : ldnf1sb +0x07(%sp)[16byte] %p7/z -> %z31.h
+a5d1b6b3 : ldnf1sb z19.h, p5/Z, [x21, #1, MUL VL]    : ldnf1sb +0x10(%x21)[16byte] %p5/z -> %z19.h
+a5d2baf5 : ldnf1sb z21.h, p6/Z, [x23, #2, MUL VL]    : ldnf1sb +0x20(%x23)[16byte] %p6/z -> %z21.h
+a5d3bb17 : ldnf1sb z23.h, p6/Z, [x24, #3, MUL VL]    : ldnf1sb +0x30(%x24)[16byte] %p6/z -> %z23.h
+a5d4bf59 : ldnf1sb z25.h, p7/Z, [x26, #4, MUL VL]    : ldnf1sb +0x40(%x26)[16byte] %p7/z -> %z25.h
+a5d5bf9b : ldnf1sb z27.h, p7/Z, [x28, #5, MUL VL]    : ldnf1sb +0x50(%x28)[16byte] %p7/z -> %z27.h
+a5d7bfff : ldnf1sb z31.h, p7/Z, [sp, #7, MUL VL]     : ldnf1sb +0x70(%sp)[16byte] %p7/z -> %z31.h
 
 # LDNF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1SH-Z.P.BI-S64)
-a518a000 : ldnf1sh z0.d, p0/Z, [x0, #-8, MUL VL]     : ldnf1sh -0x08(%x0)[8byte] %p0/z -> %z0.d
-a519a482 : ldnf1sh z2.d, p1/Z, [x4, #-7, MUL VL]     : ldnf1sh -0x07(%x4)[8byte] %p1/z -> %z2.d
-a51aa8c4 : ldnf1sh z4.d, p2/Z, [x6, #-6, MUL VL]     : ldnf1sh -0x06(%x6)[8byte] %p2/z -> %z4.d
-a51ba906 : ldnf1sh z6.d, p2/Z, [x8, #-5, MUL VL]     : ldnf1sh -0x05(%x8)[8byte] %p2/z -> %z6.d
-a51cad48 : ldnf1sh z8.d, p3/Z, [x10, #-4, MUL VL]    : ldnf1sh -0x04(%x10)[8byte] %p3/z -> %z8.d
-a51dad6a : ldnf1sh z10.d, p3/Z, [x11, #-3, MUL VL]   : ldnf1sh -0x03(%x11)[8byte] %p3/z -> %z10.d
-a51eb1ac : ldnf1sh z12.d, p4/Z, [x13, #-2, MUL VL]   : ldnf1sh -0x02(%x13)[8byte] %p4/z -> %z12.d
-a51fb1ee : ldnf1sh z14.d, p4/Z, [x15, #-1, MUL VL]   : ldnf1sh -0x01(%x15)[8byte] %p4/z -> %z14.d
+a518a000 : ldnf1sh z0.d, p0/Z, [x0, #-8, MUL VL]     : ldnf1sh -0x40(%x0)[8byte] %p0/z -> %z0.d
+a519a482 : ldnf1sh z2.d, p1/Z, [x4, #-7, MUL VL]     : ldnf1sh -0x38(%x4)[8byte] %p1/z -> %z2.d
+a51aa8c4 : ldnf1sh z4.d, p2/Z, [x6, #-6, MUL VL]     : ldnf1sh -0x30(%x6)[8byte] %p2/z -> %z4.d
+a51ba906 : ldnf1sh z6.d, p2/Z, [x8, #-5, MUL VL]     : ldnf1sh -0x28(%x8)[8byte] %p2/z -> %z6.d
+a51cad48 : ldnf1sh z8.d, p3/Z, [x10, #-4, MUL VL]    : ldnf1sh -0x20(%x10)[8byte] %p3/z -> %z8.d
+a51dad6a : ldnf1sh z10.d, p3/Z, [x11, #-3, MUL VL]   : ldnf1sh -0x18(%x11)[8byte] %p3/z -> %z10.d
+a51eb1ac : ldnf1sh z12.d, p4/Z, [x13, #-2, MUL VL]   : ldnf1sh -0x10(%x13)[8byte] %p4/z -> %z12.d
+a51fb1ee : ldnf1sh z14.d, p4/Z, [x15, #-1, MUL VL]   : ldnf1sh -0x08(%x15)[8byte] %p4/z -> %z14.d
 a510b630 : ldnf1sh z16.d, p5/Z, [x17, #0, MUL VL]    : ldnf1sh (%x17)[8byte] %p5/z -> %z16.d
 a510b671 : ldnf1sh z17.d, p5/Z, [x19, #0, MUL VL]    : ldnf1sh (%x19)[8byte] %p5/z -> %z17.d
-a511b6b3 : ldnf1sh z19.d, p5/Z, [x21, #1, MUL VL]    : ldnf1sh +0x01(%x21)[8byte] %p5/z -> %z19.d
-a512baf5 : ldnf1sh z21.d, p6/Z, [x23, #2, MUL VL]    : ldnf1sh +0x02(%x23)[8byte] %p6/z -> %z21.d
-a513bb17 : ldnf1sh z23.d, p6/Z, [x24, #3, MUL VL]    : ldnf1sh +0x03(%x24)[8byte] %p6/z -> %z23.d
-a514bf59 : ldnf1sh z25.d, p7/Z, [x26, #4, MUL VL]    : ldnf1sh +0x04(%x26)[8byte] %p7/z -> %z25.d
-a515bf9b : ldnf1sh z27.d, p7/Z, [x28, #5, MUL VL]    : ldnf1sh +0x05(%x28)[8byte] %p7/z -> %z27.d
-a517bfff : ldnf1sh z31.d, p7/Z, [sp, #7, MUL VL]     : ldnf1sh +0x07(%sp)[8byte] %p7/z -> %z31.d
+a511b6b3 : ldnf1sh z19.d, p5/Z, [x21, #1, MUL VL]    : ldnf1sh +0x08(%x21)[8byte] %p5/z -> %z19.d
+a512baf5 : ldnf1sh z21.d, p6/Z, [x23, #2, MUL VL]    : ldnf1sh +0x10(%x23)[8byte] %p6/z -> %z21.d
+a513bb17 : ldnf1sh z23.d, p6/Z, [x24, #3, MUL VL]    : ldnf1sh +0x18(%x24)[8byte] %p6/z -> %z23.d
+a514bf59 : ldnf1sh z25.d, p7/Z, [x26, #4, MUL VL]    : ldnf1sh +0x20(%x26)[8byte] %p7/z -> %z25.d
+a515bf9b : ldnf1sh z27.d, p7/Z, [x28, #5, MUL VL]    : ldnf1sh +0x28(%x28)[8byte] %p7/z -> %z27.d
+a517bfff : ldnf1sh z31.d, p7/Z, [sp, #7, MUL VL]     : ldnf1sh +0x38(%sp)[8byte] %p7/z -> %z31.d
 
 # LDNF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1SH-Z.P.BI-S32)
-a538a000 : ldnf1sh z0.s, p0/Z, [x0, #-8, MUL VL]     : ldnf1sh -0x08(%x0)[16byte] %p0/z -> %z0.s
-a539a482 : ldnf1sh z2.s, p1/Z, [x4, #-7, MUL VL]     : ldnf1sh -0x07(%x4)[16byte] %p1/z -> %z2.s
-a53aa8c4 : ldnf1sh z4.s, p2/Z, [x6, #-6, MUL VL]     : ldnf1sh -0x06(%x6)[16byte] %p2/z -> %z4.s
-a53ba906 : ldnf1sh z6.s, p2/Z, [x8, #-5, MUL VL]     : ldnf1sh -0x05(%x8)[16byte] %p2/z -> %z6.s
-a53cad48 : ldnf1sh z8.s, p3/Z, [x10, #-4, MUL VL]    : ldnf1sh -0x04(%x10)[16byte] %p3/z -> %z8.s
-a53dad6a : ldnf1sh z10.s, p3/Z, [x11, #-3, MUL VL]   : ldnf1sh -0x03(%x11)[16byte] %p3/z -> %z10.s
-a53eb1ac : ldnf1sh z12.s, p4/Z, [x13, #-2, MUL VL]   : ldnf1sh -0x02(%x13)[16byte] %p4/z -> %z12.s
-a53fb1ee : ldnf1sh z14.s, p4/Z, [x15, #-1, MUL VL]   : ldnf1sh -0x01(%x15)[16byte] %p4/z -> %z14.s
+a538a000 : ldnf1sh z0.s, p0/Z, [x0, #-8, MUL VL]     : ldnf1sh -0x80(%x0)[16byte] %p0/z -> %z0.s
+a539a482 : ldnf1sh z2.s, p1/Z, [x4, #-7, MUL VL]     : ldnf1sh -0x70(%x4)[16byte] %p1/z -> %z2.s
+a53aa8c4 : ldnf1sh z4.s, p2/Z, [x6, #-6, MUL VL]     : ldnf1sh -0x60(%x6)[16byte] %p2/z -> %z4.s
+a53ba906 : ldnf1sh z6.s, p2/Z, [x8, #-5, MUL VL]     : ldnf1sh -0x50(%x8)[16byte] %p2/z -> %z6.s
+a53cad48 : ldnf1sh z8.s, p3/Z, [x10, #-4, MUL VL]    : ldnf1sh -0x40(%x10)[16byte] %p3/z -> %z8.s
+a53dad6a : ldnf1sh z10.s, p3/Z, [x11, #-3, MUL VL]   : ldnf1sh -0x30(%x11)[16byte] %p3/z -> %z10.s
+a53eb1ac : ldnf1sh z12.s, p4/Z, [x13, #-2, MUL VL]   : ldnf1sh -0x20(%x13)[16byte] %p4/z -> %z12.s
+a53fb1ee : ldnf1sh z14.s, p4/Z, [x15, #-1, MUL VL]   : ldnf1sh -0x10(%x15)[16byte] %p4/z -> %z14.s
 a530b630 : ldnf1sh z16.s, p5/Z, [x17, #0, MUL VL]    : ldnf1sh (%x17)[16byte] %p5/z -> %z16.s
 a530b671 : ldnf1sh z17.s, p5/Z, [x19, #0, MUL VL]    : ldnf1sh (%x19)[16byte] %p5/z -> %z17.s
-a531b6b3 : ldnf1sh z19.s, p5/Z, [x21, #1, MUL VL]    : ldnf1sh +0x01(%x21)[16byte] %p5/z -> %z19.s
-a532baf5 : ldnf1sh z21.s, p6/Z, [x23, #2, MUL VL]    : ldnf1sh +0x02(%x23)[16byte] %p6/z -> %z21.s
-a533bb17 : ldnf1sh z23.s, p6/Z, [x24, #3, MUL VL]    : ldnf1sh +0x03(%x24)[16byte] %p6/z -> %z23.s
-a534bf59 : ldnf1sh z25.s, p7/Z, [x26, #4, MUL VL]    : ldnf1sh +0x04(%x26)[16byte] %p7/z -> %z25.s
-a535bf9b : ldnf1sh z27.s, p7/Z, [x28, #5, MUL VL]    : ldnf1sh +0x05(%x28)[16byte] %p7/z -> %z27.s
-a537bfff : ldnf1sh z31.s, p7/Z, [sp, #7, MUL VL]     : ldnf1sh +0x07(%sp)[16byte] %p7/z -> %z31.s
+a531b6b3 : ldnf1sh z19.s, p5/Z, [x21, #1, MUL VL]    : ldnf1sh +0x10(%x21)[16byte] %p5/z -> %z19.s
+a532baf5 : ldnf1sh z21.s, p6/Z, [x23, #2, MUL VL]    : ldnf1sh +0x20(%x23)[16byte] %p6/z -> %z21.s
+a533bb17 : ldnf1sh z23.s, p6/Z, [x24, #3, MUL VL]    : ldnf1sh +0x30(%x24)[16byte] %p6/z -> %z23.s
+a534bf59 : ldnf1sh z25.s, p7/Z, [x26, #4, MUL VL]    : ldnf1sh +0x40(%x26)[16byte] %p7/z -> %z25.s
+a535bf9b : ldnf1sh z27.s, p7/Z, [x28, #5, MUL VL]    : ldnf1sh +0x50(%x28)[16byte] %p7/z -> %z27.s
+a537bfff : ldnf1sh z31.s, p7/Z, [sp, #7, MUL VL]     : ldnf1sh +0x70(%sp)[16byte] %p7/z -> %z31.s
 
 # LDNF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1SW-Z.P.BI-S64)
-a498a000 : ldnf1sw z0.d, p0/Z, [x0, #-8, MUL VL]     : ldnf1sw -0x08(%x0)[16byte] %p0/z -> %z0.d
-a499a482 : ldnf1sw z2.d, p1/Z, [x4, #-7, MUL VL]     : ldnf1sw -0x07(%x4)[16byte] %p1/z -> %z2.d
-a49aa8c4 : ldnf1sw z4.d, p2/Z, [x6, #-6, MUL VL]     : ldnf1sw -0x06(%x6)[16byte] %p2/z -> %z4.d
-a49ba906 : ldnf1sw z6.d, p2/Z, [x8, #-5, MUL VL]     : ldnf1sw -0x05(%x8)[16byte] %p2/z -> %z6.d
-a49cad48 : ldnf1sw z8.d, p3/Z, [x10, #-4, MUL VL]    : ldnf1sw -0x04(%x10)[16byte] %p3/z -> %z8.d
-a49dad6a : ldnf1sw z10.d, p3/Z, [x11, #-3, MUL VL]   : ldnf1sw -0x03(%x11)[16byte] %p3/z -> %z10.d
-a49eb1ac : ldnf1sw z12.d, p4/Z, [x13, #-2, MUL VL]   : ldnf1sw -0x02(%x13)[16byte] %p4/z -> %z12.d
-a49fb1ee : ldnf1sw z14.d, p4/Z, [x15, #-1, MUL VL]   : ldnf1sw -0x01(%x15)[16byte] %p4/z -> %z14.d
+a498a000 : ldnf1sw z0.d, p0/Z, [x0, #-8, MUL VL]     : ldnf1sw -0x80(%x0)[16byte] %p0/z -> %z0.d
+a499a482 : ldnf1sw z2.d, p1/Z, [x4, #-7, MUL VL]     : ldnf1sw -0x70(%x4)[16byte] %p1/z -> %z2.d
+a49aa8c4 : ldnf1sw z4.d, p2/Z, [x6, #-6, MUL VL]     : ldnf1sw -0x60(%x6)[16byte] %p2/z -> %z4.d
+a49ba906 : ldnf1sw z6.d, p2/Z, [x8, #-5, MUL VL]     : ldnf1sw -0x50(%x8)[16byte] %p2/z -> %z6.d
+a49cad48 : ldnf1sw z8.d, p3/Z, [x10, #-4, MUL VL]    : ldnf1sw -0x40(%x10)[16byte] %p3/z -> %z8.d
+a49dad6a : ldnf1sw z10.d, p3/Z, [x11, #-3, MUL VL]   : ldnf1sw -0x30(%x11)[16byte] %p3/z -> %z10.d
+a49eb1ac : ldnf1sw z12.d, p4/Z, [x13, #-2, MUL VL]   : ldnf1sw -0x20(%x13)[16byte] %p4/z -> %z12.d
+a49fb1ee : ldnf1sw z14.d, p4/Z, [x15, #-1, MUL VL]   : ldnf1sw -0x10(%x15)[16byte] %p4/z -> %z14.d
 a490b630 : ldnf1sw z16.d, p5/Z, [x17, #0, MUL VL]    : ldnf1sw (%x17)[16byte] %p5/z -> %z16.d
 a490b671 : ldnf1sw z17.d, p5/Z, [x19, #0, MUL VL]    : ldnf1sw (%x19)[16byte] %p5/z -> %z17.d
-a491b6b3 : ldnf1sw z19.d, p5/Z, [x21, #1, MUL VL]    : ldnf1sw +0x01(%x21)[16byte] %p5/z -> %z19.d
-a492baf5 : ldnf1sw z21.d, p6/Z, [x23, #2, MUL VL]    : ldnf1sw +0x02(%x23)[16byte] %p6/z -> %z21.d
-a493bb17 : ldnf1sw z23.d, p6/Z, [x24, #3, MUL VL]    : ldnf1sw +0x03(%x24)[16byte] %p6/z -> %z23.d
-a494bf59 : ldnf1sw z25.d, p7/Z, [x26, #4, MUL VL]    : ldnf1sw +0x04(%x26)[16byte] %p7/z -> %z25.d
-a495bf9b : ldnf1sw z27.d, p7/Z, [x28, #5, MUL VL]    : ldnf1sw +0x05(%x28)[16byte] %p7/z -> %z27.d
-a497bfff : ldnf1sw z31.d, p7/Z, [sp, #7, MUL VL]     : ldnf1sw +0x07(%sp)[16byte] %p7/z -> %z31.d
+a491b6b3 : ldnf1sw z19.d, p5/Z, [x21, #1, MUL VL]    : ldnf1sw +0x10(%x21)[16byte] %p5/z -> %z19.d
+a492baf5 : ldnf1sw z21.d, p6/Z, [x23, #2, MUL VL]    : ldnf1sw +0x20(%x23)[16byte] %p6/z -> %z21.d
+a493bb17 : ldnf1sw z23.d, p6/Z, [x24, #3, MUL VL]    : ldnf1sw +0x30(%x24)[16byte] %p6/z -> %z23.d
+a494bf59 : ldnf1sw z25.d, p7/Z, [x26, #4, MUL VL]    : ldnf1sw +0x40(%x26)[16byte] %p7/z -> %z25.d
+a495bf9b : ldnf1sw z27.d, p7/Z, [x28, #5, MUL VL]    : ldnf1sw +0x50(%x28)[16byte] %p7/z -> %z27.d
+a497bfff : ldnf1sw z31.d, p7/Z, [sp, #7, MUL VL]     : ldnf1sw +0x70(%sp)[16byte] %p7/z -> %z31.d
 
 # LDNF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1W-Z.P.BI-U32)
-a558a000 : ldnf1w z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnf1w -0x08(%x0)[32byte] %p0/z -> %z0.s
-a559a482 : ldnf1w z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnf1w -0x07(%x4)[32byte] %p1/z -> %z2.s
-a55aa8c4 : ldnf1w z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnf1w -0x06(%x6)[32byte] %p2/z -> %z4.s
-a55ba906 : ldnf1w z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnf1w -0x05(%x8)[32byte] %p2/z -> %z6.s
-a55cad48 : ldnf1w z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnf1w -0x04(%x10)[32byte] %p3/z -> %z8.s
-a55dad6a : ldnf1w z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnf1w -0x03(%x11)[32byte] %p3/z -> %z10.s
-a55eb1ac : ldnf1w z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnf1w -0x02(%x13)[32byte] %p4/z -> %z12.s
-a55fb1ee : ldnf1w z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnf1w -0x01(%x15)[32byte] %p4/z -> %z14.s
+a558a000 : ldnf1w z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnf1w -0x0100(%x0)[32byte] %p0/z -> %z0.s
+a559a482 : ldnf1w z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnf1w -0xe0(%x4)[32byte] %p1/z -> %z2.s
+a55aa8c4 : ldnf1w z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnf1w -0xc0(%x6)[32byte] %p2/z -> %z4.s
+a55ba906 : ldnf1w z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnf1w -0xa0(%x8)[32byte] %p2/z -> %z6.s
+a55cad48 : ldnf1w z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnf1w -0x80(%x10)[32byte] %p3/z -> %z8.s
+a55dad6a : ldnf1w z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnf1w -0x60(%x11)[32byte] %p3/z -> %z10.s
+a55eb1ac : ldnf1w z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnf1w -0x40(%x13)[32byte] %p4/z -> %z12.s
+a55fb1ee : ldnf1w z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnf1w -0x20(%x15)[32byte] %p4/z -> %z14.s
 a550b630 : ldnf1w z16.s, p5/Z, [x17, #0, MUL VL]     : ldnf1w (%x17)[32byte] %p5/z -> %z16.s
 a550b671 : ldnf1w z17.s, p5/Z, [x19, #0, MUL VL]     : ldnf1w (%x19)[32byte] %p5/z -> %z17.s
-a551b6b3 : ldnf1w z19.s, p5/Z, [x21, #1, MUL VL]     : ldnf1w +0x01(%x21)[32byte] %p5/z -> %z19.s
-a552baf5 : ldnf1w z21.s, p6/Z, [x23, #2, MUL VL]     : ldnf1w +0x02(%x23)[32byte] %p6/z -> %z21.s
-a553bb17 : ldnf1w z23.s, p6/Z, [x24, #3, MUL VL]     : ldnf1w +0x03(%x24)[32byte] %p6/z -> %z23.s
-a554bf59 : ldnf1w z25.s, p7/Z, [x26, #4, MUL VL]     : ldnf1w +0x04(%x26)[32byte] %p7/z -> %z25.s
-a555bf9b : ldnf1w z27.s, p7/Z, [x28, #5, MUL VL]     : ldnf1w +0x05(%x28)[32byte] %p7/z -> %z27.s
-a557bfff : ldnf1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnf1w +0x07(%sp)[32byte] %p7/z -> %z31.s
+a551b6b3 : ldnf1w z19.s, p5/Z, [x21, #1, MUL VL]     : ldnf1w +0x20(%x21)[32byte] %p5/z -> %z19.s
+a552baf5 : ldnf1w z21.s, p6/Z, [x23, #2, MUL VL]     : ldnf1w +0x40(%x23)[32byte] %p6/z -> %z21.s
+a553bb17 : ldnf1w z23.s, p6/Z, [x24, #3, MUL VL]     : ldnf1w +0x60(%x24)[32byte] %p6/z -> %z23.s
+a554bf59 : ldnf1w z25.s, p7/Z, [x26, #4, MUL VL]     : ldnf1w +0x80(%x26)[32byte] %p7/z -> %z25.s
+a555bf9b : ldnf1w z27.s, p7/Z, [x28, #5, MUL VL]     : ldnf1w +0xa0(%x28)[32byte] %p7/z -> %z27.s
+a557bfff : ldnf1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnf1w +0xe0(%sp)[32byte] %p7/z -> %z31.s
 
 # LDNF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNF1W-Z.P.BI-U64)
-a578a000 : ldnf1w z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1w -0x08(%x0)[16byte] %p0/z -> %z0.d
-a579a482 : ldnf1w z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1w -0x07(%x4)[16byte] %p1/z -> %z2.d
-a57aa8c4 : ldnf1w z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1w -0x06(%x6)[16byte] %p2/z -> %z4.d
-a57ba906 : ldnf1w z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1w -0x05(%x8)[16byte] %p2/z -> %z6.d
-a57cad48 : ldnf1w z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1w -0x04(%x10)[16byte] %p3/z -> %z8.d
-a57dad6a : ldnf1w z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1w -0x03(%x11)[16byte] %p3/z -> %z10.d
-a57eb1ac : ldnf1w z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1w -0x02(%x13)[16byte] %p4/z -> %z12.d
-a57fb1ee : ldnf1w z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1w -0x01(%x15)[16byte] %p4/z -> %z14.d
+a578a000 : ldnf1w z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnf1w -0x80(%x0)[16byte] %p0/z -> %z0.d
+a579a482 : ldnf1w z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnf1w -0x70(%x4)[16byte] %p1/z -> %z2.d
+a57aa8c4 : ldnf1w z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnf1w -0x60(%x6)[16byte] %p2/z -> %z4.d
+a57ba906 : ldnf1w z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnf1w -0x50(%x8)[16byte] %p2/z -> %z6.d
+a57cad48 : ldnf1w z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnf1w -0x40(%x10)[16byte] %p3/z -> %z8.d
+a57dad6a : ldnf1w z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnf1w -0x30(%x11)[16byte] %p3/z -> %z10.d
+a57eb1ac : ldnf1w z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnf1w -0x20(%x13)[16byte] %p4/z -> %z12.d
+a57fb1ee : ldnf1w z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnf1w -0x10(%x15)[16byte] %p4/z -> %z14.d
 a570b630 : ldnf1w z16.d, p5/Z, [x17, #0, MUL VL]     : ldnf1w (%x17)[16byte] %p5/z -> %z16.d
 a570b671 : ldnf1w z17.d, p5/Z, [x19, #0, MUL VL]     : ldnf1w (%x19)[16byte] %p5/z -> %z17.d
-a571b6b3 : ldnf1w z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1w +0x01(%x21)[16byte] %p5/z -> %z19.d
-a572baf5 : ldnf1w z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1w +0x02(%x23)[16byte] %p6/z -> %z21.d
-a573bb17 : ldnf1w z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1w +0x03(%x24)[16byte] %p6/z -> %z23.d
-a574bf59 : ldnf1w z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1w +0x04(%x26)[16byte] %p7/z -> %z25.d
-a575bf9b : ldnf1w z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1w +0x05(%x28)[16byte] %p7/z -> %z27.d
-a577bfff : ldnf1w z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1w +0x07(%sp)[16byte] %p7/z -> %z31.d
+a571b6b3 : ldnf1w z19.d, p5/Z, [x21, #1, MUL VL]     : ldnf1w +0x10(%x21)[16byte] %p5/z -> %z19.d
+a572baf5 : ldnf1w z21.d, p6/Z, [x23, #2, MUL VL]     : ldnf1w +0x20(%x23)[16byte] %p6/z -> %z21.d
+a573bb17 : ldnf1w z23.d, p6/Z, [x24, #3, MUL VL]     : ldnf1w +0x30(%x24)[16byte] %p6/z -> %z23.d
+a574bf59 : ldnf1w z25.d, p7/Z, [x26, #4, MUL VL]     : ldnf1w +0x40(%x26)[16byte] %p7/z -> %z25.d
+a575bf9b : ldnf1w z27.d, p7/Z, [x28, #5, MUL VL]     : ldnf1w +0x50(%x28)[16byte] %p7/z -> %z27.d
+a577bfff : ldnf1w z31.d, p7/Z, [sp, #7, MUL VL]      : ldnf1w +0x70(%sp)[16byte] %p7/z -> %z31.d
 
 # LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>] (LDNT1B-Z.P.BR-Contiguous)
 a400c000 : ldnt1b z0.b, p0/Z, [x0, x0]               : ldnt1b (%x0,%x0)[32byte] %p0/z -> %z0.b
@@ -15078,22 +15078,22 @@ a41ddf9b : ldnt1b z27.b, p7/Z, [x28, x29]            : ldnt1b (%x28,%x29)[32byte
 a41edfff : ldnt1b z31.b, p7/Z, [sp, x30]             : ldnt1b (%sp,%x30)[32byte] %p7/z -> %z31.b
 
 # LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNT1B-Z.P.BI-Contiguous)
-a408e000 : ldnt1b z0.b, p0/Z, [x0, #-8, MUL VL]      : ldnt1b -0x08(%x0)[32byte] %p0/z -> %z0.b
-a409e482 : ldnt1b z2.b, p1/Z, [x4, #-7, MUL VL]      : ldnt1b -0x07(%x4)[32byte] %p1/z -> %z2.b
-a40ae8c4 : ldnt1b z4.b, p2/Z, [x6, #-6, MUL VL]      : ldnt1b -0x06(%x6)[32byte] %p2/z -> %z4.b
-a40be906 : ldnt1b z6.b, p2/Z, [x8, #-5, MUL VL]      : ldnt1b -0x05(%x8)[32byte] %p2/z -> %z6.b
-a40ced48 : ldnt1b z8.b, p3/Z, [x10, #-4, MUL VL]     : ldnt1b -0x04(%x10)[32byte] %p3/z -> %z8.b
-a40ded6a : ldnt1b z10.b, p3/Z, [x11, #-3, MUL VL]    : ldnt1b -0x03(%x11)[32byte] %p3/z -> %z10.b
-a40ef1ac : ldnt1b z12.b, p4/Z, [x13, #-2, MUL VL]    : ldnt1b -0x02(%x13)[32byte] %p4/z -> %z12.b
-a40ff1ee : ldnt1b z14.b, p4/Z, [x15, #-1, MUL VL]    : ldnt1b -0x01(%x15)[32byte] %p4/z -> %z14.b
+a408e000 : ldnt1b z0.b, p0/Z, [x0, #-8, MUL VL]      : ldnt1b -0x0100(%x0)[32byte] %p0/z -> %z0.b
+a409e482 : ldnt1b z2.b, p1/Z, [x4, #-7, MUL VL]      : ldnt1b -0xe0(%x4)[32byte] %p1/z -> %z2.b
+a40ae8c4 : ldnt1b z4.b, p2/Z, [x6, #-6, MUL VL]      : ldnt1b -0xc0(%x6)[32byte] %p2/z -> %z4.b
+a40be906 : ldnt1b z6.b, p2/Z, [x8, #-5, MUL VL]      : ldnt1b -0xa0(%x8)[32byte] %p2/z -> %z6.b
+a40ced48 : ldnt1b z8.b, p3/Z, [x10, #-4, MUL VL]     : ldnt1b -0x80(%x10)[32byte] %p3/z -> %z8.b
+a40ded6a : ldnt1b z10.b, p3/Z, [x11, #-3, MUL VL]    : ldnt1b -0x60(%x11)[32byte] %p3/z -> %z10.b
+a40ef1ac : ldnt1b z12.b, p4/Z, [x13, #-2, MUL VL]    : ldnt1b -0x40(%x13)[32byte] %p4/z -> %z12.b
+a40ff1ee : ldnt1b z14.b, p4/Z, [x15, #-1, MUL VL]    : ldnt1b -0x20(%x15)[32byte] %p4/z -> %z14.b
 a400f630 : ldnt1b z16.b, p5/Z, [x17, #0, MUL VL]     : ldnt1b (%x17)[32byte] %p5/z -> %z16.b
 a400f671 : ldnt1b z17.b, p5/Z, [x19, #0, MUL VL]     : ldnt1b (%x19)[32byte] %p5/z -> %z17.b
-a401f6b3 : ldnt1b z19.b, p5/Z, [x21, #1, MUL VL]     : ldnt1b +0x01(%x21)[32byte] %p5/z -> %z19.b
-a402faf5 : ldnt1b z21.b, p6/Z, [x23, #2, MUL VL]     : ldnt1b +0x02(%x23)[32byte] %p6/z -> %z21.b
-a403fb17 : ldnt1b z23.b, p6/Z, [x24, #3, MUL VL]     : ldnt1b +0x03(%x24)[32byte] %p6/z -> %z23.b
-a404ff59 : ldnt1b z25.b, p7/Z, [x26, #4, MUL VL]     : ldnt1b +0x04(%x26)[32byte] %p7/z -> %z25.b
-a405ff9b : ldnt1b z27.b, p7/Z, [x28, #5, MUL VL]     : ldnt1b +0x05(%x28)[32byte] %p7/z -> %z27.b
-a407ffff : ldnt1b z31.b, p7/Z, [sp, #7, MUL VL]      : ldnt1b +0x07(%sp)[32byte] %p7/z -> %z31.b
+a401f6b3 : ldnt1b z19.b, p5/Z, [x21, #1, MUL VL]     : ldnt1b +0x20(%x21)[32byte] %p5/z -> %z19.b
+a402faf5 : ldnt1b z21.b, p6/Z, [x23, #2, MUL VL]     : ldnt1b +0x40(%x23)[32byte] %p6/z -> %z21.b
+a403fb17 : ldnt1b z23.b, p6/Z, [x24, #3, MUL VL]     : ldnt1b +0x60(%x24)[32byte] %p6/z -> %z23.b
+a404ff59 : ldnt1b z25.b, p7/Z, [x26, #4, MUL VL]     : ldnt1b +0x80(%x26)[32byte] %p7/z -> %z25.b
+a405ff9b : ldnt1b z27.b, p7/Z, [x28, #5, MUL VL]     : ldnt1b +0xa0(%x28)[32byte] %p7/z -> %z27.b
+a407ffff : ldnt1b z31.b, p7/Z, [sp, #7, MUL VL]      : ldnt1b +0xe0(%sp)[32byte] %p7/z -> %z31.b
 
 # LDNT1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #3] (LDNT1D-Z.P.BR-Contiguous)
 a580c000 : ldnt1d z0.d, p0/Z, [x0, x0, LSL #3]       : ldnt1d (%x0,%x0,lsl #3)[32byte] %p0/z -> %z0.d
@@ -15114,22 +15114,22 @@ a59ddf9b : ldnt1d z27.d, p7/Z, [x28, x29, LSL #3]    : ldnt1d (%x28,%x29,lsl #3)
 a59edfff : ldnt1d z31.d, p7/Z, [sp, x30, LSL #3]     : ldnt1d (%sp,%x30,lsl #3)[32byte] %p7/z -> %z31.d
 
 # LDNT1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNT1D-Z.P.BI-Contiguous)
-a588e000 : ldnt1d z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnt1d -0x08(%x0)[32byte] %p0/z -> %z0.d
-a589e482 : ldnt1d z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnt1d -0x07(%x4)[32byte] %p1/z -> %z2.d
-a58ae8c4 : ldnt1d z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnt1d -0x06(%x6)[32byte] %p2/z -> %z4.d
-a58be906 : ldnt1d z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnt1d -0x05(%x8)[32byte] %p2/z -> %z6.d
-a58ced48 : ldnt1d z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnt1d -0x04(%x10)[32byte] %p3/z -> %z8.d
-a58ded6a : ldnt1d z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnt1d -0x03(%x11)[32byte] %p3/z -> %z10.d
-a58ef1ac : ldnt1d z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnt1d -0x02(%x13)[32byte] %p4/z -> %z12.d
-a58ff1ee : ldnt1d z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnt1d -0x01(%x15)[32byte] %p4/z -> %z14.d
+a588e000 : ldnt1d z0.d, p0/Z, [x0, #-8, MUL VL]      : ldnt1d -0x0100(%x0)[32byte] %p0/z -> %z0.d
+a589e482 : ldnt1d z2.d, p1/Z, [x4, #-7, MUL VL]      : ldnt1d -0xe0(%x4)[32byte] %p1/z -> %z2.d
+a58ae8c4 : ldnt1d z4.d, p2/Z, [x6, #-6, MUL VL]      : ldnt1d -0xc0(%x6)[32byte] %p2/z -> %z4.d
+a58be906 : ldnt1d z6.d, p2/Z, [x8, #-5, MUL VL]      : ldnt1d -0xa0(%x8)[32byte] %p2/z -> %z6.d
+a58ced48 : ldnt1d z8.d, p3/Z, [x10, #-4, MUL VL]     : ldnt1d -0x80(%x10)[32byte] %p3/z -> %z8.d
+a58ded6a : ldnt1d z10.d, p3/Z, [x11, #-3, MUL VL]    : ldnt1d -0x60(%x11)[32byte] %p3/z -> %z10.d
+a58ef1ac : ldnt1d z12.d, p4/Z, [x13, #-2, MUL VL]    : ldnt1d -0x40(%x13)[32byte] %p4/z -> %z12.d
+a58ff1ee : ldnt1d z14.d, p4/Z, [x15, #-1, MUL VL]    : ldnt1d -0x20(%x15)[32byte] %p4/z -> %z14.d
 a580f630 : ldnt1d z16.d, p5/Z, [x17, #0, MUL VL]     : ldnt1d (%x17)[32byte] %p5/z -> %z16.d
 a580f671 : ldnt1d z17.d, p5/Z, [x19, #0, MUL VL]     : ldnt1d (%x19)[32byte] %p5/z -> %z17.d
-a581f6b3 : ldnt1d z19.d, p5/Z, [x21, #1, MUL VL]     : ldnt1d +0x01(%x21)[32byte] %p5/z -> %z19.d
-a582faf5 : ldnt1d z21.d, p6/Z, [x23, #2, MUL VL]     : ldnt1d +0x02(%x23)[32byte] %p6/z -> %z21.d
-a583fb17 : ldnt1d z23.d, p6/Z, [x24, #3, MUL VL]     : ldnt1d +0x03(%x24)[32byte] %p6/z -> %z23.d
-a584ff59 : ldnt1d z25.d, p7/Z, [x26, #4, MUL VL]     : ldnt1d +0x04(%x26)[32byte] %p7/z -> %z25.d
-a585ff9b : ldnt1d z27.d, p7/Z, [x28, #5, MUL VL]     : ldnt1d +0x05(%x28)[32byte] %p7/z -> %z27.d
-a587ffff : ldnt1d z31.d, p7/Z, [sp, #7, MUL VL]      : ldnt1d +0x07(%sp)[32byte] %p7/z -> %z31.d
+a581f6b3 : ldnt1d z19.d, p5/Z, [x21, #1, MUL VL]     : ldnt1d +0x20(%x21)[32byte] %p5/z -> %z19.d
+a582faf5 : ldnt1d z21.d, p6/Z, [x23, #2, MUL VL]     : ldnt1d +0x40(%x23)[32byte] %p6/z -> %z21.d
+a583fb17 : ldnt1d z23.d, p6/Z, [x24, #3, MUL VL]     : ldnt1d +0x60(%x24)[32byte] %p6/z -> %z23.d
+a584ff59 : ldnt1d z25.d, p7/Z, [x26, #4, MUL VL]     : ldnt1d +0x80(%x26)[32byte] %p7/z -> %z25.d
+a585ff9b : ldnt1d z27.d, p7/Z, [x28, #5, MUL VL]     : ldnt1d +0xa0(%x28)[32byte] %p7/z -> %z27.d
+a587ffff : ldnt1d z31.d, p7/Z, [sp, #7, MUL VL]      : ldnt1d +0xe0(%sp)[32byte] %p7/z -> %z31.d
 
 # LDNT1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1] (LDNT1H-Z.P.BR-Contiguous)
 a480c000 : ldnt1h z0.h, p0/Z, [x0, x0, LSL #1]       : ldnt1h (%x0,%x0,lsl #1)[32byte] %p0/z -> %z0.h
@@ -15150,22 +15150,22 @@ a49ddf9b : ldnt1h z27.h, p7/Z, [x28, x29, LSL #1]    : ldnt1h (%x28,%x29,lsl #1)
 a49edfff : ldnt1h z31.h, p7/Z, [sp, x30, LSL #1]     : ldnt1h (%sp,%x30,lsl #1)[32byte] %p7/z -> %z31.h
 
 # LDNT1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNT1H-Z.P.BI-Contiguous)
-a488e000 : ldnt1h z0.h, p0/Z, [x0, #-8, MUL VL]      : ldnt1h -0x08(%x0)[32byte] %p0/z -> %z0.h
-a489e482 : ldnt1h z2.h, p1/Z, [x4, #-7, MUL VL]      : ldnt1h -0x07(%x4)[32byte] %p1/z -> %z2.h
-a48ae8c4 : ldnt1h z4.h, p2/Z, [x6, #-6, MUL VL]      : ldnt1h -0x06(%x6)[32byte] %p2/z -> %z4.h
-a48be906 : ldnt1h z6.h, p2/Z, [x8, #-5, MUL VL]      : ldnt1h -0x05(%x8)[32byte] %p2/z -> %z6.h
-a48ced48 : ldnt1h z8.h, p3/Z, [x10, #-4, MUL VL]     : ldnt1h -0x04(%x10)[32byte] %p3/z -> %z8.h
-a48ded6a : ldnt1h z10.h, p3/Z, [x11, #-3, MUL VL]    : ldnt1h -0x03(%x11)[32byte] %p3/z -> %z10.h
-a48ef1ac : ldnt1h z12.h, p4/Z, [x13, #-2, MUL VL]    : ldnt1h -0x02(%x13)[32byte] %p4/z -> %z12.h
-a48ff1ee : ldnt1h z14.h, p4/Z, [x15, #-1, MUL VL]    : ldnt1h -0x01(%x15)[32byte] %p4/z -> %z14.h
+a488e000 : ldnt1h z0.h, p0/Z, [x0, #-8, MUL VL]      : ldnt1h -0x0100(%x0)[32byte] %p0/z -> %z0.h
+a489e482 : ldnt1h z2.h, p1/Z, [x4, #-7, MUL VL]      : ldnt1h -0xe0(%x4)[32byte] %p1/z -> %z2.h
+a48ae8c4 : ldnt1h z4.h, p2/Z, [x6, #-6, MUL VL]      : ldnt1h -0xc0(%x6)[32byte] %p2/z -> %z4.h
+a48be906 : ldnt1h z6.h, p2/Z, [x8, #-5, MUL VL]      : ldnt1h -0xa0(%x8)[32byte] %p2/z -> %z6.h
+a48ced48 : ldnt1h z8.h, p3/Z, [x10, #-4, MUL VL]     : ldnt1h -0x80(%x10)[32byte] %p3/z -> %z8.h
+a48ded6a : ldnt1h z10.h, p3/Z, [x11, #-3, MUL VL]    : ldnt1h -0x60(%x11)[32byte] %p3/z -> %z10.h
+a48ef1ac : ldnt1h z12.h, p4/Z, [x13, #-2, MUL VL]    : ldnt1h -0x40(%x13)[32byte] %p4/z -> %z12.h
+a48ff1ee : ldnt1h z14.h, p4/Z, [x15, #-1, MUL VL]    : ldnt1h -0x20(%x15)[32byte] %p4/z -> %z14.h
 a480f630 : ldnt1h z16.h, p5/Z, [x17, #0, MUL VL]     : ldnt1h (%x17)[32byte] %p5/z -> %z16.h
 a480f671 : ldnt1h z17.h, p5/Z, [x19, #0, MUL VL]     : ldnt1h (%x19)[32byte] %p5/z -> %z17.h
-a481f6b3 : ldnt1h z19.h, p5/Z, [x21, #1, MUL VL]     : ldnt1h +0x01(%x21)[32byte] %p5/z -> %z19.h
-a482faf5 : ldnt1h z21.h, p6/Z, [x23, #2, MUL VL]     : ldnt1h +0x02(%x23)[32byte] %p6/z -> %z21.h
-a483fb17 : ldnt1h z23.h, p6/Z, [x24, #3, MUL VL]     : ldnt1h +0x03(%x24)[32byte] %p6/z -> %z23.h
-a484ff59 : ldnt1h z25.h, p7/Z, [x26, #4, MUL VL]     : ldnt1h +0x04(%x26)[32byte] %p7/z -> %z25.h
-a485ff9b : ldnt1h z27.h, p7/Z, [x28, #5, MUL VL]     : ldnt1h +0x05(%x28)[32byte] %p7/z -> %z27.h
-a487ffff : ldnt1h z31.h, p7/Z, [sp, #7, MUL VL]      : ldnt1h +0x07(%sp)[32byte] %p7/z -> %z31.h
+a481f6b3 : ldnt1h z19.h, p5/Z, [x21, #1, MUL VL]     : ldnt1h +0x20(%x21)[32byte] %p5/z -> %z19.h
+a482faf5 : ldnt1h z21.h, p6/Z, [x23, #2, MUL VL]     : ldnt1h +0x40(%x23)[32byte] %p6/z -> %z21.h
+a483fb17 : ldnt1h z23.h, p6/Z, [x24, #3, MUL VL]     : ldnt1h +0x60(%x24)[32byte] %p6/z -> %z23.h
+a484ff59 : ldnt1h z25.h, p7/Z, [x26, #4, MUL VL]     : ldnt1h +0x80(%x26)[32byte] %p7/z -> %z25.h
+a485ff9b : ldnt1h z27.h, p7/Z, [x28, #5, MUL VL]     : ldnt1h +0xa0(%x28)[32byte] %p7/z -> %z27.h
+a487ffff : ldnt1h z31.h, p7/Z, [sp, #7, MUL VL]      : ldnt1h +0xe0(%sp)[32byte] %p7/z -> %z31.h
 
 # LDNT1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #2] (LDNT1W-Z.P.BR-Contiguous)
 a500c000 : ldnt1w z0.s, p0/Z, [x0, x0, LSL #2]       : ldnt1w (%x0,%x0,lsl #2)[32byte] %p0/z -> %z0.s
@@ -15186,22 +15186,22 @@ a51ddf9b : ldnt1w z27.s, p7/Z, [x28, x29, LSL #2]    : ldnt1w (%x28,%x29,lsl #2)
 a51edfff : ldnt1w z31.s, p7/Z, [sp, x30, LSL #2]     : ldnt1w (%sp,%x30,lsl #2)[32byte] %p7/z -> %z31.s
 
 # LDNT1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] (LDNT1W-Z.P.BI-Contiguous)
-a508e000 : ldnt1w z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnt1w -0x08(%x0)[32byte] %p0/z -> %z0.s
-a509e482 : ldnt1w z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnt1w -0x07(%x4)[32byte] %p1/z -> %z2.s
-a50ae8c4 : ldnt1w z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnt1w -0x06(%x6)[32byte] %p2/z -> %z4.s
-a50be906 : ldnt1w z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnt1w -0x05(%x8)[32byte] %p2/z -> %z6.s
-a50ced48 : ldnt1w z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnt1w -0x04(%x10)[32byte] %p3/z -> %z8.s
-a50ded6a : ldnt1w z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnt1w -0x03(%x11)[32byte] %p3/z -> %z10.s
-a50ef1ac : ldnt1w z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnt1w -0x02(%x13)[32byte] %p4/z -> %z12.s
-a50ff1ee : ldnt1w z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnt1w -0x01(%x15)[32byte] %p4/z -> %z14.s
+a508e000 : ldnt1w z0.s, p0/Z, [x0, #-8, MUL VL]      : ldnt1w -0x0100(%x0)[32byte] %p0/z -> %z0.s
+a509e482 : ldnt1w z2.s, p1/Z, [x4, #-7, MUL VL]      : ldnt1w -0xe0(%x4)[32byte] %p1/z -> %z2.s
+a50ae8c4 : ldnt1w z4.s, p2/Z, [x6, #-6, MUL VL]      : ldnt1w -0xc0(%x6)[32byte] %p2/z -> %z4.s
+a50be906 : ldnt1w z6.s, p2/Z, [x8, #-5, MUL VL]      : ldnt1w -0xa0(%x8)[32byte] %p2/z -> %z6.s
+a50ced48 : ldnt1w z8.s, p3/Z, [x10, #-4, MUL VL]     : ldnt1w -0x80(%x10)[32byte] %p3/z -> %z8.s
+a50ded6a : ldnt1w z10.s, p3/Z, [x11, #-3, MUL VL]    : ldnt1w -0x60(%x11)[32byte] %p3/z -> %z10.s
+a50ef1ac : ldnt1w z12.s, p4/Z, [x13, #-2, MUL VL]    : ldnt1w -0x40(%x13)[32byte] %p4/z -> %z12.s
+a50ff1ee : ldnt1w z14.s, p4/Z, [x15, #-1, MUL VL]    : ldnt1w -0x20(%x15)[32byte] %p4/z -> %z14.s
 a500f630 : ldnt1w z16.s, p5/Z, [x17, #0, MUL VL]     : ldnt1w (%x17)[32byte] %p5/z -> %z16.s
 a500f671 : ldnt1w z17.s, p5/Z, [x19, #0, MUL VL]     : ldnt1w (%x19)[32byte] %p5/z -> %z17.s
-a501f6b3 : ldnt1w z19.s, p5/Z, [x21, #1, MUL VL]     : ldnt1w +0x01(%x21)[32byte] %p5/z -> %z19.s
-a502faf5 : ldnt1w z21.s, p6/Z, [x23, #2, MUL VL]     : ldnt1w +0x02(%x23)[32byte] %p6/z -> %z21.s
-a503fb17 : ldnt1w z23.s, p6/Z, [x24, #3, MUL VL]     : ldnt1w +0x03(%x24)[32byte] %p6/z -> %z23.s
-a504ff59 : ldnt1w z25.s, p7/Z, [x26, #4, MUL VL]     : ldnt1w +0x04(%x26)[32byte] %p7/z -> %z25.s
-a505ff9b : ldnt1w z27.s, p7/Z, [x28, #5, MUL VL]     : ldnt1w +0x05(%x28)[32byte] %p7/z -> %z27.s
-a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0x07(%sp)[32byte] %p7/z -> %z31.s
+a501f6b3 : ldnt1w z19.s, p5/Z, [x21, #1, MUL VL]     : ldnt1w +0x20(%x21)[32byte] %p5/z -> %z19.s
+a502faf5 : ldnt1w z21.s, p6/Z, [x23, #2, MUL VL]     : ldnt1w +0x40(%x23)[32byte] %p6/z -> %z21.s
+a503fb17 : ldnt1w z23.s, p6/Z, [x24, #3, MUL VL]     : ldnt1w +0x60(%x24)[32byte] %p6/z -> %z23.s
+a504ff59 : ldnt1w z25.s, p7/Z, [x26, #4, MUL VL]     : ldnt1w +0x80(%x26)[32byte] %p7/z -> %z25.s
+a505ff9b : ldnt1w z27.s, p7/Z, [x28, #5, MUL VL]     : ldnt1w +0xa0(%x28)[32byte] %p7/z -> %z27.s
+a507ffff : ldnt1w z31.s, p7/Z, [sp, #7, MUL VL]      : ldnt1w +0xe0(%sp)[32byte] %p7/z -> %z31.s
 
 # LDR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
 858003c0 : ldr p0, [x30]                            : ldr    (%x30)[4byte] -> %p0
@@ -20990,70 +20990,70 @@ e41ebf9b : st1b z27.d, p7, [x28, z30.d]              : st1b   %z27.d %p7 -> (%x2
 e41fbfff : st1b z31.d, p7, [sp, z31.d]               : st1b   %z31.d %p7 -> (%sp,%z31.d)[4byte]
 
 # ST1B    { <Zt>.<T> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST1B-Z.P.BI-_)
-e408e000 : st1b z0.b, p0, [x0, #-8, MUL VL]          : st1b   %z0.b %p0 -> -0x08(%x0)[32byte]
-e409e482 : st1b z2.b, p1, [x4, #-7, MUL VL]          : st1b   %z2.b %p1 -> -0x07(%x4)[32byte]
-e40ae8c4 : st1b z4.b, p2, [x6, #-6, MUL VL]          : st1b   %z4.b %p2 -> -0x06(%x6)[32byte]
-e40be906 : st1b z6.b, p2, [x8, #-5, MUL VL]          : st1b   %z6.b %p2 -> -0x05(%x8)[32byte]
-e40ced48 : st1b z8.b, p3, [x10, #-4, MUL VL]         : st1b   %z8.b %p3 -> -0x04(%x10)[32byte]
-e40ded6a : st1b z10.b, p3, [x11, #-3, MUL VL]        : st1b   %z10.b %p3 -> -0x03(%x11)[32byte]
-e40ef1ac : st1b z12.b, p4, [x13, #-2, MUL VL]        : st1b   %z12.b %p4 -> -0x02(%x13)[32byte]
-e40ff1ee : st1b z14.b, p4, [x15, #-1, MUL VL]        : st1b   %z14.b %p4 -> -0x01(%x15)[32byte]
+e408e000 : st1b z0.b, p0, [x0, #-8, MUL VL]          : st1b   %z0.b %p0 -> -0x0100(%x0)[32byte]
+e409e482 : st1b z2.b, p1, [x4, #-7, MUL VL]          : st1b   %z2.b %p1 -> -0xe0(%x4)[32byte]
+e40ae8c4 : st1b z4.b, p2, [x6, #-6, MUL VL]          : st1b   %z4.b %p2 -> -0xc0(%x6)[32byte]
+e40be906 : st1b z6.b, p2, [x8, #-5, MUL VL]          : st1b   %z6.b %p2 -> -0xa0(%x8)[32byte]
+e40ced48 : st1b z8.b, p3, [x10, #-4, MUL VL]         : st1b   %z8.b %p3 -> -0x80(%x10)[32byte]
+e40ded6a : st1b z10.b, p3, [x11, #-3, MUL VL]        : st1b   %z10.b %p3 -> -0x60(%x11)[32byte]
+e40ef1ac : st1b z12.b, p4, [x13, #-2, MUL VL]        : st1b   %z12.b %p4 -> -0x40(%x13)[32byte]
+e40ff1ee : st1b z14.b, p4, [x15, #-1, MUL VL]        : st1b   %z14.b %p4 -> -0x20(%x15)[32byte]
 e400f630 : st1b z16.b, p5, [x17, #0, MUL VL]         : st1b   %z16.b %p5 -> (%x17)[32byte]
 e400f671 : st1b z17.b, p5, [x19, #0, MUL VL]         : st1b   %z17.b %p5 -> (%x19)[32byte]
-e401f6b3 : st1b z19.b, p5, [x21, #1, MUL VL]         : st1b   %z19.b %p5 -> +0x01(%x21)[32byte]
-e402faf5 : st1b z21.b, p6, [x23, #2, MUL VL]         : st1b   %z21.b %p6 -> +0x02(%x23)[32byte]
-e403fb17 : st1b z23.b, p6, [x24, #3, MUL VL]         : st1b   %z23.b %p6 -> +0x03(%x24)[32byte]
-e404ff59 : st1b z25.b, p7, [x26, #4, MUL VL]         : st1b   %z25.b %p7 -> +0x04(%x26)[32byte]
-e405ff9b : st1b z27.b, p7, [x28, #5, MUL VL]         : st1b   %z27.b %p7 -> +0x05(%x28)[32byte]
-e407ffff : st1b z31.b, p7, [sp, #7, MUL VL]          : st1b   %z31.b %p7 -> +0x07(%sp)[32byte]
-e428e000 : st1b z0.h, p0, [x0, #-8, MUL VL]          : st1b   %z0.h %p0 -> -0x08(%x0)[16byte]
-e429e482 : st1b z2.h, p1, [x4, #-7, MUL VL]          : st1b   %z2.h %p1 -> -0x07(%x4)[16byte]
-e42ae8c4 : st1b z4.h, p2, [x6, #-6, MUL VL]          : st1b   %z4.h %p2 -> -0x06(%x6)[16byte]
-e42be906 : st1b z6.h, p2, [x8, #-5, MUL VL]          : st1b   %z6.h %p2 -> -0x05(%x8)[16byte]
-e42ced48 : st1b z8.h, p3, [x10, #-4, MUL VL]         : st1b   %z8.h %p3 -> -0x04(%x10)[16byte]
-e42ded6a : st1b z10.h, p3, [x11, #-3, MUL VL]        : st1b   %z10.h %p3 -> -0x03(%x11)[16byte]
-e42ef1ac : st1b z12.h, p4, [x13, #-2, MUL VL]        : st1b   %z12.h %p4 -> -0x02(%x13)[16byte]
-e42ff1ee : st1b z14.h, p4, [x15, #-1, MUL VL]        : st1b   %z14.h %p4 -> -0x01(%x15)[16byte]
+e401f6b3 : st1b z19.b, p5, [x21, #1, MUL VL]         : st1b   %z19.b %p5 -> +0x20(%x21)[32byte]
+e402faf5 : st1b z21.b, p6, [x23, #2, MUL VL]         : st1b   %z21.b %p6 -> +0x40(%x23)[32byte]
+e403fb17 : st1b z23.b, p6, [x24, #3, MUL VL]         : st1b   %z23.b %p6 -> +0x60(%x24)[32byte]
+e404ff59 : st1b z25.b, p7, [x26, #4, MUL VL]         : st1b   %z25.b %p7 -> +0x80(%x26)[32byte]
+e405ff9b : st1b z27.b, p7, [x28, #5, MUL VL]         : st1b   %z27.b %p7 -> +0xa0(%x28)[32byte]
+e407ffff : st1b z31.b, p7, [sp, #7, MUL VL]          : st1b   %z31.b %p7 -> +0xe0(%sp)[32byte]
+e428e000 : st1b z0.h, p0, [x0, #-8, MUL VL]          : st1b   %z0.h %p0 -> -0x80(%x0)[16byte]
+e429e482 : st1b z2.h, p1, [x4, #-7, MUL VL]          : st1b   %z2.h %p1 -> -0x70(%x4)[16byte]
+e42ae8c4 : st1b z4.h, p2, [x6, #-6, MUL VL]          : st1b   %z4.h %p2 -> -0x60(%x6)[16byte]
+e42be906 : st1b z6.h, p2, [x8, #-5, MUL VL]          : st1b   %z6.h %p2 -> -0x50(%x8)[16byte]
+e42ced48 : st1b z8.h, p3, [x10, #-4, MUL VL]         : st1b   %z8.h %p3 -> -0x40(%x10)[16byte]
+e42ded6a : st1b z10.h, p3, [x11, #-3, MUL VL]        : st1b   %z10.h %p3 -> -0x30(%x11)[16byte]
+e42ef1ac : st1b z12.h, p4, [x13, #-2, MUL VL]        : st1b   %z12.h %p4 -> -0x20(%x13)[16byte]
+e42ff1ee : st1b z14.h, p4, [x15, #-1, MUL VL]        : st1b   %z14.h %p4 -> -0x10(%x15)[16byte]
 e420f630 : st1b z16.h, p5, [x17, #0, MUL VL]         : st1b   %z16.h %p5 -> (%x17)[16byte]
 e420f671 : st1b z17.h, p5, [x19, #0, MUL VL]         : st1b   %z17.h %p5 -> (%x19)[16byte]
-e421f6b3 : st1b z19.h, p5, [x21, #1, MUL VL]         : st1b   %z19.h %p5 -> +0x01(%x21)[16byte]
-e422faf5 : st1b z21.h, p6, [x23, #2, MUL VL]         : st1b   %z21.h %p6 -> +0x02(%x23)[16byte]
-e423fb17 : st1b z23.h, p6, [x24, #3, MUL VL]         : st1b   %z23.h %p6 -> +0x03(%x24)[16byte]
-e424ff59 : st1b z25.h, p7, [x26, #4, MUL VL]         : st1b   %z25.h %p7 -> +0x04(%x26)[16byte]
-e425ff9b : st1b z27.h, p7, [x28, #5, MUL VL]         : st1b   %z27.h %p7 -> +0x05(%x28)[16byte]
-e427ffff : st1b z31.h, p7, [sp, #7, MUL VL]          : st1b   %z31.h %p7 -> +0x07(%sp)[16byte]
-e448e000 : st1b z0.s, p0, [x0, #-8, MUL VL]          : st1b   %z0.s %p0 -> -0x08(%x0)[8byte]
-e449e482 : st1b z2.s, p1, [x4, #-7, MUL VL]          : st1b   %z2.s %p1 -> -0x07(%x4)[8byte]
-e44ae8c4 : st1b z4.s, p2, [x6, #-6, MUL VL]          : st1b   %z4.s %p2 -> -0x06(%x6)[8byte]
-e44be906 : st1b z6.s, p2, [x8, #-5, MUL VL]          : st1b   %z6.s %p2 -> -0x05(%x8)[8byte]
-e44ced48 : st1b z8.s, p3, [x10, #-4, MUL VL]         : st1b   %z8.s %p3 -> -0x04(%x10)[8byte]
-e44ded6a : st1b z10.s, p3, [x11, #-3, MUL VL]        : st1b   %z10.s %p3 -> -0x03(%x11)[8byte]
-e44ef1ac : st1b z12.s, p4, [x13, #-2, MUL VL]        : st1b   %z12.s %p4 -> -0x02(%x13)[8byte]
-e44ff1ee : st1b z14.s, p4, [x15, #-1, MUL VL]        : st1b   %z14.s %p4 -> -0x01(%x15)[8byte]
+e421f6b3 : st1b z19.h, p5, [x21, #1, MUL VL]         : st1b   %z19.h %p5 -> +0x10(%x21)[16byte]
+e422faf5 : st1b z21.h, p6, [x23, #2, MUL VL]         : st1b   %z21.h %p6 -> +0x20(%x23)[16byte]
+e423fb17 : st1b z23.h, p6, [x24, #3, MUL VL]         : st1b   %z23.h %p6 -> +0x30(%x24)[16byte]
+e424ff59 : st1b z25.h, p7, [x26, #4, MUL VL]         : st1b   %z25.h %p7 -> +0x40(%x26)[16byte]
+e425ff9b : st1b z27.h, p7, [x28, #5, MUL VL]         : st1b   %z27.h %p7 -> +0x50(%x28)[16byte]
+e427ffff : st1b z31.h, p7, [sp, #7, MUL VL]          : st1b   %z31.h %p7 -> +0x70(%sp)[16byte]
+e448e000 : st1b z0.s, p0, [x0, #-8, MUL VL]          : st1b   %z0.s %p0 -> -0x40(%x0)[8byte]
+e449e482 : st1b z2.s, p1, [x4, #-7, MUL VL]          : st1b   %z2.s %p1 -> -0x38(%x4)[8byte]
+e44ae8c4 : st1b z4.s, p2, [x6, #-6, MUL VL]          : st1b   %z4.s %p2 -> -0x30(%x6)[8byte]
+e44be906 : st1b z6.s, p2, [x8, #-5, MUL VL]          : st1b   %z6.s %p2 -> -0x28(%x8)[8byte]
+e44ced48 : st1b z8.s, p3, [x10, #-4, MUL VL]         : st1b   %z8.s %p3 -> -0x20(%x10)[8byte]
+e44ded6a : st1b z10.s, p3, [x11, #-3, MUL VL]        : st1b   %z10.s %p3 -> -0x18(%x11)[8byte]
+e44ef1ac : st1b z12.s, p4, [x13, #-2, MUL VL]        : st1b   %z12.s %p4 -> -0x10(%x13)[8byte]
+e44ff1ee : st1b z14.s, p4, [x15, #-1, MUL VL]        : st1b   %z14.s %p4 -> -0x08(%x15)[8byte]
 e440f630 : st1b z16.s, p5, [x17, #0, MUL VL]         : st1b   %z16.s %p5 -> (%x17)[8byte]
 e440f671 : st1b z17.s, p5, [x19, #0, MUL VL]         : st1b   %z17.s %p5 -> (%x19)[8byte]
-e441f6b3 : st1b z19.s, p5, [x21, #1, MUL VL]         : st1b   %z19.s %p5 -> +0x01(%x21)[8byte]
-e442faf5 : st1b z21.s, p6, [x23, #2, MUL VL]         : st1b   %z21.s %p6 -> +0x02(%x23)[8byte]
-e443fb17 : st1b z23.s, p6, [x24, #3, MUL VL]         : st1b   %z23.s %p6 -> +0x03(%x24)[8byte]
-e444ff59 : st1b z25.s, p7, [x26, #4, MUL VL]         : st1b   %z25.s %p7 -> +0x04(%x26)[8byte]
-e445ff9b : st1b z27.s, p7, [x28, #5, MUL VL]         : st1b   %z27.s %p7 -> +0x05(%x28)[8byte]
-e447ffff : st1b z31.s, p7, [sp, #7, MUL VL]          : st1b   %z31.s %p7 -> +0x07(%sp)[8byte]
-e468e000 : st1b z0.d, p0, [x0, #-8, MUL VL]          : st1b   %z0.d %p0 -> -0x08(%x0)[4byte]
-e469e482 : st1b z2.d, p1, [x4, #-7, MUL VL]          : st1b   %z2.d %p1 -> -0x07(%x4)[4byte]
-e46ae8c4 : st1b z4.d, p2, [x6, #-6, MUL VL]          : st1b   %z4.d %p2 -> -0x06(%x6)[4byte]
-e46be906 : st1b z6.d, p2, [x8, #-5, MUL VL]          : st1b   %z6.d %p2 -> -0x05(%x8)[4byte]
-e46ced48 : st1b z8.d, p3, [x10, #-4, MUL VL]         : st1b   %z8.d %p3 -> -0x04(%x10)[4byte]
-e46ded6a : st1b z10.d, p3, [x11, #-3, MUL VL]        : st1b   %z10.d %p3 -> -0x03(%x11)[4byte]
-e46ef1ac : st1b z12.d, p4, [x13, #-2, MUL VL]        : st1b   %z12.d %p4 -> -0x02(%x13)[4byte]
-e46ff1ee : st1b z14.d, p4, [x15, #-1, MUL VL]        : st1b   %z14.d %p4 -> -0x01(%x15)[4byte]
+e441f6b3 : st1b z19.s, p5, [x21, #1, MUL VL]         : st1b   %z19.s %p5 -> +0x08(%x21)[8byte]
+e442faf5 : st1b z21.s, p6, [x23, #2, MUL VL]         : st1b   %z21.s %p6 -> +0x10(%x23)[8byte]
+e443fb17 : st1b z23.s, p6, [x24, #3, MUL VL]         : st1b   %z23.s %p6 -> +0x18(%x24)[8byte]
+e444ff59 : st1b z25.s, p7, [x26, #4, MUL VL]         : st1b   %z25.s %p7 -> +0x20(%x26)[8byte]
+e445ff9b : st1b z27.s, p7, [x28, #5, MUL VL]         : st1b   %z27.s %p7 -> +0x28(%x28)[8byte]
+e447ffff : st1b z31.s, p7, [sp, #7, MUL VL]          : st1b   %z31.s %p7 -> +0x38(%sp)[8byte]
+e468e000 : st1b z0.d, p0, [x0, #-8, MUL VL]          : st1b   %z0.d %p0 -> -0x20(%x0)[4byte]
+e469e482 : st1b z2.d, p1, [x4, #-7, MUL VL]          : st1b   %z2.d %p1 -> -0x1c(%x4)[4byte]
+e46ae8c4 : st1b z4.d, p2, [x6, #-6, MUL VL]          : st1b   %z4.d %p2 -> -0x18(%x6)[4byte]
+e46be906 : st1b z6.d, p2, [x8, #-5, MUL VL]          : st1b   %z6.d %p2 -> -0x14(%x8)[4byte]
+e46ced48 : st1b z8.d, p3, [x10, #-4, MUL VL]         : st1b   %z8.d %p3 -> -0x10(%x10)[4byte]
+e46ded6a : st1b z10.d, p3, [x11, #-3, MUL VL]        : st1b   %z10.d %p3 -> -0x0c(%x11)[4byte]
+e46ef1ac : st1b z12.d, p4, [x13, #-2, MUL VL]        : st1b   %z12.d %p4 -> -0x08(%x13)[4byte]
+e46ff1ee : st1b z14.d, p4, [x15, #-1, MUL VL]        : st1b   %z14.d %p4 -> -0x04(%x15)[4byte]
 e460f630 : st1b z16.d, p5, [x17, #0, MUL VL]         : st1b   %z16.d %p5 -> (%x17)[4byte]
 e460f671 : st1b z17.d, p5, [x19, #0, MUL VL]         : st1b   %z17.d %p5 -> (%x19)[4byte]
-e461f6b3 : st1b z19.d, p5, [x21, #1, MUL VL]         : st1b   %z19.d %p5 -> +0x01(%x21)[4byte]
-e462faf5 : st1b z21.d, p6, [x23, #2, MUL VL]         : st1b   %z21.d %p6 -> +0x02(%x23)[4byte]
-e463fb17 : st1b z23.d, p6, [x24, #3, MUL VL]         : st1b   %z23.d %p6 -> +0x03(%x24)[4byte]
-e464ff59 : st1b z25.d, p7, [x26, #4, MUL VL]         : st1b   %z25.d %p7 -> +0x04(%x26)[4byte]
-e465ff9b : st1b z27.d, p7, [x28, #5, MUL VL]         : st1b   %z27.d %p7 -> +0x05(%x28)[4byte]
-e467ffff : st1b z31.d, p7, [sp, #7, MUL VL]          : st1b   %z31.d %p7 -> +0x07(%sp)[4byte]
+e461f6b3 : st1b z19.d, p5, [x21, #1, MUL VL]         : st1b   %z19.d %p5 -> +0x04(%x21)[4byte]
+e462faf5 : st1b z21.d, p6, [x23, #2, MUL VL]         : st1b   %z21.d %p6 -> +0x08(%x23)[4byte]
+e463fb17 : st1b z23.d, p6, [x24, #3, MUL VL]         : st1b   %z23.d %p6 -> +0x0c(%x24)[4byte]
+e464ff59 : st1b z25.d, p7, [x26, #4, MUL VL]         : st1b   %z25.d %p7 -> +0x10(%x26)[4byte]
+e465ff9b : st1b z27.d, p7, [x28, #5, MUL VL]         : st1b   %z27.d %p7 -> +0x14(%x28)[4byte]
+e467ffff : st1b z31.d, p7, [sp, #7, MUL VL]          : st1b   %z31.d %p7 -> +0x1c(%sp)[4byte]
 
 # ST1B    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] (ST1B-Z.P.BZ-S.x32.unscaled)
 e4408000 : st1b z0.s, p0, [x0, z0.s, UXTW]           : st1b   %z0.s %p0 -> (%x0,%z0.s,uxtw)[8byte]
@@ -21266,22 +21266,22 @@ e5fd5f9b : st1d z27.d, p7, [x28, x29, LSL #3]        : st1d   %z27.d %p7 -> (%x2
 e5fe5fff : st1d z31.d, p7, [sp, x30, LSL #3]         : st1d   %z31.d %p7 -> (%sp,%x30,lsl #3)[32byte]
 
 # ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST1D-Z.P.BI-_)
-e5e8e000 : st1d z0.d, p0, [x0, #-8, MUL VL]          : st1d   %z0.d %p0 -> -0x08(%x0)[32byte]
-e5e9e482 : st1d z2.d, p1, [x4, #-7, MUL VL]          : st1d   %z2.d %p1 -> -0x07(%x4)[32byte]
-e5eae8c4 : st1d z4.d, p2, [x6, #-6, MUL VL]          : st1d   %z4.d %p2 -> -0x06(%x6)[32byte]
-e5ebe906 : st1d z6.d, p2, [x8, #-5, MUL VL]          : st1d   %z6.d %p2 -> -0x05(%x8)[32byte]
-e5eced48 : st1d z8.d, p3, [x10, #-4, MUL VL]         : st1d   %z8.d %p3 -> -0x04(%x10)[32byte]
-e5eded6a : st1d z10.d, p3, [x11, #-3, MUL VL]        : st1d   %z10.d %p3 -> -0x03(%x11)[32byte]
-e5eef1ac : st1d z12.d, p4, [x13, #-2, MUL VL]        : st1d   %z12.d %p4 -> -0x02(%x13)[32byte]
-e5eff1ee : st1d z14.d, p4, [x15, #-1, MUL VL]        : st1d   %z14.d %p4 -> -0x01(%x15)[32byte]
+e5e8e000 : st1d z0.d, p0, [x0, #-8, MUL VL]          : st1d   %z0.d %p0 -> -0x0100(%x0)[32byte]
+e5e9e482 : st1d z2.d, p1, [x4, #-7, MUL VL]          : st1d   %z2.d %p1 -> -0xe0(%x4)[32byte]
+e5eae8c4 : st1d z4.d, p2, [x6, #-6, MUL VL]          : st1d   %z4.d %p2 -> -0xc0(%x6)[32byte]
+e5ebe906 : st1d z6.d, p2, [x8, #-5, MUL VL]          : st1d   %z6.d %p2 -> -0xa0(%x8)[32byte]
+e5eced48 : st1d z8.d, p3, [x10, #-4, MUL VL]         : st1d   %z8.d %p3 -> -0x80(%x10)[32byte]
+e5eded6a : st1d z10.d, p3, [x11, #-3, MUL VL]        : st1d   %z10.d %p3 -> -0x60(%x11)[32byte]
+e5eef1ac : st1d z12.d, p4, [x13, #-2, MUL VL]        : st1d   %z12.d %p4 -> -0x40(%x13)[32byte]
+e5eff1ee : st1d z14.d, p4, [x15, #-1, MUL VL]        : st1d   %z14.d %p4 -> -0x20(%x15)[32byte]
 e5e0f630 : st1d z16.d, p5, [x17, #0, MUL VL]         : st1d   %z16.d %p5 -> (%x17)[32byte]
 e5e0f671 : st1d z17.d, p5, [x19, #0, MUL VL]         : st1d   %z17.d %p5 -> (%x19)[32byte]
-e5e1f6b3 : st1d z19.d, p5, [x21, #1, MUL VL]         : st1d   %z19.d %p5 -> +0x01(%x21)[32byte]
-e5e2faf5 : st1d z21.d, p6, [x23, #2, MUL VL]         : st1d   %z21.d %p6 -> +0x02(%x23)[32byte]
-e5e3fb17 : st1d z23.d, p6, [x24, #3, MUL VL]         : st1d   %z23.d %p6 -> +0x03(%x24)[32byte]
-e5e4ff59 : st1d z25.d, p7, [x26, #4, MUL VL]         : st1d   %z25.d %p7 -> +0x04(%x26)[32byte]
-e5e5ff9b : st1d z27.d, p7, [x28, #5, MUL VL]         : st1d   %z27.d %p7 -> +0x05(%x28)[32byte]
-e5e7ffff : st1d z31.d, p7, [sp, #7, MUL VL]          : st1d   %z31.d %p7 -> +0x07(%sp)[32byte]
+e5e1f6b3 : st1d z19.d, p5, [x21, #1, MUL VL]         : st1d   %z19.d %p5 -> +0x20(%x21)[32byte]
+e5e2faf5 : st1d z21.d, p6, [x23, #2, MUL VL]         : st1d   %z21.d %p6 -> +0x40(%x23)[32byte]
+e5e3fb17 : st1d z23.d, p6, [x24, #3, MUL VL]         : st1d   %z23.d %p6 -> +0x60(%x24)[32byte]
+e5e4ff59 : st1d z25.d, p7, [x26, #4, MUL VL]         : st1d   %z25.d %p7 -> +0x80(%x26)[32byte]
+e5e5ff9b : st1d z27.d, p7, [x28, #5, MUL VL]         : st1d   %z27.d %p7 -> +0xa0(%x28)[32byte]
+e5e7ffff : st1d z31.d, p7, [sp, #7, MUL VL]          : st1d   %z31.d %p7 -> +0xe0(%sp)[32byte]
 
 # ST1H    { <Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D, <extend>] (ST1H-Z.P.BZ-D.x32.unscaled)
 e4808000 : st1h z0.d, p0, [x0, z0.d, UXTW]           : st1h   %z0.d %p0 -> (%x0,%z0.d,uxtw)[8byte]
@@ -21438,54 +21438,54 @@ e4bebf9b : st1h z27.d, p7, [x28, z30.d, LSL #1]      : st1h   %z27.d %p7 -> (%x2
 e4bfbfff : st1h z31.d, p7, [sp, z31.d, LSL #1]       : st1h   %z31.d %p7 -> (%sp,%z31.d,lsl #1)[8byte]
 
 # ST1H    { <Zt>.<T> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST1H-Z.P.BI-_)
-e4a8e000 : st1h z0.h, p0, [x0, #-8, MUL VL]          : st1h   %z0.h %p0 -> -0x08(%x0)[32byte]
-e4a9e482 : st1h z2.h, p1, [x4, #-7, MUL VL]          : st1h   %z2.h %p1 -> -0x07(%x4)[32byte]
-e4aae8c4 : st1h z4.h, p2, [x6, #-6, MUL VL]          : st1h   %z4.h %p2 -> -0x06(%x6)[32byte]
-e4abe906 : st1h z6.h, p2, [x8, #-5, MUL VL]          : st1h   %z6.h %p2 -> -0x05(%x8)[32byte]
-e4aced48 : st1h z8.h, p3, [x10, #-4, MUL VL]         : st1h   %z8.h %p3 -> -0x04(%x10)[32byte]
-e4aded6a : st1h z10.h, p3, [x11, #-3, MUL VL]        : st1h   %z10.h %p3 -> -0x03(%x11)[32byte]
-e4aef1ac : st1h z12.h, p4, [x13, #-2, MUL VL]        : st1h   %z12.h %p4 -> -0x02(%x13)[32byte]
-e4aff1ee : st1h z14.h, p4, [x15, #-1, MUL VL]        : st1h   %z14.h %p4 -> -0x01(%x15)[32byte]
+e4a8e000 : st1h z0.h, p0, [x0, #-8, MUL VL]          : st1h   %z0.h %p0 -> -0x0100(%x0)[32byte]
+e4a9e482 : st1h z2.h, p1, [x4, #-7, MUL VL]          : st1h   %z2.h %p1 -> -0xe0(%x4)[32byte]
+e4aae8c4 : st1h z4.h, p2, [x6, #-6, MUL VL]          : st1h   %z4.h %p2 -> -0xc0(%x6)[32byte]
+e4abe906 : st1h z6.h, p2, [x8, #-5, MUL VL]          : st1h   %z6.h %p2 -> -0xa0(%x8)[32byte]
+e4aced48 : st1h z8.h, p3, [x10, #-4, MUL VL]         : st1h   %z8.h %p3 -> -0x80(%x10)[32byte]
+e4aded6a : st1h z10.h, p3, [x11, #-3, MUL VL]        : st1h   %z10.h %p3 -> -0x60(%x11)[32byte]
+e4aef1ac : st1h z12.h, p4, [x13, #-2, MUL VL]        : st1h   %z12.h %p4 -> -0x40(%x13)[32byte]
+e4aff1ee : st1h z14.h, p4, [x15, #-1, MUL VL]        : st1h   %z14.h %p4 -> -0x20(%x15)[32byte]
 e4a0f630 : st1h z16.h, p5, [x17, #0, MUL VL]         : st1h   %z16.h %p5 -> (%x17)[32byte]
 e4a0f671 : st1h z17.h, p5, [x19, #0, MUL VL]         : st1h   %z17.h %p5 -> (%x19)[32byte]
-e4a1f6b3 : st1h z19.h, p5, [x21, #1, MUL VL]         : st1h   %z19.h %p5 -> +0x01(%x21)[32byte]
-e4a2faf5 : st1h z21.h, p6, [x23, #2, MUL VL]         : st1h   %z21.h %p6 -> +0x02(%x23)[32byte]
-e4a3fb17 : st1h z23.h, p6, [x24, #3, MUL VL]         : st1h   %z23.h %p6 -> +0x03(%x24)[32byte]
-e4a4ff59 : st1h z25.h, p7, [x26, #4, MUL VL]         : st1h   %z25.h %p7 -> +0x04(%x26)[32byte]
-e4a5ff9b : st1h z27.h, p7, [x28, #5, MUL VL]         : st1h   %z27.h %p7 -> +0x05(%x28)[32byte]
-e4a7ffff : st1h z31.h, p7, [sp, #7, MUL VL]          : st1h   %z31.h %p7 -> +0x07(%sp)[32byte]
-e4c8e000 : st1h z0.s, p0, [x0, #-8, MUL VL]          : st1h   %z0.s %p0 -> -0x08(%x0)[16byte]
-e4c9e482 : st1h z2.s, p1, [x4, #-7, MUL VL]          : st1h   %z2.s %p1 -> -0x07(%x4)[16byte]
-e4cae8c4 : st1h z4.s, p2, [x6, #-6, MUL VL]          : st1h   %z4.s %p2 -> -0x06(%x6)[16byte]
-e4cbe906 : st1h z6.s, p2, [x8, #-5, MUL VL]          : st1h   %z6.s %p2 -> -0x05(%x8)[16byte]
-e4cced48 : st1h z8.s, p3, [x10, #-4, MUL VL]         : st1h   %z8.s %p3 -> -0x04(%x10)[16byte]
-e4cded6a : st1h z10.s, p3, [x11, #-3, MUL VL]        : st1h   %z10.s %p3 -> -0x03(%x11)[16byte]
-e4cef1ac : st1h z12.s, p4, [x13, #-2, MUL VL]        : st1h   %z12.s %p4 -> -0x02(%x13)[16byte]
-e4cff1ee : st1h z14.s, p4, [x15, #-1, MUL VL]        : st1h   %z14.s %p4 -> -0x01(%x15)[16byte]
+e4a1f6b3 : st1h z19.h, p5, [x21, #1, MUL VL]         : st1h   %z19.h %p5 -> +0x20(%x21)[32byte]
+e4a2faf5 : st1h z21.h, p6, [x23, #2, MUL VL]         : st1h   %z21.h %p6 -> +0x40(%x23)[32byte]
+e4a3fb17 : st1h z23.h, p6, [x24, #3, MUL VL]         : st1h   %z23.h %p6 -> +0x60(%x24)[32byte]
+e4a4ff59 : st1h z25.h, p7, [x26, #4, MUL VL]         : st1h   %z25.h %p7 -> +0x80(%x26)[32byte]
+e4a5ff9b : st1h z27.h, p7, [x28, #5, MUL VL]         : st1h   %z27.h %p7 -> +0xa0(%x28)[32byte]
+e4a7ffff : st1h z31.h, p7, [sp, #7, MUL VL]          : st1h   %z31.h %p7 -> +0xe0(%sp)[32byte]
+e4c8e000 : st1h z0.s, p0, [x0, #-8, MUL VL]          : st1h   %z0.s %p0 -> -0x80(%x0)[16byte]
+e4c9e482 : st1h z2.s, p1, [x4, #-7, MUL VL]          : st1h   %z2.s %p1 -> -0x70(%x4)[16byte]
+e4cae8c4 : st1h z4.s, p2, [x6, #-6, MUL VL]          : st1h   %z4.s %p2 -> -0x60(%x6)[16byte]
+e4cbe906 : st1h z6.s, p2, [x8, #-5, MUL VL]          : st1h   %z6.s %p2 -> -0x50(%x8)[16byte]
+e4cced48 : st1h z8.s, p3, [x10, #-4, MUL VL]         : st1h   %z8.s %p3 -> -0x40(%x10)[16byte]
+e4cded6a : st1h z10.s, p3, [x11, #-3, MUL VL]        : st1h   %z10.s %p3 -> -0x30(%x11)[16byte]
+e4cef1ac : st1h z12.s, p4, [x13, #-2, MUL VL]        : st1h   %z12.s %p4 -> -0x20(%x13)[16byte]
+e4cff1ee : st1h z14.s, p4, [x15, #-1, MUL VL]        : st1h   %z14.s %p4 -> -0x10(%x15)[16byte]
 e4c0f630 : st1h z16.s, p5, [x17, #0, MUL VL]         : st1h   %z16.s %p5 -> (%x17)[16byte]
 e4c0f671 : st1h z17.s, p5, [x19, #0, MUL VL]         : st1h   %z17.s %p5 -> (%x19)[16byte]
-e4c1f6b3 : st1h z19.s, p5, [x21, #1, MUL VL]         : st1h   %z19.s %p5 -> +0x01(%x21)[16byte]
-e4c2faf5 : st1h z21.s, p6, [x23, #2, MUL VL]         : st1h   %z21.s %p6 -> +0x02(%x23)[16byte]
-e4c3fb17 : st1h z23.s, p6, [x24, #3, MUL VL]         : st1h   %z23.s %p6 -> +0x03(%x24)[16byte]
-e4c4ff59 : st1h z25.s, p7, [x26, #4, MUL VL]         : st1h   %z25.s %p7 -> +0x04(%x26)[16byte]
-e4c5ff9b : st1h z27.s, p7, [x28, #5, MUL VL]         : st1h   %z27.s %p7 -> +0x05(%x28)[16byte]
-e4c7ffff : st1h z31.s, p7, [sp, #7, MUL VL]          : st1h   %z31.s %p7 -> +0x07(%sp)[16byte]
-e4e8e000 : st1h z0.d, p0, [x0, #-8, MUL VL]          : st1h   %z0.d %p0 -> -0x08(%x0)[8byte]
-e4e9e482 : st1h z2.d, p1, [x4, #-7, MUL VL]          : st1h   %z2.d %p1 -> -0x07(%x4)[8byte]
-e4eae8c4 : st1h z4.d, p2, [x6, #-6, MUL VL]          : st1h   %z4.d %p2 -> -0x06(%x6)[8byte]
-e4ebe906 : st1h z6.d, p2, [x8, #-5, MUL VL]          : st1h   %z6.d %p2 -> -0x05(%x8)[8byte]
-e4eced48 : st1h z8.d, p3, [x10, #-4, MUL VL]         : st1h   %z8.d %p3 -> -0x04(%x10)[8byte]
-e4eded6a : st1h z10.d, p3, [x11, #-3, MUL VL]        : st1h   %z10.d %p3 -> -0x03(%x11)[8byte]
-e4eef1ac : st1h z12.d, p4, [x13, #-2, MUL VL]        : st1h   %z12.d %p4 -> -0x02(%x13)[8byte]
-e4eff1ee : st1h z14.d, p4, [x15, #-1, MUL VL]        : st1h   %z14.d %p4 -> -0x01(%x15)[8byte]
+e4c1f6b3 : st1h z19.s, p5, [x21, #1, MUL VL]         : st1h   %z19.s %p5 -> +0x10(%x21)[16byte]
+e4c2faf5 : st1h z21.s, p6, [x23, #2, MUL VL]         : st1h   %z21.s %p6 -> +0x20(%x23)[16byte]
+e4c3fb17 : st1h z23.s, p6, [x24, #3, MUL VL]         : st1h   %z23.s %p6 -> +0x30(%x24)[16byte]
+e4c4ff59 : st1h z25.s, p7, [x26, #4, MUL VL]         : st1h   %z25.s %p7 -> +0x40(%x26)[16byte]
+e4c5ff9b : st1h z27.s, p7, [x28, #5, MUL VL]         : st1h   %z27.s %p7 -> +0x50(%x28)[16byte]
+e4c7ffff : st1h z31.s, p7, [sp, #7, MUL VL]          : st1h   %z31.s %p7 -> +0x70(%sp)[16byte]
+e4e8e000 : st1h z0.d, p0, [x0, #-8, MUL VL]          : st1h   %z0.d %p0 -> -0x40(%x0)[8byte]
+e4e9e482 : st1h z2.d, p1, [x4, #-7, MUL VL]          : st1h   %z2.d %p1 -> -0x38(%x4)[8byte]
+e4eae8c4 : st1h z4.d, p2, [x6, #-6, MUL VL]          : st1h   %z4.d %p2 -> -0x30(%x6)[8byte]
+e4ebe906 : st1h z6.d, p2, [x8, #-5, MUL VL]          : st1h   %z6.d %p2 -> -0x28(%x8)[8byte]
+e4eced48 : st1h z8.d, p3, [x10, #-4, MUL VL]         : st1h   %z8.d %p3 -> -0x20(%x10)[8byte]
+e4eded6a : st1h z10.d, p3, [x11, #-3, MUL VL]        : st1h   %z10.d %p3 -> -0x18(%x11)[8byte]
+e4eef1ac : st1h z12.d, p4, [x13, #-2, MUL VL]        : st1h   %z12.d %p4 -> -0x10(%x13)[8byte]
+e4eff1ee : st1h z14.d, p4, [x15, #-1, MUL VL]        : st1h   %z14.d %p4 -> -0x08(%x15)[8byte]
 e4e0f630 : st1h z16.d, p5, [x17, #0, MUL VL]         : st1h   %z16.d %p5 -> (%x17)[8byte]
 e4e0f671 : st1h z17.d, p5, [x19, #0, MUL VL]         : st1h   %z17.d %p5 -> (%x19)[8byte]
-e4e1f6b3 : st1h z19.d, p5, [x21, #1, MUL VL]         : st1h   %z19.d %p5 -> +0x01(%x21)[8byte]
-e4e2faf5 : st1h z21.d, p6, [x23, #2, MUL VL]         : st1h   %z21.d %p6 -> +0x02(%x23)[8byte]
-e4e3fb17 : st1h z23.d, p6, [x24, #3, MUL VL]         : st1h   %z23.d %p6 -> +0x03(%x24)[8byte]
-e4e4ff59 : st1h z25.d, p7, [x26, #4, MUL VL]         : st1h   %z25.d %p7 -> +0x04(%x26)[8byte]
-e4e5ff9b : st1h z27.d, p7, [x28, #5, MUL VL]         : st1h   %z27.d %p7 -> +0x05(%x28)[8byte]
-e4e7ffff : st1h z31.d, p7, [sp, #7, MUL VL]          : st1h   %z31.d %p7 -> +0x07(%sp)[8byte]
+e4e1f6b3 : st1h z19.d, p5, [x21, #1, MUL VL]         : st1h   %z19.d %p5 -> +0x08(%x21)[8byte]
+e4e2faf5 : st1h z21.d, p6, [x23, #2, MUL VL]         : st1h   %z21.d %p6 -> +0x10(%x23)[8byte]
+e4e3fb17 : st1h z23.d, p6, [x24, #3, MUL VL]         : st1h   %z23.d %p6 -> +0x18(%x24)[8byte]
+e4e4ff59 : st1h z25.d, p7, [x26, #4, MUL VL]         : st1h   %z25.d %p7 -> +0x20(%x26)[8byte]
+e4e5ff9b : st1h z27.d, p7, [x28, #5, MUL VL]         : st1h   %z27.d %p7 -> +0x28(%x28)[8byte]
+e4e7ffff : st1h z31.d, p7, [sp, #7, MUL VL]          : st1h   %z31.d %p7 -> +0x38(%sp)[8byte]
 
 # ST1H    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend>] (ST1H-Z.P.BZ-S.x32.unscaled)
 e4c08000 : st1h z0.s, p0, [x0, z0.s, UXTW]           : st1h   %z0.s %p0 -> (%x0,%z0.s,uxtw)[16byte]
@@ -21782,38 +21782,38 @@ e55bbfbb : st1w z27.d, p7, [z29.d, #108]             : st1w   %z27.d %p7 -> +0x6
 e55fbfff : st1w z31.d, p7, [z31.d, #124]             : st1w   %z31.d %p7 -> +0x7c(%z31.d)[16byte]
 
 # ST1W    { <Zt>.<T> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST1W-Z.P.BI-_)
-e548e000 : st1w z0.s, p0, [x0, #-8, MUL VL]          : st1w   %z0.s %p0 -> -0x08(%x0)[32byte]
-e549e482 : st1w z2.s, p1, [x4, #-7, MUL VL]          : st1w   %z2.s %p1 -> -0x07(%x4)[32byte]
-e54ae8c4 : st1w z4.s, p2, [x6, #-6, MUL VL]          : st1w   %z4.s %p2 -> -0x06(%x6)[32byte]
-e54be906 : st1w z6.s, p2, [x8, #-5, MUL VL]          : st1w   %z6.s %p2 -> -0x05(%x8)[32byte]
-e54ced48 : st1w z8.s, p3, [x10, #-4, MUL VL]         : st1w   %z8.s %p3 -> -0x04(%x10)[32byte]
-e54ded6a : st1w z10.s, p3, [x11, #-3, MUL VL]        : st1w   %z10.s %p3 -> -0x03(%x11)[32byte]
-e54ef1ac : st1w z12.s, p4, [x13, #-2, MUL VL]        : st1w   %z12.s %p4 -> -0x02(%x13)[32byte]
-e54ff1ee : st1w z14.s, p4, [x15, #-1, MUL VL]        : st1w   %z14.s %p4 -> -0x01(%x15)[32byte]
+e548e000 : st1w z0.s, p0, [x0, #-8, MUL VL]          : st1w   %z0.s %p0 -> -0x0100(%x0)[32byte]
+e549e482 : st1w z2.s, p1, [x4, #-7, MUL VL]          : st1w   %z2.s %p1 -> -0xe0(%x4)[32byte]
+e54ae8c4 : st1w z4.s, p2, [x6, #-6, MUL VL]          : st1w   %z4.s %p2 -> -0xc0(%x6)[32byte]
+e54be906 : st1w z6.s, p2, [x8, #-5, MUL VL]          : st1w   %z6.s %p2 -> -0xa0(%x8)[32byte]
+e54ced48 : st1w z8.s, p3, [x10, #-4, MUL VL]         : st1w   %z8.s %p3 -> -0x80(%x10)[32byte]
+e54ded6a : st1w z10.s, p3, [x11, #-3, MUL VL]        : st1w   %z10.s %p3 -> -0x60(%x11)[32byte]
+e54ef1ac : st1w z12.s, p4, [x13, #-2, MUL VL]        : st1w   %z12.s %p4 -> -0x40(%x13)[32byte]
+e54ff1ee : st1w z14.s, p4, [x15, #-1, MUL VL]        : st1w   %z14.s %p4 -> -0x20(%x15)[32byte]
 e540f630 : st1w z16.s, p5, [x17, #0, MUL VL]         : st1w   %z16.s %p5 -> (%x17)[32byte]
 e540f671 : st1w z17.s, p5, [x19, #0, MUL VL]         : st1w   %z17.s %p5 -> (%x19)[32byte]
-e541f6b3 : st1w z19.s, p5, [x21, #1, MUL VL]         : st1w   %z19.s %p5 -> +0x01(%x21)[32byte]
-e542faf5 : st1w z21.s, p6, [x23, #2, MUL VL]         : st1w   %z21.s %p6 -> +0x02(%x23)[32byte]
-e543fb17 : st1w z23.s, p6, [x24, #3, MUL VL]         : st1w   %z23.s %p6 -> +0x03(%x24)[32byte]
-e544ff59 : st1w z25.s, p7, [x26, #4, MUL VL]         : st1w   %z25.s %p7 -> +0x04(%x26)[32byte]
-e545ff9b : st1w z27.s, p7, [x28, #5, MUL VL]         : st1w   %z27.s %p7 -> +0x05(%x28)[32byte]
-e547ffff : st1w z31.s, p7, [sp, #7, MUL VL]          : st1w   %z31.s %p7 -> +0x07(%sp)[32byte]
-e568e000 : st1w z0.d, p0, [x0, #-8, MUL VL]          : st1w   %z0.d %p0 -> -0x08(%x0)[16byte]
-e569e482 : st1w z2.d, p1, [x4, #-7, MUL VL]          : st1w   %z2.d %p1 -> -0x07(%x4)[16byte]
-e56ae8c4 : st1w z4.d, p2, [x6, #-6, MUL VL]          : st1w   %z4.d %p2 -> -0x06(%x6)[16byte]
-e56be906 : st1w z6.d, p2, [x8, #-5, MUL VL]          : st1w   %z6.d %p2 -> -0x05(%x8)[16byte]
-e56ced48 : st1w z8.d, p3, [x10, #-4, MUL VL]         : st1w   %z8.d %p3 -> -0x04(%x10)[16byte]
-e56ded6a : st1w z10.d, p3, [x11, #-3, MUL VL]        : st1w   %z10.d %p3 -> -0x03(%x11)[16byte]
-e56ef1ac : st1w z12.d, p4, [x13, #-2, MUL VL]        : st1w   %z12.d %p4 -> -0x02(%x13)[16byte]
-e56ff1ee : st1w z14.d, p4, [x15, #-1, MUL VL]        : st1w   %z14.d %p4 -> -0x01(%x15)[16byte]
+e541f6b3 : st1w z19.s, p5, [x21, #1, MUL VL]         : st1w   %z19.s %p5 -> +0x20(%x21)[32byte]
+e542faf5 : st1w z21.s, p6, [x23, #2, MUL VL]         : st1w   %z21.s %p6 -> +0x40(%x23)[32byte]
+e543fb17 : st1w z23.s, p6, [x24, #3, MUL VL]         : st1w   %z23.s %p6 -> +0x60(%x24)[32byte]
+e544ff59 : st1w z25.s, p7, [x26, #4, MUL VL]         : st1w   %z25.s %p7 -> +0x80(%x26)[32byte]
+e545ff9b : st1w z27.s, p7, [x28, #5, MUL VL]         : st1w   %z27.s %p7 -> +0xa0(%x28)[32byte]
+e547ffff : st1w z31.s, p7, [sp, #7, MUL VL]          : st1w   %z31.s %p7 -> +0xe0(%sp)[32byte]
+e568e000 : st1w z0.d, p0, [x0, #-8, MUL VL]          : st1w   %z0.d %p0 -> -0x80(%x0)[16byte]
+e569e482 : st1w z2.d, p1, [x4, #-7, MUL VL]          : st1w   %z2.d %p1 -> -0x70(%x4)[16byte]
+e56ae8c4 : st1w z4.d, p2, [x6, #-6, MUL VL]          : st1w   %z4.d %p2 -> -0x60(%x6)[16byte]
+e56be906 : st1w z6.d, p2, [x8, #-5, MUL VL]          : st1w   %z6.d %p2 -> -0x50(%x8)[16byte]
+e56ced48 : st1w z8.d, p3, [x10, #-4, MUL VL]         : st1w   %z8.d %p3 -> -0x40(%x10)[16byte]
+e56ded6a : st1w z10.d, p3, [x11, #-3, MUL VL]        : st1w   %z10.d %p3 -> -0x30(%x11)[16byte]
+e56ef1ac : st1w z12.d, p4, [x13, #-2, MUL VL]        : st1w   %z12.d %p4 -> -0x20(%x13)[16byte]
+e56ff1ee : st1w z14.d, p4, [x15, #-1, MUL VL]        : st1w   %z14.d %p4 -> -0x10(%x15)[16byte]
 e560f630 : st1w z16.d, p5, [x17, #0, MUL VL]         : st1w   %z16.d %p5 -> (%x17)[16byte]
 e560f671 : st1w z17.d, p5, [x19, #0, MUL VL]         : st1w   %z17.d %p5 -> (%x19)[16byte]
-e561f6b3 : st1w z19.d, p5, [x21, #1, MUL VL]         : st1w   %z19.d %p5 -> +0x01(%x21)[16byte]
-e562faf5 : st1w z21.d, p6, [x23, #2, MUL VL]         : st1w   %z21.d %p6 -> +0x02(%x23)[16byte]
-e563fb17 : st1w z23.d, p6, [x24, #3, MUL VL]         : st1w   %z23.d %p6 -> +0x03(%x24)[16byte]
-e564ff59 : st1w z25.d, p7, [x26, #4, MUL VL]         : st1w   %z25.d %p7 -> +0x04(%x26)[16byte]
-e565ff9b : st1w z27.d, p7, [x28, #5, MUL VL]         : st1w   %z27.d %p7 -> +0x05(%x28)[16byte]
-e567ffff : st1w z31.d, p7, [sp, #7, MUL VL]          : st1w   %z31.d %p7 -> +0x07(%sp)[16byte]
+e561f6b3 : st1w z19.d, p5, [x21, #1, MUL VL]         : st1w   %z19.d %p5 -> +0x10(%x21)[16byte]
+e562faf5 : st1w z21.d, p6, [x23, #2, MUL VL]         : st1w   %z21.d %p6 -> +0x20(%x23)[16byte]
+e563fb17 : st1w z23.d, p6, [x24, #3, MUL VL]         : st1w   %z23.d %p6 -> +0x30(%x24)[16byte]
+e564ff59 : st1w z25.d, p7, [x26, #4, MUL VL]         : st1w   %z25.d %p7 -> +0x40(%x26)[16byte]
+e565ff9b : st1w z27.d, p7, [x28, #5, MUL VL]         : st1w   %z27.d %p7 -> +0x50(%x28)[16byte]
+e567ffff : st1w z31.d, p7, [sp, #7, MUL VL]          : st1w   %z31.d %p7 -> +0x70(%sp)[16byte]
 
 # ST1W    { <Zt>.S }, <Pg>, [<Xn|SP>, <Zm>.S, <extend> #2] (ST1W-Z.P.BZ-S.x32.scaled)
 e5608000 : st1w z0.s, p0, [x0, z0.s, UXTW #2]        : st1w   %z0.s %p0 -> (%x0,%z0.s,uxtw #2)[32byte]
@@ -21886,22 +21886,22 @@ e43d7f9b : st2b {z27.b, z28.b}, p7, [x28, x29]       : st2b   %z27.b %z28.b %p7 
 e43e7fff : st2b {z31.b, z0.b}, p7, [sp, x30]         : st2b   %z31.b %z0.b %p7 -> (%sp,%x30)[64byte]
 
 # ST2B    { <Zt1>.B, <Zt2>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST2B-Z.P.BI-Contiguous)
-e438e000 : st2b {z0.b, z1.b}, p0, [x0, #-16, MUL VL] : st2b   %z0.b %z1.b %p0 -> -0x10(%x0)[64byte]
-e439e482 : st2b {z2.b, z3.b}, p1, [x4, #-14, MUL VL] : st2b   %z2.b %z3.b %p1 -> -0x0e(%x4)[64byte]
-e43ae8c4 : st2b {z4.b, z5.b}, p2, [x6, #-12, MUL VL] : st2b   %z4.b %z5.b %p2 -> -0x0c(%x6)[64byte]
-e43be906 : st2b {z6.b, z7.b}, p2, [x8, #-10, MUL VL] : st2b   %z6.b %z7.b %p2 -> -0x0a(%x8)[64byte]
-e43ced48 : st2b {z8.b, z9.b}, p3, [x10, #-8, MUL VL] : st2b   %z8.b %z9.b %p3 -> -0x08(%x10)[64byte]
-e43ded6a : st2b {z10.b, z11.b}, p3, [x11, #-6, MUL VL] : st2b   %z10.b %z11.b %p3 -> -0x06(%x11)[64byte]
-e43ef1ac : st2b {z12.b, z13.b}, p4, [x13, #-4, MUL VL] : st2b   %z12.b %z13.b %p4 -> -0x04(%x13)[64byte]
-e43ff1ee : st2b {z14.b, z15.b}, p4, [x15, #-2, MUL VL] : st2b   %z14.b %z15.b %p4 -> -0x02(%x15)[64byte]
+e438e000 : st2b {z0.b, z1.b}, p0, [x0, #-16, MUL VL] : st2b   %z0.b %z1.b %p0 -> -0x0200(%x0)[64byte]
+e439e482 : st2b {z2.b, z3.b}, p1, [x4, #-14, MUL VL] : st2b   %z2.b %z3.b %p1 -> -0x01c0(%x4)[64byte]
+e43ae8c4 : st2b {z4.b, z5.b}, p2, [x6, #-12, MUL VL] : st2b   %z4.b %z5.b %p2 -> -0x0180(%x6)[64byte]
+e43be906 : st2b {z6.b, z7.b}, p2, [x8, #-10, MUL VL] : st2b   %z6.b %z7.b %p2 -> -0x0140(%x8)[64byte]
+e43ced48 : st2b {z8.b, z9.b}, p3, [x10, #-8, MUL VL] : st2b   %z8.b %z9.b %p3 -> -0x0100(%x10)[64byte]
+e43ded6a : st2b {z10.b, z11.b}, p3, [x11, #-6, MUL VL] : st2b   %z10.b %z11.b %p3 -> -0xc0(%x11)[64byte]
+e43ef1ac : st2b {z12.b, z13.b}, p4, [x13, #-4, MUL VL] : st2b   %z12.b %z13.b %p4 -> -0x80(%x13)[64byte]
+e43ff1ee : st2b {z14.b, z15.b}, p4, [x15, #-2, MUL VL] : st2b   %z14.b %z15.b %p4 -> -0x40(%x15)[64byte]
 e430f630 : st2b {z16.b, z17.b}, p5, [x17, #0, MUL VL] : st2b   %z16.b %z17.b %p5 -> (%x17)[64byte]
 e430f671 : st2b {z17.b, z18.b}, p5, [x19, #0, MUL VL] : st2b   %z17.b %z18.b %p5 -> (%x19)[64byte]
-e431f6b3 : st2b {z19.b, z20.b}, p5, [x21, #2, MUL VL] : st2b   %z19.b %z20.b %p5 -> +0x02(%x21)[64byte]
-e432faf5 : st2b {z21.b, z22.b}, p6, [x23, #4, MUL VL] : st2b   %z21.b %z22.b %p6 -> +0x04(%x23)[64byte]
-e433fb17 : st2b {z23.b, z24.b}, p6, [x24, #6, MUL VL] : st2b   %z23.b %z24.b %p6 -> +0x06(%x24)[64byte]
-e434ff59 : st2b {z25.b, z26.b}, p7, [x26, #8, MUL VL] : st2b   %z25.b %z26.b %p7 -> +0x08(%x26)[64byte]
-e435ff9b : st2b {z27.b, z28.b}, p7, [x28, #10, MUL VL] : st2b   %z27.b %z28.b %p7 -> +0x0a(%x28)[64byte]
-e437ffff : st2b {z31.b, z0.b}, p7, [sp, #14, MUL VL] : st2b   %z31.b %z0.b %p7 -> +0x0e(%sp)[64byte]
+e431f6b3 : st2b {z19.b, z20.b}, p5, [x21, #2, MUL VL] : st2b   %z19.b %z20.b %p5 -> +0x40(%x21)[64byte]
+e432faf5 : st2b {z21.b, z22.b}, p6, [x23, #4, MUL VL] : st2b   %z21.b %z22.b %p6 -> +0x80(%x23)[64byte]
+e433fb17 : st2b {z23.b, z24.b}, p6, [x24, #6, MUL VL] : st2b   %z23.b %z24.b %p6 -> +0xc0(%x24)[64byte]
+e434ff59 : st2b {z25.b, z26.b}, p7, [x26, #8, MUL VL] : st2b   %z25.b %z26.b %p7 -> +0x0100(%x26)[64byte]
+e435ff9b : st2b {z27.b, z28.b}, p7, [x28, #10, MUL VL] : st2b   %z27.b %z28.b %p7 -> +0x0140(%x28)[64byte]
+e437ffff : st2b {z31.b, z0.b}, p7, [sp, #14, MUL VL] : st2b   %z31.b %z0.b %p7 -> +0x01c0(%sp)[64byte]
 
 # ST2D    { <Zt1>.D, <Zt2>.D }, <Pg>, [<Xn|SP>, <Xm>, LSL #3] (ST2D-Z.P.BR-Contiguous)
 e5a06000 : st2d {z0.d, z1.d}, p0, [x0, x0, LSL #3]   : st2d   %z0.d %z1.d %p0 -> (%x0,%x0,lsl #3)[64byte]
@@ -21922,22 +21922,22 @@ e5bd7f9b : st2d {z27.d, z28.d}, p7, [x28, x29, LSL #3] : st2d   %z27.d %z28.d %p
 e5be7fff : st2d {z31.d, z0.d}, p7, [sp, x30, LSL #3] : st2d   %z31.d %z0.d %p7 -> (%sp,%x30,lsl #3)[64byte]
 
 # ST2D    { <Zt1>.D, <Zt2>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST2D-Z.P.BI-Contiguous)
-e5b8e000 : st2d {z0.d, z1.d}, p0, [x0, #-16, MUL VL] : st2d   %z0.d %z1.d %p0 -> -0x10(%x0)[64byte]
-e5b9e482 : st2d {z2.d, z3.d}, p1, [x4, #-14, MUL VL] : st2d   %z2.d %z3.d %p1 -> -0x0e(%x4)[64byte]
-e5bae8c4 : st2d {z4.d, z5.d}, p2, [x6, #-12, MUL VL] : st2d   %z4.d %z5.d %p2 -> -0x0c(%x6)[64byte]
-e5bbe906 : st2d {z6.d, z7.d}, p2, [x8, #-10, MUL VL] : st2d   %z6.d %z7.d %p2 -> -0x0a(%x8)[64byte]
-e5bced48 : st2d {z8.d, z9.d}, p3, [x10, #-8, MUL VL] : st2d   %z8.d %z9.d %p3 -> -0x08(%x10)[64byte]
-e5bded6a : st2d {z10.d, z11.d}, p3, [x11, #-6, MUL VL] : st2d   %z10.d %z11.d %p3 -> -0x06(%x11)[64byte]
-e5bef1ac : st2d {z12.d, z13.d}, p4, [x13, #-4, MUL VL] : st2d   %z12.d %z13.d %p4 -> -0x04(%x13)[64byte]
-e5bff1ee : st2d {z14.d, z15.d}, p4, [x15, #-2, MUL VL] : st2d   %z14.d %z15.d %p4 -> -0x02(%x15)[64byte]
+e5b8e000 : st2d {z0.d, z1.d}, p0, [x0, #-16, MUL VL] : st2d   %z0.d %z1.d %p0 -> -0x0200(%x0)[64byte]
+e5b9e482 : st2d {z2.d, z3.d}, p1, [x4, #-14, MUL VL] : st2d   %z2.d %z3.d %p1 -> -0x01c0(%x4)[64byte]
+e5bae8c4 : st2d {z4.d, z5.d}, p2, [x6, #-12, MUL VL] : st2d   %z4.d %z5.d %p2 -> -0x0180(%x6)[64byte]
+e5bbe906 : st2d {z6.d, z7.d}, p2, [x8, #-10, MUL VL] : st2d   %z6.d %z7.d %p2 -> -0x0140(%x8)[64byte]
+e5bced48 : st2d {z8.d, z9.d}, p3, [x10, #-8, MUL VL] : st2d   %z8.d %z9.d %p3 -> -0x0100(%x10)[64byte]
+e5bded6a : st2d {z10.d, z11.d}, p3, [x11, #-6, MUL VL] : st2d   %z10.d %z11.d %p3 -> -0xc0(%x11)[64byte]
+e5bef1ac : st2d {z12.d, z13.d}, p4, [x13, #-4, MUL VL] : st2d   %z12.d %z13.d %p4 -> -0x80(%x13)[64byte]
+e5bff1ee : st2d {z14.d, z15.d}, p4, [x15, #-2, MUL VL] : st2d   %z14.d %z15.d %p4 -> -0x40(%x15)[64byte]
 e5b0f630 : st2d {z16.d, z17.d}, p5, [x17, #0, MUL VL] : st2d   %z16.d %z17.d %p5 -> (%x17)[64byte]
 e5b0f671 : st2d {z17.d, z18.d}, p5, [x19, #0, MUL VL] : st2d   %z17.d %z18.d %p5 -> (%x19)[64byte]
-e5b1f6b3 : st2d {z19.d, z20.d}, p5, [x21, #2, MUL VL] : st2d   %z19.d %z20.d %p5 -> +0x02(%x21)[64byte]
-e5b2faf5 : st2d {z21.d, z22.d}, p6, [x23, #4, MUL VL] : st2d   %z21.d %z22.d %p6 -> +0x04(%x23)[64byte]
-e5b3fb17 : st2d {z23.d, z24.d}, p6, [x24, #6, MUL VL] : st2d   %z23.d %z24.d %p6 -> +0x06(%x24)[64byte]
-e5b4ff59 : st2d {z25.d, z26.d}, p7, [x26, #8, MUL VL] : st2d   %z25.d %z26.d %p7 -> +0x08(%x26)[64byte]
-e5b5ff9b : st2d {z27.d, z28.d}, p7, [x28, #10, MUL VL] : st2d   %z27.d %z28.d %p7 -> +0x0a(%x28)[64byte]
-e5b7ffff : st2d {z31.d, z0.d}, p7, [sp, #14, MUL VL] : st2d   %z31.d %z0.d %p7 -> +0x0e(%sp)[64byte]
+e5b1f6b3 : st2d {z19.d, z20.d}, p5, [x21, #2, MUL VL] : st2d   %z19.d %z20.d %p5 -> +0x40(%x21)[64byte]
+e5b2faf5 : st2d {z21.d, z22.d}, p6, [x23, #4, MUL VL] : st2d   %z21.d %z22.d %p6 -> +0x80(%x23)[64byte]
+e5b3fb17 : st2d {z23.d, z24.d}, p6, [x24, #6, MUL VL] : st2d   %z23.d %z24.d %p6 -> +0xc0(%x24)[64byte]
+e5b4ff59 : st2d {z25.d, z26.d}, p7, [x26, #8, MUL VL] : st2d   %z25.d %z26.d %p7 -> +0x0100(%x26)[64byte]
+e5b5ff9b : st2d {z27.d, z28.d}, p7, [x28, #10, MUL VL] : st2d   %z27.d %z28.d %p7 -> +0x0140(%x28)[64byte]
+e5b7ffff : st2d {z31.d, z0.d}, p7, [sp, #14, MUL VL] : st2d   %z31.d %z0.d %p7 -> +0x01c0(%sp)[64byte]
 
 # ST2H    { <Zt1>.H, <Zt2>.H }, <Pg>, [<Xn|SP>, <Xm>, LSL #1] (ST2H-Z.P.BR-Contiguous)
 e4a06000 : st2h {z0.h, z1.h}, p0, [x0, x0, LSL #1]   : st2h   %z0.h %z1.h %p0 -> (%x0,%x0,lsl #1)[64byte]
@@ -21958,22 +21958,22 @@ e4bd7f9b : st2h {z27.h, z28.h}, p7, [x28, x29, LSL #1] : st2h   %z27.h %z28.h %p
 e4be7fff : st2h {z31.h, z0.h}, p7, [sp, x30, LSL #1] : st2h   %z31.h %z0.h %p7 -> (%sp,%x30,lsl #1)[64byte]
 
 # ST2H    { <Zt1>.H, <Zt2>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST2H-Z.P.BI-Contiguous)
-e4b8e000 : st2h {z0.h, z1.h}, p0, [x0, #-16, MUL VL] : st2h   %z0.h %z1.h %p0 -> -0x10(%x0)[64byte]
-e4b9e482 : st2h {z2.h, z3.h}, p1, [x4, #-14, MUL VL] : st2h   %z2.h %z3.h %p1 -> -0x0e(%x4)[64byte]
-e4bae8c4 : st2h {z4.h, z5.h}, p2, [x6, #-12, MUL VL] : st2h   %z4.h %z5.h %p2 -> -0x0c(%x6)[64byte]
-e4bbe906 : st2h {z6.h, z7.h}, p2, [x8, #-10, MUL VL] : st2h   %z6.h %z7.h %p2 -> -0x0a(%x8)[64byte]
-e4bced48 : st2h {z8.h, z9.h}, p3, [x10, #-8, MUL VL] : st2h   %z8.h %z9.h %p3 -> -0x08(%x10)[64byte]
-e4bded6a : st2h {z10.h, z11.h}, p3, [x11, #-6, MUL VL] : st2h   %z10.h %z11.h %p3 -> -0x06(%x11)[64byte]
-e4bef1ac : st2h {z12.h, z13.h}, p4, [x13, #-4, MUL VL] : st2h   %z12.h %z13.h %p4 -> -0x04(%x13)[64byte]
-e4bff1ee : st2h {z14.h, z15.h}, p4, [x15, #-2, MUL VL] : st2h   %z14.h %z15.h %p4 -> -0x02(%x15)[64byte]
+e4b8e000 : st2h {z0.h, z1.h}, p0, [x0, #-16, MUL VL] : st2h   %z0.h %z1.h %p0 -> -0x0200(%x0)[64byte]
+e4b9e482 : st2h {z2.h, z3.h}, p1, [x4, #-14, MUL VL] : st2h   %z2.h %z3.h %p1 -> -0x01c0(%x4)[64byte]
+e4bae8c4 : st2h {z4.h, z5.h}, p2, [x6, #-12, MUL VL] : st2h   %z4.h %z5.h %p2 -> -0x0180(%x6)[64byte]
+e4bbe906 : st2h {z6.h, z7.h}, p2, [x8, #-10, MUL VL] : st2h   %z6.h %z7.h %p2 -> -0x0140(%x8)[64byte]
+e4bced48 : st2h {z8.h, z9.h}, p3, [x10, #-8, MUL VL] : st2h   %z8.h %z9.h %p3 -> -0x0100(%x10)[64byte]
+e4bded6a : st2h {z10.h, z11.h}, p3, [x11, #-6, MUL VL] : st2h   %z10.h %z11.h %p3 -> -0xc0(%x11)[64byte]
+e4bef1ac : st2h {z12.h, z13.h}, p4, [x13, #-4, MUL VL] : st2h   %z12.h %z13.h %p4 -> -0x80(%x13)[64byte]
+e4bff1ee : st2h {z14.h, z15.h}, p4, [x15, #-2, MUL VL] : st2h   %z14.h %z15.h %p4 -> -0x40(%x15)[64byte]
 e4b0f630 : st2h {z16.h, z17.h}, p5, [x17, #0, MUL VL] : st2h   %z16.h %z17.h %p5 -> (%x17)[64byte]
 e4b0f671 : st2h {z17.h, z18.h}, p5, [x19, #0, MUL VL] : st2h   %z17.h %z18.h %p5 -> (%x19)[64byte]
-e4b1f6b3 : st2h {z19.h, z20.h}, p5, [x21, #2, MUL VL] : st2h   %z19.h %z20.h %p5 -> +0x02(%x21)[64byte]
-e4b2faf5 : st2h {z21.h, z22.h}, p6, [x23, #4, MUL VL] : st2h   %z21.h %z22.h %p6 -> +0x04(%x23)[64byte]
-e4b3fb17 : st2h {z23.h, z24.h}, p6, [x24, #6, MUL VL] : st2h   %z23.h %z24.h %p6 -> +0x06(%x24)[64byte]
-e4b4ff59 : st2h {z25.h, z26.h}, p7, [x26, #8, MUL VL] : st2h   %z25.h %z26.h %p7 -> +0x08(%x26)[64byte]
-e4b5ff9b : st2h {z27.h, z28.h}, p7, [x28, #10, MUL VL] : st2h   %z27.h %z28.h %p7 -> +0x0a(%x28)[64byte]
-e4b7ffff : st2h {z31.h, z0.h}, p7, [sp, #14, MUL VL] : st2h   %z31.h %z0.h %p7 -> +0x0e(%sp)[64byte]
+e4b1f6b3 : st2h {z19.h, z20.h}, p5, [x21, #2, MUL VL] : st2h   %z19.h %z20.h %p5 -> +0x40(%x21)[64byte]
+e4b2faf5 : st2h {z21.h, z22.h}, p6, [x23, #4, MUL VL] : st2h   %z21.h %z22.h %p6 -> +0x80(%x23)[64byte]
+e4b3fb17 : st2h {z23.h, z24.h}, p6, [x24, #6, MUL VL] : st2h   %z23.h %z24.h %p6 -> +0xc0(%x24)[64byte]
+e4b4ff59 : st2h {z25.h, z26.h}, p7, [x26, #8, MUL VL] : st2h   %z25.h %z26.h %p7 -> +0x0100(%x26)[64byte]
+e4b5ff9b : st2h {z27.h, z28.h}, p7, [x28, #10, MUL VL] : st2h   %z27.h %z28.h %p7 -> +0x0140(%x28)[64byte]
+e4b7ffff : st2h {z31.h, z0.h}, p7, [sp, #14, MUL VL] : st2h   %z31.h %z0.h %p7 -> +0x01c0(%sp)[64byte]
 
 # ST2W    { <Zt1>.S, <Zt2>.S }, <Pg>, [<Xn|SP>, <Xm>, LSL #2] (ST2W-Z.P.BR-Contiguous)
 e5206000 : st2w {z0.s, z1.s}, p0, [x0, x0, LSL #2]   : st2w   %z0.s %z1.s %p0 -> (%x0,%x0,lsl #2)[64byte]
@@ -21994,22 +21994,22 @@ e53d7f9b : st2w {z27.s, z28.s}, p7, [x28, x29, LSL #2] : st2w   %z27.s %z28.s %p
 e53e7fff : st2w {z31.s, z0.s}, p7, [sp, x30, LSL #2] : st2w   %z31.s %z0.s %p7 -> (%sp,%x30,lsl #2)[64byte]
 
 # ST2W    { <Zt1>.S, <Zt2>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST2W-Z.P.BI-Contiguous)
-e538e000 : st2w {z0.s, z1.s}, p0, [x0, #-16, MUL VL] : st2w   %z0.s %z1.s %p0 -> -0x10(%x0)[64byte]
-e539e482 : st2w {z2.s, z3.s}, p1, [x4, #-14, MUL VL] : st2w   %z2.s %z3.s %p1 -> -0x0e(%x4)[64byte]
-e53ae8c4 : st2w {z4.s, z5.s}, p2, [x6, #-12, MUL VL] : st2w   %z4.s %z5.s %p2 -> -0x0c(%x6)[64byte]
-e53be906 : st2w {z6.s, z7.s}, p2, [x8, #-10, MUL VL] : st2w   %z6.s %z7.s %p2 -> -0x0a(%x8)[64byte]
-e53ced48 : st2w {z8.s, z9.s}, p3, [x10, #-8, MUL VL] : st2w   %z8.s %z9.s %p3 -> -0x08(%x10)[64byte]
-e53ded6a : st2w {z10.s, z11.s}, p3, [x11, #-6, MUL VL] : st2w   %z10.s %z11.s %p3 -> -0x06(%x11)[64byte]
-e53ef1ac : st2w {z12.s, z13.s}, p4, [x13, #-4, MUL VL] : st2w   %z12.s %z13.s %p4 -> -0x04(%x13)[64byte]
-e53ff1ee : st2w {z14.s, z15.s}, p4, [x15, #-2, MUL VL] : st2w   %z14.s %z15.s %p4 -> -0x02(%x15)[64byte]
+e538e000 : st2w {z0.s, z1.s}, p0, [x0, #-16, MUL VL] : st2w   %z0.s %z1.s %p0 -> -0x0200(%x0)[64byte]
+e539e482 : st2w {z2.s, z3.s}, p1, [x4, #-14, MUL VL] : st2w   %z2.s %z3.s %p1 -> -0x01c0(%x4)[64byte]
+e53ae8c4 : st2w {z4.s, z5.s}, p2, [x6, #-12, MUL VL] : st2w   %z4.s %z5.s %p2 -> -0x0180(%x6)[64byte]
+e53be906 : st2w {z6.s, z7.s}, p2, [x8, #-10, MUL VL] : st2w   %z6.s %z7.s %p2 -> -0x0140(%x8)[64byte]
+e53ced48 : st2w {z8.s, z9.s}, p3, [x10, #-8, MUL VL] : st2w   %z8.s %z9.s %p3 -> -0x0100(%x10)[64byte]
+e53ded6a : st2w {z10.s, z11.s}, p3, [x11, #-6, MUL VL] : st2w   %z10.s %z11.s %p3 -> -0xc0(%x11)[64byte]
+e53ef1ac : st2w {z12.s, z13.s}, p4, [x13, #-4, MUL VL] : st2w   %z12.s %z13.s %p4 -> -0x80(%x13)[64byte]
+e53ff1ee : st2w {z14.s, z15.s}, p4, [x15, #-2, MUL VL] : st2w   %z14.s %z15.s %p4 -> -0x40(%x15)[64byte]
 e530f630 : st2w {z16.s, z17.s}, p5, [x17, #0, MUL VL] : st2w   %z16.s %z17.s %p5 -> (%x17)[64byte]
 e530f671 : st2w {z17.s, z18.s}, p5, [x19, #0, MUL VL] : st2w   %z17.s %z18.s %p5 -> (%x19)[64byte]
-e531f6b3 : st2w {z19.s, z20.s}, p5, [x21, #2, MUL VL] : st2w   %z19.s %z20.s %p5 -> +0x02(%x21)[64byte]
-e532faf5 : st2w {z21.s, z22.s}, p6, [x23, #4, MUL VL] : st2w   %z21.s %z22.s %p6 -> +0x04(%x23)[64byte]
-e533fb17 : st2w {z23.s, z24.s}, p6, [x24, #6, MUL VL] : st2w   %z23.s %z24.s %p6 -> +0x06(%x24)[64byte]
-e534ff59 : st2w {z25.s, z26.s}, p7, [x26, #8, MUL VL] : st2w   %z25.s %z26.s %p7 -> +0x08(%x26)[64byte]
-e535ff9b : st2w {z27.s, z28.s}, p7, [x28, #10, MUL VL] : st2w   %z27.s %z28.s %p7 -> +0x0a(%x28)[64byte]
-e537ffff : st2w {z31.s, z0.s}, p7, [sp, #14, MUL VL] : st2w   %z31.s %z0.s %p7 -> +0x0e(%sp)[64byte]
+e531f6b3 : st2w {z19.s, z20.s}, p5, [x21, #2, MUL VL] : st2w   %z19.s %z20.s %p5 -> +0x40(%x21)[64byte]
+e532faf5 : st2w {z21.s, z22.s}, p6, [x23, #4, MUL VL] : st2w   %z21.s %z22.s %p6 -> +0x80(%x23)[64byte]
+e533fb17 : st2w {z23.s, z24.s}, p6, [x24, #6, MUL VL] : st2w   %z23.s %z24.s %p6 -> +0xc0(%x24)[64byte]
+e534ff59 : st2w {z25.s, z26.s}, p7, [x26, #8, MUL VL] : st2w   %z25.s %z26.s %p7 -> +0x0100(%x26)[64byte]
+e535ff9b : st2w {z27.s, z28.s}, p7, [x28, #10, MUL VL] : st2w   %z27.s %z28.s %p7 -> +0x0140(%x28)[64byte]
+e537ffff : st2w {z31.s, z0.s}, p7, [sp, #14, MUL VL] : st2w   %z31.s %z0.s %p7 -> +0x01c0(%sp)[64byte]
 
 # ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>, <Xm>] (ST3B-Z.P.BR-Contiguous)
 e4406000 : st3b {z0.b, z1.b, z2.b}, p0, [x0, x0]     : st3b   %z0.b %z1.b %z2.b %p0 -> (%x0,%x0)[96byte]
@@ -22030,22 +22030,22 @@ e45d7f9b : st3b {z27.b, z28.b, z29.b}, p7, [x28, x29] : st3b   %z27.b %z28.b %z2
 e45e7fff : st3b {z31.b, z0.b, z1.b}, p7, [sp, x30]   : st3b   %z31.b %z0.b %z1.b %p7 -> (%sp,%x30)[96byte]
 
 # ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST3B-Z.P.BI-Contiguous)
-e458e000 : st3b {z0.b, z1.b, z2.b}, p0, [x0, #-24, MUL VL] : st3b   %z0.b %z1.b %z2.b %p0 -> -0x18(%x0)[96byte]
-e459e482 : st3b {z2.b, z3.b, z4.b}, p1, [x4, #-21, MUL VL] : st3b   %z2.b %z3.b %z4.b %p1 -> -0x15(%x4)[96byte]
-e45ae8c4 : st3b {z4.b, z5.b, z6.b}, p2, [x6, #-18, MUL VL] : st3b   %z4.b %z5.b %z6.b %p2 -> -0x12(%x6)[96byte]
-e45be906 : st3b {z6.b, z7.b, z8.b}, p2, [x8, #-15, MUL VL] : st3b   %z6.b %z7.b %z8.b %p2 -> -0x0f(%x8)[96byte]
-e45ced48 : st3b {z8.b, z9.b, z10.b}, p3, [x10, #-12, MUL VL] : st3b   %z8.b %z9.b %z10.b %p3 -> -0x0c(%x10)[96byte]
-e45ded6a : st3b {z10.b, z11.b, z12.b}, p3, [x11, #-9, MUL VL] : st3b   %z10.b %z11.b %z12.b %p3 -> -0x09(%x11)[96byte]
-e45ef1ac : st3b {z12.b, z13.b, z14.b}, p4, [x13, #-6, MUL VL] : st3b   %z12.b %z13.b %z14.b %p4 -> -0x06(%x13)[96byte]
-e45ff1ee : st3b {z14.b, z15.b, z16.b}, p4, [x15, #-3, MUL VL] : st3b   %z14.b %z15.b %z16.b %p4 -> -0x03(%x15)[96byte]
+e458e000 : st3b {z0.b, z1.b, z2.b}, p0, [x0, #-24, MUL VL] : st3b   %z0.b %z1.b %z2.b %p0 -> -0x0300(%x0)[96byte]
+e459e482 : st3b {z2.b, z3.b, z4.b}, p1, [x4, #-21, MUL VL] : st3b   %z2.b %z3.b %z4.b %p1 -> -0x02a0(%x4)[96byte]
+e45ae8c4 : st3b {z4.b, z5.b, z6.b}, p2, [x6, #-18, MUL VL] : st3b   %z4.b %z5.b %z6.b %p2 -> -0x0240(%x6)[96byte]
+e45be906 : st3b {z6.b, z7.b, z8.b}, p2, [x8, #-15, MUL VL] : st3b   %z6.b %z7.b %z8.b %p2 -> -0x01e0(%x8)[96byte]
+e45ced48 : st3b {z8.b, z9.b, z10.b}, p3, [x10, #-12, MUL VL] : st3b   %z8.b %z9.b %z10.b %p3 -> -0x0180(%x10)[96byte]
+e45ded6a : st3b {z10.b, z11.b, z12.b}, p3, [x11, #-9, MUL VL] : st3b   %z10.b %z11.b %z12.b %p3 -> -0x0120(%x11)[96byte]
+e45ef1ac : st3b {z12.b, z13.b, z14.b}, p4, [x13, #-6, MUL VL] : st3b   %z12.b %z13.b %z14.b %p4 -> -0xc0(%x13)[96byte]
+e45ff1ee : st3b {z14.b, z15.b, z16.b}, p4, [x15, #-3, MUL VL] : st3b   %z14.b %z15.b %z16.b %p4 -> -0x60(%x15)[96byte]
 e450f630 : st3b {z16.b, z17.b, z18.b}, p5, [x17, #0, MUL VL] : st3b   %z16.b %z17.b %z18.b %p5 -> (%x17)[96byte]
 e450f671 : st3b {z17.b, z18.b, z19.b}, p5, [x19, #0, MUL VL] : st3b   %z17.b %z18.b %z19.b %p5 -> (%x19)[96byte]
-e451f6b3 : st3b {z19.b, z20.b, z21.b}, p5, [x21, #3, MUL VL] : st3b   %z19.b %z20.b %z21.b %p5 -> +0x03(%x21)[96byte]
-e452faf5 : st3b {z21.b, z22.b, z23.b}, p6, [x23, #6, MUL VL] : st3b   %z21.b %z22.b %z23.b %p6 -> +0x06(%x23)[96byte]
-e453fb17 : st3b {z23.b, z24.b, z25.b}, p6, [x24, #9, MUL VL] : st3b   %z23.b %z24.b %z25.b %p6 -> +0x09(%x24)[96byte]
-e454ff59 : st3b {z25.b, z26.b, z27.b}, p7, [x26, #12, MUL VL] : st3b   %z25.b %z26.b %z27.b %p7 -> +0x0c(%x26)[96byte]
-e455ff9b : st3b {z27.b, z28.b, z29.b}, p7, [x28, #15, MUL VL] : st3b   %z27.b %z28.b %z29.b %p7 -> +0x0f(%x28)[96byte]
-e457ffff : st3b {z31.b, z0.b, z1.b}, p7, [sp, #21, MUL VL] : st3b   %z31.b %z0.b %z1.b %p7 -> +0x15(%sp)[96byte]
+e451f6b3 : st3b {z19.b, z20.b, z21.b}, p5, [x21, #3, MUL VL] : st3b   %z19.b %z20.b %z21.b %p5 -> +0x60(%x21)[96byte]
+e452faf5 : st3b {z21.b, z22.b, z23.b}, p6, [x23, #6, MUL VL] : st3b   %z21.b %z22.b %z23.b %p6 -> +0xc0(%x23)[96byte]
+e453fb17 : st3b {z23.b, z24.b, z25.b}, p6, [x24, #9, MUL VL] : st3b   %z23.b %z24.b %z25.b %p6 -> +0x0120(%x24)[96byte]
+e454ff59 : st3b {z25.b, z26.b, z27.b}, p7, [x26, #12, MUL VL] : st3b   %z25.b %z26.b %z27.b %p7 -> +0x0180(%x26)[96byte]
+e455ff9b : st3b {z27.b, z28.b, z29.b}, p7, [x28, #15, MUL VL] : st3b   %z27.b %z28.b %z29.b %p7 -> +0x01e0(%x28)[96byte]
+e457ffff : st3b {z31.b, z0.b, z1.b}, p7, [sp, #21, MUL VL] : st3b   %z31.b %z0.b %z1.b %p7 -> +0x02a0(%sp)[96byte]
 
 # ST3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>, [<Xn|SP>, <Xm>, LSL #3] (ST3D-Z.P.BR-Contiguous)
 e5c06000 : st3d {z0.d, z1.d, z2.d}, p0, [x0, x0, LSL #3] : st3d   %z0.d %z1.d %z2.d %p0 -> (%x0,%x0,lsl #3)[96byte]
@@ -22066,22 +22066,22 @@ e5dd7f9b : st3d {z27.d, z28.d, z29.d}, p7, [x28, x29, LSL #3] : st3d   %z27.d %z
 e5de7fff : st3d {z31.d, z0.d, z1.d}, p7, [sp, x30, LSL #3] : st3d   %z31.d %z0.d %z1.d %p7 -> (%sp,%x30,lsl #3)[96byte]
 
 # ST3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST3D-Z.P.BI-Contiguous)
-e5d8e000 : st3d {z0.d, z1.d, z2.d}, p0, [x0, #-24, MUL VL] : st3d   %z0.d %z1.d %z2.d %p0 -> -0x18(%x0)[96byte]
-e5d9e482 : st3d {z2.d, z3.d, z4.d}, p1, [x4, #-21, MUL VL] : st3d   %z2.d %z3.d %z4.d %p1 -> -0x15(%x4)[96byte]
-e5dae8c4 : st3d {z4.d, z5.d, z6.d}, p2, [x6, #-18, MUL VL] : st3d   %z4.d %z5.d %z6.d %p2 -> -0x12(%x6)[96byte]
-e5dbe906 : st3d {z6.d, z7.d, z8.d}, p2, [x8, #-15, MUL VL] : st3d   %z6.d %z7.d %z8.d %p2 -> -0x0f(%x8)[96byte]
-e5dced48 : st3d {z8.d, z9.d, z10.d}, p3, [x10, #-12, MUL VL] : st3d   %z8.d %z9.d %z10.d %p3 -> -0x0c(%x10)[96byte]
-e5dded6a : st3d {z10.d, z11.d, z12.d}, p3, [x11, #-9, MUL VL] : st3d   %z10.d %z11.d %z12.d %p3 -> -0x09(%x11)[96byte]
-e5def1ac : st3d {z12.d, z13.d, z14.d}, p4, [x13, #-6, MUL VL] : st3d   %z12.d %z13.d %z14.d %p4 -> -0x06(%x13)[96byte]
-e5dff1ee : st3d {z14.d, z15.d, z16.d}, p4, [x15, #-3, MUL VL] : st3d   %z14.d %z15.d %z16.d %p4 -> -0x03(%x15)[96byte]
+e5d8e000 : st3d {z0.d, z1.d, z2.d}, p0, [x0, #-24, MUL VL] : st3d   %z0.d %z1.d %z2.d %p0 -> -0x0300(%x0)[96byte]
+e5d9e482 : st3d {z2.d, z3.d, z4.d}, p1, [x4, #-21, MUL VL] : st3d   %z2.d %z3.d %z4.d %p1 -> -0x02a0(%x4)[96byte]
+e5dae8c4 : st3d {z4.d, z5.d, z6.d}, p2, [x6, #-18, MUL VL] : st3d   %z4.d %z5.d %z6.d %p2 -> -0x0240(%x6)[96byte]
+e5dbe906 : st3d {z6.d, z7.d, z8.d}, p2, [x8, #-15, MUL VL] : st3d   %z6.d %z7.d %z8.d %p2 -> -0x01e0(%x8)[96byte]
+e5dced48 : st3d {z8.d, z9.d, z10.d}, p3, [x10, #-12, MUL VL] : st3d   %z8.d %z9.d %z10.d %p3 -> -0x0180(%x10)[96byte]
+e5dded6a : st3d {z10.d, z11.d, z12.d}, p3, [x11, #-9, MUL VL] : st3d   %z10.d %z11.d %z12.d %p3 -> -0x0120(%x11)[96byte]
+e5def1ac : st3d {z12.d, z13.d, z14.d}, p4, [x13, #-6, MUL VL] : st3d   %z12.d %z13.d %z14.d %p4 -> -0xc0(%x13)[96byte]
+e5dff1ee : st3d {z14.d, z15.d, z16.d}, p4, [x15, #-3, MUL VL] : st3d   %z14.d %z15.d %z16.d %p4 -> -0x60(%x15)[96byte]
 e5d0f630 : st3d {z16.d, z17.d, z18.d}, p5, [x17, #0, MUL VL] : st3d   %z16.d %z17.d %z18.d %p5 -> (%x17)[96byte]
 e5d0f671 : st3d {z17.d, z18.d, z19.d}, p5, [x19, #0, MUL VL] : st3d   %z17.d %z18.d %z19.d %p5 -> (%x19)[96byte]
-e5d1f6b3 : st3d {z19.d, z20.d, z21.d}, p5, [x21, #3, MUL VL] : st3d   %z19.d %z20.d %z21.d %p5 -> +0x03(%x21)[96byte]
-e5d2faf5 : st3d {z21.d, z22.d, z23.d}, p6, [x23, #6, MUL VL] : st3d   %z21.d %z22.d %z23.d %p6 -> +0x06(%x23)[96byte]
-e5d3fb17 : st3d {z23.d, z24.d, z25.d}, p6, [x24, #9, MUL VL] : st3d   %z23.d %z24.d %z25.d %p6 -> +0x09(%x24)[96byte]
-e5d4ff59 : st3d {z25.d, z26.d, z27.d}, p7, [x26, #12, MUL VL] : st3d   %z25.d %z26.d %z27.d %p7 -> +0x0c(%x26)[96byte]
-e5d5ff9b : st3d {z27.d, z28.d, z29.d}, p7, [x28, #15, MUL VL] : st3d   %z27.d %z28.d %z29.d %p7 -> +0x0f(%x28)[96byte]
-e5d7ffff : st3d {z31.d, z0.d, z1.d}, p7, [sp, #21, MUL VL] : st3d   %z31.d %z0.d %z1.d %p7 -> +0x15(%sp)[96byte]
+e5d1f6b3 : st3d {z19.d, z20.d, z21.d}, p5, [x21, #3, MUL VL] : st3d   %z19.d %z20.d %z21.d %p5 -> +0x60(%x21)[96byte]
+e5d2faf5 : st3d {z21.d, z22.d, z23.d}, p6, [x23, #6, MUL VL] : st3d   %z21.d %z22.d %z23.d %p6 -> +0xc0(%x23)[96byte]
+e5d3fb17 : st3d {z23.d, z24.d, z25.d}, p6, [x24, #9, MUL VL] : st3d   %z23.d %z24.d %z25.d %p6 -> +0x0120(%x24)[96byte]
+e5d4ff59 : st3d {z25.d, z26.d, z27.d}, p7, [x26, #12, MUL VL] : st3d   %z25.d %z26.d %z27.d %p7 -> +0x0180(%x26)[96byte]
+e5d5ff9b : st3d {z27.d, z28.d, z29.d}, p7, [x28, #15, MUL VL] : st3d   %z27.d %z28.d %z29.d %p7 -> +0x01e0(%x28)[96byte]
+e5d7ffff : st3d {z31.d, z0.d, z1.d}, p7, [sp, #21, MUL VL] : st3d   %z31.d %z0.d %z1.d %p7 -> +0x02a0(%sp)[96byte]
 
 # ST3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>, [<Xn|SP>, <Xm>, LSL #1] (ST3H-Z.P.BR-Contiguous)
 e4c06000 : st3h {z0.h, z1.h, z2.h}, p0, [x0, x0, LSL #1] : st3h   %z0.h %z1.h %z2.h %p0 -> (%x0,%x0,lsl #1)[96byte]
@@ -22102,22 +22102,22 @@ e4dd7f9b : st3h {z27.h, z28.h, z29.h}, p7, [x28, x29, LSL #1] : st3h   %z27.h %z
 e4de7fff : st3h {z31.h, z0.h, z1.h}, p7, [sp, x30, LSL #1] : st3h   %z31.h %z0.h %z1.h %p7 -> (%sp,%x30,lsl #1)[96byte]
 
 # ST3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST3H-Z.P.BI-Contiguous)
-e4d8e000 : st3h {z0.h, z1.h, z2.h}, p0, [x0, #-24, MUL VL] : st3h   %z0.h %z1.h %z2.h %p0 -> -0x18(%x0)[96byte]
-e4d9e482 : st3h {z2.h, z3.h, z4.h}, p1, [x4, #-21, MUL VL] : st3h   %z2.h %z3.h %z4.h %p1 -> -0x15(%x4)[96byte]
-e4dae8c4 : st3h {z4.h, z5.h, z6.h}, p2, [x6, #-18, MUL VL] : st3h   %z4.h %z5.h %z6.h %p2 -> -0x12(%x6)[96byte]
-e4dbe906 : st3h {z6.h, z7.h, z8.h}, p2, [x8, #-15, MUL VL] : st3h   %z6.h %z7.h %z8.h %p2 -> -0x0f(%x8)[96byte]
-e4dced48 : st3h {z8.h, z9.h, z10.h}, p3, [x10, #-12, MUL VL] : st3h   %z8.h %z9.h %z10.h %p3 -> -0x0c(%x10)[96byte]
-e4dded6a : st3h {z10.h, z11.h, z12.h}, p3, [x11, #-9, MUL VL] : st3h   %z10.h %z11.h %z12.h %p3 -> -0x09(%x11)[96byte]
-e4def1ac : st3h {z12.h, z13.h, z14.h}, p4, [x13, #-6, MUL VL] : st3h   %z12.h %z13.h %z14.h %p4 -> -0x06(%x13)[96byte]
-e4dff1ee : st3h {z14.h, z15.h, z16.h}, p4, [x15, #-3, MUL VL] : st3h   %z14.h %z15.h %z16.h %p4 -> -0x03(%x15)[96byte]
+e4d8e000 : st3h {z0.h, z1.h, z2.h}, p0, [x0, #-24, MUL VL] : st3h   %z0.h %z1.h %z2.h %p0 -> -0x0300(%x0)[96byte]
+e4d9e482 : st3h {z2.h, z3.h, z4.h}, p1, [x4, #-21, MUL VL] : st3h   %z2.h %z3.h %z4.h %p1 -> -0x02a0(%x4)[96byte]
+e4dae8c4 : st3h {z4.h, z5.h, z6.h}, p2, [x6, #-18, MUL VL] : st3h   %z4.h %z5.h %z6.h %p2 -> -0x0240(%x6)[96byte]
+e4dbe906 : st3h {z6.h, z7.h, z8.h}, p2, [x8, #-15, MUL VL] : st3h   %z6.h %z7.h %z8.h %p2 -> -0x01e0(%x8)[96byte]
+e4dced48 : st3h {z8.h, z9.h, z10.h}, p3, [x10, #-12, MUL VL] : st3h   %z8.h %z9.h %z10.h %p3 -> -0x0180(%x10)[96byte]
+e4dded6a : st3h {z10.h, z11.h, z12.h}, p3, [x11, #-9, MUL VL] : st3h   %z10.h %z11.h %z12.h %p3 -> -0x0120(%x11)[96byte]
+e4def1ac : st3h {z12.h, z13.h, z14.h}, p4, [x13, #-6, MUL VL] : st3h   %z12.h %z13.h %z14.h %p4 -> -0xc0(%x13)[96byte]
+e4dff1ee : st3h {z14.h, z15.h, z16.h}, p4, [x15, #-3, MUL VL] : st3h   %z14.h %z15.h %z16.h %p4 -> -0x60(%x15)[96byte]
 e4d0f630 : st3h {z16.h, z17.h, z18.h}, p5, [x17, #0, MUL VL] : st3h   %z16.h %z17.h %z18.h %p5 -> (%x17)[96byte]
 e4d0f671 : st3h {z17.h, z18.h, z19.h}, p5, [x19, #0, MUL VL] : st3h   %z17.h %z18.h %z19.h %p5 -> (%x19)[96byte]
-e4d1f6b3 : st3h {z19.h, z20.h, z21.h}, p5, [x21, #3, MUL VL] : st3h   %z19.h %z20.h %z21.h %p5 -> +0x03(%x21)[96byte]
-e4d2faf5 : st3h {z21.h, z22.h, z23.h}, p6, [x23, #6, MUL VL] : st3h   %z21.h %z22.h %z23.h %p6 -> +0x06(%x23)[96byte]
-e4d3fb17 : st3h {z23.h, z24.h, z25.h}, p6, [x24, #9, MUL VL] : st3h   %z23.h %z24.h %z25.h %p6 -> +0x09(%x24)[96byte]
-e4d4ff59 : st3h {z25.h, z26.h, z27.h}, p7, [x26, #12, MUL VL] : st3h   %z25.h %z26.h %z27.h %p7 -> +0x0c(%x26)[96byte]
-e4d5ff9b : st3h {z27.h, z28.h, z29.h}, p7, [x28, #15, MUL VL] : st3h   %z27.h %z28.h %z29.h %p7 -> +0x0f(%x28)[96byte]
-e4d7ffff : st3h {z31.h, z0.h, z1.h}, p7, [sp, #21, MUL VL] : st3h   %z31.h %z0.h %z1.h %p7 -> +0x15(%sp)[96byte]
+e4d1f6b3 : st3h {z19.h, z20.h, z21.h}, p5, [x21, #3, MUL VL] : st3h   %z19.h %z20.h %z21.h %p5 -> +0x60(%x21)[96byte]
+e4d2faf5 : st3h {z21.h, z22.h, z23.h}, p6, [x23, #6, MUL VL] : st3h   %z21.h %z22.h %z23.h %p6 -> +0xc0(%x23)[96byte]
+e4d3fb17 : st3h {z23.h, z24.h, z25.h}, p6, [x24, #9, MUL VL] : st3h   %z23.h %z24.h %z25.h %p6 -> +0x0120(%x24)[96byte]
+e4d4ff59 : st3h {z25.h, z26.h, z27.h}, p7, [x26, #12, MUL VL] : st3h   %z25.h %z26.h %z27.h %p7 -> +0x0180(%x26)[96byte]
+e4d5ff9b : st3h {z27.h, z28.h, z29.h}, p7, [x28, #15, MUL VL] : st3h   %z27.h %z28.h %z29.h %p7 -> +0x01e0(%x28)[96byte]
+e4d7ffff : st3h {z31.h, z0.h, z1.h}, p7, [sp, #21, MUL VL] : st3h   %z31.h %z0.h %z1.h %p7 -> +0x02a0(%sp)[96byte]
 
 # ST3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>, [<Xn|SP>, <Xm>, LSL #2] (ST3W-Z.P.BR-Contiguous)
 e5406000 : st3w {z0.s, z1.s, z2.s}, p0, [x0, x0, LSL #2] : st3w   %z0.s %z1.s %z2.s %p0 -> (%x0,%x0,lsl #2)[96byte]
@@ -22138,22 +22138,22 @@ e55d7f9b : st3w {z27.s, z28.s, z29.s}, p7, [x28, x29, LSL #2] : st3w   %z27.s %z
 e55e7fff : st3w {z31.s, z0.s, z1.s}, p7, [sp, x30, LSL #2] : st3w   %z31.s %z0.s %z1.s %p7 -> (%sp,%x30,lsl #2)[96byte]
 
 # ST3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST3W-Z.P.BI-Contiguous)
-e558e000 : st3w {z0.s, z1.s, z2.s}, p0, [x0, #-24, MUL VL] : st3w   %z0.s %z1.s %z2.s %p0 -> -0x18(%x0)[96byte]
-e559e482 : st3w {z2.s, z3.s, z4.s}, p1, [x4, #-21, MUL VL] : st3w   %z2.s %z3.s %z4.s %p1 -> -0x15(%x4)[96byte]
-e55ae8c4 : st3w {z4.s, z5.s, z6.s}, p2, [x6, #-18, MUL VL] : st3w   %z4.s %z5.s %z6.s %p2 -> -0x12(%x6)[96byte]
-e55be906 : st3w {z6.s, z7.s, z8.s}, p2, [x8, #-15, MUL VL] : st3w   %z6.s %z7.s %z8.s %p2 -> -0x0f(%x8)[96byte]
-e55ced48 : st3w {z8.s, z9.s, z10.s}, p3, [x10, #-12, MUL VL] : st3w   %z8.s %z9.s %z10.s %p3 -> -0x0c(%x10)[96byte]
-e55ded6a : st3w {z10.s, z11.s, z12.s}, p3, [x11, #-9, MUL VL] : st3w   %z10.s %z11.s %z12.s %p3 -> -0x09(%x11)[96byte]
-e55ef1ac : st3w {z12.s, z13.s, z14.s}, p4, [x13, #-6, MUL VL] : st3w   %z12.s %z13.s %z14.s %p4 -> -0x06(%x13)[96byte]
-e55ff1ee : st3w {z14.s, z15.s, z16.s}, p4, [x15, #-3, MUL VL] : st3w   %z14.s %z15.s %z16.s %p4 -> -0x03(%x15)[96byte]
+e558e000 : st3w {z0.s, z1.s, z2.s}, p0, [x0, #-24, MUL VL] : st3w   %z0.s %z1.s %z2.s %p0 -> -0x0300(%x0)[96byte]
+e559e482 : st3w {z2.s, z3.s, z4.s}, p1, [x4, #-21, MUL VL] : st3w   %z2.s %z3.s %z4.s %p1 -> -0x02a0(%x4)[96byte]
+e55ae8c4 : st3w {z4.s, z5.s, z6.s}, p2, [x6, #-18, MUL VL] : st3w   %z4.s %z5.s %z6.s %p2 -> -0x0240(%x6)[96byte]
+e55be906 : st3w {z6.s, z7.s, z8.s}, p2, [x8, #-15, MUL VL] : st3w   %z6.s %z7.s %z8.s %p2 -> -0x01e0(%x8)[96byte]
+e55ced48 : st3w {z8.s, z9.s, z10.s}, p3, [x10, #-12, MUL VL] : st3w   %z8.s %z9.s %z10.s %p3 -> -0x0180(%x10)[96byte]
+e55ded6a : st3w {z10.s, z11.s, z12.s}, p3, [x11, #-9, MUL VL] : st3w   %z10.s %z11.s %z12.s %p3 -> -0x0120(%x11)[96byte]
+e55ef1ac : st3w {z12.s, z13.s, z14.s}, p4, [x13, #-6, MUL VL] : st3w   %z12.s %z13.s %z14.s %p4 -> -0xc0(%x13)[96byte]
+e55ff1ee : st3w {z14.s, z15.s, z16.s}, p4, [x15, #-3, MUL VL] : st3w   %z14.s %z15.s %z16.s %p4 -> -0x60(%x15)[96byte]
 e550f630 : st3w {z16.s, z17.s, z18.s}, p5, [x17, #0, MUL VL] : st3w   %z16.s %z17.s %z18.s %p5 -> (%x17)[96byte]
 e550f671 : st3w {z17.s, z18.s, z19.s}, p5, [x19, #0, MUL VL] : st3w   %z17.s %z18.s %z19.s %p5 -> (%x19)[96byte]
-e551f6b3 : st3w {z19.s, z20.s, z21.s}, p5, [x21, #3, MUL VL] : st3w   %z19.s %z20.s %z21.s %p5 -> +0x03(%x21)[96byte]
-e552faf5 : st3w {z21.s, z22.s, z23.s}, p6, [x23, #6, MUL VL] : st3w   %z21.s %z22.s %z23.s %p6 -> +0x06(%x23)[96byte]
-e553fb17 : st3w {z23.s, z24.s, z25.s}, p6, [x24, #9, MUL VL] : st3w   %z23.s %z24.s %z25.s %p6 -> +0x09(%x24)[96byte]
-e554ff59 : st3w {z25.s, z26.s, z27.s}, p7, [x26, #12, MUL VL] : st3w   %z25.s %z26.s %z27.s %p7 -> +0x0c(%x26)[96byte]
-e555ff9b : st3w {z27.s, z28.s, z29.s}, p7, [x28, #15, MUL VL] : st3w   %z27.s %z28.s %z29.s %p7 -> +0x0f(%x28)[96byte]
-e557ffff : st3w {z31.s, z0.s, z1.s}, p7, [sp, #21, MUL VL] : st3w   %z31.s %z0.s %z1.s %p7 -> +0x15(%sp)[96byte]
+e551f6b3 : st3w {z19.s, z20.s, z21.s}, p5, [x21, #3, MUL VL] : st3w   %z19.s %z20.s %z21.s %p5 -> +0x60(%x21)[96byte]
+e552faf5 : st3w {z21.s, z22.s, z23.s}, p6, [x23, #6, MUL VL] : st3w   %z21.s %z22.s %z23.s %p6 -> +0xc0(%x23)[96byte]
+e553fb17 : st3w {z23.s, z24.s, z25.s}, p6, [x24, #9, MUL VL] : st3w   %z23.s %z24.s %z25.s %p6 -> +0x0120(%x24)[96byte]
+e554ff59 : st3w {z25.s, z26.s, z27.s}, p7, [x26, #12, MUL VL] : st3w   %z25.s %z26.s %z27.s %p7 -> +0x0180(%x26)[96byte]
+e555ff9b : st3w {z27.s, z28.s, z29.s}, p7, [x28, #15, MUL VL] : st3w   %z27.s %z28.s %z29.s %p7 -> +0x01e0(%x28)[96byte]
+e557ffff : st3w {z31.s, z0.s, z1.s}, p7, [sp, #21, MUL VL] : st3w   %z31.s %z0.s %z1.s %p7 -> +0x02a0(%sp)[96byte]
 
 # ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>, <Xm>] (ST4B-Z.P.BR-Contiguous)
 e4606000 : st4b {z0.b, z1.b, z2.b, z3.b}, p0, [x0, x0] : st4b   %z0.b %z1.b %z2.b %z3.b %p0 -> (%x0,%x0)[128byte]
@@ -22174,22 +22174,22 @@ e47d7f9b : st4b {z27.b, z28.b, z29.b, z30.b}, p7, [x28, x29] : st4b   %z27.b %z2
 e47e7fff : st4b {z31.b, z0.b, z1.b, z2.b}, p7, [sp, x30] : st4b   %z31.b %z0.b %z1.b %z2.b %p7 -> (%sp,%x30)[128byte]
 
 # ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST4B-Z.P.BI-Contiguous)
-e478e000 : st4b {z0.b, z1.b, z2.b, z3.b}, p0, [x0, #-32, MUL VL] : st4b   %z0.b %z1.b %z2.b %z3.b %p0 -> -0x20(%x0)[128byte]
-e479e482 : st4b {z2.b, z3.b, z4.b, z5.b}, p1, [x4, #-28, MUL VL] : st4b   %z2.b %z3.b %z4.b %z5.b %p1 -> -0x1c(%x4)[128byte]
-e47ae8c4 : st4b {z4.b, z5.b, z6.b, z7.b}, p2, [x6, #-24, MUL VL] : st4b   %z4.b %z5.b %z6.b %z7.b %p2 -> -0x18(%x6)[128byte]
-e47be906 : st4b {z6.b, z7.b, z8.b, z9.b}, p2, [x8, #-20, MUL VL] : st4b   %z6.b %z7.b %z8.b %z9.b %p2 -> -0x14(%x8)[128byte]
-e47ced48 : st4b {z8.b, z9.b, z10.b, z11.b}, p3, [x10, #-16, MUL VL] : st4b   %z8.b %z9.b %z10.b %z11.b %p3 -> -0x10(%x10)[128byte]
-e47ded6a : st4b {z10.b, z11.b, z12.b, z13.b}, p3, [x11, #-12, MUL VL] : st4b   %z10.b %z11.b %z12.b %z13.b %p3 -> -0x0c(%x11)[128byte]
-e47ef1ac : st4b {z12.b, z13.b, z14.b, z15.b}, p4, [x13, #-8, MUL VL] : st4b   %z12.b %z13.b %z14.b %z15.b %p4 -> -0x08(%x13)[128byte]
-e47ff1ee : st4b {z14.b, z15.b, z16.b, z17.b}, p4, [x15, #-4, MUL VL] : st4b   %z14.b %z15.b %z16.b %z17.b %p4 -> -0x04(%x15)[128byte]
+e478e000 : st4b {z0.b, z1.b, z2.b, z3.b}, p0, [x0, #-32, MUL VL] : st4b   %z0.b %z1.b %z2.b %z3.b %p0 -> -0x0400(%x0)[128byte]
+e479e482 : st4b {z2.b, z3.b, z4.b, z5.b}, p1, [x4, #-28, MUL VL] : st4b   %z2.b %z3.b %z4.b %z5.b %p1 -> -0x0380(%x4)[128byte]
+e47ae8c4 : st4b {z4.b, z5.b, z6.b, z7.b}, p2, [x6, #-24, MUL VL] : st4b   %z4.b %z5.b %z6.b %z7.b %p2 -> -0x0300(%x6)[128byte]
+e47be906 : st4b {z6.b, z7.b, z8.b, z9.b}, p2, [x8, #-20, MUL VL] : st4b   %z6.b %z7.b %z8.b %z9.b %p2 -> -0x0280(%x8)[128byte]
+e47ced48 : st4b {z8.b, z9.b, z10.b, z11.b}, p3, [x10, #-16, MUL VL] : st4b   %z8.b %z9.b %z10.b %z11.b %p3 -> -0x0200(%x10)[128byte]
+e47ded6a : st4b {z10.b, z11.b, z12.b, z13.b}, p3, [x11, #-12, MUL VL] : st4b   %z10.b %z11.b %z12.b %z13.b %p3 -> -0x0180(%x11)[128byte]
+e47ef1ac : st4b {z12.b, z13.b, z14.b, z15.b}, p4, [x13, #-8, MUL VL] : st4b   %z12.b %z13.b %z14.b %z15.b %p4 -> -0x0100(%x13)[128byte]
+e47ff1ee : st4b {z14.b, z15.b, z16.b, z17.b}, p4, [x15, #-4, MUL VL] : st4b   %z14.b %z15.b %z16.b %z17.b %p4 -> -0x80(%x15)[128byte]
 e470f630 : st4b {z16.b, z17.b, z18.b, z19.b}, p5, [x17, #0, MUL VL] : st4b   %z16.b %z17.b %z18.b %z19.b %p5 -> (%x17)[128byte]
 e470f671 : st4b {z17.b, z18.b, z19.b, z20.b}, p5, [x19, #0, MUL VL] : st4b   %z17.b %z18.b %z19.b %z20.b %p5 -> (%x19)[128byte]
-e471f6b3 : st4b {z19.b, z20.b, z21.b, z22.b}, p5, [x21, #4, MUL VL] : st4b   %z19.b %z20.b %z21.b %z22.b %p5 -> +0x04(%x21)[128byte]
-e472faf5 : st4b {z21.b, z22.b, z23.b, z24.b}, p6, [x23, #8, MUL VL] : st4b   %z21.b %z22.b %z23.b %z24.b %p6 -> +0x08(%x23)[128byte]
-e473fb17 : st4b {z23.b, z24.b, z25.b, z26.b}, p6, [x24, #12, MUL VL] : st4b   %z23.b %z24.b %z25.b %z26.b %p6 -> +0x0c(%x24)[128byte]
-e474ff59 : st4b {z25.b, z26.b, z27.b, z28.b}, p7, [x26, #16, MUL VL] : st4b   %z25.b %z26.b %z27.b %z28.b %p7 -> +0x10(%x26)[128byte]
-e475ff9b : st4b {z27.b, z28.b, z29.b, z30.b}, p7, [x28, #20, MUL VL] : st4b   %z27.b %z28.b %z29.b %z30.b %p7 -> +0x14(%x28)[128byte]
-e477ffff : st4b {z31.b, z0.b, z1.b, z2.b}, p7, [sp, #28, MUL VL] : st4b   %z31.b %z0.b %z1.b %z2.b %p7 -> +0x1c(%sp)[128byte]
+e471f6b3 : st4b {z19.b, z20.b, z21.b, z22.b}, p5, [x21, #4, MUL VL] : st4b   %z19.b %z20.b %z21.b %z22.b %p5 -> +0x80(%x21)[128byte]
+e472faf5 : st4b {z21.b, z22.b, z23.b, z24.b}, p6, [x23, #8, MUL VL] : st4b   %z21.b %z22.b %z23.b %z24.b %p6 -> +0x0100(%x23)[128byte]
+e473fb17 : st4b {z23.b, z24.b, z25.b, z26.b}, p6, [x24, #12, MUL VL] : st4b   %z23.b %z24.b %z25.b %z26.b %p6 -> +0x0180(%x24)[128byte]
+e474ff59 : st4b {z25.b, z26.b, z27.b, z28.b}, p7, [x26, #16, MUL VL] : st4b   %z25.b %z26.b %z27.b %z28.b %p7 -> +0x0200(%x26)[128byte]
+e475ff9b : st4b {z27.b, z28.b, z29.b, z30.b}, p7, [x28, #20, MUL VL] : st4b   %z27.b %z28.b %z29.b %z30.b %p7 -> +0x0280(%x28)[128byte]
+e477ffff : st4b {z31.b, z0.b, z1.b, z2.b}, p7, [sp, #28, MUL VL] : st4b   %z31.b %z0.b %z1.b %z2.b %p7 -> +0x0380(%sp)[128byte]
 
 # ST4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>, [<Xn|SP>, <Xm>, LSL #3] (ST4D-Z.P.BR-Contiguous)
 e5e06000 : st4d {z0.d, z1.d, z2.d, z3.d}, p0, [x0, x0, LSL #3] : st4d   %z0.d %z1.d %z2.d %z3.d %p0 -> (%x0,%x0,lsl #3)[128byte]
@@ -22210,22 +22210,22 @@ e5fd7f9b : st4d {z27.d, z28.d, z29.d, z30.d}, p7, [x28, x29, LSL #3] : st4d   %z
 e5fe7fff : st4d {z31.d, z0.d, z1.d, z2.d}, p7, [sp, x30, LSL #3] : st4d   %z31.d %z0.d %z1.d %z2.d %p7 -> (%sp,%x30,lsl #3)[128byte]
 
 # ST4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST4D-Z.P.BI-Contiguous)
-e5f8e000 : st4d {z0.d, z1.d, z2.d, z3.d}, p0, [x0, #-32, MUL VL] : st4d   %z0.d %z1.d %z2.d %z3.d %p0 -> -0x20(%x0)[128byte]
-e5f9e482 : st4d {z2.d, z3.d, z4.d, z5.d}, p1, [x4, #-28, MUL VL] : st4d   %z2.d %z3.d %z4.d %z5.d %p1 -> -0x1c(%x4)[128byte]
-e5fae8c4 : st4d {z4.d, z5.d, z6.d, z7.d}, p2, [x6, #-24, MUL VL] : st4d   %z4.d %z5.d %z6.d %z7.d %p2 -> -0x18(%x6)[128byte]
-e5fbe906 : st4d {z6.d, z7.d, z8.d, z9.d}, p2, [x8, #-20, MUL VL] : st4d   %z6.d %z7.d %z8.d %z9.d %p2 -> -0x14(%x8)[128byte]
-e5fced48 : st4d {z8.d, z9.d, z10.d, z11.d}, p3, [x10, #-16, MUL VL] : st4d   %z8.d %z9.d %z10.d %z11.d %p3 -> -0x10(%x10)[128byte]
-e5fded6a : st4d {z10.d, z11.d, z12.d, z13.d}, p3, [x11, #-12, MUL VL] : st4d   %z10.d %z11.d %z12.d %z13.d %p3 -> -0x0c(%x11)[128byte]
-e5fef1ac : st4d {z12.d, z13.d, z14.d, z15.d}, p4, [x13, #-8, MUL VL] : st4d   %z12.d %z13.d %z14.d %z15.d %p4 -> -0x08(%x13)[128byte]
-e5fff1ee : st4d {z14.d, z15.d, z16.d, z17.d}, p4, [x15, #-4, MUL VL] : st4d   %z14.d %z15.d %z16.d %z17.d %p4 -> -0x04(%x15)[128byte]
+e5f8e000 : st4d {z0.d, z1.d, z2.d, z3.d}, p0, [x0, #-32, MUL VL] : st4d   %z0.d %z1.d %z2.d %z3.d %p0 -> -0x0400(%x0)[128byte]
+e5f9e482 : st4d {z2.d, z3.d, z4.d, z5.d}, p1, [x4, #-28, MUL VL] : st4d   %z2.d %z3.d %z4.d %z5.d %p1 -> -0x0380(%x4)[128byte]
+e5fae8c4 : st4d {z4.d, z5.d, z6.d, z7.d}, p2, [x6, #-24, MUL VL] : st4d   %z4.d %z5.d %z6.d %z7.d %p2 -> -0x0300(%x6)[128byte]
+e5fbe906 : st4d {z6.d, z7.d, z8.d, z9.d}, p2, [x8, #-20, MUL VL] : st4d   %z6.d %z7.d %z8.d %z9.d %p2 -> -0x0280(%x8)[128byte]
+e5fced48 : st4d {z8.d, z9.d, z10.d, z11.d}, p3, [x10, #-16, MUL VL] : st4d   %z8.d %z9.d %z10.d %z11.d %p3 -> -0x0200(%x10)[128byte]
+e5fded6a : st4d {z10.d, z11.d, z12.d, z13.d}, p3, [x11, #-12, MUL VL] : st4d   %z10.d %z11.d %z12.d %z13.d %p3 -> -0x0180(%x11)[128byte]
+e5fef1ac : st4d {z12.d, z13.d, z14.d, z15.d}, p4, [x13, #-8, MUL VL] : st4d   %z12.d %z13.d %z14.d %z15.d %p4 -> -0x0100(%x13)[128byte]
+e5fff1ee : st4d {z14.d, z15.d, z16.d, z17.d}, p4, [x15, #-4, MUL VL] : st4d   %z14.d %z15.d %z16.d %z17.d %p4 -> -0x80(%x15)[128byte]
 e5f0f630 : st4d {z16.d, z17.d, z18.d, z19.d}, p5, [x17, #0, MUL VL] : st4d   %z16.d %z17.d %z18.d %z19.d %p5 -> (%x17)[128byte]
 e5f0f671 : st4d {z17.d, z18.d, z19.d, z20.d}, p5, [x19, #0, MUL VL] : st4d   %z17.d %z18.d %z19.d %z20.d %p5 -> (%x19)[128byte]
-e5f1f6b3 : st4d {z19.d, z20.d, z21.d, z22.d}, p5, [x21, #4, MUL VL] : st4d   %z19.d %z20.d %z21.d %z22.d %p5 -> +0x04(%x21)[128byte]
-e5f2faf5 : st4d {z21.d, z22.d, z23.d, z24.d}, p6, [x23, #8, MUL VL] : st4d   %z21.d %z22.d %z23.d %z24.d %p6 -> +0x08(%x23)[128byte]
-e5f3fb17 : st4d {z23.d, z24.d, z25.d, z26.d}, p6, [x24, #12, MUL VL] : st4d   %z23.d %z24.d %z25.d %z26.d %p6 -> +0x0c(%x24)[128byte]
-e5f4ff59 : st4d {z25.d, z26.d, z27.d, z28.d}, p7, [x26, #16, MUL VL] : st4d   %z25.d %z26.d %z27.d %z28.d %p7 -> +0x10(%x26)[128byte]
-e5f5ff9b : st4d {z27.d, z28.d, z29.d, z30.d}, p7, [x28, #20, MUL VL] : st4d   %z27.d %z28.d %z29.d %z30.d %p7 -> +0x14(%x28)[128byte]
-e5f7ffff : st4d {z31.d, z0.d, z1.d, z2.d}, p7, [sp, #28, MUL VL] : st4d   %z31.d %z0.d %z1.d %z2.d %p7 -> +0x1c(%sp)[128byte]
+e5f1f6b3 : st4d {z19.d, z20.d, z21.d, z22.d}, p5, [x21, #4, MUL VL] : st4d   %z19.d %z20.d %z21.d %z22.d %p5 -> +0x80(%x21)[128byte]
+e5f2faf5 : st4d {z21.d, z22.d, z23.d, z24.d}, p6, [x23, #8, MUL VL] : st4d   %z21.d %z22.d %z23.d %z24.d %p6 -> +0x0100(%x23)[128byte]
+e5f3fb17 : st4d {z23.d, z24.d, z25.d, z26.d}, p6, [x24, #12, MUL VL] : st4d   %z23.d %z24.d %z25.d %z26.d %p6 -> +0x0180(%x24)[128byte]
+e5f4ff59 : st4d {z25.d, z26.d, z27.d, z28.d}, p7, [x26, #16, MUL VL] : st4d   %z25.d %z26.d %z27.d %z28.d %p7 -> +0x0200(%x26)[128byte]
+e5f5ff9b : st4d {z27.d, z28.d, z29.d, z30.d}, p7, [x28, #20, MUL VL] : st4d   %z27.d %z28.d %z29.d %z30.d %p7 -> +0x0280(%x28)[128byte]
+e5f7ffff : st4d {z31.d, z0.d, z1.d, z2.d}, p7, [sp, #28, MUL VL] : st4d   %z31.d %z0.d %z1.d %z2.d %p7 -> +0x0380(%sp)[128byte]
 
 # ST4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>, [<Xn|SP>, <Xm>, LSL #1] (ST4H-Z.P.BR-Contiguous)
 e4e06000 : st4h {z0.h, z1.h, z2.h, z3.h}, p0, [x0, x0, LSL #1] : st4h   %z0.h %z1.h %z2.h %z3.h %p0 -> (%x0,%x0,lsl #1)[128byte]
@@ -22246,22 +22246,22 @@ e4fd7f9b : st4h {z27.h, z28.h, z29.h, z30.h}, p7, [x28, x29, LSL #1] : st4h   %z
 e4fe7fff : st4h {z31.h, z0.h, z1.h, z2.h}, p7, [sp, x30, LSL #1] : st4h   %z31.h %z0.h %z1.h %z2.h %p7 -> (%sp,%x30,lsl #1)[128byte]
 
 # ST4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST4H-Z.P.BI-Contiguous)
-e4f8e000 : st4h {z0.h, z1.h, z2.h, z3.h}, p0, [x0, #-32, MUL VL] : st4h   %z0.h %z1.h %z2.h %z3.h %p0 -> -0x20(%x0)[128byte]
-e4f9e482 : st4h {z2.h, z3.h, z4.h, z5.h}, p1, [x4, #-28, MUL VL] : st4h   %z2.h %z3.h %z4.h %z5.h %p1 -> -0x1c(%x4)[128byte]
-e4fae8c4 : st4h {z4.h, z5.h, z6.h, z7.h}, p2, [x6, #-24, MUL VL] : st4h   %z4.h %z5.h %z6.h %z7.h %p2 -> -0x18(%x6)[128byte]
-e4fbe906 : st4h {z6.h, z7.h, z8.h, z9.h}, p2, [x8, #-20, MUL VL] : st4h   %z6.h %z7.h %z8.h %z9.h %p2 -> -0x14(%x8)[128byte]
-e4fced48 : st4h {z8.h, z9.h, z10.h, z11.h}, p3, [x10, #-16, MUL VL] : st4h   %z8.h %z9.h %z10.h %z11.h %p3 -> -0x10(%x10)[128byte]
-e4fded6a : st4h {z10.h, z11.h, z12.h, z13.h}, p3, [x11, #-12, MUL VL] : st4h   %z10.h %z11.h %z12.h %z13.h %p3 -> -0x0c(%x11)[128byte]
-e4fef1ac : st4h {z12.h, z13.h, z14.h, z15.h}, p4, [x13, #-8, MUL VL] : st4h   %z12.h %z13.h %z14.h %z15.h %p4 -> -0x08(%x13)[128byte]
-e4fff1ee : st4h {z14.h, z15.h, z16.h, z17.h}, p4, [x15, #-4, MUL VL] : st4h   %z14.h %z15.h %z16.h %z17.h %p4 -> -0x04(%x15)[128byte]
+e4f8e000 : st4h {z0.h, z1.h, z2.h, z3.h}, p0, [x0, #-32, MUL VL] : st4h   %z0.h %z1.h %z2.h %z3.h %p0 -> -0x0400(%x0)[128byte]
+e4f9e482 : st4h {z2.h, z3.h, z4.h, z5.h}, p1, [x4, #-28, MUL VL] : st4h   %z2.h %z3.h %z4.h %z5.h %p1 -> -0x0380(%x4)[128byte]
+e4fae8c4 : st4h {z4.h, z5.h, z6.h, z7.h}, p2, [x6, #-24, MUL VL] : st4h   %z4.h %z5.h %z6.h %z7.h %p2 -> -0x0300(%x6)[128byte]
+e4fbe906 : st4h {z6.h, z7.h, z8.h, z9.h}, p2, [x8, #-20, MUL VL] : st4h   %z6.h %z7.h %z8.h %z9.h %p2 -> -0x0280(%x8)[128byte]
+e4fced48 : st4h {z8.h, z9.h, z10.h, z11.h}, p3, [x10, #-16, MUL VL] : st4h   %z8.h %z9.h %z10.h %z11.h %p3 -> -0x0200(%x10)[128byte]
+e4fded6a : st4h {z10.h, z11.h, z12.h, z13.h}, p3, [x11, #-12, MUL VL] : st4h   %z10.h %z11.h %z12.h %z13.h %p3 -> -0x0180(%x11)[128byte]
+e4fef1ac : st4h {z12.h, z13.h, z14.h, z15.h}, p4, [x13, #-8, MUL VL] : st4h   %z12.h %z13.h %z14.h %z15.h %p4 -> -0x0100(%x13)[128byte]
+e4fff1ee : st4h {z14.h, z15.h, z16.h, z17.h}, p4, [x15, #-4, MUL VL] : st4h   %z14.h %z15.h %z16.h %z17.h %p4 -> -0x80(%x15)[128byte]
 e4f0f630 : st4h {z16.h, z17.h, z18.h, z19.h}, p5, [x17, #0, MUL VL] : st4h   %z16.h %z17.h %z18.h %z19.h %p5 -> (%x17)[128byte]
 e4f0f671 : st4h {z17.h, z18.h, z19.h, z20.h}, p5, [x19, #0, MUL VL] : st4h   %z17.h %z18.h %z19.h %z20.h %p5 -> (%x19)[128byte]
-e4f1f6b3 : st4h {z19.h, z20.h, z21.h, z22.h}, p5, [x21, #4, MUL VL] : st4h   %z19.h %z20.h %z21.h %z22.h %p5 -> +0x04(%x21)[128byte]
-e4f2faf5 : st4h {z21.h, z22.h, z23.h, z24.h}, p6, [x23, #8, MUL VL] : st4h   %z21.h %z22.h %z23.h %z24.h %p6 -> +0x08(%x23)[128byte]
-e4f3fb17 : st4h {z23.h, z24.h, z25.h, z26.h}, p6, [x24, #12, MUL VL] : st4h   %z23.h %z24.h %z25.h %z26.h %p6 -> +0x0c(%x24)[128byte]
-e4f4ff59 : st4h {z25.h, z26.h, z27.h, z28.h}, p7, [x26, #16, MUL VL] : st4h   %z25.h %z26.h %z27.h %z28.h %p7 -> +0x10(%x26)[128byte]
-e4f5ff9b : st4h {z27.h, z28.h, z29.h, z30.h}, p7, [x28, #20, MUL VL] : st4h   %z27.h %z28.h %z29.h %z30.h %p7 -> +0x14(%x28)[128byte]
-e4f7ffff : st4h {z31.h, z0.h, z1.h, z2.h}, p7, [sp, #28, MUL VL] : st4h   %z31.h %z0.h %z1.h %z2.h %p7 -> +0x1c(%sp)[128byte]
+e4f1f6b3 : st4h {z19.h, z20.h, z21.h, z22.h}, p5, [x21, #4, MUL VL] : st4h   %z19.h %z20.h %z21.h %z22.h %p5 -> +0x80(%x21)[128byte]
+e4f2faf5 : st4h {z21.h, z22.h, z23.h, z24.h}, p6, [x23, #8, MUL VL] : st4h   %z21.h %z22.h %z23.h %z24.h %p6 -> +0x0100(%x23)[128byte]
+e4f3fb17 : st4h {z23.h, z24.h, z25.h, z26.h}, p6, [x24, #12, MUL VL] : st4h   %z23.h %z24.h %z25.h %z26.h %p6 -> +0x0180(%x24)[128byte]
+e4f4ff59 : st4h {z25.h, z26.h, z27.h, z28.h}, p7, [x26, #16, MUL VL] : st4h   %z25.h %z26.h %z27.h %z28.h %p7 -> +0x0200(%x26)[128byte]
+e4f5ff9b : st4h {z27.h, z28.h, z29.h, z30.h}, p7, [x28, #20, MUL VL] : st4h   %z27.h %z28.h %z29.h %z30.h %p7 -> +0x0280(%x28)[128byte]
+e4f7ffff : st4h {z31.h, z0.h, z1.h, z2.h}, p7, [sp, #28, MUL VL] : st4h   %z31.h %z0.h %z1.h %z2.h %p7 -> +0x0380(%sp)[128byte]
 
 # ST4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>, [<Xn|SP>, <Xm>, LSL #2] (ST4W-Z.P.BR-Contiguous)
 e5606000 : st4w {z0.s, z1.s, z2.s, z3.s}, p0, [x0, x0, LSL #2] : st4w   %z0.s %z1.s %z2.s %z3.s %p0 -> (%x0,%x0,lsl #2)[128byte]
@@ -22282,22 +22282,22 @@ e57d7f9b : st4w {z27.s, z28.s, z29.s, z30.s}, p7, [x28, x29, LSL #2] : st4w   %z
 e57e7fff : st4w {z31.s, z0.s, z1.s, z2.s}, p7, [sp, x30, LSL #2] : st4w   %z31.s %z0.s %z1.s %z2.s %p7 -> (%sp,%x30,lsl #2)[128byte]
 
 # ST4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (ST4W-Z.P.BI-Contiguous)
-e578e000 : st4w {z0.s, z1.s, z2.s, z3.s}, p0, [x0, #-32, MUL VL] : st4w   %z0.s %z1.s %z2.s %z3.s %p0 -> -0x20(%x0)[128byte]
-e579e482 : st4w {z2.s, z3.s, z4.s, z5.s}, p1, [x4, #-28, MUL VL] : st4w   %z2.s %z3.s %z4.s %z5.s %p1 -> -0x1c(%x4)[128byte]
-e57ae8c4 : st4w {z4.s, z5.s, z6.s, z7.s}, p2, [x6, #-24, MUL VL] : st4w   %z4.s %z5.s %z6.s %z7.s %p2 -> -0x18(%x6)[128byte]
-e57be906 : st4w {z6.s, z7.s, z8.s, z9.s}, p2, [x8, #-20, MUL VL] : st4w   %z6.s %z7.s %z8.s %z9.s %p2 -> -0x14(%x8)[128byte]
-e57ced48 : st4w {z8.s, z9.s, z10.s, z11.s}, p3, [x10, #-16, MUL VL] : st4w   %z8.s %z9.s %z10.s %z11.s %p3 -> -0x10(%x10)[128byte]
-e57ded6a : st4w {z10.s, z11.s, z12.s, z13.s}, p3, [x11, #-12, MUL VL] : st4w   %z10.s %z11.s %z12.s %z13.s %p3 -> -0x0c(%x11)[128byte]
-e57ef1ac : st4w {z12.s, z13.s, z14.s, z15.s}, p4, [x13, #-8, MUL VL] : st4w   %z12.s %z13.s %z14.s %z15.s %p4 -> -0x08(%x13)[128byte]
-e57ff1ee : st4w {z14.s, z15.s, z16.s, z17.s}, p4, [x15, #-4, MUL VL] : st4w   %z14.s %z15.s %z16.s %z17.s %p4 -> -0x04(%x15)[128byte]
+e578e000 : st4w {z0.s, z1.s, z2.s, z3.s}, p0, [x0, #-32, MUL VL] : st4w   %z0.s %z1.s %z2.s %z3.s %p0 -> -0x0400(%x0)[128byte]
+e579e482 : st4w {z2.s, z3.s, z4.s, z5.s}, p1, [x4, #-28, MUL VL] : st4w   %z2.s %z3.s %z4.s %z5.s %p1 -> -0x0380(%x4)[128byte]
+e57ae8c4 : st4w {z4.s, z5.s, z6.s, z7.s}, p2, [x6, #-24, MUL VL] : st4w   %z4.s %z5.s %z6.s %z7.s %p2 -> -0x0300(%x6)[128byte]
+e57be906 : st4w {z6.s, z7.s, z8.s, z9.s}, p2, [x8, #-20, MUL VL] : st4w   %z6.s %z7.s %z8.s %z9.s %p2 -> -0x0280(%x8)[128byte]
+e57ced48 : st4w {z8.s, z9.s, z10.s, z11.s}, p3, [x10, #-16, MUL VL] : st4w   %z8.s %z9.s %z10.s %z11.s %p3 -> -0x0200(%x10)[128byte]
+e57ded6a : st4w {z10.s, z11.s, z12.s, z13.s}, p3, [x11, #-12, MUL VL] : st4w   %z10.s %z11.s %z12.s %z13.s %p3 -> -0x0180(%x11)[128byte]
+e57ef1ac : st4w {z12.s, z13.s, z14.s, z15.s}, p4, [x13, #-8, MUL VL] : st4w   %z12.s %z13.s %z14.s %z15.s %p4 -> -0x0100(%x13)[128byte]
+e57ff1ee : st4w {z14.s, z15.s, z16.s, z17.s}, p4, [x15, #-4, MUL VL] : st4w   %z14.s %z15.s %z16.s %z17.s %p4 -> -0x80(%x15)[128byte]
 e570f630 : st4w {z16.s, z17.s, z18.s, z19.s}, p5, [x17, #0, MUL VL] : st4w   %z16.s %z17.s %z18.s %z19.s %p5 -> (%x17)[128byte]
 e570f671 : st4w {z17.s, z18.s, z19.s, z20.s}, p5, [x19, #0, MUL VL] : st4w   %z17.s %z18.s %z19.s %z20.s %p5 -> (%x19)[128byte]
-e571f6b3 : st4w {z19.s, z20.s, z21.s, z22.s}, p5, [x21, #4, MUL VL] : st4w   %z19.s %z20.s %z21.s %z22.s %p5 -> +0x04(%x21)[128byte]
-e572faf5 : st4w {z21.s, z22.s, z23.s, z24.s}, p6, [x23, #8, MUL VL] : st4w   %z21.s %z22.s %z23.s %z24.s %p6 -> +0x08(%x23)[128byte]
-e573fb17 : st4w {z23.s, z24.s, z25.s, z26.s}, p6, [x24, #12, MUL VL] : st4w   %z23.s %z24.s %z25.s %z26.s %p6 -> +0x0c(%x24)[128byte]
-e574ff59 : st4w {z25.s, z26.s, z27.s, z28.s}, p7, [x26, #16, MUL VL] : st4w   %z25.s %z26.s %z27.s %z28.s %p7 -> +0x10(%x26)[128byte]
-e575ff9b : st4w {z27.s, z28.s, z29.s, z30.s}, p7, [x28, #20, MUL VL] : st4w   %z27.s %z28.s %z29.s %z30.s %p7 -> +0x14(%x28)[128byte]
-e577ffff : st4w {z31.s, z0.s, z1.s, z2.s}, p7, [sp, #28, MUL VL] : st4w   %z31.s %z0.s %z1.s %z2.s %p7 -> +0x1c(%sp)[128byte]
+e571f6b3 : st4w {z19.s, z20.s, z21.s, z22.s}, p5, [x21, #4, MUL VL] : st4w   %z19.s %z20.s %z21.s %z22.s %p5 -> +0x80(%x21)[128byte]
+e572faf5 : st4w {z21.s, z22.s, z23.s, z24.s}, p6, [x23, #8, MUL VL] : st4w   %z21.s %z22.s %z23.s %z24.s %p6 -> +0x0100(%x23)[128byte]
+e573fb17 : st4w {z23.s, z24.s, z25.s, z26.s}, p6, [x24, #12, MUL VL] : st4w   %z23.s %z24.s %z25.s %z26.s %p6 -> +0x0180(%x24)[128byte]
+e574ff59 : st4w {z25.s, z26.s, z27.s, z28.s}, p7, [x26, #16, MUL VL] : st4w   %z25.s %z26.s %z27.s %z28.s %p7 -> +0x0200(%x26)[128byte]
+e575ff9b : st4w {z27.s, z28.s, z29.s, z30.s}, p7, [x28, #20, MUL VL] : st4w   %z27.s %z28.s %z29.s %z30.s %p7 -> +0x0280(%x28)[128byte]
+e577ffff : st4w {z31.s, z0.s, z1.s, z2.s}, p7, [sp, #28, MUL VL] : st4w   %z31.s %z0.s %z1.s %z2.s %p7 -> +0x0380(%sp)[128byte]
 
 # STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>] (STNT1B-Z.P.BR-Contiguous)
 e4006000 : stnt1b z0.b, p0, [x0, x0]                 : stnt1b %z0.b %p0 -> (%x0,%x0)[32byte]
@@ -22318,22 +22318,22 @@ e41d7f9b : stnt1b z27.b, p7, [x28, x29]              : stnt1b %z27.b %p7 -> (%x2
 e41e7fff : stnt1b z31.b, p7, [sp, x30]               : stnt1b %z31.b %p7 -> (%sp,%x30)[32byte]
 
 # STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (STNT1B-Z.P.BI-Contiguous)
-e418e000 : stnt1b z0.b, p0, [x0, #-8, MUL VL]        : stnt1b %z0.b %p0 -> -0x08(%x0)[32byte]
-e419e482 : stnt1b z2.b, p1, [x4, #-7, MUL VL]        : stnt1b %z2.b %p1 -> -0x07(%x4)[32byte]
-e41ae8c4 : stnt1b z4.b, p2, [x6, #-6, MUL VL]        : stnt1b %z4.b %p2 -> -0x06(%x6)[32byte]
-e41be906 : stnt1b z6.b, p2, [x8, #-5, MUL VL]        : stnt1b %z6.b %p2 -> -0x05(%x8)[32byte]
-e41ced48 : stnt1b z8.b, p3, [x10, #-4, MUL VL]       : stnt1b %z8.b %p3 -> -0x04(%x10)[32byte]
-e41ded6a : stnt1b z10.b, p3, [x11, #-3, MUL VL]      : stnt1b %z10.b %p3 -> -0x03(%x11)[32byte]
-e41ef1ac : stnt1b z12.b, p4, [x13, #-2, MUL VL]      : stnt1b %z12.b %p4 -> -0x02(%x13)[32byte]
-e41ff1ee : stnt1b z14.b, p4, [x15, #-1, MUL VL]      : stnt1b %z14.b %p4 -> -0x01(%x15)[32byte]
+e418e000 : stnt1b z0.b, p0, [x0, #-8, MUL VL]        : stnt1b %z0.b %p0 -> -0x0100(%x0)[32byte]
+e419e482 : stnt1b z2.b, p1, [x4, #-7, MUL VL]        : stnt1b %z2.b %p1 -> -0xe0(%x4)[32byte]
+e41ae8c4 : stnt1b z4.b, p2, [x6, #-6, MUL VL]        : stnt1b %z4.b %p2 -> -0xc0(%x6)[32byte]
+e41be906 : stnt1b z6.b, p2, [x8, #-5, MUL VL]        : stnt1b %z6.b %p2 -> -0xa0(%x8)[32byte]
+e41ced48 : stnt1b z8.b, p3, [x10, #-4, MUL VL]       : stnt1b %z8.b %p3 -> -0x80(%x10)[32byte]
+e41ded6a : stnt1b z10.b, p3, [x11, #-3, MUL VL]      : stnt1b %z10.b %p3 -> -0x60(%x11)[32byte]
+e41ef1ac : stnt1b z12.b, p4, [x13, #-2, MUL VL]      : stnt1b %z12.b %p4 -> -0x40(%x13)[32byte]
+e41ff1ee : stnt1b z14.b, p4, [x15, #-1, MUL VL]      : stnt1b %z14.b %p4 -> -0x20(%x15)[32byte]
 e410f630 : stnt1b z16.b, p5, [x17, #0, MUL VL]       : stnt1b %z16.b %p5 -> (%x17)[32byte]
 e410f671 : stnt1b z17.b, p5, [x19, #0, MUL VL]       : stnt1b %z17.b %p5 -> (%x19)[32byte]
-e411f6b3 : stnt1b z19.b, p5, [x21, #1, MUL VL]       : stnt1b %z19.b %p5 -> +0x01(%x21)[32byte]
-e412faf5 : stnt1b z21.b, p6, [x23, #2, MUL VL]       : stnt1b %z21.b %p6 -> +0x02(%x23)[32byte]
-e413fb17 : stnt1b z23.b, p6, [x24, #3, MUL VL]       : stnt1b %z23.b %p6 -> +0x03(%x24)[32byte]
-e414ff59 : stnt1b z25.b, p7, [x26, #4, MUL VL]       : stnt1b %z25.b %p7 -> +0x04(%x26)[32byte]
-e415ff9b : stnt1b z27.b, p7, [x28, #5, MUL VL]       : stnt1b %z27.b %p7 -> +0x05(%x28)[32byte]
-e417ffff : stnt1b z31.b, p7, [sp, #7, MUL VL]        : stnt1b %z31.b %p7 -> +0x07(%sp)[32byte]
+e411f6b3 : stnt1b z19.b, p5, [x21, #1, MUL VL]       : stnt1b %z19.b %p5 -> +0x20(%x21)[32byte]
+e412faf5 : stnt1b z21.b, p6, [x23, #2, MUL VL]       : stnt1b %z21.b %p6 -> +0x40(%x23)[32byte]
+e413fb17 : stnt1b z23.b, p6, [x24, #3, MUL VL]       : stnt1b %z23.b %p6 -> +0x60(%x24)[32byte]
+e414ff59 : stnt1b z25.b, p7, [x26, #4, MUL VL]       : stnt1b %z25.b %p7 -> +0x80(%x26)[32byte]
+e415ff9b : stnt1b z27.b, p7, [x28, #5, MUL VL]       : stnt1b %z27.b %p7 -> +0xa0(%x28)[32byte]
+e417ffff : stnt1b z31.b, p7, [sp, #7, MUL VL]        : stnt1b %z31.b %p7 -> +0xe0(%sp)[32byte]
 
 # STNT1D  { <Zt>.D }, <Pg>, [<Xn|SP>, <Xm>, LSL #3] (STNT1D-Z.P.BR-Contiguous)
 e5806000 : stnt1d z0.d, p0, [x0, x0, LSL #3]         : stnt1d %z0.d %p0 -> (%x0,%x0,lsl #3)[32byte]
@@ -22354,22 +22354,22 @@ e59d7f9b : stnt1d z27.d, p7, [x28, x29, LSL #3]      : stnt1d %z27.d %p7 -> (%x2
 e59e7fff : stnt1d z31.d, p7, [sp, x30, LSL #3]       : stnt1d %z31.d %p7 -> (%sp,%x30,lsl #3)[32byte]
 
 # STNT1D  { <Zt>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (STNT1D-Z.P.BI-Contiguous)
-e598e000 : stnt1d z0.d, p0, [x0, #-8, MUL VL]        : stnt1d %z0.d %p0 -> -0x08(%x0)[32byte]
-e599e482 : stnt1d z2.d, p1, [x4, #-7, MUL VL]        : stnt1d %z2.d %p1 -> -0x07(%x4)[32byte]
-e59ae8c4 : stnt1d z4.d, p2, [x6, #-6, MUL VL]        : stnt1d %z4.d %p2 -> -0x06(%x6)[32byte]
-e59be906 : stnt1d z6.d, p2, [x8, #-5, MUL VL]        : stnt1d %z6.d %p2 -> -0x05(%x8)[32byte]
-e59ced48 : stnt1d z8.d, p3, [x10, #-4, MUL VL]       : stnt1d %z8.d %p3 -> -0x04(%x10)[32byte]
-e59ded6a : stnt1d z10.d, p3, [x11, #-3, MUL VL]      : stnt1d %z10.d %p3 -> -0x03(%x11)[32byte]
-e59ef1ac : stnt1d z12.d, p4, [x13, #-2, MUL VL]      : stnt1d %z12.d %p4 -> -0x02(%x13)[32byte]
-e59ff1ee : stnt1d z14.d, p4, [x15, #-1, MUL VL]      : stnt1d %z14.d %p4 -> -0x01(%x15)[32byte]
+e598e000 : stnt1d z0.d, p0, [x0, #-8, MUL VL]        : stnt1d %z0.d %p0 -> -0x0100(%x0)[32byte]
+e599e482 : stnt1d z2.d, p1, [x4, #-7, MUL VL]        : stnt1d %z2.d %p1 -> -0xe0(%x4)[32byte]
+e59ae8c4 : stnt1d z4.d, p2, [x6, #-6, MUL VL]        : stnt1d %z4.d %p2 -> -0xc0(%x6)[32byte]
+e59be906 : stnt1d z6.d, p2, [x8, #-5, MUL VL]        : stnt1d %z6.d %p2 -> -0xa0(%x8)[32byte]
+e59ced48 : stnt1d z8.d, p3, [x10, #-4, MUL VL]       : stnt1d %z8.d %p3 -> -0x80(%x10)[32byte]
+e59ded6a : stnt1d z10.d, p3, [x11, #-3, MUL VL]      : stnt1d %z10.d %p3 -> -0x60(%x11)[32byte]
+e59ef1ac : stnt1d z12.d, p4, [x13, #-2, MUL VL]      : stnt1d %z12.d %p4 -> -0x40(%x13)[32byte]
+e59ff1ee : stnt1d z14.d, p4, [x15, #-1, MUL VL]      : stnt1d %z14.d %p4 -> -0x20(%x15)[32byte]
 e590f630 : stnt1d z16.d, p5, [x17, #0, MUL VL]       : stnt1d %z16.d %p5 -> (%x17)[32byte]
 e590f671 : stnt1d z17.d, p5, [x19, #0, MUL VL]       : stnt1d %z17.d %p5 -> (%x19)[32byte]
-e591f6b3 : stnt1d z19.d, p5, [x21, #1, MUL VL]       : stnt1d %z19.d %p5 -> +0x01(%x21)[32byte]
-e592faf5 : stnt1d z21.d, p6, [x23, #2, MUL VL]       : stnt1d %z21.d %p6 -> +0x02(%x23)[32byte]
-e593fb17 : stnt1d z23.d, p6, [x24, #3, MUL VL]       : stnt1d %z23.d %p6 -> +0x03(%x24)[32byte]
-e594ff59 : stnt1d z25.d, p7, [x26, #4, MUL VL]       : stnt1d %z25.d %p7 -> +0x04(%x26)[32byte]
-e595ff9b : stnt1d z27.d, p7, [x28, #5, MUL VL]       : stnt1d %z27.d %p7 -> +0x05(%x28)[32byte]
-e597ffff : stnt1d z31.d, p7, [sp, #7, MUL VL]        : stnt1d %z31.d %p7 -> +0x07(%sp)[32byte]
+e591f6b3 : stnt1d z19.d, p5, [x21, #1, MUL VL]       : stnt1d %z19.d %p5 -> +0x20(%x21)[32byte]
+e592faf5 : stnt1d z21.d, p6, [x23, #2, MUL VL]       : stnt1d %z21.d %p6 -> +0x40(%x23)[32byte]
+e593fb17 : stnt1d z23.d, p6, [x24, #3, MUL VL]       : stnt1d %z23.d %p6 -> +0x60(%x24)[32byte]
+e594ff59 : stnt1d z25.d, p7, [x26, #4, MUL VL]       : stnt1d %z25.d %p7 -> +0x80(%x26)[32byte]
+e595ff9b : stnt1d z27.d, p7, [x28, #5, MUL VL]       : stnt1d %z27.d %p7 -> +0xa0(%x28)[32byte]
+e597ffff : stnt1d z31.d, p7, [sp, #7, MUL VL]        : stnt1d %z31.d %p7 -> +0xe0(%sp)[32byte]
 
 # STNT1H  { <Zt>.H }, <Pg>, [<Xn|SP>, <Xm>, LSL #1] (STNT1H-Z.P.BR-Contiguous)
 e4806000 : stnt1h z0.h, p0, [x0, x0, LSL #1]         : stnt1h %z0.h %p0 -> (%x0,%x0,lsl #1)[32byte]
@@ -22390,22 +22390,22 @@ e49d7f9b : stnt1h z27.h, p7, [x28, x29, LSL #1]      : stnt1h %z27.h %p7 -> (%x2
 e49e7fff : stnt1h z31.h, p7, [sp, x30, LSL #1]       : stnt1h %z31.h %p7 -> (%sp,%x30,lsl #1)[32byte]
 
 # STNT1H  { <Zt>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (STNT1H-Z.P.BI-Contiguous)
-e498e000 : stnt1h z0.h, p0, [x0, #-8, MUL VL]        : stnt1h %z0.h %p0 -> -0x08(%x0)[32byte]
-e499e482 : stnt1h z2.h, p1, [x4, #-7, MUL VL]        : stnt1h %z2.h %p1 -> -0x07(%x4)[32byte]
-e49ae8c4 : stnt1h z4.h, p2, [x6, #-6, MUL VL]        : stnt1h %z4.h %p2 -> -0x06(%x6)[32byte]
-e49be906 : stnt1h z6.h, p2, [x8, #-5, MUL VL]        : stnt1h %z6.h %p2 -> -0x05(%x8)[32byte]
-e49ced48 : stnt1h z8.h, p3, [x10, #-4, MUL VL]       : stnt1h %z8.h %p3 -> -0x04(%x10)[32byte]
-e49ded6a : stnt1h z10.h, p3, [x11, #-3, MUL VL]      : stnt1h %z10.h %p3 -> -0x03(%x11)[32byte]
-e49ef1ac : stnt1h z12.h, p4, [x13, #-2, MUL VL]      : stnt1h %z12.h %p4 -> -0x02(%x13)[32byte]
-e49ff1ee : stnt1h z14.h, p4, [x15, #-1, MUL VL]      : stnt1h %z14.h %p4 -> -0x01(%x15)[32byte]
+e498e000 : stnt1h z0.h, p0, [x0, #-8, MUL VL]        : stnt1h %z0.h %p0 -> -0x0100(%x0)[32byte]
+e499e482 : stnt1h z2.h, p1, [x4, #-7, MUL VL]        : stnt1h %z2.h %p1 -> -0xe0(%x4)[32byte]
+e49ae8c4 : stnt1h z4.h, p2, [x6, #-6, MUL VL]        : stnt1h %z4.h %p2 -> -0xc0(%x6)[32byte]
+e49be906 : stnt1h z6.h, p2, [x8, #-5, MUL VL]        : stnt1h %z6.h %p2 -> -0xa0(%x8)[32byte]
+e49ced48 : stnt1h z8.h, p3, [x10, #-4, MUL VL]       : stnt1h %z8.h %p3 -> -0x80(%x10)[32byte]
+e49ded6a : stnt1h z10.h, p3, [x11, #-3, MUL VL]      : stnt1h %z10.h %p3 -> -0x60(%x11)[32byte]
+e49ef1ac : stnt1h z12.h, p4, [x13, #-2, MUL VL]      : stnt1h %z12.h %p4 -> -0x40(%x13)[32byte]
+e49ff1ee : stnt1h z14.h, p4, [x15, #-1, MUL VL]      : stnt1h %z14.h %p4 -> -0x20(%x15)[32byte]
 e490f630 : stnt1h z16.h, p5, [x17, #0, MUL VL]       : stnt1h %z16.h %p5 -> (%x17)[32byte]
 e490f671 : stnt1h z17.h, p5, [x19, #0, MUL VL]       : stnt1h %z17.h %p5 -> (%x19)[32byte]
-e491f6b3 : stnt1h z19.h, p5, [x21, #1, MUL VL]       : stnt1h %z19.h %p5 -> +0x01(%x21)[32byte]
-e492faf5 : stnt1h z21.h, p6, [x23, #2, MUL VL]       : stnt1h %z21.h %p6 -> +0x02(%x23)[32byte]
-e493fb17 : stnt1h z23.h, p6, [x24, #3, MUL VL]       : stnt1h %z23.h %p6 -> +0x03(%x24)[32byte]
-e494ff59 : stnt1h z25.h, p7, [x26, #4, MUL VL]       : stnt1h %z25.h %p7 -> +0x04(%x26)[32byte]
-e495ff9b : stnt1h z27.h, p7, [x28, #5, MUL VL]       : stnt1h %z27.h %p7 -> +0x05(%x28)[32byte]
-e497ffff : stnt1h z31.h, p7, [sp, #7, MUL VL]        : stnt1h %z31.h %p7 -> +0x07(%sp)[32byte]
+e491f6b3 : stnt1h z19.h, p5, [x21, #1, MUL VL]       : stnt1h %z19.h %p5 -> +0x20(%x21)[32byte]
+e492faf5 : stnt1h z21.h, p6, [x23, #2, MUL VL]       : stnt1h %z21.h %p6 -> +0x40(%x23)[32byte]
+e493fb17 : stnt1h z23.h, p6, [x24, #3, MUL VL]       : stnt1h %z23.h %p6 -> +0x60(%x24)[32byte]
+e494ff59 : stnt1h z25.h, p7, [x26, #4, MUL VL]       : stnt1h %z25.h %p7 -> +0x80(%x26)[32byte]
+e495ff9b : stnt1h z27.h, p7, [x28, #5, MUL VL]       : stnt1h %z27.h %p7 -> +0xa0(%x28)[32byte]
+e497ffff : stnt1h z31.h, p7, [sp, #7, MUL VL]        : stnt1h %z31.h %p7 -> +0xe0(%sp)[32byte]
 
 # STNT1W  { <Zt>.S }, <Pg>, [<Xn|SP>, <Xm>, LSL #2] (STNT1W-Z.P.BR-Contiguous)
 e5006000 : stnt1w z0.s, p0, [x0, x0, LSL #2]         : stnt1w %z0.s %p0 -> (%x0,%x0,lsl #2)[32byte]
@@ -22426,22 +22426,22 @@ e51d7f9b : stnt1w z27.s, p7, [x28, x29, LSL #2]      : stnt1w %z27.s %p7 -> (%x2
 e51e7fff : stnt1w z31.s, p7, [sp, x30, LSL #2]       : stnt1w %z31.s %p7 -> (%sp,%x30,lsl #2)[32byte]
 
 # STNT1W  { <Zt>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] (STNT1W-Z.P.BI-Contiguous)
-e518e000 : stnt1w z0.s, p0, [x0, #-8, MUL VL]        : stnt1w %z0.s %p0 -> -0x08(%x0)[32byte]
-e519e482 : stnt1w z2.s, p1, [x4, #-7, MUL VL]        : stnt1w %z2.s %p1 -> -0x07(%x4)[32byte]
-e51ae8c4 : stnt1w z4.s, p2, [x6, #-6, MUL VL]        : stnt1w %z4.s %p2 -> -0x06(%x6)[32byte]
-e51be906 : stnt1w z6.s, p2, [x8, #-5, MUL VL]        : stnt1w %z6.s %p2 -> -0x05(%x8)[32byte]
-e51ced48 : stnt1w z8.s, p3, [x10, #-4, MUL VL]       : stnt1w %z8.s %p3 -> -0x04(%x10)[32byte]
-e51ded6a : stnt1w z10.s, p3, [x11, #-3, MUL VL]      : stnt1w %z10.s %p3 -> -0x03(%x11)[32byte]
-e51ef1ac : stnt1w z12.s, p4, [x13, #-2, MUL VL]      : stnt1w %z12.s %p4 -> -0x02(%x13)[32byte]
-e51ff1ee : stnt1w z14.s, p4, [x15, #-1, MUL VL]      : stnt1w %z14.s %p4 -> -0x01(%x15)[32byte]
+e518e000 : stnt1w z0.s, p0, [x0, #-8, MUL VL]        : stnt1w %z0.s %p0 -> -0x0100(%x0)[32byte]
+e519e482 : stnt1w z2.s, p1, [x4, #-7, MUL VL]        : stnt1w %z2.s %p1 -> -0xe0(%x4)[32byte]
+e51ae8c4 : stnt1w z4.s, p2, [x6, #-6, MUL VL]        : stnt1w %z4.s %p2 -> -0xc0(%x6)[32byte]
+e51be906 : stnt1w z6.s, p2, [x8, #-5, MUL VL]        : stnt1w %z6.s %p2 -> -0xa0(%x8)[32byte]
+e51ced48 : stnt1w z8.s, p3, [x10, #-4, MUL VL]       : stnt1w %z8.s %p3 -> -0x80(%x10)[32byte]
+e51ded6a : stnt1w z10.s, p3, [x11, #-3, MUL VL]      : stnt1w %z10.s %p3 -> -0x60(%x11)[32byte]
+e51ef1ac : stnt1w z12.s, p4, [x13, #-2, MUL VL]      : stnt1w %z12.s %p4 -> -0x40(%x13)[32byte]
+e51ff1ee : stnt1w z14.s, p4, [x15, #-1, MUL VL]      : stnt1w %z14.s %p4 -> -0x20(%x15)[32byte]
 e510f630 : stnt1w z16.s, p5, [x17, #0, MUL VL]       : stnt1w %z16.s %p5 -> (%x17)[32byte]
 e510f671 : stnt1w z17.s, p5, [x19, #0, MUL VL]       : stnt1w %z17.s %p5 -> (%x19)[32byte]
-e511f6b3 : stnt1w z19.s, p5, [x21, #1, MUL VL]       : stnt1w %z19.s %p5 -> +0x01(%x21)[32byte]
-e512faf5 : stnt1w z21.s, p6, [x23, #2, MUL VL]       : stnt1w %z21.s %p6 -> +0x02(%x23)[32byte]
-e513fb17 : stnt1w z23.s, p6, [x24, #3, MUL VL]       : stnt1w %z23.s %p6 -> +0x03(%x24)[32byte]
-e514ff59 : stnt1w z25.s, p7, [x26, #4, MUL VL]       : stnt1w %z25.s %p7 -> +0x04(%x26)[32byte]
-e515ff9b : stnt1w z27.s, p7, [x28, #5, MUL VL]       : stnt1w %z27.s %p7 -> +0x05(%x28)[32byte]
-e517ffff : stnt1w z31.s, p7, [sp, #7, MUL VL]        : stnt1w %z31.s %p7 -> +0x07(%sp)[32byte]
+e511f6b3 : stnt1w z19.s, p5, [x21, #1, MUL VL]       : stnt1w %z19.s %p5 -> +0x20(%x21)[32byte]
+e512faf5 : stnt1w z21.s, p6, [x23, #2, MUL VL]       : stnt1w %z21.s %p6 -> +0x40(%x23)[32byte]
+e513fb17 : stnt1w z23.s, p6, [x24, #3, MUL VL]       : stnt1w %z23.s %p6 -> +0x60(%x24)[32byte]
+e514ff59 : stnt1w z25.s, p7, [x26, #4, MUL VL]       : stnt1w %z25.s %p7 -> +0x80(%x26)[32byte]
+e515ff9b : stnt1w z27.s, p7, [x28, #5, MUL VL]       : stnt1w %z27.s %p7 -> +0xa0(%x28)[32byte]
+e517ffff : stnt1w z31.s, p7, [sp, #7, MUL VL]        : stnt1w %z31.s %p7 -> +0xe0(%sp)[32byte]
 
 # STR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
 e58003c0 : str p0, [x30]                            : str    %p0 -> (%x30)[4byte]

--- a/suite/tests/api/ir_aarch64_sve.c
+++ b/suite/tests/api/ir_aarch64_sve.c
@@ -15357,63 +15357,63 @@ TEST_INSTR(ld1b_sve_pred)
     /* Testing LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_8_0[6] = {
-        "ld1b   -0x08(%x0)[16byte] %p0/z -> %z0.h",
-        "ld1b   -0x03(%x7)[16byte] %p2/z -> %z5.h",
+        "ld1b   -0x80(%x0)[16byte] %p0/z -> %z0.h",
+        "ld1b   -0x30(%x7)[16byte] %p2/z -> %z5.h",
         "ld1b   (%x12)[16byte] %p3/z -> %z10.h",
-        "ld1b   +0x03(%x17)[16byte] %p5/z -> %z16.h",
-        "ld1b   +0x05(%x22)[16byte] %p6/z -> %z21.h",
-        "ld1b   +0x07(%sp)[16byte] %p7/z -> %z31.h",
+        "ld1b   +0x30(%x17)[16byte] %p5/z -> %z16.h",
+        "ld1b   +0x50(%x22)[16byte] %p6/z -> %z21.h",
+        "ld1b   +0x70(%sp)[16byte] %p7/z -> %z31.h",
     };
-    TEST_LOOP(
-        ld1b, ld1b_sve_pred, 6, expected_8_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_8_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_9_0[6] = {
-        "ld1b   -0x08(%x0)[8byte] %p0/z -> %z0.s",
-        "ld1b   -0x03(%x7)[8byte] %p2/z -> %z5.s",
+        "ld1b   -0x40(%x0)[8byte] %p0/z -> %z0.s",
+        "ld1b   -0x18(%x7)[8byte] %p2/z -> %z5.s",
         "ld1b   (%x12)[8byte] %p3/z -> %z10.s",
-        "ld1b   +0x03(%x17)[8byte] %p5/z -> %z16.s",
-        "ld1b   +0x05(%x22)[8byte] %p6/z -> %z21.s",
-        "ld1b   +0x07(%sp)[8byte] %p7/z -> %z31.s",
+        "ld1b   +0x18(%x17)[8byte] %p5/z -> %z16.s",
+        "ld1b   +0x28(%x22)[8byte] %p6/z -> %z21.s",
+        "ld1b   +0x38(%sp)[8byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ld1b, ld1b_sve_pred, 6, expected_9_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_9_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 
     /* Testing LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_10_0[6] = {
-        "ld1b   -0x08(%x0)[4byte] %p0/z -> %z0.d",
-        "ld1b   -0x03(%x7)[4byte] %p2/z -> %z5.d",
+        "ld1b   -0x20(%x0)[4byte] %p0/z -> %z0.d",
+        "ld1b   -0x0c(%x7)[4byte] %p2/z -> %z5.d",
         "ld1b   (%x12)[4byte] %p3/z -> %z10.d",
-        "ld1b   +0x03(%x17)[4byte] %p5/z -> %z16.d",
-        "ld1b   +0x05(%x22)[4byte] %p6/z -> %z21.d",
-        "ld1b   +0x07(%sp)[4byte] %p7/z -> %z31.d",
+        "ld1b   +0x0c(%x17)[4byte] %p5/z -> %z16.d",
+        "ld1b   +0x14(%x22)[4byte] %p6/z -> %z21.d",
+        "ld1b   +0x1c(%sp)[4byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ld1b, ld1b_sve_pred, 6, expected_10_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_4));
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_10_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 4 * imm4[i],
+                                    OPSZ_4));
 
     /* Testing LD1B    { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_11_0[6] = {
-        "ld1b   -0x08(%x0)[32byte] %p0/z -> %z0.b",
-        "ld1b   -0x03(%x7)[32byte] %p2/z -> %z5.b",
+        "ld1b   -0x0100(%x0)[32byte] %p0/z -> %z0.b",
+        "ld1b   -0x60(%x7)[32byte] %p2/z -> %z5.b",
         "ld1b   (%x12)[32byte] %p3/z -> %z10.b",
-        "ld1b   +0x03(%x17)[32byte] %p5/z -> %z16.b",
-        "ld1b   +0x05(%x22)[32byte] %p6/z -> %z21.b",
-        "ld1b   +0x07(%sp)[32byte] %p7/z -> %z31.b",
+        "ld1b   +0x60(%x17)[32byte] %p5/z -> %z16.b",
+        "ld1b   +0xa0(%x22)[32byte] %p6/z -> %z21.b",
+        "ld1b   +0xe0(%sp)[32byte] %p7/z -> %z31.b",
     };
-    TEST_LOOP(
-        ld1b, ld1b_sve_pred, 6, expected_11_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(ld1b, ld1b_sve_pred, 6, expected_11_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 }
 
 TEST_INSTR(ld1rob_sve_pred)
@@ -15735,48 +15735,48 @@ TEST_INSTR(ld1sb_sve_pred)
     /* Testing LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_7_0[6] = {
-        "ld1sb  -0x08(%x0)[16byte] %p0/z -> %z0.h",
-        "ld1sb  -0x03(%x7)[16byte] %p2/z -> %z5.h",
+        "ld1sb  -0x80(%x0)[16byte] %p0/z -> %z0.h",
+        "ld1sb  -0x30(%x7)[16byte] %p2/z -> %z5.h",
         "ld1sb  (%x12)[16byte] %p3/z -> %z10.h",
-        "ld1sb  +0x03(%x17)[16byte] %p5/z -> %z16.h",
-        "ld1sb  +0x05(%x22)[16byte] %p6/z -> %z21.h",
-        "ld1sb  +0x07(%sp)[16byte] %p7/z -> %z31.h",
+        "ld1sb  +0x30(%x17)[16byte] %p5/z -> %z16.h",
+        "ld1sb  +0x50(%x22)[16byte] %p6/z -> %z21.h",
+        "ld1sb  +0x70(%sp)[16byte] %p7/z -> %z31.h",
     };
-    TEST_LOOP(
-        ld1sb, ld1sb_sve_pred, 6, expected_7_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_7_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_8_0[6] = {
-        "ld1sb  -0x08(%x0)[8byte] %p0/z -> %z0.s",
-        "ld1sb  -0x03(%x7)[8byte] %p2/z -> %z5.s",
+        "ld1sb  -0x40(%x0)[8byte] %p0/z -> %z0.s",
+        "ld1sb  -0x18(%x7)[8byte] %p2/z -> %z5.s",
         "ld1sb  (%x12)[8byte] %p3/z -> %z10.s",
-        "ld1sb  +0x03(%x17)[8byte] %p5/z -> %z16.s",
-        "ld1sb  +0x05(%x22)[8byte] %p6/z -> %z21.s",
-        "ld1sb  +0x07(%sp)[8byte] %p7/z -> %z31.s",
+        "ld1sb  +0x18(%x17)[8byte] %p5/z -> %z16.s",
+        "ld1sb  +0x28(%x22)[8byte] %p6/z -> %z21.s",
+        "ld1sb  +0x38(%sp)[8byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ld1sb, ld1sb_sve_pred, 6, expected_8_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_8_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 
     /* Testing LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_9_0[6] = {
-        "ld1sb  -0x08(%x0)[4byte] %p0/z -> %z0.d",
-        "ld1sb  -0x03(%x7)[4byte] %p2/z -> %z5.d",
+        "ld1sb  -0x20(%x0)[4byte] %p0/z -> %z0.d",
+        "ld1sb  -0x0c(%x7)[4byte] %p2/z -> %z5.d",
         "ld1sb  (%x12)[4byte] %p3/z -> %z10.d",
-        "ld1sb  +0x03(%x17)[4byte] %p5/z -> %z16.d",
-        "ld1sb  +0x05(%x22)[4byte] %p6/z -> %z21.d",
-        "ld1sb  +0x07(%sp)[4byte] %p7/z -> %z31.d",
+        "ld1sb  +0x0c(%x17)[4byte] %p5/z -> %z16.d",
+        "ld1sb  +0x14(%x22)[4byte] %p6/z -> %z21.d",
+        "ld1sb  +0x1c(%sp)[4byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ld1sb, ld1sb_sve_pred, 6, expected_9_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_4));
+    TEST_LOOP(ld1sb, ld1sb_sve_pred, 6, expected_9_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 4 * imm4[i],
+                                    OPSZ_4));
 }
 
 TEST_INSTR(ldnt1b_sve_pred)
@@ -15797,14 +15797,14 @@ TEST_INSTR(ldnt1b_sve_pred)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
 
     /* Testing LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4_1_0[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4_1_0[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "ldnt1b -0x08(%x0)[32byte] %p0/z -> %z0.b",
-        "ldnt1b -0x03(%x7)[32byte] %p2/z -> %z5.b",
+        "ldnt1b -0x0100(%x0)[32byte] %p0/z -> %z0.b",
+        "ldnt1b -0x60(%x7)[32byte] %p2/z -> %z5.b",
         "ldnt1b (%x12)[32byte] %p3/z -> %z10.b",
-        "ldnt1b +0x03(%x17)[32byte] %p5/z -> %z16.b",
-        "ldnt1b +0x05(%x22)[32byte] %p6/z -> %z21.b",
-        "ldnt1b +0x07(%sp)[32byte] %p7/z -> %z31.b",
+        "ldnt1b +0x60(%x17)[32byte] %p5/z -> %z16.b",
+        "ldnt1b +0xa0(%x22)[32byte] %p6/z -> %z21.b",
+        "ldnt1b +0xe0(%sp)[32byte] %p7/z -> %z31.b",
     };
     TEST_LOOP(ldnt1b, ldnt1b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -15986,60 +15986,60 @@ TEST_INSTR(st1b_sve_pred)
     /* Testing ST1B    { <Zt>.<Ts> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_5_0[6] = {
-        "st1b   %z0.b %p0 -> -0x08(%x0)[32byte]",
-        "st1b   %z5.b %p2 -> -0x03(%x7)[32byte]",
+        "st1b   %z0.b %p0 -> -0x0100(%x0)[32byte]",
+        "st1b   %z5.b %p2 -> -0x60(%x7)[32byte]",
         "st1b   %z10.b %p3 -> (%x12)[32byte]",
-        "st1b   %z16.b %p5 -> +0x03(%x17)[32byte]",
-        "st1b   %z21.b %p6 -> +0x05(%x22)[32byte]",
-        "st1b   %z31.b %p7 -> +0x07(%sp)[32byte]",
+        "st1b   %z16.b %p5 -> +0x60(%x17)[32byte]",
+        "st1b   %z21.b %p6 -> +0xa0(%x22)[32byte]",
+        "st1b   %z31.b %p7 -> +0xe0(%sp)[32byte]",
     };
-    TEST_LOOP(
-        st1b, st1b_sve_pred, 6, expected_5_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_5_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 
     const char *const expected_5_1[6] = {
-        "st1b   %z0.h %p0 -> -0x08(%x0)[16byte]",
-        "st1b   %z5.h %p2 -> -0x03(%x7)[16byte]",
+        "st1b   %z0.h %p0 -> -0x80(%x0)[16byte]",
+        "st1b   %z5.h %p2 -> -0x30(%x7)[16byte]",
         "st1b   %z10.h %p3 -> (%x12)[16byte]",
-        "st1b   %z16.h %p5 -> +0x03(%x17)[16byte]",
-        "st1b   %z21.h %p6 -> +0x05(%x22)[16byte]",
-        "st1b   %z31.h %p7 -> +0x07(%sp)[16byte]",
+        "st1b   %z16.h %p5 -> +0x30(%x17)[16byte]",
+        "st1b   %z21.h %p6 -> +0x50(%x22)[16byte]",
+        "st1b   %z31.h %p7 -> +0x70(%sp)[16byte]",
     };
-    TEST_LOOP(
-        st1b, st1b_sve_pred, 6, expected_5_1[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_5_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     const char *const expected_5_2[6] = {
-        "st1b   %z0.s %p0 -> -0x08(%x0)[8byte]",
-        "st1b   %z5.s %p2 -> -0x03(%x7)[8byte]",
+        "st1b   %z0.s %p0 -> -0x40(%x0)[8byte]",
+        "st1b   %z5.s %p2 -> -0x18(%x7)[8byte]",
         "st1b   %z10.s %p3 -> (%x12)[8byte]",
-        "st1b   %z16.s %p5 -> +0x03(%x17)[8byte]",
-        "st1b   %z21.s %p6 -> +0x05(%x22)[8byte]",
-        "st1b   %z31.s %p7 -> +0x07(%sp)[8byte]",
+        "st1b   %z16.s %p5 -> +0x18(%x17)[8byte]",
+        "st1b   %z21.s %p6 -> +0x28(%x22)[8byte]",
+        "st1b   %z31.s %p7 -> +0x38(%sp)[8byte]",
     };
-    TEST_LOOP(
-        st1b, st1b_sve_pred, 6, expected_5_2[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_5_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 
     const char *const expected_5_3[6] = {
-        "st1b   %z0.d %p0 -> -0x08(%x0)[4byte]",
-        "st1b   %z5.d %p2 -> -0x03(%x7)[4byte]",
+        "st1b   %z0.d %p0 -> -0x20(%x0)[4byte]",
+        "st1b   %z5.d %p2 -> -0x0c(%x7)[4byte]",
         "st1b   %z10.d %p3 -> (%x12)[4byte]",
-        "st1b   %z16.d %p5 -> +0x03(%x17)[4byte]",
-        "st1b   %z21.d %p6 -> +0x05(%x22)[4byte]",
-        "st1b   %z31.d %p7 -> +0x07(%sp)[4byte]",
+        "st1b   %z16.d %p5 -> +0x0c(%x17)[4byte]",
+        "st1b   %z21.d %p6 -> +0x14(%x22)[4byte]",
+        "st1b   %z31.d %p7 -> +0x1c(%sp)[4byte]",
     };
-    TEST_LOOP(
-        st1b, st1b_sve_pred, 6, expected_5_3[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_4));
+    TEST_LOOP(st1b, st1b_sve_pred, 6, expected_5_3[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 4 * imm4[i],
+                                    OPSZ_4));
 }
 
 TEST_INSTR(stnt1b_sve_pred)
@@ -16060,14 +16060,14 @@ TEST_INSTR(stnt1b_sve_pred)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32));
 
     /* Testing STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4_1_0[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4_1_0[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "stnt1b %z0.b %p0 -> -0x08(%x0)[32byte]",
-        "stnt1b %z5.b %p2 -> -0x03(%x7)[32byte]",
+        "stnt1b %z0.b %p0 -> -0x0100(%x0)[32byte]",
+        "stnt1b %z5.b %p2 -> -0x60(%x7)[32byte]",
         "stnt1b %z10.b %p3 -> (%x12)[32byte]",
-        "stnt1b %z16.b %p5 -> +0x03(%x17)[32byte]",
-        "stnt1b %z21.b %p6 -> +0x05(%x22)[32byte]",
-        "stnt1b %z31.b %p7 -> +0x07(%sp)[32byte]",
+        "stnt1b %z16.b %p5 -> +0x60(%x17)[32byte]",
+        "stnt1b %z21.b %p6 -> +0xa0(%x22)[32byte]",
+        "stnt1b %z31.b %p7 -> +0xe0(%sp)[32byte]",
     };
     TEST_LOOP(stnt1b, stnt1b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -17074,14 +17074,14 @@ TEST_INSTR(ld2b_sve_pred)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_64));
 
     /* Testing LD2B    { <Zt1>.B, <Zt2>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4_1_0[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4_1_0[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "ld2b   -0x10(%x0)[64byte] %p0/z -> %z0.b %z1.b",
-        "ld2b   -0x06(%x7)[64byte] %p2/z -> %z5.b %z6.b",
+        "ld2b   -0x0200(%x0)[64byte] %p0/z -> %z0.b %z1.b",
+        "ld2b   -0xc0(%x7)[64byte] %p2/z -> %z5.b %z6.b",
         "ld2b   (%x12)[64byte] %p3/z -> %z10.b %z11.b",
-        "ld2b   +0x06(%x17)[64byte] %p5/z -> %z16.b %z17.b",
-        "ld2b   +0x0a(%x22)[64byte] %p6/z -> %z21.b %z22.b",
-        "ld2b   +0x0e(%sp)[64byte] %p7/z -> %z31.b %z0.b",
+        "ld2b   +0xc0(%x17)[64byte] %p5/z -> %z16.b %z17.b",
+        "ld2b   +0x0140(%x22)[64byte] %p6/z -> %z21.b %z22.b",
+        "ld2b   +0x01c0(%sp)[64byte] %p7/z -> %z31.b %z0.b",
     };
     TEST_LOOP(ld2b, ld2b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -17109,14 +17109,14 @@ TEST_INSTR(ld3b_sve_pred)
 
     /* Testing LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
      */
-    static const int imm4_1_0[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4_1_0[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "ld3b   -0x18(%x0)[96byte] %p0/z -> %z0.b %z1.b %z2.b",
-        "ld3b   -0x09(%x7)[96byte] %p2/z -> %z5.b %z6.b %z7.b",
+        "ld3b   -0x0300(%x0)[96byte] %p0/z -> %z0.b %z1.b %z2.b",
+        "ld3b   -0x0120(%x7)[96byte] %p2/z -> %z5.b %z6.b %z7.b",
         "ld3b   (%x12)[96byte] %p3/z -> %z10.b %z11.b %z12.b",
-        "ld3b   +0x09(%x17)[96byte] %p5/z -> %z16.b %z17.b %z18.b",
-        "ld3b   +0x0f(%x22)[96byte] %p6/z -> %z21.b %z22.b %z23.b",
-        "ld3b   +0x15(%sp)[96byte] %p7/z -> %z31.b %z0.b %z1.b",
+        "ld3b   +0x0120(%x17)[96byte] %p5/z -> %z16.b %z17.b %z18.b",
+        "ld3b   +0x01e0(%x22)[96byte] %p6/z -> %z21.b %z22.b %z23.b",
+        "ld3b   +0x02a0(%sp)[96byte] %p7/z -> %z31.b %z0.b %z1.b",
     };
     TEST_LOOP(ld3b, ld3b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -17145,14 +17145,14 @@ TEST_INSTR(ld4b_sve_pred)
 
     /* Testing LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>,
      * MUL VL}] */
-    static const int imm4_1_0[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4_1_0[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "ld4b   -0x20(%x0)[128byte] %p0/z -> %z0.b %z1.b %z2.b %z3.b",
-        "ld4b   -0x0c(%x7)[128byte] %p2/z -> %z5.b %z6.b %z7.b %z8.b",
+        "ld4b   -0x0400(%x0)[128byte] %p0/z -> %z0.b %z1.b %z2.b %z3.b",
+        "ld4b   -0x0180(%x7)[128byte] %p2/z -> %z5.b %z6.b %z7.b %z8.b",
         "ld4b   (%x12)[128byte] %p3/z -> %z10.b %z11.b %z12.b %z13.b",
-        "ld4b   +0x0c(%x17)[128byte] %p5/z -> %z16.b %z17.b %z18.b %z19.b",
-        "ld4b   +0x14(%x22)[128byte] %p6/z -> %z21.b %z22.b %z23.b %z24.b",
-        "ld4b   +0x1c(%sp)[128byte] %p7/z -> %z31.b %z0.b %z1.b %z2.b",
+        "ld4b   +0x0180(%x17)[128byte] %p5/z -> %z16.b %z17.b %z18.b %z19.b",
+        "ld4b   +0x0280(%x22)[128byte] %p6/z -> %z21.b %z22.b %z23.b %z24.b",
+        "ld4b   +0x0380(%sp)[128byte] %p7/z -> %z31.b %z0.b %z1.b %z2.b",
     };
     TEST_LOOP(ld4b, ld4b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -17179,14 +17179,14 @@ TEST_INSTR(st2b_sve_pred)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_64));
 
     /* Testing ST2B    { <Zt1>.B, <Zt2>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4_1_0[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4_1_0[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "st2b   %z0.b %z1.b %p0 -> -0x10(%x0)[64byte]",
-        "st2b   %z5.b %z6.b %p2 -> -0x06(%x7)[64byte]",
+        "st2b   %z0.b %z1.b %p0 -> -0x0200(%x0)[64byte]",
+        "st2b   %z5.b %z6.b %p2 -> -0xc0(%x7)[64byte]",
         "st2b   %z10.b %z11.b %p3 -> (%x12)[64byte]",
-        "st2b   %z16.b %z17.b %p5 -> +0x06(%x17)[64byte]",
-        "st2b   %z21.b %z22.b %p6 -> +0x0a(%x22)[64byte]",
-        "st2b   %z31.b %z0.b %p7 -> +0x0e(%sp)[64byte]",
+        "st2b   %z16.b %z17.b %p5 -> +0xc0(%x17)[64byte]",
+        "st2b   %z21.b %z22.b %p6 -> +0x0140(%x22)[64byte]",
+        "st2b   %z31.b %z0.b %p7 -> +0x01c0(%sp)[64byte]",
     };
     TEST_LOOP(st2b, st2b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -17214,14 +17214,14 @@ TEST_INSTR(st3b_sve_pred)
 
     /* Testing ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
      */
-    static const int imm4_1_0[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4_1_0[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "st3b   %z0.b %z1.b %z2.b %p0 -> -0x18(%x0)[96byte]",
-        "st3b   %z5.b %z6.b %z7.b %p2 -> -0x09(%x7)[96byte]",
+        "st3b   %z0.b %z1.b %z2.b %p0 -> -0x0300(%x0)[96byte]",
+        "st3b   %z5.b %z6.b %z7.b %p2 -> -0x0120(%x7)[96byte]",
         "st3b   %z10.b %z11.b %z12.b %p3 -> (%x12)[96byte]",
-        "st3b   %z16.b %z17.b %z18.b %p5 -> +0x09(%x17)[96byte]",
-        "st3b   %z21.b %z22.b %z23.b %p6 -> +0x0f(%x22)[96byte]",
-        "st3b   %z31.b %z0.b %z1.b %p7 -> +0x15(%sp)[96byte]",
+        "st3b   %z16.b %z17.b %z18.b %p5 -> +0x0120(%x17)[96byte]",
+        "st3b   %z21.b %z22.b %z23.b %p6 -> +0x01e0(%x22)[96byte]",
+        "st3b   %z31.b %z0.b %z1.b %p7 -> +0x02a0(%sp)[96byte]",
     };
     TEST_LOOP(st3b, st3b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -17250,14 +17250,14 @@ TEST_INSTR(st4b_sve_pred)
 
     /* Testing ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>{, #<simm>,
      * MUL VL}] */
-    static const int imm4_1_0[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4_1_0[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "st4b   %z0.b %z1.b %z2.b %z3.b %p0 -> -0x20(%x0)[128byte]",
-        "st4b   %z5.b %z6.b %z7.b %z8.b %p2 -> -0x0c(%x7)[128byte]",
+        "st4b   %z0.b %z1.b %z2.b %z3.b %p0 -> -0x0400(%x0)[128byte]",
+        "st4b   %z5.b %z6.b %z7.b %z8.b %p2 -> -0x0180(%x7)[128byte]",
         "st4b   %z10.b %z11.b %z12.b %z13.b %p3 -> (%x12)[128byte]",
-        "st4b   %z16.b %z17.b %z18.b %z19.b %p5 -> +0x0c(%x17)[128byte]",
-        "st4b   %z21.b %z22.b %z23.b %z24.b %p6 -> +0x14(%x22)[128byte]",
-        "st4b   %z31.b %z0.b %z1.b %z2.b %p7 -> +0x1c(%sp)[128byte]",
+        "st4b   %z16.b %z17.b %z18.b %z19.b %p5 -> +0x0180(%x17)[128byte]",
+        "st4b   %z21.b %z22.b %z23.b %z24.b %p6 -> +0x0280(%x22)[128byte]",
+        "st4b   %z31.b %z0.b %z1.b %z2.b %p7 -> +0x0380(%sp)[128byte]",
     };
     TEST_LOOP(st4b, st4b_sve_pred, 6, expected_1_0[i],
               opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
@@ -17508,48 +17508,48 @@ TEST_INSTR(ld1h_sve_pred)
     /* Testing LD1H    { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_10_0[6] = {
-        "ld1h   -0x08(%x0)[32byte] %p0/z -> %z0.h",
-        "ld1h   -0x03(%x7)[32byte] %p2/z -> %z5.h",
+        "ld1h   -0x0100(%x0)[32byte] %p0/z -> %z0.h",
+        "ld1h   -0x60(%x7)[32byte] %p2/z -> %z5.h",
         "ld1h   (%x12)[32byte] %p3/z -> %z10.h",
-        "ld1h   +0x03(%x17)[32byte] %p5/z -> %z16.h",
-        "ld1h   +0x05(%x22)[32byte] %p6/z -> %z21.h",
-        "ld1h   +0x07(%sp)[32byte] %p7/z -> %z31.h",
+        "ld1h   +0x60(%x17)[32byte] %p5/z -> %z16.h",
+        "ld1h   +0xa0(%x22)[32byte] %p6/z -> %z21.h",
+        "ld1h   +0xe0(%sp)[32byte] %p7/z -> %z31.h",
     };
-    TEST_LOOP(
-        ld1h, ld1h_sve_pred, 6, expected_10_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_10_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 
     /* Testing LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_11_0[6] = {
-        "ld1h   -0x08(%x0)[16byte] %p0/z -> %z0.s",
-        "ld1h   -0x03(%x7)[16byte] %p2/z -> %z5.s",
+        "ld1h   -0x80(%x0)[16byte] %p0/z -> %z0.s",
+        "ld1h   -0x30(%x7)[16byte] %p2/z -> %z5.s",
         "ld1h   (%x12)[16byte] %p3/z -> %z10.s",
-        "ld1h   +0x03(%x17)[16byte] %p5/z -> %z16.s",
-        "ld1h   +0x05(%x22)[16byte] %p6/z -> %z21.s",
-        "ld1h   +0x07(%sp)[16byte] %p7/z -> %z31.s",
+        "ld1h   +0x30(%x17)[16byte] %p5/z -> %z16.s",
+        "ld1h   +0x50(%x22)[16byte] %p6/z -> %z21.s",
+        "ld1h   +0x70(%sp)[16byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ld1h, ld1h_sve_pred, 6, expected_11_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_11_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_12_0[6] = {
-        "ld1h   -0x08(%x0)[8byte] %p0/z -> %z0.d",
-        "ld1h   -0x03(%x7)[8byte] %p2/z -> %z5.d",
+        "ld1h   -0x40(%x0)[8byte] %p0/z -> %z0.d",
+        "ld1h   -0x18(%x7)[8byte] %p2/z -> %z5.d",
         "ld1h   (%x12)[8byte] %p3/z -> %z10.d",
-        "ld1h   +0x03(%x17)[8byte] %p5/z -> %z16.d",
-        "ld1h   +0x05(%x22)[8byte] %p6/z -> %z21.d",
-        "ld1h   +0x07(%sp)[8byte] %p7/z -> %z31.d",
+        "ld1h   +0x18(%x17)[8byte] %p5/z -> %z16.d",
+        "ld1h   +0x28(%x22)[8byte] %p6/z -> %z21.d",
+        "ld1h   +0x38(%sp)[8byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ld1h, ld1h_sve_pred, 6, expected_12_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ld1h, ld1h_sve_pred, 6, expected_12_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 }
 
 TEST_INSTR(ld1sh_sve_pred)
@@ -17778,33 +17778,33 @@ TEST_INSTR(ld1sh_sve_pred)
     /* Testing LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_9_0[6] = {
-        "ld1sh  -0x08(%x0)[16byte] %p0/z -> %z0.s",
-        "ld1sh  -0x03(%x7)[16byte] %p2/z -> %z5.s",
+        "ld1sh  -0x80(%x0)[16byte] %p0/z -> %z0.s",
+        "ld1sh  -0x30(%x7)[16byte] %p2/z -> %z5.s",
         "ld1sh  (%x12)[16byte] %p3/z -> %z10.s",
-        "ld1sh  +0x03(%x17)[16byte] %p5/z -> %z16.s",
-        "ld1sh  +0x05(%x22)[16byte] %p6/z -> %z21.s",
-        "ld1sh  +0x07(%sp)[16byte] %p7/z -> %z31.s",
+        "ld1sh  +0x30(%x17)[16byte] %p5/z -> %z16.s",
+        "ld1sh  +0x50(%x22)[16byte] %p6/z -> %z21.s",
+        "ld1sh  +0x70(%sp)[16byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ld1sh, ld1sh_sve_pred, 6, expected_9_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_9_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_10_0[6] = {
-        "ld1sh  -0x08(%x0)[8byte] %p0/z -> %z0.d",
-        "ld1sh  -0x03(%x7)[8byte] %p2/z -> %z5.d",
+        "ld1sh  -0x40(%x0)[8byte] %p0/z -> %z0.d",
+        "ld1sh  -0x18(%x7)[8byte] %p2/z -> %z5.d",
         "ld1sh  (%x12)[8byte] %p3/z -> %z10.d",
-        "ld1sh  +0x03(%x17)[8byte] %p5/z -> %z16.d",
-        "ld1sh  +0x05(%x22)[8byte] %p6/z -> %z21.d",
-        "ld1sh  +0x07(%sp)[8byte] %p7/z -> %z31.d",
+        "ld1sh  +0x18(%x17)[8byte] %p5/z -> %z16.d",
+        "ld1sh  +0x28(%x22)[8byte] %p6/z -> %z21.d",
+        "ld1sh  +0x38(%sp)[8byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ld1sh, ld1sh_sve_pred, 6, expected_10_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ld1sh, ld1sh_sve_pred, 6, expected_10_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 }
 
 TEST_INSTR(ld1w_sve_pred)
@@ -18032,33 +18032,33 @@ TEST_INSTR(ld1w_sve_pred)
     /* Testing LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_9_0[6] = {
-        "ld1w   -0x08(%x0)[32byte] %p0/z -> %z0.s",
-        "ld1w   -0x03(%x7)[32byte] %p2/z -> %z5.s",
+        "ld1w   -0x0100(%x0)[32byte] %p0/z -> %z0.s",
+        "ld1w   -0x60(%x7)[32byte] %p2/z -> %z5.s",
         "ld1w   (%x12)[32byte] %p3/z -> %z10.s",
-        "ld1w   +0x03(%x17)[32byte] %p5/z -> %z16.s",
-        "ld1w   +0x05(%x22)[32byte] %p6/z -> %z21.s",
-        "ld1w   +0x07(%sp)[32byte] %p7/z -> %z31.s",
+        "ld1w   +0x60(%x17)[32byte] %p5/z -> %z16.s",
+        "ld1w   +0xa0(%x22)[32byte] %p6/z -> %z21.s",
+        "ld1w   +0xe0(%sp)[32byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ld1w, ld1w_sve_pred, 6, expected_9_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_9_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 
     /* Testing LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_10_0[6] = {
-        "ld1w   -0x08(%x0)[16byte] %p0/z -> %z0.d",
-        "ld1w   -0x03(%x7)[16byte] %p2/z -> %z5.d",
+        "ld1w   -0x80(%x0)[16byte] %p0/z -> %z0.d",
+        "ld1w   -0x30(%x7)[16byte] %p2/z -> %z5.d",
         "ld1w   (%x12)[16byte] %p3/z -> %z10.d",
-        "ld1w   +0x03(%x17)[16byte] %p5/z -> %z16.d",
-        "ld1w   +0x05(%x22)[16byte] %p6/z -> %z21.d",
-        "ld1w   +0x07(%sp)[16byte] %p7/z -> %z31.d",
+        "ld1w   +0x30(%x17)[16byte] %p5/z -> %z16.d",
+        "ld1w   +0x50(%x22)[16byte] %p6/z -> %z21.d",
+        "ld1w   +0x70(%sp)[16byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ld1w, ld1w_sve_pred, 6, expected_10_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ld1w, ld1w_sve_pred, 6, expected_10_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 }
 
 TEST_INSTR(ld1d_sve_pred)
@@ -18191,14 +18191,14 @@ TEST_INSTR(ld1d_sve_pred)
                                                   true, 0, 0, OPSZ_32, 3));
 
     /* Testing LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_6_0[6] = {
-        "ld1d   -0x08(%x0)[32byte] %p0/z -> %z0.d",
-        "ld1d   -0x03(%x7)[32byte] %p2/z -> %z5.d",
+        "ld1d   -0x0100(%x0)[32byte] %p0/z -> %z0.d",
+        "ld1d   -0x60(%x7)[32byte] %p2/z -> %z5.d",
         "ld1d   (%x12)[32byte] %p3/z -> %z10.d",
-        "ld1d   +0x03(%x17)[32byte] %p5/z -> %z16.d",
-        "ld1d   +0x05(%x22)[32byte] %p6/z -> %z21.d",
-        "ld1d   +0x07(%sp)[32byte] %p7/z -> %z31.d",
+        "ld1d   +0x60(%x17)[32byte] %p5/z -> %z16.d",
+        "ld1d   +0xa0(%x22)[32byte] %p6/z -> %z21.d",
+        "ld1d   +0xe0(%sp)[32byte] %p7/z -> %z31.d",
     };
     TEST_LOOP(
         ld1d, ld1d_sve_pred, 6, expected_6_0[i],
@@ -18337,14 +18337,14 @@ TEST_INSTR(ld1sw_sve_pred)
                                                   true, 0, 0, OPSZ_16, 2));
 
     /* Testing LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -128, -48, 0, 48, 80, 112 };
     const char *const expected_6_0[6] = {
-        "ld1sw  -0x08(%x0)[16byte] %p0/z -> %z0.d",
-        "ld1sw  -0x03(%x7)[16byte] %p2/z -> %z5.d",
+        "ld1sw  -0x80(%x0)[16byte] %p0/z -> %z0.d",
+        "ld1sw  -0x30(%x7)[16byte] %p2/z -> %z5.d",
         "ld1sw  (%x12)[16byte] %p3/z -> %z10.d",
-        "ld1sw  +0x03(%x17)[16byte] %p5/z -> %z16.d",
-        "ld1sw  +0x05(%x22)[16byte] %p6/z -> %z21.d",
-        "ld1sw  +0x07(%sp)[16byte] %p7/z -> %z31.d",
+        "ld1sw  +0x30(%x17)[16byte] %p5/z -> %z16.d",
+        "ld1sw  +0x50(%x22)[16byte] %p6/z -> %z21.d",
+        "ld1sw  +0x70(%sp)[16byte] %p7/z -> %z31.d",
     };
     TEST_LOOP(
         ld1sw, ld1sw_sve_pred, 6, expected_6_0[i],
@@ -18593,46 +18593,46 @@ TEST_INSTR(st1h_sve_pred)
     /* Testing ST1H    { <Zt>.<Ts> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_8_0[6] = {
-        "st1h   %z0.h %p0 -> -0x08(%x0)[32byte]",
-        "st1h   %z5.h %p2 -> -0x03(%x7)[32byte]",
+        "st1h   %z0.h %p0 -> -0x0100(%x0)[32byte]",
+        "st1h   %z5.h %p2 -> -0x60(%x7)[32byte]",
         "st1h   %z10.h %p3 -> (%x12)[32byte]",
-        "st1h   %z16.h %p5 -> +0x03(%x17)[32byte]",
-        "st1h   %z21.h %p6 -> +0x05(%x22)[32byte]",
-        "st1h   %z31.h %p7 -> +0x07(%sp)[32byte]",
+        "st1h   %z16.h %p5 -> +0x60(%x17)[32byte]",
+        "st1h   %z21.h %p6 -> +0xa0(%x22)[32byte]",
+        "st1h   %z31.h %p7 -> +0xe0(%sp)[32byte]",
     };
-    TEST_LOOP(
-        st1h, st1h_sve_pred, 6, expected_8_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_8_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 
     const char *const expected_8_1[6] = {
-        "st1h   %z0.s %p0 -> -0x08(%x0)[16byte]",
-        "st1h   %z5.s %p2 -> -0x03(%x7)[16byte]",
+        "st1h   %z0.s %p0 -> -0x80(%x0)[16byte]",
+        "st1h   %z5.s %p2 -> -0x30(%x7)[16byte]",
         "st1h   %z10.s %p3 -> (%x12)[16byte]",
-        "st1h   %z16.s %p5 -> +0x03(%x17)[16byte]",
-        "st1h   %z21.s %p6 -> +0x05(%x22)[16byte]",
-        "st1h   %z31.s %p7 -> +0x07(%sp)[16byte]",
+        "st1h   %z16.s %p5 -> +0x30(%x17)[16byte]",
+        "st1h   %z21.s %p6 -> +0x50(%x22)[16byte]",
+        "st1h   %z31.s %p7 -> +0x70(%sp)[16byte]",
     };
-    TEST_LOOP(
-        st1h, st1h_sve_pred, 6, expected_8_1[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_8_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     const char *const expected_8_2[6] = {
-        "st1h   %z0.d %p0 -> -0x08(%x0)[8byte]",
-        "st1h   %z5.d %p2 -> -0x03(%x7)[8byte]",
+        "st1h   %z0.d %p0 -> -0x40(%x0)[8byte]",
+        "st1h   %z5.d %p2 -> -0x18(%x7)[8byte]",
         "st1h   %z10.d %p3 -> (%x12)[8byte]",
-        "st1h   %z16.d %p5 -> +0x03(%x17)[8byte]",
-        "st1h   %z21.d %p6 -> +0x05(%x22)[8byte]",
-        "st1h   %z31.d %p7 -> +0x07(%sp)[8byte]",
+        "st1h   %z16.d %p5 -> +0x18(%x17)[8byte]",
+        "st1h   %z21.d %p6 -> +0x28(%x22)[8byte]",
+        "st1h   %z31.d %p7 -> +0x38(%sp)[8byte]",
     };
-    TEST_LOOP(
-        st1h, st1h_sve_pred, 6, expected_8_2[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(st1h, st1h_sve_pred, 6, expected_8_2[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 }
 
 TEST_INSTR(st1w_sve_pred)
@@ -18860,32 +18860,32 @@ TEST_INSTR(st1w_sve_pred)
     /* Testing ST1W    { <Zt>.<Ts> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_8_0[6] = {
-        "st1w   %z0.s %p0 -> -0x08(%x0)[32byte]",
-        "st1w   %z5.s %p2 -> -0x03(%x7)[32byte]",
+        "st1w   %z0.s %p0 -> -0x0100(%x0)[32byte]",
+        "st1w   %z5.s %p2 -> -0x60(%x7)[32byte]",
         "st1w   %z10.s %p3 -> (%x12)[32byte]",
-        "st1w   %z16.s %p5 -> +0x03(%x17)[32byte]",
-        "st1w   %z21.s %p6 -> +0x05(%x22)[32byte]",
-        "st1w   %z31.s %p7 -> +0x07(%sp)[32byte]",
+        "st1w   %z16.s %p5 -> +0x60(%x17)[32byte]",
+        "st1w   %z21.s %p6 -> +0xa0(%x22)[32byte]",
+        "st1w   %z31.s %p7 -> +0xe0(%sp)[32byte]",
     };
-    TEST_LOOP(
-        st1w, st1w_sve_pred, 6, expected_8_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_8_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 
     const char *const expected_8_1[6] = {
-        "st1w   %z0.d %p0 -> -0x08(%x0)[16byte]",
-        "st1w   %z5.d %p2 -> -0x03(%x7)[16byte]",
+        "st1w   %z0.d %p0 -> -0x80(%x0)[16byte]",
+        "st1w   %z5.d %p2 -> -0x30(%x7)[16byte]",
         "st1w   %z10.d %p3 -> (%x12)[16byte]",
-        "st1w   %z16.d %p5 -> +0x03(%x17)[16byte]",
-        "st1w   %z21.d %p6 -> +0x05(%x22)[16byte]",
-        "st1w   %z31.d %p7 -> +0x07(%sp)[16byte]",
+        "st1w   %z16.d %p5 -> +0x30(%x17)[16byte]",
+        "st1w   %z21.d %p6 -> +0x50(%x22)[16byte]",
+        "st1w   %z31.d %p7 -> +0x70(%sp)[16byte]",
     };
-    TEST_LOOP(
-        st1w, st1w_sve_pred, 6, expected_8_1[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_reg(Pn_half_six_offset_0[i]),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(st1w, st1w_sve_pred, 6, expected_8_1[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 }
 
 TEST_INSTR(st1d_sve_pred)
@@ -19018,14 +19018,14 @@ TEST_INSTR(st1d_sve_pred)
                                                   true, 0, 0, OPSZ_32, 3));
 
     /* Testing ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_6_0[6] = {
-        "st1d   %z0.d %p0 -> -0x08(%x0)[32byte]",
-        "st1d   %z5.d %p2 -> -0x03(%x7)[32byte]",
+        "st1d   %z0.d %p0 -> -0x0100(%x0)[32byte]",
+        "st1d   %z5.d %p2 -> -0x60(%x7)[32byte]",
         "st1d   %z10.d %p3 -> (%x12)[32byte]",
-        "st1d   %z16.d %p5 -> +0x03(%x17)[32byte]",
-        "st1d   %z21.d %p6 -> +0x05(%x22)[32byte]",
-        "st1d   %z31.d %p7 -> +0x07(%sp)[32byte]",
+        "st1d   %z16.d %p5 -> +0x60(%x17)[32byte]",
+        "st1d   %z21.d %p6 -> +0xa0(%x22)[32byte]",
+        "st1d   %z31.d %p7 -> +0xe0(%sp)[32byte]",
     };
     TEST_LOOP(
         st1d, st1d_sve_pred, 6, expected_6_0[i],
@@ -19053,14 +19053,14 @@ TEST_INSTR(ld2d_sve_pred)
                                                   true, 0, 0, OPSZ_64, 3));
 
     /* Testing LD2D    { <Zt1>.D, <Zt2>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "ld2d   -0x10(%x0)[64byte] %p0/z -> %z0.d %z1.d",
-        "ld2d   -0x06(%x7)[64byte] %p2/z -> %z5.d %z6.d",
+        "ld2d   -0x0200(%x0)[64byte] %p0/z -> %z0.d %z1.d",
+        "ld2d   -0xc0(%x7)[64byte] %p2/z -> %z5.d %z6.d",
         "ld2d   (%x12)[64byte] %p3/z -> %z10.d %z11.d",
-        "ld2d   +0x06(%x17)[64byte] %p5/z -> %z16.d %z17.d",
-        "ld2d   +0x0a(%x22)[64byte] %p6/z -> %z21.d %z22.d",
-        "ld2d   +0x0e(%sp)[64byte] %p7/z -> %z31.d %z0.d",
+        "ld2d   +0xc0(%x17)[64byte] %p5/z -> %z16.d %z17.d",
+        "ld2d   +0x0140(%x22)[64byte] %p6/z -> %z21.d %z22.d",
+        "ld2d   +0x01c0(%sp)[64byte] %p7/z -> %z31.d %z0.d",
     };
     TEST_LOOP(
         ld2d, ld2d_sve_pred, 6, expected_1_0[i],
@@ -19088,14 +19088,14 @@ TEST_INSTR(ld2h_sve_pred)
                                                   true, 0, 0, OPSZ_64, 1));
 
     /* Testing LD2H    { <Zt1>.H, <Zt2>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "ld2h   -0x10(%x0)[64byte] %p0/z -> %z0.h %z1.h",
-        "ld2h   -0x06(%x7)[64byte] %p2/z -> %z5.h %z6.h",
+        "ld2h   -0x0200(%x0)[64byte] %p0/z -> %z0.h %z1.h",
+        "ld2h   -0xc0(%x7)[64byte] %p2/z -> %z5.h %z6.h",
         "ld2h   (%x12)[64byte] %p3/z -> %z10.h %z11.h",
-        "ld2h   +0x06(%x17)[64byte] %p5/z -> %z16.h %z17.h",
-        "ld2h   +0x0a(%x22)[64byte] %p6/z -> %z21.h %z22.h",
-        "ld2h   +0x0e(%sp)[64byte] %p7/z -> %z31.h %z0.h",
+        "ld2h   +0xc0(%x17)[64byte] %p5/z -> %z16.h %z17.h",
+        "ld2h   +0x0140(%x22)[64byte] %p6/z -> %z21.h %z22.h",
+        "ld2h   +0x01c0(%sp)[64byte] %p7/z -> %z31.h %z0.h",
     };
     TEST_LOOP(
         ld2h, ld2h_sve_pred, 6, expected_1_0[i],
@@ -19123,14 +19123,14 @@ TEST_INSTR(ld2w_sve_pred)
                                                   true, 0, 0, OPSZ_64, 2));
 
     /* Testing LD2W    { <Zt1>.S, <Zt2>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "ld2w   -0x10(%x0)[64byte] %p0/z -> %z0.s %z1.s",
-        "ld2w   -0x06(%x7)[64byte] %p2/z -> %z5.s %z6.s",
+        "ld2w   -0x0200(%x0)[64byte] %p0/z -> %z0.s %z1.s",
+        "ld2w   -0xc0(%x7)[64byte] %p2/z -> %z5.s %z6.s",
         "ld2w   (%x12)[64byte] %p3/z -> %z10.s %z11.s",
-        "ld2w   +0x06(%x17)[64byte] %p5/z -> %z16.s %z17.s",
-        "ld2w   +0x0a(%x22)[64byte] %p6/z -> %z21.s %z22.s",
-        "ld2w   +0x0e(%sp)[64byte] %p7/z -> %z31.s %z0.s",
+        "ld2w   +0xc0(%x17)[64byte] %p5/z -> %z16.s %z17.s",
+        "ld2w   +0x0140(%x22)[64byte] %p6/z -> %z21.s %z22.s",
+        "ld2w   +0x01c0(%sp)[64byte] %p7/z -> %z31.s %z0.s",
     };
     TEST_LOOP(
         ld2w, ld2w_sve_pred, 6, expected_1_0[i],
@@ -19144,76 +19144,76 @@ TEST_INSTR(ldnf1b_sve_pred)
     /* Testing LDNF1B  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_0_0[6] = {
-        "ldnf1b -0x08(%x0)[16byte] %p0/z -> %z0.h",
-        "ldnf1b -0x03(%x7)[16byte] %p2/z -> %z5.h",
+        "ldnf1b -0x80(%x0)[16byte] %p0/z -> %z0.h",
+        "ldnf1b -0x30(%x7)[16byte] %p2/z -> %z5.h",
         "ldnf1b (%x12)[16byte] %p3/z -> %z10.h",
-        "ldnf1b +0x03(%x17)[16byte] %p5/z -> %z16.h",
-        "ldnf1b +0x05(%x22)[16byte] %p6/z -> %z21.h",
-        "ldnf1b +0x07(%sp)[16byte] %p7/z -> %z31.h",
+        "ldnf1b +0x30(%x17)[16byte] %p5/z -> %z16.h",
+        "ldnf1b +0x50(%x22)[16byte] %p6/z -> %z21.h",
+        "ldnf1b +0x70(%sp)[16byte] %p7/z -> %z31.h",
     };
-    TEST_LOOP(
-        ldnf1b, ldnf1b_sve_pred, 6, expected_0_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ldnf1b, ldnf1b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LDNF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_1_0[6] = {
-        "ldnf1b -0x08(%x0)[8byte] %p0/z -> %z0.s",
-        "ldnf1b -0x03(%x7)[8byte] %p2/z -> %z5.s",
+        "ldnf1b -0x40(%x0)[8byte] %p0/z -> %z0.s",
+        "ldnf1b -0x18(%x7)[8byte] %p2/z -> %z5.s",
         "ldnf1b (%x12)[8byte] %p3/z -> %z10.s",
-        "ldnf1b +0x03(%x17)[8byte] %p5/z -> %z16.s",
-        "ldnf1b +0x05(%x22)[8byte] %p6/z -> %z21.s",
-        "ldnf1b +0x07(%sp)[8byte] %p7/z -> %z31.s",
+        "ldnf1b +0x18(%x17)[8byte] %p5/z -> %z16.s",
+        "ldnf1b +0x28(%x22)[8byte] %p6/z -> %z21.s",
+        "ldnf1b +0x38(%sp)[8byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ldnf1b, ldnf1b_sve_pred, 6, expected_1_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ldnf1b, ldnf1b_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 
     /* Testing LDNF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_2_0[6] = {
-        "ldnf1b -0x08(%x0)[4byte] %p0/z -> %z0.d",
-        "ldnf1b -0x03(%x7)[4byte] %p2/z -> %z5.d",
+        "ldnf1b -0x20(%x0)[4byte] %p0/z -> %z0.d",
+        "ldnf1b -0x0c(%x7)[4byte] %p2/z -> %z5.d",
         "ldnf1b (%x12)[4byte] %p3/z -> %z10.d",
-        "ldnf1b +0x03(%x17)[4byte] %p5/z -> %z16.d",
-        "ldnf1b +0x05(%x22)[4byte] %p6/z -> %z21.d",
-        "ldnf1b +0x07(%sp)[4byte] %p7/z -> %z31.d",
+        "ldnf1b +0x0c(%x17)[4byte] %p5/z -> %z16.d",
+        "ldnf1b +0x14(%x22)[4byte] %p6/z -> %z21.d",
+        "ldnf1b +0x1c(%sp)[4byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ldnf1b, ldnf1b_sve_pred, 6, expected_2_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_4));
+    TEST_LOOP(ldnf1b, ldnf1b_sve_pred, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 4 * imm4[i],
+                                    OPSZ_4));
 
     /* Testing LDNF1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_3_0[6] = {
-        "ldnf1b -0x08(%x0)[32byte] %p0/z -> %z0.b",
-        "ldnf1b -0x03(%x7)[32byte] %p2/z -> %z5.b",
+        "ldnf1b -0x0100(%x0)[32byte] %p0/z -> %z0.b",
+        "ldnf1b -0x60(%x7)[32byte] %p2/z -> %z5.b",
         "ldnf1b (%x12)[32byte] %p3/z -> %z10.b",
-        "ldnf1b +0x03(%x17)[32byte] %p5/z -> %z16.b",
-        "ldnf1b +0x05(%x22)[32byte] %p6/z -> %z21.b",
-        "ldnf1b +0x07(%sp)[32byte] %p7/z -> %z31.b",
+        "ldnf1b +0x60(%x17)[32byte] %p5/z -> %z16.b",
+        "ldnf1b +0xa0(%x22)[32byte] %p6/z -> %z21.b",
+        "ldnf1b +0xe0(%sp)[32byte] %p7/z -> %z31.b",
     };
-    TEST_LOOP(
-        ldnf1b, ldnf1b_sve_pred, 6, expected_3_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(ldnf1b, ldnf1b_sve_pred, 6, expected_3_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_1),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 }
 
 TEST_INSTR(ldnf1d_sve_pred)
 {
     /* Testing LDNF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_0_0[6] = {
-        "ldnf1d -0x08(%x0)[32byte] %p0/z -> %z0.d",
-        "ldnf1d -0x03(%x7)[32byte] %p2/z -> %z5.d",
+        "ldnf1d -0x0100(%x0)[32byte] %p0/z -> %z0.d",
+        "ldnf1d -0x60(%x7)[32byte] %p2/z -> %z5.d",
         "ldnf1d (%x12)[32byte] %p3/z -> %z10.d",
-        "ldnf1d +0x03(%x17)[32byte] %p5/z -> %z16.d",
-        "ldnf1d +0x05(%x22)[32byte] %p6/z -> %z21.d",
-        "ldnf1d +0x07(%sp)[32byte] %p7/z -> %z31.d",
+        "ldnf1d +0x60(%x17)[32byte] %p5/z -> %z16.d",
+        "ldnf1d +0xa0(%x22)[32byte] %p6/z -> %z21.d",
+        "ldnf1d +0xe0(%sp)[32byte] %p7/z -> %z31.d",
     };
     TEST_LOOP(
         ldnf1d, ldnf1d_sve_pred, 6, expected_0_0[i],
@@ -19227,48 +19227,48 @@ TEST_INSTR(ldnf1h_sve_pred)
     /* Testing LDNF1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_0_0[6] = {
-        "ldnf1h -0x08(%x0)[32byte] %p0/z -> %z0.h",
-        "ldnf1h -0x03(%x7)[32byte] %p2/z -> %z5.h",
+        "ldnf1h -0x0100(%x0)[32byte] %p0/z -> %z0.h",
+        "ldnf1h -0x60(%x7)[32byte] %p2/z -> %z5.h",
         "ldnf1h (%x12)[32byte] %p3/z -> %z10.h",
-        "ldnf1h +0x03(%x17)[32byte] %p5/z -> %z16.h",
-        "ldnf1h +0x05(%x22)[32byte] %p6/z -> %z21.h",
-        "ldnf1h +0x07(%sp)[32byte] %p7/z -> %z31.h",
+        "ldnf1h +0x60(%x17)[32byte] %p5/z -> %z16.h",
+        "ldnf1h +0xa0(%x22)[32byte] %p6/z -> %z21.h",
+        "ldnf1h +0xe0(%sp)[32byte] %p7/z -> %z31.h",
     };
-    TEST_LOOP(
-        ldnf1h, ldnf1h_sve_pred, 6, expected_0_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(ldnf1h, ldnf1h_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 
     /* Testing LDNF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_1_0[6] = {
-        "ldnf1h -0x08(%x0)[16byte] %p0/z -> %z0.s",
-        "ldnf1h -0x03(%x7)[16byte] %p2/z -> %z5.s",
+        "ldnf1h -0x80(%x0)[16byte] %p0/z -> %z0.s",
+        "ldnf1h -0x30(%x7)[16byte] %p2/z -> %z5.s",
         "ldnf1h (%x12)[16byte] %p3/z -> %z10.s",
-        "ldnf1h +0x03(%x17)[16byte] %p5/z -> %z16.s",
-        "ldnf1h +0x05(%x22)[16byte] %p6/z -> %z21.s",
-        "ldnf1h +0x07(%sp)[16byte] %p7/z -> %z31.s",
+        "ldnf1h +0x30(%x17)[16byte] %p5/z -> %z16.s",
+        "ldnf1h +0x50(%x22)[16byte] %p6/z -> %z21.s",
+        "ldnf1h +0x70(%sp)[16byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ldnf1h, ldnf1h_sve_pred, 6, expected_1_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ldnf1h, ldnf1h_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LDNF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_2_0[6] = {
-        "ldnf1h -0x08(%x0)[8byte] %p0/z -> %z0.d",
-        "ldnf1h -0x03(%x7)[8byte] %p2/z -> %z5.d",
+        "ldnf1h -0x40(%x0)[8byte] %p0/z -> %z0.d",
+        "ldnf1h -0x18(%x7)[8byte] %p2/z -> %z5.d",
         "ldnf1h (%x12)[8byte] %p3/z -> %z10.d",
-        "ldnf1h +0x03(%x17)[8byte] %p5/z -> %z16.d",
-        "ldnf1h +0x05(%x22)[8byte] %p6/z -> %z21.d",
-        "ldnf1h +0x07(%sp)[8byte] %p7/z -> %z31.d",
+        "ldnf1h +0x18(%x17)[8byte] %p5/z -> %z16.d",
+        "ldnf1h +0x28(%x22)[8byte] %p6/z -> %z21.d",
+        "ldnf1h +0x38(%sp)[8byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ldnf1h, ldnf1h_sve_pred, 6, expected_2_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ldnf1h, ldnf1h_sve_pred, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 }
 
 TEST_INSTR(ldnf1sb_sve_pred)
@@ -19276,48 +19276,48 @@ TEST_INSTR(ldnf1sb_sve_pred)
     /* Testing LDNF1SB { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_0_0[6] = {
-        "ldnf1sb -0x08(%x0)[16byte] %p0/z -> %z0.h",
-        "ldnf1sb -0x03(%x7)[16byte] %p2/z -> %z5.h",
+        "ldnf1sb -0x80(%x0)[16byte] %p0/z -> %z0.h",
+        "ldnf1sb -0x30(%x7)[16byte] %p2/z -> %z5.h",
         "ldnf1sb (%x12)[16byte] %p3/z -> %z10.h",
-        "ldnf1sb +0x03(%x17)[16byte] %p5/z -> %z16.h",
-        "ldnf1sb +0x05(%x22)[16byte] %p6/z -> %z21.h",
-        "ldnf1sb +0x07(%sp)[16byte] %p7/z -> %z31.h",
+        "ldnf1sb +0x30(%x17)[16byte] %p5/z -> %z16.h",
+        "ldnf1sb +0x50(%x22)[16byte] %p6/z -> %z21.h",
+        "ldnf1sb +0x70(%sp)[16byte] %p7/z -> %z31.h",
     };
-    TEST_LOOP(
-        ldnf1sb, ldnf1sb_sve_pred, 6, expected_0_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ldnf1sb, ldnf1sb_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_2),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LDNF1SB { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_1_0[6] = {
-        "ldnf1sb -0x08(%x0)[8byte] %p0/z -> %z0.s",
-        "ldnf1sb -0x03(%x7)[8byte] %p2/z -> %z5.s",
+        "ldnf1sb -0x40(%x0)[8byte] %p0/z -> %z0.s",
+        "ldnf1sb -0x18(%x7)[8byte] %p2/z -> %z5.s",
         "ldnf1sb (%x12)[8byte] %p3/z -> %z10.s",
-        "ldnf1sb +0x03(%x17)[8byte] %p5/z -> %z16.s",
-        "ldnf1sb +0x05(%x22)[8byte] %p6/z -> %z21.s",
-        "ldnf1sb +0x07(%sp)[8byte] %p7/z -> %z31.s",
+        "ldnf1sb +0x18(%x17)[8byte] %p5/z -> %z16.s",
+        "ldnf1sb +0x28(%x22)[8byte] %p6/z -> %z21.s",
+        "ldnf1sb +0x38(%sp)[8byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ldnf1sb, ldnf1sb_sve_pred, 6, expected_1_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ldnf1sb, ldnf1sb_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 
     /* Testing LDNF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_2_0[6] = {
-        "ldnf1sb -0x08(%x0)[4byte] %p0/z -> %z0.d",
-        "ldnf1sb -0x03(%x7)[4byte] %p2/z -> %z5.d",
+        "ldnf1sb -0x20(%x0)[4byte] %p0/z -> %z0.d",
+        "ldnf1sb -0x0c(%x7)[4byte] %p2/z -> %z5.d",
         "ldnf1sb (%x12)[4byte] %p3/z -> %z10.d",
-        "ldnf1sb +0x03(%x17)[4byte] %p5/z -> %z16.d",
-        "ldnf1sb +0x05(%x22)[4byte] %p6/z -> %z21.d",
-        "ldnf1sb +0x07(%sp)[4byte] %p7/z -> %z31.d",
+        "ldnf1sb +0x0c(%x17)[4byte] %p5/z -> %z16.d",
+        "ldnf1sb +0x14(%x22)[4byte] %p6/z -> %z21.d",
+        "ldnf1sb +0x1c(%sp)[4byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ldnf1sb, ldnf1sb_sve_pred, 6, expected_2_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_4));
+    TEST_LOOP(ldnf1sb, ldnf1sb_sve_pred, 6, expected_2_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 4 * imm4[i],
+                                    OPSZ_4));
 }
 
 TEST_INSTR(ldnf1sh_sve_pred)
@@ -19325,46 +19325,46 @@ TEST_INSTR(ldnf1sh_sve_pred)
     /* Testing LDNF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_0_0[6] = {
-        "ldnf1sh -0x08(%x0)[16byte] %p0/z -> %z0.s",
-        "ldnf1sh -0x03(%x7)[16byte] %p2/z -> %z5.s",
+        "ldnf1sh -0x80(%x0)[16byte] %p0/z -> %z0.s",
+        "ldnf1sh -0x30(%x7)[16byte] %p2/z -> %z5.s",
         "ldnf1sh (%x12)[16byte] %p3/z -> %z10.s",
-        "ldnf1sh +0x03(%x17)[16byte] %p5/z -> %z16.s",
-        "ldnf1sh +0x05(%x22)[16byte] %p6/z -> %z21.s",
-        "ldnf1sh +0x07(%sp)[16byte] %p7/z -> %z31.s",
+        "ldnf1sh +0x30(%x17)[16byte] %p5/z -> %z16.s",
+        "ldnf1sh +0x50(%x22)[16byte] %p6/z -> %z21.s",
+        "ldnf1sh +0x70(%sp)[16byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ldnf1sh, ldnf1sh_sve_pred, 6, expected_0_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ldnf1sh, ldnf1sh_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 
     /* Testing LDNF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_1_0[6] = {
-        "ldnf1sh -0x08(%x0)[8byte] %p0/z -> %z0.d",
-        "ldnf1sh -0x03(%x7)[8byte] %p2/z -> %z5.d",
+        "ldnf1sh -0x40(%x0)[8byte] %p0/z -> %z0.d",
+        "ldnf1sh -0x18(%x7)[8byte] %p2/z -> %z5.d",
         "ldnf1sh (%x12)[8byte] %p3/z -> %z10.d",
-        "ldnf1sh +0x03(%x17)[8byte] %p5/z -> %z16.d",
-        "ldnf1sh +0x05(%x22)[8byte] %p6/z -> %z21.d",
-        "ldnf1sh +0x07(%sp)[8byte] %p7/z -> %z31.d",
+        "ldnf1sh +0x18(%x17)[8byte] %p5/z -> %z16.d",
+        "ldnf1sh +0x28(%x22)[8byte] %p6/z -> %z21.d",
+        "ldnf1sh +0x38(%sp)[8byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ldnf1sh, ldnf1sh_sve_pred, 6, expected_1_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_8));
+    TEST_LOOP(ldnf1sh, ldnf1sh_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 8 * imm4[i],
+                                    OPSZ_8));
 }
 
 TEST_INSTR(ldnf1sw_sve_pred)
 {
     /* Testing LDNF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -128, -48, 0, 48, 80, 112 };
     const char *const expected_0_0[6] = {
-        "ldnf1sw -0x08(%x0)[16byte] %p0/z -> %z0.d",
-        "ldnf1sw -0x03(%x7)[16byte] %p2/z -> %z5.d",
+        "ldnf1sw -0x80(%x0)[16byte] %p0/z -> %z0.d",
+        "ldnf1sw -0x30(%x7)[16byte] %p2/z -> %z5.d",
         "ldnf1sw (%x12)[16byte] %p3/z -> %z10.d",
-        "ldnf1sw +0x03(%x17)[16byte] %p5/z -> %z16.d",
-        "ldnf1sw +0x05(%x22)[16byte] %p6/z -> %z21.d",
-        "ldnf1sw +0x07(%sp)[16byte] %p7/z -> %z31.d",
+        "ldnf1sw +0x30(%x17)[16byte] %p5/z -> %z16.d",
+        "ldnf1sw +0x50(%x22)[16byte] %p6/z -> %z21.d",
+        "ldnf1sw +0x70(%sp)[16byte] %p7/z -> %z31.d",
     };
     TEST_LOOP(
         ldnf1sw, ldnf1sw_sve_pred, 6, expected_0_0[i],
@@ -19378,33 +19378,33 @@ TEST_INSTR(ldnf1w_sve_pred)
     /* Testing LDNF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
     const char *const expected_0_0[6] = {
-        "ldnf1w -0x08(%x0)[32byte] %p0/z -> %z0.s",
-        "ldnf1w -0x03(%x7)[32byte] %p2/z -> %z5.s",
+        "ldnf1w -0x0100(%x0)[32byte] %p0/z -> %z0.s",
+        "ldnf1w -0x60(%x7)[32byte] %p2/z -> %z5.s",
         "ldnf1w (%x12)[32byte] %p3/z -> %z10.s",
-        "ldnf1w +0x03(%x17)[32byte] %p5/z -> %z16.s",
-        "ldnf1w +0x05(%x22)[32byte] %p6/z -> %z21.s",
-        "ldnf1w +0x07(%sp)[32byte] %p7/z -> %z31.s",
+        "ldnf1w +0x60(%x17)[32byte] %p5/z -> %z16.s",
+        "ldnf1w +0xa0(%x22)[32byte] %p6/z -> %z21.s",
+        "ldnf1w +0xe0(%sp)[32byte] %p7/z -> %z31.s",
     };
-    TEST_LOOP(
-        ldnf1w, ldnf1w_sve_pred, 6, expected_0_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_32));
+    TEST_LOOP(ldnf1w, ldnf1w_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 32 * imm4[i],
+                                    OPSZ_32));
 
     /* Testing LDNF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
     const char *const expected_1_0[6] = {
-        "ldnf1w -0x08(%x0)[16byte] %p0/z -> %z0.d",
-        "ldnf1w -0x03(%x7)[16byte] %p2/z -> %z5.d",
+        "ldnf1w -0x80(%x0)[16byte] %p0/z -> %z0.d",
+        "ldnf1w -0x30(%x7)[16byte] %p2/z -> %z5.d",
         "ldnf1w (%x12)[16byte] %p3/z -> %z10.d",
-        "ldnf1w +0x03(%x17)[16byte] %p5/z -> %z16.d",
-        "ldnf1w +0x05(%x22)[16byte] %p6/z -> %z21.d",
-        "ldnf1w +0x07(%sp)[16byte] %p7/z -> %z31.d",
+        "ldnf1w +0x30(%x17)[16byte] %p5/z -> %z16.d",
+        "ldnf1w +0x50(%x22)[16byte] %p6/z -> %z21.d",
+        "ldnf1w +0x70(%sp)[16byte] %p7/z -> %z31.d",
     };
-    TEST_LOOP(
-        ldnf1w, ldnf1w_sve_pred, 6, expected_1_0[i],
-        opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
-        opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
-        opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, imm4[i], OPSZ_16));
+    TEST_LOOP(ldnf1w, ldnf1w_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_base_disp(Xn_six_offset_2_sp[i], DR_REG_NULL, 0, 16 * imm4[i],
+                                    OPSZ_16));
 }
 
 TEST_INSTR(ld3d_sve_pred)
@@ -19428,14 +19428,14 @@ TEST_INSTR(ld3d_sve_pred)
     /* Testing LD3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL
      * VL}]
      */
-    static const int imm4[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "ld3d   -0x18(%x0)[96byte] %p0/z -> %z0.d %z1.d %z2.d",
-        "ld3d   -0x09(%x7)[96byte] %p2/z -> %z5.d %z6.d %z7.d",
+        "ld3d   -0x0300(%x0)[96byte] %p0/z -> %z0.d %z1.d %z2.d",
+        "ld3d   -0x0120(%x7)[96byte] %p2/z -> %z5.d %z6.d %z7.d",
         "ld3d   (%x12)[96byte] %p3/z -> %z10.d %z11.d %z12.d",
-        "ld3d   +0x09(%x17)[96byte] %p5/z -> %z16.d %z17.d %z18.d",
-        "ld3d   +0x0f(%x22)[96byte] %p6/z -> %z21.d %z22.d %z23.d",
-        "ld3d   +0x15(%sp)[96byte] %p7/z -> %z31.d %z0.d %z1.d",
+        "ld3d   +0x0120(%x17)[96byte] %p5/z -> %z16.d %z17.d %z18.d",
+        "ld3d   +0x01e0(%x22)[96byte] %p6/z -> %z21.d %z22.d %z23.d",
+        "ld3d   +0x02a0(%sp)[96byte] %p7/z -> %z31.d %z0.d %z1.d",
     };
     TEST_LOOP(
         ld3d, ld3d_sve_pred, 6, expected_1_0[i],
@@ -19465,14 +19465,14 @@ TEST_INSTR(ld3h_sve_pred)
     /* Testing LD3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL
      * VL}]
      */
-    static const int imm4[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "ld3h   -0x18(%x0)[96byte] %p0/z -> %z0.h %z1.h %z2.h",
-        "ld3h   -0x09(%x7)[96byte] %p2/z -> %z5.h %z6.h %z7.h",
+        "ld3h   -0x0300(%x0)[96byte] %p0/z -> %z0.h %z1.h %z2.h",
+        "ld3h   -0x0120(%x7)[96byte] %p2/z -> %z5.h %z6.h %z7.h",
         "ld3h   (%x12)[96byte] %p3/z -> %z10.h %z11.h %z12.h",
-        "ld3h   +0x09(%x17)[96byte] %p5/z -> %z16.h %z17.h %z18.h",
-        "ld3h   +0x0f(%x22)[96byte] %p6/z -> %z21.h %z22.h %z23.h",
-        "ld3h   +0x15(%sp)[96byte] %p7/z -> %z31.h %z0.h %z1.h",
+        "ld3h   +0x0120(%x17)[96byte] %p5/z -> %z16.h %z17.h %z18.h",
+        "ld3h   +0x01e0(%x22)[96byte] %p6/z -> %z21.h %z22.h %z23.h",
+        "ld3h   +0x02a0(%sp)[96byte] %p7/z -> %z31.h %z0.h %z1.h",
     };
     TEST_LOOP(
         ld3h, ld3h_sve_pred, 6, expected_1_0[i],
@@ -19502,14 +19502,14 @@ TEST_INSTR(ld3w_sve_pred)
     /* Testing LD3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL
      * VL}]
      */
-    static const int imm4[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "ld3w   -0x18(%x0)[96byte] %p0/z -> %z0.s %z1.s %z2.s",
-        "ld3w   -0x09(%x7)[96byte] %p2/z -> %z5.s %z6.s %z7.s",
+        "ld3w   -0x0300(%x0)[96byte] %p0/z -> %z0.s %z1.s %z2.s",
+        "ld3w   -0x0120(%x7)[96byte] %p2/z -> %z5.s %z6.s %z7.s",
         "ld3w   (%x12)[96byte] %p3/z -> %z10.s %z11.s %z12.s",
-        "ld3w   +0x09(%x17)[96byte] %p5/z -> %z16.s %z17.s %z18.s",
-        "ld3w   +0x0f(%x22)[96byte] %p6/z -> %z21.s %z22.s %z23.s",
-        "ld3w   +0x15(%sp)[96byte] %p7/z -> %z31.s %z0.s %z1.s",
+        "ld3w   +0x0120(%x17)[96byte] %p5/z -> %z16.s %z17.s %z18.s",
+        "ld3w   +0x01e0(%x22)[96byte] %p6/z -> %z21.s %z22.s %z23.s",
+        "ld3w   +0x02a0(%sp)[96byte] %p7/z -> %z31.s %z0.s %z1.s",
     };
     TEST_LOOP(
         ld3w, ld3w_sve_pred, 6, expected_1_0[i],
@@ -19539,14 +19539,14 @@ TEST_INSTR(ld4d_sve_pred)
 
     /* Testing LD4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>/Z, [<Xn|SP>{,
      * #<simm>, MUL VL}] */
-    static const int imm4[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "ld4d   -0x20(%x0)[128byte] %p0/z -> %z0.d %z1.d %z2.d %z3.d",
-        "ld4d   -0x0c(%x7)[128byte] %p2/z -> %z5.d %z6.d %z7.d %z8.d",
+        "ld4d   -0x0400(%x0)[128byte] %p0/z -> %z0.d %z1.d %z2.d %z3.d",
+        "ld4d   -0x0180(%x7)[128byte] %p2/z -> %z5.d %z6.d %z7.d %z8.d",
         "ld4d   (%x12)[128byte] %p3/z -> %z10.d %z11.d %z12.d %z13.d",
-        "ld4d   +0x0c(%x17)[128byte] %p5/z -> %z16.d %z17.d %z18.d %z19.d",
-        "ld4d   +0x14(%x22)[128byte] %p6/z -> %z21.d %z22.d %z23.d %z24.d",
-        "ld4d   +0x1c(%sp)[128byte] %p7/z -> %z31.d %z0.d %z1.d %z2.d",
+        "ld4d   +0x0180(%x17)[128byte] %p5/z -> %z16.d %z17.d %z18.d %z19.d",
+        "ld4d   +0x0280(%x22)[128byte] %p6/z -> %z21.d %z22.d %z23.d %z24.d",
+        "ld4d   +0x0380(%sp)[128byte] %p7/z -> %z31.d %z0.d %z1.d %z2.d",
     };
     TEST_LOOP(
         ld4d, ld4d_sve_pred, 6, expected_1_0[i],
@@ -19576,14 +19576,14 @@ TEST_INSTR(ld4h_sve_pred)
 
     /* Testing LD4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>/Z, [<Xn|SP>{,
      * #<simm>, MUL VL}] */
-    static const int imm4[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "ld4h   -0x20(%x0)[128byte] %p0/z -> %z0.h %z1.h %z2.h %z3.h",
-        "ld4h   -0x0c(%x7)[128byte] %p2/z -> %z5.h %z6.h %z7.h %z8.h",
+        "ld4h   -0x0400(%x0)[128byte] %p0/z -> %z0.h %z1.h %z2.h %z3.h",
+        "ld4h   -0x0180(%x7)[128byte] %p2/z -> %z5.h %z6.h %z7.h %z8.h",
         "ld4h   (%x12)[128byte] %p3/z -> %z10.h %z11.h %z12.h %z13.h",
-        "ld4h   +0x0c(%x17)[128byte] %p5/z -> %z16.h %z17.h %z18.h %z19.h",
-        "ld4h   +0x14(%x22)[128byte] %p6/z -> %z21.h %z22.h %z23.h %z24.h",
-        "ld4h   +0x1c(%sp)[128byte] %p7/z -> %z31.h %z0.h %z1.h %z2.h",
+        "ld4h   +0x0180(%x17)[128byte] %p5/z -> %z16.h %z17.h %z18.h %z19.h",
+        "ld4h   +0x0280(%x22)[128byte] %p6/z -> %z21.h %z22.h %z23.h %z24.h",
+        "ld4h   +0x0380(%sp)[128byte] %p7/z -> %z31.h %z0.h %z1.h %z2.h",
     };
     TEST_LOOP(
         ld4h, ld4h_sve_pred, 6, expected_1_0[i],
@@ -19613,14 +19613,14 @@ TEST_INSTR(ld4w_sve_pred)
 
     /* Testing LD4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>/Z, [<Xn|SP>{,
      * #<simm>, MUL VL}] */
-    static const int imm4[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "ld4w   -0x20(%x0)[128byte] %p0/z -> %z0.s %z1.s %z2.s %z3.s",
-        "ld4w   -0x0c(%x7)[128byte] %p2/z -> %z5.s %z6.s %z7.s %z8.s",
+        "ld4w   -0x0400(%x0)[128byte] %p0/z -> %z0.s %z1.s %z2.s %z3.s",
+        "ld4w   -0x0180(%x7)[128byte] %p2/z -> %z5.s %z6.s %z7.s %z8.s",
         "ld4w   (%x12)[128byte] %p3/z -> %z10.s %z11.s %z12.s %z13.s",
-        "ld4w   +0x0c(%x17)[128byte] %p5/z -> %z16.s %z17.s %z18.s %z19.s",
-        "ld4w   +0x14(%x22)[128byte] %p6/z -> %z21.s %z22.s %z23.s %z24.s",
-        "ld4w   +0x1c(%sp)[128byte] %p7/z -> %z31.s %z0.s %z1.s %z2.s",
+        "ld4w   +0x0180(%x17)[128byte] %p5/z -> %z16.s %z17.s %z18.s %z19.s",
+        "ld4w   +0x0280(%x22)[128byte] %p6/z -> %z21.s %z22.s %z23.s %z24.s",
+        "ld4w   +0x0380(%sp)[128byte] %p7/z -> %z31.s %z0.s %z1.s %z2.s",
     };
     TEST_LOOP(
         ld4w, ld4w_sve_pred, 6, expected_1_0[i],
@@ -19648,14 +19648,14 @@ TEST_INSTR(ldnt1d_sve_pred)
                                                   true, 0, 0, OPSZ_32, 3));
 
     /* Testing LDNT1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "ldnt1d -0x08(%x0)[32byte] %p0/z -> %z0.d",
-        "ldnt1d -0x03(%x7)[32byte] %p2/z -> %z5.d",
+        "ldnt1d -0x0100(%x0)[32byte] %p0/z -> %z0.d",
+        "ldnt1d -0x60(%x7)[32byte] %p2/z -> %z5.d",
         "ldnt1d (%x12)[32byte] %p3/z -> %z10.d",
-        "ldnt1d +0x03(%x17)[32byte] %p5/z -> %z16.d",
-        "ldnt1d +0x05(%x22)[32byte] %p6/z -> %z21.d",
-        "ldnt1d +0x07(%sp)[32byte] %p7/z -> %z31.d",
+        "ldnt1d +0x60(%x17)[32byte] %p5/z -> %z16.d",
+        "ldnt1d +0xa0(%x22)[32byte] %p6/z -> %z21.d",
+        "ldnt1d +0xe0(%sp)[32byte] %p7/z -> %z31.d",
     };
     TEST_LOOP(
         ldnt1d, ldnt1d_sve_pred, 6, expected_1_0[i],
@@ -19683,14 +19683,14 @@ TEST_INSTR(ldnt1w_sve_pred)
                                                   true, 0, 0, OPSZ_32, 2));
 
     /* Testing LDNT1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "ldnt1w -0x08(%x0)[32byte] %p0/z -> %z0.s",
-        "ldnt1w -0x03(%x7)[32byte] %p2/z -> %z5.s",
+        "ldnt1w -0x0100(%x0)[32byte] %p0/z -> %z0.s",
+        "ldnt1w -0x60(%x7)[32byte] %p2/z -> %z5.s",
         "ldnt1w (%x12)[32byte] %p3/z -> %z10.s",
-        "ldnt1w +0x03(%x17)[32byte] %p5/z -> %z16.s",
-        "ldnt1w +0x05(%x22)[32byte] %p6/z -> %z21.s",
-        "ldnt1w +0x07(%sp)[32byte] %p7/z -> %z31.s",
+        "ldnt1w +0x60(%x17)[32byte] %p5/z -> %z16.s",
+        "ldnt1w +0xa0(%x22)[32byte] %p6/z -> %z21.s",
+        "ldnt1w +0xe0(%sp)[32byte] %p7/z -> %z31.s",
     };
     TEST_LOOP(
         ldnt1w, ldnt1w_sve_pred, 6, expected_1_0[i],
@@ -19718,14 +19718,14 @@ TEST_INSTR(ldnt1h_sve_pred)
                                                   true, 0, 0, OPSZ_32, 1));
 
     /* Testing LDNT1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "ldnt1h -0x08(%x0)[32byte] %p0/z -> %z0.h",
-        "ldnt1h -0x03(%x7)[32byte] %p2/z -> %z5.h",
+        "ldnt1h -0x0100(%x0)[32byte] %p0/z -> %z0.h",
+        "ldnt1h -0x60(%x7)[32byte] %p2/z -> %z5.h",
         "ldnt1h (%x12)[32byte] %p3/z -> %z10.h",
-        "ldnt1h +0x03(%x17)[32byte] %p5/z -> %z16.h",
-        "ldnt1h +0x05(%x22)[32byte] %p6/z -> %z21.h",
-        "ldnt1h +0x07(%sp)[32byte] %p7/z -> %z31.h",
+        "ldnt1h +0x60(%x17)[32byte] %p5/z -> %z16.h",
+        "ldnt1h +0xa0(%x22)[32byte] %p6/z -> %z21.h",
+        "ldnt1h +0xe0(%sp)[32byte] %p7/z -> %z31.h",
     };
     TEST_LOOP(
         ldnt1h, ldnt1h_sve_pred, 6, expected_1_0[i],
@@ -19753,14 +19753,14 @@ TEST_INSTR(st2d_sve_pred)
                                                   true, 0, 0, OPSZ_64, 3));
 
     /* Testing ST2D    { <Zt1>.D, <Zt2>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "st2d   %z0.d %z1.d %p0 -> -0x10(%x0)[64byte]",
-        "st2d   %z5.d %z6.d %p2 -> -0x06(%x7)[64byte]",
+        "st2d   %z0.d %z1.d %p0 -> -0x0200(%x0)[64byte]",
+        "st2d   %z5.d %z6.d %p2 -> -0xc0(%x7)[64byte]",
         "st2d   %z10.d %z11.d %p3 -> (%x12)[64byte]",
-        "st2d   %z16.d %z17.d %p5 -> +0x06(%x17)[64byte]",
-        "st2d   %z21.d %z22.d %p6 -> +0x0a(%x22)[64byte]",
-        "st2d   %z31.d %z0.d %p7 -> +0x0e(%sp)[64byte]",
+        "st2d   %z16.d %z17.d %p5 -> +0xc0(%x17)[64byte]",
+        "st2d   %z21.d %z22.d %p6 -> +0x0140(%x22)[64byte]",
+        "st2d   %z31.d %z0.d %p7 -> +0x01c0(%sp)[64byte]",
     };
     TEST_LOOP(
         st2d, st2d_sve_pred, 6, expected_1_0[i],
@@ -19788,14 +19788,14 @@ TEST_INSTR(st2h_sve_pred)
                                                   true, 0, 0, OPSZ_64, 1));
 
     /* Testing ST2H    { <Zt1>.H, <Zt2>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "st2h   %z0.h %z1.h %p0 -> -0x10(%x0)[64byte]",
-        "st2h   %z5.h %z6.h %p2 -> -0x06(%x7)[64byte]",
+        "st2h   %z0.h %z1.h %p0 -> -0x0200(%x0)[64byte]",
+        "st2h   %z5.h %z6.h %p2 -> -0xc0(%x7)[64byte]",
         "st2h   %z10.h %z11.h %p3 -> (%x12)[64byte]",
-        "st2h   %z16.h %z17.h %p5 -> +0x06(%x17)[64byte]",
-        "st2h   %z21.h %z22.h %p6 -> +0x0a(%x22)[64byte]",
-        "st2h   %z31.h %z0.h %p7 -> +0x0e(%sp)[64byte]",
+        "st2h   %z16.h %z17.h %p5 -> +0xc0(%x17)[64byte]",
+        "st2h   %z21.h %z22.h %p6 -> +0x0140(%x22)[64byte]",
+        "st2h   %z31.h %z0.h %p7 -> +0x01c0(%sp)[64byte]",
     };
     TEST_LOOP(
         st2h, st2h_sve_pred, 6, expected_1_0[i],
@@ -19823,14 +19823,14 @@ TEST_INSTR(st2w_sve_pred)
                                                   true, 0, 0, OPSZ_64, 2));
 
     /* Testing ST2W    { <Zt1>.S, <Zt2>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -16, -6, 0, 6, 10, 14 };
+    static const int imm4[6] = { -512, -192, 0, 192, 320, 448 };
     const char *const expected_1_0[6] = {
-        "st2w   %z0.s %z1.s %p0 -> -0x10(%x0)[64byte]",
-        "st2w   %z5.s %z6.s %p2 -> -0x06(%x7)[64byte]",
+        "st2w   %z0.s %z1.s %p0 -> -0x0200(%x0)[64byte]",
+        "st2w   %z5.s %z6.s %p2 -> -0xc0(%x7)[64byte]",
         "st2w   %z10.s %z11.s %p3 -> (%x12)[64byte]",
-        "st2w   %z16.s %z17.s %p5 -> +0x06(%x17)[64byte]",
-        "st2w   %z21.s %z22.s %p6 -> +0x0a(%x22)[64byte]",
-        "st2w   %z31.s %z0.s %p7 -> +0x0e(%sp)[64byte]",
+        "st2w   %z16.s %z17.s %p5 -> +0xc0(%x17)[64byte]",
+        "st2w   %z21.s %z22.s %p6 -> +0x0140(%x22)[64byte]",
+        "st2w   %z31.s %z0.s %p7 -> +0x01c0(%sp)[64byte]",
     };
     TEST_LOOP(
         st2w, st2w_sve_pred, 6, expected_1_0[i],
@@ -19860,14 +19860,14 @@ TEST_INSTR(st3d_sve_pred)
     /* Testing ST3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL
      * VL}]
      */
-    static const int imm4[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "st3d   %z0.d %z1.d %z2.d %p0 -> -0x18(%x0)[96byte]",
-        "st3d   %z5.d %z6.d %z7.d %p2 -> -0x09(%x7)[96byte]",
+        "st3d   %z0.d %z1.d %z2.d %p0 -> -0x0300(%x0)[96byte]",
+        "st3d   %z5.d %z6.d %z7.d %p2 -> -0x0120(%x7)[96byte]",
         "st3d   %z10.d %z11.d %z12.d %p3 -> (%x12)[96byte]",
-        "st3d   %z16.d %z17.d %z18.d %p5 -> +0x09(%x17)[96byte]",
-        "st3d   %z21.d %z22.d %z23.d %p6 -> +0x0f(%x22)[96byte]",
-        "st3d   %z31.d %z0.d %z1.d %p7 -> +0x15(%sp)[96byte]",
+        "st3d   %z16.d %z17.d %z18.d %p5 -> +0x0120(%x17)[96byte]",
+        "st3d   %z21.d %z22.d %z23.d %p6 -> +0x01e0(%x22)[96byte]",
+        "st3d   %z31.d %z0.d %z1.d %p7 -> +0x02a0(%sp)[96byte]",
     };
     TEST_LOOP(
         st3d, st3d_sve_pred, 6, expected_1_0[i],
@@ -19897,14 +19897,14 @@ TEST_INSTR(st3h_sve_pred)
     /* Testing ST3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL
      * VL}]
      */
-    static const int imm4[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "st3h   %z0.h %z1.h %z2.h %p0 -> -0x18(%x0)[96byte]",
-        "st3h   %z5.h %z6.h %z7.h %p2 -> -0x09(%x7)[96byte]",
+        "st3h   %z0.h %z1.h %z2.h %p0 -> -0x0300(%x0)[96byte]",
+        "st3h   %z5.h %z6.h %z7.h %p2 -> -0x0120(%x7)[96byte]",
         "st3h   %z10.h %z11.h %z12.h %p3 -> (%x12)[96byte]",
-        "st3h   %z16.h %z17.h %z18.h %p5 -> +0x09(%x17)[96byte]",
-        "st3h   %z21.h %z22.h %z23.h %p6 -> +0x0f(%x22)[96byte]",
-        "st3h   %z31.h %z0.h %z1.h %p7 -> +0x15(%sp)[96byte]",
+        "st3h   %z16.h %z17.h %z18.h %p5 -> +0x0120(%x17)[96byte]",
+        "st3h   %z21.h %z22.h %z23.h %p6 -> +0x01e0(%x22)[96byte]",
+        "st3h   %z31.h %z0.h %z1.h %p7 -> +0x02a0(%sp)[96byte]",
     };
     TEST_LOOP(
         st3h, st3h_sve_pred, 6, expected_1_0[i],
@@ -19934,14 +19934,14 @@ TEST_INSTR(st3w_sve_pred)
     /* Testing ST3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL
      * VL}]
      */
-    static const int imm4[6] = { -24, -9, 0, 9, 15, 21 };
+    static const int imm4[6] = { -768, -288, 0, 288, 480, 672 };
     const char *const expected_1_0[6] = {
-        "st3w   %z0.s %z1.s %z2.s %p0 -> -0x18(%x0)[96byte]",
-        "st3w   %z5.s %z6.s %z7.s %p2 -> -0x09(%x7)[96byte]",
+        "st3w   %z0.s %z1.s %z2.s %p0 -> -0x0300(%x0)[96byte]",
+        "st3w   %z5.s %z6.s %z7.s %p2 -> -0x0120(%x7)[96byte]",
         "st3w   %z10.s %z11.s %z12.s %p3 -> (%x12)[96byte]",
-        "st3w   %z16.s %z17.s %z18.s %p5 -> +0x09(%x17)[96byte]",
-        "st3w   %z21.s %z22.s %z23.s %p6 -> +0x0f(%x22)[96byte]",
-        "st3w   %z31.s %z0.s %z1.s %p7 -> +0x15(%sp)[96byte]",
+        "st3w   %z16.s %z17.s %z18.s %p5 -> +0x0120(%x17)[96byte]",
+        "st3w   %z21.s %z22.s %z23.s %p6 -> +0x01e0(%x22)[96byte]",
+        "st3w   %z31.s %z0.s %z1.s %p7 -> +0x02a0(%sp)[96byte]",
     };
     TEST_LOOP(
         st3w, st3w_sve_pred, 6, expected_1_0[i],
@@ -19971,14 +19971,14 @@ TEST_INSTR(st4d_sve_pred)
 
     /* Testing ST4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>, [<Xn|SP>{,
      * #<simm>, MUL VL}] */
-    static const int imm4[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "st4d   %z0.d %z1.d %z2.d %z3.d %p0 -> -0x20(%x0)[128byte]",
-        "st4d   %z5.d %z6.d %z7.d %z8.d %p2 -> -0x0c(%x7)[128byte]",
+        "st4d   %z0.d %z1.d %z2.d %z3.d %p0 -> -0x0400(%x0)[128byte]",
+        "st4d   %z5.d %z6.d %z7.d %z8.d %p2 -> -0x0180(%x7)[128byte]",
         "st4d   %z10.d %z11.d %z12.d %z13.d %p3 -> (%x12)[128byte]",
-        "st4d   %z16.d %z17.d %z18.d %z19.d %p5 -> +0x0c(%x17)[128byte]",
-        "st4d   %z21.d %z22.d %z23.d %z24.d %p6 -> +0x14(%x22)[128byte]",
-        "st4d   %z31.d %z0.d %z1.d %z2.d %p7 -> +0x1c(%sp)[128byte]",
+        "st4d   %z16.d %z17.d %z18.d %z19.d %p5 -> +0x0180(%x17)[128byte]",
+        "st4d   %z21.d %z22.d %z23.d %z24.d %p6 -> +0x0280(%x22)[128byte]",
+        "st4d   %z31.d %z0.d %z1.d %z2.d %p7 -> +0x0380(%sp)[128byte]",
     };
     TEST_LOOP(
         st4d, st4d_sve_pred, 6, expected_1_0[i],
@@ -20008,14 +20008,14 @@ TEST_INSTR(st4h_sve_pred)
 
     /* Testing ST4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>, [<Xn|SP>{,
      * #<simm>, MUL VL}] */
-    static const int imm4[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "st4h   %z0.h %z1.h %z2.h %z3.h %p0 -> -0x20(%x0)[128byte]",
-        "st4h   %z5.h %z6.h %z7.h %z8.h %p2 -> -0x0c(%x7)[128byte]",
+        "st4h   %z0.h %z1.h %z2.h %z3.h %p0 -> -0x0400(%x0)[128byte]",
+        "st4h   %z5.h %z6.h %z7.h %z8.h %p2 -> -0x0180(%x7)[128byte]",
         "st4h   %z10.h %z11.h %z12.h %z13.h %p3 -> (%x12)[128byte]",
-        "st4h   %z16.h %z17.h %z18.h %z19.h %p5 -> +0x0c(%x17)[128byte]",
-        "st4h   %z21.h %z22.h %z23.h %z24.h %p6 -> +0x14(%x22)[128byte]",
-        "st4h   %z31.h %z0.h %z1.h %z2.h %p7 -> +0x1c(%sp)[128byte]",
+        "st4h   %z16.h %z17.h %z18.h %z19.h %p5 -> +0x0180(%x17)[128byte]",
+        "st4h   %z21.h %z22.h %z23.h %z24.h %p6 -> +0x0280(%x22)[128byte]",
+        "st4h   %z31.h %z0.h %z1.h %z2.h %p7 -> +0x0380(%sp)[128byte]",
     };
     TEST_LOOP(
         st4h, st4h_sve_pred, 6, expected_1_0[i],
@@ -20045,14 +20045,14 @@ TEST_INSTR(st4w_sve_pred)
 
     /* Testing ST4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>, [<Xn|SP>{,
      * #<simm>, MUL VL}] */
-    static const int imm4[6] = { -32, -12, 0, 12, 20, 28 };
+    static const int imm4[6] = { -1024, -384, 0, 384, 640, 896 };
     const char *const expected_1_0[6] = {
-        "st4w   %z0.s %z1.s %z2.s %z3.s %p0 -> -0x20(%x0)[128byte]",
-        "st4w   %z5.s %z6.s %z7.s %z8.s %p2 -> -0x0c(%x7)[128byte]",
+        "st4w   %z0.s %z1.s %z2.s %z3.s %p0 -> -0x0400(%x0)[128byte]",
+        "st4w   %z5.s %z6.s %z7.s %z8.s %p2 -> -0x0180(%x7)[128byte]",
         "st4w   %z10.s %z11.s %z12.s %z13.s %p3 -> (%x12)[128byte]",
-        "st4w   %z16.s %z17.s %z18.s %z19.s %p5 -> +0x0c(%x17)[128byte]",
-        "st4w   %z21.s %z22.s %z23.s %z24.s %p6 -> +0x14(%x22)[128byte]",
-        "st4w   %z31.s %z0.s %z1.s %z2.s %p7 -> +0x1c(%sp)[128byte]",
+        "st4w   %z16.s %z17.s %z18.s %z19.s %p5 -> +0x0180(%x17)[128byte]",
+        "st4w   %z21.s %z22.s %z23.s %z24.s %p6 -> +0x0280(%x22)[128byte]",
+        "st4w   %z31.s %z0.s %z1.s %z2.s %p7 -> +0x0380(%sp)[128byte]",
     };
     TEST_LOOP(
         st4w, st4w_sve_pred, 6, expected_1_0[i],
@@ -20080,14 +20080,14 @@ TEST_INSTR(stnt1d_sve_pred)
                                                   true, 0, 0, OPSZ_32, 3));
 
     /* Testing STNT1D  { <Zt>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "stnt1d %z0.d %p0 -> -0x08(%x0)[32byte]",
-        "stnt1d %z5.d %p2 -> -0x03(%x7)[32byte]",
+        "stnt1d %z0.d %p0 -> -0x0100(%x0)[32byte]",
+        "stnt1d %z5.d %p2 -> -0x60(%x7)[32byte]",
         "stnt1d %z10.d %p3 -> (%x12)[32byte]",
-        "stnt1d %z16.d %p5 -> +0x03(%x17)[32byte]",
-        "stnt1d %z21.d %p6 -> +0x05(%x22)[32byte]",
-        "stnt1d %z31.d %p7 -> +0x07(%sp)[32byte]",
+        "stnt1d %z16.d %p5 -> +0x60(%x17)[32byte]",
+        "stnt1d %z21.d %p6 -> +0xa0(%x22)[32byte]",
+        "stnt1d %z31.d %p7 -> +0xe0(%sp)[32byte]",
     };
     TEST_LOOP(
         stnt1d, stnt1d_sve_pred, 6, expected_1_0[i],
@@ -20115,14 +20115,14 @@ TEST_INSTR(stnt1h_sve_pred)
                                                   true, 0, 0, OPSZ_32, 1));
 
     /* Testing STNT1H  { <Zt>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "stnt1h %z0.h %p0 -> -0x08(%x0)[32byte]",
-        "stnt1h %z5.h %p2 -> -0x03(%x7)[32byte]",
+        "stnt1h %z0.h %p0 -> -0x0100(%x0)[32byte]",
+        "stnt1h %z5.h %p2 -> -0x60(%x7)[32byte]",
         "stnt1h %z10.h %p3 -> (%x12)[32byte]",
-        "stnt1h %z16.h %p5 -> +0x03(%x17)[32byte]",
-        "stnt1h %z21.h %p6 -> +0x05(%x22)[32byte]",
-        "stnt1h %z31.h %p7 -> +0x07(%sp)[32byte]",
+        "stnt1h %z16.h %p5 -> +0x60(%x17)[32byte]",
+        "stnt1h %z21.h %p6 -> +0xa0(%x22)[32byte]",
+        "stnt1h %z31.h %p7 -> +0xe0(%sp)[32byte]",
     };
     TEST_LOOP(
         stnt1h, stnt1h_sve_pred, 6, expected_1_0[i],
@@ -20150,14 +20150,14 @@ TEST_INSTR(stnt1w_sve_pred)
                                                   true, 0, 0, OPSZ_32, 2));
 
     /* Testing STNT1W  { <Zt>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}] */
-    static const int imm4[6] = { -8, -3, 0, 3, 5, 7 };
+    static const int imm4[6] = { -256, -96, 0, 96, 160, 224 };
     const char *const expected_1_0[6] = {
-        "stnt1w %z0.s %p0 -> -0x08(%x0)[32byte]",
-        "stnt1w %z5.s %p2 -> -0x03(%x7)[32byte]",
+        "stnt1w %z0.s %p0 -> -0x0100(%x0)[32byte]",
+        "stnt1w %z5.s %p2 -> -0x60(%x7)[32byte]",
         "stnt1w %z10.s %p3 -> (%x12)[32byte]",
-        "stnt1w %z16.s %p5 -> +0x03(%x17)[32byte]",
-        "stnt1w %z21.s %p6 -> +0x05(%x22)[32byte]",
-        "stnt1w %z31.s %p7 -> +0x07(%sp)[32byte]",
+        "stnt1w %z16.s %p5 -> +0x60(%x17)[32byte]",
+        "stnt1w %z21.s %p6 -> +0xa0(%x22)[32byte]",
+        "stnt1w %z31.s %p7 -> +0xe0(%sp)[32byte]",
     };
     TEST_LOOP(
         stnt1w, stnt1w_sve_pred, 6, expected_1_0[i],


### PR DESCRIPTION
All SVE scalar+immediate LD[1234]/ST[1234] have a signed 4-bit immediate value that encodes a vector index offset from the base register. This value was being used directly in the IR for instructions, however base+disp memory operands should always use a byte displacement.

This changes the codec to use byte displacements in the IR and updates the codec unit tests accordingly.

The following instructions are updated:

```
LD1B    { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1B    { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1B    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1B    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1D    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1H    { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1H    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1H    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1SB   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1SB   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1SB   { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1SH   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1SH   { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1SW   { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1W    { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD1W    { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD2B    { <Zt1>.B, <Zt2>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD2D    { <Zt1>.D, <Zt2>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD2H    { <Zt1>.H, <Zt2>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD2W    { <Zt1>.S, <Zt2>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LD4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1B  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1B  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1B  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1H  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1H  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1SB { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1SB { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1SB { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1SH { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1SH { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1SW { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNF1W  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNT1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNT1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
LDNT1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<simm>, MUL VL}]
ST1B    { <Zt>.<T> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST1D    { <Zt>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST1H    { <Zt>.<T> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST1W    { <Zt>.<T> }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST2B    { <Zt1>.B, <Zt2>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST2D    { <Zt1>.D, <Zt2>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST2H    { <Zt1>.H, <Zt2>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST2W    { <Zt1>.S, <Zt2>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST3B    { <Zt1>.B, <Zt2>.B, <Zt3>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST3D    { <Zt1>.D, <Zt2>.D, <Zt3>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST3H    { <Zt1>.H, <Zt2>.H, <Zt3>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST3W    { <Zt1>.S, <Zt2>.S, <Zt3>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST4B    { <Zt1>.B, <Zt2>.B, <Zt3>.B, <Zt4>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST4D    { <Zt1>.D, <Zt2>.D, <Zt3>.D, <Zt4>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST4H    { <Zt1>.H, <Zt2>.H, <Zt3>.H, <Zt4>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
ST4W    { <Zt1>.S, <Zt2>.S, <Zt3>.S, <Zt4>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
STNT1D  { <Zt>.D }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
STNT1H  { <Zt>.H }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
STNT1W  { <Zt>.S }, <Pg>, [<Xn|SP>{, #<simm>, MUL VL}]
```

Issue: #3044