### PR TITLE
i#6399: Update Debian repository to fix RISC-V CI build

### DIFF
--- a/.github/workflows/ci-riscv64.yml
+++ b/.github/workflows/ci-riscv64.yml
@@ -77,7 +77,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install doxygen vera++ cmake crossbuild-essential-riscv64 git  \
           qemu-user qemu-user-binfmt
-        sudo add-apt-repository 'deb [trusted=yes arch=riscv64] http://deb.debian.org/debian-ports sid main'
+        sudo add-apt-repository 'deb [trusted=yes arch=riscv64] http://deb.debian.org/debian sid main'
         apt download libunwind8:riscv64 libunwind-dev:riscv64 liblzma5:riscv64 \
           zlib1g:riscv64 zlib1g-dev:riscv64 libsnappy1v5:riscv64 libsnappy-dev:riscv64 \
           liblz4-1:riscv64 liblz4-dev:riscv64


### PR DESCRIPTION
Updates the RISC-V Debian repository from debian-ports to debian.
This is to fix the RISC-V build in our CI workflows which is currently
failing because debian-ports doesn't support arch=riscv64 anymore.

As per the news on  https://www.ports.debian.org, riscv64 is now
part of the official archive instead.

```
Thu, 26 Oct 2023 22:28:36 +0200
The riscv64 architecture has been [added to the official archive](https://lists.debian.org/debian-riscv/2023/07/msg00053.html) a few months ago. Given most of the packages have now been rebuilt, it has just been removed from the debian-ports archive.
```

Fixes #6399