### PR TITLE
i#5505 kernel trace: Fix relative header import path

### DIFF
--- a/clients/drcachesim/drpt2trace/ir2trace.h
+++ b/clients/drcachesim/drpt2trace/ir2trace.h
@@ -44,7 +44,7 @@
 #include <vector>
 #include <mutex>
 #include "drir.h"
-#include "../common/trace_entry.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {


### PR DESCRIPTION
Modifies an import statement to use a non-relative path to header file.

This is required for third-party integration to work properly. Not sure
how this was missed in #6381.

Issue: #5505