### PR TITLE
i#5843 scheduler: Add direct thread switch marker

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -560,6 +560,14 @@ typedef enum {
      */
     TRACE_MARKER_TYPE_SYSCALL_FAILED,
 
+    /**
+     * This marker is emitted prior to a system call that causes an immediate switch to
+     * another thread on the same core (with the current thread entering an unscheduled
+     * state), bypassing the kernel scheduler's normal dynamic switch code based on run
+     * queues.  The marker value holds the thread id of the target thread.
+     */
+    TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH,
+
     // ...
     // These values are reserved for future built-in marker types.
     // ...

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -410,6 +410,10 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         case TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL:
             std::cerr << "<marker: maybe-blocking system call>\n";
             break;
+        case TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH:
+            std::cerr << "<marker: direct switch to thread " << memref.marker.marker_value
+                      << ">\n";
+            break;
         case TRACE_MARKER_TYPE_WINDOW_ID:
             // Handled above.
             break;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1133,6 +1133,15 @@ protected:
                           OUT bool *last_bb_handled, OUT bool *flush_decode_cache);
 
     /**
+     * Performs any additional actions for the marker "marker_type" with value
+     * "marker_val", beyond writing out a marker record.  New records can be written to
+     * "buf".  Returns whether successful.
+     */
+    virtual bool
+    process_marker_additionally(raw2trace_thread_data_t *tdata,
+                                trace_marker_type_t marker_type, uintptr_t marker_val,
+                                byte *&buf, OUT bool *flush_decode_cache);
+    /**
      * Read the header of a thread, by calling get_next_entry() successively to
      * populate the header values. The timestamp field is populated only
      * for legacy traces.
@@ -1265,6 +1274,10 @@ protected:
     {
         modmap_ptr_ = modmap;
     }
+
+    /** Returns whether this system number *might* block. */
+    virtual bool
+    is_maybe_blocking_syscall(uintptr_t number);
 
     const module_mapper_t *modmap_ptr_ = nullptr;
 
@@ -1491,9 +1504,6 @@ private:
 
     bool
     should_omit_syscall(raw2trace_thread_data_t *tdata);
-
-    bool
-    is_maybe_blocking_syscall(uintptr_t number);
 
     int worker_count_;
     std::vector<std::vector<raw2trace_thread_data_t *>> worker_tasks_;


### PR DESCRIPTION
Adds a new marker type TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH for use with custom kernel scheduling features where one thread directly switches to another on the same cpu.

Refactors raw2trace marker processing code to allow a subclass to insert the new marker.

Makes the raw2trace blocking syscall code virtual to allow a subclass to label custom syscalls as blocking.

Given that the changes are used in separate code it is not simple to make a test of the raw2trace refactoring + virtual. For the marker: tests that use the marker will be forthcoming in scheduler_unit_tests.

Issue: #5843