### PR TITLE
i#6397: Add instr_is_opnd_store_source()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -174,6 +174,7 @@ Further non-compatibility-affecting changes include:
  - Added -record_syscall to drmemtrace for recording syscall parameters.
  - Added opportunity to run multiple drcachesim analysis tools simultaneously.
  - Added support of loading separately-built analysis tools to drcachesim dynamically.
+ - Added instr_is_opnd_store_source().
 
 **************************************************
 <hr>

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -2942,20 +2942,21 @@
  * Creates an LDR immediate instruction.
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rt      The output register.
- * \param Xn      The input register or stack pointer
+ * \param Xn      The input register or stack pointer.
  * \param Rn      The input memory disposition.
  * \param imm     Immediate int of the input register offset
  */
 #define INSTR_CREATE_ldr_imm(dc, Rt, Xn, Rn, imm) \
     instr_create_2dst_3src(dc, OP_ldr, Rt, Xn, Rn, Xn, imm)
 
+/* XXX: This should auto-extract the base reg and the immediate from the memop! */
 /**
  * Creates a STR immediate instruction.
  * \param dc      The void * dcontext used to allocate memory for the #instr_t.
  * \param Rt      The output memory disposition.
- * \param Xt      The input register or stack pointer.
- * \param Xn      The output register
- * \param imm     Immediate int of the output register offset
+ * \param Xt      The input register or stack pointer to store.
+ * \param Xn      The output register which must be the address base register.
+ * \param imm     Immediate int of the output register offset.
  */
 #define INSTR_CREATE_str_imm(dc, Rt, Xt, Xn, imm) \
     instr_create_2dst_3src(dc, OP_str, Rt, Xn, Xt, Xn, imm)

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -864,6 +864,18 @@ DR_API
 void
 instr_set_target(instr_t *cti_instr, opnd_t target);
 
+DR_API
+/**
+ * If \p store_instr is not a store (instr_writes_memory() returns false), returns
+ * false.  If \p store_instr is a store (instr_writes_memory() returns true), returns
+ * whether its source operand with index \p source_ordinal (as passed to
+ * instr_get_src()) is a source for the value that is stored.  (If not, it may be an
+ * address register that is updated for pre-index or post-index writeback forms, or
+ * some other source that does not directly affect the value written to memory.)
+ */
+bool
+instr_is_opnd_store_source(instr_t *store_instr, int source_ordinal);
+
 INSTR_INLINE_INTERNALLY
 DR_API
 /** Returns true iff \p instr's operands are up to date. */

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -761,7 +761,7 @@ instr_is_opnd_store_source(instr_t *store_instr, int source_ordinal)
      * identifying which sources flow into the (typically unique) memory
      * destination is a key piece of information we do try to provide.  We do
      * not yet go as far as labeling this in the IR decoding codec/table info
-     * sources and rely on operand ordering conventions.  If these heuristics
+     * sources and thus rely on operand ordering conventions.  If these heuristics
      * prove too fragile we can move toward more direct support, but by
      * providing an official helper function here now we at least get all users
      * using the same code we can update later.
@@ -818,7 +818,8 @@ instr_is_opnd_store_source(instr_t *store_instr, int source_ordinal)
         /* Is the last dest an address register? */
         opnd_t last_dst = instr_get_dst(store_instr, instr_num_dsts(store_instr) - 1);
         if (opnd_is_reg(last_dst) &&
-            opnd_uses_reg(instr_get_dst(store_instr, 0), opnd_get_reg(last_dst))) {
+            /* See whether the memory operation uses the last dest reg. */
+            opnd_uses_reg(memop, opnd_get_reg(last_dst))) {
             /* Is there an identical source operand register, at the end or prior to
              * an immed that is at the end?
              */

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -201,6 +201,47 @@ test_categories(void)
     ASSERT(cat == DR_INSTR_CATEGORY_UNCATEGORIZED);
 }
 
+static void
+test_store_source(void)
+{
+    instr_t *in = XINST_CREATE_store(GD, OPND_CREATE_MEMPTR(DR_REG_R0, 42),
+                                     opnd_create_reg(DR_REG_R1));
+    ASSERT(!instr_is_opnd_store_source(in, -1)); /* Out of bounds. */
+    ASSERT(instr_is_opnd_store_source(in, 0));   /* r1. */
+    ASSERT(!instr_is_opnd_store_source(in, 1));  /* Out of bounds. */
+    instr_destroy(GD, in);
+
+    in = INSTR_CREATE_str_imm(GD, OPND_CREATE_MEMPTR(DR_REG_R0, 16),
+                              opnd_create_reg(DR_REG_R1), opnd_create_reg(DR_REG_R0),
+                              OPND_CREATE_INT(16));
+    ASSERT(instr_is_opnd_store_source(in, 0));  /* r1. */
+    ASSERT(!instr_is_opnd_store_source(in, 1)); /* r0. */
+    ASSERT(!instr_is_opnd_store_source(in, 2)); /* immed. */
+    instr_destroy(GD, in);
+
+    /* Test data==addr reg. */
+    in = INSTR_CREATE_str_imm(GD, OPND_CREATE_MEMPTR(DR_REG_R0, 16),
+                              opnd_create_reg(DR_REG_R0), opnd_create_reg(DR_REG_R0),
+                              OPND_CREATE_INT(16));
+    ASSERT(instr_is_opnd_store_source(in, 0));  /* r0. */
+    ASSERT(!instr_is_opnd_store_source(in, 1)); /* r0 address. */
+    ASSERT(!instr_is_opnd_store_source(in, 2)); /* immed. */
+    instr_destroy(GD, in);
+
+    in = INSTR_CREATE_stp(GD, OPND_CREATE_MEMPTR(DR_REG_R0, 0),
+                          opnd_create_reg(DR_REG_R1), opnd_create_reg(DR_REG_R2));
+    ASSERT(instr_is_opnd_store_source(in, 0)); /* r1. */
+    ASSERT(instr_is_opnd_store_source(in, 1)); /* r2. */
+    instr_destroy(GD, in);
+
+    /* Test data==addr reg. */
+    in = INSTR_CREATE_stp(GD, OPND_CREATE_MEMPTR(DR_REG_R0, 0),
+                          opnd_create_reg(DR_REG_R0), opnd_create_reg(DR_REG_R1));
+    ASSERT(instr_is_opnd_store_source(in, 0)); /* r0. */
+    ASSERT(instr_is_opnd_store_source(in, 1)); /* r1. */
+    instr_destroy(GD, in);
+}
+
 int
 main()
 {
@@ -211,6 +252,8 @@ main()
     test_mov_instr_addr();
 
     test_categories();
+
+    test_store_source();
 
     print("done\n");
 

--- a/suite/tests/api/drdecode_arm.c
+++ b/suite/tests/api/drdecode_arm.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -110,12 +110,57 @@ test_noalloc(void)
      */
 }
 
+static void
+test_store_source(void)
+{
+    instr_t *in = XINST_CREATE_store(GD, OPND_CREATE_MEMPTR(DR_REG_R0, 42),
+                                     opnd_create_reg(DR_REG_R1));
+    ASSERT(!instr_is_opnd_store_source(in, -1)); /* Out of bounds. */
+    ASSERT(instr_is_opnd_store_source(in, 0));   /* r1. */
+    ASSERT(!instr_is_opnd_store_source(in, 1));  /* Out of bounds. */
+    instr_destroy(GD, in);
+
+    in = INSTR_CREATE_push(GD, opnd_create_reg(DR_REG_R1));
+    ASSERT(instr_is_opnd_store_source(in, 0));  /* r1. */
+    ASSERT(!instr_is_opnd_store_source(in, 1)); /* immed. */
+    ASSERT(!instr_is_opnd_store_source(in, 2)); /* sp. */
+    instr_destroy(GD, in);
+
+    in = INSTR_CREATE_str_wbimm(GD, OPND_CREATE_MEMPTR(DR_REG_R0, 42),
+                                opnd_create_reg(DR_REG_R0), OPND_CREATE_INT(16));
+    ASSERT(instr_is_opnd_store_source(in, 0));  /* r0. */
+    ASSERT(!instr_is_opnd_store_source(in, 1)); /* immed. */
+    ASSERT(!instr_is_opnd_store_source(in, 2)); /* r0 address. */
+    instr_destroy(GD, in);
+
+    in = INSTR_CREATE_stmdb_wb(GD, OPND_CREATE_MEMLIST(DR_REG_R3), 10,
+                               opnd_create_reg(DR_REG_R0), opnd_create_reg(DR_REG_R1),
+                               opnd_create_reg(DR_REG_R2), opnd_create_reg(DR_REG_R3),
+                               opnd_create_reg(DR_REG_R4), opnd_create_reg(DR_REG_R5),
+                               opnd_create_reg(DR_REG_R6), opnd_create_reg(DR_REG_R7),
+                               opnd_create_reg(DR_REG_R8), opnd_create_reg(DR_REG_R9));
+    ASSERT(instr_is_opnd_store_source(in, 0));   /* r0. */
+    ASSERT(instr_is_opnd_store_source(in, 1));   /* r1. */
+    ASSERT(instr_is_opnd_store_source(in, 2));   /* r2. */
+    ASSERT(instr_is_opnd_store_source(in, 3));   /* r3. */
+    ASSERT(instr_is_opnd_store_source(in, 4));   /* r4. */
+    ASSERT(instr_is_opnd_store_source(in, 5));   /* r5. */
+    ASSERT(instr_is_opnd_store_source(in, 6));   /* r6. */
+    ASSERT(instr_is_opnd_store_source(in, 7));   /* r7. */
+    ASSERT(instr_is_opnd_store_source(in, 8));   /* r8. */
+    ASSERT(instr_is_opnd_store_source(in, 9));   /* r9. */
+    ASSERT(!instr_is_opnd_store_source(in, 10)); /* r3 addr. */
+    instr_destroy(GD, in);
+}
+
 int
 main()
 {
     test_LSB();
 
     test_noalloc();
+
+    test_store_source();
 
     printf("done\n");
 

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -214,14 +214,14 @@ test_store_source(void)
 
 #ifndef X64
     in = INSTR_CREATE_pusha(GD);
-    ASSERT(!instr_is_opnd_store_source(in, 0)); /* xsp. */
-    ASSERT(instr_is_opnd_store_source(in, 1));  /* xax. */
-    ASSERT(instr_is_opnd_store_source(in, 2));  /* xbx. */
-    ASSERT(instr_is_opnd_store_source(in, 3));  /* xcx. */
-    ASSERT(instr_is_opnd_store_source(in, 4));  /* xdx. */
-    ASSERT(instr_is_opnd_store_source(in, 5));  /* xbp. */
-    ASSERT(instr_is_opnd_store_source(in, 6));  /* xsi. */
-    ASSERT(instr_is_opnd_store_source(in, 7));  /* xdi. */
+    ASSERT(instr_is_opnd_store_source(in, 0)); /* xsp. */
+    ASSERT(instr_is_opnd_store_source(in, 1)); /* xax. */
+    ASSERT(instr_is_opnd_store_source(in, 2)); /* xbx. */
+    ASSERT(instr_is_opnd_store_source(in, 3)); /* xcx. */
+    ASSERT(instr_is_opnd_store_source(in, 4)); /* xdx. */
+    ASSERT(instr_is_opnd_store_source(in, 5)); /* xbp. */
+    ASSERT(instr_is_opnd_store_source(in, 6)); /* xsi. */
+    ASSERT(instr_is_opnd_store_source(in, 7)); /* xdi. */
     instr_destroy(GD, in);
 #endif
 }

--- a/suite/tests/api/drdecode_x86.c
+++ b/suite/tests/api/drdecode_x86.c
@@ -185,6 +185,47 @@ test_categories(void)
     CHECK_CATEGORY(GD, instr, buf, DR_INSTR_CATEGORY_BRANCH);
 }
 
+static void
+test_store_source(void)
+{
+    instr_t *in = XINST_CREATE_store(GD, OPND_CREATE_MEMPTR(DR_REG_XAX, 42),
+                                     opnd_create_reg(DR_REG_XDX));
+    ASSERT(!instr_is_opnd_store_source(in, -1)); /* Out of bounds. */
+    ASSERT(instr_is_opnd_store_source(in, 0));   /* xdx. */
+    ASSERT(!instr_is_opnd_store_source(in, 1));  /* Out of bounds. */
+    instr_destroy(GD, in);
+
+    in = INSTR_CREATE_add(GD, OPND_CREATE_MEMPTR(DR_REG_XAX, 42),
+                          opnd_create_reg(DR_REG_XDX));
+    ASSERT(!instr_is_opnd_store_source(in, -1)); /* Out of bounds. */
+    ASSERT(instr_is_opnd_store_source(in, 0));   /* xdx. */
+    ASSERT(instr_is_opnd_store_source(in, 1));   /* memop. */
+    ASSERT(!instr_is_opnd_store_source(in, 2));  /* Out of bounds. */
+    instr_destroy(GD, in);
+
+    in = INSTR_CREATE_cmpxchg8b(
+        GD, opnd_create_base_disp(DR_REG_XAX, DR_REG_NULL, 0, 42, OPSZ_8));
+    ASSERT(!instr_is_opnd_store_source(in, 0)); /* Memop. */
+    ASSERT(!instr_is_opnd_store_source(in, 1)); /* xax. */
+    ASSERT(!instr_is_opnd_store_source(in, 2)); /* xdx. */
+    ASSERT(instr_is_opnd_store_source(in, 3));  /* xcx. */
+    ASSERT(instr_is_opnd_store_source(in, 4));  /* xbx. */
+    instr_destroy(GD, in);
+
+#ifndef X64
+    in = INSTR_CREATE_pusha(GD);
+    ASSERT(!instr_is_opnd_store_source(in, 0)); /* xsp. */
+    ASSERT(instr_is_opnd_store_source(in, 1));  /* xax. */
+    ASSERT(instr_is_opnd_store_source(in, 2));  /* xbx. */
+    ASSERT(instr_is_opnd_store_source(in, 3));  /* xcx. */
+    ASSERT(instr_is_opnd_store_source(in, 4));  /* xdx. */
+    ASSERT(instr_is_opnd_store_source(in, 5));  /* xbp. */
+    ASSERT(instr_is_opnd_store_source(in, 6));  /* xsi. */
+    ASSERT(instr_is_opnd_store_source(in, 7));  /* xdi. */
+    instr_destroy(GD, in);
+#endif
+}
+
 int
 main()
 {
@@ -197,6 +238,8 @@ main()
     test_noalloc();
 
     test_categories();
+
+    test_store_source();
 
     printf("done\n");
 


### PR DESCRIPTION
Adds a new IR API routine instr_is_opnd_store_source() which identifies whether a given source operand supplies the value to be stored into memory for a store instruction.  Although generally DR avoids modeling dataflow, especially for complex SIMD shifts, this data identification is useful enough that we provide a helper function.  However, we do not go as far as annotating the decoder operands, and instead deduce the answer based on conventions in our IR, which should suffice for now and even if not as clean as decoder markup it is better to have this helper in one place we could improve in the future instead of different users trying to figure this out.

Adds some tests for each architecture.

Fixes #6397