### PR TITLE
i#4393 AArch64 codec: Move FCVT from v82 to v80.

### DIFF
--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -297,6 +297,10 @@ x1001010xx0xxxxxxxxxxxxxxxxxxxxx  n   90   BASE        eor            wx0 : wx5 
 000111100x1xxxxxxxxx11xxxxxxxxxx  r   109  BASE      fcsel       fcsel_sd
 0001111000100010110000xxxxxxxxxx  n   110  BASE       fcvt             d0 : s5
 0001111001100010010000xxxxxxxxxx  n   110  BASE       fcvt             s0 : d5
+0001111000100011110000xxxxxxxxxx  n   110  BASE       fcvt             h0 : s5
+0001111001100011110000xxxxxxxxxx  n   110  BASE       fcvt             h0 : d5
+0001111011100010010000xxxxxxxxxx  n   110  BASE       fcvt             s0 : h5
+0001111011100010110000xxxxxxxxxx  n   110  BASE       fcvt             d0 : h5
 0001111000100100000000xxxxxxxxxx  n   111  BASE     fcvtas             w0 : s5
 1001111000100100000000xxxxxxxxxx  n   111  BASE     fcvtas             x0 : s5
 0001111001100100000000xxxxxxxxxx  n   111  BASE     fcvtas             w0 : d5

--- a/core/ir/aarch64/codec_v82.txt
+++ b/core/ir/aarch64/codec_v82.txt
@@ -72,10 +72,6 @@
 0001111011100000001000xxxxx11000  w   108  FP16     fcmpe      : h5 zero_fp_const
 00011110111xxxxx001000xxxxx10000  w   108  FP16     fcmpe      : h5 h16
 00011110111xxxxxxxxx11xxxxxxxxxx  r   109  FP16     fcsel  fcsel_h
-0001111000100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : s5
-0001111001100011110000xxxxxxxxxx  n   110  FP16      fcvt   h0 : d5
-0001111011100010010000xxxxxxxxxx  n   110  FP16      fcvt   s0 : h5
-0001111011100010110000xxxxxxxxxx  n   110  FP16      fcvt   d0 : h5
 0x00111001111001110010xxxxxxxxxx  n   111  FP16    fcvtas  dq0 : dq5 h_sz
 0101111001111001110010xxxxxxxxxx  n   111  FP16    fcvtas   h0 : h5
 0001111011100100000000xxxxxxxxxx  n   111  FP16    fcvtas   w0 : h5


### PR DESCRIPTION
Move `FCVT` from `codec_v82.txt` to `codec_v80.txt` and replace `FP16` with `BASE` as these instructions work without the FP16 feature.

No need to move the tests as they were already in `dis-a64.txt`!