### PR TITLE
i#6444 no exit: Add invariant check for thread exit

### DIFF
--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -168,10 +168,12 @@ protected:
 
         uint64_t cur_interval_index;
         uint64_t cur_interval_init_instr_count;
-        // Identifier for the shard. Currently, shards map only to threads, so this is
-        // the thread id.
+        // Identifier for the shard (thread or core id).
         int64_t shard_id;
+        // Ordinal for the shard.
+        int shard_index = 0;
         std::vector<analyzer_tool_shard_data_t> tool_data;
+        bool exited = false;
 
     private:
         // Delete copy constructor and assignment operator to avoid overhead of

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -151,21 +151,23 @@ run_checker(const std::vector<memref_t> &memrefs, bool expect_error,
                                    serial_schedule_file);
         void *shardA = nullptr, *shardB = nullptr, *shardC = nullptr;
         for (const auto &memref : memrefs) {
-            if (memref.instr.tid == TID_A) {
+            switch (memref.instr.tid) {
+            case TID_A:
                 if (shardA == nullptr)
                     shardA = checker.parallel_shard_init(TID_A, NULL);
                 checker.parallel_shard_memref(shardA, memref);
-            } else if (memref.instr.tid == TID_B) {
+                break;
+            case TID_B:
                 if (shardB == nullptr)
                     shardB = checker.parallel_shard_init(TID_B, NULL);
                 checker.parallel_shard_memref(shardB, memref);
-            } else if (memref.instr.tid == TID_C) {
+                break;
+            case TID_C:
                 if (shardC == nullptr)
                     shardC = checker.parallel_shard_init(TID_C, NULL);
                 checker.parallel_shard_memref(shardC, memref);
-            } else {
-                std::cerr << "Internal test error: unknown tid\n";
-                return false;
+                break;
+            default: std::cerr << "Internal test error: unknown tid\n"; return false;
             }
         }
         if (shardA != nullptr)

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -926,7 +926,6 @@ check_rseq()
 {
 #ifdef UNIX
     std::cerr << "Testing rseq\n";
-    constexpr memref_tid_t TID_A = 1;
     // Roll back rseq final instr.
     {
         std::vector<memref_t> memrefs = {
@@ -991,7 +990,6 @@ bool
 check_function_markers()
 {
     std::cerr << "Testing function markers\n";
-    constexpr memref_tid_t TID_A = 1;
     constexpr addr_t CALL_PC = 2;
     constexpr size_t CALL_SZ = 2;
     // Incorrectly between instr and memref.
@@ -1637,11 +1635,11 @@ check_duplicate_syscall_with_same_pc()
             gen_instr_encoded(ADDR + 2, { 0x0f, 0x05 }), // 0x7fcf3b9dd9eb: 0f 05 syscall
 #    elif defined(ARM_64)
             gen_instr_encoded(ADDR, 0xd4000001,
-                              2), // 0x7fcf3b9d: 0xd4000001 svc #0x0
+                              TID_A), // 0x7fcf3b9d: 0xd4000001 svc #0x0
             gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR + 4, 0xd4000001,
-                              2), // 0x7fcf3b9dd9eb: 0xd4000001 svc #0x0
+                              TID_A), // 0x7fcf3b9dd9eb: 0xd4000001 svc #0x0
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
@@ -1683,7 +1681,6 @@ check_syscalls()
     instrlist_append(ilist, sys);
     instrlist_append(ilist, move1);
     static constexpr addr_t BASE_ADDR = 0x123450;
-    static constexpr memref_tid_t TID_A = 1;
     static constexpr uintptr_t FILE_TYPE =
         OFFLINE_FILE_TYPE_ENCODINGS | OFFLINE_FILE_TYPE_SYSCALL_NUMBERS;
     bool res = true;
@@ -2487,7 +2484,6 @@ bool
 check_filter_endpoint()
 {
     std::cerr << "Testing filter end-point marker and file type\n";
-    static constexpr memref_tid_t TID_A = 1;
     // Matching marker and file type: correct.
     {
         std::vector<memref_t> memrefs = {

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -69,8 +69,9 @@ public:
         : invariant_checker_t(offline)
     {
     }
-    checker_no_abort_t(bool offline, std::istream *serial_schedule_file)
+    checker_no_abort_t(bool offline, bool serial, std::istream *serial_schedule_file)
         : invariant_checker_t(offline, 1, "invariant_checker_test", serial_schedule_file)
+        , serial_(serial)
     {
     }
     std::vector<error_info_t> errors_;
@@ -78,6 +79,11 @@ public:
     bool
     print_results() override
     {
+        if (serial_) {
+            for (const auto &keyval : shard_map_) {
+                parallel_shard_exit(keyval.second.get());
+            }
+        }
         per_shard_t global;
         check_schedule_data(&global);
         return true;
@@ -98,9 +104,14 @@ protected:
                                 shard->instr_count_since_last_timestamp_ });
         }
     }
+    bool serial_ = false;
 };
 
 /* Assumes there are at most 3 threads with tids 1, 2, and 3 in memrefs. */
+static constexpr memref_tid_t TID_BASE = 1;
+static constexpr memref_tid_t TID_A = TID_BASE;
+static constexpr memref_tid_t TID_B = TID_BASE + 1;
+static constexpr memref_tid_t TID_C = TID_BASE + 2;
 bool
 run_checker(const std::vector<memref_t> &memrefs, bool expect_error,
             const error_info_t &expected_error_info = {},
@@ -109,7 +120,8 @@ run_checker(const std::vector<memref_t> &memrefs, bool expect_error,
 {
     // Serial.
     {
-        checker_no_abort_t checker(true /*offline*/, serial_schedule_file);
+        checker_no_abort_t checker(/*offline=*/true, /*serial=*/true,
+                                   serial_schedule_file);
         for (const auto &memref : memrefs) {
             checker.process_memref(memref);
         }
@@ -135,25 +147,33 @@ run_checker(const std::vector<memref_t> &memrefs, bool expect_error,
             serial_schedule_file->clear();
             serial_schedule_file->seekg(0, std::ios::beg);
         }
-        checker_no_abort_t checker(true /*offline*/, serial_schedule_file);
-        void *shard1 = checker.parallel_shard_init(1, NULL);
-        void *shard2 = checker.parallel_shard_init(2, NULL);
-        void *shard3 = checker.parallel_shard_init(3, NULL);
+        checker_no_abort_t checker(/*offline=*/true, /*serial=*/false,
+                                   serial_schedule_file);
+        void *shardA = nullptr, *shardB = nullptr, *shardC = nullptr;
         for (const auto &memref : memrefs) {
-            if (memref.instr.tid == 1)
-                checker.parallel_shard_memref(shard1, memref);
-            else if (memref.instr.tid == 2)
-                checker.parallel_shard_memref(shard2, memref);
-            else if (memref.instr.tid == 3)
-                checker.parallel_shard_memref(shard3, memref);
-            else {
+            if (memref.instr.tid == TID_A) {
+                if (shardA == nullptr)
+                    shardA = checker.parallel_shard_init(TID_A, NULL);
+                checker.parallel_shard_memref(shardA, memref);
+            } else if (memref.instr.tid == TID_B) {
+                if (shardB == nullptr)
+                    shardB = checker.parallel_shard_init(TID_B, NULL);
+                checker.parallel_shard_memref(shardB, memref);
+            } else if (memref.instr.tid == TID_C) {
+                if (shardC == nullptr)
+                    shardC = checker.parallel_shard_init(TID_C, NULL);
+                checker.parallel_shard_memref(shardC, memref);
+            } else {
                 std::cerr << "Internal test error: unknown tid\n";
                 return false;
             }
         }
-        checker.parallel_shard_exit(shard1);
-        checker.parallel_shard_exit(shard2);
-        checker.parallel_shard_exit(shard3);
+        if (shardA != nullptr)
+            checker.parallel_shard_exit(shardA);
+        if (shardB != nullptr)
+            checker.parallel_shard_exit(shardB);
+        if (shardC != nullptr)
+            checker.parallel_shard_exit(shardC);
         checker.print_results();
         if (expect_error) {
             if (checker.errors_.size() != 1 ||
@@ -179,9 +199,17 @@ check_branch_target_after_branch()
     // Correct simple test.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(1, 1), gen_branch(1, 2),
-            gen_instr(1, 3), gen_marker(2, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_instr(2, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_branch(TID_A, 2),
+            gen_instr(TID_A, 3),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_instr(TID_B, 1),
+            gen_exit(TID_A),
+            gen_exit(TID_B)
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -189,18 +217,23 @@ check_branch_target_after_branch()
     // Incorrect simple test.
     {
         constexpr uintptr_t TIMESTAMP = 3;
-        constexpr memref_tid_t TID = 1;
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_branch(TID, 2),
-            gen_marker(TID + 1, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP),
-            gen_instr(TID + 1, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP),
-            gen_instr(TID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_branch(TID_A, 2),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP),
+            gen_instr(TID_B, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP),
+            gen_instr(TID_A, 3),
+            gen_exit(TID_A),
+            gen_exit(TID_B)
         };
         if (!run_checker(memrefs, true,
-                         { "Branch target not immediately after branch", TID,
-                           /*ref_ordinal=*/4, /*last_timestamp=*/TIMESTAMP,
+                         { "Branch target not immediately after branch", TID_A,
+                           /*ref_ordinal=*/6, /*last_timestamp=*/TIMESTAMP,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch bad branch target position")) {
             return false;
@@ -209,15 +242,21 @@ check_branch_target_after_branch()
     // Invariant relaxed for thread exit or signal.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(3, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
-            gen_marker(3, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_branch(3, 2),
-            gen_exit(3),
-            gen_instr(1, 1),
-            gen_branch(1, 2),
-            gen_marker(1, TRACE_MARKER_TYPE_KERNEL_EVENT, 3),
-            gen_marker(2, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_instr(2, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_branch(TID_C, 2),
+            gen_exit(TID_C),
+            gen_instr(TID_A, 1),
+            gen_branch(TID_A, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 3),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_instr(TID_B, 4),
+            gen_exit(TID_A),
+            gen_exit(TID_B)
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -229,16 +268,16 @@ bool
 check_sane_control_flow()
 {
     std::cerr << "Testing control flow\n";
-    constexpr memref_tid_t TID = 1;
     // Incorrect simple test.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_instr(TID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), gen_instr(TID_A, 1),
+            gen_instr(TID_A, 3), gen_exit(TID_A)
         };
         if (!run_checker(memrefs, true,
-                         { "Non-explicit control flow has no marker", TID,
-                           /*ref_ordinal=*/2, /*last_timestamp=*/0,
+                         { "Non-explicit control flow has no marker", TID_A,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch bad control flow"))
             return false;
@@ -246,14 +285,17 @@ check_sane_control_flow()
     // Incorrect test with timestamp markers.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 2),
-            gen_instr(TID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 3),
-            gen_instr(TID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 3),
+            gen_instr(TID_A, 3),
+            gen_exit(TID_A)
         };
         if (!run_checker(memrefs, true,
-                         { "Non-explicit control flow has no marker", TID,
-                           /*ref_ordinal=*/4, /*last_timestamp=*/3,
+                         { "Non-explicit control flow has no marker", TID_A,
+                           /*ref_ordinal=*/6, /*last_timestamp=*/3,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch bad control flow")) {
             return false;
@@ -262,9 +304,15 @@ check_sane_control_flow()
     // Correct test: branches with no encodings.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),   gen_branch(TID, 2),  gen_instr(TID, 3), // Not taken.
-            gen_branch(TID, 4),  gen_instr(TID, 101),                    // Taken.
-            gen_instr(TID, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_branch(TID_A, 2),
+            gen_instr(TID_A, 3), // Not taken.
+            gen_branch(TID_A, 4),
+            gen_instr(TID_A, 101), // Taken.
+            gen_instr(TID_A, 102),
+            gen_exit(TID_A)
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -290,17 +338,20 @@ check_sane_control_flow()
         instrlist_append(ilist, move2);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_branch(1), cond_jmp },
-            { gen_instr(1), move2 }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_branch(TID_A), cond_jmp },
+            { gen_instr(TID_A), move2 },
+            { gen_exit(TID_A), nullptr }
         };
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
-                         { "Branch does not go to the correct target", TID,
-                           /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                         { "Branch does not go to the correct target", TID_A,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch branch not going to its target")) {
             return false;
@@ -321,10 +372,13 @@ check_sane_control_flow()
         instrlist_append(ilist, move2);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_branch(1), cond_jmp },
-            { gen_instr(1), move1 }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_branch(TID_A), cond_jmp },
+            { gen_instr(TID_A), move1 },
+            { gen_exit(TID_A), nullptr }
         };
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
@@ -336,11 +390,14 @@ check_sane_control_flow()
     // String loop.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID, 1),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID_A, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID_A, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID_A, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_NO_FETCH, TID_A, 1),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -348,9 +405,12 @@ check_sane_control_flow()
     // Kernel-mediated.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/1, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -360,13 +420,16 @@ check_sane_control_flow()
     // marker.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/1, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 3),
+            gen_exit(TID_A),
         };
         if (!run_checker(
                 memrefs, true,
-                { "Non-explicit control flow has no marker @ kernel_event marker", TID,
-                  /*ref_ordinal=*/2, /*last_timestamp=*/0,
+                { "Non-explicit control flow has no marker @ kernel_event marker", TID_A,
+                  /*ref_ordinal=*/4, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/1 },
                 "Failed to catch PC discontinuity for an instruction followed by "
                 "kernel xfer marker")) {
@@ -377,11 +440,14 @@ check_sane_control_flow()
     // instruction.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/1, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
-            gen_instr(TID, /*pc=*/2, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
+            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -391,7 +457,11 @@ check_sane_control_flow()
     // kernel event.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 3),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -400,11 +470,14 @@ check_sane_control_flow()
     // Correct test: Pre-signal instr continues after signal.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/2, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
-            gen_instr(TID, /*pc=*/2, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
+            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -414,12 +487,15 @@ check_sane_control_flow()
     // of type TRACE_TYPE_INSTR_SYSENTER.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/5, /*size=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_SYSENTER, TID, /*pc=*/6, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/5, /*size=*/1),
+            gen_instr_type(TRACE_TYPE_INSTR_SYSENTER, TID_A, /*pc=*/6, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -428,12 +504,15 @@ check_sane_control_flow()
     // Correct test: RSEQ abort in last signal context.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
             // The RSEQ_ABORT marker is always follwed by a KERNEL_EVENT marker.
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 40),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 40),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT, 40),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 40),
             // We get a signal after the RSEQ abort.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -443,9 +522,12 @@ check_sane_control_flow()
     // have an encoding with it. This case will only occur in legacy or stripped traces.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/1, /*size=*/1),
-            gen_branch(TID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 50),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_branch(TID_A, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 50),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -454,17 +536,20 @@ check_sane_control_flow()
     // Correct test: back-to-back signals without any intervening instruction.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
             // First signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
             // Second signal.
             // The Marker value for this signal needs to be 102.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
-            gen_instr(TID, /*pc=*/102, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_instr(TID_A, /*pc=*/102, /*size=*/1),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -473,20 +558,25 @@ check_sane_control_flow()
     // Correct test: back-to-back signals after an RSEQ abort.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
             // This is the signal which caused the RSEQ abort.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
             // We get a signal after the RSEQ abort.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
             // The kernel event marker has the same value as the previous one.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
-            gen_instr(TID, /*pc=*/301, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_instr(TID_A, /*pc=*/301, /*size=*/1),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -496,25 +586,30 @@ check_sane_control_flow()
     // abort.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
             // This is the signal which caused the RSEQ abort.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
             // We get a signal after the RSEQ abort.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
-            gen_instr(TID, /*pc=*/301, /*size=*/1),
-            gen_instr(TID, /*pc=*/302, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_instr(TID_A, /*pc=*/301, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/302, /*size=*/1),
             // The kernel event marker should point to the previous instruction
             // at PC 302, instead of 301.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_exit(TID_A),
         };
         if (!run_checker(
                 memrefs, true,
-                { "Non-explicit control flow has no marker @ kernel_event marker", TID,
-                  /*ref_ordinal=*/10, /*last_timestamp=*/0,
+                { "Non-explicit control flow has no marker @ kernel_event marker", TID_A,
+                  /*ref_ordinal=*/13, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/4 },
                 "Failed to catch PC discontinuity for an instruction followed by "
                 "kernel xfer marker")) {
@@ -524,22 +619,25 @@ check_sane_control_flow()
     // Incorrect test: back-to-back signals without any intervening instruction.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
             // First signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
             // Second signal.
             // There will be a PC discontinuity here since the marker value is 500, and
             // the previous PC is 101.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 500),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 500),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_exit(TID_A),
         };
         if (!run_checker(
                 memrefs, true,
-                { "Non-explicit control flow has no marker @ kernel_event marker", TID,
-                  /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                { "Non-explicit control flow has no marker @ kernel_event marker", TID_A,
+                  /*ref_ordinal=*/7, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/2 },
                 "Failed to catch PC discontinuity for back-to-back signals without any "
                 "intervening instruction")) {
@@ -560,16 +658,20 @@ check_sane_control_flow()
         static constexpr addr_t BASE_ADDR = 0x123450;
         static constexpr uintptr_t WILL_BE_REPLACED = 0;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID), cbr_to_move },
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, WILL_BE_REPLACED), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, WILL_BE_REPLACED), move },
             /* TODO i#6316: The nop PC is incorrect. We need to add a check for equality
                beteen the KERNEL_XFER marker and the prev instr fall-through. */
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, WILL_BE_REPLACED), nop },
-            { gen_instr(TID), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, WILL_BE_REPLACED), nop },
+            { gen_instr(TID_A), move },
+            { gen_exit(TID_A), nullptr },
         };
         std::vector<memref_t> memrefs =
             add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
@@ -593,21 +695,25 @@ check_sane_control_flow()
         static constexpr addr_t BASE_ADDR = 0x123450;
         static constexpr uintptr_t WILL_BE_REPLACED = 0;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID), cbr_to_move },
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, WILL_BE_REPLACED), move },
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, WILL_BE_REPLACED), nop },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, WILL_BE_REPLACED), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, WILL_BE_REPLACED), nop },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         std::vector<memref_t> memrefs =
             add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
-                         { "Signal handler return point incorrect", TID,
-                           /*ref_ordinal=*/6, /*last_timestamp=*/0,
+                         { "Signal handler return point incorrect", TID_A,
+                           /*ref_ordinal=*/8, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch bad signal handler return")) {
             return false;
@@ -623,13 +729,17 @@ check_kernel_xfer()
 {
 #ifdef UNIX
     std::cerr << "Testing kernel xfers\n";
-    constexpr memref_tid_t TID = 1;
     // Return to recorded interruption point.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),   gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, 101), gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, 101),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -637,12 +747,15 @@ check_kernel_xfer()
     // Signal before any instr in the trace.
     {
         std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             // No instr in the beginning here. Should skip pre-signal instr check
             // on return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, 101),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, 101),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -650,16 +763,19 @@ check_kernel_xfer()
     // Nested signals without any intervening instr.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
             // No intervening instr here. Should skip pre-signal instr check on
             // return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 101),
-            gen_instr(TID, 201),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
-            gen_instr(TID, 101),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 101),
+            gen_instr(TID_A, 201),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_instr(TID_A, 101),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -667,16 +783,19 @@ check_kernel_xfer()
     // Nested signals without any intervening instr or initial instr.
     {
         std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             // No initial instr. Should skip pre-signal instr check on return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
             // No intervening instr here. Should skip pre-signal instr check on
             // return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 101),
-            gen_instr(TID, 201),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
-            gen_instr(TID, 101),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 101),
+            gen_instr(TID_A, 201),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_instr(TID_A, 101),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -685,22 +804,25 @@ check_kernel_xfer()
     // intervening instr between them.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, 101),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, 101),
             // First signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
-            gen_instr(TID, 201),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_instr(TID_A, 201),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
             // Second signal.
             // No intervening instr here. Should use instr at pc = 101 for
             // pre-signal instr check on return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
-            gen_instr(TID, 201),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
-            gen_instr(TID, 102),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 103),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_instr(TID_A, 201),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_instr(TID_A, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 103),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -710,26 +832,29 @@ check_kernel_xfer()
     // and its outer signal.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
             // Outer signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
             // First signal.
             // No intervening instr here. Should skip pre-signal instr check
             // on return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
-            gen_instr(TID, 201),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_instr(TID_A, 201),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
             // Second signal.
             // No intervening instr here. Since there's no pre-signal instr
             // for the first signal as well, we did not see any instr at this
             // signal-depth. So the pre-signal check should be skipped on return
             // of this signal too.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
-            gen_instr(TID, 201),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
-            gen_instr(TID, 102),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 103),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_instr(TID_A, 201),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_instr(TID_A, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 103),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -737,13 +862,16 @@ check_kernel_xfer()
     // Trace starts in a signal.
     {
         std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             // Already inside the first signal.
-            gen_instr(TID, 11),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 12),
+            gen_instr(TID_A, 11),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 12),
             // Should skip the pre-signal instr check and the kernel_event marker
             // equality check, since we did not see the beginning of the signal in
             // the trace.
-            gen_instr(TID, 2),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -752,17 +880,20 @@ check_kernel_xfer()
     // instr after we return from the first one.
     {
         std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             // Already inside the first signal.
-            gen_instr(TID, 11),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 12),
+            gen_instr(TID_A, 11),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 12),
             // No intervening instr here. Should skip pre-signal instr check on
             // return; this is a special case as it would require *removing* the
             // pc = 11 instr from pre_signal_instr_ as it was not in this newly
             // discovered outermost scope.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, 21),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 22),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, 21),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 22),
+            gen_instr(TID_A, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -770,13 +901,18 @@ check_kernel_xfer()
     // Fail to return to recorded interruption point.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),   gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, 101), gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
-            gen_instr(TID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, 101),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 102),
+            gen_instr(TID_A, 3),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Signal handler return point incorrect", TID,
-                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                         { "Signal handler return point incorrect", TID_A,
+                           /*ref_ordinal=*/7, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/3 },
                          "Failed to catch bad signal handler return"))
             return false;
@@ -790,33 +926,39 @@ check_rseq()
 {
 #ifdef UNIX
     std::cerr << "Testing rseq\n";
-    constexpr memref_tid_t TID = 1;
+    constexpr memref_tid_t TID_A = 1;
     // Roll back rseq final instr.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
-            gen_instr(TID, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
+            gen_instr(TID_A, 1),
             // Rolled back instr at pc=2 size=1.
             // Point to the abort handler.
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 4),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
-            gen_instr(TID, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_instr(TID_A, 4),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
     }
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
-            gen_instr(TID, 1),
-            gen_instr(TID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
+            gen_instr(TID_A, 1),
+            gen_instr(TID_A, 2),
             // A fault in the instrumented execution.
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
-            gen_instr(TID, 10),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 11),
-            gen_instr(TID, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_instr(TID_A, 10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 11),
+            gen_instr(TID_A, 4),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -824,16 +966,19 @@ check_rseq()
     // Fail to roll back rseq final instr.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
-            gen_instr(TID, 1),
-            gen_instr(TID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 4),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
-            gen_instr(TID, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ENTRY, 3),
+            gen_instr(TID_A, 1),
+            gen_instr(TID_A, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 4),
+            gen_instr(TID_A, 4),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Rseq post-abort instruction not rolled back", TID,
-                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                         { "Rseq post-abort instruction not rolled back", TID_A,
+                           /*ref_ordinal=*/6, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch bad rseq abort"))
             return false;
@@ -846,22 +991,25 @@ bool
 check_function_markers()
 {
     std::cerr << "Testing function markers\n";
-    constexpr memref_tid_t TID = 1;
+    constexpr memref_tid_t TID_A = 1;
     constexpr addr_t CALL_PC = 2;
     constexpr size_t CALL_SZ = 2;
     // Incorrectly between instr and memref.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, CALL_PC, CALL_SZ),
-            gen_marker(1, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, CALL_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
             // There should be just one error.
-            gen_marker(1, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
-            gen_marker(1, TRACE_MARKER_TYPE_FUNC_ARG, 2),
-            gen_data(1, true, 42, 8),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_data(TID_A, true, 42, 8),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Function marker misplaced between instr and memref", TID,
-                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                         { "Function marker misplaced between instr and memref", TID_A,
+                           /*ref_ordinal=*/7, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch misplaced function marker"))
             return false;
@@ -869,12 +1017,15 @@ check_function_markers()
     // Incorrectly not after a branch.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Function marker should be after a branch", TID,
-                           /*ref_ordinal=*/2, /*last_timestamp=*/0,
+                         { "Function marker should be after a branch", TID_A,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch function marker not after branch"))
             return false;
@@ -882,14 +1033,17 @@ check_function_markers()
     // Incorrect return address.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, CALL_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ + 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, CALL_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ + 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Function marker retaddr should match prior call", TID,
-                           /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                         { "Function marker retaddr should match prior call", TID_A,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch wrong function retaddr"))
             return false;
@@ -897,13 +1051,16 @@ check_function_markers()
     // Incorrectly not after a branch with a load in between.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_data(TID, true, 42, 8),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_data(TID_A, true, 42, 8),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Function marker should be after a branch", TID,
-                           /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                         { "Function marker should be after a branch", TID_A,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch function marker after non-branch with load"))
             return false;
@@ -911,11 +1068,14 @@ check_function_markers()
     // Correctly after a branch.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, CALL_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, CALL_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -923,13 +1083,16 @@ check_function_markers()
     // Correctly after a branch with memref for the branch.
     {
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, CALL_PC, CALL_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID, 3),
-            gen_data(TID, true, 42, 8),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, CALL_PC, CALL_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, 3),
+            gen_data(TID_A, true, 42, 8),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -937,9 +1100,13 @@ check_function_markers()
     // Correctly at the beginning of the trace.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ARG, 2),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -950,10 +1117,13 @@ check_function_markers()
         constexpr addr_t JUMP_PC = 2;
         constexpr size_t JUMP_SZ = 2;
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_JUMP, TID, JUMP_PC, JUMP_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, /*pc=*/123456),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_JUMP, TID_A, JUMP_PC, JUMP_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, /*pc=*/123456),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -967,6 +1137,8 @@ check_function_markers()
         constexpr size_t RETURN_SZ = 3;
 
         std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             // The sequence is based on the following functions:
             // BASE_PC:
             //   call FUNC1_PC
@@ -981,27 +1153,29 @@ check_function_markers()
             //   ret
             //
             // Call function 1.
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, BASE_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, BASE_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
 
             // Call function 2.
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, FUNC1_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, FUNC1_PC + CALL_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, FUNC1_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, FUNC1_PC + CALL_SZ),
 
-            gen_instr(TID, FUNC2_PC, INSTR_SZ),
+            gen_instr(TID_A, FUNC2_PC, INSTR_SZ),
             // Return from function 2.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, FUNC2_PC + INSTR_SZ, RETURN_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, FUNC2_PC + INSTR_SZ,
+                           RETURN_SZ),
 
-            gen_instr(TID, FUNC1_PC + CALL_SZ, INSTR_SZ),
+            gen_instr(TID_A, FUNC1_PC + CALL_SZ, INSTR_SZ),
             // A tail recursion that jumps back to the beginning of function 1.
-            gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID,
+            gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A,
                            FUNC1_PC + CALL_SZ + INSTR_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 1),
             // The return address should be the same as the return address of
             // the original call to function 1.
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1018,35 +1192,40 @@ check_function_markers()
         constexpr size_t SYSCALL_SZ = 2;
 
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, BASE_PC, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, BASE_PC, 1),
             // kernel xfer.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, BASE_PC + 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 6),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, BASE_PC + 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 6),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             // Call function 1.
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, SIG_HANDLER_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, SIG_HANDLER_PC + CALL_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, SIG_HANDLER_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, SIG_HANDLER_PC + CALL_SZ),
             // Call function 2.
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, FUNC1_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, FUNC1_PC + CALL_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, FUNC1_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, FUNC1_PC + CALL_SZ),
             // Return from function 2.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, FUNC2_PC, RETURN_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, FUNC2_PC, RETURN_SZ),
             // Return from function 1.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, FUNC1_PC + CALL_SZ, RETURN_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, FUNC1_PC + CALL_SZ, RETURN_SZ),
             // Return from the signal handler.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG_HANDLER_PC + CALL_SZ,
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG_HANDLER_PC + CALL_SZ,
                            RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SYSCALL_PC, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 16),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_instr(TID_A, SYSCALL_PC, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 16),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             // Syscall xfer.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 17),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 17),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1061,26 +1240,31 @@ check_function_markers()
         constexpr size_t SYSCALL_SZ = 2;
 
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, BASE_PC, INSTR_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, BASE_PC + INSTR_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, BASE_PC, INSTR_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, BASE_PC + INSTR_SZ),
             // No intervening instr here. Should skip pre-signal instr check on
             // return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC),
-            gen_instr(TID, SIG2_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG2_PC + INSTR_SZ, RETURN_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC),
+            gen_instr(TID_A, SIG2_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG2_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG2_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
-            gen_instr(TID, SIG1_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG1_PC + INSTR_SZ, RETURN_SZ),
+            gen_instr(TID_A, SIG1_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG1_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG1_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
-            gen_instr(TID, BASE_PC + INSTR_SZ, INSTR_SZ),
+            gen_instr(TID_A, BASE_PC + INSTR_SZ, INSTR_SZ),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1096,38 +1280,44 @@ check_function_markers()
         constexpr size_t SYSCALL_SZ = 2;
 
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, BASE_PC, INSTR_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, BASE_PC + INSTR_SZ),
-            gen_instr(TID, SIG1_PC, INSTR_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, BASE_PC, INSTR_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, BASE_PC + INSTR_SZ),
+            gen_instr(TID_A, SIG1_PC, INSTR_SZ),
             // First signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC + INSTR_SZ),
-            gen_instr(TID, SIG2_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG2_PC + INSTR_SZ, RETURN_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC + INSTR_SZ),
+            gen_instr(TID_A, SIG2_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG2_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG2_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
             // Second signal.
             // No intervening instr here. Should use instr at pc = 101 for
             // pre-signal instr check on return.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC + INSTR_SZ),
-            gen_instr(TID, SIG2_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG2_PC + INSTR_SZ, RETURN_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC + INSTR_SZ),
+            gen_instr(TID_A, SIG2_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG2_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG2_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
 
-            gen_instr(TID, SIG1_PC + INSTR_SZ, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG1_PC + INSTR_SZ * 2,
+            gen_instr(TID_A, SIG1_PC + INSTR_SZ, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG1_PC + INSTR_SZ * 2,
                            RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, SIG1_PC + INSTR_SZ + INSTR_SZ),
-            gen_instr(TID, BASE_PC + INSTR_SZ, INSTR_SZ),
+            gen_instr(TID_A, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
+                       SIG1_PC + INSTR_SZ + INSTR_SZ),
+            gen_instr(TID_A, BASE_PC + INSTR_SZ, INSTR_SZ),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1140,26 +1330,30 @@ check_function_markers()
         constexpr size_t ABORT_HANDLER_OFFSET = 10;
 
         std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             // Call function 1.
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, BASE_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, BASE_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
 
-            gen_instr(TID, FUNC_PC, INSTR_SZ),
+            gen_instr(TID_A, FUNC_PC, INSTR_SZ),
             // Rolled back instr at pc=FUNC_PC+INSTR_SZ size=CALL_SZ.
             // Point to the abort handler.
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, FUNC_PC + ABORT_HANDLER_OFFSET),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT,
                        FUNC_PC + ABORT_HANDLER_OFFSET),
-            gen_instr(TID, FUNC_PC + ABORT_HANDLER_OFFSET, INSTR_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT,
+                       FUNC_PC + ABORT_HANDLER_OFFSET),
+            gen_instr(TID_A, FUNC_PC + ABORT_HANDLER_OFFSET, INSTR_SZ),
 
             // A tail recursion that jumps back to the beginning of function 1.
-            gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID,
+            gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A,
                            FUNC_PC + ABORT_HANDLER_OFFSET + INSTR_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 1),
             // The return address should be the same as the return address of
             // the original call to function 1.
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, BASE_PC + CALL_SZ),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1175,23 +1369,28 @@ check_function_markers()
         constexpr size_t RETURN_SZ = 3;
 
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, CALL_PC, CALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
-            gen_instr(TID, SIG_HANDLER_PC),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, CALL_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
+            gen_instr(TID_A, SIG_HANDLER_PC),
             // Return from the signal handler.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG_HANDLER_PC + 1, RETURN_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG_HANDLER_PC + 1, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SYSCALL_PC, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 16),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_instr(TID_A, SYSCALL_PC, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 16),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             // Syscall xfer.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 17),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 17),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1205,20 +1404,25 @@ check_function_markers()
         constexpr size_t RETURN_SZ = 3;
 
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, SIG_HANDLER_PC),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, SIG_HANDLER_PC),
             // Return from the signal handler.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG_HANDLER_PC + 1, RETURN_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG_HANDLER_PC + 1, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SYSCALL_PC, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 16),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_instr(TID_A, SYSCALL_PC, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 16),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             // Syscall xfer.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 17),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 17),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1233,21 +1437,26 @@ check_function_markers()
         constexpr size_t RETURN_SZ = 3;
 
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
-            gen_instr(TID, SIG_HANDLER_PC),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
+            gen_instr(TID_A, SIG_HANDLER_PC),
             // Return from the signal handler.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG_HANDLER_PC + 1, RETURN_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG_HANDLER_PC + 1, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SYSCALL_PC, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 16),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_instr(TID_A, SYSCALL_PC, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 16),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             // Syscall xfer.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 17),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 17),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, CALL_PC + CALL_SZ),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1261,26 +1470,31 @@ check_function_markers()
         constexpr size_t RETURN_SZ = 3;
 
         std::vector<memref_t> memrefs = {
-            gen_instr(TID, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
-            gen_instr(TID, SIG_HANDLER_PC),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, SIG_HANDLER_PC),
             // Return from the signal handler.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG_HANDLER_PC + 1, RETURN_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG_HANDLER_PC + 1, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SYSCALL_PC, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 16),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_instr(TID_A, SYSCALL_PC, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 16),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             // Syscall xfer.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 17),
-            gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, SYSCALL_PC + SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 17),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             // There should not be a function ID marker here.
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Function marker should be after a branch", TID,
-                           /*ref_ordinal=*/12, /*last_timestamp=*/17,
+                         { "Function marker should be after a branch", TID_A,
+                           /*ref_ordinal=*/15, /*last_timestamp=*/17,
                            /*instrs_since_last_timestamp=*/0 },
                          "Failed to catch function marker not after branch"))
             return false;
@@ -1297,27 +1511,32 @@ check_function_markers()
         constexpr size_t SYSCALL_SZ = 2;
 
         std::vector<memref_t> memrefs = {
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, BASE_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, BASE_PC, CALL_SZ),
             // First signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
             // Second signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC),
-            gen_instr(TID, SIG2_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG2_PC + INSTR_SZ, RETURN_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, SIG1_PC),
+            gen_instr(TID_A, SIG2_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG2_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn of the second signal.
-            gen_instr(TID, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG2_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
-            gen_instr(TID, SIG1_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG1_PC + INSTR_SZ, RETURN_SZ),
+            gen_instr(TID_A, SIG1_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG1_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn of the first signal.
-            gen_instr(TID, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG1_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
             // Function marker of the call before the first signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1334,27 +1553,32 @@ check_function_markers()
         constexpr size_t SYSCALL_SZ = 2;
 
         std::vector<memref_t> memrefs = {
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID, BASE_PC, CALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, BASE_PC, CALL_SZ),
             // First signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
-            gen_instr(TID, SIG1_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG1_PC + INSTR_SZ, RETURN_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
+            gen_instr(TID_A, SIG1_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG1_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG1_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG1_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
             // Second signal with no intervening instr.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
-            gen_instr(TID, SIG2_PC, INSTR_SZ),
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID, SIG2_PC + INSTR_SZ, RETURN_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, FUNC_PC),
+            gen_instr(TID_A, SIG2_PC, INSTR_SZ),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, SIG2_PC + INSTR_SZ, RETURN_SZ),
             // Sigreturn.
-            gen_instr(TID, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER,
+            gen_instr(TID_A, SIG2_PC + INSTR_SZ + RETURN_SZ, SYSCALL_SZ),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
                        SIG2_PC + INSTR_SZ + RETURN_SZ + SYSCALL_SZ),
             // Function marker of the call before the first signal.
-            gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, 2),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1372,26 +1596,29 @@ check_duplicate_syscall_with_same_pc()
     constexpr addr_t ADDR = 0x7fcf3b9d;
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
             gen_instr_encoded(ADDR, { 0x0f, 0x05 }), // 0x7fcf3b9d: 0f 05 syscall
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 6),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 6),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR, { 0x0f, 0x05 }), // 0x7fcf3b9d: 0f 05 syscall
 #    elif defined(ARM_64)
             gen_instr_encoded(ADDR,
                               0xd4000001), // 0x7fcf3b9d: 0xd4000001 svc #0x0
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 6),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 6),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR,
                               0xd4000001), // 0x7fcf3b9d: 0xd4000001 svc #0x0
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
+            gen_exit(TID_A)
         };
         if (!run_checker(memrefs, true,
                          { "Duplicate syscall instrs with the same PC", /*tid=*/1,
-                           /*ref_ordinal=*/5, /*last_timestamp=*/6,
+                           /*ref_ordinal=*/7, /*last_timestamp=*/6,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch duplicate syscall instrs with the same PC"))
             return false;
@@ -1400,22 +1627,25 @@ check_duplicate_syscall_with_same_pc()
     // Correct: syscalls with different PCs.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
 #    if defined(X86_64) || defined(X86_32)
             gen_instr_encoded(ADDR, { 0x0f, 0x05 }), // 0x7fcf3b9d: 0f 05 syscall
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR + 2, { 0x0f, 0x05 }), // 0x7fcf3b9dd9eb: 0f 05 syscall
 #    elif defined(ARM_64)
             gen_instr_encoded(ADDR, 0xd4000001,
                               2), // 0x7fcf3b9d: 0xd4000001 svc #0x0
-            gen_marker(1, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(1, TRACE_MARKER_TYPE_CPU_ID, 3),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3),
             gen_instr_encoded(ADDR + 4, 0xd4000001,
                               2), // 0x7fcf3b9dd9eb: 0xd4000001 svc #0x0
 #    else
         // TODO i#5871: Add AArch32 (and RISC-V) encodings.
 #    endif
+            gen_exit(TID_A)
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -1453,7 +1683,7 @@ check_syscalls()
     instrlist_append(ilist, sys);
     instrlist_append(ilist, move1);
     static constexpr addr_t BASE_ADDR = 0x123450;
-    static constexpr memref_tid_t TID = 1;
+    static constexpr memref_tid_t TID_A = 1;
     static constexpr uintptr_t FILE_TYPE =
         OFFLINE_FILE_TYPE_ENCODINGS | OFFLINE_FILE_TYPE_SYSCALL_NUMBERS;
     bool res = true;
@@ -1461,9 +1691,12 @@ check_syscalls()
         // Correct: syscall followed by marker (no timestamps; modeling versions
         // prior to TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS).
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), sys },
-            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, false))
@@ -1475,18 +1708,21 @@ check_syscalls()
         uintptr_t sys_func_id =
             static_cast<uintptr_t>(func_trace_t::TRACE_FUNC_ID_SYSCALL_BASE) + 202;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), sys },
-            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, sys_func_id), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ARG, 0), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_ID, sys_func_id), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FUNC_RETVAL, 0), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 111), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
-            { gen_instr(TID), move1 }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, sys_func_id), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ARG, 0), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, sys_func_id), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETVAL, 0), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 111), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_instr(TID_A), move1 },
+            { gen_exit(TID_A), nullptr }
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, false))
@@ -1495,11 +1731,14 @@ check_syscalls()
     {
         // Correct: syscall followed by marker with timestamp+cpu in between.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), sys },
-            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, false))
@@ -1508,14 +1747,17 @@ check_syscalls()
     {
         // Incorrect: syscall with no marker.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), sys },
-            { gen_instr(TID), move1 }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_instr(TID_A), move1 },
+            { gen_exit(TID_A), nullptr }
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall marker missing after syscall instruction", TID,
-                           /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                         { "Syscall marker missing after syscall instruction", TID_A,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch syscall without number marker")) {
             res = false;
@@ -1524,14 +1766,17 @@ check_syscalls()
     {
         // Incorrect: marker with no syscall.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), move1 },
-            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), move1 },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall marker not placed after syscall instruction", TID,
-                           /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                         { "Syscall marker not placed after syscall instruction", TID_A,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch misplaced syscall marker")) {
             res = false;
@@ -1542,14 +1787,17 @@ check_syscalls()
     {
         // Correct: syscall preceded by timestamp+cpu.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
                          TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), sys },
-            { gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 101), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, false))
@@ -1558,17 +1806,20 @@ check_syscalls()
     {
         // Incorrect: syscall with no preceding timestamp+cpu.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
                          TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), sys },
-            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall marker not preceded by timestamp + cpuid", TID,
-                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                         { "Syscall marker not preceded by timestamp + cpuid", TID_A,
+                           /*ref_ordinal=*/6, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch syscall without timestamp+cpuid")) {
             res = false;
@@ -1577,18 +1828,21 @@ check_syscalls()
     {
         // Incorrect: syscall with preceding cpu but no timestamp.
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION,
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
                          TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
-            { gen_instr(TID), sys },
-            { gen_marker(TID, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, 3), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         if (!run_checker(memrefs, true,
-                         { "Syscall marker not preceded by timestamp + cpuid", TID,
-                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                         { "Syscall marker not preceded by timestamp + cpuid", TID_A,
+                           /*ref_ordinal=*/7, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch syscall without timestamp")) {
             res = false;
@@ -1623,16 +1877,19 @@ check_rseq_side_exit_discontinuity()
     instrlist_append(ilist, move2);
 
     std::vector<memref_with_IR_t> memref_instr_vec = {
-        { gen_marker(1, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+        { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
           nullptr },
+        { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+        { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
         // Rseq entry marker not added to make the sequence look like a legacy
         // trace.
-        { gen_branch(1), cond_jmp },
-        { gen_instr(1), store },
-        { gen_data(1, false, 42, 4), nullptr },
+        { gen_branch(TID_A), cond_jmp },
+        { gen_instr(TID_A), store },
+        { gen_data(TID_A, false, 42, 4), nullptr },
         // move1 instruction missing due to the 'side-exit' at move2 which is
         // the target of cond_jmp.
-        { gen_instr(1), move2 }
+        { gen_instr(TID_A), move2 },
+        { gen_exit(TID_A), nullptr }
     };
 
     // TODO i#6023: Use this IR based encoder in other tests as well.
@@ -1641,7 +1898,7 @@ check_rseq_side_exit_discontinuity()
     instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
     if (!run_checker(memrefs, true,
                      { "PC discontinuity due to rseq side exit", /*tid=*/1,
-                       /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                       /*ref_ordinal=*/7, /*last_timestamp=*/0,
                        /*instrs_since_last_timestamp=*/3 },
                      "Failed to catch PC discontinuity from rseq side exit")) {
         return false;
@@ -1655,21 +1912,20 @@ check_schedule_file()
     std::cerr << "Testing schedule files\n";
     // Synthesize a serial schedule file.
     // We leave the cpu-schedule testing to the real-app tests.
-    static constexpr memref_tid_t TID_BASE = 1; // Assumed by run_checker.
     static constexpr memref_tid_t TIMESTAMP_BASE = 100;
     static constexpr int CPU_BASE = 6;
     std::string serial_fname = "tmp_inv_check_serial.bin";
     std::vector<schedule_entry_t> sched;
-    sched.emplace_back(TID_BASE, TIMESTAMP_BASE, CPU_BASE, 0);
+    sched.emplace_back(TID_A, TIMESTAMP_BASE, CPU_BASE, 0);
     // Include same-timestamp records to stress handling that.
-    sched.emplace_back(TID_BASE + 2, TIMESTAMP_BASE, CPU_BASE + 1, 0);
-    sched.emplace_back(TID_BASE + 1, TIMESTAMP_BASE, CPU_BASE + 2, 0);
-    sched.emplace_back(TID_BASE, TIMESTAMP_BASE + 1, CPU_BASE + 1, 2);
-    sched.emplace_back(TID_BASE + 1, TIMESTAMP_BASE + 2, CPU_BASE, 1);
+    sched.emplace_back(TID_C, TIMESTAMP_BASE, CPU_BASE + 1, 0);
+    sched.emplace_back(TID_B, TIMESTAMP_BASE, CPU_BASE + 2, 0);
+    sched.emplace_back(TID_A, TIMESTAMP_BASE + 1, CPU_BASE + 1, 2);
+    sched.emplace_back(TID_B, TIMESTAMP_BASE + 2, CPU_BASE, 1);
     // Include records with the same thread ID, timestamp, and CPU, but
     // different start_instruction is being used for comparison.
-    sched.emplace_back(TID_BASE + 2, TIMESTAMP_BASE + 3, CPU_BASE + 2, 3);
-    sched.emplace_back(TID_BASE + 2, TIMESTAMP_BASE + 3, CPU_BASE + 2, 4);
+    sched.emplace_back(TID_C, TIMESTAMP_BASE + 3, CPU_BASE + 2, 3);
+    sched.emplace_back(TID_C, TIMESTAMP_BASE + 3, CPU_BASE + 2, 4);
     {
         std::ofstream serial_file(serial_fname, std::ofstream::binary);
         if (!serial_file)
@@ -1681,32 +1937,41 @@ check_schedule_file()
     {
         // Create a schedule that matches the file.
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
-            gen_instr(TID_BASE, 1),
-            gen_instr(TID_BASE, 2),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
-            gen_instr(TID_BASE + 2, 1),
-            gen_instr(TID_BASE + 2, 2),
-            gen_instr(TID_BASE + 2, 3),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
-            gen_instr(TID_BASE + 1, 1),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 1),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
-            gen_instr(TID_BASE, 3),
-            gen_instr(TID_BASE, 4),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 2),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
-            gen_instr(TID_BASE + 1, 2),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
-            gen_instr(TID_BASE + 2, 4),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
+            gen_instr(TID_A, 1),
+            gen_instr(TID_A, 2),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
+            gen_instr(TID_C, 1),
+            gen_instr(TID_C, 2),
+            gen_instr(TID_C, 3),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_instr(TID_B, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
+            gen_instr(TID_A, 3),
+            gen_instr(TID_A, 4),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 2),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
+            gen_instr(TID_B, 2),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_instr(TID_C, 4),
             // Markers for the second schedule entry with the same thread ID,
             // timestamp, and CPU as the previous one with a different start_instruction.
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_exit(TID_A),
+            gen_exit(TID_B),
+            gen_exit(TID_C),
         };
         std::ifstream serial_read(serial_fname, std::ifstream::binary);
         if (!serial_read)
@@ -1717,26 +1982,35 @@ check_schedule_file()
     {
         // Create a schedule that does not match the file in record count.
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
-            gen_instr(TID_BASE, 1),
-            gen_instr(TID_BASE, 2),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
-            gen_instr(TID_BASE + 2, 1),
-            gen_instr(TID_BASE + 2, 2),
-            gen_instr(TID_BASE + 2, 3),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
-            gen_instr(TID_BASE + 1, 1),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 1),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
-            gen_instr(TID_BASE, 3),
-            gen_instr(TID_BASE, 4),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 2),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
-            gen_instr(TID_BASE + 1, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
+            gen_instr(TID_A, 1),
+            gen_instr(TID_A, 2),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
+            gen_instr(TID_C, 1),
+            gen_instr(TID_C, 2),
+            gen_instr(TID_C, 3),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_instr(TID_B, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
+            gen_instr(TID_A, 3),
+            gen_instr(TID_A, 4),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 2),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
+            gen_instr(TID_B, 2),
             // Missing the final timestamp+cpu.
+            gen_exit(TID_A),
+            gen_exit(TID_B),
+            gen_exit(TID_C),
         };
         std::ifstream serial_read(serial_fname, std::ifstream::binary);
         if (!serial_read)
@@ -1751,37 +2025,46 @@ check_schedule_file()
     {
         // Create a schedule that does not match the file in one record.
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
-            gen_instr(TID_BASE, 1),
-            gen_instr(TID_BASE, 2),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
-            gen_instr(TID_BASE + 2, 1),
-            gen_instr(TID_BASE + 2, 2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
+            gen_instr(TID_A, 1),
+            gen_instr(TID_A, 2),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
+            gen_instr(TID_C, 1),
+            gen_instr(TID_C, 2),
             // Missing one instruction here.
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
-            gen_instr(TID_BASE + 1, 1),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 1),
-            gen_marker(TID_BASE, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
-            gen_instr(TID_BASE, 3),
-            gen_instr(TID_BASE, 4),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 2),
-            gen_marker(TID_BASE + 1, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
-            gen_instr(TID_BASE + 1, 2),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
-            gen_instr(TID_BASE + 2, 3),
-            gen_instr(TID_BASE + 2, 4),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
-            gen_marker(TID_BASE + 2, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_instr(TID_B, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 1),
+            gen_instr(TID_A, 3),
+            gen_instr(TID_A, 4),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 2),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE),
+            gen_instr(TID_B, 2),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_instr(TID_C, 3),
+            gen_instr(TID_C, 4),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP_BASE + 3),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CPU_ID, CPU_BASE + 2),
+            gen_exit(TID_A),
+            gen_exit(TID_B),
+            gen_exit(TID_C),
         };
         std::ifstream serial_read(serial_fname, std::ifstream::binary);
         if (!serial_read)
             return false;
         if (!run_checker(memrefs, true,
-                         { "Serial schedule entry does not match trace", TID_BASE + 2,
+                         { "Serial schedule entry does not match trace", TID_C,
                            /*ref_ordinal=*/3, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/0 },
                          "Failed to catch incorrect serial schedule entry", &serial_read))
@@ -1795,15 +2078,17 @@ bool
 check_branch_decoration()
 {
     std::cerr << "Testing branch decoration\n";
-    static constexpr memref_tid_t TID = 1;
     // Indirect branch target: correct.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
-            gen_instr(TID, /*pc=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID_A, /*pc=*/2, /*size=*/1,
                            /*target=*/32),
-            gen_instr(TID, /*pc=*/32),
+            gen_instr(TID_A, /*pc=*/32),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1813,12 +2098,15 @@ check_branch_decoration()
     // We ensure the next PC is obtained from the kernel event interruption.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
-            gen_instr(TID, /*pc=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID_A, /*pc=*/2, /*size=*/1,
                            /*target=*/32),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 32),
-            gen_instr(TID, /*pc=*/999),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 32),
+            gen_instr(TID_A, /*pc=*/999),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -1827,14 +2115,17 @@ check_branch_decoration()
     // Indirect branch target: incorrect zero target PC.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
-            gen_instr(TID, /*pc=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID_A, /*pc=*/2, /*size=*/1,
                            /*target=*/0),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Indirect branches must contain targets", TID,
-                           /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                         { "Indirect branches must contain targets", TID_A,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch missing indirect branch target field"))
             return false;
@@ -1842,15 +2133,18 @@ check_branch_decoration()
     // Indirect branch target: incorrect target value.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
-            gen_instr(TID, /*pc=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID_A, /*pc=*/2, /*size=*/1,
                            /*target=*/32),
-            gen_instr(TID, /*pc=*/33),
+            gen_instr(TID_A, /*pc=*/33),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Branch does not go to the correct target", TID,
-                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                         { "Branch does not go to the correct target", TID_A,
+                           /*ref_ordinal=*/6, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/3 },
                          "Failed to catch bad indirect branch target field"))
             return false;
@@ -1859,17 +2153,20 @@ check_branch_decoration()
     // Indirect branch target with kernel event: marker value incorrect.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
-            gen_instr(TID, /*pc=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID, /*pc=*/2, /*size=*/1,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_CALL, TID_A, /*pc=*/2, /*size=*/1,
                            /*target=*/32),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 999),
-            gen_instr(TID, /*pc=*/32),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 999),
+            gen_instr(TID_A, /*pc=*/32),
+            gen_exit(TID_A),
         };
         if (!run_checker(
                 memrefs, true,
-                { "Branch does not go to the correct target @ kernel_event marker", TID,
-                  /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                { "Branch does not go to the correct target @ kernel_event marker", TID_A,
+                  /*ref_ordinal=*/6, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/2 },
                 "Failed to catch bad indirect branch target field")) {
             return false;
@@ -1878,19 +2175,24 @@ check_branch_decoration()
     // Correct test: back-to-back signals after an RSEQ abort.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
-            gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID, /*pc=*/101, /*size=*/1,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
+                       OFFLINE_FILE_TYPE_SYSCALL_NUMBERS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID_A, /*pc=*/101, /*size=*/1,
                            /*target=*/0),
-            gen_marker(TID, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_RSEQ_ABORT, 102),
             // This is the signal which caused the RSEQ abort.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 102),
             // We get a signal after the RSEQ abort.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
-            gen_instr(TID, /*pc=*/201, /*size=*/1),
-            gen_marker(TID, TRACE_MARKER_TYPE_SYSCALL, 15),
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 15),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 202),
             // The kernel event marker has the same value as the previous one.
-            gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 301),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
             return false;
@@ -1900,14 +2202,17 @@ check_branch_decoration()
     // Deprecated branch type.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
-            gen_instr(TID, /*pc=*/1),
-            gen_instr_type(TRACE_TYPE_INSTR_CONDITIONAL_JUMP, TID, /*pc=*/2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_instr_type(TRACE_TYPE_INSTR_CONDITIONAL_JUMP, TID_A, /*pc=*/2),
+            gen_exit(TID_A),
         };
         if (!run_checker(
                 memrefs, true,
-                { "The CONDITIONAL_JUMP type is deprecated and should not appear", TID,
-                  /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                { "The CONDITIONAL_JUMP type is deprecated and should not appear", TID_A,
+                  /*ref_ordinal=*/5, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/2 },
                 "Failed to catch deprecated branch type"))
             return false;
@@ -1925,12 +2230,16 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID), cbr_to_move },
-            { gen_instr(TID), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_instr(TID_A), move },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -1951,13 +2260,17 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID), cbr_to_move },
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), move },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), move },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -1978,18 +2291,22 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID), cbr_to_move },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
                          { "Branch does not go to the correct target", /*tid=*/1,
-                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                           /*ref_ordinal=*/6, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch taken branch falling through"))
             return false;
@@ -2008,13 +2325,17 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID), cbr_to_move },
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), nop },
-            { gen_instr(TID), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_TAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), nop },
+            { gen_instr(TID_A), move },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -2022,7 +2343,7 @@ check_branch_decoration()
                 memrefs, true,
                 { "Branch does not go to the correct target @ kernel_event marker",
                   /*tid=*/1,
-                  /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                  /*ref_ordinal=*/6, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/1 },
                 "Failed to catch taken branch falling through to signal"))
             return false;
@@ -2041,12 +2362,16 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID), cbr_to_move },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -2067,13 +2392,17 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID), cbr_to_move },
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), nop },
-            { gen_instr(TID), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), nop },
+            { gen_instr(TID_A), move },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -2094,18 +2423,22 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID), cbr_to_move },
-            { gen_instr(TID), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_instr(TID_A), move },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
-                         { "Branch does not go to the correct target", TID,
-                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                         { "Branch does not go to the correct target", TID_A,
+                           /*ref_ordinal=*/6, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch untaken branch going to taken target"))
             return false;
@@ -2124,20 +2457,24 @@ check_branch_decoration()
         instrlist_append(ilist, move);
         static constexpr addr_t BASE_ADDR = 0x123450;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_VERSION, TRACE_ENTRY_VERSION_BRANCH_INFO),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
               nullptr },
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID), cbr_to_move },
-            { gen_marker(TID, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), move },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr_type(TRACE_TYPE_INSTR_UNTAKEN_JUMP, TID_A), cbr_to_move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), move },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(
                 memrefs, true,
-                { "Branch does not go to the correct target @ kernel_event marker", TID,
-                  /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                { "Branch does not go to the correct target @ kernel_event marker", TID_A,
+                  /*ref_ordinal=*/6, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/1 },
                 "Failed to catch untaken branch going to taken target at signal"))
             return false;
@@ -2150,19 +2487,21 @@ bool
 check_filter_endpoint()
 {
     std::cerr << "Testing filter end-point marker and file type\n";
-    static constexpr memref_tid_t TID = 1;
+    static constexpr memref_tid_t TID_A = 1;
     // Matching marker and file type: correct.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
                        OFFLINE_FILE_TYPE_IFILTERED |
                            OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP),
-            gen_marker(TID, TRACE_MARKER_TYPE_INSTRUCTION_COUNT, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
-            gen_marker(TID, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_marker(TID, TRACE_MARKER_TYPE_FILTER_ENDPOINT, 0),
-            gen_instr(TID),
-            gen_exit(TID),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_INSTRUCTION_COUNT, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILTER_ENDPOINT, 0),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -2170,21 +2509,23 @@ check_filter_endpoint()
     // Missing TRACE_MARKER_TYPE_FILTER_ENDPOINT marker: incorrect.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE,
                        OFFLINE_FILE_TYPE_IFILTERED |
                            OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP),
-            gen_marker(TID, TRACE_MARKER_TYPE_INSTRUCTION_COUNT, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
-            gen_marker(TID, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID),
-            gen_exit(TID),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_INSTRUCTION_COUNT, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(
                 memrefs, true,
                 { "Expected to find TRACE_MARKER_TYPE_FILTER_ENDPOINT for the given "
                   "file type",
-                  TID,
-                  /*ref_ordinal=*/6, /*last_timestamp=*/0,
+                  TID_A,
+                  /*ref_ordinal=*/8, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/1 },
                 "Failed to catch missing TRACE_MARKER_TYPE_FILTER_ENDPOINT marker"))
             return false;
@@ -2192,13 +2533,13 @@ check_filter_endpoint()
     // Unexpected TRACE_MARKER_TYPE_FILTER_ENDPOINT marker: incorrect.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_IFILTERED),
-            gen_marker(TID, TRACE_MARKER_TYPE_INSTRUCTION_COUNT, 1),
-            gen_marker(TID, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
-            gen_marker(TID, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_marker(TID, TRACE_MARKER_TYPE_FILTER_ENDPOINT, 0),
-            gen_instr(TID),
-            gen_exit(TID),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_IFILTERED),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_INSTRUCTION_COUNT, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILTER_ENDPOINT, 0),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
                          { "Found TRACE_MARKER_TYPE_FILTER_ENDPOINT without the "
@@ -2216,13 +2557,17 @@ check_filter_endpoint()
 bool
 check_timestamps_increase_monotonically(void)
 {
-    static constexpr memref_tid_t TID = 1;
+    std::cerr << "Testing timestamp ordering\n";
     // Correct: timestamps increase monotonically.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 10),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -2230,14 +2575,18 @@ check_timestamps_increase_monotonically(void)
     // Incorrect: timestamp does not increase monotonically.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 0),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 10),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 5),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 5),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
                          { "Timestamp does not increase monotonically",
                            /*tid=*/1,
-                           /*ref_ordinal=*/3, /*last_timestamp=*/10,
+                           /*ref_ordinal=*/5, /*last_timestamp=*/10,
                            /*instrs_since_last_timestamp=*/0 },
                          "Failed to catch timestamps not increasing "
                          "monotonically"))
@@ -2247,11 +2596,15 @@ check_timestamps_increase_monotonically(void)
     // Correct: timestamp rollovers.
     {
         std::vector<memref_t> memrefs = {
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP,
                        (std::numeric_limits<uintptr_t>::max)() - 10),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP,
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP,
                        (std::numeric_limits<uintptr_t>::max)()),
-            gen_marker(TID, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 10),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))
             return false;
@@ -2266,7 +2619,6 @@ check_read_write_records_match_operands()
     // Only the number of memory read and write records is checked against the
     // operands. Address and size are not used.
     std::cerr << "Testing number of memory read/write records matching operands\n";
-    constexpr memref_tid_t TID = 1;
 
     // Correct: number of read records matches the operand.
     {
@@ -2276,10 +2628,13 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, load);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), load },
-            { gen_data(TID, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), load },
+            { gen_data(TID_A, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_exit(TID_A), nullptr }
         };
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
@@ -2296,17 +2651,20 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, load);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), load },
-            { gen_data(TID, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr },
-            { gen_data(TID, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), load },
+            { gen_data(TID_A, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_data(TID_A, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_exit(TID_A), nullptr }
         };
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
-                         { "Too many read records", TID, /*ref_ordinal=*/4,
+                         { "Too many read records", TID_A, /*ref_ordinal=*/6,
                            /*last_timestamp=*/0, /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch too many read records"))
             return false;
@@ -2321,16 +2679,19 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, nop);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), load },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), load },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
-                         { "Missing read records", TID, /*ref_ordinal=*/3,
+                         { "Missing read records", TID_A, /*ref_ordinal=*/5,
                            /*last_timestamp=*/0, /*instrs_since_last_timestamp=*/2 },
                          "Failed to catch missing read records"))
             return false;
@@ -2343,10 +2704,13 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, store);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), store },
-            { gen_data(TID, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), store },
+            { gen_data(TID_A, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_exit(TID_A), nullptr }
         };
 
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
@@ -2364,18 +2728,21 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, store);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), store },
-            { gen_data(TID, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr },
-            { gen_data(TID, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), store },
+            { gen_data(TID_A, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_data(TID_A, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_exit(TID_A), nullptr }
         };
 
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
-                         { "Too many write records", TID, /*ref_ordinal=*/4,
+                         { "Too many write records", TID_A, /*ref_ordinal=*/6,
                            /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch too many write records"))
@@ -2391,17 +2758,20 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, nop);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), store },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), store },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
 
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         auto memrefs = add_encodings_to_memrefs(ilist, memref_instr_vec, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
         if (!run_checker(memrefs, true,
-                         { "Missing write records", TID, /*ref_ordinal=*/3,
+                         { "Missing write records", TID_A, /*ref_ordinal=*/5,
                            /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/2 },
                          "Fail to catch missing write records"))
@@ -2415,11 +2785,14 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, movs);
 
         std::vector<memref_with_IR_t> memref_instr_vec = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), movs },
-            { gen_data(TID, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr },
-            { gen_data(TID, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr }
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), movs },
+            { gen_data(TID_A, /*load=*/true, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_data(TID_A, /*load=*/false, /*addr=*/0, /*size=*/0), nullptr },
+            { gen_exit(TID_A), nullptr }
         };
 
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
@@ -2437,11 +2810,14 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, clflush);
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), clflush },
-            { gen_addr(TID, /*type=*/TRACE_TYPE_DATA_FLUSH, /*addr=*/0, /*size=*/0),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), clflush },
+            { gen_addr(TID_A, /*type=*/TRACE_TYPE_DATA_FLUSH, /*addr=*/0, /*size=*/0),
               nullptr },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -2458,10 +2834,13 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, nop);
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), rep_movs },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), rep_movs },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -2481,10 +2860,13 @@ check_read_write_records_match_operands()
         instrlist_append(ilist, nop);
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         std::vector<memref_with_IR_t> memref_setup = {
-            { gen_marker(TID, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
               nullptr },
-            { gen_instr(TID), lea },
-            { gen_instr(TID), nop },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), lea },
+            { gen_instr(TID_A), nop },
+            { gen_exit(TID_A), nullptr },
         };
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
         instrlist_clear_and_destroy(GLOBAL_DCONTEXT, ilist);
@@ -2493,6 +2875,55 @@ check_read_write_records_match_operands()
         }
     }
 #endif
+    return true;
+}
+
+bool
+check_exit_found(void)
+{
+    std::cerr << "Testing thread exits\n";
+    // Correct: all threads have exits.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_B),
+            gen_exit(TID_B),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_C),
+            gen_exit(TID_C),
+        };
+        if (!run_checker(memrefs, false))
+            return false;
+    }
+    // Incorrect: a thread is missing an exit.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_B),
+            // Missing exit.
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_C),
+            gen_exit(TID_C),
+        };
+        if (!run_checker(memrefs, true,
+                         { "Thread is missing exit", /*tid=*/TID_B,
+                           /*ref_ordinal=*/3, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/1 },
+                         "Failed to catch missing thread exit"))
+            return false;
+    }
     return true;
 }
 
@@ -2505,7 +2936,7 @@ test_main(int argc, const char *argv[])
         check_rseq_side_exit_discontinuity() && check_schedule_file() &&
         check_branch_decoration() && check_filter_endpoint() &&
         check_timestamps_increase_monotonically() &&
-        check_read_write_records_match_operands()) {
+        check_read_write_records_match_operands() && check_exit_found()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -132,7 +132,13 @@ bool
 invariant_checker_t::parallel_shard_exit(void *shard_data)
 {
     per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
-    report_if_false(shard, shard->saw_thread_exit_, "Thread is missing exit");
+    report_if_false(shard,
+                    shard->saw_thread_exit_
+                        // XXX i#6444: For online on some Windows tests we see threads
+                        // exiting w/o the tracer inserting an exit.  Until we figure
+                        // that out we disable this error for Windows online.
+                        IF_WINDOWS(|| !knob_offline_),
+                    "Thread is missing exit");
     if (!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_DFILTERED,
                  shard->file_type_)) {
         report_if_false(shard, shard->expected_read_records_ == 0,

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -177,6 +177,7 @@ protected:
         int instrs_until_interrupt_ = -1;
         int memrefs_until_interrupt_ = -1;
 #endif
+        bool saw_thread_exit_ = false;
         bool saw_timestamp_but_no_instr_ = false;
         bool found_cache_line_size_marker_ = false;
         bool found_instr_count_marker_ = false;


### PR DESCRIPTION
Adds an invariant check that each thread has an exit record in a drmemtrace.

Adds a path for the analyzer to call process_shard_exit() when there is no exit record.
Manually tested this on a real truncated trace.

Adds a unit test.

The new check failed on nearly every existing unit test, requiring adding thread exits.  That in turn triggered exit checks on missing headers and filetypes.  I ended up having to edit every test case.  As part of this I standardized the tid constants used.

Issue: #6444