### PR TITLE
i#5843 scheduler: Only consider long-latency syscalls blocking

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -748,6 +748,9 @@ add_subdirectory(tools/external)
 # We build larger executables here.  All tests are added in suite/tests/ except unit tests.
 # Be sure to give the targets qualified test names ("tool.drcache*...").
 
+# XXX: Try to add a macro add_drcachesim_test() to share common pieces
+# of these executables.
+
 if (BUILD_TESTS)
   add_executable(tool.reuse_distance.unit_tests tests/reuse_distance_test.cpp)
   target_link_libraries(tool.reuse_distance.unit_tests drmemtrace_reuse_distance

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -907,6 +907,16 @@ if (BUILD_TESTS)
     set_tests_properties(tool.drcachesim.invariant_checker_test PROPERTIES
       TIMEOUT ${test_seconds})
 
+    add_executable(tool.drcachesim.schedule_stats_test tests/schedule_stats_test.cpp)
+    configure_DynamoRIO_standalone(tool.drcachesim.schedule_stats_test)
+    add_win32_flags(tool.drcachesim.schedule_stats_test)
+    target_link_libraries(tool.drcachesim.schedule_stats_test drmemtrace_schedule_stats
+        drmemtrace_static drmemtrace_analyzer test_helpers)
+    add_test(NAME tool.drcachesim.schedule_stats_test
+             COMMAND tool.drcachesim.schedule_stats_test)
+    set_tests_properties(tool.drcachesim.schedule_stats_test PROPERTIES
+      TIMEOUT ${test_seconds})
+
     add_executable(tool.drcacheoff.view_test tests/view_test.cpp reader/file_reader.cpp)
     configure_DynamoRIO_standalone(tool.drcacheoff.view_test)
     add_win32_flags(tool.drcacheoff.view_test)

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -257,6 +257,8 @@ analyzer_multi_t::init_dynamic_schedule()
     sched_ops.quantum_duration = op_sched_quantum.get_value();
     if (op_sched_time.get_value())
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+    sched_ops.syscall_switch_threshold = op_sched_syscall_switch_us.get_value();
+    sched_ops.blocking_switch_threshold = op_sched_blocking_switch_us.get_value();
 #ifdef HAS_ZIP
     if (!op_record_file.get_value().empty()) {
         record_schedule_zip_.reset(new zipfile_ostream_t(op_record_file.get_value()));

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -838,6 +838,18 @@ droption_t<bool> op_sched_order_time(DROPTION_SCOPE_ALL, "sched_order_time", tru
                                      "Applies to -core_sharded and -core_serial. "
                                      "Whether to honor recorded timestamps for ordering");
 
+droption_t<uint64_t> op_sched_syscall_switch_us(
+    DROPTION_SCOPE_ALL, "sched_syscall_switch_us", 500,
+    "Minimum latency to consider any syscall blocking.",
+    "Minimum latency in timestamp units (us) to consider any syscall blocking. "
+    "Applies to -core_sharded and -core_serial. ");
+
+droption_t<uint64_t> op_sched_blocking_switch_us(
+    DROPTION_SCOPE_ALL, "sched_blocking_switch_us", 100,
+    "Minimum latency to consider a maybe-blocking syscall blocking.",
+    "Minimum latency in timestamp units (us) to consider any syscall that is marked as "
+    "maybe-blocking to be blocking. Applies to -core_sharded and -core_serial. ");
+
 #ifdef HAS_ZIP
 droption_t<std::string> op_record_file(DROPTION_SCOPE_FRONTEND, "record_file", "",
                                        "Path for storing record of schedule",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -840,15 +840,16 @@ droption_t<bool> op_sched_order_time(DROPTION_SCOPE_ALL, "sched_order_time", tru
 
 droption_t<uint64_t> op_sched_syscall_switch_us(
     DROPTION_SCOPE_ALL, "sched_syscall_switch_us", 500,
-    "Minimum latency to consider any syscall blocking.",
-    "Minimum latency in timestamp units (us) to consider any syscall blocking. "
-    "Applies to -core_sharded and -core_serial. ");
+    "Minimum latency to consider any syscall as incurring a context switch.",
+    "Minimum latency in timestamp units (us) to consider any syscall as incurring "
+    "a context switch.  Applies to -core_sharded and -core_serial. ");
 
 droption_t<uint64_t> op_sched_blocking_switch_us(
     DROPTION_SCOPE_ALL, "sched_blocking_switch_us", 100,
-    "Minimum latency to consider a maybe-blocking syscall blocking.",
+    "Minimum latency to consider a maybe-blocking syscall as incurring a context switch.",
     "Minimum latency in timestamp units (us) to consider any syscall that is marked as "
-    "maybe-blocking to be blocking. Applies to -core_sharded and -core_serial. ");
+    "maybe-blocking to incur a context switch. Applies to -core_sharded and "
+    "-core_serial. ");
 
 #ifdef HAS_ZIP
 droption_t<std::string> op_record_file(DROPTION_SCOPE_FRONTEND, "record_file", "",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -191,6 +191,8 @@ extern dynamorio::droption::droption_t<bool> op_core_serial;
 extern dynamorio::droption::droption_t<int64_t> op_sched_quantum;
 extern dynamorio::droption::droption_t<bool> op_sched_time;
 extern dynamorio::droption::droption_t<bool> op_sched_order_time;
+extern dynamorio::droption::droption_t<uint64_t> op_sched_syscall_switch_us;
+extern dynamorio::droption::droption_t<uint64_t> op_sched_blocking_switch_us;
 #ifdef HAS_ZIP
 extern dynamorio::droption::droption_t<std::string> op_record_file;
 extern dynamorio::droption::droption_t<std::string> op_replay_file;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -981,7 +981,7 @@ protected:
         uint64_t queue_counter = 0;
         // Used to switch on the instruction *after* a long-latency syscall.
         bool processing_syscall = false;
-        bool processing_blocking_syscall = false;
+        bool processing_maybe_blocking_syscall = false;
         uint64_t pre_syscall_timestamp = 0;
         // Use for special kernel features where one thread specifies a target
         // thread to replace it.
@@ -1293,7 +1293,7 @@ protected:
 
     // The input's lock must be held by the caller.
     bool
-    treat_syscall_as_blocking(input_info_t *input);
+    syscall_incurs_switch(input_info_t *input);
 
     // sched_lock_ must be held by the caller.
     // "for_output" is which output stream is looking for a new input; only an

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -496,6 +496,20 @@ public:
          * of traced cores).
          */
         archive_istream_t *replay_as_traced_istream = nullptr;
+        /**
+         * Determines the minimum latency in the unit of the trace's timestamps
+         * (microseconds) for which a non-maybe-blocking system call (one without
+         * a #TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL marker) will be treated as
+         * blocking and trigger a context switch.
+         */
+        uint64_t syscall_switch_threshold = 500;
+        /**
+         * Determines the minimum latency in the unit of the trace's timestamps
+         * (microseconds) for which a maybe-blocking system call (one with
+         * a #TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL marker) will be treated as
+         * blocking and trigger a context switch.
+         */
+        uint64_t blocking_switch_threshold = 100;
     };
 
     /**
@@ -965,8 +979,10 @@ protected:
         bool order_by_timestamp = false;
         // Global ready queue counter used to provide FIFO for same-priority inputs.
         uint64_t queue_counter = 0;
-        // Used to switch on the instruction *after* a blocking syscall.
+        // Used to switch on the instruction *after* a long-latency syscall.
+        bool processing_syscall = false;
         bool processing_blocking_syscall = false;
+        uint64_t pre_syscall_timestamp = 0;
         // Use for special kernel features where one thread specifies a target
         // thread to replace it.
         input_ordinal_t switch_to_input = INVALID_INPUT_ORDINAL;
@@ -1274,6 +1290,10 @@ protected:
     // sched_lock_ must be held by the caller.
     void
     add_to_ready_queue(input_info_t *input);
+
+    // The input's lock must be held by the caller.
+    bool
+    treat_syscall_as_blocking(input_info_t *input);
 
     // sched_lock_ must be held by the caller.
     // "for_output" is which output stream is looking for a new input; only an

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -3,10 +3,10 @@ Total counts:
            4 cores
            8 threads
       638938 instructions
-           [78] total context switches
-   0.01[0-9]* CSPKI \(context switches per 1000 instructions\)
-       ..... instructions per context switch
-           [78] voluntary context switches
+           5 total context switches
+   0.0078255 CSPKI \(context switches per 1000 instructions\)
+      127788 instructions per context switch
+           5 voluntary context switches
            0 direct context switches
       100.00% voluntary switches
         0.00% direct switches

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -3,10 +3,10 @@ Total counts:
            4 cores
            8 threads
       638938 instructions
-           5 total context switches
-   0.0078255 CSPKI \(context switches per 1000 instructions\)
-      127788 instructions per context switch
-           5 voluntary context switches
+           [78] total context switches
+   0.01[0-9]* CSPKI \(context switches per 1000 instructions\)
+       ..... instructions per context switch
+           [78] voluntary context switches
            0 direct context switches
       100.00% voluntary switches
         0.00% direct switches
@@ -29,7 +29,7 @@ Core #0 counts:
            0 direct switch requests
            0 waits
 Core #1 counts:
-           2 threads
+           . threads
       *[0-9]* instructions
            . total context switches
    0.0[0-9.]* CSPKI \(context switches per 1000 instructions\)
@@ -38,35 +38,35 @@ Core #1 counts:
            0 direct context switches
       100.00% voluntary switches
         0.00% direct switches
-          .. system calls
+         *[0-9]* system calls
            . maybe-blocking system calls
            0 direct switch requests
            0 waits
 Core #2 counts:
-           2 threads
+           . threads
       *[0-9]* instructions
-           1 total context switches
+           . total context switches
    0.0[0-9.]* CSPKI \(context switches per 1000 instructions\)
       *[0-9]* instructions per context switch
-           1 voluntary context switches
+           . voluntary context switches
            0 direct context switches
       100.00% voluntary switches
         0.00% direct switches
-          .. system calls
+         *[0-9]* system calls
            . maybe-blocking system calls
            0 direct switch requests
            0 waits
 Core #3 counts:
-           2 threads
+           . threads
       *[0-9]* instructions
-           1 total context switches
+           . total context switches
    0.0[0-9.]* CSPKI \(context switches per 1000 instructions\)
       *[0-9]* instructions per context switch
-           1 voluntary context switches
+           . voluntary context switches
            0 direct context switches
       100.00% voluntary switches
         0.00% direct switches
-          .. system calls
+         *[0-9]* system calls
            . maybe-blocking system calls
            0 direct switch requests
            0 waits

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -91,14 +91,14 @@ run_schedule_stats(const std::vector<std::vector<memref_t>> &memrefs,
         size_t memref_idx = 0;
     };
     std::vector<per_core_t> per_core(memrefs.size());
-    for (size_t cpu = 0; cpu < memrefs.size(); ++cpu) {
+    for (int cpu = 0; cpu < static_cast<int>(memrefs.size()); ++cpu) {
         per_core[cpu].worker_data = tool.parallel_worker_init(cpu);
         per_core[cpu].shard_data = tool.parallel_shard_init_stream(
             cpu, per_core[cpu].worker_data, &per_core[cpu].stream);
     }
     // Walk in lockstep until all are empty.
-    size_t num_finished = 0;
-    while (num_finished < memrefs.size()) {
+    int num_finished = 0;
+    while (num_finished < static_cast<int>(memrefs.size())) {
         for (size_t cpu = 0; cpu < memrefs.size(); ++cpu) {
             if (per_core[cpu].finished)
                 continue;
@@ -113,7 +113,7 @@ run_schedule_stats(const std::vector<std::vector<memref_t>> &memrefs,
             }
         }
     }
-    for (size_t cpu = 0; cpu < memrefs.size(); ++cpu) {
+    for (int cpu = 0; cpu < static_cast<int>(memrefs.size()); ++cpu) {
         tool.parallel_shard_exit(per_core[cpu].shard_data);
         tool.parallel_worker_exit(per_core[cpu].worker_data);
     }

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -79,6 +79,11 @@ run_schedule_stats(const std::vector<std::vector<memref_t>> &memrefs,
         {
             return input_id_;
         }
+        memtrace_stream_t *
+        get_input_interface() const override
+        {
+            return const_cast<mock_stream_t *>(this);
+        }
 
     private:
         int64_t input_id_ = 0;

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -1,0 +1,208 @@
+/* **********************************************************
+ * Copyright (c) 2021-2023 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Test for checks performed by invariant_checker_t that are not tested
+ * by the signal_invariants app's prefetch and handler markers.
+ * This looks for precise error strings from invariant_checker.cpp: but
+ * we will notice if the literals get out of sync as the test will fail.
+ */
+
+#undef NDEBUG
+#include <assert.h>
+
+#include <fstream>
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+
+#include "../tools/schedule_stats.h"
+#include "../common/memref.h"
+#include "memref_gen.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+using ::dynamorio::drmemtrace::default_memtrace_stream_t;
+using ::dynamorio::drmemtrace::memref_t;
+using ::dynamorio::drmemtrace::memref_tid_t;
+using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_WAIT;
+using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH;
+using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL;
+using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL;
+
+// Bypasses the analyzer and scheduler for a controlled test sequence.
+// Alternates the per-core memref vectors in lockstep.
+static schedule_stats_t::counters_t
+run_schedule_stats(const std::vector<std::vector<memref_t>> &memrefs,
+                   const std::unordered_map<memref_tid_t, int64_t> &tid2ord)
+{
+    schedule_stats_t tool(/*print_every=*/1, /*verbosity=*/2);
+    // schedule_stats_t uses get_input_id() to identify switches.
+    class mock_stream_t : public default_memtrace_stream_t {
+    public:
+        void
+        set_input_id(int64_t input_id)
+        {
+            input_id_ = input_id;
+        }
+        int64_t
+        get_input_id() const override
+        {
+            return input_id_;
+        }
+
+    private:
+        int64_t input_id_ = 0;
+    };
+    struct per_core_t {
+        void *worker_data;
+        void *shard_data;
+        mock_stream_t stream;
+        bool finished = false;
+        size_t memref_idx = 0;
+    };
+    std::vector<per_core_t> per_core(memrefs.size());
+    for (size_t cpu = 0; cpu < memrefs.size(); ++cpu) {
+        per_core[cpu].worker_data = tool.parallel_worker_init(cpu);
+        per_core[cpu].shard_data = tool.parallel_shard_init_stream(
+            cpu, per_core[cpu].worker_data, &per_core[cpu].stream);
+    }
+    // Walk in lockstep until all are empty.
+    size_t num_finished = 0;
+    while (num_finished < memrefs.size()) {
+        for (size_t cpu = 0; cpu < memrefs.size(); ++cpu) {
+            if (per_core[cpu].finished)
+                continue;
+            memref_t memref = memrefs[cpu][per_core[cpu].memref_idx];
+            per_core[cpu].stream.set_input_id(tid2ord.at(memref.instr.tid));
+            bool res = tool.parallel_shard_memref(per_core[cpu].shard_data, memref);
+            assert(res);
+            ++per_core[cpu].memref_idx;
+            if (per_core[cpu].memref_idx >= memrefs[cpu].size()) {
+                per_core[cpu].finished = true;
+                ++num_finished;
+            }
+        }
+    }
+    for (size_t cpu = 0; cpu < memrefs.size(); ++cpu) {
+        tool.parallel_shard_exit(per_core[cpu].shard_data);
+        tool.parallel_worker_exit(per_core[cpu].worker_data);
+    }
+    return tool.get_total_counts();
+}
+
+static bool
+test_basic_stats()
+{
+    static constexpr int64_t TID_A = 42;
+    static constexpr int64_t TID_B = 142;
+    static constexpr int64_t TID_C = 242;
+    std::unordered_map<memref_tid_t, int64_t> tid2ord;
+    tid2ord[TID_A] = 0;
+    tid2ord[TID_B] = 1;
+    tid2ord[TID_C] = 2;
+    std::vector<std::vector<memref_t>> memrefs = {
+        {
+            gen_instr(TID_A),
+            // Involuntary switch.
+            gen_instr(TID_B),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1100),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1600),
+            // Voluntary switch, on non-maybe-blocking-marked syscall.
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2100),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_C),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2300),
+            // Direct switch.
+            gen_instr(TID_C),
+            // No switch: latency too small.
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2500),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2599),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3100),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_A),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3300),
+            // Direct switch requested but failed.
+            gen_instr(TID_C),
+        },
+        {
+            gen_instr(TID_B),
+            // Involuntary switch.
+            gen_instr(TID_A),
+            // Involuntary switch.
+            gen_instr(TID_C),
+            gen_instr(TID_C),
+            gen_instr(TID_C),
+            // Wait.
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_WAIT, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_WAIT, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_WAIT, 0),
+            // Involuntary switch.
+            gen_instr(TID_B),
+            gen_instr(TID_B),
+            gen_instr(TID_B),
+        },
+    };
+    auto result = run_schedule_stats(memrefs, tid2ord);
+    assert(result.instrs == 16);
+    assert(result.total_switches == 6);
+    assert(result.voluntary_switches == 2);
+    assert(result.direct_switches == 1);
+    assert(result.syscalls == 4);
+    assert(result.maybe_blocking_syscalls == 3);
+    assert(result.direct_switch_requests == 2);
+    assert(result.waits == 3);
+    return true;
+}
+
+int
+test_main(int argc, const char *argv[])
+{
+    if (test_basic_stats()) {
+        std::cerr << "schedule_stats_test passed\n";
+        return 0;
+    }
+    std::cerr << "schedule_stats_test FAILED\n";
+    exit(1);
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1577,11 +1577,12 @@ test_synthetic_with_syscalls_precise()
         make_version(TRACE_ENTRY_VERSION),
         make_timestamp(20),
         make_instr(10),
+        make_timestamp(120),
         make_marker(TRACE_MARKER_TYPE_SYSCALL, SYSNUM),
         make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
         make_marker(TRACE_MARKER_TYPE_FUNC_ID, 100),
         make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 42),
-        make_timestamp(50),
+        make_timestamp(250),
         make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
         make_marker(TRACE_MARKER_TYPE_FUNC_ID, 100),
         make_marker(TRACE_MARKER_TYPE_FUNC_RETVAL, 0),
@@ -1631,6 +1632,7 @@ test_synthetic_with_syscalls_precise()
         check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
         check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
         check_ref(refs, idx, TID_A, TRACE_TYPE_INSTR) &&
+        check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP) &&
         check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_SYSCALL) &&
         check_ref(refs, idx, TID_A, TRACE_TYPE_MARKER,
                   TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL) &&

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -114,7 +114,7 @@ protected:
         counters_t counters;
         int64_t prev_input = -1;
         // These are cleared when an instruction is seen.
-        bool saw_maybe_blocking = false;
+        bool saw_syscall = false;
         memref_tid_t direct_switch_target = INVALID_THREAD_ID;
         bool saw_exit = false;
         // A representation of the thread interleavings.

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -51,7 +51,7 @@ namespace drmemtrace {
 
 class schedule_stats_t : public analysis_tool_t {
 public:
-    schedule_stats_t(uint64_t print_every, unsigned int verbose);
+    schedule_stats_t(uint64_t print_every, unsigned int verbose = 0);
     ~schedule_stats_t() override;
     std::string
     initialize_stream(memtrace_stream_t *serial_stream) override;


### PR DESCRIPTION
Rather than context switching on every syscall labeled maybe-blocking, the scheduler uses the now-available syscall latency to decide whether the syscall should block and result in a context switch.

Adds two new command line options, -sched_syscall_switch_us (default 500us) and -sched_blocking_switch_us (default 100us), and corresponding scheduler_t inputs, to control the latency thresholds. To avoid relying too much on the maybe-blocking labels, we do consider a very-high-latency syscall not marked as maybe-blocking to block.

Adds a new schedule_stats unit test.

Tested in a large proprietary app where this reduces the context switch rate from ~100x too high down to ~10x too high.  The next step of adding i/o wait times should further improve the representativeness.

Issue: #5843