### PR TITLE
i#4111: Update HREF link to ArmIE on home page

### DIFF
--- a/api/docs/home.dox
+++ b/api/docs/home.dox
@@ -59,7 +59,7 @@ and AArch64 hardware.
 # Existing DynamoRIO-based tools
 
 DynamoRIO is the basis for some well-known external tools:
-- The [Arm Instruction Emulator (ArmIE)](https://developer.arm.com/tools-and-software/server-and-hpc/arm-architecture-tools/arm-instruction-emulator)
+- The [Arm Instruction Emulator (ArmIE)](https://developer.arm.com/Tools%20and%20Software/Arm%20Instruction%20Emulator)
 - [WinAFL](https://github.com/googleprojectzero/winafl), the Windows fuzzing tool, as an instrumentation and code coverage engine
 - The fine-grained profiler for ARM [DrCCTProf](https://xl10.github.io/blog/drcctprof.html)
 - The portable and efficient framework for fine-grained value profilers [VClinic](https://github.com/VClinic/VClinic)


### PR DESCRIPTION
The Arm Instruction Emulator home page on developer.arm.com has moved. Link to it at https://dynamorio.org/index.html updated.

Issue: #4111