### PR TITLE
i#3544 RV64: Refine fault translation and signal handling

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3866,6 +3866,14 @@ set_stolen_reg_val(priv_mcontext_t *mc, reg_t newval)
 {
     *(reg_t *)(((byte *)mc) + opnd_get_reg_dcontext_offs(dr_reg_stolen)) = newval;
 }
+
+#    ifdef RISCV64
+void
+set_tp_reg_val(priv_mcontext_t *mc, reg_t newval)
+{
+    *(reg_t *)(((byte *)mc) + opnd_get_reg_dcontext_offs(DR_REG_TP)) = newval;
+}
+#    endif
 #endif
 
 #ifdef PROFILE_RDTSC

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1569,7 +1569,7 @@ translate_x86_to_x64(dcontext_t *dcontext, instrlist_t *ilist,
                      DR_PARAM_INOUT instr_t **instr);
 #endif
 
-#ifdef AARCHXX
+#if defined( AARCHXX) || defined(RISCV64)
 bool
 instr_is_ldstex_mangling(dcontext_t *dcontext, instr_t *inst);
 #endif

--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -1569,7 +1569,7 @@ translate_x86_to_x64(dcontext_t *dcontext, instrlist_t *ilist,
                      DR_PARAM_INOUT instr_t **instr);
 #endif
 
-#if defined( AARCHXX) || defined(RISCV64)
+#if defined(AARCHXX) || defined(RISCV64)
 bool
 instr_is_ldstex_mangling(dcontext_t *dcontext, instr_t *inst);
 #endif

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -470,6 +470,10 @@ reg_t
 get_stolen_reg_val(priv_mcontext_t *context);
 void
 set_stolen_reg_val(priv_mcontext_t *mc, reg_t newval);
+#    ifdef RISCV64
+void
+set_tp_reg_val(priv_mcontext_t *mc, reg_t newval);
+#    endif
 #endif
 const char *
 get_branch_type_name(ibl_branch_type_t branch_type);

--- a/core/arch/riscv64/mangle.c
+++ b/core/arch/riscv64/mangle.c
@@ -674,7 +674,6 @@ instr_is_ldstex_mangling(dcontext_t *dcontext, instr_t *instr)
 
     ptr_int_t val;
     if (instr_get_opcode(instr) == OP_fence || instr_get_opcode(instr) == OP_bne ||
-        instr_get_opcode(instr) == OP_bne ||
         /* Check for sc.w/d+bne+jal pattern.  */
         (instr_get_opcode(instr) == OP_jal && instr_get_prev(instr) != NULL &&
          instr_get_opcode(instr_get_prev(instr)) == OP_bne &&

--- a/core/arch/riscv64/mangle.c
+++ b/core/arch/riscv64/mangle.c
@@ -272,8 +272,7 @@ patch_mov_immed_arch(dcontext_t *dcontext, ptr_int_t val, byte *pc, instr_t *fir
 bool
 instr_check_xsp_mangling(dcontext_t *dcontext, instr_t *inst, int *xsp_adjust)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
+    /* Not apply to RISC-V. */
     return false;
 }
 

--- a/core/arch/riscv64/mangle.c
+++ b/core/arch/riscv64/mangle.c
@@ -681,6 +681,8 @@ instr_is_ldstex_mangling(dcontext_t *dcontext, instr_t *instr)
          instr_is_exclusive_store(instr_get_prev(instr_get_prev(instr)))) ||
         instr_is_exclusive_load(instr) || instr_is_exclusive_store(instr) ||
         (instr_is_mov_constant(instr, &val) &&
+         /* XXX: These are fragile, should we look backward a bit to check for more
+            specific patterns? */
          (val == 1 /* cas fail */ || val == -1 /* reservation invalidation */ ||
           val == 4 /* lr.w/sc.w size */ || val == 8 /* lr.d/sc.d size */)))
         return true;

--- a/core/arch/riscv64/mangle.c
+++ b/core/arch/riscv64/mangle.c
@@ -272,7 +272,7 @@ patch_mov_immed_arch(dcontext_t *dcontext, ptr_int_t val, byte *pc, instr_t *fir
 bool
 instr_check_xsp_mangling(dcontext_t *dcontext, instr_t *inst, int *xsp_adjust)
 {
-    /* Not apply to RISC-V. */
+    /* Does not apply to RISC-V. */
     return false;
 }
 

--- a/core/arch/x86_code.c
+++ b/core/arch/x86_code.c
@@ -306,7 +306,7 @@ new_thread_setup(priv_mcontext_t *mc)
     ASSERT(rc != -1); /* this better be a new thread */
     dcontext = get_thread_private_dcontext();
     ASSERT(dcontext != NULL);
-#    ifdef AARCHXX
+#    if defined(AARCHXX) || defined(RISCV64)
     set_app_lib_tls_base_from_clone_record(dcontext, crec);
 #    endif
 #    ifdef ARM

--- a/core/translate.c
+++ b/core/translate.c
@@ -132,6 +132,8 @@ instr_is_inline_syscall_jmp(dcontext_t *dcontext, instr_t *inst)
              /* A32 uses a regular jump */
              instr_get_opcode(inst) == OP_b) &&
             opnd_is_instr(instr_get_target(inst)));
+#    elif defined(RISCV64)
+    return (instr_get_opcode(inst) == OP_jal && opnd_is_instr(instr_get_target(inst)));
 #    else
     ASSERT_NOT_IMPLEMENTED(false);
     return false;
@@ -304,14 +306,14 @@ translate_walk_track_pre_instr(dcontext_t *tdcontext, instr_t *inst,
         walk->unsupported_mangle = false;
         walk->xsp_adjust = 0;
         for (reg_id_t r = 0; r < REG_SPILL_NUM; r++) {
-#ifndef AARCHXX
+#ifdef X86
             /* we should have seen a restore for every spill, unless at
              * fragment-ending jump to ibl, which shouldn't come here
              */
             ASSERT(walk->reg_spill_offs[r] == UINT_MAX);
             walk->reg_spill_offs[r] = UINT_MAX; /* be paranoid */
 #else
-            /* On AArchXX we do spill registers across app instrs and mangle
+            /* On AArchXX/RISCV64 we do spill registers across app instrs and mangle
              * regions, though right now only the following routines do this:
              * - mangle_stolen_reg()
              * - mangle_gpr_list_read()
@@ -399,9 +401,6 @@ translate_walk_track_post_instr(dcontext_t *tdcontext, instr_t *inst,
          * comment above for post-mangling traces), and so for local
          * spills like rip-rel and ind branches this is fine.
          */
-#if defined(RISCV64)
-        ASSERT_NOT_IMPLEMENTED(false);
-#endif
         if (instr_is_cti(inst) &&
 #ifdef X86
             /* Do not reset for a trace-cmp jecxz or jmp (32-bit) or
@@ -420,10 +419,7 @@ translate_walk_track_post_instr(dcontext_t *tdcontext, instr_t *inst,
               (!opnd_is_pc(instr_get_target(inst)) ||
                (opnd_get_pc(instr_get_target(inst)) >= walk->start_cache &&
                 opnd_get_pc(instr_get_target(inst)) < walk->end_cache))))
-#elif defined(RISCV64)
-            /* FIXME i#3544: Not implemented */
-            false
-#else
+#elif defined(AARCHXX)
             /* Do not reset for cbnz/bne in ldstex mangling, nor for the b after strex. */
             !(instr_get_opcode(inst) == OP_cbnz ||
               (instr_get_opcode(inst) == OP_b &&
@@ -432,6 +428,17 @@ translate_walk_track_post_instr(dcontext_t *tdcontext, instr_t *inst,
               (instr_get_opcode(inst) == OP_b &&
                (instr_get_prev(inst) != NULL &&
                 instr_is_exclusive_store(instr_get_prev(inst)))))
+#elif defined(RISCV64)
+            /* Do not reset for bne in LR/SC mangling, nor for the jal after SC.
+             * This should be kept in sync with mangle_exclusive_monitor_op().
+             */
+            !(instr_get_opcode(inst) == OP_bne ||
+              (instr_get_opcode(inst) == OP_jal && instr_get_prev(inst) != NULL &&
+               instr_get_opcode(instr_get_prev(inst)) == OP_bne &&
+               instr_get_prev(instr_get_prev(inst)) != NULL &&
+               instr_is_exclusive_store(instr_get_prev(instr_get_prev(inst)))))
+#else
+#    error Unsupported architecture
 #endif
         ) {
             /* FIXME i#1551: add ARM version of the series of trace cti checks above */
@@ -547,7 +554,7 @@ translate_walk_track_post_instr(dcontext_t *tdcontext, instr_t *inst,
             /* nothing to do */
         }
 #endif
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
         else if (instr_is_ldstex_mangling(tdcontext, inst)) {
             /* nothing to do */
         }

--- a/core/unix/os_public.h
+++ b/core/unix/os_public.h
@@ -205,6 +205,7 @@ typedef kernel_sigcontext_t sigcontext_t;
 #    define SC_SYSNUM_REG SC_R7
 #    define SC_RETURN_REG SC_R0
 #elif defined(RISCV64)
+#    define SC_TP SC_FIELD(sc_regs.tp)
 #    define SC_A0 SC_FIELD(sc_regs.a0)
 #    define SC_A1 SC_FIELD(sc_regs.a1)
 #    define SC_A2 SC_FIELD(sc_regs.a2)

--- a/core/unix/signal_linux_riscv64.c
+++ b/core/unix/signal_linux_riscv64.c
@@ -57,7 +57,39 @@ save_fpstate(dcontext_t *dcontext, sigframe_rt_t *frame)
 void
 dump_sigcontext(dcontext_t *dcontext, sigcontext_t *sc)
 {
-    LOG(THREAD, LOG_ASYNCH, 1, "FIXME i#3544: NYI on RISCV64");
+
+    LOG(THREAD, LOG_ASYNCH, 1, "\tpc  = " PFX "\n", sc->sc_regs.pc);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tra  = " PFX "\n", sc->sc_regs.ra);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tsp  = " PFX "\n", sc->sc_regs.sp);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tgp  = " PFX "\n", sc->sc_regs.gp);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ttp  = " PFX "\n", sc->sc_regs.tp);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tt0  = " PFX "\n", sc->sc_regs.t0);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tt1  = " PFX "\n", sc->sc_regs.t1);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tt2  = " PFX "\n", sc->sc_regs.t2);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts0  = " PFX "\n", sc->sc_regs.s0);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts1  = " PFX "\n", sc->sc_regs.s1);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta0  = " PFX "\n", sc->sc_regs.a0);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta1  = " PFX "\n", sc->sc_regs.a1);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta2  = " PFX "\n", sc->sc_regs.a2);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta3  = " PFX "\n", sc->sc_regs.a3);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta4  = " PFX "\n", sc->sc_regs.a4);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta5  = " PFX "\n", sc->sc_regs.a5);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta6  = " PFX "\n", sc->sc_regs.a6);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ta7  = " PFX "\n", sc->sc_regs.a7);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts2  = " PFX "\n", sc->sc_regs.s2);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts3  = " PFX "\n", sc->sc_regs.s3);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts4  = " PFX "\n", sc->sc_regs.s4);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts5  = " PFX "\n", sc->sc_regs.s5);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts6  = " PFX "\n", sc->sc_regs.s6);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts7  = " PFX "\n", sc->sc_regs.s7);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts8  = " PFX "\n", sc->sc_regs.s8);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts9  = " PFX "\n", sc->sc_regs.s9);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts10 = " PFX "\n", sc->sc_regs.s10);
+    LOG(THREAD, LOG_ASYNCH, 1, "\ts11 = " PFX "\n", sc->sc_regs.s11);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tt3  = " PFX "\n", sc->sc_regs.t3);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tt4  = " PFX "\n", sc->sc_regs.t4);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tt5  = " PFX "\n", sc->sc_regs.t5);
+    LOG(THREAD, LOG_ASYNCH, 1, "\tt6  = " PFX "\n", sc->sc_regs.t6);
 }
 #endif /* DEBUG */
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5870,6 +5870,7 @@ if (RISCV64)
     code_api|client.stack-overflow
     code_api|client.truncate
     code_api|common.broadfun
+    code_api|common.fib
     code_api|libutil.drconfig_test
     code_api|libutil.frontend_test
     code_api|linux.exit
@@ -5879,6 +5880,7 @@ if (RISCV64)
     code_api|linux.sigaction_nosignals
     code_api|linux.signalfd
     code_api|pthreads.pthreads
+    code_api|pthreads.pthreads_exit
     code_api|pthreads.pthreads_exit
     code_api|security-linux.trampoline
     no_code_api,no_intercept_all_signals|linux.sigaction

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5870,7 +5870,6 @@ if (RISCV64)
     code_api|client.stack-overflow
     code_api|client.truncate
     code_api|common.broadfun
-    code_api|common.fib
     code_api|libutil.drconfig_test
     code_api|libutil.frontend_test
     code_api|linux.exit

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4996,14 +4996,12 @@ if (UNIX)
     target_link_libraries(linux.signal_pre_syscall rt)
   endif ()
 
-  if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
-    tobuild(linux.bad-signal-stack linux/bad-signal-stack.c)
+  tobuild(linux.bad-signal-stack linux/bad-signal-stack.c)
 
-    # i#1145: test re-starting syscalls, both inlined and from dispatch
-    tobuild(linux.eintr linux/eintr.c)
-    link_with_pthread(linux.eintr)
-    torunonly(linux.eintr-noinline linux.eintr linux/eintr.c "-no_ignore_syscalls" "")
-  endif (NOT RISCV64)
+  # i#1145: test re-starting syscalls, both inlined and from dispatch
+  tobuild(linux.eintr linux/eintr.c)
+  link_with_pthread(linux.eintr)
+  torunonly(linux.eintr-noinline linux.eintr linux/eintr.c "-no_ignore_syscalls" "")
 
   if (NOT ANDROID AND NOT RISCV64) # XXX i#1874: get working on Android
     # TODO i#3544: Port tests to RISC-V 64

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5881,7 +5881,6 @@ if (RISCV64)
     code_api|linux.signalfd
     code_api|pthreads.pthreads
     code_api|pthreads.pthreads_exit
-    code_api|pthreads.pthreads_exit
     code_api|security-linux.trampoline
     no_code_api,no_intercept_all_signals|linux.sigaction
     PROPERTIES LABELS RUNS_ON_QEMU)


### PR DESCRIPTION
Refine fault translation and signal handling, part of the linux.signalXXXX tests works on real hardware; however, they do not work on QEMU, so we can't enable them on CI.

Issue: #3544