### PR TITLE
i#6416: Replace vdso raw bytes with per-block encodings

### DIFF
--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -432,9 +432,6 @@ public:
     void
     set_entry_addr(byte *buf_ptr, addr_t addr) override;
 
-    uint64_t
-    get_modoffs(void *drcontext, app_pc pc, DR_PARAM_OUT uint *modidx);
-
     int
     append_pid(byte *buf_ptr, process_id_t pid) override;
     int
@@ -555,6 +552,10 @@ private:
     void
     flush_instr_encodings();
 
+    bool
+    does_pc_require_encoding(void *drcontext, app_pc pc, uint *modidx_out,
+                             app_pc *modbase_out);
+
     // Custom module fields are global (since drmodtrack's support is global, we don't
     // try to pass void* user data params through).
     static void *(*user_load_)(module_data_t *module, int seg_idx);
@@ -566,6 +567,8 @@ private:
     print_custom_module_data(void *data, char *dst, size_t max_len);
     static void
     free_custom_module_data(void *data);
+    // Unfortunately this cached vdso base must be global as well.
+    static std::atomic<uintptr_t> vdso_modbase_;
 
     // These identify the 4 fields we store in the label data area array.
     static constexpr int LABEL_DATA_ELIDED_INDEX = 0;       // Index among all operands.

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -157,11 +157,14 @@ offline_instru_t::load_custom_module_data(module_data_t *module, int seg_idx)
     // We used to store the vdso contents, but we now use separate block encodings
     // for vdso code.  So we just find the vdso here, and pass through the user's data
     // for all modules.
-    if ((name != nullptr &&
-         (strstr(name, "linux-gate.so") == name ||
-          strstr(name, "linux-vdso.so") == name)) ||
-        (module->names.file_name != NULL && strcmp(name, "[vdso]") == 0)) {
-        DR_ASSERT(vdso_modbase_.load(std::memory_order_acquire) == 0);
+    if (seg_idx == 0 &&
+        ((name != nullptr &&
+          (strstr(name, "linux-gate.so") == name ||
+           strstr(name, "linux-vdso.so") == name)) ||
+         (module->names.file_name != NULL && strcmp(name, "[vdso]") == 0))) {
+        DR_ASSERT(vdso_modbase_.load(std::memory_order_acquire) == 0 ||
+                  vdso_modbase_.load(std::memory_order_acquire) ==
+                      reinterpret_cast<uintptr_t>(module->start));
         vdso_modbase_.store(reinterpret_cast<uintptr_t>(module->start),
                             std::memory_order_release);
     }


### PR DESCRIPTION
Removes the vdso raw bytes we were storing in the module file for offline drmemtraces.  Switches to using per-block encodings instead. This avoids problems with hooked vsysenter on 32-bit AMD.

Tested on tool.drcacheoff.simple on 32-bit AMD on a machine where that test failed every time before this fix.

Removes the unused offline_instru_t::get_modoffs() rather than updating it for the vdso change.

Issue: #6416, #2062
Fixes #6416