### PR TITLE
i#6417: Handle AMD 32-bit syscall instruction.

### DIFF
--- a/core/synch.c
+++ b/core/synch.c
@@ -273,7 +273,11 @@ is_at_do_syscall(dcontext_t *dcontext, app_pc pc, byte *esp)
 #else
         return is_after_or_restarted_do_syscall(dcontext, pc, false /*!vsys*/);
 #endif
-    } else if (get_syscall_method() == SYSCALL_METHOD_SYSENTER) {
+    } else if (get_syscall_method() ==
+               SYSCALL_METHOD_SYSENTER IF_X86_32(
+                   ||
+                   (get_syscall_method() == SYSCALL_METHOD_SYSCALL &&
+                    cpu_info.vendor == VENDOR_AMD))) {
 #ifdef WINDOWS
         if (pc == vsyscall_after_syscall) {
             if (DYNAMO_OPTION(sygate_sysenter))


### PR DESCRIPTION
Handle AMD 32-bit syscall instruction.

The  fix is to check for AMD 32-bit SYSCALL in is_at_do_syscall().

Here's more details:

CI x86-32 signalNNNN tests started failing recently. After checking the log, the failures happen on AMD 32-bit system.
Based on the debug logs 

AMD:

  0xf7f90583  89 cd                mov    %ecx -> %ebp
  0xf7f90585  0f 05                syscall  -> %ecx
interp: syscall @ 0xf7f90585
instr_get_opcode(instr): 95
change_prot(0xf7f90000, 0x2000, rwx) => mprotect(0xf7f90000, 0x2000, 7)==2 pages
change_prot(0xf7f90000, 0x2000, r-x) => mprotect(0xf7f90000, 0x2000, 5)==2 pages
set_syscall_method to 3make_writable: pc 0x441fc000 -> 0x441fc000-0x441fe000 0
Just updated syscall routine:      
  0x441fd240  0f 05                syscall  -> %ecx
  0x441fd242  a3 5c 29 18 44       mov    %eax -> 0x4418295c[4byte]

whereas Intel uses sysenter, and set the syscall_method to SYSCALL_METHOD_SYSENTER:

  0xf7f71583  89 e5                mov    %esp -> %ebp
  0xf7f71585  0f 34                sysenter  -> %esp
interp: syscall @ 0xf7f71585
change_prot(0xf7f71000, 0x2000, rwx) => mprotect(0xf7f71000, 0x2000, 7)==2 pages
change_prot(0xf7f71000, 0x2000, r-x) => mprotect(0xf7f71000, 0x2000, 5)==2 pages
set_syscall_method to 2make_writable: pc 0x4845a000 -> 0x4845a000-0x4845c000 0
Just updated syscall routine:
  0x4845b240  0f 34                sysenter  -> %esp
  0x4845b242  a3 5c 09 3e 48       mov    %eax -> 0x483e095c[4byte]


Issue: #6417