### PR TITLE
i#3044: AArch64 SVE2 codec: add vector+scalar versions of st/ldnt

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -7951,7 +7951,8 @@ memory_transfer_size_from_dtype(uint enc)
 }
 
 static inline bool
-decode_svemem_vec_sd_gpr16(uint size_bit, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+decode_svemem_vec_sd_gpr16(uint size_bit, uint enc, int opcode, byte *pc,
+                           OUT opnd_t *opnd)
 {
     const aarch64_reg_offset msz = BITS(enc, 24, 23);
     const uint scale = 1 << msz;
@@ -7981,7 +7982,7 @@ decode_svemem_vec_sd_gpr16(uint size_bit, uint enc, int opcode, byte *pc, OUT op
 
 static inline bool
 encode_svemem_vec_sd_gpr16(uint size_bit, uint enc, int opcode, byte *pc, opnd_t opnd,
-                                OUT uint *enc_out)
+                           OUT uint *enc_out)
 {
 
     uint single_bit_value = 0;
@@ -8024,7 +8025,6 @@ encode_svemem_vec_sd_gpr16(uint size_bit, uint enc, int opcode, byte *pc, opnd_t
     return true;
 }
 
-
 /*
  * svemem_vec_sssd_gpr16: SVE memory address with GPR offset [<Zn>.S/D{, <Xm>}],
  * size determined by bit 22
@@ -8038,7 +8038,7 @@ decode_opnd_svemem_vec_22sd_gpr16(uint enc, int opcode, byte *pc, OUT opnd_t *op
 
 static inline bool
 encode_opnd_svemem_vec_22sd_gpr16(uint enc, int opcode, byte *pc, opnd_t opnd,
-                                OUT uint *enc_out)
+                                  OUT uint *enc_out)
 {
     return encode_svemem_vec_sd_gpr16(22, enc, opcode, pc, opnd, enc_out);
 }
@@ -8449,7 +8449,7 @@ decode_opnd_svemem_vec_30sd_gpr16(uint enc, int opcode, byte *pc, OUT opnd_t *op
 
 static inline bool
 encode_opnd_svemem_vec_30sd_gpr16(uint enc, int opcode, byte *pc, opnd_t opnd,
-                                OUT uint *enc_out)
+                                  OUT uint *enc_out)
 {
     return encode_svemem_vec_sd_gpr16(30, enc, opcode, pc, opnd, enc_out);
 }

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -7950,6 +7950,99 @@ memory_transfer_size_from_dtype(uint enc)
     return opnd_size_from_bytes((1 << insz) * elements);
 }
 
+static inline bool
+decode_svemem_vec_sd_gpr16(uint size_bit, uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    const aarch64_reg_offset msz = BITS(enc, 24, 23);
+    const uint scale = 1 << msz;
+
+    uint single_bit_value = 0;
+
+    if (size_bit == 22)
+        single_bit_value = 1;
+
+    const aarch64_reg_offset element_size =
+        BITS(enc, size_bit, size_bit) == single_bit_value ? SINGLE_REG : DOUBLE_REG;
+
+    const opnd_size_t mem_transfer =
+        opnd_size_from_bytes(scale * get_elements_in_sve_vector(element_size));
+
+    const reg_id_t zn = decode_vreg(Z_REG, extract_uint(enc, 5, 5));
+    ASSERT(reg_is_z(zn));
+
+    const reg_id_t xm = decode_reg(extract_uint(enc, 16, 5), true, false /* XZR */);
+    ASSERT(reg_is_gpr(xm));
+
+    *opnd = opnd_create_vector_base_disp_aarch64(
+        zn, xm, get_opnd_size_from_offset(element_size), DR_EXTEND_UXTX, false, 0, 0,
+        mem_transfer, 0);
+    return true;
+}
+
+static inline bool
+encode_svemem_vec_sd_gpr16(uint size_bit, uint enc, int opcode, byte *pc, opnd_t opnd,
+                                OUT uint *enc_out)
+{
+
+    uint single_bit_value = 0;
+
+    if (size_bit == 22)
+        single_bit_value = 1;
+
+    // Element size is a part of the constant bits
+    const aarch64_reg_offset element_size =
+        BITS(enc, size_bit, size_bit) == single_bit_value ? SINGLE_REG : DOUBLE_REG;
+
+    if (!opnd_is_base_disp(opnd) || opnd_get_index(opnd) == DR_REG_NULL ||
+        get_vector_element_reg_offset(opnd) != element_size)
+        return false;
+
+    bool index_scaled;
+    uint index_scale_amount;
+    if (opnd_get_index_extend(opnd, &index_scaled, &index_scale_amount) !=
+            DR_EXTEND_UXTX ||
+        index_scaled || index_scale_amount != 0)
+        return false;
+
+    uint zreg_number;
+    opnd_size_t reg_size = OPSZ_SCALABLE;
+    IF_RETURN_FALSE(!encode_vreg(&reg_size, &zreg_number, opnd_get_base(opnd)))
+
+    const aarch64_reg_offset msz = BITS(enc, 24, 23);
+    const uint scale = 1 << msz;
+
+    const opnd_size_t mem_transfer =
+        opnd_size_from_bytes(scale * get_elements_in_sve_vector(element_size));
+    IF_RETURN_FALSE(opnd_get_size(opnd) != mem_transfer)
+
+    uint xreg_number;
+    bool is_x = false;
+    IF_RETURN_FALSE(!encode_reg(&xreg_number, &is_x, opnd_get_index(opnd), false) ||
+                    !is_x)
+
+    *enc_out |= (xreg_number << 16) | (zreg_number << 5);
+    return true;
+}
+
+
+/*
+ * svemem_vec_sssd_gpr16: SVE memory address with GPR offset [<Zn>.S/D{, <Xm>}],
+ * size determined by bit 22
+ */
+
+static inline bool
+decode_opnd_svemem_vec_22sd_gpr16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_svemem_vec_sd_gpr16(22, enc, opcode, pc, opnd);
+}
+
+static inline bool
+encode_opnd_svemem_vec_22sd_gpr16(uint enc, int opcode, byte *pc, opnd_t opnd,
+                                OUT uint *enc_out)
+{
+    return encode_svemem_vec_sd_gpr16(22, enc, opcode, pc, opnd, enc_out);
+}
+
 /* SVE memory operand [<Xn|SP>{, #<imm>, MUL VL}] 1 dest register */
 
 static inline bool
@@ -8349,66 +8442,16 @@ encode_opnd_x16imm(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_ou
 /* svemem_vec_sd_gpr16: SVE memory address with GPR offset [<Zn>.S/D{, <Xm>}] */
 
 static inline bool
-decode_opnd_svemem_vec_sd_gpr16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+decode_opnd_svemem_vec_30sd_gpr16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
 {
-    const aarch64_reg_offset msz = BITS(enc, 24, 23);
-    const uint scale = 1 << msz;
-
-    const aarch64_reg_offset element_size =
-        BITS(enc, 30, 30) > 0 ? DOUBLE_REG : SINGLE_REG;
-
-    const opnd_size_t mem_transfer =
-        opnd_size_from_bytes(scale * get_elements_in_sve_vector(element_size));
-
-    const reg_id_t zn = decode_vreg(Z_REG, extract_uint(enc, 5, 5));
-    ASSERT(reg_is_z(zn));
-
-    const reg_id_t xm = decode_reg(extract_uint(enc, 16, 5), true, false /* XZR */);
-    ASSERT(reg_is_gpr(xm));
-
-    *opnd = opnd_create_vector_base_disp_aarch64(
-        zn, xm, get_opnd_size_from_offset(element_size), DR_EXTEND_UXTX, false, 0, 0,
-        mem_transfer, 0);
-    return true;
+    return decode_svemem_vec_sd_gpr16(30, enc, opcode, pc, opnd);
 }
 
 static inline bool
-encode_opnd_svemem_vec_sd_gpr16(uint enc, int opcode, byte *pc, opnd_t opnd,
+encode_opnd_svemem_vec_30sd_gpr16(uint enc, int opcode, byte *pc, opnd_t opnd,
                                 OUT uint *enc_out)
 {
-    // Element size is a part of the constant bits
-    const aarch64_reg_offset element_size =
-        BITS(enc, 30, 30) > 0 ? DOUBLE_REG : SINGLE_REG;
-
-    if (!opnd_is_base_disp(opnd) || opnd_get_index(opnd) == DR_REG_NULL ||
-        get_vector_element_reg_offset(opnd) != element_size)
-        return false;
-
-    bool index_scaled;
-    uint index_scale_amount;
-    if (opnd_get_index_extend(opnd, &index_scaled, &index_scale_amount) !=
-            DR_EXTEND_UXTX ||
-        index_scaled || index_scale_amount != 0)
-        return false;
-
-    uint zreg_number;
-    opnd_size_t reg_size = OPSZ_SCALABLE;
-    IF_RETURN_FALSE(!encode_vreg(&reg_size, &zreg_number, opnd_get_base(opnd)))
-
-    const aarch64_reg_offset msz = BITS(enc, 24, 23);
-    const uint scale = 1 << msz;
-
-    const opnd_size_t mem_transfer =
-        opnd_size_from_bytes(scale * get_elements_in_sve_vector(element_size));
-    IF_RETURN_FALSE(opnd_get_size(opnd) != mem_transfer)
-
-    uint xreg_number;
-    bool is_x = false;
-    IF_RETURN_FALSE(!encode_reg(&xreg_number, &is_x, opnd_get_index(opnd), false) ||
-                    !is_x)
-
-    *enc_out |= (xreg_number << 16) | (zreg_number << 5);
-    return true;
+    return encode_svemem_vec_sd_gpr16(30, enc, opcode, pc, opnd, enc_out);
 }
 
 /* index3: index of D subreg in Q register: 0-1 */

--- a/core/ir/aarch64/codec_sve2.txt
+++ b/core/ir/aarch64/codec_sve2.txt
@@ -86,11 +86,18 @@
 01100100101xxxxx0110x1xxxxxxxxxx  n   1070 SVE2    fmlslt          z_s_0 : z_s_0 z_msz_bhsd_5 z3_msz_bhsd_16 i3_index_11
 01000101xx1xxxxx110xxxxxxxxxxxxx  n   1145 SVE2   histcnt    z_size_sd_0 : p10_zer_lo z_size_sd_5 z_size_sd_16
 01000101001xxxxx101000xxxxxxxxxx  n   1071 SVE2   histseg          z_b_0 : z_b_5 z_b_16
-11000100000xxxxx100xxxxxxxxxxxxx  n   1186 SVE2   ldnt1sb          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
-10000100000xxxxx100xxxxxxxxxxxxx  n   1186 SVE2   ldnt1sb          z_s_0 : svemem_vec_sd_gpr16 p10_zer_lo
-11000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
-10000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_s_0 : svemem_vec_sd_gpr16 p10_zer_lo
-11000101000xxxxx100xxxxxxxxxxxxx  n   1188 SVE2   ldnt1sw          z_d_0 : svemem_vec_sd_gpr16 p10_zer_lo
+11000100000xxxxx110xxxxxxxxxxxxx  n   950  SVE2    ldnt1b          z_d_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+10000100000xxxxx101xxxxxxxxxxxxx  n   950  SVE2    ldnt1b          z_s_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+11000101100xxxxx110xxxxxxxxxxxxx  n   992  SVE2    ldnt1d   z_d_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+11000100100xxxxx110xxxxxxxxxxxxx  n   993  SVE2    ldnt1h          z_d_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+10000100100xxxxx101xxxxxxxxxxxxx  n   993  SVE2    ldnt1h          z_s_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+11000100000xxxxx100xxxxxxxxxxxxx  n   1186 SVE2   ldnt1sb          z_d_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+10000100000xxxxx100xxxxxxxxxxxxx  n   1186 SVE2   ldnt1sb          z_s_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+11000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_d_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+10000100100xxxxx100xxxxxxxxxxxxx  n   1187 SVE2   ldnt1sh          z_s_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+11000101000xxxxx100xxxxxxxxxxxxx  n   1188 SVE2   ldnt1sw          z_d_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+11000101000xxxxx110xxxxxxxxxxxxx  n   994  SVE2    ldnt1w          z_d_0 : svemem_vec_30sd_gpr16 p10_zer_lo
+10000101000xxxxx101xxxxxxxxxxxxx  n   994  SVE2    ldnt1w   z_s_0 : svemem_vec_30sd_gpr16 p10_zer_lo
 01000101xx1xxxxx100xxxxxxxx0xxxx  w   1189 SVE2     match    p_size_bh_0 : p10_zer_lo z_size_bh_5 z_size_bh_16
 00000100111xxxxx001111xxxxxxxxxx  n   1072 SVE2      nbsl          z_d_0 : z_d_0 z_d_16 z_d_5
 01000101xx1xxxxx100xxxxxxxx1xxxx  w   1190 SVE2    nmatch    p_size_bh_0 : p10_zer_lo z_size_bh_5 z_size_bh_16
@@ -223,6 +230,13 @@
 01000101xx0xxxxx100011xxxxxxxxxx  n   1116 SVE2   ssubltb   z_size_hsd_0 : z_sizep1_bhs_5 z_sizep1_bhs_16
 01000101xx0xxxxx010100xxxxxxxxxx  n   1117 SVE2    ssubwb   z_size_hsd_0 : z_size_hsd_5 z_sizep1_bhs_16
 01000101xx0xxxxx010101xxxxxxxxxx  n   1118 SVE2    ssubwt   z_size_hsd_0 : z_size_hsd_5 z_sizep1_bhs_16
+11100100000xxxxx001xxxxxxxxxxxxx  n   952  SVE2    stnt1b       svemem_vec_22sd_gpr16 : z_d_0 p10_lo
+11100100010xxxxx001xxxxxxxxxxxxx  n   952  SVE2    stnt1b       svemem_vec_22sd_gpr16 : z_s_0 p10_lo
+11100101100xxxxx001xxxxxxxxxxxxx  n   1004 SVE2    stnt1d       svemem_vec_30sd_gpr16 : z_d_0 p10_lo
+11100100100xxxxx001xxxxxxxxxxxxx  n   1005 SVE2    stnt1h       svemem_vec_22sd_gpr16 : z_d_0 p10_lo
+11100100110xxxxx001xxxxxxxxxxxxx  n   1005 SVE2    stnt1h       svemem_vec_22sd_gpr16 : z_s_0 p10_lo
+11100101000xxxxx001xxxxxxxxxxxxx  n   1006 SVE2    stnt1w       svemem_vec_22sd_gpr16 : z_d_0 p10_lo
+11100101010xxxxx001xxxxxxxxxxxxx  n   1006 SVE2    stnt1w       svemem_vec_22sd_gpr16 : z_s_0 p10_lo
 01000101xx1xxxxx011100xxxxxxxxxx  n   1119 SVE2    subhnb  z_sizep1_bhs_0 : z_size_hsd_5 z_size_hsd_16
 01000101xx1xxxxx011101xxxxxxxxxx  n   1120 SVE2    subhnt  z_sizep1_bhs_0 : z_sizep1_bhs_0 z_size_hsd_5 z_size_hsd_16
 01000100xx011100100xxxxxxxxxxxxx  n   474  SVE2    suqadd  z_size_bhsd_0 : p10_mrg_lo z_size_bhsd_0 z_size_bhsd_5

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -11541,6 +11541,8 @@
  * \verbatim
  *    LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>, <Xm>]
  *    LDNT1B  { <Zt>.B }, <Pg>/Z, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    LDNT1B  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
+ *    LDNT1B  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -11549,9 +11551,12 @@
  *             constructed with the function:
  *             For the [\<Xn|SP\>, \<Xm\>] variant:
  *             opnd_create_base_disp_aarch64(Rn, Rm,
- *             DR_EXTEND_UXTX, 0, 0, 0, opnd_size_from_bytes(dr_get_sve_vector_length() /
- * 8)) For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant: opnd_create_base_disp(Rn,
- * DR_REG_NULL, 0, imm, opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             DR_EXTEND_UXTX, 0, 0, 0, opnd_size_from_bytes(
+ *             dr_get_sve_vector_length() / 8))
+ *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant: opnd_create_base_disp(Rn,
+ *             DR_REG_NULL, 0, imm, opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the vector+scalar variant: opnd_create_base_disp_aarch64(Zn, Rm,
+ *             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_1)
  */
 #define INSTR_CREATE_ldnt1b_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldnt1b, Zt, Rn, Pg)
@@ -11606,6 +11611,8 @@
  * \verbatim
  *    STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>, <Xm>]
  *    STNT1B  { <Zt>.B }, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    STNT1B  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
+ *    STNT1B  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -11614,9 +11621,22 @@
  *             constructed with the function:
  *             For the [\<Xn|SP\>, \<Xm\>] variant:
  *             opnd_create_base_disp_aarch64(Rn, Rm,
- *             DR_EXTEND_UXTX, 0, 0, 0, opnd_size_from_bytes(dr_get_sve_vector_length() /
- * 8)) For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant: opnd_create_base_disp(Rn,
- * DR_REG_NULL, 0, imm, opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(dr_get_sve_vector_length() /
+ *             8))
+ *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm,
+ *             opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the [\<Zn\>.D{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_8,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 8),
+ *             0)
+ *             For the [\<Zn\>.S{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_4,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 4),
+ *             0)
  */
 #define INSTR_CREATE_stnt1b_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_stnt1b, Rn, Zt, Pg)
@@ -12809,6 +12829,7 @@
  * \verbatim
  *    LDNT1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #3]
  *    LDNT1D  { <Zt>.D }, <Pg>/Z, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    LDNT1D  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -12822,6 +12843,10 @@
  *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant:
  *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm,
  *             opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the [\<Zn\>.D{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_8,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes()), 0)
  */
 #define INSTR_CREATE_ldnt1d_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldnt1d, Zt, Rn, Pg)
@@ -12833,6 +12858,8 @@
  * \verbatim
  *    LDNT1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #1]
  *    LDNT1H  { <Zt>.H }, <Pg>/Z, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    LDNT1H  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
+ *    LDNT1H  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -12846,6 +12873,15 @@
  *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant:
  *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm,
  *             opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the [\<Zn\>.D{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_8,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 4),
+ *             0)
+ *             For the [\<Zn\>.S{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_4,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 2), 0)
  */
 #define INSTR_CREATE_ldnt1h_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldnt1h, Zt, Rn, Pg)
@@ -12857,6 +12893,8 @@
  * \verbatim
  *    LDNT1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>, <Xm>, LSL #2]
  *    LDNT1W  { <Zt>.S }, <Pg>/Z, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    LDNT1W  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
+ *    LDNT1W  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The destination vector register, Z (Scalable).
@@ -12870,6 +12908,12 @@
  *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant:
  *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm,
  *             opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the [\<Zn\>.D{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_8,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 2), 0)
+ *             For the [\<Zn\>.S{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0, opnd_size_from_bytes(proc_get_vector_length_bytes()), 0)
  */
 #define INSTR_CREATE_ldnt1w_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldnt1w, Zt, Rn, Pg)
@@ -13097,6 +13141,7 @@
  * \verbatim
  *    STNT1D  { <Zt>.D }, <Pg>, [<Xn|SP>, <Xm>, LSL #3]
  *    STNT1D  { <Zt>.D }, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    STNT1D  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -13111,6 +13156,10 @@
  *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant:
  *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm,
  *             opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the [\<Zn\>.D{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_8,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes()), 0)
  */
 #define INSTR_CREATE_stnt1d_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_stnt1d, Rn, Zt, Pg)
@@ -13122,6 +13171,8 @@
  * \verbatim
  *    STNT1H  { <Zt>.H }, <Pg>, [<Xn|SP>, <Xm>, LSL #1]
  *    STNT1H  { <Zt>.H }, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    STNT1H  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
+ *    STNT1H  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -13135,6 +13186,14 @@
  *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant:
  *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm,
  *             opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the [\<Zn\>.D{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_8,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 4), 0)
+ *             For the [\<Zn\>.S{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_4,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 2), 0)
  */
 #define INSTR_CREATE_stnt1h_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_stnt1h, Rn, Zt, Pg)
@@ -13146,6 +13205,8 @@
  * \verbatim
  *    STNT1W  { <Zt>.S }, <Pg>, [<Xn|SP>, <Xm>, LSL #2]
  *    STNT1W  { <Zt>.S }, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]
+ *    STNT1W  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
+ *    STNT1W  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}]
  * \endverbatim
  * \param dc   The void * dcontext used to allocate memory for the #instr_t.
  * \param Zt   The first source vector register, Z (Scalable).
@@ -13159,6 +13220,14 @@
  *             For the [\<Xn|SP\>{, #\<imm\>, MUL VL}] variant:
  *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, imm,
  *             opnd_size_from_bytes(dr_get_sve_vector_length() / 8))
+ *             For the [\<Zn\>.D{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_8,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 2), 0)
+ *             For the [\<Zn\>.S{, \<Xm\>}] variant:
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_4,
+ *             DR_EXTEND_UXTX, 0, 0, 0,
+ *             opnd_size_from_bytes(proc_get_vector_length_bytes()), 0)
  */
 #define INSTR_CREATE_stnt1w_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_stnt1w, Rn, Zt, Pg)

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -12913,7 +12913,8 @@
  *             DR_EXTEND_UXTX, 0, 0, 0,
  *             opnd_size_from_bytes(proc_get_vector_length_bytes() / 2), 0)
  *             For the [\<Zn\>.S{, \<Xm\>}] variant:
- *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0, opnd_size_from_bytes(proc_get_vector_length_bytes()), 0)
+ *             opnd_create_vector_base_disp_aarch64(Zn, Xm, OPSZ_4, DR_EXTEND_UXTX, 0, 0,
+ *             0, opnd_size_from_bytes(proc_get_vector_length_bytes()), 0)
  */
 #define INSTR_CREATE_ldnt1w_sve_pred(dc, Zt, Pg, Rn) \
     instr_create_1dst_2src(dc, OP_ldnt1w, Zt, Rn, Pg)

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -356,6 +356,7 @@
 -------??--xxxxx------xxxxx-----  sveprf_gpr_shf   # SVE memory address [<Xn|SP>, <Xm>, LSL #x] for prefetch operation
 -------??-?xxxxx------xxxxx-----  svemem_gpr_vec64 # SVE memory address (64-bit offset) [<Xn|SP>, <Zm>.D{, <mod>}]
 -------??-xxxxxxx-----xxxxx-----  mem7_tag       # Write bytes is fixed at 16bytes, post/pre/offset is in 24:23, with memory tag scaling
+-------???-xxxxx------xxxxx-----  svemem_vec_22sd_gpr16 # SVE memort operand [<Zn>.S/D{, <Xm>}]
 -------????-xxxx------xxxxx-----  svemem_gpr_simm4_vl_1reg # SVE memory operand [<Xn|SP>{, #<imm>, MUL VL}]
                                                            # 1 src/dest register
 -------????xxxxx------xxxxx-----  svemem_ssz_gpr_shf # SVE memory operand [<Xn|SP>, <Xm>, LSL #x]
@@ -374,7 +375,7 @@
 -------xx--xxxxx----------------  z_msz_bhsd_16   # z register with element size determined by msz
 -?--------------------xxxxx-----  mem0p      # gets size from 30; no offset, pair
 -?---------xxxxx????------------  x16imm     # computes immed from 30 and 15:12
--?-----??--xxxxx------xxxxx-----  svemem_vec_sd_gpr16  # SVE memory address with GPR offset [<Zn>.S/D{, <Xm>}]
+-?-----??--xxxxx------xxxxx-----  svemem_vec_30sd_gpr16  # SVE memory address with GPR offset [<Zn>.S/D{, <Xm>}]
 -x------------------------------  index3     # index of D subreg in Q: 0-1
 -x-------------------------xxxxx  wx0_30     # X register if bit 30 is set, else W
 -x-------------------------xxxxx  dq0        # Q register if bit 30 is set, else D

--- a/suite/tests/api/dis-a64-sve2.txt
+++ b/suite/tests/api/dis-a64-sve2.txt
@@ -1600,6 +1600,96 @@
 453da39b : histseg z27.b, z28.b, z29.b               : histseg %z28.b %z29.b -> %z27.b
 453fa3ff : histseg z31.b, z31.b, z31.b               : histseg %z31.b %z31.b -> %z31.b
 
+# LDNT1B  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] (LDNT1B-Z.P.AR-S.x32.unscaled)
+8400a000 : ldnt1b z0.s, p0/Z, [z0.s, x0]             : ldnt1b (%z0.s,%x0)[8byte] %p0/z -> %z0.s
+8405a482 : ldnt1b z2.s, p1/Z, [z4.s, x5]             : ldnt1b (%z4.s,%x5)[8byte] %p1/z -> %z2.s
+8407a8c4 : ldnt1b z4.s, p2/Z, [z6.s, x7]             : ldnt1b (%z6.s,%x7)[8byte] %p2/z -> %z4.s
+8409a906 : ldnt1b z6.s, p2/Z, [z8.s, x9]             : ldnt1b (%z8.s,%x9)[8byte] %p2/z -> %z6.s
+840bad48 : ldnt1b z8.s, p3/Z, [z10.s, x11]           : ldnt1b (%z10.s,%x11)[8byte] %p3/z -> %z8.s
+840cad8a : ldnt1b z10.s, p3/Z, [z12.s, x12]          : ldnt1b (%z12.s,%x12)[8byte] %p3/z -> %z10.s
+840eb1cc : ldnt1b z12.s, p4/Z, [z14.s, x14]          : ldnt1b (%z14.s,%x14)[8byte] %p4/z -> %z12.s
+8410b20e : ldnt1b z14.s, p4/Z, [z16.s, x16]          : ldnt1b (%z16.s,%x16)[8byte] %p4/z -> %z14.s
+8412b650 : ldnt1b z16.s, p5/Z, [z18.s, x18]          : ldnt1b (%z18.s,%x18)[8byte] %p5/z -> %z16.s
+8414b671 : ldnt1b z17.s, p5/Z, [z19.s, x20]          : ldnt1b (%z19.s,%x20)[8byte] %p5/z -> %z17.s
+8416b6b3 : ldnt1b z19.s, p5/Z, [z21.s, x22]          : ldnt1b (%z21.s,%x22)[8byte] %p5/z -> %z19.s
+8418baf5 : ldnt1b z21.s, p6/Z, [z23.s, x24]          : ldnt1b (%z23.s,%x24)[8byte] %p6/z -> %z21.s
+8419bb37 : ldnt1b z23.s, p6/Z, [z25.s, x25]          : ldnt1b (%z25.s,%x25)[8byte] %p6/z -> %z23.s
+841bbf79 : ldnt1b z25.s, p7/Z, [z27.s, x27]          : ldnt1b (%z27.s,%x27)[8byte] %p7/z -> %z25.s
+841dbfbb : ldnt1b z27.s, p7/Z, [z29.s, x29]          : ldnt1b (%z29.s,%x29)[8byte] %p7/z -> %z27.s
+841ebfff : ldnt1b z31.s, p7/Z, [z31.s, x30]          : ldnt1b (%z31.s,%x30)[8byte] %p7/z -> %z31.s
+
+# LDNT1B  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] (LDNT1B-Z.P.AR-D.64.unscaled)
+c400c000 : ldnt1b z0.d, p0/Z, [z0.d, x0]             : ldnt1b (%z0.d,%x0)[4byte] %p0/z -> %z0.d
+c405c482 : ldnt1b z2.d, p1/Z, [z4.d, x5]             : ldnt1b (%z4.d,%x5)[4byte] %p1/z -> %z2.d
+c407c8c4 : ldnt1b z4.d, p2/Z, [z6.d, x7]             : ldnt1b (%z6.d,%x7)[4byte] %p2/z -> %z4.d
+c409c906 : ldnt1b z6.d, p2/Z, [z8.d, x9]             : ldnt1b (%z8.d,%x9)[4byte] %p2/z -> %z6.d
+c40bcd48 : ldnt1b z8.d, p3/Z, [z10.d, x11]           : ldnt1b (%z10.d,%x11)[4byte] %p3/z -> %z8.d
+c40ccd8a : ldnt1b z10.d, p3/Z, [z12.d, x12]          : ldnt1b (%z12.d,%x12)[4byte] %p3/z -> %z10.d
+c40ed1cc : ldnt1b z12.d, p4/Z, [z14.d, x14]          : ldnt1b (%z14.d,%x14)[4byte] %p4/z -> %z12.d
+c410d20e : ldnt1b z14.d, p4/Z, [z16.d, x16]          : ldnt1b (%z16.d,%x16)[4byte] %p4/z -> %z14.d
+c412d650 : ldnt1b z16.d, p5/Z, [z18.d, x18]          : ldnt1b (%z18.d,%x18)[4byte] %p5/z -> %z16.d
+c414d671 : ldnt1b z17.d, p5/Z, [z19.d, x20]          : ldnt1b (%z19.d,%x20)[4byte] %p5/z -> %z17.d
+c416d6b3 : ldnt1b z19.d, p5/Z, [z21.d, x22]          : ldnt1b (%z21.d,%x22)[4byte] %p5/z -> %z19.d
+c418daf5 : ldnt1b z21.d, p6/Z, [z23.d, x24]          : ldnt1b (%z23.d,%x24)[4byte] %p6/z -> %z21.d
+c419db37 : ldnt1b z23.d, p6/Z, [z25.d, x25]          : ldnt1b (%z25.d,%x25)[4byte] %p6/z -> %z23.d
+c41bdf79 : ldnt1b z25.d, p7/Z, [z27.d, x27]          : ldnt1b (%z27.d,%x27)[4byte] %p7/z -> %z25.d
+c41ddfbb : ldnt1b z27.d, p7/Z, [z29.d, x29]          : ldnt1b (%z29.d,%x29)[4byte] %p7/z -> %z27.d
+c41edfff : ldnt1b z31.d, p7/Z, [z31.d, x30]          : ldnt1b (%z31.d,%x30)[4byte] %p7/z -> %z31.d
+
+# LDNT1D  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] (LDNT1D-Z.P.AR-D.64.unscaled)
+c580c000 : ldnt1d z0.d, p0/Z, [z0.d, x0]             : ldnt1d (%z0.d,%x0)[32byte] %p0/z -> %z0.d
+c585c482 : ldnt1d z2.d, p1/Z, [z4.d, x5]             : ldnt1d (%z4.d,%x5)[32byte] %p1/z -> %z2.d
+c587c8c4 : ldnt1d z4.d, p2/Z, [z6.d, x7]             : ldnt1d (%z6.d,%x7)[32byte] %p2/z -> %z4.d
+c589c906 : ldnt1d z6.d, p2/Z, [z8.d, x9]             : ldnt1d (%z8.d,%x9)[32byte] %p2/z -> %z6.d
+c58bcd48 : ldnt1d z8.d, p3/Z, [z10.d, x11]           : ldnt1d (%z10.d,%x11)[32byte] %p3/z -> %z8.d
+c58ccd8a : ldnt1d z10.d, p3/Z, [z12.d, x12]          : ldnt1d (%z12.d,%x12)[32byte] %p3/z -> %z10.d
+c58ed1cc : ldnt1d z12.d, p4/Z, [z14.d, x14]          : ldnt1d (%z14.d,%x14)[32byte] %p4/z -> %z12.d
+c590d20e : ldnt1d z14.d, p4/Z, [z16.d, x16]          : ldnt1d (%z16.d,%x16)[32byte] %p4/z -> %z14.d
+c592d650 : ldnt1d z16.d, p5/Z, [z18.d, x18]          : ldnt1d (%z18.d,%x18)[32byte] %p5/z -> %z16.d
+c594d671 : ldnt1d z17.d, p5/Z, [z19.d, x20]          : ldnt1d (%z19.d,%x20)[32byte] %p5/z -> %z17.d
+c596d6b3 : ldnt1d z19.d, p5/Z, [z21.d, x22]          : ldnt1d (%z21.d,%x22)[32byte] %p5/z -> %z19.d
+c598daf5 : ldnt1d z21.d, p6/Z, [z23.d, x24]          : ldnt1d (%z23.d,%x24)[32byte] %p6/z -> %z21.d
+c599db37 : ldnt1d z23.d, p6/Z, [z25.d, x25]          : ldnt1d (%z25.d,%x25)[32byte] %p6/z -> %z23.d
+c59bdf79 : ldnt1d z25.d, p7/Z, [z27.d, x27]          : ldnt1d (%z27.d,%x27)[32byte] %p7/z -> %z25.d
+c59ddfbb : ldnt1d z27.d, p7/Z, [z29.d, x29]          : ldnt1d (%z29.d,%x29)[32byte] %p7/z -> %z27.d
+c59edfff : ldnt1d z31.d, p7/Z, [z31.d, x30]          : ldnt1d (%z31.d,%x30)[32byte] %p7/z -> %z31.d
+
+# LDNT1H  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] (LDNT1H-Z.P.AR-S.x32.unscaled)
+8480a000 : ldnt1h z0.s, p0/Z, [z0.s, x0]             : ldnt1h (%z0.s,%x0)[16byte] %p0/z -> %z0.s
+8485a482 : ldnt1h z2.s, p1/Z, [z4.s, x5]             : ldnt1h (%z4.s,%x5)[16byte] %p1/z -> %z2.s
+8487a8c4 : ldnt1h z4.s, p2/Z, [z6.s, x7]             : ldnt1h (%z6.s,%x7)[16byte] %p2/z -> %z4.s
+8489a906 : ldnt1h z6.s, p2/Z, [z8.s, x9]             : ldnt1h (%z8.s,%x9)[16byte] %p2/z -> %z6.s
+848bad48 : ldnt1h z8.s, p3/Z, [z10.s, x11]           : ldnt1h (%z10.s,%x11)[16byte] %p3/z -> %z8.s
+848cad8a : ldnt1h z10.s, p3/Z, [z12.s, x12]          : ldnt1h (%z12.s,%x12)[16byte] %p3/z -> %z10.s
+848eb1cc : ldnt1h z12.s, p4/Z, [z14.s, x14]          : ldnt1h (%z14.s,%x14)[16byte] %p4/z -> %z12.s
+8490b20e : ldnt1h z14.s, p4/Z, [z16.s, x16]          : ldnt1h (%z16.s,%x16)[16byte] %p4/z -> %z14.s
+8492b650 : ldnt1h z16.s, p5/Z, [z18.s, x18]          : ldnt1h (%z18.s,%x18)[16byte] %p5/z -> %z16.s
+8494b671 : ldnt1h z17.s, p5/Z, [z19.s, x20]          : ldnt1h (%z19.s,%x20)[16byte] %p5/z -> %z17.s
+8496b6b3 : ldnt1h z19.s, p5/Z, [z21.s, x22]          : ldnt1h (%z21.s,%x22)[16byte] %p5/z -> %z19.s
+8498baf5 : ldnt1h z21.s, p6/Z, [z23.s, x24]          : ldnt1h (%z23.s,%x24)[16byte] %p6/z -> %z21.s
+8499bb37 : ldnt1h z23.s, p6/Z, [z25.s, x25]          : ldnt1h (%z25.s,%x25)[16byte] %p6/z -> %z23.s
+849bbf79 : ldnt1h z25.s, p7/Z, [z27.s, x27]          : ldnt1h (%z27.s,%x27)[16byte] %p7/z -> %z25.s
+849dbfbb : ldnt1h z27.s, p7/Z, [z29.s, x29]          : ldnt1h (%z29.s,%x29)[16byte] %p7/z -> %z27.s
+849ebfff : ldnt1h z31.s, p7/Z, [z31.s, x30]          : ldnt1h (%z31.s,%x30)[16byte] %p7/z -> %z31.s
+
+# LDNT1H  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] (LDNT1H-Z.P.AR-D.64.unscaled)
+c480c000 : ldnt1h z0.d, p0/Z, [z0.d, x0]             : ldnt1h (%z0.d,%x0)[8byte] %p0/z -> %z0.d
+c485c482 : ldnt1h z2.d, p1/Z, [z4.d, x5]             : ldnt1h (%z4.d,%x5)[8byte] %p1/z -> %z2.d
+c487c8c4 : ldnt1h z4.d, p2/Z, [z6.d, x7]             : ldnt1h (%z6.d,%x7)[8byte] %p2/z -> %z4.d
+c489c906 : ldnt1h z6.d, p2/Z, [z8.d, x9]             : ldnt1h (%z8.d,%x9)[8byte] %p2/z -> %z6.d
+c48bcd48 : ldnt1h z8.d, p3/Z, [z10.d, x11]           : ldnt1h (%z10.d,%x11)[8byte] %p3/z -> %z8.d
+c48ccd8a : ldnt1h z10.d, p3/Z, [z12.d, x12]          : ldnt1h (%z12.d,%x12)[8byte] %p3/z -> %z10.d
+c48ed1cc : ldnt1h z12.d, p4/Z, [z14.d, x14]          : ldnt1h (%z14.d,%x14)[8byte] %p4/z -> %z12.d
+c490d20e : ldnt1h z14.d, p4/Z, [z16.d, x16]          : ldnt1h (%z16.d,%x16)[8byte] %p4/z -> %z14.d
+c492d650 : ldnt1h z16.d, p5/Z, [z18.d, x18]          : ldnt1h (%z18.d,%x18)[8byte] %p5/z -> %z16.d
+c494d671 : ldnt1h z17.d, p5/Z, [z19.d, x20]          : ldnt1h (%z19.d,%x20)[8byte] %p5/z -> %z17.d
+c496d6b3 : ldnt1h z19.d, p5/Z, [z21.d, x22]          : ldnt1h (%z21.d,%x22)[8byte] %p5/z -> %z19.d
+c498daf5 : ldnt1h z21.d, p6/Z, [z23.d, x24]          : ldnt1h (%z23.d,%x24)[8byte] %p6/z -> %z21.d
+c499db37 : ldnt1h z23.d, p6/Z, [z25.d, x25]          : ldnt1h (%z25.d,%x25)[8byte] %p6/z -> %z23.d
+c49bdf79 : ldnt1h z25.d, p7/Z, [z27.d, x27]          : ldnt1h (%z27.d,%x27)[8byte] %p7/z -> %z25.d
+c49ddfbb : ldnt1h z27.d, p7/Z, [z29.d, x29]          : ldnt1h (%z29.d,%x29)[8byte] %p7/z -> %z27.d
+c49edfff : ldnt1h z31.d, p7/Z, [z31.d, x30]          : ldnt1h (%z31.d,%x30)[8byte] %p7/z -> %z31.d
+
 # LDNT1SB { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] (LDNT1SB-Z.P.AR-S.x32.unscaled)
 84008000 : ldnt1sb z0.s, p0/Z, [z0.s, x0]            : ldnt1sb (%z0.s,%x0)[8byte] %p0/z -> %z0.s
 84058482 : ldnt1sb z2.s, p1/Z, [z4.s, x5]            : ldnt1sb (%z4.s,%x5)[8byte] %p1/z -> %z2.s
@@ -1689,6 +1779,42 @@ c5199b37 : ldnt1sw z23.d, p6/Z, [z25.d, x25]         : ldnt1sw (%z25.d,%x25)[16b
 c51b9f79 : ldnt1sw z25.d, p7/Z, [z27.d, x27]         : ldnt1sw (%z27.d,%x27)[16byte] %p7/z -> %z25.d
 c51d9fbb : ldnt1sw z27.d, p7/Z, [z29.d, x29]         : ldnt1sw (%z29.d,%x29)[16byte] %p7/z -> %z27.d
 c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16byte] %p7/z -> %z31.d
+
+# LDNT1W  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] (LDNT1W-Z.P.AR-S.x32.unscaled)
+8500a000 : ldnt1w z0.s, p0/Z, [z0.s, x0]             : ldnt1w (%z0.s,%x0)[32byte] %p0/z -> %z0.s
+8505a482 : ldnt1w z2.s, p1/Z, [z4.s, x5]             : ldnt1w (%z4.s,%x5)[32byte] %p1/z -> %z2.s
+8507a8c4 : ldnt1w z4.s, p2/Z, [z6.s, x7]             : ldnt1w (%z6.s,%x7)[32byte] %p2/z -> %z4.s
+8509a906 : ldnt1w z6.s, p2/Z, [z8.s, x9]             : ldnt1w (%z8.s,%x9)[32byte] %p2/z -> %z6.s
+850bad48 : ldnt1w z8.s, p3/Z, [z10.s, x11]           : ldnt1w (%z10.s,%x11)[32byte] %p3/z -> %z8.s
+850cad8a : ldnt1w z10.s, p3/Z, [z12.s, x12]          : ldnt1w (%z12.s,%x12)[32byte] %p3/z -> %z10.s
+850eb1cc : ldnt1w z12.s, p4/Z, [z14.s, x14]          : ldnt1w (%z14.s,%x14)[32byte] %p4/z -> %z12.s
+8510b20e : ldnt1w z14.s, p4/Z, [z16.s, x16]          : ldnt1w (%z16.s,%x16)[32byte] %p4/z -> %z14.s
+8512b650 : ldnt1w z16.s, p5/Z, [z18.s, x18]          : ldnt1w (%z18.s,%x18)[32byte] %p5/z -> %z16.s
+8514b671 : ldnt1w z17.s, p5/Z, [z19.s, x20]          : ldnt1w (%z19.s,%x20)[32byte] %p5/z -> %z17.s
+8516b6b3 : ldnt1w z19.s, p5/Z, [z21.s, x22]          : ldnt1w (%z21.s,%x22)[32byte] %p5/z -> %z19.s
+8518baf5 : ldnt1w z21.s, p6/Z, [z23.s, x24]          : ldnt1w (%z23.s,%x24)[32byte] %p6/z -> %z21.s
+8519bb37 : ldnt1w z23.s, p6/Z, [z25.s, x25]          : ldnt1w (%z25.s,%x25)[32byte] %p6/z -> %z23.s
+851bbf79 : ldnt1w z25.s, p7/Z, [z27.s, x27]          : ldnt1w (%z27.s,%x27)[32byte] %p7/z -> %z25.s
+851dbfbb : ldnt1w z27.s, p7/Z, [z29.s, x29]          : ldnt1w (%z29.s,%x29)[32byte] %p7/z -> %z27.s
+851ebfff : ldnt1w z31.s, p7/Z, [z31.s, x30]          : ldnt1w (%z31.s,%x30)[32byte] %p7/z -> %z31.s
+
+# LDNT1W  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] (LDNT1W-Z.P.AR-D.64.unscaled)
+c500c000 : ldnt1w z0.d, p0/Z, [z0.d, x0]             : ldnt1w (%z0.d,%x0)[16byte] %p0/z -> %z0.d
+c505c482 : ldnt1w z2.d, p1/Z, [z4.d, x5]             : ldnt1w (%z4.d,%x5)[16byte] %p1/z -> %z2.d
+c507c8c4 : ldnt1w z4.d, p2/Z, [z6.d, x7]             : ldnt1w (%z6.d,%x7)[16byte] %p2/z -> %z4.d
+c509c906 : ldnt1w z6.d, p2/Z, [z8.d, x9]             : ldnt1w (%z8.d,%x9)[16byte] %p2/z -> %z6.d
+c50bcd48 : ldnt1w z8.d, p3/Z, [z10.d, x11]           : ldnt1w (%z10.d,%x11)[16byte] %p3/z -> %z8.d
+c50ccd8a : ldnt1w z10.d, p3/Z, [z12.d, x12]          : ldnt1w (%z12.d,%x12)[16byte] %p3/z -> %z10.d
+c50ed1cc : ldnt1w z12.d, p4/Z, [z14.d, x14]          : ldnt1w (%z14.d,%x14)[16byte] %p4/z -> %z12.d
+c510d20e : ldnt1w z14.d, p4/Z, [z16.d, x16]          : ldnt1w (%z16.d,%x16)[16byte] %p4/z -> %z14.d
+c512d650 : ldnt1w z16.d, p5/Z, [z18.d, x18]          : ldnt1w (%z18.d,%x18)[16byte] %p5/z -> %z16.d
+c514d671 : ldnt1w z17.d, p5/Z, [z19.d, x20]          : ldnt1w (%z19.d,%x20)[16byte] %p5/z -> %z17.d
+c516d6b3 : ldnt1w z19.d, p5/Z, [z21.d, x22]          : ldnt1w (%z21.d,%x22)[16byte] %p5/z -> %z19.d
+c518daf5 : ldnt1w z21.d, p6/Z, [z23.d, x24]          : ldnt1w (%z23.d,%x24)[16byte] %p6/z -> %z21.d
+c519db37 : ldnt1w z23.d, p6/Z, [z25.d, x25]          : ldnt1w (%z25.d,%x25)[16byte] %p6/z -> %z23.d
+c51bdf79 : ldnt1w z25.d, p7/Z, [z27.d, x27]          : ldnt1w (%z27.d,%x27)[16byte] %p7/z -> %z25.d
+c51ddfbb : ldnt1w z27.d, p7/Z, [z29.d, x29]          : ldnt1w (%z29.d,%x29)[16byte] %p7/z -> %z27.d
+c51edfff : ldnt1w z31.d, p7/Z, [z31.d, x30]          : ldnt1w (%z31.d,%x30)[16byte] %p7/z -> %z31.d
 
 # MATCH   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T> (MATCH-P.P.ZZ-_)
 45208000 : match p0.b, p0/Z, z0.b, z0.b              : match  %p0/z %z0.b %z0.b -> %p0.b
@@ -7181,6 +7307,132 @@ c51e9fff : ldnt1sw z31.d, p7/Z, [z31.d, x30]         : ldnt1sw (%z31.d,%x30)[16b
 45db5759 : ssubwt z25.d, z26.d, z27.s                : ssubwt %z26.d %z27.s -> %z25.d
 45dd579b : ssubwt z27.d, z28.d, z29.s                : ssubwt %z28.d %z29.s -> %z27.d
 45df57ff : ssubwt z31.d, z31.d, z31.s                : ssubwt %z31.d %z31.s -> %z31.d
+
+# STNT1B  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] (STNT1B-Z.P.AR-D.64.unscaled)
+e4002000 : stnt1b z0.d, p0, [z0.d, x0]               : stnt1b %z0.d %p0 -> (%z0.d,%x0)[4byte]
+e4052482 : stnt1b z2.d, p1, [z4.d, x5]               : stnt1b %z2.d %p1 -> (%z4.d,%x5)[4byte]
+e40728c4 : stnt1b z4.d, p2, [z6.d, x7]               : stnt1b %z4.d %p2 -> (%z6.d,%x7)[4byte]
+e4092906 : stnt1b z6.d, p2, [z8.d, x9]               : stnt1b %z6.d %p2 -> (%z8.d,%x9)[4byte]
+e40b2d48 : stnt1b z8.d, p3, [z10.d, x11]             : stnt1b %z8.d %p3 -> (%z10.d,%x11)[4byte]
+e40c2d8a : stnt1b z10.d, p3, [z12.d, x12]            : stnt1b %z10.d %p3 -> (%z12.d,%x12)[4byte]
+e40e31cc : stnt1b z12.d, p4, [z14.d, x14]            : stnt1b %z12.d %p4 -> (%z14.d,%x14)[4byte]
+e410320e : stnt1b z14.d, p4, [z16.d, x16]            : stnt1b %z14.d %p4 -> (%z16.d,%x16)[4byte]
+e4123650 : stnt1b z16.d, p5, [z18.d, x18]            : stnt1b %z16.d %p5 -> (%z18.d,%x18)[4byte]
+e4143671 : stnt1b z17.d, p5, [z19.d, x20]            : stnt1b %z17.d %p5 -> (%z19.d,%x20)[4byte]
+e41636b3 : stnt1b z19.d, p5, [z21.d, x22]            : stnt1b %z19.d %p5 -> (%z21.d,%x22)[4byte]
+e4183af5 : stnt1b z21.d, p6, [z23.d, x24]            : stnt1b %z21.d %p6 -> (%z23.d,%x24)[4byte]
+e4193b37 : stnt1b z23.d, p6, [z25.d, x25]            : stnt1b %z23.d %p6 -> (%z25.d,%x25)[4byte]
+e41b3f79 : stnt1b z25.d, p7, [z27.d, x27]            : stnt1b %z25.d %p7 -> (%z27.d,%x27)[4byte]
+e41d3fbb : stnt1b z27.d, p7, [z29.d, x29]            : stnt1b %z27.d %p7 -> (%z29.d,%x29)[4byte]
+e41e3fff : stnt1b z31.d, p7, [z31.d, x30]            : stnt1b %z31.d %p7 -> (%z31.d,%x30)[4byte]
+
+# STNT1B  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}] (STNT1B-Z.P.AR-S.x32.unscaled)
+e4402000 : stnt1b z0.s, p0, [z0.s, x0]               : stnt1b %z0.s %p0 -> (%z0.s,%x0)[8byte]
+e4452482 : stnt1b z2.s, p1, [z4.s, x5]               : stnt1b %z2.s %p1 -> (%z4.s,%x5)[8byte]
+e44728c4 : stnt1b z4.s, p2, [z6.s, x7]               : stnt1b %z4.s %p2 -> (%z6.s,%x7)[8byte]
+e4492906 : stnt1b z6.s, p2, [z8.s, x9]               : stnt1b %z6.s %p2 -> (%z8.s,%x9)[8byte]
+e44b2d48 : stnt1b z8.s, p3, [z10.s, x11]             : stnt1b %z8.s %p3 -> (%z10.s,%x11)[8byte]
+e44c2d8a : stnt1b z10.s, p3, [z12.s, x12]            : stnt1b %z10.s %p3 -> (%z12.s,%x12)[8byte]
+e44e31cc : stnt1b z12.s, p4, [z14.s, x14]            : stnt1b %z12.s %p4 -> (%z14.s,%x14)[8byte]
+e450320e : stnt1b z14.s, p4, [z16.s, x16]            : stnt1b %z14.s %p4 -> (%z16.s,%x16)[8byte]
+e4523650 : stnt1b z16.s, p5, [z18.s, x18]            : stnt1b %z16.s %p5 -> (%z18.s,%x18)[8byte]
+e4543671 : stnt1b z17.s, p5, [z19.s, x20]            : stnt1b %z17.s %p5 -> (%z19.s,%x20)[8byte]
+e45636b3 : stnt1b z19.s, p5, [z21.s, x22]            : stnt1b %z19.s %p5 -> (%z21.s,%x22)[8byte]
+e4583af5 : stnt1b z21.s, p6, [z23.s, x24]            : stnt1b %z21.s %p6 -> (%z23.s,%x24)[8byte]
+e4593b37 : stnt1b z23.s, p6, [z25.s, x25]            : stnt1b %z23.s %p6 -> (%z25.s,%x25)[8byte]
+e45b3f79 : stnt1b z25.s, p7, [z27.s, x27]            : stnt1b %z25.s %p7 -> (%z27.s,%x27)[8byte]
+e45d3fbb : stnt1b z27.s, p7, [z29.s, x29]            : stnt1b %z27.s %p7 -> (%z29.s,%x29)[8byte]
+e45e3fff : stnt1b z31.s, p7, [z31.s, x30]            : stnt1b %z31.s %p7 -> (%z31.s,%x30)[8byte]
+
+# STNT1D  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] (STNT1D-Z.P.AR-D.64.unscaled)
+e5802000 : stnt1d z0.d, p0, [z0.d, x0]               : stnt1d %z0.d %p0 -> (%z0.d,%x0)[32byte]
+e5852482 : stnt1d z2.d, p1, [z4.d, x5]               : stnt1d %z2.d %p1 -> (%z4.d,%x5)[32byte]
+e58728c4 : stnt1d z4.d, p2, [z6.d, x7]               : stnt1d %z4.d %p2 -> (%z6.d,%x7)[32byte]
+e5892906 : stnt1d z6.d, p2, [z8.d, x9]               : stnt1d %z6.d %p2 -> (%z8.d,%x9)[32byte]
+e58b2d48 : stnt1d z8.d, p3, [z10.d, x11]             : stnt1d %z8.d %p3 -> (%z10.d,%x11)[32byte]
+e58c2d8a : stnt1d z10.d, p3, [z12.d, x12]            : stnt1d %z10.d %p3 -> (%z12.d,%x12)[32byte]
+e58e31cc : stnt1d z12.d, p4, [z14.d, x14]            : stnt1d %z12.d %p4 -> (%z14.d,%x14)[32byte]
+e590320e : stnt1d z14.d, p4, [z16.d, x16]            : stnt1d %z14.d %p4 -> (%z16.d,%x16)[32byte]
+e5923650 : stnt1d z16.d, p5, [z18.d, x18]            : stnt1d %z16.d %p5 -> (%z18.d,%x18)[32byte]
+e5943671 : stnt1d z17.d, p5, [z19.d, x20]            : stnt1d %z17.d %p5 -> (%z19.d,%x20)[32byte]
+e59636b3 : stnt1d z19.d, p5, [z21.d, x22]            : stnt1d %z19.d %p5 -> (%z21.d,%x22)[32byte]
+e5983af5 : stnt1d z21.d, p6, [z23.d, x24]            : stnt1d %z21.d %p6 -> (%z23.d,%x24)[32byte]
+e5993b37 : stnt1d z23.d, p6, [z25.d, x25]            : stnt1d %z23.d %p6 -> (%z25.d,%x25)[32byte]
+e59b3f79 : stnt1d z25.d, p7, [z27.d, x27]            : stnt1d %z25.d %p7 -> (%z27.d,%x27)[32byte]
+e59d3fbb : stnt1d z27.d, p7, [z29.d, x29]            : stnt1d %z27.d %p7 -> (%z29.d,%x29)[32byte]
+e59e3fff : stnt1d z31.d, p7, [z31.d, x30]            : stnt1d %z31.d %p7 -> (%z31.d,%x30)[32byte]
+
+# STNT1H  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] (STNT1H-Z.P.AR-D.64.unscaled)
+e4802000 : stnt1h z0.d, p0, [z0.d, x0]               : stnt1h %z0.d %p0 -> (%z0.d,%x0)[8byte]
+e4852482 : stnt1h z2.d, p1, [z4.d, x5]               : stnt1h %z2.d %p1 -> (%z4.d,%x5)[8byte]
+e48728c4 : stnt1h z4.d, p2, [z6.d, x7]               : stnt1h %z4.d %p2 -> (%z6.d,%x7)[8byte]
+e4892906 : stnt1h z6.d, p2, [z8.d, x9]               : stnt1h %z6.d %p2 -> (%z8.d,%x9)[8byte]
+e48b2d48 : stnt1h z8.d, p3, [z10.d, x11]             : stnt1h %z8.d %p3 -> (%z10.d,%x11)[8byte]
+e48c2d8a : stnt1h z10.d, p3, [z12.d, x12]            : stnt1h %z10.d %p3 -> (%z12.d,%x12)[8byte]
+e48e31cc : stnt1h z12.d, p4, [z14.d, x14]            : stnt1h %z12.d %p4 -> (%z14.d,%x14)[8byte]
+e490320e : stnt1h z14.d, p4, [z16.d, x16]            : stnt1h %z14.d %p4 -> (%z16.d,%x16)[8byte]
+e4923650 : stnt1h z16.d, p5, [z18.d, x18]            : stnt1h %z16.d %p5 -> (%z18.d,%x18)[8byte]
+e4943671 : stnt1h z17.d, p5, [z19.d, x20]            : stnt1h %z17.d %p5 -> (%z19.d,%x20)[8byte]
+e49636b3 : stnt1h z19.d, p5, [z21.d, x22]            : stnt1h %z19.d %p5 -> (%z21.d,%x22)[8byte]
+e4983af5 : stnt1h z21.d, p6, [z23.d, x24]            : stnt1h %z21.d %p6 -> (%z23.d,%x24)[8byte]
+e4993b37 : stnt1h z23.d, p6, [z25.d, x25]            : stnt1h %z23.d %p6 -> (%z25.d,%x25)[8byte]
+e49b3f79 : stnt1h z25.d, p7, [z27.d, x27]            : stnt1h %z25.d %p7 -> (%z27.d,%x27)[8byte]
+e49d3fbb : stnt1h z27.d, p7, [z29.d, x29]            : stnt1h %z27.d %p7 -> (%z29.d,%x29)[8byte]
+e49e3fff : stnt1h z31.d, p7, [z31.d, x30]            : stnt1h %z31.d %p7 -> (%z31.d,%x30)[8byte]
+
+# STNT1H  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}] (STNT1H-Z.P.AR-S.x32.unscaled)
+e4c02000 : stnt1h z0.s, p0, [z0.s, x0]               : stnt1h %z0.s %p0 -> (%z0.s,%x0)[16byte]
+e4c52482 : stnt1h z2.s, p1, [z4.s, x5]               : stnt1h %z2.s %p1 -> (%z4.s,%x5)[16byte]
+e4c728c4 : stnt1h z4.s, p2, [z6.s, x7]               : stnt1h %z4.s %p2 -> (%z6.s,%x7)[16byte]
+e4c92906 : stnt1h z6.s, p2, [z8.s, x9]               : stnt1h %z6.s %p2 -> (%z8.s,%x9)[16byte]
+e4cb2d48 : stnt1h z8.s, p3, [z10.s, x11]             : stnt1h %z8.s %p3 -> (%z10.s,%x11)[16byte]
+e4cc2d8a : stnt1h z10.s, p3, [z12.s, x12]            : stnt1h %z10.s %p3 -> (%z12.s,%x12)[16byte]
+e4ce31cc : stnt1h z12.s, p4, [z14.s, x14]            : stnt1h %z12.s %p4 -> (%z14.s,%x14)[16byte]
+e4d0320e : stnt1h z14.s, p4, [z16.s, x16]            : stnt1h %z14.s %p4 -> (%z16.s,%x16)[16byte]
+e4d23650 : stnt1h z16.s, p5, [z18.s, x18]            : stnt1h %z16.s %p5 -> (%z18.s,%x18)[16byte]
+e4d43671 : stnt1h z17.s, p5, [z19.s, x20]            : stnt1h %z17.s %p5 -> (%z19.s,%x20)[16byte]
+e4d636b3 : stnt1h z19.s, p5, [z21.s, x22]            : stnt1h %z19.s %p5 -> (%z21.s,%x22)[16byte]
+e4d83af5 : stnt1h z21.s, p6, [z23.s, x24]            : stnt1h %z21.s %p6 -> (%z23.s,%x24)[16byte]
+e4d93b37 : stnt1h z23.s, p6, [z25.s, x25]            : stnt1h %z23.s %p6 -> (%z25.s,%x25)[16byte]
+e4db3f79 : stnt1h z25.s, p7, [z27.s, x27]            : stnt1h %z25.s %p7 -> (%z27.s,%x27)[16byte]
+e4dd3fbb : stnt1h z27.s, p7, [z29.s, x29]            : stnt1h %z27.s %p7 -> (%z29.s,%x29)[16byte]
+e4de3fff : stnt1h z31.s, p7, [z31.s, x30]            : stnt1h %z31.s %p7 -> (%z31.s,%x30)[16byte]
+
+# STNT1W  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] (STNT1W-Z.P.AR-D.64.unscaled)
+e5002000 : stnt1w z0.d, p0, [z0.d, x0]               : stnt1w %z0.d %p0 -> (%z0.d,%x0)[16byte]
+e5052482 : stnt1w z2.d, p1, [z4.d, x5]               : stnt1w %z2.d %p1 -> (%z4.d,%x5)[16byte]
+e50728c4 : stnt1w z4.d, p2, [z6.d, x7]               : stnt1w %z4.d %p2 -> (%z6.d,%x7)[16byte]
+e5092906 : stnt1w z6.d, p2, [z8.d, x9]               : stnt1w %z6.d %p2 -> (%z8.d,%x9)[16byte]
+e50b2d48 : stnt1w z8.d, p3, [z10.d, x11]             : stnt1w %z8.d %p3 -> (%z10.d,%x11)[16byte]
+e50c2d8a : stnt1w z10.d, p3, [z12.d, x12]            : stnt1w %z10.d %p3 -> (%z12.d,%x12)[16byte]
+e50e31cc : stnt1w z12.d, p4, [z14.d, x14]            : stnt1w %z12.d %p4 -> (%z14.d,%x14)[16byte]
+e510320e : stnt1w z14.d, p4, [z16.d, x16]            : stnt1w %z14.d %p4 -> (%z16.d,%x16)[16byte]
+e5123650 : stnt1w z16.d, p5, [z18.d, x18]            : stnt1w %z16.d %p5 -> (%z18.d,%x18)[16byte]
+e5143671 : stnt1w z17.d, p5, [z19.d, x20]            : stnt1w %z17.d %p5 -> (%z19.d,%x20)[16byte]
+e51636b3 : stnt1w z19.d, p5, [z21.d, x22]            : stnt1w %z19.d %p5 -> (%z21.d,%x22)[16byte]
+e5183af5 : stnt1w z21.d, p6, [z23.d, x24]            : stnt1w %z21.d %p6 -> (%z23.d,%x24)[16byte]
+e5193b37 : stnt1w z23.d, p6, [z25.d, x25]            : stnt1w %z23.d %p6 -> (%z25.d,%x25)[16byte]
+e51b3f79 : stnt1w z25.d, p7, [z27.d, x27]            : stnt1w %z25.d %p7 -> (%z27.d,%x27)[16byte]
+e51d3fbb : stnt1w z27.d, p7, [z29.d, x29]            : stnt1w %z27.d %p7 -> (%z29.d,%x29)[16byte]
+e51e3fff : stnt1w z31.d, p7, [z31.d, x30]            : stnt1w %z31.d %p7 -> (%z31.d,%x30)[16byte]
+
+# STNT1W  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}] (STNT1W-Z.P.AR-S.x32.unscaled)
+e5402000 : stnt1w z0.s, p0, [z0.s, x0]               : stnt1w %z0.s %p0 -> (%z0.s,%x0)[32byte]
+e5452482 : stnt1w z2.s, p1, [z4.s, x5]               : stnt1w %z2.s %p1 -> (%z4.s,%x5)[32byte]
+e54728c4 : stnt1w z4.s, p2, [z6.s, x7]               : stnt1w %z4.s %p2 -> (%z6.s,%x7)[32byte]
+e5492906 : stnt1w z6.s, p2, [z8.s, x9]               : stnt1w %z6.s %p2 -> (%z8.s,%x9)[32byte]
+e54b2d48 : stnt1w z8.s, p3, [z10.s, x11]             : stnt1w %z8.s %p3 -> (%z10.s,%x11)[32byte]
+e54c2d8a : stnt1w z10.s, p3, [z12.s, x12]            : stnt1w %z10.s %p3 -> (%z12.s,%x12)[32byte]
+e54e31cc : stnt1w z12.s, p4, [z14.s, x14]            : stnt1w %z12.s %p4 -> (%z14.s,%x14)[32byte]
+e550320e : stnt1w z14.s, p4, [z16.s, x16]            : stnt1w %z14.s %p4 -> (%z16.s,%x16)[32byte]
+e5523650 : stnt1w z16.s, p5, [z18.s, x18]            : stnt1w %z16.s %p5 -> (%z18.s,%x18)[32byte]
+e5543671 : stnt1w z17.s, p5, [z19.s, x20]            : stnt1w %z17.s %p5 -> (%z19.s,%x20)[32byte]
+e55636b3 : stnt1w z19.s, p5, [z21.s, x22]            : stnt1w %z19.s %p5 -> (%z21.s,%x22)[32byte]
+e5583af5 : stnt1w z21.s, p6, [z23.s, x24]            : stnt1w %z21.s %p6 -> (%z23.s,%x24)[32byte]
+e5593b37 : stnt1w z23.s, p6, [z25.s, x25]            : stnt1w %z23.s %p6 -> (%z25.s,%x25)[32byte]
+e55b3f79 : stnt1w z25.s, p7, [z27.s, x27]            : stnt1w %z25.s %p7 -> (%z27.s,%x27)[32byte]
+e55d3fbb : stnt1w z27.s, p7, [z29.s, x29]            : stnt1w %z27.s %p7 -> (%z29.s,%x29)[32byte]
+e55e3fff : stnt1w z31.s, p7, [z31.s, x30]            : stnt1w %z31.s %p7 -> (%z31.s,%x30)[32byte]
 
 # SUBHNB  <Zd>.<T>, <Zn>.<Tb>, <Zm>.<Tb> (SUBHNB-Z.ZZ-_)
 45607000 : subhnb z0.b, z0.h, z0.h                   : subhnb %z0.h %z0.h -> %z0.b

--- a/suite/tests/api/ir_aarch64_sve2.c
+++ b/suite/tests/api/ir_aarch64_sve2.c
@@ -8359,6 +8359,262 @@ TEST_INSTR(whilewr_sve)
               opnd_create_reg_element_vector(Pn_six_offset_0[i], OPSZ_8),
               opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
 }
+
+TEST_INSTR(ldnt1b_sve_pred)
+{
+
+    /* Testing LDNT1B  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "ldnt1b (%z0.d,%x0)[4byte] %p0/z -> %z0.d",
+        "ldnt1b (%z7.d,%x8)[4byte] %p2/z -> %z5.d",
+        "ldnt1b (%z12.d,%x13)[4byte] %p3/z -> %z10.d",
+        "ldnt1b (%z18.d,%x18)[4byte] %p5/z -> %z16.d",
+        "ldnt1b (%z23.d,%x23)[4byte] %p6/z -> %z21.d",
+        "ldnt1b (%z31.d,%x30)[4byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldnt1b, ldnt1b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_4, 0));
+
+    /* Testing LDNT1B  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "ldnt1b (%z0.s,%x0)[8byte] %p0/z -> %z0.s",
+        "ldnt1b (%z7.s,%x8)[8byte] %p2/z -> %z5.s",
+        "ldnt1b (%z12.s,%x13)[8byte] %p3/z -> %z10.s",
+        "ldnt1b (%z18.s,%x18)[8byte] %p5/z -> %z16.s",
+        "ldnt1b (%z23.s,%x23)[8byte] %p6/z -> %z21.s",
+        "ldnt1b (%z31.s,%x30)[8byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldnt1b, ldnt1b_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_8, 0));
+}
+
+TEST_INSTR(ldnt1d_sve_pred)
+{
+
+    /* Testing LDNT1D  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "ldnt1d (%z0.d,%x0)[32byte] %p0/z -> %z0.d",
+        "ldnt1d (%z7.d,%x8)[32byte] %p2/z -> %z5.d",
+        "ldnt1d (%z12.d,%x13)[32byte] %p3/z -> %z10.d",
+        "ldnt1d (%z18.d,%x18)[32byte] %p5/z -> %z16.d",
+        "ldnt1d (%z23.d,%x23)[32byte] %p6/z -> %z21.d",
+        "ldnt1d (%z31.d,%x30)[32byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldnt1d, ldnt1d_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_32, 0));
+}
+
+TEST_INSTR(ldnt1h_sve_pred)
+{
+
+    /* Testing LDNT1H  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "ldnt1h (%z0.d,%x0)[8byte] %p0/z -> %z0.d",
+        "ldnt1h (%z7.d,%x8)[8byte] %p2/z -> %z5.d",
+        "ldnt1h (%z12.d,%x13)[8byte] %p3/z -> %z10.d",
+        "ldnt1h (%z18.d,%x18)[8byte] %p5/z -> %z16.d",
+        "ldnt1h (%z23.d,%x23)[8byte] %p6/z -> %z21.d",
+        "ldnt1h (%z31.d,%x30)[8byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldnt1h, ldnt1h_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_8, 0));
+
+    /* Testing LDNT1H  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "ldnt1h (%z0.s,%x0)[16byte] %p0/z -> %z0.s",
+        "ldnt1h (%z7.s,%x8)[16byte] %p2/z -> %z5.s",
+        "ldnt1h (%z12.s,%x13)[16byte] %p3/z -> %z10.s",
+        "ldnt1h (%z18.s,%x18)[16byte] %p5/z -> %z16.s",
+        "ldnt1h (%z23.s,%x23)[16byte] %p6/z -> %z21.s",
+        "ldnt1h (%z31.s,%x30)[16byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldnt1h, ldnt1h_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_16, 0));
+}
+
+TEST_INSTR(ldnt1w_sve_pred)
+{
+
+    /* Testing LDNT1W  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "ldnt1w (%z0.d,%x0)[16byte] %p0/z -> %z0.d",
+        "ldnt1w (%z7.d,%x8)[16byte] %p2/z -> %z5.d",
+        "ldnt1w (%z12.d,%x13)[16byte] %p3/z -> %z10.d",
+        "ldnt1w (%z18.d,%x18)[16byte] %p5/z -> %z16.d",
+        "ldnt1w (%z23.d,%x23)[16byte] %p6/z -> %z21.d",
+        "ldnt1w (%z31.d,%x30)[16byte] %p7/z -> %z31.d",
+    };
+    TEST_LOOP(ldnt1w, ldnt1w_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_16, 0));
+
+    /* Testing LDNT1W  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "ldnt1w (%z0.s,%x0)[32byte] %p0/z -> %z0.s",
+        "ldnt1w (%z7.s,%x8)[32byte] %p2/z -> %z5.s",
+        "ldnt1w (%z12.s,%x13)[32byte] %p3/z -> %z10.s",
+        "ldnt1w (%z18.s,%x18)[32byte] %p5/z -> %z16.s",
+        "ldnt1w (%z23.s,%x23)[32byte] %p6/z -> %z21.s",
+        "ldnt1w (%z31.s,%x30)[32byte] %p7/z -> %z31.s",
+    };
+    TEST_LOOP(ldnt1w, ldnt1w_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_predicate_reg(Pn_half_six_offset_0[i], false),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_32, 0));
+}
+
+TEST_INSTR(stnt1b_sve_pred)
+{
+
+    /* Testing STNT1B  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "stnt1b %z0.d %p0 -> (%z0.d,%x0)[4byte]",
+        "stnt1b %z5.d %p2 -> (%z7.d,%x8)[4byte]",
+        "stnt1b %z10.d %p3 -> (%z12.d,%x13)[4byte]",
+        "stnt1b %z16.d %p5 -> (%z18.d,%x18)[4byte]",
+        "stnt1b %z21.d %p6 -> (%z23.d,%x23)[4byte]",
+        "stnt1b %z31.d %p7 -> (%z31.d,%x30)[4byte]",
+    };
+    TEST_LOOP(stnt1b, stnt1b_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_4, 0));
+
+    /* Testing STNT1B  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "stnt1b %z0.s %p0 -> (%z0.s,%x0)[8byte]",
+        "stnt1b %z5.s %p2 -> (%z7.s,%x8)[8byte]",
+        "stnt1b %z10.s %p3 -> (%z12.s,%x13)[8byte]",
+        "stnt1b %z16.s %p5 -> (%z18.s,%x18)[8byte]",
+        "stnt1b %z21.s %p6 -> (%z23.s,%x23)[8byte]",
+        "stnt1b %z31.s %p7 -> (%z31.s,%x30)[8byte]",
+    };
+    TEST_LOOP(stnt1b, stnt1b_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_8, 0));
+}
+
+TEST_INSTR(stnt1d_sve_pred)
+{
+
+    /* Testing STNT1D  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "stnt1d %z0.d %p0 -> (%z0.d,%x0)[32byte]",
+        "stnt1d %z5.d %p2 -> (%z7.d,%x8)[32byte]",
+        "stnt1d %z10.d %p3 -> (%z12.d,%x13)[32byte]",
+        "stnt1d %z16.d %p5 -> (%z18.d,%x18)[32byte]",
+        "stnt1d %z21.d %p6 -> (%z23.d,%x23)[32byte]",
+        "stnt1d %z31.d %p7 -> (%z31.d,%x30)[32byte]",
+    };
+    TEST_LOOP(stnt1d, stnt1d_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_32, 0));
+}
+
+TEST_INSTR(stnt1h_sve_pred)
+{
+
+    /* Testing STNT1H  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "stnt1h %z0.d %p0 -> (%z0.d,%x0)[8byte]",
+        "stnt1h %z5.d %p2 -> (%z7.d,%x8)[8byte]",
+        "stnt1h %z10.d %p3 -> (%z12.d,%x13)[8byte]",
+        "stnt1h %z16.d %p5 -> (%z18.d,%x18)[8byte]",
+        "stnt1h %z21.d %p6 -> (%z23.d,%x23)[8byte]",
+        "stnt1h %z31.d %p7 -> (%z31.d,%x30)[8byte]",
+    };
+    TEST_LOOP(stnt1h, stnt1h_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_8, 0));
+
+    /* Testing STNT1H  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "stnt1h %z0.s %p0 -> (%z0.s,%x0)[16byte]",
+        "stnt1h %z5.s %p2 -> (%z7.s,%x8)[16byte]",
+        "stnt1h %z10.s %p3 -> (%z12.s,%x13)[16byte]",
+        "stnt1h %z16.s %p5 -> (%z18.s,%x18)[16byte]",
+        "stnt1h %z21.s %p6 -> (%z23.s,%x23)[16byte]",
+        "stnt1h %z31.s %p7 -> (%z31.s,%x30)[16byte]",
+    };
+    TEST_LOOP(stnt1h, stnt1h_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_16, 0));
+}
+
+TEST_INSTR(stnt1w_sve_pred)
+{
+
+    /* Testing STNT1W  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}] */
+    const char *const expected_0_0[6] = {
+        "stnt1w %z0.d %p0 -> (%z0.d,%x0)[16byte]",
+        "stnt1w %z5.d %p2 -> (%z7.d,%x8)[16byte]",
+        "stnt1w %z10.d %p3 -> (%z12.d,%x13)[16byte]",
+        "stnt1w %z16.d %p5 -> (%z18.d,%x18)[16byte]",
+        "stnt1w %z21.d %p6 -> (%z23.d,%x23)[16byte]",
+        "stnt1w %z31.d %p7 -> (%z31.d,%x30)[16byte]",
+    };
+    TEST_LOOP(stnt1w, stnt1w_sve_pred, 6, expected_0_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_8),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_8, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_16, 0));
+
+    /* Testing STNT1W  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}] */
+    const char *const expected_1_0[6] = {
+        "stnt1w %z0.s %p0 -> (%z0.s,%x0)[32byte]",
+        "stnt1w %z5.s %p2 -> (%z7.s,%x8)[32byte]",
+        "stnt1w %z10.s %p3 -> (%z12.s,%x13)[32byte]",
+        "stnt1w %z16.s %p5 -> (%z18.s,%x18)[32byte]",
+        "stnt1w %z21.s %p6 -> (%z23.s,%x23)[32byte]",
+        "stnt1w %z31.s %p7 -> (%z31.s,%x30)[32byte]",
+    };
+    TEST_LOOP(stnt1w, stnt1w_sve_pred, 6, expected_1_0[i],
+              opnd_create_reg_element_vector(Zn_six_offset_0[i], OPSZ_4),
+              opnd_create_reg(Pn_half_six_offset_0[i]),
+              opnd_create_vector_base_disp_aarch64(Zn_six_offset_2[i], Xn_six_offset_3[i],
+                                                   OPSZ_4, DR_EXTEND_UXTX, 0, 0, 0,
+                                                   OPSZ_32, 0));
+}
 int
 main(int argc, char *argv[])
 {
@@ -8602,6 +8858,15 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(whilehs_sve);
     RUN_INSTR_TEST(whilerw_sve);
     RUN_INSTR_TEST(whilewr_sve);
+
+    RUN_INSTR_TEST(ldnt1b_sve_pred);
+    RUN_INSTR_TEST(ldnt1d_sve_pred);
+    RUN_INSTR_TEST(ldnt1h_sve_pred);
+    RUN_INSTR_TEST(ldnt1w_sve_pred);
+    RUN_INSTR_TEST(stnt1b_sve_pred);
+    RUN_INSTR_TEST(stnt1d_sve_pred);
+    RUN_INSTR_TEST(stnt1h_sve_pred);
+    RUN_INSTR_TEST(stnt1w_sve_pred);
 
     print("All SVE2 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
    LDNT1B  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
    LDNT1D  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
    LDNT1H  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
    LDNT1W  { <Zt>.D }, <Pg>/Z, [<Zn>.D{, <Xm>}]
    STNT1B  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
    STNT1D  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
    STNT1H  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
    STNT1W  { <Zt>.D }, <Pg>, [<Zn>.D{, <Xm>}]
    LDNT1B  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
    LDNT1H  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
    LDNT1W  { <Zt>.S }, <Pg>/Z, [<Zn>.S{, <Xm>}]
    STNT1B  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}]
    STNT1H  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}]
    STNT1W  { <Zt>.S }, <Pg>, [<Zn>.S{, <Xm>}]
```
issue: #3044