### PR TITLE
i#3544 RV64: Fix CI rsync issue

### DIFF
--- a/.github/workflows/ci-riscv64.yml
+++ b/.github/workflows/ci-riscv64.yml
@@ -85,7 +85,9 @@ jobs:
         for i in *.deb; do dpkg-deb -x $i ../extract; done
         for i in include lib; do sudo rsync -av ../extract/usr/${i}/riscv64-linux-gnu/ /usr/riscv64-linux-gnu/${i}/; done
         sudo rsync -av ../extract/usr/include/ /usr/riscv64-linux-gnu/include/
-        sudo rsync -av ../extract/lib/riscv64-linux-gnu/ /usr/riscv64-linux-gnu/lib/
+        if test -e "../extract/lib/riscv64-linux-gnu/"; then \
+          sudo rsync -av ../extract/lib/riscv64-linux-gnu/ /usr/riscv64-linux-gnu/lib/; \
+        fi
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}


### PR DESCRIPTION
Adds a check for the existence of a package install dir when manually copying packages for the cross-compile setup as it seems to not be present in newer versions of the packages.

Issue: #3544