### PR TITLE
i#5365 Fix some tests which fail when build with -O3

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -501,13 +501,13 @@ set(sve_tests
       client.null_instrument client.large_options client.stolen-reg-index
       client.gonative client.drmgr-test client.drx_buf-test
       client.drbbdup-drwrap-test client.drbbdup-emul-test client.process-id
-      client.drreg-test client.low_on_memory client.tls client.drx-scattergather
-      client.drwrap-test client.drwrap-drreg-test drstatecmp-fuzz-app
-      client.drutil-test client.stolen-reg client.ldstex api.dis-a64 api.reenc-a64
-      api.opnd api.detach api.detach_state api.detach_signal api.detach_spawn
-      api.detach_spawn_stress_FLAKY api.detach_spawn_quick_exit api.ibl-stress
-      api.ibl-stress-aarch64-far-link_LONG api.static_startstop api.static_noclient
-      api.static_noinit api.static_detach api.static_prepop
+      client.drreg-test client.low_on_memory client.tls client.drwrap-test
+      client.drwrap-drreg-test drstatecmp-fuzz-app client.drutil-test client.stolen-reg
+      client.ldstex client.drsyms-test client.drwrap-test-detach api.dis-a64
+      api.reenc-a64 api.opnd api.detach api.detach_state api.detach_signal
+      api.detach_spawn api.detach_spawn_stress_FLAKY api.detach_spawn_quick_exit
+      api.ibl-stress api.ibl-stress-aarch64-far-link_LONG api.static_startstop
+      api.static_noclient api.static_noinit api.static_detach api.static_prepop
       api.static_reattach_client_flags api.static_crash api.static_sideline_FLAKY
       api.static_symbols api.static_maps_mixup_yesvars
       api.static_maps_mixup_novars_FLAKY api.thread_churn client.app_args

--- a/suite/tests/client-interface/drsyms-test.cpp
+++ b/suite/tests/client-interface/drsyms-test.cpp
@@ -77,7 +77,7 @@ Foo::Bar(int a)
     return dll_export(a + 1);
 }
 
-extern "C" EXPORT int
+extern "C" EXPORT int NOINLINE
 exe_export(int a)
 {
     Foo f;

--- a/suite/tests/client-interface/drwrap-test-detach.cpp
+++ b/suite/tests/client-interface/drwrap-test-detach.cpp
@@ -61,7 +61,7 @@ static int pre_count;
 static int post_count;
 
 extern "C" { /* Make it easy to get the name across platforms. */
-EXPORT void
+EXPORT void NOINLINE
 wrapped_subfunc(void)
 {
 #ifdef LINUX


### PR DESCRIPTION
- client.drsyms-test and client.drwrap-test-detach: The tests expect to observe a certain function call a certain sub-function but it doesn't happen when built with optimisation on because the sub-function gets inlined. This is fixed by marking the sub-functions as NOINLINE.

- client.drx-scattergather and client.drx-scattergather-bbdup: The test clients used with these tests count the number of scatter/gather instructions that are expanded and print the number at the end of the test, which gets checked against a reference value. Building the test app with -O3 causes some code to be auto vectorized so there are additional scatter/gather instructions which throws off the count. I removed this tests from the sve_tests list so it won't be built with -O3.

Issue: #5365