### PR TITLE
i#3544 RV64: Enable sample.bbbuf test

### DIFF
--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -35,10 +35,6 @@ if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
   set(DEBUG ON)
 endif ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
 
-if (RISCV64) # TODO i#3544: Port tests to RISC-V 64
-  return()
-endif (RISCV64)
-
 # To match Makefiles and have just one build type per configured build
 # dir, we collapse VS generator configs to a single choice.
 # This must be done prior to the project() command and the var

--- a/api/samples/bbbuf.c
+++ b/api/samples/bbbuf.c
@@ -64,7 +64,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
 {
     app_pc pc = dr_fragment_app_pc(tag);
     reg_id_t reg;
-    /* We need a 2nd scratch reg for several operations on AArch32 and AArch64 only. */
+    /* We need a 2nd scratch reg for several operations on AArchXX and RISCV64. */
     reg_id_t reg2 = DR_REG_NULL;
 
     /* By default drmgr enables auto-predication, which predicates all instructions with
@@ -84,9 +84,9 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
         return DR_EMIT_DEFAULT;
     }
 
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
     /* We need a second register here, because the drx_buf routines need a scratch reg
-     * for AArch32 and AArch64.
+     * for AArchXX and RISCV64.
      */
     if (drreg_reserve_register(drcontext, bb, inst, NULL, &reg2) != DRREG_SUCCESS) {
         DR_ASSERT(false); /* cannot recover */
@@ -109,7 +109,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     if (drreg_unreserve_register(drcontext, bb, inst, reg) != DRREG_SUCCESS)
         DR_ASSERT(false);
 
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
     if (drreg_unreserve_register(drcontext, bb, inst, reg2) != DRREG_SUCCESS)
         DR_ASSERT(false);
 #endif

--- a/core/arch/riscv64/mangle.c
+++ b/core/arch/riscv64/mangle.c
@@ -89,8 +89,11 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                           opnd_add_flags(opnd_create_immed_int(-max_offs, OPSZ_12b),
                                          DR_OPND_IMM_PRINT_DECIMAL)));
 
+    /* Skip X0 slot. */
+    dstack_offs += XSP_SZ;
+
     /* Push GPRs. */
-    for (int i = 1; i < DR_NUM_GPR_REGS; i++) {
+    for (int i = 0; i < DR_NUM_GPR_REGS; i++) {
         if (cci->reg_skip[i])
             continue;
 
@@ -100,7 +103,7 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                 opnd_add_flags(opnd_create_base_disp(DR_REG_SP, DR_REG_NULL, 0,
                                                      dstack_offs + i * XSP_SZ, OPSZ_8),
                                DR_OPND_IMM_PRINT_DECIMAL),
-                opnd_create_reg(DR_REG_ZERO + i)));
+                opnd_create_reg(DR_REG_START_GPR + i)));
     }
 
     dstack_offs += DR_NUM_GPR_REGS * XSP_SZ;
@@ -197,13 +200,13 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
     current_offs -= DR_NUM_GPR_REGS * XSP_SZ;
 
     /* Pop GPRs. */
-    for (int i = 1; i < DR_NUM_GPR_REGS; i++) {
+    for (int i = 0; i < DR_NUM_GPR_REGS; i++) {
         if (cci->reg_skip[i])
             continue;
 
         PRE(ilist, instr,
             INSTR_CREATE_ld(
-                dcontext, opnd_create_reg(DR_REG_X0 + i),
+                dcontext, opnd_create_reg(DR_REG_START_GPR + i),
                 opnd_add_flags(opnd_create_base_disp(DR_REG_SP, DR_REG_NULL, 0,
                                                      current_offs + i * XSP_SZ, OPSZ_8),
                                DR_OPND_IMM_PRINT_DECIMAL)));

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1284,11 +1284,11 @@ enum {
     DR_REG_LAST_VALID_ENUM = DR_REG_FCSR, /**< Last valid register enum. */
     DR_REG_LAST_ENUM = DR_REG_FCSR,       /**< Last value of register enums. */
 
-    DR_REG_START_64 = DR_REG_X0,  /**< Start of 64-bit register enum values. */
+    DR_REG_START_64 = DR_REG_X1,  /**< Start of 64-bit register enum values. */
     DR_REG_STOP_64 = DR_REG_F31,  /**< End of 64-bit register enum values. */
-    DR_REG_START_32 = DR_REG_X0,  /**< Start of 32-bit register enum values. */
+    DR_REG_START_32 = DR_REG_X1,  /**< Start of 32-bit register enum values. */
     DR_REG_STOP_32 = DR_REG_F31,  /**< End of 32-bit register enum values. */
-    DR_REG_START_GPR = DR_REG_X0, /**< Start of general registers. */
+    DR_REG_START_GPR = DR_REG_X1, /**< Start of general registers. */
     DR_REG_STOP_GPR = DR_REG_X31, /**< End of general registers. */
     DR_REG_START_FPR = DR_REG_F0, /**< Start of floating-point registers. */
     DR_REG_STOP_FPR = DR_REG_F31, /**< End of floating-point registers. */

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2772,6 +2772,9 @@ reg_get_size(reg_id_t reg)
 #    endif
     if (reg == DR_REG_TPIDRURW || reg == DR_REG_TPIDRURO)
         return OPSZ_PTR;
+#elif defined(RISCV64)
+    if (reg == DR_REG_X0)
+        return OPSZ_8;
 #endif
     LOG(GLOBAL, LOG_ANNOTATIONS, 2, "reg=%d, %s, last reg=%d\n", reg,
         get_register_name(reg), DR_REG_LAST_ENUM);

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -997,7 +997,8 @@ drreg_reserve_reg_internal(void *drcontext, instrlist_t *ilist, instr_t *where,
             if (pt->reg[idx].in_use)
                 continue;
             if (reg ==
-                dr_get_stolen_reg() IF_ARM(|| reg == DR_REG_PC) IF_RISCV64(|| reg == DR_REG_TP)
+                dr_get_stolen_reg() IF_ARM(|| reg == DR_REG_PC)
+                    IF_RISCV64(|| reg == DR_REG_TP)
                 /* Avoid xsp, even if it appears dead in things like OP_sysenter.
                  * On AArch64 use of SP is very restricted.
                  */

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -997,7 +997,7 @@ drreg_reserve_reg_internal(void *drcontext, instrlist_t *ilist, instr_t *where,
             if (pt->reg[idx].in_use)
                 continue;
             if (reg ==
-                dr_get_stolen_reg() IF_ARM(|| reg == DR_REG_PC)
+                dr_get_stolen_reg() IF_ARM(|| reg == DR_REG_PC) IF_RISCV64(|| reg == DR_REG_TP)
                 /* Avoid xsp, even if it appears dead in things like OP_sysenter.
                  * On AArch64 use of SP is very restricted.
                  */

--- a/ext/drx/drx_buf.c
+++ b/ext/drx/drx_buf.c
@@ -439,7 +439,7 @@ drx_buf_insert_update_buf_ptr_2byte(void *drcontext, drx_buf_t *buf, instrlist_t
             XINST_CREATE_store_2bytes(drcontext,
                                       OPND_CREATE_MEM16(buf->tls_seg, buf->tls_offs),
                                       opnd_create_reg(buf_ptr)));
-#elif defined(AARCH64)
+#elif defined(AARCH64) || defined(RISCV64)
     if (stride > 0xfff) {
         /* Fall back to XINST_CREATE_load_int() if stride has more than 12 bits.
          * Another possibility, avoiding a scratch register, would be:
@@ -461,9 +461,6 @@ drx_buf_insert_update_buf_ptr_2byte(void *drcontext, drx_buf_t *buf, instrlist_t
             XINST_CREATE_store_2bytes(drcontext,
                                       OPND_CREATE_MEM16(buf->tls_seg, buf->tls_offs),
                                       opnd_create_reg(reg_64_to_32(buf_ptr))));
-#elif defined(RISCV64)
-    /* FIXME i#3544: Not implemented */
-    DR_ASSERT_MSG(false, "Not implemented");
 #else
 #    error NYI
 #endif
@@ -493,16 +490,12 @@ drx_buf_insert_buf_store_1byte(void *drcontext, drx_buf_t *buf, instrlist_t *ili
 #ifdef X86
         instr =
             XINST_CREATE_store_1byte(drcontext, OPND_CREATE_MEM8(buf_ptr, offset), opnd);
-#elif defined(AARCHXX)
+#elif defined(AARCHXX) || defined(RISCV64)
         /* this will certainly not fault, so don't set a translation */
         MINSERT(ilist, where,
                 XINST_CREATE_load_int(drcontext, opnd_create_reg(scratch), opnd));
         instr = XINST_CREATE_store_1byte(drcontext, OPND_CREATE_MEM8(buf_ptr, offset),
                                          opnd_create_reg(scratch));
-#elif defined(RISCV64)
-        /* FIXME i#3544: Not implemented */
-        DR_ASSERT_MSG(false, "Not implemented");
-        return false;
 #else
 #    error NYI
 #endif
@@ -527,16 +520,12 @@ drx_buf_insert_buf_store_2bytes(void *drcontext, drx_buf_t *buf, instrlist_t *il
 #ifdef X86
         instr = XINST_CREATE_store_2bytes(drcontext, OPND_CREATE_MEM16(buf_ptr, offset),
                                           opnd);
-#elif defined(AARCHXX)
+#elif defined(AARCHXX) || defined(RISCV64)
         /* this will certainly not fault, so don't set a translation */
         MINSERT(ilist, where,
                 XINST_CREATE_load_int(drcontext, opnd_create_reg(scratch), opnd));
         instr = XINST_CREATE_store_2bytes(drcontext, OPND_CREATE_MEM16(buf_ptr, offset),
                                           opnd_create_reg(scratch));
-#elif defined(RISCV64)
-        /* FIXME i#3544: Not implemented */
-        DR_ASSERT_MSG(false, "Not implemented");
-        return false;
 #else
 #    error NYI
 #endif
@@ -549,7 +538,7 @@ drx_buf_insert_buf_store_2bytes(void *drcontext, drx_buf_t *buf, instrlist_t *il
     return true;
 }
 
-#if defined(X86_64) || defined(AARCH64)
+#if defined(X86_64) || defined(AARCH64) || defined(RISCV64)
 /* only valid on platforms where OPSZ_PTR != OPSZ_4 */
 static bool
 drx_buf_insert_buf_store_4bytes(void *drcontext, drx_buf_t *buf, instrlist_t *ilist,
@@ -562,7 +551,7 @@ drx_buf_insert_buf_store_4bytes(void *drcontext, drx_buf_t *buf, instrlist_t *il
     if (opnd_is_immed(opnd)) {
 #    ifdef X86_64
         instr = XINST_CREATE_store(drcontext, OPND_CREATE_MEM32(buf_ptr, offset), opnd);
-#    elif defined(AARCH64)
+#    elif defined(AARCH64) || defined(RISCV64)
         /* this will certainly not fault, so don't set a translation */
         instrlist_insert_mov_immed_ptrsz(drcontext, opnd_get_immed_int(opnd),
                                          opnd_create_reg(scratch), ilist, where, NULL,
@@ -631,7 +620,7 @@ drx_buf_insert_buf_store(void *drcontext, drx_buf_t *buf, instrlist_t *ilist,
     case OPSZ_2:
         return drx_buf_insert_buf_store_2bytes(drcontext, buf, ilist, where, buf_ptr,
                                                scratch, opnd, offset);
-#if defined(X86_64) || defined(AARCH64)
+#if defined(X86_64) || defined(AARCH64) || defined(RISCV64)
     case OPSZ_4:
         return drx_buf_insert_buf_store_4bytes(drcontext, buf, ilist, where, buf_ptr,
                                                scratch, opnd, offset);

--- a/ext/drx/drx_buf.c
+++ b/ext/drx/drx_buf.c
@@ -598,7 +598,7 @@ drx_buf_insert_buf_store_ptrsz(void *drcontext, drx_buf_t *buf, instrlist_t *ili
             if (last == NULL || first == last)
                 break;
         }
-#elif defined(AARCHXX)
+#elif defined(AARCHXX) || defined(RISCV64)
         instr_t *instr;
         instrlist_insert_mov_immed_ptrsz(drcontext, immed, opnd_create_reg(scratch),
                                          ilist, where, &first, &last);
@@ -606,14 +606,6 @@ drx_buf_insert_buf_store_ptrsz(void *drcontext, drx_buf_t *buf, instrlist_t *ili
                                    opnd_create_reg(scratch));
         INSTR_XL8(instr, instr_get_app_pc(where));
         MINSERT(ilist, where, instr);
-#elif defined(RISCV64)
-        /* FIXME i#3544: Not implemented */
-        DR_ASSERT_MSG(false, "Not implemented");
-        /* Marking as unused to silence -Wunused-variable. */
-        (void)first;
-        (void)last;
-        (void)immed;
-        return false;
 #else
 #    error NYI
 #endif

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5911,9 +5911,7 @@ if (RISCV64)
     code_api|linux.infinite
     code_api|linux.longjmp
     code_api|linux.prctl
-    code_api|linux.sigaction_nosignals
     code_api|linux.signalfd
-    code_api|pthreads.pthreads
     code_api|pthreads.pthreads_exit
     code_api|sample.bbbuf
     code_api|security-linux.trampoline

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2135,10 +2135,11 @@ if (X86)
   set(control_flags "eflags")
 elseif (AARCHXX)
   set(control_flags "nzcv")
+elseif (RISCV64)
+  # XXX: RISC-V does not have control flags, so a dummy test is used.
+  set(control_flags "hello")
 endif ()
-if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
-  tobuild(common.${control_flags} common/${control_flags}.c)
-endif ()
+tobuild(common.${control_flags} common/${control_flags}.c)
 
 if (X86) # FIXME i#1551, i#1569: port asm to ARM and AArch64
   tobuild(common.floatpc common/floatpc.c)
@@ -5914,6 +5915,7 @@ if (RISCV64)
     code_api|linux.signalfd
     code_api|pthreads.pthreads
     code_api|pthreads.pthreads_exit
+    code_api|sample.bbbuf
     code_api|security-linux.trampoline
     no_code_api,no_intercept_all_signals|linux.sigaction
     PROPERTIES LABELS RUNS_ON_QEMU)


### PR DESCRIPTION
This patch enables sample.bbbuf test with the following fixes:

- x0 on RISC-V is like XZR on AArch64, so do not consider it as a general register
- tp should be avoided in `drreg_reserve_reg_internal()`
- RISC-V does not have control flags, so a dummy hello test is used for `control_flags` instead

Also removed `linux.sigaction_nosignals` and `pthreads.pthreads` from `RUNS_ON_QEMU` since they are not working on real hardware.

#3544