### PR TITLE
i#6471 sched idle: Add idle time from blocking syscalls

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -259,6 +259,7 @@ analyzer_multi_t::init_dynamic_schedule()
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
     sched_ops.syscall_switch_threshold = op_sched_syscall_switch_us.get_value();
     sched_ops.blocking_switch_threshold = op_sched_blocking_switch_us.get_value();
+    sched_ops.block_time_scale = op_sched_block_scale.get_value();
 #ifdef HAS_ZIP
     if (!op_record_file.get_value().empty()) {
         record_schedule_zip_.reset(new zipfile_ostream_t(op_record_file.get_value()));

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -851,6 +851,11 @@ droption_t<uint64_t> op_sched_blocking_switch_us(
     "maybe-blocking to incur a context switch. Applies to -core_sharded and "
     "-core_serial. ");
 
+droption_t<double>
+    op_sched_block_scale(DROPTION_SCOPE_ALL, "sched_block_scale", 1.,
+                         "Input block time scale factor",
+                         "A higher value here results in blocking syscalls "
+                         "keeping inputs unscheduled for longer.");
 #ifdef HAS_ZIP
 droption_t<std::string> op_record_file(DROPTION_SCOPE_FRONTEND, "record_file", "",
                                        "Path for storing record of schedule",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -193,6 +193,7 @@ extern dynamorio::droption::droption_t<bool> op_sched_time;
 extern dynamorio::droption::droption_t<bool> op_sched_order_time;
 extern dynamorio::droption::droption_t<uint64_t> op_sched_syscall_switch_us;
 extern dynamorio::droption::droption_t<uint64_t> op_sched_blocking_switch_us;
+extern dynamorio::droption::droption_t<double> op_sched_block_scale;
 #ifdef HAS_ZIP
 extern dynamorio::droption::droption_t<std::string> op_record_file;
 extern dynamorio::droption::droption_t<std::string> op_replay_file;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1582,20 +1582,6 @@ scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(input_info_t *input
 }
 
 template <typename RecordType, typename ReaderType>
-void
-scheduler_tmpl_t<RecordType, ReaderType>::print_ready_queue_stats()
-{
-    // NOCHECK want a heartbeat w/ key stats to understand muppet:
-    // # non-eof inputs (== queue size)
-    // # blocked inputs
-    //
-    // schedule_stats: # blocking syscalls (identify from latency or from cxt sw?)
-    //   and then instructions per blocking syscall
-    //
-    // muppet too many cxt sw
-}
-
-template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
     output_ordinal_t for_output, input_info_t *&new_input)

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2089,11 +2089,11 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
             uint64_t duration = outputs_[output]
                                     .record[outputs_[output].record_index]
                                     .value.idle_duration;
-            uint64_t cur_time = get_output_time(output);
-            if (cur_time - outputs_[output].wait_start_time < duration) {
+            uint64_t now = get_output_time(output);
+            if (now - outputs_[output].wait_start_time < duration) {
                 VPRINT(this, 4,
                        "next_record[%d]: elapsed %" PRIu64 " < duration %" PRIu64 "\n",
-                       output, cur_time - outputs_[output].wait_start_time, duration);
+                       output, now - outputs_[output].wait_start_time, duration);
                 return sched_type_t::STATUS_WAIT;
             } else
                 outputs_[output].wait_start_time = 0;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1360,9 +1360,6 @@ protected:
     stream_status_t
     pop_from_ready_queue(output_ordinal_t for_output, input_info_t *&new_input);
 
-    // sched_lock_ must be held by the caller.
-    void
-    print_ready_queue_stats();
     ///
     ///////////////////////////////////////////////////////////////////////////
 

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -527,10 +527,11 @@ public:
          * latency exceeds #syscall_switch_threshold or #blocking_switch_threshold.  A
          * "block time factor" is computed from the syscall latency divided by either
          * #syscall_switch_threshold or #blocking_switch_threshold.  This factor is
-         * multiplied by this field #block_time_scale.  For #QUANTUM_TIME, that amount of
-         * time, as reported by the time parameter to next_record(), must pass before the
-         * input is no longer considered blocked.  For instruction quanta, that count of
-         * scheduler selections must occur before the input is actually selected.
+         * multiplied by this field #block_time_scale to produce a final value.  For
+         * #QUANTUM_TIME, that final value's amount of time, as reported by the time
+         * parameter to next_record(), must pass before the input is no longer considered
+         * blocked.  For instruction quanta, that final value's count of scheduler
+         * selections must occur before the input is actually selected.
          */
         double block_time_scale = 1.;
     };

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -101,6 +101,11 @@ droption_t<bool> op_honor_stamps(DROPTION_SCOPE_ALL, "honor_stamps", true,
                                  "Whether to honor recorded timestamps for ordering",
                                  "Whether to honor recorded timestamps for ordering");
 
+droption_t<double> op_block_time_scale(DROPTION_SCOPE_ALL, "block_time_scale", 1.,
+                                       "Input block time scale factor",
+                                       "A higher value here results in blocking syscalls "
+                                       "keeping inputs unscheduled for longer.");
+
 #ifdef HAS_ZIP
 droption_t<std::string> op_record_file(DROPTION_SCOPE_FRONTEND, "record_file", "",
                                        "Path for storing record of schedule",
@@ -319,6 +324,7 @@ _tmain(int argc, const TCHAR *targv[])
     sched_ops.quantum_duration = op_sched_quantum.get_value();
     if (op_sched_time.get_value())
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+    sched_ops.block_time_scale = op_block_time_scale.get_value();
 #ifdef HAS_ZIP
     std::unique_ptr<zipfile_ostream_t> record_zip;
     std::unique_ptr<zipfile_istream_t> replay_zip;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -33,6 +33,7 @@
 #define NOMINMAX // Avoid windows.h messing up std::min.
 #undef NDEBUG
 #include <assert.h>
+#include <algorithm>
 #include <cstring>
 #include <iostream>
 #include <thread>
@@ -806,7 +807,7 @@ test_real_file_queries_and_filters(const char *testdir)
 // Assumes the input threads are all tid_base plus an offset < 26.
 static std::vector<std::string>
 run_lockstep_simulation(scheduler_t &scheduler, int num_outputs, memref_tid_t tid_base,
-                        bool send_time = false)
+                        bool send_time = false, bool print_markers = true)
 {
     // Walk the outputs in lockstep for crude but deterministic concurrency.
     std::vector<scheduler_t::stream_t *> outputs(num_outputs, nullptr);
@@ -816,6 +817,10 @@ run_lockstep_simulation(scheduler_t &scheduler, int num_outputs, memref_tid_t ti
     int num_eof = 0;
     // Record the threads, one char each.
     std::vector<std::string> sched_as_string(num_outputs);
+    static constexpr char THREAD_LETTER_START = 'A';
+    static constexpr char WAIT_SYMBOL = '-';
+    static constexpr char IDLE_SYMBOL = '_';
+    static constexpr char NON_INSTR_SYMBOL = '.';
     while (num_eof < num_outputs) {
         for (int i = 0; i < num_outputs; i++) {
             if (eof[i])
@@ -839,22 +844,22 @@ run_lockstep_simulation(scheduler_t &scheduler, int num_outputs, memref_tid_t ti
                 continue;
             }
             if (status == scheduler_t::STATUS_WAIT) {
-                sched_as_string[i] += '-';
+                sched_as_string[i] += WAIT_SYMBOL;
                 continue;
             }
             if (status == scheduler_t::STATUS_IDLE) {
-                sched_as_string[i] += '_';
+                sched_as_string[i] += IDLE_SYMBOL;
                 continue;
             }
             assert(status == scheduler_t::STATUS_OK);
             if (type_is_instr(memref.instr.type)) {
                 sched_as_string[i] +=
-                    'A' + static_cast<char>(memref.instr.tid - tid_base);
+                    THREAD_LETTER_START + static_cast<char>(memref.instr.tid - tid_base);
             } else {
                 // While this makes the string longer, it is just too confusing
                 // with the same letter seemingly on 2 cores at once without these
                 // fillers to line everything up in time.
-                sched_as_string[i] += '.';
+                sched_as_string[i] += NON_INSTR_SYMBOL;
             }
         }
     }
@@ -871,6 +876,15 @@ run_lockstep_simulation(scheduler_t &scheduler, int num_outputs, memref_tid_t ti
                 continue;
             assert(inputs.find(sched_as_string[out][step]) == inputs.end());
             inputs.insert(sched_as_string[out][step]);
+        }
+    }
+    if (!print_markers) {
+        // We kept the dots internally for our same-timestep check above.
+        for (int i = 0; i < num_outputs; ++i) {
+            sched_as_string[i].erase(std::remove(sched_as_string[i].begin(),
+                                                 sched_as_string[i].end(),
+                                                 NON_INSTR_SYMBOL),
+                                     sched_as_string[i].end());
         }
     }
     return sched_as_string;
@@ -976,6 +990,12 @@ test_synthetic_time_quanta()
         refs[i].push_back(make_timestamp(10));
         refs[i].push_back(make_instr(10));
         refs[i].push_back(make_instr(30));
+        if (i == 0) {
+            refs[i].push_back(make_timestamp(20));
+            refs[i].push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 42));
+            refs[i].push_back(make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0));
+            refs[i].push_back(make_timestamp(220));
+        }
         refs[i].push_back(make_instr(50));
         refs[i].push_back(make_exit(TID_BASE + i));
     }
@@ -997,6 +1017,7 @@ test_synthetic_time_quanta()
                                                    /*verbosity=*/4);
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
         sched_ops.quantum_duration = 3;
+        sched_ops.block_time_scale = 5.; // Ensure it waits a while.
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, sched_ops) !=
@@ -1010,7 +1031,7 @@ test_synthetic_time_quanta()
             scheduler_t::stream_status_t status = stream->next_record(memref, time);
             if (status != expect_status) {
                 std::cerr << "Expected status " << expect_status << " != " << status
-                          << "\n";
+                          << " at time " << time << "\n";
                 assert(false);
             }
             if (status == scheduler_t::STATUS_OK) {
@@ -1043,18 +1064,30 @@ test_synthetic_time_quanta()
         check_next(cpu0, ++time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_INSTR);
         // Advance cpu1 which is now at its quantum end at time 6 and should switch.
         check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_INSTR);
-        check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_INSTR);
-        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_THREAD_EXIT);
+        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
+        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
+        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
+        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
+        // We just hit a blocking syscall in A so we swap to B.
         check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
-        // This is another quantum end at 9 but the queue is empty.
+        // This is another quantum end at 9 but no other input is available.
         check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
-        // Finish off the inputs.
+        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_THREAD_EXIT);
+        check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
+        // Finish off C on cpu 0.
         check_next(cpu0, ++time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_INSTR);
         check_next(cpu0, ++time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_INSTR);
         check_next(cpu0, time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_THREAD_EXIT);
-        check_next(cpu0, time, scheduler_t::STATUS_IDLE);
-        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_THREAD_EXIT);
-        check_next(cpu1, time, scheduler_t::STATUS_EOF);
+        // Both cpus wait until A is unblocked.
+        check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
+        check_next(cpu0, ++time, scheduler_t::STATUS_IDLE);
+        check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
+        check_next(cpu0, ++time, scheduler_t::STATUS_IDLE);
+        check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
+        check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_INSTR);
+        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_THREAD_EXIT);
+        check_next(cpu1, ++time, scheduler_t::STATUS_EOF);
+        check_next(cpu0, ++time, scheduler_t::STATUS_EOF);
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
     }
@@ -1083,8 +1116,8 @@ test_synthetic_time_quanta()
         for (int i = 0; i < NUM_OUTPUTS; i++) {
             std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
         }
-        assert(sched_as_string[0] == "..A..CCC._");
-        assert(sched_as_string[1] == "..BAA.BB.");
+        assert(sched_as_string[0] == "..A..CCC._________");
+        assert(sched_as_string[1] == "..BA....BB.____A.");
     }
 #endif
 }
@@ -1412,21 +1445,36 @@ test_synthetic_with_syscalls_multiple()
             std::vector<trace_entry_t> inputs;
             inputs.push_back(make_thread(tid));
             inputs.push_back(make_pid(1));
+            inputs.push_back(make_version(TRACE_ENTRY_VERSION));
+            uint64_t stamp =
+                10000 * workload_idx + 1000 * (NUM_INPUTS_PER_WORKLOAD - input_idx);
             for (int instr_idx = 0; instr_idx < NUM_INSTRS; instr_idx++) {
-                // Sprinkle timestamps every other instruction.  We use the
-                // same formula as test_synthetic_with_priorities().
-                if (instr_idx % 2 == 0) {
-                    inputs.push_back(make_timestamp(
-                        1000 * workload_idx +
-                        100 * (NUM_INPUTS_PER_WORKLOAD - input_idx) + 10 * instr_idx));
+                // Sprinkle timestamps every other instruction.  We use a similar
+                // priority scheme as test_synthetic_with_priorities() but we leave
+                // room for blocking syscall timestamp gaps.
+                if (instr_idx % 2 == 0 &&
+                    (inputs.back().type != TRACE_TYPE_MARKER ||
+                     inputs.back().size != TRACE_MARKER_TYPE_TIMESTAMP)) {
+                    inputs.push_back(make_timestamp(stamp));
                 }
                 inputs.push_back(make_instr(42 + instr_idx * 4));
                 // Insert some blocking syscalls in the high-priority (see below)
                 // middle threads.
                 if (input_idx == 1 && instr_idx % (workload_idx + 1) == workload_idx) {
+                    inputs.push_back(make_timestamp(stamp + 10));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 42));
                     inputs.push_back(
                         make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0));
+                    // Blocked for 5 100-threshold blocking-syscall units.
+                    inputs.push_back(make_timestamp(stamp + 550));
+                } else {
+                    // Insert meta records to keep the locksteps lined up.
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
                 }
+                stamp += 10;
             }
             inputs.push_back(make_exit(tid));
             readers.emplace_back(
@@ -1465,23 +1513,26 @@ test_synthetic_with_syscalls_multiple()
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, sched_ops) !=
         scheduler_t::STATUS_SUCCESS)
         assert(false);
-    std::vector<std::string> sched_as_string =
-        run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_BASE);
+    // We omit the "." marker chars to keep the strings short enough to be readable.
+    std::vector<std::string> sched_as_string = run_lockstep_simulation(
+        scheduler, NUM_OUTPUTS, TID_BASE, /*send_time=*/false, /*print_markers=*/false);
     for (int i = 0; i < NUM_OUTPUTS; i++) {
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
     // See the test_synthetic_with_priorities() test which has our base sequence.
     // But now B hits a syscall every instr, and E every other instr, so neither
     // reaches its 3-instr quantum.  (H's syscalls are every 3rd instr coinciding with its
-    // quantum.)  Furthermore, B isn't finished by the time E and H are done and we see
-    // the lower-priority C and F getting scheduled while B is in a wait state for its
-    // blocking syscall.
+    // quantum.)  Furthermore, B, E, and H are blocked long enough that we see
+    // the lower-priority C and F getting scheduled.  We end up with idle cores
+    // while we wait for B.
+    // We've omitted the "." marker records so these are not precisely simultaneous,
+    // so the view here may show 2 on the same core at once: but we check for that
+    // with the "." in run_lockstep_simulation().  The omitted "." markers also
+    // explains why the two strings are different lengths.
     assert(sched_as_string[0] ==
-           ".B..HH.H.B.H.HH..B.HH.H..B.E.B...II.I.JJ.JJ.JJ.JJ.J.CC.C.II.I..DD.DA.AA.G.GG."
-           "DD.D.___");
+           "BHHHFFFJJJJJJJBEEHHHIIIFFFAAAHHHBAAAGGGAAABGGG__B___B___B");
     assert(sched_as_string[1] ==
-           ".EE..B..EE..B..EE..B..EE...CC.C.FF.FB..C.CC.F.FF.I.II.FF.F..AA.A.GG.GD.DD.AA."
-           "A.GG.G.");
+           "EECCCIIICCCJJFFFCCCBIIIEEDDDGGGDDDEEDDD____EB__________________________");
 }
 
 static void
@@ -1507,20 +1558,36 @@ test_synthetic_with_syscalls_single()
             std::vector<trace_entry_t> inputs;
             inputs.push_back(make_thread(tid));
             inputs.push_back(make_pid(1));
+            inputs.push_back(make_version(TRACE_ENTRY_VERSION));
+            uint64_t stamp =
+                10000 * workload_idx + 1000 * (NUM_INPUTS_PER_WORKLOAD - input_idx);
             for (int instr_idx = 0; instr_idx < NUM_INSTRS; instr_idx++) {
-                // Sprinkle timestamps every other instruction.  We use the
-                // same formula as test_synthetic_with_priorities().
-                if (instr_idx % 2 == 0) {
-                    inputs.push_back(make_timestamp(
-                        1000 * workload_idx +
-                        100 * (NUM_INPUTS_PER_WORKLOAD - input_idx) + 10 * instr_idx));
+                // Sprinkle timestamps every other instruction.  We use a similar
+                // priority scheme as test_synthetic_with_priorities() but we leave
+                // room for blocking syscall timestamp gaps.
+                if (instr_idx % 2 == 0 &&
+                    (inputs.back().type != TRACE_TYPE_MARKER ||
+                     inputs.back().size != TRACE_MARKER_TYPE_TIMESTAMP)) {
+                    inputs.push_back(make_timestamp(stamp));
                 }
                 inputs.push_back(make_instr(42 + instr_idx * 4));
-                // Insert some blocking syscalls.
+                // Insert some blocking syscalls in the high-priority (see below)
+                // middle threads.
                 if (instr_idx % 3 == 1) {
+                    inputs.push_back(make_timestamp(stamp + 10));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 42));
                     inputs.push_back(
                         make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0));
+                    // Blocked for 3 100-threshold blocking-syscall units.
+                    inputs.push_back(make_timestamp(stamp + 350));
+                } else {
+                    // Insert meta records to keep the locksteps lined up.
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
                 }
+                stamp += 10;
             }
             inputs.push_back(make_exit(tid));
             readers.emplace_back(
@@ -1543,8 +1610,11 @@ test_synthetic_with_syscalls_single()
     for (int i = 0; i < NUM_OUTPUTS; i++) {
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
-    assert(sched_as_string[0] == ".AA..AA.A.A.AA..A.");
-    assert(sched_as_string[1] == "__________________");
+    // We expect an idle CPU every 3 instrs but starting at the 2nd (1-based % 3).
+    assert(sched_as_string[0] ==
+           "..A....A....__A....A.....A....__A.....A....A....__A.....");
+    assert(sched_as_string[1] ==
+           "________________________________________________________");
 }
 
 static bool
@@ -1626,7 +1696,7 @@ test_synthetic_with_syscalls_precise()
     std::vector<memref_t> refs;
     for (scheduler_t::stream_status_t status = stream->next_record(memref);
          status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
-        if (status == scheduler_t::STATUS_WAIT)
+        if (status == scheduler_t::STATUS_WAIT || status == scheduler_t::STATUS_IDLE)
             continue;
         assert(status == scheduler_t::STATUS_OK);
         refs.push_back(memref);
@@ -1769,12 +1839,80 @@ test_synthetic_with_syscalls_latencies()
 }
 
 static void
+test_synthetic_with_syscalls_idle()
+{
+    std::cerr << "\n----------------\nTesting syscall idle time duration\n";
+    // We test that a blocked input is put to the back of the queue on each retry.
+    static constexpr int NUM_INPUTS = 4;
+    static constexpr int NUM_OUTPUTS = 1;
+    static constexpr int NUM_INSTRS = 12;
+    static constexpr memref_tid_t TID_BASE = 100;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    std::vector<scheduler_t::input_reader_t> readers;
+    for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
+        memref_tid_t tid = TID_BASE + input_idx;
+        std::vector<trace_entry_t> inputs;
+        inputs.push_back(make_thread(tid));
+        inputs.push_back(make_pid(1));
+        inputs.push_back(make_version(TRACE_ENTRY_VERSION));
+        uint64_t stamp = 10000 * NUM_INPUTS;
+        inputs.push_back(make_timestamp(stamp));
+        for (int instr_idx = 0; instr_idx < NUM_INSTRS; instr_idx++) {
+            inputs.push_back(make_instr(42 + instr_idx * 4));
+            if (instr_idx == 1) {
+                // Insert a blocking syscall in one input.
+                if (input_idx == 0) {
+                    inputs.push_back(make_timestamp(stamp + 10));
+                    inputs.push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 42));
+                    inputs.push_back(
+                        make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0));
+                    // Blocked for 2 100-threshold blocking-syscall units, but
+                    // after each queue rejection it should go to the back of
+                    // the queue and all the other inputs should be selected
+                    // before another retry.
+                    inputs.push_back(make_timestamp(stamp + 210));
+                } else {
+                    // Insert a timestamp to match the blocked input so the inputs
+                    // are all at equal priority in the queue.
+                    inputs.push_back(make_timestamp(stamp + 210));
+                }
+            }
+        }
+        inputs.push_back(make_exit(tid));
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), tid);
+    }
+    sched_inputs.emplace_back(std::move(readers));
+    scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                               scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                               scheduler_t::SCHEDULER_DEFAULTS,
+                                               /*verbosity=*/3);
+    sched_ops.quantum_duration = 3;
+    scheduler_t scheduler;
+    if (scheduler.init(sched_inputs, NUM_OUTPUTS, sched_ops) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    std::vector<std::string> sched_as_string =
+        run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_BASE);
+    for (int i = 0; i < NUM_OUTPUTS; i++) {
+        std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+    }
+    // The timestamps provide the ABCD ordering, but A's blocking syscall after its
+    // 2nd instr makes it delayed for 3 full queue cycles of BCD BCD: A's duration
+    // of 2 is decremented after the 1st (to 1) and 2nd (to 0) and A is finally
+    // schedulable after the 3rd.
+    assert(sched_as_string[0] ==
+           "..AA......BB.B..CC.C..DD.DBBBCCCDDDBBBCCCDDDAAABBB.CCC.DDD.AAAAAAA.");
+}
+
+static void
 test_synthetic_with_syscalls()
 {
     test_synthetic_with_syscalls_multiple();
     test_synthetic_with_syscalls_single();
     test_synthetic_with_syscalls_precise();
     test_synthetic_with_syscalls_latencies();
+    test_synthetic_with_syscalls_idle();
 }
 
 #if (defined(X86_64) || defined(ARM_64)) && defined(HAS_ZIP)
@@ -3161,7 +3299,6 @@ test_inactive()
         check_next(stream1, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_THREAD_EXIT);
         check_next(stream1, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_THREAD_EXIT);
         check_next(stream1, scheduler_t::STATUS_EOF);
-
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
     }
@@ -3209,6 +3346,7 @@ test_direct_switch()
     std::vector<trace_entry_t> refs_A = {
         make_thread(TID_A),
         make_pid(1),
+        make_version(TRACE_ENTRY_VERSION),
         // A has the earliest timestamp and starts.
         make_timestamp(1001),
         make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
@@ -3226,6 +3364,7 @@ test_direct_switch()
     std::vector<trace_entry_t> refs_B = {
         make_thread(TID_B),
         make_pid(1),
+        make_version(TRACE_ENTRY_VERSION),
         // B would go next by timestamp, so this is a good test of direct switches.
         make_timestamp(2001),
         make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
@@ -3238,6 +3377,7 @@ test_direct_switch()
     std::vector<trace_entry_t> refs_C = {
         make_thread(TID_C),
         make_pid(1),
+        make_version(TRACE_ENTRY_VERSION),
         make_timestamp(3001),
         make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
         make_instr(/*pc=*/301),
@@ -3263,9 +3403,11 @@ test_direct_switch()
                          std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_C);
     // The string constructor writes "." for markers.
     // We expect A's first switch to be to C even though B has an earlier timestamp.
-    // TODO i#5843: Once we have i/o wait times we can make this more interesting
-    // by having C be unschedule-able at switch time.
-    static const char *const CORE0_SCHED_STRING = "..AA........CC......A...BBBB.C...";
+    // We expect C's direct switch to A to proceed immediately even though A still
+    // has significant blocked time left.  But then after B is scheduled and finishes,
+    // we still have to wait for C's block time so we see idle underscores:
+    static const char *const CORE0_SCHED_STRING =
+        "...AA.........CC......A....BBBB.____________________C...";
 
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(std::move(readers));
@@ -3294,6 +3436,7 @@ test_main(int argc, const char *argv[])
     // Avoid races with lazy drdecode init (b/279350357).
     dr_standalone_init();
 
+    test_direct_switch();
     test_serial();
     test_parallel();
     test_param_checks();


### PR DESCRIPTION
Adds a longer waiting period on blocking syscalls using either provided output time or for instruction-based quanta a count of queue selections before a blocked input is actually selected.  Since the scheduler does not have timer interrupts or regular points of control and relies on its user calling it, idle inputs are kept on the ready queue and are checked for becoming unblocked when the ready queue is queried.

The wait duration is set based on the "wait time factor" which is the syscall latency divided by the context switch threshold multipled by a user-provided "block_time_scale" option which can be used to scale up or down the durations.

The wait duration is erased on a direct switch to an input.

Adds a new replay record type to represent idle time on replay.

Augments the unit tests to include blocking high-latency syscalls to test the new feature in various sub-tests.

Issue: #6471