### PR TITLE
i#6471 sched idle: Fix assert define

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -745,7 +745,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
             for (int i = 0; i < static_cast<output_ordinal_t>(outputs_.size()); ++i) {
                 if (i < static_cast<input_ordinal_t>(inputs_.size())) {
                     input_info_t *queue_next;
-#ifdef DEBUG
+#ifndef NDEBUG
                     sched_type_t::stream_status_t status =
 #endif
                         pop_from_ready_queue(i, queue_next);


### PR DESCRIPTION
Fixes an assert variable decl to use #ifndef NDEBUG instead of #ifdef DEBUG to support builds in between DEBUG and NDEBUG.  We don't have such builds on Github but some third-party builders use them.

Issue: #6471