### PR TITLE
i#3544 RV64: Enable sample.bbcount test

### DIFF
--- a/api/samples/bbcount.c
+++ b/api/samples/bbcount.c
@@ -124,7 +124,8 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
                                * here won't be used: drreg's slots will be.
                                */
                               SPILL_SLOT_MAX + 1,
-                              IF_AARCHXX_(SPILL_SLOT_MAX + 1) & global_count, 1, 0);
+                              IF_AARCHXX_OR_RISCV64_(SPILL_SLOT_MAX + 1) & global_count,
+                              1, 0);
 
 #if defined(VERBOSE) && defined(VERBOSE_VERBOSE)
     dr_printf("Finished instrumenting dynamorio_basic_block(tag=" PFX ")\n", tag);

--- a/api/samples/opcode_count.cpp
+++ b/api/samples/opcode_count.cpp
@@ -100,7 +100,7 @@ event_opcode_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *i
          * here won't be used: drreg's slots will be.
          */
         static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
-        IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
+        IF_AARCHXX_OR_RISCV64_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
             global_opcode_count,
         1,
         /* TODO i#4215: DRX_COUNTER_LOCK is not yet supported on ARM. */
@@ -139,7 +139,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
          * here won't be used: drreg's slots will be.
          */
         static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1),
-        IF_AARCHXX_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
+        IF_AARCHXX_OR_RISCV64_(static_cast<dr_spill_slot_t>(SPILL_SLOT_MAX + 1)) &
             global_total_count,
         (int)bb_size,
         /* TODO i#4215: DRX_COUNTER_LOCK is not yet supported on ARM. */

--- a/api/samples/opcodes.c
+++ b/api/samples/opcodes.c
@@ -236,7 +236,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
                                        * here won't be used: drreg's slots will be.
                                        */
                                       SPILL_SLOT_MAX + 1,
-                                      IF_AARCHXX_(SPILL_SLOT_MAX + 1) &
+                                      IF_AARCHXX_OR_RISCV64_(SPILL_SLOT_MAX + 1) &
                                           count[isa_idx][instr_get_opcode(ins)],
                                       1,
                                       /* DRX_COUNTER_LOCK is not yet supported on ARM */

--- a/core/ir/riscv64/instr_create_api.h.in
+++ b/core/ir/riscv64/instr_create_api.h.in
@@ -279,6 +279,12 @@
  */
 #define OPND_CREATE_ABSMEM(addr, size) opnd_create_rel_addr(addr, size)
 
+/**
+ * Create an immediate integer operand. For RISCV64 the size of an immediate
+ * is ignored when encoding, so there is no need to specify the final size.
+ */
+#define OPND_CREATE_INT(val) OPND_CREATE_INTPTR(val)
+
 /** @} */ /* end doxygen group */
 
 /****************************************************************************

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -481,6 +481,22 @@ typedef struct _instr_t instr_t;
 #    define _IF_NOT_RISCV64(x) , x
 #endif
 
+#if defined(AARCHXX) || defined(RISCV64)
+#    define IF_AARCHXX_OR_RISCV64(x) x
+#    define IF_AARCHXX_OR_RISCV64_ELSE(x, y) x
+#    define IF_AARCHXX_OR_RISCV64_(x) x,
+#    define _IF_AARCHXX_OR_RISCV64(x) , x
+#    define IF_NOT_AARCHXX_OR_RISCV64(x)
+#    define _IF_NOT_AARCHXX_OR_RISCV64(x)
+#else
+#    define IF_AARCHXX_OR_RISCV64(x)
+#    define IF_AARCHXX_OR_RISCV64_ELSE(x, y) y
+#    define IF_AARCHXX_OR_RISCV64_(x)
+#    define _IF_AARCHXX_OR_RISCV64(x)
+#    define IF_NOT_AARCHXX_OR_RISCV64(x) x
+#    define _IF_NOT_AARCHXX_OR_RISCV64(x) , x
+#endif
+
 #ifdef ANDROID
 #    define IF_ANDROID(x) x
 #    define IF_ANDROID_ELSE(x, y) x

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -219,10 +219,13 @@ drx_aflags_are_dead(instr_t *where)
  * INSTRUMENTATION
  */
 
-#ifdef AARCHXX
 /* XXX i#1603: add liveness analysis and pick dead regs */
+#if defined(AARCHXX)
 #    define SCRATCH_REG0 DR_REG_R0
 #    define SCRATCH_REG1 DR_REG_R1
+#elif defined(RISCV64)
+#    define SCRATCH_REG0 DR_REG_A0
+#    define SCRATCH_REG1 DR_REG_A1
 #endif
 
 /* insert a label instruction with note */
@@ -419,14 +422,14 @@ DR_EXPORT
 bool
 drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
                           dr_spill_slot_t slot,
-                          IF_AARCHXX_(dr_spill_slot_t slot2) void *addr, int value,
-                          uint flags)
+                          IF_AARCHXX_OR_RISCV64_(dr_spill_slot_t slot2) void *addr,
+                          int value, uint flags)
 {
     instr_t *instr;
     bool use_drreg = false;
 #ifdef X86
     bool save_aflags = true;
-#elif defined(AARCHXX)
+#elif defined(AARCHXX) || defined(RISCV64)
     bool save_regs = true;
     reg_id_t reg1, reg2;
 #endif
@@ -443,7 +446,8 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
     if (drmgr_current_bb_phase(drcontext) == DRMGR_PHASE_INSERTION) {
         use_drreg = true;
         if (drmgr_current_bb_phase(drcontext) == DRMGR_PHASE_INSERTION &&
-            (slot != SPILL_SLOT_MAX + 1 IF_AARCHXX(|| slot2 != SPILL_SLOT_MAX + 1))) {
+            (slot !=
+             SPILL_SLOT_MAX + 1 IF_AARCHXX_OR_RISCV64(|| slot2 != SPILL_SLOT_MAX + 1))) {
             ASSERT(false, "with drmgr, SPILL_SLOT_MAX+1 must be passed");
             return false;
         }
@@ -454,9 +458,9 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
 
     /* check whether we can add lock */
     if (TEST(DRX_COUNTER_LOCK, flags)) {
-#ifdef AARCHXX
-        /* TODO i#1551,i#1569: implement for AArchXX. */
-        ASSERT(false, "DRX_COUNTER_LOCK not implemented for AArchXX");
+#if defined(AARCHXX) || defined(RISCV64)
+        /* TODO i#1551,i#1569,i#3544: implement for AArchXX/RISCV64. */
+        ASSERT(false, "DRX_COUNTER_LOCK not implemented for AArchXX/RISCV64");
         return false;
 #endif
         if (IF_NOT_X64(is_64 ||) /* 64-bit counter in 32-bit mode */
@@ -514,12 +518,12 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
                                     true /* restore oflag */, slot, DR_REG_NULL);
         }
     }
-#elif defined(AARCHXX)
-#    ifdef ARM
+#endif
+#ifdef ARM
     /* FIXME i#1551: implement 64-bit counter support */
     ASSERT(!is_64, "DRX_COUNTER_64BIT is not implemented for ARM_32");
-#    endif /* ARM */
-
+#endif /* ARM */
+#if defined(AARCHXX) || defined(RISCV64)
     if (use_drreg) {
         if (drreg_reserve_register(drcontext, ilist, where, NULL, &reg1) !=
                 DRREG_SUCCESS ||
@@ -567,7 +571,7 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
         MINSERT(ilist, where,
                 INSTR_CREATE_stlr(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
                                   opnd_create_reg(reg2)));
-#    else /* ARM */
+#    elif defined(ARM)
         MINSERT(ilist, where,
                 XINST_CREATE_load(drcontext, opnd_create_reg(reg2),
                                   OPND_CREATE_MEMPTR(reg1, 0)));
@@ -585,11 +589,14 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
         MINSERT(ilist, where,
                 XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
                                    opnd_create_reg(reg2)));
+#    else /* RISCV64 */
+        ASSERT(false, "DRX_COUNTER_REL_ACQ not implemented for RISCV64");
 #    endif
     } else {
         MINSERT(ilist, where,
                 XINST_CREATE_load(drcontext, opnd_create_reg(reg2),
                                   OPND_CREATE_MEMPTR(reg1, 0)));
+#    ifdef AARCHXX
         if (value >= 0) {
             MINSERT(ilist, where,
                     XINST_CREATE_add(drcontext, opnd_create_reg(reg2),
@@ -599,6 +606,11 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
                     XINST_CREATE_sub(drcontext, opnd_create_reg(reg2),
                                      OPND_CREATE_INT(-value)));
         }
+#    else /* RISCV64 */
+        MINSERT(
+            ilist, where,
+            XINST_CREATE_add(drcontext, opnd_create_reg(reg2), OPND_CREATE_INT(value)));
+#    endif
         MINSERT(ilist, where,
                 XINST_CREATE_store(drcontext, OPND_CREATE_MEMPTR(reg1, 0),
                                    opnd_create_reg(reg2)));
@@ -615,15 +627,6 @@ drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
         ilist_insert_note_label(drcontext, ilist, where,
                                 NOTE_VAL(DRX_NOTE_AFLAGS_RESTORE_END));
     }
-#elif defined(RISCV64)
-    /* FIXME i#3544: Not implemented - below to make compiler happy */
-    ASSERT(false, "Not implemented");
-    instr = merge_prev_drx_spill(ilist, where, false);
-    ilist_insert_note_label(drcontext, ilist, where,
-                            NOTE_VAL(DRX_NOTE_AFLAGS_RESTORE_BEGIN));
-    ilist_insert_note_label(drcontext, ilist, where,
-                            NOTE_VAL(DRX_NOTE_AFLAGS_RESTORE_END));
-    return false;
 #endif
     return true;
 }

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -174,8 +174,8 @@ DR_EXPORT
 bool
 drx_insert_counter_update(void *drcontext, instrlist_t *ilist, instr_t *where,
                           dr_spill_slot_t slot,
-                          IF_AARCHXX_(dr_spill_slot_t slot2) void *addr, int value,
-                          uint flags);
+                          IF_AARCHXX_OR_RISCV64_(dr_spill_slot_t slot2) void *addr,
+                          int value, uint flags);
 
 /***************************************************************************
  * SOFT KILLS

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5916,6 +5916,7 @@ if (RISCV64)
     code_api|linux.signalfd
     code_api|pthreads.pthreads_exit
     code_api|sample.bbbuf
+    code_api|sample.bbcount
     code_api|security-linux.trampoline
     code_api|tool.drdisas
     no_code_api,no_intercept_all_signals|linux.sigaction


### PR DESCRIPTION
This patch enables sample.bbbuf test with the following changes:

- Adds `IF_AARCHXX_OR_RISCV64*` macros so they can share some code
- Implements `drx_insert_counter_update()` without `DRX_COUNTER_REL_ACQ` support

Issue: #3544