### PR TITLE
i3544 RV64: Enable a few more sample tests

### DIFF
--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -241,7 +241,7 @@ add_sample_client(memtrace_simple "memtrace_simple.c;utils.c" "drmgr;drreg;druti
 add_sample_client(memval_simple   "memval_simple.c;utils.c"   "drmgr;drreg;drutil;drx")
 add_sample_client(instrace_simple "instrace_simple.c;utils.c" "drmgr;drreg;drx")
 add_sample_client(opcode_count    "opcode_count.cpp"    "drmgr;drreg;drx;droption")
-if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
+if (X86) # FIXME i#1551, i#1569, i#3544: port to ARM/AArch64/RISCV64
   add_sample_client(cbr         "cbr.c"           "drmgr")
   add_sample_client(countcalls  "countcalls.c"    "drmgr;drreg")
   add_sample_client(inc2add     "inc2add.c"       "drmgr;drreg")

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -264,6 +264,7 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
             instr_create_restore_from_tls(dcontext, SCRATCH_REG0, TLS_REG0_SLOT));
     } else {
         IF_AARCH64(ASSERT_NOT_REACHED());
+        IF_RISCV64(ASSERT_NOT_REACHED());
         PRE(ilist, instr, instr_create_save_to_dcontext(dcontext, REG_XSP, XSP_OFFSET));
 #ifdef WINDOWS
         if (!cci->out_of_line_swap) {

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -52,11 +52,8 @@
  */
 #ifdef X86
 #    define DR_FPSTATE_BUF_SIZE 512
-#elif defined(RISCV64)
-/* FIXME i#3544: Not implemented */
-#    define DR_FPSTATE_BUF_SIZE 1
-#elif defined(ARM) || defined(AARCH64)
-/* On ARM/AArch64 proc_save_fpstate saves nothing, so use the smallest
+#elif defined(ARM) || defined(AARCH64) || defined(RISCV64)
+/* On ARM/AArch64/RISCV64 proc_save_fpstate saves nothing, so use the smallest
  * legal size for an array.
  */
 #    define DR_FPSTATE_BUF_SIZE 1

--- a/core/arch/riscv64/mangle.c
+++ b/core/arch/riscv64/mangle.c
@@ -164,13 +164,16 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
     if (cci == NULL)
         cci = &default_clean_call_info;
     uint current_offs;
-    current_offs =
-        get_clean_call_switch_stack_size() - proc_num_simd_registers() * XSP_SZ;
+    current_offs = get_clean_call_switch_stack_size() -
+        proc_num_simd_registers() * sizeof(dr_simd_t);
 
+    /* sp is the stack pointer, which should not be poped. */
+    cci->reg_skip[DR_REG_SP - DR_REG_START_GPR] = true;
+
+    current_offs -= XSP_SZ;
     PRE(ilist, instr,
         INSTR_CREATE_ld(dcontext, opnd_create_reg(DR_REG_A0),
                         OPND_CREATE_MEM64(DR_REG_SP, current_offs)));
-
     /* csrw a0, fcsr */
     PRE(ilist, instr,
         INSTR_CREATE_csrrw(dcontext, opnd_create_reg(DR_REG_X0),

--- a/core/arch/riscv64/proc.c
+++ b/core/arch/riscv64/proc.c
@@ -236,8 +236,9 @@ DR_API
 size_t
 proc_save_fpstate(byte *buf)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
+    /* All registers are saved by insert_push_all_registers so nothing extra
+     * needs to be saved here.
+     */
     return DR_FPSTATE_BUF_SIZE;
 }
 
@@ -245,8 +246,7 @@ DR_API
 void
 proc_restore_fpstate(byte *buf)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
+    /* Nothing to restore. */
 }
 
 void

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5923,6 +5923,7 @@ if (RISCV64)
     code_api|pthreads.pthreads_exit
     code_api|sample.bbbuf
     code_api|sample.bbcount
+    code_api|sample.bbsize
     code_api|security-linux.trampoline
     code_api|tool.drdisas
     no_code_api,no_intercept_all_signals|linux.sigaction

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5924,6 +5924,12 @@ if (RISCV64)
     code_api|sample.bbbuf
     code_api|sample.bbcount
     code_api|sample.bbsize
+    code_api|sample.empty
+    code_api|sample.opcode_count
+    code_api|sample.signal
+    code_api|sample.syscall
+    code_api|sample.inline
+    code_api|sample.stl_test
     code_api|security-linux.trampoline
     code_api|tool.drdisas
     no_code_api,no_intercept_all_signals|linux.sigaction

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5924,12 +5924,14 @@ if (RISCV64)
     code_api|sample.bbbuf
     code_api|sample.bbcount
     code_api|sample.bbsize
+    code_api|sample.div
     code_api|sample.empty
+    code_api|sample.inline
+    code_api|sample.inscount
     code_api|sample.opcode_count
     code_api|sample.signal
-    code_api|sample.syscall
-    code_api|sample.inline
     code_api|sample.stl_test
+    code_api|sample.syscall
     code_api|security-linux.trampoline
     code_api|tool.drdisas
     no_code_api,no_intercept_all_signals|linux.sigaction


### PR DESCRIPTION
This patch fixes a bug in `insert_pop_all_registers()` and thus enables the following sample tests:

code_api|sample.bbsize
code_api|sample.div
code_api|sample.empty
code_api|sample.inline
code_api|sample.inscount
code_api|sample.opcode_count
code_api|sample.signal
code_api|sample.stl_test
code_api|sample.syscall

Issue: #3544