### PR TITLE
i#6471 idle: Add better idle time modeling

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -262,6 +262,7 @@ analyzer_multi_t::init_dynamic_schedule()
     sched_ops.syscall_switch_threshold = op_sched_syscall_switch_us.get_value();
     sched_ops.blocking_switch_threshold = op_sched_blocking_switch_us.get_value();
     sched_ops.block_time_scale = op_sched_block_scale.get_value();
+    sched_ops.block_time_max = op_sched_block_max_us.get_value();
 #ifdef HAS_ZIP
     if (!op_record_file.get_value().empty()) {
         record_schedule_zip_.reset(new zipfile_ostream_t(op_record_file.get_value()));

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -851,11 +851,18 @@ droption_t<uint64_t> op_sched_blocking_switch_us(
     "maybe-blocking to incur a context switch. Applies to -core_sharded and "
     "-core_serial. ");
 
-droption_t<double>
-    op_sched_block_scale(DROPTION_SCOPE_ALL, "sched_block_scale", 1.,
-                         "Input block time scale factor",
-                         "A higher value here results in blocking syscalls "
-                         "keeping inputs unscheduled for longer.");
+droption_t<double> op_sched_block_scale(
+    DROPTION_SCOPE_ALL, "sched_block_scale", 1000., "Input block time scale factor",
+    "The scale applied to the microsecond latency of blocking system calls.  A higher "
+    "value here results in blocking syscalls keeping inputs unscheduled for longer.  "
+    "This should roughly equal the slowdown of instruction record processing versus the "
+    "original (untraced) application execution.");
+
+droption_t<uint64_t> op_sched_block_max_us(DROPTION_SCOPE_ALL, "sched_block_max_us",
+                                           25000000,
+                                           "Maximum blocked input time, in microseconds",
+                                           "The maximum blocked time, after scaling with "
+                                           "-sched_block_scale.");
 #ifdef HAS_ZIP
 droption_t<std::string> op_record_file(DROPTION_SCOPE_FRONTEND, "record_file", "",
                                        "Path for storing record of schedule",
@@ -875,8 +882,8 @@ droption_t<std::string>
 
 // Schedule_stats options.
 droption_t<uint64_t>
-    op_schedule_stats_print_every(DROPTION_SCOPE_ALL, "schedule_stats_print_every", 5000,
-                                  "A letter is printed every N instrs",
+    op_schedule_stats_print_every(DROPTION_SCOPE_ALL, "schedule_stats_print_every",
+                                  500000, "A letter is printed every N instrs",
                                   "A letter is printed every N instrs or N waits");
 
 droption_t<std::string> op_syscall_template_file(

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -858,6 +858,15 @@ droption_t<double> op_sched_block_scale(
     "This should roughly equal the slowdown of instruction record processing versus the "
     "original (untraced) application execution.");
 
+// We have a max to avoid outlier latencies that are already a second or more from
+// scaling up to tens of minutes.  We assume a cap is representative as the outliers
+// likely were not part of key dependence chains.  Without a cap the other threads all
+// finish and the simulation waits for tens of minutes further for a couple of outliers.
+// The cap remains a flag and not a constant as different length traces and different
+// speed simulators need different idle time ranges, so we need to be able to tune this
+// to achieve desired cpu usage targets.  The default value was selected while tuning
+// a 1-minute-long schedule_stats run on a 112-core 500-thread large application
+// to produce good cpu usage without unduly increasing tool runtime.
 droption_t<uint64_t> op_sched_block_max_us(DROPTION_SCOPE_ALL, "sched_block_max_us",
                                            25000000,
                                            "Maximum blocked input time, in microseconds",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -194,6 +194,7 @@ extern dynamorio::droption::droption_t<bool> op_sched_order_time;
 extern dynamorio::droption::droption_t<uint64_t> op_sched_syscall_switch_us;
 extern dynamorio::droption::droption_t<uint64_t> op_sched_blocking_switch_us;
 extern dynamorio::droption::droption_t<double> op_sched_block_scale;
+extern dynamorio::droption::droption_t<uint64_t> op_sched_block_max_us;
 #ifdef HAS_ZIP
 extern dynamorio::droption::droption_t<std::string> op_record_file;
 extern dynamorio::droption::droption_t<std::string> op_replay_file;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1636,6 +1636,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
         add_to_ready_queue(save);
     VDO(this, 1, {
         static int heartbeat;
+        // We are ok with races as the cadence is approximate.
         if (++heartbeat % 500 == 0) {
             VPRINT(this, 1, "heartbeat[%d] %zd in queue; %d blocked => %d %d\n",
                    for_output, ready_priority_.size(), num_blocked_,
@@ -2076,9 +2077,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
     // do return an error on a time smaller than an input's current start time when we
     // check for quantum end.
     if (cur_time == 0) {
-        // It's more efficient for QUANTUM_TIME to get the time here instead of
-        // in get_output_time().  This also makes the two more similarly behaved
-        // with respect to blocking system calls.
+        // It's more efficient for QUANTUM_INSTRUCTIONS to get the time here instead of
+        // in get_output_time().  This also makes the two more similarly behaved with
+        // respect to blocking system calls.
         cur_time = get_time_micros();
     }
     outputs_[output].cur_time = cur_time; // Invalid values are checked below.

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2101,7 +2101,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                 outputs_[output].wait_start_time = 0;
         }
         VPRINT(this, 5, "next_record[%d]: need new input (cur=waiting)\n", output);
-        sched_type_t::stream_status_t res = pick_next_input(output, 0.);
+        sched_type_t::stream_status_t res = pick_next_input(output, 0);
         if (res != sched_type_t::STATUS_OK && res != sched_type_t::STATUS_SKIPPED)
             return res;
         outputs_[output].waiting = false;
@@ -2162,7 +2162,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                 lock.unlock();
                 VPRINT(this, 5, "next_record[%d]: need new input (cur=%d eof)\n", output,
                        input->index);
-                sched_type_t::stream_status_t res = pick_next_input(output, false);
+                sched_type_t::stream_status_t res = pick_next_input(output, 0);
                 if (res != sched_type_t::STATUS_OK && res != sched_type_t::STATUS_SKIPPED)
                     return res;
                 input = &inputs_[outputs_[output].cur_input];

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1576,10 +1576,12 @@ scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(input_info_t *input
     VPRINT(
         this, 4,
         "add_to_ready_queue (pre-size %zu): input %d priority %d timestamp delta %" PRIu64
-        " block factor %3.2f time %" PRIu64 "\n",
+        " block time %" PRIu64 " start time %" PRIu64 "\n",
         ready_priority_.size(), input->index, input->priority,
-        input->reader->get_last_timestamp() - input->base_timestamp,
-        input->block_time_factor, input->blocked_start_time);
+        input->reader->get_last_timestamp() - input->base_timestamp, input->blocked_time,
+        input->blocked_start_time);
+    if (input->blocked_time > 0)
+        ++num_blocked_;
     input->queue_counter = ++ready_counter_;
     ready_priority_.push(input);
 }
@@ -1593,6 +1595,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
     std::set<input_info_t *> blocked;
     input_info_t *res = nullptr;
     sched_type_t::stream_status_t status = STATUS_OK;
+    uint64_t cur_time = (num_blocked_ > 0) ? get_output_time(for_output) : 0;
     while (!ready_priority_.empty()) {
         res = ready_priority_.top();
         ready_priority_.pop();
@@ -1600,33 +1603,19 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
             // For blocked inputs, as we don't have interrupts or other regular
             // control points we only check for being unblocked when an input
             // would be chosen to run.  We thus keep blocked inputs in the ready queue.
-            if (options_.quantum_unit == QUANTUM_TIME) {
-                if (res->block_time_factor > 0 &&
-                    outputs_[for_output].cur_time - res->blocked_start_time <
-                        options_.block_time_scale * res->block_time_factor) {
-                    VPRINT(
-                        this, 4,
-                        "pop queue: %d still blocked for %4.1f (%3.2f * %3.2f - (%" PRIu64
-                        " - %" PRIu64 ")\n",
-                        res->index,
-                        options_.block_time_scale * res->block_time_factor -
-                            (outputs_[for_output].cur_time - res->blocked_start_time),
-                        options_.block_time_scale, res->block_time_factor,
-                        outputs_[for_output].cur_time, res->blocked_start_time);
-                    // We keep searching for a suitable input.
-                    blocked.insert(res);
-                } else
-                    break;
-            } else {
-                if (res->block_time_factor > 0) {
-                    VPRINT(this, 4, "pop queue: %d still blocked for %4.1f\n", res->index,
-                           res->block_time_factor);
-                    --res->block_time_factor;
-                    // We keep searching for a suitable input.
-                    blocked.insert(res);
-                } else
-                    break;
+            if (res->blocked_time > 0) {
+                assert(cur_time > 0);
+                --num_blocked_;
             }
+            if (res->blocked_time > 0 &&
+                cur_time - res->blocked_start_time < res->blocked_time) {
+                VPRINT(this, 4, "pop queue: %d still blocked for %" PRIu64 "\n",
+                       res->index,
+                       res->blocked_time - (cur_time - res->blocked_start_time));
+                // We keep searching for a suitable input.
+                blocked.insert(res);
+            } else
+                break;
         } else {
             // We keep searching for a suitable input.
             skipped.insert(res);
@@ -1645,13 +1634,21 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
     // Re-add the blocked ones to the back.
     for (input_info_t *save : blocked)
         add_to_ready_queue(save);
+    VDO(this, 1, {
+        static int heartbeat;
+        if (++heartbeat % 500 == 0) {
+            VPRINT(this, 1, "heartbeat[%d] %zd in queue; %d blocked => %d %d\n",
+                   for_output, ready_priority_.size(), num_blocked_,
+                   res == nullptr ? -1 : res->index, status);
+        }
+    });
     if (res != nullptr) {
         VPRINT(this, 4,
                "pop_from_ready_queue[%d] (post-size %zu): input %d priority %d timestamp "
                "delta %" PRIu64 "\n",
                for_output, ready_priority_.size(), res->index, res->priority,
                res->reader->get_last_timestamp() - res->base_timestamp);
-        res->block_time_factor = 0.;
+        res->blocked_time = 0;
     }
     new_input = res;
     return status;
@@ -1660,7 +1657,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
 template <typename RecordType, typename ReaderType>
 bool
 scheduler_tmpl_t<RecordType, ReaderType>::syscall_incurs_switch(input_info_t *input,
-                                                                double &block_time_factor)
+                                                                uint64_t &blocked_time)
 {
     uint64_t post_time = input->reader->get_last_timestamp();
     assert(input->processing_syscall || input->processing_maybe_blocking_syscall);
@@ -1668,7 +1665,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::syscall_incurs_switch(input_info_t *in
         // This is a legacy trace that does not have timestamps bracketing syscalls.
         // We switch on every maybe-blocking syscall in this case and have a simplified
         // blocking model.
-        block_time_factor = 1.;
+        blocked_time = options_.blocking_switch_threshold;
         return input->processing_maybe_blocking_syscall;
     }
     assert(input->pre_syscall_timestamp > 0);
@@ -1677,13 +1674,22 @@ scheduler_tmpl_t<RecordType, ReaderType>::syscall_incurs_switch(input_info_t *in
     uint64_t threshold = input->processing_maybe_blocking_syscall
         ? options_.blocking_switch_threshold
         : options_.syscall_switch_threshold;
-    block_time_factor = static_cast<double>(latency) / threshold;
-    if (options_.quantum_unit == QUANTUM_INSTRUCTIONS)
-        block_time_factor *= options_.block_time_scale;
-    VPRINT(this, 3, "input %d %ssyscall latency %" PRIu64 " => factor %4.1f\n",
+    blocked_time =
+        static_cast<uint64_t>(static_cast<double>(latency) * options_.block_time_scale);
+    if (blocked_time > options_.block_time_max) {
+        // We have a max to avoid outlier latencies that are already a second or
+        // more from scaling up to tens of minutes.  We assume a cap is representative
+        // as the outliers likely were not part of key dependence chains.  Without a
+        // cap the other threads all finish and the simulation waits for tens of
+        // minutes further for a couple of outliers.
+        blocked_time = options_.block_time_max;
+    }
+    VPRINT(this, 3,
+           "input %d %ssyscall latency %" PRIu64 " * scale %5.1f => blocked time %" PRIu64
+           "\n",
            input->index,
            input->processing_maybe_blocking_syscall ? "maybe-blocking " : "", latency,
-           block_time_factor);
+           options_.block_time_scale, blocked_time);
     return latency >= threshold;
 }
 
@@ -1877,7 +1883,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input_as_previously(
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t output,
-                                                          double block_time_factor)
+                                                          uint64_t blocked_time)
 {
     sched_type_t::stream_status_t res = sched_type_t::STATUS_OK;
     bool need_lock =
@@ -1917,14 +1923,13 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                 if (res != sched_type_t::STATUS_OK)
                     return res;
             } else if (options_.mapping == MAP_TO_ANY_OUTPUT) {
-                if (block_time_factor > 0. && prev_index != INVALID_INPUT_ORDINAL) {
+                if (blocked_time > 0 && prev_index != INVALID_INPUT_ORDINAL) {
                     std::lock_guard<std::mutex> lock(*inputs_[prev_index].lock);
-                    if (inputs_[prev_index].block_time_factor == 0.) {
-                        VPRINT(this, 2, "next_record[%d]: block time factor %3.2f\n",
-                               output, block_time_factor);
-                        inputs_[prev_index].block_time_factor = block_time_factor;
-                        inputs_[prev_index].blocked_start_time =
-                            outputs_[output].cur_time;
+                    if (inputs_[prev_index].blocked_time == 0) {
+                        VPRINT(this, 2, "next_record[%d]: blocked time %" PRIu64 "\n",
+                               output, blocked_time);
+                        inputs_[prev_index].blocked_time = blocked_time;
+                        inputs_[prev_index].blocked_start_time = get_output_time(output);
                     } else {
                         // If we looped we could have the same prev_index.
                         assert(iters > 1);
@@ -1942,13 +1947,13 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         ready_priority_.erase(target);
                         index = target->index;
                         // Erase any remaining wait time for the target.
-                        if (target->block_time_factor != 0.) {
+                        if (target->blocked_time > 0) {
                             VPRINT(this, 3,
-                                   "next_record[%d]: direct switch erasing block time "
-                                   "factor "
-                                   "%4.1f for input %d\n",
-                                   output, target->block_time_factor, target->index);
-                            target->block_time_factor = 0.;
+                                   "next_record[%d]: direct switch erasing blocked time "
+                                   "for input %d\n",
+                                   output, target->index);
+                            --num_blocked_;
+                            target->blocked_time = 0;
                         }
                     } else {
                         // TODO i#5843: If the target is running on another output, we
@@ -1965,13 +1970,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                 }
                 if (index != INVALID_INPUT_ORDINAL) {
                     // We found a direct switch target above.
-                } else if (ready_queue_empty() && block_time_factor == 0.) {
+                } else if (ready_queue_empty() && blocked_time == 0) {
                     if (prev_index == INVALID_INPUT_ORDINAL)
                         return eof_or_idle(output);
-                    std::lock_guard<std::mutex> lock(*inputs_[prev_index].lock);
-                    if (inputs_[prev_index].at_eof)
+                    auto lock = std::unique_lock<std::mutex>(*inputs_[prev_index].lock);
+                    if (inputs_[prev_index].at_eof) {
+                        lock.unlock();
                         return eof_or_idle(output);
-                    else
+                    } else
                         index = prev_index; // Go back to prior.
                 } else {
                     // Give up the input before we go to the queue so we can add
@@ -1997,8 +2003,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         return status;
                     }
                     if (queue_next == nullptr) {
-                        assert(block_time_factor == 0. ||
-                               prev_index == INVALID_INPUT_ORDINAL);
+                        assert(blocked_time == 0 || prev_index == INVALID_INPUT_ORDINAL);
                         return eof_or_idle(output);
                     }
                     index = queue_next->index;
@@ -2070,6 +2075,12 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
     // We do not enforce a globally increasing time to avoid the synchronization cost; we
     // do return an error on a time smaller than an input's current start time when we
     // check for quantum end.
+    if (cur_time == 0) {
+        // It's more efficient for QUANTUM_TIME to get the time here instead of
+        // in get_output_time().  This also makes the two more similarly behaved
+        // with respect to blocking system calls.
+        cur_time = get_time_micros();
+    }
     outputs_[output].cur_time = cur_time; // Invalid values are checked below.
     if (!outputs_[output].active)
         return sched_type_t::STATUS_IDLE;
@@ -2170,7 +2181,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         VDO(this, 5, print_record(record););
         bool need_new_input = false;
         bool preempt = false;
-        double block_time_factor = 0.;
+        uint64_t blocked_time = 0;
         uint64_t prev_time_in_quantum = 0;
         if (options_.mapping == MAP_AS_PREVIOUSLY) {
             assert(outputs_[output].record_index >= 0);
@@ -2235,7 +2246,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                         input->switch_to_input = it->second;
                     }
                 } else if (record_type_is_instr(record)) {
-                    if (syscall_incurs_switch(input, block_time_factor)) {
+                    if (syscall_incurs_switch(input, blocked_time)) {
                         // Model as blocking and should switch to a different input.
                         need_new_input = true;
                         VPRINT(this, 3,
@@ -2323,8 +2334,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
             VPRINT(this, 5, "next_record[%d]: queuing candidate record\n", output);
             input->queue.push_back(record);
             lock.unlock();
-            sched_type_t::stream_status_t res =
-                pick_next_input(output, block_time_factor);
+            sched_type_t::stream_status_t res = pick_next_input(output, blocked_time);
             if (res != sched_type_t::STATUS_OK && res != sched_type_t::STATUS_WAIT &&
                 res != sched_type_t::STATUS_SKIPPED)
                 return res;
@@ -2385,7 +2395,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         }
         break;
     }
-    VPRINT(this, 4, "next_record[%d]: from %d: ", output, input->index);
+    VPRINT(this, 4, "next_record[%d]: from %d @%" PRId64 ": ", output, input->index,
+           cur_time);
     VDO(this, 4, print_record(record););
 
     outputs_[output].last_record = record;
@@ -2493,6 +2504,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::eof_or_idle(output_ordinal_t output)
         assert(options_.mapping != MAP_AS_PREVIOUSLY || outputs_[output].at_eof);
         return sched_type_t::STATUS_EOF;
     } else {
+        set_cur_input(output, INVALID_INPUT_ORDINAL);
         outputs_[output].waiting = true;
         return sched_type_t::STATUS_IDLE;
     }

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1527,7 +1527,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::close_schedule_segment(output_ordinal_
         return sched_type_t::STATUS_OK;
     }
     if (outputs_[output].record.back().type == schedule_record_t::IDLE) {
-        uint64_t end = get_output_time(output);
+        // Just like in record_schedule_segment() we use wall-clock time for recording
+        // replay timestamps.
+        uint64_t end = get_time_micros();
         assert(end >= outputs_[output].record.back().timestamp);
         outputs_[output].record.back().value.idle_duration =
             end - outputs_[output].record.back().timestamp;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -524,16 +524,27 @@ public:
         uint64_t blocking_switch_threshold = 100;
         /**
          * Controls the amount of time inputs are considered blocked at a syscall whose
-         * latency exceeds #syscall_switch_threshold or #blocking_switch_threshold.  A
-         * "block time factor" is computed from the syscall latency divided by either
-         * #syscall_switch_threshold or #blocking_switch_threshold.  This factor is
-         * multiplied by this field #block_time_scale to produce a final value.  For
-         * #QUANTUM_TIME, that final value's amount of time, as reported by the time
-         * parameter to next_record(), must pass before the input is no longer considered
-         * blocked.  For instruction quanta, that final value's count of scheduler
-         * selections must occur before the input is actually selected.
+         * latency exceeds #syscall_switch_threshold or #blocking_switch_threshold.  The
+         * syscall latency (in microseconds) is multiplied by this field to produce the
+         * blocked time.  For #QUANTUM_TIME, that blocked time in the units reported by
+         * the time parameter to next_record() must pass before the input is no longer
+         * considered blocked.  Since the system call latencies are in microseconds, this
+         * #block_time_scale should be set to the number of next_record() time units in
+         * one simulated microsecond.  For #QUANTUM_INSTRUCTIONS, the blocked time in
+         * wall-clock microseconds must pass before the input is actually selected
+         * (wall-clock time is used as there is no reasonable alternative with no other
+         * uniform notion of time); thus, the #block_time_scale value here should equal
+         * the slowdown of the instruction record processing versus the original
+         * (untraced) application execution.  The blocked time is clamped to a maximum
+         * value controlled by #block_time_max.
          */
-        double block_time_scale = 1.;
+        double block_time_scale = 1000.;
+        /**
+         * The maximum time, in microseconds, for an input to be considered blocked
+         * for any one system call.  This is applied after multiplying by
+         * #block_time_scale.
+         */
+        uint64_t block_time_max = 25000000;
     };
 
     /**
@@ -1018,8 +1029,9 @@ protected:
         uint64_t prev_time_in_quantum = 0;
         uint64_t time_spent_in_quantum = 0;
         // These fields model waiting at a blocking syscall.
-        double block_time_factor = 0.;
-        uint64_t blocked_start_time = 0; // For QUANTUM_TIME only.
+        // The units are us for instr quanta and simuilation time for time quanta.
+        uint64_t blocked_time = 0.;
+        uint64_t blocked_start_time = 0;
     };
 
     // Format for recording a schedule to disk.  A separate sequence of these records
@@ -1232,7 +1244,7 @@ protected:
     // Finds the next input stream for the 'output_ordinal'-th output stream.
     // No input_info_t lock can be held on entry.
     stream_status_t
-    pick_next_input(output_ordinal_t output, double block_time_factor);
+    pick_next_input(output_ordinal_t output, uint64_t blocked_time);
 
     // Helper for pick_next_input() for MAP_AS_PREVIOUSLY.
     // No input_info_t lock can be held on entry.
@@ -1354,7 +1366,7 @@ protected:
     // The input's lock must be held by the caller.
     // Returns a multiplier for how long the input should be considered blocked.
     bool
-    syscall_incurs_switch(input_info_t *input, double &block_time_factor);
+    syscall_incurs_switch(input_info_t *input, uint64_t &blocked_time);
 
     // sched_lock_ must be held by the caller.
     // "for_output" is which output stream is looking for a new input; only an
@@ -1385,6 +1397,8 @@ protected:
     // timestamp in each workload in order to mix inputs from different workloads in the
     // same queue.  FIFO ordering is used for same-priority entries.
     flexible_queue_t<input_info_t *, InputTimestampComparator> ready_priority_;
+    // Trackes the count of blocked inputs.  Protected by sched_lock_.
+    int num_blocked_ = 0;
     // Global ready queue counter used to provide FIFO for same-priority inputs.
     uint64_t ready_counter_ = 0;
     // Count of inputs not yet at eof.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1030,7 +1030,7 @@ protected:
         uint64_t time_spent_in_quantum = 0;
         // These fields model waiting at a blocking syscall.
         // The units are us for instr quanta and simuilation time for time quanta.
-        uint64_t blocked_time = 0.;
+        uint64_t blocked_time = 0;
         uint64_t blocked_start_time = 0;
     };
 

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -3,10 +3,10 @@ Total counts:
            4 cores
            8 threads
       638938 instructions
-           5 total context switches
-   0\.0078255 CSPKI \(context switches per 1000 instructions\)
-      127788 instructions per context switch
-           5 voluntary context switches
+           6 total context switches
+   0\.0093906 CSPKI \(context switches per 1000 instructions\)
+      106490 instructions per context switch
+           6 voluntary context switches
            0 direct context switches
       100\.00% voluntary switches
         0\.00% direct switches
@@ -15,7 +15,12 @@ Total counts:
            0 direct switch requests
            0 waits
     *[0-9]* idles
-      *[0-9\.]*% cpu busy
+      *[0-9\.]*% cpu busy by record count
+   *[0-9]* cpu microseconds
+   *[0-9]* idle microseconds
+   *[0-9]* idle microseconds at last instr
+      *[0-9\.]*% cpu busy by time
+      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #0 counts:
            . threads
       *[0-9]* instructions
@@ -31,7 +36,12 @@ Core #0 counts:
            0 direct switch requests
            0 waits
     *[0-9]* idles
-      *[0-9\.]*% cpu busy
+      *[0-9\.]*% cpu busy by record count
+   *[0-9]* cpu microseconds
+   *[0-9]* idle microseconds
+   *[0-9]* idle microseconds at last instr
+      *[0-9\.]*% cpu busy by time
+      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #1 counts:
            . threads
       *[0-9]* instructions
@@ -47,7 +57,12 @@ Core #1 counts:
            0 direct switch requests
            0 waits
     *[0-9]* idles
-      *[0-9\.]*% cpu busy
+      *[0-9\.]*% cpu busy by record count
+   *[0-9]* cpu microseconds
+   *[0-9]* idle microseconds
+   *[0-9]* idle microseconds at last instr
+      *[0-9\.]*% cpu busy by time
+      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #2 counts:
            . threads
       *[0-9]* instructions
@@ -63,7 +78,12 @@ Core #2 counts:
            0 direct switch requests
            0 waits
     *[0-9]* idles
-      *[0-9\.]*% cpu busy
+      *[0-9\.]*% cpu busy by record count
+   *[0-9]* cpu microseconds
+   *[0-9]* idle microseconds
+   *[0-9]* idle microseconds at last instr
+      *[0-9\.]*% cpu busy by time
+      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #3 counts:
            . threads
       *[0-9]* instructions
@@ -79,7 +99,12 @@ Core #3 counts:
            0 direct switch requests
            0 waits
     *[0-9]* idles
-      *[0-9\.]*% cpu busy
+      *[0-9\.]*% cpu busy by record count
+   *[0-9]* cpu microseconds
+   *[0-9]* idle microseconds
+   *[0-9]* idle microseconds at last instr
+      *[0-9\.]*% cpu busy by time
+      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #0 schedule: [A-Ha-h_]*
 Core #1 schedule: [A-Ha-h_]*
 Core #2 schedule: [A-Ha-h_]*

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -197,7 +197,10 @@ test_basic_stats()
     assert(result.direct_switch_requests == 2);
     assert(result.waits == 3);
     assert(result.idle_microseconds == 0);
+    // XXX: For 32-bit Windows test VMs we see coarse time updates resulting in 0's.
+#if !(defined(WIN32) && !defined(X64))
     assert(result.cpu_microseconds > 0);
+#endif
     return true;
 }
 
@@ -256,10 +259,15 @@ test_idle()
     assert(result.waits == 3);
     assert(result.idles == 6);
     // It is hard to test wall-clock time precise values so we have sanity checks.
+    std::cerr << "got idle " << result.idle_microseconds << "us, cpu "
+              << result.cpu_microseconds << "us\n"; // NOCHECK
+    // XXX: For 32-bit Windows test VMs we see coarse time updates resulting in 0's.
+#if !(defined(WIN32) && !defined(X64))
     assert(result.idle_microseconds > 0);
     assert(result.idle_micros_at_last_instr > 0 &&
            result.idle_micros_at_last_instr <= result.idle_microseconds);
     assert(result.cpu_microseconds > 0);
+#endif
     return true;
 }
 

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -197,8 +197,8 @@ test_basic_stats()
     assert(result.direct_switch_requests == 2);
     assert(result.waits == 3);
     assert(result.idle_microseconds == 0);
-    // XXX: For 32-bit Windows test VMs we see coarse time updates resulting in 0's.
-#if !(defined(WIN32) && !defined(X64))
+    // XXX: For Windows test VMs we see coarse time updates resulting in 0's.
+#ifndef WIN32
     assert(result.cpu_microseconds > 0);
 #endif
     return true;
@@ -261,8 +261,8 @@ test_idle()
     // It is hard to test wall-clock time precise values so we have sanity checks.
     std::cerr << "got idle " << result.idle_microseconds << "us, cpu "
               << result.cpu_microseconds << "us\n"; // NOCHECK
-    // XXX: For 32-bit Windows test VMs we see coarse time updates resulting in 0's.
-#if !(defined(WIN32) && !defined(X64))
+    // XXX: For Windows test VMs we see coarse time updates resulting in 0's.
+#ifndef WIN32
     assert(result.idle_microseconds > 0);
     assert(result.idle_micros_at_last_instr > 0 &&
            result.idle_micros_at_last_instr <= result.idle_microseconds);

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -960,13 +960,14 @@ test_synthetic()
         for (int i = 0; i < NUM_OUTPUTS; i++) {
             std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
         }
-#if !(defined(WIN32) && !defined(X64))
-        // XXX: Win32 microseconds on test VMs are very coarse and stay the same
+#ifndef WIN32
+        // XXX: Windows microseconds on test VMs are very coarse and stay the same
         // for long periods.  Instruction quanta use wall-clock idle times, so
         // the result is extreme variations here.  We try to adjust by handling
-        // any schedule with singleton 'A' and 'B', but in some cases on Win32
+        // any schedule with singleton 'A' and 'B', but in some cases on Windows
         // we see the A and B delayed all the way to the very end where they
-        // are adjacent to their own letters.  We just give up on this test on Win32.
+        // are adjacent to their own letters.  We just give up on checking the
+        // precise output for this test on Windows.
         if (sched_as_string[0] != CORE0_SCHED_STRING ||
             sched_as_string[1] != CORE1_SCHED_STRING) {
             bool found_single_A = false, found_single_B = false;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1166,8 +1166,11 @@ test_synthetic_time_quanta()
         for (int i = 0; i < NUM_OUTPUTS; i++) {
             std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
         }
-        assert(sched_as_string[0] == "..A..CCC._________");
-        assert(sched_as_string[1] == "..BA....BB.____A.");
+        // For replay the scheduler has to use wall-clock instead of passed-in time,
+        // so the idle portions at the end here can have variable idle and wait
+        // record counts.  We thus just check the start.
+        assert(sched_as_string[0].substr(0, 10) == "..A..CCC._");
+        assert(sched_as_string[1].substr(0, 12) == "..BA....BB._");
     }
 #endif
 }

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -307,6 +307,21 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
 }
 
 void
+schedule_stats_t::print_percentage(double numerator, double denominator,
+                                   const std::string &label)
+{
+    double fraction;
+    if (denominator == 0) {
+        if (numerator == 0)
+            fraction = 0.;
+        else
+            fraction = 1.;
+    } else
+        fraction = numerator / denominator;
+    std::cerr << std::setw(12) << std::setprecision(2) << 100 * fraction << label;
+}
+
+void
 schedule_stats_t::print_counters(const counters_t &counters)
 {
     std::cerr << std::setw(12) << counters.threads.size() << " threads\n";
@@ -326,17 +341,11 @@ schedule_stats_t::print_counters(const counters_t &counters)
               << counters.voluntary_switches << " voluntary context switches\n";
     std::cerr << std::setw(12) << counters.direct_switches
               << " direct context switches\n";
-    if (counters.total_switches > 0) {
-        std::cerr << std::setw(12) << std::setprecision(2)
-                  << 100 *
-                (counters.voluntary_switches /
-                 static_cast<double>(counters.total_switches))
-                  << "% voluntary switches\n";
-        std::cerr << std::setw(12) << std::setprecision(2)
-                  << 100 *
-                (counters.direct_switches / static_cast<double>(counters.total_switches))
-                  << "% direct switches\n";
-    }
+    print_percentage(static_cast<double>(counters.voluntary_switches),
+                     static_cast<double>(counters.total_switches),
+                     "% voluntary switches\n");
+    print_percentage(static_cast<double>(counters.direct_switches),
+                     static_cast<double>(counters.total_switches), "% direct switches\n");
     std::cerr << std::setw(12) << counters.syscalls << " system calls\n";
     std::cerr << std::setw(12) << counters.maybe_blocking_syscalls
               << " maybe-blocking system calls\n";
@@ -344,25 +353,21 @@ schedule_stats_t::print_counters(const counters_t &counters)
               << " direct switch requests\n";
     std::cerr << std::setw(12) << counters.waits << " waits\n";
     std::cerr << std::setw(12) << counters.idles << " idles\n";
-    std::cerr << std::setw(12) << std::setprecision(2)
-              << 100 *
-            (counters.instrs / static_cast<double>(counters.instrs + counters.idles))
-              << "% cpu busy by record count\n";
+    print_percentage(static_cast<double>(counters.instrs),
+                     static_cast<double>(counters.instrs + counters.idles),
+                     "% cpu busy by record count\n");
     std::cerr << std::setw(12) << counters.cpu_microseconds << " cpu microseconds\n";
     std::cerr << std::setw(12) << counters.idle_microseconds << " idle microseconds\n";
     std::cerr << std::setw(12) << counters.idle_micros_at_last_instr
               << " idle microseconds at last instr\n";
-    std::cerr << std::setw(12) << std::setprecision(2)
-              << 100 *
-            (counters.cpu_microseconds /
-             static_cast<double>(counters.cpu_microseconds + counters.idle_microseconds))
-              << "% cpu busy by time\n";
-    std::cerr << std::setw(12) << std::setprecision(2)
-              << 100 *
-            (counters.cpu_microseconds /
-             static_cast<double>(counters.cpu_microseconds +
-                                 counters.idle_micros_at_last_instr))
-              << "% cpu busy by time, ignoring idle past last instr\n";
+    print_percentage(
+        static_cast<double>(counters.cpu_microseconds),
+        static_cast<double>(counters.cpu_microseconds + counters.idle_microseconds),
+        "% cpu busy by time\n");
+    print_percentage(static_cast<double>(counters.cpu_microseconds),
+                     static_cast<double>(counters.cpu_microseconds +
+                                         counters.idle_micros_at_last_instr),
+                     "% cpu busy by time, ignoring idle past last instr\n");
 }
 
 bool

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -34,6 +34,13 @@
 
 #include "schedule_stats.h"
 
+#ifdef WINDOWS
+#    define WIN32_LEAN_AND_MEAN
+#    include <windows.h>
+#else
+#    include <sys/time.h>
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -123,6 +130,14 @@ bool
 schedule_stats_t::parallel_shard_exit(void *shard_data)
 {
     // Nothing (we read the shard data in print_results).
+    per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
+    if (shard->prev_was_idle) {
+        shard->counters.idle_microseconds +=
+            get_current_microseconds() - shard->segment_start_microseconds;
+    } else if (!shard->prev_was_wait) {
+        shard->counters.cpu_microseconds +=
+            get_current_microseconds() - shard->segment_start_microseconds;
+    }
     return true;
 }
 
@@ -131,6 +146,25 @@ schedule_stats_t::parallel_shard_error(void *shard_data)
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     return per_shard->error;
+}
+
+uint64_t
+schedule_stats_t::get_current_microseconds()
+{
+#ifdef UNIX
+    struct timeval time;
+    if (gettimeofday(&time, nullptr) != 0)
+        return 0;
+    return time.tv_sec * 1000000 + time.tv_usec;
+#else
+    SYSTEMTIME sys_time;
+    GetSystemTime(&sys_time);
+    FILETIME file_time;
+    if (!SystemTimeToFileTime(&sys_time, &file_time))
+        return 0;
+    return file_time.dwLowDateTime +
+        (static_cast<uint64_t>(file_time.dwHighDateTime) << 32);
+#endif
 }
 
 bool
@@ -163,8 +197,10 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
     // Cache and reset here to ensure we reset on early return paths.
     bool was_wait = shard->prev_was_wait;
     bool was_idle = shard->prev_was_idle;
+    int64_t prev_input = shard->prev_input;
     shard->prev_was_wait = false;
     shard->prev_was_idle = false;
+    shard->prev_input = -1;
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_WAIT) {
         ++shard->counters.waits;
@@ -187,6 +223,11 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         if (!was_idle) {
             shard->thread_sequence += IDLE_SYMBOL;
             shard->cur_segment_instrs = 0;
+            if (!was_wait && shard->segment_start_microseconds > 0) {
+                shard->counters.idle_microseconds +=
+                    get_current_microseconds() - shard->segment_start_microseconds;
+            }
+            shard->segment_start_microseconds = get_current_microseconds();
         } else {
             ++shard->cur_segment_instrs;
             if (shard->cur_segment_instrs == knob_print_every_) {
@@ -197,7 +238,7 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         return true;
     }
     int64_t input = shard->stream->get_input_id();
-    if (input != shard->prev_input) {
+    if (input != prev_input) {
         // We convert to letters which only works well for <=26 inputs.
         if (!shard->thread_sequence.empty()) {
             ++shard->counters.total_switches;
@@ -209,6 +250,11 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         shard->thread_sequence +=
             THREAD_LETTER_INITIAL_START + static_cast<char>(input % 26);
         shard->cur_segment_instrs = 0;
+        if (!was_wait && !was_idle && shard->segment_start_microseconds > 0) {
+            shard->counters.cpu_microseconds +=
+                get_current_microseconds() - shard->segment_start_microseconds;
+        }
+        shard->segment_start_microseconds = get_current_microseconds();
         if (knob_verbose_ >= 2) {
             std::ostringstream line;
             line << "Core #" << std::setw(2) << shard->core << " @" << std::setw(9)
@@ -226,11 +272,12 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
                  << " == thread " << memref.instr.tid << "\n";
             std::cerr << line.str();
         }
-        shard->prev_input = input;
     }
+    shard->prev_input = input;
     if (type_is_instr(memref.instr.type)) {
         ++shard->counters.instrs;
         ++shard->cur_segment_instrs;
+        shard->counters.idle_micros_at_last_instr = shard->counters.idle_microseconds;
         if (shard->cur_segment_instrs == knob_print_every_) {
             shard->thread_sequence +=
                 THREAD_LETTER_SUBSEQUENT_START + static_cast<char>(input % 26);
@@ -300,7 +347,22 @@ schedule_stats_t::print_counters(const counters_t &counters)
     std::cerr << std::setw(12) << std::setprecision(2)
               << 100 *
             (counters.instrs / static_cast<double>(counters.instrs + counters.idles))
-              << "% cpu busy\n";
+              << "% cpu busy by record count\n";
+    std::cerr << std::setw(12) << counters.cpu_microseconds << " cpu microseconds\n";
+    std::cerr << std::setw(12) << counters.idle_microseconds << " idle microseconds\n";
+    std::cerr << std::setw(12) << counters.idle_micros_at_last_instr
+              << " idle microseconds at last instr\n";
+    std::cerr << std::setw(12) << std::setprecision(2)
+              << 100 *
+            (counters.cpu_microseconds /
+             static_cast<double>(counters.cpu_microseconds + counters.idle_microseconds))
+              << "% cpu busy by time\n";
+    std::cerr << std::setw(12) << std::setprecision(2)
+              << 100 *
+            (counters.cpu_microseconds /
+             static_cast<double>(counters.cpu_microseconds +
+                                 counters.idle_micros_at_last_instr))
+              << "% cpu busy by time, ignoring idle past last instr\n";
 }
 
 bool

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -89,6 +89,9 @@ public:
             direct_switch_requests += rhs.direct_switch_requests;
             waits += rhs.waits;
             idles += rhs.idles;
+            idle_microseconds += rhs.idle_microseconds;
+            idle_micros_at_last_instr += rhs.idle_micros_at_last_instr;
+            cpu_microseconds += rhs.cpu_microseconds;
             for (const memref_tid_t tid : rhs.threads) {
                 threads.insert(tid);
             }
@@ -103,6 +106,9 @@ public:
         int64_t direct_switch_requests = 0;
         int64_t waits = 0;
         int64_t idles = 0;
+        uint64_t idle_microseconds = 0;
+        uint64_t idle_micros_at_last_instr = 0;
+        uint64_t cpu_microseconds = 0;
         std::unordered_set<memref_tid_t> threads;
     };
     counters_t
@@ -124,10 +130,15 @@ protected:
         uint64_t cur_segment_instrs = 0;
         bool prev_was_wait = false;
         bool prev_was_idle = false;
+        // Computing %-idle.
+        uint64_t segment_start_microseconds = 0;
     };
 
     void
     print_counters(const counters_t &counters);
+
+    uint64_t
+    get_current_microseconds();
 
     uint64_t knob_print_every_ = 0;
     unsigned int knob_verbose_ = 0;

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -135,6 +135,9 @@ protected:
     };
 
     void
+    print_percentage(double numerator, double denominator, const std::string &label);
+
+    void
     print_counters(const counters_t &counters);
 
     uint64_t


### PR DESCRIPTION
Changes instruction quantum idle handling to use wall-clock time, instead of a counter decremented in queue pops.  The counter was skewed unfairly by the rate of queue queries.  This results in all quanta using a unified time-based approach for blocked time.

Changes block_time_scale to remove the division by the latency threshold.  Now the scale is directly multiplied by the latency to result in the blocked time units.  The default scale is set to 1000 which matches the wall-clock time to process an instruction by the schedule_stats tool (about 1 instruction per microsecond) and which should be a rough match for many simulators passing one nanosecond cycle per instruction as the time unit.

Adds a new scheduler option block_time_max and drcachesim option -sched_block_max which caps the blocked time for a syscall (default 25 seconds) to avoid outliers being scaled to extreme amounts of time.

Adds a heartbeat of queue lookups, currently only in debug build, to help understand behavior over time.

Sets the input ordinal to invalid while idle.  This also causes schedule_stats to consider a transition from idle to a valid input to be a context switch, which matches how the Linux kernel counts switches.

Augments schedule_stats with a wall-clock measure of cpu and idle time for a much fairer %cpu metric than the previous one based purely on record counts, as schedule_stats processes an instruction much more quickly than an idle record.  Adds two %cpu metrics: one that does not include idle time past the final instruction (for skewed finishes across cores) and one that includes idle time until all cpus are done.

Increases the default -schedule_stats_print_every to 500K to avoid extremely long strings for larger workloads.

Updates the scheduler unit tests for the timing changes, changing the ones testing idle time to use a deterministic mock time quantum to avoid wall-clock time flakiness.

Tested on large traces on dozens of cores with known idle characteristics where by tweaking the parameters I was able to get reasonably representative idle times.

Issue: #6471