### PR TITLE
Remove "pre" tags from bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,11 +29,10 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots or Pasted Text**
 If applicable, add screenshots to help explain your problem.  For text, please cut and paste the text here, delimited by lines consisting of three backtics to render it verbatim, like this:
-<pre>
+
 ```
 paste output here
 ```
-</pre>
 
 **Versions**
  - What version of DynamoRIO are you using?


### PR DESCRIPTION
Removes the `<pre>` tags which made the backticks visible when rendered (as in the issue template view at
https://github.com/DynamoRIO/dynamorio/issues/templates/edit) in favor of making the raw source edit less confusing.