### PR TITLE
i#5694 core-sharded: Add core-serial support

### DIFF
--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -218,6 +218,8 @@ protected:
     init_scheduler(const std::string &trace_path, memref_tid_t only_thread, int verbosity,
                    typename sched_type_t::scheduler_options_t options);
 
+    // For core-sharded, worker_count_ must be set prior to calling this; for parallel
+    // mode if it is not set it will be set to the underlying core count.
     bool
     init_scheduler(std::unique_ptr<ReaderType> reader,
                    std::unique_ptr<ReaderType> reader_end, int verbosity,

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -192,12 +192,7 @@ analyzer_multi_t::analyzer_multi_t()
     scheduler_t::scheduler_options_t sched_ops;
     if (op_core_sharded.get_value() || op_core_serial.get_value()) {
         if (op_core_serial.get_value()) {
-            // TODO i#5694: Add serial core-sharded support by having the
-            // analyzer create #cores streams but walk them in lockstep.
-            // Then, update drcachesim to use get_output_cpuid().
-            error_string_ = "-core_serial is not yet implemented";
-            success_ = false;
-            return;
+            parallel_ = false;
         }
         sched_ops = init_dynamic_schedule();
     }
@@ -284,10 +279,6 @@ analyzer_multi_t::init_dynamic_schedule()
 bool
 analyzer_multi_t::create_analysis_tools()
 {
-    /* TODO i#2006: add multiple tool support. */
-    /* TODO i#2006: create a single top-level tool for multi-component
-     * tools.
-     */
     tools_ = new analysis_tool_t *[max_num_tools_];
     if (!op_simulator_type.get_value().empty()) {
         std::stringstream stream(op_simulator_type.get_value());

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -289,8 +289,9 @@ droption_t<bool> op_cpu_scheduling(
     "round-robin fashion.  This option causes the scheduler to instead use the recorded "
     "cpu that each thread executed on (at a granularity of the trace buffer size) "
     "for scheduling, mapping traced cpu's to cores and running each segment of each "
-    "thread "
-    "on the core that owns the recorded cpu for that segment.");
+    "thread on the core that owns the recorded cpu for that segment. "
+    "This option is not supported with -core_serial; use "
+    "-cpu_schedule_file with -core_serial instead.");
 
 droption_t<bytesize_t> op_max_trace_size(
     DROPTION_SCOPE_CLIENT, "max_trace_size", 0,

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -591,6 +591,14 @@ public:
         std::unique_ptr<ReaderType> kernel_switch_reader;
         /** The end reader for #kernel_switch_reader. */
         std::unique_ptr<ReaderType> kernel_switch_reader_end;
+        /**
+         * If true, enables a mode where all outputs are serialized into one global outer
+         * layer output.  The single global output stream alternates in round-robin
+         * lockstep amoung each core output.  The inner outputs operate just like they
+         * would with no serialization, other than timing differences relative to other
+         * outputs.
+         */
+        bool single_lockstep_output = false;
     };
 
     /**
@@ -628,9 +636,10 @@ public:
     class stream_t : public memtrace_stream_t {
     public:
         stream_t(scheduler_tmpl_t<RecordType, ReaderType> *scheduler, int ordinal,
-                 int verbosity = 0)
+                 int verbosity = 0, int max_ordinal = -1)
             : scheduler_(scheduler)
             , ordinal_(ordinal)
+            , max_ordinal_(max_ordinal)
             , verbosity_(verbosity)
         {
         }
@@ -933,6 +942,9 @@ public:
     protected:
         scheduler_tmpl_t<RecordType, ReaderType> *scheduler_ = nullptr;
         int ordinal_ = -1;
+        // If max_ordinal_ >= 0, ordinal_ is incremented modulo max_ordinal_ at the start
+        // of every next_record() invocation.
+        int max_ordinal_ = -1;
         int verbosity_ = 0;
         uint64_t cur_ref_count_ = 0;
         uint64_t cur_instr_count_ = 0;
@@ -971,7 +983,7 @@ public:
     {
         if (ordinal < 0 || ordinal >= static_cast<output_ordinal_t>(outputs_.size()))
             return nullptr;
-        return &outputs_[ordinal].stream;
+        return outputs_[ordinal].stream;
     }
 
     /** Returns the number of input streams. */
@@ -1160,12 +1172,16 @@ protected:
                       output_ordinal_t ordinal,
                       typename spec_type_t::speculator_flags_t speculator_flags,
                       RecordType last_record_init, int verbosity = 0)
-            : stream(scheduler, ordinal, verbosity)
+            : self_stream(scheduler, ordinal, verbosity)
+            , stream(&self_stream)
             , speculator(speculator_flags, verbosity)
             , last_record(last_record_init)
         {
         }
-        stream_t stream;
+        stream_t self_stream;
+        // Normally stream points to &self_stream, but for single_lockstep_output
+        // it points to a global stream shared among all outputs.
+        stream_t *stream;
         // This is an index into the inputs_ vector so -1 is an invalid value.
         // This is set to >=0 for all non-empty outputs during init().
         input_ordinal_t cur_input = INVALID_INPUT_ORDINAL;
@@ -1510,6 +1526,8 @@ protected:
     };
     std::unordered_map<switch_type_t, std::vector<RecordType>, switch_type_hash_t>
         switch_sequence_;
+    // For single_lockstep_output.
+    std::unique_ptr<stream_t> global_stream_;
 };
 
 /** See #dynamorio::drmemtrace::scheduler_tmpl_t. */

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -594,9 +594,9 @@ public:
         /**
          * If true, enables a mode where all outputs are serialized into one global outer
          * layer output.  The single global output stream alternates in round-robin
-         * lockstep amoung each core output.  The inner outputs operate just like they
+         * lockstep among each core output.  The core outputs operate just like they
          * would with no serialization, other than timing differences relative to other
-         * outputs.
+         * core outputs.
          */
         bool single_lockstep_output = false;
     };

--- a/clients/drcachesim/simulator/simulator.cpp
+++ b/clients/drcachesim/simulator/simulator.cpp
@@ -76,9 +76,11 @@ simulator_t::init_knobs(unsigned int num_cores, uint64_t skip_refs, uint64_t war
     knob_verbose_ = verbose;
     last_thread_ = 0;
     last_core_ = 0;
-    cpu_counts_.resize(knob_num_cores_, 0);
-    thread_counts_.resize(knob_num_cores_, 0);
-    thread_ever_counts_.resize(knob_num_cores_, 0);
+    if (shard_type_ == SHARD_BY_THREAD) {
+        cpu_counts_.resize(knob_num_cores_, 0);
+        thread_counts_.resize(knob_num_cores_, 0);
+        thread_ever_counts_.resize(knob_num_cores_, 0);
+    }
 
     if (knob_warmup_refs_ > 0 && (knob_warmup_fraction_ > 0.0)) {
         ERRMSG("Usage error: Either warmup_refs OR warmup_fraction can be set");
@@ -87,12 +89,31 @@ simulator_t::init_knobs(unsigned int num_cores, uint64_t skip_refs, uint64_t war
     }
 }
 
+std::string
+simulator_t::initialize_stream(memtrace_stream_t *serial_stream)
+{
+    serial_stream_ = serial_stream;
+    return "";
+}
+
+std::string
+simulator_t::initialize_shard_type(shard_type_t shard_type)
+{
+    shard_type_ = shard_type;
+    if (shard_type_ == SHARD_BY_CORE && knob_cpu_scheduling_) {
+        return "Usage error: -cpu_scheduling not supported with -core_serial; use "
+               "-cpu_schedule_file with -core_serial instead";
+    }
+    return "";
+}
+
 bool
 simulator_t::process_memref(const memref_t &memref)
 {
     if (memref.marker.type != TRACE_TYPE_MARKER)
         return true;
     if (memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID && knob_cpu_scheduling_) {
+        assert(shard_type_ == SHARD_BY_THREAD);
         int cpu = (int)(intptr_t)memref.marker.marker_value;
         if (cpu < 0)
             return true;
@@ -218,6 +239,27 @@ simulator_t::find_emptiest_core(std::vector<int> &counts) const
 int
 simulator_t::core_for_thread(memref_tid_t tid)
 {
+    if (shard_type_ == SHARD_BY_CORE) {
+        int cpu = serial_stream_->get_output_cpuid();
+        // While the scheduler uses a 0-based ordinal for all but replaying as-traced,
+        // to handle as-traced and in case the scheduler changes its cpuids we map
+        // to a 0-based index.
+        if (cpu == last_cpu_)
+            return last_core_;
+        int core;
+        auto exists = cpu2core_.find(cpu);
+        if (exists == cpu2core_.end()) {
+            core = cpu2core_.size();
+            cpu2core_[cpu] = core;
+            if (knob_verbose_ >= 1) {
+                std::cerr << "new cpu " << cpu << " => core " << core << "\n";
+            }
+        } else
+            core = exists->second;
+        last_cpu_ = cpu;
+        last_core_ = core;
+        return core;
+    }
     auto exists = thread2core_.find(tid);
     if (exists != thread2core_.end())
         return exists->second;
@@ -242,6 +284,8 @@ simulator_t::core_for_thread(memref_tid_t tid)
 void
 simulator_t::handle_thread_exit(memref_tid_t tid)
 {
+    if (shard_type_ == SHARD_BY_CORE)
+        return;
     std::unordered_map<memref_tid_t, int>::iterator exists = thread2core_.find(tid);
     assert(exists != thread2core_.end());
     assert(thread_counts_[exists->second] > 0);
@@ -256,17 +300,20 @@ simulator_t::handle_thread_exit(memref_tid_t tid)
 void
 simulator_t::print_core(int core) const
 {
-    if (!knob_cpu_scheduling_) {
+    if (!knob_cpu_scheduling_ && shard_type_ == SHARD_BY_THREAD) {
         std::cerr << "Core #" << core << " (" << thread_ever_counts_[core]
                   << " thread(s))" << std::endl;
     } else {
         std::cerr << "Core #" << core;
-        if (cpu_counts_[core] == 0) {
+        if (shard_type_ == SHARD_BY_THREAD && cpu_counts_[core] == 0) {
             // We keep the "(s)" mainly to simplify test templates.
             std::cerr << " (0 traced CPU(s))" << std::endl;
             return;
         }
-        std::cerr << " (" << cpu_counts_[core] << " traced CPU(s): ";
+        std::cerr << " (";
+        if (shard_type_ == SHARD_BY_THREAD) // Always 1:1 for SHARD_BY_CORE.
+            std::cerr << cpu_counts_[core] << " ";
+        std::cerr << "traced CPU(s): ";
         bool need_comma = false;
         for (auto iter = cpu2core_.begin(); iter != cpu2core_.end(); ++iter) {
             if (iter->second == core) {

--- a/clients/drcachesim/simulator/simulator.cpp
+++ b/clients/drcachesim/simulator/simulator.cpp
@@ -253,7 +253,7 @@ simulator_t::core_for_thread(memref_tid_t tid)
         int core;
         auto exists = cpu2core_.find(cpu);
         if (exists == cpu2core_.end()) {
-            core = cpu2core_.size();
+            core = static_cast<int>(cpu2core_.size());
             cpu2core_[cpu] = core;
             if (knob_verbose_ >= 1) {
                 std::cerr << "new cpu " << cpu << " => core " << core << "\n";

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -114,11 +114,11 @@ protected:
     shard_type_t shard_type_ = SHARD_BY_THREAD;
     memtrace_stream_t *serial_stream_ = nullptr;
     memref_tid_t last_thread_; // Only used for SHARD_BY_THREAD.
-    int last_cpu_ = -1;
+    int64_t last_cpu_ = -1;
     int last_core_;
 
     // For thread mapping to cores:
-    std::unordered_map<int, int> cpu2core_;
+    std::unordered_map<int64_t, int> cpu2core_;
     // The following fields are only used for SHARD_BY_THREAD.
     std::unordered_map<memref_tid_t, int> thread2core_;
     std::vector<int> cpu_counts_;

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -61,6 +61,13 @@ public:
                 double warmup_fraction, uint64_t sim_refs, bool cpu_scheduling,
                 bool use_physical, unsigned int verbose);
     virtual ~simulator_t() = 0;
+
+    std::string
+    initialize_stream(memtrace_stream_t *serial_stream) override;
+
+    std::string
+    initialize_shard_type(shard_type_t shard_type) override;
+
     bool
     process_memref(const memref_t &memref) override;
 
@@ -104,11 +111,15 @@ protected:
     bool knob_use_physical_;
     unsigned int knob_verbose_;
 
-    memref_tid_t last_thread_;
+    shard_type_t shard_type_ = SHARD_BY_THREAD;
+    memtrace_stream_t *serial_stream_ = nullptr;
+    memref_tid_t last_thread_; // Only used for SHARD_BY_THREAD.
+    int last_cpu_ = -1;
     int last_core_;
 
     // For thread mapping to cores:
     std::unordered_map<int, int> cpu2core_;
+    // The following fields are only used for SHARD_BY_THREAD.
     std::unordered_map<memref_tid_t, int> thread2core_;
     std::vector<int> cpu_counts_;
     std::vector<int> thread_counts_;

--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -1,0 +1,224 @@
+Schedule stats tool results:
+Total counts:
+           4 cores
+           8 threads
+      638938 instructions
+           6 total context switches
+   0.0093906 CSPKI \(context switches per 1000 instructions\)
+      106490 instructions per context switch
+           6 voluntary context switches
+           0 direct context switches
+      100.00% voluntary switches
+        0.00% direct switches
+         161 system calls
+           2 maybe-blocking system calls
+           0 direct switch requests
+           0 waits
+      345686 idles
+       64.89% cpu busy by record count
+    [0-9 ]* cpu microseconds
+    [0-9 ]* idle microseconds
+    [0-9 ]* idle microseconds at last instr
+    [0-9\. ]*% cpu busy by time
+    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+Core #0 counts:
+           2 threads
+      117015 instructions
+           3 total context switches
+   0.0256377 CSPKI \(context switches per 1000 instructions\)
+       39005 instructions per context switch
+           3 voluntary context switches
+           0 direct context switches
+      100.00% voluntary switches
+        0.00% direct switches
+         125 system calls
+           2 maybe-blocking system calls
+           0 direct switch requests
+           0 waits
+      323689 idles
+       26.55% cpu busy by record count
+    [0-9 ]* cpu microseconds
+    [0-9 ]* idle microseconds
+    [0-9 ]* idle microseconds at last instr
+    [0-9\. ]*% cpu busy by time
+    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+Core #1 counts:
+           2 threads
+      170398 instructions
+           1 total context switches
+   0.0058686 CSPKI \(context switches per 1000 instructions\)
+      170398 instructions per context switch
+           1 voluntary context switches
+           0 direct context switches
+      100.00% voluntary switches
+        0.00% direct switches
+          10 system calls
+           0 maybe-blocking system calls
+           0 direct switch requests
+           0 waits
+       21986 idles
+       88.57% cpu busy by record count
+    [0-9 ]* cpu microseconds
+    [0-9 ]* idle microseconds
+    [0-9 ]* idle microseconds at last instr
+    [0-9\. ]*% cpu busy by time
+    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+Core #2 counts:
+           2 threads
+      175766 instructions
+           1 total context switches
+   0.0056894 CSPKI \(context switches per 1000 instructions\)
+      175766 instructions per context switch
+           1 voluntary context switches
+           0 direct context switches
+      100.00% voluntary switches
+        0.00% direct switches
+          13 system calls
+           0 maybe-blocking system calls
+           0 direct switch requests
+           0 waits
+           0 idles
+      100.00% cpu busy by record count
+    [0-9 ]* cpu microseconds
+    [0-9 ]* idle microseconds
+    [0-9 ]* idle microseconds at last instr
+    [0-9\. ]*% cpu busy by time
+    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+Core #3 counts:
+           2 threads
+      175759 instructions
+           1 total context switches
+   0.0056896 CSPKI \(context switches per 1000 instructions\)
+      175759 instructions per context switch
+           1 voluntary context switches
+           0 direct context switches
+      100.00% voluntary switches
+        0.00% direct switches
+          13 system calls
+           0 maybe-blocking system calls
+           0 direct switch requests
+           0 waits
+          11 idles
+       99.99% cpu busy by record count
+    [0-9 ]* cpu microseconds
+    [0-9 ]* idle microseconds
+    [0-9 ]* idle microseconds at last instr
+    [0-9\. ]*% cpu busy by time
+    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+Core #0 schedule: FHF_F_
+Core #1 schedule: DA_
+Core #2 schedule: GC
+Core #3 schedule: BE_
+
+===========================================================================
+Basic counts tool results:
+Total counts:
+      638938 total \(fetched\) instructions
+        5969 total unique \(fetched\) instructions
+      546585 total non-fetched instructions
+           0 total prefetches
+      676963 total data loads
+      725896 total data stores
+           0 total icache flushes
+           0 total dcache flushes
+           8 total threads
+        1574 total scheduling markers
+         168 total transfer markers
+           0 total function id markers
+           0 total function return address markers
+           0 total function argument markers
+           0 total function return value markers
+           0 total physical address \+ virtual address marker pairs
+           0 total physical address unavailable markers
+         161 total system call number markers
+           2 total blocking system call markers
+          40 total other markers
+        8569 total encodings
+Core 2 counts:
+      175766 \(fetched\) instructions
+         445 unique \(fetched\) instructions
+      157499 non-fetched instructions
+           0 prefetches
+      192758 data loads
+      207661 data stores
+           0 icache flushes
+           0 dcache flushes
+           2 threads
+         294 scheduling markers
+           2 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
+          13 system call number markers
+           0 blocking system call markers
+          10 other markers
+         875 encodings
+Core 3 counts:
+      175759 \(fetched\) instructions
+         445 unique \(fetched\) instructions
+      157500 non-fetched instructions
+           0 prefetches
+      192758 data loads
+      207658 data stores
+           0 icache flushes
+           0 dcache flushes
+           2 threads
+         292 scheduling markers
+           2 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
+          13 system call number markers
+           0 blocking system call markers
+          10 other markers
+         875 encodings
+Core 1 counts:
+      170398 \(fetched\) instructions
+         445 unique \(fetched\) instructions
+      152836 non-fetched instructions
+           0 prefetches
+      187014 data loads
+      201468 data stores
+           0 icache flushes
+           0 dcache flushes
+           2 threads
+         280 scheduling markers
+           2 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
+          10 system call number markers
+           0 blocking system call markers
+          10 other markers
+         754 encodings
+Core 0 counts:
+      117015 \(fetched\) instructions
+        5969 unique \(fetched\) instructions
+       78750 non-fetched instructions
+           0 prefetches
+      104433 data loads
+      109109 data stores
+           0 icache flushes
+           0 dcache flushes
+           2 threads
+         708 scheduling markers
+         162 transfer markers
+           0 function id markers
+           0 function return address markers
+           0 function argument markers
+           0 function return value markers
+           0 physical address \+ virtual address marker pairs
+           0 physical address unavailable markers
+         125 system call number markers
+           2 blocking system call markers
+          10 other markers
+        6065 encodings

--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -22,93 +22,17 @@ Total counts:
     [0-9\. ]*% cpu busy by time
     [0-9\. ]*% cpu busy by time, ignoring idle past last instr
 Core #0 counts:
-           2 threads
-      117015 instructions
-           3 total context switches
-   0.0256377 CSPKI \(context switches per 1000 instructions\)
-       39005 instructions per context switch
-           3 voluntary context switches
-           0 direct context switches
-      100.00% voluntary switches
-        0.00% direct switches
-         125 system calls
-           2 maybe-blocking system calls
-           0 direct switch requests
-           0 waits
-      323689 idles
-       26.55% cpu busy by record count
-    [0-9 ]* cpu microseconds
-    [0-9 ]* idle microseconds
-    [0-9 ]* idle microseconds at last instr
-    [0-9\. ]*% cpu busy by time
-    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+.*
 Core #1 counts:
-           2 threads
-      170398 instructions
-           1 total context switches
-   0.0058686 CSPKI \(context switches per 1000 instructions\)
-      170398 instructions per context switch
-           1 voluntary context switches
-           0 direct context switches
-      100.00% voluntary switches
-        0.00% direct switches
-          10 system calls
-           0 maybe-blocking system calls
-           0 direct switch requests
-           0 waits
-       21986 idles
-       88.57% cpu busy by record count
-    [0-9 ]* cpu microseconds
-    [0-9 ]* idle microseconds
-    [0-9 ]* idle microseconds at last instr
-    [0-9\. ]*% cpu busy by time
-    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+.*
 Core #2 counts:
-           2 threads
-      175766 instructions
-           1 total context switches
-   0.0056894 CSPKI \(context switches per 1000 instructions\)
-      175766 instructions per context switch
-           1 voluntary context switches
-           0 direct context switches
-      100.00% voluntary switches
-        0.00% direct switches
-          13 system calls
-           0 maybe-blocking system calls
-           0 direct switch requests
-           0 waits
-           0 idles
-      100.00% cpu busy by record count
-    [0-9 ]* cpu microseconds
-    [0-9 ]* idle microseconds
-    [0-9 ]* idle microseconds at last instr
-    [0-9\. ]*% cpu busy by time
-    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+.*
 Core #3 counts:
-           2 threads
-      175759 instructions
-           1 total context switches
-   0.0056896 CSPKI \(context switches per 1000 instructions\)
-      175759 instructions per context switch
-           1 voluntary context switches
-           0 direct context switches
-      100.00% voluntary switches
-        0.00% direct switches
-          13 system calls
-           0 maybe-blocking system calls
-           0 direct switch requests
-           0 waits
-          11 idles
-       99.99% cpu busy by record count
-    [0-9 ]* cpu microseconds
-    [0-9 ]* idle microseconds
-    [0-9 ]* idle microseconds at last instr
-    [0-9\. ]*% cpu busy by time
-    [0-9\. ]*% cpu busy by time, ignoring idle past last instr
-Core #0 schedule: FHF_F_
-Core #1 schedule: DA_
-Core #2 schedule: GC
-Core #3 schedule: BE_
+.*
+Core #0 schedule: [A-H_]*
+Core #1 schedule: [A-H_]*
+Core #2 schedule: [A-H_]*
+Core #3 schedule: [A-H_]*
 
 ===========================================================================
 Basic counts tool results:
@@ -134,91 +58,11 @@ Total counts:
            2 total blocking system call markers
           40 total other markers
         8569 total encodings
-Core 2 counts:
-      175766 \(fetched\) instructions
-         445 unique \(fetched\) instructions
-      157499 non-fetched instructions
-           0 prefetches
-      192758 data loads
-      207661 data stores
-           0 icache flushes
-           0 dcache flushes
-           2 threads
-         294 scheduling markers
-           2 transfer markers
-           0 function id markers
-           0 function return address markers
-           0 function argument markers
-           0 function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-          13 system call number markers
-           0 blocking system call markers
-          10 other markers
-         875 encodings
-Core 3 counts:
-      175759 \(fetched\) instructions
-         445 unique \(fetched\) instructions
-      157500 non-fetched instructions
-           0 prefetches
-      192758 data loads
-      207658 data stores
-           0 icache flushes
-           0 dcache flushes
-           2 threads
-         292 scheduling markers
-           2 transfer markers
-           0 function id markers
-           0 function return address markers
-           0 function argument markers
-           0 function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-          13 system call number markers
-           0 blocking system call markers
-          10 other markers
-         875 encodings
-Core 1 counts:
-      170398 \(fetched\) instructions
-         445 unique \(fetched\) instructions
-      152836 non-fetched instructions
-           0 prefetches
-      187014 data loads
-      201468 data stores
-           0 icache flushes
-           0 dcache flushes
-           2 threads
-         280 scheduling markers
-           2 transfer markers
-           0 function id markers
-           0 function return address markers
-           0 function argument markers
-           0 function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-          10 system call number markers
-           0 blocking system call markers
-          10 other markers
-         754 encodings
-Core 0 counts:
-      117015 \(fetched\) instructions
-        5969 unique \(fetched\) instructions
-       78750 non-fetched instructions
-           0 prefetches
-      104433 data loads
-      109109 data stores
-           0 icache flushes
-           0 dcache flushes
-           2 threads
-         708 scheduling markers
-         162 transfer markers
-           0 function id markers
-           0 function return address markers
-           0 function argument markers
-           0 function return value markers
-           0 physical address \+ virtual address marker pairs
-           0 physical address unavailable markers
-         125 system call number markers
-           2 blocking system call markers
-          10 other markers
-        6065 encodings
+Core [0-9] counts:
+.*
+Core [0-9] counts:
+.*
+Core [0-9] counts:
+.*
+Core [0-9] counts:
+.*

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -817,12 +817,16 @@ unit_test_core_sharded()
         assert(res);
         std::cerr.rdbuf(prev_buf);
         // Make sure the large cpuids are mapped to core 0 and core 1.
-        assert(std::regex_search(output.str(), std::regex(R"DELIM((.|\n)*
+        // XXX: This regex causes a "regex_constants::error_complexity"
+        // exception on Windows; for now we disable this part of the test there.
+#ifndef WINDOWS
+        assert(std::regex_search(output.str(), std::regex(R"DELIM((.|\r?\n)*
 Core #0 \(traced CPU\(s\): #123400\)
-(.|\n)*
+(.|\r?\n)*
 Core #1 \(traced CPU\(s\): #567800\)
-(.|\n)*
+(.|\r?\n)*
 )DELIM")));
+#endif
     }
 }
 

--- a/clients/drcachesim/tests/simulate_as_traced.templatex
+++ b/clients/drcachesim/tests/simulate_as_traced.templatex
@@ -1,0 +1,116 @@
+Cache simulation results:
+Core #0 \(traced CPU\(s\): #9\)
+  L1I0 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                           94.?091
+    Misses:                             68
+    Compulsory misses:                  68
+    Invalidations:                       0
+    Miss rate:                        0.?07%
+  L1D0 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                          200.?175
+    Misses:                             40
+    Compulsory misses:                  70
+    Invalidations:                       0
+    Prefetch hits:                      10
+    Prefetch misses:                    30
+    Miss rate:                        0.?02%
+Core #1 \(traced CPU\(s\): #10\)
+  L1I1 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                           94.?076
+    Misses:                             66
+    Compulsory misses:                  66
+    Invalidations:                       0
+    Miss rate:                        0.?07%
+  L1D1 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                          200.?168
+    Misses:                             38
+    Compulsory misses:                  67
+    Invalidations:                       0
+    Prefetch hits:                       9
+    Prefetch misses:                    29
+    Miss rate:                        0.?02%
+Core #2 \(traced CPU\(s\): #5\)
+  L1I2 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                          188.?232
+    Misses:                             68
+    Compulsory misses:                  68
+    Invalidations:                       0
+    Miss rate:                        0.?04%
+  L1D2 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                          400.?362
+    Misses:                             59
+    Compulsory misses:                 105
+    Invalidations:                       0
+    Prefetch hits:                      13
+    Prefetch misses:                    46
+    Miss rate:                        0.?01%
+Core #3 \(traced CPU\(s\): #1\)
+  L1I3 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                           94.?076
+    Misses:                             66
+    Compulsory misses:                  66
+    Invalidations:                       0
+    Miss rate:                        0.?07%
+  L1D3 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                          200.?168
+    Misses:                             38
+    Compulsory misses:                  67
+    Invalidations:                       0
+    Prefetch hits:                       9
+    Prefetch misses:                    29
+    Miss rate:                        0.?02%
+Core #4 \(traced CPU\(s\): #8\)
+  L1I4 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                           29.?568
+    Misses:                            587
+    Compulsory misses:                 575
+    Invalidations:                       0
+    Miss rate:                        1.?95%
+  L1D4 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                           12.?893
+    Misses:                            458
+    Compulsory misses:                 717
+    Invalidations:                       0
+    Prefetch hits:                     106
+    Prefetch misses:                   352
+    Miss rate:                        3.?43%
+Core #5 \(traced CPU\(s\): #0\)
+  L1I5 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                           94.?083
+    Misses:                             68
+    Compulsory misses:                  68
+    Invalidations:                       0
+    Miss rate:                        0.?07%
+  L1D5 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                          200.?172
+    Misses:                             40
+    Compulsory misses:                  70
+    Invalidations:                       0
+    Prefetch hits:                      10
+    Prefetch misses:                    30
+    Miss rate:                        0.?02%
+Core #6 \(traced CPU\(s\): #11\)
+  L1I6 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                           88.?342
+    Misses:                             52
+    Compulsory misses:                  52
+    Invalidations:                       0
+    Miss rate:                        0.?06%
+  L1D6 \(size=32768, assoc=8, block=64, LRU\) stats:
+    Hits:                          188.?235
+    Misses:                             33
+    Compulsory misses:                  61
+    Invalidations:                       0
+    Prefetch hits:                       5
+    Prefetch misses:                    28
+    Miss rate:                        0.?02%
+LL \(size=8388608, assoc=16, block=64, LRU\) stats:
+    Hits:                              567
+    Misses:                          1.?114
+    Compulsory misses:               1.?512
+    Invalidations:                       0
+    Prefetch hits:                     146
+    Prefetch misses:                   398
+    Local miss rate:                 66.?27%
+    Child hits:                  2.?084.?803
+    Total miss rate:                  0.?05%

--- a/clients/drcachesim/tests/simulate_as_traced.templatex
+++ b/clients/drcachesim/tests/simulate_as_traced.templatex
@@ -1,116 +1,116 @@
 Cache simulation results:
 Core #0 \(traced CPU\(s\): #9\)
   L1I0 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                           94.?091
+    Hits:                         *94.?091
     Misses:                             68
     Compulsory misses:                  68
     Invalidations:                       0
-    Miss rate:                        0.?07%
+    Miss rate:                        0.07%
   L1D0 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                          200.?175
+    Hits:                        *200.?175
     Misses:                             40
     Compulsory misses:                  70
     Invalidations:                       0
     Prefetch hits:                      10
     Prefetch misses:                    30
-    Miss rate:                        0.?02%
+    Miss rate:                        0.02%
 Core #1 \(traced CPU\(s\): #10\)
   L1I1 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                           94.?076
+    Hits:                         *94.?076
     Misses:                             66
     Compulsory misses:                  66
     Invalidations:                       0
-    Miss rate:                        0.?07%
+    Miss rate:                        0.07%
   L1D1 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                          200.?168
+    Hits:                        *200.?168
     Misses:                             38
     Compulsory misses:                  67
     Invalidations:                       0
     Prefetch hits:                       9
     Prefetch misses:                    29
-    Miss rate:                        0.?02%
+    Miss rate:                        0.02%
 Core #2 \(traced CPU\(s\): #5\)
   L1I2 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                          188.?232
+    Hits:                        *188.?232
     Misses:                             68
     Compulsory misses:                  68
     Invalidations:                       0
-    Miss rate:                        0.?04%
+    Miss rate:                        0.04%
   L1D2 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                          400.?362
+    Hits:                        *400.?362
     Misses:                             59
     Compulsory misses:                 105
     Invalidations:                       0
     Prefetch hits:                      13
     Prefetch misses:                    46
-    Miss rate:                        0.?01%
+    Miss rate:                        0.01%
 Core #3 \(traced CPU\(s\): #1\)
   L1I3 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                           94.?076
+    Hits:                         *94.?076
     Misses:                             66
     Compulsory misses:                  66
     Invalidations:                       0
-    Miss rate:                        0.?07%
+    Miss rate:                        0.07%
   L1D3 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                          200.?168
+    Hits:                        *200.?168
     Misses:                             38
     Compulsory misses:                  67
     Invalidations:                       0
     Prefetch hits:                       9
     Prefetch misses:                    29
-    Miss rate:                        0.?02%
+    Miss rate:                        0.02%
 Core #4 \(traced CPU\(s\): #8\)
   L1I4 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                           29.?568
+    Hits:                         *29.?568
     Misses:                            587
     Compulsory misses:                 575
     Invalidations:                       0
-    Miss rate:                        1.?95%
+    Miss rate:                        1.95%
   L1D4 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                           12.?893
+    Hits:                         *12.?893
     Misses:                            458
     Compulsory misses:                 717
     Invalidations:                       0
     Prefetch hits:                     106
     Prefetch misses:                   352
-    Miss rate:                        3.?43%
+    Miss rate:                        3.43%
 Core #5 \(traced CPU\(s\): #0\)
   L1I5 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                           94.?083
+    Hits:                         *94.?083
     Misses:                             68
     Compulsory misses:                  68
     Invalidations:                       0
-    Miss rate:                        0.?07%
+    Miss rate:                        0.07%
   L1D5 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                          200.?172
+    Hits:                        *200.?172
     Misses:                             40
     Compulsory misses:                  70
     Invalidations:                       0
     Prefetch hits:                      10
     Prefetch misses:                    30
-    Miss rate:                        0.?02%
+    Miss rate:                        0.02%
 Core #6 \(traced CPU\(s\): #11\)
   L1I6 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                           88.?342
+    Hits:                         *88.?342
     Misses:                             52
     Compulsory misses:                  52
     Invalidations:                       0
-    Miss rate:                        0.?06%
+    Miss rate:                        0.06%
   L1D6 \(size=32768, assoc=8, block=64, LRU\) stats:
-    Hits:                          188.?235
+    Hits:                        *188.?235
     Misses:                             33
     Compulsory misses:                  61
     Invalidations:                       0
     Prefetch hits:                       5
     Prefetch misses:                    28
-    Miss rate:                        0.?02%
+    Miss rate:                        0.02%
 LL \(size=8388608, assoc=16, block=64, LRU\) stats:
     Hits:                              567
-    Misses:                          1.?114
-    Compulsory misses:               1.?512
+    Misses:                        *1.?114
+    Compulsory misses:             *1.?512
     Invalidations:                       0
     Prefetch hits:                     146
     Prefetch misses:                   398
-    Local miss rate:                 66.?27%
-    Child hits:                  2.?084.?803
-    Total miss rate:                  0.?05%
+    Local miss rate:                 66.27%
+    Child hits:               *2.?084.?803
+    Total miss rate:                  0.05%

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -274,7 +274,8 @@ protected:
     void
     compute_shard_interval_result(per_shard_t *shard, uint64_t interval_id);
 
-    // The keys here are int for parallel, tid for serial.
+    // The keys here are int index for parallel, tid for serial, cpu for
+    // core-sharded.
     std::unordered_map<memref_tid_t, per_shard_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init.  In all other accesses to
     // shard_map (process_memref, print_results) we are single-threaded.

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -147,7 +147,7 @@ protected:
     unsigned int knob_verbose_ = 0;
     // We use an ordered map to get our output in order.  This table is not
     // used on the hot path so its performance does not matter.
-    std::map<int, per_shard_t *> shard_map_;
+    std::map<int64_t, per_shard_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init.  In all other accesses to
     // shard_map (in print_results) we are single-threaded.
     std::mutex shard_map_mutex_;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3799,6 +3799,17 @@ if (BUILD_CLIENTS)
           "")
         set(tool.schedule_stats_nopreempt_rawtemp ON) # no preprocessor
 
+        torunonly_simtool(core_serial ${ci_shared_app}
+          "-indir ${thread_trace_dir} -simulator_type schedule_stats:basic_counts -core_serial"
+          "")
+        set(tool.core_serial_rawtemp ON) # no preprocessor
+
+        set(cpu_sched_path "${thread_trace_dir}/cpu_schedule.bin.zip")
+        torunonly_simtool(simulate_as_traced ${ci_shared_app}
+          "-indir ${thread_trace_dir} -core_serial -cpu_schedule_file ${cpu_sched_path} -cores 7"
+          "")
+        set(tool.simulate_as_traced_rawtemp ON) # no preprocessor
+
         set(switch_file
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/mock_switch_sequences.x64.zip")
         torunonly_simtool(switch_insertion ${ci_shared_app}


### PR DESCRIPTION
Adds a new scheduler option single_lockstep_output which multiplexes the virtual core output streams onto a single global stream.  This is simple to implement as the existing scheduler_t::stream_t class already multiplexes inputs onto an output.

Hooks up the drcachesim launcher -core_serial option to this new scheduler mode.

Updates the schedule_stats, basic_counts, and cache_simulator tools to support core_serial.  For cache_simulator, the existing thread-to-core mapping code for round-robin and for -cpu_scheduling is kept for when in thread-sharded mode; in core-sharded mode, the scheduler's cpuid is mapped to a core index.

Adds a core_serial test of schedule_stats and basic_counts and a test of cache_simulator using the scheduler's -cpu_schedule_file as-traced mode.

Adds some dr$sim unit tests for cpuid to core mapping and error modes.

Issue: #5694