### PR TITLE
Identify each test variation in linux.clone test output

### DIFF
--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -104,8 +104,8 @@ static void *stack;
 void
 test_thread(bool share_sighand, bool clone_vm, bool use_clone3)
 {
-    print("%s(share_sighand %d, clone_vm %d, use_clone3 %d)\n",
-          __FUNCTION__, share_sighand, clone_vm, use_clone3);
+    print("%s(share_sighand %d, clone_vm %d, use_clone3 %d)\n", __FUNCTION__,
+          share_sighand, clone_vm, use_clone3);
     if (use_clone3) {
 #ifdef SYS_clone3
         child = create_thread_clone3(run_with_exit, &stack, share_sighand, clone_vm);

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -104,6 +104,8 @@ static void *stack;
 void
 test_thread(bool share_sighand, bool clone_vm, bool use_clone3)
 {
+    print("%s(share_sighand %d, clone_vm %d, use_clone3 %d)\n",
+          __FUNCTION__, share_sighand, clone_vm, use_clone3);
     if (use_clone3) {
 #ifdef SYS_clone3
         child = create_thread_clone3(run_with_exit, &stack, share_sighand, clone_vm);

--- a/suite/tests/linux/clone.expect
+++ b/suite/tests/linux/clone.expect
@@ -1,3 +1,4 @@
+test_thread(share_sighand 0, clone_vm 0, use_clone3 0)
 Sideline thread started
 i = 2500000
 i = 5000000
@@ -11,6 +12,7 @@ i = 22500000
 i = 25000000
 Sideline thread finished
 Child has exited
+test_thread(share_sighand 0, clone_vm 0, use_clone3 1)
 Sideline thread started
 i = 2500000
 i = 5000000
@@ -24,6 +26,7 @@ i = 22500000
 i = 25000000
 Sideline thread finished
 Child has exited
+test_thread(share_sighand 0, clone_vm 1, use_clone3 0)
 Sideline thread started
 i = 2500000
 i = 5000000
@@ -37,6 +40,7 @@ i = 22500000
 i = 25000000
 Sideline thread finished
 Child has exited
+test_thread(share_sighand 0, clone_vm 1, use_clone3 1)
 Sideline thread started
 i = 2500000
 i = 5000000
@@ -50,6 +54,7 @@ i = 22500000
 i = 25000000
 Sideline thread finished
 Child has exited
+test_thread(share_sighand 1, clone_vm 1, use_clone3 0)
 Sideline thread started
 i = 2500000
 i = 5000000
@@ -63,6 +68,7 @@ i = 22500000
 i = 25000000
 Sideline thread finished
 Child has exited
+test_thread(share_sighand 1, clone_vm 1, use_clone3 1)
 Sideline thread started
 i = 2500000
 i = 5000000


### PR DESCRIPTION
The output is basically the same for each test variation, making it hard to correlate each test's output with the test's code.