### PR TITLE
i#6514 clone: Fix app segv when passing null stack ptr

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -817,12 +817,18 @@ create_clone_record(dcontext_t *dcontext, reg_t *app_thread_xsp)
              * cl_args->stack. But we expect the highest (non-inclusive)
              * in the clone record's app_thread_xsp.
              */
-            record->app_thread_xsp = dr_clone_args->stack + dr_clone_args->stack_size;
+            if (dr_clone_args->stack == 0)
+                record->app_thread_xsp = get_mcontext(dcontext)->xsp;
+            else
+                record->app_thread_xsp = dr_clone_args->stack + dr_clone_args->stack_size;
             record->clone_flags = dr_clone_args->flags;
             record->app_clone_args = app_clone_args;
         } else {
 #endif
-            record->app_thread_xsp = *app_thread_xsp;
+            if (*app_thread_xsp == 0)
+                record->app_thread_xsp = get_mcontext(dcontext)->xsp;
+            else
+                record->app_thread_xsp = *app_thread_xsp;
             record->clone_flags = dcontext->sys_param0;
             IF_LINUX(record->app_clone_args = NULL);
 #ifdef LINUX

--- a/suite/tests/linux/clone.template
+++ b/suite/tests/linux/clone.template
@@ -82,3 +82,61 @@ i = 22500000
 i = 25000000
 Sideline thread finished
 Child has exited
+#if defined(X86)
+test_with_null_stack_pointer(clone_vm 0, use_clone3 0)
+Sideline thread started
+i = 2500000
+i = 5000000
+i = 7500000
+i = 10000000
+i = 12500000
+i = 15000000
+i = 17500000
+i = 20000000
+i = 22500000
+i = 25000000
+Sideline thread finished
+Child has exited
+test_with_null_stack_pointer(clone_vm 0, use_clone3 1)
+Sideline thread started
+i = 2500000
+i = 5000000
+i = 7500000
+i = 10000000
+i = 12500000
+i = 15000000
+i = 17500000
+i = 20000000
+i = 22500000
+i = 25000000
+Sideline thread finished
+Child has exited
+test_with_null_stack_pointer(clone_vm 1, use_clone3 0)
+Sideline thread started
+i = 2500000
+i = 5000000
+i = 7500000
+i = 10000000
+i = 12500000
+i = 15000000
+i = 17500000
+i = 20000000
+i = 22500000
+i = 25000000
+Sideline thread finished
+Child has exited
+test_with_null_stack_pointer(clone_vm 1, use_clone3 1)
+Sideline thread started
+i = 2500000
+i = 5000000
+i = 7500000
+i = 10000000
+i = 12500000
+i = 15000000
+i = 17500000
+i = 20000000
+i = 22500000
+i = 25000000
+Sideline thread finished
+Child has exited
+#endif


### PR DESCRIPTION
Recognize the special case of passing NULL for the stack pointer to clone(), clone3(). Passing NULL for the stack pointer is just a shorthand way of saying that that the child gets the parent's stack pointer value. This is what Go does for its fork/exec support.

Fixes: #6514