### PR TITLE
i#6529: Check end of section headers mapped

### DIFF
--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -581,7 +581,8 @@ rseq_process_module(module_area_t *ma, bool at_map, bool saw_glibc_rseq_reg)
     ELF_SECTION_HEADER_TYPE *sec_hdr = NULL;
     char *strtab;
     ssize_t load_offs = ma->start - ma->os_data.base_address;
-    if (at_map && elf_hdr->e_shoff + ma->start < ma->end) {
+    if (at_map &&
+        elf_hdr->e_shoff + elf_hdr->e_shnum * sizeof(*sec_hdr) + ma->start < ma->end) {
         sec_map = elf_hdr->e_shoff + ma->start;
         sec_hdr = (ELF_SECTION_HEADER_TYPE *)sec_map;
         /* We assume strtab is there too. */

--- a/core/unix/rseq_linux.c
+++ b/core/unix/rseq_linux.c
@@ -582,7 +582,8 @@ rseq_process_module(module_area_t *ma, bool at_map, bool saw_glibc_rseq_reg)
     char *strtab;
     ssize_t load_offs = ma->start - ma->os_data.base_address;
     if (at_map &&
-        elf_hdr->e_shoff + elf_hdr->e_shnum * sizeof(*sec_hdr) + ma->start < ma->end) {
+        elf_hdr->e_shoff + elf_hdr->e_shnum * elf_hdr->e_shentsize + ma->start <
+            ma->end) {
         sec_map = elf_hdr->e_shoff + ma->start;
         sec_hdr = (ELF_SECTION_HEADER_TYPE *)sec_map;
         /* We assume strtab is there too. */


### PR DESCRIPTION
Updates the rseq_process_module() check for the section headers being in the mapped region to check the endpoint instead of the start point.

Tested locally: now client.drwrap-test passes when it failed with the toolchain on my local machine.

Fixes #6529