### PR TITLE
i#6530: Support alternate libc name in drsyms-test

### DIFF
--- a/suite/tests/client-interface/drsyms-test.dll.cpp
+++ b/suite/tests/client-interface/drsyms-test.dll.cpp
@@ -580,7 +580,7 @@ lookup_dll_syms(void *dc, const module_data_t *dll_data, bool loaded)
     dll_base = dll_data->start;
 
 #ifdef UNIX
-    if (strstr(dll_path, "/libc-")) {
+    if (strstr(dll_path, "/libc-") != nullptr || strstr(dll_path, "/libc.") != nullptr) {
         lookup_glibc_syms(dc, dll_data);
         return;
     }


### PR DESCRIPTION
The drsyms-test was looking for "/libc-" to find the libc library, which failes to find "/usr/lib/x86_64-linux-gnu/libc.so.6".  We update the search here to allow a dot.

Tested locally where the test failed before.

Fixes #6530