### PR TITLE
i#5926 libdw: Add new interface dr_running_under_dynamorio()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2008-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -190,6 +190,7 @@ Further non-compatibility-affecting changes include:
  - Added support of loading separately-built analysis tools to drcachesim dynamically.
  - Added instr_is_opnd_store_source().
  - Added kernel context switch sequence injection support to the drmemtrace scheduler.
+ - Added dr_running_under_dynamorio().
 
 **************************************************
 <hr>

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2023, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -102,6 +102,15 @@ DR_API
 /** Returns true if all DynamoRIO caches are thread private. */
 bool
 dr_using_all_private_caches(void);
+
+DR_API
+/**
+ * Returns false if DynamoRIO is being used as a regular standalone library.
+ * Returns true if DynamoRIO is controlling the application by running
+ * its code through a sofwtare code cache.
+ */
+bool
+dr_running_under_dynamorio(void);
 
 DR_API
 /** \deprecated Replaced by dr_set_process_exit_behavior() */

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -105,9 +105,10 @@ dr_using_all_private_caches(void);
 
 DR_API
 /**
- * Returns false if DynamoRIO is being used as a regular standalone library.
+ * Returns false if DynamoRIO is being used as a "regular" standalone library
+ * (see dr_standalone_init() and \ref page_standalone).
  * Returns true if DynamoRIO is controlling the application by running
- * its code through a sofwtare code cache.
+ * its code through a software code cache.
  */
 bool
 dr_running_under_dynamorio(void);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2010-2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -2507,6 +2507,13 @@ bool
 dr_using_all_private_caches(void)
 {
     return !SHARED_FRAGMENTS_ENABLED();
+}
+
+DR_API
+bool
+dr_running_under_dynamorio(void)
+{
+    return !standalone_library;
 }
 
 DR_API

--- a/suite/tests/api/ir_x86.c
+++ b/suite/tests/api/ir_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2869,6 +2869,8 @@ main(int argc, char *argv[])
     void *dcontext = GLOBAL_DCONTEXT;
 #else
     void *dcontext = dr_standalone_init();
+
+    ASSERT(!dr_running_under_dynamorio());
 
     /* simple test of deadlock_avoidance, etc. being disabled in standalone */
     void *x = dr_mutex_create();

--- a/suite/tests/client-interface/dr_options.dll.c
+++ b/suite/tests/client-interface/dr_options.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -63,6 +63,8 @@ dr_init(client_id_t client_id)
      * should match the value read from the arbitrary query API.
      */
     ASSERT(dr_using_all_private_caches());
+
+    ASSERT(dr_running_under_dynamorio());
 
     /* Query non-existent options. */
     int_option = 1;


### PR DESCRIPTION
Adds a new API routine dr_running_under_dynamorio() which is similar to the application interface dr_app_running_under_dynamorio() but is callable from a client.  The use case is code meant for us both in managed mode under DR and in standalone library mode.  Sometimes the behavior for the two differs significantly, such as whether certain library routines are safe when linked statically.

Adds sanity checks to some existing tests.

The driving use case is in drsyms's support for libdw.  The actual use of this will come in that libdw commit.

Issue: #5926