### PR TITLE
Fix detach test through "-attach"

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -1412,7 +1412,7 @@ function(torun test key source native standalone_dr dr_ops exe_ops added_out pas
         set(exe_ops "${exe_ops};-v;-attach")
       endif ()
       if ("${runall}" MATCHES "<detach>")
-        set(exe_ops "${exe_ops};-v;")
+        set(exe_ops "${exe_ops};-v;-attach")
       endif ()
       if ("${runall}" MATCHES "<block>")
         set(exe_ops "${exe_ops};-block")


### PR DESCRIPTION
 Add an extra "-attach" option inside linux.infloop's exe_ops to avoid failed memory protection.