### PR TITLE
i#6541 privlib: Add try/except around private library init/fini

### DIFF
--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -8385,7 +8385,7 @@ check_in_last_thread_vm_area(dcontext_t *dcontext, app_pc pc)
                    data->last_area->start <= pc);
     }
     /* last decoded app pc may be in last shared area instead */
-    if (!in_last && DYNAMO_OPTION(shared_bbs)) {
+    if (!in_last && DYNAMO_OPTION(shared_bbs) && shared_data != NULL) {
         /* We avoid the high-ranked shared_vm_areas lock which can easily cause
          * rank order violations (i#3346).  We're trying to catch the scenario
          * where a shared bb is being built and we fault decoding it.  There,


### PR DESCRIPTION
Wraps private library init/fini calls in a try/except on Linux (as is already done on Windows) and reports a crash as a SYSLOG_ERROR pointing at the library's name.  This is much better than a weird assert or mysterious secondary crash later.

Adds a check for shared_data==NULL in check_thread_in_last_vmwarea() to avoid a crash seen there.

Issue: #6541