### PR TITLE
Use 64-bit in Linux examples in docs

### DIFF
--- a/api/docs/building.dox
+++ b/api/docs/building.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -198,7 +198,29 @@ If you wish to run the test suite, you should enable BUILD_TESTS.
 
 ----------------
 
-## Cross-Compiling for ARM on Linux
+## Cross-Compiling for 64-bit ARM (AArch64) on Linux
+
+Install the cross compiler for the `gnueabihf` target:
+
+```
+$ sudo apt-get install g++-aarch64-linux-gnu
+```
+
+Check out the sources as normal, and point at our toolchain CMake file:
+
+```
+$ git clone https://github.com/DynamoRIO/dynamorio.git
+$ mkdir build_aarch64
+$ cd build_aarch64
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-arm64.cmake ../dynamorio
+$ make -j
+```
+
+To build a client, again use the toolchain file, as well as pointing at a DynamoRIO installation using `-DDynamoRIO_DIR=<path>` as described in the package documentation.
+
+----------------
+
+## Cross-Compiling for 32-bit ARM (AArch32) on Linux
 
 Install the cross compiler for the `gnueabihf` target:
 

--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * ******************************************************************************/
@@ -318,7 +318,7 @@ There are two methods for invoking an application under DynamoRIO:
 As an example of the simpler method, the following command runs \c ls
 under DynamoRIO with the bbsize sample client:
 \code
-% bin32/drrun -c samples/bin32/libbbsize.so -- ls
+% bin64/drrun -c samples/bin64/libbbsize.so -- ls
 \endcode
 
 Alternatively, you can first run the target, and then use \c drrun
@@ -328,7 +328,7 @@ In particular, if the application is in the middle of a blocking syscall,
 DynamoRIO will wait for that to finish.  To instead force interruption of
 the syscall, additionally pass -skip_syscall.
 \code
-% bin32/drrun -attach <target_pid> -c samples/bin32/libbbsize.so
+% bin64/drrun -attach <target_pid> -c samples/bin64/libbbsize.so
 \endcode
 
 This attach feature requires ptrace capabilities, which can be enabled
@@ -340,7 +340,7 @@ with this command:
 Then, you can also detach DynamoRIO from the target process
 without affecting the normal execution of the application.
 \code
-% bin32/drconfig -detach <target_pid>
+% bin64/drconfig -detach <target_pid>
 \endcode
 
 Run \c drrun with no options to get a list of the options and
@@ -390,7 +390,7 @@ To \ref sec_comm "nudge" a process with pid \c targetpid running under
 DynamoRIO and pass argument "5" to the nudge callback, use the \c
 drnudgeunix tool:
 \code
-bin32/drnudgeunix -pid targetpid -client 0 5
+bin64/drnudgeunix -pid targetpid -client 0 5
 \endcode
 This will result in a nudge event with argument=5 delivered to the
 client callback registered with dr_register_nudge_event() in the


### PR DESCRIPTION
Updates the example command lines in the Linux Deployment docs to use 64-bit which is far more common these days.