### PR TITLE
i#5926 elfutils: Add submodule init to all git clone commands

### DIFF
--- a/api/docs/building.dox
+++ b/api/docs/building.dox
@@ -47,7 +47,7 @@ To build DynamoRIO on Linux, use the following commands as a guide.  This builds
   # other distributions (in particular, use "cmake3" for Ubuntu Trusty).
   $ sudo apt-get install cmake g++ g++-multilib doxygen git zlib1g-dev libunwind-dev libsnappy-dev liblz4-dev
   # Get sources and initialize the submodules.
-  $ git clone --recursive https://github.com/DynamoRIO/dynamorio.git
+  $ git clone --recurse-submodules -j4 https://github.com/DynamoRIO/dynamorio.git
   # Make a separate build directory.  Building in the source directory is not
   # supported.
   $ cd dynamorio && mkdir build && cd build
@@ -78,7 +78,7 @@ To build 64-bit DynamoRIO in release mode, launch the `Visual Studio 2019 > x64 
 
   ```
   # Get sources.
-  $ git clone https://github.com/DynamoRIO/dynamorio.git
+  $ git clone --recurse-submodules -j4 https://github.com/DynamoRIO/dynamorio.git
   # Make a separate build directory.  Building in the source directory is not
   # supported.
   $ cd dynamorio && mkdir build && cd build
@@ -209,7 +209,7 @@ $ sudo apt-get install g++-aarch64-linux-gnu
 Check out the sources as normal, and point at our toolchain CMake file:
 
 ```
-$ git clone https://github.com/DynamoRIO/dynamorio.git
+$ git clone --recurse-submodules -j4 https://github.com/DynamoRIO/dynamorio.git
 $ mkdir build_aarch64
 $ cd build_aarch64
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-arm64.cmake ../dynamorio
@@ -231,7 +231,7 @@ $ sudo apt-get install gcc-arm-linux-gnueabihf binutils-arm-linux-gnueabihf g++-
 Check out the sources as normal, and point at our toolchain CMake file:
 
 ```
-$ git clone https://github.com/DynamoRIO/dynamorio.git
+$ git clone --recurse-submodules -j4 https://github.com/DynamoRIO/dynamorio.git
 $ mkdir build_arm
 $ cd build_arm
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-arm32.cmake ../dynamorio
@@ -263,7 +263,7 @@ Now check out the sources as normal, and point at our toolchain CMake file.  If 
 
 
 ```
-$ git clone https://github.com/DynamoRIO/dynamorio.git
+$ git clone --recurse-submodules -j4 https://github.com/DynamoRIO/dynamorio.git
 $ mkdir build_android
 $ cd build_android
 $ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-android.cmake -DANDROID_TOOLCHAIN=/mytooldir/android-ndk-21 -DDR_COPY_TO_DEVICE=ON ../dynamorio

--- a/api/docs/workflow.dox
+++ b/api/docs/workflow.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -53,13 +53,13 @@ Clone the repository, either via ssh if you've set up ssh keys in your
 Github profile:
 
 ~~~{.unparsed}
-git clone git@github.com:DynamoRIO/dynamorio.git
+git clone --recurse-submodules -j4 git@github.com:DynamoRIO/dynamorio.git
 ~~~
 
 Or via https:
 
 ~~~{.unparsed}
-git clone https://github.com/DynamoRIO/dynamorio.git
+git clone --recurse-submodules -j4 https://github.com/DynamoRIO/dynamorio.git
 ~~~
 
 # Configuring Author Information and Aliases


### PR DESCRIPTION
Submodules are now required for Linux (for elfutils for drsyms) so we go ahead and add them to all git clone commands in the documentation.

Issue: #5926