### PR TITLE
i#3544, i#1551, i#1569 signal: Remove a non-existing field in sigframe_rt_t

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3644,7 +3644,6 @@ convert_frame_to_nonrt(dcontext_t *dcontext, int sig, sigframe_rt_t *f_old,
     f_new->sig_noclobber = f_new->sig;
 #    elif defined(ARM)
     memcpy(&f_new->uc, &f_old->uc, sizeof(f_new->uc));
-    memcpy(f_new->retcode, f_old->retcode, sizeof(f_new->retcode));
     /* now fill in our extra field */
     f_new->sig_noclobber = f_old->info.si_signo;
 #    endif /* X86 */

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3644,6 +3644,7 @@ convert_frame_to_nonrt(dcontext_t *dcontext, int sig, sigframe_rt_t *f_old,
     f_new->sig_noclobber = f_new->sig;
 #    elif defined(ARM)
     memcpy(&f_new->uc, &f_old->uc, sizeof(f_new->uc));
+    memcpy(f_new->retcode, f_old->retcode, sizeof(f_new->retcode));
     /* now fill in our extra field */
     f_new->sig_noclobber = f_old->info.si_signo;
 #    endif /* X86 */

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -214,7 +214,11 @@ typedef _STRUCT_UCONTEXT /* == __darwin_ucontext */ kernel_ucontext_t;
  * (these are from /usr/src/linux/arch/i386/kernel/signal.c for kernel 2.4.17)
  */
 
-#    define RETCODE_SIZE 8
+#    if defined(X86) && !defined(X64)
+#        define RETCODE_SIZE 8
+#    elif defined(ARM)
+#        define RETCODE_SIZE 16
+#    endif
 
 typedef struct sigframe {
 #    ifdef X86
@@ -280,11 +284,9 @@ typedef struct rt_sigframe {
 #    elif defined(AARCHXX)
     kernel_siginfo_t info;
     kernel_ucontext_t uc;
-    char retcode[RETCODE_SIZE];
 #    elif defined(RISCV64)
     kernel_siginfo_t info;
     kernel_ucontext_t uc;
-    char retcode[RETCODE_SIZE];
 #    endif
 
 #elif defined(MACOS)

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -284,6 +284,9 @@ typedef struct rt_sigframe {
 #    elif defined(AARCHXX)
     kernel_siginfo_t info;
     kernel_ucontext_t uc;
+#        ifdef ARM
+    char retcode[RETCODE_SIZE];
+#        endif
 #    elif defined(RISCV64)
     kernel_siginfo_t info;
     kernel_ucontext_t uc;

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -214,7 +214,7 @@ typedef _STRUCT_UCONTEXT /* == __darwin_ucontext */ kernel_ucontext_t;
  * (these are from /usr/src/linux/arch/i386/kernel/signal.c for kernel 2.4.17)
  */
 
-#    if defined(X86) && !defined(X64)
+#    if defined(X86)
 #        define RETCODE_SIZE 8
 #    elif defined(ARM)
 #        define RETCODE_SIZE 16


### PR DESCRIPTION
The `retcode` field in `sigframe_rt_t` is only available in x86 and AArch32, this fixes a buffer overflow in `memcpy_rt_frame()` on RISC-V.

Issue: #3544 #1551 #1569