### PR TITLE
i#6508: Fix a compilation error in release build

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1208,8 +1208,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::read_switch_sequences()
     while (*reader != *reader_end) {
         RecordType record = **reader;
         // Only remember the records between the markers.
-        trace_marker_type_t marker_type;
-        uintptr_t marker_value;
+        trace_marker_type_t marker_type = TRACE_MARKER_TYPE_RESERVED_END;
+        uintptr_t marker_value = 0;
         if (record_type_is_marker(record, marker_type, marker_value) &&
             marker_type == TRACE_MARKER_TYPE_CONTEXT_SWITCH_START) {
             switch_type = static_cast<sched_type_t::switch_type_t>(marker_value);


### PR DESCRIPTION
A release build on RISC-V outputs the following compilation error:

```
$HOME/dynamorio/clients/drcachesim/scheduler/scheduler.cpp:1223:70: error: ‘marker_type’ may be used uninitialized [-Werror=maybe-uninitialized]
 1223 |         if (record_type_is_marker(record, marker_type, marker_value) &&
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
 1224 |             marker_type == TRACE_MARKER_TYPE_CONTEXT_SWITCH_END) {
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$HOME/dynamorio/clients/drcachesim/scheduler/scheduler.cpp:1211:29: note: ‘marker_type’ was declared here
 1211 |         trace_marker_type_t marker_type;
      |                             ^~~~~~~~~~~
$HOME/dynamorio/clients/drcachesim/scheduler/scheduler.cpp:1225:17: error: ‘marker_value’ may be used uninitialized [-Werror=maybe-uninitialized]
    }
 1225 |             if (static_cast<sched_type_t::switch_type_t>(marker_value) != switch_type) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
$HOME/dynamorio/clients/drcachesim/scheduler/scheduler.cpp:1212:19: note: ‘marker_value’ was declared here
 1212 |         uintptr_t marker_value;
      |                   ^~~~~~~~~~~~
```