### PR TITLE
i#5740: Remove attach/detach flaky-list entries on a64

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # **********************************************************
-# Copyright () 2016-2023 Google, Inc.  All rights reserved.
+# Copyright () 2016-2024 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -339,9 +339,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|linux.fib-conflict-early' => 1,
                                    'code_api|linux.mangle_asynch' => 1,
                                    'code_api,tracedump_text,tracedump_origins,syntax_intel|common.loglevel' => 1, # i#1807
-                                   'code_api|client.attach_test' => 1, # i#5740
-                                   'code_api|client.detach_test' => 1, # i#5740
-                                   'code_api|client.attach_blocking' => 1, # i#5740
                                    'code_api|tool.drcacheoff.rseq' => 1, # i#5734
                                    'code_api|tool.drcacheoff.windows-zlib' => 1, # i#5507
                                    );


### PR DESCRIPTION
Now that we've enabled ptrace privileges on the a64 testing machine we can remove the attach/detach tests from the flaky list as they no longer hang.  The attach test passed 100x in a row for me so it doesn't seem to be hitting flakes seen on other platforms like #6452.

Issue: #5740, #6558, #6127
Fixes #5740