### PR TITLE
i#5926: Update elfutils submodule to https protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
     url = https://github.com/madler/zlib.git
 [submodule "third_party/elfutils"]
     path = third_party/elfutils
-    url = git://sourceware.org/git/elfutils.git
+    url = https://sourceware.org/git/elfutils.git


### PR DESCRIPTION
Use HTTPs version of the elfutils submodule URL as it's easier for users behind an HTTP proxy.