### PR TITLE
i#4304 unexpected_return unreachable on aarch64: Use long branch

### DIFF
--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -104,19 +104,6 @@ DECL_EXTERN(initstack_mutex)
 DECL_EXTERN(icache_op_struct)
 DECL_EXTERN(linkstub_selfmod)
 
-/* For debugging: report an error if the function called by call_switch_stack()
- * unexpectedly returns.  Also used elsewhere.
- */
-        DECLARE_FUNC(unexpected_return)
-GLOBAL_LABEL(unexpected_return:)
-        CALLC3(GLOBAL_REF(d_r_internal_error), HEX(0), HEX(0), HEX(0))
-        /* d_r_internal_error normally never returns */
-        /* Infinite loop is intentional.  Can we do better in release build?
-         * XXX: why not a debug instr?
-         */
-        JUMP  GLOBAL_REF(unexpected_return)
-        END_FUNC(unexpected_return)
-
 /* bool mrs_id_reg_supported(void)
  * Checks for kernel support of the MRS instr when reading system registers
  * above exception level EL0, by attempting to read Instruction Set Attribute
@@ -158,7 +145,9 @@ call_dispatch_alt_stack_no_free:
         /* Switch stack back. */
         mov      sp, x19
         /* Test return_on_return. */
-        cbz      w20, GLOBAL_REF(unexpected_return)
+        cbnz     w20, call_dispatch_alt_stack_ok_return
+        bl       GLOBAL_REF(unexpected_return)
+call_dispatch_alt_stack_ok_return:
         /* Restore and return. */
         ldr      x19, [sp, #16]
         ldp      x20, x30, [sp], #32

--- a/core/arch/arm/arm.asm
+++ b/core/arch/arm/arm.asm
@@ -114,7 +114,9 @@ call_dispatch_alt_stack_no_free:
         /* after call, so we can use REG_R3 as the scratch register */
         ldr      REG_R3, [sp, #8/* r4, lr */] /* ARG5 */
         cmp      REG_R3, #0
-        beq      GLOBAL_REF(unexpected_return)
+        bne      call_dispatch_alt_stack_ok_return
+        bl       GLOBAL_REF(unexpected_return)
+call_dispatch_alt_stack_ok_return:
         /* restore and return */
         pop      {REG_R4, pc}
         END_FUNC(call_switch_stack)

--- a/core/arch/riscv64/riscv64.asm
+++ b/core/arch/riscv64/riscv64.asm
@@ -95,7 +95,9 @@ call_dispatch_alt_stack_no_free:
         jalr     ARG3
         /* Switch stack back. */
         mv       sp, s0
-        beqz     s1, GLOBAL_LABEL(unexpected_return)
+        bnez     s1, call_dispatch_alt_stack_ok_return
+        jal      GLOBAL_LABEL(unexpected_return)
+call_dispatch_alt_stack_ok_return:
         /* Restore the stack. */
         ld       s1, 0 (sp)
         ld       s0, 8 (sp)

--- a/core/drlibc/drlibc_xarch.asm
+++ b/core/drlibc/drlibc_xarch.asm
@@ -37,15 +37,15 @@
 #include "../arch/asm_defines.asm"
 START_FILE
 
-/* For AArch64, drlibc has no references to unexpected_return, and in fact we
- * have a relocation reachability error if we include it here (i#4304), so
- * we limit its use in drlibc to x86 or arm.
- */
-#ifndef AARCH64
 DECL_EXTERN(d_r_internal_error)
 
 /* For debugging: report an error if the function called by call_switch_stack()
  * unexpectedly returns.  Also used elsewhere.
+ * i#4304: When calling this function do not use short branch instructions,
+ * eg, conditional branch instructions on aarch64. They don't have enough
+ * bits of offset to reach this. Instead, use unconditional branch or
+ * call instructions (eg, b, bl on aarch64) that have a sufficient number of
+ * bits.
  */
         DECLARE_FUNC(unexpected_return)
 GLOBAL_LABEL(unexpected_return:)
@@ -56,6 +56,5 @@ GLOBAL_LABEL(unexpected_return:)
          */
         JUMP  GLOBAL_REF(unexpected_return)
         END_FUNC(unexpected_return)
-#endif
 
 END_FILE

--- a/core/drlibc/drlibc_xarch.asm
+++ b/core/drlibc/drlibc_xarch.asm
@@ -42,10 +42,12 @@ DECL_EXTERN(d_r_internal_error)
 /* For debugging: report an error if the function called by call_switch_stack()
  * unexpectedly returns.  Also used elsewhere.
  * i#4304: When calling this function do not use short branch instructions,
- * eg, conditional branch instructions on aarch64. They don't have enough
+ * e.g., conditional branch instructions on aarch64. They don't have enough
  * bits of offset to reach this. Instead, use unconditional branch or
- * call instructions (eg, b, bl on aarch64) that have a sufficient number of
- * bits.
+ * call instructions (e.g., b, bl on aarch64) that have a sufficient number
+ * of bits. On x86, and other architectures where a call instruction requires
+ * the stack, only use branch instructions: This can get called when there
+ * is insufficient stack.
  */
         DECLARE_FUNC(unexpected_return)
 GLOBAL_LABEL(unexpected_return:)


### PR DESCRIPTION
Fix i#4304 in a different way by always using a branch/call instruction with enough bits of offset to reach the unexpected_return function. Conditional branches don't always have enough offsets to branch to any function within a binary: they're generally only intended for branching within a single function. On aarch64 conditional branch instructions have 19 bits of offset and unconditional branch and call instructions have 26 bits, and is used for every other function call so we should be good for awhile.

Fixes #4304