### PR TITLE
i#6423,i#5412: Ignore Windows flaky tests

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -304,6 +304,9 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 # We list this without any "options|" which will match all variations.
                 'common.floatpc_xl8all' => 1, # i#2267
                 'code_api|client.file_io' => 1, # i#5802
+                # These we have failed to reproduce after many attempts under tmate.
+                'code_api|tool.drcacheoff.burst_traceopts' => 1, # i#6423
+                'code_api|tool.drcacheoff.burst_replaceall' => 1, # i#5412
                 );
             if ($is_long) {
                 # These are important tests so we only ignore in the long suite,


### PR DESCRIPTION
Adds two tracing tests to the 64-bit Windows ignore list:

i#6423 tool.drcacheoff.burst_traceopts: though a disturbing assert, many attempts to reproduce including under tmate have failed.

i#5412 tool.drcacheoff.burst_replaceall: this one appears to be non-deterministic output ordering so a true flake.

Issue: #5412, #6423