### PR TITLE
i#6575: dr_{get,set}_sve_vector_length missing export specifiers

### DIFF
--- a/core/ir/encode_api.h
+++ b/core/ir/encode_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -74,6 +74,7 @@ DR_API
 dr_isa_mode_t
 dr_get_isa_mode(void *drcontext);
 
+DR_API
 /**
  * AArch64 Scalable Vector Extension's vector length in bits is one of:
  * 128 256 384 512 640 768 896 1024 1152 1280 1408 1536 1664 1792 1920 2048
@@ -83,6 +84,7 @@ dr_get_isa_mode(void *drcontext);
 void
 dr_set_sve_vector_length(int vl);
 
+DR_API
 /**
  * Read AArch64 Scalable Vector Extension's vector length, in bits.
  */

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2016 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -6924,6 +6924,18 @@ test_internal_encode(void *dcontext)
     instr_destroy(dcontext, jmp);
 }
 
+static void
+test_vector_length(void *dcontext)
+{
+    /* XXX i#6575: Add further tests.  For now, make sure these are exported. */
+    const int new_len = 2048;
+    /* XXX: Probably this should return a bool so we know whether it succeeded!
+     * It says it fails if on actual SVE hardware: but is there an easy way to know?
+     */
+    dr_set_sve_vector_length(new_len);
+    ASSERT(dr_get_sve_vector_length() == new_len);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -7101,6 +7113,8 @@ main(int argc, char *argv[])
     ld4r(dcontext);
 
     test_internal_encode(dcontext);
+
+    test_vector_length(dcontext);
 
     print("All tests complete\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
dr_set_sve_vector_length() and dr_get_sve_vector_length() in encode_api.h were missing DR_API specifiers and thus were not exported from libdynamorio, causing link errors.

Adds a test to ir_aarch64.c which fails without the fix.  However, the test may fail on actual SVE hardware: updating it is future work, maybe by changing dr_set_sve_vector_length() to return a bool.

Also tested on the same internal build where the failure was observed.

Issue: #6575