### PR TITLE
Export drlibc interface functions

### DIFF
--- a/core/drlibc/drlibc_x86.asm
+++ b/core/drlibc/drlibc_x86.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * ********************************************************** */
 
@@ -58,7 +58,7 @@ DECL_EXTERN(unexpected_return)
  * For Linux, the argument max is 6.
  * For MacOS, the argument max is 6 for x64 and 7 for x86.
  */
-        DECLARE_FUNC(dynamorio_syscall)
+        DECLARE_EXPORTED_FUNC(dynamorio_syscall)
 GLOBAL_LABEL(dynamorio_syscall:)
         /* x64 kernel doesn't clobber all the callee-saved registers */
         push     REG_XBX /* stack now aligned for x64 */
@@ -363,7 +363,7 @@ dynamorio_mach_syscall_next:
  * sets the exception mask flags for both regular float and xmm packed float
  */
 #define FUNCNAME dr_fpu_exception_init
-        DECLARE_FUNC(FUNCNAME)
+        DECLARE_EXPORTED_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
         fninit
         push     HEX(1f80)
@@ -376,8 +376,12 @@ GLOBAL_LABEL(FUNCNAME:)
 /* void get_mmx_val(OUT uint64 *val, uint index)
  * Returns the value of mmx register #index in val.
  */
-#define FUNCNAME get_mmx_val
+        #define FUNCNAME get_mmx_val
+#ifdef WINDOWS
         DECLARE_FUNC_SEH(FUNCNAME)
+#else
+        DECLARE_EXPORTED_FUNC(FUNCNAME)
+#endif
 GLOBAL_LABEL(FUNCNAME:)
         mov      REG_XAX, ARG1
         mov      REG_XCX, ARG2

--- a/core/drlibc/drlibc_xarch.asm
+++ b/core/drlibc/drlibc_xarch.asm
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,7 +49,7 @@ DECL_EXTERN(d_r_internal_error)
  * the stack, only use branch instructions: This can get called when there
  * is insufficient stack.
  */
-        DECLARE_FUNC(unexpected_return)
+        DECLARE_EXPORTED_FUNC(unexpected_return)
 GLOBAL_LABEL(unexpected_return:)
         CALLC3(GLOBAL_REF(d_r_internal_error), HEX(0), HEX(0), HEX(0))
         /* d_r_internal_error normally never returns */


### PR DESCRIPTION
Exports dynamorio_syscall, dr_fpu_exception_init, get_mmx_val, and unexpected_return in drlibc.  This solves linker issues when the drlibc and drstring libraries are linked in other build systems. Unfortunately it is not simple to make a test here; manually tested in a separate build system