### PR TITLE
i#6452,i#6536: Disable flaky attach_test, disable_test for unix x86-64

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -389,6 +389,8 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 );
             %ignore_failures_64 = (
                 'code_api|tool.drcacheoff.burst_threadfilter' => 1, # i#2941
+                'code_api|client.attach_test' => 1, # i#6452
+                'code_api|client.detach_test' => 1, # i#6536
                 # These are from the long suite.
                 'code_api,opt_memory|common.loglevel' => 1, # i#1807
                 'code_api,opt_speed|common.decode-stress' => 1, # i#1807


### PR DESCRIPTION
Adds two tests to the x86-64 unix ignore list:

i#6452 code_api|client.attach_test
i#6536 code_api|client.detach_test

Issue: #6452, #6536