### PR TITLE
i#6417 AMD 32-bit: Temporarily, drastically reduce x86-32 tests run

### DIFF
--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2022 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2024 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -91,6 +91,11 @@ if (UNIX AND NOT APPLE AND NOT ANDROID AND NOT cross_riscv64_linux_only)
     # just a few tests.
     set(extra_ctest_args INCLUDE_LABEL UBUNTU_22)
     set(arg_debug_only ON)
+  elseif (arg_32_only)
+    # TODO i#6417: The switch to AMD VM's for GA CI has broken many of our tests.
+    # This includes timeouts which increases suite length.
+    # Until we get ths x86-32 job back green, we drop back to a small set of tests.
+    set(extra_ctest_args INCLUDE_LABEL UBUNTU_22)
   endif ()
 endif ()
 

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -91,7 +91,7 @@ if (UNIX AND NOT APPLE AND NOT ANDROID AND NOT cross_riscv64_linux_only)
     # just a few tests.
     set(extra_ctest_args INCLUDE_LABEL UBUNTU_22)
     set(arg_debug_only ON)
-  elseif (arg_32_only)
+  elseif (arg_32_only AND NOT cross_aarchxx_linux_only AND NOT cross_android_only)
     # TODO i#6417: The switch to AMD VM's for GA CI has broken many of our tests.
     # This includes timeouts which increases suite length.
     # Until we get ths x86-32 job back green, we drop back to a small set of tests.


### PR DESCRIPTION
We have lived with our x86-32 GA CI job being red from massive test failures from the AMD switch for long enough.  The fix here may be too drastic, but it's simple: we scale back to the tiny set of tests run on ubuntu22.  I considered listing the failures on the ignore list, but with timeouts included this job was just taking too long.

The plan is to have another Fixit and try to fix enough AMD failures we can re-enable the full job.

Issue: #6417