### PR TITLE
i#6584: Fix buffer overflow in dr_set_sve_vector_length

### DIFF
--- a/core/ir/decode_shared.c
+++ b/core/ir/decode_shared.c
@@ -182,13 +182,14 @@ int sve_veclens[] = { 128,  256,  384,  512,  640,  768,  896,  1024,
 bool
 dr_set_sve_vector_length(int vl)
 {
-    /* TODO i#3044: Vector length will be read from h/w when running on SVE. */
     for (int i = 0; i < sizeof(sve_veclens) / sizeof(sve_veclens[0]); i++) {
         if (vl == sve_veclens[i]) {
             sve_veclen = vl;
             return true;
         }
     }
+    /* Make unusual values visible in case our internal uses mess up. */
+    ASSERT_CURIOSITY(false);
     return false;
 }
 

--- a/core/ir/decode_shared.c
+++ b/core/ir/decode_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -179,17 +179,17 @@ int sve_veclen;
 int sve_veclens[] = { 128,  256,  384,  512,  640,  768,  896,  1024,
                       1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048 };
 
-void
+bool
 dr_set_sve_vector_length(int vl)
 {
     /* TODO i#3044: Vector length will be read from h/w when running on SVE. */
-    for (int i = 0; i < sizeof(sve_veclens); i++) {
+    for (int i = 0; i < sizeof(sve_veclens) / sizeof(sve_veclens[0]); i++) {
         if (vl == sve_veclens[i]) {
             sve_veclen = vl;
-            return;
+            return true;
         }
     }
-    CLIENT_ASSERT(false, "invalid SVE vector length");
+    return false;
 }
 
 int

--- a/core/ir/encode_api.h
+++ b/core/ir/encode_api.h
@@ -78,10 +78,11 @@ DR_API
 /**
  * AArch64 Scalable Vector Extension's vector length in bits is one of:
  * 128 256 384 512 640 768 896 1024 1152 1280 1408 1536 1664 1792 1920 2048
+ * Returns whether successful.
  * TODO i#3044: This function will only allow setting vector length if not
  * running on SVE.
  */
-void
+bool
 dr_set_sve_vector_length(int vl);
 
 DR_API

--- a/suite/tests/api/ir_aarch64.c
+++ b/suite/tests/api/ir_aarch64.c
@@ -6929,11 +6929,16 @@ test_vector_length(void *dcontext)
 {
     /* XXX i#6575: Add further tests.  For now, make sure these are exported. */
     const int new_len = 2048;
-    /* XXX: Probably this should return a bool so we know whether it succeeded!
-     * It says it fails if on actual SVE hardware: but is there an easy way to know?
+    /* XXX: Make this test work when on actual SVE hardware where this API routine
+     * is documented as failing.
      */
-    dr_set_sve_vector_length(new_len);
+    bool res = dr_set_sve_vector_length(new_len);
+    ASSERT(res);
     ASSERT(dr_get_sve_vector_length() == new_len);
+    /* Ensure invalid lengths return failure. */
+    ASSERT(!dr_set_sve_vector_length(0));
+    ASSERT(!dr_set_sve_vector_length(1));
+    ASSERT(!dr_set_sve_vector_length(4096));
 }
 
 int


### PR DESCRIPTION
Fixes a buffer overflow in dr_set_sve_vector_length().

Changes dr_set_sve_vector_length() to return a boolean.

Updates the dr_set_sve_vector_length() test to check failure cases.

Tested in an internal build with a memory tool where the overflow was detected:
confirmed no error is reported anymore (with the raw2trace call to
dr_set_sve_vector_length() put back to pass 0 for arm-on-x86).

Fixes: #6584