### PR TITLE
i#6580: Disable pytype check on aarch64 codec line

### DIFF
--- a/core/ir/aarch64/codec.py
+++ b/core/ir/aarch64/codec.py
@@ -70,7 +70,7 @@ class Opnd:
 
 def opnd_stem(opnd_name):
     """Strip off all flags from the opnd"""
-    return opnd_name.split(".")[0]
+    return opnd_name.split(".")[0] # pytype: disable=attribute-error
 
 def opnd_flags(opnd_name):
     """Return the opnd's flags"""


### PR DESCRIPTION
Disable a pytype static analysis check on opnd_stem() in aarch64/codec.py as the analysis produces a false positive.

Tested on an internal build where pytype is enabled.

Fixes #6580