### PR TITLE
i#6514 null SP to clone(), part 2: Have linux clone test use dynamori…

### DIFF
--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -708,9 +708,6 @@ dynamorio_condvar_wake_and_jmp(KSYNCH_TYPE *ksynch /*in xax/r0*/,
 void
 dynamorio_nonrt_sigreturn(void);
 #        endif
-thread_id_t
-dynamorio_clone(uint flags, byte *newsp, void *ptid, void *tls, void *ctid,
-                void (*func)(void));
 void
 xfer_to_new_libdr(app_pc entry, void **init_sp, byte *cur_dr_map, size_t cur_dr_size);
 #    endif

--- a/core/drlibc/drlibc.h
+++ b/core/drlibc/drlibc.h
@@ -72,6 +72,7 @@ dynamorio_mach_syscall(uint sysnum, uint num_args, ...);
 #    else
 ptr_int_t
 dynamorio_syscall(uint sysnum, uint num_args, ...);
+/* N.B. func must not return. */
 thread_id_t
 dynamorio_clone(uint flags, byte *newsp, void *ptid, void *tls, void *ctid,
                 void (*func)(void));

--- a/core/drlibc/drlibc.h
+++ b/core/drlibc/drlibc.h
@@ -72,6 +72,9 @@ dynamorio_mach_syscall(uint sysnum, uint num_args, ...);
 #    else
 ptr_int_t
 dynamorio_syscall(uint sysnum, uint num_args, ...);
+thread_id_t
+dynamorio_clone(uint flags, byte *newsp, void *ptid, void *tls, void *ctid,
+                void (*func)(void));
 #    endif
 #endif
 

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -64,10 +64,6 @@ typedef unsigned long ulong;
  */
 #define CLONE3_SYSCALL_NUM 435
 
-/* i#762: Hard to get clone() from sched.h, so copy prototype. */
-extern int
-clone(int (*fn)(void *arg), void *child_stack, int flags, void *arg, ...);
-
 #define THREAD_STACK_SIZE (32 * 1024)
 
 #ifdef X64
@@ -80,8 +76,7 @@ clone(int (*fn)(void *arg), void *child_stack, int flags, void *arg, ...);
 static int
 make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void));
 static pid_t
-create_thread(int (*fcn)(void *), void *arg, void **stack, bool share_sighand,
-              bool clone_vm);
+create_thread(void (*fcn)(void), void **stack, bool share_sighand, bool clone_vm);
 #ifdef SYS_clone3
 static pid_t
 create_thread_clone3(void (*fcn)(void), void **stack, bool share_sighand, bool clone_vm);
@@ -113,10 +108,10 @@ test_thread(bool share_sighand, bool clone_vm, bool use_clone3)
         /* If SYS_clone3 is not defined, we simply use SYS_clone instead, so that
          * the expected output is the same in both cases.
          */
-        child = create_thread(run, NULL, &stack, share_sighand, clone_vm);
+        child = create_thread(run_with_exit, &stack, share_sighand, clone_vm);
 #endif
     } else
-        child = create_thread(run, NULL, &stack, share_sighand, clone_vm);
+        child = create_thread(run_with_exit, &stack, share_sighand, clone_vm);
     assert(child > -1);
     delete_thread(child, stack);
 }
@@ -192,14 +187,14 @@ void *p_tid, *c_tid;
  * first argument is passed in "arg". Returns the PID of the new
  * thread */
 static pid_t
-create_thread(int (*fcn)(void *), void *arg, void **stack, bool share_sighand,
-              bool clone_vm)
+create_thread(void (*fcn)(void), void **stack, bool share_sighand, bool clone_vm)
 {
     /* !clone_vm && share_sighand is not supported. */
     assert(clone_vm || !share_sighand);
     pid_t newpid;
     int flags;
     void *my_stack;
+    void *stack_ptr;
 
     my_stack = stack_alloc(THREAD_STACK_SIZE);
 
@@ -211,10 +206,12 @@ create_thread(int (*fcn)(void *), void *arg, void **stack, bool share_sighand,
     flags = (SIGCHLD | CLONE_FS | CLONE_FILES | (share_sighand ? CLONE_SIGHAND : 0) |
              (clone_vm ? CLONE_VM : 0));
     /* The stack arg should point to the stack's highest address (non-inclusive). */
-    newpid = clone(fcn, (void *)((size_t)my_stack + THREAD_STACK_SIZE), flags, arg,
-                   &p_tid, NULL, &c_tid);
+    stack_ptr = (void *)((size_t)my_stack + THREAD_STACK_SIZE);
+    newpid = dynamorio_clone(flags, stack_ptr, &p_tid, NULL, &c_tid, fcn);
 
-    if (newpid == -1) {
+    if (newpid < 0) {
+        /* dynamorio_clone doesn't set errno */
+        errno = -newpid;
         perror("Error calling clone\n");
         stack_free(my_stack, THREAD_STACK_SIZE);
         return -1;


### PR DESCRIPTION
…o_clone

Now that dynamorio_clone() is in drlibc we can use it in the linux clone.c test.

Issue #6514