### PR TITLE
I6593 zipfile reading support

### DIFF
--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -226,6 +226,21 @@ file_reader_t<zipfile_reader_t>::skip_instructions(uint64_t instruction_count)
  */
 
 template <>
+record_file_reader_t<zipfile_reader_t>::record_file_reader_t()
+{
+    input_file_->file = nullptr;
+}
+
+template <>
+record_file_reader_t<zipfile_reader_t>::~record_file_reader_t<zipfile_reader_t>()
+{
+    if (input_file_->file != nullptr) {
+        unzClose(input_file_->file);
+        input_file_->file = nullptr;
+    }
+}
+
+template <>
 bool
 record_file_reader_t<zipfile_reader_t>::open_single_file(const std::string &path)
 {

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -40,6 +40,27 @@ namespace drmemtrace {
 // sources.  The docs are the header files:
 // https://github.com/madler/zlib/blob/master/contrib/minizip/unzip.h
 
+/**************************************************************************
+ * Common logic used in the zipfile_reader_t specializations for file_reader_t
+ * and record_file_reader_t.
+ */
+
+bool
+open_single_file_common(const std::string &path, zipfile_reader_t &zread)
+{
+    unzFile file = unzOpen(path.c_str());
+    if (file == nullptr)
+        return false;
+    zread = zipfile_reader_t(file, path);
+    if (unzGoToFirstFile(file) != UNZ_OK || unzOpenCurrentFile(file) != UNZ_OK)
+        return false;
+    return true;
+}
+
+/**************************************************
+ * zipfile_reader_t specializations for file_reader_t.
+ */
+
 /* clang-format off */ /* (make vera++ newline-after-type check happy) */
 template <>
 /* clang-format on */
@@ -63,12 +84,9 @@ template <>
 bool
 file_reader_t<zipfile_reader_t>::open_single_file(const std::string &path)
 {
-    unzFile file = unzOpen(path.c_str());
-    if (file == nullptr)
-        return false;
-    input_file_ = zipfile_reader_t(file, path);
-    if (unzGoToFirstFile(file) != UNZ_OK || unzOpenCurrentFile(file) != UNZ_OK)
-        return false;
+    zipfile_reader_t zread;
+    if (!open_single_file_common(path,zread)) return false;
+    input_file_ = std::move(zread);
     VPRINT(this, 1, "Opened input file %s\n", path.c_str());
     return true;
 }
@@ -201,6 +219,71 @@ file_reader_t<zipfile_reader_t>::skip_instructions(uint64_t instruction_count)
     // the fast chunk jumps we just did).
     // Subtract 1 to pass the target instr itself.
     return skip_instructions_with_timestamp(stop_count - 1);
+}
+
+/*********************************************************
+ * zipfile_reader_t specializations for record_file_reader_t.
+ */
+
+template <>
+bool
+record_file_reader_t<zipfile_reader_t>::open_single_file(const std::string &path)
+{
+    zipfile_reader_t zread;
+    if (!open_single_file_common(path,zread)) return false;
+    input_file_ = std::unique_ptr<zipfile_reader_t>(new zipfile_reader_t(zread));
+    VPRINT(this, 1, "Opened input file %s\n", path.c_str());
+    return true;
+}
+
+template <>
+bool record_file_reader_t<zipfile_reader_t>::read_next_entry()
+{
+    zipfile_reader_t *zipfile = input_file_.get();
+    if (zipfile->cur_buf >= zipfile->max_buf) {
+        int num_read =
+            unzReadCurrentFile(zipfile->file, zipfile->buf, sizeof(zipfile->buf));
+        if (num_read == 0) {
+            // read_next_entry() stored the last-read entry into entry_copy_.
+            if ((cur_entry_.type != TRACE_TYPE_MARKER ||
+                 cur_entry_.size != TRACE_MARKER_TYPE_CHUNK_FOOTER) &&
+                cur_entry_.type != TRACE_TYPE_FOOTER) {
+                zipfile->name[0] = '\0'; /* Just in case. */
+                unzGetCurrentFileInfo64(zipfile->file, nullptr, zipfile->name,
+                                        sizeof(zipfile->name), nullptr, 0, nullptr, 0);
+                VPRINT(this, 1, "Chunk is missing footer: truncation detected in %s %s\n",
+                       zipfile->path.c_str(), zipfile->name);
+                return false;
+            }
+            if (unzCloseCurrentFile(zipfile->file) != UNZ_OK)
+                return false;
+            int res = unzGoToNextFile(zipfile->file);
+            if (res != UNZ_OK) {
+                if (res == UNZ_END_OF_LIST_OF_FILE) {
+                    VPRINT(this, 2, "Hit EOF in %s\n", zipfile->path.c_str());
+                    eof_ = true;
+                }
+                return false;
+            }
+            if (unzOpenCurrentFile(zipfile->file) != UNZ_OK)
+                return false;
+            num_read =
+                unzReadCurrentFile(zipfile->file, zipfile->buf, sizeof(zipfile->buf));
+        }
+        if (num_read < static_cast<int>(sizeof(cur_entry_))) {
+            VPRINT(this, 1, "Failed to read: returned %d in %s\n", num_read,
+                   zipfile->path.c_str());
+            return false;
+        }
+        zipfile->cur_buf = zipfile->buf;
+        zipfile->max_buf = zipfile->buf + (num_read / sizeof(*zipfile->max_buf));
+    }
+    cur_entry_ = *zipfile->cur_buf;
+    ++zipfile->cur_buf;
+    VPRINT(this, 5, "Read %s: type=%s (%d), size=%d, addr=%zu\n", zipfile->path.c_str(),
+           trace_type_names[cur_entry_.type], cur_entry_.type, cur_entry_.size,
+           cur_entry_.addr);
+    return true;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/reader/zipfile_file_reader.h
+++ b/clients/drcachesim/reader/zipfile_file_reader.h
@@ -38,6 +38,7 @@
 #include <zlib.h>
 #include "minizip/unzip.h"
 #include "file_reader.h"
+#include "record_file_reader.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -69,6 +70,7 @@ struct zipfile_reader_t {
 };
 
 typedef file_reader_t<zipfile_reader_t> zipfile_file_reader_t;
+typedef record_file_reader_t<zipfile_reader_t> zipfile_record_file_reader_t;
 
 /* Declare this so the compiler knows not to use the default implementation in the
  * class declaration.

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -309,8 +309,11 @@ scheduler_tmpl_t<trace_entry_t, record_reader_t>::get_reader(const std::string &
 {
     // TODO i#5675: Add support for other file formats, particularly
     // .zip files.
-    if (ends_with(path, ".sz") || ends_with(path, ".zip"))
+    if (ends_with(path, ".sz"))
         return nullptr;
+    if (ends_with(path, ".zip"))
+        return std::unique_ptr<dynamorio::drmemtrace::record_reader_t>(
+            new zipfile_record_file_reader_t(path, verbosity));
     return std::unique_ptr<dynamorio::drmemtrace::record_reader_t>(
         new default_record_file_reader_t(path, verbosity));
 }


### PR DESCRIPTION
The record filter does not support filtering .zip traces today. Since we have moved to .zip as the default format, we should add that support.