### PR TITLE
i#6604: Use gcc_struct in elfutils only on x86

### DIFF
--- a/ext/drsyms/elfutils/config.h
+++ b/ext/drsyms/elfutils/config.h
@@ -72,7 +72,9 @@
 #define HAVE_FALLTHROUGH 1
 
 /* Defined if __attribute__((gcc_struct)) is supported */
-#define HAVE_GCC_STRUCT 1
+#if defined(__x86_64__) || defined(__i386__)
+#    define HAVE_GCC_STRUCT 1
+#endif
 
 /* Define to 1 if you have the `getrlimit' function. */
 #define HAVE_GETRLIMIT 1


### PR DESCRIPTION
Makes HAVE_GCC_STRUCT in our elfutils config.h conditional on building on x86, which is the only place the gcc_struct attribute is supported.

Fixes #6604