### PR TITLE
i#6596 linux.clone* tests on Ubuntu: Handle struct clone_args not defined

### DIFF
--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -108,8 +108,7 @@ test_thread(bool share_sighand, bool clone_vm, bool use_clone3)
      * the output is the same.
      */
     pid_t (*create_thread_func)(void (*fcn)(void), void **stack, bool share_sighand,
-                                bool clone_vm) =
-        create_thread;
+                                bool clone_vm) = create_thread;
 #ifdef SYS_clone3
     if (use_clone3 && clone3_available)
         create_thread_func = create_thread_clone3;

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -130,8 +130,8 @@ main()
 
     /* In some environments, we see that the kernel supports clone3 even though
      * SYS_clone3 is not defined by glibc. So we don't predicate our efforts on
-     * whether SYS_clone3 is defined.
-    /* Plus in some scenarios SYS_clone3 is defined but clone3 returns ENOSYS.
+     * whether SYS_clone3 is defined. Plus in some scenarios SYS_clone3 is
+     * defined but clone3 returns ENOSYS.
      * E.g., when running in a container under Ubuntu 22.04 i#6596
      * see https://github.com/moby/moby/pull/42681
      */

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -78,8 +78,10 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void));
 static pid_t
 create_thread(void (*fcn)(void), void **stack, bool share_sighand, bool clone_vm);
 
+#ifdef SYS_clone3
 static pid_t
 create_thread_clone3(void (*fcn)(void), void **stack, bool share_sighand, bool clone_vm);
+#endif
 
 static bool clone3_available = false;
 

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -109,9 +109,8 @@ test_thread(bool share_sighand, bool clone_vm, bool use_clone3)
      * the output is the same.
      */
     pid_t (*create_thread_func)(void (*fcn)(void), void **stack, bool share_sighand,
-                                bool clone_vm) = create_thread;
-    if (use_clone3 && clone3_available)
-        create_thread_func = create_thread_clone3;
+                                bool clone_vm) =
+        (use_clone3 && clone3_available) ? create_thread_clone3 : create_thread;
 
     child = create_thread_func(run_with_exit, &stack, share_sighand, clone_vm);
 


### PR DESCRIPTION
Fix build errors resulting from #6597 by using DR's copy of struct clone_args

This has happened on Android.

Fixes #6596