### PR TITLE
i#6612: Add code_api|api.rseq to Linux x64 flaky test ignore list

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -305,6 +305,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'finite_shared_bb_cache,cache_shared_bb_regen|common.nativeexec' => 1, # i#1807
                 'finite_shared_trace_cache,cache_shared_trace_regen|common.nativeexec' => 1, # i#1807
                 # We list this without any "options|" which will match all variations.
+                'api.rseq' => 1, # i#6612
                 'common.floatpc_xl8all' => 1, # i#2267
                 'code_api|client.file_io' => 1, # i#5802
                 # These we have failed to reproduce after many attempts under tmate.

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -391,7 +391,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'prof_pcs,thread_private|common.nativeexec_bindnow_opt' => 1, # i#2052
                 );
             %ignore_failures_64 = (
-                'api.rseq' => 1, # i#6612
+                'code_api|api.rseq' => 1, # i#6185 i#1807
                 'code_api|tool.drcacheoff.burst_threadfilter' => 1, # i#2941
                 'code_api|client.attach_test' => 1, # i#6452
                 'code_api|client.detach_test' => 1, # i#6536

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -305,7 +305,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'finite_shared_bb_cache,cache_shared_bb_regen|common.nativeexec' => 1, # i#1807
                 'finite_shared_trace_cache,cache_shared_trace_regen|common.nativeexec' => 1, # i#1807
                 # We list this without any "options|" which will match all variations.
-                'api.rseq' => 1, # i#6612
                 'common.floatpc_xl8all' => 1, # i#2267
                 'code_api|client.file_io' => 1, # i#5802
                 # These we have failed to reproduce after many attempts under tmate.
@@ -392,6 +391,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'prof_pcs,thread_private|common.nativeexec_bindnow_opt' => 1, # i#2052
                 );
             %ignore_failures_64 = (
+                'api.rseq' => 1, # i#6612
                 'code_api|tool.drcacheoff.burst_threadfilter' => 1, # i#2941
                 'code_api|client.attach_test' => 1, # i#6452
                 'code_api|client.detach_test' => 1, # i#6536


### PR DESCRIPTION
Adds code_api|api.rseq test to Linux 64-bit ignore list
in suite/runsuite_wrapper.pl.

Issue: #1807 #6185