### PR TITLE
iX: RHEL-7 build fix due to EM_RISCV.

### DIFF
--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -42,6 +42,11 @@
 #    define DT_RELR 36
 #endif
 
+/* XXX: Workaround for EM_RISCV not being defined in elf.h on RHEL-7. */
+#ifndef EM_RISCV
+#    define EM_RISCV 243
+#endif
+
 /* XXX i#1345: support mixed-mode 32-bit and 64-bit in one process.
  * There is no official support for that on Linux or Mac and for now we do
  * not support it either, especially not mixing libraries.

--- a/core/unix/module_elf.h
+++ b/core/unix/module_elf.h
@@ -42,7 +42,7 @@
 #    define DT_RELR 36
 #endif
 
-/* XXX: Workaround for EM_RISCV not being defined in elf.h on RHEL-7. */
+/* Workaround for EM_RISCV not being defined in elf.h on RHEL-7. */
 #ifndef EM_RISCV
 #    define EM_RISCV 243
 #endif


### PR DESCRIPTION
The elf.h header file on RHEL-7 does not define EM_RISCV which is being used in the source files. This results in a build failure. This change fixes the issue.