### PR TITLE
i#6615: linux.bad-signal-stack test fails on Ubuntu 22.04

### DIFF
--- a/suite/tests/linux/bad-signal-stack.c
+++ b/suite/tests/linux/bad-signal-stack.c
@@ -30,13 +30,15 @@
  * DAMAGE.
  */
 
-#include "tools.h"
 #include <unistd.h>
 #include <signal.h>
 #include <ucontext.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <assert.h>
+/* i#6615 include tools.h after signal.h to avoid issues on
+ * ubuntu 22:04 caused by _GNU_SOURCE being defined */
+#include "tools.h"
 
 #define ALT_STACK_SIZE (SIGSTKSZ * 4)
 

--- a/suite/tests/linux/bad-signal-stack.c
+++ b/suite/tests/linux/bad-signal-stack.c
@@ -32,7 +32,6 @@
 
 #include <unistd.h>
 #include <signal.h>
-#include <ucontext.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <assert.h>


### PR DESCRIPTION
Update bad-signal-stack.c to include tools.h after the other header files so that _GNU_SOURCE is not defined when signal.h is included.

Fixes #6615