### PR TITLE
i#3544 RV64: Implements more functions and enable more tests

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -184,6 +184,7 @@ mixed_mode_enabled(void)
 #    define SCRATCH_REG4_OFFS REG4_OFFSET
 #    define SCRATCH_REG5_OFFS REG5_OFFSET
 #    define REG_OFFSET(reg) (X0_OFFSET + ((reg)-DR_REG_X0) * sizeof(reg_t))
+#    define FREG_OFFSET(reg) (F0_OFFSET + ((reg)-DR_REG_F0) * sizeof(reg_t))
 #    define CALL_SCRATCH_REG DR_REG_T6
 #    define MC_IBL_REG a2
 #    define MC_RETVAL_REG a0

--- a/core/arch/riscv64/emit_utils.c
+++ b/core/arch/riscv64/emit_utils.c
@@ -659,7 +659,16 @@ append_restore_xflags(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
 void
 append_restore_simd_reg(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
 {
-    /* No-op. */
+    opnd_t memopnd;
+
+    /* Floating-point register is not SIMD registers in RISC-V, but to be consistent with
+     * other architectures, we handle them here.
+     */
+    for (int reg = DR_REG_F0; reg <= DR_REG_F31; reg++) {
+        memopnd = opnd_create_dcontext_field_via_reg_sz(
+            dcontext, REG_NULL, REG_OFFSET(reg), reg_get_size(reg));
+        APP(ilist, INSTR_CREATE_fld(dcontext, opnd_create_reg(reg), memopnd));
+    }
 }
 
 /* Append instructions to restore gpr on fcache enter, to be executed
@@ -749,7 +758,16 @@ append_save_gpr(dcontext_t *dcontext, instrlist_t *ilist, bool ibl_end, bool abs
 void
 append_save_simd_reg(dcontext_t *dcontext, instrlist_t *ilist, bool absolute)
 {
-    /* No-op. */
+    opnd_t memopnd;
+
+    /* Floating-point register is not SIMD registers in RISC-V, but to be consistent with
+     * other architectures, we handle them here.
+     */
+    for (int reg = DR_REG_F0; reg <= DR_REG_F31; reg++) {
+        memopnd = opnd_create_dcontext_field_via_reg_sz(
+            dcontext, REG_NULL, REG_OFFSET(reg), reg_get_size(reg));
+        APP(ilist, INSTR_CREATE_fsd(dcontext, memopnd, opnd_create_reg(reg)));
+    }
 }
 
 /* Scratch reg0 is holding exit stub. */

--- a/core/arch/riscv64/emit_utils.c
+++ b/core/arch/riscv64/emit_utils.c
@@ -540,8 +540,39 @@ cbr_fallthrough_exit_cti(cache_pc prev_cti_pc)
 void
 unlink_indirect_exit(dcontext_t *dcontext, fragment_t *f, linkstub_t *l)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
+    byte *stub_pc = (byte *)EXIT_STUB_PC(dcontext, f, l);
+    uint *pc;
+    cache_pc exit_target;
+    ibl_code_t *ibl_code = NULL;
+    ASSERT(linkstub_owned_by_fragment(dcontext, f, l));
+    ASSERT(LINKSTUB_INDIRECT(l->flags));
+    /* Target is always the same, so if it's already unlinked, this is a nop. */
+    if (!TEST(LINK_LINKED, l->flags))
+        return;
+    ibl_code = get_ibl_routine_code(dcontext, extract_branchtype(l->flags), f->flags);
+    exit_target = ibl_code->unlinked_ibl_entry;
+
+    /* Set pc to the last instruction in the stub.
+     * See insert_exit_stub_other_flags(), the last instruction in indirect exit stub will
+     * always be a c.nop.
+     */
+    pc = (uint *)(stub_pc +
+                  exit_stub_size(dcontext, ibl_code->indirect_branch_lookup_routine,
+                                 f->flags) -
+                  RISCV64_INSTR_COMPRESSED_SIZE);
+    pc = get_stub_branch(pc) - 1;
+
+    ASSERT(get_ibl_entry_tls_offs(dcontext, exit_target) <= (2 << 11) - 1);
+    /* Format of the ld instruction:
+        | imm[11:0] |  rs1  |011|  rd  |0000011|
+        ^   31-20   ^ 19-15 ^   ^ 11-7 ^
+     */
+    /* ld a1, offs(reg_stolen) */
+    *(uint *)vmcode_get_writable_addr((byte *)pc) = 0x3003 |
+        get_ibl_entry_tls_offs(dcontext, exit_target) << 20 |
+        (dr_reg_stolen - DR_REG_ZERO) << 15 | (DR_REG_A1 - DR_REG_ZERO) << 7;
+
+    machine_cache_sync(pc, pc + 1, true);
 }
 
 /*******************************************************************************

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4755,8 +4755,8 @@ find_next_fragment_from_gencode(dcontext_t *dcontext, sigcontext_t *sc)
         if (f == NULL && sc->SC_XCX != 0)
             f = fragment_lookup(dcontext, (app_pc)sc->SC_XCX);
 #elif defined(RISCV64)
-        /* FIXME i#3544: Not implemented */
-        ASSERT_NOT_IMPLEMENTED(false);
+        if (f == NULL && sc->SC_A2 != 0)
+            f = fragment_lookup(dcontext, (app_pc)(sc->SC_A2));
 #else
 #    error Unsupported arch.
 #endif

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5993,23 +5993,42 @@ if (RISCV64)
     code_api|api.ir
     code_api|api.ir-static
     code_api|client.app_args
+    code_api|client.app_args
+    code_api|client.blackbox
     code_api|client.blackbox
     code_api|client.crashmsg
+    code_api|client.crashmsg
+    code_api|client.execfault
     code_api|client.execfault
     code_api|client.mangle_suspend
+    code_api|client.mangle_suspend
+    code_api|client.null_instrument
     code_api|client.null_instrument
     code_api|client.option_parse
+    code_api|client.option_parse
+    code_api|client.partial_module_map
     code_api|client.partial_module_map
     code_api|client.stack-overflow
+    code_api|client.stack-overflow
     code_api|client.truncate
+    code_api|client.unregister
     code_api|common.broadfun
+    code_api|common.hello
+    code_api|libutil.drconfig_test
     code_api|libutil.drconfig_test
     code_api|libutil.frontend_test
+    code_api|libutil.frontend_test
+    code_api|linux.exit
     code_api|linux.exit
     code_api|linux.infinite
+    code_api|linux.infinite
+    code_api|linux.longjmp
     code_api|linux.longjmp
     code_api|linux.prctl
+    code_api|linux.prctl
     code_api|linux.signalfd
+    code_api|pthreads.pthreads
+    code_api|pthreads.pthreads_exit
     code_api|pthreads.pthreads_exit
     code_api|sample.bbbuf
     code_api|sample.bbcount
@@ -6018,12 +6037,21 @@ if (RISCV64)
     code_api|sample.empty
     code_api|sample.inline
     code_api|sample.inscount
+    code_api|sample.inscount.cleancall
+    code_api|sample.inscount.prof-pcs.cleancall
     code_api|sample.opcode_count
     code_api|sample.signal
     code_api|sample.stl_test
+    code_api|sample.stl_test
+    code_api|sample.syscall
     code_api|sample.syscall
     code_api|security-linux.trampoline
+    code_api|security-linux.trampoline
+    code_api|tool.drcachesim.missfile-config-file
+    code_api|tool.drcachesim.syscall-mix
+    code_api|tool.drcov.fib
     code_api|tool.drdisas
+    code_api|tool.histogram
     code_api|tool.reuse_distance
     no_code_api,no_intercept_all_signals|linux.sigaction
     PROPERTIES LABELS RUNS_ON_QEMU)


### PR DESCRIPTION
Added a few more tests to `RUNS_ON_QEMU` and more tests (like `linux.signalXXXX`) is passing under real hardware, but not on QEMU for some reason unknown for now.

Issue: #3544 