### PR TITLE
i#6620: Fix record_filter_launcher on Windows

### DIFF
--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -34,8 +34,8 @@
 
 #ifdef WINDOWS
 #    define NOMINMAX // Avoid windows.h messing up std::max.
-#    define UNICODE
-#    define _UNICODE
+#    define UNICODE  // For Windows headers.
+#    define _UNICODE // For C headers.
 #endif
 
 #include "analyzer.h"

--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -32,6 +32,12 @@
 
 /* Standalone record filter tool launcher for file traces. */
 
+#ifdef WINDOWS
+#    define NOMINMAX // Avoid windows.h messing up std::max.
+#    define UNICODE
+#    define _UNICODE
+#endif
+
 #include "analyzer.h"
 #include "droption.h"
 #include "dr_frontend.h"
@@ -77,8 +83,10 @@ static droption_t<unsigned int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 0, 0, 
                                            "Verbosity level for notifications.");
 
 static droption_t<uint64_t>
+    // Wrap max in parens to work around Visual Studio compiler issues with the
+    // max macro (even despite NOMINMAX defined above).
     op_stop_timestamp(DROPTION_SCOPE_ALL, "stop_timestamp", 0, 0,
-                      std::numeric_limits<uint64_t>::max(),
+                      (std::numeric_limits<uint64_t>::max)(),
                       "Timestamp (in us) in the trace when to stop filtering.",
                       "Record filtering will be disabled (everything will be output) "
                       "when the tool sees a TRACE_MARKER_TYPE_TIMESTAMP marker with "
@@ -124,6 +132,10 @@ int
 _tmain(int argc, const TCHAR *targv[])
 {
     disable_popups();
+
+#if defined(WINDOWS) && !defined(_UNICODE)
+#    error _UNICODE must be defined
+#endif
 
     char **argv;
     drfront_status_t sc = drfront_convert_args(targv, &argv, argc);


### PR DESCRIPTION
Fixes an up-front failure with the record_filter_launcher tool on Windows by defining _UNICODE.

Tested both manually and with the new automated test in PR #6598.

Fixes: #6620