### PR TITLE
i#6627: Fix multiply defined label in linux/clone.c

### DIFF
--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -249,9 +249,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "mov %[fcn], %%rdx\n\t"
                  "syscall\n\t"
                  "test %%rax, %%rax\n\t"
-                 "jnz parent\n\t"
+                 "jnz 1f\n\t"
                  "call *%%rdx\n\t"
-                 "parent:\n\t"
+                 "1:\n\t"
                  "mov %%rax, %[result]\n\t"
                  : [ result ] "=m"(result)
                  : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
@@ -265,9 +265,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "mov %[fcn], %%edx\n\t"
                  "int $0x80\n\t"
                  "test %%eax, %%eax\n\t"
-                 "jnz parent\n\t"
+                 "jnz 1f\n\t"
                  "call *%%edx\n\t"
-                 "parent:\n\t"
+                 "1:\n\t"
                  "mov %%eax, %[result]\n\t"
                  : [ result ] "=m"(result)
                  : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
@@ -280,9 +280,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "ldr x1, %[clone_args_size]\n\t"
                  "ldr x2, %[fcn]\n\t"
                  "svc #0\n\t"
-                 "cbnz x0, parent\n\t"
+                 "cbnz x0, 1f\n\t"
                  "blr x2\n\t"
-                 "parent:\n\t"
+                 "1:\n\t"
                  "str x0, %[result]\n\t"
                  : [ result ] "=m"(result)
                  : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),


### PR DESCRIPTION
Fix having label "parent" multiply defined by replacing it with a "local label":
Ref: https://sourceware.org/binutils/docs-2.42/as/Symbol-Names.html

The multiple definition is caused by make_clone3_syscall being inlined into create_thread_clone3.

Tested by running the following before/after the patch:

cd build && \
  clang \
  -I../dynamorio/core/drlibc \
  -I../dynamorio/core/lib \
  -I../dynamorio/suite/tests \
  -I. \
  -Iinclude \
  -O1 \
  -c ../dynamorio/suite/tests/linux/clone.c \
  -o clone.o

Fixes #6627