### PR TITLE
i#2626: AArch64 codec: Add BTI hinted instruction

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -223,6 +223,7 @@ proc_init_arch(void)
         LOG(GLOBAL, LOG_TOP, 1, "Processor features:\n ID_AA64PFR1_EL1 = 0x%016lx\n",
             cpu_info.features.flags_aa64pfr1);
         LOG_FEATURE(FEATURE_MTE);
+        LOG_FEATURE(FEATURE_BTI);
     });
 #    endif
 #endif
@@ -296,7 +297,7 @@ enable_all_test_cpu_features()
         FEATURE_BF16,   FEATURE_I8MM,       FEATURE_F64MM,   FEATURE_FlagM,
         FEATURE_JSCVT,  FEATURE_DPB,        FEATURE_DPB2,    FEATURE_SVE2,
         FEATURE_SVEAES, FEATURE_SVEBitPerm, FEATURE_SVESHA3, FEATURE_SVESM4,
-        FEATURE_MTE
+        FEATURE_MTE,    FEATURE_BTI
     };
     for (int i = 0; i < BUFFER_SIZE_ELEMENTS(features); ++i) {
         proc_set_feature(features[i], true);

--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -361,6 +361,7 @@ typedef enum {
     FEATURE_SVESM4 = DEF_FEAT(AA64ZFR0, 10, 1, 0), /**< SVE2 + SM4(AArch64) */
     FEATURE_SVEBitPerm = DEF_FEAT(AA64ZFR0, 4, 1, 0), /**< SVE2 + BitPerm(AArch64) */
     FEATURE_MTE = DEF_FEAT(AA64PFR1, 2, 1, 0),        /**< Memory Tagging Extension */
+    FEATURE_BTI = DEF_FEAT(AA64PFR1, 0, 1, 0),        /**< Branch Target Identification*/
 } feature_bit_t;
 #endif
 #ifdef RISCV64

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -2461,6 +2461,20 @@ encode_opnd_fpimm1_half_two_5(uint enc, int opcode, byte *pc, opnd_t opnd,
     return encode_float_const_pair(5, 0.5f, 2.0f, opnd, enc_out);
 }
 
+/* imm2_6: 2-bit immediate from bits 6-7 */
+
+static inline bool
+decode_opnd_imm2_6(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
+{
+    return decode_opnd_int(6, 2, false, 0, OPSZ_3b, 0, enc, opnd);
+}
+
+static inline bool
+encode_opnd_imm2_6(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
+{
+    return encode_opnd_int(6, 2, false, 0, 0, opnd, enc_out);
+}
+
 /* op2: 3-bit immediate from bits 5-7 */
 
 static inline bool
@@ -9696,6 +9710,7 @@ decode_category(uint encoding, instr_t *instr)
 #include "decode_gen_sve2.h"
 #include "decode_gen_sve.h"
 #include "decode_gen_v86.h"
+#include "decode_gen_v85.h"
 #include "decode_gen_v84.h"
 #include "decode_gen_v83.h"
 #include "decode_gen_v82.h"
@@ -9704,6 +9719,7 @@ decode_category(uint encoding, instr_t *instr)
 #include "encode_gen_sve2.h"
 #include "encode_gen_sve.h"
 #include "encode_gen_v86.h"
+#include "encode_gen_v85.h"
 #include "encode_gen_v84.h"
 #include "encode_gen_v83.h"
 #include "encode_gen_v82.h"

--- a/core/ir/aarch64/codec.py
+++ b/core/ir/aarch64/codec.py
@@ -670,7 +670,7 @@ def main():
     # and SVE2 are partially supported. The null terminator element at the end
     # is required by some generator functions to correctly generate links
     # between each version's decode/encode logic.
-    isa_versions = ['v80', 'v81', 'v82', 'v83', 'v84', 'v86', 'sve', 'sve2', '']
+    isa_versions = ['v80', 'v81', 'v82', 'v83', 'v84', 'v85', 'v86', 'sve', 'sve2', '']
 
     # Read the instruction operand definitions. Used by the codec when
     # generating code to decode and encode instructions.

--- a/core/ir/aarch64/codec_sve.txt
+++ b/core/ir/aarch64/codec_sve.txt
@@ -825,10 +825,10 @@
 0000010011010101101xxxxxxxxxxxxx  n   804  SVE     uxtw          z_d_0 : p10_mrg_lo.gov z_d_5
 00000101xx10xxxx0100100xxxx0xxxx  n   557  SVE     uzp1  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011010xxxxxxxxxx  n   557  SVE     uzp1  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
-00000101101xxxxx000010xxxxxxxxxx  n   557  F64MM   uzp1          z_q_0 : z_q_5 z_q_16
+00000101101xxxxx000010xxxxxxxxxx  n   557  F64MM    uzp1          z_q_0 : z_q_5 z_q_16
 00000101xx10xxxx0100110xxxx0xxxx  n   558  SVE     uzp2  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011011xxxxxxxxxx  n   558  SVE     uzp2  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
-00000101101xxxxx000011xxxxxxxxxx  n   558  F64MM   uzp2          z_q_0 : z_q_5 z_q_16
+00000101101xxxxx000011xxxxxxxxxx  n   558  F64MM    uzp2          z_q_0 : z_q_5 z_q_16
 00100101xx1xxxxx000001xxxxx1xxxx  w   877  SVE  whilele  p_size_bhsd_0 : w5 w16
 00100101xx1xxxxx000101xxxxx1xxxx  w   877  SVE  whilele  p_size_bhsd_0 : x5 x16
 00100101xx1xxxxx000011xxxxx0xxxx  w   878  SVE  whilelo  p_size_bhsd_0 : w5 w16
@@ -840,7 +840,7 @@
 00100101001010001001000xxxx00000  n   820  SVE    wrffr                : p_b_5
 00000101xx10xxxx0100000xxxx0xxxx  n   565  SVE     zip1  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011000xxxxxxxxxx  n   565  SVE     zip1  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16
-00000101101xxxxx000000xxxxxxxxxx  n   565  F64MM   zip1          z_q_0 : z_q_5 z_q_16
+00000101101xxxxx000000xxxxxxxxxx  n   565  F64MM    zip1          z_q_0 : z_q_5 z_q_16
 00000101101xxxxx000001xxxxxxxxxx  n   566  SVE     zip2          z_q_0 : z_q_5 z_q_16
 00000101xx10xxxx0100010xxxx0xxxx  n   566  SVE     zip2  p_size_bhsd_0 : p_size_bhsd_5 p_size_bhsd_16
 00000101xx1xxxxx011001xxxxxxxxxx  n   566  SVE     zip2  z_size_bhsd_0 : z_size_bhsd_5 z_size_bhsd_16

--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -229,8 +229,8 @@ x1011010100xxxxxxxxx01xxxxxxxxxx  r   81   BASE      csneg            wx0 : wx5 
 110101010000101101111101001xxxxx  n   1058 DPB2   dc_cvadp                : memx0
 110101010000101101111100001xxxxx  n   1059 DPB     dc_cvap                : memx0
 110101010000101101111011001xxxxx  n   573  BASE    dc_cvau                : memx0
-110101010000101101110100011xxxxx  n  1209  MTE      dc_gva          memx0 :
-110101010000101101110100100xxxxx  n  1210  MTE     dc_gzva          memx0 :
+110101010000101101110100011xxxxx  n   1209 MTE      dc_gva          memx0 :
+110101010000101101110100100xxxxx  n   1210 MTE     dc_gzva          memx0 :
 110101010000100001110110010xxxxx  n   574  BASE     dc_isw                : x0
 110101010000100001110110001xxxxx  n   575  BASE    dc_ivac                : memx0
 110101010000101101110100001xxxxx  n   568  BASE     dc_zva          memx0 :

--- a/core/ir/aarch64/codec_v85.txt
+++ b/core/ir/aarch64/codec_v85.txt
@@ -1,0 +1,38 @@
+# **********************************************************
+# Copyright (c) 2024 ARM Limited. All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of ARM Limited nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# This file defines instruction encodings for v8.5 instructions.
+
+# See header comments in codec_v80.txt and opnd_defs.txt to understand how
+# instructions are defined for the purposes of decode and encode code
+# generation.
+
+# Instruction definitions:
+110101010000001100100100xx011111  n   1211  BTI        bti                : imm2_6

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -857,6 +857,19 @@
 #define INSTR_CREATE_ic_ialluis(dc) instr_create_0dst_0src(dc, OP_ic_ialluis)
 
 /**
+ * Creates a BTI instruction to  guard against the execution of instructions
+ * which are not the intended target of a branch, and is a NOP on hardware
+ * which does not support FEAT_BTI. BTI belongs to the hints instruction class.
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    BTI    #<imm>
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param imm   The imm representing the appropriate bti symbol
+ */
+#define INSTR_CREATE_bti(dc, imm) instr_create_0dst_1src(dc, OP_bti, imm)
+
+/**
  * Creates a CLREX instruction.
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
  */

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -108,6 +108,7 @@
 --------------------------x-----  fpimm1_half_one_5 # 1 bit floating-point index, represents 0.5 or 1.0
 --------------------------x-----  fpimm1_zero_one_5 # 1 bit floating-point index, represents 0.0 or 1.0
 --------------------------x-----  fpimm1_half_two_5 # 1 bit floating-point index, represents 0.5 or 2.0
+------------------------xx------  imm2_6     # 2 bit immediate from 6-7
 ------------------------xxx-----  op2        # 3 bit immediate from 5-7
 -----------------------xxxx-----  p_b_5      # P register with a byte element size
 -----------------------xxxx-----  p5         # P register

--- a/make/CMake_aarch64_gen_codec.cmake
+++ b/make/CMake_aarch64_gen_codec.cmake
@@ -82,6 +82,8 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v81.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v82.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v83.txt
+          ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v84.txt
+          ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v85.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_v86.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_sve.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec_sve2.txt

--- a/make/aarch64_check_codec_order.py
+++ b/make/aarch64_check_codec_order.py
@@ -108,9 +108,9 @@ def main():
     print('  OK!')
 
     # The Arm AArch64's architecture versions supported by the DynamoRIO codec.
-    # Currently, v8.0 is fully supported, while v8.1, v8.2, v8.3, v8.4, v8.6, SVE,
-    # and SVE2 are partially supported.
-    isa_versions = ['v80', 'v81', 'v82', 'v83', 'v84', 'v86', 'sve', 'sve2']
+    # Currently, v8.0 is fully supported, while v8.1, v8.2, v8.3, v8.4, v8.5,
+    # v8.6, SVE, and SVE2 are partially supported.
+    isa_versions = ['v80', 'v81', 'v82', 'v83', 'v84', 'v85', 'v86', 'sve', 'sve2']
 
     codecsort_py = os.path.join(src_dir, "codecsort.py")
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -490,8 +490,8 @@ endfunction(append_link_flags)
 # TODO i#6429 Change this allowlist to a blocklist.
 set(sve_tests
       simple_app api.ir api.ir_negative api.ir_v81 api.ir_v82 api.ir_v83 api.ir_v84
-      api.ir_v86 api.ir_sve api.ir_sve2 api.ir-static api.drdecode common.broadfun
-      common.fib common.nzcv common.getretaddr common.segfault
+      api.ir_v85 api.ir_v86 api.ir_sve api.ir_sve2 api.ir-static api.drdecode
+      common.broadfun common.fib common.nzcv common.getretaddr common.segfault
       common.allasm_aarch64_isa common.allasm_aarch64_cache allasm_aarch64_prefetch
       allasm_aarch64_flush libutil.frontend_test libutil.drconfig_test
       client.call-retarget client.modules client.annotation-concurrency
@@ -2029,6 +2029,7 @@ if (NOT ANDROID)
     tobuild_api(api.ir_v82 api/ir_aarch64_v82.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_v83 api/ir_aarch64_v83.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_v84 api/ir_aarch64_v84.c "" "" OFF OFF OFF)
+    tobuild_api(api.ir_v85 api/ir_aarch64_v85.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_v86 api/ir_aarch64_v86.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_sve api/ir_aarch64_sve.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_sve2 api/ir_aarch64_sve2.c "" "" OFF OFF OFF)
@@ -3237,6 +3238,8 @@ elseif (AARCH64)
     "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64-v83.txt" OFF OFF)
   torunonly_api(api.dis-a64-v84 api.dis-a64 api/dis-a64.c ""
     "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64-v84.txt" OFF OFF)
+  torunonly_api(api.dis-a64-v85 api.dis-a64 api/dis-a64.c ""
+    "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64-v85.txt" OFF OFF)
   torunonly_api(api.dis-a64-v86 api.dis-a64 api/dis-a64.c ""
     "-q;${CMAKE_CURRENT_SOURCE_DIR}/api/dis-a64-v86.txt" OFF OFF)
   torunonly_api(api.dis-a64-sve api.dis-a64 api/dis-a64.c ""

--- a/suite/tests/api/dis-a64-v85.txt
+++ b/suite/tests/api/dis-a64-v85.txt
@@ -1,0 +1,40 @@
+# **********************************************************
+# Copyright (c) 2024 ARM Limited. All rights reserved.
+# **********************************************************
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of ARM Limited nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
+# Test data for DynamoRIO's AArch64 v8.5 encoder, decoder and disassembler.
+# See dis-a64-sve.txt for the formatting.
+
+# Tests:
+
+d503241f : bti #0                         : bti    $0x00
+d503245f : bti #1                         : bti    $0x01
+d503249f : bti #2                         : bti    $0x02
+d50324df : bti #3                         : bti    $0x03
+

--- a/suite/tests/api/ir_aarch64_v85.c
+++ b/suite/tests/api/ir_aarch64_v85.c
@@ -1,0 +1,83 @@
+/* **********************************************************
+ * Copyright (c) 2023 ARM Limited. All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ARM Limited nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ARM LIMITED OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Define DR_FAST_IR to verify that everything compiles when we call the inline
+ * versions of these routines.
+ */
+#ifndef STANDALONE_DECODER
+#    define DR_FAST_IR 1
+#endif
+
+/* Uses the DR API, using DR as a standalone library, rather than
+ * being a client library working with DR on a target program.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "tools.h"
+
+#include "ir_aarch64.h"
+
+TEST_INSTR(bti)
+{
+    /* Testing BTI    #<imm> */
+    const int imm[4] = { 0, 1, 2, 3 };
+
+    const char *const expected_0_0[4] = { "bti    $0x00", "bti    $0x01", "bti    $0x02",
+                                          "bti    $0x03" };
+    TEST_LOOP(bti, bti, 4, expected_0_0[i], opnd_create_immed_uint(imm[i], OPSZ_3b));
+}
+
+int
+main(int argc, char *argv[])
+{
+#ifdef STANDALONE_DECODER
+    void *dcontext = GLOBAL_DCONTEXT;
+#else
+    void *dcontext = dr_standalone_init();
+#endif
+    bool result = true;
+    bool test_result;
+    instr_t *instr;
+
+    enable_all_test_cpu_features();
+
+    RUN_INSTR_TEST(bti);
+
+    print("All v8.5 tests complete.\n");
+#ifndef STANDALONE_DECODER
+    dr_standalone_exit();
+#endif
+    if (result)
+        return 0;
+    return 1;
+}

--- a/suite/tests/api/ir_aarch64_v85.expect
+++ b/suite/tests/api/ir_aarch64_v85.expect
@@ -1,0 +1,1 @@
+All v8.5 tests complete.


### PR DESCRIPTION
This patch adds the tests and code to recognise the BTI instruction when it is encoded as a HINT

As this is the first v8.5 instruction, it also adds the appropriate infrastructure for generating that
codec.

issues: #2626