### PR TITLE
Revert "i#6627: Fix multiply defined label in linux/clone.c (#6628)"

### DIFF
--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -249,9 +249,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "mov %[fcn], %%rdx\n\t"
                  "syscall\n\t"
                  "test %%rax, %%rax\n\t"
-                 "jnz 1f\n\t"
+                 "jnz parent\n\t"
                  "call *%%rdx\n\t"
-                 "1:\n\t"
+                 "parent:\n\t"
                  "mov %%rax, %[result]\n\t"
                  : [result] "=m"(result)
                  : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
@@ -265,9 +265,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "mov %[fcn], %%edx\n\t"
                  "int $0x80\n\t"
                  "test %%eax, %%eax\n\t"
-                 "jnz 1f\n\t"
+                 "jnz parent\n\t"
                  "call *%%edx\n\t"
-                 "1:\n\t"
+                 "parent:\n\t"
                  "mov %%eax, %[result]\n\t"
                  : [result] "=m"(result)
                  : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
@@ -280,9 +280,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "ldr x1, %[clone_args_size]\n\t"
                  "ldr x2, %[fcn]\n\t"
                  "svc #0\n\t"
-                 "cbnz x0, 1f\n\t"
+                 "cbnz x0, parent\n\t"
                  "blr x2\n\t"
-                 "1:\n\t"
+                 "parent:\n\t"
                  "str x0, %[result]\n\t"
                  : [result] "=m"(result)
                  : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),


### PR DESCRIPTION
This reverts commit 984e33548cde2b9869d16a60b15383c494470386 as it breaks our internal build.

Issue: #6627