### PR TITLE
Revert "Reformat suite/tests/linux/clone.c (#6629)"

### DIFF
--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -47,7 +47,7 @@
 #include <string.h>
 #include <errno.h>
 
-#include "tools.h"                          /* for nolibc_* wrappers. */
+#include "tools.h" /* for nolibc_* wrappers. */
 #include "../../core/unix/include/clone3.h" /* for clone3_syscall_args_t */
 
 #ifdef ANDROID
@@ -253,9 +253,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "call *%%rdx\n\t"
                  "parent:\n\t"
                  "mov %%rax, %[result]\n\t"
-                 : [result] "=m"(result)
-                 : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
-                   [clone_args_size] "m"(clone_args_size), [fcn] "m"(fcn)
+                 : [ result ] "=m"(result)
+                 : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
+                   [ clone_args_size ] "m"(clone_args_size), [ fcn ] "m"(fcn)
                  /* syscall clobbers rcx and r11 */
                  : "rax", "rdi", "rsi", "rdx", "rcx", "r11", "memory");
 #    else
@@ -269,9 +269,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "call *%%edx\n\t"
                  "parent:\n\t"
                  "mov %%eax, %[result]\n\t"
-                 : [result] "=m"(result)
-                 : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
-                   [clone_args_size] "m"(clone_args_size), [fcn] "m"(fcn)
+                 : [ result ] "=m"(result)
+                 : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
+                   [ clone_args_size ] "m"(clone_args_size), [ fcn ] "m"(fcn)
                  : "eax", "ebx", "ecx", "edx", "memory");
 #    endif
 #elif defined(AARCH64)
@@ -284,9 +284,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "blr x2\n\t"
                  "parent:\n\t"
                  "str x0, %[result]\n\t"
-                 : [result] "=m"(result)
-                 : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
-                   [clone_args_size] "m"(clone_args_size), [fcn] "m"(fcn)
+                 : [ result ] "=m"(result)
+                 : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
+                   [ clone_args_size ] "m"(clone_args_size), [ fcn ] "m"(fcn)
                  : "x0", "x1", "x2", "x8", "memory");
 #elif defined(ARM)
     /* XXX: Add asm wrapper for ARM.


### PR DESCRIPTION
This reverts commit ef572627cab469b830d08d7be22f1de9d581e8da as it breaks out internal build's workaround for i#6627.