### PR TITLE
i#6627: Fix multiply defined label in linux/clone.c

### DIFF
--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -47,7 +47,7 @@
 #include <string.h>
 #include <errno.h>
 
-#include "tools.h" /* for nolibc_* wrappers. */
+#include "tools.h"                          /* for nolibc_* wrappers. */
 #include "../../core/unix/include/clone3.h" /* for clone3_syscall_args_t */
 
 #ifdef ANDROID
@@ -253,9 +253,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "call *%%rdx\n\t"
                  "1:\n\t"
                  "mov %%rax, %[result]\n\t"
-                 : [ result ] "=m"(result)
-                 : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
-                   [ clone_args_size ] "m"(clone_args_size), [ fcn ] "m"(fcn)
+                 : [result] "=m"(result)
+                 : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
+                   [clone_args_size] "m"(clone_args_size), [fcn] "m"(fcn)
                  /* syscall clobbers rcx and r11 */
                  : "rax", "rdi", "rsi", "rdx", "rcx", "r11", "memory");
 #    else
@@ -269,9 +269,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "call *%%edx\n\t"
                  "1:\n\t"
                  "mov %%eax, %[result]\n\t"
-                 : [ result ] "=m"(result)
-                 : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
-                   [ clone_args_size ] "m"(clone_args_size), [ fcn ] "m"(fcn)
+                 : [result] "=m"(result)
+                 : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
+                   [clone_args_size] "m"(clone_args_size), [fcn] "m"(fcn)
                  : "eax", "ebx", "ecx", "edx", "memory");
 #    endif
 #elif defined(AARCH64)
@@ -284,9 +284,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "blr x2\n\t"
                  "1:\n\t"
                  "str x0, %[result]\n\t"
-                 : [ result ] "=m"(result)
-                 : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
-                   [ clone_args_size ] "m"(clone_args_size), [ fcn ] "m"(fcn)
+                 : [result] "=m"(result)
+                 : [sys_clone3] "i"(CLONE3_SYSCALL_NUM), [clone_args] "m"(clone_args),
+                   [clone_args_size] "m"(clone_args_size), [fcn] "m"(fcn)
                  : "x0", "x1", "x2", "x8", "memory");
 #elif defined(ARM)
     /* XXX: Add asm wrapper for ARM.

--- a/suite/tests/linux/clone.c
+++ b/suite/tests/linux/clone.c
@@ -249,9 +249,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "mov %[fcn], %%rdx\n\t"
                  "syscall\n\t"
                  "test %%rax, %%rax\n\t"
-                 "jnz parent\n\t"
+                 "jnz 1f\n\t"
                  "call *%%rdx\n\t"
-                 "parent:\n\t"
+                 "1:\n\t"
                  "mov %%rax, %[result]\n\t"
                  : [ result ] "=m"(result)
                  : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
@@ -265,9 +265,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "mov %[fcn], %%edx\n\t"
                  "int $0x80\n\t"
                  "test %%eax, %%eax\n\t"
-                 "jnz parent\n\t"
+                 "jnz 1f\n\t"
                  "call *%%edx\n\t"
-                 "parent:\n\t"
+                 "1:\n\t"
                  "mov %%eax, %[result]\n\t"
                  : [ result ] "=m"(result)
                  : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),
@@ -280,9 +280,9 @@ make_clone3_syscall(void *clone_args, ulong clone_args_size, void (*fcn)(void))
                  "ldr x1, %[clone_args_size]\n\t"
                  "ldr x2, %[fcn]\n\t"
                  "svc #0\n\t"
-                 "cbnz x0, parent\n\t"
+                 "cbnz x0, 1f\n\t"
                  "blr x2\n\t"
-                 "parent:\n\t"
+                 "1:\n\t"
                  "str x0, %[result]\n\t"
                  : [ result ] "=m"(result)
                  : [ sys_clone3 ] "i"(CLONE3_SYSCALL_NUM), [ clone_args ] "m"(clone_args),


### PR DESCRIPTION
Fix having label "parent" multiply defined by replacing it with a "local label":
Ref: https://sourceware.org/binutils/docs-2.42/as/Symbol-Names.html

The multiple definition is caused by make_clone3_syscall being inlined into create_thread_clone3.

Tested by running the following before/after the patch:

cd build && \
  clang \
  -I../dynamorio/core/drlibc \
  -I../dynamorio/core/lib \
  -I../dynamorio/suite/tests \
  -I. \
  -Iinclude \
  -O1 \
  -c ../dynamorio/suite/tests/linux/clone.c \
  -o clone.o

This reapplies commit 984e33548cde2b9869d16a60b15383c494470386 (#6628) that was reverted in commit 79e3c58a2ba545c5635d23f1d8060e2a9aa4c8f5 (#6633).

This also reapplies commit ef572627cab469b830d08d7be22f1de9d581e8da (#6629) that was reverted in commit c244df14f1695b4e171b594cf58a3f47dff91f8a (6634).
This reformatting patch (#6629) was added to this patch to simplify integration with google source base.

Fixes #6627