### PR TITLE
i#6636: Add randomized schedule feature

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -256,6 +256,7 @@ analyzer_multi_t::init_dynamic_schedule()
     sched_ops.blocking_switch_threshold = op_sched_blocking_switch_us.get_value();
     sched_ops.block_time_scale = op_sched_block_scale.get_value();
     sched_ops.block_time_max = op_sched_block_max_us.get_value();
+    sched_ops.randomize_next_input = op_sched_randomize.get_value();
 #ifdef HAS_ZIP
     if (!op_record_file.get_value().empty()) {
         record_schedule_zip_.reset(new zipfile_ostream_t(op_record_file.get_value()));

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -899,7 +899,7 @@ droption_t<std::string> op_sched_switch_file(
 
 droption_t<bool> op_sched_randomize(
     DROPTION_SCOPE_FRONTEND, "sched_randomize", false,
-    "Pick next inputs randomnly on context switches",
+    "Pick next inputs randomly on context switches",
     "Applies to -core_sharded and -core_serial.  Disables the normal methods of "
     "choosing the next input based on priority, timestamps (if -sched_order_time is "
     "set), and FIFO order and instead selects the next input randomly. "

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -896,6 +896,14 @@ droption_t<std::string> op_sched_switch_file(
     "sequences.  The file can contain multiple sequences each with regular trace headers "
     "and the sequence proper bracketed by TRACE_MARKER_TYPE_CONTEXT_SWITCH_START and "
     "TRACE_MARKER_TYPE_CONTEXT_SWITCH_END markers.");
+
+droption_t<bool> op_sched_randomize(
+    DROPTION_SCOPE_FRONTEND, "sched_randomize", false,
+    "Pick next inputs randomnly on context switches",
+    "Applies to -core_sharded and -core_serial.  Disables the normal methods of "
+    "choosing the next input based on priority, timestamps (if -sched_order_time is "
+    "set), and FIFO order and instead selects the next input randomly. "
+    "This is intended for experimental use in sensitivity studies.");
 
 // Schedule_stats options.
 droption_t<uint64_t>

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -201,6 +201,7 @@ extern dynamorio::droption::droption_t<std::string> op_replay_file;
 extern dynamorio::droption::droption_t<std::string> op_cpu_schedule_file;
 #endif
 extern dynamorio::droption::droption_t<std::string> op_sched_switch_file;
+extern dynamorio::droption::droption_t<bool> op_sched_randomize;
 extern dynamorio::droption::droption_t<uint64_t> op_schedule_stats_print_every;
 extern dynamorio::droption::droption_t<std::string> op_syscall_template_file;
 

--- a/clients/drcachesim/scheduler/flexible_queue.h
+++ b/clients/drcachesim/scheduler/flexible_queue.h
@@ -41,6 +41,7 @@
  */
 
 #define NOMINMAX // Avoid windows.h messing up std::max.
+#include <assert.h>
 #include <iostream>
 #include <limits>
 #include <random>
@@ -94,12 +95,14 @@ public:
     T
     top() const
     {
+        assert(!empty());
         return entries_[0]; // Undefined if empty.
     }
 
     T
     get_random_entry() // Not const as it change rand_gen's state.
     {
+        assert(!empty());
         // minstd_rand returns uint_fast32_t.  We do not support get_random_entry()
         // for queues with >2^32 entries.
         return entries_[rand_gen_() % size()]; // Undefined if empty.

--- a/clients/drcachesim/scheduler/flexible_queue.h
+++ b/clients/drcachesim/scheduler/flexible_queue.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2023-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -43,6 +43,7 @@
 #define NOMINMAX // Avoid windows.h messing up std::max.
 #include <iostream>
 #include <limits>
+#include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -66,10 +67,10 @@ public:
     // max macro (even despite NOMINMAX defined above).
     static constexpr index_t INVALID_INDEX = (std::numeric_limits<index_t>::max)();
 
-    flexible_queue_t() = default;
-    explicit flexible_queue_t(int verbose)
+    flexible_queue_t(int rand_seed = 0, int verbose = 0)
         : verbose_(verbose)
     {
+        rand_gen_.seed(rand_seed);
     }
     bool
     push(T entry)
@@ -94,6 +95,14 @@ public:
     top() const
     {
         return entries_[0]; // Undefined if empty.
+    }
+
+    T
+    get_random_entry() // Not const as it change rand_gen's state.
+    {
+        // minstd_rand returns uint_fast32_t.  We do not support get_random_entry()
+        // for queues with >2^32 entries.
+        return entries_[rand_gen_() % size()]; // Undefined if empty.
     }
 
     bool
@@ -223,6 +232,7 @@ private:
     comparator_t compare_;
     std::unordered_map<T, index_t, hash_t> entry2index_;
     int verbose_ = 0;
+    std::minstd_rand rand_gen_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1745,8 +1745,13 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
     sched_type_t::stream_status_t status = STATUS_OK;
     uint64_t cur_time = (num_blocked_ > 0) ? get_output_time(for_output) : 0;
     while (!ready_priority_.empty()) {
-        res = ready_priority_.top();
-        ready_priority_.pop();
+        if (options_.randomize_next_input) {
+            res = ready_priority_.get_random_entry();
+            ready_priority_.erase(res);
+        } else {
+            res = ready_priority_.top();
+            ready_priority_.pop();
+        }
         if (res->binding.empty() || res->binding.find(for_output) != res->binding.end()) {
             // For blocked inputs, as we don't have interrupts or other regular
             // control points we only check for being unblocked when an input

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -607,6 +607,14 @@ public:
          * core outputs.
          */
         bool single_lockstep_output = false;
+        /**
+         * If true, enables a mode where the normal methods of choosing the next input
+         * based on priority, timestamps (if -sched_order_time is set), and FIFO order
+         * are disabled.  Instead, the scheduler selects the next input randomly.  Output
+         * bindings are still honored.  This is intended for experimental use in
+         * sensitivity studies.
+         */
+        bool randomize_next_input = false;
     };
 
     /**
@@ -1009,6 +1017,7 @@ public:
 
     /** Default constructor. */
     scheduler_tmpl_t()
+        : ready_priority_(static_cast<int>(get_time_micros()))
     {
     }
     virtual ~scheduler_tmpl_t() = default;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -3796,6 +3796,63 @@ test_kernel_switch_sequences()
     }
 }
 
+void
+test_random_schedule()
+{
+    std::cerr << "\n----------------\nTesting random scheduling\n";
+    static constexpr int NUM_INPUTS = 7;
+    static constexpr int NUM_OUTPUTS = 2;
+    static constexpr int NUM_INSTRS = 9;
+    static constexpr int QUANTUM_DURATION = 3;
+    static constexpr int ITERS = 9;
+    static constexpr memref_tid_t TID_BASE = 100;
+    std::vector<trace_entry_t> inputs[NUM_INPUTS];
+    for (int i = 0; i < NUM_INPUTS; i++) {
+        memref_tid_t tid = TID_BASE + i;
+        inputs[i].push_back(make_thread(tid));
+        inputs[i].push_back(make_pid(1));
+        inputs[i].push_back(make_version(TRACE_ENTRY_VERSION));
+        inputs[i].push_back(make_timestamp(10)); // All the same time priority.
+        for (int j = 0; j < NUM_INSTRS; j++) {
+            inputs[i].push_back(make_instr(42 + j * 4));
+        }
+        inputs[i].push_back(make_exit(tid));
+    }
+    std::vector<std::set<std::string>> scheds_by_cpu(NUM_OUTPUTS);
+    for (int iter = 0; iter < ITERS; ++iter) {
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        for (int i = 0; i < NUM_INPUTS; i++) {
+            std::vector<scheduler_t::input_reader_t> readers;
+            readers.emplace_back(
+                std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[i])),
+                std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_BASE + i);
+            sched_inputs.emplace_back(std::move(readers));
+        }
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/3);
+        sched_ops.randomize_next_input = true;
+        sched_ops.quantum_duration = QUANTUM_DURATION;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        std::vector<std::string> sched_as_string =
+            run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_BASE);
+        for (int i = 0; i < NUM_OUTPUTS; i++) {
+            std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+            scheds_by_cpu[i].insert(sched_as_string[i]);
+        }
+    }
+    // With non-determinism it's hard to have a precise test.
+    // We assume most runs should be different: at least half of them (probably
+    // more but let's not make this into a flaky test).
+    for (int i = 0; i < NUM_OUTPUTS; i++) {
+        assert(scheds_by_cpu[i].size() >= ITERS / 2);
+    }
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -3831,6 +3888,7 @@ test_main(int argc, const char *argv[])
     test_inactive();
     test_direct_switch();
     test_kernel_switch_sequences();
+    test_random_schedule();
 
     dr_standalone_exit();
     return 0;


### PR DESCRIPTION
Adds a new scheduler option randomize_next_input and corresponding launcher option -sched_randomize.  When enabled, priorities and timestamps and FIFO ordering are ignored and instead a random next element from the ready queue is selected.  This will be useful for schedule sensitivity studies.

Adds a unit test.

Tested manually end-to-end as well:
```
  $ for ((i=0; i<10; ++i)); do bin64/drrun -t drcachesim -simulator_type schedule_stats -core_sharded -indir ../src/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir/ -cores 2 -sched_randomize 2>&1 | grep schedule; done
  Core #0 schedule: HEFBF_
  Core #1 schedule: GCDFA
  Core #0 schedule: GDBH
  Core #1 schedule: CFAFEF__
  Core #0 schedule: GDBF__
  Core #1 schedule: EFCFAH
  Core #0 schedule: BHFDF__
  Core #1 schedule: EGFAC
  Core #0 schedule: HAFEF__
  Core #1 schedule: GDCFB
  Core #0 schedule: ABFGF__
  Core #1 schedule: CEDFH
  Core #0 schedule: HDBF_F_F__
  Core #1 schedule: ECGA
  Core #0 schedule: HDEFA
  Core #1 schedule: CBFGF__
  Core #0 schedule: FHGFCF_
  Core #1 schedule: DEAB
  Core #0 schedule: EFABF_
  Core #1 schedule: GCDFH
```

Fixes #6636