### PR TITLE
i#6640: Switch to QueryPerformanceCounter for scheduler on Windows

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -32,13 +32,6 @@
 
 #include "analyzer.h"
 
-#ifdef WINDOWS
-#    define WIN32_LEAN_AND_MEAN
-#    include <windows.h>
-#else
-#    include <sys/time.h>
-#endif
-
 #include <stddef.h>
 #include <stdint.h>
 
@@ -387,20 +380,7 @@ template <typename RecordType, typename ReaderType>
 uint64_t
 analyzer_tmpl_t<RecordType, ReaderType>::get_current_microseconds()
 {
-#ifdef UNIX
-    struct timeval time;
-    if (gettimeofday(&time, nullptr) != 0)
-        return 0;
-    return time.tv_sec * 1000000 + time.tv_usec;
-#else
-    SYSTEMTIME sys_time;
-    GetSystemTime(&sys_time);
-    FILETIME file_time;
-    if (!SystemTimeToFileTime(&sys_time, &file_time))
-        return 0;
-    return file_time.dwLowDateTime +
-        (static_cast<uint64_t>(file_time.dwHighDateTime) << 32);
-#endif
+    return get_microsecond_timestamp();
 }
 
 template <typename RecordType, typename ReaderType>

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -197,6 +197,8 @@ split_by(std::string s, const std::string &sep)
 // On UNIX this is an absolute timestamp; but on Windows where we had
 // trouble with the GetSystemTime* functions not being granular enough
 // it's the timestamp counter from the processor.
+// (We avoid dr_get_microseconds() because not all targets link
+// in the DR library.)
 static inline uint64_t
 get_microsecond_timestamp()
 {

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -44,6 +44,7 @@
 
 #if defined(_WIN32) || defined(_WIN64) || defined(WINDOWS)
 #    define WIN32_LEAN_AND_MEAN
+#    define NOMINMAX // Avoid windows.h messing up std::min.
 #    include <windows.h>
 #else
 #    include <sys/time.h>

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -44,6 +44,8 @@
 
 #if defined(_WIN32) || defined(_WIN64) || defined(WINDOWS)
 #    define WIN32_LEAN_AND_MEAN
+#    define UNICODE  // For Windows headers.
+#    define _UNICODE // For C headers.
 #    define NOMINMAX // Avoid windows.h messing up std::min.
 #    include <windows.h>
 #else

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -42,11 +42,11 @@
 #include <string>
 #include <vector>
 
-#ifdef UNIX
-#    include <sys/time.h>
-#else
+#if defined(_WIN32) || defined(_WIN64) || defined(WINDOWS)
 #    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
+#else
+#    include <sys/time.h>
 #endif
 
 namespace dynamorio {
@@ -97,7 +97,7 @@ namespace drmemtrace {
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif
@@ -197,15 +197,15 @@ split_by(std::string s, const std::string &sep)
 static inline uint64_t
 get_microsecond_timestamp()
 {
-#ifdef UNIX
+#if defined(_WIN32) || defined(_WIN64) || defined(WINDOWS)
+    uint64_t res;
+    QueryPerformanceCounter((LARGE_INTEGER *)&res);
+    return res;
+#else
     struct timeval time;
     if (gettimeofday(&time, nullptr) != 0)
         return 0;
     return time.tv_sec * 1000000 + time.tv_usec;
-#else
-    uint64_t res;
-    QueryPerformanceCounter((LARGE_INTEGER *)&res);
-    return res;
 #endif
 }
 

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -70,12 +70,6 @@
 #endif
 #include "directory_iterator.h"
 #include "utils.h"
-#ifdef UNIX
-#    include <sys/time.h>
-#else
-#    define WIN32_LEAN_AND_MEAN
-#    include <windows.h>
-#endif
 
 #undef VPRINT
 #ifdef DEBUG
@@ -1610,24 +1604,7 @@ template <typename RecordType, typename ReaderType>
 uint64_t
 scheduler_tmpl_t<RecordType, ReaderType>::get_time_micros()
 {
-    // XXX i#5843: Should we just use dr_get_microseconds() and avoid split-OS support
-    // inside here?  We will be pulling in drdecode at least for identifying blocking
-    // syscalls so maybe full DR isn't much more since we're often linked with raw2trace
-    // which already needs it.  If we do we can remove the headers for this code too.
-#ifdef UNIX
-    struct timeval time;
-    if (gettimeofday(&time, nullptr) != 0)
-        return sched_type_t::STATUS_RECORD_FAILED;
-    return time.tv_sec * 1000000 + time.tv_usec;
-#else
-    SYSTEMTIME sys_time;
-    GetSystemTime(&sys_time);
-    FILETIME file_time;
-    if (!SystemTimeToFileTime(&sys_time, &file_time))
-        return sched_type_t::STATUS_RECORD_FAILED;
-    return file_time.dwLowDateTime +
-        (static_cast<uint64_t>(file_time.dwHighDateTime) << 32);
-#endif
+    return get_microsecond_timestamp();
 }
 
 template <typename RecordType, typename ReaderType>

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -38,10 +38,6 @@
 #ifdef WINDOWS
 #    define UNICODE
 #    define _UNICODE
-#    define WIN32_LEAN_AND_MEAN
-#    include <windows.h>
-#else
-#    include <sys/time.h>
 #endif
 
 #include "droption.h"
@@ -49,6 +45,7 @@
 #include "scheduler.h"
 #include "trace_entry.h"
 #include "test_helpers.h"
+#include "utils.h"
 #ifdef HAS_ZIP
 #    include "zipfile_istream.h"
 #    include "zipfile_ostream.h"
@@ -63,6 +60,7 @@ using ::dynamorio::drmemtrace::trace_type_names;
 using ::dynamorio::drmemtrace::zipfile_istream_t;
 using ::dynamorio::drmemtrace::zipfile_ostream_t;
 #endif
+using ::dynamorio::drmemtrace::get_microsecond_timestamp;
 using ::dynamorio::droption::droption_parser_t;
 using ::dynamorio::droption::DROPTION_SCOPE_ALL;
 using ::dynamorio::droption::DROPTION_SCOPE_FRONTEND;
@@ -127,20 +125,7 @@ droption_t<uint64_t> op_print_every(DROPTION_SCOPE_ALL, "print_every", 5000,
 uint64_t
 get_current_microseconds()
 {
-#ifdef UNIX
-    struct timeval time;
-    if (gettimeofday(&time, nullptr) != 0)
-        return 0;
-    return time.tv_sec * 1000000 + time.tv_usec;
-#else
-    SYSTEMTIME sys_time;
-    GetSystemTime(&sys_time);
-    FILETIME file_time;
-    if (!SystemTimeToFileTime(&sys_time, &file_time))
-        return 0;
-    return file_time.dwLowDateTime +
-        (static_cast<uint64_t>(file_time.dwHighDateTime) << 32);
-#endif
+    return get_microsecond_timestamp();
 }
 
 // Processes the stream of records scheduled on the "ordinal"-th virtual core with

--- a/clients/drcachesim/tests/window_test.cpp
+++ b/clients/drcachesim/tests/window_test.cpp
@@ -62,6 +62,7 @@ my_setenv(const char *var, const char *value)
 #ifdef UNIX
     return setenv(var, value, 1 /*override*/) == 0;
 #else
+    // UNICODE is defined in utils.h so to use ANSI we explicitly name it.
     return SetEnvironmentVariableA(var, value) == TRUE;
 #endif
 }

--- a/clients/drcachesim/tests/window_test.cpp
+++ b/clients/drcachesim/tests/window_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2023-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -62,7 +62,7 @@ my_setenv(const char *var, const char *value)
 #ifdef UNIX
     return setenv(var, value, 1 /*override*/) == 0;
 #else
-    return SetEnvironmentVariable(var, value) == TRUE;
+    return SetEnvironmentVariableA(var, value) == TRUE;
 #endif
 }
 

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -33,13 +33,6 @@
 #define NOMINMAX // Avoid windows.h messing up std::max.
 
 #include "schedule_stats.h"
-
-#ifdef WINDOWS
-#    define WIN32_LEAN_AND_MEAN
-#    include <windows.h>
-#else
-#    include <sys/time.h>
-#endif
 
 #include <stddef.h>
 #include <stdint.h>
@@ -162,20 +155,7 @@ schedule_stats_t::parallel_shard_error(void *shard_data)
 uint64_t
 schedule_stats_t::get_current_microseconds()
 {
-#ifdef UNIX
-    struct timeval time;
-    if (gettimeofday(&time, nullptr) != 0)
-        return 0;
-    return time.tv_sec * 1000000 + time.tv_usec;
-#else
-    SYSTEMTIME sys_time;
-    GetSystemTime(&sys_time);
-    FILETIME file_time;
-    if (!SystemTimeToFileTime(&sys_time, &file_time))
-        return 0;
-    return file_time.dwLowDateTime +
-        (static_cast<uint64_t>(file_time.dwHighDateTime) << 32);
-#endif
+    return get_microsecond_timestamp();
 }
 
 bool


### PR DESCRIPTION
Switches from GetSystemTime on Windows to QueryPerformanceCounter in scheduler and related drmemtrace code.  GetSystemTime was returning times that did not have microsecond granularity, causing problems with identical timestamps.  QueryPerformanceCounter is not an absolute time but none of the use cases need that: they just need relative orderings.

Tested on a Windows machine where GetSystemTime returned the same value repeatedly in the test_random_schedule() test from PR #6639:

```
5: time is 133518165841993473
5: time is 133518165841993473
5: time is 133518165841993473
5: time is 133518165841993473
```

While QueryPerformanceCounter changes:

```
5: time is 3353910786292
5: time is 3353910787556
5: time is 3353910810719
5: time is 3353910811957
```

Fixes #6640