### PR TITLE
i#6635 core filter, part 1: Templatize analyzer_multi_t

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -289,8 +289,8 @@ template <>
 std::unique_ptr<record_reader_t>
 record_analyzer_multi_t::create_ipc_reader(const char *name, int verbose)
 {
-    error_string_ = "Online analysis is not supported for record_filter\n";
-    ERRMSG(error_string_.c_str());
+    error_string_ = "Online analysis is not supported for record_filter";
+    ERRMSG("%s\n", error_string_.c_str());
     return std::unique_ptr<record_reader_t>();
 }
 
@@ -298,8 +298,8 @@ template <>
 std::unique_ptr<record_reader_t>
 record_analyzer_multi_t::create_ipc_reader_end()
 {
-    error_string_ = "Online analysis is not supported for record_filter\n";
-    ERRMSG(error_string_.c_str());
+    error_string_ = "Online analysis is not supported for record_filter";
+    ERRMSG("%s\n", error_string_.c_str());
     return std::unique_ptr<record_reader_t>();
 }
 
@@ -307,8 +307,8 @@ template <>
 record_analysis_tool_t *
 record_analyzer_multi_t::create_external_tool(const std::string &tool_name)
 {
-    error_string_ = "External tools are not supported for record analysis\n";
-    ERRMSG(error_string_.c_str());
+    error_string_ = "External tools are not supported for record analysis";
+    ERRMSG("%s\n", error_string_.c_str());
     return nullptr;
 }
 
@@ -316,8 +316,8 @@ template <>
 record_analysis_tool_t *
 record_analyzer_multi_t::create_invariant_checker()
 {
-    error_string_ = "Invariant checker is not supported for record analysis\n";
-    ERRMSG(error_string_.c_str());
+    error_string_ = "Invariant checker is not supported for record analysis";
+    ERRMSG("%s\n", error_string_.c_str());
     return nullptr;
 }
 

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -289,7 +289,8 @@ template <>
 std::unique_ptr<record_reader_t>
 record_analyzer_multi_t::create_ipc_reader(const char *name, int verbose)
 {
-    // Not supported;
+    error_string_ = "Online analysis is not supported for record_filter\n";
+    ERRMSG(error_string_.c_str());
     return std::unique_ptr<record_reader_t>();
 }
 
@@ -297,7 +298,8 @@ template <>
 std::unique_ptr<record_reader_t>
 record_analyzer_multi_t::create_ipc_reader_end()
 {
-    // Not supported;
+    error_string_ = "Online analysis is not supported for record_filter\n";
+    ERRMSG(error_string_.c_str());
     return std::unique_ptr<record_reader_t>();
 }
 
@@ -305,7 +307,8 @@ template <>
 record_analysis_tool_t *
 record_analyzer_multi_t::create_external_tool(const std::string &tool_name)
 {
-    // Not supported.
+    error_string_ = "External tools are not supported for record analysis\n";
+    ERRMSG(error_string_.c_str());
     return nullptr;
 }
 
@@ -313,7 +316,8 @@ template <>
 record_analysis_tool_t *
 record_analyzer_multi_t::create_invariant_checker()
 {
-    // Not supported.
+    error_string_ = "Invariant checker is not supported for record analysis\n";
+    ERRMSG(error_string_.c_str());
     return nullptr;
 }
 
@@ -429,13 +433,12 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
                                   op_verbose.get_value(), std::move(sched_ops)))
             this->success_ = false;
     } else if (op_infile.get_value().empty()) {
-        // NOCHECK has to be in analyzer_multi_t specialization?
         // XXX i#3323: Add parallel analysis support for online tools.
         this->parallel_ = false;
         auto reader =
             create_ipc_reader(op_ipc_name.get_value().c_str(), op_verbose.get_value());
         if (!reader) {
-            this->error_string_ = "Online not supported";
+            this->error_string_ = "Failed to create IPC reader: " + this->error_string_;
             this->success_ = false;
             return;
         }

--- a/clients/drcachesim/analyzer_multi.h
+++ b/clients/drcachesim/analyzer_multi.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -45,15 +45,18 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-class analyzer_multi_t : public analyzer_t {
+template <typename RecordType, typename ReaderType>
+class analyzer_multi_tmpl_t : public analyzer_tmpl_t<RecordType, ReaderType> {
 public:
     // Usage: errors encountered during the constructor will set a flag that should
     // be queried via operator!.
-    analyzer_multi_t();
-    virtual ~analyzer_multi_t();
+    analyzer_multi_tmpl_t();
+    virtual ~analyzer_multi_tmpl_t();
 
 protected:
-    scheduler_t::scheduler_options_t
+    typedef scheduler_tmpl_t<RecordType, ReaderType> sched_type_t;
+
+    typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_options_t
     init_dynamic_schedule();
     bool
     create_analysis_tools();
@@ -62,13 +65,19 @@ protected:
     void
     destroy_analysis_tools();
 
-    analysis_tool_t *
+    std::unique_ptr<ReaderType>
+    create_ipc_reader(const char *name, int verbose);
+
+    std::unique_ptr<ReaderType>
+    create_ipc_reader_end();
+
+    analysis_tool_tmpl_t<RecordType> *
     create_analysis_tool_from_options(const std::string &type);
 
-    analysis_tool_t *
+    analysis_tool_tmpl_t<RecordType> *
     create_external_tool(const std::string &id);
 
-    analysis_tool_t *
+    analysis_tool_tmpl_t<RecordType> *
     create_invariant_checker();
 
     std::string
@@ -95,6 +104,11 @@ protected:
 
     static const int max_num_tools_ = 8;
 };
+
+typedef analyzer_multi_tmpl_t<memref_t, reader_t> analyzer_multi_t;
+
+typedef analyzer_multi_tmpl_t<trace_entry_t, dynamorio::drmemtrace::record_reader_t>
+    record_analyzer_multi_t;
 
 } // namespace drmemtrace
 } // namespace dynamorio


### PR DESCRIPTION
Templatizes analyzer_multi_t over RecordType and ReaderType as a first step toward allowing the drcachesim launcher and its set of options to be used to launch the record filter tool.

Issue: #6635