### PR TITLE
Fix CMake warning in runmulti.cmake

### DIFF
--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2023 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2024 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -101,7 +101,7 @@ macro(process_cmdline line skip_empty err_and_out)
     set(${line} ${newcmd})
   endif ()
   if (NOT ${line} MATCHES "^foreach;")
-    if (NOT ${skip_empty} OR NOT ${line} STREQUAL "" AND NOT globempty)
+    if (NOT skip_empty OR NOT ${line} STREQUAL "" AND NOT globempty)
       message("Running ${line} |${${line}}|")
       execute_process(COMMAND ${${line}}
         RESULT_VARIABLE cmd_result

--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -46,6 +46,9 @@
 # glob-expansion is passed to the command.
 # If the expansion is empty for precmd, the precmd execution is skipped.
 
+# Recognize literals in if statements
+cmake_policy(SET CMP0012 NEW)
+
 # Intra-arg space=@@ and inter-arg space=@.
 # XXX i#1327: now that we have -c and other option passing improvements we
 # should be able to get rid of this @@ stuff.
@@ -101,7 +104,7 @@ macro(process_cmdline line skip_empty err_and_out)
     set(${line} ${newcmd})
   endif ()
   if (NOT ${line} MATCHES "^foreach;")
-    if (NOT skip_empty OR NOT ${line} STREQUAL "" AND NOT globempty)
+    if (NOT ${skip_empty} OR NOT ${line} STREQUAL "" AND NOT globempty)
       message("Running ${line} |${${line}}|")
       execute_process(COMMAND ${${line}}
         RESULT_VARIABLE cmd_result

--- a/suite/tests/runmulti.cmake
+++ b/suite/tests/runmulti.cmake
@@ -46,7 +46,7 @@
 # glob-expansion is passed to the command.
 # If the expansion is empty for precmd, the precmd execution is skipped.
 
-# Recognize literals in if statements
+# Recognize literals in if statements.
 cmake_policy(SET CMP0012 NEW)
 
 # Intra-arg space=@@ and inter-arg space=@.


### PR DESCRIPTION
Fixes this warning in runmulti.cmake:

  CMake Warning (dev) at suite/tests/runmulti.cmake:104 (if):
    if given arguments:

      "NOT" "ON" "OR" "NOT" "precmd" "STREQUAL" "" "AND" "NOT" "globempty"

    An argument named "ON" appears in a conditional statement.  Policy CMP0012
    is not set: if() recognizes numbers and boolean constants.  Run "cmake
    --help-policy CMP0012" for policy details.  Use the cmake_policy command to
    set the policy and suppress this warning.