### PR TITLE
i#5365 AArch64: Fix tests on non 256-bit VL hardware

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -114,7 +114,6 @@ get_processor_specific_info(void)
      */
 #        if !defined(DR_HOST_NOT_TARGET)
     if (proc_has_feature(FEATURE_SVE)) {
-#            if !defined(BUILD_TESTS)
         uint64 vl;
         /* This RDVL instruction is inserted as raw hex because we don't build
          * with SVE enabled: i.e. not -march=armv8-a+sve, so that we can run a
@@ -129,10 +128,6 @@ get_processor_specific_info(void)
             : "x0");
         cpu_info.sve_vector_length_bytes = vl;
         dr_set_sve_vector_length(vl * 8);
-#            else
-        cpu_info.sve_vector_length_bytes = 32;
-        dr_set_sve_vector_length(256);
-#            endif
     } else {
         cpu_info.sve_vector_length_bytes = 32;
         dr_set_sve_vector_length(256);

--- a/core/ir/aarch64/codec.h
+++ b/core/ir/aarch64/codec.h
@@ -57,7 +57,7 @@ encode_common(byte *pc, instr_t *i, decode_info_t *di);
 #define BITS(_enc, bitmax, bitmin) \
     ((((uint32)(_enc)) >> (bitmin)) & (uint32)MASK((bitmax) - (bitmin) + 1))
 
-#if !defined(DR_HOST_NOT_TARGET) && !defined(STANDALONE_DECODER)
+#if !defined(DR_HOST_NOT_TARGET) && !defined(STANDALONE_DECODER) && !defined(BUILD_TESTS)
 #    define OPSZ_SVE_VL_BYTES opnd_size_from_bytes(proc_get_vector_length_bytes())
 #    define OPSZ_SVE_PL_BYTES opnd_size_from_bytes(proc_get_vector_length_bytes() / 8)
 #else


### PR DESCRIPTION
Some of the SVE tests are written assuming a 256-bit vector length so that we get consistent output from the codec regardless of the hardware vector length that the test is run on. This was previously acheived by hard coding DynamoRIO's vector length to 256-bits when built with BUILD_TESTS=1.
This worked fine for the codec tests (api.ir_sve, api.dis-a64-sve) but this breaks tests such as client.drx-scattergather which need the vector length to match the hardware.

This patch tweaks two things so that all tests should now work on all vector lengths:
 1. get_processor_specific_info() now initializes the vector length to the correct hardware value whether or not BUILD_TESTS=1. This enables the client tests to work on all vector lengths.
 2. The AArch64 codec now uses dr_get_sve_vector_length() to get the vector length when built with BUILT_TESTS=1. This allows the api tests to override the vector length used by the codec by calling dr_set_sve_vector_length().

The api tests already call enable_all_test_cpu_features() which itself calls dr_set_sve_vector_length(256) so no changes to the tests themselves were needed.

Issue: #5365