### PR TITLE
Re-enable trailing space check

### DIFF
--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -318,7 +318,7 @@ string(REGEX MATCH "[^\n] \n" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   # Get more context
   string(REGEX MATCH "\n[^\n]+ \n" match "${diff_contents}")
-#NOCOMMIT  message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")
+  message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")
 endif ()
 
 ##################################################


### PR DESCRIPTION
The trailing space runsuite check was disabled for the elfutils .patch file commits but was accidentally not re-enabled.