### PR TITLE
i#6635 core filter, part 2: Add record filter to dr$sim launcher

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -277,7 +277,7 @@ target_link_libraries(drcachesim drmemtrace_simulator drmemtrace_reuse_distance
   drmemtrace_histogram drmemtrace_reuse_time drmemtrace_basic_counts
   drmemtrace_opcode_mix drmemtrace_syscall_mix drmemtrace_view drmemtrace_func_view
   drmemtrace_raw2trace directory_iterator drmemtrace_invariant_checker
-  drmemtrace_schedule_stats)
+  drmemtrace_schedule_stats drmemtrace_record_filter)
 if (UNIX)
     target_link_libraries(drcachesim dl)
 endif ()
@@ -822,7 +822,7 @@ if (BUILD_TESTS)
     drmemtrace_histogram drmemtrace_reuse_time drmemtrace_basic_counts
     drmemtrace_opcode_mix drmemtrace_syscall_mix drmemtrace_view drmemtrace_func_view
     drmemtrace_raw2trace directory_iterator drmemtrace_invariant_checker
-    drmemtrace_schedule_stats drmemtrace_analyzer)
+    drmemtrace_schedule_stats drmemtrace_analyzer drmemtrace_record_filter)
   if (UNIX)
     target_link_libraries(tool.drcachesim.core_sharded dl)
   endif ()

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -53,6 +53,7 @@
 #include "simulator/cache_simulator_create.h"
 #include "simulator/tlb_simulator_create.h"
 #include "tools/basic_counts_create.h"
+#include "tools/filter/record_filter_create.h"
 #include "tools/func_view_create.h"
 #include "tools/histogram_create.h"
 #include "tools/invariant_checker.h"
@@ -65,6 +66,7 @@
 #include "tools/view_create.h"
 #include "tools/loader/external_config_file.h"
 #include "tools/loader/external_tool_creator.h"
+#include "tools/filter/record_filter_create.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -326,7 +328,16 @@ record_analysis_tool_t *
 record_analyzer_multi_t::create_analysis_tool_from_options(
     const std::string &simulator_type)
 {
-    // TODO i#6635: create the record_filter tool if requested.
+    if (simulator_type == RECORD_FILTER) {
+        return record_filter_tool_create(
+            op_outdir.get_value(), op_filter_stop_timestamp.get_value(),
+            op_filter_cache_size.get_value(), op_filter_trace_types.get_value(),
+            op_filter_marker_types.get_value(), op_trim_before_timestamp.get_value(),
+            op_trim_after_timestamp.get_value(), op_verbose.get_value());
+    }
+    ERRMSG("Usage error: unsupported record analyzer type \"%s\".  Only " RECORD_FILTER
+           " is supported.\n",
+           simulator_type.c_str());
     return nullptr;
 }
 

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -466,7 +466,8 @@ droption_t<std::string>
                       "Predefined types: " CPU_CACHE ", " MISS_ANALYZER ", " TLB
                       ", " REUSE_DIST ", " REUSE_TIME ", " HISTOGRAM ", " BASIC_COUNTS
                       ", " INVARIANT_CHECKER ", " SCHEDULE_STATS ", or " RECORD_FILTER
-                      ". The " RECORD_FILTER " tool cannot be combined with the others. "
+                      ". The " RECORD_FILTER " tool cannot be combined with the others "
+                      "as it operates on raw disk records. "
                       "To invoke an external tool: specify its name as identified by a "
                       "name.drcachesim config file in the DR tools directory.");
 

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -36,6 +36,9 @@
 #define _OPTIONS_H_ 1
 
 // Tool names (for -simulator_type option).
+// TODO i#6660: When we add "-tool", add "cache_simulator" or "drcachesim"
+// instead of just "-tool cache".  Ditto for "TLB".
+#define CPU_CACHE "cache"
 #define MISS_ANALYZER "miss_analyzer"
 #define TLB "TLB"
 #define HISTOGRAM "histogram"
@@ -48,6 +51,7 @@
 #define FUNC_VIEW "func_view"
 #define INVARIANT_CHECKER "invariant_checker"
 #define SCHEDULE_STATS "schedule_stats"
+#define RECORD_FILTER "record_filter"
 
 // Constants used by specific tools.
 #define REPLACE_POLICY_NON_SPECIFIED ""
@@ -56,7 +60,6 @@
 #define REPLACE_POLICY_FIFO "FIFO"
 #define PREFETCH_POLICY_NEXTLINE "nextline"
 #define PREFETCH_POLICY_NONE "none"
-#define CPU_CACHE "cache"
 #define CACHE_TYPE_INSTRUCTION "instruction"
 #define CACHE_TYPE_DATA "data"
 #define CACHE_TYPE_UNIFIED "unified"
@@ -206,6 +209,12 @@ extern dynamorio::droption::droption_t<std::string> op_sched_switch_file;
 extern dynamorio::droption::droption_t<bool> op_sched_randomize;
 extern dynamorio::droption::droption_t<uint64_t> op_schedule_stats_print_every;
 extern dynamorio::droption::droption_t<std::string> op_syscall_template_file;
+extern dynamorio::droption::droption_t<uint64_t> op_filter_stop_timestamp;
+extern dynamorio::droption::droption_t<int> op_filter_cache_size;
+extern dynamorio::droption::droption_t<std::string> op_filter_trace_types;
+extern dynamorio::droption::droption_t<std::string> op_filter_marker_types;
+extern dynamorio::droption::droption_t<uint64_t> op_trim_before_timestamp;
+extern dynamorio::droption::droption_t<uint64_t> op_trim_after_timestamp;
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -276,6 +276,7 @@ tools can also be created, as described in \ref sec_drcachesim_newtool.
 - \ref sec_tool_histogram
 - \ref sec_tool_invariant_checker
 - \ref sec_tool_syscall_mix
+- \ref sec_tool_record_filter
 
 \section sec_tool_cache_sim Cache Simulator
 
@@ -892,6 +893,51 @@ Syscall mix tool results:
               1 :       318
               1 :        11
               1 :       273
+\endcode
+
+\section sec_tool_record_filter Record Filter
+
+The record filter tool modifies a target trace.  It contains several varieties of
+filters which selectively remove records from the tool.  The filters currently provided
+include:
+
+- Removing records of types specified by the -filter_trace_types option.
+  The types are identified by their #dynamorio::drmemtrace::trace_type_t
+  enum numeric value.
+
+- Remove marker records of marker types specified by the -filter_marker_types option.
+  The types are identified by their #dynamorio::drmemtrace::trace_marker_type_t
+  enum numeric value.
+
+- Running a simple data cache filter and removing hits.  The cache is enbabled
+  and its size specified by the -filter_cache_size option.  The cache filter
+  can be applied only to the start of a trace using the -filter_stop_timestamp
+  option.
+
+- Trimming the start (via -trim_before_timestamp) and end (via -trim_after_timestamp)
+  of a trace.  Any now-empty shards are deleted entirely.
+
+Example of removing function markers:
+
+\code
+$ bin64/drrun -t drcachesim -indir mytracedir -simulator_type basic_counts
+...
+        9009 total function id markers
+        5006 total function return address markers
+        6007 total function argument markers
+        4003 total function return value markers
+...
+
+$ bin64/drrun -t drcachesim -simulator_type record_filter -filter_marker_types 4,5,6,7 -indir mytracedir -outdir newdir
+Output 1280800 entries from 1304825 entries.
+
+$ bin64/drrun -t drcachesim -indir newdir -simulator_type basic_counts
+...
+           0 total function id markers
+           0 total function return address markers
+           0 total function argument markers
+           0 total function return value markers
+...
 \endcode
 
 ****************************************************************************

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -910,12 +910,13 @@ include:
   enum numeric value.
 
 - Running a simple data cache filter and removing hits.  The cache is enbabled
-  and its size specified by the -filter_cache_size option.  The cache filter
-  can be applied only to the start of a trace using the -filter_stop_timestamp
-  option.
+  and its size specified by the -filter_cache_size option.
 
 - Trimming the start (via -trim_before_timestamp) and end (via -trim_after_timestamp)
   of a trace.  Any now-empty shards are deleted entirely.
+
+A filter can be applied only to the start of a trace using the -filter_stop_timestamp
+option.
 
 Example of removing function markers:
 

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -427,7 +427,7 @@ _tmain(int argc, const TCHAR *targv[])
         }
         // release analyzer's space
         delete analyzer;
-    } else {
+    } else if (record_analyzer != nullptr) {
         if (!record_analyzer->print_stats()) {
             std::string error_string_ = record_analyzer->get_error_string();
             FATAL_ERROR("failed to print results%s%s", error_string_.empty() ? "" : ": ",

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -85,6 +85,7 @@ namespace {
     } while (0)
 
 static analyzer_t *analyzer;
+static record_analyzer_t *record_analyzer;
 #ifdef UNIX
 static pid_t child;
 #endif
@@ -101,8 +102,14 @@ signal_handler(int sig, siginfo_t *info, void *cxt)
     if (child != 0)
         kill(child, SIGINT);
     // Destroy pipe file if it's open.
-    if (analyzer != NULL)
+    if (analyzer != nullptr) {
         delete analyzer;
+        analyzer = nullptr;
+    }
+    if (record_analyzer != nullptr) {
+        delete record_analyzer;
+        record_analyzer = nullptr;
+    }
     exit(1);
 }
 #endif
@@ -316,11 +323,20 @@ _tmain(int argc, const TCHAR *targv[])
             FATAL_ERROR("invalid -outdir %s", op_outdir.get_value().c_str());
         }
     } else {
-        analyzer = new analyzer_multi_t;
-        if (!*analyzer) {
-            std::string error_string_ = analyzer->get_error_string();
-            FATAL_ERROR("failed to initialize analyzer%s%s",
-                        error_string_.empty() ? "" : ": ", error_string_.c_str());
+        if (op_simulator_type.get_value() == RECORD_FILTER) {
+            record_analyzer = new record_analyzer_multi_t;
+            if (!*record_analyzer) {
+                std::string error_string_ = record_analyzer->get_error_string();
+                FATAL_ERROR("failed to initialize record analyzer%s%s",
+                            error_string_.empty() ? "" : ": ", error_string_.c_str());
+            }
+        } else {
+            analyzer = new analyzer_multi_t;
+            if (!*analyzer) {
+                std::string error_string_ = analyzer->get_error_string();
+                FATAL_ERROR("failed to initialize analyzer%s%s",
+                            error_string_.empty() ? "" : ": ", error_string_.c_str());
+            }
         }
     }
 
@@ -364,10 +380,18 @@ _tmain(int argc, const TCHAR *targv[])
     }
 
     if (!op_offline.get_value() || have_trace_file) {
-        if (!analyzer->run()) {
-            std::string error_string_ = analyzer->get_error_string();
-            FATAL_ERROR("failed to run analyzer%s%s", error_string_.empty() ? "" : ": ",
-                        error_string_.c_str());
+        if (analyzer != nullptr) {
+            if (!analyzer->run()) {
+                std::string error_string_ = analyzer->get_error_string();
+                FATAL_ERROR("failed to run analyzer%s%s",
+                            error_string_.empty() ? "" : ": ", error_string_.c_str());
+            }
+        } else {
+            if (!record_analyzer->run()) {
+                std::string error_string_ = record_analyzer->get_error_string();
+                FATAL_ERROR("failed to run analyzer%s%s",
+                            error_string_.empty() ? "" : ": ", error_string_.c_str());
+            }
         }
     }
 
@@ -403,6 +427,14 @@ _tmain(int argc, const TCHAR *targv[])
         }
         // release analyzer's space
         delete analyzer;
+    } else {
+        if (!record_analyzer->print_stats()) {
+            std::string error_string_ = record_analyzer->get_error_string();
+            FATAL_ERROR("failed to print results%s%s", error_string_.empty() ? "" : ": ",
+                        error_string_.c_str());
+        }
+        // release analyzer's space
+        delete record_analyzer;
     }
 
     sc = drfront_cleanup_args(argv, argc);

--- a/clients/drcachesim/tests/offline-trim.templatex
+++ b/clients/drcachesim/tests/offline-trim.templatex
@@ -1,5 +1,4 @@
 Output 290 entries from 329 entries.
-Done!
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------

--- a/clients/drcachesim/tools/filter/record_filter_create.h
+++ b/clients/drcachesim/tools/filter/record_filter_create.h
@@ -1,0 +1,76 @@
+/* **********************************************************
+ * Copyright (c) 2024 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _RECORD_FILTER_CREATE_H_
+#define _RECORD_FILTER_CREATE_H_ 1
+
+#include "analysis_tool.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+/**
+ * @file drmemtrace/record_filter_create.h
+ * @brief DrMemtrace record filter trace analysis tool creation.
+ */
+
+/**
+ * Creates a record analysis tool that filters the #trace_entry_t records of an offline
+ * trace. Streams through each shard independenty and parallelly, and writes the
+ * filtered version to the output directory with the same base name. Serial mode is not
+ * yet supported. The options specify the filter(s) to employ.
+ *
+ * @param[in] output_dir  The destination directory for the new filtered trace.
+ * @param[in] stop_timestamp  Disables filtering (outputs everything) once a timestamp
+ *   equal to or greater than this value is seen.
+ * @param[in] cache_filter_size  Enables a data cache filter with the given size in
+ *   bytes with 64-byte lines and a direct mapped LRU cache.
+ * @param[in] remove_trace_types  A comma-separated list of integers of #trace_type_t
+ *   types to remove.
+ * @param[in] remove_marker_types  A comma-separated list of integers of
+ *   #trace_marker_type_t marker types to remove.
+ * @param[in] trim_before_timestamp  Trim records from the trace's initial timestamp
+ *   up to its first timestamp whose value is greater or equal to this parameter.
+ * @param[in] trim_after_timestamp  Trim records after the trace's first timestamp
+ *   whose value is greater than this parameter.
+ */
+record_analysis_tool_t *
+record_filter_tool_create(const std::string &output_dir, uint64_t stop_timestamp,
+                          int cache_filter_size, const std::string &remove_trace_types,
+                          const std::string &remove_marker_types,
+                          uint64_t trim_before_timestamp, uint64_t trim_after_timestamp,
+                          unsigned int verbose);
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _RECORD_FILTER_CREATE_H_ */

--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -41,11 +41,7 @@
 #include "analyzer.h"
 #include "droption.h"
 #include "dr_frontend.h"
-#include "tools/filter/null_filter.h"
-#include "tools/filter/cache_filter.h"
-#include "tools/filter/type_filter.h"
-#include "tools/filter/record_filter.h"
-#include "tools/filter/trim_filter.h"
+#include "tools/filter/record_filter_create.h"
 #include "tests/test_helpers.h"
 
 #include <limits>
@@ -126,22 +122,6 @@ static droption_t<uint64_t> op_trim_after_timestamp(
     "timestamp larger than the specified value (keeps a TRACE_MARKER_TYPE_CPU_ID "
     "immediately following the transition timestamp).");
 
-template <typename T>
-std::vector<T>
-parse_string(const std::string &s, char sep = ',')
-{
-    size_t pos, at = 0;
-    if (s.empty())
-        return {};
-    std::vector<T> vec;
-    do {
-        pos = s.find(sep, at);
-        vec.push_back(static_cast<T>(std::stoi(s.substr(at, pos))));
-        at = pos + 1;
-    } while (pos != std::string::npos);
-    return vec;
-}
-
 } // namespace
 
 int
@@ -166,42 +146,12 @@ _tmain(int argc, const TCHAR *targv[])
                     droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
     }
 
-    std::vector<
-        std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>>
-        filter_funcs;
-    if (op_cache_filter_size.specified()) {
-        filter_funcs.emplace_back(
-            std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>(
-                // XXX: add more command-line options to allow the user to set these
-                // parameters.
-                new dynamorio::drmemtrace::cache_filter_t(
-                    /*cache_associativity=*/1, /*cache_line_size=*/64,
-                    op_cache_filter_size.get_value(),
-                    /*filter_data=*/true, /*filter_instrs=*/false)));
-    }
-    if (op_remove_trace_types.specified() || op_remove_marker_types.specified()) {
-        std::vector<trace_type_t> filter_trace_types =
-            parse_string<trace_type_t>(op_remove_trace_types.get_value());
-        std::vector<trace_marker_type_t> filter_marker_types =
-            parse_string<trace_marker_type_t>(op_remove_marker_types.get_value());
-        filter_funcs.emplace_back(
-            std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>(
-                new dynamorio::drmemtrace::type_filter_t(filter_trace_types,
-                                                         filter_marker_types)));
-    }
-    if (op_trim_before_timestamp.specified() || op_trim_after_timestamp.specified()) {
-        filter_funcs.emplace_back(
-            std::unique_ptr<dynamorio::drmemtrace::record_filter_t::record_filter_func_t>(
-                new dynamorio::drmemtrace::trim_filter_t(
-                    op_trim_before_timestamp.get_value(),
-                    op_trim_after_timestamp.get_value())));
-    }
-    // TODO i#5675: Add other filters.
-
     auto record_filter = std::unique_ptr<record_analysis_tool_t>(
-        new dynamorio::drmemtrace::record_filter_t(
-            op_output_dir.get_value(), std::move(filter_funcs),
-            op_stop_timestamp.get_value(), op_verbose.get_value()));
+        dynamorio::drmemtrace::record_filter_tool_create(
+            op_output_dir.get_value(), op_stop_timestamp.get_value(),
+            op_cache_filter_size.get_value(), op_remove_trace_types.get_value(),
+            op_remove_marker_types.get_value(), op_trim_before_timestamp.get_value(),
+            op_trim_after_timestamp.get_value(), op_verbose.get_value()));
     std::vector<record_analysis_tool_t *> tools;
     tools.push_back(record_filter.get());
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4638,7 +4638,7 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.trim_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
       # The filter overwrites any existing file in the dir from a prior run.
       set(tool.drcacheoff.trim_precmd
-        "${filter_path}@-trim_before_timestamp@13352268558646120@-trim_after_timestamp@13352268558646661@-trace_dir@${srcdir}@-output_dir@${outdir}")
+        "${drcachesim_path}@-simulator_type@record_filter@-trim_before_timestamp@13352268558646120@-trim_after_timestamp@13352268558646661@-indir@${srcdir}@-outdir@${outdir}")
       set(tool.drcacheoff.trim_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.trim_rawtemp ON) # no preprocessor
     endif ()


### PR DESCRIPTION
Adds "-simulator_type record_filter" support to the dr$sim launcher. This builds on the templatized analyzer_multi_t to enable using record readers and record tools.

Adds a record_filter_tool_create() function and moves the filter creation out of record_filter_launcher.

Adds dr$sim launcher options -filter_stop_timestamp, -filter_cache_size, -filter_trace_types, -filter_marker_types, -trim_before_timestamp, and -trim_after_timestamp.

Changes the trim test to use the dr$sim launcher.

Adds a section on the record filter to the drmemtrace tools documentation.

Issue: #6635