### PR TITLE
i#6643: Mark interval_state_snapshot_t data members private

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -203,6 +203,11 @@ Further non-compatibility-affecting changes include:
  - Added #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VECTOR_LENGTH marker to indicate the
    current vector length for architectures with a hardware defined or runtime changeable
    vector length (such as AArch64's SVE scalable vectors).
+ - Renamed a protected data member in #dynamorio::drmemtrace::analyzer_tmpl_t from
+   merged_interval_snapshots_ to whole_trace_interval_snapshots_ (may be relevant for
+   users sub-classing analyzer_tmpl_t).
+ - Converted #dynamorio::drmemtrace::analysis_tool_tmpl_t::interval_state_snapshot_t
+   into a class with all its data members marked private with public accessor functions.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/analysis_tool.h
+++ b/clients/drcachesim/analysis_tool.h
@@ -200,6 +200,9 @@ public:
         // Allow the analyzer framework access to private data members to set them
         // during trace interval analysis. Tools have read-only access via the public
         // accessor functions.
+        // Note that we expect X to be same as RecordType. But friend declarations
+        // cannot refer to partial specializations so we go with the separate template
+        // parameter X.
         template <typename X, typename Y> friend class analyzer_tmpl_t;
 
     public:

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -712,17 +712,17 @@ analyzer_tmpl_t<RecordType, ReaderType>::combine_interval_snapshots(
             tools_[tool_idx]->get_error_string();
         return false;
     }
-    result->instr_count_delta = 0;
-    result->instr_count_cumulative = 0;
+    result->instr_count_delta_ = 0;
+    result->instr_count_cumulative_ = 0;
     for (auto snapshot : latest_shard_snapshots) {
         if (snapshot == nullptr)
             continue;
         // As discussed in the doc for analysis_tool_t::combine_interval_snapshots,
         // we combine all shard's latest snapshots for cumulative metrics, whereas
         // we combine only the shards active in current interval for delta metrics.
-        result->instr_count_cumulative += snapshot->instr_count_cumulative;
-        if (snapshot->interval_end_timestamp == interval_end_timestamp)
-            result->instr_count_delta += snapshot->instr_count_delta;
+        result->instr_count_cumulative_ += snapshot->instr_count_cumulative_;
+        if (snapshot->interval_end_timestamp_ == interval_end_timestamp)
+            result->instr_count_delta_ += snapshot->instr_count_delta_;
     }
     return true;
 }
@@ -761,7 +761,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::merge_shard_interval_results(
                 continue;
             earliest_interval_end_timestamp =
                 std::min(earliest_interval_end_timestamp,
-                         intervals[shard_idx].front()->interval_end_timestamp);
+                         intervals[shard_idx].front()->interval_end_timestamp_);
         }
         // We're done if no shard has any interval left unprocessed.
         if (earliest_interval_end_timestamp == std::numeric_limits<uint64_t>::max()) {
@@ -779,7 +779,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::merge_shard_interval_results(
             if (intervals[shard_idx].empty())
                 continue;
             uint64_t cur_interval_end_timestamp =
-                intervals[shard_idx].front()->interval_end_timestamp;
+                intervals[shard_idx].front()->interval_end_timestamp_;
             assert(cur_interval_end_timestamp >= earliest_interval_end_timestamp);
             if (cur_interval_end_timestamp > earliest_interval_end_timestamp)
                 continue;
@@ -810,10 +810,10 @@ analyzer_tmpl_t<RecordType, ReaderType>::merge_shard_interval_results(
                                         cur_merged_interval))
             return false;
         // Add the merged interval to the result list of whole trace intervals.
-        cur_merged_interval->shard_id = analysis_tool_tmpl_t<
+        cur_merged_interval->shard_id_ = analysis_tool_tmpl_t<
             RecordType>::interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID;
-        cur_merged_interval->interval_end_timestamp = earliest_interval_end_timestamp;
-        cur_merged_interval->interval_id = compute_timestamp_interval_id(
+        cur_merged_interval->interval_end_timestamp_ = earliest_interval_end_timestamp;
+        cur_merged_interval->interval_id_ = compute_timestamp_interval_id(
             earliest_ever_interval_end_timestamp, earliest_interval_end_timestamp);
         merged_intervals.push_back(cur_merged_interval);
     }
@@ -1073,28 +1073,28 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_interval(
             return false;
         }
         if (snapshot != nullptr) {
-            snapshot->shard_id = parallel
+            snapshot->shard_id_ = parallel
                 ? worker->shard_data[shard_idx].shard_id
                 : analysis_tool_tmpl_t<
                       RecordType>::interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID;
-            snapshot->interval_id = interval_id;
+            snapshot->interval_id_ = interval_id;
             if (interval_microseconds_ > 0) {
                 // For timestamp intervals, the interval_end_timestamp is the abstract
                 // non-inclusive end timestamp for the interval_id. This is to make it
                 // easier to line up the corresponding shard interval snapshots so that
                 // we can merge them to form the whole-trace interval snapshots.
-                snapshot->interval_end_timestamp = compute_interval_end_timestamp(
+                snapshot->interval_end_timestamp_ = compute_interval_end_timestamp(
                     worker->stream->get_first_timestamp(), interval_id);
             } else {
-                snapshot->interval_end_timestamp = worker->stream->get_last_timestamp();
+                snapshot->interval_end_timestamp_ = worker->stream->get_last_timestamp();
             }
             // instr_count_cumulative for the interval snapshot is supposed to be
             // inclusive, so if the first record after the interval (that is, the record
             // we're at right now) is an instr, it must be subtracted.
-            snapshot->instr_count_cumulative =
+            snapshot->instr_count_cumulative_ =
                 worker->stream->get_instruction_ordinal() - (at_instr_record ? 1 : 0);
-            snapshot->instr_count_delta =
-                snapshot->instr_count_cumulative - interval_init_instr_count;
+            snapshot->instr_count_delta_ =
+                snapshot->instr_count_cumulative_ - interval_init_instr_count;
             worker->shard_data[shard_idx].tool_data[tool_idx].interval_snapshot_data.push(
                 snapshot);
         }

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -328,21 +328,23 @@ struct recorded_snapshot_t : public analysis_tool_t::interval_state_snapshot_t {
     bool
     operator==(const recorded_snapshot_t &rhs) const
     {
-        return shard_id == rhs.shard_id && tool_shard_id == rhs.tool_shard_id &&
-            interval_id == rhs.interval_id &&
-            interval_end_timestamp == rhs.interval_end_timestamp &&
-            instr_count_cumulative == rhs.instr_count_cumulative &&
-            instr_count_delta == rhs.instr_count_delta &&
+        return get_shard_id() == rhs.get_shard_id() &&
+            tool_shard_id == rhs.tool_shard_id &&
+            get_interval_id() == rhs.get_interval_id() &&
+            get_interval_end_timestamp() == rhs.get_interval_end_timestamp() &&
+            get_instr_count_cumulative() == rhs.get_instr_count_cumulative() &&
+            get_instr_count_delta() == rhs.get_instr_count_delta() &&
             component_intervals == rhs.component_intervals;
     }
     void
     print() const
     {
-        std::cerr << "(shard_id: " << shard_id << ", interval_id: " << interval_id
+        std::cerr << "(shard_id: " << get_shard_id()
+                  << ", interval_id: " << get_interval_id()
                   << ", tool_shard_id: " << tool_shard_id
-                  << ", end_timestamp: " << interval_end_timestamp
-                  << ", instr_count_cumulative: " << instr_count_cumulative
-                  << ", instr_count_delta: " << instr_count_delta
+                  << ", end_timestamp: " << get_interval_end_timestamp()
+                  << ", instr_count_cumulative: " << get_instr_count_cumulative()
+                  << ", instr_count_delta: " << get_instr_count_delta()
                   << ", component_intervals: ";
         for (const auto &s : component_intervals) {
             std::cerr << "(tid:" << s.tid << ", seen_memrefs:" << s.seen_memrefs
@@ -473,14 +475,15 @@ public:
         for (auto snapshot : latest_shard_snapshots) {
             if (snapshot != nullptr &&
                 (!combine_only_active_shards_ ||
-                 snapshot->interval_end_timestamp == interval_end_timestamp)) {
+                 snapshot->get_interval_end_timestamp() == interval_end_timestamp)) {
                 auto recorded_snapshot =
                     dynamic_cast<const recorded_snapshot_t *const>(snapshot);
-                if (recorded_snapshot->tool_shard_id != recorded_snapshot->shard_id) {
+                if (recorded_snapshot->tool_shard_id !=
+                    recorded_snapshot->get_shard_id()) {
                     FATAL_ERROR("shard_id stored by tool (%" PRIi64
                                 ") and framework (%" PRIi64 ") mismatch",
                                 recorded_snapshot->tool_shard_id,
-                                recorded_snapshot->shard_id);
+                                recorded_snapshot->get_shard_id());
                     return nullptr;
                 }
                 result->component_intervals.insert(

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -451,37 +451,38 @@ basic_counts_t::print_interval_results(
 {
     std::cerr << "Counts per trace interval for ";
     if (!interval_snapshots.empty() &&
-        interval_snapshots[0]->shard_id !=
+        interval_snapshots[0]->get_shard_id() !=
             interval_state_snapshot_t::WHOLE_TRACE_SHARD_ID) {
-        std::cerr << "TID " << interval_snapshots[0]->shard_id << ":\n";
+        std::cerr << "TID " << interval_snapshots[0]->get_shard_id() << ":\n";
     } else {
         std::cerr << "whole trace:\n";
     }
     counters_t last;
     for (const auto &snapshot_base : interval_snapshots) {
         auto *snapshot = dynamic_cast<count_snapshot_t *>(snapshot_base);
-        std::cerr << "Interval #" << snapshot->interval_id << " ending at timestamp "
-                  << snapshot->interval_end_timestamp << ":\n";
+        std::cerr << "Interval #" << snapshot->get_interval_id()
+                  << " ending at timestamp " << snapshot->get_interval_end_timestamp()
+                  << ":\n";
         counters_t diff = snapshot->counters;
         diff -= last;
         print_counters(diff, " interval delta");
         last = snapshot->counters;
         if (knob_verbose_ > 0) {
-            if (snapshot->instr_count_cumulative !=
+            if (snapshot->get_instr_count_cumulative() !=
                 static_cast<uint64_t>(snapshot->counters.instrs)) {
                 std::stringstream err_stream;
                 err_stream << "Cumulative instr count value provided by framework ("
-                           << snapshot->instr_count_cumulative
+                           << snapshot->get_instr_count_cumulative()
                            << ") not equal to tool value (" << snapshot->counters.instrs
                            << ")\n";
                 error_string_ = err_stream.str();
                 return false;
             }
-            if (snapshot->instr_count_delta != static_cast<uint64_t>(diff.instrs)) {
+            if (snapshot->get_instr_count_delta() != static_cast<uint64_t>(diff.instrs)) {
                 std::stringstream err_stream;
                 err_stream << "Delta instr count value provided by framework ("
-                           << snapshot->instr_count_delta << ") not equal to tool value ("
-                           << diff.instrs << ")\n";
+                           << snapshot->get_instr_count_delta()
+                           << ") not equal to tool value (" << diff.instrs << ")\n";
                 error_string_ = err_stream.str();
                 return false;
             }


### PR DESCRIPTION
Marks the data members of the base interval_state_snapshot_t as private. This is to formally disallow analysis tools that subclass this from modifying the data members such as shard_id, interval_end_timestamp, etc., some of which are essential to the interval merge logic implemented by the analyzer framework.

The analyzer framework implementation in analyzer_tmpl_t is marked as a friend class so that it can still set those private data members.

Converted interval_state_snapshot_t from a struct to a class to follow our style guide.

Issue: #6643, #6020