### PR TITLE
i#6648 trim tool: Move file removal to the end

### DIFF
--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -226,6 +226,10 @@ process_entries_and_check_result(test_record_filter_t *record_filter,
         fprintf(stderr, "Filtering exit failed\n");
         return false;
     }
+    if (!record_filter->print_results()) {
+        fprintf(stderr, "Filtering results failed\n");
+        return false;
+    }
 
     std::vector<trace_entry_t> filtered = record_filter->get_output_entries();
     // Verbose output for easier debugging.

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -168,6 +168,7 @@ protected:
         bool prev_was_output = false;
         addr_t filetype = 0;
         memref_tid_t tid = 0; // For thread-sharded.
+        bool now_empty = false;
     };
 
     virtual std::string


### PR DESCRIPTION
Since file removal of now-empty shards can involve global operations that could race among shards, we move shard removal to the aggregation stage print_results() in the record filter.

Issue: #6648, #6593