### PR TITLE
i#6668: Replace drwrap retaddr sentinel on all architectures, not just x86

### DIFF
--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -2021,9 +2021,8 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(reg_t lr))
     NOTIFY(2, "%s: level %d function " PFX "\n", __FUNCTION__, pt->wrap_level + 1, pc);
 
     app_pc retaddr = IF_X86_ELSE(get_retaddr_from_stack(xsp), (app_pc)lr);
-#ifdef X86
     if (TEST(DRWRAP_REPLACE_RETADDR, global_flags)) {
-        /* In case of a tailcall for X86, the return address has already been replaced by
+        /* In case of a tailcall, the return address has already been replaced by
          * the sentinel in the stack, we need to retrieve the return address from the
          * outer level.
          */
@@ -2034,7 +2033,6 @@ drwrap_in_callee(void *arg1, reg_t xsp _IF_NOT_X86(reg_t lr))
                    pt->wrap_level, retaddr);
         }
     }
-#endif
     drwrap_context_init(drcontext, &wrapcxt, pc, &mc, DRWRAP_WHERE_PRE_FUNC, retaddr);
 
     drwrap_in_callee_check_unwind(drcontext, pt, &mc);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4777,7 +4777,7 @@ if (BUILD_CLIENTS)
     endif (BUILD_PT_TRACER AND BUILD_PT_POST_PROCESSOR)
   endif (proc_supports_pt)
 
-  if ((ARM AND NOT ANDROID) OR X86)
+  if ((AARCHXX AND NOT ANDROID) OR X86)
     torunonly_drcacheoff(getretaddr_record_replace_retaddr common.getretaddr
             "-record_replace_retaddr -record_function tailcall_with_retaddr|1&foo|1"
             "@-simulator_type@invariant_checker" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4777,7 +4777,7 @@ if (BUILD_CLIENTS)
     endif (BUILD_PT_TRACER AND BUILD_PT_POST_PROCESSOR)
   endif (proc_supports_pt)
 
-  if (ARM OR X86)
+  if ((ARM AND NOT ANDROID) OR X86)
     torunonly_drcacheoff(getretaddr_record_replace_retaddr common.getretaddr
             "-record_replace_retaddr -record_function tailcall_with_retaddr|1&foo|1"
             "@-simulator_type@invariant_checker" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4777,7 +4777,7 @@ if (BUILD_CLIENTS)
     endif (BUILD_PT_TRACER AND BUILD_PT_POST_PROCESSOR)
   endif (proc_supports_pt)
 
-  if (X86)
+  if (NOT RISCV64)
     torunonly_drcacheoff(getretaddr_record_replace_retaddr common.getretaddr
             "-record_replace_retaddr -record_function tailcall_with_retaddr|1&foo|1"
             "@-simulator_type@invariant_checker" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4777,7 +4777,7 @@ if (BUILD_CLIENTS)
     endif (BUILD_PT_TRACER AND BUILD_PT_POST_PROCESSOR)
   endif (proc_supports_pt)
 
-  if (NOT RISCV64)
+  if (ARM OR X86)
     torunonly_drcacheoff(getretaddr_record_replace_retaddr common.getretaddr
             "-record_replace_retaddr -record_function tailcall_with_retaddr|1&foo|1"
             "@-simulator_type@invariant_checker" "")


### PR DESCRIPTION
Expand drwrap's return address sentinel replacement from just x86 (as was added in PR #6395) to cover all architectures.

When -record_replace_retaddr is used in ARM (as well as x86) platforms, the return address in the stack is replaced by the sentinel.
For a tailcall, the current implementation uses the address in the stack, the sentinel, as the return address. The change is to check if the return address in the stack is the sentinel or not. If it is, replace it with the return address of the outer level.

The problem can be reproduced by

./build/bin64/drrun -t drcachesim -offline -record_replace_retaddr -record_function 'tailcall_with_retaddr|1&foo|1' -- ../build_suite/build_debug-internal-64/suite/tests/bin/common.getretaddr

on an ARM machine.

This change expends PR #6395  to cover ARM.

Issues: #6394, #6668
Fixes: #6668 