### PR TITLE
i#6648 trim tool: Remove over-threshold timestamp

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -973,9 +973,8 @@ droption_t<uint64_t> op_trim_after_timestamp(
     DROPTION_SCOPE_ALL, "trim_after_timestamp", (std::numeric_limits<uint64_t>::max)(), 0,
     (std::numeric_limits<uint64_t>::max)(),
     "Trim records after this timestamp (in us) in the trace.",
-    "Removes all records after the first TRACE_MARKER_TYPE_TIMESTAMP marker with "
-    "timestamp larger than the specified value (keeps a TRACE_MARKER_TYPE_CPU_ID "
-    "immediately following the transition timestamp).");
+    "Removes all records from the first TRACE_MARKER_TYPE_TIMESTAMP marker with "
+    "timestamp larger than the specified value.");
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/tests/offline-trim.templatex
+++ b/clients/drcachesim/tests/offline-trim.templatex
@@ -1,4 +1,4 @@
-Output 290 entries from 329 entries.
+Output 288 entries from 329 entries.
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
@@ -21,9 +21,7 @@ Output format:
          215         119:     1992554 ifetch       5 byte\(s\) @ 0x0000000000401021 b8 01 00 00 00       mov    \$0x00000001 -> %eax
          216         120:     1992554 ifetch       2 byte\(s\) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
          217         120:     1992554 <marker: chunk footer #5>
-         218         120:     1992554 <marker: timestamp 13352268558646666>
-         219         120:     1992554 <marker: tid 1992554 on core 10>
-         220         120:     1992554 <thread 1992554 exited>
+         218         120:     1992554 <thread 1992554 exited>
 View tool results:
             120 : total instructions
 

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -683,11 +683,11 @@ test_trim_filter()
             { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 0 } }, true, { true } },
             { { TRACE_TYPE_ENCODING, 2, { ENCODING_A } }, true, { true } },
             { { TRACE_TYPE_INSTR, 2, { PC_A } }, true, { true } },
-            // Removal starts right after here.
+            // Removal starts here.
             { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 200 } },
               true,
-              { true } },
-            { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 0 } }, true, { true } },
+              { false } },
+            { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 0 } }, true, { false } },
             { { TRACE_TYPE_ENCODING, 2, { ENCODING_B } }, true, { false } },
             { { TRACE_TYPE_INSTR, 2, { PC_B } }, true, { false } },
             { { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_FOOTER, { 0 } },

--- a/clients/drcachesim/tools/record_filter_launcher.cpp
+++ b/clients/drcachesim/tools/record_filter_launcher.cpp
@@ -118,9 +118,8 @@ static droption_t<uint64_t> op_trim_after_timestamp(
     DROPTION_SCOPE_ALL, "trim_after_timestamp", (std::numeric_limits<uint64_t>::max)(), 0,
     (std::numeric_limits<uint64_t>::max)(),
     "Trim records after this timestamp (in us) in the trace.",
-    "Removes all records after the first TRACE_MARKER_TYPE_TIMESTAMP marker with "
-    "timestamp larger than the specified value (keeps a TRACE_MARKER_TYPE_CPU_ID "
-    "immediately following the transition timestamp).");
+    "Removes all records from the first TRACE_MARKER_TYPE_TIMESTAMP marker with "
+    "timestamp larger than the specified value.");
 
 } // namespace
 


### PR DESCRIPTION
The original PR #6651 ended up keeping the timestamp (+ cpuid) whose value is beyond the trim-after threshold, as it logically makes sense to have that endpoint's timestamp.  However, when that's across a blocking syscall, it canbe far into the future and result in large time gaps in the trimmed trace.  Instead, we throw out the timestamp, as the PR #6551 did in its first form.  (Other options such as editing the timestamp seem worse.)

Adjusts the unit test that tests this.

Issue: #6648