### PR TITLE
i#6675: Collapse consecutive idle replay entries

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1628,6 +1628,12 @@ scheduler_tmpl_t<RecordType, ReaderType>::record_schedule_segment(
     // We always use the current wall-clock time, as the time stored in the prior
     // next_record() call can be out of order across outputs and lead to deadlocks.
     uint64_t timestamp = get_time_micros();
+    if (type == schedule_record_t::IDLE &&
+        outputs_[output].record.back().type == schedule_record_t::IDLE) {
+        // Merge.  We don't need intermediate timestamps when idle, and consecutive
+        // idle records quickly balloon the file.
+        return sched_type_t::STATUS_OK;
+    }
     outputs_[output].record.emplace_back(type, input, start_instruction, stop_instruction,
                                          timestamp);
     // The stop is typically updated later in close_schedule_segment().

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -72,6 +72,13 @@
 namespace dynamorio {  /**< General DynamoRIO namespace. */
 namespace drmemtrace { /**< DrMemtrace tracing + simulation infrastructure namespace. */
 
+/* For testing, where schedule_record_t is not accessible. */
+class replay_file_checker_t {
+public:
+    std::string
+    check(archive_istream_t *infile);
+};
+
 /**
  * Schedules traced software threads onto simulated cpus.
  * Takes in a set of recorded traces and maps them onto a new set of output
@@ -1611,6 +1618,9 @@ protected:
     // For online where we currently have to map dynamically observed thread ids
     // to the 0-based shard index.
     std::unordered_map<memref_tid_t, int> tid2shard_;
+
+    // Our testing class needs access to schedule_record_t.
+    friend class replay_file_checker_t;
 };
 
 /** See #dynamorio::drmemtrace::scheduler_tmpl_t. */

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1149,6 +1149,14 @@ test_synthetic_time_quanta()
             assert(false);
     }
     {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
+    }
+    {
         // Replay.
         std::vector<scheduler_t::input_reader_t> readers;
         for (int i = 0; i < NUM_INPUTS; ++i) {
@@ -2285,6 +2293,14 @@ test_replay()
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
     }
+    {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
+    }
     // Now replay the schedule several times to ensure repeatability.
     for (int outer = 0; outer < 5; ++outer) {
         std::vector<scheduler_t::input_workload_t> sched_inputs;
@@ -2401,6 +2417,14 @@ test_replay_multi_threaded(const char *testdir)
             thread.join();
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
+    }
+    {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
     }
     {
         // Replay.
@@ -2741,6 +2765,14 @@ test_replay_skip()
             assert(false);
     }
     {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
+    }
+    {
         // Replay.
         std::vector<scheduler_t::input_reader_t> readers;
         readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(memrefs)),
@@ -2918,6 +2950,14 @@ test_replay_limit()
             thread.join();
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
+    }
+    {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
         for (int i = 0; i < NUM_OUTPUTS; ++i) {
             std::cerr << "Output #" << i << " schedule: " << record_schedule[i] << "\n";
         }
@@ -3005,6 +3045,14 @@ test_replay_limit()
             thread.join();
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
+    }
+    {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
         int switches = 0;
         for (int i = 0; i < NUM_OUTPUTS; ++i) {
             std::cerr << "Output #" << i << " schedule: " << record_schedule[i] << "\n";
@@ -3399,6 +3447,14 @@ test_inactive()
         check_next(stream1, scheduler_t::STATUS_EOF);
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
+    }
+    {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
     }
     {
         // Replay.


### PR DESCRIPTION
Saves substantial file space in the drmemtrace scheduler's record-replay file when cores are idling by combining consecutive idle entries.

Adds checks to all unit tests which create replay files; this requires access to the non-public record format, done via a helper class.

Also tested on several real applications: for one the record file drops from 34MB to 4K, matching the size of the as-traced schedule files.  Even tiny applications like threadsig show clear reductions.  Consecutive idle entries were ballooning these files.  Large applications had multi-GB files; with this fix they are orders of magnitude smaller.

Issue: #6471, #6675
Fixes: #6675