### PR TITLE
i#6678: Rename native ci-aarchxx workflow to ci-aarch64-native

### DIFF
--- a/.github/workflows/ci-aarch64-native.yml
+++ b/.github/workflows/ci-aarch64-native.yml
@@ -31,7 +31,7 @@
 
 # Github Actions workflow for aarch64 Continuous Integration testing.
 
-name: ci-aarchxx
+name: ci-aarch64-native
 on:
   # Run on pushes to master and on pull request changes, including from a
   # forked repo with no "push" trigger, while avoiding duplicate triggers.


### PR DESCRIPTION
Rename the native ci-aarchxx workflow back to its original name ci-aarch64-native. There are currently two workflows named ci-aarchxx which is confusing. The workflow was renamed to ci-aarchxx in #6549.

Fixes #6678