### PR TITLE
Remove unused z16 codec functions

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -4501,20 +4501,6 @@ encode_opnd_q16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
     return encode_opnd_vector_reg(16, 4, opnd, enc_out);
 }
 
-/* z16: Z register at bit position 16. */
-
-static inline bool
-decode_opnd_z16(uint enc, int opcode, byte *pc, OUT opnd_t *opnd)
-{
-    return decode_opnd_vector_reg(16, Z_REG, enc, opnd);
-}
-
-static inline bool
-encode_opnd_z16(uint enc, int opcode, byte *pc, opnd_t opnd, OUT uint *enc_out)
-{
-    return encode_opnd_vector_reg(16, Z_REG, opnd, enc_out);
-}
-
 /* z_b_16: Z register with b size elements. */
 
 static inline bool

--- a/core/ir/aarch64/opnd_defs.txt
+++ b/core/ir/aarch64/opnd_defs.txt
@@ -213,7 +213,6 @@
 -----------xxxxx----------------  x16p1      # ... add 1
 -----------xxxxx----------------  d16        # D register
 -----------xxxxx----------------  q16        # Q register
------------xxxxx----------------  z16        # Z register
 -----------xxxxx----------------  z_b_16     # Z register with b size elements
 -----------xxxxx----------------  z_h_16     # Z register with h size elements
 -----------xxxxx----------------  z_s_16     # Z register with h size elements


### PR DESCRIPTION
The compiler on my local machine complains about z16 aarch64 codec routines being unused, which is a fatal error with our build settings.  The compiler is:
```
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: arm64-apple-darwin23.3.0
```
