### PR TITLE
i#6681: Work around doxygen copydoc problem

### DIFF
--- a/api/docs/home.dox
+++ b/api/docs/home.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -34,7 +34,8 @@
  ****************************************************************************
 \mainpage Home
 
-\copydoc page_home
+\brief \copybrief page_home
+\details \copydetails page_home
 
 <div style="display:none;">
 \subpage page_home


### PR DESCRIPTION
Replaces \copydoc with both \copybrief and \copydetails to work around a doxygen problem with version 1.9.8.

Issue: #6681