### PR TITLE
i#6690 dcontext_t standalone: update doc

### DIFF
--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -48,6 +48,12 @@ DR_API
  * \warning This context cannot be used as the drcontext for a thread
  * running under DR control!  It is only for standalone programs that
  * wish to use DR as a library of disassembly, etc. routines.
+ * \warning This context is not fully thread-safe as it stores
+ * the current ISA mode DR uses in a global variable.
+ * Hence, having different threads (e.g., in a parallel analysis tool)
+ * setting different ISA modes at the same time results in a race condition.
+ * Currently we require parallel analysis tools to use their own lock/unlock
+ * mechanism to avoid such race condition when setting the ISA mode.
  * \return NULL on failure, such as running on an unsupported operating
  * system version.
  */

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -48,12 +48,16 @@ DR_API
  * \warning This context cannot be used as the drcontext for a thread
  * running under DR control!  It is only for standalone programs that
  * wish to use DR as a library of disassembly, etc. routines.
- * \warning This context is not fully thread-safe as it stores
- * the current ISA mode DR uses in a global variable.
- * Hence, having different threads (e.g., in a parallel analysis tool)
- * setting different ISA modes at the same time results in a race condition.
- * Currently we require parallel analysis tools to use their own lock/unlock
- * mechanism to avoid such race condition when setting the ISA mode.
+ * \warning This context is not fully thread-safe as it stores some state
+ * (such as dr_isa_mode_t and other fields related to AArch32 encoding
+ * and decoding) that is global and may be prone to data races.
+ * For example, having different threads use dr_set_isa_mode() to set
+ * different ISA modes at the same time can result in a data race.
+ * Furthermore, encoding and decoding of AArch32 instructions in parallel
+ * may also result in a data race.
+ * Code that uses stanalone DR context across multiple threads should
+ * implement its own lock/unlock mechanism to avoid such data races
+ * when using dr_set_isa_mode() or encoding/decoding AArch32 instructions.
  * \return NULL on failure, such as running on an unsupported operating
  * system version.
  */
@@ -72,6 +76,9 @@ dr_standalone_exit(void);
 /**
  * Use this dcontext for use with the standalone static decoder library.
  * Pass it whenever a decoding-related API routine asks for a context.
+ * Note that this GLOBAL_DCONTEXT is returned by dr_standalone_init(),
+ * beware of its limitations (especially about thread-safety) described
+ * there.
  */
 #    define GLOBAL_DCONTEXT ((void *)-1)
 #endif

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -49,17 +49,19 @@ DR_API
  * running under DR control!  It is only for standalone programs that
  * wish to use DR as a library of disassembly, etc. routines.
  * \warning This context is not fully thread-safe as it stores some state
- * (such as dr_isa_mode_t and other fields related to AArch32 encoding
+ * (such as #dr_isa_mode_t and other fields related to AArch32 encoding
  * and decoding) that is global and may be prone to data races.
  * For example, having different threads use dr_set_isa_mode() to set
  * different ISA modes at the same time can result in a data race.
  * Furthermore, encoding and decoding of AArch32 instructions in parallel
  * may also result in a data race.
- * Code that uses stanalone DR context across multiple threads should
+ * Code that uses a standalone DR context across multiple threads should
  * implement its own lock/unlock mechanism to avoid such data races
  * when using dr_set_isa_mode() or encoding/decoding AArch32 instructions.
  * \return NULL on failure, such as running on an unsupported operating
  * system version.
+ */
+/* TODO i#6690: Add better multi-thread standalone decoding support.
  */
 void *
 dr_standalone_init(void);
@@ -76,7 +78,7 @@ dr_standalone_exit(void);
 /**
  * Use this dcontext for use with the standalone static decoder library.
  * Pass it whenever a decoding-related API routine asks for a context.
- * Note that this GLOBAL_DCONTEXT is returned by dr_standalone_init(),
+ * Note that this GLOBAL_DCONTEXT is returned by dr_standalone_init();
  * beware of its limitations (especially about thread-safety) described
  * there.
  */


### PR DESCRIPTION
Documents the fact that standalone dcontext_t is not fully thread-safe, hence parallel analysis tools should be aware that when different threads set DR ISA mode at the same time a race condition happens.

Issue #6690