### PR TITLE
i#6635 core filter, part 6: Add core-sharded record filter output

### DIFF
--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -59,6 +59,10 @@ namespace drmemtrace {
 #define INVALID_THREAD_ID 0
 // We avoid collisions with DR's INVALID_PROCESS_ID by using our own name.
 #define INVALID_PID -1
+// A separate sentinel for an idle core with no software thread.
+// XXX i#6703: Export this in scheduler.h as part of its API when we have
+// the scheduler insert synthetic headers.
+#define IDLE_THREAD_ID -1
 
 // XXX: perhaps we should use a C++-ish stream approach instead
 // This cannot be named ERROR as that conflicts with Windows headers.

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2127,7 +2127,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
     std::lock_guard<std::mutex> lock(*inputs_[input].lock);
 
     if (prev_input < 0 && outputs_[output].stream->filetype_ == 0) {
-        // Set the filetype up front, to let the user query at init time as documented.
+        // Set the version and filetype up front, to let the user query at init time
+        // as documented.
+        outputs_[output].stream->version_ = inputs_[input].reader->get_version();
         outputs_[output].stream->filetype_ = inputs_[input].reader->get_filetype();
     }
 

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -867,6 +867,9 @@ public:
         /**
          * Returns the #trace_version_t value from the
          * #TRACE_MARKER_TYPE_VERSION record in the trace header.
+         * This can be queried prior to explicitly retrieving any records from
+         * output streams, unless #dynamorio::drmemtrace::scheduler_tmpl_t::
+         * scheduler_options_t.read_inputs_in_init is false.
          */
         uint64_t
         get_version() const override
@@ -881,7 +884,6 @@ public:
          * This can be queried prior to explicitly retrieving any records from
          * output streams, unless #dynamorio::drmemtrace::scheduler_tmpl_t::
          * scheduler_options_t.read_inputs_in_init is false.
-
          */
         uint64_t
         get_filetype() const override

--- a/clients/drcachesim/tests/record_filter_bycore_uni.templatex
+++ b/clients/drcachesim/tests/record_filter_bycore_uni.templatex
@@ -1,0 +1,14 @@
+#ifdef WINDOWS
+Hit delay threshold: enabling tracing.
+Exiting process after .* references.
+#else
+Hello, world!
+#endif
+Trace invariant checks passed
+Output .* entries from .* entries.
+Schedule stats tool results:
+.*
+Core #0 schedule: .*
+Core #1 schedule: .*
+Core #2 schedule: .*
+Core #3 schedule: .*

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -106,6 +106,7 @@ protected:
     {
         output_.push_back(entry);
         shard->cur_refs += shard->memref_counter.entry_memref_count(&entry);
+        shard->last_written_record = entry;
         return true;
     }
     std::string
@@ -145,6 +146,12 @@ public:
     set_last_timestamp(uint64_t last_timestamp)
     {
         last_timestamp_ = last_timestamp;
+    }
+    int64_t
+    get_input_id() const override
+    {
+        // Just one input for our tests.
+        return 0;
     }
 
 private:

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -35,6 +35,7 @@
 
 #include <stdint.h>
 
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <ostream>
@@ -128,6 +129,8 @@ public:
     print_results() override;
     bool
     parallel_shard_supported() override;
+    std::string
+    initialize_shard_type(shard_type_t shard_type) override;
     void *
     parallel_shard_init_stream(int shard_index, void *worker_data,
                                memtrace_stream_t *shard_stream) override;
@@ -139,6 +142,15 @@ public:
     parallel_shard_error(void *shard_data) override;
 
 protected:
+    // For core-sharded we need to remember encodings for an input that were
+    // seen on a different core, as there is no reader_t remembering them for us.
+    struct per_input_t {
+        // There should be no contention on the lock as each input is on
+        // just one core at a time.
+        std::mutex lock;
+        std::unordered_map<addr_t, std::vector<trace_entry_t>> pc2encoding;
+    };
+
     struct per_shard_t {
         std::string output_path;
         // One and only one of these writers can be valid.
@@ -164,11 +176,17 @@ protected:
         addr_t last_timestamp = 0;
         addr_t last_cpu_id = 0;
         std::unordered_set<addr_t> cur_chunk_pcs;
-        std::unordered_map<addr_t, std::vector<trace_entry_t>> pc2encoding;
         bool prev_was_output = false;
         addr_t filetype = 0;
-        memref_tid_t tid = 0; // For thread-sharded.
         bool now_empty = false;
+        // For thread-sharded.
+        memref_tid_t tid = 0;
+        int64_t prev_workload_id = -1;
+        // For core-sharded.
+        int64_t prev_input_id = -1;
+        trace_entry_t last_written_record;
+        // Cached value updated on context switches.
+        per_input_t *per_input = nullptr;
     };
 
     virtual std::string
@@ -193,6 +211,7 @@ protected:
     // This mutex is only needed in parallel_shard_init. In all other accesses
     // to shard_map (print_results) we are single-threaded.
     std::mutex shard_map_mutex_;
+    shard_type_t shard_type_ = SHARD_BY_THREAD;
 
 private:
     virtual bool
@@ -206,11 +225,40 @@ private:
     bool
     write_trace_entries(per_shard_t *shard, const std::vector<trace_entry_t> &entries);
 
+    inline uint64_t
+    add_to_filetype(uint64_t filetype)
+    {
+        if (stop_timestamp_ != 0) {
+            filetype |= OFFLINE_FILE_TYPE_BIMODAL_FILTERED_WARMUP;
+        }
+        if (shard_type_ == SHARD_BY_CORE) {
+            filetype |= OFFLINE_FILE_TYPE_CORE_SHARDED;
+        }
+        return filetype;
+    }
+
     std::string output_dir_;
     std::vector<std::unique_ptr<record_filter_func_t>> filters_;
     uint64_t stop_timestamp_;
     unsigned int verbosity_;
     const char *output_prefix_ = "[record_filter]";
+    // For core-sharded, but used for thread-sharded to simplify the code.
+    std::mutex input2info_mutex_;
+    // We use a pointer so we can safely cache it in per_shard_t to avoid
+    // input2info_mutex_ on every access.
+    // XXX: We could use a read-write lock but C++11 doesn't have a ready-made one.
+    // If we had the input count we could use an array and atomic reads.
+    std::unordered_map<int64_t, std::unique_ptr<per_input_t>> input2info_;
+
+    // For core-sharded we don't have a 1:1 input:output file mapping.
+    // Thus, some shards may not not have an input stream at init time, and
+    // need to figure out their file extension and header info from other shards.
+    std::mutex input_info_mutex_;
+    std::condition_variable input_info_cond_var_;
+    // The above locks guard these fields:
+    std::string output_ext_;
+    uint64_t version_ = 0;
+    uint64_t filetype_ = 0;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -241,7 +241,7 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         (TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard->filetype) || input_id < 0)
         ? tid
         : input_id;
-    if (workload_id != prev_workload_id || tid != prev_tid) {
+    if ((workload_id != prev_workload_id || tid != prev_tid) && tid != IDLE_THREAD_ID) {
         // We convert to letters which only works well for <=26 inputs.
         if (!shard->thread_sequence.empty()) {
             ++shard->counters.total_switches;

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -121,7 +121,7 @@ protected:
         int64_t core = 0; // We target core-sharded.
         counters_t counters;
         int64_t prev_workload_id = -1;
-        int64_t prev_tid = -1;
+        int64_t prev_tid = INVALID_THREAD_ID;
         // These are cleared when an instruction is seen.
         bool saw_syscall = false;
         memref_tid_t direct_switch_target = INVALID_THREAD_ID;

--- a/clients/drcachesim/tracer/raw2trace_shared.h
+++ b/clients/drcachesim/tracer/raw2trace_shared.h
@@ -143,6 +143,11 @@ public:
             return nullptr;
         return encodings_[orig_pc].bits;
     }
+    void
+    set_core_sharded(bool core_sharded)
+    {
+        core_sharded_ = core_sharded;
+    }
 
 private:
     bool saw_pid_ = false;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4601,37 +4601,62 @@ if (BUILD_CLIENTS)
       "${histo_path}@-test_mode@-test_mode_name@kernel_xfer_app@-trace_dir@${testname_full}.*.dir/trace")
 
     # Test the standalone record filter tool (beyond its unit tests).
+    # Assumes the record filter output dir is named "${testname}.filtered.dir".
+    macro (torun_record_filter testname exename template_name launch_cmd analyzer)
+      if (WIN32)
+        # Speed the test up (takes 1+ minutes otherwise).
+        set(extra_ops "-trace_after_instrs 5K -exit_after_tracing 50K")
+      else ()
+        set(extra_ops "")
+      endif ()
+      torunonly_ci(${testname} ${exename} drcachesim
+        "${template_name}.c"
+        "-offline -subdir_prefix ${testname} ${extra_ops}" "" "")
+      set(${testname}_toolname "drcachesim")
+      set(${testname}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      set(outdir "${testname}.filtered.dir")
+      set(${testname}_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+      set(${testname}_precmd
+        "foreach@${CMAKE_COMMAND}@-E@remove_directory@${testname}.*.dir")
+      # Post-process the trace and sanity check it.
+      # Use a smaller chunk threshold to test multiple chunks.
+      set(${testname}_postcmd
+        "${drcachesim_path}@-chunk_instr_count@1000@-indir@${testname}.*.dir@-simulator_type@invariant_checker")
+      # Run the record filter tool with a null filter.
+      set(${testname}_postcmd2 "${CMAKE_COMMAND}@-E@make_directory@${outdir}")
+      set(${testname}_postcmd3 ${launch_cmd})
+      # Run the analyzer on the result.
+      set(${testname}_postcmd4
+        "${drcachesim_path}@-indir@${outdir}@-simulator_type@${analyzer}")
+    endmacro ()
+
     set(testname "tool.record_filter")
-    if (WIN32)
-      # Speed the test up (takes 1+ minutes otherwise).
-      set(extra_ops "-trace_after_instrs 5K -exit_after_tracing 50K")
-    else ()
-      set(extra_ops "")
-    endif ()
-    torunonly_ci(${testname} ${ci_shared_app} drcachesim
-      "record_filter-offline.c"
-      "-offline -subdir_prefix ${testname} ${extra_ops}" "" "")
-    set(${testname}_toolname "drcachesim")
-    set(${testname}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
     get_target_path_for_execution(filter_path record_filter_launcher "${location_suffix}")
     prefix_cmd_if_necessary(filter_path ON ${filter_path})
-    set(outdir "${testname}.filtered.dir")
-    set(${testname}_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
-    set(${testname}_precmd
-      "foreach@${CMAKE_COMMAND}@-E@remove_directory@${testname}.*.dir")
-    # Post-process the trace and sanity check it.
-    # Use a smaller chunk threshold to test multiple chunks.
-    set(${testname}_postcmd
-      "${drcachesim_path}@-chunk_instr_count@1000@-indir@${testname}.*.dir@-simulator_type@invariant_checker")
-    # Run the record filter tool with a null filter.
-    set(${testname}_postcmd2 "${CMAKE_COMMAND}@-E@make_directory@${outdir}")
-    set(${testname}_postcmd3
+    torun_record_filter("${testname}" ${ci_shared_app} "record_filter-offline"
       # We assume the app name starts with "s" here to avoid colliding with
       # our output dir, while still letting the single precmd remove both.
-      "${filter_path}@-trace_dir@${testname}.s*.dir/trace@-output_dir@${outdir}")
-    # Run the invariant checker on the result.
-    set(${testname}_postcmd4
-      "${drcachesim_path}@-indir@${outdir}@-simulator_type@invariant_checker")
+      "${filter_path}@-trace_dir@${testname}.s*.dir/trace@-output_dir@${testname}.filtered.dir"
+      "invariant_checker")
+
+    # Single-threaded app on 4 cores to test start-idle cores.
+    set(testname "tool.record_filter_bycore_uni")
+    torun_record_filter("${testname}" ${ci_shared_app}
+      "record_filter_bycore_uni"
+      # We assume the app name starts with "s" here to avoid colliding with
+      # our output dir, while still letting the single precmd remove both.
+      "${drcachesim_path}@-simulator_type@record_filter@-indir@${testname}.s*.dir/trace@-core_sharded@-cores@4@-outdir@${testname}.filtered.dir"
+      "schedule_stats")
+
+    if (UNIX) # Windows multi-thread tests are too slow.
+      set(testname "tool.record_filter_bycore_multi")
+      torun_record_filter("${testname}" pthreads.ptsig
+        "record_filter_bycore_multi"
+        # We use the app name start char "p" here to avoid colliding with
+        # our output dir, while still letting the single precmd remove both.
+        "${drcachesim_path}@-simulator_type@record_filter@-indir@${testname}.p*.dir/trace@-core_sharded@-cores@3@-outdir@${testname}.filtered.dir"
+        "schedule_stats")
+    endif ()
 
     # Test the trim filter.
     if (X86 AND X64 AND ZLIB_FOUND)


### PR DESCRIPTION
Multiple changes to allow the record filter to operate in core-sharded fashion:

Makes the pc2encoding table per-input, as one input can migrate across multiple core shards and thus one core can see a later instruction without ever having seen its encoding.  To handle synchronization, there is no C++11 std:: rwlock, so we use mutexes -- but we limit their use to per-context-switch for the added global lock, and we assume there is no contention for the per-input lock as only one shard operates on one input at any one time.

Sets the memref counter reader to core_sharded_ to avoid asserts.

Appends footer records to ending-in-idle-record cores.

Adds an error check ensuring a single workload, as multiple will require expanding the keys used in some tables.

Renames the output files to include "core.<shard_index>" and not the tid.  This is surprisingly complex, as an input filename is needed to determine the output filename compression type: yet not all shards are guaranteed to have an input at the start.  A condition variable and mutex are used to coordinate this among shards.

Adds support for started-idle cores by synthesizing headers in record_filter; #6703 covers having the scheduler do this for all analyzers.  Adds the version as another field available up front from the scheduler, and adds an idle-tid sentinel needed to be distinct from INVALID_THREAD_ID.

Adds two end-to-end tests, one with a single-threaded app scheduled onto 4 cores to test start-idle cores and one to test multiple threads.  Adds a macro to share code with the existing end-to-end test.

Updates the unit test mock classes.

Issue: #6635, #6703