### PR TITLE
i#6709: Update WIX version to 6.14

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -471,7 +471,7 @@ jobs:
         7z x c:\projects\install\doxygen.zip -oc:\projects\install\doxygen > nul
         set PATH=c:\projects\install\doxygen;%PATH%
         dir "c:\Program Files (x86)\WiX Toolset"*
-        set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;%PATH%
+        set PATH=C:\Program Files (x86)\WiX Toolset v3.14\bin;%PATH%
         call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"


### PR DESCRIPTION
Updates the PATH of our package build to find the new WIX version on the GA CI VM's.

Tested: https://github.com/DynamoRIO/dynamorio/actions/runs/8308632272

Fixes #6709