### PR TITLE
i#6713: Remove same-input-same-start cpu_schedule entries

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1250,7 +1250,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::remove_zero_instruction_segments(
                 VPRINT(this, 1, "Dropping same-input=%d same-start=%" PRIu64 " entry\n",
                        input_idx, start);
                 all_sched[input_sched[input_idx][i - 1].output]
-                         [input_sched[input_idx][i - 1].output_array_idx]
+                         [static_cast<size_t>(
+                              input_sched[input_idx][i - 1].output_array_idx)]
                              .valid = false;
                 input_sched[input_idx].erase(input_sched[input_idx].begin() + i - 1);
                 // Keep the iteration on course.

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1234,6 +1234,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::remove_zero_instruction_segments(
     // starting at instruction 0, which causes confusion when determining endpoints.
     // We just drop the older entry and keep the later one, which is the one bundled
     // with actual instructions.
+    //
+    // Should we not have instruction-based control points? The skip and
+    // region-of-interest features were designed thinking about instructions, the more
+    // natural unit for microarchitectural simulators.  It seemed like that was much more
+    // usable for a user, and translated to other venues like PMU counts.  The scheduler
+    // replay features were also designed that way.  But, that makes the infrastructure
+    // messy as the underlying records are not built that way.  Xref i#6716 on an
+    // instruction-based iterator.
     for (int input_idx = 0; input_idx < static_cast<input_ordinal_t>(inputs_.size());
          ++input_idx) {
         std::sort(
@@ -1253,9 +1261,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::remove_zero_instruction_segments(
                          [static_cast<size_t>(
                               input_sched[input_idx][i - 1].output_array_idx)]
                              .valid = false;
-                input_sched[input_idx].erase(input_sched[input_idx].begin() + i - 1);
-                // Keep the iteration on course.
-                --i;
+                // If code after this used input_sched we would want to erase the
+                // entry, but we have no further use so we leave it.
             }
             prev_start = start;
         }

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1331,6 +1331,39 @@ protected:
         uint64_t wait_start_time = 0;
     };
 
+    // Used for reading as-traced schedules.
+    struct schedule_output_tracker_t {
+        schedule_output_tracker_t(bool valid, input_ordinal_t input,
+                                  uint64_t start_instruction, uint64_t timestamp)
+            : valid(valid)
+            , input(input)
+            , start_instruction(start_instruction)
+            , stop_instruction(0)
+            , timestamp(timestamp)
+        {
+        }
+        bool valid;
+        input_ordinal_t input;
+        uint64_t start_instruction;
+        uint64_t stop_instruction;
+        uint64_t timestamp;
+    };
+    // Used for reading as-traced schedules.
+    struct schedule_input_tracker_t {
+        schedule_input_tracker_t(output_ordinal_t output, uint64_t output_array_idx,
+                                 uint64_t start_instruction, uint64_t timestamp)
+            : output(output)
+            , output_array_idx(output_array_idx)
+            , start_instruction(start_instruction)
+            , timestamp(timestamp)
+        {
+        }
+        output_ordinal_t output;
+        uint64_t output_array_idx;
+        uint64_t start_instruction;
+        uint64_t timestamp;
+    };
+
     // Called just once at initialization time to set the initial input-to-output
     // mappings and state.
     scheduler_status_t
@@ -1394,10 +1427,15 @@ protected:
     read_traced_schedule();
 
     scheduler_status_t
+    remove_zero_instruction_segments(
+        std::vector<std::vector<schedule_input_tracker_t>> &input_sched,
+        std::vector<std::vector<schedule_output_tracker_t>> &all_sched);
+
+    scheduler_status_t
     check_and_fix_modulo_problem_in_schedule(
-        std::vector<std::vector<schedule_record_t>> &input_sched,
+        std::vector<std::vector<schedule_input_tracker_t>> &input_sched,
         std::vector<std::set<uint64_t>> &start2stop,
-        std::vector<std::vector<schedule_record_t>> &all_sched);
+        std::vector<std::vector<schedule_output_tracker_t>> &all_sched);
 
     scheduler_status_t
     read_recorded_schedule();

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1342,6 +1342,8 @@ protected:
             , timestamp(timestamp)
         {
         }
+        // To support removing later-discovered-as-redundant entries without
+        // a linear erase operation we have a 'valid' flag.
         bool valid;
         input_ordinal_t input;
         uint64_t start_instruction;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -3297,10 +3297,10 @@ test_replay_as_traced_dup_start()
     {
         zipfile_ostream_t outfile(cpu_fname);
         {
-            // Simple dup start: non-consecutive but in same output.
             std::vector<schedule_entry_t> sched;
             sched.emplace_back(TID_A, TIMESTAMP_BASE, CPU_0, 0);
             sched.emplace_back(TID_B, TIMESTAMP_BASE + 2, CPU_0, 0);
+            // Simple dup start: non-consecutive but in same output.
             sched.emplace_back(TID_A, TIMESTAMP_BASE + 4, CPU_0, 0);
             sched.emplace_back(TID_B, TIMESTAMP_BASE + 5, CPU_0, 4);
             std::ostringstream cpu_string;
@@ -3312,8 +3312,8 @@ test_replay_as_traced_dup_start()
                 assert(false);
         }
         {
-            // More complex dup start across outputs.
             std::vector<schedule_entry_t> sched;
+            // More complex dup start across outputs.
             sched.emplace_back(TID_B, TIMESTAMP_BASE + 1, CPU_1, 0);
             sched.emplace_back(TID_C, TIMESTAMP_BASE + 3, CPU_1, 0);
             sched.emplace_back(TID_A, TIMESTAMP_BASE + 6, CPU_1, 4);


### PR DESCRIPTION
Removes same-input-same-start cpu_schedule entries when reading the schedule file in the scheduler.  The scheduler cannot emulate a switch with no instructions in between in replay mode, and these same-start entries cause problems.

Adds a scheduler unit test.

Tested on a larger app in as-traced mode where there are many of these same-start entries and without this fix the scheduler advances too early, causing problems.

Fixes #6713