### PR TITLE
i#6734: Set filetype in record_filter start-idle shards

### DIFF
--- a/clients/drcachesim/tests/record_filter_bycore_uni.templatex
+++ b/clients/drcachesim/tests/record_filter_bycore_uni.templatex
@@ -6,9 +6,5 @@ Hello, world!
 #endif
 Trace invariant checks passed
 Output .* entries from .* entries.
-Schedule stats tool results:
+Opcode mix tool results:
 .*
-Core #0 schedule: .*
-Core #1 schedule: .*
-Core #2 schedule: .*
-Core #3 schedule: .*

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -213,7 +213,7 @@ record_filter_t::initialize_shard_output(per_shard_t *per_shard,
                    shard_stream->get_shard_index(), output_ext_.c_str(), version_,
                    filetype_);
             per_shard->output_path += output_ext_;
-            per_shard->filetype = filetype_;
+            per_shard->filetype = static_cast<addr_t>(filetype_);
             lock.unlock();
         } else if (!input_name.empty()) {
             size_t last_dot = input_name.rfind('.');
@@ -233,7 +233,7 @@ record_filter_t::initialize_shard_output(per_shard_t *per_shard,
                    shard_stream->get_shard_index(), output_ext_.c_str(), version_,
                    filetype_);
             per_shard->output_path += output_ext_;
-            per_shard->filetype = filetype_;
+            per_shard->filetype = static_cast<addr_t>(filetype_);
             lock.unlock();
             input_info_cond_var_.notify_all();
         } else {
@@ -244,7 +244,7 @@ record_filter_t::initialize_shard_output(per_shard_t *per_shard,
                    shard_stream->get_shard_index(), output_ext_.c_str(), version_,
                    filetype_);
             per_shard->output_path += output_ext_;
-            per_shard->filetype = filetype_;
+            per_shard->filetype = static_cast<addr_t>(filetype_);
             lock.unlock();
         }
     } else {

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -213,6 +213,7 @@ record_filter_t::initialize_shard_output(per_shard_t *per_shard,
                    shard_stream->get_shard_index(), output_ext_.c_str(), version_,
                    filetype_);
             per_shard->output_path += output_ext_;
+            per_shard->filetype = filetype_;
             lock.unlock();
         } else if (!input_name.empty()) {
             size_t last_dot = input_name.rfind('.');
@@ -232,6 +233,7 @@ record_filter_t::initialize_shard_output(per_shard_t *per_shard,
                    shard_stream->get_shard_index(), output_ext_.c_str(), version_,
                    filetype_);
             per_shard->output_path += output_ext_;
+            per_shard->filetype = filetype_;
             lock.unlock();
             input_info_cond_var_.notify_all();
         } else {
@@ -242,6 +244,7 @@ record_filter_t::initialize_shard_output(per_shard_t *per_shard,
                    shard_stream->get_shard_index(), output_ext_.c_str(), version_,
                    filetype_);
             per_shard->output_path += output_ext_;
+            per_shard->filetype = filetype_;
             lock.unlock();
         }
     } else {

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4649,7 +4649,10 @@ if (BUILD_CLIENTS)
       # We assume the app name starts with "s" here to avoid colliding with
       # our output dir, while still letting the single precmd remove both.
       "${drcachesim_path}@-simulator_type@record_filter@-indir@${testname}.s*.dir/trace@-core_sharded@-cores@4@-outdir@${testname}.filtered.dir"
-      "schedule_stats")
+      # We run opcode_mix to test encodings.
+      # XXX i#6684: Once we have invariant_checker support, run it here (and ensure
+      # it checks encodings).
+      "opcode_mix")
 
     if (UNIX) # Windows multi-thread tests are too slow.
       set(testname "tool.record_filter_bycore_multi")


### PR DESCRIPTION
Sets the filetype for record_filter shards from the filetype_ var to ensure start-idle shards have the correct type.

Switches to using opcode_mix in the tool.record_filter_bycore_uni test, which fails with encoding errors without this fix.

Fixes #6734