### PR TITLE
i#3544 RV64: Port stolen-reg test to RISC-V

### DIFF
--- a/core/arch/arch.c
+++ b/core/arch/arch.c
@@ -3868,6 +3868,11 @@ set_stolen_reg_val(priv_mcontext_t *mc, reg_t newval)
 }
 
 #    ifdef RISCV64
+reg_t
+get_tp_reg_val(priv_mcontext_t *mc)
+{
+    return *(reg_t *)(((byte *)mc) + opnd_get_reg_dcontext_offs(DR_REG_TP));
+}
 void
 set_tp_reg_val(priv_mcontext_t *mc, reg_t newval)
 {

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -471,6 +471,8 @@ get_stolen_reg_val(priv_mcontext_t *context);
 void
 set_stolen_reg_val(priv_mcontext_t *mc, reg_t newval);
 #    ifdef RISCV64
+reg_t
+get_tp_reg_val(priv_mcontext_t *mc);
 void
 set_tp_reg_val(priv_mcontext_t *mc, reg_t newval);
 #    endif

--- a/core/arch/riscv64/mangle.c
+++ b/core/arch/riscv64/mangle.c
@@ -572,19 +572,19 @@ mangle_stolen_reg_and_tp_reg(dcontext_t *dcontext, instrlist_t *ilist, instr_t *
 
 /* Mangle a cbr that uses stolen register and tp register as follows:
  *
- *      beq  tp, t3, target         # t3 is the stolen register
+ *      beq  tp, s11, target        # s11 is the stolen register
  * =>
- *      sd   a0, a0_slot(t3)        # spill a0
- *      ld   a0, tp_slot(t3)        # load app's tp from memory
- *      sd   a1, a1_slot(t3)        # spill a1
- *      ld   a1, stolen_slot(t3)    # laod app's t3 from memory
+ *      sd   a0, a0_slot(s11)       # spill a0
+ *      ld   a0, tp_slot(s11)       # load app's tp from memory
+ *      sd   a1, a1_slot(s11)       # spill a1
+ *      ld   a1, stolen_slot(s11)   # laod app's s11 from memory
  *      bne  a0, a1, fall
- *      ld   a0, a0_slot(t3)        # restore a0 (original branch taken)
- *      ld   a1, a1_slot(t3)        # restore a1
+ *      ld   a0, a0_slot(s11)       # restore a0 (original branch taken)
+ *      ld   a1, a1_slot(s11)       # restore a1
  *      j    target
  * fall:
- *      ld   a0, a0_slot(t3)        # restore a0 (original branch not taken)
- *      ld   a1, a1_slot(t3)        # restore a1
+ *      ld   a0, a0_slot(s11)       # restore a0 (original branch not taken)
+ *      ld   a1, a1_slot(s11)       # restore a1
  */
 static void
 mangle_cbr_stolen_reg_and_tp_reg(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
@@ -939,27 +939,27 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
  * # After mangling
  * <block 1>
  * 1:
- *      sd          a0, a0_slot(t3)         # save scratch register
+ *      sd          a0, a0_slot(s11)        # save scratch register
  *      fence       rw, rw                  # keep release semantics
  *      lw          a5, 0(a3)               # replace lr with a normal load
  *      fence       rw, rw                  # keep acquire semantics
- *      sd          a3, lrsc_addr_slot(t3)  # save address
- *      sd          a5, lrsc_val_slot(t3)   # save value
+ *      sd          a3, lrsc_addr_slot(s11) # save address
+ *      sd          a5, lrsc_val_slot(s11)  # save value
  *      li          a0, 4
- *      sd          a0, lrsc_size_slot(t3)  # save size (4 bytes)
- *      ld          a0, a0_slot(t3)         # restore scratch register
+ *      sd          a0, lrsc_size_slot(s11) # save size (4 bytes)
+ *      ld          a0, a0_slot(s11)        # restore scratch register
  *      bne         a5, a4, 1f
  *
  * <block 2>
  * 1:
- *      sd          a0, a0_slot(t3)         # save scratch register 1
- *      sd          a4, a4_slot(t3)         # save scratch register 2
- *      ld          a0, lrsc_addr_slot(t3)  # load saved address
+ *      sd          a0, a0_slot(s11)        # save scratch register 1
+ *      sd          a4, a4_slot(s11)        # save scratch register 2
+ *      ld          a0, lrsc_addr_slot(s11) # load saved address
  *      bne         a0, a3, fail            # check address
- *      ld          a0, lrsc_size_slot(t3)  # load saved size
+ *      ld          a0, lrsc_size_slot(s11) # load saved size
  *      li          a4, 4
  *      bne         a0, a4, fail            # check size
- *      ld          a0, lrsc_val_slot(t3)   # load saved value
+ *      ld          a0, lrsc_val_slot(s11)  # load saved value
  * loop:
  *      lr.w.aqrl   a4, (a3)                # begin of the CAS sequence
  *      bne         a0, a4, final
@@ -970,9 +970,9 @@ mangle_exclusive_store(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
  *      li          a1, 1                   # sets non-zero value to dst on failure
  * final:
  *      li          a0, -1
- *      sd          a0, lrsc_addr_slot(t3)  # invalidate reservation
- *      ld          a0, a0_slot(t3)         # restore scratch register 1
- *      ld          a4, a4_slot(t3)         # restore scratch register 2
+ *      sd          a0, lrsc_addr_slot(s11) # invalidate reservation
+ *      ld          a0, a0_slot(s11)        # restore scratch register 1
+ *      ld          a4, a4_slot(s11)        # restore scratch register 2
  *      bnez        a1, 1b
  */
 instr_t *

--- a/core/ir/riscv64/instr.c
+++ b/core/ir/riscv64/instr.c
@@ -277,7 +277,7 @@ instr_is_mov_constant(instr_t *instr, ptr_int_t *value)
     uint opc = instr_get_opcode(instr);
 
     if (opc == OP_addi || opc == OP_addiw || opc == OP_c_addi || opc == OP_c_addiw ||
-        opc == OP_c_addi4spn || opc == OP_c_addi16sp) {
+        opc == OP_c_addi4spn || opc == OP_c_addi16sp || opc == OP_c_li) {
         opnd_t op1 = instr_get_src(instr, 0);
         opnd_t op2 = instr_get_src(instr, 1);
         if (opnd_is_reg(op1) && opnd_get_reg(op1) == DR_REG_X0) {
@@ -455,6 +455,8 @@ bool
 instr_is_nop(instr_t *instr)
 {
     uint opc = instr_get_opcode(instr);
+    if (opc == OP_c_nop)
+        return true;
     if (instr_num_srcs(instr) < 2 || instr_num_dsts(instr) < 1)
         return false;
     opnd_t rd = instr_get_dst(instr, 0);

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6504,19 +6504,22 @@ dr_get_mcontext_priv(dcontext_t *dcontext, dr_mcontext_t *dmc, priv_mcontext_t *
     else if (TEST(DR_MC_CONTROL, dmc->flags))
         dmc->xsp = get_mcontext(dcontext)->xsp;
 
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
     if (mc != NULL || TEST(DR_MC_INTEGER, dmc->flags)) {
         /* get the stolen register's app value */
         if (mc != NULL) {
             set_stolen_reg_val(mc,
                                (reg_t)d_r_get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
+#    ifdef RISCV64
+            set_tp_reg_val(mc, (reg_t)os_get_app_tls_base(dcontext, TLS_REG_LIB));
+#    endif
         } else {
             set_stolen_reg_val(dr_mcontext_as_priv_mcontext(dmc),
                                (reg_t)d_r_get_tls(os_tls_offset(TLS_REG_STOLEN_SLOT)));
+            set_tp_reg_val(dr_mcontext_as_priv_mcontext(dmc),
+                           (reg_t)os_get_app_tls_base(dcontext, TLS_REG_LIB));
         }
     }
-#elif defined(RISCV64)
-    ASSERT_NOT_IMPLEMENTED(false);
 #endif
 
     /* XXX: should we set the pc field?
@@ -6539,7 +6542,8 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
 {
     priv_mcontext_t *state;
     dcontext_t *dcontext = (dcontext_t *)drcontext;
-    IF_AARCHXX(reg_t reg_val = 0 /* silence the compiler warning */;)
+    IF_AARCHXX_OR_RISCV64(reg_t stolen_reg_val = 0 /* silence the compiler warning */;)
+    IF_RISCV64(reg_t tp_reg_val = 0;)
     CLIENT_ASSERT(!TEST(SELFPROT_DCONTEXT, DYNAMO_OPTION(protect_mask)),
                   "DR context protection NYI");
     CLIENT_ASSERT(context != NULL, "invalid context");
@@ -6570,7 +6574,7 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
      * will override any save_fpstate xmm values, as desired.
      */
     state = get_priv_mcontext_from_dstack(dcontext);
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
     if (TEST(DR_MC_INTEGER, context->flags)) {
         /* Set the stolen register's app value in TLS, not on stack (we rely
          * on our stolen reg retaining its value on the stack)
@@ -6578,20 +6582,20 @@ dr_set_mcontext(void *drcontext, dr_mcontext_t *context)
         priv_mcontext_t *mc = dr_mcontext_as_priv_mcontext(context);
         d_r_set_tls(os_tls_offset(TLS_REG_STOLEN_SLOT), (void *)get_stolen_reg_val(mc));
         /* save the reg val on the stack to be clobbered by the the copy below */
-        reg_val = get_stolen_reg_val(state);
+        stolen_reg_val = get_stolen_reg_val(state);
+#    ifdef RISCV64
+        tp_reg_val = get_tp_reg_val(state);
+#    endif
     }
-#elif defined(RISCV64)
-    CLIENT_ASSERT(false, "NYI on RISCV64");
 #endif
     if (!dr_mcontext_to_priv_mcontext(state, context))
         return false;
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
     if (TEST(DR_MC_INTEGER, context->flags)) {
         /* restore the reg val on the stack clobbered by the copy above */
-        set_stolen_reg_val(state, reg_val);
+        set_stolen_reg_val(state, stolen_reg_val);
+        set_tp_reg_val(state, tp_reg_val);
     }
-#elif defined(RISCV64)
-    CLIENT_ASSERT(false, "NYI on RISCV64");
 #endif
 
     if (TEST(DR_MC_CONTROL, context->flags)) {
@@ -7400,7 +7404,7 @@ dr_insert_set_stolen_reg_value(void *drcontext, instrlist_t *ilist, instr_t *ins
                   "dr_insert_set_stolen_reg: reg has wrong size\n");
     CLIENT_ASSERT(!reg_is_stolen(reg),
                   "dr_insert_set_stolen_reg: reg is used by DynamoRIO\n");
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
     instrlist_meta_preinsert(
         ilist, instr, instr_create_save_to_tls(drcontext, reg, TLS_REG_STOLEN_SLOT));
 #endif

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -645,7 +645,7 @@ OPTION_DEFAULT_INTERNAL(bool, ldstex2cas, true,
 #endif
 #ifdef RISCV64
 /* We only allow register between x18 and x31 to be used. */
-OPTION_DEFAULT_INTERNAL(uint, steal_reg, 28, "The register stolen/used by DynamoRIO")
+OPTION_DEFAULT_INTERNAL(uint, steal_reg, 27, "The register stolen/used by DynamoRIO")
 #endif
 #ifdef WINDOWS_PC_SAMPLE
 OPTION_DEFAULT(uint, prof_pcs_DR, 2,

--- a/core/synch.c
+++ b/core/synch.c
@@ -1805,12 +1805,14 @@ translate_from_synchall_to_dispatch(thread_record_t *tr, thread_synch_state_t sy
          * But the stolen reg was restored to the application value during
          * translate_mcontext.
          */
-#ifdef AARCHXX
+#if defined(AARCHXX) || defined(RISCV64)
         /* Preserve the translated value from mc before we clobber it. */
         dcontext->local_state->spill_space.reg_stolen = get_stolen_reg_val(mc);
         set_stolen_reg_val(mc, (reg_t)os_get_dr_tls_base(dcontext));
-#elif defined(RISCV64)
-        ASSERT_NOT_IMPLEMENTED(false);
+#    ifdef RISCV64
+        os_set_app_tls_base(dcontext, TLS_REG_LIB, (void *)get_tp_reg_val(mc));
+        set_tp_reg_val(mc, (reg_t)os_get_app_tls_base(dcontext, TLS_REG_LIB));
+#    endif
 #endif
 
 #ifdef WINDOWS

--- a/core/translate.c
+++ b/core/translate.c
@@ -1219,6 +1219,11 @@ restore_stolen_register(dcontext_t *dcontext, priv_mcontext_t *mcontext)
     LOG(THREAD_GET, LOG_INTERP, 2, "\trestoring stolen register to " PFX "\n",
         dcontext->local_state->spill_space.reg_stolen);
     set_stolen_reg_val(mcontext, dcontext->local_state->spill_space.reg_stolen);
+#    ifdef RISCV64
+    LOG(THREAD_GET, LOG_INTERP, 2, "\trestoring tp register to " PFX "\n",
+        os_get_app_tls_base(dcontext, TLS_REG_LIB));
+    set_tp_reg_val(mcontext, (reg_t)os_get_app_tls_base(dcontext, TLS_REG_LIB));
+#    endif
 #endif
 }
 

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1770,7 +1770,7 @@ os_timeout(int time_in_milliseconds)
             IF_NOT_HAVE_TLS(ASSERT_NOT_REACHED());                              \
             ASSERT(sizeof(var) == sizeof(void *));                              \
             __asm__ __volatile__("ld t0, %0(tp) \n\t"                           \
-                                 "add t0, t0, %2\n\t"                           \
+                                 "add t0, t0, %2 \n\t"                          \
                                  "sd %1, 0(t0) \n\t"                            \
                                  :                                              \
                                  : "i"(DR_TLS_BASE_OFFSET), "r"(var), "r"(offs) \
@@ -1781,9 +1781,9 @@ os_timeout(int time_in_milliseconds)
             IF_NOT_HAVE_TLS(ASSERT_NOT_REACHED());                      \
             ASSERT(sizeof(var) == sizeof(void *));                      \
             __asm__ __volatile__("ld %0, %1(tp) \n\t"                   \
-                                 "add %0, %0, %2\n\t"                   \
+                                 "add %0, %0, %2 \n\t"                  \
                                  "ld %0, 0(%0) \n\t"                    \
-                                 : "=r"(var)                            \
+                                 : "+r"(var)                           \
                                  : "i"(DR_TLS_BASE_OFFSET), "r"(offs)); \
         } while (0)
 #endif /* X86/ARM/RISCV64 */
@@ -2092,7 +2092,7 @@ os_get_app_tls_reg_offset(reg_id_t reg)
 void *
 d_r_get_tls(ushort tls_offs)
 {
-    void *val;
+    void *val = 0;
     READ_TLS_SLOT(tls_offs, val);
     return val;
 }

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -247,6 +247,11 @@ os_get_app_tls_reg_offset(reg_id_t seg);
 void *
 os_get_app_tls_base(dcontext_t *dcontext, reg_id_t seg);
 
+#if defined(AARCHXX) || defined(RISCV64)
+bool
+os_set_app_tls_base(dcontext_t *dcontext, reg_id_t reg, void *base);
+#endif
+
 #ifdef DEBUG
 void
 os_enter_dynamorio(void);

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -224,11 +224,6 @@ os_get_priv_tls_base(dcontext_t *dcontext, reg_id_t seg);
 void
 os_tls_thread_exit(local_state_t *local_state);
 
-#if defined(AARCHXX) || defined(RISCV64)
-bool
-os_set_app_tls_base(dcontext_t *dcontext, reg_id_t reg, void *base);
-#endif
-
 #ifdef MACOS
 /* xref i#1404: we should expose these via the dr_get_os_version() API */
 #    define MACOS_VERSION_MOJAVE 18

--- a/core/unix/os_public.h
+++ b/core/unix/os_public.h
@@ -215,6 +215,7 @@ typedef kernel_sigcontext_t sigcontext_t;
 #    define SC_A6 SC_FIELD(sc_regs.a6)
 #    define SC_A7 SC_FIELD(sc_regs.a7)
 #    define SC_FP SC_FIELD(sc_regs.s0)
+#    define SC_S11 SC_FIELD(sc_regs.s11)
 #    define SC_RA SC_FIELD(sc_regs.ra)
 #    define SC_XIP SC_FIELD(sc_regs.pc)
 #    define SC_XSP SC_FIELD(sc_regs.sp)

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -4088,6 +4088,8 @@ transfer_from_sig_handler_to_fcache_return(dcontext_t *dcontext, kernel_ucontext
     /* Now put DR's base in the sigcontext. */
     set_sigcxt_stolen_reg(sc, (reg_t)*get_dr_tls_base_addr());
 #    ifdef RISCV64
+    os_set_app_tls_base(dcontext, TLS_REG_LIB, (void *)get_sigcxt_tp_reg(sc));
+    /* Now put host tp in the sigcontext. */
     set_sigcxt_tp_reg(sc, (reg_t)read_thread_register(TLS_REG_LIB));
 #    endif
 
@@ -4661,6 +4663,12 @@ adjust_syscall_for_restart(dcontext_t *dcontext, thread_sig_info_t *info, int si
      * a custom translation.
      */
     set_sigcxt_stolen_reg(sc, dcontext->local_state->spill_space.reg_stolen);
+#    ifdef RISCV64
+    /* Same for the tp register on RISC-V, here we need to put app's tp reg value
+     * into the ucontext.
+     */
+    set_sigcxt_tp_reg(sc, (reg_t)os_get_app_tls_base(dcontext, TLS_REG_LIB));
+#    endif
 #endif
     LOG(THREAD, LOG_ASYNCH, 2, "%s: sigreturn pc is now " PFX "\n", __FUNCTION__,
         sc->SC_XIP);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3200,10 +3200,12 @@ if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
   set(DynamoRIO_SET_PREFERRED_BASE OFF)
 endif (X86)
 
-if (AARCHXX)
+if (AARCHXX OR RISCV64)
   tobuild_ci(client.stolen-reg client-interface/stolen-reg.c "" "" "")
   link_with_pthread(client.stolen-reg)
+endif ()
 
+if (AARCHXX)
   tobuild_ci(client.ldstex client-interface/ldstex.c "" "" "")
   link_with_pthread(client.ldstex)
 endif ()
@@ -6150,42 +6152,27 @@ if (RISCV64)
     code_api|api.ir
     code_api|api.ir-static
     code_api|client.app_args
-    code_api|client.app_args
-    code_api|client.blackbox
+    code_api|client.stolen-reg
     code_api|client.blackbox
     code_api|client.crashmsg
-    code_api|client.crashmsg
-    code_api|client.execfault
     code_api|client.execfault
     code_api|client.mangle_suspend
-    code_api|client.mangle_suspend
-    code_api|client.null_instrument
     code_api|client.null_instrument
     code_api|client.option_parse
-    code_api|client.option_parse
     code_api|client.partial_module_map
-    code_api|client.partial_module_map
-    code_api|client.stack-overflow
     code_api|client.stack-overflow
     code_api|client.truncate
     code_api|client.unregister
     code_api|common.broadfun
     code_api|common.hello
     code_api|libutil.drconfig_test
-    code_api|libutil.drconfig_test
-    code_api|libutil.frontend_test
     code_api|libutil.frontend_test
     code_api|linux.exit
-    code_api|linux.exit
-    code_api|linux.infinite
     code_api|linux.infinite
     code_api|linux.longjmp
-    code_api|linux.longjmp
-    code_api|linux.prctl
     code_api|linux.prctl
     code_api|linux.signalfd
     code_api|pthreads.pthreads
-    code_api|pthreads.pthreads_exit
     code_api|pthreads.pthreads_exit
     code_api|sample.bbbuf
     code_api|sample.bbcount
@@ -6199,10 +6186,7 @@ if (RISCV64)
     code_api|sample.opcode_count
     code_api|sample.signal
     code_api|sample.stl_test
-    code_api|sample.stl_test
     code_api|sample.syscall
-    code_api|sample.syscall
-    code_api|security-linux.trampoline
     code_api|security-linux.trampoline
     code_api|tool.drcachesim.missfile-config-file
     code_api|tool.drcachesim.syscall-mix

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4272,7 +4272,7 @@ if (BUILD_CLIENTS)
     if (DR_HOST_X86 AND DR_HOST_X64 AND LINUX)
       torunonly_drcacheoff(opcode_categories allasm_x86_64 ""
         "@-simulator_type@opcode_mix" "")
-    
+
       # Requires sudo to access pagemap.
       # XXX: Should we not enable this outside of the Github suite where we know
       # we have passwordless sudo?  The pause for a password may cause problems
@@ -6152,7 +6152,6 @@ if (RISCV64)
     code_api|api.ir
     code_api|api.ir-static
     code_api|client.app_args
-    code_api|client.stolen-reg
     code_api|client.blackbox
     code_api|client.crashmsg
     code_api|client.execfault

--- a/suite/tests/api/ir_riscv64.c
+++ b/suite/tests/api/ir_riscv64.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023 Institue of Software Chinese Academy of Sciences (ISCAS).
+ * Copyright (c) 2024 Institute of Software Chinese Academy of Sciences (ISCAS).
  * All rights reserved.
  * **********************************************************/
 

--- a/suite/tests/client-interface/stolen-reg.c
+++ b/suite/tests/client-interface/stolen-reg.c
@@ -45,6 +45,10 @@
 
 #define STOLEN_REG_SENTINEL 42
 
+/* RISC-V ADDI instruction can only move up to 12-bit sign-extended immediate values into
+ * a register. To simplify things, we set the bad value to 0x123. */
+#define BAD_VALUE 0x123
+
 /* We assume a single thread when these are used. */
 static SIGJMP_BUF mark;
 static int sigsegv_count;
@@ -60,6 +64,8 @@ get_stolen_reg_val(void)
     __asm__ __volatile__("str x28, %0\n\t" : "=m"(val) : :);
 #elif defined(ARM)
     __asm__ __volatile__("str r10, %0\n\t" : "=m"(val) : :);
+#elif defined(RISCV64)
+    __asm__ __volatile__("mv %0, s11\n\t" : "=r"(val) : :);
 #else
 #    error Unsupported arch
 #endif
@@ -73,6 +79,9 @@ get_stolen_reg_val(void)
 #elif defined(ARM)
 #    define SET_STOLEN_REG_TO_SENTINEL() \
         __asm__ __volatile__("mov r10, #" STRINGIFY(STOLEN_REG_SENTINEL) : : : "r10")
+#elif defined(RISCV64)
+#    define SET_STOLEN_REG_TO_SENTINEL() \
+        __asm__ __volatile__("li s11, " STRINGIFY(STOLEN_REG_SENTINEL) : : : "s11")
 #else
 #    error Unsupported arch
 #endif
@@ -89,13 +98,20 @@ signal_handler(int sig, siginfo_t *siginfo, ucontext_t *ucxt)
               STOLEN_REG_SENTINEL, val);
     }
     sigcontext_t *sc = SIGCXT_FROM_UCXT(ucxt);
-    if (sc->IF_ARM_ELSE(SC_R10, SC_R28) != STOLEN_REG_SENTINEL) {
+    if (sc->IF_ARM_ELSE(SC_R10, IF_AARCH64_ELSE(SC_R28, SC_S11)) != STOLEN_REG_SENTINEL) {
         print("ERROR: Stolen register %d not preserved in signal context: %d\n",
-              STOLEN_REG_SENTINEL, sc->IF_ARM_ELSE(SC_R10, SC_R28));
+              STOLEN_REG_SENTINEL,
+              sc->IF_ARM_ELSE(SC_R10, IF_AARCH64_ELSE(SC_R28, SC_S11)));
     }
     if (sigsegv_count == 0) {
         /* Allow re-execution to no longer fault. */
+#if defined(AARCHXX)
         sc->SC_R0 = sc->SC_XSP;
+#elif defined(RISCV64)
+        sc->SC_A0 = sc->SC_XSP;
+#else
+#    error Unsupported arch
+#endif
     } else {
         SIGLONGJMP(mark, 1);
     }
@@ -124,6 +140,14 @@ cause_sigsegv(void)
                          : "=m"(val)
                          :
                          : "r0", "r1", "r10");
+#elif defined(RISCV64)
+    __asm__ __volatile__("li s11, " STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                   "li a0, 0\n\t"
+                                                                   "ld a1, (a0)\n\t"
+                                                                   "mv %0, s11\n\t"
+                         : "=r"(val)
+                         :
+                         : "a0", "a1", "s11");
 #else
 #    error Unsupported arch
 #endif
@@ -154,6 +178,13 @@ thread_func(void *arg)
                          :
                          :
                          : "r10");
+#elif defined(RISCV64)
+    __asm__ __volatile__("li s11, " STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                   "nop\n\t"
+                                                                   "nop\n\t"
+                         :
+                         :
+                         : "s11");
 #else
 #    error Unsupported arch
 #endif
@@ -207,6 +238,14 @@ main(int argc, char **argv)
                          :
                          :
                          : "r0", "r10");
+#elif defined(RISCV64)
+    __asm__ __volatile__("li s11, " STRINGIFY(STOLEN_REG_SENTINEL) "\n\t"
+                                                                   "li a0, 0\n\t"
+                                                                   "nop\n\t"
+                         :
+                         :
+                         : "a0", "s11");
+
 #else
 #    error Unsupported arch
 #endif
@@ -231,9 +270,11 @@ main(int argc, char **argv)
 
     // Checking for this sequence in stolen-reg.dll.c
 #if defined(AARCH64)
-    __asm__ __volatile__("mov x28, #0xdead" : : : "x28");
+    __asm__ __volatile__("mov x28, #" STRINGIFY(BAD_VALUE) : : : "x28");
 #elif defined(ARM)
-    __asm__ __volatile__("movw r10, #0xdead" : : : "r10");
+    __asm__ __volatile__("movw r10, #" STRINGIFY(BAD_VALUE) : : : "r10");
+#elif defined(RISCV64)
+    __asm__ __volatile__("li s11, " STRINGIFY(BAD_VALUE) : : : "s11");
 #else
 #    error Unsupported arch
 #endif

--- a/suite/tests/client-interface/stolen-reg.c
+++ b/suite/tests/client-interface/stolen-reg.c
@@ -262,11 +262,13 @@ main(int argc, char **argv)
 
     join_thread(thread);
 
+#ifndef RISCV64
     val = get_stolen_reg_val();
     if (val != STOLEN_REG_SENTINEL) {
         print("ERROR: Stolen register %d not preserved past synchall: %d\n",
               STOLEN_REG_SENTINEL, val);
     }
+#endif
 
     // Checking for this sequence in stolen-reg.dll.c
 #if defined(AARCH64)

--- a/suite/tests/client-interface/stolen-reg.dll.c
+++ b/suite/tests/client-interface/stolen-reg.dll.c
@@ -60,6 +60,9 @@ static void
 do_flush(app_pc next_pc)
 {
     dr_fprintf(STDERR, "Performing synchall flush\n");
+
+    /* FIXME i#3544: synchall translation path does not work with RISC-V yet. */
+#ifndef RISCV64
     if (!dr_flush_region(NULL, ~0UL))
         DR_ASSERT(false);
     void *drcontext = dr_get_current_drcontext();
@@ -70,6 +73,7 @@ do_flush(app_pc next_pc)
     mcontext.pc = dr_app_pc_as_jump_target(dr_get_isa_mode(drcontext), next_pc);
     dr_redirect_execution(&mcontext);
     DR_ASSERT(false);
+#endif
 }
 
 // Storing the original stolen reg before mconext set.

--- a/suite/tests/client-interface/stolen-reg.dll.c
+++ b/suite/tests/client-interface/stolen-reg.dll.c
@@ -37,7 +37,8 @@
 #include "dr_api.h"
 #include "client_tools.h"
 
-#define BAD_VALUE 0xdeadbeef
+/* See stolen-reg.c for the same definition. */
+#define BAD_VALUE 0x123
 
 /* We assume the app is single-threaded and don't worry about races. */
 static ptr_int_t app_stolen_reg_val;
@@ -51,8 +52,8 @@ restore_event(void *drcontext, void *tag, dr_mcontext_t *mcontext, bool restore_
      * restore event for simplicity.
      */
     dr_log(drcontext, DR_LOG_ALL, 2, "Changing the stolen reg value from %ld to %ld\n",
-           mcontext->IF_ARM_ELSE(r10, r28), app_stolen_reg_val);
-    mcontext->IF_ARM_ELSE(r10, r28) = app_stolen_reg_val;
+           mcontext->IF_ARM_ELSE(r10, IF_AARCH64_ELSE(r28, s11)), app_stolen_reg_val);
+    mcontext->IF_ARM_ELSE(r10, IF_AARCH64_ELSE(r28, s11)) = app_stolen_reg_val;
 }
 
 static void
@@ -94,11 +95,11 @@ read_and_restore_stolen_reg_value()
     dr_get_mcontext(drcontext, &mc);
 
     /* The key part of the test: that the modified value shows up here. */
-    DR_ASSERT(mc.IF_ARM_ELSE(r10, r28) == test_value);
+    DR_ASSERT(mc.IF_ARM_ELSE(r10, IF_AARCH64_ELSE(r28, s11)) == test_value);
     dr_fprintf(STDERR, "mc->stolen_reg after = " IF_ARM_ELSE("%d", "%ld") "\n",
-               mc.IF_ARM_ELSE(r10, r28));
+               mc.IF_ARM_ELSE(r10, IF_AARCH64_ELSE(r28, s11)));
 
-    mc.IF_ARM_ELSE(r10, r28) = orig_value;
+    mc.IF_ARM_ELSE(r10, IF_AARCH64_ELSE(r28, s11)) = orig_value;
 
     dr_set_mcontext(drcontext, &mc);
 }
@@ -119,9 +120,9 @@ change_stolen_reg_value()
     mc.flags = DR_MC_ALL;
     dr_get_mcontext(drcontext, &mc);
 
-    orig_value = mc.IF_ARM_ELSE(r10, r28);
+    orig_value = mc.IF_ARM_ELSE(r10, IF_AARCH64_ELSE(r28, s11));
 
-    mc.IF_ARM_ELSE(r10, r28) = test_value;
+    mc.IF_ARM_ELSE(r10, IF_AARCH64_ELSE(r28, s11)) = test_value;
 
     dr_set_mcontext(drcontext, &mc);
 }
@@ -136,8 +137,11 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
             next_next_instr = instr_get_next(next_instr);
         else
             next_next_instr = NULL;
-        /* Look for the sentinel-SIGSEGV sequence from the app.
-         * Look for "mov <stolen-reg>, <const>; mov r0, <const>; ldr rx, [r0].
+        /* Look for the sentinel-SIGSEGV sequence from the app:
+         *  for ARM/AArch64, look for
+         *    "mov <stolen-reg>, <const>; mov r0, <const>; ldr rx,[r0].
+         *  for RISC-V, look for
+         *    "addi <stolen-reg>, zero, <const>; addi a0, zero, <const>; ld reg, (a0).
          */
         ptr_int_t stolen_val, substitute_val;
         if (instr_is_mov_constant(instr, &stolen_val) &&
@@ -145,34 +149,41 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
             opnd_get_reg(instr_get_dst(instr, 0)) == dr_get_stolen_reg() &&
             next_instr != NULL && instr_is_mov_constant(next_instr, &substitute_val) &&
             substitute_val != stolen_val && opnd_is_reg(instr_get_dst(next_instr, 0)) &&
-            opnd_get_reg(instr_get_dst(next_instr, 0)) == DR_REG_R0 &&
+            opnd_get_reg(instr_get_dst(next_instr, 0)) ==
+                IF_AARCHXX_ELSE(DR_REG_R0, DR_REG_A0) &&
             next_next_instr != NULL && instr_reads_memory(next_next_instr) &&
             opnd_is_base_disp(instr_get_src(next_next_instr, 0)) &&
-            opnd_get_base(instr_get_src(next_next_instr, 0)) == DR_REG_R0) {
+            opnd_get_base(instr_get_src(next_next_instr, 0)) ==
+                IF_AARCHXX_ELSE(DR_REG_R0, DR_REG_A0)) {
             /* Now change the stolen reg value to be r0's value, before the crash. */
             dr_log(drcontext, DR_LOG_ALL, 2, "Setting stolen reg val in block %p\n", tag);
             app_stolen_reg_val = stolen_val;
-            dr_insert_set_stolen_reg_value(drcontext, bb, next_next_instr, DR_REG_R0);
+            dr_insert_set_stolen_reg_value(drcontext, bb, next_next_instr,
+                                           IF_AARCHXX_ELSE(DR_REG_R0, DR_REG_A0));
             break;
         }
-        /* Look for the sentinel-nop sequence prior to 2nd thread creation.
-         * Look for "mov <stolen-reg>, <const>; mov r0, <const>; nop.
+        /* Look for the sentinel-nop sequence prior to 2nd thread creation:
+         *  for ARM/AArch64, look for "mov <stolen-reg>, <const>; mov r0, <const>; nop.
+         *  for RISC-V, look for "addi <stolen-reg>, zero, <const>; addi a0, zero, 0; nop.
          */
         if (instr_is_mov_constant(instr, &stolen_val) &&
             opnd_is_reg(instr_get_dst(instr, 0)) &&
             opnd_get_reg(instr_get_dst(instr, 0)) == dr_get_stolen_reg() &&
             next_instr != NULL && instr_is_mov_constant(next_instr, &substitute_val) &&
             substitute_val != stolen_val && opnd_is_reg(instr_get_dst(next_instr, 0)) &&
-            opnd_get_reg(instr_get_dst(next_instr, 0)) == DR_REG_R0 &&
+            opnd_get_reg(instr_get_dst(next_instr, 0)) ==
+                IF_AARCHXX_ELSE(DR_REG_R0, DR_REG_A0) &&
             next_next_instr != NULL && instr_is_nop(next_next_instr)) {
             /* Change the stolen reg value. */
             dr_log(drcontext, DR_LOG_ALL, 2, "Setting stolen reg val in block %p\n", tag);
             app_stolen_reg_val = stolen_val;
-            dr_insert_set_stolen_reg_value(drcontext, bb, next_next_instr, DR_REG_R0);
+            dr_insert_set_stolen_reg_value(drcontext, bb, next_next_instr,
+                                           IF_AARCHXX_ELSE(DR_REG_R0, DR_REG_A0));
             break;
         }
-        /* Look for the sentinel-nop sequence from the app's 2nd thread.
-         * Look for "mov <stolen-reg>, <const>; nop; nop.
+        /* Look for the sentinel-nop sequence from the app's 2nd thread:
+         *  for ARM/AArch64, look for "mov <stolen-reg>, <const>; nop; nop.
+         *  for RISC-V, look for "addi <stolen-reg>, zero, <const>; nop; nop.
          */
         if (instr_is_mov_constant(instr, &stolen_val) &&
             opnd_is_reg(instr_get_dst(instr, 0)) &&
@@ -186,11 +197,13 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
             break;
         }
 
-        // Look for mov <stolen-reg>, #0xdead.
+        /* For ARM/AArch64, look for "mov <stolen-reg>, #BAD_VALUE;
+         * for RISC-V, look for "addi <stolen-reg>, zero, #BAD_VALUE.
+         */
         ptr_int_t imm1 = 0;
         if (instr_is_mov_constant(instr, &imm1) && opnd_is_reg(instr_get_dst(instr, 0)) &&
             opnd_get_reg(instr_get_dst(instr, 0)) == dr_get_stolen_reg() &&
-            imm1 == 0xdead) {
+            imm1 == BAD_VALUE) {
             dr_insert_clean_call_ex(
                 drcontext, bb, instr, (void *)change_stolen_reg_value,
                 DR_CLEANCALL_READS_APP_CONTEXT | DR_CLEANCALL_WRITES_APP_CONTEXT, 0);
@@ -208,7 +221,8 @@ void
 dr_init(client_id_t id)
 {
     // Stop test failing silently if we ever change the stolen reg value.
-    if (dr_get_stolen_reg() != IF_ARM_ELSE(DR_REG_R10, DR_REG_R28)) {
+    if (dr_get_stolen_reg() !=
+        IF_ARM_ELSE(DR_REG_R10, IF_AARCH64_ELSE(DR_REG_R28, DR_REG_S11))) {
         dr_fprintf(STDERR,
                    "ERROR: stolen reg value has changed, this test needs to be updated");
         DR_ASSERT(false);


### PR DESCRIPTION
Partially enables stolen-reg test for RISC-V, with the synchall translation path unsupported. The following modifications/fixes were made:

1. Changed the default stolen-reg from `t3` to `s11` to be a callee-saved register;
2. Ported stolen-reg.c and stolen-reg.dll.c to support RISC-V;
3. Fixed `instr_is_mov_constant()` and `instr_is_nop()` for the pattern matching in `stolen-reg.dll.c` to work;
4. Fixed `READ_TLS_SLOT()` macro register allocation issue;
5. Added more necessary loads/restores for tp register alongside stolen register;
6. Removed duplicated tests in RUNS_ON_QEMU label;

With this patch, the stolen-reg test is now working on real hardware (without the synchall translation path), but like many other tests related to signals, it does not work on QEMU.