### PR TITLE
i#3320 dr$sim bundle error: Mark multiproc test as ignore

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -357,6 +357,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api|tool.drcachesim.threads-with-config-file' => 1,  # i#3320
                                    'code_api|tool.drcachesim.coherence' => 1, # i#3320
                                    'code_api|tool.drcachesim.miss_analyzer' => 1, # i#3320
+                                   'code_api|tool.drcachesim.multiproc' => 1, # i#3320
                                    'code_api|tool.drcacheoff.burst_threads' => 1,
                                    'code_api|tool.drcacheoff.burst_threads_counts' => 1,
                                    'code_api|tool.drcacheoff.burst_threadL0filter' => 1,


### PR DESCRIPTION
The code_api|tool.drcachesim.multiproc test has failed several times in release build on the sve runner post-merge.  Despite attempts to figure out or theorize as to what is causing the failure, it remains a mystery.  For now we add multiproc to the list of failures to ignore.

Issue: #3320