### PR TITLE
i#6744: Use xrstors32 and xsaves32 for invariant checker test on x86-32.

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3272,12 +3272,14 @@ check_kernel_syscall_trace(void)
         instr_t *sti = INSTR_CREATE_sti(GLOBAL_DCONTEXT);
         instr_t *nop1 = XINST_CREATE_nop(GLOBAL_DCONTEXT);
         instr_t *nop2 = XINST_CREATE_nop(GLOBAL_DCONTEXT);
+#        if defined(X64)
         instr_t *xrstors = INSTR_CREATE_xrstors64(
             GLOBAL_DCONTEXT,
             opnd_create_base_disp(DR_REG_XCX, DR_REG_NULL, 0, 0, OPSZ_xsave));
         instr_t *xsaves = INSTR_CREATE_xsaves64(
             GLOBAL_DCONTEXT,
             opnd_create_base_disp(DR_REG_XCX, DR_REG_NULL, 0, 0, OPSZ_xsave));
+#        endif
         instr_t *hlt = INSTR_CREATE_hlt(GLOBAL_DCONTEXT);
         instr_t *nop3 = XINST_CREATE_nop(GLOBAL_DCONTEXT);
         instr_t *prefetch = INSTR_CREATE_prefetchnta(
@@ -3295,8 +3297,10 @@ check_kernel_syscall_trace(void)
         instrlist_append(ilist2, sti);
         instrlist_append(ilist2, nop1);
         instrlist_append(ilist2, nop2);
+#        if defined(X64)
         instrlist_append(ilist2, xrstors);
         instrlist_append(ilist2, xsaves);
+#        endif
         instrlist_append(ilist2, hlt);
         instrlist_append(ilist2, nop3);
         instrlist_append(ilist2, prefetch);
@@ -3328,6 +3332,7 @@ check_kernel_syscall_trace(void)
                 { gen_instr(TID_A), sti },
                 { gen_instr(TID_A), nop1 },
                 // Missing nop2. Acceptable because of the recent sti.
+#        if defined(X64)
                 { gen_instr(TID_A), xrstors },
                 // Multiple reads. Acceptable because of the prior xrstors.
                 { gen_data(TID_A, true, 42, 8), nullptr },
@@ -3340,6 +3345,7 @@ check_kernel_syscall_trace(void)
                 { gen_data(TID_A, false, 42, 8), nullptr },
                 { gen_data(TID_A, false, 42, 8), nullptr },
                 { gen_data(TID_A, false, 42, 8), nullptr },
+#        endif
                 { gen_instr(TID_A), hlt },
                 // Missing nop3. Acceptable because of the prior hlt.
                 { gen_instr(TID_A), prefetch },

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3331,7 +3331,7 @@ check_kernel_syscall_trace(void)
                 { gen_data(TID_A, true, 42, 8), nullptr },
                 { gen_instr(TID_A), sti },
                 { gen_instr(TID_A), nop1 },
-                // Missing nop2. Acceptable because of the recent sti.
+            // Missing nop2. Acceptable because of the recent sti.
 #        if defined(X64)
                 { gen_instr(TID_A), xrstors },
                 // Multiple reads. Acceptable because of the prior xrstors.

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3279,6 +3279,13 @@ check_kernel_syscall_trace(void)
         instr_t *xsaves = INSTR_CREATE_xsaves64(
             GLOBAL_DCONTEXT,
             opnd_create_base_disp(DR_REG_XCX, DR_REG_NULL, 0, 0, OPSZ_xsave));
+#        else
+        instr_t *xrstors = INSTR_CREATE_xrstors32(
+            GLOBAL_DCONTEXT,
+            opnd_create_base_disp(DR_REG_XCX, DR_REG_NULL, 0, 0, OPSZ_xsave));
+        instr_t *xsaves = INSTR_CREATE_xsaves32(
+            GLOBAL_DCONTEXT,
+            opnd_create_base_disp(DR_REG_XCX, DR_REG_NULL, 0, 0, OPSZ_xsave));
 #        endif
         instr_t *hlt = INSTR_CREATE_hlt(GLOBAL_DCONTEXT);
         instr_t *nop3 = XINST_CREATE_nop(GLOBAL_DCONTEXT);
@@ -3297,10 +3304,8 @@ check_kernel_syscall_trace(void)
         instrlist_append(ilist2, sti);
         instrlist_append(ilist2, nop1);
         instrlist_append(ilist2, nop2);
-#        if defined(X64)
         instrlist_append(ilist2, xrstors);
         instrlist_append(ilist2, xsaves);
-#        endif
         instrlist_append(ilist2, hlt);
         instrlist_append(ilist2, nop3);
         instrlist_append(ilist2, prefetch);
@@ -3331,8 +3336,7 @@ check_kernel_syscall_trace(void)
                 { gen_data(TID_A, true, 42, 8), nullptr },
                 { gen_instr(TID_A), sti },
                 { gen_instr(TID_A), nop1 },
-            // Missing nop2. Acceptable because of the recent sti.
-#        if defined(X64)
+                // Missing nop2. Acceptable because of the recent sti.
                 { gen_instr(TID_A), xrstors },
                 // Multiple reads. Acceptable because of the prior xrstors.
                 { gen_data(TID_A, true, 42, 8), nullptr },
@@ -3345,7 +3349,6 @@ check_kernel_syscall_trace(void)
                 { gen_data(TID_A, false, 42, 8), nullptr },
                 { gen_data(TID_A, false, 42, 8), nullptr },
                 { gen_data(TID_A, false, 42, 8), nullptr },
-#        endif
                 { gen_instr(TID_A), hlt },
                 // Missing nop3. Acceptable because of the prior hlt.
                 { gen_instr(TID_A), prefetch },


### PR DESCRIPTION
tool.drcachesim.invariant_checker_test  fails on x86-32 with the following error:

1/371 Test https://github.com/DynamoRIO/dynamorio/issues/11: tool.drcachesim.invariant_checker_test ...........................***Failed 0.04 sec

Recording |Too many read records| in T1 @ ref # 16 (6 instrs since timestamp 0)
Recording |Too many read records| in T1 @ ref # 17 (6 instrs since timestamp 0)
Recording |Too many read records| in T1 @ ref # 18 (6 instrs since timestamp 0)
Recording |Too many read records| in T1 @ ref # 19 (6 instrs since timestamp 0)
Recording |Too many write records| in T1 @ ref # 21 (7 instrs since timestamp 0)
Recording |Too many write records| in T1 @ ref # 22 (7 instrs since timestamp 0)
Recording |Too many write records| in T1 @ ref # 23 (7 instrs since timestamp 0)
Recording |Too many write records| in T1 @ ref # 24 (7 instrs since timestamp 0)
Unexpected error: Too many read records at ref: 16
Unexpected error: Too many read records at ref: 17
Unexpected error: Too many read records at ref: 18
Unexpected error: Too many read records at ref: 19
Unexpected error: Too many write records at ref: 21
Unexpected error: Too many write records at ref: 22
Unexpected error: Too many write records at ref: 23
Unexpected error: Too many write records at ref: 24

OP_xsaves64 and OP_xrstors32 are marked as o64 (X86_INVALID) in core/ir/x86/decode_table.c. 

instr_is_xsave() and instr_is_xrstor() return false on x86-32, hence not skipping the number of read/write record check in the invariant check on x86_32.

Use xrstors32 and xsaves32 instead for the test on x86_32.

Fixes #6744 