### PR TITLE
Fix trailing space checker to remove existing trailing spaces

### DIFF
--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -316,9 +316,12 @@ endif ()
 # to get the diff and check it.  The vera++ rules do check C/C++ code.
 
 # Check for trailing space.  This is a diff with an initial column for +-,
-# so a blank line will have one space: thus we rule that out.
+# so we need to exclude the following cases:
+# 1. existing blank line will now have one space;
+# 2. lines starting with -.
+# We do this by matching lines that start with + or a space and end with a space.
 # The clang-format check will now find these in C files, but not non-C files.
-string(REGEX MATCH "[^\n] \n" match "${diff_contents}")
+string(REGEX MATCH "^[+ ].* \n" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   # Get more context
   string(REGEX MATCH "\n[^\n]+ \n" match "${diff_contents}")

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -321,10 +321,8 @@ endif ()
 # 2. lines starting with -.
 # We do this by matching lines that start with + or a space and end with a space.
 # The clang-format check will now find these in C files, but not non-C files.
-string(REGEX MATCH "^[+ ].* \n" match "${diff_contents}")
+string(REGEX MATCH "\n[+ ][^\n]* \n" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
-  # Get more context
-  string(REGEX MATCH "\n[^\n]+ \n" match "${diff_contents}")
   message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")
 endif ()
 

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -321,6 +321,7 @@ endif ()
 # 2. lines starting with -.
 # We do this by matching lines that start with + or a space and end with a space.
 # The clang-format check will now find these in C files, but not non-C files.
+# The first line is always the diff header and can be safely skipped.
 string(REGEX MATCH "\n[+ ][^\n]* \n" match "${diff_contents}")
 if (NOT "${match}" STREQUAL "")
   message(FATAL_ERROR "ERROR: diff contains trailing spaces: ${match}")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4277,7 +4277,7 @@ if (BUILD_CLIENTS)
     if (DR_HOST_X86 AND DR_HOST_X64 AND LINUX)
       torunonly_drcacheoff(opcode_categories allasm_x86_64 ""
         "@-simulator_type@opcode_mix" "")
-    
+
       # Requires sudo to access pagemap.
       # XXX: Should we not enable this outside of the Github suite where we know
       # we have passwordless sudo?  The pause for a password may cause problems


### PR DESCRIPTION
We rely on git diff to do trailing space checks, so to remove the trailing spaces in existing lines that may have been introduced by mistake, deletion lines should be excluded during the check.

Tested with following snippets:

```cmake
cmake_minimum_required(VERSION 3.0)
project(StringRegexMatchExample)

function(match_string_with_regex input_string regex_pattern)
    string(REGEX MATCH "${regex_pattern}" match_result "${input_string}")
    if(match_result)
        message("Match")
    else()
        message("Not match")
    endif()
endfunction()

set(regex_pattern "\n[+ ][^\n]* \n")

set(input_string "diff\n hello  \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n+ \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n  \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n-hello  \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n-  \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n hello\n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n+hello\n-  \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n hello\n-  \n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\nhello\n")
match_string_with_regex("${input_string}" "${regex_pattern}")

set(input_string "diff\n\n")
match_string_with_regex("${input_string}" "${regex_pattern}")
```

Outputs:

```
Match
Match
Match
Not match
Not match
Not match
Not match
Not match
Not match
Not match
Not match
```