### PR TITLE
i#6751 trace_entry_t: pretty printer

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -165,6 +165,7 @@ add_exported_library(drmemtrace_opcode_mix STATIC tools/opcode_mix.cpp)
 add_exported_library(drmemtrace_syscall_mix STATIC tools/syscall_mix.cpp)
 add_exported_library(drmemtrace_view STATIC tools/view.cpp)
 add_exported_library(drmemtrace_func_view STATIC tools/func_view.cpp)
+add_exported_library(drmemtrace_record_view STATIC tools/record_view.cpp)
 add_exported_library(drmemtrace_invariant_checker STATIC tools/invariant_checker.cpp)
 add_exported_library(drmemtrace_schedule_stats STATIC tools/schedule_stats.cpp)
 
@@ -172,6 +173,7 @@ target_link_libraries(drmemtrace_invariant_checker drdecode)
 
 configure_DynamoRIO_standalone(drmemtrace_opcode_mix)
 configure_DynamoRIO_standalone(drmemtrace_view)
+configure_DynamoRIO_standalone(drmemtrace_record_view)
 configure_DynamoRIO_standalone(drmemtrace_invariant_checker)
 
 # We combine the cache and TLB simulators as they share code already.
@@ -276,8 +278,8 @@ configure_DynamoRIO_standalone(drcachesim)
 target_link_libraries(drcachesim drmemtrace_simulator drmemtrace_reuse_distance
   drmemtrace_histogram drmemtrace_reuse_time drmemtrace_basic_counts
   drmemtrace_opcode_mix drmemtrace_syscall_mix drmemtrace_view drmemtrace_func_view
-  drmemtrace_raw2trace directory_iterator drmemtrace_invariant_checker
-  drmemtrace_schedule_stats drmemtrace_record_filter)
+  drmemtrace_record_view drmemtrace_raw2trace directory_iterator
+  drmemtrace_invariant_checker drmemtrace_schedule_stats drmemtrace_record_filter)
 if (UNIX)
     target_link_libraries(drcachesim dl)
 endif ()
@@ -357,6 +359,7 @@ install_client_nonDR_header(drmemtrace simulator/cache_simulator_create.h)
 install_client_nonDR_header(drmemtrace simulator/tlb_simulator_create.h)
 install_client_nonDR_header(drmemtrace tools/view_create.h)
 install_client_nonDR_header(drmemtrace tools/func_view_create.h)
+install_client_nonDR_header(drmemtrace tools/record_view_create.h)
 # TODO i#6412: Create a separate directory for non-tracer headers so that
 # we can more cleanly separate tracer and raw2trace code.
 install_client_nonDR_header(drmemtrace tracer/raw2trace.h)
@@ -578,6 +581,7 @@ restore_nonclient_flags(drmemtrace_opcode_mix)
 restore_nonclient_flags(drmemtrace_syscall_mix)
 restore_nonclient_flags(drmemtrace_view)
 restore_nonclient_flags(drmemtrace_func_view)
+restore_nonclient_flags(drmemtrace_record_view)
 restore_nonclient_flags(drmemtrace_record_filter)
 restore_nonclient_flags(drmemtrace_analyzer)
 restore_nonclient_flags(drmemtrace_invariant_checker)
@@ -644,6 +648,7 @@ add_win32_flags(drmemtrace_opcode_mix)
 add_win32_flags(drmemtrace_syscall_mix)
 add_win32_flags(drmemtrace_view)
 add_win32_flags(drmemtrace_func_view)
+add_win32_flags(drmemtrace_record_view)
 add_win32_flags(drmemtrace_record_filter)
 add_win32_flags(drmemtrace_analyzer)
 add_win32_flags(drmemtrace_invariant_checker)
@@ -821,8 +826,9 @@ if (BUILD_TESTS)
     drmemtrace_raw2trace drmemtrace_simulator drmemtrace_reuse_distance
     drmemtrace_histogram drmemtrace_reuse_time drmemtrace_basic_counts
     drmemtrace_opcode_mix drmemtrace_syscall_mix drmemtrace_view drmemtrace_func_view
-    drmemtrace_raw2trace directory_iterator drmemtrace_invariant_checker
-    drmemtrace_schedule_stats drmemtrace_analyzer drmemtrace_record_filter)
+    drmemtrace_record_view drmemtrace_raw2trace directory_iterator
+    drmemtrace_invariant_checker drmemtrace_schedule_stats drmemtrace_analyzer
+    drmemtrace_record_filter)
   if (UNIX)
     target_link_libraries(tool.drcachesim.core_sharded dl)
   endif ()

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -64,6 +64,7 @@
 #include "tools/reuse_distance_create.h"
 #include "tools/reuse_time_create.h"
 #include "tools/view_create.h"
+#include "tools/record_view_create.h"
 #include "tools/loader/external_config_file.h"
 #include "tools/loader/external_tool_creator.h"
 #include "tools/filter/record_filter_create.h"
@@ -265,6 +266,8 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator
         }
         return func_view_tool_create(funclist_file_path, op_show_func_trace.get_value(),
                                      op_verbose.get_value());
+    } else if (simulator_type == RECORD_VIEW) {
+        return record_view_tool_create();
     } else if (simulator_type == INVARIANT_CHECKER) {
         return create_invariant_checker();
     } else if (simulator_type == SCHEDULE_STATS) {

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -267,7 +267,7 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator
         return func_view_tool_create(funclist_file_path, op_show_func_trace.get_value(),
                                      op_verbose.get_value());
     } else if (simulator_type == RECORD_VIEW) {
-        return record_view_tool_create();
+        return record_view_tool_create(op_sim_refs.get_value());
     } else if (simulator_type == INVARIANT_CHECKER) {
         return create_invariant_checker();
     } else if (simulator_type == SCHEDULE_STATS) {

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -49,6 +49,7 @@
 #define SYSCALL_MIX "syscall_mix"
 #define VIEW "view"
 #define FUNC_VIEW "func_view"
+#define RECORD_VIEW "record_view"
 #define INVARIANT_CHECKER "invariant_checker"
 #define SCHEDULE_STATS "schedule_stats"
 #define RECORD_FILTER "record_filter"

--- a/clients/drcachesim/tools/record_view.cpp
+++ b/clients/drcachesim/tools/record_view.cpp
@@ -1,0 +1,147 @@
+/* **********************************************************
+ * Copyright (c) 2024 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "record_view.h"
+
+#include <inttypes.h>
+#include <stdint.h>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#ifdef HAS_ZLIB
+#    include "common/gzip_ostream.h"
+#endif
+#ifdef HAS_ZIP
+#    include "common/zipfile_ostream.h"
+#endif
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "raw2trace_shared.h"
+#include "trace_entry.h"
+#include "utils.h"
+
+#undef VPRINT
+#ifdef DEBUG
+#    define VPRINT(reader, level, ...)                            \
+        do {                                                      \
+            if ((reader)->verbosity_ >= (level)) {                \
+                fprintf(stderr, "%s ", (reader)->output_prefix_); \
+                fprintf(stderr, __VA_ARGS__);                     \
+            }                                                     \
+        } while (0)
+// clang-format off
+#    define UNUSED(x) /* nothing */
+// clang-format on
+#else
+#    define VPRINT(reader, level, ...) /* nothing */
+#    define UNUSED(x) ((void)(x))
+#endif
+
+namespace dynamorio {
+namespace drmemtrace {
+
+record_analysis_tool_t *
+record_view_tool_create(void)
+{
+    return new dynamorio::drmemtrace::record_view_t();
+}
+
+record_view_t::record_view_t()
+{
+}
+
+record_view_t::~record_view_t()
+{
+}
+
+bool
+record_view_t::parallel_shard_supported()
+{
+    return false;
+}
+
+std::string
+record_view_t::initialize_shard_type(shard_type_t shard_type)
+{
+    return "";
+}
+
+void *
+record_view_t::parallel_shard_init_stream(int shard_index, void *worker_data,
+                                          memtrace_stream_t *shard_stream)
+{
+    return shard_stream;
+}
+
+bool
+record_view_t::parallel_shard_exit(void *shard_data)
+{
+    return true;
+}
+
+std::string
+record_view_t::parallel_shard_error(void *shard_data)
+{
+    return "";
+}
+
+bool
+record_view_t::parallel_shard_memref(void *shard_data, const trace_entry_t &entry)
+{
+    const char *trace_type_name = trace_type_names[entry.type];
+    std::cerr << std::string(trace_type_name) << "\n";
+
+    return true;
+}
+
+bool
+record_view_t::process_memref(const trace_entry_t &entry)
+{
+    return parallel_shard_memref(NULL, entry);
+}
+
+bool
+record_view_t::print_results()
+{
+    return true;
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/record_view.h
+++ b/clients/drcachesim/tools/record_view.h
@@ -1,0 +1,95 @@
+/* **********************************************************
+ * Copyright (c) 2024 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#ifndef _RECORD_VIEW_H_
+#define _RECORD_VIEW_H_ 1
+
+#include <stdint.h>
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "analysis_tool.h"
+#include "archive_ostream.h"
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "raw2trace_shared.h"
+#include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+/**
+ * Analysis tool that prints #trace_entry_t records of an offline trace in human readable
+ * form.
+ */
+class record_view_t : public record_analysis_tool_t {
+public:
+    record_view_t();
+
+    ~record_view_t() override;
+
+    bool
+    process_memref(const trace_entry_t &entry) override;
+
+    bool
+    print_results() override;
+
+    bool
+    parallel_shard_supported() override;
+
+    std::string
+    initialize_shard_type(shard_type_t shard_type) override;
+
+    void *
+    parallel_shard_init_stream(int shard_index, void *worker_data,
+                               memtrace_stream_t *shard_stream) override;
+
+    bool
+    parallel_shard_exit(void *shard_data) override;
+
+    bool
+    parallel_shard_memref(void *shard_data, const trace_entry_t &entry) override;
+
+    std::string
+    parallel_shard_error(void *shard_data) override;
+};
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _RECORD_VIEW_H_ */

--- a/clients/drcachesim/tools/record_view.h
+++ b/clients/drcachesim/tools/record_view.h
@@ -59,7 +59,7 @@ namespace drmemtrace {
  */
 class record_view_t : public record_analysis_tool_t {
 public:
-    record_view_t();
+    record_view_t(uint64_t sim_refs);
 
     ~record_view_t() override;
 
@@ -87,6 +87,12 @@ public:
 
     std::string
     parallel_shard_error(void *shard_data) override;
+
+protected:
+    bool
+    should_skip(void);
+
+    uint64_t sim_refs_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tools/record_view_create.h
+++ b/clients/drcachesim/tools/record_view_create.h
@@ -1,0 +1,58 @@
+/* **********************************************************
+ * Copyright (c) 2024 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* record view tool creation */
+
+#ifndef _RECORD_VIEW_CREATE_H_
+#define _RECORD_VIEW_CREATE_H_ 1
+
+#include "analysis_tool.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+/**
+ * @file drmemtrace/record_view_create.h
+ * @brief DrMemtrace record view trace analysis tool creation.
+ */
+
+/**
+ * Creates an analysis tool which prints out the the #trace_entry_t records in a trace
+ * file.
+ */
+analysis_tool_t *
+record_view_tool_create(void);
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _RECORD_VIEW_CREATE_H_ */

--- a/clients/drcachesim/tools/record_view_create.h
+++ b/clients/drcachesim/tools/record_view_create.h
@@ -50,7 +50,7 @@ namespace drmemtrace {
  * file.
  */
 analysis_tool_t *
-record_view_tool_create(void);
+record_view_tool_create(uint64_t sim_refs);
 
 } // namespace drmemtrace
 } // namespace dynamorio


### PR DESCRIPTION
Skeleton for record_view, a new tool to visualize trace_entry_t records.
Currently it prints the type of all trace_entry_t in a trace.

Issue: #6751