### PR TITLE
i#1569 AArch64: Update unsynchronized filename in building.dox

### DIFF
--- a/api/docs/building.dox
+++ b/api/docs/building.dox
@@ -217,7 +217,7 @@ Check out the sources as normal, and point at our toolchain CMake file:
 $ git clone --recurse-submodules -j4 https://github.com/DynamoRIO/dynamorio.git
 $ mkdir build_aarch64
 $ cd build_aarch64
-$ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-arm64.cmake ../dynamorio
+$ cmake -DCMAKE_TOOLCHAIN_FILE=../dynamorio/make/toolchain-aarch64.cmake ../dynamorio
 $ make -j
 ```
 


### PR DESCRIPTION
toolchain-arm64.cmake was renamed to toolchain-aarch64.cmake in PR #4753, but building.dox was not in sync.

Issue: #1569