### PR TITLE
i#6778: Gracefully handle too few drcachesim cpus

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -469,6 +469,11 @@ cache_simulator_t::process_memref(const memref_t &memref)
         }
     } else
         core_index = core_for_thread(memref.data.tid);
+    if (core_index >= static_cast<int>(knobs_.num_cores)) {
+        error_string_ = "Too-small core count " + std::to_string(knobs_.num_cores) +
+            " for trace core #" + std::to_string(core_index);
+        return false;
+    }
 
     // To support swapping to physical addresses without modifying the passed-in
     // memref (which is also passed to other tools run at the same time) we use


### PR DESCRIPTION
Adds a check with an error message for too few simulated drcachesim cpus with a core-sharded-on-disk trace.

Adds a unit test which crashes without the fix.

Also tested manually:
Before:
  $ bin64/drrun -t drcachesim -indir ../src/clients/drcachesim/tests/drmemtrace.threadsig-core-sharded.x64.tracedir/ -cores 3
  Segmentation fault
After:
  $ bin64/drrun -t drcachesim -indir ../src/clients/drcachesim/tests/drmemtrace.threadsig-core-sharded.x64.tracedir/ -cores 3
  ERROR: failed to run analyzer: Too-small core count 3 for trace core #3

Fixes #6778