### PR TITLE
i#6764: Mark detach_test flaky on win32

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -465,6 +465,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|client.drwrap-test-detach' => 1, # i#4593
                 'code_api|linux.thread-reset' => 1, # i#4604
                 'code_api|linux.clone-reset' => 1, # i#4604
+                'code_api|client.detach_test' => 1, # i#6764
                 # These are from the long suite.
                 'common.decode-stress' => 1, # i#1807 Ignored for all options.
                 'code_api,opt_speed|common.fib' => 1, # i#1807: Undiagnosed timeout.


### PR DESCRIPTION
The client.detach_test has been timing out on win32 quite frequently. We put it on the ignore list to get the test suite green.

Issue: #6764