### PR TITLE
Update incorrect docs about scheduler window ids

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -220,10 +220,10 @@ public:
          * though the input were constructed by concatenating these ranges together.  A
          * #TRACE_MARKER_TYPE_WINDOW_ID marker is inserted between
          * ranges (with a value equal to the range ordinal) to notify the client of the
-         * discontinuity (but not before the first range nor between back-to-back regions
-         * with no separation), with a #dynamorio::drmemtrace::TRACE_TYPE_THREAD_EXIT
-         * record inserted after the final range.  These ranges must be non-overlapping
-         * and in increasing order.
+         * discontinuity.  This marker is inserted between back-to-back regions with no
+         * separation, but it is not inserted prior to the first range.  A
+         * #dynamorio::drmemtrace::TRACE_TYPE_THREAD_EXIT record is inserted after the
+         * final range.  These ranges must be non-overlapping and in increasing order.
          */
         std::vector<range_t> regions_of_interest;
     };


### PR DESCRIPTION
Updates the drmemtrace scheduler regions_of_interest docs which incorrectly stated the window id markers were not inserted between back-to-back regions: they are inserted, as the code confirms (with an explicit comment) and the unit tests check.