### PR TITLE
i#2626: AArch64: Fix vector decode bugs

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1086,7 +1086,7 @@ static inline bool
 decode_opnd_dq_plus(int add, int rpos, int qpos, uint enc, OUT opnd_t *opnd)
 {
     *opnd = opnd_create_reg((TEST(1U << qpos, enc) ? DR_REG_Q0 : DR_REG_D0) +
-                            (extract_uint(enc, rpos, rpos + 5) + add) % 32);
+                            (extract_uint(enc, rpos, 5) + add) % 32);
     return true;
 }
 
@@ -1111,7 +1111,7 @@ static inline bool
 decode_opnd_sd(int rpos, int qpos, uint enc, OUT opnd_t *opnd)
 {
     *opnd = opnd_create_reg((TEST(1U << qpos, enc) ? DR_REG_D0 : DR_REG_S0) +
-                            (extract_uint(enc, rpos, rpos + 5) % 32));
+                            (extract_uint(enc, rpos, 5) % 32));
     return true;
 }
 

--- a/core/ir/instr_inline_api.h
+++ b/core/ir/instr_inline_api.h
@@ -298,7 +298,7 @@ opnd_t
 opnd_create_reg_element_vector(reg_id_t r, opnd_size_t element_size)
 {
     opnd_t opnd DR_IF_DEBUG(= { 0 }); /* FIXME: Needed until i#417 is fixed. */
-    CLIENT_ASSERT(element_size == 0 || (r <= DR_REG_LAST_ENUM && r != DR_REG_INVALID),
+    CLIENT_ASSERT(element_size != 0 && (r <= DR_REG_LAST_ENUM && r != DR_REG_INVALID),
                   "opnd_create_reg_element_vector: invalid register or no size");
     opnd.kind = REG_kind;
     opnd.size = 0; /* indicates full size of reg */


### PR DESCRIPTION
Fix incorrect assert and a decoding bug which by luck still worked.

Issue: #2626