### PR TITLE
i#6426 sched stats: Print list of threads

### DIFF
--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -1,7 +1,7 @@
 Schedule stats tool results:
 Total counts:
            4 cores
-           8 threads
+           8 threads: 1257.*
       638938 instructions
            6 total context switches
    0.0093906 CSPKI \(context switches per 1000 instructions\)

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -1,7 +1,7 @@
 Schedule stats tool results:
 Total counts:
            4 cores
-           8 threads
+           8 threads: 1257.*
       638938 instructions
            6 total context switches
    0\.0093906 CSPKI \(context switches per 1000 instructions\)
@@ -22,7 +22,7 @@ Total counts:
       *[0-9\.]*% cpu busy by time
       *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #0 counts:
-           . threads
+           . threads: 1257.*
       *[0-9]* instructions
            . total context switches
    0\.0[0-9\.]* CSPKI \(context switches per 1000 instructions\)
@@ -43,7 +43,7 @@ Core #0 counts:
       *[0-9\.]*% cpu busy by time
       *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #1 counts:
-           . threads
+           . threads: 1257.*
       *[0-9]* instructions
            . total context switches
    0\.0[0-9\.]* CSPKI \(context switches per 1000 instructions\)
@@ -64,7 +64,7 @@ Core #1 counts:
       *[0-9\.]*% cpu busy by time
       *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #2 counts:
-           . threads
+           . threads: 1257.*
       *[0-9]* instructions
            . total context switches
    0\.0[0-9\.]* CSPKI \(context switches per 1000 instructions\)
@@ -85,7 +85,7 @@ Core #2 counts:
       *[0-9\.]*% cpu busy by time
       *[0-9\.]*% cpu busy by time, ignoring idle past last instr
 Core #3 counts:
-           . threads
+           . threads: 1257.*
       *[0-9]* instructions
            . total context switches
    0\.0[0-9\.]* CSPKI \(context switches per 1000 instructions\)

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -330,7 +330,13 @@ schedule_stats_t::print_percentage(double numerator, double denominator,
 void
 schedule_stats_t::print_counters(const counters_t &counters)
 {
-    std::cerr << std::setw(12) << counters.threads.size() << " threads\n";
+    std::cerr << std::setw(12) << counters.threads.size() << " threads";
+    if (!counters.threads.empty()) {
+        std::cerr << ":";
+        for (auto thread : counters.threads)
+            std::cerr << " " << thread;
+    }
+    std::cerr << "\n";
     std::cerr << std::setw(12) << counters.instrs << " instructions\n";
     std::cerr << std::setw(12) << counters.total_switches << " total context switches\n";
     double cspki = 0.;

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -332,9 +332,14 @@ schedule_stats_t::print_counters(const counters_t &counters)
 {
     std::cerr << std::setw(12) << counters.threads.size() << " threads";
     if (!counters.threads.empty()) {
-        std::cerr << ":";
-        for (auto thread : counters.threads)
-            std::cerr << " " << thread;
+        std::cerr << ": ";
+        auto it = counters.threads.begin();
+        while (it != counters.threads.end()) {
+            std::cerr << *it;
+            ++it;
+            if (it != counters.threads.end())
+                std::cerr << ", ";
+        }
     }
     std::cerr << "\n";
     std::cerr << std::setw(12) << counters.instrs << " instructions\n";


### PR DESCRIPTION
Adds the list of threads per cpu to the schedule_stats output. Updates the schedule_stats tests to confirm some tids are printed.

Issue: #6426