### PR TITLE
i#6728 sched time stats: Relax assert for zero time

### DIFF
--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -161,7 +161,7 @@ bool
 schedule_stats_t::update_state_time(per_shard_t *shard, state_t state)
 {
     uint64_t cur = get_current_microseconds();
-    assert(cur > shard->segment_start_microseconds);
+    assert(cur >= shard->segment_start_microseconds);
     assert(shard->segment_start_microseconds > 0);
     uint64_t delta = cur - shard->segment_start_microseconds;
     switch (state) {


### PR DESCRIPTION
Relaxes an assert added in PR #6784 to allow zero time to have elapsed when updating the schedule_stats time buckets.

Issue: #6728