### PR TITLE
i#6793: Skip incorrect final interval during trace analysis

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -578,9 +578,9 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_shard_exit(
     worker->shard_data[shard_index].exited = true;
     if (interval_microseconds_ != 0 || interval_instr_count_ != 0) {
         if (!do_process_final_interval) {
-            ERRMSG(
-                "i#6793: Skipping process_interval for final interval of shard id %d\n",
-                shard_index);
+            ERRMSG("i#6793: Skipping process_interval for final interval of shard index "
+                   "%d\n",
+                   shard_index);
         } else if (!process_interval(
                        worker->shard_data[shard_index].cur_interval_index,
                        worker->shard_data[shard_index].cur_interval_init_instr_count,
@@ -701,7 +701,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks_internal(
             }
         }
     }
-    // i#6444: Workaround for cases where there is a missing thread final record in
+    // i#6444: Fallback for cases where there is a missing thread final record in
     // non-core-sharded traces, in which case we have not yet invoked
     // process_shard_exit.
     for (const auto &keyval : worker->shard_data) {

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -571,26 +571,34 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_serial(analyzer_worker_data_t &
 template <typename RecordType, typename ReaderType>
 bool
 analyzer_tmpl_t<RecordType, ReaderType>::process_shard_exit(
-    analyzer_worker_data_t *worker, int shard_index)
+    analyzer_worker_data_t *worker, int shard_index, bool do_process_final_interval)
 {
     VPRINT(this, 1, "Worker %d finished trace shard %s\n", worker->index,
            worker->stream->get_stream_name().c_str());
     worker->shard_data[shard_index].exited = true;
-    if ((interval_microseconds_ != 0 || interval_instr_count_ != 0) &&
-        (!process_interval(worker->shard_data[shard_index].cur_interval_index,
-                           worker->shard_data[shard_index].cur_interval_init_instr_count,
-                           worker,
-                           /*parallel=*/true, /*at_instr_record=*/false, shard_index) ||
-         !finalize_interval_snapshots(worker, /*parallel=*/true, shard_index)))
-        return false;
+    if (interval_microseconds_ != 0 || interval_instr_count_ != 0) {
+        if (!do_process_final_interval) {
+            ERRMSG(
+                "i#6793: Skipping process_interval for final interval of shard id %d\n",
+                shard_index);
+        } else if (!process_interval(
+                       worker->shard_data[shard_index].cur_interval_index,
+                       worker->shard_data[shard_index].cur_interval_init_instr_count,
+                       worker,
+                       /*parallel=*/true, /*at_instr_record=*/false, shard_index)) {
+            return false;
+        }
+        if (!finalize_interval_snapshots(worker, /*parallel=*/true, shard_index)) {
+            return false;
+        }
+    }
     for (int i = 0; i < num_tools_; ++i) {
         if (!tools_[i]->parallel_shard_exit(
                 worker->shard_data[shard_index].tool_data[i].shard_data)) {
             worker->error = tools_[i]->parallel_shard_error(
                 worker->shard_data[shard_index].tool_data[i].shard_data);
-            VPRINT(this, 1, "Worker %d hit shard exit error %s on trace shard %s\n",
-                   worker->index, worker->error.c_str(),
-                   worker->stream->get_stream_name().c_str());
+            VPRINT(this, 1, "Worker %d hit shard exit error %s on trace shard index %d\n",
+                   worker->index, worker->error.c_str(), shard_index);
             return false;
         }
     }
@@ -693,9 +701,18 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks_internal(
             }
         }
     }
+    // i#6444: Workaround for cases where there is a missing thread final record in
+    // non-core-sharded traces, in which case we have not yet invoked
+    // process_shard_exit.
     for (const auto &keyval : worker->shard_data) {
         if (!keyval.second.exited) {
-            if (!process_shard_exit(worker, keyval.second.shard_index)) {
+            // i#6793: We skip processing the final interval for shards exited here
+            // if the stream has already moved on and cannot provide the state for
+            // the shard anymore.
+            bool do_process_final_interval =
+                keyval.second.shard_index == worker->stream->get_shard_index();
+            if (!process_shard_exit(worker, keyval.second.shard_index,
+                                    do_process_final_interval)) {
                 return false;
             }
         }

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -248,7 +248,8 @@ protected:
     // Helper for process_tasks() which calls parallel_shard_exit() in each tool.
     // Returns false if there was an error and the caller should return early.
     bool
-    process_shard_exit(analyzer_worker_data_t *worker, int shard_index);
+    process_shard_exit(analyzer_worker_data_t *worker, int shard_index,
+                       bool do_process_final_interval = true);
 
     bool
     record_has_tid(RecordType record, memref_tid_t &tid);

--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -802,6 +802,7 @@ test_non_zero_interval_i6793_workaround(bool parallel,
     if (!parallel) {
         // Each whole trace interval is made up of only one snapshot, the
         // serial snapshot.
+        // The missing exit for tid=51 does not affect the serial intervals.
         expected_state_snapshots = { {
             // Format:
             // <interval_id, interval_end_timestamp, instr_count_cumulative,
@@ -847,6 +848,9 @@ test_non_zero_interval_i6793_workaround(bool parallel,
                 // No interval-6 including tid=51 because of its missing thread exit.
                 // So the interval merge logic did not observe any activity during the
                 // interval-6.
+                // The following whole-trace interval-7 constitutes of the interval-3
+                // from tid=51, because the interval-6 from tid=51 was dropped because
+                // of the missing thread exit.
                 recorded_snapshot_t(7, 700, 8, 1, { { 51, 7, 3 }, { 52, 10, 6 } }) } }
         };
     }


### PR DESCRIPTION
Skips generating the final interval snapshot for thread-shards that are missing the thread exit entry, during trace interval analysis in the drmemtrace analyzer framework. Such final intervals currently have incorrect data (the cumulative instr count, instr count delta, and end timestamp). Instead of generating incorrect data we skip such a final interval and print a non-fatal error message.

This issue is seen on interval analysis of only the traces affected by i#6444. That issue has already been fixed many months ago, and does not affect newer traces. This fix is to allow trace interval analysis of those older traces.

Due to i#6444, some threads were missing thread exit entries because tracing ended in an rseq region. For such traces, the i#6444 fix already added an analyzer workaround that ensures that process_shard_exit is called despite the missing thread exit event. Here we modify that workaround to skip processing the final interval when the workaround had to be invoked; this is required because the worker's trace stream would have moved on to other shards (if there were others assigned to the worker) and therefore cannot anymore provide the state (instr count, timestamp when the shard ended) required for generation of the final interval snapshot for that shard.

Note that for the shard that was the last shard in the worker's stream, we can still continue to generate the final interval snapshot, because the worker's trace stream is still good to generate state for that shard.

Adds modified version of existing interval analysis unit tests to verify the workaround.

Also fixes a log which may not print the correct stream name if the error was in a different shard than the current one (because of the same reason we're seeing the primary issue).

Issue: #6444
Fixes: #6793