### PR TITLE
i#6660 dr$sim aliases: Add -tool to replace -simulator_type

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -226,6 +226,8 @@ Further non-compatibility-affecting changes include:
    purpose of preserving register dependencies.
  - Added instr_convert_to_isa_regdeps() API that converts an #instr_t from a real ISA
    (e.g., #DR_ISA_AMD64) to the #DR_ISA_REGDEPS synthetic ISA.
+ - Added -tool as the preferred alias for -simulator_type for the drmemtrace/drcachesim
+   trace analysis tool framework.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -181,9 +181,9 @@ analyzer_multi_t::create_invariant_checker()
 
 template <>
 analysis_tool_t *
-analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator_type)
+analyzer_multi_t::create_analysis_tool_from_options(const std::string &tool)
 {
-    if (simulator_type == CPU_CACHE) {
+    if (tool == CPU_CACHE || tool == CPU_CACHE_ALT || tool == CPU_CACHE_LEGACY) {
         const std::string &config_file = op_config_file.get_value();
         if (!config_file.empty()) {
             return cache_simulator_create(config_file);
@@ -191,12 +191,12 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator
             cache_simulator_knobs_t *knobs = get_cache_simulator_knobs();
             return cache_simulator_create(*knobs);
         }
-    } else if (simulator_type == MISS_ANALYZER) {
+    } else if (tool == MISS_ANALYZER) {
         cache_simulator_knobs_t *knobs = get_cache_simulator_knobs();
         return cache_miss_analyzer_create(*knobs, op_miss_count_threshold.get_value(),
                                           op_miss_frac_threshold.get_value(),
                                           op_confidence_threshold.get_value());
-    } else if (simulator_type == TLB) {
+    } else if (tool == TLB || tool == TLB_LEGACY) {
         tlb_simulator_knobs_t knobs;
         knobs.num_cores = op_num_cores.get_value();
         knobs.page_size = op_page_size.get_value();
@@ -215,10 +215,10 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator
         knobs.cpu_scheduling = op_cpu_scheduling.get_value();
         knobs.use_physical = op_use_physical.get_value();
         return tlb_simulator_create(knobs);
-    } else if (simulator_type == HISTOGRAM) {
+    } else if (tool == HISTOGRAM) {
         return histogram_tool_create(op_line_size.get_value(), op_report_top.get_value(),
                                      op_verbose.get_value());
-    } else if (simulator_type == REUSE_DIST) {
+    } else if (tool == REUSE_DIST) {
         reuse_distance_knobs_t knobs;
         knobs.line_size = op_line_size.get_value();
         knobs.report_histogram = op_reuse_distance_histogram.get_value();
@@ -234,11 +234,11 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator
         }
         knobs.verbose = op_verbose.get_value();
         return reuse_distance_tool_create(knobs);
-    } else if (simulator_type == REUSE_TIME) {
+    } else if (tool == REUSE_TIME) {
         return reuse_time_tool_create(op_line_size.get_value(), op_verbose.get_value());
-    } else if (simulator_type == BASIC_COUNTS) {
+    } else if (tool == BASIC_COUNTS) {
         return basic_counts_tool_create(op_verbose.get_value());
-    } else if (simulator_type == OPCODE_MIX) {
+    } else if (tool == OPCODE_MIX) {
         std::string module_file_path = get_module_file_path();
         if (module_file_path.empty() && op_indir.get_value().empty() &&
             op_infile.get_value().empty() && !op_instr_encodings.get_value()) {
@@ -248,15 +248,15 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator
         }
         return opcode_mix_tool_create(module_file_path, op_verbose.get_value(),
                                       op_alt_module_dir.get_value());
-    } else if (simulator_type == SYSCALL_MIX) {
+    } else if (tool == SYSCALL_MIX) {
         return syscall_mix_tool_create(op_verbose.get_value());
-    } else if (simulator_type == VIEW) {
+    } else if (tool == VIEW) {
         std::string module_file_path = get_module_file_path();
         // The module file is optional so we don't check for emptiness.
         return view_tool_create(module_file_path, op_skip_refs.get_value(),
                                 op_sim_refs.get_value(), op_view_syntax.get_value(),
                                 op_verbose.get_value(), op_alt_module_dir.get_value());
-    } else if (simulator_type == FUNC_VIEW) {
+    } else if (tool == FUNC_VIEW) {
         std::string funclist_file_path = get_aux_file_path(
             op_funclist_file.get_value(), DRMEMTRACE_FUNCTION_LIST_FILENAME);
         if (funclist_file_path.empty()) {
@@ -265,21 +265,21 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &simulator
         }
         return func_view_tool_create(funclist_file_path, op_show_func_trace.get_value(),
                                      op_verbose.get_value());
-    } else if (simulator_type == INVARIANT_CHECKER) {
+    } else if (tool == INVARIANT_CHECKER) {
         return create_invariant_checker();
-    } else if (simulator_type == SCHEDULE_STATS) {
+    } else if (tool == SCHEDULE_STATS) {
         return schedule_stats_tool_create(op_schedule_stats_print_every.get_value(),
                                           op_verbose.get_value());
     } else {
-        auto tool = create_external_tool(simulator_type);
-        if (tool == nullptr) {
+        auto ext_tool = create_external_tool(tool);
+        if (ext_tool == nullptr) {
             ERRMSG("Usage error: unsupported analyzer type \"%s\". "
                    "Please choose " CPU_CACHE ", " MISS_ANALYZER ", " TLB ", " HISTOGRAM
                    ", " REUSE_DIST ", " BASIC_COUNTS ", " OPCODE_MIX ", " SYSCALL_MIX
                    ", " VIEW ", " FUNC_VIEW ", or some external analyzer.\n",
-                   simulator_type.c_str());
+                   tool.c_str());
         }
-        return tool;
+        return ext_tool;
     }
 }
 
@@ -326,10 +326,9 @@ record_analyzer_multi_t::create_invariant_checker()
 
 template <>
 record_analysis_tool_t *
-record_analyzer_multi_t::create_analysis_tool_from_options(
-    const std::string &simulator_type)
+record_analyzer_multi_t::create_analysis_tool_from_options(const std::string &tool)
 {
-    if (simulator_type == RECORD_FILTER) {
+    if (tool == RECORD_FILTER) {
         return record_filter_tool_create(
             op_outdir.get_value(), op_filter_stop_timestamp.get_value(),
             op_filter_cache_size.get_value(), op_filter_trace_types.get_value(),
@@ -338,7 +337,7 @@ record_analyzer_multi_t::create_analysis_tool_from_options(
     }
     ERRMSG("Usage error: unsupported record analyzer type \"%s\".  Only " RECORD_FILTER
            " is supported.\n",
-           simulator_type.c_str());
+           tool.c_str());
     return nullptr;
 }
 
@@ -535,8 +534,8 @@ bool
 analyzer_multi_tmpl_t<RecordType, ReaderType>::create_analysis_tools()
 {
     this->tools_ = new analysis_tool_tmpl_t<RecordType> *[this->max_num_tools_];
-    if (!op_simulator_type.get_value().empty()) {
-        std::stringstream stream(op_simulator_type.get_value());
+    if (!op_tool.get_value().empty()) {
+        std::stringstream stream(op_tool.get_value());
         std::string type;
         while (std::getline(stream, type, ':')) {
             if (this->num_tools_ >= this->max_num_tools_ - 1) {

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -458,18 +458,18 @@ droption_t<std::string>
                           "Specifies the replacement policy for TLBs. "
                           "Supported policies: LFU (Least Frequently Used).");
 
-// TODO i#6660: Add "-tool" alias as these are not all "simulators".
 droption_t<std::string>
-    op_simulator_type(DROPTION_SCOPE_FRONTEND, "simulator_type", CPU_CACHE,
-                      "Specifies which trace analysis tool(s) to run.  Multiple tools "
-                      "can be specified, separated by a colon (\":\").",
-                      "Predefined types: " CPU_CACHE ", " MISS_ANALYZER ", " TLB
-                      ", " REUSE_DIST ", " REUSE_TIME ", " HISTOGRAM ", " BASIC_COUNTS
-                      ", " INVARIANT_CHECKER ", " SCHEDULE_STATS ", or " RECORD_FILTER
-                      ". The " RECORD_FILTER " tool cannot be combined with the others "
-                      "as it operates on raw disk records. "
-                      "To invoke an external tool: specify its name as identified by a "
-                      "name.drcachesim config file in the DR tools directory.");
+    op_tool(DROPTION_SCOPE_FRONTEND,
+            std::vector<std::string>({ "tool", "simulator_type" }), CPU_CACHE,
+            "Specifies which trace analysis tool(s) to run.  Multiple tools "
+            "can be specified, separated by a colon (\":\").",
+            "Predefined types: " CPU_CACHE ", " MISS_ANALYZER ", " TLB ", " REUSE_DIST
+            ", " REUSE_TIME ", " HISTOGRAM ", " BASIC_COUNTS ", " INVARIANT_CHECKER
+            ", " SCHEDULE_STATS ", or " RECORD_FILTER ". The " RECORD_FILTER
+            " tool cannot be combined with the others "
+            "as it operates on raw disk records. "
+            "To invoke an external tool: specify its name as identified by a "
+            "name.drcachesim config file in the DR tools directory.");
 
 droption_t<unsigned int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 0, 0, 64,
                                     "Verbosity level",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -35,12 +35,13 @@
 #ifndef _OPTIONS_H_
 #define _OPTIONS_H_ 1
 
-// Tool names (for -simulator_type option).
-// TODO i#6660: When we add "-tool", add "cache_simulator" or "drcachesim"
-// instead of just "-tool cache".  Ditto for "TLB".
-#define CPU_CACHE "cache"
+// Tool names (for -tool option).
+#define CPU_CACHE_LEGACY "cache"
+#define CPU_CACHE "cache_simulator"
+#define CPU_CACHE_ALT "drcachesim"
 #define MISS_ANALYZER "miss_analyzer"
-#define TLB "TLB"
+#define TLB_LEGACY "TLB"
+#define TLB "TLB_simulator"
 #define HISTOGRAM "histogram"
 #define REUSE_DIST "reuse_distance"
 #define REUSE_TIME "reuse_time"
@@ -146,7 +147,7 @@ extern dynamorio::droption::droption_t<unsigned int> op_TLB_L1D_assoc;
 extern dynamorio::droption::droption_t<unsigned int> op_TLB_L2_entries;
 extern dynamorio::droption::droption_t<unsigned int> op_TLB_L2_assoc;
 extern dynamorio::droption::droption_t<std::string> op_TLB_replace_policy;
-extern dynamorio::droption::droption_t<std::string> op_simulator_type;
+extern dynamorio::droption::droption_t<std::string> op_tool;
 extern dynamorio::droption::droption_t<unsigned int> op_verbose;
 extern dynamorio::droption::droption_t<bool> op_show_func_trace;
 extern dynamorio::droption::droption_t<int> op_jobs;

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -262,7 +262,7 @@ LL stats:
 
 In addition to a CPU cache simulator, other predefined analysis tools are
 available that operate on memory address traces.  Which set of tools is used
-can be selected with the \p -simulator_type parameter.  New, custom
+can be selected with the \p -tool parameter.  New, custom
 tools can also be created, as described in \ref sec_drcachesim_newtool.
 
 - \ref sec_tool_cache_sim
@@ -332,10 +332,10 @@ LL stats:
 
 \section sec_tool_TLB_sim TLB Simulator
 
-To simulate TLB devices instead of caches, pass \p TLB to \p -simulator_type:
+To simulate TLB devices instead of caches, pass \p TLB to \p -tool:
 
 \code
-$ bin64/drrun -t drcachesim -simulator_type TLB -- ~/test/pi_estimator
+$ bin64/drrun -t drcachesim -tool TLB -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 TLB simulation results:
@@ -392,7 +392,7 @@ Core #3 (0 thread(s))
 To compute reuse distance metrics:
 
 \code
-$ bin64/drrun -t drcachesim -simulator_type reuse_distance -reuse_distance_histogram -- ~/test/pi_estimator
+$ bin64/drrun -t drcachesim -tool reuse_distance -reuse_distance_histogram -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Reuse distance tool aggregated results:
@@ -486,7 +486,7 @@ accesses (without considering uniqueness) between accesses to the same
 address:
 
 \code
-$ bin64/drrun -t drcachesim -simulator_type reuse_time -- ~/test/pi_estimator
+$ bin64/drrun -t drcachesim -tool reuse_time -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Reuse time tool aggregated results:
@@ -528,7 +528,7 @@ To simply see the counts of instructions and memory references broken down
 by thread use the basic counts tool:
 
 \code
-$ bin64/drrun -t drcachesim -simulator_type basic_counts -- ~/test/pi_estimator
+$ bin64/drrun -t drcachesim -tool basic_counts -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Basic counts tool results:
@@ -645,7 +645,7 @@ opcode for load and store but both have the same public string "mov":
 \code
 $ bin64/drrun -t drcachesim -offline -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
-$ bin64/drrun -t drcachesim -simulator_type opcode_mix -indir drmemtrace.*.dir
+$ bin64/drrun -t drcachesim -tool opcode_mix -indir drmemtrace.*.dir
 Opcode mix tool results:
          267271 : total executed instructions
           36432 :       mov
@@ -695,7 +695,7 @@ In its first two columns, the tool displays the trace record ordinal
 and the instruction fetch ordinal.
 
 \code
-$ $ bin64/drrun -t drcachesim -simulator_type view -indir drmemtrace.*.dir -sim_refs 20
+$ $ bin64/drrun -t drcachesim -tool view -indir drmemtrace.*.dir -sim_refs 20
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
@@ -795,7 +795,7 @@ more information.
 \code
 $ bin64/drrun -t drcachesim -offline -record_function 'fib|1' -- ~/test/fib 5
 Estimation of pi is 3.142425985001098
-$ bin64/drrun -t drcachesim -simulator_type func_view -indir drmemtrace.*.dir
+$ bin64/drrun -t drcachesim -tool func_view -indir drmemtrace.*.dir
 0x7fc06d2288eb => common.fib!fib(0x5)
     0x7fc06d22888e => common.fib!fib(0x4)
         0x7fc06d22888e => common.fib!fib(0x3)
@@ -829,7 +829,7 @@ Function id=0: common.fib!fib
 The top referenced cache lines are displayed by the \p histogram tool:
 
 \code
-$ bin64/drrun -t drcachesim -simulator_type histogram -- ~/test/pi_estimator
+$ bin64/drrun -t drcachesim -tool histogram -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Cache line histogram tool results:
@@ -877,7 +877,7 @@ number. This works only with traces that have these markers; that is, offline tr
 must have #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_SYSCALL_NUMBERS in their file type.
 
 \code
-$ bin64/drrun -t drcachesim -indir drmemtrace.ls.*.dir -simulator_type syscall_mix
+$ bin64/drrun -t drcachesim -indir drmemtrace.ls.*.dir -tool syscall_mix
 Syscall mix tool results:
           count : syscall_num
              17 :         9
@@ -929,7 +929,7 @@ option.
 Example of removing function markers:
 
 \code
-$ bin64/drrun -t drcachesim -indir mytracedir -simulator_type basic_counts
+$ bin64/drrun -t drcachesim -indir mytracedir -tool basic_counts
 ...
         9009 total function id markers
         5006 total function return address markers
@@ -937,10 +937,10 @@ $ bin64/drrun -t drcachesim -indir mytracedir -simulator_type basic_counts
         4003 total function return value markers
 ...
 
-$ bin64/drrun -t drcachesim -simulator_type record_filter -filter_marker_types 4,5,6,7 -indir mytracedir -outdir newdir
+$ bin64/drrun -t drcachesim -tool record_filter -filter_marker_types 4,5,6,7 -indir mytracedir -outdir newdir
 Output 1280800 entries from 1304825 entries.
 
-$ bin64/drrun -t drcachesim -indir newdir -simulator_type basic_counts
+$ bin64/drrun -t drcachesim -indir newdir -tool basic_counts
 ...
            0 total function id markers
            0 total function return address markers
@@ -1266,7 +1266,7 @@ burst_static test application</a>.
 Generally, the simulator is able to be extended to model a variety of
 caching devices.  Currently, CPU caches and TLBs are implemented.  The type of
 devices to simulate can be specified by the parameter
-"-simulator_type" (see \ref sec_drcachesim_ops).
+"-tool" (see \ref sec_drcachesim_ops).
 
 The CPU cache simulator models a configurable number of cores,
 each with an L1 data cache and an L1 instruction cache.
@@ -1393,7 +1393,7 @@ The cache simulator can be used to analyze the stream of last-level cache (LLC)
 miss addresses. This can be useful when looking for patterns that can be utilized
 in software prefetching. The current analyzer can only identify simple stride
 patterns, but it can be extended to search for more complex patterns.
-To invoke the miss analyzer, pass \p miss_analyzer to the \p -simulator_type
+To invoke the miss analyzer, pass \p miss_analyzer to the \p -tool
 parameter. To write the prefetching hints to a file use the \p -LL_miss_file
 parameter to specify the file's path and name.
 
@@ -1401,7 +1401,7 @@ For example, to run the analyzer on a benchmark called "my_benchmark" and store
 the prefetching recommendations in a file called "rec.csv", run the following:
 
 \code
-$ bin64/drrun -t drcachesim -simulator_type miss_analyzer -LL_miss_file rec.csv -- my_benchmark
+$ bin64/drrun -t drcachesim -tool miss_analyzer -LL_miss_file rec.csv -- my_benchmark
 \endcode
 
 
@@ -1669,7 +1669,7 @@ functions.
 
 \p drcachesim \p drmemtrace analysis tool framework allows to load
 non-predefined separately-built external tools. This tool can be loaded by drcachesim
-using the \p -simulator_type option.
+using the \p -tool option.
 
 ## External tool package
 

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -323,7 +323,7 @@ _tmain(int argc, const TCHAR *targv[])
             FATAL_ERROR("invalid -outdir %s", op_outdir.get_value().c_str());
         }
     } else {
-        if (op_simulator_type.get_value() == RECORD_FILTER) {
+        if (op_tool.get_value() == RECORD_FILTER) {
             record_analyzer = new record_analyzer_multi_t;
             if (!*record_analyzer) {
                 std::string error_string_ = record_analyzer->get_error_string();

--- a/clients/drcachesim/tests/core_sharded_test.cpp
+++ b/clients/drcachesim/tests/core_sharded_test.cpp
@@ -89,8 +89,7 @@ test_real_files(const char *testdir)
     // for that.
     {
         // Test thread-sharded with defaults.
-        const char *args[] = { "<exe>", "-simulator_type", "basic_counts", "-indir",
-                               dir.c_str() };
+        const char *args[] = { "<exe>", "-tool", "basic_counts", "-indir", dir.c_str() };
         std::string output = run_analyzer(sizeof(args) / sizeof(args[0]), args);
         assert(std::regex_search(output, std::regex(R"DELIM(Basic counts tool results:
 Total counts:
@@ -104,7 +103,7 @@ Thread [0-9]+ counts:
     }
     {
         // Test core-sharded with defaults.
-        const char *args[] = { "<exe>",        "-core_sharded", "-simulator_type",
+        const char *args[] = { "<exe>",        "-core_sharded", "-tool",
                                "basic_counts", "-indir",        dir.c_str() };
         std::string output = run_analyzer(sizeof(args) / sizeof(args[0]), args);
         assert(std::regex_search(output, std::regex(R"DELIM(Basic counts tool results:
@@ -122,9 +121,8 @@ Core [0-9] counts:
     }
     {
         // Test core-sharded with time quantum.
-        const char *args[] = { "<exe>",        "-core_sharded", "-simulator_type",
-                               "basic_counts", "-indir",        dir.c_str(),
-                               "-sched_time" };
+        const char *args[] = { "<exe>",  "-core_sharded", "-tool",      "basic_counts",
+                               "-indir", dir.c_str(),     "-sched_time" };
         std::string output = run_analyzer(sizeof(args) / sizeof(args[0]), args);
         assert(std::regex_search(output, std::regex(R"DELIM(Basic counts tool results:
 Total counts:
@@ -146,7 +144,7 @@ Core [0-9] counts:
         // TODO i#5694: Add more targeted checks once we have schedule_stats.
         const char *args[] = { "<exe>",
                                "-core_sharded",
-                               "-simulator_type",
+                               "-tool",
                                "basic_counts",
                                "-indir",
                                dir.c_str(),
@@ -173,16 +171,10 @@ Core [0-9] counts:
         // Test core-sharded with replay-as-traced.
         std::string cpu_file = std::string(testdir) +
             "/drmemtrace.threadsig.x64.tracedir/cpu_schedule.bin.zip";
-        const char *args[] = { "<exe>",
-                               "-core_sharded",
-                               "-simulator_type",
-                               "basic_counts",
-                               "-indir",
-                               dir.c_str(),
-                               "-cores",
-                               "7",
-                               "-cpu_schedule_file",
-                               cpu_file.c_str() };
+        const char *args[] = {
+            "<exe>",     "-core_sharded", "-tool", "basic_counts",       "-indir",
+            dir.c_str(), "-cores",        "7",     "-cpu_schedule_file", cpu_file.c_str()
+        };
         std::string output = run_analyzer(sizeof(args) / sizeof(args[0]), args);
         assert(std::regex_search(output, std::regex(R"DELIM(Basic counts tool results:
 Total counts:
@@ -230,11 +222,10 @@ Core 8 counts:
     {
         // Test record-replay.
         std::string record_file = "tmp_core_sharded_replay.zip";
-        const char *record_args[] = { "<exe>",           "-core_sharded",
-                                      "-simulator_type", "basic_counts",
-                                      "-indir",          dir.c_str(),
-                                      "-cores",          "3",
-                                      "-record_file",    record_file.c_str() };
+        const char *record_args[] = {
+            "<exe>",     "-core_sharded", "-tool", "basic_counts", "-indir",
+            dir.c_str(), "-cores",        "3",     "-record_file", record_file.c_str()
+        };
         std::string record_out =
             run_analyzer(sizeof(record_args) / sizeof(record_args[0]), record_args);
         assert(std::regex_search(record_out, std::regex(R"DELIM(Basic counts tool results:
@@ -246,11 +237,10 @@ Core .*
  *[0-9]+ threads
 (.|\n)*
 )DELIM")));
-        const char *replay_args[] = { "<exe>",           "-core_sharded",
-                                      "-simulator_type", "basic_counts",
-                                      "-indir",          dir.c_str(),
-                                      "-cores",          "3",
-                                      "-replay_file",    record_file.c_str() };
+        const char *replay_args[] = {
+            "<exe>",     "-core_sharded", "-tool", "basic_counts", "-indir",
+            dir.c_str(), "-cores",        "3",     "-replay_file", record_file.c_str()
+        };
         std::string replay_out =
             run_analyzer(sizeof(replay_args) / sizeof(replay_args[0]), replay_args);
         // The idle and wait counts can vary so we remove them.

--- a/clients/drcachesim/tools/external/example/CMakeLists.txt
+++ b/clients/drcachesim/tools/external/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2023 Google, Inc.    All rights reserved.
+# Copyright (c) 2023-2024 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -104,7 +104,7 @@ if (X86 AND X64 AND ZIP_FOUND)
     "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir")
   add_test(NAME drcachesim.empty_load
     COMMAND ${PROJECT_BINARY_DIR}/bin64/drrun -t drcachesim -offline
-     -simulator_type empty -indir ${trace_dir})
+     -tool empty -indir ${trace_dir})
   set(empty_regex "Empty tool created\nEmpty tool results:")
   set_tests_properties(drcachesim.empty_load
     PROPERTIES PASS_REGULAR_EXPRESSION "${empty_regex}")
@@ -112,8 +112,8 @@ if (X86 AND X64 AND ZIP_FOUND)
   # Simple test to ensure non-existent tool load by drcachesim should fail.
   add_test(NAME drcachesim.non-existent_load
     COMMAND ${PROJECT_BINARY_DIR}/bin64/drrun -t drcachesim -offline
-     -simulator_type non-existent -indir ${trace_dir})
-  set(nonexistent_regex "Usage error: unsupported analyzer type \"non-existent\". Please choose cache, miss_analyzer, TLB, histogram, reuse_distance, basic_counts, opcode_mix, syscall_mix, view, func_view, or some external analyzer.\nERROR: failed to initialize analyzer: Failed to create analysis tool:")
+     -tool non-existent -indir ${trace_dir})
+  set(nonexistent_regex "Usage error: unsupported analyzer type \"non-existent\". Please choose cache_simulator, miss_analyzer, TLB_simulator, histogram, reuse_distance, basic_counts, opcode_mix, syscall_mix, view, func_view, or some external analyzer.\nERROR: failed to initialize analyzer: Failed to create analysis tool:")
   set_tests_properties(drcachesim.non-existent_load
     PROPERTIES PASS_REGULAR_EXPRESSION "${nonexistent_regex}")
 endif ()

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2114,7 +2114,7 @@ if (DR_HOST_NOT_TARGET)
     prefix_cmd_if_necessary(drcachesim_path ON ${drcachesim_path})
     torunonly_api(tool.drcacheoff.altbindir "${drcachesim_path}"
       "offline-altbindir.c" ""
-      "-indir;${locdir};-simulator_type;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
+      "-indir;${locdir};-tool;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
       OFF OFF)
     set(tool.drcacheoff.altbindir_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -3671,7 +3671,7 @@ if (BUILD_CLIENTS)
       "")
 
     # TLB simulator's single-thread sanity check
-    torunonly_drcachesim(TLB-simple ${ci_shared_app} "-simulator_type TLB" "")
+    torunonly_drcachesim(TLB-simple ${ci_shared_app} "-tool TLB" "")
 
     # Test that -LL_miss_file at least doesn't crash.  It's not easy to test
     # much further.
@@ -3708,14 +3708,14 @@ if (BUILD_CLIENTS)
         "-L0_filter -test_mode -test_mode_name filter_asm_instr_count" "")
     endif ()
     torunonly_drcachesim(filter-no-i ${ci_shared_app}
-      "-L0I_filter -L0I_size 0 -simulator_type basic_counts ${test_mode_flag}" "")
+      "-L0I_filter -L0I_size 0 -tool basic_counts ${test_mode_flag}" "")
     torunonly_drcachesim(filter-i ${ci_shared_app}
-      "-L0I_filter -L0I_size 1024 -simulator_type basic_counts ${test_mode_flag}" "")
+      "-L0I_filter -L0I_size 1024 -tool basic_counts ${test_mode_flag}" "")
     set(tool.drcachesim.filter-i_expectbase "basic-counts-generic")
     torunonly_drcachesim(filter-no-d ${ci_shared_app}
-      "-L0D_filter -L0D_size 0 -simulator_type basic_counts ${test_mode_flag}" "")
+      "-L0D_filter -L0D_size 0 -tool basic_counts ${test_mode_flag}" "")
     torunonly_drcachesim(filter-d ${ci_shared_app}
-      "-L0D_filter -L0D_size 1024 -simulator_type basic_counts ${test_mode_flag}" "")
+      "-L0D_filter -L0D_size 1024 -tool basic_counts ${test_mode_flag}" "")
     set(tool.drcachesim.filter-d_expectbase "basic-counts-generic")
 
     torunonly_drcachesim(instr-only-trace ${ci_shared_app} "-instr_only_trace" "")
@@ -3723,7 +3723,7 @@ if (BUILD_CLIENTS)
     # __builtin_prefetch used in the test is not defined on MSVC.
     if (NOT MSVC)
       add_exe(builtin_prefetch ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/builtin_prefetch.c)
-      torunonly_drcachesim(builtin-prefetch-basic-counts builtin_prefetch "-simulator_type basic_counts" "")
+      torunonly_drcachesim(builtin-prefetch-basic-counts builtin_prefetch "-tool basic_counts" "")
       unset(tool.drcachesim.builtin-prefetch-basic-counts_rawtemp) # use preprocessor
     endif ()
 
@@ -3734,11 +3734,11 @@ if (BUILD_CLIENTS)
     # 1 thread, testing the thread ignore logic.  The max should be small enough
     # to not be flaky on any platform.
     torunonly_drcachesim(delay-global client.annotation-concurrency
-      "-simulator_type basic_counts -trace_after_instrs 20K -max_global_trace_refs 10K"
+      "-tool basic_counts -trace_after_instrs 20K -max_global_trace_refs 10K"
       "${annotation_test_args_shorter}")
 
     torunonly_drcachesim(windows-simple ${ci_shared_app}
-      "-trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -simulator_type basic_counts" "")
+      "-trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -tool basic_counts" "")
 
     # Test that "Warmup hits" and "Warmup misses" are printed out
     torunonly_drcachesim(warmup-valid ${ci_shared_app} "-warmup_refs 1" "")
@@ -3769,7 +3769,7 @@ if (BUILD_CLIENTS)
 
     # TLB simulator's multi-thread sanity check
     torunonly_drcachesim(TLB-threads client.annotation-concurrency
-      "-simulator_type TLB -cpu_scheduling" "${annotation_test_args_shorter}")
+      "-tool TLB -cpu_scheduling" "${annotation_test_args_shorter}")
     # i#2063: this test can time out.
     set(tool.drcachesim.TLB-threads_timeout 150)
 
@@ -3785,10 +3785,10 @@ if (BUILD_CLIENTS)
         "-data_prefetcher none" "")
 
       torunonly_drcachesim(allasm-aarch64-prefetch-basic-counts allasm_aarch64_prefetch
-        "-simulator_type basic_counts" "")
+        "-tool basic_counts" "")
 
       torunonly_drcachesim(allasm-aarch64-flush-basic-counts allasm_aarch64_flush
-        "-simulator_type basic_counts" "")
+        "-tool basic_counts" "")
     endif ()
 
     # XXX i#1703: add more dedicated tests (in suite/tests/clients/) for which
@@ -3806,7 +3806,7 @@ if (BUILD_CLIENTS)
       add_exe(stride_benchmark
         ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/stride_benchmark.cpp)
       torunonly_drcachesim(miss_analyzer stride_benchmark
-        "-simulator_type miss_analyzer -miss_count_threshold 5000 -miss_frac_threshold 0.25" "")
+        "-tool miss_analyzer -miss_count_threshold 5000 -miss_frac_threshold 0.25" "")
     endif ()
 
     # Test other analysis tools
@@ -3819,15 +3819,15 @@ if (BUILD_CLIENTS)
     endmacro (torunonly_simtool)
 
     torunonly_simtool(histogram ${ci_shared_app}
-      "-simulator_type histogram -report_top 20" "")
+      "-tool histogram -report_top 20" "")
 
     torunonly_simtool(reuse_distance ${ci_shared_app}
-      "-simulator_type reuse_distance -reuse_distance_threshold 256" "")
+      "-tool reuse_distance -reuse_distance_threshold 256" "")
 
     # We run common.decode-bad to test markers for faults
     if (X86) # decode-bad is x86-only
       torunonly_simtool(basic_counts common.decode-bad
-        "-simulator_type basic_counts" "")
+        "-tool basic_counts" "")
     endif ()
 
     if (X86 AND X64) # We only bother with a sample trace for x86_64.
@@ -3835,32 +3835,32 @@ if (BUILD_CLIENTS)
       set(small_trace_file
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.small.x64.trace")
       torunonly_simtool(reuse_offline ${ci_shared_app}
-        "-infile ${small_trace_file} -simulator_type reuse_distance -reuse_distance_histogram" "")
+        "-infile ${small_trace_file} -tool reuse_distance -reuse_distance_histogram" "")
 
       # Our multi-threaded sample trace is larger so we require gzip.
       if (ZLIB_FOUND)
         set(thread_trace_dir
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir")
         torunonly_simtool(reuse_offline_threads ${ci_shared_app}
-          "-indir ${thread_trace_dir} -simulator_type reuse_distance -reuse_distance_histogram" "")
+          "-indir ${thread_trace_dir} -tool reuse_distance -reuse_distance_histogram" "")
         set(tool.reuse_offline_threads_rawtemp ON) # no preprocessor
 
         torunonly_simtool(reuse_time_offline ${ci_shared_app}
-          "-indir ${thread_trace_dir} -simulator_type reuse_time" "")
+          "-indir ${thread_trace_dir} -tool reuse_time" "")
         set(tool.reuse_time_offline_rawtemp ON) # no preprocessor
 
         torunonly_simtool(counts_only_thread ${ci_shared_app}
-          "-indir ${thread_trace_dir} -simulator_type basic_counts -only_thread 1257604"
+          "-indir ${thread_trace_dir} -tool basic_counts -only_thread 1257604"
           "")
         set(tool.counts_only_thread_rawtemp ON) # no preprocessor
 
         torunonly_simtool(schedule_stats_nopreempt ${ci_shared_app}
-          "-indir ${thread_trace_dir} -simulator_type schedule_stats -core_sharded -sched_quantum 10000000"
+          "-indir ${thread_trace_dir} -tool schedule_stats -core_sharded -sched_quantum 10000000"
           "")
         set(tool.schedule_stats_nopreempt_rawtemp ON) # no preprocessor
 
         torunonly_simtool(core_serial ${ci_shared_app}
-          "-indir ${thread_trace_dir} -simulator_type schedule_stats:basic_counts -core_serial"
+          "-indir ${thread_trace_dir} -tool schedule_stats:basic_counts -core_serial"
           "")
         set(tool.core_serial_rawtemp ON) # no preprocessor
 
@@ -3873,18 +3873,18 @@ if (BUILD_CLIENTS)
         set(switch_file
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/mock_switch_sequences.x64.zip")
         torunonly_simtool(switch_insertion ${ci_shared_app}
-          "-indir ${thread_trace_dir} -simulator_type basic_counts -core_sharded -sched_quantum 1000 -sched_switch_file ${switch_file}"
+          "-indir ${thread_trace_dir} -tool basic_counts -core_sharded -sched_quantum 1000 -sched_switch_file ${switch_file}"
           "")
         set(tool.switch_insertion_rawtemp ON) # no preprocessor
 
         torunonly_simtool(switch_file_invariants ${ci_shared_app}
-          "-infile ${switch_file} -simulator_type invariant_checker"
+          "-infile ${switch_file} -tool invariant_checker"
           "")
         set(tool.switch_file_invariants_rawtemp ON) # no preprocessor
 
         # Sanity test that core-sharded at least runs without errors on our other tools.
         torunonly_simtool(core_sharded ${ci_shared_app}
-          "-indir ${thread_trace_dir} -simulator_type reuse_time:reuse_distance:histogram:opcode_mix:syscall_mix -core_sharded"
+          "-indir ${thread_trace_dir} -tool reuse_time:reuse_distance:histogram:opcode_mix:syscall_mix -core_sharded"
           "")
         set(tool.core_sharded_rawtemp ON) # no preprocessor
 
@@ -3892,11 +3892,11 @@ if (BUILD_CLIENTS)
         set(core_sharded_dir
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig-core-sharded.x64.tracedir")
         torunonly_simtool(core_on_disk ${ci_shared_app}
-          "-indir ${core_sharded_dir} -simulator_type basic_counts" "")
+          "-indir ${core_sharded_dir} -tool basic_counts" "")
         set(tool.core_on_disk_rawtemp ON) # no preprocessor
 
         torunonly_simtool(core_on_disk_schedule ${ci_shared_app}
-          "-indir ${core_sharded_dir} -simulator_type schedule_stats" "")
+          "-indir ${core_sharded_dir} -tool schedule_stats" "")
         set(tool.core_on_disk_schedule_rawtemp ON) # no preprocessor
       endif ()
     endif ()
@@ -3928,7 +3928,7 @@ if (BUILD_CLIENTS)
 
     if ((NOT MACOS) AND (X86 OR AARCH64))
         torunonly_drcachesim(scattergather-${ARCH_NAME} client.drx-scattergather
-        "-simulator_type invariant_checker -test_mode_name scattergather" "")
+        "-tool invariant_checker -test_mode_name scattergather" "")
       unset(tool.drcachesim.scattergather-${ARCH_NAME}_rawtemp) # use preprocessor
       if (AARCH64)
           # The AArch64 version of the test tests a lot of instruction variants and can
@@ -3957,7 +3957,7 @@ if (BUILD_CLIENTS)
       prefix_cmd_if_necessary(drraw2trace_path ON ${drraw2trace_path})
 
       torunonly_drcachesim(opcode_mix ${ci_shared_app}
-        "-instr_encodings -simulator_type opcode_mix" "")
+        "-instr_encodings -tool opcode_mix" "")
     endif (NOT RISCV64)
     # The sim_atops should start with @ and be in @-as-space format (hence "atops").
     # If the exetgt has drcachesim statically linked in, the _nodr property must be
@@ -4054,7 +4054,7 @@ if (BUILD_CLIENTS)
     if (libsnappy)
       # with a parallel tool (basic_counts)
       torunonly_api(tool.drcacheoff.snappy "${drcachesim_path}" "offline-snappy.c" ""
-        "-indir;${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.chase-snappy.x64.tracedir;-simulator_type;basic_counts"
+        "-indir;${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.chase-snappy.x64.tracedir;-tool;basic_counts"
         OFF OFF)
 
       # with a legacy serial tool (full simulator)
@@ -4075,14 +4075,14 @@ if (BUILD_CLIENTS)
 
     torunonly_drcacheoff(filter ${ci_shared_app} "-L0_filter ${test_mode_flag}" "" "")
     torunonly_drcacheoff(filter-no-i ${ci_shared_app}
-      "-L0I_filter -L0I_size 0 ${test_mode_flag}" "@-simulator_type@basic_counts" "")
+      "-L0I_filter -L0I_size 0 ${test_mode_flag}" "@-tool@basic_counts" "")
     torunonly_drcacheoff(filter-i ${ci_shared_app}
-      "-L0I_filter -L0I_size 1024 ${test_mode_flag}" "@-simulator_type@basic_counts" "")
+      "-L0I_filter -L0I_size 1024 ${test_mode_flag}" "@-tool@basic_counts" "")
     set(tool.drcacheoff.filter-i_expectbase "offline-basic-counts-generic")
     torunonly_drcacheoff(filter-no-d ${ci_shared_app}
-      "-L0D_filter -L0D_size 0 ${test_mode_flag}" "@-simulator_type@basic_counts" "")
+      "-L0D_filter -L0D_size 0 ${test_mode_flag}" "@-tool@basic_counts" "")
     torunonly_drcacheoff(filter-d ${ci_shared_app}
-      "-L0D_filter -L0D_size 1024 ${test_mode_flag}" "@-simulator_type@basic_counts" "")
+      "-L0D_filter -L0D_size 1024 ${test_mode_flag}" "@-tool@basic_counts" "")
     set(tool.drcacheoff.filter-d_expectbase "offline-basic-counts-generic")
 
     torunonly_drcacheoff(instr-only-trace ${ci_shared_app} "-instr_only_trace" "" "")
@@ -4091,25 +4091,25 @@ if (BUILD_CLIENTS)
     if (LINUX) # Test uses Linux-specific timer code.
       if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
         torunonly_drcacheoff(sysnums linux.signal_pre_syscall ""
-          "@-simulator_type@basic_counts@${test_mode_flag}" "")
+          "@-tool@basic_counts@${test_mode_flag}" "")
       endif ()
     endif ()
 
     torunonly_drcacheoff(interval-microseconds-count-output ${ci_shared_app} ""
-      "@-simulator_type@basic_counts@-interval_microseconds@1M" "")
+      "@-tool@basic_counts@-interval_microseconds@1M" "")
 
     torunonly_drcacheoff(interval-instr-count-output ${ci_shared_app} ""
-      "@-simulator_type@basic_counts@-interval_instr_count@10000" "")
+      "@-tool@basic_counts@-interval_instr_count@10000" "")
 
     torunonly_drcacheoff(interval-opcode-mix-output ${ci_shared_app} ""
-      "@-simulator_type@opcode_mix@-interval_instr_count@10000" "")
+      "@-tool@opcode_mix@-interval_instr_count@10000" "")
 
     # As for the online test, we check that only 1 thread is in the final trace.
     torunonly_drcacheoff(max-global client.annotation-concurrency
       # Include function tracing to sanity test combining with delay and max.
       # We don't use '-record_heap' as it is slow on Windows (i#6342).
       "-trace_after_instrs 20K -max_global_trace_refs 10K -record_function malloc|1"
-      "@-simulator_type@basic_counts" "${annotation_test_args_shorter}")
+      "@-tool@basic_counts" "${annotation_test_args_shorter}")
     set(tool.drcacheoff.max-global_timeout 240) # Can take >120s.
 
     torunonly_drcacheoff(delay-func ${ci_shared_app}
@@ -4122,7 +4122,7 @@ if (BUILD_CLIENTS)
       # This is also large enough to test the (non-triggering portion of) the
       # per-thread counter feature (i#5026).
       "-trace_after_instrs 200M -record_heap"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
     # There is now no data file at all: which we test by echoing the glob.
     set(tool.drcacheoff.delay-func_nopost ON)
     set(tool.drcacheoff.delay-func_postcmd
@@ -4131,66 +4131,66 @@ if (BUILD_CLIENTS)
 
     torunonly_drcacheoff(windows-simple ${ci_shared_app}
       "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
     if (ZLIB_FOUND)
       torunonly_drcacheoff(windows-zlib ${ci_shared_app}
         "-raw_compress zlib -no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
-        "@-simulator_type@basic_counts" "")
+        "@-tool@basic_counts" "")
       set(tool.drcacheoff.windows-zlib_expectbase "offline-windows-simple")
       torunonly_drcacheoff(windows-gzip ${ci_shared_app}
         "-raw_compress gzip -no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
-        "@-simulator_type@basic_counts" "")
+        "@-tool@basic_counts" "")
       set(tool.drcacheoff.windows-gzip_expectbase "offline-windows-simple")
     endif ()
     # lz4 is on by default so we test no compression here.
     torunonly_drcacheoff(windows-none ${ci_shared_app}
       "-raw_compress none -no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
     set(tool.drcacheoff.windows-none_expectbase "offline-windows-simple")
     # Ensure the invariant checker handles window transitions.
     torunonly_drcacheoff(windows-invar ${ci_shared_app}
       "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K"
-      "@-simulator_type@invariant_checker" "")
+      "@-tool@invariant_checker" "")
     if (X86 AND X64 AND UNIX)
       torunonly_drcacheoff(windows-asm allasm_repstr
         "-no_split_windows -trace_after_instrs 3 -trace_for_instrs 4 -retrace_every_instrs 4"
-        "@-simulator_type@basic_counts" "")
+        "@-tool@basic_counts" "")
     endif ()
     # Test split-file windows.
     torunonly_drcacheoff(windows-split ${ci_shared_app}
       "-trace_after_instrs 20K -trace_for_instrs 10K -retrace_every_instrs 30K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
     # The first postcmd did window #0.  There should be at least 2 more windows.
     set(tool.drcacheoff.windows-split_postcmd2
-      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-simulator_type@basic_counts")
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-tool@basic_counts")
     set(tool.drcacheoff.windows-split_postcmd3
-      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-simulator_type@basic_counts")
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
 
     # Test L0_filter_until_instrs
     torunonly_drcacheoff(L0-filter-until-instrs-windows-split ${ci_shared_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -trace_for_instrs 10K -retrace_every_instrs 10K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
     # The first postcmd did window #0.  There should be at least 2 more windows.
     set(tool.drcacheoff.L0-filter-until-instrs-windows-split_postcmd2
-      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-simulator_type@basic_counts")
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-tool@basic_counts")
     set(tool.drcacheoff.L0-filter-until-instrs-windows-split_postcmd3
-      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-simulator_type@basic_counts")
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
 
     torunonly_drcacheoff(L0-filter-until-instrs-2 ${ci_shared_app}
         "-trace_after_instrs 10 -L0_filter_until_instrs 10K -trace_for_instrs 10K -retrace_every_instrs 10K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
 
     torunonly_drcacheoff(L0-filter-until-instrs-exit-after ${ci_shared_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -exit_after_tracing 10K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
 
     torunonly_drcacheoff(L0-filter-until-instrs-max-refs ${ci_shared_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -max_global_trace_refs 10K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
 
     torunonly_drcacheoff(L0-filter-until-instrs-max-trace-size ${ci_shared_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -max_trace_size 10K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
 
     # pthreads not available with MSVC
     if (NOT MSVC)
@@ -4198,30 +4198,30 @@ if (BUILD_CLIENTS)
     # pthreads tests
     torunonly_drcacheoff(warmup-pthreads-windows-split ${ci_pthreads_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 100K -trace_for_instrs 10K -retrace_every_instrs 10K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
     # The first postcmd did window #0.  There should be at least 2 more windows.
     set(tool.drcacheoff.warmup-pthreads-windows-split_postcmd2
-      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-simulator_type@basic_counts")
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-tool@basic_counts")
     set(tool.drcacheoff.warmup-pthreads-windows-split_postcmd3
-      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-simulator_type@basic_counts")
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
 
     torunonly_drcacheoff(warmup-pthreads-2 ${ci_pthreads_app}
         "-trace_after_instrs 10 -L0_filter_until_instrs 10K -trace_for_instrs 10K -retrace_every_instrs 10K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
 
     torunonly_drcacheoff(warmup-pthreads-max-refs ${ci_pthreads_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -max_global_trace_refs 300K"
-      "@-simulator_type@basic_counts" "20000")
+      "@-tool@basic_counts" "20000")
 
     torunonly_drcacheoff(warmup-pthreads-max-trace-size ${ci_pthreads_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -max_trace_size 100K"
-      "@-simulator_type@basic_counts" "")
+      "@-tool@basic_counts" "")
     endif ()
 
 
     # __builtin_prefetch used in the test is not defined on MSVC.
     if (NOT MSVC)
-      torunonly_drcacheoff(builtin-prefetch-basic-counts builtin_prefetch "" "@-simulator_type@basic_counts" "")
+      torunonly_drcacheoff(builtin-prefetch-basic-counts builtin_prefetch "" "@-tool@basic_counts" "")
       unset(tool.drcacheoff.builtin-prefetch-basic-counts_rawtemp) # use preprocessor
     endif ()
 
@@ -4232,14 +4232,14 @@ if (BUILD_CLIENTS)
       torunonly_api(tool.drcacheoff.skip "${drcachesim_path}" "offline-skip" ""
         # Test invariants with global headers after skipping instrs.
         # Here the skip does not find real headers and we expect synthetic.
-        "-simulator_type;view;-infile;${zip_path};${test_mode_flag};-skip_instrs;62;-sim_refs;10"
+        "-tool;view;-infile;${zip_path};${test_mode_flag};-skip_instrs;62;-sim_refs;10"
         OFF OFF)
       set(tool.drcacheoff.skip_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.skip_rawtemp ON) # no preprocessor
       torunonly_api(tool.drcacheoff.skip2 "${drcachesim_path}" "offline-skip2" ""
         # Test invariants with global headers after skipping instrs.
         # Here the skip finds real headers and we expect no synthetic.
-        "-simulator_type;view;-infile;${zip_path};${test_mode_flag};-skip_instrs;63;-sim_refs;10"
+        "-tool;view;-infile;${zip_path};${test_mode_flag};-skip_instrs;63;-sim_refs;10"
         OFF OFF)
       set(tool.drcacheoff.skip2_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.skip2_rawtemp ON) # no preprocessor
@@ -4261,23 +4261,23 @@ if (BUILD_CLIENTS)
       # kernel transfer events.
       set(tool.drcacheoff.basic_counts_full_run ON)
       torunonly_drcacheoff(basic_counts common.decode-bad ""
-        "@-simulator_type@basic_counts" "")
+        "@-tool@basic_counts" "")
       unset(tool.drcacheoff.basic_counts_rawtemp)
     endif ()
     if (NOT RISCV64)
       # TODO i#3544: Port tests to RISC-V 64
       torunonly_drcacheoff(opcode_mix ${ci_shared_app} ""
-        "@-simulator_type@opcode_mix" "")
+        "@-tool@opcode_mix" "")
       # Ensure the tool works without the raw/ subdir.
       set(tool.drcacheoff.opcode_mix_postcmd
         "firstglob@${drraw2trace_path}@-indir@${dir_prefix}.*.dir")
       set(tool.drcacheoff.opcode_mix_postcmd2
         "foreach@${CMAKE_COMMAND}@-E@remove_directory@${dir_prefix}.*.dir/raw")
       set(tool.drcacheoff.opcode_mix_postcmd3
-        "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir@-simulator_type@opcode_mix")
+        "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir@-tool@opcode_mix")
 
       torunonly_drcacheoff(view ${ci_shared_app} ""
-        "@-simulator_type@view@-sim_refs@16384" "")
+        "@-tool@view@-sim_refs@16384" "")
       unset(tool.drcacheoff.view_rawtemp) # Use preprocessor
       if (AARCH64 AND proc_supports_sve)
         set(tool.drcacheoff.view_runsve 1)
@@ -4285,11 +4285,11 @@ if (BUILD_CLIENTS)
 
       set(tool.drcacheoff.func_view_full_run ON) # Fails on Windows if truncated.
       torunonly_drcacheoff(func_view common.fib "-record_function fib|1"
-        "@-simulator_type@func_view" "only_5")
+        "@-tool@func_view" "only_5")
     endif (NOT RISCV64)
     if (DR_HOST_X86 AND DR_HOST_X64 AND LINUX)
       torunonly_drcacheoff(opcode_categories allasm_x86_64 ""
-        "@-simulator_type@opcode_mix" "")
+        "@-tool@opcode_mix" "")
 
       # Requires sudo to access pagemap.
       # XXX: Should we not enable this outside of the Github suite where we know
@@ -4298,11 +4298,11 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.phys_SUDO_sudo ON)
       set(tool.drcacheoff.phys_SUDO_expectbase "offline-phys")
       torunonly_drcacheoff(phys_SUDO allasm_repstr
-        "-use_physical" "@${test_mode_flag}@-simulator_type@view" "")
+        "-use_physical" "@${test_mode_flag}@-tool@view" "")
       set(tool.drcacheoff.phys_nopriv_failok ON)
       set(tool.drcacheoff.phys_nopriv_nopost ON)
       torunonly_drcacheoff(phys_nopriv allasm_x86_64
-        "-use_physical" "@${test_mode_flag}@-simulator_type@view" "")
+        "-use_physical" "@${test_mode_flag}@-tool@view" "")
     endif ()
 
     if (UNIX AND ZLIB_FOUND)
@@ -4312,18 +4312,18 @@ if (BUILD_CLIENTS)
       # We could run this like so, but with threads the output is non-deterministic:
       #    torunonly_drcacheoff(func_view_noret tool.fib_plus
       #      "-record_function fib|1&noret_func|2|noret&noargs|0"
-      #      "@-simulator_type@func_view" "")
+      #      "@-tool@func_view" "")
       # Thus we run this manually and check in the resulting trace.  I ran with
       # a delay to shrink the size, since we are not interesting in the main thread's
       # pre-main() init:
       #     $ bin64/drrun -t drcachesim -offline -trace_after_instrs 210K \
       #       -record_function 'fib|1&noret_func|2|noret&noargs|0' -- \
       #       suite/tests/bin/tool.fib_plus
-      #     $ bin64/drrun -t drcachesim -simulator_type func_view -indir \
+      #     $ bin64/drrun -t drcachesim -tool func_view -indir \
       #       drmemtrace*.dir/
       torunonly_api(tool.drcacheoff.func_view_noret "${drcachesim_path}"
         "offline-func_view_noret.c" ""
-        "-indir;${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/offline-func-trace;-simulator_type;func_view"
+        "-indir;${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/offline-func-trace;-tool;func_view"
         OFF OFF)
       set(tool.drcacheoff.func_view_noret_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -4346,7 +4346,7 @@ if (BUILD_CLIENTS)
           COMPILE_FLAGS "${ORIG_CMAKE_CXX_FLAGS} -std=c++17 -Wno-unused-function")
       endif ()
       torunonly_drcacheoff(func_view_heap tool.heap_test
-        "-record_heap" "@-simulator_type@func_view@-no_show_func_trace" "")
+        "-record_heap" "@-tool@func_view@-no_show_func_trace" "")
       unset(tool.drcacheoff.func_view_heap_rawtemp) # use preprocessor
     endif ()
 
@@ -4370,7 +4370,7 @@ if (BUILD_CLIENTS)
     if (AARCH64)
       set(tool.drcacheoff.burst_aarch64_sys_nodr ON)
       torunonly_drcacheoff(burst_aarch64_sys tool.drcacheoff.burst_aarch64_sys ""
-        "@-simulator_type@basic_counts" "")
+        "@-tool@basic_counts" "")
     endif ()
 
     if (NOT APPLE AND NOT RISCV64) # XXX i#1997: static DR not fully supported on Mac yet
@@ -4392,12 +4392,12 @@ if (BUILD_CLIENTS)
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/scheduler")
       set(tool.drcacheoff.gencode_nodr ON)
       torunonly_drcacheoff(gencode tool.drcacheoff.gencode
-        "" "@-simulator_type@opcode_mix" "")
+        "" "@-tool@opcode_mix" "")
       unset(tool.drcacheoff.gencode_rawtemp) # Use preprocessor on template.
 
       set(tool.drcacheoff.gencode_filtered_nodr ON)
       torunonly_drcacheoff(gencode_filtered tool.drcacheoff.gencode
-        "" "@-simulator_type@opcode_mix"
+        "" "@-tool@opcode_mix"
         "-L0_filter -subdir_prefix drmemtrace.tool.drcacheoff.gencode_filtered")
 
       # TODO i#6474, i#2062: Add a similar gencode test with
@@ -4417,7 +4417,7 @@ if (BUILD_CLIENTS)
 
       set(tool.drcacheoff.burst_replaceall_nodr ON)
       torunonly_drcacheoff(burst_replaceall tool.drcacheoff.burst_replaceall ""
-        "@-simulator_type@basic_counts" "")
+        "@-tool@basic_counts" "")
       unset(tool.drcacheoff.burst_replaceall_rawtemp) # use preprocessor
 
       if (X64 AND UNIX)
@@ -4431,7 +4431,7 @@ if (BUILD_CLIENTS)
       if (LINUX)
         set(tool.drcacheoff.burst_syscall_inject_nodr ON)
         torunonly_drcacheoff(burst_syscall_inject tool.drcacheoff.burst_syscall_inject ""
-          "@-simulator_type@invariant_checker@-syscall_template_file@drmemtrace.tool.drcacheoff.burst_syscall_inject.*.dir/raw/syscall_trace_template"
+          "@-tool@invariant_checker@-syscall_template_file@drmemtrace.tool.drcacheoff.burst_syscall_inject.*.dir/raw/syscall_trace_template"
           "")
       endif ()
 
@@ -4459,26 +4459,26 @@ if (BUILD_CLIENTS)
 
         set(tool.drcacheoff.burst_threads_counts_nodr ON)
         torunonly_drcacheoff(burst_threads_counts tool.drcacheoff.burst_threads
-          "" "@-simulator_type@basic_counts"
+          "" "@-tool@basic_counts"
           # This test uses the same app as the one above, so set a new dir name.
           "-subdir_prefix drmemtrace.tool.drcacheoff.burst_threads_counts")
 
         set(tool.drcacheoff.burst_malloc_nodr ON)
         torunonly_drcacheoff(burst_malloc tool.drcacheoff.burst_malloc
-          "" "@-simulator_type@basic_counts" "")
+          "" "@-tool@basic_counts" "")
 
         set(tool.drcacheoff.burst_reattach_nodr ON)
         torunonly_drcacheoff(burst_reattach tool.drcacheoff.burst_reattach
-          "" "@-simulator_type@basic_counts" "")
+          "" "@-tool@basic_counts" "")
 
         set(tool.drcacheoff.burst_threadfilter_nodr ON)
         torunonly_drcacheoff(burst_threadfilter tool.drcacheoff.burst_threadfilter
-          "" "@-simulator_type@basic_counts" "")
+          "" "@-tool@basic_counts" "")
         # This test uses the same app as the one above, so we do not set _nodr
         # so we'll get a custom -subdir_prefix.  We have to pass that in as an
         # app arg here.
         torunonly_drcacheoff(burst_threadL0filter tool.drcacheoff.burst_threadfilter
-          "" "@-simulator_type@basic_counts"
+          "" "@-tool@basic_counts"
           "-L0_filter -L0I_size 0 -subdir_prefix tool.drcacheoff.burst_threadL0filter")
         set(tool.drcacheoff.burst_threadL0filter_nodr ON)
 
@@ -4517,7 +4517,7 @@ if (BUILD_CLIENTS)
 
     if (UNIX AND ((X86 AND X64 AND proc_supports_avx) OR (AARCH64 AND proc_supports_sve)))
       torunonly_drcacheoff(allasm-scattergather-basic-counts allasm_scattergather
-        "" "@-simulator_type@basic_counts" "")
+        "" "@-tool@basic_counts" "")
       unset(tool.drcacheoff.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
       if (X86 AND proc_supports_avx512)
         set(tool.drcacheoff.allasm-scattergather-basic-counts_runavx512 1)
@@ -4532,7 +4532,7 @@ if (BUILD_CLIENTS)
         "offline-allasm-scattergather-basic-counts-${ARCH_NAME}")
 
       torunonly_drcachesim(allasm-scattergather-basic-counts allasm_scattergather
-        "-simulator_type basic_counts" "")
+        "-tool basic_counts" "")
       unset(tool.drcachesim.allasm-scattergather-basic-counts_rawtemp) # use preprocessor
       if (X86 AND proc_supports_avx512)
         set(tool.drcachesim.allasm-scattergather-basic-counts_runavx512 1)
@@ -4549,14 +4549,14 @@ if (BUILD_CLIENTS)
 
     if (UNIX AND AARCH64 AND proc_supports_sve)
       torunonly_drcacheoff(allasm-scattergather-vl-view allasm_scattergather
-        "" "@-simulator_type@view" "")
+        "" "@-tool@view" "")
       unset(tool.drcacheoff.allasm-scattergather-vl-view_rawtemp) # use preprocessor
       set(tool.drcacheoff.allasm-scattergather-vl-view_runsve 1)
       set(tool.drcacheoff.allasm-scattergather-vl-view_expectbase
         "offline-allasm-scattergather-vl-view-${ARCH_NAME}")
 
       torunonly_drcachesim(allasm-scattergather-vl-view allasm_scattergather
-        "-simulator_type view" "")
+        "-tool view" "")
       unset(tool.drcachesim.allasm-scattergather-vl-view_rawtemp) # use preprocessor
       set(tool.drcachesim.allasm-scattergather-vl-view_runsve 1)
       set(tool.drcachesim.allasm-scattergather-vl-view_expectbase
@@ -4565,26 +4565,26 @@ if (BUILD_CLIENTS)
 
     if (UNIX AND X86 AND X64)
       torunonly_drcacheoff(allasm-repstr-basic-counts allasm_repstr
-        "" "@-simulator_type@basic_counts" "")
+        "" "@-tool@basic_counts" "")
       unset(tool.drcacheoff.allasm-repstr-basic-counts_rawtemp) # use preprocessor
       torunonly_drcachesim(allasm-repstr-basic-counts allasm_repstr
         # We test counting encodings for online.
-        "-instr_encodings -simulator_type basic_counts" "")
+        "-instr_encodings -tool basic_counts" "")
       unset(tool.drcachesim.allasm-repstr-basic-counts_rawtemp) # use preprocessor
 
       # Test -record_syscall on SYS_write == #1 with 3 args.
       torunonly_drcacheoff(allasm-record-syscall allasm_repstr
-        "-record_syscall 1|3" "@-simulator_type@view" "")
+        "-record_syscall 1|3" "@-tool@view" "")
     endif (UNIX AND X86 AND X64)
 
     torunonly_drcacheoff(invariant_checker ${ci_shared_app}
       # We pass a small instr count to test multiple chunks in a zipfile.
-      "" "@-chunk_instr_count@1000@-simulator_type@invariant_checker" "")
+      "" "@-chunk_instr_count@1000@-tool@invariant_checker" "")
 
     # pthreads not available with MSVC
     if (NOT MSVC)
       torunonly_drcacheoff(invariant_checker_pthreads ${ci_pthreads_app}
-        "" "@-simulator_type@invariant_checker" "")
+        "" "@-tool@invariant_checker" "")
     endif ()
 
     # Test the standalone histogram tool.
@@ -4644,13 +4644,13 @@ if (BUILD_CLIENTS)
       # Post-process the trace and sanity check it.
       # Use a smaller chunk threshold to test multiple chunks.
       set(${testname}_postcmd
-        "${drcachesim_path}@-chunk_instr_count@1000@-indir@${testname}.*.dir@-simulator_type@invariant_checker")
+        "${drcachesim_path}@-chunk_instr_count@1000@-indir@${testname}.*.dir@-tool@invariant_checker")
       # Run the record filter tool with a null filter.
       set(${testname}_postcmd2 "${CMAKE_COMMAND}@-E@make_directory@${outdir}")
       set(${testname}_postcmd3 ${launch_cmd})
       # Run the analyzer on the result.
       set(${testname}_postcmd4
-        "${drcachesim_path}@-indir@${outdir}@-simulator_type@${analyzer}")
+        "${drcachesim_path}@-indir@${outdir}@-tool@${analyzer}")
     endmacro ()
 
     set(testname "tool.record_filter")
@@ -4668,7 +4668,7 @@ if (BUILD_CLIENTS)
       "record_filter_bycore_uni"
       # We assume the app name starts with "s" here to avoid colliding with
       # our output dir, while still letting the single precmd remove both.
-      "${drcachesim_path}@-simulator_type@record_filter@-indir@${testname}.s*.dir/trace@-core_sharded@-cores@4@-outdir@${testname}.filtered.dir"
+      "${drcachesim_path}@-tool@record_filter@-indir@${testname}.s*.dir/trace@-core_sharded@-cores@4@-outdir@${testname}.filtered.dir"
       # We run opcode_mix to test encodings.
       # XXX i#6684: Once we have invariant_checker support, run it here (and ensure
       # it checks encodings).
@@ -4680,7 +4680,7 @@ if (BUILD_CLIENTS)
         "record_filter_bycore_multi"
         # We use the app name start char "p" here to avoid colliding with
         # our output dir, while still letting the single precmd remove both.
-        "${drcachesim_path}@-simulator_type@record_filter@-indir@${testname}.p*.dir/trace@-core_sharded@-cores@3@-outdir@${testname}.filtered.dir"
+        "${drcachesim_path}@-tool@record_filter@-indir@${testname}.p*.dir/trace@-core_sharded@-cores@3@-outdir@${testname}.filtered.dir"
         "schedule_stats")
     endif ()
 
@@ -4695,12 +4695,12 @@ if (BUILD_CLIENTS)
       file(MAKE_DIRECTORY ${srcdir})
       file(COPY ${zip_path} DESTINATION ${srcdir})
       torunonly_api(tool.drcacheoff.trim "${drcachesim_path}" "offline-trim" ""
-        "-simulator_type;view;-indir;${outdir};${test_mode_flag}"
+        "-tool;view;-indir;${outdir};${test_mode_flag}"
         OFF OFF)
       set(tool.drcacheoff.trim_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
       # The filter overwrites any existing file in the dir from a prior run.
       set(tool.drcacheoff.trim_precmd
-        "${drcachesim_path}@-simulator_type@record_filter@-trim_before_timestamp@13352268558646120@-trim_after_timestamp@13352268558646661@-indir@${srcdir}@-outdir@${outdir}")
+        "${drcachesim_path}@-tool@record_filter@-trim_before_timestamp@13352268558646120@-trim_after_timestamp@13352268558646661@-indir@${srcdir}@-outdir@${outdir}")
       set(tool.drcacheoff.trim_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.trim_rawtemp ON) # no preprocessor
 
@@ -4712,10 +4712,10 @@ if (BUILD_CLIENTS)
       file(MAKE_DIRECTORY ${outdir})
       torunonly_api(tool.record_filter_as_traced "${drcachesim_path}"
         "record_filter_as_traced"
-        "" "-simulator_type;schedule_stats;-indir;${outdir}" OFF OFF)
+        "" "-tool;schedule_stats;-indir;${outdir}" OFF OFF)
       set(tool.record_filter_as_traced_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
       set(tool.record_filter_as_traced_precmd
-        "${drcachesim_path}@-simulator_type@record_filter@-cpu_schedule_file@${sched_file}@-core_sharded@-cores@7@-indir@${trace_dir}@-outdir@${outdir}")
+        "${drcachesim_path}@-tool@record_filter@-cpu_schedule_file@${sched_file}@-core_sharded@-cores@7@-indir@${trace_dir}@-outdir@${outdir}")
       set(tool.record_filter_as_traced_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.record_filter_as_traced_rawtemp ON) # no preprocessor
@@ -4729,10 +4729,10 @@ if (BUILD_CLIENTS)
       file(MAKE_DIRECTORY ${outdir})
       torunonly_api(tool.record_filter_start_idle "${drcachesim_path}"
         "record_filter_start_idle"
-        "" "-simulator_type;schedule_stats;-indir;${outdir}" OFF OFF)
+        "" "-tool;schedule_stats;-indir;${outdir}" OFF OFF)
       set(tool.record_filter_start_idle_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
       set(tool.record_filter_start_idle_precmd
-        "${drcachesim_path}@-simulator_type@record_filter@-cpu_schedule_file@${sched_file}@-core_sharded@-cores@4@-indir@${trace_dir}@-outdir@${outdir}")
+        "${drcachesim_path}@-tool@record_filter@-cpu_schedule_file@${sched_file}@-core_sharded@-cores@4@-indir@${trace_dir}@-outdir@${outdir}")
       set(tool.record_filter_start_idle_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.record_filter_start_idle_rawtemp ON) # no preprocessor
@@ -4755,7 +4755,7 @@ if (BUILD_CLIENTS)
       set(${testname_full}_precmd
         "foreach@${CMAKE_COMMAND}@-E@remove_directory@${testname_full}.*.dir")
       set(${testname_full}_postcmd
-        "${drcachesim_path}@-indir@${testname_full}.*.dir@-simulator_type@basic_counts")
+        "${drcachesim_path}@-indir@${testname_full}.*.dir@-tool@basic_counts")
       set(${testname_full}_postcmd2
         "${prefetch_analyzer_path}@-trace_dir@${testname_full}.*.dir/trace")
     endif ()
@@ -4771,12 +4771,12 @@ if (BUILD_CLIENTS)
         "-trace_after_instrs 20000 -enable_drstatecmp" "")
       torunonly_drcacheoff(drstatecmp-delay-simple ${ci_shared_app}
         "-trace_after_instrs 20000 -enable_drstatecmp"
-        "@-simulator_type@basic_counts" "")
+        "@-tool@basic_counts" "")
     endif (NOT WIN32)
 
     # Test syscall_mix.
-    torunonly_drcachesim(syscall-mix ${ci_shared_app} "-simulator_type syscall_mix" "")
-    torunonly_drcacheoff(syscall-mix ${ci_shared_app} "" "@-simulator_type@syscall_mix" "")
+    torunonly_drcachesim(syscall-mix ${ci_shared_app} "-tool syscall_mix" "")
+    torunonly_drcacheoff(syscall-mix ${ci_shared_app} "" "@-tool@syscall_mix" "")
 
   endif (NOT ANDROID)
 
@@ -4814,7 +4814,7 @@ if (BUILD_CLIENTS)
     file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
     torunonly_api(tool.drcacheoff.altbindir "${drcachesim_path}"
       "offline-altbindir.c" ""
-      "-indir;${locdir};-simulator_type;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
+      "-indir;${locdir};-tool;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
       OFF OFF)
     set(tool.drcacheoff.altbindir_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -4830,7 +4830,7 @@ if (BUILD_CLIENTS)
     file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
     torunonly_api(tool.drcacheoff.legacy-int-offs "${drcachesim_path}"
       "offline-legacy-int-offs.c" ""
-      "-indir;${locdir};-simulator_type;basic_counts;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
+      "-indir;${locdir};-tool;basic_counts;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
       OFF OFF)
     set(tool.drcacheoff.legacy-int-offs_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -4863,20 +4863,20 @@ if (BUILD_CLIENTS)
       # dr_allow_unsafe_static_behavior. We want to perform this check on the kernel
       # tracing flow.
       torunonly_drcacheoff_kernel(simple ${ci_shared_app} "-raw_compress none" ""
-                                  "@-simulator_type@basic_counts")
+                                  "@-tool@basic_counts")
       torunonly_drcacheoff_kernel(opcode-mix ${ci_shared_app} "-raw_compress none" ""
-                                  "@-simulator_type@opcode_mix")
+                                  "@-tool@opcode_mix")
       torunonly_drcacheoff_kernel(syscall-mix ${ci_shared_app} "-raw_compress none" ""
-                                  "@-simulator_type@syscall_mix")
+                                  "@-tool@syscall_mix")
       torunonly_drcacheoff_kernel(invariant-checker ${ci_shared_app} "-raw_compress none" ""
-                                  "@-simulator_type@invariant_checker@-test_mode_name@kernel_syscall_pt_trace")
+                                  "@-tool@invariant_checker@-test_mode_name@kernel_syscall_pt_trace")
     endif (BUILD_PT_TRACER AND BUILD_PT_POST_PROCESSOR)
   endif (proc_supports_pt)
 
   if ((AARCHXX AND NOT ANDROID) OR X86)
     torunonly_drcacheoff(getretaddr_record_replace_retaddr common.getretaddr
             "-record_replace_retaddr -record_function tailcall_with_retaddr|1&foo|1"
-            "@-simulator_type@invariant_checker" "")
+            "@-tool@invariant_checker" "")
   endif ()
 
   ###########################################################################


### PR DESCRIPTION
Adds -tool as the preferred alias for the -simulator_type option for the drmemtrace/drcachesim framework.  This is long overdue as many analysis tools are not "simulators" and the original option was solely to pick between cache and TLB simulators.

Updates all uses in tests and documentation.

Adds a release note.

Changes the preferred cache and TLB simulator tool names to have _simulator suffixes.  Adds a "drcachesim" alias for the cache simulator as well.

Manually tested the "cache" and "drcachesim" aliases.

Issue: #6660