### PR TITLE
i#3544 RV64: Optimize private memcpy and memset

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1149,7 +1149,7 @@ if (BUILD_TESTS AND
       append_property_string(TARGET unit_tests LINK_FLAGS "-Wl,${ld_entry_flag},_start")
     endif ()
     if (NOT ANDROID) # everything is inside Bionic on Android
-      target_link_libraries(unit_tests c dl m pthread)
+      target_link_libraries(unit_tests dl m pthread)
     endif ()
     set_preferred_base_start_and_end(unit_tests ${preferred_base} ON)
   else (UNIX)
@@ -1159,6 +1159,7 @@ if (BUILD_TESTS AND
       LINK_FLAGS "/base:${preferred_base} ${LD_FLAGS}")
   endif (UNIX)
   target_link_libraries(unit_tests drlibc)
+  target_link_libraries(unit_tests drmemfuncs)
   get_target_path_for_execution(unit_relpath unit_tests "${location_suffix}")
   prefix_cmd_if_necessary(unit_relpath OFF ${unit_relpath})
   add_test(unit_tests ${unit_relpath})

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1151,6 +1151,7 @@ if (BUILD_TESTS AND
     if (NOT ANDROID) # everything is inside Bionic on Android
       target_link_libraries(unit_tests dl m pthread)
     endif ()
+    target_link_libraries(unit_tests drmemfuncs)
     set_preferred_base_start_and_end(unit_tests ${preferred_base} ON)
   else (UNIX)
     # Just like drinjectlib (see above) we need libc before ntdll
@@ -1159,7 +1160,6 @@ if (BUILD_TESTS AND
       LINK_FLAGS "/base:${preferred_base} ${LD_FLAGS}")
   endif (UNIX)
   target_link_libraries(unit_tests drlibc)
-  target_link_libraries(unit_tests drmemfuncs)
   get_target_path_for_execution(unit_relpath unit_tests "${location_suffix}")
   prefix_cmd_if_necessary(unit_relpath OFF ${unit_relpath})
   add_test(unit_tests ${unit_relpath})

--- a/core/arch/riscv64/memfuncs.asm
+++ b/core/arch/riscv64/memfuncs.asm
@@ -139,7 +139,7 @@ GLOBAL_LABEL(memset:)
         li       t6, 32
         mv       t0, ARG1 /* Save for return. */
 
-        /* Duplicate a single byte into whole 4 bytes register. */
+        /* Duplicate a single byte into whole 8 bytes register. */
         andi     ARG2, ARG2, 0xff
         mv       t1, ARG2
         slli     ARG2, ARG2, 8

--- a/core/arch/riscv64/memfuncs.asm
+++ b/core/arch/riscv64/memfuncs.asm
@@ -40,14 +40,21 @@
 START_FILE
 #ifdef UNIX
 
+
 /* Private memcpy.
+ * Optimize private memcpy by using loop unrolling.
  */
         DECLARE_FUNC(memcpy)
 GLOBAL_LABEL(memcpy:)
-        addi     a5, x0, 32
-        mv       t0, ARG2 /* save for return */
-copy32_:
-        blt      ARG3, a5, copy0_32
+        addi     t6, x0, 32
+        mv       t0, ARG2 /* Save dst for return */
+copy32_: 
+        /* When size is greater than 32, we use 4 ld/sd pairs 
+         * to copy 4*8=32 bytes in each iteration. 
+         * When size is less than 32, we jump to copy_remain and 
+         * use other optimized copy methods.
+         */
+        blt      ARG3, t6, copy_remain
         ld       t1, 0(ARG2)
         ld       t2, 8(ARG2)
         ld       t3, 16(ARG2)
@@ -60,16 +67,25 @@ copy32_:
         addi     ARG1, ARG1, 32
         addi     ARG2, ARG2, 32
         j        copy32_
-copy0_32:
-        add      a6, ARG2, ARG3 /* a6 = src_end */
-        add      a7, ARG1, ARG3 /* a7 = dst_end */
-        addi     a5, x0, 8
-        bge      ARG3, a5, copy8_32
-        addi     a5, x0, 4
-        bge      ARG3, a5, copy4_8
+
+copy_remain:
+        add      a6, ARG2, ARG3 /* a6 = src + size */
+        add      a7, ARG1, ARG3 /* a7 = dst + size */
+        addi     t6, x0, 8
+        bge      ARG3, t6, copy8_32
+        addi     t6, x0, 4
+        bge      ARG3, t6, copy4_8
         bgtz     ARG3, copy0_4
         j        copyexit
+
 copy0_4:
+        /* 0 < size < 4:
+         * Using a trick to avoid branches.
+         * t2 and t3 may be redundant.
+         * size = 1: t1 = src[0], t2 = src[0], t3 = src[0]
+         * size = 2: t1 = src[0], t2 = src[1], t3 = src[1]
+         * size = 3: t1 = src[0], t2 = src[1], t3 = src[2]
+         */
         srli     t4, ARG3, 1
         add      t5, t4, ARG1
         add      t4, t4, ARG2
@@ -80,35 +96,57 @@ copy0_4:
         sb       t2, -1(a7)
         sb       t3, 0(t5)
         j        copyexit
+
 copy4_8:
+        /* 4 < size < 8:
+         * Step1: Use lwu/sw pair to copy src[0]~src[3] to dst[0]~dst[3].
+         * Step2: Copy src[size-4]~src[size-1] to dst[size-4]~dst[size-1].
+         * Some overlap here, but the overhead is negligible.
+         */
         lwu      t1, 0(ARG2)
         lwu      t2, -4(a6)
         sw       t1, 0(ARG1)
         sw       t2, -4(a7)
         j        copyexit
+        
 copy8_32:
+        /* 8 < size < 32: */
+
+        /* Copy src[0]~src[7] and src[size-8]~size[size-1].
+         * Some overlap here, but the overhead is negligible.
+         */
         ld       t1, 0(ARG2)
         ld       t2, -8(a6)
         sd       t1, 0(ARG1)
         sd       t2, -8(a7)
-        addi     a5, x0, 16
-        ble      ARG3, a5, copyexit
+
+        /* If size > 16, src[8]~src[size-9] has not been copied. 
+         * Copy src[8]~src[15] with ld/sd pair.
+         */
+        addi     t6, x0, 16
+        ble      ARG3, t6, copyexit
         ld       t1, 8(ARG2)
         sd       t1, 8(ARG1)
-        addi     a5, x0, 24
-        ble      ARG3, a5, copyexit
+
+        /* If size > 24, src[16]~src[size-9] has not been copied. 
+         * Copy src[16]~src[23] with ld/sd pair.
+         */
+        addi     t6, x0, 24
+        ble      ARG3, t6, copyexit
         ld       t1, 16(ARG2)
         sd       t1, 16(ARG1)
 copyexit:
-        mv       a0, t0
+        mv       a0, t0 /* Restore original dst as return value */
         ret
         END_FUNC(memcpy)
 
 /* Private memset.
+ * Optimize private memset by using loop unrolling.
+ * Optimization method is same as memcpy.
  */
         DECLARE_FUNC(memset)
 GLOBAL_LABEL(memset:)
-        addi     a5, x0, 32
+        addi     t6, x0, 32
         mv       t0, ARG1 /* save for return */
 
         /* duplicate byte into whole register */
@@ -129,7 +167,7 @@ GLOBAL_LABEL(memset:)
         slli     ARG2, ARG2, 8
         or       t1, t1, ARG2
 set32_:
-        blt      ARG3, a5, set0_32
+        blt      ARG3, t6, set0_32
         sd       t1, 0(ARG1)
         sd       t1, 8(ARG1)
         sd       t1, 16(ARG1)
@@ -139,10 +177,10 @@ set32_:
         j        set32_
 set0_32:
         add      a6, ARG1, ARG3
-        addi     a5, x0, 8
-        bge      ARG3, a5, set8_32
-        addi     a5, x0, 4
-        bge      ARG3, a5, set4_8
+        addi     t6, x0, 8
+        bge      ARG3, t6, set8_32
+        addi     t6, x0, 4
+        bge      ARG3, t6, set4_8
         bgtz     ARG3, set0_4
         j        setexit
 set0_4:
@@ -159,14 +197,14 @@ set4_8:
 set8_32:
         sd       t1, 0(ARG1)
         sd       t1, -8(a6)
-        addi     a5, x0, 16
-        ble      ARG3, a5, setexit
+        addi     t6, x0, 16
+        ble      ARG3, t6, setexit
         sd       t1, 8(ARG1)
-        addi     a5, x0, 24
-        ble      ARG3, a5, setexit
+        addi     t6, x0, 24
+        ble      ARG3, t6, setexit
         sd       t1, 16(ARG1)
 setexit:
-        mv       a0, t0
+        mv       a0, t0 /* Restore original dst as return value */
         ret
         END_FUNC(memset)
 

--- a/core/arch/riscv64/memfuncs.asm
+++ b/core/arch/riscv64/memfuncs.asm
@@ -48,10 +48,10 @@ START_FILE
 GLOBAL_LABEL(memcpy:)
         addi     t6, x0, 32
         mv       t0, ARG2 /* Save dst for return */
-copy32_: 
-        /* When size is greater than 32, we use 4 ld/sd pairs 
-         * to copy 4*8=32 bytes in each iteration. 
-         * When size is less than 32, we jump to copy_remain and 
+copy32_:
+        /* When size is greater than 32, we use 4 ld/sd pairs
+         * to copy 4*8=32 bytes in each iteration.
+         * When size is less than 32, we jump to copy_remain and
          * use other optimized copy methods.
          */
         blt      ARG3, t6, copy_remain
@@ -67,7 +67,6 @@ copy32_:
         addi     ARG1, ARG1, 32
         addi     ARG2, ARG2, 32
         j        copy32_
-
 copy_remain:
         add      a6, ARG2, ARG3 /* a6 = src + size */
         add      a7, ARG1, ARG3 /* a7 = dst + size */
@@ -77,7 +76,6 @@ copy_remain:
         bge      ARG3, t6, copy4_8
         bgtz     ARG3, copy0_4
         j        copyexit
-
 copy0_4:
         /* 0 < size < 4:
          * Using a trick to avoid branches.
@@ -96,7 +94,6 @@ copy0_4:
         sb       t2, -1(a7)
         sb       t3, 0(t5)
         j        copyexit
-
 copy4_8:
         /* 4 < size < 8:
          * Step1: Use lwu/sw pair to copy src[0]~src[3] to dst[0]~dst[3].
@@ -108,10 +105,8 @@ copy4_8:
         sw       t1, 0(ARG1)
         sw       t2, -4(a7)
         j        copyexit
-        
 copy8_32:
         /* 8 < size < 32: */
-
         /* Copy src[0]~src[7] and src[size-8]~size[size-1].
          * Some overlap here, but the overhead is negligible.
          */
@@ -119,16 +114,14 @@ copy8_32:
         ld       t2, -8(a6)
         sd       t1, 0(ARG1)
         sd       t2, -8(a7)
-
-        /* If size > 16, src[8]~src[size-9] has not been copied. 
+        /* If size > 16, src[8]~src[size-9] has not been copied.
          * Copy src[8]~src[15] with ld/sd pair.
          */
         addi     t6, x0, 16
         ble      ARG3, t6, copyexit
         ld       t1, 8(ARG2)
         sd       t1, 8(ARG1)
-
-        /* If size > 24, src[16]~src[size-9] has not been copied. 
+        /* If size > 24, src[16]~src[size-9] has not been copied.
          * Copy src[16]~src[23] with ld/sd pair.
          */
         addi     t6, x0, 24

--- a/core/arch/riscv64/memfuncs.asm
+++ b/core/arch/riscv64/memfuncs.asm
@@ -44,63 +44,63 @@ START_FILE
  */
         DECLARE_FUNC(memcpy)
 GLOBAL_LABEL(memcpy:)
-        addi    a5, x0, 32
-        mv      t0, ARG2 /* save for return */
+        addi     a5, x0, 32
+        mv       t0, ARG2 /* save for return */
 copy32_:
-        blt     ARG3, a5, copy0_32
-        ld      t1, 0(ARG2)
-        ld      t2, 8(ARG2)
-        ld      t3, 16(ARG2)
-        ld      t4, 24(ARG2)
-        sd      t1, 0(ARG1)
-        sd      t2, 8(ARG1)
-        sd      t3, 16(ARG1)
-        sd      t4, 24(ARG1)
-        addi    ARG3, ARG3, -32
-        addi    ARG1, ARG1, 32
-        addi    ARG2, ARG2, 32
-        j       copy32_
+        blt      ARG3, a5, copy0_32
+        ld       t1, 0(ARG2)
+        ld       t2, 8(ARG2)
+        ld       t3, 16(ARG2)
+        ld       t4, 24(ARG2)
+        sd       t1, 0(ARG1)
+        sd       t2, 8(ARG1)
+        sd       t3, 16(ARG1)
+        sd       t4, 24(ARG1)
+        addi     ARG3, ARG3, -32
+        addi     ARG1, ARG1, 32
+        addi     ARG2, ARG2, 32
+        j        copy32_
 copy0_32:
-        add     a6, ARG2, ARG3 /* a6 = src_end */
-        add     a7, ARG1, ARG3 /* a7 = dst_end */
-        addi    a5, x0, 8
-        bge     ARG3, a5, copy8_32
-        addi    a5, x0, 4
-        bge     ARG3, a5, copy4_8
-        bgtz    ARG3, copy0_4
-        j       copyexit
+        add      a6, ARG2, ARG3 /* a6 = src_end */
+        add      a7, ARG1, ARG3 /* a7 = dst_end */
+        addi     a5, x0, 8
+        bge      ARG3, a5, copy8_32
+        addi     a5, x0, 4
+        bge      ARG3, a5, copy4_8
+        bgtz     ARG3, copy0_4
+        j        copyexit
 copy0_4:
-        srli    t4, ARG3, 1
-        add     t5, t4, ARG1
-        add     t4, t4, ARG2
-        lbu     t1, 0(ARG2)
-        lbu     t2, -1(a6)
-        lbu     t3, 0(t4)
-        sb      t1, 0(ARG1)
-        sb      t2, -1(a7)
-        sb      t3, 0(t5)
-        j       copyexit
+        srli     t4, ARG3, 1
+        add      t5, t4, ARG1
+        add      t4, t4, ARG2
+        lbu      t1, 0(ARG2)
+        lbu      t2, -1(a6)
+        lbu      t3, 0(t4)
+        sb       t1, 0(ARG1)
+        sb       t2, -1(a7)
+        sb       t3, 0(t5)
+        j        copyexit
 copy4_8:
-        lwu     t1, 0(ARG2)
-        lwu     t2, -4(a6)
-        sw      t1, 0(ARG1)
-        sw      t2, -4(a7)
-        j       copyexit
+        lwu      t1, 0(ARG2)
+        lwu      t2, -4(a6)
+        sw       t1, 0(ARG1)
+        sw       t2, -4(a7)
+        j        copyexit
 copy8_32:
-        ld      t1, 0(ARG2)
-        ld      t2, -8(a6)
-        sd      t1, 0(ARG1)
-        sd      t2, -8(a7)
-        addi    a5, x0, 16
-        ble     ARG3, a5, copyexit
-        ld      t1, 8(ARG2)
-        sd      t1, 8(ARG1)
-        addi    a5, x0, 24
-        ble     ARG3, a5, copyexit
-        ld      t1, 16(ARG2)
-        sd      t1, 16(ARG1)
+        ld       t1, 0(ARG2)
+        ld       t2, -8(a6)
+        sd       t1, 0(ARG1)
+        sd       t2, -8(a7)
+        addi     a5, x0, 16
+        ble      ARG3, a5, copyexit
+        ld       t1, 8(ARG2)
+        sd       t1, 8(ARG1)
+        addi     a5, x0, 24
+        ble      ARG3, a5, copyexit
+        ld       t1, 16(ARG2)
+        sd       t1, 16(ARG1)
 copyexit:
-        mv      a0, t0
+        mv       a0, t0
         ret
         END_FUNC(memcpy)
 
@@ -108,65 +108,65 @@ copyexit:
  */
         DECLARE_FUNC(memset)
 GLOBAL_LABEL(memset:)
-        addi    a5, x0, 32
-        mv      t0, ARG1 /* save for return */
+        addi     a5, x0, 32
+        mv       t0, ARG1 /* save for return */
 
         /* duplicate byte into whole register */
-        andi    ARG2, ARG2, 0xff
-        mv      t1, ARG2
-        slli    ARG2, ARG2, 8
-        or      t1, t1, ARG2
-        slli    ARG2, ARG2, 8
-        or      t1, t1, ARG2
-        slli    ARG2, ARG2, 8
-        or      t1, t1, ARG2
-        slli    ARG2, ARG2, 8
-        or      t1, t1, ARG2
-        slli    ARG2, ARG2, 8
-        or      t1, t1, ARG2
-        slli    ARG2, ARG2, 8
-        or      t1, t1, ARG2
-        slli    ARG2, ARG2, 8
-        or      t1, t1, ARG2
+        andi     ARG2, ARG2, 0xff
+        mv       t1, ARG2
+        slli     ARG2, ARG2, 8
+        or       t1, t1, ARG2
+        slli     ARG2, ARG2, 8
+        or       t1, t1, ARG2
+        slli     ARG2, ARG2, 8
+        or       t1, t1, ARG2
+        slli     ARG2, ARG2, 8
+        or       t1, t1, ARG2
+        slli     ARG2, ARG2, 8
+        or       t1, t1, ARG2
+        slli     ARG2, ARG2, 8
+        or       t1, t1, ARG2
+        slli     ARG2, ARG2, 8
+        or       t1, t1, ARG2
 set32_:
-        blt     ARG3, a5, set0_32
-        sd      t1, 0(ARG1)
-        sd      t1, 8(ARG1)
-        sd      t1, 16(ARG1)
-        sd      t1, 24(ARG1)
-        addi    ARG3, ARG3, -32
-        addi    ARG1, ARG1, 32
-        j       set32_
+        blt      ARG3, a5, set0_32
+        sd       t1, 0(ARG1)
+        sd       t1, 8(ARG1)
+        sd       t1, 16(ARG1)
+        sd       t1, 24(ARG1)
+        addi     ARG3, ARG3, -32
+        addi     ARG1, ARG1, 32
+        j        set32_
 set0_32:
-        add     a6, ARG1, ARG3
-        addi    a5, x0, 8
-        bge     ARG3, a5, set8_32
-        addi    a5, x0, 4
-        bge     ARG3, a5, set4_8
-        bgtz    ARG3, set0_4
-        j       setexit
+        add      a6, ARG1, ARG3
+        addi     a5, x0, 8
+        bge      ARG3, a5, set8_32
+        addi     a5, x0, 4
+        bge      ARG3, a5, set4_8
+        bgtz     ARG3, set0_4
+        j        setexit
 set0_4:
-        srli    t4, ARG3, 1
-        add     t4, t4, ARG1
-        sb      t1, 0(ARG1)
-        sb      t1, -1(a6)
-        sb      t1, 0(t4)
-        j       setexit
+        srli     t4, ARG3, 1
+        add      t4, t4, ARG1
+        sb       t1, 0(ARG1)
+        sb       t1, -1(a6)
+        sb       t1, 0(t4)
+        j        setexit
 set4_8:
-        sw      t1, 0(ARG1)
-        sw      t1, -4(a6)
-        j       setexit
+        sw       t1, 0(ARG1)
+        sw       t1, -4(a6)
+        j        setexit
 set8_32:
-        sd      t1, 0(ARG1)
-        sd      t1, -8(a6)
-        addi    a5, x0, 16
-        ble     ARG3, a5, setexit
-        sd      t1, 8(ARG1)
-        addi    a5, x0, 24
-        ble     ARG3, a5, setexit
-        sd      t1, 16(ARG1)
+        sd       t1, 0(ARG1)
+        sd       t1, -8(a6)
+        addi     a5, x0, 16
+        ble      ARG3, a5, setexit
+        sd       t1, 8(ARG1)
+        addi     a5, x0, 24
+        ble      ARG3, a5, setexit
+        sd       t1, 16(ARG1)
 setexit:
-        mv      a0, t0
+        mv       a0, t0
         ret
         END_FUNC(memset)
 

--- a/core/io.c
+++ b/core/io.c
@@ -1051,7 +1051,6 @@ our_memcpy_vs_libc(void)
     global_heap_free(dst, alloc_size HEAPACCT(ACCT_OTHER));
 }
 
-
 static void
 our_memset_vs_libc(void)
 {

--- a/core/io.c
+++ b/core/io.c
@@ -1035,12 +1035,12 @@ our_memcpy_vs_libc(void)
         our_memcpy_time = our_memcpy_end - our_memcpy_start;
         libc_memcpy_time = libc_memcpy_end - libc_memcpy_start;
         print_file(STDERR,
-                   "our_memcpy_time: size=" UINT64_FORMAT_STRING " " UINT64_FORMAT_STRING
-                   "\n",
+                   "our_memcpy_time: size=" UINT64_FORMAT_STRING
+                   " time=" UINT64_FORMAT_STRING "\n",
                    tests_size[j], our_memcpy_time);
         print_file(STDERR,
-                   "libc_memcpy_time: size=" UINT64_FORMAT_STRING " " UINT64_FORMAT_STRING
-                   "\n",
+                   "libc_memcpy_time: size=" UINT64_FORMAT_STRING
+                   " time=" UINT64_FORMAT_STRING "\n",
                    tests_size[j], libc_memcpy_time);
     }
     /* We could assert that we're not too much slower, but that's a recipe for


### PR DESCRIPTION
1. Optimize private memcpy and memset for RV64.
2. Add test to compare private and libc memset.
3. Compare private memcpy with libc memcpy on more small sizes.
4. Fix a bug of core/CMakeLists.txt. For unit_tests, to compare private and libc memcpy, we should link unit_tests to drmemfuncs but not link to libc.

Compare original memcpy&memset, optimized private memcpy&memset and glibc memcpy&memset.

Test command:
```
./bin64/unit_tests
```

When we use original memcpy and memset, outputs:
```
our_memcpy_time: size=1 time=0
libc_memcpy_time: size=1 time=2
our_memcpy_time: size=4 time=2
libc_memcpy_time: size=4 time=2
our_memcpy_time: size=128 time=16
libc_memcpy_time: size=128 time=4
our_memcpy_time: size=512 time=57
libc_memcpy_time: size=512 time=7
our_memcpy_time: size=8192 time=824
libc_memcpy_time: size=8192 time=79
our_memcpy_time: size=20480 time=2080
libc_memcpy_time: size=20480 time=183
our_memset_time: 4129
libc_memset_time: 292
io all done
testing string
done testing string
```

When we use optimized memcpy and memset, outputs:
```
our_memcpy_time: size=1 time=1
libc_memcpy_time: size=1 time=2
our_memcpy_time: size=4 time=1
libc_memcpy_time: size=4 time=3
our_memcpy_time: size=128 time=2
libc_memcpy_time: size=128 time=3
our_memcpy_time: size=512 time=7
libc_memcpy_time: size=512 time=7
our_memcpy_time: size=8192 time=72
libc_memcpy_time: size=8192 time=69
our_memcpy_time: size=20480 time=184
libc_memcpy_time: size=20480 time=175
our_memset_time: 307
libc_memset_time: 302
io all done
testing string
done testing string
```

Issue: #3544