### PR TITLE
i#6426 sched stats: Add histogram of instrs per switch

### DIFF
--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -22,6 +22,9 @@ Total counts:
     [0-9 ]* idle microseconds at last instr
     [0-9\. ]*% cpu busy by time
     [0-9\. ]*% cpu busy by time, ignoring idle past last instr
+  Instructions per context switch histogram:
+           0..   50000     2
+       50000..  100000     4
 Core #0 counts:
 .*
 Core #1 counts:

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -22,6 +22,9 @@ Total counts:
    *[0-9]* idle microseconds at last instr
       *[0-9\.]*% cpu busy by time
       *[0-9\.]*% cpu busy by time, ignoring idle past last instr
+  Instructions per context switch histogram:
+           0..   50000     2
+       50000..  100000     4
 Core #0 counts:
            . threads: 1257.*
       *[0-9]* instructions
@@ -36,14 +39,7 @@ Core #0 counts:
            . maybe-blocking system calls
            0 direct switch requests
            0 waits
-    *[0-9]* idles
-      *[0-9\.]*% cpu busy by record count
-   *[0-9]* cpu microseconds
-   *[0-9]* wait microseconds
-   *[0-9]* idle microseconds
-   *[0-9]* idle microseconds at last instr
-      *[0-9\.]*% cpu busy by time
-      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
+.*
 Core #1 counts:
            . threads: 1257.*
       *[0-9]* instructions
@@ -58,14 +54,7 @@ Core #1 counts:
            . maybe-blocking system calls
            0 direct switch requests
            0 waits
-    *[0-9]* idles
-      *[0-9\.]*% cpu busy by record count
-   *[0-9]* cpu microseconds
-   *[0-9]* wait microseconds
-   *[0-9]* idle microseconds
-   *[0-9]* idle microseconds at last instr
-      *[0-9\.]*% cpu busy by time
-      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
+.*
 Core #2 counts:
            . threads: 1257.*
       *[0-9]* instructions
@@ -80,14 +69,7 @@ Core #2 counts:
            . maybe-blocking system calls
            0 direct switch requests
            0 waits
-    *[0-9]* idles
-      *[0-9\.]*% cpu busy by record count
-   *[0-9]* cpu microseconds
-   *[0-9]* wait microseconds
-   *[0-9]* idle microseconds
-   *[0-9]* idle microseconds at last instr
-      *[0-9\.]*% cpu busy by time
-      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
+.*
 Core #3 counts:
            . threads: 1257.*
       *[0-9]* instructions
@@ -102,14 +84,7 @@ Core #3 counts:
            . maybe-blocking system calls
            0 direct switch requests
            0 waits
-    *[0-9]* idles
-      *[0-9\.]*% cpu busy by record count
-   *[0-9]* cpu microseconds
-   *[0-9]* wait microseconds
-   *[0-9]* idle microseconds
-   *[0-9]* idle microseconds at last instr
-      *[0-9\.]*% cpu busy by time
-      *[0-9\.]*% cpu busy by time, ignoring idle past last instr
+.*
 Core #0 schedule: [A-Ha-h_]*
 Core #1 schedule: [A-Ha-h_]*
 Core #2 schedule: [A-Ha-h_]*

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -105,7 +105,7 @@ public:
         void
         merge(const histogram_interface_t *rhs) override
         {
-            const histogram_t *rhs_hist = reinterpret_cast<const histogram_t *>(rhs);
+            const histogram_t *rhs_hist = dynamic_cast<const histogram_t *>(rhs);
             for (const auto &keyval : rhs_hist->bin2count_) {
                 bin2count_[keyval.first] += keyval.second;
             }

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -36,7 +36,9 @@
 #include <stdint.h>
 
 #include <cstdint>
+#include <iostream>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_set>
@@ -73,9 +75,51 @@ public:
     std::string
     parallel_shard_error(void *shard_data) override;
 
+    // Simple binning histogram for instrs-per-switch distribution.
+    class histogram_t {
+    public:
+        histogram_t() = default;
+        virtual ~histogram_t() = default;
+
+        virtual void
+        add(int64_t value)
+        {
+            // XXX: Add dynamic bin size changing.
+            // For now with relatively known data ranges we just stick
+            // with unchanging bin sizes.
+            uint64_t bin = value - (value % kInitialBinSize);
+            ++bin2count_[bin];
+        }
+
+        virtual void
+        merge(const histogram_t *rhs)
+        {
+            for (const auto &keyval : rhs->bin2count_) {
+                bin2count_[keyval.first] += keyval.second;
+            }
+        }
+
+        virtual void
+        print() const
+        {
+            for (const auto &keyval : bin2count_) {
+                std::cerr << std::setw(12) << keyval.first << ".." << std::setw(8)
+                          << keyval.first + kInitialBinSize << " " << std::setw(5)
+                          << keyval.second << "\n";
+            }
+        }
+
+    protected:
+        static constexpr uint64_t kInitialBinSize = 50000;
+
+        // Key is the inclusive lower bound of the bin.
+        std::map<uint64_t, uint64_t> bin2count_;
+    };
+
     struct counters_t {
         counters_t()
         {
+            instrs_per_switch = std::unique_ptr<histogram_t>(new histogram_t);
         }
         counters_t &
         operator+=(const counters_t &rhs)
@@ -96,6 +140,7 @@ public:
             for (const memref_tid_t tid : rhs.threads) {
                 threads.insert(tid);
             }
+            instrs_per_switch->merge(rhs.instrs_per_switch.get());
             return *this;
         }
         int64_t instrs = 0;
@@ -112,6 +157,7 @@ public:
         uint64_t cpu_microseconds = 0;
         uint64_t wait_microseconds = 0;
         std::unordered_set<memref_tid_t> threads;
+        std::unique_ptr<histogram_t> instrs_per_switch;
     };
     counters_t
     get_total_counts();
@@ -119,6 +165,11 @@ public:
 protected:
     // We're in one of 3 states.
     typedef enum { STATE_CPU, STATE_IDLE, STATE_WAIT } state_t;
+
+    static constexpr char THREAD_LETTER_INITIAL_START = 'A';
+    static constexpr char THREAD_LETTER_SUBSEQUENT_START = 'a';
+    static constexpr char WAIT_SYMBOL = '-';
+    static constexpr char IDLE_SYMBOL = '_';
 
     struct per_shard_t {
         std::string error;
@@ -138,6 +189,7 @@ protected:
         // Computing %-idle.
         uint64_t segment_start_microseconds = 0;
         intptr_t filetype = 0;
+        uint64_t switch_start_instrs = 0;
     };
 
     void
@@ -151,6 +203,13 @@ protected:
 
     bool
     update_state_time(per_shard_t *shard, state_t state);
+
+    void
+    record_context_switch(per_shard_t *shard, int64_t tid, int64_t input_id,
+                          int64_t letter_ord);
+
+    virtual void
+    aggregate_results(counters_t &total);
 
     uint64_t knob_print_every_ = 0;
     unsigned int knob_verbose_ = 0;


### PR DESCRIPTION
Adds a very simple histogram with fixed bin sizes recording the distribution of instructions per context switch in the schedule_stats tool.

Updates two tests to confirm the histogram is produced.

This feature is structured to allow replacing this simple histogram with a more sophisticated version in subclasses.

Issue: #6426