### PR TITLE
i#3544 RV64: Implement out-of-line clean calls

### DIFF
--- a/core/arch/arch.h
+++ b/core/arch/arch.h
@@ -662,10 +662,11 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                           instrlist_t *ilist, instr_t *instr, uint alignment,
                           opnd_t push_pc,
                           reg_id_t scratch /*optional*/
-                              _IF_AARCH64(bool out_of_line));
+                              _IF_AARCH64_OR_RISCV64(bool out_of_line));
 void
 insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t *ilist,
-                         instr_t *instr, uint alignment _IF_AARCH64(bool out_of_line));
+                         instr_t *instr,
+                         uint alignment _IF_AARCH64_OR_RISCV64(bool out_of_line));
 bool
 insert_reachable_cti(dcontext_t *dcontext, instrlist_t *ilist, instr_t *where,
                      byte *encode_pc, byte *target, bool jmp, bool returns, bool precise,

--- a/core/arch/clean_call_opt_shared.c
+++ b/core/arch/clean_call_opt_shared.c
@@ -757,14 +757,14 @@ analyze_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instr_t *where,
      */
 #        define GPR_SAVE_THRESHOLD DR_NUM_GPR_REGS
 #    endif
-#elif defined(AARCH64)
+#elif defined(AARCH64) || defined(RISCV64)
     /* Use out-of-line calls if more than 6 SIMD registers need to be saved. */
 #    define SIMD_SAVE_THRESHOLD 6
     /* Use out-of-line calls if more than 6 GP registers need to be saved. */
 #    define GPR_SAVE_THRESHOLD 6
 #endif
 
-#if defined(X86) || defined(AARCH64)
+#if defined(X86) || defined(AARCH64) || defined(RISCV64)
     /* 9. derived fields */
     /* Use out-of-line calls if more than SIMD_SAVE_THRESHOLD SIMD registers have
      * to be saved or if more than GPR_SAVE_THRESHOLD GP registers have to be saved.

--- a/core/arch/mangle_shared.c
+++ b/core/arch/mangle_shared.c
@@ -290,9 +290,9 @@ prepare_for_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist_t
         dstack_offs +=
             insert_out_of_line_context_switch(dcontext, ilist, instr, true, encode_pc);
     } else {
-        dstack_offs +=
-            insert_push_all_registers(dcontext, cci, ilist, instr, (uint)PAGE_SIZE,
-                                      OPND_CREATE_INT32(0), REG_NULL _IF_AARCH64(false));
+        dstack_offs += insert_push_all_registers(dcontext, cci, ilist, instr,
+                                                 (uint)PAGE_SIZE, OPND_CREATE_INT32(0),
+                                                 REG_NULL _IF_AARCH64_OR_RISCV64(false));
 
         insert_clear_eflags(dcontext, cci, ilist, instr);
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
@@ -373,7 +373,7 @@ cleanup_after_clean_call(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
         /* XXX: add a cci field for optimizing this away if callee makes no calls */
         insert_pop_all_registers(dcontext, cci, ilist, instr,
                                  /* see notes in prepare_for_clean_call() */
-                                 (uint)PAGE_SIZE _IF_AARCH64(false));
+                                 (uint)PAGE_SIZE _IF_AARCH64_OR_RISCV64(false));
     }
 
     /* Swap stacks back.  For thread-shared, we need to get the dcontext

--- a/core/lib/globals_api.h
+++ b/core/lib/globals_api.h
@@ -486,15 +486,31 @@ typedef struct _instr_t instr_t;
 #    define IF_AARCHXX_OR_RISCV64_ELSE(x, y) x
 #    define IF_AARCHXX_OR_RISCV64_(x) x,
 #    define _IF_AARCHXX_OR_RISCV64(x) , x
-#    define IF_NOT_AARCHXX_OR_RISCV64(x)
-#    define _IF_NOT_AARCHXX_OR_RISCV64(x)
+#    define IF_NOT_AARCHXX_AND_NOT_RISCV64(x)
+#    define _IF_NOT_AARCHXX_AND_NOT_RISCV64(x)
 #else
 #    define IF_AARCHXX_OR_RISCV64(x)
 #    define IF_AARCHXX_OR_RISCV64_ELSE(x, y) y
 #    define IF_AARCHXX_OR_RISCV64_(x)
 #    define _IF_AARCHXX_OR_RISCV64(x)
-#    define IF_NOT_AARCHXX_OR_RISCV64(x) x
-#    define _IF_NOT_AARCHXX_OR_RISCV64(x) , x
+#    define IF_NOT_AARCHXX_AND_NOT_RISCV64(x) x
+#    define _IF_NOT_AARCHXX_AND_NOT_RISCV64(x) , x
+#endif
+
+#if defined(AARCH64) || defined(RISCV64)
+#    define IF_AARCH64_OR_RISCV64(x) x
+#    define IF_AARCH64_OR_RISCV64_ELSE(x, y) x
+#    define IF_AARCH64_OR_RISCV64_(x) x,
+#    define _IF_AARCH64_OR_RISCV64(x) , x
+#    define IF_NOT_AARCH64_AND_NOT_RISCV64(x)
+#    define _IF_NOT_AARCH64_AND_NOT_RISCV64(x)
+#else
+#    define IF_AARCH64_OR_RISCV64(x)
+#    define IF_AARCH64_OR_RISCV64_ELSE(x, y) y
+#    define IF_AARCH64_OR_RISCV64_(x)
+#    define _IF_AARCH64_OR_RISCV64(x)
+#    define IF_NOT_AARCH64_AND_NOT_RISCV64(x) x
+#    define _IF_NOT_AARCH64_AND_NOT_RISCV64(x) , x
 #endif
 
 #ifdef ANDROID

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -923,15 +923,8 @@ OPTION_DEFAULT(bool, elide_back_calls, true,
 OPTION_DEFAULT(uint, selfmod_max_writes, 5, "maximum write instrs per selfmod fragment")
 /* If this is too large, clients with heavyweight instrumentation hit the
  * "exceeded maximum size" failure.
- * On RISC-V, direct branch has a range of +/- 4 KiB -- for extreme use cases, such as
- * putting a clean call before every app instruction, 15 is a safe value to use.
- *
- * TODO i#3544: For use cases heavier than one clean call per instruction, this number
- * may need to be even lower on RISC-V, for example memtrace_simple must be set to 8 to
- * work properly. State this in the documentation.
  */
-OPTION_DEFAULT(uint, max_bb_instrs, IF_RISCV64_ELSE(15, 256),
-               "maximum instrs per basic block")
+OPTION_DEFAULT(uint, max_bb_instrs, 256, "maximum instrs per basic block")
 PC_OPTION_DEFAULT(bool, process_SEH_push, IF_RETURN_AFTER_CALL_ELSE(true, false),
                   "break bb's at an SEH push so we can see the frame pushed on in "
                   "interp, required for -borland_SEH_rct")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3521,13 +3521,8 @@ if (BUILD_SAMPLES)
     foreach (sample ${sample_list})
       # FIXME i#4392: Remove sanity checks and replace with functioning tests like
       # that done for the opcode_count and memtrace_simple samples.
-      if (RISCV64 AND sample STREQUAL "memtrace_simple")
-        torunonly_ci(sample.${sample} common.${control_flags}
-          ${sample} common/${control_flags}.c "" "-max_bb_instrs 8" "")
-      else ()
-        torunonly_ci(sample.${sample} common.${control_flags}
-          ${sample} common/${control_flags}.c "" "" "")
-      endif ()
+      torunonly_ci(sample.${sample} common.${control_flags}
+        ${sample} common/${control_flags}.c "" "" "")
       if (sample STREQUAL "inscount")
         # test out-of-line clean call
         torunonly_ci(sample.${sample}.cleancall common.${control_flags} ${sample}


### PR DESCRIPTION
Implements out-of-line clean calls on RISCV64, the implementation is similar to AArch64. Also enables out-of-line by default for all clean calls. With this patch, the previous trick of reducing `-max_bb_instrs` is no longer needed.

Issue: #3544 