### PR TITLE
i#6777 AArch64 ci: Update names of jobs to be more consistent

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -60,7 +60,7 @@ jobs:
             sve: true
             sve_length: 128
     runs-on: ${{ matrix.os }}
-    name: AArch64 ${{matrix.sve && 'SVE' || ''}} precommit ${{matrix.sve_length}}
+    name: ci-aarchxx/aarch64-${{matrix.sve && 'SVE-' || ''}}precommit-${{matrix.sve_length}}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -60,7 +60,7 @@ jobs:
             sve: true
             sve_length: 128
     runs-on: ${{ matrix.os }}
-    name: aarch64-${{matrix.sve && 'sve-' || ''}}precommit${{matrix.sv_length && '-' || ''}}${{matrix.sve_length}}
+    name: aarch64-${{matrix.sve && 'sve-' || ''}}precommit${{matrix.sve_length && '-' || ''}}${{matrix.sve_length}}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -60,7 +60,7 @@ jobs:
             sve: true
             sve_length: 128
     runs-on: ${{ matrix.os }}
-    name: ci-aarchxx/aarch64-${{matrix.sve && 'SVE-' || ''}}precommit-${{matrix.sve_length}}
+    name: aarch64-${{matrix.sve && 'sve-' || ''}}precommit${{matrix.sv_length && '-' || ''}}${{matrix.sve_length}}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3


### PR DESCRIPTION
Job names were changed to be in human readable format. This patch changes them to be more consistent with the autogenerated names used by all the other CI jobs.

issue: #6777