### PR TITLE
i#6796 AArch64: Exclude ldg/stg from instr_reads/writes_memory()

### DIFF
--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -69,7 +69,23 @@ instr_length_arch(dcontext_t *dcontext, instr_t *instr)
 bool
 opc_is_not_a_real_memory_load(int opc)
 {
-    return (opc == OP_adr || opc == OP_adrp);
+    /* These instructions have a memref operand, but do not read memory:
+     * - adp/adrp do pc-relative address calculation.
+     * - ldg loads the allocation tag for the referenced address.
+     */
+    return (opc == OP_adr || opc == OP_adrp || opc == OP_ldg);
+}
+
+bool
+opc_is_not_a_real_memory_store(int opc)
+{
+    /* These instructions have a memref operand, but do not write memory:
+     * - stg/st2g stores the allocation tag for the referenced address.
+     *   note: other MTE tag storing instructions (stgp, stzg, etc) store memory as well
+     *         as allocation tags so they are not checked for here. stg/st2g only store a
+     *         tag.
+     */
+    return (opc == OP_stg || opc == OP_st2g);
 }
 
 uint

--- a/core/ir/arm/instr.c
+++ b/core/ir/arm/instr.c
@@ -76,6 +76,12 @@ opc_is_not_a_real_memory_load(int opc)
     return false;
 }
 
+bool
+opc_is_not_a_real_memory_store(int opc)
+{
+    return false;
+}
+
 /* return the branch type of the (branch) inst */
 uint
 instr_branch_type(instr_t *cti_instr)

--- a/core/ir/instr.h
+++ b/core/ir/instr.h
@@ -676,6 +676,8 @@ int
 instr_length_arch(dcontext_t *dcontext, instr_t *instr);
 bool
 opc_is_not_a_real_memory_load(int opc);
+bool
+opc_is_not_a_real_memory_store(int opc);
 
 /* Compute the index-th address for a memory operand that uses a vector register for the
  * base or index register.

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -2232,6 +2232,11 @@ instr_writes_memory(instr_t *instr)
 {
     int a;
     opnd_t curop;
+    int opc = instr_get_opcode(instr);
+
+    if (opc_is_not_a_real_memory_store(opc))
+        return false;
+
     for (a = 0; a < instr_num_dsts(instr); a++) {
         curop = instr_get_dst(instr, a);
         if (opnd_is_memory_reference(curop)) {

--- a/core/ir/riscv64/instr.c
+++ b/core/ir/riscv64/instr.c
@@ -107,6 +107,12 @@ opc_is_not_a_real_memory_load(int opc)
     return opc == OP_auipc;
 }
 
+bool
+opc_is_not_a_real_memory_store(int opc)
+{
+    return false;
+}
+
 uint
 instr_branch_type(instr_t *cti_instr)
 {

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -171,6 +171,12 @@ opc_is_not_a_real_memory_load(int opc)
     return false;
 }
 
+bool
+opc_is_not_a_real_memory_store(int opc)
+{
+    return false;
+}
+
 /* Returns whether ordinal is within the count of memory references
  * (i.e., the caller should iterate, incrementing ordinal by one,
  * until it returns false).

--- a/suite/tests/api/ir_aarch64_v86.c
+++ b/suite/tests/api/ir_aarch64_v86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023 ARM Limited. All rights reserved.
+ * Copyright (c) 2023 - 2024 ARM Limited. All rights reserved.
  * **********************************************************/
 
 /*
@@ -359,6 +359,14 @@ TEST_INSTR(ldg)
     TEST_LOOP(ldg, ldg, 6, expected[i], opnd_create_reg(Xn_six_offset_0[i]),
               opnd_create_base_disp_aarch64(Xn_six_offset_1_sp[i], DR_REG_NULL,
                                             DR_EXTEND_UXTX, 0, imm9[i], 0, OPSZ_0));
+
+    instr =
+        INSTR_CREATE_ldg(dc, opnd_create_reg(DR_REG_X0),
+                         opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                       DR_EXTEND_UXTX, 0, 0, 0, OPSZ_0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(!instr_writes_memory(instr));
+    instr_destroy(dc, instr);
 }
 
 TEST_INSTR(st2g)
@@ -378,6 +386,15 @@ TEST_INSTR(st2g)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_0),
               opnd_create_reg(Xn_six_offset_1_sp[i]), OPND_CREATE_INT(imm9[i]));
 
+    instr = INSTR_CREATE_st2g_post(dc,
+                                   opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                                 DR_EXTEND_UXTX, 0, 0, 0,
+                                                                 OPSZ_0),
+                                   opnd_create_reg(DR_REG_X0), OPND_CREATE_INT(0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(!instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing ST2G    <Xt|SP>, [<Xn|SP>, #<simm>]! */
     const char *const expected_1[6] = {
         "st2g   %x0 %x0 $0xfffffffffffff000 -> -0x1000(%x0) %x0",
@@ -392,6 +409,13 @@ TEST_INSTR(st2g)
         opnd_create_base_disp(Xn_six_offset_0_sp[i], DR_REG_NULL, 0, imm9[i], OPSZ_0),
         opnd_create_reg(Xn_six_offset_1_sp[i]));
 
+    instr = INSTR_CREATE_st2g_pre(
+        dc, opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_0),
+        opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(!instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     //    /* Testing ST2G    <Xt|SP>, [<Xn|SP>, #<simm>] */
     const char *const expected_2[6] = {
         "st2g   %x0 -> -0x1000(%x0)",   "st2g   %x6 -> -0x0a90(%x5)",
@@ -402,6 +426,15 @@ TEST_INSTR(st2g)
               opnd_create_base_disp_aarch64(Xn_six_offset_0_sp[i], DR_REG_NULL,
                                             DR_EXTEND_UXTX, 0, imm9[i], 0, OPSZ_0),
               opnd_create_reg(Xn_six_offset_1_sp[i]));
+
+    instr = INSTR_CREATE_st2g_offset(dc,
+                                     opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                                   DR_EXTEND_UXTX, 0, 0,
+                                                                   0, OPSZ_0),
+                                     opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(!instr_writes_memory(instr));
+    instr_destroy(dc, instr);
 }
 
 TEST_INSTR(stg)
@@ -421,6 +454,15 @@ TEST_INSTR(stg)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_0),
               opnd_create_reg(Xn_six_offset_1_sp[i]), OPND_CREATE_INT(imm9[i]));
 
+    instr = INSTR_CREATE_stg_post(dc,
+                                  opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                                DR_EXTEND_UXTX, 0, 0, 0,
+                                                                OPSZ_0),
+                                  opnd_create_reg(DR_REG_X0), OPND_CREATE_INT(0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(!instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STG     <Xt|SP>, [<Xn|SP>, #<simm>]! */
     const char *const expected_1[6] = {
         "stg    %x0 %x0 $0xfffffffffffff000 -> -0x1000(%x0) %x0",
@@ -435,6 +477,13 @@ TEST_INSTR(stg)
         opnd_create_base_disp(Xn_six_offset_0_sp[i], DR_REG_NULL, 0, imm9[i], OPSZ_0),
         opnd_create_reg(Xn_six_offset_1_sp[i]));
 
+    instr = INSTR_CREATE_stg_pre(
+        dc, opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_0),
+        opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(!instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STG     <Xt|SP>, [<Xn|SP>, #<simm>] */
     const char *const expected_2[6] = {
         "stg    %x0 -> -0x1000(%x0)",   "stg    %x6 -> -0x0a90(%x5)",
@@ -445,6 +494,15 @@ TEST_INSTR(stg)
               opnd_create_base_disp_aarch64(Xn_six_offset_0_sp[i], DR_REG_NULL,
                                             DR_EXTEND_UXTX, 0, imm9[i], 0, OPSZ_0),
               opnd_create_reg(Xn_six_offset_1_sp[i]));
+
+    instr = INSTR_CREATE_stg_offset(dc,
+                                    opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                                  DR_EXTEND_UXTX, 0, 0, 0,
+                                                                  OPSZ_0),
+                                    opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(!instr_writes_memory(instr));
+    instr_destroy(dc, instr);
 }
 
 TEST_INSTR(stz2g)
@@ -464,6 +522,15 @@ TEST_INSTR(stz2g)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_32),
               opnd_create_reg(Xn_six_offset_1_sp[i]), OPND_CREATE_INT(imm9[i]));
 
+    instr = INSTR_CREATE_stz2g_post(dc,
+                                    opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                                  DR_EXTEND_UXTX, 0, 0, 0,
+                                                                  OPSZ_32),
+                                    opnd_create_reg(DR_REG_X0), OPND_CREATE_INT(0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STZ2G   <Xt|SP>, [<Xn|SP>, #<simm>]! */
     const char *const expected_1[6] = {
         "stz2g  %x0 %x0 $0xfffffffffffff000 -> -0x1000(%x0)[32byte] %x0",
@@ -478,6 +545,13 @@ TEST_INSTR(stz2g)
         opnd_create_base_disp(Xn_six_offset_0_sp[i], DR_REG_NULL, 0, imm9[i], OPSZ_32),
         opnd_create_reg(Xn_six_offset_1_sp[i]));
 
+    instr = INSTR_CREATE_stz2g_pre(
+        dc, opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_32),
+        opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STZ2G   <Xt|SP>, [<Xn|SP>, #<simm>] */
     const char *const expected_2[6] = {
         "stz2g  %x0 -> -0x1000(%x0)[32byte]",   "stz2g  %x6 -> -0x0a90(%x5)[32byte]",
@@ -488,6 +562,15 @@ TEST_INSTR(stz2g)
               opnd_create_base_disp_aarch64(Xn_six_offset_0_sp[i], DR_REG_NULL,
                                             DR_EXTEND_UXTX, 0, imm9[i], 0, OPSZ_32),
               opnd_create_reg(Xn_six_offset_1_sp[i]));
+
+    instr = INSTR_CREATE_stz2g_offset(
+        dc,
+        opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, DR_EXTEND_UXTX, 0, 0, 0,
+                                      OPSZ_32),
+        opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
 }
 
 TEST_INSTR(stzg)
@@ -507,6 +590,15 @@ TEST_INSTR(stzg)
                                             DR_EXTEND_UXTX, 0, 0, 0, OPSZ_16),
               opnd_create_reg(Xn_six_offset_1_sp[i]), OPND_CREATE_INT(imm9[i]));
 
+    instr = INSTR_CREATE_stzg_post(dc,
+                                   opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                                 DR_EXTEND_UXTX, 0, 0, 0,
+                                                                 OPSZ_16),
+                                   opnd_create_reg(DR_REG_X0), OPND_CREATE_INT(0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STZG    <Xt|SP>, [<Xn|SP>, #<simm>]! */
     const char *const expected_1[6] = {
         "stzg   %x0 %x0 $0xfffffffffffff000 -> -0x1000(%x0)[16byte] %x0",
@@ -521,6 +613,13 @@ TEST_INSTR(stzg)
         opnd_create_base_disp(Xn_six_offset_0_sp[i], DR_REG_NULL, 0, imm9[i], OPSZ_16),
         opnd_create_reg(Xn_six_offset_1_sp[i]));
 
+    instr = INSTR_CREATE_stzg_pre(
+        dc, opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_16),
+        opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STZG    <Xt|SP>, [<Xn|SP>, #<simm>] */
     const char *const expected_2[6] = {
         "stzg   %x0 -> -0x1000(%x0)[16byte]",   "stzg   %x6 -> -0x0a90(%x5)[16byte]",
@@ -531,6 +630,15 @@ TEST_INSTR(stzg)
               opnd_create_base_disp_aarch64(Xn_six_offset_0_sp[i], DR_REG_NULL,
                                             DR_EXTEND_UXTX, 0, imm9[i], 0, OPSZ_16),
               opnd_create_reg(Xn_six_offset_1_sp[i]));
+
+    instr = INSTR_CREATE_stzg_offset(dc,
+                                     opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL,
+                                                                   DR_EXTEND_UXTX, 0, 0,
+                                                                   0, OPSZ_16),
+                                     opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
 }
 
 TEST_INSTR(stgp)
@@ -551,6 +659,15 @@ TEST_INSTR(stgp)
               opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]),
               OPND_CREATE_INT(imm7[i]));
 
+    instr = INSTR_CREATE_stgp_post(
+        dc,
+        opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, DR_EXTEND_UXTX, 0, 0, 0,
+                                      OPSZ_16),
+        opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X0), OPND_CREATE_INT(0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STGP    <Xt>, <Xt2>, [<Xn|SP>, #<simm>]! */
     const char *const expected_1_0[6] = {
         "stgp   %x0 %x0 %x0 $0xfffffffffffffc00 -> -0x0400(%x0)[16byte] %x0",
@@ -565,6 +682,13 @@ TEST_INSTR(stgp)
         opnd_create_base_disp(Xn_six_offset_0_sp[i], DR_REG_NULL, 0, imm7[i], OPSZ_16),
         opnd_create_reg(Xn_six_offset_1[i]), opnd_create_reg(Xn_six_offset_2[i]));
 
+    instr = INSTR_CREATE_stgp_pre(
+        dc, opnd_create_base_disp(DR_REG_X0, DR_REG_NULL, 0, 0, OPSZ_16),
+        opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
+
     /* Testing STGP    <Xt>, <Xt2>, [<Xn|SP>, #<simm>] */
     const char *const expected_2_0[6] = {
         "stgp   %x0 %x0 -> -0x0400(%x0)[16byte]",
@@ -578,6 +702,15 @@ TEST_INSTR(stgp)
               opnd_create_base_disp_aarch64(Xn_six_offset_2_sp[i], DR_REG_NULL,
                                             DR_EXTEND_UXTX, 0, imm7[i], 0, OPSZ_16),
               opnd_create_reg(Xn_six_offset_0[i]), opnd_create_reg(Xn_six_offset_1[i]));
+
+    instr = INSTR_CREATE_stgp_offset(
+        dc,
+        opnd_create_base_disp_aarch64(DR_REG_X0, DR_REG_NULL, DR_EXTEND_UXTX, 0, 0, 0,
+                                      OPSZ_16),
+        opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X0));
+    ASSERT(!instr_reads_memory(instr));
+    ASSERT(instr_writes_memory(instr));
+    instr_destroy(dc, instr);
 }
 
 TEST_INSTR(gmi)


### PR DESCRIPTION
Add ldg to the list of opcodes which are excluded from instr_reads_memory() and add a similar mechanism to exclude stg/st2g from instr_writes_memory().

These instructions have a similar operand signature to load/store instructions but they actually read/write allocation tags for the pointer indicated by the memory operand, rather than read/write the memory it points to.

Issue: #6796
Fixes: #6796