### PR TITLE
i#6662 encodings2regdeps: data race bug fix

### DIFF
--- a/clients/drcachesim/tests/record_filter-offline.templatex
+++ b/clients/drcachesim/tests/record_filter-offline.templatex
@@ -5,7 +5,9 @@ Exiting process after .* references.
 Hello, world!
 #endif
 Trace invariant checks passed
+#ifndef WINDOWS
 <unable to determine lib path for cross-arch execve>
+#endif
 Output .* entries from .* entries.
 Done!
 Trace invariant checks passed

--- a/clients/drcachesim/tests/record_filter-offline.templatex
+++ b/clients/drcachesim/tests/record_filter-offline.templatex
@@ -5,6 +5,7 @@ Exiting process after .* references.
 Hello, world!
 #endif
 Trace invariant checks passed
+<unable to determine lib path for cross-arch execve>
 Output .* entries from .* entries.
 Done!
 Trace invariant checks passed

--- a/clients/drcachesim/tests/record_filter_unit_tests.cpp
+++ b/clients/drcachesim/tests/record_filter_unit_tests.cpp
@@ -210,6 +210,7 @@ bool
 process_entries_and_check_result(test_record_filter_t *record_filter,
                                  const std::vector<test_case_t> &entries, int index)
 {
+    record_filter->initialize_stream(nullptr);
     auto stream = std::unique_ptr<local_stream_t>(new local_stream_t());
     void *shard_data =
         record_filter->parallel_shard_init_stream(0, nullptr, stream.get());

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -347,6 +347,13 @@ record_filter_t::open_new_chunk(per_shard_t *shard)
     return "";
 }
 
+std::string
+record_filter_t::initialize_stream(memtrace_stream_t *serial_stream)
+{
+    dcontext_.dcontext = dr_standalone_init();
+    return "";
+}
+
 void *
 record_filter_t::parallel_shard_init_stream(int shard_index, void *worker_data,
                                             memtrace_stream_t *shard_stream)
@@ -387,6 +394,7 @@ record_filter_t::parallel_shard_init_stream(int shard_index, void *worker_data,
         }
     }
     per_shard->record_filter_info.last_encoding = &per_shard->last_encoding;
+    per_shard->record_filter_info.dcontext = dcontext_.dcontext;
     std::lock_guard<std::mutex> guard(shard_map_mutex_);
     shard_map_[shard_index] = per_shard;
     return reinterpret_cast<void *>(per_shard);

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -70,6 +70,11 @@ public:
          * #trace_entry_t, hence the vector.
          */
         std::vector<trace_entry_t> *last_encoding;
+
+        /**
+         * Gives filters access to dcontext_t.
+         */
+        void *dcontext;
     };
 
     /**
@@ -148,6 +153,8 @@ public:
                     std::vector<std::unique_ptr<record_filter_func_t>> filters,
                     uint64_t stop_timestamp, unsigned int verbose);
     ~record_filter_t() override;
+    std::string
+    initialize_stream(memtrace_stream_t *serial_stream) override;
     bool
     process_memref(const trace_entry_t &entry) override;
     bool
@@ -286,6 +293,17 @@ private:
         return filetype;
     }
 
+    struct dcontext_cleanup_last_t {
+    public:
+        ~dcontext_cleanup_last_t()
+        {
+            if (dcontext != nullptr)
+                dr_standalone_exit();
+        }
+        void *dcontext = nullptr;
+    };
+
+    dcontext_cleanup_last_t dcontext_;
     std::string output_dir_;
     std::vector<std::unique_ptr<record_filter_func_t>> filters_;
     uint64_t stop_timestamp_;

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -73,11 +73,12 @@ public:
 
         /**
          * Gives filters access to dcontext_t.
-         */
-        /* xref i#6690 i#1595: dcontext_t is not entirely thread-safe. AArch32 encoding
-         * and decoding is problematic as the global encode_state_t and decode_state_t are
+         * Note that dcontext_t is not entirely thread-safe. AArch32 encoding and
+         * decoding is problematic as the global encode_state_t and decode_state_t are
          * used for GLOBAL_DCONTEXT. Furthermore, modifying the ISA mode can lead to data
          * races.
+         */
+        /* xref i#6690 i#1595: multi-dcontext_t solution.
          */
         void *dcontext;
     };

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -174,6 +174,16 @@ public:
     parallel_shard_error(void *shard_data) override;
 
 protected:
+    struct dcontext_cleanup_last_t {
+    public:
+        ~dcontext_cleanup_last_t()
+        {
+            if (dcontext != nullptr)
+                dr_standalone_exit();
+        }
+        void *dcontext = nullptr;
+    };
+
     // For core-sharded we need to remember encodings for an input that were
     // seen on a different core, as there is no reader_t remembering them for us.
     // XXX i#6635: Is this something the scheduler should help us with?
@@ -246,6 +256,8 @@ protected:
     virtual std::string
     get_output_basename(memtrace_stream_t *shard_stream);
 
+    dcontext_cleanup_last_t dcontext_;
+
     std::unordered_map<int, per_shard_t *> shard_map_;
     // This mutex is only needed in parallel_shard_init. In all other accesses
     // to shard_map (print_results) we are single-threaded.
@@ -293,17 +305,6 @@ private:
         return filetype;
     }
 
-    struct dcontext_cleanup_last_t {
-    public:
-        ~dcontext_cleanup_last_t()
-        {
-            if (dcontext != nullptr)
-                dr_standalone_exit();
-        }
-        void *dcontext = nullptr;
-    };
-
-    dcontext_cleanup_last_t dcontext_;
     std::string output_dir_;
     std::vector<std::unique_ptr<record_filter_func_t>> filters_;
     uint64_t stop_timestamp_;

--- a/clients/drcachesim/tools/filter/record_filter.h
+++ b/clients/drcachesim/tools/filter/record_filter.h
@@ -74,6 +74,11 @@ public:
         /**
          * Gives filters access to dcontext_t.
          */
+        /* xref i#6690 i#1595: dcontext_t is not entirely thread-safe. AArch32 encoding
+         * and decoding is problematic as the global encode_state_t and decode_state_t are
+         * used for GLOBAL_DCONTEXT. Furthermore, modifying the ISA mode can lead to data
+         * races.
+         */
         void *dcontext;
     };
 

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -426,16 +426,16 @@ opcode_mix_t::print_interval_results(
         const auto *snap = reinterpret_cast<const snapshot_t *>(base_snap);
         std::cerr << "ID:" << snap->get_interval_id() << " ending at instruction "
                   << snap->get_instr_count_cumulative() << " has "
-                  << snap->opcode_counts_.size() << " opcodes" << " and "
-                  << snap->category_counts_.size() << " categories.\n";
+                  << snap->opcode_counts_.size() << " opcodes"
+                  << " and " << snap->category_counts_.size() << " categories.\n";
         std::vector<std::pair<int, int64_t>> sorted(snap->opcode_counts_.begin(),
                                                     snap->opcode_counts_.end());
         std::sort(sorted.begin(), sorted.end(), cmp_val);
         for (int i = 0; i < PRINT_TOP_N && i < static_cast<int>(sorted.size()); ++i) {
             std::cerr << "   [" << i + 1 << "]"
                       << " Opcode: " << decode_opcode_name(sorted[i].first) << " ("
-                      << sorted[i].first << ")" << " Count=" << sorted[i].second
-                      << " PKI="
+                      << sorted[i].first << ")"
+                      << " Count=" << sorted[i].second << " PKI="
                       << sorted[i].second * 1000.0 / snap->get_instr_count_delta()
                       << "\n";
         }

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -177,7 +177,9 @@ opcode_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
          */
         if (TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, memref.marker.marker_value)) {
             std::lock_guard<std::mutex> guard(dcontext_mutex_);
-            dr_set_isa_mode(dcontext_.dcontext, DR_ISA_REGDEPS, nullptr);
+            dr_isa_mode_t isa_mode = dr_get_isa_mode(dcontext_.dcontext);
+            if (isa_mode != DR_ISA_REGDEPS)
+                dr_set_isa_mode(dcontext_.dcontext, DR_ISA_REGDEPS, nullptr);
         }
     } else if (memref.marker.type == TRACE_TYPE_MARKER &&
                memref.marker.marker_type == TRACE_MARKER_TYPE_VECTOR_LENGTH) {

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -199,6 +199,9 @@ protected:
     // For serial operation.
     worker_data_t serial_worker_;
     shard_data_t serial_shard_;
+    /* To guard the setting of isa_mode in dcontext.
+     */
+    std::mutex dcontext_mutex_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -199,8 +199,7 @@ protected:
     // For serial operation.
     worker_data_t serial_worker_;
     shard_data_t serial_shard_;
-    /* To guard the setting of isa_mode in dcontext.
-     */
+    // To guard the setting of isa_mode in dcontext.
     std::mutex dcontext_mutex_;
 };
 


### PR DESCRIPTION
Fixes a data race due to multiple dr_standalone_init() done in parallel (per shard) by encodings2regdeps_filter_t.
dcontext is now initialized one time by record_filter_t and passed to its filters through the record_filter_info_t interface.

Avoids a data race in opcode_mix where all threads set the dcontext isa_mode to DR_ISA_REGDEPS for regdeps input traces.

Issue #6662 #6812