### PR TITLE
i#3544 RV64 vector part1: Added vector extension encoder/decoder support

### DIFF
--- a/core/ir/riscv64/codec.c
+++ b/core/ir/riscv64/codec.c
@@ -1198,6 +1198,96 @@ decode_icrs1___opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *or
     return true;
 }
 
+/* Decode the zimm immediate field in vsetivli instruction (V extension):
+ * |31 30|29    20|19  15|14   12|11       7|6      0|
+ * | ... | zimm10 | zimm |  ...  |    rd    | opcode |
+ *                ^------^
+ */
+static bool
+decode_zimm_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *orig_pc,
+                 int idx, instr_t *out)
+{
+    uint32_t imm = GET_FIELD(inst, 19, 15);
+    opnd_t opnd = opnd_create_immed_uint(imm, op_sz);
+    instr_set_src(out, idx, opnd);
+    return true;
+}
+
+/* Decode the zimm10 immediate field in vsetivli instruction (V extension):
+ * |31 30|29    20|19  15|14   12|11       7|6      0|
+ * | ... | zimm10 | zimm |  ...  |    rd    | opcode |
+ *       ^--------^
+ */
+static bool
+decode_zimm10_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *orig_pc,
+                   int idx, instr_t *out)
+{
+    uint32_t imm = GET_FIELD(inst, 29, 20);
+    opnd_t opnd = opnd_create_immed_uint(imm, op_sz);
+    instr_set_src(out, idx, opnd);
+    return true;
+}
+
+/* Decode the zimm11 immediate field in vsetvli instruction (V extension):
+ * |31|30    20|19   15|14   12|11       7|6      0|
+ * |  | zimm11 |  rs1  |  ...  |    rd    | opcode |
+ *    ^--------^
+ */
+static bool
+decode_zimm11_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *orig_pc,
+                   int idx, instr_t *out)
+{
+    uint32_t imm = GET_FIELD(inst, 30, 20);
+    opnd_t opnd = opnd_create_immed_uint(imm, op_sz);
+    instr_set_src(out, idx, opnd);
+    return true;
+}
+
+/* Decode the vm (vector mask) immediate field in vector instructions (V extension):
+ * |31 26| 25 |24  0|
+ * | ... | vm | ... |
+ *       ^----^
+ */
+static bool
+decode_vm_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *orig_pc, int idx,
+               instr_t *out)
+{
+    uint32_t imm = GET_FIELD(inst, 25, 25);
+    opnd_t opnd = opnd_create_immed_uint(imm, op_sz);
+    instr_set_src(out, idx, opnd);
+    return true;
+}
+
+/* Decode the nf (nfields) immediate field in vector instructions (V extension):
+ * |31  29|28  0|
+ * |  nf  | ... |
+ * ^------^
+ */
+static bool
+decode_nf_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *orig_pc, int idx,
+               instr_t *out)
+{
+    uint32_t imm = GET_FIELD(inst, 31, 29);
+    opnd_t opnd = opnd_create_immed_uint(imm, op_sz);
+    instr_set_src(out, idx, opnd);
+    return true;
+}
+
+/* Decode the simm5 immediate field in vector instructions (V extension):
+ * |31    26| 25 |24 20|19   15|14 12|11 7|6      0|
+ * | funct6 | vm | vs2 | simm5 | ... | vd | opcode |
+ *                     ^-------^
+ */
+static bool
+decode_simm5_opnd(dcontext_t *dc, uint32_t inst, int op_sz, byte *pc, byte *orig_pc,
+                  int idx, instr_t *out)
+{
+    uint32_t imm = GET_FIELD(inst, 19, 15);
+    opnd_t opnd = opnd_create_immed_uint(imm, op_sz);
+    instr_set_src(out, idx, opnd);
+    return true;
+}
+
 /* Array of operand decode functions indexed by riscv64_fld_t.
  *
  * NOTE: After benchmarking, perhaps this could be placed in the same section as
@@ -1266,6 +1356,16 @@ opnd_dec_func_t opnd_decoders[] = {
     [RISCV64_FLD_IIMM_0] = decode_iimm_0_opnd,
     [RISCV64_FLD_ICRS1] = decode_icrs1_opnd,
     [RISCV64_FLD_ICRS1__] = decode_icrs1___opnd,
+    [RISCV64_FLD_ZIMM] = decode_zimm_opnd,
+    [RISCV64_FLD_ZIMM10] = decode_zimm10_opnd,
+    [RISCV64_FLD_ZIMM11] = decode_zimm11_opnd,
+    [RISCV64_FLD_VM] = decode_vm_opnd,
+    [RISCV64_FLD_NF] = decode_nf_opnd,
+    [RISCV64_FLD_SIMM5] = decode_simm5_opnd,
+    [RISCV64_FLD_VD] = decode_rd_opnd,
+    [RISCV64_FLD_VS1] = decode_rs1_opnd,
+    [RISCV64_FLD_VS2] = decode_rs2_opnd,
+    [RISCV64_FLD_VS3] = decode_rd_opnd,
     [RISCV64_FLD_I_S_RS1_DISP] = decode_v_s_rs1_disp_opnd,
 };
 
@@ -2531,6 +2631,90 @@ encode_v_s_rs1_disp_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out,
     return true;
 }
 
+/* Encode the zimm immediate field in vsetivli instruction (V extension):
+ * |31 30|29    20|19  15|14   12|11       7|6      0|
+ * | ... | zimm10 | zimm |  ...  |    rd    | opcode |
+ *                ^------^
+ */
+static bool
+encode_zimm_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out, decode_info_t *di)
+{
+    opnd_t opnd = instr_get_src(instr, idx);
+    uint32_t imm = opnd_get_immed_int(opnd);
+    *out |= SET_FIELD(imm, 19, 15);
+    return true;
+}
+
+/* Encode the zimm10 immediate field in vsetivli instruction (V extension):
+ * |31 30|29    20|19  15|14   12|11       7|6      0|
+ * | ... | zimm10 | zimm |  ...  |    rd    | opcode |
+ *       ^--------^
+ */
+static bool
+encode_zimm10_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out, decode_info_t *di)
+{
+    opnd_t opnd = instr_get_src(instr, idx);
+    uint32_t imm = opnd_get_immed_int(opnd);
+    *out |= SET_FIELD(imm, 29, 20);
+    return true;
+}
+
+/* Encode the zimm11 immediate field in vsetvli instruction (V extension):
+ * |31|30    20|19   15|14   12|11       7|6      0|
+ * |  | zimm11 |  rs1  |  ...  |    rd    | opcode |
+ *    ^--------^
+ */
+static bool
+encode_zimm11_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out, decode_info_t *di)
+{
+    opnd_t opnd = instr_get_src(instr, idx);
+    uint32_t imm = opnd_get_immed_int(opnd);
+    *out |= SET_FIELD(imm, 30, 20);
+    return true;
+}
+
+/* Encode the vm (vector mask) immediate field in vector instructions (V extension):
+ * |31 26| 25 |24  0|
+ * | ... | vm | ... |
+ *       ^----^
+ */
+static bool
+encode_vm_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out, decode_info_t *di)
+{
+    opnd_t opnd = instr_get_src(instr, idx);
+    uint32_t imm = opnd_get_immed_int(opnd);
+    *out |= SET_FIELD(imm, 25, 25);
+    return true;
+}
+
+/* Encode the nf (nfields) immediate field in vector instructions (V extension):
+ * |31  29|28  0|
+ * |  nf  | ... |
+ * ^------^
+ */
+static bool
+encode_nf_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out, decode_info_t *di)
+{
+    opnd_t opnd = instr_get_src(instr, idx);
+    uint32_t imm = opnd_get_immed_int(opnd);
+    *out |= SET_FIELD(imm, 31, 29);
+    return true;
+}
+
+/* Encode the simm5 immediate field in vector instructions (V extension):
+ * |31    26| 25 |24 20|19   15|14 12|11 7|6      0|
+ * | funct6 | vm | vs2 | simm5 | ... | vd | opcode |
+ *                     ^-------^
+ */
+static bool
+encode_simm5_opnd(instr_t *instr, byte *pc, int idx, uint32_t *out, decode_info_t *di)
+{
+    opnd_t opnd = instr_get_src(instr, idx);
+    int32_t imm = opnd_get_immed_int(opnd);
+    *out |= SET_FIELD(imm, 19, 15);
+    return true;
+}
+
 /* Array of operand encode functions indexed by riscv64_fld_t. */
 opnd_enc_func_t opnd_encoders[] = {
     [RISCV64_FLD_NONE] = encode_none_opnd,
@@ -2595,6 +2779,16 @@ opnd_enc_func_t opnd_encoders[] = {
     [RISCV64_FLD_IIMM_0] = encode_implicit_opnd,
     [RISCV64_FLD_ICRS1] = encode_implicit_opnd,
     [RISCV64_FLD_ICRS1__] = encode_implicit_opnd,
+    [RISCV64_FLD_ZIMM] = encode_zimm_opnd,
+    [RISCV64_FLD_ZIMM10] = encode_zimm10_opnd,
+    [RISCV64_FLD_ZIMM11] = encode_zimm11_opnd,
+    [RISCV64_FLD_VM] = encode_vm_opnd,
+    [RISCV64_FLD_NF] = encode_nf_opnd,
+    [RISCV64_FLD_SIMM5] = encode_simm5_opnd,
+    [RISCV64_FLD_VD] = encode_rd_opnd,
+    [RISCV64_FLD_VS1] = encode_rs1_opnd,
+    [RISCV64_FLD_VS2] = encode_rs2_opnd,
+    [RISCV64_FLD_VS3] = encode_rd_opnd,
     [RISCV64_FLD_I_S_RS1_DISP] = encode_implicit_opnd,
 };
 

--- a/core/ir/riscv64/codec.h
+++ b/core/ir/riscv64/codec.h
@@ -83,6 +83,7 @@ typedef enum {
     RISCV64_ISA_EXT_ZIFENCEI,
     RISCV64_ISA_EXT_XTHEADCMO,
     RISCV64_ISA_EXT_XTHEADSYNC,
+    RISCV64_ISA_EXT_V,
     RISCV64_ISA_EXT_CNT, /* Keep this last */
 } riscv64_isa_ext_t;
 
@@ -256,6 +257,17 @@ typedef enum {
     RISCV64_FLD_ICRS1,
     RISCV64_FLD_ICRS1__,
     RISCV64_FLD_I_S_RS1_DISP,
+    /* Vector extension fields. */
+    RISCV64_FLD_ZIMM,
+    RISCV64_FLD_ZIMM10,
+    RISCV64_FLD_ZIMM11,
+    RISCV64_FLD_VM,
+    RISCV64_FLD_NF,
+    RISCV64_FLD_SIMM5,
+    RISCV64_FLD_VD,
+    RISCV64_FLD_VS1,
+    RISCV64_FLD_VS2,
+    RISCV64_FLD_VS3,
     RISCV64_FLD_CNT, /* Keep this last */
 } riscv64_fld_t;
 

--- a/core/ir/riscv64/codec.py
+++ b/core/ir/riscv64/codec.py
@@ -349,6 +349,7 @@ class Field(str, Enum):
            '',
            'The immediate field in PREFETCH instructions.'
            )
+    # Fields in compressed instructions.
     CRD = (25,
            'rd',
            True,
@@ -394,7 +395,6 @@ class Field(str, Enum):
               '',
               'The second input floating-point register in `CR`, `CSS` RVC formats (inst[6:2]).'
               )
-    # Fields in compressed instructions.
     CRD_ = (30,
             'rd',
             True,
@@ -719,6 +719,97 @@ class Field(str, Enum):
                     'imm(rs1)',
                     'The register-relative memory target location (reg+imm).'
                     )
+    # Vector extension fields.
+    ZIMM = (64,
+            'zimm',
+            False,
+            False,
+            False,
+            'OPSZ_5b',
+            '',
+            'The immediate field in the vsetivli instruction.'
+            )
+    ZIMM10 = (65,
+              'zimm10',
+              False,
+              False,
+              False,
+              'OPSZ_10b',
+              '',
+              'The vtypei field in the vsetivli instruction.'
+              )
+    ZIMM11 = (66,
+              'zimm11',
+              False,
+              False,
+              False,
+              'OPSZ_11b',
+              '',
+              'The vtypei field in the vsetvli instruction.'
+              )
+    VM = (67,
+          'vm',
+          False,
+          False,
+          False,
+          'OPSZ_1b',
+          '',
+          'The vm field in vector instructions.'
+          )
+    NF = (68,
+          'nf',
+          False,
+          False,
+          False,
+          'OPSZ_3b',
+          '',
+          'The nfields field in vector instructions.'
+          )
+    SIMM5 = (69,
+             'simm5',
+             False,
+             False,
+             False,
+             'OPSZ_5b',
+             '',
+             'The immediate field in vector instructions.'
+             )
+    VD = (70,
+          'Vd',
+          True,
+          False,
+          False,
+          'OPSZ_PTR',
+          '',
+          'The output vector register (inst[11:7]).'
+          )
+    VS1 = (71,
+           'vs1',
+           False,
+           False,
+           False,
+           'OPSZ_PTR',
+           '',
+           'The first input vector register (inst[19:15]).'
+           )
+    VS2 = (72,
+           'vs2',
+           False,
+           False,
+           False,
+           'OPSZ_PTR',
+           '',
+           'The second input vector register (inst[24:20]).'
+           )
+    VS3 = (73,
+           'vs3',
+           False,
+           False,
+           False,
+           'OPSZ_PTR',
+           '',
+           'The third input vector register (inst[11:7]).'
+           )
 
     def __str__(self) -> str:
         return self.name.lower().replace("fp", "(fp)")
@@ -856,13 +947,21 @@ class IslGenerator:
         rs3 = ((inst.match & inst.mask) >> 27) & 0x1f
         if opc in [0b0000011, 0b0000111]:  # LOAD instructions
             dbg(f'fixup: {inst.name} {[f.name for f in inst.flds]}')
-            inst.flds[0] = Field.V_L_RS1_DISP
-            inst.flds.pop(1)
+            if opc == 0b0000111 and funct3 in [0b000, 0b101, 0b110, 0b111]:
+                # Vector load instructions have no imm part
+                inst.flds[-2] = Field.V_L_RS1_DISP
+            else:
+                inst.flds[0] = Field.V_L_RS1_DISP
+                inst.flds.pop(1)
             dbg(f'    -> {" " * len(inst.name)} {[f.name for f in inst.flds]}')
         elif opc in [0b0100011, 0b0100111]:  # STORE instructions
             dbg(f'fixup: {inst.name} {[f.name for f in inst.flds]}')
-            inst.flds[2] = Field.V_S_RS1_DISP
-            inst.flds.pop(0)
+            if opc == 0b0100111 and funct3 in [0b000, 0b101, 0b110, 0b111]:
+                # Vector store instructions have no imm part
+                inst.flds[-2] = Field.V_S_RS1_DISP
+            else:
+                inst.flds[2] = Field.V_S_RS1_DISP
+                inst.flds.pop(0)
             dbg(f'    -> {" " * len(inst.name)} {[f.name for f in inst.flds]}')
         elif opc == 0b0101111 and (funct3 == 0b010 or funct3 == 0b011):
             if rs3 == 0x2: # LR.W/D instructions

--- a/core/ir/riscv64/isl/v.txt
+++ b/core/ir/riscv64/isl/v.txt
@@ -1,0 +1,443 @@
+# Configuration setting
+# https://github.com/riscv/riscv-v-spec/blob/master/vcfg-format.adoc
+vsetivli          | r | zimm10 zimm rd    | 11...............111.....1010111
+vsetvli           | r | zimm11 rs1 rd     | 0................111.....1010111
+vsetvl            | r | rs2 rs1 rd        | 1000000..........111.....1010111
+
+#
+# Vector Loads and Store
+# https://github.com/riscv/riscv-v-spec/blob/master/vmem-format.adoc
+#
+# Vector Unit-Stride Instructions (including segment part)
+# https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#74-vector-unit-stride-instructions
+vlm.v             | r | rs1 vd            | 000000101011.....000.....0000111
+vsm.v             | r | rs1 vs3           | 000000101011.....000.....0100111
+vle8.v            | r | nf vm rs1 vd      | ...000.00000.....000.....0000111
+vle16.v           | r | nf vm rs1 vd      | ...000.00000.....101.....0000111
+vle32.v           | r | nf vm rs1 vd      | ...000.00000.....110.....0000111
+vle64.v           | r | nf vm rs1 vd      | ...000.00000.....111.....0000111
+vse8.v            | r | nf vm rs1 vs3     | ...000.00000.....000.....0100111
+vse16.v           | r | nf vm rs1 vs3     | ...000.00000.....101.....0100111
+vse32.v           | r | nf vm rs1 vs3     | ...000.00000.....110.....0100111
+vse64.v           | r | nf vm rs1 vs3     | ...000.00000.....111.....0100111
+
+# Vector Indexed-Unordered Instructions (including segment part)
+# https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#76-vector-indexed-instructions
+vluxei8.v         | r | nf vm vs2 rs1 vd  | ...001...........000.....0000111
+vluxei16.v        | r | nf vm vs2 rs1 vd  | ...001...........101.....0000111
+vluxei32.v        | r | nf vm vs2 rs1 vd  | ...001...........110.....0000111
+vluxei64.v        | r | nf vm vs2 rs1 vd  | ...001...........111.....0000111
+vsuxei8.v         | r | nf vm vs2 rs1 vs3 | ...001...........000.....0100111
+vsuxei16.v        | r | nf vm vs2 rs1 vs3 | ...001...........101.....0100111
+vsuxei32.v        | r | nf vm vs2 rs1 vs3 | ...001...........110.....0100111
+vsuxei64.v        | r | nf vm vs2 rs1 vs3 | ...001...........111.....0100111
+
+# Vector Strided Instructions (including segment part)
+# https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#75-vector-strided-instructions
+vlse8.v           | r | nf vm rs2 rs1 vd  | ...010...........000.....0000111
+vlse16.v          | r | nf vm rs2 rs1 vd  | ...010...........101.....0000111
+vlse32.v          | r | nf vm rs2 rs1 vd  | ...010...........110.....0000111
+vlse64.v          | r | nf vm rs2 rs1 vd  | ...010...........111.....0000111
+vsse8.v           | r | nf vm rs2 rs1 vs3 | ...010...........000.....0100111
+vsse16.v          | r | nf vm rs2 rs1 vs3 | ...010...........101.....0100111
+vsse32.v          | r | nf vm rs2 rs1 vs3 | ...010...........110.....0100111
+vsse64.v          | r | nf vm rs2 rs1 vs3 | ...010...........111.....0100111
+
+# Vector Indexed-Ordered Instructions (including segment part)
+# https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#76-vector-indexed-instructions
+vloxei8.v         | r | nf vm vs2 rs1 vd  | ...011...........000.....0000111
+vloxei16.v        | r | nf vm vs2 rs1 vd  | ...011...........101.....0000111
+vloxei32.v        | r | nf vm vs2 rs1 vd  | ...011...........110.....0000111
+vloxei64.v        | r | nf vm vs2 rs1 vd  | ...011...........111.....0000111
+vsoxei8.v         | r | nf vm vs2 rs1 vs3 | ...011...........000.....0100111
+vsoxei16.v        | r | nf vm vs2 rs1 vs3 | ...011...........101.....0100111
+vsoxei32.v        | r | nf vm vs2 rs1 vs3 | ...011...........110.....0100111
+vsoxei64.v        | r | nf vm vs2 rs1 vs3 | ...011...........111.....0100111
+
+# Unit-stride F31..29=0ault-Only-First Loads
+# https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#77-unit-stride-fault-only-first-loads
+vle8ff.v          | r | nf vm rs1 vd      | ...000.10000.....000.....0000111
+vle16ff.v         | r | nf vm rs1 vd      | ...000.10000.....101.....0000111
+vle32ff.v         | r | nf vm rs1 vd      | ...000.10000.....110.....0000111
+vle64ff.v         | r | nf vm rs1 vd      | ...000.10000.....111.....0000111
+
+# Vector Load/Store Whole Registers
+# https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#79-vector-loadstore-whole-register-instructions
+vl1re8.v          | r | rs1 vd            | 000000101000.....000.....0000111
+vl1re16.v         | r | rs1 vd            | 000000101000.....101.....0000111
+vl1re32.v         | r | rs1 vd            | 000000101000.....110.....0000111
+vl1re64.v         | r | rs1 vd            | 000000101000.....111.....0000111
+vl2re8.v          | r | rs1 vd            | 001000101000.....000.....0000111
+vl2re16.v         | r | rs1 vd            | 001000101000.....101.....0000111
+vl2re32.v         | r | rs1 vd            | 001000101000.....110.....0000111
+vl2re64.v         | r | rs1 vd            | 001000101000.....111.....0000111
+vl4re8.v          | r | rs1 vd            | 011000101000.....000.....0000111
+vl4re16.v         | r | rs1 vd            | 011000101000.....101.....0000111
+vl4re32.v         | r | rs1 vd            | 011000101000.....110.....0000111
+vl4re64.v         | r | rs1 vd            | 011000101000.....111.....0000111
+vl8re8.v          | r | rs1 vd            | 111000101000.....000.....0000111
+vl8re16.v         | r | rs1 vd            | 111000101000.....101.....0000111
+vl8re32.v         | r | rs1 vd            | 111000101000.....110.....0000111
+vl8re64.v         | r | rs1 vd            | 111000101000.....111.....0000111
+vs1r.v            | r | rs1 vs3           | 000000101000.....000.....0100111
+vs2r.v            | r | rs1 vs3           | 001000101000.....000.....0100111
+vs4r.v            | r | rs1 vs3           | 011000101000.....000.....0100111
+vs8r.v            | r | rs1 vs3           | 111000101000.....000.....0100111
+
+# Vector Floating-Point Instructions
+# https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#14-vector-floating-point-instructions
+# OPFVF
+vfadd.vf          | r | vm vs2 rs1 vd     | 000000...........101.....1010111
+vfsub.vf          | r | vm vs2 rs1 vd     | 000010...........101.....1010111
+vfmin.vf          | r | vm vs2 rs1 vd     | 000100...........101.....1010111
+vfmax.vf          | r | vm vs2 rs1 vd     | 000110...........101.....1010111
+vfsgnj.vf         | r | vm vs2 rs1 vd     | 001000...........101.....1010111
+vfsgnjn.vf        | r | vm vs2 rs1 vd     | 001001...........101.....1010111
+vfsgnjx.vf        | r | vm vs2 rs1 vd     | 001010...........101.....1010111
+vfslide1up.vf     | r | vm vs2 rs1 vd     | 001110...........101.....1010111
+vfslide1down.vf   | r | vm vs2 rs1 vd     | 001111...........101.....1010111
+vfmv.s.f          | r | rs1 vd            | 010000100000.....101.....1010111
+
+vfmerge.vfm       | r | vs2 rs1 vd        | 0101110..........101.....1010111
+vfmv.v.f          | r | rs1 vd            | 010111100000.....101.....1010111
+vmfeq.vf          | r | vm vs2 rs1 vd     | 011000...........101.....1010111
+vmfle.vf          | r | vm vs2 rs1 vd     | 011001...........101.....1010111
+vmflt.vf          | r | vm vs2 rs1 vd     | 011011...........101.....1010111
+vmfne.vf          | r | vm vs2 rs1 vd     | 011100...........101.....1010111
+vmfgt.vf          | r | vm vs2 rs1 vd     | 011101...........101.....1010111
+vmfge.vf          | r | vm vs2 rs1 vd     | 011111...........101.....1010111
+
+vfdiv.vf          | r | vm vs2 rs1 vd     | 100000...........101.....1010111
+vfrdiv.vf         | r | vm vs2 rs1 vd     | 100001...........101.....1010111
+vfmul.vf          | r | vm vs2 rs1 vd     | 100100...........101.....1010111
+vfrsub.vf         | r | vm vs2 rs1 vd     | 100111...........101.....1010111
+vfmadd.vf         | r | vm vs2 rs1 vd     | 101000...........101.....1010111
+vfnmadd.vf        | r | vm vs2 rs1 vd     | 101001...........101.....1010111
+vfmsub.vf         | r | vm vs2 rs1 vd     | 101010...........101.....1010111
+vfnmsub.vf        | r | vm vs2 rs1 vd     | 101011...........101.....1010111
+vfmacc.vf         | r | vm vs2 rs1 vd     | 101100...........101.....1010111
+vfnmacc.vf        | r | vm vs2 rs1 vd     | 101101...........101.....1010111
+vfmsac.vf         | r | vm vs2 rs1 vd     | 101110...........101.....1010111
+vfnmsac.vf        | r | vm vs2 rs1 vd     | 101111...........101.....1010111
+
+vfwadd.vf         | r | vm vs2 rs1 vd     | 110000...........101.....1010111
+vfwsub.vf         | r | vm vs2 rs1 vd     | 110010...........101.....1010111
+vfwadd.wf         | r | vm vs2 rs1 vd     | 110100...........101.....1010111
+vfwsub.wf         | r | vm vs2 rs1 vd     | 110110...........101.....1010111
+vfwmul.vf         | r | vm vs2 rs1 vd     | 111000...........101.....1010111
+vfwmacc.vf        | r | vm vs2 rs1 vd     | 111100...........101.....1010111
+vfwnmacc.vf       | r | vm vs2 rs1 vd     | 111101...........101.....1010111
+vfwmsac.vf        | r | vm vs2 rs1 vd     | 111110...........101.....1010111
+vfwnmsac.vf       | r | vm vs2 rs1 vd     | 111111...........101.....1010111
+
+# OPFVV
+vfadd.vv          | r | vm vs2 vs1 vd     | 000000...........001.....1010111
+vfredusum.vs      | r | vm vs2 vs1 vd     | 000001...........001.....1010111
+vfsub.vv          | r | vm vs2 vs1 vd     | 000010...........001.....1010111
+vfredosum.vs      | r | vm vs2 vs1 vd     | 000011...........001.....1010111
+vfmin.vv          | r | vm vs2 vs1 vd     | 000100...........001.....1010111
+vfredmin.vs       | r | vm vs2 vs1 vd     | 000101...........001.....1010111
+vfmax.vv          | r | vm vs2 vs1 vd     | 000110...........001.....1010111
+vfredmax.vs       | r | vm vs2 vs1 vd     | 000111...........001.....1010111
+vfsgnj.vv         | r | vm vs2 vs1 vd     | 001000...........001.....1010111
+vfsgnjn.vv        | r | vm vs2 vs1 vd     | 001001...........001.....1010111
+vfsgnjx.vv        | r | vm vs2 vs1 vd     | 001010...........001.....1010111
+vfmv.f.s          | r | vs2 rd            | 0100001.....00000001.....1010111
+
+vmfeq.vv          | r | vm vs2 vs1 vd     | 011000...........001.....1010111
+vmfle.vv          | r | vm vs2 vs1 vd     | 011001...........001.....1010111
+vmflt.vv          | r | vm vs2 vs1 vd     | 011011...........001.....1010111
+vmfne.vv          | r | vm vs2 vs1 vd     | 011100...........001.....1010111
+
+vfdiv.vv          | r | vm vs2 vs1 vd     | 100000...........001.....1010111
+vfmul.vv          | r | vm vs2 vs1 vd     | 100100...........001.....1010111
+vfmadd.vv         | r | vm vs2 vs1 vd     | 101000...........001.....1010111
+vfnmadd.vv        | r | vm vs2 vs1 vd     | 101001...........001.....1010111
+vfmsub.vv         | r | vm vs2 vs1 vd     | 101010...........001.....1010111
+vfnmsub.vv        | r | vm vs2 vs1 vd     | 101011...........001.....1010111
+vfmacc.vv         | r | vm vs2 vs1 vd     | 101100...........001.....1010111
+vfnmacc.vv        | r | vm vs2 vs1 vd     | 101101...........001.....1010111
+vfmsac.vv         | r | vm vs2 vs1 vd     | 101110...........001.....1010111
+vfnmsac.vv        | r | vm vs2 vs1 vd     | 101111...........001.....1010111
+
+vfcvt.xu.f.v      | r | vm vs2 vd         | 010010......00000001.....1010111
+vfcvt.x.f.v       | r | vm vs2 vd         | 010010......00001001.....1010111
+vfcvt.f.xu.v      | r | vm vs2 vd         | 010010......00010001.....1010111
+vfcvt.f.x.v       | r | vm vs2 vd         | 010010......00011001.....1010111
+vfcvt.rtz.xu.f.v  | r | vm vs2 vd         | 010010......00110001.....1010111
+vfcvt.rtz.x.f.v   | r | vm vs2 vd         | 010010......00111001.....1010111
+
+vfwcvt.xu.f.v     | r | vm vs2 vd         | 010010......01000001.....1010111
+vfwcvt.x.f.v      | r | vm vs2 vd         | 010010......01001001.....1010111
+vfwcvt.f.xu.v     | r | vm vs2 vd         | 010010......01010001.....1010111
+vfwcvt.f.x.v      | r | vm vs2 vd         | 010010......01011001.....1010111
+vfwcvt.f.f.v      | r | vm vs2 vd         | 010010......01100001.....1010111
+vfwcvt.rtz.xu.f.v | r | vm vs2 vd         | 010010......01110001.....1010111
+vfwcvt.rtz.x.f.v  | r | vm vs2 vd         | 010010......01111001.....1010111
+
+vfncvt.xu.f.w     | r | vm vs2 vd         | 010010......10000001.....1010111
+vfncvt.x.f.w      | r | vm vs2 vd         | 010010......10001001.....1010111
+vfncvt.f.xu.w     | r | vm vs2 vd         | 010010......10010001.....1010111
+vfncvt.f.x.w      | r | vm vs2 vd         | 010010......10011001.....1010111
+vfncvt.f.f.w      | r | vm vs2 vd         | 010010......10100001.....1010111
+vfncvt.rod.f.f.w  | r | vm vs2 vd         | 010010......10101001.....1010111
+vfncvt.rtz.xu.f.w | r | vm vs2 vd         | 010010......10110001.....1010111
+vfncvt.rtz.x.f.w  | r | vm vs2 vd         | 010010......10111001.....1010111
+
+vfsqrt.v          | r | vm vs2 vd         | 010011......00000001.....1010111
+vfrsqrt7.v        | r | vm vs2 vd         | 010011......00100001.....1010111
+vfrec7.v          | r | vm vs2 vd         | 010011......00101001.....1010111
+vfclass.v         | r | vm vs2 vd         | 010011......10000001.....1010111
+
+vfwadd.vv         | r | vm vs2 vs1 vd     | 110000...........001.....1010111
+vfwredusum.vs     | r | vm vs2 vs1 vd     | 110001...........001.....1010111
+vfwsub.vv         | r | vm vs2 vs1 vd     | 110010...........001.....1010111
+vfwredosum.vs     | r | vm vs2 vs1 vd     | 110011...........001.....1010111
+vfwadd.wv         | r | vm vs2 vs1 vd     | 110100...........001.....1010111
+vfwsub.wv         | r | vm vs2 vs1 vd     | 110110...........001.....1010111
+vfwmul.vv         | r | vm vs2 vs1 vd     | 111000...........001.....1010111
+vfwmacc.vv        | r | vm vs2 vs1 vd     | 111100...........001.....1010111
+vfwnmacc.vv       | r | vm vs2 vs1 vd     | 111101...........001.....1010111
+vfwmsac.vv        | r | vm vs2 vs1 vd     | 111110...........001.....1010111
+vfwnmsac.vv       | r | vm vs2 vs1 vd     | 111111...........001.....1010111
+
+# OPIVX
+vadd.vx           | r | vm vs2 rs1 vd     | 000000...........100.....1010111
+vsub.vx           | r | vm vs2 rs1 vd     | 000010...........100.....1010111
+vrsub.vx          | r | vm vs2 rs1 vd     | 000011...........100.....1010111
+vminu.vx          | r | vm vs2 rs1 vd     | 000100...........100.....1010111
+vmin.vx           | r | vm vs2 rs1 vd     | 000101...........100.....1010111
+vmaxu.vx          | r | vm vs2 rs1 vd     | 000110...........100.....1010111
+vmax.vx           | r | vm vs2 rs1 vd     | 000111...........100.....1010111
+vand.vx           | r | vm vs2 rs1 vd     | 001001...........100.....1010111
+vor.vx            | r | vm vs2 rs1 vd     | 001010...........100.....1010111
+vxor.vx           | r | vm vs2 rs1 vd     | 001011...........100.....1010111
+vrgather.vx       | r | vm vs2 rs1 vd     | 001100...........100.....1010111
+vslideup.vx       | r | vm vs2 rs1 vd     | 001110...........100.....1010111
+vslidedown.vx     | r | vm vs2 rs1 vd     | 001111...........100.....1010111
+
+vadc.vxm          | r | vs2 rs1 vd        | 0100000..........100.....1010111
+vmadc.vxm         | r | vs2 rs1 vd        | 0100010..........100.....1010111
+vmadc.vx          | r | vs2 rs1 vd        | 0100011..........100.....1010111
+vsbc.vxm          | r | vs2 rs1 vd        | 0100100..........100.....1010111
+vmsbc.vxm         | r | vs2 rs1 vd        | 0100110..........100.....1010111
+vmsbc.vx          | r | vs2 rs1 vd        | 0100111..........100.....1010111
+vmerge.vxm        | r | vs2 rs1 vd        | 0101110..........100.....1010111
+vmv.v.x           | r | rs1 vd            | 010111100000.....100.....1010111
+vmseq.vx          | r | vm vs2 rs1 vd     | 011000...........100.....1010111
+vmsne.vx          | r | vm vs2 rs1 vd     | 011001...........100.....1010111
+vmsltu.vx         | r | vm vs2 rs1 vd     | 011010...........100.....1010111
+vmslt.vx          | r | vm vs2 rs1 vd     | 011011...........100.....1010111
+vmsleu.vx         | r | vm vs2 rs1 vd     | 011100...........100.....1010111
+vmsle.vx          | r | vm vs2 rs1 vd     | 011101...........100.....1010111
+vmsgtu.vx         | r | vm vs2 rs1 vd     | 011110...........100.....1010111
+vmsgt.vx          | r | vm vs2 rs1 vd     | 011111...........100.....1010111
+
+vsaddu.vx         | r | vm vs2 rs1 vd     | 100000...........100.....1010111
+vsadd.vx          | r | vm vs2 rs1 vd     | 100001...........100.....1010111
+vssubu.vx         | r | vm vs2 rs1 vd     | 100010...........100.....1010111
+vssub.vx          | r | vm vs2 rs1 vd     | 100011...........100.....1010111
+vsll.vx           | r | vm vs2 rs1 vd     | 100101...........100.....1010111
+vsmul.vx          | r | vm vs2 rs1 vd     | 100111...........100.....1010111
+vsrl.vx           | r | vm vs2 rs1 vd     | 101000...........100.....1010111
+vsra.vx           | r | vm vs2 rs1 vd     | 101001...........100.....1010111
+vssrl.vx          | r | vm vs2 rs1 vd     | 101010...........100.....1010111
+vssra.vx          | r | vm vs2 rs1 vd     | 101011...........100.....1010111
+vnsrl.wx          | r | vm vs2 rs1 vd     | 101100...........100.....1010111
+vnsra.wx          | r | vm vs2 rs1 vd     | 101101...........100.....1010111
+vnclipu.wx        | r | vm vs2 rs1 vd     | 101110...........100.....1010111
+vnclip.wx         | r | vm vs2 rs1 vd     | 101111...........100.....1010111
+
+# OPIVV
+vadd.vv           | r | vm vs2 vs1 vd     | 000000...........000.....1010111
+vsub.vv           | r | vm vs2 vs1 vd     | 000010...........000.....1010111
+vminu.vv          | r | vm vs2 vs1 vd     | 000100...........000.....1010111
+vmin.vv           | r | vm vs2 vs1 vd     | 000101...........000.....1010111
+vmaxu.vv          | r | vm vs2 vs1 vd     | 000110...........000.....1010111
+vmax.vv           | r | vm vs2 vs1 vd     | 000111...........000.....1010111
+vand.vv           | r | vm vs2 vs1 vd     | 001001...........000.....1010111
+vor.vv            | r | vm vs2 vs1 vd     | 001010...........000.....1010111
+vxor.vv           | r | vm vs2 vs1 vd     | 001011...........000.....1010111
+vrgather.vv       | r | vm vs2 vs1 vd     | 001100...........000.....1010111
+vrgatherei16.vv   | r | vm vs2 vs1 vd     | 001110...........000.....1010111
+
+vadc.vvm          | r | vs2 vs1 vd        | 0100000..........000.....1010111
+vmadc.vvm         | r | vs2 vs1 vd        | 0100010..........000.....1010111
+vmadc.vv          | r | vs2 vs1 vd        | 0100011..........000.....1010111
+vsbc.vvm          | r | vs2 vs1 vd        | 0100100..........000.....1010111
+vmsbc.vvm         | r | vs2 vs1 vd        | 0100110..........000.....1010111
+vmsbc.vv          | r | vs2 vs1 vd        | 0100111..........000.....1010111
+vmerge.vvm        | r | vs2 vs1 vd        | 0101110..........000.....1010111
+vmv.v.v           | r | vs1 vd            | 010111100000.....000.....1010111
+vmseq.vv          | r | vm vs2 vs1 vd     | 011000...........000.....1010111
+vmsne.vv          | r | vm vs2 vs1 vd     | 011001...........000.....1010111
+vmsltu.vv         | r | vm vs2 vs1 vd     | 011010...........000.....1010111
+vmslt.vv          | r | vm vs2 vs1 vd     | 011011...........000.....1010111
+vmsleu.vv         | r | vm vs2 vs1 vd     | 011100...........000.....1010111
+vmsle.vv          | r | vm vs2 vs1 vd     | 011101...........000.....1010111
+
+vsaddu.vv         | r | vm vs2 vs1 vd     | 100000...........000.....1010111
+vsadd.vv          | r | vm vs2 vs1 vd     | 100001...........000.....1010111
+vssubu.vv         | r | vm vs2 vs1 vd     | 100010...........000.....1010111
+vssub.vv          | r | vm vs2 vs1 vd     | 100011...........000.....1010111
+vsll.vv           | r | vm vs2 vs1 vd     | 100101...........000.....1010111
+vsmul.vv          | r | vm vs2 vs1 vd     | 100111...........000.....1010111
+vsrl.vv           | r | vm vs2 vs1 vd     | 101000...........000.....1010111
+vsra.vv           | r | vm vs2 vs1 vd     | 101001...........000.....1010111
+vssrl.vv          | r | vm vs2 vs1 vd     | 101010...........000.....1010111
+vssra.vv          | r | vm vs2 vs1 vd     | 101011...........000.....1010111
+vnsrl.wv          | r | vm vs2 vs1 vd     | 101100...........000.....1010111
+vnsra.wv          | r | vm vs2 vs1 vd     | 101101...........000.....1010111
+vnclipu.wv        | r | vm vs2 vs1 vd     | 101110...........000.....1010111
+vnclip.wv         | r | vm vs2 vs1 vd     | 101111...........000.....1010111
+
+vwredsumu.vs      | r | vm vs2 vs1 vd     | 110000...........000.....1010111
+vwredsum.vs       | r | vm vs2 vs1 vd     | 110001...........000.....1010111
+
+# OPIVI
+vadd.vi           | r | vm vs2 simm5 vd   | 000000...........011.....1010111
+vrsub.vi          | r | vm vs2 simm5 vd   | 000011...........011.....1010111
+vand.vi           | r | vm vs2 simm5 vd   | 001001...........011.....1010111
+vor.vi            | r | vm vs2 simm5 vd   | 001010...........011.....1010111
+vxor.vi           | r | vm vs2 simm5 vd   | 001011...........011.....1010111
+vrgather.vi       | r | vm vs2 simm5 vd   | 001100...........011.....1010111
+vslideup.vi       | r | vm vs2 simm5 vd   | 001110...........011.....1010111
+vslidedown.vi     | r | vm vs2 simm5 vd   | 001111...........011.....1010111
+
+vadc.vim          | r | vs2 simm5 vd      | 0100000..........011.....1010111
+vmadc.vim         | r | vs2 simm5 vd      | 0100010..........011.....1010111
+vmadc.vi          | r | vs2 simm5 vd      | 0100011..........011.....1010111
+vmerge.vim        | r | vs2 simm5 vd      | 0101110..........011.....1010111
+vmv.v.i           | r | simm5 vd          | 010111100000.....011.....1010111
+vmseq.vi          | r | vm vs2 simm5 vd   | 011000...........011.....1010111
+vmsne.vi          | r | vm vs2 simm5 vd   | 011001...........011.....1010111
+vmsleu.vi         | r | vm vs2 simm5 vd   | 011100...........011.....1010111
+vmsle.vi          | r | vm vs2 simm5 vd   | 011101...........011.....1010111
+vmsgtu.vi         | r | vm vs2 simm5 vd   | 011110...........011.....1010111
+vmsgt.vi          | r | vm vs2 simm5 vd   | 011111...........011.....1010111
+
+vsaddu.vi         | r | vm vs2 simm5 vd   | 100000...........011.....1010111
+vsadd.vi          | r | vm vs2 simm5 vd   | 100001...........011.....1010111
+vsll.vi           | r | vm vs2 simm5 vd   | 100101...........011.....1010111
+vmv1r.v           | r | vs2 vd            | 1001111.....00000011.....1010111
+vmv2r.v           | r | vs2 vd            | 1001111.....00001011.....1010111
+vmv4r.v           | r | vs2 vd            | 1001111.....00011011.....1010111
+vmv8r.v           | r | vs2 vd            | 1001111.....00111011.....1010111
+vsrl.vi           | r | vm vs2 simm5 vd   | 101000...........011.....1010111
+vsra.vi           | r | vm vs2 simm5 vd   | 101001...........011.....1010111
+vssrl.vi          | r | vm vs2 simm5 vd   | 101010...........011.....1010111
+vssra.vi          | r | vm vs2 simm5 vd   | 101011...........011.....1010111
+vnsrl.wi          | r | vm vs2 simm5 vd   | 101100...........011.....1010111
+vnsra.wi          | r | vm vs2 simm5 vd   | 101101...........011.....1010111
+vnclipu.wi        | r | vm vs2 simm5 vd   | 101110...........011.....1010111
+vnclip.wi         | r | vm vs2 simm5 vd   | 101111...........011.....1010111
+
+# OPMVV
+vredsum.vs        | r | vm vs2 vs1 vd     | 000000...........010.....1010111
+vredand.vs        | r | vm vs2 vs1 vd     | 000001...........010.....1010111
+vredor.vs         | r | vm vs2 vs1 vd     | 000010...........010.....1010111
+vredxor.vs        | r | vm vs2 vs1 vd     | 000011...........010.....1010111
+vredminu.vs       | r | vm vs2 vs1 vd     | 000100...........010.....1010111
+vredmin.vs        | r | vm vs2 vs1 vd     | 000101...........010.....1010111
+vredmaxu.vs       | r | vm vs2 vs1 vd     | 000110...........010.....1010111
+vredmax.vs        | r | vm vs2 vs1 vd     | 000111...........010.....1010111
+vaaddu.vv         | r | vm vs2 vs1 vd     | 001000...........010.....1010111
+vaadd.vv          | r | vm vs2 vs1 vd     | 001001...........010.....1010111
+vasubu.vv         | r | vm vs2 vs1 vd     | 001010...........010.....1010111
+vasub.vv          | r | vm vs2 vs1 vd     | 001011...........010.....1010111
+
+vmv.x.s           | r | vs2 rd            | 0100001.....00000010.....1010111
+
+# Vector Integer Extension Instructions
+# https://github.com/riscv/riscv-v-spec/blob/e49574c92b072fd4d71e6cb20f7e8154de5b83fe/v-spec.adoc#123-vector-integer-extension
+vzext.vf8         | r | vm vs2 vd         | 010010......00010010.....1010111
+vsext.vf8         | r | vm vs2 vd         | 010010......00011010.....1010111
+vzext.vf4         | r | vm vs2 vd         | 010010......00100010.....1010111
+vsext.vf4         | r | vm vs2 vd         | 010010......00101010.....1010111
+vzext.vf2         | r | vm vs2 vd         | 010010......00110010.....1010111
+vsext.vf2         | r | vm vs2 vd         | 010010......00111010.....1010111
+
+vcompress.vm      | r | vs2 vs1 vd        | 0101111..........010.....1010111
+vmandn.mm         | r | vs2 vs1 vd        | 0110001..........010.....1010111
+vmand.mm          | r | vs2 vs1 vd        | 0110011..........010.....1010111
+vmor.mm           | r | vs2 vs1 vd        | 0110101..........010.....1010111
+vmxor.mm          | r | vs2 vs1 vd        | 0110111..........010.....1010111
+vmorn.mm          | r | vs2 vs1 vd        | 0111001..........010.....1010111
+vmnand.mm         | r | vs2 vs1 vd        | 0111011..........010.....1010111
+vmnor.mm          | r | vs2 vs1 vd        | 0111101..........010.....1010111
+vmxnor.mm         | r | vs2 vs1 vd        | 0111111..........010.....1010111
+
+vmsbf.m           | r | vm vs2 vd         | 010100......00001010.....1010111
+vmsof.m           | r | vm vs2 vd         | 010100......00010010.....1010111
+vmsif.m           | r | vm vs2 vd         | 010100......00011010.....1010111
+viota.m           | r | vm vs2 vd         | 010100......10000010.....1010111
+vid.v             | r | vm vd             | 010100.0000010001010.....1010111
+vcpop.m           | r | vm vs2 rd         | 010000......10000010.....1010111
+vfirst.m          | r | vm vs2 rd         | 010000......10001010.....1010111
+
+vdivu.vv          | r | vm vs2 vs1 vd     | 100000...........010.....1010111
+vdiv.vv           | r | vm vs2 vs1 vd     | 100001...........010.....1010111
+vremu.vv          | r | vm vs2 vs1 vd     | 100010...........010.....1010111
+vrem.vv           | r | vm vs2 vs1 vd     | 100011...........010.....1010111
+vmulhu.vv         | r | vm vs2 vs1 vd     | 100100...........010.....1010111
+vmul.vv           | r | vm vs2 vs1 vd     | 100101...........010.....1010111
+vmulhsu.vv        | r | vm vs2 vs1 vd     | 100110...........010.....1010111
+vmulh.vv          | r | vm vs2 vs1 vd     | 100111...........010.....1010111
+vmadd.vv          | r | vm vs2 vs1 vd     | 101001...........010.....1010111
+vnmsub.vv         | r | vm vs2 vs1 vd     | 101011...........010.....1010111
+vmacc.vv          | r | vm vs2 vs1 vd     | 101101...........010.....1010111
+vnmsac.vv         | r | vm vs2 vs1 vd     | 101111...........010.....1010111
+
+vwaddu.vv         | r | vm vs2 vs1 vd     | 110000...........010.....1010111
+vwadd.vv          | r | vm vs2 vs1 vd     | 110001...........010.....1010111
+vwsubu.vv         | r | vm vs2 vs1 vd     | 110010...........010.....1010111
+vwsub.vv          | r | vm vs2 vs1 vd     | 110011...........010.....1010111
+vwaddu.wv         | r | vm vs2 vs1 vd     | 110100...........010.....1010111
+vwadd.wv          | r | vm vs2 vs1 vd     | 110101...........010.....1010111
+vwsubu.wv         | r | vm vs2 vs1 vd     | 110110...........010.....1010111
+vwsub.wv          | r | vm vs2 vs1 vd     | 110111...........010.....1010111
+vwmulu.vv         | r | vm vs2 vs1 vd     | 111000...........010.....1010111
+vwmulsu.vv        | r | vm vs2 vs1 vd     | 111010...........010.....1010111
+vwmul.vv          | r | vm vs2 vs1 vd     | 111011...........010.....1010111
+vwmaccu.vv        | r | vm vs2 vs1 vd     | 111100...........010.....1010111
+vwmacc.vv         | r | vm vs2 vs1 vd     | 111101...........010.....1010111
+vwmaccsu.vv       | r | vm vs2 vs1 vd     | 111111...........010.....1010111
+
+# OPMVX
+vaaddu.vx         | r | vm vs2 rs1 vd     | 001000...........110.....1010111
+vaadd.vx          | r | vm vs2 rs1 vd     | 001001...........110.....1010111
+vasubu.vx         | r | vm vs2 rs1 vd     | 001010...........110.....1010111
+vasub.vx          | r | vm vs2 rs1 vd     | 001011...........110.....1010111
+
+vmv.s.x           | r | rs1 vd            | 010000100000.....110.....1010111
+vslide1up.vx      | r | vm vs2 rs1 vd     | 001110...........110.....1010111
+vslide1down.vx    | r | vm vs2 rs1 vd     | 001111...........110.....1010111
+
+vdivu.vx          | r | vm vs2 rs1 vd     | 100000...........110.....1010111
+vdiv.vx           | r | vm vs2 rs1 vd     | 100001...........110.....1010111
+vremu.vx          | r | vm vs2 rs1 vd     | 100010...........110.....1010111
+vrem.vx           | r | vm vs2 rs1 vd     | 100011...........110.....1010111
+vmulhu.vx         | r | vm vs2 rs1 vd     | 100100...........110.....1010111
+vmul.vx           | r | vm vs2 rs1 vd     | 100101...........110.....1010111
+vmulhsu.vx        | r | vm vs2 rs1 vd     | 100110...........110.....1010111
+vmulh.vx          | r | vm vs2 rs1 vd     | 100111...........110.....1010111
+vmadd.vx          | r | vm vs2 rs1 vd     | 101001...........110.....1010111
+vnmsub.vx         | r | vm vs2 rs1 vd     | 101011...........110.....1010111
+vmacc.vx          | r | vm vs2 rs1 vd     | 101101...........110.....1010111
+vnmsac.vx         | r | vm vs2 rs1 vd     | 101111...........110.....1010111
+
+vwaddu.vx         | r | vm vs2 rs1 vd     | 110000...........110.....1010111
+vwadd.vx          | r | vm vs2 rs1 vd     | 110001...........110.....1010111
+vwsubu.vx         | r | vm vs2 rs1 vd     | 110010...........110.....1010111
+vwsub.vx          | r | vm vs2 rs1 vd     | 110011...........110.....1010111
+vwaddu.wx         | r | vm vs2 rs1 vd     | 110100...........110.....1010111
+vwadd.wx          | r | vm vs2 rs1 vd     | 110101...........110.....1010111
+vwsubu.wx         | r | vm vs2 rs1 vd     | 110110...........110.....1010111
+vwsub.wx          | r | vm vs2 rs1 vd     | 110111...........110.....1010111
+vwmulu.vx         | r | vm vs2 rs1 vd     | 111000...........110.....1010111
+vwmulsu.vx        | r | vm vs2 rs1 vd     | 111010...........110.....1010111
+vwmul.vx          | r | vm vs2 rs1 vd     | 111011...........110.....1010111
+vwmaccu.vx        | r | vm vs2 rs1 vd     | 111100...........110.....1010111
+vwmacc.vx         | r | vm vs2 rs1 vd     | 111101...........110.....1010111
+vwmaccus.vx       | r | vm vs2 rs1 vd     | 111110...........110.....1010111
+vwmaccsu.vx       | r | vm vs2 rs1 vd     | 111111...........110.....1010111

--- a/make/CMake_riscv64_gen_codec.cmake
+++ b/make/CMake_riscv64_gen_codec.cmake
@@ -72,6 +72,7 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/rvc.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/svinval.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/system.txt
+          ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/v.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/xtheadcmo.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/xtheadsync.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/zicbom.txt


### PR DESCRIPTION
This is the first part of adding RISC-V vector (RVV) extension support to the core.

RVV is a vector architecture similar to SVE, and its vector length (VLEN) can vary from 64 up to 65536. For more information about RVV, please refer to https://github.com/riscv/riscv-isa-manual.

The code itself is compiled and preliminarily tested on real hardware with RVV (VLEN=256) support by running https://github.com/riscv-non-isa/rvv-intrinsic-doc/blob/main/examples/rvv_strlen.c.

isl/v.txt is transformed from https://github.com/riscv/riscv-opcodes/blob/master/rv_v by an off-tree one-time python script.

Follow-up patches will address the following parts with RVV support:
- encoder/decoder unit tests;
- code cache context switch;
- clean-call;
- signal context;
- scatter/gather emulation;
- sample clients and dr$sim;
- and maybe more.

Issue: #3544