### PR TITLE
i#6660 dr$sim aliases: Add "-t drmemtrace"

### DIFF
--- a/README
+++ b/README
@@ -60,9 +60,9 @@ To run the application with a DynamoRIO sample client:
 
 To run the application with a DynamoRIO-based tool:
 32-bit:
-  % bin32/drrun -t drcachesim -- ls
+  % bin32/drrun -t drmemtrace -- ls
 64-bit
-  % bin64/drrun -t drcachesim -- ls
+  % bin64/drrun -t drmemtrace -- ls
 
 To run the Dr. Memory tool which is included in release packages:
   % bin32/drrun -t drmemory -- <my-32-bit-app> <args-to-app>

--- a/api/docs/new_release.dox
+++ b/api/docs/new_release.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -161,8 +161,8 @@ bin64/drrun -t drltrace -- /work/dr/test/hello64
 bin32/drrun -t drmemory -- /work/dr/test/hello
 bin32/drrun -t drmemory_light -- /work/dr/test/hello
 bin64/drrun -t drmemory -- /work/dr/test/hello64
-bin32/drrun -t drcachesim -- /work/dr/test/hello
-bin64/drrun -t drcachesim -- /work/dr/test/hello64
+bin32/drrun -t drmemtrace -- /work/dr/test/hello
+bin64/drrun -t drmemtrace -- /work/dr/test/hello64
 bin32/drrun -t drcpusim -cpu PentiumPro -- /work/dr/test/hello
 bin64/drrun -t drcpusim -cpu Banias -- /work/dr/test/hello64
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -236,6 +236,8 @@ Further non-compatibility-affecting changes include:
    #DR_ISA_REGDEPS traces.
  - Added -tool as the preferred alias for -simulator_type for the drmemtrace/drcachesim
    trace analysis tool framework.
+ - Added "-t drmemtrace" as the preferred launcher for the drmemtrace/drcachesim
+   trace analysis tool framework.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -660,7 +660,7 @@ add_win32_flags(drmemtrace_schedule_stats)
 add_win32_flags(directory_iterator)
 add_win32_flags(test_helpers)
 if (WIN32 AND DEBUG)
-  get_target_property(sim_srcs drcachesim SOURCES)
+  get_target_property(sim_srcs drmemtrace_launcher SOURCES)
   get_target_property(raw2trace_srcs drraw2trace SOURCES)
   # The client, and our standalone DR users, had /MT added so we need to override.
   # XXX: solve this by avoiding the /MT in the first place!
@@ -755,10 +755,10 @@ if (WIN32)
   DR_install(FILES "${configlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
   DynamoRIO_get_full_path(drlib_loc dynamorio "${location_suffix}")
   DR_install(FILES "${drlib_loc}"  DESTINATION "${INSTALL_CLIENTS_BIN}")
-  add_custom_command(TARGET drcachesim POST_BUILD
+  add_custom_command(TARGET drmemtrace_launcher POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drinjectlib.dll
     ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/drinjectlib.dll VERBATIM)
-  add_custom_command(TARGET drcachesim POST_BUILD
+  add_custom_command(TARGET drmemtrace_launcher POST_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drconfiglib.dll
     ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/drconfiglib.dll VERBATIM)
   # Avoid dueling racy copies (i#4668).

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2023 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2024 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -272,28 +272,28 @@ set(drcachesim_srcs
   tracer/instru_online.cpp
   ${loader_srcs})
 
-add_executable(drcachesim ${drcachesim_srcs})
+add_executable(drmemtrace_launcher ${drcachesim_srcs})
 # In order to embed raw2trace we need to be standalone:
-configure_DynamoRIO_standalone(drcachesim)
+configure_DynamoRIO_standalone(drmemtrace_launcher)
 # Link in our tools:
-target_link_libraries(drcachesim drmemtrace_simulator drmemtrace_reuse_distance
+target_link_libraries(drmemtrace_launcher drmemtrace_simulator drmemtrace_reuse_distance
   drmemtrace_histogram drmemtrace_reuse_time drmemtrace_basic_counts
   drmemtrace_opcode_mix drmemtrace_syscall_mix drmemtrace_view drmemtrace_func_view
   drmemtrace_raw2trace directory_iterator drmemtrace_invariant_checker
   drmemtrace_schedule_stats drmemtrace_record_filter)
 if (UNIX)
-    target_link_libraries(drcachesim dl)
+    target_link_libraries(drmemtrace_launcher dl)
 endif ()
 if (libsnappy)
-  target_link_libraries(drcachesim snappy)
+  target_link_libraries(drmemtrace_launcher snappy)
 endif ()
 # To avoid dup symbol errors between drinjectlib and drdecode on Windows we have
 # to explicitly list drdecode up front:
-target_link_libraries(drcachesim drdecode drinjectlib drconfiglib drfrontendlib)
-use_DynamoRIO_extension(drcachesim droption)
+target_link_libraries(drmemtrace_launcher drdecode drinjectlib drconfiglib drfrontendlib)
+use_DynamoRIO_extension(drmemtrace_launcher droption)
 # These are also for raw2trace:
-use_DynamoRIO_extension(drcachesim drcovlib_static)
-use_DynamoRIO_extension(drcachesim drutil_static)
+use_DynamoRIO_extension(drmemtrace_launcher drcovlib_static)
+use_DynamoRIO_extension(drmemtrace_launcher drutil_static)
 
 # This is to avoid ../ and common/ in the #includes of headers that we
 # export in a single dir for 3rd-party tool integration.
@@ -444,7 +444,7 @@ if (NOT APPLE)
   configure_DynamoRIO_static(opcode_mix_launcher)
 endif ()
 
-target_link_libraries(drcachesim ${zlib_libs})
+target_link_libraries(drmemtrace_launcher ${zlib_libs})
 target_link_libraries(histogram_launcher ${zlib_libs})
 target_link_libraries(prefetch_analyzer_launcher ${zlib_libs})
 target_link_libraries(drmemtrace_raw2trace ${zlib_libs})
@@ -569,7 +569,7 @@ macro(restore_nonclient_flags target)
   endif ()
 endmacro()
 
-restore_nonclient_flags(drcachesim)
+restore_nonclient_flags(drmemtrace_launcher)
 restore_nonclient_flags(drraw2trace)
 restore_nonclient_flags(histogram_launcher)
 restore_nonclient_flags(record_filter_launcher)
@@ -634,7 +634,7 @@ macro(add_win32_flags target)
   endif ()
 endmacro ()
 
-add_win32_flags(drcachesim)
+add_win32_flags(drmemtrace_launcher)
 add_win32_flags(drraw2trace)
 add_win32_flags(histogram_launcher)
 add_win32_flags(record_filter_launcher)
@@ -673,18 +673,18 @@ endif ()
 
 place_shared_lib_in_lib_dir(drmemtrace)
 
-add_dependencies(drcachesim api_headers)
+add_dependencies(drmemtrace_launcher api_headers)
 
 # Provide a hint for how to use the client
 if (NOT DynamoRIO_INTERNAL OR NOT "${CMAKE_GENERATOR}" MATCHES "Ninja")
   add_custom_command(TARGET drmemtrace
     POST_BUILD
     COMMAND ${CMAKE_COMMAND}
-    ARGS -E echo "Usage: pass to drconfig or drrun: -t drcachesim"
+    ARGS -E echo "Usage: pass to drconfig or drrun: -t drmemtrace"
     VERBATIM)
 endif ()
 
-install_target(drcachesim ${INSTALL_CLIENTS_BIN})
+install_target(drmemtrace_launcher ${INSTALL_CLIENTS_BIN})
 install_target(drraw2trace ${INSTALL_CLIENTS_BIN})
 
 set(INSTALL_DRCACHESIM_CONFIG ${INSTALL_CLIENTS_BASE})
@@ -708,7 +708,7 @@ function (write_config_file dst bindir libdir)
   endif ()
   file(GENERATE OUTPUT ${dst} CONTENT
 "# drcachesim tool config file\n\
-FRONTEND_REL=${bindir}/$<TARGET_FILE_NAME:drcachesim>\n\
+FRONTEND_REL=${bindir}/$<TARGET_FILE_NAME:drmemtrace_launcher>\n\
 TOOL_OP=-dr\n\
 TOOL_OP_DR_PATH\n\
 TOOL_OP_DR_BUNDLE=-dr_ops\n\
@@ -720,11 +720,16 @@ ${debugopt}\n")
 endfunction ()
 
 if (X64)
-  set(CONFIG_INSTALL ${PROJECT_BINARY_DIR}/drcachesim.drrun64)
-  set(CONFIG_BUILD ${PROJECT_BINARY_DIR}/tools/drcachesim.drrun64)
+  set(CONFIG_INSTALL ${PROJECT_BINARY_DIR}/drmemtrace.drrun64)
+  set(CONFIG_BUILD ${PROJECT_BINARY_DIR}/tools/drmemtrace.drrun64)
+  # Support the older launcher name.
+  set(CONFIG_OLD_INSTALL ${PROJECT_BINARY_DIR}/drcachesim.drrun64)
+  set(CONFIG_OLD_BUILD ${PROJECT_BINARY_DIR}/tools/drcachesim.drrun64)
 else (X64)
-  set(CONFIG_INSTALL ${PROJECT_BINARY_DIR}/drcachesim.drrun32)
-  set(CONFIG_BUILD ${PROJECT_BINARY_DIR}/tools/drcachesim.drrun32)
+  set(CONFIG_INSTALL ${PROJECT_BINARY_DIR}/drmemtrace.drrun32)
+  set(CONFIG_BUILD ${PROJECT_BINARY_DIR}/tools/drmemtrace.drrun32)
+  set(CONFIG_OLD_INSTALL ${PROJECT_BINARY_DIR}/drcachesim.drrun32)
+  set(CONFIG_OLD_BUILD ${PROJECT_BINARY_DIR}/tools/drcachesim.drrun32)
 endif (X64)
 
 set(BUILD_CLIENTS_BIN clients/${INSTALL_BIN})
@@ -732,8 +737,14 @@ set(BUILD_CLIENTS_LIB clients/${INSTALL_LIB})
 
 write_config_file(${CONFIG_INSTALL} ${INSTALL_CLIENTS_BIN} ${INSTALL_CLIENTS_LIB})
 write_config_file(${CONFIG_BUILD} ${BUILD_CLIENTS_BIN} ${BUILD_CLIENTS_LIB})
+# Support the older launcher name.
+write_config_file(${CONFIG_OLD_INSTALL} ${INSTALL_CLIENTS_BIN} ${INSTALL_CLIENTS_LIB})
+write_config_file(${CONFIG_OLD_BUILD} ${BUILD_CLIENTS_BIN} ${BUILD_CLIENTS_LIB})
 
 DR_install(FILES "${CONFIG_INSTALL}" DESTINATION ${INSTALL_DRCACHESIM_CONFIG})
+register_tool_file("drmemtrace")
+# Support the older launcher name.
+DR_install(FILES "${CONFIG_OLD_INSTALL}" DESTINATION ${INSTALL_DRCACHESIM_CONFIG})
 register_tool_file("drcachesim")
 
 if (WIN32)
@@ -751,7 +762,7 @@ if (WIN32)
     COMMAND ${CMAKE_COMMAND} ARGS -E copy ${DR_LIBRARY_BASE_DIRECTORY}/drconfiglib.dll
     ${PROJECT_BINARY_DIR}/${BUILD_CLIENTS_BIN}/drconfiglib.dll VERBATIM)
   # Avoid dueling racy copies (i#4668).
-  add_dependencies(drcachesim client_dr_copy)
+  add_dependencies(drmemtrace_launcher client_dr_copy)
 endif ()
 
 add_subdirectory(tools/external)

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -707,7 +707,7 @@ function (write_config_file dst bindir libdir)
     set(debugopt "")
   endif ()
   file(GENERATE OUTPUT ${dst} CONTENT
-"# drcachesim tool config file\n\
+"# drmemtrace tracing and analysis tool config file.\n\
 FRONTEND_REL=${bindir}/$<TARGET_FILE_NAME:drmemtrace_launcher>\n\
 TOOL_OP=-dr\n\
 TOOL_OP_DR_PATH\n\
@@ -722,7 +722,8 @@ endfunction ()
 if (X64)
   set(CONFIG_INSTALL ${PROJECT_BINARY_DIR}/drmemtrace.drrun64)
   set(CONFIG_BUILD ${PROJECT_BINARY_DIR}/tools/drmemtrace.drrun64)
-  # Support the older launcher name.
+  # Support the older launcher name (i#6660 applied s/drcachesim/drmemtrace/ as
+  # "drcachesim" is just one tool and we use "drmemtrace" to refer to the framework).
   set(CONFIG_OLD_INSTALL ${PROJECT_BINARY_DIR}/drcachesim.drrun64)
   set(CONFIG_OLD_BUILD ${PROJECT_BINARY_DIR}/tools/drcachesim.drrun64)
 else (X64)
@@ -737,13 +738,13 @@ set(BUILD_CLIENTS_LIB clients/${INSTALL_LIB})
 
 write_config_file(${CONFIG_INSTALL} ${INSTALL_CLIENTS_BIN} ${INSTALL_CLIENTS_LIB})
 write_config_file(${CONFIG_BUILD} ${BUILD_CLIENTS_BIN} ${BUILD_CLIENTS_LIB})
-# Support the older launcher name.
+# Support the older launcher name (i#6660 renamed it).
 write_config_file(${CONFIG_OLD_INSTALL} ${INSTALL_CLIENTS_BIN} ${INSTALL_CLIENTS_LIB})
 write_config_file(${CONFIG_OLD_BUILD} ${BUILD_CLIENTS_BIN} ${BUILD_CLIENTS_LIB})
 
 DR_install(FILES "${CONFIG_INSTALL}" DESTINATION ${INSTALL_DRCACHESIM_CONFIG})
 register_tool_file("drmemtrace")
-# Support the older launcher name.
+# Support the older launcher name (i#6660 renamed it).
 DR_install(FILES "${CONFIG_OLD_INSTALL}" DESTINATION ${INSTALL_DRCACHESIM_CONFIG})
 register_tool_file("drcachesim")
 

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -39,10 +39,10 @@
 ***************************************************************************
 \page page_drcachesim Tracing and Analysis Framework
 
-\p drcachesim is a DynamoRIO client that collects instruction and
-memory access traces using its \p drmemtrace component and
+\p drmemtrace is a DynamoRIO client that collects instruction and
+memory access traces and
 feeds them to either an online or offline tool for analysis.  The default
-analysis tool is a CPU cache simulator, while other provided tools compute
+analysis tool is the \p drcachesim CPU cache simulator, while other provided tools compute
 metrics such as reuse distance.  The trace collector and simulator support
 multiple processes each with multiple threads.  The analysis tool framework
 is extensible, supporting the creation of new tools which can operate both
@@ -77,16 +77,16 @@ targets are provided up front.  These join the recent features of
 ****************************************************************************
 \page sec_drcachesim Overview
 
-\p drcachesim consists of two components: a tracer \p drmemtrace and an analyzer.
+\p drmemtrace consists of two types of components: the tracer and trace analyzers.
 The tracer collects a memory access trace from each thread within each
 application process.
-The analyzer consumes the traces (online or offline) and performs
+A trace analyzer consumes the traces (online or offline) and performs
 customized analysis.
-It is designed to be extensible, allowing users to easily implement a
-simulator for different devices, such as CPU caches, TLBs, page
+The framework is designed to be extensible, allowing users to easily extend the
+existing simulators for different devices such as CPU caches, TLBs, page
 caches, etc. (see \ref sec_drcachesim_extend), or to build arbitrary trace
 analysis tools (see \ref sec_drcachesim_newtool).
-The default analyzer simulates the architectural behavior of caching
+The default analyzer \p drcachesim simulates the architectural behavior of caching
 devices for a target application (or multiple applications).
 
 ****************************************************************************
@@ -191,12 +191,13 @@ Some of the more important markers are:
 The full set of markers is listed under the enum #dynamorio::drmemtrace::trace_marker_type_t.
 
 ****************************************************************************
-\page sec_drcachesim_run Running the Simulator
+\page sec_drcachesim_run Running the Cache Simulator
 
-To launch \p drcachesim, use the \p -t flag to \p drrun:
+To launch \p drcachesim, use the \p -t flag to \p drrun and specify the
+\p drmemtrace framework where the default tool to run is the cache simulator:
 
 \code
-$ bin64/drrun -t drcachesim -- /path/to/target/app <args> <for> <app>
+$ bin64/drrun -t drmemtrace -- /path/to/target/app <args> <for> <app>
 \endcode
 
 The target application will be launched under a DynamoRIO tracer
@@ -209,7 +210,7 @@ memory references passed to the simulator as well.
 Here is an example:
 
 \code
-$ bin64/drrun -t drcachesim -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Cache simulation results:
@@ -282,9 +283,9 @@ tools can also be created, as described in \ref sec_drcachesim_newtool.
 
 This is the default tool.  Here is an exmample of running it on an offline trace:
 \code
-$ bin64/drrun -t drcachesim -offline -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -offline -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
-$ bin64/drrun -t drcachesim -indir drmemtrace.*.dir
+$ bin64/drrun -t drmemtrace -indir drmemtrace.*.dir
 Cache simulation results:
 Core #0 (1 thread(s))
   L1I stats:
@@ -335,7 +336,7 @@ LL stats:
 To simulate TLB devices instead of caches, pass \p TLB to \p -tool:
 
 \code
-$ bin64/drrun -t drcachesim -tool TLB -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -tool TLB -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 TLB simulation results:
@@ -392,7 +393,7 @@ Core #3 (0 thread(s))
 To compute reuse distance metrics:
 
 \code
-$ bin64/drrun -t drcachesim -tool reuse_distance -reuse_distance_histogram -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -tool reuse_distance -reuse_distance_histogram -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Reuse distance tool aggregated results:
@@ -486,7 +487,7 @@ accesses (without considering uniqueness) between accesses to the same
 address:
 
 \code
-$ bin64/drrun -t drcachesim -tool reuse_time -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -tool reuse_time -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Reuse time tool aggregated results:
@@ -528,7 +529,7 @@ To simply see the counts of instructions and memory references broken down
 by thread use the basic counts tool:
 
 \code
-$ bin64/drrun -t drcachesim -tool basic_counts -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -tool basic_counts -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Basic counts tool results:
@@ -643,9 +644,9 @@ down by the opcodes used in DR's IR, where for x86 \p mov is split into a separa
 opcode for load and store but both have the same public string "mov":
 
 \code
-$ bin64/drrun -t drcachesim -offline -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -offline -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
-$ bin64/drrun -t drcachesim -tool opcode_mix -indir drmemtrace.*.dir
+$ bin64/drrun -t drmemtrace -tool opcode_mix -indir drmemtrace.*.dir
 Opcode mix tool results:
          267271 : total executed instructions
           36432 :       mov
@@ -695,7 +696,7 @@ In its first two columns, the tool displays the trace record ordinal
 and the instruction fetch ordinal.
 
 \code
-$ $ bin64/drrun -t drcachesim -tool view -indir drmemtrace.*.dir -sim_refs 20
+$ $ bin64/drrun -t drmemtrace -tool view -indir drmemtrace.*.dir -sim_refs 20
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
@@ -793,9 +794,9 @@ function names specified at tracing time. See \ref sec_drcachesim_funcs for
 more information.
 
 \code
-$ bin64/drrun -t drcachesim -offline -record_function 'fib|1' -- ~/test/fib 5
+$ bin64/drrun -t drmemtrace -offline -record_function 'fib|1' -- ~/test/fib 5
 Estimation of pi is 3.142425985001098
-$ bin64/drrun -t drcachesim -tool func_view -indir drmemtrace.*.dir
+$ bin64/drrun -t drmemtrace -tool func_view -indir drmemtrace.*.dir
 0x7fc06d2288eb => common.fib!fib(0x5)
     0x7fc06d22888e => common.fib!fib(0x4)
         0x7fc06d22888e => common.fib!fib(0x3)
@@ -829,7 +830,7 @@ Function id=0: common.fib!fib
 The top referenced cache lines are displayed by the \p histogram tool:
 
 \code
-$ bin64/drrun -t drcachesim -tool histogram -- ~/test/pi_estimator
+$ bin64/drrun -t drmemtrace -tool histogram -- ~/test/pi_estimator
 Estimation of pi is 3.142425985001098
 ---- <application exited with code 0> ----
 Cache line histogram tool results:
@@ -877,7 +878,7 @@ number. This works only with traces that have these markers; that is, offline tr
 must have #dynamorio::drmemtrace::OFFLINE_FILE_TYPE_SYSCALL_NUMBERS in their file type.
 
 \code
-$ bin64/drrun -t drcachesim -indir drmemtrace.ls.*.dir -tool syscall_mix
+$ bin64/drrun -t drmemtrace -indir drmemtrace.ls.*.dir -tool syscall_mix
 Syscall mix tool results:
           count : syscall_num
              17 :         9
@@ -929,7 +930,7 @@ option.
 Example of removing function markers:
 
 \code
-$ bin64/drrun -t drcachesim -indir mytracedir -tool basic_counts
+$ bin64/drrun -t drmemtrace -indir mytracedir -tool basic_counts
 ...
         9009 total function id markers
         5006 total function return address markers
@@ -937,10 +938,10 @@ $ bin64/drrun -t drcachesim -indir mytracedir -tool basic_counts
         4003 total function return value markers
 ...
 
-$ bin64/drrun -t drcachesim -tool record_filter -filter_marker_types 4,5,6,7 -indir mytracedir -outdir newdir
+$ bin64/drrun -t drmemtrace -tool record_filter -filter_marker_types 4,5,6,7 -indir mytracedir -outdir newdir
 Output 1280800 entries from 1304825 entries.
 
-$ bin64/drrun -t drcachesim -indir newdir -tool basic_counts
+$ bin64/drrun -t drmemtrace -indir newdir -tool basic_counts
 ...
            0 total function id markers
            0 total function return address markers
@@ -1134,14 +1135,14 @@ LLC {                          // LLC
 
 To dump a trace for future offline analysis, use the \p offline parameter:
 \code
-$ bin64/drrun -t drcachesim -offline -- /path/to/target/app <args> <for> <app>
+$ bin64/drrun -t drmemtrace -offline -- /path/to/target/app <args> <for> <app>
 \endcode
 
 The collected traces will be dumped into a newly created directory,
-which can be passed to drcachesim for offline cache simulation with the \p
+which can be passed to drmemtrace for offline analysis with the \p
 -indir option:
 \code
-$ bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/
+$ bin64/drrun -t drmemtrace -indir drmemtrace.app.pid.xxxx.dir/
 \endcode
 
 The direct results of the \p -offline run are raw, compacted files, stored
@@ -1156,7 +1157,7 @@ re-converting it.  Either the top-level directory or the \p trace/
 subdirectory may be pointed at with \p -indir:
 
 \code
-$ bin64/drrun -t drcachesim -indir drmemtrace.app.pid.xxxx.dir/trace
+$ bin64/drrun -t drmemtrace -indir drmemtrace.app.pid.xxxx.dir/trace
 \endcode
 
 If built with the zlib library, the canonical trace files are
@@ -1176,7 +1177,7 @@ Older versions of the simulator produced a single trace file containing all thre
 interleaved.  The \p -infile option supports reading these legacy files:
 \code
 $ gzip drmemtrace.app.pid.xxxx.dir/drmemtrace.trace
-$ bin64/drrun -t drcachesim -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace.gz
+$ bin64/drrun -t drmemtrace -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace.gz
 \endcode
 
 The same analysis tools used online are available for offline: the trace
@@ -1188,7 +1189,7 @@ with offline traces, see \ref page_debug_memtrace.
 ****************************************************************************
 \page sec_drcachesim_filter Filtered Traces
 
-Filtered traces are \p drcachesim traces filtered by an online first-level
+Filtered traces are \p drmemtrace traces filtered by an online first-level
 cache.
 
 - The \p -L0I_filter and \p -L0D_filter options can be used to enable the
@@ -1253,7 +1254,7 @@ limited in several ways:
   #dynamorio::drmemtrace::TRACE_MARKER_TYPE_WINDOW_ID markers indicate start of
   filtered records.
 
-If the application can be modified, it can be linked with the \p drcachesim
+If the application can be modified, it can be linked with the \p drmemtrace
 tracer and use DynamoRIO's start/stop API routines dr_app_setup_and_start()
 and dr_app_stop_and_cleanup() to delimit the desired trace region.  As an
 example, see <a
@@ -1296,7 +1297,7 @@ running an application with many threads on a pysical machine with 8 cpus.
 The 8 cpus are mapped to the 4 simulated cores:
 
 \code
-$ bin64/drrun -t drcachesim -cpu_scheduling -- ~/test/pi_estimator 20
+$ bin64/drrun -t drmemtrace -cpu_scheduling -- ~/test/pi_estimator 20
 Estimation of pi is 3.141592653798125
 <Stopping application /home/bruening/dr/test/threadsig (213517)>
 ---- <application exited with code 0> ----
@@ -1401,7 +1402,7 @@ For example, to run the analyzer on a benchmark called "my_benchmark" and store
 the prefetching recommendations in a file called "rec.csv", run the following:
 
 \code
-$ bin64/drrun -t drcachesim -tool miss_analyzer -LL_miss_file rec.csv -- my_benchmark
+$ bin64/drrun -t drmemtrace -tool miss_analyzer -LL_miss_file rec.csv -- my_benchmark
 \endcode
 
 
@@ -1436,14 +1437,14 @@ is specified.
 ****************************************************************************
 \page sec_drcachesim_core Core Simulation Support
 
-The \p drcachesim trace format includes information intended for use by
+The \p drmemtrace trace format includes information intended for use by
 core simulators as well as pure cache simulators.  For traces that are not
 filtered by an online first-level cache, each data reference is preceded by
 the instruction fetch entry for the instruction that issued the data
 request, which includes the instruction encoding with the opcode and operands.
 Additionally, on x86, string loop
 instructions involve a single insruction fetch followed by a loop of loads
-and/or stores.  A \p drcachesim trace includes a special "no-fetch"
+and/or stores.  A \p drmemtrace trace includes a special "no-fetch"
 instruction entry per iteration so that core simulators have the
 instruction information to go along with each load and store, while cache
 simulators can ignore these "no-fetch" entries and avoid incorrectly
@@ -1530,7 +1531,7 @@ to record is specified for each name, using a bar character to
 separate them.  An ampersand separates functions.  Here is an example:
 
 \code
-$ bin64/drrun -t drcachesim -offline -record_function 'fib|1&calloc|2'
+$ bin64/drrun -t drmemtrace -offline -record_function 'fib|1&calloc|2'
 \endcode
 
 Within the trace, each function is identified by a numeric identifier.
@@ -1552,7 +1553,7 @@ name.
 ****************************************************************************
 \page sec_drcachesim_newtool Creating New Analysis Tools
 
-\p drcachesim provides a \p drmemtrace analysis tool framework to make it
+\p drmemtrace provides an analysis tool framework to make it
 easy to create new trace analysis tools.  A new tool should subclass
 #dynamorio::drmemtrace::analysis_tool_t.
 
@@ -1667,8 +1668,8 @@ functions.
 
 \section external_tools Separately-Built Tools
 
-\p drcachesim \p drmemtrace analysis tool framework allows to load
-non-predefined separately-built external tools. This tool can be loaded by drcachesim
+The \p drmemtrace analysis tool framework allows loading
+non-predefined separately-built external tools. Such tools can be loaded by \p drmemtrace
 using the \p -tool option.
 
 ## External tool package
@@ -1690,12 +1691,12 @@ CREATOR_BIN32=/absolute/path/to/32-bit-creator-library
 CREATOR_BIN64=/absolute/path/to/64-bit-creator-library
 \endcode
 
-This enables \p drcachesim to locate the tool's creator library.  The 32 and
+This enables \p drmemtrace to locate the tool's creator library.  The 32 and
 64 specifiers allow pointing at alternate-bitwidth paths for use if
 the target application creates a child process of a different bitwidth.
 
 For more extensive actions on launching the tool, a custom front-end
-executable can be created that replaces \p drcachesim modeled after histogram_launcher.cpp
+executable can be created that replaces \p drmemtrace modeled after histogram_launcher.cpp
 or opcode_mix_launcher.cpp.
 
 The creator dynamic library should contain 2 export functions:
@@ -1714,7 +1715,7 @@ analysis_tool_create()
 }
 \endcode
 
-which allows \p drcachesim to create an analyis tool.  As an
+which allows \p drmemtrace to create an analyis tool.  As an
 example, see <a
 href="https://github.com/DynamoRIO/dynamorio/blob/master/clients/drcachesim/tools/external/example">
 minimal external analysis tool</a>.
@@ -1761,11 +1762,11 @@ tool framework's "external iterator" interface:
 ****************************************************************************
 \page sec_drcachesim_ops Simulator Parameters
 
-\p drcachesim's behavior can be controlled through options passed after the
-\p -c \p drcachesim but prior to the "--" delimiter on the command line:
+\p drmemtrace's behavior can be controlled through options passed after the
+\p -t \p drmemtrace but prior to the "--" delimiter on the command line:
 
 \code
-$ bin64/drrun -t drcachesim <options> <to> <drcachesim> -- /path/to/target/app <args> <for> <app>
+$ bin64/drrun -t drmemtrace <options> <to> <drmemtrace> -- /path/to/target/app <args> <for> <app>
 \endcode
 
 Boolean options can be disabled using a "-no_" prefix.
@@ -1778,7 +1779,7 @@ REPLACEME_WITH_OPTION_LIST
 ****************************************************************************
 \page sec_drcachesim_limit Current Limitations
 
-The \p drcachesim tool is a work in progress.  We welcome contributions in
+The \p drmemtrace framework is a work in progress.  We welcome contributions in
 these areas of missing functionality:
 
 - Multi-process online application simulation on Windows

--- a/clients/drcachesim/tests/drmemtrace.threadsig.aarch64.raw/README
+++ b/clients/drcachesim/tests/drmemtrace.threadsig.aarch64.raw/README
@@ -13,7 +13,7 @@ machine or cross-compile it) and strip it:
 Now run it with 4 threads and 2000 iterations, and possibly
 -unsafe_build_ldstex depending on your architecture:
 
-  $ bin64/drrun -unsafe_build_ldstex -t drcachesim -offline -- threadsig 4 2000
+  $ bin64/drrun -unsafe_build_ldstex -t drmemtrace -offline -- threadsig 4 2000
 
 Compress the raw files:
 

--- a/clients/drcachesim/tests/stride_benchmark.cpp
+++ b/clients/drcachesim/tests/stride_benchmark.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2023 Google LLC  All rights reserved.
+ * Copyright (c) 2018-2024 Google LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -41,7 +41,7 @@
  * * Compile the microbenchmark. Assuming g++ is the compiler being used:
  *   $ g++ -O3 -o stride_benchmark stride_benchmark.cpp
  * * Run the analyzer:
- *   $ bin64/drrun -t drcachesim -simulator_type miss_analyzer -LL_miss_file rec.csv -- \
+ *   $ bin64/drrun -t drmemtrace -tool miss_analyzer -LL_miss_file rec.csv -- \
  *     stride_benchmark
  *
  */

--- a/clients/drcachesim/tools/external/example/CMakeLists.txt
+++ b/clients/drcachesim/tools/external/example/CMakeLists.txt
@@ -103,7 +103,7 @@ if (X86 AND X64 AND ZIP_FOUND)
   set(trace_dir
     "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir")
   add_test(NAME drcachesim.empty_load
-    COMMAND ${PROJECT_BINARY_DIR}/bin64/drrun -t drcachesim -offline
+    COMMAND ${PROJECT_BINARY_DIR}/bin64/drrun -t drmemtrace -offline
      -tool empty -indir ${trace_dir})
   set(empty_regex "Empty tool created\nEmpty tool results:")
   set_tests_properties(drcachesim.empty_load
@@ -111,7 +111,7 @@ if (X86 AND X64 AND ZIP_FOUND)
 
   # Simple test to ensure non-existent tool load by drcachesim should fail.
   add_test(NAME drcachesim.non-existent_load
-    COMMAND ${PROJECT_BINARY_DIR}/bin64/drrun -t drcachesim -offline
+    COMMAND ${PROJECT_BINARY_DIR}/bin64/drrun -t drmemtrace -offline
      -tool non-existent -indir ${trace_dir})
   set(nonexistent_regex "Usage error: unsupported analyzer type \"non-existent\". Please choose cache_simulator, miss_analyzer, TLB_simulator, histogram, reuse_distance, basic_counts, opcode_mix, syscall_mix, view, func_view, or some external analyzer.\nERROR: failed to initialize analyzer: Failed to create analysis tool:")
   set_tests_properties(drcachesim.non-existent_load

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3643,11 +3643,11 @@ if (BUILD_CLIENTS)
     endif ()
 
     macro (torunonly_drcachesim testname exetgt sim_ops app_args)
-      torunonly_ci(tool.drcachesim.${testname} ${exetgt} drcachesim
+      torunonly_ci(tool.drcachesim.${testname} ${exetgt} drmemtrace_launcher
         "${testname}.c" # for templatex basename
         "-ipc_name ${IPC_PREFIX}drtestpipe_${testname} ${sim_ops}"
         "" "${app_args}")
-      set(tool.drcachesim.${testname}_toolname "drcachesim")
+      set(tool.drcachesim.${testname}_toolname "drmemtrace")
       set(tool.drcachesim.${testname}_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcachesim.${testname}_rawtemp ON) # no preprocessor
@@ -3806,10 +3806,10 @@ if (BUILD_CLIENTS)
 
     # Test other analysis tools
     macro (torunonly_simtool testname exetgt sim_ops app_args)
-      torunonly_ci(tool.${testname} ${exetgt} drcachesim
+      torunonly_ci(tool.${testname} ${exetgt} drmemtrace_launcher
         "${testname}.c" # for templatex basename
         "-ipc_name ${IPC_PREFIX}drtestpipe_${testname} ${sim_ops}" "" "${app_args}")
-      set(tool.${testname}_toolname "drcachesim")
+      set(tool.${testname}_toolname "drmemtrace")
       set(tool.${testname}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
     endmacro (torunonly_simtool)
 
@@ -3946,7 +3946,8 @@ if (BUILD_CLIENTS)
       # XXX: we could exclude the pipe files and build the offline trace
       # support by itself for Android.
       # TODO i#3544: Port tests to RISC-V 64
-      get_target_path_for_execution(drcachesim_path drcachesim "${location_suffix}")
+      get_target_path_for_execution(drcachesim_path drmemtrace_launcher
+        "${location_suffix}")
       prefix_cmd_if_necessary(drcachesim_path ON ${drcachesim_path})
       get_target_path_for_execution(drraw2trace_path drraw2trace "${location_suffix}")
       prefix_cmd_if_necessary(drraw2trace_path ON ${drraw2trace_path})
@@ -3971,12 +3972,12 @@ if (BUILD_CLIENTS)
         # Shrink test times on Appveyor.
         set(extra_ops "-max_trace_size 1M")
       endif ()
-      torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drcachesim
+      torunonly_ci(tool.drcacheoff.${testname} ${exetgt} drmemtrace_launcher
         "offline-${testname}.c" # for templatex basename
         # Set a test-unique prefix to avoid races removing/finding output.
         "-offline -subdir_prefix ${testname_full} ${extra_ops} ${tracer_ops}"
         "" "${app_args}")
-      set(${testname_full}_toolname "drcachesim")
+      set(${testname_full}_toolname "drmemtrace")
       set(${testname_full}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(${testname_full}_rawtemp ON) # no preprocessor
       set(${testname_full}_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
@@ -4311,10 +4312,10 @@ if (BUILD_CLIENTS)
       # Thus we run this manually and check in the resulting trace.  I ran with
       # a delay to shrink the size, since we are not interesting in the main thread's
       # pre-main() init:
-      #     $ bin64/drrun -t drcachesim -offline -trace_after_instrs 210K \
+      #     $ bin64/drrun -t drmemtrace -offline -trace_after_instrs 210K \
       #       -record_function 'fib|1&noret_func|2|noret&noargs|0' -- \
       #       suite/tests/bin/tool.fib_plus
-      #     $ bin64/drrun -t drcachesim -tool func_view -indir \
+      #     $ bin64/drrun -t drmemtrace -tool func_view -indir \
       #       drmemtrace*.dir/
       torunonly_api(tool.drcacheoff.func_view_noret "${drcachesim_path}"
         "offline-func_view_noret.c" ""
@@ -4484,13 +4485,13 @@ if (BUILD_CLIENTS)
           prefix_cmd_if_necessary(raw2trace_io_path ON ${raw2trace_io_path})
           macro (torunonly_raw2trace testname exetgt extra_ops app_args)
             set(testname_full "tool.raw2trace.${testname}")
-            torunonly_ci(tool.raw2trace.${testname} ${exetgt} drcachesim
+            torunonly_ci(tool.raw2trace.${testname} ${exetgt} drmemtrace_launcher
               "raw2trace-${testname}.c" # for templatex basename
               # Disable compression, since we need to seek and our compression
               # readers do not support seeking.
               "-offline -raw_compress none -subdir_prefix ${testname_full} ${extra_ops}"
               "" "${app_args}")
-            set(${testname_full}_toolname "drcachesim")
+            set(${testname_full}_toolname "drmemtrace")
             set(${testname_full}_basedir
               "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
             set(${testname_full}_rawtemp ON) # no preprocessor
@@ -4600,10 +4601,10 @@ if (BUILD_CLIENTS)
       set(histo_ops "")
     endif ()
     set(testname_full "tool.histogram.offline")
-    torunonly_ci(${testname_full} ${histo_app} drcachesim
+    torunonly_ci(${testname_full} ${histo_app} drmemtrace_launcher
       "histogram-offline.c"
       "-offline -subdir_prefix ${testname_full} ${histo_ops}" "" "")
-    set(${testname_full}_toolname "drcachesim")
+    set(${testname_full}_toolname "drmemtrace")
     set(${testname_full}_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
     set(${testname_full}_rawtemp ON) # no preprocessor
@@ -4627,10 +4628,10 @@ if (BUILD_CLIENTS)
       else ()
         set(extra_ops "")
       endif ()
-      torunonly_ci(${testname} ${exename} drcachesim
+      torunonly_ci(${testname} ${exename} drmemtrace_launcher
         "${template_name}.c"
         "-offline -subdir_prefix ${testname} ${extra_ops}" "" "")
-      set(${testname}_toolname "drcachesim")
+      set(${testname}_toolname "drmemtrace")
       set(${testname}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(outdir "${testname}.filtered.dir")
       set(${testname}_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
@@ -4747,10 +4748,10 @@ if (BUILD_CLIENTS)
 
     if (AARCH64)
       set(testname_full "tool.drcacheoff.allasm-aarch64-prefetch-counts")
-      torunonly_ci(${testname_full} allasm_aarch64_prefetch drcachesim
+      torunonly_ci(${testname_full} allasm_aarch64_prefetch drmemtrace_launcher
         "offline-allasm-aarch64-prefetch-counts"
         "-offline -subdir_prefix ${testname_full}" "" "")
-      set(${testname_full}_toolname "drcachesim")
+      set(${testname_full}_toolname "drmemtrace")
       set(${testname_full}_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(${testname_full}_rawtemp ON) # no preprocessor
@@ -4847,13 +4848,13 @@ if (BUILD_CLIENTS)
       get_target_path_for_execution(drpt2trace_path drpt2trace "${location_suffix}")
       macro (torunonly_drcacheoff_kernel testname exetgt extra_ops app_args sim_atops)
         set(testname_full "tool.drcacheoff.kernel.${testname}_SUDO")
-        torunonly_ci(${testname_full} ${exetgt} drcachesim
+        torunonly_ci(${testname_full} ${exetgt} drmemtrace_launcher
           "offline-kernel-${testname}.c" # for templatex basename
           "-offline -enable_kernel_tracing -subdir_prefix ${testname_full} ${extra_ops}"
           "" "${app_args}")
         set(${testname_full}_sudo ON)
         set(${testname_full}_self_serial ON)
-        set(${testname_full}_toolname "drcachesim")
+        set(${testname_full}_toolname "drmemtrace")
         set(${testname_full}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
         set(${testname_full}_rawtemp ON) # no preprocessor
         set(${testname_full}_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2110,7 +2110,8 @@ if (DR_HOST_NOT_TARGET)
     set(locdir ${PROJECT_BINARY_DIR}/drmemtrace.threadsig.aarch64)
     file(MAKE_DIRECTORY ${locdir})
     file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
-    get_target_path_for_execution(drcachesim_path drcachesim "${location_suffix}")
+    get_target_path_for_execution(drcachesim_path drmemtrace_launcher
+      "${location_suffix}")
     prefix_cmd_if_necessary(drcachesim_path ON ${drcachesim_path})
     torunonly_api(tool.drcacheoff.altbindir "${drcachesim_path}"
       "offline-altbindir.c" ""


### PR DESCRIPTION
Adds a tool file so "-t drmemtrace" can become the preferred way to launch the drmemtrace tool framework, as "drcachesim" is just one tool within the framework.

Updates the documentation and tests.

Renames the "drcachesim" executable to "drmemtrace_launcher".

Fixes #6660