### PR TITLE
i#6662 public traces, part 4: view tool

### DIFF
--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -616,12 +616,14 @@ run_regdeps_test(void *drcontext)
         { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 2 } },
         { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA } },
         { TRACE_TYPE_INSTR, 3, { PC } },
-        { TRACE_TYPE_ENCODING, 16, { ENCODING_REGDEPS_ISA_vpmovmskb } },
+        { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA_vpmovmskb } },
         { TRACE_TYPE_INSTR, 4, { PC_vpmovmskb } },
-        { TRACE_TYPE_ENCODING, 16, { ENCODING_REGDEPS_ISA_vmovdqu } },
+        { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA_vmovdqu } },
         { TRACE_TYPE_INSTR, 4, { PC_vmovdqu } },
         { TRACE_TYPE_FOOTER, 0, { 0 } },
     } };
+
+    /* clang-format off */
     std::string expect =
         std::string(R"DELIM(           1           0:           3 <marker: version 3>
            2           0:           3 <marker: filetype 0x20e00>
@@ -629,30 +631,11 @@ run_regdeps_test(void *drcontext)
            4           0:           3 <marker: chunk instruction count 3>
            5           0:           3 <marker: timestamp 1002>
            6           0:           3 <marker: tid 3 on core 2>
-           7           1:           3 ifetch       )DELIM") +
-        std::string(R"DELIM(3 byte(s) @ 0x00007f6fdd3ec360 )DELIM") +
-        std::string(R"DELIM(00010011 move [8byte]       %rv4 -> %rv7
-)DELIM") +
-        std::string(R"DELIM(           7           1:           3)DELIM") +
-        std::string(
-            R"DELIM(                                             00060906
-)DELIM") +
-        std::string(R"DELIM(           8           2:           3 ifetch       )DELIM") +
-        std::string(R"DELIM(4 byte(s) @ 0x00007f6fdc76cb35 )DELIM") +
-        std::string(R"DELIM(00004011 simd [32byte]       %rv76 -> %rv1
-)DELIM") +
-        std::string(R"DELIM(           8           2:           3)DELIM") +
-        std::string(
-            R"DELIM(                                             004e0321
-)DELIM") +
-        std::string(R"DELIM(           9           3:           3 ifetch       )DELIM") +
-        std::string(R"DELIM(4 byte(s) @ 0x00007f6fdc76cb2d )DELIM") +
-        std::string(R"DELIM(00004811 load simd [32byte]       %rv7 -> %rv71
-)DELIM") +
-        std::string(R"DELIM(           9           3:           3)DELIM") +
-        std::string(
-            R"DELIM(                                             00094921
+           7           1:           3 ifetch       3 byte(s) @ 0x00007f6fdd3ec360 00010011 00060906 move [8byte]       %rv4 -> %rv7
+           8           2:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb35 00004011 004e0321 simd [32byte]       %rv76 -> %rv1
+           9           3:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb2d 00004811 00094921 load simd [32byte]       %rv7 -> %rv71
 )DELIM");
+    /* clang-format on */
 
     instrlist_t *ilist_unused = nullptr;
     view_nomod_test_t view(drcontext, *ilist_unused, 0, 0);

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -595,12 +595,15 @@ run_regdeps_test(void *drcontext)
 #ifdef X64
     const memref_tid_t t1 = 3;
     std::vector<memref_tid_t> tids = { t1 };
-    constexpr addr_t PC = 0x00007f6fdd3ec360;
+    constexpr addr_t PC_mov = 0x00007f6fdd3ec360;
     constexpr addr_t PC_vpmovmskb = 0x00007f6fdc76cb35;
     constexpr addr_t PC_vmovdqu = 0x00007f6fdc76cb2d;
-    constexpr addr_t ENCODING_REGDEPS_ISA = 0x0006090600010011;
+    constexpr addr_t PC_lock_cmpxchg = 0x00007f86ef03d107;
+    constexpr addr_t ENCODING_REGDEPS_ISA_mov = 0x0006090600010011;
     constexpr addr_t ENCODING_REGDEPS_ISA_vpmovmskb = 0x004e032100004011;
     constexpr addr_t ENCODING_REGDEPS_ISA_vmovdqu = 0x0009492100004811;
+    constexpr addr_t ENCODING_REGDEPS_ISA_lock_cmpxchg_1 = 0x0402020400001931;
+    constexpr addr_t ENCODING_REGDEPS_ISA_lock_cmpxchg_2 = 0x00000026;
     std::vector<std::vector<trace_entry_t>> entries = { {
         { TRACE_TYPE_HEADER, 0, { 0x1 } },
         { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION, { 3 } },
@@ -611,15 +614,18 @@ run_regdeps_test(void *drcontext)
         { TRACE_TYPE_THREAD, 0, { t1 } },
         { TRACE_TYPE_PID, 0, { t1 } },
         { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, { 64 } },
-        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT, { 3 } },
+        { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT, { 4 } },
         { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP, { 1002 } },
         { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 2 } },
-        { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA } },
-        { TRACE_TYPE_INSTR, 3, { PC } },
+        { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA_mov } },
+        { TRACE_TYPE_INSTR, 3, { PC_mov } },
         { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA_vpmovmskb } },
         { TRACE_TYPE_INSTR, 4, { PC_vpmovmskb } },
         { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA_vmovdqu } },
         { TRACE_TYPE_INSTR, 4, { PC_vmovdqu } },
+        { TRACE_TYPE_ENCODING, 8, { ENCODING_REGDEPS_ISA_lock_cmpxchg_1 } },
+        { TRACE_TYPE_ENCODING, 4, { ENCODING_REGDEPS_ISA_lock_cmpxchg_2 } },
+        { TRACE_TYPE_INSTR, 10, { PC_lock_cmpxchg } },
         { TRACE_TYPE_FOOTER, 0, { 0 } },
     } };
 
@@ -628,12 +634,14 @@ run_regdeps_test(void *drcontext)
         std::string(R"DELIM(           1           0:           3 <marker: version 3>
            2           0:           3 <marker: filetype 0x20e00>
            3           0:           3 <marker: cache line size 64>
-           4           0:           3 <marker: chunk instruction count 3>
+           4           0:           3 <marker: chunk instruction count 4>
            5           0:           3 <marker: timestamp 1002>
            6           0:           3 <marker: tid 3 on core 2>
            7           1:           3 ifetch       3 byte(s) @ 0x00007f6fdd3ec360 00010011 00060906 move [8byte]       %rv4 -> %rv7
            8           2:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb35 00004011 004e0321 simd [32byte]       %rv76 -> %rv1
            9           3:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb2d 00004811 00094921 load simd [32byte]       %rv7 -> %rv71
+          10           4:           3 ifetch      10 byte(s) @ 0x00007f86ef03d107 00001931 04020204 load store [4byte]       %rv0 %rv2 %rv36 -> %rv0
+          10           4:           3                                             00000026
 )DELIM");
     /* clang-format on */
 

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -217,7 +217,12 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
                 return false;
             }
             filetype_record_ord_ = memstream->get_record_ordinal();
-            if (TESTANY(OFFLINE_FILE_TYPE_ARCH_ALL, memref.marker.marker_value) &&
+            /* We remove OFFLINE_FILE_TYPE_ARCH_REGDEPS from this check since
+             * DR_ISA_REGDEPS is not a real ISA and can coexist with any real
+             * architecture.
+             */
+            if (TESTANY(OFFLINE_FILE_TYPE_ARCH_ALL & ~OFFLINE_FILE_TYPE_ARCH_REGDEPS,
+                        memref.marker.marker_value) &&
                 !TESTANY(build_target_arch_type(), memref.marker.marker_value)) {
                 error_string_ = std::string("Architecture mismatch: trace recorded on ") +
                     trace_arch_string(static_cast<offline_file_type_t>(
@@ -562,10 +567,23 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         // MAX_INSTR_DIS_SZ is set to 196 in core/ir/disassemble.h but is not
         // exported so we just use the same value here.
         char buf[196];
+        /* Set dcontext ISA mode to DR_ISA_REGDEPS if trace file type has
+         * OFFLINE_FILE_TYPE_ARCH_REGDEPS set. We need this to correctly
+         * disassemble DR_ISA_REGDEPS instructions.
+         */
+        dr_isa_mode_t old_isa_mode = dr_get_isa_mode(dcontext_.dcontext);
+        bool is_regdeps_trace =
+            filetype_ != -1 && TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, filetype_);
+        if (is_regdeps_trace) {
+            dr_set_isa_mode(dcontext_.dcontext, DR_ISA_REGDEPS, &old_isa_mode);
+        }
         byte *next_pc = disassemble_to_buffer(
             dcontext_.dcontext, decode_pc, orig_pc, /*show_pc=*/false,
             /*show_bytes=*/true, buf, BUFFER_SIZE_ELEMENTS(buf),
             /*printed=*/nullptr);
+        if (is_regdeps_trace) {
+            dr_set_isa_mode(dcontext_.dcontext, old_isa_mode, nullptr);
+        }
         if (next_pc == nullptr) {
             error_string_ = "Failed to disassemble " + to_hex_string(memref.instr.addr);
             return false;
@@ -574,7 +592,7 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         disasm_cache_.insert({ orig_pc, disasm });
     }
     // Add branch decoration, which varies and so can't be cached purely by PC.
-    auto newline = disasm.find('\n');
+    size_t newline = disasm.find('\n');
     if (memref.instr.type == TRACE_TYPE_INSTR_TAKEN_JUMP)
         disasm.insert(newline, " (taken)");
     else if (memref.instr.type == TRACE_TYPE_INSTR_UNTAKEN_JUMP)
@@ -587,13 +605,16 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         disasm.insert(newline, str.str());
     }
     // Put our prefix on raw byte spillover, and skip the other columns.
-    newline = disasm.find('\n');
-    if (newline != std::string::npos && newline < disasm.size() - 1) {
+    size_t pos = 0;
+    newline = disasm.find('\n', pos);
+    while (newline != std::string::npos && newline < disasm.size() - 1) {
         std::stringstream prefix;
         print_prefix(memstream, memref, -1, prefix);
         std::string skip_name(name_width, ' ');
         disasm.insert(newline + 1,
                       prefix.str() + skip_name + "                               ");
+        pos = newline + 1;
+        newline = disasm.find('\n', pos);
     }
     std::cerr << disasm;
     ++num_disasm_instrs_;

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -230,6 +230,13 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
                     " but tool built for " + trace_arch_string(build_target_arch_type());
                 return false;
             }
+            /* Set dcontext ISA mode to DR_ISA_REGDEPS if trace file type has
+             * OFFLINE_FILE_TYPE_ARCH_REGDEPS set. We need this to correctly
+             * disassemble DR_ISA_REGDEPS instructions.
+             */
+            if (TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, filetype_)) {
+                dr_set_isa_mode(dcontext_.dcontext, DR_ISA_REGDEPS, nullptr);
+            }
             return true; // Do not count toward -sim_refs yet b/c we don't have tid.
         case TRACE_MARKER_TYPE_TIMESTAMP:
             // Delay to see whether this is a new window.  We assume a timestamp
@@ -567,23 +574,10 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         // MAX_INSTR_DIS_SZ is set to 196 in core/ir/disassemble.h but is not
         // exported so we just use the same value here.
         char buf[196];
-        /* Set dcontext ISA mode to DR_ISA_REGDEPS if trace file type has
-         * OFFLINE_FILE_TYPE_ARCH_REGDEPS set. We need this to correctly
-         * disassemble DR_ISA_REGDEPS instructions.
-         */
-        dr_isa_mode_t old_isa_mode = dr_get_isa_mode(dcontext_.dcontext);
-        bool is_regdeps_trace =
-            filetype_ != -1 && TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, filetype_);
-        if (is_regdeps_trace) {
-            dr_set_isa_mode(dcontext_.dcontext, DR_ISA_REGDEPS, &old_isa_mode);
-        }
         byte *next_pc = disassemble_to_buffer(
             dcontext_.dcontext, decode_pc, orig_pc, /*show_pc=*/false,
             /*show_bytes=*/true, buf, BUFFER_SIZE_ELEMENTS(buf),
             /*printed=*/nullptr);
-        if (is_regdeps_trace) {
-            dr_set_isa_mode(dcontext_.dcontext, old_isa_mode, nullptr);
-        }
         if (next_pc == nullptr) {
             error_string_ = "Failed to disassemble " + to_hex_string(memref.instr.addr);
             return false;
@@ -592,7 +586,7 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         disasm_cache_.insert({ orig_pc, disasm });
     }
     // Add branch decoration, which varies and so can't be cached purely by PC.
-    size_t newline = disasm.find('\n');
+    auto newline = disasm.find('\n');
     if (memref.instr.type == TRACE_TYPE_INSTR_TAKEN_JUMP)
         disasm.insert(newline, " (taken)");
     else if (memref.instr.type == TRACE_TYPE_INSTR_UNTAKEN_JUMP)
@@ -605,16 +599,13 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         disasm.insert(newline, str.str());
     }
     // Put our prefix on raw byte spillover, and skip the other columns.
-    size_t pos = 0;
-    newline = disasm.find('\n', pos);
-    while (newline != std::string::npos && newline < disasm.size() - 1) {
+    newline = disasm.find('\n');
+    if (newline != std::string::npos && newline < disasm.size() - 1) {
         std::stringstream prefix;
         print_prefix(memstream, memref, -1, prefix);
         std::string skip_name(name_width, ' ');
         disasm.insert(newline + 1,
                       prefix.str() + skip_name + "                               ");
-        pos = newline + 1;
-        newline = disasm.find('\n', pos);
     }
     std::cerr << disasm;
     ++num_disasm_instrs_;

--- a/core/ir/isa_regdeps/disassemble.c
+++ b/core/ir/isa_regdeps/disassemble.c
@@ -109,4 +109,8 @@ d_r_regdeps_print_encoding_second_line(char *buf, size_t bufsz,
             buf, bufsz, sofar, " %08x",
             *((uint *)(pc + REGDEPS_BYTES_PER_LINE + REGDEPS_BYTES_PER_WORD)));
     }
+
+    /* Add a new line at the end.
+     */
+    print_to_buffer(buf, bufsz, sofar, "\n");
 }

--- a/make/style_checks/scripts/rules/line_length_content.tcl
+++ b/make/style_checks/scripts/rules/line_length_content.tcl
@@ -48,7 +48,8 @@ array set length_exempt [list {statsx.h} {1} \
                              {instr_create_api.h} {1} \
                              {decode_gen.h} {1} \
                              {encode_gen.h} {1} \
-                             {elfdefinitions.h} {1} ]
+                             {elfdefinitions.h} {1} \
+                             {view_test.cpp} {1} ]
 
 foreach fname [getSourceFileNames] {
     set nline 1

--- a/suite/tests/api/ir_regdeps.c
+++ b/suite/tests/api/ir_regdeps.c
@@ -186,7 +186,7 @@ test_instr_create_encode_decode_disassemble_synthetic_x86_64(void *dc)
     instr_reset(dc, instr);
     decode(dc, buf, instr);
     const char *expected_disasm_str_cmps = " 00000942 08090806 load [8byte]       %rv6 "
-                                           "%rv7 %rv32 %rv35 -> %rv6 %rv7\n 00252209";
+                                           "%rv7 %rv32 %rv35 -> %rv6 %rv7\n 00252209\n";
     test_instr_encode_decode_disassemble_synthetic(dc, instr, expected_disasm_str_cmps);
 
     instr = INSTR_CREATE_maskmovq(dc, opnd_create_reg(DR_REG_MM0),
@@ -195,7 +195,7 @@ test_instr_create_encode_decode_disassemble_synthetic_x86_64(void *dc)
     instr_reset(dc, instr);
     decode(dc, buf, instr);
     const char *expected_disasm_str_maskmovq =
-        " 00005040 13120906 store simd [8byte]       %rv7 %rv16 %rv17 %rv35\n 00000025";
+        " 00005040 13120906 store simd [8byte]       %rv7 %rv16 %rv17 %rv35\n 00000025\n";
     test_instr_encode_decode_disassemble_synthetic(dc, instr,
                                                    expected_disasm_str_maskmovq);
 
@@ -205,7 +205,7 @@ test_instr_create_encode_decode_disassemble_synthetic_x86_64(void *dc)
     instr_reset(dc, instr);
     decode(dc, buf, instr);
     const char *expected_disasm_str_xchg = " 00000022 020a0204 uncategorized [4byte]     "
-                                           "  %rv0 %rv8 -> %rv0 %rv8\n 0000000a";
+                                           "  %rv0 %rv8 -> %rv0 %rv8\n 0000000a\n";
     test_instr_encode_decode_disassemble_synthetic(dc, instr, expected_disasm_str_xchg);
 
     instr = INSTR_CREATE_add(dc, opnd_create_reg(DR_REG_RAX), OPND_CREATE_INT32(42));
@@ -254,7 +254,7 @@ test_instr_create_encode_decode_disassemble_synthetic_x86_64(void *dc)
     decode(dc, buf, instr);
     const char *expected_disasm_str_vdpbf16ps_mask =
         " 00000031 65646640 uncategorized [64byte]       %rv98 %rv99 %rv102 -> %rv100\n "
-        "00000068";
+        "00000068\n";
     test_instr_encode_decode_disassemble_synthetic(dc, instr,
                                                    expected_disasm_str_vdpbf16ps_mask);
 }
@@ -352,7 +352,7 @@ test_instr_create_encode_decode_disassemble_synthetic_aarch64(void *dc)
     instr_reset(dc, instr);
     decode(dc, buf, instr);
     const char *expected_disasm_str_ldpsw =
-        " 00000813 04030206 load [8byte]       %rv0 -> %rv0 %rv1 %rv2\n 00000002";
+        " 00000813 04030206 load [8byte]       %rv0 -> %rv0 %rv1 %rv2\n 00000002\n";
     test_instr_encode_decode_disassemble_synthetic(dc, instr, expected_disasm_str_ldpsw);
 }
 #endif
@@ -413,7 +413,7 @@ test_instr_create_encode_decode_disassemble_synthetic_riscv64(void *dc)
     decode(dc, buf, instr);
     const char *expected_disasm_str_fmadd_d =
         " 00000031 25234206 uncategorized [8byte]       %rv33 %rv35 %rv36 -> %rv64\n "
-        "00000026";
+        "00000026\n";
     test_instr_encode_decode_disassemble_synthetic(dc, instr,
                                                    expected_disasm_str_fmadd_d);
 }


### PR DESCRIPTION
Modifies the view tool to handle OFFLINE_FILE_TYPE_ARCH_REGDEPS traces,
leveraging the disassembly of DR_ISA_REGDEPS instructions.
When visualizing DR_ISA_REGDEPS instructions, the view tool still prints the
instruction length and PC, which for OFFLINE_FILE_TYPE_ARCH_REGDEPS
traces are the same as those in the original trace.
Then, after the PC, the instruction encoding, categories, operation size, and 
registers are printed following the disassembly format of DR_ISA_REGDEPS
instructions (xref: #6799).

DR_ISA_REGDEPS instructions printed by the view tool look as follows:
```
[...] ifetch      10 byte(s) @ 0x00007f86ef03d107 00001931 04020204 load store [4byte]       %rv0 %rv2 %rv36 -> %rv0
[...]                                             00000026
```

We also fix a formatting bug in DR_ISA_REGDEPS instruction disassembly,
where we were missing a new line when the instruction encoding spills into
a second line.

Issue: #6662