### PR TITLE
i#3544 RV64: Rename DR_ISA_RV64IMAFDC to DR_ISA_RV64

### DIFF
--- a/api/samples/opcodes.c
+++ b/api/samples/opcodes.c
@@ -68,7 +68,7 @@ enum {
 #elif defined(AARCH64)
     ISA_ARM_A64,
 #elif defined(RISCV64)
-    ISA_RV64IMAFDC,
+    ISA_RV64,
 #endif
     NUM_ISA_MODE,
 };
@@ -204,7 +204,7 @@ get_count_isa_idx(void *drcontext)
 #elif defined(AARCH64)
     case DR_ISA_ARM_A64: return ISA_ARM_A64;
 #elif defined(RISCV64)
-    case DR_ISA_RV64IMAFDC: return ISA_RV64IMAFDC;
+    case DR_ISA_RV64: return ISA_RV64;
 #endif
     default: DR_ASSERT(false); /* NYI */
     }

--- a/core/arch/arch_exports.h
+++ b/core/arch/arch_exports.h
@@ -860,20 +860,20 @@ use_addr_prefix_on_short_disp(void)
 #include "encode_api.h"
 
 /* static version for drdecodelib */
-#define DEFAULT_ISA_MODE_STATIC                                                \
-    IF_X86_ELSE(IF_X64_ELSE(DR_ISA_AMD64, DR_ISA_IA32),                        \
-                IF_AARCHXX_ELSE(IF_X64_ELSE(DR_ISA_ARM_A64, DR_ISA_ARM_THUMB), \
-                                DR_ISA_RV64IMAFDC))
+#define DEFAULT_ISA_MODE_STATIC                 \
+    IF_X86_ELSE(                                \
+        IF_X64_ELSE(DR_ISA_AMD64, DR_ISA_IA32), \
+        IF_AARCHXX_ELSE(IF_X64_ELSE(DR_ISA_ARM_A64, DR_ISA_ARM_THUMB), DR_ISA_RV64))
 
 /* Use this one in DR proper.
  * This one is now static as well after we removed the runtime option that
  * used to be here: but I'm leaving the split to make it easier to add
  * an option in the future.
  */
-#define DEFAULT_ISA_MODE                                                       \
-    IF_X86_ELSE(IF_X64_ELSE(DR_ISA_AMD64, DR_ISA_IA32),                        \
-                IF_AARCHXX_ELSE(IF_X64_ELSE(DR_ISA_ARM_A64, DR_ISA_ARM_THUMB), \
-                                DR_ISA_RV64IMAFDC))
+#define DEFAULT_ISA_MODE                        \
+    IF_X86_ELSE(                                \
+        IF_X64_ELSE(DR_ISA_AMD64, DR_ISA_IA32), \
+        IF_AARCHXX_ELSE(IF_X64_ELSE(DR_ISA_ARM_A64, DR_ISA_ARM_THUMB), DR_ISA_RV64))
 
 /* For converting back from PC_AS_JMP_TGT on Thumb */
 #ifdef ARM
@@ -1788,7 +1788,7 @@ get_mcontext_frame_ptr(dcontext_t *dcontext, priv_mcontext_t *mc)
 #elif defined(AARCH64)
     case DR_ISA_ARM_A64: reg = mc->r29; break;
 #elif defined(RISCV64)
-    case DR_ISA_RV64IMAFDC: reg = mc->x8; break;
+    case DR_ISA_RV64: reg = mc->x8; break;
 #endif /* X86/ARM/AARCH64 */
     default: ASSERT_NOT_REACHED(); reg = 0;
     }

--- a/core/fragment.h
+++ b/core/fragment.h
@@ -194,7 +194,7 @@
         IF_AARCHXX_ELSE(IF_X64_ELSE(DR_ISA_ARM_A64,                                 \
                                     (TEST(FRAG_THUMB, (flags)) ? DR_ISA_ARM_THUMB   \
                                                                : DR_ISA_ARM_A32)),  \
-                        DR_ISA_RV64IMAFDC))
+                        DR_ISA_RV64))
 
 static inline uint
 frag_flags_from_isa_mode(dr_isa_mode_t mode)
@@ -218,7 +218,7 @@ frag_flags_from_isa_mode(dr_isa_mode_t mode)
     ASSERT(mode == DR_ISA_ARM_A32);
     return 0;
 #elif defined(RISCV64)
-    ASSERT(mode == DR_ISA_RV64IMAFDC);
+    ASSERT(mode == DR_ISA_RV64);
     return 0;
 #endif
 }

--- a/core/ir/encode_api.h
+++ b/core/ir/encode_api.h
@@ -69,9 +69,9 @@ typedef enum _dr_isa_mode_t {
      */
     DR_ISA_ARM_A64,
     /**
-     * RISC-V (rv64imafdc).
+     * RISC-V (RV64).
      */
-    DR_ISA_RV64IMAFDC,
+    DR_ISA_RV64,
     /**
      * A synthetic ISA that has the purpose of preserving register dependencies and giving
      * hints on the type of operation an instruction performs.

--- a/core/ir/riscv64/decode.c
+++ b/core/ir/riscv64/decode.c
@@ -39,7 +39,7 @@
 bool
 is_isa_mode_legal(dr_isa_mode_t mode)
 {
-    return (mode == DR_ISA_RV64IMAFDC || mode == DR_ISA_REGDEPS);
+    return (mode == DR_ISA_RV64 || mode == DR_ISA_REGDEPS);
 }
 
 app_pc

--- a/core/ir/riscv64/instr.c
+++ b/core/ir/riscv64/instr.c
@@ -43,7 +43,7 @@
 bool
 instr_set_isa_mode(instr_t *instr, dr_isa_mode_t mode)
 {
-    if (mode != DR_ISA_RV64IMAFDC && mode != DR_ISA_REGDEPS)
+    if (mode != DR_ISA_RV64 && mode != DR_ISA_REGDEPS)
         return false;
     instr->isa_mode = mode;
     return true;

--- a/core/unix/injector.c
+++ b/core/unix/injector.c
@@ -1248,7 +1248,7 @@ injectee_run_get_retval(dr_inject_info_t *info, void *dc, instrlist_t *ilist)
 #    elif defined(ARM)
     app_mode = TEST(EFLAGS_T, regs.uregs[16]) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
 #    elif defined(RISCV64)
-    app_mode = DR_ISA_RV64IMAFDC;
+    app_mode = DR_ISA_RV64;
 #    else
 #        error Unsupported arch.
 #    endif
@@ -1802,7 +1802,7 @@ inject_ptrace(dr_inject_info_t *info, const char *library_path)
 #    elif defined(ARM)
     app_mode = TEST(EFLAGS_T, regs.uregs[16]) ? DR_ISA_ARM_THUMB : DR_ISA_ARM_A32;
 #    elif defined(RISCV64)
-    app_mode = DR_ISA_RV64IMAFDC;
+    app_mode = DR_ISA_RV64;
 #    else
 #        error Unsupported arch.
 #    endif


### PR DESCRIPTION
RISC-V's ISA string describes a certain combination of extensions. For example, RV64IMAFDC is a 64-bit architecture that supports I M A F D C extensions, but there is no available hardware with this combination. For now, the most common one is RV64GC, where G is short for IMAFD_Zicsr_Zifencei.

DynamoRIO only relies on the G extension to work properly and it can run on various combinations as long as all the extensions the program requires are supported. So the name `DR_ISA_RV64IMAFDC` is not a minimum requirement, nor a combination we supported. This PR changes it to `DR_ISA_RV64` to be more generic.

Issue: #3544