### PR TITLE
i#5261 remove -intercept_all_signals: Remove option

### DIFF
--- a/core/options.c
+++ b/core/options.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -2013,14 +2013,6 @@ check_option_compatibility_helper(int recurse_count)
         dynamo_options.use_persisted = false;
         changed_options = true;
     }
-#    ifdef UNIX
-    /* PR 304708: we intercept all signals for a better client interface */
-    if (DYNAMO_OPTION(code_api) && !DYNAMO_OPTION(intercept_all_signals)) {
-        USAGE_ERROR("-code_api requires -intercept_all_signals");
-        dynamo_options.intercept_all_signals = true;
-        changed_options = true;
-    }
-#    endif
 #    ifdef UNIX
     if (DYNAMO_OPTION(max_pending_signals) < 1) {
         USAGE_ERROR("-max_pending_signals must be at least 1");

--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -768,8 +768,6 @@ OPTION_DEFAULT(bool, fail_on_stolen_fds, true,
  * to an app crash. */
 OPTION_DEFAULT(bool, avoid_dlclose, true, "Avoid calling dlclose from DynamoRIO.")
 
-/* PR 304708: we intercept all signals for a better client interface */
-OPTION_DEFAULT(bool, intercept_all_signals, true, "intercept all signals")
 OPTION_DEFAULT(bool, reroute_alarm_signals, true,
                "reroute alarm signals arriving in a blocked-for-app thread")
 OPTION_DEFAULT(uint, max_pending_signals, 8,

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -5742,26 +5742,11 @@ handle_self_signal(dcontext_t *dcontext, uint sig)
      *
      * FIXME PR 297033: watch for SIGSTOP and SIGCONT.
      *
-     * With -intercept_all_signals, we only need to watch for SIGKILL
-     * and SIGSTOP here, and we avoid the FIXMEs below.  If it's fine
-     * for DR not to clean up on a SIGKILL, then SIGSTOP is all that's
-     * left (at least once we have PR 297033 and are intercepting the
-     * various STOP variations and CONT).
+     * We now always intercept all signals, which means we only need to watch
+     * for SIGKILL and SIGSTOP here. If it's fine for DR not to clean up on a
+     * SIGKILL, then SIGSTOP is all that's left (at least once we have PR
+     * 297033 and are intercepting the various STOP variations and CONT).
      */
-    if (sig == SIGABRT && !DYNAMO_OPTION(intercept_all_signals)) {
-        LOG(GLOBAL, LOG_TOP | LOG_SYSCALLS, 1,
-            "thread " TIDFMT " sending itself a SIGABRT\n", d_r_get_thread_id());
-        KSTOP(num_exits_dir_syscall);
-        /* FIXME: need to check whether app has a handler for SIGABRT! */
-        /* FIXME PR 211180/6723: this will do SYS_exit rather than the SIGABRT.
-         * Should do set_default_signal_action(SIGABRT) (and set a flag so
-         * no races w/ another thread re-installing?) and then SYS_kill.
-         */
-        block_cleanup_and_terminate(dcontext, SYSNUM_EXIT_THREAD, -1, 0,
-                                    (is_last_app_thread() && !dynamo_exited),
-                                    IF_MACOS_ELSE(dcontext->thread_port, 0), 0);
-        ASSERT_NOT_REACHED();
-    }
 }
 
 /***************************************************************************

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -102,9 +102,6 @@ endif (UNIX)
 set(main_run_list
   # our main configuration
   "SHORT::-code_api"
-  # no_intercept_all_signals tests.
-  # TODO i#5261: Remove this suite when -intercept_all_signals is deprecated.
-  "SHORT::LIN::ONLY::sigaction$::-no_code_api -no_intercept_all_signals"
   # sanity check: run single app to make sure these options aren't totally broken
   # i#1575: ARM doesn't yet support -coarse_units
   "SHORT::X86::ONLY::client.events$::-code_api -opt_memory"
@@ -5939,7 +5936,6 @@ if (APPLE)
     code_api|api.ir-static
     code_api|api.drdecode
     code_api|linux.sigaction
-    no_code_api,no_intercept_all_signals|linux.sigaction
     code_api|linux.sigaction.native
     PROPERTIES LABELS OSX)
   if (X86)
@@ -6223,7 +6219,6 @@ if (RISCV64)
     code_api|tool.drdisas
     code_api|tool.histogram
     code_api|tool.reuse_distance
-    no_code_api,no_intercept_all_signals|linux.sigaction
     PROPERTIES LABELS RUNS_ON_QEMU)
   if (DEBUG)
     set_tests_properties(

--- a/suite/tests/linux/sigaction.c
+++ b/suite/tests/linux/sigaction.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -152,6 +152,7 @@ test_sigprocmask()
                             /*sizeof(kernel_sigset_t)*/ 8) == 0);
     assert(make_sigprocmask(~0, NULL, &original, 8) == 0);
 
+#if 1 // TODO: Not sure how to adapt this to fixing i#5261.
     /* Success cases.
      * The following should come before other tests so that some
      * signals that DR intercepts are blocked, which would require
@@ -162,6 +163,7 @@ test_sigprocmask()
     assert(make_sigprocmask(SIG_SETMASK, &new, NULL, 8) == 0);
     assert(make_sigprocmask(~0, NULL, &old, 8) == 0);
     assert(new == old);
+#endif // TODO
 
     /* EFAULT cases. */
     /* sigprocmask on MacOS does not fail when the old sigset is not


### PR DESCRIPTION
-intercept_all_signals is the default. We always want to intercept all signals. -no_intercept_all_signals requires extra code to support, and the support is problematic, eg, is racy.
Since we don't use -no_intercept_all_signals any more, remove the option.

Fixes #5261