### PR TITLE
i#6822 unscheduled: Virtualize scheduler marker processing

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -1499,7 +1499,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::get_initial_input_content(
         input_info_t &input = inputs_[i];
         bool found_filetype = false;
         bool found_timestamp = !gather_timestamps || input.next_timestamp > 0;
-        if (!found_filetype || !found_timestamp) {
+        if (process_next_initial_record(input, create_invalid_record(), found_filetype,
+                                        found_timestamp)) {
             // First, check any queued records in the input.
             // XXX: Can we create a helper to iterate the queue and then the
             // reader, and avoid the duplicated loops here?  The challenge is
@@ -1522,7 +1523,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::get_initial_input_content(
         }
         if (input.next_timestamp > 0)
             found_timestamp = true;
-        if (!found_filetype || !found_timestamp) {
+        if (process_next_initial_record(input, create_invalid_record(), found_filetype,
+                                        found_timestamp)) {
             // If we didn't find our targets in the queue, request new records.
             if (input.needs_init) {
                 input.reader->init();

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1390,6 +1390,13 @@ protected:
     scheduler_status_t
     get_initial_input_content(bool gather_timestamps);
 
+    // Allow subclasses to perform custom initial marker processing during
+    // get_initial_input_content().  Returns whether to keep reading.
+    // The caller will stop calling when an instruction record is reached.
+    virtual bool
+    process_next_initial_record(input_info_t &input, RecordType record,
+                                bool found_filetype, bool found_timestamp);
+
     // Opens up all the readers for each file in 'path' which may be a directory.
     // Returns a map of the thread id of each file to its index in inputs_.
     scheduler_status_t
@@ -1548,6 +1555,12 @@ protected:
     // Used for diagnostics: prints record fields to stderr.
     void
     print_record(const RecordType &record);
+
+    // Process each marker seen for MAP_TO_ANY_OUTPUT during next_record().
+    // The input's lock must be held by the caller.
+    virtual void
+    process_marker(input_info_t &input, output_ordinal_t output,
+                   trace_marker_type_t marker_type, uintptr_t marker_value);
 
     // Returns the get_stream_name() value for the current input stream scheduled on
     // the 'output_ordinal'-th output stream.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1393,6 +1393,8 @@ protected:
     // Allow subclasses to perform custom initial marker processing during
     // get_initial_input_content().  Returns whether to keep reading.
     // The caller will stop calling when an instruction record is reached.
+    // The 'record' may have TRACE_TYPE_INVALID in some calls in which case
+    // the two bool parameters are what the return value should be based on.
     virtual bool
     process_next_initial_record(input_info_t &input, RecordType record,
                                 bool found_filetype, bool found_timestamp);


### PR DESCRIPTION
Refactors the scheduler marker processing into two virtual functions subclasses can override: the initialization time header marker reading now has process_next_initial_record() while regular processing has process_marker().

No change in functionality.  Future work will add "unscheduled thread" support with new markers, building on this refactoring.

Issue: #6822