### PR TITLE
i#2626 AArch64 codec: Add FEAT_FlagM2 instructions

### DIFF
--- a/core/arch/aarch64/proc.c
+++ b/core/arch/aarch64/proc.c
@@ -267,7 +267,7 @@ enable_all_test_cpu_features()
         FEATURE_JSCVT,  FEATURE_DPB,        FEATURE_DPB2,    FEATURE_SVE2,
         FEATURE_SVEAES, FEATURE_SVEBitPerm, FEATURE_SVESHA3, FEATURE_SVESM4,
         FEATURE_MTE,    FEATURE_BTI,        FEATURE_FRINTTS, FEATURE_PAUTH2,
-        FEATURE_MTE2
+        FEATURE_MTE2,   FEATURE_FlagM2
     };
     for (int i = 0; i < BUFFER_SIZE_ELEMENTS(features); ++i) {
         proc_set_feature(features[i], true);

--- a/core/ir/aarch64/codec_v85.txt
+++ b/core/ir/aarch64/codec_v85.txt
@@ -37,6 +37,7 @@
 # Instruction definitions:
 
 1001000110xxxxxx^^xxxxxxxxxxxxxx  n   1207 MTE      addg           x0sp : x5sp imm6_16_tag imm4_10
+11010101000000000100^^^^01011111  rw  1219 FlagM2   axflag                :
 110101010000001100100100xx011111  n   1211 BTI       bti                : imm2_6
 0x1011100x100001111010xxxxxxxxxx  n   1212 FRINTTS frint32x     vdq_q_sd_0 : vdq_q_sd_5
 0001111001101000110000xxxxxxxxxx  n   1212 FRINTTS frint32x             d0 : d5
@@ -74,3 +75,4 @@
 1101000110xxxxxx^^xxxxxxxxxxxxxx  n   1208 MTE      subg           x0sp : x5sp imm6_16_tag imm4_10
 10011010110xxxxx000000xxxxxxxxxx  n   1205 MTE      subp             x0 : x5sp x16sp
 10111010110xxxxx000000xxxxxxxxxx  n   1206 MTE     subps             x0 : x5sp x16sp
+11010101000000000100^^^^00111111  rw  1220 FlagM2   xaflag                :

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -18386,4 +18386,25 @@
  */
 #define INSTR_CREATE_ldgm(dc, Rt, Rn) instr_create_1dst_1src(dc, OP_ldgm, Rt, Rn)
 
+/**
+ * Creates an AXFLAG instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      AXFLAG
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_axflag(dc) instr_create_0dst_0src(dc, OP_axflag)
+
+/**
+ * Creates a XAFLAG instruction.
+ *
+ * This macro is used to encode the forms:
+   \verbatim
+      XAFLAG
+   \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_xaflag(dc) instr_create_0dst_0src(dc, OP_xaflag)
 #endif /* DR_IR_MACROS_AARCH64_H */

--- a/suite/tests/api/dis-a64-v85.txt
+++ b/suite/tests/api/dis-a64-v85.txt
@@ -32,6 +32,9 @@
 # See dis-a64-sve.txt for the formatting.
 
 # Tests:
+# AXFLAG   (AXFLAG--flags)
+d5004f5f : axflag                                    : axflag
+
 d503241f : bti #0                         : bti    $0x00
 d503245f : bti #1                         : bti    $0x01
 d503249f : bti #2                         : bti    $0x02
@@ -847,4 +850,7 @@ d1afeef6 : subg x22, x23, #0x2f0, #0xb               : subg   %x23 $0x02f0 $0x0b
 d1b3f338 : subg x24, x25, #0x330, #0xc               : subg   %x25 $0x0330 $0x0c -> %x24
 d1b7f77a : subg x26, x27, #0x370, #0xd               : subg   %x27 $0x0370 $0x0d -> %x26
 d1bfffff : subg sp, sp, #0x3f0, #0xf                 : subg   %sp $0x03f0 $0x0f -> %sp
+
+# XAFLAG   (XAFLAG--flags)
+d5004f3f : xaflag                                    : xaflag
 

--- a/suite/tests/api/ir_aarch64_v85.c
+++ b/suite/tests/api/ir_aarch64_v85.c
@@ -763,6 +763,30 @@ TEST_INSTR(ldgm)
         });
 }
 
+TEST_INSTR(axflag)
+{
+    /* Testing AXFLAG */
+    TEST_LOOP_EXPECT(axflag, 1, INSTR_CREATE_axflag(dc), {
+        EXPECT_DISASSEMBLY("axflag");
+        EXPECT_TRUE(
+            TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+        EXPECT_TRUE(
+            TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+    });
+}
+
+TEST_INSTR(xaflag)
+{
+    /* Testing XAFLAG */
+    TEST_LOOP_EXPECT(xaflag, 1, INSTR_CREATE_xaflag(dc), {
+        EXPECT_DISASSEMBLY("xaflag");
+        EXPECT_TRUE(
+            TEST(EFLAGS_READ_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+        EXPECT_TRUE(
+            TEST(EFLAGS_WRITE_NZCV, instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+    });
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -808,6 +832,10 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(stgm);
     RUN_INSTR_TEST(stzgm);
     RUN_INSTR_TEST(ldgm);
+
+    /* FEAT_FlagM2 */
+    RUN_INSTR_TEST(axflag);
+    RUN_INSTR_TEST(xaflag);
 
     print("All v8.5 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
This patch adds the appropriate macros, tests and codec entries to encode the following variants:
```
AXFLAG
XAFLAG
```

Issue: #2626