### PR TITLE
Add encode/decode for new TSXLDTRK instructions.

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -7079,8 +7079,8 @@ const instr_info_t rm_extensions[][8] = {
     {OP_enclu,  0xd70f0172, catUncategorized, "enclu", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0xff]},
   },
   { /* rm extension 5 */
-    {OP_xsusldtrk, 0xf201e808, catUncategorized, "xsusldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
-    {OP_xresldtrk, 0xf201e908, catUncategorized, "xresldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
+    {OP_xsusldtrk, 0xf201e808, catOther, "xsusldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
+    {OP_xresldtrk, 0xf201e908, catOther, "xresldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},

--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1635,6 +1635,10 @@ const instr_info_t * const op_instr[] =
     /* OP_xsaves64 */  &rex_w_extensions[6][1],
     /* OP_xrstors32 */  &rex_w_extensions[7][0],
     /* OP_xrstors64 */  &rex_w_extensions[7][1],
+
+    /* TSXLDTRK */
+    /* OP_xsusldtrk */ &rm_extensions[5][0],
+    /* OP_xresldtrk */ &rm_extensions[5][1],
 };
 
 
@@ -7075,8 +7079,8 @@ const instr_info_t rm_extensions[][8] = {
     {OP_enclu,  0xd70f0172, catUncategorized, "enclu", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0xff]},
   },
   { /* rm extension 5 */
-    {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
+    {OP_xsusldtrk, 0xf201e808, catUncategorized, "xsusldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
+    {OP_xresldtrk, 0xf201e908, catUncategorized, "xresldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -529,6 +529,8 @@
 #define INSTR_CREATE_xtest(dc) instr_create_0dst_0src((dc), OP_xtest)
 #define INSTR_CREATE_clac(dc) instr_create_0dst_0src((dc), OP_clac)
 #define INSTR_CREATE_stac(dc) instr_create_0dst_0src((dc), OP_stac)
+#define INSTR_CREATE_xsusldtrk(dc) instr_create_0dst_0src((dc), OP_xsusldtrk)
+#define INSTR_CREATE_xresldtrk(dc) instr_create_0dst_0src((dc), OP_xresldtrk)
 /** @} */ /* end doxygen group */
 
 /* no destination, 1 source */

--- a/core/ir/x86/opcode_api.h
+++ b/core/ir/x86/opcode_api.h
@@ -1621,6 +1621,11 @@ enum {
     /* 1438 */ OP_xsaves64,  /**< IA-32/AMD64 xsaves64 opcode. */
     /* 1439 */ OP_xrstors32, /**< IA-32/AMD64 xrstors32 opcode. */
     /* 1440 */ OP_xrstors64, /**< IA-32/AMD64 xrstors64 opcode. */
+
+    /* TSXLDTRK */
+    /* 1441 */ OP_xsusldtrk, /**< IA-32/AMD64 xsusldtrk opcode. */
+    /* 1442 */ OP_xresldtrk, /**< IA-32/AMD64 xresldtrk opcode. */
+
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */
     OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */

--- a/suite/tests/api/ir_x86_0args.h
+++ b/suite/tests/api/ir_x86_0args.h
@@ -200,3 +200,6 @@ OPCODE(wrpkru, wrpkru, wrpkru, 0)
 
 OPCODE(clac, clac, clac, 0)
 OPCODE(stac, stac, stac, 0)
+
+OPCODE(xsusldtrk, xsusldtrk, xsusldtrk, 0)
+OPCODE(xresldtrk, xresldtrk, xresldtrk, 0)


### PR DESCRIPTION
The new TSXLDTRK feature in Sapphire Rapids adds two new instructions, XSUSLDTRK and XRESLDTRK. This commit adds support for them to the decoding and encoding machinery and adds tests.