### PR TITLE
i#6828: Fix blocked sigmask in native signal frame copy

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -6561,7 +6561,7 @@ execute_native_handler(dcontext_t *dcontext, int sig, sigframe_rt_t *our_frame,
         memcpy(&sigact_struct, &detached_sigact[sig], sizeof(sigact_struct));
         d_r_read_unlock(&detached_sigact_lock);
         memcpy(&info->app_sigblocked, &our_frame->uc.uc_sigmask,
-            sizeof(info->app_sigblocked));
+               sizeof(info->app_sigblocked));
 #ifdef HAVE_SIGALTSTACK
         thread_sig_info_t *dc_info = NULL;
         if (dcontext != NULL)

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5664,6 +5664,7 @@ main_signal_handler_C(byte *xsp)
         return;
     }
 #endif
+
     dcontext_t *dcontext = get_thread_private_dcontext();
 
 #if defined(MACOS) && !defined(AARCH64)

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -5664,7 +5664,6 @@ main_signal_handler_C(byte *xsp)
         return;
     }
 #endif
-
     dcontext_t *dcontext = get_thread_private_dcontext();
 
 #if defined(MACOS) && !defined(AARCH64)
@@ -6560,6 +6559,8 @@ execute_native_handler(dcontext_t *dcontext, int sig, sigframe_rt_t *our_frame,
         d_r_read_lock(&detached_sigact_lock);
         memcpy(&sigact_struct, &detached_sigact[sig], sizeof(sigact_struct));
         d_r_read_unlock(&detached_sigact_lock);
+        memcpy(&info->app_sigblocked, &our_frame->uc.uc_sigmask,
+            sizeof(info->app_sigblocked));
 #ifdef HAVE_SIGALTSTACK
         thread_sig_info_t *dc_info = NULL;
         if (dcontext != NULL)

--- a/suite/tests/api/detach_signal.cpp
+++ b/suite/tests/api/detach_signal.cpp
@@ -258,7 +258,8 @@ main(void)
     /* We request an alt stack for some signals but not all to test both types. */
     intercept_signal_with_mask(SIGSEGV, (handler_3_t)&handle_signal, true, &handler_mask);
     /* Setting sigstack=false forces SIGBUS native-delivery-during-detach to make a
-     * signal frame copy.
+     * signal frame copy. For more details on the reason, see reuse_cur_frame in
+     * execute_native_handler() in core/unix/signal.c.
      */
     intercept_signal_with_mask(SIGBUS, (handler_3_t)&handle_signal, false, &handler_mask);
     /* Setting sigstack=true allows SIGUSR2 native-delivery-during-detach to reuse the

--- a/suite/tests/api/detach_signal.cpp
+++ b/suite/tests/api/detach_signal.cpp
@@ -196,9 +196,7 @@ sideline_spinner(void *arg)
          * sigaltstack configured, so the sigreturn will restore the
          * blocked sigmask from the copied native signal frame.
          */
-        if (SIGSETJMP(mark) == 0) {
-            pthread_kill(pthread_self(), SIGBUS);
-        }
+        pthread_kill(pthread_self(), SIGBUS);
         /* SIGURG is blocked for some part of the test. */
         if (SIGSETJMP(mark) == 0) {
             pthread_kill(pthread_self(), SIGURG);


### PR DESCRIPTION
Adds the missing app blocked sigmask in the frame-copy created for native signal delivery during detach.

During detach we do not have the thread's dcontext_t anymore, which includes thread_sig_info_t. There is existing code that creates a synthetic thread_sig_info_t for use by execute_native_handler(). To fix this issue, we only needed to set its app_sigblocked field from the signal frame (which was delivered to the native app thread, therefore contains the actual app blocked sigmask).

Modifies the existing detach_signal test to verify this scenario.

Fixes: #6828