### PR TITLE
Support subclassing drmemtrace syscall_mix data

### DIFF
--- a/clients/drcachesim/tools/syscall_mix.h
+++ b/clients/drcachesim/tools/syscall_mix.h
@@ -70,6 +70,8 @@ public:
 
 protected:
     struct shard_data_t {
+        // Provide a virtual destructor to allow subclassing.
+        virtual ~shard_data_t() = default;
         std::unordered_map<int, int64_t> syscall_counts;
         std::unordered_map<int, int64_t> syscall_trace_counts;
         std::string error;


### PR DESCRIPTION
Adds a virtual destructor to the drmemtrace tool
syscall_mix_t::shard_data_t, to support subclassing that struct
for extended usage such as tracking callstacks for each syscall.