### PR TITLE
i#2626: Add AARCH64 Attribute registers to the DR_REG enum

### DIFF
--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -283,6 +283,18 @@ decode_sysreg(uint imm15)
 {
     reg_t sysreg;
     switch (imm15) {
+    case 0x4000: sysreg = DR_REG_MIDR_EL1; break;
+    case 0x4005: sysreg = DR_REG_MPIDR_EL1; break;
+    case 0x4006: sysreg = DR_REG_REVIDR_EL1; break;
+    case 0x4020: sysreg = DR_REG_ID_AA64PFR0_EL1; break;
+    case 0x4021: sysreg = DR_REG_ID_AA64PFR1_EL1; break;
+    case 0x4024: sysreg = DR_REG_ID_AA64ZFR0_EL1; break;
+    case 0x4028: sysreg = DR_REG_ID_AA64DFR0_EL1; break;
+    case 0x4030: sysreg = DR_REG_ID_AA64ISAR0_EL1; break;
+    case 0x4031: sysreg = DR_REG_ID_AA64ISAR1_EL1; break;
+    case 0x4032: sysreg = DR_REG_ID_AA64ISAR2_EL1; break;
+    case 0x4039: sysreg = DR_REG_ID_AA64MMFR1_EL1; break;
+    case 0x403A: sysreg = DR_REG_ID_AA64MMFR2_EL1; break;
     case 0x5a10: sysreg = DR_REG_NZCV; break;
     case 0x5a20: sysreg = DR_REG_FPCR; break;
     case 0x5a21: sysreg = DR_REG_FPSR; break;
@@ -406,6 +418,18 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
 {
     if (opnd_is_reg(opnd)) {
         switch (opnd_get_reg(opnd)) {
+        case DR_REG_MIDR_EL1: *imm15 = 0x4000; break;
+        case DR_REG_MPIDR_EL1: *imm15 = 0x4005; break;
+        case DR_REG_REVIDR_EL1: *imm15 = 0x4006; break;
+        case DR_REG_ID_AA64PFR0_EL1: *imm15 = 0x4020; break;
+        case DR_REG_ID_AA64PFR1_EL1: *imm15 = 0x4021; break;
+        case DR_REG_ID_AA64ZFR0_EL1: *imm15 = 0x4024; break;
+        case DR_REG_ID_AA64DFR0_EL1: *imm15 = 0x4028; break;
+        case DR_REG_ID_AA64ISAR0_EL1: *imm15 = 0x4030; break;
+        case DR_REG_ID_AA64ISAR1_EL1: *imm15 = 0x4031; break;
+        case DR_REG_ID_AA64ISAR2_EL1: *imm15 = 0x4032; break;
+        case DR_REG_ID_AA64MMFR1_EL1: *imm15 = 0x4039; break;
+        case DR_REG_ID_AA64MMFR2_EL1: *imm15 = 0x403A; break;
         case DR_REG_NZCV: *imm15 = 0x5a10; break;
         case DR_REG_FPCR: *imm15 = 0x5a20; break;
         case DR_REG_FPSR: *imm15 = 0x5a21; break;

--- a/core/ir/aarch64/encode.c
+++ b/core/ir/aarch64/encode.c
@@ -118,7 +118,9 @@ const char *const reg_names[] = {
     "p10", "p11", "p12", "p13", "p14", "p15",
     "ffr",
 
-    "cntvct_el0",
+    "cntvct_el0", "id_aa64isar0_el1", "id_aa64isar1_el1", "id_aa64isar2_el1",
+    "id_aa64pfr0_el1", "id_aa64mmfr1_el1", "id_aa64dfr0_el1", "id_aa64zfr0_el1",
+    "id_aa64pfr1_el1", "id_aa64mmfr2_el1", "midr_el1", "mpidr_el1", "revidr_el1",
 };
 
 
@@ -194,7 +196,10 @@ const reg_id_t dr_reg_fixer[] = { REG_NULL,
     DR_REG_P12, DR_REG_P13, DR_REG_P14, DR_REG_P15,
     DR_REG_FFR,
 
-    DR_REG_CNTVCT_EL0,
+    DR_REG_CNTVCT_EL0, DR_REG_ID_AA64ISAR0_EL1, DR_REG_ID_AA64ISAR1_EL1,
+    DR_REG_ID_AA64ISAR2_EL1, DR_REG_ID_AA64PFR0_EL1, DR_REG_ID_AA64MMFR1_EL1,
+    DR_REG_ID_AA64DFR0_EL1, DR_REG_ID_AA64ZFR0_EL1, DR_REG_ID_AA64PFR1_EL1,
+    DR_REG_ID_AA64MMFR2_EL1, DR_REG_MIDR_EL1, DR_REG_MPIDR_EL1, DR_REG_REVIDR_EL1,
 };
 
 /* Maps real ISA registers to their corresponding virtual DR_ISA_REGDEPS register.
@@ -366,6 +371,18 @@ const reg_id_t d_r_reg_id_to_virtual[] = {
     DR_REG_V195, /* DR_REG_FFR */
 
     DR_REG_V196, /* DR_REG_CNTVCT_EL0 */
+    DR_REG_V197, /* DR_REG_ID_AA64ISAR0_EL1 */
+    DR_REG_V198, /* DR_REG_ID_AA64ISAR1_EL1 */
+    DR_REG_V199, /* DR_REG_ID_AA64ISAR2_EL1 */
+    DR_REG_V200, /* DR_REG_ID_AA64PFR0_EL1 */
+    DR_REG_V201, /* DR_REG_ID_AA64MMFR1_EL1 */
+    DR_REG_V202, /* DR_REG_ID_AA64DFR0_EL1 */
+    DR_REG_V203, /* DR_REG_ID_AA64ZFR0_EL1 */
+    DR_REG_V204, /* DR_REG_ID_AA64PFR1_EL1 */
+    DR_REG_V205, /* DR_REG_ID_AA64MMFR2_EL1 */
+    DR_REG_V206, /* DR_REG_MIDR_EL1 */
+    DR_REG_V207, /* DR_REG_MPIDR_EL1 */
+    DR_REG_V208, /* DR_REG_REVIDR_EL1 */
 };
 /* clang-format on */
 

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1044,7 +1044,19 @@ enum {
 
 #    ifdef AARCH64
     /* AArch64 Counter/Timer Register(s) */
-    DR_REG_CNTVCT_EL0, /**< Virtual Timer Count Register, EL0. */
+    DR_REG_CNTVCT_EL0,       /**< Virtual Timer Count Register, EL0. */
+    DR_REG_ID_AA64ISAR0_EL1, /**< The "id_aa64isar0_el1" register. */
+    DR_REG_ID_AA64ISAR1_EL1, /**< The "id_aa64isar1_el1" register. */
+    DR_REG_ID_AA64ISAR2_EL1, /**< The "id_aa64isar2_el1" register. */
+    DR_REG_ID_AA64PFR0_EL1,  /**< The "id_aa64pfr0_el1" register. */
+    DR_REG_ID_AA64MMFR1_EL1, /**< The "id_aa64mmfr1_el1" register. */
+    DR_REG_ID_AA64DFR0_EL1,  /**< The "id_aa64dfr0_el1" register. */
+    DR_REG_ID_AA64ZFR0_EL1,  /**< The "id_aa64zfr0_el1" register. */
+    DR_REG_ID_AA64PFR1_EL1,  /**< The "id_aa64pfr1_el1" register. */
+    DR_REG_ID_AA64MMFR2_EL1, /**< The "id_aa64mmfr2_el1" register. */
+    DR_REG_MIDR_EL1,         /**< The "midr_el1" register. */
+    DR_REG_MPIDR_EL1,        /**< The "mpidr_el1" register. */
+    DR_REG_REVIDR_EL1,       /**< The "revidr_el1" register. */
 #    endif
 
 /* Aliases below here: */
@@ -1105,8 +1117,8 @@ enum {
     DR_REG_CP15_C13_3 = DR_REG_TPIDRURO,        /**< User Read-Only Thread ID Register */
 
 #    ifdef AARCH64
-    DR_REG_LAST_VALID_ENUM = DR_REG_CNTVCT_EL0, /**< Last valid register enum */
-    DR_REG_LAST_ENUM = DR_REG_CNTVCT_EL0,       /**< Last value of register enums */
+    DR_REG_LAST_VALID_ENUM = DR_REG_REVIDR_EL1, /**< Last valid register enum */
+    DR_REG_LAST_ENUM = DR_REG_REVIDR_EL1,       /**< Last value of register enums */
 #    else
     DR_REG_LAST_VALID_ENUM = DR_REG_TPIDRURO, /**< Last valid register enum */
     DR_REG_LAST_ENUM = DR_REG_TPIDRURO,       /**< Last value of register enums */

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2780,7 +2780,7 @@ reg_get_size(reg_id_t reg)
     }
     if ((reg >= DR_REG_P0 && reg <= DR_REG_P15) || reg == DR_REG_FFR)
         return OPSZ_SVE_PREDLEN_BYTES;
-    if (reg == DR_REG_CNTVCT_EL0)
+    if (reg >= DR_REG_CNTVCT_EL0 && reg <= DR_REG_REVIDR_EL1)
         return OPSZ_8;
     if (reg >= DR_REG_NZCV && reg <= DR_REG_FPSR)
         return OPSZ_8;


### PR DESCRIPTION
Registers like ID_AA64ISAR0_EL1 are readable at EL0 on Linux, but are not included in the DR_REG enum as this only includes EL0 registers.

This means that MRS instructions that read these registers will not be disassembled in the normal way in the DR log.

Issue: #2626