### PR TITLE
i#3544 RV64: Implements proc_has_feature() for vector extension

### DIFF
--- a/core/arch/proc_api.h
+++ b/core/arch/proc_api.h
@@ -195,14 +195,12 @@ typedef struct {
 
 #endif
 #ifdef RISCV64
-/* FIXME i#3544: Not implemented */
 /**
- * For RISC-V64 there are no features readable from userspace. Hence only a
- * dummy flag is there. May be replaced by actual feature flags in the future.
- * Used by proc_get_all_feature_bits().
+ * For RISC-V64 there are no features readable from userspace, so we mimic this ourselves,
+ * see signal_arch_init().  Used by proc_get_all_feature_bits().
  */
 typedef struct {
-    uint64 dummy; /**< Dummy member to keep size non-0. */
+    uint64 isa_features[1];
 } features_t;
 #endif
 
@@ -410,13 +408,15 @@ typedef enum {
 #endif
 
 #ifdef RISCV64
-/* FIXME i#3544: Not implemented */
 /**
  * Feature bits passed to proc_has_feature() to determine whether the underlying
  * processor has the feature.
+ * XXX: The enum definitions here and the bitmask of hwprobe in the kernel are kept
+ * consistent to facilitate possible switching in the future, refer to
+ * https://github.com/torvalds/linux/blob/v6.9/arch/riscv/include/uapi/asm/hwprobe.h.
  */
 typedef enum {
-    FEATURE_DUMMY = 0, /**< Dummy, non-existent feature. */
+    FEATURE_VECTOR = 2, /**< Vector extension. */
 } feature_bit_t;
 #endif
 

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -85,12 +85,7 @@ cpu_info_t cpu_info = {
     CACHE_SIZE_UNKNOWN,
     CACHE_SIZE_UNKNOWN,
     CACHE_SIZE_UNKNOWN,
-/* FIXME i#3544: (RISCV64) Not implemented */
-#ifdef AARCHXX
     {},
-#else
-    { 0 },
-#endif
     { 0x6e6b6e75, 0x006e776f }
 };
 

--- a/core/arch/proc_shared.c
+++ b/core/arch/proc_shared.c
@@ -85,7 +85,11 @@ cpu_info_t cpu_info = {
     CACHE_SIZE_UNKNOWN,
     CACHE_SIZE_UNKNOWN,
     CACHE_SIZE_UNKNOWN,
+#if defined(AARCHXX) || defined(RISCV64)
     {},
+#else
+    { 0 },
+#endif
     { 0x6e6b6e75, 0x006e776f }
 };
 

--- a/core/arch/riscv64/proc.c
+++ b/core/arch/riscv64/proc.c
@@ -139,11 +139,13 @@ proc_init_arch(void)
 }
 
 bool
-proc_has_feature(feature_bit_t f)
+proc_has_feature(feature_bit_t feature_bit)
 {
-    /* FIXME i#3544: Not implemented */
-    ASSERT_NOT_IMPLEMENTED(false);
+#ifdef DR_HOST_NOT_TARGET
     return false;
+#else
+    return *cpu_info.features.isa_features & (1 << feature_bit);
+#endif
 }
 
 void

--- a/core/unix/signal_linux_riscv64.c
+++ b/core/unix/signal_linux_riscv64.c
@@ -144,9 +144,8 @@ sigill_detected(void *func)
 
     kernel_sigaction_t act = { 0 };
     kernel_sigaction_t old_act;
-    act.flags = SA_ONSTACK | SA_RESTART | SA_SIGINFO;
-    act.handler = catch_sigill;
 
+    set_handler_sigact(&act, SIGILL, (handler_t)catch_sigill);
     sigaction_syscall(SIGILL, &act, &old_act);
 
     if (dr_setjmp(&jmpbuf) == 0) {
@@ -171,7 +170,7 @@ signal_arch_init(void)
     /* Detects RISC-V extensions support using SIGILL.
      * We could also use the riscv_hwprobe syscall (since kernel 6.4) or /proc/cpuinfo to
      * detect extension support, but as of year 2024, using SIGILL is still the most
-     * reliable way for varies devices and kernel versions.
+     * reliable way for various devices and kernel versions.
      *
      * Only supports the V extension detection for now.
      */


### PR DESCRIPTION
Detects RISC-V vector extension support using SIGILL in signal_arch_init(). Manually tested on real hardware.

Issue: #3544