### PR TITLE
i#2626 AArch64: Add missing MSR variants

### DIFF
--- a/core/ir/aarch64/codec_v80.txt
+++ b/core/ir/aarch64/codec_v80.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2016-2022 ARM Limited. All rights reserved.
+# Copyright (c) 2016-2024 ARM Limited. All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -690,9 +690,13 @@ x0011011000xxxxx0xxxxxxxxxxxxxxx  n   311  BASE       madd            wx0 : wx5 
 110100101xxxxxxxxxxxxxxxxxxxxxxx  n   317  BASE       movz             x0 : imm16 lsl imm16sh
 110101010011xxxxxxxxxxxxxxxxxxxx  er  318  BASE        mrs             x0 : sysreg
 110101010001xxxxxxxxxxxxxxxxxxxx  ew  319  BASE        msr            msr
+11010101000000000100xxxx01111111  ew  319  BASE        msr                : pstate imm4
+11010101000000000100xxxx10011111  ew  319  BASE        msr                : pstate imm4
 11010101000000000100xxxx10111111  ew  319  BASE        msr                : pstate imm4
-11010101000000110100xxxx11011111  ew  319  BASE        msr                : pstate imm4
-11010101000000110100xxxx11111111  ew  319  BASE        msr                : pstate imm4
+11010101000000110100xxxx00011111  ew  319  BASE        msr                : pstate imm4
+11010101000000110100xxxx00111111  ew  319  BASE        msr                : pstate imm4
+11010101000000110100xxxx01011111  ew  319  BASE        msr                : pstate imm4
+11010101000000110100xxxx1xx11111  ew  319  BASE        msr                : pstate imm4
 x0011011000xxxxx1xxxxxxxxxxxxxxx  n   320  BASE       msub            wx0 : wx5 wx16 wx10
 0x001110xx1xxxxx100111xxxxxxxxxx  n   321  BASE        mul            dq0 : dq5 dq16 bhs_sz
 0x001111xxxxxxxx1000x0xxxxxxxxxx  n   321  BASE        mul            dq0 : dq5 dq16_h_sz vindex_H hs_sz

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -1,6 +1,6 @@
 /* **********************************************************
  * Copyright (c) 2011-2023 Google, Inc. All rights reserved.
- * Copyright (c) 2016-2023 ARM Limited. All rights reserved.
+ * Copyright (c) 2016-2024 ARM Limited. All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc. All rights reserved.
  * **********************************************************/
 
@@ -670,8 +670,10 @@
     instr_create_1dst_3src(dc, OP_movz, rt, imm16, OPND_CREATE_LSL(), lsl)
 #define INSTR_CREATE_mrs(dc, Xt, sysreg) \
     instr_create_1dst_1src((dc), OP_mrs, (Xt), (sysreg))
-#define INSTR_CREATE_msr(dc, sysreg, Xt) \
-    instr_create_1dst_1src((dc), OP_msr, (sysreg), (Xt))
+#define INSTR_CREATE_msr(dc, sysreg, Xt_or_imm) \
+    opnd_is_immed(Xt_or_imm)?  \
+    instr_create_0dst_2src((dc), OP_msr, (sysreg), (Xt_or_imm)) : \
+    instr_create_1dst_1src((dc), OP_msr, (sysreg), (Xt_or_imm))
 #define INSTR_CREATE_nop(dc) instr_create_0dst_0src((dc), OP_nop)
 #define INSTR_CREATE_ret(dc, Rn) instr_create_0dst_1src((dc), OP_ret, (Rn))
 #define INSTR_CREATE_stp(dc, mem, rt1, rt2) \

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -670,10 +670,10 @@
     instr_create_1dst_3src(dc, OP_movz, rt, imm16, OPND_CREATE_LSL(), lsl)
 #define INSTR_CREATE_mrs(dc, Xt, sysreg) \
     instr_create_1dst_1src((dc), OP_mrs, (Xt), (sysreg))
-#define INSTR_CREATE_msr(dc, sysreg, Xt_or_imm) \
-    opnd_is_immed(Xt_or_imm)?  \
-    instr_create_0dst_2src((dc), OP_msr, (sysreg), (Xt_or_imm)) : \
-    instr_create_1dst_1src((dc), OP_msr, (sysreg), (Xt_or_imm))
+#define INSTR_CREATE_msr(dc, sysreg, Xt_or_imm)                       \
+    opnd_is_immed(Xt_or_imm)                                          \
+        ? instr_create_0dst_2src((dc), OP_msr, (sysreg), (Xt_or_imm)) \
+        : instr_create_1dst_1src((dc), OP_msr, (sysreg), (Xt_or_imm))
 #define INSTR_CREATE_nop(dc) instr_create_0dst_0src((dc), OP_nop)
 #define INSTR_CREATE_ret(dc, Rn) instr_create_0dst_1src((dc), OP_ret, (Rn))
 #define INSTR_CREATE_stp(dc, mem, rt1, rt2) \

--- a/suite/tests/api/ir_aarch64_v80.c
+++ b/suite/tests/api/ir_aarch64_v80.c
@@ -47,104 +47,104 @@
 
 #include "ir_aarch64.h"
 
+static const reg_id_t systemreg[] = {
+    DR_REG_NZCV,
+    DR_REG_FPCR,
+    DR_REG_FPSR,
+    DR_REG_MDCCSR_EL0,
+    DR_REG_DBGDTR_EL0,
+    DR_REG_DBGDTRRX_EL0,
+    DR_REG_SP_EL0,
+    DR_REG_SPSEL,
+    DR_REG_CURRENTEL,
+    DR_REG_PAN,
+    DR_REG_UAO,
+    DR_REG_CTR_EL0,
+    DR_REG_DCZID_EL0,
+    DR_REG_RNDR,
+    DR_REG_RNDRRS,
+    DR_REG_DAIF,
+    DR_REG_DIT,
+    DR_REG_SSBS,
+    DR_REG_TCO,
+    DR_REG_DSPSR_EL0,
+    DR_REG_DLR_EL0,
+    DR_REG_PMCR_EL0,
+    DR_REG_PMCNTENSET_EL0,
+    DR_REG_PMCNTENCLR_EL0,
+    DR_REG_PMOVSCLR_EL0,
+    DR_REG_PMSWINC_EL0,
+    DR_REG_PMSELR_EL0,
+    DR_REG_PMCEID0_EL0,
+    DR_REG_PMCEID1_EL0,
+    DR_REG_PMCCNTR_EL0,
+    DR_REG_PMXEVTYPER_EL0,
+    DR_REG_PMXEVCNTR_EL0,
+    DR_REG_PMUSERENR_EL0,
+    DR_REG_PMOVSSET_EL0,
+    DR_REG_SCXTNUM_EL0,
+    DR_REG_CNTFRQ_EL0,
+    DR_REG_CNTPCT_EL0,
+    DR_REG_CNTP_TVAL_EL0,
+    DR_REG_CNTP_CTL_EL0,
+    DR_REG_CNTP_CVAL_EL0,
+    DR_REG_CNTV_TVAL_EL0,
+    DR_REG_CNTV_CTL_EL0,
+    DR_REG_CNTV_CVAL_EL0,
+    DR_REG_PMEVTYPER0_EL0,
+    DR_REG_PMEVTYPER1_EL0,
+    DR_REG_PMEVTYPER2_EL0,
+    DR_REG_PMEVTYPER3_EL0,
+    DR_REG_PMEVTYPER4_EL0,
+    DR_REG_PMEVTYPER5_EL0,
+    DR_REG_PMEVTYPER6_EL0,
+    DR_REG_PMEVTYPER7_EL0,
+    DR_REG_PMEVTYPER8_EL0,
+    DR_REG_PMEVTYPER9_EL0,
+    DR_REG_PMEVTYPER10_EL0,
+    DR_REG_PMEVTYPER11_EL0,
+    DR_REG_PMEVTYPER12_EL0,
+    DR_REG_PMEVTYPER13_EL0,
+    DR_REG_PMEVTYPER14_EL0,
+    DR_REG_PMEVTYPER15_EL0,
+    DR_REG_PMEVTYPER16_EL0,
+    DR_REG_PMEVTYPER17_EL0,
+    DR_REG_PMEVTYPER18_EL0,
+    DR_REG_PMEVTYPER19_EL0,
+    DR_REG_PMEVTYPER20_EL0,
+    DR_REG_PMEVTYPER21_EL0,
+    DR_REG_PMEVTYPER22_EL0,
+    DR_REG_PMEVTYPER23_EL0,
+    DR_REG_PMEVTYPER24_EL0,
+    DR_REG_PMEVTYPER25_EL0,
+    DR_REG_PMEVTYPER26_EL0,
+    DR_REG_PMEVTYPER27_EL0,
+    DR_REG_PMEVTYPER28_EL0,
+    DR_REG_PMEVTYPER29_EL0,
+    DR_REG_PMEVTYPER30_EL0,
+    DR_REG_PMCCFILTR_EL0,
+    DR_REG_SPSR_IRQ,
+    DR_REG_SPSR_ABT,
+    DR_REG_SPSR_UND,
+    DR_REG_SPSR_FIQ,
+    DR_REG_ID_AA64ISAR0_EL1,
+    DR_REG_ID_AA64ISAR1_EL1,
+    DR_REG_ID_AA64ISAR2_EL1,
+    DR_REG_ID_AA64PFR0_EL1,
+    DR_REG_ID_AA64MMFR1_EL1,
+    DR_REG_ID_AA64DFR0_EL1,
+    DR_REG_ID_AA64ZFR0_EL1,
+    DR_REG_ID_AA64PFR1_EL1,
+    DR_REG_ID_AA64MMFR2_EL1,
+    DR_REG_MIDR_EL1,
+    DR_REG_MPIDR_EL1,
+    DR_REG_REVIDR_EL1,
+};
+static const size_t sysreg_count = sizeof(systemreg) / sizeof(systemreg[0]);
+
 TEST_INSTR(mrs)
 {
-    /* Testing MRS     <Xt>, #<imm> */
-    static const reg_id_t systemreg[] = {
-        DR_REG_NZCV,
-        DR_REG_FPCR,
-        DR_REG_FPSR,
-        DR_REG_MDCCSR_EL0,
-        DR_REG_DBGDTR_EL0,
-        DR_REG_DBGDTRRX_EL0,
-        DR_REG_SP_EL0,
-        DR_REG_SPSEL,
-        DR_REG_CURRENTEL,
-        DR_REG_PAN,
-        DR_REG_UAO,
-        DR_REG_CTR_EL0,
-        DR_REG_DCZID_EL0,
-        DR_REG_RNDR,
-        DR_REG_RNDRRS,
-        DR_REG_DAIF,
-        DR_REG_DIT,
-        DR_REG_SSBS,
-        DR_REG_TCO,
-        DR_REG_DSPSR_EL0,
-        DR_REG_DLR_EL0,
-        DR_REG_PMCR_EL0,
-        DR_REG_PMCNTENSET_EL0,
-        DR_REG_PMCNTENCLR_EL0,
-        DR_REG_PMOVSCLR_EL0,
-        DR_REG_PMSWINC_EL0,
-        DR_REG_PMSELR_EL0,
-        DR_REG_PMCEID0_EL0,
-        DR_REG_PMCEID1_EL0,
-        DR_REG_PMCCNTR_EL0,
-        DR_REG_PMXEVTYPER_EL0,
-        DR_REG_PMXEVCNTR_EL0,
-        DR_REG_PMUSERENR_EL0,
-        DR_REG_PMOVSSET_EL0,
-        DR_REG_SCXTNUM_EL0,
-        DR_REG_CNTFRQ_EL0,
-        DR_REG_CNTPCT_EL0,
-        DR_REG_CNTP_TVAL_EL0,
-        DR_REG_CNTP_CTL_EL0,
-        DR_REG_CNTP_CVAL_EL0,
-        DR_REG_CNTV_TVAL_EL0,
-        DR_REG_CNTV_CTL_EL0,
-        DR_REG_CNTV_CVAL_EL0,
-        DR_REG_PMEVTYPER0_EL0,
-        DR_REG_PMEVTYPER1_EL0,
-        DR_REG_PMEVTYPER2_EL0,
-        DR_REG_PMEVTYPER3_EL0,
-        DR_REG_PMEVTYPER4_EL0,
-        DR_REG_PMEVTYPER5_EL0,
-        DR_REG_PMEVTYPER6_EL0,
-        DR_REG_PMEVTYPER7_EL0,
-        DR_REG_PMEVTYPER8_EL0,
-        DR_REG_PMEVTYPER9_EL0,
-        DR_REG_PMEVTYPER10_EL0,
-        DR_REG_PMEVTYPER11_EL0,
-        DR_REG_PMEVTYPER12_EL0,
-        DR_REG_PMEVTYPER13_EL0,
-        DR_REG_PMEVTYPER14_EL0,
-        DR_REG_PMEVTYPER15_EL0,
-        DR_REG_PMEVTYPER16_EL0,
-        DR_REG_PMEVTYPER17_EL0,
-        DR_REG_PMEVTYPER18_EL0,
-        DR_REG_PMEVTYPER19_EL0,
-        DR_REG_PMEVTYPER20_EL0,
-        DR_REG_PMEVTYPER21_EL0,
-        DR_REG_PMEVTYPER22_EL0,
-        DR_REG_PMEVTYPER23_EL0,
-        DR_REG_PMEVTYPER24_EL0,
-        DR_REG_PMEVTYPER25_EL0,
-        DR_REG_PMEVTYPER26_EL0,
-        DR_REG_PMEVTYPER27_EL0,
-        DR_REG_PMEVTYPER28_EL0,
-        DR_REG_PMEVTYPER29_EL0,
-        DR_REG_PMEVTYPER30_EL0,
-        DR_REG_PMCCFILTR_EL0,
-        DR_REG_SPSR_IRQ,
-        DR_REG_SPSR_ABT,
-        DR_REG_SPSR_UND,
-        DR_REG_SPSR_FIQ,
-        DR_REG_ID_AA64ISAR0_EL1,
-        DR_REG_ID_AA64ISAR1_EL1,
-        DR_REG_ID_AA64ISAR2_EL1,
-        DR_REG_ID_AA64PFR0_EL1,
-        DR_REG_ID_AA64MMFR1_EL1,
-        DR_REG_ID_AA64DFR0_EL1,
-        DR_REG_ID_AA64ZFR0_EL1,
-        DR_REG_ID_AA64PFR1_EL1,
-        DR_REG_ID_AA64MMFR2_EL1,
-        DR_REG_MIDR_EL1,
-        DR_REG_MPIDR_EL1,
-        DR_REG_REVIDR_EL1,
-    };
-    static const size_t sysreg_count = sizeof(systemreg) / sizeof(systemreg[0]);
-
+    /* Testing MRS     <Xt>, <systemreg> */
     TEST_LOOP_EXPECT(
         mrs, sysreg_count,
         INSTR_CREATE_mrs(dc, opnd_create_reg(DR_REG_X0 + (i % 31)),
@@ -197,7 +197,7 @@ TEST_INSTR(mrs)
                 "mrs    %id_aa64dfr0_el1 -> %x22", "mrs    %id_aa64zfr0_el1 -> %x23",
                 "mrs    %id_aa64pfr1_el1 -> %x24", "mrs    %id_aa64mmfr2_el1 -> %x25",
                 "mrs    %midr_el1 -> %x26",        "mrs    %mpidr_el1 -> %x27",
-                "mrs    %revidr_el1 -> %x28",
+                "mrs    %revidr_el1 -> %x28"
                 /* clang-format on */
             );
             switch (systemreg[i]) {
@@ -223,6 +223,102 @@ TEST_INSTR(mrs)
         });
 }
 
+TEST_INSTR(msr)
+{
+    /* Testing MSR     <systemreg>, <Xt> */
+    TEST_LOOP_EXPECT(
+        msr, sysreg_count,
+        INSTR_CREATE_msr(dc, opnd_create_reg(systemreg[i]),
+                         opnd_create_reg(DR_REG_X0 + (i % 31))),
+        {
+            EXPECT_DISASSEMBLY(
+                /* clang-format off */
+                "msr    %x0 -> %nzcv",             "msr    %x1 -> %fpcr",
+                "msr    %x2 -> %fpsr",             "msr    %x3 -> %mdccsr_el0",
+                "msr    %x4 -> %dbgdtr_el0",       "msr    %x5 -> %dbgdtrrx_el0",
+                "msr    %x6 -> %sp_el0",           "msr    %x7 -> %spsel",
+                "msr    %x8 -> %currentel",        "msr    %x9 -> %pan",
+                "msr    %x10 -> %uao",             "msr    %x11 -> %ctr_el0",
+                "msr    %x12 -> %dczid_el0",       "msr    %x13 -> %rndr",
+                "msr    %x14 -> %rndrrs",          "msr    %x15 -> %daif",
+                "msr    %x16 -> %dit",             "msr    %x17 -> %ssbs",
+                "msr    %x18 -> %tco",             "msr    %x19 -> %dspsr_el0",
+                "msr    %x20 -> %dlr_el0",         "msr    %x21 -> %pmcr_el0",
+                "msr    %x22 -> %pmcntenset_el0",  "msr    %x23 -> %pmcntenclr_el0",
+                "msr    %x24 -> %pmovsclr_el0",    "msr    %x25 -> %pmswinc_el0",
+                "msr    %x26 -> %pmselr_el0",      "msr    %x27 -> %pmceid0_el0",
+                "msr    %x28 -> %pmceid1_el0",     "msr    %x29 -> %pmccntr_el0",
+                "msr    %x30 -> %pmxevtyper_el0",  "msr    %x0 -> %pmxevcntr_el0",
+                "msr    %x1 -> %pmuserenr_el0",    "msr    %x2 -> %pmovsset_el0",
+                "msr    %x3 -> %scxtnum_el0",      "msr    %x4 -> %cntfrq_el0",
+                "msr    %x5 -> %cntpct_el0",       "msr    %x6 -> %cntp_tval_el0",
+                "msr    %x7 -> %cntp_ctl_el0",     "msr    %x8 -> %cntp_cval_el0",
+                "msr    %x9 -> %cntv_tval_el0",    "msr    %x10 -> %cntv_ctl_el0",
+                "msr    %x11 -> %cntv_cval_el0",   "msr    %x12 -> %pmevtyper0_el0",
+                "msr    %x13 -> %pmevtyper1_el0",  "msr    %x14 -> %pmevtyper2_el0",
+                "msr    %x15 -> %pmevtyper3_el0",  "msr    %x16 -> %pmevtyper4_el0",
+                "msr    %x17 -> %pmevtyper5_el0",  "msr    %x18 -> %pmevtyper6_el0",
+                "msr    %x19 -> %pmevtyper7_el0",  "msr    %x20 -> %pmevtyper8_el0",
+                "msr    %x21 -> %pmevtyper9_el0",  "msr    %x22 -> %pmevtyper10_el0",
+                "msr    %x23 -> %pmevtyper11_el0", "msr    %x24 -> %pmevtyper12_el0",
+                "msr    %x25 -> %pmevtyper13_el0", "msr    %x26 -> %pmevtyper14_el0",
+                "msr    %x27 -> %pmevtyper15_el0", "msr    %x28 -> %pmevtyper16_el0",
+                "msr    %x29 -> %pmevtyper17_el0", "msr    %x30 -> %pmevtyper18_el0",
+                "msr    %x0 -> %pmevtyper19_el0",  "msr    %x1 -> %pmevtyper20_el0",
+                "msr    %x2 -> %pmevtyper21_el0",  "msr    %x3 -> %pmevtyper22_el0",
+                "msr    %x4 -> %pmevtyper23_el0",  "msr    %x5 -> %pmevtyper24_el0",
+                "msr    %x6 -> %pmevtyper25_el0",  "msr    %x7 -> %pmevtyper26_el0",
+                "msr    %x8 -> %pmevtyper27_el0",  "msr    %x9 -> %pmevtyper28_el0",
+                "msr    %x10 -> %pmevtyper29_el0", "msr    %x11 -> %pmevtyper30_el0",
+                "msr    %x12 -> %pmccfiltr_el0",   "msr    %x13 -> %spsr_irq",
+                "msr    %x14 -> %spsr_abt",        "msr    %x15 -> %spsr_und",
+                "msr    %x16 -> %spsr_fiq",        "msr    %x17 -> %id_aa64isar0_el1",
+                "msr    %x18 -> %id_aa64isar1_el1","msr    %x19 -> %id_aa64isar2_el1",
+                "msr    %x20 -> %id_aa64pfr0_el1", "msr    %x21 -> %id_aa64mmfr1_el1",
+                "msr    %x22 -> %id_aa64dfr0_el1", "msr    %x23 -> %id_aa64zfr0_el1",
+                "msr    %x24 -> %id_aa64pfr1_el1", "msr    %x25 -> %id_aa64mmfr2_el1",
+                "msr    %x26 -> %midr_el1",        "msr    %x27 -> %mpidr_el1",
+                "msr    %x28 -> %revidr_el1"
+                /* clang-format on */
+            );
+            switch (systemreg[i]) {
+            case DR_REG_NZCV:
+                EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
+                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_TRUE(TEST(EFLAGS_WRITE_NZCV,
+                                 instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                break;
+            default:
+                EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
+                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+                EXPECT_FALSE(TEST(EFLAGS_WRITE_NZCV,
+                                  instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+            }
+        });
+
+    /* Testing MSR     <pstatefield>, <imm> */
+    static const reg_id_t pstatefields[] = {
+        DR_REG_UAO, DR_REG_PAN, DR_REG_SPSEL,   DR_REG_SSBS,
+        DR_REG_DIT, DR_REG_TCO, DR_REG_DAIFSET, DR_REG_DAIFCLR,
+    };
+    static const size_t pstate_count = sizeof(pstatefields) / sizeof(pstatefields[0]);
+
+    TEST_LOOP_EXPECT(
+        msr, pstate_count,
+        INSTR_CREATE_msr(dc, opnd_create_reg(pstatefields[i]),
+                         opnd_create_immed_int(i, OPSZ_4b)),
+        {
+            EXPECT_DISASSEMBLY("msr    %uao $0x00", "msr    %pan $0x01",
+                               "msr    %spsel $0x02", "msr    %ssbs $0x03",
+                               "msr    %dit $0x04", "msr    %tco $0x05",
+                               "msr    %daifset $0x06", "msr    %daifclr $0x07");
+            EXPECT_FALSE(TEST(EFLAGS_READ_NZCV,
+                              instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+            EXPECT_FALSE(TEST(EFLAGS_WRITE_NZCV,
+                              instr_get_arith_flags(instr, DR_QUERY_INCLUDE_ALL)));
+        });
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -238,6 +334,7 @@ main(int argc, char *argv[])
     enable_all_test_cpu_features();
 
     RUN_INSTR_TEST(mrs);
+    RUN_INSTR_TEST(msr);
 
     print("All v8.0 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
Extends INSTR_CREATE_msr to be able to encode the immediate variant of the MSR instruction:
```
    MSR <pstatefield>, #<imm>
```

Adds codec support for some missing pstatefields, and adds missing IR and disassembly tests for MSR.

Issue: #2626