### PR TITLE
i#6844 skip-to-time: Fix typos in drmemtrace docs

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -182,11 +182,11 @@ public:
         {
         }
         /**
-         * The starting time in the microsecond timstamp units in the trace.
+         * The starting time in the microsecond timestamp units in the trace.
          */
         uint64_t start_timestamp;
         /**
-         * The ending time in the microsecond timstamp units in the trace.
+         * The ending time in the microsecond timestamp units in the trace.
          * The ending time is inclusive.  0 means the end of the trace.
          */
         uint64_t stop_timestamp;


### PR DESCRIPTION
Fixes two misspellings of "timestamp" in the docs for the new times_of_interest drmemtrace scheduler feature.

Issue: #6844