### PR TITLE
i#5843 scheduler: Raise default drmemtrace sched quantum to 6M

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -851,7 +851,8 @@ droption_t<bool> op_core_serial(
     "of options with the prefix \"sched_\" along with -cores.");
 
 droption_t<int64_t>
-    op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 1 * 1000 * 1000,
+    // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
+    op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 6 * 1000 * 1000,
                      "Scheduling quantum",
                      "Applies to -core_sharded and -core_serial. "
                      "Scheduling quantum: in microseconds of wall-clock "

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -567,7 +567,8 @@ public:
          * specified by
          * #dynamorio::drmemtrace::scheduler_tmpl_t::scheduler_options_t::quantum_unit.
          */
-        uint64_t quantum_duration = 10 * 1000 * 1000;
+        // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
+        uint64_t quantum_duration = 6 * 1000 * 1000;
         /**
          * If > 0, diagnostic messages are printed to stderr.  Higher values produce
          * more frequent diagnostics.

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -86,7 +86,8 @@ droption_t<int> op_verbose(DROPTION_SCOPE_ALL, "verbose", 1, 0, 64, "Verbosity l
 droption_t<int> op_num_cores(DROPTION_SCOPE_ALL, "num_cores", 4, 0, 8192,
                              "Number of cores", "Number of cores");
 
-droption_t<int64_t> op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 1 * 1000 * 1000,
+// We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
+droption_t<int64_t> op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 6 * 1000 * 1000,
                                      "Scheduling quantum",
                                      "Scheduling quantum: in instructions by default; in "
                                      "miroseconds if -sched_time is set.");


### PR DESCRIPTION
Fixes an inconsistency in the CLI drmemtrace scheduler quantum and the internal API by making them both the same at 6 million.  We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum. The scheduler_launcher default is also made to match.

Issue: #5843