### PR TITLE
i#3544 RV64 vector part3: Add vector instruction codec test

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2036,6 +2036,10 @@ if (NOT ANDROID)
     tobuild_api(api.ir_sve api/ir_aarch64_sve.c "" "" OFF OFF OFF)
     tobuild_api(api.ir_sve2 api/ir_aarch64_sve2.c "" "" OFF OFF OFF)
   endif (AARCH64)
+
+  if (RISCV64)
+    tobuild_api(api.ir_rvv api/ir_rvv.c  "" "" ON OFF OFF)
+  endif(RISCV64)
 endif ()
 
 # test synthetic DR_ISA_REGDEPS encoding, decoding, and disassembly
@@ -6205,6 +6209,7 @@ if (RISCV64)
     code_api|api.ir
     code_api|api.ir-static
     code_api|api.ir_regdeps
+    code_api|api.ir_rvv
     code_api|client.app_args
     code_api|client.blackbox
     code_api|client.crashmsg

--- a/suite/tests/api/ir_rvv.c
+++ b/suite/tests/api/ir_rvv.c
@@ -64,6 +64,153 @@ static byte buf[8192];
                        : 0))
 #endif
 
+#define ISLOAD true
+#define ISSTORE false
+
+#define TEST_MEM_WHOLEREG(OPCODE, MEM_type)                         \
+    do {                                                            \
+        if (MEM_type == ISLOAD) {                                   \
+            instr = INSTR_CREATE_##OPCODE(                          \
+                dc, opnd_create_reg(DR_REG_VR0),                    \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, \
+                                      reg_get_size(DR_REG_VR0)));   \
+        } else {                                                    \
+            instr = INSTR_CREATE_##OPCODE(                          \
+                dc,                                                 \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, \
+                                      reg_get_size(DR_REG_VR0)),    \
+                opnd_create_reg(DR_REG_VR0));                       \
+        }                                                           \
+        test_instr_encoding(dc, OP_##OPCODE, instr);                \
+    } while (0);
+
+#define TEST_MEM_UNIT_STRIDE(OPCODE, MEM_type)                                    \
+    do {                                                                          \
+        if (MEM_type == ISLOAD) {                                                 \
+            instr = INSTR_CREATE_##OPCODE(                                        \
+                dc, opnd_create_reg(DR_REG_VR0),                                  \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
+                                      reg_get_size(DR_REG_VR0)),                  \
+                opnd_create_immed_int(0b1, OPSZ_1b),                              \
+                opnd_create_immed_int(0b000, OPSZ_3b));                           \
+        } else {                                                                  \
+            instr = INSTR_CREATE_##OPCODE(                                        \
+                dc,                                                               \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
+                                      reg_get_size(DR_REG_VR0)),                  \
+                opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b), \
+                opnd_create_immed_int(0b000, OPSZ_3b));                           \
+        }                                                                         \
+        test_instr_encoding(dc, OP_##OPCODE, instr);                              \
+    } while (0);
+
+#define TEST_MEM_INDEX(OPCODE, MEM_type)                                          \
+    do {                                                                          \
+        if (MEM_type == ISLOAD) {                                                 \
+            instr = INSTR_CREATE_##OPCODE(                                        \
+                dc, opnd_create_reg(DR_REG_VR0),                                  \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
+                                      reg_get_size(DR_REG_VR0)),                  \
+                opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b), \
+                opnd_create_immed_int(0b000, OPSZ_3b));                           \
+        } else {                                                                  \
+            instr = INSTR_CREATE_##OPCODE(                                        \
+                dc,                                                               \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
+                                      reg_get_size(DR_REG_VR0)),                  \
+                opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),         \
+                opnd_create_immed_int(0b1, OPSZ_1b),                              \
+                opnd_create_immed_int(0b000, OPSZ_3b));                           \
+        }                                                                         \
+        test_instr_encoding(dc, OP_##OPCODE, instr);                              \
+    } while (0);
+
+#define TEST_MEM_STRIDE(OPCODE, MEM_type)                                        \
+    do {                                                                         \
+        if (MEM_type == ISLOAD) {                                                \
+            instr = INSTR_CREATE_##OPCODE(                                       \
+                dc, opnd_create_reg(DR_REG_VR0),                                 \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,              \
+                                      reg_get_size(DR_REG_VR0)),                 \
+                opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b), \
+                opnd_create_immed_int(0b000, OPSZ_3b));                          \
+        } else {                                                                 \
+            instr = INSTR_CREATE_##OPCODE(                                       \
+                dc,                                                              \
+                opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,              \
+                                      reg_get_size(DR_REG_VR0)),                 \
+                opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),         \
+                opnd_create_immed_int(0b1, OPSZ_1b),                             \
+                opnd_create_immed_int(0b000, OPSZ_3b));                          \
+        }                                                                        \
+        test_instr_encoding(dc, OP_##OPCODE, instr);                             \
+    } while (0);
+
+#define TEST_Vd_Rs1_Vs2_vm(OPCODE)                                         \
+    instr = INSTR_CREATE_##OPCODE(                                         \
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),       \
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b)); \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_Rs1_Vs2(OPCODE)                                                         \
+    instr =                                                                             \
+        INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),                          \
+                              opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2)); \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_Rs1(OPCODE)                                        \
+    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0), \
+                                  opnd_create_reg(DR_REG_A1));     \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_Vs1_Vs2_vm(OPCODE)                                         \
+    instr = INSTR_CREATE_##OPCODE(                                         \
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),      \
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b)); \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_Vs1_Vs2(OPCODE)                                                          \
+    instr =                                                                              \
+        INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),                           \
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2)); \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_IMM_Vs2_vm(OPCODE)                                                \
+    instr = INSTR_CREATE_##OPCODE(                                                \
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b), \
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));        \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_IMM_Vs2(OPCODE)                                            \
+    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),         \
+                                  opnd_create_immed_int(0b10100, OPSZ_5b), \
+                                  opnd_create_reg(DR_REG_VR1));            \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_Vs1_vm(OPCODE)                                          \
+    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),      \
+                                  opnd_create_reg(DR_REG_VR1),          \
+                                  opnd_create_immed_int(0b1, OPSZ_1b)); \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Vd_Vs1(OPCODE)                                        \
+    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0), \
+                                  opnd_create_reg(DR_REG_VR1));    \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Rd_Vs1(OPCODE)                                       \
+    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_A1), \
+                                  opnd_create_reg(DR_REG_VR0));   \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+#define TEST_Rd_Vs1_vm(OPCODE)                                          \
+    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_A1),       \
+                                  opnd_create_reg(DR_REG_VR0),          \
+                                  opnd_create_immed_int(0b1, OPSZ_1b)); \
+    test_instr_encoding(dc, OP_##OPCODE, instr);
+
+instr_t *instr;
+
 static byte *
 test_instr_encoding(void *dc, uint opcode, instr_t *instr)
 {
@@ -92,35 +239,8 @@ test_instr_encoding(void *dc, uint opcode, instr_t *instr)
 }
 
 static void
-test_instr_encoding_failure(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
-{
-    byte *pc;
-
-    pc = instr_encode_to_copy(dc, instr, buf, instr_pc);
-    ASSERT(pc == NULL);
-    instr_destroy(dc, instr);
-}
-
-static byte *
-test_instr_decoding_failure(void *dc, uint raw_instr)
-{
-    instr_t *decin;
-    byte *pc;
-
-    *(uint *)buf = raw_instr;
-    decin = instr_create(dc);
-    pc = decode(dc, buf, decin);
-    /* Returns NULL on failure. */
-    ASSERT(pc == NULL);
-    instr_destroy(dc, decin);
-    return pc;
-}
-
-static void
 test_configuration_setting(void *dc)
 {
-    instr_t *instr;
-
     instr = INSTR_CREATE_vsetivli(dc, opnd_create_reg(DR_REG_A1),
                                   opnd_create_immed_int(0b01010, OPSZ_5b),
                                   opnd_create_immed_int(0b00001000, OPSZ_10b));
@@ -137,329 +257,98 @@ test_configuration_setting(void *dc)
 static void
 test_unit_stride(void *dc)
 {
-    instr_t *instr;
+    TEST_MEM_WHOLEREG(vlm_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vsm_v, ISSTORE);
 
-    instr = INSTR_CREATE_vlm_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vlm_v, instr);
-    instr = INSTR_CREATE_vsm_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0));
-    test_instr_encoding(dc, OP_vsm_v, instr);
-    instr = INSTR_CREATE_vle8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle8_v, instr);
-    instr = INSTR_CREATE_vle16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle16_v, instr);
-    instr = INSTR_CREATE_vle32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle32_v, instr);
-    instr = INSTR_CREATE_vle64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle64_v, instr);
-    instr = INSTR_CREATE_vse8_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vse8_v, instr);
-    instr = INSTR_CREATE_vse16_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vse16_v, instr);
-    instr = INSTR_CREATE_vse32_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vse32_v, instr);
-    instr = INSTR_CREATE_vse64_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vse64_v, instr);
+    TEST_MEM_UNIT_STRIDE(vle8_v, ISLOAD);
+    TEST_MEM_UNIT_STRIDE(vle16_v, ISLOAD);
+    TEST_MEM_UNIT_STRIDE(vle32_v, ISLOAD);
+    TEST_MEM_UNIT_STRIDE(vle64_v, ISLOAD);
+
+    TEST_MEM_UNIT_STRIDE(vse8_v, ISSTORE);
+    TEST_MEM_UNIT_STRIDE(vse16_v, ISSTORE);
+    TEST_MEM_UNIT_STRIDE(vse32_v, ISSTORE);
+    TEST_MEM_UNIT_STRIDE(vse64_v, ISSTORE);
 }
 
 static void
 test_indexed_unordered(void *dc)
 {
-    instr_t *instr;
+    TEST_MEM_INDEX(vluxei8_v, ISLOAD);
+    TEST_MEM_INDEX(vluxei16_v, ISLOAD);
+    TEST_MEM_INDEX(vluxei32_v, ISLOAD);
+    TEST_MEM_INDEX(vluxei64_v, ISLOAD);
 
-    instr = INSTR_CREATE_vluxei8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vluxei8_v, instr);
-    instr = INSTR_CREATE_vluxei16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vluxei16_v, instr);
-    instr = INSTR_CREATE_vluxei32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vluxei32_v, instr);
-    instr = INSTR_CREATE_vluxei64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vluxei64_v, instr);
-
-    instr = INSTR_CREATE_vsuxei8_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsuxei8_v, instr);
-    instr = INSTR_CREATE_vsuxei16_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsuxei16_v, instr);
-    instr = INSTR_CREATE_vsuxei32_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsuxei32_v, instr);
-    instr = INSTR_CREATE_vsuxei64_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsuxei64_v, instr);
+    TEST_MEM_INDEX(vsuxei8_v, ISSTORE);
+    TEST_MEM_INDEX(vsuxei16_v, ISSTORE);
+    TEST_MEM_INDEX(vsuxei32_v, ISSTORE);
+    TEST_MEM_INDEX(vsuxei64_v, ISSTORE);
 }
 
 static void
 test_stride(void *dc)
 {
-    instr_t *instr;
+    TEST_MEM_STRIDE(vlse8_v, ISLOAD);
+    TEST_MEM_STRIDE(vlse16_v, ISLOAD);
+    TEST_MEM_STRIDE(vlse32_v, ISLOAD);
+    TEST_MEM_STRIDE(vlse64_v, ISLOAD);
 
-    instr = INSTR_CREATE_vlse8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vlse8_v, instr);
-    instr = INSTR_CREATE_vlse16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vlse16_v, instr);
-    instr = INSTR_CREATE_vlse32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vlse32_v, instr);
-    instr = INSTR_CREATE_vlse64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vlse64_v, instr);
-
-    instr = INSTR_CREATE_vsse8_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsse8_v, instr);
-    instr = INSTR_CREATE_vsse16_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsse16_v, instr);
-    instr = INSTR_CREATE_vsse32_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsse32_v, instr);
-    instr = INSTR_CREATE_vsse64_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsse64_v, instr);
+    TEST_MEM_STRIDE(vsse8_v, ISSTORE);
+    TEST_MEM_STRIDE(vsse16_v, ISSTORE);
+    TEST_MEM_STRIDE(vsse32_v, ISSTORE);
+    TEST_MEM_STRIDE(vsse64_v, ISSTORE);
 }
 
 static void
 test_indexed_ordered(void *dc)
 {
-    instr_t *instr;
+    TEST_MEM_INDEX(vloxei8_v, ISLOAD);
+    TEST_MEM_INDEX(vloxei16_v, ISLOAD);
+    TEST_MEM_INDEX(vloxei32_v, ISLOAD);
+    TEST_MEM_INDEX(vloxei64_v, ISLOAD);
 
-    instr = INSTR_CREATE_vloxei8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vloxei8_v, instr);
-    instr = INSTR_CREATE_vloxei16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vloxei16_v, instr);
-    instr = INSTR_CREATE_vloxei32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vloxei32_v, instr);
-    instr = INSTR_CREATE_vloxei64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
-        opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vloxei64_v, instr);
-    instr = INSTR_CREATE_vsoxei8_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsoxei8_v, instr);
-    instr = INSTR_CREATE_vsoxei16_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsoxei16_v, instr);
-    instr = INSTR_CREATE_vsoxei32_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsoxei32_v, instr);
-    instr = INSTR_CREATE_vsoxei64_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vsoxei64_v, instr);
+    TEST_MEM_INDEX(vsoxei8_v, ISSTORE);
+    TEST_MEM_INDEX(vsoxei16_v, ISSTORE);
+    TEST_MEM_INDEX(vsoxei32_v, ISSTORE);
+    TEST_MEM_INDEX(vsoxei64_v, ISSTORE);
 }
 
 static void
 test_unit_stride_faultfirst(void *dc)
 {
-    instr_t *instr;
-
-    instr = INSTR_CREATE_vle8ff_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle8ff_v, instr);
-    instr = INSTR_CREATE_vle16ff_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle16ff_v, instr);
-    instr = INSTR_CREATE_vle32ff_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle32ff_v, instr);
-    instr = INSTR_CREATE_vle64ff_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
-    test_instr_encoding(dc, OP_vle64ff_v, instr);
+    TEST_MEM_UNIT_STRIDE(vle8ff_v, ISLOAD);
+    TEST_MEM_UNIT_STRIDE(vle16ff_v, ISLOAD);
+    TEST_MEM_UNIT_STRIDE(vle32ff_v, ISLOAD);
+    TEST_MEM_UNIT_STRIDE(vle64ff_v, ISLOAD);
 }
 
 static void
 test_whole_register(void *dc)
 {
-    instr_t *instr;
+    TEST_MEM_WHOLEREG(vl1re8_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl1re16_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl1re32_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl1re64_v, ISLOAD);
 
-    instr = INSTR_CREATE_vl1re8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl1re8_v, instr);
-    instr = INSTR_CREATE_vl1re16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl1re16_v, instr);
-    instr = INSTR_CREATE_vl1re32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl1re32_v, instr);
-    instr = INSTR_CREATE_vl1re64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl1re64_v, instr);
+    TEST_MEM_WHOLEREG(vl2re8_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl2re16_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl2re32_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl2re64_v, ISLOAD);
 
-    instr = INSTR_CREATE_vl2re8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl2re8_v, instr);
-    instr = INSTR_CREATE_vl2re16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl2re16_v, instr);
-    instr = INSTR_CREATE_vl2re32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl2re32_v, instr);
-    instr = INSTR_CREATE_vl2re64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl2re64_v, instr);
+    TEST_MEM_WHOLEREG(vl4re8_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl4re16_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl4re32_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl4re64_v, ISLOAD);
 
-    instr = INSTR_CREATE_vl4re8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl4re8_v, instr);
-    instr = INSTR_CREATE_vl4re16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl4re16_v, instr);
-    instr = INSTR_CREATE_vl4re32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl4re32_v, instr);
-    instr = INSTR_CREATE_vl4re64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl4re64_v, instr);
+    TEST_MEM_WHOLEREG(vl8re8_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl8re16_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl8re32_v, ISLOAD);
+    TEST_MEM_WHOLEREG(vl8re64_v, ISLOAD);
 
-    instr = INSTR_CREATE_vl8re8_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl8re8_v, instr);
-    instr = INSTR_CREATE_vl8re16_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl8re16_v, instr);
-    instr = INSTR_CREATE_vl8re32_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl8re32_v, instr);
-    instr = INSTR_CREATE_vl8re64_v(
-        dc, opnd_create_reg(DR_REG_VR0),
-        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
-    test_instr_encoding(dc, OP_vl8re64_v, instr);
-
-    instr = INSTR_CREATE_vs1r_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0));
-    test_instr_encoding(dc, OP_vs1r_v, instr);
-    instr = INSTR_CREATE_vs2r_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0));
-    test_instr_encoding(dc, OP_vs2r_v, instr);
-    instr = INSTR_CREATE_vs4r_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0));
-    test_instr_encoding(dc, OP_vs4r_v, instr);
-    instr = INSTR_CREATE_vs8r_v(
-        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
-        opnd_create_reg(DR_REG_VR0));
-    test_instr_encoding(dc, OP_vs8r_v, instr);
+    TEST_MEM_WHOLEREG(vs1r_v, ISSTORE);
+    TEST_MEM_WHOLEREG(vs2r_v, ISSTORE);
+    TEST_MEM_WHOLEREG(vs4r_v, ISSTORE);
+    TEST_MEM_WHOLEREG(vs8r_v, ISSTORE);
 }
 
 static void
@@ -476,1334 +365,388 @@ test_load_store(void *dc)
 static void
 test_FVF(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_Rs1_Vs2_vm(vfadd_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfsub_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfmin_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfmax_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfsgnj_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfsgnjn_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfsgnjx_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfslide1up_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfslide1down_vf);
 
-    instr = INSTR_CREATE_vfadd_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfadd_vf, instr);
-    instr = INSTR_CREATE_vfsub_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsub_vf, instr);
-    instr = INSTR_CREATE_vfmin_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmin_vf, instr);
-    instr = INSTR_CREATE_vfmax_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmax_vf, instr);
-    instr = INSTR_CREATE_vfsgnj_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsgnj_vf, instr);
-    instr = INSTR_CREATE_vfsgnjn_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsgnjn_vf, instr);
-    instr = INSTR_CREATE_vfsgnjx_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsgnjx_vf, instr);
-    instr = INSTR_CREATE_vfslide1up_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfslide1up_vf, instr);
-    instr = INSTR_CREATE_vfslide1down_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfslide1down_vf, instr);
-    instr = INSTR_CREATE_vfmv_s_f(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1));
-    test_instr_encoding(dc, OP_vfmv_s_f, instr);
+    TEST_Vd_Rs1(vfmv_s_f);
+    TEST_Vd_Rs1(vfmv_v_f);
 
-    instr =
-        INSTR_CREATE_vfmerge_vfm(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vfmerge_vfm, instr);
-    instr = INSTR_CREATE_vfmv_v_f(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1));
-    test_instr_encoding(dc, OP_vfmv_v_f, instr);
-    instr = INSTR_CREATE_vmfeq_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfeq_vf, instr);
-    instr = INSTR_CREATE_vmfle_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfle_vf, instr);
-    instr = INSTR_CREATE_vmflt_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmflt_vf, instr);
-    instr = INSTR_CREATE_vmfne_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfne_vf, instr);
-    instr = INSTR_CREATE_vmfgt_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfgt_vf, instr);
-    instr = INSTR_CREATE_vmfge_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfge_vf, instr);
+    TEST_Vd_Rs1_Vs2(vfmerge_vfm);
+    TEST_Vd_Rs1_Vs2_vm(vmfeq_vf);
+    TEST_Vd_Rs1_Vs2_vm(vmfle_vf);
+    TEST_Vd_Rs1_Vs2_vm(vmflt_vf);
+    TEST_Vd_Rs1_Vs2_vm(vmfne_vf);
+    TEST_Vd_Rs1_Vs2_vm(vmfgt_vf);
+    TEST_Vd_Rs1_Vs2_vm(vmfge_vf);
 
-    instr = INSTR_CREATE_vfrdiv_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfrdiv_vf, instr);
-    instr = INSTR_CREATE_vfmul_vf(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmul_vf, instr);
-    instr = INSTR_CREATE_vfrsub_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfrsub_vf, instr);
-    instr = INSTR_CREATE_vfmadd_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmadd_vf, instr);
-    instr = INSTR_CREATE_vfnmadd_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmadd_vf, instr);
-    instr = INSTR_CREATE_vfmsub_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmsub_vf, instr);
-    instr = INSTR_CREATE_vfnmsub_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmsub_vf, instr);
-    instr = INSTR_CREATE_vfmacc_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmacc_vf, instr);
-    instr =
-        INSTR_CREATE_vfmerge_vfm(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vfmerge_vfm, instr);
-    instr = INSTR_CREATE_vfnmacc_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmacc_vf, instr);
-    instr = INSTR_CREATE_vfmsac_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmsac_vf, instr);
-    instr = INSTR_CREATE_vfnmsac_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmsac_vf, instr);
-
-    instr = INSTR_CREATE_vfwadd_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwadd_vf, instr);
-    instr = INSTR_CREATE_vfwsub_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwsub_vf, instr);
-    instr = INSTR_CREATE_vfwadd_wf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwadd_wf, instr);
-    instr = INSTR_CREATE_vfwsub_wf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwsub_wf, instr);
-    instr = INSTR_CREATE_vfwmul_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwmul_vf, instr);
-    instr = INSTR_CREATE_vfwmacc_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwmacc_vf, instr);
-    instr = INSTR_CREATE_vfwnmacc_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwnmacc_vf, instr);
-    instr = INSTR_CREATE_vfwmsac_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwmsac_vf, instr);
-    instr = INSTR_CREATE_vfwnmsac_vf(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwnmsac_vf, instr);
+    TEST_Vd_Rs1_Vs2_vm(vfrdiv_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfmul_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfrsub_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfmadd_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfnmadd_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfmsub_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfnmsub_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfmacc_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfnmacc_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfmsac_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfnmsac_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfwadd_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfwsub_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfwadd_wf);
+    TEST_Vd_Rs1_Vs2_vm(vfwsub_wf);
+    TEST_Vd_Rs1_Vs2_vm(vfwmul_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfwmacc_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfwnmacc_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfwmsac_vf);
+    TEST_Vd_Rs1_Vs2_vm(vfwnmsac_vf);
 }
 
 static void
 test_FVV(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_Vs1_Vs2_vm(vfadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfredusum_vs);
+    TEST_Vd_Vs1_Vs2_vm(vfsub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfredosum_vs);
+    TEST_Vd_Vs1_Vs2_vm(vfmin_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfredmin_vs);
+    TEST_Vd_Vs1_Vs2_vm(vfmax_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfredmax_vs);
+    TEST_Vd_Vs1_Vs2_vm(vfsgnj_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfsgnjn_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfsgnjx_vv);
+    TEST_Rd_Vs1(vfmv_f_s);
 
-    instr = INSTR_CREATE_vfadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfadd_vv, instr);
-    instr = INSTR_CREATE_vfredusum_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfredusum_vs, instr);
-    instr = INSTR_CREATE_vfsub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsub_vv, instr);
-    instr = INSTR_CREATE_vfredosum_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfredosum_vs, instr);
-    instr = INSTR_CREATE_vfmin_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmin_vv, instr);
-    instr = INSTR_CREATE_vfredmin_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfredmin_vs, instr);
-    instr = INSTR_CREATE_vfmax_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmax_vv, instr);
-    instr = INSTR_CREATE_vfredmax_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfredmax_vs, instr);
-    instr = INSTR_CREATE_vfsgnj_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsgnj_vv, instr);
-    instr = INSTR_CREATE_vfsgnjn_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsgnjn_vv, instr);
-    instr = INSTR_CREATE_vfsgnjx_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsgnjx_vv, instr);
-    instr = INSTR_CREATE_vfmv_f_s(dc, opnd_create_reg(DR_REG_A1),
-                                  opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vfmv_f_s, instr);
+    TEST_Vd_Vs1_Vs2_vm(vmfeq_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmfle_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmflt_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmfne_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfdiv_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfmul_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfmadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfnmadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfmsub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfnmsub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfmacc_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfnmacc_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfmsac_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfnmsac_vv);
 
-    instr = INSTR_CREATE_vmfeq_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfeq_vv, instr);
-    instr = INSTR_CREATE_vmfle_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfle_vv, instr);
-    instr = INSTR_CREATE_vmflt_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmflt_vv, instr);
-    instr = INSTR_CREATE_vmfne_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmfne_vv, instr);
+    TEST_Vd_Vs1_vm(vfcvt_xu_f_v);
+    TEST_Vd_Vs1_vm(vfcvt_x_f_v);
+    TEST_Vd_Vs1_vm(vfcvt_f_xu_v);
+    TEST_Vd_Vs1_vm(vfcvt_f_x_v);
+    TEST_Vd_Vs1_vm(vfcvt_rtz_xu_f_v);
+    TEST_Vd_Vs1_vm(vfcvt_rtz_x_f_v);
+    TEST_Vd_Vs1_vm(vfwcvt_x_f_v);
+    TEST_Vd_Vs1_vm(vfwcvt_f_xu_v);
+    TEST_Vd_Vs1_vm(vfwcvt_f_x_v);
+    TEST_Vd_Vs1_vm(vfwcvt_f_f_v);
+    TEST_Vd_Vs1_vm(vfwcvt_rtz_xu_f_v);
+    TEST_Vd_Vs1_vm(vfwcvt_rtz_x_f_v);
 
-    instr = INSTR_CREATE_vfdiv_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfdiv_vv, instr);
-    instr = INSTR_CREATE_vfmul_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmul_vv, instr);
-    instr = INSTR_CREATE_vfmadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmadd_vv, instr);
-    instr = INSTR_CREATE_vfnmadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmadd_vv, instr);
-    instr = INSTR_CREATE_vfmsub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmsub_vv, instr);
-    instr = INSTR_CREATE_vfnmsub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmsub_vv, instr);
-    instr = INSTR_CREATE_vfmacc_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmacc_vv, instr);
-    instr = INSTR_CREATE_vfnmacc_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmacc_vv, instr);
-    instr = INSTR_CREATE_vfmsac_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmsac_vv, instr);
-    instr = INSTR_CREATE_vfnmsac_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmsac_vv, instr);
+    TEST_Vd_Vs1_vm(vfncvt_xu_f_w);
+    TEST_Vd_Vs1_vm(vfncvt_x_f_w);
+    TEST_Vd_Vs1_vm(vfncvt_f_xu_w);
+    TEST_Vd_Vs1_vm(vfncvt_f_x_w);
+    TEST_Vd_Vs1_vm(vfncvt_f_f_w);
+    TEST_Vd_Vs1_vm(vfncvt_rod_f_f_w);
+    TEST_Vd_Vs1_vm(vfncvt_rtz_xu_f_w);
+    TEST_Vd_Vs1_vm(vfncvt_rtz_x_f_w);
 
-    instr = INSTR_CREATE_vfcvt_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfcvt_xu_f_v, instr);
-    instr = INSTR_CREATE_vfcvt_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                     opnd_create_reg(DR_REG_VR1),
-                                     opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfcvt_x_f_v, instr);
-    instr = INSTR_CREATE_vfcvt_f_xu_v(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfcvt_f_xu_v, instr);
-    instr = INSTR_CREATE_vfcvt_f_x_v(dc, opnd_create_reg(DR_REG_VR0),
-                                     opnd_create_reg(DR_REG_VR1),
-                                     opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfcvt_f_x_v, instr);
-    instr = INSTR_CREATE_vfcvt_rtz_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                          opnd_create_reg(DR_REG_VR1),
-                                          opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfcvt_rtz_xu_f_v, instr);
-    instr = INSTR_CREATE_vfcvt_rtz_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                         opnd_create_reg(DR_REG_VR1),
-                                         opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfcvt_rtz_x_f_v, instr);
+    TEST_Vd_Vs1_vm(vfsqrt_v);
+    TEST_Vd_Vs1_vm(vfrsqrt7_v);
+    TEST_Vd_Vs1_vm(vfrec7_v);
+    TEST_Vd_Vs1_vm(vfclass_v);
 
-    instr = INSTR_CREATE_vfcvt_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfcvt_xu_f_v, instr);
-    instr = INSTR_CREATE_vfwcvt_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwcvt_x_f_v, instr);
-    instr = INSTR_CREATE_vfwcvt_f_xu_v(dc, opnd_create_reg(DR_REG_VR0),
-                                       opnd_create_reg(DR_REG_VR1),
-                                       opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwcvt_f_xu_v, instr);
-    instr = INSTR_CREATE_vfwcvt_f_x_v(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwcvt_f_x_v, instr);
-    instr = INSTR_CREATE_vfwcvt_f_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwcvt_f_f_v, instr);
-    instr = INSTR_CREATE_vfwcvt_rtz_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                           opnd_create_reg(DR_REG_VR1),
-                                           opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwcvt_rtz_xu_f_v, instr);
-    instr = INSTR_CREATE_vfwcvt_rtz_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
-                                          opnd_create_reg(DR_REG_VR1),
-                                          opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwcvt_rtz_x_f_v, instr);
-
-    instr = INSTR_CREATE_vfncvt_xu_f_w(dc, opnd_create_reg(DR_REG_VR0),
-                                       opnd_create_reg(DR_REG_VR1),
-                                       opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_xu_f_w, instr);
-    instr = INSTR_CREATE_vfncvt_x_f_w(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_x_f_w, instr);
-    instr = INSTR_CREATE_vfncvt_f_xu_w(dc, opnd_create_reg(DR_REG_VR0),
-                                       opnd_create_reg(DR_REG_VR1),
-                                       opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_f_xu_w, instr);
-    instr = INSTR_CREATE_vfncvt_f_x_w(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_f_x_w, instr);
-    instr = INSTR_CREATE_vfncvt_f_f_w(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_f_f_w, instr);
-    instr = INSTR_CREATE_vfncvt_rod_f_f_w(dc, opnd_create_reg(DR_REG_VR0),
-                                          opnd_create_reg(DR_REG_VR1),
-                                          opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_rod_f_f_w, instr);
-    instr = INSTR_CREATE_vfncvt_rtz_xu_f_w(dc, opnd_create_reg(DR_REG_VR0),
-                                           opnd_create_reg(DR_REG_VR1),
-                                           opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_rtz_xu_f_w, instr);
-    instr = INSTR_CREATE_vfncvt_rtz_x_f_w(dc, opnd_create_reg(DR_REG_VR0),
-                                          opnd_create_reg(DR_REG_VR1),
-                                          opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfncvt_rtz_x_f_w, instr);
-
-    instr = INSTR_CREATE_vfsqrt_v(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_VR1),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfsqrt_v, instr);
-    instr = INSTR_CREATE_vfrsqrt7_v(dc, opnd_create_reg(DR_REG_VR0),
-                                    opnd_create_reg(DR_REG_VR1),
-                                    opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfrsqrt7_v, instr);
-    instr = INSTR_CREATE_vfrec7_v(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_VR1),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfrec7_v, instr);
-    instr = INSTR_CREATE_vfclass_v(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_reg(DR_REG_VR1),
-                                   opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfclass_v, instr);
-
-    instr = INSTR_CREATE_vfwadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwadd_vv, instr);
-    instr = INSTR_CREATE_vfwredusum_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwredusum_vs, instr);
-    instr = INSTR_CREATE_vfwsub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwsub_vv, instr);
-    instr = INSTR_CREATE_vfwredosum_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwredosum_vs, instr);
-    instr = INSTR_CREATE_vfwadd_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwadd_wv, instr);
-    instr = INSTR_CREATE_vfwsub_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwsub_wv, instr);
-    instr = INSTR_CREATE_vfwmul_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwmul_vv, instr);
-    instr = INSTR_CREATE_vfwmacc_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwmacc_vv, instr);
-    instr = INSTR_CREATE_vfwnmacc_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwnmacc_vv, instr);
-    instr = INSTR_CREATE_vfnmacc_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfnmacc_vv, instr);
-    instr = INSTR_CREATE_vfmsac_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfmsac_vv, instr);
-    instr = INSTR_CREATE_vfwnmsac_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfwnmsac_vv, instr);
+    TEST_Vd_Vs1_Vs2_vm(vfwadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfwredusum_vs);
+    TEST_Vd_Vs1_Vs2_vm(vfwsub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfwredosum_vs);
+    TEST_Vd_Vs1_Vs2_vm(vfwadd_wv);
+    TEST_Vd_Vs1_Vs2_vm(vfwsub_wv);
+    TEST_Vd_Vs1_Vs2_vm(vfwmul_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfwmacc_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfwnmacc_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfnmacc_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfmsac_vv);
+    TEST_Vd_Vs1_Vs2_vm(vfwnmsac_vv);
 }
 
 static void
 test_IVX(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_Rs1_Vs2_vm(vadd_vx);
+    TEST_Vd_Rs1_Vs2_vm(vsub_vx);
+    TEST_Vd_Rs1_Vs2_vm(vrsub_vx);
+    TEST_Vd_Rs1_Vs2_vm(vminu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmin_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmaxu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmax_vx);
+    TEST_Vd_Rs1_Vs2_vm(vand_vx);
+    TEST_Vd_Rs1_Vs2_vm(vor_vx);
+    TEST_Vd_Rs1_Vs2_vm(vxor_vx);
+    TEST_Vd_Rs1_Vs2_vm(vrgather_vx);
+    TEST_Vd_Rs1_Vs2_vm(vslideup_vx);
+    TEST_Vd_Rs1_Vs2_vm(vslidedown_vx);
 
-    instr = INSTR_CREATE_vadd_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vadd_vx, instr);
-    instr = INSTR_CREATE_vsub_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsub_vx, instr);
-    instr = INSTR_CREATE_vrsub_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrsub_vx, instr);
-    instr = INSTR_CREATE_vminu_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vminu_vx, instr);
-    instr = INSTR_CREATE_vmin_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmin_vx, instr);
-    instr = INSTR_CREATE_vmaxu_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmaxu_vx, instr);
-    instr = INSTR_CREATE_vmax_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmax_vx, instr);
-    instr = INSTR_CREATE_vand_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vand_vx, instr);
-    instr = INSTR_CREATE_vor_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vor_vx, instr);
-    instr = INSTR_CREATE_vxor_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vxor_vx, instr);
-    instr = INSTR_CREATE_vrgather_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrgather_vx, instr);
-    instr = INSTR_CREATE_vslideup_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vslideup_vx, instr);
-    instr = INSTR_CREATE_vslidedown_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vslidedown_vx, instr);
+    TEST_Vd_Rs1_Vs2(vadc_vxm);
+    TEST_Vd_Rs1_Vs2(vmadc_vxm);
+    TEST_Vd_Rs1_Vs2(vmadc_vx);
+    TEST_Vd_Rs1_Vs2(vsbc_vxm);
+    TEST_Vd_Rs1_Vs2(vmsbc_vxm);
+    TEST_Vd_Rs1_Vs2(vmsbc_vx);
+    TEST_Vd_Rs1_Vs2(vmerge_vxm);
+    TEST_Vd_Rs1(vmv_v_x);
 
-    instr =
-        INSTR_CREATE_vadc_vxm(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-                              opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vadc_vxm, instr);
-    instr =
-        INSTR_CREATE_vmadc_vxm(dc, opnd_create_reg(DR_REG_VR0),
-                               opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmadc_vxm, instr);
-    instr =
-        INSTR_CREATE_vmadc_vx(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-                              opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmadc_vx, instr);
-    instr =
-        INSTR_CREATE_vsbc_vxm(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-                              opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vsbc_vxm, instr);
-    instr =
-        INSTR_CREATE_vmsbc_vxm(dc, opnd_create_reg(DR_REG_VR0),
-                               opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmsbc_vxm, instr);
-    instr =
-        INSTR_CREATE_vmsbc_vx(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-                              opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmsbc_vx, instr);
-    instr =
-        INSTR_CREATE_vmerge_vxm(dc, opnd_create_reg(DR_REG_VR0),
-                                opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmerge_vxm, instr);
-    instr =
-        INSTR_CREATE_vmv_v_x(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1));
-    test_instr_encoding(dc, OP_vmv_v_x, instr);
-    instr = INSTR_CREATE_vmseq_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmseq_vx, instr);
-    instr = INSTR_CREATE_vmsne_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsne_vx, instr);
-    instr = INSTR_CREATE_vmsltu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsltu_vx, instr);
-    instr = INSTR_CREATE_vmslt_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmslt_vx, instr);
-    instr = INSTR_CREATE_vmsleu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsleu_vx, instr);
-    instr = INSTR_CREATE_vmsle_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsle_vx, instr);
-    instr = INSTR_CREATE_vmsgtu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsgtu_vx, instr);
-    instr = INSTR_CREATE_vmsgt_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsgt_vx, instr);
-
-    instr = INSTR_CREATE_vsaddu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsaddu_vx, instr);
-    instr = INSTR_CREATE_vsadd_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsadd_vx, instr);
-    instr = INSTR_CREATE_vssubu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssubu_vx, instr);
-    instr = INSTR_CREATE_vssub_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssub_vx, instr);
-    instr = INSTR_CREATE_vsll_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsll_vx, instr);
-    instr = INSTR_CREATE_vsmul_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsmul_vx, instr);
-    instr = INSTR_CREATE_vsrl_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsrl_vx, instr);
-
-    instr = INSTR_CREATE_vsra_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsra_vx, instr);
-    instr = INSTR_CREATE_vssrl_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssrl_vx, instr);
-    instr = INSTR_CREATE_vssra_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssra_vx, instr);
-    instr = INSTR_CREATE_vnsrl_wx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnsrl_wx, instr);
-    instr = INSTR_CREATE_vnsra_wx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnsra_wx, instr);
-    instr = INSTR_CREATE_vnclipu_wx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnclipu_wx, instr);
-    instr = INSTR_CREATE_vnclip_wx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnclip_wx, instr);
+    TEST_Vd_Rs1_Vs2_vm(vmseq_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmsne_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmsltu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmslt_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmsleu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmsle_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmsgtu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmsgt_vx);
+    TEST_Vd_Rs1_Vs2_vm(vsaddu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vsadd_vx);
+    TEST_Vd_Rs1_Vs2_vm(vssubu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vssub_vx);
+    TEST_Vd_Rs1_Vs2_vm(vsll_vx);
+    TEST_Vd_Rs1_Vs2_vm(vsmul_vx);
+    TEST_Vd_Rs1_Vs2_vm(vsrl_vx);
+    TEST_Vd_Rs1_Vs2_vm(vsra_vx);
+    TEST_Vd_Rs1_Vs2_vm(vssrl_vx);
+    TEST_Vd_Rs1_Vs2_vm(vssra_vx);
+    TEST_Vd_Rs1_Vs2_vm(vnsrl_wx);
+    TEST_Vd_Rs1_Vs2_vm(vnsra_wx);
+    TEST_Vd_Rs1_Vs2_vm(vnclipu_wx);
+    TEST_Vd_Rs1_Vs2_vm(vnclip_wx);
 }
 
 static void
 test_IVV(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_Vs1_Vs2_vm(vadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vsub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vminu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmin_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmaxu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmax_vv);
+    TEST_Vd_Vs1_Vs2_vm(vand_vv);
+    TEST_Vd_Vs1_Vs2_vm(vor_vv);
+    TEST_Vd_Vs1_Vs2_vm(vxor_vv);
+    TEST_Vd_Vs1_Vs2_vm(vrgather_vv);
+    TEST_Vd_Vs1_Vs2_vm(vrgatherei16_vv);
 
-    instr = INSTR_CREATE_vadd_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vadd_vv, instr);
-    instr = INSTR_CREATE_vsub_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsub_vv, instr);
-    instr = INSTR_CREATE_vminu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vminu_vv, instr);
-    instr = INSTR_CREATE_vmin_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmin_vv, instr);
-    instr = INSTR_CREATE_vmaxu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmaxu_vv, instr);
-    instr = INSTR_CREATE_vmax_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmax_vv, instr);
-    instr = INSTR_CREATE_vand_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vand_vv, instr);
-    instr = INSTR_CREATE_vor_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vor_vv, instr);
-    instr = INSTR_CREATE_vxor_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vxor_vv, instr);
-    instr = INSTR_CREATE_vrgather_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrgather_vv, instr);
-    instr = INSTR_CREATE_vrgatherei16_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrgatherei16_vv, instr);
+    TEST_Vd_Vs1_Vs2(vadc_vvm);
+    TEST_Vd_Vs1_Vs2(vmadc_vvm);
+    TEST_Vd_Vs1_Vs2(vmadc_vv);
+    TEST_Vd_Vs1_Vs2(vsbc_vvm);
+    TEST_Vd_Vs1_Vs2(vmsbc_vvm);
+    TEST_Vd_Vs1_Vs2(vmsbc_vv);
+    TEST_Vd_Vs1_Vs2(vmerge_vvm);
+    TEST_Vd_Vs1(vmv_v_v);
+    TEST_Vd_Vs1_Vs2_vm(vmseq_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmsne_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmsltu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmslt_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmsleu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmsle_vv);
 
-    instr =
-        INSTR_CREATE_vadc_vvm(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vadc_vvm, instr);
-    instr =
-        INSTR_CREATE_vmadc_vvm(dc, opnd_create_reg(DR_REG_VR0),
-                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmadc_vvm, instr);
-    instr =
-        INSTR_CREATE_vmadc_vv(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmadc_vv, instr);
-    instr =
-        INSTR_CREATE_vsbc_vvm(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vsbc_vvm, instr);
-    instr =
-        INSTR_CREATE_vmsbc_vvm(dc, opnd_create_reg(DR_REG_VR0),
-                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmsbc_vvm, instr);
-    instr =
-        INSTR_CREATE_vmsbc_vv(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmsbc_vv, instr);
-    instr =
-        INSTR_CREATE_vmerge_vvm(dc, opnd_create_reg(DR_REG_VR0),
-                                opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmerge_vvm, instr);
-    instr = INSTR_CREATE_vmv_v_v(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmv_v_v, instr);
-    instr = INSTR_CREATE_vmseq_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmseq_vv, instr);
-    instr = INSTR_CREATE_vmsne_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsne_vv, instr);
-    instr = INSTR_CREATE_vmsltu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsltu_vv, instr);
-    instr = INSTR_CREATE_vmslt_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmslt_vv, instr);
-    instr = INSTR_CREATE_vmsleu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsleu_vv, instr);
-    instr = INSTR_CREATE_vmsle_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsle_vv, instr);
+    TEST_Vd_Vs1_Vs2_vm(vsaddu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vsadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vssubu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vssub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vsll_vv);
+    TEST_Vd_Vs1_Vs2_vm(vsmul_vv);
+    TEST_Vd_Vs1_Vs2_vm(vsrl_vv);
+    TEST_Vd_Vs1_Vs2_vm(vsra_vv);
+    TEST_Vd_Vs1_Vs2_vm(vssrl_vv);
+    TEST_Vd_Vs1_Vs2_vm(vssra_vv);
+    TEST_Vd_Vs1_Vs2_vm(vnsrl_wv);
+    TEST_Vd_Vs1_Vs2_vm(vnsra_wv);
+    TEST_Vd_Vs1_Vs2_vm(vnclipu_wv);
+    TEST_Vd_Vs1_Vs2_vm(vnclip_wv);
 
-    instr = INSTR_CREATE_vsaddu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsaddu_vv, instr);
-    instr = INSTR_CREATE_vsadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsadd_vv, instr);
-    instr = INSTR_CREATE_vssubu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssubu_vv, instr);
-    instr = INSTR_CREATE_vssub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssub_vv, instr);
-    instr = INSTR_CREATE_vsll_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsll_vv, instr);
-    instr = INSTR_CREATE_vsmul_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsmul_vv, instr);
-    instr = INSTR_CREATE_vsrl_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsrl_vv, instr);
-    instr = INSTR_CREATE_vsra_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsra_vv, instr);
-    instr = INSTR_CREATE_vssrl_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssrl_vv, instr);
-    instr = INSTR_CREATE_vssra_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssra_vv, instr);
-    instr = INSTR_CREATE_vnsrl_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnsrl_wv, instr);
-    instr = INSTR_CREATE_vnsra_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnsra_wv, instr);
-    instr = INSTR_CREATE_vnclipu_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnclipu_wv, instr);
-    instr = INSTR_CREATE_vnclip_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnclip_wv, instr);
-
-    instr = INSTR_CREATE_vwredsumu_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwredsumu_vs, instr);
-    instr = INSTR_CREATE_vwredsum_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwredsum_vs, instr);
+    TEST_Vd_Vs1_Vs2_vm(vwredsumu_vs);
+    TEST_Vd_Vs1_Vs2_vm(vwredsum_vs);
 }
 
 static void
 test_IVI(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_IMM_Vs2_vm(vadd_vi);
+    TEST_Vd_IMM_Vs2_vm(vrsub_vi);
+    TEST_Vd_IMM_Vs2_vm(vand_vi);
+    TEST_Vd_IMM_Vs2_vm(vor_vi);
+    TEST_Vd_IMM_Vs2_vm(vxor_vi);
+    TEST_Vd_IMM_Vs2_vm(vrgather_vi);
+    TEST_Vd_IMM_Vs2_vm(vslideup_vi);
+    TEST_Vd_IMM_Vs2_vm(vslidedown_vi);
 
-    instr = INSTR_CREATE_vadd_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vadd_vi, instr);
-    instr = INSTR_CREATE_vrsub_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrsub_vi, instr);
-    instr = INSTR_CREATE_vand_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vand_vi, instr);
-    instr = INSTR_CREATE_vor_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vor_vi, instr);
-    instr = INSTR_CREATE_vxor_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vxor_vi, instr);
-    instr = INSTR_CREATE_vrgather_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrgather_vi, instr);
-    instr = INSTR_CREATE_vslideup_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vslideup_vi, instr);
-    instr = INSTR_CREATE_vslidedown_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vslidedown_vi, instr);
+    TEST_Vd_IMM_Vs2(vadc_vim);
+    TEST_Vd_IMM_Vs2(vmadc_vim);
+    TEST_Vd_IMM_Vs2(vmadc_vi);
+    TEST_Vd_IMM_Vs2(vmerge_vim);
 
-    instr = INSTR_CREATE_vadc_vim(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_immed_int(0b10100, OPSZ_5b),
-                                  opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vadc_vim, instr);
-    instr = INSTR_CREATE_vmadc_vim(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_immed_int(0b10100, OPSZ_5b),
-                                   opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmadc_vim, instr);
-    instr = INSTR_CREATE_vmadc_vi(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_immed_int(0b10100, OPSZ_5b),
-                                  opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmadc_vi, instr);
-    instr = INSTR_CREATE_vmerge_vim(dc, opnd_create_reg(DR_REG_VR0),
-                                    opnd_create_immed_int(0b10100, OPSZ_5b),
-                                    opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmerge_vim, instr);
     instr = INSTR_CREATE_vmv_v_i(dc, opnd_create_reg(DR_REG_VR0),
                                  opnd_create_immed_int(0b10100, OPSZ_5b));
     test_instr_encoding(dc, OP_vmv_v_i, instr);
-    instr = INSTR_CREATE_vmseq_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmseq_vi, instr);
-    instr = INSTR_CREATE_vmsne_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsne_vi, instr);
-    instr = INSTR_CREATE_vmsleu_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsleu_vi, instr);
-    instr = INSTR_CREATE_vmsle_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsle_vi, instr);
-    instr = INSTR_CREATE_vmsgtu_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsgtu_vi, instr);
-    instr = INSTR_CREATE_vmsgt_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsgt_vi, instr);
 
-    instr = INSTR_CREATE_vsaddu_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsaddu_vi, instr);
-    instr = INSTR_CREATE_vsadd_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsadd_vi, instr);
-    instr = INSTR_CREATE_vsll_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsll_vi, instr);
-    instr = INSTR_CREATE_vmv1r_v(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmv1r_v, instr);
-    instr = INSTR_CREATE_vmv2r_v(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmv2r_v, instr);
-    instr = INSTR_CREATE_vmv4r_v(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmv4r_v, instr);
-    instr = INSTR_CREATE_vmv8r_v(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmv8r_v, instr);
-    instr = INSTR_CREATE_vsaddu_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsaddu_vi, instr);
-    instr = INSTR_CREATE_vsrl_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsrl_vi, instr);
-    instr = INSTR_CREATE_vsra_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsra_vi, instr);
-    instr = INSTR_CREATE_vssrl_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssrl_vi, instr);
-    instr = INSTR_CREATE_vssra_vi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vssra_vi, instr);
-    instr = INSTR_CREATE_vnsrl_wi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnsrl_wi, instr);
-    instr = INSTR_CREATE_vnsra_wi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnsra_wi, instr);
-    instr = INSTR_CREATE_vnclipu_wi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnclipu_wi, instr);
-    instr = INSTR_CREATE_vnclip_wi(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
-        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnclip_wi, instr);
+    TEST_Vd_IMM_Vs2_vm(vmseq_vi);
+    TEST_Vd_IMM_Vs2_vm(vmsne_vi);
+    TEST_Vd_IMM_Vs2_vm(vmsleu_vi);
+    TEST_Vd_IMM_Vs2_vm(vmsle_vi);
+    TEST_Vd_IMM_Vs2_vm(vmsgtu_vi);
+    TEST_Vd_IMM_Vs2_vm(vmsgt_vi);
+
+    TEST_Vd_IMM_Vs2_vm(vsaddu_vi);
+    TEST_Vd_IMM_Vs2_vm(vsadd_vi);
+    TEST_Vd_IMM_Vs2_vm(vsll_vi);
+
+    TEST_Vd_Vs1(vmv1r_v);
+    TEST_Vd_Vs1(vmv2r_v);
+    TEST_Vd_Vs1(vmv4r_v);
+    TEST_Vd_Vs1(vmv8r_v);
+
+    TEST_Vd_IMM_Vs2_vm(vsaddu_vi);
+    TEST_Vd_IMM_Vs2_vm(vsrl_vi);
+    TEST_Vd_IMM_Vs2_vm(vsra_vi);
+    TEST_Vd_IMM_Vs2_vm(vssrl_vi);
+    TEST_Vd_IMM_Vs2_vm(vssra_vi);
+    TEST_Vd_IMM_Vs2_vm(vnsrl_wi);
+    TEST_Vd_IMM_Vs2_vm(vnsra_wi);
+    TEST_Vd_IMM_Vs2_vm(vnclipu_wi);
+    TEST_Vd_IMM_Vs2_vm(vnclip_wi);
 }
 
 static void
 test_MVV(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_Vs1_Vs2_vm(vredsum_vs);
+    TEST_Vd_Vs1_Vs2_vm(vredand_vs);
+    TEST_Vd_Vs1_Vs2_vm(vredor_vs);
+    TEST_Vd_Vs1_Vs2_vm(vredxor_vs);
+    TEST_Vd_Vs1_Vs2_vm(vredminu_vs);
+    TEST_Vd_Vs1_Vs2_vm(vredmin_vs);
+    TEST_Vd_Vs1_Vs2_vm(vredmaxu_vs);
+    TEST_Vd_Vs1_Vs2_vm(vredmax_vs);
+    TEST_Vd_Vs1_Vs2_vm(vaaddu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vaadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vasubu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vasub_vv);
 
-    instr = INSTR_CREATE_vredsum_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredsum_vs, instr);
-    instr = INSTR_CREATE_vredand_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredand_vs, instr);
-    instr = INSTR_CREATE_vredor_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredor_vs, instr);
-    instr = INSTR_CREATE_vredxor_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredxor_vs, instr);
-    instr = INSTR_CREATE_vredminu_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredminu_vs, instr);
-    instr = INSTR_CREATE_vredmin_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredmin_vs, instr);
-    instr = INSTR_CREATE_vredmaxu_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredmaxu_vs, instr);
-    instr = INSTR_CREATE_vredmax_vs(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vredmax_vs, instr);
-    instr = INSTR_CREATE_vaaddu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vaaddu_vv, instr);
-    instr = INSTR_CREATE_vaadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vaadd_vv, instr);
-    instr = INSTR_CREATE_vasubu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vasubu_vv, instr);
-    instr = INSTR_CREATE_vasub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vasub_vv, instr);
-
-    instr =
-        INSTR_CREATE_vmv_x_s(dc, opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR1));
-    test_instr_encoding(dc, OP_vmv_x_s, instr);
+    TEST_Rd_Vs1(vmv_x_s);
 }
 
 static void
 test_MVX(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_Rs1_Vs2_vm(vaaddu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vaadd_vx);
+    TEST_Vd_Rs1_Vs2_vm(vasubu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vasub_vx);
 
-    instr = INSTR_CREATE_vaaddu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vaaddu_vx, instr);
-    instr = INSTR_CREATE_vaadd_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vaadd_vx, instr);
-    instr = INSTR_CREATE_vasubu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vasubu_vx, instr);
-    instr = INSTR_CREATE_vasub_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vasub_vx, instr);
+    TEST_Vd_Rs1(vmv_s_x);
 
-    instr =
-        INSTR_CREATE_vmv_s_x(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1));
-    test_instr_encoding(dc, OP_vmv_s_x, instr);
-    instr = INSTR_CREATE_vslide1up_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vslide1up_vx, instr);
-    instr = INSTR_CREATE_vslide1down_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vslide1down_vx, instr);
+    TEST_Vd_Rs1_Vs2_vm(vslide1up_vx);
+    TEST_Vd_Rs1_Vs2_vm(vslide1down_vx);
 
-    instr = INSTR_CREATE_vdivu_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vdivu_vx, instr);
-    instr = INSTR_CREATE_vdiv_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vdiv_vx, instr);
-    instr = INSTR_CREATE_vremu_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vremu_vx, instr);
-    instr = INSTR_CREATE_vrem_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrem_vx, instr);
-    instr = INSTR_CREATE_vmulhu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmulhu_vx, instr);
-    instr = INSTR_CREATE_vmul_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmul_vx, instr);
-    instr = INSTR_CREATE_vmulhsu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmulhsu_vx, instr);
-    instr = INSTR_CREATE_vmulh_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmulh_vx, instr);
-    instr = INSTR_CREATE_vmadd_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmadd_vx, instr);
-    instr = INSTR_CREATE_vnmsub_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnmsub_vx, instr);
-    instr = INSTR_CREATE_vmacc_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmacc_vx, instr);
-    instr = INSTR_CREATE_vnmsac_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnmsac_vx, instr);
+    TEST_Vd_Rs1_Vs2_vm(vdivu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vdiv_vx);
+    TEST_Vd_Rs1_Vs2_vm(vremu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vrem_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmulhu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmul_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmulhsu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmulh_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmadd_vx);
+    TEST_Vd_Rs1_Vs2_vm(vnmsub_vx);
+    TEST_Vd_Rs1_Vs2_vm(vmacc_vx);
+    TEST_Vd_Rs1_Vs2_vm(vnmsac_vx);
 
-    instr = INSTR_CREATE_vwaddu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwaddu_vx, instr);
-    instr = INSTR_CREATE_vwadd_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwadd_vx, instr);
-    instr = INSTR_CREATE_vwsubu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsubu_vx, instr);
-    instr = INSTR_CREATE_vwsub_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsub_vx, instr);
-    instr = INSTR_CREATE_vwaddu_wx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwaddu_wx, instr);
-    instr = INSTR_CREATE_vwadd_wx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwadd_wx, instr);
-    instr = INSTR_CREATE_vwsubu_wx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsubu_wx, instr);
-    instr = INSTR_CREATE_vwsub_wx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsub_wx, instr);
-    instr = INSTR_CREATE_vwmulu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmulu_vx, instr);
-    instr = INSTR_CREATE_vwmulsu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmulsu_vx, instr);
-    instr = INSTR_CREATE_vwmul_vx(dc, opnd_create_reg(DR_REG_VR0),
-                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
-                                  opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmul_vx, instr);
-    instr = INSTR_CREATE_vwmaccu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmaccu_vx, instr);
-    instr = INSTR_CREATE_vwmacc_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmacc_vx, instr);
-    instr = INSTR_CREATE_vwmaccus_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmaccus_vx, instr);
-    instr = INSTR_CREATE_vwmaccsu_vx(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmaccsu_vx, instr);
+    TEST_Vd_Rs1_Vs2_vm(vwaddu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwadd_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwsubu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwsub_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwaddu_wx);
+    TEST_Vd_Rs1_Vs2_vm(vwadd_wx);
+    TEST_Vd_Rs1_Vs2_vm(vwsubu_wx);
+    TEST_Vd_Rs1_Vs2_vm(vwsub_wx);
+    TEST_Vd_Rs1_Vs2_vm(vwmulu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwmulsu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwmul_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwmaccu_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwmacc_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwmaccus_vx);
+    TEST_Vd_Rs1_Vs2_vm(vwmaccsu_vx);
 }
 
 static void
 test_int_extension(void *dc)
 {
-    instr_t *instr;
+    TEST_Vd_Vs1_vm(vzext_vf8);
+    TEST_Vd_Vs1_vm(vsext_vf8);
+    TEST_Vd_Vs1_vm(vzext_vf4);
+    TEST_Vd_Vs1_vm(vsext_vf4);
+    TEST_Vd_Vs1_vm(vzext_vf2);
+    TEST_Vd_Vs1_vm(vsext_vf2);
 
-    instr = INSTR_CREATE_vzext_vf8(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_reg(DR_REG_VR1),
-                                   opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vzext_vf8, instr);
-    instr = INSTR_CREATE_vsext_vf8(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_reg(DR_REG_VR1),
-                                   opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsext_vf8, instr);
-    instr = INSTR_CREATE_vzext_vf4(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_reg(DR_REG_VR1),
-                                   opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vzext_vf4, instr);
-    instr = INSTR_CREATE_vsext_vf4(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_reg(DR_REG_VR1),
-                                   opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsext_vf4, instr);
-    instr = INSTR_CREATE_vzext_vf2(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_reg(DR_REG_VR1),
-                                   opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vzext_vf2, instr);
-    instr = INSTR_CREATE_vsext_vf2(dc, opnd_create_reg(DR_REG_VR0),
-                                   opnd_create_reg(DR_REG_VR1),
-                                   opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vsext_vf2, instr);
+    TEST_Vd_Vs1_Vs2(vcompress_vm);
+    TEST_Vd_Vs1_Vs2(vmandn_mm);
+    TEST_Vd_Vs1_Vs2(vmand_mm);
+    TEST_Vd_Vs1_Vs2(vmor_mm);
+    TEST_Vd_Vs1_Vs2(vmxor_mm);
+    TEST_Vd_Vs1_Vs2(vmorn_mm);
+    TEST_Vd_Vs1_Vs2(vmnand_mm);
+    TEST_Vd_Vs1_Vs2(vmnor_mm);
+    TEST_Vd_Vs1_Vs2(vmxnor_mm);
 
-    instr = INSTR_CREATE_vcompress_vm(dc, opnd_create_reg(DR_REG_VR0),
-                                      opnd_create_reg(DR_REG_VR1),
-                                      opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vcompress_vm, instr);
-    instr =
-        INSTR_CREATE_vmandn_mm(dc, opnd_create_reg(DR_REG_VR0),
-                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmandn_mm, instr);
-    instr =
-        INSTR_CREATE_vmand_mm(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmand_mm, instr);
-    instr =
-        INSTR_CREATE_vmor_mm(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-                             opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmor_mm, instr);
-    instr =
-        INSTR_CREATE_vmxor_mm(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmxor_mm, instr);
-    instr =
-        INSTR_CREATE_vmorn_mm(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmorn_mm, instr);
-    instr =
-        INSTR_CREATE_vmnand_mm(dc, opnd_create_reg(DR_REG_VR0),
-                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmnand_mm, instr);
-    instr =
-        INSTR_CREATE_vmnor_mm(dc, opnd_create_reg(DR_REG_VR0),
-                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmnor_mm, instr);
-    instr =
-        INSTR_CREATE_vmxnor_mm(dc, opnd_create_reg(DR_REG_VR0),
-                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
-    test_instr_encoding(dc, OP_vmxnor_mm, instr);
+    TEST_Vd_Vs1_vm(vmsbf_m);
+    TEST_Vd_Vs1_vm(vmsof_m);
+    TEST_Vd_Vs1_vm(vmsif_m);
+    TEST_Vd_Vs1_vm(viota_m);
 
-    instr =
-        INSTR_CREATE_vmsbf_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-                             opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsbf_m, instr);
-    instr =
-        INSTR_CREATE_vmsof_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-                             opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsof_m, instr);
-    instr =
-        INSTR_CREATE_vmsif_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-                             opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmsif_m, instr);
-    instr =
-        INSTR_CREATE_viota_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-                             opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_viota_m, instr);
     instr = INSTR_CREATE_vid_v(dc, opnd_create_reg(DR_REG_VR0),
                                opnd_create_immed_int(0b1, OPSZ_1b));
     test_instr_encoding(dc, OP_vid_v, instr);
-    instr =
-        INSTR_CREATE_vcpop_m(dc, opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR1),
-                             opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vcpop_m, instr);
-    instr =
-        INSTR_CREATE_vfirst_m(dc, opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR1),
-                              opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vfirst_m, instr);
 
-    instr = INSTR_CREATE_vdivu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vdivu_vv, instr);
-    instr = INSTR_CREATE_vdiv_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vdiv_vv, instr);
-    instr = INSTR_CREATE_vremu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vremu_vv, instr);
-    instr = INSTR_CREATE_vrem_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vrem_vv, instr);
-    instr = INSTR_CREATE_vmulhu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmulhu_vv, instr);
-    instr = INSTR_CREATE_vmul_vv(dc, opnd_create_reg(DR_REG_VR0),
-                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
-                                 opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmul_vv, instr);
-    instr = INSTR_CREATE_vmulhsu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmulhsu_vv, instr);
-    instr = INSTR_CREATE_vmulh_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmulh_vv, instr);
-    instr = INSTR_CREATE_vmadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmadd_vv, instr);
-    instr = INSTR_CREATE_vnmsub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnmsub_vv, instr);
-    instr = INSTR_CREATE_vmacc_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vmacc_vv, instr);
-    instr = INSTR_CREATE_vnmsac_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnmsac_vv, instr);
+    TEST_Rd_Vs1_vm(vcpop_m);
+    TEST_Rd_Vs1_vm(vfirst_m);
 
-    instr = INSTR_CREATE_vnmsac_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vnmsac_vv, instr);
-    instr = INSTR_CREATE_vwadd_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwadd_vv, instr);
-    instr = INSTR_CREATE_vwsubu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsubu_vv, instr);
-    instr = INSTR_CREATE_vwsub_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsub_vv, instr);
-    instr = INSTR_CREATE_vwaddu_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwaddu_wv, instr);
-    instr = INSTR_CREATE_vwadd_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwadd_wv, instr);
-    instr = INSTR_CREATE_vwsubu_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsubu_wv, instr);
-    instr = INSTR_CREATE_vwsub_wv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwsub_wv, instr);
-    instr = INSTR_CREATE_vwmulu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmulu_vv, instr);
-    instr = INSTR_CREATE_vwmulsu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmulsu_vv, instr);
-    instr = INSTR_CREATE_vwmul_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmul_vv, instr);
-    instr = INSTR_CREATE_vwmaccu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmaccu_vv, instr);
-    instr = INSTR_CREATE_vwmacc_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmacc_vv, instr);
-    instr = INSTR_CREATE_vwmaccsu_vv(
-        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
-        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
-    test_instr_encoding(dc, OP_vwmaccsu_vv, instr);
+    TEST_Vd_Vs1_Vs2_vm(vdivu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vdiv_vv);
+    TEST_Vd_Vs1_Vs2_vm(vremu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vrem_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmulhu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmul_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmulhsu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmulh_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vnmsub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vmacc_vv);
+    TEST_Vd_Vs1_Vs2_vm(vnmsac_vv);
+    TEST_Vd_Vs1_Vs2_vm(vnmsac_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwadd_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwsubu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwsub_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwaddu_wv);
+    TEST_Vd_Vs1_Vs2_vm(vwadd_wv);
+    TEST_Vd_Vs1_Vs2_vm(vwsubu_wv);
+    TEST_Vd_Vs1_Vs2_vm(vwsub_wv);
+    TEST_Vd_Vs1_Vs2_vm(vwmulu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwmulsu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwmul_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwmaccu_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwmacc_vv);
+    TEST_Vd_Vs1_Vs2_vm(vwmaccsu_vv);
 }
 
 int

--- a/suite/tests/api/ir_rvv.c
+++ b/suite/tests/api/ir_rvv.c
@@ -1,0 +1,1852 @@
+/* **********************************************************
+ * Copyright (c) 2024 Institute of Software Chinese Academy of Sciences (ISCAS).
+ * All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ISCAS nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ISCAS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Define DR_FAST_IR to verify that everything compiles when we call the inline
+ * versions of these routines.
+ */
+#ifndef STANDALONE_DECODER
+#    define DR_FAST_IR 1
+#endif
+
+/* Uses the DR API, using DR as a standalone library, rather than
+ * being a client library working with DR on a target program.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "dr_defines.h"
+#include "dr_ir_utils.h"
+#include "tools.h"
+
+static byte buf[8192];
+
+#ifdef STANDALONE_DECODER
+#    define ASSERT(x)                                                                 \
+        ((void)((!(x)) ? (fprintf(stderr, "ASSERT FAILURE (standalone): %s:%d: %s\n", \
+                                  __FILE__, __LINE__, #x),                            \
+                          abort(), 0)                                                 \
+                       : 0))
+#else
+#    define ASSERT(x)                                                                \
+        ((void)((!(x)) ? (dr_fprintf(STDERR, "ASSERT FAILURE (client): %s:%d: %s\n", \
+                                     __FILE__, __LINE__, #x),                        \
+                          dr_abort(), 0)                                             \
+                       : 0))
+#endif
+
+static byte *
+test_instr_encoding(void *dc, uint opcode, instr_t *instr)
+{
+    instr_t *decin;
+    byte *pc, *next_pc;
+
+    ASSERT(instr_get_opcode(instr) == opcode);
+    instr_disassemble(dc, instr, STDERR);
+    print("\n");
+    ASSERT(instr_is_encoding_possible(instr));
+    pc = instr_encode(dc, instr, buf);
+    ASSERT(pc != NULL);
+    decin = instr_create(dc);
+    next_pc = decode(dc, buf, decin);
+    ASSERT(next_pc != NULL);
+    if (!instr_same(instr, decin)) {
+        print("Disassembled as:\n");
+        instr_disassemble(dc, decin, STDERR);
+        print("\n");
+        ASSERT(instr_same(instr, decin));
+    }
+
+    instr_destroy(dc, instr);
+    instr_destroy(dc, decin);
+    return pc;
+}
+
+static void
+test_instr_encoding_failure(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
+{
+    byte *pc;
+
+    pc = instr_encode_to_copy(dc, instr, buf, instr_pc);
+    ASSERT(pc == NULL);
+    instr_destroy(dc, instr);
+}
+
+static byte *
+test_instr_decoding_failure(void *dc, uint raw_instr)
+{
+    instr_t *decin;
+    byte *pc;
+
+    *(uint *)buf = raw_instr;
+    decin = instr_create(dc);
+    pc = decode(dc, buf, decin);
+    /* Returns NULL on failure. */
+    ASSERT(pc == NULL);
+    instr_destroy(dc, decin);
+    return pc;
+}
+
+static void
+test_configuration_setting(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vsetivli(dc, opnd_create_reg(DR_REG_A1),
+                                  opnd_create_immed_int(0b01010, OPSZ_5b),
+                                  opnd_create_immed_int(0b00001000, OPSZ_10b));
+    test_instr_encoding(dc, OP_vsetivli, instr);
+    instr =
+        INSTR_CREATE_vsetvli(dc, opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_A2),
+                             opnd_create_immed_int(0b000001000, OPSZ_11b));
+    test_instr_encoding(dc, OP_vsetvli, instr);
+    instr = INSTR_CREATE_vsetvl(dc, opnd_create_reg(DR_REG_A1),
+                                opnd_create_reg(DR_REG_A2), opnd_create_reg(DR_REG_A3));
+    test_instr_encoding(dc, OP_vsetvl, instr);
+}
+
+static void
+test_unit_stride(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vlm_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vlm_v, instr);
+    instr = INSTR_CREATE_vsm_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0));
+    test_instr_encoding(dc, OP_vsm_v, instr);
+    instr = INSTR_CREATE_vle8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle8_v, instr);
+    instr = INSTR_CREATE_vle16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle16_v, instr);
+    instr = INSTR_CREATE_vle32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle32_v, instr);
+    instr = INSTR_CREATE_vle64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle64_v, instr);
+    instr = INSTR_CREATE_vse8_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vse8_v, instr);
+    instr = INSTR_CREATE_vse16_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vse16_v, instr);
+    instr = INSTR_CREATE_vse32_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vse32_v, instr);
+    instr = INSTR_CREATE_vse64_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vse64_v, instr);
+}
+
+static void
+test_indexed_unordered(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vluxei8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vluxei8_v, instr);
+    instr = INSTR_CREATE_vluxei16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vluxei16_v, instr);
+    instr = INSTR_CREATE_vluxei32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vluxei32_v, instr);
+    instr = INSTR_CREATE_vluxei64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vluxei64_v, instr);
+
+    instr = INSTR_CREATE_vsuxei8_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsuxei8_v, instr);
+    instr = INSTR_CREATE_vsuxei16_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsuxei16_v, instr);
+    instr = INSTR_CREATE_vsuxei32_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsuxei32_v, instr);
+    instr = INSTR_CREATE_vsuxei64_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsuxei64_v, instr);
+}
+
+static void
+test_stride(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vlse8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vlse8_v, instr);
+    instr = INSTR_CREATE_vlse16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vlse16_v, instr);
+    instr = INSTR_CREATE_vlse32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vlse32_v, instr);
+    instr = INSTR_CREATE_vlse64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vlse64_v, instr);
+
+    instr = INSTR_CREATE_vsse8_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsse8_v, instr);
+    instr = INSTR_CREATE_vsse16_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsse16_v, instr);
+    instr = INSTR_CREATE_vsse32_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsse32_v, instr);
+    instr = INSTR_CREATE_vsse64_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A2),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsse64_v, instr);
+}
+
+static void
+test_indexed_ordered(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vloxei8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vloxei8_v, instr);
+    instr = INSTR_CREATE_vloxei16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vloxei16_v, instr);
+    instr = INSTR_CREATE_vloxei32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vloxei32_v, instr);
+    instr = INSTR_CREATE_vloxei64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b),
+        opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vloxei64_v, instr);
+    instr = INSTR_CREATE_vsoxei8_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsoxei8_v, instr);
+    instr = INSTR_CREATE_vsoxei16_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsoxei16_v, instr);
+    instr = INSTR_CREATE_vsoxei32_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsoxei32_v, instr);
+    instr = INSTR_CREATE_vsoxei64_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vsoxei64_v, instr);
+}
+
+static void
+test_unit_stride_faultfirst(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vle8ff_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle8ff_v, instr);
+    instr = INSTR_CREATE_vle16ff_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle16ff_v, instr);
+    instr = INSTR_CREATE_vle32ff_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle32ff_v, instr);
+    instr = INSTR_CREATE_vle64ff_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_immed_int(0b1, OPSZ_1b), opnd_create_immed_int(0b000, OPSZ_3b));
+    test_instr_encoding(dc, OP_vle64ff_v, instr);
+}
+
+static void
+test_whole_register(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vl1re8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl1re8_v, instr);
+    instr = INSTR_CREATE_vl1re16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl1re16_v, instr);
+    instr = INSTR_CREATE_vl1re32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl1re32_v, instr);
+    instr = INSTR_CREATE_vl1re64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl1re64_v, instr);
+
+    instr = INSTR_CREATE_vl2re8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl2re8_v, instr);
+    instr = INSTR_CREATE_vl2re16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl2re16_v, instr);
+    instr = INSTR_CREATE_vl2re32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl2re32_v, instr);
+    instr = INSTR_CREATE_vl2re64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl2re64_v, instr);
+
+    instr = INSTR_CREATE_vl4re8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl4re8_v, instr);
+    instr = INSTR_CREATE_vl4re16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl4re16_v, instr);
+    instr = INSTR_CREATE_vl4re32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl4re32_v, instr);
+    instr = INSTR_CREATE_vl4re64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl4re64_v, instr);
+
+    instr = INSTR_CREATE_vl8re8_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl8re8_v, instr);
+    instr = INSTR_CREATE_vl8re16_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl8re16_v, instr);
+    instr = INSTR_CREATE_vl8re32_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl8re32_v, instr);
+    instr = INSTR_CREATE_vl8re64_v(
+        dc, opnd_create_reg(DR_REG_VR0),
+        opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)));
+    test_instr_encoding(dc, OP_vl8re64_v, instr);
+
+    instr = INSTR_CREATE_vs1r_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0));
+    test_instr_encoding(dc, OP_vs1r_v, instr);
+    instr = INSTR_CREATE_vs2r_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0));
+    test_instr_encoding(dc, OP_vs2r_v, instr);
+    instr = INSTR_CREATE_vs4r_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0));
+    test_instr_encoding(dc, OP_vs4r_v, instr);
+    instr = INSTR_CREATE_vs8r_v(
+        dc, opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, reg_get_size(DR_REG_VR0)),
+        opnd_create_reg(DR_REG_VR0));
+    test_instr_encoding(dc, OP_vs8r_v, instr);
+}
+
+static void
+test_load_store(void *dc)
+{
+    test_unit_stride(dc);
+    test_indexed_unordered(dc);
+    test_stride(dc);
+    test_indexed_ordered(dc);
+    test_unit_stride_faultfirst(dc);
+    test_whole_register(dc);
+}
+
+static void
+test_FVF(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vfadd_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfadd_vf, instr);
+    instr = INSTR_CREATE_vfsub_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsub_vf, instr);
+    instr = INSTR_CREATE_vfmin_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmin_vf, instr);
+    instr = INSTR_CREATE_vfmax_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmax_vf, instr);
+    instr = INSTR_CREATE_vfsgnj_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsgnj_vf, instr);
+    instr = INSTR_CREATE_vfsgnjn_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsgnjn_vf, instr);
+    instr = INSTR_CREATE_vfsgnjx_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsgnjx_vf, instr);
+    instr = INSTR_CREATE_vfslide1up_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfslide1up_vf, instr);
+    instr = INSTR_CREATE_vfslide1down_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfslide1down_vf, instr);
+    instr = INSTR_CREATE_vfmv_s_f(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_vfmv_s_f, instr);
+
+    instr =
+        INSTR_CREATE_vfmerge_vfm(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vfmerge_vfm, instr);
+    instr = INSTR_CREATE_vfmv_v_f(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_vfmv_v_f, instr);
+    instr = INSTR_CREATE_vmfeq_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfeq_vf, instr);
+    instr = INSTR_CREATE_vmfle_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfle_vf, instr);
+    instr = INSTR_CREATE_vmflt_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmflt_vf, instr);
+    instr = INSTR_CREATE_vmfne_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfne_vf, instr);
+    instr = INSTR_CREATE_vmfgt_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfgt_vf, instr);
+    instr = INSTR_CREATE_vmfge_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfge_vf, instr);
+
+    instr = INSTR_CREATE_vfrdiv_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfrdiv_vf, instr);
+    instr = INSTR_CREATE_vfmul_vf(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmul_vf, instr);
+    instr = INSTR_CREATE_vfrsub_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfrsub_vf, instr);
+    instr = INSTR_CREATE_vfmadd_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmadd_vf, instr);
+    instr = INSTR_CREATE_vfnmadd_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmadd_vf, instr);
+    instr = INSTR_CREATE_vfmsub_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmsub_vf, instr);
+    instr = INSTR_CREATE_vfnmsub_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmsub_vf, instr);
+    instr = INSTR_CREATE_vfmacc_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmacc_vf, instr);
+    instr =
+        INSTR_CREATE_vfmerge_vfm(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vfmerge_vfm, instr);
+    instr = INSTR_CREATE_vfnmacc_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmacc_vf, instr);
+    instr = INSTR_CREATE_vfmsac_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmsac_vf, instr);
+    instr = INSTR_CREATE_vfnmsac_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmsac_vf, instr);
+
+    instr = INSTR_CREATE_vfwadd_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwadd_vf, instr);
+    instr = INSTR_CREATE_vfwsub_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwsub_vf, instr);
+    instr = INSTR_CREATE_vfwadd_wf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwadd_wf, instr);
+    instr = INSTR_CREATE_vfwsub_wf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwsub_wf, instr);
+    instr = INSTR_CREATE_vfwmul_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwmul_vf, instr);
+    instr = INSTR_CREATE_vfwmacc_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwmacc_vf, instr);
+    instr = INSTR_CREATE_vfwnmacc_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwnmacc_vf, instr);
+    instr = INSTR_CREATE_vfwmsac_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwmsac_vf, instr);
+    instr = INSTR_CREATE_vfwnmsac_vf(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwnmsac_vf, instr);
+}
+
+static void
+test_FVV(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vfadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfadd_vv, instr);
+    instr = INSTR_CREATE_vfredusum_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfredusum_vs, instr);
+    instr = INSTR_CREATE_vfsub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsub_vv, instr);
+    instr = INSTR_CREATE_vfredosum_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfredosum_vs, instr);
+    instr = INSTR_CREATE_vfmin_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmin_vv, instr);
+    instr = INSTR_CREATE_vfredmin_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfredmin_vs, instr);
+    instr = INSTR_CREATE_vfmax_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmax_vv, instr);
+    instr = INSTR_CREATE_vfredmax_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfredmax_vs, instr);
+    instr = INSTR_CREATE_vfsgnj_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsgnj_vv, instr);
+    instr = INSTR_CREATE_vfsgnjn_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsgnjn_vv, instr);
+    instr = INSTR_CREATE_vfsgnjx_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsgnjx_vv, instr);
+    instr = INSTR_CREATE_vfmv_f_s(dc, opnd_create_reg(DR_REG_A1),
+                                  opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vfmv_f_s, instr);
+
+    instr = INSTR_CREATE_vmfeq_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfeq_vv, instr);
+    instr = INSTR_CREATE_vmfle_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfle_vv, instr);
+    instr = INSTR_CREATE_vmflt_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmflt_vv, instr);
+    instr = INSTR_CREATE_vmfne_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmfne_vv, instr);
+
+    instr = INSTR_CREATE_vfdiv_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfdiv_vv, instr);
+    instr = INSTR_CREATE_vfmul_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmul_vv, instr);
+    instr = INSTR_CREATE_vfmadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmadd_vv, instr);
+    instr = INSTR_CREATE_vfnmadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmadd_vv, instr);
+    instr = INSTR_CREATE_vfmsub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmsub_vv, instr);
+    instr = INSTR_CREATE_vfnmsub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmsub_vv, instr);
+    instr = INSTR_CREATE_vfmacc_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmacc_vv, instr);
+    instr = INSTR_CREATE_vfnmacc_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmacc_vv, instr);
+    instr = INSTR_CREATE_vfmsac_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmsac_vv, instr);
+    instr = INSTR_CREATE_vfnmsac_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmsac_vv, instr);
+
+    instr = INSTR_CREATE_vfcvt_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfcvt_xu_f_v, instr);
+    instr = INSTR_CREATE_vfcvt_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                     opnd_create_reg(DR_REG_VR1),
+                                     opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfcvt_x_f_v, instr);
+    instr = INSTR_CREATE_vfcvt_f_xu_v(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfcvt_f_xu_v, instr);
+    instr = INSTR_CREATE_vfcvt_f_x_v(dc, opnd_create_reg(DR_REG_VR0),
+                                     opnd_create_reg(DR_REG_VR1),
+                                     opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfcvt_f_x_v, instr);
+    instr = INSTR_CREATE_vfcvt_rtz_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                          opnd_create_reg(DR_REG_VR1),
+                                          opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfcvt_rtz_xu_f_v, instr);
+    instr = INSTR_CREATE_vfcvt_rtz_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                         opnd_create_reg(DR_REG_VR1),
+                                         opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfcvt_rtz_x_f_v, instr);
+
+    instr = INSTR_CREATE_vfcvt_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfcvt_xu_f_v, instr);
+    instr = INSTR_CREATE_vfwcvt_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwcvt_x_f_v, instr);
+    instr = INSTR_CREATE_vfwcvt_f_xu_v(dc, opnd_create_reg(DR_REG_VR0),
+                                       opnd_create_reg(DR_REG_VR1),
+                                       opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwcvt_f_xu_v, instr);
+    instr = INSTR_CREATE_vfwcvt_f_x_v(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwcvt_f_x_v, instr);
+    instr = INSTR_CREATE_vfwcvt_f_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwcvt_f_f_v, instr);
+    instr = INSTR_CREATE_vfwcvt_rtz_xu_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                           opnd_create_reg(DR_REG_VR1),
+                                           opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwcvt_rtz_xu_f_v, instr);
+    instr = INSTR_CREATE_vfwcvt_rtz_x_f_v(dc, opnd_create_reg(DR_REG_VR0),
+                                          opnd_create_reg(DR_REG_VR1),
+                                          opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwcvt_rtz_x_f_v, instr);
+
+    instr = INSTR_CREATE_vfncvt_xu_f_w(dc, opnd_create_reg(DR_REG_VR0),
+                                       opnd_create_reg(DR_REG_VR1),
+                                       opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_xu_f_w, instr);
+    instr = INSTR_CREATE_vfncvt_x_f_w(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_x_f_w, instr);
+    instr = INSTR_CREATE_vfncvt_f_xu_w(dc, opnd_create_reg(DR_REG_VR0),
+                                       opnd_create_reg(DR_REG_VR1),
+                                       opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_f_xu_w, instr);
+    instr = INSTR_CREATE_vfncvt_f_x_w(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_f_x_w, instr);
+    instr = INSTR_CREATE_vfncvt_f_f_w(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_f_f_w, instr);
+    instr = INSTR_CREATE_vfncvt_rod_f_f_w(dc, opnd_create_reg(DR_REG_VR0),
+                                          opnd_create_reg(DR_REG_VR1),
+                                          opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_rod_f_f_w, instr);
+    instr = INSTR_CREATE_vfncvt_rtz_xu_f_w(dc, opnd_create_reg(DR_REG_VR0),
+                                           opnd_create_reg(DR_REG_VR1),
+                                           opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_rtz_xu_f_w, instr);
+    instr = INSTR_CREATE_vfncvt_rtz_x_f_w(dc, opnd_create_reg(DR_REG_VR0),
+                                          opnd_create_reg(DR_REG_VR1),
+                                          opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfncvt_rtz_x_f_w, instr);
+
+    instr = INSTR_CREATE_vfsqrt_v(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_VR1),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfsqrt_v, instr);
+    instr = INSTR_CREATE_vfrsqrt7_v(dc, opnd_create_reg(DR_REG_VR0),
+                                    opnd_create_reg(DR_REG_VR1),
+                                    opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfrsqrt7_v, instr);
+    instr = INSTR_CREATE_vfrec7_v(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_VR1),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfrec7_v, instr);
+    instr = INSTR_CREATE_vfclass_v(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_reg(DR_REG_VR1),
+                                   opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfclass_v, instr);
+
+    instr = INSTR_CREATE_vfwadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwadd_vv, instr);
+    instr = INSTR_CREATE_vfwredusum_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwredusum_vs, instr);
+    instr = INSTR_CREATE_vfwsub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwsub_vv, instr);
+    instr = INSTR_CREATE_vfwredosum_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwredosum_vs, instr);
+    instr = INSTR_CREATE_vfwadd_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwadd_wv, instr);
+    instr = INSTR_CREATE_vfwsub_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwsub_wv, instr);
+    instr = INSTR_CREATE_vfwmul_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwmul_vv, instr);
+    instr = INSTR_CREATE_vfwmacc_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwmacc_vv, instr);
+    instr = INSTR_CREATE_vfwnmacc_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwnmacc_vv, instr);
+    instr = INSTR_CREATE_vfnmacc_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfnmacc_vv, instr);
+    instr = INSTR_CREATE_vfmsac_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfmsac_vv, instr);
+    instr = INSTR_CREATE_vfwnmsac_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfwnmsac_vv, instr);
+}
+
+static void
+test_IVX(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vadd_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vadd_vx, instr);
+    instr = INSTR_CREATE_vsub_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsub_vx, instr);
+    instr = INSTR_CREATE_vrsub_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrsub_vx, instr);
+    instr = INSTR_CREATE_vminu_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vminu_vx, instr);
+    instr = INSTR_CREATE_vmin_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmin_vx, instr);
+    instr = INSTR_CREATE_vmaxu_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmaxu_vx, instr);
+    instr = INSTR_CREATE_vmax_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmax_vx, instr);
+    instr = INSTR_CREATE_vand_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vand_vx, instr);
+    instr = INSTR_CREATE_vor_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vor_vx, instr);
+    instr = INSTR_CREATE_vxor_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vxor_vx, instr);
+    instr = INSTR_CREATE_vrgather_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrgather_vx, instr);
+    instr = INSTR_CREATE_vslideup_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vslideup_vx, instr);
+    instr = INSTR_CREATE_vslidedown_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vslidedown_vx, instr);
+
+    instr =
+        INSTR_CREATE_vadc_vxm(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+                              opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vadc_vxm, instr);
+    instr =
+        INSTR_CREATE_vmadc_vxm(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmadc_vxm, instr);
+    instr =
+        INSTR_CREATE_vmadc_vx(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+                              opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmadc_vx, instr);
+    instr =
+        INSTR_CREATE_vsbc_vxm(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+                              opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vsbc_vxm, instr);
+    instr =
+        INSTR_CREATE_vmsbc_vxm(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmsbc_vxm, instr);
+    instr =
+        INSTR_CREATE_vmsbc_vx(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+                              opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmsbc_vx, instr);
+    instr =
+        INSTR_CREATE_vmerge_vxm(dc, opnd_create_reg(DR_REG_VR0),
+                                opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmerge_vxm, instr);
+    instr =
+        INSTR_CREATE_vmv_v_x(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_vmv_v_x, instr);
+    instr = INSTR_CREATE_vmseq_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmseq_vx, instr);
+    instr = INSTR_CREATE_vmsne_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsne_vx, instr);
+    instr = INSTR_CREATE_vmsltu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsltu_vx, instr);
+    instr = INSTR_CREATE_vmslt_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmslt_vx, instr);
+    instr = INSTR_CREATE_vmsleu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsleu_vx, instr);
+    instr = INSTR_CREATE_vmsle_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsle_vx, instr);
+    instr = INSTR_CREATE_vmsgtu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsgtu_vx, instr);
+    instr = INSTR_CREATE_vmsgt_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsgt_vx, instr);
+
+    instr = INSTR_CREATE_vsaddu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsaddu_vx, instr);
+    instr = INSTR_CREATE_vsadd_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsadd_vx, instr);
+    instr = INSTR_CREATE_vssubu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssubu_vx, instr);
+    instr = INSTR_CREATE_vssub_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssub_vx, instr);
+    instr = INSTR_CREATE_vsll_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsll_vx, instr);
+    instr = INSTR_CREATE_vsmul_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsmul_vx, instr);
+    instr = INSTR_CREATE_vsrl_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsrl_vx, instr);
+
+    instr = INSTR_CREATE_vsra_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsra_vx, instr);
+    instr = INSTR_CREATE_vssrl_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssrl_vx, instr);
+    instr = INSTR_CREATE_vssra_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssra_vx, instr);
+    instr = INSTR_CREATE_vnsrl_wx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnsrl_wx, instr);
+    instr = INSTR_CREATE_vnsra_wx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnsra_wx, instr);
+    instr = INSTR_CREATE_vnclipu_wx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnclipu_wx, instr);
+    instr = INSTR_CREATE_vnclip_wx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnclip_wx, instr);
+}
+
+static void
+test_IVV(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vadd_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vadd_vv, instr);
+    instr = INSTR_CREATE_vsub_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsub_vv, instr);
+    instr = INSTR_CREATE_vminu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vminu_vv, instr);
+    instr = INSTR_CREATE_vmin_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmin_vv, instr);
+    instr = INSTR_CREATE_vmaxu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmaxu_vv, instr);
+    instr = INSTR_CREATE_vmax_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmax_vv, instr);
+    instr = INSTR_CREATE_vand_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vand_vv, instr);
+    instr = INSTR_CREATE_vor_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vor_vv, instr);
+    instr = INSTR_CREATE_vxor_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vxor_vv, instr);
+    instr = INSTR_CREATE_vrgather_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrgather_vv, instr);
+    instr = INSTR_CREATE_vrgatherei16_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrgatherei16_vv, instr);
+
+    instr =
+        INSTR_CREATE_vadc_vvm(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vadc_vvm, instr);
+    instr =
+        INSTR_CREATE_vmadc_vvm(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmadc_vvm, instr);
+    instr =
+        INSTR_CREATE_vmadc_vv(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmadc_vv, instr);
+    instr =
+        INSTR_CREATE_vsbc_vvm(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vsbc_vvm, instr);
+    instr =
+        INSTR_CREATE_vmsbc_vvm(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmsbc_vvm, instr);
+    instr =
+        INSTR_CREATE_vmsbc_vv(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmsbc_vv, instr);
+    instr =
+        INSTR_CREATE_vmerge_vvm(dc, opnd_create_reg(DR_REG_VR0),
+                                opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmerge_vvm, instr);
+    instr = INSTR_CREATE_vmv_v_v(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmv_v_v, instr);
+    instr = INSTR_CREATE_vmseq_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmseq_vv, instr);
+    instr = INSTR_CREATE_vmsne_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsne_vv, instr);
+    instr = INSTR_CREATE_vmsltu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsltu_vv, instr);
+    instr = INSTR_CREATE_vmslt_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmslt_vv, instr);
+    instr = INSTR_CREATE_vmsleu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsleu_vv, instr);
+    instr = INSTR_CREATE_vmsle_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsle_vv, instr);
+
+    instr = INSTR_CREATE_vsaddu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsaddu_vv, instr);
+    instr = INSTR_CREATE_vsadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsadd_vv, instr);
+    instr = INSTR_CREATE_vssubu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssubu_vv, instr);
+    instr = INSTR_CREATE_vssub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssub_vv, instr);
+    instr = INSTR_CREATE_vsll_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsll_vv, instr);
+    instr = INSTR_CREATE_vsmul_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsmul_vv, instr);
+    instr = INSTR_CREATE_vsrl_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsrl_vv, instr);
+    instr = INSTR_CREATE_vsra_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsra_vv, instr);
+    instr = INSTR_CREATE_vssrl_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssrl_vv, instr);
+    instr = INSTR_CREATE_vssra_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssra_vv, instr);
+    instr = INSTR_CREATE_vnsrl_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnsrl_wv, instr);
+    instr = INSTR_CREATE_vnsra_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnsra_wv, instr);
+    instr = INSTR_CREATE_vnclipu_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnclipu_wv, instr);
+    instr = INSTR_CREATE_vnclip_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnclip_wv, instr);
+
+    instr = INSTR_CREATE_vwredsumu_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwredsumu_vs, instr);
+    instr = INSTR_CREATE_vwredsum_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwredsum_vs, instr);
+}
+
+static void
+test_IVI(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vadd_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vadd_vi, instr);
+    instr = INSTR_CREATE_vrsub_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrsub_vi, instr);
+    instr = INSTR_CREATE_vand_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vand_vi, instr);
+    instr = INSTR_CREATE_vor_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vor_vi, instr);
+    instr = INSTR_CREATE_vxor_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vxor_vi, instr);
+    instr = INSTR_CREATE_vrgather_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrgather_vi, instr);
+    instr = INSTR_CREATE_vslideup_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vslideup_vi, instr);
+    instr = INSTR_CREATE_vslidedown_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vslidedown_vi, instr);
+
+    instr = INSTR_CREATE_vadc_vim(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_immed_int(0b10100, OPSZ_5b),
+                                  opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vadc_vim, instr);
+    instr = INSTR_CREATE_vmadc_vim(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_immed_int(0b10100, OPSZ_5b),
+                                   opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmadc_vim, instr);
+    instr = INSTR_CREATE_vmadc_vi(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_immed_int(0b10100, OPSZ_5b),
+                                  opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmadc_vi, instr);
+    instr = INSTR_CREATE_vmerge_vim(dc, opnd_create_reg(DR_REG_VR0),
+                                    opnd_create_immed_int(0b10100, OPSZ_5b),
+                                    opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmerge_vim, instr);
+    instr = INSTR_CREATE_vmv_v_i(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_immed_int(0b10100, OPSZ_5b));
+    test_instr_encoding(dc, OP_vmv_v_i, instr);
+    instr = INSTR_CREATE_vmseq_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmseq_vi, instr);
+    instr = INSTR_CREATE_vmsne_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsne_vi, instr);
+    instr = INSTR_CREATE_vmsleu_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsleu_vi, instr);
+    instr = INSTR_CREATE_vmsle_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsle_vi, instr);
+    instr = INSTR_CREATE_vmsgtu_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsgtu_vi, instr);
+    instr = INSTR_CREATE_vmsgt_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsgt_vi, instr);
+
+    instr = INSTR_CREATE_vsaddu_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsaddu_vi, instr);
+    instr = INSTR_CREATE_vsadd_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsadd_vi, instr);
+    instr = INSTR_CREATE_vsll_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsll_vi, instr);
+    instr = INSTR_CREATE_vmv1r_v(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmv1r_v, instr);
+    instr = INSTR_CREATE_vmv2r_v(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmv2r_v, instr);
+    instr = INSTR_CREATE_vmv4r_v(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmv4r_v, instr);
+    instr = INSTR_CREATE_vmv8r_v(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmv8r_v, instr);
+    instr = INSTR_CREATE_vsaddu_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsaddu_vi, instr);
+    instr = INSTR_CREATE_vsrl_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsrl_vi, instr);
+    instr = INSTR_CREATE_vsra_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsra_vi, instr);
+    instr = INSTR_CREATE_vssrl_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssrl_vi, instr);
+    instr = INSTR_CREATE_vssra_vi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vssra_vi, instr);
+    instr = INSTR_CREATE_vnsrl_wi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnsrl_wi, instr);
+    instr = INSTR_CREATE_vnsra_wi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnsra_wi, instr);
+    instr = INSTR_CREATE_vnclipu_wi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnclipu_wi, instr);
+    instr = INSTR_CREATE_vnclip_wi(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b),
+        opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnclip_wi, instr);
+}
+
+static void
+test_MVV(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vredsum_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredsum_vs, instr);
+    instr = INSTR_CREATE_vredand_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredand_vs, instr);
+    instr = INSTR_CREATE_vredor_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredor_vs, instr);
+    instr = INSTR_CREATE_vredxor_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredxor_vs, instr);
+    instr = INSTR_CREATE_vredminu_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredminu_vs, instr);
+    instr = INSTR_CREATE_vredmin_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredmin_vs, instr);
+    instr = INSTR_CREATE_vredmaxu_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredmaxu_vs, instr);
+    instr = INSTR_CREATE_vredmax_vs(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vredmax_vs, instr);
+    instr = INSTR_CREATE_vaaddu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vaaddu_vv, instr);
+    instr = INSTR_CREATE_vaadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vaadd_vv, instr);
+    instr = INSTR_CREATE_vasubu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vasubu_vv, instr);
+    instr = INSTR_CREATE_vasub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vasub_vv, instr);
+
+    instr =
+        INSTR_CREATE_vmv_x_s(dc, opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR1));
+    test_instr_encoding(dc, OP_vmv_x_s, instr);
+}
+
+static void
+test_MVX(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vaaddu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vaaddu_vx, instr);
+    instr = INSTR_CREATE_vaadd_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vaadd_vx, instr);
+    instr = INSTR_CREATE_vasubu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vasubu_vx, instr);
+    instr = INSTR_CREATE_vasub_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vasub_vx, instr);
+
+    instr =
+        INSTR_CREATE_vmv_s_x(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_vmv_s_x, instr);
+    instr = INSTR_CREATE_vslide1up_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vslide1up_vx, instr);
+    instr = INSTR_CREATE_vslide1down_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vslide1down_vx, instr);
+
+    instr = INSTR_CREATE_vdivu_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vdivu_vx, instr);
+    instr = INSTR_CREATE_vdiv_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vdiv_vx, instr);
+    instr = INSTR_CREATE_vremu_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vremu_vx, instr);
+    instr = INSTR_CREATE_vrem_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrem_vx, instr);
+    instr = INSTR_CREATE_vmulhu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmulhu_vx, instr);
+    instr = INSTR_CREATE_vmul_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmul_vx, instr);
+    instr = INSTR_CREATE_vmulhsu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmulhsu_vx, instr);
+    instr = INSTR_CREATE_vmulh_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmulh_vx, instr);
+    instr = INSTR_CREATE_vmadd_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmadd_vx, instr);
+    instr = INSTR_CREATE_vnmsub_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnmsub_vx, instr);
+    instr = INSTR_CREATE_vmacc_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmacc_vx, instr);
+    instr = INSTR_CREATE_vnmsac_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnmsac_vx, instr);
+
+    instr = INSTR_CREATE_vwaddu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwaddu_vx, instr);
+    instr = INSTR_CREATE_vwadd_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwadd_vx, instr);
+    instr = INSTR_CREATE_vwsubu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsubu_vx, instr);
+    instr = INSTR_CREATE_vwsub_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsub_vx, instr);
+    instr = INSTR_CREATE_vwaddu_wx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwaddu_wx, instr);
+    instr = INSTR_CREATE_vwadd_wx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwadd_wx, instr);
+    instr = INSTR_CREATE_vwsubu_wx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsubu_wx, instr);
+    instr = INSTR_CREATE_vwsub_wx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsub_wx, instr);
+    instr = INSTR_CREATE_vwmulu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmulu_vx, instr);
+    instr = INSTR_CREATE_vwmulsu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmulsu_vx, instr);
+    instr = INSTR_CREATE_vwmul_vx(dc, opnd_create_reg(DR_REG_VR0),
+                                  opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2),
+                                  opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmul_vx, instr);
+    instr = INSTR_CREATE_vwmaccu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmaccu_vx, instr);
+    instr = INSTR_CREATE_vwmacc_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmacc_vx, instr);
+    instr = INSTR_CREATE_vwmaccus_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmaccus_vx, instr);
+    instr = INSTR_CREATE_vwmaccsu_vx(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmaccsu_vx, instr);
+}
+
+static void
+test_int_extension(void *dc)
+{
+    instr_t *instr;
+
+    instr = INSTR_CREATE_vzext_vf8(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_reg(DR_REG_VR1),
+                                   opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vzext_vf8, instr);
+    instr = INSTR_CREATE_vsext_vf8(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_reg(DR_REG_VR1),
+                                   opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsext_vf8, instr);
+    instr = INSTR_CREATE_vzext_vf4(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_reg(DR_REG_VR1),
+                                   opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vzext_vf4, instr);
+    instr = INSTR_CREATE_vsext_vf4(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_reg(DR_REG_VR1),
+                                   opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsext_vf4, instr);
+    instr = INSTR_CREATE_vzext_vf2(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_reg(DR_REG_VR1),
+                                   opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vzext_vf2, instr);
+    instr = INSTR_CREATE_vsext_vf2(dc, opnd_create_reg(DR_REG_VR0),
+                                   opnd_create_reg(DR_REG_VR1),
+                                   opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vsext_vf2, instr);
+
+    instr = INSTR_CREATE_vcompress_vm(dc, opnd_create_reg(DR_REG_VR0),
+                                      opnd_create_reg(DR_REG_VR1),
+                                      opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vcompress_vm, instr);
+    instr =
+        INSTR_CREATE_vmandn_mm(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmandn_mm, instr);
+    instr =
+        INSTR_CREATE_vmand_mm(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmand_mm, instr);
+    instr =
+        INSTR_CREATE_vmor_mm(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+                             opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmor_mm, instr);
+    instr =
+        INSTR_CREATE_vmxor_mm(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmxor_mm, instr);
+    instr =
+        INSTR_CREATE_vmorn_mm(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmorn_mm, instr);
+    instr =
+        INSTR_CREATE_vmnand_mm(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmnand_mm, instr);
+    instr =
+        INSTR_CREATE_vmnor_mm(dc, opnd_create_reg(DR_REG_VR0),
+                              opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmnor_mm, instr);
+    instr =
+        INSTR_CREATE_vmxnor_mm(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2));
+    test_instr_encoding(dc, OP_vmxnor_mm, instr);
+
+    instr =
+        INSTR_CREATE_vmsbf_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+                             opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsbf_m, instr);
+    instr =
+        INSTR_CREATE_vmsof_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+                             opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsof_m, instr);
+    instr =
+        INSTR_CREATE_vmsif_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+                             opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmsif_m, instr);
+    instr =
+        INSTR_CREATE_viota_m(dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+                             opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_viota_m, instr);
+    instr = INSTR_CREATE_vid_v(dc, opnd_create_reg(DR_REG_VR0),
+                               opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vid_v, instr);
+    instr =
+        INSTR_CREATE_vcpop_m(dc, opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR1),
+                             opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vcpop_m, instr);
+    instr =
+        INSTR_CREATE_vfirst_m(dc, opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR1),
+                              opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vfirst_m, instr);
+
+    instr = INSTR_CREATE_vdivu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vdivu_vv, instr);
+    instr = INSTR_CREATE_vdiv_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vdiv_vv, instr);
+    instr = INSTR_CREATE_vremu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vremu_vv, instr);
+    instr = INSTR_CREATE_vrem_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vrem_vv, instr);
+    instr = INSTR_CREATE_vmulhu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmulhu_vv, instr);
+    instr = INSTR_CREATE_vmul_vv(dc, opnd_create_reg(DR_REG_VR0),
+                                 opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2),
+                                 opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmul_vv, instr);
+    instr = INSTR_CREATE_vmulhsu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmulhsu_vv, instr);
+    instr = INSTR_CREATE_vmulh_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmulh_vv, instr);
+    instr = INSTR_CREATE_vmadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmadd_vv, instr);
+    instr = INSTR_CREATE_vnmsub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnmsub_vv, instr);
+    instr = INSTR_CREATE_vmacc_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vmacc_vv, instr);
+    instr = INSTR_CREATE_vnmsac_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnmsac_vv, instr);
+
+    instr = INSTR_CREATE_vnmsac_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vnmsac_vv, instr);
+    instr = INSTR_CREATE_vwadd_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwadd_vv, instr);
+    instr = INSTR_CREATE_vwsubu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsubu_vv, instr);
+    instr = INSTR_CREATE_vwsub_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsub_vv, instr);
+    instr = INSTR_CREATE_vwaddu_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwaddu_wv, instr);
+    instr = INSTR_CREATE_vwadd_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwadd_wv, instr);
+    instr = INSTR_CREATE_vwsubu_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsubu_wv, instr);
+    instr = INSTR_CREATE_vwsub_wv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwsub_wv, instr);
+    instr = INSTR_CREATE_vwmulu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmulu_vv, instr);
+    instr = INSTR_CREATE_vwmulsu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmulsu_vv, instr);
+    instr = INSTR_CREATE_vwmul_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmul_vv, instr);
+    instr = INSTR_CREATE_vwmaccu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmaccu_vv, instr);
+    instr = INSTR_CREATE_vwmacc_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmacc_vv, instr);
+    instr = INSTR_CREATE_vwmaccsu_vv(
+        dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),
+        opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b));
+    test_instr_encoding(dc, OP_vwmaccsu_vv, instr);
+}
+
+int
+main(int argc, char *argv[])
+{
+#ifdef STANDALONE_DECODER
+    void *dcontext = GLOBAL_DCONTEXT;
+#else
+    void *dcontext = dr_standalone_init();
+#endif
+
+    disassemble_set_syntax(DR_DISASM_RISCV);
+
+    test_configuration_setting(dcontext);
+    print("test_configuration_setting complete\n");
+
+    test_load_store(dcontext);
+    print("test_load_store complete\n");
+
+    test_FVF(dcontext);
+    print("test_FVF complete\n");
+
+    test_FVV(dcontext);
+    print("test_FVV complete\n");
+
+    test_IVX(dcontext);
+    print("test_IVX complete\n");
+
+    test_IVV(dcontext);
+    print("test_IVV complete\n");
+
+    test_IVI(dcontext);
+    print("test_IVI complete\n");
+
+    test_MVV(dcontext);
+    print("test_MVV complete\n");
+
+    test_MVX(dcontext);
+    print("test_MVX complete\n");
+
+    test_int_extension(dcontext);
+    print("test_int_extension complete\n");
+
+    print("All tests complete\n");
+    return 0;
+}

--- a/suite/tests/api/ir_rvv.c
+++ b/suite/tests/api/ir_rvv.c
@@ -67,54 +67,54 @@ static byte buf[8192];
 #define ISLOAD true
 #define ISSTORE false
 
-#define TEST_MEM_WHOLEREG(OPCODE, MEM_type)                         \
+#define TEST_MEM_WHOLEREG(opcode, mem_type)                         \
     do {                                                            \
-        if (MEM_type == ISLOAD) {                                   \
-            instr = INSTR_CREATE_##OPCODE(                          \
+        if (mem_type == ISLOAD) {                                   \
+            instr = INSTR_CREATE_##opcode(                          \
                 dc, opnd_create_reg(DR_REG_VR0),                    \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, \
                                       reg_get_size(DR_REG_VR0)));   \
         } else {                                                    \
-            instr = INSTR_CREATE_##OPCODE(                          \
+            instr = INSTR_CREATE_##opcode(                          \
                 dc,                                                 \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0, \
                                       reg_get_size(DR_REG_VR0)),    \
                 opnd_create_reg(DR_REG_VR0));                       \
         }                                                           \
-        test_instr_encoding(dc, OP_##OPCODE, instr);                \
+        test_instr_encoding(dc, OP_##opcode, instr);                \
     } while (0);
 
-#define TEST_MEM_UNIT_STRIDE(OPCODE, MEM_type)                                    \
+#define TEST_MEM_UNIT_STRIDE(opcode, mem_type)                                    \
     do {                                                                          \
-        if (MEM_type == ISLOAD) {                                                 \
-            instr = INSTR_CREATE_##OPCODE(                                        \
+        if (mem_type == ISLOAD) {                                                 \
+            instr = INSTR_CREATE_##opcode(                                        \
                 dc, opnd_create_reg(DR_REG_VR0),                                  \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
                                       reg_get_size(DR_REG_VR0)),                  \
                 opnd_create_immed_int(0b1, OPSZ_1b),                              \
                 opnd_create_immed_int(0b000, OPSZ_3b));                           \
         } else {                                                                  \
-            instr = INSTR_CREATE_##OPCODE(                                        \
+            instr = INSTR_CREATE_##opcode(                                        \
                 dc,                                                               \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
                                       reg_get_size(DR_REG_VR0)),                  \
                 opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b1, OPSZ_1b), \
                 opnd_create_immed_int(0b000, OPSZ_3b));                           \
         }                                                                         \
-        test_instr_encoding(dc, OP_##OPCODE, instr);                              \
+        test_instr_encoding(dc, OP_##opcode, instr);                              \
     } while (0);
 
-#define TEST_MEM_INDEX(OPCODE, MEM_type)                                          \
+#define TEST_MEM_INDEX(opcode, mem_type)                                          \
     do {                                                                          \
-        if (MEM_type == ISLOAD) {                                                 \
-            instr = INSTR_CREATE_##OPCODE(                                        \
+        if (mem_type == ISLOAD) {                                                 \
+            instr = INSTR_CREATE_##opcode(                                        \
                 dc, opnd_create_reg(DR_REG_VR0),                                  \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
                                       reg_get_size(DR_REG_VR0)),                  \
                 opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b), \
                 opnd_create_immed_int(0b000, OPSZ_3b));                           \
         } else {                                                                  \
-            instr = INSTR_CREATE_##OPCODE(                                        \
+            instr = INSTR_CREATE_##opcode(                                        \
                 dc,                                                               \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,               \
                                       reg_get_size(DR_REG_VR0)),                  \
@@ -122,20 +122,20 @@ static byte buf[8192];
                 opnd_create_immed_int(0b1, OPSZ_1b),                              \
                 opnd_create_immed_int(0b000, OPSZ_3b));                           \
         }                                                                         \
-        test_instr_encoding(dc, OP_##OPCODE, instr);                              \
+        test_instr_encoding(dc, OP_##opcode, instr);                              \
     } while (0);
 
-#define TEST_MEM_STRIDE(OPCODE, MEM_type)                                        \
+#define TEST_MEM_STRIDE(opcode, mem_type)                                        \
     do {                                                                         \
-        if (MEM_type == ISLOAD) {                                                \
-            instr = INSTR_CREATE_##OPCODE(                                       \
+        if (mem_type == ISLOAD) {                                                \
+            instr = INSTR_CREATE_##opcode(                                       \
                 dc, opnd_create_reg(DR_REG_VR0),                                 \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,              \
                                       reg_get_size(DR_REG_VR0)),                 \
                 opnd_create_reg(DR_REG_A2), opnd_create_immed_int(0b1, OPSZ_1b), \
                 opnd_create_immed_int(0b000, OPSZ_3b));                          \
         } else {                                                                 \
-            instr = INSTR_CREATE_##OPCODE(                                       \
+            instr = INSTR_CREATE_##opcode(                                       \
                 dc,                                                              \
                 opnd_create_base_disp(DR_REG_A1, DR_REG_NULL, 0, 0,              \
                                       reg_get_size(DR_REG_VR0)),                 \
@@ -143,71 +143,71 @@ static byte buf[8192];
                 opnd_create_immed_int(0b1, OPSZ_1b),                             \
                 opnd_create_immed_int(0b000, OPSZ_3b));                          \
         }                                                                        \
-        test_instr_encoding(dc, OP_##OPCODE, instr);                             \
+        test_instr_encoding(dc, OP_##opcode, instr);                             \
     } while (0);
 
-#define TEST_Vd_Rs1_Vs2_vm(OPCODE)                                         \
-    instr = INSTR_CREATE_##OPCODE(                                         \
+#define TEST_Vd_Rs1_Vs2_vm(opcode)                                         \
+    instr = INSTR_CREATE_##opcode(                                         \
         dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_A1),       \
         opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b)); \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_Rs1_Vs2(OPCODE)                                                         \
+#define TEST_Vd_Rs1_Vs2(opcode)                                                         \
     instr =                                                                             \
-        INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),                          \
+        INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0),                          \
                               opnd_create_reg(DR_REG_A1), opnd_create_reg(DR_REG_VR2)); \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_Rs1(OPCODE)                                        \
-    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0), \
+#define TEST_Vd_Rs1(opcode)                                        \
+    instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0), \
                                   opnd_create_reg(DR_REG_A1));     \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_Vs1_Vs2_vm(OPCODE)                                         \
-    instr = INSTR_CREATE_##OPCODE(                                         \
+#define TEST_Vd_Vs1_Vs2_vm(opcode)                                         \
+    instr = INSTR_CREATE_##opcode(                                         \
         dc, opnd_create_reg(DR_REG_VR0), opnd_create_reg(DR_REG_VR1),      \
         opnd_create_reg(DR_REG_VR2), opnd_create_immed_int(0b1, OPSZ_1b)); \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_Vs1_Vs2(OPCODE)                                                          \
+#define TEST_Vd_Vs1_Vs2(opcode)                                                          \
     instr =                                                                              \
-        INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),                           \
+        INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0),                           \
                               opnd_create_reg(DR_REG_VR1), opnd_create_reg(DR_REG_VR2)); \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_IMM_Vs2_vm(OPCODE)                                                \
-    instr = INSTR_CREATE_##OPCODE(                                                \
+#define TEST_Vd_IMM_Vs2_vm(opcode)                                                \
+    instr = INSTR_CREATE_##opcode(                                                \
         dc, opnd_create_reg(DR_REG_VR0), opnd_create_immed_int(0b10100, OPSZ_5b), \
         opnd_create_reg(DR_REG_VR1), opnd_create_immed_int(0b1, OPSZ_1b));        \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_IMM_Vs2(OPCODE)                                            \
-    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),         \
+#define TEST_Vd_IMM_Vs2(opcode)                                            \
+    instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0),         \
                                   opnd_create_immed_int(0b10100, OPSZ_5b), \
                                   opnd_create_reg(DR_REG_VR1));            \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_Vs1_vm(OPCODE)                                          \
-    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0),      \
+#define TEST_Vd_Vs1_vm(opcode)                                          \
+    instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0),      \
                                   opnd_create_reg(DR_REG_VR1),          \
                                   opnd_create_immed_int(0b1, OPSZ_1b)); \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Vd_Vs1(OPCODE)                                        \
-    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_VR0), \
+#define TEST_Vd_Vs1(opcode)                                        \
+    instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_VR0), \
                                   opnd_create_reg(DR_REG_VR1));    \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Rd_Vs1(OPCODE)                                       \
-    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_A1), \
+#define TEST_Rd_Vs1(opcode)                                       \
+    instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_A1), \
                                   opnd_create_reg(DR_REG_VR0));   \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
-#define TEST_Rd_Vs1_vm(OPCODE)                                          \
-    instr = INSTR_CREATE_##OPCODE(dc, opnd_create_reg(DR_REG_A1),       \
+#define TEST_Rd_Vs1_vm(opcode)                                          \
+    instr = INSTR_CREATE_##opcode(dc, opnd_create_reg(DR_REG_A1),       \
                                   opnd_create_reg(DR_REG_VR0),          \
                                   opnd_create_immed_int(0b1, OPSZ_1b)); \
-    test_instr_encoding(dc, OP_##OPCODE, instr);
+    test_instr_encoding(dc, OP_##opcode, instr);
 
 instr_t *instr;
 

--- a/suite/tests/api/ir_rvv.expect
+++ b/suite/tests/api/ir_rvv.expect
@@ -28,7 +28,7 @@ vsse8.v v0 a2 0x1 0x0 -> (a1)
 vsse16.v v0 a2 0x1 0x0 -> (a1)
 vsse32.v v0 a2 0x1 0x0 -> (a1)
 vsse64.v v0 a2 0x1 0x0 -> (a1)
-vloxei8.v (a1) v2 0x1 0x0 -> v0
+vloxei8.v (a1) v1 0x1 0x0 -> v0
 vloxei16.v (a1) v1 0x1 0x0 -> v0
 vloxei32.v (a1) v1 0x1 0x0 -> v0
 vloxei64.v (a1) v1 0x1 0x0 -> v0
@@ -71,8 +71,8 @@ vfsgnjx.vf a1 v2 0x1 -> v0
 vfslide1up.vf a1 v2 0x1 -> v0
 vfslide1down.vf a1 v2 0x1 -> v0
 vfmv.s.f a1 -> v0
-vfmerge.vfm a1 v2 -> v0
 vfmv.v.f a1 -> v0
+vfmerge.vfm a1 v2 -> v0
 vmfeq.vf a1 v2 0x1 -> v0
 vmfle.vf a1 v2 0x1 -> v0
 vmflt.vf a1 v2 0x1 -> v0
@@ -87,7 +87,6 @@ vfnmadd.vf a1 v2 0x1 -> v0
 vfmsub.vf a1 v2 0x1 -> v0
 vfnmsub.vf a1 v2 0x1 -> v0
 vfmacc.vf a1 v2 0x1 -> v0
-vfmerge.vfm a1 v2 -> v0
 vfnmacc.vf a1 v2 0x1 -> v0
 vfmsac.vf a1 v2 0x1 -> v0
 vfnmsac.vf a1 v2 0x1 -> v0
@@ -112,7 +111,7 @@ vfredmax.vs v1 v2 0x1 -> v0
 vfsgnj.vv v1 v2 0x1 -> v0
 vfsgnjn.vv v1 v2 0x1 -> v0
 vfsgnjx.vv v1 v2 0x1 -> v0
-vfmv.f.s v1 -> a1
+vfmv.f.s v0 -> a1
 vmfeq.vv v1 v2 0x1 -> v0
 vmfle.vv v1 v2 0x1 -> v0
 vmflt.vv v1 v2 0x1 -> v0
@@ -133,7 +132,6 @@ vfcvt.f.xu.v v1 0x1 -> v0
 vfcvt.f.x.v v1 0x1 -> v0
 vfcvt.rtz.xu.f.v v1 0x1 -> v0
 vfcvt.rtz.x.f.v v1 0x1 -> v0
-vfcvt.xu.f.v v1 0x1 -> v0
 vfwcvt.x.f.v v1 0x1 -> v0
 vfwcvt.f.xu.v v1 0x1 -> v0
 vfwcvt.f.x.v v1 0x1 -> v0
@@ -299,7 +297,7 @@ vaaddu.vv v1 v2 0x1 -> v0
 vaadd.vv v1 v2 0x1 -> v0
 vasubu.vv v1 v2 0x1 -> v0
 vasub.vv v1 v2 0x1 -> v0
-vmv.x.s v1 -> a1
+vmv.x.s v0 -> a1
 test_MVV complete
 vaaddu.vx a1 v2 0x1 -> v0
 vaadd.vx a1 v2 0x1 -> v0
@@ -356,8 +354,8 @@ vmsof.m v1 0x1 -> v0
 vmsif.m v1 0x1 -> v0
 viota.m v1 0x1 -> v0
 vid.v  0x1 -> v0
-vcpop.m v1 0x1 -> a1
-vfirst.m v1 0x1 -> a1
+vcpop.m v0 0x1 -> a1
+vfirst.m v0 0x1 -> a1
 vdivu.vv v1 v2 0x1 -> v0
 vdiv.vv v1 v2 0x1 -> v0
 vremu.vv v1 v2 0x1 -> v0

--- a/suite/tests/api/ir_rvv.expect
+++ b/suite/tests/api/ir_rvv.expect
@@ -1,0 +1,388 @@
+vsetivli 0xa 0x8 -> a1
+vsetvli a2 0x8 -> a1
+vsetvl a2 a3 -> a1
+test_configuration_setting complete
+vlm.v  (a1) -> v0
+vsm.v  v0 -> (a1)
+vle8.v (a1) 0x1 0x0 -> v0
+vle16.v (a1) 0x1 0x0 -> v0
+vle32.v (a1) 0x1 0x0 -> v0
+vle64.v (a1) 0x1 0x0 -> v0
+vse8.v v0 0x1 0x0 -> (a1)
+vse16.v v0 0x1 0x0 -> (a1)
+vse32.v v0 0x1 0x0 -> (a1)
+vse64.v v0 0x1 0x0 -> (a1)
+vluxei8.v (a1) v1 0x1 0x0 -> v0
+vluxei16.v (a1) v1 0x1 0x0 -> v0
+vluxei32.v (a1) v1 0x1 0x0 -> v0
+vluxei64.v (a1) v1 0x1 0x0 -> v0
+vsuxei8.v v0 v1 0x1 0x0 -> (a1)
+vsuxei16.v v0 v1 0x1 0x0 -> (a1)
+vsuxei32.v v0 v1 0x1 0x0 -> (a1)
+vsuxei64.v v0 v1 0x1 0x0 -> (a1)
+vlse8.v (a1) a2 0x1 0x0 -> v0
+vlse16.v (a1) a2 0x1 0x0 -> v0
+vlse32.v (a1) a2 0x1 0x0 -> v0
+vlse64.v (a1) a2 0x1 0x0 -> v0
+vsse8.v v0 a2 0x1 0x0 -> (a1)
+vsse16.v v0 a2 0x1 0x0 -> (a1)
+vsse32.v v0 a2 0x1 0x0 -> (a1)
+vsse64.v v0 a2 0x1 0x0 -> (a1)
+vloxei8.v (a1) v2 0x1 0x0 -> v0
+vloxei16.v (a1) v1 0x1 0x0 -> v0
+vloxei32.v (a1) v1 0x1 0x0 -> v0
+vloxei64.v (a1) v1 0x1 0x0 -> v0
+vsoxei8.v v0 v1 0x1 0x0 -> (a1)
+vsoxei16.v v0 v1 0x1 0x0 -> (a1)
+vsoxei32.v v0 v1 0x1 0x0 -> (a1)
+vsoxei64.v v0 v1 0x1 0x0 -> (a1)
+vle8ff.v (a1) 0x1 0x0 -> v0
+vle16ff.v (a1) 0x1 0x0 -> v0
+vle32ff.v (a1) 0x1 0x0 -> v0
+vle64ff.v (a1) 0x1 0x0 -> v0
+vl1re8.v (a1) -> v0
+vl1re16.v (a1) -> v0
+vl1re32.v (a1) -> v0
+vl1re64.v (a1) -> v0
+vl2re8.v (a1) -> v0
+vl2re16.v (a1) -> v0
+vl2re32.v (a1) -> v0
+vl2re64.v (a1) -> v0
+vl4re8.v (a1) -> v0
+vl4re16.v (a1) -> v0
+vl4re32.v (a1) -> v0
+vl4re64.v (a1) -> v0
+vl8re8.v (a1) -> v0
+vl8re16.v (a1) -> v0
+vl8re32.v (a1) -> v0
+vl8re64.v (a1) -> v0
+vs1r.v v0 -> (a1)
+vs2r.v v0 -> (a1)
+vs4r.v v0 -> (a1)
+vs8r.v v0 -> (a1)
+test_load_store complete
+vfadd.vf a1 v2 0x1 -> v0
+vfsub.vf a1 v2 0x1 -> v0
+vfmin.vf a1 v2 0x1 -> v0
+vfmax.vf a1 v2 0x1 -> v0
+vfsgnj.vf a1 v2 0x1 -> v0
+vfsgnjn.vf a1 v2 0x1 -> v0
+vfsgnjx.vf a1 v2 0x1 -> v0
+vfslide1up.vf a1 v2 0x1 -> v0
+vfslide1down.vf a1 v2 0x1 -> v0
+vfmv.s.f a1 -> v0
+vfmerge.vfm a1 v2 -> v0
+vfmv.v.f a1 -> v0
+vmfeq.vf a1 v2 0x1 -> v0
+vmfle.vf a1 v2 0x1 -> v0
+vmflt.vf a1 v2 0x1 -> v0
+vmfne.vf a1 v2 0x1 -> v0
+vmfgt.vf a1 v2 0x1 -> v0
+vmfge.vf a1 v2 0x1 -> v0
+vfrdiv.vf a1 v2 0x1 -> v0
+vfmul.vf a1 v2 0x1 -> v0
+vfrsub.vf a1 v2 0x1 -> v0
+vfmadd.vf a1 v2 0x1 -> v0
+vfnmadd.vf a1 v2 0x1 -> v0
+vfmsub.vf a1 v2 0x1 -> v0
+vfnmsub.vf a1 v2 0x1 -> v0
+vfmacc.vf a1 v2 0x1 -> v0
+vfmerge.vfm a1 v2 -> v0
+vfnmacc.vf a1 v2 0x1 -> v0
+vfmsac.vf a1 v2 0x1 -> v0
+vfnmsac.vf a1 v2 0x1 -> v0
+vfwadd.vf a1 v2 0x1 -> v0
+vfwsub.vf a1 v2 0x1 -> v0
+vfwadd.wf a1 v2 0x1 -> v0
+vfwsub.wf a1 v2 0x1 -> v0
+vfwmul.vf a1 v2 0x1 -> v0
+vfwmacc.vf a1 v2 0x1 -> v0
+vfwnmacc.vf a1 v2 0x1 -> v0
+vfwmsac.vf a1 v2 0x1 -> v0
+vfwnmsac.vf a1 v2 0x1 -> v0
+test_FVF complete
+vfadd.vv v1 v2 0x1 -> v0
+vfredusum.vs v1 v2 0x1 -> v0
+vfsub.vv v1 v2 0x1 -> v0
+vfredosum.vs v1 v2 0x1 -> v0
+vfmin.vv v1 v2 0x1 -> v0
+vfredmin.vs v1 v2 0x1 -> v0
+vfmax.vv v1 v2 0x1 -> v0
+vfredmax.vs v1 v2 0x1 -> v0
+vfsgnj.vv v1 v2 0x1 -> v0
+vfsgnjn.vv v1 v2 0x1 -> v0
+vfsgnjx.vv v1 v2 0x1 -> v0
+vfmv.f.s v1 -> a1
+vmfeq.vv v1 v2 0x1 -> v0
+vmfle.vv v1 v2 0x1 -> v0
+vmflt.vv v1 v2 0x1 -> v0
+vmfne.vv v1 v2 0x1 -> v0
+vfdiv.vv v1 v2 0x1 -> v0
+vfmul.vv v1 v2 0x1 -> v0
+vfmadd.vv v1 v2 0x1 -> v0
+vfnmadd.vv v1 v2 0x1 -> v0
+vfmsub.vv v1 v2 0x1 -> v0
+vfnmsub.vv v1 v2 0x1 -> v0
+vfmacc.vv v1 v2 0x1 -> v0
+vfnmacc.vv v1 v2 0x1 -> v0
+vfmsac.vv v1 v2 0x1 -> v0
+vfnmsac.vv v1 v2 0x1 -> v0
+vfcvt.xu.f.v v1 0x1 -> v0
+vfcvt.x.f.v v1 0x1 -> v0
+vfcvt.f.xu.v v1 0x1 -> v0
+vfcvt.f.x.v v1 0x1 -> v0
+vfcvt.rtz.xu.f.v v1 0x1 -> v0
+vfcvt.rtz.x.f.v v1 0x1 -> v0
+vfcvt.xu.f.v v1 0x1 -> v0
+vfwcvt.x.f.v v1 0x1 -> v0
+vfwcvt.f.xu.v v1 0x1 -> v0
+vfwcvt.f.x.v v1 0x1 -> v0
+vfwcvt.f.f.v v1 0x1 -> v0
+vfwcvt.rtz.xu.f.v v1 0x1 -> v0
+vfwcvt.rtz.x.f.v v1 0x1 -> v0
+vfncvt.xu.f.w v1 0x1 -> v0
+vfncvt.x.f.w v1 0x1 -> v0
+vfncvt.f.xu.w v1 0x1 -> v0
+vfncvt.f.x.w v1 0x1 -> v0
+vfncvt.f.f.w v1 0x1 -> v0
+vfncvt.rod.f.f.w v1 0x1 -> v0
+vfncvt.rtz.xu.f.w v1 0x1 -> v0
+vfncvt.rtz.x.f.w v1 0x1 -> v0
+vfsqrt.v v1 0x1 -> v0
+vfrsqrt7.v v1 0x1 -> v0
+vfrec7.v v1 0x1 -> v0
+vfclass.v v1 0x1 -> v0
+vfwadd.vv v1 v2 0x1 -> v0
+vfwredusum.vs v1 v2 0x1 -> v0
+vfwsub.vv v1 v2 0x1 -> v0
+vfwredosum.vs v1 v2 0x1 -> v0
+vfwadd.wv v1 v2 0x1 -> v0
+vfwsub.wv v1 v2 0x1 -> v0
+vfwmul.vv v1 v2 0x1 -> v0
+vfwmacc.vv v1 v2 0x1 -> v0
+vfwnmacc.vv v1 v2 0x1 -> v0
+vfnmacc.vv v1 v2 0x1 -> v0
+vfmsac.vv v1 v2 0x1 -> v0
+vfwnmsac.vv v1 v2 0x1 -> v0
+test_FVV complete
+vadd.vx a1 v2 0x1 -> v0
+vsub.vx a1 v2 0x1 -> v0
+vrsub.vx a1 v2 0x1 -> v0
+vminu.vx a1 v2 0x1 -> v0
+vmin.vx a1 v2 0x1 -> v0
+vmaxu.vx a1 v2 0x1 -> v0
+vmax.vx a1 v2 0x1 -> v0
+vand.vx a1 v2 0x1 -> v0
+vor.vx a1 v2 0x1 -> v0
+vxor.vx a1 v2 0x1 -> v0
+vrgather.vx a1 v2 0x1 -> v0
+vslideup.vx a1 v2 0x1 -> v0
+vslidedown.vx a1 v2 0x1 -> v0
+vadc.vxm a1 v2 -> v0
+vmadc.vxm a1 v2 -> v0
+vmadc.vx a1 v2 -> v0
+vsbc.vxm a1 v2 -> v0
+vmsbc.vxm a1 v2 -> v0
+vmsbc.vx a1 v2 -> v0
+vmerge.vxm a1 v2 -> v0
+vmv.v.x a1 -> v0
+vmseq.vx a1 v2 0x1 -> v0
+vmsne.vx a1 v2 0x1 -> v0
+vmsltu.vx a1 v2 0x1 -> v0
+vmslt.vx a1 v2 0x1 -> v0
+vmsleu.vx a1 v2 0x1 -> v0
+vmsle.vx a1 v2 0x1 -> v0
+vmsgtu.vx a1 v2 0x1 -> v0
+vmsgt.vx a1 v2 0x1 -> v0
+vsaddu.vx a1 v2 0x1 -> v0
+vsadd.vx a1 v2 0x1 -> v0
+vssubu.vx a1 v2 0x1 -> v0
+vssub.vx a1 v2 0x1 -> v0
+vsll.vx a1 v2 0x1 -> v0
+vsmul.vx a1 v2 0x1 -> v0
+vsrl.vx a1 v2 0x1 -> v0
+vsra.vx a1 v2 0x1 -> v0
+vssrl.vx a1 v2 0x1 -> v0
+vssra.vx a1 v2 0x1 -> v0
+vnsrl.wx a1 v2 0x1 -> v0
+vnsra.wx a1 v2 0x1 -> v0
+vnclipu.wx a1 v2 0x1 -> v0
+vnclip.wx a1 v2 0x1 -> v0
+test_IVX complete
+vadd.vv v1 v2 0x1 -> v0
+vsub.vv v1 v2 0x1 -> v0
+vminu.vv v1 v2 0x1 -> v0
+vmin.vv v1 v2 0x1 -> v0
+vmaxu.vv v1 v2 0x1 -> v0
+vmax.vv v1 v2 0x1 -> v0
+vand.vv v1 v2 0x1 -> v0
+vor.vv v1 v2 0x1 -> v0
+vxor.vv v1 v2 0x1 -> v0
+vrgather.vv v1 v2 0x1 -> v0
+vrgatherei16.vv v1 v2 0x1 -> v0
+vadc.vvm v1 v2 -> v0
+vmadc.vvm v1 v2 -> v0
+vmadc.vv v1 v2 -> v0
+vsbc.vvm v1 v2 -> v0
+vmsbc.vvm v1 v2 -> v0
+vmsbc.vv v1 v2 -> v0
+vmerge.vvm v1 v2 -> v0
+vmv.v.v v1 -> v0
+vmseq.vv v1 v2 0x1 -> v0
+vmsne.vv v1 v2 0x1 -> v0
+vmsltu.vv v1 v2 0x1 -> v0
+vmslt.vv v1 v2 0x1 -> v0
+vmsleu.vv v1 v2 0x1 -> v0
+vmsle.vv v1 v2 0x1 -> v0
+vsaddu.vv v1 v2 0x1 -> v0
+vsadd.vv v1 v2 0x1 -> v0
+vssubu.vv v1 v2 0x1 -> v0
+vssub.vv v1 v2 0x1 -> v0
+vsll.vv v1 v2 0x1 -> v0
+vsmul.vv v1 v2 0x1 -> v0
+vsrl.vv v1 v2 0x1 -> v0
+vsra.vv v1 v2 0x1 -> v0
+vssrl.vv v1 v2 0x1 -> v0
+vssra.vv v1 v2 0x1 -> v0
+vnsrl.wv v1 v2 0x1 -> v0
+vnsra.wv v1 v2 0x1 -> v0
+vnclipu.wv v1 v2 0x1 -> v0
+vnclip.wv v1 v2 0x1 -> v0
+vwredsumu.vs v1 v2 0x1 -> v0
+vwredsum.vs v1 v2 0x1 -> v0
+test_IVV complete
+vadd.vi 0x14 v1 0x1 -> v0
+vrsub.vi 0x14 v1 0x1 -> v0
+vand.vi 0x14 v1 0x1 -> v0
+vor.vi 0x14 v1 0x1 -> v0
+vxor.vi 0x14 v1 0x1 -> v0
+vrgather.vi 0x14 v1 0x1 -> v0
+vslideup.vi 0x14 v1 0x1 -> v0
+vslidedown.vi 0x14 v1 0x1 -> v0
+vadc.vim 0x14 v1 -> v0
+vmadc.vim 0x14 v1 -> v0
+vmadc.vi 0x14 v1 -> v0
+vmerge.vim 0x14 v1 -> v0
+vmv.v.i 0x14 -> v0
+vmseq.vi 0x14 v1 0x1 -> v0
+vmsne.vi 0x14 v1 0x1 -> v0
+vmsleu.vi 0x14 v1 0x1 -> v0
+vmsle.vi 0x14 v1 0x1 -> v0
+vmsgtu.vi 0x14 v1 0x1 -> v0
+vmsgt.vi 0x14 v1 0x1 -> v0
+vsaddu.vi 0x14 v1 0x1 -> v0
+vsadd.vi 0x14 v1 0x1 -> v0
+vsll.vi 0x14 v1 0x1 -> v0
+vmv1r.v v1 -> v0
+vmv2r.v v1 -> v0
+vmv4r.v v1 -> v0
+vmv8r.v v1 -> v0
+vsaddu.vi 0x14 v1 0x1 -> v0
+vsrl.vi 0x14 v1 0x1 -> v0
+vsra.vi 0x14 v1 0x1 -> v0
+vssrl.vi 0x14 v1 0x1 -> v0
+vssra.vi 0x14 v1 0x1 -> v0
+vnsrl.wi 0x14 v1 0x1 -> v0
+vnsra.wi 0x14 v1 0x1 -> v0
+vnclipu.wi 0x14 v1 0x1 -> v0
+vnclip.wi 0x14 v1 0x1 -> v0
+test_IVI complete
+vredsum.vs v1 v2 0x1 -> v0
+vredand.vs v1 v2 0x1 -> v0
+vredor.vs v1 v2 0x1 -> v0
+vredxor.vs v1 v2 0x1 -> v0
+vredminu.vs v1 v2 0x1 -> v0
+vredmin.vs v1 v2 0x1 -> v0
+vredmaxu.vs v1 v2 0x1 -> v0
+vredmax.vs v1 v2 0x1 -> v0
+vaaddu.vv v1 v2 0x1 -> v0
+vaadd.vv v1 v2 0x1 -> v0
+vasubu.vv v1 v2 0x1 -> v0
+vasub.vv v1 v2 0x1 -> v0
+vmv.x.s v1 -> a1
+test_MVV complete
+vaaddu.vx a1 v2 0x1 -> v0
+vaadd.vx a1 v2 0x1 -> v0
+vasubu.vx a1 v2 0x1 -> v0
+vasub.vx a1 v2 0x1 -> v0
+vmv.s.x a1 -> v0
+vslide1up.vx a1 v2 0x1 -> v0
+vslide1down.vx a1 v2 0x1 -> v0
+vdivu.vx a1 v2 0x1 -> v0
+vdiv.vx a1 v2 0x1 -> v0
+vremu.vx a1 v2 0x1 -> v0
+vrem.vx a1 v2 0x1 -> v0
+vmulhu.vx a1 v2 0x1 -> v0
+vmul.vx a1 v2 0x1 -> v0
+vmulhsu.vx a1 v2 0x1 -> v0
+vmulh.vx a1 v2 0x1 -> v0
+vmadd.vx a1 v2 0x1 -> v0
+vnmsub.vx a1 v2 0x1 -> v0
+vmacc.vx a1 v2 0x1 -> v0
+vnmsac.vx a1 v2 0x1 -> v0
+vwaddu.vx a1 v2 0x1 -> v0
+vwadd.vx a1 v2 0x1 -> v0
+vwsubu.vx a1 v2 0x1 -> v0
+vwsub.vx a1 v2 0x1 -> v0
+vwaddu.wx a1 v2 0x1 -> v0
+vwadd.wx a1 v2 0x1 -> v0
+vwsubu.wx a1 v2 0x1 -> v0
+vwsub.wx a1 v2 0x1 -> v0
+vwmulu.vx a1 v2 0x1 -> v0
+vwmulsu.vx a1 v2 0x1 -> v0
+vwmul.vx a1 v2 0x1 -> v0
+vwmaccu.vx a1 v2 0x1 -> v0
+vwmacc.vx a1 v2 0x1 -> v0
+vwmaccus.vx a1 v2 0x1 -> v0
+vwmaccsu.vx a1 v2 0x1 -> v0
+test_MVX complete
+vzext.vf8 v1 0x1 -> v0
+vsext.vf8 v1 0x1 -> v0
+vzext.vf4 v1 0x1 -> v0
+vsext.vf4 v1 0x1 -> v0
+vzext.vf2 v1 0x1 -> v0
+vsext.vf2 v1 0x1 -> v0
+vcompress.vm v1 v2 -> v0
+vmandn.mm v1 v2 -> v0
+vmand.mm v1 v2 -> v0
+vmor.mm v1 v2 -> v0
+vmxor.mm v1 v2 -> v0
+vmorn.mm v1 v2 -> v0
+vmnand.mm v1 v2 -> v0
+vmnor.mm v1 v2 -> v0
+vmxnor.mm v1 v2 -> v0
+vmsbf.m v1 0x1 -> v0
+vmsof.m v1 0x1 -> v0
+vmsif.m v1 0x1 -> v0
+viota.m v1 0x1 -> v0
+vid.v  0x1 -> v0
+vcpop.m v1 0x1 -> a1
+vfirst.m v1 0x1 -> a1
+vdivu.vv v1 v2 0x1 -> v0
+vdiv.vv v1 v2 0x1 -> v0
+vremu.vv v1 v2 0x1 -> v0
+vrem.vv v1 v2 0x1 -> v0
+vmulhu.vv v1 v2 0x1 -> v0
+vmul.vv v1 v2 0x1 -> v0
+vmulhsu.vv v1 v2 0x1 -> v0
+vmulh.vv v1 v2 0x1 -> v0
+vmadd.vv v1 v2 0x1 -> v0
+vnmsub.vv v1 v2 0x1 -> v0
+vmacc.vv v1 v2 0x1 -> v0
+vnmsac.vv v1 v2 0x1 -> v0
+vnmsac.vv v1 v2 0x1 -> v0
+vwadd.vv v1 v2 0x1 -> v0
+vwsubu.vv v1 v2 0x1 -> v0
+vwsub.vv v1 v2 0x1 -> v0
+vwaddu.wv v1 v2 0x1 -> v0
+vwadd.wv v1 v2 0x1 -> v0
+vwsubu.wv v1 v2 0x1 -> v0
+vwsub.wv v1 v2 0x1 -> v0
+vwmulu.vv v1 v2 0x1 -> v0
+vwmulsu.vv v1 v2 0x1 -> v0
+vwmul.vv v1 v2 0x1 -> v0
+vwmaccu.vv v1 v2 0x1 -> v0
+vwmacc.vv v1 v2 0x1 -> v0
+vwmaccsu.vv v1 v2 0x1 -> v0
+test_int_extension complete
+All tests complete


### PR DESCRIPTION
This is a follow-up patch of adding RISC-V vector (RVV) extension support to the core, part1 in PR https://github.com/DynamoRIO/dynamorio/pull/6810 (https://github.com/DynamoRIO/dynamorio/commit/f1ce1bca75ed24782f459543ecce57febd44311c), part2 in PR https://github.com/DynamoRIO/dynamorio/pull/6848 (https://github.com/DynamoRIO/dynamorio/commit/59d0360f3d68433c31d95c0b82082eaac275cd5c).

This patch adds ir-test of RISC-V vector extension.

Issue: #3544