### PR TITLE
i#6662 public traces, part 6: invariant_checker

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -149,9 +149,17 @@ invariant_checker_t::parallel_shard_init_stream(int shard_index, void *worker_da
     auto per_shard = std::unique_ptr<per_shard_t>(new per_shard_t);
     per_shard->stream = shard_stream;
     void *res = reinterpret_cast<void *>(per_shard.get());
-    std::lock_guard<std::mutex> guard(shard_map_mutex_);
+    std::lock_guard<std::mutex> guard(init_mutex_);
     per_shard->tid_ = shard_stream->get_tid();
     shard_map_[shard_index] = std::move(per_shard);
+    // If we are dealing with an OFFLINE_FILE_TYPE_ARCH_REGDEPS trace, we need to set the
+    // dcontext ISA mode to the correct synthetic ISA (i.e., DR_ISA_REGDEPS).
+    uint64_t filetype = shard_stream->get_filetype();
+    if (TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, filetype)) {
+        dr_isa_mode_t isa_mode = dr_get_isa_mode(drcontext_);
+        if (isa_mode != DR_ISA_REGDEPS)
+            dr_set_isa_mode(drcontext_, DR_ISA_REGDEPS, nullptr);
+    }
     return res;
 }
 
@@ -174,7 +182,13 @@ invariant_checker_t::parallel_shard_exit(void *shard_data)
                         // that out we disable this error for Windows online.
                         IF_WINDOWS(|| !knob_offline_),
                     "Thread is missing exit");
-    if (!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_DFILTERED,
+    if (!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_DFILTERED |
+                     // In OFFLINE_FILE_TYPE_ARCH_REGDEPS we can have leftover
+                     // shard->expected_[read | write]_records_ as we don't decrease this
+                     // counter when we encounter a TRACE_TYPE_[READ | WRITE]. We cannot
+                     // decrease the counter because the precise number of reads and
+                     // writes a DR_ISA_REGDEPS instruction perform cannot be determined.
+                     OFFLINE_FILE_TYPE_ARCH_REGDEPS,
                  shard->file_type_)) {
         report_if_false(shard, shard->expected_read_records_ == 0,
                         "Missing read records");
@@ -497,11 +511,15 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // Re-assign the saved value to the shard state to allow this intervening
         // maybe_blocking marker.
         shard->prev_was_syscall_marker_ = prev_was_syscall_marker_saved;
-        report_if_false(shard,
-                        shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
-                            shard->prev_entry_.marker.marker_type ==
-                                TRACE_MARKER_TYPE_SYSCALL,
-                        "Maybe-blocking marker not preceded by syscall marker");
+        report_if_false(
+            shard,
+            (shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
+             shard->prev_entry_.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL) ||
+                // In OFFLINE_FILE_TYPE_ARCH_REGDEPS traces we remove
+                // TRACE_MARKER_TYPE_SYSCALL markers, hence we disable this check for
+                // these traces.
+                TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, shard->file_type_),
+            "Maybe-blocking marker not preceded by syscall marker");
     }
 
     // Invariant: each chunk's instruction count must be identical and equal to
@@ -775,7 +793,10 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         instr_num_memory_read_access(noalloc_instr);
                     cur_instr_info.decoding.num_memory_write_access =
                         instr_num_memory_write_access(noalloc_instr);
-                    if (type_is_instr_branch(memref.instr.type)) {
+                    if (type_is_instr_branch(memref.instr.type) &&
+                        // DR_ISA_REGDEPS instructions don't have a branch target saved as
+                        // instr.src[0], so we cannot retrieve this information.
+                        !TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, shard->file_type_)) {
                         const opnd_t target = instr_get_target(noalloc_instr);
                         if (opnd_is_pc(target)) {
                             cur_instr_info.decoding.branch_target =
@@ -795,23 +816,32 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                 cur_instr_info.decoding.is_syscall)
                 shard->expect_syscall_marker_ = true;
             if (cur_instr_info.decoding.has_valid_decoding &&
-                !cur_instr_info.decoding.is_predicated &&
-                !TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_DFILTERED,
-                         shard->file_type_)) {
+                !cur_instr_info.decoding.is_predicated) {
                 // Verify the number of read/write records matches the last
                 // operand. Skip D-filtered traces which don't have every load or
                 // store records.
-                report_if_false(shard,
-                                shard->expected_read_records_ == 0 ||
-                                    // Some prefetches did not have any corresponding
-                                    // memory access in system call trace templates
-                                    // collected on QEMU.
-                                    (shard->between_kernel_syscall_trace_markers_ &&
-                                     shard->prev_instr_.decoding.is_prefetch),
-                                "Missing read records");
+                report_if_false(
+                    shard,
+                    (shard->expected_read_records_ == 0 ||
+                     // Some prefetches did not have any corresponding
+                     // memory access in system call trace templates
+                     // collected on QEMU.
+                     (shard->between_kernel_syscall_trace_markers_ &&
+                      shard->prev_instr_.decoding.is_prefetch)) ||
+                        // We cannot check for is_predicated in
+                        // OFFLINE_FILE_TYPE_ARCH_REGDEPS traces (it's always false), so
+                        // we disable this check.
+                        TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, shard->file_type_),
+                    "Missing read records");
                 shard->expected_read_records_ = 0;
-                report_if_false(shard, shard->expected_write_records_ == 0,
-                                "Missing write records");
+                report_if_false(
+                    shard,
+                    shard->expected_write_records_ == 0 ||
+                        // We cannot check for is_predicated in
+                        // OFFLINE_FILE_TYPE_ARCH_REGDEPS traces (it's always false), so
+                        // we disable this check.
+                        TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, shard->file_type_),
+                    "Missing write records");
 
                 if (!(shard->between_kernel_syscall_trace_markers_ &&
                       TESTANY(OFFLINE_FILE_TYPE_KERNEL_SYSCALL_INSTR_ONLY,
@@ -1150,7 +1180,16 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                     shard->expected_read_records_ >
                         0 IF_X86(|| relax_expected_read_count_check_for_kernel(shard)),
                     "Too many read records");
-                if (shard->expected_read_records_ > 0) {
+                if (shard->expected_read_records_ > 0 &&
+                    // We cannot decrease the shard->expected_read_records_ counter in
+                    // OFFLINE_FILE_TYPE_ARCH_REGDEPS traces because we cannot determine
+                    // the exact number of loads a DR_ISA_REGDEPS instruction performs.
+                    // If a DR_ISA_REGDEPS instruction has a DR_INSTR_CATEGORY_LOAD among
+                    // its categories, we simply set
+                    // cur_instr_info.decoding.num_memory_read_access to 1. We rely on the
+                    // next instruction to re-set shard->expected_read_records_
+                    // accordingly.
+                    !TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, shard->file_type_)) {
                     shard->expected_read_records_--;
                 }
             } else {
@@ -1160,7 +1199,16 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                     shard->expected_write_records_ >
                         0 IF_X86(|| relax_expected_write_count_check_for_kernel(shard)),
                     "Too many write records");
-                if (shard->expected_write_records_ > 0) {
+                if (shard->expected_write_records_ > 0 &&
+                    // We cannot decrease the shard->expected_write_records_ counter in
+                    // OFFLINE_FILE_TYPE_ARCH_REGDEPS traces because we cannot determine
+                    // the exact number of stores a DR_ISA_REGDEPS instruction performs.
+                    // If a DR_ISA_REGDEPS instruction has a DR_INSTR_CATEGORY_STORE among
+                    // its categories, we simply set
+                    // cur_instr_info.decoding.num_memory_write_access to 1. We rely on
+                    // the next instruction to re-set shard->expected_write_records_
+                    // accordingly.
+                    !TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, shard->file_type_)) {
                     shard->expected_write_records_--;
                 }
             }
@@ -1471,7 +1519,12 @@ invariant_checker_t::check_for_pc_discontinuity(
                     have_branch_target = true;
                 }
             }
-            if (have_branch_target && branch_target != cur_pc) {
+            if (have_branch_target && branch_target != cur_pc &&
+                // We cannot determine the branch target in OFFLINE_FILE_TYPE_ARCH_REGDEPS
+                // traces because next_pc != cur_pc + instr.size and
+                // indirect_branch_target is not saved in inst.src[0].
+                // So, we skip this invariant error.
+                !TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, shard->file_type_)) {
                 error_msg = "Branch does not go to the correct target";
             }
         } else if (cur_memref_info.decoding.has_valid_decoding &&

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -272,9 +272,11 @@ protected:
 
     void *drcontext_ = dr_standalone_init();
     std::unordered_map<int, std::unique_ptr<per_shard_t>> shard_map_;
-    // This mutex is only needed in parallel_shard_init.  In all other accesses to
-    // shard_map (process_memref, print_results) we are single-threaded.
-    std::mutex shard_map_mutex_;
+    // This mutex is only needed in parallel_shard_init to initialize shard_map_ with
+    // per_shard_t data and set dcontext_t.isa_mode, which is a global resource.
+    // In all other accesses to shard_map_ (process_memref, print_results) we are
+    // single-threaded.
+    std::mutex init_mutex_;
 
     bool knob_offline_;
     unsigned int knob_verbose_;

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -2815,6 +2815,13 @@ decode_memory_reference_size(void *drcontext, app_pc pc, uint *size_in_bytes)
 uint
 instr_num_memory_read_access(instr_t *instr)
 {
+    /* DR_ISA_REGDEPS instructions don't have an opcode, hence we use their category to
+     * determine whether they perform at least one read.
+     */
+    if (instr->isa_mode == DR_ISA_REGDEPS &&
+        TESTANY(DR_INSTR_CATEGORY_LOAD, instr_get_category(instr)))
+        return 1;
+
     int i;
     opnd_t curop;
     int count = 0;
@@ -2837,6 +2844,13 @@ instr_num_memory_read_access(instr_t *instr)
 uint
 instr_num_memory_write_access(instr_t *instr)
 {
+    /* DR_ISA_REGDEPS instructions don't have an opcode, hence we use their category to
+     * determine whether they perform at least one write.
+     */
+    if (instr->isa_mode == DR_ISA_REGDEPS &&
+        TESTANY(DR_INSTR_CATEGORY_STORE, instr_get_category(instr)))
+        return 1;
+
     int i;
     opnd_t curop;
     int count = 0;


### PR DESCRIPTION
OFFLINE_FILE_TYPE_ARCH_REGDEPS traces lack some markers and have instructions with DR_ISA_REGDEPS encodings, which don't have all the necessary information to perform all the invariant checks.
Here we disable or modify some checks for invariant errors to handle OFFLINE_FILE_TYPE_ARCH_REGDEPS synthetic traces in the invariant_checker tool.

Specifically, we disable:
- the checks for 0 read/write records at the end of trace processing, as we can't adjust the counters accordingly because we can't infer the precise number of load/stores performed by DR_ISA_REGDEPS instructions;
- the check for maybe-blocking syscall markers always being preceded by a regular syscall marker, as we don't have regular syscall markers in OFFLINE_FILE_TYPE_ARCH_REGDEPS traces;
- the setting of branch targets, as they are not saved as first source operand in DR_ISA_REGDEPS instructions;
- the check for "Missing read/write records", as we cannot check for predicated instructions in OFFLINE_FILE_TYPE_ARCH_REGDEPS traces;

We modify the check for matching loads/stores performed by a DR_ISA_REGDEPS fetched instruction with the subsequent read/write records, by requiring that if a DR_ISA_REGDEPS instruction performs a load/store (we use the instruction category to determine that), at least one subsequent read/write record must be present.

Issue #6662