### PR TITLE
i#6864: Upgrade to macos-12 for ci-osx

### DIFF
--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -51,7 +51,7 @@ defaults:
 jobs:
   # 64-bit OSX build with clang and run tests:
   osx-x86-64:
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Upgrades to macos-12 or ci-osx. As informed by https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/, macos-11 is now deprecated. This is causing our ci-osx workflow to fail and block PRs. Here we upgrade to the immediately next version for now, as that is least likely to introduce compatibility issues.

Issue: #6864