### PR TITLE
i#5036 AArch64 scatter/gather: Fix 512-bit bugs

### DIFF
--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -813,7 +813,7 @@ instr_compute_vector_address(instr_t *instr, priv_mcontext_t *mc, size_t mc_size
      * If DynamoRIO is extended in the future to support large vector lengths this
      * function will need to be updated to cope with larger predicate mask values.
      */
-    ASSERT(vl_bytes / 8 < sizeof(uint64));
+    ASSERT(vl_bytes / 8 <= sizeof(uint64));
 
     const reg_t governing_pred = opnd_get_reg(instr_get_src(instr, 1));
     ASSERT(governing_pred >= DR_REG_START_P && governing_pred <= DR_REG_STOP_P);

--- a/core/ir/decode_shared.c
+++ b/core/ir/decode_shared.c
@@ -152,6 +152,7 @@ const char *const size_names[] = {
     "OPSZ_8_of_32_evex64",
     "OPSZ_8x16",
     "OPSZ_256",
+    "OPSZ_192",
     "OPSZ_1_of_4",
     "OPSZ_2_of_4",
     "OPSZ_1_of_8",

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -222,8 +222,8 @@ enum {
     OPSZ_8x16, /**< 8 or 16 bytes, but not based on rex prefix, instead dependent
                 * on 32-bit/64-bit mode.
                 */
-
-    OPSZ_256, /**< 256 bytes. Needed for RISC-V vector extension with LMUL. */
+    OPSZ_256,  /**< 256 bytes. Needed for RISC-V vector extension with LMUL. */
+    OPSZ_192,  /**< 192 bytes. The size of 3 512-bit SVE Z registers. */
     /* Add new size here.  Also update size_names[] in decode_shared.c along with
      * the size routines in opnd_shared.c.
      */

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2000,6 +2000,7 @@ opnd_size_in_bytes(opnd_size_t size)
     case OPSZ_120: return 120;
     case OPSZ_124: return 124;
     case OPSZ_128: return 128;
+    case OPSZ_192: return 192;
     case OPSZ_256: return 256;
     case OPSZ_512: return 512;
     case OPSZ_VAR_REGLIST: return 0; /* varies to match reglist operand */
@@ -2077,6 +2078,7 @@ opnd_size_from_bytes(uint bytes)
     case 120: return OPSZ_120;
     case 124: return OPSZ_124;
     case 128: return OPSZ_128;
+    case 192: return OPSZ_192;
     case 256: return OPSZ_256;
     case 512: return OPSZ_512;
     default: return OPSZ_NA;

--- a/ext/drx/scatter_gather_aarch64.c
+++ b/ext/drx/scatter_gather_aarch64.c
@@ -298,6 +298,8 @@ get_scatter_gather_info(instr_t *instr, DR_PARAM_OUT scatter_gather_info_t *sg_i
     default: DR_ASSERT_MSG(false, "Invalid scatter/gather instruction");
     }
 
+    DR_ASSERT(sg_info->scatter_gather_size != OPSZ_NA);
+
     DR_ASSERT(sg_info->mask_reg >= DR_REG_P0 && sg_info->mask_reg <= DR_REG_P15);
 }
 


### PR DESCRIPTION
I have done some testing with 512-bit vector registers and found a couple of bugs in the scatter/gather expansion code.

 - An assert had incorrect logic (< should have been <=)
 - Added OPSZ_192, needed to represent 3 512-bit Z registers.

Issue: #5036