### PR TITLE
i#6451 AArch64: Fix large page support

### DIFF
--- a/core/options.c
+++ b/core/options.c
@@ -2785,7 +2785,17 @@ unit_test_options(void)
      * We include a smaller option to ensure we avoid printing out "0G".
      */
     get_dynamo_options_string(&dynamo_options, opstring, sizeof(opstring), true);
-    EXPECT_EQ(0, strcmp(opstring, "-vmheap_size 16G -persist_short_digest 8K "));
+#        define EXPECT_OPT(opt, val)                                                     \
+            do {                                                                         \
+                const char *start = strstr(opstring, opt);                               \
+                EXPECT_NE(start, NULL);                                                  \
+                const char expected[] = opt " " val;                                     \
+                EXPECT_STR(start, expected, sizeof(expected) / sizeof(expected[0]) - 1); \
+            } while (0)
+    EXPECT_OPT("-vmheap_size", "16G");
+    EXPECT_OPT("-persist_short_digest", "8K");
+#        undef EXPECT_OPT
+
 #    endif
 
     SELF_PROTECT_OPTIONS();

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4061,13 +4061,6 @@ client_thread_run(void)
     dcontext_t *dcontext;
     byte *xsp;
     GET_STACK_PTR(xsp);
-#    ifdef AARCH64
-    /* If we have 4K pages AArch64's Scalable Vector Extension (SVE) requires more space
-     * on the stack. Align to page boundary, similar to that in get_clone_record().
-     */
-    if (PAGE_SIZE == 4096)
-        xsp = (app_pc)ALIGN_BACKWARD(xsp, PAGE_SIZE);
-#    endif
     void *crec = get_clone_record((reg_t)xsp);
     /* i#2335: we support setup separate from start, and we want to allow a client
      * to create a client thread during init, but we do not support that thread

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -4062,10 +4062,11 @@ client_thread_run(void)
     byte *xsp;
     GET_STACK_PTR(xsp);
 #    ifdef AARCH64
-    /* AArch64's Scalable Vector Extension (SVE) requires more space on the
-     * stack. Align to page boundary, similar to that in get_clone_record().
+    /* If we have 4K pages AArch64's Scalable Vector Extension (SVE) requires more space
+     * on the stack. Align to page boundary, similar to that in get_clone_record().
      */
-    xsp = (app_pc)ALIGN_BACKWARD(xsp, PAGE_SIZE);
+    if (PAGE_SIZE == 4096)
+        xsp = (app_pc)ALIGN_BACKWARD(xsp, PAGE_SIZE);
 #    endif
     void *crec = get_clone_record((reg_t)xsp);
     /* i#2335: we support setup separate from start, and we want to allow a client

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -928,7 +928,6 @@ get_clone_record(reg_t xsp)
     /* xsp should be in a dstack, i.e., dynamorio heap.  */
     ASSERT(is_dynamo_address((app_pc)xsp));
 
-
     /* The stack usage when this is called on most platforms is less than one page so we
      * can straightforwardly find the clone record by forward aligning xsp.
      *


### PR DESCRIPTION
PR #5835 inadvertently broke support for large pages on AArch64 by introducing code that assumed a 4K page size.

The core options unit_tests were also failing on large page systems because a lot of options need to be overridden and the test was not accounting for extra options being set in the options string.

Issues: #1680, #6451
Fixes: #6451