### PR TITLE
i#6662 func_id_filter: large function IDs

### DIFF
--- a/clients/drcachesim/tests/record_filter_keep_func_ids.templatex
+++ b/clients/drcachesim/tests/record_filter_keep_func_ids.templatex
@@ -1,0 +1,15 @@
+Estimation of pi is 3.142425985001098
+
+Trace invariant checks passed
+
+Output .* entries from .* entries.
+
+Basic counts tool results:
+
+Total counts:
+.*
+           0 total function id markers
+           0 total function return address markers
+           0 total function argument markers
+           0 total function return value markers
+.*

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -38,6 +38,7 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -95,7 +96,12 @@ parse_string(const std::string &s, char sep = ',')
     std::vector<T> vec;
     do {
         pos = s.find(sep, at);
-        vec.push_back(static_cast<T>(std::stoll(s.substr(at, pos))));
+        unsigned long long parsed_number = std::stoull(s.substr(at, pos));
+        // Check that T can hold the parsed value. Otherwise, skip it.
+        if (parsed_number >= std::numeric_limits<T>::min() &&
+            parsed_number <= std::numeric_limits<T>::max()) {
+            vec.push_back(static_cast<T>(parsed_number));
+        }
         at = pos + 1;
     } while (pos != std::string::npos);
     return vec;

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -95,7 +95,7 @@ parse_string(const std::string &s, char sep = ',')
     std::vector<T> vec;
     do {
         pos = s.find(sep, at);
-        vec.push_back(static_cast<T>(std::stoi(s.substr(at, pos))));
+        vec.push_back(static_cast<T>(std::stoll(s.substr(at, pos))));
         at = pos + 1;
     } while (pos != std::string::npos);
     return vec;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4729,6 +4729,19 @@ if (BUILD_CLIENTS)
           "${drcachesim_path}@-simulator_type@record_filter@-filter_encodings2regdeps@-indir@${testname}.s*.dir/trace@-core_sharded@-cores@4@-outdir@${testname}.filtered.dir"
           # We run the opcode_mix analyzer to test econdings2regdeps filtered traces.
           "opcode_mix")
+
+        # Run func_id_filter to remove all function related markers
+        # (i.e., TRACE_MARKER_TYPE_FUNC_). Using function ID 4294967796 = 4294967296 + 500
+        # = TRACE_FUNC_ID_SYSCALL_BASE + non_existing_syscall_number, which doesn't exist
+        # in the test program to achieve this. We use a large function ID number to also
+        # test the parsing of large function IDs from command line.
+        set(testname "tool.record_filter_keep_func_ids")
+        torun_record_filter("${testname}" ${kernel_xfer_app}
+          "record_filter_keep_func_ids"
+          "${drcachesim_path}@-simulator_type@record_filter@-filter_keep_func_ids@4294967796@-indir@${testname}.${kernel_xfer_app}.*.dir/trace@-outdir@${testname}.filtered.dir"
+          # We run basic_counts on the filtered trace to check that there are no function
+          # related markers left.
+          "basic_counts")
     endif ()
 
     if (UNIX) # Windows multi-thread tests are too slow.


### PR DESCRIPTION
When filtering function related markers (i.e., TRACE_MARKER_TYPE_FUNC_) by function ID we need to provide the original marker value (function ID) in the trace to func_id_filter.
When filtering out system calls, the ID can be large due to TRACE_FUNC_ID_SYSCALL_BASE (which is 0x100000000ULL == 4294967296 for x64) that is added to the system call number, and can cause an std::out_of_range error.
We now use std::stoull to handle large function IDs.
We add a test which runs func_id_filter (part of record_filter) with a large function ID and then checks that there is no function marker left in the filtered trace with basic_counts.

Issue #6662