### PR TITLE
i#6662 type_filter: parse_string() bug fix

### DIFF
--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -96,6 +96,15 @@ parse_string(const std::string &s, char sep = ',')
     do {
         pos = s.find(sep, at);
         unsigned long long parsed_number = std::stoull(s.substr(at, pos));
+        // XXX: parsed_number may be truncated if T is not large enough.
+        // We could check that parsed_number is within the limits of T using
+        // std::numeric_limits<>::min()/max(), but this returns 0 on T that are enums,
+        // which we have when parsing trace_marker_type_t and trace_type_t values for
+        // type_filter. In order to make numeric_limits work on enum, we need to add
+        // std::underlying_type support to these enums.
+        // We also need to consider what should happen when T is not large enough to
+        // contain parsed_number. Should we skip that value? Output a warning? Output an
+        // error and abort?
         vec.push_back(static_cast<T>(parsed_number));
         at = pos + 1;
     } while (pos != std::string::npos);

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -38,7 +38,6 @@
 #include <cstdio>
 #include <fstream>
 #include <iostream>
-#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -97,11 +96,7 @@ parse_string(const std::string &s, char sep = ',')
     do {
         pos = s.find(sep, at);
         unsigned long long parsed_number = std::stoull(s.substr(at, pos));
-        // Check that T can hold the parsed value. Otherwise, skip it.
-        if (parsed_number >= std::numeric_limits<T>::min() &&
-            parsed_number <= std::numeric_limits<T>::max()) {
-            vec.push_back(static_cast<T>(parsed_number));
-        }
+        vec.push_back(static_cast<T>(parsed_number));
         at = pos + 1;
     } while (pos != std::string::npos);
     return vec;


### PR DESCRIPTION
std::numeric_limits<>::min()/max() return 0 on enum types.
This causes the parse_string() specialization for trace_marker_type_t and trace_type_t to not add any value to the vector used by type_filter to remove markers from a trace.
We revert this change to the previous behavior: always add the parsed value to the vector, even if static_cast<> might truncate it.
If we want to re-add the check that type T can hold the parsed value, we'll need to add std::underlying_type support to trace_marker_type_t and trace_type_t enums.

Issue #6662