### PR TITLE
i#3544 RV64: Fix our memcpy return value error

### DIFF
--- a/core/arch/riscv64/memfuncs.asm
+++ b/core/arch/riscv64/memfuncs.asm
@@ -47,7 +47,7 @@ START_FILE
         DECLARE_FUNC(memcpy)
 GLOBAL_LABEL(memcpy:)
         li       t6, 32
-        mv       t0, ARG2 /* Save dst for return. */
+        mv       t0, ARG1 /* Save dst for return. */
 copy32_:
         /* When size is greater than 32, we use 4 ld/sd pairs
          * to copy 4*8=32 bytes in each iteration.


### PR DESCRIPTION
We optimized RV64 memfuncs in PR #6800. However, there was a mistake where the return value of memcpy was incorrectly set to ARG2 which led to segfaults in the release build. This PR addresses this issue. Additionally, our unit_tests did not catch this error because `ret = our_memcpy(&i, &j, sizeof(i));` was optimized by the compiler to `i = j; ret = &i;`. We resolved this by utilizing the `noinline` attribute.