### PR TITLE
Clarify commit template for single vs multi-part commits

### DIFF
--- a/make/git/commit-template.txt
+++ b/make/git/commit-template.txt
@@ -1,5 +1,6 @@
-i#<number> <issue-brief>: <commit-brief>
+i#<number>: <commit-brief>
 
 <commit-details>
+<If a multi-commit issue, add a brief issue description before the : on the title line and s/Fixes/Issue:/ on the footer line>
 
 Fixes #<number>

--- a/make/git/hook-commit-msg.sh
+++ b/make/git/hook-commit-msg.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # **********************************************************
-# Copyright (c) 2014 Google, Inc.    All rights reserved.
+# Copyright (c) 2014-2024 Google, Inc.    All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@
 
 # XXX: relying on grep being on the path for now.
 # If we have devs w/ no grep we can improve this script at that point.
-grep -q -E '<number>|<issue-brief>|<commit-brief>|<commit-details>' $1
+grep -q -E '<number>|<If a multi|<commit-brief>|<commit-details>' $1
 if [ "$?" -eq "0" ]; then
     exec 1>&2
     cat <<\EOF


### PR DESCRIPTION
Removes "<issue-brief>" from the commit template title line as it is only for multi-part commits.  Adds a template line explaining what to do for multi-part commits.

Updates the unedited-template check.