### PR TITLE
i#6822 unsched: Add missing closing '>' to drmemtrace view tool

### DIFF
--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -427,7 +427,7 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
                       << ">\n";
             break;
         case TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE:
-            std::cerr << "<marker: current thread going unscheduled\n";
+            std::cerr << "<marker: current thread going unscheduled>\n";
             break;
         case TRACE_MARKER_TYPE_SYSCALL_SCHEDULE:
             std::cerr << "<marker: re-schedule thread " << memref.marker.marker_value


### PR DESCRIPTION
Adds a missing closing '>' to the drmemtrace view tool's output for a syscall that makes a thread become unscheduled.

Issue: #6822