### PR TITLE
i#6884: Add drmemtrace signal number marker

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -295,6 +295,8 @@ typedef enum {
      * Windows callbacks.
      * A restartable sequence abort handler is further identified by a prior
      * marker of type #TRACE_MARKER_TYPE_RSEQ_ABORT.
+     * A signal handler is optionally further identified by a subsequent marker
+     * of type #TRACE_MARKER_TYPE_SIGNAL_NUMBER.
      */
     TRACE_MARKER_TYPE_KERNEL_EVENT,
     /**
@@ -682,6 +684,13 @@ typedef enum {
      * marker value holds the timeout duration in microseconds.
      */
     TRACE_MARKER_TYPE_SYSCALL_ARG_TIMEOUT,
+
+    /**
+     * This marker is emitted prior to the invocation of a signal handler,
+     * after the #TRACE_MARKER_TYPE_KERNEL_EVENT record for the handler.
+     * The marker value holds the signal number.
+     */
+    TRACE_MARKER_TYPE_SIGNAL_NUMBER,
 
     // ...
     // These values are reserved for future built-in marker types.

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -333,6 +333,9 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
                           << memref.marker.marker_value << std::dec << " to handler>\n";
             }
             break;
+        case TRACE_MARKER_TYPE_SIGNAL_NUMBER:
+            std::cerr << "<marker: signal #" << memref.marker.marker_value << ">\n";
+            break;
         case TRACE_MARKER_TYPE_RSEQ_ABORT:
             std::cerr << "<marker: rseq abort from 0x" << std::hex
                       << memref.marker.marker_value << std::dec << " to handler>\n";

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2010 Massachusetts Institute of Technology  All rights reserved.
  * ******************************************************************************/
 
@@ -1720,6 +1720,10 @@ event_kernel_xfer(void *drcontext, const dr_kernel_xfer_info_t *info)
     }
     BUF_PTR(data->seg_base) +=
         instru->append_marker(BUF_PTR(data->seg_base), marker_type, marker_val);
+    if (info->type == DR_XFER_SIGNAL_DELIVERY) {
+        BUF_PTR(data->seg_base) += instru->append_marker(
+            BUF_PTR(data->seg_base), TRACE_MARKER_TYPE_SIGNAL_NUMBER, info->sig);
+    }
     // Append a timestamp to provide more accurate timing information at point
     // of interest such as kernel-mediated control transfers like these.
     append_timestamp_and_cpu_marker(data);


### PR DESCRIPTION
Adds a new drmemtrace marker holding the signal number which is emitted after the kernel event marker.  It is not emitted at the signal return point; only at the transfer to the handler.

Does not add a feature bit or increase the version as this marker is considered optional and so no mechanism is provided for users to be guaranteed that it is present.

Adds view tool support.

Adds a test that the marker is emitted in the burst_gencode test. Output from the test's trace:
```
          52          32:     1616564 ifetch       2 byte(s) @ 0x00007f615935d023 0f 0b                ud2
          53          32:     1616564 <marker: kernel xfer from 0x7f615935d023 to handler>
          54          32:     1616564 <marker: signal #4>
          55          32:     1616564 <marker: timestamp 13365562571171519>
          56          32:     1616564 <marker: tid 1616564 on core 9>
          57          33:     1616564 ifetch       1 byte(s) @ 0x00005641b091170b 55                   push   %rbp
```

Fixes #6884