### PR TITLE
i#2417 AArch64: Fix drdecode test

### DIFF
--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -61,13 +61,17 @@ static void
 test_mov_instr_addr(void)
 {
 #if !defined(DR_HOST_NOT_TARGET)
+    const uint gencode_max_size = 1024;
+    byte *generated_code =
+        (byte *)allocate_mem(gencode_max_size, ALLOW_EXEC | ALLOW_READ | ALLOW_WRITE);
+
     instrlist_t *ilist = instrlist_create(GD);
     instr_t *callee = INSTR_CREATE_label(GD);
     instrlist_append(
         ilist,
         XINST_CREATE_move(GD, opnd_create_reg(DR_REG_X1), opnd_create_reg(DR_REG_LR)));
-    instrlist_insert_mov_instr_addr(GD, callee, (byte *)ilist, opnd_create_reg(DR_REG_X0),
-                                    ilist, NULL, NULL, NULL);
+    instrlist_insert_mov_instr_addr(GD, callee, generated_code,
+                                    opnd_create_reg(DR_REG_X0), ilist, NULL, NULL, NULL);
     instrlist_append(ilist, INSTR_CREATE_blr(GD, opnd_create_reg(DR_REG_X0)));
     instrlist_append(ilist, INSTR_CREATE_ret(GD, opnd_create_reg(DR_REG_X1)));
     instrlist_append(ilist, callee);
@@ -75,9 +79,6 @@ test_mov_instr_addr(void)
                                      NULL, NULL, NULL);
     instrlist_append(ilist, XINST_CREATE_return(GD));
 
-    uint gencode_max_size = 1024;
-    byte *generated_code =
-        (byte *)allocate_mem(gencode_max_size, ALLOW_EXEC | ALLOW_READ | ALLOW_WRITE);
     assert(generated_code != NULL);
     instrlist_encode(GD, ilist, generated_code, true);
     protect_mem(generated_code, gencode_max_size, ALLOW_EXEC | ALLOW_READ);


### PR DESCRIPTION
On AArch64 instrlist_insert_mov_instr_addr() uses a sequence of movz and movk instructions to, and uses the encode_estimate pointer to determine how many movk instructions will be needed.

The test api.drdecode was calling instrlist_insert_mov_instr_addr() with this ilist as the encode_estimate pointer which proved to be a bad estimate on some systems.

The system where I was testing had:
    ilist =          0x000000001a3b0380
    generated_code = 0x0000ffffb4fb0000
Each movz/movk instruction in the sequence encodes a 16-bit immediate so
3 instructions would be needed to move an address in the generated_code
buffer, but using the ilist pointer as an estimate we would only generate
2 and end up with a truncated address.

Now the test will allocate the buffer for the generated code up front so we can use the buffer pointer as an estimate instead.

Issue: #2417