### PR TITLE
i#2417 AArch64: Fix test on large cache line cpus

### DIFF
--- a/clients/drcachesim/tests/burst_aarch64_sys.cpp
+++ b/clients/drcachesim/tests/burst_aarch64_sys.cpp
@@ -64,7 +64,7 @@ namespace drmemtrace {
 static sigjmp_buf mark;
 static int handled_sigill_count = 0;
 
-#define TO_BE_ZEROED_ARR_SIZE 512
+#define TO_BE_ZEROED_ARR_SIZE 1024
 char to_be_zeroed[TO_BE_ZEROED_ARR_SIZE];
 
 void


### PR DESCRIPTION
tool.drcacheoff.burst_aarch64_sys fails with an assert on systems with 256-byte cache lines such as A64FX.

Issue: #2417