### PR TITLE
i#6897 sched file: Create drmemtace schedule file library

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -167,8 +167,9 @@ add_exported_library(drmemtrace_view STATIC tools/view.cpp)
 add_exported_library(drmemtrace_func_view STATIC tools/func_view.cpp)
 add_exported_library(drmemtrace_invariant_checker STATIC tools/invariant_checker.cpp)
 add_exported_library(drmemtrace_schedule_stats STATIC tools/schedule_stats.cpp)
+add_exported_library(drmemtrace_schedule_file STATIC common/schedule_file.cpp)
 
-target_link_libraries(drmemtrace_invariant_checker drdecode)
+target_link_libraries(drmemtrace_invariant_checker drdecode drmemtrace_schedule_file)
 
 configure_DynamoRIO_standalone(drmemtrace_opcode_mix)
 configure_DynamoRIO_standalone(drmemtrace_view)
@@ -231,7 +232,8 @@ if (libsnappy)
 endif ()
 add_exported_library(drmemtrace_raw2trace STATIC ${raw2trace_srcs})
 configure_DynamoRIO_standalone(drmemtrace_raw2trace)
-target_link_libraries(drmemtrace_raw2trace directory_iterator drfrontendlib)
+target_link_libraries(drmemtrace_raw2trace directory_iterator drfrontendlib
+  drmemtrace_schedule_file)
 use_DynamoRIO_extension(drmemtrace_raw2trace drutil_static)
 link_with_pthread(drmemtrace_raw2trace)
 if (libsnappy)
@@ -592,6 +594,7 @@ restore_nonclient_flags(drmemtrace_record_filter)
 restore_nonclient_flags(drmemtrace_analyzer)
 restore_nonclient_flags(drmemtrace_invariant_checker)
 restore_nonclient_flags(drmemtrace_schedule_stats)
+restore_nonclient_flags(drmemtrace_schedule_file)
 
 # We need to pass /EHsc and we pull in libcmtd into drcachesim from a dep lib.
 # Thus we need to override the /MT with /MTd.
@@ -658,6 +661,7 @@ add_win32_flags(drmemtrace_record_filter)
 add_win32_flags(drmemtrace_analyzer)
 add_win32_flags(drmemtrace_invariant_checker)
 add_win32_flags(drmemtrace_schedule_stats)
+add_win32_flags(drmemtrace_schedule_file)
 add_win32_flags(directory_iterator)
 add_win32_flags(test_helpers)
 if (WIN32 AND DEBUG)
@@ -935,6 +939,15 @@ if (BUILD_TESTS)
     add_test(NAME tool.drcachesim.invariant_checker_test
              COMMAND tool.drcachesim.invariant_checker_test)
     set_tests_properties(tool.drcachesim.invariant_checker_test PROPERTIES
+      TIMEOUT ${test_seconds})
+
+    add_executable(tool.drcachesim.schedule_file_test tests/schedule_file_test.cpp)
+    add_win32_flags(tool.drcachesim.schedule_file_test)
+    target_link_libraries(tool.drcachesim.schedule_file_test
+        drmemtrace_schedule_file test_helpers)
+    add_test(NAME tool.drcachesim.schedule_file_test
+             COMMAND tool.drcachesim.schedule_file_test)
+    set_tests_properties(tool.drcachesim.schedule_file_test PROPERTIES
       TIMEOUT ${test_seconds})
 
     add_executable(tool.drcachesim.schedule_stats_test tests/schedule_stats_test.cpp)

--- a/clients/drcachesim/common/schedule_file.cpp
+++ b/clients/drcachesim/common/schedule_file.cpp
@@ -66,7 +66,6 @@ schedule_file_t::per_shard_t::record_cpu_id(memref_tid_t tid, uint64_t cpuid,
     return "";
 }
 
-// Returns the uncollapsed record sequence.
 const std::vector<schedule_entry_t> &
 schedule_file_t::get_full_serial_records()
 {
@@ -74,7 +73,7 @@ schedule_file_t::get_full_serial_records()
         aggregate_schedule_data();
     return serial_;
 }
-// Returns the record sequence with consecutive-same-thread entries collapsed.
+
 const std::vector<schedule_entry_t> &
 schedule_file_t::get_serial_records()
 {
@@ -82,6 +81,7 @@ schedule_file_t::get_serial_records()
         aggregate_schedule_data();
     return serial_redux_;
 }
+
 const std::unordered_map<uint64_t, std::vector<schedule_entry_t>> &
 schedule_file_t::get_full_cpu_records()
 {

--- a/clients/drcachesim/common/schedule_file.cpp
+++ b/clients/drcachesim/common/schedule_file.cpp
@@ -114,8 +114,6 @@ schedule_file_t::aggregate_schedule_data()
 {
     if (aggregated_)
         return;
-    // N.B.: When changing this comparator, update the comparator in
-    // invariant_checker_t::check_schedule_data too.
     auto schedule_entry_comparator = [](const schedule_entry_t &l,
                                         const schedule_entry_t &r) {
         if (l.timestamp != r.timestamp)

--- a/clients/drcachesim/common/schedule_file.cpp
+++ b/clients/drcachesim/common/schedule_file.cpp
@@ -1,0 +1,217 @@
+/* **********************************************************
+ * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Produces schedule files that record the instruction counts at thread interleaving
+ * points.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "archive_ostream.h"
+#include "memref.h"
+#include "schedule_file.h"
+#include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+std::string
+schedule_file_t::per_shard_t::record_cpu_id(memref_tid_t tid, uint64_t cpuid,
+                                            uint64_t last_timestamp, uint64_t instr_count)
+{
+    schedule_entry_t new_entry(tid, last_timestamp, cpuid, instr_count);
+    // Avoid identical entries, which are common with the end of the
+    // previous buffer's timestamp followed by the start of the next.
+    if (sched_.empty() || sched_.back() != new_entry) {
+        sched_.emplace_back(tid, last_timestamp, cpuid, instr_count);
+    }
+    if (cpu2sched_[cpuid].empty() || cpu2sched_[cpuid].back() != new_entry) {
+        cpu2sched_[cpuid].emplace_back(tid, last_timestamp, cpuid, instr_count);
+    }
+    return "";
+}
+
+// Returns the uncollapsed record sequence.
+const std::vector<schedule_entry_t> &
+schedule_file_t::get_full_serial_records()
+{
+    if (!aggregated_)
+        aggregate_schedule_data();
+    return serial_;
+}
+// Returns the record sequence with consecutive-same-thread entries collapsed.
+const std::vector<schedule_entry_t> &
+schedule_file_t::get_serial_records()
+{
+    if (!aggregated_)
+        aggregate_schedule_data();
+    return serial_redux_;
+}
+const std::unordered_map<uint64_t, std::vector<schedule_entry_t>> &
+schedule_file_t::get_full_cpu_records()
+{
+    if (!aggregated_)
+        aggregate_schedule_data();
+    return cpu2sched_;
+}
+
+const std::unordered_map<uint64_t, std::vector<schedule_entry_t>> &
+schedule_file_t::get_cpu_records()
+{
+    if (!aggregated_)
+        aggregate_schedule_data();
+    return cpu2sched_redux_;
+}
+
+std::string
+schedule_file_t::merge_shard_data(const schedule_file_t::per_shard_t &shard)
+{
+    serial_.insert(serial_.end(), shard.sched_.begin(), shard.sched_.end());
+    for (auto &keyval : shard.cpu2sched_) {
+        auto &vec = cpu2sched_[keyval.first];
+        vec.insert(vec.end(), keyval.second.begin(), keyval.second.end());
+    }
+    return "";
+}
+
+void
+schedule_file_t::aggregate_schedule_data()
+{
+    if (aggregated_)
+        return;
+    // N.B.: When changing this comparator, update the comparator in
+    // invariant_checker_t::check_schedule_data too.
+    auto schedule_entry_comparator = [](const schedule_entry_t &l,
+                                        const schedule_entry_t &r) {
+        if (l.timestamp != r.timestamp)
+            return l.timestamp < r.timestamp;
+        if (l.cpu != r.cpu)
+            return l.cpu < r.cpu;
+        // We really need to sort by either (timestamp, cpu_id,
+        // start_instruction) or (timestamp, thread_id, start_instruction): a
+        // single thread cannot be on two CPUs at the same timestamp; also a
+        // single CPU cannot have two threads at the same timestamp. We still
+        // sort by (timestamp, cpu_id, thread_id, start_instruction) to prevent
+        // inadvertent issues with test data.
+        if (l.thread != r.thread)
+            return l.thread < r.thread;
+        // We need to consider the start_instruction since it is possible to
+        // have two entries with the same timestamp, cpu_id, and thread_id.
+        return l.start_instruction < r.start_instruction;
+    };
+
+    std::sort(serial_.begin(), serial_.end(), schedule_entry_comparator);
+    // Collapse same-thread entries.
+    for (const auto &entry : serial_) {
+        if (serial_redux_.empty() || entry.thread != serial_redux_.back().thread)
+            serial_redux_.push_back(entry);
+    }
+    for (auto &keyval : cpu2sched_) {
+        std::sort(keyval.second.begin(), keyval.second.end(), schedule_entry_comparator);
+        // Collapse same-thread entries.
+        std::vector<schedule_entry_t> redux;
+        for (const auto &entry : keyval.second) {
+            if (redux.empty() || entry.thread != redux.back().thread)
+                redux.push_back(entry);
+        }
+        cpu2sched_redux_[keyval.first] = redux;
+    }
+    aggregated_ = true;
+}
+
+std::string
+schedule_file_t::write_serial_file(std::ostream *out)
+{
+    if (out == nullptr)
+        return "Output stream is null";
+    if (!aggregated_)
+        aggregate_schedule_data();
+    if (!out->write(reinterpret_cast<const char *>(serial_redux_.data()),
+                    serial_redux_.size() * sizeof(serial_redux_[0])))
+        return "Failed to write to serial schedule file";
+    return "";
+}
+
+std::string
+schedule_file_t::write_cpu_file(archive_ostream_t *out)
+{
+    if (out == nullptr)
+        return "Output archive stream is null";
+    if (!aggregated_)
+        aggregate_schedule_data();
+    for (auto &keyval : cpu2sched_redux_) {
+        std::ostringstream stream;
+        stream << keyval.first;
+        std::string err = out->open_new_component(stream.str());
+        if (!err.empty())
+            return err;
+        if (!out->write(reinterpret_cast<const char *>(keyval.second.data()),
+                        keyval.second.size() * sizeof(keyval.second[0])))
+            return "Failed to write to cpu schedule file";
+    }
+    return "";
+}
+
+std::string
+schedule_file_t::read_serial_file(std::istream *in)
+{
+    serial_.clear();
+    serial_redux_.clear();
+    schedule_entry_t next(0, 0, 0, 0);
+    while (in->read(reinterpret_cast<char *>(&next), sizeof(next))) {
+        serial_.push_back(next);
+    }
+    return "";
+}
+
+std::string
+schedule_file_t::read_cpu_file(std::istream *in)
+{
+    cpu2sched_.clear();
+    cpu2sched_redux_.clear();
+    // The zipfile reader will form a continuous stream from all elements in the
+    // archive.  We figure out which cpu each one is from on the fly.
+    schedule_entry_t next(0, 0, 0, 0);
+    while (in->read(reinterpret_cast<char *>(&next), sizeof(next))) {
+        cpu2sched_[next.cpu].push_back(next);
+    }
+    return "";
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/common/schedule_file.h
+++ b/clients/drcachesim/common/schedule_file.h
@@ -1,0 +1,117 @@
+/* **********************************************************
+ * Copyright (c) 2024 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* schedule_file_t: support for creating, sorting, writing, and reading
+ * schedule files of schedule_entry_t records.
+ */
+
+#ifndef _SCHEDULE_FILE_H_
+#define _SCHEDULE_FILE_H_ 1
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "archive_ostream.h"
+#include "memref.h"
+#include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+// Usage: add an instance of schedule_file_t::per_shard_t to each shard.
+// When a TRACE_MARKER_TYPE_CPU_ID record is encountered, call
+// record_cpu_id on that instance.
+// At aggregation time, use an instance of schedule_file_t andloop over the
+// shards calling merge_shard_data().  Now that instance can be written
+// out to a file.
+// Alternatively, use the read_* routines to read into an instane.
+
+class schedule_file_t {
+public:
+    class per_shard_t {
+    public:
+        std::string
+        record_cpu_id(memref_tid_t tid, uint64_t cpuid, uint64_t last_timestamp,
+                      uint64_t instr_count);
+
+    private:
+        friend class schedule_file_t;
+        std::vector<schedule_entry_t> sched_;
+        std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched_;
+    };
+
+    std::string
+    merge_shard_data(const per_shard_t &shard);
+
+    std::string
+    write_serial_file(std::ostream *out);
+
+    std::string
+    write_cpu_file(archive_ostream_t *out);
+
+    std::string
+    read_serial_file(std::istream *in);
+
+    std::string
+    read_cpu_file(std::istream *in);
+
+    // Returns the uncollapsed record sequence.
+    const std::vector<schedule_entry_t> &
+    get_full_serial_records();
+    // Returns the record sequence with consecutive-same-thread entries collapsed.
+    const std::vector<schedule_entry_t> &
+    get_serial_records();
+    const std::unordered_map<uint64_t, std::vector<schedule_entry_t>> &
+    get_full_cpu_records();
+    const std::unordered_map<uint64_t, std::vector<schedule_entry_t>> &
+    get_cpu_records();
+
+private:
+    void
+    aggregate_schedule_data();
+
+    // Some uses cases want both a version with all entries and one with collapsed
+    // consecutive-same-thread entries.  We assume the extra size is not significant.
+    std::vector<schedule_entry_t> serial_;
+    std::vector<schedule_entry_t> serial_redux_;
+    std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched_;
+    std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched_redux_;
+    bool aggregated_ = false;
+};
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _SCHEDULE_FILE_H_ */

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -284,7 +284,7 @@ protected:
     // produces an EOF object.
     bool eof_ = true;
 
-private:
+protected:
     uint64_t cur_ref_count_ = 0;
     uint64_t cur_instr_count_ = 0;
     uint64_t last_timestamp_ = 0;

--- a/clients/drcachesim/tests/schedule_file_test.cpp
+++ b/clients/drcachesim/tests/schedule_file_test.cpp
@@ -1,0 +1,144 @@
+/* **********************************************************
+ * Copyright (c) 2021-2024 Google, LLC  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, LLC OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Unit tests for the schedule_file_t library. */
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "memref.h"
+#include "schedule_file.h"
+#include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+bool
+check_read_and_collapse()
+{
+    std::cerr << "Testing reading and collapsing\n";
+    // Synthesize a serial schedule file.
+    // For now we leave the cpu-schedule testing to the end-to-end tests
+    // of users of the library like raw2trace and invariant_checker.
+    static constexpr uint64_t TIMESTAMP_BASE = 100;
+    static constexpr int CPU_BASE = 6;
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr memref_tid_t TID_B = 43;
+    static constexpr memref_tid_t TID_C = 44;
+    std::vector<schedule_entry_t> records;
+    records.emplace_back(TID_A, TIMESTAMP_BASE, CPU_BASE, 0);
+    // Include same-timestamp records to stress handling that.
+    records.emplace_back(TID_C, TIMESTAMP_BASE, CPU_BASE + 1, 0);
+    records.emplace_back(TID_B, TIMESTAMP_BASE, CPU_BASE + 2, 0);
+    records.emplace_back(TID_A, TIMESTAMP_BASE + 1, CPU_BASE + 1, 2);
+    records.emplace_back(TID_B, TIMESTAMP_BASE + 2, CPU_BASE, 1);
+    // Include records with the same thread ID, timestamp, and CPU, but
+    // different start_instruction.
+    records.emplace_back(TID_C, TIMESTAMP_BASE + 3, CPU_BASE + 2, 3);
+    records.emplace_back(TID_C, TIMESTAMP_BASE + 3, CPU_BASE + 2, 4);
+
+    std::ostringstream ostream;
+    for (const auto &record : records) {
+        std::string as_string(reinterpret_cast<const char *>(&record), sizeof(record));
+        ostream << as_string;
+    }
+    std::istringstream istream(ostream.str());
+
+    schedule_file_t sched;
+    std::string res = sched.read_serial_file(&istream);
+    assert(res.empty());
+
+    const std::vector<schedule_entry_t> &serial = sched.get_full_serial_records();
+    const std::vector<schedule_entry_t> &serial_redux = sched.get_serial_records();
+    assert(serial.size() == records.size());
+    for (size_t i = 0; i < serial.size(); ++i) {
+        assert(memcmp(&serial[i], &records[i], sizeof(serial[i])) == 0);
+    }
+    // We have one identical-thread record that will collapse.
+    assert(serial_redux.size() == records.size() - 1);
+    return true;
+}
+
+bool
+check_aggregate()
+{
+    std::cerr << "Testing aggregation\n";
+    static constexpr uint64_t TIMESTAMP_BASE = 100;
+    static constexpr int CPU_X = 6;
+    static constexpr int CPU_Y = 7;
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr memref_tid_t TID_B = 43;
+
+    schedule_file_t::per_shard_t shardA;
+    shardA.record_cpu_id(TID_A, CPU_X, TIMESTAMP_BASE + 0, 0);
+    shardA.record_cpu_id(TID_A, CPU_X, TIMESTAMP_BASE + 20, 4);
+    shardA.record_cpu_id(TID_A, CPU_X, TIMESTAMP_BASE + 40, 8);
+    schedule_file_t::per_shard_t shardB;
+    shardB.record_cpu_id(TID_B, CPU_Y, TIMESTAMP_BASE + 10, 0);
+    shardB.record_cpu_id(TID_B, CPU_Y, TIMESTAMP_BASE + 30, 4);
+    shardB.record_cpu_id(TID_B, CPU_Y, TIMESTAMP_BASE + 50, 8);
+
+    schedule_file_t merged;
+    merged.merge_shard_data(shardA);
+    merged.merge_shard_data(shardB);
+
+    const std::vector<schedule_entry_t> &serial = merged.get_full_serial_records();
+    assert(serial.size() == 6);
+    uint64_t last_timestamp = 0;
+    for (size_t i = 0; i < serial.size(); ++i) {
+        assert(serial[i].timestamp >= last_timestamp);
+        last_timestamp = serial[i].timestamp;
+        if (i % 2 == 0)
+            assert(serial[i].thread == TID_A);
+        else
+            assert(serial[i].thread == TID_B);
+    }
+    return true;
+}
+
+int
+test_main(int argc, const char *argv[])
+{
+    if (check_read_and_collapse() && check_aggregate()) {
+        std::cerr << "schedule_file_t tests passed\n";
+        return 0;
+    }
+    std::cerr << "schedule_file_t tests FAILED\n";
+    exit(1);
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -51,6 +51,7 @@
 #include "dr_api.h"
 #include "memref.h"
 #include "memtrace_stream.h"
+#include "schedule_file.h"
 #include "trace_entry.h"
 
 namespace dynamorio {
@@ -216,8 +217,7 @@ protected:
         uint64_t instr_count_ = 0;
         uint64_t last_timestamp_ = 0;
         uint64_t instr_count_since_last_timestamp_ = 0;
-        std::vector<schedule_entry_t> sched_;
-        std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched_;
+        schedule_file_t::per_shard_t sched_data_;
         bool skipped_instrs_ = false;
         // Rseq region state.
         bool in_rseq_region_ = false;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -71,6 +71,7 @@
 #include "raw2trace_shared.h"
 #include "reader.h"
 #include "record_file_reader.h"
+#include "schedule_file.h"
 #include "trace_entry.h"
 #include "utils.h"
 #ifdef BUILD_PT_POST_PROCESSOR
@@ -1051,8 +1052,7 @@ protected:
         bitset_hash_table_t<app_pc> encoding_emitted;
         app_pc last_encoding_emitted = nullptr;
 
-        std::vector<schedule_entry_t> sched;
-        std::unordered_map<uint64_t, std::vector<schedule_entry_t>> cpu2sched;
+        schedule_file_t::per_shard_t sched_data;
 
         // State for rolling back rseq aborts and side exits.
         bool rseq_want_rollback_ = false;


### PR DESCRIPTION
Refactors the raw2trace and invariant_checker code dealing with schedule files into a common "schedule_file" library.

Adds some unit tests for the library.

Issue: #6897