### PR TITLE
i#6913: Enable syscall stats in func_view

### DIFF
--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -140,7 +140,6 @@ func_view_t::parallel_shard_init_stream(int shard_index, void *worker_data,
     auto shard_data = new shard_data_t;
     std::lock_guard<std::mutex> guard(shard_map_mutex_);
     shard_data->tid = stream->get_tid();
-    shard_data->filetype = stream->get_filetype();
     shard_map_[shard_index] = shard_data;
     return shard_data;
 }
@@ -211,9 +210,6 @@ func_view_t::process_memref(const memref_t &memref)
     const auto &lookup = shard_map_.find(shard_index);
     if (lookup == shard_map_.end()) {
         shard = new shard_data_t;
-        // Adds support for printing SYS_futex "returns" statistics in
-        // OFFLINE_FILE_TYPE_ARCH_REGDEPS traces even with -show_func_trace set.
-        shard->filetype = serial_stream_->get_filetype();
         shard_map_[shard_index] = shard;
     } else
         shard = lookup->second;

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -93,7 +93,6 @@ protected:
     };
     struct shard_data_t {
         memref_tid_t tid = 0; // We only support SHARD_BY_THREAD.
-        uint64_t filetype = OFFLINE_FILE_TYPE_DEFAULT;
         std::unordered_map<int, func_stats_t> func_map;
         std::string error;
         // We use the function markers to record arguments and return

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -93,6 +93,7 @@ protected:
     };
     struct shard_data_t {
         memref_tid_t tid = 0; // We only support SHARD_BY_THREAD.
+        uint64_t filetype;
         std::unordered_map<int, func_stats_t> func_map;
         std::string error;
         // We use the function markers to record arguments and return

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -93,7 +93,7 @@ protected:
     };
     struct shard_data_t {
         memref_tid_t tid = 0; // We only support SHARD_BY_THREAD.
-        uint64_t filetype;
+        uint64_t filetype = OFFLINE_FILE_TYPE_DEFAULT;
         std::unordered_map<int, func_stats_t> func_map;
         std::string error;
         // We use the function markers to record arguments and return


### PR DESCRIPTION
The func_view tool does not print "call" and "return" statistics for system calls.
We add support to do so for system calls that are present in funclist.log in the
trace directory.
The file funclist.log contains one entry per line that looks like the following example:
4294967498,6,,SYS_futex (= ID, #args, *unused*, name)

We further constrain func_view to print the call-graph and call/return statistics only
for the functions present in funclist.log.

Tested manually, as adding funclist.log to a trace in suite/test/CMakeLists.txt
doesn't seem trivial and adding complexity to it doesn't seem worth it for this
change.

Fixes: #6913