### PR TITLE
Add triager docs on moderating the user list

### DIFF
--- a/api/docs/triager.dox
+++ b/api/docs/triager.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -42,6 +42,17 @@ We have a rotating Triager who is responsible for monitoring our continuous test
   - File an issue on previously-unknown failures, or update existing issues for repeats.  Consider marking tests as flaky in `runsuite_wrapper.pl` if they are keeping the master merge red.
 - Answer (or request that someone else who is more of an expert in that area answer) incoming dynamorio-users emails.
   - Sometimes emails to the list are marked as spam, so it is a good idea to directly watch the web interface: https://groups.google.com/g/DynamoRIO-Users
+- Moderate dynamorio-users emails from new users.  First, ensure that you are a member of
+  the dynamorio-users list and your role is Manager at
+  https://groups.google.com/g/dynamorio-users/members.  You will then receive an email
+  whenever a message is sent from a user who has never posted before.  Such a message
+  stays pending at https://groups.google.com/g/dynamorio-users/pending-messages until it
+  is approved or rejected.  Generally, we allow all future messages from a user when the
+  first message sent is legitimate.  At the pending message page, expand the message to
+  examine it.  Click the checkbox next to it, which enables the top buttons.  If the
+  message is spam, click "Report spam and ban author"; if it is not spam, click "Post and
+  always allow".  We generally do not use the single-message reject or allow buttons.
+  Once it is posted it will show up in the list and can be replied to there.
 - Triage reviewing pull requests filed by users
   - Make sure you receive notifications on such requests: see the issues item below on how to set that up.  Alternatively, proactively monitor the pull request list through the web site.
 - Triage issues filed by users in our issue tracker.


### PR DESCRIPTION
Adds docs to the triager page https://dynamorio.org/page_triager.html on moderating messages sent to the users list from first-time posters.