### PR TITLE
i#6913: Eliminate unsafe accesses in func_view

### DIFF
--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -228,7 +228,7 @@ func_view_t::process_memref(const memref_t &memref)
     } else
         shard = lookup->second;
     if (!process_memref_for_markers(shard, memref))
-      return false;
+        return false;
     if (!knob_full_trace_)
         return true;
     if (memref.data.type == TRACE_TYPE_THREAD_EXIT && shard->prev_was_arg) {
@@ -366,7 +366,7 @@ func_view_t::get_info_for_last_func_id(shard_data_t *shard)
     assert(shard != nullptr);
     int id = shard->last_func_id;
     assert(id != -1);
-    const auto& it = id2info_.find(id);
+    const auto &it = id2info_.find(id);
     if (it != id2info_.end())
         return it->second;
     // We don't have information on id, so set the error string.

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -119,8 +119,8 @@ func_view_t::initialize_stream(memtrace_stream_t *serial_stream)
             auto& info = id2info_[id];
             info.names.insert(entry.back());
             if (info.num_args != num_args) {
-                return "Warning: Inconsistent argument details for function ID " +
-                    std::to_string(id);
+                return "Inconsistent argument details for function ID " +
+                    std::to_string(id) + " in " + funclist_file_path_;
             }
             continue;
         }

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -116,7 +116,7 @@ func_view_t::initialize_stream(memtrace_stream_t *serial_stream)
         // If multiple syms have the same id, the args, noret, etc. come from
         // the first one.
         if (id2info_.find(id) != id2info_.end()) {
-            auto& info = id2info_[id];
+            auto &info = id2info_[id];
             info.names.insert(entry.back());
             if (info.num_args != num_args) {
                 return "Inconsistent argument details for function ID " +
@@ -213,7 +213,7 @@ func_view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     if (memref.marker.type != TRACE_TYPE_MARKER)
         return true;
     process_memref_for_markers(shard, memref);
-    return shard->error.empty();  // An error message means there was a problem.
+    return shard->error.empty(); // An error message means there was a problem.
 }
 
 bool
@@ -359,19 +359,19 @@ func_view_t::print_results()
 }
 
 func_view_t::traced_info_t &
-func_view_t::get_info_for_last_func_id(shard_data_t* shard) {
-  assert(shard != nullptr);
-  int id = shard->last_func_id;
-  assert(id != -1);
-  traced_info_t& info = id2info_[id];
-  // If this entry is uninitialized, it means we aren't expecting to see this
-  // function ID.  This likely means the funclist file is missing or incorrect.
-  if (info.num_args < 0 || info.names.empty()) {
-    shard->error = "Encountered unknown function ID=" + std::to_string(id);
-  }
-  return info;
+func_view_t::get_info_for_last_func_id(shard_data_t *shard)
+{
+    assert(shard != nullptr);
+    int id = shard->last_func_id;
+    assert(id != -1);
+    traced_info_t &info = id2info_[id];
+    // If this entry is uninitialized, it means we aren't expecting to see this
+    // function ID.  This likely means the funclist file is missing or incorrect.
+    if (info.num_args < 0 || info.names.empty()) {
+        shard->error = "Encountered unknown function ID=" + std::to_string(id);
+    }
+    return info;
 }
-
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -119,8 +119,8 @@ func_view_t::initialize_stream(memtrace_stream_t *serial_stream)
             auto& info = id2info_[id];
             info.names.insert(entry.back());
             if (info.num_args != num_args) {
-              std::cerr << "Warning: Inconsistent argument details for function ID "
-                        << std::to_string(id) << ".\n";
+                return "Warning: Inconsistent argument details for function ID " +
+                    std::to_string(id);
             }
             continue;
         }

--- a/clients/drcachesim/tools/func_view.cpp
+++ b/clients/drcachesim/tools/func_view.cpp
@@ -238,11 +238,11 @@ func_view_t::process_memref(const memref_t &memref)
         const auto &info = id2info_[shard->last_func_id];
         bool was_nested = shard->nesting_level > 0;
         if (shard->prev_noret) {
-          if (was_nested) {
-            --shard->nesting_level;
-          } else {
-            std::cerr << "WARNING: Unnested FUNC_RETADDR\n";
-          }
+            if (was_nested) {
+                --shard->nesting_level;
+            } else {
+                std::cerr << "WARNING: Unnested FUNC_RETADDR\n";
+            }
         }
         // Print a "Tnnn" prefix so threads can be distinguished.
         std::cerr << ((was_nested && shard->prev_was_arg) ? "\n" : "") << "T" << std::dec
@@ -276,9 +276,9 @@ func_view_t::process_memref(const memref_t &memref)
     }
     case TRACE_MARKER_TYPE_FUNC_RETVAL: {
         if (shard->nesting_level > 0) {
-          --shard->nesting_level;
+            --shard->nesting_level;
         } else {
-          std::cerr << "WARNING: Unnested FUNC_RETVAL\n";
+            std::cerr << "WARNING: Unnested FUNC_RETVAL\n";
         }
         if (!shard->prev_was_arg) {
             std::cerr

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -111,11 +111,16 @@ protected:
         std::string last_trace_module_name;
     };
     struct traced_info_t {
-        int id = -1;
         std::set<std::string> names;
-        int num_args = 0;
+        int num_args = -1;  // Illegal value to mark uninitialized info structs.
         bool noret = false;
     };
+
+    // Lookup the information for the shard's last_func_id and return its traced_info_t
+    // struct.  Sets shard.error if the ID is not found (but still returns a traced_info_t
+    // reference).
+    traced_info_t &
+    get_info_for_last_func_id(shard_data_t* shard);
 
     static bool
     cmp_func_stats(const std::pair<int, func_stats_t> &l,

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -112,7 +112,7 @@ protected:
     };
     struct traced_info_t {
         std::set<std::string> names;
-        int num_args = -1;  // Illegal value to mark uninitialized info structs.
+        int num_args = -1; // Illegal value to mark uninitialized info structs.
         bool noret = false;
     };
 
@@ -120,7 +120,7 @@ protected:
     // struct.  Sets shard.error if the ID is not found (but still returns a traced_info_t
     // reference).
     traced_info_t &
-    get_info_for_last_func_id(shard_data_t* shard);
+    get_info_for_last_func_id(shard_data_t *shard);
 
     static bool
     cmp_func_stats(const std::pair<int, func_stats_t> &l,

--- a/clients/drcachesim/tools/func_view.h
+++ b/clients/drcachesim/tools/func_view.h
@@ -125,7 +125,8 @@ protected:
     static bool
     cmp_func_stats(const std::pair<int, func_stats_t> &l,
                    const std::pair<int, func_stats_t> &r);
-    void
+    // Process markers, return true on success.
+    bool
     process_memref_for_markers(void *shard_data, const memref_t &memref);
     std::unordered_map<int, func_stats_t>
     compute_totals();


### PR DESCRIPTION
While debugging a malformed trace, I hit multiple crashes in func_view. This update eliminates two causes of these crashes: situations that would previously decrement the nesting level below zero now print warnings instead, and any function IDs encountered in the trace that don't have a matching funclist.log entry are reported as an error.

Fixes: #6913