### PR TITLE
i6909: Handle libelftc separately in cmake files

### DIFF
--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -431,16 +431,21 @@ if (NOT DynamoRIO_INTERNAL)
   endif ()
 
   # if we were built w/ static drsyms, clients need dependent static libs too
-  if (UNIX AND EXISTS "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libdwarf.a")
-    add_library(elf STATIC IMPORTED)
-    set_property(TARGET elf PROPERTY
-      IMPORTED_LOCATION "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libelf.a")
-    add_library(dwarf STATIC IMPORTED)
-    set_property(TARGET dwarf PROPERTY
-      IMPORTED_LOCATION "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libdwarf.a")
-    add_library(elftc STATIC IMPORTED)
-    set_property(TARGET elftc PROPERTY
-      IMPORTED_LOCATION "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libelftc.a")
+  if (UNIX)
+    # i#6909: Handle libelftc separately because libdwarf and libelf are optional.
+    if (EXISTS "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libelftc.a")
+      add_library(elftc STATIC IMPORTED)
+      set_property(TARGET elftc PROPERTY
+        IMPORTED_LOCATION "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libelftc.a")
+    endif()
+    if (EXISTS "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libdwarf.a")
+      add_library(elf STATIC IMPORTED)
+      set_property(TARGET elf PROPERTY
+        IMPORTED_LOCATION "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libelf.a")
+      add_library(dwarf STATIC IMPORTED)
+      set_property(TARGET dwarf PROPERTY
+        IMPORTED_LOCATION "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/libdwarf.a")
+    endif ()
   endif ()
   if (WIN32 AND EXISTS "${DynamoRIO_cwd}/../ext/lib${_DR_bits}/${_DR_type}/dwarf.lib")
     add_library(dwarf STATIC IMPORTED)


### PR DESCRIPTION
After switching to the elfutils submodule, libraries libelf and libdwarf became optional. Static library libelftc is still required to be linked, so in cmake files there must be a separate check for it.

The issue appears when building an external DynamoRIO client.

Issue: #6909