### PR TITLE
i#6921: Fix heap allocation on latest Linux kernel

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3480,7 +3480,7 @@ os_heap_reserve(void *preferred, size_t size, heap_error_code_t *error_code,
     if (executable)
         os_flags |= MAP_JIT;
 #endif
-#ifdef LINUX
+#if defined(LINUX) && !defined(ANDROID)
     if (preferred != NULL) {
         /* We fail if we don't get the preferred address, so we use the 4.17+
          * fixed-but-no-clobber flag to ensure the kernel actually tries for our hint.
@@ -3493,7 +3493,7 @@ os_heap_reserve(void *preferred, size_t size, heap_error_code_t *error_code,
      * system and pages aren't actually committed until we touch them.
      */
     p = mmap_syscall(preferred, size, prot, os_flags, -1, 0);
-#ifdef LINUX
+#if defined(LINUX) && !defined(ANDROID)
     if (preferred != NULL && p == (void *)(-EINVAL)) {
         /* We're probably on an old pre-4.17 kernel.
          * We could have a global var but we live w/ doing this every time.

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -3480,11 +3480,30 @@ os_heap_reserve(void *preferred, size_t size, heap_error_code_t *error_code,
     if (executable)
         os_flags |= MAP_JIT;
 #endif
+#ifdef LINUX
+    if (preferred != NULL) {
+        /* We fail if we don't get the preferred address, so we use the 4.17+
+         * fixed-but-no-clobber flag to ensure the kernel actually tries for our hint.
+         */
+        os_flags |= MAP_FIXED_NOREPLACE;
+    }
+#endif
 
-    /* FIXME: note that this memory is in fact still committed - see man mmap */
-    /* FIXME: case 2347 on Linux or -vm_reserve should be set to false */
-    /* FIXME: Need to actually get a mmap-ing with |MAP_NORESERVE */
+    /* We could try for |MAP_NORESERVE but usually overcommit is set on the
+     * system and pages aren't actually committed until we touch them.
+     */
     p = mmap_syscall(preferred, size, prot, os_flags, -1, 0);
+#ifdef LINUX
+    if (preferred != NULL && p == (void *)(-EINVAL)) {
+        /* We're probably on an old pre-4.17 kernel.
+         * We could have a global var but we live w/ doing this every time.
+         */
+        SYSLOG_INTERNAL_WARNING_ONCE(
+            "Got EINVAL on mmap: removing MAP_FIXED_NOREPLACE\n");
+        os_flags &= ~MAP_FIXED_NOREPLACE;
+        p = mmap_syscall(preferred, size, prot, os_flags, -1, 0);
+    }
+#endif
     if (!mmap_syscall_succeeded(p)) {
         *error_code = -(heap_error_code_t)(ptr_int_t)p;
         LOG(GLOBAL, LOG_HEAP, 4, "os_heap_reserve %d bytes failed " PFX "\n", size, p);
@@ -3497,8 +3516,8 @@ os_heap_reserve(void *preferred, size_t size, heap_error_code_t *error_code,
         os_heap_free(p, size, &dummy);
         ASSERT(dummy == HEAP_ERROR_SUCCESS);
         LOG(GLOBAL, LOG_HEAP, 4,
-            "os_heap_reserve %d bytes at " PFX " not preferred " PFX "\n", size,
-            preferred, p);
+            "os_heap_reserve %d bytes at " PFX " not preferred " PFX "\n", size, p,
+            preferred);
         return NULL;
     } else {
         *error_code = HEAP_ERROR_SUCCESS;
@@ -3564,7 +3583,8 @@ os_heap_reserve_in_region(void *start, void *end, size_t size,
         end);
 
     /* if no restriction on location use regular os_heap_reserve() */
-    if (start == (void *)PTR_UINT_0 && end == (void *)POINTER_MAX)
+    if (start == (void *)PTR_UINT_0 &&
+        end == (void *)ALIGN_BACKWARD(POINTER_MAX, PAGE_SIZE))
         return os_heap_reserve(NULL, size, error_code, executable);
 
         /* loop to handle races */


### PR DESCRIPTION
Fixes 3 problems hit on recent Linux kernels where our mmap hints are being ignored:

1) os_heap_reserve_in_region()'s POINTER_MAX check fails as the end is aligned,
   causing an unnecessary bounded-region search.

2) vmm_place_vmcode() tries smaller sizes on failure but does not propagate
   the new size to the caller, resulting in memory corruption.

3) os_heap_reserve() for Linux now uses the new-ish MAP_FIXED_NOREPLACE
   to get the behavior various code expects without risk of clobbering.

Tested on a 6.7.12 kernel where raw2trace failed up front reliably without these fixes but now succeeds.

Further tested the size propagation with the other fixes disabled and now we have a graceful failure instead of memory corruption and a weird crash:

```
$ clients/bin64/drmemtrace_launcher -indir drmemtrace.*.dir
<Full size vmm heap allocation failed>
<Application <path>/clients/bin64/drmemtrace_launcher (3686844).  Out of memory.  Program aborted.  Source I, type 0x0000000000000001, code 0x0000000000000001.>
```

Fixes #6921