### PR TITLE
i#6921 preferred mmap: Ensure MAP_FIXED_NOREPLACE is always defined

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -60,6 +60,9 @@
 #ifndef MAP_ANONYMOUS
 #    define MAP_ANONYMOUS MAP_ANON /* MAP_ANON on Mac */
 #endif
+#ifndef MAP_FIXED_NOREPLACE
+#    define MAP_FIXED_NOREPLACE 0x100000
+#endif
 /* for open */
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
Define MAP_FIXED_NOREPLACE if it isn't provided by the system headers, as it is not always available.

Issue: #6921