### PR TITLE
i#6685 core-shard: Add only_shards drmemtrace filter

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <set>
 #include <string>
 #include <thread>
 #include <utility>
@@ -228,7 +229,8 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t()
 template <typename RecordType, typename ReaderType>
 bool
 analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
-    const std::string &trace_path, memref_tid_t only_thread, int verbosity,
+    const std::string &trace_path, const std::set<memref_tid_t> &only_threads,
+    const std::set<int> &only_shards, int verbosity,
     typename sched_type_t::scheduler_options_t options)
 {
     verbosity_ = verbosity;
@@ -245,9 +247,8 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
         regions.emplace_back(skip_instrs_ + 1, 0);
     }
     typename sched_type_t::input_workload_t workload(trace_path, regions);
-    if (only_thread != INVALID_THREAD_ID) {
-        workload.only_threads.insert(only_thread);
-    }
+    workload.only_threads = only_threads;
+    workload.only_shards = only_shards;
     if (regions.empty() && skip_to_timestamp_ > 0) {
         workload.times_of_interest.emplace_back(skip_to_timestamp_, 0);
     }
@@ -369,7 +370,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t(
     // The scheduler will call reader_t::init() for each input file.  We assume
     // that won't block (analyzer_multi_t separates out IPC readers).
     typename sched_type_t::scheduler_options_t sched_ops;
-    if (!init_scheduler(trace_path, INVALID_THREAD_ID, verbosity, std::move(sched_ops))) {
+    if (!init_scheduler(trace_path, {}, {}, verbosity, std::move(sched_ops))) {
         success_ = false;
         error_string_ = "Failed to create scheduler";
         return;

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -219,6 +219,7 @@ protected:
 
     bool
     init_scheduler(const std::string &trace_path,
+                   // To include all threads/shards, use empty sets.
                    const std::set<memref_tid_t> &only_threads,
                    const std::set<int> &only_shards, int verbosity,
                    typename sched_type_t::scheduler_options_t options);

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -47,6 +47,7 @@
 
 #include <iterator>
 #include <memory>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -216,9 +217,10 @@ protected:
         operator=(const analyzer_worker_data_t &) = delete;
     };
 
-    // Pass INVALID_THREAD_ID for only_thread to include all threads.
     bool
-    init_scheduler(const std::string &trace_path, memref_tid_t only_thread, int verbosity,
+    init_scheduler(const std::string &trace_path,
+                   const std::set<memref_tid_t> &only_threads,
+                   const std::set<int> &only_shards, int verbosity,
                    typename sched_type_t::scheduler_options_t options);
 
     // For core-sharded, worker_count_ must be set prior to calling this; for parallel

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -347,6 +347,34 @@ record_analyzer_multi_t::create_analysis_tool_from_options(const std::string &to
  */
 
 template <typename RecordType, typename ReaderType>
+std::string
+analyzer_multi_tmpl_t<RecordType, ReaderType>::set_input_limit(
+    std::set<memref_tid_t> &only_threads, std::set<int> &only_shards)
+{
+    bool valid_limit = true;
+    if (op_only_thread.get_value() != 0) {
+        if (!op_only_threads.get_value().empty() || !op_only_shards.get_value().empty())
+            valid_limit = false;
+        only_threads.insert(op_only_thread.get_value());
+    } else if (!op_only_threads.get_value().empty()) {
+        if (!op_only_shards.get_value().empty())
+            valid_limit = false;
+        std::vector<std::string> tids = split_by(op_only_threads.get_value(), ",");
+        for (const std::string &tid : tids) {
+            only_threads.insert(strtol(tid.c_str(), nullptr, 10));
+        }
+    } else if (!op_only_shards.get_value().empty()) {
+        std::vector<std::string> tids = split_by(op_only_shards.get_value(), ",");
+        for (const std::string &tid : tids) {
+            only_shards.insert(strtol(tid.c_str(), nullptr, 10));
+        }
+    }
+    if (!valid_limit)
+        return "Only one of -only_thread, -only_threads, and -only_shards can be set.";
+    return "";
+}
+
+template <typename RecordType, typename ReaderType>
 analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
 {
     this->worker_count_ = op_jobs.get_value();
@@ -457,7 +485,16 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
     if (!op_indir.get_value().empty()) {
         std::string tracedir =
             raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
-        if (!this->init_scheduler(tracedir, op_only_thread.get_value(),
+
+        std::set<memref_tid_t> only_threads;
+        std::set<int> only_shards;
+        std::string res = set_input_limit(only_threads, only_shards);
+        if (!res.empty()) {
+            this->success_ = false;
+            this->error_string_ = res;
+            return;
+        }
+        if (!this->init_scheduler(tracedir, only_threads, only_shards,
                                   op_verbose.get_value(), std::move(sched_ops)))
             this->success_ = false;
     } else if (op_infile.get_value().empty()) {
@@ -479,9 +516,8 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
         }
     } else {
         // Legacy file.
-        if (!this->init_scheduler(op_infile.get_value(),
-                                  INVALID_THREAD_ID /*all threads*/,
-                                  op_verbose.get_value(), std::move(sched_ops)))
+        if (!this->init_scheduler(op_infile.get_value(), {}, {}, op_verbose.get_value(),
+                                  std::move(sched_ops)))
             this->success_ = false;
     }
     if (!init_analysis_tools()) {

--- a/clients/drcachesim/analyzer_multi.h
+++ b/clients/drcachesim/analyzer_multi.h
@@ -92,6 +92,9 @@ protected:
     cache_simulator_knobs_t *
     get_cache_simulator_knobs();
 
+    std::string
+    set_input_limit(std::set<memref_tid_t> &only_threads, std::set<int> &only_shards);
+
     std::unique_ptr<std::istream> serial_schedule_file_;
     // This is read in a single stream by invariant_checker and so is not
     // an archive_istream_t.

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -545,7 +545,25 @@ droption_t<int>
     op_only_thread(DROPTION_SCOPE_FRONTEND, "only_thread", 0,
                    "Only analyze this thread (0 means all)",
                    "Limits analyis to the single "
-                   "thread with the given identifier.  0 enables all threads.");
+                   "thread with the given identifier.  0 enables all threads.  "
+                   "Applies only to -indir, not to -infile.  "
+                   "Cannot be combined with -only_threads or -only_shards.");
+
+droption_t<std::string>
+    op_only_threads(DROPTION_SCOPE_FRONTEND, "only_threads", "",
+                    "Only analyze these comma-separated threads",
+                    "Limits analyis to the list of comma-separated thread ids.  "
+                    "Applies only to -indir, not to -infile.  "
+                    "Cannot be combined with -only_shards.");
+droption_t<std::string>
+    op_only_shards(DROPTION_SCOPE_FRONTEND, "only_shards", "",
+                   "Only analyze these comma-separated shard ordinals",
+                   "Limits analyis to the list of comma-separated shard ordinals. "
+                   "A shard is typically an input thread but might be a core for "
+                   "core-sharded-on-disk traces.  The ordinal is 0-based and indexes "
+                   "into the sorted order of input filenames.  "
+                   "Applies only to -indir, not to -infile.  "
+                   "Cannot be combined with -only_threads.");
 
 droption_t<bytesize_t> op_skip_instrs(
     DROPTION_SCOPE_FRONTEND, "skip_instrs", 0, "Number of instructions to skip",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -554,7 +554,7 @@ droption_t<std::string>
                     "Only analyze these comma-separated threads",
                     "Limits analyis to the list of comma-separated thread ids.  "
                     "Applies only to -indir, not to -infile.  "
-                    "Cannot be combined with -only_shards.");
+                    "Cannot be combined with -only_thread or -only_shards.");
 droption_t<std::string>
     op_only_shards(DROPTION_SCOPE_FRONTEND, "only_shards", "",
                    "Only analyze these comma-separated shard ordinals",
@@ -563,7 +563,7 @@ droption_t<std::string>
                    "core-sharded-on-disk traces.  The ordinal is 0-based and indexes "
                    "into the sorted order of input filenames.  "
                    "Applies only to -indir, not to -infile.  "
-                   "Cannot be combined with -only_threads.");
+                   "Cannot be combined with -only_thread or -only_threads.");
 
 droption_t<bytesize_t> op_skip_instrs(
     DROPTION_SCOPE_FRONTEND, "skip_instrs", 0, "Number of instructions to skip",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -165,6 +165,8 @@ extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>
     op_interval_instr_count;
 extern dynamorio::droption::droption_t<int> op_only_thread;
+extern dynamorio::droption::droption_t<std::string> op_only_threads;
+extern dynamorio::droption::droption_t<std::string> op_only_shards;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t> op_skip_instrs;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t> op_skip_refs;
 extern dynamorio::droption::droption_t<uint64_t> op_skip_to_timestamp;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1511,13 +1511,15 @@ protected:
     process_next_initial_record(input_info_t &input, RecordType record,
                                 bool &found_filetype, bool &found_timestamp);
 
-    // Opens up all the readers for each file in 'path' which may be a directory.
-    // Returns a map of the thread id of each file to its index in inputs_.
+    // Opens readers for each file in 'path', subject to the constraints in
+    // 'reader_info'.  'path' may be a directory.
+    // Updates the ti2dinput, unfiltered_tids, and input_count fields of 'reader_info'.
     scheduler_status_t
     open_readers(const std::string &path, input_reader_info_t &reader_info);
 
-    // Opens up a single reader for the (non-directory) file in 'path'.
-    // Returns a map of the thread id of the file to its index in inputs_.
+    // Opens a reader for the file in 'path', subject to the constraints in
+    // 'reader_info'.  'path' may not be a directory.
+    // Updates the ti2dinput, unfiltered_tids, and input_count fields of 'reader_info'.
     scheduler_status_t
     open_reader(const std::string &path, input_ordinal_t input_ordinal,
                 input_reader_info_t &reader_info);

--- a/clients/drcachesim/tests/only_shards.templatex
+++ b/clients/drcachesim/tests/only_shards.templatex
@@ -1,0 +1,7 @@
+Schedule stats tool results:
+Total counts:
+           2 cores
+           4 threads: 1257600, 1257602, 1257599, 1257603
+.*
+Core #0 schedule: FJ_
+Core #1 schedule: GI

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -797,8 +797,8 @@ test_only_threads()
             make_version(TRACE_ENTRY_VERSION),
             make_thread(IDLE_THREAD_ID),
             make_pid(INVALID_PID),
-            make_timestamp(-1),
-            make_marker(TRACE_MARKER_TYPE_CPU_ID, -1),
+            make_timestamp(static_cast<uint64_t>(-1)),
+            make_marker(TRACE_MARKER_TYPE_CPU_ID, static_cast<uintptr_t>(-1)),
             make_marker(TRACE_MARKER_TYPE_CORE_IDLE, 0),
             make_marker(TRACE_MARKER_TYPE_CORE_IDLE, 0),
             make_marker(TRACE_MARKER_TYPE_CORE_IDLE, 0),
@@ -826,6 +826,10 @@ test_only_threads()
              status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
             assert(status == scheduler_t::STATUS_OK);
             assert(memref.instr.tid == TID_A || memref.instr.tid == IDLE_THREAD_ID ||
+                   // In 32-bit the -1 is unsigned so the 64-bit .tid field is not
+                   // sign-extended.
+                   static_cast<uint64_t>(memref.instr.tid) ==
+                       static_cast<addr_t>(IDLE_THREAD_ID) ||
                    memref.instr.tid == INVALID_THREAD_ID);
             if (memref.marker.type == TRACE_TYPE_MARKER &&
                 memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_IDLE)

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -730,11 +730,14 @@ test_only_threads()
             assert(false);
         auto *stream = scheduler.get_stream(0);
         memref_t memref;
+        bool read_something = false;
         for (scheduler_t::stream_status_t status = stream->next_record(memref);
              status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
             assert(status == scheduler_t::STATUS_OK);
             assert(memref.instr.tid == TID_B);
+            read_something = true;
         }
+        assert(read_something);
     }
     {
         // Test invalid only_threads.

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -706,28 +706,132 @@ test_only_threads()
         make_instr(60),
         make_exit(TID_C),
     };
-    std::vector<scheduler_t::input_reader_t> readers;
-    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_A)),
-                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
-    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_B)),
-                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_B);
-    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_C)),
-                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_C);
+    auto create_readers = [&]() {
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_A)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_B)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_B);
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_C)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_C);
+        return readers;
+    };
 
-    scheduler_t scheduler;
-    std::vector<scheduler_t::input_workload_t> sched_inputs;
-    sched_inputs.emplace_back(std::move(readers));
-    sched_inputs[0].only_threads.insert(TID_B);
-    if (scheduler.init(sched_inputs, 1,
-                       scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
-        scheduler_t::STATUS_SUCCESS)
-        assert(false);
-    auto *stream = scheduler.get_stream(0);
-    memref_t memref;
-    for (scheduler_t::stream_status_t status = stream->next_record(memref);
-         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
-        assert(status == scheduler_t::STATUS_OK);
-        assert(memref.instr.tid == TID_B);
+    {
+        // Test valid only_threads.
+        std::vector<scheduler_t::input_reader_t> readers = create_readers();
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        sched_inputs[0].only_threads.insert(TID_B);
+        if (scheduler.init(sched_inputs, 1,
+                           scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        auto *stream = scheduler.get_stream(0);
+        memref_t memref;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+            assert(memref.instr.tid == TID_B);
+        }
+    }
+    {
+        // Test invalid only_threads.
+        std::vector<scheduler_t::input_reader_t> readers = create_readers();
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        sched_inputs[0].only_threads = { TID_A, TID_B + 1, TID_C };
+        if (scheduler.init(sched_inputs, 1,
+                           scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
+            scheduler_t::STATUS_ERROR_INVALID_PARAMETER)
+            assert(false);
+    }
+    {
+        // Test valid only_shards.
+        std::vector<scheduler_t::input_reader_t> readers = create_readers();
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        sched_inputs[0].only_shards = { 0, 2 };
+        if (scheduler.init(sched_inputs, 1,
+                           scheduler_t::make_scheduler_parallel_options(
+                               /*verbosity=*/4)) != scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        auto *stream = scheduler.get_stream(0);
+        memref_t memref;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+            assert(memref.instr.tid == TID_A || memref.instr.tid == TID_C);
+        }
+    }
+    {
+        // Test too-large only_shards.
+        std::vector<scheduler_t::input_reader_t> readers = create_readers();
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        sched_inputs[0].only_shards = { 1, 3 };
+        if (scheduler.init(sched_inputs, 1,
+                           scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
+            scheduler_t::STATUS_ERROR_INVALID_PARAMETER)
+            assert(false);
+    }
+    {
+        // Test too-small only_shards.
+        std::vector<scheduler_t::input_reader_t> readers = create_readers();
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        sched_inputs[0].only_shards = { 0, -1, 2 };
+        if (scheduler.init(sched_inputs, 1,
+                           scheduler_t::make_scheduler_serial_options(/*verbosity=*/4)) !=
+            scheduler_t::STATUS_ERROR_INVALID_PARAMETER)
+            assert(false);
+    }
+    {
+        // Test starts-idle with only_shards.
+        std::vector<trace_entry_t> refs_D = {
+            make_version(TRACE_ENTRY_VERSION),
+            make_thread(IDLE_THREAD_ID),
+            make_pid(INVALID_PID),
+            make_timestamp(-1),
+            make_marker(TRACE_MARKER_TYPE_CPU_ID, -1),
+            make_marker(TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            make_marker(TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            make_marker(TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            make_footer(),
+        };
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_A)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_B)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_B);
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_D)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_C);
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        sched_inputs[0].only_shards = { 0, 2 };
+        if (scheduler.init(sched_inputs, 1,
+                           scheduler_t::make_scheduler_parallel_options(
+                               /*verbosity=*/4)) != scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        auto *stream = scheduler.get_stream(0);
+        memref_t memref;
+        int idle_count = 0;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+            assert(memref.instr.tid == TID_A || memref.instr.tid == IDLE_THREAD_ID ||
+                   memref.instr.tid == INVALID_THREAD_ID);
+            if (memref.marker.type == TRACE_TYPE_MARKER &&
+                memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_IDLE)
+                ++idle_count;
+        }
+        assert(idle_count == 3);
     }
 }
 

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -204,8 +204,12 @@ std::string
 record_filter_t::get_output_basename(memtrace_stream_t *shard_stream)
 {
     if (shard_type_ == SHARD_BY_CORE) {
-        return output_dir_ + DIRSEP + "drmemtrace.core." +
-            std::to_string(shard_stream->get_shard_index()) + ".trace";
+        // Use leading 0's for the core id to ensure lexicographic sort keeps
+        // numeric core order for --only_shards.
+        std::ostringstream name;
+        name << output_dir_ << DIRSEP << "drmemtrace.core." << std::setfill('0')
+             << std::setw(6) << shard_stream->get_shard_index() << ".trace";
+        return name.str();
     } else {
         return output_dir_ + DIRSEP + shard_stream->get_stream_name();
     }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3936,6 +3936,11 @@ if (BUILD_CLIENTS)
         torunonly_simtool(core_on_disk_schedule ${ci_shared_app}
           "-indir ${core_sharded_dir} -tool schedule_stats" "")
         set(tool.core_on_disk_schedule_rawtemp ON) # no preprocessor
+
+        # Test -only_shards on core-sharded-on-disk traces.
+        torunonly_simtool(only_shards ${ci_shared_app}
+          "-indir ${core_sharded_dir} -tool schedule_stats -only_shards 2,3" "")
+        set(tool.core_on_disk_rawtemp ON) # no preprocessor
       endif ()
     endif ()
 


### PR DESCRIPTION
Adds a new filter by shard ordinal to the drmemtrace scheduler and analyzers, and adds multi-thread filtering on the command line.

Adds input_workload_t.only_shards to filter scheduler inputs by ordinal, which is mostly useful for core-sharded-on-disk traces.

Adds new CLI options -only_shards, which takes a comma-separated list of ordinals, and -only_threads, which takes a comma-separated list of tids.

Adds sorting of file names when reading inputs from a directory so that ordinals are reliable.  Adds leading 0's to record_filter's output name so this lexicographic sort keeps cores in order.

Adds error checking that any tid or ordinal filter is actually present in the inputs.

Adds an internal struct input_read_info_t to implement the new filtering inside the scheduler.

Adds scheduler unit tests of the new filters.

Adds an end-to-end test of -only_shards on a core-sharded-on-disk trace.

Also tested end-to-end manually with invalid tids, invalid ordinals, valid tids for core-sharded-on-disk, and valid ordinals for core-sharded-on-disk.

Issue: #6685