### PR TITLE
i#5437 glibc: Auto-deduce __libc_early_init offsets

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -755,9 +755,14 @@ privload_os_finalize(privmod_t *privmod)
         GLRO_dl_tls_static_align_OFFS = 0x2d0;
     }
 #    else
-    // The offsets changed between 2.35 and 2.36.
-    GLRO_dl_tls_static_size_OFFS = (ver[2] == '3' && ver[3] == '5') ? 0x328 : 0x31c;
-    GLRO_dl_tls_static_align_OFFS = (ver[2] == '3' && ver[3] == '5') ? 0x32c : 0x320;
+    if (ver[2] == '3' && ver[3] >= '8') {
+        GLRO_dl_tls_static_size_OFFS = 0x324;
+        GLRO_dl_tls_static_align_OFFS = 0x320;
+    } else {
+        // The offsets changed between 2.35 and 2.36.
+        GLRO_dl_tls_static_size_OFFS = (ver[2] == '3' && ver[3] == '5') ? 0x328 : 0x31c;
+        GLRO_dl_tls_static_align_OFFS = (ver[2] == '3' && ver[3] == '5') ? 0x32c : 0x320;
+    }
 #    endif
     size_t val = 4096, written;
     if (!safe_write_ex(glro + GLRO_dl_tls_static_size_OFFS, sizeof(val), &val,


### PR DESCRIPTION
Adds decoding of __libc_early_init to find the glibc private loader workaround
offsets we need.  The heuristic is to look for the last large (>0x100) load offset before
the first DIV.
    
Tested on 2.38 64-bit and 32-bit.

Also updates the __libc_early_init offsets for 32-bit glibc 2.38 as a fallback.
Tested locally.

Issue: #5437