### PR TITLE
i#6303: Do not split encodings when splitting pipe writes

### DIFF
--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -218,10 +218,12 @@ reader_t::process_input_entry()
                     !TESTANY(OFFLINE_FILE_TYPE_ARCH_REGDEPS, filetype_)) {
                     ERRMSG(
                         "Encoding size %zu != instr size %zu for PC 0x%zx at ord %" PRIu64
-                        " instr %" PRIu64 " last_timestamp=0x%" PRIx64 "\n",
+                        " instr %" PRIu64 " last_timestamp=0x%" PRIx64
+                        " enc: %x %x inst type: %d\n",
                         last_encoding_.size, cur_ref_.instr.size, cur_ref_.instr.addr,
                         get_record_ordinal(), get_instruction_ordinal(),
-                        get_last_timestamp());
+                        get_last_timestamp(), last_encoding_.bits[0],
+                        last_encoding_.bits[1], cur_ref_.instr.type);
                     // Encoding errors indicate serious problems so we always abort.
                     assert_release_too(false);
                 }


### PR DESCRIPTION
Encodings can occupy multiple consecutive records, especially for 32-bit where the record size is smaller.  For online tracing, we were allowing buffer splits for atomic pipe writes in between encoding records.  We fix that here.

Tested via "ctest --repeat-until-fail 10000 -R drcachesim.opcode_mix". This was failing locally every 500-1500 runs.  With named_pipe_t::get_atomic_write_size() returning 512 it was failing every 14 runs.  With the fix it has yet to fail after thousands of runs.

Fixes #6303