### PR TITLE
i#5505 kernel tracing: Dump more potential BPF JIT code

### DIFF
--- a/clients/drcachesim/tests/offline-kernel-simple.templatex
+++ b/clients/drcachesim/tests/offline-kernel-simple.templatex
@@ -3,14 +3,12 @@ Basic counts tool results:
 Total counts:
  .* total \(fetched\) instructions
  .* total unique \(fetched\) instructions
- .* total non-fetched instructions
  *[1-9][0-9]* total userspace instructions
  *[1-9][0-9]* total kernel instructions
 .*
 Thread .* counts:
  .* \(fetched\) instructions
  .* unique \(fetched\) instructions
- .* non-fetched instructions
  *[1-9][0-9]* userspace instructions
  *[1-9][0-9]* kernel instructions
 .*

--- a/clients/drcachesim/tracer/kcore_copy.cpp
+++ b/clients/drcachesim/tracer/kcore_copy.cpp
@@ -446,7 +446,7 @@ kcore_copy_t::read_kallsyms()
     ASSERT(kernel_module == nullptr, "failed to find kernel module");
 
     if (!bpf_jit_symbols.empty()) {
-        constexpr int kExtraPages = 5;
+        constexpr int kExtraPages = 10;
         /* For BPF JIT code, it seems not uncommon for /proc/kallsyms to not have full
          * page-level coverage. To ensure we copy all relevant code, we dump multiple
          * page sizes' worth of contents after each bpf-related function symbol. This is

--- a/clients/drcachesim/tracer/kcore_copy.cpp
+++ b/clients/drcachesim/tracer/kcore_copy.cpp
@@ -446,10 +446,15 @@ kcore_copy_t::read_kallsyms()
     ASSERT(kernel_module == nullptr, "failed to find kernel module");
 
     if (!bpf_jit_symbols.empty()) {
-        /* We copy a page size worth of contents after each bpf-related function symbol
-         * in an effort to make sure that the complete function is copied. This is
-         * similar to perf adding page size to the highest kernel symbol in its own
-         * kcore copy logic.
+        constexpr int kExtraPages = 5;
+        /* For BPF JIT code, it seems not uncommon for /proc/kallsyms to not have full
+         * page-level coverage. To ensure we copy all relevant code, we dump multiple
+         * page sizes' worth of contents after each bpf-related function symbol. This is
+         * somewhat similar to perf adding page size to the highest kernel symbol in
+         * its own kcore copy logic. This does not seem to inflate the kcore dump size
+         * by too much (< 1% increase, to 20MB).
+         * XXX: We could potentially expose a command-line option instead of
+         * hard-coding the kExtraPages.
          */
         size_t page_size = dr_page_size();
         proc_module_t *bpf_module = nullptr;
@@ -458,7 +463,8 @@ kcore_copy_t::read_kallsyms()
             if (bpf_module == nullptr) {
                 bpf_module = (proc_module_t *)dr_global_alloc(sizeof(proc_module_t));
                 bpf_module->start = ALIGN_BACKWARD(addr, page_size);
-                bpf_module->end = ALIGN_FORWARD(addr + page_size, page_size);
+                bpf_module->end =
+                    ALIGN_FORWARD(addr + kExtraPages * page_size, page_size);
                 ++it;
                 continue;
             }
@@ -466,7 +472,8 @@ kcore_copy_t::read_kallsyms()
                 /* Just extend the last module region if the new addr falls within
                  * the last recorded range.
                  */
-                bpf_module->end = ALIGN_FORWARD(addr + page_size, page_size);
+                bpf_module->end =
+                    ALIGN_FORWARD(addr + kExtraPages * page_size, page_size);
                 ++it;
             } else {
                 bpf_module->next = modules_;

--- a/clients/drcachesim/tracer/kcore_copy.cpp
+++ b/clients/drcachesim/tracer/kcore_copy.cpp
@@ -446,7 +446,7 @@ kcore_copy_t::read_kallsyms()
     ASSERT(kernel_module == nullptr, "failed to find kernel module");
 
     if (!bpf_jit_symbols.empty()) {
-        constexpr int kExtraPages = 10;
+        constexpr int EXTRA_PAGES = 10;
         /* For BPF JIT code, it seems not uncommon for /proc/kallsyms to not have full
          * page-level coverage. To ensure we copy all relevant code, we dump multiple
          * page sizes' worth of contents after each bpf-related function symbol. This is
@@ -454,7 +454,7 @@ kcore_copy_t::read_kallsyms()
          * its own kcore copy logic. This does not seem to inflate the kcore dump size
          * by too much (< 1% increase).
          * XXX: We could potentially expose a command-line option instead of
-         * hard-coding the kExtraPages.
+         * hard-coding the EXTRA_PAGES.
          */
         size_t page_size = dr_page_size();
         proc_module_t *bpf_module = nullptr;
@@ -464,7 +464,7 @@ kcore_copy_t::read_kallsyms()
                 bpf_module = (proc_module_t *)dr_global_alloc(sizeof(proc_module_t));
                 bpf_module->start = ALIGN_BACKWARD(addr, page_size);
                 bpf_module->end =
-                    ALIGN_FORWARD(addr + kExtraPages * page_size, page_size);
+                    ALIGN_FORWARD(addr + EXTRA_PAGES * page_size, page_size);
                 ++it;
                 continue;
             }
@@ -473,7 +473,7 @@ kcore_copy_t::read_kallsyms()
                  * the last recorded range.
                  */
                 bpf_module->end =
-                    ALIGN_FORWARD(addr + kExtraPages * page_size, page_size);
+                    ALIGN_FORWARD(addr + EXTRA_PAGES * page_size, page_size);
                 ++it;
             } else {
                 bpf_module->next = modules_;

--- a/clients/drcachesim/tracer/kcore_copy.cpp
+++ b/clients/drcachesim/tracer/kcore_copy.cpp
@@ -452,7 +452,7 @@ kcore_copy_t::read_kallsyms()
          * page sizes' worth of contents after each bpf-related function symbol. This is
          * somewhat similar to perf adding page size to the highest kernel symbol in
          * its own kcore copy logic. This does not seem to inflate the kcore dump size
-         * by too much (< 1% increase, to 20MB).
+         * by too much (< 1% increase).
          * XXX: We could potentially expose a command-line option instead of
          * hard-coding the kExtraPages.
          */


### PR DESCRIPTION
Modifies the kcore dump logic to include multiple pages worth of kcore after each BPF JIT symbol. It does not seem uncommon for /proc/kallsyms to not have full coverage of BPF JIT code seen in the PT raw trace, even at the page-level. This increases the kcore dump size only by a very small amount (< ~1%).

Verified that the PT related tests continue to work on a system that supports the Intel-PT hardware feature:

```
The following tests passed:
	code_api|tool.drcacheoff.kernel.simple_SUDO
	code_api|tool.drcacheoff.kernel.opcode-mix_SUDO
	code_api|tool.drcacheoff.kernel.syscall-mix_SUDO
	code_api|tool.drcacheoff.kernel.invariant-checker_SUDO

The following tests passed:
	code_api|client.drpttracer_SUDO-test
```

Issue: #5505