### PR TITLE
i#6947: Document "using undefined symbol!" runtime error

### DIFF
--- a/api/docs/deployment.dox
+++ b/api/docs/deployment.dox
@@ -90,6 +90,9 @@ The \p samples/CMakeLists.txt file in the release package serves as another
 example.  The top of \p DynamoRIOConfig.cmake contains detailed
 instructions as well.
 
+If your client uses DynamoRIO extensions like drmgr or drx be sure to call
+use_DynamoRIO_extension() in your client's CMakeLists.txt file.
+
 When configuring, the \p DynamoRIO_DIR CMake variable can be passed in to
 identify the directory that contains the \p DynamoRIOConfig.cmake file.  For
 example:

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -1164,6 +1164,9 @@ set(DynamoRIO_EXT_droption_INC ${DynamoRIO_cwd}/../ext/include)
 set(DynamoRIO_EXT_drmemtrace_static_NOLIB ON)
 
 # DynamoRIO Extensions
+# Failure to call this in your client CMakeLists.txt when using an extension like
+# drmgr or drx will result in an obscure "using undefined symbol!" runtime
+# error on Linux.
 function (use_DynamoRIO_extension target extname)
   if (NOT DynamoRIO_INTERNAL)
     # We only support Extensions as imported targets that have already


### PR DESCRIPTION
Add a comment documenting the "using undefined symbol!" runtime error that client developers get if they use a DynamoRIO extension like drmgr but don't call use_DynamoRIO_extension in their CMakeLists.txt.

Issue: #6947