### PR TITLE
i#4501: Undo some changes to loader_shared.c made by 9293e7ae7.

### DIFF
--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -165,6 +165,7 @@ loader_should_call_entry(privmod_t *mod)
 void
 loader_init_prologue(void)
 {
+    /* On Unix this is done (slightly differently) in loader_init_epilogue. */
 #ifdef WINDOWS
     acquire_recursive_lock(&privload_lock);
     VMVECTOR_ALLOC_VECTOR(modlist_areas, GLOBAL_DCONTEXT,

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1147,7 +1147,12 @@ privload_call_lib_func(dcontext_t *dcontext, privmod_t *privmod, fp_t func)
      */
     dummy_argv[0] = dummy_str;
     dummy_argv[1] = NULL;
-    func(1, dummy_argv, our_environ);
+    TRY_EXCEPT_ALLOW_NO_DCONTEXT(
+        dcontext, { func(1, dummy_argv, our_environ); },
+        { /* EXCEPT */
+          SYSLOG_INTERNAL_ERROR("Private library %s init/fini func " PFX " crashed",
+                                privmod->name, func);
+        });
 }
 
 bool

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1147,12 +1147,7 @@ privload_call_lib_func(dcontext_t *dcontext, privmod_t *privmod, fp_t func)
      */
     dummy_argv[0] = dummy_str;
     dummy_argv[1] = NULL;
-    TRY_EXCEPT_ALLOW_NO_DCONTEXT(
-        dcontext, { func(1, dummy_argv, our_environ); },
-        { /* EXCEPT */
-          SYSLOG_INTERNAL_ERROR("Private library %s init/fini func " PFX " crashed",
-                                privmod->name, func);
-        });
+    func(1, dummy_argv, our_environ);
 }
 
 bool

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6044,6 +6044,13 @@ if (vera++_FOUND)
   set_tests_properties(vera PROPERTIES PASS_REGULAR_EXPRESSION "${vera_regex}")
 endif ()
 
+if (UNIX)
+  get_target_path_for_execution(drrun_path drrun "${location_suffix}")
+  add_test(two_clients ${drrun_path}
+    -client ../../api/bin/libbbcount.so 0 ''
+    -client ../../api/bin/libopcodes.so 1 '' -- bin/${ci_shared_app})
+endif (UNIX)
+
 ###########################################################################
 
 # Remember that we do not reach this point for DR_HOST_NOT_TARGET, so do not


### PR DESCRIPTION
The purpose of 9293e7ae7 was to add TLS support for Windows, but it broke the use of multiple clients. This patch brings back the previous code for non-Windows, so on Unix all the loading happens later, in loader_init_epilogue().

Also add a test of two clients.

Unfortunately this patch undoes the unification of the Unix and Windows loaders that happened with 9293e7ae7. It would be good to find a way of unifying the Unix and Windows loaders that does not break the use of multiple clients (#6963).