### PR TITLE
i#6959 all-unsched: Revert only-unscheduled fix

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2967,7 +2967,13 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         return eof_or_idle(output, need_lock, prev_index);
                     auto lock = std::unique_lock<std::mutex>(*inputs_[prev_index].lock);
                     // If we can't go back to the current input, we're EOF or idle.
-                    if (inputs_[prev_index].at_eof || inputs_[prev_index].unscheduled) {
+                    // TODO i#6959: We should go the EOF/idle route if
+                    // inputs_[prev_index].unscheduled as otherwise we're ignoring its
+                    // uncheduled transition: although if there are no other threads at
+                    // all (not just an empty queue) this turns into the eof_or_idle()
+                    // all-unscheduled scenario.  Once we have some kind of early exit
+                    // option we'll add the unscheduled check here.
+                    if (inputs_[prev_index].at_eof) {
                         lock.unlock();
                         return eof_or_idle(output, need_lock, prev_index);
                     } else

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2969,7 +2969,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                     // If we can't go back to the current input, we're EOF or idle.
                     // TODO i#6959: We should go the EOF/idle route if
                     // inputs_[prev_index].unscheduled as otherwise we're ignoring its
-                    // uncheduled transition: although if there are no other threads at
+                    // unscheduled transition: although if there are no other threads at
                     // all (not just an empty queue) this turns into the eof_or_idle()
                     // all-unscheduled scenario.  Once we have some kind of early exit
                     // option we'll add the unscheduled check here.


### PR DESCRIPTION
Reverts a fix for a bug in the scheduler where it let a thread going unscheduled continue running if there are no other non-running-now scheduleable inputs.  This triggered too-frequent all-unscheduled cases and the current timeout for those is too high, causing tail delays.  We'll re-instate the fix once we add an early exit feature for that scenario.

Issue: #6959