### PR TITLE
i#6733 missing exit: Suppress drmemtrace invariant check

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -185,10 +185,10 @@ invariant_checker_t::parallel_shard_exit(void *shard_data)
     per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
     report_if_false(shard,
                     shard->saw_thread_exit_
-                        // XXX i#6444: For online on some Windows tests we see threads
+                        // XXX i#6733: For online we sometimes see threads
                         // exiting w/o the tracer inserting an exit.  Until we figure
-                        // that out we disable this error for Windows online.
-                        IF_WINDOWS(|| !knob_offline_),
+                        // that out we disable this error to unblock testing.
+                        || !knob_offline_,
                     "Thread is missing exit");
     if (!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_DFILTERED |
                      // In OFFLINE_FILE_TYPE_ARCH_REGDEPS we can have leftover


### PR DESCRIPTION
Temporarily suppresses the drmemtrace invariant checker test for a thread exit record in online mode as it is happening frequently enough in our tests that it is blocking progress, though at the same time it is very difficult to reproduce locally and figure it out.  We want our tests green as a priority for now and can re-enable once someone figures out the root cause.  This only affects online mode.

Issue: #6733