### PR TITLE
i#6938 sched migrate: Add lock contention stats

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -168,6 +168,7 @@ add_exported_library(drmemtrace_func_view STATIC tools/func_view.cpp)
 add_exported_library(drmemtrace_invariant_checker STATIC tools/invariant_checker.cpp)
 add_exported_library(drmemtrace_schedule_stats STATIC tools/schedule_stats.cpp)
 add_exported_library(drmemtrace_schedule_file STATIC common/schedule_file.cpp)
+add_exported_library(drmemtrace_mutex_dbg_owned STATIC common/mutex_dbg_owned.cpp)
 
 target_link_libraries(drmemtrace_invariant_checker drdecode drmemtrace_schedule_file)
 
@@ -284,7 +285,7 @@ target_link_libraries(drmemtrace_launcher drmemtrace_simulator drmemtrace_reuse_
   drmemtrace_histogram drmemtrace_reuse_time drmemtrace_basic_counts
   drmemtrace_opcode_mix drmemtrace_syscall_mix drmemtrace_view drmemtrace_func_view
   drmemtrace_raw2trace directory_iterator drmemtrace_invariant_checker
-  drmemtrace_schedule_stats drmemtrace_record_filter)
+  drmemtrace_schedule_stats drmemtrace_record_filter drmemtrace_mutex_dbg_owned)
 if (UNIX)
     target_link_libraries(drmemtrace_launcher dl)
 endif ()
@@ -331,7 +332,7 @@ add_exported_library(drmemtrace_analyzer STATIC
   ${snappy_reader}
   ${lz4_reader}
   )
-target_link_libraries(drmemtrace_analyzer directory_iterator)
+target_link_libraries(drmemtrace_analyzer directory_iterator drmemtrace_mutex_dbg_owned)
 if (libsnappy)
   target_link_libraries(drmemtrace_analyzer snappy)
 endif ()
@@ -610,6 +611,12 @@ macro(add_win32_flags target)
   if (DEBUG AND NOT DEFINED ${target}_uses_configure)
     append_property_list(TARGET ${target} COMPILE_DEFINITIONS "DEBUG")
   endif ()
+  if (NOT DEBUG)
+    get_property(cur TARGET ${target} PROPERTY COMPILE_DEFINITIONS)
+    if (NOT "${cur}" MATCHES "NDEBUG")
+      append_property_list(TARGET ${target} COMPILE_DEFINITIONS "NDEBUG")
+    endif ()
+  endif ()
   if (WIN32)
     if (DEBUG)
       get_property(cur TARGET ${target} PROPERTY COMPILE_FLAGS)
@@ -666,6 +673,7 @@ add_win32_flags(drmemtrace_schedule_stats)
 add_win32_flags(drmemtrace_schedule_file)
 add_win32_flags(directory_iterator)
 add_win32_flags(test_helpers)
+add_win32_flags(drmemtrace_mutex_dbg_owned)
 if (WIN32 AND DEBUG)
   get_target_property(sim_srcs drmemtrace_launcher SOURCES)
   get_target_property(raw2trace_srcs drraw2trace SOURCES)
@@ -821,13 +829,13 @@ if (BUILD_TESTS)
 
   add_executable(tool.scheduler.unit_tests tests/scheduler_unit_tests.cpp)
   target_link_libraries(tool.scheduler.unit_tests drmemtrace_analyzer test_helpers)
-  add_win32_flags(tool.scheduler.unit_tests)
   if (WIN32)
     # We have a dup symbol from linking in DR.  Linking libc first doesn't help.
     append_property_string(TARGET tool.scheduler.unit_tests LINK_FLAGS
       "/force:multiple")
   endif ()
   configure_DynamoRIO_standalone(tool.scheduler.unit_tests)
+  add_win32_flags(tool.scheduler.unit_tests)
   add_test(NAME tool.scheduler.unit_tests
     COMMAND tool.scheduler.unit_tests
     ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
@@ -881,6 +889,7 @@ if (BUILD_TESTS)
     add_executable(tool.drcacheoff.record_filter_unit_tests
                    tests/record_filter_unit_tests.cpp)
     configure_DynamoRIO_standalone(tool.drcacheoff.record_filter_unit_tests)
+    add_win32_flags(tool.drcacheoff.record_filter_unit_tests)
     target_link_libraries(tool.drcacheoff.record_filter_unit_tests drmemtrace_analyzer
       drmemtrace_basic_counts drmemtrace_record_filter test_helpers)
     add_test(NAME tool.drcacheoff.record_filter_unit_tests

--- a/clients/drcachesim/common/mutex_dbg_owned.cpp
+++ b/clients/drcachesim/common/mutex_dbg_owned.cpp
@@ -43,7 +43,6 @@ mutex_dbg_owned::lock()
 #ifdef NDEBUG
     lock_.lock();
 #else
-#    error expecting NDEBUG
     bool contended = true;
     if (lock_.try_lock())
         contended = false;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -687,10 +687,12 @@ scheduler_tmpl_t<RecordType, ReaderType>::~scheduler_tmpl_t()
         VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Migrations",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS]);
     }
+#ifndef NDEBUG
     VPRINT(this, 1, "%-27s: %9" PRId64 "\n", "Schedule lock acquired",
            sched_lock_.get_count_acquired());
     VPRINT(this, 1, "%-27s: %9" PRId64 "\n", "Schedule lock contended",
            sched_lock_.get_count_contended());
+#endif
 }
 
 template <typename RecordType, typename ReaderType>

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -687,6 +687,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::~scheduler_tmpl_t()
         VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Migrations",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS]);
     }
+    VPRINT(this, 1, "%-27s: %9" PRId64 "\n", "Schedule lock acquired",
+           sched_lock_.get_count_acquired());
+    VPRINT(this, 1, "%-27s: %9" PRId64 "\n", "Schedule lock contended",
+           sched_lock_.get_count_contended());
 }
 
 template <typename RecordType, typename ReaderType>

--- a/clients/drcachesim/tests/memref_gen.h
+++ b/clients/drcachesim/tests/memref_gen.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2023 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2024 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -190,7 +190,9 @@ add_encodings_to_memrefs(instrlist_t *ilist,
 {
     static const int MAX_DECODE_SIZE = 2048;
     byte decode_buf[MAX_DECODE_SIZE];
+#ifndef NDEBUG
     byte *pc =
+#endif
         instrlist_encode_to_copy(GLOBAL_DCONTEXT, ilist, decode_buf,
                                  reinterpret_cast<app_pc>(base_addr), nullptr, true);
     assert(pc != nullptr);


### PR DESCRIPTION
Adds lock contention counters for mutex_dbg_owned::lock() in non-NDEBUG builds.
While it's not there for release builds, the results in non-release should still be
indicative of general lock behavior.

When I just changed the mutex_dbg_owned header, the relese build static drmemtrace
tests (e.g., the burst_* ones) were all failing with floating point exceptions.  It
turns out it's due to different compilation units having different values for NDEBUG.
I tried to make them all the same: but we have some files that contain `#undef NDEBUG`
and other complexities.  So I split the mutex_dbg_owned implementation into a
.cpp file and have the mutex wrapper extra fields always present.

Prints the stats for sched_lock_ with the other scheduler stats.

Sample results on schedule_stats on a threadsig trace show a lot of contention even with only 3 cores:

```
$ clients/bin64/drmemtrace_launcher -indir ../build_x64_dbg_tests/drmemtrace.threadsig.5* -core_sharded -cores 3 -tool schedule_stats -verbose 1
[scheduler] Schedule lock acquired     :   2196602
[scheduler] Schedule lock contended    :    257580
```

Issue: #6938