### PR TITLE
i#6971 sched time: Reduce gettimeofday calls

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2337,11 +2337,7 @@ template <typename RecordType, typename ReaderType>
 uint64_t
 scheduler_tmpl_t<RecordType, ReaderType>::get_output_time(output_ordinal_t output)
 {
-    // If the user is giving us times take the most recent of those.
-    if (outputs_[output].cur_time > 0)
-        return outputs_[output].cur_time;
-    // Otherwise, use wall-clock time.
-    return get_time_micros();
+    return outputs_[output].cur_time;
 }
 
 template <typename RecordType, typename ReaderType>


### PR DESCRIPTION
Only call gettimeofday once per next_record for instruction quanta, rather than every get_output_time() call.

Future work will try to revisit using a counter to eliminate the non-determinism of wall-clock time and make analyzers behavior more like simulators, easing testing.

Issue: #6971