### PR TITLE
i#5843 scheduler: Improve speculation error checking

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -3312,8 +3312,11 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         outputs_[output].prev_speculate_pc = outputs_[output].speculate_pc;
         error_string_ = outputs_[output].speculator.next_record(
             outputs_[output].speculate_pc, record);
-        if (!error_string_.empty())
+        if (!error_string_.empty()) {
+            VPRINT(this, 1, "next_record[%d]: speculation failed: %s\n", output,
+                   error_string_.c_str());
             return sched_type_t::STATUS_INVALID;
+        }
         // Leave the cur input where it is: the ordinals will remain unchanged.
         // Also avoid the context switch checks below as we cannot switch in the
         // middle of speculating (we also don't count speculated instructions toward

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -2392,7 +2392,8 @@ test_speculation()
             assert(memref.instr.addr == 2);
             // We realize now that we mispredicted that the branch would be taken.
             // We ask to queue this record for post-speculation.
-            stream->start_speculation(100, true);
+            status = stream->start_speculation(100, true);
+            assert(status == scheduler_t::STATUS_OK);
             // Ensure unread_last_record() fails during speculation.
             assert(stream->unread_last_record() == scheduler_t::STATUS_INVALID);
             break;
@@ -2413,7 +2414,8 @@ test_speculation()
 #elif defined(ARM)
             assert(memref.instr.addr == 102 || memref.instr.addr == 104);
 #endif
-            stream->stop_speculation();
+            status = stream->stop_speculation();
+            assert(status == scheduler_t::STATUS_OK);
             break;
         case 7:
             // Back to the trace, to the queued record
@@ -2429,7 +2431,8 @@ test_speculation()
             assert(memref.instr.addr == 4);
             // We realize now that we mispredicted that the branch would be taken.
             // This time we do *not* ask to queue this record for post-speculation.
-            stream->start_speculation(200, false);
+            status = stream->start_speculation(200, false);
+            assert(status == scheduler_t::STATUS_OK);
             break;
         case 10:
             // We should now see nops from the speculator.
@@ -2437,7 +2440,8 @@ test_speculation()
             assert(memref_is_nop_instr(memref));
             assert(memref.instr.addr == 200);
             // Test a nested start_speculation().
-            stream->start_speculation(300, false);
+            status = stream->start_speculation(300, false);
+            assert(status == scheduler_t::STATUS_OK);
             // Ensure unread_last_record() fails during nested speculation.
             assert(stream->unread_last_record() == scheduler_t::STATUS_INVALID);
             break;
@@ -2445,7 +2449,8 @@ test_speculation()
             assert(type_is_instr(memref.instr.type));
             assert(memref_is_nop_instr(memref));
             assert(memref.instr.addr == 300);
-            stream->stop_speculation();
+            status = stream->stop_speculation();
+            assert(status == scheduler_t::STATUS_OK);
             break;
         case 12:
             // Back to the outer speculation layer's next PC.
@@ -2459,13 +2464,15 @@ test_speculation()
             assert(memref.instr.addr == 202 || memref.instr.addr == 204);
 #endif
             // Test a nested start_speculation(), saving the current record.
-            stream->start_speculation(400, true);
+            status = stream->start_speculation(400, true);
+            assert(status == scheduler_t::STATUS_OK);
             break;
         case 13:
             assert(type_is_instr(memref.instr.type));
             assert(memref_is_nop_instr(memref));
             assert(memref.instr.addr == 400);
-            stream->stop_speculation();
+            status = stream->stop_speculation();
+            assert(status == scheduler_t::STATUS_OK);
             break;
         case 14:
             // Back to the outer speculation layer's prior PC.
@@ -2478,7 +2485,8 @@ test_speculation()
 #elif defined(ARM)
             assert(memref.instr.addr == 202 || memref.instr.addr == 204);
 #endif
-            stream->stop_speculation();
+            status = stream->stop_speculation();
+            assert(status == scheduler_t::STATUS_OK);
             break;
         case 15:
             // Back to the trace, but skipping what we already read.


### PR DESCRIPTION
Improves speculation error checking by printing the error message on failure.  Adds missing return status checks to the speculation calls in the speculator unit test.

Issue: #5843