### PR TITLE
i#4501: In module_lookup_symbol skip other client modules.

### DIFF
--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -178,6 +178,7 @@ loader_init_prologue(void)
         privmod_t *mod =
             privload_insert(NULL, privmod_static[i].base, privmod_static[i].size,
                             privmod_static[i].name, privmod_static[i].path);
+        mod->is_top_level_client = true;
         mod->is_client = true;
     }
 
@@ -520,6 +521,7 @@ privload_insert(privmod_t *after, app_pc base, size_t size, const char *name,
     }
     mod->ref_count = 1;
     mod->externally_loaded = false;
+    mod->is_top_level_client = false; /* up to caller to set later */
     mod->is_client = false; /* up to caller to set later */
     mod->called_proc_entry = false;
     mod->called_proc_exit = false;

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -413,7 +413,9 @@ typedef struct _privmod_t {
     char path[MAXIMUM_PATH];
     uint ref_count;
     bool externally_loaded;
-    bool is_client; /* or Extension */
+    /* XXX: is_top_level_client could perhaps replace is_client */
+    bool is_top_level_client; /* set for command-line clients */
+    bool is_client; /* set for command-line client or extension */
     bool called_proc_entry;
     bool called_proc_exit;
     struct _privmod_t *next;

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -413,7 +413,7 @@ typedef struct _privmod_t {
     char path[MAXIMUM_PATH];
     uint ref_count;
     bool externally_loaded;
-    /* XXX: is_top_level_client could perhaps replace is_client */
+    /* XXX i#6982: Perhaps replace is_client with is_top_level_client. */
     bool is_top_level_client; /* set for command-line clients */
     bool is_client;           /* set for command-line client or extension */
     bool called_proc_entry;

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -415,7 +415,7 @@ typedef struct _privmod_t {
     bool externally_loaded;
     /* XXX: is_top_level_client could perhaps replace is_client */
     bool is_top_level_client; /* set for command-line clients */
-    bool is_client; /* set for command-line client or extension */
+    bool is_client;           /* set for command-line client or extension */
     bool called_proc_entry;
     bool called_proc_exit;
     struct _privmod_t *next;

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -581,9 +581,9 @@ privload_process_imports(privmod_t *mod)
                     SYSLOG_INTERNAL_WARNING(
                         "private libpthread.so loaded but not fully supported (i#956)");
                 }
-                /* i#852: identify all libs that import from DR as client libs.
-                 * XXX: this code seems stale as libdynamorio.so is already loaded
-                 * (xref #3850).
+                /* i#852: Identify all libs that import from DR as client libs.
+                 * XXX i#6982: The following condition is never true as
+                 * libdynamorio.so has already been loaded (xref #3850).
                  */
                 if (impmod->base == get_dynamorio_dll_start())
                     mod->is_client = true;

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1145,7 +1145,7 @@ module_lookup_symbol(ELF_SYM_TYPE *sym, os_privmod_data_t *pd)
          * initialised. Skipping all uninitialised modules should also work but
          * might hide a more serious problem. See i#4501.
          */
-        if (mod->is_client)
+        if (mod->is_top_level_client)
             continue;
         pd = mod->os_privmod_data;
         ASSERT(pd != NULL && name != NULL);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6044,6 +6044,13 @@ if (vera++_FOUND)
   set_tests_properties(vera PROPERTIES PASS_REGULAR_EXPRESSION "${vera_regex}")
 endif ()
 
+if (UNIX)
+  get_target_path_for_execution(drrun_path drrun "${location_suffix}")
+  add_test(two_clients ${drrun_path}
+    -client ../../api/bin/libbbcount.so 0 ''
+    -client ../../api/bin/libopcodes.so 1 '' -- bin/${ci_shared_app})
+endif (UNIX)
+
 ###########################################################################
 
 # Remember that we do not reach this point for DR_HOST_NOT_TARGET, so do not

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3647,6 +3647,17 @@ if (BUILD_SAMPLES)
         "CFLAGS=-m32;CXXFLAGS=-m32")
     endif ()
   endif ()
+  if (UNIX)
+    # XXX: Change this to go through torun() like the other tests to share
+    # output, multiplexing, _timeout, etc. features: not entirely
+    # straightforward because this test uses two clients.
+    get_target_path_for_execution(drrun_path drrun "${location_suffix}")
+    get_client_path(client1 bbcount bbcount)
+    get_client_path(client2 opcodes opcodes)
+    add_test(two_clients ${drrun_path}
+      -client ${client1} 0 ''
+      -client ${client2} 1 '' -- bin/${ci_shared_app})
+  endif (UNIX)
 endif (BUILD_SAMPLES)
 
 if (BUILD_CLIENTS)
@@ -6043,13 +6054,6 @@ if (vera++_FOUND)
     --error "${PROJECT_SOURCE_DIR}/make/style_checks/style_test.c")
   set_tests_properties(vera PROPERTIES PASS_REGULAR_EXPRESSION "${vera_regex}")
 endif ()
-
-if (UNIX)
-  get_target_path_for_execution(drrun_path drrun "${location_suffix}")
-  add_test(two_clients ${drrun_path}
-    -client ../../api/bin/libbbcount.so 0 ''
-    -client ../../api/bin/libopcodes.so 1 '' -- bin/${ci_shared_app})
-endif (UNIX)
 
 ###########################################################################
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3651,12 +3651,14 @@ if (BUILD_SAMPLES)
     # XXX: Change this to go through torun() like the other tests to share
     # output, multiplexing, _timeout, etc. features: not entirely
     # straightforward because this test uses two clients.
+    # For now, "-s 90 -quiet -killpg" is added explicitly.
     get_target_path_for_execution(drrun_path drrun "${location_suffix}")
     get_client_path(client1 bbcount bbcount)
     get_client_path(client2 opcodes opcodes)
-    add_test(two_clients ${drrun_path}
+    get_target_path_for_execution(app_path "${ci_shared_app}" "${location_suffix}")
+    add_test(two_clients ${drrun_path} -s 90 -quiet -killpg
       -client ${client1} 0 ''
-      -client ${client2} 1 '' -- bin/${ci_shared_app})
+      -client ${client2} 1 '' ${dr_test_ops} -- ${app_path})
   endif (UNIX)
 endif (BUILD_SAMPLES)
 


### PR DESCRIPTION
In `module_lookup_symbol`, which is invoked from DynamoRIO's private loader, skip other top-level client modules (but not extensions/libraries) because some will not be initialised and top-level clients should be leaves of the dependency tree and not provide symbols for other modules. Top-level client modules are recognised using a new module flag, `is_top_level_client`.

Also add a test that two clients can be loaded without a crash.

Fixes #4501