### PR TITLE
Add missing override keyword in memtrace unit tests

### DIFF
--- a/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/trace_interval_analysis_unit_tests.cpp
@@ -249,7 +249,7 @@ public:
     }
     bool
     finalize_interval_snapshots(
-        std::vector<interval_state_snapshot_t *> &interval_snapshots)
+        std::vector<interval_state_snapshot_t *> &interval_snapshots) override
     {
         if (saw_serial_generate_snapshot_) {
             error_string_ = "Did not expect finalize_interval_snapshots call in serial "


### PR DESCRIPTION
My local compiler (clang 14.0.0) complained about a missing override keyword in trace_interval_analysis_unit_tests.c; fixed here.