### PR TITLE
i#6938 sched migrate: All options in microseconds + single scale

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -553,13 +553,17 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::init_dynamic_schedule()
         op_sched_order_time.get_value() ? sched_type_t::DEPENDENCY_TIMESTAMPS
                                         : sched_type_t::DEPENDENCY_IGNORE,
         sched_type_t::SCHEDULER_DEFAULTS, op_verbose.get_value());
-    sched_ops.quantum_duration = op_sched_quantum.get_value();
-    if (op_sched_time.get_value())
+    sched_ops.time_units_per_us = op_sched_time_per_us.get_value();
+    if (op_sched_time.get_value()) {
         sched_ops.quantum_unit = sched_type_t::QUANTUM_TIME;
+        sched_ops.quantum_duration_us = op_sched_quantum.get_value();
+    } else {
+        sched_ops.quantum_duration_instrs = op_sched_quantum.get_value();
+    }
     sched_ops.syscall_switch_threshold = op_sched_syscall_switch_us.get_value();
     sched_ops.blocking_switch_threshold = op_sched_blocking_switch_us.get_value();
-    sched_ops.block_time_scale = op_sched_block_scale.get_value();
-    sched_ops.block_time_max = op_sched_block_max_us.get_value();
+    sched_ops.block_time_multiplier = op_sched_block_scale.get_value();
+    sched_ops.block_time_max_us = op_sched_block_max_us.get_value();
     sched_ops.randomize_next_input = op_sched_randomize.get_value();
     sched_ops.honor_direct_switches = !op_sched_disable_direct_switches.get_value();
 #ifdef HAS_ZIP

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -928,7 +928,7 @@ droption_t<uint64_t> op_sched_blocking_switch_us(
     "-core_serial. ");
 
 droption_t<double> op_sched_block_scale(
-    DROPTION_SCOPE_ALL, "sched_block_scale", 0.01, "Input block time scale factor",
+    DROPTION_SCOPE_ALL, "sched_block_scale", 0.1, "Input block time scale factor",
     "This value is multiplied by -sched_time_per_us to produce a scale which is applied "
     "to the as-traced microsecond latency of blocking system calls to produce the block "
     "time during simulation.  A higher value here results in blocking syscalls keeping "
@@ -945,7 +945,7 @@ droption_t<double> op_sched_block_scale(
 // long idle times with local analyzers; it may need to be increased with more
 // heavyweight analyzers/simulators.
 // TODO i#6959: Once we have -exit_if_all_unscheduled raise this.
-droption_t<uint64_t> op_sched_block_max_us(DROPTION_SCOPE_ALL, "sched_block_max_us", 250,
+droption_t<uint64_t> op_sched_block_max_us(DROPTION_SCOPE_ALL, "sched_block_max_us", 2500,
                                            "Maximum blocked input time, in microseconds",
                                            "The maximum blocked time, after scaling with "
                                            "-sched_block_scale.");
@@ -991,6 +991,13 @@ droption_t<bool> op_sched_disable_direct_switches(
     "and causes the associated system call to be treated like any other call with a "
     "switch being determined by latency and the next input in the queue.  The "
     "TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH markers are not removed from the trace.");
+
+droption_t<double> op_sched_time_units_per_us(
+    DROPTION_SCOPE_ALL, "sched_time_units_per_us", 100.,
+    "Time units per simulated microsecond",
+    "Time units (currently wall-clock time) per simulated microsecond.  This scales all "
+    "of the -sched_*_us values as it concerts wall-clock time into the simulated "
+    "microseconds measured by those options.");
 
 // Schedule_stats options.
 droption_t<uint64_t>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -893,8 +893,8 @@ droption_t<double>
                          "Wall-clock microseconds per simulated microsecond.");
 
 droption_t<int64_t>
-    // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
-    op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 6 * 1000 * 1000,
+    // We pick 10 million to match 2 instructions per nanosecond with a 5ms quantum.
+    op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 10 * 1000 * 1000,
                      "Scheduling quantum",
                      "Applies to -core_sharded and -core_serial. "
                      "Scheduling quantum in instructions, unless -sched_time is set in "
@@ -929,10 +929,13 @@ droption_t<uint64_t> op_sched_blocking_switch_us(
 
 droption_t<double> op_sched_block_scale(
     DROPTION_SCOPE_ALL, "sched_block_scale", 0.1, "Input block time scale factor",
-    "This value is multiplied by -sched_time_per_us to produce a scale which is applied "
-    "to the as-traced microsecond latency of blocking system calls to produce the block "
-    "time during simulation.  A higher value here results in blocking syscalls keeping "
-    "inputs unscheduled for longer.");
+    "A system call considered to block (see -sched_blocking_switch_us) will "
+    "block in the trace scheduler for an amount of simulator time equal to its "
+    "as-traced latency in trace-time microseconds multiplied by this parameter "
+    "and by -sched_time_per_us in simulated microseconds, subject to a "
+    "maximum of --sched_block_max_us. A higher value here results in blocking "
+    "syscalls keeping inputs unscheduled for longer. There is indirect "
+    "overhead inflating the as-traced times, so a value below 1 is typical.");
 
 // We have a max to avoid outlier latencies from scaling up to extreme times.  There is
 // some inflation in the as-traced latencies and some can be inflated more than others.
@@ -996,7 +999,7 @@ droption_t<double> op_sched_time_units_per_us(
     DROPTION_SCOPE_ALL, "sched_time_units_per_us", 100.,
     "Time units per simulated microsecond",
     "Time units (currently wall-clock time) per simulated microsecond.  This scales all "
-    "of the -sched_*_us values as it concerts wall-clock time into the simulated "
+    "of the -sched_*_us values as it converts wall-clock time into the simulated "
     "microseconds measured by those options.");
 
 // Schedule_stats options.

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -199,6 +199,7 @@ extern dynamorio::droption::droption_t<int> op_kernel_trace_buffer_size_shift;
 #endif
 extern dynamorio::droption::droption_t<bool> op_core_sharded;
 extern dynamorio::droption::droption_t<bool> op_core_serial;
+extern dynamorio::droption::droption_t<double> op_sched_time_per_us;
 extern dynamorio::droption::droption_t<int64_t> op_sched_quantum;
 extern dynamorio::droption::droption_t<bool> op_sched_time;
 extern dynamorio::droption::droption_t<bool> op_sched_order_time;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -3812,6 +3812,30 @@ scheduler_tmpl_t<RecordType, ReaderType>::eof_or_idle(output_ordinal_t output,
         (options_.mapping == MAP_AS_PREVIOUSLY &&
          live_replay_output_count_.load(std::memory_order_acquire) == 0)) {
         assert(options_.mapping != MAP_AS_PREVIOUSLY || outputs_[output].at_eof);
+#if 1 // NOCHECK
+        for (unsigned int i = 0; i < outputs_.size(); ++i) {
+            VPRINT(this, 1, "Stats for output #%d\n", i);
+            VPRINT(
+                this, 1, "  %-25s: %9" PRId64 "\n", "Switch input->input",
+                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_INPUT]);
+            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch input->idle",
+                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE]);
+            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch idle->input",
+                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_IDLE_TO_INPUT]);
+            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch nop",
+                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_NOP]);
+            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Quantum preempts",
+                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS]);
+            VPRINT(
+                this, 1, "  %-25s: %9" PRId64 "\n", "Direct switch attempts",
+                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_ATTEMPTS]);
+            VPRINT(
+                this, 1, "  %-25s: %9" PRId64 "\n", "Direct switch successes",
+                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_SUCCESSES]);
+            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Migrations",
+                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS]);
+        }
+#endif
         return sched_type_t::STATUS_EOF;
     } else {
         bool need_lock;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -3812,30 +3812,6 @@ scheduler_tmpl_t<RecordType, ReaderType>::eof_or_idle(output_ordinal_t output,
         (options_.mapping == MAP_AS_PREVIOUSLY &&
          live_replay_output_count_.load(std::memory_order_acquire) == 0)) {
         assert(options_.mapping != MAP_AS_PREVIOUSLY || outputs_[output].at_eof);
-#if 1 // NOCHECK
-        for (unsigned int i = 0; i < outputs_.size(); ++i) {
-            VPRINT(this, 1, "Stats for output #%d\n", i);
-            VPRINT(
-                this, 1, "  %-25s: %9" PRId64 "\n", "Switch input->input",
-                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_INPUT]);
-            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch input->idle",
-                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE]);
-            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch idle->input",
-                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_IDLE_TO_INPUT]);
-            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch nop",
-                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_NOP]);
-            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Quantum preempts",
-                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS]);
-            VPRINT(
-                this, 1, "  %-25s: %9" PRId64 "\n", "Direct switch attempts",
-                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_ATTEMPTS]);
-            VPRINT(
-                this, 1, "  %-25s: %9" PRId64 "\n", "Direct switch successes",
-                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_SUCCESSES]);
-            VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Migrations",
-                   outputs_[i].stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS]);
-        }
-#endif
         return sched_type_t::STATUS_EOF;
     } else {
         bool need_lock;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -898,6 +898,10 @@ template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::legacy_field_support()
 {
+    if (options_.time_units_per_us == 0) {
+        error_string_ = "time_units_per_us must be > 0";
+        return STATUS_ERROR_INVALID_PARAMETER;
+    }
     if (options_.quantum_duration > 0) {
         if (options_.struct_size > offsetof(scheduler_options_t, quantum_duration_us)) {
             error_string_ = "quantum_duration is deprecated; use quantum_duration_us and "
@@ -947,10 +951,6 @@ scheduler_tmpl_t<RecordType, ReaderType>::legacy_field_support()
     }
     if (options_.block_time_max_us == 0) {
         error_string_ = "block_time_max_us must be > 0";
-        return STATUS_ERROR_INVALID_PARAMETER;
-    }
-    if (options_.time_units_per_us == 0) {
-        error_string_ = "time_units_per_us must be > 0";
         return STATUS_ERROR_INVALID_PARAMETER;
     }
     return STATUS_SUCCESS;

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cinttypes>
+#include <cstddef>
 #include <cstdio>
 #include <iomanip>
 #include <limits>

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -949,6 +949,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::legacy_field_support()
         error_string_ = "block_time_max_us must be > 0";
         return STATUS_ERROR_INVALID_PARAMETER;
     }
+    if (options_.time_units_per_us == 0) {
+        error_string_ = "time_units_per_us must be > 0";
+        return STATUS_ERROR_INVALID_PARAMETER;
+    }
     return STATUS_SUCCESS;
 }
 
@@ -2615,17 +2619,17 @@ template <typename RecordType, typename ReaderType>
 uint64_t
 scheduler_tmpl_t<RecordType, ReaderType>::scale_blocked_time(uint64_t initial_time) const
 {
-    uint64_t scaled = static_cast<uint64_t>(static_cast<double>(initial_time) *
-                                            options_.block_time_multiplier);
-    if (scaled > options_.block_time_max_us) {
+    uint64_t scaled_us = static_cast<uint64_t>(static_cast<double>(initial_time) *
+                                               options_.block_time_multiplier);
+    if (scaled_us > options_.block_time_max_us) {
         // We have a max to avoid outlier latencies that are already a second or
         // more from scaling up to tens of minutes.  We assume a cap is representative
         // as the outliers likely were not part of key dependence chains.  Without a
         // cap the other threads all finish and the simulation waits for tens of
         // minutes further for a couple of outliers.
-        scaled = options_.block_time_max_us;
+        scaled_us = options_.block_time_max_us;
     }
-    return scaled;
+    return static_cast<uint64_t>(scaled_us * options_.time_units_per_us);
 }
 
 template <typename RecordType, typename ReaderType>
@@ -3583,7 +3587,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                 prev_time_in_quantum = input->prev_time_in_quantum;
                 input->prev_time_in_quantum = cur_time;
                 double elapsed_micros =
-                    input->time_spent_in_quantum * options_.time_units_per_us;
+                    static_cast<double>(input->time_spent_in_quantum) /
+                    options_.time_units_per_us;
                 if (elapsed_micros >= options_.quantum_duration_us &&
                     // We only switch on instruction boundaries.  We could possibly switch
                     // in between (e.g., scatter/gather long sequence of reads/writes) by

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -733,9 +733,9 @@ public:
          * picoseconds, pass one million here.  This is used to scale all of the
          * other parameters that are in microseconds (they all end in "_us": e.g.,
          * #quantum_duration_us) so that they operate on the right time scale for the
-         * passed-in simulator time.
+         * passed-in simulator time (or wall-clock microseconds if no time is passed).
          */
-        double time_units_per_us = 1000.;
+        double time_units_per_us = 100.;
         /**
          * The scheduling quantum duration for preemption, in simulated microseconds,
          * for #QUANTUM_TIME.  This value is multiplied by #time_units_per_us to
@@ -748,8 +748,8 @@ public:
          * for #QUANTUM_INSTRUCTIONS.  The time passed to next_record() is ignored
          * for purposes of quantum preempts.
          */
-        // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
-        uint64_t quantum_duration_instrs = 6 * 1000 * 1000;
+        // We pick 10 million to match 2 instructions per nanosecond with a 5ms quantum.
+        uint64_t quantum_duration_instrs = 10 * 1000 * 1000;
         /**
          * Controls the amount of time inputs are considered blocked at a syscall
          * whose as-traced latency (recorded in timestamp records in the trace)
@@ -767,7 +767,7 @@ public:
          * with #block_time_max_us, can be tuned to achieve a desired idle rate.
          * The default value errs on the side of less idle time.
          */
-        double block_time_multiplier = 0.01;
+        double block_time_multiplier = 0.1;
         /**
          * The maximum time in microseconds for an input to be considered blocked for
          * any one system call.  This value is multiplied by #time_units_per_us to
@@ -779,7 +779,7 @@ public:
          * after this amount of time those inputs are all re-scheduled.
          */
         // TODO i#6959: Once we have -exit_if_all_unscheduled raise this.
-        uint64_t block_time_max_us = 250;
+        uint64_t block_time_max_us = 2500;
     };
 
     /**
@@ -1364,11 +1364,11 @@ protected:
         uint64_t syscall_timeout_arg = 0;
         // Used to switch before we've read the next instruction.
         bool switching_pre_instruction = false;
-        // Used for time-based quanta.
+        // Used for time-based quanta.  The units are simulation time.
         uint64_t prev_time_in_quantum = 0;
         uint64_t time_spent_in_quantum = 0;
         // These fields model waiting at a blocking syscall.
-        // The units are us for instr quanta and simuilation time for time quanta.
+        // The units are in simuilation time.
         uint64_t blocked_time = 0;
         uint64_t blocked_start_time = 0;
         // An input can be "unscheduled" and not on the ready_priority_ run queue at all

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -595,8 +595,8 @@ public:
         /** The unit of the schedule time quantum. */
         quantum_unit_t quantum_unit = QUANTUM_INSTRUCTIONS;
         /**
-         * Deprecated: use #quantum_duration_us and #time_units_per_us for #QUANTUM_TIME
-         * or #quantum_duration_instrs for #QUANTUM_INSTRUCTIONS instead.  It
+         * Deprecated: use #quantum_duration_us and #time_units_per_us for #QUANTUM_TIME,
+         * or #quantum_duration_instrs for #QUANTUM_INSTRUCTIONS, instead.  It
          * is an error to set this to a non-zero value when #struct_size includes
          * #quantum_duration_us.  When #struct_size does not include
          * #quantum_duration_us and this value is non-zero, the value in
@@ -756,7 +756,7 @@ public:
          * exceeds #syscall_switch_threshold or #blocking_switch_threshold.  The
          * as-traced syscall latency (which is in traced microseconds) is multiplied
          * by this field to produce the blocked time in simulated microseconds.  Once
-         * that many simulated microseconds has passed according to the "cur_time"
+         * that many simulated microseconds have passed according to the "cur_time"
          * value passed to next_record() (multiplied by #time_units_per_us), the
          * input will be no longer considered blocked.  The blocked time is clamped
          * to a maximum value controlled by #block_time_max.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -595,12 +595,15 @@ public:
         /** The unit of the schedule time quantum. */
         quantum_unit_t quantum_unit = QUANTUM_INSTRUCTIONS;
         /**
-         * The scheduling quantum duration for preemption.  The units are
-         * specified by
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::scheduler_options_t::quantum_unit.
+         * Deprecated: use #quantum_duration_us and #time_units_per_us for #QUANTUM_TIME
+         * or #quantum_duration_instrs for #QUANTUM_INSTRUCTIONS instead.  It
+         * is an error to set this to a non-zero value when #struct_size includes
+         * #quantum_duration_us.  When #struct_size does not include
+         * #quantum_duration_us and this value is non-zero, the value in
+         * #quantum_duration_us is replaced with this value divided by the default
+         * value of #time_units_per_us.
          */
-        // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
-        uint64_t quantum_duration = 6 * 1000 * 1000;
+        uint64_t quantum_duration = 0;
         /**
          * If > 0, diagnostic messages are printed to stderr.  Higher values produce
          * more frequent diagnostics.
@@ -643,37 +646,21 @@ public:
          */
         uint64_t blocking_switch_threshold = 100;
         /**
-         * Controls the amount of time inputs are considered blocked at a syscall whose
-         * latency exceeds #syscall_switch_threshold or #blocking_switch_threshold.  The
-         * syscall latency (in microseconds) is multiplied by this field to produce the
-         * blocked time.  For #QUANTUM_TIME, that blocked time in the units reported by
-         * the time parameter to next_record() must pass before the input is no longer
-         * considered blocked.  Since the system call latencies are in microseconds, this
-         * #block_time_scale should be set to the number of next_record() time units in
-         * one simulated microsecond.  For #QUANTUM_INSTRUCTIONS, the blocked time in
-         * wall-clock microseconds must pass before the input is actually selected
-         * (wall-clock time is used as there is no reasonable alternative with no other
-         * uniform notion of time); thus, the #block_time_scale value here should equal
-         * the slowdown of the instruction record processing versus the original
-         * (untraced) application execution.  The blocked time is clamped to a maximum
-         * value controlled by #block_time_max.
-         *
-         * The default value is meant to be reasonable for simple analyzers.  It may
-         * result in too much or too little idle time depending on the analyzer or
-         * simulator and its speed; it is meant to be tuned and modified.
+         * Deprecated: use #block_time_multiplier instead.  It is an error to set
+         * this to a non-zero value when #struct_size includes #block_time_multiplier.
+         * When #struct_size does not include #block_time_multiplier and this value is
+         * non-zero, the value in #block_time_multiplier is replaced with this value
+         * divided by the default value of #time_units_per_us.
          */
-        double block_time_scale = 10.;
+        double block_time_scale = 0.;
         /**
-         * The maximum time, in the units explained by #block_time_scale (either
-         * #QUANTUM_TIME simulator time or wall-clock microseconds for
-         * #QUANTUM_INSTRUCTIONS), for an input to be considered blocked for any one
-         * system call.  This is applied after multiplying by #block_time_scale.
-         * This is also used as a fallback to avoid hangs when there are no scheduled
-         * inputs: if the only inputs left are "unscheduled" (see
-         * #TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE), after this amount of time those
-         * inputs are all re-scheduled.
+         * Deprecated: use #block_time_max_us and #time_units_per_us instead.  It is
+         * an error to set this to a non-zero value when #struct_size includes
+         * #block_time_max_us.  When #struct_size does not include #block_time_max_us
+         * and this value is non-zero, the value in #block_time_max_us is replaced
+         * with this value divided by the default value of #time_units_per_us.
          */
-        uint64_t block_time_max = 250000;
+        uint64_t block_time_max = 0;
         // XXX: Should we share the file-to-reader code currently in the scheduler
         // with the analyzer and only then need reader interfaces and not pass paths
         // to the scheduler?
@@ -740,6 +727,59 @@ public:
          * (these markers remain: they are not removed from the trace).
          */
         bool honor_direct_switches = true;
+        /**
+         * How many time units for the "cur_time" value passed to next_record() are
+         * equivalent to one simulated microsecond.  E.g., if the time units are in
+         * picoseconds, pass one million here.  This is used to scale all of the
+         * other parameters that are in microseconds (they all end in "_us": e.g.,
+         * #quantum_duration_us) so that they operate on the right time scale for the
+         * passed-in simulator time.
+         */
+        double time_units_per_us = 1000.;
+        /**
+         * The scheduling quantum duration for preemption, in simulated microseconds,
+         * for #QUANTUM_TIME.  This value is multiplied by #time_units_per_us to
+         * produce a value that is compared to the "cur_time" parameter to
+         * next_record() to determine when to force a quantum switch.
+         */
+        uint64_t quantum_duration_us = 5000;
+        /**
+         * The scheduling quantum duration for preemption, in instruction count,
+         * for #QUANTUM_INSTRUCTIONS.  The time passed to next_record() is ignored
+         * for purposes of quantum preempts.
+         */
+        // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
+        uint64_t quantum_duration_instrs = 6 * 1000 * 1000;
+        /**
+         * Controls the amount of time inputs are considered blocked at a syscall
+         * whose as-traced latency (recorded in timestamp records in the trace)
+         * exceeds #syscall_switch_threshold or #blocking_switch_threshold.  The
+         * as-traced syscall latency (which is in traced microseconds) is multiplied
+         * by this field to produce the blocked time in simulated microseconds.  Once
+         * that many simulated microseconds has passed according to the "cur_time"
+         * value passed to next_record() (multiplied by #time_units_per_us), the
+         * input will be no longer considered blocked.  The blocked time is clamped
+         * to a maximum value controlled by #block_time_max.
+         *
+         * While there is no direct overhead during tracing, indirect overhead
+         * does result in some inflation of recorded system call latencies.
+         * Thus, a value below 0 is typically used here.  This value, in combination
+         * with #block_time_max_us, can be tuned to achieve a desired idle rate.
+         * The default value errs on the side of less idle time.
+         */
+        double block_time_multiplier = 0.01;
+        /**
+         * The maximum time in microseconds for an input to be considered blocked for
+         * any one system call.  This value is multiplied by #time_units_per_us to
+         * produce a value that is compared to the "cur_time" parameter to
+         * next_record().  If any block time (see #block_time_multiplier) exceeds
+         * this value, it is capped to this value.  This value is also used as a
+         * fallback to avoid hangs when there are no scheduled inputs: if the only
+         * inputs left are "unscheduled" (see #TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE),
+         * after this amount of time those inputs are all re-scheduled.
+         */
+        // TODO i#6959: Once we have -exit_if_all_unscheduled raise this.
+        uint64_t block_time_max_us = 250;
     };
 
     /**
@@ -1531,6 +1571,9 @@ protected:
     virtual bool
     process_next_initial_record(input_info_t &input, RecordType record,
                                 bool &found_filetype, bool &found_timestamp);
+
+    scheduler_status_t
+    legacy_field_support();
 
     // Opens readers for each file in 'path', subject to the constraints in
     // 'reader_info'.  'path' may be a directory.

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -307,10 +307,13 @@ _tmain(int argc, const TCHAR *targv[])
         op_honor_stamps.get_value() ? scheduler_t::DEPENDENCY_TIMESTAMPS
                                     : scheduler_t::DEPENDENCY_IGNORE,
         scheduler_t::SCHEDULER_DEFAULTS, op_verbose.get_value());
-    sched_ops.quantum_duration = op_sched_quantum.get_value();
-    if (op_sched_time.get_value())
+    if (op_sched_time.get_value()) {
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
-    sched_ops.block_time_scale = op_block_time_scale.get_value();
+        sched_ops.quantum_duration_us = op_sched_quantum.get_value();
+    } else {
+        sched_ops.quantum_duration_instrs = op_sched_quantum.get_value();
+    }
+    sched_ops.block_time_multiplier = op_block_time_scale.get_value();
 #ifdef HAS_ZIP
     std::unique_ptr<zipfile_ostream_t> record_zip;
     std::unique_ptr<zipfile_istream_t> replay_zip;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -166,10 +166,13 @@ verify_scheduler_stats(scheduler_t::stream_t *stream, int64_t switch_input_to_in
            migrations);
 }
 
-// Returns a string with one char per input.
+// Returns a vector of strings, one per ouput, where each string has one char per input
+// showing the order of inputs scheduled onto that output.
 // Assumes the input threads are all tid_base plus an offset < 26.
-// When send_time=true, typically time_units_per_us should be set to 1 to then have
-// instruction count for all timing measures.
+// When send_time=true, the record count is passed to the scheduler as the current
+// time, to avoid relying on wall-clock time.  For this use case of send_time=true,
+// typically time_units_per_us should be set to 1 to avoid any scaling of the record
+// count for simpler small tests.
 static std::vector<std::string>
 run_lockstep_simulation(scheduler_t &scheduler, int num_outputs, memref_tid_t tid_base,
                         bool send_time = false, bool print_markers = true)

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -439,7 +439,7 @@ test_legacy_fields()
     // We do not want to block for very long.
     static constexpr uint64_t BLOCK_LATENCY = 200;
     static constexpr double BLOCK_SCALE = 0.01;
-    static constexpr double BLOCK_MAX = 50;
+    static constexpr uint64_t BLOCK_MAX = 50;
     static constexpr memref_tid_t TID_BASE = 100;
     static constexpr uint64_t START_TIME = 20;
     std::vector<trace_entry_t> inputs[NUM_INPUTS];

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -160,6 +160,101 @@ verify_scheduler_stats(scheduler_t::stream_t *stream, int64_t switch_input_to_in
            migrations);
 }
 
+// Returns a string with one char per input.
+// Assumes the input threads are all tid_base plus an offset < 26.
+// When send_time=true, typically time_units_per_us should be set to 1 to then have
+// instruction count for all timing measures.
+static std::vector<std::string>
+run_lockstep_simulation(scheduler_t &scheduler, int num_outputs, memref_tid_t tid_base,
+                        bool send_time = false, bool print_markers = true)
+{
+    // Walk the outputs in lockstep for crude but deterministic concurrency.
+    std::vector<scheduler_t::stream_t *> outputs(num_outputs, nullptr);
+    std::vector<bool> eof(num_outputs, false);
+    for (int i = 0; i < num_outputs; i++)
+        outputs[i] = scheduler.get_stream(i);
+    int num_eof = 0;
+    int64_t meta_records = 0;
+    // Record the threads, one char each.
+    std::vector<std::string> sched_as_string(num_outputs);
+    static constexpr char THREAD_LETTER_START = 'A';
+    static constexpr char WAIT_SYMBOL = '-';
+    static constexpr char IDLE_SYMBOL = '_';
+    static constexpr char NON_INSTR_SYMBOL = '.';
+    while (num_eof < num_outputs) {
+        for (int i = 0; i < num_outputs; i++) {
+            if (eof[i])
+                continue;
+            memref_t memref;
+            scheduler_t::stream_status_t status;
+            if (send_time) {
+                // We assume IPC=1 and so send the instruction count (+1 to avoid an
+                // invalid time of 0) which allows apples-to-apples comparisons with
+                // instruction quanta.  This is a per-output time which technically
+                // violates the globally-increasing requirement, so this will not work
+                // perfectly with i/o waits, but should work fine for basic tests.
+                // We add the wait and idle records to make progress with idle time.
+                status = outputs[i]->next_record(
+                    memref, outputs[i]->get_instruction_ordinal() + 1 + meta_records);
+            } else {
+                status = outputs[i]->next_record(memref);
+            }
+            if (status == scheduler_t::STATUS_EOF) {
+                ++num_eof;
+                eof[i] = true;
+                continue;
+            }
+            if (status == scheduler_t::STATUS_WAIT) {
+                sched_as_string[i] += WAIT_SYMBOL;
+                ++meta_records;
+                continue;
+            }
+            if (status == scheduler_t::STATUS_IDLE) {
+                sched_as_string[i] += IDLE_SYMBOL;
+                ++meta_records;
+                continue;
+            }
+            assert(status == scheduler_t::STATUS_OK);
+            if (type_is_instr(memref.instr.type)) {
+                sched_as_string[i] +=
+                    THREAD_LETTER_START + static_cast<char>(memref.instr.tid - tid_base);
+            } else {
+                // While this makes the string longer, it is just too confusing
+                // with the same letter seemingly on 2 cores at once without these
+                // fillers to line everything up in time.
+                sched_as_string[i] += NON_INSTR_SYMBOL;
+            }
+            assert(outputs[i]->get_shard_index() ==
+                   outputs[i]->get_output_stream_ordinal());
+        }
+    }
+    // Ensure we never see the same output on multiple cores in the same timestep.
+    size_t max_size = 0;
+    for (int i = 0; i < num_outputs; ++i)
+        max_size = std::max(max_size, sched_as_string[i].size());
+    for (int step = 0; step < static_cast<int>(max_size); ++step) {
+        std::set<char> inputs;
+        for (int out = 0; out < num_outputs; ++out) {
+            if (static_cast<int>(sched_as_string[out].size()) <= step)
+                continue;
+            if (sched_as_string[out][step] < 'A' || sched_as_string[out][step] > 'Z')
+                continue;
+            assert(inputs.find(sched_as_string[out][step]) == inputs.end());
+            inputs.insert(sched_as_string[out][step]);
+        }
+    }
+    if (!print_markers) {
+        // We kept the dots internally for our same-timestep check above.
+        for (int i = 0; i < num_outputs; ++i) {
+            sched_as_string[i].erase(std::remove(sched_as_string[i].begin(),
+                                                 sched_as_string[i].end(),
+                                                 NON_INSTR_SYMBOL),
+                                     sched_as_string[i].end());
+        }
+    }
+    return sched_as_string;
+}
+
 static void
 test_serial()
 {
@@ -294,7 +389,7 @@ test_parallel()
 }
 
 static void
-test_param_checks()
+test_invalid_regions()
 {
     std::vector<scheduler_t::input_reader_t> readers;
     readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t()),
@@ -331,6 +426,143 @@ test_param_checks()
     assert(
         scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) ==
         scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+}
+
+static void
+test_legacy_fields()
+{
+    std::cerr << "\n----------------\nTesting legacy fields\n";
+    static constexpr int NUM_INPUTS = 7;
+    static constexpr int NUM_OUTPUTS = 2;
+    static constexpr int NUM_INSTRS = 9;
+    static constexpr int QUANTUM_DURATION = 3;
+    // We do not want to block for very long.
+    static constexpr double BLOCK_LATENCY = 200;
+    static constexpr double BLOCK_SCALE = 0.01;
+    static constexpr double BLOCK_MAX = 50;
+    static constexpr memref_tid_t TID_BASE = 100;
+    static constexpr uint64_t START_TIME = 20;
+    std::vector<trace_entry_t> inputs[NUM_INPUTS];
+    for (int i = 0; i < NUM_INPUTS; i++) {
+        memref_tid_t tid = TID_BASE + i;
+        inputs[i].push_back(make_thread(tid));
+        inputs[i].push_back(make_pid(1));
+        inputs[i].push_back(make_version(TRACE_ENTRY_VERSION));
+        inputs[i].push_back(make_timestamp(START_TIME)); // All the same time priority.
+        for (int j = 0; j < NUM_INSTRS; j++) {
+            inputs[i].push_back(make_instr(42 + j * 4));
+            // Including blocking syscalls.
+            if ((i == 0 || i == 1) && j == 1) {
+                inputs[i].push_back(make_timestamp(START_TIME * 2));
+                inputs[i].push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 42));
+                inputs[i].push_back(
+                    make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0));
+                inputs[i].push_back(make_timestamp(START_TIME * 2 + BLOCK_LATENCY));
+            }
+        }
+        inputs[i].push_back(make_exit(tid));
+    }
+    {
+        // Test invalid quantum.
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[0])),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()),
+                             TID_BASE);
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS);
+        sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.quantum_duration = QUANTUM_DURATION;
+        scheduler_t scheduler;
+        assert(scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) ==
+               scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+    }
+    {
+        // Test invalid block scale.
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[0])),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()),
+                             TID_BASE);
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS);
+        sched_ops.block_time_scale = BLOCK_SCALE;
+        scheduler_t scheduler;
+        assert(scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) ==
+               scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+    }
+    {
+        // Test invalid block max.
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[0])),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()),
+                             TID_BASE);
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS);
+        sched_ops.block_time_max = BLOCK_MAX;
+        scheduler_t scheduler;
+        assert(scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) ==
+               scheduler_t::STATUS_ERROR_INVALID_PARAMETER);
+    }
+    {
+        // Test valid legacy fields.
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        for (int i = 0; i < NUM_INPUTS; i++) {
+            std::vector<scheduler_t::input_reader_t> readers;
+            readers.emplace_back(
+                std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[i])),
+                std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_BASE + i);
+            sched_inputs.emplace_back(std::move(readers));
+        }
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/4);
+        // Simulate binary compatibility with a legacy struct.
+        sched_ops.struct_size =
+            offsetof(scheduler_t::scheduler_options_t, time_units_per_us);
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
+        sched_ops.block_time_scale = BLOCK_SCALE;
+        sched_ops.block_time_max = BLOCK_MAX;
+        // To do our test we use instrs-as-time for deterministic block times.
+        sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        std::vector<std::string> sched_as_string =
+            run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_BASE, /*send_time=*/true);
+        // Hardcoding here for the 2 outputs and 7 inputs.
+        // We expect 3 letter sequences (our quantum) alternating every-other as each
+        // core alternates. The dots are markers and thread exits.
+        // A and B have a voluntary switch after their 1st 2 letters, but we expect
+        // the usage to persist to their next scheduling which should only have
+        // a single letter.
+        static const char *const CORE0_SCHED_STRING =
+            "..AA......CCC..EEE..GGGDDDFFFBBBCCC.EEE.AAA.GGG.";
+        static const char *const CORE1_SCHED_STRING =
+            "..BB......DDD..FFFABCCCEEEAAAGGGDDD.FFF.BBB.____";
+        for (int i = 0; i < NUM_OUTPUTS; i++) {
+            std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+        }
+        assert(sched_as_string[0] == CORE0_SCHED_STRING);
+        assert(sched_as_string[1] == CORE1_SCHED_STRING);
+    }
+}
+
+static void
+test_param_checks()
+{
+    test_invalid_regions();
+    test_legacy_fields();
 }
 
 // Tests regions without timestamps for a simple, direct test.
@@ -947,99 +1179,6 @@ test_real_file_queries_and_filters(const char *testdir)
 #endif
 }
 
-// Returns a string with one char per input.
-// Assumes the input threads are all tid_base plus an offset < 26.
-static std::vector<std::string>
-run_lockstep_simulation(scheduler_t &scheduler, int num_outputs, memref_tid_t tid_base,
-                        bool send_time = false, bool print_markers = true)
-{
-    // Walk the outputs in lockstep for crude but deterministic concurrency.
-    std::vector<scheduler_t::stream_t *> outputs(num_outputs, nullptr);
-    std::vector<bool> eof(num_outputs, false);
-    for (int i = 0; i < num_outputs; i++)
-        outputs[i] = scheduler.get_stream(i);
-    int num_eof = 0;
-    int64_t meta_records = 0;
-    // Record the threads, one char each.
-    std::vector<std::string> sched_as_string(num_outputs);
-    static constexpr char THREAD_LETTER_START = 'A';
-    static constexpr char WAIT_SYMBOL = '-';
-    static constexpr char IDLE_SYMBOL = '_';
-    static constexpr char NON_INSTR_SYMBOL = '.';
-    while (num_eof < num_outputs) {
-        for (int i = 0; i < num_outputs; i++) {
-            if (eof[i])
-                continue;
-            memref_t memref;
-            scheduler_t::stream_status_t status;
-            if (send_time) {
-                // We assume IPC=1 and so send the instruction count (+1 to avoid an
-                // invalid time of 0) which allows apples-to-apples comparisons with
-                // instruction quanta.  This is a per-output time which technically
-                // violates the globally-increasing requirement, so this will not work
-                // perfectly with i/o waits, but should work fine for basic tests.
-                // We add the wait and idle records to make progress with idle time.
-                status = outputs[i]->next_record(
-                    memref, outputs[i]->get_instruction_ordinal() + 1 + meta_records);
-            } else {
-                status = outputs[i]->next_record(memref);
-            }
-            if (status == scheduler_t::STATUS_EOF) {
-                ++num_eof;
-                eof[i] = true;
-                continue;
-            }
-            if (status == scheduler_t::STATUS_WAIT) {
-                sched_as_string[i] += WAIT_SYMBOL;
-                ++meta_records;
-                continue;
-            }
-            if (status == scheduler_t::STATUS_IDLE) {
-                sched_as_string[i] += IDLE_SYMBOL;
-                ++meta_records;
-                continue;
-            }
-            assert(status == scheduler_t::STATUS_OK);
-            if (type_is_instr(memref.instr.type)) {
-                sched_as_string[i] +=
-                    THREAD_LETTER_START + static_cast<char>(memref.instr.tid - tid_base);
-            } else {
-                // While this makes the string longer, it is just too confusing
-                // with the same letter seemingly on 2 cores at once without these
-                // fillers to line everything up in time.
-                sched_as_string[i] += NON_INSTR_SYMBOL;
-            }
-            assert(outputs[i]->get_shard_index() ==
-                   outputs[i]->get_output_stream_ordinal());
-        }
-    }
-    // Ensure we never see the same output on multiple cores in the same timestep.
-    size_t max_size = 0;
-    for (int i = 0; i < num_outputs; ++i)
-        max_size = std::max(max_size, sched_as_string[i].size());
-    for (int step = 0; step < static_cast<int>(max_size); ++step) {
-        std::set<char> inputs;
-        for (int out = 0; out < num_outputs; ++out) {
-            if (static_cast<int>(sched_as_string[out].size()) <= step)
-                continue;
-            if (sched_as_string[out][step] < 'A' || sched_as_string[out][step] > 'Z')
-                continue;
-            assert(inputs.find(sched_as_string[out][step]) == inputs.end());
-            inputs.insert(sched_as_string[out][step]);
-        }
-    }
-    if (!print_markers) {
-        // We kept the dots internally for our same-timestep check above.
-        for (int i = 0; i < num_outputs; ++i) {
-            sched_as_string[i].erase(std::remove(sched_as_string[i].begin(),
-                                                 sched_as_string[i].end(),
-                                                 NON_INSTR_SYMBOL),
-                                     sched_as_string[i].end());
-        }
-    }
-    return sched_as_string;
-}
-
 static void
 test_synthetic()
 {
@@ -1095,8 +1234,8 @@ test_synthetic()
                                                    scheduler_t::DEPENDENCY_IGNORE,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_DURATION;
-        sched_ops.block_time_scale = BLOCK_SCALE;
+        sched_ops.quantum_duration_instrs = QUANTUM_DURATION;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -1160,8 +1299,9 @@ test_synthetic()
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
-        sched_ops.quantum_duration = QUANTUM_DURATION;
-        sched_ops.block_time_scale = BLOCK_SCALE;
+        sched_ops.time_units_per_us = 1.;
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -1223,9 +1363,10 @@ test_synthetic_time_quanta()
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/4);
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
-        sched_ops.quantum_duration = 3;
+        sched_ops.time_units_per_us = 1.;
+        sched_ops.quantum_duration_us = 3;
         // Ensure it waits 10 steps.
-        sched_ops.block_time_scale = 10. / (POST_BLOCK_TIME - PRE_BLOCK_TIME);
+        sched_ops.block_time_multiplier = 10. / (POST_BLOCK_TIME - PRE_BLOCK_TIME);
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -1408,7 +1549,7 @@ test_synthetic_with_timestamps()
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/3);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_instrs = 3;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -1506,7 +1647,7 @@ test_synthetic_with_priorities()
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/3);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_instrs = 3;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -1592,7 +1733,7 @@ test_synthetic_with_bindings_time(bool time_deps)
         time_deps ? scheduler_t::DEPENDENCY_TIMESTAMPS : scheduler_t::DEPENDENCY_IGNORE,
         scheduler_t::SCHEDULER_DEFAULTS,
         /*verbosity=*/3);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_instrs = 3;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -1646,7 +1787,7 @@ test_synthetic_with_bindings_more_out()
                                                scheduler_t::DEPENDENCY_IGNORE,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/3);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_instrs = 3;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -1716,7 +1857,7 @@ test_synthetic_with_bindings_weighted()
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/3);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_instrs = 3;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -1828,11 +1969,12 @@ test_synthetic_with_syscalls_multiple()
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/3);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_us = 3;
     // We use our mock's time==instruction count for a deterministic result.
     sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+    sched_ops.time_units_per_us = 1.;
     sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-    sched_ops.block_time_scale = BLOCK_SCALE;
+    sched_ops.block_time_multiplier = BLOCK_SCALE;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -1936,11 +2078,12 @@ test_synthetic_with_syscalls_single()
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/4);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_us = 3;
     // We use our mock's time==instruction count for a deterministic result.
     sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+    sched_ops.time_units_per_us = 1.;
     sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-    sched_ops.block_time_scale = BLOCK_SCALE;
+    sched_ops.block_time_multiplier = BLOCK_SCALE;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -2141,7 +2284,7 @@ test_synthetic_with_syscalls_latencies()
     // We use a mock time for a deterministic result.
     sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
     sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-    sched_ops.block_time_scale = BLOCK_SCALE;
+    sched_ops.block_time_multiplier = BLOCK_SCALE;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, 1, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -2247,11 +2390,12 @@ test_synthetic_with_syscalls_idle()
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/3);
-    sched_ops.quantum_duration = 3;
+    sched_ops.quantum_duration_us = 3;
     // We use a mock time for a deterministic result.
     sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+    sched_ops.time_units_per_us = 1.;
     sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-    sched_ops.block_time_scale = BLOCK_SCALE;
+    sched_ops.block_time_multiplier = BLOCK_SCALE;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -2312,7 +2456,7 @@ test_synthetic_multi_threaded(const char *testdir)
                                                /*verbosity=*/2);
     static constexpr int NUM_OUTPUTS = 4;
     static constexpr int QUANTUM_DURATION = 2000;
-    sched_ops.quantum_duration = QUANTUM_DURATION;
+    sched_ops.quantum_duration_instrs = QUANTUM_DURATION;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
         assert(false);
@@ -2544,7 +2688,7 @@ test_replay()
                                                    scheduler_t::DEPENDENCY_IGNORE,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_INSTRS;
+        sched_ops.quantum_duration_instrs = QUANTUM_INSTRS;
 
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
@@ -2672,7 +2816,7 @@ test_replay_multi_threaded(const char *testdir)
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
         static constexpr int QUANTUM_DURATION = 2000;
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_instrs = QUANTUM_DURATION;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
             assert(false);
@@ -3300,7 +3444,7 @@ test_replay_limit()
                                                    /*verbosity=*/2);
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
-        sched_ops.quantum_duration = NUM_INSTRS / 10;
+        sched_ops.quantum_duration_instrs = NUM_INSTRS / 10;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
             assert(false);
@@ -4029,7 +4173,7 @@ test_inactive()
                                                    scheduler_t::DEPENDENCY_IGNORE,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/4);
-        sched_ops.quantum_duration = 2;
+        sched_ops.quantum_duration_instrs = 2;
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -4253,11 +4397,12 @@ test_direct_switch()
                                                    scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
         // We use our mock's time==instruction count for a deterministic result.
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -4293,11 +4438,12 @@ test_direct_switch()
                                                    scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
         // We use our mock's time==instruction count for a deterministic result.
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
         sched_ops.honor_direct_switches = false;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -4460,11 +4606,12 @@ test_unscheduled()
                                                    scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
         // We use our mock's time==instruction count for a deterministic result.
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -4497,11 +4644,12 @@ test_unscheduled()
                                                    scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
         // We use our mock's time==instruction count for a deterministic result.
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
         sched_ops.honor_direct_switches = false;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -4644,12 +4792,13 @@ test_unscheduled_fallback()
                                                    scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
         // We use our mock's time==instruction count for a deterministic result.
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
-        sched_ops.block_time_max = BLOCK_TIME_MAX;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
+        sched_ops.block_time_max_us = BLOCK_TIME_MAX;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -4681,12 +4830,13 @@ test_unscheduled_fallback()
                                                    scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_us = QUANTUM_DURATION;
         // We use our mock's time==instruction count for a deterministic result.
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
-        sched_ops.block_time_max = BLOCK_TIME_MAX;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
+        sched_ops.block_time_max_us = BLOCK_TIME_MAX;
         sched_ops.honor_direct_switches = false;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -4768,9 +4918,10 @@ test_unscheduled_initially()
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
-        sched_ops.block_time_max = BLOCK_TIME_MAX;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
+        sched_ops.block_time_max_us = BLOCK_TIME_MAX;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -4801,9 +4952,10 @@ test_unscheduled_initially()
                                                    /*verbosity=*/3);
         // We use our mock's time==instruction count for a deterministic result.
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
-        sched_ops.block_time_scale = BLOCK_SCALE;
-        sched_ops.block_time_max = BLOCK_TIME_MAX;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
+        sched_ops.block_time_max_us = BLOCK_TIME_MAX;
         sched_ops.honor_direct_switches = false;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -5014,7 +5166,7 @@ test_kernel_switch_sequences()
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
                                                /*verbosity=*/4);
-    sched_ops.quantum_duration = INSTR_QUANTUM;
+    sched_ops.quantum_duration_instrs = INSTR_QUANTUM;
     sched_ops.kernel_switch_reader = std::move(switch_reader);
     sched_ops.kernel_switch_reader_end = std::move(switch_reader_end);
     scheduler_t scheduler;
@@ -5242,7 +5394,7 @@ test_random_schedule()
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
         sched_ops.randomize_next_input = true;
-        sched_ops.quantum_duration = QUANTUM_DURATION;
+        sched_ops.quantum_duration_instrs = QUANTUM_DURATION;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -5328,8 +5480,8 @@ test_record_scheduler()
         record_scheduler_t::MAP_TO_ANY_OUTPUT, record_scheduler_t::DEPENDENCY_IGNORE,
         record_scheduler_t::SCHEDULER_DEFAULTS,
         /*verbosity=*/4);
-    sched_ops.quantum_duration = 2;
-    sched_ops.block_time_scale = 0.001; // Do not stay blocked.
+    sched_ops.quantum_duration_instrs = 2;
+    sched_ops.block_time_multiplier = 0.001; // Do not stay blocked.
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         record_scheduler_t::STATUS_SUCCESS)
         assert(false);
@@ -5457,6 +5609,7 @@ test_main(int argc, const char *argv[])
     test_kernel_switch_sequences();
     test_random_schedule();
     test_record_scheduler();
+
     dr_standalone_exit();
     return 0;
 }

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -437,7 +437,7 @@ test_legacy_fields()
     static constexpr int NUM_INSTRS = 9;
     static constexpr int QUANTUM_DURATION = 3;
     // We do not want to block for very long.
-    static constexpr double BLOCK_LATENCY = 200;
+    static constexpr uint64_t BLOCK_LATENCY = 200;
     static constexpr double BLOCK_SCALE = 0.01;
     static constexpr double BLOCK_MAX = 50;
     static constexpr memref_tid_t TID_BASE = 100;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1242,6 +1242,7 @@ test_synthetic()
                                                    /*verbosity=*/3);
         sched_ops.quantum_duration_instrs = QUANTUM_DURATION;
         sched_ops.block_time_multiplier = BLOCK_SCALE;
+        sched_ops.time_units_per_us = 1.;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -2289,6 +2290,7 @@ test_synthetic_with_syscalls_latencies()
                                                /*verbosity=*/4);
     // We use a mock time for a deterministic result.
     sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+    sched_ops.time_units_per_us = 1.;
     sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
     sched_ops.block_time_multiplier = BLOCK_SCALE;
     scheduler_t scheduler;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -34,14 +34,20 @@
 #undef NDEBUG
 #include <assert.h>
 #include <algorithm>
+#include <cstddef>
 #include <cstring>
 #include <iostream>
+#include <set>
+#include <string>
 #include <thread>
 #include <vector>
+#include <utility>
 
 #include "dr_api.h"
 #include "scheduler.h"
 #include "mock_reader.h"
+#include "memref.h"
+#include "trace_entry.h"
 #ifdef HAS_ZIP
 #    include "zipfile_istream.h"
 #    include "zipfile_ostream.h"

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -166,7 +166,7 @@ verify_scheduler_stats(scheduler_t::stream_t *stream, int64_t switch_input_to_in
            migrations);
 }
 
-// Returns a vector of strings, one per ouput, where each string has one char per input
+// Returns a vector of strings, one per output, where each string has one char per input
 // showing the order of inputs scheduled onto that output.
 // Assumes the input threads are all tid_base plus an offset < 26.
 // When send_time=true, the record count is passed to the scheduler as the current


### PR DESCRIPTION
Refactors the scheduler's time-oriented options to become based on simulated microseconds rather than being unitless and having to all be separately scaled depending on the simulator's clock.

Deprecates these scheduler_options_t fields, replacing them with new versions:
+ quantum_duration => quantum_duration_{instructions,us}
+ block_time_scale => block_time_multiplier
+ block_time_max => block_time_max_us

Adds a new "time_units_per_us" which is the single place where a simulator sets the relationship between the value passed to "cur_time" in next_record() and simulated microseconds.  The aforementioned fields are all compared to cur_time multiplied by time_units_per_us.

This is a prelude to adding yet more time-based options for the forthcoming scheduler additions with migration thresholds and rebalance periods.

Adds legacy support for binary compatibility.  Recompiling will result in error messages prompting an update to the new fields.

Adds a unit test of legacy support.

Issue: #6938