### PR TITLE
i#6981: Use consistent version for upload-artifact and download-artifact

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -127,7 +127,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: linux-tarball
         path: DynamoRIO-Linux-${{ steps.version.outputs.version_number }}.tar.gz
@@ -215,7 +215,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload AArch64
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: aarch64-tarball
         path: DynamoRIO-AArch64-Linux-${{ steps.version.outputs.version_number }}.tar.gz
@@ -303,7 +303,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload ARM
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: arm-tarball
         path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
@@ -393,7 +393,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: android-tarball
         path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
@@ -484,7 +484,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: windows-zip
         path: DynamoRIO-Windows-${{ steps.version.outputs.version_number }}.zip
@@ -562,7 +562,7 @@ jobs:
         prerelease: false
 
     - name: Download Linux
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: linux-tarball
     - name: Upload Linux
@@ -577,7 +577,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download AArch64
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: aarch64-tarball
     - name: Upload AArch64
@@ -592,7 +592,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download ARM
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: arm-tarball
     - name: Upload ARM
@@ -607,7 +607,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download Android
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: android-tarball
     - name: Upload Android
@@ -622,7 +622,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download Windows
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: windows-zip
     - name: Upload Windows

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -127,6 +127,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload Artifacts
+      # This points to the latest upload-artifact v4.x.x.
       uses: actions/upload-artifact@v4
       with:
         name: linux-tarball
@@ -215,6 +216,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload AArch64
+      # This points to the latest upload-artifact v4.x.x.
       uses: actions/upload-artifact@v4
       with:
         name: aarch64-tarball
@@ -303,6 +305,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload ARM
+      # This points to the latest upload-artifact v4.x.x.
       uses: actions/upload-artifact@v4
       with:
         name: arm-tarball
@@ -393,6 +396,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload Artifacts
+      # This points to the latest upload-artifact v4.x.x.
       uses: actions/upload-artifact@v4
       with:
         name: android-tarball
@@ -484,6 +488,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
 
     - name: Upload Artifacts
+      # This points to the latest upload-artifact v4.x.x.
       uses: actions/upload-artifact@v4
       with:
         name: windows-zip
@@ -562,6 +567,7 @@ jobs:
         prerelease: false
 
     - name: Download Linux
+      # This points to the latest download-artifact v4.x.x.
       uses: actions/download-artifact@v4
       with:
         name: linux-tarball
@@ -577,6 +583,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download AArch64
+      # This points to the latest download-artifact v4.x.x.
       uses: actions/download-artifact@v4
       with:
         name: aarch64-tarball
@@ -592,6 +599,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download ARM
+      # This points to the latest download-artifact v4.x.x.
       uses: actions/download-artifact@v4
       with:
         name: arm-tarball
@@ -607,6 +615,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download Android
+      # This points to the latest download-artifact v4.x.x.
       uses: actions/download-artifact@v4
       with:
         name: android-tarball
@@ -622,6 +631,7 @@ jobs:
         asset_content_type: application/x-gzip
 
     - name: Download Windows
+      # This points to the latest download-artifact v4.x.x.
       uses: actions/download-artifact@v4
       with:
         name: windows-zip


### PR DESCRIPTION
Changes the version used for upload-artifact and download-artifact actions to the current one recommended at https://github.com/actions/upload-artifact and https://github.com/actions/download-artifact.

For these two actions, "v4" points to the latest available v4.x.x release, as evidenced by the commit hash for the versions at https://github.com/actions/download-artifact/tags and https://github.com/actions/upload-artifact/tags. So we would still be using the latest version as suggested by the security advisory for download-artifact (https://github.com/advisories/GHSA-cxww-7g56-2vh6).

PR #6964 bumped the download-artifact version but not the upload-artifact which caused a mismatch and the #6981 issue.

Test run worked fine: https://github.com/DynamoRIO/dynamorio/actions/runs/10835746272

 Fixes: #6981