### PR TITLE
i#6938 sched migrate: Separate run queue per output

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -553,13 +553,17 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::init_dynamic_schedule()
         op_sched_order_time.get_value() ? sched_type_t::DEPENDENCY_TIMESTAMPS
                                         : sched_type_t::DEPENDENCY_IGNORE,
         sched_type_t::SCHEDULER_DEFAULTS, op_verbose.get_value());
-    sched_ops.quantum_duration = op_sched_quantum.get_value();
-    if (op_sched_time.get_value())
+    sched_ops.time_units_per_us = op_sched_time_per_us.get_value();
+    if (op_sched_time.get_value()) {
         sched_ops.quantum_unit = sched_type_t::QUANTUM_TIME;
+        sched_ops.quantum_duration_us = op_sched_quantum.get_value();
+    } else {
+        sched_ops.quantum_duration_instrs = op_sched_quantum.get_value();
+    }
     sched_ops.syscall_switch_threshold = op_sched_syscall_switch_us.get_value();
     sched_ops.blocking_switch_threshold = op_sched_blocking_switch_us.get_value();
-    sched_ops.block_time_scale = op_sched_block_scale.get_value();
-    sched_ops.block_time_max = op_sched_block_max_us.get_value();
+    sched_ops.block_time_multiplier = op_sched_block_scale.get_value();
+    sched_ops.block_time_max_us = op_sched_block_max_us.get_value();
     sched_ops.randomize_next_input = op_sched_randomize.get_value();
     sched_ops.honor_direct_switches = !op_sched_disable_direct_switches.get_value();
 #ifdef HAS_ZIP

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -98,6 +98,15 @@ public:
          * i.e., the number of input migrations to this core.
          */
         SCHED_STAT_MIGRATIONS,
+        /**
+         * Counts the number of times this output's runqueue became empty and it took
+         * work from another output's runqueue.
+         */
+        SCHED_STAT_RUNQUEUE_STEALS,
+        /**
+         * Counts the number of output runqueue rebalances triggered by this output.
+         */
+        SCHED_STAT_RUNQUEUE_REBALANCES,
         /** Count of statistic types. */
         SCHED_STAT_TYPE_COUNT,
     };

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -199,6 +199,7 @@ extern dynamorio::droption::droption_t<int> op_kernel_trace_buffer_size_shift;
 #endif
 extern dynamorio::droption::droption_t<bool> op_core_sharded;
 extern dynamorio::droption::droption_t<bool> op_core_serial;
+extern dynamorio::droption::droption_t<double> op_sched_time_per_us;
 extern dynamorio::droption::droption_t<int64_t> op_sched_quantum;
 extern dynamorio::droption::droption_t<bool> op_sched_time;
 extern dynamorio::droption::droption_t<bool> op_sched_order_time;

--- a/clients/drcachesim/scheduler/flexible_queue.h
+++ b/clients/drcachesim/scheduler/flexible_queue.h
@@ -108,6 +108,15 @@ public:
         return entries_[rand_gen_() % size()]; // Undefined if empty.
     }
 
+    // Returns an entry from the back -- or at least not from the front; it's not
+    // guaranteed to be the lowest priority, just not the highest.
+    T
+    back()
+    {
+        assert(!empty());
+        return entries_.back();
+    }
+
     bool
     empty() const
     {

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cinttypes>
+#include <cstddef>
 #include <cstdio>
 #include <iomanip>
 #include <limits>
@@ -842,6 +843,11 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
         }
     }
 
+    // Legacy field support.
+    sched_type_t::scheduler_status_t res = legacy_field_support();
+    if (res != sched_type_t::STATUS_SUCCESS)
+        return res;
+
     if (TESTANY(sched_type_t::SCHEDULER_USE_SINGLE_INPUT_ORDINALS, options_.flags) &&
         inputs_.size() == 1 && output_count == 1) {
         options_.flags = static_cast<scheduler_flags_t>(
@@ -881,11 +887,69 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
     VPRINT(this, 1, "%zu inputs\n", inputs_.size());
     live_input_count_.store(static_cast<int>(inputs_.size()), std::memory_order_release);
 
-    sched_type_t::scheduler_status_t res = read_switch_sequences();
+    res = read_switch_sequences();
     if (res != sched_type_t::STATUS_SUCCESS)
         return STATUS_ERROR_INVALID_PARAMETER;
 
     return set_initial_schedule(workload2inputs);
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::legacy_field_support()
+{
+    if (options_.quantum_duration > 0) {
+        if (options_.struct_size > offsetof(scheduler_options_t, quantum_duration_us)) {
+            error_string_ = "quantum_duration is deprecated; use quantum_duration_us and "
+                            "time_units_per_us or quantum_duration_instrs";
+            return STATUS_ERROR_INVALID_PARAMETER;
+        }
+        if (options_.quantum_unit == QUANTUM_INSTRUCTIONS) {
+            options_.quantum_duration_instrs = options_.quantum_duration;
+        } else {
+            options_.quantum_duration_us =
+                static_cast<uint64_t>(static_cast<double>(options_.quantum_duration) /
+                                      options_.time_units_per_us);
+            VPRINT(this, 2,
+                   "Legacy support: setting quantum_duration_us to %" PRIu64 "\n",
+                   options_.quantum_duration_us);
+        }
+    }
+    if (options_.quantum_duration_us == 0) {
+        error_string_ = "quantum_duration_us must be > 0";
+        return STATUS_ERROR_INVALID_PARAMETER;
+    }
+    if (options_.block_time_scale > 0) {
+        if (options_.struct_size > offsetof(scheduler_options_t, block_time_multiplier)) {
+            error_string_ = "quantum_duration is deprecated; use block_time_multiplier "
+                            "and time_units_per_us";
+            return STATUS_ERROR_INVALID_PARAMETER;
+        }
+        options_.block_time_multiplier =
+            static_cast<double>(options_.block_time_scale) / options_.time_units_per_us;
+        VPRINT(this, 2, "Legacy support: setting block_time_multiplier to %6.3f\n",
+               options_.block_time_multiplier);
+    }
+    if (options_.block_time_multiplier == 0) {
+        error_string_ = "block_time_multiplier must != 0";
+        return STATUS_ERROR_INVALID_PARAMETER;
+    }
+    if (options_.block_time_max > 0) {
+        if (options_.struct_size > offsetof(scheduler_options_t, block_time_max_us)) {
+            error_string_ = "quantum_duration is deprecated; use block_time_max_us "
+                            "and time_units_per_us";
+            return STATUS_ERROR_INVALID_PARAMETER;
+        }
+        options_.block_time_max_us = static_cast<uint64_t>(
+            static_cast<double>(options_.block_time_max) / options_.time_units_per_us);
+        VPRINT(this, 2, "Legacy support: setting block_time_max_us to %" PRIu64 "\n",
+               options_.block_time_max_us);
+    }
+    if (options_.block_time_max_us == 0) {
+        error_string_ = "block_time_max_us must be > 0";
+        return STATUS_ERROR_INVALID_PARAMETER;
+    }
+    return STATUS_SUCCESS;
 }
 
 template <typename RecordType, typename ReaderType>
@@ -2552,14 +2616,14 @@ uint64_t
 scheduler_tmpl_t<RecordType, ReaderType>::scale_blocked_time(uint64_t initial_time) const
 {
     uint64_t scaled = static_cast<uint64_t>(static_cast<double>(initial_time) *
-                                            options_.block_time_scale);
-    if (scaled > options_.block_time_max) {
+                                            options_.block_time_multiplier);
+    if (scaled > options_.block_time_max_us) {
         // We have a max to avoid outlier latencies that are already a second or
         // more from scaling up to tens of minutes.  We assume a cap is representative
         // as the outliers likely were not part of key dependence chains.  Without a
         // cap the other threads all finish and the simulation waits for tens of
         // minutes further for a couple of outliers.
-        scaled = options_.block_time_max;
+        scaled = options_.block_time_max_us;
     }
     return scaled;
 }
@@ -2587,11 +2651,11 @@ scheduler_tmpl_t<RecordType, ReaderType>::syscall_incurs_switch(input_info_t *in
         : options_.syscall_switch_threshold;
     blocked_time = scale_blocked_time(latency);
     VPRINT(this, 3,
-           "input %d %ssyscall latency %" PRIu64 " * scale %5.1f => blocked time %" PRIu64
+           "input %d %ssyscall latency %" PRIu64 " * scale %6.3f => blocked time %" PRIu64
            "\n",
            input->index,
            input->processing_maybe_blocking_syscall ? "maybe-blocking " : "", latency,
-           options_.block_time_scale, blocked_time);
+           options_.block_time_multiplier, blocked_time);
     return latency >= threshold;
 }
 
@@ -3279,6 +3343,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         // It's more efficient for QUANTUM_INSTRUCTIONS to get the time here instead of
         // in get_output_time().  This also makes the two more similarly behaved with
         // respect to blocking system calls.
+        // TODO i#6971: Use INSTRS_PER_US to replace .cur_time completely
+        // with a counter-based time, weighted appropriately for STATUS_IDLE.
         cur_time = get_time_micros();
     }
     outputs_[output].cur_time = cur_time; // Invalid values are checked below.
@@ -3492,7 +3558,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                 record_type_is_instr_boundary(record, outputs_[output].last_record) &&
                 !outputs_[output].in_kernel_code) {
                 ++input->instrs_in_quantum;
-                if (input->instrs_in_quantum > options_.quantum_duration) {
+                if (input->instrs_in_quantum > options_.quantum_duration_instrs) {
                     // We again prefer to switch to another input even if the current
                     // input has the oldest timestamp, prioritizing context switches
                     // over timestamp ordering.
@@ -3516,7 +3582,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                 input->time_spent_in_quantum += cur_time - input->prev_time_in_quantum;
                 prev_time_in_quantum = input->prev_time_in_quantum;
                 input->prev_time_in_quantum = cur_time;
-                if (input->time_spent_in_quantum >= options_.quantum_duration &&
+                double elapsed_micros =
+                    input->time_spent_in_quantum * options_.time_units_per_us;
+                if (elapsed_micros >= options_.quantum_duration_us &&
                     // We only switch on instruction boundaries.  We could possibly switch
                     // in between (e.g., scatter/gather long sequence of reads/writes) by
                     // setting input->switching_pre_instruction.
@@ -3759,13 +3827,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::eof_or_idle(output_ordinal_t output,
                     outputs_[output].wait_start_time = get_output_time(output);
                 } else {
                     uint64_t now = get_output_time(output);
-                    if (now - outputs_[output].wait_start_time >
-                        options_.block_time_max) {
+                    double elapsed_micros = (now - outputs_[output].wait_start_time) *
+                        options_.time_units_per_us;
+                    if (elapsed_micros > options_.block_time_max_us) {
                         // XXX i#6822: We may want some other options here for what to
                         // do.  We could release just one input at a time, which would be
                         // the same scheduling order (as we have FIFO in
                         // unscheduled_priority_) but may take a long time at
-                        // block_time_max each; we could declare we're done and just
+                        // block_time_max_us each; we could declare we're done and just
                         // exit, maybe under a flag or if we could see what % of total
                         // records we've processed.
                         VPRINT(this, 1,

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -48,6 +48,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -586,7 +587,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::stream_t::next_record(RecordType &reco
         ++cur_ref_count_;
     if (scheduler_->record_type_is_instr_boundary(record, prev_record_))
         ++cur_instr_count_;
-    VPRINT(scheduler_, 4,
+    VPRINT(scheduler_, 5,
            "stream record#=%" PRId64 ", instr#=%" PRId64 " (cur input %" PRId64
            " record#=%" PRId64 ", instr#=%" PRId64 ")\n",
            cur_ref_count_, cur_instr_count_, input->tid,
@@ -671,28 +672,38 @@ scheduler_tmpl_t<RecordType, ReaderType>::~scheduler_tmpl_t()
 {
     for (unsigned int i = 0; i < outputs_.size(); ++i) {
         VPRINT(this, 1, "Stats for output #%d\n", i);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch input->input",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Switch input->input",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_INPUT]);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch input->idle",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Switch input->idle",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE]);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch idle->input",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Switch idle->input",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_IDLE_TO_INPUT]);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Switch nop",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Switch nop",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_SWITCH_NOP]);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Quantum preempts",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Quantum preempts",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS]);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Direct switch attempts",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Direct switch attempts",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_ATTEMPTS]);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Direct switch successes",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Direct switch successes",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_SUCCESSES]);
-        VPRINT(this, 1, "  %-25s: %9" PRId64 "\n", "Migrations",
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Migrations",
                outputs_[i].stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS]);
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Runqueue steals",
+               outputs_[i].stats[memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS]);
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Runqueue rebalances",
+               outputs_[i].stats[memtrace_stream_t::SCHED_STAT_RUNQUEUE_REBALANCES]);
+#ifndef NDEBUG
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Runqueue lock acquired",
+               outputs_[i].runqueue.lock->get_count_acquired());
+        VPRINT(this, 1, "  %-35s: %9" PRId64 "\n", "Runqueue lock contended",
+               outputs_[i].runqueue.lock->get_count_contended());
+#endif
     }
 #ifndef NDEBUG
-    VPRINT(this, 1, "%-27s: %9" PRId64 "\n", "Schedule lock acquired",
-           sched_lock_.get_count_acquired());
-    VPRINT(this, 1, "%-27s: %9" PRId64 "\n", "Schedule lock contended",
-           sched_lock_.get_count_contended());
+    VPRINT(this, 1, "%-37s: %9" PRId64 "\n", "Unscheduled queue lock acquired",
+           unscheduled_priority_.lock->get_count_acquired());
+    VPRINT(this, 1, "%-37s: %9" PRId64 "\n", "Unscheduled queue lock contended",
+           unscheduled_priority_.lock->get_count_contended());
 #endif
 }
 
@@ -872,6 +883,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::init(
                                   ? spec_type_t::USE_NOPS
                                   // TODO i#5843: Add more flags for other options.
                                   : spec_type_t::LAST_FROM_TRACE,
+                              static_cast<int>(get_time_micros()),
                               create_invalid_record(), verbosity_);
         if (options_.single_lockstep_output)
             outputs_.back().stream = global_stream_.get();
@@ -957,8 +969,6 @@ typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
     std::unordered_map<int, std::vector<int>> &workload2inputs)
 {
-    bool need_lock;
-    auto scoped_lock = acquire_scoped_sched_lock_if_necessary(need_lock);
     // Determine whether we need to read ahead in the inputs.  There are cases where we
     // do not want to do that as it would block forever if the inputs are not available
     // (e.g., online analysis IPC readers); it also complicates ordinals so we avoid it
@@ -1081,24 +1091,47 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
             // We'll pick the starting inputs below by sorting by relative time from
             // each workload's base_timestamp, which our queue does for us.
         }
-        // We need to honor output bindings and possibly time ordering, which our queue
-        // does for us.  We want the rest of the inputs in the queue in any case so it is
-        // simplest to insert all and remove the first N.
+        // First, put all inputs into a temporary queue to sort by priority and
+        // time for us.
+        flexible_queue_t<input_info_t *, InputTimestampComparator> allq;
+        int fifo_counter = 0;
         for (int i = 0; i < static_cast<input_ordinal_t>(inputs_.size()); ++i) {
-            add_to_ready_queue(&inputs_[i]);
+            inputs_[i].queue_counter = ++fifo_counter;
+            allq.push(&inputs_[i]);
+        }
+        // Now assign round-robin to the outputs.  We have to obey bindings here: we
+        // just take the first.  This isn't guaranteed to be perfect if there are
+        // many bindings, but we run a rebalancing afterward.
+        output_ordinal_t output = 0;
+        while (!allq.empty()) {
+            input_info_t *input = allq.top();
+            allq.pop();
+            output_ordinal_t target = output;
+            if (!input->binding.empty())
+                target = *input->binding.begin();
+            else
+                output = (output + 1) % outputs_.size();
+            add_to_ready_queue(target, input);
+        }
+        sched_type_t::stream_status_t status = rebalance_queues(0, {});
+        if (status != STATUS_OK) {
+            VPRINT(this, 0, "Failed to rebalance with status %d\n", status);
+            return STATUS_ERROR_INVALID_PARAMETER;
         }
         for (int i = 0; i < static_cast<output_ordinal_t>(outputs_.size()); ++i) {
             input_info_t *queue_next;
 #ifndef NDEBUG
             sched_type_t::stream_status_t status =
 #endif
-                pop_from_ready_queue(i, queue_next);
+                pop_from_ready_queue(i, i, queue_next);
             assert(status == STATUS_OK || status == STATUS_IDLE);
             if (queue_next == nullptr)
                 set_cur_input(i, INVALID_INPUT_ORDINAL);
             else
                 set_cur_input(i, queue_next->index);
         }
+        VPRINT(this, 2, "Initial queues:\n");
+        VDO(this, 2, { print_queue_stats(); });
     }
     return STATUS_SUCCESS;
 }
@@ -1120,8 +1153,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::write_recorded_schedule()
 {
     if (options_.schedule_record_ostream == nullptr)
         return STATUS_ERROR_INVALID_PARAMETER;
-    std::lock_guard<mutex_dbg_owned> guard(sched_lock_);
     for (int i = 0; i < static_cast<int>(outputs_.size()); ++i) {
+        auto lock = acquire_scoped_output_lock_if_necessary(i);
         sched_type_t::stream_status_t status =
             record_schedule_segment(i, schedule_record_t::FOOTER, 0, 0, 0);
         if (status != sched_type_t::STATUS_OK)
@@ -2215,9 +2248,10 @@ scheduler_tmpl_t<RecordType, ReaderType>::advance_region_of_interest(
         VPRINT(this, 2, "at %" PRId64 " instrs: advancing to ROI #%d\n", cur_instr,
                input.cur_region);
         if (input.cur_region >= static_cast<int>(input.regions_of_interest.size())) {
-            if (input.at_eof)
-                return eof_or_idle(output, /*hold_sched_lock=*/false, input.index);
-            else {
+            if (input.at_eof) {
+                // XXX: We're holding input.lock which is ok during eof_or_idle.
+                return eof_or_idle(output, input.index);
+            } else {
                 // We let the user know we're done.
                 if (options_.schedule_record_ostream != nullptr) {
                     sched_type_t::stream_status_t status =
@@ -2401,7 +2435,7 @@ template <typename RecordType, typename ReaderType>
 uint64_t
 scheduler_tmpl_t<RecordType, ReaderType>::get_output_time(output_ordinal_t output)
 {
-    return outputs_[output].cur_time;
+    return outputs_[output].cur_time->load(std::memory_order_acquire);
 }
 
 template <typename RecordType, typename ReaderType>
@@ -2490,85 +2524,146 @@ scheduler_tmpl_t<RecordType, ReaderType>::close_schedule_segment(output_ordinal_
 
 template <typename RecordType, typename ReaderType>
 bool
-scheduler_tmpl_t<RecordType, ReaderType>::ready_queue_empty()
+scheduler_tmpl_t<RecordType, ReaderType>::ready_queue_empty(output_ordinal_t output)
 {
-    assert(!need_sched_lock() || sched_lock_.owned_by_cur_thread());
-    return ready_priority_.empty();
+    auto lock = acquire_scoped_output_lock_if_necessary(output);
+    return outputs_[output].runqueue.queue.empty();
 }
 
 template <typename RecordType, typename ReaderType>
 void
 scheduler_tmpl_t<RecordType, ReaderType>::add_to_unscheduled_queue(input_info_t *input)
 {
-    assert(!need_sched_lock() || sched_lock_.owned_by_cur_thread());
+    assert(input->lock->owned_by_cur_thread());
+    std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
     assert(input->unscheduled &&
            input->blocked_time == 0); // Else should be in regular queue.
     VPRINT(this, 4, "add_to_unscheduled_queue (pre-size %zu): input %d priority %d\n",
-           unscheduled_priority_.size(), input->index, input->priority);
-    input->queue_counter = ++unscheduled_counter_;
-    unscheduled_priority_.push(input);
+           unscheduled_priority_.queue.size(), input->index, input->priority);
+    input->queue_counter = ++unscheduled_priority_.fifo_counter;
+    unscheduled_priority_.queue.push(input);
+    input->prev_output = input->containing_output;
+    input->containing_output = INVALID_INPUT_ORDINAL;
 }
 
+// NOCHECK get all callers to hold input lock
 template <typename RecordType, typename ReaderType>
 void
-scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(input_info_t *input)
+scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue_hold_locks(
+    output_ordinal_t output, input_info_t *input)
 {
-    assert(!need_sched_lock() || sched_lock_.owned_by_cur_thread());
+    assert(input->lock->owned_by_cur_thread());
+    assert(!need_output_lock() || outputs_[output].runqueue.lock->owned_by_cur_thread());
     if (input->unscheduled && input->blocked_time == 0) {
+        // Ensure we get prev_output set for start-unscheduled so they won't
+        // all resume on output #0 but rather on the initial round-robin assigment.
+        input->containing_output = output;
         add_to_unscheduled_queue(input);
         return;
     }
+    assert(input->binding.empty() || input->binding.find(output) != input->binding.end());
     VPRINT(
         this, 4,
         "add_to_ready_queue (pre-size %zu): input %d priority %d timestamp delta %" PRIu64
         " block time %" PRIu64 " start time %" PRIu64 "\n",
-        ready_priority_.size(), input->index, input->priority,
+        outputs_[output].runqueue.queue.size(), input->index, input->priority,
         input->reader->get_last_timestamp() - input->base_timestamp, input->blocked_time,
         input->blocked_start_time);
     if (input->blocked_time > 0)
-        ++num_blocked_;
-    input->queue_counter = ++ready_counter_;
-    ready_priority_.push(input);
+        ++outputs_[output].runqueue.num_blocked;
+    input->queue_counter = ++outputs_[output].runqueue.fifo_counter;
+    outputs_[output].runqueue.queue.push(input);
+    input->containing_output = output;
+}
+
+template <typename RecordType, typename ReaderType>
+void
+scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(output_ordinal_t output,
+                                                             input_info_t *input)
+{
+    auto scoped_lock = acquire_scoped_output_lock_if_necessary(output);
+    std::lock_guard<mutex_dbg_owned> input_lock(*input->lock);
+    add_to_ready_queue_hold_locks(output, input);
 }
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
-scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
-    output_ordinal_t for_output, input_info_t *&new_input)
+scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue_hold_locks(
+    output_ordinal_t from_output, output_ordinal_t for_output, input_info_t *&new_input,
+    bool from_back)
 {
-    assert(!need_sched_lock() || sched_lock_.owned_by_cur_thread());
+    assert(!need_output_lock() ||
+           (outputs_[from_output].runqueue.lock->owned_by_cur_thread() &&
+            (from_output == for_output || for_output == INVALID_OUTPUT_ORDINAL ||
+             outputs_[for_output].runqueue.lock->owned_by_cur_thread())));
     std::set<input_info_t *> skipped;
     std::set<input_info_t *> blocked;
     input_info_t *res = nullptr;
     sched_type_t::stream_status_t status = STATUS_OK;
-    uint64_t cur_time = (num_blocked_ > 0) ? get_output_time(for_output) : 0;
-    while (!ready_priority_.empty()) {
-        if (options_.randomize_next_input) {
-            res = ready_priority_.get_random_entry();
-            ready_priority_.erase(res);
+    uint64_t cur_time = get_output_time(from_output);
+    while (!outputs_[from_output].runqueue.queue.empty()) {
+        if (from_back) {
+            res = outputs_[from_output].runqueue.queue.back();
+            outputs_[from_output].runqueue.queue.erase(res);
+        } else if (options_.randomize_next_input) {
+            res = outputs_[from_output].runqueue.queue.get_random_entry();
+            outputs_[from_output].runqueue.queue.erase(res);
         } else {
-            res = ready_priority_.top();
-            ready_priority_.pop();
+            res = outputs_[from_output].runqueue.queue.top();
+            outputs_[from_output].runqueue.queue.pop();
         }
         assert(!res->unscheduled ||
                res->blocked_time > 0); // Should be in unscheduled_priority_.
-        if (res->binding.empty() || res->binding.find(for_output) != res->binding.end()) {
+        if (res->binding.empty() || for_output == INVALID_OUTPUT_ORDINAL ||
+            res->binding.find(for_output) != res->binding.end()) {
             // For blocked inputs, as we don't have interrupts or other regular
             // control points we only check for being unblocked when an input
             // would be chosen to run.  We thus keep blocked inputs in the ready queue.
             if (res->blocked_time > 0) {
                 assert(cur_time > 0);
-                --num_blocked_;
+                --outputs_[from_output].runqueue.num_blocked;
             }
             if (res->blocked_time > 0 &&
+                // XXX i#6966: We have seen wall-clock time go backward, which
+                // underflows here and always matches this condition currently.
                 cur_time - res->blocked_start_time < res->blocked_time) {
                 VPRINT(this, 4, "pop queue: %d still blocked for %" PRIu64 "\n",
                        res->index,
                        res->blocked_time - (cur_time - res->blocked_start_time));
                 // We keep searching for a suitable input.
                 blocked.insert(res);
-            } else
-                break;
+            } else {
+                // We've found a candidate.  One final check if this is a migration.
+                bool found_candidate = false;
+                if (from_output == for_output)
+                    found_candidate = true;
+                else {
+                    assert(cur_time > 0 || res->last_run_time == 0);
+                    VPRINT(this, 5,
+                           "migration check %d to %d: cur=%" PRIu64 " last=%" PRIu64
+                           " delta=%" PRId64 " vs thresh %" PRIu64 "\n",
+                           from_output, for_output, cur_time, res->last_run_time,
+                           cur_time - res->last_run_time,
+                           options_.migration_threshold_us);
+                    // Guard against time going backward, which happens: i#6966.
+                    if (options_.migration_threshold_us == 0 || res->last_run_time == 0 ||
+                        (cur_time > res->last_run_time &&
+                         cur_time - res->last_run_time >=
+                             static_cast<uint64_t>(options_.migration_threshold_us *
+                                                   options_.time_units_per_us))) {
+                        VPRINT(this, 2, "migrating %d to %d\n", from_output, for_output);
+                        found_candidate = true;
+                        ++outputs_[from_output]
+                              .stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS];
+                    }
+                }
+                if (found_candidate)
+                    break;
+                else {
+                    res->blocked_time = 0;
+                    skipped.insert(res);
+                }
+            }
         } else {
             // We keep searching for a suitable input.
             skipped.insert(res);
@@ -2583,31 +2678,73 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
     // Re-add the ones we skipped, but without changing their counters so we preserve
     // the prior FIFO order.
     for (input_info_t *save : skipped)
-        ready_priority_.push(save);
+        outputs_[from_output].runqueue.queue.push(save);
     // Re-add the blocked ones to the back.
-    for (input_info_t *save : blocked)
-        add_to_ready_queue(save);
+    for (input_info_t *save : blocked) {
+        std::lock_guard<mutex_dbg_owned> input_lock(*save->lock);
+        add_to_ready_queue_hold_locks(from_output, save);
+    }
     VDO(this, 1, {
-        static int heartbeat;
+        static int output_heartbeat;
         // We are ok with races as the cadence is approximate.
-        if (++heartbeat % 2000 == 0) {
+        if (++output_heartbeat % 2000 == 0) {
+            size_t unsched_size = 0;
+            {
+                std::lock_guard<mutex_dbg_owned> unsched_lock(
+                    *unscheduled_priority_.lock);
+                unsched_size = unscheduled_priority_.queue.size();
+            }
             VPRINT(this, 1,
                    "heartbeat[%d] %zd in queue; %d blocked; %zd unscheduled => %d %d\n",
-                   for_output, ready_priority_.size(), num_blocked_,
-                   unscheduled_priority_.size(), res == nullptr ? -1 : res->index,
-                   status);
+                   from_output, outputs_[from_output].runqueue.queue.size(),
+                   outputs_[from_output].runqueue.num_blocked, unsched_size,
+                   res == nullptr ? -1 : res->index, status);
         }
     });
     if (res != nullptr) {
         VPRINT(this, 4,
                "pop_from_ready_queue[%d] (post-size %zu): input %d priority %d timestamp "
                "delta %" PRIu64 "\n",
-               for_output, ready_priority_.size(), res->index, res->priority,
-               res->reader->get_last_timestamp() - res->base_timestamp);
+               from_output, outputs_[from_output].runqueue.queue.size(), res->index,
+               res->priority, res->reader->get_last_timestamp() - res->base_timestamp);
         res->blocked_time = 0;
         res->unscheduled = false;
+        res->prev_output = res->containing_output;
+        res->containing_output = for_output;
     }
     new_input = res;
+    return status;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
+    output_ordinal_t from_output, output_ordinal_t for_output, input_info_t *&new_input)
+{
+    sched_type_t::stream_status_t status = sched_type_t::STATUS_OK;
+    {
+        std::unique_lock<mutex_dbg_owned> from_lock;
+        std::unique_lock<mutex_dbg_owned> for_lock;
+        // If we need both locks, acquire in increasing output order to avoid deadlocks if
+        // two outputs try to steal from each other.
+        if (from_output == for_output || for_output == INVALID_OUTPUT_ORDINAL) {
+            from_lock = acquire_scoped_output_lock_if_necessary(from_output);
+        } else if (from_output < for_output) {
+            from_lock = acquire_scoped_output_lock_if_necessary(from_output);
+            for_lock = acquire_scoped_output_lock_if_necessary(for_output);
+        } else {
+            for_lock = acquire_scoped_output_lock_if_necessary(for_output);
+            from_lock = acquire_scoped_output_lock_if_necessary(from_output);
+        }
+        status = pop_from_ready_queue_hold_locks(from_output, for_output, new_input);
+    }
+    VDO(this, 1, {
+        static int global_heartbeat;
+        // We are ok with races as the cadence is approximate.
+        if (++global_heartbeat % 100000 == 0) {
+            print_queue_stats();
+        }
+    });
     return status;
 }
 
@@ -2664,8 +2801,7 @@ typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
                                                         input_ordinal_t input)
 {
-    assert(!need_sched_lock() || sched_lock_.owned_by_cur_thread());
-    // XXX i#5843: Merge tracking of current inputs with ready_priority_ to better manage
+    // XXX i#5843: Merge tracking of current inputs with runqueue.queue to better manage
     // the possible 3 states of each input (a live cur_input for an output stream, in
     // the ready_queue_, or at EOF) (4 states once we add i/o wait times).
     assert(output >= 0 && output < static_cast<output_ordinal_t>(outputs_.size()));
@@ -2675,15 +2811,19 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
     if (prev_input >= 0) {
         if (options_.mapping == MAP_TO_ANY_OUTPUT && prev_input != input &&
             !inputs_[prev_input].at_eof) {
-            add_to_ready_queue(&inputs_[prev_input]);
+            add_to_ready_queue(output, &inputs_[prev_input]);
         }
-        if (prev_input != input && options_.schedule_record_ostream != nullptr) {
+        if (prev_input != input) {
             input_info_t &prev_info = inputs_[prev_input];
             std::lock_guard<mutex_dbg_owned> lock(*prev_info.lock);
-            sched_type_t::stream_status_t status =
-                close_schedule_segment(output, prev_info);
-            if (status != sched_type_t::STATUS_OK)
-                return status;
+            prev_info.cur_output = INVALID_OUTPUT_ORDINAL;
+            prev_info.last_run_time = get_output_time(output);
+            if (options_.schedule_record_ostream != nullptr) {
+                sched_type_t::stream_status_t status =
+                    close_schedule_segment(output, prev_info);
+                if (status != sched_type_t::STATUS_OK)
+                    return status;
+            }
         }
     } else if (options_.schedule_record_ostream != nullptr &&
                outputs_[output].record.back().type == schedule_record_t::IDLE) {
@@ -2708,13 +2848,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
 
     std::lock_guard<mutex_dbg_owned> lock(*inputs_[input].lock);
 
-    if (inputs_[input].prev_output != INVALID_OUTPUT_ORDINAL &&
-        inputs_[input].prev_output != output) {
-        VPRINT(this, 3, "output[%d] migrating input %d from output %d\n", output, input,
-               inputs_[input].prev_output);
-        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS];
-    }
-    inputs_[input].prev_output = output;
+    inputs_[input].cur_output = output;
+    inputs_[input].containing_output = output;
 
     if (prev_input < 0 && outputs_[output].stream->version_ == 0) {
         // Set the version and filetype up front, to let the user query at init time
@@ -2762,7 +2897,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
         }
     }
 
-    inputs_[input].prev_time_in_quantum = outputs_[output].cur_time;
+    inputs_[input].prev_time_in_quantum =
+        outputs_[output].cur_time->load(std::memory_order_acquire);
 
     if (options_.schedule_record_ostream != nullptr) {
         uint64_t instr_ord = get_instr_ordinal(inputs_[input]);
@@ -2792,14 +2928,13 @@ typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input_as_previously(
     output_ordinal_t output, input_ordinal_t &index)
 {
-    assert(!need_sched_lock() || sched_lock_.owned_by_cur_thread());
     if (outputs_[output].record_index + 1 >=
         static_cast<int>(outputs_[output].record.size())) {
         if (!outputs_[output].at_eof) {
             outputs_[output].at_eof = true;
             live_replay_output_count_.fetch_add(-1, std::memory_order_release);
         }
-        return eof_or_idle(output, need_sched_lock(), outputs_[output].cur_input);
+        return eof_or_idle(output, outputs_[output].cur_input);
     }
     const schedule_record_t &segment =
         outputs_[output].record[outputs_[output].record_index + 1];
@@ -2920,19 +3055,19 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input_as_previously(
 
 template <typename RecordType, typename ReaderType>
 bool
-scheduler_tmpl_t<RecordType, ReaderType>::need_sched_lock()
+scheduler_tmpl_t<RecordType, ReaderType>::need_output_lock()
 {
     return options_.mapping == MAP_TO_ANY_OUTPUT || options_.mapping == MAP_AS_PREVIOUSLY;
 }
 
 template <typename RecordType, typename ReaderType>
 std::unique_lock<mutex_dbg_owned>
-scheduler_tmpl_t<RecordType, ReaderType>::acquire_scoped_sched_lock_if_necessary(
-    bool &need_lock)
+scheduler_tmpl_t<RecordType, ReaderType>::acquire_scoped_output_lock_if_necessary(
+    output_ordinal_t output)
 {
-    need_lock = need_sched_lock();
-    auto scoped_lock = need_lock ? std::unique_lock<mutex_dbg_owned>(sched_lock_)
-                                 : std::unique_lock<mutex_dbg_owned>();
+    auto scoped_lock = need_output_lock()
+        ? std::unique_lock<mutex_dbg_owned>(*outputs_[output].runqueue.lock)
+        : std::unique_lock<mutex_dbg_owned>();
     return scoped_lock;
 }
 
@@ -2941,9 +3076,8 @@ typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t output,
                                                           uint64_t blocked_time)
 {
+
     sched_type_t::stream_status_t res = sched_type_t::STATUS_OK;
-    bool need_lock;
-    auto scoped_lock = acquire_scoped_sched_lock_if_necessary(need_lock);
     input_ordinal_t prev_index = outputs_[output].cur_input;
     input_ordinal_t index = INVALID_INPUT_ORDINAL;
     int iters = 0;
@@ -2979,6 +3113,29 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                 if (res != sched_type_t::STATUS_OK)
                     return res;
             } else if (options_.mapping == MAP_TO_ANY_OUTPUT) {
+                uint64_t cur_time = get_output_time(output);
+                uint64_t last_time = last_rebalance_time_.load(std::memory_order_acquire);
+                if (last_time == 0) {
+                    // Initialize.
+                    last_rebalance_time_.store(cur_time, std::memory_order_release);
+                } else {
+                    // Guard against time going backward, which happens: i#6966.
+                    if (cur_time > last_time &&
+                        cur_time - last_time >=
+                            static_cast<uint64_t>(options_.rebalance_period_us *
+                                                  options_.time_units_per_us) &&
+                        rebalancer_.load(std::memory_order_acquire) ==
+                            std::thread::id()) {
+                        VPRINT(this, 2,
+                               "Output %d hit rebalance period @%" PRIu64
+                               " (last rebalance @%" PRIu64 ")\n",
+                               output, cur_time, last_time);
+                        sched_type_t::stream_status_t status =
+                            rebalance_queues(output, {});
+                        if (status != STATUS_OK)
+                            return status;
+                    }
+                }
                 if (blocked_time > 0 && prev_index != INVALID_INPUT_ORDINAL) {
                     std::lock_guard<mutex_dbg_owned> lock(*inputs_[prev_index].lock);
                     if (inputs_[prev_index].blocked_time == 0) {
@@ -2995,34 +3152,43 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                     std::lock_guard<mutex_dbg_owned> lock(*target->lock);
                     // XXX i#5843: Add an invariant check that the next timestamp of the
                     // target is later than the pre-switch-syscall timestamp?
-                    if (ready_priority_.find(target)) {
-                        VPRINT(this, 2,
-                               "next_record[%d]: direct switch from input %d to input %d "
-                               "@%" PRIu64 "\n",
-                               output, prev_index, target->index,
-                               inputs_[prev_index].reader->get_last_timestamp());
-                        ready_priority_.erase(target);
-                        index = target->index;
-                        // Erase any remaining wait time for the target.
-                        if (target->blocked_time > 0) {
-                            VPRINT(this, 3,
-                                   "next_record[%d]: direct switch erasing blocked time "
-                                   "for input %d\n",
-                                   output, target->index);
-                            --num_blocked_;
-                            target->blocked_time = 0;
-                            target->unscheduled = false;
-                        }
-                        if (target->prev_output != INVALID_OUTPUT_ORDINAL &&
-                            target->prev_output != output) {
-                            ++outputs_[output]
-                                  .stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS];
-                        }
-                        ++outputs_[output].stats
-                              [memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_SUCCESSES];
-                    } else if (unscheduled_priority_.find(target)) {
+                    if (target->containing_output != INVALID_OUTPUT_ORDINAL) {
+                        output_info_t &out = outputs_[target->containing_output];
+                        auto target_out_lock = acquire_scoped_output_lock_if_necessary(
+                            target->containing_output);
+                        if (out.runqueue.queue.find(target)) {
+                            VPRINT(this, 2,
+                                   "next_record[%d]: direct switch from input %d to "
+                                   "input %d "
+                                   "@%" PRIu64 "\n",
+                                   output, prev_index, target->index,
+                                   inputs_[prev_index].reader->get_last_timestamp());
+                            out.runqueue.queue.erase(target);
+                            index = target->index;
+                            // Erase any remaining wait time for the target.
+                            if (target->blocked_time > 0) {
+                                VPRINT(
+                                    this, 3,
+                                    "next_record[%d]: direct switch erasing blocked time "
+                                    "for input %d\n",
+                                    output, target->index);
+                                --out.runqueue.num_blocked;
+                                target->blocked_time = 0;
+                                target->unscheduled = false;
+                            }
+                            if (target->containing_output != output) {
+                                ++out.stats[memtrace_stream_t::SCHED_STAT_MIGRATIONS];
+                            }
+                            ++out.stats
+                                  [memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_SUCCESSES];
+                        } // Else, actively running.
+                    }
+                    std::lock_guard<mutex_dbg_owned> unsched_lock(
+                        *unscheduled_priority_.lock);
+                    if (index == INVALID_INPUT_ORDINAL &&
+                        unscheduled_priority_.queue.find(target)) {
                         target->unscheduled = false;
-                        unscheduled_priority_.erase(target);
+                        unscheduled_priority_.queue.erase(target);
                         index = target->index;
                         VPRINT(this, 2,
                                "next_record[%d]: direct switch from input %d to "
@@ -3037,7 +3203,8 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         }
                         ++outputs_[output].stats
                               [memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_SUCCESSES];
-                    } else {
+                    }
+                    if (index == INVALID_INPUT_ORDINAL) {
                         // We assume that inter-input dependencies are captured in
                         // the _DIRECT_THREAD_SWITCH, _UNSCHEDULE, and _SCHEDULE markers
                         // and that if a switch request targets a thread running elsewhere
@@ -3045,7 +3212,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         // dynamic switch to whoever happens to be available (and
                         // different timing between tracing and analysis has caused this
                         // miss).
-                        VPRINT(this, 1,
+                        VPRINT(this, 2,
                                "Direct switch (from %d) target input #%d is running "
                                "elsewhere; picking a different target @%" PRIu64 "\n",
                                prev_index, target->index,
@@ -3058,23 +3225,40 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                 }
                 if (index != INVALID_INPUT_ORDINAL) {
                     // We found a direct switch target above.
-                } else if (ready_queue_empty() && blocked_time == 0) {
-                    if (prev_index == INVALID_INPUT_ORDINAL)
-                        return eof_or_idle(output, need_lock, prev_index);
-                    auto lock =
-                        std::unique_lock<mutex_dbg_owned>(*inputs_[prev_index].lock);
-                    // If we can't go back to the current input, we're EOF or idle.
-                    // TODO i#6959: We should go the EOF/idle route if
-                    // inputs_[prev_index].unscheduled as otherwise we're ignoring its
-                    // unscheduled transition: although if there are no other threads at
-                    // all (not just an empty queue) this turns into the eof_or_idle()
-                    // all-unscheduled scenario.  Once we have some kind of early exit
-                    // option we'll add the unscheduled check here.
-                    if (inputs_[prev_index].at_eof) {
-                        lock.unlock();
-                        return eof_or_idle(output, need_lock, prev_index);
-                    } else
-                        index = prev_index; // Go back to prior.
+                }
+                // XXX: We're grabbing the output runqueue lock 3x here:
+                // ready_queue_empty(), set_cur_input()'s add_to_ready_queue(),
+                // and pop_from_ready_queue().  Should we change the lock
+                // scheme to be in the caller and grab once here?
+                else if (ready_queue_empty(output) && blocked_time == 0) {
+                    if (prev_index == INVALID_INPUT_ORDINAL) {
+                        sched_type_t::stream_status_t status =
+                            eof_or_idle(output, prev_index);
+                        if (status != STATUS_STOLE)
+                            return status;
+                        index = outputs_[output].cur_input;
+                        res = STATUS_OK;
+                    } else {
+                        auto lock =
+                            std::unique_lock<mutex_dbg_owned>(*inputs_[prev_index].lock);
+                        // If we can't go back to the current input, we're EOF or idle.
+                        // TODO i#6959: We should go the EOF/idle route if
+                        // inputs_[prev_index].unscheduled as otherwise we're ignoring its
+                        // unscheduled transition: although if there are no other threads
+                        // at all (not just an empty queue) this turns into the
+                        // eof_or_idle() all-unscheduled scenario.  Once we have some kind
+                        // of early exit option we'll add the unscheduled check here.
+                        if (inputs_[prev_index].at_eof) {
+                            lock.unlock();
+                            sched_type_t::stream_status_t status =
+                                eof_or_idle(output, prev_index);
+                            if (status != STATUS_STOLE)
+                                return status;
+                            index = outputs_[output].cur_input;
+                            res = STATUS_OK;
+                        } else
+                            index = prev_index; // Go back to prior.
+                    }
                 } else {
                     // Give up the input before we go to the queue so we can add
                     // ourselves to the queue.  If we're the highest priority we
@@ -3084,7 +3268,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                     set_cur_input(output, INVALID_INPUT_ORDINAL);
                     input_info_t *queue_next = nullptr;
                     sched_type_t::stream_status_t status =
-                        pop_from_ready_queue(output, queue_next);
+                        pop_from_ready_queue(output, output, queue_next);
                     if (status != STATUS_OK) {
                         if (status == STATUS_IDLE) {
                             outputs_[output].waiting = true;
@@ -3104,10 +3288,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         return status;
                     }
                     if (queue_next == nullptr) {
-                        assert(blocked_time == 0 || prev_index == INVALID_INPUT_ORDINAL);
-                        return eof_or_idle(output, need_lock, prev_index);
-                    }
-                    index = queue_next->index;
+                        sched_type_t::stream_status_t status =
+                            eof_or_idle(output, prev_index);
+                        if (status != STATUS_STOLE)
+                            return status;
+                        index = outputs_[output].cur_input;
+                        res = STATUS_OK;
+                    } else
+                        index = queue_next->index;
                 }
             } else if (options_.deps == DEPENDENCY_TIMESTAMPS) {
                 uint64_t min_time = std::numeric_limits<uint64_t>::max();
@@ -3119,8 +3307,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
                         index = static_cast<int>(i);
                     }
                 }
-                if (index < 0)
-                    return eof_or_idle(output, need_lock, prev_index);
+                if (index < 0) {
+                    sched_type_t::stream_status_t status =
+                        eof_or_idle(output, prev_index);
+                    if (status != STATUS_STOLE)
+                        return status;
+                    index = outputs_[output].cur_input;
+                    res = STATUS_OK;
+                }
                 VPRINT(this, 2,
                        "next_record[%d]: advancing to timestamp %" PRIu64
                        " == input #%d\n",
@@ -3164,16 +3358,28 @@ scheduler_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t outpu
     }
     // We can't easily place these stats inside set_cur_input() as we call that to
     // temporarily give up our input.
-    if (prev_index == index)
-        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_NOP];
-    else if (prev_index != INVALID_INPUT_ORDINAL && index != INVALID_INPUT_ORDINAL)
-        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_INPUT];
-    else if (index == INVALID_INPUT_ORDINAL)
-        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE];
-    else
-        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_IDLE_TO_INPUT];
+    update_switch_stats(output, prev_index, index);
     set_cur_input(output, index);
     return res;
+}
+
+template <typename RecordType, typename ReaderType>
+void
+scheduler_tmpl_t<RecordType, ReaderType>::update_switch_stats(output_ordinal_t output,
+                                                              input_ordinal_t prev_input,
+                                                              input_ordinal_t new_input)
+{
+    if (prev_input == new_input)
+        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_NOP];
+    else if (prev_input != INVALID_INPUT_ORDINAL && new_input != INVALID_INPUT_ORDINAL)
+        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_INPUT];
+    else if (new_input == INVALID_INPUT_ORDINAL)
+        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE];
+    else {
+        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_IDLE_TO_INPUT];
+        // Reset the flag so we'll try to steal if we go idle again.
+        outputs_[output].tried_to_steal_on_idle = false;
+    }
 }
 
 template <typename RecordType, typename ReaderType>
@@ -3288,32 +3494,58 @@ scheduler_tmpl_t<RecordType, ReaderType>::process_marker(input_info_t &input,
         input_ordinal_t target_idx = it->second;
         VPRINT(this, 3, "input %d re-scheduling input %d @%" PRIu64 "\n", input.index,
                target_idx, input.reader->get_last_timestamp());
-        // Release the input lock before acquiring sched_lock, to meet our lock
-        // ordering convention to avoid deadlocks.
+        // Release the input lock before acquiring more input locks
         input.lock->unlock();
         {
-            bool need_sched_lock;
-            auto scoped_sched_lock =
-                acquire_scoped_sched_lock_if_necessary(need_sched_lock);
             input_info_t *target = &inputs_[target_idx];
-            std::lock_guard<mutex_dbg_owned> lock(*target->lock);
-            if (target->unscheduled) {
+            std::unique_lock<mutex_dbg_owned> target_lock(*target->lock);
+            if (target->at_eof) {
+                VPRINT(this, 3, "input %d at eof ignoring re-schedule\n", target_idx);
+            } else if (target->unscheduled) {
                 target->unscheduled = false;
-                if (unscheduled_priority_.find(target)) {
-                    add_to_ready_queue(target);
-                    unscheduled_priority_.erase(target);
-                } else if (ready_priority_.find(target)) {
+                bool on_unsched_queue = false;
+                {
+                    std::lock_guard<mutex_dbg_owned> unsched_lock(
+                        *unscheduled_priority_.lock);
+                    if (unscheduled_priority_.queue.find(target)) {
+                        unscheduled_priority_.queue.erase(target);
+                        on_unsched_queue = true;
+                    }
+                }
+                // We have to give up the unsched lock before calling add_to_ready_queue
+                // as it acquires the output lock.
+                if (on_unsched_queue) {
+                    output_ordinal_t resume_output = target->prev_output;
+                    if (resume_output == INVALID_OUTPUT_ORDINAL)
+                        resume_output = output;
+                    // We can't hold any locks when calling add_to_ready_queue.
+                    target_lock.unlock();
+                    add_to_ready_queue(resume_output, target);
+                    target_lock.lock();
+                } else {
                     // We assume blocked_time is from _ARG_TIMEOUT and is not from
                     // regularly-blocking i/o.  We assume i/o getting into the mix is
                     // rare enough or does not matter enough to try to have separate
                     // timeouts.
                     if (target->blocked_time > 0) {
-                        VPRINT(
-                            this, 3,
-                            "switchto::resume erasing blocked time for target input %d\n",
-                            target->index);
-                        --num_blocked_;
-                        target->blocked_time = 0;
+                        VPRINT(this, 3,
+                               "switchto::resume erasing blocked time for target "
+                               "input %d\n",
+                               target->index);
+                        output_ordinal_t target_output = target->containing_output;
+                        // There could be no output owner if we're mid-rebalance.
+                        if (target_output != INVALID_OUTPUT_ORDINAL) {
+                            auto scoped_output_lock =
+                                acquire_scoped_output_lock_if_necessary(target_output);
+                            output_info_t &out = outputs_[target_output];
+                            if (out.runqueue.queue.find(target)) {
+                                --out.runqueue.num_blocked;
+                            }
+                            // Decerement this holding the lock to synch with
+                            // pop_from_ready_queue().
+                            target->blocked_time = 0;
+                        } else
+                            target->blocked_time = 0;
                     }
                 }
             } else {
@@ -3347,8 +3579,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         // with a counter-based time, weighted appropriately for STATUS_IDLE.
         cur_time = get_time_micros();
     }
-    outputs_[output].cur_time = cur_time; // Invalid values are checked below.
-    if (!outputs_[output].active)
+    // Invalid values for cur_time are checked below.
+    outputs_[output].cur_time->store(cur_time, std::memory_order_release);
+    if (!outputs_[output].active->load(std::memory_order_acquire))
         return sched_type_t::STATUS_IDLE;
     if (outputs_[output].waiting) {
         if (options_.mapping == MAP_AS_PREVIOUSLY &&
@@ -3374,7 +3607,11 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
     if (outputs_[output].cur_input < 0) {
         // This happens with more outputs than inputs.  For non-empty outputs we
         // require cur_input to be set to >=0 during init().
-        return eof_or_idle(output, /*hold_sched_lock=*/false, outputs_[output].cur_input);
+        sched_type_t::stream_status_t status =
+            eof_or_idle(output, outputs_[output].cur_input);
+        assert(status != STATUS_OK);
+        if (status != STATUS_STOLE)
+            return status;
     }
     input = &inputs_[outputs_[output].cur_input];
     auto lock = std::unique_lock<mutex_dbg_owned>(*input->lock);
@@ -3456,7 +3693,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         uint64_t prev_time_in_quantum = 0;
         // XXX i#6831: Refactor to use subclasses or templates to specialize
         // scheduler code based on mapping options, to avoid these top-level
-        // conditionals in many functions?
+        // conditionals in many functions?  The next_record() and pick_next_input()
+        // could also be put into output_info_t, promoting it to a class and
+        // subclassing it per mapping mode.
         if (options_.mapping == MAP_AS_PREVIOUSLY) {
             assert(outputs_[output].record_index >= 0);
             if (outputs_[output].record_index >=
@@ -3674,6 +3913,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
         }
         if (input->needs_roi && options_.mapping != MAP_AS_PREVIOUSLY &&
             !input->regions_of_interest.empty()) {
+            input_ordinal_t prev_input = input->index;
             sched_type_t::stream_status_t res =
                 advance_region_of_interest(output, record, *input);
             if (res == sched_type_t::STATUS_SKIPPED) {
@@ -3681,6 +3921,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::next_record(output_ordinal_t output,
                 // but we do not want to come back here.
                 input->needs_roi = false;
                 input->needs_advance = false;
+                continue;
+            } else if (res == sched_type_t::STATUS_STOLE) {
+                // We need to loop to get the new record.
+                input = &inputs_[outputs_[output].cur_input];
+                update_switch_stats(output, prev_input, input->index);
+                lock.unlock();
+                lock = std::unique_lock<mutex_dbg_owned>(*input->lock);
+                lock.lock();
                 continue;
             } else if (res != sched_type_t::STATUS_OK)
                 return res;
@@ -3793,7 +4041,6 @@ scheduler_tmpl_t<RecordType, ReaderType>::mark_input_eof(input_info_t &input)
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_tmpl_t<RecordType, ReaderType>::eof_or_idle(output_ordinal_t output,
-                                                      bool hold_sched_lock,
                                                       input_ordinal_t prev_input)
 {
     // XXX i#6831: Refactor to use subclasses or templates to specialize
@@ -3808,58 +4055,39 @@ scheduler_tmpl_t<RecordType, ReaderType>::eof_or_idle(output_ordinal_t output,
          live_replay_output_count_.load(std::memory_order_acquire) == 0)) {
         assert(options_.mapping != MAP_AS_PREVIOUSLY || outputs_[output].at_eof);
         return sched_type_t::STATUS_EOF;
-    } else {
-        bool need_lock;
-        auto scoped_lock = hold_sched_lock
-            ? std::unique_lock<mutex_dbg_owned>()
-            : acquire_scoped_sched_lock_if_necessary(need_lock);
-        if (options_.mapping == MAP_TO_ANY_OUTPUT) {
-            // Workaround to avoid hangs when _SCHEDULE and/or _DIRECT_THREAD_SWITCH
-            // directives miss their targets (due to running with a subset of the
-            // original threads, or other scenarios) and we end up with no scheduled
-            // inputs but a set of unscheduled inputs who will never be scheduled.
-            VPRINT(this, 4,
-                   "eof_or_idle output=%d live=%d unsched=%zu runq=%zu blocked=%d\n",
-                   output, live_input_count_.load(std::memory_order_acquire),
-                   unscheduled_priority_.size(), ready_priority_.size(), num_blocked_);
-            if (ready_priority_.empty() && !unscheduled_priority_.empty()) {
-                if (outputs_[output].wait_start_time == 0) {
-                    outputs_[output].wait_start_time = get_output_time(output);
-                } else {
-                    uint64_t now = get_output_time(output);
-                    double elapsed_micros = (now - outputs_[output].wait_start_time) *
-                        options_.time_units_per_us;
-                    if (elapsed_micros > options_.block_time_max_us) {
-                        // XXX i#6822: We may want some other options here for what to
-                        // do.  We could release just one input at a time, which would be
-                        // the same scheduling order (as we have FIFO in
-                        // unscheduled_priority_) but may take a long time at
-                        // block_time_max_us each; we could declare we're done and just
-                        // exit, maybe under a flag or if we could see what % of total
-                        // records we've processed.
-                        VPRINT(this, 1,
-                               "eof_or_idle moving entire unscheduled queue to ready "
-                               "queue\n");
-                        while (!unscheduled_priority_.empty()) {
-                            input_info_t *tomove = unscheduled_priority_.top();
-                            std::lock_guard<mutex_dbg_owned> lock(*tomove->lock);
-                            tomove->unscheduled = false;
-                            ready_priority_.push(tomove);
-                            unscheduled_priority_.pop();
-                        }
-                        outputs_[output].wait_start_time = 0;
-                    }
-                }
-            } else {
-                outputs_[output].wait_start_time = 0;
-            }
-        }
-        outputs_[output].waiting = true;
-        if (prev_input != INVALID_INPUT_ORDINAL)
-            ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE];
-        set_cur_input(output, INVALID_INPUT_ORDINAL);
-        return sched_type_t::STATUS_IDLE;
     }
+    // Before going idle, try to steal work from another output.
+    // We start with us+1 to avoid everyone stealing from the low-numbered outputs.
+    // We only try when we first transition to idle; we rely on rebalancing after that,
+    // to avoid repeatededly grabbing other output's locks over and over.
+    if (!outputs_[output].tried_to_steal_on_idle) {
+        outputs_[output].tried_to_steal_on_idle = true;
+        for (unsigned int i = 0; i < outputs_.size(); ++i) {
+            output_ordinal_t target = (output + 1 + i) % outputs_.size();
+            if (target == output)
+                continue;
+            input_info_t *queue_next = nullptr;
+            sched_type_t::stream_status_t status =
+                pop_from_ready_queue(target, output, queue_next);
+            if (status == STATUS_OK && queue_next != nullptr) {
+                assert(status == STATUS_OK);
+                set_cur_input(output, queue_next->index);
+                ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS];
+                VPRINT(this, 2,
+                       "eof_or_idle: output %d stole input %d from %d's runqueue\n",
+                       output, queue_next->index, target);
+                return STATUS_STOLE;
+            }
+            // We didn't find anything; loop and check another output.
+        }
+        VPRINT(this, 3, "eof_or_idle: output %d failed to steal from anyone\n", output);
+    }
+    // We rely on rebalancing to handle the case of every input being unscheduled.
+    outputs_[output].waiting = true;
+    if (prev_input != INVALID_INPUT_ORDINAL)
+        ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE];
+    set_cur_input(output, INVALID_INPUT_ORDINAL);
+    return sched_type_t::STATUS_IDLE;
 }
 
 template <typename RecordType, typename ReaderType>
@@ -3889,24 +4117,196 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_output_active(output_ordinal_t out
 {
     if (options_.mapping != MAP_TO_ANY_OUTPUT)
         return sched_type_t::STATUS_INVALID;
-    if (outputs_[output].active == active)
+    if (outputs_[output].active->load(std::memory_order_acquire) == active)
         return sched_type_t::STATUS_OK;
-    outputs_[output].active = active;
+    outputs_[output].active->store(active, std::memory_order_release);
     VPRINT(this, 2, "Output stream %d is now %s\n", output,
            active ? "active" : "inactive");
-    std::lock_guard<mutex_dbg_owned> guard(sched_lock_);
+    std::vector<input_ordinal_t> ordinals;
     if (!active) {
         // Make the now-inactive output's input available for other cores.
         // This will reset its quantum too.
         // We aren't switching on a just-read instruction not passed to the consumer,
         // if the queue is empty.
-        if (inputs_[outputs_[output].cur_input].queue.empty())
-            inputs_[outputs_[output].cur_input].switching_pre_instruction = true;
-        set_cur_input(output, INVALID_INPUT_ORDINAL);
+        input_ordinal_t cur_input = outputs_[output].cur_input;
+        if (cur_input != INVALID_INPUT_ORDINAL) {
+            if (inputs_[cur_input].queue.empty())
+                inputs_[cur_input].switching_pre_instruction = true;
+            set_cur_input(output, INVALID_INPUT_ORDINAL);
+        }
+        // Move the runqueue to other outputs.
+        {
+            auto lock = acquire_scoped_output_lock_if_necessary(output);
+            while (!outputs_[output].runqueue.queue.empty()) {
+                input_info_t *tomove = outputs_[output].runqueue.queue.top();
+                ordinals.push_back(tomove->index);
+                outputs_[output].runqueue.queue.pop();
+            }
+        }
     } else {
         outputs_[output].waiting = true;
     }
-    return sched_type_t::STATUS_OK;
+    return rebalance_queues(output, ordinals);
+}
+
+template <typename RecordType, typename ReaderType>
+void
+scheduler_tmpl_t<RecordType, ReaderType>::print_queue_stats()
+{
+    size_t unsched_size = 0;
+    {
+        std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
+        unsched_size = unscheduled_priority_.queue.size();
+    }
+    int live = live_input_count_.load(std::memory_order_acquire);
+    VPRINT(this, 1, "inputs: %zd scheduleable, %zd unscheduled, %zd eof\n",
+           live - unsched_size, unsched_size, inputs_.size() - live);
+    for (unsigned int i = 0; i < outputs_.size(); ++i) {
+        auto lock = acquire_scoped_output_lock_if_necessary(i);
+        VPRINT(this, 1, "  out #%d: running #%d; %zd in queue; %d blocked\n", i,
+               // XXX: Reading this is racy; we're ok with that.
+               outputs_[i].cur_input, outputs_[i].runqueue.queue.size(),
+               outputs_[i].runqueue.num_blocked);
+    }
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_tmpl_t<RecordType, ReaderType>::rebalance_queues(
+    output_ordinal_t triggering_output, std::vector<input_ordinal_t> inputs_to_add)
+{
+    std::thread::id who;
+    if (!rebalancer_.compare_exchange_weak(who, std::this_thread::get_id(),
+                                           std::memory_order_release,
+                                           std::memory_order_relaxed)) {
+        // Someone else is rebalancing.
+        return sched_type_t::STATUS_OK;
+    }
+    sched_type_t::stream_status_t status = sched_type_t::STATUS_OK;
+    assert(options_.mapping == MAP_TO_ANY_OUTPUT);
+    VPRINT(this, 1, "Output %d triggered a rebalance @%" PRIu64 ":\n", triggering_output,
+           get_output_time(triggering_output));
+    // First, update the time to avoid more threads coming here.
+    last_rebalance_time_.store(get_output_time(triggering_output),
+                               std::memory_order_release);
+    VPRINT(this, 2, "Before rebalance:\n");
+    VDO(this, 2, { print_queue_stats(); });
+    ++outputs_[triggering_output]
+          .stats[memtrace_stream_t::SCHED_STAT_RUNQUEUE_REBALANCES];
+
+    // Workaround to avoid hangs when _SCHEDULE and/or _DIRECT_THREAD_SWITCH
+    // directives miss their targets (due to running with a subset of the
+    // original threads, or other scenarios) and we end up with no scheduled
+    // inputs but a set of unscheduled inputs who will never be scheduled.
+    // TODO i#6959: Just exit early instead, maybe under a flag.
+    // It would help to see what % of total records we've processed.
+    size_t unsched_size = 0;
+    {
+        std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
+        unsched_size = unscheduled_priority_.queue.size();
+    }
+    if (live_input_count_.load(std::memory_order_acquire) ==
+        static_cast<int>(unsched_size)) {
+        VPRINT(this, 1, "rebalancing moving entire unscheduled queue to runqueues\n");
+        {
+            std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
+            while (!unscheduled_priority_.queue.empty()) {
+                input_info_t *tomove = unscheduled_priority_.queue.top();
+                inputs_to_add.push_back(tomove->index);
+                unscheduled_priority_.queue.pop();
+            }
+        }
+        for (input_ordinal_t input : inputs_to_add) {
+            std::lock_guard<mutex_dbg_owned> lock(*inputs_[input].lock);
+            inputs_[input].unscheduled = false;
+        }
+    }
+
+    int live_inputs = live_input_count_.load(std::memory_order_acquire);
+    int live_outputs = 0;
+    for (unsigned int i = 0; i < outputs_.size(); ++i) {
+        if (outputs_[i].active->load(std::memory_order_acquire))
+            ++live_outputs;
+    }
+    double avg_per_output = live_inputs / static_cast<double>(live_outputs);
+    unsigned int avg_ceiling = static_cast<int>(std::ceil(avg_per_output));
+    unsigned int avg_floor = static_cast<int>(std::floor(avg_per_output));
+    int iteration = 0;
+    do {
+        // Walk the outputs, filling too-short queues from inputs_to_add and
+        // shrinking too-long queues into inputs_to_add.  We may need a 2nd pass
+        // for this; and a 3rd pass if bindings prevent even splitting.
+        VPRINT(
+            this, 3,
+            "Rebalance iteration %d inputs_to_add size=%zu avg_per_output=%4.1f %d-%d\n",
+            iteration, inputs_to_add.size(), avg_per_output, avg_floor, avg_ceiling);
+        // We're giving up the output locks as we go, so there may be some stealing
+        // in the middle of our operation, but the rebalancing is approximate anyway.
+        for (unsigned int i = 0; i < outputs_.size(); ++i) {
+            if (!outputs_[i].active->load(std::memory_order_acquire))
+                continue;
+            auto lock = acquire_scoped_output_lock_if_necessary(i);
+            // Only remove on the 1st iteration; later we can exceed due to binding
+            // constraints.
+            while (iteration == 0 && outputs_[i].runqueue.queue.size() > avg_ceiling) {
+                input_info_t *queue_next = nullptr;
+                // We use our regular pop_from_ready_queue which means we leave
+                // blocked inputs on the queue: those do not get rebalanced.
+                // XXX: Should we revisit that?
+                //
+                // We remove from the back to avoid penalizing the next-to-run entries
+                // at the front of the queue by putting them at the back of another
+                // queue.
+                sched_type_t::stream_status_t status = pop_from_ready_queue_hold_locks(
+                    i, INVALID_OUTPUT_ORDINAL, queue_next, /*from_back=*/true);
+                if (status == STATUS_OK && queue_next != nullptr) {
+                    VPRINT(this, 3,
+                           "Rebalance iteration %d: output %d giving up input %d\n",
+                           iteration, i, queue_next->index);
+                    assert(status == STATUS_OK);
+                    inputs_to_add.push_back(queue_next->index);
+                } else {
+                    assert(status != STATUS_OK);
+                    break;
+                }
+            }
+            std::vector<input_ordinal_t> incompatible_inputs;
+            // If we reach the 3rd iteration, we have fussy inputs with bindings.
+            // Try to add them to every output.
+            while ((outputs_[i].runqueue.queue.size() < avg_ceiling || iteration > 1) &&
+                   !inputs_to_add.empty()) {
+                input_ordinal_t ordinal = inputs_to_add.back();
+                inputs_to_add.pop_back();
+                input_info_t &input = inputs_[ordinal];
+                std::lock_guard<mutex_dbg_owned> input_lock(*input.lock);
+                if (input.binding.empty() ||
+                    input.binding.find(i) != input.binding.end()) {
+                    VPRINT(this, 3, "Rebalance iteration %d: output %d taking input %d\n",
+                           iteration, i, ordinal);
+                    add_to_ready_queue_hold_locks(i, &input);
+                } else {
+                    incompatible_inputs.push_back(ordinal);
+                }
+            }
+            inputs_to_add.insert(inputs_to_add.end(), incompatible_inputs.begin(),
+                                 incompatible_inputs.end());
+        }
+        ++iteration;
+        if (iteration >= 3 && !inputs_to_add.empty()) {
+            // This is possible with bindings limited to inactive outputs.
+            // XXX: Rather than return an error, we could add to the unscheduled queue,
+            // but do not mark the input unscheduled.  Then when an output is
+            // marked active, we could walk the unscheduled queue and take
+            // inputs not marked unscheduled.
+            VPRINT(this, 1, "Rebalance hit impossible binding\n");
+            status = sched_type_t::STATUS_IMPOSSIBLE_BINDING;
+            break;
+        }
+    } while (!inputs_to_add.empty());
+    VPRINT(this, 2, "After:\n");
+    VDO(this, 2, { print_queue_stats(); });
+    rebalancer_.store(std::thread::id(), std::memory_order_release);
+    return status;
 }
 
 template class scheduler_tmpl_t<memref_t, reader_t>;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -595,12 +595,15 @@ public:
         /** The unit of the schedule time quantum. */
         quantum_unit_t quantum_unit = QUANTUM_INSTRUCTIONS;
         /**
-         * The scheduling quantum duration for preemption.  The units are
-         * specified by
-         * #dynamorio::drmemtrace::scheduler_tmpl_t::scheduler_options_t::quantum_unit.
+         * Deprecated: use #quantum_duration_us and #time_units_per_us for #QUANTUM_TIME
+         * or #quantum_duration_instrs for #QUANTUM_INSTRUCTIONS instead.  It
+         * is an error to set this to a non-zero value when #struct_size includes
+         * #quantum_duration_us.  When #struct_size does not include
+         * #quantum_duration_us and this value is non-zero, the value in
+         * #quantum_duration_us is replaced with this value divided by the default
+         * value of #time_units_per_us.
          */
-        // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
-        uint64_t quantum_duration = 6 * 1000 * 1000;
+        uint64_t quantum_duration = 0;
         /**
          * If > 0, diagnostic messages are printed to stderr.  Higher values produce
          * more frequent diagnostics.
@@ -643,37 +646,21 @@ public:
          */
         uint64_t blocking_switch_threshold = 100;
         /**
-         * Controls the amount of time inputs are considered blocked at a syscall whose
-         * latency exceeds #syscall_switch_threshold or #blocking_switch_threshold.  The
-         * syscall latency (in microseconds) is multiplied by this field to produce the
-         * blocked time.  For #QUANTUM_TIME, that blocked time in the units reported by
-         * the time parameter to next_record() must pass before the input is no longer
-         * considered blocked.  Since the system call latencies are in microseconds, this
-         * #block_time_scale should be set to the number of next_record() time units in
-         * one simulated microsecond.  For #QUANTUM_INSTRUCTIONS, the blocked time in
-         * wall-clock microseconds must pass before the input is actually selected
-         * (wall-clock time is used as there is no reasonable alternative with no other
-         * uniform notion of time); thus, the #block_time_scale value here should equal
-         * the slowdown of the instruction record processing versus the original
-         * (untraced) application execution.  The blocked time is clamped to a maximum
-         * value controlled by #block_time_max.
-         *
-         * The default value is meant to be reasonable for simple analyzers.  It may
-         * result in too much or too little idle time depending on the analyzer or
-         * simulator and its speed; it is meant to be tuned and modified.
+         * Deprecated: use #block_time_multiplier instead.  It is an error to set
+         * this to a non-zero value when #struct_size includes #block_time_multiplier.
+         * When #struct_size does not include #block_time_multiplier and this value is
+         * non-zero, the value in #block_time_multiplier is replaced with this value
+         * divided by the default value of #time_units_per_us.
          */
-        double block_time_scale = 10.;
+        double block_time_scale = 0.;
         /**
-         * The maximum time, in the units explained by #block_time_scale (either
-         * #QUANTUM_TIME simulator time or wall-clock microseconds for
-         * #QUANTUM_INSTRUCTIONS), for an input to be considered blocked for any one
-         * system call.  This is applied after multiplying by #block_time_scale.
-         * This is also used as a fallback to avoid hangs when there are no scheduled
-         * inputs: if the only inputs left are "unscheduled" (see
-         * #TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE), after this amount of time those
-         * inputs are all re-scheduled.
+         * Deprecated: use #block_time_max_us and #time_units_per_us instead.  It is
+         * an error to set this to a non-zero value when #struct_size includes
+         * #block_time_max_us.  When #struct_size does not include #block_time_max_us
+         * and this value is non-zero, the value in #block_time_max_us is replaced
+         * with this value divided by the default value of #time_units_per_us.
          */
-        uint64_t block_time_max = 250000;
+        uint64_t block_time_max = 0;
         // XXX: Should we share the file-to-reader code currently in the scheduler
         // with the analyzer and only then need reader interfaces and not pass paths
         // to the scheduler?
@@ -740,6 +727,59 @@ public:
          * (these markers remain: they are not removed from the trace).
          */
         bool honor_direct_switches = true;
+        /**
+         * How many time units for the "cur_time" value passed to next_record() are
+         * equivalent to one simulated microsecond.  E.g., if the time units are in
+         * picoseconds, pass one million here.  This is used to scale all of the
+         * other parameters that are in microseconds (they all end in "_us": e.g.,
+         * #quantum_duration_us) so that they operate on the right time scale for the
+         * passed-in simulator time.
+         */
+        double time_units_per_us = 1000.;
+        /**
+         * The scheduling quantum duration for preemption, in simulated microseconds,
+         * for #QUANTUM_TIME.  This value is multiplied by #time_units_per_us to
+         * produce a value that is compared to the "cur_time" parameter to
+         * next_record() to determine when to force a quantum switch.
+         */
+        uint64_t quantum_duration_us = 5000;
+        /**
+         * The scheduling quantum duration for preemption, in instruction count,
+         * for #QUANTUM_INSTRUCTIONS.  The time passed to next_record() is ignored
+         * for purposes of quantum preempts.
+         */
+        // We pick 6 million to match 2 instructions per nanosecond with a 3ms quantum.
+        uint64_t quantum_duration_instrs = 6 * 1000 * 1000;
+        /**
+         * Controls the amount of time inputs are considered blocked at a syscall
+         * whose as-traced latency (recorded in timestamp records in the trace)
+         * exceeds #syscall_switch_threshold or #blocking_switch_threshold.  The
+         * as-traced syscall latency (which is in traced microseconds) is multiplied
+         * by this field to produce the blocked time in simulated microseconds.  Once
+         * that many simulated microseconds has passed according to the "cur_time"
+         * value passed to next_record() (multiplied by #time_units_per_us), the
+         * input will be no longer considered blocked.  The blocked time is clamped
+         * to a maximum value controlled by #block_time_max.
+         *
+         * While there is no direct overhead during tracing, indirect overhead
+         * does result in some inflation of recorded system call latencies.
+         * Thus, a value below 0 is typically used here.  This value, in combination
+         * with #block_time_max_us, can be tuned to achieve a desired idle rate.
+         * The default value errs on the side of less idle time.
+         */
+        double block_time_multiplier = 0.01;
+        /**
+         * The maximum time in microseconds for an input to be considered blocked for
+         * any one system call.  This value is multiplied by #time_units_per_us to
+         * produce a value that is compared to the "cur_time" parameter to
+         * next_record().  If any block time (see #block_time_multiplier) exceeds
+         * this value, it is capped to this value.  This value is also used as a
+         * fallback to avoid hangs when there are no scheduled inputs: if the only
+         * inputs left are "unscheduled" (see #TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE),
+         * after this amount of time those inputs are all re-scheduled.
+         */
+        // TODO i#6959: Once we have -exit_if_all_unscheduled raise this.
+        uint64_t block_time_max_us = 250;
     };
 
     /**
@@ -1531,6 +1571,9 @@ protected:
     virtual bool
     process_next_initial_record(input_info_t &input, RecordType record,
                                 bool &found_filetype, bool &found_timestamp);
+
+    scheduler_status_t
+    legacy_field_support();
 
     // Opens readers for each file in 'path', subject to the constraints in
     // 'reader_info'.  'path' may be a directory.

--- a/clients/drcachesim/tests/scheduler_launcher.cpp
+++ b/clients/drcachesim/tests/scheduler_launcher.cpp
@@ -307,10 +307,13 @@ _tmain(int argc, const TCHAR *targv[])
         op_honor_stamps.get_value() ? scheduler_t::DEPENDENCY_TIMESTAMPS
                                     : scheduler_t::DEPENDENCY_IGNORE,
         scheduler_t::SCHEDULER_DEFAULTS, op_verbose.get_value());
-    sched_ops.quantum_duration = op_sched_quantum.get_value();
-    if (op_sched_time.get_value())
+    if (op_sched_time.get_value()) {
         sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
-    sched_ops.block_time_scale = op_block_time_scale.get_value();
+        sched_ops.quantum_duration_us = op_sched_quantum.get_value();
+    } else {
+        sched_ops.quantum_duration_instrs = op_sched_quantum.get_value();
+    }
+    sched_ops.block_time_multiplier = op_block_time_scale.get_value();
 #ifdef HAS_ZIP
     std::unique_ptr<zipfile_ostream_t> record_zip;
     std::unique_ptr<zipfile_istream_t> replay_zip;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -34,12 +34,14 @@
 #undef NDEBUG
 #include <assert.h>
 #include <algorithm>
+#include <cctype>
 #include <cstddef>
 #include <cstring>
 #include <iostream>
 #include <set>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 #include <utility>
 
@@ -553,9 +555,9 @@ test_legacy_fields()
         // the usage to persist to their next scheduling which should only have
         // a single letter.
         static const char *const CORE0_SCHED_STRING =
-            "..AA......CCC..EEE..GGGDDDFFFBBBCCC.EEE.AAA.GGG.";
+            "..AA......CCC..EEE..GGGACCCEEEGGGAAACCC.EEGGAAE.G.A.";
         static const char *const CORE1_SCHED_STRING =
-            "..BB......DDD..FFFABCCCEEEAAAGGGDDD.FFF.BBB.____";
+            "..BB......DDD..FFFBDDDFFFBBBDDD.FFF.BBB.____________";
         for (int i = 0; i < NUM_OUTPUTS; i++) {
             std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
         }
@@ -1217,15 +1219,20 @@ test_synthetic()
         inputs[i].push_back(make_exit(tid));
     }
     // Hardcoding here for the 2 outputs and 7 inputs.
-    // We expect 3 letter sequences (our quantum) alternating every-other as each
-    // core alternates. The dots are markers and thread exits.
+    // We make assumptions on the scheduler's initial runqueue assignment
+    // being round-robin, resulting in 4 on core0 (odd parity letters) and 3 on
+    // core1 (even parity letters).
+    // We expect 3 letter sequences (our quantum).
+    // The dots are markers and thread exits.
     // A and B have a voluntary switch after their 1st 2 letters, but we expect
-    // the usage to persist to their next scheduling which should only have
+    // their cpu usage to persist to their next scheduling which should only have
     // a single letter.
+    // Since core0 has an extra input, core1 finishes its runqueue first and then
+    // steals G from core0 (migration threshold is 0) and finishes it off.
     static const char *const CORE0_SCHED_STRING =
-        "..AA......CCC..EEE..GGGDDDFFFBBBCCC.EEE.AAA.GGG.";
+        "..AA......CCC..EEE..GGGACCCEEEGGGAAACCC.EEE.AAA.";
     static const char *const CORE1_SCHED_STRING =
-        "..BB......DDD..FFFABCCCEEEAAAGGGDDD.FFF.BBB.____";
+        "..BB......DDD..FFFBDDDFFFBBBDDD.FFF.BBB.GGG.____";
     {
         // Test instruction quanta.
         std::vector<scheduler_t::input_workload_t> sched_inputs;
@@ -1242,6 +1249,9 @@ test_synthetic()
                                                    /*verbosity=*/3);
         sched_ops.quantum_duration_instrs = QUANTUM_DURATION;
         sched_ops.block_time_multiplier = BLOCK_SCALE;
+        // Migration is measured in wall-clock-time for instr quanta
+        // so avoid non-determinism by having no threshold.
+        sched_ops.migration_threshold_us = 0;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -1255,14 +1265,18 @@ test_synthetic()
         // is the instances where the same letter appears 3 times without another letter
         // appearing in between (and ignoring the last letter for an input: EOF doesn't
         // count as a preempt).
-        verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/10,
+        verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/11,
                                /*switch_input_to_idle=*/0, /*switch_idle_to_input=*/0,
-                               /*switch_nop=*/0, /*preempts=*/6, /*direct_attempts=*/0,
-                               /*direct_successes=*/0, /*migrations=*/7);
-        verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/11,
-                               /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/0,
                                /*switch_nop=*/0, /*preempts=*/8, /*direct_attempts=*/0,
-                               /*direct_successes=*/0, /*migrations=*/7);
+                               /*direct_successes=*/0, /*migrations=*/1);
+        verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/10,
+                               /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/0,
+                               /*switch_nop=*/0, /*preempts=*/6, /*direct_attempts=*/0,
+                               /*direct_successes=*/0, /*migrations=*/0);
+        assert(scheduler.get_stream(0)->get_schedule_statistic(
+                   memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS) == 0);
+        assert(scheduler.get_stream(1)->get_schedule_statistic(
+                   memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS) == 1);
 #ifndef WIN32
         // XXX: Windows microseconds on test VMs are very coarse and stay the same
         // for long periods.  Instruction quanta use wall-clock idle times, so
@@ -1308,6 +1322,7 @@ test_synthetic()
         sched_ops.time_units_per_us = 1.;
         sched_ops.quantum_duration_us = QUANTUM_DURATION;
         sched_ops.block_time_multiplier = BLOCK_SCALE;
+        sched_ops.migration_threshold_us = 0;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -1373,6 +1388,8 @@ test_synthetic_time_quanta()
         sched_ops.quantum_duration_us = 3;
         // Ensure it waits 10 steps.
         sched_ops.block_time_multiplier = 10. / (POST_BLOCK_TIME - PRE_BLOCK_TIME);
+        // Ensure steals happen in this short test.
+        sched_ops.migration_threshold_us = 0;
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -1392,12 +1409,14 @@ test_synthetic_time_quanta()
             if (status == scheduler_t::STATUS_OK) {
                 if (memref.marker.tid != expect_tid) {
                     std::cerr << "Expected tid " << expect_tid
-                              << " != " << memref.marker.tid << "\n";
+                              << " != " << memref.marker.tid << " at time " << time
+                              << "\n";
                     assert(false);
                 }
                 if (memref.marker.type != expect_type) {
                     std::cerr << "Expected type " << expect_type
-                              << " != " << memref.marker.type << "\n";
+                              << " != " << memref.marker.type << " at time " << time
+                              << "\n";
                     assert(false);
                 }
             }
@@ -1418,22 +1437,25 @@ test_synthetic_time_quanta()
         check_next(cpu0, time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_MARKER);
         check_next(cpu0, ++time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_INSTR);
         // Advance cpu1 which is now at its quantum end at time 6 and should switch.
+        // However, there's no one else in cpu1's runqueue, so it proceeds with TID_B.
+        check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
+        check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
+        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_THREAD_EXIT);
+        // cpu1 should now steal TID_A from cpu0.
         check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_INSTR);
         check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
         check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
         check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
         check_next(cpu1, time, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_MARKER);
-        // We just hit a blocking syscall in A so we swap to B.
-        check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
-        // This is another quantum end at 9 but no other input is available.
-        check_next(cpu1, ++time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
-        check_next(cpu1, time, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_THREAD_EXIT);
+        // We just hit a blocking syscall in A but there is nothing else to run.
         check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
-        // Finish off C on cpu 0.
+        // Finish off C on cpu 0.  This hits a quantum end but there's no one else.
         check_next(cpu0, ++time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_INSTR);
         check_next(cpu0, ++time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_INSTR);
         check_next(cpu0, time, scheduler_t::STATUS_OK, TID_C, TRACE_TYPE_THREAD_EXIT);
         // Both cpus wait until A is unblocked.
+        check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
+        check_next(cpu0, ++time, scheduler_t::STATUS_IDLE);
         check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
         check_next(cpu0, ++time, scheduler_t::STATUS_IDLE);
         check_next(cpu1, ++time, scheduler_t::STATUS_IDLE);
@@ -1445,15 +1467,16 @@ test_synthetic_time_quanta()
         check_next(cpu0, ++time, scheduler_t::STATUS_EOF);
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
-        // Check scheduler stats.
+        // Check scheduler stats.  2 nops (quantum end but no one else); 1 migration
+        // (the steal).
         verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/1,
                                /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/0,
                                /*switch_nop=*/1, /*preempts=*/2, /*direct_attempts=*/0,
-                               /*direct_successes=*/0, /*migrations=*/0);
-        verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/2,
-                               /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/1,
-                               /*switch_nop=*/0, /*preempts=*/1, /*direct_attempts=*/0,
                                /*direct_successes=*/0, /*migrations=*/1);
+        verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/1,
+                               /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/1,
+                               /*switch_nop=*/1, /*preempts=*/1, /*direct_attempts=*/0,
+                               /*direct_successes=*/0, /*migrations=*/0);
     }
     {
         replay_file_checker_t checker;
@@ -1492,7 +1515,7 @@ test_synthetic_time_quanta()
         // so the idle portions at the end here can have variable idle and wait
         // record counts.  We thus just check the start.
         assert(sched_as_string[0].substr(0, 10) == "..A..CCC._");
-        assert(sched_as_string[1].substr(0, 12) == "..BA....BB._");
+        assert(sched_as_string[1].substr(0, 12) == "..BBB.A...._");
     }
 #endif
 }
@@ -1568,25 +1591,28 @@ test_synthetic_with_timestamps()
     // Hardcoding here for the 3x3+1 inputs where the inverted timestamps mean the
     // priorities are {C,B,A},{F,E,D},{I,H,G},{J} within the workloads.  Across
     // workloads we should start with {C,F,I,J} and then move on to {B,E,H} and finish
-    // with {A,D,G}.  We should interleave within each group -- except once we reach J
-    // we should completely finish it.
+    // with {A,D,G}.  The scheduler's initial round-robin-in-priority-order allocation
+    // to runqueues means it will alternate in the priority order C,F,I,J,B,E,H,A,D,G:
+    // thus core0 has C,I,B,H,D and core1 has F,J,E,A,G.
+    // We should interleave within each group -- except once we reach J
+    // we should completely finish it.  There should be no migrations.
     assert(
         sched_as_string[0] ==
-        ".CC.C.II.IC.CC.F.FF.I.II.FF.F..BB.B.HH.HE.EE.BB.B.HH.H..DD.DA.AA.G.GG.DD.D._");
+        ".CC.C.II.IC.CC.I.II.CC.C.II.I..BB.B.HH.HB.BB.H.HH.BB.B.HH.H..DD.DD.DD.DD.D._");
     assert(sched_as_string[1] ==
-           ".FF.F.JJ.JJ.JJ.JJ.J.CC.C.II.I..EE.EB.BB.H.HH.EE.E..AA.A.GG.GD.DD.AA.A.GG.G.");
+           ".FF.F.JJ.JJ.JJ.JJ.J.F.FF.FF.F..EE.EE.EE.EE.E..AA.A.GG.GA.AA.G.GG.AA.A.GG.G.");
     // Check scheduler stats.  # switches is the # of letter transitions; # preempts
     // is the instances where the same letter appears 3 times without another letter
     // appearing in between (and ignoring the last letter for an input: EOF doesn't
     // count as a preempt).
-    verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/14,
+    verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/12,
                            /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/0,
-                           /*switch_nop=*/0, /*preempts=*/11, /*direct_attempts=*/0,
-                           /*direct_successes=*/0, /*migrations=*/7);
-    verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/12,
+                           /*switch_nop=*/2, /*preempts=*/10, /*direct_attempts=*/0,
+                           /*direct_successes=*/0, /*migrations=*/0);
+    verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/9,
                            /*switch_input_to_idle=*/0, /*switch_idle_to_input=*/0,
-                           /*switch_nop=*/2, /*preempts=*/9, /*direct_attempts=*/0,
-                           /*direct_successes=*/0, /*migrations=*/8);
+                           /*switch_nop=*/5, /*preempts=*/10, /*direct_attempts=*/0,
+                           /*direct_successes=*/0, /*migrations=*/0);
 }
 
 static void
@@ -1668,21 +1694,21 @@ test_synthetic_with_priorities()
     // first.  J remains uninterrupted due to lower timestamps.
     assert(
         sched_as_string[0] ==
-        ".BB.B.HH.HE.EE.BB.B.HH.H..FF.F.JJ.JJ.JJ.JJ.J.CC.C.II.I..DD.DA.AA.G.GG.DD.D._");
+        ".BB.B.HH.HB.BB.H.HH.BB.B.HH.H..FF.F.JJ.JJ.JJ.JJ.J.F.FF.FF.F..DD.DD.DD.DD.D._");
     assert(sched_as_string[1] ==
-           ".EE.EB.BB.H.HH.EE.E..CC.C.II.IC.CC.F.FF.I.II.FF.F..AA.A.GG.GD.DD.AA.A.GG.G.");
+           ".EE.EE.EE.EE.E..CC.C.II.IC.CC.I.II.CC.C.II.I..AA.A.GG.GA.AA.G.GG.AA.A.GG.G.");
     // Check scheduler stats.  # switches is the # of letter transitions; # preempts
     // is the instances where the same letter appears 3 times without another letter
     // appearing in between (and ignoring the last letter for an input: EOF doesn't
     // count as a preempt).
-    verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/12,
+    verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/9,
                            /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/0,
-                           /*switch_nop=*/2, /*preempts=*/9, /*direct_attempts=*/0,
-                           /*direct_successes=*/0, /*migrations=*/8);
-    verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/14,
+                           /*switch_nop=*/5, /*preempts=*/10, /*direct_attempts=*/0,
+                           /*direct_successes=*/0, /*migrations=*/0);
+    verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/12,
                            /*switch_input_to_idle=*/0, /*switch_idle_to_input=*/0,
-                           /*switch_nop=*/0, /*preempts=*/11, /*direct_attempts=*/0,
-                           /*direct_successes=*/0, /*migrations=*/7);
+                           /*switch_nop=*/2, /*preempts=*/10, /*direct_attempts=*/0,
+                           /*direct_successes=*/0, /*migrations=*/0);
 }
 
 static void
@@ -1740,6 +1766,9 @@ test_synthetic_with_bindings_time(bool time_deps)
         scheduler_t::SCHEDULER_DEFAULTS,
         /*verbosity=*/3);
     sched_ops.quantum_duration_instrs = 3;
+    // Migration is measured in wall-clock-time for instr quanta
+    // so avoid non-determinism by having no threshold.
+    sched_ops.migration_threshold_us = 0;
     scheduler_t scheduler;
     if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
         scheduler_t::STATUS_SUCCESS)
@@ -1749,12 +1778,15 @@ test_synthetic_with_bindings_time(bool time_deps)
     for (int i = 0; i < NUM_OUTPUTS; i++) {
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
-    // We have {A,B,C} on {2,4}, {D,E,F} on {0,1}, and {G,H,I} on {1,2,3}:
-    assert(sched_as_string[0] == ".DD.D.FF.FD.DD.F.FF.DD.D.FF.F._");
-    assert(sched_as_string[1] == ".EE.E.HH.HE.EE.I.II.EE.E.______");
-    assert(sched_as_string[2] == ".AA.A.CC.CG.GG.C.CC.HH.H.CC.C.");
-    assert(sched_as_string[3] == ".GG.G.II.IH.HH.GG.G.II.I._____");
-    assert(sched_as_string[4] == ".BB.BA.AA.B.BB.AA.A.BB.B._____");
+    // We have {A,B,C} on {2,4}, {D,E,F} on {0,1}, and {G,H,I} on {1,2,3}.
+    // We should *not* see cores stealing inputs that can't run on them: so we
+    // should see tail idle time.  We should see allowed steals with no migration
+    // threshold.
+    assert(sched_as_string[0] == ".DD.D.EE.E.FF.FD.DD.E.EE.F.FF.EE.E.FF.F.");
+    assert(sched_as_string[1] == ".GG.G.HH.HG.GG.H.HH.HH.H.DD.D.__________");
+    assert(sched_as_string[2] == ".AA.A.BB.BA.AA.B.BB.BB.B._______________");
+    assert(sched_as_string[3] == ".II.II.II.II.I.GG.G.____________________");
+    assert(sched_as_string[4] == ".CC.CC.CC.CC.C.AA.A.____________________");
 }
 
 static void
@@ -1874,11 +1906,11 @@ test_synthetic_with_bindings_weighted()
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
     // We have {A,B,C} on {2,4}, {D,E,F} on {0,1}, and {G,H,I} on {1,2,3}:
-    assert(sched_as_string[0] == ".FF.FF.FF.FF.F..EE.EE.EE.EE.E._");
-    assert(sched_as_string[1] == ".II.II.II.II.I..DD.DD.DD.DD.D._");
-    assert(sched_as_string[2] == ".CC.CC.CC.CC.C..AA.AA.AA.AA.A._");
-    assert(sched_as_string[3] == ".HH.HH.HH.HH.H..GG.GG.GG.GG.G.");
-    assert(sched_as_string[4] == ".BB.BB.BB.BB.B._______________");
+    assert(sched_as_string[0] == ".FF.FF.FF.FF.F..EE.EE.EE.EE.E..DD.DD.DD.DD.D.");
+    assert(sched_as_string[1] == ".II.II.II.II.I..HH.HH.HH.HH.H._______________");
+    assert(sched_as_string[2] == ".CC.CC.CC.CC.C..BB.BB.BB.BB.B._______________");
+    assert(sched_as_string[3] == ".GG.GG.GG.GG.G.______________________________");
+    assert(sched_as_string[4] == ".AA.AA.AA.AA.A.______________________________");
 }
 
 static void
@@ -2002,20 +2034,22 @@ test_synthetic_with_syscalls_multiple()
     // with the "." in run_lockstep_simulation().  The omitted "." markers also
     // explains why the two strings are different lengths.
     assert(sched_as_string[0] ==
-           "BHHHFFFJJJJJJBEEHHHFFFBCCCEEIIIDDDBAAAGGGDDDB________B_______");
-    assert(sched_as_string[1] == "EECCCIIICCCBEEJJJHHHIIIFFFEAAAGGGBDDDAAAGGG________B");
+           "BHHHFFFJJJJJJBHHHJJJFFFFFFBHHHDDDDDDDDDB__________B__________B__________B____"
+           "______B_______B");
+    assert(sched_as_string[1] ==
+           "EECCCIIICCCIIIEECCCIIIAAAGGGEEAAAGGEEGAAEGGAG_________");
     // Check scheduler stats.  # switches is the # of letter transitions; # preempts
     // is the instances where the same letter appears 3 times without another letter
     // appearing in between (and ignoring the last letter for an input: EOF doesn't
     // count as a preempt).
-    verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/17,
-                           /*switch_input_to_idle=*/2, /*switch_idle_to_input=*/1,
-                           /*switch_nop=*/2, /*preempts=*/11, /*direct_attempts=*/0,
-                           /*direct_successes=*/0, /*migrations=*/9);
-    verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/16,
-                           /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/1,
-                           /*switch_nop=*/0, /*preempts=*/10, /*direct_attempts=*/0,
-                           /*direct_successes=*/0, /*migrations=*/11);
+    verify_scheduler_stats(scheduler.get_stream(0), /*switch_input_to_input=*/11,
+                           /*switch_input_to_idle=*/5, /*switch_idle_to_input=*/5,
+                           /*switch_nop=*/4, /*preempts=*/10, /*direct_attempts=*/0,
+                           /*direct_successes=*/0, /*migrations=*/0);
+    verify_scheduler_stats(scheduler.get_stream(1), /*switch_input_to_input=*/19,
+                           /*switch_input_to_idle=*/1, /*switch_idle_to_input=*/0,
+                           /*switch_nop=*/3, /*preempts=*/16, /*direct_attempts=*/0,
+                           /*direct_successes=*/0, /*migrations=*/0);
 }
 
 static void
@@ -2100,8 +2134,11 @@ test_synthetic_with_syscalls_single()
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
     // We expect an idle CPU every 3 instrs but starting at the 2nd (1-based % 3).
-    assert(sched_as_string[0] == "..A....A....___________________________________A.....");
-    assert(sched_as_string[1] == "____________A....A.....A....__A.....A....A...._______");
+    // With per-output runqueues, cpu1 is idle the whole time.
+    assert(sched_as_string[0] ==
+           "..A....A....__A....A.....A....__A.....A....A....__A.....");
+    assert(sched_as_string[1] ==
+           "________________________________________________________");
 }
 
 static bool
@@ -2662,10 +2699,11 @@ test_replay()
     static constexpr int NUM_INSTRS = 9;
     static constexpr int QUANTUM_INSTRS = 3;
     // For our 2 outputs and 7 inputs:
-    // We expect 3 letter sequences (our quantum) alternating every-other as each
-    // core alternates; with an odd number the 2nd core finishes early.
-    static const char *const CORE0_SCHED_STRING = "AAACCCEEEGGGBBBDDDFFFAAA.CCC.EEE.GGG.";
-    static const char *const CORE1_SCHED_STRING = "BBBDDDFFFAAACCCEEEGGGBBB.DDD.FFF.____";
+    // We expect 3 letter sequences (our quantum) alternating every-other with
+    // odd parity letters on core0 (A,C,E,G) and even parity on core1 (B,D,F).
+    // With a smaller runqueue, the 2nd core finishes early and steals E.
+    static const char *const CORE0_SCHED_STRING = "AAACCCEEEGGGAAACCCEEEGGGAAA.CCC.GGG.";
+    static const char *const CORE1_SCHED_STRING = "BBBDDDFFFBBBDDDFFFBBB.DDD.FFF.EEE.__";
 
     static constexpr memref_tid_t TID_BASE = 100;
     std::vector<trace_entry_t> inputs[NUM_INPUTS];
@@ -2695,6 +2733,9 @@ test_replay()
                                                    scheduler_t::SCHEDULER_DEFAULTS,
                                                    /*verbosity=*/3);
         sched_ops.quantum_duration_instrs = QUANTUM_INSTRS;
+        // Migration is measured in wall-clock-time for instr quanta
+        // so avoid non-determinism by having no threshold.
+        sched_ops.migration_threshold_us = 0;
 
         zipfile_ostream_t outfile(record_fname);
         sched_ops.schedule_record_ostream = &outfile;
@@ -4253,17 +4294,17 @@ test_inactive()
         check_next(stream0, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
         // End of quantum.
         check_next(stream0, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_INSTR);
-        // Make cpu0 inactive and cpu1 active.
+        // Make cpu1 active and then cpu0 inactive.
+        status = stream1->set_active(true);
+        assert(status == scheduler_t::STATUS_OK);
         status = stream0->set_active(false);
         assert(status == scheduler_t::STATUS_OK);
         check_next(stream0, scheduler_t::STATUS_IDLE);
-        status = stream1->set_active(true);
-        assert(status == scheduler_t::STATUS_OK);
         // Now cpu1 should finish things.
+        check_next(stream1, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_THREAD_EXIT);
         check_next(stream1, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
         check_next(stream1, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_INSTR);
         check_next(stream1, scheduler_t::STATUS_OK, TID_B, TRACE_TYPE_THREAD_EXIT);
-        check_next(stream1, scheduler_t::STATUS_OK, TID_A, TRACE_TYPE_THREAD_EXIT);
         check_next(stream1, scheduler_t::STATUS_EOF);
         if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
             assert(false);
@@ -4300,8 +4341,8 @@ test_inactive()
         for (int i = 0; i < NUM_OUTPUTS; i++) {
             std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
         }
-        assert(sched_as_string[0] == "..AABA.__");
-        assert(sched_as_string[1] == "..B--BB.");
+        assert(sched_as_string[0] == "..AAB.___");
+        assert(sched_as_string[1] == "..B-ABB.");
     }
 #endif // HAS_ZIP
 }
@@ -4790,7 +4831,7 @@ test_unscheduled_fallback()
             "____________________________________________________________________________"
             "____________________________________________________________________________"
             "____________________________________________________________________________"
-            "_________________________________________________________BBBB.A.";
+            "___________BBBB.A.";
 
         std::vector<scheduler_t::input_workload_t> sched_inputs;
         sched_inputs.emplace_back(std::move(readers));
@@ -4805,6 +4846,7 @@ test_unscheduled_fallback()
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
         sched_ops.block_time_multiplier = BLOCK_SCALE;
         sched_ops.block_time_max_us = BLOCK_TIME_MAX;
+        sched_ops.rebalance_period_us = BLOCK_TIME_MAX;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
             scheduler_t::STATUS_SUCCESS)
@@ -4843,6 +4885,7 @@ test_unscheduled_fallback()
         sched_ops.blocking_switch_threshold = BLOCK_LATENCY;
         sched_ops.block_time_multiplier = BLOCK_SCALE;
         sched_ops.block_time_max_us = BLOCK_TIME_MAX;
+        sched_ops.rebalance_period_us = BLOCK_TIME_MAX;
         sched_ops.honor_direct_switches = false;
         scheduler_t scheduler;
         if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
@@ -5171,7 +5214,7 @@ test_kernel_switch_sequences()
     scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
                                                scheduler_t::DEPENDENCY_TIMESTAMPS,
                                                scheduler_t::SCHEDULER_DEFAULTS,
-                                               /*verbosity=*/4);
+                                               /*verbosity=*/3);
     sched_ops.quantum_duration_instrs = INSTR_QUANTUM;
     sched_ops.kernel_switch_reader = std::move(switch_reader);
     sched_ops.kernel_switch_reader_end = std::move(switch_reader_end);
@@ -5265,11 +5308,13 @@ test_kernel_switch_sequences()
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
     }
     assert(sched_as_string[0] ==
-           "Av0iii,Ct0iitv0iii,Ep0iipv0iii,Gp0iipv0iii,It0iitv0iii,Cp0iipiii,Ep0iipiii,"
-           "Gp0iipiii,Ap0iipiii,Bt0iitiii,Dp0iipiii,Ft0iitiii,Hp0iipiii______");
-    assert(sched_as_string[1] ==
-           "Bv0iii,Dp0iipv0iii,Ft0iitv0iii,Hp0iipv0iii,Ap0iipiii,Bt0iitiii,Dp0iipiii,"
-           "Ft0iitiii,Hp0iipiii,It0iitiii,Cp0iipiii,Ep0iipiii,Gp0iipiii,It0iitiii");
+           "Av0iii,Ct0iitv0iii,Ep0iipv0iii,Gp0iipv0iii,It0iitv0iii,Ap0iipiii,Ct0iitiii,"
+           "Ep0iipiii,Gp0iipiii,It0iitiii,Ap0iipiii,Ct0iitiii,Ep0iipiii,Gp0iipiii,"
+           "It0iitiii");
+    assert(
+        sched_as_string[1] ==
+        "Bv0iii,Dp0iipv0iii,Ft0iitv0iii,Hp0iipv0iii,Bp0iipiii,Dp0iipiii,Ft0iitiii,"
+        "Hp0iipiii,Bp0iipiii,Dp0iipiii,Ft0iitiii,Hp0iipiii___________________________");
 
     // Zoom in and check the first sequence record by record with value checks.
     int idx = 0;
@@ -5572,6 +5617,125 @@ test_record_scheduler()
     check_next(stream0, record_scheduler_t::STATUS_EOF);
 }
 
+static void
+test_rebalancing()
+{
+    std::cerr << "\n----------------\nTesting rebalancing\n";
+    // We want to get the cores into an unbalanced state.
+    // The scheduler will start out with round-robin even assignment.
+    // We use "unschedule" and "direct switch" operations to get all
+    // inputs onto one core.
+    static constexpr int NUM_OUTPUTS = 8;
+    static constexpr int NUM_INPUTS_UNSCHED = 24;
+    static constexpr int BLOCK_LATENCY = 100;
+    static constexpr double BLOCK_SCALE = 1. / (BLOCK_LATENCY);
+    static constexpr int QUANTUM_DURATION = 3 * NUM_OUTPUTS;
+    static constexpr int NUM_INSTRS = QUANTUM_DURATION * 3;
+    static constexpr int REBALANCE_PERIOD = NUM_OUTPUTS * 20 * NUM_INPUTS_UNSCHED;
+    static constexpr int MIGRATION_THRESHOLD = QUANTUM_DURATION;
+    static constexpr memref_tid_t TID_BASE = 100;
+    static constexpr memref_tid_t TID_A = TID_BASE + 0;
+    static constexpr memref_tid_t TID_B = TID_BASE + 1;
+    static constexpr uint64_t TIMESTAMP_START_INSTRS = 9999;
+
+    std::vector<trace_entry_t> refs_controller;
+    refs_controller.push_back(make_thread(TID_A));
+    refs_controller.push_back(make_pid(1));
+    refs_controller.push_back(make_version(TRACE_ENTRY_VERSION));
+    refs_controller.push_back(make_timestamp(1001));
+    refs_controller.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+    // Our controller switches to the first thread, who then switches to
+    // the next, etc.
+    refs_controller.push_back(make_instr(/*pc=*/101));
+    refs_controller.push_back(make_instr(/*pc=*/102));
+    refs_controller.push_back(make_timestamp(1101));
+    refs_controller.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+    refs_controller.push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 999));
+    refs_controller.push_back(
+        make_marker(TRACE_MARKER_TYPE_SYSCALL_ARG_TIMEOUT, BLOCK_LATENCY));
+    refs_controller.push_back(make_marker(TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_B));
+    refs_controller.push_back(make_timestamp(1201));
+    refs_controller.push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+    refs_controller.push_back(make_instr(/*pc=*/401));
+    refs_controller.push_back(make_exit(TID_A));
+    // Our unsched threads all start unscheduled.
+    std::vector<std::vector<trace_entry_t>> refs_unsched(NUM_INPUTS_UNSCHED);
+    for (int i = 0; i < NUM_INPUTS_UNSCHED; ++i) {
+        refs_unsched[i].push_back(make_thread(TID_B + i));
+        refs_unsched[i].push_back(make_pid(1));
+        refs_unsched[i].push_back(make_version(TRACE_ENTRY_VERSION));
+        refs_unsched[i].push_back(make_timestamp(2001));
+        refs_unsched[i].push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+        // B starts unscheduled with no timeout.
+        refs_unsched[i].push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 999));
+        refs_unsched[i].push_back(
+            make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0));
+        refs_unsched[i].push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE, 0));
+        refs_unsched[i].push_back(make_timestamp(3001));
+        refs_unsched[i].push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+        // Once scheduled, wake up the next thread.
+        refs_unsched[i].push_back(make_timestamp(1101 + 100 * i));
+        refs_unsched[i].push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+        refs_unsched[i].push_back(make_marker(TRACE_MARKER_TYPE_SYSCALL, 999));
+        refs_unsched[i].push_back(
+            make_marker(TRACE_MARKER_TYPE_SYSCALL_ARG_TIMEOUT, BLOCK_LATENCY));
+        refs_unsched[i].push_back(
+            make_marker(TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_B + i + 1));
+        // Give everyone the same timestamp so we alternate on preempts.
+        refs_unsched[i].push_back(make_timestamp(TIMESTAMP_START_INSTRS));
+        refs_unsched[i].push_back(make_marker(TRACE_MARKER_TYPE_CPU_ID, 0));
+        // Now run a bunch of instrs so we'll reach our rebalancing period.
+        for (int instrs = 0; instrs < NUM_INSTRS; ++instrs) {
+            refs_unsched[i].push_back(make_instr(/*pc=*/200 + instrs));
+        }
+        refs_unsched[i].push_back(make_exit(TID_B + i));
+    }
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(
+        std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_controller)),
+        std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
+    for (int i = 0; i < NUM_INPUTS_UNSCHED; ++i) {
+        readers.emplace_back(
+            std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_unsched[i])),
+            std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_B + i);
+    }
+
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(readers));
+    scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                               scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                               scheduler_t::SCHEDULER_DEFAULTS,
+                                               /*verbosity=*/3);
+    // We use our mock's time==instruction count for a deterministic result.
+    sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+    sched_ops.time_units_per_us = 1.;
+    sched_ops.quantum_duration_us = QUANTUM_DURATION;
+    sched_ops.block_time_multiplier = BLOCK_SCALE;
+    sched_ops.migration_threshold_us = MIGRATION_THRESHOLD;
+    sched_ops.rebalance_period_us = REBALANCE_PERIOD;
+    scheduler_t scheduler;
+    if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    std::vector<std::string> sched_as_string =
+        run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_BASE, /*send_time=*/true);
+    // We should see a lot of migrations away from output 0: we should see the
+    // per-output average per other output, minus the live input.
+    assert(scheduler.get_stream(0)->get_schedule_statistic(
+               memtrace_stream_t::SCHED_STAT_MIGRATIONS) >=
+           (NUM_INPUTS_UNSCHED / NUM_OUTPUTS) * (NUM_OUTPUTS - 1) - 1);
+    for (int i = 0; i < NUM_OUTPUTS; i++) {
+        std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+        // Ensure we see multiple inputs on each output.
+        std::unordered_set<char> inputs;
+        for (char c : sched_as_string[i]) {
+            if (std::isalpha(c))
+                inputs.insert(c);
+        }
+        assert(inputs.size() >= (NUM_INPUTS_UNSCHED / NUM_OUTPUTS) - 1);
+    }
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -5615,6 +5779,7 @@ test_main(int argc, const char *argv[])
     test_kernel_switch_sequences();
     test_random_schedule();
     test_record_scheduler();
+    test_rebalancing();
 
     dr_standalone_exit();
     return 0;

--- a/core/loader_shared.c
+++ b/core/loader_shared.c
@@ -178,6 +178,7 @@ loader_init_prologue(void)
         privmod_t *mod =
             privload_insert(NULL, privmod_static[i].base, privmod_static[i].size,
                             privmod_static[i].name, privmod_static[i].path);
+        mod->is_top_level_client = true;
         mod->is_client = true;
     }
 
@@ -520,6 +521,7 @@ privload_insert(privmod_t *after, app_pc base, size_t size, const char *name,
     }
     mod->ref_count = 1;
     mod->externally_loaded = false;
+    mod->is_top_level_client = false; /* up to caller to set later */
     mod->is_client = false; /* up to caller to set later */
     mod->called_proc_entry = false;
     mod->called_proc_exit = false;

--- a/core/module_shared.h
+++ b/core/module_shared.h
@@ -413,7 +413,9 @@ typedef struct _privmod_t {
     char path[MAXIMUM_PATH];
     uint ref_count;
     bool externally_loaded;
-    bool is_client; /* or Extension */
+    /* XXX i#6982: Perhaps replace is_client with is_top_level_client. */
+    bool is_top_level_client; /* set for command-line clients */
+    bool is_client;           /* set for command-line client or extension */
     bool called_proc_entry;
     bool called_proc_exit;
     struct _privmod_t *next;

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -581,9 +581,9 @@ privload_process_imports(privmod_t *mod)
                     SYSLOG_INTERNAL_WARNING(
                         "private libpthread.so loaded but not fully supported (i#956)");
                 }
-                /* i#852: identify all libs that import from DR as client libs.
-                 * XXX: this code seems stale as libdynamorio.so is already loaded
-                 * (xref #3850).
+                /* i#852: Identify all libs that import from DR as client libs.
+                 * XXX i#6982: The following condition is never true as
+                 * libdynamorio.so has already been loaded (xref #3850).
                  */
                 if (impmod->base == get_dynamorio_dll_start())
                     mod->is_client = true;

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1104,7 +1104,6 @@ module_lookup_symbol(ELF_SYM_TYPE *sym, os_privmod_data_t *pd)
 {
     app_pc res;
     const char *name;
-    privmod_t *mod;
     bool is_ifunc;
     dcontext_t *dcontext = get_thread_private_dcontext();
 
@@ -1133,11 +1132,21 @@ module_lookup_symbol(ELF_SYM_TYPE *sym, os_privmod_data_t *pd)
      * FIXME: i#461 We do not tell weak/global, but return on the first we see.
      */
     ASSERT_OWN_RECURSIVE_LOCK(true, &privload_lock);
-    mod = privload_first_module();
     /* FIXME i#3850: Symbols are currently looked up following the dependency chain
      * depth-first instead of breadth-first.
      */
-    while (mod != NULL) {
+    for (privmod_t *mod = privload_first_module(); mod != NULL;
+         mod = privload_next_module(mod)) {
+        /* Skip other client modules at this point because some will not be
+         * initialised and clients should be leaves of the dependency tree and
+         * not provide symbols for other modules. Skipping just the uninitialised
+         * client modules should also work but might introduce an element of
+         * unpredictability if we are unsure in what order modules will be
+         * initialised. Skipping all uninitialised modules should also work but
+         * might hide a more serious problem. See i#4501.
+         */
+        if (mod->is_top_level_client)
+            continue;
         pd = mod->os_privmod_data;
         ASSERT(pd != NULL && name != NULL);
 
@@ -1172,7 +1181,6 @@ module_lookup_symbol(ELF_SYM_TYPE *sym, os_privmod_data_t *pd)
             }
             return res;
         }
-        mod = privload_next_module(mod);
     }
     return NULL;
 }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3647,6 +3647,19 @@ if (BUILD_SAMPLES)
         "CFLAGS=-m32;CXXFLAGS=-m32")
     endif ()
   endif ()
+  if (UNIX)
+    # XXX: Change this to go through torun() like the other tests to share
+    # output, multiplexing, _timeout, etc. features: not entirely
+    # straightforward because this test uses two clients.
+    # For now, "-s 90 -quiet -killpg" is added explicitly.
+    get_target_path_for_execution(drrun_path drrun "${location_suffix}")
+    get_client_path(client1 bbcount bbcount)
+    get_client_path(client2 opcodes opcodes)
+    get_target_path_for_execution(app_path "${ci_shared_app}" "${location_suffix}")
+    add_test(two_clients ${drrun_path} -s 90 -quiet -killpg
+      -client ${client1} 0 ''
+      -client ${client2} 1 '' ${dr_test_ops} -- ${app_path})
+  endif (UNIX)
 endif (BUILD_SAMPLES)
 
 if (BUILD_CLIENTS)


### PR DESCRIPTION
Removes the global runqueue and global sched_lock_, replacing with
per-output runqueues which each have a lock inside a new struct
input_queue_t which clearly delineates what the lock protects.  The
unscheduled queue remains global and has its own lock as another
input_queue_t.  The output fields .active and .cur_time are now
atomics, as they are accessed from other outputs yet are separate from
the queue and its mutex.

Makes the runqueue lock usage narrow, avoiding holding locks across
the larger functions.  Establishes a lock ordering convention: input >
output > unsched.

The removal of the global sched_lock_ avoids the lock contention seen
on fast analyzers (the original design targeted heavyweight
simulators).  On a large internal trace with hundreds of threads on
>100 cores we were seeing 41% of lock attempts collide with
the global queue:
```
    [scheduler] Schedule lock acquired     :  72674364
    [scheduler] Schedule lock contended    :  30144911
```
With separate runqueues we see < 1 in 10,000 collide:
```
    [scheduler] Stats for output #0
    <...>
    [scheduler]   Runqueue lock acquired             :  34594996
    [scheduler]   Runqueue lock contended            :        29
    [scheduler] Stats for output #1
    <...>
    [scheduler]   Runqueue lock acquired             :  51130763
    [scheduler]   Runqueue lock contended            :        41
    <...>
    [scheduler]   Runqueue lock acquired             :  46305755
    [scheduler]   Runqueue lock contended            :        44
    [scheduler] Unscheduled queue lock acquired      :     27834
    [scheduler] Unscheduled queue lock contended     :       273
    $ egrep 'contend' OUT | awk '{n+=$NF}END{ print n}'
    11528
    $ egrep 'acq' OUT | awk '{n+=$NF}END{ print n}'
    6814820713
    (gdb) p 11528/6814820713.*100
    $1 = 0.00016916072315753086
```

Before an output goes idle, it attempts to steal work from another
output's runqueue.  A new input option is added controlling the
migration threshold to avoid moving jobs too frequently.  The stealing
is done inside eof_or_idle() which now returns a new internal status
code STATUS_STOLE so the various callers can be sure to read the next
record.

Adds a periodic rebalancing with a period equal to another new input
option.  Adds flexible_queue_t::back() for rebalancing to not take from
the front of the queues.

Updates an output going inactive and promoting everything-unscheduled
to use the new rebalancing.

Makes output_info_t.active atomic as it is read by other outputs
during stealing and rebalancing.

Adds a periodic rebalancing with a period equal to another new input
option.  Adds flexible_queue_t::back() for rebalancing to not take from
the front of the queues.

Updates an output going inactive and promoting everything-unscheduled
to use the new rebalancing.

Makes output_info_t.active atomic as it is read by other outputs
during stealing and rebalancing.

Adds statistics on the stealing and rebalancing instances.

Updates all of the unit tests, many of which now have different
resulting schedules.

Adds a new unit test targeting queue rebalancing.

Issue: #6938
