### PR TITLE
i#5843 scheduler: Improve drmemtrace scheduler documentation

### DIFF
--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -66,6 +66,7 @@ targets are provided up front.  These join the recent features of
  - \subpage sec_drcachesim_analyzer
  - \subpage sec_drcachesim_phys
  - \subpage sec_drcachesim_core
+ - \subpage sec_drcachesim_sched
  - \subpage sec_drcachesim_extend
  - \subpage sec_drcachesim_tracer
  - \subpage sec_drcachesim_funcs
@@ -180,7 +181,7 @@ Some of the more important markers are:
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP - The marker value provides a timestamp for this point of the trace (in units of microseconds since Jan 1, 1601 UTC). This value can be used to synchronize records from different threads as well as analyze latencies (however, tracing overhead inflates time unevenly, so time deltas should not be considered perfectly representative). It is used in the sequential analysis of a multi-threaded trace.
 
-- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID - The marker value contains the CPU identifier on which the subsequent records were collected. It is useful to help track thread migrations occurring during execution. This marker is written to the header of each trace buffer when the buffer is flushed. Note that if the thread migrates to a different CPU due to preemption by the kernel before a buffer is full, we do not output a separate #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID marker to capture the previous CPU identifier. However, we expect such cases to be rare.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID - The marker value contains the CPU identifier on which the subsequent records were collected. It helps to identify the "as traced" schedule, indicating which threads were on which cores at which times. However, this schedule is not representative and should not be treated as indicating how the application behaves without tracing.  See \ref sec_drcachesim_as_traced for further information.
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETADDR, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL - These markers are used to capture information about function calls.  Which functions to capture must be explicitly selected at tracing time.  Typical candiates are heap allocation and freeing functions.  See \ref sec_drcachesim_funcs.
 
@@ -188,12 +189,16 @@ Some of the more important markers are:
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL - This identifies a system call.  A timestamp is inserted in the trace before and after marker of this type.  This marker should be considered to be the actual system call invocation by the kernel, rather than the prior system call gateway instruction fetch record.  Thus, these timestamps provide the system call latency.
 
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE - This is inserted by the trace scheduler (see \ref sec_drcachesim_sched) when there is no work available on a core in core-sharded mode.  This is meant to simulate actual idle time on a core.
+
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_WAIT - This is inserted by the trace scheduler (see \ref sec_drcachesim_sched) during replay of a previously recorded schedule when one core gets too far ahead of another according to the recorded timestamps.  This is an artificial wait to keep the replay on track, as opposed to the natural idle time of #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE.
+
 The full set of markers is listed under the enum #dynamorio::drmemtrace::trace_marker_type_t.
 
 ****************************************************************************
-\page sec_drcachesim_run Running the Cache Simulator
+\page sec_drcachesim_run Running Tools
 
-To launch \p drcachesim, use the \p -t flag to \p drrun and specify the
+To launch \p drmemtrace, use the \p -t flag to \p drrun and specify the
 \p drmemtrace framework where the default tool to run is the cache simulator:
 
 \code
@@ -867,7 +872,7 @@ on program counter continuity and guarantees around kernel control
 transfer interruptions.  It optionally checks for restricted behavior
 that technically is legal but is not expected to happen in the target
 trace, helping to identify tracing problems and suitability for use of
-a trace for core simulation.
+a trace for core simulation (see \ref sec_drcachesim_core).
 
 \section sec_tool_syscall_mix System Call Mix
 
@@ -1286,76 +1291,79 @@ are user-specified (see \ref sec_drcachesim_ops).
 Neither simulator has a simple way to know which core any particular thread
 executed on for each of its instructions.  The tracer records which core a
 thread is on each time it writes out a full trace buffer, giving an
-approximation of the actual scheduling (at the granularity of the trace
-buffer size).  By default, these cache and TLB simulators ignore that
+approximation of the actual scheduling: but this is not representative
+due to overhead (see \ref sec_drcachesim_as_traced).  By default, these cache and TLB
+simulators ignore that
 information and schedule threads to simulated cores in a static round-robin
 fashion with load balancing to fill in gaps with new threads after threads
 exit.  The option "-cpu_scheduling" (see \ref sec_drcachesim_ops) can be
 used to instead map each physical cpu to a simulated core and use the
 recorded cpu that each segment of thread execution occurred on to schedule
-execution in a manner that more closely resembles the traced execution on
-the physical machine.  Below is an example of the output using this option
-running an application with many threads on a pysical machine with 8 cpus.
-The 8 cpus are mapped to the 4 simulated cores:
+execution following the "as traced" schedule, but as just noted this is not
+representative.  Instead, we recommend using offline traces and dynamic
+re-scheduling as explained in \ref sec_drcachesim_sched_dynamic using the
+`-core_serial` parameter.  Here is an example:
 
 \code
-$ bin64/drrun -t drmemtrace -cpu_scheduling -- ~/test/pi_estimator 20
+$ bin64/drrun -t drmemtrace -offline -- ~/test/pi_estimator 8 20
 Estimation of pi is 3.141592653798125
-<Stopping application /home/bruening/dr/test/threadsig (213517)>
----- <application exited with code 0> ----
+$ bin64/drrun -t drcachesim -core_serial -cores 3 -indir drmemtrace.pi_estimator.*.dir
 Cache simulation results:
-Core #0 (2 traced CPU(s): #2, #5)
-  L1I stats:
-    Hits:                        2,756,429
-    Misses:                          1,190
-    Miss rate:                        0.04%
-  L1D stats:
-    Hits:                        1,747,822
-    Misses:                         13,511
-    Prefetch hits:                   2,354
-    Prefetch misses:                11,157
-    Miss rate:                        0.77%
-Core #1 (2 traced CPU(s): #4, #0)
-  L1I stats:
-    Hits:                          472,948
-    Misses:                            299
-    Miss rate:                        0.06%
-  L1D stats:
-    Hits:                          895,099
-    Misses:                          1,224
-    Prefetch hits:                     253
-    Prefetch misses:                   971
+Core #0 (traced CPU(s): #0)
+  L1I0 (size=32768, assoc=8, block=64, LRU) stats:
+    Hits:                        1,853,727
+    Misses:                          2,152
+    Compulsory misses:               2,045
+    Invalidations:                       0
+    Miss rate:                        0.12%
+  L1D0 (size=32768, assoc=8, block=64, LRU) stats:
+    Hits:                          605,114
+    Misses:                         11,973
+    Compulsory misses:               9,845
+    Invalidations:                       0
+    Prefetch hits:                   1,880
+    Prefetch misses:                10,093
+    Miss rate:                        1.94%
+Core #1 (traced CPU(s): #1)
+  L1I1 (size=32768, assoc=8, block=64, LRU) stats:
+    Hits:                          942,992
+    Misses:                            461
+    Compulsory misses:                 366
+    Invalidations:                       0
+    Miss rate:                        0.05%
+  L1D1 (size=32768, assoc=8, block=64, LRU) stats:
+    Hits:                          385,134
+    Misses:                            534
+    Compulsory misses:                 775
+    Invalidations:                       0
+    Prefetch hits:                     144
+    Prefetch misses:                   390
     Miss rate:                        0.14%
-Core #2 (2 traced CPU(s): #1, #7)
-  L1I stats:
-    Hits:                          448,581
-    Misses:                            649
+Core #2 (traced CPU(s): #2)
+  L1I2 (size=32768, assoc=8, block=64, LRU) stats:
+    Hits:                          944,622
+    Misses:                            453
+    Compulsory misses:                 365
+    Invalidations:                       0
+    Miss rate:                        0.05%
+  L1D2 (size=32768, assoc=8, block=64, LRU) stats:
+    Hits:                          385,808
+    Misses:                            537
+    Compulsory misses:                 791
+    Invalidations:                       0
+    Prefetch hits:                     140
+    Prefetch misses:                   397
     Miss rate:                        0.14%
-  L1D stats:
-    Hits:                          811,483
-    Misses:                          1,723
-    Prefetch hits:                     378
-    Prefetch misses:                 1,345
-    Miss rate:                        0.21%
-Core #3 (2 traced CPU(s): #6, #3)
-  L1I stats:
-    Hits:                          275,192
-    Misses:                            154
-    Miss rate:                        0.06%
-  L1D stats:
-    Hits:                          522,655
-    Misses:                            850
-    Prefetch hits:                     173
-    Prefetch misses:                   677
-    Miss rate:                        0.16%
-LL stats:
-    Hits:                           12,491
-    Misses:                          7,109
-    Prefetch hits:                   8,922
-    Prefetch misses:                 5,228
-    Local miss rate:                 36.27%
-    Child hits:                  7,933,367
-    Total miss rate:                  0.09%
+LL (size=8388608, assoc=16, block=64, LRU) stats:
+    Hits:                            8,091
+    Misses:                          8,019
+    Compulsory misses:              13,173
+    Invalidations:                       0
+    Prefetch hits:                   5,693
+    Prefetch misses:                 5,187
+    Local miss rate:                 49.78%
+    Child hits:                  5,119,561
+    Total miss rate:                  0.16%
 \endcode
 
 The memory access traces contain some optimizations that combine references
@@ -1452,9 +1460,15 @@ instruction information to go along with each load and store, while cache
 simulators can ignore these "no-fetch" entries and avoid incorrectly
 inflating instruction fetch statistics.
 
-Traces include scheduling markers providing the timestamp and hardware
-thread identifier on each thread transition, allowing a simulator to more
-closely match the actual hardware if so desired.
+Traces include scheduling markers providing the timestamp and hardware thread identifier
+on each thread transition, allowing a simulator to more closely match the actual
+hardware if so desired: but be aware that this "as-traced" schedule is not
+representative, as shown in \ref sec_drcachesim_as_traced.  We recommend instead using
+dynamic re-scheduling of the software threads: see \ref sec_drcachesim_sched_dynamic.
+While we suggest keeping traces stored as thread-sharded and using the dynamic scheduler
+in each run, there is support for running the scheduler once and creating a new set of
+stored traces in core-sharded format: essentially switching to hardware-thread-oriented
+traces.  This is done using the \ref sec_tool_record_filter tool in `-core_sharded` mode.
 
 Traces also include markers indicating disruptions in user mode control
 flow such as signal handler entry and exit.
@@ -1479,6 +1493,164 @@ Filtered traces (filtered via -L0_filter) include the dynamic
 (pre-filtered) per-thread instruction count in a
 #dynamorio::drmemtrace::TRACE_MARKER_TYPE_INSTRUCTION_COUNT marker at
 each thread buffer boundary and at thread exit.
+
+
+****************************************************************************
+\page sec_drcachesim_sched Trace Scheduler
+
+In addition to the analysis tool framework, which targets running
+multiple tools at once either in parallel across all traced threads or
+in a serial fashion, we provide a scheduler which will map inputs to a
+given set of outputs in a specified manner.  This allows a tool such
+as a core simulator, or just a tool wanting its own control over
+advancing the trace stream (unlike the analysis tool framework where
+the framework controls the iteration), to request the next trace
+record for each output on its own.  This scheduling is also available to any analysis tool
+when the input traces are sharded by core (see the `-core_sharded` and `-core_serial`
+and various `-sched_*` option documentation under \ref sec_drcachesim_ops as well as
+core-sharded notes when \ref sec_drcachesim_newtool).
+
+********************
+\section sec_drcachesim_as_traced As-Traced Schedule Limitations
+
+During tracing, marker records (see \ref sec_drcachesim_format_other) of type
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID record the "as traced" schedule,
+indicating which threads were on which cores at which times.  However, this schedule is
+not representative and should not be treated as indicating how the application behaves
+without tracing.  In addition to only containing coarse-grain information at the top and
+bottom of trace buffers and missing any context switches occurring in the between, the
+indicated switches do not always correlate with where the untraced application would
+switch.  This is due to tracing overhead, where heavyweight instrumentation is
+interspersed with application code and heavyweight i/o operations to write out the trace
+data cause delays.  This extra overhead causes additional quantum preempts and additional
+switches due to blocking system calls for i/o.  The resulting as-traced schedule can
+contain from 2x to 10x as many context switches as the untraced
+application.  Consequently, we do not recommend using the as-traced schedule to study the
+application itself, though our scheduler does support replaying the as-traced schedule.
+
+********************
+\section sec_drcachesim_sched_dynamic Dynamic Scheduling
+
+Instead of using the as-traced schedule, we recommend re-scheduling the traced software
+threads using our trace scheduler.  Our scheduler essentially serves as an operating
+system scheduler for this purpose, though using simpler schemes.  It models separate
+runqueues per core with support for binding inputs to certain cores, priorities, idle
+time from blocking system calls, migration thresholds, rebalancing runqueues, etc.  It
+exposes a number of knobs in the form of -sched_* parameters for the command-line \p
+drmemtrace launcher or programmatically through the #dynamorio::drmemtrace::scheduler_t
+API.
+
+Dynamic scheduling provides the following benefits:
+
+- Deflation of the as-traced context switch rate (see \ref sec_drcachesim_as_traced) to
+  provide a representative context switch rate.
+
+- Support for different numbers of cores than were present during tracing.
+
+- Multi-tenant support where separately traced applications are combined, with the
+  dynamic scheduler interleaving them.  This simulates a multi-tenant machine with a mix
+  of processes running.
+
+The downsides include:
+
+- Risk of incorrect ordering between application software threads.  Today, our scheduler
+  does use the in-trace timestamps (when requested via
+  #dynamorio::drmemtrace::scheduler_t::DEPENDENCY_TIMESTAMPS) to keep things in relative
+  order.  However, enforcing representative context switch rates is considered more
+  important that honoring precise trace-buffer-based timestamp inter-input dependencies:
+  thus, timestamp ordering will be followed at context switch points for picking the
+  next input, but timestamps will not preempt an input.
+
+********************
+\section sec_drcachesim_sched_time Simulated Time
+
+As the simulator, rather than the scheduler, tracks simulated time, yet the scheduler
+needs to make some decisions based on time (such as when to preempt, when to migrate
+across cores, etc.), the simulator should pass in the current time when it queries the
+scheduler for the next record.  The simulator tells the scheduler how many units of this
+simulated time comprise one microsecond so that the scheduler can scale its other
+parameters appropriately.
+
+********************
+\section sec_drcachesim_sched_idle Idle Time
+
+The dynamic scheduler inserts markers of type
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE when there is no work available on a
+core, simulating actual idle time.  This can happen even when there are inputs
+potentially available as the scheduler simulates i/o by blocking inputs from executing
+for a period of time when they make blocking system calls.  This time is based on the
+system call latency recorded in the trace, but since this can be indirectly inflated due
+to tracing overhead the scheduler provides parameters to scale this time, exposed as
+`-sched_block_scale` and `-sched_block_max_us` to the \p drmemtrace launcher.  These can
+be modified to try to achieve a desired level of idle time during simulation.
+
+********************
+\section sec_drcachesim_sched_replay Record and Replay
+
+The scheduler supports recording a schedule and replaying it later, allowing for
+repeated execution of the same schedule.  Timestamps in the recorded schedule help to
+align the cores during replay.  If one gets too far ahead, markers of type
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_WAIT are inserted to indicate an
+artificial wait in order for the replay to get back on track.
+
+********************
+\section sec_drcachesim_sched_roi Regions of Interest
+
+The scheduler supports running a subset of each input.  A list of start and stop
+endpoints delimiting the regions of interest can be supplied with each input.  The end
+result is as though the inputs had been edited to remove all content not inside the
+target regions.
+
+********************
+\section sec_drcachesim_sched_speculation Speculation Support
+
+The scheduler contains preliminary speculation support for wrong-path execution.
+Currently it only feeds nops, but future versions plan to fill in content based on prior
+trace paths.
+
+********************
+\section sec_drcachesim_sched_ex Scheduler Interface Example
+
+Here is a simple example of using the scheduler interface directly.
+
+\code
+void
+simulate_core(scheduler_t::stream_t *stream)
+{
+    memref_t record;
+    for (scheduler_t::stream_status_t status = stream->next_record(record);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(record)) {
+        if (status == scheduler_t::STATUS_WAIT || status == scheduler_t::STATUS_IDLE) {
+            std::this_thread::yield();
+            continue;
+        }
+        assert(status == scheduler_t::STATUS_OK);
+        // Process "record" here.
+    }
+}
+
+void
+run_scheduler(const std::string &trace_directory)
+{
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(trace_directory);
+    scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                               scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                               scheduler_t::SCHEDULER_DEFAULTS);
+    constexpr int NUM_CORES = 4;
+    if (scheduler.init(sched_inputs, NUM_CORES, std::move(sched_ops)) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    std::vector<std::thread> threads;
+    threads.reserve(NUM_CORES);
+    for (int i = 0; i < NUM_CORES; ++i) {
+        threads.emplace_back(std::thread(&simulate_core, scheduler.get_stream(i)));
+    }
+    for (std::thread &thread : threads)
+        thread.join();
+}
+\endcode
 
 ****************************************************************************
 \page sec_drcachesim_extend Extending the Simulator
@@ -1721,45 +1893,6 @@ which allows \p drmemtrace to create an analyis tool.  As an
 example, see <a
 href="https://github.com/DynamoRIO/dynamorio/blob/master/clients/drcachesim/tools/external/example">
 minimal external analysis tool</a>.
-
-\section sec_drcachesim_sched Scheduler
-
-In addition to the analysis tool framework, which targets running
-multiple tools at once either in parallel across all traced threads or
-in a serial fashion, we provide a scheduler which will map inputs to a
-given set of outputs in a specified manner.  This allows a tool such
-as a core simulator, or just a tool wanting its own control over
-advancing the trace stream (unlike the analysis tool framework where
-the framework controls the iteration), to request the next trace
-record for each output on its own.  This scheduling is also available to any analysis tool
-when the input traces are sharded by core (see the `-core_sharding` option documentation
-under \ref sec_drcachesim_ops as well as \ref sec_drcachesim_newtool).
-
-Here is a simple example of a single-output, serial stream.  This also
-serves as an example of how to replace the now-removed old analysis
-tool framework's "external iterator" interface:
-
-\code
-    scheduler_t scheduler;
-    std::vector<scheduler_t::input_workload_t> sched_inputs;
-    sched_inputs.emplace_back(trace_directory);
-    if (scheduler.init(sched_inputs, 1, scheduler_t::make_scheduler_serial_options()) !=
-        scheduler_t::STATUS_SUCCESS) {
-        FATAL_ERROR("failed to initialize scheduler: %s",
-                    scheduler.get_error_string().c_str());
-    }
-    auto *stream = scheduler.get_stream(0);
-    memref_t record;
-    for (scheduler_t::stream_status_t status = stream->next_record(record);
-         status != scheduler_t::STATUS_EOF; status = stream->next_record(record)) {
-        if (status != scheduler_t::STATUS_OK)
-            FATAL_ERROR("scheduler failed to advance: %d", status);
-        if (!my_tool->process_memref(record)) {
-            FATAL_ERROR("tool failed to process entire trace: %s",
-                        my_tool->get_error_string().c_str());
-        }
-    }
-\endcode
 
 ****************************************************************************
 \page sec_drcachesim_ops Simulator Parameters

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -181,7 +181,7 @@ Some of the more important markers are:
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_TIMESTAMP - The marker value provides a timestamp for this point of the trace (in units of microseconds since Jan 1, 1601 UTC). This value can be used to synchronize records from different threads as well as analyze latencies (however, tracing overhead inflates time unevenly, so time deltas should not be considered perfectly representative). It is used in the sequential analysis of a multi-threaded trace.
 
-- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID - The marker value contains the CPU identifier on which the subsequent records were collected. It helps to identify the "as traced" schedule, indicating which threads were on which cores at which times. However, this schedule is not representative and should not be treated as indicating how the application behaves without tracing.  See \ref sec_drcachesim_as_traced for further information.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID - The marker value contains the CPU identifier on which the subsequent records were collected.  It can be used to identify the "as traced" schedule, indicating which threads were on which cores at which times.  However, this schedule is not representative and should not be treated as indicating how the application behaves without tracing.  See \ref sec_drcachesim_as_traced for further information.
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ID, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETADDR, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_ARG, #dynamorio::drmemtrace::TRACE_MARKER_TYPE_FUNC_RETVAL - These markers are used to capture information about function calls.  Which functions to capture must be explicitly selected at tracing time.  Typical candiates are heap allocation and freeing functions.  See \ref sec_drcachesim_funcs.
 
@@ -1469,6 +1469,8 @@ While we suggest keeping traces stored as thread-sharded and using the dynamic s
 in each run, there is support for running the scheduler once and creating a new set of
 stored traces in core-sharded format: essentially switching to hardware-thread-oriented
 traces.  This is done using the \ref sec_tool_record_filter tool in `-core_sharded` mode.
+The #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID markers are not modified by the
+dynamic scheduler, and should be ignored in a newly created core-sharded trace.
 
 Traces also include markers indicating disruptions in user mode control
 flow such as signal handler entry and exit.
@@ -1526,7 +1528,8 @@ data cause delays.  This extra overhead causes additional quantum preempts and a
 switches due to blocking system calls for i/o.  The resulting as-traced schedule can
 contain from 2x to 10x as many context switches as the untraced
 application.  Consequently, we do not recommend using the as-traced schedule to study the
-application itself, though our scheduler does support replaying the as-traced schedule.
+application itself, though our scheduler does support replaying the as-traced schedule
+through the -cpu_schedule_file option.
 
 ********************
 \section sec_drcachesim_sched_dynamic Dynamic Scheduling
@@ -1560,6 +1563,9 @@ The downsides include:
   important that honoring precise trace-buffer-based timestamp inter-input dependencies:
   thus, timestamp ordering will be followed at context switch points for picking the
   next input, but timestamps will not preempt an input.
+
+The #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CPU_ID markers are not modified by the
+dynamic scheduler, and should be ignored in a dynamic rescheduling.
 
 ********************
 \section sec_drcachesim_sched_time Simulated Time


### PR DESCRIPTION
Promotes the scheduler section to a full page and adds information on the deficiencies of the as-traced schedule, details of dynamic scheduling, simulated time, idle time, record-replay, regions of interest, and speculation support.  Updates the example code to include multiple threads each processing one core.

Issue: #5843