### PR TITLE
i#6938 sched migrate: Fix clang-tidy complaints

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -36,8 +36,10 @@
 #include <stdint.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cinttypes>
+#include <cmath>
 #include <cstddef>
 #include <cstdio>
 #include <iomanip>
@@ -53,6 +55,7 @@
 #include <utility>
 #include <vector>
 
+#include "flexible_queue.h"
 #include "memref.h"
 #include "memtrace_stream.h"
 #include "mutex_dbg_owned.h"
@@ -2549,7 +2552,6 @@ scheduler_tmpl_t<RecordType, ReaderType>::add_to_unscheduled_queue(input_info_t 
     input->containing_output = INVALID_INPUT_ORDINAL;
 }
 
-// NOCHECK get all callers to hold input lock
 template <typename RecordType, typename ReaderType>
 void
 scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue_hold_locks(
@@ -2560,7 +2562,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::add_to_ready_queue_hold_locks(
            outputs_[output].ready_queue.lock->owned_by_cur_thread());
     if (input->unscheduled && input->blocked_time == 0) {
         // Ensure we get prev_output set for start-unscheduled so they won't
-        // all resume on output #0 but rather on the initial round-robin assigment.
+        // all resume on output #0 but rather on the initial round-robin assignment.
         input->containing_output = output;
         add_to_unscheduled_queue(input);
         return;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1549,7 +1549,7 @@ protected:
     add_to_unscheduled_queue(input_info_t *input);
 
     uint64_t
-    scale_blocked_time(uint64_t blocked_time) const;
+    scale_blocked_time(uint64_t initial_time) const;
 
     // The input's lock must be held by the caller.
     // Returns a multiplier for how long the input should be considered blocked.


### PR DESCRIPTION
Fixes clang-tidy complaints from PR #6985 about a misspelling, mismatched parameter names, and missing includes, and removes a stale comment.

Issue: #6938