### PR TITLE
i#6938 sched migrate: Fix input not unscheduled assert

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2641,6 +2641,7 @@ scheduler_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue_hold_locks(
             } else {
                 // This input is no longer blocked.
                 res->blocked_time = 0;
+                res->unscheduled = false;
                 // We've found a candidate.  One final check if this is a migration.
                 bool found_candidate = false;
                 if (from_output == for_output)


### PR DESCRIPTION
Adds a missing clear of an input being "unscheduled" when it times out but is not selected (due to the migration threshold).  This fixes an assert a few lines above this fix the next time this input is selected in pop_from_ready_queue_hold_locks().
Tested on a particular input which triggers the assert.

Issue: #6938