### PR TITLE
i#6938 sched migrate: Reduce rebalance period to better match kernel

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1026,7 +1026,7 @@ droption_t<uint64_t> op_sched_migration_threshold_us(
     "last ran on a core before it can be migrated to another core.");
 
 droption_t<uint64_t> op_sched_rebalance_period_us(
-    DROPTION_SCOPE_ALL, "sched_rebalance_period_us", 1500000,
+    DROPTION_SCOPE_ALL, "sched_rebalance_period_us", 50000,
     "Period in microseconds at which core run queues are load-balanced",
     "The period in simulated microseconds at which per-core run queues are re-balanced "
     "to redistribute load.");

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -798,7 +798,7 @@ public:
          * #time_units_per_us to produce a value that is compared to the "cur_time"
          * parameter to next_record().
          */
-        uint64_t rebalance_period_us = 150000;
+        uint64_t rebalance_period_us = 50000;
     };
 
     /**


### PR DESCRIPTION
It turns out the Linux kernel's maximum rebalance period is 100ms (the actual value varies dynamically; our simplified scheduler uses a constant, though).  We thus drop our default value from 150ms to 50ms which should better match real machines.  We also make the launcher's default match the scheduler's default as the launcher's was even higher.

Issue: #6938