### PR TITLE
Fix printf format specifier for `memref_pid_t`

### DIFF
--- a/clients/drcachesim/simulator/caching_device_stats.cpp
+++ b/clients/drcachesim/simulator/caching_device_stats.cpp
@@ -38,6 +38,7 @@
 #    include <zlib.h>
 #endif
 
+#include <inttypes.h>
 #include <iomanip>
 #include <iostream>
 #include <locale>
@@ -170,9 +171,9 @@ caching_device_stats_t::dump_miss(const memref_t &memref)
     // It works most of the time but consider using a directory with individual files
     // per process as a future safer alternative.
 #ifdef HAS_ZLIB
-    gzprintf(file_, "%lld,0x%zx,0x%zx\n", pid, pc, addr);
+    gzprintf(file_, "%" PRId64 ",0x%zx,0x%zx\n", pid, pc, addr);
 #else
-    fprintf(file_, "%lld,0x%zx,0x%zx\n", pid, pc, addr);
+    fprintf(file_, "%" PRId64 ",0x%zx,0x%zx\n", pid, pc, addr);
 #endif
 }
 


### PR DESCRIPTION
The format specifier "%lld" used for `memref_pid_t` in printf statement may not be correct for all platform. `memref_pid_t` is `int64_t` which may be `signed long int`. `memref_pid_t` should not be print with "%lld" format specifier. Should use PRId64 defined in <inttypes.h> instead.

Further details:
distro: KDE Neon 6.0
gcc: (Ubuntu 12.3.0-1ubuntu1~22.04) 12.3.0

In "dynamorio/clients/drcachesim/common/memref.h":52
```
typedef int64_t memref_pid_t;
```

In "/usr/include/x86_64-linux-gnu/bits/stdint-intn.h":27
```
typedef __int64_t int64_t;
```

In "/usr/include/x86_64-linux-gnu/bits/types.h":44
```
typedef signed long int __int64_t;
```