### PR TITLE
Add support for custom prefetchers in drcachesim

### DIFF
--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -61,6 +61,7 @@
 #define REPLACE_POLICY_FIFO "FIFO"
 #define PREFETCH_POLICY_NEXTLINE "nextline"
 #define PREFETCH_POLICY_NONE "none"
+#define PREFETCH_POLICY_CUSTOM "custom"
 #define CACHE_TYPE_INSTRUCTION "instruction"
 #define CACHE_TYPE_DATA "data"
 #define CACHE_TYPE_UNIFIED "unified"

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -579,7 +579,7 @@ cache_simulator_t::get_prefetcher(std::string prefetcher_name)
         return new prefetcher_t((int)knobs_.line_size);
     }
     if (prefetcher_name == PREFETCH_POLICY_CUSTOM) {
-        assert(custom_prefetcher_factor_ != nullptr);
+        assert(custom_prefetcher_factory_ != nullptr);
         return custom_prefetcher_factory_->create_prefetcher((int)knobs_.line_size);
     }
     return nullptr;

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -579,6 +579,7 @@ cache_simulator_t::get_prefetcher(std::string prefetcher_name)
         return new prefetcher_t((int)knobs_.line_size);
     }
     if (prefetcher_name == PREFETCH_POLICY_CUSTOM) {
+        assert(custom_prefetcher_factor_ != nullptr);
         return custom_prefetcher_factory_->create_prefetcher((int)knobs_.line_size);
     }
     return nullptr;

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -85,13 +85,15 @@ cache_simulator_create(const std::string &config_file)
     return sim;
 }
 
-cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
+cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs,
+                                     prefetcher_factory_t *custom_prefetcher_factory)
     : simulator_t(knobs.num_cores, knobs.skip_refs, knobs.warmup_refs,
                   knobs.warmup_fraction, knobs.sim_refs, knobs.cpu_scheduling,
                   knobs.use_physical, knobs.verbose)
     , knobs_(knobs)
     , l1_icaches_(NULL)
     , l1_dcaches_(NULL)
+    , custom_prefetcher_factory_(custom_prefetcher_factory)
     , is_warmed_up_(false)
 {
     // XXX i#1703: get defaults from hardware being run on.
@@ -110,10 +112,19 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
 
     if (knobs_.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
         knobs_.data_prefetcher != PREFETCH_POLICY_NONE) {
-        // Unknown value.
-        error_string_ = " unknown data_prefetcher: '" + knobs_.data_prefetcher + "'";
-        success_ = false;
-        return;
+        if (knobs_.data_prefetcher == PREFETCH_POLICY_CUSTOM) {
+            if (custom_prefetcher_factory_ == nullptr) {
+                error_string_ =
+                    "custom prefetcher was requested but no factory was provided.";
+                success_ = false;
+                return;
+            }
+        } else {
+            // Unknown value.
+            error_string_ = " unknown data_prefetcher: '" + knobs_.data_prefetcher + "'";
+            success_ = false;
+            return;
+        }
     }
 
     bool warmup_enabled_ = ((knobs_.warmup_refs > 0) || (knobs_.warmup_fraction > 0.0));
@@ -165,9 +176,7 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
                 knobs_.L1D_assoc, (int)knobs_.line_size, (int)knobs_.L1D_size, llc,
                 new cache_stats_t((int)knobs_.line_size, "", warmup_enabled_,
                                   knobs_.model_coherence),
-                knobs_.data_prefetcher == PREFETCH_POLICY_NEXTLINE
-                    ? new prefetcher_t((int)knobs_.line_size)
-                    : nullptr,
+                get_prefetcher(knobs_.data_prefetcher),
                 cache_inclusion_policy_t::NON_INC_NON_EXC, knobs_.model_coherence,
                 (2 * i) + 1, snoop_filter_)) {
             error_string_ = "Usage error: failed to initialize L1 caches.  Ensure sizes "
@@ -189,12 +198,14 @@ cache_simulator_t::cache_simulator_t(const cache_simulator_knobs_t &knobs)
     }
 }
 
-cache_simulator_t::cache_simulator_t(std::istream *config_file)
+cache_simulator_t::cache_simulator_t(std::istream *config_file,
+                                     prefetcher_factory_t *custom_prefetcher_factory)
     : simulator_t()
     , l1_icaches_(NULL)
     , l1_dcaches_(NULL)
     , snooped_caches_(NULL)
     , snoop_filter_(NULL)
+    , custom_prefetcher_factory_(custom_prefetcher_factory)
     , is_warmed_up_(false)
 {
     std::map<std::string, cache_params_t> cache_params;
@@ -211,9 +222,19 @@ cache_simulator_t::cache_simulator_t(std::istream *config_file)
 
     if (knobs_.data_prefetcher != PREFETCH_POLICY_NEXTLINE &&
         knobs_.data_prefetcher != PREFETCH_POLICY_NONE) {
-        // Unknown prefetcher type.
-        success_ = false;
-        return;
+        if (knobs_.data_prefetcher == PREFETCH_POLICY_CUSTOM) {
+            if (custom_prefetcher_factory_ == nullptr) {
+                error_string_ = "custom prefetcher was requested but no factory was "
+                                "provided.";
+                success_ = false;
+                return;
+            }
+        } else {
+            // Unknown value.
+            error_string_ = " unknown data_prefetcher: '" + knobs_.data_prefetcher + "'";
+            success_ = false;
+            return;
+        }
     }
 
     bool warmup_enabled_ = ((knobs_.warmup_refs > 0) || (knobs_.warmup_fraction > 0.0));
@@ -337,10 +358,8 @@ cache_simulator_t::cache_simulator_t(std::istream *config_file)
                          (int)cache_config.size, parent_,
                          new cache_stats_t((int)knobs_.line_size, cache_config.miss_file,
                                            warmup_enabled_, is_coherent_),
-                         cache_config.prefetcher == PREFETCH_POLICY_NEXTLINE
-                             ? new prefetcher_t((int)knobs_.line_size)
-                             : nullptr,
-                         inclusion_policy, is_coherent_, is_snooped ? snoop_id : -1,
+                         get_prefetcher(cache_config.prefetcher), inclusion_policy,
+                         is_coherent_, is_snooped ? snoop_id : -1,
                          is_snooped ? snoop_filter_ : nullptr, children)) {
             error_string_ = "Usage error: failed to initialize the cache " + cache_name;
             success_ = false;
@@ -551,6 +570,18 @@ cache_simulator_t::process_memref(const memref_t &memref)
     }
 
     return true;
+}
+
+prefetcher_t *
+cache_simulator_t::get_prefetcher(std::string prefetcher_name)
+{
+    if (prefetcher_name == PREFETCH_POLICY_NEXTLINE) {
+        return new prefetcher_t((int)knobs_.line_size);
+    }
+    if (prefetcher_name == PREFETCH_POLICY_CUSTOM) {
+        return custom_prefetcher_factory_->create_prefetcher((int)knobs_.line_size);
+    }
+    return nullptr;
 }
 
 // Return true if the number of warmup references have been executed or if

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -71,12 +71,12 @@ public:
     // using a set of knobs. It assumes a 2-level cache hierarchy with
     // private L1 data and instruction caches and a shared LLC.
     cache_simulator_t(const cache_simulator_knobs_t &knobs,
-                      prefetcher_factory_t *custom_prefetcher_factory=nullptr);
+                      prefetcher_factory_t *custom_prefetcher_factory = nullptr);
 
     // This constructor is used when the arbitrary cache hierarchy is
     // defined in a configuration file.
     cache_simulator_t(std::istream *config_file,
-                      prefetcher_factory_t *custom_prefetcher_factory=nullptr);
+                      prefetcher_factory_t *custom_prefetcher_factory = nullptr);
 
     virtual ~cache_simulator_t();
     bool

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -70,11 +70,20 @@ public:
     // This constructor is used when the cache hierarchy is configured
     // using a set of knobs. It assumes a 2-level cache hierarchy with
     // private L1 data and instruction caches and a shared LLC.
-    cache_simulator_t(const cache_simulator_knobs_t &knobs);
+    cache_simulator_t(const cache_simulator_knobs_t &knobs)
+        : cache_simulator_t(knobs, nullptr) {};
 
     // This constructor is used when the arbitrary cache hierarchy is
     // defined in a configuration file.
-    cache_simulator_t(std::istream *config_file);
+    cache_simulator_t(std::istream *config_file)
+        : cache_simulator_t(config_file, nullptr) {};
+
+    // Additional constructors that allow the user to specify a custom
+    // prefetcher.
+    cache_simulator_t(const cache_simulator_knobs_t &knobs,
+                      prefetcher_factory_t *custom_prefetcher_factory);
+    cache_simulator_t(std::istream *config_file,
+                      prefetcher_factory_t *custom_prefetcher_factory);
 
     virtual ~cache_simulator_t();
     bool
@@ -111,6 +120,8 @@ protected:
     // Create a cache_t object with a specific replacement policy.
     virtual cache_t *
     create_cache(const std::string &name, const std::string &policy);
+    prefetcher_t *
+    get_prefetcher(std::string prefetcher_name);
 
     cache_simulator_knobs_t knobs_;
 
@@ -131,6 +142,9 @@ protected:
 
     // Snoop filter tracks ownership of cache lines across private caches.
     snoop_filter_t *snoop_filter_ = nullptr;
+
+    // Used to get prefetcher instances if the dataprefetcher knob is "custom".
+    prefetcher_factory_t *custom_prefetcher_factory_ = nullptr;
 
 private:
     bool is_warmed_up_;

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -70,20 +70,13 @@ public:
     // This constructor is used when the cache hierarchy is configured
     // using a set of knobs. It assumes a 2-level cache hierarchy with
     // private L1 data and instruction caches and a shared LLC.
-    cache_simulator_t(const cache_simulator_knobs_t &knobs)
-        : cache_simulator_t(knobs, nullptr) {};
+    cache_simulator_t(const cache_simulator_knobs_t &knobs,
+                      prefetcher_factory_t *custom_prefetcher_factory=nullptr);
 
     // This constructor is used when the arbitrary cache hierarchy is
     // defined in a configuration file.
-    cache_simulator_t(std::istream *config_file)
-        : cache_simulator_t(config_file, nullptr) {};
-
-    // Additional constructors that allow the user to specify a custom
-    // prefetcher.
-    cache_simulator_t(const cache_simulator_knobs_t &knobs,
-                      prefetcher_factory_t *custom_prefetcher_factory);
     cache_simulator_t(std::istream *config_file,
-                      prefetcher_factory_t *custom_prefetcher_factory);
+                      prefetcher_factory_t *custom_prefetcher_factory=nullptr);
 
     virtual ~cache_simulator_t();
     bool

--- a/clients/drcachesim/simulator/prefetcher.cpp
+++ b/clients/drcachesim/simulator/prefetcher.cpp
@@ -38,7 +38,6 @@
 #include "memref.h"
 #include "caching_device.h"
 #include "trace_entry.h"
-
 namespace dynamorio {
 namespace drmemtrace {
 
@@ -57,6 +56,5 @@ prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in)
     memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
     cache->request(memref);
 }
-
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/simulator/prefetcher.h
+++ b/clients/drcachesim/simulator/prefetcher.h
@@ -53,8 +53,20 @@ public:
     virtual void
     prefetch(caching_device_t *cache, const memref_t &memref);
 
-private:
+protected:
     int block_size_;
+};
+
+class prefetcher_factory_t {
+public:
+    virtual prefetcher_t *
+    create_prefetcher(int block_size)
+    {
+        return nullptr;
+    }
+    virtual ~prefetcher_factory_t()
+    {
+    }
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/simulator/prefetcher.h
+++ b/clients/drcachesim/simulator/prefetcher.h
@@ -60,13 +60,8 @@ protected:
 class prefetcher_factory_t {
 public:
     virtual prefetcher_t *
-    create_prefetcher(int block_size)
-    {
-        return nullptr;
-    }
-    virtual ~prefetcher_factory_t()
-    {
-    }
+    create_prefetcher(int block_size) = 0;
+    virtual ~prefetcher_factory_t() = default;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -279,7 +279,7 @@ unit_test_nextline_prefetcher()
     const int LINE_SIZE = 64;
     const int TEST_ACCESSES = 6;
     const int EXPECTED_MISSES_NO_PREFETCHER = TEST_ACCESSES;
-    const int EXPECTED_MISSES_NEXTLINE_PREFETCHER = TEST_ACCESSES/2;
+    const int EXPECTED_MISSES_NEXTLINE_PREFETCHER = TEST_ACCESSES / 2;
 
     // Test all misses without a prefetcher.
     cache_simulator_knobs_t knobs = make_test_knobs();
@@ -293,8 +293,8 @@ unit_test_nextline_prefetcher()
         }
     }
 
-    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0)
-           == EXPECTED_MISSES_NO_PREFETCHER);
+    assert(cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0) ==
+           EXPECTED_MISSES_NO_PREFETCHER);
 
     // Test that every other miss is prevented with a nextline prefetcher.
     knobs.data_prefetcher = "nextline";
@@ -307,8 +307,8 @@ unit_test_nextline_prefetcher()
         }
     }
 
-    assert(nextline_cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0)
-           == EXPECTED_MISSES_NEXTLINE_PREFETCHER);
+    assert(nextline_cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0) ==
+           EXPECTED_MISSES_NEXTLINE_PREFETCHER);
 }
 
 class next2line_prefetcher_factory_t : public prefetcher_factory_t {
@@ -345,7 +345,7 @@ unit_test_custom_prefetcher()
 {
     const int LINE_SIZE = 64;
     const int TEST_ACCESSES = 6;
-    const int EXPECTED_MISSES_NEXT2LINE_PREFETCHER = TEST_ACCESSES/3;
+    const int EXPECTED_MISSES_NEXT2LINE_PREFETCHER = TEST_ACCESSES / 3;
     cache_simulator_knobs_t knobs = make_test_knobs();
     knobs.data_prefetcher = "custom";
     next2line_prefetcher_factory_t next2line_prefetcher_factory;
@@ -359,8 +359,8 @@ unit_test_custom_prefetcher()
         }
     }
 
-    assert(nextline_cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0)
-           == EXPECTED_MISSES_NEXT2LINE_PREFETCHER);
+    assert(nextline_cache_sim.get_cache_metric(metric_name_t::MISSES, 1, 0) ==
+           EXPECTED_MISSES_NEXT2LINE_PREFETCHER);
 }
 void
 unit_test_child_hits()


### PR DESCRIPTION
Add constructors to the cache_simulator_t that accept a custom prefetcher factory argument.
No change to default behavior.
Added unit tests for a custom prefetcher and the existing nextline prefetcher.