### PR TITLE
i#6938 sched migrate: Add input lock to queue pop result

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2829,14 +2829,15 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
                 if (status != sched_type_t::STATUS_OK)
                     return status;
             }
-            // Now that we've updated prev_info, add it to the ready queue (once on the
-            // queues others can see it and pop it off, though they can't access/modify
-            // its fields (for identifying if it can be migrated, e.g.) until we release
-            // the input lock, so it should be safe to add first, but this order is more
-            // straightforward).
-            if (options_.mapping == MAP_TO_ANY_OUTPUT && !inputs_[prev_input].at_eof) {
-                add_to_ready_queue(output, &inputs_[prev_input]);
-            }
+        }
+        // Now that we've updated prev_info, add it to the ready queue (once on the
+        // queues others can see it and pop it off, though they can't access/modify its
+        // fields (for identifying if it can be migrated, e.g.) until we release the
+        // input lock, so it should be safe to add first, but this order is more
+        // straightforward).
+        if (options_.mapping == MAP_TO_ANY_OUTPUT && prev_input != input &&
+            !inputs_[prev_input].at_eof) {
+            add_to_ready_queue(output, &inputs_[prev_input]);
         }
     } else if (options_.schedule_record_ostream != nullptr &&
                outputs_[output].record.back().type == schedule_record_t::IDLE) {

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -2829,10 +2829,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::set_cur_input(output_ordinal_t output,
                 if (status != sched_type_t::STATUS_OK)
                     return status;
             }
-        }
-        if (options_.mapping == MAP_TO_ANY_OUTPUT && prev_input != input &&
-            !inputs_[prev_input].at_eof) {
-            add_to_ready_queue(output, &inputs_[prev_input]);
+            // Now that we've updated prev_info, add it to the ready queue (once on the
+            // queues others can see it and pop it off, though they can't access/modify
+            // its fields (for identifying if it can be migrated, e.g.) until we release
+            // the input lock, so it should be safe to add first, but this order is more
+            // straightforward).
+            if (options_.mapping == MAP_TO_ANY_OUTPUT && !inputs_[prev_input].at_eof) {
+                add_to_ready_queue(output, &inputs_[prev_input]);
+            }
         }
     } else if (options_.schedule_record_ostream != nullptr &&
                outputs_[output].record.back().type == schedule_record_t::IDLE) {


### PR DESCRIPTION
Adds a missing input lock to the result of popping from the queue.

Changes set_cur_input to set the prior input's last_run_time, etc. *before* adding to the ready queue.

Tested by running ThreadSanitizer on the same internal test where it reported a race in reading input_info_t.last_run_time by pop_from_ready_queue_hold_locks while not holding a lock (during a rebalance), versus set_cur_input writing to that field.

Issue: #6938