### PR TITLE
i#6992 doxygen 1.12: heading and reference workaround

### DIFF
--- a/api/docs/API.doxy
+++ b/api/docs/API.doxy
@@ -170,7 +170,7 @@ LATEX_HIDE_INDICES     = NO
 #---------------------------------------------------------------------------
 # configuration options related to the RTF output
 #---------------------------------------------------------------------------
-GENERATE_RTF           = YES
+GENERATE_RTF           = NO
 RTF_OUTPUT             = rtf
 COMPACT_RTF            = NO
 RTF_HYPERLINKS         = YES

--- a/api/docs/CMakeLists.txt
+++ b/api/docs/CMakeLists.txt
@@ -153,7 +153,7 @@ macro (generate_html name dest_dir embeddable)
     VERBATIM # recommended: p260
     )
   set_directory_properties(PROPERTIES
-    ADDITIONAL_MAKE_CLEAN_FILES "html;latex;rtf")
+    ADDITIONAL_MAKE_CLEAN_FILES "html;latex")
 
   add_custom_target(${name} ALL
     DEPENDS ${doxyfile}

--- a/api/docs/intro.dox
+++ b/api/docs/intro.dox
@@ -111,7 +111,6 @@ stream and acts as a runtime control point, allowing custom tools to be
 embedded inside it:
 
   \image html interpose.png
-  \image rtf interpose.png
   \image latex interpose.eps "Flow chart" width=10cm
 
 The application itself, along with the underlying operating system and
@@ -132,7 +131,6 @@ cache or when the operating system directly transfers control to the
 application (<em>kernel-mediated control transfers</em>):
 
   \image html flow-highlevel.png
-  \image rtf flow-highlevel.png
   \image latex flow-highlevel.eps "Flow chart" width=10cm
 
 DynamoRIO copies the application code one <em>dynamic basic block</em> at a
@@ -149,7 +147,6 @@ The following figure shows the flow of control between the components of
 DynamoRIO and its code caches:
 
   \image html flow.png
-  \image rtf flow.png
   \image latex flow.eps "Flow chart" width=15cm
 
 The context switch is between DynamoRIO's operational state and the machine
@@ -205,7 +202,6 @@ library that is coupled with DynamoRIO in order to jointly operate on an
 input program binary:
 
   \image html client.png
-  \image rtf client.png
   \image latex client.eps "DynamoRIO client" width=10cm
 
 To interact with the client, DynamoRIO provides specific events that a

--- a/api/docs/transp.dox
+++ b/api/docs/transp.dox
@@ -86,7 +86,6 @@ Windows, the system call interface (\e c in the figure) must be used,
 rather than the API layer.
 
   \image html windows.png
-  \image rtf windows.png
   \image latex windows.eps "Native API" width=10cm
 
 DynamoRIO provides access to resources to clients via a cross-platform

--- a/api/docs/tutorial_secdev16.dox
+++ b/api/docs/tutorial_secdev16.dox
@@ -119,13 +119,13 @@ mailing list.
 
 # References
 
--# <a name="ref1"></a>Derek Bruening and Qin Zhao.  ["Practical Memory Checking with Dr. Memory"](http://www.burningcutlery.com/derek/docs/drmem-CGO11.pdf). International Symposium on Code Generation and Optimization (CGO-11), April 2011.
+-# \anchor ref1 Derek Bruening and Qin Zhao.  ["Practical Memory Checking with Dr. Memory"](http://www.burningcutlery.com/derek/docs/drmem-CGO11.pdf). International Symposium on Code Generation and Optimization (CGO-11), April 2011.
 
--# <a name="ref2"></a>Derek Bruening, Timothy Garnett, and Saman Amarasinghe.  ["An Infrastructure for Adaptive Dynamic Optimization"](http://www.burningcutlery.com/derek/docs/adaptive-CGO03.pdf). International Symposium on Code Generation and Optimization (CGO-03), March 2003. 10 years later named the Most Influential Paper from CGO 2003.
+-# \anchor ref2 Derek Bruening, Timothy Garnett, and Saman Amarasinghe.  ["An Infrastructure for Adaptive Dynamic Optimization"](http://www.burningcutlery.com/derek/docs/adaptive-CGO03.pdf). International Symposium on Code Generation and Optimization (CGO-03), March 2003. 10 years later named the Most Influential Paper from CGO 2003.
 
--# <a name="ref3"></a>Vladimir Kiriansky, Derek Bruening, and Saman Amarasinghe. ["Secure Execution Via Program Shepherding"](http://www.burningcutlery.com/derek/docs/security-usenix.pdf). 11th USENIX Security Symposium, August 2002.
+-# \anchor ref3 Vladimir Kiriansky, Derek Bruening, and Saman Amarasinghe. ["Secure Execution Via Program Shepherding"](http://www.burningcutlery.com/derek/docs/security-usenix.pdf). 11th USENIX Security Symposium, August 2002.
 
--# <a name="ref4"></a>[http://drmemory.org](http://drmemory.org) and [http://dynamorio.org](http://dynamorio.org)
+-# \anchor ref4 [http://drmemory.org](http://drmemory.org) and [http://dynamorio.org](http://dynamorio.org)
 
 
  ****************************************************************************


### PR DESCRIPTION
Generating RTF documentation is causing `error: Style 'Heading7' redefines \s0.`
errors with doxygen 1.12. We disable RTF in api/docs/API.doxy.

We fix `warning: unable to resolve reference to 'ref1' for \ref command` issues
using `\anchor ref1` instead of `<a name="ref1"></a>` when citing papers in
"SecDev 2016 Tutorial".

Fixes #6992