### PR TITLE
i#5843 scheduler: Make scheduler_t and CLI thresholds match

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -642,14 +642,14 @@ public:
          * a #TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL marker) will be treated as
          * blocking and trigger a context switch.
          */
-        uint64_t syscall_switch_threshold = 500;
+        uint64_t syscall_switch_threshold = 30000000;
         /**
          * Determines the minimum latency in the unit of the trace's timestamps
          * (microseconds) for which a maybe-blocking system call (one with
          * a #TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL marker) will be treated as
          * blocking and trigger a context switch.
          */
-        uint64_t blocking_switch_threshold = 100;
+        uint64_t blocking_switch_threshold = 500;
         /**
          * Deprecated: use #block_time_multiplier instead.  It is an error to set
          * this to a non-zero value when #struct_size includes #block_time_multiplier.


### PR DESCRIPTION
Sets the scheduler_t system call switch thresholds to match the command-line interface defaults, which were raised a long time ago to reflect better understanding of real behavior.

Issue: #5843