### PR TITLE
i#2297: AARCH64: Implement mbr & cbr instrumentation

### DIFF
--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -265,10 +265,12 @@ if (X86) # FIXME i#1551, i#1569, i#3544: port to ARM/AArch64/RISCV64
   add_sample_client(modxfer     "modxfer.c;utils.c"     "drmgr;drreg;drx")
   add_sample_client(modxfer_app2lib "modxfer_app2lib.c" "drmgr")
   add_sample_client(instrcalls  "instrcalls.c;utils.c"  "drmgr;drsyms;drx")
-  # dr_insert_cbr_instrument_ex is NYI
-  add_sample_client(cbrtrace    "cbrtrace.c;utils.c"    "drmgr;drx")
   add_sample_client(hot_bbcount "hot_bbcount.c"         "drmgr;drreg;drbbdup;drx")
 endif (X86)
+if (X86 OR AARCH64)
+  # dr_insert_cbr_instrument_ex is NYI
+  add_sample_client(cbrtrace    "cbrtrace.c;utils.c"    "drmgr;drx")
+endif (X86 OR AARCH64)
 add_sample_client(wrap        "wrap.c"          "drmgr;drwrap")
 add_sample_client(signal      "signal.c"        "drmgr")
 add_sample_client(syscall     "syscall.c"       "drmgr")

--- a/api/samples/CMakeLists.txt
+++ b/api/samples/CMakeLists.txt
@@ -264,10 +264,11 @@ if (X86) # FIXME i#1551, i#1569, i#3544: port to ARM/AArch64/RISCV64
   # dr_insert_mbr_instrumentation is NYI
   add_sample_client(modxfer     "modxfer.c;utils.c"     "drmgr;drreg;drx")
   add_sample_client(modxfer_app2lib "modxfer_app2lib.c" "drmgr")
-  add_sample_client(instrcalls  "instrcalls.c;utils.c"  "drmgr;drsyms;drx")
   add_sample_client(hot_bbcount "hot_bbcount.c"         "drmgr;drreg;drbbdup;drx")
 endif (X86)
 if (X86 OR AARCH64)
+  # dr_insert_mbr_instrumentation is NYI
+  add_sample_client(instrcalls  "instrcalls.c;utils.c"  "drmgr;drsyms;drx")
   # dr_insert_cbr_instrument_ex is NYI
   add_sample_client(cbrtrace    "cbrtrace.c;utils.c"    "drmgr;drx")
 endif (X86 OR AARCH64)

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -658,13 +658,19 @@
     instr_create_0dst_3src((dc), OP_tbnz, (pc), (reg), (imm))
 #define INSTR_CREATE_cmp(dc, rn, rm_or_imm) \
     INSTR_CREATE_subs(dc, OPND_CREATE_ZR(rn), rn, rm_or_imm)
-#define INSTR_CREATE_eor(dc, d, s)                                      \
-    INSTR_CREATE_eor_shift(dc, d, d, s, OPND_CREATE_INT8(DR_SHIFT_LSL), \
-                           OPND_CREATE_INT8(0))
+#define INSTR_CREATE_eor(dc, d, s_or_imm)                                            \
+    opnd_is_immed(s_or_imm)                                                          \
+        ? instr_create_1dst_2src(dc, OP_eor, d, d, s_or_imm)                         \
+        : INSTR_CREATE_eor_shift(dc, d, d, s_or_imm, OPND_CREATE_INT8(DR_SHIFT_LSL), \
+                                 OPND_CREATE_INT8(0))
 #define INSTR_CREATE_eor_shift(dc, rd, rn, rm, sht, sha)                             \
     instr_create_1dst_4src(dc, OP_eor, rd, rn,                                       \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags(sht, DR_OPND_IS_SHIFT), sha)
+#define INSTR_CREATE_csinc(dc, rd, rn, rm, cond) \
+    instr_create_1dst_3src(dc, OP_csinc, rd, rn, rm, cond)
+#define INSTR_CREATE_ubfm(dc, rd, rn, lsb, width) \
+    instr_create_1dst_3src(dc, OP_ubfm, rd, rn, lsb, width)
 
 #define INSTR_CREATE_ldp(dc, rt1, rt2, mem) \
     instr_create_2dst_1src(dc, OP_ldp, rt1, rt2, mem)

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -463,12 +463,12 @@
  * they just need to know whether they need to preserve the app's flags, so maybe
  * we can just document that this may not write them.
  */
-#define XINST_CREATE_slr_s(dc, d, rm_or_imm)                                          \
-    (opnd_is_reg(rm_or_imm)                                                           \
-         ? instr_create_1dst_2src(dc, OP_lsrv, d, d, rm_or_imm)                       \
-         : instr_create_1dst_3src(dc, OP_ubfm, d, d, rm_or_imm,                       \
-                                  reg_is_32bit(opnd_get_reg(d)) ? OPND_CREATE_INT(31) \
-                                                                : OPND_CREATE_INT(63)))
+#define XINST_CREATE_slr_s(dc, d, rm_or_imm)                                     \
+    (opnd_is_reg(rm_or_imm)                                                      \
+         ? instr_create_1dst_2src(dc, OP_lsrv, d, d, rm_or_imm)                  \
+         : INSTR_CREATE_ubfm(dc, d, d, rm_or_imm,                                \
+                             reg_is_32bit(opnd_get_reg(d)) ? OPND_CREATE_INT(31) \
+                                                           : OPND_CREATE_INT(63)))
 
 /**
  * This platform-independent macro creates an instr_t for a nop instruction.
@@ -658,6 +658,15 @@
     instr_create_0dst_3src((dc), OP_tbnz, (pc), (reg), (imm))
 #define INSTR_CREATE_cmp(dc, rn, rm_or_imm) \
     INSTR_CREATE_subs(dc, OPND_CREATE_ZR(rn), rn, rm_or_imm)
+
+/**
+ * Creates an EOR instruction with one output and two inputs. For simplicity, the first
+ * input reuses the output register.
+ *
+ * \param dc        The void * dcontext used to allocate memory for the instr_t.
+ * \param d         The output register and the first input register.
+ * \param s_or_imm  The second input register or immediate.
+ */
 #define INSTR_CREATE_eor(dc, d, s_or_imm)                                            \
     opnd_is_immed(s_or_imm)                                                          \
         ? instr_create_1dst_2src(dc, OP_eor, d, d, s_or_imm)                         \
@@ -667,10 +676,30 @@
     instr_create_1dst_4src(dc, OP_eor, rd, rn,                                       \
                            opnd_create_reg_ex(opnd_get_reg(rm), 0, DR_OPND_SHIFTED), \
                            opnd_add_flags(sht, DR_OPND_IS_SHIFT), sha)
+
+/**
+ * Creates a CSINC instruction with one output and three inputs.
+ *
+ * \param dc   The void * dcontext used to allocate memory for the instr_t.
+ * \param rd   The output register.
+ * \param rn   The first input register.
+ * \param rm   The second input register.
+ * \param cond The third input condition code.
+ */
 #define INSTR_CREATE_csinc(dc, rd, rn, rm, cond) \
     instr_create_1dst_3src(dc, OP_csinc, rd, rn, rm, cond)
-#define INSTR_CREATE_ubfm(dc, rd, rn, lsb, width) \
-    instr_create_1dst_3src(dc, OP_ubfm, rd, rn, lsb, width)
+
+/**
+ * Creates an UBFM instruction with one output and three inputs.
+ *
+ * \param dc   The void * dcontext used to allocate memory for the instr_t.
+ * \param rd   The output register.
+ * \param rn   The first input register.
+ * \param immr The second input immediate.
+ * \param imms The third input immediate.
+ */
+#define INSTR_CREATE_ubfm(dc, rd, rn, immr, imms) \
+    instr_create_1dst_3src(dc, OP_ubfm, rd, rn, immr, imms)
 
 #define INSTR_CREATE_ldp(dc, rt1, rt2, mem) \
     instr_create_2dst_1src(dc, OP_ldp, rt1, rt2, mem)

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -690,7 +690,7 @@
     instr_create_1dst_3src(dc, OP_csinc, rd, rn, rm, cond)
 
 /**
- * Creates an UBFM instruction with one output and three inputs.
+ * Creates a UBFM instruction with one output and three inputs.
  *
  * \param dc   The void * dcontext used to allocate memory for the instr_t.
  * \param rd   The output register.

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6129,6 +6129,32 @@ dr_insert_mbr_instrumentation(void *drcontext, instrlist_t *ilist, instr_t *inst
 #elif defined(RISCV64)
     /* FIXME i#3544: Not implemented */
     ASSERT_NOT_IMPLEMENTED(false);
+#elif defined(AARCH64)
+    ptr_uint_t address;
+    reg_id_t target = DR_REG_NULL;
+    CLIENT_ASSERT(drcontext != NULL,
+                  "dr_insert_mbr_instrumentation: drcontext cannot be NULL");
+    address = (ptr_uint_t)instr_get_translation(instr);
+    CLIENT_ASSERT(address != 0,
+                  "dr_insert_mbr_instrumentation: can't determine app address");
+    CLIENT_ASSERT(instr_is_mbr(instr),
+                  "dr_insert_mbr_instrumentation must be applied to a mbr");
+
+    /* For all known mbr instructions on aarch64, the first source register saves the
+     * target. */
+    target = opnd_get_reg(instr_get_src(instr, 0));
+
+    dr_insert_clean_call_ex(
+        drcontext, ilist, instr, callee,
+        /* Many users will ask for mcontexts; some will set; it doesn't seem worth
+         * asking the user to pass in a flag: if they're using this they are not
+         * super concerned about overhead.
+         */
+        DR_CLEANCALL_READS_APP_CONTEXT | DR_CLEANCALL_WRITES_APP_CONTEXT, 2,
+        /* Address of mbr is 1st param. */
+        OPND_CREATE_INTPTR(address),
+        /* Indirect target is 2nd param. */
+        opnd_create_reg(target));
 #endif /* X86/ARM/RISCV64 */
 }
 

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -43,6 +43,7 @@
 #include "../globals.h" /* just to disable warning C4206 about an empty file */
 
 #include "instrument.h"
+#include "globals_api.h"
 #include "instr.h"
 #include "instr_create_shared.h"
 #include "instrlist.h"
@@ -6131,7 +6132,7 @@ dr_insert_mbr_instrumentation(void *drcontext, instrlist_t *ilist, instr_t *inst
     ASSERT_NOT_IMPLEMENTED(false);
 #elif defined(AARCH64)
     ptr_uint_t address;
-    reg_id_t target = DR_REG_NULL;
+    opnd_t target;
     CLIENT_ASSERT(drcontext != NULL,
                   "dr_insert_mbr_instrumentation: drcontext cannot be NULL");
     address = (ptr_uint_t)instr_get_translation(instr);
@@ -6140,9 +6141,8 @@ dr_insert_mbr_instrumentation(void *drcontext, instrlist_t *ilist, instr_t *inst
     CLIENT_ASSERT(instr_is_mbr(instr),
                   "dr_insert_mbr_instrumentation must be applied to a mbr");
 
-    /* For all known mbr instructions on aarch64, the first source register saves the
-     * target. */
-    target = opnd_get_reg(instr_get_src(instr, 0));
+    /* Retrieve target address. */
+    target = instr_get_target(instr);
 
     dr_insert_clean_call_ex(
         drcontext, ilist, instr, callee,
@@ -6154,7 +6154,7 @@ dr_insert_mbr_instrumentation(void *drcontext, instrlist_t *ilist, instr_t *inst
         /* Address of mbr is 1st param. */
         OPND_CREATE_INTPTR(address),
         /* Indirect target is 2nd param. */
-        opnd_create_reg(target));
+        target);
 #endif /* X86/ARM/RISCV64 */
 }
 

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6373,7 +6373,6 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
     reg_id_t dir = DR_REG_NULL;
     reg_id_t flags = DR_REG_NULL;
     int opc;
-    ;
     CLIENT_ASSERT(drcontext != NULL,
                   "dr_insert_cbr_instrumentation: drcontext cannot be NULL");
     address = (ptr_uint_t)instr_get_translation(instr);
@@ -6383,26 +6382,26 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
                   "dr_insert_cbr_instrumentation must be applied to a cbr");
     target = (ptr_uint_t)opnd_get_pc(instr_get_target(instr));
 
-    /* Compute branch direction */
+    /* Compute branch direction. */
     opc = instr_get_opcode(instr);
     if (opc == OP_cbnz || opc == OP_cbz) {
         opnd_t reg_op = instr_get_src(instr, 1);
         reg_id_t reg = opnd_get_reg(reg_op);
-        /* use dir register to compute direction */
-        dir = (reg == DR_REG_X0 || reg == DR_REG_W0) ? DR_REG_X1 : DR_REG_X0;
-        /* save old value of dir register to SPILL_SLOT_1 */
+        /* Use dir register to compute direction. */
+        dir = (reg_to_pointer_sized(reg) == DR_REG_X0) ? DR_REG_X1 : DR_REG_X0;
+        /* Save old value of dir register to SPILL_SLOT_1. */
         dr_save_reg(dcontext, ilist, instr, dir, SPILL_SLOT_1);
-        /* use flags register to save nzcv */
-        flags = (reg == DR_REG_X2 || reg == DR_REG_W2) ? DR_REG_X3 : DR_REG_X2;
-        /* save old value of flags register to SPILL_SLOT_2 */
+        /* Use flags register to save nzcv. */
+        flags = (reg_to_pointer_sized(reg) == DR_REG_X2) ? DR_REG_X3 : DR_REG_X2;
+        /* Save old value of flags register to SPILL_SLOT_2. */
         dr_save_reg(dcontext, ilist, instr, flags, SPILL_SLOT_2);
-        /* save flags to flags register */
+        /* Save flags to flags register. */
         dr_save_arith_flags_to_reg(dcontext, ilist, instr, flags);
 
-        /* compare reg against zero */
+        /* Compare reg against zero. */
         instr_t *cmp = INSTR_CREATE_cmp(dcontext, reg_op, OPND_CREATE_INT(0));
         MINSERT(ilist, instr, cmp);
-        /* compute branch direction */
+        /* Compute branch direction. */
         opnd_t dir_op = opnd_create_reg(dir);
         instr_t *cset = INSTR_CREATE_csinc(
             dcontext, dir_op, OPND_CREATE_ZR(dir_op), OPND_CREATE_ZR(dir_op),
@@ -6413,20 +6412,13 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
         reg_id_t reg = opnd_get_reg(reg_op);
         reg_id_t dir_same_width = DR_REG_NULL;
 
-        /* use dir register to compute direction */
-        if (DR_REG_START_64 <= reg && reg <= DR_REG_STOP_64) {
-            /* 64-bit register */
-            dir = (reg == DR_REG_X0) ? DR_REG_X1 : DR_REG_X0;
-            dir_same_width = (reg == DR_REG_X0) ? DR_REG_X1 : DR_REG_X0;
-        } else {
-            /* 32-bit register */
-            dir = (reg == DR_REG_W0) ? DR_REG_X1 : DR_REG_X0;
-            dir_same_width = (reg == DR_REG_W0) ? DR_REG_W1 : DR_REG_W0;
-        }
-        /* save old value of dir register to SPILL_SLOT_1 */
+        /* Use dir register to compute direction. */
+        dir = (reg_to_pointer_sized(reg) == DR_REG_X0) ? DR_REG_X1 : DR_REG_X0;
+        dir_same_width = reg_resize_to_opsz(dir, reg_get_size(reg));
+        /* Save old value of dir register to SPILL_SLOT_1. */
         dr_save_reg(dcontext, ilist, instr, dir, SPILL_SLOT_1);
 
-        /* extract tst_bit from reg */
+        /* Extract tst_bit from reg. */
         int tst_bit = opnd_get_immed_int(instr_get_src(instr, 2));
         opnd_t dir_same_width_op = opnd_create_reg(dir_same_width);
         instr_t *ubfm =
@@ -6434,18 +6426,18 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
                               OPND_CREATE_INT(tst_bit), OPND_CREATE_INT(tst_bit));
         MINSERT(ilist, instr, ubfm);
 
-        /* invert result if tbz */
+        /* Invert result if tbz. */
         if (opc == OP_tbz) {
             instr_t *eor =
                 INSTR_CREATE_eor(dcontext, dir_same_width_op, OPND_CREATE_INT(1));
             MINSERT(ilist, instr, eor);
         }
     } else if (opc == OP_bcond) {
-        /* use dir register to compute direction */
+        /* Use dir register to compute direction. */
         dir = SCRATCH_REG0;
-        /* save old value of dir register to SPILL_SLOT_1 */
+        /* Save old value of dir register to SPILL_SLOT_1. */
         dr_save_reg(dcontext, ilist, instr, dir, SPILL_SLOT_1);
-        /* compute branch direction */
+        /* Compute branch direction. */
         dr_pred_type_t pred = instr_get_predicate(instr);
         opnd_t dir_op = opnd_create_reg(dir);
         instr_t *cset = INSTR_CREATE_csinc(
@@ -6467,15 +6459,15 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
              * super concerned about overhead.
              */
             DR_CLEANCALL_READS_APP_CONTEXT | DR_CLEANCALL_WRITES_APP_CONTEXT, 5,
-            /* address of cbr is 1st parameter */
+            /* Address of cbr is 1st parameter. */
             OPND_CREATE_INTPTR(address),
-            /* target is 2nd parameter */
+            /* Target is 2nd parameter. */
             OPND_CREATE_INTPTR(target),
-            /* fall-through is 3rd parameter */
+            /* Fall-through is 3rd parameter. */
             OPND_CREATE_INTPTR(fallthrough),
-            /* branch direction is 4th parameter */
+            /* Branch direction is 4th parameter. */
             opnd_create_reg(dir),
-            /* user defined data is 5th parameter */
+            /* User defined data is 5th parameter. */
             opnd_is_null(user_data) ? OPND_CREATE_INT32(0) : user_data);
     } else {
         dr_insert_clean_call_ex(
@@ -6485,29 +6477,29 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
              * super concerned about overhead.
              */
             DR_CLEANCALL_READS_APP_CONTEXT | DR_CLEANCALL_WRITES_APP_CONTEXT, 3,
-            /* address of cbr is 1st parameter */
+            /* Address of cbr is 1st parameter. */
             OPND_CREATE_INTPTR(address),
-            /* target is 2nd parameter */
+            /* Target is 2nd parameter. */
             OPND_CREATE_INTPTR(target),
-            /* branch direction is 3rd parameter */
+            /* Branch direction is 3rd parameter. */
             opnd_create_reg(dir));
     }
 
     /* Restore state */
     if (opc == OP_cbnz || opc == OP_cbz) {
-        /* restore arith flags */
+        /* Restore arith flags. */
         dr_restore_arith_flags_from_reg(dcontext, ilist, instr, flags);
-        /* restore old value of flags register */
+        /* Restore old value of flags register. */
         dr_restore_reg(dcontext, ilist, instr, flags, SPILL_SLOT_2);
-        /* restore old value of dir register */
+        /* Restore old value of dir register. */
         dr_restore_reg(dcontext, ilist, instr, dir, SPILL_SLOT_1);
     } else if (opc == OP_bcond || opc == OP_tbnz || opc == OP_tbz) {
-        /* restore old value of dir register */
+        /* Restore old value of dir register. */
         dr_restore_reg(dcontext, ilist, instr, dir, SPILL_SLOT_1);
     } else {
         CLIENT_ASSERT(false, "unknown conditional branch type");
     }
-#endif /* X86/ARM/RISCV64 */
+#endif /* X86/ARM/RISCV64/AARCH64 */
 }
 
 DR_API void

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -43,7 +43,6 @@
 #include "../globals.h" /* just to disable warning C4206 about an empty file */
 
 #include "instrument.h"
-#include "globals_api.h"
 #include "instr.h"
 #include "instr_create_shared.h"
 #include "instrlist.h"

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -6411,6 +6411,7 @@ dr_insert_cbr_instrumentation_help(void *drcontext, instrlist_t *ilist, instr_t 
     /* Compute branch direction. */
     opc = instr_get_opcode(instr);
     if (opc == OP_cbnz || opc == OP_cbz) {
+        /* XXX: which is faster, additional conditional branch or cmp + csinc? */
         opnd_t reg_op = instr_get_src(instr, 1);
         reg_id_t reg = opnd_get_reg(reg_op);
         /* Use dir register to compute direction. */

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2514,13 +2514,15 @@ if (X86) # FIXME i#1551, i#1569: port to ARM and AArch64
         client-interface/cleancall.c "" "-thread_private -prof_pcs -opt_cleancall 0" "")
     endif (NOT X64)
   endif (UNIX)
+  tobuild_ci(client.syscall client-interface/syscall.c "" "-no_follow_children" "")
+  tobuild_ci(client.count-bbs client-interface/count-bbs.c "" "" "")
+endif (X86)
+if (X86 OR AARCH64)
   tobuild_ci(client.count-ctis client-interface/count-ctis.c "" "" "")
   # check dr_insert_cbr_instrumentation with out-of-line clean call
   torunonly_ci(client.count-ctis-noopt client.count-ctis client.count-ctis.dll
     client-interface/count-ctis.c "" "-opt_cleancall 0" "")
-  tobuild_ci(client.syscall client-interface/syscall.c "" "-no_follow_children" "")
-  tobuild_ci(client.count-bbs client-interface/count-bbs.c "" "" "")
-endif (X86)
+endif (X86 OR AARCH64)
 if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
   tobuild_ci(client.cleancallparams client-interface/cleancallparams.c "" "" "")
   tobuild_ci(client.app_inscount client-interface/app_inscount.c "" "" "")

--- a/suite/tests/client-interface/count-ctis.c
+++ b/suite/tests/client-interface/count-ctis.c
@@ -51,6 +51,7 @@ main()
 #else /* asm code *************************************************************/
 #    include "asm_defines.asm"
 /* clang-format off */
+#ifdef X86
 START_FILE
 
 #define FUNCNAME test_jecxz
@@ -95,5 +96,35 @@ GLOBAL_LABEL(FUNCNAME:)
 
 
 END_FILE
+#elif defined(AARCH64)
+START_FILE
+
+#define FUNCNAME test_jecxz
+        DECLARE_FUNC(FUNCNAME)
+GLOBAL_LABEL(FUNCNAME:)
+        mov      x1, ARG1
+        END_PROLOG
+
+        /* test cbnz */
+        mov      x1, 0
+        cbz      x1, jecxz_taken
+        nop
+     jecxz_taken:
+        mov      x1, 1
+        cbz      x1, jecxz_taken
+        nop
+     jecxz_not_taken:
+        nop
+
+        /* test x0 being preserved */
+        ldr      x1, =0xabcd1234
+        str      x1, [x0]
+
+        ret
+        END_FUNC(FUNCNAME)
+
+
+END_FILE
+#endif
 /* clang-format on */
 #endif

--- a/suite/tests/client-interface/count-ctis.c
+++ b/suite/tests/client-interface/count-ctis.c
@@ -102,6 +102,9 @@ START_FILE
 #define FUNCNAME test_jecxz
         DECLARE_FUNC(FUNCNAME)
 GLOBAL_LABEL(FUNCNAME:)
+        /* begin roi via nop; nop; add; nop */
+        nop; nop; add x0, x0, 0; nop
+
         mov      x1, ARG1
         END_PROLOG
 
@@ -207,11 +210,14 @@ GLOBAL_LABEL(FUNCNAME:)
         beq      beq_taken
         nop
      beq_taken:
-        cmp      x1, 1
-        bne      bne_taken
+        cmp      x1, 0
+        bne      bne_not_taken
         nop
-     bne_taken:
+     bne_not_taken:
         nop
+
+        /* end roi via nop; nop; add; nop */
+        nop; nop; add x0, x0, 0; nop
 
         /* test x0 being preserved */
         ldr      x1, =0xabcd1234

--- a/suite/tests/client-interface/count-ctis.c
+++ b/suite/tests/client-interface/count-ctis.c
@@ -105,15 +105,112 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      x1, ARG1
         END_PROLOG
 
-        /* test cbnz */
+        /* test cbz */
         mov      x1, 0
-        cbz      x1, jecxz_taken
+        cbz      x1, cbz_taken
         nop
-     jecxz_taken:
+     cbz_taken:
         mov      x1, 1
-        cbz      x1, jecxz_taken
+        cbz      x1, cbz_not_taken
         nop
-     jecxz_not_taken:
+     cbz_not_taken:
+        nop
+
+        /* test cbnz */
+        mov      x1, 1
+        cbnz     x1, cbnz_taken
+        nop
+     cbnz_taken:
+        mov      x1, 0
+        cbnz     x1, cbnz_not_taken
+        nop
+     cbnz_not_taken:
+        nop
+
+        /* test cbz using stolen register x28 */
+        mov      x1, x28
+        mov      x28, 0
+        cbz      x28, cbz_x28_taken
+        nop
+     cbz_x28_taken:
+        mov      x28, 1
+        cbz      x28, cbz_x28_not_taken
+        nop
+     cbz_x28_not_taken:
+        nop
+        mov      x28, x1
+
+        /* test cbnz using stolen register x28 */
+        mov      x1, x28
+        mov      x28, 1
+        cbnz     x28, cbnz_x28_taken
+        nop
+     cbnz_x28_taken:
+        mov      x28, 0
+        cbnz     x28, cbnz_x28_not_taken
+        nop
+     cbnz_x28_not_taken:
+        nop
+        mov      x28, x1
+
+        /* test tbz */
+        mov      x1, 0
+        tbz      x1, #1, tbz_taken
+        nop
+     tbz_taken:
+        mov      x1, 2
+        tbz      x1, #1, tbz_not_taken
+        nop
+     tbz_not_taken:
+        nop
+
+        /* test tbnz */
+        mov      x1, 4
+        tbnz     x1, #2, tbnz_taken
+        nop
+     tbnz_taken:
+        mov      x1, 0
+        tbnz     x1, #2, tbnz_not_taken
+        nop
+     tbnz_not_taken:
+        nop
+
+        /* test tbz using stolen register x28 */
+        mov      x1, x28
+        mov      x28, 0
+        tbz      x28, #1, tbz_x28_taken
+        nop
+     tbz_x28_taken:
+        mov      x28, 2
+        tbz      x28, #1, tbz_x28_not_taken
+        nop
+     tbz_x28_not_taken:
+        nop
+        mov      x28, x1
+
+        /* test tbnz using stolen register x28 */
+        mov      x1, x28
+        mov      x28, 2
+        tbnz     x28, #1, tbnz_x28_taken
+        nop
+     tbnz_x28_taken:
+        mov      x28, 0
+        tbnz     x28, #1, tbnz_x28_not_taken
+        nop
+     tbnz_x28_not_taken:
+        nop
+        mov      x28, x1
+
+        /* test bcond */
+        mov      x1, 0
+        cmp      x1, 0
+        beq      beq_taken
+        nop
+     beq_taken:
+        cmp      x1, 1
+        bne      bne_taken
+        nop
+     bne_taken:
         nop
 
         /* test x0 being preserved */

--- a/suite/tests/client-interface/count-ctis.dll.c
+++ b/suite/tests/client-interface/count-ctis.dll.c
@@ -41,6 +41,10 @@ uint num_jump_dir = 0;
 uint num_jump_ind = 0;
 uint num_br_cond = 0;
 uint num_ret = 0;
+#if defined(AARCH64)
+bool in_roi = false; /* Within our region of interest? */
+bool cbr_taken = true; /* Next cbr should be taken or not-taken? */
+#endif
 
 static void
 at_call_dir(app_pc src, app_pc dst)
@@ -70,6 +74,15 @@ static void
 at_br_cond(app_pc src, app_pc dst, int taken)
 {
     num_br_cond++;
+#if defined(AARCH64)
+    if (in_roi) {
+        /* In count-ctis.c, we ensure that dst - src == 0x8. */
+        ASSERT(dst == src + 0x8);
+        /* In count-ctis.c, we ensure that cbrs are taken/not taken in turns. */
+        ASSERT(cbr_taken == taken);
+        cbr_taken = !cbr_taken;
+    }
+#endif
 }
 
 static void
@@ -88,10 +101,20 @@ at_ret(app_pc src, app_pc dst)
     num_ret++;
 }
 
+static void
+at_nops()
+{
+    /* Enter or exit region of interest. */
+    in_roi = !in_roi;
+}
+
 static dr_emit_flags_t
 bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool translating)
 {
     instr_t *instr, *next_instr;
+#if defined(AARCH64)
+    instr_t *next_next_instr, *next_next_next_instr;
+#endif
 
     for (instr = instrlist_first(bb); instr != NULL; instr = next_instr) {
         next_instr = instr_get_next(instr);
@@ -130,6 +153,24 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
                 ASSERT(false);
             }
         }
+#if defined(AARCH64)
+        /* Look for pattern: nop; nop; add; nop. */
+        if (next_instr != NULL)
+            next_next_instr = instr_get_next(next_instr);
+        else
+            next_next_instr = NULL;
+        if (next_next_instr != NULL)
+            next_next_next_instr = instr_get_next(next_next_instr);
+        else
+            next_next_next_instr = NULL;
+        if (instr_is_nop(instr) && next_instr != NULL && instr_is_nop(next_instr) &&
+            next_next_instr != NULL && instr_get_opcode(next_next_instr) == OP_add &&
+            next_next_next_instr != NULL && instr_is_nop(next_next_next_instr)) {
+            /* Pattern found */
+            dr_insert_clean_call(drcontext, bb, instr, at_nops, false, 0);
+        }
+#endif
+
     }
     return DR_EMIT_DEFAULT;
 }

--- a/suite/tests/client-interface/count-ctis.dll.c
+++ b/suite/tests/client-interface/count-ctis.dll.c
@@ -104,8 +104,10 @@ at_ret(app_pc src, app_pc dst)
 static void
 at_nops()
 {
+#if defined(AARCH64)
     /* Enter or exit region of interest. */
     in_roi = !in_roi;
+#endif
 }
 
 static dr_emit_flags_t

--- a/suite/tests/client-interface/count-ctis.dll.c
+++ b/suite/tests/client-interface/count-ctis.dll.c
@@ -42,7 +42,7 @@ uint num_jump_ind = 0;
 uint num_br_cond = 0;
 uint num_ret = 0;
 #if defined(AARCH64)
-bool in_roi = false; /* Within our region of interest? */
+bool in_roi = false;   /* Within our region of interest? */
 bool cbr_taken = true; /* Next cbr should be taken or not-taken? */
 #endif
 
@@ -170,7 +170,6 @@ bb_event(void *drcontext, void *tag, instrlist_t *bb, bool for_trace, bool trans
             dr_insert_clean_call(drcontext, bb, instr, at_nops, false, 0);
         }
 #endif
-
     }
     return DR_EMIT_DEFAULT;
 }


### PR DESCRIPTION
Implement mbr & cbr instrumentation for AARCH64, previously only available for X86. For cbr instrumentation, there are three types of conditional branches on AARCH64:

1. conditional branch if (non) zero: generate code to compare the register against zero to compute the direction
2. test bit and branch if (non) zero: generate code to extract the bit out of the register (using ubfm) and then compare the bit against zero to compute the direction
3. conditional branch according to NZCV: generate code to compute the direction using csinc instruction

Special care is implemented if the stolen register x28 is used as the operand, to avoid generating incorrect results.

For mbr instrumentation, the target address is placed in the register, which is later passed to the clean call from the user.

Additional instruction creation macros are added for ubfm and csinc instructions. Support for immediate operand is added to the INSTR_CREATE_eor macro. XINST_CREATE_slr_s is updated to use the new INSTR_CREATE_ubfm macro.

Count-ctis test is now enabled due to cbr & mbr instrumentation available on AARCH64. It has been enhanced to validate the direction and target address of conditional branches to validate the instrumentation.

The instrcalls and cbrtrace example clients are enabled as well. They are tested on real AARCH64 hardware. Additionally, a manually crafted dynamorio client can successfully capture the whole control flow transfer history with this pull reuqest.

Fixes: #2297 (only for AARCH64, ARM not yet) and #2919. 
