### PR TITLE
i#6822 unscheduled: Fix bug making small timeouts infinite

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -3478,6 +3478,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::process_marker(input_info_t &input,
         input.unscheduled = true;
         if (input.syscall_timeout_arg > 0) {
             input.blocked_time = scale_blocked_time(input.syscall_timeout_arg);
+            // Clamp at 1 since 0 means an infinite timeout for unscheduled=true.
+            if (input.blocked_time == 0)
+                input.blocked_time = 1;
             input.blocked_start_time = get_output_time(output);
             VPRINT(this, 3, "input %d unscheduled for %" PRIu64 " @%" PRIu64 "\n",
                    input.index, input.blocked_time, input.reader->get_last_timestamp());
@@ -3506,6 +3509,9 @@ scheduler_tmpl_t<RecordType, ReaderType>::process_marker(input_info_t &input,
         input.unscheduled = true;
         if (input.syscall_timeout_arg > 0) {
             input.blocked_time = scale_blocked_time(input.syscall_timeout_arg);
+            // Clamp at 1 since 0 means an infinite timeout for unscheduled=true.
+            if (input.blocked_time == 0)
+                input.blocked_time = 1;
             input.blocked_start_time = get_output_time(output);
             VPRINT(this, 3, "input %d unscheduled for %" PRIu64 " @%" PRIu64 "\n",
                    input.index, input.blocked_time, input.reader->get_last_timestamp());

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -4534,7 +4534,7 @@ test_direct_switch()
 }
 
 static void
-test_unscheduled()
+test_unscheduled_base()
 {
     std::cerr << "\n----------------\nTesting unscheduled inputs\n";
     // We have just 1 output to better control the order and avoid flakiness.
@@ -5164,6 +5164,71 @@ test_unscheduled_initially_roi()
         assert(sched_as_string[0] == CORE0_SCHED_STRING);
     }
 #endif
+}
+
+static void
+test_unscheduled_small_timeout()
+{
+    // Test that a small timeout scaled to 0 does not turn into an infinite timeout.
+    std::cerr << "\n----------------\nTesting unscheduled input with small timeout\n";
+    static constexpr int NUM_OUTPUTS = 1;
+    static constexpr int WAIT_TIMEOUT = 5;
+    static constexpr double BLOCK_SCALE = 0.1;
+    static constexpr memref_tid_t TID_A = 100;
+    std::vector<trace_entry_t> refs_A = {
+        make_thread(TID_A),
+        make_pid(1),
+        make_version(TRACE_ENTRY_VERSION),
+        make_timestamp(1001),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        make_instr(/*pc=*/101),
+        make_timestamp(1002),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        make_marker(TRACE_MARKER_TYPE_SYSCALL, 999),
+        make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+        make_marker(TRACE_MARKER_TYPE_SYSCALL_ARG_TIMEOUT, WAIT_TIMEOUT),
+        make_marker(TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE, 0),
+        make_timestamp(2002),
+        make_instr(/*pc=*/102),
+        make_exit(TID_A),
+    };
+    {
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(refs_A)),
+                             std::unique_ptr<mock_reader_t>(new mock_reader_t()), TID_A);
+        static const char *const CORE0_SCHED_STRING = "...A......._A.";
+
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/3);
+        // We use our mock's time==instruction count for a deterministic result.
+        sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
+        sched_ops.block_time_multiplier = BLOCK_SCALE;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        std::vector<std::string> sched_as_string =
+            run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_A, /*send_time=*/true);
+        for (int i = 0; i < NUM_OUTPUTS; i++) {
+            std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+        }
+        assert(sched_as_string[0] == CORE0_SCHED_STRING);
+    }
+}
+
+static void
+test_unscheduled()
+{
+    test_unscheduled_base();
+    test_unscheduled_fallback();
+    test_unscheduled_initially();
+    test_unscheduled_initially_roi();
+    test_unscheduled_small_timeout();
 }
 
 static void
@@ -5802,9 +5867,6 @@ test_main(int argc, const char *argv[])
     test_inactive();
     test_direct_switch();
     test_unscheduled();
-    test_unscheduled_fallback();
-    test_unscheduled_initially();
-    test_unscheduled_initially_roi();
     test_kernel_switch_sequences();
     test_random_schedule();
     test_record_scheduler();

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -5173,7 +5173,7 @@ test_unscheduled_small_timeout()
     std::cerr << "\n----------------\nTesting unscheduled input with small timeout\n";
     static constexpr int NUM_OUTPUTS = 1;
     // 4*0.1 rounds to 0 (the scheduler's cast rounds any fraction down).
-    static constexpr int WAIT_TIMEOUT = 4;
+    static constexpr int UNSCHEDULE_TIMEOUT = 4;
     static constexpr double BLOCK_SCALE = 0.1;
     static constexpr memref_tid_t TID_A = 100;
     std::vector<trace_entry_t> refs_A = {
@@ -5187,7 +5187,7 @@ test_unscheduled_small_timeout()
         make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
         make_marker(TRACE_MARKER_TYPE_SYSCALL, 999),
         make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
-        make_marker(TRACE_MARKER_TYPE_SYSCALL_ARG_TIMEOUT, WAIT_TIMEOUT),
+        make_marker(TRACE_MARKER_TYPE_SYSCALL_ARG_TIMEOUT, UNSCHEDULE_TIMEOUT),
         make_marker(TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE, 0),
         make_timestamp(2002),
         make_instr(/*pc=*/102),

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -5172,7 +5172,8 @@ test_unscheduled_small_timeout()
     // Test that a small timeout scaled to 0 does not turn into an infinite timeout.
     std::cerr << "\n----------------\nTesting unscheduled input with small timeout\n";
     static constexpr int NUM_OUTPUTS = 1;
-    static constexpr int WAIT_TIMEOUT = 5;
+    // 4*0.1 rounds to 0 (the scheduler's cast rounds any fraction down).
+    static constexpr int WAIT_TIMEOUT = 4;
     static constexpr double BLOCK_SCALE = 0.1;
     static constexpr memref_tid_t TID_A = 100;
     std::vector<trace_entry_t> refs_A = {


### PR DESCRIPTION
Fixes a bug for going-unscheduled actions where scaling a small timeout rounds it down to 0, which is then interpreted as an infinite timeout.

Adds a unit test that fails without the fix.

Issue: #6822