### PR TITLE
i#6938 sched migrate: Remove duplicate option

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -558,7 +558,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::init_dynamic_schedule()
         op_sched_order_time.get_value() ? sched_type_t::DEPENDENCY_TIMESTAMPS
                                         : sched_type_t::DEPENDENCY_IGNORE,
         sched_type_t::SCHEDULER_DEFAULTS, op_verbose.get_value());
-    sched_ops.time_units_per_us = op_sched_time_per_us.get_value();
+    sched_ops.time_units_per_us = op_sched_time_units_per_us.get_value();
     if (op_sched_time.get_value()) {
         sched_ops.quantum_unit = sched_type_t::QUANTUM_TIME;
         sched_ops.quantum_duration_us = op_sched_quantum.get_value();
@@ -571,7 +571,6 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::init_dynamic_schedule()
     sched_ops.block_time_max_us = op_sched_block_max_us.get_value();
     sched_ops.migration_threshold_us = op_sched_migration_threshold_us.get_value();
     sched_ops.rebalance_period_us = op_sched_rebalance_period_us.get_value();
-    sched_ops.time_units_per_us = op_sched_time_units_per_us.get_value();
     sched_ops.randomize_next_input = op_sched_randomize.get_value();
     sched_ops.honor_direct_switches = !op_sched_disable_direct_switches.get_value();
 #ifdef HAS_ZIP

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -904,11 +904,6 @@ droption_t<bool> op_core_serial(
     "How the scheduling is performed is controlled by a set "
     "of options with the prefix \"sched_\" along with -cores.");
 
-droption_t<double>
-    op_sched_time_per_us(DROPTION_SCOPE_ALL, "sched_time_per_us", 1000.,
-                         "Wall-clock microseconds per simulated microsecond",
-                         "Wall-clock microseconds per simulated microsecond.");
-
 droption_t<int64_t>
     // We pick 10 million to match 2 instructions per nanosecond with a 5ms quantum.
     op_sched_quantum(DROPTION_SCOPE_ALL, "sched_quantum", 10 * 1000 * 1000,

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -202,7 +202,6 @@ extern dynamorio::droption::droption_t<int> op_kernel_trace_buffer_size_shift;
 #endif
 extern dynamorio::droption::droption_t<bool> op_core_sharded;
 extern dynamorio::droption::droption_t<bool> op_core_serial;
-extern dynamorio::droption::droption_t<double> op_sched_time_per_us;
 extern dynamorio::droption::droption_t<int64_t> op_sched_quantum;
 extern dynamorio::droption::droption_t<bool> op_sched_time;
 extern dynamorio::droption::droption_t<bool> op_sched_order_time;


### PR DESCRIPTION
Removes a duplicate option -sched_time_per_us which was accidentally added by PR #6980 separately from the similar -sched_time_units_per_us from PR #6985.

Issue: #6938