### PR TITLE
Move conditions for prefetching into the prefetch() function

### DIFF
--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -240,8 +240,8 @@ caching_device_t::request(const memref_t &memref_in)
 
         // Issue a hardware prefetch, if any, before we remember the last tag,
         // so we remember this line and not the prefetched line.
-        if (missed && !type_is_prefetch(memref.data.type) && prefetcher_ != nullptr)
-            prefetcher_->prefetch(this, memref);
+        if (prefetcher_ != nullptr)
+            prefetcher_->prefetch(this, memref, missed);
 
         if (tag + 1 <= final_tag) {
             addr_t next_addr = (tag + 1) << block_size_bits_;

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -240,7 +240,7 @@ caching_device_t::request(const memref_t &memref_in)
 
         // Issue a hardware prefetch, if any, before we remember the last tag,
         // so we remember this line and not the prefetched line.
-        if (prefetcher_ != nullptr)
+        if (prefetcher_ != nullptr && !type_is_prefetch(memref_in.data.type))
             prefetcher_->prefetch(this, memref, missed);
 
         if (tag + 1 <= final_tag) {

--- a/clients/drcachesim/simulator/prefetcher.cpp
+++ b/clients/drcachesim/simulator/prefetcher.cpp
@@ -48,13 +48,15 @@ prefetcher_t::prefetcher_t(int block_size)
 }
 
 void
-prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in)
+prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in, const bool missed)
 {
     // We implement a simple next-line prefetcher.
-    memref_t memref = memref_in;
-    memref.data.addr += block_size_;
-    memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
-    cache->request(memref);
+    if (missed && !type_is_prefetch(memref_in.data.type)) {
+      memref_t memref = memref_in;
+      memref.data.addr += block_size_;
+      memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
+      cache->request(memref);
+    }
 }
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/simulator/prefetcher.cpp
+++ b/clients/drcachesim/simulator/prefetcher.cpp
@@ -48,14 +48,15 @@ prefetcher_t::prefetcher_t(int block_size)
 }
 
 void
-prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in, const bool missed)
+prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in,
+                       const bool missed)
 {
     // We implement a simple next-line prefetcher.
     if (missed && !type_is_prefetch(memref_in.data.type)) {
-      memref_t memref = memref_in;
-      memref.data.addr += block_size_;
-      memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
-      cache->request(memref);
+        memref_t memref = memref_in;
+        memref.data.addr += block_size_;
+        memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
+        cache->request(memref);
     }
 }
 } // namespace drmemtrace

--- a/clients/drcachesim/simulator/prefetcher.cpp
+++ b/clients/drcachesim/simulator/prefetcher.cpp
@@ -52,7 +52,7 @@ prefetcher_t::prefetch(caching_device_t *cache, const memref_t &memref_in,
                        const bool missed)
 {
     // We implement a simple next-line prefetcher.
-    if (missed && !type_is_prefetch(memref_in.data.type)) {
+    if (missed) {
         memref_t memref = memref_in;
         memref.data.addr += block_size_;
         memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;

--- a/clients/drcachesim/simulator/prefetcher.h
+++ b/clients/drcachesim/simulator/prefetcher.h
@@ -50,6 +50,9 @@ public:
     virtual ~prefetcher_t()
     {
     }
+    // prefetch() will be called for all demand accesses, even those that
+    // hit in the cache. The missed parameter indicates whether the
+    // memref.data.addr is already in the cache or not.
     virtual void
     prefetch(caching_device_t *cache, const memref_t &memref, bool missed);
 

--- a/clients/drcachesim/simulator/prefetcher.h
+++ b/clients/drcachesim/simulator/prefetcher.h
@@ -51,7 +51,7 @@ public:
     {
     }
     virtual void
-    prefetch(caching_device_t *cache, const memref_t &memref);
+    prefetch(caching_device_t *cache, const memref_t &memref, bool missed);
 
 protected:
     int block_size_;

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -327,15 +327,17 @@ private:
         {
         }
         void
-        prefetch(caching_device_t *cache, const memref_t &memref_in)
+        prefetch(caching_device_t *cache, const memref_t &memref_in, const bool missed)
         {
-            // We implement a simple 2 next-line prefetcher.
-            memref_t memref = memref_in;
-            memref.data.addr += block_size_;
-            memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
-            cache->request(memref);
-            memref.data.addr += block_size_;
-            cache->request(memref);
+            // We implement a simple 2 next-line prefetcher.i
+            if (missed && !type_is_prefetch(memref_in.data.type)) {
+              memref_t memref = memref_in;
+              memref.data.addr += block_size_;
+              memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
+              cache->request(memref);
+              memref.data.addr += block_size_;
+              cache->request(memref);
+            }
         }
     };
 };

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -331,12 +331,12 @@ private:
         {
             // We implement a simple 2 next-line prefetcher.i
             if (missed && !type_is_prefetch(memref_in.data.type)) {
-              memref_t memref = memref_in;
-              memref.data.addr += block_size_;
-              memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
-              cache->request(memref);
-              memref.data.addr += block_size_;
-              cache->request(memref);
+                memref_t memref = memref_in;
+                memref.data.addr += block_size_;
+                memref.data.type = TRACE_TYPE_HARDWARE_PREFETCH;
+                cache->request(memref);
+                memref.data.addr += block_size_;
+                cache->request(memref);
             }
         }
     };

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -336,8 +336,8 @@ public:
                 hits_++;
             }
         }
-      int hits_ = 0;
-      int misses_ = 0;
+        int hits_ = 0;
+        int misses_ = 0;
     };
 
     next2line_prefetcher_t *
@@ -346,7 +346,7 @@ public:
         prefetcher_ = new next2line_prefetcher_t(block_size);
         return prefetcher_;
     }
-    next2line_prefetcher_t * prefetcher_;
+    next2line_prefetcher_t *prefetcher_;
 };
 
 void


### PR DESCRIPTION
This allows custom prefetchers to train on cache hits in addition to misses