### PR TITLE
i#7025: Restore msgbox_mask package defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2010-2023 Google, Inc.    All rights reserved.
+# Copyright (c) 2010-2024 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # Copyright (c) 2018 Arm Limited          All rights reserved.
 # **********************************************************
@@ -1840,7 +1840,8 @@ endfunction ()
 # TODO i#5767: Install an explicit zlib package on our Windows GA CI images
 # (this find_package finds a strawberry perl zlib which causes 32-bit build
 # and 64-bit private loader issues).
-if (WIN32 AND AUTOMATED_TESTING)
+option(DISABLE_ZLIB "Disable looking for and using zlib" OFF)
+if (WIN32 AND NOT DISABLE_ZLIB)
   set(ZLIB_FOUND OFF)
 else ()
   find_package(ZLIB)

--- a/make/package.cmake
+++ b/make/package.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2011-2022 Google, Inc.    All rights reserved.
+# Copyright (c) 2011-2024 Google, Inc.    All rights reserved.
 # Copyright (c) 2009-2010 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -164,9 +164,14 @@ set(base_cache "
   BUILD_NUMBER:STRING=${arg_build}
   UNIQUE_BUILD_NUMBER:STRING=${arg_ubuild}
   BUILD_PACKAGE:BOOL=ON
-  AUTOMATED_TESTING:BOOL=ON
   ${arg_cacheappend}
   ")
+
+if (WIN32)
+  # TODO i#5767: Install a working zlib package on our Windows GA CI images.
+  set(base_cache "${base_cache}
+    DISABLE_ZLIB:BOOL=ON")
+endif()
 
 # version is optional
 if (arg_version)


### PR DESCRIPTION
Replaces the AUTOMATED_TESTING set in package builds by PR #5769 with a new DISABLE_ZLIB CMake option to accomplish the goal of disabling the zlib found on these VMs while avoiding turning off msgbox_mask. The disabling by default of msgbox_mask in packages has caused many users to fail to obtain error information and has led to confusion with silent errors.

Tested: built a cronbuild based on this branch and downloaded it to the Windows VM used for #7024.
I ran this:
```
C:\Users\bruening\DynamoRIO-Windows-10.93.20004>bin64\drrun -- msg
<Application C:\Windows\system32\msg.exe (3892).  Out of memory.  Program aborted.  Source I, type 0x0000000000000001, code 0x00000000c000001c.>
```

And confirmed a messagebox popped up: thus showing that `-msgbox_mask` is *not* set to 0 anymore.

Issue: #7025