### PR TITLE
i#7044 hang: Fix deadlock regression on drmemtrace replay

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1920,8 +1920,11 @@ protected:
                              input_reader_info_t &reader_info);
 
     // The caller cannot hold the output or input lock.
+    // The caller can hold the output's current input's lock but must pass
+    // true for the 3rd parameter in that case.
     stream_status_t
-    set_cur_input(output_ordinal_t output, input_ordinal_t input);
+    set_cur_input(output_ordinal_t output, input_ordinal_t input,
+                  bool hold_cur_input_lock = false);
 
     // Finds the next input stream for the 'output_ordinal'-th output stream.
     // No input_info_t lock can be held on entry.

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1924,7 +1924,7 @@ protected:
     // true for the 3rd parameter in that case.
     stream_status_t
     set_cur_input(output_ordinal_t output, input_ordinal_t input,
-                  bool hold_cur_input_lock = false);
+                  bool caller_holds_cur_input_lock = false);
 
     // Finds the next input stream for the 'output_ordinal'-th output stream.
     // No input_info_t lock can be held on entry.


### PR DESCRIPTION
Fixes a deadlock on replay introduced by PR #6985.  If a recorded schedule has back-to-back entries with the same input (with a gap where another thread runs that input in between of course) and it has to wait for that other thread for its 2nd stint with that input, it will deadlock as it holds the input's lock while it tries to get the lock in set_cur_input().  That 2nd lock acquisition is what was added by PR #6985: that's the source of the regression.

Tested on a 12-thread threadsig trace which hangs without the fix and succeeds with the fix.  It is too large to turn into a convenient regression test.

Issue: #7044