### PR TITLE
i#7050: reset expected read/write record counts after kernel transfer

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1068,6 +1068,10 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                 shard->prev_entry_.marker.marker_type != TRACE_MARKER_TYPE_RSEQ_ABORT) {
                 shard->retaddr_stack_.push(0);
             }
+            // Reset read/write record count when the previous instruction was
+            // preempted.
+            shard->expected_read_records_ = 0;
+            shard->expected_write_records_ = 0;
         }
 #ifdef UNIX
         report_if_false(shard, memref.marker.marker_value != 0,


### PR DESCRIPTION
When an instruction is preempted by a kernel transfer, the instruction is not retired. The trace might not have captured all the read and write records. To avoid false positive, the invariant checker should reset the expected read and write record counters.

Fixes #7050