### PR TITLE
i#7044 hang: Sleep on wait in parallel drmemtrace analyzer

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -649,6 +649,10 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks_internal(
             // We synthesize a record here.  If we wanted this to count toward output
             // stream ordinals we would need to add a scheduler API to inject it.
             record = create_wait_marker();
+            if (parallel_) {
+                // Don't spin on this artificial wait; retry later.
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
         } else if (status == sched_type_t::STATUS_IDLE) {
             assert(shard_type_ == SHARD_BY_CORE);
             // We let tools know about idle time so they can analyze cpu usage.


### PR DESCRIPTION
Adds a 1ms sleep on a STATUS_WAIT in the drmemtrace analyzer when operating in parallel.  This avoids costly spinning in replay mode. Adding targeted condition variables inside the scheduler doesn't end up performing any better and is complicated by the scheduler not knowing the threading model of the user, so this is a safer and simpler solution despite not waiting on an event.

Tested on a medium-large internal trace where the spinning makes replaying as-traced take 7:35; with the sleep it takes 1:15.

Fixes #7044