### PR TITLE
i#6938 sched migrate: Add steals + rebalances to schedule stats

### DIFF
--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -16,6 +16,8 @@ Total counts:
            0 switches nop-ed
            0 quantum_preempts
            0 migrations
+           0 work steals
+           0 rebalances
          161 system calls
            2 maybe-blocking system calls
            0 direct switch requests

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -16,6 +16,8 @@ Total counts:
            0 switches nop-ed
            0 quantum_preempts
            0 migrations
+           0 work steals
+           1 rebalances
          161 system calls
            2 maybe-blocking system calls
            0 direct switch requests

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -160,6 +160,10 @@ schedule_stats_t::get_scheduler_stats(memtrace_stream_t *stream, counters_t &cou
         stream->get_schedule_statistic(memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS));
     counters.migrations = static_cast<int64_t>(
         stream->get_schedule_statistic(memtrace_stream_t::SCHED_STAT_MIGRATIONS));
+    counters.steals = static_cast<int64_t>(
+        stream->get_schedule_statistic(memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS));
+    counters.rebalances = static_cast<int64_t>(stream->get_schedule_statistic(
+        memtrace_stream_t::SCHED_STAT_RUNQUEUE_REBALANCES));
 
     // XXX: Currently, schedule_stats is measuring swap-ins to a real input.  If we
     // want to match what "perf" targeting this app would record, which is swap-outs,
@@ -417,6 +421,8 @@ schedule_stats_t::print_counters(const counters_t &counters)
     std::cerr << std::setw(12) << counters.switches_nop << " switches nop-ed\n";
     std::cerr << std::setw(12) << counters.quantum_preempts << " quantum_preempts\n";
     std::cerr << std::setw(12) << counters.migrations << " migrations\n";
+    std::cerr << std::setw(12) << counters.steals << " work steals\n";
+    std::cerr << std::setw(12) << counters.rebalances << " rebalances\n";
 
     std::cerr << std::setw(12) << counters.syscalls << " system calls\n";
     std::cerr << std::setw(12) << counters.maybe_blocking_syscalls

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -147,6 +147,8 @@ public:
             switches_nop += rhs.switches_nop;
             quantum_preempts += rhs.quantum_preempts;
             migrations += rhs.migrations;
+            steals += rhs.steals;
+            rebalances += rhs.rebalances;
             instrs += rhs.instrs;
             total_switches += rhs.total_switches;
             voluntary_switches += rhs.voluntary_switches;
@@ -173,6 +175,8 @@ public:
         int64_t switches_nop = 0;
         int64_t quantum_preempts = 0;
         int64_t migrations = 0;
+        int64_t steals = 0;
+        int64_t rebalances = 0;
         // Our own statistics.
         int64_t instrs = 0;
         int64_t total_switches = 0;


### PR DESCRIPTION
Adds two statistics reported by the scheduler to the schedule_stats report: work steals and rebalances.

Tests that something is printed out, but checks of the actual values are left to existing scheduler tests.

Issue: #6938