### PR TITLE
i#6938 sched migrate: Add observed migrations to schedule stats

### DIFF
--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -19,6 +19,7 @@ Total counts:
          161 system calls
            2 maybe-blocking system calls
            0 direct switch requests
+           0 observed migrations
            0 waits
       345686 idles
        64.89% cpu busy by record count

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -19,6 +19,7 @@ Total counts:
          161 system calls
            2 maybe-blocking system calls
            0 direct switch requests
+           0 observed migrations
            0 waits
     *[0-9]* idles
       *[0-9\.]*% cpu busy by record count

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -499,7 +499,7 @@ schedule_stats_t::aggregate_results(counters_t &total)
             memtrace_stream_t::SCHED_STAT_MIGRATIONS);
 #endif
         assert(sched_migrations == 0. ||
-               sched_migrations > shard.second->counters.observed_migrations);
+               sched_migrations >= shard.second->counters.observed_migrations);
     }
 }
 

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -495,10 +495,10 @@ schedule_stats_t::aggregate_results(counters_t &total)
         // If the scheduler is counting migrations, it may see more due to inputs
         // not yet executed moving among runqueues.
 #ifndef NDEBUG
-        int64_t sched_migrations = shard.second->stream->get_schedule_statistic(
+        double sched_migrations = shard.second->stream->get_schedule_statistic(
             memtrace_stream_t::SCHED_STAT_MIGRATIONS);
 #endif
-        assert(sched_migrations == 0 ||
+        assert(sched_migrations == 0. ||
                sched_migrations > shard.second->counters.observed_migrations);
     }
 }

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -224,7 +224,8 @@ public:
         std::size_t
         operator()(const workload_tid_t &wt) const
         {
-            return std::hash<int>()(wt.workload_id) ^ std::hash<memref_tid_t>()(wt.tid);
+            return std::hash<size_t>()(wt.workload_id) ^
+                std::hash<memref_tid_t>()(wt.tid);
         }
     };
 

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -230,7 +230,7 @@ public:
         {
             // Ensure {workload_id=X, tid=Y} doesn't always hash the same as
             // {workload_id=Y, tid=X} by avoiding a simple symmetric wid^tid.
-            return std::hash<size_t>()(wt.workload_id ^ wt.tid) ^
+            return std::hash<size_t>()(static_cast<size_t>(wt.workload_id ^ wt.tid)) ^
                 std::hash<memref_tid_t>()(wt.tid);
         }
     };

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -224,7 +224,9 @@ public:
         std::size_t
         operator()(const workload_tid_t &wt) const
         {
-            return std::hash<size_t>()(wt.workload_id) ^
+            // Ensure {workload_id=X, tid=Y} doesn't always hash the same as
+            // {workload_id=Y, tid=X} by avoiding a simple symmetric wid^tid.
+            return std::hash<size_t>()(wt.workload_id ^ wt.tid) ^
                 std::hash<memref_tid_t>()(wt.tid);
         }
     };


### PR DESCRIPTION
While the schedule_stats tool already reports the migration count from the scheduler, that is only non-zero for a dynamic schedule, resulting in 0 for core-sharded-on-disk traces.  We add "observed migrations" where schedule_stats looks for migrations on its own.  This requires a global lock on each context switch, but experimental results show that this does not seem to cause noticeable overhead.

Adds some testing.

Issue: #6938