### PR TITLE
Update changelist and download for 11.0 release

### DIFF
--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -50,7 +50,19 @@ The source code is available:
 
 For the very latest changes since the last official release, you can download \ref page_weekly_builds.
 
-The [10.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_10.0.0):
+The [11.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.0.0):
+
+  - [DynamoRIO-Windows-11.0.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-Windows-11.0.0.zip)
+
+  - [DynamoRIO-Linux-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-Linux-11.0.0.tar.gz)
+
+  - [DynamoRIO-ARM-Linux-EABIHF-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-ARM-Linux-EABIHF-11.0.0.tar.gz)
+
+  - [DynamoRIO-ARM-Android-EABI-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-ARM-Android-EABI-11.0.0.tar.gz)
+
+  - [DynamoRIO-AArch64-Linux-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-AArch64-Linux-11.0.0.tar.gz)
+
+The prior [10.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_10.0.0):
 
   - [DynamoRIO-Windows-10.0.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-Windows-10.0.0.zip)
 
@@ -61,18 +73,6 @@ The [10.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release
   - [DynamoRIO-ARM-Android-EABI-10.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-ARM-Android-EABI-10.0.0.tar.gz)
 
   - [DynamoRIO-AArch64-Linux-10.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_10.0.0/DynamoRIO-AArch64-Linux-10.0.0.tar.gz)
-
-The prior [9.0.1 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_9.0.1):
-
-  - [DynamoRIO-Windows-9.0.1.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-Windows-9.0.1.zip)
-
-  - [DynamoRIO-Linux-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-Linux-9.0.1.tar.gz)
-
-  - [DynamoRIO-ARM-Linux-EABIHF-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-ARM-Linux-EABIHF-9.0.1.tar.gz)
-
-  - [DynamoRIO-ARM-Android-EABI-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-ARM-Android-EABI-9.0.1.tar.gz)
-
-  - [DynamoRIO-AArch64-Linux-9.0.1.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_9.0.1/DynamoRIO-AArch64-Linux-9.0.1.tar.gz)
 
 
 ***************************************************************************

--- a/api/docs/new_release.dox
+++ b/api/docs/new_release.dox
@@ -90,7 +90,7 @@ Once the build is finished and posted to https://github.com/DynamoRIO/dynamorio/
 
 Also point at the changelog, as was done in this past release:
 
-https://github.com/DynamoRIO/dynamorio/releases/tag/release_10.0.0
+https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.0.0
 
 We generally edit the title to simplify it: e.g., from `release_8.0.0-1` to just `8.0.0`.
 

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -124,8 +124,17 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
-The changes between version \DR_VERSION and 10.0.0 include the following compatibility
+The changes between version \DR_VERSION and 11.0.0 include the following compatibility
 changes:
+ - No compatibility changes.
+
+Further non-compatibility-affecting changes include:
+ - No changes yet.
+
+**************************************************
+<hr>
+
+The changes between version 11.0.0 and 10.0.0 include the following compatibility
  - Marked x86 rep instructions as predicated.
  - The #dr_instr_category_t enum underwent changes to support new categories
    such as STATE, MOVE, CONVERT, and MATH.


### PR DESCRIPTION
The 11.0.0 release is now official so we update the download page for the new version and prepare the changelist for subsequent releases.