### PR TITLE
Fix typo in changelist

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -135,6 +135,7 @@ Further non-compatibility-affecting changes include:
 <hr>
 
 The changes between version 11.0.0 and 10.0.0 include the following compatibility
+changes:
  - Marked x86 rep instructions as predicated.
  - The #dr_instr_category_t enum underwent changes to support new categories
    such as STATE, MOVE, CONVERT, and MATH.


### PR DESCRIPTION
Restores the word "changes:" which was accidentally removed in PR #7066.