### PR TITLE
i#7046: clang-tidy: Clean up headers to include what is used by coredump.c and instrument.c.

### DIFF
--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -63,9 +63,6 @@
 #ifdef UNIX
 #    include <sys/time.h>       /* ITIMER_* */
 #    include "../unix/module.h" /* redirect_* functions */
-#    include "../unix/os_exports.h"
-#elif defined(WINDOWS)
-#    include "../win32/os_exports.h"
 #endif
 
 /* in utils.c, not exported to everyone */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -48,6 +48,7 @@
 #include "instrlist.h"
 #include "decode.h"
 #include "disassemble.h"
+#include "dr_tools.h"
 #include "ir_utils.h"
 #include "../fragment.h"
 #include "../fcache.h"
@@ -62,6 +63,9 @@
 #ifdef UNIX
 #    include <sys/time.h>       /* ITIMER_* */
 #    include "../unix/module.h" /* redirect_* functions */
+#    include "../unix/os_exports.h"
+#elif defined(WINDOWS)
+#    include "../win32/os_export.h"
 #endif
 
 /* in utils.c, not exported to everyone */

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -65,7 +65,7 @@
 #    include "../unix/module.h" /* redirect_* functions */
 #    include "../unix/os_exports.h"
 #elif defined(WINDOWS)
-#    include "../win32/os_export.h"
+#    include "../win32/os_exports.h"
 #endif
 
 /* in utils.c, not exported to everyone */

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -27,13 +27,16 @@
  */
 
 #include <elf.h>
+#include <stddef.h>
 #include <sys/mman.h>
 #include "../globals.h"
 
 #include "../hashtable.h"
 #include "../os_shared.h"
 #include "../synch.h"
-#include "dr_tools.h"
+#include "../utils.h"
+#include "../lib/globals_api.h"
+#include "../lib/globals_shared.h"
 #include "elf_defines.h"
 #include "memquery.h"
 


### PR DESCRIPTION
Clean up include files in core/lib/instrument.c and core/unix/coredump.c.

Issue: #7046 