### PR TITLE
i#4103 clang-tidy: Mark hierarchical headers for IWYU

### DIFF
--- a/core/globals.h
+++ b/core/globals.h
@@ -42,7 +42,7 @@
 #ifndef _GLOBALS_H_
 #define _GLOBALS_H_ 1
 
-#include "configure.h"
+#include "configure.h" // IWYU pragma: export
 
 #ifdef WINDOWS
 /* Vista SDK compiler default is to set NTDDI_VERSION to NTDDI_LONGHORN, causing
@@ -90,7 +90,7 @@
 
 #endif
 
-#include "globals_shared.h"
+#include "globals_shared.h" // IWYU pragma: export
 
 /* currently we always export statistics structure */
 #define DYNAMORIO_STATS_EXPORTS 1
@@ -291,7 +291,7 @@ typedef struct _thread_record_t {
 /* We don't include dr_api.h, that's for external use. */
 #ifdef DR_APP_EXPORTS
 /* we only export app interface if DR_APP_EXPORTS is defined */
-#    include "dr_app.h"
+#    include "dr_app.h" // IWYU pragma: export
 /* a few always-exported routines are part of the app interface */
 #    undef DYNAMORIO_EXPORT
 #    define DYNAMORIO_EXPORT DR_APP_API
@@ -307,18 +307,18 @@ typedef struct _thread_record_t {
  */
 extern int vector_length;
 
-#include "heap.h"
-#include "options_struct.h"
-#include "utils.h"
-#include "options.h"
-#include "os_exports.h"
-#include "arch_exports.h"
-#include "drlibc.h"
-#include "vmareas.h"
-#include "instrlist.h"
-#include "dispatch.h"
+#include "heap.h"           // IWYU pragma: export
+#include "options_struct.h" // IWYU pragma: export
+#include "utils.h"          // IWYU pragma: export
+#include "options.h"        // IWYU pragma: export
+#include "os_exports.h"     // IWYU pragma: export
+#include "arch_exports.h"   // IWYU pragma: export
+#include "drlibc.h"         // IWYU pragma: export
+#include "vmareas.h"        // IWYU pragma: export
+#include "instrlist.h"      // IWYU pragma: export
+#include "dispatch.h"       // IWYU pragma: export
 
-#include "dr_stats.h"
+#include "dr_stats.h" // IWYU pragma: export
 
 /* did the client request a premature exit at a potentially awkward spot
  * (nudge handler, signal handler)?

--- a/core/ir/instr_create_shared_api.h
+++ b/core/ir/instr_create_shared_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -44,17 +44,17 @@
 
 #ifndef DYNAMORIO_INTERNAL
 #    ifdef X86
-#        include "dr_ir_macros_x86.h"
+#        include "dr_ir_macros_x86.h" // IWYU pragma: export
 #    elif defined(AARCH64)
-#        include "dr_ir_macros_aarch64.h"
+#        include "dr_ir_macros_aarch64.h" // IWYU pragma: export
 #    elif defined(ARM)
-#        include "dr_ir_macros_arm.h"
+#        include "dr_ir_macros_arm.h" // IWYU pragma: export
 #    elif defined(RISCV64)
-#        include "dr_ir_macros_riscv64.h"
+#        include "dr_ir_macros_riscv64.h" // IWYU pragma: export
 #    endif
-#    include "dr_ir_opnd.h"
-#    include "dr_ir_instr.h"
-#    include "dr_ir_utils.h"
+#    include "dr_ir_opnd.h"  // IWYU pragma: export
+#    include "dr_ir_instr.h" // IWYU pragma: export
+#    include "dr_ir_utils.h" // IWYU pragma: export
 #endif
 #include <limits.h> /* For SCHAR_MAX, SCHAR_MIN. */
 

--- a/core/lib/dr_api.h
+++ b/core/lib/dr_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -44,62 +44,62 @@ extern "C" {
 #endif
 
 /* Defines and type definitions */
-#include "dr_defines.h"
+#include "dr_defines.h" // IWYU pragma: export
 
 /* Event registration routines */
-#include "dr_events.h"
+#include "dr_events.h" // IWYU pragma: export
 
 /* Application start/stop interface */
-#include "dr_app.h"
+#include "dr_app.h" // IWYU pragma: export
 
 /* opnd_t (instruction operand) routines */
-#include "dr_ir_opnd.h"
+#include "dr_ir_opnd.h" // IWYU pragma: export
 
 /* Application module (library) information. */
-#include "dr_modules.h"
+#include "dr_modules.h" // IWYU pragma: export
 
 /* Operating-system-specific queries. */
-#include "dr_os_utils.h"
+#include "dr_os_utils.h" // IWYU pragma: export
 
 /* High-level routines: memory allocation, mutex support, file
  * support, printing, thread support, adaptive optimization,
  * custom traces, processor-specific utilities, trace dumping.
  */
-#include "dr_tools.h"
+#include "dr_tools.h" // IWYU pragma: export
 
 /* Utility routines for identifying features of the processor. */
-#include "dr_proc.h"
+#include "dr_proc.h" // IWYU pragma: export
 
 /* Encoding routines. */
-#include "dr_ir_encode.h"
+#include "dr_ir_encode.h" // IWYU pragma: export
 
 /* instr_t routines */
-#include "dr_ir_instr.h"
-#include "dr_ir_instr_inline.h"
+#include "dr_ir_instr.h"        // IWYU pragma: export
+#include "dr_ir_instr_inline.h" // IWYU pragma: export
 
 /* Decoding routines. */
-#include "dr_ir_decode.h"
+#include "dr_ir_decode.h" // IWYU pragma: export
 
 /* Disassembly routines. */
-#include "dr_ir_disassemble.h"
+#include "dr_ir_disassemble.h" // IWYU pragma: export
 
 /* Instrumentation support */
-#include "dr_ir_utils.h"
+#include "dr_ir_utils.h" // IWYU pragma: export
 
 /* instrlist_t routines */
-#include "dr_ir_instrlist.h"
+#include "dr_ir_instrlist.h" // IWYU pragma: export
 
 /* opcode OP_ constants and opcode-only routines */
-#include "dr_ir_opcodes.h"
+#include "dr_ir_opcodes.h" // IWYU pragma: export
 
 /* CREATE_INSTR_ macros */
-#include "dr_ir_macros.h"
+#include "dr_ir_macros.h" // IWYU pragma: export
 
 /* Binary trace dump format. */
-#include "dr_tracedump.h"
+#include "dr_tracedump.h" // IWYU pragma: export
 
 /* Annotation handler registration routines */
-#include "dr_annotation.h"
+#include "dr_annotation.h" // IWYU pragma: export
 
 #ifndef DYNAMORIO_STANDALONE
 /**

--- a/core/lib/globals_shared.h
+++ b/core/lib/globals_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -74,14 +74,14 @@
 #    define RISCV_64
 #endif
 
-#include "globals_api.h"
+#include "globals_api.h" // IWYU pragma: export
 
 #include <limits.h> /* for USHRT_MAX */
 #ifdef UNIX
 #    include <signal.h>
 #endif
 
-#include "c_defines.h"
+#include "c_defines.h" // IWYU pragma: export
 
 #ifdef X64
 #    define POINTER_MAX ULLONG_MAX
@@ -954,9 +954,9 @@ typedef struct {
     uint flags : 2;
     int ignored2; /* siginfo_t.si_code: has meaning to kernel so we avoid using */
 #else
-    uint version;                   /* version number for future proofing */
-    uint nudge_action_mask;         /* drawn from NUDGE_DEFS above */
-    uint flags;                     /* flags drawn from above enum */
+    uint version;           /* version number for future proofing */
+    uint nudge_action_mask; /* drawn from NUDGE_DEFS above */
+    uint flags;             /* flags drawn from above enum */
 #endif
     client_id_t client_id; /* unique ID identifying client */
     uint64 client_arg;     /* argument for a client nudge */
@@ -988,7 +988,7 @@ typedef struct {
  */
 #    define HOTP_POLICY_ID_LENGTH 9
 
-#    include "probe_api.h"
+#    include "probe_api.h" // IWYU pragma: export
 
 typedef dr_probe_status_t hotp_inject_status_t;
 
@@ -1103,7 +1103,7 @@ enum {
 
 /* Internal machine context structure */
 typedef struct _priv_mcontext_t {
-#include "mcxtx_api.h"
+#include "mcxtx_api.h" // IWYU pragma: export
 } priv_mcontext_t;
 
 #endif /* _GLOBALS_SHARED_H_ */

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -43,8 +43,8 @@
 #define _OS_EXPORTS_H_ 1
 
 #include <stdarg.h>
-#include "../os_shared.h"
-#include "os_public.h"
+#include "../os_shared.h" // IWYU pragma: export
+#include "os_public.h"    // IWYU pragma: export
 /* arch_exports.h exports opnd.h, but relies on kernel_sigset_t from this header.
  * We thus directly include opnd.h here for reg_id_t to resolve the circular
  * dependence (cleaner than having to use ushort instead of reg_id_t).

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -42,8 +42,8 @@
 #ifndef _OS_EXPORTS_H_
 #define _OS_EXPORTS_H_ 1
 
-#include "os_public.h"
-#include "../os_shared.h"
+#include "os_public.h"    // IWYU pragma: export
+#include "../os_shared.h" // IWYU pragma: export
 #include "arch_exports.h" /* for priv_mcontext_t */
 #include "aslr.h"         /* for aslr_context */
 


### PR DESCRIPTION
Adds clang-tidy annotations to the deliberately hierarchical headers in core DR where one header is meant to include a set of other headers.  This avoids clang-tidy Include What You Use complaints which can cause users to include individual sub-headers, which sometimes have ordering constraints if the top-level header is not included first (or solely).

Issue: #4103