### PR TITLE
i#6624: Warn instead of ASSERT for unexpected SP value.

### DIFF
--- a/core/vmareas.c
+++ b/core/vmareas.c
@@ -3910,7 +3910,8 @@ is_on_stack(dcontext_t *dcontext, app_pc pc, vm_area_t *area)
         ok = get_memory_info(esp, &esp_base, &size, NULL);
         if (!ok) {
             /* This can happen with dr_prepopulate_cache(). */
-            ASSERT(!dynamo_started);
+            if (dynamo_started)
+                SYSLOG_INTERNAL_WARNING("Stack pointer has unexpected value");
             return false;
         }
         LOG(THREAD, LOG_VMAREAS, 3,


### PR DESCRIPTION
Downgrades an assert in vmareas.c:is_on_stack() on a bad stack pointer to a warning, as this is just a surprising application state and nothing DR can't handle.

Fixes #6624