### PR TITLE
i#6831 sched refactor, step 5: Add missing includes

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -35,7 +35,18 @@
 #include "scheduler.h"
 #include "scheduler_impl.h"
 
+#include <atomic>
 #include <cinttypes>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "mutex_dbg_owned.h"
+#include "reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/scheduler/scheduler_fixed.cpp
+++ b/clients/drcachesim/scheduler/scheduler_fixed.cpp
@@ -35,7 +35,17 @@
 #include "scheduler.h"
 #include "scheduler_impl.h"
 
+#include <atomic>
 #include <cinttypes>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#include "memref.h"
+#include "mutex_dbg_owned.h"
+#include "reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "scheduler.h"
+#include "scheduler_impl.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -61,7 +62,6 @@
 #include "mutex_dbg_owned.h"
 #include "reader.h"
 #include "record_file_reader.h"
-#include "scheduler_impl.h"
 #include "trace_entry.h"
 #ifdef HAS_LZ4
 #    include "lz4_file_reader.h"

--- a/clients/drcachesim/scheduler/scheduler_replay.cpp
+++ b/clients/drcachesim/scheduler/scheduler_replay.cpp
@@ -35,7 +35,17 @@
 #include "scheduler.h"
 #include "scheduler_impl.h"
 
+#include <atomic>
 #include <cinttypes>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+#include "memref.h"
+#include "mutex_dbg_owned.h"
+#include "reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {


### PR DESCRIPTION
Adds used include files to the 3 scheduler subclasses that were omitted when new overrides were added in step 3.

Issue: #6831