### PR TITLE
i#7084: Change handle_rseq_abort_marker parameter name interrupted to rseq_aborted.

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1510,7 +1510,7 @@ private:
     bool
     handle_rseq_abort_marker(raw2trace_thread_data_t *tdata,
                              DR_PARAM_INOUT trace_entry_t **buf_in, uint64_t cur_pc,
-                             uint64_t cur_offs, DR_PARAM_OUT bool *interrupted);
+                             uint64_t cur_offs, DR_PARAM_OUT bool *rseq_aborted);
 
     bool
     get_marker_value(raw2trace_thread_data_t *tdata,


### PR DESCRIPTION
raw2trace_t::handle_rseq_abort_marker() uses different names of the last parameter. It's interrupted in raw2trace.h
but it is rseq_aborted in raw2trace.cpp.

Change the name from interrupted to rseq_aborted to be consistent with raw2trace.cpp.

The inconsistency was introduced by PR #7058.

Fixes: https://github.com/DynamoRIO/dynamorio/issues/7084