### PR TITLE
i#7044 sched deadlock: Fix theoretical deadlock

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2292,7 +2292,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
         // straightforward).
         if (options_.mapping == sched_type_t::MAP_TO_ANY_OUTPUT && prev_input != input &&
             !inputs_[prev_input].at_eof) {
-            // This is unsafe if the caller holds this input lock: we disallow it.
+            // The caller should never hold the input lock for MAP_TO_ANY_OUTPUT.
             assert(!caller_holds_cur_input_lock);
             add_to_ready_queue(output, &inputs_[prev_input]);
         }

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2313,7 +2313,11 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
 
     int prev_workload = -1;
     if (outputs_[output].prev_input >= 0 && outputs_[output].prev_input != input) {
-        std::lock_guard<mutex_dbg_owned> lock(*inputs_[outputs_[output].prev_input].lock);
+        auto scoped_lock =
+            (caller_holds_cur_input_lock && prev_input == outputs_[output].prev_input)
+            ? std::unique_lock<mutex_dbg_owned>()
+            : std::unique_lock<mutex_dbg_owned>(
+                  *inputs_[outputs_[output].prev_input].lock);
         prev_workload = inputs_[outputs_[output].prev_input].workload;
     }
 

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2292,6 +2292,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
         // straightforward).
         if (options_.mapping == sched_type_t::MAP_TO_ANY_OUTPUT && prev_input != input &&
             !inputs_[prev_input].at_eof) {
+            // This is unsafe if the caller holds this input lock: we disallow it.
+            assert(!caller_holds_cur_input_lock);
             add_to_ready_queue(output, &inputs_[prev_input]);
         }
     } else if (options_.schedule_record_ostream != nullptr &&

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2315,6 +2315,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
 
     int prev_workload = -1;
     if (outputs_[output].prev_input >= 0 && outputs_[output].prev_input != input) {
+        // If the caller already holds the lock, do not re-acquire as that will hang.
         auto scoped_lock =
             (caller_holds_cur_input_lock && prev_input == outputs_[output].prev_input)
             ? std::unique_lock<mutex_dbg_owned>()

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -751,7 +751,8 @@ protected:
 
     // The caller cannot hold the output or input lock.
     // The caller can hold the output's current input's lock but must pass
-    // true for the 3rd parameter in that case.
+    // true for the 3rd parameter in that case; holding the lock is not
+    // allowed for MAP_TO_ANY_OUTPUT.
     stream_status_t
     set_cur_input(output_ordinal_t output, input_ordinal_t input,
                   bool caller_holds_cur_input_lock = false);


### PR DESCRIPTION
Adds a check for the caller holding the previous input's lock before acquiring it to retrieve the previous workload.  The existing code acquired the new lock without checking caller_holds_cur_input_lock, which could hang (it happened not to because the only caller who sets caller_holds_cur_input_lock to true set the current input to invalid and set_cur_input() returns prior to this point).

Issue: #7044