### PR TITLE
i#6831 sched refactor: Add set_cur_input() hooks

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_fixed.cpp
+++ b/clients/drcachesim/scheduler/scheduler_fixed.cpp
@@ -99,6 +99,23 @@ scheduler_fixed_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_fixed_tmpl_t<RecordType, ReaderType>::swap_out_input(
+    output_ordinal_t output, input_ordinal_t input, int workload,
+    bool caller_holds_input_lock)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_fixed_tmpl_t<RecordType, ReaderType>::swap_in_input(output_ordinal_t output,
+                                                              input_ordinal_t input)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_fixed_tmpl_t<RecordType, ReaderType>::pick_next_input_for_mode(
     output_ordinal_t output, uint64_t blocked_time, input_ordinal_t prev_index,
     input_ordinal_t &index)

--- a/clients/drcachesim/scheduler/scheduler_fixed.cpp
+++ b/clients/drcachesim/scheduler/scheduler_fixed.cpp
@@ -100,8 +100,7 @@ scheduler_fixed_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_fixed_tmpl_t<RecordType, ReaderType>::swap_out_input(
-    output_ordinal_t output, input_ordinal_t input, int workload,
-    bool caller_holds_input_lock)
+    output_ordinal_t output, input_ordinal_t input, bool caller_holds_input_lock)
 {
     return sched_type_t::STATUS_OK;
 }

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -663,12 +663,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::~scheduler_impl_tmpl_t()
                outputs_[i].ready_queue.lock->get_count_contended());
 #endif
     }
-#ifndef NDEBUG
-    VPRINT(this, 1, "%-37s: %9" PRId64 "\n", "Unscheduled queue lock acquired",
-           unscheduled_priority_.lock->get_count_acquired());
-    VPRINT(this, 1, "%-37s: %9" PRId64 "\n", "Unscheduled queue lock contended",
-           unscheduled_priority_.lock->get_count_contended());
-#endif
 }
 
 template <typename RecordType, typename ReaderType>
@@ -2185,63 +2179,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::close_schedule_segment(
 }
 
 template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::add_to_unscheduled_queue(
-    input_info_t *input)
-{
-    assert(input->lock->owned_by_cur_thread());
-    std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
-    assert(input->unscheduled &&
-           input->blocked_time == 0); // Else should be in regular queue.
-    VPRINT(this, 4, "add_to_unscheduled_queue (pre-size %zu): input %d priority %d\n",
-           unscheduled_priority_.queue.size(), input->index, input->priority);
-    input->queue_counter = ++unscheduled_priority_.fifo_counter;
-    unscheduled_priority_.queue.push(input);
-    input->prev_output = input->containing_output;
-    input->containing_output = sched_type_t::INVALID_INPUT_ORDINAL;
-}
-
-template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::add_to_ready_queue_hold_locks(
-    output_ordinal_t output, input_info_t *input)
-{
-    assert(input->lock->owned_by_cur_thread());
-    assert(!need_output_lock() ||
-           outputs_[output].ready_queue.lock->owned_by_cur_thread());
-    if (input->unscheduled && input->blocked_time == 0) {
-        // Ensure we get prev_output set for start-unscheduled so they won't
-        // all resume on output #0 but rather on the initial round-robin assignment.
-        input->containing_output = output;
-        add_to_unscheduled_queue(input);
-        return;
-    }
-    assert(input->binding.empty() || input->binding.find(output) != input->binding.end());
-    VPRINT(
-        this, 4,
-        "add_to_ready_queue (pre-size %zu): input %d priority %d timestamp delta %" PRIu64
-        " block time %" PRIu64 " start time %" PRIu64 "\n",
-        outputs_[output].ready_queue.queue.size(), input->index, input->priority,
-        input->reader->get_last_timestamp() - input->base_timestamp, input->blocked_time,
-        input->blocked_start_time);
-    if (input->blocked_time > 0)
-        ++outputs_[output].ready_queue.num_blocked;
-    input->queue_counter = ++outputs_[output].ready_queue.fifo_counter;
-    outputs_[output].ready_queue.queue.push(input);
-    input->containing_output = output;
-}
-
-template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(output_ordinal_t output,
-                                                                  input_info_t *input)
-{
-    auto scoped_lock = acquire_scoped_output_lock_if_necessary(output);
-    std::lock_guard<mutex_dbg_owned> input_lock(*input->lock);
-    add_to_ready_queue_hold_locks(output, input);
-}
-
-template <typename RecordType, typename ReaderType>
 uint64_t
 scheduler_impl_tmpl_t<RecordType, ReaderType>::scale_blocked_time(
     uint64_t initial_time) const
@@ -2270,31 +2207,34 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
     assert(output >= 0 && output < static_cast<output_ordinal_t>(outputs_.size()));
     // 'input' might be sched_type_t::INVALID_INPUT_ORDINAL.
     assert(input < static_cast<input_ordinal_t>(inputs_.size()));
+    // The caller should never hold the input lock for MAP_TO_ANY_OUTPUT.
+    assert(options_.mapping != sched_type_t::MAP_TO_ANY_OUTPUT ||
+           !caller_holds_cur_input_lock);
     int prev_input = outputs_[output].cur_input;
     if (prev_input >= 0) {
         if (prev_input != input) {
             input_info_t &prev_info = inputs_[prev_input];
-            auto scoped_lock = caller_holds_cur_input_lock
-                ? std::unique_lock<mutex_dbg_owned>()
-                : std::unique_lock<mutex_dbg_owned>(*prev_info.lock);
-            prev_info.cur_output = sched_type_t::INVALID_OUTPUT_ORDINAL;
-            prev_info.last_run_time = get_output_time(output);
-            if (options_.schedule_record_ostream != nullptr) {
-                stream_status_t status = close_schedule_segment(output, prev_info);
-                if (status != sched_type_t::STATUS_OK)
-                    return status;
+            // This is different from prev_workload below: that waits for a valid
+            // new workload (so swap-in trigger).
+            int workload = -1;
+            {
+                auto scoped_lock = caller_holds_cur_input_lock
+                    ? std::unique_lock<mutex_dbg_owned>()
+                    : std::unique_lock<mutex_dbg_owned>(*prev_info.lock);
+                prev_info.cur_output = sched_type_t::INVALID_OUTPUT_ORDINAL;
+                prev_info.last_run_time = get_output_time(output);
+                if (options_.schedule_record_ostream != nullptr) {
+                    stream_status_t status = close_schedule_segment(output, prev_info);
+                    if (status != sched_type_t::STATUS_OK)
+                        return status;
+                }
+                workload = prev_info.workload;
             }
-        }
-        // Now that we've updated prev_info, add it to the ready queue (once on the
-        // queues others can see it and pop it off, though they can't access/modify its
-        // fields (for identifying if it can be migrated, e.g.) until we release the
-        // input lock, so it should be safe to add first, but this order is more
-        // straightforward).
-        if (options_.mapping == sched_type_t::MAP_TO_ANY_OUTPUT && prev_input != input &&
-            !inputs_[prev_input].at_eof) {
-            // The caller should never hold the input lock for MAP_TO_ANY_OUTPUT.
-            assert(!caller_holds_cur_input_lock);
-            add_to_ready_queue(output, &inputs_[prev_input]);
+            // Let subclasses act on the outgoing input.
+            stream_status_t res =
+                swap_out_input(output, prev_input, workload, caller_holds_cur_input_lock);
+            if (res != sched_type_t::STATUS_OK)
+                return res;
         }
     } else if (options_.schedule_record_ostream != nullptr &&
                (outputs_[output].record.back().type == schedule_record_t::IDLE ||
@@ -2398,6 +2338,12 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
                 return status;
         }
     }
+
+    // Let subclasses act on the incoming input.
+    stream_status_t res = swap_in_input(output, input);
+    if (res != sched_type_t::STATUS_OK)
+        return res;
+
     return sched_type_t::STATUS_OK;
 }
 
@@ -2425,19 +2371,6 @@ typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_impl_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t output,
                                                                uint64_t blocked_time)
 {
-    VDO(this, 1, {
-        static int64_t global_heartbeat;
-        // 10K is too frequent for simple analyzer runs: it is too noisy with
-        // the new core-sharded-by-default for new users using defaults.
-        // 50K is a reasonable compromise.
-        // XXX: Add a runtime option to tweak this.
-        static constexpr int64_t GLOBAL_HEARTBEAT_CADENCE = 50000;
-        // We are ok with races as the cadence is approximate.
-        if (++global_heartbeat % GLOBAL_HEARTBEAT_CADENCE == 0) {
-            print_queue_stats();
-        }
-    });
-
     stream_status_t res = sched_type_t::STATUS_OK;
     const input_ordinal_t prev_index = outputs_[output].cur_input;
     input_ordinal_t index = sched_type_t::INVALID_INPUT_ORDINAL;
@@ -2932,46 +2865,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::get_statistic(
     if (stat >= memtrace_stream_t::SCHED_STAT_TYPE_COUNT)
         return -1;
     return static_cast<double>(outputs_[output].stats[stat]);
-}
-
-template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::print_queue_stats()
-{
-    size_t unsched_size = 0;
-    {
-        std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
-        unsched_size = unscheduled_priority_.queue.size();
-    }
-    int live = live_input_count_.load(std::memory_order_acquire);
-    // Make our multi-line output more atomic.
-    std::ostringstream ostr;
-    ostr << "Queue snapshot: inputs: " << live - unsched_size << " schedulable, "
-         << unsched_size << " unscheduled, " << inputs_.size() - live << " eof\n";
-    for (unsigned int i = 0; i < outputs_.size(); ++i) {
-        auto lock = acquire_scoped_output_lock_if_necessary(i);
-        uint64_t cur_time = get_output_time(i);
-        ostr << "  out #" << i << " @" << cur_time << ": running #"
-             << outputs_[i].cur_input << "; " << outputs_[i].ready_queue.queue.size()
-             << " in queue; " << outputs_[i].ready_queue.num_blocked << " blocked\n";
-        std::set<input_info_t *> readd;
-        input_info_t *res = nullptr;
-        while (!outputs_[i].ready_queue.queue.empty()) {
-            res = outputs_[i].ready_queue.queue.top();
-            readd.insert(res);
-            outputs_[i].ready_queue.queue.pop();
-            std::lock_guard<mutex_dbg_owned> input_lock(*res->lock);
-            if (res->blocked_time > 0) {
-                ostr << "    " << res->index << " still blocked for "
-                     << res->blocked_time - (cur_time - res->blocked_start_time) << "\n";
-            }
-        }
-        // Re-add the ones we skipped, but without changing their counters so we preserve
-        // the prior FIFO order.
-        for (input_info_t *add : readd)
-            outputs_[i].ready_queue.queue.push(add);
-    }
-    VPRINT(this, 0, "%s\n", ostr.str().c_str());
 }
 
 template class scheduler_impl_tmpl_t<memref_t, reader_t>;

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -247,6 +247,8 @@ protected:
         // The units are in simuilation time.
         uint64_t blocked_time = 0;
         uint64_t blocked_start_time = 0;
+        // XXX i#6831: Move fields like this to be specific to subclasses by changing
+        // inputs_ to a vector of unique_ptr and then subclassing input_info_t.
         // An input can be "unscheduled" and not on the ready_priority_ run queue at all
         // with an infinite timeout until directly targeted.  Such inputs are stored
         // in the unscheduled_priority_ queue.
@@ -383,28 +385,8 @@ protected:
     std::unique_lock<mutex_dbg_owned>
     acquire_scoped_output_lock_if_necessary(output_ordinal_t output);
 
-    // If input->unscheduled is true and input->blocked_time is 0, input
-    // is placed on the unscheduled_priority_ queue instead.
-    // The caller cannot hold the input's lock: this routine will acquire it.
-    void
-    add_to_ready_queue(output_ordinal_t output, input_info_t *input);
-
-    // Identical to add_to_ready_queue() except the output's lock must be held by the
-    // caller.
-    // The caller must also hold the input's lock.
-    void
-    add_to_ready_queue_hold_locks(output_ordinal_t output, input_info_t *input);
-
-    // The caller must hold the input's lock.
-    void
-    add_to_unscheduled_queue(input_info_t *input);
-
     uint64_t
     scale_blocked_time(uint64_t initial_time) const;
-
-    // Up to the caller to check verbosity before calling.
-    void
-    print_queue_stats();
 
     void
     update_switch_stats(output_ordinal_t output, input_ordinal_t prev_input,
@@ -451,6 +433,8 @@ protected:
         input_ordinal_t cur_input = sched_type_t::INVALID_INPUT_ORDINAL;
         // Holds the prior non-invalid input.
         input_ordinal_t prev_input = sched_type_t::INVALID_INPUT_ORDINAL;
+        // XXX i#6831: Move fields like this to be specific to subclasses by changing
+        // inputs_ to a vector of unique_ptr and then subclassing output_info_t.
         // For static schedules we can populate this up front and avoid needing a
         // lock for dynamically finding the next input, keeping things parallel.
         std::vector<input_ordinal_t> input_indices;
@@ -569,6 +553,21 @@ protected:
     // Should call set_cur_input() for all outputs with initial inputs.
     virtual scheduler_status_t
     set_initial_schedule(std::unordered_map<int, std::vector<int>> &workload2inputs) = 0;
+
+    // When an output's input changes from a valid (not INVALID_INPUT_ORDINAL) input to
+    // something else, swap_out_input() is called on the outgoing input (whose lock is
+    // held if "caller_holds_input_lock" is true; it will never be true for
+    // MAP_TO_ANY_OUTPUT).  This is called after the input's fields (such as cur_output
+    // and last_run_time) have been updated.
+    virtual stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) = 0;
+
+    // When an output's input changes to a valid (not INVALID_INPUT_ORDINAL) input
+    // different from the previous input, swap_in_input() is called on the incoming
+    // input (whose lock is always held by the caller).
+    virtual stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) = 0;
 
     // Allow subclasses to perform custom initial marker processing during
     // get_initial_input_content().  Returns whether to keep reading.
@@ -928,11 +927,6 @@ protected:
     // ready_queue-related plus record and record_index fields which are accessed under
     // the output's own lock.
     std::vector<output_info_t> outputs_;
-    // This lock protects unscheduled_priority_ and unscheduled_counter_.
-    // It should be acquired *after* both output or input locks: it is narrowmost.
-    mutex_dbg_owned unsched_lock_;
-    // Inputs that are unscheduled indefinitely until directly targeted.
-    input_queue_t unscheduled_priority_;
     // Count of inputs not yet at eof.
     std::atomic<int> live_input_count_;
     // In replay mode, count of outputs not yet at the end of the replay sequence.
@@ -995,6 +989,7 @@ public:
     {
         last_rebalance_time_.store(0, std::memory_order_relaxed);
     }
+    ~scheduler_dynamic_tmpl_t();
 
 private:
     using sched_type_t = scheduler_tmpl_t<RecordType, ReaderType>;
@@ -1008,11 +1003,11 @@ private:
     using
         typename scheduler_impl_tmpl_t<RecordType, ReaderType>::InputTimestampComparator;
     using typename scheduler_impl_tmpl_t<RecordType, ReaderType>::workload_tid_t;
+    using typename scheduler_impl_tmpl_t<RecordType, ReaderType>::input_queue_t;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::options_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::outputs_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::inputs_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::error_string_;
-    using scheduler_impl_tmpl_t<RecordType, ReaderType>::unscheduled_priority_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input;
     using scheduler_impl_tmpl_t<RecordType,
                                 ReaderType>::acquire_scoped_output_lock_if_necessary;
@@ -1023,6 +1018,12 @@ protected:
     scheduler_status_t
     set_initial_schedule(
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
+
+    stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override;
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
@@ -1058,6 +1059,22 @@ protected:
     bool
     ready_queue_empty(output_ordinal_t output);
 
+    // If input->unscheduled is true and input->blocked_time is 0, input
+    // is placed on the unscheduled_priority_ queue instead.
+    // The caller cannot hold the input's lock: this routine will acquire it.
+    void
+    add_to_ready_queue(output_ordinal_t output, input_info_t *input);
+
+    // Identical to add_to_ready_queue() except the output's lock must be held by the
+    // caller.
+    // The caller must also hold the input's lock.
+    void
+    add_to_ready_queue_hold_locks(output_ordinal_t output, input_info_t *input);
+
+    // The caller must hold the input's lock.
+    void
+    add_to_unscheduled_queue(input_info_t *input);
+
     // "for_output" is which output stream is looking for a new input; only an
     // input which is able to run on that output will be selected.
     // for_output can be INVALID_OUTPUT_ORDINAL, which will ignore bindings.
@@ -1073,9 +1090,18 @@ protected:
                                     output_ordinal_t for_output, input_info_t *&new_input,
                                     bool from_back = false);
 
+    // Up to the caller to check verbosity before calling.
+    void
+    print_queue_stats();
+
     // Rebalancing coordination.
     std::atomic<std::thread::id> rebalancer_;
     std::atomic<uint64_t> last_rebalance_time_;
+    // This lock protects unscheduled_priority_ and unscheduled_counter_.
+    // It should be acquired *after* both output or input locks: it is narrowmost.
+    mutex_dbg_owned unsched_lock_;
+    // Inputs that are unscheduled indefinitely until directly targeted.
+    input_queue_t unscheduled_priority_;
 };
 
 // Specialized code for replaying schedules: either a recorded dynamic schedule
@@ -1104,6 +1130,12 @@ protected:
     scheduler_status_t
     set_initial_schedule(
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
+
+    stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override;
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
@@ -1145,6 +1177,12 @@ protected:
     scheduler_status_t
     set_initial_schedule(
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
+
+    stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override;
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -554,18 +554,20 @@ protected:
     virtual scheduler_status_t
     set_initial_schedule(std::unordered_map<int, std::vector<int>> &workload2inputs) = 0;
 
-    // When an output's input changes from a valid (not INVALID_INPUT_ORDINAL) input to
-    // something else, swap_out_input() is called on the outgoing input (whose lock is
-    // held if "caller_holds_input_lock" is true; it will never be true for
-    // MAP_TO_ANY_OUTPUT).  This is called after the input's fields (such as cur_output
-    // and last_run_time) have been updated.
+    // When an output's input changes (whether between two valid inputs, from a valid to
+    // INVALID_INPUT_ORDINAL, or vice versa), swap_out_input() is called on the outgoing
+    // input (whose lock is held if "caller_holds_input_lock" is true; it will never be
+    // true for MAP_TO_ANY_OUTPUT).  This is called after the input's fields (such as
+    // cur_output and last_run_time) have been updated, if it was a valid input.
+    // This should return STATUS_OK if there is nothing to do; errors are propagated.
     virtual stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) = 0;
 
-    // When an output's input changes to a valid (not INVALID_INPUT_ORDINAL) input
+    // When an output's input changes (to a valid input or to INVALID_INPUT_ORDINAL)
     // different from the previous input, swap_in_input() is called on the incoming
-    // input (whose lock is always held by the caller).
+    // input (whose lock is always held by the caller, if a valid input).
+    // This should return STATUS_OK if there is nothing to do; errors are propagated.
     virtual stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) = 0;
 
@@ -1020,7 +1022,7 @@ protected:
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override;
     stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
@@ -1132,7 +1134,7 @@ protected:
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override;
     stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
@@ -1179,7 +1181,7 @@ protected:
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override;
     stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;

--- a/clients/drcachesim/scheduler/scheduler_replay.cpp
+++ b/clients/drcachesim/scheduler/scheduler_replay.cpp
@@ -299,8 +299,7 @@ scheduler_replay_tmpl_t<RecordType, ReaderType>::read_and_instantiate_traced_sch
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_replay_tmpl_t<RecordType, ReaderType>::swap_out_input(
-    output_ordinal_t output, input_ordinal_t input, int workload,
-    bool caller_holds_input_lock)
+    output_ordinal_t output, input_ordinal_t input, bool caller_holds_input_lock)
 {
     return sched_type_t::STATUS_OK;
 }

--- a/clients/drcachesim/scheduler/scheduler_replay.cpp
+++ b/clients/drcachesim/scheduler/scheduler_replay.cpp
@@ -298,6 +298,23 @@ scheduler_replay_tmpl_t<RecordType, ReaderType>::read_and_instantiate_traced_sch
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_replay_tmpl_t<RecordType, ReaderType>::swap_out_input(
+    output_ordinal_t output, input_ordinal_t input, int workload,
+    bool caller_holds_input_lock)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_replay_tmpl_t<RecordType, ReaderType>::swap_in_input(output_ordinal_t output,
+                                                               input_ordinal_t input)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_replay_tmpl_t<RecordType, ReaderType>::pick_next_input_for_mode(
     output_ordinal_t output, uint64_t blocked_time, input_ordinal_t prev_index,
     input_ordinal_t &index)

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -2976,7 +2976,7 @@ public:
         return sched_type_t::STATUS_ERROR_NOT_IMPLEMENTED;
     }
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override
     {
         return sched_type_t::STATUS_NOT_IMPLEMENTED;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -2976,6 +2976,17 @@ public:
         return sched_type_t::STATUS_ERROR_NOT_IMPLEMENTED;
     }
     stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override
+    {
+        return sched_type_t::STATUS_NOT_IMPLEMENTED;
+    }
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override
+    {
+        return sched_type_t::STATUS_NOT_IMPLEMENTED;
+    }
+    stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
                              input_ordinal_t prev_index, input_ordinal_t &index) override
     {


### PR DESCRIPTION
Adds swap_in_input() and swap_out_input() subclass hooks inside set_cur_input().  This allows moving ready queue functions into the dynamic subclass, and will be used there for future live workload tracking for #7067.

Moves add_to_ready_queue(), add_to_ready_queue_hold_locks(), add_to_unscheduled_queue(), and print_queue_stats() into the dynamic subclass.

Issue: #7067, #6831