### PR TITLE
i#7067: Add per-workload simultaneous output limits

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -384,7 +384,8 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t(
     // The scheduler will call reader_t::init() for each input file.  We assume
     // that won't block (analyzer_multi_t separates out IPC readers).
     typename sched_type_t::scheduler_options_t sched_ops;
-    if (!init_scheduler(trace_path, {}, {}, 0, verbosity, std::move(sched_ops))) {
+    if (!init_scheduler(trace_path, {}, {}, /*output_limit=*/0, verbosity,
+                        std::move(sched_ops))) {
         success_ = false;
         error_string_ = "Failed to create scheduler";
         return;

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -230,7 +230,7 @@ template <typename RecordType, typename ReaderType>
 bool
 analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
     const std::string &trace_path, const std::set<memref_tid_t> &only_threads,
-    const std::set<int> &only_shards, int verbosity,
+    const std::set<int> &only_shards, int output_limit, int verbosity,
     typename sched_type_t::scheduler_options_t options)
 {
     verbosity_ = verbosity;
@@ -249,6 +249,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
     typename sched_type_t::input_workload_t workload(trace_path, regions);
     workload.only_threads = only_threads;
     workload.only_shards = only_shards;
+    workload.output_limit = output_limit;
     if (regions.empty() && skip_to_timestamp_ > 0) {
         workload.times_of_interest.emplace_back(skip_to_timestamp_, 0);
     }
@@ -383,7 +384,7 @@ analyzer_tmpl_t<RecordType, ReaderType>::analyzer_tmpl_t(
     // The scheduler will call reader_t::init() for each input file.  We assume
     // that won't block (analyzer_multi_t separates out IPC readers).
     typename sched_type_t::scheduler_options_t sched_ops;
-    if (!init_scheduler(trace_path, {}, {}, verbosity, std::move(sched_ops))) {
+    if (!init_scheduler(trace_path, {}, {}, 0, verbosity, std::move(sched_ops))) {
         success_ = false;
         error_string_ = "Failed to create scheduler";
         return;

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -221,7 +221,7 @@ protected:
     init_scheduler(const std::string &trace_path,
                    // To include all threads/shards, use empty sets.
                    const std::set<memref_tid_t> &only_threads,
-                   const std::set<int> &only_shards, int verbosity,
+                   const std::set<int> &only_shards, int output_limit, int verbosity,
                    typename sched_type_t::scheduler_options_t options);
 
     // For core-sharded, worker_count_ must be set prior to calling this; for parallel

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -549,7 +549,8 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
             return;
         }
         if (!this->init_scheduler(tracedir, only_threads, only_shards,
-                                  op_verbose.get_value(), std::move(sched_ops))) {
+                                  op_sched_max_cores.get_value(), op_verbose.get_value(),
+                                  std::move(sched_ops))) {
             this->success_ = false;
             return;
         }
@@ -573,7 +574,8 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
         }
     } else {
         // Legacy file.
-        if (!this->init_scheduler(op_infile.get_value(), {}, {}, op_verbose.get_value(),
+        if (!this->init_scheduler(op_infile.get_value(), {}, {},
+                                  op_sched_max_cores.get_value(), op_verbose.get_value(),
                                   std::move(sched_ops))) {
             this->success_ = false;
             return;

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -107,6 +107,11 @@ public:
          * Counts the number of output runqueue rebalances triggered by this output.
          */
         SCHED_STAT_RUNQUEUE_REBALANCES,
+        /**
+         * Counts the instances where a workload's output limit prevented one of its
+         * inputs from being scheduled onto an output.
+         */
+        SCHED_STAT_HIT_OUTPUT_LIMIT,
         /** Count of statistic types. */
         SCHED_STAT_TYPE_COUNT,
     };

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1061,6 +1061,12 @@ droption_t<double> op_sched_exit_if_fraction_inputs_left(
     "count is not considered (as it is not available), use discretion when raising "
     "this value on uneven inputs.");
 
+droption_t<int> op_sched_max_cores(
+    DROPTION_SCOPE_ALL, "sched_max_cores", 0,
+    "Limit scheduling to this many peak live cores",
+    "If non-zero, only this many live cores can be scheduled at any one time.  "
+    "Other cores will remain idle.");
+
 // Schedule_stats options.
 droption_t<uint64_t>
     op_schedule_stats_print_every(DROPTION_SCOPE_ALL, "schedule_stats_print_every",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -222,6 +222,7 @@ extern dynamorio::droption::droption_t<uint64_t> op_sched_migration_threshold_us
 extern dynamorio::droption::droption_t<uint64_t> op_sched_rebalance_period_us;
 extern dynamorio::droption::droption_t<double> op_sched_time_units_per_us;
 extern dynamorio::droption::droption_t<double> op_sched_exit_if_fraction_inputs_left;
+extern dynamorio::droption::droption_t<int> op_sched_max_cores;
 extern dynamorio::droption::droption_t<uint64_t> op_schedule_stats_print_every;
 extern dynamorio::droption::droption_t<std::string> op_syscall_template_file;
 extern dynamorio::droption::droption_t<uint64_t> op_filter_stop_timestamp;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -393,6 +393,14 @@ public:
          */
         std::set<input_ordinal_t> only_shards;
 
+        /**
+         * If greater than zero, imposes a maximum number of outputs that the inputs
+         * comprising this workload can execute upon simultaneously.  If an input would
+         * be executed next but would exceed this cap, a different input is selected
+         * instead or the output goes idle if none are found.
+         */
+        int output_limit = 0;
+
         // Work around a known Visual Studio issue where it complains about deleted copy
         // constructors for unique_ptr by deleting our copies and defaulting our moves.
         input_workload_t(const input_workload_t &) = delete;

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -70,8 +70,7 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::~scheduler_dynamic_tmpl_t()
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
-scheduler_dynamic_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
-    std::unordered_map<int, std::vector<int>> &workload2inputs)
+scheduler_dynamic_tmpl_t<RecordType, ReaderType>::set_initial_schedule()
 {
     if (options_.mapping != sched_type_t::MAP_TO_ANY_OUTPUT)
         return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
@@ -79,11 +78,11 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
     if (options_.deps == sched_type_t::DEPENDENCY_TIMESTAMPS) {
         // Compute the min timestamp (==base_timestamp) per workload and sort
         // all inputs by relative time from the base.
-        for (int workload_idx = 0;
-             workload_idx < static_cast<int>(workload2inputs.size()); ++workload_idx) {
+        for (int workload_idx = 0; workload_idx < static_cast<int>(workloads_.size());
+             ++workload_idx) {
             uint64_t min_time = std::numeric_limits<uint64_t>::max();
             input_ordinal_t min_input = -1;
-            for (int input_idx : workload2inputs[workload_idx]) {
+            for (int input_idx : workloads_[workload_idx].inputs) {
                 if (inputs_[input_idx].next_timestamp < min_time) {
                     min_time = inputs_[input_idx].next_timestamp;
                     min_input = input_idx;
@@ -91,7 +90,7 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
             }
             if (min_input < 0)
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
-            for (int input_idx : workload2inputs[workload_idx]) {
+            for (int input_idx : workloads_[workload_idx].inputs) {
                 VPRINT(this, 4,
                        "workload %d: setting input %d base_timestamp to %" PRIu64
                        " vs next_timestamp %zu\n",
@@ -113,7 +112,7 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
     }
     // Now assign round-robin to the outputs.  We have to obey bindings here: we
     // just take the first.  This isn't guaranteed to be perfect if there are
-    // many bindings, but we run a rebalancing afterward.
+    // many bindings (or output limits), but we run a rebalancing afterward.
     output_ordinal_t output = 0;
     while (!allq.empty()) {
         input_info_t *input = allq.top();
@@ -137,9 +136,13 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
 #endif
             pop_from_ready_queue(i, i, queue_next);
         assert(status == sched_type_t::STATUS_OK || status == sched_type_t::STATUS_IDLE);
-        if (queue_next == nullptr)
-            set_cur_input(i, sched_type_t::INVALID_INPUT_ORDINAL);
-        else
+        if (queue_next == nullptr) {
+            // Try to steal, as the initial round-robin layout and rebalancing ignores
+            // ouput_limit and other factors.
+            status = eof_or_idle_for_mode(i, sched_type_t::INVALID_INPUT_ORDINAL);
+            if (status != sched_type_t::STATUS_STOLE)
+                set_cur_input(i, sched_type_t::INVALID_INPUT_ORDINAL);
+        } else
             set_cur_input(i, queue_next->index);
     }
     VPRINT(this, 2, "Initial queues:\n");
@@ -154,15 +157,17 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::swap_out_input(
     output_ordinal_t output, input_ordinal_t input, int workload,
     bool caller_holds_input_lock)
 {
+    // Our add_to_ready_queue() call is unsafe if the caller holds
+    // this input lock: we disallow it here and in the parent's
+    // set_cur_input().
+    assert(!caller_holds_input_lock);
     // Now that the caller has updated prev_info, add it to the ready queue (once on
     // the queue others can see it and pop it off).
     if (!inputs_[input].at_eof) {
-        // This is unsafe if the caller holds this input lock: we disallow it here
-        // and in the parent's set_cur_input().
-        assert(!caller_holds_input_lock);
         add_to_ready_queue(output, &inputs_[input]);
     }
-    // TODO i#7067: Track peak live core usage per workload here.
+    if (workloads_[workload].output_limit > 0)
+        workloads_[workload].live_outputs->fetch_add(-1, std::memory_order_release);
     return sched_type_t::STATUS_OK;
 }
 
@@ -171,7 +176,9 @@ typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_dynamic_tmpl_t<RecordType, ReaderType>::swap_in_input(output_ordinal_t output,
                                                                 input_ordinal_t input)
 {
-    // TODO i#7067: Track peak live core usage per workload here.
+    workload_info_t &workload = workloads_[inputs_[input].workload];
+    if (workload.output_limit > 0)
+        workload.live_outputs->fetch_add(1, std::memory_order_release);
     return sched_type_t::STATUS_OK;
 }
 
@@ -907,6 +914,9 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::eof_or_idle_for_mode(
             output_ordinal_t target = (output + i) % outputs_.size();
             assert(target != output); // Sanity check (we won't reach "output").
             input_info_t *queue_next = nullptr;
+            VPRINT(this, 2, // NOCHECK 4
+                   "eof_or_idle: output %d trying to steal from %d's ready_queue\n",
+                   output, target);
             stream_status_t status = pop_from_ready_queue(target, output, queue_next);
             if (status == sched_type_t::STATUS_OK && queue_next != nullptr) {
                 set_cur_input(output, queue_next->index);
@@ -1083,11 +1093,20 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue_hold_lock
                 res->unscheduled = false;
                 VPRINT(this, 4, "pop queue: %d @ %" PRIu64 " no longer blocked\n",
                        res->index, cur_time);
-                // We've found a candidate.  One final check if this is a migration.
                 bool found_candidate = false;
-                if (from_output == for_output)
+                // We've found a potential candidate.  Is it under its output limit?
+                workload_info_t &workload = workloads_[res->workload];
+                if (workload.output_limit > 0 &&
+                    workload.live_outputs->load(std::memory_order_acquire) >=
+                        workload.output_limit) {
+                    VPRINT(this, 2, "output[%d]: not running input %d: at output limit\n",
+                           for_output, res->index);
+                    ++outputs_[from_output]
+                          .stats[memtrace_stream_t::SCHED_STAT_HIT_OUTPUT_LIMIT];
+                } else if (from_output == for_output) {
                     found_candidate = true;
-                else {
+                } else {
+                    // One final check if this is a migration.
                     assert(cur_time > 0 || res->last_run_time == 0);
                     if (res->last_run_time == 0) {
                         // For never-executed inputs we consider their last execution
@@ -1188,8 +1207,8 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::pop_from_ready_queue(
     {
         std::unique_lock<mutex_dbg_owned> from_lock;
         std::unique_lock<mutex_dbg_owned> for_lock;
-        // If we need both locks, acquire in increasing output order to avoid deadlocks if
-        // two outputs try to steal from each other.
+        // If we need both locks, acquire in increasing output order to avoid
+        // deadlocks if two outputs try to steal from each other.
         if (from_output == for_output ||
             for_output == sched_type_t::INVALID_OUTPUT_ORDINAL) {
             from_lock = acquire_scoped_output_lock_if_necessary(from_output);

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -42,6 +42,7 @@
 #include <cstdint>
 #include <limits>
 #include <mutex>
+#include <sstream>
 #include <thread>
 #include <unordered_map>
 #include <vector>

--- a/clients/drcachesim/scheduler/scheduler_fixed.cpp
+++ b/clients/drcachesim/scheduler/scheduler_fixed.cpp
@@ -99,6 +99,23 @@ scheduler_fixed_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_fixed_tmpl_t<RecordType, ReaderType>::swap_out_input(
+    output_ordinal_t output, input_ordinal_t input, int workload,
+    bool caller_holds_input_lock)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_fixed_tmpl_t<RecordType, ReaderType>::swap_in_input(output_ordinal_t output,
+                                                              input_ordinal_t input)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_fixed_tmpl_t<RecordType, ReaderType>::pick_next_input_for_mode(
     output_ordinal_t output, uint64_t blocked_time, input_ordinal_t prev_index,
     input_ordinal_t &index)

--- a/clients/drcachesim/scheduler/scheduler_fixed.cpp
+++ b/clients/drcachesim/scheduler/scheduler_fixed.cpp
@@ -99,8 +99,7 @@ scheduler_fixed_tmpl_t<RecordType, ReaderType>::set_initial_schedule()
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_fixed_tmpl_t<RecordType, ReaderType>::swap_out_input(
-    output_ordinal_t output, input_ordinal_t input, int workload,
-    bool caller_holds_input_lock)
+    output_ordinal_t output, input_ordinal_t input, bool caller_holds_input_lock)
 {
     return sched_type_t::STATUS_OK;
 }

--- a/clients/drcachesim/scheduler/scheduler_fixed.cpp
+++ b/clients/drcachesim/scheduler/scheduler_fixed.cpp
@@ -54,8 +54,7 @@ namespace drmemtrace {
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
-scheduler_fixed_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
-    std::unordered_map<int, std::vector<int>> &workload2inputs)
+scheduler_fixed_tmpl_t<RecordType, ReaderType>::set_initial_schedule()
 {
     if (options_.mapping == sched_type_t::MAP_TO_CONSISTENT_OUTPUT) {
         // Assign the inputs up front to avoid locks once we're in parallel mode.

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -663,12 +663,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::~scheduler_impl_tmpl_t()
                outputs_[i].ready_queue.lock->get_count_contended());
 #endif
     }
-#ifndef NDEBUG
-    VPRINT(this, 1, "%-37s: %9" PRId64 "\n", "Unscheduled queue lock acquired",
-           unscheduled_priority_.lock->get_count_acquired());
-    VPRINT(this, 1, "%-37s: %9" PRId64 "\n", "Unscheduled queue lock contended",
-           unscheduled_priority_.lock->get_count_contended());
-#endif
 }
 
 template <typename RecordType, typename ReaderType>
@@ -2185,63 +2179,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::close_schedule_segment(
 }
 
 template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::add_to_unscheduled_queue(
-    input_info_t *input)
-{
-    assert(input->lock->owned_by_cur_thread());
-    std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
-    assert(input->unscheduled &&
-           input->blocked_time == 0); // Else should be in regular queue.
-    VPRINT(this, 4, "add_to_unscheduled_queue (pre-size %zu): input %d priority %d\n",
-           unscheduled_priority_.queue.size(), input->index, input->priority);
-    input->queue_counter = ++unscheduled_priority_.fifo_counter;
-    unscheduled_priority_.queue.push(input);
-    input->prev_output = input->containing_output;
-    input->containing_output = sched_type_t::INVALID_INPUT_ORDINAL;
-}
-
-template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::add_to_ready_queue_hold_locks(
-    output_ordinal_t output, input_info_t *input)
-{
-    assert(input->lock->owned_by_cur_thread());
-    assert(!need_output_lock() ||
-           outputs_[output].ready_queue.lock->owned_by_cur_thread());
-    if (input->unscheduled && input->blocked_time == 0) {
-        // Ensure we get prev_output set for start-unscheduled so they won't
-        // all resume on output #0 but rather on the initial round-robin assignment.
-        input->containing_output = output;
-        add_to_unscheduled_queue(input);
-        return;
-    }
-    assert(input->binding.empty() || input->binding.find(output) != input->binding.end());
-    VPRINT(
-        this, 4,
-        "add_to_ready_queue (pre-size %zu): input %d priority %d timestamp delta %" PRIu64
-        " block time %" PRIu64 " start time %" PRIu64 "\n",
-        outputs_[output].ready_queue.queue.size(), input->index, input->priority,
-        input->reader->get_last_timestamp() - input->base_timestamp, input->blocked_time,
-        input->blocked_start_time);
-    if (input->blocked_time > 0)
-        ++outputs_[output].ready_queue.num_blocked;
-    input->queue_counter = ++outputs_[output].ready_queue.fifo_counter;
-    outputs_[output].ready_queue.queue.push(input);
-    input->containing_output = output;
-}
-
-template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::add_to_ready_queue(output_ordinal_t output,
-                                                                  input_info_t *input)
-{
-    auto scoped_lock = acquire_scoped_output_lock_if_necessary(output);
-    std::lock_guard<mutex_dbg_owned> input_lock(*input->lock);
-    add_to_ready_queue_hold_locks(output, input);
-}
-
-template <typename RecordType, typename ReaderType>
 uint64_t
 scheduler_impl_tmpl_t<RecordType, ReaderType>::scale_blocked_time(
     uint64_t initial_time) const
@@ -2270,31 +2207,34 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
     assert(output >= 0 && output < static_cast<output_ordinal_t>(outputs_.size()));
     // 'input' might be sched_type_t::INVALID_INPUT_ORDINAL.
     assert(input < static_cast<input_ordinal_t>(inputs_.size()));
+    // The caller should never hold the input lock for MAP_TO_ANY_OUTPUT.
+    assert(options_.mapping != sched_type_t::MAP_TO_ANY_OUTPUT ||
+           !caller_holds_cur_input_lock);
     int prev_input = outputs_[output].cur_input;
     if (prev_input >= 0) {
         if (prev_input != input) {
             input_info_t &prev_info = inputs_[prev_input];
-            auto scoped_lock = caller_holds_cur_input_lock
-                ? std::unique_lock<mutex_dbg_owned>()
-                : std::unique_lock<mutex_dbg_owned>(*prev_info.lock);
-            prev_info.cur_output = sched_type_t::INVALID_OUTPUT_ORDINAL;
-            prev_info.last_run_time = get_output_time(output);
-            if (options_.schedule_record_ostream != nullptr) {
-                stream_status_t status = close_schedule_segment(output, prev_info);
-                if (status != sched_type_t::STATUS_OK)
-                    return status;
+            // This is different from prev_workload below: that waits for a valid
+            // new workload (so swap-in trigger).
+            int workload = -1;
+            {
+                auto scoped_lock = caller_holds_cur_input_lock
+                    ? std::unique_lock<mutex_dbg_owned>()
+                    : std::unique_lock<mutex_dbg_owned>(*prev_info.lock);
+                prev_info.cur_output = sched_type_t::INVALID_OUTPUT_ORDINAL;
+                prev_info.last_run_time = get_output_time(output);
+                if (options_.schedule_record_ostream != nullptr) {
+                    stream_status_t status = close_schedule_segment(output, prev_info);
+                    if (status != sched_type_t::STATUS_OK)
+                        return status;
+                }
+                workload = prev_info.workload;
             }
-        }
-        // Now that we've updated prev_info, add it to the ready queue (once on the
-        // queues others can see it and pop it off, though they can't access/modify its
-        // fields (for identifying if it can be migrated, e.g.) until we release the
-        // input lock, so it should be safe to add first, but this order is more
-        // straightforward).
-        if (options_.mapping == sched_type_t::MAP_TO_ANY_OUTPUT && prev_input != input &&
-            !inputs_[prev_input].at_eof) {
-            // The caller should never hold the input lock for MAP_TO_ANY_OUTPUT.
-            assert(!caller_holds_cur_input_lock);
-            add_to_ready_queue(output, &inputs_[prev_input]);
+            // Let subclasses act on the outgoing input.
+            stream_status_t res =
+                swap_out_input(output, prev_input, workload, caller_holds_cur_input_lock);
+            if (res != sched_type_t::STATUS_OK)
+                return res;
         }
     } else if (options_.schedule_record_ostream != nullptr &&
                (outputs_[output].record.back().type == schedule_record_t::IDLE ||
@@ -2398,6 +2338,12 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
                 return status;
         }
     }
+
+    // Let subclasses act on the incoming input.
+    stream_status_t res = swap_in_input(output, input);
+    if (res != sched_type_t::STATUS_OK)
+        return res;
+
     return sched_type_t::STATUS_OK;
 }
 
@@ -2425,19 +2371,6 @@ typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_impl_tmpl_t<RecordType, ReaderType>::pick_next_input(output_ordinal_t output,
                                                                uint64_t blocked_time)
 {
-    VDO(this, 1, {
-        static int64_t global_heartbeat;
-        // 10K is too frequent for simple analyzer runs: it is too noisy with
-        // the new core-sharded-by-default for new users using defaults.
-        // 50K is a reasonable compromise.
-        // XXX: Add a runtime option to tweak this.
-        static constexpr int64_t GLOBAL_HEARTBEAT_CADENCE = 50000;
-        // We are ok with races as the cadence is approximate.
-        if (++global_heartbeat % GLOBAL_HEARTBEAT_CADENCE == 0) {
-            print_queue_stats();
-        }
-    });
-
     stream_status_t res = sched_type_t::STATUS_OK;
     const input_ordinal_t prev_index = outputs_[output].cur_input;
     input_ordinal_t index = sched_type_t::INVALID_INPUT_ORDINAL;
@@ -2932,46 +2865,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::get_statistic(
     if (stat >= memtrace_stream_t::SCHED_STAT_TYPE_COUNT)
         return -1;
     return static_cast<double>(outputs_[output].stats[stat]);
-}
-
-template <typename RecordType, typename ReaderType>
-void
-scheduler_impl_tmpl_t<RecordType, ReaderType>::print_queue_stats()
-{
-    size_t unsched_size = 0;
-    {
-        std::lock_guard<mutex_dbg_owned> unsched_lock(*unscheduled_priority_.lock);
-        unsched_size = unscheduled_priority_.queue.size();
-    }
-    int live = live_input_count_.load(std::memory_order_acquire);
-    // Make our multi-line output more atomic.
-    std::ostringstream ostr;
-    ostr << "Queue snapshot: inputs: " << live - unsched_size << " schedulable, "
-         << unsched_size << " unscheduled, " << inputs_.size() - live << " eof\n";
-    for (unsigned int i = 0; i < outputs_.size(); ++i) {
-        auto lock = acquire_scoped_output_lock_if_necessary(i);
-        uint64_t cur_time = get_output_time(i);
-        ostr << "  out #" << i << " @" << cur_time << ": running #"
-             << outputs_[i].cur_input << "; " << outputs_[i].ready_queue.queue.size()
-             << " in queue; " << outputs_[i].ready_queue.num_blocked << " blocked\n";
-        std::set<input_info_t *> readd;
-        input_info_t *res = nullptr;
-        while (!outputs_[i].ready_queue.queue.empty()) {
-            res = outputs_[i].ready_queue.queue.top();
-            readd.insert(res);
-            outputs_[i].ready_queue.queue.pop();
-            std::lock_guard<mutex_dbg_owned> input_lock(*res->lock);
-            if (res->blocked_time > 0) {
-                ostr << "    " << res->index << " still blocked for "
-                     << res->blocked_time - (cur_time - res->blocked_start_time) << "\n";
-            }
-        }
-        // Re-add the ones we skipped, but without changing their counters so we preserve
-        // the prior FIFO order.
-        for (input_info_t *add : readd)
-            outputs_[i].ready_queue.queue.push(add);
-    }
-    VPRINT(this, 0, "%s\n", ostr.str().c_str());
 }
 
 template class scheduler_impl_tmpl_t<memref_t, reader_t>;

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2219,9 +2219,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
     if (prev_input >= 0) {
         if (prev_input != input) {
             input_info_t &prev_info = inputs_[prev_input];
-            // This is different from prev_workload below: that waits for a valid
-            // new workload (so swap-in trigger).
-            int workload = -1;
             {
                 auto scoped_lock = caller_holds_cur_input_lock
                     ? std::unique_lock<mutex_dbg_owned>()
@@ -2233,13 +2230,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
                     if (status != sched_type_t::STATUS_OK)
                         return status;
                 }
-                workload = prev_info.workload;
             }
-            // Let subclasses act on the outgoing input.
-            stream_status_t res =
-                swap_out_input(output, prev_input, workload, caller_holds_cur_input_lock);
-            if (res != sched_type_t::STATUS_OK)
-                return res;
         }
     } else if (options_.schedule_record_ostream != nullptr &&
                (outputs_[output].record.back().type == schedule_record_t::IDLE ||
@@ -2250,13 +2241,22 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
         if (status != sched_type_t::STATUS_OK)
             return status;
     }
+    if (prev_input != input) {
+        // Let subclasses act on the outgoing input.
+        stream_status_t res =
+            swap_out_input(output, prev_input, caller_holds_cur_input_lock);
+        if (res != sched_type_t::STATUS_OK)
+            return res;
+    }
     if (outputs_[output].cur_input >= 0)
         outputs_[output].prev_input = outputs_[output].cur_input;
     outputs_[output].cur_input = input;
-    if (input < 0)
-        return sched_type_t::STATUS_OK;
     if (prev_input == input)
         return sched_type_t::STATUS_OK;
+    if (input < 0) {
+        // Let subclasses act on the switch to idle.
+        return swap_in_input(output, input);
+    }
 
     int prev_workload = -1;
     if (outputs_[output].prev_input >= 0 && outputs_[output].prev_input != input) {

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -271,9 +271,9 @@ protected:
             live_outputs = std::unique_ptr<std::atomic<int>>(new std::atomic<int>());
             live_outputs->store(0, std::memory_order_relaxed);
         }
-        int output_limit;
+        int output_limit; // Read-only after constructed.
         std::unique_ptr<std::atomic<int>> live_outputs;
-        std::vector<input_ordinal_t> inputs;
+        std::vector<input_ordinal_t> inputs; // Read-only after constructed.
     };
 
     // Format for recording a schedule to disk.  A separate sequence of these records

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -586,23 +586,6 @@ protected:
     virtual stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) = 0;
 
-    // When an output's input changes (whether between two valid inputs, from a valid to
-    // INVALID_INPUT_ORDINAL, or vice versa), swap_out_input() is called on the outgoing
-    // input (whose lock is held if "caller_holds_input_lock" is true; it will never be
-    // true for MAP_TO_ANY_OUTPUT).  This is called after the input's fields (such as
-    // cur_output and last_run_time) have been updated, if it was a valid input.
-    // This should return STATUS_OK if there is nothing to do; errors are propagated.
-    virtual stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input,
-                   bool caller_holds_input_lock) = 0;
-
-    // When an output's input changes (to a valid input or to INVALID_INPUT_ORDINAL)
-    // different from the previous input, swap_in_input() is called on the incoming
-    // input (whose lock is always held by the caller, if a valid input).
-    // This should return STATUS_OK if there is nothing to do; errors are propagated.
-    virtual stream_status_t
-    swap_in_input(output_ordinal_t output, input_ordinal_t input) = 0;
-
     // Allow subclasses to perform custom initial marker processing during
     // get_initial_input_content().  Returns whether to keep reading.
     // The caller will stop calling when an instruction record is reached.
@@ -1062,12 +1045,6 @@ protected:
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input,
-                   bool caller_holds_input_lock) override;
-    stream_status_t
-    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
-
-    stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
                              input_ordinal_t prev_index, input_ordinal_t &index) override;
 
@@ -1179,12 +1156,6 @@ protected:
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input,
-                   bool caller_holds_input_lock) override;
-    stream_status_t
-    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
-
-    stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
                              input_ordinal_t prev_index, input_ordinal_t &index) override;
 
@@ -1223,12 +1194,6 @@ private:
 protected:
     scheduler_status_t
     set_initial_schedule() override;
-
-    stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input,
-                   bool caller_holds_input_lock) override;
-    stream_status_t
-    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
     swap_out_input(output_ordinal_t output, input_ordinal_t input,

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -247,6 +247,8 @@ protected:
         // The units are in simuilation time.
         uint64_t blocked_time = 0;
         uint64_t blocked_start_time = 0;
+        // XXX i#6831: Move fields like this to be specific to subclasses by changing
+        // inputs_ to a vector of unique_ptr and then subclassing input_info_t.
         // An input can be "unscheduled" and not on the ready_priority_ run queue at all
         // with an infinite timeout until directly targeted.  Such inputs are stored
         // in the unscheduled_priority_ queue.
@@ -383,28 +385,8 @@ protected:
     std::unique_lock<mutex_dbg_owned>
     acquire_scoped_output_lock_if_necessary(output_ordinal_t output);
 
-    // If input->unscheduled is true and input->blocked_time is 0, input
-    // is placed on the unscheduled_priority_ queue instead.
-    // The caller cannot hold the input's lock: this routine will acquire it.
-    void
-    add_to_ready_queue(output_ordinal_t output, input_info_t *input);
-
-    // Identical to add_to_ready_queue() except the output's lock must be held by the
-    // caller.
-    // The caller must also hold the input's lock.
-    void
-    add_to_ready_queue_hold_locks(output_ordinal_t output, input_info_t *input);
-
-    // The caller must hold the input's lock.
-    void
-    add_to_unscheduled_queue(input_info_t *input);
-
     uint64_t
     scale_blocked_time(uint64_t initial_time) const;
-
-    // Up to the caller to check verbosity before calling.
-    void
-    print_queue_stats();
 
     void
     update_switch_stats(output_ordinal_t output, input_ordinal_t prev_input,
@@ -451,6 +433,8 @@ protected:
         input_ordinal_t cur_input = sched_type_t::INVALID_INPUT_ORDINAL;
         // Holds the prior non-invalid input.
         input_ordinal_t prev_input = sched_type_t::INVALID_INPUT_ORDINAL;
+        // XXX i#6831: Move fields like this to be specific to subclasses by changing
+        // inputs_ to a vector of unique_ptr and then subclassing output_info_t.
         // For static schedules we can populate this up front and avoid needing a
         // lock for dynamically finding the next input, keeping things parallel.
         std::vector<input_ordinal_t> input_indices;
@@ -569,6 +553,21 @@ protected:
     // Should call set_cur_input() for all outputs with initial inputs.
     virtual scheduler_status_t
     set_initial_schedule(std::unordered_map<int, std::vector<int>> &workload2inputs) = 0;
+
+    // When an output's input changes from a valid (not INVALID_INPUT_ORDINAL) input to
+    // something else, swap_out_input() is called on the outgoing input (whose lock is
+    // held if "caller_holds_input_lock" is true; it will never be true for
+    // MAP_TO_ANY_OUTPUT).  This is called after the input's fields (such as cur_output
+    // and last_run_time) have been updated.
+    virtual stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) = 0;
+
+    // When an output's input changes to a valid (not INVALID_INPUT_ORDINAL) input
+    // different from the previous input, swap_in_input() is called on the incoming
+    // input (whose lock is always held by the caller).
+    virtual stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) = 0;
 
     // Allow subclasses to perform custom initial marker processing during
     // get_initial_input_content().  Returns whether to keep reading.
@@ -928,11 +927,6 @@ protected:
     // ready_queue-related plus record and record_index fields which are accessed under
     // the output's own lock.
     std::vector<output_info_t> outputs_;
-    // This lock protects unscheduled_priority_ and unscheduled_counter_.
-    // It should be acquired *after* both output or input locks: it is narrowmost.
-    mutex_dbg_owned unsched_lock_;
-    // Inputs that are unscheduled indefinitely until directly targeted.
-    input_queue_t unscheduled_priority_;
     // Count of inputs not yet at eof.
     std::atomic<int> live_input_count_;
     // In replay mode, count of outputs not yet at the end of the replay sequence.
@@ -995,6 +989,7 @@ public:
     {
         last_rebalance_time_.store(0, std::memory_order_relaxed);
     }
+    ~scheduler_dynamic_tmpl_t();
 
 private:
     using sched_type_t = scheduler_tmpl_t<RecordType, ReaderType>;
@@ -1008,11 +1003,11 @@ private:
     using
         typename scheduler_impl_tmpl_t<RecordType, ReaderType>::InputTimestampComparator;
     using typename scheduler_impl_tmpl_t<RecordType, ReaderType>::workload_tid_t;
+    using typename scheduler_impl_tmpl_t<RecordType, ReaderType>::input_queue_t;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::options_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::outputs_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::inputs_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::error_string_;
-    using scheduler_impl_tmpl_t<RecordType, ReaderType>::unscheduled_priority_;
     using scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input;
     using scheduler_impl_tmpl_t<RecordType,
                                 ReaderType>::acquire_scoped_output_lock_if_necessary;
@@ -1023,6 +1018,12 @@ protected:
     scheduler_status_t
     set_initial_schedule(
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
+
+    stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override;
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
@@ -1058,6 +1059,22 @@ protected:
     bool
     ready_queue_empty(output_ordinal_t output);
 
+    // If input->unscheduled is true and input->blocked_time is 0, input
+    // is placed on the unscheduled_priority_ queue instead.
+    // The caller cannot hold the input's lock: this routine will acquire it.
+    void
+    add_to_ready_queue(output_ordinal_t output, input_info_t *input);
+
+    // Identical to add_to_ready_queue() except the output's lock must be held by the
+    // caller.
+    // The caller must also hold the input's lock.
+    void
+    add_to_ready_queue_hold_locks(output_ordinal_t output, input_info_t *input);
+
+    // The caller must hold the input's lock.
+    void
+    add_to_unscheduled_queue(input_info_t *input);
+
     // "for_output" is which output stream is looking for a new input; only an
     // input which is able to run on that output will be selected.
     // for_output can be INVALID_OUTPUT_ORDINAL, which will ignore bindings.
@@ -1073,9 +1090,18 @@ protected:
                                     output_ordinal_t for_output, input_info_t *&new_input,
                                     bool from_back = false);
 
+    // Up to the caller to check verbosity before calling.
+    void
+    print_queue_stats();
+
     // Rebalancing coordination.
     std::atomic<std::thread::id> rebalancer_;
     std::atomic<uint64_t> last_rebalance_time_;
+    // This lock protects unscheduled_priority_ and unscheduled_counter_.
+    // It should be acquired *after* both output or input locks: it is narrowmost.
+    mutex_dbg_owned unsched_lock_;
+    // Inputs that are unscheduled indefinitely until directly targeted.
+    input_queue_t unscheduled_priority_;
 };
 
 // Specialized code for replaying schedules: either a recorded dynamic schedule
@@ -1104,6 +1130,12 @@ protected:
     scheduler_status_t
     set_initial_schedule(
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
+
+    stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override;
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
@@ -1145,6 +1177,12 @@ protected:
     scheduler_status_t
     set_initial_schedule(
         std::unordered_map<int, std::vector<int>> &workload2inputs) override;
+
+    stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override;
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
 
     stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -569,18 +569,20 @@ protected:
     virtual scheduler_status_t
     set_initial_schedule() = 0;
 
-    // When an output's input changes from a valid (not INVALID_INPUT_ORDINAL) input to
-    // something else, swap_out_input() is called on the outgoing input (whose lock is
-    // held if "caller_holds_input_lock" is true; it will never be true for
-    // MAP_TO_ANY_OUTPUT).  This is called after the input's fields (such as cur_output
-    // and last_run_time) have been updated.
+    // When an output's input changes (whether between two valid inputs, from a valid to
+    // INVALID_INPUT_ORDINAL, or vice versa), swap_out_input() is called on the outgoing
+    // input (whose lock is held if "caller_holds_input_lock" is true; it will never be
+    // true for MAP_TO_ANY_OUTPUT).  This is called after the input's fields (such as
+    // cur_output and last_run_time) have been updated, if it was a valid input.
+    // This should return STATUS_OK if there is nothing to do; errors are propagated.
     virtual stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) = 0;
 
-    // When an output's input changes to a valid (not INVALID_INPUT_ORDINAL) input
+    // When an output's input changes (to a valid input or to INVALID_INPUT_ORDINAL)
     // different from the previous input, swap_in_input() is called on the incoming
-    // input (whose lock is always held by the caller).
+    // input (whose lock is always held by the caller, if a valid input).
+    // This should return STATUS_OK if there is nothing to do; errors are propagated.
     virtual stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) = 0;
 
@@ -1037,7 +1039,7 @@ protected:
     set_initial_schedule() override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override;
     stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
@@ -1148,7 +1150,7 @@ protected:
     set_initial_schedule() override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override;
     stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;
@@ -1194,7 +1196,7 @@ protected:
     set_initial_schedule() override;
 
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override;
     stream_status_t
     swap_in_input(output_ordinal_t output, input_ordinal_t input) override;

--- a/clients/drcachesim/scheduler/scheduler_replay.cpp
+++ b/clients/drcachesim/scheduler/scheduler_replay.cpp
@@ -298,8 +298,7 @@ scheduler_replay_tmpl_t<RecordType, ReaderType>::read_and_instantiate_traced_sch
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_replay_tmpl_t<RecordType, ReaderType>::swap_out_input(
-    output_ordinal_t output, input_ordinal_t input, int workload,
-    bool caller_holds_input_lock)
+    output_ordinal_t output, input_ordinal_t input, bool caller_holds_input_lock)
 {
     return sched_type_t::STATUS_OK;
 }

--- a/clients/drcachesim/scheduler/scheduler_replay.cpp
+++ b/clients/drcachesim/scheduler/scheduler_replay.cpp
@@ -58,8 +58,7 @@ namespace drmemtrace {
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
-scheduler_replay_tmpl_t<RecordType, ReaderType>::set_initial_schedule(
-    std::unordered_map<int, std::vector<int>> &workload2inputs)
+scheduler_replay_tmpl_t<RecordType, ReaderType>::set_initial_schedule()
 {
     if (options_.mapping == sched_type_t::MAP_AS_PREVIOUSLY) {
         this->live_replay_output_count_.store(static_cast<int>(outputs_.size()),

--- a/clients/drcachesim/scheduler/scheduler_replay.cpp
+++ b/clients/drcachesim/scheduler/scheduler_replay.cpp
@@ -298,6 +298,23 @@ scheduler_replay_tmpl_t<RecordType, ReaderType>::read_and_instantiate_traced_sch
 
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_replay_tmpl_t<RecordType, ReaderType>::swap_out_input(
+    output_ordinal_t output, input_ordinal_t input, int workload,
+    bool caller_holds_input_lock)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
+scheduler_replay_tmpl_t<RecordType, ReaderType>::swap_in_input(output_ordinal_t output,
+                                                               input_ordinal_t input)
+{
+    return sched_type_t::STATUS_OK;
+}
+
+template <typename RecordType, typename ReaderType>
+typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_replay_tmpl_t<RecordType, ReaderType>::pick_next_input_for_mode(
     output_ordinal_t output, uint64_t blocked_time, input_ordinal_t prev_index,
     input_ordinal_t &index)

--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -18,6 +18,7 @@ Total counts:
            0 migrations
            0 work steals
            0 rebalances
+           0 output limits hit
          161 system calls
            2 maybe-blocking system calls
            0 direct switch requests

--- a/clients/drcachesim/tests/schedule_stats_maxcores.templatex
+++ b/clients/drcachesim/tests/schedule_stats_maxcores.templatex
@@ -1,0 +1,27 @@
+Schedule stats tool results:
+Total counts:
+           4 cores
+.*
+      *[1-9][0-9]* output limits hit
+.*
+Core #0 counts:
+.*
+      *[1-9][0-9]* output limits hit
+.*
+Core #1 counts:
+.*
+      *[1-9][0-9]* output limits hit
+.*
+Core #2 counts:
+.*
+      *[1-9][0-9]* output limits hit
+.*
+Core #3 counts:
+.*
+      *[1-9][0-9]* output limits hit
+.*
+// Ensure 2 cores start idle.
+Core #0 schedule: [A-H][A-Ha-h_]*
+Core #1 schedule: [A-Z][A-Ha-h_]*
+Core #2 schedule: _[A-Ha-h_]*
+Core #3 schedule: _[A-Ha-h_]*

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -18,6 +18,7 @@ Total counts:
            0 migrations
            0 work steals
            1 rebalances
+           0 output limits hit
          161 system calls
            2 maybe-blocking system calls
            0 direct switch requests

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -2598,8 +2598,8 @@ test_synthetic_with_output_limit()
     int64_t limits = 0;
     for (int i = 0; i < NUM_OUTPUTS; i++) {
         std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
-        limits += scheduler.get_stream(i)->get_schedule_statistic(
-            memtrace_stream_t::SCHED_STAT_HIT_OUTPUT_LIMIT);
+        limits += static_cast<int64_t>(scheduler.get_stream(i)->get_schedule_statistic(
+            memtrace_stream_t::SCHED_STAT_HIT_OUTPUT_LIMIT));
     }
     assert(limits > 0);
     // We have ABCD with no limits so they all run at once.

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -3048,7 +3048,7 @@ public:
         return sched_type_t::STATUS_ERROR_NOT_IMPLEMENTED;
     }
     stream_status_t
-    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+    swap_out_input(output_ordinal_t output, input_ordinal_t input,
                    bool caller_holds_input_lock) override
     {
         return sched_type_t::STATUS_NOT_IMPLEMENTED;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -2976,6 +2976,17 @@ public:
         return sched_type_t::STATUS_ERROR_NOT_IMPLEMENTED;
     }
     stream_status_t
+    swap_out_input(output_ordinal_t output, input_ordinal_t input, int workload,
+                   bool caller_holds_input_lock) override
+    {
+        return sched_type_t::STATUS_NOT_IMPLEMENTED;
+    }
+    stream_status_t
+    swap_in_input(output_ordinal_t output, input_ordinal_t input) override
+    {
+        return sched_type_t::STATUS_NOT_IMPLEMENTED;
+    }
+    stream_status_t
     pick_next_input_for_mode(output_ordinal_t output, uint64_t blocked_time,
                              input_ordinal_t prev_index, input_ordinal_t &index) override
     {

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -164,6 +164,8 @@ schedule_stats_t::get_scheduler_stats(memtrace_stream_t *stream, counters_t &cou
         stream->get_schedule_statistic(memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS));
     counters.rebalances = static_cast<int64_t>(stream->get_schedule_statistic(
         memtrace_stream_t::SCHED_STAT_RUNQUEUE_REBALANCES));
+    counters.at_output_limit = static_cast<int64_t>(
+        stream->get_schedule_statistic(memtrace_stream_t::SCHED_STAT_HIT_OUTPUT_LIMIT));
 
     // XXX: Currently, schedule_stats is measuring swap-ins to a real input.  If we
     // want to match what "perf" targeting this app would record, which is swap-outs,
@@ -436,6 +438,7 @@ schedule_stats_t::print_counters(const counters_t &counters)
     std::cerr << std::setw(12) << counters.migrations << " migrations\n";
     std::cerr << std::setw(12) << counters.steals << " work steals\n";
     std::cerr << std::setw(12) << counters.rebalances << " rebalances\n";
+    std::cerr << std::setw(12) << counters.at_output_limit << " output limits hit\n";
 
     std::cerr << std::setw(12) << counters.syscalls << " system calls\n";
     std::cerr << std::setw(12) << counters.maybe_blocking_syscalls

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -172,6 +172,8 @@ public:
             return *this;
         }
         // Statistics provided by scheduler.
+        // XXX: Should we change all of these to uint64_t? Never negative: but signed
+        // ints are generally recommended as better for the compiler.
         int64_t switches_input_to_input = 0;
         int64_t switches_input_to_idle = 0;
         int64_t switches_idle_to_input = 0;

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -150,6 +150,7 @@ public:
             migrations += rhs.migrations;
             steals += rhs.steals;
             rebalances += rhs.rebalances;
+            at_output_limit += rhs.at_output_limit;
             instrs += rhs.instrs;
             total_switches += rhs.total_switches;
             voluntary_switches += rhs.voluntary_switches;
@@ -179,6 +180,7 @@ public:
         int64_t migrations = 0;
         int64_t steals = 0;
         int64_t rebalances = 0;
+        int64_t at_output_limit = 0;
         // Our own statistics.
         int64_t instrs = 0;
         int64_t total_switches = 0;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3936,6 +3936,11 @@ if (BUILD_CLIENTS)
           "")
         set(tool.schedule_stats_nopreempt_rawtemp ON) # no preprocessor
 
+        torunonly_simtool(schedule_stats_maxcores ${ci_shared_app}
+          "-indir ${thread_trace_dir} -tool schedule_stats -core_sharded -sched_max_cores 2"
+          "")
+        set(tool.schedule_stats_nopreempt_rawtemp ON) # no preprocessor
+
         torunonly_simtool(core_serial ${ci_shared_app}
           "-indir ${thread_trace_dir} -tool schedule_stats:basic_counts -core_serial"
           "")


### PR DESCRIPTION
Adds a new input_workload_t field: output_limit.  This is a peak simultaneously-live output stream maximum for the inputs of that workload.

To implement, atomics are used, with a new workload_info_t array tracking per-workload fields.  A new stat
memtrace_stream_t::SCHED_STAT_HIT_OUTPUT_LIMIT is added.  An initially-idle output attempts to steal immediately, as the initial round-robin layout does not take into account output limits.

Adds a unit test.

Fixes #7067