### PR TITLE
Add decode/encode support for the Intel SERIALIZE extension.

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1637,8 +1637,11 @@ const instr_info_t * const op_instr[] =
     /* OP_xrstors64 */  &rex_w_extensions[7][1],
 
     /* TSXLDTRK */
-    /* OP_xsusldtrk */ &rm_extensions[5][0],
+    /* OP_xsusldtrk */ &prefix_extensions[191][3],
     /* OP_xresldtrk */ &rm_extensions[5][1],
+
+    /* SERIALIZE */
+    /* OP_serialize */ &prefix_extensions[191][0],
 };
 
 
@@ -5876,7 +5879,7 @@ const instr_info_t prefix_extensions[][12] = {
     {EVEX_Wb_EXT,0xf3385218, catUncategorized, "(evex_Wb ext 273)",   xx, xx, xx, xx, xx, no, x, 273},
     {EVEX_Wb_EXT,0x66385218, catUncategorized, "(evex_Wb ext 269)",   xx, xx, xx, xx, xx, no, x, 269},
     {INVALID,    0xf2385218, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
-  } , { /* prefix extension 190 */
+  }, { /* prefix extension 190 */
     {INVALID,      0x387218, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,    0xf3387218, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,    0x66387218, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
@@ -5889,6 +5892,19 @@ const instr_info_t prefix_extensions[][12] = {
     {EVEX_Wb_EXT,0xf3387208, catUncategorized, "(evex_Wb ext 272)", xx, xx, xx, xx, xx, mrm|evex|ttnone, x, 272},
     {INVALID,    0x66387218, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
     {EVEX_Wb_EXT,0xf2387218, catUncategorized, "(evex_Wb ext 271)",   xx, xx, xx, xx, xx, mrm|evex|ttnone, x, 271},
+  }, { /* prefix extension 191 */
+    {OP_serialize,   0x01e808, catOther, "serialize", xx, xx, xx, xx, xx, reqp, x, END_LIST},
+    {INVALID,      0xf301e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6601e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {OP_xsusldtrk, 0xf201e808, catOther, "xsusldtrk", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID,        0x01e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf301e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6601e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf201e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,        0x01e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf301e808, catUncategorized, "(bad)"  , xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0x6601e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
+    {INVALID,      0xf201e808, catUncategorized, "(bad)",   xx, xx, xx, xx, xx, no, x, NA},
   }
 };
 /****************************************************************************
@@ -7079,7 +7095,7 @@ const instr_info_t rm_extensions[][8] = {
     {OP_enclu,  0xd70f0172, catUncategorized, "enclu", eax, ebx, eax, ebx, ecx, mrm|xop, x, exop[0xff]},
   },
   { /* rm extension 5 */
-    {OP_xsusldtrk, 0xf201e808, catOther, "xsusldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
+    {PREFIX_EXT, 0x01e808, catUncategorized, "(prefix ext 191)", xx, xx, xx, xx, xx, no, x, 191},
     {OP_xresldtrk, 0xf201e908, catOther, "xresldtrk", xx, xx, xx, xx, xx, reqp, x, END_LIST},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -531,6 +531,7 @@
 #define INSTR_CREATE_stac(dc) instr_create_0dst_0src((dc), OP_stac)
 #define INSTR_CREATE_xsusldtrk(dc) instr_create_0dst_0src((dc), OP_xsusldtrk)
 #define INSTR_CREATE_xresldtrk(dc) instr_create_0dst_0src((dc), OP_xresldtrk)
+#define INSTR_CREATE_serialize(dc) instr_create_0dst_0src((dc), OP_serialize)
 /** @} */ /* end doxygen group */
 
 /* no destination, 1 source */

--- a/core/ir/x86/opcode_api.h
+++ b/core/ir/x86/opcode_api.h
@@ -1626,6 +1626,9 @@ enum {
     /* 1441 */ OP_xsusldtrk, /**< IA-32/AMD64 xsusldtrk opcode. */
     /* 1442 */ OP_xresldtrk, /**< IA-32/AMD64 xresldtrk opcode. */
 
+    /* SERIALIZE */
+    /* 1443 */ OP_serialize, /**< IA-32/AMD64 serialize opcode. */
+
     OP_AFTER_LAST,
     OP_FIRST = OP_add,           /**< First real opcode. */
     OP_LAST = OP_AFTER_LAST - 1, /**< Last real opcode. */

--- a/suite/tests/api/ir_x86_0args.h
+++ b/suite/tests/api/ir_x86_0args.h
@@ -203,3 +203,5 @@ OPCODE(stac, stac, stac, 0)
 
 OPCODE(xsusldtrk, xsusldtrk, xsusldtrk, 0)
 OPCODE(xresldtrk, xresldtrk, xresldtrk, 0)
+
+OPCODE(serialize, serialize, serialize, 0)


### PR DESCRIPTION
Alder Lake/Sapphire Rapids introduced the SERIALIZE extension which adds a single new SERIALIZE instruction. Support that.