### PR TITLE
i#1569: Update Arm hosted GitHub Action Runner labels

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -49,14 +49,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # This job will run in parallel.
+        # This job will run in parallel. The OS names are Runner labels taken
+        # from https://gitlab.arm.com/tooling/gha-runner-docs
         include:
-          - os: ubuntu-20-arm64-pre-sve
+          - os: ah-ubuntu_22_04-c6g_4x-50 # Graviton 2, 16 cores, 32G RAM
             sve: false
-          - os: ubuntu-20-arm64-sve
+          - os: ah-ubuntu_22_04-c7g_4x-50 # Graviton 3, 16 cores, 32G RAM
             sve: true
             sve_length: 256
-          - os: ubuntu-20-arm64-sve
+          - os: ah-ubuntu_22_04-c7g_4x-50
             sve: true
             sve_length: 128
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
These labels point to a set of Arm AWS instances which are scalable and will get better support over the long-term.

Issue: #1569