### PR TITLE
i#3544: RV64: Split PC-sensitive IR tests into another test

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2054,6 +2054,7 @@ if (NOT ANDROID)
 
   if (RISCV64)
     tobuild_api(api.ir_rvv api/ir_rvv.c  "" "" ON OFF OFF)
+    tobuild_api(api.ir_rv64_addr api/ir_rv64_addr.c  "" "" OFF OFF OFF)
   endif(RISCV64)
 endif ()
 
@@ -6415,6 +6416,7 @@ if (RISCV64)
     code_api|api.ir-static
     code_api|api.ir_regdeps
     code_api|api.ir_rvv
+    code_api|api.ir_rv64_addr
     code_api|client.app_args
     code_api|client.blackbox
     code_api|client.crashmsg

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2055,6 +2055,9 @@ if (NOT ANDROID)
   if (RISCV64)
     tobuild_api(api.ir_rvv api/ir_rvv.c  "" "" ON OFF OFF)
     tobuild_api(api.ir_rv64_addr api/ir_rv64_addr.c  "" "" OFF OFF OFF)
+
+    target_sources(api.ir PRIVATE api/ir_riscv64_common.c)
+    target_sources(api.ir_rv64_addr PRIVATE api/ir_riscv64_common.c)
   endif(RISCV64)
 endif ()
 
@@ -2068,6 +2071,8 @@ if (AARCH64)
   set(api.ir-static_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runcmp.cmake")
   set(api.ir-static_runcmp_capture "stderr")
 elseif (RISCV64)
+  target_sources(api.ir-static PRIVATE api/ir_riscv64_common.c)
+
   # The ir_riscv64.expect file is too large for CMake's regexes.
   set(api.ir-static_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runcmp.cmake")
   set(api.ir-static_runcmp_capture "stderr")

--- a/suite/tests/api/ir_riscv64.c
+++ b/suite/tests/api/ir_riscv64.c
@@ -48,116 +48,7 @@
 #include "dr_ir_utils.h"
 #include "dr_defines.h"
 
-static byte buf[8192];
-
-#ifdef STANDALONE_DECODER
-#    define ASSERT(x)                                                                 \
-        ((void)((!(x)) ? (fprintf(stderr, "ASSERT FAILURE (standalone): %s:%d: %s\n", \
-                                  __FILE__, __LINE__, #x),                            \
-                          abort(), 0)                                                 \
-                       : 0))
-#else
-#    define ASSERT(x)                                                                \
-        ((void)((!(x)) ? (dr_fprintf(STDERR, "ASSERT FAILURE (client): %s:%d: %s\n", \
-                                     __FILE__, __LINE__, #x),                        \
-                          dr_abort(), 0)                                             \
-                       : 0))
-#endif
-
-static byte *
-test_instr_encoding(void *dc, uint opcode, instr_t *instr)
-{
-    instr_t *decin;
-    byte *pc, *next_pc;
-
-    ASSERT(instr_get_opcode(instr) == opcode);
-    instr_disassemble(dc, instr, STDERR);
-    print("\n");
-    ASSERT(instr_is_encoding_possible(instr));
-    pc = instr_encode(dc, instr, buf);
-    ASSERT(pc != NULL);
-    decin = instr_create(dc);
-    next_pc = decode(dc, buf, decin);
-    ASSERT(next_pc != NULL);
-    if (!instr_same(instr, decin)) {
-        print("Disassembled as:\n");
-        instr_disassemble(dc, decin, STDERR);
-        print("\n");
-        ASSERT(instr_same(instr, decin));
-    }
-
-    instr_destroy(dc, instr);
-    instr_destroy(dc, decin);
-    return pc;
-}
-
-static void
-test_instr_encoding_failure(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
-{
-    byte *pc;
-
-    pc = instr_encode_to_copy(dc, instr, buf, instr_pc);
-    ASSERT(pc == NULL);
-    instr_destroy(dc, instr);
-}
-
-static byte *
-test_instr_decoding_failure(void *dc, uint raw_instr)
-{
-    instr_t *decin;
-    byte *pc;
-
-    *(uint *)buf = raw_instr;
-    decin = instr_create(dc);
-    pc = decode(dc, buf, decin);
-    /* Returns NULL on failure. */
-    ASSERT(pc == NULL);
-    instr_destroy(dc, decin);
-    return pc;
-}
-
-static void
-test_instr_encoding_jal_or_branch(void *dc, uint opcode, instr_t *instr)
-{
-    /* XXX i#3544: For jal and branch instructions, current disassembler will print
-     * the complete jump address, that is, an address relative to `buf`. But the
-     * value of `buf` is indeterminate at runtime, so we skip checking the disassembled
-     * format for these instructions. Same for test_instr_encoding_auipc().
-     *
-     * FIXME i#3544: For branch instructions, we should use relative offsets instead.
-     */
-    instr_t *decin;
-    byte *pc, *next_pc;
-
-    ASSERT(instr_get_opcode(instr) == opcode);
-    ASSERT(instr_is_encoding_possible(instr));
-    pc = instr_encode(dc, instr, buf);
-    ASSERT(pc != NULL);
-    decin = instr_create(dc);
-    next_pc = decode(dc, buf, decin);
-    ASSERT(next_pc != NULL);
-    ASSERT(instr_same(instr, decin));
-    instr_destroy(dc, instr);
-    instr_destroy(dc, decin);
-}
-
-static void
-test_instr_encoding_auipc(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
-{
-    instr_t *decin;
-    byte *pc, *next_pc;
-
-    ASSERT(instr_get_opcode(instr) == opcode);
-    ASSERT(instr_is_encoding_possible(instr));
-    pc = instr_encode_to_copy(dc, instr, buf, instr_pc);
-    ASSERT(pc != NULL);
-    decin = instr_create(dc);
-    next_pc = decode_from_copy(dc, buf, instr_pc, decin);
-    ASSERT(next_pc != NULL);
-    ASSERT(instr_same(instr, decin));
-    instr_destroy(dc, instr);
-    instr_destroy(dc, decin);
-}
+#include "ir_riscv64.h"
 
 static void
 test_integer_load_store(void *dc)
@@ -1068,59 +959,17 @@ test_jump_and_branch(void *dc)
                              opnd_create_immed_int(42, OPSZ_20b));
     pc = test_instr_encoding(dc, OP_lui, instr);
 
-    /* Not printing disassembly for jal and branch instructions below, see comment of
-     * test_instr_encoding_jal_or_branch(). */
-    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
-                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
-    test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
-
-    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
-                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
-    test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
-
-    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
-                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
-    /* This is expected to fail since we are using an unaligned PC (i.e. target_pc -
-     * instr_encode_pc has non-zero lower 12 bits). */
-    test_instr_encoding_failure(dc, OP_auipc, pc + 4, instr);
-
-    instr = INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_A0), opnd_create_pc(pc));
-    test_instr_encoding_jal_or_branch(dc, OP_jal, instr);
     instr = INSTR_CREATE_jalr(dc, opnd_create_reg(DR_REG_A0), opnd_create_reg(DR_REG_A1),
                               opnd_create_immed_int(42, OPSZ_12b));
     test_instr_encoding(dc, OP_jalr, instr);
 
-    instr = INSTR_CREATE_beq(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
-                             opnd_create_reg(DR_REG_A1));
-    test_instr_encoding_jal_or_branch(dc, OP_beq, instr);
-    instr = INSTR_CREATE_bne(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
-                             opnd_create_reg(DR_REG_A1));
-    test_instr_encoding_jal_or_branch(dc, OP_bne, instr);
-    instr = INSTR_CREATE_blt(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
-                             opnd_create_reg(DR_REG_A1));
-    test_instr_encoding_jal_or_branch(dc, OP_blt, instr);
-    instr = INSTR_CREATE_bge(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
-                             opnd_create_reg(DR_REG_A1));
-    test_instr_encoding_jal_or_branch(dc, OP_bge, instr);
-    instr = INSTR_CREATE_bltu(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
-                              opnd_create_reg(DR_REG_A1));
-    test_instr_encoding_jal_or_branch(dc, OP_bltu, instr);
-    instr = INSTR_CREATE_bgeu(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
-                              opnd_create_reg(DR_REG_A1));
-    test_instr_encoding_jal_or_branch(dc, OP_bgeu, instr);
-
     /* Compressed */
-    instr = INSTR_CREATE_c_j(dc, opnd_create_pc(pc));
-    test_instr_encoding_jal_or_branch(dc, OP_c_j, instr);
     instr = INSTR_CREATE_c_jr(dc, opnd_create_reg(DR_REG_A0));
-    test_instr_encoding_jal_or_branch(dc, OP_c_jr, instr);
-    /* There is no c.jal in RV64. */
+    test_instr_encoding(dc, OP_c_jr, instr);
+
     instr = INSTR_CREATE_c_jalr(dc, opnd_create_reg(DR_REG_A0));
     test_instr_encoding(dc, OP_c_jalr, instr);
-    instr = INSTR_CREATE_c_beqz(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_X8));
-    test_instr_encoding_jal_or_branch(dc, OP_c_beqz, instr);
-    instr = INSTR_CREATE_c_bnez(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_X8));
-    test_instr_encoding_jal_or_branch(dc, OP_c_bnez, instr);
+
     instr = INSTR_CREATE_c_li(dc, opnd_create_reg(DR_REG_A1),
                               opnd_create_immed_int((1 << 5) - 1, OPSZ_5b));
     test_instr_encoding(dc, OP_c_li, instr);
@@ -1441,23 +1290,6 @@ test_xinst(void *dc)
     ASSERT(opnd_is_immed_int(instr_get_src(instr, 1)) &&
            opnd_get_immed_int(instr_get_src(instr, 1)) == 0);
     test_instr_encoding(dc, OP_jalr, instr);
-
-    /* Not printing disassembly for jal and branch instructions below, see comment of
-     * test_instr_encoding_jal_or_branch(). */
-    instr = XINST_CREATE_jump(dc, opnd_create_pc(pc));
-    ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&
-           opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_ZERO);
-    test_instr_encoding_jal_or_branch(dc, OP_jal, instr);
-
-    instr = XINST_CREATE_jump_short(dc, opnd_create_pc(pc));
-    ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&
-           opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_ZERO);
-    test_instr_encoding_jal_or_branch(dc, OP_jal, instr);
-
-    instr = XINST_CREATE_call(dc, opnd_create_pc(pc));
-    ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&
-           opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_RA);
-    test_instr_encoding_jal_or_branch(dc, OP_jal, instr);
 
     instr = XINST_CREATE_add(dc, opnd_create_reg(DR_REG_A0), opnd_create_reg(DR_REG_A1));
     ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&

--- a/suite/tests/api/ir_riscv64.expect
+++ b/suite/tests/api/ir_riscv64.expect
@@ -221,8 +221,8 @@ c.xor  fp a5 -> fp
 c.sub  fp a5 -> fp
 test_integer_arith complete
 lui    0x2a -> a0
-<Internal Error: Failed to encode instruction: 'auipc  <rel> 0x000055555556f014 -> a0'>
 jalr   a1 42 -> a0
+c.jr   a0 0 -> zero
 c.jalr a0 0 -> ra
 c.li   zero 31 -> a1
 c.lui  0x1 -> a1

--- a/suite/tests/api/ir_riscv64.h
+++ b/suite/tests/api/ir_riscv64.h
@@ -64,6 +64,6 @@ byte *
 test_instr_decoding_failure(void *dc, uint raw_instr);
 
 #define test_instr_encoding(dc, opcode, instr) \
-    test_instr_encoding_copy(dc, opcode, (app_pc) & buf, instr)
+    test_instr_encoding_copy(dc, opcode, (app_pc)&buf, instr)
 
 #endif /* IR_RISCV64_H */

--- a/suite/tests/api/ir_riscv64.h
+++ b/suite/tests/api/ir_riscv64.h
@@ -1,0 +1,100 @@
+/* **********************************************************
+ * Copyright (c) 2024 Institute of Software Chinese Academy of Sciences (ISCAS).
+ * All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ISCAS nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ISCAS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+static byte buf[8192];
+
+#ifdef STANDALONE_DECODER
+#    define ASSERT(x)                                                                 \
+        ((void)((!(x)) ? (fprintf(stderr, "ASSERT FAILURE (standalone): %s:%d: %s\n", \
+                                  __FILE__, __LINE__, #x),                            \
+                          abort(), 0)                                                 \
+                       : 0))
+#else
+#    define ASSERT(x)                                                                \
+        ((void)((!(x)) ? (dr_fprintf(STDERR, "ASSERT FAILURE (client): %s:%d: %s\n", \
+                                     __FILE__, __LINE__, #x),                        \
+                          dr_abort(), 0)                                             \
+                       : 0))
+#endif
+
+static byte *
+test_instr_encoding(void *dc, uint opcode, instr_t *instr)
+{
+    instr_t *decin;
+    byte *pc, *next_pc;
+
+    ASSERT(instr_get_opcode(instr) == opcode);
+    instr_disassemble(dc, instr, STDERR);
+    print("\n");
+    ASSERT(instr_is_encoding_possible(instr));
+    pc = instr_encode(dc, instr, buf);
+    ASSERT(pc != NULL);
+    decin = instr_create(dc);
+    next_pc = decode(dc, buf, decin);
+    ASSERT(next_pc != NULL);
+    if (!instr_same(instr, decin)) {
+        print("Disassembled as:\n");
+        instr_disassemble(dc, decin, STDERR);
+        print("\n");
+        ASSERT(instr_same(instr, decin));
+    }
+
+    instr_destroy(dc, instr);
+    instr_destroy(dc, decin);
+    return pc;
+}
+
+static void
+test_instr_encoding_failure(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
+{
+    byte *pc;
+
+    pc = instr_encode_to_copy(dc, instr, buf, instr_pc);
+    ASSERT(pc == NULL);
+    instr_destroy(dc, instr);
+}
+
+static byte *
+test_instr_decoding_failure(void *dc, uint raw_instr)
+{
+    instr_t *decin;
+    byte *pc;
+
+    *(uint *)buf = raw_instr;
+    decin = instr_create(dc);
+    pc = decode(dc, buf, decin);
+    /* Returns NULL on failure. */
+    ASSERT(pc == NULL);
+    instr_destroy(dc, decin);
+    return pc;
+}

--- a/suite/tests/api/ir_riscv64.h
+++ b/suite/tests/api/ir_riscv64.h
@@ -58,12 +58,11 @@ extern byte buf[8192];
 
 byte *
 test_instr_encoding_copy(void *dc, uint opcode, app_pc instr_pc, instr_t *instr);
+byte *
+test_instr_encoding(void *dc, uint opcode, instr_t *instr);
 void
 test_instr_encoding_failure(void *dc, uint opcode, app_pc instr_pc, instr_t *instr);
 byte *
 test_instr_decoding_failure(void *dc, uint raw_instr);
-
-#define test_instr_encoding(dc, opcode, instr) \
-    test_instr_encoding_copy(dc, opcode, (app_pc)&buf, instr)
 
 #endif /* IR_RISCV64_H */

--- a/suite/tests/api/ir_riscv64_common.c
+++ b/suite/tests/api/ir_riscv64_common.c
@@ -62,6 +62,12 @@ test_instr_encoding_copy(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
     return pc;
 }
 
+byte *
+test_instr_encoding(void *dc, uint opcode, instr_t *instr)
+{
+    return test_instr_encoding_copy(dc, opcode, (app_pc)&buf, instr);
+}
+
 void
 test_instr_encoding_failure(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
 {

--- a/suite/tests/api/ir_rv64_addr.c
+++ b/suite/tests/api/ir_rv64_addr.c
@@ -50,50 +50,19 @@
 
 #include "ir_riscv64.h"
 
-static byte *
-test_instr_encoding_auipc(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
-{
-    instr_t *decin;
-    byte *pc, *next_pc;
-
-    ASSERT(instr_get_opcode(instr) == opcode);
-    instr_disassemble(dc, instr, STDERR);
-    print("\n");
-    ASSERT(instr_is_encoding_possible(instr));
-    pc = instr_encode_to_copy(dc, instr, buf, instr_pc);
-    ASSERT(pc != NULL);
-    decin = instr_create(dc);
-    next_pc = decode_from_copy(dc, buf, instr_pc, decin);
-    ASSERT(next_pc != NULL);
-    if (!instr_same(instr, decin)) {
-        print("Disassembled as:\n");
-        instr_disassemble(dc, decin, STDERR);
-        print("\n");
-        ASSERT(instr_same(instr, decin));
-    }
-
-    instr_destroy(dc, instr);
-    instr_destroy(dc, decin);
-    return pc;
-}
-
 static void
 test_jump_and_branch(void *dc)
 {
-    byte *pc;
+    byte *pc = (byte *)&buf;
     instr_t *instr;
 
-    instr = INSTR_CREATE_lui(dc, opnd_create_reg(DR_REG_A0),
-                             opnd_create_immed_int(42, OPSZ_20b));
-    pc = test_instr_encoding(dc, OP_lui, instr);
+    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
+                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
+    test_instr_encoding_copy(dc, OP_auipc, pc, instr);
 
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
                                OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
-    test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
-
-    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
-                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
-    test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
+    test_instr_encoding_copy(dc, OP_auipc, pc, instr);
 
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
                                OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));

--- a/suite/tests/api/ir_rv64_addr.c
+++ b/suite/tests/api/ir_rv64_addr.c
@@ -1,0 +1,176 @@
+/* **********************************************************
+ * Copyright (c) 2024 Institute of Software Chinese Academy of Sciences (ISCAS).
+ * All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of ISCAS nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL ISCAS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Define DR_FAST_IR to verify that everything compiles when we call the inline
+ * versions of these routines.
+ */
+#ifndef STANDALONE_DECODER
+#    define DR_FAST_IR 1
+#endif
+
+/* Uses the DR API, using DR as a standalone library, rather than
+ * being a client library working with DR on a target program.
+ */
+
+#include "configure.h"
+#include "dr_api.h"
+#include "dr_defines.h"
+#include "dr_ir_utils.h"
+#include "tools.h"
+
+#include "ir_riscv64.h"
+
+static byte *
+test_instr_encoding_auipc(void *dc, uint opcode, app_pc instr_pc, instr_t *instr)
+{
+    instr_t *decin;
+    byte *pc, *next_pc;
+
+    ASSERT(instr_get_opcode(instr) == opcode);
+    instr_disassemble(dc, instr, STDERR);
+    print("\n");
+    ASSERT(instr_is_encoding_possible(instr));
+    pc = instr_encode_to_copy(dc, instr, buf, instr_pc);
+    ASSERT(pc != NULL);
+    decin = instr_create(dc);
+    next_pc = decode_from_copy(dc, buf, instr_pc, decin);
+    ASSERT(next_pc != NULL);
+    if (!instr_same(instr, decin)) {
+        print("Disassembled as:\n");
+        instr_disassemble(dc, decin, STDERR);
+        print("\n");
+        ASSERT(instr_same(instr, decin));
+    }
+
+    instr_destroy(dc, instr);
+    instr_destroy(dc, decin);
+    return pc;
+}
+
+static void
+test_jump_and_branch(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    instr = INSTR_CREATE_lui(dc, opnd_create_reg(DR_REG_A0),
+                             opnd_create_immed_int(42, OPSZ_20b));
+    pc = test_instr_encoding(dc, OP_lui, instr);
+
+    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
+                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
+    test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
+
+    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
+                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
+    test_instr_encoding_auipc(dc, OP_auipc, pc, instr);
+
+    instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
+                               OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
+    /* This is expected to fail since we are using an unaligned PC (i.e. target_pc -
+     * instr_encode_pc has non-zero lower 12 bits). */
+    test_instr_encoding_failure(dc, OP_auipc, pc + 4, instr);
+
+    instr = INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_A0), opnd_create_pc(pc));
+    test_instr_encoding(dc, OP_jal, instr);
+
+    instr = INSTR_CREATE_beq(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
+                             opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_beq, instr);
+    instr = INSTR_CREATE_bne(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
+                             opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_bne, instr);
+    instr = INSTR_CREATE_blt(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
+                             opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_blt, instr);
+    instr = INSTR_CREATE_bge(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
+                             opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_bge, instr);
+    instr = INSTR_CREATE_bltu(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
+                              opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_bltu, instr);
+    instr = INSTR_CREATE_bgeu(dc, opnd_create_pc(pc), opnd_create_reg(DR_REG_A0),
+                              opnd_create_reg(DR_REG_A1));
+    test_instr_encoding(dc, OP_bgeu, instr);
+
+    /* Compressed */
+    instr = INSTR_CREATE_c_j(dc, opnd_create_pc(pc));
+    test_instr_encoding(dc, OP_c_j, instr);
+}
+
+static void
+test_xinst(void *dc)
+{
+    byte *pc;
+    instr_t *instr;
+
+    instr = INSTR_CREATE_lui(dc, opnd_create_reg(DR_REG_A0),
+                             opnd_create_immed_int(42, OPSZ_20b));
+    pc = test_instr_encoding(dc, OP_lui, instr);
+
+    instr = XINST_CREATE_jump(dc, opnd_create_pc(pc));
+    ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&
+           opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_ZERO);
+    test_instr_encoding(dc, OP_jal, instr);
+
+    instr = XINST_CREATE_jump_short(dc, opnd_create_pc(pc));
+    ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&
+           opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_ZERO);
+    test_instr_encoding(dc, OP_jal, instr);
+
+    instr = XINST_CREATE_call(dc, opnd_create_pc(pc));
+    ASSERT(opnd_is_reg(instr_get_dst(instr, 0)) &&
+           opnd_get_reg(instr_get_dst(instr, 0)) == DR_REG_RA);
+    test_instr_encoding(dc, OP_jal, instr);
+}
+
+int
+main(int argc, char *argv[])
+{
+#ifdef STANDALONE_DECODER
+    void *dcontext = GLOBAL_DCONTEXT;
+#else
+    void *dcontext = dr_standalone_init();
+#endif
+
+    disassemble_set_syntax(DR_DISASM_RISCV);
+
+    test_jump_and_branch(dcontext);
+    print("test_jump_and_branch complete\n");
+
+    test_xinst(dcontext);
+    print("test_xinst complete\n");
+
+    print("All tests complete\n");
+    return 0;
+}

--- a/suite/tests/api/ir_rv64_addr.c
+++ b/suite/tests/api/ir_rv64_addr.c
@@ -56,6 +56,7 @@ test_jump_and_branch(void *dc)
     byte *pc = (byte *)&buf;
     instr_t *instr;
 
+    /* (3 << 12) is a random offset with lowest 12 bits zeroed (see notes below) */
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
                                OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
     test_instr_encoding_copy(dc, OP_auipc, pc, instr);
@@ -67,7 +68,8 @@ test_jump_and_branch(void *dc)
     instr = INSTR_CREATE_auipc(dc, opnd_create_reg(DR_REG_A0),
                                OPND_CREATE_ABSMEM(pc + (3 << 12), OPSZ_0));
     /* This is expected to fail since we are using an unaligned PC (i.e. target_pc -
-     * instr_encode_pc has non-zero lower 12 bits). */
+     * instr_encode_pc has non-zero lower 12 bits, which cannot be encoded in a
+     * single auipc instruction). */
     test_instr_encoding_failure(dc, OP_auipc, pc + 4, instr);
 
     instr = INSTR_CREATE_jal(dc, opnd_create_reg(DR_REG_A0), opnd_create_pc(pc));

--- a/suite/tests/api/ir_rv64_addr.templatex
+++ b/suite/tests/api/ir_rv64_addr.templatex
@@ -1,0 +1,19 @@
+lui    0x2a -> a0
+auipc  <rel> 0x[0-9a-f]+ -> a0
+auipc  <rel> 0x[0-9a-f]+ -> a0
+<Internal Error: Failed to encode instruction: 'auipc  <rel> 0x[0-9a-f]+ -> a0'>
+jal    0x[0-9a-f]+ -> a0
+beq    0x[0-9a-f]+ a0 a1
+bne    0x[0-9a-f]+ a0 a1
+blt    0x[0-9a-f]+ a0 a1
+bge    0x[0-9a-f]+ a0 a1
+bltu   0x[0-9a-f]+ a0 a1
+bgeu   0x[0-9a-f]+ a0 a1
+c.j    0x[0-9a-f]+ -> zero
+test_jump_and_branch complete
+lui    0x2a -> a0
+jal    0x[0-9a-f]+ -> zero
+jal    0x[0-9a-f]+ -> zero
+jal    0x[0-9a-f]+ -> ra
+test_xinst complete
+All tests complete

--- a/suite/tests/api/ir_rv64_addr.templatex
+++ b/suite/tests/api/ir_rv64_addr.templatex
@@ -1,4 +1,3 @@
-lui    0x2a -> a0
 auipc  <rel> 0x[0-9a-f]+ -> a0
 auipc  <rel> 0x[0-9a-f]+ -> a0
 <Internal Error: Failed to encode instruction: 'auipc  <rel> 0x[0-9a-f]+ -> a0'>


### PR DESCRIPTION
Disassemble result of instructions like jal and auipc on riscv64 is PC-sensitve, i.e. depends on the current PC value. We used to omit the check since address of the buffer that we encode instructions to is unknown before running the test.

This commit splits IR tests of these instructions out and enables regex match to handle the varying addresses. It's important to keep it small and standalone to workaround the inefficient regex implementation of CMake.

Issue: #3544