### PR TITLE
i#2626 AArch64: Add register FPMR.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -140,6 +140,7 @@ Further non-compatibility-affecting changes include:
    restriction as dr_suspend_all_other_threads_ex(). For X86_64 platform, the feature is
    supported only when fast FP save and restore is supported. And mixed mode is not
    supported.
+ - Added the AArch64 FPMR register as DR_REG_FPMR.
 
 **************************************************
 <hr>

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -298,6 +298,7 @@ decode_sysreg(uint imm15)
     case 0x5a10: sysreg = DR_REG_NZCV; break;
     case 0x5a20: sysreg = DR_REG_FPCR; break;
     case 0x5a21: sysreg = DR_REG_FPSR; break;
+    case 0x5a22: sysreg = DR_REG_FPMR; break;
     case 0x1808: sysreg = DR_REG_MDCCSR_EL0; break;
     case 0x1820: sysreg = DR_REG_DBGDTR_EL0; break;
     case 0x1828: sysreg = DR_REG_DBGDTRRX_EL0; break;
@@ -433,6 +434,7 @@ encode_sysreg(OUT uint *imm15, opnd_t opnd)
         case DR_REG_NZCV: *imm15 = 0x5a10; break;
         case DR_REG_FPCR: *imm15 = 0x5a20; break;
         case DR_REG_FPSR: *imm15 = 0x5a21; break;
+        case DR_REG_FPMR: *imm15 = 0x5a22; break;
         case DR_REG_MDCCSR_EL0: *imm15 = 0x1808; break;
         case DR_REG_DBGDTR_EL0: *imm15 = 0x1820; break;
         case DR_REG_DBGDTRRX_EL0: *imm15 = 0x1828; break;

--- a/core/ir/aarch64/encode.c
+++ b/core/ir/aarch64/encode.c
@@ -121,6 +121,8 @@ const char *const reg_names[] = {
     "cntvct_el0", "id_aa64isar0_el1", "id_aa64isar1_el1", "id_aa64isar2_el1",
     "id_aa64pfr0_el1", "id_aa64mmfr1_el1", "id_aa64dfr0_el1", "id_aa64zfr0_el1",
     "id_aa64pfr1_el1", "id_aa64mmfr2_el1", "midr_el1", "mpidr_el1", "revidr_el1",
+
+    "fpmr",
 };
 
 
@@ -200,6 +202,8 @@ const reg_id_t dr_reg_fixer[] = { REG_NULL,
     DR_REG_ID_AA64ISAR2_EL1, DR_REG_ID_AA64PFR0_EL1, DR_REG_ID_AA64MMFR1_EL1,
     DR_REG_ID_AA64DFR0_EL1, DR_REG_ID_AA64ZFR0_EL1, DR_REG_ID_AA64PFR1_EL1,
     DR_REG_ID_AA64MMFR2_EL1, DR_REG_MIDR_EL1, DR_REG_MPIDR_EL1, DR_REG_REVIDR_EL1,
+
+    DR_REG_FPMR,
 };
 
 /* Maps real ISA registers to their corresponding virtual DR_ISA_REGDEPS register.
@@ -386,6 +390,8 @@ const reg_id_t d_r_reg_id_to_virtual[] = {
     DR_REG_VIRT206, /* DR_REG_MIDR_EL1 */
     DR_REG_VIRT207, /* DR_REG_MPIDR_EL1 */
     DR_REG_VIRT208, /* DR_REG_REVIDR_EL1 */
+
+    DR_REG_VIRT209, /* DR_REG_FPMR */
 };
 /* clang-format on */
 

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1059,6 +1059,7 @@ enum {
     DR_REG_MIDR_EL1,         /**< The "midr_el1" register. */
     DR_REG_MPIDR_EL1,        /**< The "mpidr_el1" register. */
     DR_REG_REVIDR_EL1,       /**< The "revidr_el1" register. */
+    DR_REG_FPMR,             /**< The "fpmr" register. */
 #    endif
 
 /* Aliases below here: */
@@ -1115,12 +1116,12 @@ enum {
     /** Thread Pointer/ID Register, Read-Only, EL0. */
     DR_REG_TPIDRRO_EL0 = DR_REG_TPIDRURO,
     /* ARMv7 Thread Registers */
-    DR_REG_CP15_C13_2 = DR_REG_TPIDRURW,        /**< User Read/Write Thread ID Register */
-    DR_REG_CP15_C13_3 = DR_REG_TPIDRURO,        /**< User Read-Only Thread ID Register */
+    DR_REG_CP15_C13_2 = DR_REG_TPIDRURW,  /**< User Read/Write Thread ID Register */
+    DR_REG_CP15_C13_3 = DR_REG_TPIDRURO,  /**< User Read-Only Thread ID Register */
 
 #    ifdef AARCH64
-    DR_REG_LAST_VALID_ENUM = DR_REG_REVIDR_EL1, /**< Last valid register enum */
-    DR_REG_LAST_ENUM = DR_REG_REVIDR_EL1,       /**< Last value of register enums */
+    DR_REG_LAST_VALID_ENUM = DR_REG_FPMR, /**< Last valid register enum */
+    DR_REG_LAST_ENUM = DR_REG_FPMR,       /**< Last value of register enums */
 #    else
     DR_REG_LAST_VALID_ENUM = DR_REG_TPIDRURO, /**< Last valid register enum */
     DR_REG_LAST_ENUM = DR_REG_TPIDRURO,       /**< Last value of register enums */

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2780,7 +2780,7 @@ reg_get_size(reg_id_t reg)
     }
     if ((reg >= DR_REG_P0 && reg <= DR_REG_P15) || reg == DR_REG_FFR)
         return OPSZ_SVE_PREDLEN_BYTES;
-    if (reg >= DR_REG_CNTVCT_EL0 && reg <= DR_REG_REVIDR_EL1)
+    if (reg >= DR_REG_CNTVCT_EL0 && reg <= DR_REG_FPMR)
         return OPSZ_8;
     if (reg >= DR_REG_NZCV && reg <= DR_REG_FPSR)
         return OPSZ_8;


### PR DESCRIPTION
FPMR is present only when FEAT_FPMR is implemented. It is then part of the user-mode execution state and controls the behaviour of instructions that operate on 8-bit floating-point values.

DR_REG_FPMR is added at the end of the DR_REG_ enum to improve ABI compatibility.

Change-Id: Ife0bc0239d029ca3f83fe7d6b5ecbbaceebfac5f