### PR TITLE
i#6238 op cat: Change fence opcode category to STATE

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -6597,7 +6597,10 @@ const instr_info_t mod_extensions[][2] = {
   },
   { /* mod extension 3 */
     {OP_clflush, 0x0fae37, catSIMD, "clflush", xx, xx, Mb, xx, xx, mrm, x, END_LIST},
-    {OP_sfence,  0xf80fae77, catStore | catSIMD, "sfence",  xx, xx, xx, xx, xx, mrm, x, END_LIST},
+    // If we add an "atomic" category we'd put this there.
+    // Without it, "state" might best be interpreted as a barrier, so we use it for
+    // all the OP_*fence opcodes.
+    {OP_sfence,  0xf80fae77, catState, "sfence",  xx, xx, xx, xx, xx, mrm, x, END_LIST},
   },
   { /* mod extension 4 */
     {OP_lidt,   0x0f0133, catLoad, "lidt",  xx, xx, Ms, xx, xx, mrm, x, END_LIST},
@@ -6610,11 +6613,11 @@ const instr_info_t mod_extensions[][2] = {
   { /* mod extension 6 */
     {REX_W_EXT, 0x0fae35, catUncategorized, "(rex.w ext 3)", xx, xx, xx, xx, xx, mrm, x, 3},
     /* note that gdb thinks e9-ef are "lfence (bad)" (PR 239920) */
-    {OP_lfence, 0xe80fae75, catLoad, "lfence", xx, xx, xx, xx, xx, mrm, x, END_LIST},
+    {OP_lfence, 0xe80fae75, catState, "lfence", xx, xx, xx, xx, xx, mrm, x, END_LIST},
   },
   { /* mod extension 7 */
     {REX_W_EXT,   0x0fae36, catUncategorized, "(rex.w ext 4)", xx, xx, xx, xx, xx, mrm, x, 4},
-    {OP_mfence,   0xf00fae76, catUncategorized, "mfence", xx, xx, xx, xx, xx, mrm, x, END_LIST},
+    {OP_mfence,   0xf00fae76, catState, "mfence", xx, xx, xx, xx, xx, mrm, x, END_LIST},
   },
   { /* mod extension 8 */
     {OP_vmovss,  0xf30f1010, catFP | catMove | catSIMD, "vmovss",  Vdq, xx, Wss,  xx, xx, mrm|vex, x, modx[10][0]},


### PR DESCRIPTION
The x86 OP_*fence opcodes were marked with inaccurate categories in the original PR #6308. Here we change all 3 to DR_INSTR_CATEGORY_STATE under the logic that the STATE category is the one most likely to be interpreted as a barrier by a simulator. (If we add an ATOMIC category in the future we'll switch to that.)

Issue: #6238