### PR TITLE
i#7111 cache opcodes: Add CLFLUSHOPT handling to drmemtrace

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -2825,8 +2825,11 @@ check_read_write_records_match_operands()
     {
         instr_t *clflush = INSTR_CREATE_clflush(
             GLOBAL_DCONTEXT, OPND_CREATE_MEM_clflush(REG1, REG_NULL, 0, 0));
+        instr_t *clflushopt = INSTR_CREATE_clflushopt(
+            GLOBAL_DCONTEXT, OPND_CREATE_MEM_clflush(REG1, REG_NULL, 0, 0));
         instrlist_t *ilist = instrlist_create(GLOBAL_DCONTEXT);
         instrlist_append(ilist, clflush);
+        instrlist_append(ilist, clflushopt);
         static constexpr addr_t BASE_ADDR = 0xeba4ad4;
         std::vector<memref_with_IR_t> memref_setup = {
             { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ENCODINGS),
@@ -2834,6 +2837,9 @@ check_read_write_records_match_operands()
             { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
             { gen_instr(TID_A), clflush },
+            { gen_addr(TID_A, /*type=*/TRACE_TYPE_DATA_FLUSH, /*addr=*/0, /*size=*/0),
+              nullptr },
+            { gen_instr(TID_A), clflushopt },
             { gen_addr(TID_A, /*type=*/TRACE_TYPE_DATA_FLUSH, /*addr=*/0, /*size=*/0),
               nullptr },
             { gen_exit(TID_A), nullptr },

--- a/clients/drcachesim/tracer/instru.cpp
+++ b/clients/drcachesim/tracer/instru.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -224,7 +224,7 @@ instru_t::instr_is_flush(instr_t *instr)
 {
     // Assuming we won't see any privileged instructions.
 #ifdef X86
-    if (instr_get_opcode(instr) == OP_clflush)
+    if (instr_get_opcode(instr) == OP_clflush || instr_get_opcode(instr) == OP_clflushopt)
         return true;
 #endif
 #ifdef AARCH64
@@ -239,9 +239,9 @@ instru_t::instr_to_flush_type(instr_t *instr)
 {
     DR_ASSERT(instr_is_flush(instr));
 #ifdef X86
-    // XXX: OP_clflush invalidates all levels of the processor cache
-    // hierarchy (data and instruction)
-    if (instr_get_opcode(instr) == OP_clflush)
+    // XXX: OP_clflush* invalidates all levels of the processor cache
+    // hierarchy (data and instruction).
+    if (instr_get_opcode(instr) == OP_clflush || instr_get_opcode(instr) == OP_clflushopt)
         return TRACE_TYPE_DATA_FLUSH;
 #endif
 #ifdef AARCH64


### PR DESCRIPTION
Adds handling to drmemtrace for the x86 CLFLUSHOPT opcode to treat it just like CLFLUSH; the two are similar enough for most uses.

Augments the existing CLFLUSH invariant_checker test as a sanity test of the new opcode handling.

Issue: #7111