### PR TITLE
Fix failing Windows build (`std::replace` requires `<algorithm>`)

### DIFF
--- a/clients/drcachesim/tracer/raw2trace_directory.cpp
+++ b/clients/drcachesim/tracer/raw2trace_directory.cpp
@@ -43,6 +43,7 @@
 #    include <windows.h>
 #endif
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
In raw2trace_directory.cpp, `std::replace` requires `<algorithm>`.