### PR TITLE
i#3699: Remove retcode from 32-bit ARM rt_sigframe.

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -3671,7 +3671,6 @@ convert_frame_to_nonrt(dcontext_t *dcontext, int sig, sigframe_rt_t *f_old,
     f_new->sig_noclobber = f_new->sig;
 #    elif defined(ARM)
     memcpy(&f_new->uc, &f_old->uc, sizeof(f_new->uc));
-    memcpy(f_new->retcode, f_old->retcode, sizeof(f_new->retcode));
     /* now fill in our extra field */
     f_new->sig_noclobber = f_old->info.si_signo;
 #    endif /* X86 */

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -286,9 +286,6 @@ typedef struct rt_sigframe {
 #    elif defined(AARCHXX)
     kernel_siginfo_t info;
     kernel_ucontext_t uc;
-#        ifdef ARM
-    char retcode[RETCODE_SIZE];
-#        endif
 #    elif defined(RISCV64)
     kernel_siginfo_t info;
     kernel_ucontext_t uc;


### PR DESCRIPTION
The definition did not agree with the Linux kernel's definition.
There is a retcode field in sigframe, but not in rt_sigframe.

This change made the previously failing common.segfault test pass
in a Debian 10 container running under a 64-bit 5.4.47 kernel
on Cortex-A72 hardware.

Issue: #3699