### PR TITLE
Use syscall instead of C library's gettid in drcachesim test.

### DIFF
--- a/clients/drcachesim/tests/burst_syscall_inject.cpp
+++ b/clients/drcachesim/tests/burst_syscall_inject.cpp
@@ -53,6 +53,7 @@
 #include <iostream>
 #include <string>
 #include <sys/syscall.h>
+#include <sys/types.h>
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -71,6 +72,12 @@ static instr_t *instr_in_gettid = nullptr;
         fflush(stderr);                                     \
         exit(1);                                            \
     } while (0)
+
+static pid_t
+gettid(void)
+{
+    return syscall(SYS_gettid);
+}
 
 static int
 do_some_syscalls()

--- a/clients/drcachesim/tests/burst_syscall_inject.cpp
+++ b/clients/drcachesim/tests/burst_syscall_inject.cpp
@@ -54,6 +54,9 @@
 #include <string>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#ifndef LINUX
+#    error Only Linux is supported
+#endif
 
 namespace dynamorio {
 namespace drmemtrace {


### PR DESCRIPTION
This is needed on Debian 10 and seems harmless on newer OS versions.