### PR TITLE
i#3699 ARM: Keep stack aligned in insert_{push,pop}_all_registers.

### DIFF
--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -665,6 +665,9 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
     dstack_offs += 15 * XSP_SZ;
 
     /* Make dstack_offs 8-byte algined, as we only accounted for 17 4-byte slots. */
+    PRE(ilist, instr,
+        XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP),
+                         OPND_CREATE_INT(XSP_SZ)));
     dstack_offs += XSP_SZ;
 #endif
     ASSERT(cci->skip_save_flags || cci->num_simd_skip != 0 || cci->num_regs_skip != 0 ||
@@ -769,6 +772,9 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
     }
 
 #else
+    PRE(ilist, instr,
+        XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_SP),
+                         OPND_CREATE_INT(XSP_SZ)));
     /* We rely on dr_set_mcontext_priv() to set the app's stolen reg value,
      * and the stack swap to set the sp value: we assume the stolen reg on
      * the stack still has our TLS base in it.

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -668,12 +668,14 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
                                   DR_REG_LIST_LENGTH_ARM, DR_REG_LIST_ARM));
         dstack_offs += DR_REG_LIST_LENGTH_ARM * XSP_SZ;
     }
-
-    /* Make dstack_offs 8-byte aligned, as we only accounted for 17 4-byte slots. */
+    /* Make dstack_offs 8-byte aligned as we have just pushed an odd
+     * number of 4-byte registers.
+     */
     PRE(ilist, instr,
         XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP), OPND_CREATE_INT(XSP_SZ)));
     dstack_offs += XSP_SZ;
     ASSERT(ALIGNED(dstack_offs, get_ABI_stack_alignment()));
+
 #endif
     ASSERT(cci->skip_save_flags || cci->num_simd_skip != 0 || cci->num_regs_skip != 0 ||
            dstack_offs == (uint)get_clean_call_switch_stack_size());

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -666,8 +666,7 @@ insert_push_all_registers(dcontext_t *dcontext, clean_call_info_t *cci,
 
     /* Make dstack_offs 8-byte algined, as we only accounted for 17 4-byte slots. */
     PRE(ilist, instr,
-        XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP),
-                         OPND_CREATE_INT(XSP_SZ)));
+        XINST_CREATE_sub(dcontext, opnd_create_reg(DR_REG_SP), OPND_CREATE_INT(XSP_SZ)));
     dstack_offs += XSP_SZ;
 #endif
     ASSERT(cci->skip_save_flags || cci->num_simd_skip != 0 || cci->num_regs_skip != 0 ||
@@ -773,8 +772,7 @@ insert_pop_all_registers(dcontext_t *dcontext, clean_call_info_t *cci, instrlist
 
 #else
     PRE(ilist, instr,
-        XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_SP),
-                         OPND_CREATE_INT(XSP_SZ)));
+        XINST_CREATE_add(dcontext, opnd_create_reg(DR_REG_SP), OPND_CREATE_INT(XSP_SZ)));
     /* We rely on dr_set_mcontext_priv() to set the app's stolen reg value,
      * and the stack swap to set the sp value: we assume the stolen reg on
      * the stack still has our TLS base in it.


### PR DESCRIPTION
dd1589c0c modified dstack_offs in insert_push_all_registers without generating an instruction that modifies SP. So add a SUB SP, SP, #4 there, and a corresponding ADD SP, SP, #4 in insert_pop_all_registers.

This made the test client.cleancallparams pass.

Issue: #3699