### PR TITLE
i#6662 public traces: add instr_t operation_size API

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -129,7 +129,8 @@ changes:
  - No compatibility changes yet.
 
 Further non-compatibility-affecting changes include:
- - No changes yet.
+ - Added instr_get_operation_size() and instr_set_operation_size() APIs for
+   #DR_ISA_REGDEPS #instr_t.
 
 **************************************************
 <hr>
@@ -161,8 +162,6 @@ Further non-compatibility-affecting changes include:
    source and destination operands were reversed).
  - Fixed the VEX-encoded forms of vaesdec/vaesdeclast/vaesenc/vaesenclast/vpclmulqdq
    to obey VEX.L, which they previously ignored.
- - Added instr_get_operation_size() and instr_set_operation_size() APIs for
-   #DR_ISA_REGDEPS #instr_t.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -161,6 +161,8 @@ Further non-compatibility-affecting changes include:
    source and destination operands were reversed).
  - Fixed the VEX-encoded forms of vaesdec/vaesdeclast/vaesenc/vaesenclast/vpclmulqdq
    to obey VEX.L, which they previously ignored.
+ - Added instr_get_operation_size() and instr_set_operation_size() APIs for
+   #DR_ISA_REGDEPS #instr_t.
 
 **************************************************
 <hr>

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -1997,6 +1997,22 @@ instr_convert_short_meta_jmp_to_long(void *drcontext, instrlist_t *ilist, instr_
 
 DR_API
 /**
+ * Returns the operation size of \p instr if it's a DR_ISA_REGDEPS instruction, OPSZ_NA
+ * otherwise.
+ */
+opnd_size_t
+instr_get_operation_size(instr_t *instr);
+
+DR_API
+/**
+ * Sets the operation size of \p instr to \p operation_size only if instr is a
+ * DR_ISA_REGDEPS instruction.
+ */
+void
+instr_set_operation_size(instr_t *instr, opnd_size_t operation_size);
+
+DR_API
+/**
  * Converts a real ISA (e.g., #DR_ISA_AMD64) instruction \p instr_real_isa into a
  * #DR_ISA_REGDEPS instruction and stores it into \p instr_regdeps_isa.
  * Assumes \p instr_regdeps_isa has been allocated by the caller (e.g., using

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -244,7 +244,7 @@ struct _instr_t {
 
     /* Used to hold the relative offset within an instruction list when encoding. */
     size_t offset;
-}; /* instr_t */
+};     /* instr_t */
 #endif /* DR_FAST_IR */
 
 /**

--- a/core/ir/instr_api.h
+++ b/core/ir/instr_api.h
@@ -244,7 +244,7 @@ struct _instr_t {
 
     /* Used to hold the relative offset within an instruction list when encoding. */
     size_t offset;
-};     /* instr_t */
+}; /* instr_t */
 #endif /* DR_FAST_IR */
 
 /**
@@ -1997,7 +1997,7 @@ instr_convert_short_meta_jmp_to_long(void *drcontext, instrlist_t *ilist, instr_
 
 DR_API
 /**
- * Returns the operation size of \p instr if it's a DR_ISA_REGDEPS instruction, OPSZ_NA
+ * Returns the operation size of \p instr if it's a #DR_ISA_REGDEPS instruction, #OPSZ_NA
  * otherwise.
  */
 opnd_size_t
@@ -2006,7 +2006,7 @@ instr_get_operation_size(instr_t *instr);
 DR_API
 /**
  * Sets the operation size of \p instr to \p operation_size only if instr is a
- * DR_ISA_REGDEPS instruction.
+ * #DR_ISA_REGDEPS instruction.
  */
 void
 instr_set_operation_size(instr_t *instr, opnd_size_t operation_size);

--- a/suite/tests/api/ir_regdeps.c
+++ b/suite/tests/api/ir_regdeps.c
@@ -112,9 +112,7 @@ test_instr_encode_decode_disassemble_synthetic(void *dc, instr_t *instr,
     /* Check instruction length.
      */
     ASSERT((next_pc_encode - bytes) == instr_length(dc, instr_synthetic_decoded));
-    ASSERT((next_pc_encode - bytes) == instr_length(dc, instr_synthetic_converted));
     ASSERT(instr_length(dc, instr_synthetic_decoded) != 0);
-    ASSERT(instr_length(dc, instr_synthetic_converted) != 0);
 
     /* Check for overflow.
      */

--- a/suite/tests/api/ir_regdeps.c
+++ b/suite/tests/api/ir_regdeps.c
@@ -108,10 +108,24 @@ test_instr_encode_decode_disassemble_synthetic(void *dc, instr_t *instr,
     byte *next_pc_decode = decode(dc, bytes, instr_synthetic_decoded);
     ASSERT(next_pc_decode != NULL);
     ASSERT(next_pc_encode == next_pc_decode);
+
+    /* Check instruction length.
+     */
+    ASSERT((next_pc_encode - bytes) == instr_length(dc, instr_synthetic_decoded));
+    ASSERT((next_pc_encode - bytes) == instr_length(dc, instr_synthetic_converted));
+    ASSERT(instr_length(dc, instr_synthetic_decoded) != 0);
+    ASSERT(instr_length(dc, instr_synthetic_converted) != 0);
+
     /* Check for overflow.
      */
     ASSERT((next_pc_encode - bytes) <= sizeof(bytes));
     ASSERT((next_pc_decode - bytes) <= sizeof(bytes));
+
+    /* Check operation size.
+     */
+    ASSERT(instr_get_operation_size(instr_synthetic_decoded) != OPSZ_NA);
+    ASSERT(instr_get_operation_size(instr_synthetic_decoded) ==
+           instr_get_operation_size(instr_synthetic_converted));
 
     /* Disassemble regdeps synthetic encodings to buffer.
      */


### PR DESCRIPTION
Adds instr_get_operation_size() and instr_set_operation_size() public
APIs for DR_ISA_REGDEPS instructions, which are currently the only
instructions for which operation_size is defined.

We set operation_size of DR_ISA_REGDEPS instructions with no
operands to OPSZ_0 in the convertion to REGDEPS process,
so decoded and converted instructions look the same.
Previously a converted instruction might have had an operation_size
different than OPSZ_0 even with no register operands, that would
then be corrected during encoding and subsequent decoding.
This is mostly for convenience when testing.

We update a test to also invoke the instr_length() API on
DR_ISA_REGDEPS instructions.

Issue #6662