### PR TITLE
i#6662 public traces: add signal and uncompleted instr invariants

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3603,6 +3603,7 @@ check_regdeps(void)
     }
 
     // Incorrect: TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION not allowed.
+    // XXX i#7155: Allow these markers once we update their values in record_filter.
     {
         std::vector<memref_t> memrefs = {
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ARCH_REGDEPS),

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3581,6 +3581,48 @@ check_regdeps(void)
 {
     std::cerr << "Testing regdeps traces\n";
 
+    // Incorrect: TRACE_MARKER_TYPE_SIGNAL_NUMBER not allowed.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ARCH_REGDEPS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SIGNAL_NUMBER, 42),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(
+                memrefs, true,
+                { "OFFLINE_FILE_TYPE_ARCH_REGDEPS traces cannot have "
+                  "TRACE_MARKER_TYPE_SIGNAL_NUMBER markers",
+                  /*tid=*/TID_A,
+                  /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                  /*instrs_since_last_timestamp=*/0 },
+                "Failed to catch non-allowed TRACE_MARKER_TYPE_SIGNAL_NUMBER marker"))
+            return false;
+    }
+
+    // Incorrect: TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION not allowed.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ARCH_REGDEPS),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION, 42),
+            gen_instr(TID_A),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, true,
+                         { "OFFLINE_FILE_TYPE_ARCH_REGDEPS traces cannot have "
+                           "TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION markers",
+                           /*tid=*/TID_A,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/0 },
+                         "Failed to catch non-allowed "
+                         "TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION marker"))
+            return false;
+    }
+
     // Incorrect: OFFLINE_FILE_TYPE_ARCH_AARCH64 not allowed.
     {
         std::vector<memref_t> memrefs = {

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1712,6 +1712,7 @@ invariant_checker_t::check_regdeps_invariants(per_shard_t *shard, const memref_t
                             "OFFLINE_FILE_TYPE_ARCH_REGDEPS traces cannot have "
                             "TRACE_MARKER_TYPE_SIGNAL_NUMBER markers");
             break;
+        // XXX i#7155: Allow these markers once we update their values in record_filter.
         case TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION:
             report_if_false(shard, false,
                             "OFFLINE_FILE_TYPE_ARCH_REGDEPS traces cannot have "

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1707,6 +1707,16 @@ invariant_checker_t::check_regdeps_invariants(per_shard_t *shard, const memref_t
                          "was not built on a Linux platform.\n";
 #endif
         } break;
+        case TRACE_MARKER_TYPE_SIGNAL_NUMBER:
+            report_if_false(shard, false,
+                            "OFFLINE_FILE_TYPE_ARCH_REGDEPS traces cannot have "
+                            "TRACE_MARKER_TYPE_SIGNAL_NUMBER markers");
+            break;
+        case TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION:
+            report_if_false(shard, false,
+                            "OFFLINE_FILE_TYPE_ARCH_REGDEPS traces cannot have "
+                            "TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION markers");
+            break;
         default:
             // All other markers are allowed.
             break;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4838,45 +4838,29 @@ if (BUILD_CLIENTS)
 
     if (X86 AND X64 AND UNIX AND NOT APPLE)
         # Run the invariant_checker on an OFFLINE_FILE_TYPE_ARCH_REGDEPS trace of
-        # ci_shared_app.
+        # ci_shared_app and kernel_xfer_app. We expect no invariant errors.
+        # Generate an OFFLINE_FILE_TYPE_ARCH_REGDEPS trace by running record_filter
+        # with: 1) -filter_encodings2regdeps to change instruction encodings; 2)
+        # -filter_keep_func_ids 4294967498 (which is SYS_futex, associated to the only
+        # TRACE_MARKER_TYPE_FUNC_* markers we want to keep),
+        # -filter_marker_types 19,25,27,28,30,40,41 (which correspond to
+        # TRACE_MARKER_TYPE_SYSCALL_IDX, TRACE_MARKER_TYPE_SYSCALL,
+        # TRACE_MARKER_TYPE_SYSCALL_TRACE_START, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
+        # TRACE_MARKER_TYPE_SYSCALL_FAILED, TRACE_MARKER_TYPE_SIGNAL_NUMBER,
+        # TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION), note that the removal of
+        # TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION is only temporary (xref i#7155);
+        # 3) -filter_modify_marker_value 3,-1 (which changes the value of
+        # TRACE_MARKER_TYPE_CPU_ID == 3 to INVALID_CPU_MARKER_VALUE == (uintptr_t)-1).
         set(testname "tool.invariant_checker_on_regdeps_trace_ci_shared_app")
         torun_record_filter("${testname}" ${ci_shared_app}
           "invariant_checker_on_regdeps_trace_ci_shared_app"
-          # Generate an OFFLINE_FILE_TYPE_ARCH_REGDEPS trace by running record_filter
-          # with -filter_encodings2regdeps to change instruction encodings,
-          # -filter_keep_func_ids 4294967498 (which is SYS_futex, associated to the only
-          # TRACE_MARKER_TYPE_FUNC_ markers we want to keep),
-          # -filter_marker_types 19,25,27,28,30 (which correspond to
-          # TRACE_MARKER_TYPE_SYSCALL_IDX, TRACE_MARKER_TYPE_SYSCALL,
-          # TRACE_MARKER_TYPE_SYSCALL_TRACE_START, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-          # TRACE_MARKER_TYPE_SYSCALL_FAILED,  TRACE_MARKER_TYPE_SIGNAL_NUMBER,
-          # TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION), and
-          # -filter_modify_marker_value 3,-1 (which changes the value of
-          # TRACE_MARKER_TYPE_CPU_ID == 3 to INVALID_CPU_MARKER_VALUE == (uintptr_t)-1).
           "${drcachesim_path}@-simulator_type@record_filter@-filter_encodings2regdeps@-indir@${testname}.${ci_shared_app}.*.dir/trace@-outdir@${testname}.filtered.dir@-filter_marker_types@19,25,27,28,30,40,41@-filter_keep_func_ids@4294967498@-filter_modify_marker_value@3,-1"
-          # We run the invariant_checker analyzer on the REGDEPS filtered trace.
-          # We expect no invariant errors.
           "invariant_checker")
 
-        # Run the invariant_checker on an OFFLINE_FILE_TYPE_ARCH_REGDEPS trace of
-        # kernel_xfer_app.
         set(testname "tool.invariant_checker_on_regdeps_trace_kernel_xfer_app")
         torun_record_filter("${testname}" ${kernel_xfer_app}
           "invariant_checker_on_regdeps_trace_kernel_xfer_app"
-          # Generate an OFFLINE_FILE_TYPE_ARCH_REGDEPS trace by running record_filter
-          # with -filter_encodings2regdeps to change instruction encodings,
-          # -filter_keep_func_ids 4294967498 (which is SYS_futex, associated to the only
-          # TRACE_MARKER_TYPE_FUNC_ markers we want to keep),
-          # -filter_marker_types 19,25,27,28,30,40,41 (which correspond to
-          # TRACE_MARKER_TYPE_SYSCALL_IDX, TRACE_MARKER_TYPE_SYSCALL,
-          # TRACE_MARKER_TYPE_SYSCALL_TRACE_START, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-          # TRACE_MARKER_TYPE_SYSCALL_FAILED, TRACE_MARKER_TYPE_SIGNAL_NUMBER,
-          # TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION), and
-          # -filter_modify_marker_value 3,-1 (which changes the value of
-          # TRACE_MARKER_TYPE_CPU_ID == 3 to INVALID_CPU_MARKER_VALUE == (uintptr_t)-1).
           "${drcachesim_path}@-simulator_type@record_filter@-filter_encodings2regdeps@-indir@${testname}.${kernel_xfer_app}.*.dir/trace@-outdir@${testname}.filtered.dir@-filter_marker_types@19,25,27,28,30,40,41@-filter_keep_func_ids@4294967498@-filter_modify_marker_value@3,-1"
-          # We run the invariant_checker analyzer on the REGDEPS filtered trace.
-          # We expect no invariant errors.
           "invariant_checker")
     endif ()
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4849,10 +4849,11 @@ if (BUILD_CLIENTS)
           # -filter_marker_types 19,25,27,28,30 (which correspond to
           # TRACE_MARKER_TYPE_SYSCALL_IDX, TRACE_MARKER_TYPE_SYSCALL,
           # TRACE_MARKER_TYPE_SYSCALL_TRACE_START, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-          # TRACE_MARKER_TYPE_SYSCALL_FAILED), and -filter_modify_marker_value 3,-1
-          # (which changes the value of TRACE_MARKER_TYPE_CPU_ID == 3 to
-          # INVALID_CPU_MARKER_VALUE == (uintptr_t)-1).
-          "${drcachesim_path}@-simulator_type@record_filter@-filter_encodings2regdeps@-indir@${testname}.${ci_shared_app}.*.dir/trace@-outdir@${testname}.filtered.dir@-filter_marker_types@19,25,27,28,30@-filter_keep_func_ids@4294967498@-filter_modify_marker_value@3,-1"
+          # TRACE_MARKER_TYPE_SYSCALL_FAILED,  TRACE_MARKER_TYPE_SIGNAL_NUMBER,
+          # TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION), and
+          # -filter_modify_marker_value 3,-1 (which changes the value of
+          # TRACE_MARKER_TYPE_CPU_ID == 3 to INVALID_CPU_MARKER_VALUE == (uintptr_t)-1).
+          "${drcachesim_path}@-simulator_type@record_filter@-filter_encodings2regdeps@-indir@${testname}.${ci_shared_app}.*.dir/trace@-outdir@${testname}.filtered.dir@-filter_marker_types@19,25,27,28,30,40,41@-filter_keep_func_ids@4294967498@-filter_modify_marker_value@3,-1"
           # We run the invariant_checker analyzer on the REGDEPS filtered trace.
           # We expect no invariant errors.
           "invariant_checker")
@@ -4866,13 +4867,14 @@ if (BUILD_CLIENTS)
           # with -filter_encodings2regdeps to change instruction encodings,
           # -filter_keep_func_ids 4294967498 (which is SYS_futex, associated to the only
           # TRACE_MARKER_TYPE_FUNC_ markers we want to keep),
-          # -filter_marker_types 19,25,27,28,30 (which correspond to
+          # -filter_marker_types 19,25,27,28,30,40,41 (which correspond to
           # TRACE_MARKER_TYPE_SYSCALL_IDX, TRACE_MARKER_TYPE_SYSCALL,
           # TRACE_MARKER_TYPE_SYSCALL_TRACE_START, TRACE_MARKER_TYPE_SYSCALL_TRACE_END,
-          # TRACE_MARKER_TYPE_SYSCALL_FAILED), and -filter_modify_marker_value 3,-1
-          # (which changes the value of TRACE_MARKER_TYPE_CPU_ID == 3 to
-          # INVALID_CPU_MARKER_VALUE == (uintptr_t)-1).
-          "${drcachesim_path}@-simulator_type@record_filter@-filter_encodings2regdeps@-indir@${testname}.${kernel_xfer_app}.*.dir/trace@-outdir@${testname}.filtered.dir@-filter_marker_types@19,25,27,28,30@-filter_keep_func_ids@4294967498@-filter_modify_marker_value@3,-1"
+          # TRACE_MARKER_TYPE_SYSCALL_FAILED, TRACE_MARKER_TYPE_SIGNAL_NUMBER,
+          # TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION), and
+          # -filter_modify_marker_value 3,-1 (which changes the value of
+          # TRACE_MARKER_TYPE_CPU_ID == 3 to INVALID_CPU_MARKER_VALUE == (uintptr_t)-1).
+          "${drcachesim_path}@-simulator_type@record_filter@-filter_encodings2regdeps@-indir@${testname}.${kernel_xfer_app}.*.dir/trace@-outdir@${testname}.filtered.dir@-filter_marker_types@19,25,27,28,30,40,41@-filter_keep_func_ids@4294967498@-filter_modify_marker_value@3,-1"
           # We run the invariant_checker analyzer on the REGDEPS filtered trace.
           # We expect no invariant errors.
           "invariant_checker")


### PR DESCRIPTION
Public traces should never have TRACE_MARKER_TYPE_SIGNAL_NUMBER markers.
Temporarily, we also disallow TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION
markers until we can handle their partial encoding. Eventually we want to preserve them
(xref: #7155).
We add two invariants in invariant_checker to detect the presence of these
markers in REGDEPS traces and raise an invariant error if necessary.

Updated unit tests and end-to-end tests.

Issue #6662 #7155