### PR TITLE
i#7157 syscall sched: Handle static injected syscall traces in scheduler

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -758,6 +758,9 @@ public:
          * The scheduling quantum duration for preemption, in instruction count,
          * for #QUANTUM_INSTRUCTIONS.  The time passed to next_record() is ignored
          * for purposes of quantum preempts.
+         *
+         * Instructions executed in a quantum may end up higher than the specified
+         * value to avoid interruption of the kernel system call sequence.
          */
         // We pick 10 million to match 2 instructions per nanosecond with a 5ms quantum.
         uint64_t quantum_duration_instrs = 10 * 1000 * 1000;

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -458,8 +458,9 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
         // boundaries so we live with those being before the switch.
         // XXX: Once we insert kernel traces, we may have to try harder
         // to stop before the post-syscall records.
-        if (!outputs_[output].in_syscall_code &&
-            this->record_type_is_instr_boundary(record, outputs_[output].last_record)) {
+        if (this->record_type_is_instr_boundary(record, outputs_[output].last_record) &&
+            // We want to delay the context switch until after the injected syscall trace.
+            !outputs_[output].in_syscall_code) {
             if (input->switch_to_input != sched_type_t::INVALID_INPUT_ORDINAL) {
                 // The switch request overrides any latency threshold.
                 need_new_input = true;
@@ -513,7 +514,7 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
             if (outputs_[output].in_syscall_code) {
                 VPRINT(this, 4,
                        "next_record[%d]: input %d delaying context switch "
-                       "after end of instr quantum due to syscall code\n",
+                       "after end of instr quantum due to syscall trace\n",
                        output, input->index);
 
             } else {
@@ -547,7 +548,7 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
             if (outputs_[output].in_syscall_code) {
                 VPRINT(this, 4,
                        "next_record[%d]: input %d delaying context switch after end of "
-                       "time quantum after %" PRIu64 " due to syscall code\n",
+                       "time quantum after %" PRIu64 " due to syscall trace\n",
                        output, input->index, input->time_spent_in_quantum);
             } else {
                 VPRINT(this, 4,

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -512,7 +512,9 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
         ++input->instrs_in_quantum;
         if (input->instrs_in_quantum > options_.quantum_duration_instrs) {
             if (outputs_[output].in_syscall_code) {
-                VPRINT(this, 4,
+                // XXX: Maybe this should be printed only once per-syscall-instance to
+                // reduce log spam.
+                VPRINT(this, 5,
                        "next_record[%d]: input %d delaying context switch "
                        "after end of instr quantum due to syscall trace\n",
                        output, input->index);
@@ -546,7 +548,9 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
             // setting input->switching_pre_instruction.
             this->record_type_is_instr_boundary(record, outputs_[output].last_record)) {
             if (outputs_[output].in_syscall_code) {
-                VPRINT(this, 4,
+                // XXX: Maybe this should be printed only once per-syscall-instance to
+                // reduce log spam.
+                VPRINT(this, 5,
                        "next_record[%d]: input %d delaying context switch after end of "
                        "time quantum after %" PRIu64 " due to syscall trace\n",
                        output, input->index, input->time_spent_in_quantum);
@@ -601,6 +605,10 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::process_marker(
         break;
     case TRACE_MARKER_TYPE_SYSCALL_TRACE_END:
         outputs_[output].in_syscall_code = false;
+        break;
+    case TRACE_MARKER_TYPE_TIMESTAMP:
+        // Syscall sequences are not expected to have a timestamp.
+        assert(!outputs_[output].in_syscall_code);
         break;
     case TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH: {
         if (!options_.honor_direct_switches)

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -458,7 +458,8 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
         // boundaries so we live with those being before the switch.
         // XXX: Once we insert kernel traces, we may have to try harder
         // to stop before the post-syscall records.
-        if (this->record_type_is_instr_boundary(record, outputs_[output].last_record)) {
+        if (!outputs_[output].in_syscall_code &&
+            this->record_type_is_instr_boundary(record, outputs_[output].last_record)) {
             if (input->switch_to_input != sched_type_t::INVALID_INPUT_ORDINAL) {
                 // The switch request overrides any latency threshold.
                 need_new_input = true;
@@ -506,18 +507,26 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
     }
     if (options_.quantum_unit == sched_type_t::QUANTUM_INSTRUCTIONS &&
         this->record_type_is_instr_boundary(record, outputs_[output].last_record) &&
-        !outputs_[output].in_kernel_code) {
+        !outputs_[output].in_context_switch_code) {
         ++input->instrs_in_quantum;
         if (input->instrs_in_quantum > options_.quantum_duration_instrs) {
-            // We again prefer to switch to another input even if the current
-            // input has the oldest timestamp, prioritizing context switches
-            // over timestamp ordering.
-            VPRINT(this, 4, "next_record[%d]: input %d hit end of instr quantum\n",
-                   output, input->index);
-            preempt = true;
-            need_new_input = true;
-            input->instrs_in_quantum = 0;
-            ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS];
+            if (outputs_[output].in_syscall_code) {
+                VPRINT(this, 4,
+                       "next_record[%d]: input %d delaying context switch "
+                       "after end of instr quantum due to syscall code\n",
+                       output, input->index);
+
+            } else {
+                // We again prefer to switch to another input even if the current
+                // input has the oldest timestamp, prioritizing context switches
+                // over timestamp ordering.
+                VPRINT(this, 4, "next_record[%d]: input %d hit end of instr quantum\n",
+                       output, input->index);
+                preempt = true;
+                need_new_input = true;
+                input->instrs_in_quantum = 0;
+                ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS];
+            }
         }
     } else if (options_.quantum_unit == sched_type_t::QUANTUM_TIME) {
         if (cur_time == 0 || cur_time < input->prev_time_in_quantum) {
@@ -535,14 +544,21 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::check_for_input_switch(
             // in between (e.g., scatter/gather long sequence of reads/writes) by
             // setting input->switching_pre_instruction.
             this->record_type_is_instr_boundary(record, outputs_[output].last_record)) {
-            VPRINT(this, 4,
-                   "next_record[%d]: input %d hit end of time quantum after %" PRIu64
-                   "\n",
-                   output, input->index, input->time_spent_in_quantum);
-            preempt = true;
-            need_new_input = true;
-            input->time_spent_in_quantum = 0;
-            ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS];
+            if (outputs_[output].in_syscall_code) {
+                VPRINT(this, 4,
+                       "next_record[%d]: input %d delaying context switch after end of "
+                       "time quantum after %" PRIu64 " due to syscall code\n",
+                       output, input->index, input->time_spent_in_quantum);
+            } else {
+                VPRINT(this, 4,
+                       "next_record[%d]: input %d hit end of time quantum after %" PRIu64
+                       "\n",
+                       output, input->index, input->time_spent_in_quantum);
+                preempt = true;
+                need_new_input = true;
+                input->time_spent_in_quantum = 0;
+                ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_QUANTUM_PREEMPTS];
+            }
         }
     }
     // For sched_type_t::DEPENDENCY_TIMESTAMPS: enforcing asked-for
@@ -574,16 +590,16 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::process_marker(
         break;
     case TRACE_MARKER_TYPE_CONTEXT_SWITCH_START:
         outputs_[output].in_context_switch_code = true;
-        ANNOTATE_FALLTHROUGH;
+        break;
     case TRACE_MARKER_TYPE_SYSCALL_TRACE_START:
-        outputs_[output].in_kernel_code = true;
+        outputs_[output].in_syscall_code = true;
         break;
     case TRACE_MARKER_TYPE_CONTEXT_SWITCH_END:
         // We have to delay until the next record.
         outputs_[output].hit_switch_code_end = true;
-        ANNOTATE_FALLTHROUGH;
+        break;
     case TRACE_MARKER_TYPE_SYSCALL_TRACE_END:
-        outputs_[output].in_kernel_code = false;
+        outputs_[output].in_syscall_code = false;
         break;
     case TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH: {
         if (!options_.honor_direct_switches)

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -480,7 +480,7 @@ protected:
         // This is accessed by other outputs for stealing and rebalancing.
         // Indirected so we can store it in our vector.
         std::unique_ptr<std::atomic<bool>> active;
-        bool in_kernel_code = false;
+        bool in_syscall_code = false;
         bool in_context_switch_code = false;
         bool hit_switch_code_end = false;
         // Used for time-based quanta.

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1509,7 +1509,7 @@ test_synthetic_with_syscall_seq()
         // precise output for this test on Windows.
         if (sched_as_string[0] != CORE0_SCHED_STRING ||
             sched_as_string[1] != CORE1_SCHED_STRING) {
-            bool found_single_A = false, found_single_B = false, found_single_C = false;
+            bool found_single_A = false, found_single_B = false, found_single_D = false;
             for (int cpu = 0; cpu < NUM_OUTPUTS; ++cpu) {
                 for (size_t i = 1; i < sched_as_string[cpu].size() - 1; ++i) {
                     if (sched_as_string[cpu][i] == 'A' &&
@@ -1520,10 +1520,10 @@ test_synthetic_with_syscall_seq()
                         sched_as_string[cpu][i - 1] != 'B' &&
                         sched_as_string[cpu][i + 1] != 'B')
                         found_single_B = true;
-                    if (sched_as_string[cpu][i] == 'C' &&
-                        sched_as_string[cpu][i - 1] != 'C' &&
-                        sched_as_string[cpu][i + 1] != 'C')
-                        found_single_C = true;
+                    if (sched_as_string[cpu][i] == 'D' &&
+                        sched_as_string[cpu][i - 1] != 'D' &&
+                        sched_as_string[cpu][i + 1] != 'D')
+                        found_single_D = true;
                 }
             }
             bool found_syscall_a = false, found_syscall_b = false,
@@ -1542,7 +1542,7 @@ test_synthetic_with_syscall_seq()
                     found_syscall_d = true;
                 }
             }
-            assert(found_single_A && found_single_B && found_single_C);
+            assert(found_single_A && found_single_B && found_single_D);
             assert(found_syscall_a && found_syscall_b && found_syscall_c &&
                    found_syscall_d);
         }

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1505,9 +1505,7 @@ test_synthetic_with_syscall_seq()
         // XXX: Windows microseconds on test VMs are very coarse and stay the same
         // for long periods.  Instruction quanta use wall-clock idle times, so
         // the result is extreme variations here.  We try to adjust by handling
-        // any schedule with singleton 'A' and 'B', but in some cases on Windows
-        // we see the A and B delayed all the way to the very end where they
-        // are adjacent to their own letters.  We just give up on checking the
+        // any schedule with below specific patterns.  We just give up on checking the
         // precise output for this test on Windows.
         if (sched_as_string[0] != CORE0_SCHED_STRING ||
             sched_as_string[1] != CORE1_SCHED_STRING) {

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1512,14 +1512,21 @@ test_synthetic_with_syscall_seq()
             bool found_single_A = false, found_single_B = false, found_single_D = false;
             for (int cpu = 0; cpu < NUM_OUTPUTS; ++cpu) {
                 for (size_t i = 1; i < sched_as_string[cpu].size() - 1; ++i) {
+                    // We expect a single 'A' for the first instr executed by 'A',
+                    // which will be followed by a marker ('.') for the syscall.
                     if (sched_as_string[cpu][i] == 'A' &&
                         sched_as_string[cpu][i - 1] != 'A' &&
                         sched_as_string[cpu][i + 1] != 'A')
                         found_single_A = true;
+                    // We expect a single 'B' for the last instr executed by B
+                    // which will have to be in its own separate 3-instr quantum.
                     if (sched_as_string[cpu][i] == 'B' &&
                         sched_as_string[cpu][i - 1] != 'B' &&
                         sched_as_string[cpu][i + 1] != 'B')
                         found_single_B = true;
+                    // We expect a single 'D' for the one quantum where the
+                    // 1st and 3rd instr executed by D was regular, and the
+                    // 2nd one was from a syscall (which is 'd').
                     if (sched_as_string[cpu][i] == 'D' &&
                         sched_as_string[cpu][i - 1] != 'D' &&
                         sched_as_string[cpu][i + 1] != 'D')
@@ -1529,6 +1536,8 @@ test_synthetic_with_syscall_seq()
             bool found_syscall_a = false, found_syscall_b = false,
                  found_syscall_c = false, found_syscall_d = false;
             for (int cpu = 0; cpu < NUM_OUTPUTS; ++cpu) {
+                // The '.' at beginning and end of each of the searched sequences
+                // below is for the syscall trace start and end markers.
                 if (sched_as_string[cpu].find(".a.") != std::string::npos) {
                     found_syscall_a = true;
                 }

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -1511,7 +1511,7 @@ test_synthetic_with_syscall_seq()
         // precise output for this test on Windows.
         if (sched_as_string[0] != CORE0_SCHED_STRING ||
             sched_as_string[1] != CORE1_SCHED_STRING) {
-            bool found_single_A = false, found_single_B = false;
+            bool found_single_A = false, found_single_B = false, found_single_C = false;
             for (int cpu = 0; cpu < NUM_OUTPUTS; ++cpu) {
                 for (size_t i = 1; i < sched_as_string[cpu].size() - 1; ++i) {
                     if (sched_as_string[cpu][i] == 'A' &&
@@ -1522,9 +1522,31 @@ test_synthetic_with_syscall_seq()
                         sched_as_string[cpu][i - 1] != 'B' &&
                         sched_as_string[cpu][i + 1] != 'B')
                         found_single_B = true;
+                    if (sched_as_string[cpu][i] == 'C' &&
+                        sched_as_string[cpu][i - 1] != 'C' &&
+                        sched_as_string[cpu][i + 1] != 'C')
+                        found_single_C = true;
                 }
             }
-            assert(found_single_A && found_single_B);
+            bool found_syscall_a = false, found_syscall_b = false,
+                 found_syscall_c = false, found_syscall_d = false;
+            for (int cpu = 0; cpu < NUM_OUTPUTS; ++cpu) {
+                if (sched_as_string[cpu].find(".a.") != std::string::npos) {
+                    found_syscall_a = true;
+                }
+                if (sched_as_string[cpu].find(".bbb.") != std::string::npos) {
+                    found_syscall_b = true;
+                }
+                if (sched_as_string[cpu].find(".ccc.") != std::string::npos) {
+                    found_syscall_c = true;
+                }
+                if (sched_as_string[cpu].find(".d.") != std::string::npos) {
+                    found_syscall_d = true;
+                }
+            }
+            assert(found_single_A && found_single_B && found_single_C);
+            assert(found_syscall_a && found_syscall_b && found_syscall_c &&
+                   found_syscall_d);
         }
 #endif
     }


### PR DESCRIPTION
Adds handling for statically-injected kernel syscall traces in the scheduler.

Ensures that quantum and voluntary context switches are delayed until after the statically-injected syscall trace. This involved fixing the bookkeeping logic which is done on the next user-space instr now.

Note that the injected kernel syscall traces do not include any scheduling-related markers such as TRACE_MARKER_TYPE_SYSCALL_UNSCHEDULE and TRACE_MARKER_TYPE_TIMESTAMP.

For now we keep status quo on the scheduler behavior of showing the post-syscall markers before the switch.

Adds a unit test for static-injected kernel syscall trace handling by the scheduler for various scenarios involving syscall sequences shorter and longer than the quantum, for system calls that do and do not cause context switches, and occurring at different offsets into the quantum.

Issue: #7157