### PR TITLE
Version 11.2

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -90,7 +90,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.1.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -103,7 +103,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.1.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -196,7 +196,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.1.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -285,7 +285,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.1.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -374,7 +374,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.1.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -457,7 +457,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.1.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -541,7 +541,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER="11.1.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export VERSION_NUMBER="11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))"
           export PREFIX="cronbuild-"
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,7 +581,7 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 
 # N.B.: When updating this, update all the default versions in ci-package.yml
 # and ci-docs.yml.  We should find a way to share (xref i#1565).
-set(VERSION_NUMBER_DEFAULT "11.1.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "11.2.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")

--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -50,6 +50,18 @@ The source code is available:
 
 For the very latest changes since the last official release, you can download \ref page_weekly_builds.
 
+The [11.2.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.2.0):
+
+  - [DynamoRIO-Windows-11.2.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-Windows-11.2.0.zip)
+
+  - [DynamoRIO-Linux-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-Linux-11.2.0.tar.gz)
+
+  - [DynamoRIO-ARM-Linux-EABIHF-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-ARM-Linux-EABIHF-11.2.0.tar.gz)
+
+  - [DynamoRIO-ARM-Android-EABI-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-ARM-Android-EABI-11.2.0.tar.gz)
+
+  - [DynamoRIO-AArch64-Linux-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-AArch64-Linux-11.2.0.tar.gz)
+
 The [11.1.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.1.0):
 
   - [DynamoRIO-Windows-11.1.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-Windows-11.1.0.zip)
@@ -61,18 +73,6 @@ The [11.1.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release
   - [DynamoRIO-ARM-Android-EABI-11.1.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-ARM-Android-EABI-11.1.0.tar.gz)
 
   - [DynamoRIO-AArch64-Linux-11.1.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-AArch64-Linux-11.1.0.tar.gz)
-
-The [11.0.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.0.0):
-
-  - [DynamoRIO-Windows-11.0.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-Windows-11.0.0.zip)
-
-  - [DynamoRIO-Linux-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-Linux-11.0.0.tar.gz)
-
-  - [DynamoRIO-ARM-Linux-EABIHF-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-ARM-Linux-EABIHF-11.0.0.tar.gz)
-
-  - [DynamoRIO-ARM-Android-EABI-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-ARM-Android-EABI-11.0.0.tar.gz)
-
-  - [DynamoRIO-AArch64-Linux-11.0.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.0.0/DynamoRIO-AArch64-Linux-11.0.0.tar.gz)
 
 
 ***************************************************************************


### PR DESCRIPTION
Update the version number to v11.2 to pull in #7156 .

Bumped the TRACE_ENTRY_VERSION so that analysis tools can determine compatibility with the new marker TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION.

Issue: #7050 