### PR TITLE
i#7162 div sample: Ensure clean call opnd reg is ptr sized

### DIFF
--- a/api/samples/div.c
+++ b/api/samples/div.c
@@ -138,7 +138,7 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     opnd_t opnd;
     if (instr_is_div(instr, &opnd)) {
         opnd_t div_opnd;
-        if (opnd_is_reg(div_opnd))
+        if (opnd_is_reg(opnd))
             div_opnd = opnd_create_reg(reg_to_pointer_sized(opnd_get_reg(opnd)));
         else
             div_opnd = opnd;

--- a/api/samples/div.c
+++ b/api/samples/div.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2024 Google, Inc.  All rights reserved.
  * Copyright (c) 2008 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -137,8 +137,13 @@ event_app_instruction(void *drcontext, void *tag, instrlist_t *bb, instr_t *inst
     /* if find div, insert a clean call to our instrumentation routine */
     opnd_t opnd;
     if (instr_is_div(instr, &opnd)) {
+        opnd_t div_opnd;
+        if (opnd_is_reg(div_opnd))
+            div_opnd = opnd_create_reg(reg_to_pointer_sized(opnd_get_reg(opnd)));
+        else
+            div_opnd = opnd;
         dr_insert_clean_call(drcontext, bb, instr, (void *)callback, false /*no fp save*/,
-                             2, OPND_CREATE_INTPTR(instr_get_app_pc(instr)), opnd);
+                             2, OPND_CREATE_INTPTR(instr_get_app_pc(instr)), div_opnd);
     }
     return DR_EMIT_DEFAULT;
 }


### PR DESCRIPTION
Fixes the div sample client to ensure that the opnd reg passed to dr_insert_clean_call is pointer sized.

This showed up as a CLIENT_ASSERT crash on an AArch64 machine when the div client was run on suite/tests/bin/simple_app. On affected environments, it did show up on the sample.div test also.

Fixes: #7162