### PR TITLE
i#3544: RV64: Port test common.getretaddr to RV64

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6426,6 +6426,7 @@ if (RISCV64)
     code_api|client.unregister
     code_api|common.broadfun
     code_api|common.hello
+    code_api|common.getretaddr
     code_api|libutil.drconfig_test
     code_api|libutil.frontend_test
     # TODO i#3544: code_api|linux.eintr failed under QEMU

--- a/suite/tests/common/getretaddr.c
+++ b/suite/tests/common/getretaddr.c
@@ -113,8 +113,11 @@ GLOBAL_LABEL(FUNCNAME:)
         ldr      x30, [sp], #16
         ret
 # elif defined(RISCV64)
-        /* TODO i#3544: Port tests to RISC-V 64 */
-        ret
+        mv       t0, ra
+        call     next_instr
+    next_instr:
+        mv       a0, ra
+        jr       t0
 # else
 #  error NYI
 # endif
@@ -134,7 +137,7 @@ GLOBAL_LABEL(FUNCNAME:)
         ldr      x0, [x29, #8]
         ret
 # elif defined(RISCV64)
-        /* TODO i#3544: Port tests to RISC-V 64 */
+        ld       a0, -8(fp)
         ret
 # else
 #  error NYI

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -805,9 +805,9 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      x0, x30             /* Replace first argument with return address. */
         br       x9                  /* Tailcall to function pointer. */
 #elif defined(RISCV64)
-        mv       t0, a0
-        mv       a0, ra
-        jr       t0
+        mv       t0, a0              /* Move function pointer to scratch register. */
+        mv       a0, ra              /* Replace first argument with return address. */
+        jr       t0                  /* Tailcall to function pointer. */
 #else
 # error NYI
 #endif

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -805,8 +805,9 @@ GLOBAL_LABEL(FUNCNAME:)
         mov      x0, x30             /* Replace first argument with return address. */
         br       x9                  /* Tailcall to function pointer. */
 #elif defined(RISCV64)
-        /* TODO i#3544: Port tests to RISC-V64 */
-        ret
+        mv       t0, a0
+        mv       a0, ra
+        jr       t0
 #else
 # error NYI
 #endif


### PR DESCRIPTION
Port assembly in common/getretaddr.c to riscv64 and implements tailcall_with_retaddr().

Issue: #3544