### PR TITLE
i#6662 public traces: allow one missing virtual_address in v2p.textproto

### DIFF
--- a/clients/drcachesim/reader/v2p_reader.h
+++ b/clients/drcachesim/reader/v2p_reader.h
@@ -40,6 +40,9 @@
  * }
  * In create_v2p_info_from_file() we rely on the fact that virtual_address and
  * physical_address are one after the other on two different lines.
+ * The only exception is a single missing virtual_address field, which indicates
+ * virtual_address = 0x0 ("no presence" == "0" in a textproto). This can happen if the
+ * trace makes use of that virtual address.
  * The virtual-to-physical mapping along with the page size, page count, and number of
  * bytes mapped is stored in memory in a v2p_info_t object.
  */

--- a/clients/drcachesim/tests/v2p_example.textproto
+++ b/clients/drcachesim/tests/v2p_example.textproto
@@ -12,6 +12,10 @@ address_mapping_group    {
     physical_address: 0x4
   }
   address_mapping {
+    # Missing virtual_address field on purpose (== virtual_address: 0x0)
+    physical_address: 0x6
+  }
+  address_mapping {
     virtual_address: 0x789
     physical_address: 0x5
   }

--- a/clients/drcachesim/tests/v2p_reader_unit_test.cpp
+++ b/clients/drcachesim/tests/v2p_reader_unit_test.cpp
@@ -45,7 +45,7 @@ namespace drmemtrace {
 static void
 check_v2p_info(const v2p_info_t &v2p_info)
 {
-    // Change the number of entries if v2p_map_example.textproto is updated.
+    // Change NUM_ENTRIES if clients/drcachesim/tests/v2p_example.textproto is updated.
     // Must be equal to the number of "address_mapping {...}" blocks in the textproto.
     constexpr size_t NUM_ENTRIES = 4;
     if (v2p_info.v2p_map.size() != NUM_ENTRIES) {
@@ -54,7 +54,8 @@ check_v2p_info(const v2p_info_t &v2p_info)
         exit(1);
     }
 
-    // Virtual and physical addresses must be aligned with v2p_example.textproto.
+    // Virtual and physical addresses must be aligned with
+    // clients/drcachesim/tests/v2p_example.textproto.
     const std::vector<addr_t> virtual_addresses = { 0x123, 0x456, 0x0, 0x789 };
     const std::vector<addr_t> physical_addresses = { 0x3, 0x4, 0x6, 0x5 };
     for (int i = 0; i < virtual_addresses.size(); ++i) {

--- a/clients/drcachesim/tests/v2p_reader_unit_test.cpp
+++ b/clients/drcachesim/tests/v2p_reader_unit_test.cpp
@@ -47,7 +47,7 @@ check_v2p_info(const v2p_info_t &v2p_info)
 {
     // Change the number of entries if v2p_map_example.textproto is updated.
     // Must be equal to the number of "address_mapping {...}" blocks in the textproto.
-    constexpr size_t NUM_ENTRIES = 3;
+    constexpr size_t NUM_ENTRIES = 4;
     if (v2p_info.v2p_map.size() != NUM_ENTRIES) {
         std::cerr << "v2p_map incorrect number of entries. Expected " << NUM_ENTRIES
                   << " got " << v2p_info.v2p_map.size() << ".\n";
@@ -55,8 +55,8 @@ check_v2p_info(const v2p_info_t &v2p_info)
     }
 
     // Virtual and physical addresses must be aligned with v2p_example.textproto.
-    const std::vector<addr_t> virtual_addresses = { 0x123, 0x456, 0x789 };
-    const std::vector<addr_t> physical_addresses = { 0x3, 0x4, 0x5 };
+    const std::vector<addr_t> virtual_addresses = { 0x123, 0x456, 0x0, 0x789 };
+    const std::vector<addr_t> physical_addresses = { 0x3, 0x4, 0x6, 0x5 };
     for (int i = 0; i < virtual_addresses.size(); ++i) {
         auto key_val = v2p_info.v2p_map.find(virtual_addresses[i]);
         if (key_val != v2p_info.v2p_map.end()) {


### PR DESCRIPTION
The textproto format does not have fields with value == 0.
In some cases a trace can use virtual address 0x0, which
would result in a missing virtual_address field in `v2p.textproto`.
Previously we did not allow any missing fields in `v2p.textproto`,
so this case needs to be handled.
We do so relying on the fact that multiple missing virtual_address
fields would try to map 0x0 multiple times, resulting in an error.

We add the missing virtual_address case to the unit tests.

Issue #6662