### PR TITLE
Version 11.3

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -90,7 +90,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.3.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi

--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -103,7 +103,7 @@ jobs:
       # We only use a non-zero build # when making multiple manual builds in one day.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.3.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -196,7 +196,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.3.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -285,7 +285,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.3.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -374,7 +374,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.3.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -457,7 +457,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))
+          export VERSION_NUMBER=11.3.$((`git log -n 1 --format=%ct` / (60*60*24)))
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}
         fi
@@ -541,7 +541,7 @@ jobs:
       # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
       run: |
         if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER="11.2.$((`git log -n 1 --format=%ct` / (60*60*24)))"
+          export VERSION_NUMBER="11.3.$((`git log -n 1 --format=%ct` / (60*60*24)))"
           export PREFIX="cronbuild-"
         else
           export VERSION_NUMBER=${{ github.event.inputs.version }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,7 +581,7 @@ endif (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
 
 # N.B.: When updating this, update all the default versions in ci-package.yml
 # and ci-docs.yml.  We should find a way to share (xref i#1565).
-set(VERSION_NUMBER_DEFAULT "11.2.${VERSION_NUMBER_PATCHLEVEL}")
+set(VERSION_NUMBER_DEFAULT "11.3.${VERSION_NUMBER_PATCHLEVEL}")
 # do not store the default VERSION_NUMBER in the cache to prevent a stale one
 # from preventing future version updates in a pre-existing build dir
 set(VERSION_NUMBER "" CACHE STRING "Version number: leave empty for default")

--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -50,6 +50,18 @@ The source code is available:
 
 For the very latest changes since the last official release, you can download \ref page_weekly_builds.
 
+The [11.3.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.3.0):
+
+  - [DynamoRIO-Windows-11.3.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Windows-11.3.0.zip)
+
+  - [DynamoRIO-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Linux-11.3.0.tar.gz)
+
+  - [DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz)
+
+  - [DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz)
+
+  - [DynamoRIO-AArch64-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-AArch64-Linux-11.3.0.tar.gz)
+
 The [11.2.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.2.0):
 
   - [DynamoRIO-Windows-11.2.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-Windows-11.2.0.zip)
@@ -61,18 +73,6 @@ The [11.2.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release
   - [DynamoRIO-ARM-Android-EABI-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-ARM-Android-EABI-11.2.0.tar.gz)
 
   - [DynamoRIO-AArch64-Linux-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-AArch64-Linux-11.2.0.tar.gz)
-
-The [11.1.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.1.0):
-
-  - [DynamoRIO-Windows-11.1.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-Windows-11.1.0.zip)
-
-  - [DynamoRIO-Linux-11.1.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-Linux-11.1.0.tar.gz)
-
-  - [DynamoRIO-ARM-Linux-EABIHF-11.1.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-ARM-Linux-EABIHF-11.1.0.tar.gz)
-
-  - [DynamoRIO-ARM-Android-EABI-11.1.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-ARM-Android-EABI-11.1.0.tar.gz)
-
-  - [DynamoRIO-AArch64-Linux-11.1.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.1.0/DynamoRIO-AArch64-Linux-11.1.0.tar.gz)
 
 
 ***************************************************************************

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -124,7 +124,7 @@ Dr. Memory Framework (DRMF) in the same package as DynamoRIO.  DRMF
 provides the umbra, drsyscall, and drsymcache Extensions for use by
 clients.
 
-The changes between version \DR_VERSION and 11.2.0 include the following compatibility
+The changes between version \DR_VERSION and 11.3.0 include the following compatibility
 changes:
  - No compatibility changes yet.
 
@@ -134,10 +134,22 @@ Further non-compatibility-affecting changes include:
 **************************************************
 <hr>
 
+The changes between version 11.3.0 and 11.2.0 include the following compatibility
+changes:
+ - Allow v2p.textproto file in a trace directory. This file is present in public traces.
+ - Allow v2p.textproto file to have one missing virtual_address field, which indicates
+   virtual_address == 0x0. Necessary in case a trace accesses virtual address 0x0.
+
+Further non-compatibility-affecting changes include:
+ - No changes yet.
+
+**************************************************
+<hr>
+
 The changes between version 11.2.0 and 11.1.0 include the following compatibility
 changes:
- - Added #dynamorio::drmemtrace::TRACE_ENTRY_VERSION_RETIRED_INSTRUCTIONS_ONLY to increase the
-   trace version for drmemtraces with uncompleted instructions removed.
+ - Added #dynamorio::drmemtrace::TRACE_ENTRY_VERSION_RETIRED_INSTRUCTIONS_ONLY to
+   increase the trace version for drmemtraces with uncompleted instructions removed.
 
 Further non-compatibility-affecting changes include:
  - Added instr_get_operation_size() and instr_set_operation_size() APIs for

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,12 +136,12 @@ Further non-compatibility-affecting changes include:
 
 The changes between version 11.3.0 and 11.2.0 include the following compatibility
 changes:
+ - No compatibility changes yet.
+
+Further non-compatibility-affecting changes include:
  - Allow v2p.textproto file in a trace directory. This file is present in public traces.
  - Allow v2p.textproto file to have one missing virtual_address field, which indicates
    virtual_address == 0x0. Necessary in case a trace accesses virtual address 0x0.
-
-Further non-compatibility-affecting changes include:
- - No changes yet.
 
 **************************************************
 <hr>


### PR DESCRIPTION
Update the version number to 11.3.
Necessary for compatibility with the new public traces and their
v2p.textproto file (xref: #7136 #7174).

Issue #6662