### PR TITLE
i#3699: Add more checks to is_aflags_{spill,restore} in drreg.c.

### DIFF
--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -2007,7 +2007,11 @@ is_aflags_restore(instr_t *inst)
     return (instr_get_opcode(inst) == OP_msr && instr_num_dsts(inst) == 1 &&
             opnd_is_reg(instr_get_dst(inst, 0)) &&
             opnd_get_reg(instr_get_dst(inst, 0)) == DR_REG_CPSR &&
-            instr_num_srcs(inst) == 2 && opnd_is_reg(instr_get_src(inst, 1)));
+            instr_num_srcs(inst) == 2 &&
+            opnd_is_immed_int(instr_get_src(inst, 0)) &&
+            /* Check we are writing to NZCV and Q. */
+            (opnd_get_immed_int(instr_get_src(inst, 0)) & 0x8) != 0 &&
+            opnd_is_reg(instr_get_src(inst, 1)));
 #elif defined(AARCH64)
     return (instr_get_opcode(inst) == OP_msr && instr_num_dsts(inst) == 1 &&
             opnd_is_reg(instr_get_dst(inst, 0)) &&

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1988,6 +1988,7 @@ is_aflags_spill(instr_t *inst)
 #endif
 }
 
+/* Call this function only if is_aflags_spill has returned true. */
 static reg_id_t
 aflags_spill_get_reg(instr_t *inst)
 {
@@ -2020,6 +2021,7 @@ is_aflags_restore(instr_t *inst)
 #endif
 }
 
+/* Call this function only if is_aflags_restore has returned true. */
 static reg_id_t
 aflags_restore_get_reg(instr_t *inst)
 {

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1976,11 +1976,10 @@ is_aflags_spill(instr_t *inst)
 #if defined(X86)
     return instr_get_opcode(inst) == OP_lahf;
 #elif defined(AARCHXX)
-    return (instr_get_opcode(inst) == OP_mrs &&
-            instr_num_srcs(inst) == 1 &&
+    return (instr_get_opcode(inst) == OP_mrs && instr_num_srcs(inst) == 1 &&
             opnd_is_reg(instr_get_src(inst, 0)) &&
             opnd_get_reg(instr_get_src(inst, 0)) ==
-            IF_ARM_ELSE(DR_REG_CPSR, DR_REG_NZCV));
+                IF_ARM_ELSE(DR_REG_CPSR, DR_REG_NZCV));
 #elif defined(RISCV64)
     /* RISC-V does not have any integer arithmetic or compare flag registers. */
     return false;
@@ -2004,19 +2003,15 @@ is_aflags_restore(instr_t *inst)
 #if defined(X86)
     return instr_get_opcode(inst) == OP_sahf;
 #elif defined(ARM)
-    return (instr_get_opcode(inst) == OP_msr &&
-            instr_num_dsts(inst) == 1 &&
+    return (instr_get_opcode(inst) == OP_msr && instr_num_dsts(inst) == 1 &&
             opnd_is_reg(instr_get_dst(inst, 0)) &&
             opnd_get_reg(instr_get_dst(inst, 0)) == DR_REG_CPSR &&
-            instr_num_srcs(inst) == 2 &&
-            opnd_is_reg(instr_get_src(inst, 1)));
+            instr_num_srcs(inst) == 2 && opnd_is_reg(instr_get_src(inst, 1)));
 #elif defined(AARCH64)
-    return (instr_get_opcode(inst) == OP_msr &&
-            instr_num_dsts(inst) == 1 &&
+    return (instr_get_opcode(inst) == OP_msr && instr_num_dsts(inst) == 1 &&
             opnd_is_reg(instr_get_dst(inst, 0)) &&
             opnd_get_reg(instr_get_dst(inst, 0)) == DR_REG_NZCV &&
-            instr_num_srcs(inst) == 1 &&
-            opnd_is_reg(instr_get_src(inst, 0)));
+            instr_num_srcs(inst) == 1 && opnd_is_reg(instr_get_src(inst, 0)));
 #elif defined(RISCV64)
     /* RISC-V does not have any integer arithmetic or condition flag registers. */
     return false;

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -2007,8 +2007,7 @@ is_aflags_restore(instr_t *inst)
     return (instr_get_opcode(inst) == OP_msr && instr_num_dsts(inst) == 1 &&
             opnd_is_reg(instr_get_dst(inst, 0)) &&
             opnd_get_reg(instr_get_dst(inst, 0)) == DR_REG_CPSR &&
-            instr_num_srcs(inst) == 2 &&
-            opnd_is_immed_int(instr_get_src(inst, 0)) &&
+            instr_num_srcs(inst) == 2 && opnd_is_immed_int(instr_get_src(inst, 0)) &&
             /* Check we are writing to NZCV and Q. */
             (opnd_get_immed_int(instr_get_src(inst, 0)) & 0x8) != 0 &&
             opnd_is_reg(instr_get_src(inst, 1)));

--- a/ext/drreg/drreg.c
+++ b/ext/drreg/drreg.c
@@ -1976,7 +1976,11 @@ is_aflags_spill(instr_t *inst)
 #if defined(X86)
     return instr_get_opcode(inst) == OP_lahf;
 #elif defined(AARCHXX)
-    return instr_get_opcode(inst) == OP_mrs;
+    return (instr_get_opcode(inst) == OP_mrs &&
+            instr_num_srcs(inst) == 1 &&
+            opnd_is_reg(instr_get_src(inst, 0)) &&
+            opnd_get_reg(instr_get_src(inst, 0)) ==
+            IF_ARM_ELSE(DR_REG_CPSR, DR_REG_NZCV));
 #elif defined(RISCV64)
     /* RISC-V does not have any integer arithmetic or compare flag registers. */
     return false;
@@ -1985,18 +1989,54 @@ is_aflags_spill(instr_t *inst)
 #endif
 }
 
+static reg_id_t
+aflags_spill_get_reg(instr_t *inst)
+{
+#if !(defined(X86) || defined(AARCHXX))
+    ASSERT(false, "aflags_spill_get_reg");
+#endif
+    return IF_X86_ELSE(DR_REG_XAX, opnd_get_reg(instr_get_dst(inst, 0)));
+}
+
 static inline bool
 is_aflags_restore(instr_t *inst)
 {
 #if defined(X86)
     return instr_get_opcode(inst) == OP_sahf;
-#elif defined(AARCHXX)
-    return instr_get_opcode(inst) == OP_msr;
+#elif defined(ARM)
+    return (instr_get_opcode(inst) == OP_msr &&
+            instr_num_dsts(inst) == 1 &&
+            opnd_is_reg(instr_get_dst(inst, 0)) &&
+            opnd_get_reg(instr_get_dst(inst, 0)) == DR_REG_CPSR &&
+            instr_num_srcs(inst) == 2 &&
+            opnd_is_reg(instr_get_src(inst, 1)));
+#elif defined(AARCH64)
+    return (instr_get_opcode(inst) == OP_msr &&
+            instr_num_dsts(inst) == 1 &&
+            opnd_is_reg(instr_get_dst(inst, 0)) &&
+            opnd_get_reg(instr_get_dst(inst, 0)) == DR_REG_NZCV &&
+            instr_num_srcs(inst) == 1 &&
+            opnd_is_reg(instr_get_src(inst, 0)));
 #elif defined(RISCV64)
     /* RISC-V does not have any integer arithmetic or condition flag registers. */
     return false;
 #else
 #    error Unsupported architecture
+#endif
+}
+
+static reg_id_t
+aflags_restore_get_reg(instr_t *inst)
+{
+#if defined(X86)
+    return DR_REG_XAX;
+#elif defined(ARM)
+    return opnd_get_reg(instr_get_src(inst, 1));
+#elif defined(AARCH64)
+    return opnd_get_reg(instr_get_src(inst, 0));
+#else
+    ASSERT(false, "aflags_restore_get_reg");
+    return DR_REG_NULL;
 #endif
 }
 
@@ -2119,9 +2159,9 @@ drreg_event_restore_state_without_ilist(void *drcontext, bool restore_memory,
              * aflags spill or app aflags spill. We assume the latter and update our
              * book-keeping.
              */
-            aflags_reg = IF_X86_ELSE(DR_REG_XAX, opnd_get_reg(instr_get_dst(&inst, 0)));
+            aflags_reg = aflags_spill_get_reg(&inst);
         } else if (aflags_reg != DR_REG_NULL && is_aflags_restore(&inst) &&
-                   opnd_get_reg(instr_get_src(&inst, 0)) == aflags_reg) {
+                   aflags_restore_get_reg(&inst) == aflags_reg) {
             aflags_reg = DR_REG_NULL;
         } else if (aflags_reg != DR_REG_NULL) {
             /* If the reg storing aflags gets written to before being spilled to a slot,
@@ -2322,25 +2362,20 @@ drreg_event_restore_state_with_ilist(void *drcontext, bool restore_memory,
                 if (aflags_spill_reg == DR_REG_NULL &&
                     spill_slot[GPR_IDX(AFLAGS_ALIAS_REG)] == MAX_SPILLS) {
                     /* Found a restore for app aflags from reg. */
-                    aflags_spill_reg =
-                        IF_X86_ELSE(DR_REG_XAX, opnd_get_reg(instr_get_src(inst, 0)));
+                    aflags_spill_reg = aflags_restore_get_reg(inst);
                 } else {
                     /* We need to track movement of meta aflags so that we can ignore a
                      * restore for tool_aflags_spill_reg.
                      */
-                    tool_aflags_spill_reg =
-                        IF_X86_ELSE(DR_REG_XAX, opnd_get_reg(instr_get_src(inst, 0)));
+                    tool_aflags_spill_reg = aflags_restore_get_reg(inst);
                 }
             } else if (is_aflags_spill(inst)) {
-                if (aflags_spill_reg ==
-                    IF_X86_ELSE(DR_REG_XAX, opnd_get_reg(instr_get_dst(inst, 0)))) {
+                if (aflags_spill_reg == aflags_spill_get_reg(inst)) {
                     /* Found the matching app aflags spill for the previously recorded
                      * app aflags restore.
                      */
                     aflags_spill_reg = DR_REG_NULL;
-                } else if (tool_aflags_spill_reg ==
-                           IF_X86_ELSE(DR_REG_XAX,
-                                       opnd_get_reg(instr_get_dst(inst, 0)))) {
+                } else if (tool_aflags_spill_reg == aflags_spill_get_reg(inst)) {
                     /* Found the matching tool aflags spill for the previously recorded
                      * tool aflags restore.
                      */


### PR DESCRIPTION
On ARM/AArch64 not all MRS/MSR instructions operate on aflags, and on ARM the register source operand of MSR, if there is one, is the second operand.

This change made the test sample.memval_simple pass on 32-bit ARM. (But client.drreg-test does not yet pass.)

Issue: #3699