### PR TITLE
i#6662: Fix download links for version 11.3.0

### DIFF
--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -52,15 +52,15 @@ For the very latest changes since the last official release, you can download \r
 
 The [11.3.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.3.0-1):
 
-  - [DynamoRIO-Windows-11.3.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Windows-11.3.0-1.zip)
+  - [DynamoRIO-Windows-11.3.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-Windows-11.3.0.zip)
 
-  - [DynamoRIO-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Linux-11.3.0-1.tar.gz)
+  - [DynamoRIO-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-Linux-11.3.0.tar.gz)
 
-  - [DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Linux-EABIHF-11.3.0-1.tar.gz)
+  - [DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz)
 
-  - [DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Android-EABI-11.3.0-1.tar.gz)
+  - [DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz)
 
-  - [DynamoRIO-AArch64-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-AArch64-Linux-11.3.0-1.tar.gz)
+  - [DynamoRIO-AArch64-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-AArch64-Linux-11.3.0.tar.gz)
 
 The [11.2.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.2.0):
 

--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -50,17 +50,17 @@ The source code is available:
 
 For the very latest changes since the last official release, you can download \ref page_weekly_builds.
 
-The [11.3.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.3.0):
+The [11.3.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.3.0-1):
 
-  - [DynamoRIO-Windows-11.3.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Windows-11.3.0.zip)
+  - [DynamoRIO-Windows-11.3.0.zip](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Windows-11.3.0-1.zip)
 
-  - [DynamoRIO-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Linux-11.3.0.tar.gz)
+  - [DynamoRIO-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-Linux-11.3.0-1.tar.gz)
 
-  - [DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz)
+  - [DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Linux-EABIHF-11.3.0-1.tar.gz)
 
-  - [DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz)
+  - [DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-ARM-Android-EABI-11.3.0-1.tar.gz)
 
-  - [DynamoRIO-AArch64-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-AArch64-Linux-11.3.0.tar.gz)
+  - [DynamoRIO-AArch64-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0/DynamoRIO-AArch64-Linux-11.3.0-1.tar.gz)
 
 The [11.2.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.2.0):
 


### PR DESCRIPTION
Due to building another 11.3.0 version of DynamoRIO, the download links
have the incorrect build number (no build number, instead of "1").
Here we fix the download links adding "-1" to "release_11.3.0".

Issue #6662