### PR TITLE
i#7132: Disable instr_length DEBUG_ASSERT on 32-bit ARM.

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2666,7 +2666,11 @@ instr_summary_t::construct(void *dcontext, app_pc block_start, DR_PARAM_INOUT ap
     }
     DEBUG_ASSERT(*pc > desc->pc_);
     desc->length_ = static_cast<byte>(*pc - desc->pc_);
+    // FIXME i#4016: On ARM calling instr_length causes the instruction to be
+    // reencoded and that can change the length of a T32 instr from 4 to 2.
+#ifndef ARM
     DEBUG_ASSERT(*pc - desc->pc_ == instr_length(dcontext, instr));
+#endif
 
     desc->packed_ = 0;
 


### PR DESCRIPTION
Until i#4016 is fixed, on 32-bit ARM a 4-byte T32 instruction may turn into a 2-byte instruction when decoded and then reencoded.

Fixes: #7132