### PR TITLE
i#2154 android64: Fix base address issue to get drrun working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,10 @@ if (WIN32 AND DEBUG)
 elseif (APPLE AND X64)
   # Set to higher than _PAGEZERO which is [0..0x1'00000000).
   set(preferred_base "0x171000000" CACHE STRING "Preferred library base address")
+elseif (ANDROID64)
+  # 64-bit Android needs a base of 0x1000 so that libdynamorio.so
+  # does not get overwritten by the vDSO.
+  set(preferred_base "0x1000" CACHE STRING "Preferred library base address")
 else ()
   set(preferred_base "0x71000000" CACHE STRING "Preferred library base address")
 endif ()

--- a/make/utils.cmake
+++ b/make/utils.cmake
@@ -266,8 +266,8 @@ if (UNIX)
   # XXX: this is duplicated in DynamoRIOConfig.cmake
 
   function (set_preferred_base_start_and_end target base set_bounds)
-    if (ANDROID)
-      # i#1863: Android's loader doesn't support a non-zero base.
+    if (ANDROID32)
+      # i#1863: 32-bit Android's loader doesn't support a non-zero base.
       # Turning off SET_PREFERRED_BASE is not sufficient as we get
       # a 0x10000 base.
       set(base 0)


### PR DESCRIPTION
This patch changes the base address for `libdynamorio.so` on aarch64 Android so that `libdynamorio.so`'s ELF header does not get overwritten by the `vDSO`.

`drrun` now runs error-free with basic assembly programs, and runs with 'CURIOSITY'-ies for more complex programs like a compiled 'hello world' or `pwd`.

Issue: #2154