### PR TITLE
i#2154 Android64: Fix write syscall in nolibc_print()

### DIFF
--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -379,8 +379,10 @@ nolibc_print(const char *str)
         SYS_write,
 #        endif
         3,
-#        if defined(MACOS) || defined(ANDROID)
+#        if defined(MACOS)
         stderr->_file,
+#        elif defined(ANDROID)
+        STDERR_FILENO,
 #        else
         stderr->_fileno,
 #        endif

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -378,15 +378,7 @@ nolibc_print(const char *str)
 #        else
         SYS_write,
 #        endif
-        3,
-#        if defined(MACOS)
-        stderr->_file,
-#        elif defined(ANDROID)
-        STDERR_FILENO,
-#        else
-        stderr->_fileno,
-#        endif
-        str, nolibc_strlen(str));
+        3, STDERR_FILENO, str, nolibc_strlen(str));
 }
 
 /* Safe print int syscall.


### PR DESCRIPTION
Current versions of Android make the FILE struct opaque so we can't access its members to get the file descriptor for stderr. Instead we can use STDERR_FILENO from unistd.h.

Issue: #1874, #2154