### PR TITLE
i#2154 Android64: Fix drx-scattergather-aarch64.cpp build

### DIFF
--- a/suite/tests/client-interface/drx-scattergather-aarch64.cpp
+++ b/suite/tests/client-interface/drx-scattergather-aarch64.cpp
@@ -831,8 +831,10 @@ template <typename TEST_PTRS_T> struct test_case_base_t {
             // Byte values         ||         AA||         BB||         CC||         DD||
             // Half values         ||      AA|AA||      BB|BB||      CC|CC||      DD|DD||
             // Word values         ||AA|AA|AA|AA||BB|BB|BB|BB||CC|CC|CC|CC||DD|DD|DD|DD||
-            assert(value_size != element_size_t::DOUBLE);
             switch (value_size) {
+            case element_size_t::DOUBLE:
+                assert(false); // Not reachable.
+                break;
 #define CASE(size, member, val0, val1, val2, val3)                          \
     case element_size_t::size:                                              \
         member = { { { static_cast<std::ptrdiff_t>(offsets[0]), val0 },     \


### PR DESCRIPTION
Fixes error:

```
drx-scattergather-aarch64.cpp:835:21: error: enumeration value 'DOUBLE' not handled in switch [-Werror,-Wswitch]
  835 |             switch (value_size) {
      |                     ^~~~~~~~~~
```

seen when building the test for Android.

Issue: #1874, #2154