### PR TITLE
Clarifies the drmemtrace scheduler get_shard_index() docs

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1162,10 +1162,10 @@ public:
          * For #SCHEDULER_USE_INPUT_ORDINALS or
          * #SCHEDULER_USE_SINGLE_INPUT_ORDINALS, returns the input stream ordinal, except
          * for the case of a single combined-stream input with the passed-in thread id
-         * set to INVALID_THREAD_ID (the serial analysis mode for analyzer tools) in
-         * which case the last trace record's tid as an ordinal (in the order observed
-         * in the output stream) is returned; otherwise returns the
-         * output stream ordinal.
+         * set to INVALID_THREAD_ID (the online analysis mode for analyzer tools where the
+         * inputs for multiple threads are all combined in one process-wide pipe) in which
+         * case the last trace record's tid as an ordinal (in the order observed in the
+         * output stream) is returned; otherwise returns the output stream ordinal.
          */
         int
         get_shard_index() const override;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2023-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -1163,7 +1163,8 @@ public:
          * #SCHEDULER_USE_SINGLE_INPUT_ORDINALS, returns the input stream ordinal, except
          * for the case of a single combined-stream input with the passed-in thread id
          * set to INVALID_THREAD_ID (the serial analysis mode for analyzer tools) in
-         * which case the last trace record's tid is returned; otherwise returns the
+         * which case the last trace record's tid as an ordinal (in the order observed
+         * in the output stream) is returned; otherwise returns the
          * output stream ordinal.
          */
         int


### PR DESCRIPTION
The drmemtrace scheduler get_shard_index() docs incorrectly stated it returns the tid for SCHEDULER_USE_INPUT_ORDINALS in the combined-stream serial analysis mode, when in fact it returns the ordinal of that tid in observation order.