### PR TITLE
i#7195 Fix Android library base address

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,10 +447,6 @@ if (WIN32 AND DEBUG)
 elseif (APPLE AND X64)
   # Set to higher than _PAGEZERO which is [0..0x1'00000000).
   set(preferred_base "0x171000000" CACHE STRING "Preferred library base address")
-elseif (ANDROID64)
-  # 64-bit Android needs a base of 0x1000 so that libdynamorio.so
-  # does not get overwritten by the vDSO.
-  set(preferred_base "0x1000" CACHE STRING "Preferred library base address")
 else ()
   set(preferred_base "0x71000000" CACHE STRING "Preferred library base address")
 endif ()

--- a/make/DynamoRIOConfig.cmake.in
+++ b/make/DynamoRIOConfig.cmake.in
@@ -998,7 +998,7 @@ macro (configure_DynamoRIO_client_helper target static_DR)
     if (APPLE)
       set(LD_FLAGS "-arch x86_64 -image_base ${PREFERRED_BASE}")
     elseif (UNIX)
-      if (LINKER_IS_GNU_GOLD OR LINKER_IS_LLVM_LLD)
+      if (LINKER_IS_GNU_GOLD)
         # Gold doesn't have a default version script for us to edit.  However,
         # it has a handy command line flag that does exactly what we want.  Note
         # that gnu ld has -Ttext as well, but it is very different.
@@ -1006,7 +1006,9 @@ macro (configure_DynamoRIO_client_helper target static_DR)
         # 2009.  We could switch to that if we ever drop support for old
         # linkers.
         set(PREFERRED_BASE_FLAGS "-Wl,-Ttext=${PREFERRED_BASE}")
-      else (LINKER_IS_GNU_GOLD OR LINKER_IS_LLVM_LLD)
+      elseif (LINKER_IS_LLVM_LLD)
+        set(PREFERRED_BASE_FLAGS "-Wl,--image-base=${PREFERRED_BASE}")
+      else ()
         # We use a linker script to set the preferred base
         set(LD_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/${target}.ldscript)
         # We do NOT add ${LD_SCRIPT} as an ADDITIONAL_MAKE_CLEAN_FILES since it's
@@ -1048,7 +1050,7 @@ macro (configure_DynamoRIO_client_helper target static_DR)
         # -dT is preferred, available on ld 2.18+: we could check for it
         set(LD_SCRIPT_OPTION "-T")
         set(PREFERRED_BASE_FLAGS "-Xlinker ${LD_SCRIPT_OPTION} -Xlinker \"${LD_SCRIPT}\"")
-      endif (LINKER_IS_GNU_GOLD OR LINKER_IS_LLVM_LLD)
+      endif ()
     else (APPLE)
       set(PREFERRED_BASE_FLAGS "/base:${PREFERRED_BASE} /dynamicbase:no")
     endif (APPLE)

--- a/make/utils.cmake
+++ b/make/utils.cmake
@@ -266,12 +266,6 @@ if (UNIX)
   # XXX: this is duplicated in DynamoRIOConfig.cmake
 
   function (set_preferred_base_start_and_end target base set_bounds)
-    if (ANDROID32)
-      # i#1863: 32-bit Android's loader doesn't support a non-zero base.
-      # Turning off SET_PREFERRED_BASE is not sufficient as we get
-      # a 0x10000 base.
-      set(base 0)
-    endif ()
     if (APPLE)
       set(ldflags "-image_base ${base}")
     elseif (NOT LINKER_IS_GNU_GOLD AND NOT LINKER_IS_LLVM_LLD)
@@ -298,9 +292,13 @@ if (UNIX)
     else ()
       set(ldflags "")
       if (SET_PREFERRED_BASE)
-        # FIXME: This should be -Ttext-segment for bfd, but most golds want -Ttext.
-        # See http://sourceware.org/ml/binutils/2013-02/msg00194.html
-        set(ldflags "-Wl,-Ttext=${base}")
+        if (LINKER_IS_LLVM_LLD)
+          set(ldflags "-Wl,--image-base=${base}")
+        else ()
+          # FIXME: This should be -Ttext-segment for bfd, but most golds want -Ttext.
+          # See http://sourceware.org/ml/binutils/2013-02/msg00194.html
+          set(ldflags "-Wl,-Ttext=${base}")
+        endif ()
       endif ()
       if (set_bounds)
         # Add our start and end symbols for library bounds.


### PR DESCRIPTION
Change the build scripts to use lld's `--image-base=` argument to set the preferred base address for libraries instead of `-Ttext=`.

`-Ttext=` sets the address for the `.text` section but `lld`'s section layout does not put the `.text` section first so not all sections are moved to the preferred base.

Changing it to use `--image-base=` instead means we can remove the Android special-casing and use the same preferred base address that we do for Linux.

Fixes: #7195