### PR TITLE
i#7229: Fix --fsanitize=pointer-overflow reports

### DIFF
--- a/clients/drcachesim/tracer/raw2trace_shared.cpp
+++ b/clients/drcachesim/tracer/raw2trace_shared.cpp
@@ -288,8 +288,7 @@ module_mapper_t::read_and_map_modules()
         } else if (info.containing_index != info.index) {
             // For split segments, we assume our mapped layout matches the original.
             byte *seg_map_base = modvec_[info.containing_index].map_seg_base -
-                                 modvec_[info.containing_index].orig_seg_base +
-                                 info.start;
+                modvec_[info.containing_index].orig_seg_base + info.start;
             VPRINT(1, "Secondary segment: module %d seg %p-%p = %s\n",
                    (int)modvec_.size(), seg_map_base, seg_map_base + info.size,
                    info.path);

--- a/clients/drcachesim/tracer/raw2trace_shared.cpp
+++ b/clients/drcachesim/tracer/raw2trace_shared.cpp
@@ -287,9 +287,9 @@ module_mapper_t::read_and_map_modules()
             modvec_.push_back(module_t(info.path, info.start, NULL, 0, 0, 0));
         } else if (info.containing_index != info.index) {
             // For split segments, we assume our mapped layout matches the original.
-            byte *seg_map_base =
-                (byte *)((ptr_uint_t)modvec_[info.containing_index].map_seg_base +
-                         (info.start - modvec_[info.containing_index].orig_seg_base));
+            byte *seg_map_base = modvec_[info.containing_index].map_seg_base -
+                                 modvec_[info.containing_index].orig_seg_base +
+                                 info.start;
             VPRINT(1, "Secondary segment: module %d seg %p-%p = %s\n",
                    (int)modvec_.size(), seg_map_base, seg_map_base + info.size,
                    info.path);

--- a/clients/drcachesim/tracer/raw2trace_shared.cpp
+++ b/clients/drcachesim/tracer/raw2trace_shared.cpp
@@ -287,8 +287,9 @@ module_mapper_t::read_and_map_modules()
             modvec_.push_back(module_t(info.path, info.start, NULL, 0, 0, 0));
         } else if (info.containing_index != info.index) {
             // For split segments, we assume our mapped layout matches the original.
-            byte *seg_map_base = modvec_[info.containing_index].map_seg_base +
-                (info.start - modvec_[info.containing_index].orig_seg_base);
+            byte *seg_map_base =
+                (byte *)((ptr_uint_t)modvec_[info.containing_index].map_seg_base +
+                         (info.start - modvec_[info.containing_index].orig_seg_base));
             VPRINT(1, "Secondary segment: module %d seg %p-%p = %s\n",
                    (int)modvec_.size(), seg_map_base, seg_map_base + info.size,
                    info.path);

--- a/clients/drcachesim/tracer/raw2trace_shared.h
+++ b/clients/drcachesim/tracer/raw2trace_shared.h
@@ -286,7 +286,10 @@ public:
                 reinterpret_cast<app_pc>(entry->start_pc);
         } else {
             size_t idx = static_cast<size_t>(modidx); // Avoid win32 warnings.
-            app_pc res = map_pc - modvec_[idx].map_seg_base + modvec_[idx].orig_seg_base;
+            app_pc res = reinterpret_cast<app_pc>(
+                reinterpret_cast<ptr_uint_t>(map_pc) -
+                reinterpret_cast<ptr_uint_t>(modvec_[idx].map_seg_base) +
+                reinterpret_cast<ptr_uint_t>(modvec_[idx].orig_seg_base));
 #ifdef ARM
             // Match Thumb vs Arm mode by setting LSB.
             if (TESTANY(1, modoffs))
@@ -312,8 +315,8 @@ public:
             size_t idx = static_cast<size_t>(modidx); // Avoid win32 warnings.
             // Cast to unsigned pointer-sized int first to avoid sign-extending.
             return reinterpret_cast<app_pc>(
-                       reinterpret_cast<ptr_uint_t>(modvec_[idx].orig_seg_base)) +
-                (modoffs - modvec_[idx].seg_offs);
+                reinterpret_cast<ptr_uint_t>(modvec_[idx].orig_seg_base) +
+                (modoffs - modvec_[idx].seg_offs));
         }
     }
 

--- a/clients/drcachesim/tracer/raw2trace_shared.h
+++ b/clients/drcachesim/tracer/raw2trace_shared.h
@@ -286,10 +286,7 @@ public:
                 reinterpret_cast<app_pc>(entry->start_pc);
         } else {
             size_t idx = static_cast<size_t>(modidx); // Avoid win32 warnings.
-            app_pc res = reinterpret_cast<app_pc>(
-                reinterpret_cast<ptr_uint_t>(map_pc) -
-                reinterpret_cast<ptr_uint_t>(modvec_[idx].map_seg_base) +
-                reinterpret_cast<ptr_uint_t>(modvec_[idx].orig_seg_base));
+            app_pc res = modvec_[idx].orig_seg_base - modvec_[idx].map_seg_base + map_pc;
 #ifdef ARM
             // Match Thumb vs Arm mode by setting LSB.
             if (TESTANY(1, modoffs))

--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -198,7 +198,7 @@ module_vaddr_from_prog_header(app_pc prog_header, uint num_segments,
             min_vaddr =
                 MIN(min_vaddr, (app_pc)ALIGN_BACKWARD(prog_hdr->p_vaddr, PAGE_SIZE));
             if (min_vaddr == (app_pc)prog_hdr->p_vaddr)
-                first_end = (app_pc)((ptr_uint_t)prog_hdr->p_vaddr + prog_hdr->p_memsz);
+                first_end = (app_pc)(prog_hdr->p_vaddr + prog_hdr->p_memsz);
             max_end = MAX(
                 max_end,
                 (app_pc)ALIGN_FORWARD(prog_hdr->p_vaddr + prog_hdr->p_memsz, PAGE_SIZE));
@@ -456,8 +456,7 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
              * (notably some kernels) seem to ignore it.  These corner cases are left
              * as unsolved for now.
              */
-            seg_base = (app_pc)((ptr_uint_t)ALIGN_BACKWARD(prog_hdr->p_vaddr, PAGE_SIZE) +
-                                delta);
+            seg_base = (app_pc)(ALIGN_BACKWARD(prog_hdr->p_vaddr, PAGE_SIZE) + delta);
             seg_end =
                 (app_pc)ALIGN_FORWARD(prog_hdr->p_vaddr + prog_hdr->p_filesz, PAGE_SIZE) +
                 delta;
@@ -523,8 +522,7 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
                     }
                     ASSERT(map != NULL);
                     /* fill zeros at extend size */
-                    file_end =
-                        (app_pc)((ptr_uint_t)prog_hdr->p_vaddr + prog_hdr->p_filesz);
+                    file_end = (app_pc)(prog_hdr->p_vaddr + prog_hdr->p_filesz);
                     if (seg_end > file_end + delta) {
                         /* There is typically one RW PT_LOAD segment for .data and
                          * .bss.  If .data ends and .bss starts before filesz bytes,

--- a/core/drlibc/drlibc_module_elf.c
+++ b/core/drlibc/drlibc_module_elf.c
@@ -198,7 +198,7 @@ module_vaddr_from_prog_header(app_pc prog_header, uint num_segments,
             min_vaddr =
                 MIN(min_vaddr, (app_pc)ALIGN_BACKWARD(prog_hdr->p_vaddr, PAGE_SIZE));
             if (min_vaddr == (app_pc)prog_hdr->p_vaddr)
-                first_end = (app_pc)prog_hdr->p_vaddr + prog_hdr->p_memsz;
+                first_end = (app_pc)((ptr_uint_t)prog_hdr->p_vaddr + prog_hdr->p_memsz);
             max_end = MAX(
                 max_end,
                 (app_pc)ALIGN_FORWARD(prog_hdr->p_vaddr + prog_hdr->p_memsz, PAGE_SIZE));
@@ -456,7 +456,8 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
              * (notably some kernels) seem to ignore it.  These corner cases are left
              * as unsolved for now.
              */
-            seg_base = (app_pc)ALIGN_BACKWARD(prog_hdr->p_vaddr, PAGE_SIZE) + delta;
+            seg_base = (app_pc)((ptr_uint_t)ALIGN_BACKWARD(prog_hdr->p_vaddr, PAGE_SIZE) +
+                                delta);
             seg_end =
                 (app_pc)ALIGN_FORWARD(prog_hdr->p_vaddr + prog_hdr->p_filesz, PAGE_SIZE) +
                 delta;
@@ -522,7 +523,8 @@ elf_loader_map_phdrs(elf_loader_t *elf, bool fixed, map_fn_t map_func,
                     }
                     ASSERT(map != NULL);
                     /* fill zeros at extend size */
-                    file_end = (app_pc)prog_hdr->p_vaddr + prog_hdr->p_filesz;
+                    file_end =
+                        (app_pc)((ptr_uint_t)prog_hdr->p_vaddr + prog_hdr->p_filesz);
                     if (seg_end > file_end + delta) {
                         /* There is typically one RW PT_LOAD segment for .data and
                          * .bss.  If .data ends and .bss starts before filesz bytes,

--- a/core/ir/aarch64/codec.c
+++ b/core/ir/aarch64/codec.c
@@ -1081,8 +1081,8 @@ static bool
 decode_opnd_adr_page(int scale, uint enc, byte *pc, OUT opnd_t *opnd)
 {
     uint bits = (enc >> 3 & 0x1ffffc) | (enc >> 29 & 3);
-    byte *addr = ((byte *)((ptr_uint_t)pc >> scale << scale) +
-                  extract_int(bits, 0, 21) * ((ptr_int_t)1 << scale));
+    byte *addr = (byte *)(((ptr_uint_t)pc >> scale << scale) +
+                          extract_int(bits, 0, 21) * ((ptr_int_t)1 << scale));
     *opnd = opnd_create_rel_addr(addr, OPSZ_0);
     return true;
 }

--- a/core/ir/instrlist.c
+++ b/core/ir/instrlist.c
@@ -572,7 +572,7 @@ instrlist_encode_to_copy(void *drcontext, instrlist_t *ilist, byte *copy_pc,
         byte *pc = instr_encode_to_copy(dcontext, inst, copy_pc, final_pc);
         if (pc == NULL)
             return NULL;
-        final_pc += pc - copy_pc;
+        final_pc = (byte *)((ptr_uint_t)final_pc + (ptr_uint_t)pc - (ptr_uint_t)copy_pc);
         copy_pc = pc;
     }
     return copy_pc;

--- a/core/ir/instrlist.c
+++ b/core/ir/instrlist.c
@@ -572,7 +572,7 @@ instrlist_encode_to_copy(void *drcontext, instrlist_t *ilist, byte *copy_pc,
         byte *pc = instr_encode_to_copy(dcontext, inst, copy_pc, final_pc);
         if (pc == NULL)
             return NULL;
-        final_pc = (byte *)((ptr_uint_t)final_pc + (ptr_uint_t)pc - (ptr_uint_t)copy_pc);
+        final_pc = (byte *)((ptr_uint_t)final_pc + (pc - copy_pc));
         copy_pc = pc;
     }
     return copy_pc;

--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -3021,7 +3021,8 @@ encode_cti(instr_t *instr, byte *copy_pc, byte *final_pc,
     } else {
         /* 32-bit offset */
         /* offset is from start of next instr */
-        ptr_int_t offset = target - ((ptr_int_t)(pc + 4 - copy_pc + final_pc));
+        ptr_int_t offset =
+            target - ((ptr_int_t)(pc + 4 - copy_pc + (ptr_uint_t)final_pc));
 #ifdef X64
         if (check_reachable && !REL32_REACHABLE_OFFS(offset)) {
             CLIENT_ASSERT(!assert_reachable,

--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -3021,8 +3021,7 @@ encode_cti(instr_t *instr, byte *copy_pc, byte *final_pc,
     } else {
         /* 32-bit offset */
         /* offset is from start of next instr */
-        ptr_int_t offset =
-            target - ((ptr_int_t)(pc + 4 - copy_pc + (ptr_uint_t)final_pc));
+        ptr_int_t offset = target - (pc + 4 - copy_pc + (ptr_uint_t)final_pc);
 #ifdef X64
         if (check_reachable && !REL32_REACHABLE_OFFS(offset)) {
             CLIENT_ASSERT(!assert_reachable,

--- a/core/ir/x86/encode.c
+++ b/core/ir/x86/encode.c
@@ -3010,7 +3010,7 @@ encode_cti(instr_t *instr, byte *copy_pc, byte *final_pc,
         CLIENT_ASSERT(!instr_is_cti_short_rewrite(instr, NULL),
                       "encode_cti error: jecxz/loop already mangled");
         /* offset is from start of next instr */
-        offset = target - ((ptr_int_t)(pc + 1 - copy_pc + final_pc));
+        offset = target - (pc + 1 - copy_pc + (ptr_uint_t)final_pc);
         if (check_reachable && !(offset >= INT8_MIN && offset <= INT8_MAX)) {
             CLIENT_ASSERT(!assert_reachable,
                           "encode_cti error: target beyond 8-bit reach");

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -465,11 +465,11 @@ module_read_entry_print(module_read_entry_t *entry, uint idx, char *buf, size_t 
 {
     int len, total_len = 0;
     len = dr_snprintf(buf, size,
-                      "%3u, %3u, " PFX ", " PFX ", " PFX ", " ZHEX64_FORMAT_STRING
-                      ", " PFX ", ",
+                      "%3u, %3u, " PFX ", " PFX ", " PFX
+                      ", " ZHEX64_FORMAT_STRING ", " PFX ", ",
                       idx, entry->containing_id, entry->base,
-                      (app_pc)((ptr_uint_t)entry->base + entry->size), entry->entry,
-                      entry->offset, entry->preferred_base);
+                      (app_pc)((ptr_uint_t)entry->base + entry->size),
+                      entry->entry, entry->offset, entry->preferred_base);
     if (len == -1)
         return -1;
     buf += len;

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -465,10 +465,10 @@ module_read_entry_print(module_read_entry_t *entry, uint idx, char *buf, size_t 
 {
     int len, total_len = 0;
     len = dr_snprintf(buf, size,
-                      "%3u, %3u, " PFX ", " PFX ", " PFX
-                      ", " ZHEX64_FORMAT_STRING ", " PFX ", ",
+                      "%3u, %3u, " PFX ", " PFX ", " PFX ", " ZHEX64_FORMAT_STRING
+                      ", " PFX ", ",
                       idx, entry->containing_id, entry->base,
-                      (app_pc)((ptr_uint_t)entry->base + entry->size),
+                      (app_pc)((ptr_uint_t)entry->base + (ptr_uint_t)entry->size),
                       entry->entry, entry->offset, entry->preferred_base);
     if (len == -1)
         return -1;

--- a/ext/drcovlib/modules.c
+++ b/ext/drcovlib/modules.c
@@ -467,8 +467,9 @@ module_read_entry_print(module_read_entry_t *entry, uint idx, char *buf, size_t 
     len = dr_snprintf(buf, size,
                       "%3u, %3u, " PFX ", " PFX ", " PFX ", " ZHEX64_FORMAT_STRING
                       ", " PFX ", ",
-                      idx, entry->containing_id, entry->base, entry->base + entry->size,
-                      entry->entry, entry->offset, entry->preferred_base);
+                      idx, entry->containing_id, entry->base,
+                      (app_pc)((ptr_uint_t)entry->base + entry->size), entry->entry,
+                      entry->offset, entry->preferred_base);
     if (len == -1)
         return -1;
     buf += len;


### PR DESCRIPTION
Adding to NULL is undefined behavior.

This fixes reports we detected on our internal tests
of tools depending on DynamoRIO.

Examples of reports are in #7229.

Many others are likely still undiscovered.

Issue: #7229
