### PR TITLE
i#2154 Android64: Fix linux.signal and linux.sigplain tests

### DIFF
--- a/suite/tests/api/detach_signal.cpp
+++ b/suite/tests/api/detach_signal.cpp
@@ -227,7 +227,8 @@ sideline_spinner(void *arg)
             0, /* Set padding to 0 so we can use memcmp */
         };
         res = sigprocmask(SIG_BLOCK, NULL, &check_mask);
-        assert(res == 0 && memcmp(&returned_mask, &check_mask, sizeof(returned_mask)) == 0);
+        assert(res == 0 &&
+               memcmp(&returned_mask, &check_mask, sizeof(returned_mask)) == 0);
     }
 
     stack_t check_stack;

--- a/suite/tests/api/detach_signal.cpp
+++ b/suite/tests/api/detach_signal.cpp
@@ -176,6 +176,24 @@ sideline_spinner(void *arg)
     sigaddset(&mask, SIGURG);
     res = sigprocmask(SIG_SETMASK, &mask, NULL);
     assert(res == 0);
+    sigset_t returned_mask = {
+        0, /* Set padding to 0 so we can use memcmp */
+    };
+    res = sigprocmask(SIG_BLOCK, NULL, &returned_mask);
+    assert(res == 0);
+#ifdef ANDROID64
+    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
+     * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
+     * If this bit is not also set for our mask then the assert will fail.
+     * i#7215: This may also be needed for newer versions of 32-bit Android,
+     * however we are not able to test newer versions of 32-bit Android, so
+     * cannot be sure.
+     */
+    sigaddset(&mask, __SIGRTMIN);
+#endif
+    /* Check that the mask we just set is the same as the one currently in use.
+     */
+    assert(memcmp(&mask, &returned_mask, sizeof(mask)) == 0);
 
     /* Now sit in a signal-generating loop. */
     while (!sideline_exit) {
@@ -209,7 +227,7 @@ sideline_spinner(void *arg)
             0, /* Set padding to 0 so we can use memcmp */
         };
         res = sigprocmask(SIG_BLOCK, NULL, &check_mask);
-        assert(res == 0 && memcmp(&mask, &check_mask, sizeof(mask)) == 0);
+        assert(res == 0 && memcmp(&returned_mask, &check_mask, sizeof(returned_mask)) == 0);
     }
 
     stack_t check_stack;
@@ -250,6 +268,27 @@ main(void)
     sigaddset(&handler_mask, DR_SUSPEND_SIGNAL);
     int res = sigprocmask(SIG_SETMASK, &handler_mask, &prior_mask);
     assert(res == 0);
+
+    sigset_t handler_mask_cpy;
+    memcpy(&handler_mask_cpy, &handler_mask, sizeof(handler_mask_cpy));
+    sigset_t returned_mask = {
+        0, /* Set padding to 0 so we can use memcmp */
+    };
+    res = sigprocmask(SIG_BLOCK, NULL, &returned_mask);
+    assert(res == 0);
+#ifdef ANDROID64
+    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
+     * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
+     * If this bit is not also set for our mask then the assert will fail.
+     * i#7215: This may also be needed for newer versions of 32-bit Android,
+     * however we are not able to test newer versions of 32-bit Android, so
+     * cannot be sure.
+     */
+    sigaddset(&handler_mask_cpy, __SIGRTMIN);
+#endif
+    assert(memcmp(&handler_mask_cpy, &returned_mask, sizeof(handler_mask_cpy)) == 0);
+    handler_mask = returned_mask;
+
     res = sigprocmask(SIG_SETMASK, &prior_mask, NULL);
     assert(res == 0);
 

--- a/suite/tests/linux/signal-base.h
+++ b/suite/tests/linux/signal-base.h
@@ -313,6 +313,17 @@ int
     };
     rc = sigprocmask(SIG_BLOCK, NULL, &check_mask);
     ASSERT_NOERR(rc);
+#ifdef ANDROID64
+    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
+     * __SIGRTMIN in the NDK. This occurs whether running under DR or not, and
+     * can be easily reproduced outside of these tests.
+     * If this bit is not also set for our mask then the assert will fail.
+     * i#7215: This may also be needed for newer versions of 32-bit Android,
+     * however we are not able to test newer versions of 32-bit Android, so
+     * cannot be sure.
+     */
+    sigaddset(&mask, __SIGRTMIN);
+#endif
     assert(memcmp(&mask, &check_mask, sizeof(mask)) == 0);
 
 #if USE_TIMER

--- a/suite/tests/linux/signal-base.h
+++ b/suite/tests/linux/signal-base.h
@@ -239,6 +239,24 @@ int
     sigaddset(&mask, SIGALRM);
     rc = sigprocmask(SIG_SETMASK, &mask, NULL);
     ASSERT_NOERR(rc);
+    sigset_t returned_mask = {
+        0, /* Set padding to 0 so we can use memcmp */
+    };
+    rc = sigprocmask(SIG_BLOCK, NULL, &returned_mask);
+    ASSERT_NOERR(rc);
+#ifdef ANDROID64
+    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
+     * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
+     * If this bit is not also set for our mask then the assert will fail.
+     * i#7215: This may also be needed for newer versions of 32-bit Android,
+     * however we are not able to test newer versions of 32-bit Android, so
+     * cannot be sure.
+     */
+    sigaddset(&mask, __SIGRTMIN);
+#endif
+    /* Check that the mask we just set is the same as the one currently in use.
+     */
+    assert(memcmp(&mask, &returned_mask, sizeof(mask)) == 0);
 
 #if USE_SIGSTACK
     sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);
@@ -313,18 +331,7 @@ int
     };
     rc = sigprocmask(SIG_BLOCK, NULL, &check_mask);
     ASSERT_NOERR(rc);
-#ifdef ANDROID64
-    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
-     * __SIGRTMIN in the NDK. This occurs whether running under DR or not, and
-     * can be easily reproduced outside of these tests.
-     * If this bit is not also set for our mask then the assert will fail.
-     * i#7215: This may also be needed for newer versions of 32-bit Android,
-     * however we are not able to test newer versions of 32-bit Android, so
-     * cannot be sure.
-     */
-    sigaddset(&mask, __SIGRTMIN);
-#endif
-    assert(memcmp(&mask, &check_mask, sizeof(mask)) == 0);
+    assert(memcmp(&returned_mask, &check_mask, sizeof(returned_mask)) == 0);
 
 #if USE_TIMER
     memset(&t, 0, sizeof(t));

--- a/suite/tests/linux/signal-base.h
+++ b/suite/tests/linux/signal-base.h
@@ -237,26 +237,10 @@ int
     sigemptyset(&mask);
     sigaddset(&mask, SIGURG);
     sigaddset(&mask, SIGALRM);
-    rc = sigprocmask(SIG_SETMASK, &mask, NULL);
-    ASSERT_NOERR(rc);
     sigset_t returned_mask = {
         0, /* Set padding to 0 so we can use memcmp */
     };
-    rc = sigprocmask(SIG_BLOCK, NULL, &returned_mask);
-    ASSERT_NOERR(rc);
-#ifdef ANDROID64
-    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
-     * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
-     * If this bit is not also set for our mask then the assert will fail.
-     * i#7215: This may also be needed for newer versions of 32-bit Android,
-     * however we are not able to test newer versions of 32-bit Android, so
-     * cannot be sure.
-     */
-    sigaddset(&mask, __SIGRTMIN);
-#endif
-    /* Check that the mask we just set is the same as the one currently in use.
-     */
-    assert(memcmp(&mask, &returned_mask, sizeof(mask)) == 0);
+    set_check_signal_mask(&mask, &returned_mask);
 
 #if USE_SIGSTACK
     sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);

--- a/suite/tests/linux/sigplain-base.h
+++ b/suite/tests/linux/sigplain-base.h
@@ -195,6 +195,17 @@ main(int argc, char *argv[])
     };
     rc = sigprocmask(SIG_BLOCK, NULL, &check_mask);
     ASSERT_NOERR(rc);
+#ifdef ANDROID64
+    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
+     * __SIGRTMIN in the NDK. This occurs whether running under DR or not, and
+     * can be easily reproduced outside of these tests.
+     * If this bit is not also set for our mask then the assert will fail.
+     * i#7215: This may also be needed for newer versions of 32-bit Android,
+     * however we are not able to test newer versions of 32-bit Android, so
+     * cannot be sure.
+     */
+    sigaddset(&mask, __SIGRTMIN);
+#endif
     assert(memcmp(&mask, &check_mask, sizeof(mask)) == 0);
 
 #if USE_TIMER

--- a/suite/tests/linux/sigplain-base.h
+++ b/suite/tests/linux/sigplain-base.h
@@ -144,6 +144,24 @@ main(int argc, char *argv[])
     sigaddset(&mask, SIGALRM);
     rc = sigprocmask(SIG_SETMASK, &mask, NULL);
     ASSERT_NOERR(rc);
+    sigset_t returned_mask = {
+        0, /* Set padding to 0 so we can use memcmp */
+    };
+    rc = sigprocmask(SIG_BLOCK, NULL, &returned_mask);
+    ASSERT_NOERR(rc);
+#ifdef ANDROID64
+    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
+     * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
+     * If this bit is not also set for our mask then the assert will fail.
+     * i#7215: This may also be needed for newer versions of 32-bit Android,
+     * however we are not able to test newer versions of 32-bit Android, so
+     * cannot be sure.
+     */
+    sigaddset(&mask, __SIGRTMIN);
+#endif
+    /* Check that the mask we just set is the same as the one currently in use.
+     */
+    assert(memcmp(&mask, &returned_mask, sizeof(mask)) == 0);
 
 #if USE_SIGSTACK
     sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);
@@ -195,18 +213,7 @@ main(int argc, char *argv[])
     };
     rc = sigprocmask(SIG_BLOCK, NULL, &check_mask);
     ASSERT_NOERR(rc);
-#ifdef ANDROID64
-    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
-     * __SIGRTMIN in the NDK. This occurs whether running under DR or not, and
-     * can be easily reproduced outside of these tests.
-     * If this bit is not also set for our mask then the assert will fail.
-     * i#7215: This may also be needed for newer versions of 32-bit Android,
-     * however we are not able to test newer versions of 32-bit Android, so
-     * cannot be sure.
-     */
-    sigaddset(&mask, __SIGRTMIN);
-#endif
-    assert(memcmp(&mask, &check_mask, sizeof(mask)) == 0);
+    assert(memcmp(&returned_mask, &check_mask, sizeof(returned_mask)) == 0);
 
 #if USE_TIMER
     memset(&t, 0, sizeof(t));

--- a/suite/tests/linux/sigplain-base.h
+++ b/suite/tests/linux/sigplain-base.h
@@ -142,26 +142,10 @@ main(int argc, char *argv[])
     sigemptyset(&mask);
     sigaddset(&mask, SIGURG);
     sigaddset(&mask, SIGALRM);
-    rc = sigprocmask(SIG_SETMASK, &mask, NULL);
-    ASSERT_NOERR(rc);
     sigset_t returned_mask = {
         0, /* Set padding to 0 so we can use memcmp */
     };
-    rc = sigprocmask(SIG_BLOCK, NULL, &returned_mask);
-    ASSERT_NOERR(rc);
-#ifdef ANDROID64
-    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
-     * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
-     * If this bit is not also set for our mask then the assert will fail.
-     * i#7215: This may also be needed for newer versions of 32-bit Android,
-     * however we are not able to test newer versions of 32-bit Android, so
-     * cannot be sure.
-     */
-    sigaddset(&mask, __SIGRTMIN);
-#endif
-    /* Check that the mask we just set is the same as the one currently in use.
-     */
-    assert(memcmp(&mask, &returned_mask, sizeof(mask)) == 0);
+    set_check_signal_mask(&mask, &returned_mask);
 
 #if USE_SIGSTACK
     sigstack.ss_sp = (char *)malloc(ALT_STACK_SIZE);

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -491,6 +491,32 @@ intercept_signal(int sig, handler_3_t handler, bool sigstack)
     ASSERT_NOERR(rc);
 }
 
+/* Set a signal mask and then immediately check that the current signal mask
+ * matches what we set, with considerations for special cases e.g. Android.
+ */
+void
+set_check_signal_mask(sigset_t *mask, sigset_t *returned_mask)
+{
+    int rc;
+    rc = sigprocmask(SIG_SETMASK, mask, NULL);
+    ASSERT_NOERR(rc);
+    rc = sigprocmask(SIG_BLOCK, NULL, returned_mask);
+    ASSERT_NOERR(rc);
+#ifdef ANDROID64
+    /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
+     * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
+     * If this bit is not also set for our mask then the assert will fail.
+     * i#7215: This may also be needed for newer versions of 32-bit Android,
+     * however we are not able to test newer versions of 32-bit Android, so
+     * cannot be sure.
+     */
+    sigaddset(mask, __SIGRTMIN);
+#endif
+    /* Check that the mask we just set is the same as the one currently in use.
+     */
+    assert(memcmp(mask, returned_mask, sizeof(*mask)) == 0);
+}
+
 #        ifdef AARCH64
 #            ifdef DR_HOST_NOT_TARGET
 #                define RESERVED __reserved1
@@ -598,7 +624,6 @@ dump_ucontext(ucontext_t *ucxt, bool is_sve, int vl_bytes)
 #            endif
 }
 #        endif
-
 #    endif /* UNIX */
 
 #else /* asm code *************************************************************/

--- a/suite/tests/tools.c
+++ b/suite/tests/tools.c
@@ -502,7 +502,7 @@ set_check_signal_mask(sigset_t *mask, sigset_t *returned_mask)
     ASSERT_NOERR(rc);
     rc = sigprocmask(SIG_BLOCK, NULL, returned_mask);
     ASSERT_NOERR(rc);
-#ifdef ANDROID64
+#        ifdef ANDROID64
     /* 64-bit Android always sets the 32nd bit of the signal mask, defined as
      * __SIGRTMIN in the NDK. This occurs whether running under DR or not.
      * If this bit is not also set for our mask then the assert will fail.
@@ -511,7 +511,7 @@ set_check_signal_mask(sigset_t *mask, sigset_t *returned_mask)
      * cannot be sure.
      */
     sigaddset(mask, __SIGRTMIN);
-#endif
+#        endif
     /* Check that the mask we just set is the same as the one currently in use.
      */
     assert(memcmp(mask, returned_mask, sizeof(*mask)) == 0);
@@ -624,6 +624,7 @@ dump_ucontext(ucontext_t *ucxt, bool is_sve, int vl_bytes)
 #            endif
 }
 #        endif
+
 #    endif /* UNIX */
 
 #else /* asm code *************************************************************/

--- a/suite/tests/tools.h
+++ b/suite/tests/tools.h
@@ -357,6 +357,9 @@ typedef void (*handler_3_t)(int, siginfo_t *, ucontext_t *);
 void
 intercept_signal(int sig, handler_3_t handler, bool sigstack);
 
+void
+set_check_signal_mask(sigset_t *mask, sigset_t *returned_mask);
+
 #    ifdef AARCH64
 void
 dump_ucontext(ucontext_t *ucxt, bool is_sve, int vl);


### PR DESCRIPTION
All 16 of the `linux.signalXXXX` and all 8 of the `linux.sigplainXXX` tests were failing on 64-bit Android.

These failures were due to a common `ASSERT` which checks to make sure that the signal mask that is manually created and set as the process' signal mask is the same as the actual signal mask that is in use by the process at the end of the test, i.e. the process is blocking all of the signals we asked it to block - no more and no less.

However, it seems that Android (at least 64-bit) automatically sets the 32nd/last bit of the signal mask. This means that the mask we create (which is missing this 32nd bit) is not the same as the mask that is returned at the end (with the 32nd bit), and so the test fails.

The same issue is also present in the `api.detach_signal` test and has been fixed there, however there is another issue stopping that test from passing.

This behaviour is present in these tests both with and without DynamoRIO, and can also be seen in a simple reproducer.

Issues: #2154, #7215