### PR TITLE
i#7224 skip docs: Clarify drmemtrace skip option docs

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -652,8 +652,10 @@ droption_t<bytesize_t> op_L0_filter_until_instrs(
     "full trace. Therefore TRACE_MARKER_TYPE_WINDOW_ID markers indicate start of "
     "filtered records.");
 
-// XXX i#7230: Currently the simulators count non-marker records here: we should
+// XXX i#7230: Currently the simulators count only non-marker records here: we should
 // either change that to all records to match -skip_refs, or update these docs.
+// If we update to match -skip_refs, we should make it clear that marker records
+// are not actually warming up the cache but are still being counted.
 droption_t<bytesize_t> op_warmup_refs(
     DROPTION_SCOPE_FRONTEND, "warmup_refs", 0, "Number of records to warm caches up",
     "This option is honored by certain tools such as the cache and TLB simulators. "
@@ -669,7 +671,7 @@ droption_t<double> op_warmup_fraction(
     "is computed after the skipped references and before simulated references. "
     "This flag is incompatible with warmup_refs.");
 
-// XXX i#7230: Currently the simulators count non-marker records here: we should
+// XXX i#7230: Currently the simulators count only non-marker records here: we should
 // either change that to all records to match -skip_refs, or update these docs.
 droption_t<bytesize_t> op_sim_refs(
     DROPTION_SCOPE_FRONTEND, "sim_refs", bytesize_t(1ULL << 63),
@@ -678,7 +680,9 @@ droption_t<bytesize_t> op_sim_refs(
     "the view tool.  It causes them to only analyze this many records and ignore all "
     "subsequent records.  If -skip_refs is specified, the analyzed records start after "
     "the skipped ones end; similarly, if -warmup_refs is specified, the warmup records "
-    "come prior to the -sim_refs records.");
+    "come prior to the -sim_refs records.  Since the framework is still iterating over "
+    "all the records and it is the tool who is ignoring those outside of this range, a "
+    "large trace may still take time even with a small value for this option.");
 
 droption_t<std::string>
     op_view_syntax(DROPTION_SCOPE_FRONTEND, "view_syntax", "att/arm/dr/riscv",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -602,8 +602,10 @@ droption_t<bytesize_t> op_skip_instrs(
     "an alternative which does align all threads).  When built with zipfile "
     "support, this skipping is optimized and large instruction counts can be quickly "
     "skipped; this is not the case for -skip_refs.  This will skip over top-level "
-    "metadata records (such as #TRACE_MARKER_TYPE_VERSION, #TRACE_MARKER_TYPE_FILETYPE, "
-    "#TRACE_MARKER_TYPE_PAGE_SIZE, and #TRACE_MARKER_TYPE_CACHE_LINE_SIZE) and so those "
+    "metadata records (such as #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION, "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE, "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_PAGE_SIZE, and "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_CACHE_LINE_SIZE) and so those "
     "records will not appear to analysis tools; however, their contents can be obtained "
     "from #dynamorio::drmemtrace::memtrace_stream_t API accessors.");
 
@@ -626,8 +628,10 @@ droption_t<uint64_t> op_skip_to_timestamp(
     "is required to translate the timestamp into per-thread instruction ordinals."
     "When built with zipfile support, this skipping is optimized and large "
     "instruction counts can be quickly skipped.  This will skip over top-level "
-    "metadata records (such as #TRACE_MARKER_TYPE_VERSION, #TRACE_MARKER_TYPE_FILETYPE, "
-    "#TRACE_MARKER_TYPE_PAGE_SIZE, and #TRACE_MARKER_TYPE_CACHE_LINE_SIZE) and so those "
+    "metadata records (such as #dynamorio::drmemtrace::TRACE_MARKER_TYPE_VERSION, "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_FILETYPE, "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_PAGE_SIZE, and "
+    "#dynamorio::drmemtrace::TRACE_MARKER_TYPE_CACHE_LINE_SIZE) and so those "
     "records will not appear to analysis tools; however, their contants can be obtained "
     "from #dynamorio::drmemtrace::memtrace_stream_t API accessors.");
 

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -601,15 +601,20 @@ droption_t<bytesize_t> op_skip_instrs(
     "iteration, each thread skips this many instructions (see -skip_to_timestamp for "
     "an alternative which does align all threads).  When built with zipfile "
     "support, this skipping is optimized and large instruction counts can be quickly "
-    "skipped; this is not the case for -skip_refs.");
+    "skipped; this is not the case for -skip_refs.  This will skip over top-level "
+    "metadata records (such as #TRACE_MARKER_TYPE_VERSION, #TRACE_MARKER_TYPE_FILETYPE, "
+    "#TRACE_MARKER_TYPE_PAGE_SIZE, and #TRACE_MARKER_TYPE_CACHE_LINE_SIZE) and so those "
+    "records will not appear to analysis tools; however, their contents can be obtained "
+    "from #dynamorio::drmemtrace::memtrace_stream_t API accessors.");
 
-droption_t<bytesize_t>
-    op_skip_refs(DROPTION_SCOPE_FRONTEND, "skip_refs", 0,
-                 "Number of memory references to skip",
-                 "Specifies the number of references to skip in the beginning of the "
-                 "application execution. These memory references are dropped instead "
-                 "of being simulated.  This skipping may be slow for large skip values; "
-                 "consider -skip_instrs for a faster method of skipping.");
+droption_t<bytesize_t> op_skip_refs(
+    DROPTION_SCOPE_FRONTEND, "skip_refs", 0, "Number of records to skip in certain tools",
+    "This option is honored by certain tools such as the cache and TLB simulators and "
+    "the view tool.  It causes them to ignore the specified count of records at the "
+    "start of the trace and only start processing after that count is reached.  Since "
+    "the framework is still iterating over those records and it is the tool who is "
+    "ignoring them, this skipping may be slow for large skip values; consider "
+    "-skip_instrs for a faster method of skipping inside the framework itself.");
 
 droption_t<uint64_t> op_skip_to_timestamp(
     DROPTION_SCOPE_FRONTEND, "skip_to_timestamp", 0, "Timestamp to start at",
@@ -620,7 +625,11 @@ droption_t<uint64_t> op_skip_to_timestamp(
     "specified.  Requires -cpu_schedule_file to also be specified as a schedule file "
     "is required to translate the timestamp into per-thread instruction ordinals."
     "When built with zipfile support, this skipping is optimized and large "
-    "instruction counts can be quickly skipped.");
+    "instruction counts can be quickly skipped.  This will skip over top-level "
+    "metadata records (such as #TRACE_MARKER_TYPE_VERSION, #TRACE_MARKER_TYPE_FILETYPE, "
+    "#TRACE_MARKER_TYPE_PAGE_SIZE, and #TRACE_MARKER_TYPE_CACHE_LINE_SIZE) and so those "
+    "records will not appear to analysis tools; however, their contants can be obtained "
+    "from #dynamorio::drmemtrace::memtrace_stream_t API accessors.");
 
 droption_t<bytesize_t> op_L0_filter_until_instrs(
     DROPTION_SCOPE_CLIENT, "L0_filter_until_instrs", 0,
@@ -639,12 +648,14 @@ droption_t<bytesize_t> op_L0_filter_until_instrs(
     "full trace. Therefore TRACE_MARKER_TYPE_WINDOW_ID markers indicate start of "
     "filtered records.");
 
+// XXX i#7230: Currently the simulators count non-marker records here: we should
+// either change that to all records to match -skip_refs, or update these docs.
 droption_t<bytesize_t> op_warmup_refs(
-    DROPTION_SCOPE_FRONTEND, "warmup_refs", 0,
-    "Number of memory references to warm caches up",
-    "Specifies the number of memory references to warm up caches before simulation. "
-    "The warmup references come after the skipped references and before the "
-    "simulated references. This flag is incompatible with warmup_fraction.");
+    DROPTION_SCOPE_FRONTEND, "warmup_refs", 0, "Number of records to warm caches up",
+    "This option is honored by certain tools such as the cache and TLB simulators. "
+    "It causes them to not start analysis/simulation until this many records are seen."
+    "If -skip_refs is specified, the warmup records start after "
+    "the skipped ones end. This flag is incompatible with warmup_fraction.");
 
 droption_t<double> op_warmup_fraction(
     DROPTION_SCOPE_FRONTEND, "warmup_fraction", 0.0, 0.0, 1.0,
@@ -654,12 +665,16 @@ droption_t<double> op_warmup_fraction(
     "is computed after the skipped references and before simulated references. "
     "This flag is incompatible with warmup_refs.");
 
-droption_t<bytesize_t>
-    op_sim_refs(DROPTION_SCOPE_FRONTEND, "sim_refs", bytesize_t(1ULL << 63),
-                "Number of memory references to simulate",
-                "Specifies the number of memory references to simulate. "
-                "The simulated references come after the skipped and warmup references, "
-                "and the references following the simulated ones are dropped.");
+// XXX i#7230: Currently the simulators count non-marker records here: we should
+// either change that to all records to match -skip_refs, or update these docs.
+droption_t<bytesize_t> op_sim_refs(
+    DROPTION_SCOPE_FRONTEND, "sim_refs", bytesize_t(1ULL << 63),
+    "Number of records to analyze",
+    "This option is honored by certain tools such as the cache and TLB simulators and "
+    "the view tool.  It causes them to only analyze this many records and ignore all "
+    "subsequent records.  If -skip_refs is specified, the analyzed records start after "
+    "the skipped ones end; similarly, if -warmup_refs is specified, the warmup records "
+    "come prior to the -sim_refs records.");
 
 droption_t<std::string>
     op_view_syntax(DROPTION_SCOPE_FRONTEND, "view_syntax", "att/arm/dr/riscv",

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -699,7 +699,8 @@ disassembly for online traces, pass the `-instr_encodings` option). The
 -skip_refs and -sim_refs flags can be used to
 set a start point and end point for the disassembled view. Note that these
 flags compute the number of trace entry records which are skipped or displayed which
-is distinct from the number of instruction records.
+is distinct from the number of instruction records; to skip instruction records
+use -skip_instrs or -skip_to_timestamp (this is faster than -skip_refs).
 
 The tool displays loads and stores, as well as metadata marker entries for
 timestamps, on which core and thread the subsequent instruction sequence was

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -469,6 +469,10 @@ cache_simulator_t::process_memref(const memref_t &memref)
     if (memref.marker.type == TRACE_TYPE_MARKER) {
         // We ignore markers before we ask core_for_thread, to avoid asking
         // too early on a timestamp marker.
+        // TODO i#7230: This causes -warmup_refs and -sim_refs to count non-marker
+        // records while -skip_refs counts all records.  We should either say
+        // that in the docs or change the behavior here.
+        // Plus, this skips the TRACE_MARKER_TYPE_CPU_ID handling below.
         if (knobs_.verbose >= 3) {
             std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
                       << "marker type " << memref.marker.marker_type << " value "

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -191,6 +191,10 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     if (memref.marker.type == TRACE_TYPE_MARKER) {
         // We ignore markers before we ask core_for_thread, to avoid asking
         // too early on a timestamp marker.
+        // TODO i#7230: This causes -warmup_refs and -sim_refs to count non-marker
+        // records while -skip_refs counts all records.  We should either say
+        // that in the docs or change the behavior here.
+        // Plus, this skips the TRACE_MARKER_TYPE_CPU_ID handling below.
         return true;
     }
 


### PR DESCRIPTION
Clarifies that the -{skip,sim,warmup}_refs options skip a count of trace records inside particular tools, rather than in the framework.

Clarifies that the -skip_{instrs,to_timestamp} options skip over top-level markers, but their values are available from the stream API.

Adds i#7230 TODO comments on fixing the -{sim,warmup}_refs options in the simulators to count marker records (or possibly to keep as is and update the docs).

Issue: #7224, #7230