### PR TITLE
i#7113 decode cache: Add build arch check

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1112,6 +1112,12 @@ trace_arch_string(offline_file_type_t type)
 /* We have non-client targets including this header that do not include API
  * headers defining IF_X86_ELSE, etc.  Those don't need this function so we
  * simply exclude them.
+ *
+ * TODO i#7236: If trace_entry.h is included before IF_X86_ELSE is defined by
+ * dr_defines.h, it shows up as a build failure without an obvious cause because
+ * the order between the two headers is not always immediately clear (since they
+ * may be transitively included). i#7236 notes a workaround, but this should be
+ * cleaned up.
  */
 #ifdef IF_X86_ELSE
 static inline offline_file_type_t

--- a/clients/drcachesim/tests/decode_cache_test.cpp
+++ b/clients/drcachesim/tests/decode_cache_test.cpp
@@ -37,7 +37,7 @@
 
 // Needs to be included before memref.h or build_target_arch_type() will not
 // be defined by trace_entry.h.
-#include "dr_defines.h"
+#include "dr_api.h"
 
 #include "decode_cache.h"
 #include "../common/memref.h"

--- a/clients/drcachesim/tests/decode_cache_test.cpp
+++ b/clients/drcachesim/tests/decode_cache_test.cpp
@@ -35,6 +35,10 @@
 #include <iostream>
 #include <vector>
 
+// Needs to be included before memref.h or build_target_arch_type() will not
+// be defined by trace_entry.h.
+#include "dr_defines.h"
+
 #include "decode_cache.h"
 #include "../common/memref.h"
 #include "memref_gen.h"
@@ -320,6 +324,46 @@ check_init_error_cases(void *drcontext)
         "some_module_file_path", "");
     if (!err.empty()) {
         return "Expected successful init on another decode cache instance, got error: " +
+            err;
+    }
+
+    // Decode cache that specifies a different module_file_path but it works since
+    // it's empty.
+    test_decode_cache_t<instr_decode_info_t> decode_cache_no_mod(
+        drcontext, /*include_decoded_instr=*/true,
+        /*persist_decoded_instr=*/true, nullptr);
+    err = decode_cache_no_mod.init(
+        static_cast<offline_file_type_t>(OFFLINE_FILE_TYPE_ENCODINGS), "", "");
+    if (!err.empty()) {
+        return "Expected no error for empty module file path, got: " + err;
+    }
+
+    // Decode cache init with wrong arch.
+    offline_file_type_t file_type_with_arch = build_target_arch_type();
+    offline_file_type_t file_type_with_wrong_arch = file_type_with_arch;
+    if (file_type_with_arch == OFFLINE_FILE_TYPE_ARCH_AARCH64) {
+        file_type_with_wrong_arch = OFFLINE_FILE_TYPE_ARCH_X86_64;
+    } else {
+        file_type_with_wrong_arch = OFFLINE_FILE_TYPE_ARCH_AARCH64;
+    }
+    test_decode_cache_t<instr_decode_info_t> decode_cache_wrong_arch(
+        drcontext, /*include_decoded_instr=*/true,
+        /*persist_decoded_instr=*/true, nullptr);
+    err = decode_cache_wrong_arch.init(file_type_with_wrong_arch, "some_module_file_path",
+                                       "");
+    if (err.empty()) {
+        return "Expected error on file type with wrong arch";
+    }
+
+    // Decode cache init with wrong arch but with include_decoded_instr_
+    // set to false;
+    test_decode_cache_t<instr_decode_info_t> decode_cache_wrong_arch_no_decode(
+        drcontext, /*include_decoded_instr=*/false,
+        /*persist_decoded_instr=*/false, nullptr);
+    err = decode_cache_wrong_arch_no_decode.init(file_type_with_wrong_arch,
+                                                 "some_module_file_path", "");
+    if (!err.empty()) {
+        return "Expected no error on file type with wrong arch when not decoding, got: " +
             err;
     }
 

--- a/clients/drcachesim/tools/common/decode_cache.cpp
+++ b/clients/drcachesim/tools/common/decode_cache.cpp
@@ -35,10 +35,14 @@
 #include <memory>
 #include <mutex>
 
-#include "decode_cache.h"
+// Needs to be included before trace_entry.h or build_target_arch_type will not
+// be defined by trace_entry.h.
 #include "dr_defines.h"
+
+#include "decode_cache.h"
 #include "memref.h"
 #include "raw2trace_shared.h"
+#include "trace_entry.h"
 #include "utils.h"
 
 namespace dynamorio {
@@ -170,6 +174,22 @@ instr_t *
 instr_decode_info_t::get_decoded_instr()
 {
     return instr_;
+}
+
+offline_file_type_t
+decode_cache_base_t::build_arch_file_type()
+{
+    // build_target_arch_type() is defined in trace_entry.h, but it is built
+    // conditionally only if certain symbols that are defined by dr_defines.h
+    // are already defined. It is hard to control the order in which headers
+    // are included, so to make it easier we provide this build_arch_file_type()
+    // implementation in this separate source file which is part of the
+    // drmemtrace_decode_cache build library unit.
+    //
+    // Also, this had to be an API on decode_cache_base_t instead of
+    // decode_cache_t because since decode_cache_t is a template class its
+    // implementation must be in the header.
+    return static_cast<offline_file_type_t>(build_target_arch_type());
 }
 
 // Must be in cpp and not the header, else the linker will complain about multiple

--- a/clients/drcachesim/tools/common/decode_cache.cpp
+++ b/clients/drcachesim/tools/common/decode_cache.cpp
@@ -179,7 +179,7 @@ instr_decode_info_t::get_decoded_instr()
 offline_file_type_t
 decode_cache_base_t::build_arch_file_type()
 {
-    // build_target_arch_type() is defined in trace_entry.h, but it is built
+    // i#7236: build_target_arch_type() is defined in trace_entry.h, but it is built
     // conditionally only the IF_X64_ELSE symbol that is defined by dr_api.h
     // is already defined. It is hard to control the order in which headers
     // are included, so to make it easier we provide this build_arch_file_type()

--- a/clients/drcachesim/tools/common/decode_cache.cpp
+++ b/clients/drcachesim/tools/common/decode_cache.cpp
@@ -37,7 +37,7 @@
 
 // Needs to be included before trace_entry.h or build_target_arch_type will not
 // be defined by trace_entry.h.
-#include "dr_defines.h"
+#include "dr_api.h"
 
 #include "decode_cache.h"
 #include "memref.h"
@@ -180,8 +180,8 @@ offline_file_type_t
 decode_cache_base_t::build_arch_file_type()
 {
     // build_target_arch_type() is defined in trace_entry.h, but it is built
-    // conditionally only if certain symbols that are defined by dr_defines.h
-    // are already defined. It is hard to control the order in which headers
+    // conditionally only the IF_X64_ELSE symbol that is defined by dr_api.h
+    // is already defined. It is hard to control the order in which headers
     // are included, so to make it easier we provide this build_arch_file_type()
     // implementation in this separate source file which is part of the
     // drmemtrace_decode_cache build library unit.

--- a/clients/drcachesim/tools/common/decode_cache.h
+++ b/clients/drcachesim/tools/common/decode_cache.h
@@ -216,6 +216,13 @@ protected:
     std::string
     find_mapped_trace_address(app_pc trace_pc, app_pc &decode_pc);
 
+    /**
+     * Returns the #dynamorio::drmemtrace::offline_file_type_t arch bit that
+     * corresponds to the current build environment.
+     */
+    offline_file_type_t
+    build_arch_file_type();
+
 private:
     /**
      * Creates a module_mapper_t. This does not need to worry about races as the
@@ -465,6 +472,18 @@ public:
     {
         if (init_done_) {
             return "init already done";
+        }
+        if (include_decoded_instr_) {
+            // We remove OFFLINE_FILE_TYPE_ARCH_REGDEPS from this check since
+            // DR_ISA_REGDEPS is not a real ISA and can coexist with any real
+            // architecture.
+            if (TESTANY(OFFLINE_FILE_TYPE_ARCH_ALL & ~OFFLINE_FILE_TYPE_ARCH_REGDEPS,
+                        filetype) &&
+                !TESTANY(build_arch_file_type(), filetype)) {
+                return std::string("Architecture mismatch: trace recorded on ") +
+                    trace_arch_string(static_cast<offline_file_type_t>(filetype)) +
+                    " but tool built for " + trace_arch_string(build_arch_file_type());
+            }
         }
         // If we are dealing with a regdeps trace, we need to set the dcontext
         // ISA mode to the correct synthetic ISA (i.e., DR_ISA_REGDEPS).

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -85,17 +85,6 @@ bool
 opcode_mix_t::init_decode_cache(shard_data_t *shard, void *dcontext,
                                 offline_file_type_t filetype)
 {
-    // XXX: Perhaps this should be moved into decode_cache_t::init().
-    // We remove OFFLINE_FILE_TYPE_ARCH_REGDEPS from this check since DR_ISA_REGDEPS
-    // is not a real ISA and can coexist with any real architecture.
-    if (TESTANY(OFFLINE_FILE_TYPE_ARCH_ALL & ~OFFLINE_FILE_TYPE_ARCH_REGDEPS, filetype) &&
-        !TESTANY(build_target_arch_type(), filetype)) {
-        shard->error = std::string("Architecture mismatch: trace recorded on ") +
-            trace_arch_string(static_cast<offline_file_type_t>(filetype)) +
-            " but tool built for " + trace_arch_string(build_target_arch_type());
-        return false;
-    }
-
     shard->decode_cache =
         std::unique_ptr<decode_cache_t<opcode_data_t>>(new decode_cache_t<opcode_data_t>(
             dcontext,


### PR DESCRIPTION
Moves the check that compares the current build enviroment with the arch bit of the trace file to decode_cache_t::init.

Due to some complexities in how build_target_arch_type() is declared in trace_entry.h, it had to be wrapped by a new API in decode_cache_base_t. build_target_arch_type() is defined conditionally in trace_entry.h only if dr_defines.h has already defined certain symbols. It is hard to ensure that for all builds dr_defines.h is included before trace_entry.h, so we ensure it just for decode_cache.cpp which is packaged as a separate lib unit drmemtrace_decode_cache. This also means that the new API could not be in decode_cache_t which is a template class that has to be defined in the header.

Issue: #7113, #7236