### PR TITLE
i#2154 Android64: Fix compile error

### DIFF
--- a/core/arch/aarch64/asm_offsetsx.h
+++ b/core/arch/aarch64/asm_offsetsx.h
@@ -82,5 +82,7 @@ OFFSET(spill_state_t, r5, 40)
 OFFSET(spill_state_t, fcache_return, 64)
 #define spill_state_t_OFFSET_fcache_return 64
 
+#if !defined(ANDROID)
 OFFSET(struct tlsdesc_t, arg, 8)
-#define struct_tlsdesc_t_OFFSET_arg 8
+#    define struct_tlsdesc_t_OFFSET_arg 8
+#endif


### PR DESCRIPTION
Fixes a compile error for Android64 introduced by #7202 (commit 2f2614b92):
```
core/arch/aarch64/asm_offsetsx.h:85:1: error: offsetof of incomplete type 'struct tlsdesc_t'
   85 | OFFSET(struct tlsdesc_t, arg, 8)
      | ^      ~~~~~~
```

`tlsdesc_t` is not defined on Android.

Issues: #2154, #7226