### PR TITLE
i#2417 AArch64: Update CMake in .github/workflows/ci-aarchxx*.

### DIFF
--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get update
-        sudo apt-get -y install doxygen vera++ cmake g++-aarch64-linux-gnu \
+        sudo apt-get -y install doxygen vera++ g++-aarch64-linux-gnu \
           qemu-user qemu-user-binfmt
         sudo add-apt-repository 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main'
         apt download libunwind8:arm64 libunwind-dev:arm64 liblzma5:arm64 \
@@ -84,6 +84,11 @@ jobs:
         for i in include lib; do sudo rsync -av ../extract/usr/${i}/aarch64-linux-gnu/ /usr/aarch64-linux-gnu/${i}/; done
         sudo rsync -av ../extract/usr/include/ /usr/aarch64-linux-gnu/include/
         sudo rsync -av ../extract/lib/aarch64-linux-gnu/ /usr/aarch64-linux-gnu/lib/
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.26.4'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -141,7 +146,7 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get update
-        sudo apt-get -y install doxygen vera++ cmake g++-arm-linux-gnueabihf \
+        sudo apt-get -y install doxygen vera++ g++-arm-linux-gnueabihf \
           qemu-user qemu-user-binfmt
         sudo add-apt-repository 'deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports focal main'
         apt download libunwind8:armhf libunwind-dev:armhf liblzma5:armhf \
@@ -152,6 +157,11 @@ jobs:
         for i in include lib; do sudo rsync -av ../extract/usr/${i}/arm-linux-gnueabihf/ /usr/arm-linux-gnueabihf/${i}/; done
         sudo rsync -av ../extract/usr/include/ /usr/arm-linux-gnueabihf/include/
         sudo rsync -av ../extract/lib/arm-linux-gnueabihf/ /usr/arm-linux-gnueabihf/lib/
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.26.4'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -206,7 +216,7 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get update
-        sudo apt-get -y install doxygen vera++ cmake
+        sudo apt-get -y install doxygen vera++
         cd /tmp
         wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
         unzip -q android-ndk-r10e-linux-x86_64.zip
@@ -218,6 +228,11 @@ jobs:
         ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
         ln -sf arm-linux-androideabi-ld.bfd \
           /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.26.4'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -272,8 +287,13 @@ jobs:
     - name: Create Build Environment
       run: |
         sudo apt-get update
-        sudo apt-get -y install doxygen vera++ cmake zlib1g-dev libsnappy-dev \
+        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           liblz4-dev
+
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.26.4'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -86,9 +86,10 @@ jobs:
         sudo rsync -av ../extract/lib/aarch64-linux-gnu/ /usr/aarch64-linux-gnu/lib/
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: lukka/get-cmake@latest
       with:
-        cmake-version: '3.26.4'
+        cmakeVersion: '3.26.4'
+        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -159,9 +160,10 @@ jobs:
         sudo rsync -av ../extract/lib/arm-linux-gnueabihf/ /usr/arm-linux-gnueabihf/lib/
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: lukka/get-cmake@latest
       with:
-        cmake-version: '3.26.4'
+        cmakeVersion: '3.26.4'
+        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -230,9 +232,10 @@ jobs:
           /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: lukka/get-cmake@latest
       with:
-        cmake-version: '3.26.4'
+        cmakeVersion: '3.26.4'
+        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -291,9 +294,10 @@ jobs:
           liblz4-dev
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: lukka/get-cmake@latest
       with:
-        cmake-version: '3.26.4'
+        cmakeVersion: '3.26.4'
+        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -89,7 +89,6 @@ jobs:
       uses: lukka/get-cmake@latest
       with:
         cmakeVersion: '3.26.4'
-        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -163,7 +162,6 @@ jobs:
       uses: lukka/get-cmake@latest
       with:
         cmakeVersion: '3.26.4'
-        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -235,7 +233,6 @@ jobs:
       uses: lukka/get-cmake@latest
       with:
         cmakeVersion: '3.26.4'
-        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}
@@ -297,7 +294,6 @@ jobs:
       uses: lukka/get-cmake@latest
       with:
         cmakeVersion: '3.26.4'
-        architecture: 'arm64'
 
     - name: Run Suite
       working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -89,7 +89,6 @@ jobs:
         uses: lukka/get-cmake@latest
         with:
           cmakeVersion: '3.26.4'
-          architecture: 'arm64'
 
       - name: Run Suite
         working-directory: build

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -86,9 +86,10 @@ jobs:
         run: mkdir build
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: lukka/get-cmake@latest
         with:
-          cmake-version: '3.26.4'
+          cmakeVersion: '3.26.4'
+          architecture: 'arm64'
 
       - name: Run Suite
         working-directory: build

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -85,6 +85,11 @@ jobs:
       - name: Create build directory
         run: mkdir build
 
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.26.4'
+
       - name: Run Suite
         working-directory: build
         run: ../suite/runsuite_wrapper.pl travis


### PR DESCRIPTION
CMake is updated to 3.26.4, which enables automatic retry of tests on failure.

Fixes: #2417