### PR TITLE
i#2154 Android64: Conditionally compile get_kernel_args()

### DIFF
--- a/core/unix/loader_android.c
+++ b/core/unix/loader_android.c
@@ -40,6 +40,7 @@
 #include "tls.h"
 #include "include/android_linker.h"
 #include <stddef.h>
+#include <android/api-level.h>
 
 /****************************************************************************
  * Thread Local Storage
@@ -228,9 +229,10 @@ privload_tls_exit(void *dr_tp)
                 VMM_SPECIAL_MMAP);
 }
 
-/* For standalone lib usage (i#1862: the Android loader passes
- * *nothing* to lib init routines).  This will only succeed prior to
- * Bionic's initializer, which clears the tls slot.
+#if __ANDROID_API__ < 26
+/* For standalone lib usage (i#1862: Prior to Android 8.0 the Android loader passes
+ * *nothing* to lib init routines).  This will only succeed prior to Bionic's
+ * initializer, which clears the tls slot.
  */
 bool
 get_kernel_args(int *argc DR_PARAM_OUT, char ***argv DR_PARAM_OUT,
@@ -249,3 +251,4 @@ get_kernel_args(int *argc DR_PARAM_OUT, char ***argv DR_PARAM_OUT,
     }
     return false;
 }
+#endif

--- a/core/unix/loader_android.c
+++ b/core/unix/loader_android.c
@@ -227,25 +227,3 @@ privload_tls_exit(void *dr_tp)
     heap_munmap(alloc, ALIGN_FORWARD(size_of_pthread_internal(), PAGE_SIZE),
                 VMM_SPECIAL_MMAP);
 }
-
-/* For standalone lib usage (i#1862: the Android loader passes
- * *nothing* to lib init routines).  This will only succeed prior to
- * Bionic's initializer, which clears the tls slot.
- */
-bool
-get_kernel_args(int *argc DR_PARAM_OUT, char ***argv DR_PARAM_OUT,
-                char ***envp DR_PARAM_OUT)
-{
-    android_kernel_args_t *kargs;
-    void **tls = (void **)get_segment_base(TLS_REG_LIB);
-    if (tls != NULL) {
-        kargs = (android_kernel_args_t *)tls[ANDROID_TLS_SLOT_BIONIC_PREINIT];
-        if (kargs != NULL) {
-            *argc = kargs->argc;
-            *argv = kargs->argv;
-            *envp = kargs->envp;
-            return true;
-        }
-    }
-    return false;
-}

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -93,7 +93,7 @@
 #endif
 
 #if defined(ANDROID)
-#include <android/api-level.h>
+#    include <android/api-level.h>
 #endif
 
 #include <dirent.h>

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -787,19 +787,6 @@ static init_fn_t
 INITIALIZER_ATTRIBUTES int
 _init(int argc, char **argv, char **envp)
 {
-#    ifdef ANDROID
-    /* i#1862: the Android loader passes *nothing* to lib init routines.  We
-     * rely on DR being listed before libc so we can read the TLS slot the
-     * kernel set up.
-     */
-    if (!get_kernel_args(&argc, &argv, &envp)) {
-        /* XXX: scan the stack and look for known auxv patterns or sthg. */
-        argc = 0;
-        argv = NULL;
-        envp = NULL;
-    }
-    ASSERT_MESSAGE(CHKLVL_ASSERTS, "failed to find envp", envp != NULL);
-#    endif
     return our_init(argc, argv, envp);
 }
 #endif

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -787,6 +787,19 @@ static init_fn_t
 INITIALIZER_ATTRIBUTES int
 _init(int argc, char **argv, char **envp)
 {
+#    ifdef ANDROID
+    /* i#1862: the Android loader passes *nothing* to lib init routines.  We
+     * rely on DR being listed before libc so we can read the TLS slot the
+     * kernel set up.
+     */
+    if (!get_kernel_args(&argc, &argv, &envp)) {
+        /* XXX: scan the stack and look for known auxv patterns or sthg. */
+        argc = 0;
+        argv = NULL;
+        envp = NULL;
+    }
+    ASSERT_MESSAGE(CHKLVL_ASSERTS, "failed to find envp", envp != NULL);
+#    endif
     return our_init(argc, argv, envp);
 }
 #endif

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -92,6 +92,10 @@
 #    include <mach/sync_policy.h>
 #endif
 
+#if defined(ANDROID)
+#include <android/api-level.h>
+#endif
+
 #include <dirent.h>
 
 /* for getrlimit */
@@ -787,8 +791,8 @@ static init_fn_t
 INITIALIZER_ATTRIBUTES int
 _init(int argc, char **argv, char **envp)
 {
-#    ifdef ANDROID
-    /* i#1862: the Android loader passes *nothing* to lib init routines.  We
+#    if defined(ANDROID) && __ANDROID_API__ < 26
+    /* i#1862: Prior to Android 8.0 the loader passes *nothing* to lib init routines. We
      * rely on DR being listed before libc so we can read the TLS slot the
      * kernel set up.
      */

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -468,6 +468,9 @@ privload_tls_init(void *app_tp);
 void
 privload_tls_exit(void *dr_tp);
 #ifdef ANDROID
+bool
+get_kernel_args(int *argc DR_PARAM_OUT, char ***argv DR_PARAM_OUT,
+                char ***envp DR_PARAM_OUT);
 void
 init_android_version(void);
 #endif

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -51,7 +51,7 @@
 #include "../drlibc/drlibc_unix.h"
 
 #if defined(ANDROID)
-#include <android/api-level.h>
+#    include <android/api-level.h>
 #endif
 
 /* for inline asm */
@@ -472,11 +472,11 @@ privload_tls_init(void *app_tp);
 void
 privload_tls_exit(void *dr_tp);
 #ifdef ANDROID
-#if __ANDROID_API__ < 26
+#    if __ANDROID_API__ < 26
 bool
 get_kernel_args(int *argc DR_PARAM_OUT, char ***argv DR_PARAM_OUT,
                 char ***envp DR_PARAM_OUT);
-#endif
+#    endif
 void
 init_android_version(void);
 #endif

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -468,9 +468,6 @@ privload_tls_init(void *app_tp);
 void
 privload_tls_exit(void *dr_tp);
 #ifdef ANDROID
-bool
-get_kernel_args(int *argc DR_PARAM_OUT, char ***argv DR_PARAM_OUT,
-                char ***envp DR_PARAM_OUT);
 void
 init_android_version(void);
 #endif

--- a/core/unix/os_private.h
+++ b/core/unix/os_private.h
@@ -50,6 +50,10 @@
 #include "memquery.h"
 #include "../drlibc/drlibc_unix.h"
 
+#if defined(ANDROID)
+#include <android/api-level.h>
+#endif
+
 /* for inline asm */
 #ifdef DR_HOST_X86
 #    ifdef DR_HOST_X64
@@ -468,9 +472,11 @@ privload_tls_init(void *app_tp);
 void
 privload_tls_exit(void *dr_tp);
 #ifdef ANDROID
+#if __ANDROID_API__ < 26
 bool
 get_kernel_args(int *argc DR_PARAM_OUT, char ***argv DR_PARAM_OUT,
                 char ***envp DR_PARAM_OUT);
+#endif
 void
 init_android_version(void);
 #endif


### PR DESCRIPTION
Since the original 32-bit Android port was done bionic was changed [1] to pass argc, argv, and envp to library _init() functions so when targeting newer versions of Android (>= 8.0, API level 26) we don't need the old workaround.

This fixes several tests which were failing with the error:
```
  Internal Error: DynamoRIO debug check failure: failed to find envp
  @dynamorio/core/unix/os.c:801 envp != NULL
```

[1] https://android.googlesource.com/platform/bionic/+/554374693408cd7c74d0cae596fca7349661edea

Issue: #2154