### PR TITLE
i#7091: Add -multi_indir to drmemtrace

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -253,7 +253,9 @@ analyzer_tmpl_t<RecordType, ReaderType>::init_scheduler(
             return false;
         }
         workloads.emplace_back(path, regions);
-        // Currently these modifiers apply to every workload.
+        // As documented and checked in analyzer_multi.cpp, only_threads and only_shards
+        // limits are not supported with -multi_indir.  That's already been checked, so
+        // we do not perform additional checks here.
         workloads.back().only_threads = only_threads;
         workloads.back().only_shards = only_shards;
         workloads.back().output_limit = output_limit;

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -218,7 +218,7 @@ protected:
     };
 
     bool
-    init_scheduler(const std::string &trace_path,
+    init_scheduler(const std::vector<std::string> &trace_paths,
                    // To include all threads/shards, use empty sets.
                    const std::set<memref_tid_t> &only_threads,
                    const std::set<int> &only_shards, int output_limit, int verbosity,
@@ -234,7 +234,7 @@ protected:
                    typename sched_type_t::scheduler_options_t options);
 
     bool
-    init_scheduler_common(typename sched_type_t::input_workload_t &workload,
+    init_scheduler_common(std::vector<typename sched_type_t::input_workload_t> &workloads,
                           typename sched_type_t::scheduler_options_t options);
 
     // Used for std::thread so we need an rvalue (so no &worker).

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -388,6 +388,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::set_input_limit(
 template <typename RecordType, typename ReaderType>
 analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
 {
+    this->verbosity_ = op_verbose.get_value();
     this->worker_count_ = op_jobs.get_value();
     this->skip_instrs_ = op_skip_instrs.get_value();
     this->skip_to_timestamp_ = op_skip_to_timestamp.get_value();
@@ -420,9 +421,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
     }
     if (offline_requests > 0)
         op_offline.set_value(true); // Some tools check this on post-proc runs.
-    // XXX: add a "required" flag to droption to avoid needing this here
-    if (op_indir.get_value().empty() && op_multi_indir.get_value().empty() &&
-        op_infile.get_value().empty() && op_ipc_name.get_value().empty()) {
+    else if (op_ipc_name.get_value().empty()) {
         this->error_string_ = "Usage error: -ipc_name or -indir or -multi_indir or "
                               "-infile is required\nUsage:\n" +
             droption_parser_t::usage_short(DROPTION_SCOPE_ALL);
@@ -468,6 +467,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
                 }
             }
             if (needs_processing) {
+                VPRINT(this, 1, "Post-processing raw trace %s\n", indir.c_str());
                 raw2trace_directory_t dir(op_verbose.get_value());
                 std::string dir_err =
                     dir.initialize(indir, "", op_trace_compress.get_value(),

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -358,6 +358,11 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::set_input_limit(
     std::set<memref_tid_t> &only_threads, std::set<int> &only_shards)
 {
     bool valid_limit = true;
+    if (!op_multi_indir.get_value().empty() &&
+        (op_only_thread.get_value() != 0 || !op_only_threads.get_value().empty() ||
+         !op_only_shards.get_value().empty())) {
+        return "Input limits are not currently supported with -multi_indir";
+    }
     if (op_only_thread.get_value() != 0) {
         if (!op_only_threads.get_value().empty() || !op_only_shards.get_value().empty())
             valid_limit = false;

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -139,7 +139,8 @@ analyzer_multi_t::create_invariant_checker()
         // reader(s) for seeking. For now we only read them for this test.
         // TODO i#5843: Share this code with scheduler_t or pass in for all
         // tools from here for fast skipping in serial and per-cpu modes.
-        std::string tracedir = get_input_dir();
+        std::string tracedir =
+            raw2trace_directory_t::tracedir_from_rawdir(get_input_dir());
         if (directory_iterator_t::is_directory(tracedir)) {
             directory_iterator_t end;
             directory_iterator_t iter(tracedir);

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -139,8 +139,7 @@ analyzer_multi_t::create_invariant_checker()
         // reader(s) for seeking. For now we only read them for this test.
         // TODO i#5843: Share this code with scheduler_t or pass in for all
         // tools from here for fast skipping in serial and per-cpu modes.
-        std::string tracedir =
-            raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
+        std::string tracedir = get_input_dir();
         if (directory_iterator_t::is_directory(tracedir)) {
             directory_iterator_t end;
             directory_iterator_t iter(tracedir);
@@ -246,7 +245,8 @@ analyzer_multi_t::create_analysis_tool_from_options(const std::string &tool)
     } else if (tool == OPCODE_MIX) {
         std::string module_file_path = get_module_file_path();
         if (module_file_path.empty() && op_indir.get_value().empty() &&
-            op_infile.get_value().empty() && !op_instr_encodings.get_value()) {
+            op_multi_indir.get_value().empty() && op_infile.get_value().empty() &&
+            !op_instr_encodings.get_value()) {
             ERRMSG("Usage error: the opcode_mix tool requires offline traces, or "
                    "-instr_encodings for online traces.\n");
             return nullptr;
@@ -400,69 +400,92 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
     // we still keep the serial vs parallel split for 0.
     if (this->worker_count_ == 0)
         this->parallel_ = false;
-    if (!op_indir.get_value().empty() || !op_infile.get_value().empty())
+    int offline_requests = 0;
+    if (!op_indir.get_value().empty())
+        ++offline_requests;
+    if (!op_multi_indir.get_value().empty())
+        ++offline_requests;
+    if (!op_infile.get_value().empty())
+        ++offline_requests;
+    if (offline_requests > 1) {
+        this->error_string_ = "Usage error: only one of -indir, -multi_indir, or "
+                              "-infile can be set\n";
+        this->success_ = false;
+        return;
+    }
+    if (offline_requests > 0)
         op_offline.set_value(true); // Some tools check this on post-proc runs.
     // XXX: add a "required" flag to droption to avoid needing this here
-    if (op_indir.get_value().empty() && op_infile.get_value().empty() &&
-        op_ipc_name.get_value().empty()) {
-        this->error_string_ =
-            "Usage error: -ipc_name or -indir or -infile is required\nUsage:\n" +
+    if (op_indir.get_value().empty() && op_multi_indir.get_value().empty() &&
+        op_infile.get_value().empty() && op_ipc_name.get_value().empty()) {
+        this->error_string_ = "Usage error: -ipc_name or -indir or -multi_indir or "
+                              "-infile is required\nUsage:\n" +
             droption_parser_t::usage_short(DROPTION_SCOPE_ALL);
         this->success_ = false;
         return;
     }
-    if (!op_indir.get_value().empty()) {
-        std::string tracedir =
-            raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
-        // We support the trace dir being empty if we haven't post-processed
-        // the raw files yet.
-        bool needs_processing = false;
-        if (!directory_iterator_t::is_directory(tracedir))
-            needs_processing = true;
-        else {
-            directory_iterator_t end;
-            directory_iterator_t iter(tracedir);
-            if (!iter) {
-                needs_processing = true;
-            } else {
-                int count = 0;
-                for (; iter != end; ++iter) {
-                    if ((*iter) == "." || (*iter) == ".." ||
-                        starts_with(*iter, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
-                        *iter == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
-                        continue;
-                    ++count;
-                    // XXX: It would be nice to call file_reader_t::is_complete()
-                    // but we don't have support for that for compressed files.
-                    // Thus it's up to the user to delete incomplete processed files.
-                }
-                if (count == 0)
-                    needs_processing = true;
-            }
+    std::vector<std::string> indirs;
+    if (!op_indir.get_value().empty() || !op_multi_indir.get_value().empty()) {
+        if (!op_indir.get_value().empty()) {
+            indirs.push_back(op_indir.get_value());
+        } else {
+            std::stringstream stream(op_multi_indir.get_value());
+            std::string dir;
+            while (std::getline(stream, dir, ':'))
+                indirs.push_back(dir);
         }
-        if (needs_processing) {
-            raw2trace_directory_t dir(op_verbose.get_value());
-            std::string dir_err =
-                dir.initialize(op_indir.get_value(), "", op_trace_compress.get_value(),
-                               op_syscall_template_file.get_value());
-            if (!dir_err.empty()) {
-                this->success_ = false;
-                this->error_string_ = "Directory setup failed: " + dir_err;
-                return;
+        for (const std::string &indir : indirs) {
+            std::string tracedir = raw2trace_directory_t::tracedir_from_rawdir(indir);
+            // We support the trace dir being empty if we haven't post-processed
+            // the raw files yet.
+            bool needs_processing = false;
+            if (!directory_iterator_t::is_directory(tracedir))
+                needs_processing = true;
+            else {
+                directory_iterator_t end;
+                directory_iterator_t iter(tracedir);
+                if (!iter) {
+                    needs_processing = true;
+                } else {
+                    int count = 0;
+                    for (; iter != end; ++iter) {
+                        if ((*iter) == "." || (*iter) == ".." ||
+                            starts_with(*iter, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
+                            *iter == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
+                            continue;
+                        ++count;
+                        // XXX: It would be nice to call file_reader_t::is_complete()
+                        // but we don't have support for that for compressed files.
+                        // Thus it's up to the user to delete incomplete processed files.
+                    }
+                    if (count == 0)
+                        needs_processing = true;
+                }
             }
-            raw2trace_t raw2trace(
-                dir.modfile_bytes_, dir.in_files_, dir.out_files_, dir.out_archives_,
-                dir.encoding_file_, dir.serial_schedule_file_, dir.cpu_schedule_file_,
-                nullptr, op_verbose.get_value(), op_jobs.get_value(),
-                op_alt_module_dir.get_value(), op_chunk_instr_count.get_value(),
-                dir.in_kfiles_map_, dir.kcoredir_, dir.kallsymsdir_,
-                std::move(dir.syscall_template_file_reader_),
-                op_pt2ir_best_effort.get_value());
-            std::string error = raw2trace.do_conversion();
-            if (!error.empty()) {
-                this->success_ = false;
-                this->error_string_ = "raw2trace failed: " + error;
-                return;
+            if (needs_processing) {
+                raw2trace_directory_t dir(op_verbose.get_value());
+                std::string dir_err =
+                    dir.initialize(indir, "", op_trace_compress.get_value(),
+                                   op_syscall_template_file.get_value());
+                if (!dir_err.empty()) {
+                    this->success_ = false;
+                    this->error_string_ = "Directory setup failed: " + dir_err;
+                    return;
+                }
+                raw2trace_t raw2trace(
+                    dir.modfile_bytes_, dir.in_files_, dir.out_files_, dir.out_archives_,
+                    dir.encoding_file_, dir.serial_schedule_file_, dir.cpu_schedule_file_,
+                    nullptr, op_verbose.get_value(), op_jobs.get_value(),
+                    op_alt_module_dir.get_value(), op_chunk_instr_count.get_value(),
+                    dir.in_kfiles_map_, dir.kcoredir_, dir.kallsymsdir_,
+                    std::move(dir.syscall_template_file_reader_),
+                    op_pt2ir_best_effort.get_value());
+                std::string error = raw2trace.do_conversion();
+                if (!error.empty()) {
+                    this->success_ = false;
+                    this->error_string_ = "raw2trace failed: " + error;
+                    return;
+                }
             }
         }
     }
@@ -478,8 +501,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
         // -cpu_scheduling implies thread-sharded.
         op_cpu_scheduling.get_value();
     // TODO i#7040: Add core-sharded support for online tools.
-    bool offline = !op_indir.get_value().empty() || !op_infile.get_value().empty();
-    if (offline && !sharding_specified) {
+    if (op_offline.get_value() && !sharding_specified) {
         bool all_prefer_thread_sharded = true;
         bool all_prefer_core_sharded = true;
         for (int i = 0; i < this->num_tools_; ++i) {
@@ -513,10 +535,15 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
             return;
         }
     }
+    if (!op_multi_indir.get_value().empty() && !op_core_sharded.get_value()) {
+        this->success_ = false;
+        this->error_string_ = "-multi_indir is only supported in core-sharded mode";
+        return;
+    }
 
     typename sched_type_t::scheduler_options_t sched_ops;
     if (op_core_sharded.get_value() || op_core_serial.get_value()) {
-        if (!offline) {
+        if (!op_offline.get_value()) {
             // TODO i#7040: Add core-sharded support for online tools.
             this->success_ = false;
             this->error_string_ = "Core-sharded is not yet supported for online analysis";
@@ -536,10 +563,10 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
 #endif
     }
 
-    if (!op_indir.get_value().empty()) {
-        std::string tracedir =
-            raw2trace_directory_t::tracedir_from_rawdir(op_indir.get_value());
-
+    if (!indirs.empty()) {
+        std::vector<std::string> tracedirs;
+        for (const std::string &indir : indirs)
+            tracedirs.push_back(raw2trace_directory_t::tracedir_from_rawdir(indir));
         std::set<memref_tid_t> only_threads;
         std::set<int> only_shards;
         std::string res = set_input_limit(only_threads, only_shards);
@@ -548,7 +575,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
             this->error_string_ = res;
             return;
         }
-        if (!this->init_scheduler(tracedir, only_threads, only_shards,
+        if (!this->init_scheduler(tracedirs, only_threads, only_shards,
                                   op_sched_max_cores.get_value(), op_verbose.get_value(),
                                   std::move(sched_ops))) {
             this->success_ = false;
@@ -574,9 +601,10 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
         }
     } else {
         // Legacy file.
-        if (!this->init_scheduler(op_infile.get_value(), {}, {},
-                                  op_sched_max_cores.get_value(), op_verbose.get_value(),
-                                  std::move(sched_ops))) {
+        std::vector<std::string> files;
+        files.push_back(op_infile.get_value());
+        if (!this->init_scheduler(files, {}, {}, op_sched_max_cores.get_value(),
+                                  op_verbose.get_value(), std::move(sched_ops))) {
             this->success_ = false;
             return;
         }
@@ -722,6 +750,28 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::destroy_analysis_tools()
     delete[] this->tools_;
 }
 
+template <typename RecordType, typename ReaderType>
+std::string
+analyzer_multi_tmpl_t<RecordType, ReaderType>::get_input_dir()
+{
+    std::string trace_dir;
+    if (!op_indir.get_value().empty())
+        trace_dir = op_indir.get_value();
+    else if (!op_multi_indir.get_value().empty()) {
+        // As documented, we only look in the first dir.
+        std::stringstream stream(op_multi_indir.get_value());
+        std::getline(stream, trace_dir, ':');
+    } else {
+        if (op_infile.get_value().empty()) {
+            return "";
+        }
+        size_t sep_index = op_infile.get_value().find_last_of(DIRSEP ALT_DIRSEP);
+        if (sep_index != std::string::npos)
+            trace_dir = std::string(op_infile.get_value(), 0, sep_index);
+    }
+    return trace_dir;
+}
+
 /* Get the path to an auxiliary file by examining
  * 1. The corresponding command line option
  * 2. The trace directory
@@ -737,17 +787,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::get_aux_file_path(
     if (!option_val.empty())
         file_path = option_val;
     else {
-        std::string trace_dir;
-        if (!op_indir.get_value().empty())
-            trace_dir = op_indir.get_value();
-        else {
-            if (op_infile.get_value().empty()) {
-                return "";
-            }
-            size_t sep_index = op_infile.get_value().find_last_of(DIRSEP ALT_DIRSEP);
-            if (sep_index != std::string::npos)
-                trace_dir = std::string(op_infile.get_value(), 0, sep_index);
-        }
+        std::string trace_dir = get_input_dir();
         if (raw2trace_directory_t::is_window_subdir(trace_dir)) {
             // If we're operating on a specific window, point at the parent for the
             // modfile.

--- a/clients/drcachesim/analyzer_multi.h
+++ b/clients/drcachesim/analyzer_multi.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -79,6 +79,9 @@ protected:
 
     analysis_tool_tmpl_t<RecordType> *
     create_invariant_checker();
+
+    std::string
+    get_input_dir();
 
     std::string
     get_aux_file_path(std::string option_val, std::string default_filename);

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -94,6 +94,19 @@ droption_t<std::string> op_indir(
     "The contents of this directory are internal to the tool.  Do not alter, add, or "
     "delete files here.");
 
+droption_t<std::string> op_multi_indir(
+    DROPTION_SCOPE_ALL, "multi_indir", "", "Colon-separated list of input directories",
+    "Identical to -indir except this takes a colon-separated list of directories "
+    "for offline analysis in core-sharded mode.  Multiple inputs are not supported in "
+    "any other mode; they are not supported currently with thread or shard limits; they "
+    "are not supported for interval analysis, for replaying as-traced, or for "
+    "core-sharded-on-disk inputs. Skipping is applied to every input thread. Auxiliary "
+    "files such as the traced function list (see -funclist_file), the v2p file (see "
+    "-v2p_file), schedule files for the invariant checker, and the module file (for "
+    "legacy traces without encodings) are only auto-located in the first directory "
+    "listed.  Additional support may be added in the future. See -indir for further "
+    "information on each input directory.");
+
 droption_t<std::string> op_infile(
     DROPTION_SCOPE_ALL, "infile", "", "Single offline trace input file",
     "Directs the framework to use a single trace file.  This could be a legacy "

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -95,6 +95,7 @@ extern dynamorio::droption::droption_t<std::string> op_outdir;
 extern dynamorio::droption::droption_t<std::string> op_subdir_prefix;
 extern dynamorio::droption::droption_t<std::string> op_infile;
 extern dynamorio::droption::droption_t<std::string> op_indir;
+extern dynamorio::droption::droption_t<std::string> op_multi_indir;
 extern dynamorio::droption::droption_t<std::string> op_module_file;
 extern dynamorio::droption::droption_t<std::string> op_alt_module_dir;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1327,6 +1327,10 @@ $ gzip drmemtrace.app.pid.xxxx.dir/drmemtrace.trace
 $ bin64/drrun -t drmemtrace -infile drmemtrace.app.pid.xxxx.dir/drmemtrace.trace.gz
 \endcode
 
+Multiple offline trace workload directories can be combined in
+core-sharded mode using the -multi_indir option.  The threads from
+every workload will all be interleaved together.
+
 The same analysis tools used online are available for offline: the trace
 format is identical.
 
@@ -1759,6 +1763,14 @@ The scheduler supports running a subset of each input.  A list of start and stop
 endpoints delimiting the regions of interest can be supplied with each input.  The end
 result is as though the inputs had been edited to remove all content not inside the
 target regions.
+
+********************
+\section sec_drcachesim_sched_multi Multiple Inputs
+
+The scheduler API supports multiple inputs from multiple workloads.  This can be
+achieved in the drmemtrace analyzer framework in core-sharded mode with the
+-multi_indir option.  The threads from every workload will all be interleaved
+together.
 
 ********************
 \section sec_drcachesim_sched_speculation Speculation Support

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -278,7 +278,8 @@ _tmain(int argc, const TCHAR *targv[])
                         droption_parser_t::usage_short(DROPTION_SCOPE_ALL).c_str());
         }
     }
-    have_trace_file = !op_infile.get_value().empty() || !op_indir.get_value().empty();
+    have_trace_file = !op_infile.get_value().empty() || !op_indir.get_value().empty() ||
+        !op_multi_indir.get_value().empty();
 
     if (!have_trace_file) {
         if (app_idx >= argc) {

--- a/clients/drcachesim/tests/multi_indir.templatex
+++ b/clients/drcachesim/tests/multi_indir.templatex
@@ -1,0 +1,9 @@
+Schedule stats tool results:
+Total counts:
+           3 cores
+          24 threads: .*W2.T1257.*
+     1916814 instructions
+.*
+Core #0 schedule: [A-Xa-x_]*
+Core #1 schedule: [A-Xa-x_]*
+Core #2 schedule: [A-Xa-x_]*

--- a/clients/drcachesim/tests/multi_indir.templatex
+++ b/clients/drcachesim/tests/multi_indir.templatex
@@ -1,7 +1,7 @@
 Schedule stats tool results:
 Total counts:
            3 cores
-          24 threads: .*W2.T1257.*
+          24 threads: .*W[012].T1257596.*W[012].T1257596.*W[012].T1257596.*
      1916814 instructions
 .*
 Core #0 schedule: [A-Xa-x_]*

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4032,6 +4032,12 @@ if (BUILD_CLIENTS)
           "")
         set(tool.switch_file_invariants_rawtemp ON) # no preprocessor
 
+        # Test -multi_indir with 3 copies of our sample dir.
+        torunonly_simtool(multi_indir ${ci_shared_app}
+          "-multi_indir ${thread_trace_dir}:${thread_trace_dir}:${thread_trace_dir} -tool schedule_stats -cores 3"
+          "")
+        set(tool.multi_indir_rawtemp ON) # no preprocessor
+
         # Sanity test that core-sharded at least runs without errors on our other tools.
         torunonly_simtool(core_sharded ${ci_shared_app}
           "-indir ${thread_trace_dir} -tool reuse_time:reuse_distance:histogram:opcode_mix:syscall_mix -core_sharded"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4038,12 +4038,6 @@ if (BUILD_CLIENTS)
           "")
         set(tool.multi_indir_rawtemp ON) # no preprocessor
 
-        # Test -multi_indir with 3 copies of our sample dir.
-        torunonly_simtool(multi_indir ${ci_shared_app}
-          "-multi_indir ${thread_trace_dir}:${thread_trace_dir}:${thread_trace_dir} -tool schedule_stats -cores 3"
-          "")
-        set(tool.multi_indir_rawtemp ON) # no preprocessor
-
         # Sanity test that core-sharded at least runs without errors on our other tools.
         torunonly_simtool(core_sharded ${ci_shared_app}
           "-indir ${thread_trace_dir} -tool reuse_time:reuse_distance:histogram:opcode_mix:syscall_mix -core_sharded"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4038,6 +4038,12 @@ if (BUILD_CLIENTS)
           "")
         set(tool.multi_indir_rawtemp ON) # no preprocessor
 
+        # Test -multi_indir with 3 copies of our sample dir.
+        torunonly_simtool(multi_indir ${ci_shared_app}
+          "-multi_indir ${thread_trace_dir}:${thread_trace_dir}:${thread_trace_dir} -tool schedule_stats -cores 3"
+          "")
+        set(tool.multi_indir_rawtemp ON) # no preprocessor
+
         # Sanity test that core-sharded at least runs without errors on our other tools.
         torunonly_simtool(core_sharded ${ci_shared_app}
           "-indir ${thread_trace_dir} -tool reuse_time:reuse_distance:histogram:opcode_mix:syscall_mix -core_sharded"


### PR DESCRIPTION
Adds a new option -multi_indir to the drmemtrace framework.  This allows combining multiple workload traces in core-sharded mode, interleaving threads from all the workloads together.

Updates the documentation.

Adds a test that runs 3 copies of the checked-in threadsig trace.

Manually tested error checking:
```
$ bin64/drrun -t drmemtrace -tool schedule_stats -cores 3 -multi_indir ../src/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir:../src/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir:../src/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir -only_shards 1
ERROR: failed to initialize analyzer: Input limits are not currently supported with -multi_indir
```

Issue: #7091