### PR TITLE
i#1569: Update Arm hosted GitHub Action Runner labels

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -93,8 +93,11 @@ jobs:
             doxygen \
             git \
             libunwind-dev \
+            libc6-dev \
             openssh-client \
+            openssl \
             python3 \
+            vera++ \
             zlib1g-dev
 
       - name: Set ptrace_scope to 0

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -51,12 +51,12 @@ jobs:
       matrix:
         # This job will run in parallel.
         include:
-          - os: ubuntu-20-arm64-pre-sve
+          - os: ah-ubuntu_20_04-c6g_4x-50
             sve: false
-          - os: ubuntu-20-arm64-sve
+          - os: ah-ubuntu_20_04-c7g_4x-50
             sve: true
             sve_length: 256
-          - os: ubuntu-20-arm64-sve
+          - os: ah-ubuntu_20_04-c7g_4x-50
             sve: true
             sve_length: 128
     runs-on: ${{ matrix.os }}
@@ -84,6 +84,27 @@ jobs:
 
       - name: Create build directory
         run: mkdir build
+
+      - name: Create build environment
+        run: |
+          sudo apt-get update && \
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            build-essential \
+            doxygen \
+            git \
+            libunwind-dev \
+            openssh-client \
+            python3 \
+            zlib1g-dev
+
+      - name: Set ptrace_scope to 0
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+
+      - name: Check current ptrace_scope
+        run: |
+          cat /proc/sys/kernel/yama/ptrace_scope
+          if [[ `cat /proc/sys/kernel/yama/ptrace_scope` != "0" ]]; then echo "WARNING: ptrace_scope NOT SET TO 0"; fi
 
       - name: Setup cmake
         uses: lukka/get-cmake@latest


### PR DESCRIPTION
These labels point to a set of Arm AWS instances which are scalable and will get better support over the long-term.

See: https://gitlab.arm.com/tooling/gha-runner-docs#runner-configurations

Issue: #1569