### PR TITLE
i#7245: Fix test race by using unique dirs

### DIFF
--- a/clients/drcachesim/tests/offline-altbindir.templatex
+++ b/clients/drcachesim/tests/offline-altbindir.templatex
@@ -5,9 +5,9 @@ Opcode mix tool results:
           15171 :       stp
 .*
 #elif defined(ARM)
-ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.threadsig.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for arm
+ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.altbindir.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for arm
 #elif defined(X86) && defined(X64)
-ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.threadsig.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for x86_64
+ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.altbindir.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for x86_64
 #else
 ERROR: failed to initialize analyzer: Failed to create analysis tool: Tool failed to initialize: Failed to load binaries: Failed to map module /tmp/nonexistent/threadsig
 #endif

--- a/clients/drcachesim/tests/offline-tlb_simulator_v2p.templatex
+++ b/clients/drcachesim/tests/offline-tlb_simulator_v2p.templatex
@@ -85,9 +85,9 @@ Core #3 \(1 thread\(s\)\)
     Child hits:                     *33[,\.]?002
     Total miss rate:                  0.06%
 #elif  defined(ARM)
-ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.threadsig.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for arm
+ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.tlb_simulator_v2p.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for arm
 #elif defined(X86) && defined(X64)
-ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.threadsig.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for x86_64
+ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.tlb_simulator_v2p.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for x86_64
 #else
 ERROR: failed to initialize analyzer: Failed to create analysis tool: Tool failed to initialize: Failed to load binaries: Failed to map module /tmp/nonexistent/threadsig
 #endif

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2166,7 +2166,11 @@ if (AARCH64 AND UNIX AND ZLIB_FOUND AND NOT ANDROID) # TODO i#1874: Add drcaches
     # Test TLB simulator with a virtual to physical v2p.textproto mapping.
     set(srcdir
       ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.aarch64.raw)
-    set(locdir ${PROJECT_BINARY_DIR}/drmemtrace.threadsig.aarch64)
+    set(locdir ${CMAKE_CURRENT_BINARY_DIR}/drmemtrace.tlb_simulator_v2p.aarch64)
+    # We are fine with a static config-time creation of the directory and the
+    # first test run creating the trace/ files with subsequent test runs re-using
+    # those files, as this test targets the tlb simulator.  If our srcdir had
+    # trace/ file we would just use those.
     file(REMOVE_RECURSE ${locdir})
     file(MAKE_DIRECTORY ${locdir})
     file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
@@ -2189,10 +2193,11 @@ if (DR_HOST_NOT_TARGET)
   # Limited to ZLIB_FOUND because we test gzipped .raw files here as well.
   if (BUILD_CLIENTS AND UNIX AND ZLIB_FOUND)
     # We make a writable copy so we can both write the final trace there and run our
-    # analyzer in a single command line.
+    # analyzer in a single command line.  Since we're testing postprocessing we
+    # need to dynamically clobber the directory.
     set(srcdir
       ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.aarch64.raw)
-    set(locdir ${PROJECT_BINARY_DIR}/drmemtrace.threadsig.aarch64)
+    set(locdir ${CMAKE_CURRENT_BINARY_DIR}/drmemtrace.altbindir.aarch64)
     file(MAKE_DIRECTORY ${locdir})
     file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
     get_target_path_for_execution(drcachesim_path drmemtrace_launcher
@@ -2204,6 +2209,10 @@ if (DR_HOST_NOT_TARGET)
       OFF OFF)
     set(tool.drcacheoff.altbindir_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+    set(tool.drcacheoff.altbindir_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+    set(tool.drcacheoff.altbindir_precmd
+        "${CMAKE_COMMAND}@-E@remove_directory@${locdir}/trace")
+    set(tool.drcacheoff.altbindir_failok ON)
   endif ()
 
   # The tests are not ported to build with host!=target.  Most will never work there,
@@ -5075,11 +5084,11 @@ if (BUILD_CLIENTS)
   # Limited to ZLIB_FOUND because we test gzipped .raw files here as well.
   if (UNIX AND ZLIB_FOUND)
     # We make a writable copy so we can both write the final trace there and run our
-    # analyzer in a single command line.
+    # analyzer in a single command line  Since we're testing postprocessing we
+    # need to dynamically clobber the directory.
     set(srcdir
       ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/drmemtrace.threadsig.aarch64.raw)
-    set(locdir ${PROJECT_BINARY_DIR}/drmemtrace.threadsig.aarch64)
-    file(REMOVE_RECURSE ${locdir})
+    set(locdir ${CMAKE_CURRENT_BINARY_DIR}/drmemtrace.altbindir.aarch64)
     file(MAKE_DIRECTORY ${locdir})
     file(COPY ${srcdir}/raw DESTINATION ${locdir}/)
     torunonly_api(tool.drcacheoff.altbindir "${drcachesim_path}"
@@ -5088,6 +5097,10 @@ if (BUILD_CLIENTS)
       OFF OFF)
     set(tool.drcacheoff.altbindir_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+    set(tool.drcacheoff.altbindir_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+    set(tool.drcacheoff.altbindir_precmd
+        "${CMAKE_COMMAND}@-E@remove_directory@${locdir}/trace")
+    set(tool.drcacheoff.altbindir_failok ON)
 
     # Test the legacy trace versions OFFLINE_FILE_VERSION_KERNEL_INT_PC-1 and
     # TRACE_ENTRY_VERSION_NO_KERNEL_PC.  This requires a checked-in trace and thus


### PR DESCRIPTION
Fixes a bug where the new tlb_simulator_v2p test used the same directory as the existing altbindir test.  Both tests were then clobbering each other's files.  This is solved by using unique names.

Further improves the altbindir test by dynamically removing the trace/ directory, since the test is supposed to test post-processing but wasn't if run more than once in the same build directory.

Fixes #7245