### PR TITLE
i#2154 Android64: Simplify build and add GitHub CI workflow

### DIFF
--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -212,7 +212,7 @@ jobs:
 
     - run: git fetch --no-tags --depth=1 origin master
 
-    # Fetch and install Android NDK for Andoid cross-compile build.
+    # Fetch and install Android NDK for Android cross-compile build.
     - name: Create Build Environment
       run: |
         sudo apt-get update
@@ -241,7 +241,7 @@ jobs:
         DYNAMORIO_ANDROID_TOOLCHAIN: /tmp/android-gcc-arm-ndk-10e
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}
-      run: ./suite/runsuite_wrapper.pl automated_ci
+      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
 
     - name: Send failure mail to dynamorio-devs
       if: failure() && github.ref == 'refs/heads/master'
@@ -257,6 +257,72 @@ jobs:
         body: |
           Github Actions CI workflow run FAILED!
           Workflow: ${{github.workflow}}/android-arm-cross-compile
+          Repository: ${{github.repository}}
+          Branch ref: ${{github.ref}}
+          SHA: ${{github.sha}}
+          Triggering actor: ${{github.actor}}
+          Triggering event: ${{github.event_name}}
+          Run Id: ${{github.run_id}}
+          See more details on github.com/DynamoRIO/dynamorio/actions/runs/${{github.run_id}}
+        to: dynamorio-devs@googlegroups.com
+        from: Github Action CI
+
+  # Android AArch64 cross-compile with LLVM, no tests:
+  android-aarch64-cross-compile:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    # Cancel any prior runs for a PR (but do not cancel master branch runs).
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event_name == 'pull_request' }}
+
+    - run: git fetch --no-tags --depth=1 origin master
+
+    # Fetch the Android NDK for Android cross-compile build.
+    - name: Create Build Environment
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install doxygen vera++
+        cd /tmp
+        wget https://dl.google.com/android/repository/android-ndk-r27c-linux.zip
+        unzip -q android-ndk-r27c-linux.zip
+        export ANDROID_NDK_ROOT=/tmp/android-ndk-r27c
+
+    - name: Setup cmake
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: '3.26.4'
+
+    - name: Run Suite
+      working-directory: ${{ github.workspace }}
+      env:
+        DYNAMORIO_CROSS_ANDROID_ONLY: yes
+        DYNAMORIO_ANDROID_NDK: /tmp/android-ndk-r27c
+        DYNAMORIO_ANDROID_API_LEVEL: 35
+        CI_TRIGGER: ${{ github.event_name }}
+        CI_BRANCH: ${{ github.ref }}
+      run: ./suite/runsuite_wrapper.pl automated_ci 64_only
+
+    - name: Send failure mail to dynamorio-devs
+      if: failure() && github.ref == 'refs/heads/master'
+      uses: dawidd6/action-send-mail@v2
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        username: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_USERNAME}}
+        password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
+        subject: |
+          [${{github.repository}}] ${{github.workflow}} FAILED
+          on ${{github.event_name}} at ${{github.ref}}
+        body: |
+          Github Actions CI workflow run FAILED!
+          Workflow: ${{github.workflow}}/android-aarch64-cross-compile
           Repository: ${{github.repository}}
           Branch ref: ${{github.ref}}
           SHA: ${{github.sha}}

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -533,6 +533,18 @@ if (UNIX AND ARCH_IS_X86)
     set(android_extra_rel "${android_extra_dbg}
                            ANDROID_TOOLCHAIN:PATH=$ENV{DYNAMORIO_ANDROID_TOOLCHAIN}")
   endif()
+  if (DEFINED ENV{DYNAMORIO_ANDROID_NDK})
+    set(android_extra_dbg "${android_extra_dbg}
+                           ANDROID_NDK:PATH=$ENV{DYNAMORIO_ANDROID_NDK}")
+    set(android_extra_rel "${android_extra_dbg}
+                           ANDROID_NDK:PATH=$ENV{DYNAMORIO_ANDROID_NDK}")
+  endif()
+  if (DEFINED ENV{DYNAMORIO_ANDROID_API_LEVEL})
+    set(android_extra_dbg "${android_extra_dbg}
+                           ANDROID_API_LEVEL:STRING=$ENV{DYNAMORIO_ANDROID_API_LEVEL}")
+    set(android_extra_rel "${android_extra_dbg}
+                           ANDROID_API_LEVEL:STRING=$ENV{DYNAMORIO_ANDROID_API_LEVEL}")
+  endif()
 
   # For CI cross_android_only builds, we want to fail on config failures.
   # For user suite runs, we want to just skip if there's no cross setup.
@@ -540,21 +552,35 @@ if (UNIX AND ARCH_IS_X86)
     set(optional_cross_compile ON)
   endif ()
 
-  testbuild_ex("android-debug-internal-32" OFF "
+  testbuild_ex("arm-android-debug-internal" OFF "
     DEBUG:BOOL=ON
     INTERNAL:BOOL=ON
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-android.cmake
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-android-gcc.cmake
     ${build_tests}
     ${android_extra_dbg}
     " OFF ${arg_package} "")
-  testbuild_ex("android-release-external-32" OFF "
+  testbuild_ex("arm-android-release-external" OFF "
     DEBUG:BOOL=OFF
     INTERNAL:BOOL=OFF
-    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-android.cmake
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-android-gcc.cmake
     ${android_extra_rel}
     " OFF ${arg_package} "")
-  set(run_tests ${prev_run_tests})
 
+  testbuild_ex("aarch64-android-debug-internal" ON "
+    DEBUG:BOOL=ON
+    INTERNAL:BOOL=ON
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-android-llvm.cmake
+    ${build_tests}
+    ${android_extra_dbg}
+    " OFF ${arg_package} "")
+  testbuild_ex("aarch64-android-release-external" ON "
+    DEBUG:BOOL=OFF
+    INTERNAL:BOOL=OFF
+    CMAKE_TOOLCHAIN_FILE:PATH=${CTEST_SOURCE_DIRECTORY}/make/toolchain-android-llvm.cmake
+    ${android_extra_rel}
+    " OFF ${arg_package} "")
+
+  set(run_tests ${prev_run_tests})
   set(optional_cross_compile ${prev_optional_cross_compile})
   set(ARCH_IS_X86 ON)
 endif (UNIX AND ARCH_IS_X86)


### PR DESCRIPTION
Adds a job to the GitHub CI that builds DynamoRIO for AArch64 Android.

This patch also simplifies the 64-bit Android CMake file to remove the need for the user to build `zlib`, instead allowing CMake to find the `zlib` included in the NDK. Also, the user now only needs to pass the root folder of the NDK, and a bug relating to the default Android API level has been fixed.

The Android CMake files have also been renamed to better reflect their differences - i.e. they are now named `gcc` & `llvm` rather than `android` and `android-aarch64`.

Issue: #2154