### PR TITLE
i#4800,i#5873: Disable longer test suite on merge

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # **********************************************************
-# Copyright () 2016-2024 Google, Inc.  All rights reserved.
+# Copyright () 2016-2025 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,10 @@ my $is_CI = 0;
 my $is_aarchxx = $Config{archname} =~ /(aarch64)|(arm)/;
 my $is_x86_64 = $Config{archname} =~ /x86_64/;
 my $is_riscv64 = $Config{archname} =~ /riscv64/;
-my $is_long = $ENV{'CI_TRIGGER'} eq 'push' && $ENV{'CI_BRANCH'} eq 'refs/heads/master';
+# i#4800,i#5873: We'd like to run a long suite for merges to master (via
+# "$ENV{'CI_TRIGGER'} eq 'push' && $ENV{'CI_BRANCH'} eq 'refs/heads/master'")
+# but we need pre-and-post-commmit test parity.
+my $is_long = 0;
 
 # Forward args to runsuite.cmake:
 my $args = '';

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -178,16 +178,23 @@ endif (CALLPROF AND TEST_SUITE)
 # i#4059: Reduce Appveyor time by reducing the # of tests run for 32-bit.
 # This assumes that 32-bit Windows is not as important these days.
 # We remove some of the less differentiated tests.
-# We still run the full set for merges to master.
 if (WIN32 AND NOT X64 AND "$ENV{CI_TRIGGER}" STREQUAL "pull_request")
   set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
 else ()
-  set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST OFF)
+  # i#4800,i#5873: We'd like to run the full set for merges to master but we
+  # need pre-and-post-commmit test parity.
+  set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
 endif ()
 
-# i#4800: Run long test suite on push-to-master events.
-if (RUN_LONG_SUITE OR ("$ENV{CI_TRIGGER}" STREQUAL "push" AND
-                       "$ENV{CI_BRANCH}" STREQUAL "refs/heads/master"))
+if ("$ENV{CI_TRIGGER}" STREQUAL "push" AND
+    "$ENV{CI_BRANCH}" STREQUAL "refs/heads/master")
+  # i#4800,i#5873: We'd like to run the long test suite on push-to-master events
+  # but we need parity with the pre-commit Pull Request (PR) suite for our
+  # workflow of not requiring pre-commit PR updates and re-runs.
+  # We just don't have the resources to keep the long suite green.
+endif ()
+
+if (RUN_LONG_SUITE)
   set(TEST_LONG ON)
 endif ()
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -175,15 +175,19 @@ else ()
   endif (TEST_SUITE)
 endif (CALLPROF AND TEST_SUITE)
 
-# i#4059: Reduce Appveyor time by reducing the # of tests run for 32-bit.
-# This assumes that 32-bit Windows is not as important these days.
-# We remove some of the less differentiated tests.
-if (WIN32 AND NOT X64 AND "$ENV{CI_TRIGGER}" STREQUAL "pull_request")
-  set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
+if (WIN32 AND NOT X64)
+  # i#4059: Reduce testing time by reducing the # of tests run for 32-bit.
+  # This assumes that 32-bit Windows is not as important these days.
+  # We remove some of the less differentiated tests.
+  if ("$ENV{CI_TRIGGER}" STREQUAL "pull_request")
+    set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
+  else ()
+    # i#4800,i#5873: We'd like to run the full set for merges to master but we
+    # need pre-and-post-commmit test parity.
+    set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
+  endif ()
 else ()
-  # i#4800,i#5873: We'd like to run the full set for merges to master but we
-  # need pre-and-post-commmit test parity.
-  set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST ON)
+  set(SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST OFF)
 endif ()
 
 if ("$ENV{CI_TRIGGER}" STREQUAL "push" AND


### PR DESCRIPTION
Disables running longer sets of tests on merges to master: both TEST_LONG for the general test suite and
SKIP_LESS_DIFFERENTIATED_TESTS_FOR_PULL_REQUEST being disabled for 32-bit Windows.

We ideally would run our full set of tests on merges to the master branch, but we have not had the resources to keep that suite green. And now that we are turning off the "Require branches to be up to date before merging" requirement we really want pre and post merge suites to be identical for ease of monitoring concurrent merge problems.

Issue: #4800, #5873