### PR TITLE
Fix the attach_memory_dump_test templatex to handle no msg before done.

### DIFF
--- a/suite/tests/client-interface/attach_memory_dump_test.templatex
+++ b/suite/tests/client-interface/attach_memory_dump_test.templatex
@@ -3,5 +3,4 @@ fib\(32\)=3524578
 thank you for testing memory dump
 thread init
 nudge delivered 1
-.*
-done
+.*done


### PR DESCRIPTION
Fix attach_memory_dump_test.templatex to handle the case where there is no "fib" being displayed before "done".

Fixes #7250 