### PR TITLE
i#7046 memory dump: Add NT_ARM_TLS note to store tpidr_el0 for Aarch64.

### DIFF
--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -45,6 +45,7 @@
 #include "dr_tools.h"
 #include "elf_defines.h"
 #include "memquery.h"
+#include "tls.h"
 
 /* Only X64 is supported. */
 #ifndef X64
@@ -65,6 +66,17 @@
  */
 #define NOTE_OWNER "CORE\0\0\0\0"
 #define NOTE_OWNER_LENGTH 8
+
+#if defined(AARCH64)
+/*
+ * Three notes, NT_PRSTATUS (prstatus structure), NT_FPREGSET (floating point registers)
+ * and NT_ARM_TLS (tpidr_el0) are written to the output file.
+ */
+#define PROGRAM_HEADER_NOTE_LENGTH                                                    \
+    (sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(struct elf_prstatus) + \
+     sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(elf_fpregset_t) +      \
+     sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(reg_t))
+#else
 /*
  * Two notes, NT_PRSTATUS (prstatus structure) and NT_FPREGSET (floating point registers),
  * are written to the output file.
@@ -72,6 +84,7 @@
 #define PROGRAM_HEADER_NOTE_LENGTH                                                    \
     (sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(struct elf_prstatus) + \
      sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(elf_fpregset_t))
+#endif
 
 typedef struct _section_header_info_t {
     app_pc vm_start;
@@ -268,6 +281,7 @@ mcontext_to_user_regs(DR_PARAM_IN priv_mcontext_t *mcontext,
     regs->regs[30] = mcontext->r30;
     regs->sp = mcontext->sp;
     regs->pc = (uint64_t)mcontext->pc;
+    regs->pstate = mcontext->nzcv;
 #else
 #    error Unsupported architecture
 #endif
@@ -374,6 +388,31 @@ write_fpregset_note(DR_PARAM_IN dcontext_t *dcontext, DR_PARAM_IN priv_mcontext_
     }
     return os_write(elf_file, &fpregset, sizeof(fpregset)) == sizeof(fpregset);
 }
+
+#if defined(AARCH64)
+/*
+ * Write aarch64 tpidr_el0 register to the file. This function is only
+ * applicable for aarch64. Returns true if the note is written to
+ * the file, false otherwise.
+ */
+static bool
+write_arm_tls_note(DR_PARAM_IN file_t elf_file)
+{
+    ELF_NOTE_HEADER_TYPE nhdr;
+    // Add one to include the terminating null character.
+    nhdr.n_namesz = strlen(NOTE_OWNER) + 1;
+    nhdr.n_descsz = sizeof(reg_t);
+    nhdr.n_type = NT_ARM_TLS;
+    if (os_write(elf_file, &nhdr, sizeof(nhdr)) != sizeof(nhdr)) {
+        return false;
+    }
+    if (os_write(elf_file, NOTE_OWNER, NOTE_OWNER_LENGTH) != NOTE_OWNER_LENGTH) {
+        return false;
+    }
+    const reg_t tpidr_el0 = read_thread_register(DR_REG_TPIDRURW);
+    return os_write(elf_file, &tpidr_el0, sizeof(tpidr_el0)) == sizeof(tpidr_el0);
+}
+#endif
 
 /*
  * Writes a memory dump file in ELF format. Returns true if a core dump file is written,
@@ -564,6 +603,12 @@ os_dump_core_internal(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path
         os_close(elf_file);
         return false;
     }
+#if defined(AARCH64)
+    if (!write_arm_tls_note(elf_file)) {
+        os_close(elf_file);
+        return false;
+    }
+#endif
     // Add padding to the core file such that loadable segments are aligned to
     // the page size in the core file.
     char buffer[MAX_BUFFER_SIZE];

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -45,7 +45,9 @@
 #include "dr_tools.h"
 #include "elf_defines.h"
 #include "memquery.h"
+#if defined(AARCH64)
 #include "tls.h"
+#endif
 
 /* Only X64 is supported. */
 #ifndef X64

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -72,18 +72,20 @@
  * Three notes, NT_PRSTATUS (prstatus structure), NT_FPREGSET (floating point registers)
  * and NT_ARM_TLS (tpidr_el0) are written to the output file.
  */
-#define PROGRAM_HEADER_NOTE_LENGTH                                                    \
-    (sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(struct elf_prstatus) + \
-     sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(elf_fpregset_t) +      \
-     sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(reg_t))
+#    define PROGRAM_HEADER_NOTE_LENGTH                                               \
+        (sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH +                          \
+         sizeof(struct elf_prstatus) + sizeof(ELF_NOTE_HEADER_TYPE) +                \
+         NOTE_OWNER_LENGTH + sizeof(elf_fpregset_t) + sizeof(ELF_NOTE_HEADER_TYPE) + \
+         NOTE_OWNER_LENGTH + sizeof(reg_t))
 #else
 /*
  * Two notes, NT_PRSTATUS (prstatus structure) and NT_FPREGSET (floating point registers),
  * are written to the output file.
  */
-#define PROGRAM_HEADER_NOTE_LENGTH                                                    \
-    (sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(struct elf_prstatus) + \
-     sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH + sizeof(elf_fpregset_t))
+#    define PROGRAM_HEADER_NOTE_LENGTH                                \
+        (sizeof(ELF_NOTE_HEADER_TYPE) + NOTE_OWNER_LENGTH +           \
+         sizeof(struct elf_prstatus) + sizeof(ELF_NOTE_HEADER_TYPE) + \
+         NOTE_OWNER_LENGTH + sizeof(elf_fpregset_t))
 #endif
 
 typedef struct _section_header_info_t {

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -46,7 +46,7 @@
 #include "elf_defines.h"
 #include "memquery.h"
 #if defined(AARCH64)
-#include "tls.h"
+#    include "tls.h"
 #endif
 
 /* Only X64 is supported. */

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -285,7 +285,6 @@ mcontext_to_user_regs(DR_PARAM_IN priv_mcontext_t *mcontext,
     regs->regs[30] = mcontext->r30;
     regs->sp = mcontext->sp;
     regs->pc = (uint64_t)mcontext->pc;
-    regs->pstate = mcontext->nzcv;
 #else
 #    error Unsupported architecture
 #endif
@@ -607,6 +606,8 @@ os_dump_core_internal(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path
         os_close(elf_file);
         return false;
     }
+    // XXX: We need to add support for model specific registers like FS and GS for
+    // x86_64.
 #if defined(AARCH64)
     if (!write_arm_tls_note(elf_file)) {
         os_close(elf_file);

--- a/suite/tests/client-interface/memory_dump_test.templatex
+++ b/suite/tests/client-interface/memory_dump_test.templatex
@@ -39,4 +39,7 @@ Displaying notes found at file offset 0x[0-9a-f]+ with length 0x[0-9a-f]+:
   Owner.*Data size.*Description
   CORE.*NT_PRSTATUS.*\(prstatus structure\)
   CORE.*NT_FPREGSET.*\(floating point registers\)
+#ifdef AARCH64
+  CORE.*NT_ARM_TLS.*\(AArch TLS registers\)
+#endif
 #endif


### PR DESCRIPTION
Add NT_ARM_TLS note to store  tpidr_el0 for Aarch64.

tpidr_el0 is not covered by the existing notes NT_PRSTATUS and NT_FPREGSET. 

Modified memory_dump_test.templatex to check NT_ARM_TLS for Aarch64.

Issue: #7046 