### PR TITLE
i#7046 memory dump: add missing pstate value to aarch64 user_regs_struct.

### DIFF
--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -285,6 +285,7 @@ mcontext_to_user_regs(DR_PARAM_IN priv_mcontext_t *mcontext,
     regs->regs[30] = mcontext->r30;
     regs->sp = mcontext->sp;
     regs->pc = (uint64_t)mcontext->pc;
+    regs->pstate = mcontext->nzcv;
 #else
 #    error Unsupported architecture
 #endif


### PR DESCRIPTION
#7088 missed the pstate when copying the register values from priv_mcontext_t to user_regs_struct.

The user_regs_struct has the follow fields:

struct user_regs_struct
{
  unsigned long long regs[31];
  unsigned long long sp;
  unsigned long long pc;
  unsigned long long pstate;
};

for Aarch64. The rest of the fields have already been copied.