### PR TITLE
i#3320 pipe order: Remove pipe before and after tests

### DIFF
--- a/clients/drcachesim/tests/allasm_aarch64_flush.asm
+++ b/clients/drcachesim/tests/allasm_aarch64_flush.asm
@@ -60,7 +60,7 @@ _start:
         ic       ivau, x1
 
         // Exit.
-        mov      w0, #1            // stdout
+        mov      w0, #2            // stderr
 #ifdef __APPLE__
         adrp     x1, helloworld@PAGE
         add      x1, x1, helloworld@PAGEOFF

--- a/clients/drcachesim/tests/allasm_aarch64_prefetch.asm
+++ b/clients/drcachesim/tests/allasm_aarch64_prefetch.asm
@@ -168,7 +168,7 @@ _start:
         prfum    pstl3strm, [x1]
 
         // Exit.
-        mov      w0, #1            // stdout
+        mov      w0, #2            // stderr
 #ifdef __APPLE__
         adrp     x1, helloworld@PAGE
         add      x1, x1, helloworld@PAGEOFF

--- a/clients/drcachesim/tests/allasm_scattergather_aarch64.asm
+++ b/clients/drcachesim/tests/allasm_scattergather_aarch64.asm
@@ -642,7 +642,7 @@ _start:
         // Unique instructions: 367
 
 // Exit.
-        mov      w0, #1            // stdout
+        mov      w0, #2            // stderr
 #ifdef __APPLE__
         adrp     x1, helloworld@PAGE
         add      x1, x1, helloworld@PAGEOFF

--- a/clients/drcachesim/tests/allasm_scattergather_x86.asm
+++ b/clients/drcachesim/tests/allasm_scattergather_x86.asm
@@ -229,12 +229,12 @@ incorrect_scratch:
         lea      rsi, incorrect_scratch_str
         mov      rdx, 18
 done_cmp:
-        mov      rdi, 1           // stdout
+        mov      rdi, 2           // stderr
         mov      eax, 1           // SYS_write
         syscall
 
         // Print end message.
-        mov      rdi, 1           // stdout
+        mov      rdi, 2           // stderr
         lea      rsi, hello_str
         mov      rdx, 13          // sizeof(hello_str)
         mov      eax, 1           // SYS_write

--- a/clients/drcachesim/tests/builtin_prefetch.c
+++ b/clients/drcachesim/tests/builtin_prefetch.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2020-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -55,6 +55,6 @@ main(void)
     __builtin_prefetch(&d, 1, 2);
     // L3
     __builtin_prefetch(&d, 1, 1);
-    printf("Hello, world!\n");
+    fprintf(stderr, "Hello, world!\n");
     return 0;
 }

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3803,12 +3803,22 @@ if (BUILD_CLIENTS)
       torunonly_ci(tool.drcachesim.${testname} ${exetgt} drmemtrace_launcher
         "${testname}.c" # for templatex basename
         "-ipc_name ${IPC_PREFIX}drtestpipe_${testname} ${sim_ops}"
-        "" "${app_args}")
+        "-unsafe_crash_process" "${app_args}")
       set(tool.drcachesim.${testname}_toolname "drmemtrace")
       set(tool.drcachesim.${testname}_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcachesim.${testname}_rawtemp ON) # no preprocessor
       set(tool.drcachesim.${testname}_self_serial ON)
+      if (UNIX)
+        # Avoid stale pipe files on failure causing retries to time out.
+        # We delete the file before and after just to be safe.
+        set(tool.drcachesim.${testname}_runcmp
+          "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+        set(tool.drcachesim.${testname}_precmd
+          "${CMAKE_COMMAND}@-E@remove@${IPC_PREFIX}drtestpipe_${testname}")
+        set(tool.drcachesim.${testname}_postcmd
+          "${CMAKE_COMMAND}@-E@remove@${IPC_PREFIX}drtestpipe_${testname}")
+      endif ()
     endmacro (torunonly_drcachesim)
 
     set(config_files_dir ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests)
@@ -3974,6 +3984,16 @@ if (BUILD_CLIENTS)
         "-ipc_name ${IPC_PREFIX}drtestpipe_${testname} ${sim_ops}" "" "${app_args}")
       set(tool.${testname}_toolname "drmemtrace")
       set(tool.${testname}_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      if (UNIX)
+        # Avoid stale pipe files on failure causing retries to time out.
+        # We delete the file before and after just to be safe.
+        set(tool.${testname}_runcmp
+          "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+        set(tool.${testname}_precmd
+          "${CMAKE_COMMAND}@-E@remove@${IPC_PREFIX}drtestpipe_${testname}")
+        set(tool.${testname}_postcmd
+          "${CMAKE_COMMAND}@-E@remove@${IPC_PREFIX}drtestpipe_${testname}")
+      endif ()
     endmacro (torunonly_simtool)
 
     torunonly_simtool(histogram ${ci_shared_app}

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -3803,7 +3803,7 @@ if (BUILD_CLIENTS)
       torunonly_ci(tool.drcachesim.${testname} ${exetgt} drmemtrace_launcher
         "${testname}.c" # for templatex basename
         "-ipc_name ${IPC_PREFIX}drtestpipe_${testname} ${sim_ops}"
-        "-unsafe_crash_process" "${app_args}")
+        "" "${app_args}")
       set(tool.drcachesim.${testname}_toolname "drmemtrace")
       set(tool.drcachesim.${testname}_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")

--- a/suite/tests/common/allasm_aarch64_cache.asm
+++ b/suite/tests/common/allasm_aarch64_cache.asm
@@ -56,7 +56,7 @@ loop2:  // The inner loop steps through the region writing zeroes.
         b.cc     loop1
 
         // Exit.
-        mov      w0, #1            // stdout
+        mov      w0, #2            // stderr
         // XXX: Use asm_defines.asm AARCH64_ADR_GOT()?
 #ifdef __APPLE__
         adrp     x1, alldone@PAGE

--- a/suite/tests/common/allasm_arm.asm
+++ b/suite/tests/common/allasm_arm.asm
@@ -41,7 +41,7 @@ _start:
         bic      sp, sp, #63       // align stack pointer to cache line
         mov      r3, #4
 1:
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         ldr      r1, =hello
         mov      r2, #13           // sizeof(hello)
         mov      r7, #4            // SYS_write
@@ -119,7 +119,7 @@ separate_bb:
         vqshlu.s64 d3, d9, #13
 
 // exit
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         ldr      r1, =alldone
         mov      r2, #9            // sizeof(alldone)
         mov      r7, #4            // SYS_write
@@ -132,7 +132,7 @@ separate_bb:
 _print:
         mov      r2, r1            // size of string
         mov      r1, r0            // string to print
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         mov      r7, #4            // SYS_write
         svc      0
         bx       lr
@@ -141,7 +141,7 @@ _print_pop_pc:
         push     {r4-r8,lr}
         mov      r2, r1            // size of string
         mov      r1, r0            // string to print
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         mov      r7, #4            // SYS_write
         svc      0
         pop      {r4-r8,pc}

--- a/suite/tests/common/allasm_thumb.asm
+++ b/suite/tests/common/allasm_thumb.asm
@@ -49,7 +49,7 @@ _start:
 
         mov      r3, #4
 1:
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         ldr      r1, =hello
         mov      r2, #13           // sizeof(hello)
         mov      r7, #4            // SYS_write
@@ -284,7 +284,7 @@ addpc_bb:
 
 // exit
 _exit:
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         ldr      r1, =alldone
         mov      r2, #9            // sizeof(alldone)
         mov      r7, #4            // SYS_write
@@ -297,7 +297,7 @@ _exit:
 _print:
         mov      r2, r1            // size of string
         mov      r1, r0            // string to print
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         mov      r7, #4            // SYS_write
         svc      0
         bx       lr
@@ -306,7 +306,7 @@ _print_pop_pc:
         push     {r4-r8,lr}
         mov      r2, r1            // size of string
         mov      r1, r0            // string to print
-        mov      r0, #1            // stdout
+        mov      r0, #2            // stderr
         mov      r7, #4            // SYS_write
         svc      0
         pop      {r4-r8,pc}

--- a/suite/tests/common/allasm_x86_64.asm
+++ b/suite/tests/common/allasm_x86_64.asm
@@ -41,7 +41,7 @@ _start:
 
         mov      rbx, 16          // loop counter
 loop:
-        mov      rdi, 1           // stdout
+        mov      rdi, 2           // stderr
         lea      rsi, hello
         mov      rdx, 13          // sizeof(hello)
         mov      eax, 1           // SYS_write


### PR DESCRIPTION
Adds removal of the drcachesim pipe before and after running each test, to avoid a stale pipe file causing a retry-on-failure to time out.  This should help prevent #3320 from turning the suite red from what should be a single failure passing on a retry.

Modifies the asm tests to print to stderr instead of stdout for proper ordering within runcmp.cmake (as well as to match the conventions of all other tests).

Tested by adding "-unsafe_crash_process" to the options and then:
```
$ ctest -V -R coherence
<...>
325:   <Application
325:   /usr/local/google/home/bruening/dr/git/build_x64_dbg_tests/suite/tests/bin/client.annotation-concurrency
325:   (465432).  DynamoRIO Cache Simulator Tracer internal crash at PC
325:   0x00007f46cc0614b4.  Please report this at http://dynamorio.org/issues.
325:   Program aborted.
<...>
$ ls suite/tests/drtestpipe*
ls: cannot access 'suite/tests/drtestpipe*': No such file or directory
```

Issue: #3320, #2204