### PR TITLE
Fix a false positive on gcc stringop-truncations warning

### DIFF
--- a/libutil/dr_frontend_unix.c
+++ b/libutil/dr_frontend_unix.c
@@ -281,8 +281,7 @@ drfront_get_env_var(const char *name, DR_PARAM_OUT char *buf,
     if (len_var + 1 > buflen) {
         return DRFRONT_ERROR_INVALID_SIZE;
     }
-    strncpy(buf, tmp_buf, len_var + 1);
-    buf[buflen - 1] = '\0';
+    strncpy(buf, tmp_buf, buflen);
     return DRFRONT_SUCCESS;
 }
 


### PR DESCRIPTION
Related to https://github.com/DynamoRIO/dynamorio/pull/7267. Trying to fix these all up so I can build and test locally.

This one is a false positive on gcc's `stringop-truncations` warnings saying that the `size` argument to `strncpy` is related to the source buffer and not the destination buffer.

Based on the checks before this strncpy, it is safe to use `buflen` instead as the size and to remove the explicit null terminator ~~check~~ set.

The code assigns: `size_t len_var = strlen(tmp_buf);`. At the `strncpy`, `len_var + 1 <= buflen` so then `len_var <= buflen - 1` assuming `len_var + 1` doesn't wrap, so `strncpy` copies at most `buflen-1` characters, so `strncpy(...,..., buflen)` guarantees a null terminator at or before the end of `buf`. 