### PR TITLE
i#6326 M1 hang: Work around M1 build hang

### DIFF
--- a/make/cpp2asm_support.cmake
+++ b/make/cpp2asm_support.cmake
@@ -178,6 +178,8 @@ if (NOT "${CMAKE_GENERATOR}" MATCHES "Visual Studio")
     # NASM support was added in 2.8.3.  It clears ASM_DIALECT for us.
     enable_language(ASM_NASM)
   else (APPLE AND NOT AARCH64)
+    # XXX i#6326: Avoid a cmake hang by setting this.
+    set(CMAKE_ASM_LINKER_DEPFILE_SUPPORTED TRUE)
     enable_language(ASM)
   endif ()
 endif ()


### PR DESCRIPTION
Works around a Mac M1 build hang on assembly configuration.

Tested on a local M1 machine where CMake configuration now finishes.

Issue: #6326