### PR TITLE
i#7226 asm offsets: Add missing header

### DIFF
--- a/core/unix/module_private.h
+++ b/core/unix/module_private.h
@@ -35,6 +35,7 @@
 #define MODULE_PRIVATE_H
 
 #include "configure.h"
+#include "module.h"
 
 #ifndef ANDROID
 struct tlsdesc_t {


### PR DESCRIPTION
Solves a missing header issue that results in a build error on Mac M1 with the new asm offset files from PR #7202: module.h has to be included before module_private.h so we explicitly include the former in the latter.  Tested locally on M1 Mac.

Issue: #7226