### PR TITLE
i#7157 dyn inject: Fix switch trace injection test

### DIFF
--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -5957,7 +5957,8 @@ test_kernel_switch_sequences()
         check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, scheduler_t::SWITCH_THREAD) &&
         check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
-                  TRACE_MARKER_TYPE_TIMESTAMP, THREAD_SWITCH_TIMESTAMP) &&
+                  // Verify that the timestamp is updated.
+                  TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
         check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
         check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
         check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
@@ -5975,7 +5976,8 @@ test_kernel_switch_sequences()
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, scheduler_t::SWITCH_PROCESS) &&
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
-                  TRACE_MARKER_TYPE_TIMESTAMP, PROCESS_SWITCH_TIMESTAMP) &&
+                  // Verify that the timestamp is updated.
+                  TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
@@ -5989,6 +5991,7 @@ test_kernel_switch_sequences()
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
         check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR);
+    assert(res);
 
     {
         // Test a bad input sequence.


### PR DESCRIPTION
Fixes the existing scheduler unit test that verifies kernel context switch template injection.

The res bool was unused, therefore a failure to match expectations was never reported. The expected timestamps inside the injected part of the trace should be the ones updated by the scheduler, not the original one in the trace template.

Issue: #7157