### PR TITLE
i#5873: Include hash in post-commit CI failure email subject

### DIFF
--- a/.github/workflows/failure-notification.yml
+++ b/.github/workflows/failure-notification.yml
@@ -73,7 +73,7 @@ jobs:
         password: ${{secrets.DYNAMORIO_NOTIFICATION_EMAIL_PASSWORD}}
         subject: |
           [Author Action Required] [${{github.repository}}] ${{github.workflow}} FAILED
-          on ${{github.event_name}} at ${{github.ref}}
+          on ${{github.event_name}} to ${{github.ref}} at ${{github.sha}}
         body: |
           Github Actions CI workflow run FAILED!
           Commit author must triage and fix the possible regression.


### PR DESCRIPTION
Includes the commit hash in the subject line of notification emails sent out on post-commit master merge CI failures.

Without this, failures in the same CI workflow at different commits are merged in the same subject thread. It is better to have them on different threads as the reasons for the failures could very well be different.

Issue: #5873