### PR TITLE
i#7284: Disable x86-64-alpine-3_21 in x86 workflow until fixed

### DIFF
--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -245,6 +245,8 @@ jobs:
   # 64-bit Linux build with gcc and musl.
   # TODO i#1973: Fix failing cases and enable tests in CI.
   x86-64-alpine-3_21:
+    # TODO i#7284: Disabled until fixed
+    if: false
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
x86-64-alpine jobs are failing with "gzip: stdin: not in gzip format" https://github.com/DynamoRIO/dynamorio/actions/runs/13400978358/job/37431540308?pr=7282

Disable the job until it's fixed.