### PR TITLE
i#7288: Support bit PLRU in TLB

### DIFF
--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -500,7 +500,9 @@ droption_t<std::string>
     op_TLB_replace_policy(DROPTION_SCOPE_FRONTEND, "TLB_replace_policy",
                           REPLACE_POLICY_LFU, "TLB replacement policy",
                           "Specifies the replacement policy for TLBs. "
-                          "Supported policies: LFU (Least Frequently Used).");
+                          "Supported policies: " REPLACE_POLICY_LFU
+                          " (Least Frequently Used), " REPLACE_POLICY_BIT_PLRU
+                          " (Pseudo Least Recently Used).");
 
 droption_t<std::string>
     op_tool(DROPTION_SCOPE_FRONTEND,

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -57,6 +57,7 @@
 // Constants used by specific tools.
 #define REPLACE_POLICY_NON_SPECIFIED ""
 #define REPLACE_POLICY_LRU "LRU"
+#define REPLACE_POLICY_BIT_PLRU "BIT_PLRU"
 #define REPLACE_POLICY_LFU "LFU"
 #define REPLACE_POLICY_FIFO "FIFO"
 #define PREFETCH_POLICY_NEXTLINE "nextline"

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -189,7 +189,7 @@ tlb_bit_plru_t::get_next_way_to_replace(int block_idx) const
         }
     }
     if (!zero_counter_ways.empty()) {
-        std::uniform_int_distribution<> distrib(0, zero_counter_ways.size() - 1);
+        std::uniform_int_distribution<size_t> distrib(0, zero_counter_ways.size() - 1);
         return zero_counter_ways[distrib(gen_)];
     }
     return -1;

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -71,8 +71,8 @@ tlb_t::request(const memref_t &memref_in)
     // it might also not be a good way to write a lot of helper functions
     // to isolate them.
     // TODO i#4816: This tag,pid pair lookup needs to be imposed on the parent
-    // methods invalidate(), contains_tag(), and propagate_eviction() by
-    // overriding them.
+    // methods invalidate(), contains_tag(), and propagate_eviction() by overriding
+    // them.
 
     // Unfortunately we need to make a copy for our loop so we can pass
     // the right data struct to the parent and stats collectors.

--- a/clients/drcachesim/simulator/tlb.cpp
+++ b/clients/drcachesim/simulator/tlb.cpp
@@ -189,8 +189,7 @@ tlb_bit_plru_t::get_next_way_to_replace(int block_idx) const
         }
     }
     if (!zero_counter_ways.empty()) {
-        std::uniform_int_distribution<size_t> distrib(0, zero_counter_ways.size() - 1);
-        return zero_counter_ways[distrib(gen_)];
+        return zero_counter_ways[gen_() % zero_counter_ways.size()];
     }
     return -1;
 }

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -36,6 +36,9 @@
 #ifndef _TLB_H_
 #define _TLB_H_ 1
 
+#include <optional>
+#include <random>
+
 #include "caching_device.h"
 #include "memref.h"
 #include "tlb_entry.h"
@@ -46,19 +49,65 @@ namespace drmemtrace {
 
 class tlb_t : public caching_device_t {
 public:
+    tlb_t(const std::string &name = "tlb");
+
     void
     request(const memref_t &memref) override;
 
-    // TODO i#4816: The addition of the pid as a lookup parameter beyond just the tag
-    // needs to be imposed on the parent methods invalidate(), contains_tag(), and
-    // propagate_eviction() by overriding them.
+    // TODO i#4816: The addition of the pid as a lookup parameter beyond just the
+    // tag needs to be imposed on the parent methods invalidate(), contains_tag(),
+    // and propagate_eviction() by overriding them.
+
+    // Returns the replacement policy used by this TLB.
+    virtual std::string
+    get_replace_policy() const override = 0;
 
 protected:
     void
     init_blocks() override;
-
     // Optimization: remember last pid in addition to last tag
     memref_pid_t last_pid_;
+};
+
+/**
+ * TLB with least frequently used replacement policy.
+ *
+ * LFU has us hold a counter per way in the TLB entry.
+ * The counter is incremented when the way is accessed.
+ * When evicting, we choose the way with the least frequent access count.
+ */
+class tlb_lfu_t : public tlb_t {
+public:
+    tlb_lfu_t(const std::string &name = "tlb_lfu");
+
+    std::string
+    get_replace_policy() const override;
+};
+
+/**
+ * TLB with a bit-based PLRU replacement policy.
+ *
+ * Bit pseudo-LRU has us hold one bit per way in the TLB entry.
+ * The bit is set when the way is accessed.
+ * Once all bits for a block are set, we reset them all to 0.
+ * When evicting, we choose a random way with a zero bit to evict.
+ *
+ * When seed is -1, a seed if chosen with std::random_device().
+ * XXX: Once we update our toolchains to guarantee C++17 support we
+ * could use std::optional here.
+ */
+class tlb_bit_plru_t : public tlb_t {
+public:
+    tlb_bit_plru_t(const std::string &name = "tlb_bit_plru", int seed = -1);
+
+protected:
+    void
+    access_update(int block_idx, int way) override;
+    int
+    get_next_way_to_replace(int block_idx) const override;
+    std::string
+    get_replace_policy() const override;
+    mutable std::mt19937 gen_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -113,7 +113,7 @@ protected:
     access_update(int block_idx, int way) override;
     int
     get_next_way_to_replace(int block_idx) const override;
-    mutable std::mt19937 gen_;
+    mutable std::minstd_rand gen_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/simulator/tlb.h
+++ b/clients/drcachesim/simulator/tlb.h
@@ -113,7 +113,7 @@ protected:
     access_update(int block_idx, int way) override;
     int
     get_next_way_to_replace(int block_idx) const override;
-    mutable std::minstd_rand gen_;
+    mutable std::mt19937 gen_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -283,6 +283,9 @@ tlb_simulator_t::print_results()
 tlb_t *
 tlb_simulator_t::create_tlb(std::string policy)
 {
+    // XXX: i#7287: Eventually we want to decouple the replacement policies from the cache
+    // classes. Once this happens, we will need to build the policies here and pass them
+    // to the TLB class. We have implemented this as a temporary solution.
     if (policy == REPLACE_POLICY_NON_SPECIFIED || // default LFU
         policy == REPLACE_POLICY_LFU)             // set to LFU
         return new tlb_lfu_t;

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -283,17 +283,14 @@ tlb_simulator_t::print_results()
 tlb_t *
 tlb_simulator_t::create_tlb(std::string policy)
 {
-    // XXX: how to implement different replacement policies?
-    // Should we extend tlb_t to tlb_XXX_t so as to avoid multiple inheritance?
-    // Or should we adopt multiple inheritance to have caching_device_XXX_t as one base
-    // and tlb_t as another base class?
     if (policy == REPLACE_POLICY_NON_SPECIFIED || // default LFU
         policy == REPLACE_POLICY_LFU)             // set to LFU
-        return new tlb_t;
-
+        return new tlb_lfu_t;
+    else if (policy == REPLACE_POLICY_BIT_PLRU)
+        return new tlb_bit_plru_t;
     // undefined replacement policy
     ERRMSG("Usage error: undefined replacement policy. "
-           "Please choose " REPLACE_POLICY_LFU ".\n");
+           "Please choose " REPLACE_POLICY_LFU " or " REPLACE_POLICY_BIT_PLRU ".\n");
     return NULL;
 }
 

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -86,9 +86,8 @@ public:
         ref.data.addr = addr;
         ref.data.pid = 1;
         this->request(ref);
-        auto res = this->get_next_way_to_replace(this->get_block_index(addr));
-        std::cerr << res << " " << expected_replacement_way_after_access << std::endl;
-        assert(res == expected_replacement_way_after_access);
+        assert(this->get_next_way_to_replace(this->get_block_index(addr)) ==
+               expected_replacement_way_after_access);
     }
 
     void
@@ -454,7 +453,7 @@ unit_test_tlb_plru_four_way()
     tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A x x x
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B x x
     tlb_plru_test.access_and_check(addr_vec[ADDR_C], 3); //     A B C x
-    tlb_plru_test.access_and_check(addr_vec[ADDR_D], 1); //     a b c D
+    tlb_plru_test.access_and_check(addr_vec[ADDR_D], 2); //     a b c D
     // Next replacement chosen randomly from zero bits, the test runs with const seed.
     tlb_plru_test.access_and_check(addr_vec[ADDR_A], 2); //     A b c D
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B c D

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -34,9 +34,11 @@
 #include <iostream>
 #undef NDEBUG
 #include <assert.h>
+#include <random>
 #include "cache_replacement_policy_unit_test.h"
 #include "simulator/cache_fifo.h"
 #include "simulator/cache_lru.h"
+#include "simulator/tlb.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -63,28 +65,16 @@ static const std::vector<addr_t> addr_vec = { 128 * 0, 128 * 1, 128 * 2,  128 * 
                                               128 * 4, 128 * 5, 128 * 6,  128 * 7,
                                               128 * 8, 128 * 9, 128 * 10, 128 * 11 };
 
-template <class T> class cache_policy_test_t : public T {
+template <class T> class caching_device_policy_test_t : public T {
+protected:
     int associativity_;
     int line_size_;
-    int total_size_;
 
 public:
-    cache_policy_test_t(int associativity, int line_size, int total_size)
+    caching_device_policy_test_t(int associativity, int line_size)
+        : associativity_(associativity)
+        , line_size_(line_size)
     {
-        associativity_ = associativity;
-        line_size_ = line_size;
-        total_size_ = total_size;
-    }
-    void
-    initialize_cache()
-    {
-        caching_device_stats_t *stats = new cache_stats_t(line_size_, /*miss_file=*/"",
-                                                          /*warmup_enabled=*/true);
-        if (!this->init(associativity_, line_size_, total_size_, nullptr, stats,
-                        nullptr)) {
-            std::cerr << this->get_replace_policy() << " cache failed to initialize\n";
-            exit(1);
-        }
     }
 
     void
@@ -94,9 +84,10 @@ public:
         ref.data.type = TRACE_TYPE_READ;
         ref.data.size = 1;
         ref.data.addr = addr;
+        ref.data.pid = 1;
         this->request(ref);
-        assert(this->get_next_way_to_replace(this->get_block_index(addr)) ==
-               expected_replacement_way_after_access);
+        auto res = this->get_next_way_to_replace(this->get_block_index(addr));
+        assert(res == expected_replacement_way_after_access);
     }
 
     void
@@ -135,6 +126,56 @@ public:
             }
         }
         return true;
+    }
+};
+
+template <class T> class cache_policy_test_t : public caching_device_policy_test_t<T> {
+    int total_size_;
+
+public:
+    cache_policy_test_t(int associativity, int line_size, int total_size)
+        : caching_device_policy_test_t<T>(associativity, line_size)
+        , total_size_(total_size)
+    {
+    }
+
+    void
+    initialize_cache()
+    {
+        caching_device_stats_t *stats =
+            new cache_stats_t(this->line_size_, /*miss_file=*/"",
+                              /*warmup_enabled=*/true);
+        if (!this->init(this->associativity_, this->line_size_, total_size_, nullptr,
+                        stats, nullptr)) {
+            std::cerr << this->get_replace_policy() << " cache failed to initialize\n";
+            exit(1);
+        }
+    }
+};
+
+template <class T>
+class seeded_tlb_policy_test_t : public caching_device_policy_test_t<T> {
+    int entries_;
+
+public:
+    seeded_tlb_policy_test_t(int associativity, int line_size, int entries)
+        : caching_device_policy_test_t<T>(associativity, line_size)
+        , entries_(entries)
+    {
+        this->gen_ = std::mt19937(0);
+    }
+
+    void
+    initialize_cache()
+    {
+        caching_device_stats_t *stats =
+            new cache_stats_t(this->line_size_, /*miss_file=*/"",
+                              /*warmup_enabled=*/true);
+        if (!this->init(this->associativity_, this->line_size_, entries_, nullptr,
+                        stats)) {
+            std::cerr << this->get_replace_policy() << " tlb failed to initialize\n";
+            exit(1);
+        }
     }
 };
 
@@ -393,6 +434,28 @@ unit_test_cache_lfu_eight_way()
 }
 
 void
+unit_test_tlb_plru_four_way()
+{
+    seeded_tlb_policy_test_t<tlb_bit_plru_t> tlb_plru_test(/*associativity=*/4,
+                                                           /*line_size=*/64,
+                                                           /*entries=*/4);
+    tlb_plru_test.initialize_cache();
+    assert(tlb_plru_test.get_replace_policy() == "BIT_PLRU");
+    assert(tlb_plru_test.block_indices_are_identical(addr_vec));
+    assert(tlb_plru_test.tags_are_different(addr_vec));
+    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A x x x
+    tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B x x
+    tlb_plru_test.access_and_check(addr_vec[ADDR_C], 3); //     A B C x
+    tlb_plru_test.access_and_check(addr_vec[ADDR_D], 1); //     a b c D
+    // Next replacement chosen randomly from zero bits, the test runs with const seed.
+    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 2); //     A b c D
+    tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B c D
+    tlb_plru_test.access_and_check(addr_vec[ADDR_E], 1); //     a b E d
+    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 3); //     A b E d
+    tlb_plru_test.access_and_check(addr_vec[ADDR_B], 3); //     A B E d
+}
+
+void
 unit_test_cache_replacement_policy()
 {
     unit_test_cache_lru_four_way();
@@ -401,6 +464,7 @@ unit_test_cache_replacement_policy()
     unit_test_cache_fifo_eight_way();
     unit_test_cache_lfu_four_way();
     unit_test_cache_lfu_eight_way();
+    unit_test_tlb_plru_four_way();
     // XXX i#4842: Add more test sequences.
 }
 

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -86,8 +86,8 @@ public:
         ref.data.addr = addr;
         ref.data.pid = 1;
         this->request(ref);
-        auto res = this->get_next_way_to_replace(this->get_block_index(addr));
-        assert(res == expected_replacement_way_after_access);
+        assert(this->get_next_way_to_replace(this->get_block_index(addr)) ==
+               expected_replacement_way_after_access);
     }
 
     void
@@ -182,7 +182,7 @@ public:
     seeded_tlb_policy_test_t(int associativity, int line_size, int entries)
         : tlb_policy_test_t<T>(associativity, line_size, entries)
     {
-        this->gen_ = std::mt19937(0);
+        this->gen_ = std::minstd_rand(0);
     }
 };
 
@@ -453,12 +453,12 @@ unit_test_tlb_plru_four_way()
     tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A x x x
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B x x
     tlb_plru_test.access_and_check(addr_vec[ADDR_C], 3); //     A B C x
-    tlb_plru_test.access_and_check(addr_vec[ADDR_D], 1); //     a b c D
+    tlb_plru_test.access_and_check(addr_vec[ADDR_D], 0); //     a b c D
     // Next replacement chosen randomly from zero bits, the test runs with const seed.
-    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 2); //     A b c D
+    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A b c D
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B c D
-    tlb_plru_test.access_and_check(addr_vec[ADDR_E], 1); //     a b E d
-    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 3); //     A b E d
+    tlb_plru_test.access_and_check(addr_vec[ADDR_E], 3); //     a b E d
+    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A b E d
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 3); //     A B E d
 }
 

--- a/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
+++ b/clients/drcachesim/tests/cache_replacement_policy_unit_test.cpp
@@ -86,8 +86,9 @@ public:
         ref.data.addr = addr;
         ref.data.pid = 1;
         this->request(ref);
-        assert(this->get_next_way_to_replace(this->get_block_index(addr)) ==
-               expected_replacement_way_after_access);
+        auto res = this->get_next_way_to_replace(this->get_block_index(addr));
+        std::cerr << res << " " << expected_replacement_way_after_access << std::endl;
+        assert(res == expected_replacement_way_after_access);
     }
 
     void
@@ -182,7 +183,7 @@ public:
     seeded_tlb_policy_test_t(int associativity, int line_size, int entries)
         : tlb_policy_test_t<T>(associativity, line_size, entries)
     {
-        this->gen_ = std::minstd_rand(0);
+        this->gen_ = std::mt19937(0);
     }
 };
 
@@ -453,12 +454,12 @@ unit_test_tlb_plru_four_way()
     tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A x x x
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B x x
     tlb_plru_test.access_and_check(addr_vec[ADDR_C], 3); //     A B C x
-    tlb_plru_test.access_and_check(addr_vec[ADDR_D], 0); //     a b c D
+    tlb_plru_test.access_and_check(addr_vec[ADDR_D], 1); //     a b c D
     // Next replacement chosen randomly from zero bits, the test runs with const seed.
-    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A b c D
+    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 2); //     A b c D
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 2); //     A B c D
-    tlb_plru_test.access_and_check(addr_vec[ADDR_E], 3); //     a b E d
-    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 1); //     A b E d
+    tlb_plru_test.access_and_check(addr_vec[ADDR_E], 1); //     a b E d
+    tlb_plru_test.access_and_check(addr_vec[ADDR_A], 3); //     A b E d
     tlb_plru_test.access_and_check(addr_vec[ADDR_B], 3); //     A B E d
 }
 


### PR DESCRIPTION
Added support for bit PLRU in the TLB. Added two deriving classes tlb_bit_plru_t and tlb_lfu_t that handle each option.

This is a temporary solution, and we should implement #7287 .

Fixes #7288