### PR TITLE
i#7293 print crash: Increase privload tcb size to fix crashes

### DIFF
--- a/core/unix/loader_linux.c
+++ b/core/unix/loader_linux.c
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2011-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * *******************************************************************************/
 
@@ -133,9 +133,11 @@ static size_t client_tls_size = 2 * 4096;
  * The "lea -0x900(%rax,%rbx,1),%rbx" instruction computes the thread pointer to
  * install.  The allocator used by the loader has no headers, so we don't have a
  * good way to guess how big this allocation was.  Instead we use this estimate.
+ * For Ubuntu22 glibc 2.38, the size is 0x9c0; we use 0x1000 to cover future
+ * expansion.
  */
 /* On A32, the pthread is put before tcbhead instead tcbhead being part of pthread */
-static size_t tcb_size = IF_X64_ELSE(0x900, 0x490);
+static size_t tcb_size = IF_X64_ELSE(0x1000, 0x490);
 
 /* thread contol block header type from
  * - sysdeps/x86_64/nptl/tls.h


### PR DESCRIPTION
Increases the private TLS "tcb_size" from 0x970 to 0x1000, which fixes crashes in glibc code like this with an offset larger than 0x970 on a call to fprintf by a client on Ubuntu 22:

```
(gdb) bt
    at ./libio/libioP.h:947
<fprintf from client here>

=> 0x00007ffdf70909ff <+15>:	mov    %fs:0x972,%al

_sigfault = {si_addr = 0x7ffdf78a4072

7ffdf78a2000-7ffdf78a4000 rw-p 00000000 00:00 0
7ffdf78a4000-7ffdf78a6000 ---p 00000000 00:00 0
```

This fixes the following tests which failed on Ubuntu 22:
+ client.destructor
+ client.file_io
+ code_api,satisfy_w_xor_x|client.file_io
+ sample.memtrace_simple_repstr
+ sample.memtrace_simple_repstr
+ sample.memtrace_simple
+ sample.memval_simple
+ sample.memval_simple_scattergather
+ sample.instrace_simple
+ sample.callstack
+ sample.memtrace_x86_text
+ sample.instrace_x86_text
+ tool.drcachesim.phys_SUDO
+ tool.drcacheoff.phys_SUDO
+ tool.drcacheoff.phys_nopriv

This fixes a crash in this test, but it still fails due to the internal isa mode error hit in other Ubuntu22 tests (not yet filed separately: currently under #7270):
+ tool.drcachesim.phys-threads_SUDO

Issue: #7270, #7293
Fixes #7293