### PR TITLE
i#7270 ub22: Limit emulation test to reg dests too

### DIFF
--- a/suite/tests/client-interface/emulation_api_simple.dll.c
+++ b/suite/tests/client-interface/emulation_api_simple.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2022 Google, Inc.   All rights reserved.
+ * Copyright (c) 2021-2025 Google, Inc.   All rights reserved.
  * Copyright (c) 2018 ARM Limited. All rights reserved.
  * **********************************************************
  *
@@ -129,7 +129,11 @@ should_fully_emulate_instr(instr_t *instr)
 #elif defined(X86_64)
     opnd_t dst = instr_get_dst(instr, 0);
     opnd_t src1 = instr_get_src(instr, 1);
-    if (!opnd_same(src1, dst) || !opnd_is_reg(src0) || opnd_get_size(src0) != OPSZ_8)
+    /* As noted, we limit to register operands, partly because TEST cannot
+     * take two memory operands.
+     */
+    if (!opnd_same(src1, dst) || !opnd_is_reg(src0) || !opnd_is_reg(dst) ||
+        opnd_get_size(src0) != OPSZ_8)
         return false;
 #else
 #    error Architecture not supported.


### PR DESCRIPTION
The emulation_api_simple test fails on Ubuntu 22 with "no encoding found":

```
before instrumentation:
TAG  0x000076f83bd3bcbd
 +0    L3 @0x000076f5f74bbeb8  48 b8 7f ff ff ff ff mov    $0xffefffffffffff7f -> %rax
                               ff ef ff
 +10   L3 @0x000076f5f74bbf40  48 21 05 ce fe 01 00 and    %rax <rel> 0x000076f83bd5bb9c[8byte] -> <rel> 0x000076f83bd5bb9c[8byte]
 +17   L3 @0x000076f5f74ba5e8  48 81 c4 d8 00 00 00 add    $0x00000000000000d8 %rsp -> %rsp
 +24   L3 @0x000076f5f74ba4c0  5b                   pop    %rsp (%rsp)[8byte] -> %rbx %rsp
 +25   L3 @0x000076f5f74ba578  5d                   pop    %rsp (%rsp)[8byte] -> %rbp %rsp
 +26   L3 @0x000076f5f74baaa0  41 5c                pop    %rsp (%rsp)[8byte] -> %r12 %rsp
 +28   L3 @0x000076f5f750a620  41 5d                pop    %rsp (%rsp)[8byte] -> %r13 %rsp
 +30   L3 @0x000076f5f74bacf0  41 5e                pop    %rsp (%rsp)[8byte] -> %r14 %rsp
 +32   L3 @0x000076f5f750a0d0  41 5f                pop    %rsp (%rsp)[8byte] -> %r15 %rsp
 +34   L3 @0x000076f5f74ba7e0  c3                   ret    %rsp (%rsp)[8byte] -> %rsp
END 0x000076f83bd3bcbd

after instrumentation:
TAG  0x000076f83bd3bcbd
 +0    L3 @0x000076f5f74bbeb8  48 b8 7f ff ff ff ff mov    $0xffefffffffffff7f -> %rax
                               ff ef ff
 +10   m4 @0x000076f5f750a048                       <label note=0x0000000000000001>
 +10   m4 @0x000076f5f750a598                       <label note=0x0000000000000003>
 +10   L4 @0x000076f5f74bbe30  48 f7 15 b5 82 8a 44 not    <rel> 0x000076f83bd5bb9c[8byte] -> <rel> 0x000076f83bd5bb9c[8byte]
 +17   m4 @0x000076f5f74ba3b0  65 48 a3 18 00 00 00 mov    %rax -> %gs:0x18[8byte]
                               00 00 00 00
 +28   L4 @0x000076f5f750a378  48 f7 d0             not    %rax -> %rax
 +31   L4 @0x000076f5f74ba6a0  48 09 05 b5 82 8a 44 or     %rax <rel> 0x000076f83bd5bb9c[8byte] -> <rel> 0x000076f83bd5bb9c[8byte]
 +38   m4 @0x000076f5f74bbd20  65 48 a1 18 00 00 00 mov    %gs:0x18[8byte] -> %rax
                               00 00 00 00
 +49   L4 @0x000076f5f74ba978  48 f7 15 b5 82 8a 44 not    <rel> 0x000076f83bd5bb9c[8byte] -> <rel> 0x000076f83bd5bb9c[8byte]
ERROR: Could not find encoding for: test   <rel> 0x000076f83bd5bb9c[8byte] <rel> 0x000076f83bd5bb9c[8byte]
SYSLOG_ERROR: Application /home/derek/dr/git/build_x64_dbg_tests/suite/tests/bin/simple_app (115826) DynamoRIO usage error : instr_encode error: no encoding found (see log)
```

OP_test can't take 2 memory operands: so we augment the test to ensure the destination is a register as well (its comments already said it limited to registers, but it was only checking the source).

Issue: #7270