### PR TITLE
i#7157 dyn inject: Add switch injection count to schedule_stats

### DIFF
--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -112,6 +112,10 @@ public:
          * inputs from being scheduled onto an output.
          */
         SCHED_STAT_HIT_OUTPUT_LIMIT,
+        /**
+         * Counts the instances when the context switch sequence was injected.
+         */
+        SCHED_STAT_SWITCH_SEQUENCE_INJECTIONS,
         /** Count of statistic types. */
         SCHED_STAT_TYPE_COUNT,
     };

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -115,7 +115,7 @@ public:
         /**
          * Counts the instances when the context switch sequence was injected.
          */
-        SCHED_STAT_SWITCH_SEQUENCE_INJECTIONS,
+        SCHED_STAT_KERNEL_SWITCH_SEQUENCE_INJECTIONS,
         /** Count of statistic types. */
         SCHED_STAT_TYPE_COUNT,
     };

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2309,7 +2309,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
         // odd to have regular records with the new tid before the top headers.
         if (!switch_sequence_[switch_type].empty()) {
             ++outputs_[output]
-                  .stats[memtrace_stream_t::SCHED_STAT_SWITCH_SEQUENCE_INJECTIONS];
+                  .stats[memtrace_stream_t::SCHED_STAT_KERNEL_SWITCH_SEQUENCE_INJECTIONS];
             for (int i = static_cast<int>(switch_sequence_[switch_type].size()) - 1;
                  i >= 0; --i) {
                 RecordType record = switch_sequence_[switch_type][i];

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2308,6 +2308,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::set_cur_input(
         // XXX: These will appear before the top headers of a new thread which is slightly
         // odd to have regular records with the new tid before the top headers.
         if (!switch_sequence_[switch_type].empty()) {
+            ++outputs_[output]
+                  .stats[memtrace_stream_t::SCHED_STAT_SWITCH_SEQUENCE_INJECTIONS];
             for (int i = static_cast<int>(switch_sequence_[switch_type].size()) - 1;
                  i >= 0; --i) {
                 RecordType record = switch_sequence_[switch_type][i];

--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -8,6 +8,7 @@ Total counts:
       106490 instructions per context switch
            6 voluntary context switches
            0 direct context switches
+           0 context switch sequence injections
       100.00% voluntary switches
         0.00% direct switches
            4 switches input-to-input

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -8,6 +8,7 @@ Total counts:
       106490 instructions per context switch
            6 voluntary context switches
            0 direct context switches
+           0 context switch sequence injections
       100\.00% voluntary switches
         0\.00% direct switches
            5 switches input-to-input
@@ -45,6 +46,7 @@ Core #0 counts:
       *[0-9]* instructions per context switch
            . voluntary context switches
            0 direct context switches
+           0 context switch sequence injections
       100\.00% voluntary switches
         0\.00% direct switches
 .*
@@ -56,6 +58,7 @@ Core #1 counts:
       *[0-9]* instructions per context switch
            . voluntary context switches
            0 direct context switches
+           0 context switch sequence injections
       100\.00% voluntary switches
         0\.00% direct switches
 .*
@@ -67,6 +70,7 @@ Core #2 counts:
       *[0-9]* instructions per context switch
            . voluntary context switches
            0 direct context switches
+           0 context switch sequence injections
       100\.00% voluntary switches
         0\.00% direct switches
 .*
@@ -78,6 +82,7 @@ Core #3 counts:
       *[0-9]* instructions per context switch
            . voluntary context switches
            0 direct context switches
+           0 context switch sequence injections
       100\.00% voluntary switches
         0\.00% direct switches
 .*

--- a/clients/drcachesim/tests/switch_insertion.templatex
+++ b/clients/drcachesim/tests/switch_insertion.templatex
@@ -1,8 +1,28 @@
-Basic counts tool results:
+Schedule stats tool results:
 Total counts:
-      [1-9][0-9][0-9][0-9][0-9][0-9] total \(fetched\) instructions
-        5971 total unique \(fetched\) instructions
-      [1-9][0-9][0-9][0-9][0-9][0-9] total userspace instructions
-         [1-9][0-9][0-9] total kernel instructions
-      [1-9][0-9][0-9][0-9][0-9][0-9] total non-fetched instructions
+           4 cores
+.*
+      639664 instructions
+          11 total context switches
+.*
+           6 voluntary context switches
+           0 direct context switches
+         363 context switch sequence injections
+.*
+           9 switches input-to-input
+           5 switches input-to-idle
+           2 switches idle-to-input
+.*
+Core #0 counts:
+.*
+      117223 instructions
+           8 total context switches
+.*
+           3 voluntary context switches
+           0 direct context switches
+         104 context switch sequence injections
+.*
+           6 switches input-to-input
+           3 switches input-to-idle
+           2 switches idle-to-input
 .*

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -166,6 +166,9 @@ schedule_stats_t::get_scheduler_stats(memtrace_stream_t *stream, counters_t &cou
         memtrace_stream_t::SCHED_STAT_RUNQUEUE_REBALANCES));
     counters.at_output_limit = static_cast<int64_t>(
         stream->get_schedule_statistic(memtrace_stream_t::SCHED_STAT_HIT_OUTPUT_LIMIT));
+    counters.switch_sequence_injections =
+        static_cast<int64_t>(stream->get_schedule_statistic(
+            memtrace_stream_t::SCHED_STAT_SWITCH_SEQUENCE_INJECTIONS));
 
     // XXX: Currently, schedule_stats is measuring swap-ins to a real input.  If we
     // want to match what "perf" targeting this app would record, which is swap-outs,
@@ -420,6 +423,8 @@ schedule_stats_t::print_counters(const counters_t &counters)
               << counters.voluntary_switches << " voluntary context switches\n";
     std::cerr << std::setw(12) << counters.direct_switches
               << " direct context switches\n";
+    std::cerr << std::setw(12) << counters.switch_sequence_injections
+              << " context switch sequence injections\n";
     print_percentage(static_cast<double>(counters.voluntary_switches),
                      static_cast<double>(counters.total_switches),
                      "% voluntary switches\n");

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -168,7 +168,7 @@ schedule_stats_t::get_scheduler_stats(memtrace_stream_t *stream, counters_t &cou
         stream->get_schedule_statistic(memtrace_stream_t::SCHED_STAT_HIT_OUTPUT_LIMIT));
     counters.switch_sequence_injections =
         static_cast<int64_t>(stream->get_schedule_statistic(
-            memtrace_stream_t::SCHED_STAT_SWITCH_SEQUENCE_INJECTIONS));
+            memtrace_stream_t::SCHED_STAT_KERNEL_SWITCH_SEQUENCE_INJECTIONS));
 
     // XXX: Currently, schedule_stats is measuring swap-ins to a real input.  If we
     // want to match what "perf" targeting this app would record, which is swap-outs,

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2023-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -216,6 +216,7 @@ public:
             syscalls += rhs.syscalls;
             maybe_blocking_syscalls += rhs.maybe_blocking_syscalls;
             direct_switch_requests += rhs.direct_switch_requests;
+            switch_sequence_injections += rhs.switch_sequence_injections;
             observed_migrations += rhs.observed_migrations;
             waits += rhs.waits;
             idles += rhs.idles;
@@ -252,6 +253,7 @@ public:
         int64_t syscalls = 0;
         int64_t maybe_blocking_syscalls = 0;
         int64_t direct_switch_requests = 0;
+        int64_t switch_sequence_injections = 0;
         // Our observed migrations will be <= the scheduler's reported migrations
         // for a dynamic schedule as we don't know the initial runqueue allocation
         // and so can't see the migration of an input that didn't execute in the

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4067,7 +4067,7 @@ if (BUILD_CLIENTS)
         set(switch_file
           "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/mock_switch_sequences.x64.zip")
         torunonly_simtool(switch_insertion ${ci_shared_app}
-          "-indir ${thread_trace_dir} -tool basic_counts -core_sharded -sched_quantum 1000 -sched_switch_file ${switch_file}"
+          "-indir ${thread_trace_dir} -tool schedule_stats -core_sharded -sched_quantum 1000 -sched_switch_file ${switch_file}"
           "")
         set(tool.switch_insertion_rawtemp ON) # no preprocessor
 


### PR DESCRIPTION
Adds the count of instances where the context switch sequence was injected to the schedule_stats tool output.

Modifies the switch_insertion test to use schedule_stats instead of basic_counts. This helps reveal a bug in context switch trace template dynamic injection logic that causes the injection to happen many more times than the context switch events.

This diff is split out from #7302 which fixes the above bug.

Issue: #7157