### PR TITLE
drcachesim Cleanup - Consistent argument Naming, TLB Error Printing and Destruction.

### DIFF
--- a/clients/drcachesim/simulator/cache_fifo.h
+++ b/clients/drcachesim/simulator/cache_fifo.h
@@ -54,12 +54,11 @@ public:
     {
     }
     bool
-    init(int associativity, int line_size, int total_size, caching_device_t *parent,
+    init(int associativity, int block_size, int total_size, caching_device_t *parent,
          caching_device_stats_t *stats, prefetcher_t *prefetcher = nullptr,
          cache_inclusion_policy_t inclusion_policy =
              cache_inclusion_policy_t::NON_INC_NON_EXC,
-         bool coherent_cache = false, int id_ = -1,
-         snoop_filter_t *snoop_filter_ = nullptr,
+         bool coherent_cache = false, int id = -1, snoop_filter_t *snoop_filter = nullptr,
          const std::vector<caching_device_t *> &children = {}) override;
 
     std::string

--- a/clients/drcachesim/simulator/cache_lru.h
+++ b/clients/drcachesim/simulator/cache_lru.h
@@ -53,12 +53,11 @@ public:
     {
     }
     bool
-    init(int associativity, int line_size, int total_size, caching_device_t *parent,
+    init(int associativity, int block_size, int total_size, caching_device_t *parent,
          caching_device_stats_t *stats, prefetcher_t *prefetcher = nullptr,
          cache_inclusion_policy_t inclusion_policy =
              cache_inclusion_policy_t::NON_INC_NON_EXC,
-         bool coherent_cache = false, int id_ = -1,
-         snoop_filter_t *snoop_filter_ = nullptr,
+         bool coherent_cache = false, int id = -1, snoop_filter_t *snoop_filter = nullptr,
          const std::vector<caching_device_t *> &children = {}) override;
     std::string
     get_replace_policy() const override

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -41,9 +41,9 @@
 #include <utility>
 #include <vector>
 
-#include "memref.h"
 #include "caching_device_block.h"
 #include "caching_device_stats.h"
+#include "memref.h"
 #include "prefetcher.h"
 #include "snoop_filter.h"
 #include "trace_entry.h"

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -110,6 +110,12 @@ public:
     {
         return parent_;
     }
+    void
+    set_parent(caching_device_t *parent)
+    {
+        parent_ = parent;
+        parent_->children_.push_back(this);
+    }
     inline double
     get_loaded_fraction() const
     {

--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -110,12 +110,6 @@ public:
     {
         return parent_;
     }
-    void
-    set_parent(caching_device_t *parent)
-    {
-        parent_ = parent;
-        parent_->children_.push_back(this);
-    }
     inline double
     get_loaded_fraction() const
     {

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -115,15 +115,27 @@ tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs)
 
         if (!itlbs_[i]->init(knobs_.TLB_L1I_assoc, (int)knobs_.page_size,
                              knobs_.TLB_L1I_entries, lltlbs_[i],
-                             new tlb_stats_t((int)knobs_.page_size)) ||
-            !dtlbs_[i]->init(knobs_.TLB_L1D_assoc, (int)knobs_.page_size,
+                             new tlb_stats_t((int)knobs_.page_size))) {
+            error_string_ =
+                "Usage error: failed to initialize itlbs_. Ensure entry number, "
+                "page size and associativity are powers of 2.";
+            success_ = false;
+            return;
+        }
+        if (!dtlbs_[i]->init(knobs_.TLB_L1D_assoc, (int)knobs_.page_size,
                              knobs_.TLB_L1D_entries, lltlbs_[i],
-                             new tlb_stats_t((int)knobs_.page_size)) ||
-            !lltlbs_[i]->init(knobs_.TLB_L2_assoc, (int)knobs_.page_size,
+                             new tlb_stats_t((int)knobs_.page_size))) {
+            error_string_ =
+                "Usage error: failed to initialize dtlbs_. Ensure entry number, "
+                "page size and associativity are powers of 2.";
+            success_ = false;
+            return;
+        }
+        if (!lltlbs_[i]->init(knobs_.TLB_L2_assoc, (int)knobs_.page_size,
                               knobs_.TLB_L2_entries, NULL,
                               new tlb_stats_t((int)knobs_.page_size))) {
             error_string_ =
-                "Usage error: failed to initialize TLbs_. Ensure entry number, "
+                "Usage error: failed to initialize lltlbs_. Ensure entry number, "
                 "page size and associativity are powers of 2.";
             success_ = false;
             return;

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -147,18 +147,18 @@ tlb_simulator_t::~tlb_simulator_t()
 {
     for (unsigned int i = 0; i < knobs_.num_cores; i++) {
         // Try to handle failure during construction.
-        if (itlbs_[i] == NULL)
-            return;
-        delete itlbs_[i]->get_stats();
-        delete itlbs_[i];
-        if (dtlbs_[i] == NULL)
-            return;
-        delete dtlbs_[i]->get_stats();
-        delete dtlbs_[i];
-        if (lltlbs_[i] == NULL)
-            return;
-        delete lltlbs_[i]->get_stats();
-        delete lltlbs_[i];
+        if (itlbs_[i] != NULL) {
+            delete itlbs_[i]->get_stats();
+            delete itlbs_[i];
+        }
+        if (dtlbs_[i] != NULL) {
+            delete dtlbs_[i]->get_stats();
+            delete dtlbs_[i];
+        }
+        if (lltlbs_[i] != NULL) {
+            delete lltlbs_[i]->get_stats();
+            delete lltlbs_[i];
+        }
     }
     delete[] itlbs_;
     delete[] dtlbs_;

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -117,8 +117,8 @@ tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs)
                              knobs_.TLB_L1I_entries, lltlbs_[i],
                              new tlb_stats_t((int)knobs_.page_size))) {
             error_string_ =
-                "Usage error: failed to initialize itlbs_. Ensure entry number, "
-                "page size and associativity are powers of 2.";
+                "Usage error: failed to initialize itlbs_. Ensure (entry number / "
+                "associativity) is a power of 2.";
             success_ = false;
             return;
         }
@@ -126,8 +126,8 @@ tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs)
                              knobs_.TLB_L1D_entries, lltlbs_[i],
                              new tlb_stats_t((int)knobs_.page_size))) {
             error_string_ =
-                "Usage error: failed to initialize dtlbs_. Ensure entry number, "
-                "page size and associativity are powers of 2.";
+                "Usage error: failed to initialize dtlbs_. Ensure (entry number / "
+                "associativity) is a power of 2.";
             success_ = false;
             return;
         }
@@ -135,8 +135,8 @@ tlb_simulator_t::tlb_simulator_t(const tlb_simulator_knobs_t &knobs)
                               knobs_.TLB_L2_entries, NULL,
                               new tlb_stats_t((int)knobs_.page_size))) {
             error_string_ =
-                "Usage error: failed to initialize lltlbs_. Ensure entry number, "
-                "page size and associativity are powers of 2.";
+                "Usage error: failed to initialize lltlbs_. Ensure (entry number / "
+                "associativity) is a power of 2.";
             success_ = false;
             return;
         }


### PR DESCRIPTION
Small fixes in drcachesim which were not enough to justify a separate issue.
 - Fixed inconsistent argument names in `cache_fifo_t` and `cache_lru_t` - header vs implementation.
 - Improved error printing in `tlb_t` so you can know what actually failed.
 - Sorted includes in caching_device.cpp.
 - Fixed `tlb_simulator_t`'s destructor.