### PR TITLE
i#5383: fix 'debug' field in mac drdeploy checks

### DIFF
--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -520,7 +520,7 @@ expand_dr_root(const char *dr_root, bool debug, dr_platform_t dr_platform, bool 
         { "lib32/debug/libdynamorio.dylib", true, true, false, DR_PLATFORM_32BIT },
         { "lib32/release/libdrpreload.dylib", false, false, true, DR_PLATFORM_32BIT },
         { "lib32/release/libdynamorio.dylib", true, false, false, DR_PLATFORM_32BIT },
-        { "lib64/debug/libdrpreload.dylib", true, false, true, DR_PLATFORM_64BIT },
+        { "lib64/debug/libdrpreload.dylib", true, true, true, DR_PLATFORM_64BIT },
         { "lib64/debug/libdynamorio.dylib", true, true, false, DR_PLATFORM_64BIT },
         { "lib64/release/libdrpreload.dylib", false, false, true, DR_PLATFORM_64BIT },
         { "lib64/release/libdynamorio.dylib", true, false, false, DR_PLATFORM_64BIT },


### PR DESCRIPTION
This fixes a check for a file that is expected to be present at a /debug/ path in release builds on macOS (despite files in /debug/ paths only being present in debug builds). `drrun` (without `-nocheck`) will error in release builds on macOS since `lib64/debug/libdrpreload.dylib` is not present and `is_debug` is wrongly set to false. This changes `is_debug` to be true for this file (as it should be true for all checked files living in the `lib64/debug/` path. The corresponding `lib64/release/` drpreload file is already present in the list and is already checked for release builds.

The check is here: https://github.com/DynamoRIO/dynamorio/blob/898d3fb4291706a823d19c73ff0904ea3ba4a649/tools/drdeploy.c#L576-L587

Issue: #5383