### PR TITLE
i#7270 ub22: Handle readelf warnings in memory_dump_test output.

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6513,8 +6513,6 @@ endif (NOT ANDROID AND AARCHXX)
 # workarounds so far break over time.
 set_tests_properties(
   code_api|common.broadfun
-  code_api|client.memory_dump_test
-  code_api|client.attach_memory_dump_test
   PROPERTIES LABELS UBUNTU_22)
 if (BUILD_SAMPLES AND NOT ANDROID AND NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
   set_tests_properties(
@@ -6543,6 +6541,12 @@ if (TARGET tool.drcacheoff.purestatic)
   set_tests_properties(
     code_api|tool.drcacheoff.purestatic
     PROPERTIES LABELS UBUNTU_22)
+endif()
+if (LINUX AND X64 AND NOT RISCV64 AND NOT ANDROID)
+set_tests_properties(
+  code_api|client.memory_dump_test
+  code_api|client.attach_memory_dump_test
+  PROPERTIES LABELS UBUNTU_22)
 endif()
 
 # XXX i#3544: Support for running RISC-V Linux tests under QEMU.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6513,6 +6513,8 @@ endif (NOT ANDROID AND AARCHXX)
 # workarounds so far break over time.
 set_tests_properties(
   code_api|common.broadfun
+  code_api|client.memory_dump_test
+  code_api|client.attach_memory_dump_test
   PROPERTIES LABELS UBUNTU_22)
 if (BUILD_SAMPLES AND NOT ANDROID AND NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
   set_tests_properties(

--- a/suite/tests/client-interface/memory_dump_test.templatex
+++ b/suite/tests/client-interface/memory_dump_test.templatex
@@ -4,7 +4,7 @@ nudge delivered 1
 Hello, world!
 #ifdef LINUX
 #undef UNIX
-ELF Header:
+.*ELF Header:
   Magic:   7f 45 4c 46 02 01 01 03 00 00 00 00 00 00 00 00.*
   Class:                             ELF64
   Data:                              2's complement, little endian


### PR DESCRIPTION
The memory_dump_test fails on Ubuntu 22 because of failure to match expected output. 

The failure is due to the following lines in between "Hello, world!" and "ELF Header:"

readelf: Warning: Corrupt debuglink section:
readelf: Warning: Corrupt debuglink section:
readelf: Warning: unable to open file
'/home/runner/work/dynamorio/dynamorio/build_debug-internal-64/logs/'
referenced from .debug_sup section
readelf: Warning: .note.gnu.build-id data size is too small

The memory dump file does not have a debuglink section or .note.gnu.build-id. The change is to add a ".*" before "ELF Header:" to skip the warnings.

Add client.memory_dump_test and client.attach_memory_dump_test to ubuntu22 test suites.

Issue: #7270 