### PR TITLE
i#7275: decode/x86 decode xbegin/xabort more strictly.

### DIFF
--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -1231,8 +1231,8 @@ const instr_info_t * const op_instr[] =
     /* OP_invpcid       */   &third_byte_38[103],
 
     /* Intel TSX */
-    /* OP_xabort        */   &base_extensions[17][7],
-    /* OP_xbegin        */   &base_extensions[18][7],
+    /* OP_xabort        */   &rm_extensions[6][0],
+    /* OP_xbegin        */   &rm_extensions[7][0],
     /* OP_xend          */   &rm_extensions[4][5],
     /* OP_xtest         */   &rm_extensions[4][6],
 
@@ -3038,8 +3038,7 @@ const instr_info_t base_extensions[][8] = {
     {INVALID, 0xc60024, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xc60025, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xc60026, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    /* XXX i#1314: this also sets eip */
-    {OP_xabort, 0xf8c60067, catUncategorized, "xabort", eax, xx, Ib, xx, xx, mrm, x, END_LIST},
+    {MOD_EXT, 0xc60027, catUncategorized, "(mod ext 124)", xx, xx, xx, xx, xx, mrm, x, 124},
   },
   /* group 11b (first byte c7) */
   { /* extensions[18] */
@@ -3051,7 +3050,7 @@ const instr_info_t base_extensions[][8] = {
     {INVALID, 0xc70024, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xc70025, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {INVALID, 0xc70026, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
-    {OP_xbegin, 0xf8c70067, catUncategorized, "xbegin", xx, xx, Jz, xx, xx, mrm, x, END_LIST},
+    {MOD_EXT, 0xc70027, catUncategorized, "(mod ext 125)", xx, xx, xx, xx, xx, mrm, x, 125},
   },
   /* group 12 (first bytes 0f 71): all assumed to have Ib */
   { /* extensions[19] */
@@ -7172,6 +7171,14 @@ const instr_info_t mod_extensions[][2] = {
     {OP_clwb,    0x660fae36, catOther, "clwb", xx, xx, Mb, xx, xx, mrm, no, END_LIST},
     {INVALID,    0x660fae36, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
   },
+  { /* mod extension 124 */
+    {INVALID,    0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {RM_EXT,     0xc60067, catUncategorized, "(group 7 mod + rm ext 6)", xx, xx, xx, xx, xx, mrm, x, 6},
+  },
+  { /* mod extension 125 */
+    {INVALID,    0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {RM_EXT,     0xc70067, catUncategorized, "(group 7 mod + rm ext 7)", xx, xx, xx, xx, xx, mrm, x, 7},
+  },
 };
 
 /* Naturally all of these have modrm bytes even if they have no explicit operands */
@@ -7240,6 +7247,27 @@ const instr_info_t rm_extensions[][8] = {
     {INVALID,   0x0f0131, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, NA},
     {OP_rdpkru, 0xee0f0171, catUncategorized, "rdpkru", eax, edx, ecx, xx, xx, mrm, x, END_LIST},
     {OP_wrpkru, 0xef0f0171, catUncategorized, "wrpkru", xx, xx, ecx, edx, eax, mrm, x, END_LIST},
+  },
+  { /* rm extension 6 */
+    /* XXX i#1314: this also sets eip */
+    {OP_xabort, 0xf8c60067, catUncategorized, "xabort", eax, xx, Ib, xx, xx, mrm, x, END_LIST},
+    {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+  },
+  { /* rm extension 7 */
+    {OP_xbegin, 0xf8c70067, catUncategorized, "xbegin", xx, xx, Jz, xx, xx, mrm, x, END_LIST},
+    {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
+    {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
   },
 };
 

--- a/core/ir/x86/decode_table.c
+++ b/core/ir/x86/decode_table.c
@@ -7250,7 +7250,7 @@ const instr_info_t rm_extensions[][8] = {
   },
   { /* rm extension 6 */
     /* XXX i#1314: this also sets eip */
-    {OP_xabort, 0xf8c60067, catUncategorized, "xabort", eax, xx, Ib, xx, xx, mrm, x, END_LIST},
+    {OP_xabort, 0xf8c60067, catOther, "xabort", eax, xx, Ib, xx, xx, mrm, x, END_LIST},
     {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
@@ -7260,7 +7260,7 @@ const instr_info_t rm_extensions[][8] = {
     {INVALID, 0xc60067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
   },
   { /* rm extension 7 */
-    {OP_xbegin, 0xf8c70067, catUncategorized, "xbegin", xx, xx, Jz, xx, xx, mrm, x, END_LIST},
+    {OP_xbegin, 0xf8c70067, catOther, "xbegin", xx, xx, Jz, xx, xx, mrm, x, END_LIST},
     {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},
     {INVALID, 0xc70067, catUncategorized, "(bad)", xx, xx, xx, xx, xx, no, x, END_LIST},

--- a/suite/tests/api/dis-x64.expect
+++ b/suite/tests/api/dis-x64.expect
@@ -308,11 +308,12 @@
 +0x02d3   63 15 16 c2 b9 d4    movsxd edx, <rel> dword ptr [0xffffffffe4b9c4ef]
 +0x02d9   d2 79 7d             sar    byte ptr [rcx+0x7d], cl
 +0x02dc   cb                   retf
-+0x02dd   c7 7c bb e4 8e 81 93 xbegin 0x0000000054938473
++0x02dd   c7 7c bb e4 8e 81 93...??  <INVALID>
  44
-+0x02e5   7f e2                jnle   0x00000000100002c9
-+0x02e7   e1 66                loope  0x000000001000034f
-+0x02e9   c0 ea 87             shr    dl, 0x87
++0x02de   7c bb                jl     0x000000001000029b
++0x02e0   e4 8e                in     al, 0x8e
++0x02e2   81 93 44 7f e2 e1 66 adc    dword ptr [rbx-0x1e1d80bc], 0x87eac066
+ c0 ea 87
 +0x02ec   db e0...??           <INVALID>
 +0x02ed   e0 91                loopne 0x0000000010000280
 +0x02ef   10 57 b6             adc    byte ptr [rdi-0x4a], dl
@@ -436,15 +437,15 @@
 +0x040a   6f                   outsd
 +0x040b   43 ab                stosd
 +0x040d   9b                   fwait
-+0x040e   c6 ff b8             xabort 0xb8
-+0x0411   9a f4 26 e4 be 5c b0...??  <INVALID>
-+0x0412   f4                   hlt
-+0x0413   26 e4 be             in     al, 0xbe
-+0x0416   5c                   pop    rsp
-+0x0417   b0 7d                mov    al, 0x7d
-+0x0419   3d 21 73 34 da       cmp    eax, 0xda347321
-+0x041e   69 09 aa 38 8f 9c    imul   ecx, dword ptr [rcx], 0x9c8f38aa
-+0x0424   b8 9c a0 7f 21       mov    eax, 0x217fa09c
++0x040e   c6 ff b8...??        <INVALID>
++0x040f   ff b8 9a f4 26 e4...??  <INVALID>
++0x0410   b8 9a f4 26 e4       mov    eax, 0xe426f49a
++0x0415   be 5c b0 7d 3d       mov    esi, 0x3d7db05c
++0x041a   21 73 34             and    dword ptr [rbx+0x34], esi
++0x041d   da 69 09             fisubr dword ptr [rcx+0x09]
++0x0420   aa                   stosb
++0x0421   38 8f 9c b8 9c a0    cmp    byte ptr [rdi-0x5f634764], cl
++0x0427   7f 21                jnle   0x000000001000044a
 +0x0429   38 b6 87 b4 f9 55    cmp    byte ptr [rsi+0x55f9b487], dh
 +0x042f   df 6f 31             fild   qword ptr [rdi+0x31]
 +0x0432   58                   pop    rax
@@ -1328,8 +1329,9 @@
 +0x0cb8   5f                   pop    rdi
 +0x0cb9   83 87 2a 6c ca 56 15 add    dword ptr [rdi+0x56ca6c2a], 0x15
 +0x0cc0   ae                   scasb
-+0x0cc1   c6 fa 1d             xabort 0x1d
-+0x0cc4   4f 40 44 a7          cmpsd
++0x0cc1   c6 fa 1d...??        <INVALID>
++0x0cc2   fa                   cli
++0x0cc3   1d 4f 40 44 a7       sbb    eax, 0xa744404f
 +0x0cc8   cd 66                int    0x66
 +0x0cca   19 36                sbb    dword ptr [rsi], esi
 +0x0ccc   21 36                and    dword ptr [rsi], esi
@@ -1555,11 +1557,12 @@
 +0x0f16   4e 8f 74 15 c6 79 fd...??  <INVALID>
 +0x0f17   8f 74 15 c6 79 fd...??  <INVALID>
 +0x0f18   74 15                jz     0x0000000010000f2f
-+0x0f1a   c6 79 fd 35          xabort 0x35
-+0x0f1e   9b                   fwait
-+0x0f1f   87 ad 5b f9 1a 94    xchg   dword ptr [rbp-0x6be506a5], ebp
-+0x0f25   df a0 96 97 46 e3    fbld   tbyte ptr [rax-0x1cb9686a]
-+0x0f2b   aa                   stosb
++0x0f1a   c6 79 fd 35...??     <INVALID>
++0x0f1b   79 fd                jns    0x0000000010000f1a
++0x0f1d   35 9b 87 ad 5b       xor    eax, 0x5bad879b
++0x0f22   f9                   stc
++0x0f23   1a 94 df a0 96 97 46 sbb    dl, byte ptr [rdi+rbx*8+0x469796a0]
++0x0f2a   e3 aa                jrcxz  0x0000000010000ed6
 +0x0f2c   8c 72 22...??        <INVALID>
 +0x0f2d   72 22                jb     0x0000000010000f51
 +0x0f2f   97                   xchg   edi, eax
@@ -1572,9 +1575,9 @@
 +0x0f3e   64 e1 42             loope  0x0000000010000f83
 +0x0f41   6f                   outsd
 +0x0f42   e8 f8 91 f1 96       call   0xffffffffa6f1a13f
-+0x0f47   c7 3a 64 fb b9 0f    xbegin 0x000000001fba0ab1
-+0x0f4d   61...??              <INVALID>
-+0x0f4e   b9 2b 9f 22 bb       mov    ecx, 0xbb229f2b
++0x0f47   c7 3a 64 fb b9 0f...??  <INVALID>
++0x0f48   3a 64 fb b9          cmp    ah, byte ptr [rbx+rdi*8-0x47]
++0x0f4c   0f 61 b9 2b 9f 22 bb punpcklwd mm7, qword ptr [rcx-0x44dd60d5]
 +0x0f53   08 9c f4 4b f7 6b e7 or     byte ptr [rsp+rsi*8-0x189408b5], bl
 +0x0f5a   a8 67                test   al, 0x67
 +0x0f5c   c1 22 17             shl    dword ptr [rdx], 0x17

--- a/suite/tests/api/dis-x86.expect
+++ b/suite/tests/api/dis-x86.expect
@@ -307,11 +307,12 @@
 +0x02d3   63 15 16 c2 b9 d4    arpl   word ptr [0xd4b9c216], dx
 +0x02d9   d2 79 7d             sar    byte ptr [ecx+0x7d], cl
 +0x02dc   cb                   retf
-+0x02dd   c7 7c bb e4 8e 81 93 xbegin 0x54938473
++0x02dd   c7 7c bb e4 8e 81 93...??  <INVALID>
  44
-+0x02e5   7f e2                jnle   0x100002c9
-+0x02e7   e1 66                loope  0x1000034f
-+0x02e9   c0 ea 87             shr    dl, 0x87
++0x02de   7c bb                jl     0x1000029b
++0x02e0   e4 8e                in     al, 0x8e
++0x02e2   81 93 44 7f e2 e1 66 adc    dword ptr [ebx+0xe1e27f44], 0x87eac066
+ c0 ea 87
 +0x02ec   db e0...??           <INVALID>
 +0x02ed   e0 91                loopne 0x10000280
 +0x02ef   10 57 b6             adc    byte ptr [edi-0x4a], dl
@@ -432,9 +433,10 @@
 +0x040b   43                   inc    ebx
 +0x040c   ab                   stosd
 +0x040d   9b                   fwait
-+0x040e   c6 ff b8             xabort 0xb8
-+0x0411   9a f4 26 e4 be 5c b0 call   0xb05c:0xbee426f4
-+0x0418   7d 3d                jnl    0x10000457
++0x040e   c6 ff b8...??        <INVALID>
++0x040f   ff b8 9a f4 26 e4...??  <INVALID>
++0x0410   b8 9a f4 26 e4       mov    eax, 0xe426f49a
++0x0415   be 5c b0 7d 3d       mov    esi, 0x3d7db05c
 +0x041a   21 73 34             and    dword ptr [ebx+0x34], esi
 +0x041d   da 69 09             fisubr dword ptr [ecx+0x09]
 +0x0420   aa                   stosb
@@ -1345,11 +1347,9 @@
 +0x0cb8   5f                   pop    edi
 +0x0cb9   83 87 2a 6c ca 56 15 add    dword ptr [edi+0x56ca6c2a], 0x15
 +0x0cc0   ae                   scasb
-+0x0cc1   c6 fa 1d             xabort 0x1d
-+0x0cc4   4f                   dec    edi
-+0x0cc5   40                   inc    eax
-+0x0cc6   44                   inc    esp
-+0x0cc7   a7                   cmpsd
++0x0cc1   c6 fa 1d...??        <INVALID>
++0x0cc2   fa                   cli
++0x0cc3   1d 4f 40 44 a7       sbb    eax, 0xa744404f
 +0x0cc8   cd 66                int    0x66
 +0x0cca   19 36                sbb    dword ptr [esi], esi
 +0x0ccc   21 36                and    dword ptr [esi], esi
@@ -1582,11 +1582,12 @@
 +0x0f16   4e                   dec    esi
 +0x0f17   8f 74 15 c6 79 fd...??  <INVALID>
 +0x0f18   74 15                jz     0x10000f2f
-+0x0f1a   c6 79 fd 35          xabort 0x35
-+0x0f1e   9b                   fwait
-+0x0f1f   87 ad 5b f9 1a 94    xchg   dword ptr [ebp+0x941af95b], ebp
-+0x0f25   df a0 96 97 46 e3    fbld   tbyte ptr [eax+0xe3469796]
-+0x0f2b   aa                   stosb
++0x0f1a   c6 79 fd 35...??     <INVALID>
++0x0f1b   79 fd                jns    0x10000f1a
++0x0f1d   35 9b 87 ad 5b       xor    eax, 0x5bad879b
++0x0f22   f9                   stc
++0x0f23   1a 94 df a0 96 97 46 sbb    dl, byte ptr [edi+ebx*8+0x469796a0]
++0x0f2a   e3 aa                jecxz  0x10000ed6
 +0x0f2c   8c 72 22...??        <INVALID>
 +0x0f2d   72 22                jb     0x10000f51
 +0x0f2f   97                   xchg   edi, eax
@@ -1598,9 +1599,9 @@
 +0x0f3e   64 e1 42             loope  0x10000f83
 +0x0f41   6f                   outsd
 +0x0f42   e8 f8 91 f1 96       call   0xa6f1a13f
-+0x0f47   c7 3a 64 fb b9 0f    xbegin 0x1fba0ab1
-+0x0f4d   61                   popad
-+0x0f4e   b9 2b 9f 22 bb       mov    ecx, 0xbb229f2b
++0x0f47   c7 3a 64 fb b9 0f...??  <INVALID>
++0x0f48   3a 64 fb b9          cmp    ah, byte ptr [ebx+edi*8-0x47]
++0x0f4c   0f 61 b9 2b 9f 22 bb punpcklwd mm7, qword ptr [ecx+0xbb229f2b]
 +0x0f53   08 9c f4 4b f7 6b e7 or     byte ptr [esp+esi*8+0xe76bf74b], bl
 +0x0f5a   a8 67                test   al, 0x67
 +0x0f5c   c1 22 17             shl    dword ptr [edx], 0x17
@@ -2979,7 +2980,9 @@
 +0x1cc9   82 06 bd             add    byte ptr [esi], 0xbd
 +0x1ccc   07                   pop    es
 +0x1ccd   b7 c9                mov    bh, 0xc9
-+0x1ccf   c6 7a 99 d7          xabort 0xd7
++0x1ccf   c6 7a 99 d7...??     <INVALID>
++0x1cd0   7a 99                jp     0x10001c6b
++0x1cd2   d7                   xlatb
 +0x1cd3   ef                   out    eax, dx
 +0x1cd4   cb                   retf
 +0x1cd5   24 70                and    al, 0x70


### PR DESCRIPTION
XBEGIN/ABORT are accepted only if their modrm byte is f8. Filter out other previously modrm bytes by introducing the necessary decode table entries to filter on the mod and rm fields in addition to the reg field.

Fixes #7275