### PR TITLE
Fix incorrect version # on 9.0 release notes

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -576,7 +576,7 @@ changes:
    segment index.  The custom data field is now per-segment and not per-module,
    and all callbacks are invoked separately for each segment.
 
-The changes between version \DR_VERSION and 8.0.0 include the following minor
+The changes between version 9.0.0 and 8.0.0 include the following minor
 compatibility changes:
 
  - drconfiglib (and thus drrun and drconfig) now sets only the new client path


### PR DESCRIPTION
Fixes \DR_VERSION which was left on the 9.0.0 minor compatibility change list.