### PR TITLE
i#7320: Fix isa mode assert

### DIFF
--- a/core/ir/decode_shared.c
+++ b/core/ir/decode_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -253,8 +253,11 @@ dr_set_isa_mode(void *drcontext, dr_isa_mode_t new_mode,
     dcontext_t *dcontext = (dcontext_t *)drcontext;
     dr_isa_mode_t old_mode;
     /* We would disallow but some early init routines need to use global heap */
-    if (dcontext == GLOBAL_DCONTEXT)
+    if (dcontext == GLOBAL_DCONTEXT) {
         dcontext = get_thread_private_dcontext();
+        if (dcontext == NULL)
+            dcontext = GLOBAL_DCONTEXT;
+    }
     /* Support GLOBAL_DCONTEXT or NULL for standalone/static modes */
     if (dcontext == NULL || dcontext == GLOBAL_DCONTEXT) {
 #if !defined(STANDALONE_DECODER)

--- a/core/ir/decode_shared.c
+++ b/core/ir/decode_shared.c
@@ -255,6 +255,7 @@ dr_set_isa_mode(void *drcontext, dr_isa_mode_t new_mode,
     /* We would disallow but some early init routines need to use global heap */
     if (dcontext == GLOBAL_DCONTEXT) {
         dcontext = get_thread_private_dcontext();
+        /* If we're pre-thread-init, go back to GLOBAL_DCONTEXT. */
         if (dcontext == NULL)
             dcontext = GLOBAL_DCONTEXT;
     }


### PR DESCRIPTION
Solves an isa mode assert by propagating the dcontext through read_instruction() for x86 decodes, and keeping GLOBAL_DCONTEXT when passed into dr_set_isa_mode().

The assert was triggered by a decode after DR global init but before the thread has its dcontext set up.  The passed-in dcontext turned from GLOBAL_DCONTEXT to NULL due to no propagation of dcontext through read_instruction().

Tested on an Ubuntu22 machine where client.tls and other tests hit the assert without the fix and pass with the fix.

Issue: #7270, #7320
Fixes #7320