### PR TITLE
i#7318: Do not propagate idle status on rebalance

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -889,6 +889,9 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::rebalance_queues(
                     break;
                 }
             }
+            // If we hit some fatal error, bail and propagate the error.
+            if (status != sched_type_t::STATUS_OK)
+                break;
             std::vector<input_ordinal_t> incompatible_inputs;
             // If we reach the 3rd iteration, we have fussy inputs with bindings.
             // Try to add them to every output.

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -879,8 +879,15 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::rebalance_queues(
                            "Rebalance iteration %d: output %d giving up input %d\n",
                            iteration, i, queue_next->index);
                     inputs_to_add.push_back(queue_next->index);
-                } else
+                } else {
+                    if (status == sched_type_t::STATUS_IDLE) {
+                        // An IDLE result is not an error: it just means there were no
+                        // unblocked inputs available.  We do not want to propagate it to
+                        // the caller.
+                        status = sched_type_t::STATUS_OK;
+                    }
                     break;
+                }
             }
             std::vector<input_ordinal_t> incompatible_inputs;
             // If we reach the 3rd iteration, we have fussy inputs with bindings.


### PR DESCRIPTION
Rebalancing was propagating an idle status from a runqueue to the caller, where it was treated as an error when it is in fact innocuous.

Adds a unit test that reproduces the error without the fix and passes with the fix.

Fixes https://github.com/DynamoRIO/dynamorio/issues/7318