### PR TITLE
i#7324: Add `set_parent` to `caching_device_t`

### DIFF
--- a/clients/drcachesim/simulator/caching_device.h
+++ b/clients/drcachesim/simulator/caching_device.h
@@ -36,6 +36,7 @@
 #ifndef _CACHING_DEVICE_H_
 #define _CACHING_DEVICE_H_ 1
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -112,6 +113,24 @@ public:
     get_parent() const
     {
         return parent_;
+    }
+    void
+    set_parent(caching_device_t *parent)
+    {
+        if (parent_ != NULL) {
+            parent_->children_.erase(
+                std::remove(parent_->children_.begin(), parent_->children_.end(), this),
+                parent_->children_.end());
+        }
+        if (parent != NULL) {
+            parent->children_.push_back(this);
+        }
+        parent_ = parent;
+    }
+    const std::vector<caching_device_t *> &
+    get_children() const
+    {
+        return children_;
     }
     inline double
     get_loaded_fraction() const

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -458,6 +458,42 @@ public:
 };
 
 void
+unit_test_set_parent()
+{
+    cache_t child_1;
+    cache_t child_2;
+    cache_t parent;
+    assert(child_1.init(1, 64, 1024, nullptr, new cache_stats_t(64, "", false, false)));
+    assert(child_2.init(1, 64, 1024, nullptr, new cache_stats_t(64, "", false, false)));
+    assert(parent.init(1, 64, 1024, nullptr, new cache_stats_t(64, "", false, false)));
+    // Test setting parent.
+    child_1.set_parent(&parent);
+    assert(child_1.get_parent() == &parent);
+    assert(parent.get_parent() == NULL);
+    assert(parent.get_children() == std::vector<caching_device_t *> { &child_1 });
+    assert(child_1.get_children().empty());
+    // Test removing parent.
+    child_1.set_parent(NULL);
+    assert(parent.get_parent() == NULL);
+    assert(child_1.get_parent() == NULL);
+    assert(parent.get_children().empty());
+    assert(child_1.get_children().empty());
+    // Test multiple children.
+    child_1.set_parent(&parent);
+    child_2.set_parent(&parent);
+    assert(child_1.get_parent() == &parent);
+    assert(child_2.get_parent() == &parent);
+    assert((parent.get_children() ==
+            std::vector<caching_device_t *> { &child_1, &child_2 }));
+    // Test existing child.
+    child_2.set_parent(&parent);
+    assert(child_1.get_parent() == &parent);
+    assert(child_2.get_parent() == &parent);
+    assert((parent.get_children() ==
+            std::vector<caching_device_t *> { &child_1, &child_2 }));
+}
+
+void
 unit_test_exclusive_cache()
 {
     // Create simple 3-level cache with exclusive LLC.
@@ -960,6 +996,7 @@ test_main(int argc, const char *argv[])
     unit_test_core_sharded();
     unit_test_nextline_prefetcher();
     unit_test_custom_prefetcher();
+    unit_test_set_parent();
     return 0;
 }
 


### PR DESCRIPTION
Added a function that allows setting the parent of a caching device. It handles the parent's children vector as well.
Added a test.

Fixes #7324