### PR TITLE
i#7270 ubuntu22: Relax reuse_distance.templatex

### DIFF
--- a/clients/drcachesim/tests/reuse_distance.templatex
+++ b/clients/drcachesim/tests/reuse_distance.templatex
@@ -8,7 +8,7 @@ Unique accesses: [1-9][0-9]+
 Unique cache lines accessed: [0-9]+
 .*
 Reuse distance mean: [0-9\.]+
-Reuse distance median: 1
+Reuse distance median: [01]
 Reuse distance standard deviation: [0-9\.]+
 \(Pass -reuse_distance_histogram to see all the data\.\)
 .*


### PR DESCRIPTION
Allows a median reuse distance of 0.

When run on a Github Actions Ubuntu 22 VM, it looks like the median may be 0:

reuse_dist, frequency
0,121222
1,70866
2,10108
3,5812
4,2316

Issue: #7270