### PR TITLE
i#7313: Unconditionally add libutil

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1677,9 +1677,7 @@ if (BUILD_CORE)
   add_subdirectory(core)
 endif (BUILD_CORE)
 
-if (BUILD_TOOLS OR BUILD_DRSTATS OR BUILD_CLIENTS)
-  add_subdirectory(libutil)
-endif (BUILD_TOOLS OR BUILD_DRSTATS OR BUILD_CLIENTS)
+add_subdirectory(libutil)
 
 if (BUILD_TOOLS)
   add_subdirectory(tools)


### PR DESCRIPTION
Unconditionally add libutil in CMakeLists.txt to ensure that DynamoRIO core and ext build correctly even when BUILD_TOOLS, BUILD_DRSTATS and BUILD_CLIENTS are all set to NO.

Fixes: #7313