### PR TITLE
i#5860 glibc sym: Print whole symbol name in error message

### DIFF
--- a/core/CMake_readelf.cmake
+++ b/core/CMake_readelf.cmake
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2015-2019 Google, Inc.    All rights reserved.
+# Copyright (c) 2015-2025 Google, Inc.    All rights reserved.
 # Copyright (c) 2009 VMware, Inc.    All rights reserved.
 # **********************************************************
 
@@ -119,7 +119,7 @@ endif ()
 
 if (check_libc)
   execute_process(COMMAND
-    ${READELF_EXECUTABLE} -s ${${lib_file}}
+    ${READELF_EXECUTABLE} -s --wide ${${lib_file}}
     RESULT_VARIABLE readelf_result
     ERROR_VARIABLE readelf_error
     OUTPUT_VARIABLE string


### PR DESCRIPTION
A too-recent symbol with a long name had its name omitted from our error message because `readelf -s` truncated it:

```
CMake Error at core/CMake_readelf.cmake:165 (message):
  *** Error:
  build_package/build_release-64/bin64/drconfig has too-recent import(s):

     GLOBAL DEFAULT  UND _[...]@GLIBC_2.34
```

Adding `--wide` produces the symbol name:

```
CMake Error at core/CMake_readelf.cmake:165 (message):
  *** Error:
  build_package/build_release-64/bin64/drconfig has too-recent import(s):

     GLOBAL DEFAULT  UND __libc_start_main@GLIBC_2.34
     GLOBAL DEFAULT  UND __libc_start_main@GLIBC_2.34
```

Issue: #5860