### PR TITLE
i#7338: log which config paths have been read when no config found

### DIFF
--- a/core/config.c
+++ b/core/config.c
@@ -388,6 +388,34 @@ read_config_file(file_t f, config_info_t *cfg, bool app_specific, bool overwrite
     }
 }
 
+/* Store the config file paths that have been used, for
+ * troubleshooting purposes. config_read() below can try
+ * up to five different paths.
+ */
+ #    define MAX_CONFIG_PATHS_TRIED 5
+ #    define MAX_CONFIG_PATHS (MAXIMUM_PATH * MAX_CONFIG_PATHS_TRIED)
+ static char config_paths[MAX_CONFIG_PATHS];
+ const char *
+ get_config_paths(void)
+ {
+     if (config_initialized)
+         return config_paths;
+     else
+         return NULL;
+ }
+
+static file_t
+log_path_and_open(const char *fname, int os_open_flags)
+{
+    static int config_paths_index = 0;
+
+    INFO(2, "trying config file %s", fname);
+    config_paths_index += snprintf(config_paths + config_paths_index,
+                                   MAX_CONFIG_PATHS - config_paths_index, "%s, ", fname);
+
+    return os_open(fname, OS_OPEN_READ);
+}
+
 static void
 config_read(config_info_t *cfg, const char *appname_in, process_id_t pid, const char *sfx)
 {
@@ -427,8 +455,7 @@ config_read(config_info_t *cfg, const char *appname_in, process_id_t pid, const 
                      "%s/%s/%s.%d.1%s", local, LOCAL_CONFIG_SUBDIR, appname, pid_to_check,
                      sfx);
             NULL_TERMINATE_BUFFER(cfg->fname_app);
-            INFO(2, "trying config file %s", cfg->fname_app);
-            f_app = os_open(cfg->fname_app, OS_OPEN_READ);
+            f_app = log_path_and_open(cfg->fname_app, OS_OPEN_READ);
             if (f_app != INVALID_FILE)
                 cfg->has_1config = true; /* one-time file */
         }
@@ -437,16 +464,14 @@ config_read(config_info_t *cfg, const char *appname_in, process_id_t pid, const 
             snprintf(cfg->fname_app, BUFFER_SIZE_ELEMENTS(cfg->fname_app), "%s/%s/%s.%s",
                      local, LOCAL_CONFIG_SUBDIR, appname, sfx);
             NULL_TERMINATE_BUFFER(cfg->fname_app);
-            INFO(2, "trying config file %s", cfg->fname_app);
-            f_app = os_open(cfg->fname_app, OS_OPEN_READ);
+            f_app = log_path_and_open(cfg->fname_app, OS_OPEN_READ);
         }
         /* 3) <local>/default.0config */
         if (f_default == INVALID_FILE) {
             snprintf(cfg->fname_default, BUFFER_SIZE_ELEMENTS(cfg->fname_default),
                      "%s/%s/default.0%s", local, LOCAL_CONFIG_SUBDIR, sfx);
             NULL_TERMINATE_BUFFER(cfg->fname_default);
-            INFO(2, "trying config file %s", cfg->fname_default);
-            f_default = os_open(cfg->fname_default, OS_OPEN_READ);
+            f_default = log_path_and_open(cfg->fname_default, OS_OPEN_READ);
         }
     }
 #    ifdef WINDOWS
@@ -465,16 +490,14 @@ config_read(config_info_t *cfg, const char *appname_in, process_id_t pid, const 
             snprintf(cfg->fname_app, BUFFER_SIZE_ELEMENTS(cfg->fname_app), "%s%s/%s.%s",
                      global, GLOBAL_CONFIG_SUBDIR, appname, sfx);
             NULL_TERMINATE_BUFFER(cfg->fname_app);
-            INFO(2, "trying config file %s", cfg->fname_app);
-            f_app = os_open(cfg->fname_app, OS_OPEN_READ);
+            f_app = log_path_and_open(cfg->fname_app, OS_OPEN_READ);
         }
         /* 5) <global>/default.0config */
         if (f_default == INVALID_FILE) {
             snprintf(cfg->fname_default, BUFFER_SIZE_ELEMENTS(cfg->fname_default),
                      "%s%s/default.0%s", global, GLOBAL_CONFIG_SUBDIR, sfx);
             NULL_TERMINATE_BUFFER(cfg->fname_default);
-            INFO(2, "trying config file %s", cfg->fname_default);
-            f_default = os_open(cfg->fname_default, OS_OPEN_READ);
+            f_default = log_path_and_open(cfg->fname_default, OS_OPEN_READ);
         }
     }
     if (f_app != INVALID_FILE) {

--- a/core/config.c
+++ b/core/config.c
@@ -410,8 +410,7 @@ log_path_and_open(const char *fname, int os_open_flags)
     static int config_paths_offset = 0;
 
     INFO(2, "trying config file %s", fname);
-    if (!config_initialized)
-    {
+    if (!config_initialized) {
         config_paths_offset +=
             snprintf(config_paths + config_paths_offset,
                      MAX_CONFIG_PATHS - config_paths_offset, "%s, ", fname);

--- a/core/config.c
+++ b/core/config.c
@@ -407,13 +407,17 @@ get_config_paths(void)
 static file_t
 log_path_and_open(const char *fname, int os_open_flags)
 {
-    static int config_paths_offset = 0;
+    static size_t config_paths_offset = 0;
 
     INFO(2, "trying config file %s", fname);
+
+    /* Store the config path that is being read, but only if config
+     * is being initialized, as otherwise access to the global config_paths
+     * buffer may not be thread safe.
+     */
     if (!config_initialized) {
-        config_paths_offset +=
-            snprintf(config_paths + config_paths_offset,
-                     MAX_CONFIG_PATHS - config_paths_offset, "%s, ", fname);
+        print_to_buffer(config_paths, BUFFER_SIZE_ELEMENTS(config_paths),
+                        &config_paths_offset, "%s, ", fname);
     }
 
     return os_open(fname, OS_OPEN_READ);

--- a/core/config.c
+++ b/core/config.c
@@ -388,7 +388,7 @@ read_config_file(file_t f, config_info_t *cfg, bool app_specific, bool overwrite
     }
 }
 
-/* Store the config file paths that have been used, for
+/* Store the initial config file paths that have been used, for
  * troubleshooting purposes. config_read() below can try
  * up to five different paths.
  */
@@ -407,11 +407,12 @@ get_config_paths(void)
 static file_t
 log_path_and_open(const char *fname, int os_open_flags)
 {
-    static int config_paths_index = 0;
+    static int config_paths_offset = 0;
 
     INFO(2, "trying config file %s", fname);
-    config_paths_index += snprintf(config_paths + config_paths_index,
-                                   MAX_CONFIG_PATHS - config_paths_index, "%s, ", fname);
+    if (!config_initialized)
+        config_paths_offset +=  snprintf(config_paths + config_paths_offset,
+                                       MAX_CONFIG_PATHS - config_paths_offset, "%s, ", fname);
 
     return os_open(fname, OS_OPEN_READ);
 }

--- a/core/config.c
+++ b/core/config.c
@@ -411,9 +411,11 @@ log_path_and_open(const char *fname, int os_open_flags)
 
     INFO(2, "trying config file %s", fname);
     if (!config_initialized)
+    {
         config_paths_offset +=
             snprintf(config_paths + config_paths_offset,
                      MAX_CONFIG_PATHS - config_paths_offset, "%s, ", fname);
+    }
 
     return os_open(fname, OS_OPEN_READ);
 }

--- a/core/config.c
+++ b/core/config.c
@@ -416,8 +416,9 @@ log_path_and_open(const char *fname, int os_open_flags)
      * buffer may not be thread safe.
      */
     if (!config_initialized) {
-        print_to_buffer(config_paths, BUFFER_SIZE_ELEMENTS(config_paths),
-                        &config_paths_offset, "%s, ", fname);
+        config_paths_offset += snprintf(
+            config_paths + config_paths_offset,
+            BUFFER_SIZE_ELEMENTS(config_paths) - config_paths_offset, "%s, ", fname);
     }
 
     return os_open(fname, OS_OPEN_READ);

--- a/core/config.c
+++ b/core/config.c
@@ -411,8 +411,9 @@ log_path_and_open(const char *fname, int os_open_flags)
 
     INFO(2, "trying config file %s", fname);
     if (!config_initialized)
-        config_paths_offset +=  snprintf(config_paths + config_paths_offset,
-                                       MAX_CONFIG_PATHS - config_paths_offset, "%s, ", fname);
+        config_paths_offset +=
+            snprintf(config_paths + config_paths_offset,
+                     MAX_CONFIG_PATHS - config_paths_offset, "%s, ", fname);
 
     return os_open(fname, OS_OPEN_READ);
 }

--- a/core/config.c
+++ b/core/config.c
@@ -392,17 +392,17 @@ read_config_file(file_t f, config_info_t *cfg, bool app_specific, bool overwrite
  * troubleshooting purposes. config_read() below can try
  * up to five different paths.
  */
- #    define MAX_CONFIG_PATHS_TRIED 5
- #    define MAX_CONFIG_PATHS (MAXIMUM_PATH * MAX_CONFIG_PATHS_TRIED)
- static char config_paths[MAX_CONFIG_PATHS];
- const char *
- get_config_paths(void)
- {
-     if (config_initialized)
-         return config_paths;
-     else
-         return NULL;
- }
+#    define MAX_CONFIG_PATHS_TRIED 5
+#    define MAX_CONFIG_PATHS (MAXIMUM_PATH * MAX_CONFIG_PATHS_TRIED)
+static char config_paths[MAX_CONFIG_PATHS];
+const char *
+get_config_paths(void)
+{
+    if (config_initialized)
+        return config_paths;
+    else
+        return NULL;
+}
 
 static file_t
 log_path_and_open(const char *fname, int os_open_flags)

--- a/core/config.h
+++ b/core/config.h
@@ -63,6 +63,9 @@ const char *
 get_config_val(const char *var);
 
 const char *
+get_config_paths(void);
+
+const char *
 get_config_val_ex(const char *var, bool *app_specific, bool *from_env);
 
 bool

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -619,13 +619,13 @@ dynamorio_app_init_part_two_finalize(void)
             char initial_options[MAX_OPTIONS_STRING];
             get_dynamo_options_string(&dynamo_options, initial_options,
                                       sizeof(initial_options), true);
-            if (initial_options[0])
+            if (initial_options[0] != '\0')
                 SYSLOG_INTERNAL_INFO("Initial options = %s", initial_options);
             else {
-                SYSLOG_INTERNAL_INFO("No options found. Config paths used: %s",
-                                     get_config_paths());
                 SYSLOG_INTERNAL_INFO(
-                    "Config files either missing or no permission to read them.");
+                    "No options found. Config paths used: %s\n"
+                    "Config files either missing or no permission to read them.",
+                    get_config_paths());
             }
             DOLOG(1, LOG_TOP, {
                 get_pcache_dynamo_options_string(&dynamo_options, initial_options,

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -619,7 +619,14 @@ dynamorio_app_init_part_two_finalize(void)
             char initial_options[MAX_OPTIONS_STRING];
             get_dynamo_options_string(&dynamo_options, initial_options,
                                       sizeof(initial_options), true);
-            SYSLOG_INTERNAL_INFO("Initial options = %s", initial_options);
+            if (initial_options[0])
+                SYSLOG_INTERNAL_INFO("Initial options = %s", initial_options);
+            else {
+                SYSLOG_INTERNAL_INFO("No options found. Config paths used: %s",
+                                     get_config_paths());
+                SYSLOG_INTERNAL_INFO(
+                    "Config files either missing or no permission to read them.");
+            }
             DOLOG(1, LOG_TOP, {
                 get_pcache_dynamo_options_string(&dynamo_options, initial_options,
                                                  sizeof(initial_options),

--- a/core/dynamo.c
+++ b/core/dynamo.c
@@ -623,7 +623,7 @@ dynamorio_app_init_part_two_finalize(void)
                 SYSLOG_INTERNAL_INFO("Initial options = %s", initial_options);
             else {
                 SYSLOG_INTERNAL_INFO(
-                    "No options found. Config paths used: %s\n"
+                    "No options found. Initial config paths used: %s\n"
                     "Config files either missing or no permission to read them.",
                     get_config_paths());
             }


### PR DESCRIPTION
When attaching to a running application, if the target application does not succeed in opening any config options files, the user does not know where the application has looked.

Store the config paths used and output them if no config files are found.

Fixes: #7338