### PR TITLE
i#7270 Ubuntu22: Ignore drcacheoff.windows-invar failure

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -470,6 +470,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|linux.thread-reset' => 1, # i#4604
                 'code_api|linux.clone-reset' => 1, # i#4604
                 'code_api|client.detach_test' => 1, # i#6764
+                'code_api|tool.drcacheoff.windows-invar' => 1, # i#7340
                 # These are from the long suite.
                 'common.decode-stress' => 1, # i#1807 Ignored for all options.
                 'code_api,opt_speed|common.fib' => 1, # i#1807: Undiagnosed timeout.


### PR DESCRIPTION
Adds the tool.drcacheoff.windows-invar test to the failure-ignore list for x86-32. This test was observed to consistently fail on x86-32 AMD machines in Github Actions CI runners. Interestingly, this manifested only when we tried running it on Ubuntu22, even though many AMD-specific failures were already known (#6417).

We do have a denylist for tests failing on AMD-32 in i#6417, which causes tests to not run at all. IMO, it is better to run the test but ignore the failure, than to not run the test at all, unless there are timeout issues (which is why we created the denylist), and this test does not have timeout issues.

We plan to work on the AMD-32 failures at a later date and are focusing on completing the Ubuntu22 migration currently.

Issue: #6417, #7270, #7340