### PR TITLE
i#7344: Fix the clang-format check disabled message.

### DIFF
--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -263,7 +263,7 @@ endif ()
 #
 # Prefer named version 14.0 from apt.llvm.org.
 if (DEFINED ENV{DISABLE_FORMAT_CHECKS} AND "$ENV{DISABLE_FORMAT_CHECKS}" STREQUAL "yes")
-  message("@@@clang-format check disabled")
+  message("clang-format check disabled")
 else ()
   find_program(CLANG_FORMAT_DIFF clang-format-diff-14 DOC "clang-format-diff")
   if (NOT CLANG_FORMAT_DIFF)


### PR DESCRIPTION
Remove @@@ from message("@@@clang-format check disabled") in suite/runsuite.cmake.

It was left over from #7345.

Issue: #7344 