### PR TITLE
i#7270 Ubuntu22: Increase x86-32 privload tcb size estimate

### DIFF
--- a/core/unix/loader_linux.c
+++ b/core/unix/loader_linux.c
@@ -135,9 +135,15 @@ static size_t client_tls_size = 2 * 4096;
  * good way to guess how big this allocation was.  Instead we use this estimate.
  * For Ubuntu22 glibc 2.38, the size is 0x9c0; we use 0x1000 to cover future
  * expansion.
+ * For Ubuntu22 glibc 2.35 x86-32, 0x500 seems to cover it for now.
+ * At 0x490, _IO_link_in faults at
+ * => 0xf779e5b3:  mov    %gs:0x4fe,%al
+ *    0xf779e5b9:  movzbl %al,%eax
+ *    0xf779e5bc:  mov    %eax,0x8(%edx)
+ *    0xf779e5bf:  movb   $0x0,%gs:0x4fe
  */
 /* On A32, the pthread is put before tcbhead instead tcbhead being part of pthread */
-static size_t tcb_size_estimate = IF_X64_ELSE(0x1000, 0x490);
+static size_t tcb_size_estimate = IF_X64_ELSE(0x1000, 0x500);
 
 /* thread contol block header type from
  * - sysdeps/x86_64/nptl/tls.h


### PR DESCRIPTION
Following PR #7294 which increases the privload tcb size estimate for x86-64, this increases the same for x86-32 to make it work on the Github Actions Ubuntu 22 runners.

Various tests crash with the following stacktrace without this fix:

```
(gdb) bt
#0  0xf779e5b3 in ?? ()
#1  0xf779a444 in _IO_link_in ()
#2  0xf7799206 in ?? ()
#3  0xf778c8fc in fdopen ()
#4  0xf7bb03c1 in log_stream_from_file (f=65440) at /home/runner/work/dynamorio/dynamorio/api/samples/utils.c:109 #5  0xf7baf70b in event_thread_init (drcontext=0x448efb40) at /home/runner/work/dynamorio/dynamorio/api/samples/instrace_simple.c:263 #6  0xf7b7dc07 in drmgr_thread_init_event (drcontext=0x448efb40) at /home/runner/work/dynamorio/dynamorio/ext/drmgr/drmgr.c:2639 #7  0xf7d898e1 in instrument_thread_init (dcontext=0x448efb40, client_thread=false, valid_mc=false) at /home/runner/work/dynamorio/dynamorio/core/lib/instrument.c:1506 #8  0xf7d880af in instrument_init () at /home/runner/work/dynamorio/dynamorio/core/lib/instrument.c:818 #9  0xf7c25581 in dynamorio_app_init_part_two_finalize () at /home/runner/work/dynamorio/dynamorio/core/dynamo.c:716 #10 0xf7e7d0ad in privload_early_inject (sp=0xffffbf00, old_libdr_base=0x0, old_libdr_size=0) at /home/runner/work/dynamorio/dynamorio/core/unix/loader.c:2379 #11 0xf7e303c5 in reloaded_xfer () at /home/runner/work/dynamorio/dynamorio/core/arch/x86/x86.asm:1187 (gdb) x/10i 0xf779e5b3
=> 0xf779e5b3:  mov    %gs:0x4fe,%al
   0xf779e5b9:  movzbl %al,%eax
   0xf779e5bc:  mov    %eax,0x8(%edx)
   0xf779e5bf:  movb   -bashx0,%gs:0x4fe
   0xf779e5c7:  mov    %edx,%gs:0x7c
```

The following tests pass now on the x86-32 suite on a Github Actions Ubuntu 22 runner:

```
$ ctest -R 'memval|x86_text|memtrace_simple|client.file_io|client.destructor|instrace|client.signal|windows-simple' Test project /home/runner/work/dynamorio/dynamorio/build_debug-internal-32
      Start  43: code_api|client.memval-test
 1/14 Test  #43: code_api|client.memval-test .........................   Passed    0.50 sec
      Start 186: code_api|client.signal
 2/14 Test #186: code_api|client.signal ..............................   Passed    1.67 sec
      Start 189: code_api|client.file_io
 3/14 Test #189: code_api|client.file_io .............................   Passed    0.64 sec
      Start 244: code_api|client.destructor
 4/14 Test #244: code_api|client.destructor ..........................   Passed    0.65 sec
      Start 251: code_api|sample.memtrace_simple
 5/14 Test #251: code_api|sample.memtrace_simple .....................   Passed    1.92 sec
      Start 252: code_api|sample.memval_simple
 6/14 Test #252: code_api|sample.memval_simple .......................   Passed    1.05 sec
      Start 253: code_api|sample.memval_simple_scattergather
 7/14 Test #253: code_api|sample.memval_simple_scattergather .........   Passed    1.23 sec
      Start 254: code_api|sample.instrace_simple
 8/14 Test #254: code_api|sample.instrace_simple .....................   Passed    1.51 sec
      Start 260: code_api|sample.memtrace_x86_text
 9/14 Test #260: code_api|sample.memtrace_x86_text ...................   Passed    1.64 sec
      Start 261: code_api|sample.instrace_x86_binary
10/14 Test #261: code_api|sample.instrace_x86_binary .................   Passed    1.99 sec
      Start 262: code_api|sample.instrace_x86_text
11/14 Test #262: code_api|sample.instrace_x86_text ...................   Passed    2.02 sec
      Start 299: code_api|tool.drcachesim.windows-simple
12/14 Test #299: code_api|tool.drcachesim.windows-simple .............   Passed    2.40 sec
      Start 300: code_api|tool.drcachesim.irregular-windows-simple
13/14 Test #300: code_api|tool.drcachesim.irregular-windows-simple ...   Passed    2.39 sec
      Start 335: code_api|tool.drcacheoff.windows-simple
14/14 Test #335: code_api|tool.drcacheoff.windows-simple .............   Passed    2.43 sec
```

Issue:  #7270, #7293