### PR TITLE
i#7360: Fix ldscript creation with binutils 2.44 and preferred base set

### DIFF
--- a/make/ldscript.cmake
+++ b/make/ldscript.cmake
@@ -106,7 +106,7 @@ endif ()
 # since at least 2003, where adjusting the base address only requires to replace
 # the constant (default_base that we've retrieved earlier). Extra assignments
 # to currenct location counter should be avoided, which may create holes in the
-# address space, resulting an ELF header at unexpected address and break
+# address space, resulting in an ELF header at unexpected address and breaking
 # __executable_start.
 if (set_preferred)
   string(REGEX REPLACE

--- a/make/ldscript.cmake
+++ b/make/ldscript.cmake
@@ -100,14 +100,18 @@ endif ()
 # PR 253624: right now our library has to be next to our heap, and our
 # heap needs to be in lower 4GB for our fallback TLS (PR 285410), so we
 # set a preferred base address via a linker script.
+# i#7360: binutils sets ELF base and __executable_start with ldscript like
+#     PROVIDE (__executable_start = SEGMENT_START("text-segment", 0x400000));
+#     . = SEGMENT_START("text-segment", 0x400000) + SIZEOF_HEADERS;
+# since at least 2003, where adjusting the base address only requires to replace
+# the constant (default_base that we've retrieved earlier). Extra assignments
+# to currenct location counter should be avoided, which may create holes in the
+# address space, resulting an ELF header at unexpected address and break
+# __executable_start.
 if (set_preferred)
   string(REGEX REPLACE
     "${default_base}"
     "${preferred_base}"
-    string "${string}")
-  string(REGEX REPLACE
-    "(\n{)"
-    "\\1\n  . = ${preferred_base};"
     string "${string}")
 endif (set_preferred)
 


### PR DESCRIPTION
We used to adjust current location pointer to our preferred base address at start of the linkscript, which creates a hole in the address space and allows the linker to put the ELF header and other sections before address of __executable_start symbol. This causes assertion failures when building with binutils 2.44,

	Internal Error: DynamoRIO debug check failure:
	/dynamorio/core/unix/os.c:9618 check_start == dynamo_dll_start

Since binutils ld.bfd always determines the base address by

	. = SEGMENT_START("text-segment", 0x400000) + SIZEOF_HEADERS;

starting from at least 2003, it should be fine to drop the extra adjustment and only replace the default base with our preferred base.

Fixes: #7360