### PR TITLE
i#7270 Ubuntu22: Migrate x86-{32,64}, android-arm-cross, a64-on-x86

### DIFF
--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -163,7 +163,7 @@ jobs:
 
   # Android ARM cross-compile with gcc, no tests:
   android-arm-cross-compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4
@@ -263,7 +263,7 @@ jobs:
 
   # AArch64 drdecode and drmemtrace on x86:
   a64-on-x86:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -247,7 +247,7 @@ jobs:
       # always invoked.
       if: ${{ always() }}
       with:
-        test_suite_status: ${{ format('{0} {1} | {2} {3} | {4} {5} | {6} {7} | {8} {9}',
+        test_suite_status: ${{ format('{0} {1} | {2} {3} | {4} {5}',
                                       'x86-32', needs.x86-32.result,
                                       'x86-64', needs.x86-64.result,
                                       'x86-64-alpine-3_21', needs.x86-64-alpine-3_21.result) }}

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -62,6 +62,9 @@ jobs:
   x86-64:
     runs-on: ubuntu-22.04
     steps:
+    # When checking out the repository that triggered a workflow, actions/checkout
+    # defaults to the reference or SHA for that event. See documentation for ref at
+    # https://github.com/actions/checkout
     - uses: actions/checkout@v4
       with:
         submodules: true
@@ -87,7 +90,6 @@ jobs:
           liblz4-dev g++-multilib libunwind-dev
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 
-    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
     - name: Setup newer cmake
       uses: jwlawson/actions-setup-cmake@v2
       with:

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -58,7 +58,7 @@ defaults:
   # https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations
 
 jobs:
-  # 64-bit Linux build with gcc and run tests.
+  # Ubuntu22 64-bit Linux build with gcc and run tests.
   x86-64:
     runs-on: ubuntu-22.04
     steps:
@@ -72,6 +72,11 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ github.event_name == 'pull_request' }}
 
+    # We also need origin/master for pre-commit source file checks in runsuite.cmake.
+    # But fetching multiple branches isn't supported yet: actions/checkout#214
+    # Pending PR that adds this support actions/checkout#155
+    # TODO i#4549: When necessary support is available, remove/replace the
+    # workaround here and from every job in other Github Actions CI workflows.
     - run: git fetch --no-tags --depth=1 origin master
 
     # Install multilib for non-cross-compiling Linux build.
@@ -101,7 +106,7 @@ jobs:
         CI_BRANCH: ${{ github.ref }}
         DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
 
-  # Ubuntu22 64-bit Linux build with gcc and run tests.
+  # Ubuntu22 32-bit Linux build with gcc and run tests.
   x86-32:
     runs-on: ubuntu-22.04
     steps:
@@ -118,12 +123,15 @@ jobs:
     - run: git fetch --no-tags --depth=1 origin master
 
     # Install multilib for non-cross-compiling Linux build.
+    # GA CI uses packages.microsoft.com which is missing i386 packages, and
+    # attempts at using apt with us.archive-ubuntu.com hit dep issues:
+    # so we manually install the i386 packages we need.
     - name: Create Build Environment
       run: |
         sudo apt update
         sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
           liblz4-dev g++-multilib libunwind-dev
-        sudo add-apt-repository 'deb [arch=i386] http://us.archive.ubuntu.com/ubuntu focal main'
+        sudo add-apt-repository 'deb [arch=i386] http://us.archive.ubuntu.com/ubuntu jammy main'
         apt download libunwind8:i386 libunwind-dev:i386 liblzma5:i386 \
           zlib1g:i386 zlib1g-dev:i386
         mkdir ../extract

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -58,116 +58,7 @@ defaults:
   # https://github.community/t/reusing-sharing-inheriting-steps-between-jobs-declarations
 
 jobs:
-  # 32-bit Linux build with gcc and run tests:
-  x86-32:
-    runs-on: ubuntu-20.04
-
-    # When checking out the repository that triggered a workflow, actions/checkout
-    # defaults to the reference or SHA for that event. See documentation for ref at
-    # https://github.com/actions/checkout
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    # Cancel any prior runs for a PR (but do not cancel master branch runs).
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'pull_request' }}
-
-    # We also need origin/master for pre-commit source file checks in runsuite.cmake.
-    # But fetching multiple branches isn't supported yet: actions/checkout#214
-    # Pending PR that adds this support actions/checkout#155
-    # TODO i#4549: When necessary support is available, remove/replace the
-    # workaround here and from every job in other Github Actions CI workflows.
-    - run: git fetch --no-tags --depth=1 origin master
-
-    # Install multilib for non-cross-compiling Linux build.
-    # GA CI uses packages.microsoft.com which is missing i386 packages, and
-    # attempts at using apt with us.archive-ubuntu.com hit dep issues:
-    # so we manually install the i386 packages we need.
-    - name: Create Build Environment
-      run: |
-        sudo apt update
-        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
-          liblz4-dev g++-multilib libunwind-dev
-        sudo add-apt-repository 'deb [arch=i386] http://us.archive.ubuntu.com/ubuntu focal main'
-        apt download libunwind8:i386 libunwind-dev:i386 liblzma5:i386 \
-          zlib1g:i386 zlib1g-dev:i386
-        mkdir ../extract
-        for i in *.deb; do dpkg-deb -x $i ../extract; done
-        sudo rsync -av ../extract/usr/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
-        sudo rsync -av ../extract/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
-        sudo rsync -av ../extract/usr/include/i386-linux-gnu/ /usr/include/
-        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-
-    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
-    - name: Setup newer cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.19.7'
-
-    - name: Check if format checks are disabled
-      id: are_format_checks_disabled
-      uses: ./.github/actions/are-format-checks-disabled
-
-    - name: Run Suite
-      working-directory: ${{ github.workspace }}
-      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
-      env:
-        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
-        CI_TRIGGER: ${{ github.event_name }}
-        CI_BRANCH: ${{ github.ref }}
-        GITHUB_COMMIT_AUTHOR_EMAIL: ${{ github.event.commits[0].author.email }}
-        DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
-
   # 64-bit Linux build with gcc and run tests.
-  x86-64:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    # Cancel any prior runs for a PR (but do not cancel master branch runs).
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'pull_request' }}
-
-    - run: git fetch --no-tags --depth=1 origin master
-
-    # Install multilib for non-cross-compiling Linux build.
-    - name: Create Build Environment
-      run: |
-        sudo apt update
-        sudo apt-get -y install doxygen vera++ zlib1g-dev libsnappy-dev \
-          liblz4-dev g++-multilib libunwind-dev
-        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-
-    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
-    - name: Setup newer cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.19.7'
-
-    - name: Check if format checks are disabled
-      id: are_format_checks_disabled
-      uses: ./.github/actions/are-format-checks-disabled
-
-    - name: Run Suite
-      working-directory: ${{ github.workspace }}
-      run: ./suite/runsuite_wrapper.pl automated_ci 64_only
-      env:
-        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
-        CI_TRIGGER: ${{ github.event_name }}
-        CI_BRANCH: ${{ github.ref }}
-        DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
-
-  # Ubuntu22 64-bit Linux build with gcc and run tests.
-  # XXX: A matrix could combine this with the 20.04 but our auto-cancel
-  # step cancels the 2nd job so we need to solve that first.
   x86-64-ubuntu22:
     runs-on: ubuntu-22.04
     steps:
@@ -211,8 +102,6 @@ jobs:
         DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
 
   # Ubuntu22 64-bit Linux build with gcc and run tests.
-  # XXX: A matrix could combine this with the 20.04 but our auto-cancel
-  # step cancels the 2nd job so we need to solve that first.
   x86-32-ubuntu22:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -59,7 +59,7 @@ defaults:
 
 jobs:
   # 64-bit Linux build with gcc and run tests.
-  x86-64-ubuntu22:
+  x86-64:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
         DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
 
   # Ubuntu22 64-bit Linux build with gcc and run tests.
-  x86-32-ubuntu22:
+  x86-32:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -241,7 +241,7 @@ jobs:
 
   send-failure-notification:
       uses: ./.github/workflows/failure-notification.yml
-      needs: [x86-32, x86-64, x86-64-ubuntu22, x86-32-ubuntu22, x86-64-alpine-3_21]
+      needs: [x86-32, x86-64, x86-64-alpine-3_21]
       # By default, a failure in a job skips the jobs that need it. The
       # following expression ensures that failure-notification.yml is
       # always invoked.
@@ -250,8 +250,6 @@ jobs:
         test_suite_status: ${{ format('{0} {1} | {2} {3} | {4} {5} | {6} {7} | {8} {9}',
                                       'x86-32', needs.x86-32.result,
                                       'x86-64', needs.x86-64.result,
-                                      'x86-64-ubuntu22', needs.x86-64-ubuntu22.result,
-                                      'x86-32-ubuntu22', needs.x86-32-ubuntu22.result,
                                       'x86-64-alpine-3_21', needs.x86-64-alpine-3_21.result) }}
         test_suite_results_only: ${{ join(needs.*.result, ',') }}
       secrets: inherit

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -89,11 +89,6 @@ if (UNIX AND NOT APPLE AND NOT ANDROID AND NOT cross_riscv64_linux_only)
     RESULT_VARIABLE ldd_result ERROR_VARIABLE ldd_err OUTPUT_VARIABLE ldd_out)
   if (ldd_result OR ldd_err)
     # Failed; just move on.
-  elseif (ldd_out MATCHES "GLIBC 2.3[5-9]")
-    # XXX i#5437, i#5431: While we work through Ubuntu22 issues we run
-    # just a few tests.
-    set(extra_ctest_args INCLUDE_LABEL UBUNTU_22)
-    set(arg_debug_only ON)
   elseif (arg_32_only AND NOT cross_aarchxx_linux_only AND NOT cross_android_only)
     # TODO i#6417: The switch to AMD VM's for GA CI has broken many of our tests.
     # This includes timeouts which increases suite length.

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -87,9 +87,8 @@ endforeach (arg)
 if (UNIX AND NOT APPLE AND NOT ANDROID AND NOT cross_riscv64_linux_only)
   execute_process(COMMAND ldd --version
     RESULT_VARIABLE ldd_result ERROR_VARIABLE ldd_err OUTPUT_VARIABLE ldd_out)
-  if (ldd_result OR ldd_err)
-    # Failed; just move on.
-  elseif (arg_32_only AND NOT cross_aarchxx_linux_only AND NOT cross_android_only)
+  message("ldd --version: ${ldd_out}")
+  if (arg_32_only AND NOT cross_aarchxx_linux_only AND NOT cross_android_only)
     # TODO i#6417: The switch to AMD VM's for GA CI has broken many of our tests.
     # This includes timeouts which increases suite length.
     # Until we get ths x86-32 job back green, we drop back to a small set of tests.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6545,47 +6545,6 @@ if (NOT ANDROID AND AARCHXX)
   endif ()
 endif (NOT ANDROID AND AARCHXX)
 
-# XXX i#5437, i#5431: While we work through Ubuntu22 issues we want our new GA CI job to
-# just run sanity tests that do pass now as a glibc change detector to see if our
-# workarounds so far break over time.
-set_tests_properties(
-  code_api|common.broadfun
-  PROPERTIES LABELS UBUNTU_22)
-if (BUILD_SAMPLES AND NOT ANDROID AND NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
-  set_tests_properties(
-    code_api|sample.bbsize
-    PROPERTIES LABELS UBUNTU_22)
-endif ()
-if (BUILD_CLIENTS AND NOT ANDROID)
-  set_tests_properties(
-    code_api|tool.drcachesim.simple
-    code_api|tool.drcacheoff.simple
-    PROPERTIES LABELS UBUNTU_22)
-endif ()
-if (LINUX AND X64 AND HAVE_RSEQ AND NOT RISCV64 AND NOT ANDROID) # TODO i#3544: Port tests to RISC-V 64
-  # TODO i#1874: Build drmemtrace on Android (rseq tests depend on drmemtrace).
-  set_tests_properties(
-    code_api|api.rseq
-    code_api|linux.rseq_disable
-    code_api|linux.rseq_noarray
-    code_api|linux.rseq
-    code_api|linux.rseq_table
-    code_api|tool.drcacheoff.rseq
-    PROPERTIES LABELS UBUNTU_22)
-endif ()
-if (TARGET tool.drcacheoff.purestatic)
-  # This target only easily builds on Ubuntu22+ so make sure we run it there.
-  set_tests_properties(
-    code_api|tool.drcacheoff.purestatic
-    PROPERTIES LABELS UBUNTU_22)
-endif()
-if (LINUX AND X64 AND NOT RISCV64 AND NOT ANDROID)
-set_tests_properties(
-  code_api|client.memory_dump_test
-  code_api|client.attach_memory_dump_test
-  PROPERTIES LABELS UBUNTU_22)
-endif()
-
 # XXX i#3544: Support for running RISC-V Linux tests under QEMU.
 # Currently about 1/6 of the compiled tests pass.
 if (RISCV64)


### PR DESCRIPTION
Removes the restriction on the test set run on Ubuntu22, and removes the UBUNTU_22 set itself.

Removes the x86-64 and x86-32 Ubuntu 20 Github Actions CI workflows, since we have others than run the same configuration on Ubuntu 22. Migrates the android-arm-cross-compile and a64-on-x86 to Ubuntu 22.

Removes the -ubuntu22 suffix from the workflows where that's the only variation left now.

This has been made possible after a bunch of work on #7270 by other contributors: @derekbruening, @edeiana, and @ivankyluk.

Issue: #7270