### PR TITLE
i#3544 RV64: Pass correct arguments to ifunc resolvers

### DIFF
--- a/core/unix/include/syscall_linux_riscv64.h
+++ b/core/unix/include/syscall_linux_riscv64.h
@@ -12,7 +12,7 @@
 #endif
 
 #ifndef __NR_riscv_hwprobe
-#    define __NR_riscv_hwprobe      (__NR_arch_specific_syscall + 14)
+#    define __NR_riscv_hwprobe (__NR_arch_specific_syscall + 14)
 #endif
 
 #ifndef __NR_riscv_flush_icache

--- a/core/unix/include/syscall_linux_riscv64.h
+++ b/core/unix/include/syscall_linux_riscv64.h
@@ -11,6 +11,10 @@
 #    error Only use this file on Linux
 #endif
 
+#ifndef __NR_riscv_hwprobe
+#    define __NR_riscv_hwprobe      (__NR_arch_specific_syscall + 14)
+#endif
+
 #ifndef __NR_riscv_flush_icache
 #    define __NR_riscv_flush_icache (__NR_arch_specific_syscall + 15)
 #endif

--- a/core/unix/include/syscall_linux_uapi.h
+++ b/core/unix/include/syscall_linux_uapi.h
@@ -2143,6 +2143,10 @@
 #    define SYS_riscv_flush_icache __NR_riscv_flush_icache
 #endif
 
+#ifdef __NR_riscv_hwprobe
+#    define SYS_riscv_hwprobe __NR_riscv_hwprobe
+#endif
+
 #ifdef __NR_rmdir
 #    define SYS_rmdir __NR_rmdir
 #endif

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -38,7 +38,7 @@
 #include "module_private.h"
 #include "../utils.h"
 #include "instrument.h"
-#include "syscall.h"
+#include "include/syscall.h"
 #include <stddef.h> /* offsetof */
 #include <link.h>   /* Elf_Symndx */
 

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1479,7 +1479,7 @@ resolve_ifunc(app_pc resolver_pc)
      * auxvector/hwcap bits. */
     addr = ((ifunc_resolver)resolver_pc)(0, glibc_riscv_hwprobe, NULL);
 #    else
-    /* TODO i#7392: glibc passes hwcap to ifunc resolvers on AArch32, and
+    /* TODO i#7392: glibc 2.41 passes hwcap to ifunc resolvers on AArch32, and
      * hwcap and __ifunc_arg_t structure to ifunc resolvers on AArch64.
      */
     addr = ((ELF_ADDR(*)(void))resolver_pc)();

--- a/core/unix/module_elf.c
+++ b/core/unix/module_elf.c
@@ -1462,9 +1462,9 @@ glibc_riscv_hwprobe(void *pairs, uint64_t pair_count, uint64_t cpu_count, uint64
 }
 #    endif
 
-/* TODO: dynamic loaders from different libc versions may provide different
- * arguments for the ifunc resolver. We may mimic the exact behavior with its
- * version obtained from the dynamic loader.
+/* TODO i#7392: dynamic loaders from different libc versions may provide
+ * different arguments for the ifunc resolver. We may mimic the exact behavior
+ * with its version obtained from the dynamic loader.
  */
 static ELF_ADDR
 resolve_ifunc(app_pc resolver_pc)
@@ -1479,9 +1479,8 @@ resolve_ifunc(app_pc resolver_pc)
      * auxvector/hwcap bits. */
     addr = ((ifunc_resolver)resolver_pc)(0, glibc_riscv_hwprobe, NULL);
 #    else
-    /* FIXME i#1551: glibc passes hwcap to ifunc resolvers on AArch32
-     * FIXME i#1569: glibc passes hwcap and __ifunc_arg_t structure to ifunc
-     * resolvers on AArch64.
+    /* TODO i#7392: glibc passes hwcap to ifunc resolvers on AArch32, and
+     * hwcap and __ifunc_arg_t structure to ifunc resolvers on AArch64.
      */
     addr = ((ELF_ADDR(*)(void))resolver_pc)();
 #    endif


### PR DESCRIPTION
Our private loader invokes ifunc resolvers with no arguments. Although it's correct on x86-32 and x86-64, this doesn't match glibc loader's behaviour on AArchxx and riscv64.

On riscv64, resolvers will take the garbage in register. With a newer glibc version where a pointer to `__riscv_hwprobe()` was introduced to riscv64 ifunc ABI, the resolver may invoke the garbage as the hwprobe function, breaking clients depending on libc.

Let's mimic the bahaviour of glibc's dynamic loader to keep our private loader compatible with newer glibc on riscv64.

Issue: #3544, #7392