### PR TITLE
Update style guide to avoid FIXME

### DIFF
--- a/api/docs/code_style.dox
+++ b/api/docs/code_style.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -356,10 +356,12 @@ Include the issue number using the syntax `i#<number>`.  For example (ignore lea
   */
  \endverbatim
 
--# Use `FIXME` or `TODO` in comments to indicate missing features that are required and not just optimizations or optional improvements (use `XXX` for those).
+-# Use `TODO` in comments to indicate missing features that are required and not just optimizations or optional improvements (use `XXX` for those).
+(Avoid `FIXME` in new comments as its connotations are too negative and too easily
+mis-interpreted in code audits.)
 Include the issue number using the syntax `i#<number>`.  For example (ignore leading dots -- only there to work around GitHub markdown problems with leading spaces in literal blocks in list entries):
  \verbatim
- /* FIXME i#999: we do not yet handle a corner case where ...
+ /* TODO i#999: we do not yet handle a corner case where ...
   */
  \endverbatim
 


### PR DESCRIPTION
Updates the style guide for comments to avoid `FIXME` as its connotations are too negative and too easily mis-interpreted in code audits.