### PR TITLE
i#7344: Install gh on Arm Runners and check if format checks are disabled for ci-aarchxx.

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -86,11 +86,6 @@ jobs:
       - name: Fetch master
         run: git fetch --no-tags --depth=1 origin master
 
-      - name: Create build directory
-        run: |
-          pwd
-          mkdir build
-
       - name: Create build environment
         run: |
           sudo apt-get update && \
@@ -117,6 +112,13 @@ jobs:
             && sudo apt update \
             && sudo apt install gh -y
 
+      - name: Check if format checks are disabled
+        id: are_format_checks_disabled
+        uses: ./.github/actions/are-format-checks-disabled
+
+      - name: Create build directory
+        run: mkdir build
+
       - name: Set ptrace_scope to 0
         run: |
           echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
@@ -133,16 +135,14 @@ jobs:
 
       - name: Run Suite
         working-directory: build
-        run: |
-          pwd
-          ../suite/runsuite_wrapper.pl travis
+        run: ../suite/runsuite_wrapper.pl travis
         env:
           CI_BRANCH: ${{ github.ref }}
           DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
         if: ${{ matrix.sve == false || matrix.sve_length == '' }}
 
       - name: Run Suite with sve vector length ${{ matrix.sve_length }}
-        working-directory: ${{ github.workspace }}
+        working-directory: build
         run: ../tools/run_with_vector_length.py ${{ matrix.sve_length }} ../suite/runsuite_wrapper.pl travis
         env:
           CI_BRANCH: ${{ github.ref }}

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -95,7 +95,6 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             build-essential \
             doxygen \
-            gh \
             git \
             libunwind-dev \
             libc6-dev \
@@ -104,6 +103,17 @@ jobs:
             python3 \
             vera++ \
             zlib1g-dev
+
+      - name: Install gh
+        run: |
+          (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+            && sudo mkdir -p -m 755 /etc/apt/keyrings \
+            && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+            && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+            && sudo apt update \
+            && sudo apt install gh -y
 
       - name: Set ptrace_scope to 0
         run: |

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -129,13 +129,16 @@ jobs:
         with:
           cmakeVersion: '3.26.4'
 
-      # TODO i#7344: Check if we should skip clang format checks and vera tests
-      # after gh api is installed.
+      - name: Check if format checks are disabled
+        id: are_format_checks_disabled
+        uses: ./.github/actions/are-format-checks-disabled
+
       - name: Run Suite
         working-directory: build
         run: ../suite/runsuite_wrapper.pl travis
         env:
           CI_BRANCH: ${{ github.ref }}
+          DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
         if: ${{ matrix.sve == false || matrix.sve_length == '' }}
 
       - name: Run Suite with sve vector length ${{ matrix.sve_length }}

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -149,10 +149,6 @@ jobs:
           DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
         if: ${{ matrix.sve == true && matrix.sve_length != ''}}
 
-      - name: Setup tmate session
-        if: failure()
-        uses: mxschmitt/action-tmate@v3
-
   send-failure-notification:
       uses: ./.github/workflows/failure-notification.yml
       needs: [aarch64-precommit]

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -95,6 +95,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             build-essential \
             doxygen \
+            gh \
             git \
             libunwind-dev \
             libc6-dev \

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -87,7 +87,9 @@ jobs:
         run: git fetch --no-tags --depth=1 origin master
 
       - name: Create build directory
-        run: mkdir build
+        run: |
+          pwd
+          mkdir build
 
       - name: Create build environment
         run: |
@@ -129,13 +131,11 @@ jobs:
         with:
           cmakeVersion: '3.26.4'
 
-      - name: Check if format checks are disabled
-        id: are_format_checks_disabled
-        uses: ./.github/actions/are-format-checks-disabled
-
       - name: Run Suite
-        working-directory: ${{ github.workspace }}
-        run: ../suite/runsuite_wrapper.pl travis
+        working-directory: build
+        run: |
+          pwd
+          ../suite/runsuite_wrapper.pl travis
         env:
           CI_BRANCH: ${{ github.ref }}
           DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}

--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -134,7 +134,7 @@ jobs:
         uses: ./.github/actions/are-format-checks-disabled
 
       - name: Run Suite
-        working-directory: build
+        working-directory: ${{ github.workspace }}
         run: ../suite/runsuite_wrapper.pl travis
         env:
           CI_BRANCH: ${{ github.ref }}
@@ -142,11 +142,16 @@ jobs:
         if: ${{ matrix.sve == false || matrix.sve_length == '' }}
 
       - name: Run Suite with sve vector length ${{ matrix.sve_length }}
-        working-directory: build
+        working-directory: ${{ github.workspace }}
         run: ../tools/run_with_vector_length.py ${{ matrix.sve_length }} ../suite/runsuite_wrapper.pl travis
         env:
           CI_BRANCH: ${{ github.ref }}
+          DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
         if: ${{ matrix.sve == true && matrix.sve_length != ''}}
+
+      - name: Setup tmate session
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
 
   send-failure-notification:
       uses: ./.github/workflows/failure-notification.yml


### PR DESCRIPTION
Install gh on Arm Runners to support "gh api" for #7344. Add a step to check if format checks are disabled for Aarch64.

The command to install gh on Linux is listed here: https://github.com/cli/cli/blob/trunk/docs/install_linux.md.

Fixes: #7344 