### PR TITLE
i#7344: Do not skip vera tests when format checks are disabled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1968,25 +1968,22 @@ endif (BUILD_DOCS)
 
 ###########################################################################
 # Style checks:
-if (DISABLE_FORMAT_CHECKS)
-  message(STATUS "vera++ code style checks are disabled")
-else ()
-  option(VERA_ERROR "Turn vera++ checks into error (default)" ON)
 
-  find_package(vera++ QUIET)
-  if (vera++_FOUND)
-    message(STATUS "Using vera++ for code style checks")
-    include(${VERA++_USE_FILE})
-    # We use our own modified copy in order to pass --error and for
-    # regex exclusions with vera++ 1.2.1.
-    include(third_party/vera++/use_vera++.cmake)
-    add_vera_targets_for_dynamorio(*.h *.c *.cpp
-      RECURSE
-      EXCLUSION "${PROJECT_SOURCE_DIR}/make/style_checks/exclude"
-      ROOT "${PROJECT_SOURCE_DIR}/make/style_checks")
-  else ()
-    message(STATUS "WARNING: vera++ not found: disabling code style checks")
-  endif ()
+option(VERA_ERROR "Turn vera++ checks into error (default)" ON)
+
+find_package(vera++ QUIET)
+if (vera++_FOUND)
+  message(STATUS "Using vera++ for code style checks")
+  include(${VERA++_USE_FILE})
+  # We use our own modified copy in order to pass --error and for
+  # regex exclusions with vera++ 1.2.1.
+  include(third_party/vera++/use_vera++.cmake)
+  add_vera_targets_for_dynamorio(*.h *.c *.cpp
+    RECURSE
+    EXCLUSION "${PROJECT_SOURCE_DIR}/make/style_checks/exclude"
+    ROOT "${PROJECT_SOURCE_DIR}/make/style_checks")
+else ()
+  message(STATUS "WARNING: vera++ not found: disabling code style checks")
 endif ()
 
 ###########################################################################

--- a/suite/runsuite.cmake
+++ b/suite/runsuite.cmake
@@ -302,6 +302,8 @@ else ()
   # Check for tabs other than on the revision lines.
   # The clang-format check will now find these in C files, but not non-C files.
   string(REGEX REPLACE "\n(---|\\+\\+\\+)[^\n]*\t" "" diff_notabs "${diff_contents}")
+  # Allow tabs to be removed from existing lines.
+  string(REGEX REPLACE "\n-[^\n]*\t" "" diff_notabs "${diff_notabs}")
   string(REGEX MATCH "\t" match "${diff_notabs}")
   if (NOT "${match}" STREQUAL "")
     string(REGEX MATCH "\n[^\n]*\t[^\n]*" match "${diff_notabs}")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6282,15 +6282,11 @@ if (NOT ANDROID)
   mark_execstack("${TestMemProtChg}")
 endif ()
 
-if (DISABLE_FORMAT_CHECKS)
-  message(STATUS "Style checks are disabled")
-else ()
-  if (vera++_FOUND)
-    file(READ "${PROJECT_SOURCE_DIR}/make/style_checks/style_test.templatex" vera_regex)
-    add_test(vera ${VERA++_EXECUTABLE} --root "${PROJECT_SOURCE_DIR}/make/style_checks"
-      --error "${PROJECT_SOURCE_DIR}/make/style_checks/style_test.c")
-    set_tests_properties(vera PROPERTIES PASS_REGULAR_EXPRESSION "${vera_regex}")
-  endif ()
+if (vera++_FOUND)
+  file(READ "${PROJECT_SOURCE_DIR}/make/style_checks/style_test.templatex" vera_regex)
+  add_test(vera ${VERA++_EXECUTABLE} --root "${PROJECT_SOURCE_DIR}/make/style_checks"
+    --error "${PROJECT_SOURCE_DIR}/make/style_checks/style_test.c")
+  set_tests_properties(vera PROPERTIES PASS_REGULAR_EXPRESSION "${vera_regex}")
 endif ()
 
 ###########################################################################


### PR DESCRIPTION
#7361 disables vera checks when DISABLE_FORMAT_CHECKS is present in commit messages. 

It led to #7330 breaking subsequent tests due to failed style checks. 
Files should be added to make/style_checks/exclude to skip vera tests until formats are fixed. Revert the changes to skip vera checks when DISABLE_FORMAT_CHECKS is set.

Also change suite/runsuite.cmake so that tabs check allow tabs to be removed from existing files, i.e. files merged with DISABLE_FORMAT_CHECKS set.

Tests:
Make a change with a tab and ensure the check still catches it:
```
$ ./suite/runsuite_wrapper.pl automated_ci 64_only require_format 
Forking child for stdout tee
Parent tee-ing child stdout...
Running ctest --output-on-failure -VV -S "/usr/local/google/home/kyluk/format-checks/dynamorio/suite/runsuite.cmake,automated_ci;64_only;require_format"
* Extra verbosity turned on
Reading Script: /usr/local/google/home/kyluk/format-checks/dynamorio/suite/runsuite.cmake,automated_ci;64_only;require_format
ldd --version: ldd (Debian GLIBC 2.40-6+gl0) 2.40
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.

-- Found Python3: /usr/bin/python3 (found version "3.12.8") found components: Interpreter
clang-format check passed
-- test adding tab
CMake Error at /usr/local/google/home/kyluk/format-checks/dynamorio/suite/runsuite.cmake:311 (message):
  ERROR: diff contains tabs:

  +	message(STATUS "test adding tab")


Finished running ctest --output-on-failure -VV -S "/usr/local/google/home/kyluk/format-checks/dynamorio/suite/runsuite.cmake,automated_ci;64_only;require_format"

====> FAILURE in runsuite script itself <====
CMake Error at /usr/local/google/home/kyluk/format-checks/dynamorio/suite/runsuite.cmake:311 (message):

====> FAILURE in diff pre-commit checks <====
  ERROR: diff contains tabs:

  +	message(STATUS "test adding tab")


Finished running ctest --output-on-failure -VV -S "/usr/local/google/home/kyluk/format-checks/dynamorio/suite/runsuite.cmake,automated_ci;64_only;require_format"
```

Issue: #7344 