### PR TITLE
i#7355 per-sys-stats: Add per-syscall-number whether-switch latency histograms

### DIFF
--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -346,10 +346,15 @@ public:
     {
         return "";
     }
+    void
+    set_last_timestamp(uint64_t timestamp)
+    {
+        last_timestamp_ = timestamp;
+    }
     uint64_t
     get_last_timestamp() const override
     {
-        return 0;
+        return last_timestamp_;
     }
     uint64_t
     get_first_timestamp() const override
@@ -438,6 +443,7 @@ private:
     int shard_ = 0;
     int64_t tid_ = 0;
     int64_t workload_id_ = 0;
+    int64_t last_timestamp_ = 0;
     // To let a test set just the tid and get a shard index for free.
     std::unordered_map<int64_t, int> tid2shard_;
 };

--- a/clients/drcachesim/tests/core_serial.templatex
+++ b/clients/drcachesim/tests/core_serial.templatex
@@ -39,6 +39,10 @@ Total counts:
        50000..  100000     5
   Cores per thread:
            1..       2     9
+  Latencies for syscalls that incurred a switch:
+.*
+  Latencies for syscalls that did not incur a switch:
+.*
 Core #0 counts:
 .*
 Core #1 counts:

--- a/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
+++ b/clients/drcachesim/tests/schedule_stats_nopreempt.templatex
@@ -39,6 +39,10 @@ Total counts:
        50000..  100000     4
   Cores per thread:
            1..       2     9
+  Latencies for syscalls that incurred a switch:
+.*
+  Latencies for syscalls that did not incur a switch:
+.*
 Core #0 counts:
            . threads: W0.T872.*
       *[0-9]* instructions

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2024 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2025 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -92,18 +92,31 @@ private:
     uint64_t global_time_ = 1;
 };
 
+class mock_stream_t : public default_memtrace_stream_t {
+public:
+    uint64_t
+    get_version() const override
+    {
+        return TRACE_ENTRY_VERSION;
+    }
+
+    memtrace_stream_t *
+    get_input_interface() const override
+    {
+        return const_cast<mock_stream_t *>(this);
+    }
+};
+
 // Bypasses the analyzer and scheduler for a controlled test sequence.
 // Alternates the per-core memref vectors in lockstep.
 static schedule_stats_t::counters_t
 run_schedule_stats(const std::vector<std::vector<memref_t>> &memrefs)
 {
-    // At verbosity 2+ we'd need to subclass default_memtrace_stream_t
-    // and provide a non-null get_input_interface() (point at "this").
     mock_schedule_stats_t tool(/*print_every=*/1, /*verbosity=*/1);
     struct per_core_t {
         void *worker_data;
         void *shard_data;
-        default_memtrace_stream_t stream;
+        mock_stream_t stream;
         bool finished = false;
         size_t memref_idx = 0;
     };
@@ -124,6 +137,10 @@ run_schedule_stats(const std::vector<std::vector<memref_t>> &memrefs)
             per_core[cpu].stream.set_tid(memref.instr.tid);
             per_core[cpu].stream.set_workload_id(memref.instr.pid);
             per_core[cpu].stream.set_output_cpuid(cpu);
+            if (memref.marker.type == TRACE_TYPE_MARKER &&
+                memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
+                per_core[cpu].stream.set_last_timestamp(memref.marker.marker_value);
+            }
             bool res = tool.parallel_shard_memref(per_core[cpu].shard_data, memref);
             assert(res);
             ++per_core[cpu].memref_idx;
@@ -324,12 +341,92 @@ test_cpu_footprint()
     return true;
 }
 
+static bool
+test_syscall_latencies()
+{
+    static constexpr int64_t TID_A = 42;
+    static constexpr int64_t TID_B = 142;
+    static constexpr int64_t TID_C = 242;
+    static constexpr uintptr_t SYSNUM_X = 12;
+    static constexpr uintptr_t SYSNUM_Y = 167;
+    std::vector<std::vector<memref_t>> memrefs = {
+        {
+            gen_instr(TID_A),
+            // Involuntary switch.
+            gen_instr(TID_B),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1100),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1600),
+            // Voluntary switch, on non-maybe-blocking-marked syscall.
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2100),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_Y),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_C),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2300), // Direct switch.
+            gen_instr(TID_C),
+            // No switch: latency too small.
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2500),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2599),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3100),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_Y),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_A),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3300),
+            // Direct switch requested but failed.
+            gen_instr(TID_C),
+            gen_exit(TID_C),
+            gen_exit(TID_A),
+        },
+        {
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3400),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 4400),
+            // Voluntary switch, on non-maybe-blocking-marked syscall.
+            gen_instr(TID_B),
+            gen_exit(TID_B),
+        },
+    };
+    auto result = run_schedule_stats(memrefs);
+    auto it_x_switch = result.sysnum_switch_latency.find(SYSNUM_X);
+    assert(it_x_switch != result.sysnum_switch_latency.end());
+    std::string hist_x_switch = it_x_switch->second->to_string();
+    std::cerr << "Sysnum switch latency for " << SYSNUM_X << ":\n"
+              << hist_x_switch << "\n";
+    assert(hist_x_switch ==
+           "         500..     505     1\n        1000..    1005     1\n");
+    auto it_x_noswitch = result.sysnum_noswitch_latency.find(SYSNUM_X);
+    assert(it_x_noswitch != result.sysnum_switch_latency.end());
+    std::string hist_x_noswitch = it_x_noswitch->second->to_string();
+    std::cerr << "Sysnum noswitch latency for " << SYSNUM_X << ":\n"
+              << hist_x_noswitch << "\n";
+    assert(hist_x_noswitch == "          95..     100     1\n");
+    auto it_y_switch = result.sysnum_switch_latency.find(SYSNUM_Y);
+    assert(it_y_switch != result.sysnum_switch_latency.end());
+    std::string hist_y_switch = it_y_switch->second->to_string();
+    std::cerr << "Sysnum switch latency for " << SYSNUM_Y << ":\n"
+              << hist_y_switch << "\n";
+    assert(hist_y_switch == "         200..     205     1\n");
+    auto it_y_noswitch = result.sysnum_noswitch_latency.find(SYSNUM_Y);
+    assert(it_y_noswitch != result.sysnum_noswitch_latency.end());
+    std::string hist_y_noswitch = it_y_noswitch->second->to_string();
+    std::cerr << "Sysnum noswitch latency for " << SYSNUM_Y << ":\n"
+              << hist_y_noswitch << "\n";
+    assert(hist_y_noswitch == "         200..     205     1\n");
+    return true;
+}
+
 } // namespace
 
 int
 test_main(int argc, const char *argv[])
 {
-    if (test_basic_stats() && test_idle() && test_cpu_footprint()) {
+    if (test_basic_stats() && test_idle() && test_cpu_footprint() &&
+        test_syscall_latencies()) {
         std::cerr << "schedule_stats_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -99,7 +99,7 @@ schedule_stats_t::process_memref(const memref_t &memref)
     per_shard_t *per_shard;
     const auto &lookup = shard_map_.find(serial_stream_->get_output_cpuid());
     if (lookup == shard_map_.end()) {
-        per_shard = new per_shard_t;
+        per_shard = new per_shard_t(this);
         per_shard->stream = serial_stream_;
         per_shard->core = serial_stream_->get_output_cpuid();
         per_shard->filetype = static_cast<intptr_t>(serial_stream_->get_filetype());
@@ -124,7 +124,7 @@ void *
 schedule_stats_t::parallel_shard_init_stream(int shard_index, void *worker_data,
                                              memtrace_stream_t *stream)
 {
-    auto per_shard = new per_shard_t;
+    auto per_shard = new per_shard_t(this);
     std::lock_guard<std::mutex> guard(shard_map_mutex_);
     per_shard->stream = stream;
     per_shard->core = stream->get_output_cpuid();
@@ -225,6 +225,31 @@ schedule_stats_t::record_context_switch(per_shard_t *shard, int64_t workload_id,
             ++shard->counters.voluntary_switches;
         if (shard->direct_switch_target == tid)
             ++shard->counters.direct_switches;
+        if (shard->last_syscall_number >= 0) {
+            if (shard->stream->get_version() < TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS) {
+                // Legacy versions do not have the timestamps to compute latencies.
+            } else {
+                assert(shard->pre_syscall_timestamp > 0);
+                // We don't have the post-syscall timestamp for thread exit.
+                if (shard->post_syscall_timestamp > 0) {
+                    histogram_interface_t *hist_ptr = find_or_add_histogram(
+                        shard->counters.sysnum_switch_latency, shard->last_syscall_number,
+                        kSysnumLatencyBinSize);
+                    int64_t latency =
+                        shard->post_syscall_timestamp - shard->pre_syscall_timestamp;
+                    if (knob_verbose_ >= 3) {
+                        std::cerr << "sysnum " << shard->last_syscall_number
+                                  << " switch latency " << shard->post_syscall_timestamp
+                                  << " - " << shard->pre_syscall_timestamp << " => "
+                                  << latency << "\n";
+                    }
+                    hist_ptr->add(latency);
+                }
+            }
+            shard->last_syscall_number = -1;
+            shard->pre_syscall_timestamp = 0;
+            shard->post_syscall_timestamp = 0;
+        }
         uint64_t instr_delta = shard->counters.instrs - shard->switch_start_instrs;
         shard->counters.instrs_per_switch->add(instr_delta);
         shard->switch_start_instrs = shard->counters.instrs;
@@ -359,6 +384,27 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
             shard->cur_segment_instrs = 0;
         }
         shard->direct_switch_target = INVALID_THREAD_ID;
+        if (shard->last_syscall_number >= 0 && !shard->stream->is_record_kernel()) {
+            if (shard->stream->get_version() < TRACE_ENTRY_VERSION_FREQUENT_TIMESTAMPS) {
+                // Legacy versions do not have the timestamps to compute latencies.
+            } else {
+                assert(shard->pre_syscall_timestamp > 0);
+                assert(shard->post_syscall_timestamp > 0);
+                histogram_interface_t *hist_ptr = find_or_add_histogram(
+                    shard->counters.sysnum_noswitch_latency, shard->last_syscall_number,
+                    kSysnumLatencyBinSize);
+                int64_t latency =
+                    shard->post_syscall_timestamp - shard->pre_syscall_timestamp;
+                if (knob_verbose_ >= 3) {
+                    std::cerr << "sysnum " << shard->last_syscall_number
+                              << " noswitch latency " << latency << "\n";
+                }
+                hist_ptr->add(latency);
+            }
+            shard->last_syscall_number = -1;
+            shard->pre_syscall_timestamp = 0;
+            shard->post_syscall_timestamp = 0;
+        }
         shard->saw_syscall = false;
         shard->saw_exit = false;
     }
@@ -368,6 +414,7 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL) {
             ++shard->counters.syscalls;
             shard->saw_syscall = true;
+            shard->last_syscall_number = memref.marker.marker_value;
         } else if (memref.marker.marker_type ==
                    TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL) {
             ++shard->counters.maybe_blocking_syscalls;
@@ -377,6 +424,23 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
             shard->direct_switch_target = memref.marker.marker_value;
         } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_FILETYPE) {
             shard->filetype = static_cast<intptr_t>(memref.marker.marker_value);
+        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
+            if (shard->last_syscall_number < 0) {
+                // We use get_input_interface() to get the original timestamp
+                // instead of the scheduler-normalized one.
+                // Unfortunately, we have no way to get the original for
+                // core-sharded-on-disk traces, and the normalized ones are always
+                // identical for pre vs post syscall due to not seeing any idle
+                // records yet.  So the latencies are not useful for such traces;
+                // but the syscall switch list is still useful.
+                shard->pre_syscall_timestamp =
+                    shard->stream->get_input_interface()->get_last_timestamp();
+            } else if (shard->pre_syscall_timestamp > 0) {
+                // We use get_input_interface() to get the original timestamp
+                // instead of the scheduler-normalized one.
+                shard->post_syscall_timestamp =
+                    shard->stream->get_input_interface()->get_last_timestamp();
+            }
         }
     } else if (memref.exit.type == TRACE_TYPE_THREAD_EXIT)
         shard->saw_exit = true;
@@ -484,6 +548,16 @@ schedule_stats_t::print_counters(const counters_t &counters)
         std::cerr << "  Cores per thread:\n";
         counters.cores_per_thread->print();
     }
+    std::cerr << "  Latencies for syscalls that incurred a switch:\n";
+    for (const auto &it : counters.sysnum_switch_latency) {
+        std::cerr << "    #" << it.first << "\n";
+        it.second->print();
+    }
+    std::cerr << "  Latencies for syscalls that did not incur a switch:\n";
+    for (const auto &it : counters.sysnum_noswitch_latency) {
+        std::cerr << "    #" << it.first << "\n";
+        it.second->print();
+    }
 }
 
 void
@@ -544,7 +618,7 @@ schedule_stats_t::print_results()
 {
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << "Total counts:\n";
-    counters_t total;
+    counters_t total(this);
     aggregate_results(total);
     std::cerr << std::setw(12) << shard_map_.size() << " cores\n";
     print_counters(total);
@@ -562,7 +636,7 @@ schedule_stats_t::print_results()
 schedule_stats_t::counters_t
 schedule_stats_t::get_total_counts()
 {
-    counters_t total;
+    counters_t total(this);
     aggregate_results(total);
     return total;
 }

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -188,15 +188,15 @@ public:
     };
 
     struct counters_t {
-        counters_t()
+        explicit counters_t(schedule_stats_t *analyzer)
+            : analyzer(analyzer)
         {
             static constexpr uint64_t kSwitchBinSize = 50000;
             static constexpr uint64_t kCoresBinSize = 1;
-            instrs_per_switch =
-                std::unique_ptr<histogram_interface_t>(new histogram_t(kSwitchBinSize));
-            cores_per_thread =
-                std::unique_ptr<histogram_interface_t>(new histogram_t(kCoresBinSize));
+            instrs_per_switch = analyzer->create_histogram(kSwitchBinSize);
+            cores_per_thread = analyzer->create_histogram(kCoresBinSize);
         }
+
         counters_t &
         operator+=(const counters_t &rhs)
         {
@@ -232,8 +232,19 @@ public:
             // We do not track this incrementally but for completeness we include
             // aggregation code for it.
             cores_per_thread->merge(rhs.cores_per_thread.get());
+            for (const auto &it : rhs.sysnum_switch_latency) {
+                histogram_interface_t *hist_ptr = analyzer->find_or_add_histogram(
+                    sysnum_switch_latency, it.first, kSysnumLatencyBinSize);
+                hist_ptr->merge(it.second.get());
+            }
+            for (const auto &it : rhs.sysnum_noswitch_latency) {
+                histogram_interface_t *hist_ptr = analyzer->find_or_add_histogram(
+                    sysnum_noswitch_latency, it.first, kSysnumLatencyBinSize);
+                hist_ptr->merge(it.second.get());
+            }
             return *this;
         }
+        schedule_stats_t *analyzer;
         // Statistics provided by scheduler.
         // XXX: Should we change all of these to uint64_t? Never negative: but signed
         // ints are generally recommended as better for the compiler.
@@ -275,6 +286,13 @@ public:
         // We still store it inside counters_t as this structure is assumed in
         // several places to hold all aggregated statistics.
         std::unique_ptr<histogram_interface_t> cores_per_thread;
+        // Breakdown of system calls by number (key of map) and latency (in
+        // microseconds; stored as a histogram) and whether a context switch was
+        // incurred (separate map for each).
+        std::unordered_map<int, std::unique_ptr<histogram_interface_t>>
+            sysnum_switch_latency;
+        std::unordered_map<int, std::unique_ptr<histogram_interface_t>>
+            sysnum_noswitch_latency;
     };
 
     counters_t
@@ -288,8 +306,13 @@ protected:
     static constexpr char THREAD_LETTER_SUBSEQUENT_START = 'a';
     static constexpr char WAIT_SYMBOL = '-';
     static constexpr char IDLE_SYMBOL = '_';
+    static constexpr uint64_t kSysnumLatencyBinSize = 5;
 
     struct per_shard_t {
+        per_shard_t(schedule_stats_t *analyzer)
+            : counters(analyzer)
+        {
+        }
         std::string error;
         memtrace_stream_t *stream = nullptr;
         int64_t core = 0; // We target core-sharded.
@@ -298,6 +321,9 @@ protected:
         int64_t prev_tid = INVALID_THREAD_ID;
         // These are cleared when an instruction is seen.
         bool saw_syscall = false;
+        int last_syscall_number = -1;
+        uint64_t pre_syscall_timestamp = 0;
+        uint64_t post_syscall_timestamp = 0;
         memref_tid_t direct_switch_target = INVALID_THREAD_ID;
         bool saw_exit = false;
         // A representation of the thread interleavings.
@@ -313,6 +339,26 @@ protected:
         intptr_t filetype = 0;
         uint64_t switch_start_instrs = 0;
     };
+
+    virtual std::unique_ptr<histogram_interface_t>
+    create_histogram(uint64_t bin_size = 1)
+    {
+        return std::unique_ptr<histogram_interface_t>(new histogram_t(bin_size));
+    }
+
+    histogram_interface_t *
+    find_or_add_histogram(
+        std::unordered_map<int, std::unique_ptr<histogram_interface_t>> &map, int key,
+        int bin_size = 1)
+    {
+        auto find_it = map.find(key);
+        if (find_it != map.end())
+            return find_it->second.get();
+        auto new_hist = create_histogram(bin_size);
+        histogram_interface_t *hist_ptr = new_hist.get();
+        map.insert({ key, std::move(new_hist) });
+        return hist_ptr;
+    }
 
     void
     print_percentage(double numerator, double denominator, const std::string &label);


### PR DESCRIPTION
Augments the schedule_stats drmemtrace tool to keep two histograms for each system call number: one for latencies of system calls causing a context switch, and one for latencies not switching.  Unfortunately the latencies are all 0 for core-sharded-on-disk traces; we live with that for now.

Generalizes the histogram support through virtual methods create_histogram() and find_or_add_histogram() to make it easier to use different histograms in subclasses with all the new histograms being added here.

Adds a unit test and augments top-level test expected output.

Fixes #7355