### PR TITLE
i#4103 clang-tidy: Fix clang-tidy warnings

### DIFF
--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -343,7 +343,7 @@ protected:
     };
 
     virtual std::unique_ptr<histogram_interface_t>
-    create_histogram(uint64_t bin_size = 1)
+    create_histogram(uint64_t bin_size)
     {
         return std::unique_ptr<histogram_interface_t>(new histogram_t(bin_size));
     }

--- a/core/annotations.c
+++ b/core/annotations.c
@@ -40,6 +40,8 @@
 
 #ifdef ANNOTATIONS /* around whole file */
 
+#    include "annotations_api.h"
+
 #    if !(defined(WINDOWS) && defined(X64))
 #        include "valgrind.h"
 #        include "memcheck.h"
@@ -227,7 +229,7 @@ valgrind_running_on_valgrind(dr_vg_client_request_t *request);
 #    endif
 
 static bool
-is_annotation_tag(dcontext_t *dcontext, DR_PARAM_INOUT app_pc *start_pc, instr_t *scratch,
+is_annotation_tag(dcontext_t *dcontext, DR_PARAM_INOUT app_pc *cur_pc, instr_t *scratch,
                   DR_PARAM_OUT const char **name);
 
 static void


### PR DESCRIPTION
Fixes 3 clang-tidy warnings:
+ Removes default parameter value on virtual function schedule_stats_t::create_histogram()
+ Fixes inconsistent parameter name in is_annotation_tag()
+ Adds missing annotations_api.h header

Issue: #4103, #7355