### PR TITLE
i#7363: fix exclusive mode cache policy

### DIFF
--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -671,6 +671,11 @@ cache_simulator_t::get_cache_metric(metric_name_t metric, unsigned level, unsign
 {
     caching_device_t *curr_cache;
 
+    if (level < 1) {
+        std::cerr << "Cache levels start at 1.\n";
+        return STATS_ERROR_WRONG_CACHE_LEVEL;
+    }
+
     if (core >= knobs_.num_cores) {
         return STATS_ERROR_WRONG_CORE_NUMBER;
     }

--- a/clients/drcachesim/simulator/caching_device.cpp
+++ b/clients/drcachesim/simulator/caching_device.cpp
@@ -242,9 +242,9 @@ caching_device_t::request(const memref_t &memref_in)
             // by a child cache.  So for a "normal" miss like this, only need
             // to update the stats to make sure the miss is counted.
             if (is_exclusive()) {
-              caching_device_block_t invalid_block;  // Dummy for stats update.
-              record_access_stats(memref, /*hit=*/false, &invalid_block);
-              continue;
+                caching_device_block_t invalid_block; // Dummy for stats update.
+                record_access_stats(memref, /*hit=*/false, &invalid_block);
+                continue;
             }
 
             way = replace_which_way(block_idx);

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -560,14 +560,14 @@ LLC {
     // single cache.  So this means HITS are summed, but only LLC misses count.
     auto get_hits = [&](void) {
         int64_t l1_hits = cache_sim.get_cache_metric(metric_name_t::HITS, /*level=*/1,
-                                                  /*core=*/0, cache_split_t::DATA);
+                                                     /*core=*/0, cache_split_t::DATA);
         int64_t l2_hits = cache_sim.get_cache_metric(metric_name_t::HITS, /*level=*/2,
-                                                  /*core=*/0, cache_split_t::DATA);
+                                                     /*core=*/0, cache_split_t::DATA);
         return l1_hits + l2_hits;
     };
     auto get_misses = [&](void) {
         int64_t l2_misses = cache_sim.get_cache_metric(metric_name_t::MISSES, /*level=*/2,
-                                                    /*core=*/0, cache_split_t::DATA);
+                                                       /*core=*/0, cache_split_t::DATA);
         return l2_misses;
     };
 
@@ -678,9 +678,9 @@ L1 {
     // single cache.  So this means HITS are summed, but only LLC misses count.
     auto get_hits_exc = [&](void) {
         int64_t l1_hits = cache_sim_exc.get_cache_metric(metric_name_t::HITS, /*level=*/1,
-                                                      /*core=*/0, cache_split_t::DATA);
+                                                         /*core=*/0, cache_split_t::DATA);
         int64_t l2_hits = cache_sim_exc.get_cache_metric(metric_name_t::HITS, /*level=*/2,
-                                                      /*core=*/0, cache_split_t::DATA);
+                                                         /*core=*/0, cache_split_t::DATA);
         return l1_hits + l2_hits;
     };
     auto get_misses_exc = [&](void) {
@@ -692,8 +692,9 @@ L1 {
 
     // Similar to the above, but for the 1-level 8-way cache.
     auto get_hits_8way = [&](void) {
-        int64_t l1_hits = cache_sim_8way.get_cache_metric(metric_name_t::HITS, /*level=*/1,
-                                                       /*core=*/0, cache_split_t::DATA);
+        int64_t l1_hits =
+            cache_sim_8way.get_cache_metric(metric_name_t::HITS, /*level=*/1,
+                                            /*core=*/0, cache_split_t::DATA);
         return l1_hits;
     };
     auto get_misses_8way = [&](void) {


### PR DESCRIPTION
Fixes the problem of exclusive mode caches not properly updating state related to cache policies.

The problem was exposed by recent updates to the drcachesim cache policy logic that made policy updates much more explicit.  Several situations were identified by inspection in which exclusive caches did not update the policy counters properly.

This update fixes the problem, and adds two new tests to exercise the exclusive cache policy interactions.  Also included is a minor error check in get_cache_metric() to help users avoid wasting hours debugging phantom cache problems because they incorrectly expect cache levels to start at zero.

Fixes: #7363