### PR TITLE
i#7401: Ensure unique pid,tid in drmemtrace schedules

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -132,12 +132,19 @@ changes:
  - Added new fields elf_path and elf_path_size to dr_memory_dump_spec_t. When
    dr_create_memory_dump() returns true and elf_path is not NULL, elf_path will be
    written with the path to the memory dump file.
+
+The changes between version \DR_VERSION and 11.3.0 include the following minor
+compatibility changes:
+
  - Added a separate cache replacement policy object to `caching_device_t`. `init` now
    takes an `std::unique_ptr<cache_replacement_policy_t>` that defines the replacement
    policy. It can be created manually or by using `create_cache_replacement_policy`.
    Removed the subclasses `cache_lru_t`, `cache_fifo_t`, `tlb_lfu_t`, `tlb_plru_t` that
    implemented specific cache replacement policies. Added implementations for the
    matching policies as subclasses of `cache_replacement_policy_t`.
+ - Added the workload to the top bits of the tid for multi-workload drmemtrace
+   scheduling.  The drmemtrace view tool now prints the workload and tid in
+   the form "Wn.Tmmm".
 
 Further non-compatibility-affecting changes include:
  - Changed the types of `block_size`, `total_size`, `num_blocks`, to `int64_t`

--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -67,6 +67,8 @@ enum {
     /**
      * When multiple workloads are combined in one trace, a workload ordinal is added to
      * the top (64-MEMREF_ID_WORKLOAD_SHIFT) bits of the pid and tid fields of #memref_t.
+     * We use 48 to leave some room for >32-bit identifiers (Mac has a 64-bit tid type)
+     * while still leaving plenty of room for the workload ordinal.
      */
     MEMREF_ID_WORKLOAD_SHIFT = 48,
 };
@@ -101,7 +103,7 @@ workload_from_memref_tid(memref_tid_t tid)
 static inline memref_pid_t
 pid_from_memref_pid(memref_pid_t pid)
 {
-    return pid & 0x0000ffffffffffff;
+    return pid & ((1ULL << MEMREF_ID_WORKLOAD_SHIFT) - 1);
 }
 
 /**
@@ -112,7 +114,7 @@ pid_from_memref_pid(memref_pid_t pid)
 static inline memref_tid_t
 tid_from_memref_tid(memref_tid_t tid)
 {
-    return tid & 0x0000ffffffffffff;
+    return tid & ((1ULL << MEMREF_ID_WORKLOAD_SHIFT) - 1);
 }
 
 /** A trace entry representing a data load, store, or prefetch. */

--- a/clients/drcachesim/common/memref.h
+++ b/clients/drcachesim/common/memref.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -49,8 +49,71 @@ namespace drmemtrace { /**< DrMemtrace tracing + simulation infrastructure names
 
 // On some platforms, like MacOS, a thread id is 64 bits.
 // We just make both 64 bits to cover all our bases.
-typedef int64_t memref_pid_t; /**< Process id type. */
-typedef int64_t memref_tid_t; /**< Thread id type. */
+/**
+ * Process id type.  When multiple workloads are combined in one trace, a workload ordinal
+ * is added to the top (64-MEMREF_ID_WORKLOAD_SHIFT) bits; the workload_from_memref_pid()
+ * and pid_from_memref_pid() helpers can be used to separate the values if desired.
+ */
+typedef int64_t memref_pid_t;
+/**
+ * Thread id type.  When multiple workloads are combined in one trace, a workload ordinal
+ * is added to the top (64-MEMREF_ID_WORKLOAD_SHIFT) bits; the workload_from_memref_tid()
+ * and tid_from_memref_tid() helpers can be used to separate the values if desired.
+ */
+typedef int64_t memref_tid_t;
+
+/** Constants related to tid and pid fields. */
+enum {
+    /**
+     * When multiple workloads are combined in one trace, a workload ordinal is added to
+     * the top (64-MEMREF_ID_WORKLOAD_SHIFT) bits of the pid and tid fields of #memref_t.
+     */
+    MEMREF_ID_WORKLOAD_SHIFT = 48,
+};
+
+/**
+ * When multiple workloads are combined in one trace, a workload ordinal is added to the
+ * top (64-MEMREF_ID_WORKLOAD_SHIFT) bits of the #memref_t pid field.  This function
+ * extracts the workload ordinal.
+ */
+static inline int
+workload_from_memref_pid(memref_tid_t pid)
+{
+    return pid >> MEMREF_ID_WORKLOAD_SHIFT;
+}
+
+/**
+ * When multiple workloads are combined in one trace, a workload ordinal is added to the
+ * top (64-MEMREF_ID_WORKLOAD_SHIFT) bits of the #memref_t tid field.  This function
+ * extracts the workload ordinal.
+ */
+static inline int
+workload_from_memref_tid(memref_tid_t tid)
+{
+    return tid >> MEMREF_ID_WORKLOAD_SHIFT;
+}
+
+/**
+ * When multiple workloads are combined in one trace, a workload ordinal is added to the
+ * top (64-MEMREF_ID_WORKLOAD_SHIFT) bits of the #memref_t pid field.  This function
+ * extracts just the pid.
+ */
+static inline memref_pid_t
+pid_from_memref_pid(memref_pid_t pid)
+{
+    return pid & 0x0000ffffffffffff;
+}
+
+/**
+ * When multiple workloads are combined in one trace, a workload ordinal is added to the
+ * top (64-MEMREF_ID_WORKLOAD_SHIFT) bits of the #memref_t tid field.  This function
+ * extracts just the tid.
+ */
+static inline memref_tid_t
+tid_from_memref_tid(memref_tid_t tid)
+{
+    return tid & 0x0000ffffffffffff;
+}
 
 /** A trace entry representing a data load, store, or prefetch. */
 struct _memref_data_t {

--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -247,8 +247,8 @@ public:
     /**
      * Returns a unique identifier for the current workload.  This might be an ordinal
      * from the list of active workloads, or some other identifier.  This is guaranteed
-     * to be unique among all inputs, unlike the process and thread identifiers in
-     * #memref_t. If not implemented for the current mode, -1 is returned.
+     * to be unique among all inputs. If not implemented for the current mode, -1 is
+     * returned.
      */
     virtual int64_t
     get_workload_id() const
@@ -259,8 +259,8 @@ public:
     /**
      * Returns a unique identifier for the current input trace.  This might be an ordinal
      * from the list of active inputs, or some other identifier.  This is guaranteed to
-     * be unique among all inputs, unlike the process and thread identifiers in
-     * #memref_t.  If not implemented for the current mode, -1 is returned.
+     * be unique among all inputs.  If not implemented for the current mode, -1 is
+     * returned.
      */
     virtual int64_t
     get_input_id() const

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1075,6 +1075,12 @@ typedef enum {
     OFFLINE_FILE_TYPE_KERNEL_SYSCALL_INSTR_ONLY = 0x8000,
     /**
      * Each trace shard represents one core and contains interleaved software threads.
+     * Such a trace is already scheduled, so it is run through the scheduler in a
+     * non-scheduled mode where interfaces such as get_workload_id() will not return the
+     * original separate inputs but rather the new inputs as seen by the scheduler which
+     * are a single workload with one input per core.  Use the modified #memref_t tid and
+     * pid fields with the helpers workload_from_memref_pid() and
+     * workload_from_memref_tid() to obtain the workload in this case.
      */
     OFFLINE_FILE_TYPE_CORE_SHARDED = 0x10000,
     /**

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -710,28 +710,28 @@ and the instruction fetch ordinal.
 \code
 $ $ bin64/drrun -t drmemtrace -tool view -indir drmemtrace.*.dir -sim_refs 20
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-           1           0:      31b062 <marker: version 6>
-           2           0:      31b062 <marker: filetype 0x240>
-           3           0:      31b062 <marker: cache line size 64>
-           4           0:      31b062 <marker: chunk instruction count 1024>
-           5           0:      31b062 <marker: page size 4096>
-           6           0:      31b062 <marker: timestamp 13312410768080478>
-           7           0:      31b062 <marker: tid 0x31b062 on core 7>
-           8           1:      31b062 ifetch       3 byte(s) @ 0x00007fc205a61940 48 89 e7             mov    %rsp, %rdi
-           9           2:      31b062 ifetch       5 byte(s) @ 0x00007fc205a61943 e8 b8 0c 00 00       call   $0x00007fc205a62600
-          10           2:      31b062 write        8 byte(s) @ 0x00007fff9a9e3528 by PC 0x00007fc205a61943
-          11           3:      31b062 ifetch       1 byte(s) @ 0x00007fc205a62600 55                   push   %rbp
-          12           3:      31b062 write        8 byte(s) @ 0x00007fff9a9e3520 by PC 0x00007fc205a62600
-          13           4:      31b062 ifetch       3 byte(s) @ 0x00007fc205a62601 48 89 e5             mov    %rsp, %rbp
-          14           5:      31b062 ifetch       2 byte(s) @ 0x00007fc205a62604 41 57                push   %r15
-          15           5:      31b062 write        8 byte(s) @ 0x00007fff9a9e3518 by PC 0x00007fc205a62604
-          16           6:      31b062 ifetch       2 byte(s) @ 0x00007fc205a62606 41 56                push   %r14
-          17           6:      31b062 write        8 byte(s) @ 0x00007fff9a9e3510 by PC 0x00007fc205a62606
-          18           7:      31b062 ifetch       2 byte(s) @ 0x00007fc205a62608 41 55                push   %r13
-          19           7:      31b062 write        8 byte(s) @ 0x00007fff9a9e3508 by PC 0x00007fc205a62608
-          20           8:      31b062 ifetch       2 byte(s) @ 0x00007fc205a6260a 41 54                push   %r12
+           1           0: W0.T3256418 <marker: version 6>
+           2           0: W0.T3256418 <marker: filetype 0x240>
+           3           0: W0.T3256418 <marker: cache line size 64>
+           4           0: W0.T3256418 <marker: chunk instruction count 1024>
+           5           0: W0.T3256418 <marker: page size 4096>
+           6           0: W0.T3256418 <marker: timestamp 13312410768080478>
+           7           0: W0.T3256418 <marker: W0.T3256418 on core 7>
+           8           1: W0.T3256418 ifetch       3 byte(s) @ 0x00007fc205a61940 48 89 e7             mov    %rsp, %rdi
+           9           2: W0.T3256418 ifetch       5 byte(s) @ 0x00007fc205a61943 e8 b8 0c 00 00       call   $0x00007fc205a62600
+          10           2: W0.T3256418 write        8 byte(s) @ 0x00007fff9a9e3528 by PC 0x00007fc205a61943
+          11           3: W0.T3256418 ifetch       1 byte(s) @ 0x00007fc205a62600 55                   push   %rbp
+          12           3: W0.T3256418 write        8 byte(s) @ 0x00007fff9a9e3520 by PC 0x00007fc205a62600
+          13           4: W0.T3256418 ifetch       3 byte(s) @ 0x00007fc205a62601 48 89 e5             mov    %rsp, %rbp
+          14           5: W0.T3256418 ifetch       2 byte(s) @ 0x00007fc205a62604 41 57                push   %r15
+          15           5: W0.T3256418 write        8 byte(s) @ 0x00007fff9a9e3518 by PC 0x00007fc205a62604
+          16           6: W0.T3256418 ifetch       2 byte(s) @ 0x00007fc205a62606 41 56                push   %r14
+          17           6: W0.T3256418 write        8 byte(s) @ 0x00007fff9a9e3510 by PC 0x00007fc205a62606
+          18           7: W0.T3256418 ifetch       2 byte(s) @ 0x00007fc205a62608 41 55                push   %r13
+          19           7: W0.T3256418 write        8 byte(s) @ 0x00007fff9a9e3508 by PC 0x00007fc205a62608
+          20           8: W0.T3256418 ifetch       2 byte(s) @ 0x00007fc205a6260a 41 54                push   %r12
 View tool results:
               8 : total instructions
 \endcode
@@ -740,19 +740,19 @@ An example of thread switches:
 
 \code
 ------------------------------------------------------------
-       46        0:  3264758 <marker: timestamp 13312413437398055>
-       47        0:  3264758 <marker: tid 3264758 on core 2>
-       48        1:  3264758 ifetch       3 byte(s) @ 0x00007f4ea89e4940 48 89 e7             mov    %rsp, %rdi
-       49        2:  3264758 ifetch       5 byte(s) @ 0x00007f4ea89e4943 e8 b8 0c 00 00       call   $0x00007f4ea89e5600
-       50        2:  3264758 write        8 byte(s) @ 0x00007ffd93a0cf18 by PC 0x00007f4ea89e4943
+       46        0: W0.T3264758 <marker: timestamp 13312413437398055>
+       47        0: W0.T3264758 <marker: W0.T3264758 on core 2>
+       48        1: W0.T3264758 ifetch       3 byte(s) @ 0x00007f4ea89e4940 48 89 e7             mov    %rsp, %rdi
+       49        2: W0.T3264758 ifetch       5 byte(s) @ 0x00007f4ea89e4943 e8 b8 0c 00 00       call   $0x00007f4ea89e5600
+       50        2: W0.T3264758 write        8 byte(s) @ 0x00007ffd93a0cf18 by PC 0x00007f4ea89e4943
 ...
-  2854543  2149665:  3264758 ifetch       5 byte(s) @ 0x00007f4ea7c87f8c b8 0e 00 00 00       mov    $0x0000000e, %eax
-  2854544  2149666:  3264758 ifetch       2 byte(s) @ 0x00007f4ea7c87f91 0f 05                syscall
+  2854543  2149665: W0.T3264758 ifetch       5 byte(s) @ 0x00007f4ea7c87f8c b8 0e 00 00 00       mov    $0x0000000e, %eax
+  2854544  2149666: W0.T3264758 ifetch       2 byte(s) @ 0x00007f4ea7c87f91 0f 05                syscall
 ------------------------------------------------------------
-  2854545  2149666:  3264760 <marker: timestamp 13312413438835999>
-  2854546  2149666:  3264760 <marker: tid 3264760 on core 11>
-  2854547  2149667:  3264760 ifetch       3 byte(s) @ 0x00007f4ea7d0b099 48 85 c0             test   %rax, %rax
-  2854548  2149668:  3264760 ifetch       2 byte(s) @ 0x00007f4ea7d0b09c 7c 18                jl     $0x00007f4ea7d0b0b6
+  2854545  2149666: W0.T3264760 <marker: timestamp 13312413438835999>
+  2854546  2149666: W0.T3264760 <marker: W0.T3264760 on core 11>
+  2854547  2149667: W0.T3264760 ifetch       3 byte(s) @ 0x00007f4ea7d0b099 48 85 c0             test   %rax, %rax
+  2854548  2149668: W0.T3264760 ifetch       2 byte(s) @ 0x00007f4ea7d0b09c 7c 18                jl     $0x00007f4ea7d0b0b6
 ...
 \endcode
 
@@ -762,41 +762,41 @@ with metadata showing that the signal was delivered just after an
 untaken conditional branch:
 
 \code
-      801343      601827:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa5c70 75 57                jnz    $0x00007fc2c3aa5cc9 (untaken)
-      801344      601827:     1159769 <marker: kernel xfer from 0x7fc2c3aa5c72 to handler>
-      801345      601827:     1159769 <marker: timestamp 13335923552684013>
-      801346      601827:     1159769 <marker: tid 1159769 on core 7>
-      801347      601828:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa259 55                   push   %rbp
-      801348      601828:     1159769 write        8 byte(s) @ 0x00007fff8044e930 by PC 0x00007fc2c03fa259
-      801349      601829:     1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa25a 48 89 e5             mov    %rsp, %rbp
-      801350      601830:     1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa25d 89 7d fc             mov    %edi, -0x04(%rbp)
-      801351      601830:     1159769 write        4 byte(s) @ 0x00007fff8044e92c by PC 0x00007fc2c03fa25d
-      801352      601831:     1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa260 48 89 75 f0          mov    %rsi, -0x10(%rbp)
-      801353      601831:     1159769 write        8 byte(s) @ 0x00007fff8044e920 by PC 0x00007fc2c03fa260
-      801354      601832:     1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa264 48 89 55 e8          mov    %rdx, -0x18(%rbp)
-      801355      601832:     1159769 write        8 byte(s) @ 0x00007fff8044e918 by PC 0x00007fc2c03fa264
-      801356      601833:     1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa268 83 7d fc 1a          cmp    -0x04(%rbp), $0x1a
-      801357      601833:     1159769 read         4 byte(s) @ 0x00007fff8044e92c by PC 0x00007fc2c03fa268
-      801358      601834:     1159769 ifetch       2 byte(s) @ 0x00007fc2c03fa26c 75 0f                jnz    $0x00007fc2c03fa27d (untaken)
-      801359      601835:     1159769 ifetch       6 byte(s) @ 0x00007fc2c03fa26e 8b 05 c0 3e 00 00    mov    <rel> 0x00007fc2c03fe134, %eax
-      801360      601835:     1159769 read         4 byte(s) @ 0x00007fc2c03fe134 by PC 0x00007fc2c03fa26e
-      801361      601836:     1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa274 83 c0 01             add    $0x01, %eax
-      801362      601837:     1159769 ifetch       6 byte(s) @ 0x00007fc2c03fa277 89 05 b7 3e 00 00    mov    %eax, <rel> 0x00007fc2c03fe134
-      801363      601837:     1159769 write        4 byte(s) @ 0x00007fc2c03fe134 by PC 0x00007fc2c03fa277
-      801364      601838:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27d 90                   nop
-      801365      601839:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27e 5d                   pop    %rbp
-      801366      601839:     1159769 read         8 byte(s) @ 0x00007fff8044e930 by PC 0x00007fc2c03fa27e
-      801367      601840:     1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27f c3                   ret (target 0x7fc2c3a5af90)
-      801368      601840:     1159769 read         8 byte(s) @ 0x00007fff8044e938 by PC 0x00007fc2c03fa27f
-      801369      601841:     1159769 ifetch       7 byte(s) @ 0x00007fc2c3a5af90 48 c7 c0 0f 00 00 00 mov    $0x0000000f, %rax
-      801370      601842:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3a5af97 0f 05                syscall
-      801371      601842:     1159769 <marker: system call 15>
-      801372      601842:     1159769 <marker: timestamp 13335923552684023>
-      801373      601842:     1159769 <marker: tid 1159769 on core 7>
-      801374      601842:     1159769 <marker: syscall xfer from 0x7fc2c3a5af99>
-      801375      601842:     1159769 <marker: timestamp 13335923552684029>
-      801376      601842:     1159769 <marker: tid 1159769 on core 7>
-      801377      601843:     1159769 ifetch       4 byte(s) @ 0x00007fc2c3aa5c72 48 83 c4 48          add    $0x48, %rsp
+      801343      601827: W0.T1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa5c70 75 57                jnz    $0x00007fc2c3aa5cc9 (untaken)
+      801344      601827: W0.T1159769 <marker: kernel xfer from 0x7fc2c3aa5c72 to handler>
+      801345      601827: W0.T1159769 <marker: timestamp 13335923552684013>
+      801346      601827: W0.T1159769 <marker: W0.T1159769 on core 7>
+      801347      601828: W0.T1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa259 55                   push   %rbp
+      801348      601828: W0.T1159769 write        8 byte(s) @ 0x00007fff8044e930 by PC 0x00007fc2c03fa259
+      801349      601829: W0.T1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa25a 48 89 e5             mov    %rsp, %rbp
+      801350      601830: W0.T1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa25d 89 7d fc             mov    %edi, -0x04(%rbp)
+      801351      601830: W0.T1159769 write        4 byte(s) @ 0x00007fff8044e92c by PC 0x00007fc2c03fa25d
+      801352      601831: W0.T1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa260 48 89 75 f0          mov    %rsi, -0x10(%rbp)
+      801353      601831: W0.T1159769 write        8 byte(s) @ 0x00007fff8044e920 by PC 0x00007fc2c03fa260
+      801354      601832: W0.T1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa264 48 89 55 e8          mov    %rdx, -0x18(%rbp)
+      801355      601832: W0.T1159769 write        8 byte(s) @ 0x00007fff8044e918 by PC 0x00007fc2c03fa264
+      801356      601833: W0.T1159769 ifetch       4 byte(s) @ 0x00007fc2c03fa268 83 7d fc 1a          cmp    -0x04(%rbp), $0x1a
+      801357      601833: W0.T1159769 read         4 byte(s) @ 0x00007fff8044e92c by PC 0x00007fc2c03fa268
+      801358      601834: W0.T1159769 ifetch       2 byte(s) @ 0x00007fc2c03fa26c 75 0f                jnz    $0x00007fc2c03fa27d (untaken)
+      801359      601835: W0.T1159769 ifetch       6 byte(s) @ 0x00007fc2c03fa26e 8b 05 c0 3e 00 00    mov    <rel> 0x00007fc2c03fe134, %eax
+      801360      601835: W0.T1159769 read         4 byte(s) @ 0x00007fc2c03fe134 by PC 0x00007fc2c03fa26e
+      801361      601836: W0.T1159769 ifetch       3 byte(s) @ 0x00007fc2c03fa274 83 c0 01             add    $0x01, %eax
+      801362      601837: W0.T1159769 ifetch       6 byte(s) @ 0x00007fc2c03fa277 89 05 b7 3e 00 00    mov    %eax, <rel> 0x00007fc2c03fe134
+      801363      601837: W0.T1159769 write        4 byte(s) @ 0x00007fc2c03fe134 by PC 0x00007fc2c03fa277
+      801364      601838: W0.T1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27d 90                   nop
+      801365      601839: W0.T1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27e 5d                   pop    %rbp
+      801366      601839: W0.T1159769 read         8 byte(s) @ 0x00007fff8044e930 by PC 0x00007fc2c03fa27e
+      801367      601840: W0.T1159769 ifetch       1 byte(s) @ 0x00007fc2c03fa27f c3                   ret (target 0x7fc2c3a5af90)
+      801368      601840: W0.T1159769 read         8 byte(s) @ 0x00007fff8044e938 by PC 0x00007fc2c03fa27f
+      801369      601841: W0.T1159769 ifetch       7 byte(s) @ 0x00007fc2c3a5af90 48 c7 c0 0f 00 00 00 mov    $0x0000000f, %rax
+      801370      601842: W0.T1159769 ifetch       2 byte(s) @ 0x00007fc2c3a5af97 0f 05                syscall
+      801371      601842: W0.T1159769 <marker: system call 15>
+      801372      601842: W0.T1159769 <marker: timestamp 13335923552684023>
+      801373      601842: W0.T1159769 <marker: W0.T1159769 on core 7>
+      801374      601842: W0.T1159769 <marker: syscall xfer from 0x7fc2c3a5af99>
+      801375      601842: W0.T1159769 <marker: timestamp 13335923552684029>
+      801376      601842: W0.T1159769 <marker: W0.T1159769 on core 7>
+      801377      601843: W0.T1159769 ifetch       4 byte(s) @ 0x00007fc2c3aa5c72 48 83 c4 48          add    $0x48, %rsp
 \endcode
 
 Here is an illustration of what a trace would look like when an uncompleted
@@ -805,19 +805,19 @@ is not removed (The following trace is for demonstration purpose only):
 
 \code
 
-    46914793    33950158:     3767811 ifetch       5 byte(s) @ 0x000055f52911b75e c4 42 f8 f5 e8       bzhi   %r8, %rax, %r13
-    46914794    33950159:     3767811 ifetch       5 byte(s) @ 0x000055f52911b763 c4 62 f8 f5 c3       bzhi   %rbx, %rax, %r8
-    46914795    33950160:     3767811 ifetch       4 byte(s) @ 0x000055f52911b768 48 c1 eb 33          shr    $0x33, %rbx
-    46914796    33950161:     3767811 ifetch       3 byte(s) @ 0x000055f52911b76c 48 01 f3             add    %rsi, %rbx
-    46914797    33950162:     3767811 ifetch       5 byte(s) @ 0x000055f52911b76f b8 04 00 00 00       mov    $0x00000004, %eax
+    46914793    33950158: W0.T3767811 ifetch       5 byte(s) @ 0x000055f52911b75e c4 42 f8 f5 e8       bzhi   %r8, %rax, %r13
+    46914794    33950159: W0.T3767811 ifetch       5 byte(s) @ 0x000055f52911b763 c4 62 f8 f5 c3       bzhi   %rbx, %rax, %r8
+    46914795    33950160: W0.T3767811 ifetch       4 byte(s) @ 0x000055f52911b768 48 c1 eb 33          shr    $0x33, %rbx
+    46914796    33950161: W0.T3767811 ifetch       3 byte(s) @ 0x000055f52911b76c 48 01 f3             add    %rsi, %rbx
+    46914797    33950162: W0.T3767811 ifetch       5 byte(s) @ 0x000055f52911b76f b8 04 00 00 00       mov    $0x00000004, %eax
     (The line below is for demonstration purpose only and will not appear in a real drmemtrace.)
-    46914798    33950163:     3767811 ifetch       6 byte(s) @ 0x000055f52911b774 89 85 68 ff ff ff    mov    %eax, -0x98(%rbp)
-    46914799    33950163:     3767811 <marker: kernel xfer from 0x55f52911b774 to handler>
-    46914800    33950163:     3767811 <marker: signal #27>
-    46914801    33950163:     3767811 <marker: timestamp 13373506292215933>
-    46914802    33950163:     3767811 <marker: tid 3767811 on core 4139>
-    46914803    33950164:     3767811 ifetch       1 byte(s) @ 0x000055f5298f7500 55                   push   %rbp
-    46914804    33950164:     3767811 write        8 byte(s) @ 0x00007fd98bd2f210 by PC 0x000055f5298f7500
+    46914798    33950163: W0.T3767811 ifetch       6 byte(s) @ 0x000055f52911b774 89 85 68 ff ff ff    mov    %eax, -0x98(%rbp)
+    46914799    33950163: W0.T3767811 <marker: kernel xfer from 0x55f52911b774 to handler>
+    46914800    33950163: W0.T3767811 <marker: signal #27>
+    46914801    33950163: W0.T3767811 <marker: timestamp 13373506292215933>
+    46914802    33950163: W0.T3767811 <marker: W0.T3767811 on core 4139>
+    46914803    33950164: W0.T3767811 ifetch       1 byte(s) @ 0x000055f5298f7500 55                   push   %rbp
+    46914804    33950164: W0.T3767811 write        8 byte(s) @ 0x00007fd98bd2f210 by PC 0x000055f5298f7500
 \endcode
 
 When the uncompleted mov instruction is removed, a
@@ -825,18 +825,18 @@ When the uncompleted mov instruction is removed, a
 instruction has been removed:
 
 \code
-    46914793    33950158:     3767811 ifetch       5 byte(s) @ 0x000055f52911b75e c4 42 f8 f5 e8       bzhi   %r8, %rax, %r13
-    46914794    33950159:     3767811 ifetch       5 byte(s) @ 0x000055f52911b763 c4 62 f8 f5 c3       bzhi   %rbx, %rax, %r8
-    46914795    33950160:     3767811 ifetch       4 byte(s) @ 0x000055f52911b768 48 c1 eb 33          shr    $0x33, %rbx
-    46914796    33950161:     3767811 ifetch       3 byte(s) @ 0x000055f52911b76c 48 01 f3             add    %rsi, %rbx
-    46914797    33950162:     3767811 ifetch       5 byte(s) @ 0x000055f52911b76f b8 04 00 00 00       mov    $0x00000004, %eax
-    46914798    33950163:     3767811 <marker: uncompleted instruction, encoding 0x898568ff>
-    46914799    33950163:     3767811 <marker: kernel xfer from 0x55f52911b774 to handler>
-    46914800    33950163:     3767811 <marker: signal #27>
-    46914801    33950163:     3767811 <marker: timestamp 13373506292215933>
-    46914802    33950163:     3767811 <marker: tid 3767811 on core 4139>
-    46914803    33950164:     3767811 ifetch       1 byte(s) @ 0x000055f5298f7500 55                   push   %rbp
-    46914804    33950164:     3767811 write        8 byte(s) @ 0x00007fd98bd2f210 by PC 0x000055f5298f7500
+    46914793    33950158: W0.T3767811 ifetch       5 byte(s) @ 0x000055f52911b75e c4 42 f8 f5 e8       bzhi   %r8, %rax, %r13
+    46914794    33950159: W0.T3767811 ifetch       5 byte(s) @ 0x000055f52911b763 c4 62 f8 f5 c3       bzhi   %rbx, %rax, %r8
+    46914795    33950160: W0.T3767811 ifetch       4 byte(s) @ 0x000055f52911b768 48 c1 eb 33          shr    $0x33, %rbx
+    46914796    33950161: W0.T3767811 ifetch       3 byte(s) @ 0x000055f52911b76c 48 01 f3             add    %rsi, %rbx
+    46914797    33950162: W0.T3767811 ifetch       5 byte(s) @ 0x000055f52911b76f b8 04 00 00 00       mov    $0x00000004, %eax
+    46914798    33950163: W0.T3767811 <marker: uncompleted instruction, encoding 0x898568ff>
+    46914799    33950163: W0.T3767811 <marker: kernel xfer from 0x55f52911b774 to handler>
+    46914800    33950163: W0.T3767811 <marker: signal #27>
+    46914801    33950163: W0.T3767811 <marker: timestamp 13373506292215933>
+    46914802    33950163: W0.T3767811 <marker: W0.T3767811 on core 4139>
+    46914803    33950164: W0.T3767811 ifetch       1 byte(s) @ 0x000055f5298f7500 55                   push   %rbp
+    46914804    33950164: W0.T3767811 write        8 byte(s) @ 0x00007fd98bd2f210 by PC 0x000055f5298f7500
 \endcode
 
 \section sec_tool_func_view View Function Calls
@@ -1630,13 +1630,13 @@ subsequent entry or the kernel transfer event marker (or infer branch
 behavior for rseq aborts):
 
 ```
-      801394      601853:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa91e3 7f 1b                jnle   $0x00007fc2c3aa9200 (untaken)
-      801395      601854:     1159769 ifetch       4 byte(s) @ 0x00007fc2c3aa91e5 48 83 c4 10          add    $0x10, %rsp
-      801396      601855:     1159769 ifetch       1 byte(s) @ 0x00007fc2c3aa91e9 5b                   pop    %rbx
-      801397      601855:     1159769 read         8 byte(s) @ 0x00007fff8044f6c0 by PC 0x00007fc2c3aa91e9
-      801398      601856:     1159769 ifetch       1 byte(s) @ 0x00007fc2c3aa91ea c3                   ret (target 0x7fc2c3aa81c1)
-      801399      601856:     1159769 read         8 byte(s) @ 0x00007fff8044f6c8 by PC 0x00007fc2c3aa91ea
-      801400      601857:     1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa81c1 89 c5                mov    %eax, %ebp
+      801394      601853: W0.T1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa91e3 7f 1b                jnle   $0x00007fc2c3aa9200 (untaken)
+      801395      601854: W0.T1159769 ifetch       4 byte(s) @ 0x00007fc2c3aa91e5 48 83 c4 10          add    $0x10, %rsp
+      801396      601855: W0.T1159769 ifetch       1 byte(s) @ 0x00007fc2c3aa91e9 5b                   pop    %rbx
+      801397      601855: W0.T1159769 read         8 byte(s) @ 0x00007fff8044f6c0 by PC 0x00007fc2c3aa91e9
+      801398      601856: W0.T1159769 ifetch       1 byte(s) @ 0x00007fc2c3aa91ea c3                   ret (target 0x7fc2c3aa81c1)
+      801399      601856: W0.T1159769 read         8 byte(s) @ 0x00007fff8044f6c8 by PC 0x00007fc2c3aa91ea
+      801400      601857: W0.T1159769 ifetch       2 byte(s) @ 0x00007fc2c3aa81c1 89 c5                mov    %eax, %ebp
 ```
 
 Filtered traces (filtered via -L0_filter) include the dynamic

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -712,26 +712,26 @@ $ $ bin64/drrun -t drmemtrace -tool view -indir drmemtrace.*.dir -sim_refs 20
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-           1           0:     3256418 <marker: version 6>
-           2           0:     3256418 <marker: filetype 0x240>
-           3           0:     3256418 <marker: cache line size 64>
-           4           0:     3256418 <marker: chunk instruction count 1024>
-           5           0:     3256418 <marker: page size 4096>
-           6           0:     3256418 <marker: timestamp 13312410768080478>
-           7           0:     3256418 <marker: tid 3256418 on core 7>
-           8           1:     3256418 ifetch       3 byte(s) @ 0x00007fc205a61940 48 89 e7             mov    %rsp, %rdi
-           9           2:     3256418 ifetch       5 byte(s) @ 0x00007fc205a61943 e8 b8 0c 00 00       call   $0x00007fc205a62600
-          10           2:     3256418 write        8 byte(s) @ 0x00007fff9a9e3528 by PC 0x00007fc205a61943
-          11           3:     3256418 ifetch       1 byte(s) @ 0x00007fc205a62600 55                   push   %rbp
-          12           3:     3256418 write        8 byte(s) @ 0x00007fff9a9e3520 by PC 0x00007fc205a62600
-          13           4:     3256418 ifetch       3 byte(s) @ 0x00007fc205a62601 48 89 e5             mov    %rsp, %rbp
-          14           5:     3256418 ifetch       2 byte(s) @ 0x00007fc205a62604 41 57                push   %r15
-          15           5:     3256418 write        8 byte(s) @ 0x00007fff9a9e3518 by PC 0x00007fc205a62604
-          16           6:     3256418 ifetch       2 byte(s) @ 0x00007fc205a62606 41 56                push   %r14
-          17           6:     3256418 write        8 byte(s) @ 0x00007fff9a9e3510 by PC 0x00007fc205a62606
-          18           7:     3256418 ifetch       2 byte(s) @ 0x00007fc205a62608 41 55                push   %r13
-          19           7:     3256418 write        8 byte(s) @ 0x00007fff9a9e3508 by PC 0x00007fc205a62608
-          20           8:     3256418 ifetch       2 byte(s) @ 0x00007fc205a6260a 41 54                push   %r12
+           1           0:      31b062 <marker: version 6>
+           2           0:      31b062 <marker: filetype 0x240>
+           3           0:      31b062 <marker: cache line size 64>
+           4           0:      31b062 <marker: chunk instruction count 1024>
+           5           0:      31b062 <marker: page size 4096>
+           6           0:      31b062 <marker: timestamp 13312410768080478>
+           7           0:      31b062 <marker: tid 0x31b062 on core 7>
+           8           1:      31b062 ifetch       3 byte(s) @ 0x00007fc205a61940 48 89 e7             mov    %rsp, %rdi
+           9           2:      31b062 ifetch       5 byte(s) @ 0x00007fc205a61943 e8 b8 0c 00 00       call   $0x00007fc205a62600
+          10           2:      31b062 write        8 byte(s) @ 0x00007fff9a9e3528 by PC 0x00007fc205a61943
+          11           3:      31b062 ifetch       1 byte(s) @ 0x00007fc205a62600 55                   push   %rbp
+          12           3:      31b062 write        8 byte(s) @ 0x00007fff9a9e3520 by PC 0x00007fc205a62600
+          13           4:      31b062 ifetch       3 byte(s) @ 0x00007fc205a62601 48 89 e5             mov    %rsp, %rbp
+          14           5:      31b062 ifetch       2 byte(s) @ 0x00007fc205a62604 41 57                push   %r15
+          15           5:      31b062 write        8 byte(s) @ 0x00007fff9a9e3518 by PC 0x00007fc205a62604
+          16           6:      31b062 ifetch       2 byte(s) @ 0x00007fc205a62606 41 56                push   %r14
+          17           6:      31b062 write        8 byte(s) @ 0x00007fff9a9e3510 by PC 0x00007fc205a62606
+          18           7:      31b062 ifetch       2 byte(s) @ 0x00007fc205a62608 41 55                push   %r13
+          19           7:      31b062 write        8 byte(s) @ 0x00007fff9a9e3508 by PC 0x00007fc205a62608
+          20           8:      31b062 ifetch       2 byte(s) @ 0x00007fc205a6260a 41 54                push   %r12
 View tool results:
               8 : total instructions
 \endcode

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1166,6 +1166,13 @@ public:
         /**
          * Returns the ordinal for the current
          * #dynamorio::drmemtrace::scheduler_tmpl_t::input_workload_t.
+         *
+         * For a core-sharded-on-disk trace (#OFFLINE_FILE_TYPE_CORE_SHARDED), which
+         * is already scheduled, get_workload_id() will not return the original
+         * separate inputs but rather the new inputs as seen by the scheduler which
+         * are a single workload with one input per core.  Use the modified #memref_t
+         * tid and pid fields with the helpers workload_from_memref_pid() and
+         * workload_from_memref_tid() to obtain the workload in this case.
          */
         int64_t
         get_workload_id() const override

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -460,6 +460,11 @@ public:
          * or a (potentially) blocking system call is identified.  At this point,
          * a new input is selected, taking into consideration other options such
          * as priorities, core bindings, and inter-input dependencies.
+         * In this mode, input #TRACE_MARKER_TYPE_CPU_ID marker values are modified
+         * to reflect the virtual cores; input #TRACE_MARKER_TYPE_TIMESTAMP values are
+         * modified to reflect a notion of virtual time; and input .tid and .pid
+         * #memref_t fields have the workload ordinal set in the top 32 bits in order
+         * to ensure the values are unique.
          */
         MAP_TO_ANY_OUTPUT,
         /**
@@ -470,6 +475,11 @@ public:
          * The same output count and input stream order and count must be re-specified;
          * scheduling details such as regions of interest and core bindings do not
          * need to be re-specified and are in fact ignored.
+         * In this mode, input #TRACE_MARKER_TYPE_CPU_ID marker values are modified
+         * to reflect the virtual cores; input #TRACE_MARKER_TYPE_TIMESTAMP values are
+         * modified to reflect a notion of virtual time; and input .tid and .pid
+         * #memref_t fields have the workload ordinal set in the top 32 bits in order
+         * to ensure the values are unique.
          */
         MAP_AS_PREVIOUSLY,
     };

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -464,7 +464,7 @@ public:
          * to reflect the virtual cores; input #TRACE_MARKER_TYPE_TIMESTAMP values are
          * modified to reflect a notion of virtual time; and input .tid and .pid
          * #memref_t fields have the workload ordinal set in the top 32 bits in order
-         * to ensure the values are unique.
+         * to ensure the values are unique across multiple workloads.
          */
         MAP_TO_ANY_OUTPUT,
         /**
@@ -479,7 +479,7 @@ public:
          * to reflect the virtual cores; input #TRACE_MARKER_TYPE_TIMESTAMP values are
          * modified to reflect a notion of virtual time; and input .tid and .pid
          * #memref_t fields have the workload ordinal set in the top 32 bits in order
-         * to ensure the values are unique.
+         * to ensure the values are unique across multiple workloads.
          */
         MAP_AS_PREVIOUSLY,
     };

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -463,8 +463,13 @@ public:
          * In this mode, input #TRACE_MARKER_TYPE_CPU_ID marker values are modified
          * to reflect the virtual cores; input #TRACE_MARKER_TYPE_TIMESTAMP values are
          * modified to reflect a notion of virtual time; and input .tid and .pid
-         * #memref_t fields have the workload ordinal set in the top 32 bits in order
-         * to ensure the values are unique across multiple workloads.
+         * #memref_t fields have the workload ordinal set in the top
+         * (64 - #MEMREF_ID_WORKLOAD_SHIFT) bits in order
+         * to ensure the values are unique across multiple workloads (see also
+         * workload_from_memref_pid(), workload_from_memref_tid(),
+         * pid_from_memref_tid(), and tid_from_memref_tid()).
+         * (The tid and pid changes are not supported for 32-bit builds, and
+         * do not support tid values occupying more than #MEMREF_ID_WORKLOAD_SHIFT bits.)
          */
         MAP_TO_ANY_OUTPUT,
         /**
@@ -478,8 +483,13 @@ public:
          * In this mode, input #TRACE_MARKER_TYPE_CPU_ID marker values are modified
          * to reflect the virtual cores; input #TRACE_MARKER_TYPE_TIMESTAMP values are
          * modified to reflect a notion of virtual time; and input .tid and .pid
-         * #memref_t fields have the workload ordinal set in the top 32 bits in order
-         * to ensure the values are unique across multiple workloads.
+         * #memref_t fields have the workload ordinal set in the top 32
+         * (64 - #MEMREF_ID_WORKLOAD_SHIFT) bits in order
+         * to ensure the values are unique across multiple workloads (see also
+         * workload_from_memref_pid(), workload_from_memref_tid(),
+         * pid_from_memref_tid(), and tid_from_memref_tid()).
+         * (The tid and pid changes are not supported for 32-bit builds, and
+         * do not support tid values occupying more than #MEMREF_ID_WORKLOAD_SHIFT bits.)
          */
         MAP_AS_PREVIOUSLY,
     };

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2916,6 +2916,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::update_next_record(output_ordinal
     // core-sharded-on-disk and with analyzers not using our workload identifiers.
     // To maintain the original values, we write the workload ordinal into the top
     // 32 bits.  We don't support distinguishing for 32-bit-build record_filter.
+    // We also ignore complexities on Mac with its 64-bit tid type.
     int64_t workload = get_workload_ordinal(output);
     memref_tid_t cur_tid;
     if (record_type_has_tid(record, cur_tid) && workload > 0) {

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -218,6 +218,14 @@ scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_set_tid(memref_t &record,
 }
 
 template <>
+void
+scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_set_pid(memref_t &record,
+                                                               memref_pid_t pid)
+{
+    record.marker.pid = pid;
+}
+
+template <>
 bool
 scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_is_instr(memref_t record)
 {
@@ -426,6 +434,16 @@ scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::record_type_set_tid(
     if (record.type != TRACE_TYPE_THREAD)
         return;
     record.addr = static_cast<addr_t>(tid);
+}
+
+template <>
+void
+scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::record_type_set_pid(
+    trace_entry_t &record, memref_pid_t pid)
+{
+    if (record.type != TRACE_TYPE_PID)
+        return;
+    record.addr = static_cast<addr_t>(pid);
 }
 
 template <>
@@ -2893,6 +2911,21 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::update_next_record(output_ordinal
         // Do not modify sched_type_t::MAP_TO_RECORDED_OUTPUT (turned into
         // sched_type_t::MAP_AS_PREVIOUSLY).
         return;
+    }
+    // We modify the tid and pid fields to ensure uniqueness for
+    // core-sharded-on-disk and with analyzers not using our workload identifiers.
+    // To maintain the original values, we write the workload ordinal into the top
+    // 32 bits.  We don't support distinguishing for 32-bit-build record_filter.
+    int64_t workload = get_workload_ordinal(output);
+    memref_tid_t cur_tid;
+    if (record_type_has_tid(record, cur_tid) && workload > 0) {
+        memref_tid_t new_tid = (workload << 32) | cur_tid;
+        record_type_set_tid(record, new_tid);
+    }
+    memref_pid_t cur_pid;
+    if (record_type_has_pid(record, cur_pid) && workload > 0) {
+        memref_tid_t new_pid = (workload << 32) | cur_pid;
+        record_type_set_pid(record, new_pid);
     }
     // For a dynamic schedule, the as-traced cpuids and timestamps no longer
     // apply and are just confusing (causing problems like interval analysis

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -828,6 +828,10 @@ protected:
     void
     record_type_set_tid(RecordType &record, memref_tid_t tid);
 
+    // For trace_entry_t, only sets the pid for record types that have it.
+    void
+    record_type_set_pid(RecordType &record, memref_pid_t pid);
+
     // Returns whether the given record is an instruction.
     bool
     record_type_is_instr(RecordType record);

--- a/clients/drcachesim/tests/analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/analysis_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2023-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -165,8 +165,9 @@ test_queries()
             // We have one thread for each of our NUM_INPUTS workloads.
             assert(shard->stream->get_output_cpuid() == shard->index);
             // We have just one thread per workload, so they're the same.
-            assert(shard->stream->get_workload_id() == memref.instr.tid - BASE_TID);
-            assert(shard->stream->get_input_id() == memref.instr.tid - BASE_TID);
+            memref_tid_t tid_only = memref.instr.tid & 0x00000000ffffffff;
+            assert(shard->stream->get_workload_id() == tid_only - BASE_TID);
+            assert(shard->stream->get_input_id() == tid_only - BASE_TID);
             return true;
         }
 

--- a/clients/drcachesim/tests/multi_indir.templatex
+++ b/clients/drcachesim/tests/multi_indir.templatex
@@ -1,7 +1,7 @@
 Schedule stats tool results:
 Total counts:
            3 cores
-          27 threads: .*W[012].T([12]000)?d51c6.*W[012].T([12]000)?d51c6.*W[012].T([12]000)?d51c6.*
+          27 threads: .*W[012].T872902.*W[012].T872902.*W[012].T872902.*
      1857635 instructions
 .*
 Core #0 schedule: [A-Za-z_]*

--- a/clients/drcachesim/tests/multi_indir.templatex
+++ b/clients/drcachesim/tests/multi_indir.templatex
@@ -1,7 +1,7 @@
 Schedule stats tool results:
 Total counts:
            3 cores
-          27 threads: .*W[012].T872902.*W[012].T872902.*W[012].T872902.*
+          27 threads: .*W[012].T([12]000)?d51c6.*W[012].T([12]000)?d51c6.*W[012].T([12]000)?d51c6.*
      1857635 instructions
 .*
 Core #0 schedule: [A-Za-z_]*

--- a/clients/drcachesim/tests/offline-allasm-record-syscall.templatex
+++ b/clients/drcachesim/tests/offline-allasm-record-syscall.templatex
@@ -11,7 +11,7 @@ Adios world!
 .*
           43          20:   .* ifetch       2 byte\(s\) @ 0x.* 0f 05                syscall
           44          20:   .* <marker: timestamp .*>
-          45          20:   .* <marker: tid .* on core .*>
+          45          20:   .* <marker: .* on core .*>
           46          20:   .* <marker: system call 1>
           47          20:   .* <marker: maybe-blocking system call>
           48          20:   .* <marker: function==syscall #1>

--- a/clients/drcachesim/tests/offline-burst_syscall_inject.template
+++ b/clients/drcachesim/tests/offline-burst_syscall_inject.template
@@ -9,34 +9,34 @@ Done with test.
 #endif
 Trace invariant checks passed
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-           1           0:           1 <marker: version 7>
+           1           0:       W0.T1 <marker: version 7>
 #ifdef X86
-           2           0:           1 <marker: filetype 0x4240>
+           2           0:       W0.T1 <marker: filetype 0x4240>
 #else
-           2           0:           1 <marker: filetype 0x4208>
+           2           0:       W0.T1 <marker: filetype 0x4208>
 #endif
-           3           0:           1 <marker: cache line size 64>
-           4           0:           1 <marker: page size 4096>
-           5           0:           1 <marker: timestamp 1>
+           3           0:       W0.T1 <marker: cache line size 64>
+           4           0:       W0.T1 <marker: page size 4096>
+           5           0:       W0.T1 <marker: timestamp 1>
 #ifdef X86
-           6           0:           1 <marker: trace start for system call number 39>
-           7           1:           1 ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
-           8           1:           1 <marker: trace end for system call number 39>
-           9           1:           1 <marker: trace start for system call number 186>
-          10           2:           1 ifetch       3 byte\(s\) @ 0x000000008badf000 48 8b 12             mov    \(%rdx\), %rdx
-          11           2:           1 read         8 byte\(s\) @ 0x00000000decafbad by PC 0x000000008badf000
-          12           2:           1 <marker: trace end for system call number 186>
+           6           0:       W0.T1 <marker: trace start for system call number 39>
+           7           1:       W0.T1 ifetch       1 byte\(s\) @ 0x00000000deadbe00 90                   nop
+           8           1:       W0.T1 <marker: trace end for system call number 39>
+           9           1:       W0.T1 <marker: trace start for system call number 186>
+          10           2:       W0.T1 ifetch       3 byte\(s\) @ 0x000000008badf000 48 8b 12             mov    \(%rdx\), %rdx
+          11           2:       W0.T1 read         8 byte\(s\) @ 0x00000000decafbad by PC 0x000000008badf000
+          12           2:       W0.T1 <marker: trace end for system call number 186>
 #else
-           6           0:           1 <marker: trace start for system call number 172>
-           7           1:           1 ifetch       4 byte\(s\) @ 0x00000000deadbe00 d503201f   nop
-           8           1:           1 <marker: trace end for system call number 172>
-           9           1:           1 <marker: trace start for system call number 178>
-          10           2:           1 ifetch       4 byte\(s\) @ 0x000000008badf000 f9400084   ldr    \(%x4\)\[8byte\] -> %x4
-          11           2:           1 read         8 byte\(s\) @ 0x00000000decafbad by PC 0x000000008badf000
-          12           2:           1 <marker: trace end for system call number 178>
+           6           0:       W0.T1 <marker: trace start for system call number 172>
+           7           1:       W0.T1 ifetch       4 byte\(s\) @ 0x00000000deadbe00 d503201f   nop
+           8           1:       W0.T1 <marker: trace end for system call number 172>
+           9           1:       W0.T1 <marker: trace start for system call number 178>
+          10           2:       W0.T1 ifetch       4 byte\(s\) @ 0x000000008badf000 f9400084   ldr    \(%x4\)\[8byte\] -> %x4
+          11           2:       W0.T1 read         8 byte\(s\) @ 0x00000000decafbad by PC 0x000000008badf000
+          12           2:       W0.T1 <marker: trace end for system call number 178>
 #endif
-          13           2:           1 <thread 1 exited>
+          13           2:       W0.T1 <thread W0.T1 exited>
 View tool results:
               2 : total instructions

--- a/clients/drcachesim/tests/offline-phys.templatex
+++ b/clients/drcachesim/tests/offline-phys.templatex
@@ -11,19 +11,19 @@ Adios world!
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-           1           0: +[0-9]+ <marker: version 7>
-           2           0: +[0-9]+ <marker: filetype 0xe42>
-           3           0: +[0-9]+ <marker: cache line size [0-9]+>
-           4           0: +[0-9]+ <marker: chunk instruction count [0-9]+>
-           5           0: +[0-9]+ <marker: page size [0-9]+>
-           6           0: +[0-9]+ <marker: timestamp [0-9]+>
-           7           0: +[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
-           8           0: +[0-9]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
-           9           0: +[0-9]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
-          10           0: +[0-9]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
-          11           0: +[0-9]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
-          12           0: +[0-9]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
-          13           0: +[0-9]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
-          14           0: +[0-9]+ <marker: timestamp [0-9]+>
-          15           0: +[0-9]+ <marker: tid [0-9]+ on core [0-9]+>
-          16           1: +[0-9]+ ifetch .*
+           1           0: +[0-9a-f]+ <marker: version 7>
+           2           0: +[0-9a-f]+ <marker: filetype 0xe42>
+           3           0: +[0-9a-f]+ <marker: cache line size [0-9]+>
+           4           0: +[0-9a-f]+ <marker: chunk instruction count [0-9]+>
+           5           0: +[0-9a-f]+ <marker: page size [0-9]+>
+           6           0: +[0-9a-f]+ <marker: timestamp [0-9]+>
+           7           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]+ on core [0-9]+>
+           8           0: +[0-9a-f]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+           9           0: +[0-9a-f]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+          10           0: +[0-9a-f]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+          11           0: +[0-9a-f]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+          12           0: +[0-9a-f]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+          13           0: +[0-9a-f]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+          14           0: +[0-9a-f]+ <marker: timestamp [0-9]+>
+          15           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]+ on core [0-9]+>
+          16           1: +[0-9a-f]+ ifetch .*

--- a/clients/drcachesim/tests/offline-phys.templatex
+++ b/clients/drcachesim/tests/offline-phys.templatex
@@ -9,21 +9,21 @@ Adios world!
 Adios world!
 Adios world!
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-           1           0: +[0-9a-f]+ <marker: version 7>
-           2           0: +[0-9a-f]+ <marker: filetype 0xe42>
-           3           0: +[0-9a-f]+ <marker: cache line size [0-9]+>
-           4           0: +[0-9a-f]+ <marker: chunk instruction count [0-9]+>
-           5           0: +[0-9a-f]+ <marker: page size [0-9]+>
-           6           0: +[0-9a-f]+ <marker: timestamp [0-9]+>
-           7           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]+ on core [0-9]+>
-           8           0: +[0-9a-f]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
-           9           0: +[0-9a-f]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
-          10           0: +[0-9a-f]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
-          11           0: +[0-9a-f]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
-          12           0: +[0-9a-f]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
-          13           0: +[0-9a-f]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
-          14           0: +[0-9a-f]+ <marker: timestamp [0-9]+>
-          15           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]+ on core [0-9]+>
-          16           1: +[0-9a-f]+ ifetch .*
+           1           0: +[0-9WT\.]+ <marker: version 7>
+           2           0: +[0-9WT\.]+ <marker: filetype 0xe42>
+           3           0: +[0-9WT\.]+ <marker: cache line size [0-9]+>
+           4           0: +[0-9WT\.]+ <marker: chunk instruction count [0-9]+>
+           5           0: +[0-9WT\.]+ <marker: page size [0-9]+>
+           6           0: +[0-9WT\.]+ <marker: timestamp [0-9]+>
+           7           0: +[0-9WT\.]+ <marker: [0-9WT\.]+ on core [0-9]+>
+           8           0: +[0-9WT\.]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+           9           0: +[0-9WT\.]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+          10           0: +[0-9WT\.]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+          11           0: +[0-9WT\.]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+          12           0: +[0-9WT\.]+ <marker: physical address for following virtual: 0x[0-9a-f][0-9a-f]+>
+          13           0: +[0-9WT\.]+ <marker: virtual address for prior physical: 0x[0-9a-f][0-9a-f]+>
+          14           0: +[0-9WT\.]+ <marker: timestamp [0-9]+>
+          15           0: +[0-9WT\.]+ <marker: [0-9WT\.]+ on core [0-9]+>
+          16           1: +[0-9WT\.]+ ifetch .*

--- a/clients/drcachesim/tests/offline-skip.expect
+++ b/clients/drcachesim/tests/offline-skip.expect
@@ -1,16 +1,16 @@
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-         114          62:     1992554 <marker: timestamp 13352268558646596>
-         114          62:     1992554 <marker: tid 1992554 on core 10>
-         115          63:     1992554 ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
-         116          63:     1992554 <marker: timestamp 13352268558646600>
-         117          63:     1992554 <marker: tid 1992554 on core 10>
-         118          63:     1992554 <marker: system call 1>
-         119          63:     1992554 <marker: maybe-blocking system call>
-         120          63:     1992554 <marker: timestamp 13352268558646604>
-         121          63:     1992554 <marker: tid 1992554 on core 10>
-         122          64:     1992554 ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
+         114          62:      1e676a <marker: timestamp 13352268558646596>
+         114          62:      1e676a <marker: tid 0x1e676a on core 10>
+         115          63:      1e676a ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
+         116          63:      1e676a <marker: timestamp 13352268558646600>
+         117          63:      1e676a <marker: tid  1e676a on core 10>
+         118          63:      1e676a <marker: system call 1>
+         119          63:      1e676a <marker: maybe-blocking system call>
+         120          63:      1e676a <marker: timestamp 13352268558646604>
+         121          63:      1e676a <marker: tid 0x1e676a on core 10>
+         122          64:      1e676a ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
 View tool results:
               2 : total instructions
 

--- a/clients/drcachesim/tests/offline-skip.expect
+++ b/clients/drcachesim/tests/offline-skip.expect
@@ -1,16 +1,16 @@
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-         114          62:      1e676a <marker: timestamp 13352268558646596>
-         114          62:      1e676a <marker: tid 0x1e676a on core 10>
-         115          63:      1e676a ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
-         116          63:      1e676a <marker: timestamp 13352268558646600>
-         117          63:      1e676a <marker: tid  1e676a on core 10>
-         118          63:      1e676a <marker: system call 1>
-         119          63:      1e676a <marker: maybe-blocking system call>
-         120          63:      1e676a <marker: timestamp 13352268558646604>
-         121          63:      1e676a <marker: tid 0x1e676a on core 10>
-         122          64:      1e676a ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
+         114          62: W0.T1992554 <marker: timestamp 13352268558646596>
+         114          62: W0.T1992554 <marker: W0.T1992554 on core 10>
+         115          63: W0.T1992554 ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
+         116          63: W0.T1992554 <marker: timestamp 13352268558646600>
+         117          63: W0.T1992554 <marker: W0.T1992554 on core 10>
+         118          63: W0.T1992554 <marker: system call 1>
+         119          63: W0.T1992554 <marker: maybe-blocking system call>
+         120          63: W0.T1992554 <marker: timestamp 13352268558646604>
+         121          63: W0.T1992554 <marker: W0.T1992554 on core 10>
+         122          64: W0.T1992554 ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
 View tool results:
               2 : total instructions
 

--- a/clients/drcachesim/tests/offline-skip2.expect
+++ b/clients/drcachesim/tests/offline-skip2.expect
@@ -1,17 +1,17 @@
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-         120          63:     1992554 <marker: timestamp 13352268558646604>
-         121          63:     1992554 <marker: tid 1992554 on core 10>
-         122          64:     1992554 ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
-         123          65:     1992554 ifetch       4 byte(s) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx $0x0000000000000000
-         124          66:     1992554 ifetch       2 byte(s) @ 0x0000000000401030 75 d9                jnz    $0x000000000040100b (taken)
-         125          67:     1992554 ifetch       7 byte(s) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    $0x0000000000000001 -> %rdi
-         126          68:     1992554 ifetch       8 byte(s) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
-         126          68:     1992554                                             00
-         127          69:     1992554 ifetch       7 byte(s) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    $0x000000000000000d -> %rdx
-         128          70:     1992554 ifetch       5 byte(s) @ 0x0000000000401021 b8 01 00 00 00       mov    $0x00000001 -> %eax
-         129          71:     1992554 ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
+         120          63:      1e676a <marker: timestamp 13352268558646604>
+         121          63:      1e676a <marker: tid 0x1e676a on core 10>
+         122          64:      1e676a ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
+         123          65:      1e676a ifetch       4 byte(s) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx $0x0000000000000000
+         124          66:      1e676a ifetch       2 byte(s) @ 0x0000000000401030 75 d9                jnz    $0x000000000040100b (taken)
+         125          67:      1e676a ifetch       7 byte(s) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    $0x0000000000000001 -> %rdi
+         126          68:      1e676a ifetch       8 byte(s) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
+         126          68:      1e676a                                             00
+         127          69:      1e676a ifetch       7 byte(s) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    $0x000000000000000d -> %rdx
+         128          70:      1e676a ifetch       5 byte(s) @ 0x0000000000401021 b8 01 00 00 00       mov    $0x00000001 -> %eax
+         129          71:      1e676a ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
 View tool results:
               8 : total instructions
 

--- a/clients/drcachesim/tests/offline-skip2.expect
+++ b/clients/drcachesim/tests/offline-skip2.expect
@@ -1,17 +1,17 @@
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-         120          63:      1e676a <marker: timestamp 13352268558646604>
-         121          63:      1e676a <marker: tid 0x1e676a on core 10>
-         122          64:      1e676a ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
-         123          65:      1e676a ifetch       4 byte(s) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx $0x0000000000000000
-         124          66:      1e676a ifetch       2 byte(s) @ 0x0000000000401030 75 d9                jnz    $0x000000000040100b (taken)
-         125          67:      1e676a ifetch       7 byte(s) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    $0x0000000000000001 -> %rdi
-         126          68:      1e676a ifetch       8 byte(s) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
-         126          68:      1e676a                                             00
-         127          69:      1e676a ifetch       7 byte(s) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    $0x000000000000000d -> %rdx
-         128          70:      1e676a ifetch       5 byte(s) @ 0x0000000000401021 b8 01 00 00 00       mov    $0x00000001 -> %eax
-         129          71:      1e676a ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
+         120          63: W0.T1992554 <marker: timestamp 13352268558646604>
+         121          63: W0.T1992554 <marker: W0.T1992554 on core 10>
+         122          64: W0.T1992554 ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
+         123          65: W0.T1992554 ifetch       4 byte(s) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx $0x0000000000000000
+         124          66: W0.T1992554 ifetch       2 byte(s) @ 0x0000000000401030 75 d9                jnz    $0x000000000040100b (taken)
+         125          67: W0.T1992554 ifetch       7 byte(s) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    $0x0000000000000001 -> %rdi
+         126          68: W0.T1992554 ifetch       8 byte(s) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
+         126          68: W0.T1992554                                             00
+         127          69: W0.T1992554 ifetch       7 byte(s) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    $0x000000000000000d -> %rdx
+         128          70: W0.T1992554 ifetch       5 byte(s) @ 0x0000000000401021 b8 01 00 00 00       mov    $0x00000001 -> %eax
+         129          71: W0.T1992554 ifetch       2 byte(s) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
 View tool results:
               8 : total instructions
 

--- a/clients/drcachesim/tests/offline-stdin.expect
+++ b/clients/drcachesim/tests/offline-stdin.expect
@@ -1,15 +1,15 @@
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-           1           0:      872894 <marker: version 7>
-           2           0:      872894 <marker: filetype 0x10e40>
-           3           0:      872894 <marker: cache line size 64>
-           4           0:      872894 <marker: chunk instruction count 10000000>
-           5           0:      872894 <marker: page size 4096>
-           6           0:      872894 <marker: timestamp 13386385969186755>
-           7           0:      872894 <marker: tid 872894 on core 0>
-           8           1:      872894 ifetch       6 byte\(s\) @ 0x00007f87daf7ecc9 62 e1 fe 28 6f 06    vmovdqu64 \(%rsi\), %ymm16 \{%k0\}
-           9           1:      872894 read        32 byte\(s\) @ 0x00007f8590000d51 by PC 0x00007f87daf7ecc9
-          10           2:      872894 ifetch       4 byte\(s\) @ 0x00007f87daf7eccf 48 83 fa 40          cmp    %rdx, \$0x40
+           1           0:       d51be <marker: version 7>
+           2           0:       d51be <marker: filetype 0x10e40>
+           3           0:       d51be <marker: cache line size 64>
+           4           0:       d51be <marker: chunk instruction count 10000000>
+           5           0:       d51be <marker: page size 4096>
+           6           0:       d51be <marker: timestamp 13386385969186755>
+           7           0:       d51be <marker: tid 0xd51be on core 0>
+           8           1:       d51be ifetch       6 byte\(s\) @ 0x00007f87daf7ecc9 62 e1 fe 28 6f 06    vmovdqu64 \(%rsi\), %ymm16 \{%k0\}
+           9           1:       d51be read        32 byte\(s\) @ 0x00007f8590000d51 by PC 0x00007f87daf7ecc9
+          10           2:       d51be ifetch       4 byte\(s\) @ 0x00007f87daf7eccf 48 83 fa 40          cmp    %rdx, \$0x40
 View tool results:
               2 : total instructions

--- a/clients/drcachesim/tests/offline-stdin.expect
+++ b/clients/drcachesim/tests/offline-stdin.expect
@@ -1,15 +1,15 @@
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-           1           0:       d51be <marker: version 7>
-           2           0:       d51be <marker: filetype 0x10e40>
-           3           0:       d51be <marker: cache line size 64>
-           4           0:       d51be <marker: chunk instruction count 10000000>
-           5           0:       d51be <marker: page size 4096>
-           6           0:       d51be <marker: timestamp 13386385969186755>
-           7           0:       d51be <marker: tid 0xd51be on core 0>
-           8           1:       d51be ifetch       6 byte\(s\) @ 0x00007f87daf7ecc9 62 e1 fe 28 6f 06    vmovdqu64 \(%rsi\), %ymm16 \{%k0\}
-           9           1:       d51be read        32 byte\(s\) @ 0x00007f8590000d51 by PC 0x00007f87daf7ecc9
-          10           2:       d51be ifetch       4 byte\(s\) @ 0x00007f87daf7eccf 48 83 fa 40          cmp    %rdx, \$0x40
+           1           0:  W0.T872894 <marker: version 7>
+           2           0:  W0.T872894 <marker: filetype 0x10e40>
+           3           0:  W0.T872894 <marker: cache line size 64>
+           4           0:  W0.T872894 <marker: chunk instruction count 10000000>
+           5           0:  W0.T872894 <marker: page size 4096>
+           6           0:  W0.T872894 <marker: timestamp 13386385969186755>
+           7           0:  W0.T872894 <marker: W0.T872894 on core 0>
+           8           1:  W0.T872894 ifetch       6 byte\(s\) @ 0x00007f87daf7ecc9 62 e1 fe 28 6f 06    vmovdqu64 \(%rsi\), %ymm16 \{%k0\}
+           9           1:  W0.T872894 read        32 byte\(s\) @ 0x00007f8590000d51 by PC 0x00007f87daf7ecc9
+          10           2:  W0.T872894 ifetch       4 byte\(s\) @ 0x00007f87daf7eccf 48 83 fa 40          cmp    %rdx, \$0x40
 View tool results:
               2 : total instructions

--- a/clients/drcachesim/tests/offline-trim.templatex
+++ b/clients/drcachesim/tests/offline-trim.templatex
@@ -2,26 +2,26 @@ Output 288 entries from 329 entries.
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-           1           0:     1992554 <marker: version 6>
-           2           0:     1992554 <marker: filetype 0xe40>
-           3           0:     1992554 <marker: cache line size 64>
-           4           0:     1992554 <marker: chunk instruction count 20>
-           5           0:     1992554 <marker: page size 4096>
-           6           0:     1992554 <marker: timestamp 13352268558646120>
+           1           0:      1e676a <marker: version 6>
+           2           0:      1e676a <marker: filetype 0xe40>
+           3           0:      1e676a <marker: cache line size 64>
+           4           0:      1e676a <marker: chunk instruction count 20>
+           5           0:      1e676a <marker: page size 4096>
+           6           0:      1e676a <marker: timestamp 13352268558646120>
 .*
-         207         112:     1992554 <marker: timestamp 13352268558646661>
-         208         112:     1992554 <marker: tid 1992554 on core 10>
-         209         113:     1992554 ifetch       4 byte\(s\) @ 0x0000000000401028 48 83 eb 01          sub    \$0x0000000000000001 %rbx -> %rbx
-         210         114:     1992554 ifetch       4 byte\(s\) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx \$0x0000000000000000
-         211         115:     1992554 ifetch       2 byte\(s\) @ 0x0000000000401030 75 d9                jnz    \$0x000000000040100b \(taken\)
-         212         116:     1992554 ifetch       7 byte\(s\) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    \$0x0000000000000001 -> %rdi
-         213         117:     1992554 ifetch       8 byte\(s\) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
-         213         117:     1992554                                             00
-         214         118:     1992554 ifetch       7 byte\(s\) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    \$0x000000000000000d -> %rdx
-         215         119:     1992554 ifetch       5 byte\(s\) @ 0x0000000000401021 b8 01 00 00 00       mov    \$0x00000001 -> %eax
-         216         120:     1992554 ifetch       2 byte\(s\) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
-         217         120:     1992554 <marker: chunk footer #5>
-         218         120:     1992554 <thread 1992554 exited>
+         207         112:      1e676a <marker: timestamp 13352268558646661>
+         208         112:      1e676a <marker: tid 0x1e676a on core 10>
+         209         113:      1e676a ifetch       4 byte\(s\) @ 0x0000000000401028 48 83 eb 01          sub    \$0x0000000000000001 %rbx -> %rbx
+         210         114:      1e676a ifetch       4 byte\(s\) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx \$0x0000000000000000
+         211         115:      1e676a ifetch       2 byte\(s\) @ 0x0000000000401030 75 d9                jnz    \$0x000000000040100b \(taken\)
+         212         116:      1e676a ifetch       7 byte\(s\) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    \$0x0000000000000001 -> %rdi
+         213         117:      1e676a ifetch       8 byte\(s\) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
+         213         117:      1e676a                                             00
+         214         118:      1e676a ifetch       7 byte\(s\) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    \$0x000000000000000d -> %rdx
+         215         119:      1e676a ifetch       5 byte\(s\) @ 0x0000000000401021 b8 01 00 00 00       mov    \$0x00000001 -> %eax
+         216         120:      1e676a ifetch       2 byte\(s\) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
+         217         120:      1e676a <marker: chunk footer #5>
+         218         120:      1e676a <thread 0x1e676a exited>
 View tool results:
             120 : total instructions
 

--- a/clients/drcachesim/tests/offline-trim.templatex
+++ b/clients/drcachesim/tests/offline-trim.templatex
@@ -1,27 +1,27 @@
 Output 288 entries from 329 entries.
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-           1           0:      1e676a <marker: version 6>
-           2           0:      1e676a <marker: filetype 0xe40>
-           3           0:      1e676a <marker: cache line size 64>
-           4           0:      1e676a <marker: chunk instruction count 20>
-           5           0:      1e676a <marker: page size 4096>
-           6           0:      1e676a <marker: timestamp 13352268558646120>
+           1           0: W0.T1992554 <marker: version 6>
+           2           0: W0.T1992554 <marker: filetype 0xe40>
+           3           0: W0.T1992554 <marker: cache line size 64>
+           4           0: W0.T1992554 <marker: chunk instruction count 20>
+           5           0: W0.T1992554 <marker: page size 4096>
+           6           0: W0.T1992554 <marker: timestamp 13352268558646120>
 .*
-         207         112:      1e676a <marker: timestamp 13352268558646661>
-         208         112:      1e676a <marker: tid 0x1e676a on core 10>
-         209         113:      1e676a ifetch       4 byte\(s\) @ 0x0000000000401028 48 83 eb 01          sub    \$0x0000000000000001 %rbx -> %rbx
-         210         114:      1e676a ifetch       4 byte\(s\) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx \$0x0000000000000000
-         211         115:      1e676a ifetch       2 byte\(s\) @ 0x0000000000401030 75 d9                jnz    \$0x000000000040100b \(taken\)
-         212         116:      1e676a ifetch       7 byte\(s\) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    \$0x0000000000000001 -> %rdi
-         213         117:      1e676a ifetch       8 byte\(s\) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
-         213         117:      1e676a                                             00
-         214         118:      1e676a ifetch       7 byte\(s\) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    \$0x000000000000000d -> %rdx
-         215         119:      1e676a ifetch       5 byte\(s\) @ 0x0000000000401021 b8 01 00 00 00       mov    \$0x00000001 -> %eax
-         216         120:      1e676a ifetch       2 byte\(s\) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
-         217         120:      1e676a <marker: chunk footer #5>
-         218         120:      1e676a <thread 0x1e676a exited>
+         207         112: W0.T1992554 <marker: timestamp 13352268558646661>
+         208         112: W0.T1992554 <marker: W0.T1992554 on core 10>
+         209         113: W0.T1992554 ifetch       4 byte\(s\) @ 0x0000000000401028 48 83 eb 01          sub    \$0x0000000000000001 %rbx -> %rbx
+         210         114: W0.T1992554 ifetch       4 byte\(s\) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx \$0x0000000000000000
+         211         115: W0.T1992554 ifetch       2 byte\(s\) @ 0x0000000000401030 75 d9                jnz    \$0x000000000040100b \(taken\)
+         212         116: W0.T1992554 ifetch       7 byte\(s\) @ 0x000000000040100b 48 c7 c7 01 00 00 00 mov    \$0x0000000000000001 -> %rdi
+         213         117: W0.T1992554 ifetch       8 byte\(s\) @ 0x0000000000401012 48 8d 34 25 00 20 40 lea    0x00402000 -> %rsi
+         213         117: W0.T1992554                                             00
+         214         118: W0.T1992554 ifetch       7 byte\(s\) @ 0x000000000040101a 48 c7 c2 0d 00 00 00 mov    \$0x000000000000000d -> %rdx
+         215         119: W0.T1992554 ifetch       5 byte\(s\) @ 0x0000000000401021 b8 01 00 00 00       mov    \$0x00000001 -> %eax
+         216         120: W0.T1992554 ifetch       2 byte\(s\) @ 0x0000000000401026 0f 05                syscall  -> %rcx %r11
+         217         120: W0.T1992554 <marker: chunk footer #5>
+         218         120: W0.T1992554 <thread W0.T1992554 exited>
 View tool results:
             120 : total instructions
 

--- a/clients/drcachesim/tests/offline-view.templatex
+++ b/clients/drcachesim/tests/offline-view.templatex
@@ -2,20 +2,20 @@ Hello, world!
 Output format:
 <--record#-> <--instr#->: <---tid---> <record details>
 ------------------------------------------------------------
-           1           0: +[0-9]+ <marker: version [0-9]>
-           2           0: +[0-9]+ <marker: filetype 0x[0-9a-f]*>
-           3           0: +[0-9]+ <marker: cache line size [0-9]*>
-           4           0: +[0-9]+ <marker: chunk instruction count [0-9]*>
-           5           0: +[0-9]+ <marker: page size [0-9]*>
+           1           0: +[0-9a-f]+ <marker: version [0-9]>
+           2           0: +[0-9a-f]+ <marker: filetype 0x[0-9a-f]*>
+           3           0: +[0-9a-f]+ <marker: cache line size [0-9]*>
+           4           0: +[0-9a-f]+ <marker: chunk instruction count [0-9]*>
+           5           0: +[0-9a-f]+ <marker: page size [0-9]*>
 #ifdef __ARM_FEATURE_SVE
-           6           0: +[0-9]+ <marker: vector length [0-9]* bytes>
-           7           0: +[0-9]+ <marker: timestamp [0-9]*>
-           8           0: +[0-9]+ <marker: tid [0-9]* on core [0-9]*>
-           9           1: +[0-9]+ ifetch      .*
+           6           0: +[0-9a-f]+ <marker: vector length [0-9]* bytes>
+           7           0: +[0-9a-f]+ <marker: timestamp [0-9]*>
+           8           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]* on core [0-9]*>
+           9           1: +[0-9a-f]+ ifetch      .*
 #else
-           6           0: +[0-9]+ <marker: timestamp [0-9]*>
-           7           0: +[0-9]+ <marker: tid [0-9]* on core [0-9]*>
-           8           1: +[0-9]+ ifetch      .*
+           6           0: +[0-9a-f]+ <marker: timestamp [0-9]*>
+           7           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]* on core [0-9]*>
+           8           1: +[0-9a-f]+ ifetch      .*
 #endif
 .*
 View tool results:

--- a/clients/drcachesim/tests/offline-view.templatex
+++ b/clients/drcachesim/tests/offline-view.templatex
@@ -1,21 +1,21 @@
 Hello, world!
 Output format:
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-           1           0: +[0-9a-f]+ <marker: version [0-9]>
-           2           0: +[0-9a-f]+ <marker: filetype 0x[0-9a-f]*>
-           3           0: +[0-9a-f]+ <marker: cache line size [0-9]*>
-           4           0: +[0-9a-f]+ <marker: chunk instruction count [0-9]*>
-           5           0: +[0-9a-f]+ <marker: page size [0-9]*>
+           1           0: +[0-9WT\.]+ <marker: version [0-9]>
+           2           0: +[0-9WT\.]+ <marker: filetype 0x[0-9a-f]*>
+           3           0: +[0-9WT\.]+ <marker: cache line size [0-9]*>
+           4           0: +[0-9WT\.]+ <marker: chunk instruction count [0-9]*>
+           5           0: +[0-9WT\.]+ <marker: page size [0-9]*>
 #ifdef __ARM_FEATURE_SVE
-           6           0: +[0-9a-f]+ <marker: vector length [0-9]* bytes>
-           7           0: +[0-9a-f]+ <marker: timestamp [0-9]*>
-           8           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]* on core [0-9]*>
-           9           1: +[0-9a-f]+ ifetch      .*
+           6           0: +[0-9WT\.]+ <marker: vector length [0-9]* bytes>
+           7           0: +[0-9WT\.]+ <marker: timestamp [0-9]*>
+           8           0: +[0-9WT\.]+ <marker: [0-9WT\.]* on core [0-9]*>
+           9           1: +[0-9WT\.]+ ifetch      .*
 #else
-           6           0: +[0-9a-f]+ <marker: timestamp [0-9]*>
-           7           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]* on core [0-9]*>
-           8           1: +[0-9a-f]+ ifetch      .*
+           6           0: +[0-9WT\.]+ <marker: timestamp [0-9]*>
+           7           0: +[0-9WT\.]+ <marker: [0-9WT\.]* on core [0-9]*>
+           8           1: +[0-9WT\.]+ ifetch      .*
 #endif
 .*
 View tool results:

--- a/clients/drcachesim/tests/record_filter_modify_marker_value.templatex
+++ b/clients/drcachesim/tests/record_filter_modify_marker_value.templatex
@@ -10,11 +10,11 @@ Output format:
 
 ------------------------------------------------------------
 
-           1           0: +[0-9]+ <marker: version [0-9]>
-           2           0: +[0-9]+ <marker: filetype 0x[0-9a-f]*>
-           3           0: +[0-9]+ <marker: cache line size [0-9]*>
-           4           0: +[0-9]+ <marker: chunk instruction count [0-9]*>
-           5           0: +[0-9]+ <marker: page size 2048>
-           6           0: +[0-9]+ <marker: timestamp [0-9]*>
-           7           0: +[0-9]+ <marker: tid [0-9]* on core unknown>
+           1           0: +[0-9a-f]+ <marker: version [0-9]>
+           2           0: +[0-9a-f]+ <marker: filetype 0x[0-9a-f]*>
+           3           0: +[0-9a-f]+ <marker: cache line size [0-9]*>
+           4           0: +[0-9a-f]+ <marker: chunk instruction count [0-9]*>
+           5           0: +[0-9a-f]+ <marker: page size 2048>
+           6           0: +[0-9a-f]+ <marker: timestamp [0-9]*>
+           7           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]* on core unknown>
 .*

--- a/clients/drcachesim/tests/record_filter_modify_marker_value.templatex
+++ b/clients/drcachesim/tests/record_filter_modify_marker_value.templatex
@@ -6,15 +6,15 @@ Output .* entries from .* entries.
 
 Output format:
 
-<--record#-> <--instr#->: <---tid---> <record details>
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
 
 ------------------------------------------------------------
 
-           1           0: +[0-9a-f]+ <marker: version [0-9]>
-           2           0: +[0-9a-f]+ <marker: filetype 0x[0-9a-f]*>
-           3           0: +[0-9a-f]+ <marker: cache line size [0-9]*>
-           4           0: +[0-9a-f]+ <marker: chunk instruction count [0-9]*>
-           5           0: +[0-9a-f]+ <marker: page size 2048>
-           6           0: +[0-9a-f]+ <marker: timestamp [0-9]*>
-           7           0: +[0-9a-f]+ <marker: tid 0x[0-9a-f]* on core unknown>
+           1           0: +[0-9WT\.]+ <marker: version [0-9]>
+           2           0: +[0-9WT\.]+ <marker: filetype 0x[0-9a-f]*>
+           3           0: +[0-9WT\.]+ <marker: cache line size [0-9]*>
+           4           0: +[0-9WT\.]+ <marker: chunk instruction count [0-9]*>
+           5           0: +[0-9WT\.]+ <marker: page size 2048>
+           6           0: +[0-9WT\.]+ <marker: timestamp [0-9]*>
+           7           0: +[0-9WT\.]+ <marker: [0-9WT\.]* on core unknown>
 .*

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -6158,7 +6158,8 @@ test_kernel_switch_sequences()
     // Zoom in and check the first sequence record by record with value checks.
     int idx = 0;
     bool res = true;
-    memref_tid_t workload1_tid1_final = (1ULL << 32) | (TID_BASE + 4);
+    memref_tid_t workload1_tid1_final =
+        (1ULL << MEMREF_ID_WORKLOAD_SHIFT) | (TID_BASE + 4);
     res = res &&
         check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
         check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
@@ -7047,10 +7048,12 @@ test_marker_updates()
             if (status == scheduler_t::STATUS_IDLE)
                 continue;
             assert(status == scheduler_t::STATUS_OK);
-            assert(memref.marker.tid ==
-                   ((outputs[i]->get_workload_id() << 32) | TID_BASE));
-            assert(memref.marker.pid ==
-                   ((outputs[i]->get_workload_id() << 32) | PID_BASE));
+            assert(
+                memref.marker.tid ==
+                ((outputs[i]->get_workload_id() << MEMREF_ID_WORKLOAD_SHIFT) | TID_BASE));
+            assert(
+                memref.marker.pid ==
+                ((outputs[i]->get_workload_id() << MEMREF_ID_WORKLOAD_SHIFT) | PID_BASE));
             if (memref.marker.type != TRACE_TYPE_MARKER)
                 continue;
             // Make sure the random values have some order now, satisfying invariants.

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -6158,6 +6158,7 @@ test_kernel_switch_sequences()
     // Zoom in and check the first sequence record by record with value checks.
     int idx = 0;
     bool res = true;
+    memref_tid_t workload1_tid1_final = (1UL << 32) | (TID_BASE + 4);
     res = res &&
         check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
         check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,
@@ -6185,24 +6186,24 @@ test_kernel_switch_sequences()
         check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
         check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
         // Process switch.
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_MARKER,
                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, scheduler_t::SWITCH_PROCESS) &&
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_MARKER,
                   // Verify that the timestamp is updated.
                   TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_MARKER,
                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, scheduler_t::SWITCH_PROCESS) &&
         // We now see the headers for this thread.
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_MARKER,
                   TRACE_MARKER_TYPE_VERSION) &&
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_MARKER,
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_MARKER,
                   TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
         // The 3-instr quantum should not count the 2 switch instrs.
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR) &&
-        check_ref(refs[0], idx, TID_BASE + 4, TRACE_TYPE_INSTR);
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
+        check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR);
     assert(res);
 
     {
@@ -6971,7 +6972,7 @@ test_exit_early()
 static void
 test_marker_updates()
 {
-    std::cerr << "\n----------------\nTesting marker updates\n";
+    std::cerr << "\n----------------\nTesting marker and tid/pid updates\n";
     scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
                                                scheduler_t::DEPENDENCY_IGNORE,
                                                scheduler_t::SCHEDULER_DEFAULTS,
@@ -6983,6 +6984,7 @@ test_marker_updates()
     const int NUM_INSTRS =
         static_cast<int>(sched_ops.time_units_per_us) * TIMESTAMP_GAP_US;
     static constexpr memref_tid_t TID_BASE = 100;
+    static constexpr memref_pid_t PID_BASE = 200;
     static constexpr uint64_t TIMESTAMP_BASE = 12340000;
 
     std::vector<trace_entry_t> inputs[NUM_INPUTS];
@@ -6991,9 +6993,10 @@ test_marker_updates()
     rand_gen.seed(static_cast<int>(reinterpret_cast<int64_t>(&inputs[0])));
 
     for (int i = 0; i < NUM_INPUTS; i++) {
-        memref_tid_t tid = TID_BASE + i;
+        // Each input is a separate workload with the same pid and tid.
+        memref_tid_t tid = TID_BASE;
         inputs[i].push_back(make_thread(tid));
-        inputs[i].push_back(make_pid(1));
+        inputs[i].push_back(make_pid(PID_BASE));
         inputs[i].push_back(make_version(TRACE_ENTRY_VERSION));
         // Add a randomly-increasing-value timestamp.
         uint64_t cur_timestamp = TIMESTAMP_BASE;
@@ -7016,7 +7019,7 @@ test_marker_updates()
         std::vector<scheduler_t::input_reader_t> readers;
         readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(inputs[i])),
                              std::unique_ptr<mock_reader_t>(new mock_reader_t()),
-                             TID_BASE + i);
+                             TID_BASE);
         sched_inputs.emplace_back(std::move(readers));
     }
     scheduler_t scheduler;
@@ -7044,6 +7047,10 @@ test_marker_updates()
             if (status == scheduler_t::STATUS_IDLE)
                 continue;
             assert(status == scheduler_t::STATUS_OK);
+            assert(memref.marker.tid ==
+                   ((outputs[i]->get_workload_id() << 32) | TID_BASE));
+            assert(memref.marker.pid ==
+                   ((outputs[i]->get_workload_id() << 32) | PID_BASE));
             if (memref.marker.type != TRACE_TYPE_MARKER)
                 continue;
             // Make sure the random values have some order now, satisfying invariants.

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -6158,7 +6158,7 @@ test_kernel_switch_sequences()
     // Zoom in and check the first sequence record by record with value checks.
     int idx = 0;
     bool res = true;
-    memref_tid_t workload1_tid1_final = (1UL << 32) | (TID_BASE + 4);
+    memref_tid_t workload1_tid1_final = (1ULL << 32) | (TID_BASE + 4);
     res = res &&
         check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_VERSION) &&
         check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_TIMESTAMP,

--- a/clients/drcachesim/tests/skip_unit_tests.cpp
+++ b/clients/drcachesim/tests/skip_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -118,9 +118,9 @@ test_skip_initial()
         //    Output format:
         //    <--record#-> <--instr#->: <---tid---> <record details>
         //    ------------------------------------------------------------
-        //              69          49:     3854659 <marker: timestamp 13312570674112282>
-        //              70          49:     3854659 <marker: tid 3854659 on core 3>
-        //              71          50:     3854659 ifetch    2 byte(s) @ 0x0000000401 ...
+        //              69          49:      3ad143 <marker: timestamp 13312570674112282>
+        //              70          49:      3ad143 <marker: tid 0x3ad143 on core 3>
+        //              71          50:      3ad143 ifetch    2 byte(s) @ 0x0000000401 ...
         //                                   d9                jnz    $0x000000000040100b
         std::string line;
         // First we expect "Output format:"
@@ -133,7 +133,7 @@ test_skip_initial()
         std::getline(res_stream, line, '\n');
         CHECK(starts_with(line, "------"), "missing divider line");
         // Next we expect the timestamp entry with the instruction count before
-        // a colon: "       69       49: T3854659 <marker: timestamp 13312570674112282>"
+        // a colon: "       69       49:   3ad143 <marker: timestamp 13312570674112282>"
         // We expect the count to equal the -skip_instrs value.
         std::getline(res_stream, line, '\n');
         std::stringstream expect_stream;

--- a/clients/drcachesim/tests/skip_unit_tests.cpp
+++ b/clients/drcachesim/tests/skip_unit_tests.cpp
@@ -116,24 +116,24 @@ test_skip_initial()
         std::stringstream res_stream(res);
         // Example output for -skip_instrs 49:
         //    Output format:
-        //    <--record#-> <--instr#->: <---tid---> <record details>
+        //    <--record#-> <--instr#->: <Wrkld.Tid> <record details>
         //    ------------------------------------------------------------
-        //              69          49:      3ad143 <marker: timestamp 13312570674112282>
-        //              70          49:      3ad143 <marker: tid 0x3ad143 on core 3>
-        //              71          50:      3ad143 ifetch    2 byte(s) @ 0x0000000401 ...
+        //              69          49: W0.T3854659 <marker: timestamp 13312570674112282>
+        //              70          49: W0.T3854659 <marker: W0.T3854659 on core 3>
+        //              71          50: W0.T3854659 ifetch    2 byte(s) @ 0x0000000401 ...
         //                                   d9                jnz    $0x000000000040100b
         std::string line;
         // First we expect "Output format:"
         std::getline(res_stream, line, '\n');
         CHECK(starts_with(line, "Output format"), "missing header");
-        // Next we expect "<--record#-> <--instr#->: <---tid---> <record details>"
+        // Next we expect "<--record#-> <--instr#->: <Wrkld.Tid> <record details>"
         std::getline(res_stream, line, '\n');
         CHECK(starts_with(line, "<--record#-> <--instr#->"), "missing 2nd header");
         // Next we expect "------------------------------------------------------------"
         std::getline(res_stream, line, '\n');
         CHECK(starts_with(line, "------"), "missing divider line");
         // Next we expect the timestamp entry with the instruction count before
-        // a colon: "       69       49:   3ad143 <marker: timestamp 13312570674112282>"
+        // a colon: "      69       49: W0.T3854659 <marker: timestamp 13312570674112282>"
         // We expect the count to equal the -skip_instrs value.
         std::getline(res_stream, line, '\n');
         std::stringstream expect_stream;

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -485,16 +485,16 @@ run_single_thread_chunk_test(void *drcontext)
         { TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_CPU_ID, { 3 } },
         { TRACE_TYPE_INSTR, 4, { 42 } },
     } };
-    const char *expect = R"DELIM(           1           0:           3 <marker: version 3>
-           2           0:           3 <marker: filetype 0x0>
-           3           0:           3 <marker: cache line size 64>
-           4           0:           3 <marker: chunk instruction count 2>
-           5           0:           3 <marker: timestamp 1002>
-           6           0:           3 <marker: tid 0x3 on core 2>
-           7           1:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
-           8           2:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
-           9           2:           3 <marker: chunk footer #0>
-          10           3:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
+    const char *expect = R"DELIM(           1           0:       W0.T3 <marker: version 3>
+           2           0:       W0.T3 <marker: filetype 0x0>
+           3           0:       W0.T3 <marker: cache line size 64>
+           4           0:       W0.T3 <marker: chunk instruction count 2>
+           5           0:       W0.T3 <marker: timestamp 1002>
+           6           0:       W0.T3 <marker: W0.T3 on core 2>
+           7           1:       W0.T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+           8           2:       W0.T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+           9           2:       W0.T3 <marker: chunk footer #0>
+          10           3:       W0.T3 ifetch       4 byte(s) @ 0x0000002a non-branch
 )DELIM";
     instrlist_t *ilist_unused = nullptr;
     view_nomod_test_t view(drcontext, *ilist_unused, 0, 0);
@@ -552,31 +552,31 @@ run_serial_chunk_test(void *drcontext)
         }
     };
     const char *expect =
-        R"DELIM(           1           0:           3 <marker: version 3>
-           2           0:           3 <marker: filetype 0x0>
-           3           0:           3 <marker: cache line size 64>
-           4           0:           3 <marker: chunk instruction count 20>
-           5           0:           3 <marker: timestamp 1001>
-           6           0:           3 <marker: tid 0x3 on core 2>
-           7           1:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
-           8           2:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
+        R"DELIM(           1           0:       W0.T3 <marker: version 3>
+           2           0:       W0.T3 <marker: filetype 0x0>
+           3           0:       W0.T3 <marker: cache line size 64>
+           4           0:       W0.T3 <marker: chunk instruction count 20>
+           5           0:       W0.T3 <marker: timestamp 1001>
+           6           0:       W0.T3 <marker: W0.T3 on core 2>
+           7           1:       W0.T3 ifetch       4 byte(s) @ 0x0000002a non-branch
+           8           2:       W0.T3 ifetch       4 byte(s) @ 0x0000002a non-branch
 ------------------------------------------------------------
-           9           2:           7 <marker: version 3>
-          10           2:           7 <marker: filetype 0x0>
-          11           2:           7 <marker: cache line size 64>
-          12           2:           7 <marker: chunk instruction count 2>
-          13           2:           7 <marker: timestamp 1002>
-          14           2:           7 <marker: tid 0x7 on core 2>
-          15           3:           7 ifetch       4 byte(s) @ 0x0000002a non-branch
-          16           4:           7 ifetch       4 byte(s) @ 0x0000002a non-branch
+           9           2:       W0.T7 <marker: version 3>
+          10           2:       W0.T7 <marker: filetype 0x0>
+          11           2:       W0.T7 <marker: cache line size 64>
+          12           2:       W0.T7 <marker: chunk instruction count 2>
+          13           2:       W0.T7 <marker: timestamp 1002>
+          14           2:       W0.T7 <marker: W0.T7 on core 2>
+          15           3:       W0.T7 ifetch       4 byte(s) @ 0x0000002a non-branch
+          16           4:       W0.T7 ifetch       4 byte(s) @ 0x0000002a non-branch
 ------------------------------------------------------------
-          17           4:           3 <marker: timestamp 1003>
-          18           4:           3 <marker: tid 0x3 on core 3>
-          19           5:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
+          17           4:       W0.T3 <marker: timestamp 1003>
+          18           4:       W0.T3 <marker: W0.T3 on core 3>
+          19           5:       W0.T3 ifetch       4 byte(s) @ 0x0000002a non-branch
 ------------------------------------------------------------
-          20           5:           7 <marker: timestamp 1004>
-          21           5:           7 <marker: tid 0x7 on core 3>
-          22           6:           7 ifetch       4 byte(s) @ 0x0000002a non-branch
+          20           5:       W0.T7 <marker: timestamp 1004>
+          21           5:       W0.T7 <marker: W0.T7 on core 3>
+          22           6:       W0.T7 ifetch       4 byte(s) @ 0x0000002a non-branch
 )DELIM";
     instrlist_t *ilist_unused = nullptr;
     view_nomod_test_t view(drcontext, *ilist_unused, 0, 0);
@@ -645,18 +645,18 @@ run_regdeps_test(void *drcontext)
 
     /* clang-format off */
     std::string expect =
-        std::string(R"DELIM(           1           0:           3 <marker: version 3>
-           2           0:           3 <marker: filetype 0x20e00>
-           3           0:           3 <marker: cache line size 64>
-           4           0:           3 <marker: chunk instruction count 5>
-           5           0:           3 <marker: timestamp 1002>
-           6           0:           3 <marker: tid 0x3 on core 2>
-           7           1:           3 ifetch       3 byte(s) @ 0x00007f6fdd3ec360 00010011 00060906 move [8byte]       %rv4 -> %rv7
-           8           2:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb35 00004011 004e0321 simd [32byte]       %rv76 -> %rv1
-           9           3:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb2d 00004811 00094921 load simd [32byte]       %rv7 -> %rv71
-          10           4:           3 ifetch      10 byte(s) @ 0x00007f86ef03d107 00001931 04020204 load store [4byte]       %rv0 %rv2 %rv36 -> %rv0
-          10           4:           3                                             00000026
-          11           5:           3 ifetch       2 byte(s) @ 0x00005605ec276c4d 00002200          branch  (taken)
+        std::string(R"DELIM(           1           0:       W0.T3 <marker: version 3>
+           2           0:       W0.T3 <marker: filetype 0x20e00>
+           3           0:       W0.T3 <marker: cache line size 64>
+           4           0:       W0.T3 <marker: chunk instruction count 5>
+           5           0:       W0.T3 <marker: timestamp 1002>
+           6           0:       W0.T3 <marker: W0.T3 on core 2>
+           7           1:       W0.T3 ifetch       3 byte(s) @ 0x00007f6fdd3ec360 00010011 00060906 move [8byte]       %rv4 -> %rv7
+           8           2:       W0.T3 ifetch       4 byte(s) @ 0x00007f6fdc76cb35 00004011 004e0321 simd [32byte]       %rv76 -> %rv1
+           9           3:       W0.T3 ifetch       4 byte(s) @ 0x00007f6fdc76cb2d 00004811 00094921 load simd [32byte]       %rv7 -> %rv71
+          10           4:       W0.T3 ifetch      10 byte(s) @ 0x00007f86ef03d107 00001931 04020204 load store [4byte]       %rv0 %rv2 %rv36 -> %rv0
+          10           4:       W0.T3                                             00000026
+          11           5:       W0.T3 ifetch       2 byte(s) @ 0x00005605ec276c4d 00002200          branch  (taken)
 )DELIM");
     /* clang-format on */
 

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -490,7 +490,7 @@ run_single_thread_chunk_test(void *drcontext)
            3           0:           3 <marker: cache line size 64>
            4           0:           3 <marker: chunk instruction count 2>
            5           0:           3 <marker: timestamp 1002>
-           6           0:           3 <marker: tid 3 on core 2>
+           6           0:           3 <marker: tid 0x3 on core 2>
            7           1:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
            8           2:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
            9           2:           3 <marker: chunk footer #0>
@@ -557,7 +557,7 @@ run_serial_chunk_test(void *drcontext)
            3           0:           3 <marker: cache line size 64>
            4           0:           3 <marker: chunk instruction count 20>
            5           0:           3 <marker: timestamp 1001>
-           6           0:           3 <marker: tid 3 on core 2>
+           6           0:           3 <marker: tid 0x3 on core 2>
            7           1:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
            8           2:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
 ------------------------------------------------------------
@@ -566,16 +566,16 @@ run_serial_chunk_test(void *drcontext)
           11           2:           7 <marker: cache line size 64>
           12           2:           7 <marker: chunk instruction count 2>
           13           2:           7 <marker: timestamp 1002>
-          14           2:           7 <marker: tid 7 on core 2>
+          14           2:           7 <marker: tid 0x7 on core 2>
           15           3:           7 ifetch       4 byte(s) @ 0x0000002a non-branch
           16           4:           7 ifetch       4 byte(s) @ 0x0000002a non-branch
 ------------------------------------------------------------
           17           4:           3 <marker: timestamp 1003>
-          18           4:           3 <marker: tid 3 on core 3>
+          18           4:           3 <marker: tid 0x3 on core 3>
           19           5:           3 ifetch       4 byte(s) @ 0x0000002a non-branch
 ------------------------------------------------------------
           20           5:           7 <marker: timestamp 1004>
-          21           5:           7 <marker: tid 7 on core 3>
+          21           5:           7 <marker: tid 0x7 on core 3>
           22           6:           7 ifetch       4 byte(s) @ 0x0000002a non-branch
 )DELIM";
     instrlist_t *ilist_unused = nullptr;
@@ -650,7 +650,7 @@ run_regdeps_test(void *drcontext)
            3           0:           3 <marker: cache line size 64>
            4           0:           3 <marker: chunk instruction count 5>
            5           0:           3 <marker: timestamp 1002>
-           6           0:           3 <marker: tid 3 on core 2>
+           6           0:           3 <marker: tid 0x3 on core 2>
            7           1:           3 ifetch       3 byte(s) @ 0x00007f6fdd3ec360 00010011 00060906 move [8byte]       %rv4 -> %rv7
            8           2:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb35 00004011 004e0321 simd [32byte]       %rv76 -> %rv1
            9           3:           3 ifetch       4 byte(s) @ 0x00007f6fdc76cb2d 00004811 00094921 load simd [32byte]       %rv7 -> %rv71

--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2022-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -749,7 +749,7 @@ record_filter_t::parallel_shard_memref(void *shard_data, const trace_entry_t &in
     ++per_shard->input_entry_count;
     trace_entry_t entry = input_entry;
     bool output = true;
-    // XXX: Once we have multi-workload inputs we'll want all our PC keys to become
+    // XXX i#7404: Once we have multi-workload inputs we'll want all our PC keys to become
     // pairs <get_workload_ordinal(), PC>.
     if (per_shard->shard_stream->get_workload_id() != per_shard->prev_workload_id &&
         per_shard->shard_stream->get_workload_id() >= 0 &&

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -473,7 +473,8 @@ schedule_stats_t::print_counters(const counters_t &counters)
         std::cerr << ": ";
         auto it = counters.threads.begin();
         while (it != counters.threads.end()) {
-            std::cerr << "W" << it->workload_id << ".T" << it->tid;
+            std::cerr << "W" << it->workload_id << ".T" << std::hex << it->tid
+                      << std::dec;
             ++it;
             if (it != counters.threads.end())
                 std::cerr << ", ";

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -361,8 +361,10 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
     // We use <workload,tid> to detect switches (instead of input_id) to handle
     // core-sharded-on-disk.  However, we still prefer the input_id ordinal
     // for the letters.
-    int64_t workload_id = shard->stream->get_workload_id();
     int64_t tid = shard->stream->get_tid();
+    int64_t workload_id = TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard->filetype)
+        ? workload_from_memref_tid(tid)
+        : shard->stream->get_workload_id();
     int64_t letter_ord =
         (TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard->filetype) || input_id < 0)
         ? tid
@@ -473,8 +475,7 @@ schedule_stats_t::print_counters(const counters_t &counters)
         std::cerr << ": ";
         auto it = counters.threads.begin();
         while (it != counters.threads.end()) {
-            std::cerr << "W" << it->workload_id << ".T" << std::hex << it->tid
-                      << std::dec;
+            std::cerr << "W" << it->workload_id << ".T" << tid_from_memref_tid(it->tid);
             ++it;
             if (it != counters.threads.end())
                 std::cerr << ", ";

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -351,12 +351,13 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             // we would want to track the prior tid and print out a thread switch
             // message whenever it changes.
             if (memref.marker.marker_value == INVALID_CPU_MARKER_VALUE) {
-                std::cerr << "<marker: tid 0x" << std::hex << memref.marker.tid
-                          << std::dec << " on core unknown>\n";
+                std::cerr << "<marker: W" << workload_from_memref_tid(memref.data.tid)
+                          << ".T" << tid_from_memref_tid(memref.data.tid)
+                          << " on core unknown>\n";
             } else {
-                std::cerr << "<marker: tid 0x" << std::hex << memref.marker.tid
-                          << std::dec << " on core " << memref.marker.marker_value
-                          << ">\n";
+                std::cerr << "<marker: W" << workload_from_memref_tid(memref.data.tid)
+                          << ".T" << tid_from_memref_tid(memref.data.tid) << " on core "
+                          << memref.marker.marker_value << ">\n";
             }
             break;
         case TRACE_MARKER_TYPE_KERNEL_EVENT:
@@ -532,7 +533,8 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         switch (memref.data.type) {
         default: std::cerr << "<entry type " << memref.data.type << ">\n"; return true;
         case TRACE_TYPE_THREAD_EXIT:
-            std::cerr << "<thread " << memref.data.tid << " exited>\n";
+            std::cerr << "<thread W" << workload_from_memref_tid(memref.data.tid) << ".T"
+                      << tid_from_memref_tid(memref.data.tid) << " exited>\n";
             return true;
             // The rest are address-containing types.
         case TRACE_TYPE_READ: name = "read"; break;

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -351,11 +351,12 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             // we would want to track the prior tid and print out a thread switch
             // message whenever it changes.
             if (memref.marker.marker_value == INVALID_CPU_MARKER_VALUE) {
-                std::cerr << "<marker: tid " << memref.marker.tid
-                          << " on core unknown>\n";
+                std::cerr << "<marker: tid 0x" << std::hex << memref.marker.tid
+                          << std::dec << " on core unknown>\n";
             } else {
-                std::cerr << "<marker: tid " << memref.marker.tid << " on core "
-                          << memref.marker.marker_value << ">\n";
+                std::cerr << "<marker: tid 0x" << std::hex << memref.marker.tid
+                          << std::dec << " on core " << memref.marker.marker_value
+                          << ">\n";
             }
             break;
         case TRACE_MARKER_TYPE_KERNEL_EVENT:

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -145,7 +145,8 @@ protected:
 
         stream << std::setw(RECORD_COLUMN_WIDTH) << record_ord
                << std::setw(INSTR_COLUMN_WIDTH) << memstream->get_instruction_ordinal()
-               << ": " << std::setw(TID_COLUMN_WIDTH) << memref.marker.tid << " ";
+               << ": " << std::setw(TID_COLUMN_WIDTH) << std::hex << memref.marker.tid
+               << std::dec << " ";
     }
 
     /* We make this the first field so that dr_standalone_exit() is called after

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -125,7 +125,7 @@ protected:
     print_header()
     {
         std::cerr << "Output format:\n"
-                  << "<--record#-> <--instr#->: <---tid---> <record details>\n"
+                  << "<--record#-> <--instr#->: <Wrkld.Tid> <record details>\n"
                   << "------------------------------------------------------------\n";
     }
 
@@ -143,10 +143,13 @@ protected:
         prev_tid_ = memref.instr.tid;
         prev_record_ = record_ord;
 
+        std::ostringstream wtid;
+        wtid << "W" << workload_from_memref_tid(memref.data.tid) << ".T"
+             << tid_from_memref_tid(memref.data.tid);
+
         stream << std::setw(RECORD_COLUMN_WIDTH) << record_ord
                << std::setw(INSTR_COLUMN_WIDTH) << memstream->get_instruction_ordinal()
-               << ": " << std::setw(TID_COLUMN_WIDTH) << std::hex << memref.marker.tid
-               << std::dec << " ";
+               << ": " << std::setw(TID_COLUMN_WIDTH) << wtid.str() << " ";
     }
 
     /* We make this the first field so that dr_standalone_exit() is called after


### PR DESCRIPTION
In dynamic drmemtrace schedules combining multiple workloads, there can be pid or tid collisions.  We solve that by having the scheduler set the workload ordinal in the top 32 bits of both the pid and tid. We ignore tids being 64-bit values on Mac; and we do not support unique values for 32-bit builds when trace_entry_t-based tools such as record_filter are used.

Documents this, along with missing docs for cpuid and timestamp modifications.

Updates the view tool and schedule stats to print tids in hex, to make it easier to distinguish the workload ordinal.  Updates test templates and docs for this change.

Adds scheduler unit tests.

Here is what this looks like:
```
drmemtrace -tool view -multi_indir ../src/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir:../src/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir -core_sharded -cores 1 -sched_quantum 10 2>&1 | less Output format:
<--record#-> <--instr#->: <---tid---> <record details>
------------------------------------------------------------
           1           0:       d51be <marker: version 7>
           2           0:       d51be <marker: filetype 0xe40>
           3           0:       d51be <marker: cache line size 64>
...
------------------------------------------------------------
         135          60:   1000d51be <marker: version 7>
         136          60:   1000d51be <marker: filetype 0xe40>
         137          60:   1000d51be <marker: cache line size 64>
```

Fixes #7401