### PR TITLE
i#7270,i#i5437: Add glibc 2.35 AArch32 dl_tls_static_size offs

### DIFF
--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -108,9 +108,8 @@ jobs:
         DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
 
   # ARM cross-compile with gcc, with some tests run under QEMU.
-  # We use a more recent Ubuntu for a more recent QEMU.
   arm-cross-compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -834,7 +834,12 @@ privload_os_finalize(privmod_t *privmod)
 #    endif
     if (GLRO_dl_tls_static_size_OFFS == 0) {
         // We have some versions hardcoded.
-#    ifdef X64
+#    ifdef ARM
+        // These are the numbers for glibc 2.35.
+        GLRO_dl_tls_static_size_OFFS = 368;
+        GLRO_dl_tls_static_align_OFFS = GLRO_dl_tls_static_size_OFFS + 4;
+#    else
+#        ifdef X64
         // The offsets changed between 2.38 and 2.39.
         if (ver[2] == '3' && ver[3] < '9') {
             GLRO_dl_tls_static_size_OFFS = 0x2a8;
@@ -843,7 +848,7 @@ privload_os_finalize(privmod_t *privmod)
             GLRO_dl_tls_static_size_OFFS = 0x2c8;
             GLRO_dl_tls_static_align_OFFS = 0x2d0;
         }
-#    else
+#        else
         if (ver[2] == '3' && ver[3] >= '8') {
             GLRO_dl_tls_static_size_OFFS = 0x320;
             GLRO_dl_tls_static_align_OFFS = 0x324;
@@ -854,6 +859,7 @@ privload_os_finalize(privmod_t *privmod)
             GLRO_dl_tls_static_align_OFFS =
                 (ver[2] == '3' && ver[3] == '5') ? 0x32c : 0x320;
         }
+#        endif
 #    endif
     }
     size_t val = 4096, written;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2266,7 +2266,7 @@ elseif (AARCHXX)
   torunonly(common.broadfun-stress common.broadfun common/broadfun.c
     "-stress_recreate_state" "")
   # Under QEMU this can take longer.
-  set(common/broadfun-stress_timeout 240)
+  set(common.broadfun-stress_timeout 300)
 endif ()
 
 if (X86)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2265,6 +2265,8 @@ elseif (AARCHXX)
   # For now we simply run a simple app which still exercises quite a bit.
   torunonly(common.broadfun-stress common.broadfun common/broadfun.c
     "-stress_recreate_state" "")
+  # Under QEMU this can take longer.
+  set(common/broadfun-stress_timeout 120)
 endif ()
 
 if (X86)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2266,7 +2266,7 @@ elseif (AARCHXX)
   torunonly(common.broadfun-stress common.broadfun common/broadfun.c
     "-stress_recreate_state" "")
   # Under QEMU this can take longer.
-  set(common/broadfun-stress_timeout 120)
+  set(common/broadfun-stress_timeout 240)
 endif ()
 
 if (X86)


### PR DESCRIPTION
Fixes an FPE on Ubuntu 22 for AArch32 under QEMU due to the __libc_early_init #5437 missing initialization of dl_tls_static_size by setting the offset to a value determined by experimentation.

Updates the arm-cross-compile job to Ubuntu 22.04.

Issue: #7270, #5437