### PR TITLE
i#7371 Ubuntu 22: ignore signal_racesys

### DIFF
--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -56,7 +56,7 @@ jobs:
   # AArch64 cross-compile with gcc, with some tests run under QEMU.
   # We use a more recent Ubuntu for a more recent QEMU.
   aarch64-cross-compile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -450,6 +450,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             $ignore_failures_64{'code_api|client.drx_buf-test'} = 1;
             $ignore_failures_64{'code_api|sample.memval_simple'} = 1;
             $ignore_failures_64{'code_api|client.drreg-test'} = 1;
+            $ignore_failures_64{'code_api|linux.signal_racesys'} = 1;
             $issue_no = "#6260";
         } elsif ($is_macos) {
             %ignore_failures_32 = ('code_api|common.decode-bad' => 1, # i#3127

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -450,7 +450,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             $ignore_failures_64{'code_api|client.drx_buf-test'} = 1;
             $ignore_failures_64{'code_api|sample.memval_simple'} = 1;
             $ignore_failures_64{'code_api|client.drreg-test'} = 1;
-            $ignore_failures_64{'code_api|linux.signal_racesys'} = 1;
+            $ignore_failures_64{'code_api|linux.signal_racesys'} = 1; # i#7371
             $issue_no = "#6260";
         } elsif ($is_macos) {
             %ignore_failures_32 = ('code_api|common.decode-bad' => 1, # i#3127


### PR DESCRIPTION
Adds `code_api|linux.signal_racesys` test to ignore list when executing
under QEMU on an x86 host with DynamoRIO's target set to AARCH64.
Upgrades from Ubuntu 20.04 to 22.04 for aarch64-cross-compile jobs.

Issue #7371