### PR TITLE
i#7270 ubuntu22: Update config for clang-format and docs

### DIFF
--- a/.github/workflows/ci-clang-format.yml
+++ b/.github/workflows/ci-clang-format.yml
@@ -58,7 +58,7 @@ jobs:
   # the CI resources: 64-bit hits most clang-only warnings and 64-bit
   # is the primary target these days.
   clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -62,7 +62,7 @@ jobs:
   # Docs deployment, building on Linux.
   docs:
     # We use a more recent Ubuntu for better markdown support.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Updates Github Actions CI config for ci-docs and ci-clang-format to use Ubuntu 22.04.

Issue: #7270