### PR TITLE
Remove unused xfer_aborted_rseq var

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1027,7 +1027,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             if (shard->signal_stack_.empty()) {
                 // This can happen if tracing started in the middle of a signal.
                 // Try to continue by skipping the checks.
-                shard->last_signal_context_ = { 0, {}, false };
+                shard->last_signal_context_ = { 0, {} };
                 // We have not seen any instr in the outermost scope that we just
                 // discovered.
                 shard->last_instr_in_cur_context_ = {};
@@ -1071,9 +1071,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                     report_if_false(shard, discontinuity.empty(),
                                     discontinuity + error_msg_suffix);
                 }
-                shard->signal_stack_.push({ memref.marker.marker_value,
-                                            shard->last_instr_in_cur_context_,
-                                            shard->saw_rseq_abort_ });
+                shard->signal_stack_.push(
+                    { memref.marker.marker_value, shard->last_instr_in_cur_context_ });
                 // XXX: if last_instr_in_cur_context_ is {} currently, it means this is
                 // either a signal that arrived before the first instr in the trace, or
                 // it's a nested signal without any intervening instr after its

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -177,7 +177,6 @@ protected:
         struct signal_context {
             addr_t xfer_int_pc;
             instr_info_t pre_signal_instr;
-            bool xfer_aborted_rseq;
         };
         // We only support sigreturn-using handlers so we have pairing: no longjmp.
         std::stack<signal_context> signal_stack_;
@@ -189,7 +188,7 @@ protected:
         // The defaults are set to skip various signal-related checks in case we
         // see a signal-return before a signal-start (which happens when the trace
         // starts inside the app signal handler).
-        signal_context last_signal_context_ = { 0, {}, false };
+        signal_context last_signal_context_ = { 0, {} };
 
         // For the outer-most scope, like other nested signal scopes, we start with an
         // empty memref_t to denote absence of any pre-signal instr.


### PR DESCRIPTION
Removes the unused signal_context::xfer_aborted_rseq variable. Its previous use was removed by #5965.

xfer_aborted_rseq was used to relax the pre_signal_flow_continuity check that was intentionally removed (https://github.com/DynamoRIO/dynamorio/pull/5965/files#r1329469035).