### PR TITLE
i#6495 syscall inject: Fix PC disc at kernel_event after syscall trace

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3126,6 +3126,11 @@ check_kernel_syscall_trace(void)
             { gen_instr(TID_A), move2 },
             { gen_instr(TID_A), sysend },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 42), nullptr },
+            // Consecutive system call trace, for a stronger test.
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 42), nullptr },
+            { gen_instr(TID_A), move2 },
+            { gen_instr(TID_A), sysend },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 42), nullptr },
             // The value of the kernel_event marker is set to the move instruction which
             // is the next instruction in the outer-most trace context (the context
             // outside the syscall and signal trace).
@@ -3161,6 +3166,11 @@ check_kernel_syscall_trace(void)
             { gen_instr(TID_A), move2 },
             { gen_instr(TID_A), sysend },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 42), nullptr },
+            // Consecutive system call trace, for a stronger test.
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 42), nullptr },
+            { gen_instr(TID_A), move2 },
+            { gen_instr(TID_A), sysend },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 42), nullptr },
             // The value of the kernel_event marker is incorrectly set to the
             // sysend_fallthrough instruction.
             { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, WILL_BE_REPLACED),
@@ -3178,8 +3188,8 @@ check_kernel_syscall_trace(void)
                 memrefs, true,
                 { "Non-explicit control flow has no marker @ kernel_event marker",
                   /*tid=*/TID_A,
-                  /*ref_ordinal=*/10, /*last_timestamp=*/0,
-                  /*instrs_since_last_timestamp=*/3 },
+                  /*ref_ordinal=*/14, /*last_timestamp=*/0,
+                  /*instrs_since_last_timestamp=*/5 },
                 "Failed to catch incorrect kernel_event marker value after syscall "
                 "trace"))
             res = false;

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3067,7 +3067,8 @@ check_kernel_syscall_trace(void)
 #    elif defined(AARCHXX)
     instr_t *sys =
         INSTR_CREATE_svc(GLOBAL_DCONTEXT, opnd_create_immed_int((sbyte)0x0, OPSZ_1));
-    instr_t *sysret = INSTR_CREATE_eret(GLOBAL_DCONTEXT);
+    // Use a different instruction because INSTR_CREATE_eret isn't available.
+    instr_t *sysret = XINST_CREATE_return(GLOBAL_DCONTEXT);
 #    elif defined(RISCV64)
     instr_t *sys = INSTR_CREATE_ecall(GLOBAL_DCONTEXT);
     instr_t *sysret = INSTR_CREATE_eret(GLOBAL_DCONTEXT);

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -173,13 +173,13 @@ protected:
         // On UNIX generally last_instr_in_cur_context_ should be used instead.
         instr_info_t prev_instr_;
 #ifdef UNIX
-        // We keep track of some state per nested signal depth.
-        struct signal_context {
+        // We keep track of some state per nested signal depth, or per syscall.
+        struct trace_context_t {
             addr_t xfer_int_pc;
-            instr_info_t pre_signal_instr;
+            instr_info_t pre_trace_instr;
         };
         // We only support sigreturn-using handlers so we have pairing: no longjmp.
-        std::stack<signal_context> signal_stack_;
+        std::stack<trace_context_t> trace_context_stack_;
 
         // When we see a TRACE_MARKER_TYPE_KERNEL_XFER we pop the top entry from
         // the above stack into the following. This is required because some of
@@ -188,7 +188,7 @@ protected:
         // The defaults are set to skip various signal-related checks in case we
         // see a signal-return before a signal-start (which happens when the trace
         // starts inside the app signal handler).
-        signal_context last_signal_context_ = { 0, {} };
+        trace_context_t last_trace_context_ = { 0, {} };
 
         // For the outer-most scope, like other nested signal scopes, we start with an
         // empty memref_t to denote absence of any pre-signal instr.


### PR DESCRIPTION
Fixes PC discontinuity errors reported at kernel_event markers present immediately after a syscall trace.

For traces with system call sequences, the drmemtrace invariant_checker expects the kernel_event marker to hold the next PC of the last instruction inside the syscall trace. However, it should really expect the kernel_event marker to hold the actual return point of the signal, which depends on the instr before the system call trace (which would be the immediately prior instruction for traces without any system call sequences).

We solve this by considering each system call trace as a separate trace context, similar to how signal traces are treated today.

Issue: #6495, #7157