### PR TITLE
Experimentally remove tabs from DRstats/StdAfx.cpp.

### DIFF
--- a/tools/DRstats/StdAfx.cpp
+++ b/tools/DRstats/StdAfx.cpp
@@ -35,7 +35,7 @@
 /* Copyright (c) 2002 Hewlett-Packard Company */
 
 // stdafx.cpp : source file that includes just the standard includes
-//	DynamoRIO.pch will be the pre-compiled header
-//	stdafx.obj will contain the pre-compiled type information
+//      DynamoRIO.pch will be the pre-compiled header
+//      stdafx.obj will contain the pre-compiled type information
 
 #include "stdafx.h"


### PR DESCRIPTION
I want to see if the CI tests have a problem with this.