### PR TITLE
i#6495 syscall inject: Fix PC disc at kernel_event after kernel trace

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1052,10 +1052,17 @@ typedef enum {
      * The individual traces are enclosed within a pair of
      * #TRACE_MARKER_TYPE_SYSCALL_TRACE_START and #TRACE_MARKER_TYPE_SYSCALL_TRACE_END
      * markers which also specify what system call the contained trace belongs to. This
-     * file can be used with -syscall_template_file to raw2trace to create an
-     * #OFFLINE_FILE_TYPE_KERNEL_SYSCALLS trace. See the sample file written by the
-     * burst_syscall_inject.cpp test for more details on the expected format for the
-     * system call template file.
+     * file can be used to create an #OFFLINE_FILE_TYPE_KERNEL_SYSCALLS trace with
+     * -syscall_template_file to raw2trace, with -sched_syscall_file to the
+     * drmemtrace analyzer framework, and also with #dynamorio::drmemtrace::
+     * scheduler_tmpl_t::scheduler_options_t.kernel_syscall_trace_path and #dynamorio::
+     * drmemtrace::scheduler_tmpl_t::scheduler_options_t.kernel_syscall_reader to the
+     * scheduler. Each system call trace template uses the regular drmemtrace format,
+     * including using paired #TRACE_MARKER_TYPE_KERNEL_EVENT and
+     * #TRACE_MARKER_TYPE_KERNEL_XFER markers to represent kernel interrupts during
+     * system call execution. See the sample file written by the burst_syscall_inject.cpp
+     * test for more details on the expected format for the system call template file.
+     *
      * TODO i#6495: Add support for reading a zipfile where each trace template is in
      * a separate component. This will make it easier to manually append, update, or
      * inspect the individual templates, and also allow streaming the component with the

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -2953,7 +2953,7 @@ check_exit_found(void)
 }
 
 bool
-check_kernel_trace(bool for_syscall)
+check_kernel_trace_and_signal_markers(bool for_syscall)
 {
 #ifdef UNIX
     trace_marker_type_t start_marker;
@@ -3938,8 +3938,8 @@ test_main(int argc, const char *argv[])
         check_read_write_records_match_operands() && check_exit_found() &&
         check_kernel_syscall_trace() && check_has_instructions() &&
         check_kernel_context_switch_trace() &&
-        check_kernel_trace(/*for_syscall=*/false) &&
-        check_kernel_trace(/*for_syscall=*/true) && check_regdeps()) {
+        check_kernel_trace_and_signal_markers(/*for_syscall=*/false) &&
+        check_kernel_trace_and_signal_markers(/*for_syscall=*/true) && check_regdeps()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1064,6 +1064,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         report_if_false(shard, memref.marker.marker_value != 0,
                         "Kernel event marker value missing");
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
+            // We expect a proper pairing of TRACE_MARKER_TYPE_KERNEL_EVENT and
+            // TRACE_MARKER_TYPE_KERNEL_XFER markers inside the kernel system call
+            // and context switch traces that are used for trace injection.
+            // XXX: Note that we do not make an effort to add these markers at all
+            // to the PT syscall traces today.
             report_if_false(shard,
                             shard->signal_stack_depth_at_syscall_trace_start_ <
                                 static_cast<int>(shard->signal_stack_.size()),

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -242,8 +242,10 @@ protected:
         bool between_kernel_context_switch_markers_ = false;
         instr_info_t pre_syscall_trace_instr_;
         instr_info_t pre_context_switch_trace_instr_;
+#ifdef UNIX
         int signal_stack_depth_at_syscall_trace_start_ = -1;
         int signal_stack_depth_at_context_switch_trace_start_ = -1;
+#endif
         // Relevant when -no_abort_on_invariant_error.
         uint64_t error_count_ = 0;
     };

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -242,6 +242,8 @@ protected:
         bool between_kernel_context_switch_markers_ = false;
         instr_info_t pre_syscall_trace_instr_;
         instr_info_t pre_context_switch_trace_instr_;
+        int signal_stack_depth_at_syscall_trace_start_ = -1;
+        int signal_stack_depth_at_context_switch_trace_start_ = -1;
         // Relevant when -no_abort_on_invariant_error.
         uint64_t error_count_ = 0;
     };


### PR DESCRIPTION
Fixes PC discontinuity errors reported at kernel_event markers present immediately after a syscall or context switch trace.

Immediately following a system call or context switch sequence, the drmemtrace invariant_checker currently expects the kernel_event marker to hold the next PC of the last instruction inside the kernel trace. However, it should really expect the kernel_event marker to hold the actual pc after the kernel_event interruption (which could be a signal, rseq abort, exception, callback, etc). For traces without any kernel sequences, the interrupted pc would be the immediately prior instruction, but we need special handling for traces with kernel sequences where there is a whole syscall or context switch trace intervening. We extend the drmemtrace invariant_checker logic to remember and use the pre-interruption instr for the PC discontinuity check.

We do not need to add complex "trace context" handling like we do for signals, because we do not expect nested kernel sequences.

Also adds invariant checks to ensure the kernel_event and kernel_xfer markers inside the syscall or context switch trace have parity.

Issue: #6495, #7157