### PR TITLE
i#6662 public traces: Fix regdeps crash and assert

### DIFF
--- a/core/ir/disassemble_shared.c
+++ b/core/ir/disassemble_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2001-2009 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1315,6 +1315,12 @@ internal_instr_disassemble(char *buf, size_t bufsz, size_t *sofar DR_PARAM_INOUT
         SYSLOG_INTERNAL_WARNING_ONCE("Selected disassembly style is not implemented for "
                                      "AArch64: no operands will be printed.");
 #endif
+        if (instr_get_isa_mode(instr) == DR_ISA_REGDEPS) {
+            SYSLOG_INTERNAL_WARNING_ONCE(
+                "Selected disassembly style is not implemented "
+                "for DR_ISA_REGDEPS: no operands will be printed.");
+            return;
+        }
         instr_disassemble_opnds_noimplicit(buf, bufsz, sofar, dcontext, instr);
         /* we avoid trailing spaces if no operands */
         if (*sofar == offs_pre_opnds) {

--- a/core/ir/instr_shared.c
+++ b/core/ir/instr_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3013,7 +3013,7 @@ instr_get_operation_size(instr_t *instr)
 void
 instr_set_operation_size(instr_t *instr, opnd_size_t operation_size)
 {
-    CLIENT_ASSERT(instr_get_isa_mode(instr) != DR_ISA_REGDEPS,
+    CLIENT_ASSERT(instr_get_isa_mode(instr) == DR_ISA_REGDEPS,
                   "instr_set_operation_size: only DR_ISA_REGDEPS instructions can have "
                   "an operation_size");
     instr->operation_size = operation_size;

--- a/suite/tests/api/ir_regdeps.c
+++ b/suite/tests/api/ir_regdeps.c
@@ -732,6 +732,34 @@ check_virtual_register_enum_values(void)
     CHECK_VIRTUAL_REGISTER_IDS;
 }
 
+static void
+test_invalid_disasm(void *dcontext)
+{
+    // Synthesize a regdeps instr.
+    instr_t *instr = instr_build(dcontext, OP_UNDECODED, 1, 1);
+    instr_set_isa_mode(instr, DR_ISA_REGDEPS);
+    instr_set_dst(instr, 0, opnd_create_reg(DR_REG_VIRT2));
+    instr_set_src(instr, 0, opnd_create_reg(DR_REG_VIRT5));
+    instr_set_operation_size(instr, OPSZ_8);
+
+    // Make sure it doesn't crash if we select a not-fully-supported disasm style
+    // and try to print it out.
+    disassemble_set_syntax(DR_DISASM_INTEL);
+    char buf[128];
+    size_t len =
+        instr_disassemble_to_buffer(dcontext, instr, buf, BUFFER_SIZE_ELEMENTS(buf));
+    ASSERT(len > 0);
+    disassemble_set_syntax(DR_DISASM_ATT);
+    len = instr_disassemble_to_buffer(dcontext, instr, buf, BUFFER_SIZE_ELEMENTS(buf));
+    ASSERT(len > 0);
+    disassemble_set_syntax(DR_DISASM_ARM);
+    len = instr_disassemble_to_buffer(dcontext, instr, buf, BUFFER_SIZE_ELEMENTS(buf));
+    ASSERT(len > 0);
+
+    instr_destroy(dcontext, instr);
+    disassemble_set_syntax(DR_DISASM_DR);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -757,6 +785,8 @@ main(int argc, char *argv[])
     test_virtual_register_names(dcontext);
 
     check_virtual_register_enum_values();
+
+    test_invalid_disasm(dcontext);
 
     print("All DR_ISA_REGDEPS tests are done.\n");
     dr_standalone_exit();


### PR DESCRIPTION
Fixes a backward assert in instr_set_operation_size().

Fixes a crash if a regdeps instruction is disassembled with Intel, AT&T, or Arm styles selected.

Adds a test of both issues.

Also tested on drdisas temporarily disabling the "return 1" with a command that hits a SIGSEGV without this fix; with the fix it just doesn't print operands (the SYSLOG in this PR is only visible in full-DR runs):
```
$ clients/bin64/drdisas -syntax intel -mode regdeps 00001931 04020204 00000026
'regdeps' mode does not support 'intel' syntax
 00001931 04020204 load store [4byte]
 00000026
```

Issue: #6662