### PR TITLE
i#6495 syscall inject: Fix retaddr tracking inside kernel trace

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3137,16 +3137,17 @@ check_kernel_trace_and_signal_markers(bool for_syscall)
             // check to be skipped.
             gen_instr_type(TRACE_TYPE_INSTR_DIRECT_JUMP, TID_A, /*pc=*/2),
             gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, /*func_id*/ 1),
-            // Points to pc=3 as the return address, which is correct. This
-            // failed before we made sure to not add a zero entry to
-            // retaddr_stack_ at the kernel_event inside the syscall trace.
+            // Points to pc=3 as the return address, which is correct.
+            // For the non-call branch above, nothing is added to the
+            // retaddr stack, which causes the return address == top-of-stack
+            // check to be skipped. But the check failed before we made sure
+            // to not add a zero entry to retaddr_stack_ at the kernel_event
+            // inside the syscall trace.
             gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, /*pc=*/3),
             gen_exit(TID_A),
         };
-        std::cerr << "AAA in test\n";
         if (!run_checker(memrefs, false))
             return false;
-        std::cerr << "AAA done test\n";
     }
 #endif
     return true;

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3125,11 +3125,14 @@ check_kernel_trace_and_signal_markers(bool for_syscall)
             gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 103),
             gen_marker(TID_A, end_marker, KERNEL_TRACE_TYPE),
             // In some cases, control re-enters the function with a simple
-            // branch (instead of a call).
+            // branch (instead of a call), but the invariant_checker does
+            // not push anything to retaddr_stack_ on such instructions.
             // XXX: Not tracking such non-call instructions is likely a
-            // bigger issue in retaddr_stack_ logic. This test verifies
-            // correct operation in a very specific case, where the
-            // retaddr_stack_ is empty at this point which causes the
+            // bigger issue in retaddr_stack_ logic which can manifest more
+            // easily if the trace records functions that may be nested, and
+            // the later function is invoked with a non-call branch. This
+            // test verifies correct operation in the non-nested case, where
+            // the retaddr_stack_ is empty at this point which causes the
             // retaddr_stack_.top() == TRACE_MARKER_TYPE_FUNC_RETADDR.value
             // check to be skipped.
             gen_instr_type(TRACE_TYPE_INSTR_DIRECT_JUMP, TID_A, /*pc=*/2),

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3109,41 +3109,37 @@ check_kernel_trace_and_signal_markers(bool for_syscall)
             return false;
     }
     {
+        static constexpr uintptr_t FUNC_ID = 1;
+        static constexpr uintptr_t START_PC = 1;
+        static constexpr uintptr_t FUNC_PC = 10;
+        static constexpr uintptr_t SYSCALL_LAST_PC = 100;
+        static constexpr uintptr_t INTERRUPT_HANDLER_LAST_PC = 1000;
         std::vector<memref_t> memrefs = {
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_CALL, TID_A, START_PC),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, FUNC_ID),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, START_PC + 1),
+            gen_instr(TID_A, FUNC_PC),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, KERNEL_TRACE_TYPE),
             // Below we have an interrupt inside a kernel trace.
             gen_marker(TID_A, start_marker, KERNEL_TRACE_TYPE),
             // If not for the enclosing kernel trace markers, the
             // following would add a zero entry to retaddr_stack_.
-            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 11),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, SYSCALL_LAST_PC),
             // If not for the enclosing kernel trace markers, the
             // following would pop the zero entry from the retaddr_stack_.
-            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, /*pc=*/102),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 103),
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, INTERRUPT_HANDLER_LAST_PC),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER,
+                       INTERRUPT_HANDLER_LAST_PC + 1),
+            gen_instr(TID_A, SYSCALL_LAST_PC),
             gen_marker(TID_A, end_marker, KERNEL_TRACE_TYPE),
-            // In some cases, control re-enters the function with a simple
-            // branch (instead of a call), but the invariant_checker does
-            // not push anything to retaddr_stack_ on such instructions.
-            // XXX: Not tracking such non-call instructions is likely a
-            // bigger issue in retaddr_stack_ logic which can manifest more
-            // easily if the trace records functions that may be nested, and
-            // the later function is invoked with a non-call branch. This
-            // test verifies correct operation in the non-nested case, where
-            // the retaddr_stack_ is empty at this point which causes the
-            // retaddr_stack_.top() == TRACE_MARKER_TYPE_FUNC_RETADDR.value
-            // check to be skipped.
-            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_JUMP, TID_A, /*pc=*/2),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, /*func_id*/ 1),
-            // Points to pc=3 as the return address, which is correct.
-            // For the non-call branch above, nothing is added to the
-            // retaddr stack, which causes the return address == top-of-stack
-            // check to be skipped. But the check failed before we made sure
-            // to not add a zero entry to retaddr_stack_ at the kernel_event
-            // inside the syscall trace.
-            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, /*pc=*/3),
+            // For tail calls, we see function markers following a non-call instr.
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_JUMP, TID_A, FUNC_PC + 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, FUNC_ID),
+            // Same return address as the original direct_call above.
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, START_PC + 1),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false))

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2024 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2025 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -3107,6 +3107,43 @@ check_kernel_trace_and_signal_markers(bool for_syscall)
                 "Failed to catch incorrect kernel_event marker value after " + test_type +
                     " trace"))
             return false;
+    }
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, KERNEL_TRACE_TYPE),
+            // Below we have an interrupt inside a kernel trace.
+            gen_marker(TID_A, start_marker, KERNEL_TRACE_TYPE),
+            // If not for the enclosing kernel trace markers, the
+            // following would add a zero entry to retaddr_stack_.
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 11),
+            // If not for the enclosing kernel trace markers, the
+            // following would pop the zero entry from the retaddr_stack_.
+            gen_instr_type(TRACE_TYPE_INSTR_RETURN, TID_A, /*pc=*/102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 103),
+            gen_marker(TID_A, end_marker, KERNEL_TRACE_TYPE),
+            // In some cases, control re-enters the function with a simple
+            // branch (instead of a call).
+            // XXX: Not tracking such non-call instructions is likely a
+            // bigger issue in retaddr_stack_ logic. This test verifies
+            // correct operation in a very specific case, where the
+            // retaddr_stack_ is empty at this point which causes the
+            // retaddr_stack_.top() == TRACE_MARKER_TYPE_FUNC_RETADDR.value
+            // check to be skipped.
+            gen_instr_type(TRACE_TYPE_INSTR_DIRECT_JUMP, TID_A, /*pc=*/2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_ID, /*func_id*/ 1),
+            // Points to pc=3 as the return address, which is correct. This
+            // failed before we made sure to not add a zero entry to
+            // retaddr_stack_ at the kernel_event inside the syscall trace.
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FUNC_RETADDR, /*pc=*/3),
+            gen_exit(TID_A),
+        };
+        std::cerr << "AAA in test\n";
+        if (!run_checker(memrefs, false))
+            return false;
+        std::cerr << "AAA done test\n";
     }
 #endif
     return true;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -902,6 +902,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // return markers; these are only user-space.
         if (!(shard->between_kernel_context_switch_markers_ ||
               shard->between_kernel_syscall_trace_markers_)) {
+            // Tail calls are non-call CTIs. Even though the tail-called function will have
+            // the usual function markers, we intentionally do not push anything for
+            // tail calls here. The later function return address marker check will simply
+            // reuse the top-of-stack address which is indeed the return address of the
+            // tail call also.
             if (memref.instr.type == TRACE_TYPE_INSTR_DIRECT_CALL ||
                 memref.instr.type == TRACE_TYPE_INSTR_INDIRECT_CALL) {
                 shard->retaddr_stack_.push(memref.instr.addr + memref.instr.size);

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1052,7 +1052,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // Zero is pushed as a sentinel. This push matches the return used by post
         // signal handler to run the restorer code. It is assumed that all signal
         // handlers return normally and longjmp is not used.
-        if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+        if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
+            // retaddr_stack_ tracking is only for user-space code where we do
+            // function tracing.
+            !(shard->between_kernel_syscall_trace_markers_ ||
+              shard->between_kernel_context_switch_markers_)) {
             // If the marker is preceded by an RSEQ ABORT marker, do not push the sentinel
             // since there will not be a corresponding return.
             if (shard->prev_entry_.marker.type != TRACE_TYPE_MARKER ||

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -902,8 +902,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // return markers; these are only user-space.
         if (!(shard->between_kernel_context_switch_markers_ ||
               shard->between_kernel_syscall_trace_markers_)) {
-            // Tail calls are non-call CTIs. Even though the tail-called function will have
-            // the usual function markers, we intentionally do not push anything for
+            // Tail calls are non-call CTIs. Even though the tail-called function will
+            // have the usual function markers, we intentionally do not push anything for
             // tail calls here. The later function return address marker check will simply
             // reuse the top-of-stack address which is indeed the return address of the
             // tail call also.


### PR DESCRIPTION
Fixes the tracking for return addresses in drmemtrace invariant_checker for system call and context switch traces.

This fixes "Function marker retaddr should match prior call" in traces injected with kernel syscall sequences. This error weirdly manifested in the user-space part of the trace, but only after the trace was injected with kernel sequences. See details below.

At call instructions, the invariant_checker pushes the fallthrough pc to the retaddr stack, which is compared with the value of the later function return address marker. This entry is popped from the retaddr stack when we see a return instruction. At kernel_event markers, the invariant_checker inserts a dummy zero entry in the retaddr stack which is expected to be popped when the signal handler's return instruction is seen. This zero entry is not used for any check, but is used anyway simply so that we can treat all returns the same way.

We have some existing logic that skips pushing and popping from the retaddr stack for the kernel parts of the trace (since we don't do function tracing in the kernel, we don't need to track retaddrs for the kernel trace). But there was logic missing to do the same for the dummy zero entry at kernel_event markers inside the kernel trace.

Adds a unit test (derived from a real trace) which fails without this fix. It includes a tail call, which does not push anything to the retaddr stack as it is a non-call instr. Without this fix, the top of stack held the zero entry from the prior syscall trace, which caused the function return address marker check to fail. With this fix, the top of stack holds the return address of the prior call-instr (from before the  kernel trace), which is what the tail call also returns to, so the check passes. 

Issue: #6495, #7157