### PR TITLE
i#7303 drsyscall: Define statx and statx_timestamp for older Linux releases.

### DIFF
--- a/core/unix/include/linux_stat.h
+++ b/core/unix/include/linux_stat.h
@@ -10,8 +10,8 @@
  ****************************************************************************
  ****************************************************************************/
 
-#ifndef _STAT_H
-#define _STAT_H
+#ifndef _CORE_UNIX_INCLUDE_STAT
+#define _CORE_UNIX_INCLUDE_STAT
 
 #include <linux/types.h>
 
@@ -55,4 +55,4 @@ struct statx {
                         /* 0x100 */
 };
 
-#endif /* _STAT_H */
+#endif /* _CORE_UNIX_INCLUDE_STAT */

--- a/core/unix/include/stat.h
+++ b/core/unix/include/stat.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ ****************************************************************************
+ ***
+ ***   This header was generated from kernel headers to make
+ ***   information necessary for userspace to call into the Linux
+ ***   kernel available to DynamoRIO.  It contains only constants,
+ ***   structures, and macros generated from the original header, and
+ ***   thus, contains no copyrightable information.
+ ***
+ ****************************************************************************
+ ****************************************************************************/
+
+#ifndef _STAT_H
+#define _STAT_H
+
+#include <linux/types.h>
+
+struct statx_timestamp {
+    __s64 tv_sec;
+    __u32 tv_nsec;
+    __s32 __reserved;
+};
+
+struct statx {
+    /* 0x00 */
+    __u32 stx_mask;       /* What results were written [uncond] */
+    __u32 stx_blksize;    /* Preferred general I/O size [uncond] */
+    __u64 stx_attributes; /* Flags conveying information about the file [uncond] */
+    /* 0x10 */
+    __u32 stx_nlink; /* Number of hard links */
+    __u32 stx_uid;   /* User ID of owner */
+    __u32 stx_gid;   /* Group ID of owner */
+    __u16 stx_mode;  /* File mode */
+    __u16 __spare0[1];
+    /* 0x20 */
+    __u64 stx_ino;             /* Inode number */
+    __u64 stx_size;            /* File size */
+    __u64 stx_blocks;          /* Number of 512-byte blocks allocated */
+    __u64 stx_attributes_mask; /* Mask to show what's supported in stx_attributes */
+    /* 0x40 */
+    struct statx_timestamp stx_atime; /* Last access time */
+    struct statx_timestamp stx_btime; /* File creation time */
+    struct statx_timestamp stx_ctime; /* Last attribute change time */
+    struct statx_timestamp stx_mtime; /* Last data modification time */
+    /* 0x80 */
+    __u32 stx_rdev_major; /* Device ID of special file [if bdev/cdev] */
+    __u32 stx_rdev_minor;
+    __u32 stx_dev_major; /* ID of device containing file [uncond] */
+    __u32 stx_dev_minor;
+    /* 0x90 */
+    __u64 stx_mnt_id;
+    __u64 __spare2;
+    /* 0xa0 */
+    __u64 __spare3[12]; /* Spare space for future expansion */
+                        /* 0x100 */
+};
+
+#endif /* _STAT_H */

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -126,11 +126,11 @@ macro(configure_drsyscall_target target)
   include_directories(${PROJECT_SOURCE_DIR}/ext/drmf/common)
   include_directories(${PROJECT_SOURCE_DIR}/ext/drmf/framework)
 
-  IF (UNIX)
+  if (UNIX)
     include_directories(${PROJECT_SOURCE_DIR}/core/unix/include)
   endif ()
 
-  IF (WIN32)
+  if (WIN32)
     add_dependencies(${target} ntdll_imports)
     add_definitions(${asm_defs})
     # We can't include directly from DDK b/c the DDK include dir and VS include

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -126,6 +126,10 @@ macro(configure_drsyscall_target target)
   include_directories(${PROJECT_SOURCE_DIR}/ext/drmf/common)
   include_directories(${PROJECT_SOURCE_DIR}/ext/drmf/framework)
 
+  IF (UNIX)
+    include_directories(${PROJECT_SOURCE_DIR}/core/unix/include)
+  endif ()
+
   IF (WIN32)
     add_dependencies(${target} ntdll_imports)
     add_definitions(${asm_defs})

--- a/ext/drsyscall/linux_defines.h
+++ b/ext/drsyscall/linux_defines.h
@@ -228,6 +228,11 @@
 #    define _NSIG_WORDS 1 /* avoid 0 */
 #endif
 
+/* For syscall statx which was introduced in Linux Kernel 4.11. struct statx and
+ * statx_timestamp are not defined in older versions.
+ */
+#include "stat.h"
+
 typedef struct _kernel_sigset_t {
     unsigned long sig[_NSIG_WORDS];
 } kernel_sigset_t;
@@ -263,48 +268,5 @@ struct ustat {
     char f_fpack[6];
 };
 #endif
-
-/* Syscall statx was introduced in Linux Kernel 4.11. struct statx and
- * statx_timestamp are not defined in older versions.
- */
-struct statx_timestamp {
-    uint32_t tv_sec;
-    uint32_t tv_nsec;
-    int32_t __reserved;
-};
-
-struct statx {
-    /* 0x00 */
-    uint32_t stx_mask;       /* What results were written [uncond] */
-    uint32_t stx_blksize;    /* Preferred general I/O size [uncond] */
-    uint64_t stx_attributes; /* Flags conveying information about the file [uncond] */
-    /* 0x10 */
-    uint32_t stx_nlink; /* Number of hard links */
-    uint32_t stx_uid;   /* User ID of owner */
-    uint32_t stx_gid;   /* Group ID of owner */
-    __u16 stx_mode;     /* File mode */
-    __u16 __spare0[1];
-    /* 0x20 */
-    uint64_t stx_ino;             /* Inode number */
-    uint64_t stx_size;            /* File size */
-    uint64_t stx_blocks;          /* Number of 512-byte blocks allocated */
-    uint64_t stx_attributes_mask; /* Mask to show what's supported in stx_attributes */
-    /* 0x40 */
-    struct statx_timestamp stx_atime; /* Last access time */
-    struct statx_timestamp stx_btime; /* File creation time */
-    struct statx_timestamp stx_ctime; /* Last attribute change time */
-    struct statx_timestamp stx_mtime; /* Last data modification time */
-    /* 0x80 */
-    uint32_t stx_rdev_major; /* Device ID of special file [if bdev/cdev] */
-    uint32_t stx_rdev_minor;
-    uint32_t stx_dev_major; /* ID of device containing file [uncond] */
-    uint32_t stx_dev_minor;
-    /* 0x90 */
-    uint64_t stx_mnt_id;
-    uint64_t __spare2;
-    /* 0xa0 */
-    uint64_t __spare3[12]; /* Spare space for future expansion */
-                           /* 0x100 */
-};
 
 #endif /* _LINUX_DEFINES_H */

--- a/ext/drsyscall/linux_defines.h
+++ b/ext/drsyscall/linux_defines.h
@@ -44,7 +44,6 @@
 #include <sys/time.h>      /* struct timezone */
 #include <sys/sysinfo.h>   /* struct sysinfo */
 #include <sys/timex.h>     /* struct timex */
-#include <linux/stat.h>    /* struct statx */
 #include <linux/utsname.h> /* struct new_utsname */
 #include <sched.h>         /* struct sched_param */
 
@@ -264,5 +263,48 @@ struct ustat {
     char f_fpack[6];
 };
 #endif
+
+/* Syscall statx was introduced in Linux Kernel 4.11. struct statx and
+ * statx_timestamp are not defined in older versions.
+ */
+struct statx_timestamp {
+    uint32_t tv_sec;
+    uint32_t tv_nsec;
+    int32_t __reserved;
+};
+
+struct statx {
+    /* 0x00 */
+    uint32_t stx_mask;       /* What results were written [uncond] */
+    uint32_t stx_blksize;    /* Preferred general I/O size [uncond] */
+    uint64_t stx_attributes; /* Flags conveying information about the file [uncond] */
+    /* 0x10 */
+    uint32_t stx_nlink; /* Number of hard links */
+    uint32_t stx_uid;   /* User ID of owner */
+    uint32_t stx_gid;   /* Group ID of owner */
+    __u16 stx_mode;     /* File mode */
+    __u16 __spare0[1];
+    /* 0x20 */
+    uint64_t stx_ino;             /* Inode number */
+    uint64_t stx_size;            /* File size */
+    uint64_t stx_blocks;          /* Number of 512-byte blocks allocated */
+    uint64_t stx_attributes_mask; /* Mask to show what's supported in stx_attributes */
+    /* 0x40 */
+    struct statx_timestamp stx_atime; /* Last access time */
+    struct statx_timestamp stx_btime; /* File creation time */
+    struct statx_timestamp stx_ctime; /* Last attribute change time */
+    struct statx_timestamp stx_mtime; /* Last data modification time */
+    /* 0x80 */
+    uint32_t stx_rdev_major; /* Device ID of special file [if bdev/cdev] */
+    uint32_t stx_rdev_minor;
+    uint32_t stx_dev_major; /* ID of device containing file [uncond] */
+    uint32_t stx_dev_minor;
+    /* 0x90 */
+    uint64_t stx_mnt_id;
+    uint64_t __spare2;
+    /* 0xa0 */
+    uint64_t __spare3[12]; /* Spare space for future expansion */
+                           /* 0x100 */
+};
 
 #endif /* _LINUX_DEFINES_H */

--- a/ext/drsyscall/linux_defines.h
+++ b/ext/drsyscall/linux_defines.h
@@ -231,7 +231,7 @@
 /* For syscall statx which was introduced in Linux Kernel 4.11. struct statx and
  * statx_timestamp are not defined in older versions.
  */
-#include "stat.h"
+#include "linux_stat.h"
 
 typedef struct _kernel_sigset_t {
     unsigned long sig[_NSIG_WORDS];


### PR DESCRIPTION
Syscall statx was introduced in Linux Kernel 4.11. struct statx and statx_timestamp are not defined in older versions.

Define the structs in core/unix/include/stat.h and use the header file instead of linux/stat.h.



Issue: #7304 