### PR TITLE
i#7429: Allow "aux" directory inside the trace directory

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,6 +145,13 @@ compatibility changes:
  - Added the workload to the top bits of the tid for multi-workload drmemtrace
    scheduling.  The drmemtrace view tool now prints the workload and tid in
    the form "Wn.Tmmm".
+ - Added a new directory: `aux` to the scheduler's ignore list when going through the
+   files of the trace directory.  This allows to add additional auxiliary files in the
+   trace directory (under `aux`) without increasing DynamoRIO's versions. Since the
+   scheduler can safely ignore all files under `aux` when creating the necessary readers
+   for the trace, it doesn't need to output an error, which would have forced us to
+   release a new DynamoRIO's minor version in order to support the traces with additional
+   files.
 
 Further non-compatibility-affecting changes include:
  - Changed the types of `block_size`, `total_size`, `num_blocks`, to `int64_t`

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1540,6 +1540,13 @@ typedef struct _pt_data_buf_t pt_data_buf_t;
  */
 #define DRMEMTRACE_V2P_FILENAME "v2p.textproto"
 
+/**
+ * The name of the directory inside the trace directory that contains auxiliary trace
+ * files or directories that are not required to read, analyze, or schedule a trace
+ * (e.g., the human-consumption-only info.textproto file).
+ */
+#define DRMEMTRACE_AUX_DIRNAME "aux"
+
 } // namespace drmemtrace
 } // namespace dynamorio
 

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -154,7 +154,7 @@ scheduler_impl_tmpl_t<memref_t, reader_t>::get_reader(const std::string &path,
         }
         for (; iter != end; ++iter) {
             const std::string fname = *iter;
-            if (fname == "." || fname == ".." ||
+            if (fname == "." || fname == ".." || fname == DRMEMTRACE_AUX_DIRNAME ||
                 starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
                 fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
                 continue;
@@ -1823,7 +1823,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::open_readers(
     std::vector<std::string> files;
     for (; iter != end; ++iter) {
         const std::string fname = *iter;
-        if (fname == "." || fname == ".." ||
+        if (fname == "." || fname == ".." || fname == DRMEMTRACE_AUX_DIRNAME ||
             starts_with(fname, DRMEMTRACE_SERIAL_SCHEDULE_FILENAME) ||
             fname == DRMEMTRACE_CPU_SCHEDULE_FILENAME)
             continue;

--- a/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir/aux/info.textproto
+++ b/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir/aux/info.textproto
@@ -1,0 +1,4 @@
+information {
+    peak_live_core_count: 4
+    phases: "may"
+}


### PR DESCRIPTION
To avoid bumping DynamoRIO's version whenever we add a new file to the
trace directory (due to the scheduler reporting an error when encountering
an unrecognized file), we introduce a new `aux` directory that is ignored by
the scheduler when going through the trace files inside the trace directory.
So, `aux` can contain auxiliary trace files (e.g., the human-readable
`info.textproto` file) that the scheduler does not need to explicitely know
about.

We add `aux/info.textproto` to
`clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir`
(one of the test trace directories) which needs to be ignored in order to have the
end-to-end tests that use this trace succeed (e.g., `tool.record_filter_as_traced`).

Issue #7429