### PR TITLE
i#5888 drconfiglib copy race: Add drconfiglib dep to drcopy

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -988,6 +988,7 @@ function(add_api_exe test source use_decoder use_static_DR)
           "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/drsyms.dll"
         VERBATIM)
       add_custom_target(drcopy DEPENDS "${drcopy_stamp}")
+      add_dependencies(drcopy drconfiglib)
       set(created_drcopy_target ON PARENT_SCOPE)
     endif ()
     add_dependencies(${test} drcopy)


### PR DESCRIPTION
Adds a missing dependence on drconfiglib being built before we try to copy it.  This should fix copy failures we see in the test suite.

Fixes #5888