### PR TITLE
i#7270 ub22: Rename unit_tests in core/CMakeLists.txt to core_unit_tests.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1103,16 +1103,16 @@ endif ()
 if (BUILD_TESTS AND
     ((CMAKE_CROSSCOMPILING AND DEFINED CMAKE_FIND_ROOT_PATH) OR
       (NOT DR_HOST_NOT_TARGET)))
-  add_executable(unit_tests unit_tests.c
+  add_executable(core_unit_tests unit_tests.c
     # These unit tests have been moved from the x86_code module into a new x86_code
     # test module that gets its own clang/gcc options for testing (-mno-vzeroupper).
     # We want this option to apply only to code compiled for unit_test. Also clang
     # specific target options break the clang build (xref i#3458).
     ${CORE_SRCS} ${ARCH_SRCS} ${OS_SRCS} arch/x86_code_test.c)
-  add_gen_events_deps(unit_tests)
+  add_gen_events_deps(core_unit_tests)
   if ("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
     # for parallel build correctness we need a target dependence
-    add_dependencies(unit_tests ${arch_core_asm_tgt} ${archshared_core_asm_tgt}
+    add_dependencies(core_unit_tests ${arch_core_asm_tgt} ${archshared_core_asm_tgt}
       ntdll_imports)
   endif ()
   set(unit_tests_extra_flags "")
@@ -1148,7 +1148,7 @@ if (BUILD_TESTS AND
       endif ()
     endif ()
   endif ()
-  set_target_properties(unit_tests PROPERTIES
+  set_target_properties(core_unit_tests PROPERTIES
     COMPILE_DEFINITIONS "RC_IS_TEST;STANDALONE_UNIT_TEST"
     COMPILE_FLAGS "${unit_tests_extra_flags}"
     RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${EXECUTABLE_OUTPUT_DIRECTORY}")
@@ -1157,35 +1157,35 @@ if (BUILD_TESTS AND
       # i#1228 make sure entry point of the elf binary pointing to _start.
       # Otherwise, the entry point will point to the start of .text section,
       # which might not be _start.
-      append_property_string(TARGET unit_tests LINK_FLAGS "-Wl,${ld_entry_flag},_start")
+      append_property_string(TARGET core_unit_tests LINK_FLAGS "-Wl,${ld_entry_flag},_start")
     endif ()
     if (NOT ANDROID) # everything is inside Bionic on Android
-      target_link_libraries(unit_tests dl m pthread)
+      target_link_libraries(core_unit_tests dl m pthread)
     endif ()
-    target_link_libraries(unit_tests drmemfuncs)
-    set_preferred_base_start_and_end(unit_tests ${preferred_base} ON)
+    target_link_libraries(core_unit_tests drmemfuncs)
+    set_preferred_base_start_and_end(core_unit_tests ${preferred_base} ON)
   else (UNIX)
     # Just like drinjectlib (see above) we need libc before ntdll
-    target_link_libraries(unit_tests ${static_libc_list} ntdll_imports)
-    set_target_properties(unit_tests PROPERTIES
+    target_link_libraries(core_unit_tests ${static_libc_list} ntdll_imports)
+    set_target_properties(core_unit_tests PROPERTIES
       LINK_FLAGS "/base:${preferred_base} ${LD_FLAGS}")
   endif (UNIX)
-  target_link_libraries(unit_tests drlibc)
-  get_target_path_for_execution(unit_relpath unit_tests "${location_suffix}")
+  target_link_libraries(core_unit_tests drlibc)
+  get_target_path_for_execution(unit_relpath core_unit_tests "${location_suffix}")
   prefix_cmd_if_necessary(unit_relpath OFF ${unit_relpath})
-  add_test(unit_tests ${unit_relpath})
+  add_test(core_unit_tests ${unit_relpath})
   if (APPLE)
-    set_tests_properties(unit_tests PROPERTIES LABELS OSX)
+    set_tests_properties(core_unit_tests PROPERTIES LABELS OSX)
   endif ()
   if (CMAKE_CROSSCOMPILING AND DEFINED CMAKE_FIND_ROOT_PATH AND NOT DR_COPY_TO_DEVICE)
-    set_tests_properties(unit_tests PROPERTIES LABELS RUNS_ON_QEMU)
+    set_tests_properties(core_unit_tests PROPERTIES LABELS RUNS_ON_QEMU)
     # Make sure core code detects that we're under QEMU by setting the option
     # used for that in managed mode, even though we don't really need this option
     # for its own sake.
-    set_tests_properties(unit_tests PROPERTIES ENVIRONMENT
+    set_tests_properties(core_unit_tests PROPERTIES ENVIRONMENT
       "DYNAMORIO_OPTIONS=-xarch_root ${CMAKE_FIND_ROOT_PATH}")
   endif ()
-  copy_target_to_device(unit_tests "${location_suffix}")
+  copy_target_to_device(core_unit_tests "${location_suffix}")
 endif ()
 
 ###########################################################################


### PR DESCRIPTION
Both dynamorio/core/CMakeLists.txt 
```
  add_executable(unit_tests unit_tests.c
    # These unit tests have been moved from the x86_code module into a new x86_code
    # test module that gets its own clang/gcc options for testing (-mno-vzeroupper).
    # We want this option to apply only to code compiled for unit_test. Also clang
    # specific target options break the clang build (xref i#3458).
    ${CORE_SRCS} ${ARCH_SRCS} ${OS_SRCS} arch/x86_code_test.c)
```
and DrMemory drmrmory/CMakeLists.txt
```
  if (TOOL_DR_MEMORY)
    # unit tests
    add_executable(unit_tests ${srcs})
```
use the name "unit_tests". It causes the following error on DrMemory:
```
CMake Error at CMakeLists.txt:1882 (add_executable):
  add_executable cannot create target "unit_tests" because another target
  with the same name already exists.  The existing target is an executable
  created in source directory
  "/usr/local/google/home/kyluk/DrMemory/drmemory/dynamorio/core".  See
  documentation for policy CMP0002 for more details.
```

This PR changes the name unit_tests in dynamorio/core/CMakeLists.txt to core_unit_tests.

Issue: #7270 
