### PR TITLE
i#1569 AArch64: Enable client.flush in AArch64 QEMU CI

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6534,8 +6534,8 @@ if (NOT ANDROID AND AARCHXX)
       code_api|sample.memval_simple
       PROPERTIES LABELS RUNS_ON_QEMU)
     if (DEBUG)
-           set_tests_properties(code_api|client.flush
-                                PROPERTIES LABELS RUNS_ON_QEMU)
+      set_tests_properties(code_api|client.flush
+                           PROPERTIES LABELS RUNS_ON_QEMU)
     endif ()
     if (NOT APPLE) # TODO i#5383: Port to Mac M1.
       set_tests_properties(

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6518,6 +6518,7 @@ if (NOT ANDROID AND AARCHXX)
       code_api|client.drx_buf-test
       code_api|client.emulation_api_simple
       code_api|client.execfault
+      code_api|client.flush
       code_api|client.gonative
       code_api|client.inline
       code_api|client.mangle_suspend

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6518,7 +6518,6 @@ if (NOT ANDROID AND AARCHXX)
       code_api|client.drx_buf-test
       code_api|client.emulation_api_simple
       code_api|client.execfault
-      code_api|client.flush
       code_api|client.gonative
       code_api|client.inline
       code_api|client.mangle_suspend
@@ -6534,6 +6533,10 @@ if (NOT ANDROID AND AARCHXX)
       code_api|sample.memtrace_simple
       code_api|sample.memval_simple
       PROPERTIES LABELS RUNS_ON_QEMU)
+    if (DEBUG)
+           set_tests_properties(code_api|client.flush
+                                PROPERTIES LABELS RUNS_ON_QEMU)
+    endif ()
     if (NOT APPLE) # TODO i#5383: Port to Mac M1.
       set_tests_properties(
         code_api|common.allasm_aarch64_isa

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6533,6 +6533,7 @@ if (NOT ANDROID AND AARCHXX)
       code_api|sample.memtrace_simple
       code_api|sample.memval_simple
       PROPERTIES LABELS RUNS_ON_QEMU)
+    # XXX i#1806: client.flush currently fails in release build.
     if (DEBUG)
       set_tests_properties(code_api|client.flush
                            PROPERTIES LABELS RUNS_ON_QEMU)


### PR DESCRIPTION
This test passes in our current QEMU CI environment, enable it to achieve better code coverage.

Issue: #1569