### PR TITLE
Request callstacks in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,6 +24,8 @@ Please also answer these questions:
  - What happens when you run without any client?
  - What happens when you run with debug build ("-debug" flag to drrun/drconfig/drinject)?
 
+Please provide a symbolized callstack of any crash or assert so we do not have to speculate or guess as to where it is occurring (see our [Linux gdb instructions](https://dynamorio.org/page_debugging.html#autotoc_md146) and [Windows windbg instructions](https://dynamorio.org/page_debugging.html#autotoc_md157) to see how to load DynamoRIO symbols for a callstack).
+
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 


### PR DESCRIPTION
Augments the bug filing template to request symbolized callstacks, pointing at our documentation for loading symbols.