### PR TITLE
i#7442 skip csod: Do not abort on a drmemtrace footer when skipping

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -218,7 +218,12 @@ typedef enum {
     // match TRACE_ENTRY_VERSION) in the addr field.  Unused for pipes.
     TRACE_TYPE_HEADER,
 
-    /** The final entry in an offline file or a pipe.  Not exposed to tools. */
+    /**
+     * The final entry in an offline file or a pipe.  Not exposed to tools.
+     * This can be in the middle of a derived trace when existing traces are
+     * combined into a new trace, as happens with core-sharded-on-disk traces
+     * produced by the record_filter tool in core-sharded mode.
+     */
     TRACE_TYPE_FOOTER,
 
     /** A hardware-issued prefetch (generated after tracing by a cache simulator). */

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -386,6 +386,13 @@ reader_t::process_input_entry()
             this, 2,
             "Assuming header is part of concatenated or on-disk-core-sharded traces\n");
         break;
+    case TRACE_TYPE_FOOTER:
+        // We support core-sharded-on-disk traces where an originally-thread-sharded
+        // input ends but the core-sharded new trace continues.
+        VPRINT(
+            this, 2,
+            "Assuming footer is part of concatenated or on-disk-core-sharded traces\n");
+        break;
     default:
         ERRMSG("Unknown trace entry type %s (%d)\n", trace_type_names[input_entry_->type],
                input_entry_->type);
@@ -484,7 +491,7 @@ reader_t::skip_instructions_with_timestamp(uint64_t stop_instruction_count)
         if (input_entry_ != nullptr) // Only at start: and we checked for skipping 0.
             entry_copy_ = *input_entry_;
         trace_entry_t *next = read_next_entry();
-        if (next == nullptr || next->type == TRACE_TYPE_FOOTER) {
+        if (next == nullptr) {
             VPRINT(this, 1,
                    next == nullptr ? "Failed to read next entry\n" : "Hit EOF\n");
             at_eof_ = true;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -954,6 +954,83 @@ test_regions_too_far()
 }
 
 static void
+test_regions_core_sharded()
+{
+    std::cerr << "\n----------------\nTesting region on core-sharded-on-disk trace\n";
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr memref_tid_t TID_B = 99;
+    static constexpr addr_t PC_POST_FOOTER = 101;
+    std::vector<trace_entry_t> memrefs = {
+        /* clang-format off */
+        make_thread(TID_A),
+        make_pid(1),
+        make_marker(TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+        make_timestamp(10),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        make_instr(1),
+        make_instr(2),
+        make_exit(TID_A),
+        // Test skipping across a footer.
+        make_footer(),
+        make_thread(TID_B),
+        make_pid(1),
+        make_marker(TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+        make_timestamp(10),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        make_instr(PC_POST_FOOTER),
+        make_instr(PC_POST_FOOTER + 1),
+        make_exit(TID_B),
+        make_footer(),
+        /* clang-format on */
+    };
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(memrefs)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), 1);
+
+    std::vector<scheduler_t::range_t> regions;
+    // Start beyond the footer.
+    regions.emplace_back(3, 0);
+
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(readers));
+    sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
+    if (scheduler.init(sched_inputs, 1,
+                       scheduler_t::make_scheduler_serial_options(/*verbosity=*/5)) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    int ordinal = 0;
+    auto *stream = scheduler.get_stream(0);
+    memref_t memref;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+        assert(status == scheduler_t::STATUS_OK);
+        // Because we skipped, even if not very far, we do not see the page marker.
+        switch (ordinal) {
+        case 0:
+            assert(memref.marker.type == TRACE_TYPE_MARKER);
+            assert(memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP);
+            break;
+        case 1:
+            assert(memref.marker.type == TRACE_TYPE_MARKER);
+            assert(memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID);
+            break;
+        case 2:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr == PC_POST_FOOTER);
+            break;
+        case 3:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr == PC_POST_FOOTER + 1);
+            break;
+        default: assert(ordinal == 4); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
+        }
+        ++ordinal;
+    }
+    assert(ordinal == 5);
+}
+
+static void
 test_regions()
 {
     test_regions_timestamps();
@@ -961,6 +1038,7 @@ test_regions()
     test_regions_bare_no_marker();
     test_regions_start();
     test_regions_too_far();
+    test_regions_core_sharded();
 }
 
 static void


### PR DESCRIPTION
Since a core-shared-on-disk trace typically contains the footer record from when a source software thread trace exited, the reader and its skipping logic need to not abort when they see a footer.  They don't need to do anything on a footer as the EOF logic does not rely on such a record.  Here we fix both
reader_t::skip_instructions_with_timestamp() and
reader_t::process_input_entry() to not abort on a footer.

Adds a unit test, which fails without the fix.

Issue: #7442, #6685