### PR TITLE
i#7442 skip csod: Add scheduler input mod by shard

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,6 +145,8 @@ compatibility changes:
  - Added the workload to the top bits of the tid for multi-workload drmemtrace
    scheduling.  The drmemtrace view tool now prints the workload and tid in
    the form "Wn.Tmmm".
+ - Changed the #dynamorio::drmemtrace::scheduler_tmpl_t::input_thread_info_t.
+   regions_of_interest structure layout, requiring recompiling using code.
 
 Further non-compatibility-affecting changes include:
  - Changed the types of `block_size`, `total_size`, `num_blocks`, to `int64_t`

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -386,6 +386,13 @@ reader_t::process_input_entry()
             this, 2,
             "Assuming header is part of concatenated or on-disk-core-sharded traces\n");
         break;
+    case TRACE_TYPE_FOOTER:
+        // We support core-sharded-on-disk traces where an originally-thread-sharded
+        // input ends but the core-sharded new trace continues.
+        VPRINT(
+            this, 2,
+            "Assuming footer is part of concatenated or on-disk-core-sharded traces\n");
+        break;
     default:
         ERRMSG("Unknown trace entry type %s (%d)\n", trace_type_names[input_entry_->type],
                input_entry_->type);
@@ -484,7 +491,7 @@ reader_t::skip_instructions_with_timestamp(uint64_t stop_instruction_count)
         if (input_entry_ != nullptr) // Only at start: and we checked for skipping 0.
             entry_copy_ = *input_entry_;
         trace_entry_t *next = read_next_entry();
-        if (next == nullptr || next->type == TRACE_TYPE_FOOTER) {
+        if (next == nullptr) {
             VPRINT(this, 1,
                    next == nullptr ? "Failed to read next entry\n" : "Hit EOF\n");
             at_eof_ = true;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -236,7 +236,8 @@ public:
         }
         /**
          * Size of the struct.  Not used as this structure cannot support
-         * binary-compatible additions due to limits of C++ offsetof support: thus,
+         * binary-compatible additions due to limits of C++ offsetof support with some
+         * implementations of std::set where it is not a standard-layout class: thus,
          * changes here require recompiling tools using this code.
          */
         size_t struct_size = sizeof(input_thread_info_t);

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -840,12 +840,12 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
             // non-standard-layout types.  So we ignore struct_size and only
             // provide source compatibility.
             // Vector of ordinals into input for this workload.
-            std::vector<int> which_inputs;
+            std::vector<int> which_workload_inputs;
             if (modifiers.tids.empty() && modifiers.shards.empty()) {
                 // Apply to all inputs that have not already been modified.
                 for (int i = 0; i < static_cast<int>(reader_info.input_count); ++i) {
                     if (!inputs_[reader_info.first_input_ordinal + i].has_modifier)
-                        which_inputs.push_back(i);
+                        which_workload_inputs.push_back(i);
                 }
             } else if (!modifiers.tids.empty()) {
                 if (!modifiers.shards.empty()) {
@@ -860,15 +860,16 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
                             "Cannot find tid " + std::to_string(tid) + " for modifier";
                         return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
                     }
-                    which_inputs.push_back(it->second - reader_info.first_input_ordinal);
+                    which_workload_inputs.push_back(it->second -
+                                                    reader_info.first_input_ordinal);
                 }
             } else if (!modifiers.shards.empty()) {
-                which_inputs = modifiers.shards;
+                which_workload_inputs = modifiers.shards;
             }
 
             // We assume the overhead of copying the modifiers for every thread is
             // not high and the simplified code is worthwhile.
-            for (int local_index : which_inputs) {
+            for (int local_index : which_workload_inputs) {
                 int index = local_index + reader_info.first_input_ordinal;
                 input_info_t &input = inputs_[index];
                 input.has_modifier = true;

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -775,6 +775,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
         input_reader_info_t reader_info;
         reader_info.only_threads = workload.only_threads;
         reader_info.only_shards = workload.only_shards;
+        reader_info.first_input_ordinal = static_cast<input_ordinal_t>(inputs_.size());
         if (workload.path.empty()) {
             if (workload.readers.empty())
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
@@ -834,25 +835,41 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
         }
         for (const auto &modifiers : workload.thread_modifiers) {
-            if (modifiers.struct_size != sizeof(input_thread_info_t))
-                return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
-            const std::vector<memref_tid_t> *which_tids;
-            std::vector<memref_tid_t> workload_tid_vector;
-            if (modifiers.tids.empty()) {
-                // Apply to all tids that have not already been modified.
-                for (const auto entry : reader_info.tid2input) {
-                    if (!inputs_[entry.second].has_modifier)
-                        workload_tid_vector.push_back(entry.first);
+            // We can't actually use modifiers.struct_size to provide binary
+            // backward compatibility due to C++ not supporting offsetof with
+            // non-standard-layout types.  So we ignore struct_size and only
+            // provide source compatibility.
+            // Vector of ordinals into input for this workload.
+            std::vector<int> which_inputs;
+            if (modifiers.tids.empty() && modifiers.shards.empty()) {
+                // Apply to all inputs that have not already been modified.
+                for (int i = 0; i < static_cast<int>(reader_info.input_count); ++i) {
+                    if (!inputs_[reader_info.first_input_ordinal + i].has_modifier)
+                        which_inputs.push_back(i);
                 }
-                which_tids = &workload_tid_vector;
-            } else
-                which_tids = &modifiers.tids;
+            } else if (!modifiers.tids.empty()) {
+                if (!modifiers.shards.empty()) {
+                    error_string_ =
+                        "Cannot set both tids and shards in input_thread_info_t";
+                    return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
+                }
+                for (memref_tid_t tid : modifiers.tids) {
+                    auto it = reader_info.tid2input.find(tid);
+                    if (it == reader_info.tid2input.end()) {
+                        error_string_ =
+                            "Cannot find tid " + std::to_string(tid) + " for modifier";
+                        return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
+                    }
+                    which_inputs.push_back(it->second - reader_info.first_input_ordinal);
+                }
+            } else if (!modifiers.shards.empty()) {
+                which_inputs = modifiers.shards;
+            }
+
             // We assume the overhead of copying the modifiers for every thread is
             // not high and the simplified code is worthwhile.
-            for (memref_tid_t tid : *which_tids) {
-                if (reader_info.tid2input.find(tid) == reader_info.tid2input.end())
-                    return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
-                int index = reader_info.tid2input[tid];
+            for (int i : which_inputs) {
+                int index = i + reader_info.first_input_ordinal;
                 input_info_t &input = inputs_[index];
                 input.has_modifier = true;
                 // Check for valid bindings.

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -868,8 +868,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
 
             // We assume the overhead of copying the modifiers for every thread is
             // not high and the simplified code is worthwhile.
-            for (int i : which_inputs) {
-                int index = i + reader_info.first_input_ordinal;
+            for (int local_index : which_inputs) {
+                int index = local_index + reader_info.first_input_ordinal;
                 input_info_t &input = inputs_[index];
                 input.has_modifier = true;
                 // Check for valid bindings.

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -571,6 +571,8 @@ protected:
         // The count of original pre-filtered inputs (might not match
         // unfiltered_tids.size() for core-sharded inputs with IDLE_THREAD_ID).
         uint64_t input_count = 0;
+        // The index into inputs_ at which this workload's inputs begin.
+        input_ordinal_t first_input_ordinal = 0;
     };
 
     // We assume a 2GHz clock and IPC=0.5 to match

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -954,6 +954,83 @@ test_regions_too_far()
 }
 
 static void
+test_regions_core_sharded()
+{
+    std::cerr << "\n----------------\nTesting region on core-sharded-on-disk trace\n";
+    static constexpr memref_tid_t TID_A = 42;
+    static constexpr memref_tid_t TID_B = 99;
+    static constexpr addr_t PC_POST_FOOTER = 101;
+    std::vector<trace_entry_t> memrefs = {
+        /* clang-format off */
+        make_thread(TID_A),
+        make_pid(1),
+        make_marker(TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+        make_timestamp(10),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        make_instr(1),
+        make_instr(2),
+        make_exit(TID_A),
+        // Test skipping across a footer.
+        make_footer(),
+        make_thread(TID_B),
+        make_pid(1),
+        make_marker(TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+        make_timestamp(10),
+        make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        make_instr(PC_POST_FOOTER),
+        make_instr(PC_POST_FOOTER + 1),
+        make_exit(TID_B),
+        make_footer(),
+        /* clang-format on */
+    };
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(std::unique_ptr<mock_reader_t>(new mock_reader_t(memrefs)),
+                         std::unique_ptr<mock_reader_t>(new mock_reader_t()), 1);
+
+    std::vector<scheduler_t::range_t> regions;
+    // Start beyond the footer.
+    regions.emplace_back(3, 0);
+
+    scheduler_t scheduler;
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    sched_inputs.emplace_back(std::move(readers));
+    sched_inputs[0].thread_modifiers.push_back(scheduler_t::input_thread_info_t(regions));
+    if (scheduler.init(sched_inputs, 1,
+                       scheduler_t::make_scheduler_serial_options(/*verbosity=*/5)) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    int ordinal = 0;
+    auto *stream = scheduler.get_stream(0);
+    memref_t memref;
+    for (scheduler_t::stream_status_t status = stream->next_record(memref);
+         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+        assert(status == scheduler_t::STATUS_OK);
+        // Because we skipped, even if not very far, we do not see the page marker.
+        switch (ordinal) {
+        case 0:
+            assert(memref.marker.type == TRACE_TYPE_MARKER);
+            assert(memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP);
+            break;
+        case 1:
+            assert(memref.marker.type == TRACE_TYPE_MARKER);
+            assert(memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID);
+            break;
+        case 2:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr == PC_POST_FOOTER);
+            break;
+        case 3:
+            assert(type_is_instr(memref.instr.type));
+            assert(memref.instr.addr == PC_POST_FOOTER + 1);
+            break;
+        default: assert(ordinal == 4); assert(memref.exit.type == TRACE_TYPE_THREAD_EXIT);
+        }
+        ++ordinal;
+    }
+    assert(ordinal == 5);
+}
+
+static void
 test_regions()
 {
     test_regions_timestamps();
@@ -961,6 +1038,7 @@ test_regions()
     test_regions_bare_no_marker();
     test_regions_start();
     test_regions_too_far();
+    test_regions_core_sharded();
 }
 
 static void


### PR DESCRIPTION
The drmemtrace scheduler's input_thread_info_t modifiers use a 'tids' field to allow applying the modifiers to a subset of a workload's inputs.  But for core-sharded-on-disk traces there are no thread ids. We solve that by adding a 'shards' field which can be used instead of 'tids' to specify inputs by ordinal (sorted lexicographically for a directory's files, just like for 'only_shards').

This change breaks binary compatibility, which unfortunately we cannot maintain as C++'s offsetof is not reliable on this  struct (due to some implementations of std::set not being a standard-layout class).  Adds a release note.

Adds a unit test.

Issue: #7442, i#6685
Fixes #7442