### PR TITLE
i#3995 irregular window tracing: last window bug fix

### DIFF
--- a/clients/drcachesim/tracer/instr_counter.cpp
+++ b/clients/drcachesim/tracer/instr_counter.cpp
@@ -157,13 +157,8 @@ get_current_no_trace_for_instrs_value()
     return 0;
 }
 
-// This function returns true if there exists an instruction count threshold to enable
-// tracing. A value of 0 from get_current_no_trace_for_instrs_value() means the
-// instruction count threshold is infinite, so no tracing will be enabled after.
-// This does not apply for the first "no_trace" window, where
-// get_initial_no_trace_for_instrs_value() returning 0 means: start tracing immediately.
-// We handle this special case setting the initial value of reached_trace_after_instrs to
-// false, and then setting it to true after the first "trace" window starts.
+// This function returns true if, at the current no-trace window, there exists an
+// instruction count threshold to enable tracing.
 static bool
 has_instr_count_threshold_to_enable_tracing()
 {


### PR DESCRIPTION
When a workload executed more than `DELAY_FOREVER_THRESHOLD`
(= 1024^3) instructions after the last window specified in
`-trace_instr_intervals_file`, the tracing of an unwanted, infinite "trace"
window triggered.

This happened because the last "no trace" window that we create
(not the user), was set to `DELAY_FOREVER_THRESHOLD` instead
of the larger value `UINT64_MAX`, which we assume is a large enough
value to stop tracing for the remaining of the execution of the traced
program. This last window exists to stop the tracing after the last,
user-defined window set in `-trace_instr_intervals_file` (reminder:
if the user wants to trace the end of the execution, the last window
in the file has to be large enough to cover the end of the workload
execution).

Tested manually, as a new binary that executes at least
`DELAY_FOREVER_THRESHOLD` instructions takes way more than
90 seconds to run a tool like `basic_counts`, which we normally use
to count windows (by looking at its output).

The reason `code_api|tool.drcachesim.irregular-windows-simple`
passed is that the test binary traced (`simple_app`) executes
~100k instructions, which is way less than
`DELAY_FOREVER_THRESHOLD` instructions, so the last "no trace"
window of `DELAY_FOREVER_THRESHOLD` was large enough to
not trigger a new, infinite "trace" window.

Adds a check for user-defined instruction intervals with a
duration of 0. They are meaningless, so we ignore them and
print a `NOTIFY` message letting the user know.

Adds a `NOTIFY` message when user-defined instruction intervals
overlap (in which case, they are merged).

Issue #3995