### PR TITLE
i#7449: make sure linux/infloop.c exits eventually.

### DIFF
--- a/suite/tests/linux/infloop.c
+++ b/suite/tests/linux/infloop.c
@@ -125,6 +125,10 @@ main(int argc, const char *argv[])
             if (res == -1 && errno != EINTR)
                 perror("select error");
 
+            // If the select timed out, exit.
+            if (res == 0)
+                break;
+
             /* XXX i#38: We may want a test of an auto-restart syscall as well
              * once the injector handles that.
              */


### PR DESCRIPTION
Local runs of the dynamorio test suite on my workstation often leave behind stray linux.infloop processes.  While the current code has a loop count timeout mechanism to deal with this issue, it doesn't account for the extra loop delay of select() timeouts, which can lead to extremely long runtimes.

This PR causes the loop to exit after the first select() timeout.

Fixes #7449