### PR TITLE
i#3683 android: Remove ARM-Android release package

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -268,71 +268,9 @@ jobs:
         path: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
 
   ###########################################################################
-  # Android ARM tarball:
-  android-arm:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Fetch Sources
-      run: |
-        git fetch --no-tags --depth=1 origin master
-        # Include Dr. Memory in packages.
-        git clone --depth=2 https://github.com/DynamoRIO/drmemory.git drmemory
-        cd drmemory && git submodule update --init --recursive --depth 250 && cd ..
-
-    # Fetch and install Android NDK for Andoid cross-compile build.
-    - name: Create Build Environment
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install doxygen vera++ cmake
-        cd /tmp
-        wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
-        unzip -q android-ndk-r10e-linux-x86_64.zip
-        export ANDROID_NDK_ROOT=/tmp/android-ndk-r10e
-        android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
-          --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
-          --install-dir=/tmp/android-gcc-arm-ndk-10e
-        # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
-        ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
-        ln -sf arm-linux-androideabi-ld.bfd \
-          /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
-
-    - name: Get Version
-      id: version
-      # XXX: See x86 job comments on sharing the default ver# with CMakeLists.txt.
-      run: |
-        if test -z "${{ github.event.inputs.version }}"; then
-          export VERSION_NUMBER=11.90.$((`git log -n 1 --format=%ct` / (60*60*24)))
-        else
-          export VERSION_NUMBER=${{ github.event.inputs.version }}
-        fi
-        if [ "${{ github.event.inputs.build }}" -ne 0 ]; then
-          export VERSION_NUMBER="${VERSION_NUMBER}-${{ github.event.inputs.build }}"
-        fi
-        echo "::set-output name=version_number::${VERSION_NUMBER}"
-
-    - name: Build Package
-      working-directory: ${{ github.workspace }}
-      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
-      env:
-        CI_TARGET: package
-        VERSION_NUMBER: ${{ steps.version.outputs.version_number }}
-        DYNAMORIO_CROSS_AARCHXX_LINUX_ONLY: no
-        DYNAMORIO_CROSS_ANDROID_ONLY: yes
-        DYNAMORIO_ANDROID_TOOLCHAIN: /tmp/android-gcc-arm-ndk-10e
-        CI_TRIGGER: ${{ github.event_name }}
-        CI_BRANCH: ${{ github.ref }}
-
-    - name: Upload Artifacts
-      # This points to the latest upload-artifact v4.x.x.
-      uses: actions/upload-artifact@v4
-      with:
-        name: android-tarball
-        path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
+  # Android ARM tarball: Removed due to lack of support for recent Android.
+  # TODO i#2154,i#3683: Add an Android package back when it is better supported,
+  # whether AArch64 or AArch32.
 
   ###########################################################################
   # Windows .zip with 32-bit and 64-bit x86 builds:
@@ -411,7 +349,7 @@ jobs:
   # single release job via artifacts.
 
   create_release:
-    needs: [linux-x86, linux-aarch64, linux-arm, android-arm, windows]
+    needs: [linux-x86, linux-aarch64, linux-arm, windows]
     runs-on: ubuntu-22.04
 
     steps:
@@ -498,22 +436,6 @@ jobs:
         asset_name: DynamoRIO-ARM-Linux-EABIHF-${{ steps.version.outputs.version_number }}.tar.gz
         asset_content_type: application/x-gzip
 
-    - name: Download Android
-      # This points to the latest download-artifact v4.x.x.
-      uses: actions/download-artifact@v4
-      with:
-        name: android-tarball
-    - name: Upload Android
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        # This action doesn't seem to support a glob so we need the exact name.
-        asset_path: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_name: DynamoRIO-ARM-Android-EABI-${{ steps.version.outputs.version_number }}.tar.gz
-        asset_content_type: application/x-gzip
-
     - name: Download Windows
       # This points to the latest download-artifact v4.x.x.
       uses: actions/download-artifact@v4
@@ -533,16 +455,15 @@ jobs:
 
   send-failure-notification:
       uses: ./.github/workflows/failure-notification.yml
-      needs: [create_release, windows, android-arm, linux-arm, linux-aarch64, linux-x86]
+      needs: [create_release, windows, linux-arm, linux-aarch64, linux-x86]
       # By default, a failure in a job skips the jobs that need it. The
       # following expression ensures that failure-notification.yml is
       # always invoked.
       if: ${{ always() }}
       with:
-        test_suite_status: ${{ format('{0} {1} | {2} {3} | {4} {5} | {6} {7} | {8} {9} | {10} {11}',
+        test_suite_status: ${{ format('{0} {1} | {2} {3} | {4} {5} | {6} {7} | {8} {9}',
                                       'create_release', needs.create_release.result,
                                       'windows', needs.windows.result,
-                                      'android-arm', needs.android-arm.result,
                                       'linux-arm', needs.linux-arm.result,
                                       'linux-aarch64', needs.linux-aarch64.result,
                                       'linux-x86', needs.linux-x86.result) }}

--- a/api/docs/download.dox
+++ b/api/docs/download.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -58,8 +58,6 @@ The [11.3.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release
 
   - [DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-ARM-Linux-EABIHF-11.3.0.tar.gz)
 
-  - [DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-ARM-Android-EABI-11.3.0.tar.gz)
-
   - [DynamoRIO-AArch64-Linux-11.3.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.3.0-1/DynamoRIO-AArch64-Linux-11.3.0.tar.gz)
 
 The [11.2.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release_11.2.0):
@@ -69,8 +67,6 @@ The [11.2.0 release](https://github.com/DynamoRIO/dynamorio/releases/tag/release
   - [DynamoRIO-Linux-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-Linux-11.2.0.tar.gz)
 
   - [DynamoRIO-ARM-Linux-EABIHF-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-ARM-Linux-EABIHF-11.2.0.tar.gz)
-
-  - [DynamoRIO-ARM-Android-EABI-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-ARM-Android-EABI-11.2.0.tar.gz)
 
   - [DynamoRIO-AArch64-Linux-11.2.0.tar.gz](https://github.com/DynamoRIO/dynamorio/releases/download/release_11.2.0/DynamoRIO-AArch64-Linux-11.2.0.tar.gz)
 


### PR DESCRIPTION
Removes the release of an ARM-Android binary package since it does not have good support for recent Android versions, partly because of the lack of private library support.  The package can be re-added if that support is later added; or it can be replaced with an AArch64 version if that support becomes sufficient.  But right now it is misleading to release this package as it implies it should work when most tools will fail on recent Android versions.  We do not even have solid Continuous Integration testing for AArch32 Android at this time (#4639).

Issue: #3683, #4639, #2154, #7312