### PR TITLE
i#6495 syscall inject: Handle AArch64 OP_eret

### DIFF
--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -111,6 +111,7 @@ instr_branch_type(instr_t *cti_instr)
     case OP_braaz:
     case OP_brabz: return LINK_INDIRECT | LINK_JMP;
     case OP_ret:
+    case OP_eret:
     case OP_retaa:
     case OP_retab: return LINK_INDIRECT | LINK_RETURN;
     }
@@ -178,7 +179,7 @@ bool
 instr_is_return(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    return (opc == OP_ret || opc == OP_retaa || opc == OP_retab);
+    return (opc == OP_ret || opc == OP_retaa || opc == OP_retab || opc == OP_eret);
 }
 
 bool
@@ -206,6 +207,7 @@ instr_is_mbr_arch(instr_t *instr)
     case OP_blraaz:
     case OP_blrabz:
     case OP_ret:
+    case OP_eret:
     case OP_retaa:
     case OP_retab: return true;
     default: return false;

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -179,7 +179,7 @@ bool
 instr_is_return(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    return (opc == OP_ret || opc == OP_retaa || opc == OP_retab || opc == OP_eret);
+    return (opc == OP_ret || opc == OP_eret || opc == OP_retaa || opc == OP_retab);
 }
 
 bool

--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -14218,6 +14218,17 @@
                            opnd_create_reg(DR_REG_X30))
 
 /**
+ * Creates an ERET instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    ERET
+ * \endverbatim
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ */
+#define INSTR_CREATE_eret(dc) instr_create_0dst_0src(dc, OP_eret)
+
+/**
  * Creates an ERETAA instruction.
  *
  * This macro is used to encode the forms:

--- a/suite/tests/api/ir_aarch64_v80.c
+++ b/suite/tests/api/ir_aarch64_v80.c
@@ -1,4 +1,5 @@
 /* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2024 ARM Limited. All rights reserved.
  * **********************************************************/
 
@@ -340,6 +341,12 @@ TEST_INSTR(wfi)
     TEST_LOOP_EXPECT(wfi, 1, INSTR_CREATE_wfi(dc), EXPECT_DISASSEMBLY("wfi"));
 }
 
+TEST_INSTR(eret)
+{
+    /* Testing ERET */
+    TEST_LOOP_EXPECT(eret, 1, INSTR_CREATE_eret(dc), EXPECT_DISASSEMBLY("eret"));
+}
+
 TEST_INSTR(orr)
 {
     /* Testing ORR     <Xd|SP>, <Xn>, #<imm> */
@@ -673,6 +680,7 @@ main(int argc, char *argv[])
 
     RUN_INSTR_TEST(wfe);
     RUN_INSTR_TEST(wfi);
+    RUN_INSTR_TEST(eret);
 
     RUN_INSTR_TEST(orr);
     RUN_INSTR_TEST(orr_shift);


### PR DESCRIPTION
Adds missing handling for OP_eret on AArch64. Adds the INSTR_CREATE_eret macro, and marks OP_eret properly for instr_is_mbr, instr_is_return, and instr_branch_type.

Adds unit test for eret IR decoding.

eret is not expected to be seen by the user-space DynamoRIO. We've seen it in kernel system call traces collected on QEMU as the instruction that ends the syscall trace and interrupts within the syscall trace. We want such instructions to have the TRACE_MARKER_TYPE_BRANCH_TARGET so they must be marked as an indirect branch.

Issue: #6495, #7157