### PR TITLE
i#6495 syscall inject: Handle x86 OP_sysret and OP_sysexit

### DIFF
--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -116,7 +116,7 @@ instr_branch_type(instr_t *cti_instr)
     /* We don't mark svc as an indirect branch because the user-mode DynamoRIO
      * instrumentation does not need to treat it as such. eret is typically
      * found in the kernel traces generated using other methods (like QEMU). It
-     * is useful to treat it as such to show proper continuity in the injected
+     * is useful to treat it as such to show proper PC continuity in the injected
      * traces (i#6495, i#7157).
      */
     case OP_eret: return LINK_INDIRECT;

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -517,7 +517,7 @@ instr_branch_type(instr_t *cti_instr)
      * (i#6495, i#7157).
      */
     case OP_sysexit:
-    case OP_sysret: return LINK_INDIRECT;
+    case OP_sysret: return LINK_INDIRECT | LINK_FAR;
     default:
         LOG(THREAD_GET, LOG_ALL, 0, "branch_type: unknown opcode: %d\n",
             instr_get_opcode(cti_instr));

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -508,6 +508,7 @@ instr_branch_type(instr_t *cti_instr)
         return LINK_INDIRECT | LINK_CALL | LINK_FAR;
     case OP_call_far_ind: return LINK_INDIRECT | LINK_CALL | LINK_FAR;
     case OP_ret_far:
+    case OP_iret: return LINK_INDIRECT | LINK_RETURN | LINK_FAR;
     /* We don't mark sysenter and syscall as indirect branches because
      * the user-mode DynamoRIO instrumentation does not need to treat them
      * as such. sysexit and sysret are typically found in the kernel traces
@@ -516,8 +517,7 @@ instr_branch_type(instr_t *cti_instr)
      * (i#6495, i#7157).
      */
     case OP_sysexit:
-    case OP_sysret:
-    case OP_iret: return LINK_INDIRECT | LINK_RETURN | LINK_FAR;
+    case OP_sysret: return LINK_INDIRECT;
     default:
         LOG(THREAD_GET, LOG_ALL, 0, "branch_type: unknown opcode: %d\n",
             instr_get_opcode(cti_instr));
@@ -568,15 +568,7 @@ bool
 instr_is_return(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    /* We don't mark sysenter and syscall as return because
-     * the user-mode DynamoRIO instrumentation does not need to treat them
-     * as such. sysexit and sysret are typically found in the kernel traces
-     * generated using other methods (like QEMU). It is useful to treat them
-     * as such to show proper continuity in the injected traces
-     * (i#6495, i#7157).
-     */
-    return (opc == OP_ret || opc == OP_ret_far || opc == OP_sysexit || opc == OP_sysret ||
-            opc == OP_iret);
+    return (opc == OP_ret || opc == OP_ret_far || opc == OP_iret);
 }
 
 /*** WARNING!  The following rely on ordering of opcodes! ***/
@@ -609,7 +601,7 @@ instr_is_mbr_arch(instr_t *instr) /* multi-way branch */
      */
     return (opc == OP_jmp_ind || opc == OP_call_ind || opc == OP_ret ||
             opc == OP_jmp_far_ind || opc == OP_call_far_ind || opc == OP_ret_far ||
-            opc == OP_sysexit || opc == OP_sysret || opc == OP_iret);
+            opc == OP_iret || opc == OP_sysexit || opc == OP_sysret);
 }
 
 bool

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -513,7 +513,7 @@ instr_branch_type(instr_t *cti_instr)
      * the user-mode DynamoRIO instrumentation does not need to treat them
      * as such. sysexit and sysret are typically found in the kernel traces
      * generated using other methods (like QEMU). It is useful to treat them
-     * as such to show proper continuity in the injected traces
+     * as such to show proper PC continuity in the injected traces
      * (i#6495, i#7157).
      */
     case OP_sysexit:
@@ -596,7 +596,7 @@ instr_is_mbr_arch(instr_t *instr) /* multi-way branch */
      * the user-mode DynamoRIO instrumentation does not need to treat them
      * as such. sysexit and sysret are typically found in the kernel traces
      * generated using other methods (like QEMU). It is useful to treat them
-     * as such to show proper continuity in the injected traces
+     * as such to show proper PC continuity in the injected traces
      * (i#6495, i#7157).
      */
     return (opc == OP_jmp_ind || opc == OP_call_ind || opc == OP_ret ||

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -508,6 +508,14 @@ instr_branch_type(instr_t *cti_instr)
         return LINK_INDIRECT | LINK_CALL | LINK_FAR;
     case OP_call_far_ind: return LINK_INDIRECT | LINK_CALL | LINK_FAR;
     case OP_ret_far:
+    /* We don't mark sysenter and syscall as indirect branches because
+     * the user-mode DynamoRIO instrumentation does not need to treat them
+     * as such. sysexit and sysret are typically found in the kernel traces
+     * generated using other methods (like QEMU). It is useful to treat them
+     * as such to show proper continuity in the injected traces
+     * (i#6495, i#7157).
+     */
+    case OP_sysexit:
     case OP_sysret:
     case OP_iret: return LINK_INDIRECT | LINK_RETURN | LINK_FAR;
     default:
@@ -560,7 +568,15 @@ bool
 instr_is_return(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    return (opc == OP_ret || opc == OP_ret_far || opc == OP_sysret || opc == OP_iret);
+    /* We don't mark sysenter and syscall as return because
+     * the user-mode DynamoRIO instrumentation does not need to treat them
+     * as such. sysexit and sysret are typically found in the kernel traces
+     * generated using other methods (like QEMU). It is useful to treat them
+     * as such to show proper continuity in the injected traces
+     * (i#6495, i#7157).
+     */
+    return (opc == OP_ret || opc == OP_ret_far || opc == OP_sysexit || opc == OP_sysret ||
+            opc == OP_iret);
 }
 
 /*** WARNING!  The following rely on ordering of opcodes! ***/
@@ -584,9 +600,16 @@ bool
 instr_is_mbr_arch(instr_t *instr) /* multi-way branch */
 {
     int opc = instr->opcode; /* caller ensures opcode is valid */
+    /* We don't mark sysenter and syscall as indirect branches because
+     * the user-mode DynamoRIO instrumentation does not need to treat them
+     * as such. sysexit and sysret are typically found in the kernel traces
+     * generated using other methods (like QEMU). It is useful to treat them
+     * as such to show proper continuity in the injected traces
+     * (i#6495, i#7157).
+     */
     return (opc == OP_jmp_ind || opc == OP_call_ind || opc == OP_ret ||
             opc == OP_jmp_far_ind || opc == OP_call_far_ind || opc == OP_ret_far ||
-            opc == OP_sysret || opc == OP_iret);
+            opc == OP_sysexit || opc == OP_sysret || opc == OP_iret);
 }
 
 bool

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -508,6 +508,7 @@ instr_branch_type(instr_t *cti_instr)
         return LINK_INDIRECT | LINK_CALL | LINK_FAR;
     case OP_call_far_ind: return LINK_INDIRECT | LINK_CALL | LINK_FAR;
     case OP_ret_far:
+    case OP_sysret:
     case OP_iret: return LINK_INDIRECT | LINK_RETURN | LINK_FAR;
     default:
         LOG(THREAD_GET, LOG_ALL, 0, "branch_type: unknown opcode: %d\n",
@@ -559,7 +560,7 @@ bool
 instr_is_return(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    return (opc == OP_ret || opc == OP_ret_far || opc == OP_iret);
+    return (opc == OP_ret || opc == OP_ret_far || opc == OP_iret || opc == OP_sysret);
 }
 
 /*** WARNING!  The following rely on ordering of opcodes! ***/
@@ -585,7 +586,7 @@ instr_is_mbr_arch(instr_t *instr) /* multi-way branch */
     int opc = instr->opcode; /* caller ensures opcode is valid */
     return (opc == OP_jmp_ind || opc == OP_call_ind || opc == OP_ret ||
             opc == OP_jmp_far_ind || opc == OP_call_far_ind || opc == OP_ret_far ||
-            opc == OP_iret);
+            opc == OP_sysret || opc == OP_iret);
 }
 
 bool

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -560,7 +560,7 @@ bool
 instr_is_return(instr_t *instr)
 {
     int opc = instr_get_opcode(instr);
-    return (opc == OP_ret || opc == OP_ret_far || opc == OP_iret || opc == OP_sysret);
+    return (opc == OP_ret || opc == OP_ret_far || opc == OP_sysret || opc == OP_iret);
 }
 
 /*** WARNING!  The following rely on ordering of opcodes! ***/


### PR DESCRIPTION
Marks the x86 OP_sysret and OP_sysexit properly for instr_is_mbr and instr_branch_type.

sysret and sysexit are not expected to be seen by the user-space DynamoRIO. We've seen sysret in kernel system call traces collected on QEMU as the instruction that ends the syscall trace and interrupts within the syscall trace. We want to annotate such instructions with the TRACE_MARKER_TYPE_BRANCH_TARGET marker, which requires that they must be marked as an indirect branch. This way we can show proper PC continuity in the kernel syscall injected traces.

We do not mark sysret and sysexit as return instructions because they are not returns in the usual sense that trace analysis tools would expect. E.g., they don't read the return address from the stack, and don't have matching call instrs (sysenter and syscall are not marked as a call instr either, as they're not so from the point of view of the user-mode DynamoRIO).

Issue: #6495, #7157