### PR TITLE
i#6495 syscall inject: Track syscall-fallthrough pc in raw2trace

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1604,7 +1604,8 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         // TODO i#6102: This actually does the wrong thing for SIG_IGN interrupting
         // an auto-restart syscall; we live with that until we remove it after fixing
         // the incorrect duplicate syscall error.
-        if (instr->is_syscall() && get_last_pc_if_syscall(tdata) == orig_pc &&
+        if (instr->is_syscall() &&
+            get_last_pc_fallthrough_if_syscall(tdata) == orig_pc + instr->length() &&
             instr_count == 1) {
             // Also remove the syscall marker.  It could be after a timestamp+cpuid
             // pair; we're fine removing those too and having the prior timestamp
@@ -1727,9 +1728,9 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
             } else
                 set_prev_instr_rep_string(tdata, false);
             if (instr->is_syscall())
-                set_last_pc_if_syscall(tdata, orig_pc);
+                set_last_pc_fallthrough_if_syscall(tdata, orig_pc + instr->length());
             else
-                set_last_pc_if_syscall(tdata, 0);
+                set_last_pc_fallthrough_if_syscall(tdata, 0);
             buf->size = (ushort)(skip_icache ? 0 : instr->length());
             buf->addr = (addr_t)orig_pc;
             ++buf;
@@ -3357,15 +3358,16 @@ raw2trace_t::log_instruction(uint level, app_pc decode_pc, app_pc orig_pc)
 }
 
 void
-raw2trace_t::set_last_pc_if_syscall(raw2trace_thread_data_t *tdata, app_pc value)
+raw2trace_t::set_last_pc_fallthrough_if_syscall(raw2trace_thread_data_t *tdata,
+                                                app_pc value)
 {
-    tdata->last_pc_if_syscall_ = value;
+    tdata->last_pc_fallthrough_if_syscall_ = value;
 }
 
 app_pc
-raw2trace_t::get_last_pc_if_syscall(raw2trace_thread_data_t *tdata)
+raw2trace_t::get_last_pc_fallthrough_if_syscall(raw2trace_thread_data_t *tdata)
 {
-    return tdata->last_pc_if_syscall_;
+    return tdata->last_pc_fallthrough_if_syscall_;
 }
 
 void

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -736,7 +736,7 @@ protected:
         uint64 chunk_count_ = 0;
         uint64 last_timestamp_ = 0;
         uint last_cpu_ = 0;
-        app_pc last_pc_if_syscall_ = 0;
+        app_pc last_pc_fallthrough_if_syscall_ = 0;
 
         bitset_hash_table_t<app_pc> encoding_emitted;
         app_pc last_encoding_emitted = nullptr;
@@ -1104,9 +1104,9 @@ private:
                             app_pc orig, bool write, int memop_index,
                             bool use_remembered_base, bool remember_base);
     void
-    set_last_pc_if_syscall(raw2trace_thread_data_t *tdata, app_pc value);
+    set_last_pc_fallthrough_if_syscall(raw2trace_thread_data_t *tdata, app_pc value);
     app_pc
-    get_last_pc_if_syscall(raw2trace_thread_data_t *tdata);
+    get_last_pc_fallthrough_if_syscall(raw2trace_thread_data_t *tdata);
 
     // Sets a per-traced-thread cached flag that is read by was_prev_instr_rep_string().
     void


### PR DESCRIPTION
Today, raw2trace tracks the last pc if it was a syscall, which is used to avoid consecutive duplicate system calls in the final trace.

Modifies raw2trace to instead track the fallthrough of the last pc if it was a syscall. This works just as well for the duplicate syscall check, and enables some upcoming logic which needs the fallthrough of the syscall instruction.

The existing test_duplicate_syscalls in raw2trace_unit_tests still passes.

Issue: #6495, #7157, #5934