### PR TITLE
i#7464 msb memref: Allow non-memref to follow prefetch instr

### DIFF
--- a/clients/drcachesim/tests/builtin_prefetch.c
+++ b/clients/drcachesim/tests/builtin_prefetch.c
@@ -55,6 +55,18 @@ main(void)
     __builtin_prefetch(&d, 1, 2);
     // L3
     __builtin_prefetch(&d, 1, 1);
+
+    // Prefetch with bad address.
+    // i#7464: We deliberately set one of the top 3 bits in the prefetched
+    // address. Note that even though this is an invalid address, hardware
+    // does not fault as it is only a prefetch. However, the address would
+    // overflow the 31 bits earmarked for the access address in the
+    // offline_entry_t.addr.addr raw trace entry, which would
+    // cause offline_entry_t.addr.type to be non-zero and non-all-1,
+    // therefore appearing like some other OFFLINE_TYPE_* type. raw2trace
+    // should be able to handle this discrepancy.
+    int *ptr = (int *)(1ULL << 62);
+    __builtin_prefetch(ptr);
     fprintf(stderr, "Hello, world!\n");
     return 0;
 }


### PR DESCRIPTION
Allows raw traces entries that do not look like OFFLINE_TYPE_MEMREF or OFFLINE_TYPE_MEMREF_HIGH to follow prefetch instructions during raw2trace conversion.

Prefetch instructions may generate a memref with an address that has some of the top 3 bits set which overwrites the type field to contain a value that is not either OFFLINE_TYPE_MEMREF or OFFLINE_TYPE_MEMREF_HIGH. Here, we override raw2trace logic to force it to process the raw trace entry following a prefetch instruction as a memref.

raw2trace conversion of a real trace failed with the "Unknown trace type" error without this fix. Reproduces the same issue on the builtin_prefetch app, which is now fixed.

Issue: #7464