### PR TITLE
Add raw2trace_t::is_marker_type to avoid duplication

### DIFF
--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2037,7 +2037,7 @@ raw2trace_t::should_omit_syscall(raw2trace_thread_data_t *tdata)
     const offline_entry_t *in_entry = get_next_entry(tdata);
     std::vector<offline_entry_t> saved;
     while (in_entry->timestamp.type == OFFLINE_TYPE_TIMESTAMP ||
-           (is_marker_type(in_entry, TRACE_MARKER_TYPE_CPU_ID))) {
+           is_marker_type(in_entry, TRACE_MARKER_TYPE_CPU_ID)) {
         saved.push_back(*in_entry);
         in_entry = get_next_entry(tdata);
     }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2050,7 +2050,7 @@ raw2trace_t::should_omit_syscall(raw2trace_thread_data_t *tdata)
 #endif
 }
 
-bool
+inline bool
 raw2trace_t::is_marker_type(const offline_entry_t *entry, trace_marker_type_t marker_type)
 {
     return entry->extended.type == OFFLINE_TYPE_EXTENDED &&

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1199,6 +1199,9 @@ private:
     bool
     should_omit_syscall(raw2trace_thread_data_t *tdata);
 
+    bool
+    is_marker_type(const offline_entry_t *entry, trace_marker_type_t marker_type);
+
     int worker_count_;
     std::vector<std::vector<raw2trace_thread_data_t *>> worker_tasks_;
 


### PR DESCRIPTION
Adds raw2trace_t::is_marker_type to avoid too much duplication of the not-so-trivial logic to check whether a given offline_entry_t is a marker of a specific type.