### PR TITLE
In drdeploy.c, null-terminate strings after strncpy.

### DIFF
--- a/tools/drdeploy.c
+++ b/tools/drdeploy.c
@@ -999,6 +999,7 @@ read_tool_file(const char *toolname, const char *dr_root, const char *dr_toolcon
             }
         } else if (strstr(line, "CLIENT_ABS=") == line) {
             strncpy(client, line + strlen("CLIENT_ABS="), client_size);
+            client[client_size - 1] = '\0';
             found_client = true;
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",
@@ -1007,6 +1008,7 @@ read_tool_file(const char *toolname, const char *dr_root, const char *dr_toolcon
         } else if (strstr(line, IF_X64_ELSE("CLIENT64_ABS=", "CLIENT32_ABS=")) == line) {
             strncpy(client, line + strlen(IF_X64_ELSE("CLIENT64_ABS=", "CLIENT32_ABS=")),
                     client_size);
+            client[client_size - 1] = '\0';
             found_client = true;
             if (native_path[0] != '\0') {
                 add_extra_option(tool_ops, tool_ops_size, tool_ops_sofar, "\"%s\"",
@@ -1016,6 +1018,7 @@ read_tool_file(const char *toolname, const char *dr_root, const char *dr_toolcon
             strncpy(alt_client,
                     line + strlen(IF_X64_ELSE("CLIENT32_ABS=", "CLIENT64_ABS=")),
                     alt_size);
+            alt_client[alt_size - 1] = '\0';
             if (!does_file_exist(alt_client)) {
                 alt_client[0] = '\0';
             }


### PR DESCRIPTION
In 3 of the 5 cases where strncpy is called the output string seemed not to be null-terminated.