### PR TITLE
i#7303 drsyscall: Add a library to read and write syscall arguments and memory content.

### DIFF
--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -176,3 +176,9 @@ use_DynamoRIO_extension(drsyscall_drstatic drmgr_static)
 configure_drsyscall_target(drsyscall_drstatic)
 
 install_ext_header(drsyscall.h)
+
+add_executable(drsyscall_record_reader drsyscall_record_reader.c)
+configure_DynamoRIO_standalone(drsyscall_record_reader)
+# we don't want drsyscall_record_reader installed so we avoid the standard location
+set_target_properties(drsyscall_record_reader PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/ext")

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -180,11 +180,14 @@ if (UNIX)
     drsyscall_record_lib.c
   )
 
-  add_library(drsyscall_record_lib STATIC ${drsyscall_record_lib_srcs})
-  configure_extension(drsyscall_record_lib ON OFF)
+  set(drsyscall_record_lib_external_srcs
+    ../drmf/framework/drmf_utils.c
+  )
+
+  add_library(drsyscall_record_lib STATIC ${drsyscall_record_lib_srcs}
+    ${drsyscall_record_lib_external_srcs})
+  configure_extension(drsyscall_record_lib ON ON)
   configure_DynamoRIO_client(drsyscall_record_lib)
-  append_property_string(TARGET drsyscall_record_lib COMPILE_FLAGS "-fno-exceptions")
-  set_target_properties(drsyscall_record_lib PROPERTIES INTERFACE_LINK_LIBRARIES "")
   use_DynamoRIO_extension(drutil_static drmgr_static)
 
   install_ext_header(drsyscall_record.h)
@@ -192,8 +195,8 @@ if (UNIX)
 
   add_executable(drsyscall_record_viewer drsyscall_record_viewer.c)
   configure_DynamoRIO_standalone(drsyscall_record_viewer)
+  configure_DynamoRIO_static(drsyscall_record_viewer)
   use_DynamoRIO_extension(drsyscall_record_viewer drsyscall_record_lib)
-  # We don't want drsyscall_record_viewer installed so we avoid the standard location.
   set_target_properties(drsyscall_record_viewer PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/ext")
+    RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/${INSTALL_BIN}")
 endif ()

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -175,12 +175,25 @@ use_DynamoRIO_extension(drsyscall_drstatic drcontainers_drstatuc)
 use_DynamoRIO_extension(drsyscall_drstatic drmgr_static)
 configure_drsyscall_target(drsyscall_drstatic)
 
-install_ext_header(drsyscall.h)
-
 if (UNIX)
+  set(drsyscall_record_lib_srcs
+    drsyscall_record_lib.c
+  )
+
+  add_library(drsyscall_record_lib STATIC ${drsyscall_record_lib_srcs})
+  configure_extension(drsyscall_record_lib ON OFF)
+  configure_DynamoRIO_client(drsyscall_record_lib)
+  append_property_string(TARGET drsyscall_record_lib COMPILE_FLAGS "-fno-exceptions")
+  set_target_properties(drsyscall_record_lib PROPERTIES INTERFACE_LINK_LIBRARIES "")
+  use_DynamoRIO_extension(drutil_static drmgr_static)
+
+  install_ext_header(drsyscall_record.h)
+  install_ext_header(drsyscall_record_lib.h)
+
   add_executable(drsyscall_record_reader drsyscall_record_reader.c)
   configure_DynamoRIO_standalone(drsyscall_record_reader)
-  # we don't want drsyscall_record_reader installed so we avoid the standard location
+  use_DynamoRIO_extension(drsyscall_record_reader drsyscall_record_lib)
+  # We don't want drsyscall_record_reader installed so we avoid the standard location.
   set_target_properties(drsyscall_record_reader PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/ext")
 endif ()

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -177,10 +177,10 @@ configure_drsyscall_target(drsyscall_drstatic)
 
 install_ext_header(drsyscall.h)
 
-#if (UNIX)
+if (UNIX)
   add_executable(drsyscall_record_reader drsyscall_record_reader.c)
   configure_DynamoRIO_standalone(drsyscall_record_reader)
   # we don't want drsyscall_record_reader installed so we avoid the standard location
   set_target_properties(drsyscall_record_reader PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/ext")
-#endif ()
+endif ()

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -177,8 +177,10 @@ configure_drsyscall_target(drsyscall_drstatic)
 
 install_ext_header(drsyscall.h)
 
-add_executable(drsyscall_record_reader drsyscall_record_reader.c)
-configure_DynamoRIO_standalone(drsyscall_record_reader)
-# we don't want drsyscall_record_reader installed so we avoid the standard location
-set_target_properties(drsyscall_record_reader PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/ext")
+#if (UNIX)
+  add_executable(drsyscall_record_reader drsyscall_record_reader.c)
+  configure_DynamoRIO_standalone(drsyscall_record_reader)
+  # we don't want drsyscall_record_reader installed so we avoid the standard location
+  set_target_properties(drsyscall_record_reader PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/ext")
+#endif ()

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -175,7 +175,7 @@ use_DynamoRIO_extension(drsyscall_drstatic drcontainers_drstatuc)
 use_DynamoRIO_extension(drsyscall_drstatic drmgr_static)
 configure_drsyscall_target(drsyscall_drstatic)
 
-if (UNIX)
+if (LINUX)
   set(drsyscall_record_lib_srcs
     drsyscall_record_lib.c
   )

--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -190,10 +190,10 @@ if (UNIX)
   install_ext_header(drsyscall_record.h)
   install_ext_header(drsyscall_record_lib.h)
 
-  add_executable(drsyscall_record_reader drsyscall_record_reader.c)
-  configure_DynamoRIO_standalone(drsyscall_record_reader)
-  use_DynamoRIO_extension(drsyscall_record_reader drsyscall_record_lib)
-  # We don't want drsyscall_record_reader installed so we avoid the standard location.
-  set_target_properties(drsyscall_record_reader PROPERTIES
+  add_executable(drsyscall_record_viewer drsyscall_record_viewer.c)
+  configure_DynamoRIO_standalone(drsyscall_record_viewer)
+  use_DynamoRIO_extension(drsyscall_record_viewer drsyscall_record_lib)
+  # We don't want drsyscall_record_viewer installed so we avoid the standard location.
+  set_target_properties(drsyscall_record_viewer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/ext")
 endif ()

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -41,7 +41,7 @@
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif
@@ -80,29 +80,39 @@ typedef struct syscall_record_t_ {
     // type is one of syscall_record_type_t.
     uint16_t type;
     union {
-        // The _raw_bytes entry is for initialization purposes and must be first in
-        // this list.  A byte array is used for initialization rather than an existing
-        // struct to avoid incomplete initialization due to padding or alignment
-        // constraints within a struct.  This array is not intended to be used for
-        // syscall_record_t access.
+        /**
+         * The _raw_bytes entry is for initialization purposes and must be first in
+         * this list.  A byte array is used for initialization rather than an existing
+         * struct to avoid incomplete initialization due to padding or alignment
+         * constraints within a struct.  This array is not intended to be used for
+         * syscall_record_t access.
+         */
         uint8_t _raw_bytes[SYSCALL_RECORD_UNION_SIZE_BYTES]; /**< Do not use: for init
                                                                 only. */
-        // syscall_number is used when the type is #DRSYS_SYSCALL_NUMBER or
-        // #DRSYS_RECORD_END.
+        /**
+         * The syscall number. It is used for type #DRSYS_SYSCALL_NUMBER or
+         * #DRSYS_RECORD_END.
+         */
         uint16_t syscall_number;
         START_PACKED_STRUCTURE
-        // param is used for type #DRSYS_PRECALL_PARAM and #DRSYS_POSTCALL_PARAM.
+        /**
+         * The parameter of a syscall. It is used for type #DRSYS_PRECALL_PARAM and
+         * #DRSYS_POSTCALL_PARAM.
+         */
         struct {
-            uint16_t ordinal;
-            reg_t value;
+            uint16_t ordinal; /**< The ordinal of the parameter. Set to -1 for a return
+                                 value */
+            reg_t value;      /**< The value of the parameter. */
         } END_PACKED_STRUCTURE param;
         START_PACKED_STRUCTURE
-        // content is used for type #DRSYS_MEMORY_CONTENT.
+        /**
+         * The memory address and the size of a syscall parameter. It is used for
+         * type #DRSYS_MEMORY_CONTENT. */
         struct {
-            uint8_t *address;
-            size_t size;
+            uint8_t *address; /**< The address of the memory region. */
+            size_t size;      /**< The size of the memory region. */
         } END_PACKED_STRUCTURE content;
-        // return_value is used for type #DRSYS_RETURN_VALUE.
+        /** The return value of the syscall. It is used for type #DRSYS_RETURN_VALUE. */
         reg_t return_value;
     };
 } END_PACKED_STRUCTURE syscall_record_t;

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -90,14 +90,14 @@ typedef struct syscall_record_t_ {
         uint8_t _raw_bytes[SYSCALL_RECORD_UNION_SIZE_BYTES]; /**< Do not use: for init
                                                                 only. */
         /**
-         * The syscall number. It is used for type #DRSYS_SYSCALL_NUMBER or
-         * #DRSYS_RECORD_END.
+         * The syscall number. It is used for type DRSYS_SYSCALL_NUMBER or
+         * DRSYS_RECORD_END.
          */
         uint16_t syscall_number;
         START_PACKED_STRUCTURE
         /**
-         * The parameter of a syscall. It is used for type #DRSYS_PRECALL_PARAM and
-         * #DRSYS_POSTCALL_PARAM.
+         * The parameter of a syscall. It is used for type DRSYS_PRECALL_PARAM and
+         * DRSYS_POSTCALL_PARAM.
          */
         struct {
             uint16_t ordinal; /**< The ordinal of the parameter. Set to -1 for a return
@@ -107,12 +107,12 @@ typedef struct syscall_record_t_ {
         START_PACKED_STRUCTURE
         /**
          * The memory address and the size of a syscall parameter. It is used for
-         * type #DRSYS_MEMORY_CONTENT. */
+         * type DRSYS_MEMORY_CONTENT. */
         struct {
             uint8_t *address; /**< The address of the memory region. */
             size_t size;      /**< The size of the memory region. */
         } END_PACKED_STRUCTURE content;
-        /** The return value of the syscall. It is used for type #DRSYS_RETURN_VALUE. */
+        /** The return value of the syscall. It is used for type DRSYS_RETURN_VALUE. */
         reg_t return_value;
     };
 } END_PACKED_STRUCTURE syscall_record_t;

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -57,12 +57,18 @@
 
 /** The type of the syscall record. */
 typedef enum {
-    DRSYS_SYSCALL_NUMBER = 1, /**< Start of a syscall. */
-    DRSYS_PRECALL_PARAM,      /**< Pre-syscall parameter. */
-    DRSYS_POSTCALL_PARAM,     /**< Post-syscall parameter. */
-    DRSYS_MEMORY_CONTENT,     /**< Memory address, size, and content. */
-    DRSYS_RETURN_VALUE,       /**< Return value of the syscall. */
-    DRSYS_RECORD_END,         /**< End of a syscall. */
+    /** Start of a syscall. */
+    DRSYS_SYSCALL_NUMBER = 1,
+    /** Pre-syscall parameter.*/
+    DRSYS_PRECALL_PARAM,
+    /** Post-syscall parameter. */
+    DRSYS_POSTCALL_PARAM,
+    /** Memory address, size, and content. */
+    DRSYS_MEMORY_CONTENT,
+    /** Return value of the syscall. */
+    DRSYS_RETURN_VALUE,
+    /** End of a syscall. */
+    DRSYS_RECORD_END,
 } syscall_record_type_t;
 
 /**

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -41,7 +41,7 @@
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -36,6 +36,14 @@
 #include <stdint.h>
 #include "dr_api.h"
 
+/**************************************************
+ * TOP-LEVEL ROUTINES
+ */
+/**
+ * @file drsyscall_record.h
+ * @brief Header for Dr. Syscall system call records.
+ */
+
 // XXX i#7472: Move definitions of START_PACKED_STRUCTURE and
 // END_PACKED_STRUCTURE to core.
 #ifdef WINDOWS
@@ -88,10 +96,9 @@ typedef struct syscall_record_t_ {
     union {
         /**
          * The _raw_bytes entry is for initialization purposes and must be first in
-         * this list.  A byte array is used for initialization rather than an existing
+         * this list. A byte array is used for initialization rather than an existing
          * struct to avoid incomplete initialization due to padding or alignment
-         * constraints within a struct.  This array is not intended to be used for
-         * #syscall_record_t access.
+         * constraints within a struct. This array is not intended to be used.
          */
         uint8_t _raw_bytes[SYSCALL_RECORD_UNION_SIZE_BYTES];
         /**

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -41,7 +41,7 @@
 #ifdef WINDOWS
 /* Use special C99 operator _Pragma to generate a pragma from a macro */
 #    if _MSC_VER <= 1200
-#        define ACTUAL_PRAGMA(p) _Pragma(#        p)
+#        define ACTUAL_PRAGMA(p) _Pragma(#p)
 #    else
 #        define ACTUAL_PRAGMA(p) __pragma(p)
 #    endif
@@ -85,34 +85,36 @@ typedef struct syscall_record_t_ {
          * this list.  A byte array is used for initialization rather than an existing
          * struct to avoid incomplete initialization due to padding or alignment
          * constraints within a struct.  This array is not intended to be used for
-         * syscall_record_t access.
+         * #syscall_record_t access.
          */
-        uint8_t _raw_bytes[SYSCALL_RECORD_UNION_SIZE_BYTES]; /**< Do not use: for init
-                                                                only. */
+        uint8_t _raw_bytes[SYSCALL_RECORD_UNION_SIZE_BYTES];
         /**
-         * The syscall number. It is used for type DRSYS_SYSCALL_NUMBER or
-         * DRSYS_RECORD_END.
+         * The syscall number. It is used for type #DRSYS_SYSCALL_NUMBER or
+         * #DRSYS_RECORD_END.
          */
         uint16_t syscall_number;
         START_PACKED_STRUCTURE
         /**
-         * The parameter of a syscall. It is used for type DRSYS_PRECALL_PARAM and
-         * DRSYS_POSTCALL_PARAM.
+         * The parameter of a syscall. It is used for type #DRSYS_PRECALL_PARAM and
+         * #DRSYS_POSTCALL_PARAM.
          */
         struct {
-            uint16_t ordinal; /**< The ordinal of the parameter. Set to -1 for a return
-                                 value */
-            reg_t value;      /**< The value of the parameter. */
+            /** The ordinal of the parameter. Set to -1 for a return value. */
+            uint16_t ordinal;
+            /** The value of the parameter. */
+            reg_t value;
         } END_PACKED_STRUCTURE param;
         START_PACKED_STRUCTURE
         /**
          * The memory address and the size of a syscall parameter. It is used for
-         * type DRSYS_MEMORY_CONTENT. */
+         * type #DRSYS_MEMORY_CONTENT. */
         struct {
-            uint8_t *address; /**< The address of the memory region. */
-            size_t size;      /**< The size of the memory region. */
+            /** The address of the memory region. */
+            uint8_t *address;
+            /** The size of the memory region. */
+            size_t size;
         } END_PACKED_STRUCTURE content;
-        /** The return value of the syscall. It is used for type DRSYS_RETURN_VALUE. */
+        /** The return value of the syscall. It is used for type #DRSYS_RETURN_VALUE. */
         reg_t return_value;
     };
 } END_PACKED_STRUCTURE syscall_record_t;

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -1,0 +1,78 @@
+/* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <stdint.h>
+#include "dr_api.h"
+
+typedef enum {
+    DRSYS_SYSCALL_NUMBER = 1,
+    DRSYS_PRECALL_PARAM,
+    DRSYS_POSTCALL_PARAM,
+    DRSYS_MEMORY_CONTENT,
+    DRSYS_RETURN_VALUE,
+    DRSYS_RECORD_END,
+} syscall_record_type_t;
+
+/**
+ * To enable #syscall_record_t to be default initialized reliably, a byte array is defined
+ * with the same length as the largest member of the union.
+ */
+#define SYSCALL_RECORD_UNION_SIZE_BYTES (sizeof(uint8_t *) + sizeof(size_t))
+
+typedef struct syscall_record_t_ {
+    // type is one of syscall_record_type_t.
+    uint16_t type;
+    union {
+        // The _raw_bytes entry is for initialization purposes and must be first in
+        // this list.  A byte array is used for initialization rather than an existing
+        // struct to avoid incomplete initialization due to padding or alignment
+        // constraints within a struct.  This array is not intended to be used for
+        // syscall_record_t access.
+        uint8_t _raw_bytes[SYSCALL_RECORD_UNION_SIZE_BYTES]; /**< Do not use: for init
+                                                                only. */
+        // syscall_number is used when the type is DRSYS_SYSCALL_NUMBER or
+        // DRSYS_RECORD_END.
+        uint16_t syscall_number;
+        // param is used for type DRSYS_PRECALL_PARAM and DRSYS_POSTCALL_PARAM.
+        struct {
+            uint16_t ordinal;
+            reg_t value;
+        } param;
+        // content is used for type DRSYS_MEMORY_CONTENT.
+        struct {
+            uint8_t *address;
+            size_t size;
+        } content;
+        // return_value is used for type DRSYS_RETURN_VALUE.
+        reg_t return_value;
+    };
+} __attribute__((__packed__)) syscall_record_t;

--- a/ext/drsyscall/drsyscall_record_lib.c
+++ b/ext/drsyscall/drsyscall_record_lib.c
@@ -69,16 +69,15 @@ drsyscall_read_record_file(DR_PARAM_IN FILE *output_stream,
                 return -1;
             }
             char *ptr = buffer;
-            size_t count = 0;
-            for (; count + sizeof(uint32_t) <= record.content.size;
-                 count += sizeof(uint32_t), ptr += sizeof(int32_t)) {
-                fprintf(output_stream, "%08x ", *(uint32_t *)ptr);
-                if ((count + 4) % 16 == 0) {
-                    fprintf(output_stream, "\n    ");
-                }
-            }
-            for (++ptr; count < record.content.size; ++count, ++ptr) {
+            for (size_t count = 0; count < record.content.size; ++count, ++ptr) {
                 fprintf(output_stream, "%02x", *ptr);
+                if ((count + 1) % 16 == 0) {
+                    fprintf(output_stream, "\n    ");
+                    continue;
+                }
+                if ((count + 1) % 4 == 0) {
+                    fprintf(output_stream, " ");
+                }
             }
             free(buffer);
             fprintf(output_stream, "\n");

--- a/ext/drsyscall/drsyscall_record_lib.c
+++ b/ext/drsyscall/drsyscall_record_lib.c
@@ -80,7 +80,7 @@ drsyscall_iterate_records(drsyscall_record_read_t read_func,
                 offset += sizeof(syscall_record_t);
                 remaining -= sizeof(syscall_record_t);
                 break;
-            case DRSYS_MEMORY_CONTENT:
+            case DRSYS_MEMORY_CONTENT: {
                 const size_t content_size = record->content.size;
                 if (remaining >= content_size) {
                     if (!record_cb(record, buffer + offset + sizeof(syscall_record_t),
@@ -106,7 +106,7 @@ drsyscall_iterate_records(drsyscall_record_read_t read_func,
                 global_free(content, remaining_bytes, HEAPSTAT_MISC);
                 offset = 0;
                 remaining = buffer_size;
-                break;
+            } break;
             default: global_free(buffer, buffer_size, HEAPSTAT_MISC); return false;
             }
         }

--- a/ext/drsyscall/drsyscall_record_lib.c
+++ b/ext/drsyscall/drsyscall_record_lib.c
@@ -1,0 +1,166 @@
+/* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "drsyscall.h"
+#include "drsyscall_record.h"
+
+DR_EXPORT
+int
+drsyscall_read_record_file(DR_PARAM_IN FILE *output_stream,
+                           DR_PARAM_IN FILE *error_stream, DR_PARAM_IN int record_file)
+{
+    syscall_record_t record = {};
+    while (read(record_file, &record, sizeof(record)) == sizeof(record)) {
+        switch (record.type) {
+        case DRSYS_SYSCALL_NUMBER:
+            fprintf(output_stream, "syscall: %d\n", record.syscall_number);
+            break;
+        case DRSYS_PRECALL_PARAM:
+        case DRSYS_POSTCALL_PARAM:
+            fprintf(output_stream, "%s-syscall ordinal %d, value " PIFX "\n",
+                    (record.type == DRSYS_PRECALL_PARAM ? "pre" : "post"),
+                    record.param.ordinal, record.param.value);
+            break;
+        case DRSYS_MEMORY_CONTENT:
+            fprintf(output_stream, "memory content address " PFX ", size " PIFX "\n    ",
+                    record.content.address, record.content.size);
+            char *buffer = (char *)malloc(record.content.size);
+            if (buffer == NULL) {
+                fprintf(error_stream,
+                        "failed to allocate buffer to read the record file.\n");
+                return -1;
+            }
+            if (read(record_file, buffer, record.content.size) != record.content.size) {
+                fprintf(error_stream,
+                        "failed to read " PIFX " bytes from the record file.\n",
+                        sizeof(buffer));
+                return -1;
+            }
+            char *ptr = buffer;
+            size_t count = 0;
+            for (; count + sizeof(uint32_t) <= record.content.size;
+                 count += sizeof(uint32_t), ptr += sizeof(int32_t)) {
+                fprintf(output_stream, "%08x ", *(uint32_t *)ptr);
+                if ((count + 4) % 16 == 0) {
+                    fprintf(output_stream, "\n    ");
+                }
+            }
+            for (++ptr; count < record.content.size; ++count, ++ptr) {
+                fprintf(output_stream, "%02x", *ptr);
+            }
+            free(buffer);
+            fprintf(output_stream, "\n");
+            break;
+        case DRSYS_RETURN_VALUE:
+            fprintf(output_stream, "return value " PIFX "\n", record.return_value);
+            break;
+        case DRSYS_RECORD_END:
+            fprintf(output_stream, "syscall end: %d\n", record.syscall_number);
+            break;
+        default:
+            fprintf(error_stream, "unknown record type %d\n", record.type);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+DR_EXPORT
+int
+drsyscall_write_param_record(DR_PARAM_IN int record_file, DR_PARAM_IN drsys_arg_t *arg)
+{
+    if (!arg->valid) {
+        return 0;
+    }
+
+    // Ordinal is set to -1 for return value.
+    if (arg->ordinal == -1) {
+        if (arg->pre) {
+            // Ordinal should not be -1 for pre-syscall.
+            return -1;
+        }
+        syscall_record_t record = {};
+        record.type = DRSYS_RETURN_VALUE;
+        record.return_value = arg->value64;
+        return write(record_file, &record, sizeof(record));
+    }
+    syscall_record_t record = {};
+    record.type = arg->pre ? DRSYS_PRECALL_PARAM : DRSYS_POSTCALL_PARAM;
+    record.param.ordinal = arg->ordinal;
+    record.param.value = arg->value64;
+    return write(record_file, &record, sizeof(record));
+}
+
+DR_EXPORT
+int
+drsyscall_write_memarg_record(DR_PARAM_IN int record_file, DR_PARAM_IN drsys_arg_t *arg)
+{
+    if (!arg->valid) {
+        return 0;
+    }
+
+    if ((arg->pre && arg->mode & DRSYS_PARAM_IN) ||
+        (!arg->pre && arg->mode & DRSYS_PARAM_OUT)) {
+        syscall_record_t record = {};
+        record.type = DRSYS_MEMORY_CONTENT;
+        record.content.address = arg->start_addr;
+        record.content.size = arg->size;
+        if (write(record_file, &record, sizeof(record)) != sizeof(record)) {
+            return -1;
+        }
+        return write(record_file, arg->start_addr, arg->size);
+    }
+    return 0;
+}
+
+DR_EXPORT
+int
+drsyscall_write_syscall_number_record(DR_PARAM_IN int record_file, DR_PARAM_IN int sysnum)
+{
+    syscall_record_t record = {};
+    record.type = DRSYS_SYSCALL_NUMBER;
+    record.syscall_number = sysnum;
+    return write(record_file, &record, sizeof(record));
+}
+
+DR_EXPORT
+int
+drsyscall_write_syscall_end_record(DR_PARAM_IN int record_file, DR_PARAM_IN int sysnum)
+{
+    syscall_record_t record = {};
+    record.type = DRSYS_RECORD_END;
+    record.syscall_number = sysnum;
+    return write(record_file, &record, sizeof(record));
+}

--- a/ext/drsyscall/drsyscall_record_lib.h
+++ b/ext/drsyscall/drsyscall_record_lib.h
@@ -1,0 +1,88 @@
+/* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+#ifndef _DRSYSCALL_RECORD_LIB_H_
+#define _DRSYSCALL_RECORD_LIB_H_ 1
+#include <stdio.h>
+#include <unistd.h>
+
+#include "dr_api.h"
+#include "drsyscall.h"
+#include "drsyscall_record.h"
+
+DR_EXPORT
+/**
+ * Reads system call records from \p record_file and outputs the content to \p
+ * output_stream. Any errors encountered during this process are reported to the
+ * \p error_stream.
+ * @return 0 on success, or -1 if an error occurs.
+ */
+int
+drsyscall_read_record_file(DR_PARAM_IN FILE *output_stream,
+                           DR_PARAM_IN FILE *error_stream, DR_PARAM_IN int record_file);
+
+DR_EXPORT
+/**
+ * Write a #syscall_record_t of type #DRSYS_PRECALL_PARAM or #DRSYS_PRECALL_PARAM to \p
+ * record_file based on \p arg.
+ * @return the actual number of bytes written, or -1 if an error occues.
+ */
+int
+drsyscall_write_param_record(DR_PARAM_IN int record_file, DR_PARAM_IN drsys_arg_t *arg);
+
+DR_EXPORT
+/**
+ * Write a #syscall_record_t of type #DRSYS_MEMORY_CONTENT to \p record_file based on \p
+ * arg.
+ * @return the actual number of bytes written, or -1 if an error occues.
+ */
+int
+drsyscall_write_memarg_record(DR_PARAM_IN int record_file, DR_PARAM_IN drsys_arg_t *arg);
+
+DR_EXPORT
+/**
+ * Write a #syscall_record_t of type #DRSYS_SYSCALL_NUMBER to \p record_file based on \p
+ * arg.
+ * @return the actual number of bytes written.
+ */
+int
+drsyscall_write_syscall_number_record(DR_PARAM_IN int record_file,
+                                      DR_PARAM_IN int sysnum);
+
+DR_EXPORT
+/**
+ * Write a #syscall_record_t of type #DRSYS_RECORD_END to \p record_file based on \p arg.
+ * @return the actual number of bytes written.
+ */
+int
+drsyscall_write_syscall_end_record(DR_PARAM_IN int record_file, DR_PARAM_IN int sysnum);
+
+#endif /* _DRSYSCALL_RECORD_LIB_H_ */

--- a/ext/drsyscall/drsyscall_record_lib.h
+++ b/ext/drsyscall/drsyscall_record_lib.h
@@ -39,33 +39,30 @@
 #include "drsyscall_record.h"
 
 /**
- * A user provoided function to read syscall records. Returns the number of bytes read.
+ * A user provided function to read syscall records. Returns the number of bytes read.
  * Returns 0 if there are no more records.
  */
 typedef size_t (*drsyscall_record_read_t)(DR_PARAM_IN char *buffer,
                                           DR_PARAM_IN size_t size);
 
 /**
- * A user provoided function to write syscall records. Returns the number of bytes
+ * A user provided function to write syscall records. Returns the number of bytes
  * written.
  */
 typedef size_t (*drsyscall_record_write_t)(DR_PARAM_IN char *buffer,
                                            DR_PARAM_IN size_t size);
 
 /**
- * Callback function to invoke for each syscall record. Returns true to continue, false to
- * stop.
+ * Callback function to invoke for each syscall record. For record type
+ * #DRSYS_MEMORY_CONTENT, \p buffer points to the beginning of the buffer and
+ * \p size is the size of the buffer. \p buffer is NULL and \p size is 0 for
+ * other types.
+ *
+ * Returns true to continue, false to stop.
  */
-typedef bool (*drsyscall_iter_record_cb_t)(DR_PARAM_IN syscall_record_t *record);
-
-/**
- * Callback function to invoke for each memory region. The callback function
- * might be invoked multiple times for a memory region. If \p last_buffer is
- * false, it indicates more data is available, true otherwise.
- */
-typedef bool (*drsyscall_iter_memory_cb_t)(DR_PARAM_IN char *buffer,
-                                           DR_PARAM_IN size_t size,
-                                           DR_PARAM_IN bool last_buffer);
+typedef bool (*drsyscall_iter_record_cb_t)(DR_PARAM_IN syscall_record_t *record,
+                                           DR_PARAM_IN char *buffer,
+                                           DR_PARAM_IN size_t size);
 
 DR_EXPORT
 /**
@@ -73,17 +70,12 @@ DR_EXPORT
  *
  * @param[in] read_func  A user provided function to read syscall records.
  * @param[in] record_cb  The callback to invoke for each syscall record.
- * @param[in] memory_cb  The callback to invoke for memory region content. The
- *                       callback may be invoke multiple times for a memory
- *                       region. last_buffer is set to true for the last call of
- *                       a memory region.
  *
  * \return true on success, or false if an error occurs.
  */
 bool
 drsyscall_iterate_records(DR_PARAM_IN drsyscall_record_read_t read_func,
-                          DR_PARAM_IN drsyscall_iter_record_cb_t record_cb,
-                          DR_PARAM_IN drsyscall_iter_memory_cb_t memory_cb);
+                          DR_PARAM_IN drsyscall_iter_record_cb_t record_cb);
 
 DR_EXPORT
 /**

--- a/ext/drsyscall/drsyscall_record_lib.h
+++ b/ext/drsyscall/drsyscall_record_lib.h
@@ -47,7 +47,8 @@ typedef size_t (*drsyscall_record_read_t)(DR_PARAM_IN char *buffer,
 
 /**
  * A user provided function to write syscall records. Returns the number of bytes
- * written.
+ * written. For performance optimization, the function should implement buffering
+ * to write records in bulk.
  */
 typedef size_t (*drsyscall_record_write_t)(DR_PARAM_IN char *buffer,
                                            DR_PARAM_IN size_t size);

--- a/ext/drsyscall/drsyscall_record_lib.h
+++ b/ext/drsyscall/drsyscall_record_lib.h
@@ -40,7 +40,7 @@
 
 /**
  * A user provided function to read syscall records. Returns the number of bytes read.
- * Returns 0 if there are no more records.
+ * Returns 0 if there are no more bytes.
  */
 typedef size_t (*drsyscall_record_read_t)(DR_PARAM_IN char *buffer,
                                           DR_PARAM_IN size_t size);
@@ -71,7 +71,8 @@ DR_EXPORT
  * @param[in] read_func  A user provided function to read syscall records.
  * @param[in] record_cb  The callback to invoke for each syscall record.
  *
- * \return true on success, or false if an error occurs.
+ * \return true when read_func returns 0 or record_cb returns false. Return false if an
+ * error occurs.
  */
 bool
 drsyscall_iterate_records(DR_PARAM_IN drsyscall_record_read_t read_func,

--- a/ext/drsyscall/drsyscall_record_reader.c
+++ b/ext/drsyscall/drsyscall_record_reader.c
@@ -52,7 +52,7 @@ main(int argc, char *argv[])
             break;
         case DRSYS_PRECALL_PARAM:
         case DRSYS_POSTCALL_PARAM:
-            fprintf(stdout, "%s-syscall ordinal %d, value 0x" HEX64_FORMAT_STRING "\n",
+            fprintf(stdout, "%s-syscall ordinal %d, value " PIFX "\n",
                     (record.type == DRSYS_PRECALL_PARAM ? "pre" : "post"),
                     record.param.ordinal, record.param.value);
             break;
@@ -88,8 +88,7 @@ main(int argc, char *argv[])
             fprintf(stdout, "\n");
             break;
         case DRSYS_RETURN_VALUE:
-            fprintf(stdout, "return value 0x" HEX64_FORMAT_STRING "\n",
-                    record.return_value);
+            fprintf(stdout, "return value " PIFX "\n", record.return_value);
             break;
         case DRSYS_RECORD_END:
             fprintf(stdout, "syscall end: %d\n", record.syscall_number);

--- a/ext/drsyscall/drsyscall_record_reader.c
+++ b/ext/drsyscall/drsyscall_record_reader.c
@@ -1,0 +1,101 @@
+/* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "drsyscall_record.h"
+
+int
+main(int argc, char *argv[])
+{
+    int record_file = open(argv[1], O_RDONLY);
+    if (record_file == -1) {
+        fprintf(stderr, "unable to open file %s\n", argv[1]);
+        return -1;
+    }
+    syscall_record_t record = {};
+    while (read(record_file, &record, sizeof(record)) == sizeof(record)) {
+        switch (record.type) {
+        case DRSYS_SYSCALL_NUMBER:
+            fprintf(stdout, "syscall: %d\n", record.syscall_number);
+            break;
+        case DRSYS_PRECALL_PARAM:
+        case DRSYS_POSTCALL_PARAM:
+            fprintf(stdout, "%s-syscall ordinal %d, value 0x" HEX64_FORMAT_STRING "\n",
+                    (record.type == DRSYS_PRECALL_PARAM ? "pre" : "post"),
+                    record.param.ordinal, record.param.value);
+            break;
+        case DRSYS_MEMORY_CONTENT:
+            fprintf(stdout, "memory content address " PFX ", size " PIFX "\n    ",
+                    record.content.address, record.content.size);
+            uint32_t buffer;
+            size_t count = 0;
+            for (; count + sizeof(buffer) <= record.content.size;
+                 count += sizeof(buffer)) {
+                if (read(record_file, &buffer, sizeof(buffer)) != sizeof(buffer)) {
+                    fprintf(stderr,
+                            "failed to read " PIFX " bytes from the record file.\n",
+                            sizeof(buffer));
+                    return -1;
+                }
+                fprintf(stdout, "%08x ", buffer);
+                if ((count + 4) % 16 == 0) {
+                    fprintf(stdout, "\n    ");
+                }
+            }
+            if (count < record.content.size) {
+                buffer = 0;
+                if (read(record_file, &buffer, record.content.size - count) !=
+                    record.content.size - count) {
+                    fprintf(stderr,
+                            "failed to read " PIFX " bytes from the record file.\n",
+                            record.content.size - count);
+                    return -1;
+                }
+                fprintf(stdout, "%08x", buffer);
+            }
+            fprintf(stdout, "\n");
+            break;
+        case DRSYS_RETURN_VALUE:
+            fprintf(stdout, "return value 0x" HEX64_FORMAT_STRING "\n",
+                    record.return_value);
+            break;
+        case DRSYS_RECORD_END:
+            fprintf(stdout, "syscall end: %d\n", record.syscall_number);
+            break;
+        default: fprintf(stderr, "unknown record type %d\n", record.type); return -1;
+        }
+    }
+    return 0;
+}

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6346,16 +6346,21 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
   use_DynamoRIO_extension(client.syscall-file-io-test.dll drsyscall)
 
   add_exe(linux.syscall_records linux/syscall-records.c)
-  set(client.syscall-records-test_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
-  set(client.syscall-records-test_precmd "rm@${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
-  set(client.syscall-records-test_postcmd
-      "${PROJECT_BINARY_DIR}/ext/drsyscall_record_reader@${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
+  set(client.syscall-records-test_runcmp
+    "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+  set(client.syscall-records-test_precmd
+    "rm@${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
+  string(CONCAT client.syscall-records-test_postcmd
+    "${PROJECT_BINARY_DIR}/ext/drsyscall_record_reader@"
+    "${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
   set(client.syscall-records-test_expectbase "syscall-records")
-  tobuild_ci(client.syscall-records-test client-interface/syscall-records-test.c "" "" "")
-  torunonly_ci(client.syscall-records-test linux.syscall_records client.syscall-records-test.dll
-     linux/syscall-records.c "" "" "")
-  use_DynamoRIO_extension(client.syscall-records-test.dll drmgr)
+  tobuild_ci(client.syscall-records-test
+    client-interface/syscall-records-test.c "" "" "")
+  torunonly_ci(client.syscall-records-test linux.syscall_records
+    client.syscall-records-test.dll
+    linux/syscall-records.c "" "" "")
   use_DynamoRIO_extension(client.syscall-records-test.dll drsyscall)
+  use_DynamoRIO_extension(client.syscall-records-test.dll drsyscall_record_lib)
 endif ()
 
 ###########################################################################

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6344,6 +6344,18 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
      linux/file-io.c "" "" "")
   use_DynamoRIO_extension(client.syscall-file-io-test.dll drmgr)
   use_DynamoRIO_extension(client.syscall-file-io-test.dll drsyscall)
+
+  add_exe(linux.syscall_records linux/syscall-records.c)
+  set(client.syscall-records-test_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")
+  set(client.syscall-records-test_precmd "rm@${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
+  set(client.syscall-records-test_postcmd
+      "${PROJECT_BINARY_DIR}/ext/drsyscall_record_reader@${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
+  set(client.syscall-records-test_expectbase "syscall-records")
+  tobuild_ci(client.syscall-records-test client-interface/syscall-records-test.c "" "" "")
+  torunonly_ci(client.syscall-records-test linux.syscall_records client.syscall-records-test.dll
+     linux/syscall-records.c "" "" "")
+  use_DynamoRIO_extension(client.syscall-records-test.dll drmgr)
+  use_DynamoRIO_extension(client.syscall-records-test.dll drsyscall)
 endif ()
 
 ###########################################################################

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6351,7 +6351,7 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
   set(client.syscall-records-test_precmd
     "rm@${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
   string(CONCAT client.syscall-records-test_postcmd
-    "${PROJECT_BINARY_DIR}/ext/drsyscall_record_viewer@"
+    "${PROJECT_BINARY_DIR}/${INSTALL_BIN}/drsyscall_record_viewer@"
     "${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
   set(client.syscall-records-test_expectbase "syscall-records")
   tobuild_ci(client.syscall-records-test

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6351,7 +6351,7 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
   set(client.syscall-records-test_precmd
     "rm@${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
   string(CONCAT client.syscall-records-test_postcmd
-    "${PROJECT_BINARY_DIR}/ext/drsyscall_record_reader@"
+    "${PROJECT_BINARY_DIR}/ext/drsyscall_record_viewer@"
     "${PROJECT_BINARY_DIR}/suite/tests/syscall_record_file.*")
   set(client.syscall-records-test_expectbase "syscall-records")
   tobuild_ci(client.syscall-records-test

--- a/suite/tests/client-interface/syscall-records-test.dll.c
+++ b/suite/tests/client-interface/syscall-records-test.dll.c
@@ -1,0 +1,227 @@
+/* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <stdint.h>
+#include <unistd.h>
+
+#include "dr_api.h"
+#include "client_tools.h"
+#include "drmgr.h"
+#include "drsyscall.h"
+#include "../../../ext/drsyscall/drsyscall_record.h"
+#include "syscall.h"
+
+static file_t record_file;
+
+static bool
+event_filter_syscall(void *drcontext, int sysnum)
+{
+    switch (sysnum) {
+    case SYS_close:
+    case SYS_openat:
+    case SYS_read:
+    case SYS_write: return true;
+    default: return false;
+    }
+}
+
+static bool
+drsys_iter_memarg_cb(drsys_arg_t *arg, void *user_data)
+{
+    if (!arg->valid) {
+        return true; /* keep going */
+    }
+
+    if ((arg->pre && arg->mode & DRSYS_PARAM_IN) ||
+        (!arg->pre && arg->mode & DRSYS_PARAM_OUT)) {
+        syscall_record_t record = {};
+        record.type = DRSYS_MEMORY_CONTENT;
+        record.content.address = arg->start_addr;
+        record.content.size = arg->size;
+        dr_write_file(record_file, &record, sizeof(record));
+        dr_write_file(record_file, arg->start_addr, arg->size);
+    }
+
+    return true;
+}
+
+static bool
+drsys_iter_arg_cb(drsys_arg_t *arg, void *user_data)
+{
+    if (!arg->valid) {
+        return true; /* keep going */
+    }
+
+    // ordinal is set to -1 for return value.
+    if (arg->ordinal == -1) {
+        if (!arg->pre) {
+            syscall_record_t record = {};
+            record.type = DRSYS_RETURN_VALUE;
+            record.return_value = arg->value64;
+            dr_write_file(record_file, &record, sizeof(record));
+        }
+        return true;
+    }
+    syscall_record_t record = {};
+    record.type = arg->pre ? DRSYS_PRECALL_PARAM : DRSYS_POSTCALL_PARAM;
+    record.param.ordinal = arg->ordinal;
+    record.param.value = arg->value64;
+    dr_write_file(record_file, &record, sizeof(record));
+    return true; /* keep going */
+}
+
+static bool
+event_pre_syscall(void *drcontext, int sysnum)
+{
+    if (!event_filter_syscall(drcontext, sysnum)) {
+        return true;
+    }
+    drsys_syscall_t *syscall;
+    if (drsys_cur_syscall(drcontext, &syscall) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_cur_syscall failed, sysnum = %d", sysnum);
+        return false;
+    }
+    drsys_sysnum_t sysnum_full;
+    if (drsys_syscall_number(syscall, &sysnum_full) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_syscall_number failed, sysnum = %d", sysnum);
+        return false;
+    }
+    if (sysnum != sysnum_full.number) {
+        dr_fprintf(STDERR, "primary (%d) should match DR's num %d", sysnum,
+                   sysnum_full.number);
+        return false;
+    }
+    drsys_param_type_t ret_type = DRSYS_TYPE_INVALID;
+    if (drsys_syscall_return_type(syscall, &ret_type) != DRMF_SUCCESS ||
+        ret_type == DRSYS_TYPE_INVALID || ret_type == DRSYS_TYPE_UNKNOWN) {
+        dr_fprintf(STDERR, "failed to get syscall return type, sysnum = %d", sysnum);
+        return false;
+    }
+    bool known = false;
+    if (drsys_syscall_is_known(syscall, &known) != DRMF_SUCCESS || !known) {
+        dr_fprintf(STDERR, "syscall %d is unknown", sysnum);
+        return false;
+    }
+
+    syscall_record_t record = {};
+    record.type = DRSYS_SYSCALL_NUMBER;
+    record.syscall_number = sysnum;
+    dr_write_file(record_file, &record, sizeof(record));
+
+    if (drsys_iterate_args(drcontext, drsys_iter_arg_cb, NULL) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_iterate_args failed, sysnum = %d", sysnum);
+        return false;
+    }
+    if (drsys_iterate_memargs(drcontext, drsys_iter_memarg_cb, NULL) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_iterate_memargs failed, sysnum = %d", sysnum);
+        return false;
+    }
+    return true;
+}
+
+static void
+event_post_syscall(void *drcontext, int sysnum)
+{
+    if (!event_filter_syscall(drcontext, sysnum)) {
+        return;
+    }
+    drsys_syscall_t *syscall;
+    if (drsys_cur_syscall(drcontext, &syscall) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_cur_syscall failed, sysnum = %d", sysnum);
+        return;
+    }
+    drsys_sysnum_t sysnum_full;
+    if (drsys_syscall_number(syscall, &sysnum_full) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_syscall_number failed, sysnum = %d", sysnum);
+        return;
+    }
+    if (sysnum != sysnum_full.number) {
+        dr_fprintf(STDERR, "primary (%d) should match DR's num %d", sysnum,
+                   sysnum_full.number);
+        return;
+    }
+    if (drsys_iterate_args(drcontext, drsys_iter_arg_cb, NULL) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_iterate_args failed, sysnum = %d", sysnum);
+        return;
+    }
+    if (drsys_iterate_memargs(drcontext, drsys_iter_memarg_cb, NULL) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_iterate_memargs failed, sysnum = %d", sysnum);
+        return;
+    }
+    syscall_record_t record = {};
+    record.type = DRSYS_RECORD_END;
+    record.syscall_number = sysnum;
+    dr_write_file(record_file, &record, sizeof(record));
+}
+
+static void
+exit_event(void)
+{
+    dr_close_file(record_file);
+    if (drsys_exit() != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys failed to exit");
+    }
+    drmgr_exit();
+}
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    syscall_record_t record = {};
+    ASSERT((SYSCALL_RECORD_UNION_SIZE_BYTES + sizeof(record.type)) ==
+           sizeof(syscall_record_t));
+
+    char filename[MAXIMUM_PATH];
+    sprintf(filename, "syscall_record_file.%d", getpid());
+    record_file = dr_open_file(filename, DR_FILE_WRITE_OVERWRITE);
+    if (record_file == INVALID_FILE) {
+        dr_fprintf(STDERR, "Error opening file %d\n", filename);
+        return;
+    }
+
+    drsys_options_t ops = {
+        sizeof(ops),
+        0,
+    };
+    drmgr_init();
+    if (drsys_init(id, &ops) != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys failed to init");
+        return;
+    }
+    dr_register_exit_event(exit_event);
+    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_pre_syscall_event(event_pre_syscall);
+    drmgr_register_post_syscall_event(event_post_syscall);
+    if (drsys_filter_all_syscalls() != DRMF_SUCCESS) {
+        dr_fprintf(STDERR, "drsys_filter_all_syscalls should never fail");
+    }
+}

--- a/suite/tests/linux/syscall-records.c
+++ b/suite/tests/linux/syscall-records.c
@@ -1,0 +1,72 @@
+/* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "tools.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+
+const char hello_world[] = "Hello World!";
+
+int
+main(int argc, char **argv)
+{
+    char filename[MAXIMUM_PATH];
+    sprintf(filename, "syscall_file_io_test.%d.txt", getpid());
+    int fd = open(filename, O_CREAT | O_RDWR);
+    if (fd < 0) {
+        print("failed to open file %s to write\n", filename);
+        return 1;
+    }
+    if (write(fd, hello_world, sizeof(hello_world)) != sizeof(hello_world)) {
+        print("failed to write to file %s\n", filename);
+        return 1;
+    }
+    if (lseek(fd, 0, SEEK_SET) != 0) {
+        print("failed to rewind the file %s\n", filename);
+        return 1;
+    }
+    char buffer[sizeof(hello_world) + 1];
+    if (read(fd, buffer, sizeof(hello_world)) != sizeof(hello_world)) {
+        print("failed to read from file %s\n", filename);
+        return 1;
+    }
+    if (close(fd) != 0) {
+        print("failed to close file %s after reading\n", filename);
+        return 1;
+    }
+    if (remove(filename) != 0) {
+        print("failed to remove file %s\n", filename);
+        return 1;
+    }
+    return 0;
+}

--- a/suite/tests/linux/syscall-records.templatex
+++ b/suite/tests/linux/syscall-records.templatex
@@ -1,0 +1,59 @@
+#ifdef X86
+#    ifdef X64
+#        define SYSCALL_OPENAT 257
+#        define SYSCALL_WRITE 1
+#        define SYSCALL_READ 0
+#        define SYSCALL_CLOSE 3
+#    else
+#        define SYSCALL_OPENAT 295
+#        define SYSCALL_WRITE 4
+#        define SYSCALL_READ 3
+#        define SYSCALL_CLOSE 6
+#    endif
+#elif defined(AARCH64)
+#    define SYSCALL_OPENAT 56
+#    define SYSCALL_WRITE 64
+#    define SYSCALL_READ 63
+#    define SYSCALL_CLOSE 57
+#endif
+.*
+syscall: SYSCALL_OPENAT
+pre-syscall ordinal 0, value 0x[0-9a-f]+
+pre-syscall ordinal 1, value 0x[0-9a-f]+
+pre-syscall ordinal 2, value 0x[0-9a-f]+
+pre-syscall ordinal 3, value 0x[0-9a-f]+
+memory content address 0x[0-9a-f]+, size 0x[0-9a-f]+
+.*
+post-syscall ordinal 0, value 0x[0-9a-f]+
+post-syscall ordinal 1, value 0x[0-9a-f]+
+post-syscall ordinal 2, value 0x[0-9a-f]+
+post-syscall ordinal 3, value 0x[0-9a-f]+
+return value 0x[0-9a-f]+
+syscall end: SYSCALL_OPENAT
+syscall: SYSCALL_WRITE
+pre-syscall ordinal 0, value 0x[0-9a-f]+
+pre-syscall ordinal 1, value 0x[0-9a-f]+
+pre-syscall ordinal 2, value 0xd
+memory content address 0x[0-9a-f]+, size 0xd
+    6c6c6548 6f57206f 21646c72 00000000
+post-syscall ordinal 0, value 0x[0-9a-f]+
+post-syscall ordinal 1, value 0x[0-9a-f]+
+post-syscall ordinal 2, value 0xd
+return value 0xd
+syscall end: SYSCALL_WRITE
+syscall: SYSCALL_READ
+pre-syscall ordinal 0, value 0x[0-9a-f]+
+pre-syscall ordinal 1, value 0x[0-9a-f]+
+pre-syscall ordinal 2, value 0xd
+post-syscall ordinal 0, value 0x[0-9a-f]+
+post-syscall ordinal 1, value 0x[0-9a-f]+
+post-syscall ordinal 2, value 0xd
+return value 0xd
+memory content address 0x[0-9a-f]+, size 0xd
+    6c6c6548 6f57206f 21646c72 00000000
+syscall end: SYSCALL_READ
+syscall: SYSCALL_CLOSE
+pre-syscall ordinal 0, value 0x[0-9a-f]+
+post-syscall ordinal 0, value 0x[0-9a-f]+
+return value 0x0
+syscall end: SYSCALL_CLOSE

--- a/suite/tests/linux/syscall-records.templatex
+++ b/suite/tests/linux/syscall-records.templatex
@@ -35,7 +35,7 @@ pre-syscall ordinal 0, value 0x[0-9a-f]+
 pre-syscall ordinal 1, value 0x[0-9a-f]+
 pre-syscall ordinal 2, value 0xd
 memory content address 0x[0-9a-f]+, size 0xd
-    6c6c6548 6f57206f 21646c72 00
+    48656c6c 6f20576f 726c6421 00
 post-syscall ordinal 0, value 0x[0-9a-f]+
 post-syscall ordinal 1, value 0x[0-9a-f]+
 post-syscall ordinal 2, value 0xd
@@ -50,7 +50,7 @@ post-syscall ordinal 1, value 0x[0-9a-f]+
 post-syscall ordinal 2, value 0xd
 return value 0xd
 memory content address 0x[0-9a-f]+, size 0xd
-    6c6c6548 6f57206f 21646c72 00
+    48656c6c 6f20576f 726c6421 00
 syscall end: SYSCALL_READ
 syscall: SYSCALL_CLOSE
 pre-syscall ordinal 0, value 0x[0-9a-f]+

--- a/suite/tests/linux/syscall-records.templatex
+++ b/suite/tests/linux/syscall-records.templatex
@@ -35,7 +35,7 @@ pre-syscall ordinal 0, value 0x[0-9a-f]+
 pre-syscall ordinal 1, value 0x[0-9a-f]+
 pre-syscall ordinal 2, value 0xd
 memory content address 0x[0-9a-f]+, size 0xd
-    6c6c6548 6f57206f 21646c72 00000000
+    6c6c6548 6f57206f 21646c72 00
 post-syscall ordinal 0, value 0x[0-9a-f]+
 post-syscall ordinal 1, value 0x[0-9a-f]+
 post-syscall ordinal 2, value 0xd
@@ -50,7 +50,7 @@ post-syscall ordinal 1, value 0x[0-9a-f]+
 post-syscall ordinal 2, value 0xd
 return value 0xd
 memory content address 0x[0-9a-f]+, size 0xd
-    6c6c6548 6f57206f 21646c72 00000000
+    6c6c6548 6f57206f 21646c72 00
 syscall end: SYSCALL_READ
 syscall: SYSCALL_CLOSE
 pre-syscall ordinal 0, value 0x[0-9a-f]+


### PR DESCRIPTION
Add a library, drsyscal_record_lib, to read and write syscall arguments and memory content.

Define a new structure, syscall_record_t, to store syscall arguments and memory content to a file.

Add a viewer, ext/drsyscall/drsyscall_record_viewer.c, to pretty print syscall_record_t records.

Add a new test, client.syscall-records-test, to verify  file I/O syscall arguments and memory content are stored
and retrieved correctly.

Issue: #7303 