### PR TITLE
i#7470: Fix order of unreading split trace entries

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -514,7 +514,7 @@ test_branch_delays(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
 #ifdef X64
-        // TODO i#7469: This is a bug. When looking for the kernel_event marker,
+        // TODO i#7470: This is a bug. When looking for the kernel_event marker,
         // raw2trace doesn't look for the ones preceded by the split_value marker
         // because the address was too large for a single marker. Some other marker
         // related logic also needs to expect the split_value marker.

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -441,14 +441,22 @@ test_branch_delays(void *drcontext)
         XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
     instr_t *jmp = XINST_CREATE_jump(drcontext, opnd_create_instr(move));
     instr_t *jcc = XINST_CREATE_jump_cond(drcontext, DR_PRED_EQ, opnd_create_instr(jmp));
+    instr_t *jump_mem =
+        XINST_CREATE_jump_mem(drcontext, opnd_create_mem_instr(jcc, 0, OPSZ_PTR));
+    instr_t *move2 =
+        XINST_CREATE_move(drcontext, opnd_create_reg(REG1), opnd_create_reg(REG2));
     instrlist_append(ilist, nop);
     instrlist_append(ilist, jcc);
     instrlist_append(ilist, jmp);
     instrlist_append(ilist, move);
+    instrlist_append(ilist, jump_mem);
+    instrlist_append(ilist, move2);
     size_t offs_nop = 0;
     size_t offs_jz = offs_nop + instr_length(drcontext, nop);
     size_t offs_jmp = offs_jz + instr_length(drcontext, jcc);
     size_t offs_mov = offs_jmp + instr_length(drcontext, jmp);
+    size_t offs_jump_mem = offs_mov + instr_length(drcontext, move);
+    size_t offs_mov2 = offs_jump_mem + instr_length(drcontext, jump_mem);
 
     // Now we synthesize our raw trace itself, including a valid header sequence.
     std::vector<offline_entry_t> raw;
@@ -461,6 +469,11 @@ test_branch_delays(void *drcontext)
     raw.push_back(make_core());
     raw.push_back(make_block(offs_jmp, 1));
     raw.push_back(make_block(offs_mov, 1));
+    raw.push_back(make_block(offs_jump_mem, 1));
+    // No memref needed for jump_mem because it is considered elided.
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_SPLIT_VALUE, 0x9abc));
+    raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, 0x12345678));
+    raw.push_back(make_block(offs_mov2, 1));
     raw.push_back(make_exit());
 
     std::vector<trace_entry_t> entries;
@@ -491,6 +504,19 @@ test_branch_delays(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
 #endif
         check_entry(entries, idx, TRACE_TYPE_INSTR_DIRECT_JUMP, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#ifdef X86_32
+        // An extra encoding entry is needed.
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+#endif
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET,
+                    offs_mov2) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR_INDIRECT_JUMP, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_EVENT,
+                    0x9abc12345678) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -37,6 +37,7 @@
 #include "mock_reader.h"
 #include "tracer/raw2trace.h"
 #include "tracer/raw2trace_directory.h"
+#include <iostream>
 #include <sstream>
 
 namespace dynamorio {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2794,12 +2794,12 @@ void
 raw2trace_t::unread_last_entry(raw2trace_thread_data_t *tdata)
 {
     VPRINT(5, "Unreading last entry\n");
+    tdata->pre_read.push_front(tdata->last_entry);
     if (tdata->last_entry_is_split) {
         VPRINT(4, "Unreading both parts of split entry at once\n");
         tdata->pre_read.push_front(tdata->last_split_first_entry);
         tdata->last_entry_is_split = false;
     }
-    tdata->pre_read.push_front(tdata->last_entry);
 }
 
 void

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -70,7 +70,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -70,6 +70,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 namespace dynamorio {
 namespace drmemtrace {


### PR DESCRIPTION
Fixes the order in which split trace entries such as TRACE_MARKER_TYPE_SPLIT_VALUE are unread in unread_last_entry. TRACE_MARKER_TYPE_SPLIT_VALUE must be at the front of the pre_read deque so that it is returned _before_ the actual marker, in the same order it is read from the raw trace.

Adds a raw2trace_unit_test that fails with "SPLIT_VALUE marker is not adjacent to 2nd entry" due to the previously incorrect order of the split_value marker wrt the actual marker in the deque. The error was demonstrated using a large enough kernel_event marker value. This was not seen on a real trace probably because kernel_event marker values do not need the additional marker usually.

There is an additional bug where raw2trace does not fully take into account the fact that some markers may be preceded by the TRACE_MARKER_TYPE_SPLIT_VALUE marker. Added a TODO for now.

Issue: #7470