### PR TITLE
i#7474 chunk order: Widen drmemtrace zip chunk suffixes

### DIFF
--- a/clients/drcachesim/tools/filter/record_filter.cpp
+++ b/clients/drcachesim/tools/filter/record_filter.cpp
@@ -352,8 +352,8 @@ record_filter_t::open_new_chunk(per_shard_t *shard)
     }
 
     std::ostringstream stream;
-    stream << TRACE_CHUNK_PREFIX << std::setfill('0') << std::setw(4)
-           << shard->chunk_ordinal;
+    stream << TRACE_CHUNK_PREFIX << std::setfill('0')
+           << std::setw(TRACE_CHUNK_SUFFIX_WIDTH) << shard->chunk_ordinal;
     err = shard->archive_writer->open_new_component(stream.str());
     if (!err.empty())
         return err;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3036,8 +3036,8 @@ raw2trace_t::open_new_chunk(raw2trace_thread_data_t *tdata)
     }
 
     std::ostringstream stream;
-    stream << TRACE_CHUNK_PREFIX << std::setfill('0') << std::setw(4)
-           << tdata->chunk_count_;
+    stream << TRACE_CHUNK_PREFIX << std::setfill('0')
+           << std::setw(TRACE_CHUNK_SUFFIX_WIDTH) << tdata->chunk_count_;
     tdata->error = tdata->out_archive->open_new_component(stream.str());
     if (!tdata->error.empty())
         return false;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -3036,6 +3036,19 @@ raw2trace_t::open_new_chunk(raw2trace_thread_data_t *tdata)
     }
 
     std::ostringstream stream;
+    // Ensure we have enough digits (xref i#7474).
+    uint64_t val = tdata->chunk_count_;
+    int digits = 0;
+    while (val > 0) {
+        ++digits;
+        val /= 10;
+    }
+    if (digits > TRACE_CHUNK_SUFFIX_WIDTH) {
+        tdata->error = "Chunk count " + std::to_string(tdata->chunk_count_) +
+            " exceeds max " + std::to_string(TRACE_CHUNK_SUFFIX_WIDTH) +
+            " digits in component names";
+        return false;
+    }
     stream << TRACE_CHUNK_PREFIX << std::setfill('0')
            << std::setw(TRACE_CHUNK_SUFFIX_WIDTH) << tdata->chunk_count_;
     tdata->error = tdata->out_archive->open_new_component(stream.str());

--- a/clients/drcachesim/tracer/raw2trace_shared.h
+++ b/clients/drcachesim/tracer/raw2trace_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -73,6 +73,10 @@ namespace drmemtrace {
 #define WINDOW_SUBDIR_FIRST "window.0000"
 #define TRACE_SUBDIR "trace"
 #define TRACE_CHUNK_PREFIX "chunk."
+// The chunk name is "chunk.nnnnnnnn" with leading 0's for the number suffix.
+// Some zip readers end up alphabetizing the component files, so be sure to have enough
+// leading zeroes to keep them in numeric order even with large component counts.
+#define TRACE_CHUNK_SUFFIX_WIDTH 8
 // Dir for auxiliary files. Same level as TRACE_SUBDIR and OUTFILE_SUBDIR.
 #define AUX_SUBDIR "aux"
 


### PR DESCRIPTION
The drmemtrace zip files split traces up into chunks, one per subfile. The names are of the form "chunk.0000", "chunk.0001", etc., with leading zeroes to ensure sorting keeps them in archive order, as some zip readers end up sorting.  But with more than 10K chunks (with the default 10M instructions per chunk, that's 100B instructions) an alphabetic sort no longer keeps them sorted.

We widen the suffix from 4 digits to 8 digits, and name that constant as TRACE_CHUNK_SUFFIX_WIDTH in raw2trace_sharded.h.

With no reader in this repository that hits a problem we do not attempt to add a test here.  This is being tested with an internal usage that does sort.

Adds a check to raw2trace that enough digits are present.
Tested by temporarily reducing TRACE_CHUNK_SUFFIX_WIDTH to 1:
```
$ rm -rf drmemtrace.simple_app.*.dir; bin64/drrun -t drmemtrace -offline -- suite/tests/bin/simple_app; bin64/drrun -t drmemtrace -chunk_instr_count 1000 -indir drmemtrace.simple_app.*.dir -tool basic_counts -verbose 2

[drmemtrace]: Creating new chunk #10 for thread 1070655
[drmemtrace]: Worker 0 hit error Failed to process file for thread 1070655: Chunk count 10 exceeds max 1 digits in component names on trace thread 0
ERROR: failed to initialize analyzer: raw2trace failed: Failed to process file for thread 1070655: Chunk count 10 exceeds max 1 digits in component names
```
And also to 2:
```
[drmemtrace]: Creating new chunk #100 for thread 1066720
[drmemtrace]: Worker 0 hit error Failed to process file for thread 1066720: Chunk count 100 exceeds max 2 digits in component names on trace thread 0
ERROR: failed to initialize analyzer: raw2trace failed: Failed to process file for thread 1066720: Chunk count 100 exceeds max 2 digits in component names
```

Fixes #7474