### PR TITLE
i#7474 chunk order: Validate drmemtrace chunk order

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -4364,7 +4364,7 @@ check_regdeps(void)
                            /*tid=*/TID_A,
                            /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/0 },
-                         "Failed to catch non-allowed TRACE_MARKER_TYPE_FUNC_ID "marker"))
+                         "Failed to catch non-allowed TRACE_MARKER_TYPE_FUNC_ID marker"))
             return false;
     }
 

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -4359,14 +4359,12 @@ check_regdeps(void)
         };
         if (!run_checker(memrefs, true,
                          { "OFFLINE_FILE_TYPE_ARCH_REGDEPS traces cannot have "
-                           "TRACE_MARKER_TYPE_FUNC_ID markers related to functions "
-                           "that "
+                           "TRACE_MARKER_TYPE_FUNC_ID markers related to functions that "
                            "are not SYS_futex",
                            /*tid=*/TID_A,
                            /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/0 },
-                         "Failed to catch non-allowed TRACE_MARKER_TYPE_FUNC_ID "
-                         "marker"))
+                         "Failed to catch non-allowed TRACE_MARKER_TYPE_FUNC_ID "marker"))
             return false;
     }
 
@@ -4387,12 +4385,11 @@ check_regdeps(void)
     }
 #else
     // Correct: a non-LINUX DR build should always succeed when checking
-    // TRACE_MARKER_TYPE_FUNC_ID markers, as we cannot determine if the
-    // function ID of the TRACE_MARKER_TYPE_FUNC_ID marker is allowed in the
-    // OFFLINE_FILE_TYPE_ARCH_REGDEPS trace because we cannot determine if
-    // function ID is SYS_futex or not. For this reason the
-    // TRACE_MARKER_TYPE_FUNC_ID invariant check is disbled, we print a
-    // warning instead.
+    // TRACE_MARKER_TYPE_FUNC_ID markers, as we cannot determine if the function ID of
+    // the TRACE_MARKER_TYPE_FUNC_ID marker is allowed in the
+    // OFFLINE_FILE_TYPE_ARCH_REGDEPS trace because we cannot determine if function ID is
+    // SYS_futex or not. For this reason the TRACE_MARKER_TYPE_FUNC_ID invariant check is
+    // disbled, we print a warning instead.
     {
         std::vector<memref_t> memrefs = {
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_ARCH_REGDEPS),

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -474,12 +474,18 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         "Stream interface version != trace marker");
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
-        memref.marker.marker_type == TRACE_MARKER_TYPE_CHUNK_FOOTER &&
-        !shard->skipped_instrs_) {
-        report_if_false(shard,
-                        static_cast<int64_t>(memref.marker.marker_value) ==
-                            1 + shard->last_chunk_ordinal_,
-                        "Chunks do not increase monotonically");
+        memref.marker.marker_type == TRACE_MARKER_TYPE_CHUNK_FOOTER) {
+        if (shard->skipped_instrs_) {
+            report_if_false(shard,
+                            static_cast<int64_t>(memref.marker.marker_value) >=
+                                1 + shard->last_chunk_ordinal_,
+                            "Chunks do not increase");
+        } else {
+            report_if_false(shard,
+                            static_cast<int64_t>(memref.marker.marker_value) ==
+                                1 + shard->last_chunk_ordinal_,
+                            "Chunks do not increase monotonically");
+        }
         shard->last_chunk_ordinal_ = memref.marker.marker_value;
     }
     // Ensure each syscall instruction has a marker immediately afterward.  An

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -473,6 +473,14 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                             memref.marker.marker_value == shard->stream->get_version(),
                         "Stream interface version != trace marker");
     }
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_CHUNK_FOOTER) {
+        report_if_false(shard,
+                        static_cast<int64_t>(memref.marker.marker_value) ==
+                            1 + shard->last_chunk_ordinal_,
+                        "Chunks do not increase monotonically");
+        shard->last_chunk_ordinal_ = memref.marker.marker_value;
+    }
     // Ensure each syscall instruction has a marker immediately afterward.  An
     // asynchronous signal could be delivered after the tracer recorded the syscall
     // instruction but before DR executed the syscall itself (xref i#5790) but raw2trace

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -474,7 +474,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         "Stream interface version != trace marker");
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
-        memref.marker.marker_type == TRACE_MARKER_TYPE_CHUNK_FOOTER) {
+        memref.marker.marker_type == TRACE_MARKER_TYPE_CHUNK_FOOTER &&
+        !shard->skipped_instrs_) {
         report_if_false(shard,
                         static_cast<int64_t>(memref.marker.marker_value) ==
                             1 + shard->last_chunk_ordinal_,

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -250,6 +250,7 @@ protected:
         addr_t prev_syscall_end_branch_target_ = 0;
         // Relevant when -no_abort_on_invariant_error.
         uint64_t error_count_ = 0;
+        int64_t last_chunk_ordinal_ = -1;
     };
 
     // We provide this for subclasses to run these invariants with custom


### PR DESCRIPTION
Adds a drmemtrace invariant check that the chunk footer ordinals monotonically increase. This would have caught an error with an internal zipfile reader that sorts the subfiles combined with the only-4-digit zipfile suffix.

Adds a unit test.
Also tested internally on a real world trace with out-of-order chunk reading and it does report an error:
```
Trace invariant failure in shard xxx Tnnn at ref # 14491816352 (347 instrs since timestamp 13389589136540837 in_kernel false): Chunks do not increase monotonically
```

Fixes #7474