### PR TITLE
i#7474 chunk order: Include instruction ordinal in drmemtrace invariant failure

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -133,7 +133,8 @@ invariant_checker_t::report_if_false(per_shard_t *shard, bool condition,
             return;
         }
         std::cerr << "Trace invariant failure in T" << shard->tid_ << " at ref # "
-                  << shard->stream->get_record_ordinal() << " ("
+                  << shard->stream->get_record_ordinal() << " at instruction # "
+                  << shard->stream->get_instruction_ordinal() << " ("
                   << shard->instr_count_since_last_timestamp_
                   << " instrs since timestamp " << shard->last_timestamp_
                   << "): " << invariant_name << "\n";


### PR DESCRIPTION
Adds the instruction ordinal to the drmemtrace invariant failure output, as it is much faster to skip by instruction than record for large traces. This information was desirable while working on #7474 which manifested on 100-billion-instruction-thread
traces.

Tested:
Temporarily changed the invariant on chunk counts to fail on the first chunk footer to test the failure output:
```
$ bin64/drrun -t drmemtrace -indir drmemtrace.simple_app.754774.9269.dir/ -tool invariant_checker
Trace invariant failure in T754774 at ref # 1419 at instruction # 1000 (1000 instrs since timestamp 13390545216200494): Chunk instruction counts are inconsistent
```

Issue: #7474