### PR TITLE
i#7157, i#6495: Adjust invariant for interrupted auto-restart syscalls

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1072,10 +1072,13 @@ typedef enum {
      * system call execution. Each system call trace should end with an indirect
      * branch instruction (e.g., iret/sysret/sysexit on x86, or eret on AArch64) which
      * must be preceded by a #TRACE_MARKER_TYPE_BRANCH_TARGET marker with any value;
-     * the marker's value will be appropriately set to point to the next trace
-     * instruction during syscall injection. See the sample file written by the
-     * burst_syscall_inject.cpp test for more details on the expected format for the
-     * system call template file.
+     * the marker's value will be appropriately set to point to the fallthrough pc of
+     * the prior syscall instruction. Note: if a #TRACE_MARKER_TYPE_KERNEL_EVENT
+     * immediately follows the syscall trace, it indicates interruption of the syscall
+     * by a signal; in this case, the next pc is the #TRACE_MARKER_TYPE_KERNEL_EVENT
+     * value.
+     * See the sample file written by the burst_syscall_inject.cpp test for more
+     * details on the expected format for the system call template file.
      *
      * TODO i#6495: Add support for reading a zipfile where each trace template is in
      * a separate component. This will make it easier to manually append, update, or

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3487,6 +3487,41 @@ check_kernel_syscall_trace(void)
         if (!run_checker(memrefs, false))
             res = false;
     }
+    // Control resumes at the kernel_event marker with the the sys pc, instead of the
+    // pc specified in the syscall-end branch target marker which is sys+len(sys).
+    {
+        std::vector<memref_with_IR_t> memref_setup = {
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
+                         TRACE_ENTRY_VERSION_BRANCH_INFO),
+              nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE_FULL_SYSCALL_TRACE),
+              nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
+            { gen_instr(TID_A), sys },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 42), nullptr },
+            { gen_instr(TID_A), move },
+            { gen_instr(TID_A), load },
+            { gen_data(TID_A, /*load=*/true, /*addr=*/0x1234, /*size=*/4), nullptr },
+            // add_encodings_to_memrefs removes this from the memref list and adds it
+            // to memref_t.instr.indirect_branch_target instead for the following instr.
+            // Specifies post_sys, but really the next instr is the auto-restarted sys.
+            // This is a documented case where the TRACE_MARKER_TYPE_KERNEL_EVENT value
+            // takes precedence.
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_BRANCH_TARGET, 0), post_sys },
+            { gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A), sys_return },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 0), sys },
+            { gen_instr(TID_A), move },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 0), load },
+            { gen_instr(TID_A), sys },
+            { gen_exit(TID_A), nullptr }
+        };
+        auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
+        if (!run_checker(memrefs, false))
+            res = false;
+    }
     // Incorrect indirect branch target at the syscall trace end as it mismatches with
     // the subsequence kernel_event marker.
     {

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3487,8 +3487,8 @@ check_kernel_syscall_trace(void)
         if (!run_checker(memrefs, false))
             res = false;
     }
-    // Control resumes at the kernel_event marker with the the sys pc, instead of the
-    // pc specified in the syscall-end branch target marker which is sys+len(sys).
+    // Control resumes at the kernel_event marker with the sys instr pc, instead of the
+    // pc specified in the syscall-trace-end branch_target marker which is sys+len(sys).
     {
         std::vector<memref_with_IR_t> memref_setup = {
             { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,


### PR DESCRIPTION
Adjusts the invariant expectation for injected traces of auto-restart syscalls that were interrupted by a signal.

Our raw2trace/scheduler injection logic sets the syscall-trace-end TRACE_MARKER_TYPE_BRANCH_TARGET marker to the syscall fallthrough pc, but in this case the syscall instruction is the actual next pc. Since the TRACE_MARKER_TYPE_KERNEL_EVENT marker already holds the correct next pc, it should take precedence. Notes this case in trace_entry.h.

Issue: #7157, #6495