### PR TITLE
Mark schedule_stats_t::record_context_switch() virtual

### DIFF
--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -211,8 +211,11 @@ schedule_stats_t::update_state_time(per_shard_t *shard, state_t state)
     return true;
 }
 
+// shard->prev_workload_id and shard->prev_tid are cleared when this is called,
+// so we pass in the preserved values so there's no confusion.
 void
-schedule_stats_t::record_context_switch(per_shard_t *shard, int64_t workload_id,
+schedule_stats_t::record_context_switch(per_shard_t *shard, int64_t prev_workload_id,
+                                        int64_t prev_tid, int64_t workload_id,
                                         int64_t tid, int64_t input_id, int64_t letter_ord)
 {
     // We convert to letters which only works well for <=26 inputs.
@@ -372,7 +375,8 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
     if ((workload_id != prev_workload_id || tid != prev_tid) && tid != IDLE_THREAD_ID) {
         // See XXX comment in get_scheduler_stats(): this measures swap-ins, while
         // "perf" measures swap-outs.
-        record_context_switch(shard, workload_id, tid, input_id, letter_ord);
+        record_context_switch(shard, prev_workload_id, prev_tid, workload_id, tid,
+                              input_id, letter_ord);
     }
     shard->prev_workload_id = workload_id;
     shard->prev_tid = tid;

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -374,7 +374,7 @@ protected:
     bool
     update_state_time(per_shard_t *shard, state_t state);
 
-    void
+    virtual void
     record_context_switch(per_shard_t *shard, int64_t workload_id, int64_t tid,
                           int64_t input_id, int64_t letter_ord);
 

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -374,9 +374,12 @@ protected:
     bool
     update_state_time(per_shard_t *shard, state_t state);
 
+    // shard->prev_workload_id and shard->prev_tid are cleared when this is called,
+    // so we pass in the preserved values so there's no confusion.
     virtual void
-    record_context_switch(per_shard_t *shard, int64_t workload_id, int64_t tid,
-                          int64_t input_id, int64_t letter_ord);
+    record_context_switch(per_shard_t *shard, int64_t prev_workload_id, int64_t prev_tid,
+                          int64_t workload_id, int64_t tid, int64_t input_id,
+                          int64_t letter_ord);
 
     virtual void
     aggregate_results(counters_t &total);


### PR DESCRIPTION
Makes the schedule_stats_t method record_context_switch() virtual so it can be overridden in subclasses.

Addtiionally, since shard->prev_workload_id and shard->prev_tid are cleared when this function is called,
we pass in the preserved values so there's no confusion.

Tested in an internal use case.