### PR TITLE
i#3544 RV64: Replace usage of FindPythonInterp with FindPython3 in CMake

### DIFF
--- a/make/CMake_riscv64_gen_codec.cmake
+++ b/make/CMake_riscv64_gen_codec.cmake
@@ -30,11 +30,7 @@
 
 # Commands to automatically create the codec files from
 # core/arch/riscv64/isl/*.txt.
-find_package(PythonInterp)
-
-if (NOT PYTHONINTERP_FOUND)
-  message(FATAL_ERROR "Python interpreter not found")
-endif ()
+find_package(Python3 REQUIRED Interpreter)
 
 set(RISCV64_CODEC_GEN_SRCS
   ${PROJECT_BINARY_DIR}/opcode_api.h
@@ -80,7 +76,7 @@ add_custom_command(
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/zicboz.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/zicsr.txt
           ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl/zifencei.txt
-  COMMAND ${PYTHON_EXECUTABLE}
+  COMMAND ${Python3_EXECUTABLE}
   ARGS ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/codec.py
        ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}/isl
        ${PROJECT_SOURCE_DIR}/core/ir/${ARCH_NAME}


### PR DESCRIPTION
A Python 3 interpreter is required to generate instruction codecs for RV64. Previously we make use of CMake's FindPythonInterp to search for one, but the module has been deprecated in CMake since 3.12.

This patch replaces its usage with FindPython3 introduced in CMake 3.12, which is fine since the minimum required CMake version of DynamoRIO has been raised to 3.14. This fixes warnings about CMP0148 introduced since CMake 3.27.

Issue: #3544