### PR TITLE
i#7157 dyn inject: Adapt schedule_stats to syscall traces

### DIFF
--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -437,6 +437,17 @@ public:
         workload_id_ = id;
     }
 
+    bool
+    is_record_kernel() const override
+    {
+        return in_kernel_trace_;
+    }
+    void
+    set_in_kernel_trace(bool in_kernel_trace)
+    {
+        in_kernel_trace_ = in_kernel_trace;
+    }
+
 private:
     uint64_t *record_ordinal_ = nullptr;
     int64_t cpuid_ = 0;
@@ -444,6 +455,7 @@ private:
     int64_t tid_ = 0;
     int64_t workload_id_ = 0;
     int64_t last_timestamp_ = 0;
+    bool in_kernel_trace_ = false;
     // To let a test set just the tid and get a shard index for free.
     std::unordered_map<int64_t, int> tid2shard_;
 };

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -741,7 +741,7 @@ public:
          * Each sequence should be in the regular offline drmemtrace format.
          * The sequence is inserted into the output stream on each context switch
          * of the indicated type. Each record in the inserted sequence holds the
-         * new input stream's tid and pid.
+         * next input stream's tid and pid.
          * The same file (or reader) must be passed when replaying as this kernel
          * code is not stored when recording.
          * An alternative to passing the file path is to pass #kernel_switch_reader

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -740,7 +740,8 @@ public:
          * or concatenated into a single file.
          * Each sequence should be in the regular offline drmemtrace format.
          * The sequence is inserted into the output stream on each context switch
-         * of the indicated type.
+         * of the indicated type. Each record in the inserted sequence holds the
+         * new input stream's tid and pid.
          * The same file (or reader) must be passed when replaying as this kernel
          * code is not stored when recording.
          * An alternative to passing the file path is to pass #kernel_switch_reader

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -1907,6 +1907,9 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
     uintptr_t marker_value = 0;
     for (int i = static_cast<int>(sequence.size()) - 1; i >= 0; --i) {
         RecordType record = sequence[i];
+        // TODO i#7495: Add invariant checks that ensure these are equal to the
+        // context-switched-to thread when the switch sequence is injected into a
+        // trace.
         record_type_set_tid(record, input->tid);
         record_type_set_pid(record, input->pid);
         if (record_type_is_instr(record)) {

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -1908,6 +1908,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
     for (int i = static_cast<int>(sequence.size()) - 1; i >= 0; --i) {
         RecordType record = sequence[i];
         record_type_set_tid(record, input->tid);
+        record_type_set_pid(record, input->pid);
         if (record_type_is_instr(record)) {
             set_branch_target_marker = false;
             if (!saw_any_instr) {

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -261,7 +261,6 @@ test_basic_stats_with_syscall_trace()
             gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1100),
             gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL, 0),
             gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1600),
-
             gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 0),
             gen_instr(TID_B),
             gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 0),
@@ -565,7 +564,6 @@ test_syscall_latencies_with_syscall_trace()
             gen_instr(TID_B),
             gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1100),
             gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
-
             gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSNUM_X),
             gen_instr(TID_B),
             gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSNUM_X),
@@ -608,7 +606,6 @@ test_syscall_latencies_with_syscall_trace()
         {
             gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3400),
             gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
-
             gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSNUM_X),
             gen_instr(TID_C),
             gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSNUM_X),

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -280,6 +280,13 @@ test_basic_stats_with_syscall_trace()
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 0),
             gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2300),
             // Direct switch.
+            gen_marker(
+                TID_C, TRACE_MARKER_TYPE_CONTEXT_SWITCH_START,
+                scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_THREAD),
+            gen_instr(TID_C),
+            gen_marker(
+                TID_C, TRACE_MARKER_TYPE_CONTEXT_SWITCH_END,
+                scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_THREAD),
             gen_instr(TID_C),
             // No switch: latency too small.
             gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2500),
@@ -324,7 +331,7 @@ test_basic_stats_with_syscall_trace()
         },
     };
     auto result = run_schedule_stats(memrefs);
-    assert(result.instrs == 20);
+    assert(result.instrs == 21);
     // Following are the same as test_basic_stats.
     assert(result.total_switches == 7);
     assert(result.voluntary_switches == 3);

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -644,29 +644,17 @@ test_syscall_latencies_with_syscall_trace()
     // Following are the same as test_syscall_latencies.
     auto it_x_switch = result.sysnum_switch_latency.find(SYSNUM_X);
     assert(it_x_switch != result.sysnum_switch_latency.end());
-    std::string hist_x_switch = it_x_switch->second->to_string();
-    std::cerr << "Sysnum switch latency for " << SYSNUM_X << ":\n"
-              << hist_x_switch << "\n";
-    assert(hist_x_switch ==
+    assert(it_x_switch->second->to_string() ==
            "         500..     505     1\n        1000..    1005     1\n");
     auto it_x_noswitch = result.sysnum_noswitch_latency.find(SYSNUM_X);
     assert(it_x_noswitch != result.sysnum_noswitch_latency.end());
-    std::string hist_x_noswitch = it_x_noswitch->second->to_string();
-    std::cerr << "Sysnum noswitch latency for " << SYSNUM_X << ":\n"
-              << hist_x_noswitch << "\n";
-    assert(hist_x_noswitch == "          95..     100     1\n");
+    assert(it_x_noswitch->second->to_string() == "          95..     100     1\n");
     auto it_y_switch = result.sysnum_switch_latency.find(SYSNUM_Y);
     assert(it_y_switch != result.sysnum_switch_latency.end());
-    std::string hist_y_switch = it_y_switch->second->to_string();
-    std::cerr << "Sysnum switch latency for " << SYSNUM_Y << ":\n"
-              << hist_y_switch << "\n";
-    assert(hist_y_switch == "         200..     205     1\n");
+    assert(it_y_switch->second->to_string() == "         200..     205     1\n");
     auto it_y_noswitch = result.sysnum_noswitch_latency.find(SYSNUM_Y);
     assert(it_y_noswitch != result.sysnum_noswitch_latency.end());
-    std::string hist_y_noswitch = it_y_noswitch->second->to_string();
-    std::cerr << "Sysnum noswitch latency for " << SYSNUM_Y << ":\n"
-              << hist_y_noswitch << "\n";
-    assert(hist_y_noswitch == "         200..     205     1\n");
+    assert(it_y_noswitch->second->to_string() == "         200..     205     1\n");
     return true;
 }
 

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -60,6 +60,8 @@ using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_WAIT;
 using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH;
 using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL;
 using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL;
+using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL_TRACE_END;
+using ::dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL_TRACE_START;
 
 // Create a class for testing that has reliable timing.
 // It assumes it is only used with one thread and parallel operation
@@ -137,9 +139,19 @@ run_schedule_stats(const std::vector<std::vector<memref_t>> &memrefs)
             per_core[cpu].stream.set_tid(memref.instr.tid);
             per_core[cpu].stream.set_workload_id(memref.instr.pid);
             per_core[cpu].stream.set_output_cpuid(cpu);
-            if (memref.marker.type == TRACE_TYPE_MARKER &&
-                memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
-                per_core[cpu].stream.set_last_timestamp(memref.marker.marker_value);
+            if (memref.marker.type == TRACE_TYPE_MARKER) {
+                switch (memref.marker.marker_type) {
+                case TRACE_MARKER_TYPE_SYSCALL_TRACE_START:
+                    per_core[cpu].stream.set_in_kernel_trace(true);
+                    break;
+                case TRACE_MARKER_TYPE_SYSCALL_TRACE_END:
+                    per_core[cpu].stream.set_in_kernel_trace(false);
+                    break;
+                case TRACE_MARKER_TYPE_TIMESTAMP:
+                    per_core[cpu].stream.set_last_timestamp(memref.marker.marker_value);
+                    break;
+                default:;
+                }
             }
             bool res = tool.parallel_shard_memref(per_core[cpu].shard_data, memref);
             assert(res);
@@ -220,6 +232,98 @@ test_basic_stats()
     };
     auto result = run_schedule_stats(memrefs);
     assert(result.instrs == 16);
+    assert(result.total_switches == 7);
+    assert(result.voluntary_switches == 3);
+    assert(result.direct_switches == 1);
+    assert(result.syscalls == 4);
+    assert(result.maybe_blocking_syscalls == 3);
+    assert(result.direct_switch_requests == 2);
+    // 5 migrations: A 0->1; B 1->0; A 1->0; C 0->1; B 0->1.
+    assert(result.observed_migrations == 5);
+    assert(result.waits == 3);
+    assert(result.idle_microseconds == 0);
+    assert(result.cpu_microseconds > 20);
+    assert(result.wait_microseconds >= 3);
+    return true;
+}
+
+static bool
+test_basic_stats_with_syscall_trace()
+{
+    static constexpr int64_t TID_A = 42;
+    static constexpr int64_t TID_B = 142;
+    static constexpr int64_t TID_C = 242;
+    std::vector<std::vector<memref_t>> memrefs = {
+        {
+            gen_instr(TID_A),
+            // Involuntary switch.
+            gen_instr(TID_B),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1100),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1600),
+
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 0),
+            gen_instr(TID_B),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 0),
+            // Voluntary switch, on non-maybe-blocking-marked syscall.
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2100),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_C),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 0),
+            gen_instr(TID_A),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2300),
+            // Direct switch.
+            gen_instr(TID_C),
+            // No switch: latency too small.
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2500),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 0),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2599),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3100),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_A),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 0),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3300),
+            // Direct switch requested but failed.
+            gen_instr(TID_C),
+            gen_exit(TID_C),
+            // An exit is a voluntary switch.
+            gen_exit(TID_A),
+        },
+        {
+            gen_instr(TID_B),
+            // Involuntary switch.
+            gen_instr(TID_A),
+            // Involuntary switch.
+            gen_instr(TID_C),
+            gen_instr(TID_C),
+            gen_instr(TID_C),
+            // Wait.
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_WAIT, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_WAIT, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_WAIT, 0),
+            // Involuntary switch.
+            gen_instr(TID_B),
+            gen_instr(TID_B),
+            gen_instr(TID_B),
+            gen_exit(TID_B),
+        },
+    };
+    auto result = run_schedule_stats(memrefs);
+    assert(result.instrs == 20);
+    // Following are the same as test_basic_stats.
     assert(result.total_switches == 7);
     assert(result.voluntary_switches == 3);
     assert(result.direct_switches == 1);
@@ -444,13 +548,136 @@ test_syscall_latencies()
     return true;
 }
 
+static bool
+test_syscall_latencies_with_syscall_trace()
+{
+    static constexpr int64_t TID_A = 42;
+    static constexpr int64_t TID_B = 142;
+    static constexpr int64_t TID_C = 242;
+    static constexpr int64_t TID_D = 199;
+    static constexpr int64_t TID_E = 222;
+    static constexpr uintptr_t SYSNUM_X = 12;
+    static constexpr uintptr_t SYSNUM_Y = 167;
+    std::vector<std::vector<memref_t>> memrefs = {
+        {
+            gen_instr(TID_A),
+            // Involuntary switch: ignored for syscall latencies.
+            gen_instr(TID_B),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1100),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
+
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSNUM_X),
+            gen_instr(TID_B),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSNUM_X),
+            gen_marker(TID_B, TRACE_MARKER_TYPE_TIMESTAMP, 1600),
+            // Voluntary switch: latency 500.
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_instr(TID_A),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2100),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_Y),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_C),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSNUM_Y),
+            gen_instr(TID_A),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSNUM_Y),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 2300),
+            // Direct switch: latency 200.
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2500),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSNUM_X),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSNUM_X),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 2599),
+            // No switch: latency 99 too small.
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3100),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_Y),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH, TID_A),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSNUM_Y),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSNUM_Y),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3300),
+            // Direct switch requested but failed: latency 200.
+            gen_instr(TID_C),
+            gen_exit(TID_C),
+            gen_exit(TID_A),
+        },
+        {
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 3400),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL, SYSNUM_X),
+
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSNUM_X),
+            gen_instr(TID_C),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSNUM_X),
+            gen_marker(TID_C, TRACE_MARKER_TYPE_TIMESTAMP, 4400),
+            // Voluntary switch: latency 1000.
+            // Test a thread starting at a recorded syscall after another thread on a
+            // core.
+            gen_marker(TID_E, TRACE_MARKER_TYPE_TIMESTAMP, 4500),
+
+            gen_marker(TID_E, TRACE_MARKER_TYPE_FUNC_ID, 202),
+            gen_marker(TID_E, TRACE_MARKER_TYPE_FUNC_RETVAL, static_cast<uintptr_t>(-4)),
+            gen_marker(TID_E, TRACE_MARKER_TYPE_SYSCALL_FAILED, 4),
+            gen_marker(TID_E, TRACE_MARKER_TYPE_TIMESTAMP, 5200),
+            // Preempt to D so no latency should be recorded here, despite
+            // there being a syscall with no regular instr records in between.
+            gen_instr(TID_D),
+            gen_exit(TID_E),
+            gen_exit(TID_B),
+        },
+        {
+            // Test a thread starting at a recorded syscall first thing on a core.
+            gen_marker(TID_D, TRACE_MARKER_TYPE_TIMESTAMP, 1500),
+            gen_marker(TID_D, TRACE_MARKER_TYPE_FUNC_ID, 202),
+            gen_marker(TID_D, TRACE_MARKER_TYPE_FUNC_RETVAL, static_cast<uintptr_t>(-4)),
+            gen_marker(TID_D, TRACE_MARKER_TYPE_SYSCALL_FAILED, 4),
+            gen_marker(TID_D, TRACE_MARKER_TYPE_TIMESTAMP, 3200),
+            // Preempt to E so no latency should be recorded here.
+            gen_instr(TID_E),
+            gen_exit(TID_D),
+        },
+    };
+    auto result = run_schedule_stats(memrefs);
+    // Following are the same as test_syscall_latencies.
+    auto it_x_switch = result.sysnum_switch_latency.find(SYSNUM_X);
+    assert(it_x_switch != result.sysnum_switch_latency.end());
+    std::string hist_x_switch = it_x_switch->second->to_string();
+    std::cerr << "Sysnum switch latency for " << SYSNUM_X << ":\n"
+              << hist_x_switch << "\n";
+    assert(hist_x_switch ==
+           "         500..     505     1\n        1000..    1005     1\n");
+    auto it_x_noswitch = result.sysnum_noswitch_latency.find(SYSNUM_X);
+    assert(it_x_noswitch != result.sysnum_noswitch_latency.end());
+    std::string hist_x_noswitch = it_x_noswitch->second->to_string();
+    std::cerr << "Sysnum noswitch latency for " << SYSNUM_X << ":\n"
+              << hist_x_noswitch << "\n";
+    assert(hist_x_noswitch == "          95..     100     1\n");
+    auto it_y_switch = result.sysnum_switch_latency.find(SYSNUM_Y);
+    assert(it_y_switch != result.sysnum_switch_latency.end());
+    std::string hist_y_switch = it_y_switch->second->to_string();
+    std::cerr << "Sysnum switch latency for " << SYSNUM_Y << ":\n"
+              << hist_y_switch << "\n";
+    assert(hist_y_switch == "         200..     205     1\n");
+    auto it_y_noswitch = result.sysnum_noswitch_latency.find(SYSNUM_Y);
+    assert(it_y_noswitch != result.sysnum_noswitch_latency.end());
+    std::string hist_y_noswitch = it_y_noswitch->second->to_string();
+    std::cerr << "Sysnum noswitch latency for " << SYSNUM_Y << ":\n"
+              << hist_y_noswitch << "\n";
+    assert(hist_y_noswitch == "         200..     205     1\n");
+    return true;
+}
+
 } // namespace
 
 int
 test_main(int argc, const char *argv[])
 {
-    if (test_basic_stats() && test_idle() && test_cpu_footprint() &&
-        test_syscall_latencies()) {
+    if (test_basic_stats() && test_basic_stats_with_syscall_trace() && test_idle() &&
+        test_cpu_footprint() && test_syscall_latencies() &&
+        test_syscall_latencies_with_syscall_trace()) {
         std::cerr << "schedule_stats_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -218,6 +218,8 @@ schedule_stats_t::record_context_switch(per_shard_t *shard, int64_t prev_workloa
                                         int64_t prev_tid, int64_t workload_id,
                                         int64_t tid, int64_t input_id, int64_t letter_ord)
 {
+    // We're not expected to switch in the middle of a kernel trace.
+    assert(!shard->stream->is_record_kernel());
     // We convert to letters which only works well for <=26 inputs.
     if (shard->thread_sequence.empty()) {
         std::lock_guard<std::mutex> lock(prev_core_mutex_);

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -450,8 +450,10 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_FILETYPE) {
             shard->filetype = static_cast<intptr_t>(memref.marker.marker_value);
         } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
-            // Kernel syscall traces are not expected to have timestamps.
-            assert(!shard->stream->is_record_kernel());
+            if (shard->stream->is_record_kernel()) {
+                shard->error = "Kernel traces are not expected to have timestamps.";
+                return false;
+            }
             if (shard->last_syscall_number < 0) {
                 // We use get_input_interface() to get the original timestamp
                 // instead of the scheduler-normalized one.

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -340,6 +340,7 @@ protected:
         uint64_t segment_start_microseconds = 0;
         intptr_t filetype = 0;
         uint64_t switch_start_instrs = 0;
+        bool in_syscall_trace = false;
     };
 
     virtual std::unique_ptr<histogram_interface_t>


### PR DESCRIPTION
Adapts various logic in schedule_stats to the presence of syscall traces.

Unit tests to verify more properties of the injected context switch trace are orthogonal to this PR, and will be added as part of the #7495 work.

Issue: #6495, #7157