### PR TITLE
i#7303 drsyscall: align syscall_record_t to word boundary.

### DIFF
--- a/ext/drmf/common/utils.h
+++ b/ext/drmf/common/utils.h
@@ -186,6 +186,7 @@ extern "C" {
     ((((ptr_uint_t)addr) + (size)-1) & ((alignment)-1))
 #define CROSSES_ALIGNMENT(addr, size, alignment) \
     (ALIGN_MOD(addr, size, alignment) < (size)-1)
+#define PAD(length, alignment) (ALIGN_FORWARD((length), (alignment)) - (length))
 
 #ifndef TESTANY
 #    define TEST(mask, var) (((mask) & (var)) != 0)

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -90,7 +90,7 @@ typedef enum {
  * value.
  */
 START_PACKED_STRUCTURE
-typedef struct ALIGN_VAR(sizeof(reg_t)) syscall_record_t_ {
+typedef struct ALIGN_VAR(8) syscall_record_t_ {
     // type is one of syscall_record_type_t.
     uint16_t type;
     union {

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -80,7 +80,7 @@ typedef enum {
 } syscall_record_type_t;
 
 /**
- * To enable #syscall_record_t to be default initialized reliably, a byte array is defined
+ * To enable syscall_record_t to be default initialized reliably, a byte array is defined
  * with the same length as the largest member of the union.
  */
 #define SYSCALL_RECORD_UNION_SIZE_BYTES (sizeof(uint8_t *) + sizeof(size_t))
@@ -90,7 +90,7 @@ typedef enum {
  * value.
  */
 START_PACKED_STRUCTURE
-typedef struct ALIGN_VAR(8) syscall_record_t_ {
+typedef struct ALIGN_VAR(sizeof(reg_t)) syscall_record_t_ {
     // type is one of syscall_record_type_t.
     uint16_t type;
     union {

--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -90,7 +90,7 @@ typedef enum {
  * value.
  */
 START_PACKED_STRUCTURE
-typedef struct syscall_record_t_ {
+typedef struct ALIGN_VAR(sizeof(reg_t)) syscall_record_t_ {
     // type is one of syscall_record_type_t.
     uint16_t type;
     union {

--- a/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
+++ b/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
@@ -273,8 +273,8 @@ DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
 {
     syscall_record_t record = {};
-    ASSERT((SYSCALL_RECORD_UNION_SIZE_BYTES + sizeof(record.type)) ==
-           sizeof(syscall_record_t));
+    ASSERT(ALIGN_FORWARD(SYSCALL_RECORD_UNION_SIZE_BYTES + sizeof(record.type),
+                         sizeof(reg_t)) == sizeof(syscall_record_t));
 
     char filename[MAXIMUM_PATH];
     snprintf(filename, BUFFER_SIZE_ELEMENTS(filename), "attach_syscall_record_file.%d",

--- a/suite/tests/client-interface/syscall-records-test.dll.c
+++ b/suite/tests/client-interface/syscall-records-test.dll.c
@@ -204,8 +204,8 @@ DR_EXPORT void
 dr_client_main(client_id_t id, int argc, const char *argv[])
 {
     syscall_record_t record = {};
-    ASSERT((SYSCALL_RECORD_UNION_SIZE_BYTES + sizeof(record.type)) ==
-           sizeof(syscall_record_t));
+    ASSERT(ALIGN_FORWARD(SYSCALL_RECORD_UNION_SIZE_BYTES + sizeof(record.type),
+                         sizeof(reg_t)) == sizeof(syscall_record_t));
 
     char filename[MAXIMUM_PATH];
     sprintf(filename, "syscall_record_file.%d", getpid());


### PR DESCRIPTION
Align syscall_record_t to word boundary. There are two changes:
-  change the size of the syscall_record_t to align to the size of reg_t.
-  pad memory region so that the next syscall_record_t align on word boundary.

These changes ensure access to records and memory regions using pointers without alignment issues.

Issue: #7303 