### PR TITLE
i#7496: Allow syscall injection for sigreturn

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -1862,6 +1862,10 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::maybe_inject_pending_syscall_sequ
         record_type_is_timestamp(record, timestamp_unused) ||
         // For syscalls that did not have a post-event because the trace ended.
         record_type_is_thread_exit(record) ||
+        // For sigreturn, we want to inject before the kernel_xfer marker which
+        // is after the function tracing markers (if any) but before the
+        // post-syscall timestamp marker.
+        (is_marker && marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) ||
         // For syscalls interrupted by a signal and did not have a post-syscall
         // event.
         (is_marker && marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT)) {
@@ -1919,10 +1923,9 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
                 // be the syscall for which we're injecting the trace). This is simpler
                 // than trying to get the actual next instruction on this input for which
                 // we would need to read-ahead.
-                // XXX i#6495, i#7157: The above strategy does not work for syscalls that
-                // transfer control (like sigreturn), but we do not trace those anyway
-                // today (neither using Intel-PT, nor QEMU) as there are challenges in
-                // determining the post-syscall resumption point.
+                // TODO i#7496: The above strategy does not work for syscalls that
+                // transfer control (like sigreturn) or for syscalls auto-restarted by a
+                // signal.
                 if (record_type_is_indirect_branch_instr(
                         record, has_indirect_branch_target, input->last_pc_fallthrough) &&
                     !has_indirect_branch_target) {

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3788,13 +3788,10 @@ check_kernel_syscall_trace(void)
             res = false;
     }
 #    ifdef UNIX
-    // Signal return immediately after syscall trace.
-    // This case shouldn't be possible because there must be an instr for sigreturn before
-    // the signal returns, and we don't currently inject sigreturn traces. This is
-    // relevant to test because this is an example where our heuristic to set the
-    // syscall-trace-end TRACE_MARKER_TYPE_BRANCH_TARGET to the fallthrough of the prior
-    // syscall doesn't work. This will need to be handled if we ever want to inject a
-    // syscall trace for sigreturn or other control-transferring syscalls.
+    // Signal return immediately after sigreturn syscall trace.
+    // TODO i#7496: We set the syscall trace-end branch_target marker always to the
+    // fallthrough pc of the syscall. This isn't correct for injected sigreturn traces,
+    // but we live with this for now.
     {
         std::vector<memref_with_IR_t> memref_setup = {
             { gen_marker(TID_A, TRACE_MARKER_TYPE_VERSION,
@@ -3805,8 +3802,9 @@ check_kernel_syscall_trace(void)
             { gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64), nullptr },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096), nullptr },
             { gen_instr(TID_A), sys },
-            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 42), nullptr },
-            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, SYS_rt_sigreturn), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYS_rt_sigreturn),
+              nullptr },
             { gen_instr(TID_A), move },
             { gen_instr(TID_A), load },
             { gen_data(TID_A, /*load=*/true, /*addr=*/0x1234, /*size=*/4), nullptr },
@@ -3814,19 +3812,14 @@ check_kernel_syscall_trace(void)
             // to memref_t.instr.indirect_branch_target instead for the following instr.
             { gen_marker(TID_A, TRACE_MARKER_TYPE_BRANCH_TARGET, 0), post_sys },
             { gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A), sys_return },
-            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 42), nullptr },
+            { gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYS_rt_sigreturn),
+              nullptr },
             { gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 42), nullptr },
+            { gen_instr(TID_A), move },
             { gen_exit(TID_A), nullptr }
         };
-
         auto memrefs = add_encodings_to_memrefs(ilist, memref_setup, BASE_ADDR);
-        if (!run_checker(memrefs, true,
-                         { "Unexpected signal return kernel_xfer marker immedidately "
-                           "after syscall trace",
-                           /*tid=*/TID_A,
-                           /*ref_ordinal=*/13, /*last_timestamp=*/0,
-                           /*instrs_since_last_timestamp=*/4 },
-                         "Failed to catch signal return immedately after syscall trace"))
+        if (!run_checker(memrefs, false))
             res = false;
     }
 #    endif

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -6856,14 +6856,19 @@ test_kernel_syscall_sequences()
                                 SYSCALL_BASE));
                         inputs.push_back(test_util::make_marker(
                             TRACE_MARKER_TYPE_FUNC_ARG, /*value=*/10));
-                        // First syscall on first input was interrupted by a signal,
-                        // so no post-syscall event.
                         if (input_idx == 0) {
+                            // First syscall on first input was interrupted by a signal,
+                            // so no post-syscall event.
                             inputs.push_back(test_util::make_marker(
                                 TRACE_MARKER_TYPE_KERNEL_EVENT, /*value=*/1));
                             inputs.push_back(test_util::make_marker(
                                 TRACE_MARKER_TYPE_KERNEL_XFER, /*value=*/1));
                             add_post_timestamp = false;
+                        } else if (input_idx == 1) {
+                            // First syscall on second input is a sigreturn that also
+                            // adds a kernel_xfer marker.
+                            inputs.push_back(test_util::make_marker(
+                                TRACE_MARKER_TYPE_KERNEL_XFER, /*value=*/1));
                         } else {
                             inputs.push_back(test_util::make_marker(
                                 TRACE_MARKER_TYPE_FUNC_ID,
@@ -6915,8 +6920,8 @@ test_kernel_syscall_sequences()
                "Avf0i0SsFF1ii1kk,Cvf0i0SsFF1ii1FFs0,Aii0S2iii20,Cii0S2iii20,"
                "Aii0Ss1ii10,Cii0Ss1ii10,Aii0S2iii20,Cii0S2iii20,Aii0Ss1ii10,Cii0Ss1ii10");
         assert(sched_as_string[1] ==
-               "Bvf0i0SsFF1ii1FFs0ii0S2iii20ii0Ss1ii10ii0S2iii20ii0Ss1ii10______________"
-               "__________________________________________");
+               "Bvf0i0SsFF1ii1k0ii0S2iii20ii0Ss1ii10ii0S2iii20ii0Ss1ii10______________"
+               "____________________________________________");
         // Zoom in and check the first few syscall sequences on the first output record
         // by record with value checks.
         int idx = 0;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -303,7 +303,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         case TRACE_MARKER_TYPE_FUNC_ARG:
         case TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL:
             report_if_false(shard,
-                            !shard->found_syscall_trace_after_last_userspace_instr_,
+                            shard->found_syscall_trace_after_last_userspace_instr_ == -1,
                             "Found unexpected func_arg or syscall marker after injected "
                             "syscall trace");
             break;
@@ -639,7 +639,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED |
                                     OFFLINE_FILE_TYPE_KERNEL_SYSCALL_TRACE_TEMPLATES,
                                 shard->file_type_) ||
-                            !shard->found_syscall_trace_after_last_userspace_instr_,
+                            shard->found_syscall_trace_after_last_userspace_instr_ == -1,
                         "Found multiple syscall traces after a user-space instr");
         // Need to reset to disable the PC continuity check for syscall trace template
         // files where we do have consecutive syscall traces without any intervening
@@ -685,7 +685,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                                 static_cast<int>(memref.marker.marker_value),
                             "Mismatching syscall num in trace end and syscall marker");
             // Syscall trace templates do not have any user-space instr.
-            shard->found_syscall_trace_after_last_userspace_instr_ = true;
+            shard->found_syscall_trace_after_last_userspace_instr_ =
+                memref.marker.marker_value;
         }
         // TODO i#5505: Ideally the last instruction in the system call PT trace
         // also would be an indirect CTI with a TRACE_MARKER_TYPE_BRANCH_TARGET
@@ -893,7 +894,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // marker because we may need it again if there's a consecutive syscall/switch.
         if (!shard->between_kernel_syscall_trace_markers_) {
             shard->pre_syscall_trace_instr_ = {};
-            shard->found_syscall_trace_after_last_userspace_instr_ = false;
+            shard->found_syscall_trace_after_last_userspace_instr_ = -1;
         }
         if (!shard->between_kernel_context_switch_markers_) {
             shard->pre_context_switch_trace_instr_ = {};
@@ -1164,17 +1165,19 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                 shard->retaddr_stack_.push(0);
             }
         }
+        if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER &&
+            shard->found_syscall_trace_after_last_userspace_instr_ == SYS_rt_sigreturn) {
+            // It is an undocumented property that the TRACE_MARKER_TYPE_KERNEL_XFER
+            // marker values are also set to the syscall-fallthrough pc. So it is
+            // expected that prev_syscall_end_branch_target_ == the kernel_xfer value.
+            // TODO i#7496: We skip the PC continuity check for the branch_target marker
+            // at the end of syscall traces injected for sigreturn.
+            shard->prev_syscall_end_branch_target_ = 0;
+        }
 #ifdef UNIX
         report_if_false(shard, memref.marker.marker_value != 0,
                         "Kernel event marker value missing");
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
-            // There should generally be an instr for sigreturn just before the
-            // TRACE_MARKER_TYPE_KERNEL_XFER marker, and we do not inject any traces for
-            // control-transferring system calls like sigreturn.
-            report_if_false(shard,
-                            !shard->found_syscall_trace_after_last_userspace_instr_,
-                            "Unexpected signal return kernel_xfer marker immedidately "
-                            "after syscall trace");
             // We expect a proper pairing of TRACE_MARKER_TYPE_KERNEL_EVENT and
             // TRACE_MARKER_TYPE_KERNEL_XFER markers inside the kernel system call
             // and context switch traces that are used for trace injection.

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -208,7 +208,7 @@ protected:
         bool found_syscall_marker_ = false;
         bool prev_was_syscall_marker_ = false;
         int last_syscall_marker_value_ = 0;
-        bool found_syscall_trace_after_last_userspace_instr_ = false;
+        int found_syscall_trace_after_last_userspace_instr_ = -1;
         bool found_blocking_marker_ = false;
         uint64_t syscall_count_ = 0;
         uint64_t last_instr_count_marker_ = 0;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -273,10 +273,9 @@ raw2trace_t::write_syscall_template(raw2trace_thread_data_t *tdata, byte *&buf_i
             // the syscall instruction for which we're injecting the trace. This is
             // simpler than trying to get the actual post-syscall instruction for which
             // we would perhaps even need to read-ahead to the next raw trace buffer.
-            // XXX i#6495, i#7157: The above strategy does not work for syscalls that
-            // transfer control (like sigreturn), but we do not trace those anyway today
-            // (neither using Intel-PT, nor QEMU) as there are challenges in determining
-            // the post-syscall resumption point.
+            // TODO i#7496: The above strategy does not work for syscalls that
+            // transfer control (like sigreturn) or for syscalls auto-restarted by a
+            // signal.
             if (type_is_instr_branch(static_cast<trace_type_t>(entry.type)) &&
                 !type_is_instr_direct_branch(static_cast<trace_type_t>(entry.type)) &&
                 inserted_instr_count ==
@@ -941,6 +940,10 @@ raw2trace_t::maybe_inject_pending_syscall_sequence(raw2trace_thread_data_t *tdat
         // For syscalls that did not have a post-event because the trace ended.
         (entry.extended.type == OFFLINE_TYPE_EXTENDED &&
          entry.extended.ext == OFFLINE_EXT_TYPE_FOOTER) ||
+        // For sigreturn, we want to inject before the kernel_xfer marker which
+        // is after the function tracing markers (if any) but before the
+        // post-syscall timestamp marker.
+        (is_marker && entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_XFER) ||
         // For syscalls interrupted by a signal and did not have a post-syscall
         // event.
         (is_marker && entry.extended.valueB == TRACE_MARKER_TYPE_KERNEL_EVENT)) {


### PR DESCRIPTION
Adjusts injection point for the sigreturn syscall. For SYS_rt_sigreturn we want to inject just before the TRACE_MARKER_TYPE_KERNEL_XFER marker that is present just before the syscall function tracing markers (if any) and post-syscall timestamp marker.

Fixes this for both static injection in raw2trace and dynamic injection in the drmemtrace scheduler.

Also adjusts the drmemtrace invariant checker to skip the TRACE_MARKER_TYPE_BRANCH_TARGET marker check for sigreturns. This keeps status-quo for signal return points where there is no marker that holds the continuation point (note that the TRACE_MARKER_TYPE_KERNEL_XFER marker also holds the post-sigreturn pc, not the resumption point); the resumption point is already seen in the prior TRACE_MARKER_TYPE_KERNEL_EVENT marker. Adds TODO to improve this in future, but for now we skip on adding complexity that may not be needed since the required information is already in the trace.

Also adds more unit tests for raw2trace, scheduler, and the invariant checker.

Issue: #7496, #6495, #7157