### PR TITLE
i#7496: Revert unintentionally removed drmemtrace logic for MacOS

### DIFF
--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1185,6 +1185,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             // expected to match.
             shard->prev_syscall_end_branch_target_ = 0;
         }
+#endif
+#ifdef UNIX
         report_if_false(shard, memref.marker.marker_value != 0,
                         "Kernel event marker value missing");
         if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {


### PR DESCRIPTION
Adds back drmemtrace invariant checks that were unintentionally removed for MacOS by new conditional compilation directives in #7497. Only the new invariant_checker logic added by #7497 had to be guarded by LINUX whereas the existing adjacent UNIX block should've remained guarded by UNIX.

`tool.drcachesim.invariant_checker_test` is not enabled on MacOS because of #1997 so this regression was not detected in automated pre-submit testing.

https://github.com/DynamoRIO/dynamorio/blob/4ec1eda73ff3c01a36629ac0dec9163458e4efda/clients/drcachesim/CMakeLists.txt#L1025

Issue: #7496