### PR TITLE
i#7499: Update ci-windows to use Windows 2022

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -58,7 +58,7 @@ jobs:
   ###########################################################################
   # 32-bit VS2019 and tests:
   vs2019-32:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
   ###########################################################################
   # 64-bit VS2019 and tests:
   vs2019-64:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4
@@ -154,7 +154,7 @@ jobs:
   ###########################################################################
   # 32-bit and 64-bit VS2019 release builds:
   vs2019-builds:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -93,7 +93,7 @@ jobs:
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
         set PATH=c:\projects\install\ninja;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
@@ -141,7 +141,7 @@ jobs:
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
         set PATH=c:\projects\install\ninja;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"
@@ -189,7 +189,7 @@ jobs:
         echo ------ Setting up paths ------
         7z x c:\projects\install\ninja.zip -oc:\projects\install\ninja > nul
         set PATH=c:\projects\install\ninja;%PATH%
-        call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
+        call "C:/Program Files (x86)/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat"
         echo ------ Running suite ------
         echo PATH is "%PATH%"
         echo Running in directory "%CD%"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -56,8 +56,8 @@ defaults:
 
 jobs:
   ###########################################################################
-  # 32-bit VS2019 and tests:
-  vs2019-32:
+  # 32-bit VS2022 and tests:
+  vs2022-32:
     runs-on: windows-2022
 
     steps:
@@ -104,8 +104,8 @@ jobs:
         DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
 
   ###########################################################################
-  # 64-bit VS2019 and tests:
-  vs2019-64:
+  # 64-bit VS2022 and tests:
+  vs2022-64:
     runs-on: windows-2022
 
     steps:
@@ -152,8 +152,8 @@ jobs:
         DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
 
   ###########################################################################
-  # 32-bit and 64-bit VS2019 release builds:
-  vs2019-builds:
+  # 32-bit and 64-bit VS2022 release builds:
+  vs2022-builds:
     runs-on: windows-2022
 
     steps:
@@ -201,15 +201,15 @@ jobs:
 
   send-failure-notification:
       uses: ./.github/workflows/failure-notification.yml
-      needs: [vs2019-builds, vs2019-64, vs2019-32]
+      needs: [vs2022-builds, vs2022-64, vs2022-32]
       # By default, a failure in a job skips the jobs that need it. The
       # following expression ensures that failure-notification.yml is
       # always invoked.
       if: ${{ always() }}
       with:
         test_suite_status: ${{ format('{0} {1} | {2} {3} | {4} {5}',
-                                      'vs2019-builds', needs.vs2019-builds.result,
-                                      'vs2019-64', needs.vs2019-64.result,
-                                      'vs2019-32', needs.vs2019-32.result) }}
+                                      'vs2022-builds', needs.vs2022-builds.result,
+                                      'vs2022-64', needs.vs2022-64.result,
+                                      'vs2022-32', needs.vs2022-32.result) }}
         test_suite_results_only: ${{ join(needs.*.result, ',') }}
       secrets: inherit


### PR DESCRIPTION
Windows-2019 will not be supported anymore on Github Actions after June 2025.

Issue: #7499