### PR TITLE
Suggest checking RLMIT_NOFILE on open failure in scheduler

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -1960,7 +1960,10 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::open_reader(
         return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
     std::unique_ptr<ReaderType> reader = get_reader(path, verbosity_);
     if (!reader || !reader->init()) {
-        error_string_ += "Failed to open " + path;
+        // Include a suggestion to check the open file limit.
+        // We could call getrlimit to see if it's a likely culprit; we could
+        // try to call setrlimit ourselves but that doesn't feel right.
+        error_string_ += "Failed to open " + path + " (was RLIMIT_NOFILE exceeded?)";
         return sched_type_t::STATUS_ERROR_FILE_OPEN_FAILED;
     }
     int index = static_cast<input_ordinal_t>(inputs_.size());


### PR DESCRIPTION
Since some Linux distribution shells set RLIMIT_NOFILE to 1024 by default and that's easily exceeded on some of our public trace sets, multiple users have hit an error opening a file that is puzzling to figure out. We add a suggestion to check this limit to the open file failure message.

Tested:
I synthetically added 50 threadsig files to a test dir:
```
$ ulimit -n 50
$ bin64/drrun -t drmemtrace -tool schedule_stats -cores 4 -indir drmemtrace.threadsig.3651695.9217.dir/
...
Failed to initialize scheduler: Failed to open drmemtrace.threadsig.3651695.9217.dir/trace/extra-46.trace.zip (was RLIMIT_NOFILE exceeded?)
```