### PR TITLE
i#6662 public traces: add common issues section to doc

### DIFF
--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1209,7 +1209,7 @@ Workload Traces.
   threshold is problematic when a DynamoRIO analyzer or scheduler operates on a whole
   Google trace, which can have over 2000 trace files (one per software thread). This can
   result in "Failed to initialize scheduler: Failed to open PATH/TO/MEMTRACE.ZIP". If
-  this happens, please increase the "nofile" threshold .
+  this happens, please increase the "nofile" threshold.
 
 \section sec_public_v1_deprecated Deprecated Google Workload Traces (Version 1)
 

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1209,7 +1209,7 @@ Workload Traces.
   threshold is problematic when a DynamoRIO analyzer or scheduler operates on a whole
   Google trace, which can have over 2000 trace files (one per software thread). This can
   result in "Failed to initialize scheduler: Failed to open PATH/TO/MEMTRACE.ZIP". If
-  this happens, please increase the "nofile" threshold.
+  this happens, please increase the "nofile" threshold .
 
 \section sec_public_v1_deprecated Deprecated Google Workload Traces (Version 1)
 

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1197,6 +1197,19 @@ If you would like to cite this work, you can use the following BibTeX entry:
 }
 \endverbatim
 
+\section sec_google_common_issues Common Issues
+
+Here we collect common issues that some users might experience when using the Google
+Workload Traces.
+
+- Depending on the Linux distribution used, there might be a threshold on the number of
+  files a single process can open that is set too low (e.g., 1024). This threshold can be
+  increased by setting the nofile item in /etc/security/limits.conf. A low nofile
+  threshold is problematic when a DynamoRIO analyzer or scheduler operates on a whole
+  Google trace, which can have over 2000 trace files (one per software thread). This can
+  result in "Failed to initialize scheduler: Failed to open PATH/TO/MEMTRACE.ZIP
+  (was RLIMIT_NOFILE exceeded?)". If this happens, please increase the nofile threshold.
+
 \section sec_public_v1_deprecated Deprecated Google Workload Traces (Version 1)
 
 The previous version of Google workload traces contains a subset of the

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1202,13 +1202,14 @@ If you would like to cite this work, you can use the following BibTeX entry:
 Here we collect common issues that some users might experience when using the Google
 Workload Traces.
 
-- Depending on the Linux distribution used, there might be a threshold on the number of
-  files a single process can open that is set too low (e.g., 1024). This threshold can be
-  increased by setting the nofile item in /etc/security/limits.conf. A low nofile
+- Depending on the Linux distribution used, there might be a "nofile" threshold on the
+  number of files a single process can open that is set too low (e.g., 1024). This
+  threshold can be increased using "ulimit -n 8192". A threshold of 8192 is enough for
+  Google Workload Traces. Consider adding this command to your ".bashrc". A low "nofile"
   threshold is problematic when a DynamoRIO analyzer or scheduler operates on a whole
   Google trace, which can have over 2000 trace files (one per software thread). This can
-  result in "Failed to initialize scheduler: Failed to open PATH/TO/MEMTRACE.ZIP
-  (was RLIMIT_NOFILE exceeded?)". If this happens, please increase the nofile threshold.
+  result in "Failed to initialize scheduler: Failed to open PATH/TO/MEMTRACE.ZIP". If
+  this happens, please increase the "nofile" threshold.
 
 \section sec_public_v1_deprecated Deprecated Google Workload Traces (Version 1)
 

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1202,7 +1202,7 @@ If you would like to cite this work, you can use the following BibTeX entry:
 Here we collect common issues that some users might experience when using the Google
 Workload Traces.
 
-- Depending on the Linux distribution used, there might be a "nofile" threshold on the
+- Depending on the Linux distribution used, there might be a "nofile" threshold for the
   number of files a single process can open that is set too low (e.g., 1024). This
   threshold can be increased using "ulimit -n 8192". A threshold of 8192 is enough for
   Google Workload Traces. Consider adding this command to your ".bashrc". A low "nofile"


### PR DESCRIPTION
Adds a new section: "Common Issues" that describes potential issues that
users might experience when using the Google Workload Traces.

As of now we have one issue that was hit for both public v1 and v2 traces:
"nofile" threshold can be set too low by the OS, which limits the number of
files a process (e.g., a DynamoRIO analyzer) can open. Google traces have
many files (over 2000 in some cases), so we recommend using `ulimit -n 8192`
to increase this threshold.

Issue #6662