### PR TITLE
i#7508: Add an option -memdump_on_window to the drmemtrace trace analysis tools framework.

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -180,6 +180,10 @@ Further non-compatibility-affecting changes include:
       generation alongside the scheduled traces.
  - Added AUX_SUBDIR (== "aux") to the subdirs in which get_aux_file_path() looks for
    auxiliary files (e.g., v2p.textproto).
+ - Added -memdump_on_window option to the drmemtrace trace analysis tools framework.
+   This option triggers a memory dump when a trace window opens by -trace_after_instrs,
+   -trace_instr_intervals_file, or -retrace_every_instrs. If -retrace_every_instrs is
+   also enabled, a memory dump will be captured for each individual tracing window.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -361,6 +361,14 @@ droption_t<bool> op_align_endpoints(
     "all threads and is nop-ed as soon as detach starts, eliminating the unevenness. "
     "This also allows omitting threads that did nothing during the burst.");
 
+droption_t<bool> op_memdump_on_window(
+    DROPTION_SCOPE_CLIENT, "memdump_on_window", false,
+    "Capture a memory dump when a tracing window opens",
+    "Capture a memory dump upon the initiation of tracing triggered by "
+    "-trace_after_instrs, -trace_instr_intervals_file, or -retrace_every_instrs. "
+    "If -retrace_every_instrs is also enabled, a memory dump will be captured for "
+    "each individual tracing window.");
+
 droption_t<bytesize_t> op_trace_after_instrs(
     DROPTION_SCOPE_CLIENT, "trace_after_instrs", 0,
     "Do not start tracing until N instructions",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -362,12 +362,15 @@ droption_t<bool> op_align_endpoints(
     "This also allows omitting threads that did nothing during the burst.");
 
 droption_t<bool> op_memdump_on_window(
+    // TODO i#7508: Add Windows support. raw2trace fails with "Non-module instructions
+    // found with no encoding information.". This occurs on Windows when capturing memory
+    // dumps at the start of a new tracing window.
     DROPTION_SCOPE_CLIENT, "memdump_on_window", false,
     "Capture a memory dump when a tracing window opens",
     "Capture a memory dump upon the initiation of tracing triggered by "
     "-trace_after_instrs, -trace_instr_intervals_file, or -retrace_every_instrs. "
     "If -retrace_every_instrs is also enabled, a memory dump will be captured for "
-    "each individual tracing window.");
+    "each individual tracing window. This is only supported on X64 Linux.");
 
 droption_t<bytesize_t> op_trace_after_instrs(
     DROPTION_SCOPE_CLIENT, "trace_after_instrs", 0,

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -129,6 +129,7 @@ extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t> op_max_t
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>
     op_max_global_trace_refs;
 extern dynamorio::droption::droption_t<bool> op_align_endpoints;
+extern dynamorio::droption::droption_t<bool> op_memdump_on_window;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>
     op_trace_after_instrs;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>

--- a/clients/drcachesim/tests/offline-windows-memdump.templatex
+++ b/clients/drcachesim/tests/offline-windows-memdump.templatex
@@ -1,0 +1,13 @@
+Hit delay threshold: enabling tracing.
+Hit tracing window #0 limit: disabling tracing.
+Hit retrace threshold: enabling tracing for window #1.
+.*
+Basic counts tool results:
+.*
+Total windows: [0-9]*
+Window #0:
+.*
+Window #1:
+.*
+Window #2:
+.*

--- a/clients/drcachesim/tests/offline-windows-memdump.templatex
+++ b/clients/drcachesim/tests/offline-windows-memdump.templatex
@@ -1,13 +1,18 @@
 Hit delay threshold: enabling tracing.
 Hit tracing window #0 limit: disabling tracing.
 Hit retrace threshold: enabling tracing for window #1.
+[^W]*
+Basic counts tool results:
+.*
+           1 total threads
 .*
 Basic counts tool results:
 .*
-Total windows: [0-9]*
-Window #0:
+Basic counts tool results:
 .*
-Window #1:
-.*
-Window #2:
-.*
+ELF Header:
+  Magic:   7f 45 4c 46 02 01 01 03 00 00 00 00 00 00 00 00.*
+ELF Header:
+  Magic:   7f 45 4c 46 02 01 01 03 00 00 00 00 00 00 00 00.*
+ELF Header:
+  Magic:   7f 45 4c 46 02 01 01 03 00 00 00 00 00 00 00 00.*

--- a/clients/drcachesim/tracer/instr_counter.h
+++ b/clients/drcachesim/tracer/instr_counter.h
@@ -72,7 +72,7 @@ void
 event_inscount_thread_init(void *drcontext);
 
 void
-event_inscount_init();
+event_inscount_init(client_id_t id);
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -521,9 +521,6 @@ static void
 event_nudge(void *drcontext, uint64 arg)
 {
     if (arg == TRACER_NUDGE_MEM_DUMP) {
-        char path[MAXIMUM_PATH];
-        dr_memory_dump_spec_t spec;
-        spec.size = sizeof(dr_memory_dump_spec_t);
 #ifdef WINDOWS
         /* TODO i#7508: raw2trace fails with "Non-module instructions found with no
          * encoding information.". This occurs on Windows when capturing memory dumps at
@@ -532,11 +529,14 @@ event_nudge(void *drcontext, uint64 arg)
         NOTIFY(
             0,
             "ERROR: capturing memory dump when a trace window opens is not supported.\n");
+        return;
 #else
+        char path[MAXIMUM_PATH];
+        dr_memory_dump_spec_t spec;
+        spec.size = sizeof(dr_memory_dump_spec_t);
         spec.flags = DR_MEMORY_DUMP_ELF;
         spec.elf_path = (char *)&path;
         spec.elf_path_size = MAXIMUM_PATH;
-#endif
         if (!dr_create_memory_dump(&spec)) {
             NOTIFY(0, "ERROR: failed to create memory dump.\n");
             return;
@@ -558,6 +558,7 @@ event_nudge(void *drcontext, uint64 arg)
         }
         dr_close_file(memory_dump_file);
         return;
+#endif
     }
 }
 

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -537,6 +537,19 @@ event_nudge(void *drcontext, uint64 arg)
         spec.flags = DR_MEMORY_DUMP_ELF;
         spec.elf_path = (char *)&path;
         spec.elf_path_size = MAXIMUM_PATH;
+        spec.elf_output_directory = nullptr;
+
+        char windir[MAXIMUM_PATH];
+        if (has_tracing_windows()) {
+            if (op_split_windows.get_value()) {
+                dr_snprintf(windir, BUFFER_SIZE_ELEMENTS(windir),
+                            "%s%s" WINDOW_SUBDIR_FORMAT, logsubdir, DIRSEP,
+                            tracing_window.load(std::memory_order_acquire));
+                NULL_TERMINATE_BUFFER(windir);
+                spec.elf_output_directory = windir;
+            }
+        }
+
         if (!dr_create_memory_dump(&spec)) {
             NOTIFY(0, "ERROR: failed to create memory dump.\n");
             return;

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -540,7 +540,6 @@ event_nudge(void *drcontext, uint64 arg)
     }
 }
 
-
 /***************************************************************************
  * Tracing instrumentation.
  */

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -181,6 +181,11 @@ enum {
     BBDUP_MODE_L0_FILTER = 4, /* Address tracing with L0_filter. */
 };
 
+/* Tracer nudge types. */
+enum {
+    TRACER_NUDGE_MEM_DUMP = 0,  /* Capture a memory dump. */
+};
+
 #if defined(X86_64) || defined(AARCH64)
 #    define DELAYED_CHECK_INLINED 1
 #else

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -183,7 +183,7 @@ enum {
 
 /* Tracer nudge types. */
 enum {
-    TRACER_NUDGE_MEM_DUMP = 0,  /* Capture a memory dump. */
+    TRACER_NUDGE_MEM_DUMP = 0, /* Capture a memory dump. */
 };
 
 #if defined(X86_64) || defined(AARCH64)

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -381,6 +381,12 @@ typedef struct _dr_memory_dump_spec_t {
      * in bytes, of elf_path.
      */
     size_t elf_path_size;
+    /**
+     * This field only applies to #DR_MEMORY_DUMP_ELF. This is an optional input
+     * field that, if non-NULL, specifies the output directory of the created
+     * file.
+     */
+     char *elf_output_directory;
 } dr_memory_dump_spec_t;
 
 DR_API

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -386,7 +386,7 @@ typedef struct _dr_memory_dump_spec_t {
      * field that, if non-NULL, specifies the output directory of the created
      * file.
      */
-     char *elf_output_directory;
+    char *elf_output_directory;
 } dr_memory_dump_spec_t;
 
 DR_API

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1804,9 +1804,9 @@ instrument_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace, bool tran
     if (trace_callbacks.num == 0)
         return DR_EMIT_DEFAULT;
 
-    /* do not expand or up-decode the instrlist, client gets to choose
-     * whether and how to do that
-     */
+        /* do not expand or up-decode the instrlist, client gets to choose
+         * whether and how to do that
+         */
 
 #ifdef DEBUG
     LOG(THREAD, LOG_INTERP, 3, "\ninstrument_trace ******************\n");
@@ -1815,9 +1815,9 @@ instrument_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace, bool tran
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #endif
 
-    /* We always pass Level 3 instrs to the client, since we no longer
-     * expose the expansion routines.
-     */
+        /* We always pass Level 3 instrs to the client, since we no longer
+         * expose the expansion routines.
+         */
 #ifdef UNSUPPORTED_API
     for (instr = instrlist_first_expanded(dcontext, trace); instr != NULL;
          instr = instr_get_next_expanded(dcontext, trace, instr)) {
@@ -2202,7 +2202,7 @@ instrument_signal(dcontext_t *dcontext, dr_siginfo_t *siginfo)
      * registrant should own the signal (xref i#424).
      */
     call_all_ret(ret, = ret == DR_SIGNAL_DELIVER ?, : ret, signal_callbacks,
-                 dr_signal_action_t (*)(void *, dr_siginfo_t *), (void *)dcontext,
+                 dr_signal_action_t(*)(void *, dr_siginfo_t *), (void *)dcontext,
                  siginfo);
     return ret;
 }
@@ -5335,7 +5335,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
         for (i = 0; i < cci.num_opmask_skip; i++)
             cci.opmask_skip[i] = true;
 #endif
-        /* now remove those used for param/retval */
+            /* now remove those used for param/retval */
 #ifdef X64
         if (TEST(DR_CLEANCALL_NOSAVE_XMM_NONPARAM, save_flags)) {
             /* xmm0-3 (-7 for linux) are used for params */
@@ -7835,7 +7835,7 @@ instrument_persist_ro_size(dcontext_t *dcontext, void *perscxt, size_t file_offs
      */
     if (persist_ro_size_callbacks.num > 0) {
         call_all_ret(sz, +=, , persist_ro_size_callbacks,
-                     size_t (*)(void *, void *, size_t, void **), (void *)dcontext,
+                     size_t(*)(void *, void *, size_t, void **), (void *)dcontext,
                      perscxt, file_offs + sz, &persist_user_data[idx]);
     }
     /* using size_t for API w/ clients in case we want to widen in future */
@@ -7913,7 +7913,7 @@ instrument_persist_rx_size(dcontext_t *dcontext, void *perscxt, size_t file_offs
     if (persist_rx_size_callbacks.num == 0)
         return 0;
     call_all_ret(sz, +=, , persist_rx_size_callbacks,
-                 size_t (*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
+                 size_t(*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
                  file_offs + sz, &persist_user_data[idx]);
     /* using size_t for API w/ clients in case we want to widen in future */
     CLIENT_ASSERT(CHECK_TRUNCATE_TYPE_uint(sz), "persisted cache size too large");
@@ -7957,7 +7957,7 @@ instrument_persist_rw_size(dcontext_t *dcontext, void *perscxt, size_t file_offs
     if (persist_rw_size_callbacks.num == 0)
         return 0;
     call_all_ret(sz, +=, , persist_rw_size_callbacks,
-                 size_t (*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
+                 size_t(*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
                  file_offs + sz, &persist_user_data[idx]);
     /* using size_t for API w/ clients in case we want to widen in future */
     CLIENT_ASSERT(CHECK_TRUNCATE_TYPE_uint(sz), "persisted cache size too large");

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -1804,9 +1804,9 @@ instrument_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace, bool tran
     if (trace_callbacks.num == 0)
         return DR_EMIT_DEFAULT;
 
-        /* do not expand or up-decode the instrlist, client gets to choose
-         * whether and how to do that
-         */
+    /* do not expand or up-decode the instrlist, client gets to choose
+     * whether and how to do that
+     */
 
 #ifdef DEBUG
     LOG(THREAD, LOG_INTERP, 3, "\ninstrument_trace ******************\n");
@@ -1815,9 +1815,9 @@ instrument_trace(dcontext_t *dcontext, app_pc tag, instrlist_t *trace, bool tran
         instrlist_disassemble(dcontext, tag, trace, THREAD);
 #endif
 
-        /* We always pass Level 3 instrs to the client, since we no longer
-         * expose the expansion routines.
-         */
+    /* We always pass Level 3 instrs to the client, since we no longer
+     * expose the expansion routines.
+     */
 #ifdef UNSUPPORTED_API
     for (instr = instrlist_first_expanded(dcontext, trace); instr != NULL;
          instr = instr_get_next_expanded(dcontext, trace, instr)) {
@@ -2202,7 +2202,7 @@ instrument_signal(dcontext_t *dcontext, dr_siginfo_t *siginfo)
      * registrant should own the signal (xref i#424).
      */
     call_all_ret(ret, = ret == DR_SIGNAL_DELIVER ?, : ret, signal_callbacks,
-                 dr_signal_action_t(*)(void *, dr_siginfo_t *), (void *)dcontext,
+                 dr_signal_action_t (*)(void *, dr_siginfo_t *), (void *)dcontext,
                  siginfo);
     return ret;
 }
@@ -2533,7 +2533,8 @@ dr_create_memory_dump(dr_memory_dump_spec_t *spec)
 #elif defined(LINUX) && \
     ((defined(X64) && defined(X86)) || (defined(AARCH64) && !defined(ANDROID64)))
     if (TEST(DR_MEMORY_DUMP_ELF, spec->flags)) {
-        return os_dump_core_live(get_thread_private_dcontext(), spec->elf_path,
+        return os_dump_core_live(get_thread_private_dcontext(),
+                                 spec->elf_output_directory, spec->elf_path,
                                  spec->elf_path_size);
     }
 #endif
@@ -5334,7 +5335,7 @@ dr_insert_clean_call_ex_varg(void *drcontext, instrlist_t *ilist, instr_t *where
         for (i = 0; i < cci.num_opmask_skip; i++)
             cci.opmask_skip[i] = true;
 #endif
-            /* now remove those used for param/retval */
+        /* now remove those used for param/retval */
 #ifdef X64
         if (TEST(DR_CLEANCALL_NOSAVE_XMM_NONPARAM, save_flags)) {
             /* xmm0-3 (-7 for linux) are used for params */
@@ -7834,7 +7835,7 @@ instrument_persist_ro_size(dcontext_t *dcontext, void *perscxt, size_t file_offs
      */
     if (persist_ro_size_callbacks.num > 0) {
         call_all_ret(sz, +=, , persist_ro_size_callbacks,
-                     size_t(*)(void *, void *, size_t, void **), (void *)dcontext,
+                     size_t (*)(void *, void *, size_t, void **), (void *)dcontext,
                      perscxt, file_offs + sz, &persist_user_data[idx]);
     }
     /* using size_t for API w/ clients in case we want to widen in future */
@@ -7912,7 +7913,7 @@ instrument_persist_rx_size(dcontext_t *dcontext, void *perscxt, size_t file_offs
     if (persist_rx_size_callbacks.num == 0)
         return 0;
     call_all_ret(sz, +=, , persist_rx_size_callbacks,
-                 size_t(*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
+                 size_t (*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
                  file_offs + sz, &persist_user_data[idx]);
     /* using size_t for API w/ clients in case we want to widen in future */
     CLIENT_ASSERT(CHECK_TRUNCATE_TYPE_uint(sz), "persisted cache size too large");
@@ -7956,7 +7957,7 @@ instrument_persist_rw_size(dcontext_t *dcontext, void *perscxt, size_t file_offs
     if (persist_rw_size_callbacks.num == 0)
         return 0;
     call_all_ret(sz, +=, , persist_rw_size_callbacks,
-                 size_t(*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
+                 size_t (*)(void *, void *, size_t, void **), (void *)dcontext, perscxt,
                  file_offs + sz, &persist_user_data[idx]);
     /* using size_t for API w/ clients in case we want to widen in future */
     CLIENT_ASSERT(CHECK_TRUNCATE_TYPE_uint(sz), "persisted cache size too large");

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -422,7 +422,7 @@ write_arm_tls_note(DR_PARAM_IN file_t elf_file)
  * false otherwise.
  */
 static bool
-os_dump_core_internal(dcontext_t *dcontext, char *output_directory DR_PARAM_IN,
+os_dump_core_internal(dcontext_t *dcontext, const char *output_directory DR_PARAM_IN,
                       char *path DR_PARAM_OUT, size_t path_sz)
 {
     priv_mcontext_t mc;

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -422,7 +422,8 @@ write_arm_tls_note(DR_PARAM_IN file_t elf_file)
  * false otherwise.
  */
 static bool
-os_dump_core_internal(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path_sz)
+os_dump_core_internal(dcontext_t *dcontext, char *output_directory DR_PARAM_IN,
+                      char *path DR_PARAM_OUT, size_t path_sz)
 {
     priv_mcontext_t mc;
     if (!dr_get_mcontext_priv(dcontext, NULL, &mc))
@@ -514,8 +515,8 @@ os_dump_core_internal(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path
     file_t elf_file;
     char dump_core_file_name[MAXIMUM_PATH];
     if (!get_unique_logfile(".elf", dump_core_file_name, sizeof(dump_core_file_name),
-                            /*open_directory=*/false, /*embed_timestamp=*/true,
-                            &elf_file) ||
+                            /*open_directory=*/false, output_directory,
+                            /*embed_timestamp=*/true, &elf_file) ||
         elf_file == INVALID_FILE) {
         SYSLOG_INTERNAL_ERROR("Unable to open the core dump file.");
         return false;
@@ -704,7 +705,8 @@ os_dump_core_internal(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path
  * Returns true if a core dump file is written, false otherwise.
  */
 bool
-os_dump_core_live(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path_sz)
+os_dump_core_live(dcontext_t *dcontext, char *output_directory DR_PARAM_IN,
+                  char *path DR_PARAM_OUT, size_t path_sz)
 {
 #ifdef DR_HOST_NOT_TARGET
     // Memory dump is supported only when the host and the target are the same.
@@ -725,7 +727,7 @@ os_dump_core_live(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path_sz)
     }
 
     // TODO i#7046: Add support to save register values for all threads.
-    const bool ret = os_dump_core_internal(dcontext, path, path_sz);
+    const bool ret = os_dump_core_internal(dcontext, output_directory, path, path_sz);
 
     end_synch_with_all_threads(threads, num_threads,
                                /*resume=*/true);

--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -514,7 +514,8 @@ os_dump_core_internal(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path
     file_t elf_file;
     char dump_core_file_name[MAXIMUM_PATH];
     if (!get_unique_logfile(".elf", dump_core_file_name, sizeof(dump_core_file_name),
-                            false, &elf_file) ||
+                            /*open_directory=*/false, /*embed_timestamp=*/true,
+                            &elf_file) ||
         elf_file == INVALID_FILE) {
         SYSLOG_INTERNAL_ERROR("Unable to open the core dump file.");
         return false;

--- a/core/unix/os_exports.h
+++ b/core/unix/os_exports.h
@@ -254,7 +254,8 @@ os_get_app_tls_base(dcontext_t *dcontext, reg_id_t seg);
  * mode (a process mixing 64-bit and 32-bit code) is not supported.
  */
 bool
-os_dump_core_live(dcontext_t *dcontext, char *path DR_PARAM_OUT, size_t path_sz);
+os_dump_core_live(dcontext_t *dcontext, char *output_directory DR_PARAM_IN,
+                  char *path DR_PARAM_OUT, size_t path_sz);
 #endif
 
 #if defined(AARCHXX) || defined(RISCV64)

--- a/core/utils.c
+++ b/core/utils.c
@@ -2914,8 +2914,8 @@ close_log_file(file_t f)
  */
 bool
 get_unique_logfile(const char *file_type, char *filename_buffer, uint maxlen,
-                   bool open_directory, char *output_directory, bool embed_timestamp,
-                   file_t *file)
+                   bool open_directory, const char *output_directory,
+                   bool embed_timestamp, file_t *file)
 {
     char buf[MAXIMUM_PATH];
     uint size = BUFFER_SIZE_ELEMENTS(buf), counter = 0, base_offset;

--- a/core/utils.h
+++ b/core/utils.h
@@ -1311,8 +1311,8 @@ file_t
 get_thread_private_logfile(void);
 bool
 get_unique_logfile(const char *file_type, char *filename_buffer, uint maxlen,
-                   bool open_directory, char *output_directory, bool embed_timestamp,
-                   file_t *file);
+                   bool open_directory, const char *output_directory,
+                   bool embed_timestamp, file_t *file);
 const char *
 get_app_name_for_path(void);
 const char *

--- a/core/utils.h
+++ b/core/utils.h
@@ -1311,7 +1311,7 @@ file_t
 get_thread_private_logfile(void);
 bool
 get_unique_logfile(const char *file_type, char *filename_buffer, uint maxlen,
-                   bool open_directory, file_t *file);
+                   bool open_directory, bool embed_timestamp, file_t *file);
 const char *
 get_app_name_for_path(void);
 const char *

--- a/core/utils.h
+++ b/core/utils.h
@@ -1311,7 +1311,8 @@ file_t
 get_thread_private_logfile(void);
 bool
 get_unique_logfile(const char *file_type, char *filename_buffer, uint maxlen,
-                   bool open_directory, bool embed_timestamp, file_t *file);
+                   bool open_directory, char *output_directory, bool embed_timestamp,
+                   file_t *file);
 const char *
 get_app_name_for_path(void);
 const char *

--- a/core/win32/diagnost.c
+++ b/core/win32/diagnost.c
@@ -184,7 +184,7 @@ open_diagnostics_file(DR_PARAM_IN file_t *file, DR_PARAM_OUT char *buf,
 {
     const char *file_extension = DIAGNOSTICS_FILE_XML_EXTENSION;
     get_unique_logfile(file_extension, buf, maxlen, /*open_directory=*/false,
-                       /*embed_timestamp=*/false, file);
+                       /*output_directory=*/NULL, /*embed_timestamp=*/false, file);
 }
 
 /* flags */

--- a/core/win32/diagnost.c
+++ b/core/win32/diagnost.c
@@ -183,7 +183,8 @@ open_diagnostics_file(DR_PARAM_IN file_t *file, DR_PARAM_OUT char *buf,
                       DR_PARAM_IN uint maxlen)
 {
     const char *file_extension = DIAGNOSTICS_FILE_XML_EXTENSION;
-    get_unique_logfile(file_extension, buf, maxlen, false, file);
+    get_unique_logfile(file_extension, buf, maxlen, /*open_directory=*/false,
+                       /*embed_timestamp=*/false, file);
 }
 
 /* flags */

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -414,7 +414,9 @@ init_global_profiles()
         }
     });
     if (profile_file == INVALID_FILE) {
-        get_unique_logfile(".profile", NULL, 0, false, &profile_file);
+        get_unique_logfile(".profile", /*filename_buffer=*/NULL, /*maxlen=*/0,
+                           /*open_directory=*/false, /*embed_timestamp=*/false,
+                           &profile_file);
     }
     DOLOG(1, LOG_PROFILE, {
         if (profile_file == INVALID_FILE)
@@ -7820,8 +7822,8 @@ os_dump_core_live_dump(const char *msg, char *path DR_PARAM_OUT, size_t path_sz)
     /* use no option synch for syslogs to avoid grabbing locks and risking
      * deadlock, caller should have synchronized already anyways */
     if (!get_unique_logfile(".ldmp", dump_core_file_name, sizeof(dump_core_file_name),
-                            false, &dmp_file) ||
-        dmp_file == INVALID_FILE) {
+                            /*open_directory=*/false, /*embed_timestamp*/true,
+                            &dmp_file) || dmp_file == INVALID_FILE) {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_WARNING, "Unable to open core dump file");
         return false;
     }

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -7822,7 +7822,7 @@ os_dump_core_live_dump(const char *msg, char *path DR_PARAM_OUT, size_t path_sz)
     /* use no option synch for syslogs to avoid grabbing locks and risking
      * deadlock, caller should have synchronized already anyways */
     if (!get_unique_logfile(".ldmp", dump_core_file_name, sizeof(dump_core_file_name),
-                            /*open_directory=*/false, /*embed_timestamp*/false,
+                            /*open_directory=*/false, /*embed_timestamp*/ false,
                             &dmp_file) ||
         dmp_file == INVALID_FILE) {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_WARNING, "Unable to open core dump file");

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -7822,8 +7822,8 @@ os_dump_core_live_dump(const char *msg, char *path DR_PARAM_OUT, size_t path_sz)
     /* use no option synch for syslogs to avoid grabbing locks and risking
      * deadlock, caller should have synchronized already anyways */
     if (!get_unique_logfile(".ldmp", dump_core_file_name, sizeof(dump_core_file_name),
-                            /*open_directory=*/false, /*embed_timestamp*/ false,
-                            &dmp_file) ||
+                            /*open_directory=*/false, /*output_directory=*/NULL,
+                            /*embed_timestamp*/false, &dmp_file) ||
         dmp_file == INVALID_FILE) {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_WARNING, "Unable to open core dump file");
         return false;

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -415,8 +415,8 @@ init_global_profiles()
     });
     if (profile_file == INVALID_FILE) {
         get_unique_logfile(".profile", /*filename_buffer=*/NULL, /*maxlen=*/0,
-                           /*open_directory=*/false, /*embed_timestamp=*/false,
-                           &profile_file);
+                           /*open_directory=*/false, /*output_directory=*/NULL,
+                           /*embed_timestamp=*/false, &profile_file);
     }
     DOLOG(1, LOG_PROFILE, {
         if (profile_file == INVALID_FILE)

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -7823,7 +7823,7 @@ os_dump_core_live_dump(const char *msg, char *path DR_PARAM_OUT, size_t path_sz)
      * deadlock, caller should have synchronized already anyways */
     if (!get_unique_logfile(".ldmp", dump_core_file_name, sizeof(dump_core_file_name),
                             /*open_directory=*/false, /*output_directory=*/NULL,
-                            /*embed_timestamp*/false, &dmp_file) ||
+                            /*embed_timestamp=*/false, &dmp_file) ||
         dmp_file == INVALID_FILE) {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_WARNING, "Unable to open core dump file");
         return false;

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -7822,8 +7822,9 @@ os_dump_core_live_dump(const char *msg, char *path DR_PARAM_OUT, size_t path_sz)
     /* use no option synch for syslogs to avoid grabbing locks and risking
      * deadlock, caller should have synchronized already anyways */
     if (!get_unique_logfile(".ldmp", dump_core_file_name, sizeof(dump_core_file_name),
-                            /*open_directory=*/false, /*embed_timestamp*/true,
-                            &dmp_file) || dmp_file == INVALID_FILE) {
+                            /*open_directory=*/false, /*embed_timestamp*/ true,
+                            &dmp_file) ||
+        dmp_file == INVALID_FILE) {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_WARNING, "Unable to open core dump file");
         return false;
     }

--- a/core/win32/os.c
+++ b/core/win32/os.c
@@ -7822,7 +7822,7 @@ os_dump_core_live_dump(const char *msg, char *path DR_PARAM_OUT, size_t path_sz)
     /* use no option synch for syslogs to avoid grabbing locks and risking
      * deadlock, caller should have synchronized already anyways */
     if (!get_unique_logfile(".ldmp", dump_core_file_name, sizeof(dump_core_file_name),
-                            /*open_directory=*/false, /*embed_timestamp*/ true,
+                            /*open_directory=*/false, /*embed_timestamp*/false,
                             &dmp_file) ||
         dmp_file == INVALID_FILE) {
         SYSLOG_INTERNAL_NO_OPTION_SYNCH(SYSLOG_WARNING, "Unable to open core dump file");

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4470,7 +4470,7 @@ if (BUILD_CLIENTS)
     set(tool.drcacheoff.windows-split_postcmd3
       "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
 
-    if (X64 AND LINUX)
+    if (X64 AND (LINUX OR WIN32))
       torunonly_drcacheoff(windows-memdump ${ci_shared_app}
         "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -memdump_on_window"
         "@-tool@basic_counts" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4473,7 +4473,6 @@ if (BUILD_CLIENTS)
     # TODO i#7508: Add Windows support. raw2trace fails with "Non-module instructions
     # found with no encoding information." when a memory dump is captured in the beginning
     # of a tracing window.
-    # XXX: Verify the content of the memory dump files.
     if (X64 AND LINUX)
       torunonly_drcacheoff(windows-memdump ${ci_shared_app}
         "-trace_after_instrs 20K -trace_for_instrs 10K -retrace_every_instrs 30K -memdump_on_window"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4470,6 +4470,10 @@ if (BUILD_CLIENTS)
     set(tool.drcacheoff.windows-split_postcmd3
       "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
 
+    torunonly_drcacheoff(windows-memdump ${ci_shared_app}
+      "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -memdump_on_window"
+      "@-tool@basic_counts" "")
+
     # Test L0_filter_until_instrs
     torunonly_drcacheoff(L0-filter-until-instrs-windows-split ${ci_shared_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -trace_for_instrs 10K -retrace_every_instrs 10K"

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4473,10 +4473,18 @@ if (BUILD_CLIENTS)
     # TODO i#7508: Add Windows support. raw2trace fails with "Non-module instructions
     # found with no encoding information." when a memory dump is captured in the beginning
     # of a tracing window.
+    # XXX: Verify the content of the memory dump files.
     if (X64 AND LINUX)
       torunonly_drcacheoff(windows-memdump ${ci_shared_app}
-        "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -memdump_on_window"
+        "-trace_after_instrs 20K -trace_for_instrs 10K -retrace_every_instrs 30K -memdump_on_window"
         "@-tool@basic_counts" "")
+    # The first postcmd did window #0.  There should be at least 2 more windows.
+    set(tool.drcacheoff.windows-memdump_postcmd2
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-tool@basic_counts")
+    set(tool.drcacheoff.windows-memdump_postcmd3
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
+    set(tool.drcacheoff.windows-memdump_postcmd4
+      "${READELF_EXECUTABLE}@-a@${PROJECT_BINARY_DIR}/suite/tests/${dir_prefix}.*.dir/raw/window.000?/*.elf")
     endif ()
 
     # Test L0_filter_until_instrs

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4469,8 +4469,11 @@ if (BUILD_CLIENTS)
       "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-tool@basic_counts")
     set(tool.drcacheoff.windows-split_postcmd3
       "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
-
-    if (X64 AND (LINUX OR WIN32))
+    # Test memory dump when a trace window opens.
+    # TODO i#7508: Add Windows support. raw2trace fails with "Non-module instructions
+    # found with no encoding information." when a memory dump is captured in the beginning
+    # of a tracing window.
+    if (X64 AND LINUX)
       torunonly_drcacheoff(windows-memdump ${ci_shared_app}
         "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -memdump_on_window"
         "@-tool@basic_counts" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4470,9 +4470,11 @@ if (BUILD_CLIENTS)
     set(tool.drcacheoff.windows-split_postcmd3
       "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
 
-    torunonly_drcacheoff(windows-memdump ${ci_shared_app}
-      "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -memdump_on_window"
-      "@-tool@basic_counts" "")
+    if (X64 AND LINUX)
+      torunonly_drcacheoff(windows-memdump ${ci_shared_app}
+        "-no_split_windows -trace_after_instrs 20K -trace_for_instrs 5K -retrace_every_instrs 35K -memdump_on_window"
+        "@-tool@basic_counts" "")
+    endif ()
 
     # Test L0_filter_until_instrs
     torunonly_drcacheoff(L0-filter-until-instrs-windows-split ${ci_shared_app}

--- a/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
+++ b/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
@@ -208,6 +208,7 @@ event_nudge(void *drcontext, uint64 arg)
         spec.flags = DR_MEMORY_DUMP_ELF;
         spec.elf_path = (char *)&memory_dump_file_path;
         spec.elf_path_size = BUFFER_SIZE_ELEMENTS(memory_dump_file_path);
+        spec.elf_output_directory = NULL;
 
         if (!dr_create_memory_dump(&spec)) {
             dr_fprintf(STDERR, "Error: failed to create memory dump.\n");

--- a/suite/tests/client-interface/memory_dump_test.dll.c
+++ b/suite/tests/client-interface/memory_dump_test.dll.c
@@ -58,6 +58,7 @@ event_nudge(void *drcontext, uint64 arg)
         spec.flags = DR_MEMORY_DUMP_ELF;
         spec.elf_path = (char *)&path;
         spec.elf_path_size = MAXIMUM_PATH;
+        spec.elf_output_directory = NULL;
 #endif
         if (!dr_create_memory_dump(&spec)) {
             dr_fprintf(STDERR, "Error: failed to create memory dump.\n");


### PR DESCRIPTION
Add an option -memdump_on_window to the drmemtrace trace analysis tools framework.

The option triggers a memory dump when a trace window opens by -trace_after_instrs,  -trace_instr_intervals_file, or -retrace_every_instrs. If -retrace_every_instrs is also enabled, a memory dump will be captured for each individual tracing window. 

This feature only works on Linux X64. On Windows, raw2trace fails with "Non-module instructions found with no encoding information." if it is enabled. If this flag is used on Windows, the tracer will print an error message without capturing a memory dump.

Add a new parameter, embed_timestamp, to get_unique_logfile() to embed a timestamp in the file name. Adding a timestamp to the memory dump file name allows us to better correlate the memory dump file to the timestamps in the trace files.

Add a new CI test tool.drcacheoff.windows-memdump to test the new option.

Issue: #7508 