### PR TITLE
i#7511 avx512: Identify {x,y}mm16+ as AVX-512 for lazy state preservation

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -180,6 +180,7 @@ Further non-compatibility-affecting changes include:
       generation alongside the scheduled traces.
  - Added AUX_SUBDIR (== "aux") to the subdirs in which get_aux_file_path() looks for
    auxiliary files (e.g., v2p.textproto).
+ - Added reg_is_avx512().
 
 **************************************************
 <hr>

--- a/core/arch/interp.c
+++ b/core/arch/interp.c
@@ -3484,12 +3484,15 @@ build_bb_ilist(dcontext_t *dcontext, build_bb_t *bb)
             }
             if (!d_r_is_avx512_code_in_use()) {
                 if (ZMM_ENABLED()) {
-                    if (instr_get_prefix_flag(bb->instr, PREFIX_EVEX) ||
+                    /* Check operands for precise AVX-512 detection; if we don't have
+                     * full decode with operands, we fall back on checking the
+                     * PREFIX_EVEX flag which is only set by decode_cti() and is
+                     * too broad but the best we have there.
+                     */
+                    if ((!bb->full_decode &&
+                         instr_get_prefix_flag(bb->instr, PREFIX_EVEX)) ||
                         (bb->full_decode && instr_may_write_avx512_register(bb->instr))) {
-                        /* For AVX-512 detection in bb builder, we're checking only
-                         * for the this generic prefix flag which is set by
-                         * decode_cti(), or for full decode we check the operands.
-                         * In client_process_bb, post-client instructions
+                        /* In client_process_bb, post-client instructions
                          * are again checked with instr_may_write_avx512_register().
                          */
                         LOG(THREAD, LOG_INTERP, 2, "Detected AVX-512 code in use\n");

--- a/core/ir/decode.h
+++ b/core/ir/decode.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -61,7 +61,10 @@
  */
 #    define PREFIX_SEG_FS 0x20
 #    define PREFIX_SEG_GS 0x40
-/* Prefix used for AVX-512 */
+/* Generic prefix used for AVX-512 by decode_cti().
+ * Full decode does *not* set this prefix, which is relied upon for
+ * AVX-512 detection with full decode in build_bb_ilist().
+ */
 #    define PREFIX_EVEX 0x000100000
 #endif
 

--- a/core/ir/decode.h
+++ b/core/ir/decode.h
@@ -61,9 +61,10 @@
  */
 #    define PREFIX_SEG_FS 0x20
 #    define PREFIX_SEG_GS 0x40
-/* Generic prefix used for AVX-512 by decode_cti().
- * Full decode does *not* set this prefix, which is relied upon for
- * AVX-512 detection with full decode in build_bb_ilist().
+/* Generic prefix used only by decode_cti() and used as a rough method to detect AVX-512
+ * in instr_may_write_avx512_register() and build_bb_ilist(), but it's too broad.  Full
+ * decode does *not* set this prefix and instead we use precise operand checks for
+ * AVX-512 detection when we have operand info.
  */
 #    define PREFIX_EVEX 0x000100000
 #endif

--- a/core/ir/instr.h
+++ b/core/ir/instr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -565,12 +565,13 @@ bool
 instr_can_set_single_step(instr_t *instr);
 
 /* Returns true if \p instr is part of Intel's AVX-512 instructions that may write to a
- * zmm or opmask register. It approximates this by checking whether PREFIX_EVEX is set. If
- * not set, it checks the destinations of \p instr. The decoded instr should be
- * available for inspection as this is invoked only when some client is present.
+ * ymm16-31, zmm, or opmask register. It approximates this by checking whether
+ * PREFIX_EVEX is set, for fast-decode decode_cti() instructions. If not set, it checks
+ * the destinations of \p instr. The decoded instr should be available for inspection as
+ * this is invoked only when some client is present.
  */
 bool
-instr_may_write_zmm_or_opmask_register(instr_t *instr);
+instr_may_write_avx512_register(instr_t *instr);
 #endif
 
 /* Given a machine state, returns whether or not the cbr instr would be taken

--- a/core/ir/instr.h
+++ b/core/ir/instr.h
@@ -567,8 +567,7 @@ instr_can_set_single_step(instr_t *instr);
 /* Returns true if \p instr is part of Intel's AVX-512 instructions that may write to a
  * ymm16-31, zmm, or opmask register. It approximates this by checking whether
  * PREFIX_EVEX is set, for fast-decode decode_cti() instructions. If not set, it checks
- * the destinations of \p instr. The decoded instr should be available for inspection as
- * this is invoked only when some client is present.
+ * the destinations of \p instr.
  */
 bool
 instr_may_write_avx512_register(instr_t *instr);

--- a/core/ir/opnd_api.h
+++ b/core/ir/opnd_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -3540,6 +3540,15 @@ DR_API
 bool
 reg_is_avx512_extended(reg_id_t reg);
 #endif
+
+DR_API
+/**
+ * Returns true iff \p reg refers to register added by the AVX-512 feature set.
+ * Returns true for any ZMM register, any opmask register, and any
+ * reg_is_avx512_extended() register.
+ */
+bool
+reg_is_avx512(reg_id_t reg);
 
 DR_API
 /**

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * Copyright (c) 2025 Foundation of Research and Technology, Hellas.
  * **********************************************************/
@@ -2538,7 +2538,6 @@ reg_is_extended(reg_id_t reg)
 bool
 reg_is_avx512_extended(reg_id_t reg)
 {
-    /* Note that we do consider spl, bpl, sil, and dil to be "extended" */
     return ((reg >= DR_REG_START_XMM + 16 && reg <= DR_REG_STOP_XMM) ||
             (reg >= DR_REG_START_YMM + 16 && reg <= DR_REG_STOP_YMM) ||
             (reg >= DR_REG_START_ZMM + 16 && reg <= DR_REG_STOP_ZMM));

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2549,7 +2549,7 @@ bool
 reg_is_avx512(reg_id_t reg)
 {
     return reg_is_strictly_zmm(reg) ||
-        reg_is_opmask(reg) IF_X86_X64(|| reg_is_avx512_extended(reg));
+        reg_is_opmask(reg) IF_X86_64(|| reg_is_avx512_extended(reg));
 }
 
 reg_id_t

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2545,6 +2545,13 @@ reg_is_avx512_extended(reg_id_t reg)
 #    endif
 #endif
 
+bool
+reg_is_avx512(reg_id_t reg)
+{
+    return reg_is_strictly_zmm(reg) ||
+        reg_is_opmask(reg) IF_X64(|| reg_is_avx512_extended(reg));
+}
+
 reg_id_t
 reg_32_to_opsz(reg_id_t reg, opnd_size_t sz)
 {

--- a/core/ir/opnd_shared.c
+++ b/core/ir/opnd_shared.c
@@ -2549,7 +2549,7 @@ bool
 reg_is_avx512(reg_id_t reg)
 {
     return reg_is_strictly_zmm(reg) ||
-        reg_is_opmask(reg) IF_X64(|| reg_is_avx512_extended(reg));
+        reg_is_opmask(reg) IF_X86_X64(|| reg_is_avx512_extended(reg));
 }
 
 reg_id_t

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -971,7 +971,7 @@ instr_can_set_single_step(instr_t *instr)
 }
 
 bool
-instr_may_write_zmm_or_opmask_register(instr_t *instr)
+instr_may_write_avx512_register(instr_t *instr)
 {
     if (instr_get_prefix_flag(instr, PREFIX_EVEX))
         return true;
@@ -980,7 +980,9 @@ instr_may_write_zmm_or_opmask_register(instr_t *instr)
         opnd_t dst = instr_get_dst(instr, i);
         if (opnd_is_reg(dst)) {
             if (reg_is_strictly_zmm(opnd_get_reg(dst)) ||
-                reg_is_opmask(opnd_get_reg(dst)))
+                reg_is_opmask(opnd_get_reg(dst)) ||
+                (reg_is_strictly_ymm(opnd_get_reg(dst)) &&
+                 opnd_get_reg(dst) > DR_REG_YMM15))
                 return true;
         }
     }

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -980,8 +980,8 @@ instr_may_write_avx512_register(instr_t *instr)
         opnd_t dst = instr_get_dst(instr, i);
         if (opnd_is_reg(dst)) {
             if (reg_is_strictly_zmm(opnd_get_reg(dst)) ||
-                reg_is_opmask(opnd_get_reg(dst)) ||
-                reg_is_avx512_extended(opnd_get_reg(dst)))
+                reg_is_opmask(opnd_get_reg(dst))
+                    IF_X64(|| reg_is_avx512_extended(opnd_get_reg(dst))))
                 return true;
         }
     }

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -981,8 +981,7 @@ instr_may_write_avx512_register(instr_t *instr)
         if (opnd_is_reg(dst)) {
             if (reg_is_strictly_zmm(opnd_get_reg(dst)) ||
                 reg_is_opmask(opnd_get_reg(dst)) ||
-                (reg_is_strictly_ymm(opnd_get_reg(dst)) &&
-                 opnd_get_reg(dst) > DR_REG_YMM15))
+                reg_is_avx512_extended(opnd_get_reg(dst)))
                 return true;
         }
     }

--- a/core/ir/x86/instr.c
+++ b/core/ir/x86/instr.c
@@ -979,9 +979,7 @@ instr_may_write_avx512_register(instr_t *instr)
     for (int i = 0; i < instr_num_dsts(instr); ++i) {
         opnd_t dst = instr_get_dst(instr, i);
         if (opnd_is_reg(dst)) {
-            if (reg_is_strictly_zmm(opnd_get_reg(dst)) ||
-                reg_is_opmask(opnd_get_reg(dst))
-                    IF_X64(|| reg_is_avx512_extended(opnd_get_reg(dst))))
+            if (reg_is_avx512(opnd_get_reg(dst)))
                 return true;
         }
     }


### PR DESCRIPTION
DR's lazy AVX-512 state preservation was only looking for zmm and opmask register usage: yet ymm16-31 are also AVX-512-only and my machine has ymm16 code before any zmm code runs. DR fails to preserve the state and the app state is corrupted.  Similarly, the gencode_filter test in #6490 has xmm16 in use, causing the weird printing there.

The check is augmented here to also look for xmm16+ or ymm16+.
Additionally, with full_decode, a check is added in build_bb_ilist, to fill a gap with full_decode but no client where AVX-512 would not be detected at all.

A new function reg_is_avx512() is added.

The PREFIX_EVEX is documented to clarify it is deliberately only set by decode_cti().

Tested:
My #7504 test's print() reliably printed the specifier ("%d") instead of the values when under DR without the fix; with the fix it prints the values every time.  Also confirmed in the logs with a client with a bb event that the trigger happens where expected:
```
interp: start_pc = 0x00007fd93eb06980
  0x00007fd93eb06980  62 e2 7d 28 7a c6    vpbroadcastb {%k0} %esi -> %ymm16
Detected AVX-512 code in use
  0x00007fd93eb06986  89 f8                mov    %edi -> %eax
...
        zmm16= 0x0000000000d79a481c56f7360000000200000000000000003e9d71d800007fd73e9d75f800007fd73ea1878000007fd719ccdf1000007ffd19ccde5000007ffd
        zmm17= 0x0000000000d79a481c3d8f8a000000023e9d821800007fd7000002e0000000003e9d75f800007fd73ea1878000007fd719cce32800007ffd9d117c3b00005580
```

Ran `ctest --repeat-until-fail 2000 -R off.gencode_f` to test the fix for #6490: all 2000 pass now when before it would fail every 40-100 tries.

I considered adding a regression test by modifying avx512lazy.c to use a ymm16 instruction: but that test is not useful on a machine where a system library first uses ymm16.  We would need a pure-static test, with a separate pure-static app per trigger.  I'm not sure it's worth the effort and CI runtime to build and run all of those tests.

Fixes #7511
Fixes #6490