### PR TITLE
i#7514: Fix doxygen tags in aarch64_far.dox.

### DIFF
--- a/api/docs/aarch64_far.dox
+++ b/api/docs/aarch64_far.dox
@@ -388,7 +388,7 @@ Our usage of Landing Pad will look something like:
   <th>Patched stub: Transfers to far-away linked fragment</th>
 </tr>
 <tr>
- <td>
+  <td>
 ```
  exit_cti stub
 ...
@@ -403,7 +403,7 @@ stub:
 
 
 ```
-  <td></td>
+  </td><td>
 ```
  exit_cti stub
 ...


### PR DESCRIPTION
Fix doxygen tags in aarch64_far.dox which cause the following errors in ci-winodws:

```
FAILED: api/docs/html/index.html D:/a/dynamorio/dynamorio/build_debug-internal-32/api/docs/html/index.html 
C:\Windows\system32\cmd.exe /C "cd /D D:\a\dynamorio\dynamorio\build_debug-internal-32\api\docs && "C:\Program Files\CMake\bin\cmake.exe" -D DOXYGEN_EXECUTABLE=C:/Windows/doxygen.exe -Ddoxygen_ver=1.14.0 -Dversion_number=11.90.20265 "-Dmodule_string_long=\"DynamoRIO Extension Details\"" -Dmodule_string_short=\"Extension\" -Dhome_url=\"[http://www.dynamorio.org\](http://www.dynamorio.org/)" "-Dhome_title=\"DynamoRIO Home Page\"" -Dlogo_imgfile=\"drlogo.png\" -Dembeddable=OFF -Dproj_srcdir=D:/a/dynamorio/dynamorio -Dproj_bindir=D:/a/dynamorio/dynamorio/build_debug-internal-32 -P D:/a/dynamorio/dynamorio/api/docs/CMake_rundoxygen.cmake"
CMake Error at D:/a/dynamorio/dynamorio/api/docs/CMake_rundoxygen.cmake:154 (message):
  *** C:/Windows/doxygen.exe failed: ***

  D:/a/dynamorio/dynamorio/api/docs/aarch64_far.dox:407: warning: expected
  <td>, <th> or <tr> tag but found </icode> instead!

  D:/a/dynamorio/dynamorio/api/docs/aarch64_far.dox:407: warning: Unsupported
  xml/html tag <icode> found

  D:/a/dynamorio/dynamorio/api/docs/aarch64_far.dox:416: warning: explicit
  link request to 'fcache' could not be resolved

  D:/a/dynamorio/dynamorio/api/docs/aarch64_far.dox:420: warning: Unsupported
  xml/html tag <far_fragment_pc> found

  D:/a/dynamorio/dynamorio/api/docs/aarch64_far.dox:427: warning: unexpected
  command endicode
```

Issue: #7514 