### PR TITLE
Fix NtUserOpenClipboard

### DIFF
--- a/ext/drmf/wininc/ntuser.h
+++ b/ext/drmf/wininc/ntuser.h
@@ -1872,7 +1872,7 @@ VOID NTAPI
 NtUserNotifyWinEvent(DWORD Event, HWND hWnd, LONG idObject, LONG idChild);
 
 BOOL NTAPI
-NtUserOpenClipboard(HWND hWnd, DWORD Unknown1);
+NtUserOpenClipboard(HWND hWnd, PBOOL pfEmptyClient);
 
 HDESK
 NTAPI

--- a/ext/drsyscall/table_windows_ntuser.c
+++ b/ext/drsyscall/table_windows_ntuser.c
@@ -2005,7 +2005,7 @@ syscall_info_t syscall_user32_info[] = {
       2,
       {
           { 0, sizeof(HWND), SYSARG_INLINED, DRSYS_TYPE_HANDLE },
-          { 1, sizeof(DWORD), SYSARG_INLINED, DRSYS_TYPE_UNSIGNED_INT },
+          { 1, sizeof(BOOL), W | HT, DRSYS_TYPE_BOOL },
       } },
     { { 0, 0 },
       "NtUserOpenDesktop",


### PR DESCRIPTION
This pull request updates the definition for `NtUserOpenClipboard`. For more details, see https://github.com/DynamoRIO/drmemory/pull/2558