### PR TITLE
i#199: Add dr_invoke_syscall_as_app()

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -185,6 +185,8 @@ Further non-compatibility-affecting changes include:
    -trace_instr_intervals_file, or -retrace_every_instrs. If -retrace_every_instrs is
    also enabled, a memory dump will be captured for each individual tracing window.
  - Added reg_is_avx512().
+ - Added routine dr_invoke_syscall_as_app() to invoke a system call as though the
+   application made it, meaning it goes through DR's handling.
 
 **************************************************
 <hr>

--- a/core/globals.h
+++ b/core/globals.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -413,6 +413,9 @@ typedef struct _client_data_t {
      * but only upon failures.
      */
     dr_error_code_t error_code;
+
+    /* Flag for dr_invoke_syscall_as_app(). */
+    bool skip_syscall_events;
 } client_data_t;
 
 #ifdef UNIX

--- a/core/globals.h
+++ b/core/globals.h
@@ -415,7 +415,7 @@ typedef struct _client_data_t {
     dr_error_code_t error_code;
 
     /* Flag for dr_invoke_syscall_as_app(). */
-    bool skip_syscall_events;
+    bool skip_client_syscall_events;
 } client_data_t;
 
 #ifdef UNIX

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2024, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -1264,6 +1264,21 @@ DR_API
 bool
 dr_syscall_intercept_natively(const char *name, int sysnum, int num_args,
                               int wow64_index);
+#endif
+
+#ifdef UNIX
+DR_API
+/**
+ * Invokes a system call and applies handling as though the application had executed it,
+ * but does not trigger system call events such as dr_register_pre_syscall_event().
+ * This is safer than a client invoking raw system calls that bypass DR's handling, which
+ * can cause numerous problems such as breaking DR's timer multiplexing or file
+ * descriptor isolation.
+ *
+ * \note UNIX only.
+ */
+reg_t
+dr_invoke_syscall_as_app(void *drcontext, int sysnum, int arg_count, ...);
 #endif
 
 /**************************************************

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2075,7 +2075,7 @@ instrument_filter_syscall(dcontext_t *dcontext, int sysnum)
 bool
 instrument_pre_syscall(dcontext_t *dcontext, int sysnum)
 {
-    if (dcontext->client_data->skip_syscall_events)
+    if (dcontext->client_data->skip_client_syscall_events)
         return true;
     bool exec = true;
     dcontext->client_data->in_pre_syscall = true;
@@ -2107,7 +2107,7 @@ instrument_pre_syscall(dcontext_t *dcontext, int sysnum)
 void
 instrument_post_syscall(dcontext_t *dcontext, int sysnum)
 {
-    if (dcontext->client_data->skip_syscall_events)
+    if (dcontext->client_data->skip_client_syscall_events)
         return;
     dr_where_am_i_t old_whereami = dcontext->whereami;
     if (post_syscall_callbacks.num == 0)

--- a/core/lib/instrument.c
+++ b/core/lib/instrument.c
@@ -2075,6 +2075,8 @@ instrument_filter_syscall(dcontext_t *dcontext, int sysnum)
 bool
 instrument_pre_syscall(dcontext_t *dcontext, int sysnum)
 {
+    if (dcontext->client_data->skip_syscall_events)
+        return true;
     bool exec = true;
     dcontext->client_data->in_pre_syscall = true;
     /* clear flag from dr_syscall_invoke_another() */
@@ -2105,6 +2107,8 @@ instrument_pre_syscall(dcontext_t *dcontext, int sysnum)
 void
 instrument_post_syscall(dcontext_t *dcontext, int sysnum)
 {
+    if (dcontext->client_data->skip_syscall_events)
+        return;
     dr_where_am_i_t old_whereami = dcontext->whereami;
     if (post_syscall_callbacks.num == 0)
         return;

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5801,7 +5801,10 @@ dr_invoke_syscall_as_app(void *drcontext, int sysnum, int arg_count, ...)
     reg_t saved[MAX_PARAM_COUNT];
     va_list ap;
     va_start(ap, arg_count);
-    for (int i = 0; i < arg_count; ++i) {
+    /* In some builds, Werror=array-bounds complains about saved[i] despite our
+     * arg_count check above: so we add "&& i < MAX_PARAM_COUNT" to avoid the warning.
+     */
+    for (int i = 0; i < arg_count && i < MAX_PARAM_COUNT; ++i) {
         args[i] = va_arg(ap, reg_t);
         saved[i] = sys_param(dcontext, i);
         set_syscall_param(dcontext, i, args[i]);

--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5776,6 +5776,60 @@ dr_syscall_invoke_another(void *drcontext)
     /* for x64 we don't need to copy xcx into r10 b/c we use r10 as our param */
 }
 
+/* This goes through app handling (but does not include client syscall events).
+ * That suits some client uses, but others want only DR internal handling
+ * and not app handling: which will require further work to support and
+ * does not seem trivial (e.g., setting an itimer would need to go
+ * run the dr_set_itimer() code): that's under i#199 and would be a
+ * separate API routine.
+ */
+DR_API
+reg_t
+dr_invoke_syscall_as_app(void *drcontext, int sysnum, int arg_count, ...)
+{
+    dcontext_t *dcontext = (dcontext_t *)drcontext;
+    if (dcontext == GLOBAL_DCONTEXT)
+        return -EINVAL;
+    priv_mcontext_t *mc = get_mcontext(dcontext);
+#define MAX_PARAM_COUNT 6
+    if (arg_count > MAX_PARAM_COUNT)
+        return -EINVAL;
+    reg_t args[MAX_PARAM_COUNT] = {};
+    /* We need to save the mcontext app values so we can place this syscall's
+     * values into the mcontext for pre_system_call() to examine them.
+     */
+    reg_t saved[MAX_PARAM_COUNT];
+    va_list ap;
+    va_start(ap, arg_count);
+    for (int i = 0; i < arg_count; ++i) {
+        args[i] = va_arg(ap, reg_t);
+        saved[i] = sys_param(dcontext, i);
+        set_syscall_param(dcontext, i, args[i]);
+    }
+    va_end(ap);
+    reg_t saved_sysnum = MCXT_SYSNUM_REG(mc);
+    MCXT_SYSNUM_REG(mc) = sysnum;
+    reg_t saved_res = MCXT_SYSCALL_RES(mc);
+    reg_t res;
+    /* Skip client syscall events. */
+    dcontext->client_data->skip_syscall_events = true;
+    if (!pre_system_call(dcontext)) {
+        res = MCXT_SYSCALL_RES(mc);
+    } else {
+        res = dynamorio_syscall(sysnum, arg_count, args[0], args[1], args[2], args[3],
+                                args[4], args[5]);
+        post_system_call(dcontext);
+    }
+    dcontext->client_data->skip_syscall_events = false;
+    /* Restore app registers. */
+    for (int i = 0; i < arg_count; ++i) {
+        set_syscall_param(dcontext, i, saved[i]);
+    }
+    MCXT_SYSCALL_RES(mc) = saved_res;
+    MCXT_SYSNUM_REG(mc) = saved_sysnum;
+    return res;
+}
+
 static inline bool
 is_thread_create_syscall_helper(ptr_uint_t sysnum, uint64 flags)
 {

--- a/suite/tests/client-interface/strace.dll.c
+++ b/suite/tests/client-interface/strace.dll.c
@@ -141,9 +141,11 @@ dr_init(client_id_t id)
     }
 #endif
 
-#ifdef UNIX
-    // Test that dr_invoke_syscall_as_app() goes through DR's handling by ensuring
-    // a request for the file limit is correctly reduced for -steal_fds.
+    /* We don't run the code below on Mac b/c syscall() is deprecated there. */
+#ifdef LINUX
+    /* Test that dr_invoke_syscall_as_app() goes through DR's handling by ensuring
+     * a request for the file limit is correctly reduced for -steal_fds.
+     */
     int sysnum_getrlimit =
 #    if defined(X64) || defined(MACOS)
         SYS_getrlimit

--- a/suite/tests/client-interface/strace.dll.c
+++ b/suite/tests/client-interface/strace.dll.c
@@ -146,6 +146,10 @@ dr_init(client_id_t id)
     /* Test that dr_invoke_syscall_as_app() goes through DR's handling by ensuring
      * a request for the file limit is correctly reduced for -steal_fds.
      */
+    uint64 steal_fd_value = 0;
+    bool got_value = dr_get_integer_option("steal_fds", &steal_fd_value);
+    DR_ASSERT(got_value);
+    DR_ASSERT(steal_fd_value > 0);
     int sysnum_getrlimit =
 #    if defined(X64) || defined(MACOS)
         SYS_getrlimit

--- a/suite/tests/client-interface/strace.dll.c
+++ b/suite/tests/client-interface/strace.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2017 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -54,6 +54,8 @@
 #        define SYSNUM_SIGPROCMASK SYS_sigprocmask
 #    endif
 #    include <errno.h>
+#    include <unistd.h>
+#    include <sys/resource.h>
 #endif
 
 /* Due to differences among platforms we don't display syscall #s and args
@@ -137,6 +139,28 @@ dr_init(client_id_t id)
 #    endif
         dr_fprintf(STDERR, "Client syscall is running\n");
     }
+#endif
+
+#ifdef UNIX
+    // Test that dr_invoke_syscall_as_app() goes through DR's handling by ensuring
+    // a request for the file limit is correctly reduced for -steal_fds.
+    int sysnum_getrlimit =
+#    if defined(X64) || defined(MACOS)
+        SYS_getrlimit
+#    else
+        SYS_ugetrlimit
+#    endif
+        ;
+    struct rlimit rlim_raw, rlim_dr;
+    int res = syscall(sysnum_getrlimit, RLIMIT_NOFILE, &rlim_raw);
+    if (res < 0)
+        dr_fprintf(STDERR, "raw syscall failed with %d\n", res);
+    res = dr_invoke_syscall_as_app(dr_get_current_drcontext(), sysnum_getrlimit, 2,
+                                   RLIMIT_NOFILE, &rlim_dr);
+    if (res < 0)
+        dr_fprintf(STDERR, "dr_invoke_syscall_as_app failed with %d\n", res);
+    if (rlim_raw.rlim_cur == rlim_dr.rlim_cur)
+        dr_fprintf(STDERR, "dr_invoke_syscall_as_app failed to go through DR\n");
 #endif
 }
 


### PR DESCRIPTION
Adds a new API routine dr_invoke_syscall_as_app() which invokes a system call as though the application made it, meaning it goes through DR's handling.  However, it does not trigger client syscall events (skipping them via an internal flag), which seems to be what use cases want (as otherwise each client or ext has to use flags to skip them).

(We may want a separate dr_invoke_syscall() that is not treated as an app syscall but just lets DR do its own internal tracking, but that is harder to implement and not needed for my use case, so it is left as future work for #199.)

Adds a test case that confirms DR acts on the syscall.

Issue: #199