### PR TITLE
i#7157 dyn inject: Fix bad union access in scheduler_unit_tests

### DIFF
--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -6574,7 +6574,7 @@ run_lockstep_simulation_for_kernel_seq(scheduler_t &scheduler, int num_outputs,
                     assert(prev_tid[i] != tid_from_memref_tid(memref.instr.tid));
                 } else {
                     assert(for_syscall_seq || prev_tid[i] == INVALID_THREAD_ID ||
-                        prev_tid[i] == tid_from_memref_tid(memref.instr.tid));
+                           prev_tid[i] == tid_from_memref_tid(memref.instr.tid));
                 }
             }
             prev_tid[i] = tid_from_memref_tid(memref.instr.tid);


### PR DESCRIPTION
Moves access to the memref.marker.marker_type field inside the proper if-block for markers in the memref union. Without this, the bug manifests as a crash when the test is run in an environment with sanitizers.

Issue: #7157