### PR TITLE
i#7157 dyn inject: Add tid-pid before injected switch seq

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -652,6 +652,11 @@ void
 scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::insert_switch_tid_pid(
     input_info_t &input)
 {
+    // We may not have the input's pid if read_inputs_in_init was set to false,
+    // which happens today only in IPC readers which doesn't use this path.
+    assert(input.pid != INVALID_PID);
+    assert(input.tid != INVALID_THREAD_ID);
+
     // We need explicit tid,pid records so reader_t will see the new context.
     // We insert at the front, so we have reverse order.
     trace_entry_t pid;
@@ -1669,6 +1674,10 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::process_next_initial_record(
     uintptr_t marker_value;
     if (record_type_is_invalid(record)) // Sentinel on first call.
         return true;                    // Keep reading.
+    if (input.pid == INVALID_PID)
+        record_type_has_pid(record, input.pid);
+    if (input.tid == INVALID_THREAD_ID)
+        record_type_has_tid(record, input.tid);
     if (record_type_is_non_marker_header(record))
         return true; // Keep reading.
     if (!record_type_is_marker(record, marker_type, marker_value)) {
@@ -2770,40 +2779,50 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::on_context_switch(
         outputs_[output].tried_to_steal_on_idle = false;
     }
 
+    bool injected_switch_trace = false;
     // We want to insert the context switch records (which includes the new input's
     // tid and pid, and possibly the context switch sequence) on input-to-input and
     // idle-to-input cases. This is a better control point to do that than
     // set_cur_input. Here we get the stolen input events too, and we don't have
     // to filter out the init-time set_cur_input cases.
-
-    if (inputs_[new_input].pid != INVALID_PID) {
-        insert_switch_tid_pid(inputs_[new_input]);
+    if (!switch_sequence_.empty()) {
+        switch_type_t switch_type = sched_type_t::SWITCH_INVALID;
+        if ( // XXX: idle-to-input transitions are assumed to be process switches
+             // for now. But we may want to improve this heuristic.
+            prev_input == sched_type_t::INVALID_INPUT_ORDINAL ||
+            inputs_[prev_input].workload != inputs_[new_input].workload)
+            switch_type = sched_type_t::SWITCH_PROCESS;
+        else
+            switch_type = sched_type_t::SWITCH_THREAD;
+        if (switch_sequence_.find(switch_type) != switch_sequence_.end()) {
+            stream_status_t res = inject_kernel_sequence(switch_sequence_[switch_type],
+                                                         &inputs_[new_input]);
+            if (res == stream_status_t::STATUS_OK) {
+                injected_switch_trace = true;
+                ++outputs_[output].stats
+                      [memtrace_stream_t::SCHED_STAT_KERNEL_SWITCH_SEQUENCE_INJECTIONS];
+                VPRINT(this, 3,
+                       "Inserted %zu switch records for type %d from %d.%d to %d.%d\n",
+                       switch_sequence_[switch_type].size(), switch_type,
+                       prev_input != sched_type_t::INVALID_INPUT_ORDINAL
+                           ? inputs_[prev_input].workload
+                           : -1,
+                       prev_input, inputs_[new_input].workload, new_input);
+            } else if (res != stream_status_t::STATUS_EOF) {
+                return res;
+            }
+        }
     }
-    if (switch_sequence_.empty())
-        return stream_status_t::STATUS_OK;
-    switch_type_t switch_type = sched_type_t::SWITCH_INVALID;
-    if ( // XXX: idle-to-input transitions are assumed to be process switches
-         // for now. But we may want to improve this heuristic.
-        prev_input == sched_type_t::INVALID_INPUT_ORDINAL ||
-        inputs_[prev_input].workload != inputs_[new_input].workload)
-        switch_type = sched_type_t::SWITCH_PROCESS;
-    else
-        switch_type = sched_type_t::SWITCH_THREAD;
-    if (switch_sequence_.find(switch_type) == switch_sequence_.end())
-        return stream_status_t::STATUS_OK;
-    stream_status_t res =
-        inject_kernel_sequence(switch_sequence_[switch_type], &inputs_[new_input]);
-    if (res == stream_status_t::STATUS_OK) {
-        ++outputs_[output]
-              .stats[memtrace_stream_t::SCHED_STAT_KERNEL_SWITCH_SEQUENCE_INJECTIONS];
-        VPRINT(this, 3, "Inserted %zu switch records for type %d from %d.%d to %d.%d\n",
-               switch_sequence_[switch_type].size(), switch_type,
-               prev_input != sched_type_t::INVALID_INPUT_ORDINAL
-                   ? inputs_[prev_input].workload
-                   : -1,
-               prev_input, inputs_[new_input].workload, new_input);
-    } else if (res != stream_status_t::STATUS_EOF) {
-        return res;
+
+    // We do not need synthetic tid-pid records if the original ones from the
+    // input are coming up next (which happens when the input is scheduled
+    // for the first time), unless we're also injecting a context switch trace,
+    // in which case we need the synthetic tid-pid records prior to the injected
+    // sequence (note that the tid-pid and switch records are injected LIFO in
+    // the queue).
+    if (injected_switch_trace ||
+        inputs_[new_input].last_record_tid != INVALID_THREAD_ID) {
+        insert_switch_tid_pid(inputs_[new_input]);
     }
     return stream_status_t::STATUS_OK;
 }

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -6808,7 +6808,7 @@ test_kernel_switch_sequences()
         assert(stream0->get_instruction_ordinal() == 3);
         assert(stream0->get_input_interface()->get_instruction_ordinal() == 3);
         // The synthetic TRACE_TYPE_THREAD and TRACE_TYPE_PID for the new
-        // input before the injected context switch trace. This allow identifying
+        // input before the injected context switch trace. This allows identifying
         // the injected context switch sequence records with the new input's
         // tid/pid, like what the stream APIs do.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_THREAD,

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -6807,6 +6807,13 @@ test_kernel_switch_sequences()
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
         assert(stream0->get_instruction_ordinal() == 3);
         assert(stream0->get_input_interface()->get_instruction_ordinal() == 3);
+        // The synthetic TRACE_TYPE_THREAD and TRACE_TYPE_PID for the new
+        // input before the injected context switch trace. This allow identifying
+        // the injected context switch sequence records with the new input's
+        // tid/pid, like what the stream APIs do.
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_THREAD,
+                   TID_BASE + 2);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_PID, 1);
         // Injected context switch sequence.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 1,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
@@ -6817,11 +6824,7 @@ test_kernel_switch_sequences()
 
         // cpu0 at TID_BASE+2.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_HEADER);
-        // TODO i#7157: The TRACE_TYPE_THREAD and TRACE_TYPE_PID for the new
-        // input should also be before the injected context switch trace.
-        // This is so that the trace records also identify the context switch
-        // sequence records with the new input's tid/pid, like what the stream
-        // APIs do.
+        // Original tid-pid entries from the input.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_THREAD,
                    TID_BASE + 2);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_PID, 1);
@@ -6834,6 +6837,12 @@ test_kernel_switch_sequences()
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
         assert(stream0->get_instruction_ordinal() == 8);
         assert(stream0->get_input_interface()->get_instruction_ordinal() == 3);
+        // Synthetic tid-pid records.
+        check_next(
+            stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_THREAD,
+            static_cast<addr_t>((1ULL << MEMREF_ID_WORKLOAD_SHIFT) | (TID_BASE + 4)));
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_PID,
+                   static_cast<addr_t>((1ULL << MEMREF_ID_WORKLOAD_SHIFT) | 1));
         // Injected context switch sequence.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 2,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
@@ -6843,8 +6852,7 @@ test_kernel_switch_sequences()
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
         // cpu0 at TID_BASE+4.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_HEADER);
-        // TODO i#7157: The TRACE_TYPE_THREAD and TRACE_TYPE_PID for the new
-        // input should also be before the injected context switch trace.
+        // Original tid-pid records from the input.
         check_next(
             stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_THREAD,
             static_cast<addr_t>((1ULL << MEMREF_ID_WORKLOAD_SHIFT) | (TID_BASE + 4)));
@@ -6860,6 +6868,12 @@ test_kernel_switch_sequences()
         assert(stream0->get_instruction_ordinal() == 13);
         assert(stream0->get_input_interface()->get_instruction_ordinal() == 3);
 
+        // Synthetic tid-pid records.
+        check_next(
+            stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_THREAD,
+            static_cast<addr_t>((2ULL << MEMREF_ID_WORKLOAD_SHIFT) | (TID_BASE + 6)));
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_PID,
+                   static_cast<addr_t>((2ULL << MEMREF_ID_WORKLOAD_SHIFT) | 1));
         // Injected context switch sequence.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 2,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
@@ -6869,8 +6883,7 @@ test_kernel_switch_sequences()
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
         // cpu0 at TID_BASE+6.
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_HEADER);
-        // TODO i#7157: The TRACE_TYPE_THREAD and TRACE_TYPE_PID for the new
-        // input should also be before the injected context switch trace.
+        // Original tid-pid records from the input.
         check_next(
             stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_THREAD,
             static_cast<addr_t>((2ULL << MEMREF_ID_WORKLOAD_SHIFT) | (TID_BASE + 6)));


### PR DESCRIPTION
Adds synthetic records for the new input's tid and pid before injecting the context switch sequence. This is required so that the injected switch sequence is identified by the new input's tid and pid also by the trace records themselves, like what the stream APIs do.

Makes relevant changes to the expectation in test_kernel_switch_sequences. The existing test_record_scheduler shows correct operation in the non-injection case.

Issue: #7157