### PR TITLE
Reset last branch target after usage in the reader

### DIFF
--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -199,6 +199,9 @@ reader_t::process_input_entry()
             if (type_is_instr_branch(cur_ref_.instr.type) &&
                 !type_is_instr_direct_branch(cur_ref_.instr.type)) {
                 cur_ref_.instr.indirect_branch_target = last_branch_target_;
+                // Reset the last branch target so that we don't accidentally
+                // reuse it.
+                last_branch_target_ = 0;
             } else {
                 cur_ref_.instr.indirect_branch_target = 0;
             }


### PR DESCRIPTION
Resets the tracked last_branch_target_ in reader_t after we've created a memref using it. This is to avoid cases where the marker value is reused, which shouldn't ever happen. After this change, cases where there is a missing TRACE_MARKER_TYPE_BRANCH_TARGET before an indirect branch will clearly show a zero target instead of some non-zero value, which makes it easier to detect it as an error.