### PR TITLE
Set trace version in view_t with -skip_instrs

### DIFF
--- a/clients/drcachesim/tests/offline-view-skip-instrs.templatex
+++ b/clients/drcachesim/tests/offline-view-skip-instrs.templatex
@@ -2,9 +2,7 @@ Hello, world!
 Output format:
 <--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-#ifdef COMMENT
 // We must see some return instrs with a known target pc.
-#endif
 .*ret .*\(target .*
 .*
 View tool results:

--- a/clients/drcachesim/tests/offline-view-skip-instrs.templatex
+++ b/clients/drcachesim/tests/offline-view-skip-instrs.templatex
@@ -2,6 +2,9 @@ Hello, world!
 Output format:
 <--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
+#ifdef COMMENT
+// We must see some return instrs with a known target pc.
+#endif
 .*ret .*\(target .*
 .*
 View tool results:

--- a/clients/drcachesim/tests/offline-view-skip-instrs.templatex
+++ b/clients/drcachesim/tests/offline-view-skip-instrs.templatex
@@ -1,0 +1,8 @@
+Hello, world!
+Output format:
+<--record#-> <--instr#->: <Wrkld.Tid> <record details>
+------------------------------------------------------------
+.*ret \(target .*
+.*
+View tool results:
+    *[0-9]* : total instructions

--- a/clients/drcachesim/tests/offline-view-skip-instrs.templatex
+++ b/clients/drcachesim/tests/offline-view-skip-instrs.templatex
@@ -2,7 +2,7 @@ Hello, world!
 Output format:
 <--record#-> <--instr#->: <Wrkld.Tid> <record details>
 ------------------------------------------------------------
-.*ret \(target .*
+.*ret .*\(target .*
 .*
 View tool results:
     *[0-9]* : total instructions

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -181,9 +181,9 @@ view_t::init_decode_cache()
 }
 
 bool
-view_t::init_from_stream()
+view_t::init_from_filetype()
 {
-    if (init_from_stream_done_) {
+    if (init_from_filetype_done_) {
         return true;
     }
     // We will not see a TRACE_MARKER_TYPE_FILETYPE if -skip_instrs was used.
@@ -191,9 +191,6 @@ view_t::init_from_stream()
     // use the one from the stream instead.
     if (filetype_ == -1) {
         filetype_ = static_cast<offline_file_type_t>(serial_stream_->get_filetype());
-    }
-    if (trace_version_ == -1) {
-        trace_version_ = static_cast<int>(serial_stream_->get_version());
     }
     if (!init_decode_cache()) {
         return false;
@@ -236,7 +233,7 @@ view_t::init_from_stream()
     }
     disassemble_set_syntax(flags);
 
-    init_from_stream_done_ = true;
+    init_from_filetype_done_ = true;
     return true;
 }
 
@@ -251,9 +248,6 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             // We delay printing until we know the tid.
             if (trace_version_ == -1) {
                 trace_version_ = static_cast<int>(memref.marker.marker_value);
-                if (filetype_ != -1 && !init_from_stream()) {
-                    return false;
-                }
             } else if (trace_version_ != static_cast<int>(memref.marker.marker_value)) {
                 error_string_ = std::string("Version mismatch across files");
                 return false;
@@ -264,7 +258,7 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             // We delay printing until we know the tid.
             if (filetype_ == -1) {
                 filetype_ = static_cast<offline_file_type_t>(memref.marker.marker_value);
-                if (trace_version_ != -1 && !init_from_stream()) {
+                if (!init_from_filetype()) {
                     return false;
                 }
             } else if (filetype_ !=
@@ -581,10 +575,16 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     }
 
     // In some configurations (e.g., when using -skip_instrs), we may not see the
-    // TRACE_MARKER_TYPE_FILETYPE and TRACE_MARKER_TYPE_VERSION markers at all, so we get
-    // them from the memtrace_stream_t when we get to the instrs.
-    if (!init_from_stream()) {
+    // TRACE_MARKER_TYPE_FILETYPE marker at all, so we get it from the
+    // memtrace_stream_t when we get to the instrs.
+    if (!init_from_filetype()) {
         return false;
+    }
+    // In some configurations (e.g., when using -skip_instrs), we may not see the
+    // TRACE_MARKER_TYPE_VERSION marker at all, so we get it from the
+    // memtrace_stream_t when we get to the instrs.
+    if (trace_version_ == -1) {
+        trace_version_ = static_cast<int>(serial_stream_->get_version());
     }
     std::cerr << std::left << std::setw(name_width) << "ifetch" << std::right
               << std::setw(2) << memref.instr.size << " byte(s) @ 0x" << std::hex

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -581,8 +581,8 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     }
 
     // In some configurations (e.g., when using -skip_instrs), we may not see the
-    // TRACE_MARKER_TYPE_FILETYPE marker at all, so we get it from the
-    // memtrace_stream_t when we get to the instrs.
+    // TRACE_MARKER_TYPE_FILETYPE and TRACE_MARKER_TYPE_VERSION markers at all, so we get
+    // them from the memtrace_stream_t when we get to the instrs.
     if (!init_from_stream()) {
         return false;
     }

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -31,23 +31,23 @@
  */
 
 #ifndef _VIEW_H_
-#    define _VIEW_H_ 1
+#define _VIEW_H_ 1
 
-#    include <stdint.h>
+#include <stdint.h>
 
-#    include <iomanip>
-#    include <iostream>
-#    include <memory>
-#    include <string>
-#    include <unordered_map>
-#    include <unordered_set>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
 
-#    include "dr_api.h" // Must be before trace_entry.h from analysis_tool.h.
-#    include "analysis_tool.h"
-#    include "decode_cache.h"
-#    include "memref.h"
-#    include "memtrace_stream.h"
-#    include "raw2trace.h"
+#include "dr_api.h" // Must be before trace_entry.h from analysis_tool.h.
+#include "analysis_tool.h"
+#include "decode_cache.h"
+#include "memref.h"
+#include "memtrace_stream.h"
+#include "raw2trace.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -115,11 +115,11 @@ protected:
     virtual bool
     init_decode_cache();
 
-    // Initializes various other state based on the filetype and trace version. If the
-    // TRACE_MARKER_TYPE_FILETYPE or TRACE_MARKER_TYPE_VERSION were not seen, the filetype
-    // and trace version are acquired from the memtrace_stream_t object instead.
+    // Initializes various other state based on the filetype. If the
+    // TRACE_MARKER_TYPE_FILETYPE was not seen, the filetype is acquired from the
+    // memtrace_stream_t object instead.
     bool
-    init_from_stream();
+    init_from_filetype();
 
     inline void
     print_header()
@@ -178,7 +178,7 @@ protected:
     int64_t timestamp_record_ord_ = -1;
     int64_t version_record_ord_ = -1;
     int64_t filetype_record_ord_ = -1;
-    bool init_from_stream_done_ = false;
+    bool init_from_filetype_done_ = false;
     std::unique_ptr<decode_cache_t<disasm_info_t>> decode_cache_ = nullptr;
     memtrace_stream_t *serial_stream_ = nullptr;
 

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -31,23 +31,23 @@
  */
 
 #ifndef _VIEW_H_
-#define _VIEW_H_ 1
+#    define _VIEW_H_ 1
 
-#include <stdint.h>
+#    include <stdint.h>
 
-#include <iomanip>
-#include <iostream>
-#include <memory>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
+#    include <iomanip>
+#    include <iostream>
+#    include <memory>
+#    include <string>
+#    include <unordered_map>
+#    include <unordered_set>
 
-#include "dr_api.h" // Must be before trace_entry.h from analysis_tool.h.
-#include "analysis_tool.h"
-#include "decode_cache.h"
-#include "memref.h"
-#include "memtrace_stream.h"
-#include "raw2trace.h"
+#    include "dr_api.h" // Must be before trace_entry.h from analysis_tool.h.
+#    include "analysis_tool.h"
+#    include "decode_cache.h"
+#    include "memref.h"
+#    include "memtrace_stream.h"
+#    include "raw2trace.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -119,7 +119,7 @@ protected:
     // TRACE_MARKER_TYPE_FILETYPE was not seen, the filetype is acquired from the
     // memtrace_stream_t object instead.
     bool
-    init_from_filetype();
+    init_from_stream();
 
     inline void
     print_header()
@@ -178,7 +178,7 @@ protected:
     int64_t timestamp_record_ord_ = -1;
     int64_t version_record_ord_ = -1;
     int64_t filetype_record_ord_ = -1;
-    bool init_from_filetype_done_ = false;
+    bool init_from_stream_done_ = false;
     std::unique_ptr<decode_cache_t<disasm_info_t>> decode_cache_ = nullptr;
     memtrace_stream_t *serial_stream_ = nullptr;
 

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -115,9 +115,9 @@ protected:
     virtual bool
     init_decode_cache();
 
-    // Initializes various other state based on the filetype. If the
-    // TRACE_MARKER_TYPE_FILETYPE was not seen, the filetype is acquired from the
-    // memtrace_stream_t object instead.
+    // Initializes various other state based on the filetype and trace version. If the
+    // TRACE_MARKER_TYPE_FILETYPE or TRACE_MARKER_TYPE_VERSION were not seen, the filetype
+    // and trace version are acquired from the memtrace_stream_t object instead.
     bool
     init_from_stream();
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4607,6 +4607,9 @@ if (BUILD_CLIENTS)
         set(tool.drcacheoff.view_runsve 1)
       endif ()
 
+      torunonly_drcacheoff(view-skip-instrs ${ci_shared_app} ""
+        "@-tool@view@-sim_refs@16384@-skip_instrs@1" "")
+
       set(tool.drcacheoff.func_view_full_run ON) # Fails on Windows if truncated.
       torunonly_drcacheoff(func_view common.fib "-record_function fib|1"
         "@-tool@func_view" "only_5")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4609,6 +4609,7 @@ if (BUILD_CLIENTS)
 
       torunonly_drcacheoff(view-skip-instrs ${ci_shared_app} ""
         "@-tool@view@-sim_refs@16384@-skip_instrs@1" "")
+      unset(tool.drcacheoff.view-skip-instrs_rawtemp)
 
       set(tool.drcacheoff.func_view_full_run ON) # Fails on Windows if truncated.
       torunonly_drcacheoff(func_view common.fib "-record_function fib|1"


### PR DESCRIPTION
Ensures that the view_t sets the trace_version_ also when invoked with -skip_instrs. When -skip_instrs is specified, it causes the TRACE_MARKER_TYPE_VERSION trace entry to not be seen by the tool. In this case we need to initialize it from the stream API instead; this is same as what view_t already does for file type.

Without this fix, the view tool does not print the target pc for indirect branches like ret.

Adds a unit test that verifies that there's a ret instr with the target also shown, which fails without the fix.