### PR TITLE
i#7504 time scale: Fix just-fired timer bug

### DIFF
--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -423,28 +423,39 @@ scale_itimers(void *drcontext, bool inflate)
      */
     NOTIFY(2, "Scaling itimers\n");
     const int TIMER_TYPES[] = { ITIMER_REAL, ITIMER_VIRTUAL, ITIMER_PROF };
+    int res;
     for (int i = 0; i < sizeof(TIMER_TYPES) / sizeof(TIMER_TYPES[0]); ++i) {
+        NOTIFY(2, "Scaling itimer %d\n", i);
         struct itimerval val;
         // We use dr_invoke_syscall_as_app() because DR needs to intercept these to
         // interact with its multiplexing of app and client itimers.
-        int res =
-            dr_invoke_syscall_as_app(drcontext, SYS_getitimer, 2, TIMER_TYPES[i], &val);
-        if (res == 0 &&
-            (!is_timeval_zero(&val.it_interval) || !is_timeval_zero(&val.it_value))) {
-            if (inflate) {
-                inflate_timeval(drcontext, &val.it_interval);
-                inflate_timeval(drcontext, &val.it_value);
-            } else {
-                deflate_timeval(drcontext, &val.it_interval);
-                deflate_timeval(drcontext, &val.it_value);
-            }
-            int res = dr_invoke_syscall_as_app(drcontext, SYS_setitimer, 3,
-                                               TIMER_TYPES[i], &val, NULL);
-            if (res != 0)
-                NOTIFY(0, "Failed to call setitimer for id %d\n", i);
-        } else if (res != 0) {
+        res = dr_invoke_syscall_as_app(drcontext, SYS_getitimer, 2, TIMER_TYPES[i], &val);
+        if (res != 0) {
             NOTIFY(0, "Failed to call getitimer for id %d\n", i);
+            continue;
         }
+        if (is_timeval_zero(&val.it_value) && is_timeval_zero(&val.it_interval)) {
+            /* Disabled; nothing to do. */
+            continue;
+        }
+        /* If the timer just fired, we can have a zero it_value.  If we send that
+         * to setitimer we will disable the timer, so we reset it ourselves.
+         */
+        if (is_timeval_zero(&val.it_value)) {
+            val.it_value.tv_sec = val.it_interval.tv_sec;
+            val.it_value.tv_usec = val.it_interval.tv_usec;
+        }
+        if (inflate) {
+            inflate_timeval(drcontext, &val.it_interval);
+            inflate_timeval(drcontext, &val.it_value);
+        } else {
+            deflate_timeval(drcontext, &val.it_interval);
+            deflate_timeval(drcontext, &val.it_value);
+        }
+        res = dr_invoke_syscall_as_app(drcontext, SYS_setitimer, 3, TIMER_TYPES[i], &val,
+                                       NULL);
+        if (res != 0)
+            NOTIFY(0, "Failed to call setitimer for id %d\n", i);
     }
 }
 
@@ -487,6 +498,7 @@ scale_posix_timers(void *drcontext, bool inflate)
 #define LINE_BUF_SIZE 64
     char linebuf[FILE_BUF_SIZE];
     size_t filebuf_read = 0, filebuf_pos = 0;
+    int res;
     while (dr_get_line(fd, filebuf, BUFFER_SIZE_BYTES(filebuf), &filebuf_read,
                        &filebuf_pos, linebuf, BUFFER_SIZE_BYTES(linebuf))) {
         NOTIFY(2, "Read line: |%s|\n", linebuf);
@@ -500,47 +512,64 @@ scale_posix_timers(void *drcontext, bool inflate)
              * timers in the future).  We do not want to trigger our own syscall
              * events for these, and DR indeed does not raise client events here.
              */
-            int res =
-                dr_invoke_syscall_as_app(drcontext, SYS_timer_gettime, 2, id, &spec);
-            if (res == 0 &&
-                (!is_timespec_zero(&spec.it_interval) ||
-                 !is_timespec_zero(&spec.it_value))) {
-                if (inflate) {
-                    inflate_timespec(drcontext, &spec.it_interval);
-                    inflate_timespec(drcontext, &spec.it_value);
-                } else {
-                    deflate_timespec(drcontext, &spec.it_interval);
-                    deflate_timespec(drcontext, &spec.it_value);
-                }
-                int res = dr_invoke_syscall_as_app(drcontext, SYS_timer_settime, 4, id, 0,
-                                                   &spec, NULL);
-                if (res != 0)
-                    NOTIFY(0, "Failed to call timer_settime for id %d: %d\n", id, res);
-            } else if (res != 0) {
+            res = dr_invoke_syscall_as_app(drcontext, SYS_timer_gettime, 2, id, &spec);
+            if (res != 0) {
                 NOTIFY(0, "Failed to call timer_gettime for id %d: %d\n", id, res);
+                continue;
             }
+            if (is_timespec_zero(&spec.it_value) && is_timespec_zero(&spec.it_interval)) {
+                /* Disabled; nothing to do. */
+                continue;
+            }
+            /* If the timer just fired, we can have a zero it_value.  If we send that
+             * to timer_settime we will disable the timer, so we reset it ourselves.
+             */
+            if (is_timespec_zero(&spec.it_value)) {
+                spec.it_value.tv_sec = spec.it_interval.tv_sec;
+                spec.it_value.tv_nsec = spec.it_interval.tv_nsec;
+            }
+            if (inflate) {
+                inflate_timespec(drcontext, &spec.it_interval);
+                inflate_timespec(drcontext, &spec.it_value);
+            } else {
+                deflate_timespec(drcontext, &spec.it_interval);
+                deflate_timespec(drcontext, &spec.it_value);
+            }
+            res = dr_invoke_syscall_as_app(drcontext, SYS_timer_settime, 4, id, 0, &spec,
+                                           NULL);
+            if (res != 0)
+                NOTIFY(0, "Failed to call timer_settime for id %d: %d\n", id, res);
 #else
             itimerspec64_t spec;
             /* See above comment about dr_invoke_syscall_as_app(). */
-            int res =
-                dr_invoke_syscall_as_app(drcontext, SYS_timer_gettime64, 2, id, &spec);
-            if (res == 0 &&
-                (!is_timespec64_zero(&spec.it_interval) ||
-                 !is_timespec64_zero(&spec.it_value))) {
-                if (inflate) {
-                    inflate_timespec64(drcontext, &spec.it_interval);
-                    inflate_timespec64(drcontext, &spec.it_value);
-                } else {
-                    deflate_timespec64(drcontext, &spec.it_interval);
-                    deflate_timespec64(drcontext, &spec.it_value);
-                }
-                int res = dr_invoke_syscall_as_app(drcontext, SYS_timer_settime64, 4, id,
-                                                   0, &spec, NULL);
-                if (res != 0)
-                    NOTIFY(0, "Failed to call timer_settime64 for id %d: %d\n", id, res);
-            } else if (res != 0) {
+            res = dr_invoke_syscall_as_app(drcontext, SYS_timer_gettime64, 2, id, &spec);
+            if (res != 0) {
                 NOTIFY(0, "Failed to call timer_gettime64 for id %d: %d\n", id, res);
+                continue;
             }
+            if (is_timespec64_zero(&spec.it_value) &&
+                is_timespec64_zero(&spec.it_interval)) {
+                /* Disabled; nothing to do. */
+                continue;
+            }
+            /* If the timer just fired, we can have a zero it_value.  If we send that
+             * to timer_settime we will disable the timer, so we reset it ourselves.
+             */
+            if (is_timespec64_zero(&spec.it_value)) {
+                spec.it_value.tv_sec = spec.it_interval.tv_sec;
+                spec.it_value.tv_nsec = spec.it_interval.tv_nsec;
+            }
+            if (inflate) {
+                inflate_timespec64(drcontext, &spec.it_interval);
+                inflate_timespec64(drcontext, &spec.it_value);
+            } else {
+                deflate_timespec64(drcontext, &spec.it_interval);
+                deflate_timespec64(drcontext, &spec.it_value);
+            }
+            res = dr_invoke_syscall_as_app(drcontext, SYS_timer_settime64, 4, id, 0,
+                                           &spec, NULL);
+            if (res != 0)
+                NOTIFY(0, "Failed to call timer_settime64 for id %d: %d\n", id, res);
 #endif
         }
     }

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -499,7 +499,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'code_api|linux.clone-reset' => 1, # i#4604
                 'code_api|client.detach_test' => 1, # i#6764
                 'code_api|sample.callstack' => 1, # i#7394
-                'code_api|client.drx_time_scale-test' => 1, # i#7504
                 # These are from the long suite.
                 'common.decode-stress' => 1, # i#1807 Ignored for all options.
                 'code_api,opt_speed|common.fib' => 1, # i#1807: Undiagnosed timeout.


### PR DESCRIPTION
Fixes a bug where if a timer just fired right before drx_unregister_time_scaling() queries it in order to restore it to its app duration, the drx code will end up disabling the timer by leaving the "it_value" as 0.  This is fixed by resetting the timer ourselves by setting "it_value" to "it_interval".

Removes client.drx_time_scale-test from the ignore list.

Tested:
The client.drx_time_scale-test was failing every 1 to 4 runs locally; with this fix it now passes 50x in a row.
The test was also failing quite a bit on Github 32-bit which will serve as a regression test.

Issue: #7504