### PR TITLE
i#7499 vs2022: Update how-to-build docs

### DIFF
--- a/api/docs/building.dox
+++ b/api/docs/building.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -66,15 +66,15 @@ To build DynamoRIO on Linux, use the following commands as a guide.  This builds
 
 To build DynamoRIO on Windows, first install the following software.
 
-  - Visual Studio 2019.  Other versions are not officially supported as our automated tests use VS 2019.
-  - [CMake](http://cmake.org/cmake/resources/software.html). 3.7+ is required. When prompted, we recommend adding it to your PATH.
+  - Visual Studio 2022.  Other versions are not officially supported as our automated tests use VS 2022.
+  - [CMake](http://cmake.org/cmake/resources/software.html). 3.14+ is required. When prompted, we recommend adding it to your PATH.
   - Git.  Any flavor should do, including [Git on Windows](https://git-scm.com/download/win) or Cygwin git.
   - Perl.  We recommend either [Strawberry Perl](http://strawberryperl.com/) or Cygwin perl.
   - (optional) [Cygwin](http://cygwin.com).  Only needed for building documentation.  Select the doxygen package if you do install it.  (You can also select Cygwin's perl and git as alternatives to the links above.)
 
 Once these dependencies are installed, you need to generate your project and solution files for Visual Studio using CMake.  The easiest way to do this is to launch a cmd prompt with the right environment from the Visual Studio folder in the Start menu.
 
-To build 64-bit DynamoRIO in release mode, launch the `Visual Studio 2019 > x64 Native Tools Command Prompt for VS 2019` and run the following commands:
+To build 64-bit DynamoRIO in release mode, launch the `Visual Studio 2022 > x64 Native Tools Command Prompt for VS 2022` and run the following commands:
 
   ```
   # Get sources.
@@ -83,16 +83,16 @@ To build 64-bit DynamoRIO in release mode, launch the `Visual Studio 2019 > x64 
   # supported.
   $ cd dynamorio && mkdir build && cd build
   # Configure using cmake.  Pass in the path to your source directory.
-  $ cmake -G"Visual Studio 16" -A x64 ..
+  $ cmake -G"Visual Studio 17 2022" -A x64 ..
   # Build from the command line.  Alternatively, open ALL_BUILD.vcproj in Visual
   # Studio and build from there.  You must pass --config to work around a cmake
   # bug.  (http://www.cmake.org/Bug/view.php?id=11830)
   $ cmake --build . --config RelWithDebInfo
   # Run notepad under DR to see whether it worked.
-  $ bin32\drrun.exe notepad.exe
+  $ bin64\drrun.exe notepad.exe
   ```
 
-If you need a 32-bit build, choose `x86 Native Tools Command Prompt` and pass `-G"Visual Studio 16 2019" -A Win32` to cmake.
+If you need a 32-bit build, choose `x86 Native Tools Command Prompt` and pass `-G"Visual Studio 17 2022" -A Win32` to cmake.
 
 An alternative to the command prompt is to execute the appropriate vcvars.bat command for your compiler in your shell of choice.
 
@@ -112,7 +112,7 @@ $ make -j
 
 or on Windows:
 ```
-$ cmake -G"Visual Studio 16" -A Win32 .. -DDEBUG=ON
+$ cmake -G"Visual Studio 17 2022" -A x64 .. -DDEBUG=ON
 $ cmake --build . --config Debug
 ```
 
@@ -121,7 +121,7 @@ produce a debug build currently.
 
 For 64-bit build on Windows:
 ```
-$ cmake -G"Visual Studio 16" -A x64 .. -DDEBUG=ON
+$ cmake -G"Visual Studio 17 2022" -A x64 .. -DDEBUG=ON
 $ cmake --build . --config Debug
 ```
 
@@ -145,7 +145,7 @@ In order to build you'll need the following packages:
 
   - gcc
   - binutils
-  - cmake (at least version 3.7)
+  - cmake (at least version 3.14)
   - perl
 
 In order to build the documentation, you will additionally need:
@@ -350,7 +350,7 @@ Support for aarch64-on-x86 on Windows is not yet finished; nor is support for ot
 ## Compiler
 
 First, you need the compiler, linker, and associated tools.
-Install Visual Studio 2019 which is the version used by our automated tests.
+Install Visual Studio 2022 which is the version used by our automated tests.
 
 You need to use a shell with command line support for using your
 compiler.  For example, this could be the `cmd` shell or a Cygwin shell.
@@ -368,7 +368,7 @@ command prompt from the Visual Studio Start menu folder, or run the
 
 ## CMake
 
-You need CMake (version 3.7+) for Windows (*not* for Cygwin, as we need to pass paths
+You need CMake (version 3.14+) for Windows (*not* for Cygwin, as we need to pass paths
 with drive letters to our compiler).  You can download a binary installation here:
 
   http://www.cmake.org/cmake/resources/software.html
@@ -392,7 +392,8 @@ TH`.
 If you wish to run your build commands in a Cygwin bash shell, you will need to
 set up your environment the way that Visual Studio sets up the environment.
 Below is an example that supports multiple versions of Visual Studio installed
-simultaneously.  It assumes that `/cygdrive/c` has been mounted as `/c`.
+simultaneously; however, it has not been updated for Visual Studio 2022.
+It assumes that `/cygdrive/c` has been mounted as `/c`.
 Note the use of *mixed paths* (i.e., using a drive letter but forward
 slashes) for all variables except for `PATH`:
 
@@ -549,7 +550,7 @@ cd build
 cmake-gui ..
 ```
 
-Press Configure.  On Windows, select **Visual Studio 16 2019**.  On Linux, select **Unix Makefiles**.
+Press Configure.  On Windows, select **Visual Studio 17 2022**.  On Linux, select **Unix Makefiles**.
 
 If you are on Linux, `ccmake`, a curses-based GUI, can be used instead of `cmake-gui`;
 it generates **Unix Makefiles** by default.  In `ccmake`, press `c` to configure.
@@ -642,10 +643,10 @@ cd build
 ```
  - step 4: configure using cmake
 \verbatim
-E:\dynamorio\build\>"c:\Program Files (x86)\CMake 3.7\bin\cmake-gui.exe" ..\
+E:\dynamorio\build\>"c:\Program Files (x86)\CMake 3.14\bin\cmake-gui.exe" ..\
 \endverbatim
    - step 4.1: click "Configure" button
-   - step 4.2: select "Visual studio 16"
+   - step 4.2: select "Visual studio 17 2022"
    - step 4.3: generate configuration file
  - step 5: build and install
 \verbatim
@@ -661,7 +662,7 @@ On Windows:
 ```
 mkdir build
 cd build
-cmake -G"Visual studio 16" -DBUILD_DOCS:BOOL=OFF ..
+cmake -G"Visual studio 17 2022" -A x64 -DBUILD_DOCS:BOOL=OFF ..
 cmake --build . --config Release
 ```
 
@@ -722,12 +723,12 @@ flag is set by default for not only parallel project builds but parallel file
 builds.  The fastest DynamoRIO build is a Visual Studio build from
 the command line.
 
-First, DynamoRIO requires CMake version 3.7 or higher.
+First, DynamoRIO requires CMake version 3.14 or higher.
 
 Then you can generate the Visual Studio project files with something like this:
 
 ```
-cmake -G"Visual studio 16" -DDEBUG=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF ../src
+cmake -G"Visual studio 17 2022" -A x64 -DDEBUG=ON -DCMAKE_RULE_MESSAGES:BOOL=OFF ../src
 ```
 
 You can build from the command line (actually for any generator) with this:
@@ -865,7 +866,7 @@ CMAKE_MAKE_PROGRAM variable at configuration time.  In a Visual Studio Command
 Prompt, MSBuild is on the PATH, so the absolute path is not needed:
 
 ```
-cmake -G"Visual studio 16" -DCMAKE_MAKE_PROGRAM:FILEPATH=MSBuild ../src
+cmake -G"Visual studio 17" A x64 -DCMAKE_MAKE_PROGRAM:FILEPATH=MSBuild ../src
 ```
 
 Don't forget to pass the "/m" flag (after "--") as shown above when building.


### PR DESCRIPTION
Updates the Windows how-to-build docs to use VS2022 instead of VS2019.

I tested the Quick Start instructions on a Windows machine.

Issue: #7499