### PR TITLE
i#7504 time scale: Fix DR itimer bug

### DIFF
--- a/clients/drcachesim/tests/scale_time.cpp
+++ b/clients/drcachesim/tests/scale_time.cpp
@@ -205,6 +205,24 @@ post_process(const std::string &out_subdir)
     return outdir;
 }
 
+static void
+event_sample(void *drcontext, dr_mcontext_t *mcontext)
+{
+    // Do nothing.
+}
+
+extern "C" {
+/* This dr_client_main should be called instead of the one in tracer.cpp. */
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    drmemtrace_client_main(id, argc, argv);
+    // Test itimer multiplexing interacting with scaling.
+    bool ok = dr_set_itimer(ITIMER_VIRTUAL, 10, event_sample);
+    assert(ok);
+}
+}
+
 static std::string
 gather_trace(const std::string &tracer_ops, const std::string &out_subdir)
 {

--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -8416,10 +8416,16 @@ handle_post_getitimer(dcontext_t *dcontext, bool success, int which,
         IF_DEBUG(ok =)
         safe_write_ex(&cur_timer->it_interval, sizeof(val), &val, NULL);
         ASSERT(ok);
-        if (d_r_safe_read(&cur_timer->it_value, sizeof(val), &val)) {
-            /* subtract the difference between last-asked-for value
-             * and current value to reflect elapsed time
+        if ((*info->itimer)[which].app.value == 0) {
+            IF_DEBUG(ok =)
+            safe_write_ex(&cur_timer->it_value, sizeof(val), &val, NULL);
+            ASSERT(ok);
+        } else if (d_r_safe_read(&cur_timer->it_value, sizeof(val), &val)) {
+            /* Subtract the difference between last-asked-for value
+             * and current value to reflect elapsed time.
              */
+            ASSERT((*info->itimer)[which].app.value >
+                   ((*info->itimer)[which].actual.value - timeval_to_usec(&val)));
             uint64 left = (*info->itimer)[which].app.value -
                 ((*info->itimer)[which].actual.value - timeval_to_usec(&val));
             usec_to_timeval(left, &val);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4801,7 +4801,7 @@ if (BUILD_CLIENTS)
         add_api_exe(tool.drcacheoff.scale_time
           ${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/scale_time.cpp
           OFF ON)
-        use_DynamoRIO_static_client(tool.drcacheoff.scale_time drmemtrace_static)
+        use_DynamoRIO_static_client(tool.drcacheoff.scale_time drmemtrace_nomain)
         use_DynamoRIO_drmemtrace_tracer(tool.drcacheoff.scale_time)
         target_link_libraries(tool.drcacheoff.scale_time drmemtrace_raw2trace
           drmemtrace_analyzer test_helpers rt)


### PR DESCRIPTION
Fixes a bug in DR handling of getitimer() that causes drx timer scaling to set the wrong value when the client uses dr_set_itimer(), which can result in crashes from timer signals delivered post-attach when the app has no handler.

Adds dr_set_itimer() to the tool.drcacheoff.scale_time test which prints `Failed to call setitimer for id 1: -22` without the fix.

Issue: #7504