### PR TITLE
i#7533: Pass the tracing window number in self-nudge to create a memdump.

### DIFF
--- a/clients/drcachesim/tracer/instr_counter.cpp
+++ b/clients/drcachesim/tracer/instr_counter.cpp
@@ -216,14 +216,20 @@ hit_instr_count_threshold(app_pc next_pc)
         !reached_trace_after_instrs.load(std::memory_order_acquire)) {
         NOTIFY(0, "Hit delay threshold: enabling tracing.\n");
         if (op_memdump_on_window.get_value()) {
-            dr_nudge_client(client_id, TRACER_NUDGE_MEM_DUMP);
+            dr_nudge_client(
+                client_id,
+                (static_cast<uint64>(TRACER_NUDGE_MEM_DUMP) << TRACER_NUDGE_TYPE_SHIFT) |
+                    tracing_window.load(std::memory_order_acquire));
         }
         retrace_start_timestamp.store(instru_t::get_timestamp());
     } else {
         NOTIFY(0, "Hit retrace threshold: enabling tracing for window #%zd.\n",
                tracing_window.load(std::memory_order_acquire));
         if (op_memdump_on_window.get_value()) {
-            dr_nudge_client(client_id, TRACER_NUDGE_MEM_DUMP);
+            dr_nudge_client(
+                client_id,
+                (static_cast<uint64>(TRACER_NUDGE_MEM_DUMP) << TRACER_NUDGE_TYPE_SHIFT) |
+                    tracing_window.load(std::memory_order_acquire));
         }
         retrace_start_timestamp.store(instru_t::get_timestamp());
         if (op_offline.get_value())

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -537,7 +537,7 @@ event_pre_detach()
 static void
 event_nudge(void *drcontext, uint64 arg)
 {
-    if (arg == TRACER_NUDGE_MEM_DUMP) {
+    if ((arg >> TRACER_NUDGE_TYPE_SHIFT) == TRACER_NUDGE_MEM_DUMP) {
 #ifdef WINDOWS
         /* TODO i#7508: raw2trace fails with "Non-module instructions found with no
          * encoding information.". This occurs on Windows when capturing memory dumps at
@@ -561,7 +561,7 @@ event_nudge(void *drcontext, uint64 arg)
             if (op_split_windows.get_value()) {
                 dr_snprintf(windir, BUFFER_SIZE_ELEMENTS(windir),
                             "%s%s" WINDOW_SUBDIR_FORMAT, logsubdir, DIRSEP,
-                            tracing_window.load(std::memory_order_acquire));
+                            arg & TRACER_NUDGE_VALUE_MASK);
                 NULL_TERMINATE_BUFFER(windir);
                 spec.elf_output_directory = windir;
             }

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -181,7 +181,7 @@ enum {
     BBDUP_MODE_L0_FILTER = 4, /* Address tracing with L0_filter. */
 };
 
-/* dr_nudge_client takes a 64 bits argument. We use the most significant 8 bits as the
+/* dr_nudge_client takes a 64 bit argument. We use the most significant 8 bits as the
  * type and the least significant 56 bits to pass a value to the client.
  */
 #define TRACER_NUDGE_TYPE_SHIFT 56

--- a/clients/drcachesim/tracer/tracer.h
+++ b/clients/drcachesim/tracer/tracer.h
@@ -181,6 +181,12 @@ enum {
     BBDUP_MODE_L0_FILTER = 4, /* Address tracing with L0_filter. */
 };
 
+/* dr_nudge_client takes a 64 bits argument. We use the most significant 8 bits as the
+ * type and the least significant 56 bits to pass a value to the client.
+ */
+#define TRACER_NUDGE_TYPE_SHIFT 56
+#define TRACER_NUDGE_VALUE_MASK 0x00ffffffffffffffLL
+
 /* Tracer nudge types. */
 enum {
     TRACER_NUDGE_MEM_DUMP = 0, /* Capture a memory dump. */


### PR DESCRIPTION
https://github.com/DynamoRIO/dynamorio/pull/7509 introduced a race condition affecting tracing_window access.

This occurs when hit_instr_count_threshold() sends a self-nudge. Before event_nudge() can read tracing_window, a new window might open, incrementing its value. This leads to memory dump files being written to the incorrect (next) window's directory, or failing to write if that directory hasn't yet been created.

Manual test:

Ran "drrun -t drmemtrace -offline -trace_instr_intervals_file %{TRACE_FILE} -memdump_on_window" to capture multiple traces and memory dumps with and without the change. 

There were missing memory dump files without the change. And all memory dump files were captured with the change.

Fixes #7553  