### PR TITLE
i#7230 simrefs: Add -exit_after_records drmemtrace option

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -193,6 +193,8 @@ Further non-compatibility-affecting changes include:
    application made it, meaning it goes through DR's handling.
  - Added drx_register_time_scaling() which scales timers on UNIX to align with
    the slowdown of heavyweight instrumentation.
+ - Added a new drmemtrace option -exit_after_records which applies to all
+   tools and exits after N records.
 
 **************************************************
 <hr>

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -195,6 +195,7 @@ Further non-compatibility-affecting changes include:
    the slowdown of heavyweight instrumentation.
  - Added a new drmemtrace option -exit_after_records which applies to all
    tools and exits after N records.
+ - Added get_output_record_ordinal() to the drmemtrace scheduler.
 
 **************************************************
 <hr>

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -617,6 +617,13 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_serial(analyzer_worker_data_t &
             return;
         }
         for (int i = 0; i < num_tools_; ++i) {
+            if (exit_after_records_ > 0 &&
+                worker.stream->get_record_ordinal() > exit_after_records_) {
+                VPRINT(this, 1,
+                       "Worker %d exiting after requested record count on shard %s\n",
+                       worker.index, worker.stream->get_stream_name().c_str());
+                return;
+            }
             if (tool_exited.find(i) != tool_exited.end())
                 continue;
             if (!tools_[i]->process_memref(record)) {
@@ -757,6 +764,13 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks_internal(
             return false;
         }
         for (int i = 0; i < num_tools_; ++i) {
+            if (exit_after_records_ > 0 &&
+                worker->stream->get_record_ordinal() > exit_after_records_) {
+                VPRINT(this, 1,
+                       "Worker %d exiting after requested record count on shard %s\n",
+                       worker->index, worker->stream->get_stream_name().c_str());
+                return true;
+            }
             if (tool_exited.find(i) != tool_exited.end())
                 continue;
             if (!tools_[i]->parallel_shard_memref(

--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -618,7 +618,10 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_serial(analyzer_worker_data_t &
         }
         for (int i = 0; i < num_tools_; ++i) {
             if (exit_after_records_ > 0 &&
-                worker.stream->get_record_ordinal() > exit_after_records_) {
+                // We can't use get_record_ordinal() because it's the input
+                // ordinal due to SCHEDULER_USE_INPUT_ORDINALS.  We do not want to
+                // include skipped records here.
+                worker.stream->get_output_record_ordinal() > exit_after_records_) {
                 VPRINT(this, 1,
                        "Worker %d exiting after requested record count on shard %s\n",
                        worker.index, worker.stream->get_stream_name().c_str());
@@ -765,7 +768,10 @@ analyzer_tmpl_t<RecordType, ReaderType>::process_tasks_internal(
         }
         for (int i = 0; i < num_tools_; ++i) {
             if (exit_after_records_ > 0 &&
-                worker->stream->get_record_ordinal() > exit_after_records_) {
+                // We can't use get_record_ordinal() because it's the input
+                // ordinal due to SCHEDULER_USE_INPUT_ORDINALS.  We do not want to
+                // include skipped records here.
+                worker->stream->get_output_record_ordinal() > exit_after_records_) {
                 VPRINT(this, 1,
                        "Worker %d exiting after requested record count on shard %s\n",
                        worker->index, worker->stream->get_stream_name().c_str());

--- a/clients/drcachesim/analyzer.h
+++ b/clients/drcachesim/analyzer.h
@@ -432,6 +432,7 @@ protected:
     const char *output_prefix_ = "[analyzer]";
     uint64_t skip_instrs_ = 0;
     uint64_t skip_to_timestamp_ = 0;
+    uint64_t exit_after_records_ = 0;
     uint64_t interval_microseconds_ = 0;
     uint64_t interval_instr_count_ = 0;
     int verbosity_ = 0;

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -400,6 +400,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
         this->success_ = false;
         return;
     }
+    this->exit_after_records_ = op_exit_after_records.get_value();
     this->interval_microseconds_ = op_interval_microseconds.get_value();
     this->interval_instr_count_ = op_interval_instr_count.get_value();
     // Initial measurements show it's sometimes faster to keep the parallel model

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -401,6 +401,14 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
         return;
     }
     this->exit_after_records_ = op_exit_after_records.get_value();
+    if (this->exit_after_records_ > 0 &&
+        (op_sim_refs.specified() || op_skip_refs.get_value() > 0 ||
+         op_warmup_refs.get_value() > 0 || op_warmup_fraction.get_value() > 0.)) {
+        this->error_string_ = "Usage error: -exit_after_records is not compatible with "
+                              "-sim_refs, -skip_refs, -warmup_refs, or -warmup_fraction";
+        this->success_ = false;
+        return;
+    }
     this->interval_microseconds_ = op_interval_microseconds.get_value();
     this->interval_instr_count_ = op_interval_instr_count.get_value();
     // Initial measurements show it's sometimes faster to keep the parallel model

--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -401,7 +401,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::analyzer_multi_tmpl_t()
         return;
     }
     this->exit_after_records_ = op_exit_after_records.get_value();
-    if (this->exit_after_records_ > 0 &&
+    if (op_exit_after_records.specified() &&
         (op_sim_refs.specified() || op_skip_refs.get_value() > 0 ||
          op_warmup_refs.get_value() > 0 || op_warmup_fraction.get_value() > 0.)) {
         this->error_string_ = "Usage error: -exit_after_records is not compatible with "

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -709,17 +709,19 @@ droption_t<bytesize_t> op_sim_refs(
     "If -skip_refs is specified, the analyzed records start after the skipped ones end; "
     "similarly, if -warmup_refs or -warmup_fraction is specified, the warmup records "
     "come prior to the -sim_refs records.  Use -exit_after_records for a similar feature "
-    "that works on all tools (but does not work with -warmup_*).");
+    "that works on all tools (but does not work with -warmup_*, -sim_refs, or "
+    "-skip_refs).");
 
 droption_t<bytesize_t> op_exit_after_records(
     DROPTION_SCOPE_FRONTEND, "exit_after_records", bytesize_t(1ULL << 63),
     "Limits analyzers to this many records",
-    "Causes trace analyzers to only analyze this many records and then exit.  If records "
-    "or instructions are skipped (-skip_records or -skip_instructions), that happens "
+    "Causes trace analyzers to only analyze this many records and then exit.  If "
+    "instructions are skipped (-skip_instrs), that happens "
     "first before record counting starts here.  This is similar to -sim_refs, though "
-    "it is implemented in the framework and so applies to all tools.  However, it "
-    "does not work with -warmup_fraction.  For traces with multiple shards, each shard "
-    "separately stops when it reaches this count within the shard.");
+    "it is implemented in the framework and so applies to all tools.  This option is not "
+    "compatible with -sim_refs, -skip_refs, -warmup_refs, or -warmup_fraction. "
+    "For traces with multiple shards, each shard separately stops when it reaches this "
+    "count within the shard.");
 
 droption_t<std::string>
     op_view_syntax(DROPTION_SCOPE_FRONTEND, "view_syntax", "att/arm/dr/riscv",

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -705,12 +705,21 @@ droption_t<bytesize_t> op_sim_refs(
     DROPTION_SCOPE_FRONTEND, "sim_refs", bytesize_t(1ULL << 63),
     "Number of records to analyze",
     "This option is honored by certain tools such as the cache and TLB simulators and "
-    "the view tool.  It causes them to only analyze this many records and ignore all "
-    "subsequent records.  If -skip_refs is specified, the analyzed records start after "
-    "the skipped ones end; similarly, if -warmup_refs is specified, the warmup records "
-    "come prior to the -sim_refs records.  Since the framework is still iterating over "
-    "all the records and it is the tool who is ignoring those outside of this range, a "
-    "large trace may still take time even with a small value for this option.");
+    "the view tool.  It causes them to only analyze this many records and then exit. "
+    "If -skip_refs is specified, the analyzed records start after the skipped ones end; "
+    "similarly, if -warmup_refs or -warmup_fraction is specified, the warmup records "
+    "come prior to the -sim_refs records.  Use -exit_after_records for a similar feature "
+    "that works on all tools (but does not work with -warmup_*).");
+
+droption_t<bytesize_t> op_exit_after_records(
+    DROPTION_SCOPE_FRONTEND, "exit_after_records", bytesize_t(1ULL << 63),
+    "Limits analyzers to this many records",
+    "Causes trace analyzers to only analyze this many records and then exit.  If records "
+    "or instructions are skipped (-skip_records or -skip_instructions), that happens "
+    "first before record counting starts here.  This is similar to -sim_refs, though "
+    "it is implemented in the framework and so applies to all tools.  However, it "
+    "does not work with -warmup_fraction.  For traces with multiple shards, each shard "
+    "separately stops when it reaches this count within the shard.");
 
 droption_t<std::string>
     op_view_syntax(DROPTION_SCOPE_FRONTEND, "view_syntax", "att/arm/dr/riscv",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -179,6 +179,8 @@ extern dynamorio::droption::droption_t<uint64_t> op_skip_to_timestamp;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t> op_warmup_refs;
 extern dynamorio::droption::droption_t<double> op_warmup_fraction;
 extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t> op_sim_refs;
+extern dynamorio::droption::droption_t<dynamorio::droption::bytesize_t>
+    op_exit_after_records;
 extern dynamorio::droption::droption_t<std::string> op_config_file;
 extern dynamorio::droption::droption_t<bool> op_add_noise_generator;
 extern dynamorio::droption::droption_t<unsigned int> op_report_top;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1061,6 +1061,15 @@ public:
         uint64_t
         get_record_ordinal() const override;
         /**
+         * Identical to get_record_ordinal() but ignores the
+         * #SCHEDULER_USE_INPUT_ORDINALS flag.
+         */
+        uint64_t
+        get_output_record_ordinal() const
+        {
+            return cur_ref_count_;
+        }
+        /**
          * Returns the count of instructions from the start of the trace to this point.
          * For record_scheduler_t, if any encoding records or the internal record
          * TRACE_MARKER_TYPE_BRANCH_TARGET records are present prior to an instruction

--- a/clients/drcachesim/tests/offline-all-early.templatex
+++ b/clients/drcachesim/tests/offline-all-early.templatex
@@ -1,0 +1,8 @@
+.*
+View tool results:
+              3 : total instructions
+
+===========================================================================
+Opcode mix tool results:
+              3 : total executed instructions
+.*

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4589,9 +4589,10 @@ if (BUILD_CLIENTS)
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.one_early_rawtemp ON) # no preprocessor
 
-      # Test that -exit_after_records exits all tools.
+      # Test that -exit_after_records exits all tools, and that it starts
+      # counting *after* -skip_instrs.
       torunonly_api(tool.drcacheoff.all_early "${drcachesim_path}" "offline-all-early" ""
-        "-verbose;1;-tool;view:opcode_mix;-exit_after_records;10;-infile;${zip_path}"
+        "-verbose;1;-tool;view:opcode_mix;-skip_instrs;10;-exit_after_records;5;-infile;${zip_path}"
         OFF OFF)
       set(tool.drcacheoff.all_early_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4588,6 +4588,14 @@ if (BUILD_CLIENTS)
       set(tool.drcacheoff.one_early_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.one_early_rawtemp ON) # no preprocessor
+
+      # Test that -exit_after_records exits all tools.
+      torunonly_api(tool.drcacheoff.all_early "${drcachesim_path}" "offline-all-early" ""
+        "-verbose;1;-tool;view:opcode_mix;-exit_after_records;10;-infile;${zip_path}"
+        OFF OFF)
+      set(tool.drcacheoff.all_early_basedir
+        "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
+      set(tool.drcacheoff.all_early_rawtemp ON) # no preprocessor
     endif ()
 
     # We run common.decode-bad to test markers for faults


### PR DESCRIPTION
Adds a new drmemtrace option -exit_after_records which applies to all tools and exits after N records.  However, it does not work with dr$sim's -warmup_fraction, and so we do not alias -sim_refs to this new option but keep -sim_refs separate and counted inside the simulators (and view tool: we could remove it there but without aliasing the old option it is simpler to leave it).

Updates the -sim_refs option docs to reflect #7549's exit and to refer to -exit_after_records for a similar option that works with all tools.

Adds get_output_record_ordinal() to the drmemtrace scheduler, required to get the record count *after* -skip_instrs.

Adds a test that verifies multiple tools all exit and that this starts counting after -skip_instrs.

Adds an entry to the release notes.

Issue: #7230