### PR TITLE
AArch64: Set unused parts of sve_context to zero.

### DIFF
--- a/core/unix/signal_linux_aarch64.c
+++ b/core/unix/signal_linux_aarch64.c
@@ -306,6 +306,8 @@ mcontext_to_sigcontext_simd(sig_full_cxt_t *sc_full, priv_mcontext_t *mc)
         esr->size = sizeof(struct esr_context);
 
         struct sve_context *sve = (void *)((byte *)esr + sizeof(struct esr_context));
+        const struct sve_context sve_zero = { 0 };
+        *sve = sve_zero;
         sve->head.magic = SVE_MAGIC;
         sve->vl = proc_get_vector_length_bytes();
         const uint quads_per_vector = sve_vecquad_from_veclen(sve->vl);


### PR DESCRIPTION
It was observed that all the signal tests were failing with non-debug builds on SVE hardware with recent kernels: rt_sigreturn was causing a segfault (which is confusing to debug because the PC value is taken from the sigframe). The kernel was generating the segfault because struct sve_context now has a "flags" member immediately after the "vl" member and this field contained nonsense. Rather than add the "flags" member we set the entire struct to zero before setting the fields we know about, which is what we should have done in the first place: a field called "__reserved" should generally be set to zero rather than left uninitialised. We will probably add the "flags" member later.