### PR TITLE
i#7562: Properly handle redirected libc open()

### DIFF
--- a/core/os_shared.h
+++ b/core/os_shared.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -853,6 +853,10 @@ os_get_disk_free_space(/*IN*/ file_t file_handle,
                        /*OUT*/ uint64 *AvailableQuotaBytes /*OPTIONAL*/,
                        /*OUT*/ uint64 *TotalQuotaBytes /*OPTIONAL*/,
                        /*OUT*/ uint64 *TotalVolumeBytes /*OPTIONAL*/);
+file_t
+redirect_open(const char *fname, int flags, int mode);
+void
+redirect_close(file_t f);
 
 #ifdef PROFILE_RDTSC
 extern uint kilo_hertz;

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1657,8 +1657,8 @@ static const redirect_import_t redirect_imports[] = {
      * + C++ operators in case they don't just call libc malloc?
      */
     /* We redirect these for fd isolation. */
-    { "open", (app_pc)os_open_protected },
-    { "close", (app_pc)os_close_protected },
+    { "open", (app_pc)redirect_open },
+    { "close", (app_pc)redirect_close },
     /* These libc routines can call pthread functions and cause hangs (i#4928) so
      * we use our syscall wrappers instead.
      */

--- a/suite/tests/client-interface/file_io.dll.c
+++ b/suite/tests/client-interface/file_io.dll.c
@@ -552,7 +552,11 @@ test_redirect(void)
     file_t fd = dr_open_file(path, DR_FILE_WRITE_OVERWRITE);
     dr_write_file(fd, contents, strlen(contents));
     dr_close_file(fd);
+    /* Now open with libc open() and O_RDWR as a regression test with the trigger
+     * of the i#7562 bug where O_RDWR leads to file truncation (now fixed).
+     */
     int libc_fd = open(path, O_RDWR, 0666);
+    /* Ensure it's not truncated. */
     char buf[64] = {};
     ssize_t amount = read(libc_fd, buf, strlen(contents) + 1);
     NULL_TERMINATE_BUFFER(buf);

--- a/suite/tests/client-interface/file_io.dll.c
+++ b/suite/tests/client-interface/file_io.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2007-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -40,6 +40,7 @@
 #ifdef WINDOWS
 #    include <windows.h>
 #else
+#    include <fcntl.h>
 #    include <stdlib.h>
 #    include <unistd.h>
 #    include <time.h>
@@ -64,6 +65,8 @@ static void
 test_times(void);
 static void
 test_vfprintf(void);
+static void
+test_redirect(void);
 
 byte *
 find_prot_edge(const byte *start, uint prot_flag)
@@ -319,6 +322,8 @@ dr_init(client_id_t id)
     test_times();
 
     test_vfprintf();
+
+    test_redirect();
 }
 
 /* Creates a closed, unique temporary file and returns its filename.
@@ -534,4 +539,25 @@ static void
 test_vfprintf(void)
 {
     test_vfprintf_helper(STDERR, "vfprintf check: %d\n", 1234);
+}
+
+static void
+test_redirect(void)
+{
+#ifdef LINUX
+    /* Test the private loader correctly passing libc open() flags (i#7562). */
+    char path[MAXIMUM_PATH];
+    const char *contents = "abcdefg";
+    get_temp_filename(path);
+    file_t fd = dr_open_file(path, DR_FILE_WRITE_OVERWRITE);
+    dr_write_file(fd, contents, strlen(contents));
+    dr_close_file(fd);
+    int libc_fd = open(path, O_RDWR, 0666);
+    char buf[64] = {};
+    ssize_t amount = read(libc_fd, buf, strlen(contents) + 1);
+    NULL_TERMINATE_BUFFER(buf);
+    if (strcmp(buf, contents) != 0)
+        dr_fprintf(STDERR, "libc view != DR view\n");
+    close(libc_fd);
+#endif
 }


### PR DESCRIPTION
Fixes the private loader's redirect of libc open() to a new function that properly handles the flags, instead of the old redirect which treated them as DR's custom flags.

Adds a test that hits the truncation described in the issue and so fails without the fix.

Also tested on the /dev/shm scenario described on the users list https://groups.google.com/g/dynamorio-users/c/kZHTGiIUn8Y/m/rSurDOWeAQAJ.

Fixes #7562