### PR TITLE
i#7552: Mark client.attach-memory-dump-syscall-test test as flaky on x86-64.

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -512,6 +512,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             %ignore_failures_64 = (
                 'code_api|api.rseq' => 1, # i#6185 i#1807
                 'code_api|tool.drcacheoff.burst_threadfilter' => 1, # i#2941
+                'code_api|client.attach-memory-dump-syscall-test' => 1, # i#7552
                 'code_api|client.attach_test' => 1, # i#6452
                 'code_api|client.detach_test' => 1, # i#6536
                 # These are from the long suite.


### PR DESCRIPTION
client.attach-memory-dump-syscall-test test failed with missing "syscall" line in x86-64 run.

Mark this test as flaky until we have a fix for it.

Issue: #7552 