### PR TITLE
i#7046 memory dump: Store application's tpidr_el0 value in memdump.

### DIFF
--- a/core/unix/coredump.c
+++ b/core/unix/coredump.c
@@ -399,7 +399,7 @@ write_fpregset_note(DR_PARAM_IN dcontext_t *dcontext, DR_PARAM_IN priv_mcontext_
  * the file, false otherwise.
  */
 static bool
-write_arm_tls_note(DR_PARAM_IN file_t elf_file)
+write_arm_tls_note(DR_PARAM_IN dcontext_t *dcontext, DR_PARAM_IN file_t elf_file)
 {
     ELF_NOTE_HEADER_TYPE nhdr;
     // Add one to include the terminating null character.
@@ -412,7 +412,7 @@ write_arm_tls_note(DR_PARAM_IN file_t elf_file)
     if (os_write(elf_file, NOTE_OWNER, NOTE_OWNER_LENGTH) != NOTE_OWNER_LENGTH) {
         return false;
     }
-    const reg_t tpidr_el0 = (reg_t)os_get_app_tls_base(NULL, TLS_REG_LIB);
+    const reg_t tpidr_el0 = (reg_t)os_get_app_tls_base(dcontext, TLS_REG_LIB);
     return os_write(elf_file, &tpidr_el0, sizeof(tpidr_el0)) == sizeof(tpidr_el0);
 }
 #endif
@@ -611,7 +611,7 @@ os_dump_core_internal(dcontext_t *dcontext, const char *output_directory DR_PARA
     // XXX: We need to add support for model specific registers like FS and GS for
     // x86_64.
 #if defined(AARCH64)
-    if (!write_arm_tls_note(elf_file)) {
+    if (!write_arm_tls_note(dcontext, elf_file)) {
         os_close(elf_file);
         return false;
     }


### PR DESCRIPTION
#7255 used read_thread_register(DR_REG_TPIDRURW) to get the value of tpidr_el0 value which is actually the Dr client's tpidr_el0 value. We should store the application's tpidr_el0 value instead using os_get_app_tls_base(dcontext, TLS_REG_LIB);

Tested: 

Analyzed the core dump file using gdb.

With the change:
```
=> 0x00000000004224dc:	55 d0 3b d5	mrs	x21, tpidr_el0
(gdb) stepi
0x00000000004224e0 in ?? ()
=> 0x00000000004224e0:	f6 03 02 2a	mov	w22, w2
(gdb) p/x $x21
$1 = 0x4c0790
(gdb) x/20x 0x4c0790
0x4c0790:	0x004a3c60	0x00000000	0x00000000	0x00000000
0x4c07a0:	0x004a3800	0x00000000	0x004a3808	0x00000000
0x4c07b0:	0x004a3800	0x00000000	0x004a3820	0x00000000
0x4c07c0:	0x00000000	0x00000000	0x004d0010	0x00000000
0x4c07d0:	0x004a2648	0x00000000	0x00000000	0x00000000
```
where 0x4c0790 belongs to the application section in the core dump file.

Without the change:
```
=> 0x00000000004224dc:	55 d0 3b d5	mrs	x21, tpidr_el0
(gdb) stepi
0x00000000004224e0 in ?? ()
=> 0x00000000004224e0:	f6 03 02 2a	mov	w22, w2
(gdb) p/x $x21
$1 = 0xfffd6d16f000
(gdb) x/20x 0xfffd6d16f000
0xfffd6d16f000:	0x00000000	0x00000000	0x6d150000	0x0000fffd
0xfffd6d16f010:	0xabababab	0xabababab	0xabababab	0xabababab
0xfffd6d16f020:	0xabababab	0xabababab	0xabababab	0xabababab
0xfffd6d16f030:	0xabababab	0xabababab	0xabababab	0xabababab
0xfffd6d16f040:	0xabababab	0xabababab	0xabababab	0xabababab
```
where 0xfffd6d16f000 is not part of the application section.

Issue: #7046 