### PR TITLE
i#7566: Fix 32-bit Intel sysparam regression

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5530,8 +5530,11 @@ sys_param_addr(dcontext_t *dcontext, int num)
     switch (num) {
     case 0: return &mc->IF_X86_ELSE(xbx, IF_RISCV64_ELSE(a0, r0));
     case 1:
-        return IF_X86_ELSE((dcontext->sys_was_int ? &mc->xcx : &mc->xbp),
-                           &mc->IF_RISCV64_ELSE(a1, r1));
+        return IF_X86_ELSE(
+            ((dcontext->sys_was_int || get_syscall_method() == SYSCALL_METHOD_SYSENTER)
+                 ? &mc->xcx
+                 : &mc->xbp),
+            &mc->IF_RISCV64_ELSE(a1, r1));
     case 2: return &mc->IF_X86_ELSE(xdx, IF_RISCV64_ELSE(a2, r2));
     case 3: return &mc->IF_X86_ELSE(xsi, IF_RISCV64_ELSE(a3, r3));
     case 4: return &mc->IF_X86_ELSE(xdi, IF_RISCV64_ELSE(a4, r4));


### PR DESCRIPTION
Fixes a regression from PR #7539 where sysparam 1 on Intel 32-bit should remain ecx.

Tested by running `ctest -j 12` on an Intel 32-bit debug build. Without the fix:
```
64% tests passed, 166 tests failed out of 461
```
With this fix:
```
95% tests passed, 23 tests failed out of 461
```

The vmareas assert from invalid mmap size reported in the issue is also confirmed to be gone.

Fixes #7566