### PR TITLE
i#7504 scale time: Scale sleep durations

### DIFF
--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -1133,7 +1133,9 @@ DR_API
  * event or a post-syscall (dr_register_post_syscall_event()) event.
  * From a post-syscall event this will not affect the syscall that
  * just happened (but it will affect a second syscall when using
- * dr_syscall_invoke_another().
+ * dr_syscall_invoke_another(); additionally, be careful when using
+ * from a post-syscall event as for some architectures the first
+ * syscall parameter becomes the return value.
  *
  * Sets the value of system call parameter number \p param_num to \p
  * new_value.

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -568,7 +568,8 @@ typedef struct _drx_time_scale_t {
      * application uses and impacts from modifications.
      * Only positive values are supported.
      * Each timeout is multiplied by this value.
-     * \note This is not yet supported; support is forthcoming.
+     * \note This only supports the Linux nanosleep and clock_nanosleep system calls
+     * at this time.
      */
     uint timeout_scale;
 } drx_time_scale_t;

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -502,7 +502,12 @@ event_post_syscall(void *drcontext, int sysnum)
         break;
     }
     case SYS_nanosleep:
+#ifdef X86
+        /* For AArch64 and RISC-V parameter 0 becomes the return value, so we do not
+         * want to restore the pre-syscall value.
+         */
         dr_syscall_set_param(drcontext, 0, (reg_t)data->app_set_timer_param);
+#endif
         /* Deliberate fallthrough. */
     case SYS_clock_nanosleep: {
         if (sysnum == SYS_clock_nanosleep)

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -37,6 +37,7 @@
 #include "drmgr.h"
 #include "../ext_utils.h"
 
+#include <errno.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
@@ -96,6 +97,10 @@ typedef struct _per_thread_t {
     itimerspec64_t itimer_spec64;
 #endif
     struct itimerval itimer_val;
+    struct timespec time_spec;
+#ifndef X64
+    timespec64_t time_spec64;
+#endif
     void *app_read_timer_param;
     void *app_set_timer_param;
 } per_thread_t;
@@ -131,102 +136,94 @@ is_timeval_zero(struct timeval *val)
 }
 
 static void
-inflate_timespec(void *drcontext, struct timespec *spec)
+inflate_timespec(void *drcontext, struct timespec *spec, int scale)
 {
     NOTIFY(2, "T" TIDFMT "  Original time %" SSZFC ".%.12" SSZFC "\n",
            dr_get_thread_id(drcontext), spec->tv_sec, spec->tv_nsec);
-    if (is_timespec_zero(spec))
+    if (is_timespec_zero(spec) || scale == 1)
         return;
-    spec->tv_nsec *= scale_options.timer_scale;
-    spec->tv_sec *= scale_options.timer_scale;
+    spec->tv_nsec *= scale;
+    spec->tv_sec *= scale;
     spec->tv_sec += spec->tv_nsec / MAX_TV_NSEC;
     spec->tv_nsec = spec->tv_nsec % MAX_TV_NSEC;
     NOTIFY(2, "T" TIDFMT " Inflated time by %dx: now %" SSZFC ".%.12" SSZFC "\n",
-           dr_get_thread_id(drcontext), scale_options.timer_scale, spec->tv_sec,
-           spec->tv_nsec);
+           dr_get_thread_id(drcontext), scale, spec->tv_sec, spec->tv_nsec);
 }
 
 #ifndef X64
 static void
-inflate_timespec64(void *drcontext, timespec64_t *spec)
+inflate_timespec64(void *drcontext, timespec64_t *spec, int scale)
 {
     NOTIFY(2,
            "T" TIDFMT "  Original time %" INT64_FORMAT_CODE ".%.12" INT64_FORMAT_CODE
            "\n",
            dr_get_thread_id(drcontext), spec->tv_sec, spec->tv_nsec);
-    if (is_timespec64_zero(spec))
+    if (is_timespec64_zero(spec) || scale == 1)
         return;
-    spec->tv_nsec *= scale_options.timer_scale;
-    spec->tv_sec *= scale_options.timer_scale;
+    spec->tv_nsec *= scale;
+    spec->tv_sec *= scale;
     spec->tv_sec += spec->tv_nsec / MAX_TV_NSEC;
     spec->tv_nsec = spec->tv_nsec % MAX_TV_NSEC;
     NOTIFY(2,
            "T" TIDFMT " Inflated time by %dx: now %" INT64_FORMAT_CODE
            ".%.12" INT64_FORMAT_CODE "\n",
-           dr_get_thread_id(drcontext), scale_options.timer_scale, spec->tv_sec,
-           spec->tv_nsec);
+           dr_get_thread_id(drcontext), scale, spec->tv_sec, spec->tv_nsec);
 }
 #endif
 
 static void
-deflate_timespec(void *drcontext, struct timespec *spec)
+deflate_timespec(void *drcontext, struct timespec *spec, int scale)
 {
-    if (is_timespec_zero(spec))
+    if (is_timespec_zero(spec) || scale == 1)
         return;
-    spec->tv_nsec /= scale_options.timer_scale;
-    spec->tv_nsec +=
-        (spec->tv_sec % MAX_TV_NSEC) * MAX_TV_NSEC / scale_options.timer_scale;
-    spec->tv_sec /= scale_options.timer_scale;
+    spec->tv_nsec /= scale;
+    spec->tv_nsec += (spec->tv_sec % MAX_TV_NSEC) * MAX_TV_NSEC / scale;
+    spec->tv_sec /= scale;
     NOTIFY(2, "T" TIDFMT "  Deflated time by %dx: now %" SSZFC ".%.12" SSZFC "\n",
-           dr_get_thread_id(drcontext), scale_options.timer_scale, spec->tv_sec,
-           spec->tv_nsec);
+           dr_get_thread_id(drcontext), scale, spec->tv_sec, spec->tv_nsec);
 }
 
 #ifndef X64
 static void
-deflate_timespec64(void *drcontext, timespec64_t *spec)
+deflate_timespec64(void *drcontext, timespec64_t *spec, int scale)
 {
-    if (is_timespec64_zero(spec))
+    if (is_timespec64_zero(spec) || scale == 1)
         return;
-    spec->tv_nsec /= scale_options.timer_scale;
-    spec->tv_nsec +=
-        (spec->tv_sec % MAX_TV_NSEC) * MAX_TV_NSEC / scale_options.timer_scale;
-    spec->tv_sec /= scale_options.timer_scale;
+    spec->tv_nsec /= scale;
+    spec->tv_nsec += (spec->tv_sec % MAX_TV_NSEC) * MAX_TV_NSEC / scale;
+    spec->tv_sec /= scale;
     NOTIFY(2,
            "T" TIDFMT "  Deflated time by %dx: now %" INT64_FORMAT_CODE
            ".%.12" INT64_FORMAT_CODE "\n",
-           dr_get_thread_id(drcontext), scale_options.timer_scale, spec->tv_sec,
-           spec->tv_nsec);
+           dr_get_thread_id(drcontext), scale, spec->tv_sec, spec->tv_nsec);
 }
 #endif
 
 static void
-inflate_timeval(void *drcontext, struct timeval *val)
+inflate_timeval(void *drcontext, struct timeval *val, int scale)
 {
     NOTIFY(2, "T" TIDFMT "  Original time %" SSZFC ".%.9" SSZFC "\n",
            dr_get_thread_id(drcontext), val->tv_sec, val->tv_usec);
-    if (is_timeval_zero(val))
+    if (is_timeval_zero(val) || scale == 1)
         return;
-    val->tv_usec *= scale_options.timer_scale;
-    val->tv_sec *= scale_options.timer_scale;
+    val->tv_usec *= scale;
+    val->tv_sec *= scale;
     val->tv_sec += val->tv_usec / MAX_TV_USEC;
     val->tv_usec = val->tv_usec % MAX_TV_USEC;
     NOTIFY(2, "T" TIDFMT "  Inflated time by %dx: now %" SSZFC ".%.9" SSZFC "\n",
-           dr_get_thread_id(drcontext), scale_options.timer_scale, val->tv_sec,
-           val->tv_usec);
+           dr_get_thread_id(drcontext), scale, val->tv_sec, val->tv_usec);
 }
 
 static void
-deflate_timeval(void *drcontext, struct timeval *val)
+deflate_timeval(void *drcontext, struct timeval *val, int scale)
 {
     if (is_timeval_zero(val))
         return;
-    val->tv_usec /= scale_options.timer_scale;
-    val->tv_usec += (val->tv_sec % MAX_TV_USEC) * MAX_TV_USEC / scale_options.timer_scale;
-    val->tv_sec /= scale_options.timer_scale;
+    val->tv_usec /= scale;
+    val->tv_usec += (val->tv_sec % MAX_TV_USEC) * MAX_TV_USEC / scale;
+    val->tv_sec /= scale;
     NOTIFY(2, "T" TIDFMT "  Deflated time by %dx: now %" SSZFC ".%.9" SSZFC "\n",
-           dr_get_thread_id(drcontext), scale_options.timer_scale, val->tv_sec,
-           val->tv_usec);
+           dr_get_thread_id(drcontext), scale, val->tv_sec, val->tv_usec);
 }
 
 static void
@@ -274,21 +271,24 @@ event_pre_syscall(void *drcontext, int sysnum)
             (struct itimerspec *)dr_syscall_get_param(drcontext, 3);
         NOTIFY(2, "T" TIDFMT " timer_settime flags=%d, old=%p, new=%p\n",
                dr_get_thread_id(drcontext), flags, new_spec, old_spec);
+        data->app_set_timer_param = new_spec;
+        data->app_read_timer_param = old_spec;
         if (TEST(TIMER_ABSTIME, flags)) {
             /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
             NOTIFY(0, "Absolute time is not supported\n");
+            data->app_read_timer_param = NULL; /* Don't scale in post. */
             return true;
         }
         size_t wrote;
         if (dr_safe_read(new_spec, sizeof(data->itimer_spec), &data->itimer_spec,
                          &wrote) &&
             wrote == sizeof(data->itimer_spec)) {
-            inflate_timespec(drcontext, &data->itimer_spec.it_interval);
-            inflate_timespec(drcontext, &data->itimer_spec.it_value);
+            inflate_timespec(drcontext, &data->itimer_spec.it_interval,
+                             scale_options.timer_scale);
+            inflate_timespec(drcontext, &data->itimer_spec.it_value,
+                             scale_options.timer_scale);
             dr_syscall_set_param(drcontext, 2, (reg_t)&data->itimer_spec);
-            data->app_set_timer_param = new_spec;
         }
-        data->app_read_timer_param = old_spec;
         break;
     }
 #ifndef X64
@@ -298,21 +298,24 @@ event_pre_syscall(void *drcontext, int sysnum)
         itimerspec64_t *old_spec = (itimerspec64_t *)dr_syscall_get_param(drcontext, 3);
         NOTIFY(2, "T" TIDFMT " timer_settime64 flags=%d, old=%p, new=%p\n",
                dr_get_thread_id(drcontext), flags, new_spec, old_spec);
+        data->app_set_timer_param = new_spec;
+        data->app_read_timer_param = old_spec;
         if (TEST(TIMER_ABSTIME, flags)) {
             /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
             NOTIFY(0, "Absolute time is not supported\n");
+            data->app_read_timer_param = NULL; /* Don't scale in post. */
             return true;
         }
         size_t wrote;
         if (dr_safe_read(new_spec, sizeof(data->itimer_spec64), &data->itimer_spec64,
                          &wrote) &&
             wrote == sizeof(data->itimer_spec64)) {
-            inflate_timespec64(drcontext, &data->itimer_spec64.it_interval);
-            inflate_timespec64(drcontext, &data->itimer_spec64.it_value);
+            inflate_timespec64(drcontext, &data->itimer_spec64.it_interval,
+                               scale_options.timer_scale);
+            inflate_timespec64(drcontext, &data->itimer_spec64.it_value,
+                               scale_options.timer_scale);
             dr_syscall_set_param(drcontext, 2, (reg_t)&data->itimer_spec64);
-            data->app_set_timer_param = new_spec;
         }
-        data->app_read_timer_param = old_spec;
         break;
     }
 #endif
@@ -332,21 +335,84 @@ event_pre_syscall(void *drcontext, int sysnum)
             (struct itimerval *)dr_syscall_get_param(drcontext, 1);
         struct itimerval *old_val =
             (struct itimerval *)dr_syscall_get_param(drcontext, 2);
+        data->app_set_timer_param = new_val;
+        data->app_read_timer_param = old_val;
         size_t wrote;
         if (dr_safe_read(new_val, sizeof(data->itimer_val), &data->itimer_val, &wrote) &&
             wrote == sizeof(data->itimer_val)) {
-            inflate_timeval(drcontext, &data->itimer_val.it_interval);
-            inflate_timeval(drcontext, &data->itimer_val.it_value);
+            inflate_timeval(drcontext, &data->itimer_val.it_interval,
+                            scale_options.timer_scale);
+            inflate_timeval(drcontext, &data->itimer_val.it_value,
+                            scale_options.timer_scale);
             dr_syscall_set_param(drcontext, 1, (reg_t)&data->itimer_val);
-            data->app_set_timer_param = new_val;
         }
-        data->app_read_timer_param = old_val;
         break;
     }
     case SYS_getitimer:
         NOTIFY(2, "T" TIDFMT " getitimer\n", dr_get_thread_id(drcontext));
         data->app_read_timer_param = (void *)dr_syscall_get_param(drcontext, 1);
         break;
+    case SYS_nanosleep:
+        struct timespec *spec = (struct timespec *)dr_syscall_get_param(drcontext, 0);
+        struct timespec *remain = (struct timespec *)dr_syscall_get_param(drcontext, 1);
+        NOTIFY(2, "T" TIDFMT " nanosleep time=%p, remaim=%p\n",
+               dr_get_thread_id(drcontext), spec, remain);
+        data->app_set_timer_param = spec;
+        data->app_read_timer_param = remain;
+        size_t wrote;
+        if (dr_safe_read(spec, sizeof(data->time_spec), &data->time_spec, &wrote) &&
+            wrote == sizeof(data->time_spec)) {
+            inflate_timespec(drcontext, &data->time_spec, scale_options.timeout_scale);
+            dr_syscall_set_param(drcontext, 0, (reg_t)&data->time_spec);
+        }
+        break;
+    case SYS_clock_nanosleep: {
+        int flags = (int)dr_syscall_get_param(drcontext, 1);
+        struct timespec *spec = (struct timespec *)dr_syscall_get_param(drcontext, 2);
+        struct timespec *remain = (struct timespec *)dr_syscall_get_param(drcontext, 3);
+        NOTIFY(2, "T" TIDFMT " clock_nanosleep flags=%d, time=%p, remaim=%p\n",
+               dr_get_thread_id(drcontext), flags, spec, remain);
+        data->app_set_timer_param = spec;
+        data->app_read_timer_param = remain;
+        if (TEST(TIMER_ABSTIME, flags)) {
+            /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
+            NOTIFY(0, "Absolute time is not supported\n");
+            data->app_read_timer_param = NULL; /* Don't scale in post. */
+            return true;
+        }
+        size_t wrote;
+        if (dr_safe_read(spec, sizeof(data->time_spec), &data->time_spec, &wrote) &&
+            wrote == sizeof(data->time_spec)) {
+            inflate_timespec(drcontext, &data->time_spec, scale_options.timeout_scale);
+            dr_syscall_set_param(drcontext, 2, (reg_t)&data->time_spec);
+        }
+        break;
+    }
+#ifndef X64
+    case SYS_clock_nanosleep_time64: {
+        int flags = (int)dr_syscall_get_param(drcontext, 1);
+        timespec64_t *spec = (timespec64_t *)dr_syscall_get_param(drcontext, 2);
+        timespec64_t *remain = (timespec64_t *)dr_syscall_get_param(drcontext, 3);
+        NOTIFY(2, "T" TIDFMT " clock_nanosleep_time64 flags=%d, time=%p, remaim=%p\n",
+               dr_get_thread_id(drcontext), flags, spec, remain);
+        data->app_set_timer_param = spec;
+        data->app_read_timer_param = remain;
+        if (TEST(TIMER_ABSTIME, flags)) {
+            /* TODO i#7504: Handle TIMER_ABSTIME and SYS_timer_getoverrun. */
+            NOTIFY(0, "Absolute time is not supported\n");
+            data->app_read_timer_param = NULL; /* Don't scale in post. */
+            return true;
+        }
+        size_t wrote;
+        if (dr_safe_read(spec, sizeof(data->time_spec64), &data->time_spec64, &wrote) &&
+            wrote == sizeof(data->time_spec64)) {
+            inflate_timespec64(drcontext, &data->time_spec64,
+                               scale_options.timeout_scale);
+            dr_syscall_set_param(drcontext, 2, (reg_t)&data->time_spec64);
+        }
+        break;
+    }
+#endif
     }
     return true;
 }
@@ -355,6 +421,12 @@ static void
 event_post_syscall(void *drcontext, int sysnum)
 {
     per_thread_t *data = (per_thread_t *)drmgr_get_tls_field(drcontext, tls_idx);
+    dr_syscall_result_info_t info = {
+        sizeof(info),
+    };
+    info.use_errno = true;
+    if (!dr_syscall_get_result_ex(drcontext, &info))
+        NOTIFY(1, "Can't tell whether syscall %d failed\n", sysnum);
     /* We need to pretend the actual value is the original un-inflated value. */
     switch (sysnum) {
     case SYS_timer_settime:
@@ -362,12 +434,16 @@ event_post_syscall(void *drcontext, int sysnum)
         /* Deliberate fallthrough. */
     case SYS_timer_gettime: {
         size_t wrote;
-        if (data->app_read_timer_param != NULL &&
-            dr_safe_read(data->app_read_timer_param, sizeof(data->itimer_spec),
-                         &data->itimer_spec, &wrote) &&
-            wrote == sizeof(data->itimer_spec)) {
-            deflate_timespec(drcontext, &data->itimer_spec.it_interval);
-            deflate_timespec(drcontext, &data->itimer_spec.it_value);
+        if (!info.succeeded) {
+            NOTIFY(1, "Syscall %d failed with %p: not scaling\n", sysnum, info.value);
+        } else if (data->app_read_timer_param != NULL &&
+                   dr_safe_read(data->app_read_timer_param, sizeof(data->itimer_spec),
+                                &data->itimer_spec, &wrote) &&
+                   wrote == sizeof(data->itimer_spec)) {
+            deflate_timespec(drcontext, &data->itimer_spec.it_interval,
+                             scale_options.timer_scale);
+            deflate_timespec(drcontext, &data->itimer_spec.it_value,
+                             scale_options.timer_scale);
             if (!dr_safe_write(data->app_read_timer_param, sizeof(data->itimer_spec),
                                &data->itimer_spec, &wrote) ||
                 wrote != sizeof(data->itimer_spec)) {
@@ -382,12 +458,16 @@ event_post_syscall(void *drcontext, int sysnum)
         /* Deliberate fallthrough. */
     case SYS_timer_gettime64: {
         size_t wrote;
-        if (data->app_read_timer_param != NULL &&
-            dr_safe_read(data->app_read_timer_param, sizeof(data->itimer_spec64),
-                         &data->itimer_spec64, &wrote) &&
-            wrote == sizeof(data->itimer_spec64)) {
-            deflate_timespec64(drcontext, &data->itimer_spec64.it_interval);
-            deflate_timespec64(drcontext, &data->itimer_spec64.it_value);
+        if (!info.succeeded) {
+            NOTIFY(1, "Syscall %d failed with %p: not scaling\n", sysnum, info.value);
+        } else if (data->app_read_timer_param != NULL &&
+                   dr_safe_read(data->app_read_timer_param, sizeof(data->itimer_spec64),
+                                &data->itimer_spec64, &wrote) &&
+                   wrote == sizeof(data->itimer_spec64)) {
+            deflate_timespec64(drcontext, &data->itimer_spec64.it_interval,
+                               scale_options.timer_scale);
+            deflate_timespec64(drcontext, &data->itimer_spec64.it_value,
+                               scale_options.timer_scale);
             if (!dr_safe_write(data->app_read_timer_param, sizeof(data->itimer_spec64),
                                &data->itimer_spec64, &wrote) ||
                 wrote != sizeof(data->itimer_spec64)) {
@@ -402,12 +482,16 @@ event_post_syscall(void *drcontext, int sysnum)
         /* Deliberate fallthrough. */
     case SYS_getitimer: {
         size_t wrote;
-        if (data->app_read_timer_param != NULL &&
-            dr_safe_read(data->app_read_timer_param, sizeof(data->itimer_val),
-                         &data->itimer_val, &wrote) &&
-            wrote == sizeof(data->itimer_val)) {
-            deflate_timeval(drcontext, &data->itimer_val.it_interval);
-            deflate_timeval(drcontext, &data->itimer_val.it_value);
+        if (!info.succeeded) {
+            NOTIFY(1, "Syscall %d failed with %p: not scaling\n", sysnum, info.value);
+        } else if (data->app_read_timer_param != NULL &&
+                   dr_safe_read(data->app_read_timer_param, sizeof(data->itimer_val),
+                                &data->itimer_val, &wrote) &&
+                   wrote == sizeof(data->itimer_val)) {
+            deflate_timeval(drcontext, &data->itimer_val.it_interval,
+                            scale_options.timer_scale);
+            deflate_timeval(drcontext, &data->itimer_val.it_value,
+                            scale_options.timer_scale);
             if (!dr_safe_write(data->app_read_timer_param, sizeof(data->itimer_val),
                                &data->itimer_val, &wrote) ||
                 wrote != sizeof(data->itimer_val)) {
@@ -416,6 +500,53 @@ event_post_syscall(void *drcontext, int sysnum)
         }
         break;
     }
+    case SYS_nanosleep:
+        dr_syscall_set_param(drcontext, 0, (reg_t)data->app_set_timer_param);
+        /* Deliberate fallthrough. */
+    case SYS_clock_nanosleep: {
+        if (sysnum == SYS_clock_nanosleep)
+            dr_syscall_set_param(drcontext, 2, (reg_t)data->app_set_timer_param);
+        size_t wrote;
+        if (info.succeeded) {
+            /* Nothing to do: the remainder is only written on EINTR. */
+        } else if (info.errno_value != EINTR) {
+            NOTIFY(1, "Syscall %d failed with %p: not scaling\n", sysnum, info.value);
+        } else if (data->app_read_timer_param != NULL &&
+                   dr_safe_read(data->app_read_timer_param, sizeof(data->time_spec),
+                                &data->time_spec, &wrote) &&
+                   wrote == sizeof(data->time_spec)) {
+            deflate_timespec(drcontext, &data->time_spec, scale_options.timeout_scale);
+            if (!dr_safe_write(data->app_read_timer_param, sizeof(data->time_spec),
+                               &data->time_spec, &wrote) ||
+                wrote != sizeof(data->time_spec)) {
+                NOTIFY(0, "Failed to modify sleep remaining value\n");
+            }
+        }
+        break;
+    }
+#ifndef X64
+    case SYS_clock_nanosleep_time64: {
+        dr_syscall_set_param(drcontext, 2, (reg_t)data->app_set_timer_param);
+        size_t wrote;
+        if (info.succeeded) {
+            /* Nothing to do: the remainder is only written on EINTR. */
+        } else if (info.errno_value != EINTR) {
+            NOTIFY(1, "Syscall %d failed with %p: not scaling\n", sysnum, info.value);
+        } else if (data->app_read_timer_param != NULL &&
+                   dr_safe_read(data->app_read_timer_param, sizeof(data->time_spec64),
+                                &data->time_spec64, &wrote) &&
+                   wrote == sizeof(data->time_spec64)) {
+            deflate_timespec64(drcontext, &data->time_spec64,
+                               scale_options.timeout_scale);
+            if (!dr_safe_write(data->app_read_timer_param, sizeof(data->time_spec64),
+                               &data->time_spec64, &wrote) ||
+                wrote != sizeof(data->time_spec64)) {
+                NOTIFY(0, "Failed to modify sleep remaining value\n");
+            }
+        }
+        break;
+    }
+#endif
     }
 }
 
@@ -454,11 +585,11 @@ scale_itimers(void *drcontext, bool inflate)
             val.it_value.tv_usec = val.it_interval.tv_usec;
         }
         if (inflate) {
-            inflate_timeval(drcontext, &val.it_interval);
-            inflate_timeval(drcontext, &val.it_value);
+            inflate_timeval(drcontext, &val.it_interval, scale_options.timer_scale);
+            inflate_timeval(drcontext, &val.it_value, scale_options.timer_scale);
         } else {
-            deflate_timeval(drcontext, &val.it_interval);
-            deflate_timeval(drcontext, &val.it_value);
+            deflate_timeval(drcontext, &val.it_interval, scale_options.timer_scale);
+            deflate_timeval(drcontext, &val.it_value, scale_options.timer_scale);
         }
         res = dr_invoke_syscall_as_app(drcontext, SYS_setitimer, 3, TIMER_TYPES[i], &val,
                                        NULL);
@@ -537,11 +668,11 @@ scale_posix_timers(void *drcontext, bool inflate)
                 spec.it_value.tv_nsec = spec.it_interval.tv_nsec;
             }
             if (inflate) {
-                inflate_timespec(drcontext, &spec.it_interval);
-                inflate_timespec(drcontext, &spec.it_value);
+                inflate_timespec(drcontext, &spec.it_interval, scale_options.timer_scale);
+                inflate_timespec(drcontext, &spec.it_value, scale_options.timer_scale);
             } else {
-                deflate_timespec(drcontext, &spec.it_interval);
-                deflate_timespec(drcontext, &spec.it_value);
+                deflate_timespec(drcontext, &spec.it_interval, scale_options.timer_scale);
+                deflate_timespec(drcontext, &spec.it_value, scale_options.timer_scale);
             }
             res = dr_invoke_syscall_as_app(drcontext, SYS_timer_settime, 4, id, 0, &spec,
                                            NULL);
@@ -568,11 +699,13 @@ scale_posix_timers(void *drcontext, bool inflate)
                 spec.it_value.tv_nsec = spec.it_interval.tv_nsec;
             }
             if (inflate) {
-                inflate_timespec64(drcontext, &spec.it_interval);
-                inflate_timespec64(drcontext, &spec.it_value);
+                inflate_timespec64(drcontext, &spec.it_interval,
+                                   scale_options.timer_scale);
+                inflate_timespec64(drcontext, &spec.it_value, scale_options.timer_scale);
             } else {
-                deflate_timespec64(drcontext, &spec.it_interval);
-                deflate_timespec64(drcontext, &spec.it_value);
+                deflate_timespec64(drcontext, &spec.it_interval,
+                                   scale_options.timer_scale);
+                deflate_timespec64(drcontext, &spec.it_value, scale_options.timer_scale);
             }
             res = dr_invoke_syscall_as_app(drcontext, SYS_timer_settime64, 4, id, 0,
                                            &spec, NULL);
@@ -604,8 +737,6 @@ drx_register_time_scaling(drx_time_scale_t *options)
          * without actual scaling.
          */
     }
-    if (options->timeout_scale > 1)
-        return false; /* Not supported yet. */
 
     scale_options = *options;
 

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -352,7 +352,7 @@ event_pre_syscall(void *drcontext, int sysnum)
         NOTIFY(2, "T" TIDFMT " getitimer\n", dr_get_thread_id(drcontext));
         data->app_read_timer_param = (void *)dr_syscall_get_param(drcontext, 1);
         break;
-    case SYS_nanosleep:
+    case SYS_nanosleep: {
         struct timespec *spec = (struct timespec *)dr_syscall_get_param(drcontext, 0);
         struct timespec *remain = (struct timespec *)dr_syscall_get_param(drcontext, 1);
         NOTIFY(2, "T" TIDFMT " nanosleep time=%p, remaim=%p\n",
@@ -366,6 +366,7 @@ event_pre_syscall(void *drcontext, int sysnum)
             dr_syscall_set_param(drcontext, 0, (reg_t)&data->time_spec);
         }
         break;
+    }
     case SYS_clock_nanosleep: {
         int flags = (int)dr_syscall_get_param(drcontext, 1);
         struct timespec *spec = (struct timespec *)dr_syscall_get_param(drcontext, 2);

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2975,6 +2975,11 @@ if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
       "" "" OFF ON OFF)
     use_DynamoRIO_extension(client.drx_time_scale-test drx_static)
     target_link_libraries(client.drx_time_scale-test rt)
+
+    set(client.drx_sleep_scale-test_no_reg_compat) # Avoid REG_ name conflicts.
+    tobuild_api(client.drx_sleep_scale-test client-interface/drx_sleep_scale-test.cpp
+      "" "" OFF ON OFF)
+    use_DynamoRIO_extension(client.drx_sleep_scale-test drx_static)
   endif ()
 endif (NOT RISCV64)
 

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2980,6 +2980,7 @@ if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
     tobuild_api(client.drx_sleep_scale-test client-interface/drx_sleep_scale-test.cpp
       "" "" OFF ON OFF)
     use_DynamoRIO_extension(client.drx_sleep_scale-test drx_static)
+    link_with_pthread(client.drx_sleep_scale-test)
   endif ()
 endif (NOT RISCV64)
 

--- a/suite/tests/client-interface/drx_sleep_scale-test.cpp
+++ b/suite/tests/client-interface/drx_sleep_scale-test.cpp
@@ -1,0 +1,261 @@
+/* **********************************************************
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of VMware, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syscall.h>
+
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <thread>
+
+// This is set globally in CMake for other tests so easier to undef here.
+#undef DR_REG_ENUM_COMPATIBILITY
+
+#include "configure.h"
+#include "dr_api.h"
+#include "drx.h"
+#include "tools.h"
+
+#ifndef LINUX
+#    error Only Linux supported for this test.
+#endif
+
+namespace dynamorio {
+namespace drmemtrace {
+
+#define VERBOSE 1
+#if VERBOSE
+#    define VPRINT(...) print(__VA_ARGS__)
+#else
+#    define VPRINT(...) /* nothing */
+#endif
+
+#ifndef X64
+typedef struct _timespec64_t {
+    int64 tv_sec;
+    int64 tv_nsec;
+} timespec64_t;
+#endif
+
+static pthread_cond_t condvar;
+static bool child_ready;
+static pthread_mutex_t lock;
+static std::atomic<bool> child_should_exit;
+
+bool
+my_setenv(const char *var, const char *value)
+{
+    return setenv(var, value, 1 /*override*/) == 0;
+}
+
+static void
+handler(int sig)
+{
+    // Nothing; just interrupt the sleep.
+}
+
+static void *
+thread_routine(void *arg)
+{
+    bool clock_version = static_cast<bool>(reinterpret_cast<size_t>(arg));
+    int64_t sleep_count = 0;
+
+    signal(SIGUSR1, handler);
+
+    pthread_mutex_lock(&lock);
+    child_ready = true;
+    pthread_cond_signal(&condvar);
+    pthread_mutex_unlock(&lock);
+
+    constexpr int SLEEP_NSEC = 100000;
+    struct timespec sleeptime;
+    sleeptime.tv_sec = 0;
+    sleeptime.tv_nsec = SLEEP_NSEC;
+    struct timespec remaining;
+#ifndef X64
+    timespec64_t sleeptime64;
+    sleeptime64.tv_sec = 0;
+    sleeptime64.tv_nsec = SLEEP_NSEC;
+    timespec64_t remaining64;
+#endif
+    int64_t eintr_count = 0;
+    while (!child_should_exit.load(std::memory_order_acquire)) {
+        ++sleep_count;
+        int res;
+        if (clock_version) {
+            // This is what modern libc nanosleep() calls.
+#ifdef X64
+            res = syscall(SYS_clock_nanosleep, CLOCK_REALTIME, 0, &sleeptime, &remaining);
+#else
+            res = syscall(SYS_clock_nanosleep_time64, CLOCK_REALTIME, 0, &sleeptime64,
+                          &remaining64);
+#endif
+        } else {
+            res = syscall(SYS_nanosleep, &sleeptime, &remaining);
+        }
+        if (res != 0) {
+            assert(errno == EINTR);
+            // Ensure the remaining time was deflated.
+#ifndef X64
+            if (clock_version)
+                assert(remaining64.tv_sec <= sleeptime64.tv_sec);
+            else
+#endif
+                assert(remaining.tv_sec <= sleeptime.tv_sec);
+            ++eintr_count;
+        }
+    }
+    assert(eintr_count > 0);
+    std::cerr << "eintrs=" << eintr_count << "\n";
+    return reinterpret_cast<void *>(sleep_count);
+}
+
+static int64_t
+do_some_work(bool clock_version)
+{
+    pthread_t thread;
+    void *retval;
+    pthread_mutex_init(&lock, NULL);
+    pthread_cond_init(&condvar, NULL);
+
+    pthread_mutex_lock(&lock);
+    child_ready = false;
+    pthread_mutex_unlock(&lock);
+    child_should_exit.store(false, std::memory_order_release);
+
+    int res = pthread_create(&thread, NULL, thread_routine,
+                             reinterpret_cast<void *>(clock_version));
+    assert(res == 0);
+    // Wait for the child to start running.
+    pthread_mutex_lock(&lock);
+    while (!child_ready)
+        pthread_cond_wait(&condvar, &lock);
+    pthread_mutex_unlock(&lock);
+    // Now take some time doing work so we can measure how many sleeps the child
+    // accomplishes in this time period.
+    constexpr int ITERS = 10000000;
+    double val = static_cast<double>(ITERS);
+    for (int i = 0; i < ITERS; ++i) {
+        val += sin(val);
+        // Test interrupting the thread's sleeps.
+        if (i % (ITERS / 20) == 0 ||
+            // Add a use of val so it's not optimized away.
+            val == 0.) {
+            pthread_kill(thread, SIGUSR1);
+        }
+    }
+    // Clean up.
+    child_should_exit.store(true, std::memory_order_release);
+    res = pthread_join(thread, &retval);
+    assert(res == 0);
+    pthread_cond_destroy(&condvar);
+    pthread_mutex_destroy(&lock);
+    return reinterpret_cast<int64_t>(retval);
+}
+
+static void
+event_exit(void)
+{
+    bool ok = drx_unregister_time_scaling();
+    assert(ok);
+    drx_exit();
+    dr_fprintf(STDERR, "client done\n");
+}
+
+static int64_t
+test_sleep(bool clock_version, int scale)
+{
+    std::string dr_ops("-stderr_mask 0xc -client_lib ';;" + std::to_string(scale) + "'");
+    if (!my_setenv("DYNAMORIO_OPTIONS", dr_ops.c_str()))
+        std::cerr << "failed to set env var!\n";
+    dr_app_setup_and_start();
+    int64_t count = do_some_work(clock_version);
+    dr_app_stop_and_cleanup();
+    return count;
+}
+
+static void
+test_sleep_scale()
+{
+    int64_t sleeps_default = test_sleep(/*clock_version=*/true, 1);
+    constexpr int SCALE = 100;
+    int64_t sleeps_scaled = test_sleep(/*clock_version=*/true, SCALE);
+    std::cerr << "sleeps default=" << sleeps_default << " clock scaled=" << sleeps_scaled
+              << "\n";
+    // Ensure the scaling ends up within an order of magnitude.
+    assert(sleeps_default > SCALE / 10 * sleeps_scaled);
+    // Test SYS_nanosleep.
+    sleeps_scaled = test_sleep(/*clock_version=*/false, SCALE);
+    std::cerr << "sleeps default=" << sleeps_default
+              << " noclock scaled=" << sleeps_scaled << "\n";
+    assert(sleeps_default > SCALE / 10 * sleeps_scaled);
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+DR_EXPORT void
+dr_client_main(client_id_t id, int argc, const char *argv[])
+{
+    uint timeout_scale = 1;
+    if (argc >= 2)
+        timeout_scale = atoi(argv[1]);
+    dr_fprintf(STDERR, "in dr_client_main scale=%u\n", timeout_scale);
+
+    dr_register_exit_event(dynamorio::drmemtrace::event_exit);
+    bool ok = drx_init();
+    assert(ok);
+
+    drx_time_scale_t scale = {
+        sizeof(scale),
+    };
+    scale.timer_scale = 1;
+    scale.timeout_scale = timeout_scale;
+    ok = drx_register_time_scaling(&scale);
+    assert(ok);
+}
+
+int
+main(int argc, char *argv[])
+{
+    dynamorio::drmemtrace::test_sleep_scale();
+    print("app done\n");
+    return 0;
+}

--- a/suite/tests/client-interface/drx_sleep_scale-test.templatex
+++ b/suite/tests/client-interface/drx_sleep_scale-test.templatex
@@ -1,0 +1,5 @@
+in dr_client_main.*
+client done.*
+in dr_client_main.*
+client done.*
+app done


### PR DESCRIPTION
Adds scaling of Linux SYS_nanosleep, SYS_clock_nanosleep, and SYS_clock_nanosleep_time64 system calls.

Augments the pre-existing timer scaling to check for syscall failure; checking the return code is required for sleep as the remaining time is only written when EINTR is returned.

Augments the pre-existing timer scaling to better handle an absolute flag by setting the TLS fields for post-handling prior to exiting pre-handling early, while putting this in place for sleep.

Adds a test.

Issue: #7504