### PR TITLE
i#7230 simrefs: Change skip_refs to not count markers

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -151,6 +151,8 @@ compatibility changes:
    #dynamorio::drmemtrace::analysis_tool_tmpl_t::parallel_shard_memref return
    conditions to no longer indicate an error if the error string is empty.
    This can now be used to exit early without reporting an error.
+ - Changed the -skip_refs drmemtrace option to not count markers, matching the
+   -sim_refs and -warmup_refs options.  (The new -skip_records counts markers.)
 
 Further non-compatibility-affecting changes include:
  - Changed the types of `block_size`, `total_size`, `num_blocks`, to `int64_t`

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -658,13 +658,16 @@ droption_t<bytesize_t> op_skip_records(
     "sequences, are not counted at all.");
 
 droption_t<bytesize_t> op_skip_refs(
-    DROPTION_SCOPE_FRONTEND, "skip_refs", 0, "Number of records to skip in certain tools",
-    "This option is honored by certain tools such as the cache and TLB simulators and "
-    "the view tool.  It causes them to ignore the specified count of records at the "
+    DROPTION_SCOPE_FRONTEND, "skip_refs", 0,
+    "Number of non-markers to skip in certain tools",
+    "This option is honored by certain tools such as the cache and TLB simulators.  "
+    "It causes them to ignore the specified count of non-marker (i.e., actual address "
+    "reference ('ref') records) at the "
     "start of the trace and only start processing after that count is reached.  Since "
     "the framework is still iterating over those records and it is the tool who is "
     "ignoring them, this skipping may be slow for large skip values; consider "
-    "-skip_instrs for a faster method of skipping inside the framework itself.");
+    "-skip_instrs for a faster method of skipping inside the framework itself.  "
+    "To skip markers also, use -skip_records.");
 
 droption_t<uint64_t> op_skip_to_timestamp(
     DROPTION_SCOPE_FRONTEND, "skip_to_timestamp", 0, "Timestamp to start at",
@@ -700,14 +703,11 @@ droption_t<bytesize_t> op_L0_filter_until_instrs(
     "full trace. Therefore TRACE_MARKER_TYPE_WINDOW_ID markers indicate start of "
     "filtered records.");
 
-// XXX i#7230: Currently the simulators count only non-marker records here: we should
-// either change that to all records to match -skip_refs, or update these docs.
-// If we update to match -skip_refs, we should make it clear that marker records
-// are not actually warming up the cache but are still being counted.
 droption_t<bytesize_t> op_warmup_refs(
-    DROPTION_SCOPE_FRONTEND, "warmup_refs", 0, "Number of records to warm caches up",
+    DROPTION_SCOPE_FRONTEND, "warmup_refs", 0, "Number of non-markers to warm caches up",
     "This option is honored by certain tools such as the cache and TLB simulators. "
-    "It causes them to not start analysis/simulation until this many records are seen."
+    "It causes them to not start analysis/simulation until this many non-marker records "
+    "(i.e., actual memory reference ('ref') records) are seen.  "
     "If -skip_refs is specified, the warmup records start after "
     "the skipped ones end. This flag is incompatible with warmup_fraction.");
 
@@ -719,13 +719,12 @@ droption_t<double> op_warmup_fraction(
     "is computed after the skipped references and before simulated references. "
     "This flag is incompatible with warmup_refs.");
 
-// XXX i#7230: Currently the simulators count only non-marker records here: we should
-// either change that to all records to match -skip_refs, or update these docs.
 droption_t<bytesize_t> op_sim_refs(
     DROPTION_SCOPE_FRONTEND, "sim_refs", bytesize_t(1ULL << 63),
-    "Number of records to analyze",
-    "This option is honored by certain tools such as the cache and TLB simulators and "
-    "the view tool.  It causes them to only analyze this many records and then exit. "
+    "Number of non-markers records to analyze",
+    "This option is honored by certain tools such as the cache and TLB simulators.  "
+    "It causes them to only analyze this many non-marker (i.e., actual memory reference "
+    "('ref') records) and then exit. "
     "If -skip_refs is specified, the analyzed records start after the skipped ones end; "
     "similarly, if -warmup_refs or -warmup_fraction is specified, the warmup records "
     "come prior to the -sim_refs records.  Use -exit_after_records for a similar feature "

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -437,7 +437,9 @@ bool
 cache_simulator_t::process_memref(const memref_t &memref)
 {
     if (knobs_.skip_refs > 0) {
-        knobs_.skip_refs--;
+        // Only count non-markers toward *_refs counts.
+        if (memref.marker.type != TRACE_TYPE_MARKER)
+            knobs_.skip_refs--;
         return true;
     }
 
@@ -456,36 +458,28 @@ cache_simulator_t::process_memref(const memref_t &memref)
     if (!simulator_t::process_memref(memref))
         return false;
 
-    if (memref.marker.type == TRACE_TYPE_MARKER) {
-        // We ignore markers before we ask core_for_thread, to avoid asking
-        // too early on a timestamp marker.
-        // TODO i#7230: This causes -warmup_refs and -sim_refs to count non-marker
-        // records while -skip_refs counts all records.  We should either say
-        // that in the docs or change the behavior here.
-        // Plus, this skips the TRACE_MARKER_TYPE_CPU_ID handling below.
-        if (knobs_.verbose >= 3) {
-            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
-                      << "marker type " << memref.marker.marker_type << " value "
-                      << memref.marker.marker_value << "\n";
-        }
-        return true;
-    }
-
-    int core_index;
-    if (shard_type_ == SHARD_BY_THREAD) {
-        if (memref.data.tid == last_thread_)
-            core_index = last_core_index_;
-        else {
+    // core_index can end up as INVALID_CORE_INDEX during headers but we don't use it
+    // then; we assert below on all uses cases that it's not INVALID_CORE_INDEX.
+    int core_index = INVALID_CORE_INDEX;
+    // Do not try to schedule idle onto cores as we'll then think they had activity
+    // when we print them out.
+    if (memref.marker.type != TRACE_TYPE_MARKER ||
+        memref.marker.marker_type != TRACE_MARKER_TYPE_CORE_IDLE) {
+        if (shard_type_ == SHARD_BY_THREAD) {
+            if (memref.data.tid == last_thread_ && last_core_index_ != INVALID_CORE_INDEX)
+                core_index = last_core_index_;
+            else {
+                core_index = core_for_thread(memref.data.tid);
+                last_thread_ = memref.data.tid;
+                last_core_index_ = core_index;
+            }
+        } else
             core_index = core_for_thread(memref.data.tid);
-            last_thread_ = memref.data.tid;
-            last_core_index_ = core_index;
+        if (core_index >= static_cast<int>(knobs_.num_cores)) {
+            error_string_ = "Too-small core count " + std::to_string(knobs_.num_cores) +
+                " for trace core #" + std::to_string(core_index);
+            return false;
         }
-    } else
-        core_index = core_for_thread(memref.data.tid);
-    if (core_index >= static_cast<int>(knobs_.num_cores)) {
-        error_string_ = "Too-small core count " + std::to_string(knobs_.num_cores) +
-            " for trace core #" + std::to_string(core_index);
-        return false;
     }
 
     // To support swapping to physical addresses without modifying the passed-in
@@ -505,6 +499,7 @@ cache_simulator_t::process_memref(const memref_t &memref)
                       << " @" << (void *)simref->instr.addr << " instr x"
                       << simref->instr.size << "\n";
         }
+        assert(core_index != INVALID_CORE_INDEX);
         l1_icaches_[core_index]->request(*simref);
     } else if (simref->data.type == TRACE_TYPE_READ ||
                simref->data.type == TRACE_TYPE_WRITE ||
@@ -517,6 +512,7 @@ cache_simulator_t::process_memref(const memref_t &memref)
                       << trace_type_names[simref->data.type] << " "
                       << (void *)simref->data.addr << " x" << simref->data.size << "\n";
         }
+        assert(core_index != INVALID_CORE_INDEX);
         l1_dcaches_[core_index]->request(*simref);
     } else if (simref->flush.type == TRACE_TYPE_INSTR_FLUSH) {
         if (knobs_.verbose >= 3) {
@@ -524,6 +520,7 @@ cache_simulator_t::process_memref(const memref_t &memref)
                       << " @" << (void *)simref->data.pc << " iflush "
                       << (void *)simref->data.addr << " x" << simref->data.size << "\n";
         }
+        assert(core_index != INVALID_CORE_INDEX);
         l1_icaches_[core_index]->flush(*simref);
     } else if (simref->flush.type == TRACE_TYPE_DATA_FLUSH) {
         if (knobs_.verbose >= 3) {
@@ -531,13 +528,19 @@ cache_simulator_t::process_memref(const memref_t &memref)
                       << " @" << (void *)simref->data.pc << " dflush "
                       << (void *)simref->data.addr << " x" << simref->data.size << "\n";
         }
+        assert(core_index != INVALID_CORE_INDEX);
         l1_dcaches_[core_index]->flush(*simref);
     } else if (simref->exit.type == TRACE_TYPE_THREAD_EXIT) {
         handle_thread_exit(simref->exit.tid);
         last_thread_ = 0;
-    } else if (memref.marker.type == TRACE_TYPE_MARKER &&
-               memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID) {
-        last_thread_ = 0;
+    } else if (memref.marker.type == TRACE_TYPE_MARKER) {
+        if (memref.marker.marker_type == TRACE_MARKER_TYPE_CPU_ID)
+            last_thread_ = 0;
+        if (knobs_.verbose >= 3) {
+            std::cerr << "::" << memref.data.pid << "." << memref.data.tid << ":: "
+                      << "marker type " << memref.marker.marker_type << " value "
+                      << memref.marker.marker_value << "\n";
+        }
     } else if (simref->marker.type == TRACE_TYPE_INSTR_NO_FETCH) {
         // Just ignore.
         if (knobs_.verbose >= 3) {
@@ -550,17 +553,20 @@ cache_simulator_t::process_memref(const memref_t &memref)
         return false;
     }
 
-    // reset cache stats when warming up is completed
-    if (!is_warmed_up_ && check_warmed_up()) {
-        for (auto &cache_it : all_caches_) {
-            cache_t *cache = cache_it.second;
-            cache->get_stats()->reset();
+    // Only count non-markers toward *_refs counts.
+    if (memref.marker.type != TRACE_TYPE_MARKER) {
+        // Reset cache stats when warming up is completed.
+        if (!is_warmed_up_ && check_warmed_up()) {
+            for (auto &cache_it : all_caches_) {
+                cache_t *cache = cache_it.second;
+                cache->get_stats()->reset();
+            }
+            if (knobs_.verbose >= 1) {
+                std::cerr << "Cache simulation warmed up\n";
+            }
+        } else {
+            knobs_.sim_refs--;
         }
-        if (knobs_.verbose >= 1) {
-            std::cerr << "Cache simulation warmed up\n";
-        }
-    } else {
-        knobs_.sim_refs--;
     }
 
     return true;
@@ -577,6 +583,12 @@ cache_simulator_t::get_prefetcher(std::string prefetcher_name)
         return custom_prefetcher_factory_->create_prefetcher((int)knobs_.line_size);
     }
     return nullptr;
+}
+
+bool
+cache_simulator_t::is_warmed_up()
+{
+    return is_warmed_up_;
 }
 
 // Return true if the number of warmup references have been executed or if

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -470,8 +470,10 @@ cache_simulator_t::process_memref(const memref_t &memref)
                 core_index = last_core_index_;
             else {
                 core_index = core_for_thread(memref.data.tid);
-                last_thread_ = memref.data.tid;
-                last_core_index_ = core_index;
+                if (core_index != INVALID_CORE_INDEX) {
+                    last_thread_ = memref.data.tid;
+                    last_core_index_ = core_index;
+                }
             }
         } else
             core_index = core_for_thread(memref.data.tid);

--- a/clients/drcachesim/simulator/cache_simulator.h
+++ b/clients/drcachesim/simulator/cache_simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -102,7 +102,8 @@ public:
 
     // Exposed to make it easy to test
     bool
-    check_warmed_up();
+    is_warmed_up();
+
     uint64_t
     remaining_sim_refs() const;
 
@@ -110,6 +111,9 @@ public:
     get_knobs() const;
 
 protected:
+    bool
+    check_warmed_up();
+
     prefetcher_t *
     get_prefetcher(std::string prefetcher_name);
 

--- a/clients/drcachesim/simulator/simulator.h
+++ b/clients/drcachesim/simulator/simulator.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -97,6 +97,7 @@ protected:
     int
     find_emptiest_core(std::vector<int> &counts) const;
 
+    // Returns INVALID_CORE_INDEX during headers before the first cpuid marker is seen.
     virtual int
     core_for_thread(memref_tid_t tid);
 
@@ -145,6 +146,7 @@ protected:
     std::vector<int> cpu_counts_;
     std::vector<int> thread_counts_;
     std::vector<int> thread_ever_counts_;
+    int non_marker_count_ = 0;
 
     // For virtual to physical page mappings.
     size_t page_size_ = 0;

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -204,7 +204,7 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     // ran on for each memref.
     // core_index can end up as INVALID_CORE_INDEX during headers but we don't use it
     // then; we assert below on all uses cases that it's not INVALID_CORE_INDEX.
-    int core_index;
+    int core_index = INVALID_CORE_INDEX;
     // Do not try to schedule idle onto cores as we'll then think they had activity
     // when we print them out.
     if (memref.marker.type != TRACE_TYPE_MARKER ||

--- a/clients/drcachesim/simulator/tlb_simulator.cpp
+++ b/clients/drcachesim/simulator/tlb_simulator.cpp
@@ -184,7 +184,9 @@ bool
 tlb_simulator_t::process_memref(const memref_t &memref)
 {
     if (knobs_.skip_refs > 0) {
-        knobs_.skip_refs--;
+        // Only count non-markers toward *_refs counts.
+        if (memref.marker.type != TRACE_TYPE_MARKER)
+            knobs_.skip_refs--;
         return true;
     }
 
@@ -197,19 +199,11 @@ tlb_simulator_t::process_memref(const memref_t &memref)
     if (!simulator_t::process_memref(memref))
         return false;
 
-    if (memref.marker.type == TRACE_TYPE_MARKER) {
-        // We ignore markers before we ask core_for_thread, to avoid asking
-        // too early on a timestamp marker.
-        // TODO i#7230: This causes -warmup_refs and -sim_refs to count non-marker
-        // records while -skip_refs counts all records.  We should either say
-        // that in the docs or change the behavior here.
-        // Plus, this skips the TRACE_MARKER_TYPE_CPU_ID handling below.
-        return true;
-    }
-
     // We use a static scheduling of threads to cores, as it is
     // not practical to measure which core each thread actually
     // ran on for each memref.
+    // core_index can end up as INVALID_CORE_INDEX during headers but we don't use it
+    // then; we assert below on all uses cases that it's not INVALID_CORE_INDEX.
     int core_index;
     if (memref.data.tid == last_thread_)
         core_index = last_core_index_;
@@ -229,12 +223,14 @@ tlb_simulator_t::process_memref(const memref_t &memref)
         simref = &phys_memref;
     }
 
-    if (type_is_instr(simref->instr.type))
+    if (type_is_instr(simref->instr.type)) {
+        assert(core_index != INVALID_CORE_INDEX);
         itlbs_[core_index]->request(*simref);
-    else if (simref->data.type == TRACE_TYPE_READ ||
-             simref->data.type == TRACE_TYPE_WRITE)
+    } else if (simref->data.type == TRACE_TYPE_READ ||
+               simref->data.type == TRACE_TYPE_WRITE) {
+        assert(core_index != INVALID_CORE_INDEX);
         dtlbs_[core_index]->request(*simref);
-    else if (simref->exit.type == TRACE_TYPE_THREAD_EXIT) {
+    } else if (simref->exit.type == TRACE_TYPE_THREAD_EXIT) {
         handle_thread_exit(simref->exit.tid);
         last_thread_ = 0;
     } else if (type_is_prefetch(simref->data.type) ||
@@ -255,19 +251,22 @@ tlb_simulator_t::process_memref(const memref_t &memref)
                   << (void *)simref->data.addr << " x" << simref->data.size << std::endl;
     }
 
-    // process counters for warmup and simulated references
-    if (knobs_.warmup_refs > 0) { // warm tlbs up
-        knobs_.warmup_refs--;
-        // reset tlb stats when warming up is completed
-        if (knobs_.warmup_refs == 0) {
-            for (unsigned int i = 0; i < knobs_.num_cores; i++) {
-                itlbs_[i]->get_stats()->reset();
-                dtlbs_[i]->get_stats()->reset();
-                lltlbs_[i]->get_stats()->reset();
+    // Only count non-markers toward *_refs counts.
+    if (memref.marker.type != TRACE_TYPE_MARKER) {
+        // Process counters for warmup and simulated references.
+        if (knobs_.warmup_refs > 0) { // warm tlbs up
+            knobs_.warmup_refs--;
+            // reset tlb stats when warming up is completed
+            if (knobs_.warmup_refs == 0) {
+                for (unsigned int i = 0; i < knobs_.num_cores; i++) {
+                    itlbs_[i]->get_stats()->reset();
+                    dtlbs_[i]->get_stats()->reset();
+                    lltlbs_[i]->get_stats()->reset();
+                }
             }
+        } else {
+            knobs_.sim_refs--;
         }
-    } else {
-        knobs_.sim_refs--;
     }
     return true;
 }

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -67,6 +67,8 @@ namespace drmemtrace {
         assert(aa == bb);                                         \
     }
 
+#define MY_TID 1
+
 static cache_simulator_knobs_t
 make_test_knobs()
 {
@@ -89,7 +91,7 @@ make_memref(addr_t address, trace_type_t type = TRACE_TYPE_READ, int size = 4)
     ref.data.type = type;
     ref.data.size = size;
     ref.data.addr = address;
-    ref.data.tid = 1;
+    ref.data.tid = MY_TID;
     return ref;
 }
 
@@ -109,6 +111,7 @@ unit_test_warmup_fraction()
         ref.data.type = TRACE_TYPE_READ;
         ref.data.size = 8;
         ref.data.addr = i * 128;
+        ref.data.tid = MY_TID;
         if (!cache_sim.process_memref(ref)) {
             std::cerr << "drcachesim unit_test_warmup_fraction failed: "
                       << cache_sim.get_error_string() << "\n";
@@ -116,7 +119,7 @@ unit_test_warmup_fraction()
         }
     }
 
-    if (!cache_sim.check_warmed_up()) {
+    if (!cache_sim.is_warmed_up()) {
         std::cerr << "drcachesim unit_test_warmup_fraction failed\n";
         exit(1);
     }
@@ -126,18 +129,32 @@ void
 unit_test_warmup_refs()
 {
     cache_simulator_knobs_t knobs = make_test_knobs();
-    knobs.warmup_refs = 16;
+    constexpr int WARMUP_REFS = 16;
+    knobs.warmup_refs = WARMUP_REFS;
     cache_simulator_t cache_sim(knobs);
 
     // Feed it some memrefs, warmup refs = 16 where the capacity at
-    // each level is 32 lines each. The first 16 memrefs warm up the cache and
-    // the 17th allows us to check.
+    // each level is 32 lines each. The first 16 memrefs warm up the cache.
     std::string error;
-    for (int i = 0; i < 16 + 1; i++) {
+    constexpr int MARKER_COUNT = 4;
+    for (int i = 0; i < MARKER_COUNT + WARMUP_REFS; ++i) {
+        if (cache_sim.is_warmed_up()) {
+            std::cerr << "drcachesim unit_test_warmup_refs warmed up too early\n";
+            exit(1);
+        }
         memref_t ref;
-        ref.data.type = TRACE_TYPE_READ;
-        ref.data.size = 8;
-        ref.data.addr = i * 128;
+        if (i < MARKER_COUNT) {
+            // Make the first couple markers, to ensure warmup_refs skips markers
+            // (xref i#7230).
+            ref.marker.type = TRACE_TYPE_MARKER;
+            ref.marker.marker_type = TRACE_MARKER_TYPE_CACHE_LINE_SIZE;
+            ref.marker.marker_value = 64;
+        } else {
+            ref.data.type = TRACE_TYPE_READ;
+            ref.data.size = 8;
+            ref.data.addr = i * 128;
+        }
+        ref.data.tid = MY_TID;
         if (!cache_sim.process_memref(ref)) {
             std::cerr << "drcachesim unit_test_warmup_fraction failed: "
                       << cache_sim.get_error_string() << "\n";
@@ -145,7 +162,7 @@ unit_test_warmup_refs()
         }
     }
 
-    if (!cache_sim.check_warmed_up()) {
+    if (!cache_sim.is_warmed_up()) {
         std::cerr << "drcachesim unit_test_warmup_refs failed\n";
         exit(1);
     }
@@ -155,27 +172,90 @@ void
 unit_test_sim_refs()
 {
     cache_simulator_knobs_t knobs = make_test_knobs();
-    knobs.sim_refs = 8;
+    constexpr int REF_LIMIT = 8;
+    knobs.sim_refs = REF_LIMIT;
     cache_simulator_t cache_sim(knobs);
 
     std::string error;
-    for (int i = 0; i < 16; i++) {
+    constexpr int MARKER_COUNT = 3;
+    // Go beyond and ensure we stop before then.
+    int i;
+    for (i = 0; i < MARKER_COUNT + REF_LIMIT + 100; ++i) {
         memref_t ref;
-        ref.data.type = TRACE_TYPE_READ;
-        ref.data.size = 8;
-        ref.data.addr = i * 128;
+        if (i < MARKER_COUNT) {
+            // Make the first couple markers, to ensure sim_refs skips markers
+            // (xref i#7230).
+            ref.marker.type = TRACE_TYPE_MARKER;
+            ref.marker.marker_type = TRACE_MARKER_TYPE_CACHE_LINE_SIZE;
+            ref.marker.marker_value = 64;
+        } else {
+            ref.data.type = TRACE_TYPE_READ;
+            ref.data.size = 8;
+            ref.data.addr = i * 128;
+        }
+        ref.data.tid = MY_TID;
         if (!cache_sim.process_memref(ref)) {
-            // Check we don't exit before our 8 sim_refs.
-            if (i < 8 || !cache_sim.get_error_string().empty()) {
+            // Check we don't exit before our markers + sim_refs.
+            if (!cache_sim.get_error_string().empty()) {
                 std::cerr << "drcachesim unit_test_sim_refs failed: "
                           << cache_sim.get_error_string() << "\n";
                 exit(1);
             }
+            break;
+        }
+    }
+    // The exit is on the subsequent memref, so allow ==.
+    if (i > MARKER_COUNT + REF_LIMIT) {
+        std::cerr << "drcachesim unit_test_sim_refs failed: went too far\n";
+        exit(1);
+    }
+    if (cache_sim.remaining_sim_refs() != 0) {
+        std::cerr << "drcachesim unit_test_sim_refs failed: has remaining refs\n";
+        exit(1);
+    }
+}
+
+void
+unit_test_skip_refs()
+{
+    cache_simulator_knobs_t knobs = make_test_knobs();
+    constexpr int SKIP_REFS = 16;
+    constexpr int WARMUP_REFS = 16;
+    knobs.skip_refs = SKIP_REFS;
+    knobs.warmup_refs = WARMUP_REFS;
+    cache_simulator_t cache_sim(knobs);
+
+    // Feed it some memrefs, warmup refs = 16 where the capacity at
+    // each level is 32 lines each. The first 16 memrefs warm up the cache.
+    std::string error;
+    constexpr int MARKER_COUNT = 4;
+    for (int i = 0; i < MARKER_COUNT + SKIP_REFS + WARMUP_REFS; ++i) {
+        if (cache_sim.is_warmed_up()) {
+            std::cerr << "drcachesim unit_test_warmup_refs warmed up too early\n";
+            exit(1);
+        }
+        memref_t ref;
+        if (i < MARKER_COUNT) {
+            // Make the first couple markers, to ensure skip_refs skips markers
+            // (xref i#7230).
+            ref.marker.type = TRACE_TYPE_MARKER;
+            ref.marker.marker_type = TRACE_MARKER_TYPE_CACHE_LINE_SIZE;
+            ref.marker.marker_value = 64;
+        } else {
+            ref.data.type = TRACE_TYPE_READ;
+            ref.data.size = 8;
+            ref.data.addr = i * 128;
+        }
+        ref.data.tid = MY_TID;
+        if (!cache_sim.process_memref(ref)) {
+            std::cerr << "drcachesim unit_test_warmup_fraction failed: "
+                      << cache_sim.get_error_string() << "\n";
+            exit(1);
         }
     }
 
-    if (cache_sim.remaining_sim_refs() != 0) {
-        std::cerr << "drcachesim unit_test_sim_refs failed\n";
+    if (!cache_sim.is_warmed_up()) {
+        std::cerr << "drcachesim unit_test_warmup_refs failed\n";
         exit(1);
     }
 }
@@ -190,6 +270,7 @@ unit_test_metrics_API()
     ref.data.type = TRACE_TYPE_WRITE;
     ref.data.addr = 0;
     ref.data.size = 8;
+    ref.data.tid = MY_TID;
 
     // Currently invalidates are not counted properly in the configuration of
     // cache_simulator_t with cache_simulator_knobs_t.
@@ -261,6 +342,7 @@ unit_test_compulsory_misses()
     memref_t ref;
     ref.data.type = TRACE_TYPE_INSTR;
     ref.data.size = 8;
+    ref.data.tid = MY_TID;
 
     for (int i = 0; i < 5; i++) {
         ref.data.addr = i * 64;
@@ -422,6 +504,7 @@ LLC {
     memref_t ref;
     ref.data.type = TRACE_TYPE_READ;
     ref.data.size = 1;
+    ref.data.tid = MY_TID;
 
     // We perform a bunch of accesses to the same cache line to ensure they hit.
     const int num_accesses = 16;
@@ -898,6 +981,7 @@ generate_2D_accesses(cache_t &cache, addr_t start_address, int step_size_a,
         memref_t ref;
         ref.data.type = TRACE_TYPE_READ;
         ref.data.size = 4;
+        ref.data.tid = MY_TID;
         for (int step_a = 0; step_a < step_count_a; ++step_a) {
             for (int step_b = 0; step_b < step_count_b; ++step_b) {
                 addr_t addr = start_address + step_a * step_size_a + step_b * step_size_b;
@@ -1289,6 +1373,7 @@ test_main(int argc, const char *argv[])
     unit_test_warmup_fraction();
     unit_test_warmup_refs();
     unit_test_sim_refs();
+    unit_test_skip_refs();
     unit_test_child_hits();
     unit_test_cache_replacement_policy();
     unit_test_core_sharded();


### PR DESCRIPTION
Changes the -skip_refs drmemtrace option to not count markers, matching the -sim_refs and -warmup_refs options.  (The new -skip_records counts markers.)

Adds a changelist entry.

Updates the docs for -skip_refs, -sim_refs, and -warmup_refs to clarify that they do not count markers.

Augments the drcachesim unit tests to check markers.

Cleans up the cache and tlb simulators to not short-circuit on a marker and skip later marker code, which requires a different solution for core_for_thread handling of early markers and setting the tid in tests.

A separate change will remove -skip_refs and -sim_refs from the view tool.

Issue: #7230