### PR TITLE
i#7230 sim refs: Remove -skip_refs and -sim_refs from view tool

### DIFF
--- a/api/docs/debug_memtrace.dox
+++ b/api/docs/debug_memtrace.dox
@@ -1,5 +1,5 @@
 /* ******************************************************************************
- * Copyright (c) 2010-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
  * ******************************************************************************/
 
 /*
@@ -124,7 +124,7 @@ $ unzip -p drmemtrace.app.194439.1516.dir/trace/drmemtrace.app.194439.7393.trace
 
 ## Viewing instruction disassembly
 
-You can use the `view` analysis tool with `skip_refs` and `sim_refs` parameters to select a window, or for small traces you can re-post-process with `drraw2trace` with high verbosity (`-verbose 4` is good).
+You can use the `view` analysis tool with `skip_records`, `skip_instructions`, and `exit_after_records` parameters to select a window, or for small traces you can re-post-process with `drraw2trace` with high verbosity (`-verbose 4` is good).
 
  ****************************************************************************
  */

--- a/api/docs/debug_memtrace.dox
+++ b/api/docs/debug_memtrace.dox
@@ -124,7 +124,7 @@ $ unzip -p drmemtrace.app.194439.1516.dir/trace/drmemtrace.app.194439.7393.trace
 
 ## Viewing instruction disassembly
 
-You can use the `view` analysis tool with `skip_records`, `skip_instructions`, and `exit_after_records` parameters to select a window, or for small traces you can re-post-process with `drraw2trace` with high verbosity (`-verbose 4` is good).
+You can use the `view` analysis tool with `-skip_records`, `-skip_instructions`, and `-exit_after_records` parameters to select a window, or for small traces you can re-post-process with `drraw2trace` with high verbosity (`-verbose 4` is good).
 
  ****************************************************************************
  */

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -153,6 +153,8 @@ compatibility changes:
    This can now be used to exit early without reporting an error.
  - Changed the -skip_refs drmemtrace option to not count markers, matching the
    -sim_refs and -warmup_refs options.  (The new -skip_records counts markers.)
+ - Dropped support for -skip_refs and -sim_refs in the view tool (use the new
+   -skip_records and -exit_after_records instead).
 
 Further non-compatibility-affecting changes include:
  - Changed the types of `block_size`, `total_size`, `num_blocks`, to `int64_t`

--- a/clients/drcachesim/tests/offline-one-early.templatex
+++ b/clients/drcachesim/tests/offline-one-early.templatex
@@ -1,7 +1,10 @@
 .*
-View tool results:
-              3 : total instructions
-
+TLB simulation results:
+Core #0 \(traced CPU\(s\): #0\)
+  L1I stats:
+    Hits:                                9
+    Misses:                              1
+.*
 ===========================================================================
 Opcode mix tool results:
             133 : total executed instructions

--- a/clients/drcachesim/tests/offline-skip.expect
+++ b/clients/drcachesim/tests/offline-skip.expect
@@ -11,8 +11,10 @@ Output format:
          120          63: W0.T1992554 <marker: timestamp 13352268558646604>
          121          63: W0.T1992554 <marker: W0.T1992554 on core 10>
          122          64: W0.T1992554 ifetch       4 byte(s) @ 0x0000000000401028 48 83 eb 01          sub    $0x0000000000000001 %rbx -> %rbx
+         123          65: W0.T1992554 ifetch       4 byte(s) @ 0x000000000040102c 48 83 fb 00          cmp    %rbx $0x0000000000000000
+         124          66: W0.T1992554 ifetch       2 byte(s) @ 0x0000000000401030 75 d9                jnz    $0x000000000040100b (taken)
 View tool results:
-              2 : total instructions
+              4 : total instructions
 
 ===========================================================================
 Trace invariant checks passed

--- a/clients/drcachesim/tests/skip_unit_tests.cpp
+++ b/clients/drcachesim/tests/skip_unit_tests.cpp
@@ -97,12 +97,13 @@ test_skip_initial()
         std::unique_ptr<reader_t> iter_end =
             std::unique_ptr<reader_t>(new zipfile_file_reader_t());
         // Run the tool.
-        std::unique_ptr<analysis_tool_t> tool = std::unique_ptr<analysis_tool_t>(
-            view_tool_create("", /*skip_refs=*/0, /*sim_refs=*/view_count, "att"));
+        std::unique_ptr<analysis_tool_t> tool =
+            std::unique_ptr<analysis_tool_t>(view_tool_create("", "att"));
         std::string error = tool->initialize_stream(iter.get());
         CHECK(error.empty(), error.c_str());
         iter->skip_instructions(skip_instrs);
-        for (; *iter != *iter_end; ++(*iter)) {
+        for (int records = 0; records < view_count && *iter != *iter_end;
+             ++(*iter), ++records) {
             const memref_t &memref = **iter;
             if (!tool->process_memref(memref)) {
                 if (tool->get_error_string().empty())

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -234,8 +234,8 @@ public:
 
 static std::string
 run_with_analyzer(void *drcontext, instrlist_t &ilist,
-                  const std::vector<trace_entry_t> &records, int skip_records,
-                  int num_records)
+                  const std::vector<trace_entry_t> &records, int skip_records = 0,
+                  int num_records = 0, bool no_modules = false)
 {
     memref_tid_t tid = 42;
     std::vector<scheduler_t::input_reader_t> readers;
@@ -245,7 +245,10 @@ run_with_analyzer(void *drcontext, instrlist_t &ilist,
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     sched_inputs.emplace_back(std::move(readers));
     std::vector<analysis_tool_t *> tools;
-    auto test_tool = std::unique_ptr<view_test_t>(new view_test_t(drcontext, ilist));
+    auto test_tool = std::unique_ptr<view_test_t>(
+        no_modules
+            ? reinterpret_cast<view_test_t *>(new view_nomod_test_t(drcontext, ilist))
+            : reinterpret_cast<view_test_t *>(new view_test_t(drcontext, ilist)));
     tools.push_back(test_tool.get());
     mock_analyzer_t analyzer(sched_inputs, &tools[0], (int)tools.size(), skip_records,
                              num_records);
@@ -260,12 +263,26 @@ run_with_analyzer(void *drcontext, instrlist_t &ilist,
     return res;
 }
 
-bool
-test_no_limit(void *drcontext, instrlist_t &ilist, const std::vector<memref_t> &memrefs)
+static int
+get_memref_count(const std::vector<trace_entry_t> &records)
 {
-    view_test_t view(drcontext, ilist);
-    std::string res = run_test_helper(view, memrefs);
-    if (std::count(res.begin(), res.end(), '\n') != static_cast<int>(memrefs.size())) {
+    test_util::mock_reader_t reader = test_util::mock_reader_t(records);
+    test_util::mock_reader_t reader_end = test_util::mock_reader_t();
+    int memref_count = 0;
+    for (reader.init(); reader != reader_end; ++reader) {
+        ++memref_count;
+    }
+    return memref_count;
+}
+
+bool
+test_no_limit_shared(void *drcontext, instrlist_t &ilist,
+                     const std::vector<trace_entry_t> &records, bool no_modules)
+{
+    int memref_count = get_memref_count(records);
+    std::string res = run_with_analyzer(drcontext, ilist, records, /*skip_records=*/0,
+                                        /*num_records=*/0, no_modules);
+    if (std::count(res.begin(), res.end(), '\n') != memref_count) {
         std::cerr << "Incorrect line count\n";
         return false;
     }
@@ -280,11 +297,25 @@ test_no_limit(void *drcontext, instrlist_t &ilist, const std::vector<memref_t> &
 }
 
 bool
+test_no_limit(void *drcontext, instrlist_t &ilist,
+              const std::vector<trace_entry_t> &records)
+{
+    return test_no_limit_shared(drcontext, ilist, records, /*no_modules=*/false);
+}
+
+bool
+test_no_modules(void *drcontext, instrlist_t &ilist,
+                const std::vector<trace_entry_t> &records)
+{
+    return test_no_limit_shared(drcontext, ilist, records, /*no_modules=*/false);
+}
+
+bool
 test_num_memrefs(void *drcontext, instrlist_t &ilist,
                  const std::vector<trace_entry_t> &records, int num_records)
 {
-    ASSERT(static_cast<size_t>(num_records) < records.size(),
-           "need more records to limit");
+    int memref_count = get_memref_count(records);
+    ASSERT(num_records < memref_count, "need more records to limit");
     std::string res =
         run_with_analyzer(drcontext, ilist, records, /*skip_records=*/0, num_records);
     if (std::count(res.begin(), res.end(), '\n') != num_records) {
@@ -298,7 +329,6 @@ test_num_memrefs(void *drcontext, instrlist_t &ilist,
 
 bool
 test_skip_memrefs(void *drcontext, instrlist_t &ilist,
-                  const std::vector<memref_t> &memrefs,
                   const std::vector<trace_entry_t> &records, int skip_records,
                   int num_records)
 {
@@ -306,7 +336,10 @@ test_skip_memrefs(void *drcontext, instrlist_t &ilist,
     // XXX: To test precisely skipping the instrs and data we'll need to spend
     // more effort here, but the initial delayed markers are the corner cases.
     int all_count = 0, marker_count = 0;
-    for (const auto &memref : memrefs) {
+    test_util::mock_reader_t reader = test_util::mock_reader_t(records);
+    test_util::mock_reader_t reader_end = test_util::mock_reader_t();
+    for (reader.init(); reader != reader_end; ++reader) {
+        memref_t memref = *reader;
         if (all_count++ < skip_records)
             continue;
         if (all_count - skip_records > num_records)
@@ -314,7 +347,7 @@ test_skip_memrefs(void *drcontext, instrlist_t &ilist,
         if (memref.marker.type == TRACE_TYPE_MARKER)
             ++marker_count;
     }
-    ASSERT(static_cast<size_t>(num_records + skip_records) <= memrefs.size(),
+    ASSERT(num_records + skip_records <= get_memref_count(records),
            "need more memrefs to skip");
     std::string res =
         run_with_analyzer(drcontext, ilist, records, skip_records, num_records);
@@ -352,25 +385,6 @@ test_skip_memrefs(void *drcontext, instrlist_t &ilist,
 }
 
 bool
-test_no_modules(void *drcontext, instrlist_t &ilist, const std::vector<memref_t> &memrefs)
-{
-    view_nomod_test_t view(drcontext, ilist);
-    std::string res = run_test_helper(view, memrefs);
-    if (std::count(res.begin(), res.end(), '\n') != static_cast<int>(memrefs.size())) {
-        std::cerr << "Incorrect line count\n";
-        return false;
-    }
-    std::stringstream ss(res);
-    int prefix;
-    ss >> prefix;
-    if (prefix != 1) {
-        std::cerr << "Expect 1-based line prefixes\n";
-        return false;
-    }
-    return true;
-}
-
-bool
 run_limit_tests(void *drcontext)
 {
     bool res = true;
@@ -388,22 +402,6 @@ run_limit_tests(void *drcontext)
     size_t offs_nop2 = offs_jcc + instr_length(drcontext, jcc);
 
     const memref_tid_t t1 = 3;
-    std::vector<memref_t> memrefs = {
-        gen_marker(t1, TRACE_MARKER_TYPE_VERSION, 3),
-        gen_marker(t1, TRACE_MARKER_TYPE_FILETYPE, 0),
-        gen_marker(t1, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
-        gen_marker(t1, TRACE_MARKER_TYPE_TIMESTAMP, 1001),
-        gen_marker(t1, TRACE_MARKER_TYPE_CPU_ID, 2),
-        gen_instr(t1, offs_nop1),
-        gen_data(t1, true, 0x42, 4),
-        gen_marker(t1, TRACE_MARKER_TYPE_TIMESTAMP, 1002),
-        gen_marker(t1, TRACE_MARKER_TYPE_CPU_ID, 3),
-        gen_branch(t1, offs_jcc),
-        gen_instr(t1, offs_nop2),
-        gen_data(t1, true, 0x42, 4),
-    };
-    // To test skipping and limiting we need to use an analyzer which requires
-    // a trace_entry_t version of the above.
     std::vector<trace_entry_t> records = {
         test_util::make_thread(t1),
         test_util::make_pid(/*pid=*/1),
@@ -420,18 +418,19 @@ run_limit_tests(void *drcontext)
         test_util::make_instr(offs_nop2, TRACE_TYPE_INSTR),
         test_util::make_memref(0x42, TRACE_TYPE_READ, 4),
     };
+    int memref_count = get_memref_count(records);
 
-    res = test_no_limit(drcontext, *ilist, memrefs) && res;
-    for (int i = 1; i < static_cast<int>(memrefs.size()); ++i) {
+    res = test_no_limit(drcontext, *ilist, records) && res;
+    for (int i = 1; i < memref_count; ++i) {
         res = test_num_memrefs(drcontext, *ilist, records, i) && res;
     }
     constexpr int num_refs = 2;
-    for (int i = 1; i < static_cast<int>(memrefs.size() - num_refs); ++i) {
-        res = test_skip_memrefs(drcontext, *ilist, memrefs, records, i, num_refs) && res;
+    for (int i = 1; i < memref_count - num_refs; ++i) {
+        res = test_skip_memrefs(drcontext, *ilist, records, i, num_refs) && res;
     }
 
     // Ensure missing modules are fine.
-    res = test_no_modules(drcontext, *ilist, memrefs) && res;
+    res = test_no_modules(drcontext, *ilist, records) && res;
 
     instrlist_clear_and_destroy(drcontext, ilist);
     return res;

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -384,8 +384,8 @@ run_limit_tests(void *drcontext)
     instrlist_append(ilist, jcc);
     instrlist_append(ilist, nop2);
     size_t offs_nop1 = 0;
-    size_t offs_jz = offs_nop1 + instr_length(drcontext, nop1);
-    size_t offs_nop2 = offs_jz + instr_length(drcontext, jcc);
+    size_t offs_jcc = offs_nop1 + instr_length(drcontext, nop1);
+    size_t offs_nop2 = offs_jcc + instr_length(drcontext, jcc);
 
     const memref_tid_t t1 = 3;
     std::vector<memref_t> memrefs = {
@@ -398,8 +398,8 @@ run_limit_tests(void *drcontext)
         gen_data(t1, true, 0x42, 4),
         gen_marker(t1, TRACE_MARKER_TYPE_TIMESTAMP, 1002),
         gen_marker(t1, TRACE_MARKER_TYPE_CPU_ID, 3),
-        gen_branch(t1, offs_jz),
-        gen_branch(t1, offs_nop2),
+        gen_branch(t1, offs_jcc),
+        gen_instr(t1, offs_nop2),
         gen_data(t1, true, 0x42, 4),
     };
     // To test skipping and limiting we need to use an analyzer which requires
@@ -416,8 +416,8 @@ run_limit_tests(void *drcontext)
         test_util::make_memref(0x42, TRACE_TYPE_READ, 4),
         test_util::make_marker(TRACE_MARKER_TYPE_TIMESTAMP, 1002),
         test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 3),
-        test_util::make_instr(offs_jz, TRACE_TYPE_INSTR_UNTAKEN_JUMP),
-        test_util::make_instr(offs_nop2, TRACE_TYPE_INSTR_UNTAKEN_JUMP),
+        test_util::make_instr(offs_jcc, TRACE_TYPE_INSTR_UNTAKEN_JUMP),
+        test_util::make_instr(offs_nop2, TRACE_TYPE_INSTR),
         test_util::make_memref(0x42, TRACE_TYPE_READ, 4),
     };
 

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -90,7 +90,8 @@ public:
                         std::istream *serial_schedule_file = nullptr,
                         std::istream *cpu_schedule_file = nullptr,
                         bool abort_on_invariant_error = true,
-                        bool dynamic_syscall_trace_injection = false);
+                        bool dynamic_syscall_trace_injection = false,
+                        bool trace_incomplete = false);
     virtual ~invariant_checker_t();
     std::string
     initialize_shard_type(shard_type_t shard_type) override;
@@ -254,6 +255,7 @@ protected:
         // Relevant when -no_abort_on_invariant_error.
         uint64_t error_count_ = 0;
         int64_t last_chunk_ordinal_ = -1;
+        bool adjusted_ordinal_for_incomplete_ = false;
     };
 
     // We provide this for subclasses to run these invariants with custom
@@ -318,6 +320,7 @@ protected:
 
     bool abort_on_invariant_error_ = true;
     bool dynamic_syscall_trace_injection_ = false;
+    bool trace_incomplete_ = false;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tools/view.h
+++ b/clients/drcachesim/tools/view.h
@@ -58,9 +58,8 @@ public:
     // OFFLINE_FILE_TYPE_ENCODINGS.
     // XXX: Once we update our toolchains to guarantee C++17 support we could use
     // std::optional here.
-    view_t(const std::string &module_file_path, uint64_t skip_refs, uint64_t sim_refs,
-           const std::string &syntax, unsigned int verbose,
-           const std::string &alt_module_dir = "");
+    view_t(const std::string &module_file_path, const std::string &syntax,
+           unsigned int verbose, const std::string &alt_module_dir = "");
     virtual ~view_t() = default;
     std::string
     initialize_stream(memtrace_stream_t *serial_stream) override;
@@ -107,9 +106,6 @@ protected:
             instr_t *instr, app_pc decode_pc) override;
     };
 
-    bool
-    should_skip(memtrace_stream_t *memstream, const memref_t &memref);
-
     // Creates and initializes a decode_cache_t instance to decode instructions in the
     // trace. Made virtual to allow subclasses to customize.
     virtual bool
@@ -121,13 +117,16 @@ protected:
     bool
     init_from_filetype();
 
-    inline void
+    virtual void
     print_header()
     {
         std::cerr << "Output format:\n"
                   << "<--record#-> <--instr#->: <Wrkld.Tid> <record details>\n"
                   << "------------------------------------------------------------\n";
     }
+
+    void
+    print_cached_records(memtrace_stream_t *memstream);
 
     inline void
     print_prefix(memtrace_stream_t *memstream, const memref_t &memref,
@@ -161,25 +160,16 @@ protected:
     unsigned int knob_verbose_;
     int trace_version_;
     static const std::string TOOL_NAME;
-    uint64_t knob_skip_refs_;
-    uint64_t skip_refs_left_;
-    uint64_t knob_sim_refs_;
-    uint64_t sim_refs_left_;
-    bool refs_limited_;
     std::string knob_syntax_;
     std::string knob_alt_module_dir_;
     uint64_t num_disasm_instrs_;
     memref_tid_t prev_tid_;
     uint64_t prev_record_ = 0;
     intptr_t filetype_;
-    bool saw_headers_ = false;
-    std::unordered_set<memref_tid_t> printed_header_;
     std::unordered_map<memref_tid_t, uintptr_t> last_window_;
     uintptr_t timestamp_;
     int64_t timestamp_record_ord_ = -1;
     memref_t timestamp_memref_;
-    int64_t version_record_ord_ = -1;
-    int64_t filetype_record_ord_ = -1;
     bool init_from_filetype_done_ = false;
     std::unique_ptr<decode_cache_t<disasm_info_t>> decode_cache_ = nullptr;
     memtrace_stream_t *serial_stream_ = nullptr;

--- a/clients/drcachesim/tools/view_create.h
+++ b/clients/drcachesim/tools/view_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2018-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2018-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -52,9 +52,8 @@ namespace drmemtrace {
  * It does not support online analysis.
  */
 analysis_tool_t *
-view_tool_create(const std::string &module_file_path, uint64_t skip_refs,
-                 uint64_t sim_refs, const std::string &syntax, unsigned int verbose = 0,
-                 const std::string &alt_module_dir = "");
+view_tool_create(const std::string &module_file_path, const std::string &syntax,
+                 unsigned int verbose = 0, const std::string &alt_module_dir = "");
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4196,7 +4196,7 @@ if (BUILD_CLIENTS)
           set(infile "${core_sharded_dir}/drmemtrace.core.000000.trace.zip")
           add_test(tool.drcacheoff.stdin
             ${BASH_EXE} -c
-            "${CAT_EXE} ${infile} | ${GUNZIP_EXE} | ${drrun_path} -t drmemtrace -tool view -sim_refs 10 -infile -")
+            "${CAT_EXE} ${infile} | ${GUNZIP_EXE} | ${drrun_path} -t drmemtrace -tool view -exit_after_records 10 -infile -")
           file(READ "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests/offline-stdin.expect"
             stdin_expect)
           set_tests_properties(tool.drcacheoff.stdin PROPERTIES
@@ -4565,14 +4565,14 @@ if (BUILD_CLIENTS)
       torunonly_api(tool.drcacheoff.skip "${drcachesim_path}" "offline-skip" ""
         # Test invariants with global headers after skipping instrs.
         # Here the skip does not find real headers and we expect synthetic.
-        "-tool;view;-view_syntax;dr;-infile;${zip_path};${test_mode_flag};-skip_instrs;62;-sim_refs;10"
+        "-tool;view;-view_syntax;dr;-infile;${zip_path};${test_mode_flag};-skip_instrs;62;-exit_after_records;10"
         OFF OFF)
       set(tool.drcacheoff.skip_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.skip_rawtemp ON) # no preprocessor
       torunonly_api(tool.drcacheoff.skip2 "${drcachesim_path}" "offline-skip2" ""
         # Test invariants with global headers after skipping instrs.
         # Here the skip finds real headers and we expect no synthetic.
-        "-tool;view;-view_syntax;dr;-infile;${zip_path};${test_mode_flag};-skip_instrs;63;-sim_refs;10"
+        "-tool;view;-view_syntax;dr;-infile;${zip_path};${test_mode_flag};-skip_instrs;63;-exit_after_records;10"
         OFF OFF)
       set(tool.drcacheoff.skip2_basedir "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
       set(tool.drcacheoff.skip2_rawtemp ON) # no preprocessor
@@ -4589,7 +4589,7 @@ if (BUILD_CLIENTS)
 
       # Test that one tool exiting early does not impact a second tool.
       torunonly_api(tool.drcacheoff.one_early "${drcachesim_path}" "offline-one-early" ""
-        "-verbose;1;-tool;view:opcode_mix;-sim_refs;10;-infile;${zip_path}"
+        "-verbose;1;-tool;TLB:opcode_mix;-core_serial;-sim_refs;10;-infile;${zip_path}"
         OFF OFF)
       set(tool.drcacheoff.one_early_basedir
         "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
@@ -4639,14 +4639,14 @@ if (BUILD_CLIENTS)
         "@-tool@opcode_mix@-skip_instrs@1" "")
 
       torunonly_drcacheoff(view ${ci_shared_app} ""
-        "@-tool@view@-sim_refs@16384" "")
+        "@-tool@view@-exit_after_records@16384" "")
       unset(tool.drcacheoff.view_rawtemp) # Use preprocessor
       if (AARCH64 AND proc_supports_sve)
         set(tool.drcacheoff.view_runsve 1)
       endif ()
 
       torunonly_drcacheoff(view-skip-instrs ${ci_shared_app} ""
-        "@-tool@view@-sim_refs@16384@-skip_instrs@1" "")
+        "@-tool@view@-exit_after_records@16384@-skip_instrs@1" "")
       unset(tool.drcacheoff.view-skip-instrs_rawtemp)
 
       set(tool.drcacheoff.func_view_full_run ON) # Fails on Windows if truncated.


### PR DESCRIPTION
Removes support for -skip_refs and -sim_refs from the view tool. These now count only non-markers and are limited to the simulator tools. They have been replaced by analyzer-provided -skip_records and -exit_after_records.

Adds an error message if a user tries to use the old options.

Removes the delay for printing version and filetype records. It is from a very old file reader which did not re-order records; the modern file reader re-orders so the reader_t always sees the tid before the first visible record.  This avoids having to port the old sim_refs logic for the delayed headers.

Augments invariant_checker with a flag "trace_incomplete" which relaxes the invariant that a thread exit is seen and also adds handling of skip_records via a heuristic.

Adjusts the drcacheoff.skip test to expect 2 more instructions, as -exit_after_records does not count synthetic records including the 2 markers inserted after -skip_instrs.

Augments the view_test's testing of skipping and limiting to create an analyzer and use the new options.

Changes the one_early test to use the TLB simulator instead of the view tool.

Fixes #7230