### PR TITLE
Apply drsyscall Ubuntu22 fix from drmemory

### DIFF
--- a/ext/drsyscall/drsyscall.c
+++ b/ext/drsyscall/drsyscall.c
@@ -175,7 +175,8 @@ check_syscall_gateway(instr_t *inst)
                    "multiple system call gateways not supported");
         }
     } else if (instr_get_opcode(inst) == OP_syscall) {
-        if (syscall_gateway == DRSYS_GATEWAY_UNKNOWN)
+        if (syscall_gateway == DRSYS_GATEWAY_UNKNOWN ||
+            syscall_gateway == DRSYS_GATEWAY_INT)
             syscall_gateway = DRSYS_GATEWAY_SYSCALL;
         else {
             ASSERT(syscall_gateway ==


### PR DESCRIPTION
Applies a fix needed for running the drmemory drsyscall tests on Ubuntu22 from DynamoRIO/drmemory#2561. We have to duplicate every change in both places because drsyscall is currently duplicated in drmemory and dynamorio: #7303 covers removing it from drmemory.

Issue: #7303, DynamoRIO/drmemory#2548