### PR TITLE
i#7504 time scale: Add stats on drx scaling

### DIFF
--- a/suite/tests/client-interface/drx_sleep_scale-test.cpp
+++ b/suite/tests/client-interface/drx_sleep_scale-test.cpp
@@ -213,6 +213,8 @@ event_exit(void)
                    stats[i].count_attempted, stats[i].count_failed, stats[i].count_nop);
     }
     assert(stats[DRX_SCALE_SLEEP].count_attempted > 0);
+    assert(stats[DRX_SCALE_SLEEP].count_attempted >=
+           stats[DRX_SCALE_SLEEP].count_failed + stats[DRX_SCALE_SLEEP].count_nop);
     assert(stats[DRX_SCALE_SLEEP].count_failed == 0);
     assert(stats[DRX_SCALE_SLEEP].count_nop > 0);
 

--- a/suite/tests/client-interface/drx_sleep_scale-test.templatex
+++ b/suite/tests/client-interface/drx_sleep_scale-test.templatex
@@ -1,5 +1,7 @@
 in dr_client_main.*
+.*
 client done.*
 in dr_client_main.*
+.*
 client done.*
 app done

--- a/suite/tests/client-interface/drx_time_scale-test.c
+++ b/suite/tests/client-interface/drx_time_scale-test.c
@@ -232,10 +232,15 @@ event_exit(void)
     }
     assert(stats[DRX_SCALE_ITIMER].count_attempted > 0);
     assert(stats[DRX_SCALE_ITIMER].count_failed == 0);
+    assert(stats[DRX_SCALE_ITIMER].count_attempted >=
+           stats[DRX_SCALE_ITIMER].count_failed + stats[DRX_SCALE_ITIMER].count_nop);
     // The nop for timers will be >0 as it counts it_value too so we
     // do not require it to be 0.
     assert(stats[DRX_SCALE_POSIX_TIMER].count_attempted > 0);
     assert(stats[DRX_SCALE_POSIX_TIMER].count_failed == 0);
+    assert(stats[DRX_SCALE_POSIX_TIMER].count_attempted >=
+           stats[DRX_SCALE_POSIX_TIMER].count_failed +
+               stats[DRX_SCALE_POSIX_TIMER].count_nop);
 
     ok = drx_unregister_time_scaling();
     assert(ok);

--- a/suite/tests/client-interface/drx_time_scale-test.c
+++ b/suite/tests/client-interface/drx_time_scale-test.c
@@ -223,7 +223,21 @@ disable_timers(void)
 static void
 event_exit(void)
 {
-    bool ok = drx_unregister_time_scaling();
+    drx_time_scale_stat_t *stats;
+    bool ok = drx_get_time_scaling_stats(&stats);
+    assert(ok);
+    for (int i = 0; i < DRX_SCALE_STAT_TYPES; ++i) {
+        dr_fprintf(STDERR, "type %d: attempt " SZFMT " fail " SZFMT " nop " SZFMT "\n", i,
+                   stats[i].count_attempted, stats[i].count_failed, stats[i].count_nop);
+    }
+    assert(stats[DRX_SCALE_ITIMER].count_attempted > 0);
+    assert(stats[DRX_SCALE_ITIMER].count_failed == 0);
+    // The nop for timers will be >0 as it counts it_value too so we
+    // do not require it to be 0.
+    assert(stats[DRX_SCALE_POSIX_TIMER].count_attempted > 0);
+    assert(stats[DRX_SCALE_POSIX_TIMER].count_failed == 0);
+
+    ok = drx_unregister_time_scaling();
     assert(ok);
     drx_exit();
     dr_fprintf(STDERR, "client done\n");

--- a/suite/tests/client-interface/drx_time_scale-test.templatex
+++ b/suite/tests/client-interface/drx_time_scale-test.templatex
@@ -1,8 +1,10 @@
 .*
 in dr_client_main.*
+.*
 client done
 .*
 in dr_client_main.*
+.*
 client done
 .*
 app done


### PR DESCRIPTION
Records and provides statistics on the counts of scaling attempts, failures, and nops for each class of operations that are scaled.

Adds testing of the new interface.

Issue: #7504