### PR TITLE
i#7504 time scale: Increase zero sleep to scale it

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -704,6 +704,10 @@ public:
          * blocking and trigger a context switch.
          */
         uint64_t syscall_switch_threshold = 30000000;
+        /* If we change this, we should change drx time scaling's zero sleep
+         * conversion ZERO_PRE_INFLATE_NSEC so that it hits this threshold
+         * with a 50x (commonly applied) scale.
+         */
         /**
          * Determines the minimum latency in the unit of the trace's timestamps
          * (microseconds) for which a maybe-blocking system call (one with

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -606,6 +606,10 @@ typedef struct _drx_time_scale_stat_t {
      * Count of the instances ignored (disabled timers, sleep of 0, scale of 1, etc.).
      */
     ptr_int_t count_nop;
+    /**
+     * Count of instances converted from zero to non-zero before scaling.
+     */
+    ptr_int_t count_zero_to_nonzero;
 } drx_time_scale_stat_t;
 
 /**

--- a/suite/tests/client-interface/drx_sleep_scale-test.cpp
+++ b/suite/tests/client-interface/drx_sleep_scale-test.cpp
@@ -227,6 +227,7 @@ event_exit(void)
     // sleep should have become non-0.
     assert(stats[DRX_SCALE_SLEEP].count_nop == stats[DRX_SCALE_SLEEP].count_attempted ||
            stats[DRX_SCALE_SLEEP].count_nop == 0);
+    assert(stats[DRX_SCALE_SLEEP].count_zero_to_nonzero > 0);
 
     ok = drx_unregister_time_scaling();
     assert(ok);


### PR DESCRIPTION
A sleep system call with a zero duration is not a nop and does block. We increase a requested zero to 10us so it will be inflated too.

Adds a sanity check on the nop stats to the drx sleep test. Manually tested further on a large application with drmemtrace -scale_timeouts.

Issue: #7504