### PR TITLE
i#7504 scale time: Scale futex timeouts

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -5833,6 +5833,11 @@ dr_invoke_syscall_as_app(void *drcontext, int sysnum, int arg_count, ...)
      * arches that's just the return value which equals the 1st parameter.
      */
     reg_t saved[MAX_PARAM_COUNT];
+    /* Save the sysnum and result before we call set_syscall_param() as
+     * there can be overlap between the args or number and the result.
+     */
+    reg_t saved_sysnum = MCXT_SYSNUM_REG(mc);
+    reg_t saved_res = MCXT_SYSCALL_RES(mc);
     va_list ap;
     va_start(ap, arg_count);
     /* In some builds, Werror=array-bounds complains about saved[i] despite our
@@ -5844,9 +5849,7 @@ dr_invoke_syscall_as_app(void *drcontext, int sysnum, int arg_count, ...)
         set_syscall_param(dcontext, i, args[i]);
     }
     va_end(ap);
-    reg_t saved_sysnum = MCXT_SYSNUM_REG(mc);
     MCXT_SYSNUM_REG(mc) = sysnum;
-    reg_t saved_res = MCXT_SYSCALL_RES(mc);
     reg_t res;
     /* Skip client syscall events. */
     dcontext->client_data->skip_client_syscall_events = true;

--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -579,6 +579,7 @@ typedef enum {
     DRX_SCALE_ITIMER,      /**< Any of the 3 itimers. */
     DRX_SCALE_POSIX_TIMER, /**< Any POSIX timer. */
     DRX_SCALE_SLEEP,       /**< Any sleep system call. */
+    DRX_SCALE_FUTEX,       /**< The futex system call. */
     DRX_SCALE_STAT_TYPES,  /**< Count of stat types. */
 } drx_time_scale_type_t;
 

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -364,9 +364,13 @@ event_filter_syscall(void *drcontext, int sysnum)
 #ifndef X64
     case SYS_timer_gettime64:
     case SYS_timer_settime64:
+    case SYS_clock_nanosleep_time64:
 #endif
     case SYS_setitimer:
-    case SYS_getitimer: return true;
+    case SYS_getitimer:
+    case SYS_nanosleep:
+    case SYS_clock_nanosleep:
+    case SYS_futex: return true;
     }
     return false;
 }

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -232,8 +232,8 @@ inflate_absolute_timespec(void *drcontext, struct timespec *spec, int scale,
         increment_attempt_and_failure(type);
         return false;
     }
-    int64_t cur_nanos = cur_time.tv_sec * MAX_TV_NSEC + cur_time.tv_nsec;
-    int64_t target_nanos = spec->tv_sec * MAX_TV_NSEC + spec->tv_nsec;
+    int64_t cur_nanos = (int64_t)cur_time.tv_sec * MAX_TV_NSEC + cur_time.tv_nsec;
+    int64_t target_nanos = (int64_t)spec->tv_sec * MAX_TV_NSEC + spec->tv_nsec;
     int64_t diff_nanos = target_nanos < cur_nanos ? 0 : target_nanos - cur_nanos;
     if (diff_nanos == 0) {
         diff_nanos = ZERO_PRE_INFLATE_NSEC;
@@ -245,7 +245,7 @@ inflate_absolute_timespec(void *drcontext, struct timespec *spec, int scale,
     /* Now inflate the relative. */
     inflate_timespec(drcontext, &rel, scale, type);
     /* Now convert back to absolute. */
-    int64_t scaled_diff_nanos = rel.tv_sec * MAX_TV_NSEC + rel.tv_nsec;
+    int64_t scaled_diff_nanos = (int64_t)rel.tv_sec * MAX_TV_NSEC + rel.tv_nsec;
     int64_t scaled_target_nanos = cur_nanos + scaled_diff_nanos;
     spec->tv_sec = scaled_target_nanos / MAX_TV_NSEC;
     spec->tv_nsec = scaled_target_nanos % MAX_TV_NSEC;

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -45,6 +45,9 @@
 #    ifdef LINUX
 #        include "../../core/unix/include/syscall.h"
 #        include <linux/futex.h>
+#        ifndef FUTEX_LOCK_PI2
+#            define FUTEX_LOCK_PI2 13
+#        endif
 #    else
 #        error Non-Linux not yet supported
 #        include <sys/syscall.h>

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2987,6 +2987,12 @@ if (NOT RISCV64) # TODO i#3544: Port tests to RISC-V 64
       "" "" OFF ON OFF)
     use_DynamoRIO_extension(client.drx_sleep_scale-test drx_static)
     link_with_pthread(client.drx_sleep_scale-test)
+
+    set(client.drx_timeout_scale-test_no_reg_compat) # Avoid REG_ name conflicts.
+    tobuild_api(client.drx_timeout_scale-test client-interface/drx_timeout_scale-test.cpp
+      "" "" OFF ON OFF)
+    use_DynamoRIO_extension(client.drx_timeout_scale-test drx_static)
+    link_with_pthread(client.drx_timeout_scale-test)
   endif ()
 endif (NOT RISCV64)
 

--- a/suite/tests/client-interface/drx_time_scale-test.c
+++ b/suite/tests/client-interface/drx_time_scale-test.c
@@ -227,8 +227,11 @@ event_exit(void)
     bool ok = drx_get_time_scaling_stats(&stats);
     assert(ok);
     for (int i = 0; i < DRX_SCALE_STAT_TYPES; ++i) {
-        dr_fprintf(STDERR, "type %d: attempt " SZFMT " fail " SZFMT " nop " SZFMT "\n", i,
-                   stats[i].count_attempted, stats[i].count_failed, stats[i].count_nop);
+        dr_fprintf(STDERR,
+                   "type %d: attempt " SZFMT " fail " SZFMT " nop " SZFMT
+                   " was-zero " SZFMT "\n",
+                   i, stats[i].count_attempted, stats[i].count_failed, stats[i].count_nop,
+                   stats[i].count_zero_to_nonzero);
     }
     assert(stats[DRX_SCALE_ITIMER].count_attempted > 0);
     assert(stats[DRX_SCALE_ITIMER].count_failed == 0);

--- a/suite/tests/client-interface/drx_timeout_scale-test.cpp
+++ b/suite/tests/client-interface/drx_timeout_scale-test.cpp
@@ -57,10 +57,6 @@
 #    error Only Linux supported for this test.
 #endif
 
-#ifndef FUTEX_LOCK_PI2
-#    define FUTEX_LOCK_PI2 13
-#endif
-
 namespace dynamorio {
 namespace drmemtrace {
 

--- a/suite/tests/client-interface/drx_timeout_scale-test.cpp
+++ b/suite/tests/client-interface/drx_timeout_scale-test.cpp
@@ -30,6 +30,12 @@
  * DAMAGE.
  */
 
+/* Tests system calls with timeouts.  This does share some boilerplate
+ * with drx_sleep_scale-test.cpp and drx_time_scale-test.cpp but it's
+ * not trivial to share and the other tests are too long in duration to
+ * combine into one test.
+ */
+
 #include <assert.h>
 #include <linux/futex.h>
 #include <math.h>
@@ -106,10 +112,11 @@ thread_routine(void *arg)
     timeout_zero.tv_sec = 0;
     timeout_zero.tv_nsec = 0;
     while (!child_should_exit.load(std::memory_order_acquire)) {
-        // Test a zero timeout.
         struct timespec *timeout = &timeout_default;
-        if (futex_count == 0)
+        if (futex_count == 0) {
+            // Test a zero timeout.
             timeout = &timeout_zero;
+        }
 
         // Test a relative timeout.
         int res = syscall(SYS_futex, &futex_var, FUTEX_WAIT, FUTEX_VAL, timeout,

--- a/suite/tests/client-interface/drx_timeout_scale-test.cpp
+++ b/suite/tests/client-interface/drx_timeout_scale-test.cpp
@@ -31,11 +31,11 @@
  */
 
 #include <assert.h>
+#include <linux/futex.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <string.h>
-#include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <syscall.h>
@@ -85,85 +85,59 @@ my_setenv(const char *var, const char *value)
     return setenv(var, value, 1 /*override*/) == 0;
 }
 
-static void
-handler(int sig)
-{
-    // Nothing; just interrupt the sleep.
-}
-
 static void *
 thread_routine(void *arg)
 {
     bool clock_version = static_cast<bool>(reinterpret_cast<size_t>(arg));
-    int64_t sleep_count = 0;
-
-    signal(SIGUSR1, handler);
+    int64_t futex_count = 0;
 
     pthread_mutex_lock(&lock);
     child_ready = true;
     pthread_cond_signal(&condvar);
     pthread_mutex_unlock(&lock);
 
-    constexpr int SLEEP_NSEC = 100000;
-    struct timespec sleeptime;
-    sleeptime.tv_sec = 0;
-    sleeptime.tv_nsec = SLEEP_NSEC;
-    struct timespec remaining;
-#ifndef X64
-    timespec64_t sleeptime64;
-    sleeptime64.tv_sec = 0;
-    sleeptime64.tv_nsec = SLEEP_NSEC;
-    timespec64_t remaining64;
-#endif
-    int64_t eintr_count = 0;
+    // We perform a futex that will always time out as our value never changes.
+    constexpr int FUTEX_VAL = 0xabcd;
+    int32_t futex_var = FUTEX_VAL;
+    constexpr int FUTEX_NSEC = 100000;
+    struct timespec timeout_default;
+    timeout_default.tv_sec = 0;
+    timeout_default.tv_nsec = FUTEX_NSEC;
+    struct timespec timeout_zero;
+    timeout_zero.tv_sec = 0;
+    timeout_zero.tv_nsec = 0;
     while (!child_should_exit.load(std::memory_order_acquire)) {
-        // Test a sleep of 0.
-        if (sleep_count == 0) {
-            sleeptime.tv_nsec = 0;
-#ifndef X64
-            sleeptime64.tv_nsec = 0;
-#endif
-        } else {
-            sleeptime.tv_nsec = SLEEP_NSEC;
-#ifndef X64
-            sleeptime64.tv_nsec = SLEEP_NSEC;
-#endif
-        }
-        ++sleep_count;
-        int res;
-        if (clock_version) {
-            // This is what modern libc nanosleep() calls.
-#ifdef X64
-            res = syscall(SYS_clock_nanosleep, CLOCK_REALTIME, 0, &sleeptime, &remaining);
-#else
-            res = syscall(SYS_clock_nanosleep_time64, CLOCK_REALTIME, 0, &sleeptime64,
-                          &remaining64);
-#endif
-        } else {
-            res = syscall(SYS_nanosleep, &sleeptime, &remaining);
-        }
-        if (res != 0) {
-            assert(errno == EINTR);
-            // Ensure the remaining time was deflated.
-            // Nanosleep rounds up to and the remainder can be slightly larger
-            // so we allow up to 2x.
-#ifndef X64
-            if (clock_version) {
-                assert(remaining64.tv_sec == 0 &&
-                       remaining64.tv_nsec <= 2 * sleeptime64.tv_nsec);
-            } else {
-#endif
-                assert(remaining.tv_sec == 0 &&
-                       remaining.tv_nsec <= 2 * sleeptime.tv_nsec);
-#ifndef X64
-            }
-#endif
-            ++eintr_count;
-        }
+        // Test a zero timeout.
+        struct timespec *timeout = &timeout_default;
+        if (futex_count == 0)
+            timeout = &timeout_zero;
+
+        // Test a relative timeout.
+        int res = syscall(SYS_futex, &futex_var, FUTEX_WAIT, FUTEX_VAL, timeout,
+                          /*uaddr2=*/nullptr, /*val3=*/0);
+        assert(res != 0 && errno == ETIMEDOUT);
+
+        // Test an absolute timeout.
+        struct timespec cur_time;
+        // Test both realtime and monotonic clocks.
+        bool realtime = futex_count % 2 == 0;
+        res = clock_gettime(realtime ? CLOCK_REALTIME : CLOCK_MONOTONIC, &cur_time);
+        assert(res == 0);
+        constexpr int MAX_TV_NSEC = 1000000000ULL;
+        int64_t cur_nanos = cur_time.tv_sec * MAX_TV_NSEC + cur_time.tv_nsec;
+        int64_t target_nanos = cur_nanos + FUTEX_NSEC;
+        struct timespec timeout_abs;
+        timeout_abs.tv_sec = target_nanos / MAX_TV_NSEC;
+        timeout_abs.tv_nsec = target_nanos % MAX_TV_NSEC;
+        res = syscall(SYS_futex, &futex_var,
+                      FUTEX_WAIT_BITSET | (realtime ? FUTEX_CLOCK_REALTIME : 0),
+                      FUTEX_VAL, &timeout_abs,
+                      /*uaddr2=*/nullptr, FUTEX_BITSET_MATCH_ANY);
+        assert(res != 0 && errno == ETIMEDOUT);
+
+        ++futex_count;
     }
-    assert(eintr_count > 0);
-    std::cerr << "eintrs=" << eintr_count << "\n";
-    return reinterpret_cast<void *>(sleep_count);
+    return reinterpret_cast<void *>(futex_count);
 }
 
 static int64_t
@@ -187,18 +161,12 @@ do_some_work(bool clock_version)
     while (!child_ready)
         pthread_cond_wait(&condvar, &lock);
     pthread_mutex_unlock(&lock);
-    // Now take some time doing work so we can measure how many sleeps the child
+    // Now take some time doing work so we can measure how many futexes the child
     // accomplishes in this time period.
     constexpr int ITERS = 10000000;
     double val = static_cast<double>(ITERS);
     for (int i = 0; i < ITERS; ++i) {
         val += sin(val);
-        // Test interrupting the thread's sleeps.
-        if (i % (ITERS / 20) == 0 ||
-            // Add a use of val so it's not optimized away.
-            val == 0.) {
-            pthread_kill(thread, SIGUSR1);
-        }
     }
     // Clean up.
     child_should_exit.store(true, std::memory_order_release);
@@ -222,15 +190,15 @@ event_exit(void)
                    i, stats[i].count_attempted, stats[i].count_failed, stats[i].count_nop,
                    stats[i].count_zero_to_nonzero);
     }
-    assert(stats[DRX_SCALE_SLEEP].count_attempted > 0);
-    assert(stats[DRX_SCALE_SLEEP].count_attempted >=
-           stats[DRX_SCALE_SLEEP].count_failed + stats[DRX_SCALE_SLEEP].count_nop);
-    assert(stats[DRX_SCALE_SLEEP].count_failed == 0);
+    assert(stats[DRX_SCALE_FUTEX].count_attempted > 0);
+    assert(stats[DRX_SCALE_FUTEX].count_attempted >=
+           stats[DRX_SCALE_FUTEX].count_failed + stats[DRX_SCALE_FUTEX].count_nop);
+    assert(stats[DRX_SCALE_FUTEX].count_failed == 0);
     // Either scale was 1 and everything is a nop, or if scaling then our 0-duration
-    // sleep should have become non-0.
-    assert(stats[DRX_SCALE_SLEEP].count_nop == stats[DRX_SCALE_SLEEP].count_attempted ||
-           stats[DRX_SCALE_SLEEP].count_nop == 0);
-    assert(stats[DRX_SCALE_SLEEP].count_zero_to_nonzero > 0);
+    // futex should have become non-0.
+    assert(stats[DRX_SCALE_FUTEX].count_nop == stats[DRX_SCALE_FUTEX].count_attempted ||
+           stats[DRX_SCALE_FUTEX].count_nop == 0);
+    assert(stats[DRX_SCALE_FUTEX].count_zero_to_nonzero > 0);
 
     ok = drx_unregister_time_scaling();
     assert(ok);
@@ -239,7 +207,7 @@ event_exit(void)
 }
 
 static int64_t
-test_sleep(bool clock_version, int scale)
+test_futex(bool clock_version, int scale)
 {
     std::string dr_ops("-stderr_mask 0xc -client_lib ';;" + std::to_string(scale) + "'");
     if (!my_setenv("DYNAMORIO_OPTIONS", dr_ops.c_str()))
@@ -251,20 +219,15 @@ test_sleep(bool clock_version, int scale)
 }
 
 static void
-test_sleep_scale()
+test_futex_scale()
 {
-    int64_t sleeps_default = test_sleep(/*clock_version=*/true, 1);
+    int64_t futexes_default = test_futex(/*clock_version=*/true, 1);
     constexpr int SCALE = 100;
-    int64_t sleeps_scaled = test_sleep(/*clock_version=*/true, SCALE);
-    std::cerr << "sleeps default=" << sleeps_default << " clock scaled=" << sleeps_scaled
+    int64_t futexes_scaled = test_futex(/*clock_version=*/true, SCALE);
+    std::cerr << "futexes default=" << futexes_default << " scaled=" << futexes_scaled
               << "\n";
     // Ensure the scaling ends up within an order of magnitude.
-    assert(sleeps_default > SCALE / 10 * sleeps_scaled);
-    // Test SYS_nanosleep.
-    sleeps_scaled = test_sleep(/*clock_version=*/false, SCALE);
-    std::cerr << "sleeps default=" << sleeps_default
-              << " noclock scaled=" << sleeps_scaled << "\n";
-    assert(sleeps_default > SCALE / 10 * sleeps_scaled);
+    assert(futexes_default > SCALE / 10 * futexes_scaled);
 }
 
 } // namespace drmemtrace
@@ -294,7 +257,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
 int
 main(int argc, char *argv[])
 {
-    dynamorio::drmemtrace::test_sleep_scale();
+    dynamorio::drmemtrace::test_futex_scale();
     print("app done\n");
     return 0;
 }

--- a/suite/tests/client-interface/drx_timeout_scale-test.templatex
+++ b/suite/tests/client-interface/drx_timeout_scale-test.templatex
@@ -1,0 +1,7 @@
+in dr_client_main.*
+.*
+client done.*
+in dr_client_main.*
+.*
+client done.*
+app done


### PR DESCRIPTION
Adds scaling of futex timeouts to the drx time scaling feature. Adds handling of both relative and absolute (both clock types) varieties.

Adds a new test drx_timeout_scale-test which exercises each type of timeout (and will be used for other system call timeouts as well, hence the name).

Fixes a bug in dr_invoke_syscall_as_app() where the result reg was clobbered by a new argument on AArch64 (or RISCV), causing the FUTEX_WAIT_BITSET in the new test here to fail with EFAULT.

Issue: #7504