### PR TITLE
Remove std::iterator inheritance, which is deprecated in C++17.

### DIFF
--- a/clients/drcachesim/common/directory_iterator.h
+++ b/clients/drcachesim/common/directory_iterator.h
@@ -57,7 +57,7 @@ namespace drmemtrace {
 // Iterates over files: skips sub-directories.
 // Returns the basenames of the files (i.e., not absolute paths).
 // This class is not thread-safe.
-class directory_iterator_t : public std::iterator<std::input_iterator_tag, std::string> {
+class directory_iterator_t {
 public:
     directory_iterator_t()
     {

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -77,8 +77,7 @@ namespace drmemtrace {
  * also provides more information about the trace using the
  * #dynamorio::drmemtrace::memtrace_stream_t API.
  */
-class reader_t : public std::iterator<std::input_iterator_tag, memref_t>,
-                 public memtrace_stream_t {
+class reader_t : public memtrace_stream_t {
 public:
     reader_t()
     {

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -111,8 +111,7 @@ namespace drmemtrace {
  * record_reader_t is expected to provide the exact stream of
  * #dynamorio::drmemtrace::trace_entry_t as stored on disk.
  */
-class record_reader_t : public std::iterator<std::input_iterator_tag, trace_entry_t>,
-                        public memtrace_stream_t {
+class record_reader_t : public memtrace_stream_t {
 public:
     record_reader_t(int verbosity, const char *prefix)
         : verbosity_(verbosity)

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -73,8 +73,7 @@ public:
         memset(present_, 0, sizeof(present_));
     }
 
-    class reg_id_set_iterator_t
-        : public std::iterator<std::input_iterator_tag, reg_id_t> {
+    class reg_id_set_iterator_t {
     public:
         reg_id_set_iterator_t(reg_id_set_t *set)
             : set_(set)


### PR DESCRIPTION
Building on Debian 13, with g++ 14.2.0, one of the warnings (which were not treated as errors) was:

.../reader.h:80:30: warning: 'template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator' is deprecated [-Wdeprecated-declarations]