### PR TITLE
drsyscall: capture lseek and unlinkat syscalls for attach-memory-dump-syscall-test.

### DIFF
--- a/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
+++ b/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
@@ -69,8 +69,10 @@ event_filter_syscall(void *drcontext, int sysnum)
     }
     switch (sysnum) {
     case SYS_close:
+    case SYS_lseek:
     case SYS_openat:
     case SYS_read:
+    case SYS_unlinkat:
     case SYS_write: return true;
     default: return false;
     }


### PR DESCRIPTION
Capture lseek and unlinkat syscalls in suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c. These two syscalls are used by suite/tests/linux/syscall-records-attach.c through lseek() and remove().

Issue: #7588 