### PR TITLE
i#7604 user data: Add drmgr syscall filter event

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -136,6 +136,9 @@ changes:
 The changes between version \DR_VERSION and 11.3.0 include the following minor
 compatibility changes:
 
+ - Added drmgr_register_filter_syscall_event() and
+   drmgr_register_filter_syscall_event_user_data() which are required to be used
+   instead of dr_register_filter_syscall_event() when using drmgr.
  - Added a separate cache replacement policy object to `caching_device_t`. `init` now
    takes an `std::unique_ptr<cache_replacement_policy_t>` that defines the replacement
    policy. It can be created manually or by using `create_cache_replacement_policy`.

--- a/api/samples/strace.c
+++ b/api/samples/strace.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -76,7 +76,7 @@ dr_init(client_id_t id)
         0,
     };
     drmgr_init();
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_init(id, &ops) != DRMF_SUCCESS)

--- a/api/samples/syscall.c
+++ b/api/samples/syscall.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2018 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * Copyright (c) 2009-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -112,7 +112,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
                        "http://dynamorio.org/issues");
     drmgr_init();
     write_sysnum = get_write_sysnum();
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     dr_register_exit_event(event_exit);

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -416,7 +416,7 @@ event_app_instruction_case(void *drcontext, void *tag, instrlist_t *bb, instr_t 
 static void
 instrumentation_exit()
 {
-    dr_unregister_filter_syscall_event(event_filter_syscall);
+    drmgr_unregister_filter_syscall_event(event_filter_syscall);
     if (!drmgr_unregister_pre_syscall_event(event_pre_syscall) ||
         !drmgr_unregister_kernel_xfer_event(event_kernel_xfer) ||
         !drmgr_unregister_bb_app2app_event(event_bb_app2app))
@@ -472,7 +472,7 @@ instrumentation_init()
         !drmgr_register_kernel_xfer_event(event_kernel_xfer) ||
         !drmgr_register_bb_app2app_event(event_bb_app2app, &pri_pre_bbdup))
         DR_ASSERT(false);
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
 
     if (align_attach_detach_endpoints())
         tracing_mode.store(BBDUP_MODE_NOP, std::memory_order_release);

--- a/ext/drcovlib/drcovlib.c
+++ b/ext/drcovlib/drcovlib.c
@@ -1,5 +1,5 @@
 /* ***************************************************************************
- * Copyright (c) 2012-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
  * ***************************************************************************/
 
 /*
@@ -589,7 +589,7 @@ drcovlib_init(drcovlib_options_t *ops)
     drmgr_register_thread_init_event(event_thread_init);
     drmgr_register_thread_exit_event(event_thread_exit);
     drmgr_register_bb_instrumentation_event(event_basic_block_analysis, NULL, NULL);
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
 #ifdef UNIX
     dr_register_fork_init_event(event_fork);

--- a/ext/drmf/framework/samples/strace.c
+++ b/ext/drmf/framework/samples/strace.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2014-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2014-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -55,7 +55,7 @@ event_post_syscall(void *drcontext, int sysnum)
     uint64 result;
     uint error;
     if (drsys_cur_syscall_result(drcontext, &success, &result, &error) == DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "=> 0x"HEX64_FORMAT_STRING" ("SZFMT"), error=%d%s]\n",
+        dr_fprintf(STDERR, "=> 0x" HEX64_FORMAT_STRING " (" SZFMT "), error=%d%s]\n",
                    result, (ptr_int_t)result, error, success ? "" : " (failed)");
     }
 }
@@ -71,9 +71,12 @@ event_exit(void)
 DR_EXPORT void
 dr_init(client_id_t id)
 {
-    drsys_options_t ops = { sizeof(ops), 0, };
+    drsys_options_t ops = {
+        sizeof(ops),
+        0,
+    };
     drmgr_init();
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_init(id, &ops) != DRMF_SUCCESS)

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2010-2021 Google, Inc.   All rights reserved.
+ * Copyright (c) 2010-2025 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -73,6 +73,10 @@ extern "C" {
 #    define dr_register_thread_exit_event DO_NOT_USE_thread_event_USE_drmgr_events_instead
 #    define dr_unregister_thread_exit_event \
         DO_NOT_USE_thread_event_USE_drmgr_events_instead
+#    define dr_register_filter_syscall_event \
+        DO_NOT_USE_filter_syscall_USE_drmgr_events_instead
+#    define dr_unregister_filter_syscall_event \
+        DO_NOT_USE_filter_syscall_USE_drmgr_events_instead
 #    define dr_register_pre_syscall_event DO_NOT_USE_pre_syscall_USE_drmgr_events_instead
 #    define dr_unregister_pre_syscall_event \
         DO_NOT_USE_pre_syscall_USE_drmgr_events_instead
@@ -1211,10 +1215,42 @@ drmgr_unregister_thread_exit_event_user_data(void (*func)(void *drcontext,
 
 DR_EXPORT
 /**
+ * Registers a callback function for the syscall filter event, which
+ * behaves just like DR's pre-syscall event dr_register_filter_syscall_event().
+ * \return whether successful.
+ */
+bool
+drmgr_register_filter_syscall_event(bool (*func)(void *drcontext, int sysnum));
+
+DR_EXPORT
+/**
+ * Registers a callback function for the syscall filter event, which
+ * behaves just like DR's pre-syscall event dr_register_filter_syscall_event(),
+ * ordered by \p priority. Allows for the passing of user data \p user_data
+ * which is available upon the execution of the callback.
+ * \return whether successful.
+ */
+bool
+drmgr_register_filter_syscall_event_user_data(bool (*func)(void *drcontext, int sysnum,
+                                                           void *user_data),
+                                              drmgr_priority_t *priority,
+                                              void *user_data);
+
+DR_EXPORT
+/**
+ * Unregister a callback function for the syscall filter event.
+ * \return true if unregistration is successful and false if it is not
+ * (e.g., \p func was not registered).
+ */
+bool
+drmgr_unregister_filter_syscall_event(bool (*func)(void *drcontext, int sysnum));
+
+DR_EXPORT
+/**
  * Registers a callback function for the pre-syscall event, which
  * behaves just like DR's pre-syscall event dr_register_pre_syscall_event().
  * In particular, a filter event is still needed to ensure that a pre- or post-syscall
- * event is actually called: use dr_register_filter_syscall_event().
+ * event is actually called: use drmgr_register_filter_syscall_event_user_data().
  * \return whether successful.
  */
 bool

--- a/ext/drsyscall/drsyscall.c
+++ b/ext/drsyscall/drsyscall.c
@@ -2251,7 +2251,7 @@ drsys_init(client_id_t client_id, drsys_options_t *ops)
     drmgr_register_post_syscall_event_ex(drsys_event_post_syscall_last,
                                          &pri_postsys_last);
 
-    dr_register_filter_syscall_event(drsys_event_filter_syscall);
+    drmgr_register_filter_syscall_event(drsys_event_filter_syscall);
     hashtable_init(&filtered_table, FILTERED_TABLE_HASH_BITS, HASH_INTPTR,
                    false /*!strdup*/);
 

--- a/ext/drwrap/drwrap.c
+++ b/ext/drwrap/drwrap.c
@@ -1011,7 +1011,7 @@ drwrap_init(void)
         if (wrapper != NULL) {
             sysnum_NtContinue = drmgr_decode_sysnum_from_wrapper(wrapper);
             ASSERT(sysnum_NtContinue != -1, "error decoding NtContinue");
-            dr_register_filter_syscall_event(drwrap_event_filter_syscall);
+            drmgr_register_filter_syscall_event(drwrap_event_filter_syscall);
             drmgr_register_pre_syscall_event(drwrap_event_pre_syscall);
         }
         dr_free_module_data(ntdll);
@@ -1047,7 +1047,7 @@ drwrap_exit(void)
 
 #ifdef WINDOWS
     if (sysnum_NtContinue != -1) {
-        if (!dr_unregister_filter_syscall_event(drwrap_event_filter_syscall) ||
+        if (!drmgr_unregister_filter_syscall_event(drwrap_event_filter_syscall) ||
             !drmgr_unregister_pre_syscall_event(drwrap_event_pre_syscall))
             ASSERT(false, "failed to unregister in drwrap_exit");
     }

--- a/ext/drx/drx.c
+++ b/ext/drx/drx.c
@@ -1299,7 +1299,7 @@ soft_kills_init(void)
     if (!drmgr_register_pre_syscall_event(soft_kills_pre_syscall) ||
         !drmgr_register_post_syscall_event(soft_kills_post_syscall))
         return false;
-    dr_register_filter_syscall_event(soft_kills_filter_syscall);
+    drmgr_register_filter_syscall_event(soft_kills_filter_syscall);
 
     return true;
 }

--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -1083,7 +1083,7 @@ drx_register_time_scaling(drx_time_scale_t *options)
                                           DRMGR_PRIORITY_NAME_DRX_SCALE_POST_SYS, NULL,
                                           NULL, DRMGR_PRIORITY_POST_SYS_DRX_SCALE };
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
 
     if (!drmgr_register_thread_init_event_ex(event_thread_init, &init_priority) ||
         !drmgr_register_thread_exit_event_ex(event_thread_exit, &exit_priority) ||
@@ -1126,7 +1126,7 @@ drx_unregister_time_scaling()
     scale_posix_timers(drcontext, /*inflate=*/false);
 
     return drmgr_unregister_tls_field(tls_idx) &&
-        dr_unregister_filter_syscall_event(event_filter_syscall) &&
+        drmgr_unregister_filter_syscall_event(event_filter_syscall) &&
         drmgr_unregister_pre_syscall_event(event_pre_syscall) &&
         drmgr_unregister_post_syscall_event(event_post_syscall) &&
         drmgr_unregister_thread_init_event(event_thread_init) &&

--- a/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
+++ b/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
@@ -314,7 +314,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     dr_register_exit_event(event_exit);
     drmgr_register_thread_init_event(event_thread_init);
     dr_register_nudge_event(event_nudge, id);
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS) {

--- a/suite/tests/client-interface/drmgr-test.dll.c
+++ b/suite/tests/client-interface/drmgr-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -335,7 +335,7 @@ dr_init(client_id_t id)
         drmgr_register_cls_field(event_thread_context_init, event_thread_context_exit);
     CHECK(cls_idx != -1, "drmgr_register_tls_field failed");
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     ok = drmgr_register_pre_syscall_event_ex(event_pre_sys_A, &sys_pri_A) &&
         drmgr_register_pre_syscall_event_user_data(event_pre_sys_A_user_data,
                                                    &sys_pri_A_user_data,

--- a/suite/tests/client-interface/drpttracer_SUDO-test.dll.c
+++ b/suite/tests/client-interface/drpttracer_SUDO-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2022 Google, Inc.  All rights reserved.
+ * Copyright (c) 2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -88,7 +88,7 @@ dr_init(client_id_t id)
         drmgr_register_post_syscall_event(event_post_syscall);
     CHECK(ok, "drmgr_register_*_event failed");
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
 
     tls_idx = drmgr_register_tls_field();
     CHECK(tls_idx > -1, "unable to reserve TLS field");
@@ -98,7 +98,7 @@ static void
 event_exit(void)
 {
     drpttracer_exit();
-    dr_unregister_filter_syscall_event(event_filter_syscall);
+    drmgr_unregister_filter_syscall_event(event_filter_syscall);
 
     bool ok = drmgr_unregister_thread_init_event(event_thread_init) &&
         drmgr_unregister_thread_exit_event(event_thread_exit) &&

--- a/suite/tests/client-interface/drsyscall-test.dll.c
+++ b/suite/tests/client-interface/drsyscall-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -394,7 +394,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         ASSERT(false, "drsys failed to init");
     dr_register_exit_event(exit_event);
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS)

--- a/suite/tests/client-interface/nudge_ex.dll.c
+++ b/suite/tests/client-interface/nudge_ex.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2012-2015 Google, Inc.  All rights reserved.
+ * Copyright (c) 2012-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -268,7 +268,7 @@ dr_init(client_id_t id)
         drmgr_register_cls_field(event_thread_context_init, event_thread_context_exit);
     ASSERT(cls_idx != -1);
     dr_register_nudge_event(event_nudge, id);
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     dr_register_exit_event(event_exit);

--- a/suite/tests/client-interface/strace-test.dll.c
+++ b/suite/tests/client-interface/strace-test.dll.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2020 Google, Inc.  All rights reserved.
+ * Copyright (c) 2013-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /* Dr. Memory: the memory debugger
@@ -256,7 +256,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         ASSERT(false, "drsys failed to init");
     dr_register_exit_event(exit_event);
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS)

--- a/suite/tests/client-interface/strace.dll.c
+++ b/suite/tests/client-interface/strace.dll.c
@@ -124,7 +124,7 @@ dr_init(client_id_t id)
 {
     drmgr_init();
     write_sysnum = get_write_sysnum();
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     dr_register_exit_event(event_exit);

--- a/suite/tests/client-interface/syscall-file-io-test.dll.c
+++ b/suite/tests/client-interface/syscall-file-io-test.dll.c
@@ -214,7 +214,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
     }
     dr_register_exit_event(exit_event);
 
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS) {

--- a/suite/tests/client-interface/syscall-records-test.dll.c
+++ b/suite/tests/client-interface/syscall-records-test.dll.c
@@ -234,7 +234,7 @@ dr_client_main(client_id_t id, int argc, const char *argv[])
         return;
     }
     dr_register_exit_event(exit_event);
-    dr_register_filter_syscall_event(event_filter_syscall);
+    drmgr_register_filter_syscall_event(event_filter_syscall);
     drmgr_register_pre_syscall_event(event_pre_syscall);
     drmgr_register_post_syscall_event(event_post_syscall);
     if (drsys_filter_all_syscalls() != DRMF_SUCCESS) {


### PR DESCRIPTION
Adds a drmgr filter syscall event which replaces the base DR event and provides priorities and user_data parameters.

Removes the lazy drmgr pre and post syscall registration as it is no longer needed with drmgmr always registering a filter event, but leaves the underlying lazy mechanism in place in case we want it for something else.

Updates all our samples and tests to use the drmgr event.

Adds a note to the minor compatibility change list as this will break user's builds, but has no binary compatibility consequence.

Issue: #7604