### PR TITLE
i#7303 drsyscall: fix drsyscall_drstatic library.

### DIFF
--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -172,8 +172,9 @@ configure_drsyscall_target(drsyscall_static)
 
 add_library(drsyscall_drstatic STATIC ${srcs_static})
 configure_extension(drsyscall_drstatic ON ON)
-use_DynamoRIO_extension(drsyscall_drstatic drcontainers_drstatuc)
-use_DynamoRIO_extension(drsyscall_drstatic drmgr_static)
+use_DynamoRIO_extension(drsyscall_drstatic drmgr_drstatic)
+use_DynamoRIO_extension(drsyscall_drstatic drcontainers_drstatic)
+use_DynamoRIO_extension(drsyscall_drstatic drsyms_drstatic)
 configure_drsyscall_target(drsyscall_drstatic)
 
 if (LINUX)

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6516,6 +6516,10 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
   use_DynamoRIO_extension(client.attach-memory-dump-syscall-test.dll
     drsyscall_record_lib)
 
+  # Test building with drsyscall_drstatic.
+  add_exe(client.drsyscall-test-drstatic client-interface/drsyscall-test.c "" "" "")
+  use_DynamoRIO_extension(client.drsyscall-test-drstatic drmgr_drstatic)
+  use_DynamoRIO_extension(client.drsyscall-test-drstatic drsyscall_drstatic)
 endif ()
 
 ###########################################################################

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6469,6 +6469,10 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
     -client ${strace_test_libpath} 0 "" ${dr_test_ops} -- ${app_path})
   use_DynamoRIO_extension(client.strace-test.dll drmgr)
   use_DynamoRIO_extension(client.strace-test.dll drsyscall)
+  # Test building with drsyscall_drstatic.
+  tobuild_ci(client.strace-static-test client-interface/drsyscall-test.c "" "" "")
+  use_DynamoRIO_extension(client.strace-static-test.dll drmgr_drstatic)
+  use_DynamoRIO_extension(client.strace-static-test.dll drsyscall_drstatic)
 
   tobuild_ci(sample.strace client-interface/drsyscall-test.c "" "" "")
   get_target_path_for_execution(strace_sample_test_libpath sample.strace.dll
@@ -6515,11 +6519,6 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
     drsyscall)
   use_DynamoRIO_extension(client.attach-memory-dump-syscall-test.dll
     drsyscall_record_lib)
-
-  # Test building with drsyscall_drstatic.
-  add_exe(client.drsyscall-test-drstatic client-interface/drsyscall-test.c "" "" "")
-  use_DynamoRIO_extension(client.drsyscall-test-drstatic drmgr_drstatic)
-  use_DynamoRIO_extension(client.drsyscall-test-drstatic drsyscall_drstatic)
 endif ()
 
 ###########################################################################

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6469,15 +6469,18 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
     -client ${strace_test_libpath} 0 "" ${dr_test_ops} -- ${app_path})
   use_DynamoRIO_extension(client.strace-test.dll drmgr)
   use_DynamoRIO_extension(client.strace-test.dll drsyscall)
-  # Test building with drsyscall_drstatic.
-  add_exe(client.drsyscall-static-test client-interface/drsyscall-test.dll.c "" "" "")
-  configure_DynamoRIO_static_client(client.drsyscall-static-test)
+  # Test building with drsyscall_drstatic, this is a build-only test.
+  # TODO i#7613: Add a unit test that builds and executes with drsyscall_drstatic library.
+  add_exe(client.drsyscall-drstatic-build-only-test client-interface/drsyscall-test.dll.c
+    "" "" "")
+  configure_DynamoRIO_static_client(client.drsyscall-drstatic-build-only-test)
   if (UNIX)
     # Static libs must be PIC to be linked into clients.
-    append_property_string(TARGET client.drsyscall-static-test COMPILE_FLAGS "-fPIC")
+    append_property_string(TARGET client.drsyscall-drstatic-build-only-test
+      COMPILE_FLAGS "-fPIC")
   endif ()
-  use_DynamoRIO_extension(client.drsyscall-static-test drmgr_drstatic)
-  use_DynamoRIO_extension(client.drsyscall-static-test drsyscall_drstatic)
+  use_DynamoRIO_extension(client.drsyscall-drstatic-build-only-test drmgr_drstatic)
+  use_DynamoRIO_extension(client.drsyscall-drstatic-build-only-test drsyscall_drstatic)
 
   tobuild_ci(sample.strace client-interface/drsyscall-test.c "" "" "")
   get_target_path_for_execution(strace_sample_test_libpath sample.strace.dll

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6470,8 +6470,8 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
   use_DynamoRIO_extension(client.strace-test.dll drmgr)
   use_DynamoRIO_extension(client.strace-test.dll drsyscall)
   # Test building with drsyscall_drstatic.
-  tobuild(client.drsyscall-static-test client-interface/drsyscall-test.dll.c)
-  setup_test_client_dll_basics(client.drsyscall-static-test)
+  add_exe(client.drsyscall-static-test client-interface/drsyscall-test.dll.c "" "" "")
+  configure_DynamoRIO_static_client(client.drsyscall-static-test)
   if (UNIX)
     # Static libs must be PIC to be linked into clients.
     append_property_string(TARGET client.drsyscall-static-test COMPILE_FLAGS "-fPIC")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -6470,9 +6470,14 @@ IF (NOT ANDROID AND NOT APPLE AND NOT MUSL AND NOT RISCV64 AND NOT WINDOWS)
   use_DynamoRIO_extension(client.strace-test.dll drmgr)
   use_DynamoRIO_extension(client.strace-test.dll drsyscall)
   # Test building with drsyscall_drstatic.
-  tobuild_ci(client.strace-static-test client-interface/drsyscall-test.c "" "" "")
-  use_DynamoRIO_extension(client.strace-static-test.dll drmgr_drstatic)
-  use_DynamoRIO_extension(client.strace-static-test.dll drsyscall_drstatic)
+  tobuild(client.drsyscall-static-test client-interface/drsyscall-test.dll.c)
+  setup_test_client_dll_basics(client.drsyscall-static-test)
+  if (UNIX)
+    # Static libs must be PIC to be linked into clients.
+    append_property_string(TARGET client.drsyscall-static-test COMPILE_FLAGS "-fPIC")
+  endif ()
+  use_DynamoRIO_extension(client.drsyscall-static-test drmgr_drstatic)
+  use_DynamoRIO_extension(client.drsyscall-static-test drsyscall_drstatic)
 
   tobuild_ci(sample.strace client-interface/drsyscall-test.c "" "" "")
   get_target_path_for_execution(strace_sample_test_libpath sample.strace.dll


### PR DESCRIPTION
#7396 had a typo in drcontainters_drstatic, missing drsyms_drstatic, and used the wrong library for drmgr_drstatic.

I found the issue when I tried to add drsyscall library to add_drmemtrace as follows:
```
diff --git a/clients/drcachesim/CMakeLists.txt b/clients/drcachesim/CMakeLists.txt
index c9ef34368..3e47f8322 100644
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -560,6 +560,7 @@ macro(add_drmemtrace name type static_DR no_main)
   use_DynamoRIO_extension(${name} droption)
   use_DynamoRIO_extension(${name} drcovlib${ext_sfx})
   use_DynamoRIO_extension(${name} drbbdup${ext_sfx})
+  use_DynamoRIO_extension(${name} drsyscall${ext_sfx})
   if (BUILD_PT_TRACER)
     use_DynamoRIO_extension(${name} drpttracer${ext_sfx})
   endif ()
```

Add a test to build with drsyscall_drstatic.

Tested:
I saw 
```
/usr/bin/ld: cannot find -ldrcontainers_drstatuc: No such file or directory
/usr/bin/ld: have you installed the static version of the drcontainers_drstatuc library ?
/usr/bin/ld: attempted static link of dynamic object `../../lib64/release/libdynamorio.so'
:
make[2]: *** [clients/drcachesim/CMakeFiles/tool.drcacheoff.purestatic.dir/build.make:131: clients/bin64/tool.drcacheoff.purestatic] Error 1
make[1]: *** [CMakeFiles/Makefile2:6862: clients/drcachesim/CMakeFiles/tool.drcacheoff.purestatic.dir/all] Error 2
m
```
without the change. Built successfully with the change.

Issue: #7303 