### PR TITLE
i#7604 user data: Add unreg for filter user data

### DIFF
--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -2062,6 +2062,15 @@ drmgr_unregister_filter_syscall_event(bool (*func)(void *drcontext, int sysnum))
                                       (void (*)(void))func);
 }
 
+DR_EXPORT
+bool
+drmgr_unregister_filter_syscall_event_user_data(bool (*func)(void *drcontext, int sysnum,
+                                                             void *user_data))
+{
+    return drmgr_generic_event_remove(&cblist_filter_sys, filter_sys_event_lock,
+                                      (void (*)(void))func);
+}
+
 static bool
 drmgr_filter_syscall_event(void *drcontext, int sysnum)
 {

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1247,6 +1247,16 @@ drmgr_unregister_filter_syscall_event(bool (*func)(void *drcontext, int sysnum))
 
 DR_EXPORT
 /**
+ * Unregister a callback function, which takes user data, for the syscall filter event.
+ * \return true if unregistration is successful and false if it is not
+ * (e.g., \p func was not registered).
+ */
+bool
+drmgr_unregister_filter_syscall_event_user_data(bool (*func)(void *drcontext, int sysnum,
+                                                             void *user_data));
+
+DR_EXPORT
+/**
  * Registers a callback function for the pre-syscall event, which
  * behaves just like DR's pre-syscall event dr_register_pre_syscall_event().
  * In particular, a filter event is still needed to ensure that a pre- or post-syscall

--- a/suite/tests/client-interface/drmgr-test.templatex
+++ b/suite/tests/client-interface/drmgr-test.templatex
@@ -5,6 +5,8 @@ in event_thread_init
 in insert A
 in insert B
 in insert C
+in filter_syscall_user_data
+in filter_syscall
 in pre_sys_B_user_data
 in pre_sys_B
 in pre_sys_A_user_data


### PR DESCRIPTION
Adds unregistration for the filter event with user data, which was omitted from PR #7605.

Adds testing to drmgr-test.

Issue: #7604