### PR TITLE
Remove duplicate native signal stats increments

### DIFF
--- a/core/unix/signal.c
+++ b/core/unix/signal.c
@@ -6752,8 +6752,6 @@ execute_native_handler(dcontext_t *dcontext, int sig, sigframe_rt_t *our_frame,
     if (!TEST(SA_NOMASK, (info->sighand->action[sig]->flags)))
         kernel_sigaddset(&blocked, sig);
 
-    RSTATS_INC(num_signals);
-    RSTATS_INC(num_native_signals);
     if (reuse_cur_frame) {
         /* We've determined that we can reuse the current signal frame to
          * deliver sig to the native signal handler. We want to simply jump

--- a/core/unix/signal_private.h
+++ b/core/unix/signal_private.h
@@ -422,7 +422,7 @@ typedef struct _sighand_info_t {
 } sighand_info_t;
 
 typedef struct _thread_sig_info_t {
-    /* A pointer to handler info shared in a CLONG_SIGHAND group. */
+    /* A pointer to handler info shared in a CLONE_SIGHAND group. */
     sighand_info_t *sighand;
 
     /* We save the old sigaction across a sigaction syscall so we can return it


### PR DESCRIPTION
Removes a pair of duplicate signal stats
increments from execute_native_handler().

Fixes a typo in a signal header.