### PR TITLE
i#7617: Force an empty git config, to avoid log format changes (#7617)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,9 @@ else (EXISTS "${PROJECT_SOURCE_DIR}/.svn")
   if (EXISTS "${PROJECT_SOURCE_DIR}/.git")
     find_program(GIT git DOC "git client")
     if (GIT)
+      # Avoid local git configs that change the log format, as we're about to
+      # parse it as text.
+      set(ENV{GIT_CONFIG_GLOBAL} /dev/null)
       # We want the committer date (not author date) (xref i#1565).  We request UNIX
       # timestamp format and then divide down to days to get a small enough number
       # for the Windows resource limits.


### PR DESCRIPTION
Some of my local git settings (at least one that shows GPG signatures) change the log format in a way that's breaking the parsing at cmake-time.  This sets GIT_CONFIG_GLOBAL, which causes the user's git configuration to be ignored and should avoid these sorts of issues.

Issue: #7617