### PR TITLE
i#7588 drsyscall: add include drsyscall.h to drsyscall_record.h.

### DIFF
--- a/ext/drsyscall/drsyscall_record.h
+++ b/ext/drsyscall/drsyscall_record.h
@@ -35,6 +35,7 @@
 
 #include <stdint.h>
 #include "dr_api.h"
+#include "drsyscall.h"
 
 /**************************************************
  * TOP-LEVEL ROUTINES


### PR DESCRIPTION
#7586 moved START_PACKED_STRUCTURE and END_PACKED_STRUCTURE from drsyscall_record.h to drsyscall.h without adding '#include "drsyscall.h"' to drsyscall_record.h. It only works when a file include drsyscall.h before including drsyscall_record.h.

This PR adds  '#include "drsyscall.h"'  to drsyscall_record.h to remove the dependency.

Issue: #7588 