### PR TITLE
i#7496 eret continuity: Add get_next_trace_pc reader readahead API

### DIFF
--- a/clients/drcachesim/common/memtrace_stream.h
+++ b/clients/drcachesim/common/memtrace_stream.h
@@ -311,6 +311,12 @@ public:
     {
         return -1;
     }
+
+    virtual uint64_t
+    get_next_trace_pc() const
+    {
+        return 0;
+    }
 };
 
 /**

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -237,6 +237,7 @@ file_reader_t<zipfile_reader_t>::skip_instructions(uint64_t instruction_count)
                    (chunk_instr_count_ - (cur_instr_count_ % chunk_instr_count_)));
         // Clear cached data from the prior chunk.
         zipfile->cur_buf = zipfile->max_buf;
+        entry_queue_.clear_readahead();
     }
     // Now do a linear walk the rest of the way, remembering timestamps (we have
     // duplicated timestamps at the start of the chunk to cover any skipped in

--- a/clients/drcachesim/scheduler/scheduler.cpp
+++ b/clients/drcachesim/scheduler/scheduler.cpp
@@ -344,6 +344,14 @@ scheduler_tmpl_t<RecordType, ReaderType>::stream_t::is_record_kernel() const
 }
 
 template <typename RecordType, typename ReaderType>
+uint64_t
+scheduler_tmpl_t<RecordType, ReaderType>::stream_t::get_next_trace_pc() const
+
+{
+    return scheduler_->get_input_stream(ordinal_)->get_next_trace_pc();
+}
+
+template <typename RecordType, typename ReaderType>
 double
 scheduler_tmpl_t<RecordType, ReaderType>::stream_t::get_schedule_statistic(
     schedule_statistic_t stat) const

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -1283,6 +1283,9 @@ public:
         bool
         is_record_kernel() const override;
 
+        uint64_t
+        get_next_trace_pc() const override;
+
         /**
          * Returns the value of the specified statistic for this output stream.
          * The values for all output streams must be summed to obtain global counts.

--- a/clients/drcachesim/tests/analysis_unit_tests.cpp
+++ b/clients/drcachesim/tests/analysis_unit_tests.cpp
@@ -51,35 +51,58 @@
 namespace dynamorio {
 namespace drmemtrace {
 
+template <typename RecordType, typename ReaderType>
 // An analyzer that takes in any number of scheduler inputs, plus optional direct
 // scheduler options for SHARD_BY_CORE.
-class mock_analyzer_t : public analyzer_t {
+class mock_analyzer_tmpl_t : public analyzer_tmpl_t<RecordType, ReaderType> {
 public:
-    mock_analyzer_t(std::vector<scheduler_t::input_workload_t> &sched_inputs,
-                    analysis_tool_t **tools, int num_tools, bool parallel,
-                    int worker_count, scheduler_t::scheduler_options_t *sched_ops_in)
-        : analyzer_t()
+    using analyzer_tmpl_t<RecordType, ReaderType>::num_tools_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::tools_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::parallel_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::verbosity_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::worker_count_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::shard_type_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::sched_mapping_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::sched_by_time_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::scheduler_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::success_;
+    using analyzer_tmpl_t<RecordType, ReaderType>::worker_data_;
+    using typename analyzer_tmpl_t<RecordType, ReaderType>::analyzer_worker_data_t;
+    mock_analyzer_tmpl_t(
+        std::vector<typename scheduler_tmpl_t<RecordType, ReaderType>::input_workload_t>
+            &sched_inputs,
+        analysis_tool_tmpl_t<RecordType> **tools, int num_tools, bool parallel,
+        int worker_count,
+        typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_options_t
+            *sched_ops_in)
+        : analyzer_tmpl_t<RecordType, ReaderType>()
     {
         num_tools_ = num_tools;
         tools_ = tools;
         parallel_ = parallel;
         verbosity_ = 1;
         worker_count_ = worker_count;
-        scheduler_t::scheduler_options_t sched_ops;
+        typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_options_t sched_ops;
         if (sched_ops_in != nullptr) {
             shard_type_ = SHARD_BY_CORE;
             sched_ops = std::move(*sched_ops_in);
             // XXX: We could refactor init_scheduler_common() to share a couple of
             // these lines.
-            if (sched_ops.quantum_unit == sched_type_t::QUANTUM_TIME)
+            if (sched_ops.quantum_unit ==
+                scheduler_tmpl_t<RecordType, ReaderType>::QUANTUM_TIME)
                 sched_by_time_ = true;
-        } else if (parallel)
-            sched_ops = scheduler_t::make_scheduler_parallel_options(verbosity_);
-        else
-            sched_ops = scheduler_t::make_scheduler_serial_options(verbosity_);
+        } else if (parallel) {
+            sched_ops =
+                scheduler_tmpl_t<RecordType, ReaderType>::make_scheduler_parallel_options(
+                    verbosity_);
+        } else {
+            sched_ops =
+                scheduler_tmpl_t<RecordType, ReaderType>::make_scheduler_serial_options(
+                    verbosity_);
+        }
         sched_mapping_ = sched_ops.mapping;
         if (scheduler_.init(sched_inputs, worker_count_, std::move(sched_ops)) !=
-            sched_type_t::STATUS_SUCCESS) {
+            scheduler_tmpl_t<RecordType, ReaderType>::STATUS_SUCCESS) {
             assert(false);
             success_ = false;
         }
@@ -88,6 +111,12 @@ public:
         }
     }
 };
+
+template class mock_analyzer_tmpl_t<memref_t, reader_t>;
+template class mock_analyzer_tmpl_t<trace_entry_t,
+                                    dynamorio::drmemtrace::record_reader_t>;
+
+typedef mock_analyzer_tmpl_t<memref_t, reader_t> mock_analyzer_t;
 
 bool
 test_queries()
@@ -187,6 +216,156 @@ test_queries()
     tools.push_back(test_tool.get());
     mock_analyzer_t analyzer(sched_inputs, &tools[0], (int)tools.size(),
                              /*parallel=*/true, NUM_OUTPUTS, &sched_ops);
+    assert(!!analyzer);
+    bool res = analyzer.run();
+    assert(res);
+    return true;
+}
+
+template <typename RecordType>
+class next_trace_pc_test_tool_t : public analysis_tool_tmpl_t<RecordType> {
+public:
+    bool
+    process_memref(const RecordType &record) override
+    {
+        assert(false); // Only expect parallel mode.
+        return false;
+    }
+    bool
+    print_results() override
+    {
+        return true;
+    }
+    bool
+    parallel_shard_supported() override
+    {
+        return true;
+    }
+    void *
+    parallel_shard_init_stream(int shard_index, void *worker_data,
+                               memtrace_stream_t *stream) override
+    {
+        auto per_shard = new per_shard_t;
+        per_shard->stream = stream;
+        per_shard->expected_next_trace_pc = stream->get_next_trace_pc();
+        return reinterpret_cast<void *>(per_shard);
+    }
+    bool
+    parallel_shard_exit(void *shard_data) override
+    {
+        per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
+        assert(shard->expected_next_trace_pc == 0);
+        delete shard;
+        return true;
+    }
+    bool
+    entry_has_pc(RecordType record, uint64_t &pc);
+    bool
+    parallel_shard_memref(void *shard_data, const RecordType &record) override
+    {
+        per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
+        uint64_t pc;
+        bool has_pc = entry_has_pc(record, pc);
+        if (has_pc) {
+            assert(pc == shard->expected_next_trace_pc);
+            shard->expected_next_trace_pc = shard->stream->get_next_trace_pc();
+        } else {
+            assert(shard->expected_next_trace_pc == shard->stream->get_next_trace_pc());
+        }
+        return true;
+    }
+
+private:
+    struct per_shard_t {
+        // Just a random non-zero init value so zero results do not sneak by us.
+        uint64_t expected_next_trace_pc = 0x8badf00d;
+        memtrace_stream_t *stream;
+    };
+};
+
+template <>
+bool
+next_trace_pc_test_tool_t<memref_t>::entry_has_pc(memref_t memref, uint64_t &pc)
+{
+    if (type_is_instr(memref.instr.type)) {
+        pc = memref.instr.addr;
+        return true;
+    }
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+        pc = memref.marker.marker_value;
+        return true;
+    }
+    return false;
+}
+template <>
+bool
+next_trace_pc_test_tool_t<trace_entry_t>::entry_has_pc(trace_entry_t entry, uint64_t &pc)
+{
+    if (type_is_instr(static_cast<trace_type_t>(entry.type))) {
+        pc = entry.addr;
+        return true;
+    }
+    if (static_cast<trace_type_t>(entry.type) == TRACE_TYPE_MARKER &&
+        entry.size == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+        pc = entry.addr;
+        return true;
+    }
+    return false;
+}
+
+template class next_trace_pc_test_tool_t<memref_t>;
+template class next_trace_pc_test_tool_t<trace_entry_t>;
+
+template <typename RecordType, typename ReaderType, typename MockReaderType>
+bool
+test_next_trace_pc_queries(std::string test_type)
+{
+    std::cerr << "\n----------------\nTesting next trace pc queries for " << test_type
+              << "\n";
+    std::vector<trace_entry_t> input_sequence = {
+        test_util::make_thread(/*tid=*/1),
+        test_util::make_pid(/*pid=*/1),
+        test_util::make_timestamp(1),
+        test_util::make_instr(/*pc=*/42),
+        test_util::make_memref(/*addr=*/420),
+        test_util::make_memref(/*addr=*/421),
+        test_util::make_instr(/*pc=*/43),
+        test_util::make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, 44),
+        test_util::make_timestamp(2),
+        test_util::make_instr(/*pc=*/101),
+        test_util::make_exit(/*tid=*/1),
+    };
+    static constexpr int NUM_INPUTS = 3;
+    static constexpr int NUM_OUTPUTS = 1;
+    static constexpr int BASE_TID = 100;
+    std::vector<trace_entry_t> inputs[NUM_INPUTS];
+    std::vector<typename scheduler_tmpl_t<RecordType, ReaderType>::input_workload_t>
+        sched_inputs;
+    for (int i = 0; i < NUM_INPUTS; i++) {
+        memref_tid_t tid = BASE_TID + i;
+        inputs[i] = input_sequence;
+        for (auto &record : inputs[i]) {
+            if (record.type == TRACE_TYPE_THREAD || record.type == TRACE_TYPE_THREAD_EXIT)
+                record.addr = static_cast<addr_t>(tid);
+        }
+        std::vector<typename scheduler_tmpl_t<RecordType, ReaderType>::input_reader_t>
+            readers;
+        readers.emplace_back(
+            std::unique_ptr<MockReaderType>(new MockReaderType(inputs[i])),
+            std::unique_ptr<MockReaderType>(new MockReaderType()), tid);
+        sched_inputs.emplace_back(std::move(readers));
+    }
+    typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_options_t sched_ops =
+        scheduler_tmpl_t<RecordType, ReaderType>::make_scheduler_parallel_options(
+            /*verbosity=*/3);
+    std::vector<analysis_tool_tmpl_t<RecordType> *> tools;
+    auto test_tool = std::unique_ptr<next_trace_pc_test_tool_t<RecordType>>(
+        new next_trace_pc_test_tool_t<RecordType>());
+    tools.push_back(test_tool.get());
+    mock_analyzer_tmpl_t<RecordType, ReaderType> analyzer(
+        sched_inputs, &tools[0], (int)tools.size(),
+        /*parallel=*/true, NUM_OUTPUTS, &sched_ops);
     assert(!!analyzer);
     bool res = analyzer.run();
     assert(res);
@@ -493,7 +672,11 @@ test_tool_errors()
 int
 test_main(int argc, const char *argv[])
 {
-    if (!test_queries() || !test_wait_records() || !test_tool_errors())
+    if (!test_queries() || !test_wait_records() || !test_tool_errors() ||
+        !test_next_trace_pc_queries<memref_t, reader_t, test_util::mock_reader_t>(
+            "memref_t") ||
+        !test_next_trace_pc_queries<trace_entry_t, record_reader_t,
+                                    test_util::mock_record_reader_t>("trace_entry_t"))
         return 1;
     std::cerr << "All done!\n";
     return 0;

--- a/clients/drcachesim/tests/mock_reader.h
+++ b/clients/drcachesim/tests/mock_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -53,6 +53,7 @@ public:
         : trace_(trace)
     {
         verbosity_ = 3;
+        online_ = false;
     }
     bool
     init() override


### PR DESCRIPTION
Adds a new memtrace_stream_t::get_next_trace_pc API that returns the next continuous pc that will be seen in the trace. The next continuous trace pc is either the pc of the next instr_t or the address held by the next TRACE_MARKER_TYPE_KERNEL_EVENT, whichever comes first.

Adds functionality in reader_t and record_reader_t to read-ahead the trace_entry_t from the input so that we always know the next continuous pc in the trace. This value is supplied via the get_next_trace_pc API.

The implementation is added in a trace_entry_readahead_helper_t class to allow it to be shared between reader_t and record_reader_t, which have similar but not the same interfaces. Also added entry_queue_t that holds the logic to (de)queue trace_entry_t records, which supports storing both readahead and non-readahead entries (there is some existing logic in reader_t to queue up trace_entry_t which is supported by the same queue now), and also logic to tell whether there are enough readahead entries for us to know the next continuous pc in the trace.

Adds analyzer unit tests that verify the correct operation of get_next_trace_pc for memref_t and trace_entry_t tools. Also ensured that the trace skip related tests pass.

Issue: #7496