### PR TITLE
i#7552: Fix a race condition in attach-memory-dump-syscall-test.

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -512,7 +512,6 @@ for (my $i = 0; $i <= $#lines; ++$i) {
             %ignore_failures_64 = (
                 'code_api|api.rseq' => 1, # i#6185 i#1807
                 'code_api|tool.drcacheoff.burst_threadfilter' => 1, # i#2941
-                'code_api|client.attach-memory-dump-syscall-test' => 1, # i#7552
                 'code_api|client.attach_test' => 1, # i#6452
                 'code_api|client.detach_test' => 1, # i#6536
                 # These are from the long suite.

--- a/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
+++ b/suite/tests/client-interface/attach-memory-dump-syscall-test.dll.c
@@ -265,6 +265,8 @@ event_exit(void)
         dr_fprintf(STDERR, "drsys failed to exit");
     }
     drmgr_exit();
+    /* runall.cmake for attach test requires "done" as last line once done. */
+    dr_fprintf(STDERR, "done\n");
 }
 
 static void


### PR DESCRIPTION
There is a race condition between the post-command to read the syscall record file and the DR client in attach-memory-dump-syscall-test.dll.c writing to the file. The post-command is triggered by writing "done" to  STDOUT or STDERR. This race is resolved by having the DR client write the done only after it has finished writing to the syscall record file within its exit event handler.

Removing print("done") from the signal_handler in syscall-records-attach.c introduces another race condition.
A race exists between the application making syscalls and a SIGTERM that is sent after the attach event. This could potentially cause the test to fail if no syscalls are recorded before the signal is sent. The solution is to explicitly perform a write syscall in the code, guaranteeing that at least one syscall  is recorded for the test.

Tested:
Without the changes, "ctest --repeat-until-fail 100 -R attach-memory-dump-syscall-test" usually fails before hitting 100 tests. 

With the changes, multiple runs of "ctest --repeat-until-fail 1000 -R attach-memory-dump-syscall-test " have 0 failures.

Fixes #7552 