### PR TITLE
i#7626: Fix drmemtrace input count with only_thread

### DIFF
--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -268,6 +268,9 @@ public:
          * is also set, the indices here apply to the input list *after* only those
          * matching only_shards are removed.
          */
+        // The only_shards wart is due to use cases that apply only_shards before
+        // sending a set of reader_t inputs; it is not ideal, but we do not have
+        // a simple solution for now.
         std::vector<int> shards;
         /**
          * Limits these threads to this set of output streams, which are specified by

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -263,6 +263,10 @@ public:
          * #dynamorio::drmemtrace::scheduler_tmpl_t::input_workload_t.
          * If multiple entries list the same shard ordinal, only the last one is
          * honored.
+         *
+         * If #dynamorio::drmemtrace::scheduler_tmpl_t::input_workload_t.only_shards
+         * is also set, the indices here apply to the input list *after* only those
+         * matching only_shards are removed.
          */
         std::vector<int> shards;
         /**

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -941,6 +941,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
             // not high and the simplified code is worthwhile.
             for (int local_index : which_workload_inputs) {
                 int index = local_index + reader_info.first_input_ordinal;
+                assert(index < static_cast<int>(inputs_.size()));
                 input_info_t &input = inputs_[index];
                 input.has_modifier = true;
                 // Check for valid bindings.
@@ -955,7 +956,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
                 // code with a full set as a default value) that it is worth
                 // detecting and ignoring in order to avoid hitting binding-handling
                 // code and save time in initial placement and runqueue code.
-                if (modifiers.output_binding.size() < static_cast<size_t>(output_count)) {
+                if (!modifiers.output_binding.empty() &&
+                    modifiers.output_binding.size() < static_cast<size_t>(output_count)) {
                     input.binding = modifiers.output_binding;
                 }
                 input.priority = modifiers.priority;
@@ -2008,7 +2010,6 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::open_reader(
     // That means the size of unfiltered_tids will not be the total input
     // size, which is why we have a separate input_count.
     reader_info.unfiltered_tids.insert(tid);
-    ++reader_info.input_count;
     if (!reader_info.only_threads.empty() &&
         reader_info.only_threads.find(tid) == reader_info.only_threads.end()) {
         inputs_.pop_back();
@@ -2019,6 +2020,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::open_reader(
         inputs_.pop_back();
         return sched_type_t::STATUS_SUCCESS;
     }
+    ++reader_info.input_count;
     VPRINT(this, 1, "Opened reader for tid %" PRId64 " %s\n", tid, path.c_str());
     input.tid = tid;
     input.reader = std::move(reader);

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -803,7 +803,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::check_valid_input_limits(
 {
     if (!workload.only_shards.empty()) {
         for (input_ordinal_t ord : workload.only_shards) {
-            if (ord < 0 || ord >= static_cast<input_ordinal_t>(reader_info.input_count)) {
+            if (ord < 0 ||
+                ord >= static_cast<input_ordinal_t>(reader_info.unfiltered_input_count)) {
                 error_string_ = "only_shards entry " + std::to_string(ord) +
                     " out of bounds for a shard ordinal";
                 return false;
@@ -934,6 +935,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
                                                     reader_info.first_input_ordinal);
                 }
             } else if (!modifiers.shards.empty()) {
+                // As documented, the .shards ordinals apply to the input list
+                // *after* only_* are applied.
                 which_workload_inputs = modifiers.shards;
             }
 
@@ -941,7 +944,13 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
             // not high and the simplified code is worthwhile.
             for (int local_index : which_workload_inputs) {
                 int index = local_index + reader_info.first_input_ordinal;
-                assert(index < static_cast<int>(inputs_.size()));
+                if (index >= static_cast<int>(inputs_.size())) {
+                    // This should only happen with .shards.
+                    error_string_ =
+                        "workload.thread_modifiers has an invalid .shards entry " +
+                        std::to_string(local_index);
+                    return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
+                }
                 input_info_t &input = inputs_[index];
                 input.has_modifier = true;
                 // Check for valid bindings.
@@ -2006,9 +2015,10 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::open_reader(
         error_string_ = "Failed to read " + path;
         return sched_type_t::STATUS_ERROR_FILE_READ_FAILED;
     }
+    ++reader_info.unfiltered_input_count;
     // For core-sharded inputs that start idle the tid might be IDLE_THREAD_ID.
     // That means the size of unfiltered_tids will not be the total input
-    // size, which is why we have a separate input_count.
+    // size, which is why we have a separate input_count and unfiltered_input_count.
     reader_info.unfiltered_tids.insert(tid);
     if (!reader_info.only_threads.empty() &&
         reader_info.only_threads.find(tid) == reader_info.only_threads.end()) {

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -850,7 +850,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
         if (workload.path.empty()) {
             if (workload.readers.empty())
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
-            reader_info.input_count = workload.readers.size();
+            reader_info.unfiltered_input_count = workload.readers.size();
+            reader_info.input_count = 0;
             for (int i = 0; i < static_cast<int>(workload.readers.size()); ++i) {
                 auto &reader = workload.readers[i];
                 if (!reader.reader || !reader.end)
@@ -862,6 +863,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::init(
                 if (!workload.only_shards.empty() &&
                     workload.only_shards.find(i) == workload.only_shards.end())
                     continue;
+                ++reader_info.input_count;
                 int index = static_cast<input_ordinal_t>(inputs_.size());
                 inputs_.emplace_back();
                 input_info_t &input = inputs_.back();

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -578,6 +578,8 @@ protected:
         std::set<memref_tid_t> unfiltered_tids;
         // The count of original pre-filtered inputs (might not match
         // unfiltered_tids.size() for core-sharded inputs with IDLE_THREAD_ID).
+        uint64_t unfiltered_input_count = 0;
+        // The count of filtered inputs.
         uint64_t input_count = 0;
         // The index into inputs_ at which this workload's inputs begin.
         input_ordinal_t first_input_ordinal = 0;

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4101,7 +4101,8 @@ if (BUILD_CLIENTS)
         set(tool.reuse_time_offline_rawtemp ON) # no preprocessor
 
         torunonly_simtool(counts_only_thread ${ci_shared_app}
-          "-indir ${thread_trace_dir} -tool basic_counts -only_thread 872906"
+          # We add -skip_instrs to test i#7626.
+          "-indir ${thread_trace_dir} -tool basic_counts -only_thread 872906 -skip_instrs 10"
           "")
         set(tool.counts_only_thread_rawtemp ON) # no preprocessor
 


### PR DESCRIPTION
Fixes a drmemtrace bug where the input count included threads excluded with -only_thread while the input_ array did not, leading to an array overflow.

Adds reader_info_t.unfiltered_input_count to fix a problem with the only_shards validity check.

Documents that input_thread_info_t.shards modifiers apply after only_* have filtered out inputs.

Adds a check on an invalid modifier index.

Avoids an empty binder set copy.

Adds "-skip_instrs 10" to the only_thread test, which reproduces the crash (now an invalid input error) without the fix and passes with the fix. The only_shards test exercises the unfiltered_input_count change as it fails without that change.

Fixes #7626