### PR TITLE
i#7496 eret continuity: Add reader_base_t

### DIFF
--- a/api/docs/API.doxy
+++ b/api/docs/API.doxy
@@ -66,7 +66,7 @@ SUBGROUPING            = YES
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = NO
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = YES
 EXTRACT_LOCAL_METHODS  = NO

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -145,6 +145,9 @@ changes:
    set by subclasses of #dynamorio::drmemtrace:record_reader_t to indicate EOF.
  - Changed signature of dynamorio::drmemtrace:record_reader_t::read_next_entry() to
    return a pointer to the read #dynamorio::drmemtrace:trace_entry_t instead of a bool.
+ - Added a parameter to the constructor of #dynamorio::drmemtrace:reader_t and
+   #dynamorio::drmemtrace:record_reader_t that indicates whether it is being used in
+   the online or offline mode.
 
 The changes between version \DR_VERSION and 11.3.0 include the following minor
 compatibility changes:

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -137,6 +137,14 @@ changes:
    dynamorio::drmemtrace::caching_device_t. Possible values are:
    - cache_access_type_t::HIT,
    - cache_access_type_t::MISS.
+ - Removed dynamorio::drmemtrace::reader_t::read_queued_entry(), which now does not
+   require subclasses of #dynamorio::drmemtrace::reader_t to check for queued
+   entries in their implementation of
+   #dynamorio::drmemtrace::reader_t::read_next_entry().
+ - Renamed eof_ to at_eof_ for #dynamorio::drmemtrace:record_reader_t, which must be
+   set by subclasses of #dynamorio::drmemtrace:record_reader_t to indicate EOF.
+ - Changed signature of dynamorio::drmemtrace:record_reader_t::read_next_entry() to
+   return a pointer to the read #dynamorio::drmemtrace:trace_entry_t instead of a bool.
 
 The changes between version \DR_VERSION and 11.3.0 include the following minor
 compatibility changes:

--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -143,6 +143,9 @@ changes:
    #dynamorio::drmemtrace::reader_t::read_next_entry().
  - Renamed eof_ to at_eof_ for #dynamorio::drmemtrace:record_reader_t, which must be
    set by subclasses of #dynamorio::drmemtrace:record_reader_t to indicate EOF.
+ - Renamed cur_entry_ to entry_copy_ for subclasses of
+   #dynamorio::drmemtrace:record_reader_t, which can be used instead to store the
+   entry that is read from the trace file.
  - Changed signature of dynamorio::drmemtrace:record_reader_t::read_next_entry() to
    return a pointer to the read #dynamorio::drmemtrace:trace_entry_t instead of a bool.
  - Added a parameter to the constructor of #dynamorio::drmemtrace:reader_t and

--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -239,6 +239,7 @@ set(raw2trace_srcs
   tracer/instru_online.cpp
   tracer/instru_offline.cpp
   reader/reader.cpp
+  reader/reader_base.cpp
   common/trace_entry.cpp
   reader/record_file_reader.cpp
   ${zlib_reader}
@@ -287,6 +288,7 @@ set(drcachesim_srcs
   analyzer_multi.cpp
   ${client_and_sim_srcs}
   reader/reader.cpp
+  reader/reader_base.cpp
   reader/config_reader.cpp
   reader/v2p_reader.cpp
   reader/file_reader.cpp
@@ -353,6 +355,7 @@ add_exported_library(drmemtrace_analyzer STATIC
   scheduler/noise_generator.cpp
   common/trace_entry.cpp
   reader/reader.cpp
+  reader/reader_base.cpp
   reader/config_reader.cpp
   reader/v2p_reader.cpp
   reader/file_reader.cpp
@@ -381,6 +384,7 @@ install_client_nonDR_header(drmemtrace common/archive_istream.h)
 install_client_nonDR_header(drmemtrace common/archive_ostream.h)
 install_client_nonDR_header(drmemtrace common/mutex_dbg_owned.h)
 install_client_nonDR_header(drmemtrace reader/reader.h)
+install_client_nonDR_header(drmemtrace reader/reader_base.h)
 install_client_nonDR_header(drmemtrace reader/record_file_reader.h)
 install_client_nonDR_header(drmemtrace analysis_tool.h)
 install_client_nonDR_header(drmemtrace analyzer.h)

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -122,10 +122,7 @@ template <>
 trace_entry_t *
 file_reader_t<gzip_reader_t>::read_next_entry()
 {
-    trace_entry_t *entry = read_queued_entry();
-    if (entry != nullptr)
-        return entry;
-    entry = read_next_entry_common(&input_file_, &at_eof_);
+    trace_entry_t *entry = read_next_entry_common(&input_file_, &at_eof_);
     if (entry == nullptr)
         return entry;
     VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",
@@ -161,17 +158,17 @@ record_file_reader_t<gzip_reader_t>::open_single_file(const std::string &path)
 }
 
 template <>
-bool
+trace_entry_t *
 record_file_reader_t<gzip_reader_t>::read_next_entry()
 {
-    trace_entry_t *entry = read_next_entry_common(input_file_.get(), &eof_);
+    trace_entry_t *entry = read_next_entry_common(input_file_.get(), &at_eof_);
     if (entry == nullptr)
-        return false;
+        return nullptr;
     cur_entry_ = *entry;
     VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",
            trace_type_names[cur_entry_.type], cur_entry_.type, cur_entry_.size,
            cur_entry_.addr);
-    return true;
+    return &cur_entry_;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/reader/compressed_file_reader.cpp
+++ b/clients/drcachesim/reader/compressed_file_reader.cpp
@@ -164,11 +164,11 @@ record_file_reader_t<gzip_reader_t>::read_next_entry()
     trace_entry_t *entry = read_next_entry_common(input_file_.get(), &at_eof_);
     if (entry == nullptr)
         return nullptr;
-    cur_entry_ = *entry;
+    entry_copy_ = *entry;
     VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",
-           trace_type_names[cur_entry_.type], cur_entry_.type, cur_entry_.size,
-           cur_entry_.addr);
-    return &cur_entry_;
+           trace_type_names[entry_copy_.type], entry_copy_.type, entry_copy_.size,
+           entry_copy_.addr);
+    return &entry_copy_;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/reader/file_reader.cpp
+++ b/clients/drcachesim/reader/file_reader.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2023 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -75,9 +75,6 @@ template <>
 trace_entry_t *
 file_reader_t<std::ifstream *>::read_next_entry()
 {
-    trace_entry_t *from_queue = read_queued_entry();
-    if (from_queue != nullptr)
-        return from_queue;
     if (!input_file_->read((char *)&entry_copy_, sizeof(entry_copy_))) {
         at_eof_ = input_file_->eof();
         return nullptr;

--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -77,10 +77,9 @@ template <typename T> class file_reader_t : public reader_t {
 public:
     file_reader_t();
     file_reader_t(const std::string &path, int verbosity = 0)
-        : reader_t(verbosity, "[file_reader]")
+        : reader_t(/*online=*/false, verbosity, "[file_reader]")
         , input_path_(path)
     {
-        online_ = false;
     }
     virtual ~file_reader_t();
     bool

--- a/clients/drcachesim/reader/ipc_reader.cpp
+++ b/clients/drcachesim/reader/ipc_reader.cpp
@@ -50,7 +50,7 @@ ipc_reader_t::ipc_reader_t()
 }
 
 ipc_reader_t::ipc_reader_t(const char *ipc_name, int verbosity)
-    : reader_t(verbosity, "IPC")
+    : reader_t(/*online=*/true, verbosity, "IPC")
     , pipe_(ipc_name)
 {
     // We create the pipe here so the user can set up a pipe writer
@@ -95,9 +95,6 @@ ipc_reader_t::~ipc_reader_t()
 trace_entry_t *
 ipc_reader_t::read_next_entry()
 {
-    trace_entry_t *from_queue = read_queued_entry();
-    if (from_queue != nullptr)
-        return from_queue;
     ++cur_buf_;
     if (cur_buf_ >= end_buf_) {
         ssize_t sz = pipe_.read(buf_, sizeof(buf_)); // blocking read

--- a/clients/drcachesim/reader/lz4_file_reader.cpp
+++ b/clients/drcachesim/reader/lz4_file_reader.cpp
@@ -92,10 +92,7 @@ template <>
 trace_entry_t *
 file_reader_t<lz4_reader_t>::read_next_entry()
 {
-    trace_entry_t *entry = read_queued_entry();
-    if (entry != nullptr)
-        return entry;
-    entry = read_next_entry_common(&input_file_, &at_eof_);
+    trace_entry_t *entry = read_next_entry_common(&input_file_, &at_eof_);
     if (entry == nullptr)
         return entry;
     VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -56,6 +56,10 @@ namespace drmemtrace {
             abort();             \
     } while (0)
 
+/***********************************
+ * Implementation for reader_base_t.
+ */
+
 reader_base_t::reader_base_t(int online, int verbosity, const char *output_prefix)
     : verbosity_(verbosity)
     , output_prefix_(output_prefix)
@@ -96,6 +100,10 @@ reader_base_t::operator!=(const reader_base_t &rhs) const
 {
     return !BOOLS_MATCH(at_eof_, rhs.at_eof_);
 }
+
+/***********************************
+ * Implementation for reader_t.
+ */
 
 // Work around clang-format bug: no newline after return type for single-char operator.
 // clang-format off

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -56,7 +56,7 @@ namespace drmemtrace {
             abort();             \
     } while (0)
 
-/***********************************
+/****************************************************************************
  * Implementation for reader_base_t.
  */
 
@@ -101,7 +101,7 @@ reader_base_t::operator!=(const reader_base_t &rhs) const
     return !BOOLS_MATCH(at_eof_, rhs.at_eof_);
 }
 
-/***********************************
+/****************************************************************************
  * Implementation for reader_t.
  */
 

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -56,8 +56,9 @@ namespace drmemtrace {
             abort();             \
     } while (0)
 
-reader_base_t::reader_base_t(int online, int verbosity)
+reader_base_t::reader_base_t(int online, int verbosity, const char *output_prefix)
     : verbosity_(verbosity)
+    , output_prefix_(output_prefix)
     , online_(online)
 {
 }

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -56,55 +56,6 @@ namespace drmemtrace {
             abort();             \
     } while (0)
 
-/****************************************************************************
- * Implementation for reader_base_t.
- */
-
-reader_base_t::reader_base_t(int online, int verbosity, const char *output_prefix)
-    : verbosity_(verbosity)
-    , output_prefix_(output_prefix)
-    , online_(online)
-{
-}
-
-bool
-reader_base_t::is_online()
-{
-    return online_;
-}
-
-trace_entry_t *
-reader_base_t::get_next_entry()
-{
-    if (!queue_.empty()) {
-        entry_copy_ = queue_.front();
-        queue_.pop();
-        return &entry_copy_;
-    }
-    return read_next_entry();
-}
-
-// To avoid double-dispatch (requires listing all derived types in the base here)
-// and RTTI in trying to get the right operators called for subclasses, we
-// instead directly check at_eof here.  If we end up needing to run code
-// and a bool field is not enough we can change this to invoke a virtual
-// method is_at_eof().
-bool
-reader_base_t::operator==(const reader_base_t &rhs) const
-{
-    return BOOLS_MATCH(at_eof_, rhs.at_eof_);
-}
-
-bool
-reader_base_t::operator!=(const reader_base_t &rhs) const
-{
-    return !BOOLS_MATCH(at_eof_, rhs.at_eof_);
-}
-
-/****************************************************************************
- * Implementation for reader_t.
- */
-
 // Work around clang-format bug: no newline after return type for single-char operator.
 // clang-format off
 const memref_t &

--- a/clients/drcachesim/reader/reader.cpp
+++ b/clients/drcachesim/reader/reader.cpp
@@ -56,6 +56,46 @@ namespace drmemtrace {
             abort();             \
     } while (0)
 
+reader_base_t::reader_base_t(int online, int verbosity)
+    : verbosity_(verbosity)
+    , online_(online)
+{
+}
+
+bool
+reader_base_t::is_online()
+{
+    return online_;
+}
+
+trace_entry_t *
+reader_base_t::get_next_entry()
+{
+    if (!queue_.empty()) {
+        entry_copy_ = queue_.front();
+        queue_.pop();
+        return &entry_copy_;
+    }
+    return read_next_entry();
+}
+
+// To avoid double-dispatch (requires listing all derived types in the base here)
+// and RTTI in trying to get the right operators called for subclasses, we
+// instead directly check at_eof here.  If we end up needing to run code
+// and a bool field is not enough we can change this to invoke a virtual
+// method is_at_eof().
+bool
+reader_base_t::operator==(const reader_base_t &rhs) const
+{
+    return BOOLS_MATCH(at_eof_, rhs.at_eof_);
+}
+
+bool
+reader_base_t::operator!=(const reader_base_t &rhs) const
+{
+    return !BOOLS_MATCH(at_eof_, rhs.at_eof_);
+}
+
 // Work around clang-format bug: no newline after return type for single-char operator.
 // clang-format off
 const memref_t &
@@ -65,23 +105,13 @@ reader_t::operator*()
     return cur_ref_;
 }
 
-trace_entry_t *
-reader_t::read_queued_entry()
-{
-    if (queue_.empty())
-        return nullptr;
-    entry_copy_ = queue_.front();
-    queue_.pop();
-    return &entry_copy_;
-}
-
 reader_t &
 reader_t::operator++()
 {
     // We bail if we get a partial read, or EOF, or any error.
     while (true) {
         if (bundle_idx_ == 0 /*not in instr bundle*/)
-            input_entry_ = read_next_entry();
+            input_entry_ = get_next_entry();
         if (input_entry_ == NULL) {
             if (!at_eof_) {
                 ERRMSG("Trace is truncated\n");
@@ -428,7 +458,7 @@ reader_t::pre_skip_instructions()
     // XXX: We assume the page size is the final header; it is complex to wait for
     // the timestamp as we don't want to read it yet.
     while (page_size_ == 0) {
-        input_entry_ = read_next_entry();
+        input_entry_ = get_next_entry();
         if (input_entry_ == nullptr) {
             at_eof_ = true;
             return false;
@@ -493,7 +523,7 @@ reader_t::skip_instructions_with_timestamp(uint64_t stop_instruction_count)
         // too-far instr if we didn't find a timestamp.
         if (input_entry_ != nullptr) // Only at start: and we checked for skipping 0.
             entry_copy_ = *input_entry_;
-        trace_entry_t *next = read_next_entry();
+        trace_entry_t *next = get_next_entry();
         if (next == nullptr) {
             VPRINT(this, 1,
                    next == nullptr ? "Failed to read next entry\n" : "Hit EOF\n");

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -113,7 +113,7 @@ protected:
      *
      * An invocation of this API may or may not cause an actual read from the underlying
      * source using the derived class implementation of
-     * dynamorio::drmemtrace::reader_base_t::read_next_entry().
+     * #dynamorio::drmemtrace::reader_base_t::read_next_entry().
      */
     trace_entry_t *
     get_next_entry();

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -76,8 +76,8 @@ namespace drmemtrace {
  * #dynamorio::drmemtrace::record_reader_t. This contains some interfaces and
  * implementations that are shared between the two types of readers.
  *
- * This base class is intended for logic close to reading the entries and the
- * reader interface common to the two types of readers, and not so much for
+ * This base class is intended for logic close to reading the entries, and the
+ * reader interface common to the two types of readers; not so much for
  * reader-specific logic for what to do with the entries.
  *
  * TODO i#5727: Can we potentially move other logic or interface definitions here?
@@ -140,9 +140,11 @@ protected:
     int verbosity_ = 0;
     const char *output_prefix_ = "[reader_base_t]";
 
-    // We store into this queue records already read from the input but not
-    // yet returned to the iterator. E.g., when reader_t needs to read ahead when
-    // skipping to include post-instr records.
+    /**
+     * We store into this queue records already read from the input but not
+     * yet returned to the iterator. E.g., #dynamorio::drmemtrace::reader_t
+     * needs to read ahead when skipping to include the post-instr records.
+     */
     std::queue<trace_entry_t> queue_;
     trace_entry_t entry_copy_;
 

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -85,7 +85,7 @@ namespace drmemtrace {
 class reader_base_t : public memtrace_stream_t {
 public:
     reader_base_t() = default;
-    reader_base_t(int online, int verbosity);
+    reader_base_t(int online, int verbosity, const char *output_prefix);
     virtual ~reader_base_t()
     {
     }
@@ -144,7 +144,7 @@ protected:
     // yet returned to the iterator. E.g., when reader_t needs to read ahead when
     // skipping to include post-instr records.
     std::queue<trace_entry_t> queue_;
-    trace_entry_t entry_copy_; // For use in returning a queue entry.
+    trace_entry_t entry_copy_;
 
 private:
     /**
@@ -178,8 +178,7 @@ public:
         cur_ref_ = {};
     }
     reader_t(bool online, int verbosity, const char *prefix)
-        : reader_base_t(online, verbosity)
-        , output_prefix_(prefix)
+        : reader_base_t(online, verbosity, prefix)
     {
         cur_ref_ = {};
     }
@@ -300,7 +299,6 @@ protected:
     virtual reader_t &
     skip_instructions_with_timestamp(uint64_t stop_instruction_count);
 
-    const char *output_prefix_ = "[reader]";
     uint64_t cur_ref_count_ = 0;
     int64_t suppress_ref_count_ = -1;
     uint64_t cur_instr_count_ = 0;

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -91,13 +91,6 @@ namespace drmemtrace {
  */
 class reader_base_t : public memtrace_stream_t {
 public:
-    // Ensure derived classes operate as a proper C++ iterator in all circumstances.
-    using iterator_category = std::input_iterator_tag;
-    using value_type = memref_t;
-    using difference_type = std::ptrdiff_t;
-    using pointer = value_type *;
-    using reference = value_type &;
-
     reader_base_t() = default;
     reader_base_t(int online, int verbosity, const char *output_prefix);
     virtual ~reader_base_t() = default;
@@ -187,6 +180,13 @@ private:
  */
 class reader_t : public reader_base_t {
 public:
+    // Ensure derived classes operate as a proper C++ iterator in all circumstances.
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = memref_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     reader_t()
         : reader_base_t()
     {

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -49,128 +49,12 @@
 // For exporting we avoid "../common" and rely on -I.
 #include "memref.h"
 #include "memtrace_stream.h"
+#include "reader_base.h"
 #include "trace_entry.h"
 #include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {
-
-#ifndef DR_PARAM_OUT
-#    define DR_PARAM_OUT /* just a marker */
-#endif
-
-#ifdef DEBUG
-#    define VPRINT(reader, level, ...)                            \
-        do {                                                      \
-            if ((reader)->verbosity_ >= (level)) {                \
-                fprintf(stderr, "%s ", (reader)->output_prefix_); \
-                fprintf(stderr, __VA_ARGS__);                     \
-            }                                                     \
-        } while (0)
-#else
-#    define VPRINT(reader, level, ...) /* nothing */
-#endif
-
-/**
- * Base class for #dynamorio::drmemtrace:reader_t and
- * #dynamorio::drmemtrace::record_reader_t. This contains some interfaces and
- * implementations that are shared between the two types of readers.
- *
- * This base class is intended for logic close to reading the entries, and the
- * reader interface common to the two types of readers; not so much for
- * reader-specific logic for what to do with the entries.
- *
- * This subclasses #dynamorio::drmemtrace::memtrace_stream_t because the readers
- * derived from it are expected to implement that interface. We want to avoid
- * subclasses having to inherit from multiple base classes
- * (#dynamorio::drmemtrace::reader_base_t and
- * #dynamorio::drmemtrace::memtrace_stream_t), so it is better for us to
- * inherit from #dynamorio::drmemtrace::memtrace_stream_t here.
- *
- * XXX i#5727: Can we potentially move other logic or interface definitions here?
- */
-class reader_base_t : public memtrace_stream_t {
-public:
-    reader_base_t() = default;
-    reader_base_t(int online, int verbosity, const char *output_prefix);
-    virtual ~reader_base_t() = default;
-
-    /**
-     * Initializes various state for the reader. E.g., subclasses should remember to
-     * set #at_eof_ to false here. Also reads the first entry by invoking
-     * operator++() so that operator*() is ready to provide one after init().
-     *
-     * May block for reading the first entry.
-     */
-    virtual bool
-    init() = 0;
-
-    bool
-    operator==(const reader_base_t &rhs) const;
-    bool
-    operator!=(const reader_base_t &rhs) const;
-
-protected:
-    /**
-     * Returns the next entry for this reader.
-     *
-     * If it returns nullptr, it will set the #at_eof_ field to distinguish end-of-file
-     * from an error.
-     *
-     * An invocation of this API may or may not cause an actual read from the underlying
-     * source using the derived class implementation of
-     * #dynamorio::drmemtrace::reader_base_t::read_next_entry().
-     */
-    trace_entry_t *
-    get_next_entry();
-
-    /**
-     * Returns whether the reader is operating in the online mode, which involves reading
-     * trace entries from an IPC pipe, as opposed to reading them from a more persistent
-     * media like a file on a disk.
-     */
-    bool
-    is_online();
-
-    /**
-     * Denotes whether the reader is at EOF.
-     *
-     * This should be set to false by subclasses in init() and set back to true when
-     * actual EOF is hit.
-     *
-     * Following typical stream iterator convention, the default constructor
-     * produces an EOF object.
-     */
-    bool at_eof_ = true;
-
-    int verbosity_ = 0;
-    const char *output_prefix_ = "[reader_base_t]";
-
-    /**
-     * We store into this queue records already read from the input but not
-     * yet returned to the iterator. E.g., #dynamorio::drmemtrace::reader_t
-     * needs to read ahead when skipping to include the post-instr records.
-     */
-    std::queue<trace_entry_t> queue_;
-    trace_entry_t entry_copy_;
-
-private:
-    /**
-     * This reads the next single entry from the underlying single stream of entries.
-     *
-     * If it returns nullptr, it will set the EOF bit to distinguish end-of-file from an
-     * error.
-     *
-     * This is used only by #dynamorio::drmemtrace::reader_base_t::get_next_entry()
-     * when needed to access the underlying source of entries. Subclasses that
-     * need the next entry should use
-     * #dynamorio::drmemtrace::reader_base_t::get_next_entry() instead.
-     */
-    virtual trace_entry_t *
-    read_next_entry() = 0;
-
-    bool online_ = true;
-};
 
 /**
  * Iterator over #dynamorio::drmemtrace::memref_t trace entries. This class converts a

--- a/clients/drcachesim/reader/reader.h
+++ b/clients/drcachesim/reader/reader.h
@@ -112,7 +112,8 @@ protected:
      * error in the at_eof_ data member.
      *
      * An invocation of this API may or may not cause an actual read from the underlying
-     * source using #dynamorio::drmemtrace::reader_base_t::read_next_entry().
+     * source using the derived class implementation of
+     * dynamorio::drmemtrace::reader_base_t::read_next_entry().
      */
     trace_entry_t *
     get_next_entry();

--- a/clients/drcachesim/reader/reader_base.cpp
+++ b/clients/drcachesim/reader/reader_base.cpp
@@ -1,0 +1,84 @@
+/* **********************************************************
+ * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+#include "reader_base.h"
+
+#include <queue>
+
+#include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+reader_base_t::reader_base_t(int online, int verbosity, const char *output_prefix)
+    : verbosity_(verbosity)
+    , output_prefix_(output_prefix)
+    , online_(online)
+{
+}
+
+bool
+reader_base_t::is_online()
+{
+    return online_;
+}
+
+trace_entry_t *
+reader_base_t::get_next_entry()
+{
+    if (!queue_.empty()) {
+        entry_copy_ = queue_.front();
+        queue_.pop();
+        return &entry_copy_;
+    }
+    return read_next_entry();
+}
+
+// To avoid double-dispatch (requires listing all derived types in the base here)
+// and RTTI in trying to get the right operators called for subclasses, we
+// instead directly check at_eof here.  If we end up needing to run code
+// and a bool field is not enough we can change this to invoke a virtual
+// method is_at_eof().
+bool
+reader_base_t::operator==(const reader_base_t &rhs) const
+{
+    return BOOLS_MATCH(at_eof_, rhs.at_eof_);
+}
+
+bool
+reader_base_t::operator!=(const reader_base_t &rhs) const
+{
+    return !BOOLS_MATCH(at_eof_, rhs.at_eof_);
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/reader/reader_base.cpp
+++ b/clients/drcachesim/reader/reader_base.cpp
@@ -35,6 +35,7 @@
 #include <queue>
 
 #include "trace_entry.h"
+#include "utils.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/reader_base.h
+++ b/clients/drcachesim/reader/reader_base.h
@@ -100,9 +100,9 @@ public:
     virtual bool
     init() = 0;
 
-    bool
+    virtual bool
     operator==(const reader_base_t &rhs) const;
-    bool
+    virtual bool
     operator!=(const reader_base_t &rhs) const;
 
 protected:

--- a/clients/drcachesim/reader/reader_base.h
+++ b/clients/drcachesim/reader/reader_base.h
@@ -1,0 +1,176 @@
+/* **********************************************************
+ * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* reader_base: virtual base class for an iterator that provides a single memory
+ * stream for use by a cache simulator; the iterator could be on either memref_t
+ * records or trace_entry_t records.
+ */
+
+#ifndef _READER_BASE_H_
+#define _READER_BASE_H_ 1
+
+#include <queue>
+
+// For exporting we avoid "../common" and rely on -I.
+#include "memtrace_stream.h"
+#include "trace_entry.h"
+
+namespace dynamorio {
+namespace drmemtrace {
+
+#ifndef DR_PARAM_OUT
+#    define DR_PARAM_OUT /* just a marker */
+#endif
+
+#define OUT /* just a marker */
+
+#ifdef DEBUG
+#    define VPRINT(reader, level, ...)                            \
+        do {                                                      \
+            if ((reader)->verbosity_ >= (level)) {                \
+                fprintf(stderr, "%s ", (reader)->output_prefix_); \
+                fprintf(stderr, __VA_ARGS__);                     \
+            }                                                     \
+        } while (0)
+// clang-format off
+#    define UNUSED(x) /* nothing */
+// clang-format on
+#else
+#    define VPRINT(reader, level, ...) /* nothing */
+#    define UNUSED(x) ((void)(x))
+#endif
+
+/**
+ * Base class for #dynamorio::drmemtrace:reader_t and
+ * #dynamorio::drmemtrace::record_reader_t. This contains some interfaces and
+ * implementations that are shared between the two types of readers.
+ *
+ * This base class is intended for logic close to reading the entries, and the
+ * reader interface common to the two types of readers; not so much for
+ * reader-specific logic for what to do with the entries.
+ *
+ * This subclasses #dynamorio::drmemtrace::memtrace_stream_t because the readers
+ * derived from it are expected to implement that interface. We want to avoid
+ * subclasses having to inherit from multiple base classes
+ * (#dynamorio::drmemtrace::reader_base_t and
+ * #dynamorio::drmemtrace::memtrace_stream_t), so it is better for us to
+ * inherit from #dynamorio::drmemtrace::memtrace_stream_t here.
+ *
+ * XXX i#5727: Can we potentially move other logic or interface definitions here?
+ */
+class reader_base_t : public memtrace_stream_t {
+public:
+    reader_base_t() = default;
+    reader_base_t(int online, int verbosity, const char *output_prefix);
+    virtual ~reader_base_t() = default;
+
+    /**
+     * Initializes various state for the reader. E.g., subclasses should remember to
+     * set #at_eof_ to false here. Also reads the first entry by invoking
+     * operator++() so that operator*() is ready to provide one after init().
+     *
+     * May block for reading the first entry.
+     */
+    virtual bool
+    init() = 0;
+
+    bool
+    operator==(const reader_base_t &rhs) const;
+    bool
+    operator!=(const reader_base_t &rhs) const;
+
+protected:
+    /**
+     * Returns the next entry for this reader.
+     *
+     * If it returns nullptr, it will set the #at_eof_ field to distinguish end-of-file
+     * from an error.
+     *
+     * An invocation of this API may or may not cause an actual read from the underlying
+     * source using the derived class implementation of
+     * #dynamorio::drmemtrace::reader_base_t::read_next_entry().
+     */
+    trace_entry_t *
+    get_next_entry();
+
+    /**
+     * Returns whether the reader is operating in the online mode, which involves reading
+     * trace entries from an IPC pipe, as opposed to reading them from a more persistent
+     * media like a file on a disk.
+     */
+    bool
+    is_online();
+
+    /**
+     * Denotes whether the reader is at EOF.
+     *
+     * This should be set to false by subclasses in init() and set back to true when
+     * actual EOF is hit.
+     *
+     * Following typical stream iterator convention, the default constructor
+     * produces an EOF object.
+     */
+    bool at_eof_ = true;
+
+    int verbosity_ = 0;
+    const char *output_prefix_ = "[reader_base_t]";
+
+    /**
+     * We store into this queue records already read from the input but not
+     * yet returned to the iterator. E.g., #dynamorio::drmemtrace::reader_t
+     * needs to read ahead when skipping to include the post-instr records.
+     */
+    std::queue<trace_entry_t> queue_;
+    trace_entry_t entry_copy_;
+
+private:
+    /**
+     * This reads the next single entry from the underlying single stream of entries.
+     *
+     * If it returns nullptr, it will set the EOF bit to distinguish end-of-file from an
+     * error.
+     *
+     * This is used only by #dynamorio::drmemtrace::reader_base_t::get_next_entry()
+     * when needed to access the underlying source of entries. Subclasses that
+     * need the next entry should use
+     * #dynamorio::drmemtrace::reader_base_t::get_next_entry() instead.
+     */
+    virtual trace_entry_t *
+    read_next_entry() = 0;
+
+    bool online_ = true;
+};
+
+} // namespace drmemtrace
+} // namespace dynamorio
+
+#endif /* _READER_BASE_H_ */

--- a/clients/drcachesim/reader/reader_base.h
+++ b/clients/drcachesim/reader/reader_base.h
@@ -78,12 +78,9 @@ namespace drmemtrace {
  * reader interface common to the two types of readers; not so much for
  * reader-specific logic for what to do with the entries.
  *
- * This subclasses #dynamorio::drmemtrace::memtrace_stream_t because the readers
- * derived from it are expected to implement that interface. We want to avoid
- * subclasses having to inherit from multiple base classes
- * (#dynamorio::drmemtrace::reader_base_t and
- * #dynamorio::drmemtrace::memtrace_stream_t), so it is better for us to
- * inherit from #dynamorio::drmemtrace::memtrace_stream_t here.
+ * This subclasses #dynamorio::drmemtrace::memtrace_stream_t because all readers
+ * derived from it are expected to implement that interface, but it leaves the
+ * implementation of the stream APIs to each derived class.
  *
  * XXX i#5727: Can we potentially move other logic or interface definitions here?
  */

--- a/clients/drcachesim/reader/record_file_reader.cpp
+++ b/clients/drcachesim/reader/record_file_reader.cpp
@@ -57,19 +57,19 @@ record_file_reader_t<std::ifstream>::open_single_file(const std::string &path)
 }
 
 template <>
-bool
+trace_entry_t *
 record_file_reader_t<std::ifstream>::read_next_entry()
 {
     if (!input_file_->read((char *)&cur_entry_, sizeof(cur_entry_))) {
         if (input_file_->eof()) {
-            eof_ = true;
+            at_eof_ = true;
         }
-        return false;
+        return nullptr;
     }
     VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",
            trace_type_names[cur_entry_.type], cur_entry_.type, cur_entry_.size,
            cur_entry_.addr);
-    return true;
+    return &cur_entry_;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/reader/record_file_reader.cpp
+++ b/clients/drcachesim/reader/record_file_reader.cpp
@@ -60,16 +60,16 @@ template <>
 trace_entry_t *
 record_file_reader_t<std::ifstream>::read_next_entry()
 {
-    if (!input_file_->read((char *)&cur_entry_, sizeof(cur_entry_))) {
+    if (!input_file_->read((char *)&entry_copy_, sizeof(entry_copy_))) {
         if (input_file_->eof()) {
             at_eof_ = true;
         }
         return nullptr;
     }
     VPRINT(this, 4, "Read from file: type=%s (%d), size=%d, addr=%zu\n",
-           trace_type_names[cur_entry_.type], cur_entry_.type, cur_entry_.size,
-           cur_entry_.addr);
-    return &cur_entry_;
+           trace_type_names[entry_copy_.type], entry_copy_.type, entry_copy_.size,
+           entry_copy_.addr);
+    return &entry_copy_;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/reader/record_file_reader.cpp
+++ b/clients/drcachesim/reader/record_file_reader.cpp
@@ -31,7 +31,9 @@
  */
 
 #include <fstream>
+
 #include "record_file_reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -152,10 +152,10 @@ public:
     record_reader_t &
     operator++()
     {
-        bool res = get_next_entry();
-        assert(res || at_eof_);
-        UNUSED(res);
+        trace_entry_t *next_entry = get_next_entry();
+        assert(next_entry != nullptr || at_eof_);
         if (!at_eof_) {
+            cur_entry_ = *next_entry;
             ++cur_ref_count_;
             // We increment the instr count at the encoding as that avoids multiple
             // problems with separating encodings from instrs when skipping (including

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -137,7 +137,7 @@ public:
     const trace_entry_t &
     operator*()
     {
-        return cur_entry_;
+        return entry_copy_;
     }
 
     static bool
@@ -155,29 +155,29 @@ public:
         trace_entry_t *next_entry = get_next_entry();
         assert(next_entry != nullptr || at_eof_);
         if (!at_eof_) {
-            cur_entry_ = *next_entry;
+            entry_copy_ = *next_entry;
             ++cur_ref_count_;
             // We increment the instr count at the encoding as that avoids multiple
             // problems with separating encodings from instrs when skipping (including
             // for scheduler regions of interest) and when replaying schedules: anything
             // using instr ordinals as boundaries.
             if (!prev_record_was_pre_instr_ &&
-                (record_is_pre_instr(&cur_entry_) ||
-                 type_is_instr(static_cast<trace_type_t>(cur_entry_.type))))
+                (record_is_pre_instr(&entry_copy_) ||
+                 type_is_instr(static_cast<trace_type_t>(entry_copy_.type))))
                 ++cur_instr_count_;
-            else if (cur_entry_.type == TRACE_TYPE_MARKER) {
-                switch (cur_entry_.size) {
-                case TRACE_MARKER_TYPE_VERSION: version_ = cur_entry_.addr; break;
-                case TRACE_MARKER_TYPE_FILETYPE: filetype_ = cur_entry_.addr; break;
+            else if (entry_copy_.type == TRACE_TYPE_MARKER) {
+                switch (entry_copy_.size) {
+                case TRACE_MARKER_TYPE_VERSION: version_ = entry_copy_.addr; break;
+                case TRACE_MARKER_TYPE_FILETYPE: filetype_ = entry_copy_.addr; break;
                 case TRACE_MARKER_TYPE_CACHE_LINE_SIZE:
-                    cache_line_size_ = cur_entry_.addr;
+                    cache_line_size_ = entry_copy_.addr;
                     break;
-                case TRACE_MARKER_TYPE_PAGE_SIZE: page_size_ = cur_entry_.addr; break;
+                case TRACE_MARKER_TYPE_PAGE_SIZE: page_size_ = entry_copy_.addr; break;
                 case TRACE_MARKER_TYPE_CHUNK_INSTR_COUNT:
-                    chunk_instr_count_ = cur_entry_.addr;
+                    chunk_instr_count_ = entry_copy_.addr;
                     break;
                 case TRACE_MARKER_TYPE_TIMESTAMP:
-                    last_timestamp_ = cur_entry_.addr;
+                    last_timestamp_ = entry_copy_.addr;
                     if (first_timestamp_ == 0)
                         first_timestamp_ = last_timestamp_;
                     break;
@@ -191,7 +191,7 @@ public:
                     break;
                 }
             }
-            prev_record_was_pre_instr_ = record_is_pre_instr(&cur_entry_);
+            prev_record_was_pre_instr_ = record_is_pre_instr(&entry_copy_);
         }
         return *this;
     }
@@ -262,8 +262,6 @@ protected:
     open_single_file(const std::string &input_path) = 0;
     virtual bool
     open_input_file() = 0;
-
-    trace_entry_t cur_entry_ = {};
 
 protected:
     uint64_t cur_ref_count_ = 0;

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -42,26 +42,8 @@
 #include <memory>
 
 #include "memtrace_stream.h"
-#include "reader.h"
+#include "reader_base.h"
 #include "trace_entry.h"
-
-#define OUT /* just a marker */
-
-#ifdef DEBUG
-#    define VPRINT(reader, level, ...)                            \
-        do {                                                      \
-            if ((reader)->verbosity_ >= (level)) {                \
-                fprintf(stderr, "%s ", (reader)->output_prefix_); \
-                fprintf(stderr, __VA_ARGS__);                     \
-            }                                                     \
-        } while (0)
-// clang-format off
-#    define UNUSED(x) /* nothing */
-// clang-format on
-#else
-#    define VPRINT(reader, level, ...) /* nothing */
-#    define UNUSED(x) ((void)(x))
-#endif
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -114,8 +114,7 @@ namespace drmemtrace {
 class record_reader_t : public reader_base_t {
 public:
     record_reader_t(int online, int verbosity, const char *prefix)
-        : reader_base_t(online, verbosity)
-        , output_prefix_(prefix)
+        : reader_base_t(online, verbosity, prefix)
     {
     }
     record_reader_t()
@@ -265,8 +264,6 @@ protected:
     open_input_file() = 0;
 
     trace_entry_t cur_entry_ = {};
-    int verbosity_;
-    const char *output_prefix_;
 
 protected:
     uint64_t cur_ref_count_ = 0;

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -56,7 +56,7 @@
             }                                                     \
         } while (0)
 // clang-format off
-#define UNUSED(x) /* nothing */
+#    define UNUSED(x) /* nothing */
 // clang-format on
 #else
 #    define VPRINT(reader, level, ...) /* nothing */

--- a/clients/drcachesim/reader/record_file_reader.h
+++ b/clients/drcachesim/reader/record_file_reader.h
@@ -113,6 +113,13 @@ namespace drmemtrace {
  */
 class record_reader_t : public reader_base_t {
 public:
+    // Ensure derived classes operate as a proper C++ iterator in all circumstances.
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = trace_entry_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     record_reader_t(int online, int verbosity, const char *prefix)
         : reader_base_t(online, verbosity, prefix)
     {

--- a/clients/drcachesim/reader/snappy_file_reader.cpp
+++ b/clients/drcachesim/reader/snappy_file_reader.cpp
@@ -229,9 +229,6 @@ template <>
 trace_entry_t *
 file_reader_t<snappy_reader_t>::read_next_entry()
 {
-    trace_entry_t *from_queue = read_queued_entry();
-    if (from_queue != nullptr)
-        return from_queue;
     int len = input_file_.read(sizeof(entry_copy_), &entry_copy_);
     // Returns less than asked-for if at end of file, or –1 for error.
     if (len < (int)sizeof(entry_copy_)) {

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -166,9 +166,6 @@ template <>
 trace_entry_t *
 file_reader_t<zipfile_reader_t>::read_next_entry()
 {
-    trace_entry_t *from_queue = read_queued_entry();
-    if (from_queue != nullptr)
-        return from_queue;
     if (!read_if_at_end_of_buffer(input_file_, at_eof_, entry_copy_))
         return nullptr;
     entry_copy_ = *input_file_.cur_buf;
@@ -279,17 +276,17 @@ record_file_reader_t<zipfile_reader_t>::open_single_file(const std::string &path
 }
 
 template <>
-bool
+trace_entry_t *
 record_file_reader_t<zipfile_reader_t>::read_next_entry()
 {
-    if (!read_if_at_end_of_buffer(*input_file_, eof_, cur_entry_))
-        return false;
+    if (!read_if_at_end_of_buffer(*input_file_, at_eof_, cur_entry_))
+        return nullptr;
     cur_entry_ = *input_file_->cur_buf;
     ++input_file_->cur_buf;
     VPRINT(this, 5, "Read %s: type=%s (%d), size=%d, addr=%zu\n",
            input_file_->path.c_str(), trace_type_names[cur_entry_.type], cur_entry_.type,
            cur_entry_.size, cur_entry_.addr);
-    return true;
+    return &cur_entry_;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/reader/zipfile_file_reader.cpp
+++ b/clients/drcachesim/reader/zipfile_file_reader.cpp
@@ -279,14 +279,14 @@ template <>
 trace_entry_t *
 record_file_reader_t<zipfile_reader_t>::read_next_entry()
 {
-    if (!read_if_at_end_of_buffer(*input_file_, at_eof_, cur_entry_))
+    if (!read_if_at_end_of_buffer(*input_file_, at_eof_, entry_copy_))
         return nullptr;
-    cur_entry_ = *input_file_->cur_buf;
+    entry_copy_ = *input_file_->cur_buf;
     ++input_file_->cur_buf;
     VPRINT(this, 5, "Read %s: type=%s (%d), size=%d, addr=%zu\n",
-           input_file_->path.c_str(), trace_type_names[cur_entry_.type], cur_entry_.type,
-           cur_entry_.size, cur_entry_.addr);
-    return &cur_entry_;
+           input_file_->path.c_str(), trace_type_names[entry_copy_.type],
+           entry_copy_.type, entry_copy_.size, entry_copy_.addr);
+    return &entry_copy_;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tests/mock_reader.h
+++ b/clients/drcachesim/tests/mock_reader.h
@@ -33,13 +33,13 @@
 /* A mock reader that iterates over a vector of trace_entry_t, for tests. */
 
 #ifndef _MOCK_READER_H_
-#    define _MOCK_READER_H_ 1
+#define _MOCK_READER_H_ 1
 
-#    include <vector>
+#include <vector>
 
-#    include "reader.h"
-#    include "record_file_reader.h"
-#    include "trace_entry.h"
+#include "reader.h"
+#include "record_file_reader.h"
+#include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/tests/mock_reader.h
+++ b/clients/drcachesim/tests/mock_reader.h
@@ -106,8 +106,8 @@ public:
             at_eof_ = true;
             return nullptr;
         }
-        cur_entry_ = trace_[index_];
-        return &cur_entry_;
+        entry_copy_ = trace_[index_];
+        return &entry_copy_;
     }
     std::string
     get_stream_name() const override

--- a/clients/drcachesim/tests/mock_reader.h
+++ b/clients/drcachesim/tests/mock_reader.h
@@ -50,9 +50,9 @@ class mock_reader_t : public reader_t {
 public:
     mock_reader_t() = default;
     explicit mock_reader_t(const std::vector<trace_entry_t> &trace)
-        : trace_(trace)
+        : reader_t(/*online=*/false, /*verbosity=*/3, "mock_reader_t")
+        , trace_(trace)
     {
-        verbosity_ = 3;
     }
     bool
     init() override

--- a/clients/drcachesim/tests/mock_reader.h
+++ b/clients/drcachesim/tests/mock_reader.h
@@ -33,13 +33,13 @@
 /* A mock reader that iterates over a vector of trace_entry_t, for tests. */
 
 #ifndef _MOCK_READER_H_
-#define _MOCK_READER_H_ 1
+#    define _MOCK_READER_H_ 1
 
-#include <vector>
+#    include <vector>
 
-#include "reader.h"
-#include "record_file_reader.h"
-#include "trace_entry.h"
+#    include "reader.h"
+#    include "record_file_reader.h"
+#    include "trace_entry.h"
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -64,9 +64,6 @@ public:
     trace_entry_t *
     read_next_entry() override
     {
-        trace_entry_t *entry = read_queued_entry();
-        if (entry != nullptr)
-            return entry;
         ++index_;
         if (index_ >= static_cast<int>(trace_.size())) {
             at_eof_ = true;
@@ -97,20 +94,20 @@ public:
     bool
     init() override
     {
-        eof_ = false;
+        at_eof_ = false;
         ++*this;
         return true;
     }
-    bool
+    trace_entry_t *
     read_next_entry() override
     {
         ++index_;
         if (index_ >= static_cast<int>(trace_.size())) {
-            eof_ = true;
-            return false;
+            at_eof_ = true;
+            return nullptr;
         }
         cur_entry_ = trace_[index_];
-        return true;
+        return &cur_entry_;
     }
     std::string
     get_stream_name() const override

--- a/clients/drcachesim/tests/mock_reader.h
+++ b/clients/drcachesim/tests/mock_reader.h
@@ -87,9 +87,9 @@ class mock_record_reader_t : public record_reader_t {
 public:
     mock_record_reader_t() = default;
     explicit mock_record_reader_t(const std::vector<trace_entry_t> &trace)
-        : trace_(trace)
+        : record_reader_t(/*online=*/false, /*verbosity=*/3, "mock_record_reader_t")
+        , trace_(trace)
     {
-        verbosity_ = 3;
     }
     bool
     init() override

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -456,16 +456,11 @@ public:
     {
         if (at_eof_)
             return nullptr;
-        trace_entry_t *entry = read_queued_entry();
-        if (entry != nullptr)
-            return entry;
         if (pos_ >= input_file_.size()) {
             at_eof_ = true;
             return nullptr;
         }
-        entry = &input_file_[pos_];
-        ++pos_;
-        return entry;
+        return &input_file_[pos_++];
     }
 
 private:

--- a/clients/drcachesim/tests/view_test.cpp
+++ b/clients/drcachesim/tests/view_test.cpp
@@ -447,6 +447,7 @@ public:
         at_eof_ = true;
     }
     mock_file_reader_t(const std::vector<trace_entry_t> &entries)
+        : file_reader_t<std::vector<trace_entry_t>>("<mock-file>")
     {
         input_file_ = entries;
         pos_ = 0;

--- a/clients/drcachesim/tools/common/decode_cache.h
+++ b/clients/drcachesim/tools/common/decode_cache.h
@@ -121,7 +121,7 @@ private:
      * invoke set_decode_info() for each new decoded instruction.
      *
      * The responsibility for invoking instr_destroy() on the provided \p instr
-     * lies with this #decode_info_base_t object, unless the
+     * lies with this #dynamorio::drmemtrace::decode_info_base_t object, unless the
      * #dynamorio::drmemtrace::decode_cache_t was constructed with
      * \p persist_decoded_instr_ set to false, in which case no heap allocation
      * takes place.


### PR DESCRIPTION
Adds a new base class for reader_t and record_reader_t, called reader_base_t, which holds some interface definitions and implementation common to the two kinds of readers.

Adds get_next_entry() which is intended to be used by derived classes to get the next entry, which is different from read_next_entry() which actually reads the next entry from the underlying trace source and is now made private. get_next_entry() may or may not invoke read_next_entry() depending on whether there are queued entries already available.

Removes read_queued_entry() from all derived class implementations, as that is now simply handled by the reader_base_t::get_next_entry() itself.

Renamed eof_ to at_eof_ in record_reader_t and its derived classes, as that is now declared in reader_base_t, shared with reader_t. at_eof_ is without a getter and setter on purpose, to allow derived classes to more easily use it.

Renamed cur_entry_ to entry_copy_ in record_reader_t and its derived classes, as that is now declared in reader_base_t shared with reader_t. This can be used to hold the entry read by the derived classes of record_reader_t.

Requires derived classes to provide whether or not they operate in the online mode to reader_base_t's constructor, instead of asking them to set online_ by themselves.

Enables doxygen for private class members, as we want to be able to link to read_next_entry() which is part of the virtual interface of reader_base_t, though private.

The responsibility to read queued entries before accessing the actual stream of trace entries is taken back by the reader_base_t in this PR. It was moved to the individual types of readers in #5900, perhaps in an effort to simply the reader itself.

This is in preparation for #7621 which adds more entry queuing logic to reader_base_t.

Issue: #7496, #5727