### PR TITLE
i#7496 eret continuity: Use get_next_entry in file_reader_t

### DIFF
--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -102,9 +102,6 @@ public:
     }
 
 protected:
-    trace_entry_t *
-    read_next_entry() override;
-
     virtual bool
     open_single_file(const std::string &path);
 
@@ -121,7 +118,7 @@ protected:
         // the very first time for the thread.
         trace_entry_t *entry;
         trace_entry_t header = {}, pid = {}, tid = {};
-        entry = read_next_entry();
+        entry = get_next_entry();
         if (entry == nullptr || entry->type != TRACE_TYPE_HEADER) {
             ERRMSG("Invalid header\n");
             return false;
@@ -140,7 +137,7 @@ protected:
         // even though markers can precede the tid+pid in the file, in particular
         // for legacy traces.
         std::queue<trace_entry_t> marker_queue;
-        while ((entry = read_next_entry()) != nullptr) {
+        while ((entry = get_next_entry()) != nullptr) {
             if (entry->type == TRACE_TYPE_PID) {
                 // We assume the pid entry is after the tid.
                 pid = *entry;
@@ -178,6 +175,9 @@ protected:
     T input_file_;
 
 private:
+    trace_entry_t *
+    read_next_entry() override;
+
     std::string input_path_;
 };
 


### PR DESCRIPTION
Replaces uses of read_next_entry() with get_next_entry() in file_reader_t.

Since these usages were in open_single_file() before anything was really queued, it didn't matter that get_next_entry() (which also checks the queue) wasn't used.

Under this non-virtual interface pattern, since file_reader_t itself has provided the implementation of read_next_entry(), we cannot stop it from using it, but the recommendation is to use get_next_entry().

Preserves private visibility for file_reader_t<T>::read_next_entry(), just because there's no reason to change it to protected.

Issue: #7496