### PR TITLE
i#7588 drsyscall: Add functions to write pre and post syscall records.

### DIFF
--- a/ext/drsyscall/CMakeLists.txt
+++ b/ext/drsyscall/CMakeLists.txt
@@ -170,7 +170,7 @@ use_DynamoRIO_extension(drsyscall_static drcontainers)
 use_DynamoRIO_extension(drsyscall_static drsyms_static)
 configure_drsyscall_target(drsyscall_static)
 
-add_library(drsyscall_drstatic STATIC ${srcs_static})
+add_library(drsyscall_drstatic STATIC ${srcs_static} ${external_srcs})
 configure_extension(drsyscall_drstatic ON ON)
 use_DynamoRIO_extension(drsyscall_drstatic drmgr_drstatic)
 use_DynamoRIO_extension(drsyscall_drstatic drcontainers_drstatic)
@@ -186,11 +186,21 @@ if (LINUX)
     ../drmf/framework/drmf_utils.c
   )
 
-  add_library(drsyscall_record_lib STATIC ${drsyscall_record_lib_srcs}
+  add_library(drsyscall_record_lib SHARED ${drsyscall_record_lib_srcs}
     ${drsyscall_record_lib_external_srcs})
-  configure_extension(drsyscall_record_lib ON ON)
-  configure_DynamoRIO_client(drsyscall_record_lib)
-  use_DynamoRIO_extension(drutil_static drmgr_static)
+  configure_extension(drsyscall_record_lib OFF OFF)
+  # configure_extension calls configure_DynamoRIO_client/configure_DynamoRIO_static_client
+  use_DynamoRIO_extension(drsyscall_record_lib drsyscall)
+
+  add_library(drsyscall_record_lib_static STATIC ${drsyscall_record_lib_srcs}
+    ${drsyscall_record_lib_external_srcs})
+  configure_extension(drsyscall_record_lib_static ON OFF)
+  use_DynamoRIO_extension(drsyscall_record_lib_static drsyscall_static)
+
+  add_library(drsyscall_record_lib_drstatic STATIC ${drsyscall_record_lib_srcs}
+    ${drsyscall_record_lib_external_srcs})
+  configure_extension(drsyscall_record_lib_drstatic ON ON)
+  use_DynamoRIO_extension(drsyscall_record_lib_drstatic drsyscall_drstatic)
 
   install_ext_header(drsyscall_record.h)
   install_ext_header(drsyscall_record_lib.h)
@@ -198,7 +208,7 @@ if (LINUX)
   add_executable(drsyscall_record_viewer drsyscall_record_viewer.c)
   configure_DynamoRIO_standalone(drsyscall_record_viewer)
   configure_DynamoRIO_static(drsyscall_record_viewer)
-  use_DynamoRIO_extension(drsyscall_record_viewer drsyscall_record_lib)
+  use_DynamoRIO_extension(drsyscall_record_viewer drsyscall_record_lib_static)
   set_target_properties(drsyscall_record_viewer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY${location_suffix} "${PROJECT_BINARY_DIR}/${INSTALL_BIN}")
 endif ()

--- a/ext/drsyscall/drsyscall_record_lib.c
+++ b/ext/drsyscall/drsyscall_record_lib.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "drsyscall.h"
+#include "drsyscall_os.h"
 #include "drsyscall_record.h"
 #include "drsyscall_record_lib.h"
 #include "utils.h"

--- a/ext/drsyscall/drsyscall_record_lib.c
+++ b/ext/drsyscall/drsyscall_record_lib.c
@@ -37,6 +37,15 @@
 #include "drsyscall_record_lib.h"
 #include "utils.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+c_style_function();
+#ifdef __cplusplus
+}
+#endif
+
 #define MAX_BUFFER_SIZE 8192
 
 DR_EXPORT
@@ -221,4 +230,130 @@ drsyscall_write_syscall_end_timestamp_record(
     record.syscall_number_timestamp.syscall_number = sysnum;
     record.syscall_number_timestamp.timestamp = timestamp;
     return write_func((char *)&record, sizeof(record));
+}
+
+/**
+ * A callback function to be invoked for each system call parameter. It invokes
+ * drsyscall_write_memarg_record to write a syscall record of type
+ * #DRSYS_PRECALL_PARAM when arg->pre is true, #DRSYS_POSTCALL_PARAM otherwise.
+ * Always returns true to continue the iteration to the next parameter.
+ */
+static bool
+drsyscall_iter_arg_cb(drsys_arg_t *arg, void *user_data)
+{
+    const drsyscall_record_write_t write_func = (drsyscall_record_write_t)user_data;
+    drsyscall_write_param_record(write_func, arg);
+    return true;
+}
+
+/**
+ * A callback function to be invoked for each memory region. It invokes
+ * drsyscall_write_memarg_record to write a syscall record of type
+ * #DRSYS_MEMORY_CONTENT.
+ * Always returns true to continue the iteration to the next memory region.
+ */
+static bool
+drsyscall_iter_memarg_cb(drsys_arg_t *arg, void *user_data)
+{
+    const drsyscall_record_write_t write_func = (drsyscall_record_write_t)user_data;
+    drsyscall_write_memarg_record(write_func, arg);
+    return true;
+}
+
+DR_EXPORT
+bool
+drsyscall_write_pre_syscall_records(DR_PARAM_IN drsyscall_record_write_t write_func,
+                                    DR_PARAM_IN void *drcontext, DR_PARAM_IN int sysnum,
+                                    DR_PARAM_IN uint64_t timestamp)
+{
+    drsys_syscall_t *syscall;
+    if (drsys_cur_syscall(drcontext, &syscall) != DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_cur_syscall failed, sysnum = %d", sysnum);
+        return false;
+    }
+    drsys_sysnum_t sysnum_full;
+    if (drsys_syscall_number(syscall, &sysnum_full) != DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_syscall_number failed, sysnum = %d",
+            sysnum);
+        return false;
+    }
+    if (sysnum != sysnum_full.number) {
+        LOG(drcontext, SYSCALL_VERBOSE, "primary (%d) should match DR's num %d", sysnum,
+            sysnum_full.number);
+        return false;
+    }
+    drsys_param_type_t ret_type = DRSYS_TYPE_INVALID;
+    if (drsys_syscall_return_type(syscall, &ret_type) != DRMF_SUCCESS ||
+        ret_type == DRSYS_TYPE_INVALID || ret_type == DRSYS_TYPE_UNKNOWN) {
+        LOG(drcontext, SYSCALL_VERBOSE, "failed to get syscall return type, sysnum = %d",
+            sysnum);
+        return false;
+    }
+    bool known = false;
+    if (drsys_syscall_is_known(syscall, &known) != DRMF_SUCCESS || !known) {
+        LOG(drcontext, SYSCALL_VERBOSE, "syscall %d is unknown", sysnum);
+        return false;
+    }
+
+    if (drsyscall_write_syscall_number_timestamp_record(write_func, sysnum_full,
+                                                        timestamp) == 0) {
+        LOG(drcontext, SYSCALL_VERBOSE,
+            "failed to write syscall number record, sysnum = %d", sysnum);
+        return false;
+    }
+
+    if (drsys_iterate_args(drcontext, drsyscall_iter_arg_cb, write_func) !=
+        DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_iterate_args failed, sysnum = %d", sysnum);
+        return false;
+    }
+    if (drsys_iterate_memargs(drcontext, drsyscall_iter_memarg_cb, write_func) !=
+        DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_iterate_memargs failed, sysnum = %d",
+            sysnum);
+        return false;
+    }
+    return true;
+}
+
+DR_EXPORT
+bool
+drsyscall_write_post_syscall_records(DR_PARAM_IN drsyscall_record_write_t write_func,
+                                     DR_PARAM_IN void *drcontext, DR_PARAM_IN int sysnum,
+                                     DR_PARAM_IN uint64_t timestamp)
+{
+    drsys_syscall_t *syscall;
+    if (drsys_cur_syscall(drcontext, &syscall) != DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_cur_syscall failed, sysnum = %d", sysnum);
+        return false;
+    }
+    drsys_sysnum_t sysnum_full;
+    if (drsys_syscall_number(syscall, &sysnum_full) != DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_syscall_number failed, sysnum = %d",
+            sysnum);
+        return false;
+    }
+    if (sysnum != sysnum_full.number) {
+        LOG(drcontext, SYSCALL_VERBOSE, "primary (%d) should match DR's num %d", sysnum,
+            sysnum_full.number);
+        return false;
+    }
+    if (drsys_iterate_args(drcontext, drsyscall_iter_arg_cb, write_func) !=
+        DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_iterate_args failed, sysnum = %d", sysnum);
+        return false;
+    }
+    if (drsys_iterate_memargs(drcontext, drsyscall_iter_memarg_cb, write_func) !=
+        DRMF_SUCCESS) {
+        LOG(drcontext, SYSCALL_VERBOSE, "drsys_iterate_memargs failed, sysnum = %d",
+            sysnum);
+        return false;
+    }
+    if (drsyscall_write_syscall_end_timestamp_record(write_func, sysnum_full,
+                                                     timestamp) == 0) {
+        LOG(drcontext, SYSCALL_VERBOSE, "failed to write syscall end record, sysnum = %d",
+            sysnum);
+        return false;
+    }
+    return true;
 }

--- a/ext/drsyscall/drsyscall_record_lib.c
+++ b/ext/drsyscall/drsyscall_record_lib.c
@@ -38,15 +38,6 @@
 #include "drsyscall_record_lib.h"
 #include "utils.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-void
-c_style_function();
-#ifdef __cplusplus
-}
-#endif
-
 #define MAX_BUFFER_SIZE 8192
 
 DR_EXPORT

--- a/ext/drsyscall/drsyscall_record_lib.c
+++ b/ext/drsyscall/drsyscall_record_lib.c
@@ -224,9 +224,9 @@ drsyscall_write_syscall_end_timestamp_record(
     return write_func((char *)&record, sizeof(record));
 }
 
-/**
+/*
  * A callback function to be invoked for each system call parameter. It invokes
- * drsyscall_write_memarg_record to write a syscall record of type
+ * drsyscall_write_param_recordi() to write a syscall record of type
  * #DRSYS_PRECALL_PARAM when arg->pre is true, #DRSYS_POSTCALL_PARAM otherwise.
  * Always returns true to continue the iteration to the next parameter.
  */
@@ -238,9 +238,9 @@ drsyscall_iter_arg_cb(drsys_arg_t *arg, void *user_data)
     return true;
 }
 
-/**
+/*
  * A callback function to be invoked for each memory region. It invokes
- * drsyscall_write_memarg_record to write a syscall record of type
+ * drsyscall_write_memarg_record() to write a syscall record of type
  * #DRSYS_MEMORY_CONTENT.
  * Always returns true to continue the iteration to the next memory region.
  */

--- a/ext/drsyscall/drsyscall_record_lib.h
+++ b/ext/drsyscall/drsyscall_record_lib.h
@@ -30,13 +30,13 @@
  * DAMAGE.
  */
 #ifndef _DRSYSCALL_RECORD_LIB_H_
-#    define _DRSYSCALL_RECORD_LIB_H_ 1
-#    include <stdio.h>
-#    include <unistd.h>
+#define _DRSYSCALL_RECORD_LIB_H_ 1
+#include <stdio.h>
+#include <unistd.h>
 
-#    include "dr_api.h"
-#    include "drsyscall.h"
-#    include "drsyscall_record.h"
+#include "dr_api.h"
+#include "drsyscall.h"
+#include "drsyscall_record.h"
 
 /**
  * A user provided function to read syscall records. Returns the number of bytes read.
@@ -64,9 +64,9 @@ typedef size_t (*drsyscall_record_write_t)(DR_PARAM_IN char *buffer,
 typedef bool (*drsyscall_iter_record_cb_t)(DR_PARAM_IN syscall_record_t *record,
                                            DR_PARAM_IN char *buffer,
                                            DR_PARAM_IN size_t size);
-#    ifdef __cplusplus
+#ifdef __cplusplus
 extern "C" {
-#    endif
+#endif
 
 DR_EXPORT
 /**
@@ -211,8 +211,8 @@ drsyscall_write_post_syscall_records(DR_PARAM_IN drsyscall_record_write_t write_
                                      DR_PARAM_IN void *drcontext, DR_PARAM_IN int sysnum,
                                      DR_PARAM_IN uint64_t timestamp);
 
-#    ifdef __cplusplus
+#ifdef __cplusplus
 }
-#    endif
+#endif
 
 #endif /* _DRSYSCALL_RECORD_LIB_H_ */

--- a/ext/drsyscall/drsyscall_record_lib.h
+++ b/ext/drsyscall/drsyscall_record_lib.h
@@ -64,9 +64,6 @@ typedef size_t (*drsyscall_record_write_t)(DR_PARAM_IN char *buffer,
 typedef bool (*drsyscall_iter_record_cb_t)(DR_PARAM_IN syscall_record_t *record,
                                            DR_PARAM_IN char *buffer,
                                            DR_PARAM_IN size_t size);
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 DR_EXPORT
 /**
@@ -210,9 +207,4 @@ bool
 drsyscall_write_post_syscall_records(DR_PARAM_IN drsyscall_record_write_t write_func,
                                      DR_PARAM_IN void *drcontext, DR_PARAM_IN int sysnum,
                                      DR_PARAM_IN uint64_t timestamp);
-
-#ifdef __cplusplus
-}
-#endif
-
 #endif /* _DRSYSCALL_RECORD_LIB_H_ */

--- a/ext/drsyscall/drsyscall_record_lib.h
+++ b/ext/drsyscall/drsyscall_record_lib.h
@@ -30,13 +30,13 @@
  * DAMAGE.
  */
 #ifndef _DRSYSCALL_RECORD_LIB_H_
-#define _DRSYSCALL_RECORD_LIB_H_ 1
-#include <stdio.h>
-#include <unistd.h>
+#    define _DRSYSCALL_RECORD_LIB_H_ 1
+#    include <stdio.h>
+#    include <unistd.h>
 
-#include "dr_api.h"
-#include "drsyscall.h"
-#include "drsyscall_record.h"
+#    include "dr_api.h"
+#    include "drsyscall.h"
+#    include "drsyscall_record.h"
 
 /**
  * A user provided function to read syscall records. Returns the number of bytes read.
@@ -64,6 +64,9 @@ typedef size_t (*drsyscall_record_write_t)(DR_PARAM_IN char *buffer,
 typedef bool (*drsyscall_iter_record_cb_t)(DR_PARAM_IN syscall_record_t *record,
                                            DR_PARAM_IN char *buffer,
                                            DR_PARAM_IN size_t size);
+#    ifdef __cplusplus
+extern "C" {
+#    endif
 
 DR_EXPORT
 /**
@@ -171,5 +174,45 @@ int
 drsyscall_write_syscall_end_timestamp_record(
     DR_PARAM_IN drsyscall_record_write_t write_func, DR_PARAM_IN drsys_sysnum_t sysnum,
     DR_PARAM_IN uint64_t timestamp);
+
+DR_EXPORT
+/**
+ * Write pre-syscall records of type #DRSYS_SYSCALL_NUMBER_TIMESTAMP,
+ * #DRSYS_PRECALL_PARAM, and #DRSYS_MEMORY_CONTENT of the current syscall.
+ * The caller must invoke drmgr_init() and drsys_init() before calling this function.
+ *
+ * @param[in] write_func  A user provided function to write syscall record.
+ * @param[in] drcontext   The opaque context.
+ * @param[in] sysnum      The system call number.
+ * @param[in] timestamp   The timestamp of the end of the syscall.
+ *
+ * @return true when records are written successfully, false otherwise.
+ */
+bool
+drsyscall_write_pre_syscall_records(DR_PARAM_IN drsyscall_record_write_t write_func,
+                                    DR_PARAM_IN void *drcontext, DR_PARAM_IN int sysnum,
+                                    DR_PARAM_IN uint64_t timestamp);
+
+DR_EXPORT
+/**
+ * Write pre-syscall records of type #DRSYS_POSTCALL_PARAM, #DRSYS_MEMORY_CONTENT,
+ * #DRSYS_RETURN_VALUE, and #DRSYS_RECORD_END_TIMESTAMP of the current syscall.
+ * The caller must invoke drmgr_init() and drsys_init() before calling this function.
+ *
+ * @param[in] write_func  A user provided function to write syscall record.
+ * @param[in] drcontext   The opaque context.
+ * @param[in] sysnum      The system call number.
+ * @param[in] timestamp   The timestamp of the end of the syscall.
+ *
+ * @return true when records are written successfully, false otherwise.
+ */
+bool
+drsyscall_write_post_syscall_records(DR_PARAM_IN drsyscall_record_write_t write_func,
+                                     DR_PARAM_IN void *drcontext, DR_PARAM_IN int sysnum,
+                                     DR_PARAM_IN uint64_t timestamp);
+
+#    ifdef __cplusplus
+}
+#    endif
 
 #endif /* _DRSYSCALL_RECORD_LIB_H_ */

--- a/suite/tests/client-interface/syscall-records-test.dll.c
+++ b/suite/tests/client-interface/syscall-records-test.dll.c
@@ -119,44 +119,9 @@ event_pre_syscall(void *drcontext, int sysnum)
     if (!event_filter_syscall(drcontext, sysnum)) {
         return true;
     }
-    drsys_syscall_t *syscall;
-    if (drsys_cur_syscall(drcontext, &syscall) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_cur_syscall failed, sysnum = %d", sysnum);
-        return false;
-    }
-    drsys_sysnum_t sysnum_full;
-    if (drsys_syscall_number(syscall, &sysnum_full) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_syscall_number failed, sysnum = %d", sysnum);
-        return false;
-    }
-    if (sysnum != sysnum_full.number) {
-        dr_fprintf(STDERR, "primary (%d) should match DR's num %d", sysnum,
-                   sysnum_full.number);
-        return false;
-    }
-    drsys_param_type_t ret_type = DRSYS_TYPE_INVALID;
-    if (drsys_syscall_return_type(syscall, &ret_type) != DRMF_SUCCESS ||
-        ret_type == DRSYS_TYPE_INVALID || ret_type == DRSYS_TYPE_UNKNOWN) {
-        dr_fprintf(STDERR, "failed to get syscall return type, sysnum = %d", sysnum);
-        return false;
-    }
-    bool known = false;
-    if (drsys_syscall_is_known(syscall, &known) != DRMF_SUCCESS || !known) {
-        dr_fprintf(STDERR, "syscall %d is unknown", sysnum);
-        return false;
-    }
-    if (drsyscall_write_syscall_number_timestamp_record(
-            write_file, sysnum_full, get_microsecond_timestamp()) == 0) {
-        dr_fprintf(STDERR, "failed to write syscall number record, sysnum = %d", sysnum);
-        return false;
-    }
-
-    if (drsys_iterate_args(drcontext, drsys_iter_arg_cb, NULL) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_iterate_args failed, sysnum = %d", sysnum);
-        return false;
-    }
-    if (drsys_iterate_memargs(drcontext, drsys_iter_memarg_cb, NULL) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_iterate_memargs failed, sysnum = %d", sysnum);
+    if (!drsyscall_write_pre_syscall_records(write_file, drcontext, sysnum,
+                                             get_microsecond_timestamp())) {
+        dr_fprintf(STDERR, "failed to write pre-syscall records, sysnum = %d", sysnum);
         return false;
     }
     return true;
@@ -168,33 +133,9 @@ event_post_syscall(void *drcontext, int sysnum)
     if (!event_filter_syscall(drcontext, sysnum)) {
         return;
     }
-    drsys_syscall_t *syscall;
-    if (drsys_cur_syscall(drcontext, &syscall) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_cur_syscall failed, sysnum = %d", sysnum);
-        return;
-    }
-    drsys_sysnum_t sysnum_full;
-    if (drsys_syscall_number(syscall, &sysnum_full) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_syscall_number failed, sysnum = %d", sysnum);
-        return;
-    }
-    if (sysnum != sysnum_full.number) {
-        dr_fprintf(STDERR, "primary (%d) should match DR's num %d", sysnum,
-                   sysnum_full.number);
-        return;
-    }
-    if (drsys_iterate_args(drcontext, drsys_iter_arg_cb, NULL) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_iterate_args failed, sysnum = %d", sysnum);
-        return;
-    }
-    if (drsys_iterate_memargs(drcontext, drsys_iter_memarg_cb, NULL) != DRMF_SUCCESS) {
-        dr_fprintf(STDERR, "drsys_iterate_memargs failed, sysnum = %d", sysnum);
-        return;
-    }
-    if (drsyscall_write_syscall_end_timestamp_record(write_file, sysnum_full,
-                                                     get_microsecond_timestamp()) == 0) {
-        dr_fprintf(STDERR, "failed to write syscall end record, sysnum = %d", sysnum);
-        return;
+    if (!drsyscall_write_post_syscall_records(write_file, drcontext, sysnum,
+                                              get_microsecond_timestamp())) {
+        dr_fprintf(STDERR, "failed to write post-syscall records, sysnum = %d", sysnum);
     }
 }
 


### PR DESCRIPTION
Add new functions to write pre-syscall and post-syscall records to drsyscall_record_lib.

drsyscall_write_pre_syscall_records() writes DRSYS_SYSCALL_NUMBER_TIMESTAMP, DRSYS_PRECALL_PARAM, and DRSYS_MEMORY_CONTENT records using the caller provided write function.

drsyscall_write_post_syscall_records() writes DRSYS_POSTCALL_PARAM, DRSYS_MEMORY_CONTENT,
 DRSYS_RETURN_VALUE, and DRSYS_RECORD_END_TIMESTAMP records.

The caller must invoke drmgr_init() and drsys_init() before calling these functions.

Change attach-memory-dump-syscall-test.dll.c and syscall-records-test.dll.c  to use these functions.

Update ext/drsyscall/CMakeLists.txt to change drsyscall_record_lib into a shared library, and add drsyscall_record_lib_static and drsyscall_record_lib_drstatic libraries.

Fix a bug in drsyscall_drstatic library where ${external_srcs} is missing.

Issue: #7588 