### PR TITLE
i#7630: Redirect __memcpy_chk etc. in private loader

### DIFF
--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1694,10 +1694,10 @@ static const redirect_import_t redirect_imports[] = {
     { "strstr", (app_pc)strstr },
     { "strcasecmp", (app_pc)strcasecmp },
     /* Also redirect the _chk versions (i#1747, i#46) */
-    { "memcpy_chk", (app_pc)memcpy },
-    { "memset_chk", (app_pc)memset },
-    { "memmove_chk", (app_pc)memmove },
-    { "strncpy_chk", (app_pc)strncpy },
+    { "__memcpy_chk", (app_pc)memcpy },
+    { "__memset_chk", (app_pc)memset },
+    { "__memmove_chk", (app_pc)memmove },
+    { "__strncpy_chk", (app_pc)strncpy },
 };
 #define REDIRECT_IMPORTS_NUM (sizeof(redirect_imports) / sizeof(redirect_imports[0]))
 

--- a/core/unix/loader.c
+++ b/core/unix/loader.c
@@ -1694,6 +1694,10 @@ static const redirect_import_t redirect_imports[] = {
     { "strstr", (app_pc)strstr },
     { "strcasecmp", (app_pc)strcasecmp },
     /* Also redirect the _chk versions (i#1747, i#46) */
+    { "memcpy_chk", (app_pc)memcpy },
+    { "memset_chk", (app_pc)memset },
+    { "memmove_chk", (app_pc)memmove },
+    { "strncpy_chk", (app_pc)strncpy },
     { "__memcpy_chk", (app_pc)memcpy },
     { "__memset_chk", (app_pc)memset },
     { "__memmove_chk", (app_pc)memmove },


### PR DESCRIPTION
Various tests, including drbbdup-test, were failing with some toolchain versions.

The names without the __ prefix (memcpy_chk etc.) were already being redirected.

Fixes #7630