### PR TITLE
i#7496 eret continuity: Set branch target using get_next_trace_pc()

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -61,6 +61,7 @@
 #include "memtrace_stream.h"
 #include "mutex_dbg_owned.h"
 #include "reader.h"
+#include "reader_base.h"
 #include "record_file_reader.h"
 #include "trace_entry.h"
 #ifdef HAS_LZ4
@@ -283,6 +284,23 @@ bool
 scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_is_thread_exit(memref_t record)
 {
     return record.exit.type == TRACE_TYPE_THREAD_EXIT;
+}
+
+template <>
+bool
+scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_has_pc(memref_t record,
+                                                              uint64_t &pc)
+{
+    if (type_is_instr(record.instr.type)) {
+        pc = record.instr.addr;
+        return true;
+    }
+    if (record.marker.type == TRACE_TYPE_MARKER &&
+        record.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+        pc = record.marker.marker_value;
+        return true;
+    }
+    return false;
 }
 
 template <>
@@ -569,6 +587,14 @@ scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::record_type_is_thread_exi
     trace_entry_t record)
 {
     return record.type == TRACE_TYPE_THREAD_EXIT;
+}
+
+template <>
+bool
+scheduler_impl_tmpl_t<trace_entry_t, record_reader_t>::record_type_has_pc(
+    trace_entry_t record, uint64_t &pc)
+{
+    return entry_queue_t::entry_has_pc(record, &pc);
 }
 
 template <>
@@ -1587,7 +1613,7 @@ template <typename RecordType, typename ReaderType>
 template <typename SequenceKey>
 typename scheduler_tmpl_t<RecordType, ReaderType>::scheduler_status_t
 scheduler_impl_tmpl_t<RecordType, ReaderType>::read_kernel_sequences(
-    std::unordered_map<SequenceKey, std::vector<RecordType>, custom_hash_t<SequenceKey>>
+    std::unordered_map<SequenceKey, trace_sequence_t, custom_hash_t<SequenceKey>>
         &sequence,
     std::string trace_path, std::unique_ptr<ReaderType> reader,
     std::unique_ptr<ReaderType> reader_end, trace_marker_type_t start_marker,
@@ -1641,13 +1667,18 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::read_kernel_sequences(
                     "Invalid " + sequence_type + " sequence found with default key";
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
             }
-            if (!sequence[sequence_key].empty()) {
+            if (!sequence[sequence_key].records.empty()) {
                 error_string_ += "Duplicate " + sequence_type + " sequence found";
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
             }
         }
-        if (in_sequence)
-            sequence[sequence_key].push_back(record);
+        if (in_sequence) {
+            sequence[sequence_key].records.push_back(record);
+            if (sequence[sequence_key].first_pc == 0 &&
+                record_type_has_pc(record, sequence[sequence_key].first_pc)) {
+                assert(sequence[sequence_key].first_pc != 0);
+            }
+        }
         if (is_marker && marker_type == end_marker) {
             if (!in_sequence) {
                 error_string_ += "Found " + sequence_type +
@@ -1658,12 +1689,13 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::read_kernel_sequences(
                 error_string_ += sequence_type + " marker values mismatched";
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
             }
-            if (sequence[sequence_key].empty()) {
+            if (sequence[sequence_key].records.empty()) {
                 error_string_ += sequence_type + " sequence empty";
                 return sched_type_t::STATUS_ERROR_INVALID_PARAMETER;
             }
             VPRINT(this, 1, "Read %zu kernel %s records for key %d\n",
-                   sequence[sequence_key].size(), sequence_type.c_str(), sequence_key);
+                   sequence[sequence_key].records.size(), sequence_type.c_str(),
+                   sequence_key);
             sequence_key = INVALID_SEQ_KEY;
             in_sequence = false;
         }
@@ -1847,6 +1879,9 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_pending_syscall_sequence(
     if (!record_type_is_invalid(record)) {
         // May be invalid if we're at input eof, in which case we do not need to
         // save it.
+        // We deliberately do not snapshot the next trace pc, as that can be
+        // obtained from the reader itself later when we resume returning
+        // records from the reader.
         input->queue.emplace_front(record);
     }
     int syscall_num = input->to_inject_syscall;
@@ -1858,7 +1893,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_pending_syscall_sequence(
     ++outputs_[output]
           .stats[memtrace_stream_t::SCHED_STAT_KERNEL_SYSCALL_SEQUENCE_INJECTIONS];
     VPRINT(this, 3, "Inserted %zu syscall records for syscall %d to %d.%d\n",
-           syscall_sequence_[syscall_num].size(), syscall_num, input->workload,
+           syscall_sequence_[syscall_num].records.size(), syscall_num, input->workload,
            input->index);
 
     // Return the first injected record.
@@ -1923,7 +1958,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::maybe_inject_pending_syscall_sequ
 template <typename RecordType, typename ReaderType>
 typename scheduler_tmpl_t<RecordType, ReaderType>::stream_status_t
 scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
-    std::vector<RecordType> &sequence, input_info_t *input)
+    trace_sequence_t &sequence, input_info_t *input)
 {
     // Inject kernel template code.  Since the injected records belong to this
     // input (the kernel is acting on behalf of this input) we insert them into the
@@ -1933,13 +1968,28 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
     // not affect input stream ordinals.
     // XXX: These will appear before the top headers of a new thread which is slightly
     // odd to have regular records with the new tid before the top headers.
-    assert(!sequence.empty());
+    assert(!sequence.records.empty());
     bool saw_any_instr = false;
     bool set_branch_target_marker = false;
     trace_marker_type_t marker_type;
     uintptr_t marker_value = 0;
-    for (int i = static_cast<int>(sequence.size()) - 1; i >= 0; --i) {
-        RecordType record = sequence[i];
+
+    // We walk the to-be-injected trace backwards, so next_trace_pc starts at the
+    // next pc from the input reader that would be returned after the injected records.
+    uint64_t next_trace_pc = 0;
+    // If there's a record with a pc in the front of the queue, that takes precedence.
+    if (!input->queue.empty() &&
+        record_type_has_pc(input->queue.front().record, next_trace_pc)) {
+    } else if (!input->queue.empty() && input->queue.front().next_trace_pc_valid) {
+        // Next, we check if the front record has a snapshotted value of
+        // next_trace_pc.
+        next_trace_pc = input->queue.front().next_trace_pc;
+    } else {
+        next_trace_pc = input->reader->get_next_trace_pc();
+    }
+    const uint64_t next_input_trace_pc = next_trace_pc;
+    for (int i = static_cast<int>(sequence.records.size()) - 1; i >= 0; --i) {
+        RecordType record = sequence.records[i];
         // TODO i#7495: Add invariant checks that ensure these are equal to the
         // context-switched-to thread when the switch sequence is injected into a
         // trace.
@@ -1951,16 +2001,9 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
                 saw_any_instr = true;
                 bool has_indirect_branch_target = false;
                 // If the last to-be-injected instruction is an indirect branch, set its
-                // indirect_branch_target field to the fallthrough pc of the last
-                // returned instruction from this input (for syscall injection, it would
-                // be the syscall for which we're injecting the trace). This is simpler
-                // than trying to get the actual next instruction on this input for which
-                // we would need to read-ahead.
-                // TODO i#7496: The above strategy does not work for syscalls that
-                // transfer control (like sigreturn) or for syscalls auto-restarted by a
-                // signal.
+                // indirect_branch_target field to the next pc in the input.
                 if (record_type_is_indirect_branch_instr(
-                        record, has_indirect_branch_target, input->last_pc_fallthrough) &&
+                        record, has_indirect_branch_target, next_input_trace_pc) &&
                     !has_indirect_branch_target) {
                     // trace_entry_t instr records do not hold the indirect branch target;
                     // instead a separate marker prior to the indirect branch instr holds
@@ -1971,13 +2014,15 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::inject_kernel_sequence(
         } else if (set_branch_target_marker &&
                    record_type_is_marker(record, marker_type, marker_value) &&
                    marker_type == TRACE_MARKER_TYPE_BRANCH_TARGET) {
-            record_type_set_marker_value(record, input->last_pc_fallthrough);
+            record_type_set_marker_value(record, next_input_trace_pc);
             set_branch_target_marker = false;
         }
-        // TODO i#7496: When we're in the middle of returning injected kernel records,
-        // the get_next_trace_pc() API should return the next pc in the injected sequence
-        // if there are still records left to be returned from the sequence.
-        input->queue.emplace_front(record);
+        input->queue.emplace_front(record, next_trace_pc);
+
+        // Update the next trace pc to the pc of the just-injected record. This will be
+        // used for the next injected record (which is the previous one in the sequence
+        // as we're iterating backwards).
+        record_type_has_pc(record, next_trace_pc);
     }
     return stream_status_t::STATUS_OK;
 }
@@ -2279,7 +2324,27 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::get_next_trace_pc(output_ordinal_
         inputs_[index].cur_queue_record.next_trace_pc_valid) {
         return inputs_[index].cur_queue_record.next_trace_pc;
     }
-    return inputs_[index].reader.get()->get_next_trace_pc();
+    // If the queue's front has a record that has a pc or it has a snapshotted value
+    // of the next pc, use that.
+    uint64_t pc;
+    if (!inputs_[index].queue.empty()) {
+        if (record_type_has_pc(inputs_[index].queue.front().record, pc)) {
+            return pc;
+        }
+        if (inputs_[index].queue.front().next_trace_pc_valid) {
+            return inputs_[index].queue.front().next_trace_pc;
+        }
+    }
+    // next_record returns queued records first, and then checks for pending
+    // syscall injections; we follow the same order here. This is required for
+    // the syscall-related markers that come after we know we're going to inject,
+    // but before we've queued up the syscall sequence.
+    if (inputs_[index].to_inject_syscall != input_info_t::INJECT_NONE) {
+        return inputs_[index].to_inject_syscall_first_pc;
+    }
+    // Finally, if none of the above conditions were met, the next record with a
+    // pc will be from the input reader.
+    return inputs_[index].reader->get_next_trace_pc();
 }
 
 template <typename RecordType, typename ReaderType>
@@ -2845,7 +2910,7 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::on_context_switch(
                       [memtrace_stream_t::SCHED_STAT_KERNEL_SWITCH_SEQUENCE_INJECTIONS];
                 VPRINT(this, 3,
                        "Inserted %zu switch records for type %d from %d.%d to %d.%d\n",
-                       switch_sequence_[switch_type].size(), switch_type,
+                       switch_sequence_[switch_type].records.size(), switch_type,
                        prev_input != sched_type_t::INVALID_INPUT_ORDINAL
                            ? inputs_[prev_input].workload
                            : -1,
@@ -3184,6 +3249,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::finalize_next_record(
         // The actual injection of the syscall trace happens later at the intended
         // point between the syscall function tracing markers.
         input->to_inject_syscall = static_cast<int>(marker_value);
+        input->to_inject_syscall_first_pc =
+            syscall_sequence_[input->to_inject_syscall].first_pc;
         input->saw_first_func_id_marker_after_syscall = false;
     } else if (record_type_is_instr(record, &instr_pc, &instr_size)) {
         input->last_pc_fallthrough = instr_pc + instr_size;

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -156,6 +156,11 @@ public:
     scheduler_status_t
     write_recorded_schedule();
 
+    // If the given record has a pc, sets the provided pc parameter to it and
+    // returns true, otherwise returns false and leaves it unchanged.
+    static bool
+    record_type_has_pc(RecordType record, uint64_t &pc);
+
 protected:
     typedef speculator_tmpl_t<RecordType> spec_type_t;
 
@@ -293,6 +298,8 @@ protected:
         bool skip_next_unscheduled = false;
         uint64_t last_run_time = 0;
         int to_inject_syscall = INJECT_NONE;
+        // Valid only if to_inject_syscall is not INJECT_NONE.
+        uint64_t to_inject_syscall_first_pc = 0;
         bool saw_first_func_id_marker_after_syscall = false;
 
         // Sentinel value for to_inject_syscall.
@@ -803,9 +810,11 @@ protected:
     SequenceKey
     invalid_kernel_sequence_key();
 
+    struct trace_sequence_t;
+
     template <typename SequenceKey>
     scheduler_status_t
-    read_kernel_sequences(std::unordered_map<SequenceKey, std::vector<RecordType>,
+    read_kernel_sequences(std::unordered_map<SequenceKey, trace_sequence_t,
                                              custom_hash_t<SequenceKey>> &sequence,
                           std::string trace_path, std::unique_ptr<ReaderType> reader,
                           std::unique_ptr<ReaderType> reader_end,
@@ -940,7 +949,7 @@ protected:
 
     // Performs the actual injection of the kernel sequence.
     stream_status_t
-    inject_kernel_sequence(std::vector<RecordType> &sequence, input_info_t *input);
+    inject_kernel_sequence(trace_sequence_t &sequence, input_info_t *input);
 
     // Performs the actual injection of a kernel syscall sequence, using
     // inject_kernel_sequence as helper.
@@ -1098,13 +1107,15 @@ protected:
     };
     std::unordered_map<workload_tid_t, input_ordinal_t, workload_tid_hash_t> tid2input_;
 
-    std::unordered_map<switch_type_t, std::vector<RecordType>,
-                       custom_hash_t<switch_type_t>>
+    struct trace_sequence_t {
+        std::vector<RecordType> records;
+        uint64_t first_pc = 0;
+    };
+    std::unordered_map<switch_type_t, trace_sequence_t, custom_hash_t<switch_type_t>>
         switch_sequence_;
     // We specify a custom hash function only to make it easier to generalize with
     // switch_sequence_ defined above.
-    std::unordered_map<int, std::vector<RecordType>, custom_hash_t<int>>
-        syscall_sequence_;
+    std::unordered_map<int, trace_sequence_t, custom_hash_t<int>> syscall_sequence_;
     // For single_lockstep_output.
     std::unique_ptr<stream_t> global_stream_;
     // For online where we currently have to map dynamically observed thread ids

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -421,6 +421,223 @@ test_parallel()
     assert(count == 2 * NUM_INPUTS);
 }
 
+static std::vector<trace_entry_t>
+get_mock_switch_sequence(addr_t thread_switch_pc_start = 0xcafe101,
+                         addr_t process_switch_pc_start = 0xf00d101)
+{
+    constexpr memref_tid_t TID_IN_SWITCHES = 1;
+    constexpr addr_t DONT_CARE = 0xd041ca4e;
+    return {
+        /* clang-format off */
+        test_util::make_header(TRACE_ENTRY_VERSION),
+        test_util::make_thread(TID_IN_SWITCHES),
+        test_util::make_pid(TID_IN_SWITCHES),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_timestamp(1),
+        test_util::make_marker(
+            TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, scheduler_t::SWITCH_PROCESS),
+        test_util::make_instr(process_switch_pc_start),
+        test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, DONT_CARE),
+        test_util::make_instr(process_switch_pc_start + 1,
+            TRACE_TYPE_INSTR_INDIRECT_JUMP),
+        test_util::make_marker(
+            TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, scheduler_t::SWITCH_PROCESS),
+        test_util::make_exit(TID_IN_SWITCHES),
+        test_util::make_footer(),
+        // Test a complete trace after the first one, which is how we plan to store
+        // these in an archive file.
+        test_util::make_header(TRACE_ENTRY_VERSION),
+        test_util::make_thread(TID_IN_SWITCHES),
+        test_util::make_pid(TID_IN_SWITCHES),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_marker(
+            TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, scheduler_t::SWITCH_THREAD),
+        test_util::make_instr(thread_switch_pc_start),
+        test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, DONT_CARE),
+        test_util::make_instr(thread_switch_pc_start + 1, TRACE_TYPE_INSTR_INDIRECT_JUMP),
+        test_util::make_marker(
+            TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, scheduler_t::SWITCH_THREAD),
+        test_util::make_exit(TID_IN_SWITCHES),
+        test_util::make_footer(),
+        /* clang-format on */
+    };
+}
+
+static std::vector<trace_entry_t>
+get_mock_syscall_sequence(int syscall_base, addr_t syscall_pc_start = 0xfeed101)
+{
+    constexpr memref_tid_t TID_IN_SYSCALLS = 1;
+    constexpr addr_t DONT_CARE = 0xd041ca4e;
+    return {
+        /* clang-format off */
+            test_util::make_header(TRACE_ENTRY_VERSION),
+            test_util::make_thread(TID_IN_SYSCALLS),
+            test_util::make_pid(TID_IN_SYSCALLS),
+            test_util::make_version(TRACE_ENTRY_VERSION),
+            test_util::make_timestamp(1),
+            test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL_TRACE_START, syscall_base),
+            test_util::make_instr(syscall_pc_start),
+            test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, DONT_CARE),
+            test_util::make_instr(syscall_pc_start + 1, TRACE_TYPE_INSTR_INDIRECT_JUMP),
+            test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL_TRACE_END, syscall_base),
+            // XXX: Currently all syscall traces are concatenated. We may change
+            // this to use an archive file instead.
+            test_util::make_marker(
+                TRACE_MARKER_TYPE_SYSCALL_TRACE_START, syscall_base + 1),
+            test_util::make_instr(syscall_pc_start + 10),
+            test_util::make_instr(syscall_pc_start + 11),
+            test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, DONT_CARE),
+            test_util::make_instr(syscall_pc_start + 12, TRACE_TYPE_INSTR_INDIRECT_JUMP),
+            test_util::make_marker(
+                TRACE_MARKER_TYPE_SYSCALL_TRACE_END, syscall_base + 1),
+            test_util::make_exit(TID_IN_SYSCALLS),
+            test_util::make_footer(),
+        /* clang-format on */
+    };
+}
+
+static void
+test_parallel_with_syscall_injection()
+{
+    std::cerr << "\n----------------\nTesting parallel with syscall injection\n";
+    constexpr int SYSCALL_BASE = 10;
+    std::vector<trace_entry_t> input_sequence = {
+        test_util::make_thread(1),
+        test_util::make_pid(1),
+        test_util::make_marker(TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+        test_util::make_timestamp(10),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 1),
+        test_util::make_instr(43),
+        test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL, SYSCALL_BASE),
+        test_util::make_marker(TRACE_MARKER_TYPE_FUNC_ID, 20),
+        test_util::make_marker(TRACE_MARKER_TYPE_FUNC_ARG, 1),
+        // Expected syscall injection point.
+        test_util::make_marker(TRACE_MARKER_TYPE_FUNC_ID, 20),
+        test_util::make_marker(TRACE_MARKER_TYPE_FUNC_RETVAL, 20),
+        test_util::make_marker(TRACE_MARKER_TYPE_TIMESTAMP, 101),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 102),
+        test_util::make_instr(42),
+        test_util::make_exit(1),
+    };
+
+    std::vector<trace_entry_t> syscall_sequence = get_mock_syscall_sequence(SYSCALL_BASE);
+    auto syscall_reader = std::unique_ptr<test_util::mock_reader_t>(
+        new test_util::mock_reader_t(syscall_sequence));
+    auto syscall_reader_end =
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t());
+    scheduler_t::scheduler_options_t sched_ops =
+        scheduler_t::make_scheduler_parallel_options(/*verbosity=*/4);
+    sched_ops.kernel_syscall_reader = std::move(syscall_reader);
+    sched_ops.kernel_syscall_reader_end = std::move(syscall_reader_end);
+
+    static constexpr int NUM_INPUTS = 3;
+    static constexpr int NUM_OUTPUTS = 2;
+    std::vector<trace_entry_t> inputs[NUM_INPUTS];
+    std::vector<scheduler_t::input_workload_t> sched_inputs;
+    for (int i = 0; i < NUM_INPUTS; i++) {
+        memref_tid_t tid = 100 + i;
+        inputs[i] = input_sequence;
+        for (auto &record : inputs[i]) {
+            if (record.type == TRACE_TYPE_THREAD || record.type == TRACE_TYPE_THREAD_EXIT)
+                record.addr = static_cast<addr_t>(tid);
+        }
+        std::vector<scheduler_t::input_reader_t> readers;
+        readers.emplace_back(
+            std::unique_ptr<test_util::mock_reader_t>(
+                new test_util::mock_reader_t(inputs[i])),
+            std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
+            tid);
+        sched_inputs.emplace_back(std::move(readers));
+    }
+    scheduler_t scheduler;
+    if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+        scheduler_t::STATUS_SUCCESS)
+        assert(false);
+    std::unordered_map<memref_tid_t, int> tid2stream;
+    for (int i = 0; i < NUM_OUTPUTS; i++) {
+        auto *stream = scheduler.get_stream(i);
+        memref_t memref;
+
+        // Whether we're currently in the syscall sequence records.
+        bool in_syscall = false;
+        bool saw_syscall_end = false;
+        uint64_t last_input_record_ordinal = 0;
+        uint64_t last_input_instr_ordinal = 0;
+        uint64_t last_branch_target_marker = 0;
+        uint64_t last_next_trace_pc = 0;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+            // Ensure one input thread is only in one output stream.
+            if (tid2stream.find(memref.instr.tid) == tid2stream.end()) {
+                tid2stream[memref.instr.tid] = i;
+                last_next_trace_pc = stream->get_next_trace_pc();
+            } else
+                assert(tid2stream[memref.instr.tid] == i);
+            if (memref.marker.type == TRACE_TYPE_MARKER) {
+                if (memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_START) {
+                    in_syscall = true;
+                } else if (memref.marker.marker_type ==
+                           TRACE_MARKER_TYPE_SYSCALL_TRACE_END) {
+                    saw_syscall_end = true;
+                }
+            }
+            if (type_is_instr_branch(memref.instr.type) &&
+                !type_is_instr_direct_branch(memref.instr.type)) {
+                last_branch_target_marker = memref.instr.indirect_branch_target;
+            }
+            if (type_is_instr(memref.instr.type) && saw_syscall_end) {
+                assert(last_branch_target_marker ==
+                       reinterpret_cast<uint64_t>(memref.instr.addr));
+                saw_syscall_end = false;
+            }
+            uint64_t pc;
+            if (memref.marker.type == TRACE_TYPE_MARKER &&
+                memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL) {
+                last_next_trace_pc = stream->get_next_trace_pc();
+            } else if (scheduler_impl_t::record_type_has_pc(memref, pc)) {
+                assert(pc == last_next_trace_pc);
+                last_next_trace_pc = stream->get_next_trace_pc();
+            } else {
+                assert(last_next_trace_pc == stream->get_next_trace_pc());
+            }
+            if (in_syscall) {
+                // All syscall records should have the same record and instr input
+                // ordinal as the last user-space one. Remember this analyzer mode
+                // uses USE_INPUT_ORDINALS.
+                assert(stream->get_record_ordinal() == last_input_record_ordinal);
+                assert(stream->get_instruction_ordinal() == last_input_instr_ordinal);
+            } else {
+                last_input_record_ordinal = stream->get_record_ordinal();
+                last_input_instr_ordinal = stream->get_instruction_ordinal();
+            }
+            assert(stream->get_record_ordinal() ==
+                       scheduler
+                               .get_input_stream_interface(
+                                   stream->get_input_stream_ordinal())
+                               ->get_record_ordinal() -
+                           // We readahead by one record to figure out the correct
+                           // injection point for the syscall trace.
+                           (in_syscall ? 1 : 0) ||
+                   // Relax for early on where the scheduler has read ahead for reasons
+                   // other than syscall injection.
+                   stream->get_last_timestamp() == 0);
+            assert(
+                stream->get_instruction_ordinal() ==
+                scheduler.get_input_stream_interface(stream->get_input_stream_ordinal())
+                    ->get_instruction_ordinal());
+            // Test other queries in parallel mode.
+            assert(stream->get_tid() == memref.instr.tid);
+            assert(stream->get_shard_index() == stream->get_input_stream_ordinal());
+            if (memref.marker.type == TRACE_TYPE_MARKER) {
+                if (memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_END) {
+                    in_syscall = false;
+                }
+            }
+        }
+    }
+}
+
 static void
 test_invalid_regions()
 {
@@ -2015,6 +2232,378 @@ test_synthetic_time_quanta()
 }
 
 static void
+test_synthetic_time_quanta_with_kernel()
+{
+    // This is a test of kernel syscall and switch injection done together
+    // with a case where the syscall is immediately followed by a switch
+    // sequence, and also some idles added as part of the injected syscall
+    // trace.
+    std::cerr << "\n----------------\nTesting time quanta with kernel\n";
+#ifdef HAS_ZIP
+    static constexpr memref_tid_t TID_BASE = 42;
+    static constexpr memref_tid_t TID_A = TID_BASE;
+    static constexpr memref_tid_t TID_B = TID_A + 1;
+    static constexpr memref_tid_t TID_C = TID_A + 2;
+    static constexpr memref_tid_t INPUT_ORD_MULTIPLIER = 100;
+    static constexpr memref_tid_t INSTR_1_OFFSET = 10;
+    static constexpr memref_tid_t INSTR_2_OFFSET = 30;
+    static constexpr memref_tid_t INSTR_3_OFFSET = 50;
+    static constexpr int NUM_OUTPUTS = 2;
+    static constexpr int NUM_INPUTS = 3;
+    static constexpr uint64_t BLOCK_THRESHOLD = 100;
+    static constexpr int PRE_BLOCK_TIME = 20;
+    static constexpr int POST_BLOCK_TIME = 220;
+    static constexpr int SYSCALL_BASE = 42;
+    std::vector<trace_entry_t> refs[NUM_INPUTS];
+    for (int i = 0; i < NUM_INPUTS; ++i) {
+        refs[i].push_back(test_util::make_thread(TID_BASE + i));
+        refs[i].push_back(test_util::make_pid(1));
+        refs[i].push_back(test_util::make_version(TRACE_ENTRY_VERSION));
+        refs[i].push_back(test_util::make_timestamp(10));
+        refs[i].push_back(
+            test_util::make_instr(INPUT_ORD_MULTIPLIER * i + INSTR_1_OFFSET));
+        refs[i].push_back(
+            test_util::make_instr(INPUT_ORD_MULTIPLIER * i + INSTR_2_OFFSET));
+        if (i == 0) {
+            refs[i].push_back(test_util::make_timestamp(PRE_BLOCK_TIME));
+            refs[i].push_back(
+                test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL, SYSCALL_BASE));
+            refs[i].push_back(
+                test_util::make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0));
+            refs[i].push_back(test_util::make_timestamp(POST_BLOCK_TIME));
+        }
+        refs[i].push_back(
+            test_util::make_instr(INPUT_ORD_MULTIPLIER * i + INSTR_3_OFFSET));
+        refs[i].push_back(test_util::make_exit(TID_BASE + i));
+    }
+
+    constexpr uint64_t SYSCALL_PC_START = 0xfeed101;
+    std::vector<trace_entry_t> syscall_sequence =
+        get_mock_syscall_sequence(SYSCALL_BASE, SYSCALL_PC_START);
+
+    constexpr uint64_t THREAD_SWITCH_PC_START = 0xcafe101;
+    constexpr uint64_t PROCESS_SWITCH_PC_START = 0xf00d101;
+    std::vector<trace_entry_t> switch_sequence =
+        get_mock_switch_sequence(THREAD_SWITCH_PC_START, PROCESS_SWITCH_PC_START);
+
+    std::string record_fname = "tmp_test_replay_time.zip";
+    {
+        // Record.
+        std::vector<scheduler_t::input_reader_t> readers;
+        for (int i = 0; i < NUM_INPUTS; ++i) {
+            readers.emplace_back(
+                std::unique_ptr<test_util::mock_reader_t>(
+                    new test_util::mock_reader_t(refs[i])),
+                std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
+                TID_BASE + i);
+        }
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/4);
+        // Uses same values as test_synthetic_time_quanta().
+        sched_ops.quantum_unit = scheduler_t::QUANTUM_TIME;
+        sched_ops.time_units_per_us = 1.;
+        sched_ops.quantum_duration_us = 3;
+        sched_ops.blocking_switch_threshold = BLOCK_THRESHOLD;
+        sched_ops.block_time_multiplier = 10. / (POST_BLOCK_TIME - PRE_BLOCK_TIME);
+        sched_ops.migration_threshold_us = 0;
+
+        auto syscall_reader = std::unique_ptr<test_util::mock_reader_t>(
+            new test_util::mock_reader_t(syscall_sequence));
+        auto syscall_reader_end =
+            std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t());
+        sched_ops.kernel_syscall_reader = std::move(syscall_reader);
+        sched_ops.kernel_syscall_reader_end = std::move(syscall_reader_end);
+
+        auto switch_reader = std::unique_ptr<test_util::mock_reader_t>(
+            new test_util::mock_reader_t(switch_sequence));
+        auto switch_reader_end =
+            std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t());
+        sched_ops.kernel_switch_reader = std::move(switch_reader);
+        sched_ops.kernel_switch_reader_end = std::move(switch_reader_end);
+
+        zipfile_ostream_t outfile(record_fname);
+        sched_ops.schedule_record_ostream = &outfile;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        auto check_next = [](std::string &sched, scheduler_t::stream_t *stream,
+                             uint64_t time, scheduler_t::stream_status_t expect_status,
+                             memref_tid_t expect_tid = INVALID_THREAD_ID,
+                             trace_type_t expect_type = TRACE_TYPE_READ,
+                             addr_t expect_pc_or_marker_val = 0,
+                             trace_marker_type_t expect_marker_type =
+                                 TRACE_MARKER_TYPE_RESERVED_END,
+                             addr_t expect_indirect_branch_target = 0) {
+            memref_t memref;
+            scheduler_t::stream_status_t status = stream->next_record(memref, time);
+            if (status != expect_status) {
+                std::cerr << "Expected status " << expect_status << " != " << status
+                          << " at time " << time << "\n";
+                assert(false);
+            }
+            if (status == scheduler_t::STATUS_IDLE) {
+                sched += "_";
+            } else if (status == scheduler_t::STATUS_OK) {
+                if (memref.marker.tid != expect_tid) {
+                    std::cerr << "Expected tid " << expect_tid
+                              << " != " << memref.marker.tid << " at time " << time
+                              << "\n";
+                    assert(false);
+                }
+                if (type_is_instr(memref.instr.type)) {
+                    sched += ('A' + (memref.instr.tid - TID_BASE) % 26);
+                    if (expect_pc_or_marker_val != 0 &&
+                        memref.instr.addr != expect_pc_or_marker_val) {
+                        std::cerr << "Expected pc " << expect_pc_or_marker_val
+                                  << " != " << memref.instr.addr << " at time " << time
+                                  << "\n";
+                        assert(false);
+                    }
+                    if (expect_indirect_branch_target != 0 &&
+                        memref.instr.indirect_branch_target !=
+                            expect_indirect_branch_target) {
+                        std::cerr << "Expected indirect_branch_target "
+                                  << expect_indirect_branch_target
+                                  << " != " << memref.instr.indirect_branch_target
+                                  << " at time " << time << "\n";
+                        assert(false);
+                    }
+                }
+                if (memref.marker.type == TRACE_TYPE_MARKER) {
+                    if (expect_marker_type != TRACE_MARKER_TYPE_RESERVED_END) {
+                        if (memref.marker.marker_type != expect_marker_type) {
+                            std::cerr << "Expected marker_type " << expect_marker_type
+                                      << " != " << memref.marker.marker_type
+                                      << " at time " << time << "\n";
+                            assert(false);
+                        }
+                        if (expect_pc_or_marker_val != 0 &&
+                            memref.marker.marker_value != expect_pc_or_marker_val) {
+                            std::cerr
+                                << "Expected marker_value " << expect_pc_or_marker_val
+                                << " != " << memref.marker.marker_value << " at time "
+                                << time << "\n";
+                            assert(false);
+                        }
+                    }
+                    switch (memref.marker.marker_type) {
+                    case TRACE_MARKER_TYPE_CONTEXT_SWITCH_START:
+                    case TRACE_MARKER_TYPE_CONTEXT_SWITCH_END: sched += "c"; break;
+                    case TRACE_MARKER_TYPE_SYSCALL_TRACE_START:
+                    case TRACE_MARKER_TYPE_SYSCALL_TRACE_END: sched += "s"; break;
+                    default: sched += "."; break;
+                    }
+                }
+            } else if (status != scheduler_t::STATUS_EOF) {
+                sched += "?";
+            }
+        };
+        static constexpr uint64_t INSTR_1_TID_C_PC =
+            INPUT_ORD_MULTIPLIER * 2 + INSTR_1_OFFSET;
+        static constexpr uint64_t INSTR_2_TID_A_PC =
+            INPUT_ORD_MULTIPLIER * 0 + INSTR_2_OFFSET;
+        static constexpr uint64_t INSTR_3_TID_A_PC =
+            INPUT_ORD_MULTIPLIER * 0 + INSTR_3_OFFSET;
+        static constexpr trace_marker_type_t NO_MARKER = TRACE_MARKER_TYPE_RESERVED_END;
+        uint64_t time = 1;
+        std::string sched_cpu0;
+        auto *cpu0 = scheduler.get_stream(0);
+        std::string sched_cpu1;
+        auto *cpu1 = scheduler.get_stream(1);
+
+        // Advance cpu0 to its switch from TID_A to TID_C.
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER);
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER);
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_INSTR);
+
+        // Advance cpu1 to its next quantum end.
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_B,
+                   TRACE_TYPE_MARKER);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_B,
+                   TRACE_TYPE_MARKER);
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_OK, TID_B,
+                   TRACE_TYPE_INSTR);
+
+        // switch sequence on cpu0.
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_MARKER,
+                   scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_THREAD,
+                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_INSTR, THREAD_SWITCH_PC_START);
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_C,
+                   // Ensure indirect_branch_target is correctly set to the 1st instr
+                   // in TID_C.
+                   TRACE_TYPE_INSTR_INDIRECT_JUMP, THREAD_SWITCH_PC_START + 1, NO_MARKER,
+                   INSTR_1_TID_C_PC);
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_MARKER,
+                   scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_THREAD,
+                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
+        // Now TID_C starts.
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_MARKER, INSTR_1_TID_C_PC);
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_MARKER);
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_INSTR);
+
+        // Advance cpu1 which is now at its quantum end at time 6 and should switch.
+        // However, there's no one else in cpu1's runqueue, so it proceeds with TID_B.
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_OK, TID_B,
+                   TRACE_TYPE_INSTR);
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_OK, TID_B,
+                   TRACE_TYPE_INSTR);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_B,
+                   TRACE_TYPE_THREAD_EXIT);
+        // cpu1 should now steal TID_A from cpu0.
+
+        // switch sequence on cpu1.
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER,
+                   scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_THREAD,
+                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_INSTR, THREAD_SWITCH_PC_START);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   // Ensure indirect_branch_target is correctly set to the 2nd instr
+                   // in TID_A.
+                   TRACE_TYPE_INSTR_INDIRECT_JUMP, THREAD_SWITCH_PC_START + 1, NO_MARKER,
+                   INSTR_2_TID_A_PC);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER,
+                   scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_THREAD,
+                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
+
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_INSTR, INSTR_2_TID_A_PC);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER, 0, TRACE_MARKER_TYPE_TIMESTAMP);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER, SYSCALL_BASE, TRACE_MARKER_TYPE_SYSCALL);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER, 0, TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL);
+
+        // Injected syscall sequence after the syscall instr in TID_A.
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER, SYSCALL_BASE,
+                   TRACE_MARKER_TYPE_SYSCALL_TRACE_START);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_INSTR, SYSCALL_PC_START);
+
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_INSTR_INDIRECT_JUMP, SYSCALL_PC_START + 1, NO_MARKER,
+                   // Even though there's a context switch on cpu1 after this sequence,
+                   // we set the target pc to the next one in TID_A, and not the
+                   // first one of the context switch sequence.
+                   INSTR_3_TID_A_PC);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER, SYSCALL_BASE, TRACE_MARKER_TYPE_SYSCALL_TRACE_END);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER, 0, TRACE_MARKER_TYPE_TIMESTAMP);
+        // We just hit a blocking syscall in A but there is nothing else to run.
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_IDLE);
+        // Finish off C on cpu 0.  This hits a quantum end but there's no one else.
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_INSTR);
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_INSTR);
+        check_next(sched_cpu0, cpu0, time, scheduler_t::STATUS_OK, TID_C,
+                   TRACE_TYPE_THREAD_EXIT);
+        // Both cpus wait until A is unblocked.
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_IDLE);
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_IDLE);
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_IDLE);
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_IDLE);
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_IDLE);
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_IDLE);
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_IDLE);
+
+        // Switch sequence immediately after the syscall sequence.
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER,
+                   // Counts as a process switch because of the idles.
+                   scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_PROCESS,
+                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_INSTR, PROCESS_SWITCH_PC_START);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   // Ensure indirect_branch_target is correctly set to the 3rd instr
+                   // in TID_A.
+                   TRACE_TYPE_INSTR_INDIRECT_JUMP, PROCESS_SWITCH_PC_START + 1, NO_MARKER,
+                   INSTR_3_TID_A_PC);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_MARKER,
+                   scheduler_tmpl_t<memref_t, reader_t>::switch_type_t::SWITCH_PROCESS,
+                   TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
+
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_INSTR, INSTR_3_TID_A_PC);
+        check_next(sched_cpu1, cpu1, time, scheduler_t::STATUS_OK, TID_A,
+                   TRACE_TYPE_THREAD_EXIT);
+        check_next(sched_cpu1, cpu1, ++time, scheduler_t::STATUS_EOF);
+        check_next(sched_cpu0, cpu0, ++time, scheduler_t::STATUS_EOF);
+        if (scheduler.write_recorded_schedule() != scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        std::cerr << "sched_cpu0: " << sched_cpu0 << "\n";
+        std::cerr << "sched_cpu1: " << sched_cpu1 << "\n";
+        assert(sched_cpu0 == "..AcCCc..CCC___");
+        assert(sched_cpu1 == "..BBBcAAcA...sAAs._____cAAcA");
+    }
+    {
+        replay_file_checker_t checker;
+        zipfile_istream_t infile(record_fname);
+        std::string res = checker.check(&infile);
+        if (!res.empty())
+            std::cerr << "replay file checker failed: " << res;
+        assert(res.empty());
+    }
+    {
+        // Replay.
+        std::vector<scheduler_t::input_reader_t> readers;
+        for (int i = 0; i < NUM_INPUTS; ++i) {
+            readers.emplace_back(
+                std::unique_ptr<test_util::mock_reader_t>(
+                    new test_util::mock_reader_t(refs[i])),
+                std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
+                TID_BASE + i);
+        }
+        scheduler_t scheduler;
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        sched_inputs.emplace_back(std::move(readers));
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_AS_PREVIOUSLY,
+                                                   scheduler_t::DEPENDENCY_IGNORE,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/4);
+        zipfile_istream_t infile(record_fname);
+        sched_ops.schedule_replay_istream = &infile;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        std::vector<std::string> sched_as_string =
+            run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_A);
+        for (int i = 0; i < NUM_OUTPUTS; i++) {
+            std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+        }
+        // For replay the scheduler has to use wall-clock instead of passed-in time,
+        // so the idle portions at the end here can have variable idle and wait
+        // record counts.  We thus just check the start.
+        // Same as the above but without injected kernel.
+        assert(sched_as_string[0].substr(0, 10) == "..A..CCC._");
+        assert(sched_as_string[1].substr(0, 12) == "..BBB.A...._");
+    }
+#endif
+}
+
+static void
 test_synthetic_with_timestamps()
 {
     std::cerr << "\n----------------\nTesting synthetic with timestamps\n";
@@ -2802,13 +3391,18 @@ static bool
 check_ref(std::vector<memref_t> &refs, int &idx, memref_tid_t expected_tid,
           trace_type_t expected_type,
           trace_marker_type_t expected_marker = TRACE_MARKER_TYPE_RESERVED_END,
-          uintptr_t expected_marker_or_branch_target_value = 0)
+          uintptr_t expected_marker_or_branch_target_value = 0, uint64_t pc = 0)
 {
     if (expected_tid != refs[idx].instr.tid || expected_type != refs[idx].instr.type) {
         std::cerr << "Record " << idx << " has tid " << refs[idx].instr.tid
                   << " and type " << refs[idx].instr.type << " != expected tid "
                   << expected_tid << " and expected type " << expected_type << "\n";
         return false;
+    }
+
+    if (type_is_instr(expected_type) && pc != 0 && refs[idx].instr.addr != pc) {
+        std::cerr << "Record " << idx << " has instr pc " << std::hex
+                  << refs[idx].instr.addr << " but expected " << pc << std::dec << "\n";
     }
     if (type_is_instr_branch(expected_type) &&
         !type_is_instr_direct_branch(expected_type) &&
@@ -6451,6 +7045,10 @@ run_lockstep_simulation_for_kernel_seq(scheduler_t &scheduler, int num_outputs,
     std::vector<bool> in_syscall(num_outputs, false);
     std::vector<uint64> prev_in_ord(num_outputs, 0);
     std::vector<uint64> prev_out_ord(num_outputs, 0);
+    std::vector<uint64_t> last_next_trace_pc(num_outputs, 0);
+    for (int i = 0; i < num_outputs; ++i) {
+        last_next_trace_pc[i] = outputs[i]->get_next_trace_pc();
+    }
     while (num_eof < num_outputs) {
         for (int i = 0; i < num_outputs; i++) {
             if (eof[i])
@@ -6473,6 +7071,30 @@ run_lockstep_simulation_for_kernel_seq(scheduler_t &scheduler, int num_outputs,
                 continue;
             }
             assert(status == scheduler_t::STATUS_OK);
+
+            // Tests for get_next_trace_pc().
+            uint64_t pc;
+            if (
+                // We expect the returned next trace pc to change when the decision to
+                // inject a syscall or switch trace is made.
+                // XXX: Could we avoid this and do some read-ahead so we can provide the
+                // actual next pc when returning the last instr? Perhaps doable for
+                // syscalls but not so easy for context switches as that would mean
+                // preponing the context switch decision.
+                (memref.marker.type == TRACE_TYPE_MARKER &&
+                 (memref.marker.marker_type == TRACE_MARKER_TYPE_CONTEXT_SWITCH_START ||
+                  memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL)) ||
+                // If we're not doing switch injection, then we'd see an abrupt change
+                // when the input switches.
+                (for_syscall_seq && prev_tid[i] != memref.instr.tid)) {
+                last_next_trace_pc[i] = outputs[i]->get_next_trace_pc();
+            } else if (scheduler_impl_t::record_type_has_pc(memref, pc)) {
+                assert(last_next_trace_pc[i] == pc);
+                last_next_trace_pc[i] = outputs[i]->get_next_trace_pc();
+            } else {
+                assert(last_next_trace_pc[i] == outputs[i]->get_next_trace_pc());
+            }
+
             // Ensure stream API and the trace records are consistent.
             assert(outputs[i]->get_input_interface()->get_tid() == IDLE_THREAD_ID ||
                    outputs[i]->get_input_interface()->get_tid() ==
@@ -6481,7 +7103,7 @@ run_lockstep_simulation_for_kernel_seq(scheduler_t &scheduler, int num_outputs,
                    outputs[i]->get_input_interface()->get_workload_id() ==
                        workload_from_memref_tid(memref.instr.tid));
             refs[i].push_back(memref);
-            if (tid_from_memref_tid(memref.instr.tid) != prev_tid[i]) {
+            if (memref.instr.tid != prev_tid[i]) {
                 if (!sched_as_string[i].empty())
                     sched_as_string[i] += ',';
                 sched_as_string[i] += 'A' +
@@ -6522,6 +7144,7 @@ run_lockstep_simulation_for_kernel_seq(scheduler_t &scheduler, int num_outputs,
                 assert(outputs[i]->is_record_kernel() || is_trace_end);
                 // Test that dynamically injected syscall code doesn't count toward
                 // input ordinals, but does toward output ordinals.
+
                 assert(outputs[i]->get_input_interface()->get_record_ordinal() ==
                            prev_in_ord[i] ||
                        // We readahead by one record to decide when to inject the
@@ -6529,8 +7152,12 @@ run_lockstep_simulation_for_kernel_seq(scheduler_t &scheduler, int num_outputs,
                        // be advanced by one at trace start.
                        is_trace_start);
                 assert(outputs[i]->get_record_ordinal() > prev_out_ord[i]);
-            } else
+            } else {
                 assert(!outputs[i]->is_record_synthetic());
+            }
+            assert(outputs[i]->get_tid() == tid_from_memref_tid(memref.instr.tid) &&
+                   outputs[i]->get_input_workload_ordinal() ==
+                       workload_from_memref_tid(memref.instr.tid));
             if (type_is_instr(memref.instr.type))
                 sched_as_string[i] += 'i';
             else if (memref.marker.type == TRACE_TYPE_MARKER) {
@@ -6574,10 +7201,10 @@ run_lockstep_simulation_for_kernel_seq(scheduler_t &scheduler, int num_outputs,
                     assert(prev_tid[i] != tid_from_memref_tid(memref.instr.tid));
                 } else {
                     assert(for_syscall_seq || prev_tid[i] == INVALID_THREAD_ID ||
-                           prev_tid[i] == tid_from_memref_tid(memref.instr.tid));
+                           prev_tid[i] == memref.instr.tid);
                 }
             }
-            prev_tid[i] = tid_from_memref_tid(memref.instr.tid);
+            prev_tid[i] = memref.instr.tid;
             prev_in_ord[i] = outputs[i]->get_input_interface()->get_record_ordinal();
             prev_out_ord[i] = outputs[i]->get_record_ordinal();
         }
@@ -6589,43 +7216,7 @@ static void
 test_kernel_switch_sequences()
 {
     std::cerr << "\n----------------\nTesting kernel switch sequences\n";
-    static constexpr memref_tid_t TID_IN_SWITCHES = 1;
-    static constexpr addr_t PROCESS_SWITCH_PC_START = 0xfeed101;
-    static constexpr addr_t THREAD_SWITCH_PC_START = 0xcafe101;
-    static constexpr uint64_t PROCESS_SWITCH_TIMESTAMP = 12345678;
-    static constexpr uint64_t THREAD_SWITCH_TIMESTAMP = 87654321;
-    std::vector<trace_entry_t> switch_sequence = {
-        /* clang-format off */
-        test_util::make_header(TRACE_ENTRY_VERSION),
-        test_util::make_thread(TID_IN_SWITCHES),
-        test_util::make_pid(TID_IN_SWITCHES),
-        test_util::make_version(TRACE_ENTRY_VERSION),
-        test_util::make_timestamp(PROCESS_SWITCH_TIMESTAMP),
-        test_util::make_marker(
-            TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, scheduler_t::SWITCH_PROCESS),
-        test_util::make_instr(PROCESS_SWITCH_PC_START),
-        test_util::make_instr(PROCESS_SWITCH_PC_START + 1),
-        test_util::make_marker(
-            TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, scheduler_t::SWITCH_PROCESS),
-        test_util::make_exit(TID_IN_SWITCHES),
-        test_util::make_footer(),
-        // Test a complete trace after the first one, which is how we plan to store
-        // these in an archive file.
-        test_util::make_header(TRACE_ENTRY_VERSION),
-        test_util::make_thread(TID_IN_SWITCHES),
-        test_util::make_pid(TID_IN_SWITCHES),
-        test_util::make_version(TRACE_ENTRY_VERSION),
-        test_util::make_timestamp(THREAD_SWITCH_TIMESTAMP),
-        test_util::make_marker(
-            TRACE_MARKER_TYPE_CONTEXT_SWITCH_START, scheduler_t::SWITCH_THREAD),
-        test_util::make_instr(THREAD_SWITCH_PC_START),
-        test_util::make_instr(THREAD_SWITCH_PC_START+1),
-        test_util::make_marker(
-            TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, scheduler_t::SWITCH_THREAD),
-        test_util::make_exit(TID_IN_SWITCHES),
-        test_util::make_footer(),
-        /* clang-format on */
-    };
+    std::vector<trace_entry_t> switch_sequence = get_mock_switch_sequence();
     static constexpr int NUM_WORKLOADS = 3;
     static constexpr int NUM_INPUTS_PER_WORKLOAD = 3;
     static constexpr int NUM_OUTPUTS = 2;
@@ -6633,6 +7224,9 @@ test_kernel_switch_sequences()
     static constexpr int INSTR_QUANTUM = 3;
     static constexpr uint64_t TIMESTAMP = 44226688;
     static constexpr memref_tid_t TID_BASE = 100;
+    static constexpr uint64_t THREAD_3_INSTR_1_PC = 10242;
+    static constexpr uint64_t THREAD_5_INSTR_1_PC = 10442;
+    static constexpr uint64_t THREAD_7_INSTR_1_PC = 10642;
     std::vector<scheduler_t::input_workload_t> sched_inputs;
     std::vector<record_scheduler_t::input_workload_t> sched_record_inputs;
 
@@ -6649,7 +7243,8 @@ test_kernel_switch_sequences()
             inputs.push_back(test_util::make_version(TRACE_ENTRY_VERSION));
             inputs.push_back(test_util::make_timestamp(TIMESTAMP));
             for (int instr_idx = 0; instr_idx < NUM_INSTRS; instr_idx++) {
-                inputs.push_back(test_util::make_instr(42 + instr_idx * 4));
+                inputs.push_back(test_util::make_instr(
+                    static_cast<addr_t>(tid * 100 + 42 + instr_idx * 4)));
             }
             inputs.push_back(test_util::make_exit(tid));
 
@@ -6717,7 +7312,10 @@ test_kernel_switch_sequences()
                       TRACE_MARKER_TYPE_CONTEXT_SWITCH_START,
                       scheduler_t::SWITCH_THREAD) &&
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
-            check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
+            check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR_INDIRECT_JUMP,
+                      TRACE_MARKER_TYPE_RESERVED_END,
+                      // Points to the 1st instruction in thread 3.
+                      static_cast<uintptr_t>(THREAD_3_INSTR_1_PC)) &&
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_CONTEXT_SWITCH_END, scheduler_t::SWITCH_THREAD) &&
             // We now see the headers for this thread.
@@ -6726,7 +7324,8 @@ test_kernel_switch_sequences()
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
             // The 3-instr quantum should not count the 2 switch instrs.
-            check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
+            check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR,
+                      TRACE_MARKER_TYPE_RESERVED_END, 0, THREAD_3_INSTR_1_PC) &&
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
             // Process switch.
@@ -6734,7 +7333,10 @@ test_kernel_switch_sequences()
                       TRACE_MARKER_TYPE_CONTEXT_SWITCH_START,
                       scheduler_t::SWITCH_PROCESS) &&
             check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
-            check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
+            check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR_INDIRECT_JUMP,
+                      TRACE_MARKER_TYPE_RESERVED_END,
+                      // Points to the 1th instr in thread 5.
+                      static_cast<uintptr_t>(THREAD_5_INSTR_1_PC)) &&
             check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_CONTEXT_SWITCH_END,
                       scheduler_t::SWITCH_PROCESS) &&
@@ -6744,7 +7346,8 @@ test_kernel_switch_sequences()
             check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
             // The 3-instr quantum should not count the 2 switch instrs.
-            check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
+            check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR,
+                      TRACE_MARKER_TYPE_RESERVED_END, 0, THREAD_5_INSTR_1_PC) &&
             check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR) &&
             check_ref(refs[0], idx, workload1_tid1_final, TRACE_TYPE_INSTR);
         assert(res);
@@ -6818,7 +7421,10 @@ test_kernel_switch_sequences()
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 1,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
-        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER,
+                   THREAD_3_INSTR_1_PC, TRACE_MARKER_TYPE_BRANCH_TARGET);
+        check_next(stream0, record_scheduler_t::STATUS_OK,
+                   TRACE_TYPE_INSTR_INDIRECT_JUMP);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 1,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
 
@@ -6832,7 +7438,8 @@ test_kernel_switch_sequences()
                    TRACE_MARKER_TYPE_VERSION);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 0,
                    TRACE_MARKER_TYPE_TIMESTAMP);
-        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR,
+                   THREAD_3_INSTR_1_PC);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
         assert(stream0->get_instruction_ordinal() == 8);
@@ -6847,7 +7454,10 @@ test_kernel_switch_sequences()
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 2,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
-        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER,
+                   THREAD_5_INSTR_1_PC, TRACE_MARKER_TYPE_BRANCH_TARGET);
+        check_next(stream0, record_scheduler_t::STATUS_OK,
+                   TRACE_TYPE_INSTR_INDIRECT_JUMP);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 2,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
         // cpu0 at TID_BASE+4.
@@ -6862,7 +7472,8 @@ test_kernel_switch_sequences()
                    TRACE_MARKER_TYPE_VERSION);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 0,
                    TRACE_MARKER_TYPE_TIMESTAMP);
-        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR,
+                   THREAD_5_INSTR_1_PC);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
         assert(stream0->get_instruction_ordinal() == 13);
@@ -6878,7 +7489,10 @@ test_kernel_switch_sequences()
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 2,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_START);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
-        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER,
+                   THREAD_7_INSTR_1_PC, TRACE_MARKER_TYPE_BRANCH_TARGET);
+        check_next(stream0, record_scheduler_t::STATUS_OK,
+                   TRACE_TYPE_INSTR_INDIRECT_JUMP);
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 2,
                    TRACE_MARKER_TYPE_CONTEXT_SWITCH_END);
         // cpu0 at TID_BASE+6.
@@ -6889,9 +7503,16 @@ test_kernel_switch_sequences()
             static_cast<addr_t>((2ULL << MEMREF_ID_WORKLOAD_SHIFT) | (TID_BASE + 6)));
         check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_PID,
                    static_cast<addr_t>((2ULL << MEMREF_ID_WORKLOAD_SHIFT) | 1));
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 0,
+                   TRACE_MARKER_TYPE_VERSION);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_MARKER, 0,
+                   TRACE_MARKER_TYPE_TIMESTAMP);
+        check_next(stream0, record_scheduler_t::STATUS_OK, TRACE_TYPE_INSTR,
+                   THREAD_7_INSTR_1_PC);
     }
-
     {
+        static constexpr memref_tid_t TID_IN_SWITCHES = 1;
+        constexpr addr_t PROCESS_SWITCH_PC_START = 0xfeed101;
         // Test a bad input sequence.
         std::vector<trace_entry_t> bad_switch_sequence = {
             /* clang-format off */
@@ -6947,40 +7568,14 @@ static void
 test_kernel_syscall_sequences()
 {
     std::cerr << "\n----------------\nTesting kernel syscall sequences\n";
-    static constexpr memref_tid_t TID_IN_SYSCALLS = 1;
     static constexpr int SYSCALL_BASE = 42;
-    static constexpr addr_t SYSCALL_PC_START = 0xfeed101;
     static constexpr int NUM_OUTPUTS = 2;
     static constexpr memref_tid_t TID_BASE = 100;
     static constexpr offline_file_type_t FILE_TYPE =
         offline_file_type_t::OFFLINE_FILE_TYPE_SYSCALL_NUMBERS;
     {
-        std::vector<trace_entry_t> syscall_sequence = {
-            /* clang-format off */
-            test_util::make_header(TRACE_ENTRY_VERSION),
-            test_util::make_thread(TID_IN_SYSCALLS),
-            test_util::make_pid(TID_IN_SYSCALLS),
-            test_util::make_version(TRACE_ENTRY_VERSION),
-            test_util::make_timestamp(0),
-            test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSCALL_BASE),
-            test_util::make_instr(SYSCALL_PC_START),
-            test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, 0),
-            test_util::make_instr(SYSCALL_PC_START + 1, TRACE_TYPE_INSTR_INDIRECT_JUMP),
-            test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSCALL_BASE),
-            // XXX: Currently all syscall traces are concatenated. We may change
-            // this to use an archive file instead.
-            test_util::make_marker(
-                TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSCALL_BASE + 1),
-            test_util::make_instr(SYSCALL_PC_START + 10),
-            test_util::make_instr(SYSCALL_PC_START + 11),
-            test_util::make_marker(TRACE_MARKER_TYPE_BRANCH_TARGET, 0),
-            test_util::make_instr(SYSCALL_PC_START + 12, TRACE_TYPE_INSTR_INDIRECT_JUMP),
-            test_util::make_marker(
-                TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSCALL_BASE + 1),
-            test_util::make_exit(TID_IN_SYSCALLS),
-            test_util::make_footer(),
-            /* clang-format on */
-        };
+        std::vector<trace_entry_t> syscall_sequence =
+            get_mock_syscall_sequence(SYSCALL_BASE);
         auto syscall_reader = std::unique_ptr<test_util::mock_reader_t>(
             new test_util::mock_reader_t(syscall_sequence));
         auto syscall_reader_end =
@@ -6989,6 +7584,10 @@ test_kernel_syscall_sequences()
         static constexpr int NUM_INSTRS = 9;
         static constexpr int INSTR_QUANTUM = 3;
         static constexpr uint64_t TIMESTAMP = 44226688;
+        static constexpr uint64_t SIGNAL_INT_PC = 0xdecafbad;
+        static constexpr uint64_t THREAD_1_INSTR_2_PC = 42 * TID_BASE + 1 * 4;
+        static constexpr uint64_t THREAD_1_INSTR_4_PC = 42 * TID_BASE + 3 * 4;
+        static constexpr uint64_t THREAD_3_INSTR_2_PC = 42 * (TID_BASE + 2) + 1 * 4;
         std::vector<scheduler_t::input_workload_t> sched_inputs;
         std::vector<scheduler_t::input_reader_t> readers;
         for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
@@ -7032,8 +7631,15 @@ test_kernel_syscall_sequences()
                         if (input_idx == 0) {
                             // First syscall on first input was interrupted by a signal,
                             // so no post-syscall event.
+                            // Generally the signal interruption pc in kernel_event is
+                            // the fallthrough of the prior instr and the next instr is
+                            // at the signal handler which may be a further away pc. But
+                            // we keep setup simple and pretend the signal interruption
+                            // pc is SIGNAL_INT_PC. We only want to ensure this is
+                            // the PC that shows up as the branch_target at the
+                            // syscall-trace-final indirect branch.
                             inputs.push_back(test_util::make_marker(
-                                TRACE_MARKER_TYPE_KERNEL_EVENT, /*value=*/1));
+                                TRACE_MARKER_TYPE_KERNEL_EVENT, SIGNAL_INT_PC));
                             inputs.push_back(test_util::make_marker(
                                 TRACE_MARKER_TYPE_KERNEL_XFER, /*value=*/1));
                             add_post_timestamp = false;
@@ -7127,13 +7733,16 @@ test_kernel_syscall_sequences()
                       TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSCALL_BASE) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR_INDIRECT_JUMP,
-                      TRACE_MARKER_TYPE_RESERVED_END, 42 * TID_BASE + 1 * 4) &&
+                      // As this syscall was interrupted by the signal, the return point
+                      // after the syscall is the interruption pc. The kernel_event marker
+                      // coming up next shows the transfer to the signal handler.
+                      TRACE_MARKER_TYPE_RESERVED_END, SIGNAL_INT_PC) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSCALL_BASE) &&
 
             // Signal interruption on first thread.
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER,
-                      TRACE_MARKER_TYPE_KERNEL_EVENT, 1) &&
+                      TRACE_MARKER_TYPE_KERNEL_EVENT, SIGNAL_INT_PC) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_KERNEL_XFER, 1) &&
 
@@ -7159,12 +7768,17 @@ test_kernel_syscall_sequences()
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_FUNC_ARG, 10) &&
 
-            // Syscall_1 trace on second thread.
+            // Syscall_1 trace on third thread.
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_SYSCALL_TRACE_START, SYSCALL_BASE) &&
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR) &&
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR_INDIRECT_JUMP,
-                      TRACE_MARKER_TYPE_RESERVED_END, 42 * (TID_BASE + 2) + 1 * 4) &&
+                      TRACE_MARKER_TYPE_RESERVED_END,
+                      // This points to the next instruction on this thread
+                      // itself, even though the output switches to a new input
+                      // after this.
+                      static_cast<uintptr_t>(THREAD_3_INSTR_2_PC)) &&
+
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSCALL_BASE) &&
 
@@ -7182,7 +7796,8 @@ test_kernel_syscall_sequences()
             check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
 
-            check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR) &&
+            check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR,
+                      TRACE_MARKER_TYPE_RESERVED_END, 0, THREAD_1_INSTR_2_PC) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
@@ -7194,16 +7809,19 @@ test_kernel_syscall_sequences()
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_INSTR_INDIRECT_JUMP,
-                      TRACE_MARKER_TYPE_RESERVED_END, 42 * TID_BASE + 3 * 4) &&
+                      TRACE_MARKER_TYPE_RESERVED_END, THREAD_1_INSTR_4_PC) &&
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER,
                       TRACE_MARKER_TYPE_SYSCALL_TRACE_END, SYSCALL_BASE + 1) &&
-
             // Post syscall timestamp.
             check_ref(refs[0], idx, TID_BASE, TRACE_TYPE_MARKER,
-                      TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP);
+                      TRACE_MARKER_TYPE_TIMESTAMP, TIMESTAMP) &&
+            check_ref(refs[0], idx, TID_BASE + 2, TRACE_TYPE_INSTR,
+                      TRACE_MARKER_TYPE_RESERVED_END, 0, THREAD_3_INSTR_2_PC);
         assert(res);
     }
     {
+        constexpr memref_tid_t TID_IN_SYSCALLS = 1;
+        constexpr addr_t SYSCALL_PC_START = 0xfeed101;
         // Test a bad input sequence.
         std::vector<trace_entry_t> bad_syscall_sequence = {
             /* clang-format off */
@@ -8370,9 +8988,15 @@ test_main(int argc, const char *argv[])
     assert(argc == 2);
     // Avoid races with lazy drdecode init (b/279350357).
     dr_standalone_init();
+    test_parallel_with_syscall_injection();
+    test_synthetic_time_quanta_with_kernel();
+    test_kernel_switch_sequences();
+    test_kernel_syscall_sequences();
+    return 0;
 
     test_serial();
     test_parallel();
+    test_parallel_with_syscall_injection();
     test_param_checks();
     test_regions();
     test_only_threads();
@@ -8380,6 +9004,7 @@ test_main(int argc, const char *argv[])
     test_synthetic();
     test_synthetic_with_syscall_seq();
     test_synthetic_time_quanta();
+    test_synthetic_time_quanta_with_kernel();
     test_synthetic_with_timestamps();
     test_synthetic_with_priorities();
     test_synthetic_with_bindings();


### PR DESCRIPTION
Adds logic in the drmemtrace scheduler to set the branch target of syscall- and switch-final indirect branch instructions (e.g., eret on AArch64) to the next instruction in the thread's trace.

- The syscall-trace-final indirect branch now points to the next instruction as seen on the thread shard, which may be the syscall-fallthrough or the syscall instruction again for auto-restart syscalls.
- The context-switch-trace-final indirect branch points to the next instruction of the new input.
- When there is a syscall trace immediately followed by a switch trace, the syscall-final indirect branch still points to next instruction as seen on the thread shard.

When reading the kernel trace templates, we discover and record the first instruction of the template, which we present as the next trace pc just prior to the trace's injection.

Augments the get_next_trace_pc() implementation to return the next pc in the injected trace, when it is queried in the middle of dynamic injection. Enables invariant checks on the get_next_trace_pc() output during the dynamically injected part of the trace.

Adds unit tests for:
- analyzer parallel mode with syscall injection
- scheduler syscall+switch injection that has some idles
- extends existing syscall and switch scheduler tests

Issue: #7496