### PR TITLE
i#7598 attach gap: Add drmgr pre-detach event

### DIFF
--- a/api/docs/release.dox
+++ b/api/docs/release.dox
@@ -199,6 +199,11 @@ compatibility changes:
    drmgr_unregister_post_attach_event_user_data(), which are required to be used
    instead of dr_register_post_attach_event() when using drmgr and provide
    priorities and user data to the post-attach event.
+ - Added drmgr_register_pre_detach_event(), drmgr_unregister_pre_detach_event(),
+   drmgr_register_pre_detach_event_user_data(), and
+   drmgr_unregister_pre_detach_event_user_data(), which are required to be used
+   instead of dr_register_pre_detach_event() when using drmgr and provide
+   priorities and user data to the pre-detach event.
 
 Further non-compatibility-affecting changes include:
  - Changed the types of `block_size`, `total_size`, `num_blocks`, to `int64_t`

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2086,6 +2086,7 @@ event_exit(void)
     }
     drmgr_unregister_exit_event(event_exit);
     drmgr_unregister_post_attach_event(event_post_attach);
+    drmgr_unregister_pre_detach_event(event_pre_detach);
 
     /* Clear callbacks and globals to support re-attach when linked statically. */
     file_ops_func = file_ops_func_t();
@@ -2545,7 +2546,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
         FATAL("Failed to register post-attach event.\n");
     attached_midway = dr_attached_midrun();
 
-    dr_register_pre_detach_event(event_pre_detach);
+    drmgr_register_pre_detach_event(event_pre_detach);
     dr_register_nudge_event(event_nudge, id);
 
     /* We need our thread exit event to run *before* drmodtrack's as we may

--- a/ext/drmgr/drmgr.c
+++ b/ext/drmgr/drmgr.c
@@ -55,6 +55,8 @@
 #undef dr_unregister_exit_event
 #undef dr_register_post_attach_event
 #undef dr_unregister_post_attach_event
+#undef dr_register_pre_detach_event
+#undef dr_unregister_pre_detach_event
 #undef dr_register_thread_init_event
 #undef dr_unregister_thread_init_event
 #undef dr_register_thread_exit_event
@@ -144,6 +146,10 @@ typedef struct _generic_event_entry_t {
             void (*cb_no_user_data)();
             void (*cb_user_data)(void *);
         } post_attach_cb;
+        union {
+            void (*cb_no_user_data)();
+            void (*cb_user_data)(void *);
+        } pre_detach_cb;
         union {
             void (*cb_no_user_data)(void *);
             void (*cb_user_data)(void *, void *);
@@ -349,6 +355,8 @@ static void *exit_event_lock;
 
 static cb_list_t cb_list_post_attach;
 static void *post_attach_event_lock;
+static cb_list_t cb_list_pre_detach;
+static void *pre_detach_event_lock;
 
 /* Thread event cbs and rwlock */
 static cb_list_t cb_list_thread_init;
@@ -413,6 +421,9 @@ drmgr_exit_event(void);
 
 static void
 drmgr_post_attach_event(void);
+
+static void
+drmgr_pre_detach_event(void);
 
 static void
 drmgr_thread_init_event(void *drcontext);
@@ -501,6 +512,7 @@ drmgr_init(void)
     bb_cb_lock = dr_rwlock_create();
     exit_event_lock = dr_rwlock_create();
     post_attach_event_lock = dr_rwlock_create();
+    pre_detach_event_lock = dr_rwlock_create();
     thread_event_lock = dr_rwlock_create();
     tls_lock = dr_mutex_create();
     cls_event_lock = dr_rwlock_create();
@@ -523,6 +535,7 @@ drmgr_init(void)
 
     dr_register_exit_event(drmgr_exit_event);
     dr_register_post_attach_event(drmgr_post_attach_event);
+    dr_register_pre_detach_event(drmgr_pre_detach_event);
 
     dr_register_thread_init_event(drmgr_thread_init_event);
     dr_register_thread_exit_event(drmgr_thread_exit_event);
@@ -567,6 +580,7 @@ our_exit_event(void)
     drmgr_event_exit();
 
     dr_unregister_post_attach_event(drmgr_post_attach_event);
+    dr_unregister_pre_detach_event(drmgr_pre_detach_event);
 
     dr_unregister_thread_init_event(drmgr_thread_init_event);
     dr_unregister_thread_exit_event(drmgr_thread_exit_event);
@@ -614,6 +628,7 @@ our_exit_event(void)
     dr_rwlock_destroy(thread_event_lock);
     dr_rwlock_destroy(exit_event_lock);
     dr_rwlock_destroy(post_attach_event_lock);
+    dr_rwlock_destroy(pre_detach_event_lock);
     dr_rwlock_destroy(bb_cb_lock);
 
     dr_mutex_destroy(note_lock);
@@ -1955,6 +1970,7 @@ drmgr_event_init(void)
 {
     cblist_init(&cb_list_exit, sizeof(generic_event_entry_t));
     cblist_init(&cb_list_post_attach, sizeof(generic_event_entry_t));
+    cblist_init(&cb_list_pre_detach, sizeof(generic_event_entry_t));
     cblist_init(&cb_list_thread_init, sizeof(generic_event_entry_t));
     cblist_init(&cb_list_thread_exit, sizeof(generic_event_entry_t));
     cblist_init(&cblist_cls_init, sizeof(generic_event_entry_t));
@@ -1986,6 +2002,7 @@ drmgr_event_exit(void)
      */
     cblist_delete(&cb_list_exit);
     cblist_delete(&cb_list_post_attach);
+    cblist_delete(&cb_list_pre_detach);
     cblist_delete(&cb_list_thread_init);
     cblist_delete(&cb_list_thread_exit);
     cblist_delete(&cblist_cls_init);
@@ -2125,6 +2142,65 @@ drmgr_post_attach_event(void)
             (*iter.cbs.generic[i].cb.post_attach_cb.cb_no_user_data)();
         else {
             (*iter.cbs.generic[i].cb.post_attach_cb.cb_user_data)(user_data);
+        }
+    }
+    cblist_delete_local(drcontext, &iter, BUFFER_SIZE_ELEMENTS(local));
+}
+
+DR_EXPORT
+bool
+drmgr_register_pre_detach_event(void (*func)(void))
+{
+    return drmgr_generic_event_add(&cb_list_pre_detach, pre_detach_event_lock, func, NULL,
+                                   false, NULL);
+}
+
+DR_EXPORT
+bool
+drmgr_register_pre_detach_event_user_data(void (*func)(void *user_data),
+                                          drmgr_priority_t *priority, void *user_data)
+{
+    return drmgr_generic_event_add(&cb_list_pre_detach, pre_detach_event_lock,
+                                   (void (*)(void))func, priority, true, user_data);
+}
+
+DR_EXPORT
+bool
+drmgr_unregister_pre_detach_event(void (*func)(void))
+{
+    return drmgr_generic_event_remove(&cb_list_pre_detach, pre_detach_event_lock,
+                                      (void (*)(void))func);
+}
+
+DR_EXPORT
+bool
+drmgr_unregister_pre_detach_event_user_data(void (*func)(void *user_data))
+{
+    return drmgr_generic_event_remove(&cb_list_pre_detach, pre_detach_event_lock,
+                                      (void (*)(void))func);
+}
+
+static void
+drmgr_pre_detach_event(void)
+{
+    generic_event_entry_t local[EVENTS_STACK_SZ];
+    cb_list_t iter;
+    uint i;
+    void *drcontext = GLOBAL_DCONTEXT;
+    dr_rwlock_read_lock(pre_detach_event_lock);
+    cblist_create_local(drcontext, &cb_list_pre_detach, &iter, (byte *)local,
+                        BUFFER_SIZE_ELEMENTS(local));
+    dr_rwlock_read_unlock(pre_detach_event_lock);
+
+    for (i = 0; i < iter.num_def; i++) {
+        if (!iter.cbs.generic[i].pri.valid)
+            continue;
+        bool is_using_user_data = iter.cbs.generic[i].is_using_user_data;
+        void *user_data = iter.cbs.generic[i].user_data;
+        if (is_using_user_data == false)
+            (*iter.cbs.generic[i].cb.pre_detach_cb.cb_no_user_data)();
+        else {
+            (*iter.cbs.generic[i].cb.pre_detach_cb.cb_user_data)(user_data);
         }
     }
     cblist_delete_local(drcontext, &iter, BUFFER_SIZE_ELEMENTS(local));

--- a/ext/drmgr/drmgr.h
+++ b/ext/drmgr/drmgr.h
@@ -1194,6 +1194,45 @@ drmgr_unregister_post_attach_event_user_data(void (*func)(void *user_data));
 
 DR_EXPORT
 /**
+ * Registers a callback function for the pre_detach event, which behaves
+ * just like the event registered by dr_register_pre_detach_event().
+ * \return whether successful.
+ */
+bool
+drmgr_register_pre_detach_event(void (*func)(void));
+
+DR_EXPORT
+/**
+ * Registers a callback function for the pre_detach event, which behaves
+ * just like the event registered by dr_register_pre_detach_event() but is
+ * ordered by \p priority. Allows for the passing of user data \p user_data
+ * which is available upon the execution of the callback.
+ * \return whether successful.
+ */
+bool
+drmgr_register_pre_detach_event_user_data(void (*func)(void *user_data),
+                                          drmgr_priority_t *priority, void *user_data);
+
+DR_EXPORT
+/**
+ * Unregister a callback function for the pre_detach event.
+ * \return true if unregistration is successful and false if it is not
+ * (e.g., \p func was not registered).
+ */
+bool
+drmgr_unregister_pre_detach_event(void (*func)(void));
+
+DR_EXPORT
+/**
+ * Unregister a callback function for the pre_detach event.
+ * \return true if unregistration is successful and false if it is not
+ * (e.g., \p func was not registered).
+ */
+bool
+drmgr_unregister_pre_detach_event_user_data(void (*func)(void *user_data));
+
+DR_EXPORT
+/**
  * Registers a callback function for the thread initialization event.
  * drmgr calls \p func whenever the application creates a new thread.
  * \return whether successful.


### PR DESCRIPTION
Adds drmgr mediation of the pre-detach event to provide a user-data version and priorities.

Adds testing in an existing test that uses drmgr and detach.

Updates the changelist compatibility section as this requires clients to switch from the base DR event.

Issue: #7598, #7604