### PR TITLE
i#7496 eret continuity: Fix uninit bool in scheduler

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -226,7 +226,7 @@ protected:
         // Records should be removed from the front of the queue using the
         // get_queued_record() helper which sets the related state automatically.
         std::deque<queued_record_t> queue;
-        bool cur_from_queue;
+        bool cur_from_queue = false;
         // Valid only if cur_from_queue is set.
         queued_record_t cur_queue_record;
 


### PR DESCRIPTION
Initializes scheduler_impl_tmpl_t::cur_from_queue to false. This was detected by ASAN.

The bool was uninitialized before the recent i#7496 changes as well, but it was detected by ASAN when a use was introduced in the memtrace_stream_t API implementation by the scheduler.

Issue: #7496