### PR TITLE
i#7504 scale time: Avoid scaling overflows

### DIFF
--- a/ext/drx/drx.h
+++ b/ext/drx/drx.h
@@ -597,8 +597,10 @@ typedef struct _drx_time_scale_stat_t {
     /**
      * Count of the instances that might need scaling.
      * For timers, this counts the initial value and the interval separately.
-     * If #count_failed and #count_nop are subtracted from this, the result
-     * is the count that were successfully scaled to a larger duration.
+     * This is incremented in addition to any of the other counts; if the sum
+     * of the other counts is subtracted from this value, the result is the count
+     * of instances that were were successfully scaled to a larger duration without
+     * further categorization.
      */
     ptr_int_t count_attempted;
     /**
@@ -613,6 +615,12 @@ typedef struct _drx_time_scale_stat_t {
      * Count of instances converted from zero to non-zero before scaling.
      */
     ptr_int_t count_zero_to_nonzero;
+    /**
+     * Count of the instances where scaling could not be completed as the
+     * time fields would have overflowed.  This indicates abnormal values used
+     * by the application which were so large scaling would not have mattered.
+     */
+    ptr_int_t count_time_too_large;
 } drx_time_scale_stat_t;
 
 /**

--- a/suite/tests/client-interface/drx_timeout_scale-test.cpp
+++ b/suite/tests/client-interface/drx_timeout_scale-test.cpp
@@ -52,6 +52,7 @@
 #include "../../core/unix/include/syscall.h"
 
 #include <assert.h>
+#include <limits.h>
 #include <linux/futex.h>
 #include <math.h>
 #include <pthread.h>
@@ -97,9 +98,38 @@ my_setenv(const char *var, const char *value)
     return setenv(var, value, 1 /*override*/) == 0;
 }
 
+static void
+test_overflow()
+{
+    // Test large timeout values that will overflow if scaled.
+    // We use a mismatched value to avoid actually waiting that long
+    // and ensure the scaling doesn't create an invalid timeout.
+    constexpr int FUTEX_VAL = 0xabcd;
+    int32_t mismatch_var = FUTEX_VAL + 1;
+
+    constexpr int MAX_TV_NSEC = 1000000000ULL;
+    struct timespec timeout;
+    timeout.tv_sec = IF_X64_ELSE(INT64_MAX, INT_MAX) / 10;
+    timeout.tv_nsec = MAX_TV_NSEC - 1;
+
+    // Test a too-large relative timeout.
+    int res = syscall(SYS_futex, &mismatch_var, FUTEX_WAIT, FUTEX_VAL, &timeout,
+                      /*uaddr2=*/nullptr, /*val3=*/0);
+    // A timeout overflow will return EINVAL so make sure we see EAGAIN (from
+    // the futex val not matching the target) instead.
+    assert(res != 0 && errno == EAGAIN);
+
+    // Test a too-large absolute timeout.
+    res = syscall(SYS_futex, &mismatch_var, FUTEX_WAIT_BITSET | FUTEX_CLOCK_REALTIME,
+                  FUTEX_VAL, &timeout, /*uaddr2=*/nullptr, FUTEX_BITSET_MATCH_ANY);
+    assert(res != 0 && errno == EAGAIN);
+}
+
 static int64_t
 perform_futexes()
 {
+    test_overflow();
+
     // We perform a futex that will always time out as our value never changes.
     int64_t futex_count = 0;
     constexpr int FUTEX_VAL = 0xabcd;
@@ -295,10 +325,23 @@ event_exit(void *user_data)
     assert(stats[cur_optype].count_attempted > 0);
     assert(stats[cur_optype].count_attempted >=
            stats[cur_optype].count_failed + stats[cur_optype].count_nop);
-    assert(stats[cur_optype].count_failed == 0);
+    if (cur_optype == DRX_SCALE_FUTEX) {
+        // We passed in too-large-to-scale values: 2 if scaling, 1 if not, for
+        // 64-bit; 1 and 0 for 32-bit..
+#ifdef X64
+        assert(stats[cur_optype].count_failed == 1 ||
+               stats[cur_optype].count_failed == 2);
+#else
+        assert(stats[cur_optype].count_failed == 1 ||
+               stats[cur_optype].count_failed == 0);
+#endif
+    } else {
+        assert(stats[cur_optype].count_failed == 0);
+    }
     // Either scale was 1 and everything is a nop, or if scaling then our 0-duration
     // futex should have become non-0.
-    assert(stats[cur_optype].count_nop == stats[cur_optype].count_attempted ||
+    assert(stats[cur_optype].count_nop ==
+               (stats[cur_optype].count_attempted - stats[cur_optype].count_failed) ||
            stats[cur_optype].count_nop == 0);
     if (cur_optype == DRX_SCALE_FUTEX) {
         assert(stats[cur_optype].count_zero_to_nonzero > 0);

--- a/suite/tests/client-interface/drx_timeout_scale-test.templatex
+++ b/suite/tests/client-interface/drx_timeout_scale-test.templatex
@@ -7,6 +7,7 @@ in dr_client_main.*
 .*Refusing to scale too-large time.*
 #ifdef X64
 .*Refusing to scale too-large absolute time.*
+.*Refusing to scale too-large absolute time.*
 #endif
 client done.*
 in dr_client_main.*

--- a/suite/tests/client-interface/drx_timeout_scale-test.templatex
+++ b/suite/tests/client-interface/drx_timeout_scale-test.templatex
@@ -1,7 +1,14 @@
 in dr_client_main.*
-.*
+#ifdef X64
+.*Refusing to scale too-large absolute time.*
+#endif
 client done.*
 in dr_client_main.*
-.*
+.*Refusing to scale too-large time.*
+#ifdef X64
+.*Refusing to scale too-large absolute time.*
+#endif
+client done.*
+in dr_client_main.*
 client done.*
 app done


### PR DESCRIPTION
Adds checks when scaling timeouts to prevent overflow.
Adds a new stat count_time_too_large to count such cases.

Adds test cases that fail without the new checks.

Further tested on an internal case where an app failed without this fix.

Issue: #7504