### PR TITLE
i#6685: Use IDLE_THREAD_ID for core_idle markers

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -142,7 +142,7 @@ analyzer_t::create_idle_marker()
     memref_t record = {}; // Zero the other fields.
     record.marker.type = TRACE_TYPE_MARKER;
     record.marker.marker_type = TRACE_MARKER_TYPE_CORE_IDLE;
-    record.marker.tid = INVALID_THREAD_ID;
+    record.marker.tid = IDLE_THREAD_ID;
     return record;
 }
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -297,7 +297,7 @@ typedef enum {
 } trace_type_t;
 
 /**
- * A separate sentinel for an idle core with no software thread.
+ * A thread id sentinel for an idle core with no software thread.
  */
 constexpr int IDLE_THREAD_ID = -1;
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -639,7 +639,9 @@ typedef enum {
      * is roughly the time where a regular record could have been read and passed
      * along.  This idle marker indicates that a core actually had no work to do,
      * as opposed to #TRACE_MARKER_TYPE_CORE_WAIT which is an artifact of an
-     * imposed re-created schedule.
+     * imposed re-created schedule.  When presented as a
+     * #dynamorio::drmemtrace::memref_t record, the tid field will be set to
+     * #dynamorio::drmemtrace::IDLE_THREAD_ID.
      */
     TRACE_MARKER_TYPE_CORE_IDLE,
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -296,6 +296,11 @@ typedef enum {
     // Update trace_type_names[] when adding here.
 } trace_type_t;
 
+/**
+ * A separate sentinel for an idle core with no software thread.
+ */
+constexpr int IDLE_THREAD_ID = -1;
+
 /** The sub-type for TRACE_TYPE_MARKER. */
 /* For offline traces, we are not able to place a marker accurately in the middle
  * of a block (except for kernel event markers which contain their interruption PC).

--- a/clients/drcachesim/common/utils.h
+++ b/clients/drcachesim/common/utils.h
@@ -59,10 +59,6 @@ namespace drmemtrace {
 #define INVALID_THREAD_ID 0
 // We avoid collisions with DR's INVALID_PROCESS_ID by using our own name.
 #define INVALID_PID -1
-// A separate sentinel for an idle core with no software thread.
-// XXX i#6703: Export this in scheduler.h as part of its API when we have
-// the scheduler insert synthetic headers.
-#define IDLE_THREAD_ID -1
 
 // XXX: perhaps we should use a C++-ish stream approach instead
 // This cannot be named ERROR as that conflicts with Windows headers.

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -193,7 +193,7 @@ Some of the more important markers are:
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_SYSCALL - This identifies a system call.  A timestamp is inserted in the trace before and after marker of this type.  This marker should be considered to be the actual system call invocation by the kernel, rather than the prior system call gateway instruction fetch record.  Thus, these timestamps provide the system call latency.
 
-- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE - This is inserted by the trace scheduler (see \ref sec_drcachesim_sched) when there is no work available on a core in core-sharded mode.  This is meant to simulate actual idle time on a core.
+- #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE - This is inserted by the trace scheduler (see \ref sec_drcachesim_sched) when there is no work available on a core in core-sharded mode.  This is meant to simulate actual idle time on a core.  When presented as part of a #dynamorio::drmemtrace::memref_t record, the scheduler sets the tid for the marker to #dynamorio::drmemtrace::IDLE_THREAD_ID.
 
 - #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_WAIT - This is inserted by the trace scheduler (see \ref sec_drcachesim_sched) during replay of a previously recorded schedule when one core gets too far ahead of another according to the recorded timestamps.  This is an artificial wait to keep the replay on track, as opposed to the natural idle time of #dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE.
 
@@ -1782,7 +1782,9 @@ parameters appropriately.
 \section sec_drcachesim_sched_idle Idle Time
 
 The dynamic scheduler inserts markers of type
-#dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE when there is no work available on a
+#dynamorio::drmemtrace::TRACE_MARKER_TYPE_CORE_IDLE (with the tid field set to
+#dynamorio::drmemtrace::IDLE_THREAD_ID when it is presented as a
+#dynamorio::drmemtrace::memref_t record) when there is no work available on a
 core, simulating actual idle time.  This can happen even when there are inputs
 potentially available as the scheduler simulates i/o by blocking inputs from executing
 for a period of time when they make blocking system calls.  This time is based on the

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -193,7 +193,7 @@ bool
 scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_has_tid(memref_t record,
                                                                memref_tid_t &tid)
 {
-    if (record.marker.tid == INVALID_THREAD_ID)
+    if (record.marker.tid == INVALID_THREAD_ID || record.marker.tid == IDLE_THREAD_ID)
         return false;
     tid = record.marker.tid;
     return true;

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -193,7 +193,7 @@ bool
 scheduler_impl_tmpl_t<memref_t, reader_t>::record_type_has_tid(memref_t record,
                                                                memref_tid_t &tid)
 {
-    if (record.marker.tid == INVALID_THREAD_ID || record.marker.tid == IDLE_THREAD_ID)
+    if (record.marker.tid == INVALID_THREAD_ID)
         return false;
     tid = record.marker.tid;
     return true;
@@ -3298,7 +3298,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::update_next_record(output_ordinal
     // on Mac with its 64-bit tid type.
     int64_t workload = get_workload_ordinal(output);
     memref_tid_t cur_tid;
-    if (record_type_has_tid(record, cur_tid) && workload > 0) {
+    if (record_type_has_tid(record, cur_tid) && cur_tid != IDLE_THREAD_ID &&
+        workload > 0) {
         memref_tid_t new_tid = (workload << MEMREF_ID_WORKLOAD_SHIFT) | cur_tid;
         record_type_set_tid(record, new_tid);
     }

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -875,6 +875,7 @@ protected:
     pick_next_input(output_ordinal_t output, uint64_t blocked_time);
 
     // If the given record has a thread id field, returns true and the value.
+    // This considers IDLE_THREAD_ID as a valid tid.
     bool
     record_type_has_tid(RecordType record, memref_tid_t &tid);
 

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -358,9 +358,9 @@ test_idle()
         {
             gen_instr(TID_B),
             gen_instr(TID_B),
-            gen_marker(TID_B, TRACE_MARKER_TYPE_CORE_IDLE, 0),
-            gen_marker(TID_B, TRACE_MARKER_TYPE_CORE_IDLE, 0),
-            gen_marker(TID_B, TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 0),
             // A switch from idle w/ no syscall is an involuntary switch.
             gen_instr(TID_B),
             gen_instr(TID_B),
@@ -368,14 +368,17 @@ test_idle()
             gen_exit(TID_B),
         },
         {
+            // This is a start-idle core.
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            // Switch to the first thread from the start-idle state.
             gen_instr(TID_C),
             // Involuntary switch.
             gen_instr(TID_A),
             // Involuntary switch.
             gen_instr(TID_C),
-            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_IDLE, 0),
-            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_IDLE, 0),
-            gen_marker(TID_C, TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 0),
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 0),
             // A switch from idle w/ no syscall is an involuntary switch.
             gen_instr(TID_C),
             gen_instr(TID_C),
@@ -394,7 +397,7 @@ test_idle()
     };
     auto result = run_schedule_stats(memrefs);
     assert(result.instrs == 13);
-    assert(result.total_switches == 6);
+    assert(result.total_switches == 7);
     assert(result.voluntary_switches == 1);
     assert(result.direct_switches == 0);
     assert(result.syscalls == 0);
@@ -402,7 +405,7 @@ test_idle()
     assert(result.direct_switch_requests == 0);
     assert(result.observed_migrations == 0);
     assert(result.waits == 3);
-    assert(result.idles == 6);
+    assert(result.idles == 7);
     assert(result.idle_microseconds >= 6);
     assert(result.idle_micros_at_last_instr > 0 &&
            result.idle_micros_at_last_instr <= result.idle_microseconds);

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -131,6 +131,7 @@ basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     counters_t *counters = &per_shard->counters[per_shard->counters.size() - 1];
     if (memref.instr.tid != INVALID_THREAD_ID &&
+        memref.instr.tid != IDLE_THREAD_ID &&
         memref.instr.tid != per_shard->last_tid_) {
         counters->unique_threads.insert(memref.instr.tid);
         per_shard->last_tid_ = memref.instr.tid;

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -130,8 +130,7 @@ basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     counters_t *counters = &per_shard->counters[per_shard->counters.size() - 1];
-    if (memref.instr.tid != INVALID_THREAD_ID &&
-        memref.instr.tid != IDLE_THREAD_ID &&
+    if (memref.instr.tid != INVALID_THREAD_ID && memref.instr.tid != IDLE_THREAD_ID &&
         memref.instr.tid != per_shard->last_tid_) {
         counters->unique_threads.insert(memref.instr.tid);
         per_shard->last_tid_ = memref.instr.tid;

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -339,7 +339,7 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         // scheduler_tmpl_t::stream_status_t::STATUS_IDLE), which are converted
         // to a TRACE_MARKER_TYPE_CORE_IDLE with tid set to IDLE_THREAD_ID,
         // in the same manner as above.
-        assert(memref.marker.tid == IDLE_THREAD_ID);
+        assert(memref.marker.tid == dynamorio::drmemtrace::IDLE_THREAD_ID);
         shard->cur_state = STATE_IDLE;
     } else
         shard->cur_state = STATE_CPU;
@@ -394,7 +394,7 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
     assert(tid != INVALID_THREAD_ID);
     if ((workload_id != prev_workload_id || tid != prev_tid) &&
         // Do not count the initial records of a start-idle core.
-        tid != IDLE_THREAD_ID) {
+        tid != dynamorio::drmemtrace::IDLE_THREAD_ID) {
         if (shard->in_syscall_trace) {
             shard->error =
                 "Found unexpected switch in the middle of a kernel syscall trace.";

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -327,13 +327,13 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         shard->cur_state = STATE_WAIT;
     else if (memref.marker.type == TRACE_TYPE_MARKER &&
              memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_IDLE) {
-        // For trace scheduling done online (during trace analysis), we expect
+        // When analyzing dynamically scheduled trace records, we expect
         // scheduler_tmpl_t::stream_status_t::STATUS_IDLE to be converted to
         // a TRACE_MARKER_TYPE_CORE_IDLE with tid set to IDLE_THREAD_ID.
-        // For already-scheduled traces (aka core-sharded-on-disk traces), the
-        // TRACE_MARKER_TYPE_CORE_IDLE on disk may not have a preceding
-        // tid marker set to IDLE_THREAD_ID (therefore may be associated with
-        // the tid of the prior input as far as the on-disk records are
+        // When analyzing already-scheduled traces (aka core-sharded-on-disk
+        // traces), the TRACE_MARKER_TYPE_CORE_IDLE on disk may not have a
+        // preceding tid marker set to IDLE_THREAD_ID (therefore may be associated
+        // with the tid of the prior input as far as the on-disk records are
         // concerned). But we have scheduler logic that converts such on-disk
         // TRACE_MARKER_TYPE_CORE_IDLE into the scheduler idle status (that is,
         // scheduler_tmpl_t::stream_status_t::STATUS_IDLE), which are converted

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -391,7 +391,7 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         (TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard->filetype) || input_id < 0)
         ? tid
         : input_id;
-    assert (tid != INVALID_THREAD_ID);
+    assert(tid != INVALID_THREAD_ID);
     if ((workload_id != prev_workload_id || tid != prev_tid) &&
         // Do not count the initial records of a start-idle core.
         tid != IDLE_THREAD_ID) {


### PR DESCRIPTION
Changes analyzer_t::create_idle_marker() to use IDLE_THREAD_ID when creating marker records of type TRACE_MARKER_TYPE_CORE_IDLE. IDLE_THREAD_ID is the proper sentinel to be used for such records.

Extends an existing unit test to verify that transitions from start-idle to an input are counted as a switch.

Modifies test setup to also use the correct IDLE_THREAD_ID sentinel for core_idle markers.

Documents that record_type_has_tid considers IDLE_THREAD_ID as a valid thread id; it needs to because when opening a new core-sharded-on-disk file for a core that started idle, we cannot keep reading ahead until we find an actual tid.

Issue: #6685