### PR TITLE
i#7643: Simplify icache sync on AArch64: act on IC IVAU immediately.

### DIFF
--- a/core/arch/aarch64/aarch64.asm
+++ b/core/arch/aarch64/aarch64.asm
@@ -629,7 +629,6 @@ GLOBAL_LABEL(tlsdesc_resolver:)
  * IC IVAU, Xt. When we enter here:
  *
  * X0 contains the pointer to spill_state_t.
- * X30 contains the return address in the fragment cache (no longer required).
  * TLS_REG0_SLOT contains app's X0.
  * TLS_REG1_SLOT contains app's X30.
  * TLS_REG2_SLOT contains the argument of "IC IVAU, Xt".

--- a/core/arch/aarch64/asm_offsetsx.h
+++ b/core/arch/aarch64/asm_offsetsx.h
@@ -49,19 +49,6 @@ OFFSET(dcontext_t, dstack, 0x9f8)
 OFFSET(dcontext_t, is_exiting, 0xa00)
 #define dcontext_t_OFFSET_is_exiting 0xa00
 
-OFFSET(icache_op_struct_t, flag, 0)
-#define icache_op_struct_t_OFFSET_flag 0
-OFFSET(icache_op_struct_t, lock, 4)
-#define icache_op_struct_t_OFFSET_lock 4
-OFFSET(icache_op_struct_t, linesize, 8)
-#define icache_op_struct_t_OFFSET_linesize 8
-OFFSET(icache_op_struct_t, begin, 16)
-#define icache_op_struct_t_OFFSET_begin 16
-OFFSET(icache_op_struct_t, end, 24)
-#define icache_op_struct_t_OFFSET_end 24
-OFFSET(icache_op_struct_t, spill, 32)
-#define icache_op_struct_t_OFFSET_spill 32
-
 OFFSET(priv_mcontext_t, simd, 288)
 #define priv_mcontext_t_OFFSET_simd 288
 SIZE(priv_mcontext_t, 2480)

--- a/core/arch/aarch64/mangle_aarch64.h
+++ b/core/arch/aarch64/mangle_aarch64.h
@@ -37,36 +37,5 @@
 /* Defined in aarch64.asm. */
 void
 icache_op_ic_ivau_asm(void);
-void
-icache_op_isb_asm(void);
-
-/* XXX i#7643: The design with this global struct will probably have
- * to be changed. There is at least one inter-thread issue with the
- * current code when an address given by an IC IVAU gets picked up by
- * a different thread on a different core; the second thread could
- * then get swapped out, and the first thread could attempt to run the
- * modified code, before the flush_fragments_from_region has happened.
- */
-typedef struct ALIGN_VAR(16) _icache_op_struct_t {
-    /* This flag is set if any icache lines have been invalidated. */
-    unsigned int flag;
-    /* The lower half of the address of "lock" must be non-zero as we want to
-     * acquire the lock using only two free registers and STXR Ws, Wt, [Xn]
-     * requires s != t and s != n, so we use t == n. With this ordering of the
-     * members alignment guarantees that bit 2 of the address of "lock" is set.
-     */
-    unsigned int lock;
-    /* The icache line size. This is discovered using the system register
-     * ctr_el0 and will be (1 << (2 + n)) with 0 <= n < 16.
-     */
-    size_t linesize;
-    /* If these are equal then no icache lines have been invalidated. Otherwise
-     * they are both aligned to the icache line size and describe a set of
-     * consecutive icache lines (which could wrap around the top of memory).
-     */
-    void *begin, *end;
-    /* Some space to spill registers. */
-    ptr_uint_t spill[2];
-} icache_op_struct_t;
 
 #endif /* _MANGLE_AARCH64_H_ */

--- a/core/arch/aarchxx/mangle.c
+++ b/core/arch/aarchxx/mangle.c
@@ -3047,12 +3047,10 @@ mangle_icache_op(dcontext_t *dcontext, instrlist_t *ilist, instr_t *instr,
         PRE(ilist, instr, /* mov x0, x28 */
             XINST_CREATE_move(dcontext, opnd_create_reg(DR_REG_X0),
                               opnd_create_reg(dr_reg_stolen)));
-        PRE(ilist, instr, /* blr x30 */
-            INSTR_CREATE_blr(dcontext, opnd_create_reg(DR_REG_X30)));
-        PRE(ilist, instr, /* ldp x0, x30, [x28] */
-            INSTR_CREATE_ldp(
-                dcontext, opnd_create_reg(DR_REG_X0), opnd_create_reg(DR_REG_X30),
-                opnd_create_base_disp(dr_reg_stolen, DR_REG_NULL, 0, 0, OPSZ_16)));
+        PRE(ilist, instr, /* br x30 */
+            INSTR_CREATE_br(dcontext, opnd_create_reg(DR_REG_X30)));
+        /* Does not return. */
+
         /* Remove original instruction. */
         instrlist_remove(ilist, instr);
         instr_destroy(dcontext, instr);

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -405,8 +405,6 @@ instr_is_icache_op(instr_t *instr)
     int opc = instr_get_opcode(instr);
     if (opc == OP_ic_ivau)
         return true; /* ic ivau, xT */
-    if (opc == OP_isb)
-        return true; /* isb */
     return false;
 }
 


### PR DESCRIPTION
Instead of accumulating IC IVAU addresses in a global struct and only acting on them when an ISB is seen, act on each IC IVAU immediately and in the same thread. This may be slower in some cases as there may be multiple calls to flush_fragments_synch_unlink_priv instead of a single call but it avoids an inter-thread issue.

Fixes #7643