### PR TITLE
Document that dr_sscanf supports character sets

### DIFF
--- a/core/io.c
+++ b/core/io.c
@@ -574,7 +574,6 @@ d_r_vsscanf(const char *str, const char *fmt, va_list ap)
                 break;
             /* XXX: Modifiers we could add support for:
              * - j, z, t: C99 modifiers for intmax_t, size_t, and ptrdiff_t.
-             * - [] scan sets: These are complicated and better to avoid.
              * - .*: For dynamically sized strings.  Not part of C scanf.
              * - n$: Store the result into the nth pointer arg after fmt.
              */

--- a/core/lib/dr_tools.h
+++ b/core/lib/dr_tools.h
@@ -1906,6 +1906,12 @@ DR_API
  * - \%x: Matches an unsigned hexadecimal integer, with or without a leading 0x.
  * - \%p: Matches a pointer-sized hexadecimal integer as %x does.
  * - \%%: Matches a literal % character.  Does not store output.
+ * - \%[..]: Matches characters in the set within the brackets, or all other
+ *   characters if the first character after the open bracket is ^.
+ *   To include a close bracket in the set, make it the first set character.
+ *   A range of characters can be specified with a hyphen.
+ *   The result is copied into the provided output string buffer.
+ *   To avoid buffer overflow, the caller should use a width specifier.
  *
  * Supported format modifiers:
  * - *: The * modifier causes the scan to match the specifier, but not store any


### PR DESCRIPTION
Our internal sscanf implementation does support character sets, but the dr_sscanf docs did not include that information before.