### PR TITLE
i#7540: Check value of steal_reg on AArch64 as on ARM.

### DIFF
--- a/core/options.c
+++ b/core/options.c
@@ -2383,10 +2383,11 @@ check_option_compatibility_helper(int recurse_count)
     }
 #    endif
 
-#    ifdef ARM
-    if (DYNAMO_OPTION(steal_reg) < 8 /* DR_REG_STOLEN_MIN */ ||
-        DYNAMO_OPTION(steal_reg) > IF_X64_ELSE(29, 12) /* DR_REG_STOLEN_MAX */) {
-        USAGE_ERROR("-steal_reg only supports register between r8 and r12(A32)/r29(A64)");
+#    ifdef AARCHXX
+    if (DYNAMO_OPTION(steal_reg) < DR_REG_STOLEN_MIN - DR_REG_R0 ||
+        DYNAMO_OPTION(steal_reg) > DR_REG_STOLEN_MAX - DR_REG_R0) {
+        USAGE_ERROR("-steal_reg only supports register between %d and %d",
+                    DR_REG_STOLEN_MIN - DR_REG_R0, DR_REG_STOLEN_MAX - DR_REG_R0);
         dynamo_options.steal_reg = IF_X64_ELSE(28 /*r28*/, 10 /*r10*/);
         changed_options = true;
     }

--- a/core/options.c
+++ b/core/options.c
@@ -2386,7 +2386,7 @@ check_option_compatibility_helper(int recurse_count)
 #    ifdef AARCHXX
     if (DYNAMO_OPTION(steal_reg) < DR_REG_STOLEN_MIN - DR_REG_R0 ||
         DYNAMO_OPTION(steal_reg) > DR_REG_STOLEN_MAX - DR_REG_R0) {
-        USAGE_ERROR("-steal_reg only supports register between %d and %d",
+        USAGE_ERROR("-steal_reg only supports register between r%d and r%d",
                     DR_REG_STOLEN_MIN - DR_REG_R0, DR_REG_STOLEN_MAX - DR_REG_R0);
         dynamo_options.steal_reg = IF_X64_ELSE(28 /*r28*/, 10 /*r10*/);
         changed_options = true;


### PR DESCRIPTION
The existing check was ARM-only, though it was probably intended to be used on AArch64 too. Also, use the MIN/MAX macros instead of just referring to them in a comment.

Fixes #7540