### PR TITLE
i#1472: Mark symtest as flaky in win64

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -321,6 +321,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 );
 
             %ignore_failures_64 = (
+                'code_api|api.symtest' => 1, # i#1472
                 # i#7529: New failures on GA Server22.
                 'code_api|client.annotation-detection' => 1, # i#7529
                 'code_api|client.annotation-detection-opt' => 1, # i#7529


### PR DESCRIPTION
The api.symtest test started failing repeatedly on win64. We suspect an OS update on the VMs in Github Actions. Marking as ignore until someone has resources to spend to investigate.

Issue: #1472