### PR TITLE
i#6684: Add missing import for uint64_t to reader_base.cpp

### DIFF
--- a/clients/drcachesim/reader/reader_base.cpp
+++ b/clients/drcachesim/reader/reader_base.cpp
@@ -34,6 +34,7 @@
 
 #include <cassert>
 #include <cinttypes>
+#include <cstdint>
 #include <queue>
 #include <stack>
 


### PR DESCRIPTION
Adds a missing cstdint import for uint64_t, highlighted by bots.

Issue: #6684 