### PR TITLE
i#7576 a64 detach: Ignore detach_state failures

### DIFF
--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -438,6 +438,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                                    'code_api,tracedump_text,tracedump_origins,syntax_intel|common.loglevel' => 1, # i#1807
                                    'code_api|tool.drcacheoff.rseq' => 1, # i#5734
                                    'code_api|tool.drcacheoff.windows-zlib' => 1, # i#5507
+                                   'code_api|api.detach_state' => 1, # i#7576
                                    );
             # XXX i#5365: fix flaky AArch64 tests running on SVE hardware.
             # Note that apart from tool.drcachesim.scattergather-aarch64, these


### PR DESCRIPTION
Adds api.detach_state on AArch64 to the ignore list temporarily. PR #7655 triggered an underlying synchall bug causing the test to be red quite frequently; but we'd like to keep the #7655 fix in place, though it's at the risk of missing future regressions to AArch64 detach.

Issue: #7576