### PR TITLE
i#7487: fix tool's crashes due to cfg thunk implemented on 24h2 and above

### DIFF
--- a/core/win32/drwinapi/ntdll_redir.h
+++ b/core/win32/drwinapi/ntdll_redir.h
@@ -207,6 +207,15 @@ redirect_LdrLoadDll(DR_PARAM_IN PWSTR path OPTIONAL,
                     DR_PARAM_IN PULONG characteristics OPTIONAL,
                     DR_PARAM_IN PUNICODE_STRING name, DR_PARAM_OUT PVOID *handle);
 
+PVOID NTAPI
+redirect_LdrResolveDelayLoadedAPI(DR_PARAM_IN PVOID ParentModuleBase,
+                                  DR_PARAM_IN PCIMAGE_DELAYLOAD_DESCRIPTOR
+                                      DelayloadDescriptor,
+                                  DR_PARAM_IN PDELAYLOAD_FAILURE_DLL_CALLBACK FailureDllHook,
+                                  DR_PARAM_IN PVOID FailureSystemHook,
+                                  DR_PARAM_OUT PIMAGE_THUNK_DATA ThunkAddress,
+                                  DR_PARAM_IN ULONG Flags);
+
 /* This is exported by some kernel32.dll versions, but it's just forwarded
  * directly or there's a stub that calls the real impl in ntdll.
  */

--- a/core/win32/ntdll.c
+++ b/core/win32/ntdll.c
@@ -2298,6 +2298,26 @@ query_virtual_memory(const byte *pc, MEMORY_BASIC_INFORMATION *mbi, size_t mbile
     return got;
 }
 
+/* Query image extension information for Windows 11 24H2+ CFG support (i#XXXX).
+ * Returns NTSTATUS from NtQueryVirtualMemory.
+ */
+NTSTATUS
+query_memory_image_extension(const byte *module_base,
+                              MEMORY_IMAGE_EXTENSION_INFORMATION *ext_info)
+{
+    NTSTATUS res;
+    SIZE_T got = 0;
+
+    ASSERT(ext_info != NULL);
+    memset(ext_info, 0, sizeof(MEMORY_IMAGE_EXTENSION_INFORMATION));
+
+    res = NT_SYSCALL(QueryVirtualMemory, NT_CURRENT_PROCESS, module_base,
+                     MemoryImageExtensionInformation, ext_info,
+                     sizeof(MEMORY_IMAGE_EXTENSION_INFORMATION), &got);
+
+    return res;
+}
+
 NTSTATUS
 get_mapped_file_name(const byte *pc, PWSTR buf, USHORT buf_bytes)
 {

--- a/core/win32/ntdll.h
+++ b/core/win32/ntdll.h
@@ -1374,6 +1374,11 @@ nt_remote_query_virtual_memory(HANDLE process, const byte *pc,
 size_t
 query_virtual_memory(const byte *pc, MEMORY_BASIC_INFORMATION *mbi, size_t mbilen);
 
+/* Query image extension information for Windows 11 24H2+ CFG support (i#XXXX) */
+NTSTATUS
+query_memory_image_extension(const byte *module_base,
+                              MEMORY_IMAGE_EXTENSION_INFORMATION *ext_info);
+
 NTSTATUS
 get_mapped_file_name(const byte *pc, PWSTR buf, USHORT buf_bytes);
 
@@ -2350,6 +2355,30 @@ typedef struct IMAGE_COR20_HEADER {
 #ifndef IMAGE_SCN_ALIGN_MASK
 #    define IMAGE_SCN_ALIGN_MASK 0x00F00000 /* from latest winnt.h */
 #endif                                      /* IMAGE_SCN_ALIGN_MASK */
+
+/* delayloadhandler.h */
+typedef struct _DELAYLOAD_PROC_DESCRIPTOR {
+    ULONG ImportDescribedByName;
+    union {
+        LPCSTR Name;
+        ULONG Ordinal;
+    } Description;
+} DELAYLOAD_PROC_DESCRIPTOR, *PDELAYLOAD_PROC_DESCRIPTOR;
+
+typedef struct _DELAYLOAD_INFO {
+    ULONG Size;
+    PCIMAGE_DELAYLOAD_DESCRIPTOR DelayloadDescriptor;
+    PIMAGE_THUNK_DATA ThunkAddress;
+    LPCSTR TargetDllName;
+    DELAYLOAD_PROC_DESCRIPTOR TargetApiDescriptor;
+    PVOID TargetModuleBase;
+    PVOID Unused;
+    ULONG LastError;
+} DELAYLOAD_INFO, *PDELAYLOAD_INFO;
+
+typedef PVOID(WINAPI *PDELAYLOAD_FAILURE_DLL_CALLBACK)(
+    _In_ ULONG NotificationReason, _In_ PDELAYLOAD_INFO DelayloadInfo);
+
 
 NTSTATUS
 nt_initialize_shared_directory(HANDLE *shared_directory /* OUT */, bool permanent);

--- a/core/win32/ntdll_types.h
+++ b/core/win32/ntdll_types.h
@@ -101,8 +101,26 @@ typedef enum _MEMORY_INFORMATION_CLASS {
     MemoryBasicInformation,
     MemoryWorkingSetList,
     MemorySectionName,
-    MemoryBasicVlmInformation
+    MemoryBasicVlmInformation,
+    /* Windows 11 24H2+ (i#7487): CFG extension information */
+    MemoryImageExtensionInformation = 14
 } MEMORY_INFORMATION_CLASS;
+
+/* Windows 11 24H2+ (i#7487): CFG extension memory region information.
+ * See https://ynwarcs.github.io/Win11-24H2-CFG for details.
+ */
+typedef enum _MEMORY_IMAGE_EXTENSION_TYPE {
+    MemoryImageExtensionCfgScp,
+    MemoryImageExtensionCfgEmulatedScp,
+    MemoryImageExtensionTypeMax,
+} MEMORY_IMAGE_EXTENSION_TYPE;
+
+typedef struct _MEMORY_IMAGE_EXTENSION_INFORMATION {
+    MEMORY_IMAGE_EXTENSION_TYPE ExtensionType;
+    ULONG Flags;
+    PVOID ExtensionImageBaseRva;
+    SIZE_T ExtensionSize;
+} MEMORY_IMAGE_EXTENSION_INFORMATION, *PMEMORY_IMAGE_EXTENSION_INFORMATION;
 
 /* from DDK2003SP1/3790.1830/inc/ddk/wnet/ntddk.h */
 typedef enum _PROCESSINFOCLASS {

--- a/core/win32/os_exports.h
+++ b/core/win32/os_exports.h
@@ -67,6 +67,10 @@
 #define WINDOWS_VERSION_XP 51
 #define WINDOWS_VERSION_2000 50
 #define WINDOWS_VERSION_NT 40
+
+/* Windows build numbers (from get_os_version_ex()) */
+#define WINDOWS_BUILD_11_24H2 22631 /* Windows 11 24H2 introduces CFG extensions */
+
 int
 get_os_version(void);
 void


### PR DESCRIPTION
This commit fixes the crashes on the tool when it encounters cfg thunks `guard_dispatch_icall$thunk$xxx` that was dereferenced to extended image memory located at ntdll by OS kernel, which leads to invalid memory for private library.

Apart from that, `redirect_GetModuleFileNameW` seems to be broken as it returns the ascii version for the filename instead of unicode version.

Fixes #7487