### PR TITLE
i#7714 missing switch cases: Add default case in burst_syscall_inject

### DIFF
--- a/clients/drcachesim/tests/burst_syscall_inject.cpp
+++ b/clients/drcachesim/tests/burst_syscall_inject.cpp
@@ -524,8 +524,7 @@ look_for_syscall_trace(void *dr_context, std::string trace_dir)
                 // marker and the injected trace, so we preserve prev_syscall_num_marker.
                 prev_syscall_num_marker = prev_syscall_num_marker_saved;
                 break;
-            default:
-                break;
+            default: break;
             }
             continue;
         }


### PR DESCRIPTION
Adds a default switch case in burst_syscall_inject.cpp so that all marker types are handled more clearly. Highlighted as a warning by clang.

Issue: #7714