### PR TITLE
i#7725 neg time: Allow 2us negative time in drmemtraces

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -3886,9 +3886,9 @@ test_negative_timestamps(void *drcontext)
         instrlist_t *ilist = instrlist_create(drcontext);
         constexpr uint64_t TIME_A = 100;
         constexpr uint64_t TIME_B = 110;
-        constexpr uint64_t TIME_C = 108; // Negative but beyond threshold.
+        constexpr uint64_t TIME_C = 107; // Negative but beyond threshold.
         constexpr uint64_t TIME_D = 111;
-        constexpr uint64_t TIME_E = 110; // Negative and under threshold.
+        constexpr uint64_t TIME_E = 109; // Negative and under threshold.
 
         std::vector<offline_entry_t> raw;
         raw.push_back(make_header());

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -503,7 +503,7 @@ raw2trace_t::process_marker(raw2trace_thread_data_t *tdata,
             // If a subclass overrides process_marker() and acts before us, they'll
             // see the old one, but the difference is minimal and if it really matters
             // they'll have to arrange to run after our code.
-            constexpr int64 NEGATIVE_TIME_CORRECT_THREHSOLD_US = 1;
+            constexpr int64 NEGATIVE_TIME_CORRECT_THREHSOLD_US = 2;
             if (tdata->last_timestamp_ - stamp <= NEGATIVE_TIME_CORRECT_THREHSOLD_US) {
                 stamp = tdata->last_timestamp_;
                 marker_val = static_cast<uintptr_t>(stamp);


### PR DESCRIPTION
Increases the allowed negative time delta from 1us to 2us to handle observed 2us decreases from kernel timestamp anomalies.

Updates the unit test.

Issue: #7725