### PR TITLE
i#7746: Use double inc in drmgr to support re-init

### DIFF
--- a/suite/tests/client-interface/drmgr-test.dll.c
+++ b/suite/tests/client-interface/drmgr-test.dll.c
@@ -486,6 +486,10 @@ event_exit(void)
         !drmgr_unregister_post_attach_event_user_data(event_post_attach_user_data))
         CHECK(false, "drmgr unregister filter failed");
 
+    // Test re-init.
+    drmgr_exit();
+    drmgr_init();
+
     drmgr_exit();
     dr_fprintf(STDERR, "all done\n");
 }


### PR DESCRIPTION
Switches drmgr's solution for legacy clients to use a double increment, to support re-initialization prior to DR's exit event while still supporting legacy clients.

This fixes the drmemory build, which was in turn blocking the dynamorio cronbuild.

Adds a test case that fails without the fix.
The existing tests cover the legacy support.

Fixes #7746