### PR TITLE
i#5365 AArch64 tests: fix drcacheoff.scale_time test for Ubuntu 24.04

### DIFF
--- a/clients/drcachesim/tests/scale_time.cpp
+++ b/clients/drcachesim/tests/scale_time.cpp
@@ -148,6 +148,8 @@ static int
 do_some_work(void)
 {
     enable_timers();
+    // Do real work to trigger CPU time-based timers.
+    // Use rand() so that the compiler cannot optimise out some of the work.
     int total = 0;
 
     for (int i = 0; i < 100000; i++)


### PR DESCRIPTION
Fix tool.drcacheoff.scale_time unit test by replacing the calls to malloc() with calls to rand() which the compiler cannot optimize out. It seems that g++ 11.5 was able to optimize out the calls to malloc() and the resulting code was too fast for the timers to fire.

Issue: #5365