### PR TITLE
i#7770: Increase tool.drcacheoff.scale_time timeout

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4924,6 +4924,8 @@ if (BUILD_CLIENTS)
         set(tool.drcacheoff.scale_time_nodr ON)
         set(tool.drcacheoff.scale_time_nopost ON)
         torunonly_drcacheoff(scale_time tool.drcacheoff.scale_time "" "" "")
+        # This test can take more than 90s in 32-bit GA CI (i#7770).
+        set(tool.drcacheoff.scale_time_timeout 180)
 
         set(tool.drcacheoff.burst_sleep_nodr ON)
         set(tool.drcacheoff.burst_sleep_nopost ON)


### PR DESCRIPTION
The tool.drcacheoff.scale_time test has been exceeding its 90s timeout and failing on the 32-bit x86 GA CI. We increase its timeout to 180s here.

Fixes #7770