### PR TITLE
i#6107 mod bug: Skip workaround for newer versions

### DIFF
--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -5025,73 +5025,150 @@ test_replay_as_traced_i6107_workaround()
     static constexpr uint64_t TIMESTAMP_BASE = 100;
     static constexpr int CPU = 6;
 
-    std::vector<trace_entry_t> inputs[NUM_INPUTS];
-    for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
-        memref_tid_t tid = TID_BASE + input_idx;
-        inputs[input_idx].push_back(test_util::make_thread(tid));
-        inputs[input_idx].push_back(test_util::make_pid(1));
-        for (int step_idx = 0; step_idx <= CHUNK_NUM_INSTRS / SCHED_STEP_INSTRS;
-             ++step_idx) {
-            inputs[input_idx].push_back(test_util::make_timestamp(101 + step_idx));
-            for (int instr_idx = 0; instr_idx < SCHED_STEP_INSTRS; ++instr_idx) {
-                inputs[input_idx].push_back(test_util::make_instr(42 + instr_idx));
-            }
-        }
-        inputs[input_idx].push_back(test_util::make_exit(tid));
-    }
-
-    // Synthesize a cpu-schedule file with the i#6107 bug.
-    // Interleave the two inputs to test handling that.
-    std::string cpu_fname = "tmp_test_cpu_i6107.zip";
     {
-        std::vector<schedule_entry_t> sched;
-        for (int step_idx = 0; step_idx <= CHUNK_NUM_INSTRS / SCHED_STEP_INSTRS;
-             ++step_idx) {
-            for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
-                sched.emplace_back(TID_BASE + input_idx, TIMESTAMP_BASE + step_idx, CPU,
-                                   // The bug has modulo chunk count as the count.
-                                   step_idx * SCHED_STEP_INSTRS % CHUNK_NUM_INSTRS);
+        std::vector<trace_entry_t> inputs[NUM_INPUTS];
+        for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
+            memref_tid_t tid = TID_BASE + input_idx;
+            inputs[input_idx].push_back(test_util::make_thread(tid));
+            inputs[input_idx].push_back(test_util::make_pid(1));
+            // Deliberately not inserting a version.
+            for (int step_idx = 0; step_idx <= CHUNK_NUM_INSTRS / SCHED_STEP_INSTRS;
+                 ++step_idx) {
+                inputs[input_idx].push_back(test_util::make_timestamp(101 + step_idx));
+                for (int instr_idx = 0; instr_idx < SCHED_STEP_INSTRS; ++instr_idx) {
+                    inputs[input_idx].push_back(test_util::make_instr(42 + instr_idx));
+                }
             }
+            inputs[input_idx].push_back(test_util::make_exit(tid));
         }
-        std::ostringstream cpu_string;
-        cpu_string << CPU;
-        zipfile_ostream_t outfile(cpu_fname);
-        std::string err = outfile.open_new_component(cpu_string.str());
-        assert(err.empty());
-        if (!outfile.write(reinterpret_cast<char *>(sched.data()),
-                           sched.size() * sizeof(sched[0])))
-            assert(false);
-    }
+        // Synthesize a cpu-schedule file with the i#6107 bug.
+        // Interleave the two inputs to test handling that.
+        std::string cpu_fname = "tmp_test_cpu_i6107.zip";
+        {
+            std::vector<schedule_entry_t> sched;
+            for (int step_idx = 0; step_idx <= CHUNK_NUM_INSTRS / SCHED_STEP_INSTRS;
+                 ++step_idx) {
+                for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
+                    sched.emplace_back(TID_BASE + input_idx, TIMESTAMP_BASE + step_idx,
+                                       CPU,
+                                       // The bug has modulo chunk count as the count.
+                                       step_idx * SCHED_STEP_INSTRS % CHUNK_NUM_INSTRS);
+                }
+            }
+            std::ostringstream cpu_string;
+            cpu_string << CPU;
+            zipfile_ostream_t outfile(cpu_fname);
+            std::string err = outfile.open_new_component(cpu_string.str());
+            assert(err.empty());
+            if (!outfile.write(reinterpret_cast<char *>(sched.data()),
+                               sched.size() * sizeof(sched[0])))
+                assert(false);
+        }
 
-    // Replay the recorded schedule.
-    std::vector<scheduler_t::input_workload_t> sched_inputs;
-    for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
-        memref_tid_t tid = TID_BASE + input_idx;
-        std::vector<scheduler_t::input_reader_t> readers;
-        readers.emplace_back(
-            std::unique_ptr<test_util::mock_reader_t>(
-                new test_util::mock_reader_t(inputs[input_idx])),
-            std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
-            tid);
-        sched_inputs.emplace_back(std::move(readers));
+        // Replay the recorded schedule.
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
+            memref_tid_t tid = TID_BASE + input_idx;
+            std::vector<scheduler_t::input_reader_t> readers;
+            readers.emplace_back(
+                std::unique_ptr<test_util::mock_reader_t>(
+                    new test_util::mock_reader_t(inputs[input_idx])),
+                std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
+                tid);
+            sched_inputs.emplace_back(std::move(readers));
+        }
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_RECORDED_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/2);
+        zipfile_istream_t infile(cpu_fname);
+        sched_ops.replay_as_traced_istream = &infile;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        // Since it initialized we didn't get an invalid schedule order.
+        // Make sure the stream works too.
+        auto *stream = scheduler.get_stream(0);
+        memref_t memref;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+        }
     }
-    scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_RECORDED_OUTPUT,
-                                               scheduler_t::DEPENDENCY_TIMESTAMPS,
-                                               scheduler_t::SCHEDULER_DEFAULTS,
-                                               /*verbosity=*/2);
-    zipfile_istream_t infile(cpu_fname);
-    sched_ops.replay_as_traced_istream = &infile;
-    scheduler_t scheduler;
-    if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
-        scheduler_t::STATUS_SUCCESS)
-        assert(false);
-    // Since it initialized we didn't get an invalid schedule order.
-    // Make sure the stream works too.
-    auto *stream = scheduler.get_stream(0);
-    memref_t memref;
-    for (scheduler_t::stream_status_t status = stream->next_record(memref);
-         status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
-        assert(status == scheduler_t::STATUS_OK);
+    {
+        // Now test identical timestamps, where the workaround would fail,
+        // except set a newer version number known to not have the bug.
+        std::vector<trace_entry_t> inputs[NUM_INPUTS];
+        for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
+            memref_tid_t tid = TID_BASE + input_idx;
+            inputs[input_idx].push_back(test_util::make_thread(tid));
+            inputs[input_idx].push_back(test_util::make_pid(1));
+            inputs[input_idx].push_back(
+                test_util::make_version(TRACE_ENTRY_VERSION_BRANCH_INFO));
+            for (int step_idx = 0; step_idx <= CHUNK_NUM_INSTRS / SCHED_STEP_INSTRS;
+                 ++step_idx) {
+                inputs[input_idx].push_back(test_util::make_timestamp(101 + step_idx));
+                for (int instr_idx = 0; instr_idx < SCHED_STEP_INSTRS; ++instr_idx) {
+                    inputs[input_idx].push_back(test_util::make_instr(42 + instr_idx));
+                }
+            }
+            inputs[input_idx].push_back(test_util::make_exit(tid));
+        }
+        std::string cpu_fname = "tmp_test_cpu_i6107_duptimes.zip";
+        {
+            std::vector<schedule_entry_t> sched;
+            for (int step_idx = 0; step_idx <= CHUNK_NUM_INSTRS / SCHED_STEP_INSTRS;
+                 ++step_idx) {
+                for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
+                    uint64_t timestamp = TIMESTAMP_BASE + step_idx;
+                    if (step_idx == 1 && input_idx == NUM_INPUTS - 1)
+                        --timestamp; // Duplicate the prior timstamp.
+                    sched.emplace_back(TID_BASE + input_idx, timestamp, CPU,
+                                       // There's no modulo bug.
+                                       step_idx * SCHED_STEP_INSTRS);
+                }
+            }
+            std::ostringstream cpu_string;
+            cpu_string << CPU;
+            zipfile_ostream_t outfile(cpu_fname);
+            std::string err = outfile.open_new_component(cpu_string.str());
+            assert(err.empty());
+            if (!outfile.write(reinterpret_cast<char *>(sched.data()),
+                               sched.size() * sizeof(sched[0])))
+                assert(false);
+        }
+
+        // Replay the recorded schedule.
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        for (int input_idx = 0; input_idx < NUM_INPUTS; input_idx++) {
+            memref_tid_t tid = TID_BASE + input_idx;
+            std::vector<scheduler_t::input_reader_t> readers;
+            readers.emplace_back(
+                std::unique_ptr<test_util::mock_reader_t>(
+                    new test_util::mock_reader_t(inputs[input_idx])),
+                std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()),
+                tid);
+            sched_inputs.emplace_back(std::move(readers));
+        }
+        scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_RECORDED_OUTPUT,
+                                                   scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                                   scheduler_t::SCHEDULER_DEFAULTS,
+                                                   /*verbosity=*/2);
+        zipfile_istream_t infile(cpu_fname);
+        sched_ops.replay_as_traced_istream = &infile;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        // Since it initialized we didn't get an invalid schedule order.
+        // Make sure the stream works too.
+        auto *stream = scheduler.get_stream(0);
+        memref_t memref;
+        for (scheduler_t::stream_status_t status = stream->next_record(memref);
+             status != scheduler_t::STATUS_EOF; status = stream->next_record(memref)) {
+            assert(status == scheduler_t::STATUS_OK);
+        }
     }
 #endif
 }


### PR DESCRIPTION
The workaround for #6107 can't handle duplicate timestamps, which we do sometimes see in real traces. We don't need the workaround for current traces, though, so a version check avoids the need to run it at all, as we've incremented the trace version twice since then.

Adds a unit test that fails without the fix.

Issue: #6107