### PR TITLE
i#5365 Fix client.attach_test on latest platforms

### DIFF
--- a/suite/tests/linux/infloop.c
+++ b/suite/tests/linux/infloop.c
@@ -143,5 +143,5 @@ main(int argc, const char *argv[])
         close(pipefd[1]);
     }
 
-    return result;
+    return 0;
 }


### PR DESCRIPTION
It seems that modern compilers are able to optimise out the loop in infloop.c. Add a call to rand() to prevent this, allowing the test to complete before the application terminates.

Issue: #5365