### PR TITLE
i#5365 AArch64 tests: rseq tests failing on CentOS 9

### DIFF
--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2062,6 +2062,12 @@ macro (set_up_test_lists)
   endforeach(run)
 endmacro ()
 
+# Stop glibc registering its own rseq structure as this interferes with
+# the rseq tests.
+function(disable_glibc_rseq test_name)
+  set("${test_name}_env" "GLIBC_TUNABLES=glibc.pthread.rseq=0" PARENT_SCOPE)
+endfunction(disable_glibc_rseq)
+
 ###########################################################################
 # tests
 
@@ -4827,18 +4833,18 @@ if (BUILD_CLIENTS)
         "-trace_after_instrs 5K"
         # Run thread-sharded for the invariant checker.
         "@${test_mode_flag}@-test_mode_name@rseq_app@-no_core_sharded" "")
-      set(tool.drcacheoff.rseq_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+      disable_glibc_rseq(tool.drcacheoff.rseq)
       # Test filtering.
       torunonly_drcacheoff(rseq-filter linux.rseq
         "-trace_after_instrs 5K -L0_filter"
         "@${test_mode_flag}@-test_mode_name@rseq_app@-no_core_sharded" "")
       set(tool.drcacheoff.rseq-filter_expectbase "offline-rseq")
-      set(tool.drcacheoff.rseq-filter_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+      disable_glibc_rseq(tool.drcacheoff.rseq-filter)
       torunonly_drcacheoff(rseq-dfilter linux.rseq
         "-trace_after_instrs 5K -L0D_filter"
         "@${test_mode_flag}@-test_mode_name@rseq_app@-no_core_sharded" "")
       set(tool.drcacheoff.rseq-dfilter_expectbase "offline-rseq")
-      set(tool.drcacheoff.rseq-dfilter_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+      disable_glibc_rseq(tool.drcacheoff.rseq-dfilter)
     endif ()
 
     if (AARCH64)
@@ -6196,16 +6202,16 @@ if (UNIX)
     # TODO i#1874: Build drmemtrace on Android (RSEQ_TEST_ATTACH depends on drmemtrace).
     set(linux.rseq_no_reg_compat)
     tobuild(linux.rseq linux/rseq.cpp)
-    set(linux.rseq_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+    disable_glibc_rseq(linux.rseq)
     # Test the other sections.  Unfortunately we need a separate binary for each.
     tobuild(linux.rseq_table linux/rseq.cpp)
     append_property_list(TARGET linux.rseq_table
       COMPILE_DEFINITIONS "RSEQ_TEST_USE_OLD_SECTION_NAME")
-    set(linux.rseq_table_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+    disable_glibc_rseq(linux.rseq_table)
     tobuild(linux.rseq_noarray linux/rseq.cpp)
     append_property_list(TARGET linux.rseq_noarray
       COMPILE_DEFINITIONS "RSEQ_TEST_USE_NO_ARRAY")
-    set(linux.rseq_noarray_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+    disable_glibc_rseq(linux.rseq_noarray)
     # Test attaching, which has a separate lazy rseq check.
     # We build with static DR to also test client interactions.
     tobuild_api(api.rseq linux/rseq.cpp "" "" OFF ON OFF)
@@ -6214,10 +6220,10 @@ if (UNIX)
     use_DynamoRIO_static_client(api.rseq drmemtrace_nomain)
     use_DynamoRIO_drmemtrace_tracer(api.rseq)
     set(api.rseq_expectbase rseq_client)
-    set(api.rseq_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+    disable_glibc_rseq(api.rseq)
     # Test non-compliant code with our workaround flag.
     tobuild_ops(linux.rseq_disable linux/rseq_disable.c "-disable_rseq" "")
-    set(api.rseq_disable_env "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+    disable_glibc_rseq(api.rseq_disable)
   endif ()
   # Test Linux brk emulation.
   if (LINUX)


### PR DESCRIPTION
glibc 2.35+ (and 2.34+ for RHEL/CentOS and possibly other OSes that backported the feature) make use of the rseq syscall which interferes with DynamoRIO's rseq tests.

The rseq syscall in the rseq tests was always failing with errno set to EINVAL because glibc had already registered its own rseq structure and only one registration is allowed per thread.

We can fix this by explicitly turning off glibc's rseq registration for the effected tests by setting the environment variable: "GLIBC_TUNABLES=glibc.pthread.rseq=0".

Also fix the CMakeLists.txt function set_properties() which was erroneously adding the test prefix to the environment variable.

Issue: #5365

Co-authored-by: Jack Gallagher <jack.gallagher@arm.com>