### PR TITLE
i#7796 Windows Doxygen: Mitigate failures by pinning to older version

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2025 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2026 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -291,6 +291,9 @@ jobs:
 
     # Install Doxygen.
     - uses: ssciwr/doxygen-install@v1
+      with:
+        # TODO i#7796: Fix failures seen on Doxygen 1.16.1.
+        version: "1.14.0"
 
     - name: Download Packages
       shell: powershell

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2025 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2026 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Mitigates Windows CI workflow failures seen due to Doxygen warnings in the recent automatic update to v1.16.1. For now we pin to v1.14.0, the version before the update.

Adds a TODO to fix the underlying issues and remove the workaround.

Issue: #7796