### PR TITLE
i#3320 instr assert: Ignore irregular-windows-simple + add offline

### DIFF
--- a/clients/drcachesim/tests/offline-irregular-windows-simple.templatex
+++ b/clients/drcachesim/tests/offline-irregular-windows-simple.templatex
@@ -1,0 +1,13 @@
+Hit delay threshold: enabling tracing.
+Hit tracing window #0 limit: disabling tracing.
+Hit retrace threshold: enabling tracing for window #1.
+Hit tracing window #1 limit: disabling tracing.
+Hit retrace threshold: enabling tracing for window #2.
+Hit tracing window #2 limit: disabling tracing.
+.*
+Basic counts tool results:
+.*
+Basic counts tool results:
+.*
+Basic counts tool results:
+.*

--- a/suite/runsuite_wrapper.pl
+++ b/suite/runsuite_wrapper.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # **********************************************************
-# Copyright () 2016-2025 Google, Inc.  All rights reserved.
+# Copyright () 2016-2026 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -552,6 +552,7 @@ for (my $i = 0; $i <= $#lines; ++$i) {
                 'prof_pcs,thread_private|common.nativeexec_exe_opt' => 1, # i#2052
                 'prof_pcs,thread_private|common.nativeexec_retakeover_opt' => 1, # i#2052
                 'prof_pcs,thread_private|common.nativeexec_bindnow_opt' => 1, # i#2052
+                'code_api|tool.drcachesim.irregular-windows-simple' => 1, # i#3320
                 );
             if ($is_long) {
                 # These are important tests so we only ignore in the long suite,

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4591,6 +4591,16 @@ if (BUILD_CLIENTS)
       "${READELF_EXECUTABLE}@-a@${PROJECT_BINARY_DIR}/suite/tests/${dir_prefix}.*.dir/raw/window.000?/*.elf")
     endif ()
 
+    # Offline version of this test.
+    torunonly_drcacheoff(irregular-windows-simple ${ci_shared_app}
+      "-trace_instr_intervals_file ${config_files_dir}/instr_intervals_example.csv"
+      "@-tool@basic_counts" "")
+    # The first postcmd did window #0.  There should be 2 more windows.
+    set(tool.drcacheoff.irregular-windows-simple_postcmd2
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0001@-tool@basic_counts")
+    set(tool.drcacheoff.irregular-windows-simple_postcmd3
+      "firstglob@${drcachesim_path}@-indir@${dir_prefix}.*.dir/raw/window.0002@-tool@basic_counts")
+
     # Test L0_filter_until_instrs
     torunonly_drcacheoff(L0-filter-until-instrs-windows-split ${ci_shared_app}
         "-trace_after_instrs 10K -L0_filter_until_instrs 10K -trace_for_instrs 10K -retrace_every_instrs 10K"


### PR DESCRIPTION
Adds the tool.drcachesim.irregular-windows-simple test to the ignore list for x86_64 as it is hitting the type_is_instr drcachesim online assert frequently. Unfortuantely we have not been able to figure out the weird pipe behavior causing the assert, and we can't easily continue past it. The 3x retry should make it very rare but somehow this test keeps hitting it.

To mitigate the loss of coverage, adds an offline version of the same test, to ensure we have a non-ignored regression test of the -trace_instr_intervals_file feature.

Issue: #3320