### PR TITLE
i#7695 x32 fail: Add legacy drmemtrace header diagnostics

### DIFF
--- a/clients/drcachesim/reader/file_reader.h
+++ b/clients/drcachesim/reader/file_reader.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -147,7 +147,10 @@ protected:
             else if (entry->type == TRACE_TYPE_MARKER)
                 readahead_deque.push_back(*entry);
             else {
-                ERRMSG("Unexpected trace sequence\n");
+                ERRMSG("Unexpected trace sequence in %s: found type %d after pid.type=%d "
+                       "tid.type=%d #queued=%zu\n",
+                       input_path_.c_str(), entry->type, pid.type, tid.type,
+                       readahead_deque.size());
                 return false;
             }
         }


### PR DESCRIPTION
Augments the drmemtrace header order error message with more information to try to diagnose the weird x86-32 legacy trace test failures we're seeing on Github Actions.

Issue: #7695