### PR TITLE
i#3424: document NULL where behavior for dr_insert_clean_call

### DIFF
--- a/core/lib/dr_ir_utils.h
+++ b/core/lib/dr_ir_utils.h
@@ -363,7 +363,7 @@ DR_API
  * parameters, make a call to \p callee, clean up the parameters, and
  * then restore the saved state.
  * If \p where is NULL, the clean call is inserted at the default pre-insertion
- * point for the instruction list.
+ * point for the instruction list, which currently appends to the list.
  *
  * The callee must use the standard C calling convention that matches the
  * underlying 32-bit or 64-bit binary interface convention ("cdecl"). Other


### PR DESCRIPTION
This PR documents the behavior of passing NULL as the `where` argument to `dr_insert_clean_call()`.

The behavior already exists and is documented internally in a non-Doxygen
comment in `instrlist.h`, but was not exposed in the public API documentation.

No runtime behavior is changed.

Fixes #3424
