### PR TITLE
i#5365 AArch64 tests: Use Ubuntu 24 for AArch64 CI

### DIFF
--- a/.github/workflows/ci-aarchxx.yml
+++ b/.github/workflows/ci-aarchxx.yml
@@ -55,12 +55,12 @@ jobs:
       matrix:
         # This job will run in parallel.
         include:
-          - os: ah-ubuntu_20_04-c6g_4x-50
+          - os: ah-ubuntu_24_04-c6g_4x-50
             sve: false
-          - os: ah-ubuntu_20_04-c7g_4x-50
+          - os: ah-ubuntu_24_04-c7g_4x-50
             sve: true
             sve_length: 256
-          - os: ah-ubuntu_20_04-c7g_4x-50
+          - os: ah-ubuntu_24_04-c7g_4x-50
             sve: true
             sve_length: 128
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The AArch64 pipelines should use Ubuntu 24 as Ubuntu 20 is getting old now.

Issue: #5365