### PR TITLE
i#7821: Undefine bool to fix clang-17 build

### DIFF
--- a/core/optionsx.h
+++ b/core/optionsx.h
@@ -1,5 +1,5 @@
 /* *******************************************************************************
- * Copyright (c) 2010-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2010-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2011 Massachusetts Institute of Technology  All rights reserved.
  * Copyright (c) 2003-2010 VMware, Inc.  All rights reserved.
  * *******************************************************************************/
@@ -66,6 +66,11 @@
 /* The liststring_t type is assumed to contain ;-separated values that are
  * appended to if multiple option instances are specified
  */
+
+#ifdef bool
+/* Avoid problems with bool macros on Mac. */
+#    undef bool
+#endif
 
 /* Shortcuts for the common cases */
 #define OPTION_DEFAULT(type, name, value, description) \


### PR DESCRIPTION
There is a define of bool coming from some system header on clang-17 on Mac.  It only affects the optionsx.h expansion, and undefining there solves it while a top-level undefine does not.

Fixes #7821