### PR TITLE
i#7823: Look for MEMPROT_EXEC when looking for the executable

### DIFF
--- a/core/unix/os.c
+++ b/core/unix/os.c
@@ -10245,7 +10245,7 @@ os_walk_address_space(memquery_iter_t *iter, bool add_modules)
             /* we already added the whole image region when we hit the first map for it */
             image = true;
             DODEBUG({ map_type = "ELF SO"; });
-        } else if (TEST(MEMPROT_READ, iter->prot) &&
+        } else if (TEST(MEMPROT_READ | MEMPROT_EXEC, iter->prot) &&
                    module_is_header(iter->vm_start, size)) {
             DEBUG_DECLARE(size_t image_size = size;)
             app_pc mod_base, mod_first_end, mod_max_end;


### PR DESCRIPTION
I don't know the larger context of what's going on here, but just from looking at the place of the assent it seems somewhat sane to be checking for MEMPROT_EXEC here (or possibly even above where we're looking for MEMPROT_READ) -- we're looking for the executable, so the mapping must be executable.

This makes the assert stop triggering for us, but I'm not sure if it has some other issues.

Fixes #7823