### PR TITLE
Handle empty module full_paths in drmemtrace func_trace

### DIFF
--- a/clients/drcachesim/tracer/func_trace.cpp
+++ b/clients/drcachesim/tracer/func_trace.cpp
@@ -190,6 +190,7 @@ get_pc_by_symbol(const module_data_t *mod, const char *symbol)
     } else if (mod->full_path == nullptr) {
         NOTIFY(2, "Missing module path for base pc=%p; cannot look up symbols\n",
                mod->start);
+        return nullptr;
     } else {
         // If failed to find the symbol in the dynamic symbol table, then we try to find
         // it in the module loaded by reading the module file in mod->full_path.


### PR DESCRIPTION
We've seen crashes in drmemtrace func_trace code which seem to be from null module full_path fields. This has been seen elsewhere, and other DR code checks for null in this field. We add such null checks to func_trace.

End-to-end testing is difficult as we do not fully understand when the path is completely absent. There are no unit tests set up for these func_trace functions; leaving that as beyond the scope of this simple fix.