### PR TITLE
i#7826: Fix drx time scale verbose=2 null dereferences

### DIFF
--- a/ext/drx/drx_time_scale.c
+++ b/ext/drx/drx_time_scale.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2025-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -725,7 +725,8 @@ event_pre_syscall(void *drcontext, int sysnum)
         struct timespec *spec = (struct timespec *)dr_syscall_get_param(drcontext, 3);
         data->app_set_timer_param = spec;
         NOTIFY(2, "T" TIDFMT " epoll_pwait2 time=%p %" SSZFC ".%.12" SSZFC "\n",
-               dr_get_thread_id(drcontext), spec, spec->tv_sec, spec->tv_nsec);
+               dr_get_thread_id(drcontext), spec, spec == NULL ? 0 : spec->tv_sec,
+               spec == NULL ? 0 : spec->tv_nsec);
         if (spec == NULL) /* Infinite. */
             break;
         size_t wrote;
@@ -746,7 +747,8 @@ event_pre_syscall(void *drcontext, int sysnum)
         NOTIFY(2,
                "T" TIDFMT " epoll_pwait2 time=%p %" INT64_FORMAT_CODE
                ".%.12" INT64_FORMAT_CODE "\n",
-               dr_get_thread_id(drcontext), spec, spec->tv_sec, spec->tv_nsec);
+               dr_get_thread_id(drcontext), spec, spec == NULL ? 0 : spec->tv_sec,
+               spec == NULL ? 0 : spec->tv_nsec);
         if (spec == NULL) /* Infinite. */
             break;
         size_t wrote;

--- a/suite/tests/client-interface/drx_timeout_scale-test.cpp
+++ b/suite/tests/client-interface/drx_timeout_scale-test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2025-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -238,6 +238,10 @@ perform_epolls()
                            /*sigmask=*/nullptr);
         assert(res == 0);
         ++epoll_count;
+        // Test a null timeout to ensure we don't fall over.
+        res = epoll_pwait2(/*fd=*/-1, &events, EPOLL_MAX_EVENTS, /*timeout=*/nullptr,
+                           /*sigmask=*/nullptr);
+        assert(res != 0);
 #endif
     }
     return epoll_count;


### PR DESCRIPTION
Fixes drx time scale crashes when verbosity is raised to 2+ and an epoll_pwait2 system call is invoked by the app with a null (infinite) timeout.

Adds a test case of a null timeout to epoll_pwait2.

Tested by raising verbosity and observing a crash with the fix and no crash without the fix.
Also tested on the internal test that first hit this issue.

Fixes #7826