### PR TITLE
i#7590: Cache replacement policy configuration

### DIFF
--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -216,15 +216,15 @@ configure_cache(const config_t &params, cache_params_t *cache)
                 if (cache->replace_policy == REPLACE_POLICY_RRIP &&
                     p.second.children.size() > 1) {
                     // Read configuration of the RRIP replacement policy.
-                    rrip_config_t *rrip_conf = new rrip_config_t();
-                    if (!configure_rrip_policy(p.second.children, rrip_conf)) {
+                    std::unique_ptr<rrip_config_t> rrip_conf { new rrip_config_t() };
+                    if (!configure_rrip_policy(p.second.children, rrip_conf.get())) {
                         ERRMSG("Failed to read RRIP replacement policy parameters at "
                                "line %d "
                                "column %d\n",
                                p.second.val_line, p.second.val_column);
                         return false;
                     }
-                    cache->replace_policy_config = rrip_conf;
+                    cache->replace_policy_config = std::move(rrip_conf);
                 }
             } else
 

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -226,13 +226,13 @@ configure_cache(const config_t &params, cache_params_t *cache)
                     }
                     cache->replace_policy_config = std::move(rrip_conf);
                 }
-            } else
-
+            } else {
                 // Replacement policy specified by name
                 if (!parse_param_value_or_fail(p.first, p.second,
                                                &cache->replace_policy)) {
                     return false;
                 }
+            }
             if (cache->replace_policy != REPLACE_POLICY_NON_SPECIFIED &&
                 cache->replace_policy != REPLACE_POLICY_LRU &&
                 cache->replace_policy != REPLACE_POLICY_LFU &&

--- a/clients/drcachesim/reader/config_reader.cpp
+++ b/clients/drcachesim/reader/config_reader.cpp
@@ -33,6 +33,7 @@
 #include "config_reader.h"
 #include "config_reader_helpers.h"
 #include <sstream>
+#include <set>
 
 namespace dynamorio {
 namespace drmemtrace {
@@ -86,6 +87,45 @@ convert_string_to_size(const std::string &s, uint64_t &size)
         size = (uint64_t)(input * scale);
     else {
         size = 0;
+        return false;
+    }
+    return true;
+}
+
+bool
+configure_rrip_policy(const config_t &params, rrip_config_t *config)
+{
+    // All parameters are mandatory if the replacement policy configuration specified.
+    std::set<std::string> required = { "rrpv_bits", "rrpv_period",
+                                       "rrpv_long_per_period" };
+
+    for (const auto &p : params) {
+        if (p.first == "rrpv_bits") {
+            if (!parse_param_value_or_fail(p.first, p.second, &config->rrpv_bits)) {
+                return false;
+            }
+            required.erase(p.first);
+        } else if (p.first == "rrpv_period") {
+            if (!parse_param_value_or_fail(p.first, p.second, &config->rrpv_period)) {
+                return false;
+            }
+            required.erase(p.first);
+        } else if (p.first == "rrpv_long_per_period") {
+            if (!parse_param_value_or_fail(p.first, p.second,
+                                           &config->rrpv_long_per_period)) {
+                return false;
+            }
+            required.erase(p.first);
+        } else if (p.first == "type") {
+            // This parameter already read, just skip it.
+        } else {
+            ERRMSG("Unexpected parameter %s at line %d column %d\n", p.first.c_str(),
+                   p.second.val_line, p.second.val_column);
+            return false;
+        }
+    }
+    if (!required.empty()) {
+        ERRMSG("Missed parameter %s\n", required.begin()->c_str());
         return false;
     }
     return true;
@@ -159,9 +199,40 @@ configure_cache(const config_t &params, cache_params_t *cache)
         } else if (p.first == "replace_policy") {
             // Cache replacement policy: REPLACE_POLICY_LRU (default),
             // REPLACE_POLICY_LFU or REPLACE_POLICY_FIFO.
-            if (!parse_param_value_or_fail(p.first, p.second, &cache->replace_policy)) {
-                return false;
-            }
+            if (p.second.type == config_param_node_t::MAP) {
+                // Replacement policy configuration is a nested structure.
+                // Read replacement policy type.
+                const auto type_it = p.second.children.find("type");
+                if (type_it == p.second.children.end()) {
+                    ERRMSG("Replacement policy type should be specified at line %d "
+                           "column %d\n",
+                           p.second.val_line, p.second.val_column);
+                    return false;
+                }
+                if (!parse_param_value_or_fail(p.first, type_it->second,
+                                               &cache->replace_policy)) {
+                    return false;
+                }
+                if (cache->replace_policy == REPLACE_POLICY_RRIP &&
+                    p.second.children.size() > 1) {
+                    // Read configuration of the RRIP replacement policy.
+                    rrip_config_t *rrip_conf = new rrip_config_t();
+                    if (!configure_rrip_policy(p.second.children, rrip_conf)) {
+                        ERRMSG("Failed to read RRIP replacement policy parameters at "
+                               "line %d "
+                               "column %d\n",
+                               p.second.val_line, p.second.val_column);
+                        return false;
+                    }
+                    cache->replace_policy_config = rrip_conf;
+                }
+            } else
+
+                // Replacement policy specified by name
+                if (!parse_param_value_or_fail(p.first, p.second,
+                                               &cache->replace_policy)) {
+                    return false;
+                }
             if (cache->replace_policy != REPLACE_POLICY_NON_SPECIFIED &&
                 cache->replace_policy != REPLACE_POLICY_LRU &&
                 cache->replace_policy != REPLACE_POLICY_LFU &&

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -52,8 +52,6 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-struct cache_replacement_policy_config_t;
-
 // Cache configuration settings.
 struct cache_params_t {
     cache_params_t()

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -46,9 +46,12 @@
 
 #include "options.h"
 #include "cache_simulator_create.h"
+#include "create_cache_replacement_policy.h"
 
 namespace dynamorio {
 namespace drmemtrace {
+
+struct cache_replacement_policy_config_t;
 
 // Cache configuration settings.
 struct cache_params_t {
@@ -61,6 +64,7 @@ struct cache_params_t {
         , exclusive(false)
         , parent(CACHE_PARENT_MEMORY)
         , replace_policy(REPLACE_POLICY_LRU)
+        , replace_policy_config(nullptr)
         , prefetcher(PREFETCH_POLICY_NONE)
         , miss_file("")
     {
@@ -89,6 +93,8 @@ struct cache_params_t {
     // Cache replacement policy as described by the runtime option
     // op_replace_policy (see ../common/options.cpp).
     std::string replace_policy;
+    // Parameters of cache replacement policy
+    cache_replacement_policy_config_t *replace_policy_config;
     // Type of prefetcher as described by the runtime option
     // op_data_prefetcher (see ../common/options.cpp).
     std::string prefetcher;

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -46,7 +46,7 @@
 
 #include "options.h"
 #include "cache_simulator_create.h"
-#include "create_cache_replacement_policy.h"
+#include "cache_replacement_policy_config.h"
 
 namespace dynamorio {
 namespace drmemtrace {

--- a/clients/drcachesim/reader/config_reader.h
+++ b/clients/drcachesim/reader/config_reader.h
@@ -43,6 +43,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "options.h"
 #include "cache_simulator_create.h"
@@ -94,7 +95,7 @@ struct cache_params_t {
     // op_replace_policy (see ../common/options.cpp).
     std::string replace_policy;
     // Parameters of cache replacement policy
-    cache_replacement_policy_config_t *replace_policy_config;
+    std::unique_ptr<cache_replacement_policy_config_t> replace_policy_config;
     // Type of prefetcher as described by the runtime option
     // op_data_prefetcher (see ../common/options.cpp).
     std::string prefetcher;

--- a/clients/drcachesim/simulator/cache_replacement_policy_config.h
+++ b/clients/drcachesim/simulator/cache_replacement_policy_config.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -30,25 +30,23 @@
  * DAMAGE.
  */
 
-#ifndef _CREATE_CACHE_REPLACEMENT_POLICY_H_
-#define _CREATE_CACHE_REPLACEMENT_POLICY_H_
-
-#include <memory>
-#include <string>
-
-#include "cache_replacement_policy.h"
-#include "cache_replacement_policy_config.h"
+#ifndef _CACHE_REPLACEMENT_POLICY_CONFIG_H_
+#define _CACHE_REPLACEMENT_POLICY_CONFIG_H_
 
 namespace dynamorio {
 namespace drmemtrace {
 
-/// Initializes and returns a specific replacement policy.
-std::unique_ptr<cache_replacement_policy_t>
-create_cache_replacement_policy(const std::string &policy, int num_sets,
-                                int associativity,
-                                cache_replacement_policy_config_t *config = nullptr);
+struct cache_replacement_policy_config_t {
+    virtual ~cache_replacement_policy_config_t() = default;
+};
+
+struct rrip_config_t : cache_replacement_policy_config_t {
+    size_t rrpv_bits;
+    size_t rrpv_period;
+    size_t rrpv_long_per_period;
+};
 
 } // namespace drmemtrace
 } // namespace dynamorio
 
-#endif /* _CREATE_CACHE_REPLACEMENT_POLICY_H_ */
+#endif /* _CACHE_REPLACEMENT_POLICY_CONFIG_H_ */

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -344,10 +344,10 @@ cache_simulator_t::cache_simulator_t(std::istream *config_file,
                          (int)cache_config.size, parent_,
                          new cache_stats_t((int)knobs_.line_size, cache_config.miss_file,
                                            warmup_enabled_, is_coherent_),
-                         create_cache_replacement_policy(cache_config.replace_policy,
-                                                         (int)cache_config.size /
-                                                             (int)knobs_.line_size,
-                                                         (int)cache_config.assoc),
+                         create_cache_replacement_policy(
+                             cache_config.replace_policy,
+                             (int)cache_config.size / (int)knobs_.line_size,
+                             (int)cache_config.assoc, cache_config.replace_policy_config),
                          get_prefetcher(cache_config.prefetcher), inclusion_policy,
                          is_coherent_, is_snooped ? snoop_id : -1,
                          is_snooped ? snoop_filter_ : nullptr, children)) {

--- a/clients/drcachesim/simulator/cache_simulator.cpp
+++ b/clients/drcachesim/simulator/cache_simulator.cpp
@@ -264,16 +264,16 @@ cache_simulator_t::cache_simulator_t(std::istream *config_file,
              * multiple children to place the snoop filter.
              * Fully shared caches are marked as non-coherent.
              */
-            cache_params_t current_cache = cache_params.find(LL_name)->second;
+            const cache_params_t *current_cache = &(cache_params.find(LL_name)->second);
             non_coherent_caches_[LL_name] = all_caches_[LL_name];
-            while (current_cache.children.size() == 1) {
-                std::string child_name = current_cache.children[0];
+            while (current_cache->children.size() == 1) {
+                std::string child_name = current_cache->children[0];
                 non_coherent_caches_[child_name] = all_caches_[child_name];
-                current_cache = cache_params.find(child_name)->second;
+                current_cache = &(cache_params.find(child_name)->second);
             }
-            if (current_cache.children.size() > 0) {
-                lowest_shared_cache = current_cache.name;
-                total_snooped_caches = (unsigned int)current_cache.children.size();
+            if (current_cache->children.size() > 0) {
+                lowest_shared_cache = current_cache->name;
+                total_snooped_caches = (unsigned int)current_cache->children.size();
             }
         } else {
             total_snooped_caches = num_LL;
@@ -347,7 +347,8 @@ cache_simulator_t::cache_simulator_t(std::istream *config_file,
                          create_cache_replacement_policy(
                              cache_config.replace_policy,
                              (int)cache_config.size / (int)knobs_.line_size,
-                             (int)cache_config.assoc, cache_config.replace_policy_config),
+                             (int)cache_config.assoc,
+                             std::move(cache_config.replace_policy_config)),
                          get_prefetcher(cache_config.prefetcher), inclusion_policy,
                          is_coherent_, is_snooped ? snoop_id : -1,
                          is_snooped ? snoop_filter_ : nullptr, children)) {

--- a/clients/drcachesim/simulator/create_cache_replacement_policy.cpp
+++ b/clients/drcachesim/simulator/create_cache_replacement_policy.cpp
@@ -48,7 +48,8 @@ namespace drmemtrace {
 
 std::unique_ptr<cache_replacement_policy_t>
 create_cache_replacement_policy(const std::string &policy, int num_sets,
-                                int associativity)
+                                int associativity,
+                                cache_replacement_policy_config_t *config)
 {
     // default LRU
     if (policy.empty() || policy == REPLACE_POLICY_LRU) {
@@ -65,7 +66,17 @@ create_cache_replacement_policy(const std::string &policy, int num_sets,
             new policy_bit_plru_t(num_sets, associativity));
     }
     if (policy == REPLACE_POLICY_RRIP) {
-        return std::unique_ptr<policy_rrip_t>(new policy_rrip_t(num_sets, associativity));
+        rrip_config_t *rrip_conf = dynamic_cast<rrip_config_t *>(config);
+        if (rrip_conf) {
+            // Configuration specified. Use it.
+            return std::unique_ptr<policy_rrip_t>(new policy_rrip_t(
+                num_sets, associativity, rrip_conf->rrpv_bits, rrip_conf->rrpv_period,
+                rrip_conf->rrpv_long_per_period));
+        } else {
+            // Configuration missed. Use default parameters.
+            return std::unique_ptr<policy_rrip_t>(
+                new policy_rrip_t(num_sets, associativity));
+        }
     }
     return nullptr;
 }

--- a/clients/drcachesim/simulator/create_cache_replacement_policy.cpp
+++ b/clients/drcachesim/simulator/create_cache_replacement_policy.cpp
@@ -49,7 +49,7 @@ namespace drmemtrace {
 std::unique_ptr<cache_replacement_policy_t>
 create_cache_replacement_policy(const std::string &policy, int num_sets,
                                 int associativity,
-                                cache_replacement_policy_config_t *config)
+                                std::unique_ptr<cache_replacement_policy_config_t> config)
 {
     // default LRU
     if (policy.empty() || policy == REPLACE_POLICY_LRU) {
@@ -66,7 +66,7 @@ create_cache_replacement_policy(const std::string &policy, int num_sets,
             new policy_bit_plru_t(num_sets, associativity));
     }
     if (policy == REPLACE_POLICY_RRIP) {
-        rrip_config_t *rrip_conf = dynamic_cast<rrip_config_t *>(config);
+        const rrip_config_t *rrip_conf = dynamic_cast<rrip_config_t *>(config.get());
         if (rrip_conf) {
             // Configuration specified. Use it.
             return std::unique_ptr<policy_rrip_t>(new policy_rrip_t(

--- a/clients/drcachesim/simulator/create_cache_replacement_policy.h
+++ b/clients/drcachesim/simulator/create_cache_replacement_policy.h
@@ -44,9 +44,9 @@ namespace drmemtrace {
 
 /// Initializes and returns a specific replacement policy.
 std::unique_ptr<cache_replacement_policy_t>
-create_cache_replacement_policy(const std::string &policy, int num_sets,
-                                int associativity,
-                                cache_replacement_policy_config_t *config = nullptr);
+create_cache_replacement_policy(
+    const std::string &policy, int num_sets, int associativity,
+    std::unique_ptr<cache_replacement_policy_config_t> config = nullptr);
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/simulator/create_cache_replacement_policy.h
+++ b/clients/drcachesim/simulator/create_cache_replacement_policy.h
@@ -41,10 +41,21 @@
 namespace dynamorio {
 namespace drmemtrace {
 
+struct cache_replacement_policy_config_t {
+    virtual ~cache_replacement_policy_config_t() = default;
+};
+
+struct rrip_config_t : cache_replacement_policy_config_t {
+    size_t rrpv_bits;
+    size_t rrpv_period;
+    size_t rrpv_long_per_period;
+};
+
 /// Initializes and returns a specific replacement policy.
 std::unique_ptr<cache_replacement_policy_t>
 create_cache_replacement_policy(const std::string &policy, int num_sets,
-                                int associativity);
+                                int associativity,
+                                cache_replacement_policy_config_t *config = nullptr);
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/tests/config_reader_unit_test.cpp
+++ b/clients/drcachesim/tests/config_reader_unit_test.cpp
@@ -42,8 +42,8 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-static cache_params_t
-find_cache(const std::map<std::string, cache_params_t> &caches, std::string name)
+static const cache_params_t &
+find_cache(const std::map<std::string, cache_params_t> &caches, const std::string &name)
 {
     auto cache_it = caches.find(name);
     if (cache_it == caches.end()) {
@@ -60,7 +60,7 @@ check_cache(const std::map<std::string, cache_params_t> &caches, std::string nam
             std::string parent_, std::string replace_policy, std::string prefetcher,
             std::string miss_file)
 {
-    auto cache = find_cache(caches, name);
+    const auto &cache = find_cache(caches, name);
     if (cache.type != type || cache.core != core || cache.size != size ||
         cache.assoc != assoc || cache.inclusive != inclusive || cache.parent != parent_ ||
         cache.replace_policy != replace_policy || cache.prefetcher != prefetcher ||
@@ -319,7 +319,7 @@ unit_test_replacement_policy()
             exit(1);
         }
 
-        auto cache_L1 = find_cache(caches, "L1");
+        const auto &cache_L1 = find_cache(caches, "L1");
         if (cache_L1.replace_policy != "LRU") {
             std::cerr
                 << "drcachesim config_reader_test failed (simple; wrong replace_policy "
@@ -333,7 +333,7 @@ unit_test_replacement_policy()
             exit(1);
         }
 
-        auto cache_L2 = find_cache(caches, "L2");
+        const auto &cache_L2 = find_cache(caches, "L2");
         if (cache_L2.replace_policy != "RRIP") {
             std::cerr << "drcachesim config_reader_test failed (wrong replace_policy "
                       << cache_L2.replace_policy << " for cache " << cache_L2.name
@@ -362,7 +362,7 @@ unit_test_replacement_policy()
             exit(1);
         }
 
-        auto cache_L1 = find_cache(caches, "L1");
+        const auto &cache_L1 = find_cache(caches, "L1");
         if (cache_L1.replace_policy != "LRU") {
             std::cerr
                 << "drcachesim config_reader_test failed (simple; wrong replace_policy "
@@ -376,7 +376,7 @@ unit_test_replacement_policy()
             exit(1);
         }
 
-        auto cache_L2 = find_cache(caches, "L2");
+        const auto &cache_L2 = find_cache(caches, "L2");
         if (cache_L2.replace_policy != "RRIP") {
             std::cerr << "drcachesim config_reader_test failed (wrong replace_policy "
                       << cache_L2.replace_policy << " for cache " << cache_L2.name
@@ -407,7 +407,7 @@ unit_test_replacement_policy()
             exit(1);
         }
 
-        auto cache_L2 = find_cache(caches, "L2");
+        const auto &cache_L2 = find_cache(caches, "L2");
         if (cache_L2.replace_policy != "RRIP") {
             std::cerr << "drcachesim config_reader_test failed (wrong replace_policy "
                       << cache_L2.replace_policy << " for cache " << cache_L2.name
@@ -420,7 +420,8 @@ unit_test_replacement_policy()
                       << cache_L2.name << ")\n";
             exit(1);
         }
-        auto rrip_config = dynamic_cast<rrip_config_t *>(cache_L2.replace_policy_config);
+        const auto &rrip_config =
+            dynamic_cast<rrip_config_t *>(cache_L2.replace_policy_config.get());
         if (rrip_config->rrpv_bits != 2 || rrip_config->rrpv_period != 32 ||
             rrip_config->rrpv_long_per_period != 3) {
             std::cerr << "drcachesim config_reader_test failed (wrong "

--- a/clients/drcachesim/tests/config_reader_unit_test.cpp
+++ b/clients/drcachesim/tests/config_reader_unit_test.cpp
@@ -60,7 +60,7 @@ check_cache(const std::map<std::string, cache_params_t> &caches, std::string nam
             std::string parent_, std::string replace_policy, std::string prefetcher,
             std::string miss_file)
 {
-    const auto &cache = find_cache(caches, name);
+    const cache_params_t &cache = find_cache(caches, name);
     if (cache.type != type || cache.core != core || cache.size != size ||
         cache.assoc != assoc || cache.inclusive != inclusive || cache.parent != parent_ ||
         cache.replace_policy != replace_policy || cache.prefetcher != prefetcher ||
@@ -420,7 +420,7 @@ unit_test_replacement_policy()
                       << cache_L2.name << ")\n";
             exit(1);
         }
-        const auto &rrip_config =
+        const rrip_config_t *rrip_config =
             dynamic_cast<rrip_config_t *>(cache_L2.replace_policy_config.get());
         if (rrip_config->rrpv_bits != 2 || rrip_config->rrpv_period != 32 ||
             rrip_config->rrpv_long_per_period != 3) {

--- a/clients/drcachesim/tests/config_reader_unit_test.cpp
+++ b/clients/drcachesim/tests/config_reader_unit_test.cpp
@@ -42,11 +42,8 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-static void
-check_cache(const std::map<std::string, cache_params_t> &caches, std::string name,
-            std::string type, int core, uint64_t size, unsigned int assoc, bool inclusive,
-            std::string parent_, std::string replace_policy, std::string prefetcher,
-            std::string miss_file)
+static cache_params_t
+find_cache(const std::map<std::string, cache_params_t> &caches, std::string name)
 {
     auto cache_it = caches.find(name);
     if (cache_it == caches.end()) {
@@ -54,9 +51,16 @@ check_cache(const std::map<std::string, cache_params_t> &caches, std::string nam
                   << " unfound)\n";
         exit(1);
     }
+    return cache_it->second;
+}
 
-    auto &cache = cache_it->second;
-
+static void
+check_cache(const std::map<std::string, cache_params_t> &caches, std::string name,
+            std::string type, int core, uint64_t size, unsigned int assoc, bool inclusive,
+            std::string parent_, std::string replace_policy, std::string prefetcher,
+            std::string miss_file)
+{
+    auto cache = find_cache(caches, name);
     if (cache.type != type || cache.core != core || cache.size != size ||
         cache.assoc != assoc || cache.inclusive != inclusive || cache.parent != parent_ ||
         cache.replace_policy != replace_policy || cache.prefetcher != prefetcher ||
@@ -292,6 +296,173 @@ unit_test_inclusion_policy()
             std::cerr << "drcachesim inclusion_policy_test failed (conflicting exclusive "
                          "and inclusive)"
                       << std::endl;
+            exit(1);
+        }
+    }
+}
+
+void
+unit_test_replacement_policy()
+{
+    {
+        // Correct: Specified replacement policy name
+        cache_simulator_knobs_t knobs;
+        std::map<std::string, cache_params_t> caches;
+
+        std::stringstream ss;
+        ss.str("num_cores 1\n"
+               "L1{type unified core 0 parent L2 replace_policy LRU}\n"
+               "L2{type unified replace_policy RRIP}\n");
+        config_reader_t config;
+        if (!config.configure(&ss, knobs, caches)) {
+            std::cerr << "drcachesim config_reader_test failed (simple)" << std::endl;
+            exit(1);
+        }
+
+        auto cache_L1 = find_cache(caches, "L1");
+        if (cache_L1.replace_policy != "LRU") {
+            std::cerr
+                << "drcachesim config_reader_test failed (simple; wrong replace_policy "
+                << cache_L1.replace_policy << " for cache " << cache_L1.name << ")\n";
+            exit(1);
+        }
+        if (cache_L1.replace_policy_config != nullptr) {
+            std::cerr << "drcachesim config_reader_test failed (simple; "
+                         "replace_policy_config not null for cache "
+                      << cache_L1.name << ")\n";
+            exit(1);
+        }
+
+        auto cache_L2 = find_cache(caches, "L2");
+        if (cache_L2.replace_policy != "RRIP") {
+            std::cerr << "drcachesim config_reader_test failed (wrong replace_policy "
+                      << cache_L2.replace_policy << " for cache " << cache_L2.name
+                      << ")\n";
+            exit(1);
+        }
+        if (cache_L2.replace_policy_config != nullptr) {
+            std::cerr << "drcachesim config_reader_test failed (simple; "
+                         "replace_policy_config not null for cache "
+                      << cache_L2.name << ")\n";
+            exit(1);
+        }
+    }
+    {
+        // Correct: Specified replacement policy map
+        cache_simulator_knobs_t knobs;
+        std::map<std::string, cache_params_t> caches;
+
+        std::stringstream ss;
+        ss.str("num_cores 1\n"
+               "L1{type unified core 0 parent L2 replace_policy {type LRU}}\n"
+               "L2{type unified replace_policy {type RRIP}}\n");
+        config_reader_t config;
+        if (!config.configure(&ss, knobs, caches)) {
+            std::cerr << "drcachesim replacement_policy_test failed (map)" << std::endl;
+            exit(1);
+        }
+
+        auto cache_L1 = find_cache(caches, "L1");
+        if (cache_L1.replace_policy != "LRU") {
+            std::cerr
+                << "drcachesim config_reader_test failed (simple; wrong replace_policy "
+                << cache_L1.replace_policy << " for cache " << cache_L1.name << ")\n";
+            exit(1);
+        }
+        if (cache_L1.replace_policy_config != nullptr) {
+            std::cerr << "drcachesim config_reader_test failed (simple; "
+                         "replace_policy_config not null for cache "
+                      << cache_L1.name << ")\n";
+            exit(1);
+        }
+
+        auto cache_L2 = find_cache(caches, "L2");
+        if (cache_L2.replace_policy != "RRIP") {
+            std::cerr << "drcachesim config_reader_test failed (wrong replace_policy "
+                      << cache_L2.replace_policy << " for cache " << cache_L2.name
+                      << ")\n";
+            exit(1);
+        }
+        if (cache_L2.replace_policy_config != nullptr) {
+            std::cerr << "drcachesim config_reader_test failed (simple; "
+                         "replace_policy_config not null for cache "
+                      << cache_L2.name << ")\n";
+            exit(1);
+        }
+    }
+    {
+        // Correct: Specified replacement policy RRIP with parameters
+        cache_simulator_knobs_t knobs;
+        std::map<std::string, cache_params_t> caches;
+
+        std::stringstream ss;
+        ss.str("num_cores 1\n"
+               "L1{type unified core 0 parent L2 replace_policy LRU}\n"
+               "L2{type unified replace_policy {type RRIP rrpv_bits 2 rrpv_period 32 "
+               "rrpv_long_per_period 3}}\n");
+        config_reader_t config;
+        if (!config.configure(&ss, knobs, caches)) {
+            std::cerr << "drcachesim replacement_policy_test failed (simple RRIP)"
+                      << std::endl;
+            exit(1);
+        }
+
+        auto cache_L2 = find_cache(caches, "L2");
+        if (cache_L2.replace_policy != "RRIP") {
+            std::cerr << "drcachesim config_reader_test failed (wrong replace_policy "
+                      << cache_L2.replace_policy << " for cache " << cache_L2.name
+                      << ")\n";
+            exit(1);
+        }
+        if (cache_L2.replace_policy_config == nullptr) {
+            std::cerr << "drcachesim config_reader_test failed (simple; "
+                         "replace_policy_config is null for cache "
+                      << cache_L2.name << ")\n";
+            exit(1);
+        }
+        auto rrip_config = dynamic_cast<rrip_config_t *>(cache_L2.replace_policy_config);
+        if (rrip_config->rrpv_bits != 2 || rrip_config->rrpv_period != 32 ||
+            rrip_config->rrpv_long_per_period != 3) {
+            std::cerr << "drcachesim config_reader_test failed (wrong "
+                         "replace_policy_config for cache "
+                      << cache_L2.name << ")\n";
+            exit(1);
+        }
+    }
+    {
+        // Incorrect: Missed parameters for replacement policy RRIP
+        cache_simulator_knobs_t knobs;
+        std::map<std::string, cache_params_t> caches;
+
+        std::stringstream ss;
+        ss.str(
+            "num_cores 1\n"
+            "L1{type unified core 0 parent L2 replace_policy LRU}\n"
+            "L2{type unified replace_policy {type RRIP rrpv_bits 2 rrpv_period 32}}\n");
+        config_reader_t config;
+        if (config.configure(&ss, knobs, caches)) {
+            std::cerr << "drcachesim replacement_policy_test failed (missed parameters "
+                         "for RRIP)"
+                      << std::endl;
+            exit(1);
+        }
+    }
+    {
+        // Incorrect: Unexpected parameters for replacement policy RRIP
+        cache_simulator_knobs_t knobs;
+        std::map<std::string, cache_params_t> caches;
+
+        std::stringstream ss;
+        ss.str("num_cores 1\n"
+               "L1{type unified core 0 parent L2 replace_policy LRU}\n"
+               "L2{type unified replace_policy {type RRIP rrpv_bits 2 rrpv_period 32 "
+               "rrpv_long_per_period 1 extra_param 8}}\n");
+        config_reader_t config;
+        if (config.configure(&ss, knobs, caches)) {
+            std::cerr
+                << "drcachesim replacement_policy_test failed (unexpected parameters "
+                   "for RRIP)"
+                << std::endl;
             exit(1);
         }
     }

--- a/clients/drcachesim/tests/config_reader_unit_test.h
+++ b/clients/drcachesim/tests/config_reader_unit_test.h
@@ -48,6 +48,9 @@ void
 unit_test_inclusion_policy();
 
 void
+unit_test_replacement_policy();
+
+void
 unit_test_get_type_name();
 
 void

--- a/clients/drcachesim/tests/drcachesim_unit_tests.cpp
+++ b/clients/drcachesim/tests/drcachesim_unit_tests.cpp
@@ -1367,6 +1367,7 @@ test_main(int argc, const char *argv[])
     unit_test_config_reader(std::string(argv[1]));
     unit_test_config_reader_basic();
     unit_test_inclusion_policy();
+    unit_test_replacement_policy();
     unit_test_v2p_reader(std::string(argv[1]));
     unit_test_tlb_simulator(std::string(argv[1]));
     unit_test_cache_associativity();


### PR DESCRIPTION
Implemented parsing nested structure containing cache replacement policy configuration

Use cache replacement policy with default parameters
    replace_policy <name>

Define custom parameters for cache replacement policy
    replace_policy{
        type <name>     # Cache replacement policy name
        # Cache replacement policy parameters
    }

Available parameters for RRIP policy are:
- rrpv_bits
- rrpv_period
- rrpv_long_per_period

Fixes #7590