### PR TITLE
i#7854 wholesys traces: Support markers in counts and view tool

### DIFF
--- a/clients/drcachesim/CMakeLists.txt
+++ b/clients/drcachesim/CMakeLists.txt
@@ -980,6 +980,17 @@ if (BUILD_TESTS)
       ${test_seconds})
   endif ()
 
+  add_executable(tool.drcacheoff.wholesys_trace_analysis_tests
+                 tests/wholesys_trace_analysis_tests.cpp)
+  configure_DynamoRIO_standalone(tool.drcacheoff.wholesys_trace_analysis_tests)
+  add_win32_flags(tool.drcacheoff.wholesys_trace_analysis_tests ON)
+  target_link_libraries(tool.drcacheoff.wholesys_trace_analysis_tests
+    drmemtrace_basic_counts test_helpers)
+  add_test(NAME tool.drcacheoff.wholesys_trace_analysis_tests
+           COMMAND tool.drcacheoff.wholesys_trace_analysis_tests)
+  set_tests_properties(tool.drcacheoff.wholesys_trace_analysis_tests PROPERTIES TIMEOUT
+    ${test_seconds})
+
   add_executable(tool.drcacheoff.trace_interval_analysis_unit_tests
                  tests/trace_interval_analysis_unit_tests.cpp)
   add_win32_flags(tool.drcacheoff.trace_interval_analysis_unit_tests ON)

--- a/clients/drcachesim/tests/core_sharded_test.cpp
+++ b/clients/drcachesim/tests/core_sharded_test.cpp
@@ -176,6 +176,7 @@ Core [0-9] counts:
         assert(std::distance(std::sregex_iterator(output.begin(), output.end(), count),
                              std::sregex_iterator()) == 3);
     }
+#    ifdef DISABLED_FOR_i7858
     {
         // Test core-sharded with replay-as-traced.
         std::string cpu_file = std::string(testdir) +
@@ -198,6 +199,7 @@ Core 8 counts:
 (.|\n)*
 )DELIM")));
     }
+#    endif
     {
         // Test record-replay.
         std::string record_file = "tmp_core_sharded_replay.zip";

--- a/clients/drcachesim/tests/core_sharded_test.cpp
+++ b/clients/drcachesim/tests/core_sharded_test.cpp
@@ -189,31 +189,30 @@ Core [0-9] counts:
         // apparently too large for our std::regex_search below (i#7858), so we try to
         // reduce the haystack by extracting only the relevant stats from the full
         // output.
-        // The last line in the total stats or stats for any core.
-        constexpr char kLastStats[] = " encodings\n";
-        std::size_t total_stats_end_index = output.find(kLastStats);
+        // The last line that we're interested in.
+        constexpr char kLastRelevantLine[] = " threads\n";
+        std::size_t total_stats_end_index = output.find(kLastRelevantLine);
         assert(total_stats_end_index != std::string::npos);
         std::string total_stats =
-            output.substr(0, total_stats_end_index + strlen(kLastStats));
+            output.substr(0, total_stats_end_index + strlen(kLastRelevantLine));
         assert(
             std::regex_search(total_stats, std::regex(R"DELIM(Basic counts tool results:
 Total counts:
       650576 total \(fetched\) instructions
 (.|\n)*
            9 total threads
-(.|\n)*
 )DELIM")));
         std::size_t core_8_onwards_stats_index = output.find("Core 8 counts");
         assert(core_8_onwards_stats_index != std::string::npos);
         std::string core_8_onwards_stats = output.substr(core_8_onwards_stats_index);
-        std::size_t core_8_stats_index = core_8_onwards_stats.find(kLastStats);
-        std::string core_8_stats =
-            core_8_onwards_stats.substr(0, core_8_stats_index + strlen(kLastStats));
+        std::size_t core_8_stats_end_index = core_8_onwards_stats.find(kLastRelevantLine);
+        assert(core_8_stats_end_index != std::string::npos);
+        std::string core_8_stats = core_8_onwards_stats.substr(
+            0, core_8_stats_end_index + strlen(kLastRelevantLine));
         assert(std::regex_search(core_8_stats, std::regex(R"DELIM(Core 8 counts:
       156381 \(fetched\) instructions
 (.|\n)*
            1 threads
-(.|\n)*
 )DELIM")));
     }
     {

--- a/clients/drcachesim/tests/core_sharded_test.cpp
+++ b/clients/drcachesim/tests/core_sharded_test.cpp
@@ -176,7 +176,6 @@ Core [0-9] counts:
         assert(std::distance(std::sregex_iterator(output.begin(), output.end(), count),
                              std::sregex_iterator()) == 3);
     }
-#    ifdef DISABLED_FOR_i7858
     {
         // Test core-sharded with replay-as-traced.
         std::string cpu_file = std::string(testdir) +
@@ -186,20 +185,37 @@ Core [0-9] counts:
             dir.c_str(), "-cores",        "11",    "-cpu_schedule_file", cpu_file.c_str()
         };
         std::string output = run_analyzer(sizeof(args) / sizeof(args[0]), args);
-        assert(std::regex_search(output, std::regex(R"DELIM(Basic counts tool results:
+        // We're sharding into 11 cores which creates an output string which is
+        // apparently too large for our std::regex_search below (i#7858), so we try to
+        // reduce the haystack by extracting only the relevant stats from the full
+        // output.
+        // The last line in the total stats or stats for any core.
+        constexpr char kLastStats[] = " encodings\n";
+        std::size_t total_stats_end_index = output.find(kLastStats);
+        assert(total_stats_end_index != std::string::npos);
+        std::string total_stats =
+            output.substr(0, total_stats_end_index + strlen(kLastStats));
+        assert(
+            std::regex_search(total_stats, std::regex(R"DELIM(Basic counts tool results:
 Total counts:
       650576 total \(fetched\) instructions
 (.|\n)*
            9 total threads
 (.|\n)*
-Core 8 counts:
+)DELIM")));
+        std::size_t core_8_onwards_stats_index = output.find("Core 8 counts");
+        assert(core_8_onwards_stats_index != std::string::npos);
+        std::string core_8_onwards_stats = output.substr(core_8_onwards_stats_index);
+        std::size_t core_8_stats_index = core_8_onwards_stats.find(kLastStats);
+        std::string core_8_stats =
+            core_8_onwards_stats.substr(0, core_8_stats_index + strlen(kLastStats));
+        assert(std::regex_search(core_8_stats, std::regex(R"DELIM(Core 8 counts:
       156381 \(fetched\) instructions
 (.|\n)*
            1 threads
 (.|\n)*
 )DELIM")));
     }
-#    endif
     {
         // Test record-replay.
         std::string record_file = "tmp_core_sharded_replay.zip";

--- a/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
+++ b/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
@@ -67,7 +67,7 @@ run_basic_counts(const std::vector<memref_t> &memrefs)
 }
 
 static bool
-test_hardware_xfer_markers()
+test_hardware_xfer_marker_counts()
 {
     std::vector<memref_t> memrefs = {
         gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
@@ -84,9 +84,10 @@ test_hardware_xfer_markers()
         gen_exit(TID_A),
     };
     basic_counts_t::counters_t counts = run_basic_counts(memrefs);
+    int64_t expected_hardware_xfer_markers = 3;
     if (counts.hardware_xfer_markers != 3) {
-        fprintf(stderr, "Expected 3 hardware xfer markers, found %ld\n",
-                counts.hardware_xfer_markers);
+        fprintf(stderr, "Expected %ld hardware xfer markers, found %ld\n",
+                expected_hardware_xfer_markers, counts.hardware_xfer_markers);
         return false;
     }
     fprintf(stderr, "test_hardware_xfer_markers passed\n");
@@ -97,7 +98,7 @@ int
 test_main(int argc, const char *argv[])
 {
     dr_standalone_init();
-    if (!test_hardware_xfer_markers())
+    if (!test_hardware_xfer_marker_counts())
         return 1;
     fprintf(stderr, "All done!\n");
     dr_standalone_exit();

--- a/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
+++ b/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
@@ -86,7 +86,7 @@ test_hardware_xfer_marker_counts()
     basic_counts_t::counters_t counts = run_basic_counts(memrefs);
     int64_t expected_hardware_xfer_markers = 3;
     if (counts.hardware_xfer_markers != expected_hardware_xfer_markers) {
-        fprintf(stderr, "Expected %ld hardware xfer markers, found %ld\n",
+        fprintf(stderr, "Expected %" PRId64 " hardware xfer markers, found %" PRId64 "\n",
                 expected_hardware_xfer_markers, counts.hardware_xfer_markers);
         return false;
     }

--- a/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
+++ b/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
@@ -97,11 +97,9 @@ test_hardware_xfer_marker_counts()
 int
 test_main(int argc, const char *argv[])
 {
-    dr_standalone_init();
     if (!test_hardware_xfer_marker_counts())
         return 1;
     fprintf(stderr, "All done!\n");
-    dr_standalone_exit();
     return 0;
 }
 

--- a/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
+++ b/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
@@ -1,0 +1,108 @@
+/* **********************************************************
+ * Copyright (c) 2026 Google, Inc.  All rights reserved.
+ * **********************************************************/
+
+/*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Google, Inc. nor the names of its contributors may be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL GOOGLE, INC. OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ */
+
+/* Unit tests for analysis of OFFLINE_FILE_TYPE_WHOLE_SYSTEM traces. */
+
+#include "dr_api.h"
+#include "tools/basic_counts.h"
+#include "memref_gen.h"
+
+#include <vector>
+
+namespace dynamorio {
+namespace drmemtrace {
+
+static constexpr memref_tid_t TID_A = 11;
+static constexpr addr_t PC = 1001;
+static constexpr addr_t SOME_VAL = 1;
+
+class local_stream_t : public default_memtrace_stream_t {
+public:
+    int64_t
+    get_tid() const override
+    {
+        return TID_A;
+    }
+};
+
+basic_counts_t::counters_t
+run_basic_counts(const std::vector<memref_t> &memrefs)
+{
+    auto stream = std::unique_ptr<local_stream_t>(new local_stream_t());
+    auto tool = std::unique_ptr<basic_counts_t>(new basic_counts_t(/*verbose=*/0));
+    tool->initialize_stream(stream.get());
+    for (const memref_t &memref : memrefs) {
+        tool->process_memref(memref);
+    }
+    return tool->get_total_counts();
+}
+
+static bool
+test_hardware_xfer_markers()
+{
+    std::vector<memref_t> memrefs = {
+        gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+        gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+        gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, SOME_VAL),
+        gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, SOME_VAL),
+        gen_instr(TID_A, PC),
+        gen_instr(TID_A, PC + 1),
+        gen_marker(TID_A, TRACE_MARKER_TYPE_TIMESTAMP, 0),
+        gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, SOME_VAL),
+        gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, SOME_VAL),
+        gen_instr(TID_A, PC + 2),
+        gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, SOME_VAL),
+        gen_exit(TID_A),
+    };
+    basic_counts_t::counters_t counts = run_basic_counts(memrefs);
+    if (counts.hardware_xfer_markers != 3) {
+        fprintf(stderr, "Expected 3 hardware xfer markers, found %ld\n",
+                counts.hardware_xfer_markers);
+        return false;
+    }
+    fprintf(stderr, "test_hardware_xfer_markers passed\n");
+    return true;
+}
+
+int
+test_main(int argc, const char *argv[])
+{
+    dr_standalone_init();
+    if (!test_hardware_xfer_markers())
+        return 1;
+    fprintf(stderr, "All done!\n");
+    dr_standalone_exit();
+    return 0;
+}
+
+} // namespace drmemtrace
+} // namespace dynamorio

--- a/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
+++ b/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
@@ -85,7 +85,7 @@ test_hardware_xfer_marker_counts()
     };
     basic_counts_t::counters_t counts = run_basic_counts(memrefs);
     int64_t expected_hardware_xfer_markers = 3;
-    if (counts.hardware_xfer_markers != 3) {
+    if (counts.hardware_xfer_markers != expected_hardware_xfer_markers) {
         fprintf(stderr, "Expected %ld hardware xfer markers, found %ld\n",
                 expected_hardware_xfer_markers, counts.hardware_xfer_markers);
         return false;

--- a/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
+++ b/clients/drcachesim/tests/wholesys_trace_analysis_tests.cpp
@@ -36,6 +36,7 @@
 #include "tools/basic_counts.h"
 #include "memref_gen.h"
 
+#include <cinttypes>
 #include <vector>
 
 namespace dynamorio {

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -278,7 +278,7 @@ basic_counts_t::cmp_threads(const std::pair<memref_tid_t, per_shard_t *> &l,
 
 void
 basic_counts_t::print_counters(const counters_t &counters, const std::string &prefix,
-                               bool for_kernel_trace)
+                               bool for_kernel_trace, bool for_whole_system_trace)
 {
     std::cerr << std::setw(12) << counters.instrs << prefix
               << " (fetched) instructions\n";
@@ -286,7 +286,7 @@ basic_counts_t::print_counters(const counters_t &counters, const std::string &pr
         std::cerr << std::setw(12) << counters.unique_pc_addrs.size() << prefix
                   << " unique (fetched) instructions\n";
     }
-    if (for_kernel_trace) {
+    if (for_kernel_trace || for_whole_system_trace) {
         std::cerr << std::setw(12) << counters.user_instrs << prefix
                   << " userspace instructions\n";
         std::cerr << std::setw(12) << counters.kernel_instrs << prefix
@@ -294,7 +294,7 @@ basic_counts_t::print_counters(const counters_t &counters, const std::string &pr
     }
     std::cerr << std::setw(12) << counters.instrs_nofetch << prefix
               << " non-fetched instructions\n";
-    if (for_kernel_trace) {
+    if (for_kernel_trace || for_whole_system_trace) {
         std::cerr << std::setw(12) << counters.user_nofetch_instrs << prefix
                   << " non-fetched userspace instructions\n";
         std::cerr << std::setw(12) << counters.kernel_nofetch_instrs << prefix
@@ -318,8 +318,12 @@ basic_counts_t::print_counters(const counters_t &counters, const std::string &pr
     std::cerr << std::setw(12) << counters.wait_markers << prefix << " wait markers\n";
     std::cerr << std::setw(12) << counters.xfer_markers << prefix
               << " kernel transfer markers\n";
-    std::cerr << std::setw(12) << counters.hardware_xfer_markers << prefix
-              << " hardware transfer markers\n";
+    if (for_whole_system_trace) {
+        // These markers are seen only in OFFLINE_FILE_TYPE_WHOLE_SYSTEM traces, so
+        // we skip them in the output altogether if they're not relevant.
+        std::cerr << std::setw(12) << counters.hardware_xfer_markers << prefix
+                  << " hardware transfer markers\n";
+    }
     std::cerr << std::setw(12) << counters.func_id_markers << prefix
               << " function id markers\n";
     std::cerr << std::setw(12) << counters.func_retaddr_markers << prefix
@@ -350,6 +354,7 @@ basic_counts_t::print_results()
     }
 
     bool for_kernel_trace = false;
+    bool for_whole_system_trace = false;
     for (const auto &shard : shard_map_) {
         for (const auto &ctr : shard.second->counters) {
             total += ctr;
@@ -360,6 +365,10 @@ basic_counts_t::print_results()
                     shard.second->filetype_)) {
             for_kernel_trace = true;
         }
+        if (!for_whole_system_trace &&
+            TESTANY(OFFLINE_FILE_TYPE_WHOLE_SYSTEM, shard.second->filetype_)) {
+            for_whole_system_trace = true;
+        }
     }
     // Print kernel data if context switches were inserted.
     if (total.kernel_instrs > 0)
@@ -367,7 +376,7 @@ basic_counts_t::print_results()
     total.shard_count = shard_map_.size();
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << "Total counts:\n";
-    print_counters(total, TOTAL_COUNT_PREFIX, for_kernel_trace);
+    print_counters(total, TOTAL_COUNT_PREFIX, for_kernel_trace, for_whole_system_trace);
 
     if (num_windows > 1) {
         std::cerr << "Total windows: " << num_windows << "\n";
@@ -375,8 +384,8 @@ basic_counts_t::print_results()
             std::cerr << "Window #" << i << ":\n";
             for (const auto &shard : shard_map_) {
                 if (shard.second->counters.size() > i) {
-                    print_counters(shard.second->counters[i], " window",
-                                   for_kernel_trace);
+                    print_counters(shard.second->counters[i], " window", for_kernel_trace,
+                                   for_whole_system_trace);
                 }
             }
         }
@@ -391,7 +400,8 @@ basic_counts_t::print_results()
             std::cerr << "Thread " << keyvals.second->tid << " counts:\n";
         else
             std::cerr << "Core " << keyvals.second->core << " counts:\n";
-        print_counters(keyvals.second->counters[0], "", for_kernel_trace);
+        print_counters(keyvals.second->counters[0], "", for_kernel_trace,
+                       for_whole_system_trace);
     }
 
     // TODO i#3599: also print thread-per-window stats.

--- a/clients/drcachesim/tools/basic_counts.cpp
+++ b/clients/drcachesim/tools/basic_counts.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2024 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -173,6 +173,10 @@ basic_counts_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
         } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
                    memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
             ++counters->xfer_markers;
+        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT ||
+                   memref.marker.marker_type ==
+                       TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) {
+            ++counters->hardware_xfer_markers;
         } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_IDLE) {
             ++counters->idle_markers;
         } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_WAIT) {
@@ -314,6 +318,8 @@ basic_counts_t::print_counters(const counters_t &counters, const std::string &pr
     std::cerr << std::setw(12) << counters.wait_markers << prefix << " wait markers\n";
     std::cerr << std::setw(12) << counters.xfer_markers << prefix
               << " kernel transfer markers\n";
+    std::cerr << std::setw(12) << counters.hardware_xfer_markers << prefix
+              << " hardware transfer markers\n";
     std::cerr << std::setw(12) << counters.func_id_markers << prefix
               << " function id markers\n";
     std::cerr << std::setw(12) << counters.func_retaddr_markers << prefix

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -106,6 +106,7 @@ public:
             idle_markers += rhs.idle_markers;
             wait_markers += rhs.wait_markers;
             xfer_markers += rhs.xfer_markers;
+            hardware_xfer_markers += rhs.hardware_xfer_markers;
             func_id_markers += rhs.func_id_markers;
             func_retaddr_markers += rhs.func_retaddr_markers;
             func_arg_markers += rhs.func_arg_markers;
@@ -141,6 +142,7 @@ public:
             idle_markers -= rhs.idle_markers;
             wait_markers -= rhs.wait_markers;
             xfer_markers -= rhs.xfer_markers;
+            hardware_xfer_markers -= rhs.hardware_xfer_markers;
             func_id_markers -= rhs.func_id_markers;
             func_retaddr_markers -= rhs.func_retaddr_markers;
             func_arg_markers -= rhs.func_arg_markers;
@@ -176,6 +178,7 @@ public:
                 stores == rhs.stores && sched_markers == rhs.sched_markers &&
                 idle_markers == rhs.idle_markers && wait_markers == rhs.wait_markers &&
                 xfer_markers == rhs.xfer_markers &&
+                hardware_xfer_markers == rhs.hardware_xfer_markers &&
                 func_id_markers == rhs.func_id_markers &&
                 func_retaddr_markers == rhs.func_retaddr_markers &&
                 func_arg_markers == rhs.func_arg_markers &&
@@ -202,7 +205,8 @@ public:
         int64_t sched_markers = 0; // Timestamps and cpuids.
         int64_t idle_markers = 0;
         int64_t wait_markers = 0;
-        int64_t xfer_markers = 0; // Kernel transfers.
+        int64_t xfer_markers = 0;          // Kernel transfers.
+        int64_t hardware_xfer_markers = 0; // Hardware transfers.
         int64_t func_id_markers = 0;
         int64_t func_retaddr_markers = 0;
         int64_t func_arg_markers = 0;

--- a/clients/drcachesim/tools/basic_counts.h
+++ b/clients/drcachesim/tools/basic_counts.h
@@ -290,7 +290,7 @@ protected:
                 const std::pair<memref_tid_t, per_shard_t *> &r);
     void
     print_counters(const counters_t &counters, const std::string &prefix,
-                   bool for_kernel_trace = false);
+                   bool for_kernel_trace = false, bool for_whole_system_trace = false);
     void
     compute_shard_interval_result(per_shard_t *shard, uint64_t interval_id);
 

--- a/clients/drcachesim/tools/view.cpp
+++ b/clients/drcachesim/tools/view.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -458,6 +458,13 @@ view_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
             // ISA.
             std::cerr << "<marker: uncompleted instruction, encoding 0x" << std::hex
                       << memref.marker.marker_value << std::dec << ">\n";
+            break;
+        case TRACE_MARKER_TYPE_HARDWARE_EVENT:
+            std::cerr << "<marker: hardware xfer from 0x" << std::hex
+                      << memref.marker.marker_value << std::dec << " to handler>\n";
+            break;
+        case TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN:
+            std::cerr << "<marker: hardware context return\n";
             break;
         default:
             std::cerr << "<marker: type " << memref.marker.marker_type << "; value "


### PR DESCRIPTION
Adds support for the new TRACE_MARKER_TYPE_HARDWARE_EVENT and TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN to the drmemtrace basic_counts and view tools.

Issue: #7854