### PR TITLE
i#7860 load bal: Make analyzer logs visible in release build

### DIFF
--- a/clients/drcachesim/analyzer.cpp
+++ b/clients/drcachesim/analyzer.cpp
@@ -67,6 +67,17 @@
 #endif
 #include "common/utils.h"
 
+#undef VPRINT
+// Make printing available in release build by not using ifdef DEBUG here.
+// The usefulness for diagnostics outweighs any overhead from extra branches.
+#define VPRINT(analyzer, level, ...)                            \
+    do {                                                        \
+        if ((analyzer)->verbosity_ >= (level)) {                \
+            fprintf(stderr, "%s ", (analyzer)->output_prefix_); \
+            fprintf(stderr, __VA_ARGS__);                       \
+        }                                                       \
+    } while (0)
+
 namespace dynamorio {
 namespace drmemtrace {
 


### PR DESCRIPTION
Makes VPRINT defined in release build for the analyzer.  The usefulness for diagnostics outweighs any overhead from extra branches.

Tested:

Before, in a non-DEBUG build directory:
```
$ bin64/drrun -t drmemtrace -tool basic_counts -infile ../src/clients/drcachesim/tests/drmemtrace.allasm_x86_64.trace.zip -verbose 1 2>&1 | grep analyzer
```

After:
```
$ bin64/drrun -t drmemtrace -tool basic_counts -infile ../src/clients/drcachesim/tests/drmemtrace.allasm_x86_64.trace.zip -verbose 1 2>&1 | grep analyzer
[analyzer] Creating 12 worker threads
[analyzer] Worker 0 starting on trace shard 0 stream is 0x55f2e2113110
[analyzer] Worker 0 finished trace shard drmemtrace.allasm_x86_64.trace.zip
```

Issue: #7860