### PR TITLE
i#6672 C++17: Remove Android 32-bit CI

### DIFF
--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -250,7 +250,7 @@ jobs:
 
   send-failure-notification:
       uses: ./.github/workflows/failure-notification.yml
-      needs: [aarch64-cross-compile, arm-cross-compile, android-arm-cross-compile, android-aarch64-cross-compile, a64-on-x86]
+      needs: [aarch64-cross-compile, arm-cross-compile, android-aarch64-cross-compile, a64-on-x86]
       # By default, a failure in a job skips the jobs that need it. The
       # following expression ensures that failure-notification.yml is
       # always invoked.
@@ -259,7 +259,6 @@ jobs:
         test_suite_status: ${{ format('{0} {1} | {2} {3} | {4} {5} | {6} {7} | {8} {9}',
                                       'aarch64-cross-compile', needs.aarch64-cross-compile.result,
                                       'arm-cross-compile', needs.arm-cross-compile.result,
-                                      'android-arm-cross-compile', needs.android-arm-cross-compile.result,
                                       'android-aarch64-cross-compile', needs.android-aarch64-cross-compile.result,
                                       'a64-on-x86', needs.a64-on-x86.result) }}
         test_suite_results_only: ${{ join(needs.*.result, ',') }}

--- a/.github/workflows/ci-aarchxx-cross.yml
+++ b/.github/workflows/ci-aarchxx-cross.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2025 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2026 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -159,59 +159,6 @@ jobs:
         CI_TRIGGER: ${{ github.event_name }}
         CI_BRANCH: ${{ github.ref }}
         DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
-
-  # Android ARM cross-compile with gcc, no tests:
-  android-arm-cross-compile:
-    runs-on: ubuntu-22.04
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    # Cancel any prior runs for a PR (but do not cancel master branch runs).
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      if: ${{ github.event_name == 'pull_request' }}
-
-    - run: git fetch --no-tags --depth=1 origin master
-
-    # Fetch and install Android NDK for Android cross-compile build.
-    - name: Create Build Environment
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install doxygen vera++
-        cd /tmp
-        wget https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
-        unzip -q android-ndk-r10e-linux-x86_64.zip
-        export ANDROID_NDK_ROOT=/tmp/android-ndk-r10e
-        android-ndk-r10e/build/tools/make-standalone-toolchain.sh --arch=arm \
-          --toolchain=arm-linux-androideabi-4.9 --platform=android-21 \
-          --install-dir=/tmp/android-gcc-arm-ndk-10e
-        # Manually force using ld.bfd, setting CMAKE_LINKER does not work.
-        ln -sf ld.bfd /tmp/android-gcc-arm-ndk-10e/arm-linux-androideabi/bin/ld
-        ln -sf arm-linux-androideabi-ld.bfd \
-          /tmp/android-gcc-arm-ndk-10e/bin/arm-linux-androideabi-ld
-
-    - name: Setup cmake
-      uses: lukka/get-cmake@latest
-      with:
-        cmakeVersion: '3.26.4'
-
-    - name: Check if format checks are disabled
-      id: are_format_checks_disabled
-      uses: ./.github/actions/are-format-checks-disabled
-
-    - name: Run Suite
-      working-directory: ${{ github.workspace }}
-      env:
-        DYNAMORIO_CROSS_ANDROID_ONLY: yes
-        DYNAMORIO_ANDROID_TOOLCHAIN: /tmp/android-gcc-arm-ndk-10e
-        CI_TRIGGER: ${{ github.event_name }}
-        CI_BRANCH: ${{ github.ref }}
-        DISABLE_FORMAT_CHECKS: ${{ steps.are_format_checks_disabled.outputs.disable_format_checks }}
-      run: ./suite/runsuite_wrapper.pl automated_ci 32_only
 
   # Android AArch64 cross-compile with LLVM, no tests:
   android-aarch64-cross-compile:


### PR DESCRIPTION
32-bit Android is no longer supported in mainstream Android, and the toolchain we were using doesn't support C++17 to which we'd like to upgrade. We've decided it is not worth the effort to upgrade the Android NDK and get it to work with our 32-bit build given the lack of 32-bit Android devices. We're dropping the CI build and removing it from the required builds for merges. We'll leave other support in the code base for now.

Issue: #6672