### PR TITLE
Align client thread stack on aarch64

### DIFF
--- a/core/drlibc/drlibc_aarch64.asm
+++ b/core/drlibc/drlibc_aarch64.asm
@@ -155,6 +155,7 @@ GLOBAL_LABEL(dynamorio_mach_syscall:)
  */
         DECLARE_FUNC(dynamorio_clone)
 GLOBAL_LABEL(dynamorio_clone:)
+        and      ARG2, ARG2, #-FRAME_ALIGNMENT /* Ensure stack alignment. */
         stp      ARG6, x0, [ARG2, #-16]! /* func is now on TOS of newsp */
         /* All args are already in syscall registers. */
         mov      SYSNUM_REG, #SYS_clone

--- a/core/ir/opnd.h
+++ b/core/ir/opnd.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2000-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -291,13 +291,14 @@ enum {
     REGPARM_6 = DR_REG_R6,
     REGPARM_7 = DR_REG_R7,
     NUM_REGPARM = 8,
+    REGPARM_END_ALIGN = 16,
 #    else
     DR_SYSNUM_REG = DR_REG_R7,
     NUM_REGPARM = 4,
+    REGPARM_END_ALIGN = 8,
 #    endif /* 64/32 */
     REDZONE_SIZE = 0,
     REGPARM_MINSTACK = 0,
-    REGPARM_END_ALIGN = 8,
 #elif defined(RISCV64)
     DR_SYSNUM_REG = DR_REG_A7,
     REGPARM_0 = DR_REG_A0,


### PR DESCRIPTION
Ensures the client thread stack is aligned on aarch64. It happens to be aligned today but it is fragile.

create_clone_record() aligns to XSTATE_ALIGNMENT which is set to REGPARM_END_ALIGN, which was 8 on AArch64. Here we change it to 16, along with adding an insurance alignment inside dynamorio_clone() (just like we have on x86).