### PR TITLE
i#7839 direct fallback: Use rwlock to reduce contention

### DIFF
--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -304,8 +304,10 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::pick_next_input_for_mode(
     }
     flexible_queue_t<input_ordinal_t> local_direct_targets;
     if (options_.direct_switch_fallbacks &&
+        // A direct switch requires a valid prev_index to have initiated it.
         prev_index != sched_type_t::INVALID_INPUT_ORDINAL &&
         inputs_[prev_index].switch_to_input != sched_type_t::INVALID_INPUT_ORDINAL) {
+        // Create a local copy for the loop below.
         // Use a read lock here to avoid contention which can significantly
         // degrade performance.
         std::shared_lock<std::shared_mutex> target_set_rlock(direct_target_rwlock_);

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -43,6 +43,7 @@
 #include <limits>
 #include <mutex>
 #include <random>
+#include <shared_mutex>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
@@ -302,8 +303,12 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::pick_next_input_for_mode(
         }
     }
     flexible_queue_t<input_ordinal_t> local_direct_targets;
-    if (options_.direct_switch_fallbacks) {
-        std::unique_lock<mutex_dbg_owned> target_set_lock(direct_target_lock_);
+    if (options_.direct_switch_fallbacks &&
+        prev_index != sched_type_t::INVALID_INPUT_ORDINAL &&
+        inputs_[prev_index].switch_to_input != sched_type_t::INVALID_INPUT_ORDINAL) {
+        // Use a read lock here to avoid contention which can significantly
+        // degrade performance.
+        std::shared_lock<std::shared_mutex> target_set_rlock(direct_target_rwlock_);
         local_direct_targets = direct_targets_;
     }
     size_t fallback_attempts = 0;
@@ -696,8 +701,17 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::process_marker(
         } else {
             input.switch_to_input = it->second;
             if (options_.direct_switch_fallbacks) {
-                std::unique_lock<mutex_dbg_owned> target_set_lock(direct_target_lock_);
-                if (!direct_targets_.find(input.switch_to_input)) {
+                bool target_recorded = false;
+                // Avoid the write lock for the common case of already added.
+                {
+                    std::shared_lock<std::shared_mutex> target_set_rlock(
+                        direct_target_rwlock_);
+                    if (direct_targets_.find(input.switch_to_input))
+                        target_recorded = true;
+                }
+                if (!target_recorded) {
+                    std::unique_lock<std::shared_mutex> target_set_wlock(
+                        direct_target_rwlock_);
                     VPRINT(this, 2, "Adding input #%d to direct target set\n",
                            input.switch_to_input);
                     direct_targets_.push(input.switch_to_input);
@@ -1403,7 +1417,7 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::mark_input_eof_for_mode(
 {
     if (options_.direct_switch_fallbacks) {
         VPRINT(this, 2, "Removing input #%dn from direct target set\n", input.index);
-        std::unique_lock<mutex_dbg_owned> target_set_lock(direct_target_lock_);
+        std::unique_lock<std::shared_mutex> target_set_wlock(direct_target_rwlock_);
         direct_targets_.erase(input.index);
     }
     return sched_type_t::STATUS_OK;

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -49,6 +49,7 @@
 #include <queue>
 #include <random>
 #include <set>
+#include <shared_mutex>
 #include <stack>
 #include <string>
 #include <unordered_map>
@@ -1272,9 +1273,9 @@ protected:
     // Inputs that are unscheduled indefinitely until directly targeted.
     input_queue_t unscheduled_priority_;
     std::minstd_rand rand_gen_;
-    // This lock protects direct_targets_.
+    // This read-write lock protects direct_targets_.
     // It should be acquired *after* both output or input locks.
-    mutex_dbg_owned direct_target_lock_;
+    std::shared_mutex direct_target_rwlock_;
     flexible_queue_t<input_ordinal_t> direct_targets_;
 };
 

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -1276,6 +1276,14 @@ protected:
     // This read-write lock protects direct_targets_.
     // It should be acquired *after* both output or input locks.
     std::shared_mutex direct_target_rwlock_;
+    // The set of inputs observed to have been targeted by direct switches.
+    // We use these as fallbacks to find alternate direct targets.
+    // We do not want to pick among the general input set as there are some
+    // inputs with different roles within the application (e.g., poller threads)
+    // which should not be activated by direct switches from main threads.
+    // Ideally, we would partition into separate scheduling trees as the inputs
+    // that are targeted can fall into different groups themselves, but we
+    // do not have that information and it may be difficult to capture.
     flexible_queue_t<input_ordinal_t> direct_targets_;
 };
 


### PR DESCRIPTION
The drmemtrace scheduler direct_switch_fallbacks feature's lock was adding so much contention it was causing uneven schedules. Switching to a read-write lock solves that.

Tested on a large 80-virtual-core scheduling with
direct_switch_fallbacks turned on. Without the fix, we consistently see a couple of cores with 100x fewer total records (instructions + idles) than the busiest cores. Profiling showed lock contention as a problem. With the fix, the least busy core's record count is only 2x smaller than the busiest core, which is about what we see on a real run (instruction count, without tracing). This also matches what we see with drmemtrace scheduling with direct_switch_fallbacks turned off. Additionally, a profile shows the lock contention on the direct_target_lock is no longer a bottleneck.

Issue: #7839