### PR TITLE
i#7860 core balance: Report core ratio in schedule_stats

### DIFF
--- a/clients/drcachesim/tests/schedule_stats_maxcores.templatex
+++ b/clients/drcachesim/tests/schedule_stats_maxcores.templatex
@@ -27,4 +27,4 @@ Core #2 schedule: _[A-Ia-i_]*
 Core #3 schedule: _[A-Ia-i_]*
 Core #0 switch-outs:
 .*
-Ratio of largest to smallest core: .*
+Max activity ratio between cores: .*

--- a/clients/drcachesim/tests/schedule_stats_maxcores.templatex
+++ b/clients/drcachesim/tests/schedule_stats_maxcores.templatex
@@ -27,3 +27,4 @@ Core #2 schedule: _[A-Ia-i_]*
 Core #3 schedule: _[A-Ia-i_]*
 Core #0 switch-outs:
 .*
+Ratio of largest to smallest core: .*

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -89,7 +89,7 @@ public:
     }
 
     double
-    get_core_ratio()
+    get_max_core_activity_ratio()
     {
         return max_core_activity_ratio_;
     }
@@ -953,7 +953,7 @@ test_core_ratio()
     };
     mock_schedule_stats_t tool(/*print_every=*/1, /*verbosity=*/1);
     run_schedule_stats_with_tool(tool, memrefs);
-    double ratio = tool.get_core_ratio();
+    double ratio = tool.get_max_core_activity_ratio();
     std::cerr << "Core ratio: " << ratio << "\n";
     assert(ratio > 2.999 && ratio <= 3.001);
     return true;

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -91,7 +91,7 @@ public:
     double
     get_core_ratio()
     {
-        return max_core_record_ratio_;
+        return max_core_activity_ratio_;
     }
 
     bool

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -88,6 +88,12 @@ public:
         return global_time_;
     }
 
+    double
+    get_core_ratio()
+    {
+        return max_core_record_ratio_;
+    }
+
     bool
     parallel_shard_memref(void *shard_data, const memref_t &memref) override
     {
@@ -159,12 +165,12 @@ private:
 
 // Bypasses the analyzer and scheduler for a controlled test sequence.
 // Alternates the per-core memref vectors in lockstep.
+// This version takes in the tool.
 static schedule_stats_t::counters_t
-run_schedule_stats(
-    const std::vector<std::vector<memref_t>> &memrefs,
+run_schedule_stats_with_tool(
+    mock_schedule_stats_t &tool, const std::vector<std::vector<memref_t>> &memrefs,
     const std::vector<std::vector<schedule_record_t>> *expected_record = nullptr)
 {
-    mock_schedule_stats_t tool(/*print_every=*/1, /*verbosity=*/1);
     struct per_core_t {
         void *worker_data;
         void *shard_data;
@@ -248,6 +254,17 @@ run_schedule_stats(
         }
     }
     return tool.get_total_counts();
+}
+
+// Bypasses the analyzer and scheduler for a controlled test sequence.
+// Alternates the per-core memref vectors in lockstep.
+static schedule_stats_t::counters_t
+run_schedule_stats(
+    const std::vector<std::vector<memref_t>> &memrefs,
+    const std::vector<std::vector<schedule_record_t>> *expected_record = nullptr)
+{
+    mock_schedule_stats_t tool(/*print_every=*/1, /*verbosity=*/1);
+    return run_schedule_stats_with_tool(tool, memrefs, expected_record);
 }
 
 static bool
@@ -903,6 +920,45 @@ test_syscall_latencies_with_kernel_trace()
     return true;
 }
 
+static bool
+test_core_ratio()
+{
+    static constexpr int64_t PID = 1234;
+    static constexpr int64_t TID = 242;
+    static constexpr addr_t INSTR_PC = 1001;
+    static constexpr size_t INSTR_SIZE = 4;
+    std::vector<std::vector<memref_t>> memrefs = {
+        {
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+        },
+        {
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+        },
+        {
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+            gen_instr(TID, INSTR_PC, INSTR_SIZE, PID),
+        },
+    };
+    mock_schedule_stats_t tool(/*print_every=*/1, /*verbosity=*/1);
+    run_schedule_stats_with_tool(tool, memrefs);
+    double ratio = tool.get_core_ratio();
+    std::cerr << "Core ratio: " << ratio << "\n";
+    assert(ratio > 2.999 && ratio <= 3.001);
+    return true;
+}
+
 } // namespace
 
 int
@@ -910,7 +966,7 @@ test_main(int argc, const char *argv[])
 {
     if (test_basic_stats() && test_basic_stats_with_syscall_trace() && test_idle() &&
         test_cpu_footprint() && test_syscall_latencies() &&
-        test_syscall_latencies_with_kernel_trace()) {
+        test_syscall_latencies_with_kernel_trace() && test_core_ratio()) {
         std::cerr << "schedule_stats_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -41,6 +41,7 @@
 #include <cassert>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -663,38 +664,50 @@ schedule_stats_t::aggregate_results(counters_t &total)
 {
     std::unordered_map<workload_tid_t, std::unordered_set<int64_t>, workload_tid_hash_t>
         cpu_footprint;
-    for (const auto &shard : shard_map_) {
+    int64_t min_records = std::numeric_limits<int64_t>::max();
+    int64_t max_records = std::numeric_limits<int64_t>::min();
+    for (const auto &[index, shard] : shard_map_) {
         // First update our per-shard data with per-shard stats from the scheduler.
-        get_scheduler_stats(shard.second->stream, shard.second->counters);
+        get_scheduler_stats(shard->stream, shard->counters);
 
-        total += shard.second->counters;
+        total += shard->counters;
 
-        for (const workload_tid_t wtid : shard.second->counters.threads) {
-            cpu_footprint[wtid].insert(shard.second->core);
+        // Compute the record count range among cores to give an idea of how "even"
+        // the schedule is. Maybe it would be fairer, for measuring analyzer worker
+        // thread load balancing, to count *all* records including loads/stores and
+        // markers, but the focus here is more on how a microarchitectural simulator
+        // would view these cores, so we focus on just instructions and idles.
+        // This still gives a good idea of the worker thread balancing.
+        int64_t records = shard->counters.instrs + shard->counters.idles;
+        min_records = std::min(records, min_records);
+        max_records = std::max(records, max_records);
+
+        for (const workload_tid_t wtid : shard->counters.threads) {
+            cpu_footprint[wtid].insert(shard->core);
         }
 
         // Sanity check against the scheduler's own stats, unless the trace
         // is pre-scheduled, or we're in core-serial mode where we don't have access
         // to the separate output streams, or we're in a unit test with a mock
         // stream and no stats.
-        if (TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard.second->filetype) ||
+        if (TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard->filetype) ||
             serial_stream_ != nullptr ||
-            shard.second->stream->get_schedule_statistic(
+            shard->stream->get_schedule_statistic(
                 memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_INPUT) < 0)
             continue;
         // We assume our counts fit in the get_schedule_statistic()'s double's 54-bit
         // mantissa and thus we can safely use "==".
         // Currently our switch count ignores idle-to-input.
-        assert(shard.second->counters.total_switches ==
-               shard.second->stream->get_schedule_statistic(
+        assert(shard->counters.total_switches ==
+               shard->stream->get_schedule_statistic(
                    memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_INPUT) +
-                   shard.second->stream->get_schedule_statistic(
+                   shard->stream->get_schedule_statistic(
                        memtrace_stream_t::SCHED_STAT_SWITCH_INPUT_TO_IDLE));
-        assert(shard.second->counters.direct_switch_requests ==
-               shard.second->stream->get_schedule_statistic(
+        assert(shard->counters.direct_switch_requests ==
+               shard->stream->get_schedule_statistic(
                    memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_ATTEMPTS));
-        assert(shard.second->counters.direct_switches ==
-               shard.second->stream->get_schedule_statistic(
+        assert(shard->counters.direct_switches ==
+               shard->stream->get_schedule_statistic(
                    memtrace_stream_t::SCHED_STAT_DIRECT_SWITCH_SUCCESSES));
     }
     // Our observed_migrations are counted on the destination core, while
@@ -709,6 +722,8 @@ schedule_stats_t::aggregate_results(counters_t &total)
     for (const auto &entry : cpu_footprint) {
         total.cores_per_thread->add(entry.second.size());
     }
+
+    max_core_record_ratio_ = static_cast<double>(max_records) / min_records;
 }
 
 bool
@@ -756,6 +771,7 @@ schedule_stats_t::print_results()
             std::cerr << "    ... (increase -verbose to see more)\n";
         }
     }
+    std::cerr << "Ratio of largest to smallest core: " << max_core_record_ratio_ << "\n";
     return true;
 }
 

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -664,23 +664,23 @@ schedule_stats_t::aggregate_results(counters_t &total)
 {
     std::unordered_map<workload_tid_t, std::unordered_set<int64_t>, workload_tid_hash_t>
         cpu_footprint;
-    int64_t min_records = std::numeric_limits<int64_t>::max();
-    int64_t max_records = std::numeric_limits<int64_t>::min();
+    int64_t min_activity = std::numeric_limits<int64_t>::max();
+    int64_t max_activity = std::numeric_limits<int64_t>::min();
     for (const auto &[index, shard] : shard_map_) {
         // First update our per-shard data with per-shard stats from the scheduler.
         get_scheduler_stats(shard->stream, shard->counters);
 
         total += shard->counters;
 
-        // Compute the record count range among cores to give an idea of how "even"
-        // the schedule is. Maybe it would be fairer, for measuring analyzer worker
-        // thread load balancing, to count *all* records including loads/stores and
-        // markers, but the focus here is more on how a microarchitectural simulator
-        // would view these cores, so we focus on just instructions and idles.
-        // This still gives a good idea of the worker thread balancing.
-        int64_t records = shard->counters.instrs + shard->counters.idles;
-        min_records = std::min(records, min_records);
-        max_records = std::max(records, max_records);
+        // Compute the activity range among cores to give an idea of how "even" the
+        // schedule is. For measuring analyzer worker thread load balancing, it would
+        // be fairer count all records including loads/stores and markers, but the
+        // focus here is more on how a microarchitectural simulator would view these
+        // cores, so we focus on just instructions and idles. This still gives a good
+        // idea of the worker thread balancing.
+        int64_t activity = shard->counters.instrs + shard->counters.idles;
+        min_activity = std::min(activity, min_activity);
+        max_activity = std::max(activity, max_activity);
 
         for (const workload_tid_t wtid : shard->counters.threads) {
             cpu_footprint[wtid].insert(shard->core);
@@ -723,7 +723,7 @@ schedule_stats_t::aggregate_results(counters_t &total)
         total.cores_per_thread->add(entry.second.size());
     }
 
-    max_core_record_ratio_ = static_cast<double>(max_records) / min_records;
+    max_core_activity_ratio_ = static_cast<double>(max_activity) / min_activity;
 }
 
 bool
@@ -771,7 +771,7 @@ schedule_stats_t::print_results()
             std::cerr << "    ... (increase -verbose to see more)\n";
         }
     }
-    std::cerr << "Ratio of largest to smallest core: " << max_core_record_ratio_ << "\n";
+    std::cerr << "Max activity ratio between cores: " << max_core_activity_ratio_ << "\n";
     return true;
 }
 

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -674,7 +674,7 @@ schedule_stats_t::aggregate_results(counters_t &total)
 
         // Compute the activity range among cores to give an idea of how "even" the
         // schedule is. For measuring analyzer worker thread load balancing, it would
-        // be fairer count all records including loads/stores and markers, but the
+        // be fairer to count all records including loads/stores and markers, but the
         // focus here is more on how a microarchitectural simulator would view these
         // cores, so we focus on just instructions and idles. This still gives a good
         // idea of the worker thread balancing.

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -479,6 +479,8 @@ protected:
     // remember the last core for each input.
     std::unordered_map<workload_tid_t, int64_t, workload_tid_hash_t> prev_core_;
     std::mutex prev_core_mutex_;
+    // Ratio of largest instructions+idles to smallest across the cores.
+    double max_core_record_ratio_;
 };
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -480,7 +480,7 @@ protected:
     std::unordered_map<workload_tid_t, int64_t, workload_tid_hash_t> prev_core_;
     std::mutex prev_core_mutex_;
     // Ratio of largest instructions+idles to smallest across the cores.
-    double max_core_record_ratio_;
+    double max_core_activity_ratio_;
 };
 
 } // namespace drmemtrace


### PR DESCRIPTION
Adds the ratio of instructions+idles between the max and min such count for all cores, in the schedule_stats tool. This is to indicate the load balancing when fed into a microarchitectural simulator; this also gives a good idea of the worker thread load balancing for analyzers (though loads/stores and markers are not included).

Adds a unit test.

Issue: #7860