### PR TITLE
i#6684 csod invariants: Disable thread exit check for core-sharded

### DIFF
--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2025 Google, LLC  All rights reserved.
+ * Copyright (c) 2021-2026 Google, LLC  All rights reserved.
  * **********************************************************/
 
 /*
@@ -5318,6 +5318,20 @@ check_core_sharded()
                                 /*ref_ordinal=*/4, /*last_timestamp=*/0,
                                 /*instrs_since_last_timestamp=*/1 },
                               "Failed to catch unexpected tid on core_idle"))
+            return false;
+    }
+    // Verify that no missing thread exit is reported for core-sharded.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_instr(TID_B, /*pc=*/2),
+            gen_instr(TID_B, /*pc=*/3),
+            gen_marker(IDLE_THREAD_ID, TRACE_MARKER_TYPE_CORE_IDLE, 1),
+        };
+        if (!run_csod_checker(memrefs, false))
             return false;
     }
     return true;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2017-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2017-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -205,6 +205,10 @@ invariant_checker_t::parallel_shard_exit(void *shard_data)
     }
     report_if_false(shard,
                     shard->saw_thread_exit_ ||
+                        // For core-sharded, even if we changed to per-tid tracking,
+                        // typically the trace ends early to avoid tail artifacts, so we
+                        // have to abandon this check.
+                        core_sharded_ ||
                         trace_incomplete_
                         // XXX i#6733: For online we sometimes see threads
                         // exiting w/o the tracer inserting an exit.  Until we figure


### PR DESCRIPTION
Disables the "Thread is missing exit" drmemtrace invariant check for core-sharded traces where even if we switch to per-software-thread tracking of exit records we would still have errors from the scheduler exiting early to avoid tail artifacts.

Adds a unit test; confirmed it fails without the fix:
```
$ ctest -V -R checker_test
16: Recording |Thread is missing exit| in T-1 @ ref # 6 (3 instrs since timestamp 0)
16: Unexpected error: Thread is missing exit at ref: 6
16: invariant_checker_test FAILED
1/1 Test #16: tool.drcachesim.invariant_checker_test ...***Failed    0.04 sec
```

Issue: #6684