### PR TITLE
i#7872: Remove CMake 3.19.7 pinning for x86 Linux CI

### DIFF
--- a/.github/workflows/ci-package.yml
+++ b/.github/workflows/ci-package.yml
@@ -96,12 +96,6 @@ jobs:
         sudo rsync -av ../extract/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
         sudo rsync -av ../extract/usr/include/i386-linux-gnu/ /usr/include/
 
-    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
-    - name: Setup newer cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.19.7'
-
     - name: Get Version
       id: version
       # We support setting the version and build for manual builds.

--- a/.github/workflows/ci-x86.yml
+++ b/.github/workflows/ci-x86.yml
@@ -1,5 +1,5 @@
 # **********************************************************
-# Copyright (c) 2020-2025 Google, Inc.  All rights reserved.
+# Copyright (c) 2020-2026 Google, Inc.  All rights reserved.
 # **********************************************************
 
 # Redistribution and use in source and binary forms, with or without
@@ -90,11 +90,6 @@ jobs:
           liblz4-dev g++-multilib libunwind-dev
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
 
-    - name: Setup newer cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.19.7'
-
     - name: Check if format checks are disabled
       id: are_format_checks_disabled
       uses: ./.github/actions/are-format-checks-disabled
@@ -142,12 +137,6 @@ jobs:
         sudo rsync -av ../extract/lib/i386-linux-gnu/ /usr/lib/i386-linux-gnu/
         sudo rsync -av ../extract/usr/include/i386-linux-gnu/ /usr/include/
         echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
-
-    # Use a newer cmake to avoid 32-bit toolchain problems (i#4830).
-    - name: Setup newer cmake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '3.19.7'
 
     - name: Check if format checks are disabled
       id: are_format_checks_disabled


### PR DESCRIPTION
Removes the CMake 3.19.7 pinning as that version is no longer available via the action step we're using.
The newer CMake versions seem to not have the problem that 3.20 had.

Fixes #7872
Fixes #4830