### PR TITLE
i#7868: Add record_schedule_stats tool version

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -353,9 +353,12 @@ record_analyzer_multi_t::create_analysis_tool_from_options(const std::string &to
             op_trim_after_instr.get_value(), op_encodings2regdeps.get_value(),
             op_filter_func_ids.get_value(), op_modify_marker_value.get_value(),
             op_filter_kernel.get_value(), op_verbose.get_value());
+    } else if (tool == SCHEDULE_STATS) {
+        return record_schedule_stats_tool_create(
+            op_schedule_stats_print_every.get_value(), op_verbose.get_value());
     }
     ERRMSG("Usage error: unsupported record analyzer type \"%s\".  Only " RECORD_FILTER
-           " is supported.\n",
+           " and " SCHEDULE_STATS " are supported.\n",
            tool.c_str());
     return nullptr;
 }

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -976,7 +976,7 @@ include:
 - Trimming the start (via -trim_before_timestamp) and end (via -trim_after_timestamp)
   of a trace.  Any now-empty shards are deleted entirely.
 
-- Created a core-sharded-on-disk trace by running in core-sharded mode.  It is
+- Creating a core-sharded-on-disk trace by running in core-sharded mode.  It is
   recommended to run the schedule_stats tool at the same time to gather schedule
   statistics when using a dynamic schedule.
 

--- a/clients/drcachesim/docs/drcachesim.dox.in
+++ b/clients/drcachesim/docs/drcachesim.dox.in
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -975,6 +975,10 @@ include:
 
 - Trimming the start (via -trim_before_timestamp) and end (via -trim_after_timestamp)
   of a trace.  Any now-empty shards are deleted entirely.
+
+- Created a core-sharded-on-disk trace by running in core-sharded mode.  It is
+  recommended to run the schedule_stats tool at the same time to gather schedule
+  statistics when using a dynamic schedule.
 
 A filter can be applied only to the start of a trace using the -filter_stop_timestamp
 option.

--- a/clients/drcachesim/launcher.cpp
+++ b/clients/drcachesim/launcher.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2015-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2015-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -324,7 +324,10 @@ _tmain(int argc, const TCHAR *targv[])
             FATAL_ERROR("invalid -outdir %s", op_outdir.get_value().c_str());
         }
     } else {
-        if (op_tool.get_value() == RECORD_FILTER) {
+        // We assume RECORD_FILTER isn't a substring of some other tool.
+        // We use it as the trigger since the other record tool, schedule_stats,
+        // should only be run if RECORD_FILTER is also being run.
+        if (op_tool.get_value().find(RECORD_FILTER) != std::string::npos) {
             record_analyzer = new record_analyzer_multi_t;
             if (!*record_analyzer) {
                 std::string error_string_ = record_analyzer->get_error_string();

--- a/clients/drcachesim/tests/record_filter_plus_stats.templatex
+++ b/clients/drcachesim/tests/record_filter_plus_stats.templatex
@@ -1,0 +1,14 @@
+#ifdef WINDOWS
+Hit delay threshold: enabling tracing.
+Exiting process after .* references.
+#else
+Hello, world!
+#endif
+Trace invariant checks passed
+Output .* entries from .* entries.
+.*
+Schedule stats tool results:
+.*
+Max activity ratio between cores: .*
+Basic counts tool results:
+.*

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1550,7 +1550,7 @@ invariant_checker_t::process_memref(const memref_t &memref)
         auto per_shard_unique = std::unique_ptr<per_shard_t>(new per_shard_t);
         per_shard = per_shard_unique.get();
         per_shard->stream = serial_stream_;
-        per_shard->shard_id_ = serial_stream_->get_shard_index();
+        per_shard->shard_id_ = shard_index;
         per_shard->tid_ = serial_stream_->get_tid();
         per_shard->last_next_trace_pc_ = serial_stream_->get_next_trace_pc();
         shard_map_[shard_index] = std::move(per_shard_unique);

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -57,7 +57,9 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-const std::string schedule_stats_t::TOOL_NAME = "Schedule stats tool";
+template <typename RecordType>
+const std::string schedule_stats_template_t<RecordType>::TOOL_NAME =
+    "Schedule stats tool";
 
 analysis_tool_t *
 schedule_stats_tool_create(uint64_t print_every, unsigned int verbose)
@@ -65,37 +67,154 @@ schedule_stats_tool_create(uint64_t print_every, unsigned int verbose)
     return new schedule_stats_t(print_every, verbose);
 }
 
-schedule_stats_t::schedule_stats_t(uint64_t print_every, unsigned int verbose)
+record_analysis_tool_t *
+record_schedule_stats_tool_create(uint64_t print_every, unsigned int verbose)
+{
+    return new record_schedule_stats_t(print_every, verbose);
+}
+
+/******************************************************************************
+ * Specializations for schedule_stats_template_t<trace_entry_t>, aka
+ * schedule_stats_t.
+ */
+
+template <>
+trace_type_t
+schedule_stats_template_t<memref_t>::get_record_type(memref_t record)
+{
+    return record.marker.type;
+}
+
+template <>
+bool
+schedule_stats_template_t<memref_t>::is_record_marker(memref_t record,
+                                                      trace_marker_type_t &type,
+                                                      uintptr_t &value)
+{
+    if (record.marker.type != TRACE_TYPE_MARKER)
+        return false;
+    type = record.marker.marker_type;
+    value = record.marker.marker_value;
+    return true;
+}
+
+template <>
+bool
+schedule_stats_template_t<memref_t>::is_record_instr(memref_t record, addr_t *pc,
+                                                     size_t *size)
+{
+    if (type_is_instr(record.instr.type)) {
+        if (pc != nullptr)
+            *pc = record.instr.addr;
+        if (size != nullptr)
+            *size = record.instr.size;
+        return true;
+    }
+    return false;
+}
+
+template <>
+bool
+schedule_stats_template_t<memref_t>::get_record_tid(memref_t record, memref_tid_t &tid)
+{
+    if (record.marker.tid == INVALID_THREAD_ID)
+        return false;
+    tid = record.marker.tid;
+    return true;
+}
+
+/******************************************************************************
+ * Specializations for schedule_stats_template_t<memref_t>, aka
+ * record_schedule_stats_t.
+ */
+
+template <>
+trace_type_t
+schedule_stats_template_t<trace_entry_t>::get_record_type(trace_entry_t record)
+{
+    return static_cast<trace_type_t>(record.type);
+}
+
+template <>
+bool
+schedule_stats_template_t<trace_entry_t>::is_record_marker(trace_entry_t record,
+                                                           trace_marker_type_t &type,
+                                                           uintptr_t &value)
+{
+    if (record.type != TRACE_TYPE_MARKER)
+        return false;
+    type = static_cast<trace_marker_type_t>(record.size);
+    value = record.addr;
+    return true;
+}
+
+template <>
+bool
+schedule_stats_template_t<trace_entry_t>::is_record_instr(trace_entry_t record,
+                                                          addr_t *pc, size_t *size)
+{
+    if (type_is_instr(static_cast<trace_type_t>(record.type))) {
+        if (pc != nullptr)
+            *pc = record.addr;
+        if (size != nullptr)
+            *size = record.size;
+        return true;
+    }
+    return false;
+}
+
+template <>
+bool
+schedule_stats_template_t<trace_entry_t>::get_record_tid(trace_entry_t record,
+                                                         memref_tid_t &tid)
+{
+    if (record.type != TRACE_TYPE_THREAD)
+        return false;
+    tid = static_cast<memref_tid_t>(record.addr);
+    return true;
+}
+
+/********************************************************************
+ * schedule_stats_template_t routines that do not need to be specialized.
+ */
+
+template <typename RecordType>
+schedule_stats_template_t<RecordType>::schedule_stats_template_t(uint64_t print_every,
+                                                                 unsigned int verbose)
     : knob_print_every_(print_every)
     , knob_verbose_(verbose)
 {
     // Empty.
 }
 
-schedule_stats_t::~schedule_stats_t()
+template <typename RecordType>
+schedule_stats_template_t<RecordType>::~schedule_stats_template_t()
 {
     for (auto &iter : shard_map_) {
         delete iter.second;
     }
 }
 
+template <typename RecordType>
 std::string
-schedule_stats_t::initialize_stream(memtrace_stream_t *serial_stream)
+schedule_stats_template_t<RecordType>::initialize_stream(memtrace_stream_t *serial_stream)
 {
     serial_stream_ = serial_stream;
     return "";
 }
 
+template <typename RecordType>
 std::string
-schedule_stats_t::initialize_shard_type(shard_type_t shard_type)
+schedule_stats_template_t<RecordType>::initialize_shard_type(shard_type_t shard_type)
 {
     if (shard_type != SHARD_BY_CORE)
         return "Only core-sharded operation is supported";
     return "";
 }
 
+template <typename RecordType>
 bool
-schedule_stats_t::process_memref(const memref_t &memref)
+schedule_stats_template_t<RecordType>::process_memref(const RecordType &record)
 {
     per_shard_t *per_shard;
     const auto &lookup = shard_map_.find(serial_stream_->get_output_cpuid());
@@ -108,22 +227,24 @@ schedule_stats_t::process_memref(const memref_t &memref)
         shard_map_[per_shard->core] = per_shard;
     } else
         per_shard = lookup->second;
-    if (!parallel_shard_memref(reinterpret_cast<void *>(per_shard), memref)) {
-        error_string_ = per_shard->error;
+    if (!parallel_shard_memref(reinterpret_cast<void *>(per_shard), record)) {
+        this->error_string_ = per_shard->error;
         return false;
     }
     return true;
 }
 
+template <typename RecordType>
 bool
-schedule_stats_t::parallel_shard_supported()
+schedule_stats_template_t<RecordType>::parallel_shard_supported()
 {
     return true;
 }
 
+template <typename RecordType>
 void *
-schedule_stats_t::parallel_shard_init_stream(int shard_index, void *worker_data,
-                                             memtrace_stream_t *stream)
+schedule_stats_template_t<RecordType>::parallel_shard_init_stream(
+    int shard_index, void *worker_data, memtrace_stream_t *stream)
 {
     auto per_shard = new per_shard_t(this);
     std::lock_guard<std::mutex> guard(shard_map_mutex_);
@@ -135,8 +256,9 @@ schedule_stats_t::parallel_shard_init_stream(int shard_index, void *worker_data,
     return reinterpret_cast<void *>(per_shard);
 }
 
+template <typename RecordType>
 bool
-schedule_stats_t::parallel_shard_exit(void *shard_data)
+schedule_stats_template_t<RecordType>::parallel_shard_exit(void *shard_data)
 {
     // Nothing (we read the shard data in print_results).
     per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
@@ -145,8 +267,10 @@ schedule_stats_t::parallel_shard_exit(void *shard_data)
     return true;
 }
 
+template <typename RecordType>
 void
-schedule_stats_t::get_scheduler_stats(memtrace_stream_t *stream, counters_t &counters)
+schedule_stats_template_t<RecordType>::get_scheduler_stats(memtrace_stream_t *stream,
+                                                           counters_t &counters)
 {
     counters.switches_input_to_input =
         static_cast<int64_t>(stream->get_schedule_statistic(
@@ -175,21 +299,25 @@ schedule_stats_t::get_scheduler_stats(memtrace_stream_t *stream, counters_t &cou
             memtrace_stream_t::SCHED_STAT_KERNEL_SYSCALL_SEQUENCE_INJECTIONS));
 }
 
+template <typename RecordType>
 std::string
-schedule_stats_t::parallel_shard_error(void *shard_data)
+schedule_stats_template_t<RecordType>::parallel_shard_error(void *shard_data)
 {
     per_shard_t *per_shard = reinterpret_cast<per_shard_t *>(shard_data);
     return per_shard->error;
 }
 
+template <typename RecordType>
 uint64_t
-schedule_stats_t::get_current_microseconds()
+schedule_stats_template_t<RecordType>::get_current_microseconds()
 {
     return get_microsecond_timestamp();
 }
 
+template <typename RecordType>
 bool
-schedule_stats_t::update_state_time(per_shard_t *shard, state_t state)
+schedule_stats_template_t<RecordType>::update_state_time(per_shard_t *shard,
+                                                         state_t state)
 {
     uint64_t cur = get_current_microseconds();
     assert(cur >= shard->segment_start_microseconds);
@@ -207,10 +335,11 @@ schedule_stats_t::update_state_time(per_shard_t *shard, state_t state)
 
 // shard->prev_workload_id and shard->prev_tid are cleared when this is called,
 // so we pass in the preserved values so there's no confusion.
+template <typename RecordType>
 void
-schedule_stats_t::record_context_switch(per_shard_t *shard, int64_t prev_workload_id,
-                                        int64_t prev_tid, int64_t workload_id,
-                                        int64_t tid, int64_t input_id, int64_t letter_ord)
+schedule_stats_template_t<RecordType>::record_context_switch(
+    per_shard_t *shard, int64_t prev_workload_id, int64_t prev_tid, int64_t workload_id,
+    int64_t tid, int64_t input_id, int64_t letter_ord)
 {
     bool add_to_counts =
         // Don't count switching from WAIT, or the initial entry on a core.
@@ -336,15 +465,20 @@ schedule_stats_t::record_context_switch(per_shard_t *shard, int64_t prev_workloa
     }
 }
 
+template <typename RecordType>
 bool
-schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
+schedule_stats_template_t<RecordType>::parallel_shard_memref(void *shard_data,
+                                                             const RecordType &record)
 {
     per_shard_t *shard = reinterpret_cast<per_shard_t *>(shard_data);
     int64_t input_id = shard->stream->get_input_id();
+    trace_marker_type_t marker_type = TRACE_MARKER_TYPE_RESERVED_END;
+    uintptr_t marker_value = 0;
+    bool is_marker = is_record_marker(record, marker_type, marker_value);
     assert(shard->stream->get_input_interface() != nullptr ||
-           (memref.marker.type == TRACE_TYPE_MARKER &&
-            (memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_IDLE ||
-             memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_WAIT)));
+           (is_marker &&
+            (marker_type == TRACE_MARKER_TYPE_CORE_IDLE ||
+             marker_type == TRACE_MARKER_TYPE_CORE_WAIT)));
     if (knob_verbose_ >= 4) {
         std::ostringstream line;
         memtrace_stream_t *input_stream = shard->stream->get_input_interface();
@@ -357,12 +491,12 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
              << (input_stream == nullptr ? -1 : input_stream->get_record_ordinal())
              << " refs, " << std::setw(9)
              << (input_stream == nullptr ? -1 : input_stream->get_instruction_ordinal())
-             << " instrs: " << std::setw(16) << trace_type_names[memref.marker.type];
-        if (type_is_instr(memref.instr.type))
-            line << " pc=" << std::hex << memref.instr.addr << std::dec;
-        else if (memref.marker.type == TRACE_TYPE_MARKER) {
-            line << " " << memref.marker.marker_type
-                 << " val=" << memref.marker.marker_value;
+             << " instrs: " << std::setw(16) << trace_type_names[get_record_type(record)];
+        addr_t pc = 0;
+        if (is_record_instr(record, &pc))
+            line << " pc=" << std::hex << pc << std::dec;
+        else if (is_marker) {
+            line << " " << marker_type << " val=" << marker_value;
         }
         line << "\n";
         std::cerr << line.str();
@@ -370,11 +504,9 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
     state_t prev_state = shard->cur_state;
     int64_t tid = INVALID_THREAD_ID;
     int64_t workload_id = INVALID_WORKLOAD_ID;
-    if (memref.marker.type == TRACE_TYPE_MARKER &&
-        memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_WAIT)
+    if (is_marker && marker_type == TRACE_MARKER_TYPE_CORE_WAIT)
         shard->cur_state = STATE_WAIT;
-    else if (memref.marker.type == TRACE_TYPE_MARKER &&
-             memref.marker.marker_type == TRACE_MARKER_TYPE_CORE_IDLE) {
+    else if (is_marker && marker_type == TRACE_MARKER_TYPE_CORE_IDLE) {
         // When analyzing dynamically scheduled trace records, we expect
         // scheduler_tmpl_t::stream_status_t::STATUS_IDLE to be converted to
         // a TRACE_MARKER_TYPE_CORE_IDLE with tid set to IDLE_THREAD_ID.
@@ -387,7 +519,11 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         // scheduler_tmpl_t::stream_status_t::STATUS_IDLE), which are converted
         // to a TRACE_MARKER_TYPE_CORE_IDLE with tid set to IDLE_THREAD_ID,
         // in the same manner as above.
-        assert(memref.marker.tid == dynamorio::drmemtrace::IDLE_THREAD_ID);
+#ifndef NDEBUG
+        memref_tid_t record_tid;
+#endif
+        assert(!get_record_tid(record, record_tid) ||
+               record_tid == dynamorio::drmemtrace::IDLE_THREAD_ID);
         tid = dynamorio::drmemtrace::IDLE_THREAD_ID;
         shard->cur_state = STATE_IDLE;
     } else {
@@ -397,11 +533,9 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
             ? workload_from_memref_tid(tid)
             : shard->stream->get_workload_id();
     }
-    if (memref.marker.type == TRACE_TYPE_MARKER &&
-        memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_START)
+    if (is_marker && marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_START)
         shard->in_syscall_trace = true;
-    else if (memref.marker.type == TRACE_TYPE_MARKER &&
-             memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_END)
+    else if (is_marker && marker_type == TRACE_MARKER_TYPE_SYSCALL_TRACE_END)
         shard->in_syscall_trace = false;
     if (shard->cur_state != prev_state) {
         if (!update_state_time(shard, prev_state))
@@ -455,7 +589,7 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         return true;
     }
 
-    if (type_is_instr(memref.instr.type)) {
+    if (is_record_instr(record)) {
         ++shard->counters.instrs;
         ++shard->cur_segment_instrs;
         shard->counters.idle_micros_at_last_instr = shard->counters.idle_microseconds;
@@ -498,23 +632,31 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
         }
         shard->saw_exit = false;
     }
-    if (memref.instr.tid != INVALID_THREAD_ID)
-        shard->counters.threads.insert(workload_tid_t(workload_id, memref.instr.tid));
-    if (memref.marker.type == TRACE_TYPE_MARKER) {
-        if (memref.marker.marker_type == TRACE_MARKER_TYPE_SYSCALL) {
+#ifndef NDEBUG
+    memref_tid_t record_tid;
+#endif
+    if (shard->stream->get_tid() != INVALID_THREAD_ID) {
+        assert(!get_record_tid(record, record_tid) ||
+               record_tid == shard->stream->get_tid());
+        shard->counters.threads.insert(
+            workload_tid_t(workload_id, shard->stream->get_tid()));
+    } else {
+        assert(!get_record_tid(record, record_tid));
+    }
+    if (is_marker) {
+        if (marker_type == TRACE_MARKER_TYPE_SYSCALL) {
             ++shard->counters.syscalls;
             shard->saw_syscall = true;
-            shard->last_syscall_number = static_cast<int>(memref.marker.marker_value);
-        } else if (memref.marker.marker_type ==
-                   TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL) {
+            shard->last_syscall_number = static_cast<int>(marker_value);
+        } else if (marker_type == TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL) {
             ++shard->counters.maybe_blocking_syscalls;
             shard->saw_syscall = true;
-        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH) {
+        } else if (marker_type == TRACE_MARKER_TYPE_DIRECT_THREAD_SWITCH) {
             ++shard->counters.direct_switch_requests;
-            shard->direct_switch_target = memref.marker.marker_value;
-        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_FILETYPE) {
-            shard->filetype = static_cast<intptr_t>(memref.marker.marker_value);
-        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
+            shard->direct_switch_target = marker_value;
+        } else if (marker_type == TRACE_MARKER_TYPE_FILETYPE) {
+            shard->filetype = static_cast<intptr_t>(marker_value);
+        } else if (marker_type == TRACE_MARKER_TYPE_TIMESTAMP) {
             if (shard->stream->is_record_kernel()) {
                 shard->error = "Kernel traces are not expected to have timestamps.";
                 return false;
@@ -536,14 +678,16 @@ schedule_stats_t::parallel_shard_memref(void *shard_data, const memref_t &memref
                     shard->stream->get_input_interface()->get_last_timestamp();
             }
         }
-    } else if (memref.exit.type == TRACE_TYPE_THREAD_EXIT)
+    } else if (get_record_type(record) == TRACE_TYPE_THREAD_EXIT)
         shard->saw_exit = true;
     return true;
 }
 
+template <typename RecordType>
 void
-schedule_stats_t::print_percentage(double numerator, double denominator,
-                                   const std::string &label)
+schedule_stats_template_t<RecordType>::print_percentage(double numerator,
+                                                        double denominator,
+                                                        const std::string &label)
 {
     double fraction;
     if (denominator == 0) {
@@ -556,8 +700,9 @@ schedule_stats_t::print_percentage(double numerator, double denominator,
     std::cerr << std::setw(12) << std::setprecision(2) << 100 * fraction << label;
 }
 
+template <typename RecordType>
 void
-schedule_stats_t::print_counters(const counters_t &counters)
+schedule_stats_template_t<RecordType>::print_counters(const counters_t &counters)
 {
     std::cerr << std::setw(12) << counters.threads.size() << " threads";
     if (!counters.threads.empty()) {
@@ -659,8 +804,9 @@ schedule_stats_t::print_counters(const counters_t &counters)
     }
 }
 
+template <typename RecordType>
 void
-schedule_stats_t::aggregate_results(counters_t &total)
+schedule_stats_template_t<RecordType>::aggregate_results(counters_t &total)
 {
     std::unordered_map<workload_tid_t, std::unordered_set<int64_t>, workload_tid_hash_t>
         cpu_footprint;
@@ -726,8 +872,9 @@ schedule_stats_t::aggregate_results(counters_t &total)
     max_core_activity_ratio_ = static_cast<double>(max_activity) / min_activity;
 }
 
+template <typename RecordType>
 bool
-schedule_stats_t::print_results()
+schedule_stats_template_t<RecordType>::print_results()
 {
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << "Total counts:\n";
@@ -775,17 +922,20 @@ schedule_stats_t::print_results()
     return true;
 }
 
-schedule_stats_t::counters_t
-schedule_stats_t::get_total_counts()
+template <typename RecordType>
+typename schedule_stats_template_t<RecordType>::counters_t
+schedule_stats_template_t<RecordType>::get_total_counts()
 {
     counters_t total(this);
     aggregate_results(total);
     return total;
 }
 
+template <typename RecordType>
 bool
-schedule_stats_t::get_switch_record(
-    int core, std::vector<schedule_stats_t::schedule_record_t> &record)
+schedule_stats_template_t<RecordType>::get_switch_record(
+    int core,
+    std::vector<schedule_stats_template_t<RecordType>::schedule_record_t> &record)
 {
     const auto &lookup = shard_map_.find(core);
     if (lookup == shard_map_.end())
@@ -793,6 +943,9 @@ schedule_stats_t::get_switch_record(
     record = lookup->second->switch_record;
     return true;
 }
+
+template class schedule_stats_template_t<memref_t>;
+template class schedule_stats_template_t<trace_entry_t>;
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -74,7 +74,7 @@ record_schedule_stats_tool_create(uint64_t print_every, unsigned int verbose)
 }
 
 /******************************************************************************
- * Specializations for schedule_stats_template_t<trace_entry_t>, aka
+ * Specializations for schedule_stats_template_t<memref_t>, aka
  * schedule_stats_t.
  */
 
@@ -124,7 +124,7 @@ schedule_stats_template_t<memref_t>::get_record_tid(memref_t record, memref_tid_
 }
 
 /******************************************************************************
- * Specializations for schedule_stats_template_t<memref_t>, aka
+ * Specializations for schedule_stats_template_t<trace_entry_t>, aka
  * record_schedule_stats_t.
  */
 

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -637,7 +637,7 @@ schedule_stats_template_t<RecordType>::parallel_shard_memref(void *shard_data,
 #endif
     if (shard->stream->get_tid() != INVALID_THREAD_ID) {
         assert(!get_record_tid(record, record_tid) ||
-               record_tid == shard->stream->get_tid());
+               tid_from_memref_tid(record_tid) == shard->stream->get_tid());
         shard->counters.threads.insert(
             workload_tid_t(workload_id, shard->stream->get_tid()));
     } else {

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -637,6 +637,8 @@ schedule_stats_template_t<RecordType>::parallel_shard_memref(void *shard_data,
 #endif
     if (shard->stream->get_tid() != INVALID_THREAD_ID) {
         assert(!get_record_tid(record, record_tid) ||
+               // Early header markers do not have a valid tid field.
+               record_tid == -1 || record_tid == INVALID_THREAD_ID ||
                tid_from_memref_tid(record_tid) == shard->stream->get_tid());
         shard->counters.threads.insert(
             workload_tid_t(workload_id, shard->stream->get_tid()));

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -78,7 +78,7 @@ public:
     bool
     parallel_shard_exit(void *shard_data) override;
     bool
-    parallel_shard_memref(void *shard_data, const RecordType &memref) override;
+    parallel_shard_memref(void *shard_data, const RecordType &record) override;
     std::string
     parallel_shard_error(void *shard_data) override;
 

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -52,16 +52,17 @@
 namespace dynamorio {
 namespace drmemtrace {
 
-class schedule_stats_t : public analysis_tool_t {
+template <typename RecordType>
+class schedule_stats_template_t : public analysis_tool_tmpl_t<RecordType> {
 public:
-    schedule_stats_t(uint64_t print_every, unsigned int verbose = 0);
-    ~schedule_stats_t() override;
+    schedule_stats_template_t(uint64_t print_every, unsigned int verbose = 0);
+    ~schedule_stats_template_t() override;
     std::string
     initialize_stream(memtrace_stream_t *serial_stream) override;
     std::string
     initialize_shard_type(shard_type_t shard_type) override;
     bool
-    process_memref(const memref_t &memref) override;
+    process_memref(const RecordType &memref) override;
     bool
     print_results() override;
     bool
@@ -77,7 +78,7 @@ public:
     bool
     parallel_shard_exit(void *shard_data) override;
     bool
-    parallel_shard_memref(void *shard_data, const memref_t &memref) override;
+    parallel_shard_memref(void *shard_data, const RecordType &memref) override;
     std::string
     parallel_shard_error(void *shard_data) override;
 
@@ -188,7 +189,7 @@ public:
     };
 
     struct counters_t {
-        explicit counters_t(schedule_stats_t *analyzer)
+        explicit counters_t(schedule_stats_template_t *analyzer)
             : analyzer(analyzer)
         {
             instrs_per_switch = analyzer->create_histogram(kSwitchBinSize);
@@ -247,7 +248,7 @@ public:
             }
             return *this;
         }
-        schedule_stats_t *analyzer;
+        schedule_stats_template_t *analyzer;
         // Statistics provided by scheduler.
         // XXX: Should we change all of these to uint64_t? Never negative: but signed
         // ints are generally recommended as better for the compiler.
@@ -381,7 +382,7 @@ protected:
     static constexpr int64_t INVALID_WORKLOAD_ID = -1;
 
     struct per_shard_t {
-        per_shard_t(schedule_stats_t *analyzer)
+        per_shard_t(schedule_stats_template_t *analyzer)
             : counters(analyzer)
         {
         }
@@ -440,6 +441,21 @@ protected:
         return hist_ptr;
     }
 
+    trace_type_t
+    get_record_type(RecordType record);
+
+    // Returns whether the given record is an instruction; if so, optionally
+    // returns its pc and size.
+    bool
+    is_record_instr(RecordType record, addr_t *pc = nullptr, size_t *size = nullptr);
+
+    // If the given record is a marker, returns true and its fields.
+    bool
+    is_record_marker(RecordType record, trace_marker_type_t &type, uintptr_t &value);
+
+    bool
+    get_record_tid(RecordType record, memref_tid_t &tid);
+
     void
     print_percentage(double numerator, double denominator, const std::string &label);
 
@@ -482,6 +498,10 @@ protected:
     // Ratio of largest instructions+idles to smallest across the cores.
     double max_core_activity_ratio_;
 };
+
+typedef schedule_stats_template_t<memref_t> schedule_stats_t;
+
+typedef schedule_stats_template_t<trace_entry_t> record_schedule_stats_t;
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/clients/drcachesim/tools/schedule_stats_create.h
+++ b/clients/drcachesim/tools/schedule_stats_create.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2023-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2023-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -54,6 +54,14 @@ namespace drmemtrace {
  */
 analysis_tool_t *
 schedule_stats_tool_create(uint64_t print_every, unsigned int verbose = 0);
+
+/**
+ * Creates a record analysis tool which counts the number and type of context switches
+ * in a core-sharded trace schedule.  The tool fails if run in any mode besides
+ * core-sharded.
+ */
+record_analysis_tool_t *
+record_schedule_stats_tool_create(uint64_t print_every, unsigned int verbose = 0);
 
 } // namespace drmemtrace
 } // namespace dynamorio

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -5238,6 +5238,14 @@ if (BUILD_CLIENTS)
       # it checks encodings).
       "opcode_mix")
 
+    # Test running record_schedule_stats at the same time as record_filte.
+    set(testname "tool.record_filter_plus_stats")
+    torun_record_filter("${testname}" ${ci_shared_app}
+      "record_filter_plus_stats"
+      # As above, we assume the app name starts with "s" here.
+      "${drcachesim_path}@-tool@record_filter:schedule_stats@-indir@${testname}.s*.dir/trace@-core_sharded@-cores@4@-outdir@${testname}.filtered.dir"
+      "basic_counts")
+
     if (X86 AND X64 AND ZLIB_FOUND)
         set(testname "tool.record_filter_encodings2regdeps")
         torun_record_filter("${testname}" ${ci_shared_app}


### PR DESCRIPTION
Templatizes the schedule_stats tool to provide a trace_entry_t "record_" version which can be run alongside record_filter for better statistics when creating new core-sharded-on-disk traces (running afterward
loses some stats only available from the live scheduler).

Tested:

Added a new regression test tool.record_filter_plus_stats.

Also tested manually:
```
$ bin64/drrun -t drmemtrace -core_sharded -tool record_filter:schedule_stats -cores 3 \
-indir ../src/clients/drcachesim/tests/drmemtrace.threadsig.x64.tracedir -verbose 1 -outdir foo
...
Core #0 schedule: DEA__A_A__A_A_D_E_A_D
Core #1 schedule: CGH__H____C_____________
Core #2 schedule: IBF_____BF__F______
...
$ ls -sh foo
total 992K
4.0K cpu_schedule.bin.zip              356K drmemtrace.core.000002.trace.zip
236K drmemtrace.core.000000.trace.zip  4.0K serial_schedule.bin.gz
392K drmemtrace.core.000001.trace.zip
```

Fixes #7868