### PR TITLE
i#2440 AArch64 IR: Add macros and tests for v8.1 LSE instructions

### DIFF
--- a/core/ir/aarch64/instr_create_api.h
+++ b/core/ir/aarch64/instr_create_api.h
@@ -4561,6 +4561,357 @@
  */
 #define INSTR_CREATE_stllrh(dc, Rt, Rn) instr_create_1dst_1src(dc, OP_stllrh, Rt, Rn)
 
+/** @name CAS single-register variants */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/**
+ * Creates a CAS single-register variant instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    CAS<order>  <Ws>, <Wt>, [<Xn|SP>{, #0}]
+ *    CAS<order>  <Xs>, <Xt>, [<Xn|SP>{, #0}]
+ *    CAS<order>B <Ws>, <Wt>, [<Xn|SP>{, #0}]
+ *    CAS<order>H <Ws>, <Wt>, [<Xn|SP>{, #0}]
+ * \endverbatim
+ * where \<order\> is A, AL, L, or absent.
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rs   The first source and destination register. Use W (Word, 32 bits)
+ *             for byte and halfword forms, and W or X (Extended, 64 bits) for
+ *             word and doubleword forms.
+ * \param Rt   The second source register. Use W (Word, 32 bits) for byte and
+ *             halfword forms, and W or X (Extended, 64 bits) for word and
+ *             doubleword forms.
+ * \param mem  The source and destination memory address operand constructed with the
+ *             function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, 0, opsz)
+ */
+#define INSTR_CREATE_cas(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_cas, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casa(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casa, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casab(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casab, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casah(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casah, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casal(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casal, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casalb, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casalh, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casb(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casb, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_cash(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_cash, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_casl(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_casl, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_caslb(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_caslb, Rs, mem, Rs, Rt, mem)
+#define INSTR_CREATE_caslh(dc, Rs, Rt, mem) \
+    instr_create_2dst_3src(dc, OP_caslh, Rs, mem, Rs, Rt, mem)
+/** @} */ /* end doxygen group */
+
+/** @name CASP pair variants */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/**
+ * Creates a CASP pair variant instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    CASP<order> <Ws1>, <Ws2>, <Wt1>, <Wt2>, [<Xn|SP>{, #0}]
+ *    CASP<order> <Xs1>, <Xs2>, <Xt1>, <Xt2>, [<Xn|SP>{, #0}]
+ * \endverbatim
+ * where \<order\> is A, AL, L, or absent.
+ * \param dc    The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rs1   The first source and destination register, W (Word, 32 bits)
+ *              or X (Extended, 64 bits).
+ * \param Rs2   The second source and destination register, W (Word, 32 bits)
+ *              or X (Extended, 64 bits).
+ * \param Rt1   The first source register, W (Word, 32 bits) or X (Extended, 64 bits).
+ * \param Rt2   The second source register, W (Word, 32 bits) or X (Extended, 64 bits).
+ * \param mem   The source and destination memory address operand constructed with the
+ *              function:
+ *              opnd_create_base_disp(Rn, DR_REG_NULL, 0, 0, opsz)
+ */
+#define INSTR_CREATE_casp(dc, Rs1, Rs2, Rt1, Rt2, mem) \
+    instr_create_3dst_5src(dc, OP_casp, Rs1, Rs2, mem, Rs1, Rs2, Rt1, Rt2, mem)
+#define INSTR_CREATE_caspa(dc, Rs1, Rs2, Rt1, Rt2, mem) \
+    instr_create_3dst_5src(dc, OP_caspa, Rs1, Rs2, mem, Rs1, Rs2, Rt1, Rt2, mem)
+#define INSTR_CREATE_caspal(dc, Rs1, Rs2, Rt1, Rt2, mem) \
+    instr_create_3dst_5src(dc, OP_caspal, Rs1, Rs2, mem, Rs1, Rs2, Rt1, Rt2, mem)
+#define INSTR_CREATE_caspl(dc, Rs1, Rs2, Rt1, Rt2, mem) \
+    instr_create_3dst_5src(dc, OP_caspl, Rs1, Rs2, mem, Rs1, Rs2, Rt1, Rt2, mem)
+/** @} */ /* end doxygen group */
+
+/** @name LSE atomic load-operation variants */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/**
+ * Creates an LSE atomic load-operation variant instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    LD<op><order>  <Ws>, <Wt>, [<Xn|SP>]
+ *    LD<op><order>  <Xs>, <Xt>, [<Xn|SP>]
+ *    LD<op><order>B <Ws>, <Wt>, [<Xn|SP>]
+ *    LD<op><order>H <Ws>, <Wt>, [<Xn|SP>]
+ * \endverbatim
+ * where \<op\> is ADD, CLR, EOR, SET, SMAX, SMIN, UMAX, or UMIN, and \<order\>
+ * is A, AL, L, or absent.
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rs   The first source register. Use W (Word, 32 bits) for byte and
+ *             halfword forms, and W or X (Extended, 64 bits) for word and
+ *             doubleword forms.
+ * \param Rt   The first destination register. Use W (Word, 32 bits) for byte
+ *             and halfword forms, and W or X (Extended, 64 bits) for word and
+ *             doubleword forms.
+ * \param mem  The source and destination memory address operand constructed with the
+ *             function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, 0, opsz)
+ */
+#define INSTR_CREATE_ldadd(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldadd, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldadda(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldadda, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddal(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddal, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddalb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddalh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldaddlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldaddlh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclr(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclr, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclra(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclra, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclrab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclrab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclrah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclrah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclral(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclral, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclralb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclralb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclralh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclralh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclrb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclrb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclrh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclrh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclrl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclrl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclrlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclrlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldclrlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldclrlh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeor(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeor, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeora(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeora, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeorab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeorab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeorah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeorah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeoral(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeoral, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeoralb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeoralb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeoralh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeoralh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeorb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeorb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeorh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeorh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeorl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeorl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeorlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeorlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldeorlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldeorlh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldset(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldset, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldseta(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldseta, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetal(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetal, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetalb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetalh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldseth(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldseth, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsetlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsetlh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmax(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmax, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxa(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxa, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxal(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxal, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxalb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxalh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmaxlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmaxlh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmin(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmin, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsmina(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsmina, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminal(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminal, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminalb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminalh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldsminlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldsminlh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumax(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumax, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxa(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxa, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxal(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxal, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxalb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxalh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumaxlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumaxlh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumin(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumin, Rt, mem, Rs, mem)
+#define INSTR_CREATE_ldumina(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_ldumina, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminal(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminal, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminalb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminalh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminlb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminlb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_lduminlh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_lduminlh, Rt, mem, Rs, mem)
+/** @} */ /* end doxygen group */
+
+/** @name LSE atomic swap variants */
+/** @{ */ /* doxygen start group; w/ DISTRIBUTE_GROUP_DOC=YES, one comment suffices. */
+/**
+ * Creates an LSE atomic swap variant instruction.
+ *
+ * This macro is used to encode the forms:
+ * \verbatim
+ *    SWP<order>  <Ws>, <Wt>, [<Xn|SP>]
+ *    SWP<order>  <Xs>, <Xt>, [<Xn|SP>]
+ *    SWP<order>B <Ws>, <Wt>, [<Xn|SP>]
+ *    SWP<order>H <Ws>, <Wt>, [<Xn|SP>]
+ * \endverbatim
+ * where \<order\> is A, AL, L, or absent.
+ * \param dc   The void * dcontext used to allocate memory for the #instr_t.
+ * \param Rs   The first source register. Use W (Word, 32 bits) for byte and
+ *             halfword forms, and W or X (Extended, 64 bits) for word and
+ *             doubleword forms.
+ * \param Rt   The first destination register. Use W (Word, 32 bits) for byte
+ *             and halfword forms, and W or X (Extended, 64 bits) for word and
+ *             doubleword forms.
+ * \param mem  The source and destination memory address operand constructed with the
+ *             function:
+ *             opnd_create_base_disp(Rn, DR_REG_NULL, 0, 0, opsz)
+ */
+#define INSTR_CREATE_swp(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swp, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpa(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpa, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpab(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpab, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpah(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpah, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpal(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpal, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpalb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpalb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpalh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpalh, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swph(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swph, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swpl(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swpl, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swplb(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swplb, Rt, mem, Rs, mem)
+#define INSTR_CREATE_swplh(dc, Rs, Rt, mem) \
+    instr_create_2dst_2src(dc, OP_swplh, Rt, mem, Rs, mem)
+/** @} */ /* end doxygen group */
+
 /**
  * Creates a LDAPR load-acquire instruction.
  *

--- a/suite/tests/api/ir_aarch64_v81.c
+++ b/suite/tests/api/ir_aarch64_v81.c
@@ -366,6 +366,404 @@ TEST_INSTR(stllrh)
     }
 }
 
+#define DEFINE_CAS_WORD_DOUBLE_TEST(name, mnemonic)                                \
+    TEST_INSTR(name)                                                               \
+    {                                                                              \
+        /* Testing the word form. */                                               \
+        TEST_LOOP_EXPECT(                                                          \
+            name, 6,                                                               \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Wn_six_offset_0[i]),           \
+                                opnd_create_reg(Wn_six_offset_1[i]),               \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],       \
+                                                      DR_REG_NULL, 0, 0, OPSZ_4)), \
+            {                                                                      \
+                EXPECT_DISASSEMBLY(                                                \
+                    mnemonic "%w0 %w0 (%x0)[4byte] -> %w0 (%x0)[4byte]",           \
+                    mnemonic "%w5 %w6 (%x7)[4byte] -> %w5 (%x7)[4byte]",           \
+                    mnemonic "%w10 %w11 (%x12)[4byte] -> %w10 (%x12)[4byte]",      \
+                    mnemonic "%w15 %w16 (%x17)[4byte] -> %w15 (%x17)[4byte]",      \
+                    mnemonic "%w20 %w21 (%x22)[4byte] -> %w20 (%x22)[4byte]",      \
+                    mnemonic "%w30 %w30 (%sp)[4byte] -> %w30 (%sp)[4byte]");       \
+                                                                                   \
+                EXPECT_TRUE(instr_reads_memory(instr));                            \
+                EXPECT_TRUE(instr_writes_memory(instr));                           \
+            });                                                                    \
+                                                                                   \
+        /* Testing the doubleword form. */                                         \
+        TEST_LOOP_EXPECT(                                                          \
+            name, 6,                                                               \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Xn_six_offset_0[i]),           \
+                                opnd_create_reg(Xn_six_offset_1[i]),               \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],       \
+                                                      DR_REG_NULL, 0, 0, OPSZ_8)), \
+            {                                                                      \
+                EXPECT_DISASSEMBLY(                                                \
+                    mnemonic "%x0 %x0 (%x0)[8byte] -> %x0 (%x0)[8byte]",           \
+                    mnemonic "%x5 %x6 (%x7)[8byte] -> %x5 (%x7)[8byte]",           \
+                    mnemonic "%x10 %x11 (%x12)[8byte] -> %x10 (%x12)[8byte]",      \
+                    mnemonic "%x15 %x16 (%x17)[8byte] -> %x15 (%x17)[8byte]",      \
+                    mnemonic "%x20 %x21 (%x22)[8byte] -> %x20 (%x22)[8byte]",      \
+                    mnemonic "%x30 %x30 (%sp)[8byte] -> %x30 (%sp)[8byte]");       \
+                                                                                   \
+                EXPECT_TRUE(instr_reads_memory(instr));                            \
+                EXPECT_TRUE(instr_writes_memory(instr));                           \
+            });                                                                    \
+    }
+
+#define DEFINE_CAS_BYTE_TEST(name, mnemonic)                                       \
+    TEST_INSTR(name)                                                               \
+    {                                                                              \
+        /* Testing the byte form. */                                               \
+        TEST_LOOP_EXPECT(                                                          \
+            name, 6,                                                               \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Wn_six_offset_0[i]),           \
+                                opnd_create_reg(Wn_six_offset_1[i]),               \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],       \
+                                                      DR_REG_NULL, 0, 0, OPSZ_1)), \
+            {                                                                      \
+                EXPECT_DISASSEMBLY(                                                \
+                    mnemonic "%w0 %w0 (%x0)[1byte] -> %w0 (%x0)[1byte]",           \
+                    mnemonic "%w5 %w6 (%x7)[1byte] -> %w5 (%x7)[1byte]",           \
+                    mnemonic "%w10 %w11 (%x12)[1byte] -> %w10 (%x12)[1byte]",      \
+                    mnemonic "%w15 %w16 (%x17)[1byte] -> %w15 (%x17)[1byte]",      \
+                    mnemonic "%w20 %w21 (%x22)[1byte] -> %w20 (%x22)[1byte]",      \
+                    mnemonic "%w30 %w30 (%sp)[1byte] -> %w30 (%sp)[1byte]");       \
+                                                                                   \
+                EXPECT_TRUE(instr_reads_memory(instr));                            \
+                EXPECT_TRUE(instr_writes_memory(instr));                           \
+            });                                                                    \
+    }
+
+#define DEFINE_CAS_HALF_TEST(name, mnemonic)                                       \
+    TEST_INSTR(name)                                                               \
+    {                                                                              \
+        /* Testing the halfword form. */                                           \
+        TEST_LOOP_EXPECT(                                                          \
+            name, 6,                                                               \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Wn_six_offset_0[i]),           \
+                                opnd_create_reg(Wn_six_offset_1[i]),               \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],       \
+                                                      DR_REG_NULL, 0, 0, OPSZ_2)), \
+            {                                                                      \
+                EXPECT_DISASSEMBLY(                                                \
+                    mnemonic "%w0 %w0 (%x0)[2byte] -> %w0 (%x0)[2byte]",           \
+                    mnemonic "%w5 %w6 (%x7)[2byte] -> %w5 (%x7)[2byte]",           \
+                    mnemonic "%w10 %w11 (%x12)[2byte] -> %w10 (%x12)[2byte]",      \
+                    mnemonic "%w15 %w16 (%x17)[2byte] -> %w15 (%x17)[2byte]",      \
+                    mnemonic "%w20 %w21 (%x22)[2byte] -> %w20 (%x22)[2byte]",      \
+                    mnemonic "%w30 %w30 (%sp)[2byte] -> %w30 (%sp)[2byte]");       \
+                                                                                   \
+                EXPECT_TRUE(instr_reads_memory(instr));                            \
+                EXPECT_TRUE(instr_writes_memory(instr));                           \
+            });                                                                    \
+    }
+
+DEFINE_CAS_WORD_DOUBLE_TEST(cas, "cas    ")
+DEFINE_CAS_WORD_DOUBLE_TEST(casa, "casa   ")
+DEFINE_CAS_BYTE_TEST(casab, "casab  ")
+DEFINE_CAS_HALF_TEST(casah, "casah  ")
+DEFINE_CAS_WORD_DOUBLE_TEST(casal, "casal  ")
+DEFINE_CAS_BYTE_TEST(casalb, "casalb ")
+DEFINE_CAS_HALF_TEST(casalh, "casalh ")
+DEFINE_CAS_BYTE_TEST(casb, "casb   ")
+DEFINE_CAS_HALF_TEST(cash, "cash   ")
+DEFINE_CAS_WORD_DOUBLE_TEST(casl, "casl   ")
+DEFINE_CAS_BYTE_TEST(caslb, "caslb  ")
+DEFINE_CAS_HALF_TEST(caslh, "caslh  ")
+
+#undef DEFINE_CAS_HALF_TEST
+#undef DEFINE_CAS_BYTE_TEST
+#undef DEFINE_CAS_WORD_DOUBLE_TEST
+
+#define DEFINE_CASP_WORD_DOUBLE_TEST(name, mnemonic)                                  \
+    TEST_INSTR(name)                                                                  \
+    {                                                                                 \
+        const reg_id_t Ws1[6] = { DR_REG_W0,  DR_REG_W4,  DR_REG_W10,                 \
+                                  DR_REG_W14, DR_REG_W20, DR_REG_W30 };               \
+        const reg_id_t Ws2[6] = { DR_REG_W1,  DR_REG_W5,  DR_REG_W11,                 \
+                                  DR_REG_W15, DR_REG_W21, DR_REG_WZR };               \
+        const reg_id_t Wt1[6] = { DR_REG_W0,  DR_REG_W6,  DR_REG_W12,                 \
+                                  DR_REG_W16, DR_REG_W22, DR_REG_W30 };               \
+        const reg_id_t Wt2[6] = { DR_REG_W1,  DR_REG_W7,  DR_REG_W13,                 \
+                                  DR_REG_W17, DR_REG_W23, DR_REG_WZR };               \
+        const reg_id_t Xs1[6] = { DR_REG_X0,  DR_REG_X4,  DR_REG_X10,                 \
+                                  DR_REG_X14, DR_REG_X20, DR_REG_X30 };               \
+        const reg_id_t Xs2[6] = { DR_REG_X1,  DR_REG_X5,  DR_REG_X11,                 \
+                                  DR_REG_X15, DR_REG_X21, DR_REG_XZR };               \
+        const reg_id_t Xt1[6] = { DR_REG_X0,  DR_REG_X6,  DR_REG_X12,                 \
+                                  DR_REG_X16, DR_REG_X22, DR_REG_X30 };               \
+        const reg_id_t Xt2[6] = { DR_REG_X1,  DR_REG_X7,  DR_REG_X13,                 \
+                                  DR_REG_X17, DR_REG_X23, DR_REG_XZR };               \
+                                                                                      \
+        /* Testing the word pair form. */                                             \
+        TEST_LOOP_EXPECT(                                                             \
+            name, 6,                                                                  \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Ws1[i]), opnd_create_reg(Ws2[i]), \
+                                opnd_create_reg(Wt1[i]), opnd_create_reg(Wt2[i]),     \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],          \
+                                                      DR_REG_NULL, 0, 0, OPSZ_8)),    \
+            {                                                                         \
+                EXPECT_DISASSEMBLY(                                                   \
+                    mnemonic "%w0 %w1 %w0 %w1 (%x0)[8byte] -> %w0 %w1 "               \
+                             "(%x0)[8byte]",                                          \
+                    mnemonic "%w4 %w5 %w6 %w7 (%x7)[8byte] -> %w4 %w5 "               \
+                             "(%x7)[8byte]",                                          \
+                    mnemonic "%w10 %w11 %w12 %w13 (%x12)[8byte] -> %w10 %w11 "        \
+                             "(%x12)[8byte]",                                         \
+                    mnemonic "%w14 %w15 %w16 %w17 (%x17)[8byte] -> %w14 %w15 "        \
+                             "(%x17)[8byte]",                                         \
+                    mnemonic "%w20 %w21 %w22 %w23 (%x22)[8byte] -> %w20 %w21 "        \
+                             "(%x22)[8byte]",                                         \
+                    mnemonic "%w30 %wzr %w30 %wzr (%sp)[8byte] -> %w30 %wzr "         \
+                             "(%sp)[8byte]");                                         \
+                                                                                      \
+                EXPECT_TRUE(instr_reads_memory(instr));                               \
+                EXPECT_TRUE(instr_writes_memory(instr));                              \
+            });                                                                       \
+                                                                                      \
+        /* Testing the doubleword pair form. */                                       \
+        TEST_LOOP_EXPECT(                                                             \
+            name, 6,                                                                  \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Xs1[i]), opnd_create_reg(Xs2[i]), \
+                                opnd_create_reg(Xt1[i]), opnd_create_reg(Xt2[i]),     \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],          \
+                                                      DR_REG_NULL, 0, 0, OPSZ_16)),   \
+            {                                                                         \
+                EXPECT_DISASSEMBLY(                                                   \
+                    mnemonic "%x0 %x1 %x0 %x1 (%x0)[16byte] -> %x0 %x1 "              \
+                             "(%x0)[16byte]",                                         \
+                    mnemonic "%x4 %x5 %x6 %x7 (%x7)[16byte] -> %x4 %x5 "              \
+                             "(%x7)[16byte]",                                         \
+                    mnemonic "%x10 %x11 %x12 %x13 (%x12)[16byte] -> %x10 %x11 "       \
+                             "(%x12)[16byte]",                                        \
+                    mnemonic "%x14 %x15 %x16 %x17 (%x17)[16byte] -> %x14 %x15 "       \
+                             "(%x17)[16byte]",                                        \
+                    mnemonic "%x20 %x21 %x22 %x23 (%x22)[16byte] -> %x20 %x21 "       \
+                             "(%x22)[16byte]",                                        \
+                    mnemonic "%x30 %xzr %x30 %xzr (%sp)[16byte] -> %x30 %xzr "        \
+                             "(%sp)[16byte]");                                        \
+                                                                                      \
+                EXPECT_TRUE(instr_reads_memory(instr));                               \
+                EXPECT_TRUE(instr_writes_memory(instr));                              \
+            });                                                                       \
+    }
+
+DEFINE_CASP_WORD_DOUBLE_TEST(casp, "casp   ")
+DEFINE_CASP_WORD_DOUBLE_TEST(caspa, "caspa  ")
+DEFINE_CASP_WORD_DOUBLE_TEST(caspal, "caspal ")
+DEFINE_CASP_WORD_DOUBLE_TEST(caspl, "caspl  ")
+
+#undef DEFINE_CASP_WORD_DOUBLE_TEST
+
+#define DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(name, mnemonic)                              \
+    TEST_INSTR(name)                                                                    \
+    {                                                                                   \
+        /* Testing the word form. */                                                    \
+        TEST_LOOP_EXPECT(                                                               \
+            name, 6,                                                                    \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Wn_six_offset_0[i]),                \
+                                opnd_create_reg(Wn_six_offset_1[i]),                    \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],            \
+                                                      DR_REG_NULL, 0, 0, OPSZ_4)),      \
+            {                                                                           \
+                EXPECT_DISASSEMBLY(mnemonic "%w0 (%x0)[4byte] -> %w0 (%x0)[4byte]",     \
+                                   mnemonic "%w5 (%x7)[4byte] -> %w6 (%x7)[4byte]",     \
+                                   mnemonic "%w10 (%x12)[4byte] -> %w11 (%x12)[4byte]", \
+                                   mnemonic "%w15 (%x17)[4byte] -> %w16 (%x17)[4byte]", \
+                                   mnemonic "%w20 (%x22)[4byte] -> %w21 (%x22)[4byte]", \
+                                   mnemonic "%w30 (%sp)[4byte] -> %w30 (%sp)[4byte]");  \
+                                                                                        \
+                EXPECT_TRUE(instr_reads_memory(instr));                                 \
+                EXPECT_TRUE(instr_writes_memory(instr));                                \
+            });                                                                         \
+                                                                                        \
+        /* Testing the doubleword form. */                                              \
+        TEST_LOOP_EXPECT(                                                               \
+            name, 6,                                                                    \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Xn_six_offset_0[i]),                \
+                                opnd_create_reg(Xn_six_offset_1[i]),                    \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],            \
+                                                      DR_REG_NULL, 0, 0, OPSZ_8)),      \
+            {                                                                           \
+                EXPECT_DISASSEMBLY(mnemonic "%x0 (%x0)[8byte] -> %x0 (%x0)[8byte]",     \
+                                   mnemonic "%x5 (%x7)[8byte] -> %x6 (%x7)[8byte]",     \
+                                   mnemonic "%x10 (%x12)[8byte] -> %x11 (%x12)[8byte]", \
+                                   mnemonic "%x15 (%x17)[8byte] -> %x16 (%x17)[8byte]", \
+                                   mnemonic "%x20 (%x22)[8byte] -> %x21 (%x22)[8byte]", \
+                                   mnemonic "%x30 (%sp)[8byte] -> %x30 (%sp)[8byte]");  \
+                                                                                        \
+                EXPECT_TRUE(instr_reads_memory(instr));                                 \
+                EXPECT_TRUE(instr_writes_memory(instr));                                \
+            });                                                                         \
+    }
+
+#define DEFINE_LSE_ATOMIC_BYTE_TEST(name, mnemonic)                                     \
+    TEST_INSTR(name)                                                                    \
+    {                                                                                   \
+        /* Testing the byte form. */                                                    \
+        TEST_LOOP_EXPECT(                                                               \
+            name, 6,                                                                    \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Wn_six_offset_0[i]),                \
+                                opnd_create_reg(Wn_six_offset_1[i]),                    \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],            \
+                                                      DR_REG_NULL, 0, 0, OPSZ_1)),      \
+            {                                                                           \
+                EXPECT_DISASSEMBLY(mnemonic "%w0 (%x0)[1byte] -> %w0 (%x0)[1byte]",     \
+                                   mnemonic "%w5 (%x7)[1byte] -> %w6 (%x7)[1byte]",     \
+                                   mnemonic "%w10 (%x12)[1byte] -> %w11 (%x12)[1byte]", \
+                                   mnemonic "%w15 (%x17)[1byte] -> %w16 (%x17)[1byte]", \
+                                   mnemonic "%w20 (%x22)[1byte] -> %w21 (%x22)[1byte]", \
+                                   mnemonic "%w30 (%sp)[1byte] -> %w30 (%sp)[1byte]");  \
+                                                                                        \
+                EXPECT_TRUE(instr_reads_memory(instr));                                 \
+                EXPECT_TRUE(instr_writes_memory(instr));                                \
+            });                                                                         \
+    }
+
+#define DEFINE_LSE_ATOMIC_HALF_TEST(name, mnemonic)                                     \
+    TEST_INSTR(name)                                                                    \
+    {                                                                                   \
+        /* Testing the halfword form. */                                                \
+        TEST_LOOP_EXPECT(                                                               \
+            name, 6,                                                                    \
+            INSTR_CREATE_##name(dc, opnd_create_reg(Wn_six_offset_0[i]),                \
+                                opnd_create_reg(Wn_six_offset_1[i]),                    \
+                                opnd_create_base_disp(Xn_six_offset_2_sp[i],            \
+                                                      DR_REG_NULL, 0, 0, OPSZ_2)),      \
+            {                                                                           \
+                EXPECT_DISASSEMBLY(mnemonic "%w0 (%x0)[2byte] -> %w0 (%x0)[2byte]",     \
+                                   mnemonic "%w5 (%x7)[2byte] -> %w6 (%x7)[2byte]",     \
+                                   mnemonic "%w10 (%x12)[2byte] -> %w11 (%x12)[2byte]", \
+                                   mnemonic "%w15 (%x17)[2byte] -> %w16 (%x17)[2byte]", \
+                                   mnemonic "%w20 (%x22)[2byte] -> %w21 (%x22)[2byte]", \
+                                   mnemonic "%w30 (%sp)[2byte] -> %w30 (%sp)[2byte]");  \
+                                                                                        \
+                EXPECT_TRUE(instr_reads_memory(instr));                                 \
+                EXPECT_TRUE(instr_writes_memory(instr));                                \
+            });                                                                         \
+    }
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldadd, "ldadd  ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldadda, "ldadda ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldaddab, "ldaddab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldaddah, "ldaddah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldaddal, "ldaddal ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldaddalb, "ldaddalb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldaddalh, "ldaddalh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldaddb, "ldaddb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldaddh, "ldaddh ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldaddl, "ldaddl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldaddlb, "ldaddlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldaddlh, "ldaddlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldclr, "ldclr  ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldclra, "ldclra ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldclrab, "ldclrab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldclrah, "ldclrah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldclral, "ldclral ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldclralb, "ldclralb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldclralh, "ldclralh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldclrb, "ldclrb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldclrh, "ldclrh ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldclrl, "ldclrl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldclrlb, "ldclrlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldclrlh, "ldclrlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldeor, "ldeor  ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldeora, "ldeora ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldeorab, "ldeorab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldeorah, "ldeorah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldeoral, "ldeoral ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldeoralb, "ldeoralb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldeoralh, "ldeoralh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldeorb, "ldeorb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldeorh, "ldeorh ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldeorl, "ldeorl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldeorlb, "ldeorlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldeorlh, "ldeorlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldset, "ldset  ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldseta, "ldseta ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsetab, "ldsetab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsetah, "ldsetah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsetal, "ldsetal ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsetalb, "ldsetalb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsetalh, "ldsetalh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsetb, "ldsetb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldseth, "ldseth ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsetl, "ldsetl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsetlb, "ldsetlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsetlh, "ldsetlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsmax, "ldsmax ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsmaxa, "ldsmaxa ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsmaxab, "ldsmaxab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsmaxah, "ldsmaxah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsmaxal, "ldsmaxal ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsmaxalb, "ldsmaxalb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsmaxalh, "ldsmaxalh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsmaxb, "ldsmaxb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsmaxh, "ldsmaxh ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsmaxl, "ldsmaxl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsmaxlb, "ldsmaxlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsmaxlh, "ldsmaxlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsmin, "ldsmin ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsmina, "ldsmina ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsminab, "ldsminab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsminah, "ldsminah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsminal, "ldsminal ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsminalb, "ldsminalb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsminalh, "ldsminalh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsminb, "ldsminb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsminh, "ldsminh ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldsminl, "ldsminl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldsminlb, "ldsminlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldsminlh, "ldsminlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldumax, "ldumax ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldumaxa, "ldumaxa ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldumaxab, "ldumaxab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldumaxah, "ldumaxah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldumaxal, "ldumaxal ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldumaxalb, "ldumaxalb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldumaxalh, "ldumaxalh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldumaxb, "ldumaxb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldumaxh, "ldumaxh ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldumaxl, "ldumaxl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(ldumaxlb, "ldumaxlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(ldumaxlh, "ldumaxlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldumin, "ldumin ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(ldumina, "ldumina ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(lduminab, "lduminab ")
+DEFINE_LSE_ATOMIC_HALF_TEST(lduminah, "lduminah ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(lduminal, "lduminal ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(lduminalb, "lduminalb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(lduminalh, "lduminalh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(lduminb, "lduminb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(lduminh, "lduminh ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(lduminl, "lduminl ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(lduminlb, "lduminlb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(lduminlh, "lduminlh ")
+
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(swp, "swp    ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(swpa, "swpa   ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(swpab, "swpab  ")
+DEFINE_LSE_ATOMIC_HALF_TEST(swpah, "swpah  ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(swpal, "swpal  ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(swpalb, "swpalb ")
+DEFINE_LSE_ATOMIC_HALF_TEST(swpalh, "swpalh ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(swpb, "swpb   ")
+DEFINE_LSE_ATOMIC_HALF_TEST(swph, "swph   ")
+DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST(swpl, "swpl   ")
+DEFINE_LSE_ATOMIC_BYTE_TEST(swplb, "swplb  ")
+DEFINE_LSE_ATOMIC_HALF_TEST(swplh, "swplh  ")
+
+#undef DEFINE_LSE_ATOMIC_HALF_TEST
+#undef DEFINE_LSE_ATOMIC_BYTE_TEST
+#undef DEFINE_LSE_ATOMIC_WORD_DOUBLE_TEST
+
 int
 main(int argc, char *argv[])
 {
@@ -389,6 +787,132 @@ main(int argc, char *argv[])
     RUN_INSTR_TEST(stllr);
     RUN_INSTR_TEST(stllrb);
     RUN_INSTR_TEST(stllrh);
+
+    /* LSE */
+    RUN_INSTR_TEST(cas);
+    RUN_INSTR_TEST(casa);
+    RUN_INSTR_TEST(casab);
+    RUN_INSTR_TEST(casah);
+    RUN_INSTR_TEST(casal);
+    RUN_INSTR_TEST(casalb);
+    RUN_INSTR_TEST(casalh);
+    RUN_INSTR_TEST(casb);
+    RUN_INSTR_TEST(cash);
+    RUN_INSTR_TEST(casl);
+    RUN_INSTR_TEST(caslb);
+    RUN_INSTR_TEST(caslh);
+    RUN_INSTR_TEST(casp);
+    RUN_INSTR_TEST(caspa);
+    RUN_INSTR_TEST(caspal);
+    RUN_INSTR_TEST(caspl);
+    RUN_INSTR_TEST(ldadd);
+    RUN_INSTR_TEST(ldadda);
+    RUN_INSTR_TEST(ldaddab);
+    RUN_INSTR_TEST(ldaddah);
+    RUN_INSTR_TEST(ldaddal);
+    RUN_INSTR_TEST(ldaddalb);
+    RUN_INSTR_TEST(ldaddalh);
+    RUN_INSTR_TEST(ldaddb);
+    RUN_INSTR_TEST(ldaddh);
+    RUN_INSTR_TEST(ldaddl);
+    RUN_INSTR_TEST(ldaddlb);
+    RUN_INSTR_TEST(ldaddlh);
+    RUN_INSTR_TEST(ldclr);
+    RUN_INSTR_TEST(ldclra);
+    RUN_INSTR_TEST(ldclrab);
+    RUN_INSTR_TEST(ldclrah);
+    RUN_INSTR_TEST(ldclral);
+    RUN_INSTR_TEST(ldclralb);
+    RUN_INSTR_TEST(ldclralh);
+    RUN_INSTR_TEST(ldclrb);
+    RUN_INSTR_TEST(ldclrh);
+    RUN_INSTR_TEST(ldclrl);
+    RUN_INSTR_TEST(ldclrlb);
+    RUN_INSTR_TEST(ldclrlh);
+    RUN_INSTR_TEST(ldeor);
+    RUN_INSTR_TEST(ldeora);
+    RUN_INSTR_TEST(ldeorab);
+    RUN_INSTR_TEST(ldeorah);
+    RUN_INSTR_TEST(ldeoral);
+    RUN_INSTR_TEST(ldeoralb);
+    RUN_INSTR_TEST(ldeoralh);
+    RUN_INSTR_TEST(ldeorb);
+    RUN_INSTR_TEST(ldeorh);
+    RUN_INSTR_TEST(ldeorl);
+    RUN_INSTR_TEST(ldeorlb);
+    RUN_INSTR_TEST(ldeorlh);
+    RUN_INSTR_TEST(ldset);
+    RUN_INSTR_TEST(ldseta);
+    RUN_INSTR_TEST(ldsetab);
+    RUN_INSTR_TEST(ldsetah);
+    RUN_INSTR_TEST(ldsetal);
+    RUN_INSTR_TEST(ldsetalb);
+    RUN_INSTR_TEST(ldsetalh);
+    RUN_INSTR_TEST(ldsetb);
+    RUN_INSTR_TEST(ldseth);
+    RUN_INSTR_TEST(ldsetl);
+    RUN_INSTR_TEST(ldsetlb);
+    RUN_INSTR_TEST(ldsetlh);
+    RUN_INSTR_TEST(ldsmax);
+    RUN_INSTR_TEST(ldsmaxa);
+    RUN_INSTR_TEST(ldsmaxab);
+    RUN_INSTR_TEST(ldsmaxah);
+    RUN_INSTR_TEST(ldsmaxal);
+    RUN_INSTR_TEST(ldsmaxalb);
+    RUN_INSTR_TEST(ldsmaxalh);
+    RUN_INSTR_TEST(ldsmaxb);
+    RUN_INSTR_TEST(ldsmaxh);
+    RUN_INSTR_TEST(ldsmaxl);
+    RUN_INSTR_TEST(ldsmaxlb);
+    RUN_INSTR_TEST(ldsmaxlh);
+    RUN_INSTR_TEST(ldsmin);
+    RUN_INSTR_TEST(ldsmina);
+    RUN_INSTR_TEST(ldsminab);
+    RUN_INSTR_TEST(ldsminah);
+    RUN_INSTR_TEST(ldsminal);
+    RUN_INSTR_TEST(ldsminalb);
+    RUN_INSTR_TEST(ldsminalh);
+    RUN_INSTR_TEST(ldsminb);
+    RUN_INSTR_TEST(ldsminh);
+    RUN_INSTR_TEST(ldsminl);
+    RUN_INSTR_TEST(ldsminlb);
+    RUN_INSTR_TEST(ldsminlh);
+    RUN_INSTR_TEST(ldumax);
+    RUN_INSTR_TEST(ldumaxa);
+    RUN_INSTR_TEST(ldumaxab);
+    RUN_INSTR_TEST(ldumaxah);
+    RUN_INSTR_TEST(ldumaxal);
+    RUN_INSTR_TEST(ldumaxalb);
+    RUN_INSTR_TEST(ldumaxalh);
+    RUN_INSTR_TEST(ldumaxb);
+    RUN_INSTR_TEST(ldumaxh);
+    RUN_INSTR_TEST(ldumaxl);
+    RUN_INSTR_TEST(ldumaxlb);
+    RUN_INSTR_TEST(ldumaxlh);
+    RUN_INSTR_TEST(ldumin);
+    RUN_INSTR_TEST(ldumina);
+    RUN_INSTR_TEST(lduminab);
+    RUN_INSTR_TEST(lduminah);
+    RUN_INSTR_TEST(lduminal);
+    RUN_INSTR_TEST(lduminalb);
+    RUN_INSTR_TEST(lduminalh);
+    RUN_INSTR_TEST(lduminb);
+    RUN_INSTR_TEST(lduminh);
+    RUN_INSTR_TEST(lduminl);
+    RUN_INSTR_TEST(lduminlb);
+    RUN_INSTR_TEST(lduminlh);
+    RUN_INSTR_TEST(swp);
+    RUN_INSTR_TEST(swpa);
+    RUN_INSTR_TEST(swpab);
+    RUN_INSTR_TEST(swpah);
+    RUN_INSTR_TEST(swpal);
+    RUN_INSTR_TEST(swpalb);
+    RUN_INSTR_TEST(swpalh);
+    RUN_INSTR_TEST(swpb);
+    RUN_INSTR_TEST(swph);
+    RUN_INSTR_TEST(swpl);
+    RUN_INSTR_TEST(swplb);
+    RUN_INSTR_TEST(swplh);
 
     print("All v8.1 tests complete.\n");
 #ifndef STANDALONE_DECODER


### PR DESCRIPTION
Adds previously missing INSTR_CREATE_* macros for v8.1 LSE atomic instructions and IR tests that make use of the macros.

Issue: #2440