### PR TITLE
i#7842: Add ISA feature to opcode_mix

### DIFF
--- a/clients/drcachesim/tests/offline-altbindir.templatex
+++ b/clients/drcachesim/tests/offline-altbindir.templatex
@@ -1,8 +1,8 @@
 #ifdef AARCH64
 Opcode mix tool results:
          126122 : total executed instructions
-          15924 :     bcond
-          15171 :       stp
+          15924 :     bcond (BASE)
+          15171 :       stp (BASE)
 .*
 #elif defined(ARM)
 ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.altbindir.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for arm

--- a/clients/drcachesim/tests/offline-altbindir.templatex
+++ b/clients/drcachesim/tests/offline-altbindir.templatex
@@ -1,8 +1,8 @@
 #ifdef AARCH64
 Opcode mix tool results:
          126122 : total executed instructions
-          15924 :     bcond (BASE)
-          15171 :       stp (BASE)
+          15924 :     bcond \(BASE\)
+          15171 :       stp \(BASE\)
 .*
 #elif defined(ARM)
 ERROR: failed to initialize analyzer: Directory setup failed: Failed sanity checks for thread log file .*/drmemtrace.altbindir.aarch64/raw/drmemtrace.threadsig..*.raw.gz: Architecture mismatch: trace recorded on aarch64 but tools built for arm

--- a/clients/drcachesim/tests/offline-gencode.templatex
+++ b/clients/drcachesim/tests/offline-gencode.templatex
@@ -7,7 +7,7 @@ Opcode mix tool results:
 #ifdef X86
  *[0-9][0-9][0-9] : *lahf
 #elif defined(AARCH64)
- *[0-9][0-9][0-9] : *psb (SPE)
+ *[0-9][0-9][0-9] : *psb \(SPE\)
 #elif defined(ARM)
  *[0-9][0-9][0-9] : *yield
 #else

--- a/clients/drcachesim/tests/offline-gencode.templatex
+++ b/clients/drcachesim/tests/offline-gencode.templatex
@@ -7,7 +7,7 @@ Opcode mix tool results:
 #ifdef X86
  *[0-9][0-9][0-9] : *lahf
 #elif defined(AARCH64)
- *[0-9][0-9][0-9] : *psb
+ *[0-9][0-9][0-9] : *psb (SPE)
 #elif defined(ARM)
  *[0-9][0-9][0-9] : *yield
 #else

--- a/clients/drcachesim/tests/offline-interval-opcode-mix-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-opcode-mix-output.templatex
@@ -2,8 +2,8 @@ Hello, world!
  *Opcode mix tool results:
     *[0-9]* : total executed instructions
 #ifdef AARCH64
-  *[1-9][0-9]* : *[a-z][ a-z]* \([a-z]*\)
-  *[1-9][0-9]* : *[a-z][ a-z]* \([a-z]*\)
+  *[1-9][0-9]* : *[a-z][ a-z]* \([a-z,A-Z,0-9]*\)
+  *[1-9][0-9]* : *[a-z][ a-z]* \([a-z,A-Z,0-9]*\)
 #else
   *[1-9][0-9]* : *[a-z][ a-z]*
   *[1-9][0-9]* : *[a-z][ a-z]*
@@ -13,8 +13,8 @@ Printing unmerged per-shard interval results:
 There were [0-9]* intervals created.
 ID:1 ending at instruction 10000 has [0-9]* opcodes and [0-9]* categories.
 #ifdef AARCH64
- *\[1\] Opcode: [ a-z]* \([0-9]*\) ISA feature: [a-z]* Count=[0-9]* PKI=[0-9\.]*
- *\[2\] Opcode: [ a-z]* \([0-9]*\) ISA feature: [a-z]* Count=[0-9]* PKI=[0-9\.]*
+ *\[1\] Opcode: [ a-z]* \([0-9]*\) ISA feature: [a-z,A-Z,0-9]* Count=[0-9]* PKI=[0-9\.]*
+ *\[2\] Opcode: [ a-z]* \([0-9]*\) ISA feature: [a-z,A-Z,0-9]* Count=[0-9]* PKI=[0-9\.]*
 #else
  *\[1\] Opcode: [ a-z]* \([0-9]*\) Count=[0-9]* PKI=[0-9\.]*
  *\[2\] Opcode: [ a-z]* \([0-9]*\) Count=[0-9]* PKI=[0-9\.]*

--- a/clients/drcachesim/tests/offline-interval-opcode-mix-output.templatex
+++ b/clients/drcachesim/tests/offline-interval-opcode-mix-output.templatex
@@ -1,12 +1,22 @@
 Hello, world!
  *Opcode mix tool results:
     *[0-9]* : total executed instructions
+#ifdef AARCH64
+  *[1-9][0-9]* : *[a-z][ a-z]* \([a-z]*\)
+  *[1-9][0-9]* : *[a-z][ a-z]* \([a-z]*\)
+#else
   *[1-9][0-9]* : *[a-z][ a-z]*
   *[1-9][0-9]* : *[a-z][ a-z]*
+#endif
 .*
 Printing unmerged per-shard interval results:
 There were [0-9]* intervals created.
 ID:1 ending at instruction 10000 has [0-9]* opcodes and [0-9]* categories.
+#ifdef AARCH64
+ *\[1\] Opcode: [ a-z]* \([0-9]*\) ISA feature: [a-z]* Count=[0-9]* PKI=[0-9\.]*
+ *\[2\] Opcode: [ a-z]* \([0-9]*\) ISA feature: [a-z]* Count=[0-9]* PKI=[0-9\.]*
+#else
  *\[1\] Opcode: [ a-z]* \([0-9]*\) Count=[0-9]* PKI=[0-9\.]*
  *\[2\] Opcode: [ a-z]* \([0-9]*\) Count=[0-9]* PKI=[0-9\.]*
+#endif
 .*

--- a/clients/drcachesim/tests/offline-opcode_mix.templatex
+++ b/clients/drcachesim/tests/offline-opcode_mix.templatex
@@ -1,8 +1,15 @@
 Hello, world!
 Opcode mix tool results:
     *[0-9]* : total executed instructions
+#ifdef AARCH64
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+#else
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
+#endif
 .*

--- a/clients/drcachesim/tests/offline-skip_instrs_opcode_mix.templatex
+++ b/clients/drcachesim/tests/offline-skip_instrs_opcode_mix.templatex
@@ -1,8 +1,15 @@
 Hello, world!
 Opcode mix tool results:
     *[0-9]* : total executed instructions
+#ifdef AARCH64
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+#else
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
+#endif
 .*

--- a/clients/drcachesim/tests/opcode_mix.templatex
+++ b/clients/drcachesim/tests/opcode_mix.templatex
@@ -2,8 +2,15 @@ Hello, world!
 ---- <application exited with code 0> ----
 Opcode mix tool results:
     *[0-9]* : total executed instructions
+#ifdef AARCH64
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+    *[0-9]* : [a-z ]* \([a-z,A-Z,0-9]*\)
+#else
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
     *[0-9]* : [a-z ]*
+#endif
 .*

--- a/clients/drcachesim/tests/opcode_mix_test.cpp
+++ b/clients/drcachesim/tests/opcode_mix_test.cpp
@@ -53,27 +53,12 @@ public:
         , instrs_(instrs)
     {
     }
-    std::unordered_map<int, int64_t>
-    get_opcode_counts(void *shard)
+
+    std::unordered_map<opcode_isa_feat_t, int64_t, opcode_isa_hasher_t>
+    get_opcode_isa_counts(void *shard)
     {
         shard_data_t *shard_data = reinterpret_cast<shard_data_t *>(shard);
-        std::unordered_map<int, int64_t> opcode_counts;
-        for (const auto &opcode_isa_count : shard_data->opcode_isa_counts) {
-            const int opcode = opcode_isa_count.first.opcode;
-            opcode_counts[opcode] += opcode_isa_count.second;
-        }
-        return opcode_counts;
-    }
-    std::unordered_map<uint, int64_t>
-    get_isa_feature_counts(void *shard)
-    {
-        shard_data_t *shard_data = reinterpret_cast<shard_data_t *>(shard);
-        std::unordered_map<uint, int64_t> isa_feature_counts;
-        for (const auto &opcode_isa_count : shard_data->opcode_isa_counts) {
-            const uint isa_feature = opcode_isa_count.first.isa_feature;
-            isa_feature_counts[isa_feature] += opcode_isa_count.second;
-        }
-        return isa_feature_counts;
+        return shard_data->opcode_isa_feat_counts;
     }
 
 protected:
@@ -157,37 +142,22 @@ check_opcode_mix(void *drcontext, bool use_module_mapper)
             return opcode_mix.parallel_shard_error(shard_data);
         }
     }
-    std::unordered_map<int, int64_t> opcode_counts =
-        opcode_mix.get_opcode_counts(shard_data);
-    if (opcode_counts.size() != 2) {
-        return "Found incorrect count of opcodes";
+    std::unordered_map<opcode_mix_t::opcode_isa_feat_t, int64_t,
+                       opcode_mix_t::opcode_isa_hasher_t>
+        opcode_isa_counts = opcode_mix.get_opcode_isa_counts(shard_data);
+    if (opcode_isa_counts.size() != 2) {
+        return "Found incorrect count of <opcode, isa_feat> pairs";
     }
-    int64_t nop_count = opcode_counts[instr_get_opcode(nop)];
+    int64_t nop_count = opcode_isa_counts[opcode_mix_t::opcode_isa_feat_t(
+        instr_get_opcode(nop), instr_get_isa_feature((byte *)nop, nop))];
     if (nop_count != 2) {
         return "Found incorrect nop count";
     }
-    int64_t ret_count = opcode_counts[instr_get_opcode(ret)];
+    int64_t ret_count = opcode_isa_counts[opcode_mix_t::opcode_isa_feat_t(
+        instr_get_opcode(ret), instr_get_isa_feature((byte *)ret, ret))];
     if (ret_count != 1) {
         return "Found incorrect ret count";
     }
-    std::unordered_map<uint, int64_t> isa_feature_counts =
-        opcode_mix.get_isa_feature_counts(shard_data);
-    if (isa_feature_counts.size() != 1) {
-        return "Found incorrect count of ISA features";
-    }
-#ifdef AARCH64
-    // Opcodes nop and ret both have ISA_FEAT_BASE.
-    if (isa_feature_counts[ISA_FEAT_BASE] != 3) {
-        return "Found incorrect ISA_FEAT_BASE count";
-    }
-#else
-    // TODO i#7842: once ISA feature is implemented for other architectures, update the
-    // check for this count accordingly. Currently, other architectures always return
-    // ISA_FEAT_UNKNOWN.
-    if (isa_feature_counts[ISA_FEAT_UNKNOWN] != 3) {
-        return "Found incorrect ISA_FEAT_UNKNOWN count";
-    }
-#endif
     std::cerr << "check_opcode_mix with use_module_mapper: " << use_module_mapper
               << " passed\n";
     return "";

--- a/clients/drcachesim/tests/opcode_mix_test.cpp
+++ b/clients/drcachesim/tests/opcode_mix_test.cpp
@@ -57,7 +57,12 @@ public:
     get_opcode_mix(void *shard)
     {
         shard_data_t *shard_data = reinterpret_cast<shard_data_t *>(shard);
-        return shard_data->opcode_counts;
+        std::unordered_map<int, int64_t> opcode_mix;
+        for (const auto &opcode_isa_count : shard_data->opcode_isa_counts) {
+            const int opcode = decode_opcode_from_key(opcode_isa_count.first);
+            opcode_mix[opcode] = opcode_isa_count.second;
+        }
+        return opcode_mix;
     }
 
 protected:

--- a/clients/drcachesim/tests/opcode_mix_test.cpp
+++ b/clients/drcachesim/tests/opcode_mix_test.cpp
@@ -54,15 +54,26 @@ public:
     {
     }
     std::unordered_map<int, int64_t>
-    get_opcode_mix(void *shard)
+    get_opcode_counts(void *shard)
     {
         shard_data_t *shard_data = reinterpret_cast<shard_data_t *>(shard);
-        std::unordered_map<int, int64_t> opcode_mix;
+        std::unordered_map<int, int64_t> opcode_counts;
         for (const auto &opcode_isa_count : shard_data->opcode_isa_counts) {
-            const int opcode = decode_opcode_from_key(opcode_isa_count.first);
-            opcode_mix[opcode] = opcode_isa_count.second;
+            const int opcode = opcode_isa_count.first.opcode;
+            opcode_counts[opcode] += opcode_isa_count.second;
         }
-        return opcode_mix;
+        return opcode_counts;
+    }
+    std::unordered_map<uint, int64_t>
+    get_isa_feature_counts(void *shard)
+    {
+        shard_data_t *shard_data = reinterpret_cast<shard_data_t *>(shard);
+        std::unordered_map<uint, int64_t> isa_feature_counts;
+        for (const auto &opcode_isa_count : shard_data->opcode_isa_counts) {
+            const uint isa_feature = opcode_isa_count.first.isa_feature;
+            isa_feature_counts[isa_feature] += opcode_isa_count.second;
+        }
+        return isa_feature_counts;
     }
 
 protected:
@@ -146,18 +157,37 @@ check_opcode_mix(void *drcontext, bool use_module_mapper)
             return opcode_mix.parallel_shard_error(shard_data);
         }
     }
-    std::unordered_map<int, int64_t> mix = opcode_mix.get_opcode_mix(shard_data);
-    if (mix.size() != 2) {
+    std::unordered_map<int, int64_t> opcode_counts =
+        opcode_mix.get_opcode_counts(shard_data);
+    if (opcode_counts.size() != 2) {
         return "Found incorrect count of opcodes";
     }
-    int64_t nop_count = mix[instr_get_opcode(nop)];
+    int64_t nop_count = opcode_counts[instr_get_opcode(nop)];
     if (nop_count != 2) {
         return "Found incorrect nop count";
     }
-    int64_t ret_count = mix[instr_get_opcode(ret)];
+    int64_t ret_count = opcode_counts[instr_get_opcode(ret)];
     if (ret_count != 1) {
         return "Found incorrect ret count";
     }
+    std::unordered_map<uint, int64_t> isa_feature_counts =
+        opcode_mix.get_isa_feature_counts(shard_data);
+    if (isa_feature_counts.size() != 1) {
+        return "Found incorrect count of ISA features";
+    }
+#ifdef AARCH64
+    // Opcodes nop and ret both have ISA_FEAT_BASE.
+    if (isa_feature_counts[ISA_FEAT_BASE] != 3) {
+        return "Found incorrect ISA_FEAT_BASE count";
+    }
+#else
+    // TODO i#7842: once ISA feature is implemented for other architectures, update the
+    // check for this count accordingly. Currently, other architectures always return
+    // ISA_FEAT_UNKNOWN.
+    if (isa_feature_counts[ISA_FEAT_UNKNOWN] != 3) {
+        return "Found incorrect ISA_FEAT_UNKNOWN count";
+    }
+#endif
     std::cerr << "check_opcode_mix with use_module_mapper: " << use_module_mapper
               << " passed\n";
     return "";

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -196,8 +196,8 @@ opcode_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     }
     // The opcode_data here will never be nullptr since we return
     // early if the prior add_decode_info returned an error.
-    ++shard->opcode_isa_counts[opcode_isa_feat_t(opcode_data->opcode_,
-                                                 opcode_data->isa_feature_)];
+    ++shard->opcode_isa_feat_counts[opcode_isa_feat_t(opcode_data->opcode_,
+                                                      opcode_data->isa_feature_)];
     ++shard->category_counts[opcode_data->category_];
     return true;
 }
@@ -219,7 +219,7 @@ opcode_mix_t::process_memref(const memref_t &memref)
     return true;
 }
 
-// Order by count first, then by key, if the key is an integer value.
+// Order first by count, then by key, if the key is an integer value.
 template <typename T>
 static bool
 cmp_val(const std::pair<T, int64_t> &l, const std::pair<T, int64_t> &r)
@@ -227,7 +227,7 @@ cmp_val(const std::pair<T, int64_t> &l, const std::pair<T, int64_t> &r)
     return (l.second > r.second) || (l.second == r.second && l.first < r.first);
 }
 
-// Specialization for opcode_isa_feat_t, used as key in opcode_isa_map.
+// Specialization for opcode_isa_feat_t, used as key in opcode_isa_feat_counts map.
 // Order first by count, then by opcode, then by ISA feature.
 template <>
 bool
@@ -283,8 +283,8 @@ opcode_mix_t::print_results()
     } else {
         for (const auto &shard : shard_map_) {
             aggregated.instr_count += shard.second->instr_count;
-            for (const auto &keyvals : shard.second->opcode_isa_counts) {
-                aggregated.opcode_isa_counts[keyvals.first] += keyvals.second;
+            for (const auto &keyvals : shard.second->opcode_isa_feat_counts) {
+                aggregated.opcode_isa_feat_counts[keyvals.first] += keyvals.second;
             }
             for (const auto &keyvals : shard.second->category_counts) {
                 aggregated.category_counts[keyvals.first] += keyvals.second;
@@ -294,11 +294,11 @@ opcode_mix_t::print_results()
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << std::setw(15) << total->instr_count
               << " : total executed instructions\n";
-    std::vector<std::pair<opcode_isa_feat_t, int64_t>> sorted_opcode_isa_counts(
-        total->opcode_isa_counts.begin(), total->opcode_isa_counts.end());
-    std::sort(sorted_opcode_isa_counts.begin(), sorted_opcode_isa_counts.end(),
+    std::vector<std::pair<opcode_isa_feat_t, int64_t>> sorted_opcode_isa_feat_counts(
+        total->opcode_isa_feat_counts.begin(), total->opcode_isa_feat_counts.end());
+    std::sort(sorted_opcode_isa_feat_counts.begin(), sorted_opcode_isa_feat_counts.end(),
               cmp_val<opcode_mix_t::opcode_isa_feat_t>);
-    for (const auto &keyvals : sorted_opcode_isa_counts) {
+    for (const auto &keyvals : sorted_opcode_isa_feat_counts) {
         const int opcode = keyvals.first.opcode;
         const uint isa_feature = keyvals.first.isa_feature;
         std::cerr << std::setw(15) << keyvals.second << " : " << std::setw(9)
@@ -338,7 +338,7 @@ opcode_mix_t::generate_shard_interval_snapshot(void *shard_data, uint64_t interv
     assert(shard_data != nullptr);
     auto &shard = *reinterpret_cast<shard_data_t *>(shard_data);
     auto *snap = new snapshot_t;
-    snap->opcode_isa_counts_ = shard.opcode_isa_counts;
+    snap->opcode_isa_feat_counts_ = shard.opcode_isa_feat_counts;
     snap->category_counts_ = shard.category_counts;
     return snap;
 }
@@ -353,8 +353,9 @@ opcode_mix_t::finalize_interval_snapshots(
     for (int i = static_cast<int>(interval_snapshots.size()) - 1; i > 0; --i) {
         auto &this_snap = *reinterpret_cast<snapshot_t *>(interval_snapshots[i]);
         auto &prior_snap = *reinterpret_cast<snapshot_t *>(interval_snapshots[i - 1]);
-        for (auto &opc_isa_count : this_snap.opcode_isa_counts_) {
-            opc_isa_count.second -= prior_snap.opcode_isa_counts_[opc_isa_count.first];
+        for (auto &opc_isa_feat_count : this_snap.opcode_isa_feat_counts_) {
+            opc_isa_feat_count.second -=
+                prior_snap.opcode_isa_feat_counts_[opc_isa_feat_count.first];
         }
         for (auto &cat_count : this_snap.category_counts_) {
             cat_count.second -= prior_snap.category_counts_[cat_count.first];
@@ -376,8 +377,9 @@ opcode_mix_t::combine_interval_snapshots(
             snap->get_interval_end_timestamp() != interval_end_timestamp) {
             continue;
         }
-        for (const auto opc_isa_count : snap->opcode_isa_counts_) {
-            super_snap->opcode_isa_counts_[opc_isa_count.first] += opc_isa_count.second;
+        for (const auto opc_isa_feat_count : snap->opcode_isa_feat_counts_) {
+            super_snap->opcode_isa_feat_counts_[opc_isa_feat_count.first] +=
+                opc_isa_feat_count.second;
         }
         for (const auto cat_count : snap->category_counts_) {
             super_snap->category_counts_[cat_count.first] += cat_count.second;
@@ -397,10 +399,10 @@ opcode_mix_t::print_interval_results(
         const auto *snap = reinterpret_cast<const snapshot_t *>(base_snap);
         std::cerr << "ID:" << snap->get_interval_id() << " ending at instruction "
                   << snap->get_instr_count_cumulative() << " has "
-                  << snap->opcode_isa_counts_.size() << " opcodes and "
+                  << snap->opcode_isa_feat_counts_.size() << " opcodes and "
                   << snap->category_counts_.size() << " categories.\n";
         std::vector<std::pair<opcode_isa_feat_t, int64_t>> sorted(
-            snap->opcode_isa_counts_.begin(), snap->opcode_isa_counts_.end());
+            snap->opcode_isa_feat_counts_.begin(), snap->opcode_isa_feat_counts_.end());
         std::sort(sorted.begin(), sorted.end(), cmp_val<opcode_mix_t::opcode_isa_feat_t>);
         for (int i = 0; i < PRINT_TOP_N && i < static_cast<int>(sorted.size()); ++i) {
             const int opcode = sorted[i].first.opcode;

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -401,7 +401,7 @@ opcode_mix_t::print_interval_results(
         const auto *snap = reinterpret_cast<const snapshot_t *>(base_snap);
         std::cerr << "ID:" << snap->get_interval_id() << " ending at instruction "
                   << snap->get_instr_count_cumulative() << " has "
-                  << snap->opcode_isa_counts_.size() << " opcodes" << " and "
+                  << snap->opcode_isa_counts_.size() << " opcodes and "
                   << snap->category_counts_.size() << " categories.\n";
         std::vector<std::pair<uint64_t, int64_t>> sorted(snap->opcode_isa_counts_.begin(),
                                                          snap->opcode_isa_counts_.end());

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -241,7 +241,7 @@ opcode_mix_t::decode_opcode_from_key(uint64_t key)
 uint
 opcode_mix_t::decode_isa_from_key(uint64_t key)
 {
-    return static_cast<uint>(key & 0xffffffff);
+    return static_cast<uint>(key & 0x0000ffff);
 }
 
 std::string

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -229,19 +229,24 @@ cmp_val(const std::pair<T, int64_t> &l, const std::pair<T, int64_t> &r)
 uint64_t
 opcode_mix_t::encode_opcode_isa(int opcode, uint isa_feature)
 {
+    // Combines opcode and isa_feature in a uint64_t by setting the opcode to the upper 32
+    // bits and the ISA feature enum constant to the lower 32 bits.
     return (static_cast<uint64_t>(opcode) << 32) | static_cast<uint64_t>(isa_feature);
 }
 
 int
 opcode_mix_t::decode_opcode_from_key(uint64_t key)
 {
+    // Shift the opcode to the lower 32 bits to retrieve it as an int.
     return static_cast<int>(key >> 32);
 }
 
 uint
 opcode_mix_t::decode_isa_from_key(uint64_t key)
 {
-    return static_cast<uint>(key & 0x0000ffff);
+    // The cast to uint truncates the upper 32 bits of the key, leaving the isa_feature
+    // as a uint.
+    return static_cast<uint>(key);
 }
 
 std::string

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -196,7 +196,8 @@ opcode_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     }
     // The opcode_data here will never be nullptr since we return
     // early if the prior add_decode_info returned an error.
-    ++shard->opcode_counts[opcode_data->opcode_];
+    ++shard->opcode_isa_counts[encode_opcode_isa(opcode_data->opcode_,
+                                                 opcode_data->isa_feature_)];
     ++shard->category_counts[opcode_data->category_];
     return true;
 }
@@ -218,10 +219,29 @@ opcode_mix_t::process_memref(const memref_t &memref)
     return true;
 }
 
+template <typename T>
 static bool
-cmp_val(const std::pair<int, int64_t> &l, const std::pair<int, int64_t> &r)
+cmp_val(const std::pair<T, int64_t> &l, const std::pair<T, int64_t> &r)
 {
     return (l.second > r.second) || (l.second == r.second && l.first < r.first);
+}
+
+uint64_t
+opcode_mix_t::encode_opcode_isa(int opcode, uint isa_feature)
+{
+    return (static_cast<uint64_t>(opcode) << 32) | static_cast<uint64_t>(isa_feature);
+}
+
+int
+opcode_mix_t::decode_opcode_from_key(uint64_t key)
+{
+    return static_cast<int>(key >> 32);
+}
+
+uint
+opcode_mix_t::decode_isa_from_key(uint64_t key)
+{
+    return static_cast<uint>(key & 0xffffffff);
 }
 
 std::string
@@ -266,8 +286,8 @@ opcode_mix_t::print_results()
     } else {
         for (const auto &shard : shard_map_) {
             aggregated.instr_count += shard.second->instr_count;
-            for (const auto &keyvals : shard.second->opcode_counts) {
-                aggregated.opcode_counts[keyvals.first] += keyvals.second;
+            for (const auto &keyvals : shard.second->opcode_isa_counts) {
+                aggregated.opcode_isa_counts[keyvals.first] += keyvals.second;
             }
             for (const auto &keyvals : shard.second->category_counts) {
                 aggregated.category_counts[keyvals.first] += keyvals.second;
@@ -277,19 +297,26 @@ opcode_mix_t::print_results()
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << std::setw(15) << total->instr_count
               << " : total executed instructions\n";
-    std::vector<std::pair<int, int64_t>> sorted(total->opcode_counts.begin(),
-                                                total->opcode_counts.end());
-    std::sort(sorted.begin(), sorted.end(), cmp_val);
-    for (const auto &keyvals : sorted) {
+    std::vector<std::pair<uint64_t, int64_t>> sorted_opcode_isa_counts(
+        total->opcode_isa_counts.begin(), total->opcode_isa_counts.end());
+    std::sort(sorted_opcode_isa_counts.begin(), sorted_opcode_isa_counts.end(),
+              cmp_val<uint64_t>);
+    for (const auto &keyvals : sorted_opcode_isa_counts) {
+        const int opcode = decode_opcode_from_key(keyvals.first);
+        const uint isa_feature = decode_isa_from_key(keyvals.first);
         std::cerr << std::setw(15) << keyvals.second << " : " << std::setw(9)
-                  << decode_opcode_name(keyvals.first) << "\n";
+                  << decode_opcode_name(opcode);
+        if (isa_feature != ISA_FEAT_UNKNOWN)
+            std::cerr << " (" << instr_get_isa_feature_name(isa_feature) << ")";
+        std::cerr << "\n";
     }
     std::cerr << "\n";
     std::cerr << std::setw(15) << total->category_counts.size()
               << " : sets of categories\n";
     std::vector<std::pair<uint, int64_t>> sorted_category_counts(
         total->category_counts.begin(), total->category_counts.end());
-    std::sort(sorted_category_counts.begin(), sorted_category_counts.end(), cmp_val);
+    std::sort(sorted_category_counts.begin(), sorted_category_counts.end(),
+              cmp_val<uint>);
     for (const auto &keyvals : sorted_category_counts) {
         std::cerr << std::setw(15) << keyvals.second << " : " << std::setw(9)
                   << get_category_names(keyvals.first) << "\n";
@@ -310,7 +337,7 @@ opcode_mix_t::generate_shard_interval_snapshot(void *shard_data, uint64_t interv
     assert(shard_data != nullptr);
     auto &shard = *reinterpret_cast<shard_data_t *>(shard_data);
     auto *snap = new snapshot_t;
-    snap->opcode_counts_ = shard.opcode_counts;
+    snap->opcode_isa_counts_ = shard.opcode_isa_counts;
     snap->category_counts_ = shard.category_counts;
     return snap;
 }
@@ -325,8 +352,8 @@ opcode_mix_t::finalize_interval_snapshots(
     for (int i = static_cast<int>(interval_snapshots.size()) - 1; i > 0; --i) {
         auto &this_snap = *reinterpret_cast<snapshot_t *>(interval_snapshots[i]);
         auto &prior_snap = *reinterpret_cast<snapshot_t *>(interval_snapshots[i - 1]);
-        for (auto &opc_count : this_snap.opcode_counts_) {
-            opc_count.second -= prior_snap.opcode_counts_[opc_count.first];
+        for (auto &opc_isa_count : this_snap.opcode_isa_counts_) {
+            opc_isa_count.second -= prior_snap.opcode_isa_counts_[opc_isa_count.first];
         }
         for (auto &cat_count : this_snap.category_counts_) {
             cat_count.second -= prior_snap.category_counts_[cat_count.first];
@@ -348,8 +375,8 @@ opcode_mix_t::combine_interval_snapshots(
             snap->get_interval_end_timestamp() != interval_end_timestamp) {
             continue;
         }
-        for (const auto opc_count : snap->opcode_counts_) {
-            super_snap->opcode_counts_[opc_count.first] += opc_count.second;
+        for (const auto opc_isa_count : snap->opcode_isa_counts_) {
+            super_snap->opcode_isa_counts_[opc_isa_count.first] += opc_isa_count.second;
         }
         for (const auto cat_count : snap->category_counts_) {
             super_snap->category_counts_[cat_count.first] += cat_count.second;
@@ -369,22 +396,26 @@ opcode_mix_t::print_interval_results(
         const auto *snap = reinterpret_cast<const snapshot_t *>(base_snap);
         std::cerr << "ID:" << snap->get_interval_id() << " ending at instruction "
                   << snap->get_instr_count_cumulative() << " has "
-                  << snap->opcode_counts_.size() << " opcodes"
-                  << " and " << snap->category_counts_.size() << " categories.\n";
-        std::vector<std::pair<int, int64_t>> sorted(snap->opcode_counts_.begin(),
-                                                    snap->opcode_counts_.end());
-        std::sort(sorted.begin(), sorted.end(), cmp_val);
+                  << snap->opcode_isa_counts_.size() << " opcodes" << " and "
+                  << snap->category_counts_.size() << " categories.\n";
+        std::vector<std::pair<uint64_t, int64_t>> sorted(snap->opcode_isa_counts_.begin(),
+                                                         snap->opcode_isa_counts_.end());
+        std::sort(sorted.begin(), sorted.end(), cmp_val<uint64_t>);
         for (int i = 0; i < PRINT_TOP_N && i < static_cast<int>(sorted.size()); ++i) {
+            const int opcode = decode_opcode_from_key(sorted[i].first);
+            const uint isa_feature = decode_isa_from_key(sorted[i].first);
             std::cerr << "   [" << i + 1 << "]"
-                      << " Opcode: " << decode_opcode_name(sorted[i].first) << " ("
-                      << sorted[i].first << ")"
-                      << " Count=" << sorted[i].second << " PKI="
+                      << " Opcode: " << decode_opcode_name(opcode) << " (" << opcode
+                      << ")";
+            if (isa_feature != ISA_FEAT_UNKNOWN)
+                std::cerr << " ISA feature: " << instr_get_isa_feature_name(isa_feature);
+            std::cerr << " Count=" << sorted[i].second << " PKI="
                       << sorted[i].second * 1000.0 / snap->get_instr_count_delta()
                       << "\n";
         }
         std::vector<std::pair<uint, int64_t>> sorted_cats(snap->category_counts_.begin(),
                                                           snap->category_counts_.end());
-        std::sort(sorted_cats.begin(), sorted_cats.end(), cmp_val);
+        std::sort(sorted_cats.begin(), sorted_cats.end(), cmp_val<uint>);
         for (int i = 0; i < PRINT_TOP_N && i < static_cast<int>(sorted_cats.size());
              ++i) {
             std::cerr << "   [" << i + 1 << "]"
@@ -411,6 +442,7 @@ opcode_mix_t::opcode_data_t::set_decode_info_derived(
 {
     opcode_ = instr_get_opcode(instr);
     category_ = instr_get_category(instr);
+    isa_feature_ = instr_get_isa_feature(decode_pc, instr);
     return "";
 }
 

--- a/clients/drcachesim/tools/opcode_mix.cpp
+++ b/clients/drcachesim/tools/opcode_mix.cpp
@@ -196,7 +196,7 @@ opcode_mix_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
     }
     // The opcode_data here will never be nullptr since we return
     // early if the prior add_decode_info returned an error.
-    ++shard->opcode_isa_counts[encode_opcode_isa(opcode_data->opcode_,
+    ++shard->opcode_isa_counts[opcode_isa_feat_t(opcode_data->opcode_,
                                                  opcode_data->isa_feature_)];
     ++shard->category_counts[opcode_data->category_];
     return true;
@@ -219,6 +219,7 @@ opcode_mix_t::process_memref(const memref_t &memref)
     return true;
 }
 
+// Order by count first, then by key, if the key is an integer value.
 template <typename T>
 static bool
 cmp_val(const std::pair<T, int64_t> &l, const std::pair<T, int64_t> &r)
@@ -226,27 +227,18 @@ cmp_val(const std::pair<T, int64_t> &l, const std::pair<T, int64_t> &r)
     return (l.second > r.second) || (l.second == r.second && l.first < r.first);
 }
 
-uint64_t
-opcode_mix_t::encode_opcode_isa(int opcode, uint isa_feature)
+// Specialization for opcode_isa_feat_t, used as key in opcode_isa_map.
+// Order first by count, then by opcode, then by ISA feature.
+template <>
+bool
+cmp_val<opcode_mix_t::opcode_isa_feat_t>(
+    const std::pair<opcode_mix_t::opcode_isa_feat_t, int64_t> &l,
+    const std::pair<opcode_mix_t::opcode_isa_feat_t, int64_t> &r)
 {
-    // Combines opcode and isa_feature in a uint64_t by setting the opcode to the upper 32
-    // bits and the ISA feature enum constant to the lower 32 bits.
-    return (static_cast<uint64_t>(opcode) << 32) | static_cast<uint64_t>(isa_feature);
-}
-
-int
-opcode_mix_t::decode_opcode_from_key(uint64_t key)
-{
-    // Shift the opcode to the lower 32 bits to retrieve it as an int.
-    return static_cast<int>(key >> 32);
-}
-
-uint
-opcode_mix_t::decode_isa_from_key(uint64_t key)
-{
-    // The cast to uint truncates the upper 32 bits of the key, leaving the isa_feature
-    // as a uint.
-    return static_cast<uint>(key);
+    return (l.second > r.second) ||
+        (l.second == r.second && l.first.opcode < r.first.opcode) ||
+        (l.second == r.second && l.first.opcode == r.first.opcode &&
+         l.first.isa_feature < r.first.isa_feature);
 }
 
 std::string
@@ -302,15 +294,19 @@ opcode_mix_t::print_results()
     std::cerr << TOOL_NAME << " results:\n";
     std::cerr << std::setw(15) << total->instr_count
               << " : total executed instructions\n";
-    std::vector<std::pair<uint64_t, int64_t>> sorted_opcode_isa_counts(
+    std::vector<std::pair<opcode_isa_feat_t, int64_t>> sorted_opcode_isa_counts(
         total->opcode_isa_counts.begin(), total->opcode_isa_counts.end());
     std::sort(sorted_opcode_isa_counts.begin(), sorted_opcode_isa_counts.end(),
-              cmp_val<uint64_t>);
+              cmp_val<opcode_mix_t::opcode_isa_feat_t>);
     for (const auto &keyvals : sorted_opcode_isa_counts) {
-        const int opcode = decode_opcode_from_key(keyvals.first);
-        const uint isa_feature = decode_isa_from_key(keyvals.first);
+        const int opcode = keyvals.first.opcode;
+        const uint isa_feature = keyvals.first.isa_feature;
         std::cerr << std::setw(15) << keyvals.second << " : " << std::setw(9)
                   << decode_opcode_name(opcode);
+        // TODO i#7842: print all ISA features once instr_get_isa_feature() is implemented
+        // for all architectures (or at least X86). Currently it's only implemented for
+        // AARCH64, so we avoid polluting the output of opcode_mix with <unknown> ISA
+        // feature.
         if (isa_feature != ISA_FEAT_UNKNOWN)
             std::cerr << " (" << instr_get_isa_feature_name(isa_feature) << ")";
         std::cerr << "\n";
@@ -403,15 +399,19 @@ opcode_mix_t::print_interval_results(
                   << snap->get_instr_count_cumulative() << " has "
                   << snap->opcode_isa_counts_.size() << " opcodes and "
                   << snap->category_counts_.size() << " categories.\n";
-        std::vector<std::pair<uint64_t, int64_t>> sorted(snap->opcode_isa_counts_.begin(),
-                                                         snap->opcode_isa_counts_.end());
-        std::sort(sorted.begin(), sorted.end(), cmp_val<uint64_t>);
+        std::vector<std::pair<opcode_isa_feat_t, int64_t>> sorted(
+            snap->opcode_isa_counts_.begin(), snap->opcode_isa_counts_.end());
+        std::sort(sorted.begin(), sorted.end(), cmp_val<opcode_mix_t::opcode_isa_feat_t>);
         for (int i = 0; i < PRINT_TOP_N && i < static_cast<int>(sorted.size()); ++i) {
-            const int opcode = decode_opcode_from_key(sorted[i].first);
-            const uint isa_feature = decode_isa_from_key(sorted[i].first);
+            const int opcode = sorted[i].first.opcode;
+            const uint isa_feature = sorted[i].first.isa_feature;
             std::cerr << "   [" << i + 1 << "]"
                       << " Opcode: " << decode_opcode_name(opcode) << " (" << opcode
                       << ")";
+            // TODO i#7842: print all ISA features once instr_get_isa_feature() is
+            // implemented for all architectures (or at least X86). Currently it's only
+            // implemented for AARCH64, so we avoid polluting the output of opcode_mix
+            // with <unknown> ISA feature.
             if (isa_feature != ISA_FEAT_UNKNOWN)
                 std::cerr << " ISA feature: " << instr_get_isa_feature_name(isa_feature);
             std::cerr << " Count=" << sorted[i].second << " PKI="

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -41,6 +41,7 @@
 #include <string>
 #include <utility>
 #include <unordered_map>
+#include <vector>
 
 #include "dr_api.h" // Must be before trace_entry.h from analysis_tool.h.
 #include "analysis_tool.h"
@@ -54,6 +55,26 @@ namespace drmemtrace {
 
 class opcode_mix_t : public analysis_tool_t {
 public:
+    /**
+     * Represent an opcode and its ISA feature, used as key in opcode_isa_counts map.
+     */
+    struct opcode_isa_feat_t {
+        opcode_isa_feat_t(int opc, uint feat)
+            : opcode(opc)
+            , isa_feature(feat)
+        {
+        }
+
+        bool
+        operator==(const opcode_isa_feat_t &other) const
+        {
+            return opcode == other.opcode && isa_feature == other.isa_feature;
+        }
+
+        int opcode = OP_INVALID;
+        uint isa_feature = ISA_FEAT_INVALID;
+    };
+
     // The module_file_path is optional and unused for traces with
     // OFFLINE_FILE_TYPE_ENCODINGS.
     // XXX: Once we update our toolchains to guarantee C++17 support we could use
@@ -101,15 +122,6 @@ public:
         std::vector<interval_state_snapshot_t *> &interval_snapshots) override;
 
 protected:
-    uint64_t
-    encode_opcode_isa(int opcode, uint isa_feature);
-
-    int
-    decode_opcode_from_key(uint64_t key);
-
-    uint
-    decode_isa_from_key(uint64_t key);
-
     std::string
     get_category_names(uint category);
 
@@ -145,11 +157,20 @@ protected:
             instr_t *instr, app_pc decode_pc) override;
     };
 
+    struct opcode_isa_hasher_t {
+        std::size_t
+        operator()(const opcode_isa_feat_t &k) const
+        {
+            return (static_cast<uint64_t>(k.opcode) << 32) | k.isa_feature;
+        }
+    };
+
     class snapshot_t : public interval_state_snapshot_t {
     public:
         // Snapshot the counts as cumulative stats, and then converted them to deltas in
         // finalize_interval_snapshots().  Printed interval results are all deltas.
-        std::unordered_map<uint64_t, int64_t> opcode_isa_counts_;
+        std::unordered_map<opcode_isa_feat_t, int64_t, opcode_isa_hasher_t>
+            opcode_isa_counts_;
         std::unordered_map<uint, int64_t> category_counts_;
     };
 
@@ -159,7 +180,11 @@ protected:
         }
 
         int64_t instr_count = 0;
-        std::unordered_map<uint64_t, int64_t> opcode_isa_counts;
+        std::unordered_map<opcode_isa_feat_t, int64_t, opcode_isa_hasher_t>
+            opcode_isa_counts;
+        // We report category sets frequency counts separately from <opcode, isa_feature>
+        // counts, as we only care about how many instructions belong to a given set of
+        // categories and not which <opcode, isa_feature> they belong to.
         std::unordered_map<uint, int64_t> category_counts;
         std::string error;
         dynamorio::drmemtrace::memtrace_stream_t *stream = nullptr;

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -101,6 +101,15 @@ public:
         std::vector<interval_state_snapshot_t *> &interval_snapshots) override;
 
 protected:
+    uint64_t
+    encode_opcode_isa(int opcode, uint isa_feature);
+
+    int
+    decode_opcode_from_key(uint64_t key);
+
+    uint
+    decode_isa_from_key(uint64_t key);
+
     std::string
     get_category_names(uint category);
 
@@ -108,15 +117,19 @@ protected:
     public:
         opcode_data_t()
             : opcode_(OP_INVALID)
+            , isa_feature_(ISA_FEAT_INVALID)
             , category_(DR_INSTR_CATEGORY_UNCATEGORIZED)
         {
         }
-        opcode_data_t(int opcode, uint category)
+        opcode_data_t(int opcode, uint isa_feature, uint category)
             : opcode_(opcode)
+            , isa_feature_(isa_feature)
             , category_(category)
         {
         }
         int opcode_;
+        // ISA feature of an instruction (e.g., SVE, SVE2 in AARCH64).
+        uint isa_feature_;
         /*
          * The category field is a uint instead of a dr_instr_category_t because
          * multiple category bits can be set when an instruction belongs to more
@@ -136,7 +149,7 @@ protected:
     public:
         // Snapshot the counts as cumulative stats, and then converted them to deltas in
         // finalize_interval_snapshots().  Printed interval results are all deltas.
-        std::unordered_map<int, int64_t> opcode_counts_;
+        std::unordered_map<uint64_t, int64_t> opcode_isa_counts_;
         std::unordered_map<uint, int64_t> category_counts_;
     };
 
@@ -146,7 +159,7 @@ protected:
         }
 
         int64_t instr_count = 0;
-        std::unordered_map<int, int64_t> opcode_counts;
+        std::unordered_map<uint64_t, int64_t> opcode_isa_counts;
         std::unordered_map<uint, int64_t> category_counts;
         std::string error;
         dynamorio::drmemtrace::memtrace_stream_t *stream = nullptr;

--- a/clients/drcachesim/tools/opcode_mix.h
+++ b/clients/drcachesim/tools/opcode_mix.h
@@ -75,6 +75,14 @@ public:
         uint isa_feature = ISA_FEAT_INVALID;
     };
 
+    struct opcode_isa_hasher_t {
+        std::size_t
+        operator()(const opcode_isa_feat_t &k) const
+        {
+            return (static_cast<uint64_t>(k.opcode) << 32) | k.isa_feature;
+        }
+    };
+
     // The module_file_path is optional and unused for traces with
     // OFFLINE_FILE_TYPE_ENCODINGS.
     // XXX: Once we update our toolchains to guarantee C++17 support we could use
@@ -157,20 +165,12 @@ protected:
             instr_t *instr, app_pc decode_pc) override;
     };
 
-    struct opcode_isa_hasher_t {
-        std::size_t
-        operator()(const opcode_isa_feat_t &k) const
-        {
-            return (static_cast<uint64_t>(k.opcode) << 32) | k.isa_feature;
-        }
-    };
-
     class snapshot_t : public interval_state_snapshot_t {
     public:
         // Snapshot the counts as cumulative stats, and then converted them to deltas in
         // finalize_interval_snapshots().  Printed interval results are all deltas.
         std::unordered_map<opcode_isa_feat_t, int64_t, opcode_isa_hasher_t>
-            opcode_isa_counts_;
+            opcode_isa_feat_counts_;
         std::unordered_map<uint, int64_t> category_counts_;
     };
 
@@ -181,7 +181,7 @@ protected:
 
         int64_t instr_count = 0;
         std::unordered_map<opcode_isa_feat_t, int64_t, opcode_isa_hasher_t>
-            opcode_isa_counts;
+            opcode_isa_feat_counts;
         // We report category sets frequency counts separately from <opcode, isa_feature>
         // counts, as we only care about how many instructions belong to a given set of
         // categories and not which <opcode, isa_feature> they belong to.

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2259,7 +2259,6 @@ if (DR_HOST_NOT_TARGET)
       "offline-altbindir.c" ""
       "-indir;${locdir};-tool;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
       OFF OFF)
-    unset(tool.drcacheoff.altbindir_rawtemp ON) # use preprocessor
     set(tool.drcacheoff.altbindir_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
     set(tool.drcacheoff.altbindir_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -2259,6 +2259,7 @@ if (DR_HOST_NOT_TARGET)
       "offline-altbindir.c" ""
       "-indir;${locdir};-tool;opcode_mix;-alt_module_dir;${srcdir};-module_file;${locdir}/raw/modules.log"
       OFF OFF)
+    unset(tool.drcacheoff.altbindir_rawtemp ON) # use preprocessor
     set(tool.drcacheoff.altbindir_basedir
       "${PROJECT_SOURCE_DIR}/clients/drcachesim/tests")
     set(tool.drcacheoff.altbindir_runcmp "${CMAKE_CURRENT_SOURCE_DIR}/runmulti.cmake")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4371,6 +4371,7 @@ if (BUILD_CLIENTS)
 
       torunonly_drcachesim(opcode_mix ${ci_shared_app}
         "-instr_encodings -tool opcode_mix" "")
+      unset(tool.drcachesim.opcode_mix_rawtemp) # use preprocessor
     endif (NOT RISCV64)
     # The sim_atops should start with @ and be in @-as-space format (hence "atops").
     # If the exetgt has drcachesim statically linked in, the _nodr property must be
@@ -4753,6 +4754,7 @@ if (BUILD_CLIENTS)
       # TODO i#3544: Port tests to RISC-V 64
       torunonly_drcacheoff(opcode_mix ${ci_shared_app} ""
         "@-tool@opcode_mix" "")
+      unset(tool.drcacheoff.opcode_mix_rawtemp) # use preprocessor
 
       # Ensure the tool works without the raw/ subdir.
       set(tool.drcacheoff.opcode_mix_postcmd
@@ -4764,6 +4766,7 @@ if (BUILD_CLIENTS)
 
       torunonly_drcacheoff(skip_instrs_opcode_mix ${ci_shared_app} ""
         "@-tool@opcode_mix@-skip_instrs@1" "")
+      unset(tool.drcacheoff.skip_instrs_opcode_mix_rawtemp) # use preprocessor
 
       torunonly_drcacheoff(view ${ci_shared_app} ""
         "@-tool@view@-exit_after_records@16384" "")

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4526,6 +4526,7 @@ if (BUILD_CLIENTS)
 
     torunonly_drcacheoff(interval-opcode-mix-output ${ci_shared_app} ""
       "@-tool@opcode_mix@-interval_instr_count@10000" "")
+    unset(tool.drcacheoff.interval-opcode-mix-output_rawtemp) # use preprocessor
 
     # As for the online test, we check that only 1 thread is in the final trace.
     torunonly_drcacheoff(max-global ${concurrent_test_app}

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -291,6 +291,14 @@ test_isa_features(void)
     instr_t *instr = NULL;
     uint isa_feat = ISA_FEAT_INVALID;
 
+    /* ISA feature defined in core/ir/aarch64/codec_v80.txt. */
+    instr = INSTR_CREATE_adrp(dc, opnd_create_reg(DR_REG_X1),
+                              OPND_CREATE_ABSMEM((void *)0x0000000020208000, OPSZ_0));
+    isa_feat = instr_get_isa_feature((byte *)&unused_buf, instr);
+    ASSERT(isa_feat == ISA_FEAT_BASE);
+    ASSERT(strncmp(instr_get_isa_feature_name(isa_feat), "BASE", strlen("BASE")) == 0);
+    instr_destroy(GD, instr);
+
     /* ISA feature defined in core/ir/aarch64/codec_v81.txt. */
     instr = INSTR_CREATE_sqrdmlsh_scalar(GD, opnd_create_reg(DR_REG_H0),
                                          opnd_create_reg(DR_REG_H0),

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -292,7 +292,7 @@ test_isa_features(void)
     uint isa_feat = ISA_FEAT_INVALID;
 
     /* ISA feature defined in core/ir/aarch64/codec_v80.txt. */
-    instr = INSTR_CREATE_adrp(dc, opnd_create_reg(DR_REG_X1),
+    instr = INSTR_CREATE_adrp(GD, opnd_create_reg(DR_REG_X1),
                               OPND_CREATE_ABSMEM((void *)0x0000000020208000, OPSZ_0));
     isa_feat = instr_get_isa_feature((byte *)&unused_buf, instr);
     ASSERT(isa_feat == ISA_FEAT_BASE);

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -291,14 +291,6 @@ test_isa_features(void)
     instr_t *instr = NULL;
     uint isa_feat = ISA_FEAT_INVALID;
 
-    /* ISA feature defined in core/ir/aarch64/codec_v80.txt. */
-    instr = INSTR_CREATE_adrp(GD, opnd_create_reg(DR_REG_X1),
-                              OPND_CREATE_ABSMEM((void *)0x0000000020208000, OPSZ_0));
-    isa_feat = instr_get_isa_feature((byte *)&unused_buf, instr);
-    ASSERT(isa_feat == ISA_FEAT_BASE);
-    ASSERT(strncmp(instr_get_isa_feature_name(isa_feat), "BASE", strlen("BASE")) == 0);
-    instr_destroy(GD, instr);
-
     /* ISA feature defined in core/ir/aarch64/codec_v81.txt. */
     instr = INSTR_CREATE_sqrdmlsh_scalar(GD, opnd_create_reg(DR_REG_H0),
                                          opnd_create_reg(DR_REG_H0),


### PR DESCRIPTION
Substitutes the `opcode_counts` map with an `opcode_isa_counts`
map that counts the frequency of <opcode, isa_feature> pairs
instead of just opcodes.
This map's key is a newly introduced `struct opcode_isa_feat_t`,
its hash is constructed by shifting the 32-bit opcode value into the
upper half of the key and bitwise-ORing it with the 32-bit ISA feature
constant, effectively creating a unique identifier for every
<opcode, isa_feature> pair.
Adds the ISA feature information to the `opcode_mix` output for
AARCH64, which now looks like:
```
Opcode mix tool results:
         126122 : total executed instructions
          15924 :     bcond (BASE)
          15171 :       stp (BASE)
...
```
The `opcode_mix` output for other architectures is left unchanged,
as extracting ISA features (e.g., BASE, SVE, SVE2, etc.) is effectively
implemented only for AARCH64, while other architectures always
return `<unknown>` ISA feature at the moment, which would
unnecessarily pollute the output of `opcode_mix`.

Updates unit test and  end-to-end tests that rely on the output of
`opcode_mix` accordingly.

Issue #7842