### PR TITLE
i#7854 wholesys traces: Invariant checks for hw cxt markers

### DIFF
--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -1266,7 +1266,9 @@ entry_has_pc(const trace_entry_t &entry, uint64_t &pc)
         return true;
     }
     if (static_cast<trace_type_t>(entry.type) == TRACE_TYPE_MARKER &&
-        static_cast<trace_marker_type_t>(entry.size) == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+        (static_cast<trace_marker_type_t>(entry.size) == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+         static_cast<trace_marker_type_t>(entry.size) ==
+             TRACE_MARKER_TYPE_HARDWARE_EVENT)) {
         pc = entry.addr;
         return true;
     }

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -762,10 +762,10 @@ typedef enum {
      * the #OFFLINE_FILE_TYPE_WHOLE_SYSTEM file type bit.  It is used in traces that
      * record the whole-system view of events; it is loosely similar to the
      * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT marker that is used to
-     * indicate discontinuities due to user signals in the regular user-mode view
-     * traces, but it is additionally present also at system calls.  The value of this
-     * marker contains the program counter at the interruption point.  If the interruption
-     * point is just after a branch, this value is the target of that branch.
+     * indicate discontinuities in the regular user-mode view traces.  The value of
+     * this marker contains the program counter at the interruption point.  If the
+     * interruption point is just after a branch, this value is the target of that
+     * branch.
      */
     TRACE_MARKER_TYPE_HARDWARE_EVENT,
 

--- a/clients/drcachesim/common/trace_entry.h
+++ b/clients/drcachesim/common/trace_entry.h
@@ -758,14 +758,14 @@ typedef enum {
 
     /**
      * This marker is used to indicate an occurrence of a discontinuity in regular
-     * execution flow caused by an exception or interrupt, in traces with the
-     * #OFFLINE_FILE_TYPE_WHOLE_SYSTEM file type bit.  It is used in traces that
+     * execution flow caused by an exception, interrupt, or system call, in traces with
+     * the #OFFLINE_FILE_TYPE_WHOLE_SYSTEM file type bit.  It is used in traces that
      * record the whole-system view of events; it is loosely similar to the
      * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT marker that is used to
      * indicate discontinuities due to user signals in the regular user-mode view
-     * traces.  The value of this marker contains the program counter at the
-     * interruption point.  If the interruption point is just after a branch, this
-     * value is the target of that branch.
+     * traces, but it is additionally present also at system calls.  The value of this
+     * marker contains the program counter at the interruption point.  If the interruption
+     * point is just after a branch, this value is the target of that branch.
      */
     TRACE_MARKER_TYPE_HARDWARE_EVENT,
 
@@ -780,11 +780,9 @@ typedef enum {
      * indicate control-altering syscalls which includes user event (UNIX signal,
      * Windows callback, exception, or APC) handler returns that match up to prior
      * #dynamorio::drmemtrace::TRACE_MARKER_TYPE_KERNEL_EVENT markers in the
-     * regular user-mode view traces.  Note that multiple instances of this marker may
-     * match to a single prior #dynamorio::drmemtrace::TRACE_MARKER_TYPE_HARDWARE_EVENT
-     * marker.  Note that this may not be present on other cases that change the
-     * privilege level (e.g., far branch on x86; syscall gateways). The marker value
-     * does not hold any information currently.
+     * regular user-mode view traces. Note that this may not be present on other cases
+     * that change the privilege level (e.g., far branch on x86; syscall gateways). The
+     * marker value does not hold any information currently.
      */
     TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN,
 

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -5502,7 +5502,7 @@ check_hardware_event_markers()
         std::vector<memref_t> memrefs = {
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
             gen_exit(TID_A),
         };
@@ -5521,11 +5521,11 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
-            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/101),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/2),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
@@ -5539,7 +5539,7 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 3),
             gen_exit(TID_A),
         };
@@ -5560,11 +5560,11 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
-            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/101),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_instr(TID_A, /*pc=*/5, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/5),
             gen_exit(TID_A),
         };
         if (!run_checker(
@@ -5582,15 +5582,15 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 10),
-            gen_instr(TID_A, /*pc=*/20, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 103),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 11),
+            gen_instr(TID_A, /*pc=*/20),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 21),
+            gen_instr(TID_A, /*pc=*/11),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 12),
+            gen_instr(TID_A, /*pc=*/2),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
@@ -5605,9 +5605,9 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/10),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
@@ -5615,7 +5615,7 @@ check_hardware_event_markers()
         };
         if (!run_checker(
                 memrefs, true,
-                { "Syscall trace has extra hardware_event_return marker", TID_A,
+                { "Syscall trace has extra hardware_context_return marker", TID_A,
                   /*ref_ordinal=*/9, /*last_timestamp=*/0,
                   /*instrs_since_last_timestamp=*/2 },
                 "Failed to catch mismatched hardware context return in syscall trace")) {
@@ -5632,9 +5632,9 @@ check_hardware_event_markers()
             gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/1, /*size=*/1,
                            /*indirect_branch_target=*/2),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/10),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/2),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
@@ -5651,9 +5651,9 @@ check_hardware_event_markers()
             gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/1, /*size=*/1,
                            /*indirect_branch_target=*/2),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/10),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_instr(TID_A, /*pc=*/5, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/5),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
@@ -5672,14 +5672,14 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/101),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 102),
-            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/201),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 202),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 102),
-            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/201),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 202),
-            gen_instr(TID_A, /*pc=*/102, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/102),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
@@ -5693,14 +5693,14 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 10),
-            gen_instr(TID_A, /*pc=*/20, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 103),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/20),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 21),
+            gen_instr(TID_A, /*pc=*/10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 11),
+            gen_instr(TID_A, /*pc=*/2),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
@@ -5716,15 +5716,15 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 123),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 123),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/20, /*size=*/1,
-                           /*indirect_branch_target=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/10, /*size=*/1,
+                           /*indirect_branch_target=*/2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 11),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 123),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/2),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {
@@ -5737,10 +5737,10 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 2),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 11),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
@@ -5757,10 +5757,10 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 1),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 2),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 11),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
@@ -5780,13 +5780,13 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
             gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/10, /*size=*/1,
-                           /*indirect_branch_target=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 1),
+                           /*indirect_branch_target=*/2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 123),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
@@ -5797,9 +5797,8 @@ check_hardware_event_markers()
             return false;
         }
     }
-    // Incorrect test: Hardware context event occurring within a syscall trace context,
-    // hardware_context_return immediately preceding syscall_trace_end, returns to
-    // incorrect PC.
+    // Incorrect test: Syscall in whole-system trace returns to correct non-fallthrough
+    // pc.
     {
         uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
             OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
@@ -5807,15 +5806,38 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
-            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/20, /*size=*/1,
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 5),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/10, /*size=*/1,
                            /*indirect_branch_target=*/5),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 1),
-            gen_instr(TID_A, /*pc=*/5, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 11),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 123),
+            gen_instr(TID_A, /*pc=*/5),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+    // Incorrect test: Syscall in whole-system trace returns to incorrect pc.
+    {
+        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
+            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 5),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/10, /*size=*/1,
+                           /*indirect_branch_target=*/6),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 11),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 123),
+            gen_instr(TID_A, /*pc=*/6),
             gen_exit(TID_A),
         };
         if (!run_checker(
@@ -5827,16 +5849,16 @@ check_hardware_event_markers()
             return false;
         }
     }
-    // Correct test: Starts inside a hardware context event, popping across context return
-    // safely.
+    // Correct test: Starts inside a hardware context event.
     {
         std::vector<memref_t> memrefs = {
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
-            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
-            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
-            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_instr(TID_A, /*pc=*/10),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 11),
+            // Never-before-seen context; no discontinuity.
+            gen_instr(TID_A, /*pc=*/2),
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, false)) {

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -5495,6 +5495,7 @@ check_core_sharded_with_kernel()
 bool
 check_hardware_event_markers()
 {
+#ifdef UNIX
     std::cerr << "Testing hardware event markers\n";
     // Incorrect test: Hardware event markers found in non-whole-system trace.
     {
@@ -5826,6 +5827,23 @@ check_hardware_event_markers()
             return false;
         }
     }
+    // Correct test: Starts inside a hardware context event, popping across context return
+    // safely.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+#endif
     return true;
 }
 

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -5496,6 +5496,8 @@ bool
 check_hardware_event_markers()
 {
 #ifdef UNIX
+    constexpr uintptr_t FILE_TYPE =
+        OFFLINE_FILE_TYPE_SYSCALL_NUMBERS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
     std::cerr << "Testing hardware event markers\n";
     // Incorrect test: Hardware event markers found in non-whole-system trace.
     {
@@ -5533,8 +5535,30 @@ check_hardware_event_markers()
             return false;
         }
     }
+    // Incorrect test: Cannot have both whole_system and kernel_syscalls bit set in
+    // file type.
+    {
+        uintptr_t file_type =
+            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(
+                memrefs, true,
+                { "Trace cannot have both whole_system and kernel_syscalls bit set",
+                  TID_A,
+                  /*ref_ordinal=*/1, /*last_timestamp=*/0,
+                  /*instrs_since_last_timestamp=*/0 },
+                "Failed to catch invalid file type combination")) {
+            return false;
+        }
+    }
     // Incorrect test (PC discontinuity): Transition to discontinuous PC in hardware
-    // context return.
+    // event marker.
     {
         std::vector<memref_t> memrefs = {
             gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
@@ -5600,10 +5624,8 @@ check_hardware_event_markers()
     }
     // Incorrect test: Mismatched hardware context return inside a syscall trace.
     {
-        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
-            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             gen_instr(TID_A, /*pc=*/1),
@@ -5711,10 +5733,9 @@ check_hardware_event_markers()
     // Correct test: Syscall trace, which is supposed to have hardware_event and
     // hardware_context_return too.
     {
-        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
-            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             gen_instr(TID_A, /*pc=*/1),
@@ -5775,10 +5796,9 @@ check_hardware_event_markers()
     }
     // Incorrect test: Syscall trace has an extra/unpopped hardware_event marker.
     {
-        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
-            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             gen_instr(TID_A, /*pc=*/1),
@@ -5801,15 +5821,18 @@ check_hardware_event_markers()
     // Correct test: Syscall in whole-system trace allowed to return to
     // non-fallthrough pc if the hardware_event marker has the same pc.
     {
-        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
-            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             gen_instr(TID_A, /*pc=*/1),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 123),
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 123),
+            // Control is expected to return to some PC other than non-fallthrough
+            // of the syscall. This is a known discontinuity at the syscall event
+            // itself possibly due to some whole-system event like switching to a
+            // different thread.
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 5),
             gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/10, /*size=*/1,
                            /*indirect_branch_target=*/5),
@@ -5824,10 +5847,8 @@ check_hardware_event_markers()
     }
     // Incorrect test: Syscall in whole-system trace returns to incorrect pc.
     {
-        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
-            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
         std::vector<memref_t> memrefs = {
-            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, FILE_TYPE),
             gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
             gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
             gen_instr(TID_A, /*pc=*/1),

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -5798,8 +5798,8 @@ check_hardware_event_markers()
             return false;
         }
     }
-    // Incorrect test: Syscall in whole-system trace returns to correct non-fallthrough
-    // pc.
+    // Correct test: Syscall in whole-system trace allowed to return to
+    // non-fallthrough pc if the hardware_event marker has the same pc.
     {
         uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
             OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -5831,8 +5831,10 @@ check_hardware_event_markers()
             gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 123),
             // Control is expected to return to some PC other than non-fallthrough
             // of the syscall. This is a known discontinuity at the syscall event
-            // itself possibly due to some whole-system event like switching to a
-            // different thread.
+            // itself. We allow this because some system calls indeed may cause
+            // a context switch to a different thread (the whole-system trace
+            // view shows all threads interleaved), or control transfers on the
+            // same one.
             gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 5),
             gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/10, /*size=*/1,
                            /*indirect_branch_target=*/5),

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -5507,7 +5507,8 @@ check_hardware_event_markers()
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { "Hardware event marker found in non-whole-system trace", TID_A,
+                         { "Hardware context marker found in non-whole-system trace",
+                           TID_A,
                            /*ref_ordinal=*/4, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/1 },
                          "Failed to catch hardware event in non-WS trace")) {

--- a/clients/drcachesim/tests/invariant_checker_test.cpp
+++ b/clients/drcachesim/tests/invariant_checker_test.cpp
@@ -3063,7 +3063,7 @@ check_kernel_trace_and_signal_markers(bool for_syscall)
             gen_exit(TID_A),
         };
         if (!run_checker(memrefs, true,
-                         { test_type + " trace has extra kernel_event marker",
+                         { test_type + " trace has extra context event marker",
                            /*tid=*/TID_A,
                            /*ref_ordinal=*/10, /*last_timestamp=*/0,
                            /*instrs_since_last_timestamp=*/3 },
@@ -5492,6 +5492,343 @@ check_core_sharded_with_kernel()
     return true;
 }
 
+bool
+check_hardware_event_markers()
+{
+    std::cerr << "Testing hardware event markers\n";
+    // Incorrect test: Hardware event markers found in non-whole-system trace.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, true,
+                         { "Hardware event marker found in non-whole-system trace", TID_A,
+                           /*ref_ordinal=*/4, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/1 },
+                         "Failed to catch hardware event in non-WS trace")) {
+            return false;
+        }
+    }
+    // Correct test: Hardware event markers in a whole-system trace, transitions
+    // seamlessly.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+    // Incorrect test (PC discontinuity): Transition to discontinuous PC in hardware
+    // context return.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 3),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(
+                memrefs, true,
+                { "Non-explicit control flow has no marker @ hardware_event marker",
+                  TID_A,
+                  /*ref_ordinal=*/5, /*last_timestamp=*/0,
+                  /*instrs_since_last_timestamp=*/1 },
+                "Failed to catch PC discontinuity in WS hardware event")) {
+            return false;
+        }
+    }
+    // Incorrect test: Hardware context return in a whole-system trace with a PC gap in
+    // user-space (incorrect resumption PC).
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_instr(TID_A, /*pc=*/5, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(
+                memrefs, true,
+                { "Interrupt handler return point incorrect", TID_A,
+                  /*ref_ordinal=*/8, /*last_timestamp=*/0,
+                  /*instrs_since_last_timestamp=*/3 },
+                "Failed to catch incorrect return PC after hardware event return")) {
+            return false;
+        }
+    }
+    // Correct test: Nested hardware events in a whole-system trace.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 10),
+            gen_instr(TID_A, /*pc=*/20, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 103),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+    // Incorrect test: Mismatched hardware context return inside a syscall trace.
+    {
+        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
+            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(
+                memrefs, true,
+                { "Syscall trace has extra hardware_event_return marker", TID_A,
+                  /*ref_ordinal=*/9, /*last_timestamp=*/0,
+                  /*instrs_since_last_timestamp=*/2 },
+                "Failed to catch mismatched hardware context return in syscall trace")) {
+            return false;
+        }
+    }
+    // Correct test: Interrupted indirect branch by hardware event in a whole-system
+    // trace, returns to correct PC (the branch target PC).
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/1, /*size=*/1,
+                           /*indirect_branch_target=*/2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_instr(TID_A, /*pc=*/2, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+    // Incorrect test: Interrupted indirect branch by hardware event in a whole-system
+    // trace, returns to incorrect PC.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/1, /*size=*/1,
+                           /*indirect_branch_target=*/2),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 2),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_instr(TID_A, /*pc=*/5, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, true,
+                         { "Interrupt handler return point incorrect", TID_A,
+                           /*ref_ordinal=*/8, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/3 },
+                         "Failed to catch incorrect return PC after interrupted indirect "
+                         "branch")) {
+            return false;
+        }
+    }
+    // Correct test: Consecutive hardware events without intervening instruction inside a
+    // whole-system trace.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/101, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 102),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 202),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 102),
+            gen_instr(TID_A, /*pc=*/201, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 202),
+            gen_instr(TID_A, /*pc=*/102, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+    // Correct test: Nested hardware events without any intervening instruction inside a
+    // whole-system trace.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 10),
+            gen_instr(TID_A, /*pc=*/20, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 103),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+    // Correct test: Syscall trace, which is supposed to have hardware_event and
+    // hardware_context_return too.
+    {
+        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
+            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 123),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/20, /*size=*/1,
+                           /*indirect_branch_target=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 123),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, false)) {
+            return false;
+        }
+    }
+    // Incorrect test: Enters with HARDWARE_EVENT but exits with KERNEL_XFER.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_XFER, 2),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, true,
+                         { "Mismatched signal/interrupt context return marker", TID_A,
+                           /*ref_ordinal=*/7, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/2 },
+                         "Failed to catch mismatched KERNEL_XFER after HARDWARE_EVENT")) {
+            return false;
+        }
+    }
+    // Incorrect test: Enters with KERNEL_EVENT but exits with HARDWARE_CONTEXT_RETURN.
+    {
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, OFFLINE_FILE_TYPE_WHOLE_SYSTEM),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_KERNEL_EVENT, 1),
+            gen_instr(TID_A, /*pc=*/10, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 2),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, true,
+                         { "Mismatched signal/interrupt context return marker", TID_A,
+                           /*ref_ordinal=*/7, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/2 },
+                         "Failed to catch mismatched HARDWARE_CONTEXT_RETURN after "
+                         "KERNEL_EVENT")) {
+            return false;
+        }
+    }
+    // Incorrect test: Syscall trace has an extra/unpopped hardware_event marker.
+    {
+        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
+            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/10, /*size=*/1,
+                           /*indirect_branch_target=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(memrefs, true,
+                         { "Syscall trace has extra context event marker", TID_A,
+                           /*ref_ordinal=*/9, /*last_timestamp=*/0,
+                           /*instrs_since_last_timestamp=*/2 },
+                         "Failed to catch extra hardware_event inside syscall trace")) {
+            return false;
+        }
+    }
+    // Incorrect test: Hardware context event occurring within a syscall trace context,
+    // hardware_context_return immediately preceding syscall_trace_end, returns to
+    // incorrect PC.
+    {
+        uintptr_t file_type = OFFLINE_FILE_TYPE_SYSCALL_NUMBERS |
+            OFFLINE_FILE_TYPE_KERNEL_SYSCALLS | OFFLINE_FILE_TYPE_WHOLE_SYSTEM;
+        std::vector<memref_t> memrefs = {
+            gen_marker(TID_A, TRACE_MARKER_TYPE_FILETYPE, file_type),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_CACHE_LINE_SIZE, 64),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_PAGE_SIZE, 4096),
+            gen_instr(TID_A, /*pc=*/1, /*size=*/1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_START, 1),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_EVENT, 1),
+            gen_instr_type(TRACE_TYPE_INSTR_INDIRECT_JUMP, TID_A, /*pc=*/20, /*size=*/1,
+                           /*indirect_branch_target=*/5),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN, 102),
+            gen_marker(TID_A, TRACE_MARKER_TYPE_SYSCALL_TRACE_END, 1),
+            gen_instr(TID_A, /*pc=*/5, /*size=*/1),
+            gen_exit(TID_A),
+        };
+        if (!run_checker(
+                memrefs, true,
+                { "Syscall return point incorrect in wholesys trace", TID_A,
+                  /*ref_ordinal=*/11, /*last_timestamp=*/0,
+                  /*instrs_since_last_timestamp=*/3 },
+                "Failed to catch incorrect return PC in wholesys syscall trace")) {
+            return false;
+        }
+    }
+    return true;
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -5506,7 +5843,8 @@ test_main(int argc, const char *argv[])
         check_kernel_context_switch_trace() &&
         check_kernel_trace_and_signal_markers(/*for_syscall=*/false) &&
         check_kernel_trace_and_signal_markers(/*for_syscall=*/true) && check_regdeps() &&
-        check_chunk_order() && check_core_sharded() && check_core_sharded_with_kernel()) {
+        check_chunk_order() && check_core_sharded() && check_core_sharded_with_kernel() &&
+        check_hardware_event_markers()) {
         std::cerr << "invariant_checker_test passed\n";
         return 0;
     }

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -32,7 +32,6 @@
 
 #include "invariant_checker.h"
 
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1373,7 +1372,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             // to the PT syscall traces today.
             std::string marker_name = "kernel_xfer";
             if (memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) {
-                marker_name = "hardware_event_return";
+                marker_name = "hardware_context_return";
             }
             std::string syscall_msg =
                 "Syscall trace has extra " + marker_name + " marker";

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -605,6 +605,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         is_a_unit_test(shard) ||
                             shard->file_type_ == shard->stream->get_filetype(),
                         "Stream interface filetype != trace marker");
+        report_if_false(
+            shard,
+            !TESTANY(OFFLINE_FILE_TYPE_WHOLE_SYSTEM, shard->file_type_) ||
+                !TESTANY(OFFLINE_FILE_TYPE_KERNEL_SYSCALLS, shard->file_type_),
+            "Trace cannot have both whole_system and kernel_syscalls bit set");
     }
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         memref.marker.marker_type == TRACE_MARKER_TYPE_INSTRUCTION_COUNT) {
@@ -776,7 +781,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         report_if_false(shard,
                         TESTANY(OFFLINE_FILE_TYPE_KERNEL_SYSCALLS |
                                     OFFLINE_FILE_TYPE_KERNEL_SYSCALL_INSTR_ONLY |
-                                    OFFLINE_FILE_TYPE_KERNEL_SYSCALL_TRACE_TEMPLATES,
+                                    OFFLINE_FILE_TYPE_KERNEL_SYSCALL_TRACE_TEMPLATES |
+                                    OFFLINE_FILE_TYPE_WHOLE_SYSTEM,
                                 shard->file_type_),
                         "Found kernel syscall trace without corresponding file type");
         report_if_false(shard, !shard->between_kernel_syscall_trace_markers_,
@@ -1255,9 +1261,9 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                 handler_name = "Interrupt";
             }
             std::string error_msg = handler_name + " handler return point incorrect";
-            // Whole-system traces sometimes have the hardware_event and
-            // hardware_context_return markers nested inside the syscall_trace_start
-            // and syscall_trace_end markers, in which case they are really for the
+            // Whole-system trace hardware_event and hardware_context_return markers
+            // are sometimes nested inside the syscall_trace_start and
+            // syscall_trace_end markers, in which case they are really for the
             // system call.
             if (shard->prev_xfer_marker_.marker.marker_type ==
                     TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN &&

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1230,7 +1230,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         if (is_context_return_marker(shard->prev_xfer_marker_.marker.marker_type)) {
             // For the following checks, we use the values popped from the
             // context_stack_ into last_context_ at the last
-            // TRACE_MARKER_TYPE_KERNEL_XFER marker.
+            // TRACE_MARKER_TYPE_KERNEL_XFER or
+            // TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN marker.
             bool context_event_marker_equality =
                 // Skip this check if we did not see the corresponding
                 // kernel_event or hardware_event marker in the trace because
@@ -1386,8 +1387,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                             shard->context_stack_depth_at_context_switch_trace_start_ <
                                 static_cast<int>(shard->context_stack_.size()),
                             switch_msg);
-            // We assume paired signal entry-exit (so no longjmp and no rseq
-            // inside signal handlers).
+            // We assume paired signal/interrupt entry-exit (so no longjmp and no rseq
+            // inside signal/interrupt handlers).
             if (shard->context_stack_.empty()) {
                 // This can happen if tracing started in the middle of a signal.
                 // Try to continue by skipping the checks.

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -32,6 +32,7 @@
 
 #include "invariant_checker.h"
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -306,6 +307,20 @@ invariant_checker_t::is_dynamically_core_sharded(per_shard_t *shard)
     return core_sharded_ && !TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard->file_type_);
 }
 
+static bool
+is_context_event_marker(const trace_marker_type_t marker_type)
+{
+    return marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+        marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT;
+}
+
+static bool
+is_context_return_marker(const trace_marker_type_t marker_type)
+{
+    return marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
+        marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN;
+}
+
 bool
 invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &memref)
 {
@@ -341,6 +356,12 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             memref, TESTANY(OFFLINE_FILE_TYPE_CORE_SHARDED, shard->file_type_));
     }
 
+    if (memref.marker.type == TRACE_TYPE_MARKER &&
+        (memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT ||
+         memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN)) {
+        report_if_false(shard, TESTANY(OFFLINE_FILE_TYPE_WHOLE_SYSTEM, shard->file_type_),
+                        "Hardware event marker found in non-whole-system trace");
+    }
     // These markers are allowed between the syscall marker and a possible
     // syscall trace.
     bool prev_was_syscall_marker_saved = shard->prev_was_syscall_marker_;
@@ -419,11 +440,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                             at_skip || shard->last_next_trace_pc_ == memref.instr.addr,
                             "Unexpected next trace pc from instr");
         } else if (memref.marker.type == TRACE_TYPE_MARKER &&
-                   memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+                   is_context_event_marker(memref.marker.marker_type)) {
             report_if_false(shard,
                             at_skip ||
                                 shard->last_next_trace_pc_ == memref.marker.marker_value,
-                            "Unexpected next trace pc from kernel_event marker");
+                            "Unexpected next trace pc from context event marker");
         } else {
             report_if_false(
                 shard,
@@ -797,7 +818,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         shard->pre_syscall_trace_instr_ = shard->prev_instr_;
         shard->between_kernel_syscall_trace_markers_ = true;
 #ifdef UNIX
-        shard->signal_stack_depth_at_syscall_trace_start_ = shard->signal_stack_.size();
+        shard->context_stack_depth_at_syscall_trace_start_ = shard->context_stack_.size();
 #endif
         shard->saw_syscall_trace_.insert(static_cast<int>(memref.marker.marker_value));
     }
@@ -838,17 +859,17 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         if (shard->between_kernel_syscall_trace_markers_) {
 #ifdef UNIX
             report_if_false(shard,
-                            shard->signal_stack_depth_at_syscall_trace_start_ ==
-                                static_cast<int>(shard->signal_stack_.size()),
-                            "Syscall trace has extra kernel_event marker");
-            shard->signal_stack_depth_at_syscall_trace_start_ = -1;
+                            shard->context_stack_depth_at_syscall_trace_start_ ==
+                                static_cast<int>(shard->context_stack_.size()),
+                            "Syscall trace has extra context event marker");
+            shard->context_stack_depth_at_syscall_trace_start_ = -1;
 #endif
             shard->between_kernel_syscall_trace_markers_ = false;
             // Pretend the prev instruction to be the last user-space instruction,
             // so that later PC continuity checks properly verify the user-space view
             // of the trace.
             // PC equality between the syscall-end branch target marker value and the
-            // next instruction PC (or the next kernel_event marker PC if a signal is
+            // next instruction PC (or the next context event marker PC if a signal is
             // next) is also verified in check_for_pc_discontinuity.
             shard->prev_instr_ = shard->pre_syscall_trace_instr_;
 #ifdef UNIX
@@ -862,8 +883,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                         "Nested kernel context switch traces are not expected");
         shard->between_kernel_context_switch_markers_ = true;
 #ifdef UNIX
-        shard->signal_stack_depth_at_context_switch_trace_start_ =
-            shard->signal_stack_.size();
+        shard->context_stack_depth_at_context_switch_trace_start_ =
+            shard->context_stack_.size();
 #endif
         switch_type_t switch_type =
             static_cast<switch_type_t>(memref.marker.marker_value);
@@ -886,11 +907,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
             // Protected by above if-condition to avoid noise from another invariant
             // error due to a missing start marker.
             report_if_false(shard,
-                            shard->signal_stack_depth_at_context_switch_trace_start_ ==
-                                static_cast<int>(shard->signal_stack_.size()),
-                            "Context switch trace has extra kernel_event marker");
+                            shard->context_stack_depth_at_context_switch_trace_start_ ==
+                                static_cast<int>(shard->context_stack_.size()),
+                            "Context switch trace has extra context event marker");
         }
-        shard->signal_stack_depth_at_context_switch_trace_start_ = -1;
+        shard->context_stack_depth_at_context_switch_trace_start_ = -1;
 #endif
         report_if_false(
             shard,
@@ -947,8 +968,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                      // The last instruction is not known if the signal arrived before any
                      // instructions in the trace, or the trace started mid-signal. We
                      // assume the function markers are correct to avoid false positives.
-                     shard->last_signal_context_.pre_signal_instr.memref.instr.addr ==
-                         0 ||
+                     shard->last_context_.pre_context_instr.memref.instr.addr == 0 ||
                      // The last instruction of the outer-most scope was a branch.
                      type_is_instr_branch(
                          shard->last_instr_in_cur_context_.memref.instr.type))),
@@ -1201,38 +1221,50 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // elsewhere.
         const std::string non_explicit_flow_violation_msg = check_for_pc_discontinuity(
             shard, shard->prev_instr_, cur_instr_info, expect_encoding,
-            /*at_kernel_event=*/false);
+            /*at_context_event=*/false);
         report_if_false(shard, non_explicit_flow_violation_msg.empty(),
                         non_explicit_flow_violation_msg);
 
 #ifdef UNIX
-        // Ensure signal handlers return to the interruption point.
-        if (shard->prev_xfer_marker_.marker.marker_type ==
-            TRACE_MARKER_TYPE_KERNEL_XFER) {
+        // Ensure signal/interrupt handlers return to the interruption point.
+        if (is_context_return_marker(shard->prev_xfer_marker_.marker.marker_type)) {
             // For the following checks, we use the values popped from the
-            // signal_stack_ into last_signal_context_ at the last
+            // context_stack_ into last_context_ at the last
             // TRACE_MARKER_TYPE_KERNEL_XFER marker.
-            bool kernel_event_marker_equality =
+            bool context_event_marker_equality =
                 // Skip this check if we did not see the corresponding
-                // kernel_event marker in the trace because the trace
-                // started mid-signal.
-                shard->last_signal_context_.xfer_int_pc == 0 ||
+                // kernel_event or hardware_event marker in the trace because
+                // the trace started mid-signal/interrupt.
+                shard->last_context_.xfer_int_pc == 0 ||
                 // Regular check for equality with kernel event marker pc.
-                memref.instr.addr == shard->last_signal_context_.xfer_int_pc ||
+                memref.instr.addr == shard->last_context_.xfer_int_pc ||
                 // DR hands us a different address for sysenter than the
                 // resumption point.
-                shard->last_signal_context_.pre_signal_instr.memref.instr.type ==
+                shard->last_context_.pre_context_instr.memref.instr.type ==
                     TRACE_TYPE_INSTR_SYSENTER // clang-format off
                 // The AArch64 scatter/gather expansion test skips faulting
                 // instructions in the signal handler by incrementing the PC.
                 IF_AARCH64(||
                            (knob_test_name_ == "scattergather" &&
                             memref.instr.addr ==
-                                shard->last_signal_context_.xfer_int_pc + 4));
+                                shard->last_context_.xfer_int_pc + 4));
             // clang-format on
+            std::string handler_name = "Signal";
+            if (shard->prev_xfer_marker_.marker.marker_type ==
+                TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) {
+                handler_name = "Interrupt";
+            }
+            std::string error_msg = handler_name + " handler return point incorrect";
+            if (shard->prev_xfer_marker_.marker.marker_type ==
+                    TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN &&
+                shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
+                shard->prev_entry_.marker.marker_type ==
+                    TRACE_MARKER_TYPE_SYSCALL_TRACE_END) {
+                error_msg = "Syscall return point incorrect in wholesys trace";
+            }
             report_if_false(
                 shard,
-                kernel_event_marker_equality ||
+                context_event_marker_equality ||
                     // Nested signal.  XXX: This only works for our annotated test
                     // signal_invariants where we know shard->app_handler_pc_.
                     memref.instr.addr == shard->app_handler_pc_ ||
@@ -1242,7 +1274,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                     // Instruction-filtered can easily skip the return point.
                     TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED,
                             shard->file_type_),
-                "Signal handler return point incorrect");
+                error_msg);
         }
         // last_instr_in_cur_context_ is recorded as the pre-signal instr when we see a
         // TRACE_MARKER_TYPE_KERNEL_EVENT marker. Note that we cannot perform this
@@ -1305,8 +1337,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         // Ignore timestamp, etc. markers which show up at signal delivery boundaries
         // b/c the tracer does a buffer flush there.
-        (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-         memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)) {
+        (is_context_event_marker(memref.marker.marker_type) ||
+         is_context_return_marker(memref.marker.marker_type))) {
         if (knob_verbose_ >= 3) {
             std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: "
                       << "marker type " << memref.marker.marker_type << " value 0x"
@@ -1315,7 +1347,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         // Zero is pushed as a sentinel. This push matches the return used by post
         // signal handler to run the restorer code. It is assumed that all signal
         // handlers return normally and longjmp is not used.
-        if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
+        if (is_context_event_marker(memref.marker.marker_type) &&
             // retaddr_stack_ tracking is only for user-space code where we do
             // function tracing.
             !(shard->between_kernel_syscall_trace_markers_ ||
@@ -1330,48 +1362,73 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
 #ifdef UNIX
         report_if_false(shard, memref.marker.marker_value != 0,
                         "Kernel event marker value missing");
-        if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
+        if (is_context_return_marker(memref.marker.marker_type)) {
             // We expect a proper pairing of TRACE_MARKER_TYPE_KERNEL_EVENT and
-            // TRACE_MARKER_TYPE_KERNEL_XFER markers inside the kernel system call
-            // and context switch traces that are used for trace injection.
+            // TRACE_MARKER_TYPE_KERNEL_XFER markers, and
+            // TRACE_MARKER_TYPE_HARDWARE_EVENT and
+            // TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers inside the kernel system
+            // call and context switch traces.
             // XXX: Note that we do not make an effort to add these markers at all
             // to the PT syscall traces today.
+            std::string marker_name = "kernel_xfer";
+            if (memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) {
+                marker_name = "hardware_event_return";
+            }
+            std::string syscall_msg =
+                "Syscall trace has extra " + marker_name + " marker";
+            std::string switch_msg =
+                "Context switch trace has extra " + marker_name + " marker";
             report_if_false(shard,
-                            shard->signal_stack_depth_at_syscall_trace_start_ <
-                                static_cast<int>(shard->signal_stack_.size()),
-                            "Syscall trace has extra kernel_xfer marker");
+                            shard->context_stack_depth_at_syscall_trace_start_ <
+                                static_cast<int>(shard->context_stack_.size()),
+                            syscall_msg);
             report_if_false(shard,
-                            shard->signal_stack_depth_at_context_switch_trace_start_ <
-                                static_cast<int>(shard->signal_stack_.size()),
-                            "Context switch trace has extra kernel_xfer marker");
+                            shard->context_stack_depth_at_context_switch_trace_start_ <
+                                static_cast<int>(shard->context_stack_.size()),
+                            switch_msg);
             // We assume paired signal entry-exit (so no longjmp and no rseq
             // inside signal handlers).
-            if (shard->signal_stack_.empty()) {
+            if (shard->context_stack_.empty()) {
                 // This can happen if tracing started in the middle of a signal.
                 // Try to continue by skipping the checks.
-                shard->last_signal_context_ = { 0, {} };
+                shard->last_context_ = { 0, {}, TRACE_MARKER_TYPE_KERNEL_EVENT };
                 // We have not seen any instr in the outermost scope that we just
                 // discovered.
                 shard->last_instr_in_cur_context_ = {};
             } else {
-                // The pre_signal_instr for this signal may be {} in some cases:
-                // - for nested signals without any intervening instr
-                // - if there's a signal at the very beginning of the trace
+                // The pre_context_instr for this signal or interrupt may be {} in some
+                // cases:
+                // - for nested signals/interrupts without any intervening instr
+                // - if there's a signal/interrupt at the very beginning of the trace
                 // In both these cases the empty instr implies that it should not
-                // be used for the pre-signal instr check.
-                shard->last_signal_context_ = shard->signal_stack_.top();
-                shard->signal_stack_.pop();
+                // be used for the pre-signal/interrupt instr check.
+                shard->last_context_ = shard->context_stack_.top();
+                shard->context_stack_.pop();
+                if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER) {
+                    report_if_false(shard,
+                                    shard->last_context_.context_marker_type ==
+                                        TRACE_MARKER_TYPE_KERNEL_EVENT,
+                                    "Mismatched signal/interrupt context return marker");
+                } else if (memref.marker.marker_type ==
+                           TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) {
+                    report_if_false(shard,
+                                    shard->last_context_.context_marker_type ==
+                                        TRACE_MARKER_TYPE_HARDWARE_EVENT,
+                                    "Mismatched signal/interrupt context return marker");
+                }
                 // In the case where there's no instr between two consecutive signals
-                // (at the same nesting depth), the pre-signal instr for the second
-                // signal should be same as the pre-signal instr for the first one.
+                // or interrupts (at the same nesting depth), the pre-signal/interrupt
+                // instr for the second signal/interrupt should be same as the
+                // pre-interruption instr for the first one.
                 // Here we restore last_instr_in_cur_context_ to the last instr we
-                // saw *in the same nesting depth* before the first signal.
+                // saw *in the same nesting depth* before the first signal/interrupt.
                 shard->last_instr_in_cur_context_ =
-                    shard->last_signal_context_.pre_signal_instr;
+                    shard->last_context_.pre_context_instr;
             }
-        } else if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT) {
+        } else if (is_context_event_marker(memref.marker.marker_type)) {
             // If preceded by an RSEQ abort marker, this is not really a signal.
-            if (shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
+            if (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT &&
+                shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
                 shard->prev_entry_.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT) {
                 saw_rseq_abort = true;
             } else {
@@ -1387,8 +1444,11 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                     const std::string discontinuity = check_for_pc_discontinuity(
                         shard, shard->last_instr_in_cur_context_, memref_info,
                         TESTANY(OFFLINE_FILE_TYPE_ENCODINGS, shard->file_type_),
-                        /*at_kernel_event=*/true);
-                    const std::string error_msg_suffix = " @ kernel_event marker";
+                        /*at_context_event=*/true);
+                    std::string error_msg_suffix = " @ kernel_event marker";
+                    if (memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT) {
+                        error_msg_suffix = " @ hardware_event marker";
+                    }
                     report_if_false(shard, discontinuity.empty(),
                                     discontinuity + error_msg_suffix);
                 } else if (shard->prev_kernel_end_branch_target_ != 0 &&
@@ -1405,8 +1465,9 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                                     "context-first kernel_event marker");
                     shard->prev_kernel_end_branch_target_ = 0;
                 }
-                shard->signal_stack_.push(
-                    { memref.marker.marker_value, shard->last_instr_in_cur_context_ });
+                shard->context_stack_.push({ memref.marker.marker_value,
+                                             shard->last_instr_in_cur_context_,
+                                             memref.marker.marker_type });
                 // XXX: if last_instr_in_cur_context_ is {} currently, it means this is
                 // either a signal that arrived before the first instr in the trace, or
                 // it's a nested signal without any intervening instr after its
@@ -1724,16 +1785,16 @@ std::string
 invariant_checker_t::check_for_pc_discontinuity(
     per_shard_t *shard, const per_shard_t::instr_info_t &prev_instr_info,
     const per_shard_t::instr_info_t &cur_memref_info, bool expect_encoding,
-    bool at_kernel_event)
+    bool at_context_event)
 {
     const memref_t prev_instr = prev_instr_info.memref;
     std::string error_msg = "";
     bool have_branch_target = false;
     addr_t branch_target = 0;
     const addr_t prev_instr_trace_pc = prev_instr.instr.addr;
-    // cur_memref_info is a marker (not an instruction) if at_kernel_event is true.
-    const addr_t cur_pc = at_kernel_event ? cur_memref_info.memref.marker.marker_value
-                                          : cur_memref_info.memref.instr.addr;
+    // cur_memref_info is a marker (not an instruction) if at_context_event is true.
+    const addr_t cur_pc = at_context_event ? cur_memref_info.memref.marker.marker_value
+                                           : cur_memref_info.memref.instr.addr;
     if (shard->prev_kernel_end_branch_target_ != 0) {
         const addr_t kernel_end_branch_target = shard->prev_kernel_end_branch_target_;
         shard->prev_kernel_end_branch_target_ = 0;
@@ -1793,22 +1854,22 @@ invariant_checker_t::check_for_pc_discontinuity(
            cur_memref_info.memref.instr.size == prev_instr.instr.size))) ||
         // Same PC is allowed for a kernel interruption which may restart the
         // same instruction.
-        (prev_instr_trace_pc == cur_pc && at_kernel_event) ||
+        (prev_instr_trace_pc == cur_pc && at_context_event) ||
         // Kernel-mediated, but we can't tell if we had a thread swap.
-        (shard->prev_xfer_marker_.instr.tid != 0 && !at_kernel_event &&
-         (shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-          shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER ||
+        (shard->prev_xfer_marker_.instr.tid != 0 && !at_context_event &&
+         (is_context_event_marker(shard->prev_xfer_marker_.marker.marker_type) ||
+          is_context_return_marker(shard->prev_xfer_marker_.marker.marker_type) ||
           shard->prev_xfer_marker_.marker.marker_type == TRACE_MARKER_TYPE_RSEQ_ABORT)) ||
 #ifdef UNIX
         // In case of an RSEQ abort followed by a signal, the pre-signal-instr PC is
         // different from the interruption PC which is the RSEQ handler. If there is a
         // back-to-back signal without any intervening instructions, the kernel transfer
         // marker of the second signal should point to the same interruption PC, and not
-        // the pre-signal-instr PC. The shard->last_signal_context_ has not been updated,
+        // the pre-signal-instr PC. The shard->last_context_ has not been updated,
         // it still points to the previous signal context.
-        (at_kernel_event && cur_pc == shard->last_signal_context_.xfer_int_pc &&
+        (at_context_event && cur_pc == shard->last_context_.xfer_int_pc &&
          prev_instr_trace_pc ==
-             shard->last_signal_context_.pre_signal_instr.memref.instr.addr) ||
+             shard->last_context_.pre_context_instr.memref.instr.addr) ||
 #endif
         // We expect a gap on a window transition.
         shard->window_transition_ ||
@@ -2067,8 +2128,8 @@ invariant_checker_t::per_shard_t::reset_at_context_switch(const memref_t &memref
     expect_syscall_trace_ = false;
     prev_kernel_end_branch_target_ = 0;
 #ifdef UNIX
-    signal_stack_ = std::stack<signal_context>();
-    last_signal_context_ = { 0, {} };
+    context_stack_ = std::stack<signal_context>();
+    last_context_ = { 0, {} };
     last_instr_in_cur_context_ = {};
     saw_rseq_abort_ = false;
     instrs_until_interrupt_ = -1;

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -359,7 +359,7 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
         (memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_EVENT ||
          memref.marker.marker_type == TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN)) {
         report_if_false(shard, TESTANY(OFFLINE_FILE_TYPE_WHOLE_SYSTEM, shard->file_type_),
-                        "Hardware event marker found in non-whole-system trace");
+                        "Hardware context marker found in non-whole-system trace");
     }
     // These markers are allowed between the syscall marker and a possible
     // syscall trace.
@@ -1255,6 +1255,10 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
                 handler_name = "Interrupt";
             }
             std::string error_msg = handler_name + " handler return point incorrect";
+            // Whole-system traces sometimes have the hardware_event and
+            // hardware_context_return markers nested inside the syscall_trace_start
+            // and syscall_trace_end markers, in which case they are really for the
+            // system call.
             if (shard->prev_xfer_marker_.marker.marker_type ==
                     TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN &&
                 shard->prev_entry_.marker.type == TRACE_TYPE_MARKER &&
@@ -1337,8 +1341,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         // Ignore timestamp, etc. markers which show up at signal delivery boundaries
         // b/c the tracer does a buffer flush there.
-        (is_context_event_marker(memref.marker.marker_type) ||
-         is_context_return_marker(memref.marker.marker_type))) {
+        (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
+         memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)) {
         if (knob_verbose_ >= 3) {
             std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: "
                       << "marker type " << memref.marker.marker_type << " value 0x"

--- a/clients/drcachesim/tools/invariant_checker.cpp
+++ b/clients/drcachesim/tools/invariant_checker.cpp
@@ -1341,8 +1341,8 @@ invariant_checker_t::parallel_shard_memref(void *shard_data, const memref_t &mem
     if (memref.marker.type == TRACE_TYPE_MARKER &&
         // Ignore timestamp, etc. markers which show up at signal delivery boundaries
         // b/c the tracer does a buffer flush there.
-        (memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_EVENT ||
-         memref.marker.marker_type == TRACE_MARKER_TYPE_KERNEL_XFER)) {
+        (is_context_event_marker(memref.marker.marker_type) ||
+         is_context_return_marker(memref.marker.marker_type))) {
         if (knob_verbose_ >= 3) {
             std::cerr << "::" << memref.data.pid << ":" << memref.data.tid << ":: "
                       << "marker type " << memref.marker.marker_type << " value 0x"

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -181,10 +181,11 @@ protected:
         // We keep track of some state per nested signal depth.
         struct signal_context {
             addr_t xfer_int_pc;
-            instr_info_t pre_signal_instr;
+            instr_info_t pre_context_instr;
+            trace_marker_type_t context_marker_type;
         };
         // We only support sigreturn-using handlers so we have pairing: no longjmp.
-        std::stack<signal_context> signal_stack_;
+        std::stack<signal_context> context_stack_;
 
         // When we see a TRACE_MARKER_TYPE_KERNEL_XFER we pop the top entry from
         // the above stack into the following. This is required because some of
@@ -193,7 +194,7 @@ protected:
         // The defaults are set to skip various signal-related checks in case we
         // see a signal-return before a signal-start (which happens when the trace
         // starts inside the app signal handler).
-        signal_context last_signal_context_ = { 0, {} };
+        signal_context last_context_ = { 0, {}, TRACE_MARKER_TYPE_KERNEL_EVENT };
 
         // For the outer-most scope, like other nested signal scopes, we start with an
         // empty memref_t to denote absence of any pre-signal instr.
@@ -256,8 +257,8 @@ protected:
         instr_info_t pre_syscall_trace_instr_;
         instr_info_t pre_context_switch_trace_instr_;
 #ifdef UNIX
-        int signal_stack_depth_at_syscall_trace_start_ = -1;
-        int signal_stack_depth_at_context_switch_trace_start_ = -1;
+        int context_stack_depth_at_syscall_trace_start_ = -1;
+        int context_stack_depth_at_context_switch_trace_start_ = -1;
 #endif
         addr_t prev_kernel_end_branch_target_ = 0;
         // Relevant when -no_abort_on_invariant_error.

--- a/clients/drcachesim/tools/invariant_checker.h
+++ b/clients/drcachesim/tools/invariant_checker.h
@@ -178,7 +178,7 @@ protected:
         // On UNIX generally last_instr_in_cur_context_ should be used instead.
         instr_info_t prev_instr_;
 #ifdef UNIX
-        // We keep track of some state per nested signal depth.
+        // We keep track of some state per nested signal/interrupt context depth.
         struct signal_context {
             addr_t xfer_int_pc;
             instr_info_t pre_context_instr;
@@ -187,17 +187,18 @@ protected:
         // We only support sigreturn-using handlers so we have pairing: no longjmp.
         std::stack<signal_context> context_stack_;
 
-        // When we see a TRACE_MARKER_TYPE_KERNEL_XFER we pop the top entry from
+        // When we see a context return marker (TRACE_MARKER_TYPE_KERNEL_XFER or
+        // TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN) we pop the top entry from
         // the above stack into the following. This is required because some of
-        // our signal-related checks happen after the above stack is already popped
-        // at the TRACE_MARKER_TYPE_KERNEL_XFER marker.
-        // The defaults are set to skip various signal-related checks in case we
-        // see a signal-return before a signal-start (which happens when the trace
-        // starts inside the app signal handler).
+        // our context-event-related checks happen after the above stack is already popped
+        // at the context return marker.
+        // The defaults are set to skip various context-event-related checks in case we
+        // see a context-return before a context-start (which happens when the trace
+        // starts inside the app signal/interrupt handler).
         signal_context last_context_ = { 0, {}, TRACE_MARKER_TYPE_KERNEL_EVENT };
 
-        // For the outer-most scope, like other nested signal scopes, we start with an
-        // empty memref_t to denote absence of any pre-signal instr.
+        // For the outer-most scope, like other nested context scopes, we start with an
+        // empty memref_t to denote absence of any pre-signal/interrupt instr.
         instr_info_t last_instr_in_cur_context_;
 
         bool saw_rseq_abort_ = false;


### PR DESCRIPTION
Augments the invariant checker to identify the TRACE_MARKER_TYPE_HARDWARE_EVENT and TRACE_MARKER_TYPE_HARDWARE_CONTEXT_RETURN markers.

This involves treating them similarly to the existing TRACE_MARKER_TYPE_KERNEL_EVENT and TRACE_MARKER_TYPE_KERNEL_XFER markers, and keeping track of the enclosed part of the trace in a separate context.

Also adds unit tests for the various hardware context marker related scenarios.

Issue: #7854