### PR TITLE
i#7881 rebalance: Report instruction ratio in schedule_stats (#7869)

### DIFF
--- a/clients/drcachesim/tests/schedule_stats_maxcores.templatex
+++ b/clients/drcachesim/tests/schedule_stats_maxcores.templatex
@@ -28,3 +28,4 @@ Core #3 schedule: _[A-Ia-i_]*
 Core #0 switch-outs:
 .*
 Max activity ratio between cores: .*
+Max instruction ratio between cores: .*

--- a/clients/drcachesim/tests/schedule_stats_test.cpp
+++ b/clients/drcachesim/tests/schedule_stats_test.cpp
@@ -94,6 +94,12 @@ public:
         return max_core_activity_ratio_;
     }
 
+    double
+    get_max_core_instruction_ratio()
+    {
+        return max_core_instruction_ratio_;
+    }
+
     bool
     parallel_shard_memref(void *shard_data, const memref_t &memref) override
     {
@@ -953,9 +959,12 @@ test_core_ratio()
     };
     mock_schedule_stats_t tool(/*print_every=*/1, /*verbosity=*/1);
     run_schedule_stats_with_tool(tool, memrefs);
-    double ratio = tool.get_max_core_activity_ratio();
-    std::cerr << "Core ratio: " << ratio << "\n";
-    assert(ratio > 2.999 && ratio <= 3.001);
+    double activity_ratio = tool.get_max_core_activity_ratio();
+    std::cerr << "Core activity ratio: " << activity_ratio << "\n";
+    assert(activity_ratio > 2.999 && activity_ratio <= 3.001);
+    double instruction_ratio = tool.get_max_core_instruction_ratio();
+    std::cerr << "Core instruction ratio: " << instruction_ratio << "\n";
+    assert(instruction_ratio > 2.999 && instruction_ratio <= 3.001);
     return true;
 }
 

--- a/clients/drcachesim/tools/schedule_stats.cpp
+++ b/clients/drcachesim/tools/schedule_stats.cpp
@@ -814,6 +814,8 @@ schedule_stats_template_t<RecordType>::aggregate_results(counters_t &total)
         cpu_footprint;
     int64_t min_activity = std::numeric_limits<int64_t>::max();
     int64_t max_activity = std::numeric_limits<int64_t>::min();
+    int64_t min_instrs = std::numeric_limits<int64_t>::max();
+    int64_t max_instrs = std::numeric_limits<int64_t>::min();
     for (const auto &[index, shard] : shard_map_) {
         // First update our per-shard data with per-shard stats from the scheduler.
         get_scheduler_stats(shard->stream, shard->counters);
@@ -829,6 +831,8 @@ schedule_stats_template_t<RecordType>::aggregate_results(counters_t &total)
         int64_t activity = shard->counters.instrs + shard->counters.idles;
         min_activity = std::min(activity, min_activity);
         max_activity = std::max(activity, max_activity);
+        min_instrs = std::min(shard->counters.instrs, min_instrs);
+        max_instrs = std::max(shard->counters.instrs, max_instrs);
 
         for (const workload_tid_t wtid : shard->counters.threads) {
             cpu_footprint[wtid].insert(shard->core);
@@ -872,6 +876,7 @@ schedule_stats_template_t<RecordType>::aggregate_results(counters_t &total)
     }
 
     max_core_activity_ratio_ = static_cast<double>(max_activity) / min_activity;
+    max_core_instruction_ratio_ = static_cast<double>(max_instrs) / min_instrs;
 }
 
 template <typename RecordType>
@@ -921,6 +926,8 @@ schedule_stats_template_t<RecordType>::print_results()
         }
     }
     std::cerr << "Max activity ratio between cores: " << max_core_activity_ratio_ << "\n";
+    std::cerr << "Max instruction ratio between cores: " << max_core_instruction_ratio_
+              << "\n";
     return true;
 }
 

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -497,6 +497,8 @@ protected:
     std::mutex prev_core_mutex_;
     // Ratio of largest instructions+idles to smallest across the cores.
     double max_core_activity_ratio_;
+    // Ratio of most instructions to fewest across the cores.
+    double max_core_instruction_ratio_;
 };
 
 typedef schedule_stats_template_t<memref_t> schedule_stats_t;

--- a/clients/drcachesim/tools/schedule_stats.h
+++ b/clients/drcachesim/tools/schedule_stats.h
@@ -496,9 +496,9 @@ protected:
     std::unordered_map<workload_tid_t, int64_t, workload_tid_hash_t> prev_core_;
     std::mutex prev_core_mutex_;
     // Ratio of largest instructions+idles to smallest across the cores.
-    double max_core_activity_ratio_;
+    double max_core_activity_ratio_ = -1.;
     // Ratio of most instructions to fewest across the cores.
-    double max_core_instruction_ratio_;
+    double max_core_instruction_ratio_ = -1.;
 };
 
 typedef schedule_stats_template_t<memref_t> schedule_stats_t;


### PR DESCRIPTION
Adds the ratio of just instructions (as opposed to the existing "activity" which is instructions+idles for #7860) between the max and min such count for all cores, in the schedule_stats tool. This indicates the schedule balance and is useful for tuning the scheduler's inter-core stealing and rebalancing heuristics.

Adds a unit test.

Issue: #7881