### PR TITLE
i#7889: Zero upper vector on gather to lower bits

### DIFF
--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
@@ -3,11 +3,20 @@ Hello world!
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
+#ifdef __AVX512F__
+         175 total \(fetched\) instructions
+         175 total unique \(fetched\) instructions
+#else
          116 total \(fetched\) instructions
          116 total unique \(fetched\) instructions
+#endif
            0 total non-fetched instructions
            0 total prefetches
+#ifdef __AVX512F__
+          52 total data loads
+#else
           10 total data loads
+#endif
            5 total data stores
            0 total icache flushes
            0 total dcache flushes
@@ -15,11 +24,20 @@ Total counts:
      .* total timestamp \+ cpuid markers
 .*
 Thread .* counts:
+#ifdef __AVX512F__
+         175 \(fetched\) instructions
+         175 unique \(fetched\) instructions
+#else
          116 \(fetched\) instructions
          116 unique \(fetched\) instructions
+#endif
            0 non-fetched instructions
            0 prefetches
+#ifdef __AVX512F__
+          52 data loads
+#else
           10 data loads
+#endif
            5 data stores
            0 icache flushes
            0 dcache flushes

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
@@ -14,10 +14,11 @@ Total counts:
            0 total prefetches
 #ifdef __AVX512F__
           52 total data loads
+           9 total data stores
 #else
           10 total data loads
-#endif
            5 total data stores
+#endif
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -35,10 +36,11 @@ Thread .* counts:
            0 prefetches
 #ifdef __AVX512F__
           52 data loads
+           9 data stores
 #else
           10 data loads
-#endif
            5 data stores
+#endif
            0 icache flushes
            0 dcache flushes
      .* timestamp \+ cpuid markers

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
@@ -3,11 +3,11 @@ Hello world!
 ---- <application exited with code 0> ----
 Basic counts tool results:
 Total counts:
-          96 total \(fetched\) instructions
-          96 total unique \(fetched\) instructions
+         116 total \(fetched\) instructions
+         116 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
-           6 total data loads
+          10 total data loads
            5 total data stores
            0 total icache flushes
            0 total dcache flushes
@@ -15,11 +15,11 @@ Total counts:
      .* total timestamp \+ cpuid markers
 .*
 Thread .* counts:
-          96 \(fetched\) instructions
-          96 unique \(fetched\) instructions
+         116 \(fetched\) instructions
+         116 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
-           6 data loads
+          10 data loads
            5 data stores
            0 icache flushes
            0 dcache flushes

--- a/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/allasm-scattergather-basic-counts-x86.templatex
@@ -4,11 +4,11 @@ Hello world!
 Basic counts tool results:
 Total counts:
 #ifdef __AVX512F__
-         175 total \(fetched\) instructions
-         175 total unique \(fetched\) instructions
+         170 total \(fetched\) instructions
+         170 total unique \(fetched\) instructions
 #else
-         116 total \(fetched\) instructions
-         116 total unique \(fetched\) instructions
+         111 total \(fetched\) instructions
+         111 total unique \(fetched\) instructions
 #endif
            0 total non-fetched instructions
            0 total prefetches
@@ -26,11 +26,11 @@ Total counts:
 .*
 Thread .* counts:
 #ifdef __AVX512F__
-         175 \(fetched\) instructions
-         175 unique \(fetched\) instructions
+         170 \(fetched\) instructions
+         170 unique \(fetched\) instructions
 #else
-         116 \(fetched\) instructions
-         116 unique \(fetched\) instructions
+         111 \(fetched\) instructions
+         111 unique \(fetched\) instructions
 #endif
            0 non-fetched instructions
            0 prefetches

--- a/clients/drcachesim/tests/allasm_scattergather_x86.asm
+++ b/clients/drcachesim/tests/allasm_scattergather_x86.asm
@@ -1,5 +1,5 @@
  /* **********************************************************
- * Copyright (c) 2021 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -217,10 +217,175 @@ _start:
         cmp      eax, 0xffffffff
         jne      incorrect
 
+        // Test 4: Verify that gather into XMM zeroes the upper YMM bits.
+        // Initialize ymm4 to all 1s.
+        vpcmpeqd ymm4, ymm4, ymm4
+
+        // Set up mask in xmm13 (all 1s)
+        vpcmpeqd xmm13, xmm13, xmm13
+
+        // Gather into xmm4.
+        // Upper 128 bits of ymm4 should be zeroed.
+        vpgatherdd xmm4, [arr + xmm11*4], xmm13
+
+        // Extract upper 128 bits of ymm4 into xmm5.
+        vextracti128 xmm5, ymm4, 1
+
+        // Verify xmm5 is all zeroes.
+        vptest   xmm5, xmm5
+        jnz      incorrect_zeroing
+
+        // Test 5: Verify that gather into XMM zeroes the upper YMM bits even
+        // when mask is all 0s.
+        // Initialize ymm4 to all 1s.
+        vpcmpeqd ymm4, ymm4, ymm4
+
+        // Set up mask in xmm13 (all 0s)
+        vpxor    xmm13, xmm13, xmm13
+
+        // Gather into xmm4.
+        // Since mask is 0, no elements are gathered.
+        // Lower 128 bits of ymm4 should remain all 1s (preserved).
+        // Upper 128 bits of ymm4 should be zeroed.
+        vpgatherdd xmm4, [arr + xmm11*4], xmm13
+
+        // Verify xmm4 is all ones, since gather uses merge masking
+        // and xmm4 was all ones before the vpgatherdd.
+        vpcmpeqd xmm6, xmm6, xmm6
+        pcmpeqq  xmm4, xmm6
+        vpextrd  eax, xmm4, 0
+        cmp      eax, 0xffffffff
+        jne      incorrect_zeroing_mask0
+        vpextrd  eax, xmm4, 2
+        cmp      eax, 0xffffffff
+        jne      incorrect_zeroing_mask0
+
+        // Verify upper bits of ymm4 are zeroed.
+        vextracti128 xmm5, ymm4, 1
+        vptest   xmm5, xmm5
+        jnz      incorrect_zeroing_mask0
+
+#ifdef __AVX512F__
+        // Test 6: Verify that EVEX gather into XMM zeroes the upper ZMM
+        // bits (128-511).
+        // Initialize zmm4 to all 1s.
+        vmovdqu64 zmm4, [ones_512]
+
+        // Set up mask in k1 (all 1s for 4 elements)
+        mov      eax, 0xf
+        kmovw    k1, eax
+
+        // Gather into xmm4.
+        vpgatherdd xmm4 {k1}, [arr + xmm11*4]
+
+        // Store zmm4 to memory to inspect.
+        vmovdqu64 [zmm_dest], zmm4
+
+        // Verify upper 384 bits (bytes 16-63) are all zeroes.
+        mov      rax, qword ptr [zmm_dest + 16]
+        or       rax, qword ptr [zmm_dest + 24]
+        or       rax, qword ptr [zmm_dest + 32]
+        or       rax, qword ptr [zmm_dest + 40]
+        or       rax, qword ptr [zmm_dest + 48]
+        or       rax, qword ptr [zmm_dest + 56]
+        cmp      rax, 0
+        jne      incorrect_avx512_zeroing
+
+        // Test 7: Verify that EVEX gather into XMM zeroes the upper ZMM
+        // bits even when mask is 0.
+        // Initialize zmm4 to all 1s.
+        vmovdqu64 zmm4, [ones_512]
+
+        // Set up mask in k1 (all 0s)
+        xor      eax, eax
+        kmovw    k1, eax
+
+        // Gather into xmm4.
+        vpgatherdd xmm4 {k1}, [arr + xmm11*4]
+
+        // Store zmm4 to memory to inspect.
+        vmovdqu64 [zmm_dest], zmm4
+
+        // Verify the xmm part is all ones, since gather uses merge
+        // masking and xmm was all ones before the vpgatherdd.
+        mov      rax, qword ptr [zmm_dest]
+        and      rax, qword ptr [zmm_dest + 8]
+        cmp      rax, -1
+        jne      incorrect_avx512_zeroing_mask0
+
+        mov      rax, qword ptr [zmm_dest + 16]
+        or       rax, qword ptr [zmm_dest + 24]
+        or       rax, qword ptr [zmm_dest + 32]
+        or       rax, qword ptr [zmm_dest + 40]
+        or       rax, qword ptr [zmm_dest + 48]
+        or       rax, qword ptr [zmm_dest + 56]
+        cmp      rax, 0
+        jne      incorrect_avx512_zeroing_mask0
+
+        // Test 8: Verify that EVEX gather into YMM zeroes the upper ZMM
+        // bits (256-511).
+        // Prepare ymm11 (indices) by duplicating xmm11.
+        vinserti128 ymm11, ymm11, xmm11, 1
+
+        // Initialize zmm4 to all 1s.
+        vmovdqu64 zmm4, [ones_512]
+
+        // Set up mask in k1 (all 1s for 8 elements)
+        mov      eax, 0xff
+        kmovw    k1, eax
+
+        // Gather into ymm4.
+        vpgatherdd ymm4 {k1}, [arr + ymm11*4]
+
+        // Store zmm4 to memory.
+        vmovdqu64 [zmm_dest], zmm4
+
+        // Verify upper 256 bits (bytes 32-63) are all zeroes.
+        mov      rax, qword ptr [zmm_dest + 32]
+        or       rax, qword ptr [zmm_dest + 40]
+        or       rax, qword ptr [zmm_dest + 48]
+        or       rax, qword ptr [zmm_dest + 56]
+        cmp      rax, 0
+        jne      incorrect_avx512_ymm_zeroing
+
+        // Test 9: Verify that EVEX gather into YMM zeroes the upper ZMM
+        // bits even when mask is 0.
+        // Initialize zmm4 to all 1s.
+        vmovdqu64 zmm4, [ones_512]
+
+        // Set up mask in k1 (all 0s)
+        xor      eax, eax
+        kmovw    k1, eax
+
+        // Gather into ymm4.
+        vpgatherdd ymm4 {k1}, [arr + ymm11*4]
+
+        // Store zmm4 to memory.
+        vmovdqu64 [zmm_dest], zmm4
+
+        // Verify the ymm part is all ones, because gather is merge
+        // masking and it was all ones before the vpgatherdd.
+        mov      rax, qword ptr [zmm_dest]
+        and      rax, qword ptr [zmm_dest + 8]
+        and      rax, qword ptr [zmm_dest + 16]
+        and      rax, qword ptr [zmm_dest + 24]
+        cmp      rax, -1
+        jne      incorrect_avx512_ymm_zeroing_mask0
+
+        // Verify the upper part of zmm is all zero.
+        mov      rax, qword ptr [zmm_dest + 32]
+        or       rax, qword ptr [zmm_dest + 40]
+        or       rax, qword ptr [zmm_dest + 48]
+        or       rax, qword ptr [zmm_dest + 56]
+        cmp      rax, 0
+        jne      incorrect_avx512_ymm_zeroing_mask0
+#endif
+
         // Print comparison result.
         lea      rsi, correct_str
         mov      rdx, 8           // sizeof(correct_str)
         jmp      done_cmp
+
 incorrect:
         lea      rsi, incorrect_str
         mov      rdx, 10          // sizeof(incorrect_str)
@@ -228,6 +393,30 @@ incorrect:
 incorrect_scratch:
         lea      rsi, incorrect_scratch_str
         mov      rdx, 18
+        jmp      done_cmp
+incorrect_zeroing:
+        lea      rsi, incorrect_zeroing_str
+        mov      rdx, 28          // sizeof(incorrect_zeroing_str)
+        jmp      done_cmp
+incorrect_zeroing_mask0:
+        lea      rsi, incorrect_zeroing_mask0_str
+        mov      rdx, 34          // sizeof(incorrect_zeroing_mask0_str)
+        jmp      done_cmp
+incorrect_avx512_zeroing:
+        lea      rsi, incorrect_avx512_zeroing_str
+        mov      rdx, 30          // sizeof(incorrect_avx512_zeroing_str)
+        jmp      done_cmp
+incorrect_avx512_zeroing_mask0:
+        lea      rsi, incorrect_avx512_zeroing_mask0_str
+        mov      rdx, 36          // sizeof(incorrect_avx512_zeroing_mask0_str)
+        jmp      done_cmp
+incorrect_avx512_ymm_zeroing:
+        lea      rsi, incorrect_avx512_ymm_zeroing_str
+        mov      rdx, 30          // sizeof(incorrect_avx512_ymm_zeroing_str)
+        jmp      done_cmp
+incorrect_avx512_ymm_zeroing_mask0:
+        lea      rsi, incorrect_avx512_ymm_zeroing_mask0_str
+        mov      rdx, 36          // sizeof(incorrect_avx512_ymm_zeroing_mask0_str)
 done_cmp:
         mov      rdi, 2           // stderr
         mov      eax, 1           // SYS_write
@@ -255,9 +444,25 @@ incorrect_str:
         .string  "Incorrect\n"
 incorrect_scratch_str:
         .string  "Incorrect scratch\n"
+incorrect_zeroing_str:
+        .string  "Incorrect YMM upper zeroing\n"
+incorrect_zeroing_mask0_str:
+        .string  "Incorrect YMM upper zeroing mask0\n"
 arr_neg:
         .zero    4
 arr:
         .zero    16
 save_mm0:
+        .zero    64
+incorrect_avx512_zeroing_str:
+        .string  "Incorrect AVX-512 XMM zeroing\n"
+incorrect_avx512_zeroing_mask0_str:
+        .string  "Incorrect AVX-512 XMM zeroing mask0\n"
+incorrect_avx512_ymm_zeroing_str:
+        .string  "Incorrect AVX-512 YMM zeroing\n"
+incorrect_avx512_ymm_zeroing_mask0_str:
+        .string  "Incorrect AVX-512 YMM zeroing mask0\n"
+ones_512:
+        .quad    -1, -1, -1, -1, -1, -1, -1, -1
+zmm_dest:
         .zero    64

--- a/clients/drcachesim/tests/allasm_scattergather_x86.asm
+++ b/clients/drcachesim/tests/allasm_scattergather_x86.asm
@@ -252,13 +252,8 @@ _start:
         // Verify xmm4 is all ones, since gather uses merge masking
         // and xmm4 was all ones before the vpgatherdd.
         vpcmpeqd xmm6, xmm6, xmm6
-        pcmpeqq  xmm4, xmm6
-        vpextrd  eax, xmm4, 0
-        cmp      eax, 0xffffffff
-        jne      incorrect_zeroing_mask0
-        vpextrd  eax, xmm4, 2
-        cmp      eax, 0xffffffff
-        jne      incorrect_zeroing_mask0
+        vptest   xmm4, xmm6
+        jnc      incorrect_zeroing_mask0
 
         // Verify upper bits of ymm4 are zeroed.
         vextracti128 xmm5, ymm4, 1

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
@@ -2,11 +2,20 @@ Correct
 Hello world!
 Basic counts tool results:
 Total counts:
+#ifdef __AVX512F__
+         175 total \(fetched\) instructions
+         175 total unique \(fetched\) instructions
+#else
          116 total \(fetched\) instructions
          116 total unique \(fetched\) instructions
+#endif
            0 total non-fetched instructions
            0 total prefetches
+#ifdef __AVX512F__
+          52 total data loads
+#else
           10 total data loads
+#endif
            5 total data stores
            0 total icache flushes
            0 total dcache flushes
@@ -14,11 +23,20 @@ Total counts:
      .* total timestamp \+ cpuid markers
 .*
 Thread .* counts:
+#ifdef __AVX512F__
+         175 \(fetched\) instructions
+         175 unique \(fetched\) instructions
+#else
          116 \(fetched\) instructions
          116 unique \(fetched\) instructions
+#endif
            0 non-fetched instructions
            0 prefetches
+#ifdef __AVX512F__
+          52 data loads
+#else
           10 data loads
+#endif
            5 data stores
            0 icache flushes
            0 dcache flushes

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
@@ -2,11 +2,11 @@ Correct
 Hello world!
 Basic counts tool results:
 Total counts:
-          96 total \(fetched\) instructions
-          96 total unique \(fetched\) instructions
+         116 total \(fetched\) instructions
+         116 total unique \(fetched\) instructions
            0 total non-fetched instructions
            0 total prefetches
-           6 total data loads
+          10 total data loads
            5 total data stores
            0 total icache flushes
            0 total dcache flushes
@@ -14,11 +14,11 @@ Total counts:
      .* total timestamp \+ cpuid markers
 .*
 Thread .* counts:
-          96 \(fetched\) instructions
-          96 unique \(fetched\) instructions
+         116 \(fetched\) instructions
+         116 unique \(fetched\) instructions
            0 non-fetched instructions
            0 prefetches
-           6 data loads
+          10 data loads
            5 data stores
            0 icache flushes
            0 dcache flushes

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
@@ -13,10 +13,11 @@ Total counts:
            0 total prefetches
 #ifdef __AVX512F__
           52 total data loads
+           9 total data stores
 #else
           10 total data loads
-#endif
            5 total data stores
+#endif
            0 total icache flushes
            0 total dcache flushes
            1 total threads
@@ -34,10 +35,11 @@ Thread .* counts:
            0 prefetches
 #ifdef __AVX512F__
           52 data loads
+           9 data stores
 #else
           10 data loads
-#endif
            5 data stores
+#endif
            0 icache flushes
            0 dcache flushes
      .* timestamp \+ cpuid markers

--- a/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
+++ b/clients/drcachesim/tests/offline-allasm-scattergather-basic-counts-x86.templatex
@@ -3,11 +3,11 @@ Hello world!
 Basic counts tool results:
 Total counts:
 #ifdef __AVX512F__
-         175 total \(fetched\) instructions
-         175 total unique \(fetched\) instructions
+         170 total \(fetched\) instructions
+         170 total unique \(fetched\) instructions
 #else
-         116 total \(fetched\) instructions
-         116 total unique \(fetched\) instructions
+         111 total \(fetched\) instructions
+         111 total unique \(fetched\) instructions
 #endif
            0 total non-fetched instructions
            0 total prefetches
@@ -25,11 +25,11 @@ Total counts:
 .*
 Thread .* counts:
 #ifdef __AVX512F__
-         175 \(fetched\) instructions
-         175 unique \(fetched\) instructions
+         170 \(fetched\) instructions
+         170 unique \(fetched\) instructions
 #else
-         116 \(fetched\) instructions
-         116 unique \(fetched\) instructions
+         111 \(fetched\) instructions
+         111 unique \(fetched\) instructions
 #endif
            0 non-fetched instructions
            0 prefetches

--- a/ext/drx/scatter_gather_x86.c
+++ b/ext/drx/scatter_gather_x86.c
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2013-2025 Google, Inc.   All rights reserved.
+ * Copyright (c) 2013-2026 Google, Inc.   All rights reserved.
  * **********************************************************/
 
 /*
@@ -68,6 +68,7 @@
 #    define IF_DEBUG(x)    /* nothing */
 #endif                     /* DEBUG */
 
+#define HALF_XMM_REG_SIZE 8
 #define XMM_REG_SIZE 16
 #define YMM_REG_SIZE 32
 #define ZMM_REG_SIZE 64
@@ -726,7 +727,7 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
 {
     uint processed_bytes =
         no_of_elements * opnd_size_in_bytes(sg_info->scalar_value_size);
-    uint max_vector_bytes = proc_avx512_enabled() ? 64 : 32;
+    uint max_vector_bytes = proc_avx512_enabled() ? ZMM_REG_SIZE : YMM_REG_SIZE;
     if (processed_bytes == max_vector_bytes)
         return true;
     /* We may have a partial gather if the index size is larger than the data size,
@@ -746,8 +747,10 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
     }
 
     reg_id_t dst_reg = sg_info->gather_dst_reg;
-    if (processed_bytes == 8) {
-        /* E.g., vpgatherqd/vgatherqps xmm0 {k1}, [xax + xmm1 * 4] */
+    if (processed_bytes == HALF_XMM_REG_SIZE) {
+        /* Partial gather example:
+         * vpgatherqd/vgatherqps xmm0 {k1}, [xax + xmm1 * 4]
+         */
         reg_id_t dst_xmm = reg_resize_to_opsz(dst_reg, OPSZ_16);
         /* vmovq between xmm registers is a 64-bit move: it copies the lowest
          * 64 bits onto themselves (preserving gathered data) and explicitly
@@ -757,8 +760,9 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
                INSTR_XL8(INSTR_CREATE_vmovq(drcontext, opnd_create_reg(dst_xmm),
                                             opnd_create_reg(dst_xmm)),
                          orig_app_pc));
-    } else if (processed_bytes == 16) {
-        /* E.g., vpgatherqd/vgatherqps xmm0 {k1}, [xax + ymm1 * 4]
+    } else if (processed_bytes == XMM_REG_SIZE) {
+        /* Partial gather example:
+         * vpgatherqd/vgatherqps xmm0 {k1}, [xax + ymm1 * 4]
          * where the dest reg is inflated to YMM size by the DR decoder, by design.
          */
         reg_id_t dst_xmm = reg_resize_to_opsz(dst_reg, OPSZ_16);
@@ -770,8 +774,9 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
                INSTR_XL8(INSTR_CREATE_vmovdqa(drcontext, opnd_create_reg(dst_xmm),
                                               opnd_create_reg(dst_xmm)),
                          orig_app_pc));
-    } else if (processed_bytes == 32) {
-        /* E.g., vpgatherqd/vgatherqps ymm0 {k1}, [xax + zmm1 * 4]
+    } else if (processed_bytes == YMM_REG_SIZE) {
+        /* Partial gather example:
+         * vpgatherqd/vgatherqps ymm0 {k1}, [xax + zmm1 * 4]
          * where the dest reg is inflated to zmm size by the DR decoder, by design.
          */
         reg_id_t dst_ymm = reg_resize_to_opsz(dst_reg, OPSZ_32);

--- a/ext/drx/scatter_gather_x86.c
+++ b/ext/drx/scatter_gather_x86.c
@@ -726,18 +726,24 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
 {
     uint processed_bytes =
         no_of_elements * opnd_size_in_bytes(sg_info->scalar_value_size);
-    if (processed_bytes == opnd_size_in_bytes(sg_info->scatter_gather_size))
+    uint max_vector_bytes = proc_avx512_enabled() ? 64 : 32;
+    if (processed_bytes == max_vector_bytes)
         return true;
     /* We may have a partial gather if the index size is larger than the data size,
      * which causes only the first half of the destination vector reg to be loaded.
      * E.g., for vpgatherqd and vgatherqps.
+     * Or we may have a full gather into a smaller vector register (XMM or YMM)
+     * where we need to zero out the remaining upper bits of the larger register
+     * (YMM or ZMM) due to VEX/EVEX encoding rules.
      * We cannot zero out the whole vector before the gather expansion because we
      * want to preserve initial values of masked data elements that are not supposed
      * to be loaded/overwritten.
      */
-    ASSERT(processed_bytes * 2 == opnd_size_in_bytes(sg_info->scatter_gather_size),
-           "Partial gather must statically fill exactly half of the destination "
-           "register.");
+    if (processed_bytes < opnd_size_in_bytes(sg_info->scatter_gather_size)) {
+        ASSERT(processed_bytes * 2 == opnd_size_in_bytes(sg_info->scatter_gather_size),
+               "Partial gather must statically fill exactly half of the destination "
+               "register.");
+    }
 
     reg_id_t dst_reg = sg_info->gather_dst_reg;
     if (processed_bytes == 8) {

--- a/ext/drx/scatter_gather_x86.c
+++ b/ext/drx/scatter_gather_x86.c
@@ -761,9 +761,9 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
                                             opnd_create_reg(dst_xmm)),
                          orig_app_pc));
     } else if (processed_bytes == XMM_REG_SIZE) {
-        /* Partial gather example:
+        /* This also handles partial gathers into inflated ymm (i#7887) such as:
          * vpgatherqd/vgatherqps xmm0 {k1}, [xax + ymm1 * 4]
-         * where the dest reg is inflated to YMM size by the DR decoder, by design.
+         * where the dest reg is inflated to ymm size by the DR decoder, by design.
          */
         reg_id_t dst_xmm = reg_resize_to_opsz(dst_reg, OPSZ_16);
         /* vmovdqa between xmm registers is a 128-bit move: it copies the full
@@ -775,7 +775,7 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
                                               opnd_create_reg(dst_xmm)),
                          orig_app_pc));
     } else if (processed_bytes == YMM_REG_SIZE) {
-        /* Partial gather example:
+        /* This also handles partial gathers into inflated zmm (i#7887) such as:
          * vpgatherqd/vgatherqps ymm0 {k1}, [xax + zmm1 * 4]
          * where the dest reg is inflated to zmm size by the DR decoder, by design.
          */

--- a/ext/drx/scatter_gather_x86.c
+++ b/ext/drx/scatter_gather_x86.c
@@ -761,9 +761,10 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
                                             opnd_create_reg(dst_xmm)),
                          orig_app_pc));
     } else if (processed_bytes == XMM_REG_SIZE) {
-        /* This also handles partial gathers into inflated ymm (i#7887) such as:
-         * vpgatherqd/vgatherqps xmm0 {k1}, [xax + ymm1 * 4]
-         * where the dest reg is inflated to ymm size by the DR decoder, by design.
+        /* The DR decoder (incorrectly; i#7887) inflates some xmm destinations into
+         * ymm (e.g., vpgatherqd/vgatherqps xmm0 {k1}, [xax + ymm1 * 4]), making
+         * them appear as though they are "partial" gathers; regardless, they need
+         * zeroing and will come here.
          */
         reg_id_t dst_xmm = reg_resize_to_opsz(dst_reg, OPSZ_16);
         /* vmovdqa between xmm registers is a 128-bit move: it copies the full
@@ -775,9 +776,10 @@ expand_gather_zero_remaining_lanes(void *drcontext, instrlist_t *bb, instr_t *sg
                                               opnd_create_reg(dst_xmm)),
                          orig_app_pc));
     } else if (processed_bytes == YMM_REG_SIZE) {
-        /* This also handles partial gathers into inflated zmm (i#7887) such as:
-         * vpgatherqd/vgatherqps ymm0 {k1}, [xax + zmm1 * 4]
-         * where the dest reg is inflated to zmm size by the DR decoder, by design.
+        /* The DR decoder (incorrectly; i#7887) inflates some ymm destinations into
+         * zmm (e.g., vpgatherqd/vgatherqps ymm0 {k1}, [xax + zmm1 * 4]), making
+         * them appear as though they are "partial" gathers; regardless, they need
+         * zeroing and will come here.
          */
         reg_id_t dst_ymm = reg_resize_to_opsz(dst_reg, OPSZ_32);
         /* vmovdqa between ymm registers is a 256-bit move: it copies the full


### PR DESCRIPTION
Invokes the logic to zero the upper bits of the ymm/zmm vector (depending on whether the machine supports AVX2 or AVX512), when only the lower bits of it that map to xmm or ymm are gathered into.

#7883 added the zeroing logic already but invoked it only for partial gathers where there's a mismatch between the index and data element sizes. Here we invoke it for all cases where the vector gathered into is smaller than the full length supported by the machine.

Extends the allasm_scattergather_x86.asm test to verify that the upper part of the vector gathered-into is indeed zeroed. This works fine when not under DynamoRIO which verifies our assumptions.

Verified on a machine with AVX-512 that the tests pass:

```
The following tests passed:
        code_api|client.drx-scattergather
        code_api|client.drx-scattergather-bbdup
        code_api|sample.memval_simple_scattergather
        code_api|tool.drcachesim.scattergather-x86
        code_api|tool.drcacheoff.allasm-scattergather-basic-counts
        code_api|tool.drcachesim.allasm-scattergather-basic-counts
```

Also verified that each of the new sub-tests fail without the fix.

Fixes: #7889