### PR TITLE
i#7695: Allow 32-bit log about AVX-512 not fully supported

### DIFF
--- a/clients/drcachesim/tests/scattergather-x86.templatex
+++ b/clients/drcachesim/tests/scattergather-x86.templatex
@@ -1,5 +1,6 @@
 #ifdef __AVX512F__
-AVX-512 gather ok
+(<Application .*AVX-512 was detected at PC 0x[0-9a-f]+. AVX-512 is not fully supported yet.>
+)?AVX-512 gather ok
 AVX-512 gather ok
 #ifdef X64
 AVX-512 gather ok

--- a/suite/tests/client-interface/drx-scattergather-x86.templatex
+++ b/suite/tests/client-interface/drx-scattergather-x86.templatex
@@ -1,5 +1,6 @@
 #ifdef __AVX512F__
-AVX-512 gather ok
+(<Application .*AVX-512 was detected at PC 0x[0-9a-f]+. AVX-512 is not fully supported yet.>
+)?AVX-512 gather ok
 AVX-512 gather ok
 #ifdef X64
 AVX-512 gather ok


### PR DESCRIPTION
This log is printed always on 32-bit because of some missing support when there's any AVX-512 instr seen. It should be expected.

Tested using x86-32 build on a VM with AVX-512 supported where the following tests used to fail without this fix but now pass.

```
        233 - code_api|client.drx-scattergather (Failed)
        234 - code_api|client.drx-scattergather-bbdup (Failed)
        263 - code_api|sample.memval_simple_scattergather (Failed)
        321 - code_api|tool.drcachesim.scattergather-x86 (Failed)
```

Issue: #7695