### PR TITLE
i#7842: ISA feature AARCH64 bug fix

### DIFF
--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -894,12 +894,13 @@ uint
 instr_get_isa_feature(byte *pc, instr_t *instr)
 {
     decode_info_t di;
-    // We only need to identify the instruction's ISA feature and not actually generate a
-    // valid encoding, so we can safely skip the reachability check, which, for
-    // instructions like bcond, checks if the target address in the instructions operand
-    // is reachable from the instructions' pc. Depending on how this function is used, pc
-    // is not necessarily the instruction's actual pc, it can be an unrelated address like
-    // a buffer, so disabling the reachability check is necessary.
+    /* We only need to identify the instruction's ISA feature and not actually generate a
+     * valid encoding, so we can safely skip the reachability check, which, for
+     * instructions like bcond, checks if the target address in the instructions operand
+     * is reachable from the instructions' pc. Depending on how this function is used, pc
+     * is not necessarily the instruction's actual pc, it can be an unrelated address like
+     * a buffer, so disabling the reachability check is necessary.
+     */
     di.check_reachable = false;
     return isa_feature_common(pc, instr, &di);
 }

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -894,6 +894,13 @@ uint
 instr_get_isa_feature(byte *pc, instr_t *instr)
 {
     decode_info_t di;
+    // We only need to identify the instruction's ISA feature and not actually generate a
+    // valid encoding, so we can safely skip the reachability check, which, for
+    // instructions like bcond, enables the reachability check of the target address in
+    // its operand and the instructions' pc. This is necessary as, depending on how this
+    // function is used, pc is not necessarily the instruction's actual pc, it can be an
+    // unrelated address like a buffer.
+    di.check_reachable = true;
     return isa_feature_common(pc, instr, &di);
 }
 

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -896,11 +896,11 @@ instr_get_isa_feature(byte *pc, instr_t *instr)
     decode_info_t di;
     // We only need to identify the instruction's ISA feature and not actually generate a
     // valid encoding, so we can safely skip the reachability check, which, for
-    // instructions like bcond, enables the reachability check of the target address in
-    // its operand and the instructions' pc. This is necessary as, depending on how this
-    // function is used, pc is not necessarily the instruction's actual pc, it can be an
-    // unrelated address like a buffer.
-    di.check_reachable = true;
+    // instructions like bcond, checks if the target address in the instructions operand
+    // is reachable from the instructions' pc. Depending on how this function is used, pc
+    // is not necessarily the instruction's actual pc, it can be an unrelated address like
+    // a buffer, so disabling the reachability check is necessary.
+    di.check_reachable = false;
     return isa_feature_common(pc, instr, &di);
 }
 

--- a/core/ir/aarch64/instr.c
+++ b/core/ir/aarch64/instr.c
@@ -896,8 +896,8 @@ instr_get_isa_feature(byte *pc, instr_t *instr)
     decode_info_t di;
     /* We only need to identify the instruction's ISA feature and not actually generate a
      * valid encoding, so we can safely skip the reachability check, which, for
-     * instructions like bcond, checks if the target address in the instructions operand
-     * is reachable from the instructions' pc. Depending on how this function is used, pc
+     * instructions like bcond, checks if the target address in the instruction's operand
+     * is reachable from the instruction's pc. Depending on how this function is used, pc
      * is not necessarily the instruction's actual pc, it can be an unrelated address like
      * a buffer, so disabling the reachability check is necessary.
      */

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -294,7 +294,7 @@ test_isa_features(void)
     /* ISA feature defined in core/ir/aarch64/codec_v80.txt.
      * Test bcond with distant target to reproduce the check reachability issue.
      * We use a target PC that is far away from &unused_buf to trigger the reachability
-     * failure, if it were enabled (which is not supposed to). That would cause
+     * failure, if reachability checking were incorrectly enabled. That would cause
      * instr_get_isa_feature() to return ISA_FEAT_INVALID instead of ISA_FEAT_BASE.
      */
     instr =

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -291,21 +291,15 @@ test_isa_features(void)
     instr_t *instr = NULL;
     uint isa_feat = ISA_FEAT_INVALID;
 
-    /* Test bcond with distant target to reproduce the reachability issue. */
-    /* We use a target PC that is far away from &unused_buf to trigger the reachability
-     * failure. */
-    instr =
-        INSTR_CREATE_bcond(GD, opnd_create_pc((app_pc)((char *)&unused_buf + 0x1000000)));
-    instr_set_predicate(instr, DR_PRED_EQ);
-    isa_feat = instr_get_isa_feature((byte *)&unused_buf, instr);
-    /* With di.check_reachable = true (as currently forced in instr.c), this will fail
-     * and return ISA_FEAT_INVALID instead of ISA_FEAT_BASE.
+    /* ISA feature defined in core/ir/aarch64/codec_v80.txt.
+     * Test bcond with distant target to reproduce the check reachability issue.
+     * We use a target PC that is far away from &unused_buf to trigger the reachability
+     * failure, if it were enabled (which is not supposed to). That would cause
+     * instr_get_isa_feature() to return ISA_FEAT_INVALID instead of ISA_FEAT_BASE.
      */
-    ASSERT(isa_feat == ISA_FEAT_INVALID);
-    instr_destroy(GD, instr);
-
-    /* ISA feature defined in core/ir/aarch64/codec_v80.txt. */
-    instr = INSTR_CREATE_bcond(GD, opnd_create_pc((app_pc)0xffffffff));
+    instr =
+        INSTR_CREATE_bcond(GD, opnd_create_pc((app_pc)((byte *)&unused_buf + 0x1000000)));
+    instr_set_predicate(instr, DR_PRED_EQ);
     isa_feat = instr_get_isa_feature((byte *)&unused_buf, instr);
     ASSERT(isa_feat == ISA_FEAT_BASE);
     ASSERT(strncmp(instr_get_isa_feature_name(isa_feat), "BASE", strlen("BASE")) == 0);

--- a/suite/tests/api/drdecode_aarch64.c
+++ b/suite/tests/api/drdecode_aarch64.c
@@ -291,6 +291,26 @@ test_isa_features(void)
     instr_t *instr = NULL;
     uint isa_feat = ISA_FEAT_INVALID;
 
+    /* Test bcond with distant target to reproduce the reachability issue. */
+    /* We use a target PC that is far away from &unused_buf to trigger the reachability
+     * failure. */
+    instr =
+        INSTR_CREATE_bcond(GD, opnd_create_pc((app_pc)((char *)&unused_buf + 0x1000000)));
+    instr_set_predicate(instr, DR_PRED_EQ);
+    isa_feat = instr_get_isa_feature((byte *)&unused_buf, instr);
+    /* With di.check_reachable = true (as currently forced in instr.c), this will fail
+     * and return ISA_FEAT_INVALID instead of ISA_FEAT_BASE.
+     */
+    ASSERT(isa_feat == ISA_FEAT_INVALID);
+    instr_destroy(GD, instr);
+
+    /* ISA feature defined in core/ir/aarch64/codec_v80.txt. */
+    instr = INSTR_CREATE_bcond(GD, opnd_create_pc((app_pc)0xffffffff));
+    isa_feat = instr_get_isa_feature((byte *)&unused_buf, instr);
+    ASSERT(isa_feat == ISA_FEAT_BASE);
+    ASSERT(strncmp(instr_get_isa_feature_name(isa_feat), "BASE", strlen("BASE")) == 0);
+    instr_destroy(GD, instr);
+
     /* ISA feature defined in core/ir/aarch64/codec_v81.txt. */
     instr = INSTR_CREATE_sqrdmlsh_scalar(GD, opnd_create_reg(DR_REG_H0),
                                          opnd_create_reg(DR_REG_H0),


### PR DESCRIPTION
Fixes `instr_get_isa_feature()` in AARCH64 where instructions like `bcond`
were incorrectly reported with an `<invalid>` ISA feature in the opcode_mix tool.
The root cause was that `instr_get_isa_feature()` instantiated a `decode_info_t`
struct without initialization, leaving the `check_reachable` flag containing
indeterminate stack data.
When this flag happened to be true, the encoding walk of `instr_get_isa_feature()`
enforced reachability checks on PC-relative operands.
Depending on how `instr_get_isa_feature()` is used, `pc` is not necessarily the
instruction's actual pc, it can be an unrelated address like a buffer, so disabling
the reachability check is necessary.

Adds a unit test that would trigger returning `<invalid>` ISA feature if the
reachability check were to be enabled.

Issue #7842