### PR TITLE
i#7881: Repeatedly try to steal from other cores in scheduler

### DIFF
--- a/clients/drcachesim/analyzer_multi.cpp
+++ b/clients/drcachesim/analyzer_multi.cpp
@@ -700,6 +700,7 @@ analyzer_multi_tmpl_t<RecordType, ReaderType>::init_dynamic_schedule()
     sched_ops.honor_infinite_timeouts = op_sched_infinite_timeouts.get_value();
     sched_ops.migration_threshold_us = op_sched_migration_threshold_us.get_value();
     sched_ops.rebalance_period_us = op_sched_rebalance_period_us.get_value();
+    sched_ops.steal_attempt_period = op_sched_steal_attempt_period.get_value();
     sched_ops.randomize_next_input = op_sched_randomize.get_value();
     sched_ops.honor_direct_switches = !op_sched_disable_direct_switches.get_value();
     sched_ops.exit_if_fraction_inputs_left =

--- a/clients/drcachesim/common/options.cpp
+++ b/clients/drcachesim/common/options.cpp
@@ -1175,6 +1175,13 @@ droption_t<uint64_t> op_sched_rebalance_period_us(
     "The period in simulated microseconds at which per-core run queues are re-balanced "
     "to redistribute load.");
 
+droption_t<uint64_t> op_sched_steal_attempt_period(
+    DROPTION_SCOPE_ALL, "sched_steal_attempt_period", 10000,
+    "Period in idles at which cores attempt to steal from other cores",
+    "The cadence of steal attempts when an output is idle. Each output keeps track of "
+    "consecutive idles and attempts to steal when its idles hit a multiple of this value "
+    "(including at 0).  Setting this parameter to 0 disables stealing.");
+
 droption_t<double> op_sched_exit_if_fraction_inputs_left(
     DROPTION_SCOPE_FRONTEND, "sched_exit_if_fraction_inputs_left", 0.1,
     "Exit if non-EOF inputs left are <= this fraction of the total",

--- a/clients/drcachesim/common/options.h
+++ b/clients/drcachesim/common/options.h
@@ -234,6 +234,7 @@ extern dynamorio::droption::droption_t<bool> op_sched_disable_direct_switches;
 extern dynamorio::droption::droption_t<bool> op_sched_infinite_timeouts;
 extern dynamorio::droption::droption_t<uint64_t> op_sched_migration_threshold_us;
 extern dynamorio::droption::droption_t<uint64_t> op_sched_rebalance_period_us;
+extern dynamorio::droption::droption_t<uint64_t> op_sched_steal_attempt_period;
 extern dynamorio::droption::droption_t<double> op_sched_time_units_per_us;
 extern dynamorio::droption::droption_t<double> op_sched_exit_if_fraction_inputs_left;
 extern dynamorio::droption::droption_t<int> op_sched_random_initial_layout;

--- a/clients/drcachesim/scheduler/scheduler.h
+++ b/clients/drcachesim/scheduler/scheduler.h
@@ -931,6 +931,12 @@ public:
          * application is not using direct switches for dependencies.
          */
         bool direct_switch_fallbacks = false;
+        /**
+         * The cadence of steal attempts when an output is idle.  Each output keeps track
+         * of consecutive idles and attempts to steal when its idles hit a multiple of
+         * this value (including at 0).  Setting this field to 0 disables stealing.
+         */
+        uint64_t steal_attempt_period = 10000;
         // When adding new options, also add to print_configuration().
     };
 

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -1051,12 +1051,12 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::eof_or_idle_for_mode(
                live_inputs);
         return sched_type_t::STATUS_EOF;
     }
-    //  Before going idle, try to steal work from another output.
-    //  We start with us+1 to avoid everyone stealing from the low-numbered outputs.
-    //  We only try when we first transition to idle; we rely on rebalancing after
-    //  that, to avoid repeatededly grabbing other output's locks over and over.
-    if (!outputs_[output].tried_to_steal_on_idle) {
-        outputs_[output].tried_to_steal_on_idle = true;
+    // When going idle, periodically try to steal work from another output.
+    // We don't want to try every time as we'll cause too much lock contention.
+    // We start with us+1 to avoid everyone stealing from the low-numbered outputs
+    // (better to randomly pick target cores?).
+    if (options_.steal_attempt_period > 0 &&
+        outputs_[output].consecutive_idles++ % options_.steal_attempt_period == 0) {
         for (unsigned int i = 1; i < outputs_.size(); ++i) {
             output_ordinal_t target = (output + i) % outputs_.size();
             assert(target != output); // Sanity check (we won't reach "output").

--- a/clients/drcachesim/scheduler/scheduler_dynamic.cpp
+++ b/clients/drcachesim/scheduler/scheduler_dynamic.cpp
@@ -1071,6 +1071,10 @@ scheduler_dynamic_tmpl_t<RecordType, ReaderType>::eof_or_idle_for_mode(
                 VPRINT(this, 2,
                        "eof_or_idle: output %d stole input %d from %d's ready_queue\n",
                        output, queue_next->index, target);
+                // This stolen task now has a core to itself, so it may make extra
+                // progress without competition: but that is better than this core
+                // sitting idle while the task is not running; plus, the next global
+                // rebalance will even runqueues out further.
                 return sched_type_t::STATUS_STOLE;
             }
             // We didn't find anything; loop and check another output.

--- a/clients/drcachesim/scheduler/scheduler_impl.cpp
+++ b/clients/drcachesim/scheduler/scheduler_impl.cpp
@@ -2914,8 +2914,8 @@ scheduler_impl_tmpl_t<RecordType, ReaderType>::on_context_switch(
     } else {
         VPRINT(this, 2, "Switch on output %d idle-to-input %d", output, new_input);
         ++outputs_[output].stats[memtrace_stream_t::SCHED_STAT_SWITCH_IDLE_TO_INPUT];
-        // Reset the flag so we'll try to steal if we go idle again.
-        outputs_[output].tried_to_steal_on_idle = false;
+        // Reset the counter controlling stealing if we go idle again.
+        outputs_[output].consecutive_idles = 0;
     }
 
     // We want to insert the context switch records (which includes the new input's

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -528,7 +528,7 @@ protected:
         // during execution, so it requires atomic accesses.
         std::unique_ptr<std::atomic<int>> record_index;
         bool waiting = false; // Waiting or idling.
-        // Used to limit stealing to one attempt per transition to idle.
+        // Used to limit stealing to one attempt per options_.steal_attempt_period idles.
         int64_t consecutive_idles = 0;
         // This is accessed by other outputs for stealing and rebalancing.
         // Indirected so we can store it in our vector.

--- a/clients/drcachesim/scheduler/scheduler_impl.h
+++ b/clients/drcachesim/scheduler/scheduler_impl.h
@@ -529,7 +529,7 @@ protected:
         std::unique_ptr<std::atomic<int>> record_index;
         bool waiting = false; // Waiting or idling.
         // Used to limit stealing to one attempt per transition to idle.
-        bool tried_to_steal_on_idle = false;
+        int64_t consecutive_idles = 0;
         // This is accessed by other outputs for stealing and rebalancing.
         // Indirected so we can store it in our vector.
         std::unique_ptr<std::atomic<bool>> active;

--- a/clients/drcachesim/tests/scheduler_unit_tests.cpp
+++ b/clients/drcachesim/tests/scheduler_unit_tests.cpp
@@ -9081,6 +9081,248 @@ test_initial_migrate()
     assert(sched_as_string[1] == CORE1_SCHED_STRING);
 }
 
+static scheduler_t::scheduler_options_t
+set_up_steal_period_options(std::vector<trace_entry_t> refs_A, memref_tid_t TID_A,
+                            std::vector<trace_entry_t> refs_B, memref_tid_t TID_B,
+                            std::vector<trace_entry_t> refs_C, memref_tid_t TID_C,
+                            std::vector<trace_entry_t> refs_D, memref_tid_t TID_D,
+                            std::vector<trace_entry_t> refs_E, memref_tid_t TID_E,
+                            std::vector<trace_entry_t> refs_F, memref_tid_t TID_F,
+                            uint64_t BLOCK_THRESHOLD,
+                            std::vector<scheduler_t::input_workload_t> &sched_inputs)
+{
+    static constexpr uint64_t MIGRATION_THRESHOLD = 10;
+    static constexpr uint64_t STEAL_ATTEMPT_PERIOD = 4;
+    std::vector<scheduler_t::input_reader_t> readers;
+    readers.emplace_back(
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t(refs_A)),
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()), TID_A);
+    readers.emplace_back(
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t(refs_B)),
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()), TID_B);
+    readers.emplace_back(
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t(refs_C)),
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()), TID_C);
+    readers.emplace_back(
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t(refs_D)),
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()), TID_D);
+    readers.emplace_back(
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t(refs_E)),
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()), TID_E);
+    readers.emplace_back(
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t(refs_F)),
+        std::unique_ptr<test_util::mock_reader_t>(new test_util::mock_reader_t()), TID_F);
+    sched_inputs.emplace_back(std::move(readers));
+    scheduler_t::scheduler_options_t sched_ops(scheduler_t::MAP_TO_ANY_OUTPUT,
+                                               scheduler_t::DEPENDENCY_TIMESTAMPS,
+                                               scheduler_t::SCHEDULER_DEFAULTS,
+                                               /*verbosity=*/3);
+    // Run everything.
+    sched_ops.exit_if_fraction_inputs_left = 0.;
+    // Use a round-robin layout for simpler deterministic testing.
+    sched_ops.random_initial_layout = -1;
+    sched_ops.block_time_multiplier = 0.001; // Do not stay blocked.
+    sched_ops.blocking_switch_threshold = BLOCK_THRESHOLD;
+    sched_ops.time_units_per_us = 1.;
+    sched_ops.migration_threshold_us = MIGRATION_THRESHOLD;
+    sched_ops.steal_attempt_period = STEAL_ATTEMPT_PERIOD;
+    return sched_ops;
+}
+
+static void
+test_steal_period()
+{
+    std::cerr << "\n----------------\nTesting steal period\n";
+    static constexpr int NUM_OUTPUTS = 2;
+    static constexpr memref_tid_t TID_BASE = 100;
+    static constexpr memref_tid_t TID_A = TID_BASE + 0;
+    static constexpr memref_tid_t TID_B = TID_BASE + 1;
+    static constexpr memref_tid_t TID_C = TID_BASE + 2;
+    static constexpr memref_tid_t TID_D = TID_BASE + 3;
+    static constexpr memref_tid_t TID_E = TID_BASE + 4;
+    static constexpr memref_tid_t TID_F = TID_BASE + 5;
+    static constexpr uint64_t TIMESTAMP_START = 10;
+    static constexpr uint64_t PRE_SYS_TIMESTAMP = TIMESTAMP_START + 100;
+    static constexpr uint64_t BLOCK_THRESHOLD = 500;
+
+    // We set up a round-robin assignemt with 3 inputs on each output: A, C, E
+    // on output #0 and B, D, F on #1.
+    // A and C both block quickly and #1 runs E the rest of the time.
+    // B, D, and F are short, so #1 finishes and goes idle, where it steals
+    // A and C: but it fails with each initially as they haven't met the migration
+    // threshold.
+    std::vector<trace_entry_t> refs_A = {
+        /* clang-format off */
+        test_util::make_thread(TID_A),
+        test_util::make_pid(1),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_timestamp(TIMESTAMP_START),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        test_util::make_instr(10),
+        test_util::make_timestamp(PRE_SYS_TIMESTAMP),
+        test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL, 42),
+        test_util::make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+        test_util::make_timestamp(PRE_SYS_TIMESTAMP + BLOCK_THRESHOLD),
+        test_util::make_instr(11),
+        test_util::make_exit(TID_A),
+        /* clang-format on */
+    };
+    std::vector<trace_entry_t> refs_B = {
+        /* clang-format off */
+        test_util::make_thread(TID_B),
+        test_util::make_pid(1),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_timestamp(TIMESTAMP_START + 10),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        test_util::make_instr(10),
+        test_util::make_exit(TID_B),
+        /* clang-format on */
+    };
+    std::vector<trace_entry_t> refs_C = {
+        /* clang-format off */
+        test_util::make_thread(TID_C),
+        test_util::make_pid(1),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_timestamp(TIMESTAMP_START + 20),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        test_util::make_instr(10),
+        test_util::make_instr(11),
+        test_util::make_instr(12),
+        test_util::make_timestamp(PRE_SYS_TIMESTAMP),
+        test_util::make_marker(TRACE_MARKER_TYPE_SYSCALL, 42),
+        test_util::make_marker(TRACE_MARKER_TYPE_MAYBE_BLOCKING_SYSCALL, 0),
+        test_util::make_timestamp(PRE_SYS_TIMESTAMP + BLOCK_THRESHOLD),
+        test_util::make_instr(13),
+        test_util::make_exit(TID_C),
+        /* clang-format on */
+    };
+    std::vector<trace_entry_t> refs_D = {
+        /* clang-format off */
+        test_util::make_thread(TID_D),
+        test_util::make_pid(1),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_timestamp(TIMESTAMP_START + 30),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        test_util::make_instr(10),
+        test_util::make_exit(TID_D),
+        /* clang-format on */
+    };
+    std::vector<trace_entry_t> refs_E = {
+        /* clang-format off */
+        test_util::make_thread(TID_E),
+        test_util::make_pid(1),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_timestamp(TIMESTAMP_START + 40),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_instr(10),
+        test_util::make_exit(TID_E),
+        /* clang-format on */
+    };
+    std::vector<trace_entry_t> refs_F = {
+        /* clang-format off */
+        test_util::make_thread(TID_F),
+        test_util::make_pid(1),
+        test_util::make_version(TRACE_ENTRY_VERSION),
+        test_util::make_timestamp(TIMESTAMP_START + 50),
+        test_util::make_marker(TRACE_MARKER_TYPE_CPU_ID, 0),
+        test_util::make_instr(10),
+        test_util::make_exit(TID_F),
+        /* clang-format on */
+    };
+    {
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        scheduler_t::scheduler_options_t sched_ops = set_up_steal_period_options(
+            refs_A, TID_A, refs_B, TID_B, refs_C, TID_C, refs_D, TID_D, refs_E, TID_E,
+            refs_F, TID_F, BLOCK_THRESHOLD, sched_inputs);
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        std::vector<std::string> sched_as_string =
+            run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_BASE, /*send_time=*/true);
+        for (int i = 0; i < NUM_OUTPUTS; i++) {
+            std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+        }
+        // As described above, #1 steals A and C but only after first going idle
+        // (because the targets haven't hit the migration threshold yet), thus
+        // testing repeated steal attempts: each steal is after multiple of 4 idles
+        // (the steal period).
+        static const char *const CORE0_SCHED_STRING =
+            "...A.......CCC.......EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.";
+        static const char *const CORE1_SCHED_STRING =
+            "...B....D....F.________A.____C.__________________________";
+        assert(sched_as_string[0] == CORE0_SCHED_STRING);
+        assert(sched_as_string[1] == CORE1_SCHED_STRING);
+        assert(scheduler.get_stream(0)->get_schedule_statistic(
+                   memtrace_stream_t::SCHED_STAT_MIGRATIONS) == 2);
+        assert(scheduler.get_stream(1)->get_schedule_statistic(
+                   memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS) == 2);
+    }
+    {
+        // Now run without steal retries.
+        std::vector<scheduler_t::input_workload_t> sched_inputs;
+        scheduler_t::scheduler_options_t sched_ops = set_up_steal_period_options(
+            refs_A, TID_A, refs_B, TID_B, refs_C, TID_C, refs_D, TID_D, refs_E, TID_E,
+            refs_F, TID_F, BLOCK_THRESHOLD, sched_inputs);
+        // Disable retries: only attempt when first go idle.
+        sched_ops.steal_attempt_period *= 100;
+        scheduler_t scheduler;
+        if (scheduler.init(sched_inputs, NUM_OUTPUTS, std::move(sched_ops)) !=
+            scheduler_t::STATUS_SUCCESS)
+            assert(false);
+        std::vector<std::string> sched_as_string =
+            run_lockstep_simulation(scheduler, NUM_OUTPUTS, TID_BASE, /*send_time=*/true);
+        // There are now no steals since #1 only tries when it first goes idle.
+        static const char *const CORE0_SCHED_STRING =
+            "...A.......CCC.......EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.A.C.";
+        static const char *const CORE1_SCHED_STRING =
+            "...B....D....F.______________________________________________";
+        for (int i = 0; i < NUM_OUTPUTS; i++) {
+            std::cerr << "cpu #" << i << " schedule: " << sched_as_string[i] << "\n";
+            assert(scheduler.get_stream(i)->get_schedule_statistic(
+                       memtrace_stream_t::SCHED_STAT_MIGRATIONS) == 0);
+        }
+        assert(sched_as_string[0] == CORE0_SCHED_STRING);
+        assert(sched_as_string[1] == CORE1_SCHED_STRING);
+        assert(scheduler.get_stream(1)->get_schedule_statistic(
+                   memtrace_stream_t::SCHED_STAT_RUNQUEUE_STEALS) == 0);
+    }
+}
+
 static void
 test_exit_early()
 {
@@ -9764,6 +10006,7 @@ test_main(int argc, const char *argv[])
     test_record_scheduler_i7574();
     test_rebalancing();
     test_initial_migrate();
+    test_steal_period();
     test_exit_early();
     test_marker_updates();
     test_options_match();


### PR DESCRIPTION
Previously, a core going idle tried to steal work from other cores just once at the transition to idle.  We've found this leads to too-uneven workloads with larger core counts and non-negligible idle fractions.  To solve, we repeatedly try to steal, at a cadence in idle counts specified by a new scheduler parameter steal_attempt_period with a new launcher option -sched_steal_attempt_periodj.

Tested:

Adds a unit test.

Tested on large workloads on many cores where this improves the max instruction ratio among cores from values like 7x down to under 2x.

Fixes #7881