### PR TITLE
i#7899: Make multi-indir deterministic

### DIFF
--- a/clients/drcachesim/tests/multi_indir.templatex
+++ b/clients/drcachesim/tests/multi_indir.templatex
@@ -2,7 +2,7 @@ Schedule stats tool results:
 Total counts:
            3 cores
           27 threads: .*W[012].T872902.*W[012].T872902.*W[012].T872902.*
-     1930251 instructions
+     1951728 instructions
 .*
 Core #0 schedule: [A-Za-z_]*
 Core #1 schedule: [A-Za-z_]*

--- a/suite/tests/CMakeLists.txt
+++ b/suite/tests/CMakeLists.txt
@@ -4262,8 +4262,10 @@ if (BUILD_CLIENTS)
         set(tool.switch_file_invariants_rawtemp ON) # no preprocessor
 
         # Test -multi_indir with 3 copies of our sample dir.
+        # We set -sched_exit_if_fraction_inputs_left to 0 so our exact instruction
+        # count check in the template will always match.
         torunonly_simtool(multi_indir ${ci_shared_app}
-          "-multi_indir ${thread_trace_dir}:${thread_trace_dir}:${thread_trace_dir} ${thread_trace_scale} -tool schedule_stats -cores 3"
+          "-multi_indir ${thread_trace_dir}:${thread_trace_dir}:${thread_trace_dir} ${thread_trace_scale} -tool schedule_stats -cores 3 -sched_exit_if_fraction_inputs_left 0"
           "")
         set(tool.multi_indir_rawtemp ON) # no preprocessor
 


### PR DESCRIPTION
Sets -sched_exit_if_fraction_inputs_left to 0 so our exact instruction count check in the template will always match.

Tested: "ctest --repeat-until-fail 100 -R multi_indir" now passes locally when before this test would fail every 3 or 4 runs.

Fixes #7899