### PR TITLE
i#1734 top bits: Make missing memrefs fatal errors

### DIFF
--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2021-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2021-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -429,6 +429,33 @@ run_raw2trace(void *drcontext, const std::vector<offline_entry_t> raw, instrlist
     return true;
 }
 
+// Takes ownership of ilist and destroys it.
+// Returns the failure string.
+std::string
+run_raw2trace_for_error_string(void *drcontext, const std::vector<offline_entry_t> raw,
+                               instrlist_t *ilist)
+{
+    // We need an istream so we use istringstream.
+    std::ostringstream raw_out;
+    for (const auto &entry : raw) {
+        std::string as_string(reinterpret_cast<const char *>(&entry),
+                              reinterpret_cast<const char *>(&entry + 1));
+        raw_out << as_string;
+    }
+    std::istringstream raw_in(raw_out.str());
+    std::vector<std::istream *> input;
+    input.push_back(&raw_in);
+
+    // We need an ostream to capture out.
+    std::ostringstream result_stream;
+    std::vector<std::ostream *> output;
+    output.push_back(&result_stream);
+
+    // Run raw2trace with our subclass supplying our decodings.
+    raw2trace_test_t raw2trace(input, output, *ilist, drcontext);
+    return raw2trace.do_conversion();
+}
+
 bool
 test_branch_delays(void *drcontext)
 {
@@ -807,8 +834,10 @@ test_chunk_boundaries(void *drcontext)
     raw.push_back(make_block(offs_move1, 2));
     raw.push_back(make_block(offs_jmp2, 1));
     raw.push_back(make_block(offs_move2, 2));
+    raw.push_back(make_memref(42)); // ret load.
     raw.push_back(make_block(offs_jcc1, 1));
     raw.push_back(make_block(offs_ret1, 1));
+    raw.push_back(make_memref(42)); // ret load.
     raw.push_back(make_block(offs_move1, 1));
     // TODO i#5724: Add repeats of the same instrs to test re-emitting encodings
     // in new chunks.
@@ -862,6 +891,7 @@ test_chunk_boundaries(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
 #ifdef X86_32
         // An extra encoding entry is needed.
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
@@ -883,6 +913,7 @@ test_chunk_boundaries(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         // Block 5.
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         // Block 6.
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
@@ -959,9 +990,11 @@ test_chunk_encodings(void *drcontext)
     // Add a final chunk boundary right between a branch;ret pair.
     raw.push_back(make_block(offs_nop_start, 4));
     raw.push_back(make_block(offs_ret, 1));
+    raw.push_back(make_memref(42)); // ret load.
     // Test that we don't get another encoding for a 2nd instance of the ret
     // (yes, nonsensical having the ret target itself: that's ok).
     raw.push_back(make_block(offs_ret, 1));
+    raw.push_back(make_memref(42)); // ret load.
     // Re-use move2 for the target of the 2nd ret to it isn't truncated.
     raw.push_back(make_block(offs_move2, 1));
     raw.push_back(make_exit());
@@ -1042,9 +1075,11 @@ test_chunk_encodings(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1, offs_ret) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
         // There should be no encoding before the 2nd instance.
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1, offs_ret) &&
+        check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         // Footer.
@@ -2997,6 +3032,7 @@ test_branch_decoration(void *drcontext)
         // Now repeat that branch to test encodings.
         raw.push_back(make_block(offs_mov, 2));
         raw.push_back(make_block(offs_store, 1));
+        raw.push_back(make_memref(42));
         raw.push_back(make_exit());
 
         std::vector<trace_entry_t> entries;
@@ -3026,6 +3062,7 @@ test_branch_decoration(void *drcontext)
             check_entry(entries, idx, TRACE_TYPE_INSTR_TAKEN_JUMP, -1, offs_jcc) &&
             check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
             check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+            check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
             check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
             check_entry(entries, idx, TRACE_TYPE_FOOTER, -1);
     }
@@ -3068,6 +3105,7 @@ test_branch_decoration(void *drcontext)
         raw.push_back(make_block(offs_mov, 2));
         raw.push_back(make_block(offs_jcc_move, 1));
         raw.push_back(make_block(offs_store, 1));
+        raw.push_back(make_memref(42));
         raw.push_back(make_exit());
 
         std::vector<trace_entry_t> entries;
@@ -3108,6 +3146,7 @@ test_branch_decoration(void *drcontext)
             check_entry(entries, idx, TRACE_TYPE_INSTR_UNTAKEN_JUMP, -1, offs_jcc_move) &&
             check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
             check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+            check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
             check_entry(entries, idx, TRACE_TYPE_THREAD_EXIT, -1) &&
             check_entry(entries, idx, TRACE_TYPE_FOOTER, -1);
     }
@@ -4119,6 +4158,72 @@ test_negative_timestamps(void *drcontext)
     }
 }
 
+bool
+test_missing_memref(void *drcontext)
+{
+#ifdef X86
+    std::cerr << "\n===============\nTesting missing memref\n";
+    {
+        // Test a conditional block.
+        instrlist_t *ilist = instrlist_create(drcontext);
+        instr_t *nop = XINST_CREATE_nop(drcontext);
+        instr_t *cmov = INSTR_CREATE_cmovcc(drcontext, OP_cmovnle, opnd_create_reg(REG1),
+                                            OPND_CREATE_MEMPTR(REG2, 0));
+        instr_t *ret = XINST_CREATE_return(drcontext);
+        instrlist_append(ilist, nop);
+        instrlist_append(ilist, cmov);
+        instrlist_append(ilist, ret);
+        size_t offs_cmov = instr_length(drcontext, nop);
+
+        std::vector<offline_entry_t> raw;
+        raw.push_back(make_header());
+        raw.push_back(make_tid());
+        raw.push_back(make_pid());
+        raw.push_back(make_line_size());
+        raw.push_back(make_timestamp());
+        raw.push_back(make_core());
+        raw.push_back(make_block(offs_cmov, 2));
+        // Just one memref for ret, none for cmov.
+        raw.push_back(make_memref(42));
+        raw.push_back(make_exit());
+
+        std::string error = run_raw2trace_for_error_string(drcontext, raw, ilist);
+        CHECK(error.empty(), "Failed to allow missing memref in conditional block");
+    }
+    {
+        // Test an unconditional block.
+        instrlist_t *ilist = instrlist_create(drcontext);
+        instr_t *nop = XINST_CREATE_nop(drcontext);
+        instr_t *load = INSTR_CREATE_mov_ld(drcontext, opnd_create_reg(REG1),
+                                            OPND_CREATE_MEMPTR(REG2, 0));
+        instr_t *ret = XINST_CREATE_return(drcontext);
+        instrlist_append(ilist, nop);
+        instrlist_append(ilist, load);
+        instrlist_append(ilist, ret);
+        size_t offs_load = instr_length(drcontext, nop);
+
+        std::vector<offline_entry_t> raw;
+        raw.push_back(make_header());
+        raw.push_back(make_tid());
+        raw.push_back(make_pid());
+        raw.push_back(make_line_size());
+        raw.push_back(make_timestamp());
+        raw.push_back(make_core());
+        raw.push_back(make_block(offs_load, 2));
+        // Just 1 memref when load+ret should be 2 total: error.
+        raw.push_back(make_memref(42));
+        raw.push_back(make_exit());
+
+        std::string error = run_raw2trace_for_error_string(drcontext, raw, ilist);
+        CHECK(!error.empty() &&
+                  error.find("Missing memref in unconditional block") !=
+                      std::string::npos,
+              "Failed to detect missing memref");
+    }
+#endif
+    return true;
+}
+
 int
 test_main(int argc, const char *argv[])
 {
@@ -4144,7 +4249,7 @@ test_main(int argc, const char *argv[])
         !test_stats_timestamp_instr_count(drcontext) ||
         !test_is_maybe_blocking_syscall(drcontext) || !test_ifiltered(drcontext) ||
         !test_asynchronous_signal(drcontext) || !test_syscall_injection(drcontext) ||
-        !test_negative_timestamps(drcontext))
+        !test_negative_timestamps(drcontext) || !test_missing_memref(drcontext))
         return 1;
     return 0;
 }

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -4185,7 +4185,7 @@ test_missing_memref(void *drcontext)
 #ifdef X86
     std::cerr << "\n===============\nTesting missing memref\n";
     {
-        // Test a conditional block.
+        // Test a block with conditional loads/stores.
         instrlist_t *ilist = instrlist_create(drcontext);
         instr_t *nop = XINST_CREATE_nop(drcontext);
         instr_t *cmov = INSTR_CREATE_cmovcc(drcontext, OP_cmovnle, opnd_create_reg(REG1),
@@ -4204,8 +4204,9 @@ test_missing_memref(void *drcontext)
         raw.push_back(make_timestamp());
         raw.push_back(make_core());
         raw.push_back(make_block(offs_cmov, 2));
-        // Just one memref for ret, none for cmov.
-        raw.push_back(make_memref(42));
+        // We have no memref for the cmov, which is normal, but we also omit
+        // one for the memref just to show there is no error when any instruction
+        // in the block is condtional.
         raw.push_back(make_exit());
 
         std::string error = run_raw2trace_for_error_string(drcontext, raw, ilist);
@@ -4237,7 +4238,7 @@ test_missing_memref(void *drcontext)
 
         std::string error = run_raw2trace_for_error_string(drcontext, raw, ilist);
         CHECK(!error.empty() &&
-                  error.find("Missing memref in unconditional block") !=
+                  error.find("Missing memref in block without predicated accesses") !=
                       std::string::npos,
               "Failed to detect missing memref");
     }

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -2087,7 +2087,9 @@ test_rseq_side_exit_signal(void *drcontext)
     // A discontinuity as we continue with the side exit target.
     // But, a signal arrived (whose interruption must be that target).
     raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_EVENT, offs_move3));
-    raw.push_back(make_block(offs_move1, 1));
+    // Re-use the rseq end as our signal handler.
+    raw.push_back(make_block(offs_move1, 2));
+    raw.push_back(make_memref(42));
     raw.push_back(make_marker(TRACE_MARKER_TYPE_KERNEL_XFER, offs_store));
     raw.push_back(make_block(offs_move3, 1));
     raw.push_back(make_exit());
@@ -2122,6 +2124,9 @@ test_rseq_side_exit_signal(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_EVENT) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move1) &&
+        check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
+        check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_store) &&
+        check_entry(entries, idx, TRACE_TYPE_WRITE, -1) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_KERNEL_XFER) &&
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1, offs_move3) &&

--- a/clients/drcachesim/tests/raw2trace_unit_tests.cpp
+++ b/clients/drcachesim/tests/raw2trace_unit_tests.cpp
@@ -834,10 +834,14 @@ test_chunk_boundaries(void *drcontext)
     raw.push_back(make_block(offs_move1, 2));
     raw.push_back(make_block(offs_jmp2, 1));
     raw.push_back(make_block(offs_move2, 2));
+#ifdef X86
     raw.push_back(make_memref(42)); // ret load.
+#endif
     raw.push_back(make_block(offs_jcc1, 1));
     raw.push_back(make_block(offs_ret1, 1));
+#ifdef X86
     raw.push_back(make_memref(42)); // ret load.
+#endif
     raw.push_back(make_block(offs_move1, 1));
     // TODO i#5724: Add repeats of the same instrs to test re-emitting encodings
     // in new chunks.
@@ -891,7 +895,9 @@ test_chunk_boundaries(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1) &&
+#ifdef X86
         check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
+#endif
 #ifdef X86_32
         // An extra encoding entry is needed.
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
@@ -913,7 +919,9 @@ test_chunk_boundaries(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         // Block 5.
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1) &&
+#ifdef X86
         check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
+#endif
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         // Block 6.
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
@@ -990,11 +998,15 @@ test_chunk_encodings(void *drcontext)
     // Add a final chunk boundary right between a branch;ret pair.
     raw.push_back(make_block(offs_nop_start, 4));
     raw.push_back(make_block(offs_ret, 1));
+#ifdef X86
     raw.push_back(make_memref(42)); // ret load.
+#endif
     // Test that we don't get another encoding for a 2nd instance of the ret
     // (yes, nonsensical having the ret target itself: that's ok).
     raw.push_back(make_block(offs_ret, 1));
+#ifdef X86
     raw.push_back(make_memref(42)); // ret load.
+#endif
     // Re-use move2 for the target of the 2nd ret to it isn't truncated.
     raw.push_back(make_block(offs_move2, 1));
     raw.push_back(make_exit());
@@ -1075,11 +1087,15 @@ test_chunk_encodings(void *drcontext)
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1, offs_ret) &&
+#ifdef X86
         check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
+#endif
         // There should be no encoding before the 2nd instance.
         check_entry(entries, idx, TRACE_TYPE_MARKER, TRACE_MARKER_TYPE_BRANCH_TARGET) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR_RETURN, -1, offs_ret) &&
+#ifdef X86
         check_entry(entries, idx, TRACE_TYPE_READ, -1) &&
+#endif
         check_entry(entries, idx, TRACE_TYPE_ENCODING, -1) &&
         check_entry(entries, idx, TRACE_TYPE_INSTR, -1) &&
         // Footer.

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -503,6 +503,12 @@ public:
                          DR_PARAM_OUT int *memopnd_index, DR_PARAM_OUT bool *is_write,
                          DR_PARAM_OUT bool *needs_base);
 
+    void
+    set_disable_optimizations(bool disable_optimizations)
+    {
+        disable_optimizations_ = disable_optimizations;
+    }
+
 private:
     struct custom_module_data_t {
         custom_module_data_t(const char *base_in, size_t size_in, void *user_in)

--- a/clients/drcachesim/tracer/instru.h
+++ b/clients/drcachesim/tracer/instru.h
@@ -492,7 +492,10 @@ public:
     opnd_is_elidable(opnd_t memop, DR_PARAM_OUT reg_id_t &base, int version);
     // Inserts labels marking elidable addresses. label_marks_elidable() identifies them.
     // "version" is an OFFLINE_FILE_VERSION* constant.
-    void
+    // Returns the count of addresses that will be recorded in the trace, or -1 if
+    // the count is unknown (due to predicated/conditional loads/stores or
+    // online filtering).
+    int
     identify_elidable_addresses(void *drcontext, instrlist_t *ilist, int version,
                                 bool memref_needs_full_info);
     bool
@@ -539,7 +542,8 @@ private:
                               instr_t *app, opnd_t ref, bool write);
     ssize_t (*write_file_func_)(file_t file, const void *data, size_t count);
 
-    void
+    // Returns whether elidable; if so, inserts an info label.
+    bool
     opnd_check_elidable(void *drcontext, instrlist_t *ilist, instr_t *instr, opnd_t memop,
                         int op_index, int memop_index, bool write, int version,
                         reg_id_set_t &saw_base);

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -903,7 +903,7 @@ offline_instru_t::opnd_is_elidable(opnd_t memop, DR_PARAM_OUT reg_id_t &base, in
     return true;
 }
 
-void
+bool
 offline_instru_t::opnd_check_elidable(void *drcontext, instrlist_t *ilist, instr_t *instr,
                                       opnd_t memop, int op_index, int memop_index,
                                       bool write, int version, reg_id_set_t &saw_base)
@@ -912,7 +912,7 @@ offline_instru_t::opnd_check_elidable(void *drcontext, instrlist_t *ilist, instr
     // displacement, as well as rip-relative or absolute-address operands.
     reg_id_t base;
     if (!opnd_is_elidable(memop, base, version))
-        return;
+        return false;
     // When adding new elision cases, be sure to check "version" to keep backward
     // compatibility.  See the opnd_is_elidable() notes.  Here we insert a label if
     // we find a base that has not changed or a rip-relative operand.
@@ -925,8 +925,10 @@ offline_instru_t::opnd_check_elidable(void *drcontext, instrlist_t *ilist, instr
         data->data[LABEL_DATA_ELIDED_IS_WRITE] = write;
         data->data[LABEL_DATA_ELIDED_NEEDS_BASE] = (base != DR_REG_NULL);
         MINSERT(ilist, instr, note);
+        return true;
     } else
         saw_base.insert(base);
+    return false;
 }
 
 bool
@@ -952,17 +954,17 @@ offline_instru_t::label_marks_elidable(instr_t *instr, DR_PARAM_OUT int *opnd_in
     return true;
 }
 
-void
+int
 offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilist,
                                               int version, bool memref_needs_full_info)
 {
+    int total_traced_mem_count = -1;
     // Analysis for eliding redundant addresses we can reconstruct during
     // post-processing.
-    if (disable_optimizations_)
-        return;
-    // We can't elide when doing filtering.
+    bool contains_predication = false;
+    // We can't elide when doing filtering; we also don't know the total count.
     if (memref_needs_full_info)
-        return;
+        return -1;
     reg_id_set_t saw_base;
     for (instr_t *instr = instrlist_first(ilist); instr != NULL;
          instr = instr_get_next(instr)) {
@@ -975,10 +977,10 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
         // drx_expand_scatter_gather) when building the ilist.
         if (drutil_instr_is_stringop_loop(instr)
                 IF_X86_OR_AARCH64(|| instr_is_scatter(instr) || instr_is_gather(instr))) {
-            return;
+            return -1;
         }
         if (drmgr_is_emulation_start(instr) || drmgr_is_emulation_end(instr)) {
-            return;
+            return -1;
         }
     }
     for (instr_t *instr = instrlist_first_app(ilist); instr != NULL;
@@ -986,16 +988,21 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
         // For now we bail at predication.
         if (instr_get_predicate(instr) != DR_PRED_NONE) {
             saw_base.clear();
+            contains_predication = true;
             continue;
         }
         // Use instr_{reads,writes}_memory() to rule out LEA and NOP.
         if (instr_reads_memory(instr) || instr_writes_memory(instr)) {
-            int mem_count = 0;
+            int opnd_mem_count = 0;
             for (int i = 0; i < instr_num_srcs(instr); i++) {
                 if (opnd_is_memory_reference(instr_get_src(instr, i))) {
-                    opnd_check_elidable(drcontext, ilist, instr, instr_get_src(instr, i),
-                                        i, mem_count, false, version, saw_base);
-                    ++mem_count;
+                    if (disable_optimizations_)
+                        ++total_traced_mem_count;
+                    else if (!opnd_check_elidable(
+                                 drcontext, ilist, instr, instr_get_src(instr, i), i,
+                                 opnd_mem_count, false, version, saw_base))
+                        ++total_traced_mem_count;
+                    ++opnd_mem_count;
                 }
             }
             // Rule out sharing with any dest if the base is written to.  The ISA
@@ -1007,12 +1014,16 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
                 else
                     ++reg_it;
             }
-            mem_count = 0;
+            opnd_mem_count = 0;
             for (int i = 0; i < instr_num_dsts(instr); i++) {
                 if (opnd_is_memory_reference(instr_get_dst(instr, i))) {
-                    opnd_check_elidable(drcontext, ilist, instr, instr_get_dst(instr, i),
-                                        i, mem_count, true, version, saw_base);
-                    ++mem_count;
+                    if (disable_optimizations_)
+                        ++total_traced_mem_count;
+                    else if (!opnd_check_elidable(
+                                 drcontext, ilist, instr, instr_get_dst(instr, i), i,
+                                 opnd_mem_count, true, version, saw_base))
+                        ++total_traced_mem_count;
+                    ++opnd_mem_count;
                 }
             }
         }
@@ -1027,6 +1038,9 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
                 ++reg_it;
         }
     }
+    if (contains_predication)
+        return -1;
+    return total_traced_mem_count;
 }
 
 } // namespace drmemtrace

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -958,10 +958,10 @@ int
 offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilist,
                                               int version, bool memref_needs_full_info)
 {
-    int total_traced_mem_count = -1;
+    int total_traced_mem_count = 0;
     // Analysis for eliding redundant addresses we can reconstruct during
     // post-processing.
-    bool contains_predication = false;
+    bool contains_memory_predication = false;
     // We can't elide when doing filtering; we also don't know the total count.
     if (memref_needs_full_info)
         return -1;
@@ -985,14 +985,17 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
     }
     for (instr_t *instr = instrlist_first_app(ilist); instr != NULL;
          instr = instr_get_next_app(instr)) {
+        // Use instr_{reads,writes}_memory() to rule out LEA and NOP.
+        bool instr_accesses_memory =
+            instr_reads_memory(instr) || instr_writes_memory(instr);
         // For now we bail at predication.
         if (instr_get_predicate(instr) != DR_PRED_NONE) {
             saw_base.clear();
-            contains_predication = true;
+            if (instr_accesses_memory)
+                contains_memory_predication = true;
             continue;
         }
-        // Use instr_{reads,writes}_memory() to rule out LEA and NOP.
-        if (instr_reads_memory(instr) || instr_writes_memory(instr)) {
+        if (instr_accesses_memory) {
             int opnd_mem_count = 0;
             for (int i = 0; i < instr_num_srcs(instr); i++) {
                 if (opnd_is_memory_reference(instr_get_src(instr, i))) {
@@ -1038,7 +1041,7 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
                 ++reg_it;
         }
     }
-    if (contains_predication)
+    if (contains_memory_predication)
         return -1;
     return total_traced_mem_count;
 }

--- a/clients/drcachesim/tracer/instru_offline.cpp
+++ b/clients/drcachesim/tracer/instru_offline.cpp
@@ -958,7 +958,6 @@ int
 offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilist,
                                               int version, bool memref_needs_full_info)
 {
-    int total_traced_mem_count = 0;
     // Analysis for eliding redundant addresses we can reconstruct during
     // post-processing.
     bool contains_memory_predication = false;
@@ -983,6 +982,7 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
             return -1;
         }
     }
+    int total_traced_mem_count = 0;
     for (instr_t *instr = instrlist_first_app(ilist); instr != NULL;
          instr = instr_get_next_app(instr)) {
         // Use instr_{reads,writes}_memory() to rule out LEA and NOP.
@@ -1003,8 +1003,9 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
                         ++total_traced_mem_count;
                     else if (!opnd_check_elidable(
                                  drcontext, ilist, instr, instr_get_src(instr, i), i,
-                                 opnd_mem_count, false, version, saw_base))
+                                 opnd_mem_count, false, version, saw_base)) {
                         ++total_traced_mem_count;
+                    }
                     ++opnd_mem_count;
                 }
             }
@@ -1024,8 +1025,9 @@ offline_instru_t::identify_elidable_addresses(void *drcontext, instrlist_t *ilis
                         ++total_traced_mem_count;
                     else if (!opnd_check_elidable(
                                  drcontext, ilist, instr, instr_get_dst(instr, i), i,
-                                 opnd_mem_count, true, version, saw_base))
+                                 opnd_mem_count, true, version, saw_base)) {
                         ++total_traced_mem_count;
+                    }
                     ++opnd_mem_count;
                 }
             }

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1421,7 +1421,8 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
                                         uint64 modoffs, app_pc start_pc, uint instr_count)
 {
     int version = get_version(tdata);
-    // Old versions have no elision; we also skip memcount-based checks there.
+    // Old versions have no elision; we also skip memcount-based checks there
+    // for simplicity.
     if (version <= OFFLINE_FILE_VERSION_NO_ELISION)
         return true;
     // Filtered and instruction-only traces have no elision; we also skip
@@ -1833,6 +1834,7 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         // The trace is recording instruction retirement, premmpted instructions
         // and the corresponding memrefs, and instructions causing a fault are
         // removed.
+        DR_ASSERT(!interrupted);
         interrupted = interrupted_by_kernel_event(tdata, cur_pc, cur_offs);
         if (interrupted) {
             // Insert the TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION marker to
@@ -1926,14 +1928,14 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                             // dest/src of the original scatter/gather instr for all.
                             is_scatter ? instr->mem_dest_at(0) : instr->mem_src_at(0),
                             is_scatter, reg_vals, &reached_end_of_memrefs,
-                            expect_all_memrefs, &consumed_memrefs))
+                            expect_all_memrefs, consumed_memrefs))
                         return false;
                 }
             } else {
                 for (uint j = 0; j < instr->num_mem_srcs(); j++) {
                     if (!append_memref(tdata, &buf, instr, instr->mem_src_at(j), false,
                                        reg_vals, nullptr, expect_all_memrefs,
-                                       &consumed_memrefs))
+                                       consumed_memrefs))
                         return false;
                 }
                 // We break before subsequent memrefs on an interrupt, though with
@@ -1941,7 +1943,7 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                 for (uint j = 0; !interrupted && j < instr->num_mem_dests(); j++) {
                     if (!append_memref(tdata, &buf, instr, instr->mem_dest_at(j), true,
                                        reg_vals, nullptr, expect_all_memrefs,
-                                       &consumed_memrefs))
+                                       consumed_memrefs))
                         return false;
                 }
             }
@@ -1961,6 +1963,7 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
             }
         }
         // Check for rseq abort *after* the instruction.
+        DR_ASSERT(!rseq_aborted);
         if (!handle_rseq_abort_marker(tdata, &buf, cur_pc, cur_offs, &rseq_aborted))
             return false;
 
@@ -2257,7 +2260,7 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
                            instr_summary_t::memref_summary_t memref, bool write,
                            std::unordered_map<reg_id_t, addr_t> &reg_vals,
                            DR_PARAM_OUT bool *reached_end_of_memrefs,
-                           bool expect_all_memrefs, DR_PARAM_OUT int *consumed_memrefs)
+                           bool expect_all_memrefs, DR_PARAM_OUT int &consumed_memrefs)
 {
     DR_ASSERT(!TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, get_file_type(tdata)));
     trace_entry_t *buf = *buf_in;
@@ -2314,11 +2317,11 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
          (in_entry->addr.type != OFFLINE_TYPE_MEMREF &&
           in_entry->addr.type != OFFLINE_TYPE_MEMREF_HIGH))) {
         if (expect_all_memrefs) {
-            tdata->error = "Missing memref in unconditional block";
+            tdata->error = "Missing memref in block without predicated accesses";
             log(1,
-                "Error: missing memref in unconditional block "
+                "Error: missing memref in block without predicated accesses "
                 "(next type is 0x" ZHEX64_FORMAT_STRING "; consumed %d memrefs)\n",
-                in_entry == nullptr ? 0 : in_entry->combined_value, *consumed_memrefs);
+                in_entry == nullptr ? 0 : in_entry->combined_value, consumed_memrefs);
             if (in_entry != nullptr)
                 unread_last_entry(tdata);
             return false;
@@ -2363,7 +2366,7 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         DR_ASSERT(in_entry != nullptr);
         // We take the full value, to handle low or high.
         buf->addr = (addr_t)in_entry->combined_value;
-        ++(*consumed_memrefs);
+        ++consumed_memrefs;
     }
     if (memref.remember_base &&
         tdata->instru_offline.opnd_is_elidable(memref.opnd, base, version)) {

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1424,7 +1424,8 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
         return true;
     // Filtered and instruction-only traces have no elision; we also skip
     // memcount-based checks.
-    if (TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_INSTRUCTION_ONLY,
+    if (TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_DFILTERED |
+                    OFFLINE_FILE_TYPE_IFILTERED | OFFLINE_FILE_TYPE_INSTRUCTION_ONLY,
                 get_file_type(tdata)))
         return true;
     // We build an ilist to use identify_elidable_addresses() and fill in

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1419,7 +1419,7 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
                                         uint64 modoffs, app_pc start_pc, uint instr_count)
 {
     int version = get_version(tdata);
-    // Old versions have no elision.
+    // Old versions have no elision; we also skip memcount-based checks there.
     if (version <= OFFLINE_FILE_VERSION_NO_ELISION)
         return true;
     // Filtered and instruction-only traces have no elision.
@@ -1441,7 +1441,13 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
         instrlist_append(ilist, inst);
     }
 
-    instru_offline_.identify_elidable_addresses(dcontext_, ilist, version, false);
+    int total_traced_mem_count =
+        instru_offline_.identify_elidable_addresses(dcontext_, ilist, version, false);
+    if (!set_block_mem_count(tdata, modidx, modoffs, start_pc, instr_count,
+                             total_traced_mem_count)) {
+        tdata->error = "Failed to set flags for elided base address";
+        return false;
+    }
 
     for (instr_t *inst = instrlist_first(ilist); inst != nullptr;
          inst = instr_get_next(inst)) {
@@ -1664,6 +1670,7 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
     // Legacy traces need the offset, not the pc.
     uint64_t cur_offs = in_entry->pc.modoffs;
     std::unordered_map<reg_id_t, addr_t> reg_vals;
+    int total_mem_count = -1;
     if (instr_count == 0) {
         // L0 filtering adds a PC entry with a count of 0 prior to each memref.
         skip_icache = true;
@@ -1679,11 +1686,22 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                                             in_entry->pc.modoffs, start_pc, instr_count))
                 return false;
         }
+        block_summary_t *block = lookup_block_summary(tdata, in_entry->pc.modidx,
+                                                      in_entry->pc.modoffs, start_pc);
+        DR_ASSERT(block != nullptr);
+        // Currently we only use total_mem_count to compute expect_all_memrefs,
+        // but we will want it for handling tagged addresses if we need to
+        // identify block boundaries in the presence of ambiguous records.
+        total_mem_count = block->total_mem_count;
     }
+    bool expect_all_memrefs = total_mem_count >= 0;
+    log(4, "expect_all_memrefs=%d total_mem_count=%d\n", expect_all_memrefs,
+        total_mem_count);
     if (instrs_are_separate && instr_count != 1) {
         tdata->error = "cannot mix 0-count and >1-count";
         return false;
     }
+    int consumed_memrefs = 0;
     for (uint i = 0; i < instr_count; ++i) {
         trace_entry_t *buf_start = get_write_buffer(tdata);
         trace_entry_t *buf = buf_start;
@@ -1896,20 +1914,23 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
                             // only the original app instr though. So we use the 0th
                             // dest/src of the original scatter/gather instr for all.
                             is_scatter ? instr->mem_dest_at(0) : instr->mem_src_at(0),
-                            is_scatter, reg_vals, &reached_end_of_memrefs))
+                            is_scatter, reg_vals, &reached_end_of_memrefs,
+                            expect_all_memrefs, &consumed_memrefs))
                         return false;
                 }
             } else {
                 for (uint j = 0; j < instr->num_mem_srcs(); j++) {
                     if (!append_memref(tdata, &buf, instr, instr->mem_src_at(j), false,
-                                       reg_vals, nullptr))
+                                       reg_vals, nullptr, expect_all_memrefs,
+                                       &consumed_memrefs))
                         return false;
                 }
                 // We break before subsequent memrefs on an interrupt, though with
                 // today's tracer that will never happen (i#3958).
                 for (uint j = 0; !interrupted && j < instr->num_mem_dests(); j++) {
                     if (!append_memref(tdata, &buf, instr, instr->mem_dest_at(j), true,
-                                       reg_vals, nullptr))
+                                       reg_vals, nullptr, expect_all_memrefs,
+                                       &consumed_memrefs))
                         return false;
                 }
             }
@@ -1961,6 +1982,12 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         }
         if (rseq_aborted || interrupted)
             break;
+    }
+    if (expect_all_memrefs && consumed_memrefs != total_mem_count) {
+        tdata->error = "Failed to find expected memref count";
+        log(1, "Expected %d memrefs but found %d memrefs\n", total_mem_count,
+            consumed_memrefs);
+        return false;
     }
     *handled = true;
     return true;
@@ -2218,7 +2245,8 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
                            const instr_summary_t *instr,
                            instr_summary_t::memref_summary_t memref, bool write,
                            std::unordered_map<reg_id_t, addr_t> &reg_vals,
-                           DR_PARAM_OUT bool *reached_end_of_memrefs)
+                           DR_PARAM_OUT bool *reached_end_of_memrefs,
+                           bool expect_all_memrefs, DR_PARAM_OUT int *consumed_memrefs)
 {
     DR_ASSERT(!TESTANY(OFFLINE_FILE_TYPE_INSTRUCTION_ONLY, get_file_type(tdata)));
     trace_entry_t *buf = *buf_in;
@@ -2273,6 +2301,16 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         (in_entry == nullptr ||
          (in_entry->addr.type != OFFLINE_TYPE_MEMREF &&
           in_entry->addr.type != OFFLINE_TYPE_MEMREF_HIGH))) {
+        if (expect_all_memrefs) {
+            tdata->error = "Missing memref in unconditional block";
+            log(1,
+                "Error: missing memref in unconditional block "
+                "(next type is 0x" ZHEX64_FORMAT_STRING ")\n",
+                in_entry == nullptr ? 0 : in_entry->combined_value);
+            if (in_entry != nullptr)
+                unread_last_entry(tdata);
+            return false;
+        }
         // This happens when there are predicated memrefs in the bb, or for a
         // zero-iter rep string loop, or for a multi-memref instr with -L0_filter.
         // For predicated memrefs, they could be earlier, so "instr"
@@ -2313,6 +2351,7 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         DR_ASSERT(in_entry != nullptr);
         // We take the full value, to handle low or high.
         buf->addr = (addr_t)in_entry->combined_value;
+        ++consumed_memrefs;
     }
     if (memref.remember_base &&
         instru_offline_.opnd_is_elidable(memref.opnd, base, version)) {
@@ -2657,6 +2696,37 @@ raw2trace_t::lookup_block_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
     return ret;
 }
 
+raw2trace_t::block_summary_t *
+raw2trace_t::create_block_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                  uint64 modoffs, app_pc block_start, int instr_count)
+{
+
+    block_summary_t *block = new block_summary_t(block_start, instr_count);
+    decode_cache_[tdata->worker].add(modidx, modoffs, block);
+    VPRINT(5,
+           "Created new block summary " PFX " for " PFX " modidx=" INT64_FORMAT_STRING
+           " modoffs=" HEX64_FORMAT_STRING "\n",
+           block, block_start, modidx, modoffs);
+    tdata->last_decode_block_start = block_start;
+    tdata->last_decode_modidx = modidx;
+    tdata->last_decode_modoffs = modoffs;
+    tdata->last_block_summary = block;
+    return block;
+}
+
+bool
+raw2trace_t::set_block_mem_count(raw2trace_thread_data_t *tdata, uint64 modidx,
+                                 uint64 modoffs, app_pc block_start, int instr_count,
+                                 int total_traced_mem_count)
+{
+    block_summary_t *block = lookup_block_summary(tdata, modidx, modoffs, block_start);
+    if (block == nullptr) {
+        block = create_block_summary(tdata, modidx, modoffs, block_start, instr_count);
+    }
+    block->total_mem_count = total_traced_mem_count;
+    return true;
+}
+
 instr_summary_t *
 raw2trace_t::lookup_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
                                   uint64 modoffs, app_pc block_start, int index,
@@ -2690,18 +2760,9 @@ raw2trace_t::create_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
                                   DR_PARAM_INOUT app_pc *pc, app_pc orig)
 {
     if (block == nullptr) {
-        block = new block_summary_t(block_start, instr_count);
-        DEBUG_ASSERT(index >= 0 && index < static_cast<int>(block->instrs.size()));
-        decode_cache_[tdata->worker].add(modidx, modoffs, block);
-        VPRINT(5,
-               "Created new block summary " PFX " for " PFX " modidx=" INT64_FORMAT_STRING
-               " modoffs=" HEX64_FORMAT_STRING "\n",
-               block, block_start, modidx, modoffs);
-        tdata->last_decode_block_start = block_start;
-        tdata->last_decode_modidx = modidx;
-        tdata->last_decode_modoffs = modoffs;
-        tdata->last_block_summary = block;
+        block = create_block_summary(tdata, modidx, modoffs, block_start, instr_count);
     }
+    DEBUG_ASSERT(index >= 0 && index < static_cast<int>(block->instrs.size()));
     instr_summary_t *desc = &block->instrs[index];
     if (!instr_summary_t::construct(dcontext_, block_start, pc, orig, desc, verbosity_)) {
         WARN("Encountered invalid/undecodable instr @ idx=" INT64_FORMAT_STRING

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1696,8 +1696,9 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         block_summary_t *block = lookup_block_summary(tdata, in_entry->pc.modidx,
                                                       in_entry->pc.modoffs, start_pc);
         if (block == nullptr) {
-            // This must be an i-filtered trace.
-            DR_ASSERT(instrs_are_separate);
+            // This must be a filtered or instr-only trace.
+            DR_ASSERT(instrs_are_separate || is_instr_only_trace ||
+                      TESTANY(OFFLINE_FILE_TYPE_DFILTERED, get_file_type(tdata)));
         } else {
             total_mem_count = block->total_mem_count;
         }
@@ -1710,6 +1711,8 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         return false;
     }
     int consumed_memrefs = 0;
+    bool interrupted = false;
+    bool rseq_aborted = false;
     for (uint i = 0; i < instr_count; ++i) {
         trace_entry_t *buf_start = get_write_buffer(tdata);
         trace_entry_t *buf = buf_start;
@@ -1830,7 +1833,7 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         // The trace is recording instruction retirement, premmpted instructions
         // and the corresponding memrefs, and instructions causing a fault are
         // removed.
-        const bool interrupted = interrupted_by_kernel_event(tdata, cur_pc, cur_offs);
+        interrupted = interrupted_by_kernel_event(tdata, cur_pc, cur_offs);
         if (interrupted) {
             // Insert the TRACE_MARKER_TYPE_UNCOMPLETED_INSTRUCTION marker to
             // indicate an instruction is removed from the trace because it was
@@ -1958,7 +1961,6 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
             }
         }
         // Check for rseq abort *after* the instruction.
-        bool rseq_aborted = false;
         if (!handle_rseq_abort_marker(tdata, &buf, cur_pc, cur_offs, &rseq_aborted))
             return false;
 
@@ -1991,7 +1993,8 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         if (rseq_aborted || interrupted)
             break;
     }
-    if (expect_all_memrefs && consumed_memrefs != total_mem_count) {
+    if (expect_all_memrefs && !interrupted && !rseq_aborted &&
+        consumed_memrefs != total_mem_count) {
         tdata->error = "Failed to find expected memref count";
         log(1, "Expected %d memrefs but found %d memrefs\n", total_mem_count,
             consumed_memrefs);

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1422,9 +1422,9 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
     // Old versions have no elision; we also skip memcount-based checks there.
     if (version <= OFFLINE_FILE_VERSION_NO_ELISION)
         return true;
-    // Filtered and instruction-only traces have no elision.
-    if (TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS |
-                    OFFLINE_FILE_TYPE_INSTRUCTION_ONLY,
+    // Filtered and instruction-only traces have no elision; we also skip
+    // memcount-based checks.
+    if (TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_INSTRUCTION_ONLY,
                 get_file_type(tdata)))
         return true;
     // We build an ilist to use identify_elidable_addresses() and fill in
@@ -1447,6 +1447,10 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
                              total_traced_mem_count)) {
         tdata->error = "Failed to set flags for elided base address";
         return false;
+    }
+    if (TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, get_file_type(tdata))) {
+        // If optimizations are enabled we're done now that we have the count.
+        return true;
     }
 
     for (instr_t *inst = instrlist_first(ilist); inst != nullptr;
@@ -1688,11 +1692,12 @@ raw2trace_t::append_bb_entries(raw2trace_thread_data_t *tdata,
         }
         block_summary_t *block = lookup_block_summary(tdata, in_entry->pc.modidx,
                                                       in_entry->pc.modoffs, start_pc);
-        DR_ASSERT(block != nullptr);
-        // Currently we only use total_mem_count to compute expect_all_memrefs,
-        // but we will want it for handling tagged addresses if we need to
-        // identify block boundaries in the presence of ambiguous records.
-        total_mem_count = block->total_mem_count;
+        if (block == nullptr) {
+            // This must be an i-filtered trace.
+            DR_ASSERT(instrs_are_separate);
+        } else {
+            total_mem_count = block->total_mem_count;
+        }
     }
     bool expect_all_memrefs = total_mem_count >= 0;
     log(4, "expect_all_memrefs=%d total_mem_count=%d\n", expect_all_memrefs,
@@ -2351,7 +2356,7 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         DR_ASSERT(in_entry != nullptr);
         // We take the full value, to handle low or high.
         buf->addr = (addr_t)in_entry->combined_value;
-        ++consumed_memrefs;
+        ++(*consumed_memrefs);
     }
     if (memref.remember_base &&
         instru_offline_.opnd_is_elidable(memref.opnd, base, version)) {
@@ -2703,7 +2708,7 @@ raw2trace_t::create_block_summary(raw2trace_thread_data_t *tdata, uint64 modidx,
 
     block_summary_t *block = new block_summary_t(block_start, instr_count);
     decode_cache_[tdata->worker].add(modidx, modoffs, block);
-    VPRINT(5,
+    VPRINT(4,
            "Created new block summary " PFX " for " PFX " modidx=" INT64_FORMAT_STRING
            " modoffs=" HEX64_FORMAT_STRING "\n",
            block, block_start, modidx, modoffs);
@@ -2724,6 +2729,10 @@ raw2trace_t::set_block_mem_count(raw2trace_thread_data_t *tdata, uint64 modidx,
         block = create_block_summary(tdata, modidx, modoffs, block_start, instr_count);
     }
     block->total_mem_count = total_traced_mem_count;
+    VPRINT(4,
+           "Set block mem count for " PFX " modidx=" INT64_FORMAT_STRING
+           " modoffs=" HEX64_FORMAT_STRING " to %d\n",
+           block_start, modidx, modoffs, total_traced_mem_count);
     return true;
 }
 

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2317,8 +2317,8 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
             tdata->error = "Missing memref in unconditional block";
             log(1,
                 "Error: missing memref in unconditional block "
-                "(next type is 0x" ZHEX64_FORMAT_STRING ")\n",
-                in_entry == nullptr ? 0 : in_entry->combined_value);
+                "(next type is 0x" ZHEX64_FORMAT_STRING "; consumed %d memrefs)\n",
+                in_entry == nullptr ? 0 : in_entry->combined_value, *consumed_memrefs);
             if (in_entry != nullptr)
                 unread_last_entry(tdata);
             return false;

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -1023,6 +1023,8 @@ raw2trace_t::process_next_thread_buffer(raw2trace_thread_data_t *tdata,
         // another source.
         tdata->saw_header = trace_metadata_reader_t::is_thread_start(
             in_entry, &tdata->error, &tdata->version, &tdata->file_type);
+        tdata->instru_offline.set_disable_optimizations(
+            TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, tdata->file_type));
         VPRINT(2, "Trace file version is %d; type is %d\n", tdata->version,
                tdata->file_type);
         if (!tdata->error.empty())
@@ -1442,8 +1444,8 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
         instrlist_append(ilist, inst);
     }
 
-    int total_traced_mem_count =
-        instru_offline_.identify_elidable_addresses(dcontext_, ilist, version, false);
+    int total_traced_mem_count = tdata->instru_offline.identify_elidable_addresses(
+        dcontext_, ilist, version, false);
     if (!set_block_mem_count(tdata, modidx, modoffs, start_pc, instr_count,
                              total_traced_mem_count)) {
         tdata->error = "Failed to set flags for elided base address";
@@ -1458,8 +1460,8 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
          inst = instr_get_next(inst)) {
         int index, memop_index;
         bool write, needs_base;
-        if (!instru_offline_.label_marks_elidable(inst, &index, &memop_index, &write,
-                                                  &needs_base))
+        if (!tdata->instru_offline.label_marks_elidable(inst, &index, &memop_index,
+                                                        &write, &needs_base))
             continue;
         // There could be multiple labels for one instr (e.g., "push (%rsp)".
         instr_t *meminst = instr_get_next(inst);
@@ -1489,7 +1491,7 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
         opnd_t elided_op =
             write ? instr_get_dst(meminst, index) : instr_get_src(meminst, index);
         reg_id_t base;
-        bool got_base = instru_offline_.opnd_is_elidable(elided_op, base, version);
+        bool got_base = tdata->instru_offline.opnd_is_elidable(elided_op, base, version);
         DR_ASSERT(got_base && base != DR_REG_NULL);
         int remember_index = -1;
         for (instr_t *prev = meminst; prev != nullptr; prev = instr_get_prev(prev)) {
@@ -1504,8 +1506,8 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
                 for (int i = 0; i < instr_num_srcs(prev); i++) {
                     reg_id_t prev_base;
                     if (opnd_is_memory_reference(instr_get_src(prev, i))) {
-                        if (instru_offline_.opnd_is_elidable(instr_get_src(prev, i),
-                                                             prev_base, version) &&
+                        if (tdata->instru_offline.opnd_is_elidable(instr_get_src(prev, i),
+                                                                   prev_base, version) &&
                             prev_base == base) {
                             remember_index = mem_count;
                             break;
@@ -1519,8 +1521,8 @@ raw2trace_t::analyze_elidable_addresses(raw2trace_thread_data_t *tdata, uint64 m
                 for (int i = 0; i < instr_num_dsts(prev); i++) {
                     reg_id_t prev_base;
                     if (opnd_is_memory_reference(instr_get_dst(prev, i))) {
-                        if (instru_offline_.opnd_is_elidable(instr_get_dst(prev, i),
-                                                             prev_base, version) &&
+                        if (tdata->instru_offline.opnd_is_elidable(instr_get_dst(prev, i),
+                                                                   prev_base, version) &&
                             prev_base == base) {
                             remember_index = mem_count;
                             remember_write = true;
@@ -2265,7 +2267,8 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         DR_ASSERT(!TESTANY(OFFLINE_FILE_TYPE_FILTERED | OFFLINE_FILE_TYPE_IFILTERED |
                                OFFLINE_FILE_TYPE_DFILTERED,
                            get_file_type(tdata)));
-        bool is_elidable = instru_offline_.opnd_is_elidable(memref.opnd, base, version);
+        bool is_elidable =
+            tdata->instru_offline.opnd_is_elidable(memref.opnd, base, version);
         DR_ASSERT(is_elidable);
         if (base == DR_REG_NULL) {
             DR_ASSERT(IF_REL_ADDRS(opnd_is_near_rel_addr(memref.opnd) ||)
@@ -2360,12 +2363,12 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
         ++(*consumed_memrefs);
     }
     if (memref.remember_base &&
-        instru_offline_.opnd_is_elidable(memref.opnd, base, version)) {
+        tdata->instru_offline.opnd_is_elidable(memref.opnd, base, version)) {
         log(5, "Remembering base " PFX " for %s\n", buf->addr, get_register_name(base));
         reg_vals[base] = buf->addr;
     }
     if (!TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, get_file_type(tdata)) &&
-        instru_offline_.opnd_disp_is_elidable(memref.opnd)) {
+        tdata->instru_offline.opnd_disp_is_elidable(memref.opnd)) {
         // We stored only the base reg, as an optimization.
         buf->addr += opnd_get_disp(memref.opnd);
     }
@@ -3619,6 +3622,8 @@ raw2trace_t::set_file_type(raw2trace_thread_data_t *tdata, offline_file_type_t f
     // entries that follow after TRACE_MARKER_TYPE_FILTER_ENDPOINT. This does not affect
     // the written-out type.
     tdata->file_type = file_type;
+    tdata->instru_offline.set_disable_optimizations(
+        TESTANY(OFFLINE_FILE_TYPE_NO_OPTIMIZATIONS, file_type));
 }
 
 raw2trace_t::raw2trace_t(

--- a/clients/drcachesim/tracer/raw2trace.cpp
+++ b/clients/drcachesim/tracer/raw2trace.cpp
@@ -2381,6 +2381,8 @@ raw2trace_t::append_memref(raw2trace_thread_data_t *tdata,
                 "Error: missing memref in block without predicated accesses "
                 "(next type is 0x" ZHEX64_FORMAT_STRING "; consumed %d memrefs)\n",
                 in_entry == nullptr ? 0 : in_entry->combined_value, consumed_memrefs);
+            // Though we're returning a presumably fatal error, we reset the state just in
+            // case the caller handles and continues.
             if (in_entry != nullptr)
                 unread_last_entry(tdata);
             return false;

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2016-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2016-2026 Google, Inc.  All rights reserved.
  * **********************************************************/
 
 /*
@@ -626,6 +626,7 @@ protected:
         }
         app_pc start_pc;
         std::vector<instr_summary_t> instrs;
+        int total_mem_count = 0;
     };
 
     struct branch_info_t {
@@ -1097,6 +1098,14 @@ private:
     block_summary_t *
     lookup_block_summary(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
                          app_pc block_start);
+    block_summary_t *
+    create_block_summary(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                         app_pc block_start, int instr_count);
+    // Creates a new block summary if one doesn't exist.
+    bool
+    set_block_mem_count(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
+                        app_pc block_start, int instr_count, int total_traced_mem_count);
+
     instr_summary_t *
     lookup_instr_summary(raw2trace_thread_data_t *tdata, uint64 modidx, uint64 modoffs,
                          app_pc block_start, int index, app_pc pc,
@@ -1219,7 +1228,8 @@ private:
     append_memref(raw2trace_thread_data_t *tdata, DR_PARAM_INOUT trace_entry_t **buf_in,
                   const instr_summary_t *instr, instr_summary_t::memref_summary_t memref,
                   bool write, std::unordered_map<reg_id_t, addr_t> &reg_vals,
-                  DR_PARAM_OUT bool *reached_end_of_memrefs);
+                  DR_PARAM_OUT bool *reached_end_of_memrefs, bool expect_all_memrefs,
+                  DR_PARAM_OUT int *consumed_memrefs);
 
     bool
     should_omit_syscall(raw2trace_thread_data_t *tdata);

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -1230,7 +1230,7 @@ private:
                   const instr_summary_t *instr, instr_summary_t::memref_summary_t memref,
                   bool write, std::unordered_map<reg_id_t, addr_t> &reg_vals,
                   DR_PARAM_OUT bool *reached_end_of_memrefs, bool expect_all_memrefs,
-                  DR_PARAM_OUT int *consumed_memrefs);
+                  DR_PARAM_OUT int &consumed_memrefs);
 
     bool
     should_omit_syscall(raw2trace_thread_data_t *tdata);

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -687,6 +687,7 @@ protected:
         offline_file_type_t file_type;
         size_t cache_line_size = 0;
         std::deque<offline_entry_t> pre_read;
+        offline_instru_t instru_offline;
 
         // Used to delay a thread-buffer-final branch to keep it next to its target.
         std::vector<trace_entry_t> delayed_branch;
@@ -1360,7 +1361,6 @@ private:
     // Chunking for seeking support in compressed files.
     uint64_t chunk_instr_count_ = 0;
 
-    offline_instru_t instru_offline_;
     const std::vector<module_t> *modvec_ptr_ = nullptr;
 
     // For decoding kernel PT traces.

--- a/clients/drcachesim/tracer/raw2trace.h
+++ b/clients/drcachesim/tracer/raw2trace.h
@@ -626,7 +626,7 @@ protected:
         }
         app_pc start_pc;
         std::vector<instr_summary_t> instrs;
-        int total_mem_count = 0;
+        int total_mem_count = -1;
     };
 
     struct branch_info_t {

--- a/clients/drcachesim/tracer/tracer.cpp
+++ b/clients/drcachesim/tracer/tracer.cpp
@@ -2471,7 +2471,7 @@ drmemtrace_client_main(client_id_t id, int argc, const char *argv[])
     // all addresses during tracing or when instruction or data address entries
     // are being filtered.
     if (op_use_physical.get_value() || op_L0I_filter.get_value() ||
-        op_L0D_filter.get_value())
+        op_L0D_filter.get_value() || op_L0_filter_until_instrs.get_value())
         op_disable_optimizations.set_value(true);
 
     init_record_syscall();

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -1,5 +1,5 @@
 /* **********************************************************
- * Copyright (c) 2011-2025 Google, Inc.  All rights reserved.
+ * Copyright (c) 2011-2026 Google, Inc.  All rights reserved.
  * Copyright (c) 2002-2010 VMware, Inc.  All rights reserved.
  * **********************************************************/
 
@@ -314,7 +314,7 @@
  * precisely where this instruction will be encoded).
  */
 #define XINST_CREATE_jump_cond(dc, pred, t) \
-    (INSTR_CREATE_jcc((dc), (pred)-DR_PRED_O + OP_jo, (t)))
+    (INSTR_CREATE_jcc((dc), (pred) - DR_PRED_O + OP_jo, (t)))
 
 /**
  * This platform-independent macro creates an #instr_t for an unconditional
@@ -3051,8 +3051,9 @@
  * \param d The opnd_t explicit destination operand for the instruction.
  * \param s The opnd_t explicit source operand for the instruction.
  */
-#define INSTR_CREATE_cmovcc(dc, op, d, s) \
-    INSTR_PRED(instr_create_1dst_1src((dc), (op), (d), (s)), DR_PRED_O + (op)-OP_cmovo)
+#define INSTR_CREATE_cmovcc(dc, op, d, s)                    \
+    INSTR_PRED(instr_create_1dst_1src((dc), (op), (d), (s)), \
+               (dr_pred_type_t)((int)DR_PRED_O + (op) - OP_cmovo))
 
 /**
  * This INSTR_CREATE_xxx_imm macro creates an #instr_t with opcode OP_xxx and the given

--- a/core/ir/x86/instr_create_api.h
+++ b/core/ir/x86/instr_create_api.h
@@ -314,7 +314,7 @@
  * precisely where this instruction will be encoded).
  */
 #define XINST_CREATE_jump_cond(dc, pred, t) \
-    (INSTR_CREATE_jcc((dc), (pred) - DR_PRED_O + OP_jo, (t)))
+    (INSTR_CREATE_jcc((dc), (pred)-DR_PRED_O + OP_jo, (t)))
 
 /**
  * This platform-independent macro creates an #instr_t for an unconditional
@@ -3053,7 +3053,7 @@
  */
 #define INSTR_CREATE_cmovcc(dc, op, d, s)                    \
     INSTR_PRED(instr_create_1dst_1src((dc), (op), (d), (s)), \
-               (dr_pred_type_t)((int)DR_PRED_O + (op) - OP_cmovo))
+               (dr_pred_type_t)((int)DR_PRED_O + (op)-OP_cmovo))
 
 /**
  * This INSTR_CREATE_xxx_imm macro creates an #instr_t with opcode OP_xxx and the given


### PR DESCRIPTION
Turns missing load/store records in raw2trace into fatal errors, for earlier and more useful error reporting. This can only be done in basic blocks which do not contain any predicated/conditional loads/stores nor any expanded sequences like rep-string or scatter/gather.

Adds memref counting and whether we expect to see all memrefs to the existing elision analysis.  Stores the data in the raw2trace block summary and uses it during operand handling.

Adds unit tests for both directions of the error.

Fixes unit tests that currently violate the new error.

Fixes some minor bugs that are not worth separating out as they do not have significant implications without the other changes here:
+ tracer.cpp fails to set op_disable_optimizations for op_L0_filter_until_instrs
+ raw2trace was checking the old _FILTERED instead of _{I,D}FILTERED
+ raw2trace wasn't setting disable_optimizations_ in instru_offline. This fix is a little more involved, accomplished by moving the instru_offline field to the per-thread data structure so it can be set from the filetype.

Issue: #1734